### PR TITLE
feat: category filter + conflict log retention

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -44,6 +44,7 @@ RATE_LIMIT_RPM = int(os.environ.get("RATE_LIMIT_RPM", "0"))  # 0 = unlimited
 
 # Client log retention
 LOG_RETENTION_DAYS = int(os.environ.get("LOG_RETENTION_DAYS", "7"))
+CONFLICT_LOG_RETENTION_DAYS = int(os.environ.get("CONFLICT_LOG_RETENTION_DAYS", "30"))
 
 # Redis (optional — enables shared state for multi-instance deployments)
 REDIS_URL = os.environ.get("REDIS_URL") or None  # None/empty = disabled, use in-memory backends

--- a/api/log_store.py
+++ b/api/log_store.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 import psycopg
 
-from config import LOG_RETENTION_DAYS
+from config import CONFLICT_LOG_RETENTION_DAYS, LOG_RETENTION_DAYS
 from pool import get_pool
 
 logger = logging.getLogger("engram")
@@ -75,11 +75,17 @@ def insert_logs(user_id: str, entries: list[dict]) -> int:
         )
         conn.execute(sql, params)
 
-        # Piggyback cleanup: delete old entries for this user
-        cutoff = datetime.now(timezone.utc) - timedelta(days=LOG_RETENTION_DAYS)
+        # Piggyback cleanup: delete old entries for this user.
+        # Conflict logs get longer retention for auditing.
+        now = datetime.now(timezone.utc)
+        default_cutoff = now - timedelta(days=LOG_RETENTION_DAYS)
+        conflict_cutoff = now - timedelta(days=CONFLICT_LOG_RETENTION_DAYS)
         conn.execute(
-            "DELETE FROM client_logs WHERE user_id = %s AND created_at < %s",
-            (user_id, cutoff),
+            "DELETE FROM client_logs WHERE user_id = %s AND ("
+            "  (category != 'conflict' AND created_at < %s) OR"
+            "  (category = 'conflict' AND created_at < %s)"
+            ")",
+            (user_id, default_cutoff, conflict_cutoff),
         )
         conn.commit()
 
@@ -89,6 +95,7 @@ def insert_logs(user_id: str, entries: list[dict]) -> int:
 def get_logs(
     user_id: str,
     level: str | None = None,
+    category: str | None = None,
     since: datetime | None = None,
     limit: int = 200,
 ) -> list[dict]:
@@ -100,6 +107,9 @@ def get_logs(
     if level:
         conditions.append("level = %s")
         params.append(level)
+    if category:
+        conditions.append("category = %s")
+        params.append(category)
     if since:
         conditions.append("ts >= %s")
         params.append(since)

--- a/api/main.py
+++ b/api/main.py
@@ -584,6 +584,7 @@ def ingest_logs_endpoint(req: ClientLogBatch, user: dict = Depends(get_current_u
 @app.get("/logs")
 def get_logs_endpoint(
     level: str = Query(default="", description="Filter by level (error, warn, info)"),
+    category: str = Query(default="", description="Filter by category (e.g. conflict, pull, push, lifecycle)"),
     since: str = Query(default="", description="ISO 8601 timestamp"),
     limit: int = Query(default=200, ge=1, le=1000),
     user: dict = Depends(get_current_user_api_key),
@@ -596,5 +597,5 @@ def get_logs_endpoint(
             since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid 'since' timestamp.")
-    logs = log_store.get_logs(user_id, level=level or None, since=since_dt, limit=limit)
+    logs = log_store.get_logs(user_id, level=level or None, category=category or None, since=since_dt, limit=limit)
     return {"logs": logs}


### PR DESCRIPTION
## Summary
- Add `category` query param to `GET /logs` for filtering (e.g. `?category=conflict`)
- Add `CONFLICT_LOG_RETENTION_DAYS=30` env var — conflict logs kept 30 days, others 7
- Split piggyback cleanup to respect per-category retention

Pairs with Rasbandit/Engram-obsidian-sync PR for plugin-side conflict logging.

## Test plan
- [ ] `GET /logs?category=conflict` returns only conflict entries
- [ ] `GET /logs?category=conflict&level=error` combines filters
- [ ] Logs older than 7 days pruned for non-conflict categories
- [ ] Conflict logs survive past 7 days up to 30 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)