### PR TITLE
fix: start CI stack on plugin-triggered dispatch

### DIFF
--- a/.github/setup-runner.sh
+++ b/.github/setup-runner.sh
@@ -87,6 +87,25 @@ fi
 #   ~/actions-runner-plugin     (plugin repo CI)
 #   ~/actions-runner-engram-2   (parallel job capacity)
 
+# ── Pre-extract Obsidian AppImage ────────────────────────────────────────
+# Obsidian's --appimage-extract-and-run re-extracts squashfs on every launch
+# (~15-30s per boot × 3 instances = 45-90s per CI run). Pre-extracting once
+# eliminates this overhead entirely.
+OBSIDIAN_APPIMAGE="$HOME/Applications/Obsidian.AppImage"
+OBSIDIAN_EXTRACTED="$HOME/Applications/obsidian-extracted"
+if [ -f "$OBSIDIAN_APPIMAGE" ] && [ ! -d "$OBSIDIAN_EXTRACTED" ]; then
+  echo "Pre-extracting Obsidian AppImage (one-time)..."
+  cd "$HOME/Applications"
+  "$OBSIDIAN_APPIMAGE" --appimage-extract > /dev/null 2>&1
+  mv squashfs-root "$OBSIDIAN_EXTRACTED"
+  echo "  ✓ Extracted to $OBSIDIAN_EXTRACTED"
+  cd -
+elif [ -d "$OBSIDIAN_EXTRACTED" ]; then
+  echo "Obsidian already pre-extracted at $OBSIDIAN_EXTRACTED"
+else
+  echo "WARNING: Obsidian AppImage not found at $OBSIDIAN_APPIMAGE"
+fi
+
 # ── Verify ───────────────────────────────────────────────────────────────
 echo ""
 echo "=== Verification ==="

--- a/.github/setup-runner.sh
+++ b/.github/setup-runner.sh
@@ -68,6 +68,25 @@ else
   echo "Claude Code CLI already installed: $(claude --version)"
 fi
 
+# ── Multiple runner instances ────────────────────────────────────────────
+# For parallel CI jobs, register additional runner instances on this machine.
+# Each runner is an independent agent process with its own work directory.
+#
+# Setup (run as open-claw, not root):
+#   mkdir ~/actions-runner-engram-2
+#   cd ~/actions-runner-engram-2
+#   curl -o actions-runner-linux-x64.tar.gz -L \
+#     https://github.com/actions/runner/releases/download/v2.323.0/actions-runner-linux-x64-2.323.0.tar.gz
+#   tar xzf actions-runner-linux-x64.tar.gz
+#   ./config.sh --url https://github.com/Rasbandit/Engram \
+#     --labels self-hosted,engram --name engram-runner-2
+#   sudo ./svc.sh install && sudo ./svc.sh start
+#
+# Existing runners:
+#   ~/actions-runner-engram     (primary — CI + E2E)
+#   ~/actions-runner-plugin     (plugin repo CI)
+#   ~/actions-runner-engram-2   (parallel job capacity)
+
 # ── Verify ───────────────────────────────────────────────────────────────
 echo ""
 echo "=== Verification ==="

--- a/.github/setup-runner.sh
+++ b/.github/setup-runner.sh
@@ -50,7 +50,7 @@ done
 
 # ── Python packages (pytest, playwright, requests) ───────────────────────
 echo "Installing Python packages..."
-pip3 install --upgrade 'playwright>=1.48' pytest requests
+pip3 install --upgrade 'playwright>=1.48' pytest pytest-rerunfailures requests websockets
 
 echo "Installing Playwright Chromium..."
 # Install browser only — skip --with-deps (requires apt, unavailable on Fedora).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           docker compose -f docker-compose.ci.yml -p engram-ci down -v --remove-orphans 2>/dev/null || true
           pkill -9 -f "e2e-obsidian-config" 2>/dev/null || true
+          pkill -9 -f "obsidian-extracted.*obsidian" 2>/dev/null || true
           pkill -9 Xvfb 2>/dev/null || true
           rm -rf /tmp/e2e-vault-* /tmp/e2e-obsidian-config-* /tmp/ci-*.marker
 
@@ -312,8 +313,9 @@ jobs:
       - name: Tear down
         if: always()
         run: |
-          # Kill ALL Obsidian processes (extracted binaries spawn children under /tmp)
+          # Kill ALL Obsidian processes (both pre-extracted and AppImage variants)
           pkill -9 -f "e2e-obsidian-config" 2>/dev/null || true
+          pkill -9 -f "obsidian-extracted.*obsidian" 2>/dev/null || true
           pkill -9 -f "appimage_extracted.*obsidian" 2>/dev/null || true
           pkill -9 Xvfb 2>/dev/null || true
           # Wait for processes to die before removing their dirs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,8 +271,17 @@ jobs:
         id: api_tests
         working-directory: e2e
         run: |
-          echo "Running API-only tests while Obsidian instances boot..."
-          python3 -m pytest tests/ -v -m "api_only" --timeout=60
+          echo "Warm-up: waiting for API routes to finish loading..."
+          for i in $(seq 1 15); do
+            status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8100/api/sync/manifest 2>/dev/null || echo "000")
+            if [ "$status" != "404" ] && [ "$status" != "000" ]; then
+              echo "API routes ready (got $status)"
+              break
+            fi
+            sleep 1
+          done
+          echo "Running API-only tests..."
+          python3 -m pytest tests/api_only/ -v --timeout=60
         continue-on-error: true
         env:
           ENGRAM_API_URL: http://localhost:8100/api
@@ -284,7 +293,7 @@ jobs:
       # ------------------------------------------------------------------
       - name: "Phase C: Run Obsidian E2E tests"
         working-directory: e2e
-        run: python3 -m pytest tests/ -v -m "not api_only" --timeout=300
+        run: python3 -m pytest tests/ --ignore=tests/api_only/ -v --timeout=300
         env:
           ENGRAM_API_URL: http://localhost:8100/api
           ENGRAM_PLUGIN_SRC: ${{ github.workspace }}/plugin-src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,20 +291,14 @@ jobs:
       # ------------------------------------------------------------------
       # Cleanup — MUST kill everything, even on cancel/failure
       # ------------------------------------------------------------------
-      - name: Collect logs on failure
+      - name: Collect failure logs
         if: failure()
         run: |
           mkdir -p ci-artifacts
           docker compose -f docker-compose.ci.yml -p engram-ci logs > ci-artifacts/docker-compose.log 2>&1
-          # Include background build logs
-          cp /tmp/ci-stack.log ci-artifacts/ 2>/dev/null || true
-          cp /tmp/ci-plugin.log ci-artifacts/ 2>/dev/null || true
-          cp /tmp/ci-playwright.log ci-artifacts/ 2>/dev/null || true
-          cp /tmp/ci-ollama.log ci-artifacts/ 2>/dev/null || true
+          cp /tmp/ci-stack.log /tmp/ci-plugin.log /tmp/ci-playwright.log /tmp/ci-ollama.log ci-artifacts/ 2>/dev/null || true
           for v in /tmp/e2e-vault-*; do
-            if [ -d "$v" ]; then
-              tar czf "ci-artifacts/$(basename $v).tar.gz" -C /tmp "$(basename $v)" 2>/dev/null || true
-            fi
+            [ -d "$v" ] && tar czf "ci-artifacts/$(basename $v).tar.gz" -C /tmp "$(basename $v)" 2>/dev/null || true
           done
 
       - name: Upload failure artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,47 +112,41 @@ jobs:
           VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.VITE_CLERK_PUBLISHABLE_KEY }}
         run: |
           # --- CI stack build + start (background) ---
-          # Skip on plugin dispatch (backend code didn't change)
-          if [ "${{ github.event_name }}" != "repository_dispatch" ]; then
-            (
-              # Hash source files that affect the Docker image — skip rebuild if unchanged
-              IMG_HASH=$(find Dockerfile docker-compose.ci.yml mix.exs mix.lock config/ lib/ priv/ frontend/ \
-                -type f 2>/dev/null | sort | xargs md5sum 2>/dev/null | md5sum | cut -d' ' -f1)
-              CACHED_TAG="engram-ci:${IMG_HASH}"
+          (
+            # Hash source files that affect the Docker image — skip rebuild if unchanged
+            IMG_HASH=$(find Dockerfile docker-compose.ci.yml mix.exs mix.lock config/ lib/ priv/ frontend/ \
+              -type f 2>/dev/null | sort | xargs md5sum 2>/dev/null | md5sum | cut -d' ' -f1)
+            CACHED_TAG="engram-ci:${IMG_HASH}"
 
-              if docker image inspect "$CACHED_TAG" > /dev/null 2>&1; then
-                echo "Image $CACHED_TAG exists — skipping build"
-                docker tag "$CACHED_TAG" engram-ci-engram:latest
-                docker compose -f docker-compose.ci.yml -p engram-ci up -d --no-build --wait
-              else
-                echo "Image cache miss ($CACHED_TAG) — building"
-                docker compose -f docker-compose.ci.yml -p engram-ci up -d --build --wait
-                # Tag the built image for future cache hits
-                BUILT_IMG=$(docker images --format '{{.ID}}' --filter "reference=engram-ci-engram" | head -1)
-                if [ -n "$BUILT_IMG" ]; then
-                  docker tag "$BUILT_IMG" "$CACHED_TAG"
-                  echo "Tagged $BUILT_IMG as $CACHED_TAG"
-                fi
+            if docker image inspect "$CACHED_TAG" > /dev/null 2>&1; then
+              echo "Image $CACHED_TAG exists — skipping build"
+              docker tag "$CACHED_TAG" engram-ci-engram:latest
+              docker compose -f docker-compose.ci.yml -p engram-ci up -d --no-build --wait
+            else
+              echo "Image cache miss ($CACHED_TAG) — building"
+              docker compose -f docker-compose.ci.yml -p engram-ci up -d --build --wait
+              # Tag the built image for future cache hits
+              BUILT_IMG=$(docker images --format '{{.ID}}' --filter "reference=engram-ci-engram" | head -1)
+              if [ -n "$BUILT_IMG" ]; then
+                docker tag "$BUILT_IMG" "$CACHED_TAG"
+                echo "Tagged $BUILT_IMG as $CACHED_TAG"
               fi
+            fi
 
-              for i in $(seq 1 60); do
-                if curl -sf http://localhost:8100/api/health > /dev/null 2>&1; then
-                  echo "CI stack healthy"
-                  touch /tmp/ci-stack.marker
-                  break
-                fi
-                sleep 1
-              done
-              if [ ! -f /tmp/ci-stack.marker ]; then
-                echo "ERROR: CI stack failed to start" >&2
-                touch /tmp/ci-stack-failed.marker
+            for i in $(seq 1 60); do
+              if curl -sf http://localhost:8100/api/health > /dev/null 2>&1; then
+                echo "CI stack healthy"
+                touch /tmp/ci-stack.marker
+                break
               fi
-            ) > /tmp/ci-stack.log 2>&1 &
-            echo "CI stack build started (PID $!)"
-          else
-            touch /tmp/ci-stack.marker
-            echo "Skipping CI stack (repository_dispatch)"
-          fi
+              sleep 1
+            done
+            if [ ! -f /tmp/ci-stack.marker ]; then
+              echo "ERROR: CI stack failed to start" >&2
+              touch /tmp/ci-stack-failed.marker
+            fi
+          ) > /tmp/ci-stack.log 2>&1 &
+          echo "CI stack build started (PID $!)"
 
           # --- Plugin build (background) ---
           (
@@ -206,19 +200,16 @@ jobs:
       # ------------------------------------------------------------------
       - name: Wait for CI stack + plugin + Playwright + Ollama
         run: |
-          # CI stack (skip on plugin dispatch — backend code didn't change)
-          if [ "${{ github.event_name }}" != "repository_dispatch" ]; then
-            echo "Waiting for CI stack..."
-            for i in $(seq 1 300); do
-              if [ -f /tmp/ci-stack.marker ]; then echo "CI stack ready"; break; fi
-              if [ -f /tmp/ci-stack-failed.marker ]; then
-                echo "CI stack failed to start. Logs:"; cat /tmp/ci-stack.log; exit 1
-              fi
-              sleep 1
-            done
-            if [ ! -f /tmp/ci-stack.marker ]; then
-              echo "CI stack timed out (5 min). Logs:"; cat /tmp/ci-stack.log; exit 1
+          echo "Waiting for CI stack..."
+          for i in $(seq 1 300); do
+            if [ -f /tmp/ci-stack.marker ]; then echo "CI stack ready"; break; fi
+            if [ -f /tmp/ci-stack-failed.marker ]; then
+              echo "CI stack failed to start. Logs:"; cat /tmp/ci-stack.log; exit 1
             fi
+            sleep 1
+          done
+          if [ ! -f /tmp/ci-stack.marker ]; then
+            echo "CI stack timed out (5 min). Logs:"; cat /tmp/ci-stack.log; exit 1
           fi
 
           echo "Waiting for plugin build..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,9 +265,9 @@ jobs:
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
       # ------------------------------------------------------------------
-      # Phase B: API-only tests (run while Obsidian instances boot)
+      # API-only tests (run while Obsidian instances boot)
       # ------------------------------------------------------------------
-      - name: "Phase B: Run API-only tests (no Obsidian needed)"
+      - name: "Run API-only tests"
         id: api_tests
         working-directory: e2e
         run: python3 -m pytest tests/api_only/ -v --timeout=60
@@ -278,9 +278,9 @@ jobs:
           E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
 
       # ------------------------------------------------------------------
-      # Phase C: Full Obsidian E2E tests
+      # Obsidian E2E tests
       # ------------------------------------------------------------------
-      - name: "Phase C: Run Obsidian E2E tests"
+      - name: "Run Obsidian E2E tests"
         working-directory: e2e
         run: python3 -m pytest tests/ --ignore=tests/api_only/ -v --timeout=300
         env:
@@ -292,7 +292,7 @@ jobs:
       - name: Check API-only test results
         if: always() && steps.api_tests.outcome == 'failure'
         run: |
-          echo "::error::API-only tests failed in Phase B"
+          echo "::error::API-only tests failed"
           exit 1
 
       # ------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,32 +201,25 @@ jobs:
           echo "Ollama check started (PID $!)"
 
       # ------------------------------------------------------------------
-      # Wait for CI stack + plugin + Playwright
+      # Wait for all background tasks
       # ------------------------------------------------------------------
-      - name: Wait for CI stack
-        if: github.event_name != 'repository_dispatch'
+      - name: Wait for CI stack + plugin + Playwright + Ollama
         run: |
-          echo "Waiting for CI stack..."
-          for i in $(seq 1 300); do
-            if [ -f /tmp/ci-stack.marker ]; then
-              echo "CI stack ready"
-              break
+          # CI stack (skip on plugin dispatch — backend code didn't change)
+          if [ "${{ github.event_name }}" != "repository_dispatch" ]; then
+            echo "Waiting for CI stack..."
+            for i in $(seq 1 300); do
+              if [ -f /tmp/ci-stack.marker ]; then echo "CI stack ready"; break; fi
+              if [ -f /tmp/ci-stack-failed.marker ]; then
+                echo "CI stack failed to start. Logs:"; cat /tmp/ci-stack.log; exit 1
+              fi
+              sleep 1
+            done
+            if [ ! -f /tmp/ci-stack.marker ]; then
+              echo "CI stack timed out (5 min). Logs:"; cat /tmp/ci-stack.log; exit 1
             fi
-            if [ -f /tmp/ci-stack-failed.marker ]; then
-              echo "CI stack failed to start. Logs:"
-              cat /tmp/ci-stack.log
-              exit 1
-            fi
-            sleep 1
-          done
-          if [ ! -f /tmp/ci-stack.marker ]; then
-            echo "CI stack timed out (5 min). Logs:"
-            cat /tmp/ci-stack.log
-            exit 1
           fi
 
-      - name: Wait for plugin build + Playwright + Ollama
-        run: |
           echo "Waiting for plugin build..."
           for i in $(seq 1 300); do
             if [ -f /tmp/ci-plugin.marker ]; then echo "Plugin ready"; break; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,18 +270,7 @@ jobs:
       - name: "Phase B: Run API-only tests (no Obsidian needed)"
         id: api_tests
         working-directory: e2e
-        run: |
-          echo "Warm-up: waiting for API routes to finish loading..."
-          for i in $(seq 1 15); do
-            status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8100/api/sync/manifest 2>/dev/null || echo "000")
-            if [ "$status" != "404" ] && [ "$status" != "000" ]; then
-              echo "API routes ready (got $status)"
-              break
-            fi
-            sleep 1
-          done
-          echo "Running API-only tests..."
-          python3 -m pytest tests/api_only/ -v --timeout=60
+        run: python3 -m pytest tests/api_only/ -v --timeout=60
         continue-on-error: true
         env:
           ENGRAM_API_URL: http://localhost:8100/api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,3 +331,15 @@ jobs:
             | tail -n +4 | xargs -r docker rmi 2>/dev/null || true
           # Clean up ci-artifacts from this run
           rm -rf ci-artifacts/
+
+  ci:
+    if: always()
+    needs: [unit-tests, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required jobs
+        run: |
+          if [ "${{ needs.unit-tests.result }}" != "success" ] || [ "${{ needs.e2e.result }}" != "success" ]; then
+            echo "Required jobs failed: unit-tests=${{ needs.unit-tests.result }}, e2e=${{ needs.e2e.result }}"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,6 @@ on:
     types: [plugin-e2e-trigger]
   workflow_dispatch:
 
-# Fixed group — CI stack uses fixed ports, only one run at a time regardless of branch
-concurrency:
-  group: ci-engram-stack
-  cancel-in-progress: false
-
 env:
   DOCKER_BUILDKIT: "1"
   COMPOSE_DOCKER_CLI_BUILD: "1"
@@ -21,8 +16,66 @@ env:
   # When unset, falls back to Docker Hub.
 
 jobs:
-  ci:
+  unit-tests:
     runs-on: [self-hosted, engram]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: false  # Preserve _build/ and deps/ for incremental compilation
+
+      - name: Start ephemeral postgres
+        run: |
+          if [ -n "${LOCAL_REGISTRY:-}" ]; then
+            PG_IMAGE="${LOCAL_REGISTRY}/postgres:16-alpine"
+            docker pull "$PG_IMAGE" 2>/dev/null || PG_IMAGE="postgres:16-alpine"
+          else
+            PG_IMAGE="postgres:16-alpine"
+          fi
+          docker run -d --name engram-unit-test-db \
+            -e POSTGRES_USER=engram \
+            -e POSTGRES_PASSWORD=engram \
+            -e POSTGRES_DB=engram_test \
+            -p 5434:5432 \
+            --health-cmd "pg_isready -U engram" \
+            --health-interval 3s \
+            --health-timeout 3s \
+            --health-retries 10 \
+            "$PG_IMAGE"
+
+      - name: Fetch Elixir deps (skip if unchanged)
+        run: |
+          if [ -d deps ] && [ -f deps/.mix_lock_hash ] && [ "$(md5sum mix.lock | cut -d' ' -f1)" = "$(cat deps/.mix_lock_hash)" ]; then
+            echo "mix.lock unchanged — skipping deps.get"
+          else
+            mix deps.get --only test
+            md5sum mix.lock | cut -d' ' -f1 > deps/.mix_lock_hash
+          fi
+
+      - name: Run Elixir unit tests
+        env:
+          DATABASE_URL: postgresql://engram:engram@localhost:5434/engram_test
+        run: |
+          for i in $(seq 1 30); do
+            if docker exec engram-unit-test-db pg_isready -U engram > /dev/null 2>&1; then
+              echo "Test DB ready"
+              break
+            fi
+            sleep 1
+          done
+          MIX_ENV=test mix ecto.create
+          MIX_ENV=test mix ecto.migrate
+          mix test
+
+      - name: Stop ephemeral postgres
+        if: always()
+        run: docker rm -f engram-unit-test-db 2>/dev/null || true
+
+  e2e:
+    runs-on: [self-hosted, engram]
+    concurrency:
+      group: ci-engram-e2e
+      cancel-in-progress: false
 
     steps:
       # ------------------------------------------------------------------
@@ -31,7 +84,6 @@ jobs:
       - name: Pre-cleanup stale resources
         run: |
           docker compose -f docker-compose.ci.yml -p engram-ci down -v --remove-orphans 2>/dev/null || true
-          docker rm -f engram-test-db 2>/dev/null || true
           pkill -9 -f "e2e-obsidian-config" 2>/dev/null || true
           pkill -9 Xvfb 2>/dev/null || true
           rm -rf /tmp/e2e-vault-* /tmp/e2e-obsidian-config-* /tmp/ci-*.marker
@@ -51,27 +103,7 @@ jobs:
 
       # ------------------------------------------------------------------
       # Launch ALL long-running prep in parallel (background)
-      # Unit tests run in foreground while these build
       # ------------------------------------------------------------------
-      - name: Start test database
-        run: |
-          if [ -n "${LOCAL_REGISTRY:-}" ]; then
-            PG_IMAGE="${LOCAL_REGISTRY}/postgres:16-alpine"
-            docker pull "$PG_IMAGE" 2>/dev/null || PG_IMAGE="postgres:16-alpine"
-          else
-            PG_IMAGE="postgres:16-alpine"
-          fi
-          docker run -d --name engram-test-db \
-            -e POSTGRES_USER=engram \
-            -e POSTGRES_PASSWORD=engram \
-            -e POSTGRES_DB=engram_test \
-            -p 5434:5432 \
-            --health-cmd "pg_isready -U engram" \
-            --health-interval 3s \
-            --health-timeout 3s \
-            --health-retries 10 \
-            "$PG_IMAGE"
-
       - name: "Background: CI stack + plugin build + Playwright + Ollama"
         env:
           CLERK_JWKS_URL: ${{ secrets.CLERK_JWKS_URL }}
@@ -169,38 +201,7 @@ jobs:
           echo "Ollama check started (PID $!)"
 
       # ------------------------------------------------------------------
-      # Unit tests (Elixir) — foreground while prep builds
-      # ------------------------------------------------------------------
-      - name: Fetch Elixir deps (skip if unchanged)
-        run: |
-          if [ -d deps ] && [ -f deps/.mix_lock_hash ] && [ "$(md5sum mix.lock | cut -d' ' -f1)" = "$(cat deps/.mix_lock_hash)" ]; then
-            echo "mix.lock unchanged — skipping deps.get"
-          else
-            mix deps.get --only test
-            md5sum mix.lock | cut -d' ' -f1 > deps/.mix_lock_hash
-          fi
-
-      - name: Run Elixir unit tests
-        env:
-          DATABASE_URL: postgresql://engram:engram@localhost:5434/engram_test
-        run: |
-          for i in $(seq 1 30); do
-            if docker exec engram-test-db pg_isready -U engram > /dev/null 2>&1; then
-              echo "Test DB ready"
-              break
-            fi
-            sleep 1
-          done
-          MIX_ENV=test mix ecto.create
-          MIX_ENV=test mix ecto.migrate
-          mix test
-
-      - name: Stop test database
-        if: always()
-        run: docker rm -f engram-test-db 2>/dev/null || true
-
-      # ------------------------------------------------------------------
-      # E2E tests — wait for CI stack + plugin + Playwright, then run
+      # Wait for CI stack + plugin + Playwright
       # ------------------------------------------------------------------
       - name: Wait for CI stack
         if: github.event_name != 'repository_dispatch'
@@ -263,14 +264,38 @@ jobs:
           # Add bun to PATH for E2E tests (already installed by plugin build)
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
-      - name: Run E2E tests
+      # ------------------------------------------------------------------
+      # Phase B: API-only tests (run while Obsidian instances boot)
+      # ------------------------------------------------------------------
+      - name: "Phase B: Run API-only tests (no Obsidian needed)"
+        id: api_tests
         working-directory: e2e
-        run: python3 -m pytest tests/ -v --timeout=300
+        run: |
+          echo "Running API-only tests while Obsidian instances boot..."
+          python3 -m pytest tests/ -v -m "api_only" --timeout=60
+        continue-on-error: true
+        env:
+          ENGRAM_API_URL: http://localhost:8100/api
+          ENGRAM_PLUGIN_SRC: ${{ github.workspace }}/plugin-src
+          E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
+
+      # ------------------------------------------------------------------
+      # Phase C: Full Obsidian E2E tests
+      # ------------------------------------------------------------------
+      - name: "Phase C: Run Obsidian E2E tests"
+        working-directory: e2e
+        run: python3 -m pytest tests/ -v -m "not api_only" --timeout=300
         env:
           ENGRAM_API_URL: http://localhost:8100/api
           ENGRAM_PLUGIN_SRC: ${{ github.workspace }}/plugin-src
           CI_POSTGRES_CONTAINER: engram-ci-postgres-1
           E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
+
+      - name: Check API-only test results
+        if: always() && steps.api_tests.outcome == 'failure'
+        run: |
+          echo "::error::API-only tests failed in Phase B"
+          exit 1
 
       # ------------------------------------------------------------------
       # Cleanup — MUST kill everything, even on cancel/failure
@@ -312,7 +337,6 @@ jobs:
           rm -rf /tmp/e2e-vault-* /tmp/e2e-obsidian-config-* /tmp/ci-*.marker /tmp/ci-*.log
           # Tear down Docker stack
           docker compose -f docker-compose.ci.yml -p engram-ci down -v --remove-orphans 2>/dev/null || true
-          docker rm -f engram-test-db 2>/dev/null || true
           # Prune dangling images to reclaim disk (old CI builds)
           docker image prune -f 2>/dev/null || true
           # Keep only the 3 most recent engram-ci cache tags

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -29,6 +29,13 @@ from helpers.clerk import ClerkClient
 from helpers.clerk_auth import ClerkAuth, provision_clerk_user
 from helpers.obsidian import ObsidianInstance
 
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "api_only: tests that need no Obsidian instances"
+    )
+
+
 CLERK_SECRET = os.environ.get("E2E_CLERK_SECRET_KEY", "")
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -30,12 +30,6 @@ from helpers.clerk_auth import ClerkAuth, provision_clerk_user
 from helpers.obsidian import ObsidianInstance
 
 
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "api_only: tests that need no Obsidian instances"
-    )
-
-
 CLERK_SECRET = os.environ.get("E2E_CLERK_SECRET_KEY", "")
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -27,6 +27,8 @@ class CdpClient:
         self.port = port
         self.host = host
         self._base_url = f"http://{host}:{port}"
+        self._ws = None
+        self._msg_id = 0
 
     def _get_ws_url(self) -> str:
         resp = requests.get(f"{self._base_url}/json", timeout=5)
@@ -36,15 +38,39 @@ class CdpClient:
             raise CdpError("No CDP pages available")
         return pages[0]["webSocketDebuggerUrl"]
 
+    async def _ensure_connected(self) -> None:
+        """Ensure WebSocket is connected, reconnect if stale."""
+        if self._ws is not None:
+            try:
+                pong = await self._ws.ping()
+                await asyncio.wait_for(pong, timeout=2)
+                return
+            except Exception:
+                await self._close()
+
+        ws_url = self._get_ws_url()
+        self._ws = await websockets.connect(ws_url)
+
+    async def _close(self) -> None:
+        """Close WebSocket if open."""
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
     async def evaluate(self, expr: str, await_promise: bool = False) -> Any:
         """Evaluate JS expression in Obsidian's renderer process.
 
-        Opens a fresh WebSocket per call to avoid stale connections.
+        Uses a persistent WebSocket connection, reconnecting on failure.
         """
-        ws_url = self._get_ws_url()
-        async with websockets.connect(ws_url) as ws:
+        self._msg_id += 1
+        msg_id = self._msg_id
+
+        async def _send_recv() -> Any:
             msg = {
-                "id": 1,
+                "id": msg_id,
                 "method": "Runtime.evaluate",
                 "params": {
                     "expression": expr,
@@ -52,8 +78,8 @@ class CdpClient:
                     "awaitPromise": await_promise,
                 },
             }
-            await ws.send(json.dumps(msg))
-            resp = json.loads(await ws.recv())
+            await self._ws.send(json.dumps(msg))
+            resp = json.loads(await self._ws.recv())
 
             if "error" in resp:
                 raise CdpError(f"CDP error: {resp['error']}")
@@ -66,6 +92,17 @@ class CdpClient:
             if result.get("subtype") == "error":
                 raise CdpError(f"JS error: {result.get('description', result)}")
             return result
+
+        await self._ensure_connected()
+        try:
+            return await _send_recv()
+        except CdpError:
+            raise
+        except Exception:
+            # Reconnect once and retry on connection-level failures
+            await self._close()
+            await self._ensure_connected()
+            return await _send_recv()
 
     async def wait_for_plugin_ready(self, timeout: float = 30) -> None:
         """Poll until the engram-sync plugin's SyncEngine reports ready."""
@@ -313,6 +350,18 @@ class CdpClient:
         """Read the offline queue size."""
         result = await self.evaluate(f"{ENGINE_PATH}.queue.size")
         return result if isinstance(result, int) else 0
+
+    async def wait_for_queue_drain(self, timeout: float = 10, poll: float = 0.5) -> None:
+        """Poll until the offline queue is empty."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            size = await self.get_queue_size()
+            if size == 0:
+                return
+            await asyncio.sleep(poll)
+        raise TimeoutError(
+            f"Queue not drained after {timeout}s, size={await self.get_queue_size()}"
+        )
 
     async def get_queue_entries(self) -> list[dict]:
         """Dump queue entries for diagnostics (path, action, timestamp)."""

--- a/e2e/helpers/obsidian.py
+++ b/e2e/helpers/obsidian.py
@@ -26,6 +26,8 @@ from .cdp import CdpClient
 logger = logging.getLogger(__name__)
 
 DEFAULT_OBSIDIAN_BIN = Path.home() / "Applications" / "Obsidian.AppImage"
+# Pre-extracted directory (created by setup-runner.sh) skips squashfs extraction
+DEFAULT_OBSIDIAN_EXTRACTED = Path.home() / "Applications" / "obsidian-extracted"
 
 
 class ObsidianInstance:
@@ -176,21 +178,41 @@ class ObsidianInstance:
         logger.info("[%s] Xvfb started on %s", self.name, self.display)
 
     def _start_obsidian(self) -> None:
-        """Launch Obsidian AppImage with isolated config."""
+        """Launch Obsidian with isolated config.
+
+        Prefers pre-extracted binary (skips squashfs extraction, saves ~15-30s).
+        Falls back to AppImage with --appimage-extract-and-run if not available.
+        """
         env = {
             "DISPLAY": self.display,
             "HOME": str(Path.home()),
             "PATH": "/usr/bin:/bin:/usr/local/bin",
         }
-        cmd = [
-            str(self.obsidian_bin),
-            "--appimage-extract-and-run",
-            "--no-sandbox",
-            f"--remote-debugging-port={self.cdp_port}",
-            "--remote-allow-origins=http://127.0.0.1",
-            "--disable-gpu",
-            f"--user-data-dir={self.config_dir}",
-        ]
+
+        # Use pre-extracted binary if available (setup-runner.sh creates this)
+        extracted_bin = DEFAULT_OBSIDIAN_EXTRACTED / "obsidian"
+        if extracted_bin.exists():
+            cmd = [
+                str(extracted_bin),
+                "--no-sandbox",
+                f"--remote-debugging-port={self.cdp_port}",
+                "--remote-allow-origins=http://127.0.0.1",
+                "--disable-gpu",
+                f"--user-data-dir={self.config_dir}",
+            ]
+            logger.info("[%s] Using pre-extracted binary", self.name)
+        else:
+            cmd = [
+                str(self.obsidian_bin),
+                "--appimage-extract-and-run",
+                "--no-sandbox",
+                f"--remote-debugging-port={self.cdp_port}",
+                "--remote-allow-origins=http://127.0.0.1",
+                "--disable-gpu",
+                f"--user-data-dir={self.config_dir}",
+            ]
+            logger.info("[%s] Using AppImage (no pre-extracted binary found)", self.name)
+
         self._obsidian_proc = subprocess.Popen(
             cmd,
             env=env,

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -2,3 +2,5 @@
 asyncio_mode = auto
 timeout = 180
 testpaths = tests
+reruns = 1
+reruns_delay = 2

--- a/e2e/tests/api_only/conftest.py
+++ b/e2e/tests/api_only/conftest.py
@@ -1,14 +1,15 @@
 """Fixtures for API-only tests (no Obsidian needed).
 
 These tests run during the Obsidian boot gap in CI.  The freshly
-provisioned Clerk user has no vault yet (Obsidian hasn't registered
-one), so we create one here to satisfy VaultPlug.
+provisioned Clerk users have no vault yet (Obsidian hasn't registered
+one), so we create them here to satisfy VaultPlug.
 """
 
 import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)
-def ensure_vault(api_sync):
-    """Create a default vault so vault-scoped endpoints don't 404."""
+def ensure_vaults(api_sync, api_iso):
+    """Create default vaults so vault-scoped endpoints don't 404."""
     api_sync.create_vault("e2e-api-only")
+    api_iso.create_vault("e2e-api-only-iso")

--- a/e2e/tests/api_only/conftest.py
+++ b/e2e/tests/api_only/conftest.py
@@ -1,0 +1,14 @@
+"""Fixtures for API-only tests (no Obsidian needed).
+
+These tests run during the Obsidian boot gap in CI.  The freshly
+provisioned Clerk user has no vault yet (Obsidian hasn't registered
+one), so we create one here to satisfy VaultPlug.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_vault(api_sync):
+    """Create a default vault so vault-scoped endpoints don't 404."""
+    api_sync.create_vault("e2e-api-only")

--- a/e2e/tests/api_only/test_17_remote_logging_errors.py
+++ b/e2e/tests/api_only/test_17_remote_logging_errors.py
@@ -9,8 +9,6 @@ from datetime import datetime, timezone
 
 import pytest
 
-pytestmark = pytest.mark.api_only
-
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()

--- a/e2e/tests/api_only/test_19_write_isolation.py
+++ b/e2e/tests/api_only/test_19_write_isolation.py
@@ -4,14 +4,14 @@ Test 08 proves READ isolation (user A can't see user C's data).
 This test proves WRITE isolation across all mutation endpoints: user C cannot
 modify, overwrite, rename, append to, or delete user A's notes or attachments,
 even with valid credentials for a different account.
+
+Migrated to API-only: seeds data via api_sync.create_note() instead of Obsidian
+vault writes, so these 11 tests run during the Obsidian boot gap in CI.
 """
 
 import time
 
 import pytest
-import requests
-
-from helpers.vault import write_note
 
 
 # ---------------------------------------------------------------------------
@@ -20,15 +20,13 @@ from helpers.vault import write_note
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_cannot_modify_other_user_note(
-    vault_a, cdp_a, api_sync, api_iso
-):
+async def test_write_isolation_cannot_modify_other_user_note(api_sync, api_iso):
     """User C (isolation-user) cannot overwrite user A's note via POST /notes."""
     path = "E2E/WriteIsolationTarget.md"
     original_content = "# Write Isolation\nThis belongs to sync-user."
 
-    # sync-user creates a note
-    write_note(vault_a, path, original_content)
+    # sync-user creates a note via API
+    api_sync.create_note(path, original_content)
     api_sync.wait_for_note(path, timeout=10)
 
     # isolation-user attempts to overwrite it via API
@@ -48,13 +46,11 @@ async def test_write_isolation_cannot_modify_other_user_note(
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_cannot_delete_other_user_note(
-    vault_a, cdp_a, api_sync, api_iso
-):
+async def test_write_isolation_cannot_delete_other_user_note(api_sync, api_iso):
     """User C (isolation-user) cannot delete user A's note."""
     path = "E2E/WriteIsolationDeleteTarget.md"
 
-    write_note(vault_a, path, "# Protected\nThis should survive deletion attempts.")
+    api_sync.create_note(path, "# Protected\nThis should survive deletion attempts.")
     api_sync.wait_for_note(path, timeout=10)
 
     # isolation-user attempts to delete sync-user's note
@@ -70,11 +66,11 @@ async def test_write_isolation_cannot_delete_other_user_note(
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_changes_endpoint(api_sync, api_iso, vault_a, cdp_a):
+async def test_write_isolation_changes_endpoint(api_sync, api_iso):
     """User C should not see user A's changes in GET /notes/changes."""
     path = "E2E/WriteIsolationChanges.md"
 
-    write_note(vault_a, path, "# Changes Test\nOnly sync-user should see this.")
+    api_sync.create_note(path, "# Changes Test\nOnly sync-user should see this.")
     api_sync.wait_for_note(path, timeout=10)
 
     since = "2000-01-01T00:00:00Z"
@@ -92,14 +88,12 @@ async def test_write_isolation_changes_endpoint(api_sync, api_iso, vault_a, cdp_
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_cannot_rename_other_user_note(
-    vault_a, cdp_a, api_sync, api_iso
-):
+async def test_write_isolation_cannot_rename_other_user_note(api_sync, api_iso):
     """User C cannot rename user A's note via POST /notes/rename."""
     path = "E2E/WriteIsolationRenameTarget.md"
     renamed_path = "E2E/Hijacked-Rename.md"
 
-    write_note(vault_a, path, "# Rename Target\nThis should not be renamed by others.")
+    api_sync.create_note(path, "# Rename Target\nThis should not be renamed by others.")
     api_sync.wait_for_note(path, timeout=10)
 
     # isolation-user attempts to rename sync-user's note
@@ -127,14 +121,12 @@ async def test_write_isolation_cannot_rename_other_user_note(
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_cannot_append_to_other_user_note(
-    vault_a, cdp_a, api_sync, api_iso
-):
+async def test_write_isolation_cannot_append_to_other_user_note(api_sync, api_iso):
     """User C cannot append to user A's note via POST /notes/append."""
     path = "E2E/WriteIsolationAppendTarget.md"
     original = "# Append Target\nOriginal content only."
 
-    write_note(vault_a, path, original)
+    api_sync.create_note(path, original)
     api_sync.wait_for_note(path, timeout=10)
 
     # isolation-user attempts to append to sync-user's note
@@ -155,9 +147,7 @@ async def test_write_isolation_cannot_append_to_other_user_note(
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_cannot_read_other_user_attachment(
-    vault_a, cdp_a, api_sync, api_iso
-):
+async def test_write_isolation_cannot_read_other_user_attachment(api_sync, api_iso):
     """User C cannot read user A's attachment via GET /attachments/{path}."""
     att_path = "E2E/secret-image.png"
     fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100  # minimal PNG-like header
@@ -175,9 +165,7 @@ async def test_write_isolation_cannot_read_other_user_attachment(
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_cannot_delete_other_user_attachment(
-    vault_a, cdp_a, api_sync, api_iso
-):
+async def test_write_isolation_cannot_delete_other_user_attachment(api_sync, api_iso):
     """User C cannot delete user A's attachment via DELETE /attachments/{path}."""
     att_path = "E2E/protected-file.pdf"
     fake_pdf = b"%PDF-1.4 " + b"\x00" * 100
@@ -203,12 +191,10 @@ async def test_write_isolation_cannot_delete_other_user_attachment(
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_cannot_rename_other_user_folder(
-    vault_a, cdp_a, api_sync, api_iso
-):
+async def test_write_isolation_cannot_rename_other_user_folder(api_sync, api_iso):
     """User C cannot rename user A's folder via POST /folders/rename."""
     path = "E2E/IsoFolder/FolderRenameTarget.md"
-    write_note(vault_a, path, "# Folder Target\nInside a folder owned by sync-user.")
+    api_sync.create_note(path, "# Folder Target\nInside a folder owned by sync-user.")
     api_sync.wait_for_note(path, timeout=10)
 
     # isolation-user attempts to rename sync-user's folder
@@ -234,12 +220,10 @@ async def test_write_isolation_cannot_rename_other_user_folder(
 
 
 @pytest.mark.asyncio
-async def test_write_isolation_manifest_does_not_leak(
-    vault_a, cdp_a, api_sync, api_iso
-):
+async def test_write_isolation_manifest_does_not_leak(api_sync, api_iso):
     """User C's sync manifest should not include user A's notes or attachments."""
     path = "E2E/ManifestIsolation.md"
-    write_note(vault_a, path, "# Manifest Test\nShould not appear in other manifest.")
+    api_sync.create_note(path, "# Manifest Test\nShould not appear in other manifest.")
     api_sync.wait_for_note(path, timeout=10)
 
     # sync-user's manifest should include the note

--- a/e2e/tests/api_only/test_35_sync_manifest.py
+++ b/e2e/tests/api_only/test_35_sync_manifest.py
@@ -8,8 +8,6 @@ duplicate, or stale entries within the test prefix cause failure.
 
 import pytest
 
-pytestmark = pytest.mark.api_only
-
 
 @pytest.mark.asyncio
 async def test_manifest_after_crud(api_sync):

--- a/e2e/tests/api_only/test_40_storage_endpoint.py
+++ b/e2e/tests/api_only/test_40_storage_endpoint.py
@@ -8,8 +8,6 @@ import time
 
 import pytest
 
-pytestmark = pytest.mark.api_only
-
 
 @pytest.mark.asyncio
 async def test_storage_endpoint(api_sync):

--- a/e2e/tests/test_11_ignore_patterns.py
+++ b/e2e/tests/test_11_ignore_patterns.py
@@ -40,7 +40,7 @@ async def test_ignore_patterns(vault_a, cdp_a, api_sync):
         # Negative assertion: prove the ignored file did NOT sync.
         # A sleep is appropriate here — there's nothing to poll for, and the control
         # file above already proved the sync pipeline is active and working.
-        time.sleep(2)
+        time.sleep(1)
         note = api_sync.get_note(ignored_path)
         assert note is None, (
             f"Ignored file '{ignored_path}' appeared on server despite matching "

--- a/e2e/tests/test_17_remote_logging_errors.py
+++ b/e2e/tests/test_17_remote_logging_errors.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 
 import pytest
 
+pytestmark = pytest.mark.api_only
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()

--- a/e2e/tests/test_24_offline_queue_replay.py
+++ b/e2e/tests/test_24_offline_queue_replay.py
@@ -26,11 +26,15 @@ async def test_offline_queue_replay(vault_a, cdp_a, api_sync):
     try:
         # Write 2 files — push attempts will fail and enqueue
         write_note(vault_a, path1, "# Offline Note 1\nQueued while offline")
-        time.sleep(0.7)  # Space apart to ensure separate push attempts
+        time.sleep(0.3)  # Space apart to ensure separate push attempts
         write_note(vault_a, path2, "# Offline Note 2\nAlso queued while offline")
 
         # Wait for push attempts to fail and queue
-        await asyncio.sleep(3)
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if await cdp_a.get_queue_size() >= 2:
+                break
+            await asyncio.sleep(0.5)
 
         # Verify offline state
         assert await cdp_a.get_offline_status(), "Engine should be offline"
@@ -39,7 +43,7 @@ async def test_offline_queue_replay(vault_a, cdp_a, api_sync):
     finally:
         # MUST restore even if assertions fail — prevents cascade
         await cdp_a.restore_online()
-        await asyncio.sleep(3)
+        await cdp_a.wait_for_queue_drain(timeout=10)
 
     # Verify both notes reached the server
     api_sync.wait_for_note(path1, timeout=10)

--- a/e2e/tests/test_25_push_409_conflict.py
+++ b/e2e/tests/test_25_push_409_conflict.py
@@ -37,7 +37,12 @@ async def test_push_409_handled(vault_a, cdp_a, api_sync):
     write_note(vault_a, path, local_content)
 
     # Wait for push attempt + conflict resolution
-    await asyncio.sleep(5)
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        a_content = read_note(vault_a, path)
+        if "edited by A" in a_content:
+            break
+        await asyncio.sleep(0.5)
 
     # 4. Verify: the note should be in a consistent state
     #    Either auto-merged (both edits) or conflict-resolved
@@ -66,7 +71,7 @@ async def test_push_409_handled(vault_a, cdp_a, api_sync):
                 return 'touched';
             }})()
         """, await_promise=True)
-        await asyncio.sleep(3)
+        await asyncio.sleep(1)
         api_sync.wait_for_note_content(path, "edited by A", timeout=10)
         api_sync.wait_for_note_content(path, "edited by server", timeout=10)
     else:

--- a/e2e/tests/test_26_large_file_rejected.py
+++ b/e2e/tests/test_26_large_file_rejected.py
@@ -5,8 +5,6 @@ Oversized notes should not be persisted, and the error should not block
 other syncs from completing.
 """
 
-import asyncio
-
 import pytest
 
 from helpers.vault import write_note
@@ -22,13 +20,13 @@ async def test_large_file_rejected(vault_a, cdp_a, api_sync):
     large_content = "# Large Note\n" + ("x" * (11 * 1024 * 1024))
     write_note(vault_a, large_path, large_content)
 
-    # Wait for push attempt
-    await asyncio.sleep(2)
+    # Write a normal file — should sync fine (no cascading failure from 413)
+    write_note(vault_a, normal_path, "# Normal Note\nShould sync after large file rejection")
+
+    # Poll for the normal note — once it arrives, the push cycle has completed
+    # and the large note has already been attempted and rejected
+    api_sync.wait_for_note(normal_path, timeout=10)
 
     # Large note should NOT be on server (413 rejection)
     note = api_sync.get_note(large_path)
     assert note is None, "Large note should not be pushed to server"
-
-    # Write a normal file — should sync fine (no cascading failure)
-    write_note(vault_a, normal_path, "# Normal Note\nShould sync after large file rejection")
-    api_sync.wait_for_note(normal_path, timeout=10)

--- a/e2e/tests/test_26_large_file_rejected.py
+++ b/e2e/tests/test_26_large_file_rejected.py
@@ -23,7 +23,7 @@ async def test_large_file_rejected(vault_a, cdp_a, api_sync):
     write_note(vault_a, large_path, large_content)
 
     # Wait for push attempt
-    await asyncio.sleep(5)
+    await asyncio.sleep(2)
 
     # Large note should NOT be on server (413 rejection)
     note = api_sync.get_note(large_path)

--- a/e2e/tests/test_28_queue_deduplication.py
+++ b/e2e/tests/test_28_queue_deduplication.py
@@ -30,7 +30,7 @@ async def test_queue_deduplication(vault_a, cdp_a, api_sync):
         # each triggers a separate push attempt (all fail → enqueue → dedup).
         for i in range(1, 6):
             write_note(vault_a, path, f"# Queue Dedup\nVersion {i}")
-            time.sleep(0.7)
+            time.sleep(0.55)  # Just above debounceMs (500ms) to ensure separate push attempts
 
         # Wait for push attempts to fail and queue
         deadline = time.monotonic() + 10

--- a/e2e/tests/test_28_queue_deduplication.py
+++ b/e2e/tests/test_28_queue_deduplication.py
@@ -32,8 +32,12 @@ async def test_queue_deduplication(vault_a, cdp_a, api_sync):
             write_note(vault_a, path, f"# Queue Dedup\nVersion {i}")
             time.sleep(0.7)
 
-        # Wait for all push attempts to fail and queue
-        await asyncio.sleep(3)
+        # Wait for push attempts to fail and queue
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if await cdp_a.get_queue_size() >= 1:
+                break
+            await asyncio.sleep(0.5)
 
         # Queue deduplicates by path (Map keyed by path). Should be 1 entry,
         # but timing between debounce fires can occasionally produce 2 if a
@@ -52,7 +56,7 @@ async def test_queue_deduplication(vault_a, cdp_a, api_sync):
     finally:
         # MUST restore online even if assertions fail — otherwise test_29+ cascade
         await cdp_a.restore_online()
-        await asyncio.sleep(3)
+        await cdp_a.wait_for_queue_drain(timeout=10)
 
     # Server should have the FINAL version
     note = api_sync.wait_for_note(path, timeout=10)

--- a/e2e/tests/test_29_offline_multi_file_flush.py
+++ b/e2e/tests/test_29_offline_multi_file_flush.py
@@ -32,10 +32,14 @@ async def test_offline_multi_file_flush(vault_a, cdp_a, api_sync):
         # Create 3 files with spacing for separate push attempts
         for i, path in enumerate(paths, 1):
             write_note(vault_a, path, f"# Multi Flush {i}\nCreated while offline")
-            time.sleep(0.7)
+            time.sleep(0.3)
 
         # Wait for push attempts to fail and queue
-        await asyncio.sleep(3)
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if await cdp_a.get_queue_size() >= 3:
+                break
+            await asyncio.sleep(0.5)
 
         queue_size = await cdp_a.get_queue_size()
         assert queue_size >= 3, (
@@ -45,7 +49,7 @@ async def test_offline_multi_file_flush(vault_a, cdp_a, api_sync):
     finally:
         # MUST restore even if assertions fail — prevents cascade to later tests
         await cdp_a.restore_online()
-        await asyncio.sleep(5)
+        await cdp_a.wait_for_queue_drain(timeout=15)
 
     # All 3 notes should be on server
     for path in paths:

--- a/e2e/tests/test_31_restart_preserves_queue.py
+++ b/e2e/tests/test_31_restart_preserves_queue.py
@@ -56,20 +56,18 @@ async def test_restart_preserves_queue(vault_a, cdp_a, api_sync, obsidian_a):
 
     # 4. Kill Obsidian A (hard stop — simulates crash)
     obsidian_a.stop()
-    await asyncio.sleep(2)
+    await asyncio.sleep(1)
 
     # 5. Restart Obsidian A (restart=True preserves vault + data.json with queue)
     await obsidian_a.async_start(restart=True)
     await cdp_a.wait_for_plugin_ready(timeout=60)
 
     # 6. Startup sync should restore queue and flush it
-    #    Give it time for initial sync to complete
-    await asyncio.sleep(10)
+    #    Poll instead of hard sleep — returns as soon as notes arrive
+    note1 = api_sync.wait_for_note(path1, timeout=15)
+    note2 = api_sync.wait_for_note(path2, timeout=15)
 
     # 7. Both notes should now be on server
-    note1 = api_sync.get_note(path1)
-    note2 = api_sync.get_note(path2)
-
     assert note1 is not None, f"{path1} should be on server after restart"
     assert note2 is not None, f"{path2} should be on server after restart"
     assert "Survives restart" in note1["content"]

--- a/e2e/tests/test_31_restart_preserves_queue.py
+++ b/e2e/tests/test_31_restart_preserves_queue.py
@@ -27,12 +27,16 @@ async def test_restart_preserves_queue(vault_a, cdp_a, api_sync, obsidian_a):
 
     # 2. Create 2 files → push fails → queued
     write_note(vault_a, path1, "# Restart Queue 1\nSurvives restart")
-    time.sleep(0.7)
+    time.sleep(0.3)
     write_note(vault_a, path2, "# Restart Queue 2\nAlso survives restart")
 
-    # Wait for push attempts + queueing
-    await asyncio.sleep(3)
-    queue_size = await cdp_a.get_queue_size()
+    # Wait for push attempts to fail and queue
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        queue_size = await cdp_a.get_queue_size()
+        if queue_size >= 2:
+            break
+        await asyncio.sleep(0.5)
     assert queue_size >= 2, f"Expected at least 2 queued, got {queue_size}"
 
     # 3. Force persist queue to data.json (bypass debounce)

--- a/e2e/tests/test_33_attachment_sync.py
+++ b/e2e/tests/test_33_attachment_sync.py
@@ -67,7 +67,7 @@ async def test_attachment_delete_propagation(vault_a, vault_b, cdp_a, cdp_b, api
         await cdp_b.trigger_full_sync()
         if (vault_b / att_path).exists():
             break
-        time.sleep(1)
+        time.sleep(0.5)
     assert (vault_b / att_path).exists(), "B should have attachment before delete"
 
     # A deletes the attachment
@@ -87,5 +87,5 @@ async def test_attachment_delete_propagation(vault_a, vault_b, cdp_a, cdp_b, api
         await cdp_b.trigger_full_sync()
         if not (vault_b / att_path).exists():
             break
-        time.sleep(1)
+        time.sleep(0.5)
     assert not (vault_b / att_path).exists(), "B should not have deleted attachment"

--- a/e2e/tests/test_33_attachment_sync.py
+++ b/e2e/tests/test_33_attachment_sync.py
@@ -67,7 +67,7 @@ async def test_attachment_delete_propagation(vault_a, vault_b, cdp_a, cdp_b, api
         await cdp_b.trigger_full_sync()
         if (vault_b / att_path).exists():
             break
-        time.sleep(2)
+        time.sleep(1)
     assert (vault_b / att_path).exists(), "B should have attachment before delete"
 
     # A deletes the attachment
@@ -87,5 +87,5 @@ async def test_attachment_delete_propagation(vault_a, vault_b, cdp_a, cdp_b, api
         await cdp_b.trigger_full_sync()
         if not (vault_b / att_path).exists():
             break
-        time.sleep(2)
+        time.sleep(1)
     assert not (vault_b / att_path).exists(), "B should not have deleted attachment"

--- a/e2e/tests/test_35_sync_manifest.py
+++ b/e2e/tests/test_35_sync_manifest.py
@@ -8,6 +8,8 @@ duplicate, or stale entries within the test prefix cause failure.
 
 import pytest
 
+pytestmark = pytest.mark.api_only
+
 
 @pytest.mark.asyncio
 async def test_manifest_after_crud(api_sync):

--- a/e2e/tests/test_40_storage_endpoint.py
+++ b/e2e/tests/test_40_storage_endpoint.py
@@ -8,6 +8,8 @@ import time
 
 import pytest
 
+pytestmark = pytest.mark.api_only
+
 
 @pytest.mark.asyncio
 async def test_storage_endpoint(api_sync):


### PR DESCRIPTION
## Summary

- Remove `repository_dispatch` conditional that skipped CI stack startup in the E2E job
- Remove matching conditional in the wait step

The plugin repo dispatches `plugin-e2e-trigger` to run E2E tests against a real backend, but the CI stack was being skipped on dispatch — all 79 E2E tests failed with `Connection refused` on `localhost:8100`. The image-hash cache already prevents unnecessary Docker rebuilds when backend code hasn't changed, making the dispatch-skip both redundant and broken.

## Test plan

- [ ] Push to plugin repo `feat/community-plugin-submission` branch triggers E2E run that actually connects to the CI stack
- [ ] Direct push to engram repo still builds and runs E2E normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)