### PR TITLE
feat: report E2E status back to plugin repo on dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,33 @@ jobs:
           exit 1
 
       # ------------------------------------------------------------------
+      # Report E2E status back to the plugin repo (dispatch only)
+      # ------------------------------------------------------------------
+      - name: Report E2E status to plugin repo
+        if: always() && github.event_name == 'repository_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
+        run: |
+          PLUGIN_SHA="${{ github.event.client_payload.plugin_ref }}"
+          if [ -z "$PLUGIN_SHA" ]; then
+            echo "No plugin_ref in payload, skipping status report"
+            exit 0
+          fi
+          # Determine overall E2E result from prior steps
+          if [ "${{ job.status }}" = "success" ]; then
+            STATE="success"
+            DESC="E2E tests passed"
+          else
+            STATE="failure"
+            DESC="E2E tests failed"
+          fi
+          gh api "repos/Rasbandit/Engram-obsidian-sync/statuses/${PLUGIN_SHA}" \
+            -f state="$STATE" \
+            -f context="backend/e2e" \
+            -f description="$DESC" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      # ------------------------------------------------------------------
       # Cleanup — MUST kill everything, even on cancel/failure
       # ------------------------------------------------------------------
       - name: Collect failure logs


### PR DESCRIPTION
## Summary

- After E2E job completes on `repository_dispatch`, post a commit status (`backend/e2e`) back to the plugin repo's commit SHA
- Reports success or failure with a link back to the Engram CI run
- Only runs on `repository_dispatch` events — no effect on regular pushes

This closes the loop on the cross-repo CI: the plugin repo's branch protection requires `backend/e2e` as a status check, but until now the Engram E2E never reported back. Each plugin push dispatches E2E, and now E2E reports the result on the exact commit, so the plugin PR becomes mergeable.

## Test plan

- [ ] Merge this, then push a no-op commit to the plugin PR — verify `backend/e2e` status appears on the PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)