### PR TITLE
fix: add continue-on-error to E2E status callback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,7 @@ jobs:
       # ------------------------------------------------------------------
       - name: Report E2E status to plugin repo
         if: always() && github.event_name == 'repository_dispatch'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
         run: |


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the status report step so a PAT permission issue doesn't fail the E2E job

The `CROSS_REPO_PAT` currently lacks `repo:status` scope, causing the callback to 403. This makes the E2E job report failure even though all tests passed. With `continue-on-error`, the step can fail without masking the actual test results.

**Action needed:** Update `CROSS_REPO_PAT` to include `repo:status` scope (classic) or "Commit statuses: Read and write" (fine-grained) so the callback actually works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)