### PR TITLE
fix: resolve full SHA for plugin status callback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,11 +289,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
         run: |
-          PLUGIN_SHA="${{ github.event.client_payload.plugin_ref }}"
-          if [ -z "$PLUGIN_SHA" ]; then
+          SHORT_SHA="${{ github.event.client_payload.plugin_ref }}"
+          if [ -z "$SHORT_SHA" ]; then
             echo "No plugin_ref in payload, skipping status report"
             exit 0
           fi
+          # Resolve to full 40-char SHA (short SHAs from manual dispatches won't work)
+          PLUGIN_SHA=$(gh api "repos/Rasbandit/Engram-obsidian-sync/commits/${SHORT_SHA}" --jq '.sha')
           # Determine overall E2E result from prior steps
           if [ "${{ job.status }}" = "success" ]; then
             STATE="success"


### PR DESCRIPTION
## Summary

- Resolve short SHA to full 40-char SHA via the commits API before posting commit status

The GitHub statuses API silently accepts but doesn't actually apply statuses when given a short SHA. The plugin CI sends `github.sha` (full SHA) so automated dispatches work, but manual dispatches with short SHAs would fail silently.

## Test plan

- [x] Manual dispatch with short SHA `14a49dc` now resolves correctly
- [x] Plugin PR #13 shows `backend/e2e: SUCCESS` and is mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)