### PR TITLE
fix(ci): parallel-safe CI + automated FastRaid deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
           echo "Plugin branch: $BRANCH"
           if [ -d plugin-src/.git ]; then
             cd plugin-src
+            git checkout -- .
+            git clean -fd
             git fetch origin "$BRANCH"
             git checkout "$BRANCH"
             git pull origin "$BRANCH"


### PR DESCRIPTION
## Summary
- **Fix plugin checkout**: reset `plugin-src/` working dir before branch switch (stale `main.js` from prior builds)
- **Parallel-safe unit tests**: dynamic postgres container name + random port via `GITHUB_RUN_ID`
- **Parallel-safe e2e tests**: remove concurrency lock — all resources (compose project, ports, marker files, vault paths, Xvfb displays, CDP ports) isolated per run
- **Automated FastRaid deploy**: on merge to main, build + push to GHCR, trigger Unraid native container update via SSH
- **Version enforcement**: deploy fails if `mix.exs` version already exists in GHCR (forces bump on every merge)

## What changed

| File | Change |
|------|--------|
| `ci.yml` | Dynamic ports for unit-test postgres, full e2e isolation, deploy job |
| `docker-compose.ci.yml` | Ports overridable via `CI_ENGRAM_PORT` / `CI_PG_PORT` / `CI_QDRANT_PORT` |
| `e2e/conftest.py` | Read vault paths, CDP ports, display numbers from env vars |
| `e2e/helpers/obsidian.py` | Accept optional `config_dir` parameter |
| `deploy/fastraid-deploy.sh` | Pull + trigger `updateDocker.php` + health check |

## Test plan
- [ ] CI passes with parallel-safe isolation (no port conflicts)
- [ ] `make ci-up` still works locally (env var defaults match old hardcoded values)
- [ ] Deploy job skipped on feature branches, runs on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)