### PR TITLE
fix: OAuth token refresh, channel topic, deploy + E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,14 @@ jobs:
           # Xvfb display numbers (offset by run number to avoid collisions)
           DISPLAY_BASE=$(( (GITHUB_RUN_NUMBER % 30) * 3 + 50 ))
 
+          # Validate all ports are non-empty (get_free_port can fail silently)
+          for var in ENGRAM_PORT PG_PORT QDRANT_PORT CDP_PORT_A CDP_PORT_B CDP_PORT_C; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Port allocation failed for $var"
+              exit 1
+            fi
+          done
+
           echo "engram_port=$ENGRAM_PORT" >> "$GITHUB_OUTPUT"
           echo "pg_port=$PG_PORT" >> "$GITHUB_OUTPUT"
           echo "qdrant_port=$QDRANT_PORT" >> "$GITHUB_OUTPUT"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -104,11 +104,11 @@ end
 
 # Clerk auth (JWKS for JWT verification)
 if clerk_jwks_url = System.get_env("CLERK_JWKS_URL") do
-  config :engram, :clerk_jwks_url, clerk_jwks_url
+  config :engram, :clerk_jwks_url, String.trim(clerk_jwks_url)
 end
 
 if clerk_issuer = System.get_env("CLERK_ISSUER") do
-  config :engram, :clerk_issuer, clerk_issuer
+  config :engram, :clerk_issuer, String.trim(clerk_issuer)
 end
 
 # Stripe billing

--- a/deploy/fastraid-deploy.sh
+++ b/deploy/fastraid-deploy.sh
@@ -2,9 +2,8 @@
 # Deploy Engram to FastRaid (Unraid).
 # Called by CI on merge to main, or manually via SSH.
 #
-# Uses Unraid's native container update: pulls the new image, then
-# updateDocker.php recreates only containers with new images available
-# using their XML template as the source of truth.
+# Uses Unraid's native update_container script to recreate just the
+# engram container from its XML template after pulling the new image.
 set -euo pipefail
 
 IMAGE="ghcr.io/rasbandit/engram:latest"
@@ -12,8 +11,8 @@ IMAGE="ghcr.io/rasbandit/engram:latest"
 echo "==> Pulling $IMAGE"
 docker pull "$IMAGE"
 
-echo "==> Triggering Unraid container update"
-/usr/local/emhttp/plugins/ca.update.applications/scripts/updateDocker.php
+echo "==> Updating engram container"
+/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/update_container engram
 
 echo "==> Waiting for health check"
 for i in $(seq 1 30); do

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -53,7 +53,7 @@ DISPLAY_BASE = int(os.environ.get("E2E_DISPLAY_BASE") or "99")
 
 @pytest.fixture(scope="session")
 def ts():
-    return datetime.now().strftime("%Y%m%d%H%M%S")
+    return datetime.now().strftime("%Y%m%d%H%M%S%f")
 
 
 @pytest.fixture(scope="session")
@@ -75,6 +75,8 @@ def sync_user(ts, clerk_client):
         "E2E_CLERK_SECRET_KEY is required — legacy password auth has been removed"
     )
     email = f"e2e-sync-{ts}@example.com"
+    # Clean up stale user with same email from previous failed runs
+    clerk_client.cleanup_user(email)
     password = secrets.token_urlsafe(32)
     clerk_user_id, clerk_auth, api_key = provision_clerk_user(
         clerk_client, email, password, API_URL,
@@ -89,6 +91,8 @@ def isolation_user(ts, clerk_client):
         "E2E_CLERK_SECRET_KEY is required — legacy password auth has been removed"
     )
     email = f"e2e-iso-{ts}@example.com"
+    # Clean up stale user with same email from previous failed runs
+    clerk_client.cleanup_user(email)
     password = secrets.token_urlsafe(32)
     clerk_user_id, clerk_auth, api_key = provision_clerk_user(
         clerk_client, email, password, API_URL,

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -34,7 +34,7 @@ CLERK_SECRET = os.environ.get("E2E_CLERK_SECRET_KEY", "")
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 
-API_URL = os.environ.get("ENGRAM_API_URL", "http://localhost:8100/api")
+API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
 PLUGIN_SRC = Path(os.environ.get("ENGRAM_PLUGIN_SRC", Path(__file__).parent.parent / "plugin"))
 OBSIDIAN_BIN = Path.home() / "Applications" / "Obsidian.AppImage"
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -41,10 +41,10 @@ OBSIDIAN_BIN = Path.home() / "Applications" / "Obsidian.AppImage"
 # Dynamic ports/paths for parallel CI runs (defaults match legacy hardcoded values)
 VAULT_PREFIX = os.environ.get("E2E_VAULT_PREFIX", "/tmp/e2e-vault")
 CONFIG_PREFIX = os.environ.get("E2E_CONFIG_PREFIX", "/tmp/e2e-obsidian-config")
-CDP_PORT_A = int(os.environ.get("E2E_CDP_PORT_A", "9250"))
-CDP_PORT_B = int(os.environ.get("E2E_CDP_PORT_B", "9251"))
-CDP_PORT_C = int(os.environ.get("E2E_CDP_PORT_C", "9252"))
-DISPLAY_BASE = int(os.environ.get("E2E_DISPLAY_BASE", "99"))
+CDP_PORT_A = int(os.environ.get("E2E_CDP_PORT_A") or "9250")
+CDP_PORT_B = int(os.environ.get("E2E_CDP_PORT_B") or "9251")
+CDP_PORT_C = int(os.environ.get("E2E_CDP_PORT_C") or "9252")
+DISPLAY_BASE = int(os.environ.get("E2E_DISPLAY_BASE") or "99")
 
 
 # ---------------------------------------------------------------------------

--- a/e2e/helpers/oauth.py
+++ b/e2e/helpers/oauth.py
@@ -63,16 +63,32 @@ async def provision_oauth_tokens(
 
 
 async def provision_oauth_for_existing_user(
-    clerk_client, api_url: str, clerk_user_id: str, *, label: str = "cross"
+    clerk_client, api_url: str, clerk_user_id: str, *, label: str = "cross",
+    api_key: str | None = None,
 ) -> dict:
     """Run device flow for an EXISTING Clerk user (no new user created).
 
     Returns tokens dict. Useful for cross-auth tests where both API key and
-    OAuth need to target the same user.
+    OAuth need to target the same user. Uses the user's existing vault
+    (looked up via session token) to avoid hitting vault limits.
     """
     ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
 
     session_token = clerk_client.create_session_token(clerk_user_id)
+
+    # Look up the user's existing vault to avoid creating a new one
+    # (free tier has a vault limit — "new" would fail with 422)
+    auth_header = f"Bearer {api_key}" if api_key else f"Bearer {session_token}"
+    vaults_resp = requests.get(
+        f"{api_url}/vaults",
+        headers={"Authorization": auth_header},
+        timeout=10,
+    )
+    assert vaults_resp.status_code == 200, f"Failed to list vaults: {vaults_resp.status_code}"
+    vaults = vaults_resp.json()
+    assert len(vaults) > 0, "Existing user has no vaults"
+    vault_id = str(vaults[0]["id"])
+    logger.info("Using existing vault %s for OAuth %s flow", vault_id, label)
 
     client_id = f"e2e-oauth-{label}-{ts}"
     flow = start_device_flow(api_url, client_id)
@@ -81,8 +97,7 @@ async def provision_oauth_for_existing_user(
         f"{api_url}/auth/device/authorize",
         json={
             "user_code": flow["user_code"],
-            "vault_id": "new",
-            "vault_name": f"E2E OAuth {label}",
+            "vault_id": vault_id,
         },
         headers={"Authorization": f"Bearer {session_token}"},
         timeout=10,

--- a/e2e/helpers/oauth.py
+++ b/e2e/helpers/oauth.py
@@ -85,7 +85,7 @@ async def provision_oauth_for_existing_user(
         timeout=10,
     )
     assert vaults_resp.status_code == 200, f"Failed to list vaults: {vaults_resp.status_code}"
-    vaults = vaults_resp.json()
+    vaults = vaults_resp.json().get("vaults", [])
     assert len(vaults) > 0, "Existing user has no vaults"
     vault_id = str(vaults[0]["id"])
     logger.info("Using existing vault %s for OAuth %s flow", vault_id, label)

--- a/e2e/helpers/oauth.py
+++ b/e2e/helpers/oauth.py
@@ -1,0 +1,179 @@
+"""OAuth test helpers — shared setup/teardown for E2E tests that swap auth.
+
+Provides functions to:
+- Provision OAuth tokens via device flow for a NEW Clerk user
+- Swap an Obsidian plugin instance to OAuth auth via CDP
+- Restore original API key auth after test
+- Wait for WebSocket channel to connect after auth change
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+import time
+from datetime import datetime
+
+import requests
+
+from helpers.device_flow import start_device_flow, poll_for_tokens
+
+logger = logging.getLogger(__name__)
+
+_P = "app.plugins.plugins['engram-sync']"
+
+
+async def provision_oauth_tokens(
+    clerk_client, api_url: str, *, label: str = "test"
+) -> tuple[str, dict]:
+    """Create a Clerk user, run device flow, return (clerk_user_id, tokens).
+
+    Each call creates a unique user with a timestamped email to avoid collisions.
+    The label is used in the email prefix for log traceability.
+    """
+    ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
+    email = f"e2e-oauth-{label}-{ts}@example.com"
+    password = secrets.token_urlsafe(32)
+
+    clerk_user_id = clerk_client.create_user(email, password)
+    logger.info("Created Clerk user for %s: %s (%s)", label, clerk_user_id, email)
+
+    session_token = clerk_client.create_session_token(clerk_user_id)
+
+    client_id = f"e2e-oauth-{label}-{ts}"
+    flow = start_device_flow(api_url, client_id)
+
+    resp = requests.post(
+        f"{api_url}/auth/device/authorize",
+        json={
+            "user_code": flow["user_code"],
+            "vault_id": "new",
+            "vault_name": f"E2E OAuth {label}",
+        },
+        headers={"Authorization": f"Bearer {session_token}"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, f"Device authorize failed: {resp.status_code}"
+
+    tokens = poll_for_tokens(api_url, flow["device_code"], timeout=30)
+    assert "access_token" in tokens
+    return clerk_user_id, tokens
+
+
+async def provision_oauth_for_existing_user(
+    clerk_client, api_url: str, clerk_user_id: str, *, label: str = "cross"
+) -> dict:
+    """Run device flow for an EXISTING Clerk user (no new user created).
+
+    Returns tokens dict. Useful for cross-auth tests where both API key and
+    OAuth need to target the same user.
+    """
+    ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
+
+    session_token = clerk_client.create_session_token(clerk_user_id)
+
+    client_id = f"e2e-oauth-{label}-{ts}"
+    flow = start_device_flow(api_url, client_id)
+
+    resp = requests.post(
+        f"{api_url}/auth/device/authorize",
+        json={
+            "user_code": flow["user_code"],
+            "vault_id": "new",
+            "vault_name": f"E2E OAuth {label}",
+        },
+        headers={"Authorization": f"Bearer {session_token}"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, f"Device authorize failed: {resp.status_code}"
+
+    tokens = poll_for_tokens(api_url, flow["device_code"], timeout=30)
+    assert "access_token" in tokens
+    return tokens
+
+
+async def swap_to_oauth(cdp, tokens: dict) -> str:
+    """Swap Obsidian plugin to OAuth auth via CDP.
+
+    Returns original settings as JSON string for later restore.
+    """
+    original = await cdp.evaluate(
+        f"JSON.stringify({{apiKey: {_P}.settings.apiKey, "
+        f"refreshToken: {_P}.settings.refreshToken, "
+        f"vaultId: {_P}.settings.vaultId, "
+        f"userEmail: {_P}.settings.userEmail, "
+        f"authMethod: {_P}.settings.authMethod || 'apikey'}})"
+    )
+
+    refresh_token = json.dumps(tokens["refresh_token"])
+    vault_id = json.dumps(str(tokens["vault_id"]))
+    user_email = json.dumps(tokens.get("user_email", ""))
+
+    js = f"""
+    (async function() {{
+        const plugin = {_P};
+        plugin.settings.apiKey = '';
+        plugin.settings.refreshToken = {refresh_token};
+        plugin.settings.vaultId = {vault_id};
+        plugin.settings.userEmail = {user_email};
+        plugin.settings.authMethod = 'oauth';
+        await plugin.saveSettings();
+        plugin.authProvider = plugin.createAuthProvider();
+        if (plugin.authProvider) {{
+            plugin.api.setAuthProvider(plugin.authProvider);
+            if (plugin.noteStream) {{
+                plugin.noteStream.setAuthProvider(plugin.authProvider);
+            }}
+        }}
+        plugin.setupNoteStream();
+        return 'oauth configured';
+    }})()
+    """
+    result = await cdp.evaluate(js, await_promise=True)
+    logger.info("Plugin swapped to OAuth: %s", result)
+    return original
+
+
+async def restore_auth(cdp, original_settings_json: str) -> None:
+    """Restore Obsidian plugin to its original auth settings via CDP."""
+    settings = json.loads(original_settings_json)
+    api_key = json.dumps(settings.get("apiKey", ""))
+    refresh_token = json.dumps(settings.get("refreshToken", ""))
+    vault_id = json.dumps(settings.get("vaultId", ""))
+    user_email = json.dumps(settings.get("userEmail", ""))
+    auth_method = json.dumps(settings.get("authMethod", "apikey"))
+
+    js = f"""
+    (async function() {{
+        const plugin = {_P};
+        plugin.settings.apiKey = {api_key};
+        plugin.settings.refreshToken = {refresh_token};
+        plugin.settings.vaultId = {vault_id};
+        plugin.settings.userEmail = {user_email};
+        plugin.settings.authMethod = {auth_method};
+        await plugin.saveSettings();
+        plugin.authProvider = plugin.createAuthProvider();
+        if (plugin.authProvider) {{
+            plugin.api.setAuthProvider(plugin.authProvider);
+            if (plugin.noteStream) {{
+                plugin.noteStream.setAuthProvider(plugin.authProvider);
+            }}
+        }}
+        plugin.setupNoteStream();
+        return 'auth restored';
+    }})()
+    """
+    result = await cdp.evaluate(js, await_promise=True)
+    logger.info("Plugin auth restored: %s", result)
+
+
+async def wait_for_stream(cdp, timeout: float = 15) -> None:
+    """Poll until WebSocket channel is connected after auth change."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if await cdp.check_stream_connected():
+            return
+        await asyncio.sleep(1)
+    raise TimeoutError(f"WebSocket channel not connected after {timeout}s")

--- a/e2e/tests/test_47_oauth_websocket_live_sync.py
+++ b/e2e/tests/test_47_oauth_websocket_live_sync.py
@@ -1,0 +1,178 @@
+"""Test 47: OAuth-authenticated client receives WebSocket broadcasts in real-time.
+
+Regression test for the setupNoteStream fix — previously, WebSocket channel
+setup only checked for apiKey (null for OAuth users), so OAuth clients never
+joined the channel and missed all real-time broadcasts.
+
+After the fix, setupNoteStream checks for refreshToken too, and the channel
+topic is always sync:{user_id}:{vault_id}.
+
+Requires E2E_CLERK_SECRET_KEY env var for device flow provisioning.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from urllib.parse import quote
+
+import pytest
+import requests
+
+from helpers.oauth import provision_oauth_tokens, swap_to_oauth, restore_auth, wait_for_stream
+from helpers.vault import read_note, wait_for_content, wait_for_file, wait_for_file_gone
+
+logger = logging.getLogger(__name__)
+
+API_URL = os.environ.get("ENGRAM_API_URL", "http://localhost:8100/api")
+CLERK_SECRET = os.environ.get("E2E_CLERK_SECRET_KEY", "")
+
+pytestmark = pytest.mark.skipif(
+    not CLERK_SECRET,
+    reason="E2E_CLERK_SECRET_KEY not set — skipping OAuth WebSocket tests",
+)
+
+RT_TIMEOUT = 10  # slightly more generous than test_45 for OAuth overhead
+
+
+def _log_latency(label: str, t0: float) -> float:
+    elapsed = time.monotonic() - t0
+    logger.info("LATENCY [%s]: %.3fs", label, elapsed)
+    return elapsed
+
+
+@pytest.mark.asyncio
+async def test_oauth_client_receives_api_create(vault_a, cdp_a, clerk_client):
+    """OAuth-authenticated plugin receives real-time broadcast when API creates a note.
+
+    This is the core regression test: before the fix, OAuth clients never joined
+    the WebSocket channel because setupNoteStream only checked for apiKey.
+    """
+    clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="ws")
+    original_settings = None
+
+    try:
+        original_settings = await swap_to_oauth(cdp_a, tokens)
+        await wait_for_stream(cdp_a)
+
+        connected = await cdp_a.check_stream_connected()
+        assert connected, "OAuth client's WebSocket channel is not connected"
+
+        path = "E2E/OAuthWSCreate.md"
+        content = "# OAuth WS Create\nCreated via API, should arrive via WebSocket"
+        headers = {
+            "Authorization": f"Bearer {tokens['access_token']}",
+            "X-Vault-ID": str(tokens["vault_id"]),
+        }
+        resp = requests.post(
+            f"{API_URL}/notes",
+            json={"path": path, "content": content, "mtime": time.time()},
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code in (200, 201), f"API create failed: {resp.status_code}"
+
+        t0 = time.monotonic()
+        a_content = wait_for_file(vault_a, path, timeout=RT_TIMEOUT)
+        _log_latency("oauth_api_create", t0)
+
+        assert "should arrive via WebSocket" in a_content
+
+    finally:
+        if original_settings:
+            await restore_auth(cdp_a, original_settings)
+            await wait_for_stream(cdp_a)
+        clerk_client.delete_user(clerk_user_id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_client_receives_api_update(vault_a, cdp_a, clerk_client):
+    """OAuth client receives updated content via WebSocket when API upserts a note."""
+    clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="ws")
+    original_settings = None
+
+    try:
+        original_settings = await swap_to_oauth(cdp_a, tokens)
+        await wait_for_stream(cdp_a)
+
+        path = "E2E/OAuthWSUpdate.md"
+        headers = {
+            "Authorization": f"Bearer {tokens['access_token']}",
+            "X-Vault-ID": str(tokens["vault_id"]),
+        }
+
+        # Create initial version
+        resp = requests.post(
+            f"{API_URL}/notes",
+            json={"path": path, "content": "# V1\nInitial", "mtime": time.time()},
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code in (200, 201), f"Initial create failed: {resp.status_code}"
+        wait_for_file(vault_a, path, timeout=RT_TIMEOUT)
+
+        # Update via API
+        t0 = time.monotonic()
+        resp = requests.post(
+            f"{API_URL}/notes",
+            json={"path": path, "content": "# V2\nUpdated via API", "mtime": time.time()},
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code in (200, 201), f"Update failed: {resp.status_code}"
+        wait_for_content(vault_a, path, "Updated via API", timeout=RT_TIMEOUT)
+        _log_latency("oauth_api_update", t0)
+
+        assert "Updated via API" in read_note(vault_a, path)
+
+    finally:
+        if original_settings:
+            await restore_auth(cdp_a, original_settings)
+            await wait_for_stream(cdp_a)
+        clerk_client.delete_user(clerk_user_id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_client_receives_api_delete(vault_a, cdp_a, clerk_client):
+    """OAuth client removes file from vault when API deletes a note via WebSocket."""
+    clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="ws")
+    original_settings = None
+
+    try:
+        original_settings = await swap_to_oauth(cdp_a, tokens)
+        await wait_for_stream(cdp_a)
+
+        path = "E2E/OAuthWSDelete.md"
+        headers = {
+            "Authorization": f"Bearer {tokens['access_token']}",
+            "X-Vault-ID": str(tokens["vault_id"]),
+        }
+
+        # Create and wait for arrival
+        resp = requests.post(
+            f"{API_URL}/notes",
+            json={"path": path, "content": "# Delete Me", "mtime": time.time()},
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code in (200, 201), f"Create failed: {resp.status_code}"
+        wait_for_file(vault_a, path, timeout=RT_TIMEOUT)
+
+        # Delete via API
+        t0 = time.monotonic()
+        resp = requests.delete(
+            f"{API_URL}/notes/{quote(path, safe='')}",
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code in (200, 204), f"Delete failed: {resp.status_code}"
+
+        wait_for_file_gone(vault_a, path, timeout=RT_TIMEOUT)
+        _log_latency("oauth_api_delete", t0)
+
+    finally:
+        if original_settings:
+            await restore_auth(cdp_a, original_settings)
+            await wait_for_stream(cdp_a)
+        clerk_client.delete_user(clerk_user_id)

--- a/e2e/tests/test_48_oauth_reconnect_catchup.py
+++ b/e2e/tests/test_48_oauth_reconnect_catchup.py
@@ -1,0 +1,151 @@
+"""Test 48: OAuth client WebSocket reconnect → catch-up pull.
+
+When an OAuth-authenticated client's WebSocket channel drops, changes made
+while disconnected should be delivered via catch-up pull on reconnect.
+
+This combines the reconnect pattern (test_23) with OAuth authentication to
+ensure token refresh and channel re-join work correctly after disconnection.
+
+Requires E2E_CLERK_SECRET_KEY env var for device flow provisioning.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+
+import pytest
+import requests
+
+from helpers.oauth import provision_oauth_tokens, swap_to_oauth, restore_auth, wait_for_stream
+from helpers.vault import read_note, wait_for_content, wait_for_file
+
+logger = logging.getLogger(__name__)
+
+API_URL = os.environ.get("ENGRAM_API_URL", "http://localhost:8100/api")
+CLERK_SECRET = os.environ.get("E2E_CLERK_SECRET_KEY", "")
+
+pytestmark = pytest.mark.skipif(
+    not CLERK_SECRET,
+    reason="E2E_CLERK_SECRET_KEY not set — skipping OAuth reconnect tests",
+)
+
+RT_TIMEOUT = 15  # generous for reconnect + catch-up overhead
+
+
+def _log_latency(label: str, t0: float) -> float:
+    elapsed = time.monotonic() - t0
+    logger.info("LATENCY [%s]: %.3fs", label, elapsed)
+    return elapsed
+
+
+@pytest.mark.asyncio
+async def test_oauth_reconnect_catches_up(vault_a, cdp_a, clerk_client):
+    """OAuth channel drops, API creates note, channel reconnects, client gets note.
+
+    Proves that OAuth token re-auth + channel re-join works after disconnect,
+    and the catch-up pull fetches missed changes.
+    """
+    clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="rc")
+    original_settings = None
+
+    try:
+        original_settings = await swap_to_oauth(cdp_a, tokens)
+        await wait_for_stream(cdp_a)
+
+        assert await cdp_a.check_stream_connected(), "OAuth channel should be connected"
+
+        # Disconnect the WebSocket channel
+        await cdp_a.disconnect_stream()
+        await asyncio.sleep(0.5)
+        assert not await cdp_a.check_stream_connected(), "Channel should be disconnected"
+
+        # Create a note via API while channel is down
+        path = "E2E/OAuthReconnect.md"
+        content = "# OAuth Reconnect\nCreated while OAuth client was disconnected"
+        headers = {
+            "Authorization": f"Bearer {tokens['access_token']}",
+            "X-Vault-ID": str(tokens["vault_id"]),
+        }
+        resp = requests.post(
+            f"{API_URL}/notes",
+            json={"path": path, "content": content, "mtime": time.time()},
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code in (200, 201), f"Create failed: {resp.status_code}"
+
+        # Reconnect — should trigger catch-up pull
+        t0 = time.monotonic()
+        await cdp_a.reconnect_stream()
+
+        a_content = wait_for_file(vault_a, path, timeout=RT_TIMEOUT)
+        _log_latency("oauth_reconnect_catchup", t0)
+
+        assert "Created while OAuth client was disconnected" in a_content
+
+    finally:
+        if original_settings:
+            await restore_auth(cdp_a, original_settings)
+            await wait_for_stream(cdp_a)
+        clerk_client.delete_user(clerk_user_id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_reconnect_receives_update(vault_a, cdp_a, clerk_client):
+    """OAuth channel drops, API updates existing note, reconnect delivers update.
+
+    Edge case: file already exists locally, content changes while disconnected.
+    """
+    clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="rc")
+    original_settings = None
+
+    try:
+        original_settings = await swap_to_oauth(cdp_a, tokens)
+        await wait_for_stream(cdp_a)
+
+        path = "E2E/OAuthReconnectUpdate.md"
+        headers = {
+            "Authorization": f"Bearer {tokens['access_token']}",
+            "X-Vault-ID": str(tokens["vault_id"]),
+        }
+
+        # Create initial note and wait for arrival
+        resp = requests.post(
+            f"{API_URL}/notes",
+            json={"path": path, "content": "# V1\nOriginal content", "mtime": time.time()},
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code in (200, 201), f"Initial create failed: {resp.status_code}"
+        wait_for_file(vault_a, path, timeout=RT_TIMEOUT)
+
+        # Disconnect
+        await cdp_a.disconnect_stream()
+        await asyncio.sleep(0.5)
+
+        # Update while disconnected
+        resp = requests.post(
+            f"{API_URL}/notes",
+            json={"path": path, "content": "# V2\nUpdated while disconnected", "mtime": time.time()},
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code in (200, 201), f"Update failed: {resp.status_code}"
+
+        # Reconnect — catch-up should deliver update
+        t0 = time.monotonic()
+        await cdp_a.reconnect_stream()
+
+        wait_for_content(vault_a, path, "Updated while disconnected", timeout=RT_TIMEOUT)
+        _log_latency("oauth_reconnect_update", t0)
+
+        assert "Updated while disconnected" in read_note(vault_a, path)
+
+    finally:
+        if original_settings:
+            await restore_auth(cdp_a, original_settings)
+            await wait_for_stream(cdp_a)
+        clerk_client.delete_user(clerk_user_id)

--- a/e2e/tests/test_49_cross_auth_sync.py
+++ b/e2e/tests/test_49_cross_auth_sync.py
@@ -58,7 +58,8 @@ async def test_apikey_push_oauth_receives(
     pushes it, and A should receive the broadcast.
     """
     tokens = await provision_oauth_for_existing_user(
-        clerk_client, API_URL, sync_user[1], label="cross"
+        clerk_client, API_URL, sync_user[1], label="cross",
+        api_key=sync_user[3],
     )
     original_settings = None
 
@@ -96,7 +97,8 @@ async def test_oauth_push_apikey_receives(
     A is swapped to OAuth. A writes a file, syncs, B should get it.
     """
     tokens = await provision_oauth_for_existing_user(
-        clerk_client, API_URL, sync_user[1], label="cross"
+        clerk_client, API_URL, sync_user[1], label="cross",
+        api_key=sync_user[3],
     )
     original_settings = None
 

--- a/e2e/tests/test_49_cross_auth_sync.py
+++ b/e2e/tests/test_49_cross_auth_sync.py
@@ -1,0 +1,192 @@
+"""Test 49: Cross-auth bidirectional sync + rapid edit edge cases.
+
+Verifies that OAuth and API key authenticated clients can coexist on the same
+channel topic and sync bidirectionally. Also tests rapid successive edits to
+catch debounce/dedup edge cases.
+
+Requires E2E_CLERK_SECRET_KEY env var.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+
+import pytest
+
+from helpers.oauth import (
+    provision_oauth_for_existing_user,
+    swap_to_oauth,
+    restore_auth,
+    wait_for_stream,
+)
+from helpers.vault import read_note, wait_for_content, wait_for_file, write_note
+
+logger = logging.getLogger(__name__)
+
+API_URL = os.environ.get("ENGRAM_API_URL", "http://localhost:8100/api")
+CLERK_SECRET = os.environ.get("E2E_CLERK_SECRET_KEY", "")
+
+pytestmark = pytest.mark.skipif(
+    not CLERK_SECRET,
+    reason="E2E_CLERK_SECRET_KEY not set — skipping cross-auth sync tests",
+)
+
+RT_TIMEOUT = 10
+
+
+def _log_latency(label: str, t0: float) -> float:
+    elapsed = time.monotonic() - t0
+    logger.info("LATENCY [%s]: %.3fs", label, elapsed)
+    return elapsed
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bidirectional sync across auth methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apikey_push_oauth_receives(
+    vault_a, vault_b, cdp_a, cdp_b, api_sync, sync_user, clerk_client
+):
+    """API key client (B) pushes a note → OAuth client (A) receives via WebSocket.
+
+    A is swapped to OAuth, B stays on API key. B creates a note via file write,
+    pushes it, and A should receive the broadcast.
+    """
+    tokens = await provision_oauth_for_existing_user(
+        clerk_client, API_URL, sync_user[1], label="cross"
+    )
+    original_settings = None
+
+    try:
+        original_settings = await swap_to_oauth(cdp_a, tokens)
+        await wait_for_stream(cdp_a)
+
+        # B (API key) creates a note
+        path = "E2E/CrossAuthApikeyToOauth.md"
+        content = "# API Key → OAuth\nPushed by API key client, received by OAuth"
+        write_note(vault_b, path, content)
+
+        # Wait for B to push to server
+        api_sync.wait_for_note(path, timeout=10)
+
+        # A (OAuth) should receive via WebSocket
+        t0 = time.monotonic()
+        a_content = wait_for_file(vault_a, path, timeout=RT_TIMEOUT)
+        _log_latency("apikey_push_oauth_receives", t0)
+
+        assert "received by OAuth" in a_content
+
+    finally:
+        if original_settings:
+            await restore_auth(cdp_a, original_settings)
+            await wait_for_stream(cdp_a)
+
+
+@pytest.mark.asyncio
+async def test_oauth_push_apikey_receives(
+    vault_a, vault_b, cdp_a, cdp_b, api_sync, sync_user, clerk_client
+):
+    """OAuth client (A) pushes a note → API key client (B) receives via WebSocket.
+
+    A is swapped to OAuth. A writes a file, syncs, B should get it.
+    """
+    tokens = await provision_oauth_for_existing_user(
+        clerk_client, API_URL, sync_user[1], label="cross"
+    )
+    original_settings = None
+
+    try:
+        original_settings = await swap_to_oauth(cdp_a, tokens)
+        await wait_for_stream(cdp_a)
+
+        assert await cdp_a.check_stream_connected(), "A (OAuth) not connected"
+        assert await cdp_b.check_stream_connected(), "B (API key) not connected"
+
+        # A (OAuth) creates a note and syncs
+        path = "E2E/CrossAuthOauthToApikey.md"
+        content = "# OAuth → API Key\nPushed by OAuth client, received by API key"
+        write_note(vault_a, path, content)
+
+        result = await cdp_a.trigger_full_sync()
+        logger.info("OAuth push result: %s", result)
+
+        # B (API key) should receive via WebSocket
+        t0 = time.monotonic()
+        b_content = wait_for_file(vault_b, path, timeout=RT_TIMEOUT)
+        _log_latency("oauth_push_apikey_receives", t0)
+
+        assert "received by API key" in b_content
+
+    finally:
+        if original_settings:
+            await restore_auth(cdp_a, original_settings)
+            await wait_for_stream(cdp_a)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Rapid successive edits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rapid_api_edits_final_content_arrives(vault_b, cdp_b, api_sync):
+    """Multiple rapid API edits to same note → final content arrives at client.
+
+    Tests that debounce/dedup logic doesn't drop the final update.
+    """
+    connected = await cdp_b.check_stream_connected()
+    assert connected, "B's WebSocket channel is not connected"
+
+    path = "E2E/RapidEdits.md"
+
+    # Fire 5 rapid edits (no sleep between them)
+    for i in range(1, 6):
+        api_sync.create_note(path, f"# Rapid Edit\nVersion {i} of 5")
+
+    # Final content should arrive
+    t0 = time.monotonic()
+    wait_for_content(vault_b, path, "Version 5 of 5", timeout=RT_TIMEOUT)
+    _log_latency("rapid_edits_final", t0)
+
+    final = read_note(vault_b, path)
+    assert "Version 5 of 5" in final, f"Expected final version, got: {final[:200]}"
+
+
+@pytest.mark.asyncio
+async def test_rapid_api_edits_content_not_stale(vault_b, cdp_b, api_sync):
+    """After rapid edits settle, content should be the LATEST version, not an earlier one.
+
+    Stronger assertion: verifies no stale intermediate version persists after
+    the dust settles. Waits extra time to ensure no late broadcast overwrites
+    the final content with an earlier version.
+    """
+    connected = await cdp_b.check_stream_connected()
+    assert connected, "B's WebSocket channel is not connected"
+
+    path = "E2E/RapidEditsStale.md"
+
+    # Rapid-fire edits
+    for i in range(1, 8):
+        api_sync.create_note(path, f"# Stale Check\nIteration {i}")
+
+    # Wait for final version to land
+    wait_for_content(vault_b, path, "Iteration 7", timeout=RT_TIMEOUT)
+
+    # Wait extra to ensure no stale version overwrites the final one
+    await asyncio.sleep(3)
+
+    final = read_note(vault_b, path)
+    assert "Iteration 7" in final, (
+        f"Content should be latest iteration (7), got: {final[:200]}"
+    )
+    # Verify the file contains ONLY the final iteration's content line
+    # (earlier iterations should have been overwritten, not appended)
+    assert final.count("Iteration") == 1, (
+        f"Expected exactly one 'Iteration' line (the final one), "
+        f"but found {final.count('Iteration')}: {final[:300]}"
+    )

--- a/e2e/tests/test_50_channel_topic_enforcement.py
+++ b/e2e/tests/test_50_channel_topic_enforcement.py
@@ -1,0 +1,134 @@
+"""Test 50: Channel topic format enforcement + stream connectivity checks.
+
+Regression tests for the backend change that removed the legacy
+sync:{user_id} backwards-compat topic. Only sync:{user_id}:{vault_id}
+is accepted now.
+
+Also verifies that the plugin's WebSocket stream correctly connects with
+the vault-scoped topic and that connectivity checks report accurate state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+from helpers.vault import wait_for_file, write_note
+
+logger = logging.getLogger(__name__)
+
+RT_TIMEOUT = 10
+
+
+@pytest.mark.asyncio
+async def test_stream_connects_with_vault_topic(cdp_a, cdp_b):
+    """Both A and B plugins connect their WebSocket channels successfully.
+
+    Proves the plugin joins sync:{user_id}:{vault_id} (not the removed
+    sync:{user_id} topic) and the backend accepts it.
+    """
+    # Wait for both to connect (may need a moment after prior tests)
+    for _ in range(10):
+        a_ok = await cdp_a.check_stream_connected()
+        b_ok = await cdp_b.check_stream_connected()
+        if a_ok and b_ok:
+            break
+        await asyncio.sleep(1)
+
+    assert await cdp_a.check_stream_connected(), "A's channel should be connected"
+    assert await cdp_b.check_stream_connected(), "B's channel should be connected"
+
+
+@pytest.mark.asyncio
+async def test_stream_reports_disconnected_after_drop(cdp_b):
+    """After explicit disconnect, isLiveConnected reports false.
+
+    Verifies the status tracking is accurate (not stale).
+    """
+    # Ensure connected first
+    for _ in range(10):
+        if await cdp_b.check_stream_connected():
+            break
+        await asyncio.sleep(1)
+    assert await cdp_b.check_stream_connected()
+
+    # Disconnect
+    await cdp_b.disconnect_stream()
+    await asyncio.sleep(0.5)
+
+    assert not await cdp_b.check_stream_connected(), (
+        "isLiveConnected should be false after disconnect"
+    )
+
+    # Reconnect for subsequent tests and wait for it to complete
+    await cdp_b.reconnect_stream()
+    for _ in range(10):
+        if await cdp_b.check_stream_connected():
+            break
+        await asyncio.sleep(1)
+
+
+@pytest.mark.asyncio
+async def test_reconnect_rejoins_correct_topic(vault_a, vault_b, cdp_a, cdp_b, api_sync):
+    """After disconnect + reconnect, channel still works (correct topic re-joined).
+
+    This catches regressions where reconnect might try the old topic format.
+    """
+    # Ensure B is connected
+    for _ in range(10):
+        if await cdp_b.check_stream_connected():
+            break
+        await asyncio.sleep(1)
+    assert await cdp_b.check_stream_connected()
+
+    # Disconnect B
+    await cdp_b.disconnect_stream()
+    await asyncio.sleep(0.5)
+
+    # Reconnect B
+    await cdp_b.reconnect_stream()
+
+    # Verify channel is functional by pushing a note through it
+    path = "E2E/TopicReconnectCheck.md"
+    content = "# Topic Reconnect\nVerifying channel works after reconnect"
+    write_note(vault_a, path, content)
+    api_sync.wait_for_note(path, timeout=10)
+
+    # B should receive via the reconnected channel
+    t0 = time.monotonic()
+    b_content = wait_for_file(vault_b, path, timeout=RT_TIMEOUT)
+    elapsed = time.monotonic() - t0
+    logger.info("LATENCY [topic_reconnect]: %.3fs", elapsed)
+
+    assert "Verifying channel works after reconnect" in b_content
+
+
+@pytest.mark.asyncio
+async def test_live_sync_still_works_after_all_tests(
+    vault_a, vault_b, cdp_a, cdp_b, api_sync
+):
+    """Smoke test: basic live sync still works at the end of the test suite.
+
+    Guards against test pollution — if earlier tests leaked state or broke
+    auth, this catches it.
+    """
+    for _ in range(10):
+        a_ok = await cdp_a.check_stream_connected()
+        b_ok = await cdp_b.check_stream_connected()
+        if a_ok and b_ok:
+            break
+        await asyncio.sleep(1)
+
+    assert await cdp_a.check_stream_connected(), "A's channel broken after prior tests"
+    assert await cdp_b.check_stream_connected(), "B's channel broken after prior tests"
+
+    path = "E2E/SmokeAfterTests.md"
+    content = "# Smoke Test\nLive sync still works after all E2E tests"
+    write_note(vault_a, path, content)
+    api_sync.wait_for_note(path, timeout=10)
+
+    b_content = wait_for_file(vault_b, path, timeout=RT_TIMEOUT)
+    assert "Live sync still works" in b_content

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -5,8 +5,6 @@ defmodule EngramWeb.SyncChannel do
   Topic: "sync:{user_id}:{vault_id}"
   Auth:  socket.assigns.current_user must match user_id; vault must belong to that user.
 
-  Backwards-compat: "sync:{user_id}" (no vault) falls back to the user's default vault.
-
   Client → Server events: push_note, delete_note, rename_note, pull_changes
   Server → Client broadcasts: note_changed
   """
@@ -52,45 +50,9 @@ defmodule EngramWeb.SyncChannel do
           {:error, %{reason: "unauthorized"}}
         end
 
-      # Backwards-compat: old topic "sync:{user_id}" without vault
-      # The client joined "sync:{user_id}" but broadcasts go to
-      # "sync:{user_id}:{vault_id}". Subscribe to the vault-scoped
-      # topic so this process receives those broadcasts.
-      [user_id_str] ->
-        if to_string(user.id) == user_id_str do
-          case Vaults.get_default_vault(user) do
-            {:ok, vault} ->
-              case check_api_key_access(socket, vault) do
-                :ok ->
-                  vault_topic = "sync:#{user_id_str}:#{vault.id}"
-                  EngramWeb.Endpoint.subscribe(vault_topic)
-                  socket = assign(socket, :vault, vault)
-                  send(self(), {:after_join, params})
-                  {:ok, socket}
-
-                :forbidden ->
-                  {:error, %{reason: "api_key_vault_forbidden"}}
-              end
-
-            {:error, _} ->
-              {:error, %{reason: "no_default_vault"}}
-          end
-        else
-          {:error, %{reason: "unauthorized"}}
-        end
-
       _ ->
         {:error, %{reason: "invalid_topic"}}
     end
-  end
-
-  # Forward broadcasts from the vault-scoped topic to backwards-compat clients.
-  # When a client joins "sync:{user_id}" (no vault), we subscribe to
-  # "sync:{user_id}:{vault_id}" — those broadcasts arrive here as messages.
-  @impl true
-  def handle_info(%Phoenix.Socket.Broadcast{event: event, payload: payload}, socket) do
-    push(socket, event, payload)
-    {:noreply, socket}
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.1.4",
+      version: "0.1.5",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/channels/sync_channel_test.exs
+++ b/test/engram_web/channels/sync_channel_test.exs
@@ -76,36 +76,11 @@ defmodule EngramWeb.SyncChannelTest do
                subscribe_and_join(socket, EngramWeb.SyncChannel, "sync:#{user.id}:notanint")
     end
 
-    test "backwards-compat: join without vault_id uses default vault", %{user: user} do
+    test "rejects topic without vault_id", %{user: user} do
       socket = user_socket(user)
-      # user already has a default vault from setup
-      assert {:ok, _, _} =
+
+      assert {:error, %{reason: "invalid_topic"}} =
                subscribe_and_join(socket, EngramWeb.SyncChannel, "sync:#{user.id}")
-    end
-
-    test "backwards-compat: receives vault-scoped broadcasts", %{user: user, vault: vault} do
-      socket = user_socket(user)
-      {:ok, _, _socket} =
-        subscribe_and_join(socket, EngramWeb.SyncChannel, "sync:#{user.id}")
-
-      # Broadcast to the vault-scoped topic (what Notes.broadcast_change uses)
-      EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "note_changed", %{
-        "event_type" => "upsert",
-        "path" => "test.md",
-        "vault_id" => vault.id
-      })
-
-      # The backwards-compat client should receive it
-      assert_push "note_changed", %{"event_type" => "upsert", "path" => "test.md"}
-    end
-
-    test "backwards-compat: returns error when no default vault exists" do
-      # New user with no vault inserted
-      bare_user = insert(:user)
-      socket = user_socket(bare_user)
-
-      assert {:error, %{reason: "no_default_vault"}} =
-               subscribe_and_join(socket, EngramWeb.SyncChannel, "sync:#{bare_user.id}")
     end
   end
 
@@ -146,21 +121,11 @@ defmodule EngramWeb.SyncChannelTest do
                )
     end
 
-    test "restricted key on backwards-compat topic checks default vault access", %{user: user, vault: _vault} do
+    test "restricted key on topic without vault_id gets invalid_topic", %{user: user} do
       {:ok, _raw, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-compat")
-
-      # Restrict to a non-default vault (create another first)
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
-      {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Vault B"})
-
-      Engram.Repo.insert_all("api_key_vaults", [
-        %{api_key_id: api_key_record.id, vault_id: vault_b.id}
-      ])
-
       socket = user_socket(user, api_key_record)
 
-      # Join without vault_id → resolves to default vault → key doesn't have access
-      assert {:error, %{reason: "api_key_vault_forbidden"}} =
+      assert {:error, %{reason: "invalid_topic"}} =
                subscribe_and_join(socket, EngramWeb.SyncChannel, "sync:#{user.id}")
     end
 


### PR DESCRIPTION
## Summary

- **Channel topic cleanup**: Remove legacy `sync:{user_id}` backwards-compat topic — only `sync:{user_id}:{vault_id}` accepted now
- **Clerk env fix**: Trim whitespace from Clerk env vars to prevent trailing newline auth failures
- **Deploy fix**: Target only engram container in deploy script, not all containers
- **OAuth E2E tests**: 4 new E2E tests (47-50) covering OAuth WebSocket live sync, reconnect catch-up, cross-auth bidirectional sync, and channel topic enforcement

## Test plan

- [ ] CI: unit tests pass
- [ ] CI: E2E tests pass (including new tests 47-50)
- [ ] Deploy to FastRaid after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)