### PR TITLE
feat(crypto): pluggable key providers — phases 1-3 (Local provider + note encryption)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ env:
   # When set, docker-compose.ci.yml pulls images from the local FastRaid registry.
   # When unset, falls back to Docker Hub.
 
+  # CI-only encryption master key. Ephemeral — CI databases are recreated per run,
+  # so the key does not protect persistent data. Production deploys must override
+  # with a secret via `fly secrets set ENCRYPTION_MASTER_KEY=...`.
+  KEY_PROVIDER: "local"
+  ENCRYPTION_MASTER_KEY: "vZ+e130Hffn5T1ljBb3FH1rFIKc42kTK86jmUEusLio="
+
 jobs:
   version-check:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ See `docs/context/testing-strategy.md` for full strategy, tooling, and CI pipeli
 | `docs/context/testing-strategy.md` | Test layers, ExUnit tooling, CI pipeline |
 | `docs/context/production-deployment.md` | Fly.io deploy, backups, observability, security checklist |
 | `docs/context/pricing-strategy.md` | Full SaaS pricing model |
+| `docs/context/docker-build-cache-pitfalls.md` | Why `_build` cache mount across RUN steps ships stale beams |
 | `docs/context/benchmark-plan.md` | Embedding/chunking/reranker benchmark methodology |
 | `docs/context/code-audit-2026-04.md` | Full codebase audit: 7 CRITICAL, 18 HIGH, 30 MEDIUM findings |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,12 @@ RUN --mount=type=cache,target=/app/deps,id=mix-deps \
 COPY lib lib
 COPY priv priv
 COPY config/runtime.exs config/
+# Purge app beams before compile. --force regenerates touched files but
+# does NOT remove stale beams when lib/ files are deleted or moved;
+# this ensures the cache-mounted _build has exactly the current source.
 RUN --mount=type=cache,target=/app/deps,id=mix-deps \
     --mount=type=cache,target=/app/_build,id=mix-build \
+    rm -rf /app/_build/prod/lib/engram && \
     mix compile --force
 
 # Build release — copy frontend assets in, then assemble.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
 # Multi-stage build: compile release in builder, run in minimal image
+# cache-bust: 2026-04-18-encryption-auto-provision
 ARG ELIXIR_VERSION=1.17.3
 ARG OTP_VERSION=27.1.2
 ARG DEBIAN_VERSION=bookworm-20241202-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,20 +48,15 @@ RUN --mount=type=cache,target=/app/deps,id=mix-deps \
 COPY lib lib
 COPY priv priv
 COPY config/runtime.exs config/
-# Purge app beams before compile. --force regenerates touched files but
-# does NOT remove stale beams when lib/ files are deleted or moved;
-# this ensures the cache-mounted _build has exactly the current source.
-RUN --mount=type=cache,target=/app/deps,id=mix-deps \
-    --mount=type=cache,target=/app/_build,id=mix-build \
-    rm -rf /app/_build/prod/lib/engram && \
-    mix compile --force
-
-# Build release — copy frontend assets in, then assemble.
-# Uses separate _build cache for compile above, then copies out
-# to avoid stale release binaries from cached _build.
 COPY --from=frontend /priv/static/app priv/static/app
+# Compile and release in one RUN, no _build cache mount. Splitting the
+# two steps with a shared _build cache produced stale beams in CI —
+# `mix compile --force` ran but `mix release` in the next RUN still
+# saw old beam files. Single-step build is correct; the extra minute
+# of compile time is worth the guarantee that the release matches the
+# current source.
 RUN --mount=type=cache,target=/app/deps,id=mix-deps \
-    --mount=type=cache,target=/app/_build,id=mix-build \
+    mix compile --force && \
     mix release && \
     cp -r /app/_build/prod/rel/engram /app/_release
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -82,6 +82,11 @@ config :tailwind,
     cd: Path.expand("..", __DIR__)
   ]
 
+# Key provider defaults (overridden by runtime.exs via env vars)
+config :engram,
+  key_provider: Engram.Crypto.KeyProvider.Local,
+  dek_cache_ttl_ms: 3_600_000
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -157,6 +157,22 @@ if config_env() != :test do
   config :engram, :stripe_pro_price_id, System.get_env("STRIPE_PRO_PRICE_ID")
 end
 
+# Key provider — skip in :test so test.exs stable key is not overwritten by a nil env read.
+# Dev and prod (including Docker CI containers) read from KEY_PROVIDER / ENCRYPTION_MASTER_KEY.
+if config_env() != :test do
+  key_provider_module =
+    case System.get_env("KEY_PROVIDER", "local") do
+      "local" -> Engram.Crypto.KeyProvider.Local
+      other -> raise "Unknown KEY_PROVIDER=#{other}; supported: local"
+    end
+
+  config :engram,
+    key_provider: key_provider_module,
+    encryption_master_key: System.get_env("ENCRYPTION_MASTER_KEY"),
+    encryption_master_key_previous: System.get_env("ENCRYPTION_MASTER_KEY_PREVIOUS"),
+    dek_cache_ttl_ms: String.to_integer(System.get_env("DEK_CACHE_TTL_MS", "3600000"))
+end
+
 # Endpoint URL — used by EngramWeb.Endpoint.url() for device flow verification links,
 # email URLs, etc. Works in dev and prod. Defaults to localhost in dev.
 if phx_host = System.get_env("PHX_HOST") do

--- a/config/test.exs
+++ b/config/test.exs
@@ -85,3 +85,9 @@ config :engram, :stripe_pro_price_id, "price_pro_test"
 
 # Default to local auth provider in tests
 config :engram, :auth_provider, :local
+
+# Stable test master key — 32 bytes of 0xAB, base64-encoded
+config :engram,
+  key_provider: Engram.Crypto.KeyProvider.Local,
+  encryption_master_key:
+    Base.encode64(:binary.copy(<<0xAB>>, 32))

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -41,6 +41,9 @@ services:
       CLERK_JWKS_URL: ${CLERK_JWKS_URL:-}
       CLERK_ISSUER: ${CLERK_ISSUER:-}
       CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY:-}
+      KEY_PROVIDER: ${KEY_PROVIDER:-local}
+      ENCRYPTION_MASTER_KEY: ${ENCRYPTION_MASTER_KEY:-vZ+e130Hffn5T1ljBb3FH1rFIKc42kTK86jmUEusLio=}
+      ENCRYPTION_MASTER_KEY_PREVIOUS: ${ENCRYPTION_MASTER_KEY_PREVIOUS:-}
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4000/api/health || exit 1"]
       start_period: 3s

--- a/docker-compose.elixir.yml
+++ b/docker-compose.elixir.yml
@@ -4,6 +4,9 @@ services:
     env_file: .env.elixir
     environment:
       DATABASE_URL: postgresql://engram:engram@postgres:5432/engram
+      KEY_PROVIDER: ${KEY_PROVIDER:-local}
+      ENCRYPTION_MASTER_KEY: ${ENCRYPTION_MASTER_KEY:?set ENCRYPTION_MASTER_KEY in .env}
+      ENCRYPTION_MASTER_KEY_PREVIOUS: ${ENCRYPTION_MASTER_KEY_PREVIOUS:-}
     ports:
       - "8000:8000"
     depends_on:

--- a/docs/context/docker-build-cache-pitfalls.md
+++ b/docs/context/docker-build-cache-pitfalls.md
@@ -1,0 +1,71 @@
+# Context Doc: Docker Build Cache Pitfalls
+
+_Last verified: 2026-04-18_
+
+## Status
+Working — current Dockerfile compiles and releases in one RUN step without the `_build` cache mount.
+
+## What This Is
+How the backend Dockerfile packages an Elixir release, and why the old split-step design produced stale beam files in CI.
+
+## Environment
+- `backend/Dockerfile` — multi-stage Elixir release build.
+- Triggered by `docker-compose.ci.yml` (self-hosted runner on FastRaid) and any local `docker compose -f docker-compose.ci.yml build`.
+- Cache mounts are BuildKit-scoped (`id=mix-deps`, `id=mix-build` historically) — persistent named volumes on the builder host, survive across runs.
+
+## The Pitfall
+
+**Symptom:** a fixed bug appears to still be present in CI. Stacktrace line numbers point to code that no longer exists at that line in the current source. `mix compile --force` output shows files being compiled, but the released app behaves like the old source.
+
+**Root cause:** the Dockerfile used to split compilation into two RUN steps that both mounted the same `_build` cache volume:
+
+```dockerfile
+# OLD — DO NOT REINTRODUCE
+RUN --mount=type=cache,target=/app/_build,id=mix-build \
+    mix compile --force
+
+RUN --mount=type=cache,target=/app/_build,id=mix-build \
+    mix release && cp -r /app/_build/prod/rel/engram /app/_release
+```
+
+`mix compile --force` wrote fresh beams into the cache volume. `mix release` in the next RUN step mounted the same cache volume — but BuildKit's layer caching + the persistent cache meant the release step sometimes packaged stale beams that had been written by an earlier build. `--force` in the compile step did not help because the stale files lived in the release step's view of `_build/prod/rel/`, which `mix release` generated from whatever it saw in the cache.
+
+Cache-busting the layer hash (editing the Dockerfile top, adding comments, changing copy paths) had **no effect** — cache mounts persist independently of layer hashes.
+
+## The Fix
+
+Merge compile and release into a single RUN step and drop the `_build` cache mount entirely. Only `deps` is cached; `_build` is regenerated every build.
+
+```dockerfile
+RUN --mount=type=cache,target=/app/deps,id=mix-deps \
+    mix compile --force && \
+    mix release && \
+    cp -r /app/_build/prod/rel/engram /app/_release
+```
+
+The extra ~1 minute of compile time is worth the guarantee that the released image matches the committed source.
+
+## Key Commands / Patterns
+
+- Verify a CI build is using fresh code: check the stack log for `Image cache miss (engram-ci:<sha>) — building` AND `Compiling N files (.ex)` AND look for expected file-level compilation output.
+- If a stacktrace line number disagrees with current source, **suspect build cache first, not code**. `git show HEAD -- <file>` to confirm the commit has the change; if yes, it is a deployment/cache issue, not a source issue.
+- Local test: `docker compose -f docker-compose.ci.yml build --no-cache engram` forces a full rebuild without BuildKit cache.
+
+## Failed Approaches / Dead Ends
+
+1. **Cache-bust by editing Dockerfile top.** Layer-hash invalidation does not clear mounted cache volumes. No effect.
+2. **`rm -rf /app/_build/prod/lib/engram` before `mix compile --force`.** Purges beams in the compile-step's view, but the release step mounts the cache independently and may see unrelated stale files. No effect.
+3. **Adding comment-only changes to the Dockerfile to force layer rebuild.** Same as #1 — does not touch cache-mount contents.
+
+## Gotchas
+
+- `_build` cache mounts are a footgun for any multi-step build that both writes to and reads from `_build` across RUN steps. Keep them within a single RUN or remove entirely.
+- BuildKit cache mount IDs (`id=mix-build`) are shared across repositories on the same runner. A different project's build could theoretically pollute the mount — one more reason to avoid `_build` caching.
+- When debugging, `gh run view --log` truncates BuildKit output. Use `gh run download` and inspect `ci-*-stack.log` for the full build log.
+- The only safe cache for Elixir releases is `deps` (compiled dependencies). App beams must be rebuilt from source every time.
+
+## References
+
+- `backend/Dockerfile` — the fix landed in commit `7d8d636` on `feat/pluggable-key-providers`.
+- `docs/context/e2e-debugging.md` (workspace repo) — older dead-end theory around `_build` cache that was NOT the same issue but was a related symptom.
+- BuildKit cache mount docs: https://docs.docker.com/build/cache/optimize/#use-cache-mounts

--- a/e2e/helpers/clerk.py
+++ b/e2e/helpers/clerk.py
@@ -42,8 +42,15 @@ class ClerkClient:
         return users[0]["id"]
 
     def create_user(self, email: str, password: str) -> str:
-        """Create a Clerk user via Backend API. Returns user_id."""
-        # Derive a username from the email (Clerk instance may require it)
+        """Create a Clerk user via Backend API. Returns user_id.
+
+        Idempotent: if Clerk reports the email as already taken (422
+        form_identifier_exists), returns the existing user's ID rather
+        than raising. Handles the common case where a prior fixture
+        created the user but a downstream step (API key creation,
+        network hiccup) failed mid-setup, causing pytest-rerunfailures
+        to re-invoke provision_user with the same email.
+        """
         username = email.split("@")[0]
         resp = self.session.post(
             f"{self.base_url}/users",
@@ -55,12 +62,31 @@ class ClerkClient:
             },
             timeout=10,
         )
+        if resp.status_code == 422 and self._is_identifier_taken(resp):
+            existing_id = self.find_user_by_email(email)
+            if existing_id:
+                logger.warning(
+                    "Clerk user %s already exists for %s — reusing", existing_id, email
+                )
+                return existing_id
+            logger.error(
+                "Clerk says %s is taken but lookup found nothing: %s",
+                email, resp.text,
+            )
         if not resp.ok:
-            logger.error("Clerk create_user failed: %s %s", resp.status_code, resp.text)
+            logger.error("Clerk create_user failed for %s: %s %s", email, resp.status_code, resp.text)
         resp.raise_for_status()
         user_id = resp.json()["id"]
         logger.info("Created Clerk user %s (%s)", user_id, email)
         return user_id
+
+    @staticmethod
+    def _is_identifier_taken(resp: requests.Response) -> bool:
+        try:
+            errors = resp.json().get("errors", [])
+        except ValueError:
+            return False
+        return any(e.get("code") == "form_identifier_exists" for e in errors)
 
     def create_session_token(self, user_id: str) -> str:
         """Create a session for a user and return a short-lived JWT.

--- a/e2e/tests/api_only/test_62_encrypted_vault.py
+++ b/e2e/tests/api_only/test_62_encrypted_vault.py
@@ -61,17 +61,14 @@ def _enable_vault_encryption(vault_id: int) -> None:
 class TestEncryptedVaultRoundTrip:
     """Write and read a note from an encrypted vault via HTTP."""
 
-    def test_encrypted_vault_round_trip(self, api_sync):
+    def test_encrypted_vault_round_trip(self, api_sync, sync_client_id):
         """Plaintext written to an encrypted vault is returned as plaintext on read."""
-        unique = f"enc-{int(time.time())}"
-        vault_name = f"e2e-encrypted-{unique}"
-        client_id = f"e2e-enc-{unique}"
-
-        # 1. Register a vault (starts unencrypted — changeset doesn't cast `encrypted`)
-        vault_data, status = api_sync.register_vault(vault_name, client_id)
-        assert status in (200, 201), f"register_vault failed: {status} {vault_data}"
-        vault_id = vault_data.get("id")
-        assert vault_id is not None, f"No vault id in response: {vault_data}"
+        # 1. Find the vault pre-registered in the api_sync fixture by client_id
+        #    (avoids hitting free-tier limit which allows 1 vault per user).
+        vaults = api_sync.list_vaults()
+        vault = next((v for v in vaults if v.get("client_id") == sync_client_id), None)
+        assert vault is not None, f"No vault found with client_id={sync_client_id}. Vaults: {vaults}"
+        vault_id = vault["id"]
 
         # 2. Enable encryption at the DB level (toggle endpoint is a future phase)
         _enable_vault_encryption(vault_id)
@@ -82,17 +79,26 @@ class TestEncryptedVaultRoundTrip:
         plaintext = "secret diary entry — only plaintext should come back"
         note_path = "journal/today.md"
 
-        # 4. Upsert note
-        resp = vault_client.session.post(
-            f"{API_URL}/notes",
-            json={"path": note_path, "content": plaintext, "mtime": time.time()},
-            timeout=10,
-        )
-        assert resp.ok, f"upsert_note failed: {resp.status_code} {resp.text[:300]}"
+        try:
+            # 4. Upsert note
+            resp = vault_client.session.post(
+                f"{API_URL}/notes",
+                json={"path": note_path, "content": plaintext, "mtime": time.time()},
+                timeout=10,
+            )
+            assert resp.ok, f"upsert_note failed: {resp.status_code} {resp.text[:300]}"
 
-        # 5. Read back — must return decrypted plaintext
-        note = vault_client.get_note(note_path)
-        assert note is not None, f"Note not found after upsert: {note_path}"
-        assert note["content"] == plaintext, (
-            f"Expected plaintext content, got: {note['content'][:100]!r}"
-        )
+            # 5. Read back — must return decrypted plaintext
+            note = vault_client.get_note(note_path)
+            assert note is not None, f"Note not found after upsert: {note_path}"
+            assert note["content"] == plaintext, (
+                f"Expected plaintext content, got: {note['content'][:100]!r}"
+            )
+        finally:
+            # Teardown: disable encryption so subsequent tests using this vault aren't affected
+            sql = f"UPDATE vaults SET encrypted = false WHERE id = {int(vault_id)};\n"
+            cmd = [
+                "docker", "exec", "-i", CI_POSTGRES_CONTAINER,
+                "psql", "-U", "engram", "-d", "engram",
+            ]
+            subprocess.run(cmd, input=sql, capture_output=True, text=True, timeout=15)

--- a/e2e/tests/api_only/test_62_encrypted_vault.py
+++ b/e2e/tests/api_only/test_62_encrypted_vault.py
@@ -1,0 +1,98 @@
+"""Test 62: Encrypted vault round-trip via HTTP API.
+
+Registers a vault, enables encryption directly in the DB (the vault
+changeset does not cast `encrypted` yet — the toggle UI is a future
+phase), writes a note, reads it back, asserts the API returns plaintext.
+
+This is the acceptance test for end-to-end encryption across a real HTTP
+boundary. It runs in the api_only CI job (no Obsidian, no Clerk needed).
+
+Design note: we cannot set encrypted=true through the public API today
+because Vault.changeset/2 only casts a restricted field list. Until the
+encryption-toggle endpoint ships we patch the DB row directly via psql,
+mirroring the same docker-exec pattern used in cleanup.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+
+import pytest
+import requests
+
+API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+CI_POSTGRES_CONTAINER = os.environ.get("CI_POSTGRES_CONTAINER", "engram-postgres-1")
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _enable_vault_encryption(vault_id: int) -> None:
+    """Flip vaults.encrypted = true for a specific vault ID via psql.
+
+    Uses the same docker-exec pattern as cleanup.py. Safe: vault_id is an
+    integer supplied by the test, never from user input.
+    """
+    sql = f"UPDATE vaults SET encrypted = true WHERE id = {int(vault_id)};\n"
+    cmd = [
+        "docker", "exec", "-i", CI_POSTGRES_CONTAINER,
+        "psql", "-U", "engram", "-d", "engram",
+    ]
+    result = subprocess.run(cmd, input=sql, capture_output=True, text=True, timeout=15)
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "No such container" in stderr:
+            pytest.skip(f"CI postgres container {CI_POSTGRES_CONTAINER!r} not found — skipping encrypted-vault E2E")
+        raise RuntimeError(f"psql update failed: {stderr}")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptedVaultRoundTrip:
+    """Write and read a note from an encrypted vault via HTTP."""
+
+    def test_encrypted_vault_round_trip(self, api_sync):
+        """Plaintext written to an encrypted vault is returned as plaintext on read."""
+        unique = f"enc-{int(time.time())}"
+        vault_name = f"e2e-encrypted-{unique}"
+        client_id = f"e2e-enc-{unique}"
+
+        # 1. Register a vault (starts unencrypted — changeset doesn't cast `encrypted`)
+        vault_data, status = api_sync.register_vault(vault_name, client_id)
+        assert status in (200, 201), f"register_vault failed: {status} {vault_data}"
+        vault_id = vault_data.get("id")
+        assert vault_id is not None, f"No vault id in response: {vault_data}"
+
+        # 2. Enable encryption at the DB level (toggle endpoint is a future phase)
+        _enable_vault_encryption(vault_id)
+
+        # 3. Build an ApiClient that sends X-Vault-ID so vault-scoped endpoints resolve
+        vault_client = api_sync.with_vault(vault_id)
+
+        plaintext = "secret diary entry — only plaintext should come back"
+        note_path = "journal/today.md"
+
+        # 4. Upsert note
+        resp = vault_client.session.post(
+            f"{API_URL}/notes",
+            json={"path": note_path, "content": plaintext, "mtime": time.time()},
+            timeout=10,
+        )
+        assert resp.ok, f"upsert_note failed: {resp.status_code} {resp.text[:300]}"
+
+        # 5. Read back — must return decrypted plaintext
+        note = vault_client.get_note(note_path)
+        assert note is not None, f"Note not found after upsert: {note_path}"
+        assert note["content"] == plaintext, (
+            f"Expected plaintext content, got: {note['content'][:100]!r}"
+        )

--- a/e2e/tests/api_only/test_62_encrypted_vault.py
+++ b/e2e/tests/api_only/test_62_encrypted_vault.py
@@ -61,14 +61,14 @@ def _enable_vault_encryption(vault_id: int) -> None:
 class TestEncryptedVaultRoundTrip:
     """Write and read a note from an encrypted vault via HTTP."""
 
-    def test_encrypted_vault_round_trip(self, api_sync, sync_client_id):
+    def test_encrypted_vault_round_trip(self, api_sync):
         """Plaintext written to an encrypted vault is returned as plaintext on read."""
-        # 1. Find the vault pre-registered in the api_sync fixture by client_id
-        #    (avoids hitting free-tier limit which allows 1 vault per user).
+        # 1. Use the vault api_sync already registered (free tier = 1 vault/user).
+        #    The /vaults list endpoint returns {id, name, slug, ...} — no client_id —
+        #    so we take the first (and only) entry rather than matching by client_id.
         vaults = api_sync.list_vaults()
-        vault = next((v for v in vaults if v.get("client_id") == sync_client_id), None)
-        assert vault is not None, f"No vault found with client_id={sync_client_id}. Vaults: {vaults}"
-        vault_id = vault["id"]
+        assert vaults, f"api_sync should have pre-registered a vault; got {vaults}"
+        vault_id = vaults[0]["id"]
 
         # 2. Enable encryption at the DB level (toggle endpoint is a future phase)
         _enable_vault_encryption(vault_id)

--- a/lib/engram/accounts.ex
+++ b/lib/engram/accounts.ex
@@ -236,6 +236,22 @@ defmodule Engram.Accounts do
     :crypto.hash(:sha256, raw_token) |> Base.encode16(case: :lower)
   end
 
+  # ── Encryption ─────────────────────────────────────────────────
+
+  @doc """
+  Updates encryption-related fields on a user. Used by Engram.Crypto during
+  DEK provisioning. Separate from general user updates so the change surface
+  is narrow.
+  """
+  @spec update_user_encryption(Engram.Accounts.User.t(), map()) ::
+          {:ok, Engram.Accounts.User.t()} | {:error, Ecto.Changeset.t()}
+  def update_user_encryption(%User{} = user, attrs) do
+    user
+    |> Ecto.Changeset.cast(attrs, [:encrypted_dek, :dek_version, :key_provider])
+    |> Ecto.Changeset.validate_required([:encrypted_dek, :dek_version, :key_provider])
+    |> Repo.update(skip_tenant_check: true)
+  end
+
   # ── JWT ─────────────────────────────────────────────────────────
 
   def generate_jwt(user) do

--- a/lib/engram/accounts/user.ex
+++ b/lib/engram/accounts/user.ex
@@ -7,6 +7,9 @@ defmodule Engram.Accounts.User do
     field :password_hash, :string
     field :role, :string, default: "member"
     field :display_name, :string
+    field :encrypted_dek, :binary
+    field :dek_version, :integer, default: 1
+    field :key_provider, :string, default: "local"
 
     belongs_to :plan, Engram.Billing.Plan
     has_many :notes, Engram.Notes.Note

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -16,6 +16,7 @@ defmodule Engram.Application do
         {DNSCluster, query: Application.get_env(:engram, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: Engram.PubSub},
         EngramWeb.Presence,
+        Engram.Crypto.DekCache,
         {Oban, Application.fetch_env!(:engram, Oban)},
         clerk_strategy_child(),
         EngramWeb.Endpoint

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -7,6 +7,8 @@ defmodule Engram.Application do
 
   @impl true
   def start(_type, _args) do
+    Engram.Crypto.Config.validate!()
+
     children =
       [
         EngramWeb.Telemetry,

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -96,7 +96,7 @@ defmodule Engram.Crypto do
   """
   @spec maybe_decrypt_note_fields(Engram.Notes.Note.t(), User.t()) ::
           {:ok, Engram.Notes.Note.t()} | {:error, term()}
-  def maybe_decrypt_note_fields(%Engram.Notes.Note{content_nonce: nil} = note, _user),
+  def maybe_decrypt_note_fields(%Engram.Notes.Note{content_ciphertext: nil} = note, _user),
     do: {:ok, note}
 
   def maybe_decrypt_note_fields(%Engram.Notes.Note{} = note, %User{} = user) do

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -1,0 +1,59 @@
+defmodule Engram.Crypto do
+  @moduledoc """
+  Public API for encryption. Wraps the KeyProvider behaviour and DekCache.
+
+  Lazy DEK provisioning: users get a DEK only when encryption is first needed.
+  """
+
+  alias Engram.Accounts
+  alias Engram.Accounts.User
+  alias Engram.Crypto.{DekCache, KeyProvider.Resolver}
+
+  @doc """
+  Ensures the user has a wrapped DEK stored. Idempotent — returns the user
+  untouched if `encrypted_dek` is already present.
+  """
+  @spec ensure_user_dek(User.t()) :: {:ok, User.t()} | {:error, term()}
+  def ensure_user_dek(%User{encrypted_dek: blob} = user) when is_binary(blob), do: {:ok, user}
+
+  def ensure_user_dek(%User{} = user) do
+    provider = Resolver.provider_for(user.id)
+    dek = provider.generate_dek()
+
+    with {:ok, wrapped} <- provider.wrap_dek(dek, %{user_id: user.id}),
+         {:ok, user} <-
+           Accounts.update_user_encryption(user, %{
+             encrypted_dek: wrapped,
+             dek_version: 1,
+             key_provider: Atom.to_string(provider.name())
+           }) do
+      DekCache.put(user.id, dek)
+      {:ok, user}
+    end
+  end
+
+  @doc """
+  Returns the plaintext DEK for a user, unwrapping via the provider if not cached.
+  """
+  @spec get_dek(User.t()) :: {:ok, <<_::256>>} | {:error, term()}
+  def get_dek(%User{encrypted_dek: nil}), do: {:error, :no_dek}
+
+  def get_dek(%User{id: user_id, encrypted_dek: blob}) do
+    case DekCache.get(user_id) do
+      {:ok, dek} ->
+        {:ok, dek}
+
+      :miss ->
+        provider = Resolver.provider_for(user_id)
+
+        case provider.unwrap_dek(blob, %{user_id: user_id}) do
+          {:ok, dek} ->
+            DekCache.put(user_id, dek)
+            {:ok, dek}
+
+          {:error, _} = err ->
+            err
+        end
+    end
+  end
+end

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -7,7 +7,7 @@ defmodule Engram.Crypto do
 
   alias Engram.Accounts
   alias Engram.Accounts.User
-  alias Engram.Crypto.{DekCache, KeyProvider.Resolver}
+  alias Engram.Crypto.{DekCache, Envelope, KeyProvider.Resolver}
 
   @doc """
   Ensures the user has a wrapped DEK stored. Idempotent — returns the user
@@ -54,6 +54,58 @@ defmodule Engram.Crypto do
           {:error, _} = err ->
             err
         end
+    end
+  end
+
+  @doc """
+  If `vault.encrypted`, encrypts `content`, `title`, `tags`; sets plaintext
+  fields to nil; adds `_ciphertext` + `_nonce` fields. Otherwise passes through.
+  """
+  @spec maybe_encrypt_note_fields(map(), User.t(), Engram.Vaults.Vault.t()) ::
+          {:ok, map()} | {:error, term()}
+  def maybe_encrypt_note_fields(attrs, _user, %Engram.Vaults.Vault{encrypted: false}),
+    do: {:ok, attrs}
+
+  def maybe_encrypt_note_fields(attrs, %User{} = user, %Engram.Vaults.Vault{encrypted: true}) do
+    with {:ok, dek} <- get_dek(user) do
+      content = Map.get(attrs, :content) || Map.get(attrs, "content") || ""
+      title = Map.get(attrs, :title) || Map.get(attrs, "title") || ""
+      tags = Map.get(attrs, :tags) || Map.get(attrs, "tags") || []
+
+      {content_ct, content_nonce} = Envelope.encrypt(content, dek)
+      {title_ct, title_nonce} = Envelope.encrypt(title, dek)
+      {tags_ct, tags_nonce} = Envelope.encrypt(:erlang.term_to_binary(tags), dek)
+
+      {:ok,
+       attrs
+       |> Map.put(:content, nil)
+       |> Map.put(:title, nil)
+       |> Map.put(:tags, nil)
+       |> Map.put(:content_ciphertext, content_ct)
+       |> Map.put(:content_nonce, content_nonce)
+       |> Map.put(:title_ciphertext, title_ct)
+       |> Map.put(:title_nonce, title_nonce)
+       |> Map.put(:tags_ciphertext, tags_ct)
+       |> Map.put(:tags_nonce, tags_nonce)}
+    end
+  end
+
+  @doc """
+  If note has ciphertext columns populated, decrypt them into `content`/`title`/`tags`.
+  Otherwise return the note unchanged.
+  """
+  @spec maybe_decrypt_note_fields(Engram.Notes.Note.t(), User.t()) ::
+          {:ok, Engram.Notes.Note.t()} | {:error, term()}
+  def maybe_decrypt_note_fields(%Engram.Notes.Note{content_nonce: nil} = note, _user),
+    do: {:ok, note}
+
+  def maybe_decrypt_note_fields(%Engram.Notes.Note{} = note, %User{} = user) do
+    with {:ok, dek} <- get_dek(user),
+         {:ok, content} <- Envelope.decrypt(note.content_ciphertext, note.content_nonce, dek),
+         {:ok, title} <- Envelope.decrypt(note.title_ciphertext, note.title_nonce, dek),
+         {:ok, tags_bin} <- Envelope.decrypt(note.tags_ciphertext, note.tags_nonce, dek) do
+      tags = :erlang.binary_to_term(tags_bin, [:safe])
+      {:ok, %{note | content: content, title: title, tags: tags}}
     end
   end
 end

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -67,7 +67,8 @@ defmodule Engram.Crypto do
     do: {:ok, attrs}
 
   def maybe_encrypt_note_fields(attrs, %User{} = user, %Engram.Vaults.Vault{encrypted: true}) do
-    with {:ok, dek} <- get_dek(user) do
+    with {:ok, user} <- ensure_user_dek(user),
+         {:ok, dek} <- get_dek(user) do
       content = Map.get(attrs, :content) || Map.get(attrs, "content") || ""
       title = Map.get(attrs, :title) || Map.get(attrs, "title") || ""
       tags = Map.get(attrs, :tags) || Map.get(attrs, "tags") || []

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -67,6 +67,9 @@ defmodule Engram.Crypto do
     do: {:ok, attrs}
 
   def maybe_encrypt_note_fields(attrs, %User{} = user, %Engram.Vaults.Vault{encrypted: true}) do
+    require Logger
+    Logger.debug("maybe_encrypt_note_fields auto-provision path for user_id=#{user.id}")
+
     with {:ok, user} <- ensure_user_dek(user),
          {:ok, dek} <- get_dek(user) do
       content = Map.get(attrs, :content) || Map.get(attrs, "content") || ""

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -106,6 +106,9 @@ defmodule Engram.Crypto do
          {:ok, tags_bin} <- Envelope.decrypt(note.tags_ciphertext, note.tags_nonce, dek) do
       tags = :erlang.binary_to_term(tags_bin, [:safe])
       {:ok, %{note | content: content, title: title, tags: tags}}
+    else
+      :error -> {:error, :decrypt_failed}
+      {:error, _} = err -> err
     end
   end
 end

--- a/lib/engram/crypto/config.ex
+++ b/lib/engram/crypto/config.ex
@@ -1,0 +1,64 @@
+defmodule Engram.Crypto.Config do
+  @moduledoc """
+  Validates encryption configuration at application boot.
+  Raises with actionable messages if misconfigured.
+  """
+
+  @valid_providers [
+    Engram.Crypto.KeyProvider.Local
+    # Future: Engram.Crypto.KeyProvider.AwsKms, Engram.Crypto.KeyProvider.Passphrase
+  ]
+
+  @spec validate!() :: :ok
+  def validate! do
+    provider = Application.get_env(:engram, :key_provider)
+
+    unless provider in @valid_providers do
+      raise "unknown key_provider #{inspect(provider)}; valid options: #{inspect(@valid_providers)}"
+    end
+
+    if provider == Engram.Crypto.KeyProvider.Local do
+      validate_local_master_key!()
+    end
+
+    :ok
+  end
+
+  @doc "Returns the decoded 32-byte master key for the Local provider."
+  @spec local_master_key!() :: <<_::256>>
+  def local_master_key! do
+    raw = Application.get_env(:engram, :encryption_master_key)
+    decode_master_key!(raw, "ENCRYPTION_MASTER_KEY")
+  end
+
+  @doc "Returns the decoded 32-byte previous master key if set, else nil. For rotation."
+  @spec local_master_key_previous() :: <<_::256>> | nil
+  def local_master_key_previous do
+    case Application.get_env(:engram, :encryption_master_key_previous) do
+      nil -> nil
+      "" -> nil
+      raw -> decode_master_key!(raw, "ENCRYPTION_MASTER_KEY_PREVIOUS")
+    end
+  end
+
+  defp validate_local_master_key! do
+    _ = local_master_key!()
+    :ok
+  end
+
+  defp decode_master_key!(nil, name), do: raise("#{name} is required when KEY_PROVIDER=local")
+  defp decode_master_key!("", name), do: raise("#{name} is required when KEY_PROVIDER=local")
+
+  defp decode_master_key!(raw, name) when is_binary(raw) do
+    case Base.decode64(raw) do
+      {:ok, <<_::256>> = key} ->
+        key
+
+      {:ok, other} ->
+        raise "#{name} must decode to 32 bytes; got #{byte_size(other)} bytes"
+
+      :error ->
+        raise "#{name} must be valid base64"
+    end
+  end
+end

--- a/lib/engram/crypto/config.ex
+++ b/lib/engram/crypto/config.ex
@@ -13,8 +13,15 @@ defmodule Engram.Crypto.Config do
   def validate! do
     provider = Application.get_env(:engram, :key_provider)
 
-    unless provider in @valid_providers do
-      raise "unknown key_provider #{inspect(provider)}; valid options: #{inspect(@valid_providers)}"
+    cond do
+      is_nil(provider) ->
+        raise "key_provider is not configured — set :engram, :key_provider in config"
+
+      provider not in @valid_providers ->
+        raise "unknown key_provider #{inspect(provider)}; valid options: #{inspect(@valid_providers)}"
+
+      true ->
+        :ok
     end
 
     if provider == Engram.Crypto.KeyProvider.Local do

--- a/lib/engram/crypto/dek_cache.ex
+++ b/lib/engram/crypto/dek_cache.ex
@@ -1,0 +1,93 @@
+defmodule Engram.Crypto.DekCache do
+  @moduledoc """
+  ETS-backed cache for unwrapped DEKs. TTL-based expiry; sweep GenServer
+  evicts expired entries periodically. On node shutdown, all DEKs vanish
+  (correct — they re-populate on next request via KMS/Local unwrap).
+  """
+
+  use GenServer
+
+  @table :engram_dek_cache
+  @sweep_interval_ms :timer.minutes(5)
+
+  ## Public API
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec get(user_id :: integer()) :: {:ok, <<_::256>>} | :miss
+  def get(user_id) do
+    case :ets.lookup(@table, user_id) do
+      [{^user_id, dek, expires_at}] ->
+        if :erlang.system_time(:millisecond) < expires_at do
+          {:ok, dek}
+        else
+          :ets.delete(@table, user_id)
+          :miss
+        end
+
+      [] ->
+        :miss
+    end
+  end
+
+  @spec put(user_id :: integer(), dek :: <<_::256>>, ttl_ms :: non_neg_integer() | nil) :: :ok
+  def put(user_id, <<_::256>> = dek, ttl_ms \\ nil) do
+    ttl = ttl_ms || Application.get_env(:engram, :dek_cache_ttl_ms, 3_600_000)
+    expires_at = :erlang.system_time(:millisecond) + ttl
+    :ets.insert(@table, {user_id, dek, expires_at})
+    :ok
+  end
+
+  @spec invalidate(user_id :: integer()) :: :ok
+  def invalidate(user_id) do
+    :ets.delete(@table, user_id)
+    :ok
+  end
+
+  @spec invalidate_all() :: :ok
+  def invalidate_all do
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  @doc "Force an immediate sweep; exposed for tests."
+  def sweep_now, do: GenServer.call(__MODULE__, :sweep)
+
+  ## GenServer
+
+  @impl true
+  def init(:ok) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call(:sweep, _from, state) do
+    sweep()
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    sweep()
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_interval_ms)
+
+  defp sweep do
+    now = :erlang.system_time(:millisecond)
+    :ets.foldl(
+      fn {user_id, _dek, expires_at}, _acc ->
+        if now >= expires_at, do: :ets.delete(@table, user_id)
+        nil
+      end,
+      nil,
+      @table
+    )
+  end
+end

--- a/lib/engram/crypto/dek_cache.ex
+++ b/lib/engram/crypto/dek_cache.ex
@@ -59,6 +59,13 @@ defmodule Engram.Crypto.DekCache do
 
   @impl true
   def init(:ok) do
+    # :public is required because get/put/invalidate are called directly by
+    # caller processes (Notes, Oban workers) without routing through this
+    # GenServer — avoids serialization bottleneck on hot path. Trade-off:
+    # any BEAM process can read wrapped DEKs from the table. Acceptable
+    # because plaintext DEKs never persist to disk and are cleared on
+    # node restart. If tightening to :protected, move get/put/invalidate
+    # into GenServer.call/cast.
     :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
     schedule_sweep()
     {:ok, %{}}

--- a/lib/engram/crypto/envelope.ex
+++ b/lib/engram/crypto/envelope.ex
@@ -30,4 +30,6 @@ defmodule Engram.Crypto.Envelope do
       end
     end
   end
+
+  def decrypt(_ct_with_tag, _nonce, <<_::256>>), do: :error
 end

--- a/lib/engram/crypto/envelope.ex
+++ b/lib/engram/crypto/envelope.ex
@@ -1,0 +1,33 @@
+defmodule Engram.Crypto.Envelope do
+  @moduledoc """
+  Stateless AES-256-GCM authenticated encryption.
+  Ciphertext layout returned by encrypt/2 is `ciphertext || tag` (16-byte tag suffix).
+  The nonce is returned separately; callers store it alongside ciphertext.
+  """
+
+  @cipher :aes_256_gcm
+  @nonce_bytes 12
+  @tag_bytes 16
+
+  @spec encrypt(binary(), <<_::256>>) :: {binary(), binary()}
+  def encrypt(plaintext, <<_::256>> = dek) when is_binary(plaintext) do
+    nonce = :crypto.strong_rand_bytes(@nonce_bytes)
+    {ct, tag} = :crypto.crypto_one_time_aead(@cipher, dek, nonce, plaintext, <<>>, true)
+    {ct <> tag, nonce}
+  end
+
+  @spec decrypt(binary(), binary(), <<_::256>>) :: {:ok, binary()} | :error
+  def decrypt(ct_with_tag, nonce, <<_::256>> = dek)
+      when is_binary(ct_with_tag) and byte_size(nonce) == @nonce_bytes do
+    size = byte_size(ct_with_tag) - @tag_bytes
+    if size < 0 do
+      :error
+    else
+      <<ct::binary-size(size), tag::binary-size(@tag_bytes)>> = ct_with_tag
+      case :crypto.crypto_one_time_aead(@cipher, dek, nonce, ct, <<>>, tag, false) do
+        plaintext when is_binary(plaintext) -> {:ok, plaintext}
+        :error -> :error
+      end
+    end
+  end
+end

--- a/lib/engram/crypto/key_provider.ex
+++ b/lib/engram/crypto/key_provider.ex
@@ -1,0 +1,24 @@
+defmodule Engram.Crypto.KeyProvider do
+  @moduledoc """
+  Behaviour for wrapping/unwrapping per-user Data Encryption Keys (DEKs).
+  Implementations: Local, AwsKms (future), Passphrase (future).
+
+  `ctx` carries per-user state. AwsKms and Local ignore it; Passphrase reads it.
+  """
+
+  @type dek :: <<_::256>>
+  @type wrapped :: binary()
+  @type ctx :: %{:user_id => integer(), optional(:session_token) => String.t()}
+
+  @callback name() :: atom()
+  @callback generate_dek() :: dek()
+  @callback wrap_dek(dek(), ctx()) :: {:ok, wrapped()} | {:error, term()}
+  @callback unwrap_dek(wrapped(), ctx()) ::
+              {:ok, dek()} | {:error, :needs_unlock | term()}
+  @callback supports_async_workers?() :: boolean()
+  @callback rotate_wrapping(wrapped(), ctx()) :: {:ok, wrapped()} | {:error, term()}
+
+  @doc "Default DEK generator — providers may override."
+  @spec default_generate_dek() :: dek()
+  def default_generate_dek, do: :crypto.strong_rand_bytes(32)
+end

--- a/lib/engram/crypto/key_provider/local.ex
+++ b/lib/engram/crypto/key_provider/local.ex
@@ -1,0 +1,59 @@
+defmodule Engram.Crypto.KeyProvider.Local do
+  @moduledoc """
+  KeyProvider implementation backed by an env-var master key.
+  Wraps DEKs with AES-256-GCM using ENCRYPTION_MASTER_KEY.
+  Supports one-key-back fallback for rotation via ENCRYPTION_MASTER_KEY_PREVIOUS.
+  """
+
+  @behaviour Engram.Crypto.KeyProvider
+
+  alias Engram.Crypto.Envelope
+  alias Engram.Crypto.Config
+
+  @impl true
+  def name, do: :local
+
+  @impl true
+  def generate_dek, do: Engram.Crypto.KeyProvider.default_generate_dek()
+
+  @impl true
+  def wrap_dek(<<_::256>> = dek, _ctx) do
+    master = Config.local_master_key!()
+    {ct, nonce} = Envelope.encrypt(dek, master)
+    {:ok, <<nonce::binary-size(12), ct::binary>>}
+  end
+
+  @impl true
+  def unwrap_dek(<<nonce::binary-size(12), ct::binary>>, _ctx) do
+    current = Config.local_master_key!()
+
+    case Envelope.decrypt(ct, nonce, current) do
+      {:ok, <<_::256>> = dek} ->
+        {:ok, dek}
+
+      :error ->
+        case Config.local_master_key_previous() do
+          nil ->
+            {:error, :invalid_wrapping}
+
+          prev ->
+            case Envelope.decrypt(ct, nonce, prev) do
+              {:ok, <<_::256>> = dek} -> {:ok, dek}
+              :error -> {:error, :invalid_wrapping}
+            end
+        end
+    end
+  end
+
+  def unwrap_dek(_other, _ctx), do: {:error, :malformed_wrapped_blob}
+
+  @impl true
+  def supports_async_workers?, do: true
+
+  @impl true
+  def rotate_wrapping(wrapped, ctx) do
+    with {:ok, dek} <- unwrap_dek(wrapped, ctx) do
+      wrap_dek(dek, ctx)
+    end
+  end
+end

--- a/lib/engram/crypto/key_provider/resolver.ex
+++ b/lib/engram/crypto/key_provider/resolver.ex
@@ -1,0 +1,14 @@
+defmodule Engram.Crypto.KeyProvider.Resolver do
+  @moduledoc """
+  Returns the configured KeyProvider module. v1 uses compile-time/runtime
+  config; future BYOK will look up per-user from users.key_provider column.
+  """
+
+  @spec provider() :: module()
+  def provider do
+    Application.get_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+  end
+
+  @spec provider_for(user_id :: integer()) :: module()
+  def provider_for(_user_id), do: provider()
+end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -140,7 +140,8 @@ defmodule Engram.Notes do
             :not_found
 
           note ->
-            new_title = Helpers.extract_title(note.content || "", new_path)
+            decrypted_note = decrypt_if_needed(note, user)
+            new_title = Helpers.extract_title(decrypted_note.content || "", new_path)
 
             {count, _} =
               from(n in Note, where: n.id == ^note.id)
@@ -423,7 +424,8 @@ defmodule Engram.Notes do
             end
 
           new_path = new_note_folder <> String.slice(note.path, String.length(note.folder)..-1//1)
-          new_title = Helpers.extract_title(note.content || "", new_path)
+          decrypted_note = decrypt_if_needed(note, user)
+          new_title = Helpers.extract_title(decrypted_note.content || "", new_path)
 
           {note.id, note.path, new_path, new_note_folder, new_title}
         end)
@@ -485,8 +487,15 @@ defmodule Engram.Notes do
 
   defp decrypt_if_needed(%Note{} = note, user) do
     case Engram.Crypto.maybe_decrypt_note_fields(note, user) do
-      {:ok, decrypted} -> decrypted
-      {:error, _reason} -> note
+      {:ok, decrypted} ->
+        decrypted
+
+      {:error, reason} ->
+        Logger.error(
+          "decrypt_failed user_id=#{user.id} note_id=#{note.id} reason=#{inspect(reason)}"
+        )
+
+        note
     end
   end
 

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -107,7 +107,7 @@ defmodule Engram.Notes do
 
     case result do
       {:ok, nil} -> {:error, :not_found}
-      {:ok, note} -> {:ok, note}
+      {:ok, note} -> {:ok, decrypt_if_needed(note, user)}
       _ -> {:error, :not_found}
     end
   end
@@ -159,7 +159,7 @@ defmodule Engram.Notes do
         Oban.insert(EmbedNote.new_debounced(note.id, old_path: old_path))
         broadcast_change(user.id, vault.id, "delete", old_path)
         broadcast_change(user.id, vault.id, "upsert", note.path, note)
-        {:ok, note}
+        {:ok, decrypt_if_needed(note, user)}
 
       {:ok, :not_found} ->
         {:error, :not_found}
@@ -224,6 +224,8 @@ defmodule Engram.Notes do
 
     changes =
       Enum.map(notes, fn note ->
+        note = decrypt_if_needed(note, user)
+
         %{
           path: note.path,
           title: note.title,
@@ -373,7 +375,7 @@ defmodule Engram.Notes do
         Repo.all(query)
       end)
 
-    {:ok, notes}
+    {:ok, decrypt_if_needed(notes, user)}
   end
 
   @doc """
@@ -474,6 +476,19 @@ defmodule Engram.Notes do
   # ---------------------------------------------------------------------------
   # Private
   # ---------------------------------------------------------------------------
+
+  defp decrypt_if_needed(nil, _user), do: nil
+
+  defp decrypt_if_needed(%Note{} = note, user) do
+    case Engram.Crypto.maybe_decrypt_note_fields(note, user) do
+      {:ok, decrypted} -> decrypted
+      {:error, _reason} -> note
+    end
+  end
+
+  defp decrypt_if_needed(notes, user) when is_list(notes) do
+    Enum.map(notes, &decrypt_if_needed(&1, user))
+  end
 
   defp validate_path(nil),
     do:

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -4,6 +4,8 @@ defmodule Engram.Notes do
   All operations are tenant-scoped via Repo.with_tenant/2.
   """
 
+  require Logger
+
   import Ecto.Query
 
   alias Engram.Repo
@@ -74,6 +76,7 @@ defmodule Engram.Notes do
             Oban.insert(EmbedNote.new_debounced(note.id))
           end
 
+          note = decrypt_for_broadcast(note, user)
           broadcast_change(user.id, vault.id, "upsert", note.path, note)
           {:ok, note}
 
@@ -158,8 +161,9 @@ defmodule Engram.Notes do
       {:ok, {:ok, note}} ->
         Oban.insert(EmbedNote.new_debounced(note.id, old_path: old_path))
         broadcast_change(user.id, vault.id, "delete", old_path)
-        broadcast_change(user.id, vault.id, "upsert", note.path, note)
-        {:ok, decrypt_if_needed(note, user)}
+        decrypted = decrypt_for_broadcast(note, user)
+        broadcast_change(user.id, vault.id, "upsert", note.path, decrypted)
+        {:ok, decrypted}
 
       {:ok, :not_found} ->
         {:error, :not_found}
@@ -488,6 +492,22 @@ defmodule Engram.Notes do
 
   defp decrypt_if_needed(notes, user) when is_list(notes) do
     Enum.map(notes, &decrypt_if_needed(&1, user))
+  end
+
+  # Like decrypt_if_needed but logs a warning on decrypt failure before returning
+  # the original struct. Used before broadcast so operators know content is empty.
+  defp decrypt_for_broadcast(%Note{} = note, user) do
+    case Engram.Crypto.maybe_decrypt_note_fields(note, user) do
+      {:ok, decrypted} ->
+        decrypted
+
+      {:error, reason} ->
+        Logger.warning(
+          "broadcast decrypt failed: user_id=#{user.id} note_id=#{note.id} reason=#{inspect(reason)}"
+        )
+
+        note
+    end
   end
 
   defp validate_path(nil),

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -21,29 +21,27 @@ defmodule Engram.Notes do
     mtime = attrs["mtime"] || attrs[:mtime]
     client_version = attrs["version"] || attrs[:version]
 
-    with {:ok, path} <- validate_path(path) do
-      sanitized_path = PathSanitizer.sanitize(path)
-      title = Helpers.extract_title(content, sanitized_path)
-      folder = Helpers.extract_folder(sanitized_path)
-      tags = Helpers.extract_tags(content)
-      hash = content_hash(content)
-
-      now = DateTime.utc_now()
-
-      note_attrs = %{
-        path: sanitized_path,
-        content: content,
-        title: title,
-        folder: folder,
-        tags: tags,
-        content_hash: hash,
-        mtime: mtime,
-        user_id: user.id,
-        vault_id: vault.id,
-        created_at: now,
-        updated_at: now
-      }
-
+    with {:ok, path} <- validate_path(path),
+         sanitized_path = PathSanitizer.sanitize(path),
+         title = Helpers.extract_title(content, sanitized_path),
+         folder = Helpers.extract_folder(sanitized_path),
+         tags = Helpers.extract_tags(content),
+         hash = content_hash(content),
+         now = DateTime.utc_now(),
+         note_attrs = %{
+           path: sanitized_path,
+           content: content,
+           title: title,
+           folder: folder,
+           tags: tags,
+           content_hash: hash,
+           mtime: mtime,
+           user_id: user.id,
+           vault_id: vault.id,
+           created_at: now,
+           updated_at: now
+         },
+         {:ok, note_attrs} <- Engram.Crypto.maybe_encrypt_note_fields(note_attrs, user, vault) do
       changeset = Note.changeset(%Note{}, note_attrs)
 
       result =

--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -27,6 +27,12 @@ defmodule Engram.Notes.Note do
     timestamps(type: :utc_datetime_usec, inserted_at: :created_at)
   end
 
+  @encryption_fields [
+    :content_ciphertext, :content_nonce,
+    :title_ciphertext, :title_nonce,
+    :tags_ciphertext, :tags_nonce
+  ]
+
   def changeset(note, attrs) do
     note
     |> cast(attrs, [
@@ -41,7 +47,7 @@ defmodule Engram.Notes.Note do
       :user_id,
       :vault_id,
       :deleted_at
-    ], empty_values: [])
+    ] ++ @encryption_fields, empty_values: [])
     |> validate_required([:path, :user_id, :vault_id])
     |> default_content()
     |> unique_constraint([:user_id, :vault_id, :path], name: :notes_user_vault_path_active_index)

--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -13,6 +13,12 @@ defmodule Engram.Notes.Note do
     field :embed_hash, :string
     field :mtime, :float
     field :deleted_at, :utc_datetime_usec
+    field :content_ciphertext, :binary
+    field :content_nonce, :binary
+    field :title_ciphertext, :binary
+    field :title_nonce, :binary
+    field :tags_ciphertext, :binary
+    field :tags_nonce, :binary
 
     belongs_to :user, Engram.Accounts.User
     belongs_to :vault, Engram.Vaults.Vault

--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -9,6 +9,11 @@ defmodule Engram.Vaults.Vault do
     field :client_id, :string
     field :is_default, :boolean, default: false
     field :deleted_at, :utc_datetime
+    field :encrypted, :boolean, default: false
+    field :encrypted_at, :utc_datetime_usec
+    field :encryption_status, :string, default: "none"
+    field :decrypt_requested_at, :utc_datetime_usec
+    field :last_toggle_at, :utc_datetime_usec
 
     belongs_to :user, Engram.Accounts.User
     # has_many :notes and :attachments added in Task 6 once vault_id FK is added to those tables

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -26,6 +26,8 @@ defmodule Engram.Workers.EmbedNote do
 
   import Ecto.Query
 
+  alias Engram.Accounts
+  alias Engram.Crypto
   alias Engram.Indexing
   alias Engram.Notes.Note
   alias Engram.Repo
@@ -48,17 +50,26 @@ defmodule Engram.Workers.EmbedNote do
         :ok
 
       note ->
-        # If renamed, clean up old path's Qdrant points before re-indexing
-        if old_path do
-          Indexing.delete_points_by_path(note, old_path)
-        end
+        user = Accounts.get_user!(note.user_id)
 
-        case Indexing.index_note(note) do
-          {:ok, _count} ->
-            stamp_embed_hash(note)
-            :ok
+        case Crypto.maybe_decrypt_note_fields(note, user) do
+          {:ok, decrypted_note} ->
+            # If renamed, clean up old path's Qdrant points before re-indexing
+            if old_path do
+              Indexing.delete_points_by_path(decrypted_note, old_path)
+            end
+
+            case Indexing.index_note(decrypted_note) do
+              {:ok, _count} ->
+                stamp_embed_hash(note)
+                :ok
+
+              {:error, reason} ->
+                {:error, reason}
+            end
 
           {:error, reason} ->
+            Logger.error("EmbedNote decrypt failed: user_id=#{note.user_id} note_id=#{note.id} reason=#{inspect(reason)}")
             {:error, reason}
         end
     end

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -23,10 +23,15 @@ defmodule EngramWeb.NotesController do
           |> put_status(409)
           |> json(%{conflict: true, server_note: note_json(server_note)})
 
-        {:error, changeset} ->
+        {:error, %Ecto.Changeset{} = changeset} ->
           conn
           |> put_status(422)
           |> json(%{errors: format_errors(changeset)})
+
+        {:error, reason} ->
+          require Logger
+          Logger.error("upsert_note returned unexpected error: #{inspect(reason)}")
+          conn |> put_status(500) |> json(%{error: "internal", reason: inspect(reason)})
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.2.1",
+      version: "0.3.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260418000001_add_user_encryption_columns.exs
+++ b/priv/repo/migrations/20260418000001_add_user_encryption_columns.exs
@@ -1,0 +1,11 @@
+defmodule Engram.Repo.Migrations.AddUserEncryptionColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :encrypted_dek, :binary
+      add :dek_version, :integer, default: 1, null: false
+      add :key_provider, :string, default: "local", null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260418000002_add_vault_encryption_columns.exs
+++ b/priv/repo/migrations/20260418000002_add_vault_encryption_columns.exs
@@ -1,0 +1,13 @@
+defmodule Engram.Repo.Migrations.AddVaultEncryptionColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:vaults) do
+      add :encrypted, :boolean, default: false, null: false
+      add :encrypted_at, :utc_datetime_usec
+      add :encryption_status, :string, default: "none", null: false
+      add :decrypt_requested_at, :utc_datetime_usec
+      add :last_toggle_at, :utc_datetime_usec
+    end
+  end
+end

--- a/priv/repo/migrations/20260418000003_add_note_encryption_columns.exs
+++ b/priv/repo/migrations/20260418000003_add_note_encryption_columns.exs
@@ -1,0 +1,14 @@
+defmodule Engram.Repo.Migrations.AddNoteEncryptionColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notes) do
+      add :content_ciphertext, :binary
+      add :content_nonce, :binary
+      add :title_ciphertext, :binary
+      add :title_nonce, :binary
+      add :tags_ciphertext, :binary
+      add :tags_nonce, :binary
+    end
+  end
+end

--- a/test/engram/crypto/config_test.exs
+++ b/test/engram/crypto/config_test.exs
@@ -1,0 +1,45 @@
+defmodule Engram.Crypto.ConfigTest do
+  use ExUnit.Case, async: false
+  alias Engram.Crypto.Config
+
+  @valid_key_b64 Base.encode64(:crypto.strong_rand_bytes(32))
+
+  setup do
+    orig = Application.get_all_env(:engram)
+    on_exit(fn ->
+      Application.put_env(:engram, :key_provider, Keyword.get(orig, :key_provider))
+      Application.put_env(:engram, :encryption_master_key, Keyword.get(orig, :encryption_master_key))
+    end)
+    :ok
+  end
+
+  test "valid local config passes" do
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+    Application.put_env(:engram, :encryption_master_key, @valid_key_b64)
+    assert :ok = Config.validate!()
+  end
+
+  test "crashes on missing master key when provider is local" do
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+    Application.put_env(:engram, :encryption_master_key, nil)
+    assert_raise RuntimeError, ~r/ENCRYPTION_MASTER_KEY/, fn -> Config.validate!() end
+  end
+
+  test "crashes on malformed master key" do
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+    Application.put_env(:engram, :encryption_master_key, "not-base64!!!")
+    assert_raise RuntimeError, ~r/base64/, fn -> Config.validate!() end
+  end
+
+  test "crashes on wrong-length master key" do
+    short = Base.encode64(:crypto.strong_rand_bytes(16))
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+    Application.put_env(:engram, :encryption_master_key, short)
+    assert_raise RuntimeError, ~r/32 bytes/, fn -> Config.validate!() end
+  end
+
+  test "crashes on unknown provider" do
+    Application.put_env(:engram, :key_provider, NotAModule)
+    assert_raise RuntimeError, ~r/unknown/i, fn -> Config.validate!() end
+  end
+end

--- a/test/engram/crypto/config_test.exs
+++ b/test/engram/crypto/config_test.exs
@@ -42,4 +42,9 @@ defmodule Engram.Crypto.ConfigTest do
     Application.put_env(:engram, :key_provider, NotAModule)
     assert_raise RuntimeError, ~r/unknown/i, fn -> Config.validate!() end
   end
+
+  test "crashes with clear message when key_provider is not configured" do
+    Application.put_env(:engram, :key_provider, nil)
+    assert_raise RuntimeError, ~r/not configured/, fn -> Config.validate!() end
+  end
 end

--- a/test/engram/crypto/dek_cache_test.exs
+++ b/test/engram/crypto/dek_cache_test.exs
@@ -1,0 +1,41 @@
+defmodule Engram.Crypto.DekCacheTest do
+  use ExUnit.Case, async: false
+  alias Engram.Crypto.DekCache
+
+  setup do
+    DekCache.invalidate_all()
+    :ok
+  end
+
+  @dek :binary.copy(<<0xAA>>, 32)
+
+  test "put + get round-trip" do
+    DekCache.put(1, @dek)
+    assert {:ok, @dek} = DekCache.get(1)
+  end
+
+  test "miss returns :miss" do
+    assert :miss = DekCache.get(404)
+  end
+
+  test "invalidate removes entry" do
+    DekCache.put(1, @dek)
+    DekCache.invalidate(1)
+    assert :miss = DekCache.get(1)
+  end
+
+  test "invalidate_all clears everything" do
+    DekCache.put(1, @dek)
+    DekCache.put(2, @dek)
+    DekCache.invalidate_all()
+    assert :miss = DekCache.get(1)
+    assert :miss = DekCache.get(2)
+  end
+
+  test "entries expire after TTL" do
+    DekCache.put(1, @dek, _ttl_ms = 10)
+    Process.sleep(25)
+    DekCache.sweep_now()
+    assert :miss = DekCache.get(1)
+  end
+end

--- a/test/engram/crypto/envelope_test.exs
+++ b/test/engram/crypto/envelope_test.exs
@@ -33,4 +33,13 @@ defmodule Engram.Crypto.EnvelopeTest do
     {ct, nonce} = Envelope.encrypt("", @dek)
     assert {:ok, ""} = Envelope.decrypt(ct, nonce, @dek)
   end
+
+  test "rejects malformed (wrong-length) nonce" do
+    {ct, _nonce} = Envelope.encrypt("secret", @dek)
+    short_nonce = :crypto.strong_rand_bytes(8)
+    assert :error = Envelope.decrypt(ct, short_nonce, @dek)
+
+    long_nonce = :crypto.strong_rand_bytes(16)
+    assert :error = Envelope.decrypt(ct, long_nonce, @dek)
+  end
 end

--- a/test/engram/crypto/envelope_test.exs
+++ b/test/engram/crypto/envelope_test.exs
@@ -1,0 +1,36 @@
+defmodule Engram.Crypto.EnvelopeTest do
+  use ExUnit.Case, async: true
+  alias Engram.Crypto.Envelope
+
+  @dek :crypto.strong_rand_bytes(32)
+
+  test "round-trips plaintext" do
+    {ct, nonce} = Envelope.encrypt("hello world", @dek)
+    assert {:ok, "hello world"} = Envelope.decrypt(ct, nonce, @dek)
+  end
+
+  test "produces unique nonces" do
+    {_, n1} = Envelope.encrypt("x", @dek)
+    {_, n2} = Envelope.encrypt("x", @dek)
+    refute n1 == n2
+    assert byte_size(n1) == 12
+  end
+
+  test "rejects tampered ciphertext" do
+    {ct, nonce} = Envelope.encrypt("secret", @dek)
+    <<first, rest::binary>> = ct
+    tampered = <<Bitwise.bxor(first, 1), rest::binary>>
+    assert :error = Envelope.decrypt(tampered, nonce, @dek)
+  end
+
+  test "rejects wrong key" do
+    {ct, nonce} = Envelope.encrypt("secret", @dek)
+    other_key = :crypto.strong_rand_bytes(32)
+    assert :error = Envelope.decrypt(ct, nonce, other_key)
+  end
+
+  test "handles empty plaintext" do
+    {ct, nonce} = Envelope.encrypt("", @dek)
+    assert {:ok, ""} = Envelope.decrypt(ct, nonce, @dek)
+  end
+end

--- a/test/engram/crypto/local_provider_test.exs
+++ b/test/engram/crypto/local_provider_test.exs
@@ -1,0 +1,65 @@
+defmodule Engram.Crypto.KeyProvider.LocalTest do
+  use ExUnit.Case, async: false
+  alias Engram.Crypto.KeyProvider.Local
+
+  setup do
+    key = :crypto.strong_rand_bytes(32)
+    Application.put_env(:engram, :encryption_master_key, Base.encode64(key))
+    on_exit(fn -> Application.delete_env(:engram, :encryption_master_key_previous) end)
+    {:ok, key: key}
+  end
+
+  test "name/0" do
+    assert Local.name() == :local
+  end
+
+  test "generate_dek returns 32 bytes" do
+    assert byte_size(Local.generate_dek()) == 32
+  end
+
+  test "wrap/unwrap round-trips" do
+    dek = Local.generate_dek()
+    {:ok, wrapped} = Local.wrap_dek(dek, %{user_id: 1})
+    assert {:ok, ^dek} = Local.unwrap_dek(wrapped, %{user_id: 1})
+  end
+
+  test "wrap produces distinct blobs for same DEK" do
+    dek = Local.generate_dek()
+    {:ok, w1} = Local.wrap_dek(dek, %{user_id: 1})
+    {:ok, w2} = Local.wrap_dek(dek, %{user_id: 1})
+    refute w1 == w2
+  end
+
+  test "unwrap fails on tampered blob" do
+    dek = Local.generate_dek()
+    {:ok, <<first, rest::binary>>} = Local.wrap_dek(dek, %{user_id: 1})
+    tampered = <<Bitwise.bxor(first, 1), rest::binary>>
+    assert {:error, _} = Local.unwrap_dek(tampered, %{user_id: 1})
+  end
+
+  test "unwrap falls back to previous key during rotation" do
+    old_key = :crypto.strong_rand_bytes(32)
+    new_key = :crypto.strong_rand_bytes(32)
+
+    Application.put_env(:engram, :encryption_master_key, Base.encode64(old_key))
+    dek = Local.generate_dek()
+    {:ok, wrapped_with_old} = Local.wrap_dek(dek, %{user_id: 1})
+
+    Application.put_env(:engram, :encryption_master_key, Base.encode64(new_key))
+    Application.put_env(:engram, :encryption_master_key_previous, Base.encode64(old_key))
+
+    assert {:ok, ^dek} = Local.unwrap_dek(wrapped_with_old, %{user_id: 1})
+  end
+
+  test "supports_async_workers? returns true" do
+    assert Local.supports_async_workers?() == true
+  end
+
+  test "rotate_wrapping re-wraps with current key" do
+    dek = Local.generate_dek()
+    {:ok, old_wrapped} = Local.wrap_dek(dek, %{user_id: 1})
+    {:ok, new_wrapped} = Local.rotate_wrapping(old_wrapped, %{user_id: 1})
+    refute old_wrapped == new_wrapped
+    assert {:ok, ^dek} = Local.unwrap_dek(new_wrapped, %{user_id: 1})
+  end
+end

--- a/test/engram/crypto/provider_conformance_test.exs
+++ b/test/engram/crypto/provider_conformance_test.exs
@@ -1,0 +1,48 @@
+defmodule Engram.Crypto.ProviderConformanceTest do
+  @moduledoc """
+  Shared conformance exercised against every KeyProvider. Any new provider
+  must pass these assertions without modification.
+  """
+  use ExUnit.Case, async: false
+
+  @providers [Engram.Crypto.KeyProvider.Local]
+
+  setup do
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+    :ok
+  end
+
+  for provider <- @providers do
+    @tag provider: provider
+    test "#{inspect(provider)}: name is an atom", %{} do
+      assert is_atom(unquote(provider).name())
+    end
+
+    test "#{inspect(provider)}: generate_dek is 32 bytes" do
+      assert byte_size(unquote(provider).generate_dek()) == 32
+    end
+
+    test "#{inspect(provider)}: wrap/unwrap round-trips" do
+      dek = unquote(provider).generate_dek()
+      ctx = %{user_id: 1}
+      {:ok, wrapped} = unquote(provider).wrap_dek(dek, ctx)
+      assert {:ok, ^dek} = unquote(provider).unwrap_dek(wrapped, ctx)
+    end
+
+    test "#{inspect(provider)}: rotate_wrapping preserves DEK" do
+      dek = unquote(provider).generate_dek()
+      ctx = %{user_id: 1}
+      {:ok, wrapped} = unquote(provider).wrap_dek(dek, ctx)
+      {:ok, rotated} = unquote(provider).rotate_wrapping(wrapped, ctx)
+      assert {:ok, ^dek} = unquote(provider).unwrap_dek(rotated, ctx)
+    end
+
+    test "#{inspect(provider)}: supports_async_workers? is boolean" do
+      assert is_boolean(unquote(provider).supports_async_workers?())
+    end
+  end
+end

--- a/test/engram/crypto/provider_swap_test.exs
+++ b/test/engram/crypto/provider_swap_test.exs
@@ -1,0 +1,61 @@
+defmodule Engram.Crypto.ProviderSwapTest do
+  @moduledoc """
+  Verifies provider-swap safety: wrapping blobs from one master key are
+  unreadable under a different master key. The error surfaces as a clean
+  {:error, _} (not a crash or silent corruption). Operators must migrate
+  data explicitly before swapping keys in production.
+  """
+
+  use Engram.DataCase, async: false
+
+  alias Engram.Crypto
+  alias Engram.Crypto.DekCache
+
+  setup do
+    DekCache.invalidate_all()
+    orig_key = Application.get_env(:engram, :encryption_master_key)
+
+    on_exit(fn ->
+      Application.put_env(:engram, :encryption_master_key, orig_key)
+      Application.delete_env(:engram, :encryption_master_key_previous)
+    end)
+
+    :ok
+  end
+
+  test "unwrap fails cleanly after master key swap" do
+    key_a = Base.encode64(:crypto.strong_rand_bytes(32))
+    key_b = Base.encode64(:crypto.strong_rand_bytes(32))
+
+    # Provision a DEK wrapped under key A
+    Application.put_env(:engram, :encryption_master_key, key_a)
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    DekCache.invalidate(user.id)
+
+    # Swap to key B — no ENCRYPTION_MASTER_KEY_PREVIOUS, so no fallback
+    Application.put_env(:engram, :encryption_master_key, key_b)
+    Application.delete_env(:engram, :encryption_master_key_previous)
+
+    # Must fail cleanly — no crash, no garbage returned
+    assert {:error, _reason} = Crypto.get_dek(user)
+  end
+
+  test "unwrap succeeds during rotation window (previous key set)" do
+    key_a = Base.encode64(:crypto.strong_rand_bytes(32))
+    key_b = Base.encode64(:crypto.strong_rand_bytes(32))
+
+    # Provision a DEK wrapped under key A
+    Application.put_env(:engram, :encryption_master_key, key_a)
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    DekCache.invalidate(user.id)
+
+    # Rotation: current = B, previous = A (just swapped — fallback is available)
+    Application.put_env(:engram, :encryption_master_key, key_b)
+    Application.put_env(:engram, :encryption_master_key_previous, key_a)
+
+    assert {:ok, dek} = Crypto.get_dek(user)
+    assert byte_size(dek) == 32
+  end
+end

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -34,4 +34,70 @@ defmodule Engram.CryptoTest do
   test "get_dek returns error if no DEK provisioned", %{user: user} do
     assert {:error, :no_dek} = Crypto.get_dek(user)
   end
+
+  describe "maybe_encrypt_note_fields/3" do
+    test "passes through when vault is not encrypted", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      vault = %Engram.Vaults.Vault{encrypted: false}
+
+      attrs = %{content: "hi", title: "t", tags: ["a", "b"]}
+      {:ok, out} = Crypto.maybe_encrypt_note_fields(attrs, user, vault)
+
+      assert out.content == "hi"
+      refute Map.has_key?(out, :content_ciphertext)
+    end
+
+    test "encrypts when vault is encrypted", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      vault = %Engram.Vaults.Vault{encrypted: true}
+
+      attrs = %{content: "secret", title: "Journal", tags: ["mood"]}
+      {:ok, out} = Crypto.maybe_encrypt_note_fields(attrs, user, vault)
+
+      assert out.content == nil
+      assert out.title == nil
+      assert out.tags == nil
+      assert is_binary(out.content_ciphertext)
+      assert byte_size(out.content_nonce) == 12
+      assert is_binary(out.tags_ciphertext)
+    end
+  end
+
+  describe "maybe_decrypt_note_fields/2" do
+    test "passes through unencrypted note", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      note = %Engram.Notes.Note{content: "plain", title: "t", tags: ["a"]}
+      {:ok, out} = Crypto.maybe_decrypt_note_fields(note, user)
+      assert out.content == "plain"
+    end
+
+    test "decrypts when ciphertext columns are present", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      vault = %Engram.Vaults.Vault{encrypted: true}
+
+      {:ok, encrypted} =
+        Crypto.maybe_encrypt_note_fields(
+          %{content: "secret", title: "T", tags: ["x"]},
+          user,
+          vault
+        )
+
+      note = %Engram.Notes.Note{
+        content: nil,
+        title: nil,
+        tags: nil,
+        content_ciphertext: encrypted.content_ciphertext,
+        content_nonce: encrypted.content_nonce,
+        title_ciphertext: encrypted.title_ciphertext,
+        title_nonce: encrypted.title_nonce,
+        tags_ciphertext: encrypted.tags_ciphertext,
+        tags_nonce: encrypted.tags_nonce
+      }
+
+      {:ok, out} = Crypto.maybe_decrypt_note_fields(note, user)
+      assert out.content == "secret"
+      assert out.title == "T"
+      assert out.tags == ["x"]
+    end
+  end
 end

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -1,0 +1,37 @@
+defmodule Engram.CryptoTest do
+  use Engram.DataCase, async: false
+  alias Engram.Crypto
+  alias Engram.Crypto.DekCache
+
+  setup do
+    DekCache.invalidate_all()
+    user = insert(:user)
+    {:ok, user: user}
+  end
+
+  test "ensure_user_dek provisions a DEK once", %{user: user} do
+    {:ok, user1} = Crypto.ensure_user_dek(user)
+    assert is_binary(user1.encrypted_dek)
+    assert user1.dek_version == 1
+    assert user1.key_provider == "local"
+
+    # Idempotent: calling again returns the same wrapped DEK
+    {:ok, user2} = Crypto.ensure_user_dek(user1)
+    assert user2.encrypted_dek == user1.encrypted_dek
+  end
+
+  test "get_dek caches after first unwrap", %{user: user} do
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    # ensure_user_dek pre-populates the cache; clear it to exercise the unwrap path.
+    DekCache.invalidate(user.id)
+    assert :miss = DekCache.get(user.id)
+
+    {:ok, dek} = Crypto.get_dek(user)
+    assert byte_size(dek) == 32
+    assert {:ok, ^dek} = DekCache.get(user.id)
+  end
+
+  test "get_dek returns error if no DEK provisioned", %{user: user} do
+    assert {:error, :no_dek} = Crypto.get_dek(user)
+  end
+end

--- a/test/engram/notes/encryption_test.exs
+++ b/test/engram/notes/encryption_test.exs
@@ -85,6 +85,88 @@ defmodule Engram.Notes.EncryptionTest do
       assert renamed.content == "# Before\n\nsome content here"
     end
 
+    test "rename on encrypted vault derives title from decrypted heading" do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      original_content = "# The Real Title\n\nbody text here"
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "before/note.md",
+          "content" => original_content,
+          "mtime" => 1_000.0,
+          "version" => 1
+        })
+
+      {:ok, renamed} = Notes.rename_note(user, vault, "before/note.md", "after/note.md")
+
+      # Title must be derived from the decrypted heading, not the new path filename.
+      # If decrypt failed and fell back to the encrypted struct, extract_title would
+      # see ciphertext bytes and produce a garbage or path-derived title — this
+      # assertion catches that regression.
+      assert renamed.title == "The Real Title"
+    end
+
+    test "decrypt error logs without crashing" do
+      import ExUnit.CaptureLog
+
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "broken/note.md",
+          "content" => "will be unreadable",
+          "mtime" => 1_000.0,
+          "version" => 1
+        })
+
+      # Corrupt the ciphertext in the DB so Envelope.decrypt returns an error
+      {:ok, raw} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          Engram.Repo.get_by!(Engram.Notes.Note, path: "broken/note.md", user_id: user.id)
+        end)
+
+      <<first, rest::binary>> = raw.content_ciphertext
+      tampered_ct = <<Bitwise.bxor(first, 1), rest::binary>>
+
+      {:ok, _} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          raw
+          |> Ecto.Changeset.change(content_ciphertext: tampered_ct)
+          |> Engram.Repo.update()
+        end)
+
+      # Clear DEK cache to force a fresh unwrap (removes a confounding variable)
+      Engram.Crypto.DekCache.invalidate(user.id)
+
+      log =
+        capture_log(fn ->
+          result = Notes.get_note(user, vault, "broken/note.md")
+
+          case result do
+            {:ok, n} ->
+              # Decrypt failed: returned struct should NOT contain the original plaintext
+              refute n.content == "will be unreadable"
+
+            {:error, _} ->
+              # Also acceptable: error is surfaced instead of silently returning corrupt data
+              :ok
+          end
+        end)
+
+      # The error was logged with user_id and note_id for operator triage
+      assert log =~ "decrypt_failed"
+      assert log =~ "user_id=#{user.id}"
+      assert log =~ "note_id=#{note.id}"
+
+      # Critical: log must NOT contain the plaintext or any DEK material
+      refute log =~ "will be unreadable"
+    end
+
     test "unencrypted vault stores plaintext unchanged, ciphertext is nil" do
       user = insert(:user)
       vault = insert(:vault, user: user, encrypted: false)

--- a/test/engram/notes/encryption_test.exs
+++ b/test/engram/notes/encryption_test.exs
@@ -1,0 +1,71 @@
+defmodule Engram.Notes.EncryptionTest do
+  use Engram.DataCase, async: false
+
+  alias Engram.Crypto.DekCache
+  alias Engram.Notes
+
+  # DekCache is a global GenServer; must be synchronous and flushed between tests.
+  setup do
+    DekCache.invalidate_all()
+    :ok
+  end
+
+  describe "encrypted vault round-trip" do
+    test "upsert then read returns plaintext, DB columns hold ciphertext" do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      {:ok, _note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "journal/today.md",
+          "content" => "dear diary, I feel seen",
+          "mtime" => 1_000.0
+        })
+
+      # Public read path decrypts and returns plaintext
+      {:ok, note} = Notes.get_note(user, vault, "journal/today.md")
+      assert note.content == "dear diary, I feel seen"
+
+      # Raw DB: plaintext content is replaced by empty string (default_content guard),
+      # title is nil, ciphertext columns are populated, nonce is 12 bytes,
+      # and the ciphertext bytes do NOT equal the plaintext string.
+      {:ok, raw} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          Engram.Repo.get_by!(Engram.Notes.Note, path: "journal/today.md", user_id: user.id)
+        end)
+
+      # content is cleared (coerced to "" by the changeset default_content guard)
+      assert raw.content == ""
+      # title is nil (no default coercion)
+      assert raw.title == nil
+      # ciphertext columns are populated
+      assert is_binary(raw.content_ciphertext)
+      assert byte_size(raw.content_ciphertext) > 0
+      # nonce is exactly 12 bytes (AES-256-GCM standard)
+      assert byte_size(raw.content_nonce) == 12
+      # ciphertext does not equal the original plaintext bytes
+      refute raw.content_ciphertext == "dear diary, I feel seen"
+    end
+
+    test "unencrypted vault stores plaintext unchanged, ciphertext is nil" do
+      user = insert(:user)
+      vault = insert(:vault, user: user, encrypted: false)
+
+      {:ok, _note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "recipes/chicken.md",
+          "content" => "400F for 25min",
+          "mtime" => 1_000.0
+        })
+
+      {:ok, raw} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          Engram.Repo.get_by!(Engram.Notes.Note, path: "recipes/chicken.md", user_id: user.id)
+        end)
+
+      assert raw.content == "400F for 25min"
+      assert raw.content_ciphertext == nil
+    end
+  end
+end

--- a/test/engram/notes/encryption_test.exs
+++ b/test/engram/notes/encryption_test.exs
@@ -48,6 +48,43 @@ defmodule Engram.Notes.EncryptionTest do
       refute raw.content_ciphertext == "dear diary, I feel seen"
     end
 
+    test "upsert returns plaintext struct (not encrypted)" do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      {:ok, note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "return/test.md",
+          "content" => "plain text returned",
+          "mtime" => 1_000.0,
+          "version" => 1
+        })
+
+      # The returned struct must contain plaintext, not ciphertext
+      assert note.content == "plain text returned"
+      refute note.title == nil
+    end
+
+    test "rename_note returns plaintext struct for encrypted vault" do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      {:ok, _} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "rename/before.md",
+          "content" => "# Before\n\nsome content here",
+          "mtime" => 1_000.0
+        })
+
+      {:ok, renamed} = Engram.Notes.rename_note(user, vault, "rename/before.md", "rename/after.md")
+
+      # Returned struct must be plaintext
+      assert renamed.path == "rename/after.md"
+      assert renamed.content == "# Before\n\nsome content here"
+    end
+
     test "unencrypted vault stores plaintext unchanged, ciphertext is nil" do
       user = insert(:user)
       vault = insert(:vault, user: user, encrypted: false)

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -4,6 +4,8 @@ defmodule Engram.Workers.EmbedNoteTest do
 
   import Mox
 
+  alias Engram.Crypto
+  alias Engram.Crypto.DekCache
   alias Engram.Notes
   alias Engram.Notes.Note
   alias Engram.Workers.EmbedNote
@@ -101,6 +103,39 @@ defmodule Engram.Workers.EmbedNoteTest do
     test "discards job when note is soft-deleted", %{user: user} do
       note = insert(:note, user: user, deleted_at: DateTime.utc_now())
       assert {:discard, _} = perform_job(EmbedNote, %{note_id: note.id})
+    end
+
+    test "decrypts content before indexing for encrypted vault", %{bypass: bypass} do
+      DekCache.invalidate_all()
+
+      user = insert(:user)
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      # upsert_note encrypts content on the way in
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "secure/secret.md",
+          "content" => "# Secret\n\nClassified content.",
+          "mtime" => 1_000.0
+        })
+
+      # Embedder should receive non-empty texts (plaintext chunks, not "")
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        # texts come from Markdown.parse on the decrypted content — must be non-empty
+        assert texts != []
+        assert Enum.all?(texts, fn t -> is_binary(t) and t != "" end)
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+      end)
+
+      stub_qdrant(bypass)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      # embed_hash should be stamped, confirming the job ran to completion
+      updated = Repo.get!(Note, note.id, skip_tenant_check: true)
+      assert updated.embed_hash == updated.content_hash
     end
   end
 


### PR DESCRIPTION
## Summary

Ships end-to-end encryption-at-rest for notes using the **Local** KeyProvider (env-var master key), with the pluggable-provider abstraction in place so AWS KMS and Passphrase providers (phases 7 + 8) slot in via follow-up PRs.

- Per-user DEKs wrapped via `KeyProvider` behaviour; `Local` impl uses AES-256-GCM with `ENCRYPTION_MASTER_KEY` and supports one-key-back rotation fallback via `ENCRYPTION_MASTER_KEY_PREVIOUS`.
- DEKs cached in ETS (`Engram.Crypto.DekCache`) with TTL sweep; lazy provisioning per user.
- Boot-time `Engram.Crypto.Config.validate!/0` crashes loudly on misconfiguration.
- Note `content` / `title` / `tags` encrypted when `vault.encrypted = true`; **parallel ciphertext + nonce columns** (plan diverged from original spec, which proposed modifying `content` to `:binary` — parallel columns avoid destructive ALTER and enable dual-format reads).
- `Notes.upsert_note` and all read paths (`get_note`, `rename_note`, `list_changes`, `list_notes_in_folder`) wired.
- 752 tests pass, 0 compile warnings.

Spec: `docs/superpowers/specs/2026-04-17-pluggable-key-providers-design.md`
Plan: `docs/superpowers/plans/2026-04-18-pluggable-key-providers-phase-1-3.md`

## Architecture

`KeyProvider` behaviour with uniform `ctx` param lets AWS KMS / Local / Passphrase coexist under one contract. `Resolver.provider_for/1` returns the configured module; future BYOK reads `users.key_provider` for per-user dispatch.

## Out of scope (follow-up plans)

- Phase 4: Qdrant payload encryption
- Phase 5: Attachment encryption
- Phase 6: Vault toggle Oban workers (24h delayed decrypt, email confirmation, 7-day cooldown)
- Phase 7: AWS KMS provider
- Phase 8: Passphrase provider (Argon2id + \`/unlock\` endpoint)

## Known wart (follow-up)

\`Note.changeset\` \`default_content\` guard converts \`nil → ""\`, so encrypted notes store \`content=""\` instead of \`content=nil\`. Plaintext never exposed (ciphertext column is authoritative), but fix cleanly in Phase 4 cleanup.

## Test plan

- [x] \`mix test\` passes (752 tests, 0 failures, 7 skipped)
- [x] Boot crashes on missing \`ENCRYPTION_MASTER_KEY\` with actionable message
- [x] Boot crashes on wrong master key length
- [x] Raw DB spot-check: encrypted notes store ciphertext in \`content_ciphertext\`, not plaintext in \`content\`
- [x] Read round-trip: \`upsert_note\` + \`get_note\` returns plaintext
- [x] Unencrypted vaults unchanged (passthrough)
- [x] Rotation fallback: blob wrapped with old key unwraps via \`ENCRYPTION_MASTER_KEY_PREVIOUS\`
- [ ] E2E suite (\`make e2e\`) — run in CI; encryption is transparent to API so should pass unchanged
- [ ] Raw \`psql\` check on a dev DB after a live encrypted write

🤖 Generated with [Claude Code](https://claude.com/claude-code)