### PR TITLE
feat(crypto): Phase 4 — Qdrant payload encryption

### DIFF
--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -115,4 +115,33 @@ defmodule Engram.Crypto do
       {:error, _} = err -> err
     end
   end
+
+  @doc """
+  If `vault.encrypted`, encrypts `text`, `title`, `heading_path` in the
+  payload map using the user's DEK. Adds `text_nonce`, `title_nonce`,
+  `heading_path_nonce` keys; all six crypto fields are base64-encoded
+  binaries. Other keys (user_id, vault_id, source_path, folder, tags,
+  chunk_index) are untouched. Unencrypted vault → passthrough.
+  """
+  @spec maybe_encrypt_qdrant_payload(map(), User.t(), Engram.Vaults.Vault.t()) ::
+          {:ok, map()} | {:error, term()}
+  def maybe_encrypt_qdrant_payload(payload, _user, %Engram.Vaults.Vault{encrypted: false}),
+    do: {:ok, payload}
+
+  def maybe_encrypt_qdrant_payload(payload, %User{} = user, %Engram.Vaults.Vault{encrypted: true}) do
+    with {:ok, dek} <- get_dek(user) do
+      {text_ct, text_nonce} = Envelope.encrypt(Map.get(payload, :text) || "", dek)
+      {title_ct, title_nonce} = Envelope.encrypt(Map.get(payload, :title) || "", dek)
+      {hp_ct, hp_nonce} = Envelope.encrypt(Map.get(payload, :heading_path) || "", dek)
+
+      {:ok,
+       payload
+       |> Map.put(:text, Base.encode64(text_ct))
+       |> Map.put(:text_nonce, Base.encode64(text_nonce))
+       |> Map.put(:title, Base.encode64(title_ct))
+       |> Map.put(:title_nonce, Base.encode64(title_nonce))
+       |> Map.put(:heading_path, Base.encode64(hp_ct))
+       |> Map.put(:heading_path_nonce, Base.encode64(hp_nonce))}
+    end
+  end
 end

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -5,6 +5,8 @@ defmodule Engram.Crypto do
   Lazy DEK provisioning: users get a DEK only when encryption is first needed.
   """
 
+  require Logger
+
   alias Engram.Accounts
   alias Engram.Accounts.User
   alias Engram.Crypto.{DekCache, Envelope, KeyProvider.Resolver}
@@ -67,7 +69,6 @@ defmodule Engram.Crypto do
     do: {:ok, attrs}
 
   def maybe_encrypt_note_fields(attrs, %User{} = user, %Engram.Vaults.Vault{encrypted: true}) do
-    require Logger
     Logger.debug("maybe_encrypt_note_fields auto-provision path for user_id=#{user.id}")
 
     with {:ok, user} <- ensure_user_dek(user),
@@ -145,8 +146,6 @@ defmodule Engram.Crypto do
     end
   end
 
-  require Logger
-
   @doc """
   Decrypts a list of Qdrant search candidates in-place based on each
   candidate's vault's `encrypted` flag (looked up in `vaults_by_id`).
@@ -168,7 +167,7 @@ defmodule Engram.Crypto do
       {:ok, dek_or_nil} ->
         decrypted =
           candidates
-          |> Enum.flat_map(&decrypt_one(&1, user, vaults_by_id, dek_or_nil))
+          |> Enum.flat_map(&decrypt_one(&1, vaults_by_id, dek_or_nil))
 
         if decrypted == [] and candidates != [] do
           {:error, :decrypt_failed}
@@ -208,7 +207,7 @@ defmodule Engram.Crypto do
   end
 
   # Returns [decrypted_candidate] on success, [] on drop.
-  defp decrypt_one(candidate, _user, vaults_by_id, dek) do
+  defp decrypt_one(candidate, vaults_by_id, dek) do
     vault_id_key = to_string(candidate.vault_id)
 
     case Map.get(vaults_by_id, vault_id_key) do

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -144,4 +144,148 @@ defmodule Engram.Crypto do
        |> Map.put(:heading_path_nonce, Base.encode64(hp_nonce))}
     end
   end
+
+  require Logger
+
+  @doc """
+  Decrypts a list of Qdrant search candidates in-place based on each
+  candidate's vault's `encrypted` flag (looked up in `vaults_by_id`).
+
+  - Per-candidate decrypt failure → `Logger.error` + telemetry
+    `[:engram, :search, :decrypt_failed]` + candidate dropped.
+  - Missing vault entry in `vaults_by_id` → telemetry
+    `[:engram, :search, :payload_shape_mismatch]` + candidate dropped.
+  - All candidates dropped → `{:error, :decrypt_failed}`.
+  - Empty input → `{:ok, []}`.
+  """
+  @spec maybe_decrypt_qdrant_candidates([map()], User.t(), %{String.t() => Engram.Vaults.Vault.t()}) ::
+          {:ok, [map()]} | {:error, :decrypt_failed}
+  def maybe_decrypt_qdrant_candidates([], _user, _vaults_by_id), do: {:ok, []}
+
+  def maybe_decrypt_qdrant_candidates(candidates, %User{} = user, vaults_by_id)
+      when is_list(candidates) and is_map(vaults_by_id) do
+    case get_dek_if_any_encrypted(user, candidates, vaults_by_id) do
+      {:ok, dek_or_nil} ->
+        decrypted =
+          candidates
+          |> Enum.flat_map(&decrypt_one(&1, user, vaults_by_id, dek_or_nil))
+
+        if decrypted == [] and candidates != [] do
+          {:error, :decrypt_failed}
+        else
+          {:ok, decrypted}
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  # Lazy DEK load — only fetch if at least one candidate is in an encrypted vault.
+  defp get_dek_if_any_encrypted(user, candidates, vaults_by_id) do
+    if Enum.any?(candidates, fn c -> encrypted_vault?(c, vaults_by_id) end) do
+      case get_dek(user) do
+        {:ok, dek} ->
+          {:ok, dek}
+
+        {:error, reason} ->
+          Logger.error(
+            "qdrant decrypt: failed to load DEK for user_id=#{user.id} reason=#{inspect(reason)}"
+          )
+
+          {:error, :decrypt_failed}
+      end
+    else
+      {:ok, nil}
+    end
+  end
+
+  defp encrypted_vault?(candidate, vaults_by_id) do
+    case Map.get(vaults_by_id, to_string(candidate.vault_id)) do
+      %Engram.Vaults.Vault{encrypted: true} -> true
+      _ -> false
+    end
+  end
+
+  # Returns [decrypted_candidate] on success, [] on drop.
+  defp decrypt_one(candidate, _user, vaults_by_id, dek) do
+    vault_id_key = to_string(candidate.vault_id)
+
+    case Map.get(vaults_by_id, vault_id_key) do
+      nil ->
+        :telemetry.execute(
+          [:engram, :search, :payload_shape_mismatch],
+          %{count: 1},
+          %{vault_id: vault_id_key, qdrant_id: candidate.qdrant_id}
+        )
+
+        Logger.error(
+          "qdrant decrypt: vault_id=#{vault_id_key} not in lookup map; qdrant_id=#{candidate.qdrant_id}"
+        )
+
+        []
+
+      %Engram.Vaults.Vault{encrypted: false} ->
+        if Map.has_key?(candidate, :text_nonce) do
+          :telemetry.execute(
+            [:engram, :search, :payload_shape_mismatch],
+            %{count: 1},
+            %{vault_id: vault_id_key, qdrant_id: candidate.qdrant_id}
+          )
+
+          Logger.error(
+            "qdrant decrypt: vault_id=#{vault_id_key} marked unencrypted but payload has text_nonce; qdrant_id=#{candidate.qdrant_id}"
+          )
+
+          []
+        else
+          [candidate]
+        end
+
+      %Engram.Vaults.Vault{encrypted: true} ->
+        do_decrypt_candidate(candidate, dek)
+    end
+  end
+
+  defp do_decrypt_candidate(candidate, dek) do
+    with {:ok, text_ct} <- safe_decode64(candidate.text),
+         {:ok, text_nonce} <- safe_decode64(candidate.text_nonce),
+         {:ok, title_ct} <- safe_decode64(candidate.title),
+         {:ok, title_nonce} <- safe_decode64(candidate.title_nonce),
+         {:ok, hp_ct} <- safe_decode64(candidate.heading_path),
+         {:ok, hp_nonce} <- safe_decode64(candidate.heading_path_nonce),
+         {:ok, text} <- Envelope.decrypt(text_ct, text_nonce, dek),
+         {:ok, title} <- Envelope.decrypt(title_ct, title_nonce, dek),
+         {:ok, heading_path} <- Envelope.decrypt(hp_ct, hp_nonce, dek) do
+      decrypted =
+        candidate
+        |> Map.put(:text, text)
+        |> Map.put(:title, title)
+        |> Map.put(:heading_path, heading_path)
+        |> Map.drop([:text_nonce, :title_nonce, :heading_path_nonce])
+
+      [decrypted]
+    else
+      reason ->
+        :telemetry.execute(
+          [:engram, :search, :decrypt_failed],
+          %{count: 1},
+          %{
+            qdrant_id: candidate.qdrant_id,
+            vault_id: to_string(candidate.vault_id),
+            reason: inspect(reason)
+          }
+        )
+
+        Logger.error(
+          "qdrant decrypt: failed for qdrant_id=#{candidate.qdrant_id} vault_id=#{candidate.vault_id} reason=#{inspect(reason)}"
+        )
+
+        []
+    end
+  end
+
+  defp safe_decode64(nil), do: :error
+  defp safe_decode64(s) when is_binary(s), do: Base.decode64(s)
+  defp safe_decode64(_), do: :error
 end

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -200,42 +200,67 @@ defmodule Engram.Crypto do
   end
 
   defp encrypted_vault?(candidate, vaults_by_id) do
-    case Map.get(vaults_by_id, to_string(candidate.vault_id)) do
-      %Engram.Vaults.Vault{encrypted: true} -> true
-      _ -> false
+    case candidate_vault_id(candidate) do
+      nil ->
+        false
+
+      id ->
+        case Map.get(vaults_by_id, id) do
+          %Engram.Vaults.Vault{encrypted: true} -> true
+          _ -> false
+        end
+    end
+  end
+
+  defp candidate_vault_id(candidate) do
+    case Map.get(candidate, :vault_id) do
+      nil -> nil
+      v -> to_string(v)
     end
   end
 
   # Returns [decrypted_candidate] on success, [] on drop.
   defp decrypt_one(candidate, vaults_by_id, dek) do
-    vault_id_key = to_string(candidate.vault_id)
+    vault_id_key = candidate_vault_id(candidate)
 
+    cond do
+      # No vault_id and no ciphertext — legacy / plaintext candidate, pass through.
+      is_nil(vault_id_key) and not Map.has_key?(candidate, :text_nonce) ->
+        [candidate]
+
+      # No vault_id but ciphertext present — shape mismatch, drop.
+      is_nil(vault_id_key) ->
+        emit_shape_mismatch(nil, candidate, "missing vault_id with text_nonce present")
+        []
+
+      true ->
+        lookup_and_decrypt(candidate, vault_id_key, vaults_by_id, dek)
+    end
+  end
+
+  defp emit_shape_mismatch(vault_id_key, candidate, reason) do
+    qdrant_id = Map.get(candidate, :qdrant_id)
+
+    :telemetry.execute(
+      [:engram, :search, :payload_shape_mismatch],
+      %{count: 1},
+      %{vault_id: vault_id_key, qdrant_id: qdrant_id}
+    )
+
+    Logger.error(
+      "qdrant decrypt shape mismatch: vault_id=#{inspect(vault_id_key)} qdrant_id=#{inspect(qdrant_id)} reason=#{reason}"
+    )
+  end
+
+  defp lookup_and_decrypt(candidate, vault_id_key, vaults_by_id, dek) do
     case Map.get(vaults_by_id, vault_id_key) do
       nil ->
-        :telemetry.execute(
-          [:engram, :search, :payload_shape_mismatch],
-          %{count: 1},
-          %{vault_id: vault_id_key, qdrant_id: candidate.qdrant_id}
-        )
-
-        Logger.error(
-          "qdrant decrypt: vault_id=#{vault_id_key} not in lookup map; qdrant_id=#{candidate.qdrant_id}"
-        )
-
+        emit_shape_mismatch(vault_id_key, candidate, "vault not in lookup map")
         []
 
       %Engram.Vaults.Vault{encrypted: false} ->
         if Map.has_key?(candidate, :text_nonce) do
-          :telemetry.execute(
-            [:engram, :search, :payload_shape_mismatch],
-            %{count: 1},
-            %{vault_id: vault_id_key, qdrant_id: candidate.qdrant_id}
-          )
-
-          Logger.error(
-            "qdrant decrypt: vault_id=#{vault_id_key} marked unencrypted but payload has text_nonce; qdrant_id=#{candidate.qdrant_id}"
-          )
-
+          emit_shape_mismatch(vault_id_key, candidate, "vault marked unencrypted but payload has text_nonce")
           []
         else
           [candidate]
@@ -247,12 +272,12 @@ defmodule Engram.Crypto do
   end
 
   defp do_decrypt_candidate(candidate, dek) do
-    with {:ok, text_ct} <- safe_decode64(candidate.text),
-         {:ok, text_nonce} <- safe_decode64(candidate.text_nonce),
-         {:ok, title_ct} <- safe_decode64(candidate.title),
-         {:ok, title_nonce} <- safe_decode64(candidate.title_nonce),
-         {:ok, hp_ct} <- safe_decode64(candidate.heading_path),
-         {:ok, hp_nonce} <- safe_decode64(candidate.heading_path_nonce),
+    with {:ok, text_ct} <- safe_decode64(Map.get(candidate, :text)),
+         {:ok, text_nonce} <- safe_decode64(Map.get(candidate, :text_nonce)),
+         {:ok, title_ct} <- safe_decode64(Map.get(candidate, :title)),
+         {:ok, title_nonce} <- safe_decode64(Map.get(candidate, :title_nonce)),
+         {:ok, hp_ct} <- safe_decode64(Map.get(candidate, :heading_path)),
+         {:ok, hp_nonce} <- safe_decode64(Map.get(candidate, :heading_path_nonce)),
          {:ok, text} <- Envelope.decrypt(text_ct, text_nonce, dek),
          {:ok, title} <- Envelope.decrypt(title_ct, title_nonce, dek),
          {:ok, heading_path} <- Envelope.decrypt(hp_ct, hp_nonce, dek) do
@@ -266,18 +291,21 @@ defmodule Engram.Crypto do
       [decrypted]
     else
       reason ->
+        qdrant_id = Map.get(candidate, :qdrant_id)
+        vault_id = Map.get(candidate, :vault_id)
+
         :telemetry.execute(
           [:engram, :search, :decrypt_failed],
           %{count: 1},
           %{
-            qdrant_id: candidate.qdrant_id,
-            vault_id: to_string(candidate.vault_id),
+            qdrant_id: qdrant_id,
+            vault_id: to_string(vault_id),
             reason: inspect(reason)
           }
         )
 
         Logger.error(
-          "qdrant decrypt: failed for qdrant_id=#{candidate.qdrant_id} vault_id=#{candidate.vault_id} reason=#{inspect(reason)}"
+          "qdrant decrypt: failed for qdrant_id=#{inspect(qdrant_id)} vault_id=#{inspect(vault_id)} reason=#{inspect(reason)}"
         )
 
         []

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -123,6 +123,14 @@ defmodule Engram.Crypto do
   `heading_path_nonce` keys; all six crypto fields are base64-encoded
   binaries. Other keys (user_id, vault_id, source_path, folder, tags,
   chunk_index) are untouched. Unencrypted vault → passthrough.
+
+  Unlike `maybe_encrypt_note_fields/3`, this function does NOT call
+  `ensure_user_dek/1`. Reason: Qdrant indexing only runs after a note has
+  been written through `Notes.upsert_note/3`, which provisions the DEK on
+  the first encrypted write. A missing DEK here signals a config bug
+  (e.g., a vault manually flipped to `encrypted: true` without using the
+  Phase 6 `EncryptVault` toggle worker) — fail-loud via Oban retry +
+  telemetry is preferable to silently lazy-provisioning.
   """
   @spec maybe_encrypt_qdrant_payload(map(), User.t(), Engram.Vaults.Vault.t()) ::
           {:ok, map()} | {:error, term()}

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -21,8 +21,11 @@ defmodule Engram.Indexing do
   @doc """
   Full pipeline for a note: parse → embed → delete old chunks → upsert new chunks.
   Returns {:ok, chunk_count} or {:error, reason}.
+
+  Takes the note's vault so Qdrant payloads can be encrypted when
+  `vault.encrypted = true`.
   """
-  def index_note(note) do
+  def index_note(note, %Engram.Vaults.Vault{} = vault) do
     chunks = Markdown.parse(note.content || "", note.path)
 
     if chunks == [] do
@@ -33,7 +36,7 @@ defmodule Engram.Indexing do
 
       with :ok <- Qdrant.ensure_collection(collection(), dims),
            {:ok, vectors} <- embed_for_indexing(context_texts),
-           :ok <- replace_chunks(note, chunks, vectors) do
+           :ok <- replace_chunks(note, vault, chunks, vectors) do
         {:ok, length(chunks)}
       end
     end
@@ -69,7 +72,7 @@ defmodule Engram.Indexing do
     end
   end
 
-  defp replace_chunks(note, chunks, vectors) do
+  defp replace_chunks(note, vault, chunks, vectors) do
     # Delete from Qdrant first (external, idempotent) — if this fails, Postgres is untouched
     with :ok <- Qdrant.delete_by_note(collection(), to_string(note.user_id), to_string(note.vault_id), note.path) do
       # skip_tenant_check: trusted internal pipeline, already scoped by note_id/user_id
@@ -102,27 +105,48 @@ defmodule Engram.Indexing do
           skip_tenant_check: true
         )
 
-      qdrant_points =
-        Enum.zip(inserted, Enum.zip(chunks, vectors))
-        |> Enum.map(fn {row, {chunk, vector}} ->
-          %{
-            id: row.qdrant_point_id,
-            vector: vector,
-            payload: %{
-              user_id: to_string(note.user_id),
-              vault_id: to_string(note.vault_id),
-              source_path: note.path,
-              title: note.title,
-              folder: note.folder || "",
-              tags: note.tags || [],
-              heading_path: chunk.heading_path,
-              text: chunk.text,
-              chunk_index: row.position
-            }
+      user = Engram.Accounts.get_user!(note.user_id)
+
+      result =
+        inserted
+        |> Enum.zip(Enum.zip(chunks, vectors))
+        |> Enum.reduce_while({:ok, []}, fn {row, {chunk, vector}}, {:ok, acc} ->
+          base_payload = %{
+            user_id: to_string(note.user_id),
+            vault_id: to_string(note.vault_id),
+            source_path: note.path,
+            title: note.title,
+            folder: note.folder || "",
+            tags: note.tags || [],
+            heading_path: chunk.heading_path,
+            text: chunk.text,
+            chunk_index: row.position
           }
+
+          case Engram.Crypto.maybe_encrypt_qdrant_payload(base_payload, user, vault) do
+            {:ok, payload} ->
+              {:cont, {:ok, [%{id: row.qdrant_point_id, vector: vector, payload: payload} | acc]}}
+
+            {:error, reason} = err ->
+              :telemetry.execute(
+                [:engram, :indexing, :encrypt_failed],
+                %{count: 1},
+                %{
+                  user_id: note.user_id,
+                  vault_id: note.vault_id,
+                  note_id: note.id,
+                  reason: inspect(reason)
+                }
+              )
+
+              {:halt, err}
+          end
         end)
 
-      Qdrant.upsert_points(collection(), qdrant_points)
+      case result do
+        {:ok, qdrant_points} -> Qdrant.upsert_points(collection(), Enum.reverse(qdrant_points))
+        {:error, _} = err -> err
+      end
     end
   end
 end

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -73,80 +73,69 @@ defmodule Engram.Indexing do
   end
 
   defp replace_chunks(note, vault, chunks, vectors) do
-    # Delete from Qdrant first (external, idempotent) — if this fails, Postgres is untouched
-    with :ok <- Qdrant.delete_by_note(collection(), to_string(note.user_id), to_string(note.vault_id), note.path) do
+    # Encrypt-first: build payloads + encrypt in memory BEFORE any mutation.
+    # If any chunk's encryption fails, no Postgres row or Qdrant point is touched
+    # and prior state survives for the next Oban retry.
+    user = Engram.Accounts.get_user!(note.user_id)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    prepared =
+      Enum.zip(chunks, vectors)
+      |> Enum.reduce_while({:ok, []}, fn {chunk, vector}, {:ok, acc} ->
+        point_id = Ecto.UUID.generate()
+
+        base_payload = %{
+          user_id: to_string(note.user_id),
+          vault_id: to_string(note.vault_id),
+          source_path: note.path,
+          title: note.title,
+          folder: note.folder || "",
+          tags: note.tags || [],
+          heading_path: chunk.heading_path,
+          text: chunk.text,
+          chunk_index: chunk.position
+        }
+
+        case Engram.Crypto.maybe_encrypt_qdrant_payload(base_payload, user, vault) do
+          {:ok, payload} ->
+            row = %{
+              note_id: note.id,
+              user_id: note.user_id,
+              vault_id: note.vault_id,
+              position: chunk.position,
+              heading_path: chunk.heading_path,
+              char_start: chunk.char_start,
+              char_end: chunk.char_end,
+              qdrant_point_id: point_id,
+              created_at: now
+            }
+
+            point = %{id: point_id, vector: vector, payload: payload}
+            {:cont, {:ok, [{row, point} | acc]}}
+
+          {:error, reason} = err ->
+            :telemetry.execute(
+              [:engram, :indexing, :encrypt_failed],
+              %{count: 1},
+              %{
+                user_id: note.user_id,
+                vault_id: note.vault_id,
+                note_id: note.id,
+                reason: inspect(reason)
+              }
+            )
+
+            {:halt, err}
+        end
+      end)
+
+    with {:ok, prepared_pairs} <- prepared,
+         {chunk_rows, qdrant_points} = prepared_pairs |> Enum.reverse() |> Enum.unzip(),
+         :ok <- Qdrant.delete_by_note(collection(), to_string(note.user_id), to_string(note.vault_id), note.path) do
       # skip_tenant_check: trusted internal pipeline, already scoped by note_id/user_id
       Repo.delete_all(from(c in Chunk, where: c.note_id == ^note.id), skip_tenant_check: true)
-
-      # Build new chunk rows + Qdrant points
-      now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-      chunk_rows =
-        Enum.zip(chunks, vectors)
-        |> Enum.map(fn {chunk, _vector} ->
-          point_id = Ecto.UUID.generate()
-
-          %{
-            note_id: note.id,
-            user_id: note.user_id,
-            vault_id: note.vault_id,
-            position: chunk.position,
-            heading_path: chunk.heading_path,
-            char_start: chunk.char_start,
-            char_end: chunk.char_end,
-            qdrant_point_id: point_id,
-            created_at: now
-          }
-        end)
-
-      {_, inserted} =
-        Repo.insert_all(Chunk, chunk_rows,
-          returning: [:id, :qdrant_point_id, :position],
-          skip_tenant_check: true
-        )
-
-      user = Engram.Accounts.get_user!(note.user_id)
-
-      result =
-        inserted
-        |> Enum.zip(Enum.zip(chunks, vectors))
-        |> Enum.reduce_while({:ok, []}, fn {row, {chunk, vector}}, {:ok, acc} ->
-          base_payload = %{
-            user_id: to_string(note.user_id),
-            vault_id: to_string(note.vault_id),
-            source_path: note.path,
-            title: note.title,
-            folder: note.folder || "",
-            tags: note.tags || [],
-            heading_path: chunk.heading_path,
-            text: chunk.text,
-            chunk_index: row.position
-          }
-
-          case Engram.Crypto.maybe_encrypt_qdrant_payload(base_payload, user, vault) do
-            {:ok, payload} ->
-              {:cont, {:ok, [%{id: row.qdrant_point_id, vector: vector, payload: payload} | acc]}}
-
-            {:error, reason} = err ->
-              :telemetry.execute(
-                [:engram, :indexing, :encrypt_failed],
-                %{count: 1},
-                %{
-                  user_id: note.user_id,
-                  vault_id: note.vault_id,
-                  note_id: note.id,
-                  reason: inspect(reason)
-                }
-              )
-
-              {:halt, err}
-          end
-        end)
-
-      case result do
-        {:ok, qdrant_points} -> Qdrant.upsert_points(collection(), Enum.reverse(qdrant_points))
-        {:error, _} = err -> err
-      end
+      Repo.insert_all(Chunk, chunk_rows, skip_tenant_check: true)
+      Qdrant.upsert_points(collection(), qdrant_points)
     end
   end
 end

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -70,9 +70,27 @@ defmodule Engram.Search do
         |> then(&if(tags, do: Keyword.put(&1, :tags, tags), else: &1))
         |> then(&if(folder, do: Keyword.put(&1, :folder, folder), else: &1))
 
-      with {:ok, candidates} <- Qdrant.search(collection(), vector, search_opts) do
-        reranker().rerank(query, candidates, limit)
+      with {:ok, candidates} <- Qdrant.search(collection(), vector, search_opts),
+           vaults_by_id = load_candidate_vaults(user, vault, candidates),
+           {:ok, decrypted} <-
+             Engram.Crypto.maybe_decrypt_qdrant_candidates(candidates, user, vaults_by_id) do
+        reranker().rerank(query, decrypted, limit)
       end
     end
+  end
+
+  # Single-vault search: return the passed-in vault directly — no extra DB query.
+  # Cross-vault search (vault=nil): batch-load only the vaults referenced by candidates.
+  defp load_candidate_vaults(_user, %Engram.Vaults.Vault{id: id} = v, _candidates),
+    do: %{to_string(id) => v}
+
+  defp load_candidate_vaults(user, nil, candidates) do
+    vault_ids =
+      candidates
+      |> Enum.map(&Map.get(&1, :vault_id))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    Engram.Vaults.list_for_ids(user, vault_ids)
   end
 end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -122,9 +122,10 @@ defmodule Engram.Vaults do
   Non-integer entries are silently filtered (they cannot match an integer PK).
   Returns a map keyed by stringified vault id: `%{"5" => %Vault{}}`.
 
-  Enforces tenant scoping explicitly via a `user_id == ^user_id` clause
-  (belt-and-suspenders alongside RLS). Excludes soft-deleted vaults, matching
-  `list_vaults/1` and `get_vault/2` conventions.
+  Tenant scoping is enforced via an explicit `user_id == ^user_id` clause.
+  RLS is bypassed (`skip_tenant_check: true`) for performance — the explicit
+  clause is the sole guarantee, so it MUST NOT be removed. Excludes
+  soft-deleted vaults, matching `list_vaults/1` and `get_vault/2` conventions.
   """
   @spec list_for_ids(Engram.Accounts.User.t(), [String.t()]) :: %{String.t() => Vault.t()}
   def list_for_ids(%Engram.Accounts.User{id: user_id}, vault_ids) when is_list(vault_ids) do

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -115,6 +115,38 @@ defmodule Engram.Vaults do
     vaults
   end
 
+  @doc """
+  Loads vaults owned by `user` whose IDs appear in `vault_ids`.
+
+  `vault_ids` is a list of strings (as they arrive from Qdrant payload JSON).
+  Non-integer entries are silently filtered (they cannot match an integer PK).
+  Returns a map keyed by stringified vault id: `%{"5" => %Vault{}}`.
+
+  Enforces tenant scoping explicitly via a `user_id == ^user_id` clause
+  (belt-and-suspenders alongside RLS).
+  """
+  @spec list_for_ids(Engram.Accounts.User.t(), [String.t()]) :: %{String.t() => Vault.t()}
+  def list_for_ids(%Engram.Accounts.User{id: user_id}, vault_ids) when is_list(vault_ids) do
+    ids =
+      vault_ids
+      |> Enum.uniq()
+      |> Enum.flat_map(fn s ->
+        case Integer.parse(to_string(s)) do
+          {n, ""} -> [n]
+          _ -> []
+        end
+      end)
+
+    if ids == [] do
+      %{}
+    else
+      Vault
+      |> where([v], v.user_id == ^user_id and v.id in ^ids)
+      |> Repo.all(skip_tenant_check: true)
+      |> Map.new(fn v -> {to_string(v.id), v} end)
+    end
+  end
+
   # ── Get ─────────────────────────────────────────────────────────────────────
 
   @doc """

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -123,7 +123,8 @@ defmodule Engram.Vaults do
   Returns a map keyed by stringified vault id: `%{"5" => %Vault{}}`.
 
   Enforces tenant scoping explicitly via a `user_id == ^user_id` clause
-  (belt-and-suspenders alongside RLS).
+  (belt-and-suspenders alongside RLS). Excludes soft-deleted vaults, matching
+  `list_vaults/1` and `get_vault/2` conventions.
   """
   @spec list_for_ids(Engram.Accounts.User.t(), [String.t()]) :: %{String.t() => Vault.t()}
   def list_for_ids(%Engram.Accounts.User{id: user_id}, vault_ids) when is_list(vault_ids) do
@@ -141,7 +142,7 @@ defmodule Engram.Vaults do
       %{}
     else
       Vault
-      |> where([v], v.user_id == ^user_id and v.id in ^ids)
+      |> where([v], v.user_id == ^user_id and v.id in ^ids and is_nil(v.deleted_at))
       |> Repo.all(skip_tenant_check: true)
       |> Map.new(fn v -> {to_string(v.id), v} end)
     end

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -199,15 +199,24 @@ defmodule Engram.Vector.Qdrant do
 
         results =
           Enum.map(points, fn p ->
+            payload = p["payload"] || %{}
+
             %{
               score: p["score"],
-              text: get_in(p, ["payload", "text"]),
-              title: get_in(p, ["payload", "title"]),
-              heading_path: get_in(p, ["payload", "heading_path"]),
-              source_path: get_in(p, ["payload", "source_path"]),
-              tags: get_in(p, ["payload", "tags"]) || [],
-              qdrant_id: p["id"]
+              text: Map.get(payload, "text"),
+              title: Map.get(payload, "title"),
+              heading_path: Map.get(payload, "heading_path"),
+              source_path: Map.get(payload, "source_path"),
+              tags: Map.get(payload, "tags") || [],
+              vault_id: Map.get(payload, "vault_id"),
+              qdrant_id: p["id"],
+              # Nonce keys are only present on encrypted-vault chunks; nil otherwise.
+              text_nonce: Map.get(payload, "text_nonce"),
+              title_nonce: Map.get(payload, "title_nonce"),
+              heading_path_nonce: Map.get(payload, "heading_path_nonce")
             }
+            |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+            |> Map.new()
           end)
 
         {:ok, results}

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -53,27 +53,34 @@ defmodule Engram.Workers.EmbedNote do
       note ->
         user = Accounts.get_user!(note.user_id)
 
-        case Crypto.maybe_decrypt_note_fields(note, user) do
-          {:ok, decrypted_note} ->
-            # If renamed, clean up old path's Qdrant points before re-indexing
-            if old_path do
-              Indexing.delete_points_by_path(decrypted_note, old_path)
-            end
+        # Load vault up front so we can drive both the decrypt path (future) and
+        # the index call. skip_tenant_check: trusted internal worker.
+        # Missing vault means the note is orphaned — nothing to index, discard.
+        case Repo.get(Vault, note.vault_id, skip_tenant_check: true) do
+          nil ->
+            {:discard, "vault #{note.vault_id} not found for note #{note.id}"}
 
-            vault = Repo.get(Vault, decrypted_note.vault_id, skip_tenant_check: true)
+          %Vault{} = vault ->
+            case Crypto.maybe_decrypt_note_fields(note, user) do
+              {:ok, decrypted_note} ->
+                # If renamed, clean up old path's Qdrant points before re-indexing
+                if old_path do
+                  Indexing.delete_points_by_path(decrypted_note, old_path)
+                end
 
-            case Indexing.index_note(decrypted_note, vault) do
-              {:ok, _count} ->
-                stamp_embed_hash(note)
-                :ok
+                case Indexing.index_note(decrypted_note, vault) do
+                  {:ok, _count} ->
+                    stamp_embed_hash(note)
+                    :ok
+
+                  {:error, reason} ->
+                    {:error, reason}
+                end
 
               {:error, reason} ->
+                Logger.error("EmbedNote decrypt failed: user_id=#{note.user_id} note_id=#{note.id} reason=#{inspect(reason)}")
                 {:error, reason}
             end
-
-          {:error, reason} ->
-            Logger.error("EmbedNote decrypt failed: user_id=#{note.user_id} note_id=#{note.id} reason=#{inspect(reason)}")
-            {:error, reason}
         end
     end
   end

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -31,6 +31,7 @@ defmodule Engram.Workers.EmbedNote do
   alias Engram.Indexing
   alias Engram.Notes.Note
   alias Engram.Repo
+  alias Engram.Vaults.Vault
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
@@ -59,7 +60,9 @@ defmodule Engram.Workers.EmbedNote do
               Indexing.delete_points_by_path(decrypted_note, old_path)
             end
 
-            case Indexing.index_note(decrypted_note) do
+            vault = Repo.get(Vault, decrypted_note.vault_id, skip_tenant_check: true)
+
+            case Indexing.index_note(decrypted_note, vault) do
               {:ok, _count} ->
                 stamp_embed_hash(note)
                 :ok

--- a/lib/mix/tasks/parity.validate.ex
+++ b/lib/mix/tasks/parity.validate.ex
@@ -250,7 +250,7 @@ defmodule Mix.Tasks.Parity.Validate do
             "mtime" => :os.system_time(:second) / 1
           })
 
-        {:ok, chunk_count} = Engram.Indexing.index_note(note)
+        {:ok, chunk_count} = Engram.Indexing.index_note(note, vault)
 
         if chunk_count == 0 do
           {:fail, "indexing produced 0 chunks"}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.3.1",
+      version: "0.4.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto/qdrant_payload_test.exs
+++ b/test/engram/crypto/qdrant_payload_test.exs
@@ -1,0 +1,90 @@
+defmodule Engram.Crypto.QdrantPayloadTest do
+  use Engram.DataCase, async: false
+  alias Engram.Crypto
+  alias Engram.Crypto.DekCache
+  alias Engram.Vaults.Vault
+
+  setup do
+    DekCache.invalidate_all()
+    user = insert(:user)
+    {:ok, user: user}
+  end
+
+  @base_payload %{
+    user_id: "1",
+    vault_id: "5",
+    source_path: "journal/today.md",
+    folder: "journal",
+    tags: ["personal"],
+    chunk_index: 0,
+    text: "dear diary",
+    title: "today",
+    heading_path: "intro"
+  }
+
+  describe "maybe_encrypt_qdrant_payload/3" do
+    test "passes through when vault is not encrypted", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      vault = %Vault{encrypted: false}
+
+      assert {:ok, out} = Crypto.maybe_encrypt_qdrant_payload(@base_payload, user, vault)
+      assert out == @base_payload
+    end
+
+    test "encrypts text/title/heading_path when vault is encrypted", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      vault = %Vault{encrypted: true}
+
+      assert {:ok, out} = Crypto.maybe_encrypt_qdrant_payload(@base_payload, user, vault)
+
+      # Plaintext fields untouched
+      assert out.user_id == "1"
+      assert out.vault_id == "5"
+      assert out.source_path == "journal/today.md"
+      assert out.folder == "journal"
+      assert out.tags == ["personal"]
+      assert out.chunk_index == 0
+
+      # Encrypted fields are base64 strings, different from plaintext
+      assert is_binary(out.text)
+      assert is_binary(out.title)
+      assert is_binary(out.heading_path)
+      refute out.text == "dear diary"
+      refute out.title == "today"
+      refute out.heading_path == "intro"
+
+      # Nonces present, base64, 12 bytes decoded
+      assert is_binary(out.text_nonce)
+      assert byte_size(Base.decode64!(out.text_nonce)) == 12
+      assert byte_size(Base.decode64!(out.title_nonce)) == 12
+      assert byte_size(Base.decode64!(out.heading_path_nonce)) == 12
+    end
+
+    test "produces distinct nonces across calls", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      vault = %Vault{encrypted: true}
+
+      {:ok, o1} = Crypto.maybe_encrypt_qdrant_payload(@base_payload, user, vault)
+      {:ok, o2} = Crypto.maybe_encrypt_qdrant_payload(@base_payload, user, vault)
+
+      refute o1.text_nonce == o2.text_nonce
+      refute o1.text == o2.text
+    end
+
+    test "returns {:error, :no_dek} when user lacks a DEK on encrypted vault", %{user: user} do
+      # No ensure_user_dek — user.encrypted_dek stays nil
+      vault = %Vault{encrypted: true}
+      assert {:error, :no_dek} = Crypto.maybe_encrypt_qdrant_payload(@base_payload, user, vault)
+    end
+
+    test "encrypts empty strings deterministically-shaped", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      vault = %Vault{encrypted: true}
+      payload = %{@base_payload | text: "", title: "", heading_path: ""}
+
+      assert {:ok, out} = Crypto.maybe_encrypt_qdrant_payload(payload, user, vault)
+      # Empty plaintext still produces 16-byte GCM tag → non-empty b64 ciphertext
+      assert byte_size(Base.decode64!(out.text)) == 16
+    end
+  end
+end

--- a/test/engram/crypto/qdrant_payload_test.exs
+++ b/test/engram/crypto/qdrant_payload_test.exs
@@ -252,5 +252,70 @@ defmodule Engram.Crypto.QdrantPayloadTest do
         :telemetry.detach(handler_id)
       end
     end
+
+    test "drops candidate with text_nonce but no vault_id (shape mismatch)", %{user: user} do
+      # Legacy candidate missing vault_id but carrying ciphertext — impossible via
+      # the normal index path (Phase 4 always writes vault_id), but defensive.
+      broken = %{
+        score: 0.5,
+        qdrant_id: "qid-broken",
+        source_path: "x.md",
+        tags: [],
+        text: "dGVzdA==",
+        title: "dA==",
+        heading_path: "aA==",
+        text_nonce: "bm9uY2Vfbm9uY2VfMTI=",
+        title_nonce: "bm9uY2Vfbm9uY2VfMTI=",
+        heading_path_nonce: "bm9uY2Vfbm9uY2VfMTI="
+      }
+
+      handler_id = {__MODULE__, :missing_vault_id_handler, System.unique_integer()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :search, :payload_shape_mismatch],
+        fn _e, m, meta, _ -> send(test_pid, {:shape_mismatch, m, meta}) end,
+        nil
+      )
+
+      try do
+        assert {:error, :decrypt_failed} =
+                 Crypto.maybe_decrypt_qdrant_candidates([broken], user, %{})
+
+        assert_received {:shape_mismatch, %{count: 1}, %{qdrant_id: "qid-broken"}}
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
+
+    test "returns :decrypt_failed and logs when encrypted candidate + user has no DEK" do
+      # User without ensure_user_dek — encrypted_dek stays nil → get_dek returns {:error, :no_dek}
+      user = insert(:user)
+      vault = %Vault{id: 5, encrypted: true}
+
+      candidate = %{
+        score: 0.9,
+        qdrant_id: "qid-x",
+        vault_id: "5",
+        source_path: "a.md",
+        tags: [],
+        text: "dGVzdA==",
+        title: "dA==",
+        heading_path: "aA==",
+        text_nonce: "bm9uY2Vfbm9uY2VfMTI=",
+        title_nonce: "bm9uY2Vfbm9uY2VfMTI=",
+        heading_path_nonce: "bm9uY2Vfbm9uY2VfMTI="
+      }
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:error, :decrypt_failed} =
+                   Crypto.maybe_decrypt_qdrant_candidates([candidate], user, %{"5" => vault})
+        end)
+
+      assert log =~ "failed to load DEK"
+      assert log =~ "user_id=#{user.id}"
+    end
   end
 end

--- a/test/engram/crypto/qdrant_payload_test.exs
+++ b/test/engram/crypto/qdrant_payload_test.exs
@@ -1,5 +1,6 @@
 defmodule Engram.Crypto.QdrantPayloadTest do
   use Engram.DataCase, async: false
+  import Bitwise
   alias Engram.Crypto
   alias Engram.Crypto.DekCache
   alias Engram.Vaults.Vault
@@ -85,6 +86,171 @@ defmodule Engram.Crypto.QdrantPayloadTest do
       assert {:ok, out} = Crypto.maybe_encrypt_qdrant_payload(payload, user, vault)
       # Empty plaintext still produces 16-byte GCM tag → non-empty b64 ciphertext
       assert byte_size(Base.decode64!(out.text)) == 16
+    end
+  end
+
+  describe "maybe_decrypt_qdrant_candidates/3" do
+    setup %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      enc_vault = %Vault{id: 5, encrypted: true}
+      plain_vault = %Vault{id: 7, encrypted: false}
+
+      # Build one encrypted candidate
+      {:ok, enc_payload} =
+        Crypto.maybe_encrypt_qdrant_payload(
+          %{text: "secret", title: "T", heading_path: "intro"},
+          user,
+          enc_vault
+        )
+
+      enc_candidate = %{
+        score: 0.9,
+        qdrant_id: "qid-1",
+        vault_id: "5",
+        source_path: "a.md",
+        tags: [],
+        text: enc_payload.text,
+        title: enc_payload.title,
+        heading_path: enc_payload.heading_path,
+        text_nonce: enc_payload.text_nonce,
+        title_nonce: enc_payload.title_nonce,
+        heading_path_nonce: enc_payload.heading_path_nonce
+      }
+
+      plain_candidate = %{
+        score: 0.8,
+        qdrant_id: "qid-2",
+        vault_id: "7",
+        source_path: "b.md",
+        tags: [],
+        text: "plain",
+        title: "P",
+        heading_path: "root"
+      }
+
+      vaults_by_id = %{"5" => enc_vault, "7" => plain_vault}
+
+      {:ok,
+       user: user,
+       enc_candidate: enc_candidate,
+       plain_candidate: plain_candidate,
+       vaults_by_id: vaults_by_id}
+    end
+
+    test "round-trips encrypted candidates to plaintext", %{
+      user: user,
+      enc_candidate: enc,
+      vaults_by_id: vaults
+    } do
+      assert {:ok, [out]} = Crypto.maybe_decrypt_qdrant_candidates([enc], user, vaults)
+      assert out.text == "secret"
+      assert out.title == "T"
+      assert out.heading_path == "intro"
+      refute Map.has_key?(out, :text_nonce)
+    end
+
+    test "passes through unencrypted candidates byte-exact", %{
+      user: user,
+      plain_candidate: pc,
+      vaults_by_id: vaults
+    } do
+      assert {:ok, [out]} = Crypto.maybe_decrypt_qdrant_candidates([pc], user, vaults)
+      assert out == pc
+    end
+
+    test "handles mixed list", %{
+      user: user,
+      enc_candidate: enc,
+      plain_candidate: pc,
+      vaults_by_id: vaults
+    } do
+      assert {:ok, [a, b]} = Crypto.maybe_decrypt_qdrant_candidates([enc, pc], user, vaults)
+      assert a.text == "secret"
+      assert b.text == "plain"
+    end
+
+    test "drops tampered candidate, keeps others, emits telemetry + error log", %{
+      user: user,
+      enc_candidate: enc,
+      plain_candidate: pc,
+      vaults_by_id: vaults
+    } do
+      # Tamper: flip one bit of the base64-decoded ciphertext, re-encode
+      <<first, rest::binary>> = Base.decode64!(enc.text)
+      tampered_ct = Base.encode64(<<Bitwise.bxor(first, 1), rest::binary>>)
+      tampered = %{enc | text: tampered_ct}
+
+      handler_id = {__MODULE__, :decrypt_failed_handler, System.unique_integer()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :search, :decrypt_failed],
+        fn _event, measurements, meta, _ ->
+          send(test_pid, {:telemetry_fired, measurements, meta})
+        end,
+        nil
+      )
+
+      try do
+        log =
+          ExUnit.CaptureLog.capture_log(fn ->
+            assert {:ok, [out]} =
+                     Crypto.maybe_decrypt_qdrant_candidates([tampered, pc], user, vaults)
+
+            # Only the plaintext candidate survives
+            assert out.qdrant_id == "qid-2"
+          end)
+
+        assert log =~ "decrypt"
+        assert_received {:telemetry_fired, %{count: 1}, %{qdrant_id: "qid-1"}}
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
+
+    test "returns :decrypt_failed when ALL candidates fail", %{
+      user: user,
+      enc_candidate: enc,
+      vaults_by_id: vaults
+    } do
+      <<first, rest::binary>> = Base.decode64!(enc.text)
+      tampered_ct = Base.encode64(<<Bitwise.bxor(first, 1), rest::binary>>)
+      tampered = %{enc | text: tampered_ct}
+
+      assert {:error, :decrypt_failed} =
+               Crypto.maybe_decrypt_qdrant_candidates([tampered], user, vaults)
+    end
+
+    test "empty input returns {:ok, []}", %{user: user, vaults_by_id: vaults} do
+      assert {:ok, []} = Crypto.maybe_decrypt_qdrant_candidates([], user, vaults)
+    end
+
+    test "drops candidate when vault_id-to-vault map is missing an entry", %{
+      user: user,
+      enc_candidate: enc
+    } do
+      # Vault 5 not in map → shape-mismatch guard
+      empty = %{}
+
+      handler_id = {__MODULE__, :shape_mismatch_handler, System.unique_integer()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :search, :payload_shape_mismatch],
+        fn _e, m, meta, _ -> send(test_pid, {:shape_mismatch, m, meta}) end,
+        nil
+      )
+
+      try do
+        assert {:error, :decrypt_failed} =
+                 Crypto.maybe_decrypt_qdrant_candidates([enc], user, empty)
+
+        assert_received {:shape_mismatch, _, _}
+      after
+        :telemetry.detach(handler_id)
+      end
     end
   end
 end

--- a/test/engram/crypto/qdrant_payload_test.exs
+++ b/test/engram/crypto/qdrant_payload_test.exs
@@ -1,6 +1,6 @@
 defmodule Engram.Crypto.QdrantPayloadTest do
   use Engram.DataCase, async: false
-  import Bitwise
+  import Bitwise, only: [bxor: 2]
   alias Engram.Crypto
   alias Engram.Crypto.DekCache
   alias Engram.Vaults.Vault
@@ -177,7 +177,7 @@ defmodule Engram.Crypto.QdrantPayloadTest do
     } do
       # Tamper: flip one bit of the base64-decoded ciphertext, re-encode
       <<first, rest::binary>> = Base.decode64!(enc.text)
-      tampered_ct = Base.encode64(<<Bitwise.bxor(first, 1), rest::binary>>)
+      tampered_ct = Base.encode64(<<bxor(first, 1), rest::binary>>)
       tampered = %{enc | text: tampered_ct}
 
       handler_id = {__MODULE__, :decrypt_failed_handler, System.unique_integer()}
@@ -215,7 +215,7 @@ defmodule Engram.Crypto.QdrantPayloadTest do
       vaults_by_id: vaults
     } do
       <<first, rest::binary>> = Base.decode64!(enc.text)
-      tampered_ct = Base.encode64(<<Bitwise.bxor(first, 1), rest::binary>>)
+      tampered_ct = Base.encode64(<<bxor(first, 1), rest::binary>>)
       tampered = %{enc | text: tampered_ct}
 
       assert {:error, :decrypt_failed} =

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -255,6 +255,70 @@ defmodule Engram.IndexingTest do
         :telemetry.detach(handler_id)
       end
     end
+
+    test "encryption failure preserves prior chunks (no partial-failure drift)", %{bypass: bypass} do
+      # Index once successfully, then re-index with a missing DEK. The old
+      # chunks must survive because encrypt-first aborts before any Postgres
+      # mutation.
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      {:ok, note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "atomic/note.md",
+          "content" => "# Title\n\nFirst body.",
+          "mtime" => 1_000.0
+        })
+
+      {:ok, plaintext_note} = Engram.Crypto.maybe_decrypt_note_fields(note, user)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, 2, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> [0.1, 0.2, 0.3] end)}
+      end)
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+      end)
+
+      assert {:ok, initial_count} = Indexing.index_note(plaintext_note, vault)
+      assert initial_count > 0
+
+      import Ecto.Query
+
+      original_ids =
+        Engram.Repo.all(
+          from(c in Engram.Notes.Chunk, where: c.note_id == ^plaintext_note.id, select: c.id),
+          skip_tenant_check: true
+        )
+        |> Enum.sort()
+
+      assert length(original_ids) == initial_count
+
+      # Clear the DEK so the next index_note/2 fails at encrypt.
+      Engram.Repo.update_all(
+        from(u in Engram.Accounts.User, where: u.id == ^user.id),
+        [set: [encrypted_dek: nil]],
+        skip_tenant_check: true
+      )
+
+      Engram.Crypto.DekCache.invalidate(user.id)
+
+      assert {:error, :no_dek} = Indexing.index_note(plaintext_note, vault)
+
+      # Old chunks must still be there — encrypt-first means no Postgres mutation
+      # happens when encryption fails.
+      surviving_ids =
+        Engram.Repo.all(
+          from(c in Engram.Notes.Chunk, where: c.note_id == ^plaintext_note.id, select: c.id),
+          skip_tenant_check: true
+        )
+        |> Enum.sort()
+
+      assert surviving_ids == original_ids,
+             "expected prior chunks to survive failed re-index; got #{inspect(surviving_ids)} vs #{inspect(original_ids)}"
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -28,11 +28,11 @@ defmodule Engram.IndexingTest do
   end
 
   # ---------------------------------------------------------------------------
-  # index_note/1
+  # index_note/2
   # ---------------------------------------------------------------------------
 
-  describe "index_note/1" do
-    test "embeds chunks and upserts to Qdrant + Postgres", %{bypass: bypass, note: note} do
+  describe "index_note/2" do
+    test "embeds chunks and upserts to Qdrant + Postgres", %{bypass: bypass, note: note, vault: vault} do
       # Mock embedder returns one 3-dim vector per chunk
       Engram.MockEmbedder
       |> expect(:embed_texts, fn texts ->
@@ -47,7 +47,7 @@ defmodule Engram.IndexingTest do
         |> Plug.Conn.send_resp(200, ~s({"result": true}))
       end)
 
-      assert {:ok, chunk_count} = Indexing.index_note(note)
+      assert {:ok, chunk_count} = Indexing.index_note(note, vault)
       assert chunk_count > 0
 
       # Postgres chunks rows should be created (skip_tenant_check: tests are trusted)
@@ -56,7 +56,7 @@ defmodule Engram.IndexingTest do
       assert length(chunks) == chunk_count
     end
 
-    test "uses doc embed model when configured", %{bypass: bypass, note: note} do
+    test "uses doc embed model when configured", %{bypass: bypass, note: note, vault: vault} do
       Application.put_env(:engram, :doc_embed_model, "voyage-4-large")
       on_exit(fn -> Application.delete_env(:engram, :doc_embed_model) end)
 
@@ -71,11 +71,11 @@ defmodule Engram.IndexingTest do
         |> Plug.Conn.send_resp(200, ~s({"result": true}))
       end)
 
-      assert {:ok, chunk_count} = Indexing.index_note(note)
+      assert {:ok, chunk_count} = Indexing.index_note(note, vault)
       assert chunk_count > 0
     end
 
-    test "skips embedding for empty content" do
+    test "skips embedding for empty content", %{vault: vault} do
       note = %Engram.Notes.Note{
         id: 999,
         path: "Test/Empty.md",
@@ -89,7 +89,104 @@ defmodule Engram.IndexingTest do
         content_hash: ""
       }
 
-      assert {:ok, 0} = Indexing.index_note(note)
+      assert {:ok, 0} = Indexing.index_note(note, vault)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # index_note/2 with encrypted vault
+  # ---------------------------------------------------------------------------
+
+  describe "index_note/2 with encrypted vault" do
+    test "encrypts text/title/heading_path in Qdrant payload", %{bypass: bypass, user: user} do
+      Engram.Crypto.DekCache.invalidate_all()
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "secret/note.md",
+          "content" => "# Secret\n\nClassified body.",
+          "mtime" => 1_000.0
+        })
+
+      # Re-decrypt since upsert_note encrypted the note content (Phase 3 behaviour).
+      {:ok, note} = Engram.Crypto.maybe_decrypt_note_fields(note, user)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> [0.1, 0.2, 0.3] end)}
+      end)
+
+      test_pid = self()
+
+      Bypass.expect(bypass, fn conn ->
+        if String.contains?(conn.request_path, "/points") and conn.method == "PUT" do
+          {:ok, body, conn} = Plug.Conn.read_body(conn)
+          send(test_pid, {:upsert_body, Jason.decode!(body)})
+          Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+        else
+          Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+        end
+      end)
+
+      assert {:ok, _count} = Indexing.index_note(note, vault)
+
+      assert_received {:upsert_body, body}
+      points = body["points"]
+      assert length(points) > 0
+
+      Enum.each(points, fn p ->
+        payload = p["payload"]
+        assert Map.has_key?(payload, "text_nonce")
+        assert Map.has_key?(payload, "title_nonce")
+        assert Map.has_key?(payload, "heading_path_nonce")
+        # text should be base64-encoded ciphertext, not the plaintext
+        refute payload["text"] == "Classified body."
+        refute payload["text"] =~ "Classified"
+        assert is_binary(payload["text_nonce"])
+        # base64 round-trip should succeed
+        assert {:ok, _} = Base.decode64(payload["text"])
+        assert {:ok, _} = Base.decode64(payload["text_nonce"])
+      end)
+    end
+
+    test "unencrypted vault → plaintext payload unchanged", %{bypass: bypass, user: user} do
+      vault = insert(:vault, user: user, encrypted: false)
+
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "plain/note.md",
+          "content" => "Plain body",
+          "mtime" => 1_000.0
+        })
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> [0.1, 0.2, 0.3] end)}
+      end)
+
+      test_pid = self()
+
+      Bypass.expect(bypass, fn conn ->
+        if String.contains?(conn.request_path, "/points") and conn.method == "PUT" do
+          {:ok, body, conn} = Plug.Conn.read_body(conn)
+          send(test_pid, {:upsert_body, Jason.decode!(body)})
+          Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+        else
+          Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+        end
+      end)
+
+      assert {:ok, _} = Indexing.index_note(note, vault)
+      assert_received {:upsert_body, body}
+
+      Enum.each(body["points"], fn p ->
+        refute Map.has_key?(p["payload"], "text_nonce")
+        refute Map.has_key?(p["payload"], "title_nonce")
+        refute Map.has_key?(p["payload"], "heading_path_nonce")
+        assert is_binary(p["payload"]["text"])
+      end)
     end
   end
 
@@ -98,7 +195,7 @@ defmodule Engram.IndexingTest do
   # ---------------------------------------------------------------------------
 
   describe "delete_note_index/1" do
-    test "deletes chunks from Postgres and Qdrant", %{bypass: bypass, note: note} do
+    test "deletes chunks from Postgres and Qdrant", %{bypass: bypass, note: note, vault: vault} do
       # First index it
       Engram.MockEmbedder
       |> expect(:embed_texts, fn texts ->
@@ -111,7 +208,7 @@ defmodule Engram.IndexingTest do
         |> Plug.Conn.send_resp(200, ~s({"result": true}))
       end)
 
-      {:ok, _} = Indexing.index_note(note)
+      {:ok, _} = Indexing.index_note(note, vault)
 
       # Now delete — Qdrant should get a delete request
       Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/delete", fn conn ->

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -188,6 +188,73 @@ defmodule Engram.IndexingTest do
         assert is_binary(p["payload"]["text"])
       end)
     end
+
+    test "emits encrypt_failed telemetry when DEK missing on encrypted vault", %{bypass: bypass} do
+      # User has NO DEK provisioned — encrypted vault → maybe_encrypt_qdrant_payload
+      # returns {:error, :no_dek} → reduce_while halts → telemetry fires.
+      user = insert(:user)
+      vault = insert(:vault, user: user, encrypted: true)
+
+      {:ok, note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "no-dek/note.md",
+          "content" => "body",
+          "mtime" => 1_000.0
+        })
+
+      # Reload user — upsert_note auto-provisioned the DEK via
+      # maybe_encrypt_note_fields, but our local user struct is stale.
+      user = Engram.Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
+
+      # Decrypt note while DEK still exists (simulates worker's decrypt step).
+      {:ok, plaintext_note} = Engram.Crypto.maybe_decrypt_note_fields(note, user)
+
+      # Now clear the DEK so that Indexing's re-encrypt attempt fails.
+      # upsert_note auto-provisioned via maybe_encrypt_note_fields; simulate the
+      # "DEK missing at index time" scenario that emits telemetry.
+      import Ecto.Query
+      Engram.Repo.update_all(
+        from(u in Engram.Accounts.User, where: u.id == ^user.id),
+        [set: [encrypted_dek: nil]],
+        skip_tenant_check: true
+      )
+
+      Engram.Crypto.DekCache.invalidate(user.id)
+      user_cleared = Engram.Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
+      _ = user_cleared
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> [0.1, 0.2, 0.3] end)}
+      end)
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+      end)
+
+      handler_id = {__MODULE__, :encrypt_failed_handler, System.unique_integer()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :indexing, :encrypt_failed],
+        fn _event, measurements, meta, _ ->
+          send(test_pid, {:encrypt_failed_fired, measurements, meta})
+        end,
+        nil
+      )
+
+      try do
+        assert {:error, :no_dek} = Indexing.index_note(plaintext_note, vault)
+
+        assert_received {:encrypt_failed_fired, %{count: 1}, meta}
+        assert meta.user_id == user.id
+        assert meta.vault_id == vault.id
+        assert meta.note_id == plaintext_note.id
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/search_integration_test.exs
+++ b/test/engram/search_integration_test.exs
@@ -1,0 +1,82 @@
+defmodule Engram.SearchIntegrationTest do
+  use Engram.DataCase, async: false
+
+  @moduletag :qdrant_integration
+
+  setup do
+    Engram.Crypto.DekCache.invalidate_all()
+    user = insert(:user)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    enc_vault = insert(:vault, user: user, encrypted: true)
+
+    # Use a test-isolated Qdrant collection so we can drop it after.
+    col = "engram_test_#{System.unique_integer([:positive])}"
+    old_col = Application.get_env(:engram, :qdrant_collection)
+    Application.put_env(:engram, :qdrant_collection, col)
+
+    on_exit(fn ->
+      Engram.Vector.Qdrant.delete_collection(col)
+      Application.put_env(:engram, :qdrant_collection, old_col)
+    end)
+
+    {:ok, user: user, vault: enc_vault, collection: col}
+  end
+
+  test "encrypted vault round-trip: upsert → raw payload is ciphertext → search returns plaintext",
+       %{user: user, vault: vault, collection: col} do
+    note =
+      insert(:note,
+        user: user,
+        vault: vault,
+        content: "# Journal\n\nSensitive body content.",
+        title: "Journal"
+      )
+
+    {:ok, _n} = Engram.Indexing.index_note(note, vault)
+
+    # Raw fetch from Qdrant — inspect payloads to confirm ciphertext shape.
+    {:ok, info} = Engram.Vector.Qdrant.collection_info(col)
+    assert info["points_count"] >= 1
+
+    {:ok, resp} =
+      Req.post("http://localhost:6333/collections/#{col}/points/scroll",
+        json: %{limit: 10, with_payload: true}
+      )
+
+    point = hd(resp.body["result"]["points"])
+    payload = point["payload"]
+
+    assert payload["text_nonce"] != nil
+    assert payload["text"] != "# Journal"
+    assert payload["title"] != "Journal"
+    assert payload["vault_id"] == to_string(vault.id)
+
+    # Search must return plaintext.
+    {:ok, results} = Engram.Search.search(user, vault, "sensitive body")
+
+    assert results != []
+
+    Enum.each(results, fn r ->
+      assert is_binary(r.text)
+      refute Map.has_key?(r, :text_nonce)
+    end)
+  end
+
+  test "unencrypted vault round-trip: plaintext end to end", %{user: user, collection: col} do
+    plain_vault = insert(:vault, user: user, encrypted: false)
+    _ = col
+
+    note =
+      insert(:note,
+        user: user,
+        vault: plain_vault,
+        content: "Plain content with searchable words.",
+        title: "Plain"
+      )
+
+    {:ok, _} = Engram.Indexing.index_note(note, plain_vault)
+
+    {:ok, results} = Engram.Search.search(user, plain_vault, "searchable")
+    assert Enum.any?(results, fn r -> r.text =~ "searchable" end)
+  end
+end

--- a/test/engram/search_integration_test.exs
+++ b/test/engram/search_integration_test.exs
@@ -62,9 +62,8 @@ defmodule Engram.SearchIntegrationTest do
     end)
   end
 
-  test "unencrypted vault round-trip: plaintext end to end", %{user: user, collection: col} do
+  test "unencrypted vault round-trip: plaintext end to end", %{user: user} do
     plain_vault = insert(:vault, user: user, encrypted: false)
-    _ = col
 
     note =
       insert(:note,

--- a/test/engram/search_test.exs
+++ b/test/engram/search_test.exs
@@ -1,6 +1,7 @@
 defmodule Engram.SearchTest do
   use Engram.DataCase, async: false
 
+  import Bitwise, only: [bxor: 2]
   import Mox
 
   alias Engram.Search
@@ -267,6 +268,120 @@ defmodule Engram.SearchTest do
 
       result = Search.search(user, vault, "query")
       refute result == {:error, :feature_not_available}
+    end
+  end
+
+  describe "search/4 with encrypted vaults" do
+    setup do
+      Engram.Crypto.DekCache.invalidate_all()
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      enc_vault = insert(:vault, user: user, encrypted: true, encrypted_at: DateTime.utc_now())
+
+      {:ok, user: user, enc_vault: enc_vault}
+    end
+
+    test "decrypts encrypted-vault candidates before returning results", %{
+      bypass: bypass,
+      user: user,
+      enc_vault: vault
+    } do
+      {:ok, enc} =
+        Engram.Crypto.maybe_encrypt_qdrant_payload(
+          %{text: "alpha body", title: "Alpha", heading_path: "root"},
+          user,
+          vault
+        )
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      qdrant_result = %{
+        "result" => [
+          %{
+            "id" => "qid-a",
+            "score" => 0.95,
+            "payload" => %{
+              "text" => enc.text,
+              "title" => enc.title,
+              "heading_path" => enc.heading_path,
+              "text_nonce" => enc.text_nonce,
+              "title_nonce" => enc.title_nonce,
+              "heading_path_nonce" => enc.heading_path_nonce,
+              "source_path" => "a.md",
+              "tags" => [],
+              "user_id" => to_string(user.id),
+              "vault_id" => to_string(vault.id)
+            }
+          }
+        ]
+      }
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(qdrant_result))
+      end)
+
+      assert {:ok, [result]} = Search.search(user, vault, "query")
+      assert result.text == "alpha body"
+      assert result.title == "Alpha"
+      assert result.heading_path == "root"
+      refute Map.has_key?(result, :text_nonce)
+    end
+
+    test "returns {:error, :decrypt_failed} when ALL encrypted candidates fail decrypt", %{
+      bypass: bypass,
+      user: user,
+      enc_vault: vault
+    } do
+      {:ok, enc} =
+        Engram.Crypto.maybe_encrypt_qdrant_payload(
+          %{text: "beta body", title: "Beta", heading_path: "root"},
+          user,
+          vault
+        )
+
+      # Tamper: flip one bit of the decoded ciphertext.
+      <<first, rest::binary>> = Base.decode64!(enc.text)
+      tampered_text = Base.encode64(<<bxor(first, 1), rest::binary>>)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      qdrant_result = %{
+        "result" => [
+          %{
+            "id" => "qid-b",
+            "score" => 0.9,
+            "payload" => %{
+              "text" => tampered_text,
+              "title" => enc.title,
+              "heading_path" => enc.heading_path,
+              "text_nonce" => enc.text_nonce,
+              "title_nonce" => enc.title_nonce,
+              "heading_path_nonce" => enc.heading_path_nonce,
+              "source_path" => "b.md",
+              "tags" => [],
+              "user_id" => to_string(user.id),
+              "vault_id" => to_string(vault.id)
+            }
+          }
+        ]
+      }
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(qdrant_result))
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:error, :decrypt_failed} = Search.search(user, vault, "query")
+        end)
+
+      assert log =~ "decrypt"
     end
   end
 end

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -390,4 +390,50 @@ defmodule Engram.VaultsTest do
       assert :forbidden = Vaults.check_api_key_access(api_key, vault)
     end
   end
+
+  describe "list_for_ids/2" do
+    test "returns map keyed by stringified vault id" do
+      user = insert(:user)
+      v1 = insert(:vault, user: user)
+      v2 = insert(:vault, user: user)
+
+      result = Engram.Vaults.list_for_ids(user, [to_string(v1.id), to_string(v2.id)])
+
+      assert Map.keys(result) |> Enum.sort() ==
+               Enum.sort([to_string(v1.id), to_string(v2.id)])
+      assert result[to_string(v1.id)].id == v1.id
+    end
+
+    test "filters out other users' vaults" do
+      user_a = insert(:user)
+      user_b = insert(:user)
+      v_a = insert(:vault, user: user_a)
+      v_b = insert(:vault, user: user_b)
+
+      # user_a requests both IDs — only their own vault returned
+      result = Engram.Vaults.list_for_ids(user_a, [to_string(v_a.id), to_string(v_b.id)])
+
+      assert Map.keys(result) == [to_string(v_a.id)]
+    end
+
+    test "deduplicates and tolerates non-integer strings" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+
+      result =
+        Engram.Vaults.list_for_ids(user, [
+          to_string(vault.id),
+          to_string(vault.id),
+          "not-a-number",
+          ""
+        ])
+
+      assert result == %{to_string(vault.id) => result[to_string(vault.id)]}
+    end
+
+    test "empty list returns empty map" do
+      user = insert(:user)
+      assert Engram.Vaults.list_for_ids(user, []) == %{}
+    end
+  end
 end

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -435,5 +435,16 @@ defmodule Engram.VaultsTest do
       user = insert(:user)
       assert Engram.Vaults.list_for_ids(user, []) == %{}
     end
+
+    test "excludes soft-deleted vaults" do
+      user = insert(:user)
+      deleted =
+        insert(:vault,
+          user: user,
+          deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+
+      assert Engram.Vaults.list_for_ids(user, [to_string(deleted.id)]) == %{}
+    end
   end
 end

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -129,14 +129,38 @@ defmodule Engram.Workers.EmbedNoteTest do
         {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
       end)
 
-      stub_qdrant(bypass)
+      test_pid = self()
+
+      Bypass.expect(bypass, fn conn ->
+        if String.contains?(conn.request_path, "/points") and conn.method == "PUT" do
+          {:ok, body, conn} = Plug.Conn.read_body(conn)
+          send(test_pid, {:upsert_body, Jason.decode!(body)})
+          Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+        else
+          Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+        end
+      end)
 
       assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      # Confirms the worker loaded the (encrypted) vault and passed it into the
+      # indexing pipeline: payloads must carry nonces and ciphertext, not plaintext.
+      assert_received {:upsert_body, body}
+      points = body["points"]
+      assert length(points) > 0
+
+      Enum.each(points, fn p ->
+        payload = p["payload"]
+        assert Map.has_key?(payload, "text_nonce")
+        assert Map.has_key?(payload, "title_nonce")
+        refute payload["text"] =~ "Classified"
+      end)
 
       # embed_hash should be stamped, confirming the job ran to completion
       updated = Repo.get!(Note, note.id, skip_tenant_check: true)
       assert updated.embed_hash == updated.content_hash
     end
+
   end
 
   describe "job scheduling" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,12 @@
 ExUnit.start(assert_receive_timeout: 2_000)
 Ecto.Adapters.SQL.Sandbox.mode(Engram.Repo, :manual)
 
+# Exclude :qdrant_integration tests unless QDRANT_INTEGRATION=1 is set.
+# These tests require a running Qdrant instance at localhost:6333 (CI stack).
+if System.get_env("QDRANT_INTEGRATION") != "1" do
+  ExUnit.configure(exclude: [:qdrant_integration])
+end
+
 # Ensure SPA index.html has </head> for config injection.
 # CI has no frontend build → write a minimal stub.
 # Real build (detected by `id="root"`) missing </head> = error, not overwrite:


### PR DESCRIPTION
## Summary

End-to-end Qdrant payload encryption for notes in encrypted vaults. Builds on Phases 1-3 (PR #37).

- Encrypts `text`, `title`, `heading_path` in Qdrant payload when `vault.encrypted = true`
- Decrypts candidates after retrieval, before reranker (Jina never sees ciphertext)
- `tags`, `folder`, `source_path`, `vault_id`, `chunk_index` stay plaintext (filter pushdown)
- Vectors never encrypted (already computed from plaintext by worker decrypt path)
- Per-candidate decrypt failure → log + telemetry + drop; ALL failing → `{:error, :decrypt_failed}` → HTTP 502
- New telemetry: `[:engram, :search, :decrypt_failed]`, `[:engram, :search, :payload_shape_mismatch]`, `[:engram, :indexing, :encrypt_failed]`

## Changes

- `Engram.Crypto.maybe_encrypt_qdrant_payload/3` + `maybe_decrypt_qdrant_candidates/3`
- `Engram.Vaults.list_for_ids/2` — batch vault lookup with tenant scoping + soft-delete filter
- `Engram.Vector.Qdrant.search/3` now surfaces `vault_id` + nonce keys in results
- `Engram.Indexing.index_note/1 → /2` — takes vault, encrypts payload per chunk
- `Engram.Workers.EmbedNote` — loads vault, hardened with `{:discard, ...}` for orphan notes
- `Engram.Search.do_search/4` — batch-loads candidate vaults, decrypts before rerank

## Test plan

- [x] `mix test` — 781 tests, 0 failures (2 integration tests gated by `QDRANT_INTEGRATION=1`)
- [x] `mix compile --warnings-as-errors` — clean
- [x] TDD throughout; round-trip tests use real `Crypto.Envelope`, not mocks
- [x] Tamper test (bit-flip ciphertext) confirms GCM auth rejects + telemetry fires
- [ ] `QDRANT_INTEGRATION=1 mix test` — real Qdrant round-trip (requires CI stack)
- [ ] Manual dev smoke: encrypt vault via psql, write note, confirm Qdrant raw payload is ciphertext, confirm search returns plaintext

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-04-18-encryption-phase-4-qdrant-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-encryption-phase-4-qdrant.md`

## Out of scope (follow-up phases)

- Phase 5: attachment encryption
- Phase 6: vault toggle Oban workers + Qdrant `set_payload` backfill
- Phase 7: AWS KMS KeyProvider
- Phase 8: Passphrase KeyProvider + unlock flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)