### PR TITLE
fix(e2e): test_29 queue flake — wait per-path + extend timeout

### DIFF
--- a/e2e/tests/test_29_offline_multi_file_flush.py
+++ b/e2e/tests/test_29_offline_multi_file_flush.py
@@ -34,17 +34,24 @@ async def test_offline_multi_file_flush(vault_a, cdp_a, api_sync):
             write_note(vault_a, path, f"# Multi Flush {i}\nCreated while offline")
             time.sleep(0.3)
 
-        # Wait for push attempts to fail and queue
-        deadline = time.monotonic() + 10
+        # Wait for EACH path to appear in the queue. Under xdist with 2 workers,
+        # Obsidian's file-watch → push-attempt → queue cycle can exceed 10s for
+        # the last-written file; 30s matches the drain timeout below.
+        paths_set = set(paths)
+        deadline = time.monotonic() + 30
+        queued_paths: set[str] = set()
+
         while time.monotonic() < deadline:
-            if await cdp_a.get_queue_size() >= 3:
+            entries = await cdp_a.get_queue_entries()
+            queued_paths = {e["path"] for e in entries}
+            if paths_set.issubset(queued_paths):
                 break
             await asyncio.sleep(0.5)
 
-        queue_size = await cdp_a.get_queue_size()
-        assert queue_size >= 3, (
-            f"Expected at least 3 queued entries, got {queue_size}. "
-            f"Entries: {await cdp_a.get_queue_entries()}"
+        missing = paths_set - queued_paths
+        assert not missing, (
+            f"Expected all 3 paths queued within 30s. Missing: {sorted(missing)}. "
+            f"Queued entries: {await cdp_a.get_queue_entries()}"
         )
     finally:
         # MUST restore even if assertions fail — prevents cascade to later tests

--- a/e2e/tests/test_31_restart_preserves_queue.py
+++ b/e2e/tests/test_31_restart_preserves_queue.py
@@ -32,14 +32,24 @@ async def test_restart_preserves_queue(vault_a, cdp_a, api_sync, obsidian_a):
     time.sleep(0.3)
     write_note(vault_a, path2, "# Restart Queue 2\nAlso survives restart")
 
-    # Wait for push attempts to fail and queue
-    deadline = time.monotonic() + 10
+    # Wait for EACH path to appear in the queue. Same pattern as test_29:
+    # under xdist load, a count-based 10s poll can miss the last write.
+    paths_set = {path1, path2}
+    deadline = time.monotonic() + 30
+    queued_paths: set[str] = set()
+
     while time.monotonic() < deadline:
-        queue_size = await cdp_a.get_queue_size()
-        if queue_size >= 2:
+        entries = await cdp_a.get_queue_entries()
+        queued_paths = {e["path"] for e in entries}
+        if paths_set.issubset(queued_paths):
             break
         await asyncio.sleep(0.5)
-    assert queue_size >= 2, f"Expected at least 2 queued, got {queue_size}"
+
+    missing = paths_set - queued_paths
+    assert not missing, (
+        f"Expected both paths queued within 30s. Missing: {sorted(missing)}. "
+        f"Queued entries: {await cdp_a.get_queue_entries()}"
+    )
 
     # 3. Force persist queue to data.json (bypass debounce)
     await cdp_a.evaluate("""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Eliminates flaky failures in \`test_29_offline_multi_file_flush\`. Same flake hit PR #38 CI (\`got 2, expected 3\` queued entries).

**Root cause:** test polled \`cdp_a.get_queue_size() >= 3\` with a 10s deadline. Under 2-worker xdist load, Obsidian's file-watch → push-attempt → queue cycle for the last-written file sometimes exceeds 10s — so only 2 of 3 entries were queued by the time the assert ran.

**Fix:** wait for each specific path to appear in the queue (not just count), and extend the deadline to 30s to match the drain timeout in the same test's \`finally\` block. Assertion now names missing paths, making future triage trivial.

## Test plan

- [x] Local: test file compiles / imports clean
- [ ] CI: e2e-clerk + e2e-local pass on this branch
- [ ] CI: no regression in other test_2x offline-queue tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)