### PR TITLE
fix(ci): push via docker/build-push-action + test flake retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -806,9 +806,6 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
       - name: Extract and validate version
         id: version
         run: |
@@ -818,39 +815,50 @@ jobs:
             exit 1
           fi
 
+          IMAGE_LC="ghcr.io/${{ github.repository_owner }}/engram"
+          IMAGE_LC=$(echo "$IMAGE_LC" | tr '[:upper:]' '[:lower:]')
+
           # Check version was bumped from the previous deploy
-          IMAGE="ghcr.io/${{ github.repository_owner }}/engram"
-          IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
-          if docker manifest inspect "${IMAGE}:${VERSION}" > /dev/null 2>&1; then
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin > /dev/null
+          if docker manifest inspect "${IMAGE_LC}:${VERSION}" > /dev/null 2>&1; then
             echo "ERROR: Version ${VERSION} already exists in GHCR. Bump the version in mix.exs before merging." >&2
             exit 1
           fi
 
+          SHA_SHORT="${GITHUB_SHA::7}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "image=$IMAGE_LC" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$SHA_SHORT" >> "$GITHUB_OUTPUT"
           echo "Version ${VERSION} is new — proceeding"
 
-      - name: Build and push image
-        # buildx --push bypasses the local containerd image store. Docker 29's
-        # containerd-snapshotter pusher emits OCI attestation manifests that
-        # GHCR rejects with 405 on /blobs/uploads/. --provenance=false +
-        # --sbom=false suppress those attestations; --platform pins to a single
-        # arch so no manifest list is produced either.
-        run: |
-          IMAGE="ghcr.io/${{ github.repository_owner }}/engram"
-          IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA="${{ github.sha }}"
+      # Host daemon on the runner has Docker 29's containerd-snapshotter enabled,
+      # whose push client hits GHCR with `405 Not Allowed` on /blobs/uploads/.
+      # docker-container driver runs buildkit in an isolated container with its
+      # own push path, sidestepping the host daemon entirely.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
 
-          docker buildx build \
-            --provenance=false \
-            --sbom=false \
-            --platform=linux/amd64 \
-            -t "${IMAGE}:latest" \
-            -t "${IMAGE}:${VERSION}" \
-            -t "${IMAGE}:${SHA::7}" \
-            --push \
-            .
-          echo "Pushed ${IMAGE}:latest, ${IMAGE}:${VERSION}, and ${IMAGE}:${SHA::7}"
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          provenance: false
+          sbom: false
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.version.outputs.image }}:latest
+            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.version }}
+            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.sha_short }}
 
       - name: Deploy to FastRaid
         env:

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -4,6 +4,10 @@ timeout = 180
 testpaths = tests
 reruns = 1
 reruns_delay = 2
+# -ra = show short summary for (a)ll non-passing outcomes, including reruns.
+# Without this, rerun tracebacks never appear in CI logs, making flakes
+# impossible to diagnose post-hoc.
+addopts = -ra
 
 # ── Logging ──────────────────────────────────────────────────────────────
 # log_cli is OFF by default — stdout flushing per log line adds latency

--- a/e2e/tests/api_only/test_60_local_auth.py
+++ b/e2e/tests/api_only/test_60_local_auth.py
@@ -19,8 +19,36 @@ import time
 
 import pytest
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+
+
+def _build_session() -> requests.Session:
+    """requests.Session with a retry adapter.
+
+    TestRefresh fixtures and bodies make 1–2 HTTP calls each against a local
+    Phoenix endpoint. pytest-rerunfailures was catching sporadic transient
+    failures (connection reset, 502 during worker churn) as full test reruns,
+    polluting CI output. Retry at the HTTP layer instead so transient network
+    noise never escalates to a rerun.
+    """
+    retry = Retry(
+        total=3,
+        backoff_factor=0.2,
+        status_forcelist=(502, 503, 504),
+        allowed_methods=frozenset(["GET", "POST", "PUT", "DELETE"]),
+        raise_on_status=False,
+    )
+    s = requests.Session()
+    adapter = HTTPAdapter(max_retries=retry)
+    s.mount("http://", adapter)
+    s.mount("https://", adapter)
+    return s
+
+
+http = _build_session()
 
 
 def unique_email(label: str) -> str:
@@ -40,7 +68,7 @@ class TestRegistration:
     def test_first_user_is_admin(self):
         """First registered user gets admin role."""
         email = unique_email("admin")
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/register",
             json={"email": email, "password": PASSWORD},
             timeout=10,
@@ -55,7 +83,7 @@ class TestRegistration:
     def test_register_returns_refresh_cookie(self):
         """Registration sets an HTTP-only refresh_token cookie."""
         email = unique_email("cookie")
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/register",
             json={"email": email, "password": PASSWORD},
             timeout=10,
@@ -66,14 +94,14 @@ class TestRegistration:
     def test_duplicate_email_rejected(self):
         """Cannot register twice with the same email."""
         email = unique_email("dup")
-        resp1 = requests.post(
+        resp1 = http.post(
             f"{API_URL}/auth/register",
             json={"email": email, "password": PASSWORD},
             timeout=10,
         )
         assert resp1.status_code == 201
 
-        resp2 = requests.post(
+        resp2 = http.post(
             f"{API_URL}/auth/register",
             json={"email": email, "password": PASSWORD},
             timeout=10,
@@ -82,7 +110,7 @@ class TestRegistration:
 
     def test_missing_password_rejected(self):
         """Registration without password returns 422."""
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/register",
             json={"email": unique_email("nopass")},
             timeout=10,
@@ -99,7 +127,7 @@ class TestLogin:
     @pytest.fixture(scope="class", autouse=True)
     def _registered_user(self, request):
         email = unique_email("login")
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/register",
             json={"email": email, "password": PASSWORD},
             timeout=10,
@@ -109,7 +137,7 @@ class TestLogin:
 
     def test_valid_credentials(self):
         """Login with correct password returns access token + refresh cookie."""
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/login",
             json={"email": self.email, "password": PASSWORD},
             timeout=10,
@@ -122,7 +150,7 @@ class TestLogin:
 
     def test_wrong_password(self):
         """Login with wrong password returns 401."""
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/login",
             json={"email": self.email, "password": "WrongPassword!"},
             timeout=10,
@@ -131,7 +159,7 @@ class TestLogin:
 
     def test_nonexistent_user(self):
         """Login with unknown email returns 401."""
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/login",
             json={"email": "nobody-ever@test.com", "password": PASSWORD},
             timeout=10,
@@ -148,7 +176,7 @@ class TestRefresh:
     @pytest.fixture(autouse=True)
     def _registered_session(self):
         self.email = unique_email("refresh")
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/register",
             json={"email": self.email, "password": PASSWORD},
             timeout=10,
@@ -159,7 +187,7 @@ class TestRefresh:
 
     def test_refresh_returns_new_tokens(self):
         """POST /auth/refresh with valid cookie returns new access token + rotated cookie."""
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/refresh",
             cookies={"refresh_token": self.refresh_cookie},
             timeout=10,
@@ -175,14 +203,14 @@ class TestRefresh:
 
     def test_refresh_token_works_for_api(self):
         """Access token from refresh can authenticate API calls."""
-        resp = requests.post(
+        resp = http.post(
             f"{API_URL}/auth/refresh",
             cookies={"refresh_token": self.refresh_cookie},
             timeout=10,
         )
         new_token = resp.json()["access_token"]
 
-        me_resp = requests.get(
+        me_resp = http.get(
             f"{API_URL}/me",
             headers={"Authorization": f"Bearer {new_token}"},
             timeout=10,
@@ -193,7 +221,7 @@ class TestRefresh:
     def test_old_refresh_token_rejected_after_rotation(self):
         """After rotation, the old refresh token should be rejected."""
         # Use the token (rotates it)
-        resp1 = requests.post(
+        resp1 = http.post(
             f"{API_URL}/auth/refresh",
             cookies={"refresh_token": self.refresh_cookie},
             timeout=10,
@@ -201,7 +229,7 @@ class TestRefresh:
         assert resp1.status_code == 200
 
         # Reuse the old token — should fail (reuse detection)
-        resp2 = requests.post(
+        resp2 = http.post(
             f"{API_URL}/auth/refresh",
             cookies={"refresh_token": self.refresh_cookie},
             timeout=10,
@@ -212,7 +240,7 @@ class TestRefresh:
 
     def test_missing_cookie_rejected(self):
         """Refresh without cookie returns 401."""
-        resp = requests.post(f"{API_URL}/auth/refresh", timeout=10)
+        resp = http.post(f"{API_URL}/auth/refresh", timeout=10)
         assert resp.status_code == 401
 
 
@@ -227,7 +255,7 @@ class TestLogout:
         email = unique_email("logout")
 
         # Register
-        reg = requests.post(
+        reg = http.post(
             f"{API_URL}/auth/register",
             json={"email": email, "password": PASSWORD},
             timeout=10,
@@ -236,7 +264,7 @@ class TestLogout:
         cookie = reg.cookies["refresh_token"]
 
         # Logout
-        logout_resp = requests.post(
+        logout_resp = http.post(
             f"{API_URL}/auth/logout",
             cookies={"refresh_token": cookie},
             timeout=10,
@@ -244,7 +272,7 @@ class TestLogout:
         assert logout_resp.status_code == 204
 
         # Try to refresh — should fail
-        refresh_resp = requests.post(
+        refresh_resp = http.post(
             f"{API_URL}/auth/refresh",
             cookies={"refresh_token": cookie},
             timeout=10,

--- a/e2e/tests/api_only/test_60_local_auth.py
+++ b/e2e/tests/api_only/test_60_local_auth.py
@@ -25,30 +25,46 @@ from urllib3.util.retry import Retry
 API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
 
 
-def _build_session() -> requests.Session:
-    """requests.Session with a retry adapter.
+_RETRY = Retry(
+    total=3,
+    backoff_factor=0.2,
+    status_forcelist=(502, 503, 504),
+    allowed_methods=frozenset(["GET", "POST", "PUT", "DELETE"]),
+    raise_on_status=False,
+)
 
-    TestRefresh fixtures and bodies make 1–2 HTTP calls each against a local
-    Phoenix endpoint. pytest-rerunfailures was catching sporadic transient
-    failures (connection reset, 502 during worker churn) as full test reruns,
-    polluting CI output. Retry at the HTTP layer instead so transient network
-    noise never escalates to a rerun.
+
+class _RetryClient:
+    """Fresh ``requests.Session`` per call.
+
+    A shared Session persists cookies across calls, which breaks the refresh
+    tests: a rotated cookie from the session jar would override the
+    per-call ``cookies=`` kwarg. New Session per call = empty jar, so the
+    test's explicit cookies (or absence of them) reach the server verbatim.
+    Retry adapter still covers transient network/5xx without bleeding state.
     """
-    retry = Retry(
-        total=3,
-        backoff_factor=0.2,
-        status_forcelist=(502, 503, 504),
-        allowed_methods=frozenset(["GET", "POST", "PUT", "DELETE"]),
-        raise_on_status=False,
-    )
-    s = requests.Session()
-    adapter = HTTPAdapter(max_retries=retry)
-    s.mount("http://", adapter)
-    s.mount("https://", adapter)
-    return s
+
+    def _session(self) -> requests.Session:
+        s = requests.Session()
+        adapter = HTTPAdapter(max_retries=_RETRY)
+        s.mount("http://", adapter)
+        s.mount("https://", adapter)
+        return s
+
+    def post(self, url, **kw):
+        return self._session().post(url, **kw)
+
+    def get(self, url, **kw):
+        return self._session().get(url, **kw)
+
+    def put(self, url, **kw):
+        return self._session().put(url, **kw)
+
+    def delete(self, url, **kw):
+        return self._session().delete(url, **kw)
 
 
-http = _build_session()
+http = _RetryClient()
 
 
 def unique_email(label: str) -> str:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.4.1",
+      version: "0.4.2",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- **PR #40's buildx --push still 405'd** on GHCR. Reproduced locally from the runner with a fresh PAT, confirming it's a Docker 29 containerd-snapshotter ↔ GHCR push bug, not auth or workflow shape.
- Switch deploy to the canonical GHCR recipe: `docker/setup-buildx-action` with `driver: docker-container` (runs buildkit in its own container, isolated from the host daemon), `docker/login-action@v3`, `docker/build-push-action@v6`.
- Bumps `0.4.1 → 0.4.2` so `version-check` passes vs main.
- Also includes: retry adapter on `test_60_local_auth.py` HTTP calls + `addopts = -ra` to surface rerun tracebacks. Three `TestRefresh` tests have been flaking across recent green runs; retry at the HTTP layer so transient network noise never escalates to a rerun.

## Test plan
- [ ] `version-check` passes (0.4.2 ≠ 0.4.1 on main)
- [ ] `deploy-fastraid` completes `Build and push image` with no 405
- [ ] All three tags (`latest`, `0.4.2`, `${SHA::7}`) appear in GHCR
- [ ] FastRaid deploy verifies `/api/health` returns version `0.4.2`
- [ ] E2E `TestRefresh::*` tests no longer show RERUN in job output

🤖 Generated with [Claude Code](https://claude.com/claude-code)