### PR TITLE
feat(crypto): Phase 6 backend — vault encryption toggle + backfill

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -48,7 +48,7 @@ config :hammer,
 config :engram, Oban,
   engine: Oban.Engines.Basic,
   repo: Engram.Repo,
-  queues: [embed: 5, reindex: 1, maintenance: 2],
+  queues: [embed: 5, reindex: 1, maintenance: 2, crypto_backfill: 1],
   plugins: [
     {Oban.Plugins.Pruner, max_age: 7 * 24 * 3600},
     Oban.Plugins.Lifeline,

--- a/e2e/helpers/crypto_probe.py
+++ b/e2e/helpers/crypto_probe.py
@@ -107,7 +107,7 @@ def _qdrant_scroll(vault_id: int, limit: int = 100) -> list[dict]:
     resp = requests.post(
         f"{QDRANT_URL}/collections/{QDRANT_COLLECTION}/points/scroll",
         json={
-            "filter": {"must": [{"key": "vault_id", "match": {"value": int(vault_id)}}]},
+            "filter": {"must": [{"key": "vault_id", "match": {"value": str(int(vault_id))}}]},
             "limit": limit,
             "with_payload": True,
             "with_vector": False,
@@ -233,7 +233,7 @@ def wait_for_qdrant_indexed(vault_id: int, path: str, timeout: float = 30.0) -> 
                 json={
                     "filter": {
                         "must": [
-                            {"key": "vault_id", "match": {"value": int(vault_id)}},
+                            {"key": "vault_id", "match": {"value": str(int(vault_id))}},
                             {"key": "source_path", "match": {"value": path}},
                         ]
                     },

--- a/e2e/helpers/crypto_probe.py
+++ b/e2e/helpers/crypto_probe.py
@@ -1,0 +1,102 @@
+"""Database + Qdrant probes for at-rest encryption assertions.
+
+Used by E2E tests that need to verify ciphertext is actually at rest
+(not just that the API returns plaintext). Mirrors the docker-exec psql
+pattern from cleanup.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+CI_POSTGRES_CONTAINER = os.environ.get("CI_POSTGRES_CONTAINER", "engram-postgres-1")
+QDRANT_URL = os.environ.get("QDRANT_URL", "http://10.0.20.201:6333")
+QDRANT_COLLECTION = os.environ.get("QDRANT_COLLECTION", "ci_test_notes")
+
+
+def _psql(sql: str, *, fetch: bool = False) -> str:
+    """Run SQL via docker exec psql. Returns stdout (or raises on error)."""
+    args = ["-v", "ON_ERROR_STOP=1"]
+    if fetch:
+        args += ["-t", "-A", "-F", "|"]  # tuples-only, unaligned, pipe-separated
+    cmd = ["docker", "exec", "-i", CI_POSTGRES_CONTAINER, "psql", "-U", "engram", "-d", "engram", *args]
+    result = subprocess.run(cmd, input=sql, capture_output=True, text=True, timeout=15)
+    if result.returncode != 0:
+        raise RuntimeError(f"psql failed: {result.stderr.strip()}\nSQL: {sql!r}")
+    return result.stdout.strip()
+
+
+def _fetch_note_row(vault_id: int, path: str) -> dict:
+    """SELECT the encryption columns for a note. Returns dict or raises AssertionError
+    if the note doesn't exist."""
+    safe_path = path.replace("'", "''")
+    sql = (
+        f"SELECT content, title, content_ciphertext IS NOT NULL, content_nonce IS NOT NULL, "
+        f"title_ciphertext IS NOT NULL, title_nonce IS NOT NULL, tags_ciphertext IS NOT NULL "
+        f"FROM notes WHERE vault_id = {int(vault_id)} AND path = '{safe_path}';"
+    )
+    out = _psql(sql, fetch=True)
+    assert out, f"Note not found in DB: vault_id={vault_id} path={path!r}"
+    line = out.splitlines()[0]
+    content, title, c_ct, c_n, t_ct, t_n, tag_ct = line.split("|")
+    return {
+        "content": content,
+        "content_is_null": content == "",
+        "title": title,
+        "title_is_null": title == "",
+        "content_ciphertext_present": c_ct == "t",
+        "content_nonce_present": c_n == "t",
+        "title_ciphertext_present": t_ct == "t",
+        "title_nonce_present": t_n == "t",
+        "tags_ciphertext_present": tag_ct == "t",
+    }
+
+
+def assert_note_ciphertext_at_rest(vault_id: int, path: str) -> None:
+    """Assert the note at (vault_id, path) is stored as ciphertext."""
+    row = _fetch_note_row(vault_id, path)
+    failures = []
+    if not row["content_is_null"]:
+        failures.append(f"content is not NULL (got: {row['content'][:60]!r})")
+    if not row["title_is_null"]:
+        failures.append(f"title is not NULL (got: {row['title'][:60]!r})")
+    if not row["content_ciphertext_present"]:
+        failures.append("content_ciphertext is NULL")
+    if not row["content_nonce_present"]:
+        failures.append("content_nonce is NULL")
+    if not row["title_ciphertext_present"]:
+        failures.append("title_ciphertext is NULL")
+    if not row["title_nonce_present"]:
+        failures.append("title_nonce is NULL")
+    assert not failures, (
+        f"Expected ciphertext at rest for vault_id={vault_id} path={path!r}; "
+        f"failures: {failures}"
+    )
+
+
+def assert_note_plaintext_at_rest(vault_id: int, path: str) -> None:
+    """Inverse. Content column populated, ciphertext columns NULL."""
+    row = _fetch_note_row(vault_id, path)
+    failures = []
+    if row["content_is_null"]:
+        failures.append("content is NULL (expected plaintext)")
+    if row["content_ciphertext_present"]:
+        failures.append("content_ciphertext is set (expected NULL)")
+    if row["content_nonce_present"]:
+        failures.append("content_nonce is set (expected NULL)")
+    if row["title_ciphertext_present"]:
+        failures.append("title_ciphertext is set (expected NULL)")
+    if row["title_nonce_present"]:
+        failures.append("title_nonce is set (expected NULL)")
+    assert not failures, (
+        f"Expected plaintext at rest for vault_id={vault_id} path={path!r}; "
+        f"failures: {failures}"
+    )

--- a/e2e/helpers/crypto_probe.py
+++ b/e2e/helpers/crypto_probe.py
@@ -40,7 +40,7 @@ def _fetch_note_row(vault_id: int, path: str) -> dict:
     if the note doesn't exist."""
     sql = (
         f"\\set target_path '{path}'\n"
-        f"SELECT content IS NULL, title IS NULL, "
+        f"SELECT (content IS NULL OR content = ''), (title IS NULL OR title = ''), "
         f"content_ciphertext IS NOT NULL, content_nonce IS NOT NULL, "
         f"title_ciphertext IS NOT NULL, title_nonce IS NOT NULL, tags_ciphertext IS NOT NULL "
         f"FROM notes WHERE vault_id = {int(vault_id)} AND path = :'target_path';"
@@ -48,10 +48,10 @@ def _fetch_note_row(vault_id: int, path: str) -> dict:
     out = _psql(sql, fetch=True)
     assert out, f"Note not found in DB: vault_id={vault_id} path={path!r}"
     line = out.splitlines()[0]
-    c_null, t_null, c_ct, c_n, t_ct, t_n, tag_ct = line.split("|")
+    c_cleared, t_cleared, c_ct, c_n, t_ct, t_n, tag_ct = line.split("|")
     return {
-        "content_is_null": c_null == "t",
-        "title_is_null": t_null == "t",
+        "content_cleared": c_cleared == "t",
+        "title_cleared": t_cleared == "t",
         "content_ciphertext_present": c_ct == "t",
         "content_nonce_present": c_n == "t",
         "title_ciphertext_present": t_ct == "t",
@@ -64,10 +64,10 @@ def assert_note_ciphertext_at_rest(vault_id: int, path: str) -> None:
     """Assert the note at (vault_id, path) is stored as ciphertext."""
     row = _fetch_note_row(vault_id, path)
     failures = []
-    if not row["content_is_null"]:
-        failures.append("content is not NULL")
-    if not row["title_is_null"]:
-        failures.append("title is not NULL")
+    if not row["content_cleared"]:
+        failures.append("content is not cleared (not NULL and not empty)")
+    if not row["title_cleared"]:
+        failures.append("title is not cleared (not NULL and not empty)")
     if not row["content_ciphertext_present"]:
         failures.append("content_ciphertext is NULL")
     if not row["content_nonce_present"]:
@@ -86,8 +86,8 @@ def assert_note_plaintext_at_rest(vault_id: int, path: str) -> None:
     """Inverse. Content column populated, ciphertext columns NULL."""
     row = _fetch_note_row(vault_id, path)
     failures = []
-    if row["content_is_null"]:
-        failures.append("content is NULL (expected plaintext)")
+    if row["content_cleared"]:
+        failures.append("content is cleared (NULL or empty — expected plaintext)")
     if row["content_ciphertext_present"]:
         failures.append("content_ciphertext is set (expected NULL)")
     if row["content_nonce_present"]:

--- a/e2e/helpers/crypto_probe.py
+++ b/e2e/helpers/crypto_probe.py
@@ -37,21 +37,20 @@ def _psql(sql: str, *, fetch: bool = False) -> str:
 def _fetch_note_row(vault_id: int, path: str) -> dict:
     """SELECT the encryption columns for a note. Returns dict or raises AssertionError
     if the note doesn't exist."""
-    safe_path = path.replace("'", "''")
     sql = (
-        f"SELECT content, title, content_ciphertext IS NOT NULL, content_nonce IS NOT NULL, "
+        f"\\set target_path '{path}'\n"
+        f"SELECT content IS NULL, title IS NULL, "
+        f"content_ciphertext IS NOT NULL, content_nonce IS NOT NULL, "
         f"title_ciphertext IS NOT NULL, title_nonce IS NOT NULL, tags_ciphertext IS NOT NULL "
-        f"FROM notes WHERE vault_id = {int(vault_id)} AND path = '{safe_path}';"
+        f"FROM notes WHERE vault_id = {int(vault_id)} AND path = :'target_path';"
     )
     out = _psql(sql, fetch=True)
     assert out, f"Note not found in DB: vault_id={vault_id} path={path!r}"
     line = out.splitlines()[0]
-    content, title, c_ct, c_n, t_ct, t_n, tag_ct = line.split("|")
+    c_null, t_null, c_ct, c_n, t_ct, t_n, tag_ct = line.split("|")
     return {
-        "content": content,
-        "content_is_null": content == "",
-        "title": title,
-        "title_is_null": title == "",
+        "content_is_null": c_null == "t",
+        "title_is_null": t_null == "t",
         "content_ciphertext_present": c_ct == "t",
         "content_nonce_present": c_n == "t",
         "title_ciphertext_present": t_ct == "t",
@@ -65,9 +64,9 @@ def assert_note_ciphertext_at_rest(vault_id: int, path: str) -> None:
     row = _fetch_note_row(vault_id, path)
     failures = []
     if not row["content_is_null"]:
-        failures.append(f"content is not NULL (got: {row['content'][:60]!r})")
+        failures.append("content is not NULL")
     if not row["title_is_null"]:
-        failures.append(f"title is not NULL (got: {row['title'][:60]!r})")
+        failures.append("title is not NULL")
     if not row["content_ciphertext_present"]:
         failures.append("content_ciphertext is NULL")
     if not row["content_nonce_present"]:

--- a/e2e/helpers/crypto_probe.py
+++ b/e2e/helpers/crypto_probe.py
@@ -171,6 +171,56 @@ def _looks_base64(s: str) -> bool:
     return bool(re.fullmatch(r"[A-Za-z0-9+/=]+", s))
 
 
+def wait_for_encryption_status(
+    api_client, vault_id: int, target: str, *, timeout: float = 60.0
+) -> dict:
+    """Poll GET /api/vaults/:id/encryption_progress every 1s until
+    status == target. Returns last response body. Raises TimeoutError otherwise.
+
+    `api_client` must be an authenticated ApiClient (api_sync or vault-scoped)."""
+    api_url = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+    deadline = time.monotonic() + timeout
+    last_body = None
+    while time.monotonic() < deadline:
+        resp = api_client.session.get(
+            f"{api_url}/vaults/{vault_id}/encryption_progress",
+            timeout=5,
+        )
+        if resp.ok:
+            last_body = resp.json()
+            if last_body.get("status") == target:
+                return last_body
+        time.sleep(1)
+    raise TimeoutError(
+        f"Vault {vault_id} never reached encryption_status={target!r} within {timeout}s; "
+        f"last body: {last_body!r}"
+    )
+
+
+def backdate_last_toggle(vault_id: int, *, days: int) -> None:
+    """Shift vaults.last_toggle_at into the past so cooldown check passes.
+    Used between encrypt and decrypt steps in a single test run."""
+    sql = (
+        f"UPDATE vaults SET last_toggle_at = last_toggle_at - interval '{int(days)} days' "
+        f"WHERE id = {int(vault_id)};"
+    )
+    _psql(sql)
+
+
+def backdate_decrypt_requested(vault_id: int, *, hours: int) -> None:
+    """Shift decrypt_requested_at AND the scheduled Oban DecryptVault job's
+    scheduled_at into the past so the scheduler picks it up immediately."""
+    sql = (
+        f"UPDATE vaults SET decrypt_requested_at = decrypt_requested_at - interval '{int(hours)} hours' "
+        f"WHERE id = {int(vault_id)}; "
+        f"UPDATE oban_jobs SET scheduled_at = scheduled_at - interval '{int(hours)} hours' "
+        f"WHERE worker = 'Engram.Workers.DecryptVault' "
+        f"AND (args->>'vault_id')::int = {int(vault_id)} "
+        f"AND state = 'scheduled';"
+    )
+    _psql(sql)
+
+
 def wait_for_qdrant_indexed(vault_id: int, path: str, timeout: float = 30.0) -> None:
     """Poll Qdrant for a point whose source_path matches `path`. Raises TimeoutError
     on timeout. Needed before probing Qdrant ciphertext in tests because the embed

--- a/e2e/helpers/crypto_probe.py
+++ b/e2e/helpers/crypto_probe.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 import time
 
@@ -98,4 +99,105 @@ def assert_note_plaintext_at_rest(vault_id: int, path: str) -> None:
     assert not failures, (
         f"Expected plaintext at rest for vault_id={vault_id} path={path!r}; "
         f"failures: {failures}"
+    )
+
+
+def _qdrant_scroll(vault_id: int, limit: int = 100) -> list[dict]:
+    """POST /collections/{coll}/points/scroll with a vault_id filter."""
+    resp = requests.post(
+        f"{QDRANT_URL}/collections/{QDRANT_COLLECTION}/points/scroll",
+        json={
+            "filter": {"must": [{"key": "vault_id", "match": {"value": int(vault_id)}}]},
+            "limit": limit,
+            "with_payload": True,
+            "with_vector": False,
+        },
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()["result"]["points"]
+
+
+def assert_qdrant_ciphertext(vault_id: int, min_chunks: int = 1) -> None:
+    """Assert Qdrant payload for this vault contains ciphertext, not plaintext.
+    Phase 4 spec: when a vault is encrypted, text/title/heading_path are
+    replaced with *_ciphertext + *_nonce. Plaintext keys are absent."""
+    points = _qdrant_scroll(vault_id)
+    assert len(points) >= min_chunks, (
+        f"Expected >= {min_chunks} Qdrant points for vault_id={vault_id}, got {len(points)}"
+    )
+    failures = []
+    for i, p in enumerate(points[:min_chunks]):
+        payload = p.get("payload", {})
+        if "text_nonce" not in payload:
+            failures.append(f"point[{i}] payload missing 'text_nonce'; keys: {sorted(payload.keys())}")
+        if "title_nonce" not in payload:
+            failures.append(f"point[{i}] payload missing 'title_nonce'")
+        if "heading_path_nonce" not in payload:
+            failures.append(f"point[{i}] payload missing 'heading_path_nonce'")
+        text_val = payload.get("text", "")
+        if text_val and not _looks_base64(text_val):
+            failures.append(f"point[{i}] 'text' looks like plaintext: {text_val[:80]!r}")
+    assert not failures, (
+        f"Expected Qdrant ciphertext for vault_id={vault_id}; failures: {failures}"
+    )
+
+
+def assert_qdrant_plaintext(vault_id: int, min_chunks: int = 1) -> None:
+    """Inverse — no *_nonce keys, plaintext text present."""
+    points = _qdrant_scroll(vault_id)
+    assert len(points) >= min_chunks, (
+        f"Expected >= {min_chunks} Qdrant points for vault_id={vault_id}, got {len(points)}"
+    )
+    failures = []
+    for i, p in enumerate(points[:min_chunks]):
+        payload = p.get("payload", {})
+        for nonce_key in ("text_nonce", "title_nonce", "heading_path_nonce"):
+            if nonce_key in payload:
+                failures.append(f"point[{i}] payload has {nonce_key!r} (expected plaintext)")
+        if not payload.get("text"):
+            failures.append(f"point[{i}] payload missing 'text'")
+    assert not failures, (
+        f"Expected Qdrant plaintext for vault_id={vault_id}; failures: {failures}"
+    )
+
+
+def _looks_base64(s: str) -> bool:
+    """Base64 heuristic: only [A-Za-z0-9+/=], length multiple of 4, no spaces."""
+    if " " in s or "\n" in s:
+        return False
+    if len(s) % 4 != 0:
+        return False
+    return bool(re.fullmatch(r"[A-Za-z0-9+/=]+", s))
+
+
+def wait_for_qdrant_indexed(vault_id: int, path: str, timeout: float = 30.0) -> None:
+    """Poll Qdrant for a point whose source_path matches `path`. Raises TimeoutError
+    on timeout. Needed before probing Qdrant ciphertext in tests because the embed
+    worker is async."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.post(
+                f"{QDRANT_URL}/collections/{QDRANT_COLLECTION}/points/scroll",
+                json={
+                    "filter": {
+                        "must": [
+                            {"key": "vault_id", "match": {"value": int(vault_id)}},
+                            {"key": "source_path", "match": {"value": path}},
+                        ]
+                    },
+                    "limit": 1,
+                    "with_payload": False,
+                    "with_vector": False,
+                },
+                timeout=5,
+            )
+            if resp.ok and resp.json()["result"]["points"]:
+                return
+        except (requests.ConnectionError, requests.Timeout, KeyError):
+            pass
+        time.sleep(1)
+    raise TimeoutError(
+        f"Qdrant never indexed vault_id={vault_id} path={path!r} within {timeout}s"
     )

--- a/e2e/tests/api_only/test_62_encrypted_vault.py
+++ b/e2e/tests/api_only/test_62_encrypted_vault.py
@@ -58,6 +58,10 @@ def reset_vault_encryption(api_sync):
         api_sync.session.post(f"{API_URL}/vaults/{vault_id}/decrypt", timeout=10)
         backdate_decrypt_requested(vault_id, hours=25)
         wait_for_encryption_status(api_sync, vault_id, "none", timeout=60)
+        # Leave the vault ready for any subsequent test (or rerun) — the
+        # POST /decrypt above reset last_toggle_at to 'now', so backdate it
+        # again.
+        backdate_last_toggle(vault_id, days=8)
 
 
 class TestEncryptedVaultRoundTrip:

--- a/e2e/tests/api_only/test_62_encrypted_vault.py
+++ b/e2e/tests/api_only/test_62_encrypted_vault.py
@@ -1,104 +1,107 @@
-"""Test 62: Encrypted vault round-trip via HTTP API.
+"""Test 62: Encrypted vault round-trip via HTTP API with at-rest probes.
 
-Registers a vault, enables encryption directly in the DB (the vault
-changeset does not cast `encrypted` yet — the toggle UI is a future
-phase), writes a note, reads it back, asserts the API returns plaintext.
+Registers a vault, enables encryption via the real toggle endpoint
+(POST /api/vaults/:id/encrypt), writes a note through the HTTP API,
+reads it back as plaintext, and directly probes Postgres + Qdrant
+to prove the note is ciphertext at rest.
 
-This is the acceptance test for end-to-end encryption across a real HTTP
-boundary. It runs in the api_only CI job (no Obsidian, no Clerk needed).
+This is the acceptance test for end-to-end encryption across a real
+HTTP boundary. It runs in the api_only CI job (no Obsidian, no Clerk).
 
-Design note: we cannot set encrypted=true through the public API today
-because Vault.changeset/2 only casts a restricted field list. Until the
-encryption-toggle endpoint ships we patch the DB row directly via psql,
-mirroring the same docker-exec pattern used in cleanup.py.
+Teardown is non-trivial: cooldown + 24h decrypt delay are normally
+enforced, so the `reset_vault_encryption` fixture uses SQL time-travel
+(same docker-exec pattern) to bypass them and restore the vault to
+'none' status before the next test touches it.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import subprocess
 import time
 
 import pytest
-import requests
+
+from helpers.crypto_probe import (
+    assert_note_ciphertext_at_rest,
+    assert_qdrant_ciphertext,
+    backdate_decrypt_requested,
+    backdate_last_toggle,
+    wait_for_encryption_status,
+    wait_for_qdrant_indexed,
+)
 
 API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
-CI_POSTGRES_CONTAINER = os.environ.get("CI_POSTGRES_CONTAINER", "engram-postgres-1")
 
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# DB helpers
-# ---------------------------------------------------------------------------
-
-
-def _enable_vault_encryption(vault_id: int) -> None:
-    """Flip vaults.encrypted = true for a specific vault ID via psql.
-
-    Uses the same docker-exec pattern as cleanup.py. Safe: vault_id is an
-    integer supplied by the test, never from user input.
-    """
-    sql = f"UPDATE vaults SET encrypted = true WHERE id = {int(vault_id)};\n"
-    cmd = [
-        "docker", "exec", "-i", CI_POSTGRES_CONTAINER,
-        "psql", "-U", "engram", "-d", "engram",
-    ]
-    result = subprocess.run(cmd, input=sql, capture_output=True, text=True, timeout=15)
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        if "No such container" in stderr:
-            pytest.skip(f"CI postgres container {CI_POSTGRES_CONTAINER!r} not found — skipping encrypted-vault E2E")
-        raise RuntimeError(f"psql update failed: {stderr}")
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
+@pytest.fixture
+def reset_vault_encryption(api_sync):
+    """Teardown — put the shared vault back to 'none' status via real decrypt flow,
+    bypassing cooldown and the 24h delay with SQL time-travel."""
+    yield
+    vaults = api_sync.list_vaults()
+    if not vaults:
+        return
+    vault_id = vaults[0]["id"]
+    resp = api_sync.session.get(
+        f"{API_URL}/vaults/{vault_id}/encryption_progress", timeout=5
+    )
+    if not resp.ok:
+        return
+    status = resp.json().get("status")
+    if status in ("encrypted", "encrypting"):
+        if status == "encrypting":
+            wait_for_encryption_status(api_sync, vault_id, "encrypted", timeout=60)
+        backdate_last_toggle(vault_id, days=8)
+        api_sync.session.post(f"{API_URL}/vaults/{vault_id}/decrypt", timeout=10)
+        backdate_decrypt_requested(vault_id, hours=25)
+        wait_for_encryption_status(api_sync, vault_id, "none", timeout=60)
 
 
 class TestEncryptedVaultRoundTrip:
-    """Write and read a note from an encrypted vault via HTTP."""
+    """Write and read a note from an encrypted vault via HTTP, with at-rest probes."""
 
-    def test_encrypted_vault_round_trip(self, api_sync):
-        """Plaintext written to an encrypted vault is returned as plaintext on read."""
-        # 1. Use the vault api_sync already registered (free tier = 1 vault/user).
-        #    The /vaults list endpoint returns {id, name, slug, ...} — no client_id —
-        #    so we take the first (and only) entry rather than matching by client_id.
+    def test_encrypted_vault_round_trip(self, api_sync, reset_vault_encryption):
+        """Plaintext written to an encrypted vault is ciphertext at rest but
+        transparent plaintext over the wire."""
         vaults = api_sync.list_vaults()
         assert vaults, f"api_sync should have pre-registered a vault; got {vaults}"
         vault_id = vaults[0]["id"]
-
-        # 2. Enable encryption at the DB level (toggle endpoint is a future phase)
-        _enable_vault_encryption(vault_id)
-
-        # 3. Build an ApiClient that sends X-Vault-ID so vault-scoped endpoints resolve
         vault_client = api_sync.with_vault(vault_id)
 
+        # 1. Toggle encryption via real endpoint
+        resp = vault_client.session.post(
+            f"{API_URL}/vaults/{vault_id}/encrypt", timeout=10
+        )
+        assert resp.status_code == 202, (
+            f"encrypt failed: {resp.status_code} {resp.text[:300]}"
+        )
+
+        # 2. Wait for backfill to finish (empty vault — should be near-instant)
+        wait_for_encryption_status(vault_client, vault_id, "encrypted", timeout=30)
+
+        # 3. Write note
         plaintext = "secret diary entry — only plaintext should come back"
         note_path = "journal/today.md"
+        resp = vault_client.session.post(
+            f"{API_URL}/notes",
+            json={"path": note_path, "content": plaintext, "mtime": time.time()},
+            timeout=10,
+        )
+        assert resp.ok, f"upsert_note failed: {resp.status_code} {resp.text[:300]}"
 
-        try:
-            # 4. Upsert note
-            resp = vault_client.session.post(
-                f"{API_URL}/notes",
-                json={"path": note_path, "content": plaintext, "mtime": time.time()},
-                timeout=10,
-            )
-            assert resp.ok, f"upsert_note failed: {resp.status_code} {resp.text[:300]}"
+        # 4. Read back — transparent decrypt returns plaintext
+        note = vault_client.get_note(note_path)
+        assert note is not None, f"Note not found after upsert: {note_path}"
+        assert note["content"] == plaintext, (
+            f"Expected plaintext content, got: {note['content'][:100]!r}"
+        )
 
-            # 5. Read back — must return decrypted plaintext
-            note = vault_client.get_note(note_path)
-            assert note is not None, f"Note not found after upsert: {note_path}"
-            assert note["content"] == plaintext, (
-                f"Expected plaintext content, got: {note['content'][:100]!r}"
-            )
-        finally:
-            # Teardown: disable encryption so subsequent tests using this vault aren't affected
-            sql = f"UPDATE vaults SET encrypted = false WHERE id = {int(vault_id)};\n"
-            cmd = [
-                "docker", "exec", "-i", CI_POSTGRES_CONTAINER,
-                "psql", "-U", "engram", "-d", "engram",
-            ]
-            subprocess.run(cmd, input=sql, capture_output=True, text=True, timeout=15)
+        # 5. PROBE: at-rest ciphertext in Postgres
+        assert_note_ciphertext_at_rest(vault_id, note_path)
+
+        # 6. PROBE: at-rest ciphertext in Qdrant (after embed worker)
+        wait_for_qdrant_indexed(vault_id, note_path, timeout=30)
+        assert_qdrant_ciphertext(vault_id, min_chunks=1)

--- a/e2e/tests/api_only/test_62_encrypted_vault.py
+++ b/e2e/tests/api_only/test_62_encrypted_vault.py
@@ -107,5 +107,5 @@ class TestEncryptedVaultRoundTrip:
         assert_note_ciphertext_at_rest(vault_id, note_path)
 
         # 6. PROBE: at-rest ciphertext in Qdrant (after embed worker)
-        wait_for_qdrant_indexed(vault_id, note_path, timeout=30)
+        wait_for_qdrant_indexed(vault_id, note_path, timeout=60)
         assert_qdrant_ciphertext(vault_id, min_chunks=1)

--- a/e2e/tests/api_only/test_64_vault_toggle_backfill.py
+++ b/e2e/tests/api_only/test_64_vault_toggle_backfill.py
@@ -14,8 +14,6 @@ import logging
 import os
 import time
 
-import pytest
-
 from helpers.crypto_probe import (
     assert_note_ciphertext_at_rest,
     assert_note_plaintext_at_rest,
@@ -40,6 +38,9 @@ class TestVaultToggleBackfill:
         assert vaults
         vault_id = vaults[0]["id"]
         vault_client = api_sync.with_vault(vault_id)
+
+        # Starting-state guard — fail fast if a prior test left the vault encrypted
+        wait_for_encryption_status(vault_client, vault_id, "none", timeout=5)
 
         notes = [
             ("meeting-notes.md", "Meeting with Alice about Q2 roadmap"),

--- a/e2e/tests/api_only/test_64_vault_toggle_backfill.py
+++ b/e2e/tests/api_only/test_64_vault_toggle_backfill.py
@@ -1,0 +1,104 @@
+"""Test 64: Full vault toggle backfill cycle via HTTP API.
+
+Writes 3 plaintext notes → toggles encryption ON → backfill converts all
+to ciphertext (probed directly in Postgres + Qdrant) → time-travels past
+cooldown + 24h delay → toggles encryption OFF → backfill converts all
+back to plaintext.
+
+Proves the toggle endpoint + Oban backfill worker + decrypt worker end to end.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import pytest
+
+from helpers.crypto_probe import (
+    assert_note_ciphertext_at_rest,
+    assert_note_plaintext_at_rest,
+    assert_qdrant_ciphertext,
+    assert_qdrant_plaintext,
+    backdate_decrypt_requested,
+    backdate_last_toggle,
+    wait_for_encryption_status,
+    wait_for_qdrant_indexed,
+)
+
+API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+
+logger = logging.getLogger(__name__)
+
+
+class TestVaultToggleBackfill:
+    """Toggle encrypt + backfill + decrypt cycle with pre-existing plaintext notes."""
+
+    def test_toggle_backfill_full_cycle(self, api_sync):
+        vaults = api_sync.list_vaults()
+        assert vaults
+        vault_id = vaults[0]["id"]
+        vault_client = api_sync.with_vault(vault_id)
+
+        notes = [
+            ("meeting-notes.md", "Meeting with Alice about Q2 roadmap"),
+            ("ideas.md", "Idea: a search engine that forgets"),
+            ("journal/2026-04-22.md", "Today I learned about envelope encryption"),
+        ]
+
+        # 1. Push 3 plaintext notes
+        for path, content in notes:
+            resp = vault_client.session.post(
+                f"{API_URL}/notes",
+                json={"path": path, "content": content, "mtime": time.time()},
+                timeout=10,
+            )
+            assert resp.ok, f"push failed for {path}: {resp.status_code} {resp.text[:300]}"
+
+        # 2. Baseline — plaintext at rest (DB + Qdrant)
+        for path, _ in notes:
+            assert_note_plaintext_at_rest(vault_id, path)
+        for path, _ in notes:
+            wait_for_qdrant_indexed(vault_id, path, timeout=30)
+        assert_qdrant_plaintext(vault_id, min_chunks=len(notes))
+
+        # 3. Toggle encrypt
+        resp = vault_client.session.post(
+            f"{API_URL}/vaults/{vault_id}/encrypt", timeout=10
+        )
+        assert resp.status_code == 202
+        wait_for_encryption_status(vault_client, vault_id, "encrypted", timeout=90)
+
+        # 4. All notes ciphertext at rest, but plaintext over the wire
+        for path, content in notes:
+            assert_note_ciphertext_at_rest(vault_id, path)
+            got = vault_client.get_note(path)
+            assert got is not None and got["content"] == content, (
+                f"Post-encrypt read mismatch for {path}: {got!r}"
+            )
+        assert_qdrant_ciphertext(vault_id, min_chunks=len(notes))
+
+        # 5. Time-travel past 7-day cooldown
+        backdate_last_toggle(vault_id, days=8)
+
+        # 6. Request decrypt
+        resp = vault_client.session.post(
+            f"{API_URL}/vaults/{vault_id}/decrypt", timeout=10
+        )
+        assert resp.status_code == 202, (
+            f"decrypt request failed: {resp.status_code} {resp.text[:300]}"
+        )
+
+        # 7. Time-travel past 24h delay (both vault row + scheduled Oban job)
+        backdate_decrypt_requested(vault_id, hours=25)
+
+        # 8. Wait for scheduler pickup + decrypt backfill
+        wait_for_encryption_status(vault_client, vault_id, "none", timeout=90)
+
+        # 9. All notes plaintext at rest
+        for path, content in notes:
+            assert_note_plaintext_at_rest(vault_id, path)
+            got = vault_client.get_note(path)
+            assert got is not None and got["content"] == content
+        assert_qdrant_plaintext(vault_id, min_chunks=len(notes))

--- a/e2e/tests/api_only/test_64_vault_toggle_backfill.py
+++ b/e2e/tests/api_only/test_64_vault_toggle_backfill.py
@@ -61,7 +61,7 @@ class TestVaultToggleBackfill:
         for path, _ in notes:
             assert_note_plaintext_at_rest(vault_id, path)
         for path, _ in notes:
-            wait_for_qdrant_indexed(vault_id, path, timeout=30)
+            wait_for_qdrant_indexed(vault_id, path, timeout=60)
         assert_qdrant_plaintext(vault_id, min_chunks=len(notes))
 
         # 3. Toggle encrypt

--- a/e2e/tests/test_63_encrypted_sync_obsidian.py
+++ b/e2e/tests/test_63_encrypted_sync_obsidian.py
@@ -51,6 +51,10 @@ def reset_vault_encryption(api_sync):
         api_sync.session.post(f"{API_URL}/vaults/{vault_id}/decrypt", timeout=10)
         backdate_decrypt_requested(vault_id, hours=25)
         wait_for_encryption_status(api_sync, vault_id, "none", timeout=60)
+        # Leave the vault ready for any subsequent test (or rerun) — the
+        # POST /decrypt above reset last_toggle_at to 'now', so backdate it
+        # again.
+        backdate_last_toggle(vault_id, days=8)
 
 
 @pytest.mark.asyncio

--- a/e2e/tests/test_63_encrypted_sync_obsidian.py
+++ b/e2e/tests/test_63_encrypted_sync_obsidian.py
@@ -91,7 +91,7 @@ async def test_encrypted_sync_obsidian(
     assert_note_ciphertext_at_rest(vault_id, path)
 
     # 5. PROBE: ciphertext in Qdrant (after embed worker)
-    wait_for_qdrant_indexed(vault_id, path, timeout=30)
+    wait_for_qdrant_indexed(vault_id, path, timeout=60)
     assert_qdrant_ciphertext(vault_id, min_chunks=1)
 
     # 6. B pulls via full sync

--- a/e2e/tests/test_63_encrypted_sync_obsidian.py
+++ b/e2e/tests/test_63_encrypted_sync_obsidian.py
@@ -1,0 +1,99 @@
+"""Test 63: Obsidian plugin round-trip across an encrypted vault.
+
+Vault A and B share one user/vault. Encryption is toggled on via the real
+endpoint. A writes a file via filesystem → plugin watcher pushes to backend
+→ DB + Qdrant probed for ciphertext at rest → B pulls → plaintext on disk.
+
+Proves full plugin → HTTP → Postgres + Qdrant → HTTP → plugin chain with
+encryption on.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from helpers.crypto_probe import (
+    assert_note_ciphertext_at_rest,
+    assert_qdrant_ciphertext,
+    backdate_decrypt_requested,
+    backdate_last_toggle,
+    wait_for_encryption_status,
+    wait_for_qdrant_indexed,
+)
+from helpers.vault import read_note, write_note
+
+API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def reset_vault_encryption(api_sync):
+    """Teardown — put the vault back to 'none' state via real decrypt flow."""
+    yield
+    vaults = api_sync.list_vaults()
+    if not vaults:
+        return
+    vault_id = vaults[0]["id"]
+    resp = api_sync.session.get(
+        f"{API_URL}/vaults/{vault_id}/encryption_progress", timeout=5
+    )
+    if not resp.ok:
+        return
+    status = resp.json().get("status")
+    if status in ("encrypted", "encrypting"):
+        if status == "encrypting":
+            wait_for_encryption_status(api_sync, vault_id, "encrypted", timeout=60)
+        backdate_last_toggle(vault_id, days=8)
+        api_sync.session.post(f"{API_URL}/vaults/{vault_id}/decrypt", timeout=10)
+        backdate_decrypt_requested(vault_id, hours=25)
+        wait_for_encryption_status(api_sync, vault_id, "none", timeout=60)
+
+
+@pytest.mark.asyncio
+async def test_encrypted_sync_obsidian(
+    vault_a, vault_b, cdp_a, cdp_b, api_sync, reset_vault_encryption
+):
+    """Plugin A pushes to encrypted vault; ciphertext at rest; plugin B pulls plaintext."""
+    vaults = api_sync.list_vaults()
+    assert vaults
+    vault_id = vaults[0]["id"]
+    vault_client = api_sync.with_vault(vault_id)
+
+    # Starting-state guard — a prior test may have left the vault in an unexpected state
+    wait_for_encryption_status(vault_client, vault_id, "none", timeout=5)
+
+    # 1. Enable encryption (empty vault — backfill near-instant)
+    resp = vault_client.session.post(
+        f"{API_URL}/vaults/{vault_id}/encrypt", timeout=10
+    )
+    assert resp.status_code == 202, f"encrypt failed: {resp.status_code} {resp.text[:300]}"
+    wait_for_encryption_status(vault_client, vault_id, "encrypted", timeout=30)
+
+    # 2. A writes a file — plugin watcher picks it up
+    path = "E2E/EncryptedSyncE2E.md"
+    plaintext = "# Top Secret\nOnly cipher should appear at rest."
+    write_note(vault_a, path, plaintext)
+
+    # 3. Wait for plugin push → backend
+    note = api_sync.wait_for_note(path, timeout=15)
+    assert "Top Secret" in note["content"]
+    assert "Only cipher" in note["content"]
+
+    # 4. PROBE: ciphertext in Postgres
+    assert_note_ciphertext_at_rest(vault_id, path)
+
+    # 5. PROBE: ciphertext in Qdrant (after embed worker)
+    wait_for_qdrant_indexed(vault_id, path, timeout=30)
+    assert_qdrant_ciphertext(vault_id, min_chunks=1)
+
+    # 6. B pulls via full sync
+    await cdp_b.trigger_full_sync()
+
+    # 7. B's filesystem has plaintext
+    b_content = read_note(vault_b, path)
+    assert "Top Secret" in b_content, "B did not receive A's note as plaintext"
+    assert "Only cipher" in b_content

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -423,4 +423,27 @@ defmodule Engram.Crypto do
       {:error, reason} -> {:error, reason}
     end
   end
+
+  @spec cancel_decrypt_vault(Engram.Vaults.Vault.t(), Engram.Accounts.User.t()) ::
+          {:ok, Engram.Vaults.Vault.t()} | {:error, :bad_status}
+  def cancel_decrypt_vault(%Engram.Vaults.Vault{} = vault, %Engram.Accounts.User{} = user) do
+    Engram.Repo.with_tenant(user.id, fn ->
+      locked = Engram.Repo.get!(Engram.Vaults.Vault, vault.id, lock: "FOR UPDATE")
+
+      if locked.encryption_status != "decrypt_pending" do
+        Engram.Repo.rollback(:bad_status)
+      else
+        locked
+        |> Ecto.Changeset.change(%{
+          encryption_status: "encrypted",
+          decrypt_requested_at: nil
+        })
+        |> Engram.Repo.update!()
+      end
+    end)
+    |> case do
+      {:ok, vault} -> {:ok, vault}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 end

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -323,4 +323,54 @@ defmodule Engram.Crypto do
   defp safe_decode64(nil), do: :error
   defp safe_decode64(s) when is_binary(s), do: Base.decode64(s)
   defp safe_decode64(_), do: :error
+
+  @cooldown_days 7
+
+  @spec encrypt_vault(Engram.Vaults.Vault.t(), Engram.Accounts.User.t()) ::
+          {:ok, Engram.Vaults.Vault.t()} | {:error, :cooldown | :bad_status | term()}
+  def encrypt_vault(%Engram.Vaults.Vault{} = vault, %Engram.Accounts.User{} = user) do
+    Engram.Repo.with_tenant(user.id, fn ->
+      locked = Engram.Repo.get!(Engram.Vaults.Vault, vault.id, lock: "FOR UPDATE")
+
+      cond do
+        locked.encryption_status != "none" ->
+          Engram.Repo.rollback(:bad_status)
+
+        cooldown_active?(locked) ->
+          Engram.Repo.rollback(:cooldown)
+
+        true ->
+          now = DateTime.utc_now()
+
+          updated =
+            locked
+            |> Ecto.Changeset.change(%{
+              encrypted: true,
+              encryption_status: "encrypting",
+              last_toggle_at: now
+            })
+            |> Engram.Repo.update!()
+
+          {:ok, _} =
+            Engram.Workers.EncryptVault.new(%{
+              vault_id: vault.id,
+              user_id: user.id,
+              cursor: 0
+            })
+            |> Oban.insert()
+
+          updated
+      end
+    end)
+    |> case do
+      {:ok, vault} -> {:ok, vault}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp cooldown_active?(%Engram.Vaults.Vault{last_toggle_at: nil}), do: false
+
+  defp cooldown_active?(%Engram.Vaults.Vault{last_toggle_at: ts}) do
+    DateTime.diff(DateTime.utc_now(), ts, :day) < @cooldown_days
+  end
 end

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -373,4 +373,54 @@ defmodule Engram.Crypto do
   defp cooldown_active?(%Engram.Vaults.Vault{last_toggle_at: ts}) do
     DateTime.diff(DateTime.utc_now(), ts, :day) < @cooldown_days
   end
+
+  @decrypt_delay_hours 24
+
+  @spec request_decrypt_vault(Engram.Vaults.Vault.t(), Engram.Accounts.User.t()) ::
+          {:ok, Engram.Vaults.Vault.t()} | {:error, :cooldown | :bad_status | term()}
+  def request_decrypt_vault(%Engram.Vaults.Vault{} = vault, %Engram.Accounts.User{} = user) do
+    Engram.Repo.with_tenant(user.id, fn ->
+      locked = Engram.Repo.get!(Engram.Vaults.Vault, vault.id, lock: "FOR UPDATE")
+
+      cond do
+        locked.encryption_status != "encrypted" ->
+          Engram.Repo.rollback(:bad_status)
+
+        cooldown_active?(locked) ->
+          Engram.Repo.rollback(:cooldown)
+
+        true ->
+          now = DateTime.utc_now()
+          scheduled_at = DateTime.add(now, @decrypt_delay_hours, :hour)
+
+          updated =
+            locked
+            |> Ecto.Changeset.change(%{
+              encryption_status: "decrypt_pending",
+              decrypt_requested_at: now,
+              last_toggle_at: now
+            })
+            |> Engram.Repo.update!()
+
+          {:ok, _} =
+            Engram.Workers.DecryptVault.new(
+              %{vault_id: vault.id, user_id: user.id, cursor: 0},
+              scheduled_at: scheduled_at
+            )
+            |> Oban.insert()
+
+          :telemetry.execute(
+            [:engram, :crypto, :decrypt_requested],
+            %{},
+            %{vault_id: vault.id, user_id: user.id, scheduled_at: scheduled_at}
+          )
+
+          updated
+      end
+    end)
+    |> case do
+      {:ok, vault} -> {:ok, vault}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 end

--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -60,4 +60,19 @@ defmodule Engram.Notes.Note do
       changeset
     end
   end
+
+  def encryption_changeset(note, attrs) do
+    note
+    |> cast(attrs, [
+      :content,
+      :content_ciphertext,
+      :content_nonce,
+      :title,
+      :title_ciphertext,
+      :title_nonce,
+      :tags,
+      :tags_ciphertext,
+      :tags_nonce
+    ])
+  end
 end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -292,6 +292,50 @@ defmodule Engram.Vaults do
     end
   end
 
+  # ── Encryption progress ────────────────────────────────────────────────────
+
+  @doc """
+  Returns processed/total counts for encryption backfill progress.
+
+  - `total`: every note in the vault
+  - `processed`: notes whose `content_ciphertext` is present (encrypting path)
+    or inverse (decrypting path), based on the vault's current
+    `encryption_status`. For terminal states ("none", "encrypted") progress
+    is considered complete (`processed == total`).
+  """
+  @spec encryption_progress(Vault.t()) :: %{processed: non_neg_integer(), total: non_neg_integer()}
+  def encryption_progress(%Vault{} = vault) do
+    {:ok, counts} =
+      Repo.with_tenant(vault.user_id, fn ->
+        total =
+          Repo.one(
+            from(n in Engram.Notes.Note,
+              where: n.vault_id == ^vault.id,
+              select: count(n.id)
+            )
+          )
+
+        encrypted_count =
+          Repo.one(
+            from(n in Engram.Notes.Note,
+              where: n.vault_id == ^vault.id and not is_nil(n.content_ciphertext),
+              select: count(n.id)
+            )
+          )
+
+        %{total: total, encrypted: encrypted_count}
+      end)
+
+    processed =
+      case vault.encryption_status do
+        "encrypting" -> counts.encrypted
+        "decrypting" -> counts.total - counts.encrypted
+        _ -> counts.total
+      end
+
+    %{processed: processed, total: counts.total}
+  end
+
   # ── Private helpers ─────────────────────────────────────────────────────────
 
   defp count_vaults(user_id) do

--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -28,4 +28,14 @@ defmodule Engram.Vaults.Vault do
     |> unique_constraint([:user_id, :slug], name: :vaults_user_id_slug_index)
     |> unique_constraint([:user_id, :client_id], name: :vaults_user_id_client_id_index)
   end
+
+  @doc """
+  Updates only the `encryption_status` field of a vault. Used for state transitions
+  between "none", "encrypting", "encrypted", "decrypting".
+  """
+  def update_status(%__MODULE__{} = vault, status) when is_binary(status) do
+    vault
+    |> Ecto.Changeset.change(%{encryption_status: status})
+    |> Engram.Repo.update()
+  end
 end

--- a/lib/engram/workers/decrypt_vault.ex
+++ b/lib/engram/workers/decrypt_vault.ex
@@ -1,7 +1,161 @@
 defmodule Engram.Workers.DecryptVault do
-  @moduledoc "Oban worker: restore plaintext for a vault. Implemented in Task 9."
-  use Oban.Worker, queue: :crypto_backfill, max_attempts: 5
+  @moduledoc """
+  Restores plaintext for every note in a vault. Runs 24h after
+  request_decrypt_vault/2, unless cancelled. Same batch/cursor/idempotency
+  shape as EncryptVault. Order: Postgres decrypt first (so we have plaintext
+  in hand), then Qdrant re-index with plaintext payload.
+  """
+
+  use Oban.Worker,
+    queue: :crypto_backfill,
+    max_attempts: 5,
+    unique: [keys: [:vault_id], states: [:available, :scheduled, :executing]]
+
+  import Ecto.Query
+  require Logger
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Notes.Note
+  alias Engram.Repo
+  alias Engram.Vaults.Vault
+
+  @batch_size 100
 
   @impl Oban.Worker
-  def perform(%Oban.Job{}), do: :ok
+  def perform(%Oban.Job{args: %{"vault_id" => vault_id, "user_id" => user_id, "cursor" => cursor}}) do
+    Repo.with_tenant(user_id, fn ->
+      vault = Repo.get!(Vault, vault_id)
+      user = Repo.get!(User, user_id)
+
+      case vault.encryption_status do
+        "encrypted" ->
+          Logger.info("DecryptVault cancelled: vault #{vault_id} back to encrypted")
+          :ok
+
+        status when status in ["decrypt_pending", "decrypting"] ->
+          {:ok, vault} = ensure_decrypting(vault)
+          process_batch(vault, user, cursor)
+
+        other ->
+          Logger.error("DecryptVault impossible state: vault #{vault_id} status=#{other}")
+          {:error, :bad_status}
+      end
+    end)
+    |> case do
+      {:ok, result} -> result
+      other -> other
+    end
+  end
+
+  defp ensure_decrypting(%Vault{encryption_status: "decrypting"} = v), do: {:ok, v}
+
+  defp ensure_decrypting(vault) do
+    locked = Repo.get!(Vault, vault.id, lock: "FOR UPDATE")
+
+    updated =
+      locked
+      |> Ecto.Changeset.change(%{encryption_status: "decrypting"})
+      |> Repo.update!()
+
+    {:ok, updated}
+  end
+
+  defp process_batch(vault, user, cursor) do
+    notes =
+      from(n in Note,
+        where: n.vault_id == ^vault.id and n.id > ^cursor,
+        order_by: [asc: n.id],
+        limit: @batch_size
+      )
+      |> Repo.all()
+
+    case Enum.reduce_while(notes, {:ok, cursor}, &decrypt_note(&1, &2, user, vault)) do
+      {:ok, last_id} ->
+        if length(notes) == @batch_size do
+          {:ok, _} =
+            __MODULE__.new(%{
+              vault_id: vault.id,
+              user_id: user.id,
+              cursor: last_id
+            })
+            |> Oban.insert()
+
+          :ok
+        else
+          finalize_vault(vault)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp decrypt_note(%Note{} = note, {:ok, _last}, user, vault) do
+    with {:ok, plain_note} <- decrypt_postgres(note, user),
+         :ok <- reindex_plaintext(plain_note, vault) do
+      :telemetry.execute(
+        [:engram, :crypto, :backfill, :note_decrypted],
+        %{},
+        %{vault_id: vault.id, note_id: note.id}
+      )
+
+      {:cont, {:ok, note.id}}
+    else
+      error ->
+        Logger.error("DecryptVault failed note #{note.id}: #{inspect(error)}")
+        {:halt, error}
+    end
+  end
+
+  defp decrypt_postgres(%Note{} = note, user) do
+    with {:ok, decrypted} <- Crypto.maybe_decrypt_note_fields(note, user) do
+      note
+      |> Note.encryption_changeset(%{
+        content: decrypted.content,
+        title: decrypted.title,
+        tags: decrypted.tags,
+        content_ciphertext: nil,
+        content_nonce: nil,
+        title_ciphertext: nil,
+        title_nonce: nil,
+        tags_ciphertext: nil,
+        tags_nonce: nil
+      })
+      |> Repo.update()
+    end
+  end
+
+  defp reindex_plaintext(%Note{} = note, vault) do
+    # Re-index with vault.encrypted=false so the payload is plaintext.
+    plaintext_vault = %{vault | encrypted: false}
+
+    case Engram.Indexing.index_note(note, plaintext_vault) do
+      {:ok, _} -> :ok
+      :ok -> :ok
+      error -> error
+    end
+  end
+
+  defp finalize_vault(vault) do
+    locked = Repo.get!(Vault, vault.id, lock: "FOR UPDATE")
+
+    if locked.encryption_status == "decrypting" do
+      locked
+      |> Ecto.Changeset.change(%{
+        encrypted: false,
+        encryption_status: "none",
+        encrypted_at: nil
+      })
+      |> Repo.update!()
+    end
+
+    :telemetry.execute(
+      [:engram, :crypto, :backfill, :vault_decrypted],
+      %{},
+      %{vault_id: vault.id}
+    )
+
+    :ok
+  end
 end

--- a/lib/engram/workers/decrypt_vault.ex
+++ b/lib/engram/workers/decrypt_vault.ex
@@ -1,0 +1,7 @@
+defmodule Engram.Workers.DecryptVault do
+  @moduledoc "Oban worker: restore plaintext for a vault. Implemented in Task 9."
+  use Oban.Worker, queue: :crypto_backfill, max_attempts: 5
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}), do: :ok
+end

--- a/lib/engram/workers/encrypt_vault.ex
+++ b/lib/engram/workers/encrypt_vault.ex
@@ -1,0 +1,7 @@
+defmodule Engram.Workers.EncryptVault do
+  @moduledoc "Oban worker: backfill-encrypts notes in a vault. Implemented in Task 8."
+  use Oban.Worker, queue: :crypto_backfill, max_attempts: 5
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}), do: :ok
+end

--- a/lib/engram/workers/encrypt_vault.ex
+++ b/lib/engram/workers/encrypt_vault.ex
@@ -1,7 +1,146 @@
 defmodule Engram.Workers.EncryptVault do
-  @moduledoc "Oban worker: backfill-encrypts notes in a vault. Implemented in Task 8."
-  use Oban.Worker, queue: :crypto_backfill, max_attempts: 5
+  @moduledoc """
+  Backfill-encrypts every note in a vault. Batch of 100 per job invocation,
+  per-note atomicity (Postgres transaction + idempotent Qdrant set_payload),
+  cursor-resumable on crash. Re-enqueues itself until the final batch,
+  then flips vault status to "encrypted".
+  """
+
+  use Oban.Worker,
+    queue: :crypto_backfill,
+    max_attempts: 5,
+    unique: [keys: [:vault_id], states: [:available, :scheduled, :executing]]
+
+  import Ecto.Query
+  require Logger
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Notes.Note
+  alias Engram.Repo
+  alias Engram.Vaults.Vault
+
+  @batch_size 100
 
   @impl Oban.Worker
-  def perform(%Oban.Job{}), do: :ok
+  def perform(%Oban.Job{args: %{"vault_id" => vault_id, "user_id" => user_id, "cursor" => cursor}}) do
+    Repo.with_tenant(user_id, fn ->
+      vault = Repo.get!(Vault, vault_id)
+      user = Repo.get!(User, user_id)
+
+      if vault.encryption_status != "encrypting" do
+        Logger.info("EncryptVault no-op: vault #{vault_id} status=#{vault.encryption_status}")
+        :ok
+      else
+        with {:ok, user} <- Crypto.ensure_user_dek(user) do
+          process_batch(vault, user, cursor)
+        end
+      end
+    end)
+    |> case do
+      {:ok, result} -> result
+      other -> other
+    end
+  end
+
+  defp process_batch(vault, user, cursor) do
+    notes =
+      from(n in Note,
+        where: n.vault_id == ^vault.id and n.id > ^cursor,
+        order_by: [asc: n.id],
+        limit: @batch_size
+      )
+      |> Repo.all()
+
+    case Enum.reduce_while(notes, {:ok, cursor}, &encrypt_note(&1, &2, user, vault)) do
+      {:ok, last_id} ->
+        if length(notes) == @batch_size do
+          {:ok, _} =
+            __MODULE__.new(%{
+              vault_id: vault.id,
+              user_id: user.id,
+              cursor: last_id
+            })
+            |> Oban.insert()
+
+          :ok
+        else
+          finalize_vault(vault, length(notes))
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp encrypt_note(%Note{} = note, {:ok, _last}, user, vault) do
+    started_at = System.monotonic_time()
+
+    # Qdrant indexing runs against the plaintext note so Markdown.parse can
+    # produce chunks. Postgres encryption then stamps ciphertext columns
+    # (plaintext fields are cleared only in the DB row).
+    with :ok <- encrypt_qdrant(note, vault),
+         {:ok, _encrypted_note} <- encrypt_postgres(note, user, vault) do
+      duration = System.monotonic_time() - started_at
+
+      :telemetry.execute(
+        [:engram, :crypto, :backfill, :note_encrypted],
+        %{duration: duration},
+        %{vault_id: vault.id, note_id: note.id}
+      )
+
+      {:cont, {:ok, note.id}}
+    else
+      {:error, reason} ->
+        Logger.error("EncryptVault failed note #{note.id}: #{inspect(reason)}")
+        {:halt, {:error, reason}}
+    end
+  end
+
+  defp encrypt_postgres(%Note{} = note, user, vault) do
+    attrs = %{
+      content: note.content || "",
+      title: note.title,
+      tags: note.tags
+    }
+
+    case Crypto.maybe_encrypt_note_fields(attrs, user, vault) do
+      {:ok, encrypted_attrs} ->
+        note
+        |> Note.encryption_changeset(encrypted_attrs)
+        |> Repo.update()
+
+      error ->
+        error
+    end
+  end
+
+  defp encrypt_qdrant(%Note{} = note, vault) do
+    case Engram.Indexing.index_note(note, vault) do
+      {:ok, _} -> :ok
+      :ok -> :ok
+      error -> error
+    end
+  end
+
+  defp finalize_vault(vault, processed_count) do
+    locked = Repo.get!(Vault, vault.id, lock: "FOR UPDATE")
+
+    if locked.encryption_status == "encrypting" do
+      locked
+      |> Ecto.Changeset.change(%{
+        encryption_status: "encrypted",
+        encrypted_at: DateTime.utc_now()
+      })
+      |> Repo.update!()
+    end
+
+    :telemetry.execute(
+      [:engram, :crypto, :backfill, :vault_encrypted],
+      %{processed: processed_count},
+      %{vault_id: vault.id}
+    )
+
+    :ok
+  end
 end

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -94,6 +94,46 @@ defmodule EngramWeb.VaultsController do
     end
   end
 
+  # ── encrypt / decrypt toggles ──────────────────────────────────────────────
+
+  def encrypt(conn, %{"id" => id}) do
+    toggle_action(conn, id, &Engram.Crypto.encrypt_vault/2)
+  end
+
+  def request_decrypt(conn, %{"id" => id}) do
+    toggle_action(conn, id, &Engram.Crypto.request_decrypt_vault/2)
+  end
+
+  def cancel_decrypt(conn, %{"id" => id}) do
+    toggle_action(conn, id, &Engram.Crypto.cancel_decrypt_vault/2)
+  end
+
+  def encryption_progress(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    with {:ok, vault_id} <- parse_vault_id(id),
+         {:ok, vault} <- Vaults.get_vault(user, vault_id) do
+      %{processed: p, total: t} = Vaults.encryption_progress(vault)
+
+      started_at =
+        case vault.encryption_status do
+          "encrypting" -> vault.last_toggle_at
+          "decrypting" -> vault.decrypt_requested_at
+          _ -> nil
+        end
+
+      json(conn, %{
+        processed: p,
+        total: t,
+        status: vault.encryption_status,
+        started_at: started_at
+      })
+    else
+      {:error, :not_found} -> not_found(conn)
+      {:error, :invalid_id} -> not_found(conn)
+    end
+  end
+
   # ── register ───────────────────────────────────────────────────────────────
 
   def register(conn, params) do
@@ -134,7 +174,12 @@ defmodule EngramWeb.VaultsController do
       description: vault.description,
       slug: vault.slug,
       is_default: vault.is_default,
-      created_at: vault.created_at
+      created_at: vault.created_at,
+      encrypted: vault.encrypted,
+      encryption_status: vault.encryption_status,
+      encrypted_at: vault.encrypted_at,
+      decrypt_requested_at: vault.decrypt_requested_at,
+      last_toggle_at: vault.last_toggle_at
     }
   end
 
@@ -148,6 +193,55 @@ defmodule EngramWeb.VaultsController do
     case Integer.parse(id) do
       {n, ""} -> {:ok, n}
       _ -> :error
+    end
+  end
+
+  # with/1-friendly variant — returns {:error, :invalid_id} instead of bare :error
+  defp parse_vault_id(id) do
+    case parse_id(id) do
+      {:ok, n} -> {:ok, n}
+      :error -> {:error, :invalid_id}
+    end
+  end
+
+  defp toggle_action(conn, id, fun) do
+    user = conn.assigns.current_user
+
+    with {:ok, vault_id} <- parse_vault_id(id),
+         {:ok, vault} <- Vaults.get_vault(user, vault_id),
+         {:ok, updated} <- fun.(vault, user) do
+      conn |> put_status(202) |> json(%{vault: vault_json(updated)})
+    else
+      {:error, :not_found} ->
+        not_found(conn)
+
+      {:error, :invalid_id} ->
+        not_found(conn)
+
+      {:error, :cooldown} ->
+        retry_after = compute_retry_after(id, conn.assigns.current_user)
+
+        conn
+        |> put_status(429)
+        |> json(%{error: "cooldown_active", retry_after: retry_after})
+
+      {:error, :bad_status} ->
+        conn
+        |> put_status(409)
+        |> json(%{error: "invalid_status_transition"})
+
+      _ ->
+        send_resp(conn, 500, "")
+    end
+  end
+
+  defp compute_retry_after(id, user) do
+    with {:ok, vault_id} <- parse_vault_id(id),
+         {:ok, vault} <- Vaults.get_vault(user, vault_id),
+         %DateTime{} = toggled <- vault.last_toggle_at do
+      toggled |> DateTime.add(7, :day) |> DateTime.to_iso8601()
+    else
+      _ -> nil
     end
   end
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -74,6 +74,10 @@ defmodule EngramWeb.Router do
     get "/vaults/:id", VaultsController, :show
     patch "/vaults/:id", VaultsController, :update
     delete "/vaults/:id", VaultsController, :delete
+    post "/vaults/:id/encrypt", VaultsController, :encrypt
+    post "/vaults/:id/decrypt", VaultsController, :request_decrypt
+    delete "/vaults/:id/decrypt", VaultsController, :cancel_decrypt
+    get "/vaults/:id/encryption_progress", VaultsController, :encryption_progress
 
     # Billing
     get "/billing/status", BillingController, :status

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.4.3",
+      version: "0.5.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto/cancel_decrypt_vault_test.exs
+++ b/test/engram/crypto/cancel_decrypt_vault_test.exs
@@ -1,0 +1,38 @@
+defmodule Engram.Crypto.CancelDecryptVaultTest do
+  use Engram.DataCase, async: false
+
+  alias Engram.Crypto
+  alias Engram.Vaults.Vault
+
+  setup do
+    user = insert(:user)
+    now = DateTime.utc_now()
+
+    vault =
+      insert(:vault,
+        user: user,
+        encrypted: true,
+        encryption_status: "decrypt_pending",
+        decrypt_requested_at: now,
+        last_toggle_at: now
+      )
+
+    %{user: user, vault: vault}
+  end
+
+  describe "cancel_decrypt_vault/2" do
+    test "flips vault back to encrypted and clears decrypt_requested_at", %{user: user, vault: vault} do
+      original_toggle = vault.last_toggle_at
+      assert {:ok, updated} = Crypto.cancel_decrypt_vault(vault, user)
+      assert updated.encryption_status == "encrypted"
+      assert is_nil(updated.decrypt_requested_at)
+      # last_toggle_at unchanged — cooldown anchors on original decrypt request
+      assert DateTime.compare(updated.last_toggle_at, original_toggle) == :eq
+    end
+
+    test "returns :bad_status when not in decrypt_pending", %{user: user, vault: vault} do
+      {:ok, vault} = Vault.update_status(vault, "encrypted")
+      assert {:error, :bad_status} = Crypto.cancel_decrypt_vault(vault, user)
+    end
+  end
+end

--- a/test/engram/crypto/encrypt_vault_test.exs
+++ b/test/engram/crypto/encrypt_vault_test.exs
@@ -1,0 +1,47 @@
+defmodule Engram.Crypto.EncryptVaultTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Crypto
+  alias Engram.Vaults.Vault
+  alias Engram.Workers.EncryptVault
+  alias Engram.Repo
+
+  setup do
+    user = insert(:user)
+    vault = insert(:vault, user: user, encrypted: false, encryption_status: "none")
+    %{user: user, vault: vault}
+  end
+
+  describe "encrypt_vault/2" do
+    test "flips vault to encrypting and enqueues EncryptVault worker", %{user: user, vault: vault} do
+      assert {:ok, updated} = Crypto.encrypt_vault(vault, user)
+      assert updated.encrypted == true
+      assert updated.encryption_status == "encrypting"
+      assert updated.last_toggle_at != nil
+      assert_enqueued(worker: EncryptVault, args: %{"vault_id" => vault.id, "user_id" => user.id, "cursor" => 0})
+    end
+
+    test "returns :bad_status when already encrypted", %{user: user, vault: vault} do
+      {:ok, vault} = Vault.update_status(vault, "encrypted")
+      assert {:error, :bad_status} = Crypto.encrypt_vault(vault, user)
+    end
+
+    test "returns :bad_status when currently encrypting", %{user: user, vault: vault} do
+      {:ok, vault} = Vault.update_status(vault, "encrypting")
+      assert {:error, :bad_status} = Crypto.encrypt_vault(vault, user)
+    end
+
+    test "returns :cooldown when last_toggle_at within 7 days", %{user: user, vault: vault} do
+      recent = DateTime.utc_now() |> DateTime.add(-3, :day)
+      {:ok, vault} = vault |> Ecto.Changeset.change(%{last_toggle_at: recent}) |> Repo.update()
+      assert {:error, :cooldown} = Crypto.encrypt_vault(vault, user)
+    end
+
+    test "succeeds when last_toggle_at > 7 days ago", %{user: user, vault: vault} do
+      old = DateTime.utc_now() |> DateTime.add(-8, :day)
+      {:ok, vault} = vault |> Ecto.Changeset.change(%{last_toggle_at: old}) |> Repo.update()
+      assert {:ok, _} = Crypto.encrypt_vault(vault, user)
+    end
+  end
+end

--- a/test/engram/crypto/request_decrypt_vault_test.exs
+++ b/test/engram/crypto/request_decrypt_vault_test.exs
@@ -1,0 +1,70 @@
+defmodule Engram.Crypto.RequestDecryptVaultTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Crypto
+  alias Engram.Vaults.Vault
+  alias Engram.Workers.DecryptVault
+  alias Engram.Repo
+
+  setup do
+    user = insert(:user)
+    old = DateTime.utc_now() |> DateTime.add(-8, :day)
+
+    vault =
+      insert(:vault,
+        user: user,
+        encrypted: true,
+        encryption_status: "encrypted",
+        encrypted_at: old,
+        last_toggle_at: old
+      )
+
+    %{user: user, vault: vault}
+  end
+
+  describe "request_decrypt_vault/2" do
+    test "flips vault to decrypt_pending and schedules DecryptVault at +24h", %{user: user, vault: vault} do
+      assert {:ok, updated} = Crypto.request_decrypt_vault(vault, user)
+      assert updated.encryption_status == "decrypt_pending"
+      assert updated.decrypt_requested_at != nil
+      assert updated.last_toggle_at != nil
+      assert DateTime.diff(updated.last_toggle_at, vault.last_toggle_at, :second) > 0
+
+      job = all_enqueued(worker: DecryptVault) |> List.first()
+      refute is_nil(job)
+      assert job.args == %{"vault_id" => vault.id, "user_id" => user.id, "cursor" => 0}
+      diff_seconds = DateTime.diff(job.scheduled_at, DateTime.utc_now(), :second)
+      assert diff_seconds > 23 * 3600 and diff_seconds <= 24 * 3600
+    end
+
+    test "returns :bad_status when not encrypted", %{user: user, vault: vault} do
+      {:ok, vault} = Vault.update_status(vault, "none")
+      assert {:error, :bad_status} = Crypto.request_decrypt_vault(vault, user)
+    end
+
+    test "returns :cooldown when last_toggle_at within 7 days", %{user: user, vault: vault} do
+      recent = DateTime.utc_now() |> DateTime.add(-3, :day)
+      {:ok, vault} = vault |> Ecto.Changeset.change(%{last_toggle_at: recent}) |> Repo.update()
+      assert {:error, :cooldown} = Crypto.request_decrypt_vault(vault, user)
+    end
+
+    test "emits :decrypt_requested telemetry", %{user: user, vault: vault} do
+      :telemetry.attach(
+        "test-decrypt-requested",
+        [:engram, :crypto, :decrypt_requested],
+        fn _name, _measurements, meta, _config ->
+          send(self(), {:telemetry, meta})
+        end,
+        nil
+      )
+
+      {:ok, _} = Crypto.request_decrypt_vault(vault, user)
+      assert_receive {:telemetry, %{vault_id: id, user_id: uid}}, 100
+      assert id == vault.id
+      assert uid == user.id
+
+      :telemetry.detach("test-decrypt-requested")
+    end
+  end
+end

--- a/test/engram/search_integration_test.exs
+++ b/test/engram/search_integration_test.exs
@@ -78,4 +78,60 @@ defmodule Engram.SearchIntegrationTest do
     {:ok, results} = Engram.Search.search(user, plain_vault, "searchable")
     assert Enum.any?(results, fn r -> r.text =~ "searchable" end)
   end
+
+  describe "vault toggle round-trip" do
+    test "plaintext -> encrypt -> ciphertext at rest -> search -> decrypt -> plaintext",
+         %{user: user} do
+      insert(:user_override, user: user, overrides: %{"max_vaults" => 5})
+
+      vault =
+        insert(:vault, user: user, encrypted: false, encryption_status: "none")
+
+      # Seed a plaintext note with a chunk indexed in Qdrant.
+      note =
+        insert(:note,
+          user: user,
+          vault: vault,
+          content: "Project Vaniel launches Tuesday",
+          title: "Vaniel launch"
+        )
+
+      {:ok, _} = Engram.Indexing.index_note(note, vault)
+
+      # Toggle encryption on.
+      {:ok, vault} = Engram.Crypto.encrypt_vault(vault, user)
+      :ok = Oban.drain_queue(queue: :crypto_backfill)
+
+      # Assert ciphertext at rest: Postgres columns + note encrypted.
+      encrypted_note =
+        Engram.Repo.get!(Engram.Notes.Note, note.id, skip_tenant_check: true)
+
+      assert encrypted_note.content_ciphertext != nil
+      assert encrypted_note.title_ciphertext != nil
+
+      # Search still works (decrypts after Qdrant retrieval).
+      vault = Engram.Repo.get!(Engram.Vaults.Vault, vault.id, skip_tenant_check: true)
+      {:ok, results} = Engram.Search.search(user, vault, "Vaniel launch", limit: 5)
+      assert length(results) > 0
+
+      # Backdate last_toggle_at to bypass the 7-day encrypt/decrypt cooldown.
+      old = DateTime.utc_now() |> DateTime.add(-8, :day)
+
+      {:ok, vault} =
+        vault
+        |> Ecto.Changeset.change(%{last_toggle_at: old})
+        |> Engram.Repo.update(skip_tenant_check: true)
+
+      # Toggle decrypt (simulate 24h with drain scheduled).
+      {:ok, _vault} = Engram.Crypto.request_decrypt_vault(vault, user)
+      :ok = Oban.drain_queue(queue: :crypto_backfill, with_scheduled: true)
+
+      # Plaintext restored.
+      restored =
+        Engram.Repo.get!(Engram.Notes.Note, note.id, skip_tenant_check: true)
+
+      assert restored.content == "Project Vaniel launches Tuesday"
+      assert is_nil(restored.content_ciphertext)
+    end
+  end
 end

--- a/test/engram/workers/decrypt_vault_test.exs
+++ b/test/engram/workers/decrypt_vault_test.exs
@@ -1,0 +1,107 @@
+defmodule Engram.Workers.DecryptVaultTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Mox
+
+  alias Engram.Crypto
+  alias Engram.Repo
+  alias Engram.Notes.Note
+  alias Engram.Vaults.Vault
+  alias Engram.Workers.DecryptVault
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+    on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
+
+    # Global embedder stub — worker re-indexes via Engram.Indexing.
+    Mox.stub(Engram.MockEmbedder, :embed_texts, fn texts ->
+      {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+    end)
+
+    Mox.stub(Engram.MockEmbedder, :embed_texts, fn texts, _opts ->
+      {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+    end)
+
+    user = insert(:user)
+
+    vault =
+      insert(:vault,
+        user: user,
+        encrypted: true,
+        encryption_status: "decrypt_pending",
+        decrypt_requested_at: DateTime.utc_now(),
+        last_toggle_at: DateTime.utc_now()
+      )
+
+    %{bypass: bypass, user: user, vault: vault}
+  end
+
+  defp stub_qdrant(bypass) do
+    Bypass.expect(bypass, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, ~s({"result": true, "status": "ok"}))
+    end)
+  end
+
+  describe "perform/1" do
+    test "no-ops when vault is in encrypted state (cancelled)", %{user: user, vault: vault} do
+      {:ok, vault} = Vault.update_status(vault, "encrypted")
+
+      assert :ok =
+               perform_job(DecryptVault, %{
+                 "vault_id" => vault.id,
+                 "user_id" => user.id,
+                 "cursor" => 0
+               })
+
+      reloaded = Repo.get!(Vault, vault.id, skip_tenant_check: true)
+      assert reloaded.encryption_status == "encrypted"
+    end
+
+    test "flips to decrypting then none, clears ciphertext columns", %{bypass: bypass, user: user, vault: vault} do
+      stub_qdrant(bypass)
+
+      # Seed an encrypted note using the real crypto helper.
+      {:ok, _} = Crypto.ensure_user_dek(user)
+      {:ok, enc} = Crypto.maybe_encrypt_note_fields(%{content: "secret", title: "t", tags: ["x"]}, user, vault)
+
+      note =
+        insert(:note,
+          user: user,
+          vault: vault,
+          content: enc.content,
+          content_ciphertext: enc.content_ciphertext,
+          content_nonce: enc.content_nonce,
+          title: enc.title,
+          title_ciphertext: enc.title_ciphertext,
+          title_nonce: enc.title_nonce,
+          tags: enc.tags,
+          tags_ciphertext: enc.tags_ciphertext,
+          tags_nonce: enc.tags_nonce
+        )
+
+      assert :ok =
+               perform_job(DecryptVault, %{
+                 "vault_id" => vault.id,
+                 "user_id" => user.id,
+                 "cursor" => 0
+               })
+
+      reloaded = Repo.get!(Note, note.id, skip_tenant_check: true)
+      assert reloaded.content == "secret"
+      assert is_nil(reloaded.content_ciphertext)
+      assert is_nil(reloaded.content_nonce)
+
+      v = Repo.get!(Vault, vault.id, skip_tenant_check: true)
+      assert v.encryption_status == "none"
+      assert v.encrypted == false
+      assert is_nil(v.encrypted_at)
+    end
+  end
+end

--- a/test/engram/workers/encrypt_vault_test.exs
+++ b/test/engram/workers/encrypt_vault_test.exs
@@ -1,0 +1,146 @@
+defmodule Engram.Workers.EncryptVaultTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Mox
+
+  alias Engram.Repo
+  alias Engram.Notes.Note
+  alias Engram.Vaults.Vault
+  alias Engram.Workers.EncryptVault
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+    on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
+
+    Mox.stub(Engram.MockEmbedder, :embed_texts, fn texts ->
+      {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+    end)
+
+    Mox.stub(Engram.MockEmbedder, :embed_texts, fn texts, _opts ->
+      {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+    end)
+
+    user = insert(:user)
+
+    vault =
+      insert(:vault,
+        user: user,
+        encrypted: true,
+        encryption_status: "encrypting",
+        last_toggle_at: DateTime.utc_now()
+      )
+
+    %{bypass: bypass, user: user, vault: vault}
+  end
+
+  defp stub_qdrant_set_payload(bypass) do
+    Bypass.expect(bypass, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, ~s({"result": true, "status": "ok"}))
+    end)
+  end
+
+  describe "perform/1" do
+    test "no-ops when vault is not in encrypting status", %{vault: vault, user: user} do
+      {:ok, vault} = Vault.update_status(vault, "encrypted")
+
+      assert :ok =
+               perform_job(EncryptVault, %{
+                 "vault_id" => vault.id,
+                 "user_id" => user.id,
+                 "cursor" => 0
+               })
+    end
+
+    test "encrypts notes in batch and stamps ciphertext columns", %{bypass: bypass, vault: vault, user: user} do
+      stub_qdrant_set_payload(bypass)
+
+      note = insert(:note, user: user, vault: vault, content: "secret body", title: "Top Secret")
+
+      assert :ok =
+               perform_job(EncryptVault, %{
+                 "vault_id" => vault.id,
+                 "user_id" => user.id,
+                 "cursor" => 0
+               })
+
+      reloaded = Repo.get!(Note, note.id, skip_tenant_check: true)
+      assert reloaded.content_ciphertext != nil
+      assert reloaded.content_nonce != nil
+      assert reloaded.title_ciphertext != nil
+    end
+
+    test "finalizes vault to encrypted when batch is under 100", %{bypass: bypass, vault: vault, user: user} do
+      stub_qdrant_set_payload(bypass)
+      insert(:note, user: user, vault: vault, content: "x")
+
+      :ok =
+        perform_job(EncryptVault, %{
+          "vault_id" => vault.id,
+          "user_id" => user.id,
+          "cursor" => 0
+        })
+
+      updated = Repo.get!(Vault, vault.id, skip_tenant_check: true)
+      assert updated.encryption_status == "encrypted"
+      assert updated.encrypted_at != nil
+    end
+
+    test "re-enqueues with new cursor when batch is full", %{bypass: bypass, vault: vault, user: user} do
+      stub_qdrant_set_payload(bypass)
+      # Insert 100 notes — full batch.
+      for i <- 1..100 do
+        insert(:note, user: user, vault: vault, content: "note-#{i}", path: "n/#{i}.md")
+      end
+
+      :ok =
+        perform_job(EncryptVault, %{
+          "vault_id" => vault.id,
+          "user_id" => user.id,
+          "cursor" => 0
+        })
+
+      # Should NOT finalize — batch was full, more work remains.
+      updated = Repo.get!(Vault, vault.id, skip_tenant_check: true)
+      assert updated.encryption_status == "encrypting"
+
+      # Should re-enqueue with new cursor.
+      assert_enqueued(worker: EncryptVault)
+    end
+
+    test "emits :note_encrypted and :vault_encrypted telemetry", %{bypass: bypass, vault: vault, user: user} do
+      stub_qdrant_set_payload(bypass)
+      insert(:note, user: user, vault: vault, content: "x")
+
+      test_pid = self()
+
+      :telemetry.attach_many(
+        "test-encrypt-telemetry",
+        [
+          [:engram, :crypto, :backfill, :note_encrypted],
+          [:engram, :crypto, :backfill, :vault_encrypted]
+        ],
+        fn name, _m, meta, _c -> send(test_pid, {:telemetry, name, meta}) end,
+        nil
+      )
+
+      :ok =
+        perform_job(EncryptVault, %{
+          "vault_id" => vault.id,
+          "user_id" => user.id,
+          "cursor" => 0
+        })
+
+      assert_receive {:telemetry, [:engram, :crypto, :backfill, :note_encrypted], _}, 500
+      assert_receive {:telemetry, [:engram, :crypto, :backfill, :vault_encrypted], _}, 500
+
+      :telemetry.detach("test-encrypt-telemetry")
+    end
+  end
+end

--- a/test/engram_web/controllers/vaults_controller_encryption_test.exs
+++ b/test/engram_web/controllers/vaults_controller_encryption_test.exs
@@ -1,0 +1,117 @@
+defmodule EngramWeb.VaultsControllerEncryptionTest do
+  use EngramWeb.ConnCase, async: false
+
+  alias Engram.Accounts
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+    {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
+    conn = put_req_header(conn, "authorization", "Bearer #{raw_key}")
+    {:ok, conn: conn, user: user}
+  end
+
+  describe "POST /api/vaults/:id/encrypt" do
+    test "202 with updated vault on success", %{conn: conn, user: user} do
+      vault = insert(:vault, user: user, encrypted: false, encryption_status: "none")
+      resp = post(conn, ~p"/api/vaults/#{vault.id}/encrypt")
+      json = json_response(resp, 202)
+      assert json["vault"]["encryption_status"] == "encrypting"
+    end
+
+    test "429 on cooldown", %{conn: conn, user: user} do
+      recent = DateTime.utc_now() |> DateTime.add(-3, :day)
+
+      vault =
+        insert(:vault,
+          user: user,
+          encrypted: false,
+          encryption_status: "none",
+          last_toggle_at: recent
+        )
+
+      resp = post(conn, ~p"/api/vaults/#{vault.id}/encrypt")
+      json = json_response(resp, 429)
+      assert json["error"] == "cooldown_active"
+      assert json["retry_after"]
+    end
+
+    test "409 when already encrypted", %{conn: conn, user: user} do
+      vault = insert(:vault, user: user, encrypted: true, encryption_status: "encrypted")
+      resp = post(conn, ~p"/api/vaults/#{vault.id}/encrypt")
+      json = json_response(resp, 409)
+      assert json["error"] == "invalid_status_transition"
+    end
+
+    test "403 or 404 when not vault owner", %{conn: conn} do
+      other = insert(:user)
+      insert(:user_override, user: other, overrides: %{"max_vaults" => 5})
+      vault = insert(:vault, user: other, encrypted: false, encryption_status: "none")
+      resp = post(conn, ~p"/api/vaults/#{vault.id}/encrypt")
+      assert resp.status in [403, 404]
+    end
+  end
+
+  describe "POST /api/vaults/:id/decrypt" do
+    test "202 and schedules decrypt", %{conn: conn, user: user} do
+      old = DateTime.utc_now() |> DateTime.add(-8, :day)
+
+      vault =
+        insert(:vault,
+          user: user,
+          encrypted: true,
+          encryption_status: "encrypted",
+          last_toggle_at: old
+        )
+
+      resp = post(conn, ~p"/api/vaults/#{vault.id}/decrypt")
+      json = json_response(resp, 202)
+      assert json["vault"]["encryption_status"] == "decrypt_pending"
+      assert json["vault"]["decrypt_requested_at"]
+    end
+  end
+
+  describe "DELETE /api/vaults/:id/decrypt" do
+    test "202 cancels pending decrypt", %{conn: conn, user: user} do
+      vault =
+        insert(:vault,
+          user: user,
+          encrypted: true,
+          encryption_status: "decrypt_pending",
+          decrypt_requested_at: DateTime.utc_now(),
+          last_toggle_at: DateTime.utc_now()
+        )
+
+      resp = delete(conn, ~p"/api/vaults/#{vault.id}/decrypt")
+      json = json_response(resp, 202)
+      assert json["vault"]["encryption_status"] == "encrypted"
+    end
+
+    test "409 when nothing to cancel", %{conn: conn, user: user} do
+      vault = insert(:vault, user: user, encrypted: true, encryption_status: "encrypted")
+      resp = delete(conn, ~p"/api/vaults/#{vault.id}/decrypt")
+      assert json_response(resp, 409)
+    end
+  end
+
+  describe "GET /api/vaults/:id/encryption_progress" do
+    test "returns processed/total counts", %{conn: conn, user: user} do
+      vault = insert(:vault, user: user, encrypted: true, encryption_status: "encrypting")
+
+      insert(:note,
+        user: user,
+        vault: vault,
+        content_ciphertext: <<1, 2, 3>>,
+        content_nonce: <<4, 5>>
+      )
+
+      insert(:note, user: user, vault: vault, content: "plain")
+
+      resp = get(conn, ~p"/api/vaults/#{vault.id}/encryption_progress")
+      json = json_response(resp, 200)
+      assert json["total"] == 2
+      assert json["processed"] == 1
+      assert json["status"] == "encrypting"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ships Phase 6 backend: user-facing vault encryption toggle, cursor-resumable Oban backfill workers, toggle/progress HTTP API, and now the E2E at-rest test suite. Frontend UI remains deferred.

## What's in

**Crypto API (`Engram.Crypto`):**
- `encrypt_vault/2` — flips vault to `encrypting`, enqueues `EncryptVault` worker. 7-day cooldown, `FOR UPDATE` lock, RLS-safe via `with_tenant`.
- `request_decrypt_vault/2` — schedules `DecryptVault` at +24h, emits `[:engram, :crypto, :decrypt_requested]` telemetry (hook for future email notification).
- `cancel_decrypt_vault/2` — rolls vault back to `encrypted`; preserves `last_toggle_at` so cooldown anchors on original decrypt decision.

**Oban workers (queue `:crypto_backfill`, concurrency 1):**
- `EncryptVault` — batches of 100, per-note atomicity, cursor resume. Order: Qdrant index against plaintext in-memory note, then Postgres ciphertext stamp. Idempotent on retry.
- `DecryptVault` — scheduled +24h by `request_decrypt_vault/2`. No-ops if vault flipped back to `encrypted` (cancel race). Otherwise flips to `decrypting`, restores plaintext across Postgres + Qdrant, finalizes to `none`.

**HTTP endpoints (`VaultsController`):**
- `POST /api/vaults/:id/encrypt` → 202/409/429/404
- `POST /api/vaults/:id/decrypt` → 202/409/429/404
- `DELETE /api/vaults/:id/decrypt` → 202/409/404
- `GET /api/vaults/:id/encryption_progress` → 200 `{processed, total, status, started_at}`

**E2E encryption-at-rest test suite (NEW in this push):**
- `helpers/crypto_probe.py` — shared helpers: DB probes (`assert_note_ciphertext_at_rest` / `_plaintext_at_rest` via `\set`/`:'var'` binding), Qdrant probes (`assert_qdrant_ciphertext` / `_plaintext` via scroll API), `wait_for_encryption_status` polling, SQL time-travel (`backdate_last_toggle`, `backdate_decrypt_requested`) for cooldown + 24h delay bypass.
- `tests/api_only/test_62_encrypted_vault.py` — migrated from SQL-hack to real `POST /encrypt` endpoint + adds DB/Qdrant at-rest probes. Teardown fixture runs real decrypt flow with SQL time-travel.
- `tests/api_only/test_64_vault_toggle_backfill.py` — full toggle lifecycle: 3 plaintext notes → `POST /encrypt` → ciphertext at rest (DB + Qdrant) → backdate cooldown + 24h → `POST /decrypt` → plaintext restored. Starting-state guard + Qdrant indexing wait.
- `tests/test_63_encrypted_sync_obsidian.py` — full plugin chain: Vault A filesystem write → plugin push → ciphertext at rest (DB + Qdrant) → Vault B `trigger_full_sync` → plaintext on disk in B.

**Integration test:** `test/engram/search_integration_test.exs` — gated by `QDRANT_INTEGRATION=1`; round-trip plaintext → encrypt → assert ciphertext at rest → search still works → decrypt → plaintext restored.

## Scope cut — frontend deferred

Plan originally included a React `EncryptionPanel` + `VaultSettings` page, Vitest runner, and SPA-driven E2E. During implementation the subagent discovered the SPA has **no vault settings page at all** and **no unit test runner installed** — building those is a separate, non-encryption concern. Shipping backend + full E2E now; tracking the frontend integration as its own plan once vault settings UI is scoped.

## Known limitations carried forward

- Attachments remain plaintext (Phase 5 is a separate PR).
- No email confirmation on decrypt request — see `docs/superpowers/specs/2026-04-21-encryption-phase-6-email-todo.md`.
- `crypto.ex` now ~380 LOC; `NoteFields` + `QdrantPayload` submodule split on follow-up list.

## Test plan

- [x] `mix test` — 811 tests, 0 failures.
- [x] `mix compile --warnings-as-errors` — clean.
- [ ] CI e2e-local green (picks up tests 62 + 64 new at-rest probes)
- [ ] CI e2e-clerk green
- [ ] CI e2e-browser green (picks up test 63 Obsidian sync)
- [ ] `QDRANT_INTEGRATION=1 mix test --only qdrant_integration` — runs in CI against real Qdrant.

## Specs

- `docs/superpowers/specs/2026-04-21-encryption-phase-6-design.md`
- `docs/superpowers/specs/2026-04-21-encryption-phase-6-email-todo.md`
- `docs/superpowers/specs/2026-04-22-e2e-encryption-at-rest-tests-design.md` (workspace repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)