### PR TITLE
fix: allowlist Obsidian origin in CORS for plugin device flow

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -234,8 +234,10 @@ if config_env() == :prod do
   # Without it (CI, local dev), defaults apply: CORS allows "*", WS allows all.
   if phx_host = System.get_env("PHX_HOST") do
     scheme = System.get_env("PHX_SCHEME") || "https"
-    config :engram, :cors_origin, "#{scheme}://#{phx_host}"
-    config :engram, :websocket_check_origin, ["#{scheme}://#{phx_host}", "app://obsidian.md"]
+    web_origin = "#{scheme}://#{phx_host}"
+    obsidian_origins = ["app://obsidian.md", "capacitor://localhost", "http://localhost"]
+    config :engram, :cors_origin, [web_origin | obsidian_origins]
+    config :engram, :websocket_check_origin, [web_origin | obsidian_origins]
   end
 
   # ## SSL Support

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -6,7 +6,8 @@ defmodule EngramWeb.DeviceAuthController do
 
   @verification_path "/app/link"
 
-  def start(conn, %{"client_id" => client_id}) do
+  def start(conn, params) do
+    client_id = Map.get(params, "client_id", "unknown")
     case DeviceFlow.start_device_flow(client_id) do
       {:ok, auth} ->
         base_url = EngramWeb.Endpoint.url()

--- a/lib/engram_web/plugs/cors.ex
+++ b/lib/engram_web/plugs/cors.ex
@@ -1,7 +1,13 @@
 defmodule EngramWeb.Plugs.CORS do
   @moduledoc """
-  Simple CORS plug — allows all origins (auth is via Bearer token, not cookies).
-  Handles OPTIONS preflight and adds headers to all responses.
+  CORS plug — auth is via Bearer token, not cookies, so allowlist is permissive
+  on origin but echoes the request Origin when it matches so non-browser clients
+  (Obsidian Electron via fetch) get an exact match.
+
+  Config `:cors_origin` accepts:
+    * `"*"` — allow any (default for dev/CI when PHX_HOST unset)
+    * `"https://x"` — single origin
+    * `["https://x", "app://obsidian.md"]` — allowlist; request Origin echoed if in list, else first
   """
 
   import Plug.Conn
@@ -22,13 +28,23 @@ defmodule EngramWeb.Plugs.CORS do
 
   defp put_cors_headers(conn) do
     conn
-    |> put_resp_header("access-control-allow-origin", cors_origin())
+    |> put_resp_header("access-control-allow-origin", resolve_origin(conn))
     |> put_resp_header("access-control-allow-methods", "GET, POST, PUT, DELETE, OPTIONS")
     |> put_resp_header("access-control-allow-headers", "authorization, content-type")
     |> put_resp_header("access-control-max-age", "86400")
   end
 
-  defp cors_origin do
-    Application.get_env(:engram, :cors_origin, "*")
+  defp resolve_origin(conn) do
+    case Application.get_env(:engram, :cors_origin, "*") do
+      "*" ->
+        "*"
+
+      origin when is_binary(origin) ->
+        origin
+
+      [first | _] = allowlist when is_list(allowlist) ->
+        request_origin = get_req_header(conn, "origin") |> List.first()
+        if request_origin && request_origin in allowlist, do: request_origin, else: first
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/plugs/cors_test.exs
+++ b/test/engram_web/plugs/cors_test.exs
@@ -41,4 +41,34 @@ defmodule EngramWeb.Plugs.CORSTest do
     origin = Application.get_env(:engram, :cors_origin, "*")
     assert is_binary(origin) or is_list(origin)
   end
+
+  test "list config echoes request Origin when in allowlist" do
+    Application.put_env(:engram, :cors_origin, [
+      "http://engram.ax",
+      "app://obsidian.md"
+    ])
+    on_exit(fn -> Application.delete_env(:engram, :cors_origin) end)
+
+    conn =
+      build_conn()
+      |> put_req_header("origin", "app://obsidian.md")
+      |> options("/api/health")
+
+    assert get_resp_header(conn, "access-control-allow-origin") == ["app://obsidian.md"]
+  end
+
+  test "list config falls back to first entry when Origin not in allowlist" do
+    Application.put_env(:engram, :cors_origin, [
+      "http://engram.ax",
+      "app://obsidian.md"
+    ])
+    on_exit(fn -> Application.delete_env(:engram, :cors_origin) end)
+
+    conn =
+      build_conn()
+      |> put_req_header("origin", "https://evil.example.com")
+      |> options("/api/health")
+
+    assert get_resp_header(conn, "access-control-allow-origin") == ["http://engram.ax"]
+  end
 end


### PR DESCRIPTION
## Summary
- Production CORS was locked to a single PHX_HOST origin, blocking the Obsidian plugin's device-flow `POST /api/auth/device` (fetch()-based, so browser CORS applies; `Origin: app://obsidian.md` ≠ `http://engram.ax`).
- `cors.ex` now accepts an allowlist and echoes the request Origin when it matches; falls back to first entry otherwise.
- `runtime.exs` CORS allowlist includes `app://obsidian.md`, `capacitor://localhost`, `http://localhost` (mobile + desktop) alongside the PHX_HOST origin.
- `device_auth_controller.start/2` now tolerates a missing `client_id` (defaults to `"unknown"`).

## Test plan
- [x] `mix test test/engram_web/plugs/cors_test.exs` — 6/6 pass (2 new tests for allowlist echo + fallback)
- [x] Local `make dev` smoke test — `POST /api/auth/device` from `Origin: app://obsidian.md` returns expected payload
- [ ] Post-deploy: confirm Obsidian plugin Sign in opens link page on .153
- [ ] Verify nginx access log shows `OPTIONS` followed by `POST /api/auth/device` from Obsidian client

🤖 Generated with [Claude Code](https://claude.com/claude-code)