### PR TITLE
fix: align access-token expires_in with actual JWT TTL

### DIFF
--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -13,7 +13,6 @@ defmodule Engram.Auth.DeviceFlow do
   @device_code_bytes 32
   @refresh_token_prefix "engram_rt_"
   @refresh_token_bytes 32
-  @access_token_ttl_seconds 3600
   @refresh_token_ttl_days 90
   @device_code_ttl_seconds 300
 
@@ -118,7 +117,7 @@ defmodule Engram.Auth.DeviceFlow do
          %{
            access_token: access_token,
            refresh_token: raw_refresh,
-           expires_in: @access_token_ttl_seconds
+           expires_in: Engram.Token.ttl_seconds()
          }}
     end
   end
@@ -157,7 +156,7 @@ defmodule Engram.Auth.DeviceFlow do
        refresh_token: raw_refresh,
        vault_id: auth.vault_id,
        user_email: auth.user.email,
-       expires_in: @access_token_ttl_seconds
+       expires_in: Engram.Token.ttl_seconds()
      }}
   end
 

--- a/lib/engram/auth/providers/local.ex
+++ b/lib/engram/auth/providers/local.ex
@@ -6,8 +6,6 @@ defmodule Engram.Auth.Providers.Local do
 
   @behaviour Engram.Auth.Provider
 
-  @access_token_ttl 15 * 60
-
   @impl true
   def verify_token(token) do
     case Engram.Token.verify_and_validate(token) do
@@ -55,7 +53,7 @@ defmodule Engram.Auth.Providers.Local do
     claims = %{
       "sub" => external_id,
       "email" => email,
-      "exp" => :os.system_time(:second) + @access_token_ttl,
+      "exp" => :os.system_time(:second) + Engram.Token.ttl_seconds(),
       "iss" => "engram",
       "aud" => "engram"
     }

--- a/lib/engram/token.ex
+++ b/lib/engram/token.ex
@@ -1,7 +1,15 @@
 defmodule Engram.Token do
   use Joken.Config
 
+  # Single source of truth for access-token lifetime. Used both as the JWT
+  # `exp` claim duration and as the `expires_in` field returned to clients —
+  # keeping these in sync is required for clients to refresh on time.
+  @ttl_seconds 15 * 60
+
   add_hook(Joken.Hooks.RequiredClaims, ["iss", "aud"])
+
+  @doc "Access-token lifetime in seconds."
+  def ttl_seconds, do: @ttl_seconds
 
   @impl true
   def token_config do
@@ -9,7 +17,7 @@ defmodule Engram.Token do
     # that would conflict with our explicit add_claim registrations below.
     # Without skip, Joken would try to register its own iss/aud generators and the
     # duplicate key definitions would raise a runtime error.
-    default_claims(default_exp: 15 * 60, skip: [:iss, :aud])
+    default_claims(default_exp: @ttl_seconds, skip: [:iss, :aud])
     |> add_claim("iss", fn -> "engram" end, &(&1 == "engram"))
     |> add_claim("aud", fn -> "engram" end, &(&1 == "engram"))
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.2",
+      version: "0.5.3",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/auth/device_flow_test.exs
+++ b/test/engram/auth/device_flow_test.exs
@@ -77,7 +77,21 @@ defmodule Engram.Auth.DeviceFlowTest do
       assert String.starts_with?(result.refresh_token, "engram_rt_")
       assert result.vault_id == vault.id
       assert result.user_email == user.email
-      assert result.expires_in == 3600
+      assert result.expires_in == Engram.Token.ttl_seconds()
+    end
+
+    test "expires_in matches the actual JWT exp claim" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+
+      issued_at = Joken.current_time()
+      {:ok, result} = DeviceFlow.exchange_device_code(auth.device_code)
+      {:ok, claims} = Engram.Token.verify_and_validate(result.access_token)
+
+      jwt_ttl = claims["exp"] - issued_at
+      assert_in_delta jwt_ttl, result.expires_in, 2
     end
 
     test "marks device code as consumed after exchange" do
@@ -112,7 +126,7 @@ defmodule Engram.Auth.DeviceFlowTest do
       assert is_binary(refreshed.access_token)
       assert is_binary(refreshed.refresh_token)
       assert refreshed.refresh_token != initial.refresh_token
-      assert refreshed.expires_in == 3600
+      assert refreshed.expires_in == Engram.Token.ttl_seconds()
     end
 
     test "old refresh token is revoked after rotation" do

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -81,7 +81,7 @@ defmodule EngramWeb.DeviceAuthControllerTest do
       assert String.starts_with?(resp["refresh_token"], "engram_rt_")
       assert resp["vault_id"] == vault.id
       assert resp["user_email"] == user.email
-      assert resp["expires_in"] == 3600
+      assert resp["expires_in"] == Engram.Token.ttl_seconds()
     end
 
     test "returns expired for consumed code", %{conn: conn} do
@@ -110,7 +110,7 @@ defmodule EngramWeb.DeviceAuthControllerTest do
       assert is_binary(resp["access_token"])
       assert is_binary(resp["refresh_token"])
       assert resp["refresh_token"] != tokens.refresh_token
-      assert resp["expires_in"] == 3600
+      assert resp["expires_in"] == Engram.Token.ttl_seconds()
     end
 
     test "rejects revoked refresh token", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Server returned `expires_in: 3600` while Joken's `default_exp` was 900s, so clients delayed refresh by ~45 min and produced a flood of 401s once the JWT expired but before the client refreshed.
- Single source of truth: `Engram.Token.ttl_seconds/0` — used both for the JWT `exp` claim and the `expires_in` returned to clients. Device flow + Local provider now derive TTL from this helper.

## Why this was hard to spot
Two TTLs in two files looked plausible because they were both labeled "access token TTL" and both written as `15 * 60` / `3600`. Verified the bug by capturing a real client JWT and replaying it through `Engram.Token.verify_and_validate/1` — only the `exp` claim failed; signature passed. Redeploy was a coincidence.

## Test plan
- [x] `mix test` — 820 tests, 0 failures
- [x] New test: `expires_in matches the actual JWT exp claim` — proves the two values are derived from one source
- [x] Existing controller + device-flow tests updated to assert against `Engram.Token.ttl_seconds()` instead of the literal `3600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)