### PR TITLE
chore: log reason on auth rejection

### DIFF
--- a/lib/engram/auth/token_resolver.ex
+++ b/lib/engram/auth/token_resolver.ex
@@ -46,11 +46,20 @@ defmodule Engram.Auth.TokenResolver do
   def resolve(_), do: {:error, :invalid_token}
 
   defp authenticate_internal_jwt(token) do
-    with {:ok, %{"user_id" => user_id}} when is_integer(user_id) <- Accounts.verify_jwt(token),
-         %Accounts.User{} = user <- Accounts.get_user(user_id) do
-      {:ok, user}
-    else
-      _ -> {:error, :invalid_token}
+    case Accounts.verify_jwt(token) do
+      {:ok, %{"user_id" => user_id}} when is_integer(user_id) ->
+        case Accounts.get_user(user_id) do
+          %Accounts.User{} = user -> {:ok, user}
+          _ -> {:error, :user_not_found}
+        end
+
+      {:ok, _claims} ->
+        {:error, :missing_claims}
+
+      {:error, reason} ->
+        # Preserve Joken's structured failure (e.g. [claim: "exp", ...]) so the
+        # auth plug can log *why* the token was rejected.
+        {:error, reason}
     end
   end
 end

--- a/lib/engram_web/plugs/auth.ex
+++ b/lib/engram_web/plugs/auth.ex
@@ -7,9 +7,12 @@ defmodule EngramWeb.Plugs.Auth do
   3. Legacy JWT: `Authorization: Bearer <jwt-without-kid>` — for backward compat (HS256)
 
   Sets `conn.assigns.current_user` on success, halts with 401 on failure.
+  Logs the failure reason at :info so 401s in production are diagnosable
+  (expired token vs bad signature vs missing user) without a redeploy.
   """
 
   import Plug.Conn
+  require Logger
 
   def init(opts), do: opts
 
@@ -23,7 +26,9 @@ defmodule EngramWeb.Plugs.Auth do
         |> assign(:current_user, user)
         |> assign(:current_api_key, api_key)
 
-      {:error, _reason} ->
+      {:error, reason} ->
+        Logger.info("auth rejected: #{format_reason(reason)} path=#{conn.request_path}")
+
         conn
         |> put_resp_content_type("application/json")
         |> send_resp(401, Jason.encode!(%{error: "unauthorized"}))
@@ -37,4 +42,17 @@ defmodule EngramWeb.Plugs.Auth do
       _ -> {:error, :no_auth}
     end
   end
+
+  # Joken returns its claim-validation failures as a keyword list (e.g.
+  # [message: "Invalid token", claim: "exp", claim_val: 1777359682]). Surface
+  # the offending claim so "expired" looks different from "bad signature" in logs.
+  defp format_reason(reason) when is_list(reason) do
+    case Keyword.get(reason, :claim) do
+      nil -> "invalid_token (#{Keyword.get(reason, :message, "unknown")})"
+      claim -> "claim_invalid:#{claim}"
+    end
+  end
+
+  defp format_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_reason(reason), do: inspect(reason)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.3",
+      version: "0.5.4",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/plugs/auth_test.exs
+++ b/test/engram_web/plugs/auth_test.exs
@@ -1,6 +1,8 @@
 defmodule EngramWeb.Plugs.AuthTest do
   use EngramWeb.ConnCase, async: false
 
+  import ExUnit.CaptureLog
+
   alias Engram.Accounts
   alias EngramWeb.Plugs.Auth
 
@@ -67,6 +69,46 @@ defmodule EngramWeb.Plugs.AuthTest do
 
     assert conn.status == 401
     assert conn.halted
+  end
+
+  describe "401 logging" do
+    setup do
+      previous_level = Logger.level()
+      Logger.configure(level: :info)
+      on_exit(fn -> Logger.configure(level: previous_level) end)
+      :ok
+    end
+
+    test "logs claim_invalid:exp when access token is expired" do
+      claims = %{
+        "user_id" => 1,
+        "iss" => "engram",
+        "aud" => "engram",
+        "exp" => Joken.current_time() - 60
+      }
+
+      signer = Joken.Signer.create("HS256", Application.get_env(:joken, :default_signer))
+      {:ok, expired_token} = Joken.Signer.sign(claims, signer)
+
+      log =
+        capture_log([level: :info], fn ->
+          build_conn()
+          |> put_req_header("authorization", "Bearer #{expired_token}")
+          |> Auth.call([])
+        end)
+
+      assert log =~ "auth rejected"
+      assert log =~ "claim_invalid:exp"
+    end
+
+    test "logs no_auth when authorization header is missing" do
+      log =
+        capture_log([level: :info], fn ->
+          build_conn() |> Auth.call([])
+        end)
+
+      assert log =~ "auth rejected: no_auth"
+    end
   end
 
   test "returns 401 for JWT referencing deleted user" do


### PR DESCRIPTION
## Summary
- Auth plug halted with a generic 401 and no log line, so production 401 floods required code-side decoding to diagnose. Now emits a structured `:info` log on rejection (e.g. `claim_invalid:exp`, `no_auth`, `invalid_signature`, `user_not_found`).
- `TokenResolver.authenticate_internal_jwt/1` previously flattened any error to `:invalid_token`, swallowing Joken's structured failure. Pass it through so the offending claim survives.

## Context
Standalone defense-in-depth — independent from the access-token TTL fix and the plugin 401-retry. With this in place, future 401 floods are diagnosable from logs alone.

## Test plan
- [x] `mix test` — 821 tests, 0 failures
- [x] New tests: expired JWT logs `claim_invalid:exp`, missing auth header logs `no_auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)