### PR TITLE
ci+chore: skip backend-internal jobs on plugin dispatch; add pre-push version hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Pre-push hook: refuse to push branches whose mix.exs version still matches
+# main. CI's `version-check` job enforces the same rule, but failing here
+# shaves ~30s off the feedback loop and avoids burning a CI runner.
+#
+# Bypass for WIP / draft branches with: git push --no-verify
+
+set -euo pipefail
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Allow main, tags, and detached HEAD to push freely.
+if [ "$current_branch" = "main" ] || [ "$current_branch" = "HEAD" ]; then
+  exit 0
+fi
+
+# Compare branch version against origin/main. If origin/main is unfetched, skip
+# the check rather than block the push — fetching here would slow every push.
+if ! git rev-parse --verify --quiet origin/main >/dev/null; then
+  exit 0
+fi
+
+extract_version() {
+  grep -m1 'version:' "$1" 2>/dev/null | sed 's/.*"\(.*\)".*/\1/'
+}
+
+branch_version="$(extract_version mix.exs)"
+main_version="$(git show origin/main:mix.exs 2>/dev/null | grep -m1 'version:' | sed 's/.*"\(.*\)".*/\1/')"
+
+if [ -z "$branch_version" ] || [ -z "$main_version" ]; then
+  exit 0
+fi
+
+if [ "$branch_version" = "$main_version" ]; then
+  cat >&2 <<EOF
+✖ pre-push: mix.exs version ($branch_version) has not been bumped from main.
+
+  Bump the version in mix.exs before pushing:
+    sed -i 's/version: "$main_version"/version: "<new>"/' mix.exs
+
+  To push WIP without bumping, use: git push --no-verify
+EOF
+  exit 1
+fi
+
+echo "✓ pre-push: mix.exs version differs from main (main=$main_version, branch=$branch_version)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,15 @@ on:
         required: false
         default: "main"
 
+# Serialize all backend CI runs on the self-hosted runner pool. Two parallel
+# `docker compose build` invocations collide on the shared buildkit cache
+# mounts (`id=mix-deps`, `id=mix-build`) and intermittently abort with
+# "graceful_stop" mid-compile. Queue runs instead of cancelling so plugin
+# dispatches and main pushes both complete.
+concurrency:
+  group: engram-backend-ci
+  cancel-in-progress: false
+
 env:
   DOCKER_BUILDKIT: "1"
   COMPOSE_DOCKER_CLI_BUILD: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,8 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   unit-tests:
+    # Skip on cross-repo plugin dispatch — plugin can't regress backend ExUnit.
+    if: github.event_name != 'repository_dispatch'
     runs-on: [self-hosted, engram]
 
     env:
@@ -547,6 +549,9 @@ jobs:
         run: find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   e2e-local:
+    # Skip on cross-repo plugin dispatch — plugin uses Clerk JWTs in production,
+    # so the local-auth API path is backend-internal.
+    if: github.event_name != 'repository_dispatch'
     runs-on: [self-hosted, engram]
 
     env:
@@ -668,6 +673,9 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   e2e-browser:
+    # Skip on cross-repo plugin dispatch — Playwright targets backend's React
+    # frontend, which the plugin (separate repo) cannot affect.
+    if: github.event_name != 'repository_dispatch'
     runs-on: [self-hosted, engram]
 
     env:
@@ -810,15 +818,29 @@ jobs:
           EL="${{ needs.e2e-local.result }}"
           EB="${{ needs.e2e-browser.result }}"
 
-          # version-check is skipped on main (only runs on branches) — that's expected
+          # version-check is skipped on main (only runs on branches) — that's expected.
           if [ "$VC" != "success" ] && [ "$VC" != "skipped" ]; then
             echo "::error::version-check failed — bump mix.exs version before merging"
             exit 1
           fi
-          if [ "$UT" != "success" ] || [ "$EC" != "success" ] || [ "$EL" != "success" ] || [ "$EB" != "success" ]; then
-            echo "Required jobs failed: unit-tests=$UT, e2e-clerk=$EC, e2e-local=$EL, e2e-browser=$EB"
+
+          # e2e-clerk is the only job that exercises the plugin↔backend contract,
+          # so it must succeed regardless of trigger.
+          if [ "$EC" != "success" ]; then
+            echo "::error::e2e-clerk failed: $EC"
             exit 1
           fi
+
+          # On cross-repo plugin dispatch (plugin-e2e-trigger), unit-tests / e2e-local
+          # / e2e-browser are intentionally skipped — plugin cannot regress backend
+          # internals. Only assert success when those jobs actually ran.
+          for pair in "unit-tests=$UT" "e2e-local=$EL" "e2e-browser=$EB"; do
+            name="${pair%=*}"; result="${pair#*=}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "::error::$name failed: $result"
+              exit 1
+            fi
+          done
 
   deploy-fastraid:
     if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.ci.result == 'success'

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Any AI assistant that speaks MCP can query your vault:
 
 ```bash
 mix deps.get
-mix ecto.setup    # Create DB + run migrations + seeds
+mix ecto.setup            # Create DB + run migrations + seeds
+bash scripts/install-hooks.sh  # One-time: enables pre-push version-bump check
 ```
 
 ### 2. Configure

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.4",
+      version: "0.5.5",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Point this clone's git hooks at .githooks/ in the repo. Run once after
+# cloning; idempotent.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+git config core.hooksPath .githooks
+chmod +x .githooks/*
+echo "✓ Git hooks installed: $(git config core.hooksPath)"


### PR DESCRIPTION
## Summary
- **Workflow gate:** plugin's cross-repo dispatch (`plugin-e2e-trigger`) used to fire all 5 backend jobs. Only `e2e-clerk` exercises the plugin↔backend contract — the other three (`unit-tests`, `e2e-local`, `e2e-browser`) test backend internals the plugin can't reach (separate repo, plugin uses Clerk JWTs in production). Skip them on dispatch. `ci` rollup treats `skipped` as acceptable for the gated jobs but still requires `e2e-clerk` success.
- **Pre-push hook:** new `.githooks/pre-push` aborts if `mix.exs` version matches `origin/main`. Catches forgotten bumps ~30s before CI would. Bypass with `--no-verify`. Wired up via `scripts/install-hooks.sh` (one-time setup; README updated).

## Why
Plugin PRs were ~5 min of mostly-noise backend CI. With the gate, only the job that can actually fail runs — saves runner time and gets `backend/e2e` posted faster, unblocking plugin merges sooner. Pre-push hook is paired defense for the version-check that's burned several CI cycles this week.

## Test plan
- [x] Local hook self-tested (rejects matching version, accepts bumped)
- [x] Hook ran on this branch's push and approved 0.5.5
- [ ] After merge: confirm next plugin PR's dispatched backend run shows only `e2e-clerk` running

🤖 Generated with [Claude Code](https://claude.com/claude-code)