### PR TITLE
feat: mix engram.set_cooldown admin task

### DIFF
--- a/lib/engram/accounts.ex
+++ b/lib/engram/accounts.ex
@@ -252,6 +252,24 @@ defmodule Engram.Accounts do
     |> Repo.update(skip_tenant_check: true)
   end
 
+  @doc """
+  Set per-user encryption-toggle cooldown.
+
+  `days` may be `nil` (no cooldown — user can re-toggle immediately) or a
+  non-negative integer (days the user must wait between encrypt/decrypt
+  toggles). Negative values raise `FunctionClauseError`. Used by the hosted
+  operator to throttle abusive toggling per user without affecting
+  self-hosted defaults (which leave the column NULL).
+  """
+  @spec set_encryption_toggle_cooldown_days(Engram.Accounts.User.t(), nil | non_neg_integer()) ::
+          {:ok, Engram.Accounts.User.t()} | {:error, Ecto.Changeset.t()}
+  def set_encryption_toggle_cooldown_days(%User{} = user, days)
+      when is_nil(days) or (is_integer(days) and days >= 0) do
+    user
+    |> Ecto.Changeset.change(%{encryption_toggle_cooldown_days: days})
+    |> Repo.update(skip_tenant_check: true)
+  end
+
   # ── JWT ─────────────────────────────────────────────────────────
 
   def generate_jwt(user) do

--- a/lib/mix/tasks/engram.set_cooldown.ex
+++ b/lib/mix/tasks/engram.set_cooldown.ex
@@ -1,0 +1,74 @@
+defmodule Mix.Tasks.Engram.SetCooldown do
+  @moduledoc """
+  Set per-user encryption-toggle cooldown without dropping into raw SQL.
+
+      mix engram.set_cooldown <user_id> <days|null>
+
+  `days` accepts a non-negative integer (cooldown in days) or `null`/`none`
+  to clear the column (the user can re-toggle encryption immediately).
+  Used by the hosted operator until a Stripe-webhook driver is in place;
+  see `docs/encryption-toggle-followups.md` Phase 3 #10.
+  """
+
+  use Mix.Task
+
+  alias Engram.Accounts
+
+  @shortdoc "Set encryption_toggle_cooldown_days for a user"
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    case args do
+      [user_id_str, days_str] ->
+        with {:ok, user_id} <- parse_user_id(user_id_str),
+             {:ok, days} <- parse_days(days_str) do
+          do_set(user_id, days)
+        else
+          {:error, msg} ->
+            Mix.shell().error(msg)
+            System.halt(1)
+        end
+
+      _ ->
+        Mix.shell().error("Usage: mix engram.set_cooldown <user_id> <days|null>")
+        System.halt(1)
+    end
+  end
+
+  defp parse_user_id(s) do
+    case Integer.parse(s) do
+      {n, ""} when n > 0 -> {:ok, n}
+      _ -> {:error, "user_id must be a positive integer (got #{inspect(s)})"}
+    end
+  end
+
+  defp parse_days(s) when s in ["null", "none", "NULL"], do: {:ok, nil}
+
+  defp parse_days(s) do
+    case Integer.parse(s) do
+      {n, ""} when n >= 0 -> {:ok, n}
+      _ -> {:error, "days must be a non-negative integer or 'null' (got #{inspect(s)})"}
+    end
+  end
+
+  defp do_set(user_id, days) do
+    case Accounts.get_user(user_id) do
+      nil ->
+        Mix.shell().error("No user with id=#{user_id}")
+        System.halt(1)
+
+      user ->
+        case Accounts.set_encryption_toggle_cooldown_days(user, days) do
+          {:ok, _user} ->
+            label = if is_nil(days), do: "NULL (no cooldown)", else: "#{days} day(s)"
+            Mix.shell().info("Set user #{user_id} cooldown to #{label}")
+
+          {:error, changeset} ->
+            Mix.shell().error("Update failed: #{inspect(changeset.errors)}")
+            System.halt(1)
+        end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.7",
+      version: "0.5.8",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/accounts_test.exs
+++ b/test/engram/accounts_test.exs
@@ -163,4 +163,36 @@ defmodule Engram.AccountsTest do
       assert {:error, _reason} = Accounts.verify_jwt("garbage.token.here")
     end
   end
+
+  describe "set_encryption_toggle_cooldown_days/2" do
+    test "stores integer days" do
+      user = insert(:user)
+      assert {:ok, updated} = Accounts.set_encryption_toggle_cooldown_days(user, 7)
+      assert updated.encryption_toggle_cooldown_days == 7
+    end
+
+    test "stores zero (treated as 'no cooldown' by Crypto)" do
+      user = insert(:user)
+      assert {:ok, updated} = Accounts.set_encryption_toggle_cooldown_days(user, 0)
+      assert updated.encryption_toggle_cooldown_days == 0
+    end
+
+    test "clears column to NULL" do
+      user =
+        insert(:user)
+        |> Ecto.Changeset.change(%{encryption_toggle_cooldown_days: 7})
+        |> Engram.Repo.update!(skip_tenant_check: true)
+
+      assert {:ok, updated} = Accounts.set_encryption_toggle_cooldown_days(user, nil)
+      assert updated.encryption_toggle_cooldown_days == nil
+    end
+
+    test "rejects negative days at the function clause" do
+      user = insert(:user)
+
+      assert_raise FunctionClauseError, fn ->
+        Accounts.set_encryption_toggle_cooldown_days(user, -1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- New `mix engram.set_cooldown <user_id> <days|null>` Mix task — replaces the raw-SQL admin path for setting `users.encryption_toggle_cooldown_days`.
- New `Engram.Accounts.set_encryption_toggle_cooldown_days/2` helper keeps validation (non-negative integer or nil) in the context module; the Mix task is a thin CLI wrapper.

## Test plan

- [x] `mix test test/engram/accounts_test.exs` — 19/19 pass
- [x] Compile clean
- [ ] Manual smoke on FastRaid: `docker exec engram bin/engram eval 'Mix.Tasks.Engram.SetCooldown.run(["1", "7"])'` (or `mix engram.set_cooldown 1 7` from a release)

Closes Phase 2 #7 from `docs/encryption-toggle-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)