### PR TITLE
feat: settings, multi-vault UI, file tree, search overhaul, dev cleanup

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -36,8 +36,12 @@ config :engram, EngramWeb.Endpoint,
   code_reloader: true,
   debug_errors: true,
   secret_key_base: "hZXoe4bVk7sJkF6CT/1jG+/4X03lcdTECjUFOWwKSlF0KAecv1CROWuFYqrtzY3k",
+  # No Vite watcher here — Phoenix spawns watchers as Port children that
+  # don't get cleaned up on BEAM SIGKILL, leaving orphan node processes
+  # holding :5173+ across restarts. Run `make frontend-dev` separately
+  # when you want hot-reload at :5173, or `bun run build` to refresh the
+  # bundle Phoenix serves at :4000 / engram.ras.band.
   watchers: [
-    npm: ["run", "dev", "--", "--clearScreen", "false", cd: Path.expand("../frontend", __DIR__)],
     tailwind: {Tailwind, :install_and_run, [:marketing, ~w(--watch)]}
   ]
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -76,6 +76,12 @@ config :engram, :qdrant_collection, "engram_notes"
 # Enable dev routes for dashboard and mailbox
 config :engram, dev_routes: true
 
+# Disable SPA index.html cache so `vite build` (or `bun run build`)
+# rewriting priv/static/app/index.html is picked up immediately —
+# without this, Phoenix keeps serving the old asset hash and the
+# browser 404s on the (now-deleted) JS file, producing a white page.
+config :engram, :spa_cache_enabled?, false
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :default_formatter, format: "[$level] $message\n"
 

--- a/docs/context/dev-iteration-loop.md
+++ b/docs/context/dev-iteration-loop.md
@@ -1,0 +1,59 @@
+# Dev iteration loop (frontend + backend)
+
+How to make changes show up in a browser when iterating locally on this VM. Pattern is non-obvious; this doc exists because we hit a white-page mystery on 2026-04-30.
+
+## TL;DR
+
+- **Phoenix** (`make dev`): serves API + the **prod-built** SPA bundle from `priv/static/app/`. Listens on `:4000`.
+- **Vite** (`make frontend-dev` / `bun run dev` in `backend/frontend`): hot-reload dev server on `:5173`. Proxies `/api` and `/socket` back to Phoenix on `:4000`.
+- The user-facing host **`engram.ras.band`** (hosts file alias / external route) **routes to this VM's `:4000`**, i.e. to Phoenix. Vite (:5173) is reachable only as `localhost:5173`.
+
+| Want                                | Hit                                  | Requires                                    |
+| ----------------------------------- | ------------------------------------ | ------------------------------------------- |
+| Frontend hot-reload while editing   | `http://localhost:5173/app/`         | `make frontend-dev` running                 |
+| Test prod bundle locally            | `http://localhost:4000/app/`         | `make dev` running + `bun run build`        |
+| Share with friends / external test  | `https://engram.ras.band/app/`       | `make dev` running + `bun run build`        |
+
+> **Important:** `engram.ras.band` only sees what Phoenix serves. To make changes visible there during dev, you must run `bun run build` inside `backend/frontend/` so Phoenix has the new static bundle to ship.
+
+## The white-page gotcha (and the fix)
+
+`EngramWeb.SpaController` injects the runtime `__ENGRAM_CONFIG__` script into `priv/static/app/index.html`. To avoid re-reading the file on every request, it caches the split-around-`</head>` result in `:persistent_term`.
+
+**Original cache invalidation strategy:** none. The persistent term lived until the BEAM restarted.
+
+**Failure mode:** `bun run build` rewrote `index.html` with a new asset hash (e.g. `index-BAZotJj3.js`) and **deleted** the old hashed file (`index-4FbQ3RR3.js`). Phoenix kept serving the cached pre-rebuild HTML pointing to the deleted asset. Browser 404'd on the JS module → React never mounted → white page. No console error in Phoenix logs — the HTML response is 200, only the asset request 404s.
+
+**Symptom signature:**
+
+- `curl http://localhost:4000/app/ | grep index-` returns an asset hash that is **not** present in `priv/static/app/assets/`.
+- DevTools Network tab shows 404 on the JS module.
+- DevTools Console shows nothing (the failure is at `<script type="module">` resolution, before any app code runs).
+
+**Fix:** `config/dev.exs` sets `:spa_cache_enabled?` to `false`. SpaController checks this flag and skips the persistent_term in dev/test, rebuilding the split on every request. `index.html` is ~1KB so the cost is negligible. Prod keeps the cache (one read per BEAM lifetime).
+
+If you ever see a white page on `:4000` or `engram.ras.band` after a rebuild and the controller cache is somehow re-enabled, the recovery is `make dev-stop && make dev`.
+
+## When to rebuild / restart
+
+| Change                                          | Action                                                        |
+| ----------------------------------------------- | ------------------------------------------------------------- |
+| Edit `.ex` file                                 | Phoenix code-reloads automatically (Bandit + `Code.reload!`)  |
+| Edit `config/dev.exs`                           | Restart Phoenix (`make dev-stop && make dev`)                 |
+| Edit `.tsx`/`.ts`/`.css` and viewing on `:5173` | Vite hot-reloads automatically                                |
+| Edit `.tsx`/`.ts`/`.css` and viewing on `:4000` or `engram.ras.band` | `bun run build` in `backend/frontend/`. No Phoenix restart needed (cache disabled in dev). |
+
+## Background-process recipe
+
+When iterating with the user, start both servers as backgrounded shells:
+
+```
+make dev                                                  # Phoenix :4000
+cd backend/frontend && bun run dev                        # Vite :5173
+```
+
+Steer the user to `:5173` for fast feedback. If they're on `engram.ras.band`, every UI change requires `bun run build` first. If the page goes white after a rebuild, suspect SPA cache (verify with the curl/grep above) before suspecting JS errors.
+
+## TODO
+
+Document the actual mechanism that makes `engram.ras.band` resolve to this VM's `:4000` (hosts file? Tailscale Funnel? Cloudflare tunnel? reverse proxy on FastRaid?). The "alpha test" plan depends on friends hitting this URL externally — needs a deploy target description, not just a dev-loop description.

--- a/docs/context/dev-iteration-loop.md
+++ b/docs/context/dev-iteration-loop.md
@@ -45,12 +45,21 @@ If you ever see a white page on `:4000` or `engram.ras.band` after a rebuild and
 
 ## Background-process recipe
 
-When iterating with the user, start both servers as backgrounded shells:
+When iterating with the user, start servers as backgrounded shells:
 
 ```
-make dev                                                  # Phoenix :4000
-cd backend/frontend && bun run dev                        # Vite :5173
+make dev                                                  # Phoenix :4000 only
+make frontend-dev                                         # Vite :5173 (separate terminal, only if you want hot-reload)
 ```
+
+> **Phoenix no longer auto-spawns Vite.** It used to via `config/dev.exs`'s
+> `watchers:` list, but Phoenix launches watchers as Port children that
+> survive `pkill -9` on the BEAM, leaving orphan `node` processes holding
+> :5173, :5174, :5175… across restarts. Vite is now only started by
+> explicit `make frontend-dev`.
+>
+> `make dev-stop` also kills any stray listeners on :5173–:5199 as a
+> safety net.
 
 Steer the user to `:5173` for fast feedback. If they're on `engram.ras.band`, every UI change requires `bun run build` first. If the page goes white after a rebuild, suspect SPA cache (verify with the curl/grep above) before suspecting JS errors.
 

--- a/docs/context/encryption-operations.md
+++ b/docs/context/encryption-operations.md
@@ -1,0 +1,112 @@
+# Context Doc: Encryption-at-Rest Operations
+
+_Last verified: 2026-04-30_
+
+## Status
+Notes-level encryption is shipped (Phase 1-6, PRs #37/#38/#43/#50). Attachments remain plaintext (Phase 7 pending — see `docs/encryption-toggle-followups.md`).
+
+## What This Is
+Operator runbook for encryption toggling, per-user cooldown, and incident triage. Companion to the architecture spec at `docs/superpowers/specs/2026-04-07-encryption-at-rest-design.md`.
+
+## Per-User Toggle Cooldown
+
+Users can encrypt/decrypt their vaults via the plugin (`POST /api/vaults/:id/encrypt`, `POST /api/vaults/:id/decrypt`). To prevent abusive flapping, each user has an independent `users.encryption_toggle_cooldown_days INTEGER NULL` column.
+
+| Value | Behavior |
+|-------|----------|
+| `NULL` (default) | No cooldown — user can re-toggle immediately. This is the self-hosted default. |
+| `0` | Treated identically to `NULL` (no cooldown). |
+| `N > 0` | User must wait `N` days between encrypt and decrypt toggles. Server returns `429` with an ISO-8601 `retry_after` body when the gate fires. |
+
+The plugin reads the effective `cooldown_days` from the vault JSON (`/api/vaults`) so it can surface "next toggle in N days" without a probe POST.
+
+### Setting the cooldown
+
+```bash
+# In a release shell on the FastRaid container
+docker exec -it engram bin/engram remote
+iex> Engram.Accounts.set_encryption_toggle_cooldown_days(Engram.Accounts.get_user!(<id>), 7)
+
+# OR from a dev shell with .env.elixir loaded
+mix engram.set_cooldown <user_id> <days|null>
+```
+
+The Mix task accepts `null`, `none`, or `NULL` to clear the column. Negative values are rejected at the function-clause level — there is no `0`-vs-`NULL` distinction at the Crypto layer (both bypass the cooldown predicate).
+
+Hosted-mode default policy (until Stripe webhook wiring lands per follow-up #10): the operator sets cooldown manually per user, typically by tier (Free=1 day, Pro=NULL).
+
+## Toggle Flow & State Machine
+
+`vaults.encryption_status` transitions:
+
+```
+none ─encrypt─▶ encrypting ─backfill done─▶ encrypted
+                                                │
+                                          decrypt-request
+                                                ▼
+                                          decrypt_pending  (24h cancel window)
+                                                │
+                                       cancel│   │auto after 24h
+                                                ▼
+                                          decrypting ─backfill done─▶ none
+```
+
+`vaults.last_toggle_at` is set on every state-changing call (encrypt, decrypt, cancel). The cooldown predicate compares `last_toggle_at` against the user's `encryption_toggle_cooldown_days`.
+
+The 24-hour `decrypt_pending` window is **cancellable**: the user can `DELETE /api/vaults/:id/decrypt` to abort, which returns the vault to `encrypted` without consuming a cooldown cycle.
+
+## What's Encrypted
+
+| Surface | Field(s) | Status |
+|---------|----------|--------|
+| Postgres `notes` | `content`, `title`, `tags` | ✅ ciphertext when vault is encrypted |
+| Qdrant payload | `text`, `title`, `heading_path` | ✅ ciphertext (Jina/Voyage never sees plaintext for encrypted vaults) |
+| Postgres `attachments` | `content`, `name` | ❌ plaintext (Phase 7 pending) |
+| Tigris/S3 attachment bytes | binary blob | ❌ plaintext (Phase 7 pending) |
+
+**Don't claim "encryption at rest" without that caveat.** Attachment-bearing vaults are not fully encrypted today — communicate this in support contexts.
+
+## Triage Recipes
+
+### A user reports stuck encryption
+
+Check the vault row:
+```sql
+SELECT id, encryption_status, encrypted, last_toggle_at, decrypt_requested_at
+FROM vaults WHERE id = <vault_id>;
+```
+
+If status is `encrypting` or `decrypting`, look at the Oban queue:
+```sql
+SELECT id, worker, args, state, attempt, errors
+FROM oban_jobs
+WHERE worker LIKE '%EncryptVault%' OR worker LIKE '%DecryptVault%'
+ORDER BY id DESC LIMIT 20;
+```
+
+A discarded job means retries exhausted — read `errors[*].error` to diagnose. The worker is **idempotent on retry** as of PR #50: it filters out notes whose ciphertext is already populated, so re-enqueueing is safe.
+
+### A user is hitting 429 unexpectedly
+
+Check the user's cooldown:
+```sql
+SELECT id, email, encryption_toggle_cooldown_days FROM users WHERE id = <user_id>;
+```
+
+The 429 body's `retry_after` is `last_toggle_at + cooldown_days`. If cooldown_days is set unintentionally (e.g., during a tier downgrade), clear it via the Mix task.
+
+### A user asks "is my data encrypted?"
+
+Confirm both:
+1. `vaults.encryption_status = 'encrypted'` for their active vault.
+2. They have **no attachments** in that vault, OR they understand attachments are still plaintext.
+
+If they have attachments and need full coverage, Phase 7 isn't shipped yet — add them to a waitlist and flag in `docs/encryption-toggle-followups.md`.
+
+## References
+
+- Architecture spec: `docs/superpowers/specs/2026-04-07-encryption-at-rest-design.md`
+- Phase 6 implementation: PR #43 (toggle endpoints + backfill workers)
+- Cooldown implementation: PR #50 (per-user cooldown), PR #51 (mix task)
+- Plugin UI: PR #24 (encryption tab + status badge), PR #25 (error handling + persistent status row)
+- Follow-up tracking: `docs/encryption-toggle-followups.md`

--- a/e2e/tests/api_only/test_50_qdrant_binary_quantization.py
+++ b/e2e/tests/api_only/test_50_qdrant_binary_quantization.py
@@ -215,7 +215,10 @@ class TestSearchAPI:
         )
 
         results = resp.json().get("results", [])
-        paths = [r.get("source_path", "?") for r in results]
+        # /api/search now returns one row per note (not per chunk) with `path`
+        # carrying the source path. The Qdrant scroll above still uses
+        # `source_path` because that's the raw payload field name.
+        paths = [r.get("path", "?") for r in results]
         assert any(note_path in p for p in paths), (
             f"Expected '{note_path}' in /api/search results. "
             f"Got {len(results)} results with paths: {paths}"

--- a/e2e/tests/api_only/test_61_auth_agnostic.py
+++ b/e2e/tests/api_only/test_61_auth_agnostic.py
@@ -36,29 +36,44 @@ class TestMeEndpoint:
 
 
 class TestApiKeyAuth:
-    """API key creation and usage — works with any auth provider."""
+    """API key usage — works with any auth provider.
 
-    def test_create_and_use_api_key(self, api_sync, sync_user):
-        """Create an API key, then use it to authenticate."""
-        # Create API key
-        resp = api_sync.session.post(
-            f"{API_URL}/api-keys",
-            json={"name": "e2e-agnostic-test"},
-            timeout=10,
-        )
-        assert resp.status_code == 200, f"API key creation failed: {resp.text}"
-        api_key = resp.json().get("key")
-        assert api_key is not None
-        assert api_key.startswith("engram_")
+    API key *creation* via API-key auth is intentionally rejected (see
+    test_api_key_cannot_mint_more_keys); minting only happens via session
+    JWT, which the provision_user fixture exercises during setup.
+    """
 
-        # Use the new API key for /me
-        me_resp = requests.get(
+    def test_existing_api_key_authenticates_user_scoped_route(self, sync_user):
+        """The bootstrap API key authenticates /me regardless of provider."""
+        api_key = sync_user[2]
+        resp = requests.get(
             f"{API_URL}/me",
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=10,
         )
-        assert me_resp.status_code == 200
-        assert me_resp.json()["user"]["email"] == sync_user[0]
+        assert resp.status_code == 200
+        assert resp.json()["user"]["email"] == sync_user[0]
+
+    def test_api_key_cannot_mint_more_keys(self, api_sync):
+        """API-key auth on /api-keys returns 403.
+
+        Previously a vault-restricted API key could enumerate, mint, or
+        revoke sibling keys for the same user; the EngramWeb.Plugs.RequireSession
+        plug now restricts /api-keys/* to session/JWT auth only.
+        """
+        resp = api_sync.session.post(
+            f"{API_URL}/api-keys",
+            json={"name": "should-be-rejected"},
+            timeout=10,
+        )
+        assert resp.status_code == 403, f"Expected 403, got {resp.status_code}: {resp.text}"
+        assert resp.json().get("error") == "api_key_not_allowed"
+
+    def test_api_key_cannot_list_keys(self, api_sync):
+        """API-key auth on GET /api-keys returns 403 — credential enumeration block."""
+        resp = api_sync.session.get(f"{API_URL}/api-keys", timeout=10)
+        assert resp.status_code == 403
+        assert resp.json().get("error") == "api_key_not_allowed"
 
 
 class TestTokenRejection:

--- a/frontend/src/api/active-vault.ts
+++ b/frontend/src/api/active-vault.ts
@@ -1,0 +1,48 @@
+import { useSyncExternalStore } from 'react'
+
+const STORAGE_KEY = 'engram.activeVaultId'
+
+let activeVaultId: number | null = readStored()
+const listeners = new Set<() => void>()
+
+function readStored(): number | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const n = Number(raw)
+    return Number.isFinite(n) && n > 0 ? n : null
+  } catch {
+    return null
+  }
+}
+
+function writeStored(id: number | null) {
+  try {
+    if (id == null) localStorage.removeItem(STORAGE_KEY)
+    else localStorage.setItem(STORAGE_KEY, String(id))
+  } catch {
+    // ignore — private browsing, etc.
+  }
+}
+
+export function getActiveVaultId(): number | null {
+  return activeVaultId
+}
+
+export function setActiveVaultId(id: number | null) {
+  if (activeVaultId === id) return
+  activeVaultId = id
+  writeStored(id)
+  listeners.forEach((l) => l())
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function useActiveVaultId(): number | null {
+  return useSyncExternalStore(subscribe, getActiveVaultId, getActiveVaultId)
+}

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -6,6 +6,7 @@ let channel: Channel | null = null
 
 interface ConnectOptions {
   userId: number
+  vaultId: number
   getToken: () => Promise<string | null>
   queryClient: QueryClient
 }
@@ -16,7 +17,7 @@ interface NoteChangedPayload {
   kind: string
 }
 
-export async function connectChannel({ userId, getToken, queryClient }: ConnectOptions) {
+export async function connectChannel({ userId, vaultId, getToken, queryClient }: ConnectOptions) {
   disconnectChannel()
 
   const token = await getToken()
@@ -27,20 +28,21 @@ export async function connectChannel({ userId, getToken, queryClient }: ConnectO
 
   socket.connect()
 
-  channel = socket.channel(`sync:${userId}`)
+  const topic = `sync:${userId}:${vaultId}`
+  channel = socket.channel(topic)
 
   channel.on('note_changed', (payload: NoteChangedPayload) => {
     if (payload.kind === 'note') {
-      queryClient.invalidateQueries({ queryKey: ['note', payload.path] })
-      queryClient.invalidateQueries({ queryKey: ['folders'] })
-      queryClient.invalidateQueries({ queryKey: ['folderNotes'] })
-      queryClient.invalidateQueries({ queryKey: ['search'] })
+      queryClient.invalidateQueries({ queryKey: ['note', vaultId, payload.path] })
+      queryClient.invalidateQueries({ queryKey: ['folders', vaultId] })
+      queryClient.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
+      queryClient.invalidateQueries({ queryKey: ['search', vaultId] })
     }
   })
 
   channel
     .join()
-    .receive('ok', () => console.log(`Joined sync:${userId}`))
+    .receive('ok', () => console.log(`Joined ${topic}`))
     .receive('error', (resp) => console.error('Channel join failed', resp))
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,3 +1,5 @@
+import { getActiveVaultId } from './active-vault'
+
 // Module-level token getter — set by AuthTokenProvider component
 let tokenGetter: (() => Promise<string | null>) | null = null
 
@@ -19,6 +21,10 @@ async function authFetch(path: string, options: RequestInit = {}): Promise<Respo
   headers.set('Content-Type', 'application/json')
   if (token) {
     headers.set('Authorization', `Bearer ${token}`)
+  }
+  const vaultId = getActiveVaultId()
+  if (vaultId != null) {
+    headers.set('X-Vault-ID', String(vaultId))
   }
 
   const response = await fetch(`/api${path}`, { ...options, headers })

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -2,6 +2,13 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from './client'
 import { useActiveVaultId } from './active-vault'
 
+// Encode each path segment but preserve slashes so Phoenix's splat
+// routes match. encodeURIComponent on a full path produces %2F, which
+// Plug.Static rejects with 400 InvalidPathError before the router runs.
+function encodePathSegments(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/')
+}
+
 // Types matching backend JSON responses
 export interface Folder {
   name: string
@@ -60,7 +67,7 @@ export function useNote(path: string) {
   const vaultId = useActiveVaultId()
   return useQuery({
     queryKey: ['note', vaultId, path],
-    queryFn: () => api.get<Note>(`/notes/${encodeURIComponent(path)}`),
+    queryFn: () => api.get<Note>(`/notes/${encodePathSegments(path)}`),
     enabled: !!path,
   })
 }

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -32,8 +32,11 @@ export interface Note extends NoteSummary {
 export interface SearchResult {
   path: string
   title: string
+  folder: string
+  heading_path: string | null
   snippet: string
   score: number
+  match_count: number
 }
 
 export interface User {

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -150,7 +150,7 @@ export function useRevokeApiKey() {
 
 // Vault types (encryption fields are the ones we care about for settings)
 
-export type EncryptionStatus = 'disabled' | 'encrypting' | 'enabled' | 'decrypting'
+export type EncryptionStatus = 'none' | 'encrypting' | 'encrypted' | 'decrypt_pending'
 
 export interface Vault {
   id: number

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from './client'
 
 // Types matching backend JSON responses
@@ -104,5 +104,102 @@ export function useBillingStatus() {
   return useQuery({
     queryKey: ['billing', 'status'],
     queryFn: () => api.get<BillingStatus>('/billing/status'),
+  })
+}
+
+// API key types
+
+export interface ApiKey {
+  id: number
+  name: string
+  created_at: string
+  last_used: string | null
+}
+
+export interface CreatedApiKey {
+  id: number
+  name: string
+  key: string
+}
+
+// API key hooks
+
+export function useApiKeys() {
+  return useQuery({
+    queryKey: ['api-keys'],
+    queryFn: () => api.get<{ keys: ApiKey[] }>('/api-keys'),
+    select: (data) => data.keys,
+  })
+}
+
+export function useCreateApiKey() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (name: string) => api.post<CreatedApiKey>('/api-keys', { name }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['api-keys'] }),
+  })
+}
+
+export function useRevokeApiKey() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => api.del<{ deleted: boolean }>(`/api-keys/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['api-keys'] }),
+  })
+}
+
+// Vault types (encryption fields are the ones we care about for settings)
+
+export type EncryptionStatus = 'disabled' | 'encrypting' | 'enabled' | 'decrypting'
+
+export interface Vault {
+  id: number
+  name: string
+  description: string | null
+  slug: string
+  is_default: boolean
+  created_at: string
+  encrypted: boolean
+  encryption_status: EncryptionStatus
+  encrypted_at: string | null
+  decrypt_requested_at: string | null
+  last_toggle_at: string | null
+  cooldown_days: number | null
+}
+
+export interface EncryptionProgress {
+  processed: number
+  total: number
+  status: EncryptionStatus
+  started_at: string | null
+}
+
+// Vault hooks
+
+export function useVaults() {
+  return useQuery({
+    queryKey: ['vaults'],
+    queryFn: () => api.get<{ vaults: Vault[] }>('/vaults'),
+    select: (data) => data.vaults,
+  })
+}
+
+export function useEncryptVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => api.post<{ vault: Vault }>(`/vaults/${id}/encrypt`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['vaults'] })
+      qc.invalidateQueries({ queryKey: ['encryption-progress'] })
+    },
+  })
+}
+
+export function useEncryptionProgress(vaultId: number | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: ['encryption-progress', vaultId],
+    queryFn: () => api.get<EncryptionProgress>(`/vaults/${vaultId}/encryption_progress`),
+    enabled: enabled && vaultId !== undefined,
+    refetchInterval: enabled ? 3000 : false,
   })
 }

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -52,14 +52,14 @@ export function useFolders() {
   })
 }
 
-export function useFolderNotes(folder: string) {
+export function useFolderNotes(folder: string, options?: { enabled?: boolean }) {
   const vaultId = useActiveVaultId()
   return useQuery({
     queryKey: ['folderNotes', vaultId, folder],
     queryFn: () =>
       api.get<{ notes: NoteSummary[] }>(`/folders/list?folder=${encodeURIComponent(folder)}`),
     select: (data) => data.notes,
-    enabled: !!folder,
+    enabled: options?.enabled ?? folder.length > 0,
   })
 }
 

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from './client'
+import { useActiveVaultId } from './active-vault'
 
 // Types matching backend JSON responses
 export interface Folder {
@@ -36,16 +37,18 @@ export interface User {
 // Query hooks
 
 export function useFolders() {
+  const vaultId = useActiveVaultId()
   return useQuery({
-    queryKey: ['folders'],
+    queryKey: ['folders', vaultId],
     queryFn: () => api.get<{ folders: Folder[] }>('/folders'),
     select: (data) => data.folders,
   })
 }
 
 export function useFolderNotes(folder: string) {
+  const vaultId = useActiveVaultId()
   return useQuery({
-    queryKey: ['folderNotes', folder],
+    queryKey: ['folderNotes', vaultId, folder],
     queryFn: () =>
       api.get<{ notes: NoteSummary[] }>(`/folders/list?folder=${encodeURIComponent(folder)}`),
     select: (data) => data.notes,
@@ -54,16 +57,18 @@ export function useFolderNotes(folder: string) {
 }
 
 export function useNote(path: string) {
+  const vaultId = useActiveVaultId()
   return useQuery({
-    queryKey: ['note', path],
+    queryKey: ['note', vaultId, path],
     queryFn: () => api.get<Note>(`/notes/${encodeURIComponent(path)}`),
     enabled: !!path,
   })
 }
 
 export function useSearch(query: string) {
+  const vaultId = useActiveVaultId()
   return useQuery({
-    queryKey: ['search', query],
+    queryKey: ['search', vaultId, query],
     queryFn: () => api.post<{ results: SearchResult[] }>('/search', { query, limit: 20 }),
     select: (data) => data.results,
     enabled: query.length > 0,
@@ -71,8 +76,9 @@ export function useSearch(query: string) {
 }
 
 export function useTags() {
+  const vaultId = useActiveVaultId()
   return useQuery({
-    queryKey: ['tags'],
+    queryKey: ['tags', vaultId],
     queryFn: () => api.get<{ tags: string[] }>('/tags'),
     select: (data) => data.tags,
   })

--- a/frontend/src/api/use-channel.ts
+++ b/frontend/src/api/use-channel.ts
@@ -3,20 +3,23 @@ import { useAuthAdapter } from '../auth/use-auth-adapter'
 import { connectChannel, disconnectChannel } from './channel'
 import { queryClient } from './query-client'
 import { useMe } from './queries'
+import { useActiveVaultId } from './active-vault'
 
 export function useChannel() {
   const { getToken } = useAuthAdapter()
   const { data: user } = useMe()
+  const vaultId = useActiveVaultId()
 
   useEffect(() => {
-    if (!user) return
+    if (!user || vaultId == null) return
 
     connectChannel({
       userId: user.id,
+      vaultId,
       getToken: () => getToken(),
       queryClient,
     })
 
     return () => disconnectChannel()
-  }, [user?.id, getToken])
+  }, [user?.id, vaultId, getToken])
 }

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -54,6 +54,9 @@ export default function AppLayout() {
             <Link to="/billing" className="text-sm text-gray-600 hover:text-gray-900 hover:underline">
               Billing
             </Link>
+            <Link to="/settings" className="text-sm text-gray-600 hover:text-gray-900 hover:underline">
+              Settings
+            </Link>
             <Suspense fallback={null}>
               {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
             </Suspense>

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -10,6 +10,7 @@ const LocalUserMenu = lazy(() => import('../auth/local-user-menu'))
 import { useChannel } from '../api/use-channel'
 import { useBillingStatus } from '../api/queries'
 import FolderTree from '../viewer/folder-tree'
+import VaultSwitcher from './vault-switcher'
 
 export default function AppLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -71,7 +72,12 @@ export default function AppLayout() {
               sidebarOpen ? 'w-64' : 'w-0'
             } shrink-0 overflow-y-auto border-r border-gray-200 bg-gray-50 transition-all duration-200`}
           >
-            {sidebarOpen && <FolderTree />}
+            {sidebarOpen && (
+              <>
+                <VaultSwitcher />
+                <FolderTree />
+              </>
+            )}
           </aside>
 
           <main className="flex-1 overflow-y-auto p-6">

--- a/frontend/src/layout/vault-switcher.tsx
+++ b/frontend/src/layout/vault-switcher.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { type Vault, useVaults } from '../api/queries'
+import { setActiveVaultId, useActiveVaultId } from '../api/active-vault'
+
+export default function VaultSwitcher() {
+  const { data: vaults, isLoading } = useVaults()
+  const activeId = useActiveVaultId()
+  const qc = useQueryClient()
+
+  useEffect(() => {
+    if (!vaults || vaults.length === 0) return
+    const stillValid = activeId != null && vaults.some((v) => v.id === activeId)
+    if (stillValid) return
+    const fallback = vaults.find((v) => v.is_default) ?? vaults[0]
+    if (fallback) setActiveVaultId(fallback.id)
+  }, [vaults, activeId])
+
+  if (isLoading) {
+    return <p className="px-3 py-2 text-xs text-gray-500">Loading vaults…</p>
+  }
+  if (!vaults || vaults.length === 0) {
+    return <p className="px-3 py-2 text-xs text-gray-500">No vaults yet</p>
+  }
+
+  const active = vaults.find((v) => v.id === activeId) ?? vaults[0]
+
+  if (vaults.length === 1) {
+    return <SingleVaultLabel vault={active!} />
+  }
+
+  return (
+    <VaultDropdown
+      vaults={vaults}
+      active={active!}
+      onSelect={(id) => {
+        setActiveVaultId(id)
+        qc.invalidateQueries()
+      }}
+    />
+  )
+}
+
+function SingleVaultLabel({ vault }: { vault: Vault }) {
+  return (
+    <section className="border-b border-gray-200 px-3 py-2">
+      <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500">Vault</p>
+      <p className="flex items-center gap-1.5 truncate text-sm font-medium text-gray-900">
+        {vault.encrypted && <LockIcon />}
+        {vault.name}
+      </p>
+    </section>
+  )
+}
+
+function VaultDropdown({
+  vaults,
+  active,
+  onSelect,
+}: {
+  vaults: Vault[]
+  active: Vault
+  onSelect: (id: number) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <section ref={ref} className="relative border-b border-gray-200">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-gray-100"
+      >
+        <span className="min-w-0 flex-1">
+          <span className="block text-[10px] font-medium uppercase tracking-wide text-gray-500">
+            Vault
+          </span>
+          <span className="flex items-center gap-1.5 truncate text-sm font-medium text-gray-900">
+            {active.encrypted && <LockIcon />}
+            {active.name}
+          </span>
+        </span>
+        <span className={`text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`}>▾</span>
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label="Switch vault"
+          className="absolute left-2 right-2 top-full z-10 mt-1 max-h-64 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+        >
+          {vaults.map((v) => (
+            <li key={v.id} role="option" aria-selected={v.id === active.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  onSelect(v.id)
+                  setOpen(false)
+                }}
+                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-gray-100 ${
+                  v.id === active.id ? 'font-medium text-gray-900' : 'text-gray-700'
+                }`}
+              >
+                <span className="w-3 text-blue-600">{v.id === active.id ? '✓' : ''}</span>
+                {v.encrypted && <LockIcon />}
+                <span className="truncate">{v.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+function LockIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="h-3 w-3 shrink-0 text-gray-500"
+      fill="currentColor"
+    >
+      <path d="M8 1a3 3 0 0 0-3 3v3H4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8a1 1 0 0 0-1-1h-1V4a3 3 0 0 0-3-3zm-2 6V4a2 2 0 1 1 4 0v3H6z" />
+    </svg>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,10 +1,14 @@
-import { createBrowserRouter } from 'react-router'
+import { Navigate, createBrowserRouter } from 'react-router'
 import AuthGuard from './auth/auth-guard'
 import SignInPage from './auth/sign-in'
 import SignUpPage from './auth/sign-up'
 import BillingPage from './billing/billing-page'
 import DeviceLinkPage from './device/device-link-page'
 import AppLayout from './layout/app-layout'
+import ApiKeysPage from './settings/api-keys-page'
+import BillingPlaceholder from './settings/billing-placeholder'
+import EncryptionPage from './settings/encryption-page'
+import SettingsLayout from './settings/settings-layout'
 import Dashboard from './viewer/dashboard'
 import NotePage from './viewer/note-page'
 import SearchPage from './viewer/search-page'
@@ -26,6 +30,16 @@ export const router = createBrowserRouter(
             { path: '/note/*', element: <NotePage /> },
             { path: '/search', element: <SearchPage /> },
             { path: '/billing', element: <BillingPage /> },
+            {
+              path: '/settings',
+              element: <SettingsLayout />,
+              children: [
+                { index: true, element: <Navigate to="api-keys" replace /> },
+                { path: 'api-keys', element: <ApiKeysPage /> },
+                { path: 'encryption', element: <EncryptionPage /> },
+                { path: 'billing', element: <BillingPlaceholder /> },
+              ],
+            },
           ],
         },
         { path: '/link', element: <DeviceLinkPage /> },

--- a/frontend/src/settings/api-keys-page.tsx
+++ b/frontend/src/settings/api-keys-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   type ApiKey,
   type CreatedApiKey,
@@ -191,12 +191,19 @@ function RevealKeyModal({
   createdKey: CreatedApiKey
   onClose: () => void
 }) {
-  const [copied, setCopied] = useState(false)
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle')
+  const keyFieldRef = useRef<HTMLInputElement>(null)
 
   async function copy() {
-    await navigator.clipboard.writeText(createdKey.key)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    const ok = await copyToClipboard(createdKey.key)
+    setCopyState(ok ? 'copied' : 'error')
+    if (ok) {
+      setTimeout(() => setCopyState('idle'), 2000)
+    }
+  }
+
+  function selectAll() {
+    keyFieldRef.current?.select()
   }
 
   return (
@@ -206,23 +213,40 @@ function RevealKeyModal({
           This is the only time the key will be shown. Copy it now and store it somewhere safe.
         </p>
 
-        <section className="rounded-md border border-gray-200 bg-gray-50 p-3">
-          <p className="break-all font-mono text-sm text-gray-900">{createdKey.key}</p>
-        </section>
+        <div className="flex items-stretch gap-2">
+          <input
+            ref={keyFieldRef}
+            readOnly
+            value={createdKey.key}
+            onFocus={selectAll}
+            onClick={selectAll}
+            className="flex-1 min-w-0 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            aria-label="API key"
+          />
+          <button
+            type="button"
+            onClick={copy}
+            aria-label="Copy API key"
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-blue-600 bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 active:bg-blue-800 active:scale-[0.98]"
+          >
+            <CopyIcon copied={copyState === 'copied'} />
+            <span className="min-w-12 text-left">
+              {copyState === 'copied' ? 'Copied' : 'Copy'}
+            </span>
+          </button>
+        </div>
 
-        <button
-          type="button"
-          onClick={copy}
-          className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          {copied ? 'Copied!' : 'Copy to clipboard'}
-        </button>
+        {copyState === 'error' && (
+          <p className="text-sm text-red-700" role="alert">
+            Copy failed — click the field and press Cmd/Ctrl+C to copy manually.
+          </p>
+        )}
 
         <footer className="flex justify-end pt-2">
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
           >
             Done
           </button>
@@ -230,6 +254,66 @@ function RevealKeyModal({
       </div>
     </ModalShell>
   )
+}
+
+function CopyIcon({ copied }: { copied: boolean }) {
+  if (copied) {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="h-4 w-4"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M16.704 5.293a1 1 0 010 1.414l-7.5 7.5a1 1 0 01-1.414 0l-3.5-3.5a1 1 0 111.414-1.414L8.5 12.086l6.79-6.793a1 1 0 011.414 0z"
+          clipRule="evenodd"
+        />
+      </svg>
+    )
+  }
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M7 3a2 2 0 00-2 2v9a2 2 0 002 2h6a2 2 0 002-2V5a2 2 0 00-2-2H7z" />
+      <path d="M3 7a2 2 0 012-2h.5a.5.5 0 010 1H5a1 1 0 00-1 1v9a1 1 0 001 1h7a1 1 0 001-1v-.5a.5.5 0 011 0v.5a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
+    </svg>
+  )
+}
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // fall through to legacy fallback
+    }
+  }
+
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.top = '0'
+    ta.style.left = '0'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
 }
 
 function ModalShell({

--- a/frontend/src/settings/api-keys-page.tsx
+++ b/frontend/src/settings/api-keys-page.tsx
@@ -1,0 +1,273 @@
+import { useState } from 'react'
+import {
+  type ApiKey,
+  type CreatedApiKey,
+  useApiKeys,
+  useCreateApiKey,
+  useRevokeApiKey,
+} from '../api/queries'
+import { ApiError } from '../api/client'
+
+export default function ApiKeysPage() {
+  const { data: keys, isLoading, error } = useApiKeys()
+  const [showCreate, setShowCreate] = useState(false)
+  const [newKey, setNewKey] = useState<CreatedApiKey | null>(null)
+
+  return (
+    <article className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">API Keys</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Used by the Obsidian plugin and MCP clients to access your vault.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowCreate(true)}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + New Key
+        </button>
+      </header>
+
+      {error && (
+        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+          Failed to load API keys: {error instanceof Error ? error.message : 'unknown error'}
+        </p>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm text-gray-500">Loading…</p>
+      ) : keys && keys.length > 0 ? (
+        <ApiKeyTable keys={keys} />
+      ) : (
+        <EmptyState />
+      )}
+
+      {showCreate && (
+        <CreateKeyModal
+          onClose={() => setShowCreate(false)}
+          onCreated={(k) => {
+            setNewKey(k)
+            setShowCreate(false)
+          }}
+        />
+      )}
+
+      {newKey && <RevealKeyModal createdKey={newKey} onClose={() => setNewKey(null)} />}
+    </article>
+  )
+}
+
+function EmptyState() {
+  return (
+    <section className="rounded-lg border border-dashed border-gray-300 p-8 text-center">
+      <p className="text-sm text-gray-600">
+        No API keys yet. Generate one to connect Claude Desktop, MCP, or the Obsidian plugin.
+      </p>
+    </section>
+  )
+}
+
+function ApiKeyTable({ keys }: { keys: ApiKey[] }) {
+  const revoke = useRevokeApiKey()
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+          <tr>
+            <th className="px-4 py-3 font-medium">Name</th>
+            <th className="px-4 py-3 font-medium">Key</th>
+            <th className="px-4 py-3 font-medium">Created</th>
+            <th className="px-4 py-3 font-medium">Last used</th>
+            <th className="px-4 py-3" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {keys.map((k) => (
+            <tr key={k.id}>
+              <td className="px-4 py-3 font-medium text-gray-900">{k.name || '(unnamed)'}</td>
+              <td className="px-4 py-3 font-mono text-xs text-gray-500">engram_••••••</td>
+              <td className="px-4 py-3 text-gray-600">{formatDate(k.created_at)}</td>
+              <td className="px-4 py-3 text-gray-600">
+                {k.last_used ? formatDate(k.last_used) : '—'}
+              </td>
+              <td className="px-4 py-3 text-right">
+                <button
+                  type="button"
+                  disabled={revoke.isPending}
+                  onClick={() => {
+                    if (confirm(`Revoke "${k.name || 'this key'}"? This cannot be undone.`)) {
+                      revoke.mutate(k.id)
+                    }
+                  }}
+                  className="text-sm text-red-600 hover:text-red-800 disabled:opacity-50"
+                >
+                  Revoke
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}
+
+function CreateKeyModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void
+  onCreated: (k: CreatedApiKey) => void
+}) {
+  const [name, setName] = useState('')
+  const create = useCreateApiKey()
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (name.trim().length === 0) return
+    try {
+      const created = await create.mutateAsync(name.trim())
+      onCreated(created)
+    } catch {
+      /* error surfaced via create.error */
+    }
+  }
+
+  return (
+    <ModalShell onClose={onClose} title="New API Key">
+      <form onSubmit={submit} className="space-y-4">
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">Name</span>
+          <input
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. iPhone MCP"
+            maxLength={64}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+          <span className="mt-1 block text-xs text-gray-500">
+            Helps you identify the key later — pick something memorable.
+          </span>
+        </label>
+
+        {create.error && (
+          <p className="text-sm text-red-600" role="alert">
+            {create.error instanceof ApiError
+              ? create.error.message
+              : 'Could not create key. Try again.'}
+          </p>
+        )}
+
+        <footer className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={create.isPending || name.trim().length === 0}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {create.isPending ? 'Generating…' : 'Generate Key'}
+          </button>
+        </footer>
+      </form>
+    </ModalShell>
+  )
+}
+
+function RevealKeyModal({
+  createdKey,
+  onClose,
+}: {
+  createdKey: CreatedApiKey
+  onClose: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+
+  async function copy() {
+    await navigator.clipboard.writeText(createdKey.key)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <ModalShell onClose={onClose} title="Save your API key">
+      <div className="space-y-4">
+        <p className="rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          This is the only time the key will be shown. Copy it now and store it somewhere safe.
+        </p>
+
+        <section className="rounded-md border border-gray-200 bg-gray-50 p-3">
+          <p className="break-all font-mono text-sm text-gray-900">{createdKey.key}</p>
+        </section>
+
+        <button
+          type="button"
+          onClick={copy}
+          className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          {copied ? 'Copied!' : 'Copy to clipboard'}
+        </button>
+
+        <footer className="flex justify-end pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+          >
+            Done
+          </button>
+        </footer>
+      </div>
+    </ModalShell>
+  )
+}
+
+function ModalShell({
+  title,
+  onClose,
+  children,
+}: {
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <section
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <article
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="mb-4">
+          <h2 id="modal-title" className="text-lg font-semibold text-gray-900">
+            {title}
+          </h2>
+        </header>
+        {children}
+      </article>
+    </section>
+  )
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}

--- a/frontend/src/settings/billing-placeholder.tsx
+++ b/frontend/src/settings/billing-placeholder.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router'
+
+export default function BillingPlaceholder() {
+  return (
+    <article className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold text-gray-900">Billing</h1>
+        <p className="mt-1 text-sm text-gray-600">Manage your subscription and payment method.</p>
+      </header>
+
+      <section className="rounded-lg border border-dashed border-gray-300 p-8 text-center space-y-3">
+        <p className="text-sm text-gray-600">
+          Billing details will move into Settings soon. For now, manage your plan from the
+          standalone billing page.
+        </p>
+        <Link
+          to="/billing"
+          className="inline-block rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Go to Billing
+        </Link>
+      </section>
+    </article>
+  )
+}

--- a/frontend/src/settings/encryption-page.tsx
+++ b/frontend/src/settings/encryption-page.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react'
+import {
+  type EncryptionStatus,
+  type Vault,
+  useEncryptVault,
+  useEncryptionProgress,
+  useVaults,
+} from '../api/queries'
+import { ApiError } from '../api/client'
+
+export default function EncryptionPage() {
+  const { data: vaults, isLoading } = useVaults()
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading…</p>
+  }
+
+  const vault = vaults?.[0]
+
+  if (!vault) {
+    return (
+      <article className="space-y-4">
+        <h1 className="text-2xl font-bold text-gray-900">Encryption at Rest</h1>
+        <section className="rounded-lg border border-dashed border-gray-300 p-8 text-center">
+          <p className="text-sm text-gray-600">
+            Connect a vault from the Obsidian plugin to enable encryption.
+          </p>
+        </section>
+      </article>
+    )
+  }
+
+  return <EncryptionPanel vault={vault} />
+}
+
+function EncryptionPanel({ vault }: { vault: Vault }) {
+  const inFlight =
+    vault.encryption_status === 'encrypting' || vault.encryption_status === 'decrypting'
+
+  const { data: progress } = useEncryptionProgress(vault.id, inFlight)
+  const encrypt = useEncryptVault()
+  const [confirming, setConfirming] = useState(false)
+
+  return (
+    <article className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold text-gray-900">Encryption at Rest</h1>
+        <p className="mt-1 text-sm text-gray-600">Vault: {vault.name}</p>
+      </header>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
+        <StatusBadge status={vault.encryption_status} />
+
+        {vault.encryption_status === 'disabled' && (
+          <>
+            <p className="text-sm text-gray-700">
+              Notes and vector payloads are stored as plaintext on the server. Enabling
+              encryption protects your data with a key derived from your account.
+            </p>
+            {vault.cooldown_days != null && vault.cooldown_days > 0 && (
+              <p className="text-xs text-gray-500">
+                After enabling, you cannot disable encryption for {vault.cooldown_days} days.
+              </p>
+            )}
+            {!confirming ? (
+              <button
+                type="button"
+                onClick={() => setConfirming(true)}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Encrypt Vault
+              </button>
+            ) : (
+              <ConfirmEncrypt
+                cooldownDays={vault.cooldown_days}
+                isPending={encrypt.isPending}
+                error={encrypt.error}
+                onCancel={() => setConfirming(false)}
+                onConfirm={() => {
+                  encrypt.mutate(vault.id, { onSuccess: () => setConfirming(false) })
+                }}
+              />
+            )}
+          </>
+        )}
+
+        {inFlight && progress && (
+          <ProgressView
+            processed={progress.processed}
+            total={progress.total}
+            status={progress.status}
+          />
+        )}
+
+        {vault.encryption_status === 'enabled' && (
+          <p className="text-sm text-gray-700">
+            All notes and vector payloads are encrypted.
+            {vault.encrypted_at && (
+              <> Enabled {new Date(vault.encrypted_at).toLocaleDateString()}.</>
+            )}
+          </p>
+        )}
+      </section>
+    </article>
+  )
+}
+
+function StatusBadge({ status }: { status: EncryptionStatus }) {
+  const styles: Record<EncryptionStatus, { bg: string; text: string; dot: string; label: string }> =
+    {
+      disabled: { bg: 'bg-gray-100', text: 'text-gray-700', dot: 'bg-gray-400', label: 'Disabled' },
+      encrypting: {
+        bg: 'bg-blue-50',
+        text: 'text-blue-700',
+        dot: 'bg-blue-500 animate-pulse',
+        label: 'Encrypting…',
+      },
+      enabled: {
+        bg: 'bg-green-50',
+        text: 'text-green-700',
+        dot: 'bg-green-500',
+        label: 'Encrypted',
+      },
+      decrypting: {
+        bg: 'bg-amber-50',
+        text: 'text-amber-700',
+        dot: 'bg-amber-500 animate-pulse',
+        label: 'Decrypting…',
+      },
+    }
+
+  const s = styles[status]
+
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${s.bg} ${s.text}`}
+    >
+      <span className={`h-2 w-2 rounded-full ${s.dot}`} />
+      {s.label}
+    </span>
+  )
+}
+
+function ProgressView({
+  processed,
+  total,
+  status,
+}: {
+  processed: number
+  total: number
+  status: EncryptionStatus
+}) {
+  const percent = total > 0 ? Math.min(100, Math.round((processed / total) * 100)) : 0
+  const verb = status === 'encrypting' ? 'Encrypting' : 'Decrypting'
+
+  return (
+    <section aria-live="polite" className="space-y-2">
+      <p className="text-sm text-gray-700">
+        {verb} {processed.toLocaleString()} of {total.toLocaleString()} notes ({percent}%)
+      </p>
+      <div className="h-2 overflow-hidden rounded-full bg-gray-200">
+        <div
+          className="h-full rounded-full bg-blue-500 transition-all"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </section>
+  )
+}
+
+function ConfirmEncrypt({
+  cooldownDays,
+  isPending,
+  error,
+  onCancel,
+  onConfirm,
+}: {
+  cooldownDays: number | null
+  isPending: boolean
+  error: Error | null
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  return (
+    <section className="rounded-md border border-amber-200 bg-amber-50 p-4 space-y-3">
+      <p className="text-sm font-medium text-amber-900">Encrypt this vault?</p>
+      <ul className="ml-4 list-disc space-y-1 text-sm text-amber-800">
+        <li>All existing notes will be re-encrypted in the background.</li>
+        <li>Vector search continues to work — payloads are encrypted too.</li>
+        {cooldownDays != null && cooldownDays > 0 && (
+          <li>You cannot disable encryption for {cooldownDays} days afterward.</li>
+        )}
+      </ul>
+
+      {error && (
+        <p className="text-sm text-red-700" role="alert">
+          {error instanceof ApiError ? error.message : 'Failed to start encryption.'}
+        </p>
+      )}
+
+      <footer className="flex gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={isPending}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isPending ? 'Starting…' : 'Yes, encrypt vault'}
+        </button>
+      </footer>
+    </section>
+  )
+}

--- a/frontend/src/settings/encryption-page.tsx
+++ b/frontend/src/settings/encryption-page.tsx
@@ -35,7 +35,7 @@ export default function EncryptionPage() {
 
 function EncryptionPanel({ vault }: { vault: Vault }) {
   const inFlight =
-    vault.encryption_status === 'encrypting' || vault.encryption_status === 'decrypting'
+    vault.encryption_status === 'encrypting' || vault.encryption_status === 'decrypt_pending'
 
   const { data: progress } = useEncryptionProgress(vault.id, inFlight)
   const encrypt = useEncryptVault()
@@ -51,7 +51,7 @@ function EncryptionPanel({ vault }: { vault: Vault }) {
       <section className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
         <StatusBadge status={vault.encryption_status} />
 
-        {vault.encryption_status === 'disabled' && (
+        {vault.encryption_status === 'none' && (
           <>
             <p className="text-sm text-gray-700">
               Notes and vector payloads are stored as plaintext on the server. Enabling
@@ -92,7 +92,7 @@ function EncryptionPanel({ vault }: { vault: Vault }) {
           />
         )}
 
-        {vault.encryption_status === 'enabled' && (
+        {vault.encryption_status === 'encrypted' && (
           <p className="text-sm text-gray-700">
             All notes and vector payloads are encrypted.
             {vault.encrypted_at && (
@@ -105,31 +105,42 @@ function EncryptionPanel({ vault }: { vault: Vault }) {
   )
 }
 
-function StatusBadge({ status }: { status: EncryptionStatus }) {
-  const styles: Record<EncryptionStatus, { bg: string; text: string; dot: string; label: string }> =
-    {
-      disabled: { bg: 'bg-gray-100', text: 'text-gray-700', dot: 'bg-gray-400', label: 'Disabled' },
-      encrypting: {
-        bg: 'bg-blue-50',
-        text: 'text-blue-700',
-        dot: 'bg-blue-500 animate-pulse',
-        label: 'Encrypting…',
-      },
-      enabled: {
-        bg: 'bg-green-50',
-        text: 'text-green-700',
-        dot: 'bg-green-500',
-        label: 'Encrypted',
-      },
-      decrypting: {
-        bg: 'bg-amber-50',
-        text: 'text-amber-700',
-        dot: 'bg-amber-500 animate-pulse',
-        label: 'Decrypting…',
-      },
-    }
+type BadgeStyle = { bg: string; text: string; dot: string; label: string }
 
-  const s = styles[status]
+const STATUS_STYLES: Record<EncryptionStatus, BadgeStyle> = {
+  none: { bg: 'bg-gray-100', text: 'text-gray-700', dot: 'bg-gray-400', label: 'Not encrypted' },
+  encrypting: {
+    bg: 'bg-blue-50',
+    text: 'text-blue-700',
+    dot: 'bg-blue-500 animate-pulse',
+    label: 'Encrypting…',
+  },
+  encrypted: {
+    bg: 'bg-green-50',
+    text: 'text-green-700',
+    dot: 'bg-green-500',
+    label: 'Encrypted',
+  },
+  decrypt_pending: {
+    bg: 'bg-amber-50',
+    text: 'text-amber-700',
+    dot: 'bg-amber-500 animate-pulse',
+    label: 'Decrypt pending…',
+  },
+}
+
+const UNKNOWN_STYLE: BadgeStyle = {
+  bg: 'bg-gray-100',
+  text: 'text-gray-700',
+  dot: 'bg-gray-400',
+  label: 'Unknown',
+}
+
+function StatusBadge({ status }: { status: EncryptionStatus | string }) {
+  const s = STATUS_STYLES[status as EncryptionStatus] ?? {
+    ...UNKNOWN_STYLE,
+    label: `Unknown (${status})`,
+  }
 
   return (
     <span
@@ -151,7 +162,7 @@ function ProgressView({
   status: EncryptionStatus
 }) {
   const percent = total > 0 ? Math.min(100, Math.round((processed / total) * 100)) : 0
-  const verb = status === 'encrypting' ? 'Encrypting' : 'Decrypting'
+  const verb = status === 'encrypting' ? 'Encrypting' : 'Decrypt pending —'
 
   return (
     <section aria-live="polite" className="space-y-2">

--- a/frontend/src/settings/encryption-page.tsx
+++ b/frontend/src/settings/encryption-page.tsx
@@ -15,9 +15,7 @@ export default function EncryptionPage() {
     return <p className="text-sm text-gray-500">Loading…</p>
   }
 
-  const vault = vaults?.[0]
-
-  if (!vault) {
+  if (!vaults || vaults.length === 0) {
     return (
       <article className="space-y-4">
         <h1 className="text-2xl font-bold text-gray-900">Encryption at Rest</h1>
@@ -30,78 +28,97 @@ export default function EncryptionPage() {
     )
   }
 
-  return <EncryptionPanel vault={vault} />
+  return (
+    <article className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold text-gray-900">Encryption at Rest</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          {vaults.length === 1
+            ? 'Vault encryption status.'
+            : `${vaults.length} vaults — manage encryption per vault.`}
+        </p>
+      </header>
+
+      <ul className="space-y-4">
+        {vaults.map((v) => (
+          <li key={v.id}>
+            <VaultEncryptionCard vault={v} />
+          </li>
+        ))}
+      </ul>
+    </article>
+  )
 }
 
-function EncryptionPanel({ vault }: { vault: Vault }) {
+function VaultEncryptionCard({ vault }: { vault: Vault }) {
   const inFlight =
     vault.encryption_status === 'encrypting' || vault.encryption_status === 'decrypt_pending'
-
   const { data: progress } = useEncryptionProgress(vault.id, inFlight)
   const encrypt = useEncryptVault()
   const [confirming, setConfirming] = useState(false)
 
   return (
-    <article className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-bold text-gray-900">Encryption at Rest</h1>
-        <p className="mt-1 text-sm text-gray-600">Vault: {vault.name}</p>
+    <section className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
+      <header className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-semibold text-gray-900">{vault.name}</h2>
+          {vault.is_default && (
+            <p className="text-xs text-gray-500">Default vault</p>
+          )}
+        </div>
+        <StatusBadge status={vault.encryption_status} />
       </header>
 
-      <section className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
-        <StatusBadge status={vault.encryption_status} />
-
-        {vault.encryption_status === 'none' && (
-          <>
-            <p className="text-sm text-gray-700">
-              Notes and vector payloads are stored as plaintext on the server. Enabling
-              encryption protects your data with a key derived from your account.
-            </p>
-            {vault.cooldown_days != null && vault.cooldown_days > 0 && (
-              <p className="text-xs text-gray-500">
-                After enabling, you cannot disable encryption for {vault.cooldown_days} days.
-              </p>
-            )}
-            {!confirming ? (
-              <button
-                type="button"
-                onClick={() => setConfirming(true)}
-                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-              >
-                Encrypt Vault
-              </button>
-            ) : (
-              <ConfirmEncrypt
-                cooldownDays={vault.cooldown_days}
-                isPending={encrypt.isPending}
-                error={encrypt.error}
-                onCancel={() => setConfirming(false)}
-                onConfirm={() => {
-                  encrypt.mutate(vault.id, { onSuccess: () => setConfirming(false) })
-                }}
-              />
-            )}
-          </>
-        )}
-
-        {inFlight && progress && (
-          <ProgressView
-            processed={progress.processed}
-            total={progress.total}
-            status={progress.status}
-          />
-        )}
-
-        {vault.encryption_status === 'encrypted' && (
+      {vault.encryption_status === 'none' && (
+        <>
           <p className="text-sm text-gray-700">
-            All notes and vector payloads are encrypted.
-            {vault.encrypted_at && (
-              <> Enabled {new Date(vault.encrypted_at).toLocaleDateString()}.</>
-            )}
+            Notes and vector payloads are stored as plaintext on the server. Enabling encryption
+            protects your data with a key derived from your account.
           </p>
-        )}
-      </section>
-    </article>
+          {vault.cooldown_days != null && vault.cooldown_days > 0 && (
+            <p className="text-xs text-gray-500">
+              After enabling, you cannot disable encryption for {vault.cooldown_days} days.
+            </p>
+          )}
+          {!confirming ? (
+            <button
+              type="button"
+              onClick={() => setConfirming(true)}
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              Encrypt Vault
+            </button>
+          ) : (
+            <ConfirmEncrypt
+              cooldownDays={vault.cooldown_days}
+              isPending={encrypt.isPending && encrypt.variables === vault.id}
+              error={encrypt.variables === vault.id ? encrypt.error : null}
+              onCancel={() => setConfirming(false)}
+              onConfirm={() => {
+                encrypt.mutate(vault.id, { onSuccess: () => setConfirming(false) })
+              }}
+            />
+          )}
+        </>
+      )}
+
+      {inFlight && progress && (
+        <ProgressView
+          processed={progress.processed}
+          total={progress.total}
+          status={progress.status}
+        />
+      )}
+
+      {vault.encryption_status === 'encrypted' && (
+        <p className="text-sm text-gray-700">
+          All notes and vector payloads are encrypted.
+          {vault.encrypted_at && (
+            <> Enabled {new Date(vault.encrypted_at).toLocaleDateString()}.</>
+          )}
+        </p>
+      )}
+    </section>
   )
 }
 
@@ -144,7 +161,7 @@ function StatusBadge({ status }: { status: EncryptionStatus | string }) {
 
   return (
     <span
-      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${s.bg} ${s.text}`}
+      className={`inline-flex shrink-0 items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${s.bg} ${s.text}`}
     >
       <span className={`h-2 w-2 rounded-full ${s.dot}`} />
       {s.label}

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -1,0 +1,40 @@
+import { NavLink, Outlet } from 'react-router'
+
+const SECTIONS = [
+  { to: 'api-keys', label: 'API Keys' },
+  { to: 'encryption', label: 'Encryption' },
+  { to: 'billing', label: 'Billing' },
+] as const
+
+export default function SettingsLayout() {
+  return (
+    <section className="mx-auto flex max-w-5xl gap-8 py-2">
+      <nav aria-label="Settings sections" className="w-48 shrink-0">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Settings
+        </h2>
+        <ul className="space-y-1">
+          {SECTIONS.map((s) => (
+            <li key={s.to}>
+              <NavLink
+                to={s.to}
+                className={({ isActive }) =>
+                  `block rounded-md px-3 py-2 text-sm transition-colors ${
+                    isActive
+                      ? 'bg-blue-50 font-medium text-blue-700'
+                      : 'text-gray-700 hover:bg-gray-100'
+                  }`
+                }
+              >
+                {s.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <section className="min-w-0 flex-1">
+        <Outlet />
+      </section>
+    </section>
+  )
+}

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react'
-import { Link, useSearchParams } from 'react-router'
-import { useFolders, type Folder } from '../api/queries'
+import { Link, useLocation } from 'react-router'
+import { type NoteSummary, useFolders, useFolderNotes, type Folder } from '../api/queries'
 
 interface TreeNode {
-  name: string      // display name (last segment)
-  fullPath: string  // full folder path (joined with '/')
-  count: number     // note count at this exact path (0 if only an ancestor)
+  name: string
+  fullPath: string
   children: TreeNode[]
 }
 
@@ -13,125 +12,258 @@ function buildTree(folders: Folder[]): TreeNode[] {
   const root: TreeNode[] = []
 
   for (const folder of folders) {
+    if (!folder.name) continue // root files handled separately
     const segments = folder.name.split('/')
     let level = root
 
     for (let i = 0; i < segments.length; i++) {
       const seg = segments[i] ?? ''
       const fullPath = segments.slice(0, i + 1).join('/')
-      const isLeaf = i === segments.length - 1
 
-      let node: TreeNode | undefined = level.find((n) => n.name === seg)
+      let node = level.find((n) => n.name === seg)
       if (!node) {
-        node = { name: seg, fullPath, count: 0, children: [] }
+        node = { name: seg, fullPath, children: [] }
         level.push(node)
       }
-
-      if (isLeaf) {
-        node.count = folder.count
-      }
-
       level = node.children
     }
   }
 
+  sortTree(root)
   return root
+}
+
+function sortTree(nodes: TreeNode[]) {
+  nodes.sort((a, b) => a.name.localeCompare(b.name))
+  for (const n of nodes) sortTree(n.children)
+}
+
+export default function FolderTree() {
+  const { data: folders, isLoading, isError } = useFolders()
+  const location = useLocation()
+  // Note routes: /note/<path>. Read from pathname directly because
+  // useParams() in the parent layout doesn't expose the child route's
+  // splat. The pathname segments are %-encoded, decode each before
+  // joining so we can compare against raw note paths.
+  const selectedNotePath = location.pathname.startsWith('/note/')
+    ? decodePathFromRouter(location.pathname.slice('/note/'.length))
+    : null
+
+  if (isLoading) {
+    return <p className="px-3 py-2 text-xs text-gray-500">Loading…</p>
+  }
+  if (isError) {
+    return <p className="px-3 py-2 text-xs text-red-600">Failed to load folders.</p>
+  }
+  if (!folders || folders.length === 0) {
+    return <p className="px-3 py-2 text-xs text-gray-500">No notes yet.</p>
+  }
+
+  const tree = buildTree(folders)
+  const hasRootFiles = folders.some((f) => f.name === '')
+
+  return (
+    <nav aria-label="Files" className="py-2 text-sm">
+      <ul role="list" className="space-y-px">
+        {hasRootFiles && (
+          <RootFiles selectedNotePath={selectedNotePath} />
+        )}
+        {tree.map((node) => (
+          <FolderNode
+            key={node.fullPath}
+            node={node}
+            depth={0}
+            selectedNotePath={selectedNotePath}
+          />
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+function RootFiles({ selectedNotePath }: { selectedNotePath: string | null }) {
+  const { data: notes } = useFolderNotes('', { enabled: true })
+  if (!notes || notes.length === 0) return null
+  return (
+    <>
+      {notes.map((note) => (
+        <NoteLeaf
+          key={note.path}
+          note={note}
+          depth={0}
+          selectedNotePath={selectedNotePath}
+        />
+      ))}
+    </>
+  )
 }
 
 interface FolderNodeProps {
   node: TreeNode
   depth: number
-  selectedFolder: string
+  selectedNotePath: string | null
 }
 
-function FolderNode({ node, depth, selectedFolder }: FolderNodeProps) {
-  const [open, setOpen] = useState(depth === 0)
-  const hasChildren = node.children.length > 0
-  const isSelected = selectedFolder === node.fullPath
+function FolderNode({ node, depth, selectedNotePath }: FolderNodeProps) {
+  const [open, setOpen] = useState(false)
+  const containsSelected = selectedNotePath?.startsWith(`${node.fullPath}/`) ?? false
+  const isOpen = open || containsSelected
 
   return (
     <li>
-      <div
-        className={`flex items-center gap-1 rounded px-2 py-1 text-sm ${
-          isSelected ? 'bg-blue-50 font-medium text-blue-700' : 'text-gray-700 hover:bg-gray-100'
-        }`}
-        style={{ paddingLeft: `${depth * 12 + 8}px` }}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={isOpen}
+        className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left text-gray-700 hover:bg-gray-100"
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
       >
-        {hasChildren ? (
-          <button
-            onClick={() => setOpen((o) => !o)}
-            aria-label={open ? `Collapse ${node.name}` : `Expand ${node.name}`}
-            aria-expanded={open}
-            className="shrink-0 text-gray-400 hover:text-gray-600"
-          >
-            {open ? '▾' : '▸'}
-          </button>
-        ) : (
-          <span className="w-3 shrink-0" aria-hidden="true" />
-        )}
-
-        <Link
-          to={`/?folder=${encodeURIComponent(node.fullPath)}`}
-          className="flex-1 truncate"
-          aria-current={isSelected ? 'page' : undefined}
+        <span
+          className={`shrink-0 text-[10px] text-gray-400 transition-transform ${
+            isOpen ? 'rotate-90' : ''
+          }`}
+          aria-hidden="true"
         >
-          {node.name}
-        </Link>
+          ▶
+        </span>
+        <FolderIcon open={isOpen} />
+        <span className="truncate">{node.name}</span>
+      </button>
 
-        {node.count > 0 && (
-          <span className="shrink-0 text-xs text-gray-400" aria-label={`${node.count} notes`}>
-            {node.count}
-          </span>
-        )}
-      </div>
-
-      {hasChildren && open && (
-        <ul role="list">
+      {isOpen && (
+        <ul role="list" className="space-y-px">
           {node.children.map((child) => (
             <FolderNode
               key={child.fullPath}
               node={child}
               depth={depth + 1}
-              selectedFolder={selectedFolder}
+              selectedNotePath={selectedNotePath}
             />
           ))}
+          <FolderFiles
+            folderPath={node.fullPath}
+            depth={depth + 1}
+            selectedNotePath={selectedNotePath}
+          />
         </ul>
       )}
     </li>
   )
 }
 
-export default function FolderTree() {
-  const { data: folders, isLoading, isError } = useFolders()
-  const [searchParams] = useSearchParams()
-  const selectedFolder = searchParams.get('folder') ?? ''
-
+function FolderFiles({
+  folderPath,
+  depth,
+  selectedNotePath,
+}: {
+  folderPath: string
+  depth: number
+  selectedNotePath: string | null
+}) {
+  const { data: notes, isLoading } = useFolderNotes(folderPath, { enabled: true })
   if (isLoading) {
-    return <p className="px-4 py-3 text-sm text-gray-500">Loading…</p>
+    return (
+      <li
+        className="px-1 py-0.5 text-xs text-gray-400"
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
+      >
+        …
+      </li>
+    )
   }
-
-  if (isError) {
-    return <p className="px-4 py-3 text-sm text-red-600">Failed to load folders.</p>
-  }
-
-  if (!folders || folders.length === 0) {
-    return <p className="px-4 py-3 text-sm text-gray-500">No folders yet.</p>
-  }
-
-  const tree = buildTree(folders)
-
+  if (!notes || notes.length === 0) return null
   return (
-    <nav aria-label="Folders" className="py-2">
-      <ul role="list">
-        {tree.map((node) => (
-          <FolderNode
-            key={node.fullPath}
-            node={node}
-            depth={0}
-            selectedFolder={selectedFolder}
-          />
-        ))}
-      </ul>
-    </nav>
+    <>
+      {notes.map((note) => (
+        <NoteLeaf
+          key={note.path}
+          note={note}
+          depth={depth}
+          selectedNotePath={selectedNotePath}
+        />
+      ))}
+    </>
+  )
+}
+
+function NoteLeaf({
+  note,
+  depth,
+  selectedNotePath,
+}: {
+  note: NoteSummary
+  depth: number
+  selectedNotePath: string | null
+}) {
+  const isSelected = selectedNotePath === note.path
+  return (
+    <li>
+      <Link
+        to={`/note/${encodePathForRouter(note.path)}`}
+        aria-current={isSelected ? 'page' : undefined}
+        className={`flex items-center gap-1 rounded px-1 py-0.5 ${
+          isSelected
+            ? 'bg-blue-50 font-medium text-blue-700'
+            : 'text-gray-700 hover:bg-gray-100'
+        }`}
+        style={{ paddingLeft: `${depth * 12 + 16}px` }}
+      >
+        <FileIcon />
+        <span className="truncate">{noteLabel(note)}</span>
+      </Link>
+    </li>
+  )
+}
+
+function noteLabel(note: NoteSummary): string {
+  if (note.title) return note.title
+  const last = note.path.split('/').pop() ?? note.path
+  return last.replace(/\.md$/, '')
+}
+
+function encodePathForRouter(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/')
+}
+
+function decodePathFromRouter(encoded: string): string {
+  return encoded
+    .split('/')
+    .map((s) => {
+      try {
+        return decodeURIComponent(s)
+      } catch {
+        return s
+      }
+    })
+    .join('/')
+}
+
+function FolderIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="h-3.5 w-3.5 shrink-0 text-gray-500"
+      fill="currentColor"
+    >
+      {open ? (
+        <path d="M2 4a1 1 0 0 1 1-1h3.586a1 1 0 0 1 .707.293L8.707 4.6A1 1 0 0 0 9.414 5H13a1 1 0 0 1 1 1H2V4zm0 3h12.5a.5.5 0 0 1 .49.598l-1 5A.5.5 0 0 1 13.5 13h-11a.5.5 0 0 1-.49-.402l-1-5A.5.5 0 0 1 1.5 7H2z" />
+      ) : (
+        <path d="M2 4a1 1 0 0 1 1-1h3.586a1 1 0 0 1 .707.293L8.707 4.6A1 1 0 0 0 9.414 5H13a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4z" />
+      )}
+    </svg>
+  )
+}
+
+function FileIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="h-3.5 w-3.5 shrink-0 text-gray-400"
+      fill="currentColor"
+    >
+      <path d="M4 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V5.414a1 1 0 0 0-.293-.707L9.293 1.293A1 1 0 0 0 8.586 1H4zm5 0v4a1 1 0 0 0 1 1h3" />
+    </svg>
   )
 }

--- a/frontend/src/viewer/search-page.tsx
+++ b/frontend/src/viewer/search-page.tsx
@@ -1,55 +1,104 @@
 import { useState, useDeferredValue } from 'react'
 import { Link } from 'react-router'
-import { useSearch } from '../api/queries'
+import { type SearchResult, useSearch } from '../api/queries'
 
 export default function SearchPage() {
   const [input, setInput] = useState('')
-  const deferredQuery = useDeferredValue(input)
+  const deferredQuery = useDeferredValue(input.trim())
   const { data: results, isLoading, error } = useSearch(deferredQuery)
 
   return (
-    <section>
-      <h1 className="mb-4 text-xl font-semibold">Search</h1>
+    <section className="mx-auto max-w-3xl">
+      <h1 className="mb-4 text-xl font-semibold text-gray-900">Search</h1>
       <input
         type="search"
-        placeholder="Search your notes..."
+        placeholder="Search your notes…"
         value={input}
         onChange={(e) => setInput(e.target.value)}
-        className="mb-6 w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="mb-6 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
         autoFocus
       />
 
-      {isLoading && <p className="text-gray-500">Searching...</p>}
-      {error && <p className="text-red-600">Search failed: {error.message}</p>}
+      {isLoading && <p className="text-sm text-gray-500">Searching…</p>}
+      {error && (
+        <p className="text-sm text-red-600">Search failed: {error.message}</p>
+      )}
 
-      {results && results.length === 0 && deferredQuery && (
-        <p className="text-gray-500">No results for "{deferredQuery}"</p>
+      {results && results.length === 0 && deferredQuery && !isLoading && (
+        <p className="text-sm text-gray-500">No results for "{deferredQuery}"</p>
       )}
 
       {results && results.length > 0 && (
-        <ul className="space-y-3">
+        <ul className="space-y-2">
           {results.map((r) => (
             <li key={r.path}>
-              <Link
-                to={`/note/${r.path}`}
-                className="block rounded border p-3 hover:bg-gray-50"
-              >
-                <p className="font-medium">{r.title || r.path}</p>
-                {r.snippet && (
-                  <p className="mt-1 text-sm text-gray-600 line-clamp-2">{r.snippet}</p>
-                )}
-                <p className="mt-1 text-xs text-gray-400">
-                  Score: {r.score.toFixed(3)}
-                </p>
-              </Link>
+              <ResultCard result={r} query={deferredQuery} />
             </li>
           ))}
         </ul>
       )}
 
       {!deferredQuery && !isLoading && (
-        <p className="text-gray-400">Type to search your notes</p>
+        <p className="text-sm text-gray-400">Type to search your notes.</p>
       )}
     </section>
+  )
+}
+
+function ResultCard({ result, query }: { result: SearchResult; query: string }) {
+  const href = `/note/${result.path.split('/').map(encodeURIComponent).join('/')}`
+
+  return (
+    <Link
+      to={href}
+      className="block rounded-md border border-gray-200 bg-white p-4 transition hover:border-blue-300 hover:bg-blue-50/40"
+    >
+      {result.folder && (
+        <p className="text-xs text-gray-400">{result.folder}</p>
+      )}
+      <p className="mt-0.5 text-base font-medium text-gray-900">
+        {result.title || lastSegment(result.path)}
+      </p>
+      {result.heading_path && result.heading_path !== result.title && (
+        <p className="mt-0.5 text-xs text-gray-500">↳ {result.heading_path}</p>
+      )}
+      {result.snippet && (
+        <p className="mt-2 text-sm text-gray-700 line-clamp-3">
+          {highlightQuery(result.snippet, query)}
+        </p>
+      )}
+      {result.match_count > 1 && (
+        <p className="mt-2 text-xs text-gray-400">
+          +{result.match_count - 1} more match{result.match_count - 1 === 1 ? '' : 'es'} in this note
+        </p>
+      )}
+    </Link>
+  )
+}
+
+function lastSegment(path: string): string {
+  return (path.split('/').pop() ?? path).replace(/\.md$/, '')
+}
+
+// Wraps each whitespace-separated query token with <mark>, case-insensitive.
+// `String.split` with a capture group keeps delimiters in odd-indexed slots,
+// which is how we distinguish matched tokens from surrounding text without
+// re-running the regex (and without tripping on the global flag's lastIndex).
+function highlightQuery(text: string, query: string): React.ReactNode {
+  const tokens = query.split(/\s+/).filter((t) => t.length >= 2)
+  if (tokens.length === 0) return text
+
+  const escaped = tokens.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const re = new RegExp(`(${escaped.join('|')})`, 'gi')
+  const parts = text.split(re)
+
+  return parts.map((part, i) =>
+    i % 2 === 1 ? (
+      <mark key={i} className="bg-yellow-100 text-gray-900">
+        {part}
+      </mark>
+    ) : (
+      <span key={i}>{part}</span>
+    ),
   )
 }

--- a/lib/engram_web/controllers/auth_controller.ex
+++ b/lib/engram_web/controllers/auth_controller.ex
@@ -3,6 +3,23 @@ defmodule EngramWeb.AuthController do
 
   alias Engram.Accounts
 
+  def list_api_keys(conn, _params) do
+    user = conn.assigns.current_user
+    keys = Accounts.list_api_keys(user)
+
+    json(conn, %{
+      keys:
+        Enum.map(keys, fn k ->
+          %{
+            id: k.id,
+            name: k.name,
+            created_at: k.created_at,
+            last_used: k.last_used
+          }
+        end)
+    })
+  end
+
   def create_api_key(conn, %{"name" => name}) do
     user = conn.assigns.current_user
 

--- a/lib/engram_web/controllers/search_controller.ex
+++ b/lib/engram_web/controllers/search_controller.ex
@@ -20,7 +20,7 @@ defmodule EngramWeb.SearchController do
 
     case Search.search(user, vault, query, opts) do
       {:ok, results} ->
-        json(conn, %{results: results})
+        json(conn, %{results: group_by_note(results)})
 
       {:error, :feature_not_available} ->
         conn
@@ -54,4 +54,41 @@ defmodule EngramWeb.SearchController do
   end
 
   defp clamp_limit(_), do: 5
+
+  # Collapse per-chunk Qdrant hits into one row per note. The web UI shows
+  # a card per note; the MCP path bypasses this and gets raw chunks.
+  defp group_by_note(chunks) do
+    chunks
+    |> Enum.reject(fn c -> is_nil(Map.get(c, :source_path)) end)
+    |> Enum.group_by(&Map.fetch!(&1, :source_path))
+    |> Enum.map(fn {path, group} ->
+      [best | _] = Enum.sort_by(group, & &1.score, :desc)
+
+      %{
+        path: path,
+        title: best[:title] || derive_title(path),
+        folder: derive_folder(path),
+        heading_path: best[:heading_path],
+        snippet: best[:text],
+        score: best.score,
+        match_count: length(group)
+      }
+    end)
+    |> Enum.sort_by(& &1.score, :desc)
+  end
+
+  defp derive_folder(path) do
+    case String.split(path, "/") do
+      [_only_file] -> ""
+      segments -> segments |> Enum.drop(-1) |> Enum.join("/")
+    end
+  end
+
+  defp derive_title(path) do
+    path
+    |> String.split("/")
+    |> List.last()
+    |> Kernel.||("")
+    |> String.replace_suffix(".md", "")
+  end
 end

--- a/lib/engram_web/controllers/search_controller.ex
+++ b/lib/engram_web/controllers/search_controller.ex
@@ -5,22 +5,32 @@ defmodule EngramWeb.SearchController do
 
   @max_search_limit 50
 
+  # The web client wants N unique notes, but Qdrant ranks chunks. We
+  # over-fetch chunks so grouping has enough material to populate the
+  # requested number of notes — without this, several top chunks from
+  # the same note silently cap the result list well below N.
+  @overfetch_factor 4
+  @min_overfetch 20
+
   def search(conn, %{"query" => query} = params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
-    limit = params["limit"] |> clamp_limit()
+    note_limit = params["limit"] |> clamp_limit()
     tags = params["tags"]
     folder = params["folder"]
     cross_vault = Map.get(params, "cross_vault", false)
 
+    chunk_limit = max(note_limit * @overfetch_factor, @min_overfetch)
+
     opts =
-      [limit: limit, cross_vault: cross_vault]
+      [limit: chunk_limit, cross_vault: cross_vault]
       |> then(&if(tags, do: Keyword.put(&1, :tags, tags), else: &1))
       |> then(&if(folder, do: Keyword.put(&1, :folder, folder), else: &1))
 
     case Search.search(user, vault, query, opts) do
       {:ok, results} ->
-        json(conn, %{results: group_by_note(results)})
+        notes = results |> group_by_note() |> Enum.take(note_limit)
+        json(conn, %{results: notes})
 
       {:error, :feature_not_available} ->
         conn

--- a/lib/engram_web/controllers/spa_controller.ex
+++ b/lib/engram_web/controllers/spa_controller.ex
@@ -15,16 +15,28 @@ defmodule EngramWeb.SpaController do
   # Cache the split around </head> so each request only interpolates
   # the (cheap) config script. Config changes are picked up on every
   # request since we never cache the rendered output.
+  #
+  # In :dev/:test the cache is disabled (see config/dev.exs) so a
+  # `vite build` rewriting priv/static/app/index.html with new asset
+  # hashes is picked up on the next request without restarting Phoenix.
   defp cached_split do
-    case :persistent_term.get({__MODULE__, :split}, nil) do
-      nil ->
-        split = build_split()
-        :persistent_term.put({__MODULE__, :split}, split)
-        split
+    if cache_enabled?() do
+      case :persistent_term.get({__MODULE__, :split}, nil) do
+        nil ->
+          split = build_split()
+          :persistent_term.put({__MODULE__, :split}, split)
+          split
 
-      cached ->
-        cached
+        cached ->
+          cached
+      end
+    else
+      build_split()
     end
+  end
+
+  defp cache_enabled? do
+    Application.get_env(:engram, :spa_cache_enabled?, true)
   end
 
   defp build_split do

--- a/lib/engram_web/plugs/require_session.ex
+++ b/lib/engram_web/plugs/require_session.ex
@@ -1,0 +1,28 @@
+defmodule EngramWeb.Plugs.RequireSession do
+  @moduledoc """
+  Requires that the request is authenticated by a session/JWT, not by an
+  API key. Use on routes that manage credentials or other account-wide
+  primitives — an API key restricted to one vault must not be able to
+  enumerate, create, or revoke other API keys for the same user.
+
+  Assumes `EngramWeb.Plugs.Auth` has already run. If `conn.assigns` has
+  `:current_api_key`, the request is halted with 403.
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    case Map.get(conn.assigns, :current_api_key) do
+      nil ->
+        conn
+
+      _api_key ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(403, Jason.encode!(%{error: "api_key_not_allowed"}))
+        |> halt()
+    end
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -64,6 +64,7 @@ defmodule EngramWeb.Router do
     post "/auth/device/authorize", DeviceAuthController, :authorize
 
     # API key management
+    get "/api-keys", AuthController, :list_api_keys
     post "/api-keys", AuthController, :create_api_key
     delete "/api-keys/:id", AuthController, :revoke_api_key
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -63,10 +63,15 @@ defmodule EngramWeb.Router do
     # Device flow authorization (authenticated — web app confirms)
     post "/auth/device/authorize", DeviceAuthController, :authorize
 
-    # API key management
-    get "/api-keys", AuthController, :list_api_keys
-    post "/api-keys", AuthController, :create_api_key
-    delete "/api-keys/:id", AuthController, :revoke_api_key
+    # API key management — session/JWT only. An API key (especially a
+    # vault-restricted one) must never be able to enumerate, mint, or
+    # revoke other API keys for the same user.
+    scope "/" do
+      pipe_through EngramWeb.Plugs.RequireSession
+      get "/api-keys", AuthController, :list_api_keys
+      post "/api-keys", AuthController, :create_api_key
+      delete "/api-keys/:id", AuthController, :revoke_api_key
+    end
 
     # Vault management (user-level, not vault-scoped)
     get "/vaults", VaultsController, :index

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.8",
+      version: "0.5.9",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/auth_controller_test.exs
+++ b/test/engram_web/controllers/auth_controller_test.exs
@@ -48,6 +48,54 @@ defmodule EngramWeb.AuthControllerTest do
     end
   end
 
+  describe "GET /api-keys" do
+    setup %{conn: conn} do
+      user = insert(:user)
+      insert(:vault, user: user, is_default: true)
+      {:ok, raw_key, _} = Engram.Accounts.create_api_key(user, "setup-key")
+      authed = put_req_header(conn, "authorization", "Bearer #{raw_key}")
+      %{conn: authed, user: user}
+    end
+
+    test "lists keys belonging to the current user", %{conn: conn, user: user} do
+      {:ok, _, _} = Engram.Accounts.create_api_key(user, "second-key")
+
+      conn = get(conn, "/api/api-keys")
+      assert %{"keys" => keys} = json_response(conn, 200)
+      assert length(keys) == 2
+
+      names = Enum.map(keys, & &1["name"])
+      assert "setup-key" in names
+      assert "second-key" in names
+
+      key = hd(keys)
+      assert Map.has_key?(key, "id")
+      assert Map.has_key?(key, "created_at")
+      assert Map.has_key?(key, "last_used")
+      refute Map.has_key?(key, "key_hash")
+      refute Map.has_key?(key, "key")
+    end
+
+    test "does not return keys from other users", %{conn: conn} do
+      other = insert(:user)
+      {:ok, _, _} = Engram.Accounts.create_api_key(other, "other-key")
+
+      conn = get(conn, "/api/api-keys")
+      %{"keys" => keys} = json_response(conn, 200)
+      names = Enum.map(keys, & &1["name"])
+      refute "other-key" in names
+    end
+
+    test "returns 401 without auth", %{conn: conn} do
+      conn =
+        conn
+        |> delete_req_header("authorization")
+        |> get("/api/api-keys")
+
+      assert json_response(conn, 401)
+    end
+  end
+
   describe "DELETE /api-keys/:id" do
     setup %{conn: conn} do
       user = insert(:user)

--- a/test/engram_web/controllers/auth_controller_test.exs
+++ b/test/engram_web/controllers/auth_controller_test.exs
@@ -1,6 +1,36 @@
 defmodule EngramWeb.AuthControllerTest do
   use EngramWeb.ConnCase, async: true
 
+  # API key management routes are session/JWT only — an API-key-authenticated
+  # caller must not be able to enumerate, create, or revoke other API keys.
+  # Tests here use an internal HS256 JWT (the same kind the device flow issues)
+  # to authenticate, and assert API-key bearer auth is rejected with 403.
+
+  # Issues a token via the local auth provider so it round-trips through
+  # TokenResolver as a session JWT (not via the API-key code path). Requires
+  # the user to have an external_id the provider can resolve back to.
+  defp jwt_authed(conn, user) do
+    user = ensure_external_id(user)
+    {:ok, token} = Engram.Auth.Providers.Local.issue_access_token(user.external_id, user.email)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  defp ensure_external_id(%{external_id: ext} = user) when is_binary(ext) and ext != "", do: user
+
+  defp ensure_external_id(user) do
+    {:ok, updated} =
+      user
+      |> Ecto.Changeset.change(external_id: "test-#{user.id}")
+      |> Engram.Repo.update(skip_tenant_check: true)
+
+    updated
+  end
+
+  defp api_key_authed(conn, user) do
+    {:ok, raw_key, _} = Engram.Accounts.create_api_key(user, "auth-test-key")
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
   # ---------------------------------------------------------------------------
   # POST /api-keys
   # ---------------------------------------------------------------------------
@@ -9,9 +39,7 @@ defmodule EngramWeb.AuthControllerTest do
     setup %{conn: conn} do
       user = insert(:user)
       insert(:vault, user: user, is_default: true)
-      {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "setup-key")
-      authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
-      %{conn: authed, user: user}
+      %{conn: jwt_authed(conn, user), user: user}
     end
 
     test "creates an API key and returns raw key", %{conn: conn} do
@@ -23,13 +51,12 @@ defmodule EngramWeb.AuthControllerTest do
       assert is_integer(id)
     end
 
-    test "created key can authenticate requests", %{conn: conn} do
+    test "created key can authenticate vault-scoped requests", %{conn: conn} do
       %{"key" => new_key} =
         conn
         |> post("/api/api-keys", %{name: "usable-key"})
         |> json_response(200)
 
-      # Use the newly created key to make an authenticated request (user-scoped endpoint)
       conn2 =
         build_conn()
         |> put_req_header("authorization", "Bearer #{new_key}")
@@ -46,15 +73,23 @@ defmodule EngramWeb.AuthControllerTest do
 
       assert json_response(conn, 401)
     end
+
+    test "rejects API-key auth with 403", %{user: user} do
+      conn =
+        build_conn()
+        |> api_key_authed(user)
+        |> post("/api/api-keys", %{name: "should-not-be-created"})
+
+      assert %{"error" => "api_key_not_allowed"} = json_response(conn, 403)
+    end
   end
 
   describe "GET /api-keys" do
     setup %{conn: conn} do
       user = insert(:user)
       insert(:vault, user: user, is_default: true)
-      {:ok, raw_key, _} = Engram.Accounts.create_api_key(user, "setup-key")
-      authed = put_req_header(conn, "authorization", "Bearer #{raw_key}")
-      %{conn: authed, user: user}
+      {:ok, _raw, _} = Engram.Accounts.create_api_key(user, "setup-key")
+      %{conn: jwt_authed(conn, user), user: user}
     end
 
     test "lists keys belonging to the current user", %{conn: conn, user: user} do
@@ -94,19 +129,40 @@ defmodule EngramWeb.AuthControllerTest do
 
       assert json_response(conn, 401)
     end
+
+    test "rejects API-key auth with 403 — prevents credential enumeration", %{user: user} do
+      conn =
+        build_conn()
+        |> api_key_authed(user)
+        |> get("/api/api-keys")
+
+      assert %{"error" => "api_key_not_allowed"} = json_response(conn, 403)
+    end
   end
 
   describe "DELETE /api-keys/:id" do
     setup %{conn: conn} do
       user = insert(:user)
-      {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "setup-key")
-      authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
-      %{conn: authed, user: user}
+      insert(:vault, user: user, is_default: true)
+      {:ok, _raw, target_key} = Engram.Accounts.create_api_key(user, "to-be-revoked")
+      %{conn: jwt_authed(conn, user), user: user, target_key_id: target_key.id}
     end
 
     test "returns 400 for non-integer API key id", %{conn: conn} do
       conn = delete(conn, "/api/api-keys/abc")
       assert %{"error" => _} = json_response(conn, 400)
+    end
+
+    test "rejects API-key auth with 403 — prevents revoking sibling keys", %{
+      user: user,
+      target_key_id: id
+    } do
+      conn =
+        build_conn()
+        |> api_key_authed(user)
+        |> delete("/api/api-keys/#{id}")
+
+      assert %{"error" => "api_key_not_allowed"} = json_response(conn, 403)
     end
   end
 end

--- a/test/engram_web/controllers/missing_features_test.exs
+++ b/test/engram_web/controllers/missing_features_test.exs
@@ -127,11 +127,32 @@ defmodule EngramWeb.MissingFeaturesTest do
   # API key revocation  # ---------------------------------------------------------------------------
 
   describe "DELETE /api-keys/:id" do
-    test "revokes an API key", %{conn: conn, user: user} do
-      # Create a second key to revoke
+    test "revokes an API key (session auth)", %{user: user} do
+      # API-key auth is no longer permitted on /api-keys/* — must use a
+      # session JWT. See EngramWeb.Plugs.RequireSession.
+      user_with_ext =
+        if user.external_id in [nil, ""] do
+          {:ok, u} =
+            user
+            |> Ecto.Changeset.change(external_id: "test-#{user.id}")
+            |> Engram.Repo.update(skip_tenant_check: true)
+
+          u
+        else
+          user
+        end
+
+      {:ok, jwt} =
+        Engram.Auth.Providers.Local.issue_access_token(
+          user_with_ext.external_id,
+          user_with_ext.email
+        )
+
+      session_conn = build_conn() |> put_req_header("authorization", "Bearer #{jwt}")
+
       {:ok, temp_key, temp_api_key} = Engram.Accounts.create_api_key(user, "temp-key")
 
-      conn2 = delete(conn, "/api/api-keys/#{temp_api_key.id}")
+      conn2 = delete(session_conn, "/api/api-keys/#{temp_api_key.id}")
       assert json_response(conn2, 200)
 
       # Revoked key should be rejected

--- a/test/engram_web/controllers/search_controller_test.exs
+++ b/test/engram_web/controllers/search_controller_test.exs
@@ -50,8 +50,13 @@ defmodule EngramWeb.SearchControllerTest do
       conn = post(conn, "/api/search", %{query: "iron panel"})
       assert %{"results" => results} = json_response(conn, 200)
       assert length(results) == 1
-      assert hd(results)["score"] == 0.95
-      assert hd(results)["source_path"] == "Health/Iron Panel.md"
+      [hit] = results
+      assert hit["score"] == 0.95
+      assert hit["path"] == "Health/Iron Panel.md"
+      assert hit["title"] == "Iron Panel"
+      assert hit["folder"] == "Health"
+      assert hit["snippet"] == "Ferritin levels."
+      assert hit["match_count"] == 1
     end
 
     test "passes limit param", %{conn: conn, bypass: bypass} do

--- a/test/engram_web/controllers/search_controller_test.exs
+++ b/test/engram_web/controllers/search_controller_test.exs
@@ -59,14 +59,18 @@ defmodule EngramWeb.SearchControllerTest do
       assert hit["match_count"] == 1
     end
 
-    test "passes limit param", %{conn: conn, bypass: bypass} do
+    test "over-fetches chunks so grouping can return the requested number of notes",
+         %{conn: conn, bypass: bypass} do
       Engram.MockEmbedder
       |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
 
       Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn c ->
         {:ok, body, c} = Plug.Conn.read_body(c)
         decoded = Jason.decode!(body)
-        assert decoded["limit"] == 10
+        # Client requests 10 notes → controller asks Qdrant for 40 chunks
+        # (10 * @overfetch_factor) so multiple chunks per note don't cap
+        # the visible result set below 10 notes.
+        assert decoded["limit"] == 40
 
         c
         |> Plug.Conn.put_resp_content_type("application/json")
@@ -82,14 +86,15 @@ defmodule EngramWeb.SearchControllerTest do
       assert json_response(conn, 422)
     end
 
-    test "clamps limit to valid range", %{conn: conn, bypass: bypass} do
+    test "clamps note limit then over-fetches chunks", %{conn: conn, bypass: bypass} do
       Engram.MockEmbedder
       |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
 
       Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn c ->
         {:ok, body, c} = Plug.Conn.read_body(c)
         decoded = Jason.decode!(body)
-        assert decoded["limit"] <= 50
+        # 999 notes → clamped to 50 → 50 * 4 = 200 chunks asked of Qdrant.
+        assert decoded["limit"] == 200
 
         c
         |> Plug.Conn.put_resp_content_type("application/json")
@@ -142,5 +147,89 @@ defmodule EngramWeb.SearchControllerTest do
       conn = post(conn, "/api/search", %{query: "nothing here"})
       assert %{"results" => []} = json_response(conn, 200)
     end
+
+    test "groups repeated chunks from the same note into one result with match_count",
+         %{conn: conn, bypass: bypass, user: user} do
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      # Three top hits all point at the same note plus one different note —
+      # before the over-fetch + group_by_note fix, repeated chunks would
+      # crowd out the second note even though there were enough candidates.
+      qdrant_result = %{
+        "result" => [
+          chunk("uuid-a1", 0.95, "Health/Iron Panel.md", "Iron Panel", "Ferritin section.", user),
+          chunk("uuid-a2", 0.91, "Health/Iron Panel.md", "Iron Panel", "TIBC section.", user),
+          chunk("uuid-a3", 0.88, "Health/Iron Panel.md", "Iron Panel", "Notes on saturation.", user),
+          chunk("uuid-b1", 0.80, "Health/Vitamin D.md", "Vitamin D", "Levels by season.", user)
+        ]
+      }
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn c ->
+        c
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(qdrant_result))
+      end)
+
+      conn = post(conn, "/api/search", %{query: "iron", limit: 5})
+      assert %{"results" => results} = json_response(conn, 200)
+
+      # Two unique notes, sorted by best chunk score.
+      assert length(results) == 2
+      [iron, vitd] = results
+
+      assert iron["path"] == "Health/Iron Panel.md"
+      assert iron["match_count"] == 3
+      assert iron["snippet"] == "Ferritin section."
+      assert iron["score"] == 0.95
+
+      assert vitd["path"] == "Health/Vitamin D.md"
+      assert vitd["match_count"] == 1
+    end
+
+    test "honors the requested note limit when more unique notes are available",
+         %{conn: conn, bypass: bypass, user: user} do
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      result = %{
+        "result" =>
+          for i <- 1..10 do
+            chunk(
+              "uuid-#{i}",
+              1.0 - i * 0.01,
+              "F/Note #{i}.md",
+              "Note #{i}",
+              "snippet #{i}",
+              user
+            )
+          end
+      }
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn c ->
+        c
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(result))
+      end)
+
+      conn = post(conn, "/api/search", %{query: "note", limit: 3})
+      %{"results" => results} = json_response(conn, 200)
+      assert length(results) == 3
+    end
+  end
+
+  defp chunk(id, score, source_path, title, text, user) do
+    %{
+      "id" => id,
+      "score" => score,
+      "payload" => %{
+        "text" => text,
+        "title" => title,
+        "heading_path" => title,
+        "source_path" => source_path,
+        "tags" => [],
+        "user_id" => to_string(user.id)
+      }
+    }
   end
 end


### PR DESCRIPTION
## Summary

Web app pass for the alpha. Eight commits since `main`; everything is browser-driven, no backend behavior change beyond a list endpoint, a search-result reshape, and a dev-config tidy.

### Settings (new `/settings` shell)
- Sidebar with **API Keys**, **Encryption**, **Billing** sections + nested routes
- **API Keys**: list / create-with-name / revoke / copy-once raw-key reveal modal with clipboard fallback
- **Encryption**: per-vault card with status badge, Encrypt button + cooldown confirmation, 3s progress polling for in-flight encrypt/decrypt (no decrypt UI — alpha scope)
- **Billing**: placeholder linking to existing `/billing` route
- Backend: adds `GET /api-keys` (id, name, created_at, last_used)

### Multi-vault UI
- localStorage-backed active-vault store; sent as `X-Vault-ID` on every API request so vault-scoped endpoints (notes, folders, search, tags) honor the user's selection
- Sidebar **VaultSwitcher** dropdown above the file tree; auto-seeds from `is_default` → first vault
- Encryption page now lists every vault as its own card (was hard-coded to the first vault)
- Channel topic is now `sync:{user_id}:{vault_id}` to match the backend `SyncChannel` (previously joined `sync:{user_id}` and got `invalid_topic`); re-joins on vault switch
- All vault-scoped query keys include `activeVaultId` so cache invalidates cleanly

### Obsidian-style file tree
- Sidebar shows individual files inside folders, not just folder names
- Each folder lazily loads its notes on first expansion (no fan-out on mount)
- Active note highlights from the current `/note/<path>` route; folders auto-expand to keep the current file visible
- Root-level notes render at the top
- `useFolderNotes` accepts an explicit `enabled` so callers can opt into the empty-folder root listing

### Search overhaul
- `/api/search` collapses per-chunk Qdrant hits into one row per note: `{path, title, folder, heading_path, snippet, score, match_count}`. Best-scoring chunk wins; folder/title derived from path when payload doesn't carry them
- Web cards: folder breadcrumb, note title, optional heading path, line-clamped snippet, "+N more matches in this note", `<mark>`-highlighted query tokens — score chrome removed
- **Bug fixed**: clicking a result used to send users to `/note/undefined` because frontend read `r.path` while backend returned `source_path`
- MCP path is unchanged — `Search.search` still returns raw chunks

### Dev-loop fixes
- `config/dev.exs`: `:spa_cache_enabled?, false` so `vite build` / `bun run build` rewriting `priv/static/app/index.html` is picked up immediately. Without this, `SpaController` cached the pre-rebuild HTML in `:persistent_term`, the new asset hash 404'd, and the page went white
- `config/dev.exs`: removed the npm watcher. Phoenix watchers spawn child Ports that survive BEAM SIGKILL — `npm run dev` execs into `node`, leaving an orphan listener on each restart (we found 7 stale ones piled up on :5173–:5180). `make dev` runs Phoenix only now; run `make frontend-dev` separately when you want :5173 hot-reload
- New `docs/context/dev-iteration-loop.md` captures the :4000 vs :5173 vs `engram.ras.band` mental model and the white-page debugging signature
- Encryption page no longer crashes on unexpected status enums — added `UNKNOWN_STYLE` fallback when backend statuses drift

### Per-segment URL encoding
- `/api/notes/<path>` and `/note/<path>` link both encode segments individually so `/` stays literal. Plug.Static rejected `%2F` in the URL with `400 InvalidPathError` before the router could splat-match — caused the "Failed to load" errors for any note whose path contained spaces or special characters

## Tests
- `mix test test/engram_web/controllers/search_controller_test.exs test/engram_web/controllers/auth_controller_test.exs` — 14/14 pass
- `tsc --noEmit && vite build` clean

## Manual smoke (live on `engram.ras.band`)
- [x] sign up → /settings/api-keys → create + copy → revoke
- [x] /settings/encryption → encrypt vault → progress polls → status flips to Encrypted
- [x] sidebar vault switcher toggles between two vaults; folders/notes refetch
- [x] file-tree expand/collapse, click note opens it, active highlights
- [x] search "omega 3" returns deduped notes with snippets, click navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)