### PR TITLE
fix(attachments): version-aware read path + clear stale BYTEA on S3 upsert

### DIFF
--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -79,8 +79,10 @@ defmodule Engram.Attachments do
         {:ok, nil}
 
       {:ok, %Attachment{content: content} = att} when not is_nil(content) ->
-        # Content already in the row (Database adapter)
-        {:ok, att}
+        # Content in the BYTEA column. Route through decrypt_if_needed so
+        # version=1 rows whose ciphertext lives in `content` (e.g. from a
+        # mis-configured backfill) still decrypt instead of serving raw bytes.
+        decrypt_if_needed(att, content, user)
 
       {:ok, %Attachment{} = att} ->
         # Content stored externally (S3 adapter) — fetch it
@@ -241,6 +243,7 @@ defmodule Engram.Attachments do
             base_attrs
             |> Map.put(:encryption_version, 1)
             |> Map.put(:content_nonce, nonce)
+            |> Map.put(:content, nil)
 
           {:ok, key, attrs, ciphertext}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.15",
+      version: "0.5.16",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -241,6 +241,82 @@ defmodule Engram.AttachmentsTest do
       assert {:error, :decrypt_failed} =
                Engram.Attachments.get_attachment(user, vault, "ghost.bin")
     end
+
+    test "row with version=1 AND non-nil BYTEA content decrypts the BYTEA in place" do
+      # Guards against the failure mode where Storage.Database.put overwrites
+      # the BYTEA `content` column with ciphertext while the worker also flips
+      # `encryption_version=1`. The read path MUST route through decrypt_if_needed
+      # — short-circuiting on `content non-nil` would serve raw ciphertext.
+      user = insert(:user) |> Engram.Repo.reload!()
+      vault = insert(:vault, user: user)
+      plaintext = "double-stored bytes"
+
+      {:ok, _att} =
+        Engram.Attachments.upsert_attachment(user, vault, %{
+          "path" => "double.bin",
+          "content_base64" => Base.encode64(plaintext),
+          "mtime" => 0.0
+        })
+
+      # Pull the ciphertext out of InMemory storage and stuff it into the row's
+      # BYTEA content column to simulate the post-corruption shape.
+      key = "#{user.id}/#{vault.id}/double.bin"
+      {:ok, ciphertext} = Engram.Storage.InMemory.get(key)
+
+      {:ok, {1, _}} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          from(a in Engram.Attachments.Attachment,
+            where: a.user_id == ^user.id and a.vault_id == ^vault.id and a.path == "double.bin"
+          )
+          |> Engram.Repo.update_all(set: [content: ciphertext])
+        end)
+
+      {:ok, fetched} = Engram.Attachments.get_attachment(user, vault, "double.bin")
+      assert fetched.content == plaintext
+    end
+
+    test "S3 re-upload over a legacy BYTEA row clears stale content column" do
+      # Guards against the upsert leaving stale plaintext in `content` after
+      # switching a row from version=0 BYTEA to version=1 S3.
+      user = insert(:user) |> Engram.Repo.reload!()
+      vault = insert(:vault, user: user)
+
+      # Step 1: write a legacy BYTEA row using the Database adapter.
+      prev = Application.get_env(:engram, :storage)
+      Application.put_env(:engram, :storage, Engram.Storage.Database)
+
+      {:ok, _legacy} =
+        Engram.Attachments.upsert_attachment(user, vault, %{
+          "path" => "migrate.bin",
+          "content_base64" => Base.encode64("legacy plaintext"),
+          "mtime" => 0.0
+        })
+
+      # Step 2: flip back to S3 (InMemory) and re-upload the same path.
+      Application.put_env(:engram, :storage, prev)
+
+      {:ok, _new} =
+        Engram.Attachments.upsert_attachment(user, vault, %{
+          "path" => "migrate.bin",
+          "content_base64" => Base.encode64("fresh plaintext"),
+          "mtime" => 1.0
+        })
+
+      # Row's BYTEA content must be cleared so the read path doesn't serve stale
+      # bytes via the `content non-nil` short-circuit.
+      {:ok, raw} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          Engram.Repo.one(
+            from(a in Engram.Attachments.Attachment,
+              where:
+                a.user_id == ^user.id and a.vault_id == ^vault.id and a.path == "migrate.bin",
+              select: a.content
+            )
+          )
+        end)
+
+      assert is_nil(raw)
+    end
   end
 
   describe "get_attachment/3 with S3 storage (content nil)" do


### PR DESCRIPTION
## Summary

Two related read-path bugs in the attachments context, exposed by the 0.5.15 backfill incident on saas (root cause: missing `STORAGE_BACKEND=s3` env caused `Storage.Database.put` to overwrite BYTEA `content` with ciphertext). Both bugs are independently real even with proper env config.

- `get_attachment/3` short-circuited on `content non-nil` regardless of `encryption_version`. Now routes through `decrypt_if_needed/3` so version=1 BYTEA rows decrypt instead of serving raw GCM ciphertext. Version=0 still passes through unchanged.
- `prepare_upload/6` S3 branch never set `content: nil` in attrs, so re-uploading over a legacy BYTEA row left stale plaintext in the column — the same short-circuit then served stale bytes. Now explicitly clears.

## Test plan

- [x] New test `row with version=1 AND non-nil BYTEA content decrypts the BYTEA in place` — fails on main (returns ciphertext), passes after fix
- [x] New test `S3 re-upload over a legacy BYTEA row clears stale content column` — fails on main (content non-nil), passes after fix
- [x] Existing 859 tests still pass (no regressions)
- [x] Existing `legacy BYTEA row is returned without decrypt attempt` still green — version=0 passthrough preserved
- [ ] After merge: deploy-fastraid ships 0.5.16, then re-test attachment fetch on saas after pushing originals from plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)