### PR TITLE
fix(endpoint): guard nil-scheme URI in WebSocket origin check

### DIFF
--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -19,6 +19,8 @@ defmodule EngramWeb.Endpoint do
     end
   end
 
+  defp normalize_origin(%URI{scheme: nil}), do: nil
+
   defp normalize_origin(%URI{scheme: scheme, host: host, port: port}) do
     default = URI.default_port(scheme)
     port_part = if is_nil(port) or port == default, do: "", else: ":#{port}"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.16",
+      version: "0.5.17",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/endpoint_config_test.exs
+++ b/test/engram_web/endpoint_config_test.exs
@@ -47,6 +47,22 @@ defmodule EngramWeb.EndpointConfigTest do
     assert EngramWeb.Endpoint.check_origin(URI.parse("https://anything.example.com"))
   end
 
+  # Origin headers can arrive scheme-less ("null", "anonymous", clients sending
+  # malformed values). Phoenix calls our MFA with URI.parse(origin) which yields
+  # %URI{scheme: nil, ...}. URI.default_port(nil) raises FunctionClauseError —
+  # without a guard, every such request crashes the WS transport and floods logs.
+  test "Endpoint.check_origin/1 rejects URI with nil scheme without crashing" do
+    Application.put_env(:engram, :websocket_check_origin, [
+      "http://engram.ax",
+      "app://obsidian.md"
+    ])
+
+    on_exit(fn -> Application.delete_env(:engram, :websocket_check_origin) end)
+
+    refute EngramWeb.Endpoint.check_origin(URI.parse("null"))
+    refute EngramWeb.Endpoint.check_origin(%URI{scheme: nil, host: nil, port: nil})
+  end
+
   test "Endpoint.check_origin/1 normalizes URI with explicit non-default port" do
     Application.put_env(:engram, :websocket_check_origin, [
       "http://engram.ax:8080"


### PR DESCRIPTION
## Summary

Phoenix.Socket.Transport calls our `check_origin` MFA with `URI.parse(origin)`. Origin headers can arrive scheme-less (`null`, `anonymous`, malformed values from misbehaving clients), which yields `%URI{scheme: nil}`. `URI.default_port(nil)` raises `FunctionClauseError`, crashing every such WS handshake and flooding logs (~1 error/sec on saas during heavy plugin reconnect loops).

Add a clause that returns `nil` for scheme-less URIs so the allowlist comparison rejects gracefully.

Surfaced during the 0.5.16 saas attachment push — 70 errors/min in the saas log alongside healthy HTTP traffic. Pre-existing latent bug, exposed by aggressive WS reconnects.

## Test plan

- [x] New unit test: `URI.parse("null")` (scheme=nil) → check_origin returns false, no crash
- [x] Existing 9 origin tests still green (URI struct + binary + non-default port + integration paths)
- [x] Full unit suite: 862/0
- [ ] After deploy 0.5.17: saas log error rate from `URI.default_port` drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)