### PR TITLE
feat(attachments): cut writes to S3-only (A.4, 0.5.18)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,8 +24,10 @@ config :engram, EngramWeb.Endpoint,
   http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 
 if config_env() != :test do
-  # Storage backend — select adapter from STORAGE_BACKEND env var (s3 or database)
-  case System.get_env("STORAGE_BACKEND", "database") do
+  # Storage backend — S3-only as of A.4 (PR #61). The legacy `database` adapter
+  # still exists for read-only access to pre-encryption BYTEA rows but cannot
+  # accept new writes. Setting STORAGE_BACKEND=database is a misconfiguration.
+  case System.get_env("STORAGE_BACKEND", "s3") do
     "s3" ->
       config :engram, :storage, Engram.Storage.S3
       config :engram, :storage_bucket, System.get_env("STORAGE_BUCKET", "engram-attachments")
@@ -40,8 +42,16 @@ if config_env() != :test do
         host: System.get_env("STORAGE_HOST"),
         port: String.to_integer(System.get_env("STORAGE_PORT", "443"))
 
-    _ ->
-      config :engram, :storage, Engram.Storage.Database
+    "database" ->
+      raise """
+      STORAGE_BACKEND=database is no longer supported (A.4, PR #61).
+      Attachment writes go to S3-compatible object storage only.
+      Set STORAGE_BACKEND=s3 plus STORAGE_BUCKET, STORAGE_ACCESS_KEY_ID,
+      STORAGE_SECRET_ACCESS_KEY, STORAGE_HOST (and friends).
+      """
+
+    other ->
+      raise "Unknown STORAGE_BACKEND=#{inspect(other)} — expected \"s3\""
   end
 
   # Embedder — select adapter from EMBED_BACKEND env var (voyage or ollama)
@@ -109,11 +119,13 @@ end
 
 # Auth provider selection: "local" (built-in email/password) or "clerk" (SaaS JWKS)
 # Default: local — self-hosters get working auth with zero third-party config.
-auth_provider = case System.get_env("AUTH_PROVIDER", "local") do
-  "local" -> :local
-  "clerk" -> :clerk
-  other -> raise "Invalid AUTH_PROVIDER=#{other}. Valid values: local, clerk"
-end
+auth_provider =
+  case System.get_env("AUTH_PROVIDER", "local") do
+    "local" -> :local
+    "clerk" -> :clerk
+    other -> raise "Invalid AUTH_PROVIDER=#{other}. Valid values: local, clerk"
+  end
+
 config :engram, :auth_provider, auth_provider
 
 # Rate limit override for CI E2E tests (only effective when CI=true).
@@ -126,12 +138,16 @@ end
 # Note: use local variable, not Application.get_env — runtime.exs config
 # is accumulated and not yet applied, so get_env reads stale config.
 if auth_provider == :clerk do
-  clerk_jwks_url = System.get_env("CLERK_JWKS_URL") ||
-    raise "CLERK_JWKS_URL is required when AUTH_PROVIDER=clerk"
+  clerk_jwks_url =
+    System.get_env("CLERK_JWKS_URL") ||
+      raise "CLERK_JWKS_URL is required when AUTH_PROVIDER=clerk"
+
   config :engram, :clerk_jwks_url, String.trim(clerk_jwks_url)
 
-  clerk_issuer = System.get_env("CLERK_ISSUER") ||
-    raise "CLERK_ISSUER is required when AUTH_PROVIDER=clerk"
+  clerk_issuer =
+    System.get_env("CLERK_ISSUER") ||
+      raise "CLERK_ISSUER is required when AUTH_PROVIDER=clerk"
+
   config :engram, :clerk_issuer, String.trim(clerk_issuer)
 
   clerk_pub_key =
@@ -140,6 +156,7 @@ if auth_provider == :clerk do
       "" -> raise "CLERK_PUBLISHABLE_KEY is set but empty when AUTH_PROVIDER=clerk"
       key -> key
     end
+
   config :engram, :clerk_publishable_key, clerk_pub_key
 end
 
@@ -180,7 +197,11 @@ phx_hosts = Engram.HostOrigins.parse(System.get_env("PHX_HOST"))
 
 if phx_hosts do
   scheme = System.get_env("PHX_SCHEME") || if(config_env() == :prod, do: "https", else: "http")
-  url_port = String.to_integer(System.get_env("PHX_PORT") || if(config_env() == :prod, do: "443", else: "80"))
+
+  url_port =
+    String.to_integer(
+      System.get_env("PHX_PORT") || if(config_env() == :prod, do: "443", else: "80")
+    )
 
   config :engram, EngramWeb.Endpoint,
     url: [host: phx_hosts.canonical_host, port: url_port, scheme: scheme]

--- a/docs/context/encryption-operations.md
+++ b/docs/context/encryption-operations.md
@@ -11,9 +11,17 @@ Notes-level encryption is shipped (Phase 1-6, PRs #37/#38/#43/#50). Attachments 
 - Legacy BYTEA reads continue to work unchanged (dual-flow `get_attachment`).
 - `mix engram.backfill_bytea_to_s3` enqueues one Oban job per (user, vault) with legacy rows.
 - Worker is idempotent and cursor-driven; rerun is safe.
-- BYTEA column NOT yet dropped — happens in PR #60 after PR #59 cuts writes to S3-only.
+- BYTEA column NOT yet dropped — happens in PR #62 after PR #61 cuts writes to S3-only.
 - Telemetry events for encrypt/decrypt are deferred to PR #59 (Phase A reland keeps surface area minimal).
 - See `docs/superpowers/plans/2026-05-02-encryption-attachments-reland.md` for the full reland plan + production runbook.
+
+### A.4 — Cut writes to S3-only (PR #61, 0.5.18)
+
+- `prepare_upload/6` no longer branches on adapter — single encrypted S3 write path.
+- `STORAGE_BACKEND=database` is now a fatal misconfig: `runtime.exs` raises at boot.
+- Boot default flipped from `database` → `s3`; legacy `Storage.Database` adapter remains for read-only access to pre-encryption BYTEA rows until A.5 retires it.
+- Defense in depth: even if adapter somehow resolves to `Storage.Database`, `prepare_upload/6` returns `{:error, :writes_disabled}` rather than silently overwriting BYTEA with ciphertext (the 2026-05-02 corruption shape).
+- BYTEA `content` column + `Storage.Database` adapter retire in PR #62 (A.5) once selfhost is verified at zero `WHERE encryption_version = 0 AND content IS NOT NULL` rows.
 
 ## What This Is
 Operator runbook for encryption toggling, per-user cooldown, and incident triage. Companion to the architecture spec at `docs/superpowers/specs/2026-04-07-encryption-at-rest-design.md`.

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -120,7 +120,9 @@ defmodule Engram.Attachments do
 
     Repo.with_tenant(user.id, fn ->
       from(a in Attachment,
-        where: a.path == ^path and a.user_id == ^user.id and a.vault_id == ^vault.id and is_nil(a.deleted_at)
+        where:
+          a.path == ^path and a.user_id == ^user.id and a.vault_id == ^vault.id and
+            is_nil(a.deleted_at)
       )
       |> Repo.update_all(set: [deleted_at: now, updated_at: now])
     end)
@@ -142,7 +144,11 @@ defmodule Engram.Attachments do
 
       {:error, reason} ->
         require Logger
-        Logger.warning("Failed to delete blob key=#{key}: #{inspect(reason)} (row already soft-deleted)")
+
+        Logger.warning(
+          "Failed to delete blob key=#{key}: #{inspect(reason)} (row already soft-deleted)"
+        )
+
         :ok
     end
   end
@@ -213,10 +219,20 @@ defmodule Engram.Attachments do
   end
 
   defp prepare_upload(user, vault, path, plaintext, mtime, explicit_mime) do
+    # A.4 — writes are S3-only. If the adapter is still `Storage.Database`
+    # (legacy deploy or template drift), refuse rather than silently writing
+    # ciphertext into the BYTEA `content` column.
+    if Storage.adapter() == Storage.Database do
+      {:error, :writes_disabled}
+    else
+      do_prepare_upload(user, vault, path, plaintext, mtime, explicit_mime)
+    end
+  end
+
+  defp do_prepare_upload(user, vault, path, plaintext, mtime, explicit_mime) do
     mime = explicit_mime || detect_mime(path)
     hash = :crypto.hash(:md5, plaintext) |> Base.encode16(case: :lower)
     key = Storage.key(user.id, vault.id, path)
-    backend = Storage.adapter()
 
     base_attrs = %{
       path: path,
@@ -230,23 +246,17 @@ defmodule Engram.Attachments do
       deleted_at: nil
     }
 
-    cond do
-      backend == Storage.Database ->
-        {:ok, key, Map.put(base_attrs, :content, plaintext), :skip}
+    with {:ok, user} <- Crypto.ensure_user_dek(user),
+         {:ok, dek} <- Crypto.get_dek(user) do
+      {ciphertext, nonce} = Envelope.encrypt(plaintext, dek)
 
-      true ->
-        with {:ok, user} <- Crypto.ensure_user_dek(user),
-             {:ok, dek} <- Crypto.get_dek(user) do
-          {ciphertext, nonce} = Envelope.encrypt(plaintext, dek)
+      attrs =
+        base_attrs
+        |> Map.put(:encryption_version, 1)
+        |> Map.put(:content_nonce, nonce)
+        |> Map.put(:content, nil)
 
-          attrs =
-            base_attrs
-            |> Map.put(:encryption_version, 1)
-            |> Map.put(:content_nonce, nonce)
-            |> Map.put(:content, nil)
-
-          {:ok, key, attrs, ciphertext}
-        end
+      {:ok, key, attrs, ciphertext}
     end
   end
 
@@ -263,7 +273,11 @@ defmodule Engram.Attachments do
     {:ok, %{att | content: binary}}
   end
 
-  defp decrypt_if_needed(%Attachment{encryption_version: 1, content_nonce: nonce} = att, ciphertext, user) do
+  defp decrypt_if_needed(
+         %Attachment{encryption_version: 1, content_nonce: nonce} = att,
+         ciphertext,
+         user
+       ) do
     fresh_user = if is_nil(user.encrypted_dek), do: Repo.reload!(user), else: user
 
     with {:ok, dek} <- Crypto.get_dek(fresh_user),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.17",
+      version: "0.5.18",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -40,6 +40,20 @@ defmodule Engram.AttachmentsTest do
       assert att.size_bytes == byte_size("test image content")
     end
 
+    test "refuses to write when storage adapter is Storage.Database", %{user: user, vault: vault} do
+      # A.4 cut writes to S3-only. If a deploy still has STORAGE_BACKEND=database
+      # (or template drift unsets it), we must NOT silently fall through to the
+      # S3 write path that would push ciphertext into the BYTEA `content` column —
+      # that's the exact corruption shape from the 2026-05-02 incident.
+      Application.put_env(:engram, :storage, Engram.Storage.Database)
+
+      assert {:error, :writes_disabled} =
+               Attachments.upsert_attachment(user, vault, %{
+                 "path" => @path,
+                 "content_base64" => @valid_content
+               })
+    end
+
     test "rejects attachment over max size", %{user: user, vault: vault} do
       oversized = Base.encode64(:binary.copy("x", 6 * 1024 * 1024))
 
@@ -199,16 +213,7 @@ defmodule Engram.AttachmentsTest do
       user = insert(:user)
       vault = insert(:vault, user: user)
 
-      prev = Application.get_env(:engram, :storage)
-      Application.put_env(:engram, :storage, Engram.Storage.Database)
-      on_exit(fn -> Application.put_env(:engram, :storage, prev) end)
-
-      {:ok, _att} =
-        Engram.Attachments.upsert_attachment(user, vault, %{
-          "path" => "legacy.bin",
-          "content_base64" => Base.encode64("legacy plaintext"),
-          "mtime" => 0.0
-        })
+      seed_legacy_bytea_row!(user, vault, "legacy.bin", "legacy plaintext")
 
       {:ok, fetched} = Engram.Attachments.get_attachment(user, vault, "legacy.bin")
       assert fetched.content == "legacy plaintext"
@@ -281,20 +286,9 @@ defmodule Engram.AttachmentsTest do
       user = insert(:user) |> Engram.Repo.reload!()
       vault = insert(:vault, user: user)
 
-      # Step 1: write a legacy BYTEA row using the Database adapter.
-      prev = Application.get_env(:engram, :storage)
-      Application.put_env(:engram, :storage, Engram.Storage.Database)
+      seed_legacy_bytea_row!(user, vault, "migrate.bin", "legacy plaintext")
 
-      {:ok, _legacy} =
-        Engram.Attachments.upsert_attachment(user, vault, %{
-          "path" => "migrate.bin",
-          "content_base64" => Base.encode64("legacy plaintext"),
-          "mtime" => 0.0
-        })
-
-      # Step 2: flip back to S3 (InMemory) and re-upload the same path.
-      Application.put_env(:engram, :storage, prev)
-
+      # Re-upload the same path via the (current) S3 path.
       {:ok, _new} =
         Engram.Attachments.upsert_attachment(user, vault, %{
           "path" => "migrate.bin",
@@ -320,7 +314,11 @@ defmodule Engram.AttachmentsTest do
   end
 
   describe "get_attachment/3 with S3 storage (content nil)" do
-    test "fetches binary from storage backend when content is nil", %{user: user, vault: vault, storage_key: storage_key} do
+    test "fetches binary from storage backend when content is nil", %{
+      user: user,
+      vault: vault,
+      storage_key: storage_key
+    } do
       # Insert an attachment row with content: nil and a storage_key
       {:ok, _att} =
         Repo.with_tenant(user.id, fn ->
@@ -346,7 +344,11 @@ defmodule Engram.AttachmentsTest do
                Attachments.get_attachment(user, vault, @path)
     end
 
-    test "returns storage error when blob is missing for live row", %{user: user, vault: vault, storage_key: storage_key} do
+    test "returns storage error when blob is missing for live row", %{
+      user: user,
+      vault: vault,
+      storage_key: storage_key
+    } do
       {:ok, _att} =
         Repo.with_tenant(user.id, fn ->
           %Attachment{}
@@ -369,10 +371,34 @@ defmodule Engram.AttachmentsTest do
 
       log =
         capture_log(fn ->
-          assert {:error, {:storage, :blob_missing}} = Attachments.get_attachment(user, vault, @path)
+          assert {:error, {:storage, :blob_missing}} =
+                   Attachments.get_attachment(user, vault, @path)
         end)
 
       assert log =~ "Attachment blob missing"
     end
+  end
+
+  # Insert a legacy `encryption_version=0` row with plaintext in the BYTEA
+  # `content` column — same shape `Storage.Database` produced before A.4.
+  # Used to verify the read path still serves pre-encryption attachments
+  # until A.5 retires the column entirely.
+  defp seed_legacy_bytea_row!(user, vault, path, plaintext) do
+    Repo.with_tenant(user.id, fn ->
+      %Attachment{}
+      |> Attachment.changeset(%{
+        path: path,
+        content: plaintext,
+        content_hash: :crypto.hash(:md5, plaintext) |> Base.encode16(case: :lower),
+        mime_type: "application/octet-stream",
+        size_bytes: byte_size(plaintext),
+        mtime: 0.0,
+        user_id: user.id,
+        vault_id: vault.id,
+        storage_key: "#{user.id}/#{vault.id}/#{path}",
+        encryption_version: 0
+      })
+      |> Repo.insert!()
+    end)
   end
 end

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -45,7 +45,12 @@ defmodule Engram.AttachmentsTest do
       # (or template drift unsets it), we must NOT silently fall through to the
       # S3 write path that would push ciphertext into the BYTEA `content` column —
       # that's the exact corruption shape from the 2026-05-02 incident.
+      #
+      # Application env is process-global; restore on exit so async tests in
+      # other files (e.g. AttachmentsControllerTest) don't see Database leak in.
+      prev = Application.get_env(:engram, :storage)
       Application.put_env(:engram, :storage, Engram.Storage.Database)
+      on_exit(fn -> Application.put_env(:engram, :storage, prev) end)
 
       assert {:error, :writes_disabled} =
                Attachments.upsert_attachment(user, vault, %{

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -1,5 +1,10 @@
 defmodule EngramWeb.AttachmentsControllerTest do
-  use EngramWeb.ConnCase, async: true
+  # async: false because AttachmentsTest (also async: false) mutates the
+  # global :storage adapter via Application.put_env. ExUnit runs async: true
+  # cases first, then async: false serially — making this file async: false
+  # serializes it against AttachmentsTest and prevents adapter races where
+  # a POST/GET pair straddles a flip to MockStorage or Storage.Database.
+  use EngramWeb.ConnCase, async: false
 
   @sample_content "Hello, binary world!"
   @sample_base64 Base.encode64("Hello, binary world!")


### PR DESCRIPTION
## Summary
- `Engram.Attachments.prepare_upload/6` is now single-path: every new upload encrypts and stores to S3.
- Defense in depth: if `Storage.adapter()` ever resolves to `Storage.Database` (legacy STORAGE_BACKEND, template drift), the upload returns `{:error, :writes_disabled}` instead of silently writing ciphertext into the BYTEA `content` column. This is the exact corruption shape the 2026-05-02 incident took 133 saas attachments through.
- `runtime.exs`: default flipped from `database` → `s3`; explicit `database` raises at boot with a fix-up message.
- `Storage.Database` adapter and BYTEA `content` column **remain in place** for read-only access to pre-encryption rows; A.5 (PR #62) retires them once selfhost is verified at zero `WHERE encryption_version = 0 AND content IS NOT NULL` rows.
- `mix.exs` 0.5.17 → 0.5.18; `docs/context/encryption-operations.md` updated with A.4 entry.

## Test plan
- [x] `mix test test/engram/attachments_test.exs` — 17/17 (incl. new `refuses to write when storage adapter is Storage.Database`)
- [x] `mix test` full suite — 863 passing, 7 skipped
- [ ] CI green
- [ ] Pre-merge: SSH FastRaid and confirm `STORAGE_BACKEND=s3` is set in BOTH `my-engram-saas.xml` and `my-engram-selfhost.xml` Unraid templates (drift check per `feedback_unraid_template_drift.md`)
- [ ] Post-deploy: `docker exec engram-saas /app/bin/engram rpc 'IO.inspect(Engram.Storage.adapter())'` returns `Engram.Storage.S3`
- [ ] Post-deploy: upload a new attachment via plugin, verify object lands in MinIO and `encryption_version=1` in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)