### PR TITLE
fix(logging): replace Phoenix request logger to stop path leaks

### DIFF
--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -9,6 +9,7 @@ defmodule Engram.Application do
   def start(_type, _args) do
     Engram.Crypto.Config.validate!()
     install_log_redaction_filter()
+    EngramWeb.RequestLogger.attach()
 
     children =
       [

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -49,7 +49,11 @@ defmodule EngramWeb.Endpoint do
   end
 
   plug Plug.RequestId
-  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+  # `log: false` suppresses Phoenix.Logger's default request log emission,
+  # which interpolates conn.method + conn.request_path into the message body
+  # (past the metadata-only RedactFilter). EngramWeb.RequestLogger replaces
+  # it with a structured equivalent that routes the path through metadata.
+  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint], log: false
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],

--- a/lib/engram_web/request_logger.ex
+++ b/lib/engram_web/request_logger.ex
@@ -1,0 +1,58 @@
+defmodule EngramWeb.RequestLogger do
+  @moduledoc """
+  Telemetry handler that emits one structured log line per HTTP request.
+
+  Replaces Phoenix's default `Plug.Telemetry` log emission, which interpolates
+  `conn.method` and `conn.request_path` directly into the message body — past
+  the reach of `Engram.Logger.RedactFilter`, which by design only scrubs
+  metadata, not message strings.
+
+  Phoenix's emission is suppressed via `plug Plug.Telemetry, log: false` in
+  `EngramWeb.Endpoint`. This module attaches at boot from `Engram.Application`.
+
+  Message body holds only safe scalars (`method`, `status`, `duration_ms`).
+  Sensitive fields (`request_path`, `request_query`) are routed through
+  metadata where the redact filter scrubs them. `user_id` is forwarded for
+  triage; it is not in the redact filter's sensitive-key set.
+  """
+
+  require Logger
+
+  @handler_id :engram_request_logger
+  @event [:phoenix, :endpoint, :stop]
+
+  @doc """
+  Attach (or re-attach) the telemetry handler. Idempotent — detaches first
+  so repeated boots don't accumulate stale handlers.
+  """
+  def attach do
+    _ = :telemetry.detach(@handler_id)
+
+    :ok =
+      :telemetry.attach(
+        @handler_id,
+        @event,
+        &__MODULE__.handle_event/4,
+        nil
+      )
+  end
+
+  @doc false
+  def handle_event(@event, %{duration: duration}, %{conn: conn}, _config) do
+    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+
+    Logger.info(
+      "#{conn.method} #{conn.status} in #{duration_ms}ms",
+      method: conn.method,
+      status: conn.status,
+      request_path: conn.request_path,
+      request_query: conn.query_string,
+      user_id: current_user_id(conn)
+    )
+  end
+
+  def handle_event(_, _, _, _), do: :ok
+
+  defp current_user_id(%Plug.Conn{assigns: %{current_user: %{id: id}}}), do: id
+  defp current_user_id(_), do: nil
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.21",
+      version: "0.5.22",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/request_logger_test.exs
+++ b/test/engram_web/request_logger_test.exs
@@ -1,0 +1,137 @@
+defmodule EngramWeb.RequestLoggerTest do
+  use ExUnit.Case, async: false
+
+  alias Engram.Test.LogCapture
+  alias EngramWeb.RequestLogger
+
+  @sentinel_path "/api/notes/secret-folder/XYZZYZ-LOGTEST-CONFIDENTIAL.md"
+  @sentinel_query "q=XYZZYZ-LOGTEST-USER-SEARCH"
+
+  setup do
+    previous_level = Logger.level()
+    Logger.configure(level: :info)
+    RequestLogger.attach()
+
+    on_exit(fn ->
+      :telemetry.detach(:engram_request_logger)
+      Logger.configure(level: previous_level)
+    end)
+
+    :ok
+  end
+
+  test "emits message with only method + status + duration — no path bytes" do
+    conn = %Plug.Conn{
+      method: "GET",
+      request_path: @sentinel_path,
+      query_string: @sentinel_query,
+      status: 401
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute(
+          [:phoenix, :endpoint, :stop],
+          %{duration: 5_000_000},
+          %{conn: conn}
+        )
+      end)
+
+    event = find_request_event(events)
+    assert event, "expected a request log event, got: #{inspect(events)}"
+
+    msg = render_msg(event.msg)
+    assert msg =~ "GET"
+    assert msg =~ "401"
+    assert msg =~ ~r/\d+ms/
+
+    refute msg =~ "XYZZYZ", "leaked path content into message body: #{inspect(msg)}"
+  end
+
+  test "routes request_path + request_query through metadata where the redact filter scrubs them" do
+    conn = %Plug.Conn{
+      method: "GET",
+      request_path: @sentinel_path,
+      query_string: @sentinel_query,
+      status: 200
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute(
+          [:phoenix, :endpoint, :stop],
+          %{duration: 1_000_000},
+          %{conn: conn}
+        )
+      end)
+
+    event = find_request_event(events)
+    assert event
+
+    assert event.meta[:request_path] == "[REDACTED]"
+    assert event.meta[:request_query] == "[REDACTED]"
+    refute inspect(event.meta) =~ "XYZZYZ"
+  end
+
+  test "passes through method, status, user_id as structured metadata (not redacted)" do
+    user = %{id: 42}
+
+    conn = %Plug.Conn{
+      method: "POST",
+      request_path: "/api/notes",
+      query_string: "",
+      status: 201,
+      assigns: %{current_user: user}
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute(
+          [:phoenix, :endpoint, :stop],
+          %{duration: 2_000_000},
+          %{conn: conn}
+        )
+      end)
+
+    event = find_request_event(events)
+    assert event
+
+    assert event.meta[:method] == "POST"
+    assert event.meta[:status] == 201
+    assert event.meta[:user_id] == 42
+  end
+
+  test "tolerates absent current_user assign (anonymous request)" do
+    conn = %Plug.Conn{
+      method: "GET",
+      request_path: "/api/health",
+      query_string: "",
+      status: 200,
+      assigns: %{}
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute(
+          [:phoenix, :endpoint, :stop],
+          %{duration: 100_000},
+          %{conn: conn}
+        )
+      end)
+
+    event = find_request_event(events)
+    assert event
+    assert event.meta[:user_id] == nil
+  end
+
+  defp find_request_event(events) do
+    Enum.find(events, fn e ->
+      msg = render_msg(e.msg)
+      msg =~ ~r/^[A-Z]+ \d+ in \d+ms$/
+    end)
+  end
+
+  defp render_msg({:string, s}), do: IO.iodata_to_binary(s)
+  defp render_msg({:report, _}), do: ""
+  defp render_msg(other), do: to_string(other)
+end


### PR DESCRIPTION
## Summary

Replaces Phoenix.Logger's per-request log emission, which interpolates `conn.method` + `conn.request_path` directly into the message body (past the metadata-only `RedactFilter` from PR #63). Every authenticated request was leaking the full path to logs in prod, including `/api/notes/<user-content path>` and `/api/attachments/<user-content path>`.

## What was leaking

Smoke-tested live on saas after PR #63 deployed (engram 0.5.20), hitting a 401 with sentinel path:

\`\`\`
[info] GET /api/notes/secret-folder/XYZZYZ-LOGTEST.md   ← Phoenix.Logger, leaks path
[info] auth rejected                                      ← my redacted line, scrubbed correctly
\`\`\`

The first line is what this PR replaces.

## Changes

- New `EngramWeb.RequestLogger` — telemetry handler attached at boot to `[:phoenix, :endpoint, :stop]`. Emits one structured line per request with method+status+duration in the message body and `request_path`, `request_query`, `user_id` in metadata. `RedactFilter` scrubs path/query automatically.
- `EngramWeb.Endpoint`: `plug Plug.Telemetry, ..., log: false` — Phoenix.Logger respects this option and skips its own emission.
- `Engram.Application.start/2` hooks `RequestLogger.attach/0` (idempotent — detach first).
- Bumps backend 0.5.21 → 0.5.22.

## Tests

- 4 unit tests on `RequestLogger` covering message body shape (no path bytes), metadata routing through the filter, structured field passthrough (method/status/user_id), and anonymous-request tolerance.
- All existing tests still pass (852 total).

## Out of scope

- `[:phoenix, :error_rendered]` telemetry events also accept `:log` option but are currently unused (we don't customize 500 pages). If we add error views later, audit then.
- Phase B (HMAC paths) eventually replaces the visible-path concept entirely. This PR is a stop-gap until then so prod isn't leaking for the next 1-2 weeks.

## Test plan

- [x] `mix test` — 852/852
- [ ] Smoke on FastRaid post-deploy: hit a 401 with sentinel path, verify both lines are scrubbed (only `<METHOD> <STATUS> in <Nms>` in message body, no path bytes anywhere)
- [ ] Verify a 200 path also doesn't leak
- [ ] `:telemetry.list_handlers/1` shows `:engram_request_logger` attached to `[:phoenix, :endpoint, :stop]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)