### PR TITLE
fix(phase-b1): backfill queue + mix task gap + docstring

### DIFF
--- a/lib/engram/workers/backfill_phase_b_hmac.ex
+++ b/lib/engram/workers/backfill_phase_b_hmac.ex
@@ -17,7 +17,7 @@ defmodule Engram.Workers.BackfillPhaseBHmac do
   """
 
   use Oban.Worker,
-    queue: :backfill,
+    queue: :crypto_backfill,
     max_attempts: 5,
     # Intentionally excludes `executing` — the worker re-enqueues itself for
     # the next batch from inside `perform/1`, where its own job is still in the

--- a/lib/mix/tasks/engram.backfill_phase_b_hmac.ex
+++ b/lib/mix/tasks/engram.backfill_phase_b_hmac.ex
@@ -1,21 +1,45 @@
 defmodule Mix.Tasks.Engram.BackfillPhaseBHmac do
   @moduledoc """
   Enqueues `Engram.Workers.BackfillPhaseBHmac` jobs for every (user, vault)
-  combination that has at least one row with `path_hmac IS NULL` in notes,
+  combination that has at least one row with `path_hmac IS NULL` in notes or
   attachments, or `name_hmac IS NULL` in vaults.
 
   Idempotent — re-runs are safe. The worker itself skips populated rows.
 
-  Usage from a release shell on FastRaid:
-      docker exec engram-saas /app/bin/engram eval 'Mix.Task.run("engram.backfill_phase_b_hmac")'
+  Usage:
+
+    # Local dev (mix available):
+    mix engram.backfill_phase_b_hmac
+
+    # Production (release — Mix not available, use rpc with inline body):
+    docker exec engram-saas /app/bin/engram rpc "
+    import Ecto.Query
+    alias Engram.Notes.Note
+    alias Engram.Attachments.Attachment
+    alias Engram.Vaults.Vault
+    alias Engram.Repo
+    alias Engram.Workers.BackfillPhaseBHmac
+
+    note_pairs = Repo.all(from(n in Note, where: is_nil(n.path_hmac), group_by: [n.user_id, n.vault_id], select: {n.user_id, n.vault_id}), skip_tenant_check: true)
+    attachment_pairs = Repo.all(from(a in Attachment, where: is_nil(a.path_hmac), group_by: [a.user_id, a.vault_id], select: {a.user_id, a.vault_id}), skip_tenant_check: true)
+    vault_pairs = Repo.all(from(v in Vault, where: is_nil(v.name_hmac), select: {v.user_id, v.id}), skip_tenant_check: true)
+    pairs = (note_pairs ++ attachment_pairs ++ vault_pairs) |> Enum.uniq()
+
+    for {uid, vid} <- pairs do
+      %{\"user_id\" => uid, \"vault_id\" => vid, \"last_id\" => 0} |> BackfillPhaseBHmac.new() |> Oban.insert!()
+    end
+    IO.puts(\"enqueued \#{length(pairs)}\")
+    "
   """
 
   use Mix.Task
 
   import Ecto.Query
 
+  alias Engram.Attachments.Attachment
   alias Engram.Notes.Note
   alias Engram.Repo
+  alias Engram.Vaults.Vault
   alias Engram.Workers.BackfillPhaseBHmac
 
   @shortdoc "Enqueue Phase B HMAC backfill jobs"
@@ -23,16 +47,7 @@ defmodule Mix.Tasks.Engram.BackfillPhaseBHmac do
   def run(_args) do
     Mix.Task.run("app.start")
 
-    pairs =
-      Repo.all(
-        from(n in Note,
-          where: is_nil(n.path_hmac),
-          group_by: [n.user_id, n.vault_id],
-          select: {n.user_id, n.vault_id}
-        ),
-        skip_tenant_check: true
-      )
-      |> Enum.uniq()
+    pairs = gather_pairs()
 
     IO.puts("Enqueueing Phase B backfill for #{length(pairs)} (user, vault) pairs")
 
@@ -42,6 +57,46 @@ defmodule Mix.Tasks.Engram.BackfillPhaseBHmac do
       |> Oban.insert!()
     end
 
-    IO.puts("Done. Watch oban_jobs queue=:backfill for progress.")
+    IO.puts("Done. Watch oban_jobs queue=:crypto_backfill for progress.")
+  end
+
+  @doc """
+  Returns deduplicated `{user_id, vault_id}` pairs needing Phase B backfill,
+  sourced from the union of:
+  - notes with `path_hmac IS NULL`
+  - attachments with `path_hmac IS NULL`
+  - vaults with `name_hmac IS NULL`
+  """
+  def gather_pairs do
+    note_pairs =
+      Repo.all(
+        from(n in Note,
+          where: is_nil(n.path_hmac),
+          group_by: [n.user_id, n.vault_id],
+          select: {n.user_id, n.vault_id}
+        ),
+        skip_tenant_check: true
+      )
+
+    attachment_pairs =
+      Repo.all(
+        from(a in Attachment,
+          where: is_nil(a.path_hmac),
+          group_by: [a.user_id, a.vault_id],
+          select: {a.user_id, a.vault_id}
+        ),
+        skip_tenant_check: true
+      )
+
+    vault_pairs =
+      Repo.all(
+        from(v in Vault,
+          where: is_nil(v.name_hmac),
+          select: {v.user_id, v.id}
+        ),
+        skip_tenant_check: true
+      )
+
+    (note_pairs ++ attachment_pairs ++ vault_pairs) |> Enum.uniq()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.24",
+      version: "0.5.25",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/mix/tasks/engram_backfill_phase_b_hmac_test.exs
+++ b/test/mix/tasks/engram_backfill_phase_b_hmac_test.exs
@@ -1,0 +1,120 @@
+defmodule Mix.Tasks.Engram.BackfillPhaseBHmacTest do
+  use Engram.DataCase, async: false
+
+  alias Engram.Attachments.Attachment
+  alias Engram.Notes.Note
+  alias Engram.Repo
+  alias Mix.Tasks.Engram.BackfillPhaseBHmac
+
+  describe "gather_pairs/0" do
+    test "includes vault-only pair when vault has name_hmac=nil and no notes" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+
+      # Verify factory leaves name_hmac nil
+      assert is_nil(vault.name_hmac)
+
+      pairs = BackfillPhaseBHmac.gather_pairs()
+
+      assert {user.id, vault.id} in pairs
+    end
+
+    test "includes pair from note with path_hmac=nil" do
+      user = insert(:user)
+      vault = insert(:vault, user: user, name_hmac: <<1::256>>)
+
+      Repo.with_tenant(user.id, fn ->
+        %Note{}
+        |> Note.changeset(%{
+          path: "docs/legacy.md",
+          folder: "docs",
+          content: "x",
+          tags: [],
+          user_id: user.id,
+          vault_id: vault.id
+        })
+        |> Repo.insert!()
+      end)
+
+      pairs = BackfillPhaseBHmac.gather_pairs()
+
+      assert {user.id, vault.id} in pairs
+    end
+
+    test "includes pair from attachment with path_hmac=nil and no notes needing backfill" do
+      user = insert(:user)
+      vault = insert(:vault, user: user, name_hmac: <<1::256>>)
+
+      Repo.with_tenant(user.id, fn ->
+        %Attachment{}
+        |> Ecto.Changeset.change(%{
+          path: "files/image.png",
+          content_hash: "abc123",
+          mime_type: "image/png",
+          size_bytes: 4,
+          content_nonce: <<0::96>>,
+          encryption_version: 1,
+          user_id: user.id,
+          vault_id: vault.id
+        })
+        |> Repo.insert!()
+      end)
+
+      pairs = BackfillPhaseBHmac.gather_pairs()
+
+      assert {user.id, vault.id} in pairs
+    end
+
+    test "excludes vault when all three sources are already populated" do
+      user = insert(:user)
+      vault = insert(:vault, user: user, name_hmac: <<1::256>>)
+
+      # Note with path_hmac set
+      Repo.with_tenant(user.id, fn ->
+        %Note{}
+        |> Note.changeset(%{
+          path: "done/note.md",
+          folder: "done",
+          content: "x",
+          tags: [],
+          user_id: user.id,
+          vault_id: vault.id,
+          path_hmac: <<2::256>>,
+          path_ciphertext: <<3::128>>,
+          path_nonce: <<4::96>>
+        })
+        |> Repo.insert!()
+      end)
+
+      pairs = BackfillPhaseBHmac.gather_pairs()
+
+      refute {user.id, vault.id} in pairs
+    end
+
+    test "deduplicates pairs appearing in multiple sources" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+
+      # Both note and vault contribute the same pair
+      assert is_nil(vault.name_hmac)
+
+      Repo.with_tenant(user.id, fn ->
+        %Note{}
+        |> Note.changeset(%{
+          path: "dup/note.md",
+          folder: "dup",
+          content: "x",
+          tags: [],
+          user_id: user.id,
+          vault_id: vault.id
+        })
+        |> Repo.insert!()
+      end)
+
+      pairs = BackfillPhaseBHmac.gather_pairs()
+
+      count = Enum.count(pairs, fn p -> p == {user.id, vault.id} end)
+      assert count == 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three Phase B.1 cleanup fixes discovered while running prod backfill on 0.5.24:

1. **Worker queue mismatch** — `BackfillPhaseBHmac` declared `:backfill` but Oban only runs `:crypto_backfill`. Required manual `UPDATE oban_jobs SET queue = ...` to drain prod. Now declares `:crypto_backfill` to match.
2. **Mix task gap** — task only enumerated `(user, vault)` pairs from notes-with-null-hmac. Empty vaults or attachment-only-orphan vaults were skipped. Verified gap in prod (3 saas vaults + 2 selfhost vaults required manual enqueue). Now enumerates union of notes + attachments + vaults via `gather_pairs/0`.
3. **Mix task docstring** — claimed `Mix.Task.run("...")` works in release `eval`. It doesn't (Mix isn't in release). Replaced with working `rpc`-based inline-body recipe.

## Test plan

- [x] Worker queue fix — `queue: :crypto_backfill` in worker module; existing worker tests pass (no queue assertion to update)
- [x] `gather_pairs/0` helper unit tests added (5 tests): vault-only pair, note pair, attachment pair, fully-populated exclusion, deduplication
- [x] `mix test` green — 882 tests, 0 failures