### PR TITLE
feat(encryption): Phase B.2 — read switch + Qdrant payload migration

### DIFF
--- a/e2e/helpers/crypto_probe.py
+++ b/e2e/helpers/crypto_probe.py
@@ -354,6 +354,35 @@ def set_user_cooldown_days(user_id: int, days: int | None) -> None:
     )
 
 
+def tamper_note_plaintext_columns(
+    vault_id: int, path: str, *, new_path: str, new_folder: str
+) -> None:
+    """Corrupt a note's plaintext `path` and `folder` columns directly via SQL.
+
+    Used by Phase B.2 invariant tests: after this call the plaintext columns
+    no longer match reality, but path_hmac / path_ciphertext / folder_hmac /
+    folder_ciphertext are untouched. Any controller that still reads from the
+    plaintext columns will fail; controllers that source from ciphertext stay
+    correct.
+
+    The note is located via `path_hmac` of the original `path` so this works
+    even when the plaintext column has already been NULLed by encryption."""
+    sql = (
+        f"\\set tamper_path '{new_path}'\n"
+        f"\\set tamper_folder '{new_folder}'\n"
+        f"\\set lookup_path '{path}'\n"
+        f"UPDATE notes SET path = :'tamper_path', folder = :'tamper_folder' "
+        f"WHERE vault_id = {int(vault_id)} AND path = :'lookup_path';"
+    )
+    out = _psql(sql)
+    if "UPDATE 0" in out:
+        raise AssertionError(
+            f"tamper_note_plaintext_columns matched zero rows "
+            f"(vault_id={vault_id}, path={path!r}); plaintext path column may "
+            f"already be NULL — use note_id-based tampering instead"
+        )
+
+
 def get_user_id_for_vault(vault_id: int) -> int:
     """Look up the owning user_id for a vault. Used by tests that need to
     set per-user encryption settings without going through the API."""

--- a/e2e/helpers/crypto_probe.py
+++ b/e2e/helpers/crypto_probe.py
@@ -365,8 +365,11 @@ def tamper_note_plaintext_columns(
     plaintext columns will fail; controllers that source from ciphertext stay
     correct.
 
-    The note is located via `path_hmac` of the original `path` so this works
-    even when the plaintext column has already been NULLed by encryption."""
+    The note is located via the plaintext `path` column (still populated in
+    Phase B.2 — additive write, drop comes in B.3). Once B.3 NULLs that
+    column this helper will hit `UPDATE 0` and raise — switch to a
+    note-id-based variant at that point. The defensive AssertionError below
+    surfaces that failure mode loudly."""
     sql = (
         f"\\set tamper_path '{new_path}'\n"
         f"\\set tamper_folder '{new_folder}'\n"

--- a/e2e/tests/api_only/test_67_filtered_search_hmac.py
+++ b/e2e/tests/api_only/test_67_filtered_search_hmac.py
@@ -123,13 +123,31 @@ class TestFilteredSearchOnEncryptedVault:
         for path, _, _ in note_specs:
             wait_for_qdrant_indexed(vault_id, path, timeout=90)
 
-        # 4. Unfiltered search must hit every note (sanity)
+        # 3a. Sanity — confirm frontmatter parsing landed `target_tag` on the
+        #     target note. Without this guard, a future regression in
+        #     `Helpers.extract_tags/1` could silently produce empty tags and
+        #     the tag filter test below would still narrow to one note (for
+        #     the wrong reason: matching no-tag rows vs. matching by HMAC).
+        target_note = client.get_note(target_path)
+        assert target_note is not None, (
+            f"Target note {target_path} should be retrievable for sanity check"
+        )
+        assert target_tag in (target_note.get("tags") or []), (
+            f"Frontmatter parser did not extract {target_tag!r}. "
+            f"Got tags={target_note.get('tags')!r} — tag filter test below "
+            f"would pass for the wrong reason without this guard."
+        )
+
+        # 4. Unfiltered search must hit every seeded note. Assert the count
+        #    so a regression that drops two of three results (and happens to
+        #    keep target_path) doesn't silently pass.
         unfiltered = self._search(client, "fingerprint", limit=20)
         unfiltered_paths = {r.get("path") for r in unfiltered}
-        for path, _, _ in note_specs:
-            assert path in unfiltered_paths, (
-                f"Unfiltered search missed {path}; got {unfiltered_paths}"
-            )
+        seeded_paths = {p for p, _, _ in note_specs}
+        assert seeded_paths <= unfiltered_paths, (
+            f"Unfiltered search missed seeded notes. "
+            f"Missing: {seeded_paths - unfiltered_paths}. Got: {unfiltered_paths}"
+        )
 
         # 5. Folder filter must narrow to one note
         by_folder = self._search(

--- a/e2e/tests/api_only/test_67_filtered_search_hmac.py
+++ b/e2e/tests/api_only/test_67_filtered_search_hmac.py
@@ -1,0 +1,194 @@
+"""Test 67: /api/search folder + tag filtering against an encrypted vault.
+
+Phase B.2.3 read switch: when an encrypted vault posts `?folder=` or `?tags=`
+on /api/search, the backend must translate the plaintext params into
+HMAC fingerprints (folder_hmac / tags_hmac) and forward them to Qdrant.
+Qdrant points carry only HMACs — never the plaintext folder or tag — yet
+the API caller still gets human-readable results back.
+
+This test proves end-to-end that:
+  1. Plaintext `folder` filter narrows the result set (papers/quantum).
+  2. Plaintext `tags` filter narrows the result set.
+  3. Combined filters compose (must-match-all).
+  4. Unfiltered search still returns multiple matches.
+
+API-only (no Obsidian, no Clerk gate). Reuses the encrypted vault pattern
+from test_62: toggles encryption via the real endpoint, writes notes via
+HTTP, lets the embed worker index them, then exercises /api/search.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import pytest
+
+from helpers.crypto_probe import (
+    backdate_decrypt_requested,
+    backdate_last_toggle,
+    wait_for_encryption_status,
+    wait_for_qdrant_indexed,
+)
+
+API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+
+logger = logging.getLogger(__name__)
+
+
+def _frontmatter_note(title: str, tags: list[str], body: str) -> str:
+    tag_list = ", ".join(tags)
+    return (
+        f"---\n"
+        f"tags: [{tag_list}]\n"
+        f"---\n"
+        f"# {title}\n\n"
+        f"{body}\n"
+    )
+
+
+@pytest.fixture
+def reset_vault_encryption(api_sync):
+    """Roll the shared vault back to 'none' status — same SQL time-travel
+    pattern as test_62. Idempotent if the vault is already 'none'."""
+    yield
+    vaults = api_sync.list_vaults()
+    if not vaults:
+        return
+    vault_id = vaults[0]["id"]
+    resp = api_sync.session.get(
+        f"{API_URL}/vaults/{vault_id}/encryption_progress", timeout=5
+    )
+    if not resp.ok:
+        return
+    status = resp.json().get("status")
+    if status in ("encrypted", "encrypting"):
+        if status == "encrypting":
+            wait_for_encryption_status(api_sync, vault_id, "encrypted", timeout=60)
+        backdate_last_toggle(vault_id, days=8)
+        api_sync.session.post(f"{API_URL}/vaults/{vault_id}/decrypt", timeout=10)
+        backdate_decrypt_requested(vault_id, hours=25)
+        wait_for_encryption_status(api_sync, vault_id, "none", timeout=60)
+        backdate_last_toggle(vault_id, days=8)
+
+
+class TestFilteredSearchOnEncryptedVault:
+    """Folder + tag filters on /api/search against an encrypted vault must
+    translate to HMAC filters in Qdrant and still narrow the result set."""
+
+    def test_folder_and_tag_filters_compose(self, api_sync, reset_vault_encryption):
+        vaults = api_sync.list_vaults()
+        assert vaults, "api_sync should have a registered vault"
+        vault_id = vaults[0]["id"]
+        client = api_sync.with_vault(vault_id)
+
+        # 1. Toggle vault to encrypted (empty vault, near-instant)
+        resp = client.session.post(
+            f"{API_URL}/vaults/{vault_id}/encrypt", timeout=10
+        )
+        assert resp.status_code == 202, (
+            f"encrypt failed: {resp.status_code} {resp.text[:300]}"
+        )
+        wait_for_encryption_status(client, vault_id, "encrypted", timeout=30)
+
+        # 2. Write three notes with distinct folders + tags. The shared
+        #    keyword "fingerprint" lets one query match all three so we
+        #    can verify the filter (not the embedding) does the narrowing.
+        ts = int(time.time())
+        target_path = f"papers/research/quantum-{ts}.md"
+        target_tag = f"physics-{ts}"
+
+        note_specs = [
+            (target_path, ["research", target_tag], "Quantum entanglement fingerprint study"),
+            (f"papers/notes/coffee-{ts}.md", ["lifestyle"], "Coffee brewing fingerprint"),
+            (f"journal/today-{ts}.md", ["personal"], "Daily journal fingerprint entry"),
+        ]
+
+        for path, tags, body in note_specs:
+            resp = client.session.post(
+                f"{API_URL}/notes",
+                json={
+                    "path": path,
+                    "content": _frontmatter_note("Note", tags, body),
+                    "mtime": time.time(),
+                },
+                timeout=10,
+            )
+            assert resp.ok, (
+                f"upsert {path} failed: {resp.status_code} {resp.text[:300]}"
+            )
+
+        # 3. Wait for the embed worker to land all three in Qdrant
+        for path, _, _ in note_specs:
+            wait_for_qdrant_indexed(vault_id, path, timeout=90)
+
+        # 4. Unfiltered search must hit every note (sanity)
+        unfiltered = self._search(client, "fingerprint", limit=20)
+        unfiltered_paths = {r.get("path") for r in unfiltered}
+        for path, _, _ in note_specs:
+            assert path in unfiltered_paths, (
+                f"Unfiltered search missed {path}; got {unfiltered_paths}"
+            )
+
+        # 5. Folder filter must narrow to one note
+        by_folder = self._search(
+            client, "fingerprint", folder="papers/research", limit=20
+        )
+        by_folder_paths = {r.get("path") for r in by_folder}
+        assert by_folder_paths == {target_path}, (
+            f"folder filter should match exactly {{{target_path}}}, "
+            f"got {by_folder_paths}"
+        )
+
+        # 6. Tag filter must narrow to one note
+        by_tag = self._search(client, "fingerprint", tags=[target_tag], limit=20)
+        by_tag_paths = {r.get("path") for r in by_tag}
+        assert by_tag_paths == {target_path}, (
+            f"tag filter should match exactly {{{target_path}}}, got {by_tag_paths}"
+        )
+
+        # 7. Combined filters compose (must-match-all)
+        combined = self._search(
+            client,
+            "fingerprint",
+            folder="papers/research",
+            tags=[target_tag],
+            limit=20,
+        )
+        combined_paths = {r.get("path") for r in combined}
+        assert combined_paths == {target_path}, (
+            f"combined filter should match {{{target_path}}}, got {combined_paths}"
+        )
+
+        # 8. Mismatched filters return zero (HMAC for nonexistent tag must
+        #    not collide with anything indexed)
+        empty = self._search(
+            client, "fingerprint", tags=[f"nonexistent-{ts}"], limit=20
+        )
+        assert empty == [], (
+            f"unknown tag should return empty results, got {empty}"
+        )
+
+    @staticmethod
+    def _search(
+        client,
+        query: str,
+        *,
+        folder: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 5,
+    ) -> list[dict]:
+        body: dict = {"query": query, "limit": limit}
+        if folder is not None:
+            body["folder"] = folder
+        if tags is not None:
+            body["tags"] = tags
+
+        resp = client.session.post(
+            f"{API_URL}/search", json=body, timeout=30
+        )
+        assert resp.status_code == 200, (
+            f"/api/search failed: {resp.status_code} {resp.text[:300]}"
+        )
+        return resp.json().get("results", [])

--- a/e2e/tests/api_only/test_68_tamper_plaintext_invariant.py
+++ b/e2e/tests/api_only/test_68_tamper_plaintext_invariant.py
@@ -1,0 +1,157 @@
+"""Test 68: Tamper-plaintext invariant — controllers source from ciphertext.
+
+Phase B.2.6: lookup uses `path_hmac`, not the plaintext `path` column;
+GET responses are decrypted from `path_ciphertext` / `folder_ciphertext`,
+not read from the plaintext columns. This test proves both halves at
+the HTTP boundary by directly corrupting the plaintext columns via SQL
+and verifying the API still returns the correct value.
+
+If a controller silently falls back to the plaintext column, this test
+catches it. Once Phase B.3 drops the plaintext columns the test still
+applies — the corruption simply has no effect, and the assertions pass.
+
+API-only (no Obsidian, no Clerk). Reuses the encrypted-vault toggle
+pattern from test_62.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import pytest
+
+from helpers.crypto_probe import (
+    backdate_decrypt_requested,
+    backdate_last_toggle,
+    tamper_note_plaintext_columns,
+    wait_for_encryption_status,
+)
+
+API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def reset_vault_encryption(api_sync):
+    yield
+    vaults = api_sync.list_vaults()
+    if not vaults:
+        return
+    vault_id = vaults[0]["id"]
+    resp = api_sync.session.get(
+        f"{API_URL}/vaults/{vault_id}/encryption_progress", timeout=5
+    )
+    if not resp.ok:
+        return
+    status = resp.json().get("status")
+    if status in ("encrypted", "encrypting"):
+        if status == "encrypting":
+            wait_for_encryption_status(api_sync, vault_id, "encrypted", timeout=60)
+        backdate_last_toggle(vault_id, days=8)
+        api_sync.session.post(f"{API_URL}/vaults/{vault_id}/decrypt", timeout=10)
+        backdate_decrypt_requested(vault_id, hours=25)
+        wait_for_encryption_status(api_sync, vault_id, "none", timeout=60)
+        backdate_last_toggle(vault_id, days=8)
+
+
+class TestTamperPlaintextInvariant:
+    """Corrupting the plaintext path/folder columns must not change what
+    GET /notes/:path or GET /folders/list returns."""
+
+    def test_get_note_uses_ciphertext_after_plaintext_tamper(
+        self, api_sync, reset_vault_encryption
+    ):
+        vaults = api_sync.list_vaults()
+        assert vaults, "api_sync should have a registered vault"
+        vault_id = vaults[0]["id"]
+        client = api_sync.with_vault(vault_id)
+
+        # 1. Encrypt the vault
+        resp = client.session.post(
+            f"{API_URL}/vaults/{vault_id}/encrypt", timeout=10
+        )
+        assert resp.status_code == 202, (
+            f"encrypt failed: {resp.status_code} {resp.text[:300]}"
+        )
+        wait_for_encryption_status(client, vault_id, "encrypted", timeout=30)
+
+        # 2. Write a note (plaintext over the wire, ciphertext at rest)
+        ts = int(time.time())
+        note_path = f"projects/secret-{ts}.md"
+        original_folder = "projects"
+        plaintext = f"truly secret payload {ts}"
+
+        resp = client.session.post(
+            f"{API_URL}/notes",
+            json={
+                "path": note_path,
+                "content": plaintext,
+                "mtime": time.time(),
+            },
+            timeout=10,
+        )
+        assert resp.ok, f"upsert failed: {resp.status_code} {resp.text[:300]}"
+
+        # 3. Sanity — read back returns plaintext via ciphertext path
+        note = client.get_note(note_path)
+        assert note is not None, "Note must exist after upsert"
+        assert plaintext in note.get("content", ""), (
+            f"Initial GET should return plaintext, got: {note.get('content')!r}"
+        )
+
+        # 4. CORRUPT the plaintext path + folder columns directly via SQL.
+        #    HMAC + ciphertext columns are untouched.
+        tamper_note_plaintext_columns(
+            vault_id,
+            note_path,
+            new_path="CORRUPTED/wrong-path.md",
+            new_folder="CORRUPTED/wrong-folder",
+        )
+
+        # 5. GET the note by its real path. Lookup goes through path_hmac
+        #    (B.2.0) and the response decrypts from ciphertext (B.2.6) —
+        #    must succeed and return the original plaintext.
+        note_after = client.get_note(note_path)
+        assert note_after is not None, (
+            "GET /notes/:path must still locate the note via path_hmac "
+            "after the plaintext column was corrupted"
+        )
+        assert plaintext in note_after.get("content", ""), (
+            f"GET /notes/:path returned wrong content after tamper. "
+            f"Got: {note_after.get('content')!r}"
+        )
+
+        # The returned `path` field must equal the original (decrypted from
+        # path_ciphertext) — never the corrupted plaintext column value.
+        returned_path = note_after.get("path")
+        assert returned_path == note_path, (
+            f"GET response path must be decrypted from ciphertext, got "
+            f"{returned_path!r} (corruption leaked through from plaintext column)"
+        )
+
+        # 6. GET /folders/list?folder=projects — must still include this
+        #    note. Folder lookup is via folder_hmac (B.2.6); the corrupted
+        #    `folder = 'CORRUPTED/wrong-folder'` column must not affect it.
+        listing = client.list_folder(original_folder)
+        listed_paths = [
+            n.get("path") for n in listing.get("notes", []) if isinstance(n, dict)
+        ]
+        assert note_path in listed_paths, (
+            f"Folder listing for {original_folder!r} must include {note_path!r} "
+            f"via folder_hmac lookup. Got: {listed_paths}"
+        )
+
+        # 7. GET /folders/list with the corrupted folder name must return
+        #    NOTHING for our note — proves listing keys off folder_hmac of
+        #    the request, not the plaintext column.
+        bad_listing = client.list_folder("CORRUPTED/wrong-folder")
+        bad_paths = [
+            n.get("path") for n in bad_listing.get("notes", []) if isinstance(n, dict)
+        ]
+        assert note_path not in bad_paths, (
+            f"Folder listing keyed off the tampered plaintext column — "
+            f"controller must derive folder_hmac from the requested folder name"
+        )

--- a/e2e/tests/test_31_restart_preserves_queue.py
+++ b/e2e/tests/test_31_restart_preserves_queue.py
@@ -74,10 +74,13 @@ async def test_restart_preserves_queue(vault_a, cdp_a, api_sync, obsidian_a):
     await obsidian_a.async_start(restart=True)
     await cdp_a.wait_for_plugin_ready(timeout=60)
 
-    # 6. Startup sync should restore queue and flush it
-    #    Poll instead of hard sleep — returns as soon as notes arrive
-    note1 = api_sync.wait_for_note(path1, timeout=15)
-    note2 = api_sync.wait_for_note(path2, timeout=15)
+    # 6. Startup sync should restore queue and flush it.
+    #    Poll instead of hard sleep — returns as soon as notes arrive.
+    #    Same xdist race class as PR #39: the cycle of plugin-ready →
+    #    SyncEngine.startupSync → queue.replay → push can exceed 15s under
+    #    2-worker load. Match the queue-wait deadline (30s) on both.
+    note1 = api_sync.wait_for_note(path1, timeout=30)
+    note2 = api_sync.wait_for_note(path2, timeout=30)
 
     # 7. Both notes should now be on server
     assert note1 is not None, f"{path1} should be on server after restart"

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -62,24 +62,33 @@ defmodule Engram.Attachments do
   """
   def get_attachment(user, vault, path) do
     path = PathSanitizer.sanitize(path)
+    user = fresh_user(user)
 
     result =
-      Repo.with_tenant(user.id, fn ->
-        Repo.one(
-          from(a in Attachment,
-            where:
-              a.path == ^path and a.user_id == ^user.id and a.vault_id == ^vault.id and
-                is_nil(a.deleted_at)
+      with {:ok, filter_key} <- Crypto.dek_filter_key(user) do
+        path_hmac = Crypto.hmac_field(filter_key, path)
+
+        Repo.with_tenant(user.id, fn ->
+          Repo.one(
+            from(a in Attachment,
+              where:
+                a.path_hmac == ^path_hmac and a.user_id == ^user.id and
+                  a.vault_id == ^vault.id and is_nil(a.deleted_at)
+            )
           )
-        )
-      end)
-      |> unwrap_tenant()
+        end)
+        |> unwrap_tenant()
+      end
 
     case result do
+      {:error, :no_dek} ->
+        {:ok, nil}
+
       {:ok, nil} ->
         {:ok, nil}
 
       {:ok, %Attachment{} = att} ->
+        {:ok, att} = Crypto.maybe_decrypt_attachment_fields(att, user)
         key = att.storage_key || Storage.key(user.id, vault.id, path)
 
         case Storage.adapter().get(key) do
@@ -115,21 +124,31 @@ defmodule Engram.Attachments do
   """
   def delete_attachment(user, vault, path) do
     path = PathSanitizer.sanitize(path)
+    user = fresh_user(user)
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    Repo.with_tenant(user.id, fn ->
-      from(a in Attachment,
-        where:
-          a.path == ^path and a.user_id == ^user.id and a.vault_id == ^vault.id and
-            is_nil(a.deleted_at)
-      )
-      |> Repo.update_all(set: [deleted_at: now, updated_at: now])
-    end)
+    case Crypto.dek_filter_key(user) do
+      {:ok, filter_key} ->
+        path_hmac = Crypto.hmac_field(filter_key, path)
 
-    # Best-effort blob cleanup — row is already soft-deleted so this is safe to retry later
-    delete_external(user.id, vault.id, path)
+        Repo.with_tenant(user.id, fn ->
+          from(a in Attachment,
+            where:
+              a.path_hmac == ^path_hmac and a.user_id == ^user.id and
+                a.vault_id == ^vault.id and is_nil(a.deleted_at)
+          )
+          |> Repo.update_all(set: [deleted_at: now, updated_at: now])
+        end)
 
-    :ok
+        # Best-effort blob cleanup — row is already soft-deleted so this is safe to retry later
+        delete_external(user.id, vault.id, path)
+
+        :ok
+
+      {:error, :no_dek} ->
+        # No DEK = no attachments to delete; mirror get_attachment's defensive empty.
+        :ok
+    end
   end
 
   defp delete_external(user_id, vault_id, path) do
@@ -155,22 +174,39 @@ defmodule Engram.Attachments do
   Lists attachment changes since a given timestamp. Returns metadata only (no content).
   """
   def list_changes(user, vault, since) do
+    user = fresh_user(user)
+    # Phase B.2.6 — load full Attachment rows so path can be decrypted from
+    # ciphertext. The previous select-shape preview returned `a.path` directly
+    # which won't survive B.3's column drop. Metadata-only output preserved.
     Repo.with_tenant(user.id, fn ->
       from(a in Attachment,
         where: a.user_id == ^user.id and a.vault_id == ^vault.id and a.updated_at >= ^since,
-        order_by: [asc: a.updated_at],
-        select: %{
-          path: a.path,
-          mime_type: a.mime_type,
-          size_bytes: a.size_bytes,
-          mtime: a.mtime,
-          updated_at: a.updated_at,
-          deleted_at: a.deleted_at
-        }
+        order_by: [asc: a.updated_at]
       )
       |> Repo.all()
     end)
     |> unwrap_tenant()
+    |> case do
+      {:ok, atts} ->
+        changes =
+          Enum.map(atts, fn att ->
+            {:ok, decrypted} = Crypto.maybe_decrypt_attachment_fields(att, user)
+
+            %{
+              path: decrypted.path,
+              mime_type: decrypted.mime_type,
+              size_bytes: decrypted.size_bytes,
+              mtime: decrypted.mtime,
+              updated_at: decrypted.updated_at,
+              deleted_at: decrypted.deleted_at
+            }
+          end)
+
+        {:ok, changes}
+
+      err ->
+        err
+    end
   end
 
   @doc """
@@ -255,10 +291,14 @@ defmodule Engram.Attachments do
     end
   end
 
-  defp decrypt(%Attachment{content_nonce: nonce} = att, ciphertext, user) do
-    fresh_user = if is_nil(user.encrypted_dek), do: Repo.reload!(user), else: user
+  # Reload the user from DB if the in-memory struct doesn't reflect a DEK that
+  # was provisioned by an earlier write (the writer's user struct doesn't
+  # mutate the caller's). Read paths use this before any DEK derivation.
+  defp fresh_user(%Engram.Accounts.User{encrypted_dek: nil} = user), do: Repo.reload!(user)
+  defp fresh_user(%Engram.Accounts.User{} = user), do: user
 
-    with {:ok, dek} <- Crypto.get_dek(fresh_user),
+  defp decrypt(%Attachment{content_nonce: nonce} = att, ciphertext, user) do
+    with {:ok, dek} <- Crypto.get_dek(fresh_user(user)),
          {:ok, plaintext} <- Envelope.decrypt(ciphertext, nonce, dek) do
       {:ok, %{att | content: plaintext}}
     else

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -150,6 +150,50 @@ defmodule Engram.Crypto do
   end
 
   @doc """
+  Decrypts the Phase B `path_ciphertext` on an attachment into the virtual
+  `path` field. No-op when ciphertext is nil (legacy pre-B.1 row).
+  """
+  @spec maybe_decrypt_attachment_fields(Engram.Attachments.Attachment.t(), User.t()) ::
+          {:ok, Engram.Attachments.Attachment.t()} | {:error, term()}
+  def maybe_decrypt_attachment_fields(
+        %Engram.Attachments.Attachment{path_ciphertext: nil} = att,
+        _user
+      ),
+      do: {:ok, att}
+
+  def maybe_decrypt_attachment_fields(
+        %Engram.Attachments.Attachment{} = att,
+        %User{} = user
+      ) do
+    with {:ok, dek} <- get_dek(user),
+         {:ok, path} <- Envelope.decrypt(att.path_ciphertext, att.path_nonce, dek) do
+      {:ok, %{att | path: path}}
+    else
+      :error -> {:error, :decrypt_failed}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
+  Decrypts `name_ciphertext` on a vault into the virtual `name` field.
+  No-op when ciphertext is nil (legacy pre-B.1 row).
+  """
+  @spec maybe_decrypt_vault_fields(Engram.Vaults.Vault.t(), User.t()) ::
+          {:ok, Engram.Vaults.Vault.t()} | {:error, term()}
+  def maybe_decrypt_vault_fields(%Engram.Vaults.Vault{name_ciphertext: nil} = vault, _user),
+    do: {:ok, vault}
+
+  def maybe_decrypt_vault_fields(%Engram.Vaults.Vault{} = vault, %User{} = user) do
+    with {:ok, dek} <- get_dek(user),
+         {:ok, name} <- Envelope.decrypt(vault.name_ciphertext, vault.name_nonce, dek) do
+      {:ok, %{vault | name: name}}
+    else
+      :error -> {:error, :decrypt_failed}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
   If `vault.encrypted`, encrypts `text`, `title`, `heading_path` in the
   payload map using the user's DEK. Adds `text_nonce`, `title_nonce`,
   `heading_path_nonce` keys; all six crypto fields are base64-encoded

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -19,18 +19,28 @@ defmodule Engram.Crypto do
   def ensure_user_dek(%User{encrypted_dek: blob} = user) when is_binary(blob), do: {:ok, user}
 
   def ensure_user_dek(%User{} = user) do
-    provider = Resolver.provider_for(user.id)
-    dek = provider.generate_dek()
+    # The in-memory struct has no DEK, but the DB might already have one from
+    # an earlier write that the caller's struct didn't pick up. Reload before
+    # generating — without this, every caller holding a stale user struct
+    # silently rotates the DEK and corrupts every existing ciphertext.
+    case Accounts.get_user(user.id) do
+      %User{encrypted_dek: blob} = reloaded when is_binary(blob) ->
+        {:ok, reloaded}
 
-    with {:ok, wrapped} <- provider.wrap_dek(dek, %{user_id: user.id}),
-         {:ok, user} <-
-           Accounts.update_user_encryption(user, %{
-             encrypted_dek: wrapped,
-             dek_version: 1,
-             key_provider: Atom.to_string(provider.name())
-           }) do
-      DekCache.put(user.id, dek)
-      {:ok, user}
+      _ ->
+        provider = Resolver.provider_for(user.id)
+        dek = provider.generate_dek()
+
+        with {:ok, wrapped} <- provider.wrap_dek(dek, %{user_id: user.id}),
+             {:ok, user} <-
+               Accounts.update_user_encryption(user, %{
+                 encrypted_dek: wrapped,
+                 dek_version: 1,
+                 key_provider: Atom.to_string(provider.name())
+               }) do
+          DekCache.put(user.id, dek)
+          {:ok, user}
+        end
     end
   end
 

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -96,21 +96,53 @@ defmodule Engram.Crypto do
   end
 
   @doc """
-  If note has ciphertext columns populated, decrypt them into `content`/`title`/`tags`.
-  Otherwise return the note unchanged.
+  If note has ciphertext columns populated, decrypt them into the matching
+  plaintext virtual fields. Phase 4 ciphertext (`content` / `title` / `tags`)
+  and Phase B ciphertext (`path` / `folder`) are decrypted independently — a
+  note can have one set populated and not the other (e.g., legacy unencrypted
+  vault that has been B.1-backfilled but not Phase 4-encrypted).
+
+  Returns `{:ok, note}` unchanged when no ciphertext is present.
   """
   @spec maybe_decrypt_note_fields(Engram.Notes.Note.t(), User.t()) ::
           {:ok, Engram.Notes.Note.t()} | {:error, term()}
-  def maybe_decrypt_note_fields(%Engram.Notes.Note{content_ciphertext: nil} = note, _user),
+  def maybe_decrypt_note_fields(%Engram.Notes.Note{} = note, %User{} = user) do
+    if needs_note_decrypt?(note) do
+      with {:ok, dek} <- get_dek(user),
+           {:ok, note} <- decrypt_phase_4_note_fields(note, dek),
+           {:ok, note} <- decrypt_phase_b_note_fields(note, dek) do
+        {:ok, note}
+      end
+    else
+      {:ok, note}
+    end
+  end
+
+  defp needs_note_decrypt?(%Engram.Notes.Note{} = note),
+    do: not is_nil(note.content_ciphertext) or not is_nil(note.path_ciphertext)
+
+  defp decrypt_phase_4_note_fields(%Engram.Notes.Note{content_ciphertext: nil} = note, _dek),
     do: {:ok, note}
 
-  def maybe_decrypt_note_fields(%Engram.Notes.Note{} = note, %User{} = user) do
-    with {:ok, dek} <- get_dek(user),
-         {:ok, content} <- Envelope.decrypt(note.content_ciphertext, note.content_nonce, dek),
+  defp decrypt_phase_4_note_fields(%Engram.Notes.Note{} = note, dek) do
+    with {:ok, content} <- Envelope.decrypt(note.content_ciphertext, note.content_nonce, dek),
          {:ok, title} <- Envelope.decrypt(note.title_ciphertext, note.title_nonce, dek),
          {:ok, tags_bin} <- Envelope.decrypt(note.tags_ciphertext, note.tags_nonce, dek) do
       tags = :erlang.binary_to_term(tags_bin, [:safe])
       {:ok, %{note | content: content, title: title, tags: tags}}
+    else
+      :error -> {:error, :decrypt_failed}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp decrypt_phase_b_note_fields(%Engram.Notes.Note{path_ciphertext: nil} = note, _dek),
+    do: {:ok, note}
+
+  defp decrypt_phase_b_note_fields(%Engram.Notes.Note{} = note, dek) do
+    with {:ok, path} <- Envelope.decrypt(note.path_ciphertext, note.path_nonce, dek),
+         {:ok, folder} <- Envelope.decrypt(note.folder_ciphertext, note.folder_nonce, dek) do
+      {:ok, %{note | path: path, folder: folder}}
     else
       :error -> {:error, :decrypt_failed}
       {:error, _} = err -> err

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -108,7 +108,13 @@ defmodule Engram.Indexing do
   Remove all indexed data for a note (Qdrant points first, then Postgres chunks).
   """
   def delete_note_index(note) do
-    with :ok <- Qdrant.delete_by_note(collection(), to_string(note.user_id), to_string(note.vault_id), note.path) do
+    with :ok <-
+           Qdrant.delete_by_note(
+             collection(),
+             to_string(note.user_id),
+             to_string(note.vault_id),
+             note.path
+           ) do
       Repo.delete_all(from(c in Chunk, where: c.note_id == ^note.id), skip_tenant_check: true)
       :ok
     end
@@ -148,7 +154,13 @@ defmodule Engram.Indexing do
           tags: note.tags || [],
           heading_path: chunk.heading_path,
           text: chunk.text,
-          chunk_index: chunk.position
+          chunk_index: chunk.position,
+          # Phase B.2.4 (additive): write hmacs alongside plaintext so the
+          # B.2.5 backfill worker has a target shape and B.2.3 read switch
+          # can flip atomically once existing points are rewritten.
+          path_hmac: encode_hmac(note.path_hmac),
+          folder_hmac: encode_hmac(note.folder_hmac),
+          tags_hmac: Enum.map(note.tags_hmac || [], &Base.encode64/1)
         }
 
         case Engram.Crypto.maybe_encrypt_qdrant_payload(base_payload, user, vault) do
@@ -189,4 +201,10 @@ defmodule Engram.Indexing do
       {:ok, %{note: note, chunk_rows: chunk_rows, qdrant_points: qdrant_points}}
     end
   end
+
+  # Encodes a Phase B HMAC binary as base64 for JSON-safe Qdrant payload.
+  # Returns nil for nil — leaves the field absent so legacy/un-backfilled
+  # rows don't poison filters with a fake hmac.
+  defp encode_hmac(nil), do: nil
+  defp encode_hmac(bin) when is_binary(bin), do: Base.encode64(bin)
 end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -313,22 +313,35 @@ defmodule Engram.Notes do
   """
   @spec list_folders(map(), map()) :: {:ok, [String.t()]}
   def list_folders(user, vault) do
-    {:ok, folders} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.all(
-          from(n in Note,
-            where:
-              n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
-                n.folder != "" and
-                not is_nil(n.folder),
-            select: n.folder,
-            distinct: true,
-            order_by: n.folder
-          )
-        )
-      end)
+    case Engram.Crypto.dek_filter_key(user) do
+      {:ok, filter_key} ->
+        {:ok, dek} = Engram.Crypto.get_dek(user)
+        empty_hmac = Engram.Crypto.hmac_field(filter_key, "")
 
-    {:ok, folders}
+        {:ok, rows} =
+          Repo.with_tenant(user.id, fn ->
+            Repo.all(
+              from(n in Note,
+                where:
+                  n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
+                    not is_nil(n.folder_hmac) and n.folder_hmac != ^empty_hmac,
+                distinct: n.folder_hmac,
+                select: {n.folder_ciphertext, n.folder_nonce}
+              )
+            )
+          end)
+
+        folders =
+          rows
+          |> Enum.map(fn {ct, nonce} -> decrypt_envelope!(ct, nonce, dek) end)
+          |> Enum.sort()
+
+        {:ok, folders}
+
+      # No DEK = user has no encrypted data possible = no folders.
+      {:error, :no_dek} ->
+        {:ok, []}
+    end
   end
 
   @doc """
@@ -368,22 +381,39 @@ defmodule Engram.Notes do
   @spec list_folders_with_counts(map(), map()) ::
           {:ok, [%{folder: String.t(), count: integer()}]}
   def list_folders_with_counts(user, vault) do
-    {:ok, rows} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.all(
-          from(n in Note,
-            where: n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at),
-            group_by: n.folder,
-            select: %{folder: n.folder, count: count(n.id)},
-            order_by: n.folder
-          )
-        )
-      end)
+    case Engram.Crypto.dek_filter_key(user) do
+      {:ok, _filter_key} ->
+        {:ok, dek} = Engram.Crypto.get_dek(user)
 
-    # Normalize nil folder to ""
-    rows = Enum.map(rows, fn r -> %{r | folder: r.folder || ""} end)
+        {:ok, rows} =
+          Repo.with_tenant(user.id, fn ->
+            Repo.all(
+              from(n in Note,
+                where:
+                  n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
+                    not is_nil(n.folder_hmac),
+                distinct: n.folder_hmac,
+                select: %{
+                  ct: n.folder_ciphertext,
+                  nonce: n.folder_nonce,
+                  count: fragment("COUNT(*) OVER (PARTITION BY ?)", n.folder_hmac)
+                }
+              )
+            )
+          end)
 
-    {:ok, rows}
+        folders =
+          rows
+          |> Enum.map(fn %{ct: ct, nonce: nonce, count: count} ->
+            %{folder: decrypt_envelope!(ct, nonce, dek), count: count}
+          end)
+          |> Enum.sort_by(& &1.folder)
+
+        {:ok, folders}
+
+      {:error, :no_dek} ->
+        {:ok, []}
+    end
   end
 
   @doc """
@@ -557,6 +587,16 @@ defmodule Engram.Notes do
 
   defp decrypt_if_needed(notes, user) when is_list(notes) do
     Enum.map(notes, &decrypt_if_needed(&1, user))
+  end
+
+  # Decrypts an envelope (ciphertext + nonce) with the user's DEK.
+  # Raises if decryption fails — used in Phase B aggregations where a failure
+  # means data corruption, not a recoverable condition.
+  defp decrypt_envelope!(ct, nonce, dek) do
+    case Engram.Crypto.Envelope.decrypt(ct, nonce, dek) do
+      {:ok, plaintext} -> plaintext
+      :error -> raise "Phase B envelope decryption failed"
+    end
   end
 
   # Like decrypt_if_needed but logs a warning on decrypt failure before returning

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -181,15 +181,20 @@ defmodule Engram.Notes do
               )
 
             if count == 1 do
+              # Splice the freshly-encrypted Phase B fields into the in-memory
+              # struct too — without this, decrypt_for_broadcast would decrypt
+              # the OLD path_ciphertext and clobber `path` back to the old
+              # value when path/folder go through maybe_decrypt_note_fields.
               {:ok,
-               %{
-                 note
-                 | path: new_path,
-                   folder: new_folder,
-                   title: new_title,
-                   embed_hash: nil,
-                   updated_at: now
-               }}
+               note
+               |> struct!(phase_b_kw)
+               |> struct!(
+                 path: new_path,
+                 folder: new_folder,
+                 title: new_title,
+                 embed_hash: nil,
+                 updated_at: now
+               )}
             else
               :not_found
             end
@@ -422,30 +427,33 @@ defmodule Engram.Notes do
   """
   @spec list_notes_in_folder(map(), map(), String.t()) :: {:ok, [Note.t()]}
   def list_notes_in_folder(user, vault, folder) do
-    {:ok, notes} =
-      Repo.with_tenant(user.id, fn ->
-        query =
-          if folder == "" do
-            # Root-level notes have folder = nil or ""
-            from(n in Note,
-              where:
-                n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
-                  (is_nil(n.folder) or n.folder == ""),
-              order_by: n.title
-            )
-          else
-            from(n in Note,
-              where:
-                n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
-                  n.folder == ^folder,
-              order_by: n.title
-            )
-          end
+    # Phase B.2.6 — match by folder_hmac so the lookup survives B.3's drop of
+    # the plaintext `folder` column. Both root ("") and named folders go
+    # through the same HMAC equality check; the empty string has its own
+    # well-defined HMAC.
+    case Engram.Crypto.dek_filter_key(user) do
+      {:ok, filter_key} ->
+        target_hmac = Engram.Crypto.hmac_field(filter_key, folder)
 
-        Repo.all(query)
-      end)
+        {:ok, notes} =
+          Repo.with_tenant(user.id, fn ->
+            Repo.all(
+              from(n in Note,
+                where:
+                  n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
+                    n.folder_hmac == ^target_hmac,
+                order_by: n.title
+              )
+            )
+          end)
 
-    {:ok, decrypt_if_needed(notes, user)}
+        {:ok, decrypt_if_needed(notes, user)}
+
+      {:error, :no_dek} ->
+        # Mirrors the list_folders (B.2.2) defensive empty: no DEK = no
+        # encrypted notes possible = empty result.
+        {:ok, []}
+    end
   end
 
   @doc """

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -99,21 +99,40 @@ defmodule Engram.Notes do
   """
   @spec get_note(map(), map(), String.t()) :: {:ok, Note.t()} | {:error, :not_found}
   def get_note(user, vault, path) do
-    result =
-      Repo.with_tenant(user.id, fn ->
-        Repo.one(
-          from(n in Note,
-            where:
-              n.user_id == ^user.id and n.vault_id == ^vault.id and n.path == ^path and
-                is_nil(n.deleted_at)
-          )
-        )
-      end)
-
-    case result do
+    case find_note_by_path(user, vault, path) do
       {:ok, nil} -> {:error, :not_found}
       {:ok, note} -> {:ok, decrypt_if_needed(note, user)}
       _ -> {:error, :not_found}
+    end
+  end
+
+  # Phase B.2: single normalization helper for path lookups.
+  # All callers route through here so post-B.3 column drop is mechanical.
+  # Opens its own tenant context — use note_by_path_query/3 directly when
+  # already inside Repo.with_tenant (Repo.with_tenant does not nest safely:
+  # the inner `after` Process.delete clobbers the parent's tenant key).
+  defp find_note_by_path(user, vault, path) do
+    case note_by_path_query(user, vault, path) do
+      {:ok, query} ->
+        Repo.with_tenant(user.id, fn -> Repo.one(query) end)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Builds the HMAC-based note lookup query. Caller runs it inside their own
+  # tenant context (or via find_note_by_path/3 when none is active).
+  defp note_by_path_query(user, vault, path) do
+    with {:ok, filter_key} <- Engram.Crypto.dek_filter_key(user) do
+      hmac = Engram.Crypto.hmac_field(filter_key, path)
+
+      {:ok,
+       from(n in Note,
+         where:
+           n.user_id == ^user.id and n.vault_id == ^vault.id and n.path_hmac == ^hmac and
+             is_nil(n.deleted_at)
+       )}
     end
   end
 
@@ -128,16 +147,17 @@ defmodule Engram.Notes do
     new_folder = Helpers.extract_folder(new_path)
     now = DateTime.utc_now()
 
+    with {:ok, user} <- Engram.Crypto.ensure_user_dek(user) do
+      do_rename_note(user, vault, old_path, new_path, new_folder, now)
+    end
+  end
+
+  defp do_rename_note(user, vault, old_path, new_path, new_folder, now) do
+    {:ok, lookup_query} = note_by_path_query(user, vault, old_path)
+
     result =
       Repo.with_tenant(user.id, fn ->
-        # Fetch current note for content (to derive title from new path)
-        case Repo.one(
-               from(n in Note,
-                 where:
-                   n.user_id == ^user.id and n.vault_id == ^vault.id and n.path == ^old_path and
-                     is_nil(n.deleted_at)
-               )
-             ) do
+        case Repo.one(lookup_query) do
           nil ->
             :not_found
 
@@ -145,16 +165,19 @@ defmodule Engram.Notes do
             decrypted_note = decrypt_if_needed(note, user)
             new_title = Helpers.extract_title(decrypted_note.content || "", new_path)
 
+            phase_b_kw = phase_b_keyword_for(user, new_path, new_folder, note.tags || [])
+
             {count, _} =
               from(n in Note, where: n.id == ^note.id)
               |> Repo.update_all(
-                set: [
-                  path: new_path,
-                  folder: new_folder,
-                  title: new_title,
-                  embed_hash: nil,
-                  updated_at: now
-                ]
+                set:
+                  [
+                    path: new_path,
+                    folder: new_folder,
+                    title: new_title,
+                    embed_hash: nil,
+                    updated_at: now
+                  ] ++ phase_b_kw
               )
 
             if count == 1 do
@@ -197,16 +220,11 @@ defmodule Engram.Notes do
   def delete_note(user, vault, path) do
     now = DateTime.utc_now()
 
-    {:ok, note} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.one(
-          from(n in Note,
-            where:
-              n.user_id == ^user.id and n.vault_id == ^vault.id and n.path == ^path and
-                is_nil(n.deleted_at)
-          )
-        )
-      end)
+    note =
+      case find_note_by_path(user, vault, path) do
+        {:ok, note} -> note
+        _ -> nil
+      end
 
     if note do
       Repo.with_tenant(user.id, fn ->
@@ -410,6 +428,12 @@ defmodule Engram.Notes do
     new_folder = String.trim_trailing(new_folder, "/")
     old_prefix = old_folder <> "/"
 
+    with {:ok, user} <- Engram.Crypto.ensure_user_dek(user) do
+      do_rename_folder(user, vault, old_folder, old_prefix, new_folder)
+    end
+  end
+
+  defp do_rename_folder(user, vault, old_folder, old_prefix, new_folder) do
     {:ok, notes} =
       Repo.with_tenant(user.id, fn ->
         Repo.all(
@@ -444,20 +468,23 @@ defmodule Engram.Notes do
           decrypted_note = decrypt_if_needed(note, user)
           new_title = Helpers.extract_title(decrypted_note.content || "", new_path)
 
-          {note.id, note.path, new_path, new_note_folder, new_title}
+          {note.id, note.path, new_path, new_note_folder, new_title, note.tags || []}
         end)
 
       Repo.with_tenant(user.id, fn ->
-        Enum.each(updates, fn {id, _old_path, new_path, new_note_folder, new_title} ->
+        Enum.each(updates, fn {id, _old_path, new_path, new_note_folder, new_title, tags} ->
+          phase_b_kw = phase_b_keyword_for(user, new_path, new_note_folder, tags)
+
           from(n in Note, where: n.id == ^id)
           |> Repo.update_all(
-            set: [
-              path: new_path,
-              folder: new_note_folder,
-              title: new_title,
-              embed_hash: nil,
-              updated_at: now
-            ]
+            set:
+              [
+                path: new_path,
+                folder: new_note_folder,
+                title: new_title,
+                embed_hash: nil,
+                updated_at: now
+              ] ++ phase_b_kw
           )
         end)
       end)
@@ -465,17 +492,21 @@ defmodule Engram.Notes do
       # Insert soft-deleted tombstones for old paths so the HTTP changes feed
       # includes delete signals. Without these, polling clients retain stale
       # files at old paths after a folder rename.
-      old_paths = Enum.map(updates, fn {_id, old_path, _new, _folder, _title} -> old_path end)
+      old_paths =
+        Enum.map(updates, fn {_id, old_path, _new, _folder, _title, _tags} -> old_path end)
 
       mtime_float = DateTime.to_unix(now) + 0.0
 
       tombstones =
         Enum.map(old_paths, fn old_path ->
-          %{
+          old_path_folder = Helpers.extract_folder(old_path)
+          phase_b_kw = phase_b_keyword_for(user, old_path, old_path_folder, [])
+
+          base = %{
             path: old_path,
             content: "",
             title: "",
-            folder: Helpers.extract_folder(old_path),
+            folder: old_path_folder,
             tags: [],
             content_hash: "",
             mtime: mtime_float,
@@ -485,6 +516,8 @@ defmodule Engram.Notes do
             updated_at: now,
             deleted_at: now
           }
+
+          Map.merge(base, Map.new(phase_b_kw))
         end)
 
       Repo.with_tenant(user.id, fn ->
@@ -492,7 +525,7 @@ defmodule Engram.Notes do
       end)
 
       # Side effects outside the transaction — broadcast + reindex
-      Enum.each(updates, fn {id, old_note_path, new_path, _folder, _title} ->
+      Enum.each(updates, fn {id, old_note_path, new_path, _folder, _title, _tags} ->
         Oban.insert(Engram.Workers.EmbedNote.new_debounced(id, old_path: old_note_path))
         broadcast_change(user.id, vault.id, "delete", old_note_path)
         broadcast_change(user.id, vault.id, "upsert", new_path)
@@ -585,12 +618,20 @@ defmodule Engram.Notes do
   # If get_dek still fails after ensure, that is a real bug — raises rather
   # than silently skipping to enforce the "Phase B is mandatory" contract.
   defp inject_phase_b_fields(attrs, user, path, folder, tags) do
+    Map.merge(attrs, Map.new(phase_b_keyword_for(user, path, folder, tags)))
+  end
+
+  # Returns a keyword list of Phase B field updates suitable for splicing into
+  # `Repo.update_all(set: [...])` or `Repo.insert_all` rows. Single source of
+  # truth for HMAC + envelope computation across upsert and rename paths.
+  # Caller MUST have ensured the user has a DEK.
+  defp phase_b_keyword_for(user, path, folder, tags) do
     {:ok, dek} = Engram.Crypto.get_dek(user)
     {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
     {path_ct, path_n} = Engram.Crypto.Envelope.encrypt(path, dek)
     {folder_ct, folder_n} = Engram.Crypto.Envelope.encrypt(folder, dek)
 
-    Map.merge(attrs, %{
+    [
       path_ciphertext: path_ct,
       path_nonce: path_n,
       path_hmac: Engram.Crypto.hmac_field(filter_key, path),
@@ -598,6 +639,6 @@ defmodule Engram.Notes do
       folder_nonce: folder_n,
       folder_hmac: Engram.Crypto.hmac_field(filter_key, folder),
       tags_hmac: Enum.map(tags || [], &Engram.Crypto.hmac_field(filter_key, &1))
-    })
+    ]
   end
 end

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -63,20 +63,61 @@ defmodule Engram.Search do
     # Fetch more candidates when reranking is active
     fetch_limit = if reranker_active?(), do: max(limit * 4, @min_candidates), else: limit
 
-    with {:ok, [vector]} <- embed_for_search(query) do
-      search_opts =
-        [user_id: to_string(user.id), limit: fetch_limit]
-        |> then(&if(vault, do: Keyword.put(&1, :vault_id, to_string(vault.id)), else: &1))
-        |> then(&if(tags, do: Keyword.put(&1, :tags, tags), else: &1))
-        |> then(&if(folder, do: Keyword.put(&1, :folder, folder), else: &1))
+    case translate_phase_b_filters(user, folder, tags) do
+      {:ok, phase_b_kw} ->
+        with {:ok, [vector]} <- embed_for_search(query) do
+          search_opts =
+            [user_id: to_string(user.id), limit: fetch_limit]
+            |> then(&if(vault, do: Keyword.put(&1, :vault_id, to_string(vault.id)), else: &1))
+            |> Keyword.merge(phase_b_kw)
 
-      with {:ok, candidates} <- Qdrant.search(collection(), vector, search_opts),
-           vaults_by_id = load_candidate_vaults(user, vault, candidates),
-           {:ok, decrypted} <-
-             Engram.Crypto.maybe_decrypt_qdrant_candidates(candidates, user, vaults_by_id) do
-        reranker().rerank(query, decrypted, limit)
-      end
+          with {:ok, candidates} <- Qdrant.search(collection(), vector, search_opts),
+               vaults_by_id = load_candidate_vaults(user, vault, candidates),
+               {:ok, decrypted} <-
+                 Engram.Crypto.maybe_decrypt_qdrant_candidates(candidates, user, vaults_by_id) do
+            reranker().rerank(query, decrypted, limit)
+          end
+        end
+
+      :no_dek_with_filter ->
+        # Caller asked to filter by folder/tags but has no DEK provisioned —
+        # impossible to derive HMAC, and the user has no encrypted points to
+        # match anyway. Mirrors list_folders (B.2.2) defensive empty.
+        {:ok, []}
     end
+  end
+
+  # Returns either {:ok, kw} where kw is the [folder_hmac: ..., tags_hmac: ...]
+  # subset to merge into Qdrant search opts, or :no_dek_with_filter when the
+  # caller asked for a filter but has no DEK to derive the HMAC. An unfiltered
+  # search (no folder, no tags) is always {:ok, []} — DEK not required.
+  defp translate_phase_b_filters(_user, nil, nil), do: {:ok, []}
+
+  defp translate_phase_b_filters(user, folder, tags) do
+    case Engram.Crypto.dek_filter_key(user) do
+      {:ok, filter_key} ->
+        kw =
+          []
+          |> maybe_put_folder_hmac(filter_key, folder)
+          |> maybe_put_tags_hmac(filter_key, tags)
+
+        {:ok, kw}
+
+      {:error, :no_dek} ->
+        :no_dek_with_filter
+    end
+  end
+
+  defp maybe_put_folder_hmac(kw, _filter_key, nil), do: kw
+
+  defp maybe_put_folder_hmac(kw, filter_key, folder),
+    do: Keyword.put(kw, :folder_hmac, Base.encode64(Engram.Crypto.hmac_field(filter_key, folder)))
+
+  defp maybe_put_tags_hmac(kw, _filter_key, nil), do: kw
+
+  defp maybe_put_tags_hmac(kw, filter_key, tags) do
+    encoded = Enum.map(tags, &Base.encode64(Engram.Crypto.hmac_field(filter_key, &1)))
+    Keyword.put(kw, :tags_hmac, encoded)
   end
 
   # Single-vault search: return the passed-in vault directly — no extra DB query.

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -112,6 +112,8 @@ defmodule Engram.Vaults do
   Returns all non-deleted vaults for a user, ordered by inserted_at ascending.
   """
   def list_vaults(user) do
+    user = fresh_user(user)
+
     {:ok, vaults} =
       Repo.with_tenant(user.id, fn ->
         Repo.all(
@@ -121,7 +123,7 @@ defmodule Engram.Vaults do
         )
       end)
 
-    vaults
+    Enum.map(vaults, &decrypt_vault_if_needed(&1, user))
   end
 
   @doc """
@@ -165,6 +167,8 @@ defmodule Engram.Vaults do
   or {:error, :not_found}.
   """
   def get_vault(user, vault_id) do
+    user = fresh_user(user)
+
     result =
       Repo.with_tenant(user.id, fn ->
         Repo.one(
@@ -175,7 +179,7 @@ defmodule Engram.Vaults do
 
     case result do
       {:ok, nil} -> {:error, :not_found}
-      {:ok, vault} -> {:ok, vault}
+      {:ok, vault} -> {:ok, decrypt_vault_if_needed(vault, user)}
       _ -> {:error, :not_found}
     end
   end
@@ -184,6 +188,8 @@ defmodule Engram.Vaults do
   Returns {:ok, vault} for the user's default vault, or {:error, :no_default_vault}.
   """
   def get_default_vault(user) do
+    user = fresh_user(user)
+
     result =
       Repo.with_tenant(user.id, fn ->
         Repo.one(
@@ -194,7 +200,7 @@ defmodule Engram.Vaults do
 
     case result do
       {:ok, nil} -> {:error, :no_default_vault}
-      {:ok, vault} -> {:ok, vault}
+      {:ok, vault} -> {:ok, decrypt_vault_if_needed(vault, user)}
       _ -> {:error, :no_default_vault}
     end
   end
@@ -497,5 +503,30 @@ defmodule Engram.Vaults do
       {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
       {k, v} -> {k, v}
     end)
+  end
+
+  # Reload the user struct if its in-memory `encrypted_dek` is nil — the
+  # caller may be holding a stale struct from before a write provisioned a
+  # DEK. Same hazard the Attachments context handles via fresh_user/1.
+  defp fresh_user(%Engram.Accounts.User{encrypted_dek: nil} = user), do: Repo.reload!(user)
+  defp fresh_user(%Engram.Accounts.User{} = user), do: user
+
+  # Decrypts vault.name from name_ciphertext when populated. On decrypt
+  # failure logs and returns the row unchanged — operator visibility without
+  # killing the request. Mirrors `decrypt_if_needed` in Notes context.
+  defp decrypt_vault_if_needed(%Vault{} = vault, user) do
+    case Engram.Crypto.maybe_decrypt_vault_fields(vault, user) do
+      {:ok, decrypted} ->
+        decrypted
+
+      {:error, reason} ->
+        require Logger
+
+        Logger.error(
+          "vault decrypt_failed user_id=#{user.id} vault_id=#{vault.id} reason=#{inspect(reason)}"
+        )
+
+        vault
+    end
   end
 end

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -111,6 +111,29 @@ defmodule Engram.Vector.Qdrant do
   end
 
   @doc """
+  Patch (overwrite-or-add) the given payload keys on the listed point ids.
+  Vectors are untouched — this is the cost-free path for re-shaping payloads
+  without re-running the embedder. Empty `point_ids` is a no-op.
+
+  Used by `Engram.Workers.QdrantPayloadPhaseB` to backfill `path_hmac` /
+  `folder_hmac` / `tags_hmac` onto pre-existing Qdrant points after the
+  Phase B.2.4 additive write lands but before the Phase B.2.3 read switch.
+  """
+  def set_payload(col \\ nil, point_ids, payload)
+  def set_payload(_col, [], _payload), do: :ok
+
+  def set_payload(col, point_ids, payload) when is_list(point_ids) and is_map(payload) do
+    col = col || collection()
+    opts = [json: %{points: point_ids, payload: payload}] ++ req_opts()
+
+    case Req.post("#{base_url()}/collections/#{col}/points/payload", opts) do
+      {:ok, %{status: 200}} -> :ok
+      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
   Delete all points for a given user+vault+path combination.
   """
   def delete_by_note(col \\ nil, user_id, vault_id, path) do
@@ -191,6 +214,7 @@ defmodule Engram.Vector.Qdrant do
       else
         base
       end
+
     opts = [json: body] ++ req_opts()
 
     case Req.post("#{base_url()}/collections/#{col}/points/query", opts) do

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -182,24 +182,34 @@ defmodule Engram.Vector.Qdrant do
   Vector similarity search. Returns list of result structs with score + payload.
 
   Options:
-  - `:user_id`  — filter to this user's points (required for tenant isolation)
-  - `:vault_id` — filter to a specific vault (omit for cross-vault search)
-  - `:limit`    — number of results (default 5)
-  - `:tags`     — filter to points with ANY of these tags
-  - `:folder`   — filter to points in this folder
+  - `:user_id`     — filter to this user's points (required for tenant isolation)
+  - `:vault_id`    — filter to a specific vault (omit for cross-vault search)
+  - `:limit`       — number of results (default 5)
+  - `:folder_hmac` — filter to points whose folder_hmac equals this value
+                     (Phase B.2.3 — base64-encoded HMAC, no plaintext folder)
+  - `:tags_hmac`   — filter to points with ANY of these tag HMACs
+                     (Phase B.2.3 — base64-encoded list, no plaintext tags)
   """
   def search(col \\ nil, vector, search_opts) do
     col = col || collection()
     user_id = Keyword.fetch!(search_opts, :user_id)
     vault_id = Keyword.get(search_opts, :vault_id)
     limit = Keyword.get(search_opts, :limit, 5)
-    tags = Keyword.get(search_opts, :tags)
-    folder = Keyword.get(search_opts, :folder)
+    tags_hmac = Keyword.get(search_opts, :tags_hmac)
+    folder_hmac = Keyword.get(search_opts, :folder_hmac)
 
     must = [%{key: "user_id", match: %{value: user_id}}]
     must = if vault_id, do: must ++ [%{key: "vault_id", match: %{value: vault_id}}], else: must
-    must = if tags, do: [%{key: "tags", match: %{any: tags}} | must], else: must
-    must = if folder, do: [%{key: "folder", match: %{value: folder}} | must], else: must
+
+    must =
+      if tags_hmac,
+        do: [%{key: "tags_hmac", match: %{any: tags_hmac}} | must],
+        else: must
+
+    must =
+      if folder_hmac,
+        do: [%{key: "folder_hmac", match: %{value: folder_hmac}} | must],
+        else: must
 
     base = %{
       query: vector,

--- a/lib/engram/workers/qdrant_payload_phase_b.ex
+++ b/lib/engram/workers/qdrant_payload_phase_b.ex
@@ -1,0 +1,117 @@
+defmodule Engram.Workers.QdrantPayloadPhaseB do
+  @moduledoc """
+  Phase B.2.5 — re-shapes existing Qdrant payloads with the Phase B HMAC keys
+  (`path_hmac` / `folder_hmac` / `tags_hmac`) so the B.2.3 read switch can
+  filter by them. PATCHes payloads via `Qdrant.set_payload/3` instead of
+  re-upserting full points: vectors are not touched, no Voyage cost.
+
+  Cursor-driven per (user, vault), batch of 100 notes per invocation. Reads
+  HMAC bytes straight off the note row (B.1 backfill is the source of truth)
+  and base64-encodes them for JSON-safe transport — same encoding that
+  `Engram.Indexing.build_prepared/4` uses for fresh writes (B.2.4).
+
+  Idempotent on retry: the cursor advances over note ids, and a re-PATCH with
+  identical payload is a no-op on the Qdrant side.
+  """
+
+  use Oban.Worker,
+    queue: :crypto_backfill,
+    max_attempts: 5,
+    # `executing` excluded so self-reenqueue from inside `perform/1` isn't
+    # flagged as a duplicate — same hazard documented in BackfillPhaseBHmac.
+    unique: [keys: [:user_id, :vault_id], states: [:available, :scheduled]]
+
+  import Ecto.Query
+
+  alias Engram.Notes.{Chunk, Note}
+  alias Engram.Repo
+  alias Engram.Vector.Qdrant
+
+  @batch_size 100
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "vault_id" => vault_id} = args}) do
+    last_id = Map.get(args, "last_id", 0)
+
+    {:ok, cursor_result} =
+      Repo.with_tenant(user_id, fn ->
+        process_batch(user_id, vault_id, last_id)
+      end)
+
+    case cursor_result do
+      {:done, _last} ->
+        :ok
+
+      {:error, _} = err ->
+        err
+
+      {:more, next_cursor} ->
+        %{"user_id" => user_id, "vault_id" => vault_id, "last_id" => next_cursor}
+        |> __MODULE__.new()
+        |> Oban.insert()
+
+        :ok
+    end
+  end
+
+  defp process_batch(user_id, vault_id, last_id) do
+    notes =
+      from(n in Note,
+        where: n.user_id == ^user_id and n.vault_id == ^vault_id and n.id > ^last_id,
+        order_by: [asc: n.id],
+        limit: @batch_size
+      )
+      |> Repo.all()
+
+    case Enum.reduce_while(notes, :ok, &patch_note/2) do
+      :ok ->
+        case notes do
+          [] -> {:done, last_id}
+          _ -> {:more, List.last(notes).id}
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp patch_note(%Note{} = note, _acc) do
+    point_ids =
+      from(c in Chunk,
+        where: c.note_id == ^note.id and not is_nil(c.qdrant_point_id),
+        select: c.qdrant_point_id
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    case point_ids do
+      [] ->
+        {:cont, :ok}
+
+      ids ->
+        case Qdrant.set_payload(nil, ids, build_payload(note)) do
+          :ok -> {:cont, :ok}
+          {:error, _} = err -> {:halt, err}
+        end
+    end
+  end
+
+  # Pre-Phase-B-1 rows have nil HMACs; backfill must run first. Skip the
+  # absent fields rather than write nil — that would poison filters with a
+  # null match. `encode_hmac/1` mirrors the encoding in `Indexing.build_prepared/4`.
+  defp build_payload(%Note{} = note) do
+    %{}
+    |> maybe_put(:path_hmac, encode_hmac(note.path_hmac))
+    |> maybe_put(:folder_hmac, encode_hmac(note.folder_hmac))
+    |> maybe_put(:tags_hmac, encode_tags_hmac(note.tags_hmac))
+  end
+
+  defp maybe_put(map, _k, nil), do: map
+  defp maybe_put(map, k, v), do: Map.put(map, k, v)
+
+  defp encode_hmac(nil), do: nil
+  defp encode_hmac(bin) when is_binary(bin), do: Base.encode64(bin)
+
+  defp encode_tags_hmac(nil), do: nil
+  defp encode_tags_hmac([]), do: []
+  defp encode_tags_hmac(list) when is_list(list), do: Enum.map(list, &Base.encode64/1)
+end

--- a/lib/mix/tasks/engram.qdrant_payload_phase_b.ex
+++ b/lib/mix/tasks/engram.qdrant_payload_phase_b.ex
@@ -1,0 +1,73 @@
+defmodule Mix.Tasks.Engram.QdrantPayloadPhaseB do
+  @moduledoc """
+  Enqueues `Engram.Workers.QdrantPayloadPhaseB` jobs for every (user, vault)
+  combination that has at least one chunk row in Postgres — the universe of
+  Qdrant points the worker needs to PATCH. Idempotent: rerunning is safe; the
+  worker patches with identical payloads (no-op on Qdrant) and the cursor
+  advances over note ids regardless.
+
+  Run **after** Phase B.1 backfill is complete (worker reads `path_hmac` /
+  `folder_hmac` / `tags_hmac` straight off the note row).
+
+  Usage:
+
+    # Local dev (mix available):
+    mix engram.qdrant_payload_phase_b
+
+    # Production (release — Mix not available, use rpc with inline body):
+    docker exec engram-saas /app/bin/engram rpc "
+    import Ecto.Query
+    alias Engram.Notes.Chunk
+    alias Engram.Repo
+    alias Engram.Workers.QdrantPayloadPhaseB
+
+    pairs = Repo.all(from(c in Chunk, group_by: [c.user_id, c.vault_id], select: {c.user_id, c.vault_id}), skip_tenant_check: true)
+
+    for {uid, vid} <- pairs do
+      %{\"user_id\" => uid, \"vault_id\" => vid, \"last_id\" => 0} |> QdrantPayloadPhaseB.new() |> Oban.insert!()
+    end
+    IO.puts(\"enqueued \#{length(pairs)}\")
+    "
+  """
+
+  use Mix.Task
+
+  import Ecto.Query
+
+  alias Engram.Notes.Chunk
+  alias Engram.Repo
+  alias Engram.Workers.QdrantPayloadPhaseB
+
+  @shortdoc "Enqueue Phase B Qdrant payload PATCH jobs"
+
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    pairs = gather_pairs()
+
+    IO.puts("Enqueueing Qdrant payload Phase B PATCH for #{length(pairs)} (user, vault) pairs")
+
+    for {user_id, vault_id} <- pairs do
+      %{"user_id" => user_id, "vault_id" => vault_id, "last_id" => 0}
+      |> QdrantPayloadPhaseB.new()
+      |> Oban.insert!()
+    end
+
+    IO.puts("Done. Watch oban_jobs queue=:crypto_backfill for progress.")
+  end
+
+  @doc """
+  Returns deduplicated `{user_id, vault_id}` pairs derived from the chunks
+  table. Pairs without any chunks (and therefore no Qdrant points) are
+  skipped — there's nothing for the worker to PATCH.
+  """
+  def gather_pairs do
+    Repo.all(
+      from(c in Chunk,
+        group_by: [c.user_id, c.vault_id],
+        select: {c.user_id, c.vault_id}
+      ),
+      skip_tenant_check: true
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.25",
+      version: "0.5.26",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -183,6 +183,52 @@ defmodule Engram.AttachmentsTest do
       assert byte_size(stored) == byte_size(plaintext) + 16
     end
 
+    test "get_attachment locates row via path_hmac and returns decrypt-sourced path (B.2.6)" do
+      user = insert(:user) |> Engram.Repo.reload!()
+      vault = insert(:vault, user: user)
+
+      {:ok, created} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "Real/file.bin",
+          "content_base64" => Base.encode64("hello"),
+          "mtime" => 0.0
+        })
+
+      {:ok, _} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          from(a in Attachment, where: a.id == ^created.id)
+          |> Engram.Repo.update_all(set: [path: "TAMPERED-PATH"])
+        end)
+
+      assert {:ok, fetched} = Attachments.get_attachment(user, vault, "Real/file.bin")
+      assert fetched.id == created.id
+      # Response path comes from decrypted ciphertext, not the tampered column.
+      assert fetched.path == "Real/file.bin"
+    end
+
+    test "list_changes returns decrypt-sourced path even when plaintext column is tampered (B.2.6)" do
+      user = insert(:user) |> Engram.Repo.reload!()
+      vault = insert(:vault, user: user)
+
+      {:ok, created} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "Notes/img.png",
+          "content_base64" => Base.encode64("img"),
+          "mtime" => 0.0
+        })
+
+      {:ok, _} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          from(a in Attachment, where: a.id == ^created.id)
+          |> Engram.Repo.update_all(set: [path: "TAMPERED-PATH"])
+        end)
+
+      assert {:ok, [change]} =
+               Attachments.list_changes(user, vault, ~U[2000-01-01 00:00:00.000000Z])
+
+      assert change.path == "Notes/img.png"
+    end
+
     test "round-trips encrypted attachment via get_attachment" do
       user = insert(:user) |> Engram.Repo.reload!()
       vault = insert(:vault, user: user)

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -20,6 +20,28 @@ defmodule Engram.CryptoTest do
     assert user2.encrypted_dek == user1.encrypted_dek
   end
 
+  test "ensure_user_dek does NOT rotate when caller holds a stale struct (encrypted_dek=nil) but DB has a blob",
+       %{user: user} do
+    # Regression for the data-corruption bug fixed in B.2.6: callers holding
+    # a stale user struct (e.g. an in-memory copy fetched before encryption was
+    # toggled on) would silently rotate the DEK on every ensure_user_dek call,
+    # invalidating every existing ciphertext for the user.
+    {:ok, provisioned} = Crypto.ensure_user_dek(user)
+    assert is_binary(provisioned.encrypted_dek)
+    original_blob = provisioned.encrypted_dek
+
+    # `user` is the original fixture struct, still carrying encrypted_dek=nil.
+    assert is_nil(user.encrypted_dek)
+
+    {:ok, after_call} = Crypto.ensure_user_dek(user)
+
+    assert after_call.encrypted_dek == original_blob,
+           "stale-struct call rotated the DEK — every existing ciphertext is now unrecoverable"
+
+    assert after_call.dek_version == provisioned.dek_version
+    assert after_call.key_provider == provisioned.key_provider
+  end
+
   test "get_dek caches after first unwrap", %{user: user} do
     {:ok, user} = Crypto.ensure_user_dek(user)
     # ensure_user_dek pre-populates the cache; clear it to exercise the unwrap path.

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -32,7 +32,11 @@ defmodule Engram.IndexingTest do
   # ---------------------------------------------------------------------------
 
   describe "index_note/2" do
-    test "embeds chunks and upserts to Qdrant + Postgres", %{bypass: bypass, note: note, vault: vault} do
+    test "embeds chunks and upserts to Qdrant + Postgres", %{
+      bypass: bypass,
+      note: note,
+      vault: vault
+    } do
       # Mock embedder returns one 3-dim vector per chunk
       Engram.MockEmbedder
       |> expect(:embed_texts, fn texts ->
@@ -151,6 +155,55 @@ defmodule Engram.IndexingTest do
       end)
     end
 
+    test "Phase B: payload includes base64-encoded path/folder/tags hmacs",
+         %{bypass: bypass, user: user} do
+      Engram.Crypto.DekCache.invalidate_all()
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user)
+
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Health/iron.md",
+          "content" => "---\ntags: [labs, ferritin]\n---\n# Iron",
+          "mtime" => 1_000.0
+        })
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> [0.1, 0.2, 0.3] end)}
+      end)
+
+      test_pid = self()
+
+      Bypass.expect(bypass, fn conn ->
+        if String.contains?(conn.request_path, "/points") and conn.method == "PUT" do
+          {:ok, body, conn} = Plug.Conn.read_body(conn)
+          send(test_pid, {:upsert_body, Jason.decode!(body)})
+          Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+        else
+          Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+        end
+      end)
+
+      assert {:ok, _} = Indexing.index_note(note, vault)
+      assert_received {:upsert_body, body}
+
+      {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
+      expected_path_hmac = Base.encode64(Engram.Crypto.hmac_field(filter_key, "Health/iron.md"))
+      expected_folder_hmac = Base.encode64(Engram.Crypto.hmac_field(filter_key, "Health"))
+      expected_labs_hmac = Base.encode64(Engram.Crypto.hmac_field(filter_key, "labs"))
+      expected_ferritin_hmac = Base.encode64(Engram.Crypto.hmac_field(filter_key, "ferritin"))
+
+      Enum.each(body["points"], fn p ->
+        payload = p["payload"]
+        assert payload["path_hmac"] == expected_path_hmac
+        assert payload["folder_hmac"] == expected_folder_hmac
+        assert is_list(payload["tags_hmac"])
+        assert expected_labs_hmac in payload["tags_hmac"]
+        assert expected_ferritin_hmac in payload["tags_hmac"]
+      end)
+    end
+
     test "unencrypted vault → plaintext payload unchanged", %{bypass: bypass, user: user} do
       vault = insert(:vault, user: user, encrypted: false)
 
@@ -214,6 +267,7 @@ defmodule Engram.IndexingTest do
       # upsert_note auto-provisioned via maybe_encrypt_note_fields; simulate the
       # "DEK missing at index time" scenario that emits telemetry.
       import Ecto.Query
+
       Engram.Repo.update_all(
         from(u in Engram.Accounts.User, where: u.id == ^user.id),
         [set: [encrypted_dek: nil]],

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -466,6 +466,30 @@ defmodule Engram.NotesTest do
       {:ok, folders} = Notes.list_folders(user, vault)
       refute "Private Folder" in folders
     end
+
+    test "groups by folder_hmac and decrypts ciphertext (post-B.3 simulation)",
+         %{user: user, vault: vault} do
+      Notes.upsert_note(user, vault, %{
+        "path" => "Real/Note.md",
+        "content" => "x",
+        "mtime" => 1_000.0
+      })
+
+      # Tamper plaintext folder column — must not affect the grouped result.
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(
+            from(n in Engram.Notes.Note,
+              where: n.user_id == ^user.id and n.vault_id == ^vault.id
+            ),
+            set: [folder: "TAMPERED"]
+          )
+        end)
+
+      {:ok, folders} = Notes.list_folders(user, vault)
+      assert "Real" in folders
+      refute "TAMPERED" in folders
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -645,6 +669,37 @@ defmodule Engram.NotesTest do
     test "returns empty list when no notes", %{user: user, vault: vault} do
       {:ok, folders} = Notes.list_folders_with_counts(user, vault)
       assert folders == []
+    end
+
+    test "groups by folder_hmac and decrypts ciphertext (post-B.3 simulation)",
+         %{user: user, vault: vault} do
+      Notes.upsert_note(user, vault, %{
+        "path" => "Health/A.md",
+        "content" => "x",
+        "mtime" => 1_000.0
+      })
+
+      Notes.upsert_note(user, vault, %{
+        "path" => "Health/B.md",
+        "content" => "y",
+        "mtime" => 1_000.0
+      })
+
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(
+            from(n in Engram.Notes.Note,
+              where: n.user_id == ^user.id and n.vault_id == ^vault.id
+            ),
+            set: [folder: "TAMPERED"]
+          )
+        end)
+
+      {:ok, folders} = Notes.list_folders_with_counts(user, vault)
+      health = Enum.find(folders, &(&1.folder == "Health"))
+      assert health
+      assert health.count == 2
+      refute Enum.any?(folders, &(&1.folder == "TAMPERED"))
     end
 
     test "excludes soft-deleted notes", %{user: user, vault: vault} do

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -11,6 +11,11 @@ defmodule Engram.NotesTest do
     insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
     insert(:user_override, user: other_user, overrides: %{"max_vaults" => -1})
 
+    # Phase B reads derive a filter key from the user's DEK. Provision DEK
+    # upfront so test users carry encrypted_dek in-struct without a reload.
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, other_user} = Engram.Crypto.ensure_user_dek(other_user)
+
     {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
     {:ok, other_vault} = Engram.Vaults.create_vault(other_user, %{name: "Test"})
 
@@ -226,6 +231,27 @@ defmodule Engram.NotesTest do
 
     test "returns not_found for nonexistent path", %{user: user, vault: vault} do
       assert {:error, :not_found} = Notes.get_note(user, vault, "Nope/Missing.md")
+    end
+
+    test "locates note via path_hmac, ignoring plaintext path column",
+         %{user: user, vault: vault} do
+      {:ok, created} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Test/Hmac.md",
+          "content" => "# Hmac",
+          "mtime" => 1_000.0
+        })
+
+      # Tamper plaintext path to a sentinel — if lookup still uses `n.path == ^path`
+      # the row will not be found. If it uses `n.path_hmac`, the row is still found.
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          from(n in Engram.Notes.Note, where: n.id == ^created.id)
+          |> Repo.update_all(set: [path: "TAMPERED-DO-NOT-MATCH"])
+        end)
+
+      assert {:ok, found} = Notes.get_note(user, vault, "Test/Hmac.md")
+      assert found.id == created.id
     end
   end
 
@@ -890,6 +916,56 @@ defmodule Engram.NotesTest do
 
       # Other user's note untouched
       assert {:ok, _} = Notes.get_note(other_user, other_vault, "Shared/Note.md")
+    end
+
+    test "recomputes path_hmac and folder_hmac for the new path/folder",
+         %{user: user, vault: vault} do
+      {:ok, before} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Old/Note.md",
+          "content" => "# Old",
+          "mtime" => 1_000.0
+        })
+
+      {:ok, 1} = Notes.rename_folder(user, vault, "Old", "New")
+
+      {:ok, after_row} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.one(from(n in Engram.Notes.Note, where: n.id == ^before.id))
+        end)
+
+      {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
+      assert after_row.path_hmac == Engram.Crypto.hmac_field(filter_key, "New/Note.md")
+      assert after_row.folder_hmac == Engram.Crypto.hmac_field(filter_key, "New")
+      refute after_row.path_hmac == before.path_hmac
+      refute after_row.folder_hmac == before.folder_hmac
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # rename_note/4 path_hmac regression
+  # ---------------------------------------------------------------------------
+
+  describe "rename_note/4 phase B sync" do
+    test "recomputes path_hmac and folder_hmac for the new path/folder",
+         %{user: user, vault: vault} do
+      {:ok, before} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Folder/Old.md",
+          "content" => "# Old",
+          "mtime" => 1_000.0
+        })
+
+      {:ok, _} = Notes.rename_note(user, vault, "Folder/Old.md", "Folder/New.md")
+
+      {:ok, after_row} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.one(from(n in Engram.Notes.Note, where: n.id == ^before.id))
+        end)
+
+      {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
+      assert after_row.path_hmac == Engram.Crypto.hmac_field(filter_key, "Folder/New.md")
+      refute after_row.path_hmac == before.path_hmac
     end
   end
 end

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -233,6 +233,42 @@ defmodule Engram.NotesTest do
       assert {:error, :not_found} = Notes.get_note(user, vault, "Nope/Missing.md")
     end
 
+    test "returns decrypt-sourced path/folder/tags even when plaintext columns are tampered (B.2.6)",
+         %{user: user} do
+      # Phase 4 tags ciphertext is only populated for encrypted vaults — use
+      # one here so this test exercises BOTH Phase B path/folder ciphertext
+      # (always-on after B.1) AND Phase 4 tags ciphertext.
+      vault = insert(:vault, user: user, encrypted: true)
+
+      {:ok, created} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Real/Note.md",
+          "content" => "---\ntags: [t1, t2]\n---\n# Real Note\n\nbody"
+        })
+
+      # Tamper every plaintext column the response reads from. After B.3 these
+      # columns will be DROPPED — this test simulates that future state by
+      # corrupting the plaintext source so any read that leaks back to it
+      # surfaces the wrong value.
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          from(n in Engram.Notes.Note, where: n.id == ^created.id)
+          |> Repo.update_all(
+            set: [
+              path: "TAMPERED-PATH",
+              folder: "TAMPERED-FOLDER",
+              tags: ["TAMPERED-TAG"]
+            ]
+          )
+        end)
+
+      assert {:ok, found} = Notes.get_note(user, vault, "Real/Note.md")
+
+      assert found.path == "Real/Note.md"
+      assert found.folder == "Real"
+      assert Enum.sort(found.tags) == Enum.sort(["t1", "t2"])
+    end
+
     test "locates note via path_hmac, ignoring plaintext path column",
          %{user: user, vault: vault} do
       {:ok, created} =
@@ -465,6 +501,28 @@ defmodule Engram.NotesTest do
 
       {:ok, folders} = Notes.list_folders(user, vault)
       refute "Private Folder" in folders
+    end
+
+    test "list_notes_in_folder filters by folder_hmac, ignoring plaintext folder column (B.2.6)",
+         %{user: user, vault: vault} do
+      {:ok, created} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Real/Note.md",
+          "content" => "x"
+        })
+
+      # Tamper plaintext folder to a non-matching value. If the lookup uses
+      # `n.folder == ^folder` the row will be missed; folder_hmac still matches.
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          from(n in Engram.Notes.Note, where: n.id == ^created.id)
+          |> Repo.update_all(set: [folder: "TAMPERED-FOLDER"])
+        end)
+
+      assert {:ok, [note]} = Notes.list_notes_in_folder(user, vault, "Real")
+      assert note.id == created.id
+      # Decrypt also fixes the folder display value.
+      assert note.folder == "Real"
     end
 
     test "groups by folder_hmac and decrypts ciphertext (post-B.3 simulation)",

--- a/test/engram/search_test.exs
+++ b/test/engram/search_test.exs
@@ -13,7 +13,7 @@ defmodule Engram.SearchTest do
     Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
     on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
 
-    user = insert(:user)
+    {:ok, user} = insert(:user) |> Engram.Crypto.ensure_user_dek()
     vault = insert(:vault, user: user)
     %{bypass: bypass, user: user, vault: vault}
   end
@@ -74,16 +74,26 @@ defmodule Engram.SearchTest do
       assert {:ok, []} = Search.search(user, vault, "query")
     end
 
-    test "passes folder filter to Qdrant", %{bypass: bypass, user: user, vault: vault} do
+    test "translates :folder opt into folder_hmac filter (Phase B.2.3)",
+         %{bypass: bypass, user: user, vault: vault} do
       Engram.MockEmbedder
       |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
+      expected_hmac = Base.encode64(Engram.Crypto.hmac_field(filter_key, "Health"))
 
       Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         decoded = Jason.decode!(body)
         conditions = decoded["filter"]["must"]
         keys = Enum.map(conditions, & &1["key"])
-        assert "folder" in keys
+
+        # Plaintext folder filter is gone; HMAC filter takes its place.
+        refute "folder" in keys
+        assert "folder_hmac" in keys
+
+        folder_cond = Enum.find(conditions, &(&1["key"] == "folder_hmac"))
+        assert folder_cond["match"]["value"] == expected_hmac
 
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
@@ -93,23 +103,50 @@ defmodule Engram.SearchTest do
       assert {:ok, []} = Search.search(user, vault, "query", folder: "Health")
     end
 
-    test "passes tags filter to Qdrant", %{bypass: bypass, user: user, vault: vault} do
+    test "translates :tags opt into tags_hmac filter (Phase B.2.3)",
+         %{bypass: bypass, user: user, vault: vault} do
       Engram.MockEmbedder
       |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
+
+      expected_hmacs =
+        ["health", "labs"]
+        |> Enum.map(&Base.encode64(Engram.Crypto.hmac_field(filter_key, &1)))
 
       Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         decoded = Jason.decode!(body)
         conditions = decoded["filter"]["must"]
         keys = Enum.map(conditions, & &1["key"])
-        assert "tags" in keys
+
+        refute "tags" in keys
+        assert "tags_hmac" in keys
+
+        tags_cond = Enum.find(conditions, &(&1["key"] == "tags_hmac"))
+        assert Enum.sort(tags_cond["match"]["any"]) == Enum.sort(expected_hmacs)
 
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.send_resp(200, ~s({"result": []}))
       end)
 
-      assert {:ok, []} = Search.search(user, vault, "query", tags: ["health"])
+      assert {:ok, []} = Search.search(user, vault, "query", tags: ["health", "labs"])
+    end
+
+    test "user without DEK returns empty result for filtered search instead of crashing",
+         %{bypass: bypass} do
+      # Brand-new user — no notes upserted, no DEK provisioned. Mirrors the
+      # multi-tenant edge case fixed for list_folders in B.2.2.
+      user_no_dek = insert(:user)
+      vault = insert(:vault, user: user_no_dek)
+
+      Bypass.stub(bypass, "POST", "/collections/engram_notes/points/query", fn _ ->
+        flunk("Qdrant must not be queried when caller has no DEK and supplied folder/tags")
+      end)
+
+      assert {:ok, []} = Search.search(user_no_dek, vault, "query", folder: "Health")
+      assert {:ok, []} = Search.search(user_no_dek, vault, "query", tags: ["x"])
     end
 
     test "returns error when embedder fails", %{user: user, vault: vault} do
@@ -119,7 +156,11 @@ defmodule Engram.SearchTest do
       assert {:error, _} = Search.search(user, vault, "iron panel")
     end
 
-    test "fetches 4x candidates when reranker is configured", %{bypass: bypass, user: user, vault: vault} do
+    test "fetches 4x candidates when reranker is configured", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
       # Configure Jina reranker via behaviour
       jina_bypass = Bypass.open()
       Application.put_env(:engram, :reranker, Engram.Rerankers.Jina)
@@ -200,7 +241,11 @@ defmodule Engram.SearchTest do
       assert {:ok, []} = Search.search(user, vault, "test query")
     end
 
-    test "uses default embed when query model not configured", %{bypass: bypass, user: user, vault: vault} do
+    test "uses default embed when query model not configured", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
       Application.delete_env(:engram, :query_embed_model)
 
       Engram.MockEmbedder
@@ -217,7 +262,11 @@ defmodule Engram.SearchTest do
       assert {:ok, []} = Search.search(user, vault, "test query")
     end
 
-    test "returns empty list when Qdrant returns no results", %{bypass: bypass, user: user, vault: vault} do
+    test "returns empty list when Qdrant returns no results", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
       Engram.MockEmbedder
       |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
 
@@ -230,7 +279,10 @@ defmodule Engram.SearchTest do
       assert {:ok, []} = Search.search(user, vault, "nothing")
     end
 
-    test "cross-vault search returns error when feature disabled (free plan)", %{user: user, vault: vault} do
+    test "cross-vault search returns error when feature disabled (free plan)", %{
+      user: user,
+      vault: vault
+    } do
       # Free plan user has no plan_id; @default_limits has cross_vault_search: false
       assert user.plan_id == nil
 
@@ -238,7 +290,10 @@ defmodule Engram.SearchTest do
                Search.search(user, vault, "query", cross_vault: true)
     end
 
-    test "cross-vault search proceeds past billing gate when feature enabled (pro plan)", %{bypass: bypass, vault: vault} do
+    test "cross-vault search proceeds past billing gate when feature enabled (pro plan)", %{
+      bypass: bypass,
+      vault: vault
+    } do
       plan = insert(:plan, limits: %{"cross_vault_search" => true})
       pro_user = insert(:user, plan_id: plan.id)
 
@@ -255,7 +310,11 @@ defmodule Engram.SearchTest do
       refute result == {:error, :feature_not_available}
     end
 
-    test "default (non-cross-vault) search skips billing gate for free plan user", %{bypass: bypass, user: user, vault: vault} do
+    test "default (non-cross-vault) search skips billing gate for free plan user", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
       # Free plan user — no cross_vault opt — should never hit the billing check
       Engram.MockEmbedder
       |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)

--- a/test/engram/vault_isolation_test.exs
+++ b/test/engram/vault_isolation_test.exs
@@ -11,6 +11,9 @@ defmodule Engram.VaultIsolationTest do
     user = insert(:user)
     insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
 
+    # Phase B reads derive a filter key from the user's DEK — provision upfront.
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+
     {:ok, vault_a} = Vaults.create_vault(user, %{name: "Personal"})
     {:ok, vault_b} = Vaults.create_vault(user, %{name: "Work"})
 
@@ -22,7 +25,11 @@ defmodule Engram.VaultIsolationTest do
   # ---------------------------------------------------------------------------
 
   describe "note isolation across vaults" do
-    test "note in vault_a is not visible from vault_b", %{user: user, vault_a: vault_a, vault_b: vault_b} do
+    test "note in vault_a is not visible from vault_b", %{
+      user: user,
+      vault_a: vault_a,
+      vault_b: vault_b
+    } do
       {:ok, _} =
         Notes.upsert_note(user, vault_a, %{
           "path" => "test.md",
@@ -33,7 +40,11 @@ defmodule Engram.VaultIsolationTest do
       assert {:error, :not_found} = Notes.get_note(user, vault_b, "test.md")
     end
 
-    test "note in vault_b is not visible from vault_a", %{user: user, vault_a: vault_a, vault_b: vault_b} do
+    test "note in vault_b is not visible from vault_a", %{
+      user: user,
+      vault_a: vault_a,
+      vault_b: vault_b
+    } do
       {:ok, _} =
         Notes.upsert_note(user, vault_b, %{
           "path" => "test.md",

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -1,12 +1,47 @@
 defmodule Engram.VaultsTest do
   use Engram.DataCase, async: true
 
+  import Ecto.Query
+
   alias Engram.Vaults
+  alias Engram.Vaults.Vault
 
   setup do
     user = insert(:user)
     other_user = insert(:user)
     %{user: user, other_user: other_user}
+  end
+
+  describe "B.2.6 — name decrypt on read" do
+    test "list_vaults returns decrypt-sourced name even when plaintext name is tampered",
+         %{user: user} do
+      {:ok, created} = Vaults.create_vault(user, %{name: "My Real Vault"})
+
+      Repo.update_all(
+        from(v in Vault, where: v.id == ^created.id),
+        [set: [name: "TAMPERED"]],
+        skip_tenant_check: true
+      )
+
+      vaults = Vaults.list_vaults(user)
+      assert [vault] = vaults
+      assert vault.id == created.id
+      assert vault.name == "My Real Vault"
+    end
+
+    test "get_vault returns decrypt-sourced name even when plaintext name is tampered",
+         %{user: user} do
+      {:ok, created} = Vaults.create_vault(user, %{name: "Vault Alpha"})
+
+      Repo.update_all(
+        from(v in Vault, where: v.id == ^created.id),
+        [set: [name: "TAMPERED"]],
+        skip_tenant_check: true
+      )
+
+      assert {:ok, vault} = Vaults.get_vault(user, created.id)
+      assert vault.name == "Vault Alpha"
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/vector/qdrant_test.exs
+++ b/test/engram/vector/qdrant_test.exs
@@ -71,6 +71,48 @@ defmodule Engram.Vector.QdrantTest do
     end
   end
 
+  describe "set_payload/3" do
+    test "patches payload onto specific point ids without re-upserting vectors", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/test_col/points/payload", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+
+        assert decoded["points"] == ["uuid-1", "uuid-2"]
+        assert decoded["payload"]["path_hmac"] == "AAAA"
+        assert decoded["payload"]["folder_hmac"] == "BBBB"
+        assert decoded["payload"]["tags_hmac"] == ["TTTT"]
+        # Vectors must NOT be sent — set_payload is a payload-only PATCH.
+        refute Map.has_key?(decoded, "vectors")
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": {"status": "acknowledged"}}))
+      end)
+
+      payload = %{path_hmac: "AAAA", folder_hmac: "BBBB", tags_hmac: ["TTTT"]}
+      assert :ok = Qdrant.set_payload("test_col", ["uuid-1", "uuid-2"], payload)
+    end
+
+    test "returns :ok on empty point list without HTTP call", %{bypass: bypass} do
+      # No Bypass.expect — any call would fail the test
+      Bypass.stub(bypass, "POST", "/collections/test_col/points/payload", fn _ ->
+        flunk("set_payload must not call Qdrant for empty point list")
+      end)
+
+      assert :ok = Qdrant.set_payload("test_col", [], %{path_hmac: "x"})
+    end
+
+    test "returns error on non-200 response", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/test_col/points/payload", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(400, ~s({"status":{"error":"bad request"}}))
+      end)
+
+      assert {:error, {400, _}} = Qdrant.set_payload("test_col", ["uuid-1"], %{path_hmac: "x"})
+    end
+  end
+
   describe "delete_by_vault/3" do
     test "posts correct filter with user_id and vault_id must conditions", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/collections/test_col/points/delete", fn conn ->

--- a/test/engram/vector/qdrant_test.exs
+++ b/test/engram/vector/qdrant_test.exs
@@ -226,6 +226,56 @@ defmodule Engram.Vector.QdrantTest do
       assert hd(results).score == 0.95
     end
 
+    test "translates :folder_hmac opt to folder_hmac filter key (Phase B.2.3)",
+         %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/test_col/points/query", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+        conditions = decoded["filter"]["must"]
+
+        cond = Enum.find(conditions, &(&1["key"] == "folder_hmac"))
+        assert cond, "expected a folder_hmac filter, got #{inspect(conditions)}"
+        assert cond["match"]["value"] == "FOLDER-HMAC-B64"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"result" => []}))
+      end)
+
+      vector = List.duplicate(0.1, 1024)
+
+      assert {:ok, []} =
+               Qdrant.search("test_col", vector,
+                 user_id: "1",
+                 folder_hmac: "FOLDER-HMAC-B64"
+               )
+    end
+
+    test "translates :tags_hmac opt to tags_hmac filter with match.any (Phase B.2.3)",
+         %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/test_col/points/query", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+        conditions = decoded["filter"]["must"]
+
+        cond = Enum.find(conditions, &(&1["key"] == "tags_hmac"))
+        assert cond, "expected a tags_hmac filter, got #{inspect(conditions)}"
+        assert Enum.sort(cond["match"]["any"]) == Enum.sort(["HASH-A", "HASH-B"])
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"result" => []}))
+      end)
+
+      vector = List.duplicate(0.1, 1024)
+
+      assert {:ok, []} =
+               Qdrant.search("test_col", vector,
+                 user_id: "1",
+                 tags_hmac: ["HASH-A", "HASH-B"]
+               )
+    end
+
     test "includes binary quantization rescore params", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/collections/test_col/points/query", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)

--- a/test/engram/workers/qdrant_payload_phase_b_test.exs
+++ b/test/engram/workers/qdrant_payload_phase_b_test.exs
@@ -1,0 +1,239 @@
+defmodule Engram.Workers.QdrantPayloadPhaseBTest do
+  @moduledoc """
+  Phase B.2.5 — re-upsert worker drives `Qdrant.set_payload` (PATCH) for every
+  pre-Phase-B point so HMAC keys land in Qdrant payloads without paying for
+  Voyage re-embedding. Cursor-driven, idempotent on retry.
+  """
+
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Notes
+  alias Engram.Notes.Chunk
+  alias Engram.Repo
+  alias Engram.Workers.QdrantPayloadPhaseB
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+    on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
+
+    {:ok, user} = insert(:user) |> Engram.Crypto.ensure_user_dek()
+    vault = insert(:vault, user: user)
+    %{bypass: bypass, user: user, vault: vault}
+  end
+
+  describe "perform/1" do
+    test "PATCHes path_hmac/folder_hmac/tags_hmac onto every chunk point of every note",
+         %{bypass: bypass, user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Health/Iron Panel.md",
+          "content" => "---\ntags: [health, labs]\n---\n# Iron Panel\n\nFerritin levels."
+        })
+
+      # Insert two chunk rows with known qdrant_point_ids so we can assert the
+      # PATCH targets exactly those ids. Bypass schema-level constraints with
+      # skip_tenant_check (this is a test fixture, not a tenant operation).
+      point_id_1 = Ecto.UUID.generate()
+      point_id_2 = Ecto.UUID.generate()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(
+        Chunk,
+        [
+          %{
+            note_id: note.id,
+            user_id: user.id,
+            vault_id: vault.id,
+            position: 0,
+            heading_path: "Iron Panel",
+            char_start: 0,
+            char_end: 10,
+            qdrant_point_id: point_id_1,
+            created_at: now
+          },
+          %{
+            note_id: note.id,
+            user_id: user.id,
+            vault_id: vault.id,
+            position: 1,
+            heading_path: "Iron Panel",
+            char_start: 10,
+            char_end: 20,
+            qdrant_point_id: point_id_2,
+            created_at: now
+          }
+        ],
+        skip_tenant_check: true
+      )
+
+      test_pid = self()
+
+      Bypass.expect(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:set_payload, Jason.decode!(body)})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": {"status": "acknowledged"}}))
+      end)
+
+      :ok =
+        perform_job(QdrantPayloadPhaseB, %{
+          "user_id" => user.id,
+          "vault_id" => vault.id,
+          "last_id" => 0
+        })
+
+      assert_receive {:set_payload, decoded}, 1_000
+
+      assert Enum.sort(decoded["points"]) == Enum.sort([point_id_1, point_id_2])
+
+      payload = decoded["payload"]
+      assert is_binary(payload["path_hmac"])
+      assert is_binary(payload["folder_hmac"])
+      assert is_list(payload["tags_hmac"])
+      assert length(payload["tags_hmac"]) == 2
+
+      # The HMACs in the payload must equal the base64-encoded values stored on
+      # the note row (Phase B.1 backfill is the source of truth for HMACs).
+      reloaded = Repo.get!(Engram.Notes.Note, note.id, skip_tenant_check: true)
+      assert payload["path_hmac"] == Base.encode64(reloaded.path_hmac)
+      assert payload["folder_hmac"] == Base.encode64(reloaded.folder_hmac)
+
+      assert Enum.sort(payload["tags_hmac"]) ==
+               Enum.sort(Enum.map(reloaded.tags_hmac, &Base.encode64/1))
+    end
+
+    test "skips notes with no chunks (no PATCH call)", %{bypass: bypass, user: user, vault: vault} do
+      # upsert_note populates path_hmac etc but does not synchronously create
+      # chunks (those come via EmbedNote async). So this note has zero chunks.
+      {:ok, _note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "empty.md",
+          "content" => "x",
+          "tags" => []
+        })
+
+      Bypass.stub(bypass, "POST", "/collections/engram_notes/points/payload", fn _ ->
+        flunk("set_payload must not be called when a note has no chunks")
+      end)
+
+      :ok =
+        perform_job(QdrantPayloadPhaseB, %{
+          "user_id" => user.id,
+          "vault_id" => vault.id,
+          "last_id" => 0
+        })
+    end
+
+    test "re-enqueues with new cursor when batch is full",
+         %{bypass: bypass, user: user, vault: vault} do
+      # Fill a batch (100). No chunks needed — the cursor advances on note ids
+      # regardless of whether each note had any Qdrant points.
+      for i <- 1..100 do
+        {:ok, _} =
+          Notes.upsert_note(user, vault, %{
+            "path" => "batch/n-#{i}.md",
+            "content" => "c",
+            "tags" => []
+          })
+      end
+
+      Bypass.stub(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": {"status": "acknowledged"}}))
+      end)
+
+      :ok =
+        perform_job(QdrantPayloadPhaseB, %{
+          "user_id" => user.id,
+          "vault_id" => vault.id,
+          "last_id" => 0
+        })
+
+      assert_enqueued(worker: QdrantPayloadPhaseB)
+    end
+
+    test "returns :ok and does not re-enqueue when batch is empty",
+         %{bypass: bypass, user: user, vault: vault} do
+      Bypass.stub(bypass, "POST", "/collections/engram_notes/points/payload", fn _ ->
+        flunk("Qdrant must not be called for an empty batch")
+      end)
+
+      :ok =
+        perform_job(QdrantPayloadPhaseB, %{
+          "user_id" => user.id,
+          "vault_id" => vault.id,
+          "last_id" => 0
+        })
+
+      refute_enqueued(worker: QdrantPayloadPhaseB)
+    end
+
+    test "is idempotent — second run with same cursor is a no-op for already-walked notes",
+         %{bypass: bypass, user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "idem.md",
+          "content" => "c",
+          "tags" => ["t"]
+        })
+
+      point_id = Ecto.UUID.generate()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(
+        Chunk,
+        [
+          %{
+            note_id: note.id,
+            user_id: user.id,
+            vault_id: vault.id,
+            position: 0,
+            heading_path: "h",
+            char_start: 0,
+            char_end: 1,
+            qdrant_point_id: point_id,
+            created_at: now
+          }
+        ],
+        skip_tenant_check: true
+      )
+
+      call_count = :counters.new(1, [:atomics])
+
+      Bypass.expect(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+        :counters.add(call_count, 1, 1)
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": {"status": "acknowledged"}}))
+      end)
+
+      # First run — patches the one note.
+      :ok =
+        perform_job(QdrantPayloadPhaseB, %{
+          "user_id" => user.id,
+          "vault_id" => vault.id,
+          "last_id" => 0
+        })
+
+      assert :counters.get(call_count, 1) == 1
+
+      # Resume from past the last walked id — should be a no-op.
+      last = note.id
+
+      :ok =
+        perform_job(QdrantPayloadPhaseB, %{
+          "user_id" => user.id,
+          "vault_id" => vault.id,
+          "last_id" => last
+        })
+
+      assert :counters.get(call_count, 1) == 1
+    end
+  end
+end

--- a/test/engram_web/channels/sync_channel_test.exs
+++ b/test/engram_web/channels/sync_channel_test.exs
@@ -6,6 +6,8 @@ defmodule EngramWeb.SyncChannelTest do
   setup do
     user = insert(:user)
     other_user = insert(:user)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, other_user} = Engram.Crypto.ensure_user_dek(other_user)
     vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "channel-test")
 
@@ -129,7 +131,10 @@ defmodule EngramWeb.SyncChannelTest do
                subscribe_and_join(socket, EngramWeb.SyncChannel, "sync:#{user.id}")
     end
 
-    test "unrestricted key (no api_key_vaults rows) can join any vault", %{user: user, vault: vault} do
+    test "unrestricted key (no api_key_vaults rows) can join any vault", %{
+      user: user,
+      vault: vault
+    } do
       {:ok, _raw, api_key_record} = Engram.Accounts.create_api_key(user, "unrestricted-chan")
 
       socket = user_socket(user, api_key_record)
@@ -156,7 +161,11 @@ defmodule EngramWeb.SyncChannelTest do
       assert note["version"] == 1
     end
 
-    test "broadcasts note_changed to other subscribers", %{socket: socket, user: user, vault: vault} do
+    test "broadcasts note_changed to other subscribers", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
       # Second subscriber on the same channel topic
       other_socket = user_socket(user)
       {:ok, _, _} = join_sync(other_socket, user, vault)
@@ -184,7 +193,11 @@ defmodule EngramWeb.SyncChannelTest do
 
       # Notes context uses Endpoint.broadcast (not broadcast_from!), so sender
       # also receives the note_changed event. Clients should deduplicate by path/version.
-      assert_push "note_changed", %{"event_type" => "upsert", "path" => "Test/Echo.md", "content" => "# Echo"}
+      assert_push "note_changed", %{
+        "event_type" => "upsert",
+        "path" => "Test/Echo.md",
+        "content" => "# Echo"
+      }
     end
 
     test "sanitizes path in push_note", %{socket: socket} do
@@ -223,7 +236,11 @@ defmodule EngramWeb.SyncChannelTest do
       assert {:error, :not_found} = Notes.get_note(user, vault, "Test/ToDelete.md")
     end
 
-    test "broadcasts note_changed with event_type delete", %{socket: socket, user: user, vault: vault} do
+    test "broadcasts note_changed with event_type delete", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
       Notes.upsert_note(user, vault, %{
         "path" => "Test/Gone.md",
         "content" => "# Gone",
@@ -236,6 +253,7 @@ defmodule EngramWeb.SyncChannelTest do
         "event_type" => "delete",
         "path" => "Test/Gone.md"
       }
+
       # Notes context broadcasts via Endpoint.broadcast (includes sender)
     end
 
@@ -267,7 +285,11 @@ defmodule EngramWeb.SyncChannelTest do
       assert note["path"] == "Test/Renamed.md"
     end
 
-    test "broadcasts note_changed for old and new path", %{socket: socket, user: user, vault: vault} do
+    test "broadcasts note_changed for old and new path", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
       Notes.upsert_note(user, vault, %{
         "path" => "Test/MoveSrc.md",
         "content" => "# Move",

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -7,6 +7,7 @@ defmodule EngramWeb.McpControllerTest do
 
   setup %{conn: conn} do
     user = insert(:user)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
@@ -537,6 +538,7 @@ defmodule EngramWeb.McpControllerTest do
   describe "MCP vault switching with restricted API key" do
     setup do
       user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
       vault_a = insert(:vault, user: user, is_default: true, name: "Vault A")
 
       # Override limit so user can have 2 vaults

--- a/test/mix/tasks/engram_qdrant_payload_phase_b_test.exs
+++ b/test/mix/tasks/engram_qdrant_payload_phase_b_test.exs
@@ -12,10 +12,10 @@ defmodule Mix.Tasks.Engram.QdrantPayloadPhaseBTest do
   alias Mix.Tasks.Engram.QdrantPayloadPhaseB
 
   describe "gather_pairs/0" do
-    test "returns {user_id, vault_id} pairs that have chunks" do
+    test "returns {user_id, vault_id} pairs that have chunks, excluding chunkless vaults" do
       user = insert(:user)
       vault = insert(:vault, user: user)
-      _other_vault = insert(:vault, user: user)
+      chunkless_vault = insert(:vault, user: user)
 
       now = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -40,6 +40,7 @@ defmodule Mix.Tasks.Engram.QdrantPayloadPhaseBTest do
       pairs = QdrantPayloadPhaseB.gather_pairs()
 
       assert {user.id, vault.id} in pairs
+      refute {user.id, chunkless_vault.id} in pairs
     end
 
     test "deduplicates pairs across many chunks of the same (user, vault)" do

--- a/test/mix/tasks/engram_qdrant_payload_phase_b_test.exs
+++ b/test/mix/tasks/engram_qdrant_payload_phase_b_test.exs
@@ -1,0 +1,105 @@
+defmodule Mix.Tasks.Engram.QdrantPayloadPhaseBTest do
+  @moduledoc """
+  Phase B.2.5 — mix task that enqueues `Engram.Workers.QdrantPayloadPhaseB`
+  jobs from the chunks table. Skips (user, vault) pairs with no chunks
+  (nothing to PATCH in Qdrant).
+  """
+
+  use Engram.DataCase, async: false
+
+  alias Engram.Notes.Chunk
+  alias Engram.Repo
+  alias Mix.Tasks.Engram.QdrantPayloadPhaseB
+
+  describe "gather_pairs/0" do
+    test "returns {user_id, vault_id} pairs that have chunks" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      _other_vault = insert(:vault, user: user)
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(
+        Chunk,
+        [
+          %{
+            note_id: insert_note_for(user, vault).id,
+            user_id: user.id,
+            vault_id: vault.id,
+            position: 0,
+            heading_path: "h",
+            char_start: 0,
+            char_end: 1,
+            qdrant_point_id: Ecto.UUID.generate(),
+            created_at: now
+          }
+        ],
+        skip_tenant_check: true
+      )
+
+      pairs = QdrantPayloadPhaseB.gather_pairs()
+
+      assert {user.id, vault.id} in pairs
+    end
+
+    test "deduplicates pairs across many chunks of the same (user, vault)" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      note = insert_note_for(user, vault)
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all(
+        Chunk,
+        for i <- 0..4 do
+          %{
+            note_id: note.id,
+            user_id: user.id,
+            vault_id: vault.id,
+            position: i,
+            heading_path: "h",
+            char_start: i * 10,
+            char_end: i * 10 + 5,
+            qdrant_point_id: Ecto.UUID.generate(),
+            created_at: now
+          }
+        end,
+        skip_tenant_check: true
+      )
+
+      pairs = QdrantPayloadPhaseB.gather_pairs()
+
+      assert Enum.count(pairs, fn p -> p == {user.id, vault.id} end) == 1
+    end
+
+    test "excludes (user, vault) pairs that have zero chunks" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      _note_without_chunks = insert_note_for(user, vault)
+
+      pairs = QdrantPayloadPhaseB.gather_pairs()
+
+      refute {user.id, vault.id} in pairs
+    end
+
+    test "returns empty list when no chunks exist anywhere" do
+      assert QdrantPayloadPhaseB.gather_pairs() == []
+    end
+  end
+
+  defp insert_note_for(user, vault) do
+    {:ok, note} =
+      Repo.with_tenant(user.id, fn ->
+        Engram.Notes.Note.changeset(%Engram.Notes.Note{}, %{
+          path: "fixtures/n-#{System.unique_integer([:positive])}.md",
+          folder: "fixtures",
+          content: "x",
+          tags: [],
+          user_id: user.id,
+          vault_id: vault.id
+        })
+        |> Repo.insert!()
+      end)
+
+    note
+  end
+end


### PR DESCRIPTION
## Summary

Phase B.2 of the [Tier 2 encryption plan](https://github.com/Rasbandit/Engram/blob/main/../engram-workspace/docs/encryption-tier-2-plan.md) — the **read switch**. Every code path that previously located rows by plaintext `path`/`folder`/`tags` now uses the HMAC fingerprints written by Phase B.1; every controller response is sourced from decrypted ciphertext, not plaintext columns. After this PR ships, the plaintext columns are write-only and unreferenced for any read; B.3 will drop them.

## What changes

| Sub-task | Scope | Commit |
|---|---|---|
| **B.2.0** | version bump to 0.5.26 | `a2b02ac` |
| **B.2.1** | `Notes.get_note` / `rename_note` / `rename_folder` / `delete_note` route through `path_hmac` lookups; B.1 dual-write rename-gap fix (rename ops now recompute path/folder ciphertext + hmacs in `update_all`) | `c2eb38b` |
| **B.2.2** | `Notes.list_folders` + `list_folders_with_counts` use `DISTINCT ON folder_hmac` + decrypt | `19a907b` |
| **B.2.4** | `Indexing.build_prepared/4` writes `path_hmac`/`folder_hmac`/`tags_hmac` (base64) into Qdrant payload — additive, prepares the shape for B.2.5 | `10a2e0b` |
| **B.2.5** | New `Engram.Workers.QdrantPayloadPhaseB` + `Qdrant.set_payload/3` helper. Cursor-driven Oban worker on `:crypto_backfill`, PATCHes HMAC keys onto every existing point — no Voyage re-embedding | `a0da59b` |
| **B.2.3** | `Search.do_search/4` derives `filter_key`, hmacs `:folder` + `:tags` opts. `Qdrant.search/3` flips filter keys from `\"folder\"`/`\"tags\"` to `\"folder_hmac\"`/`\"tags_hmac\"` | `3e0ad8b` |
| **B.2.6** | `Crypto.maybe_decrypt_note_fields/2` extended for `path`/`folder`. New helpers for attachments + vaults. `list_notes_in_folder` / `get_attachment` / `delete_attachment` filter by HMAC. Latent `ensure_user_dek` data-corruption bug fixed (see below) | `fe1c297`, `414609b`, `515b8df` |

## Notable: latent data-corruption bug fixed

`Crypto.ensure_user_dek/1` previously always generated a NEW DEK whenever its argument's in-memory `encrypted_dek` was nil — even if the DB already had one provisioned. Two `Vaults.create_vault` calls with the same stale user struct → DEK rotated twice → first vault's `name_ciphertext` becomes undecryptable.

Latent because reads didn't actually decrypt these fields until B.2.6. Surfaced via spurious decrypt-failure log noise in vaults_test. Fix reloads from DB before deciding to generate; auto-provision only runs when the DB is also empty.

## Migration & deploy ordering (IMPORTANT)

Qdrant has no `ALTER TABLE` equivalent — existing points must be physically re-PATCHed BEFORE the read switch can flip. Required deploy order:

1. **Merge & deploy this PR** — fresh writes will get HMAC payload keys (B.2.4).
2. **Run `mix engram.qdrant_payload_phase_b`** (or RPC equivalent in prod) — backfills every existing point.
3. **Soak** — verify search still returns hits for filtered queries (folder/tags). At this point reads are already going through `folder_hmac` / `tags_hmac` so step 2 is the load-bearing one.
4. **B.3** can then drop plaintext `path`/`folder`/`name` columns + plaintext `tags` array.

If step 2 is skipped, filtered searches (`folder:` / `tags:`) will return empty for any pre-B.2.4 point because the new filter keys don't exist on those payloads.

## Lessons from the implementation (added to plan doc)

1. **B.1 dual-write only fired in `upsert_note`** — bulk `update_all` paths in `rename_note` / `rename_folder` / rename tombstones missed the path/folder ciphertext + hmac sync. Found by failing tests right after B.2.1's read switch went live. Project invariant: every path that mutates a Phase B field must route through `phase_b_keyword_for/4`.
2. **`Repo.with_tenant/2` does not nest safely** — its `after Process.delete(:engram_tenant)` clobbers parent context. Worked around by splitting helpers (one opens tenant, one returns just the query). Worth a separate fix.
3. **Brand-new users have no DEK on first read.** Pattern for all Phase B aggregations: `case dek_filter_key(user) do {:ok, _} -> ... ; {:error, :no_dek} -> {:ok, []}` — don't auto-provision DEK on a GET.
4. **Qdrant migration order is reverse of Postgres** — additive write → backfill → read flip. Use `set_payload` to avoid re-embedding.

## Tests

- 905 tests / 0 failures locally.
- New invariant tests under each context: tampering the plaintext `path`/`folder`/`tags`/`name` column must NOT change controller-visible response. This becomes the load-bearing assertion for B.3 column-drop readiness.
- New worker tests cover happy path, no-op on chunkless notes, no-op on empty batch, re-enqueue on full batch, idempotent second run.

## Test plan

- [x] Local `mix test` — 905 / 0
- [ ] CI green
- [ ] Smoke on saas: filtered search by folder + tags returns expected hits
- [ ] Run `mix engram.qdrant_payload_phase_b` on saas; tail Oban for completion
- [ ] Re-smoke filtered search
- [ ] Sample N notes; verify path_ciphertext + plaintext path agree (B.1 invariant still holds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)