### PR TITLE
feat(crypto): encryption tier-3 phase T3.0 — bleeders bundle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,7 @@ docs
 *.md
 !README.md
 .worktrees
+# T3.0.3 — never bake a BEAM crash dump into a Docker image. May contain
+# plaintext DEKs / master key from process heap at the moment of crash.
+erl_crash.dump
+**/erl_crash.dump

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,4 +82,10 @@ EXPOSE 4000
 
 ENV PHX_SERVER=true
 
+# T3.0.3 — refuse to write erl_crash.dump on BEAM crash. The dump would
+# include plaintext DEKs (ETS) + master key (LocalKeyProvider state) from
+# process heap. Unraid templates also set this; this line is the defense-
+# in-depth default so a template that drifts can't open the leak.
+ENV ERL_CRASH_DUMP_BYTES=0
+
 CMD /app/bin/engram eval "Engram.Release.migrate()" && exec /app/bin/engram start

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -219,7 +219,11 @@ if config_env() == :prod do
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     # For machines with several cores, consider starting multiple pools of `pool_size`
     # pool_count: 4,
-    socket_options: maybe_ipv6
+    socket_options: maybe_ipv6,
+    # T3.0.2 — defense-in-depth. Prevents Ecto SQL params (path, folder,
+    # tags, wrapped DEK on UPDATE) from hitting :debug logs if anyone
+    # bumps prod log level. Audit-only; prod log level today is :info.
+    log: false
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/lib/engram/accounts/user.ex
+++ b/lib/engram/accounts/user.ex
@@ -1,15 +1,19 @@
 defmodule Engram.Accounts.User do
   use Ecto.Schema
 
+  # T3.0.5 — Allowlist serialization. Anything not listed is invisible to
+  # Jason.encode!/1 even if a future controller does `json(conn, %{user: user})`.
+  @derive {Jason.Encoder, only: [:id, :email, :role, :display_name, :created_at, :updated_at]}
+
   schema "users" do
     field :email, :string
     field :external_id, :string
-    field :password_hash, :string
+    field :password_hash, :string, redact: true
     field :role, :string, default: "member"
     field :display_name, :string
-    field :encrypted_dek, :binary
-    field :dek_version, :integer, default: 1
-    field :key_provider, :string, default: "local"
+    field :encrypted_dek, :binary, redact: true
+    field :dek_version, :integer, default: 1, redact: true
+    field :key_provider, :string, default: "local", redact: true
 
     belongs_to :plan, Engram.Billing.Plan
     has_many :notes, Engram.Notes.Note

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -123,9 +123,10 @@ defmodule Engram.Crypto do
   end
 
   defp needs_note_decrypt?(%Engram.Notes.Note{} = note) do
-    # T3.0.4 — include tags_ciphertext. Sub-helpers short-circuit on each
-    # field's own nil, but the outer gate must trigger if *any* ciphertext
-    # is present, otherwise tags-only rows skip decrypt silently.
+    # T3.0.4 — gate on the three independent ciphertext "groups." Sub-helpers
+    # short-circuit on each field's own nil, so we only need to check one
+    # representative per group: content (with title), path (with folder),
+    # and tags (standalone). Any group present → load DEK + run decrypt.
     not is_nil(note.content_ciphertext) or
       not is_nil(note.path_ciphertext) or
       not is_nil(note.tags_ciphertext)

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -122,8 +122,14 @@ defmodule Engram.Crypto do
     end
   end
 
-  defp needs_note_decrypt?(%Engram.Notes.Note{} = note),
-    do: not is_nil(note.content_ciphertext) or not is_nil(note.path_ciphertext)
+  defp needs_note_decrypt?(%Engram.Notes.Note{} = note) do
+    # T3.0.4 — include tags_ciphertext. Sub-helpers short-circuit on each
+    # field's own nil, but the outer gate must trigger if *any* ciphertext
+    # is present, otherwise tags-only rows skip decrypt silently.
+    not is_nil(note.content_ciphertext) or
+      not is_nil(note.path_ciphertext) or
+      not is_nil(note.tags_ciphertext)
+  end
 
   defp decrypt_phase_4_note_fields(%Engram.Notes.Note{content_ciphertext: nil} = note, _dek),
     do: {:ok, note}

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -64,5 +64,6 @@ defmodule EngramWeb.BillingController do
     [code: e.code, message: e.message, request_id: e.request_id]
   end
 
-  defp stripe_error_meta(other), do: [reason: inspect(other)]
+  # Logger metadata helper only — both call sites pipe into Logger.error/2.
+  defp stripe_error_meta(other), do: [reason: inspect(other)] # noqa: T3.0.6 — Logger metadata only
 end

--- a/lib/engram_web/controllers/health_controller.ex
+++ b/lib/engram_web/controllers/health_controller.ex
@@ -20,10 +20,15 @@ defmodule EngramWeb.HealthController do
     |> json(%{status: status, checks: checks})
   end
 
+  # T3.0.1 follow-up — never `inspect/1` an error reason into a JSON
+  # response body. Postgrex / Mint structs interpolated via inspect can
+  # carry connection strings, hostnames, or dependency-internal shapes.
+  # `format_error/1` keeps the message low-cardinality and predictable.
+
   defp check_postgres do
     case Ecto.Adapters.SQL.query(Engram.Repo, "SELECT 1", []) do
       {:ok, _} -> "ok"
-      {:error, reason} -> "error: #{inspect(reason)}"
+      {:error, reason} -> "error: #{format_error(reason)}"
     end
   rescue
     e -> "error: #{Exception.message(e)}"
@@ -35,9 +40,13 @@ defmodule EngramWeb.HealthController do
     case Req.get("#{qdrant_url}/healthz", receive_timeout: 5_000, retry: false) do
       {:ok, %{status: status}} when status in 200..299 -> "ok"
       {:ok, %{status: status}} -> "error: status #{status}"
-      {:error, reason} -> "error: #{inspect(reason)}"
+      {:error, reason} -> "error: #{format_error(reason)}"
     end
   rescue
     e -> "error: #{Exception.message(e)}"
   end
+
+  defp format_error(%{__exception__: true} = e), do: Exception.message(e)
+  defp format_error(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_error(_), do: "internal"
 end

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -82,11 +82,23 @@ defmodule EngramWeb.McpController do
     end
   catch
     kind, reason ->
+      # T3.0.1 follow-up — never `inspect/1` an exit/throw reason into a
+      # response body. The reason can be an arbitrary term originating
+      # deep in the call stack (including %Note{} virtual decrypted fields
+      # if the throw came out of a crypto path). Log structured details
+      # server-side; surface a low-cardinality label to the client.
+      require Logger
+
+      Logger.error("mcp tool dispatch trapped",
+        kind: kind,
+        reason_label: classify_throw_reason(reason)
+      )
+
       message =
         case kind do
           :error -> Exception.message(reason)
-          :exit -> "Process exited: #{inspect(reason)}"
-          :throw -> "Unexpected throw: #{inspect(reason)}"
+          :exit -> "Process exited"
+          :throw -> "Unexpected throw"
         end
 
       {:ok,
@@ -95,6 +107,11 @@ defmodule EngramWeb.McpController do
          "isError" => true
        }}
   end
+
+  defp classify_throw_reason(reason) when is_atom(reason), do: reason
+  defp classify_throw_reason(%{__exception__: true} = e), do: e.__struct__
+  defp classify_throw_reason({tag, _}) when is_atom(tag), do: {tag, :_}
+  defp classify_throw_reason(_), do: :unknown
 
   # -- Vault resolution --
 

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -30,8 +30,14 @@ defmodule EngramWeb.NotesController do
 
         {:error, reason} ->
           require Logger
-          Logger.error("upsert_note returned unexpected error: #{inspect(reason)}")
-          conn |> put_status(500) |> json(%{error: "internal", reason: inspect(reason)})
+
+          Logger.error("upsert_note returned unexpected error",
+            reason: inspect(reason),
+            user_id: user.id,
+            vault_id: vault.id
+          )
+
+          conn |> put_status(500) |> json(%{error: "internal"})
       end
     end
   end

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -31,8 +31,14 @@ defmodule EngramWeb.NotesController do
         {:error, reason} ->
           require Logger
 
+          # T3.0.1 follow-up — log a low-cardinality label, not the raw
+          # struct. The catch-all branch can be reached with %Ecto.Changeset{},
+          # %Postgrex.Error{}, plain atoms, or future variants. Any of those
+          # could carry virtual decrypted note fields if a future regression
+          # surfaces a %Note{} inside a reason tuple. Label keeps the metric
+          # signal without the leak surface.
           Logger.error("upsert_note returned unexpected error",
-            reason: inspect(reason),
+            reason_label: classify_reason(reason),
             user_id: user.id,
             vault_id: vault.id
           )
@@ -168,4 +174,9 @@ defmodule EngramWeb.NotesController do
   end
 
   defp format_errors(changeset), do: EngramWeb.format_errors(changeset)
+
+  defp classify_reason(reason) when is_atom(reason), do: reason
+  defp classify_reason(%Ecto.Changeset{}), do: :changeset
+  defp classify_reason(%{__exception__: true} = e), do: e.__struct__
+  defp classify_reason(_), do: :unknown
 end

--- a/lib/engram_web/controllers/spa_controller.ex
+++ b/lib/engram_web/controllers/spa_controller.ex
@@ -54,7 +54,9 @@ defmodule EngramWeb.SpaController do
       case Application.get_env(:engram, :auth_provider, :local) do
         :local -> "local"
         :clerk -> "clerk"
-        other -> raise "Invalid :auth_provider config: #{inspect(other)}"
+        other ->
+          # noqa: T3.0.6 — boot-time raise; value is an app config atom, never user input.
+          raise "Invalid :auth_provider config: #{inspect(other)}" # noqa: T3.0.6
       end
 
     config = %{

--- a/lib/engram_web/controllers/webhook_controller.ex
+++ b/lib/engram_web/controllers/webhook_controller.ex
@@ -96,10 +96,11 @@ defmodule EngramWeb.WebhookController do
   # those values come from Stripe (potentially echoing emails or customer
   # input). Reduce to the error tuple list, which carries only field names
   # and validator messages.
+  # Logger metadata helper only — sole call site is Logger.warning/2 above.
   defp format_reason(%Ecto.Changeset{} = cs) do
-    Ecto.Changeset.traverse_errors(cs, fn {msg, _opts} -> msg end) |> inspect()
+    Ecto.Changeset.traverse_errors(cs, fn {msg, _opts} -> msg end) |> inspect() # noqa: T3.0.6 — Logger metadata only
   end
 
   defp format_reason(reason) when is_atom(reason), do: reason
-  defp format_reason(reason), do: inspect(reason)
+  defp format_reason(reason), do: inspect(reason) # noqa: T3.0.6 — Logger metadata only
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.29",
+      version: "0.5.30",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/accounts/user_schema_test.exs
+++ b/test/engram/accounts/user_schema_test.exs
@@ -1,0 +1,70 @@
+defmodule Engram.Accounts.UserSchemaTest do
+  # T3.0.5 — User schema must redact key material from inspect/1 and
+  # Jason.Encoder must allowlist serializable fields. Closes the
+  # `inspect(user)` regression class and the `json(conn, %{user: user})`
+  # landmine identified in the encryption tier-3 audit.
+  use Engram.DataCase, async: true
+
+  alias Engram.Accounts.User
+
+  defp user_with_secrets do
+    %User{
+      id: 1,
+      email: "alice@example.com",
+      role: "member",
+      display_name: "Alice",
+      external_id: "ext-1",
+      password_hash: "$2b$12$secrethashvalue",
+      encrypted_dek: <<0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE>>,
+      dek_version: 7,
+      key_provider: "local"
+    }
+  end
+
+  describe "inspect/1" do
+    test "masks encrypted_dek bytes" do
+      out = inspect(user_with_secrets())
+      refute out =~ "deadbeef"
+      refute out =~ "DEADBEEF"
+      refute out =~ ~r/<<0xDE/i
+      refute out =~ "encrypted_dek:"
+    end
+
+    test "drops the field entirely from inspect output (Ecto redact behavior)" do
+      out = inspect(user_with_secrets())
+      # Ecto redact: true causes inspect/1 to omit the field and emit `...` truncation marker.
+      assert out =~ "..."
+    end
+
+    test "masks password_hash" do
+      out = inspect(user_with_secrets())
+      refute out =~ "secrethashvalue"
+    end
+
+    test "masks dek_version and key_provider (defense-in-depth)" do
+      out = inspect(user_with_secrets())
+      refute out =~ "dek_version: 7"
+      refute out =~ ~s|key_provider: "local"|
+    end
+  end
+
+  describe "Jason.Encoder" do
+    test "encodes only allowlisted fields" do
+      json = Jason.encode!(user_with_secrets())
+      decoded = Jason.decode!(json)
+
+      allowed = ~w(id email role display_name created_at updated_at)
+      assert MapSet.new(Map.keys(decoded)) == MapSet.new(allowed)
+    end
+
+    test "never emits encrypted_dek, password_hash, dek_version, key_provider" do
+      json = Jason.encode!(user_with_secrets())
+      refute json =~ "encrypted_dek"
+      refute json =~ "password_hash"
+      refute json =~ "dek_version"
+      refute json =~ "key_provider"
+      refute json =~ "deadbeef"
+      refute json =~ "secrethashvalue"
+    end
+  end
+end

--- a/test/engram/accounts/user_schema_test.exs
+++ b/test/engram/accounts/user_schema_test.exs
@@ -30,11 +30,12 @@ defmodule Engram.Accounts.UserSchemaTest do
       refute out =~ "encrypted_dek:"
     end
 
-    test "drops the field entirely from inspect output (Ecto redact behavior)" do
-      out = inspect(user_with_secrets())
-      # Ecto redact: true causes inspect/1 to omit the field and emit `...` truncation marker.
-      assert out =~ "..."
-    end
+    # The contract this protects is "no sensitive bytes appear in inspect/1
+    # output." That contract is fully covered by the refute-based tests
+    # above (no `deadbeef`, no `secrethashvalue`, no `encrypted_dek:` key).
+    # Asserting the truncation marker `...` would pass for the wrong reason
+    # — Ecto's redact-derived Inspect impl varies across versions (literal
+    # `**redacted**` in some, dropped+truncated in others).
 
     test "masks password_hash" do
       out = inspect(user_with_secrets())
@@ -65,6 +66,30 @@ defmodule Engram.Accounts.UserSchemaTest do
       refute json =~ "key_provider"
       refute json =~ "deadbeef"
       refute json =~ "secrethashvalue"
+    end
+
+    test "allowlist matches the schema's actual timestamp field name" do
+      # Regression guard: the schema overrides `inserted_at: :created_at`
+      # via `timestamps/1`. If anyone reverts to the Ecto default, the
+      # allowlist's `:created_at` entry would reference a field absent
+      # from the struct. Jason raises Protocol.UndefinedError at runtime
+      # in that case. This test exercises the full encode path with a
+      # populated timestamp so the schema/allowlist pair stays in sync.
+      now = ~U[2026-05-07 12:00:00Z]
+
+      user = %User{
+        id: 42,
+        email: "ts@example.com",
+        role: "member",
+        display_name: "TS",
+        created_at: now,
+        updated_at: now
+      }
+
+      decoded = Jason.encode!(user) |> Jason.decode!()
+
+      assert decoded["created_at"] == "2026-05-07T12:00:00Z"
+      assert decoded["updated_at"] == "2026-05-07T12:00:00Z"
     end
   end
 end

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -107,6 +107,26 @@ defmodule Engram.CryptoTest do
       assert out.title == "T"
       assert out.tags == ["x"]
     end
+
+    test "decrypts tags-only row (regression: T3.0.4 / M7 gate fix)", %{user: user} do
+      # T3.0.4 — gate previously skipped decrypt when only tags_ciphertext
+      # was set (content_ciphertext + path_ciphertext both nil). Latent
+      # post-B.4, but a single ordering change in upsert could expose it.
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      {:ok, dek} = Crypto.get_dek(user)
+      tags_bin = :erlang.term_to_binary(["alpha", "beta"])
+      {tags_ct, tags_n} = Crypto.Envelope.encrypt(tags_bin, dek)
+
+      note = %Engram.Notes.Note{
+        content_ciphertext: nil,
+        path_ciphertext: nil,
+        tags_ciphertext: tags_ct,
+        tags_nonce: tags_n
+      }
+
+      {:ok, out} = Crypto.maybe_decrypt_note_fields(note, user)
+      assert out.tags == ["alpha", "beta"]
+    end
   end
 
   describe "dek_filter_key/1" do

--- a/test/engram_web/controllers/no_inspect_in_json_response_test.exs
+++ b/test/engram_web/controllers/no_inspect_in_json_response_test.exs
@@ -1,37 +1,53 @@
 defmodule EngramWeb.NoInspectInJsonResponseTest do
-  # T3.0.1 — Static source lint. `inspect(struct)` interpolated into a
-  # `json(conn, ...)` body can leak ciphertext, virtual decrypted fields,
-  # or struct internals to clients. Forbid the pattern at file scope so
-  # any future controller cannot regress.
+  # T3.0.1 — Static source lint. `inspect(...)` reaching a JSON response
+  # body can leak ciphertext, virtual decrypted fields, struct internals,
+  # connection strings, hostnames, etc. The original ban was a same-line
+  # `json(...inspect(...))` regex; reviewer feedback (PR #73) flagged that
+  # `health_controller.ex` was leaking via indirection (the `inspect/1`
+  # output was assigned into a map field 12 lines from the `json/2` call).
+  #
+  # Stronger rule: no `inspect/1` may appear *anywhere* in a controller
+  # source file, except inside an explicitly allowlisted context. Keeping
+  # error reasons out of HTTP bodies is the value here, not micro-tracking
+  # which line they reach.
   use ExUnit.Case, async: true
+
+  alias Engram.Test.SourceLint
 
   @controllers_dir Path.join([File.cwd!(), "lib/engram_web/controllers"])
 
-  test "no controller emits `inspect(...)` inside a `json(` call" do
+  # Allowlisted call contexts where `inspect/1` is fine because the result
+  # never reaches a response body.
+  @allowed_call_prefixes [
+    # Logger metadata is scrubbed by RedactFilter and never serialized.
+    "Logger.",
+    "Logger ",
+    # Telemetry metadata is server-side only.
+    ":telemetry.execute",
+    "telemetry.execute"
+  ]
+
+  # Per-line opt-out marker. Required only for known-safe call sites that
+  # the prefix allowlist can't see (e.g. helper definitions invoked exclusively
+  # from Logger metadata, or boot-time `raise` calls). Reviewers reject
+  # unjustified annotations.
+  @allow_marker "noqa: T3.0.6"
+
+  test "no controller calls `inspect/1` outside an allowlisted context" do
     offenders =
       @controllers_dir
-      |> walk_ex_files()
+      |> SourceLint.walk_ex_files()
       |> Enum.flat_map(&scan_file/1)
 
     assert offenders == [],
-           "Found `inspect(...)` inside `json(` calls — leaks struct internals to clients:\n" <>
+           "Controllers must not call `inspect/1` outside of Logger / telemetry sinks.\n" <>
+             "Use `Exception.message/1` for exception structs, or a `format_error/1`\n" <>
+             "helper for atom reasons. See health_controller.ex format_error/1.\n" <>
+             "If the call is provably safe (Logger-only helper / boot-time raise),\n" <>
+             "annotate the line with `# noqa: T3.0.6 — <reason>` AND keep it short.\n\n" <>
              Enum.map_join(offenders, "\n", fn {file, line, snippet} ->
                "  #{Path.relative_to_cwd(file)}:#{line}  #{snippet}"
              end)
-  end
-
-  defp walk_ex_files(dir) do
-    dir
-    |> File.ls!()
-    |> Enum.flat_map(fn entry ->
-      path = Path.join(dir, entry)
-
-      cond do
-        File.dir?(path) -> walk_ex_files(path)
-        String.ends_with?(entry, ".ex") -> [path]
-        true -> []
-      end
-    end)
   end
 
   defp scan_file(path) do
@@ -40,9 +56,17 @@ defmodule EngramWeb.NoInspectInJsonResponseTest do
     |> String.split("\n")
     |> Enum.with_index(1)
     |> Enum.filter(fn {line, _i} ->
-      # Anything matching `json(...inspect(...)...)` on the same source line.
-      Regex.match?(~r/json\([^)]*inspect\(/, line)
+      Regex.match?(~r/\binspect\(/, line) and
+        not SourceLint.commented?(line) and
+        not allowed_context?(line)
     end)
     |> Enum.map(fn {line, i} -> {path, i, String.trim(line)} end)
+  end
+
+  defp allowed_context?(line) do
+    String.contains?(line, @allow_marker) or
+      Enum.any?(@allowed_call_prefixes, fn prefix ->
+        String.contains?(line, prefix)
+      end)
   end
 end

--- a/test/engram_web/controllers/no_inspect_in_json_response_test.exs
+++ b/test/engram_web/controllers/no_inspect_in_json_response_test.exs
@@ -1,0 +1,48 @@
+defmodule EngramWeb.NoInspectInJsonResponseTest do
+  # T3.0.1 — Static source lint. `inspect(struct)` interpolated into a
+  # `json(conn, ...)` body can leak ciphertext, virtual decrypted fields,
+  # or struct internals to clients. Forbid the pattern at file scope so
+  # any future controller cannot regress.
+  use ExUnit.Case, async: true
+
+  @controllers_dir Path.join([File.cwd!(), "lib/engram_web/controllers"])
+
+  test "no controller emits `inspect(...)` inside a `json(` call" do
+    offenders =
+      @controllers_dir
+      |> walk_ex_files()
+      |> Enum.flat_map(&scan_file/1)
+
+    assert offenders == [],
+           "Found `inspect(...)` inside `json(` calls — leaks struct internals to clients:\n" <>
+             Enum.map_join(offenders, "\n", fn {file, line, snippet} ->
+               "  #{Path.relative_to_cwd(file)}:#{line}  #{snippet}"
+             end)
+  end
+
+  defp walk_ex_files(dir) do
+    dir
+    |> File.ls!()
+    |> Enum.flat_map(fn entry ->
+      path = Path.join(dir, entry)
+
+      cond do
+        File.dir?(path) -> walk_ex_files(path)
+        String.ends_with?(entry, ".ex") -> [path]
+        true -> []
+      end
+    end)
+  end
+
+  defp scan_file(path) do
+    path
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.filter(fn {line, _i} ->
+      # Anything matching `json(...inspect(...)...)` on the same source line.
+      Regex.match?(~r/json\([^)]*inspect\(/, line)
+    end)
+    |> Enum.map(fn {line, i} -> {path, i, String.trim(line)} end)
+  end
+end

--- a/test/engram_web/no_user_struct_leak_test.exs
+++ b/test/engram_web/no_user_struct_leak_test.exs
@@ -1,0 +1,89 @@
+defmodule EngramWeb.NoUserStructLeakTest do
+  # T3.0.6 — Static source lint. The User schema redacts key fields and
+  # the Jason.Encoder is allowlist-only (T3.0.5), but we still ban risky
+  # patterns at file scope so a future PR can never accidentally land:
+  #
+  #   * `json(conn, %{user: user})` — relies on the allowlist holding;
+  #     one accidental `@derive {Jason.Encoder, except: [...]}` flip would
+  #     leak the wrapped DEK to clients.
+  #   * `json(conn, user)`           — same, plus implicit struct serialization.
+  #   * `inspect(user)`              — relies on `redact: true` holding.
+  #
+  # Forcing explicit field projection (`%{id: user.id, email: user.email, ...}`)
+  # is one CR comment away from any reviewer. This lint catches it at PR-CI.
+  use ExUnit.Case, async: true
+
+  @lib_dir Path.join(File.cwd!(), "lib")
+
+  @forbidden [
+    {~r/json\(\s*conn\s*,\s*%\{\s*user:\s*user\b/, "json(conn, %{user: user})"},
+    {~r/json\(\s*conn\s*,\s*user\s*\)/, "json(conn, user)"},
+    {~r/\binspect\(\s*user\s*\)/, "inspect(user)"}
+  ]
+
+  describe "regex sanity (TDD: prove the lint catches what it should)" do
+    test "matches `json(conn, %{user: user})`" do
+      [{regex, _}] = Enum.filter(@forbidden, fn {_, l} -> l == "json(conn, %{user: user})" end)
+      assert Regex.match?(regex, "    json(conn, %{user: user})")
+      assert Regex.match?(regex, "json(conn, %{user: user, extra: 1})")
+      refute Regex.match?(regex, "json(conn, %{id: user.id, email: user.email})")
+    end
+
+    test "matches `json(conn, user)`" do
+      [{regex, _}] = Enum.filter(@forbidden, fn {_, l} -> l == "json(conn, user)" end)
+      assert Regex.match?(regex, "json(conn, user)")
+      refute Regex.match?(regex, "json(conn, user_payload)")
+      refute Regex.match?(regex, "json(conn, %{user: user})")
+    end
+
+    test "matches `inspect(user)`" do
+      [{regex, _}] = Enum.filter(@forbidden, fn {_, l} -> l == "inspect(user)" end)
+      assert Regex.match?(regex, ~S|Logger.error("...#{inspect(user)}")|)
+      assert Regex.match?(regex, "inspect(user)")
+      refute Regex.match?(regex, "inspect(user_id)")
+      refute Regex.match?(regex, "inspect(user_payload)")
+    end
+  end
+
+  test "no lib/ source contains banned user-struct leak patterns" do
+    offenders =
+      @lib_dir
+      |> walk_ex_files()
+      |> Enum.flat_map(&scan_file/1)
+
+    assert offenders == [],
+           "Found banned user-struct leak patterns in lib/:\n" <>
+             Enum.map_join(offenders, "\n", fn {file, line, label, snippet} ->
+               "  #{Path.relative_to_cwd(file)}:#{line}  [#{label}]  #{snippet}"
+             end)
+  end
+
+  defp walk_ex_files(dir) do
+    dir
+    |> File.ls!()
+    |> Enum.flat_map(fn entry ->
+      path = Path.join(dir, entry)
+
+      cond do
+        File.dir?(path) -> walk_ex_files(path)
+        String.ends_with?(entry, ".ex") -> [path]
+        true -> []
+      end
+    end)
+  end
+
+  defp scan_file(path) do
+    lines = path |> File.read!() |> String.split("\n") |> Enum.with_index(1)
+
+    for {line, i} <- lines,
+        not commented?(line),
+        {regex, label} <- @forbidden,
+        Regex.match?(regex, line) do
+      {path, i, label, String.trim(line)}
+    end
+  end
+
+  # Skip lines that start with `#` so the docstring/comment in the User
+  # schema referencing the banned patterns does not self-trip the lint.
+  defp commented?(line), do: Regex.match?(~r/^\s*#/, line)
+end

--- a/test/engram_web/no_user_struct_leak_test.exs
+++ b/test/engram_web/no_user_struct_leak_test.exs
@@ -9,46 +9,62 @@ defmodule EngramWeb.NoUserStructLeakTest do
   #   * `json(conn, user)`           — same, plus implicit struct serialization.
   #   * `inspect(user)`              — relies on `redact: true` holding.
   #
-  # Forcing explicit field projection (`%{id: user.id, email: user.email, ...}`)
-  # is one CR comment away from any reviewer. This lint catches it at PR-CI.
+  # Variants matter: real call sites bind users as `current_user`,
+  # `target_user`, etc. The regex set covers all common bindings.
   use ExUnit.Case, async: true
+
+  alias Engram.Test.SourceLint
 
   @lib_dir Path.join(File.cwd!(), "lib")
 
+  # Match any binding that ends in `user` (user, current_user, target_user,
+  # other_user, etc.) but not unrelated bindings like `user_id` or
+  # `user_payload`. The trailing word boundary + `\b` after the suffix
+  # prevents false positives.
+  @user_binding ~S"(?:[a-z_]+_)?user"
+
   @forbidden [
-    {~r/json\(\s*conn\s*,\s*%\{\s*user:\s*user\b/, "json(conn, %{user: user})"},
-    {~r/json\(\s*conn\s*,\s*user\s*\)/, "json(conn, user)"},
-    {~r/\binspect\(\s*user\s*\)/, "inspect(user)"}
+    {~r/json\(\s*conn\s*,\s*%\{\s*user:\s*#{@user_binding}\b/,
+     "json(conn, %{user: <user-binding>})"},
+    {~r/json\(\s*conn\s*,\s*#{@user_binding}\s*\)/, "json(conn, <user-binding>)"},
+    {~r/\binspect\(\s*#{@user_binding}\s*\)/, "inspect(<user-binding>)"}
   ]
 
   describe "regex sanity (TDD: prove the lint catches what it should)" do
-    test "matches `json(conn, %{user: user})`" do
-      [{regex, _}] = Enum.filter(@forbidden, fn {_, l} -> l == "json(conn, %{user: user})" end)
+    test "matches `json(conn, %{user: ...})` with various bindings" do
+      [{regex, _}] = pick("json(conn, %{user: <user-binding>})")
       assert Regex.match?(regex, "    json(conn, %{user: user})")
-      assert Regex.match?(regex, "json(conn, %{user: user, extra: 1})")
+      assert Regex.match?(regex, "json(conn, %{user: current_user, extra: 1})")
+      assert Regex.match?(regex, "json(conn, %{user: target_user})")
       refute Regex.match?(regex, "json(conn, %{id: user.id, email: user.email})")
     end
 
-    test "matches `json(conn, user)`" do
-      [{regex, _}] = Enum.filter(@forbidden, fn {_, l} -> l == "json(conn, user)" end)
+    test "matches bare `json(conn, <user-binding>)`" do
+      [{regex, _}] = pick("json(conn, <user-binding>)")
       assert Regex.match?(regex, "json(conn, user)")
+      assert Regex.match?(regex, "json(conn, current_user)")
+      assert Regex.match?(regex, "json(conn, target_user)")
       refute Regex.match?(regex, "json(conn, user_payload)")
+      refute Regex.match?(regex, "json(conn, user_id)")
       refute Regex.match?(regex, "json(conn, %{user: user})")
     end
 
-    test "matches `inspect(user)`" do
-      [{regex, _}] = Enum.filter(@forbidden, fn {_, l} -> l == "inspect(user)" end)
+    test "matches `inspect(<user-binding>)`" do
+      [{regex, _}] = pick("inspect(<user-binding>)")
       assert Regex.match?(regex, ~S|Logger.error("...#{inspect(user)}")|)
       assert Regex.match?(regex, "inspect(user)")
+      assert Regex.match?(regex, "inspect(current_user)")
       refute Regex.match?(regex, "inspect(user_id)")
       refute Regex.match?(regex, "inspect(user_payload)")
     end
+
+    defp pick(label), do: Enum.filter(@forbidden, fn {_, l} -> l == label end)
   end
 
   test "no lib/ source contains banned user-struct leak patterns" do
     offenders =
       @lib_dir
-      |> walk_ex_files()
+      |> SourceLint.walk_ex_files()
       |> Enum.flat_map(&scan_file/1)
 
     assert offenders == [],
@@ -58,32 +74,14 @@ defmodule EngramWeb.NoUserStructLeakTest do
              end)
   end
 
-  defp walk_ex_files(dir) do
-    dir
-    |> File.ls!()
-    |> Enum.flat_map(fn entry ->
-      path = Path.join(dir, entry)
-
-      cond do
-        File.dir?(path) -> walk_ex_files(path)
-        String.ends_with?(entry, ".ex") -> [path]
-        true -> []
-      end
-    end)
-  end
-
   defp scan_file(path) do
     lines = path |> File.read!() |> String.split("\n") |> Enum.with_index(1)
 
     for {line, i} <- lines,
-        not commented?(line),
+        not SourceLint.commented?(line),
         {regex, label} <- @forbidden,
         Regex.match?(regex, line) do
       {path, i, label, String.trim(line)}
     end
   end
-
-  # Skip lines that start with `#` so the docstring/comment in the User
-  # schema referencing the banned patterns does not self-trip the lint.
-  defp commented?(line), do: Regex.match?(~r/^\s*#/, line)
 end

--- a/test/support/source_lint.ex
+++ b/test/support/source_lint.ex
@@ -1,0 +1,34 @@
+defmodule Engram.Test.SourceLint do
+  @moduledoc """
+  Shared helpers for static-source lint tests.
+
+  Used by encryption tier-3 lint tests to walk `lib/` (or any subtree) and
+  flag forbidden patterns at PR-CI time. Centralized so that adding a new
+  lint test does not duplicate the directory walker / comment skipper.
+  """
+
+  @doc "Recursively collect every `*.ex` file under `dir`."
+  @spec walk_ex_files(Path.t()) :: [Path.t()]
+  def walk_ex_files(dir) do
+    dir
+    |> File.ls!()
+    |> Enum.flat_map(fn entry ->
+      path = Path.join(dir, entry)
+
+      cond do
+        File.dir?(path) -> walk_ex_files(path)
+        String.ends_with?(entry, ".ex") -> [path]
+        true -> []
+      end
+    end)
+  end
+
+  @doc """
+  True when the line starts (after optional leading whitespace) with `#`.
+
+  Used so that lint tests can document the patterns they ban *inside* the
+  test file's own code without self-tripping the lint.
+  """
+  @spec commented?(String.t()) :: boolean()
+  def commented?(line), do: Regex.match?(~r/^\s*#/, line)
+end


### PR DESCRIPTION
## Summary

Phase **T3.0** of the encryption tier-3 hardening plan (`docs/encryption-tier-3-audit.md`). Cheap, high-value fixes that close the loudest leak surfaces identified by the six-lens audit on 2026-05-07. Bundled in one PR per the plan's "stop the bleeding" framing.

Each commit is an independent fix with its own test where testable.

| Commit | Audit ID | What it closes |
|---|---|---|
| `feat(crypto): redact User key fields + allowlist Jason.Encoder` | **T3.0.5** | `inspect(user)` regression class + `json(conn, %{user: user})` landmine |
| `fix(crypto): strip inspect(reason) from notes upsert 500 body` | **T3.0.1 / H4** | Note ciphertext / virtual-decrypted-fields leak via 500 response body |
| `fix(crypto): gate needs_note_decrypt? on tags_ciphertext too` | **T3.0.4 / M7** | Tags-only row silently skipping decrypt |
| `fix(crypto): silence Ecto SQL params in prod logs` | **T3.0.2 / M6** | Wrapped DEK on UPDATE leaking to log if log level bumps |
| `fix(crypto): refuse BEAM crash dumps in prod images` | **T3.0.3 / M9** | Plaintext DEK + master key in `erl_crash.dump` on host volume |
| `test(crypto): CI lint banning user-struct leaks` | **T3.0.6** | Future PR re-introducing any of the above patterns |
| `chore(release): 0.5.30` | — | Version bump |

## Out-of-band changes (already applied to FastRaid)

- `my-engram-saas.xml` + `my-engram-selfhost.xml` Unraid templates — added explicit `ERL_CRASH_DUMP_BYTES=0` env var (per `feedback_unraid_template_drift` policy). `.bak.<ts>` snapshots taken first.
- Local `backend/erl_crash.dump` (6.3M, dated 2026-05-05) — deleted from disk. Held BEAM heap from a crash that almost certainly contained the prod-equivalent master key.

## Test plan

- [x] `mix test` — 868 tests, 0 failures
- [x] `Jason.encode!(user)` only emits allowlist (`id, email, role, display_name, created_at, updated_at`); refutes encryption fields
- [x] `inspect(user)` does not contain `encrypted_dek` / `password_hash` bytes
- [x] Tags-only row decrypts to expected list (regression test added)
- [x] Static-source lint catches planted `json(conn, %{user: user})` / `json(conn, user)` / `inspect(user)` patterns
- [x] Static-source lint catches `inspect(...)` inside `json(...)` controller responses
- [ ] Manual prod-log smoke after deploy: `kubectl logs` (or Unraid container logs) contains zero SQL params; zero ciphertext bytes in 500 response bodies

## What's next (per plan)

After this lands:

1. **Phase T3.1** — `ensure_user_dek/1` race fix (C1, half day)
2. **Phase T3.2** — Oban arg leak scrub (H3, half day)
3. **Phase T3.3** — DekCache `:protected` + `process_flag(:sensitive, true)` (H2 + M9 finishing, 1 day)

Tracking `docs/encryption-tier-3-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)