### PR TITLE
fix(crypto): T3.2 — replace plaintext path args in Oban workers with HMAC (H3)

### DIFF
--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -98,14 +98,24 @@ defmodule Engram.Indexing do
   end
 
   @doc """
-  Delete Qdrant points for a specific path (used after rename to clean up old path).
+  Delete Qdrant points for a specific path-hmac (used after rename to clean
+  up old path's points). T3.2 — `path_hmac` is the base64-encoded HMAC of
+  the note path; carrying plaintext path through Oban args defeats Phase B
+  encryption for the rename window.
   """
-  def delete_points_by_path(note, path) do
-    Qdrant.delete_by_note(collection(), to_string(note.user_id), to_string(note.vault_id), path)
+  def delete_points_by_path_hmac(note, path_hmac) do
+    Qdrant.delete_by_note(
+      collection(),
+      to_string(note.user_id),
+      to_string(note.vault_id),
+      path_hmac
+    )
   end
 
   @doc """
-  Remove all indexed data for a note (Qdrant points first, then Postgres chunks).
+  Remove all indexed data for a note (Qdrant points first, then Postgres
+  chunks). T3.2 — Qdrant filter keys off `path_hmac` (base64), not plaintext
+  `source_path`. The note row's `path_hmac` is the source of truth.
   """
   def delete_note_index(note) do
     with :ok <-
@@ -113,7 +123,7 @@ defmodule Engram.Indexing do
              collection(),
              to_string(note.user_id),
              to_string(note.vault_id),
-             note.path
+             encode_hmac(note.path_hmac)
            ) do
       Repo.delete_all(from(c in Chunk, where: c.note_id == ^note.id), skip_tenant_check: true)
       :ok

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -214,7 +214,8 @@ defmodule Engram.Notes do
 
     case result do
       {:ok, {:ok, note}} ->
-        Oban.insert(EmbedNote.new_debounced(note.id, old_path: old_path))
+        # T3.2 — pass old_path_hmac (base64) to the worker, never plaintext.
+        Oban.insert(EmbedNote.new_debounced(note.id, old_path_hmac: old_path_hmac_b64!(user, old_path)))
         broadcast_change(user.id, vault.id, "delete", old_path)
         decrypted = decrypt_or_raise!(note, user)
         broadcast_change(user.id, vault.id, "upsert", note.path, decrypted)
@@ -248,12 +249,14 @@ defmodule Engram.Notes do
         |> Repo.update_all(set: [deleted_at: now, updated_at: now])
       end)
 
+      # T3.2 — pass path_hmac (base64), never plaintext path. The note row
+      # already carries `path_hmac` raw bytes; base64-encode for JSON safety.
       Oban.insert(
         DeleteNoteIndex.new(%{
           note_id: note.id,
           user_id: note.user_id,
           vault_id: note.vault_id,
-          path: path
+          path_hmac: Base.encode64(note.path_hmac)
         })
       )
     end
@@ -615,9 +618,15 @@ defmodule Engram.Notes do
         Repo.insert_all(Note, tombstones, on_conflict: :nothing)
       end)
 
-      # Side effects outside the transaction — broadcast + reindex
+      # Side effects outside the transaction — broadcast + reindex.
+      # T3.2 — pass old_path_hmac (base64) to the worker, never plaintext.
       Enum.each(updates, fn {id, old_note_path, new_path, _folder, _title} ->
-        Oban.insert(Engram.Workers.EmbedNote.new_debounced(id, old_path: old_note_path))
+        Oban.insert(
+          Engram.Workers.EmbedNote.new_debounced(id,
+            old_path_hmac: old_path_hmac_b64!(user, old_note_path)
+          )
+        )
+
         broadcast_change(user.id, vault.id, "delete", old_note_path)
         broadcast_change(user.id, vault.id, "upsert", new_path)
       end)
@@ -629,6 +638,15 @@ defmodule Engram.Notes do
   # ---------------------------------------------------------------------------
   # Private
   # ---------------------------------------------------------------------------
+
+  # T3.2 helper — base64-encoded HMAC of a plaintext path under the user's
+  # filter key. Used at Oban-enqueue boundaries so plaintext path / old_path
+  # never enters `oban_jobs.args` JSONB. Raises on filter-key load failure
+  # (Phase B.4 invariant: every authenticated request has a usable DEK).
+  defp old_path_hmac_b64!(user, path) do
+    {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
+    filter_key |> Engram.Crypto.hmac_field(path) |> Base.encode64()
+  end
 
   # Phase B.3: decryption MUST raise on failure. Returning the un-decrypted
   # struct (with virtual path/folder/tags = nil) silently serializes

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -130,16 +130,20 @@ defmodule Engram.Vector.Qdrant do
   end
 
   @doc """
-  Delete all points for a given user+vault+path combination.
+  Delete all points for a given user+vault+path-hmac combination.
+
+  T3.2 — `path_hmac` is the base64-encoded HMAC of the note path under the
+  user's filter key. Qdrant payloads carry `path_hmac` as a plaintext-safe
+  filter key alongside the encrypted `source_path` (Phase B.2.4).
   """
-  def delete_by_note(col \\ nil, user_id, vault_id, path) do
+  def delete_by_note(col \\ nil, user_id, vault_id, path_hmac) do
     col = col || collection()
 
     filter = %{
       must: [
         %{key: "user_id", match: %{value: user_id}},
         %{key: "vault_id", match: %{value: vault_id}},
-        %{key: "source_path", match: %{value: path}}
+        %{key: "path_hmac", match: %{value: path_hmac}}
       ]
     }
 

--- a/lib/engram/workers/delete_note_index.ex
+++ b/lib/engram/workers/delete_note_index.ex
@@ -2,8 +2,10 @@ defmodule Engram.Workers.DeleteNoteIndex do
   @moduledoc """
   Oban worker: deletes Qdrant points and DB chunks for a soft-deleted note.
 
-  Enqueued from Notes.delete_note/3 instead of a fire-and-forget Task,
-  ensuring testability (Oban manual mode) and retry on transient failures.
+  Enqueued from `Notes.delete_note/3`. Args carry `path_hmac` (base64), not
+  plaintext `path` — see encryption tier-3 audit T3.2 / H3. Plaintext in
+  `oban_jobs.args` JSONB defeats Phase B at-rest encryption for the
+  duration of any in-flight or recently-completed job.
   """
 
   use Oban.Worker, queue: :indexing, max_attempts: 3
@@ -16,11 +18,22 @@ defmodule Engram.Workers.DeleteNoteIndex do
           "note_id" => note_id,
           "user_id" => user_id,
           "vault_id" => vault_id,
-          "path" => path
+          "path_hmac" => path_hmac_b64
         }
       }) do
-    note = %{id: note_id, user_id: user_id, vault_id: vault_id, path: path}
-    Indexing.delete_note_index(note)
-    :ok
+    # `Indexing.delete_note_index/1` reads `note.path_hmac` directly. We
+    # decode the base64 arg back into the raw HMAC bytes the function
+    # expects on `note` rows. Skipping the user/vault enrichment because
+    # `Indexing.delete_note_index/1` only needs a struct-like with
+    # `:user_id`, `:vault_id`, `:path_hmac`, and `:id`.
+    case Base.decode64(path_hmac_b64) do
+      {:ok, path_hmac} ->
+        note = %{id: note_id, user_id: user_id, vault_id: vault_id, path_hmac: path_hmac}
+        Indexing.delete_note_index(note)
+        :ok
+
+      :error ->
+        {:discard, "invalid path_hmac base64 for note_id=#{note_id}"}
+    end
   end
 end

--- a/lib/engram/workers/delete_note_index.ex
+++ b/lib/engram/workers/delete_note_index.ex
@@ -36,4 +36,16 @@ defmodule Engram.Workers.DeleteNoteIndex do
         {:discard, "invalid path_hmac base64 for note_id=#{note_id}"}
     end
   end
+
+  # T3.2 — defensive fall-through. The strict head above expects the
+  # post-T3.2 arg shape; the migration that ships in this PR deletes any
+  # in-flight jobs carrying the legacy `path` key, but deploy ordering is
+  # not load-bearing on this clause: any unrecognized shape is discarded
+  # with a structured reason so a stale enqueue from a rolled-back deploy
+  # does not raise FunctionClauseError + retry storm. Crucially, the
+  # legacy `path` plaintext key is exactly the leak T3.2/H3 closed —
+  # there is no scenario where we want to "process" such a job.
+  def perform(%Oban.Job{args: args}) do
+    {:discard, "T3.2 legacy or malformed args (keys=#{inspect(Map.keys(args))})"}
+  end
 end

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -36,7 +36,8 @@ defmodule Engram.Workers.EmbedNote do
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
     note_id = args["note_id"]
-    old_path = args["old_path"]
+    # T3.2 — `old_path_hmac` is a base64-encoded HMAC, never plaintext path.
+    old_path_hmac_b64 = args["old_path_hmac"]
 
     # skip_tenant_check: trusted internal worker — queries already scoped to note_id/user_id
     case Repo.get(Note, note_id, skip_tenant_check: true) do
@@ -46,7 +47,8 @@ defmodule Engram.Workers.EmbedNote do
       %Note{deleted_at: deleted_at} when not is_nil(deleted_at) ->
         {:discard, "note #{note_id} is soft-deleted"}
 
-      %Note{content_hash: hash, embed_hash: hash} when not is_nil(hash) and is_nil(old_path) ->
+      %Note{content_hash: hash, embed_hash: hash}
+      when not is_nil(hash) and is_nil(old_path_hmac_b64) ->
         # Already embedded this exact content and no rename pending — skip
         :ok
 
@@ -64,8 +66,8 @@ defmodule Engram.Workers.EmbedNote do
             case Crypto.maybe_decrypt_note_fields(note, user) do
               {:ok, decrypted_note} ->
                 # If renamed, clean up old path's Qdrant points before re-indexing
-                if old_path do
-                  Indexing.delete_points_by_path(decrypted_note, old_path)
+                if old_path_hmac_b64 do
+                  Indexing.delete_points_by_path_hmac(decrypted_note, old_path_hmac_b64)
                 end
 
                 case Indexing.index_note(decrypted_note, vault) do
@@ -111,13 +113,18 @@ defmodule Engram.Workers.EmbedNote do
   Build an Oban job with 5-second debounce.
   `replace: [:scheduled_at]` resets the timer on rapid edits (dedup by note_id).
 
-  Pass `old_path:` when the note was renamed — the worker will delete old Qdrant
-  points before re-indexing under the new path.
+  Pass `old_path_hmac:` (base64) when the note was renamed — the worker will
+  delete old-path Qdrant points before re-indexing under the new path. T3.2:
+  HMAC bytes (not plaintext path) are what survives in `oban_jobs.args` JSONB.
   """
   def new_debounced(note_id, opts \\ []) do
     scheduled_at = DateTime.add(DateTime.utc_now(), 5, :second)
     args = %{note_id: note_id}
-    args = if opts[:old_path], do: Map.put(args, :old_path, opts[:old_path]), else: args
+
+    args =
+      if opts[:old_path_hmac],
+        do: Map.put(args, :old_path_hmac, opts[:old_path_hmac]),
+        else: args
 
     new(
       args,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.31",
+      version: "0.5.32",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260508000001_t3_2_flush_legacy_oban_args.exs
+++ b/priv/repo/migrations/20260508000001_t3_2_flush_legacy_oban_args.exs
@@ -1,0 +1,36 @@
+defmodule Engram.Repo.Migrations.T32FlushLegacyObanArgs do
+  use Ecto.Migration
+
+  @moduledoc """
+  T3.2 / H3 — flush in-flight Oban jobs whose args still carry plaintext
+  `path` / `old_path` keys. After this PR's worker rename, those args are
+  unreadable by the new perform clause, and the legacy keys themselves
+  are exactly the leak we are closing — leaving them in `oban_jobs.args`
+  defeats Phase B at-rest encryption for the retention window.
+
+  Targets ONLY pending / scheduled jobs in the two affected workers:
+    - `Engram.Workers.DeleteNoteIndex` with arg key `path`
+    - `Engram.Workers.EmbedNote`       with arg key `old_path`
+
+  Completed and discarded jobs are left untouched — they are tombstoned
+  by Oban's pruner on the existing retention schedule.
+  """
+
+  def up do
+    execute("""
+    DELETE FROM oban_jobs
+    WHERE state IN ('available', 'scheduled', 'retryable')
+      AND (
+        (worker = 'Engram.Workers.DeleteNoteIndex' AND args ? 'path')
+        OR
+        (worker = 'Engram.Workers.EmbedNote' AND args ? 'old_path')
+      )
+    """)
+  end
+
+  def down do
+    # Irreversible — the deleted jobs cannot be re-enqueued from the new
+    # producer signatures because we no longer have the plaintext args.
+    :ok
+  end
+end

--- a/test/engram/vector/qdrant_test.exs
+++ b/test/engram/vector/qdrant_test.exs
@@ -177,21 +177,27 @@ defmodule Engram.Vector.QdrantTest do
   end
 
   describe "delete_by_note/4" do
-    test "posts filter delete for user+vault+path", %{bypass: bypass} do
+    test "posts filter delete keyed on path_hmac (T3.2)", %{bypass: bypass} do
+      # T3.2 — Qdrant filter keys off `path_hmac` (HMAC base64) instead of
+      # plaintext `source_path`. Plaintext path in `oban_jobs.args` would
+      # have defeated Phase B at-rest encryption for the rename / delete
+      # window; HMAC bytes are safe to JSON-encode.
       Bypass.expect_once(bypass, "POST", "/collections/test_col/points/delete", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         decoded = Jason.decode!(body)
         conditions = decoded["filter"]["must"]
         keys = Enum.map(conditions, & &1["key"])
         assert "user_id" in keys
-        assert "source_path" in keys
+        assert "vault_id" in keys
+        assert "path_hmac" in keys
+        refute "source_path" in keys
 
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.send_resp(200, ~s({"result": {"status": "ok"}}))
       end)
 
-      assert :ok = Qdrant.delete_by_note("test_col", "user-1", "vault-1", "Test/Note.md")
+      assert :ok = Qdrant.delete_by_note("test_col", "user-1", "vault-1", "stub-hmac-base64")
     end
   end
 

--- a/test/engram/workers/no_plaintext_args_test.exs
+++ b/test/engram/workers/no_plaintext_args_test.exs
@@ -1,0 +1,59 @@
+defmodule Engram.Workers.NoPlaintextArgsTest do
+  # T3.2 / H3 — Static source lint. Oban worker `args` is a JSONB column
+  # in `oban_jobs.args` and lands in DB dumps, Oban Web UI, and retention
+  # windows. Plaintext path / title / content / tags / folder / old_path /
+  # name keys defeat Phase B's at-rest encryption for the duration of any
+  # in-flight or recently-completed job.
+  #
+  # The audit's T3.2.3 acceptance criterion: "no `oban_jobs.args` row in
+  # any worker enqueues keys named path|title|content|tags|folder|old_path|name."
+  use ExUnit.Case, async: true
+
+  alias Engram.Test.SourceLint
+
+  @workers_dir Path.join(File.cwd!(), "lib/engram/workers")
+
+  # Banned keys when used as map literal keys in worker args. Match shape:
+  #   "path" =>          # JSON-string-keyed args
+  #   path:              # atom-keyed args
+  # Per audit T3.2.3.
+  @banned_keys ~w(path title content tags folder old_path name)
+
+  test "no Oban worker file uses banned plaintext arg keys" do
+    offenders =
+      @workers_dir
+      |> SourceLint.walk_ex_files()
+      |> Enum.flat_map(&scan_file/1)
+
+    assert offenders == [],
+           "Oban worker source contains banned plaintext arg keys.\n" <>
+             "Replace `path` / `old_path` with `path_hmac` / `old_path_hmac` (base64).\n" <>
+             "Other plaintext fields (title/content/tags/folder/name) must never enter\n" <>
+             "oban_jobs.args — they are JSONB and survive in DB dumps + retention.\n\n" <>
+             Enum.map_join(offenders, "\n", fn {file, line, key, snippet} ->
+               "  #{Path.relative_to_cwd(file)}:#{line}  [#{key}]  #{snippet}"
+             end)
+  end
+
+  defp scan_file(path) do
+    lines = path |> File.read!() |> String.split("\n") |> Enum.with_index(1)
+
+    for {line, i} <- lines,
+        not SourceLint.commented?(line),
+        not String.contains?(line, "noqa: T3.2"),
+        key <- @banned_keys,
+        Regex.match?(map_key_regex(key), line) do
+      {path, i, key, String.trim(line)}
+    end
+  end
+
+  # Match either `"key" =>` (string-keyed JSON) or `key:` (atom-keyed) when
+  # used as a map field. Anchored with non-word boundary on the left to
+  # avoid matching `old_path` when scanning for `path`. The lookahead
+  # excludes `path_hmac` etc. — only the bare key counts.
+  defp map_key_regex(key) do
+    # Negative lookahead `_` prevents `path:` from matching `path_hmac:`.
+    # `(?<![A-Za-z_])` left boundary stops `path` from matching `old_path`.
+    Regex.compile!(~s/(?<![A-Za-z_])(?:"#{key}"\\s*=>|#{key}:)(?![A-Za-z_])/)
+  end
+end


### PR DESCRIPTION
## Summary

Phase **T3.2** of the encryption tier-3 hardening plan. Closes audit **H3**.

`Engram.Workers.DeleteNoteIndex` and `Engram.Workers.EmbedNote` carried plaintext `path` / `old_path` in `oban_jobs.args` JSONB. That column survives in DB dumps, Oban Web UI, and retention windows — defeats Phase B at-rest encryption for the duration of any in-flight or recently-completed job.

## Worker arg shape

| Worker | Old | New |
|---|---|---|
| `DeleteNoteIndex` | `"path"` (plaintext) | `"path_hmac"` (base64 HMAC) |
| `EmbedNote` (rename) | `"old_path"` (plaintext) | `"old_path_hmac"` (base64 HMAC) |

## Why HMAC works without reindexing Qdrant

Phase B.2.4 already wrote `path_hmac` into every Qdrant payload alongside the encrypted `source_path`. `Qdrant.delete_by_note/4` simply switches its filter `key` from `source_path` to `path_hmac`. No backfill required.

## Files

- `lib/engram/workers/delete_note_index.ex`, `lib/engram/workers/embed_note.ex` — worker shape
- `lib/engram/indexing.ex` — `delete_note_index/1` reads `note.path_hmac`; `delete_points_by_path/2` renamed to `delete_points_by_path_hmac/2`
- `lib/engram/vector/qdrant.ex` — `delete_by_note/4` filters on `path_hmac`
- `lib/engram/notes.ex` — `delete_note/3` + `rename_note/4` + bulk-rename pass HMAC; new private helper `old_path_hmac_b64!/2` derives HMAC from plaintext at the producer boundary
- `priv/repo/migrations/20260508000001_t3_2_flush_legacy_oban_args.exs` — one-shot DELETE of in-flight jobs that still carry plaintext args (irreversible)
- `test/engram/workers/no_plaintext_args_test.exs` — static-source CI lint banning plaintext keys (`path|title|content|tags|folder|old_path|name`) in `lib/engram/workers/`
- `test/engram/vector/qdrant_test.exs` — updated assertion: filter must include `path_hmac`, must NOT include `source_path`

## Test plan

- [x] `mix test` — 871 tests, 0 failures
- [x] Lint test fails on legacy worker shape, passes after refactor
- [x] Existing notes/rename/delete suites unchanged in behavior (covered)
- [ ] FastRaid deploy: confirm migration runs cleanly + Oban dashboard shows zero `DeleteNoteIndex` / `EmbedNote` jobs with plaintext arg keys post-migration

## Forward notes

Qdrant payload's `source_path` field is still plaintext (line 151 `lib/engram/indexing.ex`) — that's a different leak class than T3.2 (this PR closed the `oban_jobs.args` JSONB exposure). The Qdrant payload plaintext is covered by future T3.6 (AAD bind) which rewraps payloads anyway. Tracking in audit doc.

## What's next

1. **Phase T3.3** — DekCache `:protected` + `process_flag(:sensitive, true)` (H2 + M9 finishing, ~1 day)
2. **Phase T3.4** — wrapped-blob versioning byte + per-row `dek_version` (M2 + H5 + M4, ~1 day)

Then the rotation flywheel (T3.5 → T3.7) per the Environment context section of the audit doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)