### PR TITLE
fix(crypto): T3.3 — DekCache :protected + :sensitive flag (H2 + M9)

### DIFF
--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -19,9 +19,13 @@ defmodule Engram.Crypto do
   untouched if `encrypted_dek` is already present.
   """
   @spec ensure_user_dek(User.t()) :: {:ok, User.t()} | {:error, term()}
-  def ensure_user_dek(%User{encrypted_dek: blob} = user) when is_binary(blob), do: {:ok, user}
+  def ensure_user_dek(%User{encrypted_dek: blob} = user) when is_binary(blob) do
+    mark_sensitive()
+    {:ok, user}
+  end
 
   def ensure_user_dek(%User{} = user) do
+    mark_sensitive()
     # T3.1 / C1 — first-write provisioning runs inside a single transaction
     # with `SELECT ... FOR UPDATE` on the user row. This serializes
     # concurrent first-writes for the same user: the second writer's
@@ -84,7 +88,21 @@ defmodule Engram.Crypto do
   @spec get_dek(User.t()) :: {:ok, <<_::256>>} | {:error, term()}
   def get_dek(%User{encrypted_dek: nil}), do: {:error, :no_dek}
 
+  # T3.3 / M9 — mark every caller process that touches a plaintext DEK as
+  # `:sensitive`, so its heap is excluded from any future BEAM crash dump.
+  # Set-once-per-process: process_flag/2 is sticky for the process lifetime.
+  # Cost is negligible — Phoenix request handlers and Oban workers process
+  # encryption-bearing requests on essentially every job, so the flag would
+  # be set on first call regardless.
+  @compile {:inline, mark_sensitive: 0}
+  defp mark_sensitive do
+    :erlang.process_flag(:sensitive, true)
+    :ok
+  end
+
   def get_dek(%User{id: user_id, encrypted_dek: blob}) do
+    mark_sensitive()
+
     case DekCache.get(user_id) do
       {:ok, dek} ->
         {:ok, dek}

--- a/lib/engram/crypto/dek_cache.ex
+++ b/lib/engram/crypto/dek_cache.ex
@@ -3,6 +3,20 @@ defmodule Engram.Crypto.DekCache do
   ETS-backed cache for unwrapped DEKs. TTL-based expiry; sweep GenServer
   evicts expired entries periodically. On node shutdown, all DEKs vanish
   (correct — they re-populate on next request via KMS/Local unwrap).
+
+  ## Security posture (T3.3 / H2 + M9)
+
+  Reads go directly through ETS for `read_concurrency: true` performance.
+  Writes (`put/3`, `invalidate/1`, `invalidate_all/0`, sweep) all flow
+  through this GenServer because the table is `:protected` — only the
+  owning process can mutate it. Any foreign-process `:ets.insert/2` or
+  `:ets.delete/2` raises `ArgumentError`. Pre-T3.3 the table was `:public`,
+  exposing every cached plaintext DEK to a poison-replace attack from any
+  in-process actor (LiveDashboard, remote IEx, future deps).
+
+  The owner GenServer also sets `:erlang.process_flag(:sensitive, true)`
+  so its heap (which holds plaintext DEKs in the ETS table backing
+  storage) is excluded from any future BEAM crash dump.
   """
 
   use GenServer
@@ -23,7 +37,11 @@ defmodule Engram.Crypto.DekCache do
         if :erlang.system_time(:millisecond) < expires_at do
           {:ok, dek}
         else
-          :ets.delete(@table, user_id)
+          # T3.3 — eviction of an expired entry must go through the owner
+          # process. Foreign processes cannot delete from a :protected ETS
+          # table directly. Cast is fine: a stale entry living for one
+          # extra request is harmless (decrypt under the same key).
+          GenServer.cast(__MODULE__, {:expire, user_id})
           :miss
         end
 
@@ -36,45 +54,100 @@ defmodule Engram.Crypto.DekCache do
   def put(user_id, <<_::256>> = dek, ttl_ms \\ nil) do
     ttl = ttl_ms || Application.get_env(:engram, :dek_cache_ttl_ms, 3_600_000)
     expires_at = :erlang.system_time(:millisecond) + ttl
-    :ets.insert(@table, {user_id, dek, expires_at})
-    :ok
+    # GenServer.call (sync) so callers downstream can rely on the cache
+    # being hot before the next read. The audit suggested cast for "writes
+    # are rare," but cache-miss is paired with a network unwrap or DB
+    # round-trip that already cost ms — one extra GenServer hop is noise.
+    GenServer.call(__MODULE__, {:put, user_id, dek, expires_at})
   end
 
   @spec invalidate(user_id :: integer()) :: :ok
   def invalidate(user_id) do
-    :ets.delete(@table, user_id)
-    :ok
+    GenServer.call(__MODULE__, {:invalidate, user_id})
   end
 
   @spec invalidate_all() :: :ok
   def invalidate_all do
-    :ets.delete_all_objects(@table)
-    :ok
+    GenServer.call(__MODULE__, :invalidate_all)
   end
 
   @doc "Force an immediate sweep; exposed for tests."
   def sweep_now, do: GenServer.call(__MODULE__, :sweep)
 
+  @doc false
+  # T3.3 / M9 — test helper only. `process_info(pid, :sensitive)` is not
+  # a valid introspection key on current OTP, so we round-trip through
+  # the owner: `process_flag/2` returns the previous value, so toggling
+  # true→true is a non-mutating read.
+  @spec sensitive_flag?() :: boolean()
+  def sensitive_flag?, do: GenServer.call(__MODULE__, :__sensitive_flag__)
+
   ## GenServer
 
   @impl true
   def init(:ok) do
-    # :public is required because get/put/invalidate are called directly by
-    # caller processes (Notes, Oban workers) without routing through this
-    # GenServer — avoids serialization bottleneck on hot path. Trade-off:
-    # any BEAM process can read wrapped DEKs from the table. Acceptable
-    # because plaintext DEKs never persist to disk and are cleared on
-    # node restart. If tightening to :protected, move get/put/invalidate
-    # into GenServer.call/cast.
-    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    # T3.3 / H2 — `:protected` means only this process can mutate the
+    # table. Foreign reads still work (set: true is the default). The
+    # `read_concurrency: true` flag keeps direct-ETS reads cheap from
+    # any caller process.
+    :ets.new(@table, [:named_table, :protected, :set, read_concurrency: true])
+
+    # T3.3 / M9 — exclude this process's heap from any BEAM crash dump.
+    # The ETS table's data lives in this process's memory map, so plaintext
+    # DEKs would otherwise be recoverable from `erl_crash.dump`.
+    :erlang.process_flag(:sensitive, true)
+
     schedule_sweep()
     {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:put, user_id, dek, expires_at}, _from, state) do
+    :ets.insert(@table, {user_id, dek, expires_at})
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:invalidate, user_id}, _from, state) do
+    :ets.delete(@table, user_id)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(:invalidate_all, _from, state) do
+    :ets.delete_all_objects(@table)
+    {:reply, :ok, state}
   end
 
   @impl true
   def handle_call(:sweep, _from, state) do
     sweep()
     {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(:__sensitive_flag__, _from, state) do
+    # process_flag/2 returns previous value; toggling true→true reads
+    # without mutating.
+    was = :erlang.process_flag(:sensitive, true)
+    {:reply, was, state}
+  end
+
+  @impl true
+  def handle_cast({:expire, user_id}, state) do
+    # Re-check expiry under the owner — another caller may have already
+    # refreshed the entry. Only delete if still expired.
+    case :ets.lookup(@table, user_id) do
+      [{^user_id, _dek, expires_at}] ->
+        if :erlang.system_time(:millisecond) >= expires_at do
+          :ets.delete(@table, user_id)
+        end
+
+      [] ->
+        :ok
+    end
+
+    {:noreply, state}
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.32",
+      version: "0.5.33",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto/dek_cache_test.exs
+++ b/test/engram/crypto/dek_cache_test.exs
@@ -38,4 +38,39 @@ defmodule Engram.Crypto.DekCacheTest do
     DekCache.sweep_now()
     assert :miss = DekCache.get(1)
   end
+
+  describe "T3.3 / H2 — ETS write protection" do
+    @table :engram_dek_cache
+
+    test "ETS table is :protected (foreign-process write raises)" do
+      # Pre-fix: table was :public, so any process could `:ets.insert` and
+      # poison-replace a victim's DEK. Post-fix: only the DekCache GenServer
+      # can write; foreign-process attempts must raise ArgumentError.
+      attacker_dek = :binary.copy(<<0xFF>>, 32)
+      now = :erlang.system_time(:millisecond)
+
+      assert_raise ArgumentError, fn ->
+        :ets.insert(@table, {99_999, attacker_dek, now + 60_000})
+      end
+    end
+
+    test "ETS table is :protected (foreign-process delete raises)" do
+      DekCache.put(1, @dek)
+
+      assert_raise ArgumentError, fn ->
+        :ets.delete(@table, 1)
+      end
+
+      # Sanity: legitimate API still works.
+      assert {:ok, @dek} = DekCache.get(1)
+    end
+
+    test "DekCache GenServer process has :sensitive flag set (M9 — exclude from crash dump)" do
+      # `process_info(pid, :sensitive)` is not a valid introspection key on
+      # current OTP. We round-trip through the GenServer instead: the helper
+      # asks the process to read its own flag (process_flag/2 returns the
+      # previous value, so toggling true→true is a non-mutating read).
+      assert true == DekCache.sensitive_flag?()
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Phase **T3.3** of the encryption tier-3 hardening plan. Closes audit **H2** (DekCache write surface) and finishes **M9** (process heap exclusion from BEAM crash dumps; Dockerfile `ERL_CRASH_DUMP_BYTES=0` from T3.0.3 was the first half).

## H2 — DekCache ETS lockdown

Pre-fix: `lib/engram/crypto/dek_cache.ex` opened the table as `:public`. Any in-process actor could call `:ets.insert(:engram_dek_cache, {victim_user_id, attacker_dek, ...})` and poison-replace a cached DEK. Today only one writer, but the moment `LiveDashboard` or remote IEx mounts on the production node, this becomes a one-line cross-user swap exploit (plus a `:ets.tab2list/1` dump of every cached plaintext DEK).

Post-fix: `:protected` table — only the owner GenServer can mutate. All writes route through `GenServer.call` (`put/3`, `invalidate/1`, `invalidate_all/0`) or `GenServer.cast` (expired-entry eviction from `get/1`). Reads stay direct ETS so `read_concurrency: true` performance is intact.

## M9 — `:sensitive` process flag

`:erlang.process_flag(:sensitive, true)` excludes a process's heap from any future BEAM crash dump. Set on:

- `DekCache.init/1` — the ETS table backing storage lives in this process's memory map
- `Crypto.ensure_user_dek/1` + `Crypto.get_dek/1` — every caller process that pulls a plaintext DEK into its own heap (Phoenix request handlers, Oban workers). Sticky for the process lifetime; cost is negligible.

Combined with `ERL_CRASH_DUMP_BYTES=0` (T3.0.3) this is belt-and-suspenders: even if a future deploy unsets the env var, the heaps that hold key material are still excluded from the dump.

## Tests

- ETS foreign-process `:ets.insert` raises `ArgumentError`
- ETS foreign-process `:ets.delete` raises `ArgumentError`
- DekCache GenServer process has `:sensitive` flag set (verified via test-only `sensitive_flag?/0` round-trip; `process_info(:sensitive)` is not introspectable on current OTP, so we toggle through the owner)

874 tests, 0 failures across the full backend suite.

## Test plan

- [x] `mix test` — 874 tests, 0 failures
- [x] Foreign-process write/delete tests fail before fix, pass after
- [x] Existing DekCache TTL + invalidation tests stay green under the new sync `call` write path
- [ ] FastRaid deploy: confirm app boots cleanly and DEK-bearing endpoints (e.g. notes upsert + search) function — the cache hot path is unchanged for reads

## What's next

1. **Phase T3.4** — wrapped-blob versioning byte + per-row `dek_version` (M2 + H5 + M4, ~1 day) — load-bearing for the rotation flywheel
2. **Phase T3.5** — master-key rotation backfill (C2 + M3 + C3, ~2 days)

Then T3.6 (AAD bind) → T3.7 (per-user DEK rotation primitive) per the rotation flywheel plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)