### PR TITLE
fix(crypto): T3.4 — wrap-format version byte + per-row dek_version (M2 + H5)

### DIFF
--- a/lib/engram/attachments/attachment.ex
+++ b/lib/engram/attachments/attachment.ex
@@ -22,6 +22,8 @@ defmodule Engram.Attachments.Attachment do
     field :storage_key, :string
     field :deleted_at, :utc_datetime
     field :encryption_version, :integer, default: 1
+    # T3.4 / H5 — DEK version this row's ciphertext was wrapped under.
+    field :dek_version, :integer, default: 1
     field :content_nonce, :binary
 
     belongs_to :user, Engram.Accounts.User

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -88,18 +88,6 @@ defmodule Engram.Crypto do
   @spec get_dek(User.t()) :: {:ok, <<_::256>>} | {:error, term()}
   def get_dek(%User{encrypted_dek: nil}), do: {:error, :no_dek}
 
-  # T3.3 / M9 — mark every caller process that touches a plaintext DEK as
-  # `:sensitive`, so its heap is excluded from any future BEAM crash dump.
-  # Set-once-per-process: process_flag/2 is sticky for the process lifetime.
-  # Cost is negligible — Phoenix request handlers and Oban workers process
-  # encryption-bearing requests on essentially every job, so the flag would
-  # be set on first call regardless.
-  @compile {:inline, mark_sensitive: 0}
-  defp mark_sensitive do
-    :erlang.process_flag(:sensitive, true)
-    :ok
-  end
-
   def get_dek(%User{id: user_id, encrypted_dek: blob}) do
     mark_sensitive()
 
@@ -119,6 +107,17 @@ defmodule Engram.Crypto do
             err
         end
     end
+  end
+
+  # T3.3 / M9 — mark every caller process that touches a plaintext DEK as
+  # `:sensitive`, so its heap is excluded from any future BEAM crash dump.
+  # Set-once-per-process: process_flag/2 is sticky for the process lifetime.
+  # Cost is negligible — Phoenix request handlers and Oban workers process
+  # encryption-bearing requests on essentially every job.
+  @compile {:inline, mark_sensitive: 0}
+  defp mark_sensitive do
+    :erlang.process_flag(:sensitive, true)
+    :ok
   end
 
   @doc """

--- a/lib/engram/crypto/key_provider/local.ex
+++ b/lib/engram/crypto/key_provider/local.ex
@@ -3,12 +3,35 @@ defmodule Engram.Crypto.KeyProvider.Local do
   KeyProvider implementation backed by an env-var master key.
   Wraps DEKs with AES-256-GCM using ENCRYPTION_MASTER_KEY.
   Supports one-key-back fallback for rotation via ENCRYPTION_MASTER_KEY_PREVIOUS.
+
+  ## Wrap format (T3.4 / M2)
+
+  New writes use a 2-byte header before nonce + ciphertext:
+
+      <<0x01, 0x01, nonce::binary-size(12), ct::binary>>
+      # ^^^   ^^^   ^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^
+      #  |     |    |                       AES-GCM ct + 16-byte tag
+      #  |     |    fresh per-encrypt nonce
+      #  |     algorithm id (0x01 = AES-256-GCM)
+      #  wrap-format version (0x01 = first header-bearing version)
+
+  Pre-T3.4 rows in DB carry the legacy raw shape `<<nonce::12, ct::binary>>`
+  (no header). `unwrap_dek/2` reads both shapes — the version-byte form
+  matches first, and a 60-byte raw shape falls through to the legacy
+  clause. Disambiguation is by total `byte_size/1`:
+
+      legacy: 12 (nonce) + 32 (DEK) + 16 (GCM tag) = 60 bytes
+      v1:      2 (header) + 60                     = 62 bytes
   """
 
   @behaviour Engram.Crypto.KeyProvider
 
   alias Engram.Crypto.Envelope
   alias Engram.Crypto.Config
+
+  # T3.4 / M2 — wrap-format constants.
+  @wrap_version_v1 0x01
+  @alg_aes_256_gcm 0x01
 
   @impl true
   def name, do: :local
@@ -20,11 +43,31 @@ defmodule Engram.Crypto.KeyProvider.Local do
   def wrap_dek(<<_::256>> = dek, _ctx) do
     master = Config.local_master_key!()
     {ct, nonce} = Envelope.encrypt(dek, master)
-    {:ok, <<nonce::binary-size(12), ct::binary>>}
+
+    {:ok,
+     <<@wrap_version_v1, @alg_aes_256_gcm, nonce::binary-size(12), ct::binary>>}
   end
 
   @impl true
-  def unwrap_dek(<<nonce::binary-size(12), ct::binary>>, _ctx) do
+  def unwrap_dek(blob, ctx) when is_binary(blob) do
+    case blob do
+      <<@wrap_version_v1, @alg_aes_256_gcm, nonce::binary-size(12), ct::binary>>
+      when byte_size(blob) == 62 ->
+        do_unwrap(ct, nonce, ctx)
+
+      <<nonce::binary-size(12), ct::binary>> when byte_size(blob) == 60 ->
+        # T3.4 — legacy pre-header shape. Kept for backward read so the
+        # wrap-version rollout does not require a backfill pass.
+        do_unwrap(ct, nonce, ctx)
+
+      _ ->
+        {:error, :malformed_wrapped_blob}
+    end
+  end
+
+  def unwrap_dek(_other, _ctx), do: {:error, :malformed_wrapped_blob}
+
+  defp do_unwrap(ct, nonce, _ctx) do
     current = Config.local_master_key!()
 
     case Envelope.decrypt(ct, nonce, current) do
@@ -44,8 +87,6 @@ defmodule Engram.Crypto.KeyProvider.Local do
         end
     end
   end
-
-  def unwrap_dek(_other, _ctx), do: {:error, :malformed_wrapped_blob}
 
   @impl true
   def supports_async_workers?, do: true

--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -14,6 +14,11 @@ defmodule Engram.Notes.Note do
     field :content, :string, virtual: true
 
     field :version, :integer, default: 1
+    # T3.4 / H5 — DEK version this row's ciphertext was wrapped under.
+    # Default 1 today; future rotation campaigns stamp the new version on
+    # rewritten rows. Read path consumers key off this column once T3.5 /
+    # T3.7 introduce a `users.dek_version > 1` cohort.
+    field :dek_version, :integer, default: 1
     field :content_hash, :string
     field :embed_hash, :string
     field :mtime, :float

--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -14,6 +14,8 @@ defmodule Engram.Vaults.Vault do
     field :name_ciphertext, :binary
     field :name_nonce, :binary
     field :name_hmac, :binary
+    # T3.4 / H5 — DEK version this row's ciphertext was wrapped under.
+    field :dek_version, :integer, default: 1
 
     belongs_to :user, Engram.Accounts.User
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.33",
+      version: "0.5.34",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260508000002_t3_4_add_per_row_dek_version.exs
+++ b/priv/repo/migrations/20260508000002_t3_4_add_per_row_dek_version.exs
@@ -1,0 +1,29 @@
+defmodule Engram.Repo.Migrations.T34AddPerRowDekVersion do
+  use Ecto.Migration
+
+  @moduledoc """
+  T3.4 / H5 — adds a `dek_version :: integer` column to every table whose
+  rows carry user-DEK ciphertext. Default 1 for legacy rows; future per-user
+  or per-row rotation campaigns (T3.5 / T3.7) stamp the new version on every
+  rewritten row.
+
+  Read paths can decide which DEK to use for decrypt by inspecting this
+  column once rotation introduces a `users.dek_version > 1` cohort. Today
+  the column is informational — wrapping is single-version — but adding it
+  now means future rotations don't require a schema migration mid-rollout.
+  """
+
+  def change do
+    alter table(:notes) do
+      add :dek_version, :integer, null: false, default: 1
+    end
+
+    alter table(:attachments) do
+      add :dek_version, :integer, null: false, default: 1
+    end
+
+    alter table(:vaults) do
+      add :dek_version, :integer, null: false, default: 1
+    end
+  end
+end

--- a/test/engram/crypto/local_provider_test.exs
+++ b/test/engram/crypto/local_provider_test.exs
@@ -62,4 +62,40 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
     refute old_wrapped == new_wrapped
     assert {:ok, ^dek} = Local.unwrap_dek(new_wrapped, %{user_id: 1})
   end
+
+  describe "T3.4 / M2 — wrap-format versioning" do
+    test "new wraps carry the version + algorithm header bytes (`<<0x01, 0x01, ...>>`)" do
+      # T3.4 / M2 — wrap-format version byte + algorithm-id byte. Enables
+      # algorithm-agility without scan-and-trial-decrypt across the
+      # encrypted_dek population.
+      dek = Local.generate_dek()
+      {:ok, wrapped} = Local.wrap_dek(dek, %{user_id: 1})
+
+      assert <<0x01, 0x01, _nonce::binary-size(12), _ct::binary>> = wrapped
+      # 1 (ver) + 1 (alg) + 12 (nonce) + 32 (DEK plaintext) + 16 (GCM tag) = 62
+      assert byte_size(wrapped) == 62
+    end
+
+    test "unwrap reads legacy-format blobs (back-compat for pre-T3.4 rows)" do
+      # T3.4 — Local.wrap_dek pre-T3.4 emitted `<<nonce::12, ct::binary>>`
+      # without a header. Existing rows in DB carry that shape; unwrap MUST
+      # round-trip them so the migration does not require a backfill pass.
+      dek = Local.generate_dek()
+      master = Engram.Crypto.Config.local_master_key!()
+      {ct, nonce} = Engram.Crypto.Envelope.encrypt(dek, master)
+      legacy_blob = <<nonce::binary-size(12), ct::binary>>
+
+      assert byte_size(legacy_blob) == 60
+      assert {:ok, ^dek} = Local.unwrap_dek(legacy_blob, %{user_id: 1})
+    end
+
+    test "unwrap rejects unknown wrap-format version bytes" do
+      # Future-proofing: a 62-byte blob whose first byte is not 0x01 is
+      # neither v1 nor any legitimate legacy shape (legacy is 60 bytes).
+      # Must fail loudly rather than fall through to a partial parse.
+      bogus = <<0x99, 0x01, :crypto.strong_rand_bytes(60)::binary>>
+      assert byte_size(bogus) == 62
+      assert {:error, _} = Local.unwrap_dek(bogus, %{user_id: 1})
+    end
+  end
 end

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -108,6 +108,20 @@ defmodule Engram.CryptoTest do
       assert out.tags == ["x"]
     end
 
+    test "newly-inserted note rows carry dek_version=1 (T3.4 / H5)", %{user: user} do
+      # T3.4 / H5 — the per-row column was added with default 1. New rows
+      # inserted via the factory satisfy that default. This test locks the
+      # contract so the column doesn't get accidentally dropped or
+      # repurposed before the rotation flywheel uses it.
+      vault = insert(:vault, user: user)
+      note = insert(:note, user: user, vault: vault)
+
+      reloaded =
+        Engram.Repo.get!(Engram.Notes.Note, note.id, skip_tenant_check: true)
+
+      assert reloaded.dek_version == 1
+    end
+
     test "decrypts tags-only row (regression: T3.0.4 / M7 gate fix)", %{user: user} do
       # T3.0.4 — gate previously skipped decrypt when only tags_ciphertext
       # was set (content_ciphertext + path_ciphertext both nil). Latent

--- a/test/engram/logger/redact_filter_test.exs
+++ b/test/engram/logger/redact_filter_test.exs
@@ -149,12 +149,33 @@ defmodule Engram.Logger.RedactFilterTest do
         require Logger
         Logger.warning("blob failed", storage_key: @sentinel, reason: :enoent)
 
-        assert_receive {:log_event, event}, 500
+        # Filter on `:storage_key` — `async: true` with a global :logger
+        # primary filter means concurrent tests' Logger calls also reach
+        # this handler. Pre-T3.4 the test asserted on the FIRST event
+        # received, which flaked under CI parallelism.
+        event = wait_for_event_with_storage_key(500)
+
         assert event.meta.storage_key == "[REDACTED]"
         assert event.meta.reason == :enoent
       after
         :logger.remove_handler(handler_id)
       end
+    end
+  end
+
+  defp wait_for_event_with_storage_key(timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait(deadline)
+  end
+
+  defp do_wait(deadline) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:log_event, %{meta: %{storage_key: _}} = event} -> event
+      {:log_event, _other} -> do_wait(deadline)
+    after
+      remaining -> flunk("no log event with :storage_key arrived within budget")
     end
   end
 


### PR DESCRIPTION
## Summary

Phase **T3.4** of the encryption tier-3 hardening plan. Bundles **M2** (wrap-format version byte) + **H5** (per-row `dek_version` column). Load-bearing for the T3.5 → T3.7 rotation flywheel:
- `dek_version` is the column rotation campaigns stamp on rewritten rows
- The wrap-format version byte unblocks algorithm agility without scan-and-trial decrypt across the entire `encrypted_dek` population

**M4 deferred** to T3.5 (gating `_PREVIOUS` fallback needs the master-key version concept that rotation introduces).

## M2 — Wrap format

| Format | Shape | Total bytes |
|---|---|---|
| Legacy (pre-T3.4) | `<<nonce::12, ct::binary>>` | 60 |
| v1 (post-T3.4) | `<<0x01, 0x01, nonce::12, ct::binary>>` | 62 |

`Local.unwrap_dek/2` reads both shapes — disambiguates by total `byte_size/1`. No backfill required. Unknown version bytes raise `:malformed_wrapped_blob`.

## H5 — Per-row `dek_version`

Migration `20260508000002_t3_4_add_per_row_dek_version` adds `dek_version :: integer NOT NULL DEFAULT 1` to `notes`, `attachments`, `vaults`. Schema structs updated. Existing rows keep `dek_version = 1`; future rotation campaigns stamp the new version on rewritten rows.

Read paths key off the column once T3.5/T3.7 introduce a `users.dek_version > 1` cohort. Today the column is informational — having it now means future rotations don't require a schema migration mid-rollout.

## Bonus

Collapsed a compiler warning left over from T3.3 (`get_dek/1` clauses had an interleaved private function defined between them). Function moved next to its callers.

## Tests

- New v1 wraps carry `<<0x01, 0x01, ...>>` and round-trip
- Legacy 60-byte raw blobs still round-trip via the back-compat clause
- Unknown version bytes rejected
- Newly-inserted note rows carry `dek_version = 1`

878 tests, 0 failures.

## Test plan

- [x] `mix test` — 878 tests, 0 failures
- [x] `mix ecto.migrate` runs cleanly locally (3 alter table calls)
- [ ] FastRaid deploy: confirm migration runs cleanly + existing notes/attachments/vaults read paths still decrypt (back-compat clause exercised on every legacy row)

## What's next

1. **Phase T3.5** — Master-key rotation backfill (C2 + M3 + C3, ~2 days). Builds on this PR's wrap-format version byte.
2. **Phase T3.6** — AAD bind for AES-GCM (H1, ~2-3 days).
3. **Phase T3.7** — Per-user DEK rotation primitive (H6, ~3 days).

Each phase shares rewrap machinery with the prior one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)