### PR TITLE
feat(crypto): T3.6 — AAD-bind every AES-GCM op (H1)

### DIFF
--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -29,13 +29,14 @@ defmodule Engram.Attachments do
 
     with {:ok, plaintext} <- decode_base64(content_b64),
          :ok <- validate_size(plaintext),
-         {:ok, key, changeset_attrs, ciphertext} <-
-           prepare_upload(user, vault, path, plaintext, mtime, explicit_mime),
-         :ok <- store_external(key, ciphertext, changeset_attrs.mime_type) do
-      path_hmac = changeset_attrs.path_hmac
+         {:ok, user} <- Crypto.ensure_user_dek(user),
+         {:ok, filter_key} <- Crypto.dek_filter_key(user) do
+      path_hmac = Crypto.hmac_field(filter_key, path)
 
-      Repo.with_tenant(user.id, fn ->
-        existing =
+      # Find existing FIRST so we can reuse its id for AAD; otherwise
+      # pre-allocate a fresh attachment id from the bigserial sequence.
+      existing =
+        Repo.with_tenant(user.id, fn ->
           Repo.one(
             from(a in Attachment,
               where:
@@ -43,26 +44,43 @@ defmodule Engram.Attachments do
                   a.vault_id == ^vault.id
             )
           )
-
-        case existing do
-          nil ->
-            %Attachment{}
-            |> Attachment.changeset(changeset_attrs)
-            |> Repo.insert()
-
-          att ->
-            att
-            |> Attachment.changeset(changeset_attrs)
-            |> Repo.update()
+        end)
+        |> unwrap_tenant()
+        |> case do
+          {:ok, att} -> att
+          {:error, _} -> nil
         end
-      end)
-      |> unwrap_tenant()
-      |> case do
-        # Phase B.3: path is virtual — splice the plaintext we already have
-        # onto the returned struct so callers can read att.path without a
-        # second decrypt round-trip.
-        {:ok, att} -> {:ok, %{att | path: path}}
-        other -> other
+
+      att_id =
+        case existing do
+          nil -> Crypto.next_row_id(:attachments)
+          %Attachment{id: id} -> id
+        end
+
+      with {:ok, key, changeset_attrs, ciphertext} <-
+             prepare_upload(user, vault, att_id, path, path_hmac, plaintext, mtime, explicit_mime),
+           :ok <- store_external(key, ciphertext, changeset_attrs.mime_type) do
+        Repo.with_tenant(user.id, fn ->
+          case existing do
+            nil ->
+              %Attachment{id: att_id}
+              |> Attachment.changeset(changeset_attrs)
+              |> Repo.insert()
+
+            att ->
+              att
+              |> Attachment.changeset(changeset_attrs)
+              |> Repo.update()
+          end
+        end)
+        |> unwrap_tenant()
+        |> case do
+          # Phase B.3: path is virtual — splice the plaintext we already
+          # have onto the returned struct so callers can read att.path
+          # without a second decrypt round-trip.
+          {:ok, att} -> {:ok, %{att | path: path}}
+          other -> other
+        end
       end
     end
   end
@@ -263,17 +281,17 @@ defmodule Engram.Attachments do
       else: :ok
   end
 
-  defp prepare_upload(user, vault, path, plaintext, mtime, explicit_mime) do
+  defp prepare_upload(user, vault, att_id, path, path_hmac, plaintext, mtime, explicit_mime) do
     mime = explicit_mime || detect_mime(path)
     key = Storage.key(user.id, vault.id, path)
 
-    with {:ok, user} <- Crypto.ensure_user_dek(user),
-         {:ok, dek} <- Crypto.get_dek(user),
+    with {:ok, dek} <- Crypto.get_dek(user),
          {:ok, content_key} <- Crypto.dek_content_hash_key(user) do
       hash = Crypto.hmac_content_hash(content_key, plaintext)
-      {ciphertext, nonce} = Envelope.encrypt(plaintext, dek)
-      {path_ct, path_n} = Envelope.encrypt(path, dek)
-      {:ok, filter_key} = Crypto.dek_filter_key(user)
+      content_aad = Crypto.aad_for_row(:attachments, :content, att_id)
+      path_aad = Crypto.aad_for_row(:attachments, :path, att_id)
+      {ciphertext, nonce} = Envelope.encrypt(plaintext, dek, content_aad)
+      {path_ct, path_n} = Envelope.encrypt(path, dek, path_aad)
 
       attrs = %{
         content_hash: hash,
@@ -285,10 +303,11 @@ defmodule Engram.Attachments do
         storage_key: key,
         deleted_at: nil,
         encryption_version: 1,
+        dek_version: Crypto.row_version_aad_bound(),
         content_nonce: nonce,
         path_ciphertext: path_ct,
         path_nonce: path_n,
-        path_hmac: Crypto.hmac_field(filter_key, path)
+        path_hmac: path_hmac
       }
 
       {:ok, key, attrs, ciphertext}
@@ -309,8 +328,13 @@ defmodule Engram.Attachments do
   defp fresh_user(%Engram.Accounts.User{} = user), do: user
 
   defp decrypt(%Attachment{content_nonce: nonce} = att, ciphertext, user) do
+    aad =
+      if is_integer(att.dek_version) and att.dek_version >= 2,
+        do: Crypto.aad_for_row(:attachments, :content, att.id),
+        else: <<>>
+
     with {:ok, dek} <- Crypto.get_dek(fresh_user(user)),
-         {:ok, plaintext} <- Envelope.decrypt(ciphertext, nonce, dek) do
+         {:ok, plaintext} <- Envelope.decrypt(ciphertext, nonce, dek, aad) do
       {:ok, %{att | content: plaintext}}
     else
       :error -> {:error, :decrypt_failed}

--- a/lib/engram/attachments/attachment.ex
+++ b/lib/engram/attachments/attachment.ex
@@ -47,6 +47,7 @@ defmodule Engram.Attachments.Attachment do
       :storage_key,
       :deleted_at,
       :encryption_version,
+      :dek_version,
       :content_nonce
     ])
     |> validate_required([

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -14,6 +14,90 @@ defmodule Engram.Crypto do
   alias Engram.Crypto.{DekCache, Envelope, KeyProvider.Resolver}
   alias Engram.Repo
 
+  # T3.6 / H1 — per-row encryption format version.
+  #   1 = legacy: ciphertext was written with empty AAD (`<<>>`).
+  #   2 = AAD-bound: ciphertext is bound to "<table>:<column>:<row_id>"
+  #       (or "qdrant:<collection>:<qdrant_id>:<field>" for Qdrant payloads).
+  # Writers stamp `:aad_bound` (= 2) on every new row. Reads dispatch on the
+  # row's stored value: legacy rows decrypt with empty AAD, AAD-bound rows
+  # reconstruct the bind string from the row's identity.
+  #
+  # Distinct from `users.dek_version` (master-key generation, T3.5) and from
+  # the wrap-format byte on `users.encrypted_dek` (0x01 = no AAD,
+  # 0x02 = AAD-bound, T3.6). The three version concepts are intentionally
+  # orthogonal — a user can hold an AAD-bound wrapped DEK (0x02) while still
+  # carrying legacy `dek_version=1` rows pending the rebind backfill, or vice
+  # versa during the migration window.
+  @row_version_legacy 1
+  @row_version_aad_bound 2
+
+  @doc "Per-row encryption format version stamped on AAD-bound writes."
+  def row_version_aad_bound, do: @row_version_aad_bound
+
+  @doc "Per-row legacy version (no AAD)."
+  def row_version_legacy, do: @row_version_legacy
+
+  @doc """
+  Pre-allocates a primary-key id from a table's bigserial sequence. Used
+  before AAD-bound INSERT so the row's AAD can include its eventual `row_id`.
+  Caller passes the allocated `id` into the changeset; Ecto inserts with
+  the explicit id and the sequence already advanced.
+  """
+  @spec next_row_id(atom() | String.t()) :: pos_integer()
+  def next_row_id(table) when is_atom(table), do: next_row_id(Atom.to_string(table))
+
+  def next_row_id(table) when is_binary(table) do
+    # Postgrex's typed parameter encoder cannot encode `regclass` from a
+    # text bind, so we interpolate the sequence name as a literal. The
+    # `table` argument is a fixed atom-list (callers in this codebase
+    # pass `:notes`, `:attachments`, `:vaults`) — there is no user input
+    # path that reaches this string. The strict whitelist guards the
+    # boundary in case a future caller passes something dynamic.
+    unless table in ["notes", "attachments", "vaults"] do
+      raise ArgumentError,
+            "next_row_id: unsupported table #{inspect(table)}. " <>
+              "Add to the allowlist in Engram.Crypto."
+    end
+
+    seq = table <> "_id_seq"
+
+    %Postgrex.Result{rows: [[id]]} =
+      Repo.query!("SELECT nextval('#{seq}')", [])
+
+    id
+  end
+
+  @doc "AAD string for a relational row's column. T3.6 / H1."
+  @spec aad_for_row(atom() | String.t(), atom() | String.t(), term()) :: binary()
+  def aad_for_row(table, column, row_id) when is_binary(table) and is_binary(column),
+    do: table <> ":" <> column <> ":" <> to_string(row_id)
+
+  def aad_for_row(table, column, row_id) when is_atom(table),
+    do: aad_for_row(Atom.to_string(table), column, row_id)
+
+  def aad_for_row(table, column, row_id) when is_atom(column),
+    do: aad_for_row(table, Atom.to_string(column), row_id)
+
+  @doc "AAD string for a Qdrant payload field. Bound to point UUID, not chunk_index."
+  @spec aad_for_qdrant(String.t(), String.t(), atom() | String.t()) :: binary()
+  def aad_for_qdrant(collection, qdrant_id, field) when is_atom(field),
+    do: aad_for_qdrant(collection, qdrant_id, Atom.to_string(field))
+
+  def aad_for_qdrant(collection, qdrant_id, field)
+      when is_binary(collection) and is_binary(qdrant_id) and is_binary(field),
+      do: "qdrant:" <> collection <> ":" <> qdrant_id <> ":" <> field
+
+  @doc "AAD string for a wrapped DEK. Binds the wrap to the user it belongs to."
+  @spec aad_for_wrapped_dek(term()) :: binary()
+  def aad_for_wrapped_dek(user_id), do: "dek:v1:" <> to_string(user_id)
+
+  # Returns the AAD to pass at decrypt time for a given row column. Legacy
+  # rows return `<<>>`; AAD-bound rows return the constructed bind string.
+  defp decrypt_aad(%_{dek_version: v} = row, table, column) when v >= @row_version_aad_bound,
+    do: aad_for_row(table, column, row.id)
+
+  defp decrypt_aad(_row, _table, _column), do: <<>>
+
   @doc """
   Ensures the user has a wrapped DEK stored. Idempotent — returns the user
   untouched if `encrypted_dek` is already present.
@@ -136,19 +220,23 @@ defmodule Engram.Crypto do
   `Engram.Notes.phase_b_keyword_for/4`. This helper does not touch tags —
   that's a Phase B contract.
   """
-  @spec encrypt_note_fields(map(), User.t()) :: {:ok, map()} | {:error, term()}
-  def encrypt_note_fields(attrs, %User{} = user) do
+  @spec encrypt_note_fields(map(), User.t(), pos_integer()) :: {:ok, map()} | {:error, term()}
+  def encrypt_note_fields(attrs, %User{} = user, note_id) when is_integer(note_id) do
     with {:ok, user} <- ensure_user_dek(user),
          {:ok, dek} <- get_dek(user) do
       content = Map.get(attrs, :content) || Map.get(attrs, "content") || ""
       title = Map.get(attrs, :title) || Map.get(attrs, "title") || ""
 
-      {content_ct, content_nonce} = Envelope.encrypt(content, dek)
-      {title_ct, title_nonce} = Envelope.encrypt(title, dek)
+      content_aad = aad_for_row(:notes, :content, note_id)
+      title_aad = aad_for_row(:notes, :title, note_id)
+      {content_ct, content_nonce} = Envelope.encrypt(content, dek, content_aad)
+      {title_ct, title_nonce} = Envelope.encrypt(title, dek, title_aad)
 
       {:ok,
        attrs
        |> Map.drop([:content, :title, "content", "title"])
+       |> Map.put(:id, note_id)
+       |> Map.put(:dek_version, @row_version_aad_bound)
        |> Map.put(:content_ciphertext, content_ct)
        |> Map.put(:content_nonce, content_nonce)
        |> Map.put(:title_ciphertext, title_ct)
@@ -194,8 +282,13 @@ defmodule Engram.Crypto do
     do: {:ok, note}
 
   defp decrypt_phase_4_note_fields(%Engram.Notes.Note{} = note, dek) do
-    with {:ok, content} <- Envelope.decrypt(note.content_ciphertext, note.content_nonce, dek),
-         {:ok, title} <- Envelope.decrypt(note.title_ciphertext, note.title_nonce, dek) do
+    content_aad = decrypt_aad(note, :notes, :content)
+    title_aad = decrypt_aad(note, :notes, :title)
+
+    with {:ok, content} <-
+           Envelope.decrypt(note.content_ciphertext, note.content_nonce, dek, content_aad),
+         {:ok, title} <-
+           Envelope.decrypt(note.title_ciphertext, note.title_nonce, dek, title_aad) do
       {:ok, %{note | content: content, title: title}}
     else
       :error -> {:error, :decrypt_failed}
@@ -207,8 +300,12 @@ defmodule Engram.Crypto do
     do: {:ok, note}
 
   defp decrypt_phase_b_note_fields(%Engram.Notes.Note{} = note, dek) do
-    with {:ok, path} <- Envelope.decrypt(note.path_ciphertext, note.path_nonce, dek),
-         {:ok, folder} <- Envelope.decrypt(note.folder_ciphertext, note.folder_nonce, dek) do
+    path_aad = decrypt_aad(note, :notes, :path)
+    folder_aad = decrypt_aad(note, :notes, :folder)
+
+    with {:ok, path} <- Envelope.decrypt(note.path_ciphertext, note.path_nonce, dek, path_aad),
+         {:ok, folder} <-
+           Envelope.decrypt(note.folder_ciphertext, note.folder_nonce, dek, folder_aad) do
       {:ok, %{note | path: path, folder: folder}}
     else
       :error -> {:error, :decrypt_failed}
@@ -222,7 +319,9 @@ defmodule Engram.Crypto do
     do: {:ok, note}
 
   defp decrypt_phase_b_tags(%Engram.Notes.Note{} = note, dek) do
-    case Envelope.decrypt(note.tags_ciphertext, note.tags_nonce, dek) do
+    tags_aad = decrypt_aad(note, :notes, :tags)
+
+    case Envelope.decrypt(note.tags_ciphertext, note.tags_nonce, dek, tags_aad) do
       {:ok, tags_bin} ->
         {:ok, %{note | tags: :erlang.binary_to_term(tags_bin, [:safe])}}
 
@@ -247,8 +346,10 @@ defmodule Engram.Crypto do
         %Engram.Attachments.Attachment{} = att,
         %User{} = user
       ) do
+    path_aad = decrypt_aad(att, :attachments, :path)
+
     with {:ok, dek} <- get_dek(user),
-         {:ok, path} <- Envelope.decrypt(att.path_ciphertext, att.path_nonce, dek) do
+         {:ok, path} <- Envelope.decrypt(att.path_ciphertext, att.path_nonce, dek, path_aad) do
       {:ok, %{att | path: path}}
     else
       :error -> {:error, :decrypt_failed}
@@ -266,8 +367,10 @@ defmodule Engram.Crypto do
     do: {:ok, vault}
 
   def maybe_decrypt_vault_fields(%Engram.Vaults.Vault{} = vault, %User{} = user) do
+    name_aad = decrypt_aad(vault, :vaults, :name)
+
     with {:ok, dek} <- get_dek(user),
-         {:ok, name} <- Envelope.decrypt(vault.name_ciphertext, vault.name_nonce, dek) do
+         {:ok, name} <- Envelope.decrypt(vault.name_ciphertext, vault.name_nonce, dek, name_aad) do
       {:ok, %{vault | name: name}}
     else
       :error -> {:error, :decrypt_failed}
@@ -287,6 +390,14 @@ defmodule Engram.Crypto do
   `Notes.upsert_note/3`, which provisions the DEK. A missing DEK here
   signals a config bug; fail-loud via Oban retry + telemetry is preferable
   to silent lazy-provisioning.
+
+  ## 2-arity vs 4-arity (T3.6)
+
+  The 2-arity form emits non-AAD-bound payloads — kept for tests that mock
+  Qdrant search responses without threading through a stable point id.
+  Production code must use the 4-arity AAD-bound variant; every real point
+  flows through `Engram.Indexing.prepare_index/2` which generates the
+  point UUID before calling `encrypt_qdrant_payload/4`.
   """
   @spec encrypt_qdrant_payload(map(), User.t()) :: {:ok, map()} | {:error, term()}
   def encrypt_qdrant_payload(payload, %User{} = user) do
@@ -306,6 +417,31 @@ defmodule Engram.Crypto do
     end
   end
 
+  @spec encrypt_qdrant_payload(map(), User.t(), String.t(), String.t()) ::
+          {:ok, map()} | {:error, term()}
+  def encrypt_qdrant_payload(payload, %User{} = user, collection, qdrant_id)
+      when is_binary(collection) and is_binary(qdrant_id) do
+    with {:ok, dek} <- get_dek(user) do
+      text_aad = aad_for_qdrant(collection, qdrant_id, :text)
+      title_aad = aad_for_qdrant(collection, qdrant_id, :title)
+      hp_aad = aad_for_qdrant(collection, qdrant_id, :heading_path)
+
+      {text_ct, text_nonce} = Envelope.encrypt(Map.get(payload, :text) || "", dek, text_aad)
+      {title_ct, title_nonce} = Envelope.encrypt(Map.get(payload, :title) || "", dek, title_aad)
+      {hp_ct, hp_nonce} = Envelope.encrypt(Map.get(payload, :heading_path) || "", dek, hp_aad)
+
+      {:ok,
+       payload
+       |> Map.put(:text, Base.encode64(text_ct))
+       |> Map.put(:text_nonce, Base.encode64(text_nonce))
+       |> Map.put(:title, Base.encode64(title_ct))
+       |> Map.put(:title_nonce, Base.encode64(title_nonce))
+       |> Map.put(:heading_path, Base.encode64(hp_ct))
+       |> Map.put(:heading_path_nonce, Base.encode64(hp_nonce))
+       |> Map.put(:aad_version, @row_version_aad_bound)}
+    end
+  end
+
   @doc """
   Decrypts a list of Qdrant search candidates in-place. Phase B.4:
   encryption is mandatory, so every candidate with a known vault is
@@ -322,9 +458,11 @@ defmodule Engram.Crypto do
           String.t() => Engram.Vaults.Vault.t()
         }) ::
           {:ok, [map()]} | {:error, :decrypt_failed}
-  def decrypt_qdrant_candidates([], _user, _vaults_by_id), do: {:ok, []}
+  def decrypt_qdrant_candidates(candidates, user, vaults_by_id, collection \\ nil)
 
-  def decrypt_qdrant_candidates(candidates, %User{} = user, vaults_by_id)
+  def decrypt_qdrant_candidates([], _user, _vaults_by_id, _collection), do: {:ok, []}
+
+  def decrypt_qdrant_candidates(candidates, %User{} = user, vaults_by_id, collection)
       when is_list(candidates) and is_map(vaults_by_id) do
     # Lazy DEK load — only fetch if at least one candidate carries
     # ciphertext. Mocked test traffic that returns plaintext-only
@@ -333,7 +471,7 @@ defmodule Engram.Crypto do
       {:ok, dek_or_nil} ->
         decrypted =
           candidates
-          |> Enum.flat_map(&decrypt_one(&1, vaults_by_id, dek_or_nil))
+          |> Enum.flat_map(&decrypt_one(&1, vaults_by_id, dek_or_nil, collection))
 
         if decrypted == [] and candidates != [] do
           {:error, :decrypt_failed}
@@ -371,7 +509,7 @@ defmodule Engram.Crypto do
   # Phase B.4: every production payload MUST carry vault_id + text_nonce.
   # Anything else is a shape mismatch — dropped + telemetry, no plaintext
   # passthrough that could leak ciphertext-as-plaintext on a malformed point.
-  defp decrypt_one(candidate, vaults_by_id, dek) do
+  defp decrypt_one(candidate, vaults_by_id, dek, collection) do
     vault_id_key = candidate_vault_id(candidate)
 
     cond do
@@ -384,7 +522,7 @@ defmodule Engram.Crypto do
         []
 
       true ->
-        lookup_and_decrypt(candidate, vault_id_key, vaults_by_id, dek)
+        lookup_and_decrypt(candidate, vault_id_key, vaults_by_id, dek, collection)
     end
   end
 
@@ -402,27 +540,47 @@ defmodule Engram.Crypto do
     )
   end
 
-  defp lookup_and_decrypt(candidate, vault_id_key, vaults_by_id, dek) do
+  defp lookup_and_decrypt(candidate, vault_id_key, vaults_by_id, dek, collection) do
     case Map.get(vaults_by_id, vault_id_key) do
       nil ->
         emit_shape_mismatch(vault_id_key, candidate, "vault not in lookup map")
         []
 
       %Engram.Vaults.Vault{} ->
-        do_decrypt_candidate(candidate, dek)
+        do_decrypt_candidate(candidate, dek, collection)
     end
   end
 
-  defp do_decrypt_candidate(candidate, dek) do
+  # T3.6 — AAD-bound payloads carry `aad_version >= 2`. Older points written
+  # before this PR have neither key — fall back to empty AAD. `collection`
+  # may be nil when callers haven't been threaded through yet (legacy reads
+  # only); empty AAD applies in that case too.
+  defp qdrant_aad(candidate, collection, field) do
+    aad_version = Map.get(candidate, :aad_version)
+    qdrant_id = Map.get(candidate, :qdrant_id)
+
+    if is_binary(collection) and is_binary(qdrant_id) and aad_version_aad_bound?(aad_version),
+      do: aad_for_qdrant(collection, qdrant_id, field),
+      else: <<>>
+  end
+
+  defp aad_version_aad_bound?(v) when is_integer(v) and v >= @row_version_aad_bound, do: true
+  defp aad_version_aad_bound?(_), do: false
+
+  defp do_decrypt_candidate(candidate, dek, collection) do
+    text_aad = qdrant_aad(candidate, collection, :text)
+    title_aad = qdrant_aad(candidate, collection, :title)
+    hp_aad = qdrant_aad(candidate, collection, :heading_path)
+
     with {:ok, text_ct} <- safe_decode64(Map.get(candidate, :text)),
          {:ok, text_nonce} <- safe_decode64(Map.get(candidate, :text_nonce)),
          {:ok, title_ct} <- safe_decode64(Map.get(candidate, :title)),
          {:ok, title_nonce} <- safe_decode64(Map.get(candidate, :title_nonce)),
          {:ok, hp_ct} <- safe_decode64(Map.get(candidate, :heading_path)),
          {:ok, hp_nonce} <- safe_decode64(Map.get(candidate, :heading_path_nonce)),
-         {:ok, text} <- Envelope.decrypt(text_ct, text_nonce, dek),
-         {:ok, title} <- Envelope.decrypt(title_ct, title_nonce, dek),
-         {:ok, heading_path} <- Envelope.decrypt(hp_ct, hp_nonce, dek) do
+         {:ok, text} <- Envelope.decrypt(text_ct, text_nonce, dek, text_aad),
+         {:ok, title} <- Envelope.decrypt(title_ct, title_nonce, dek, title_aad),
+         {:ok, heading_path} <- Envelope.decrypt(hp_ct, hp_nonce, dek, hp_aad) do
       decrypted =
         candidate
         |> Map.put(:text, text)

--- a/lib/engram/crypto/aad_rebind.ex
+++ b/lib/engram/crypto/aad_rebind.ex
@@ -1,0 +1,368 @@
+defmodule Engram.Crypto.AadRebind do
+  @moduledoc """
+  T3.6 / H1 — per-user AAD-rebind backfill.
+
+  For each user, walks `notes`, `attachments`, and `vaults` rows with
+  `dek_version < target_version` (default 2). For each legacy row:
+
+    1. Decrypts every ciphertext column with empty AAD (legacy semantics).
+    2. Re-encrypts with row-id-bound AAD
+       (`"<table>:<column>:<row_id>"`).
+    3. Stamps `dek_version = target_version` on the row in a single
+       UPDATE so the read path's AAD dispatch flips atomically.
+
+  Also upgrades the user's `encrypted_dek` wrap format from v1 (or pre-T3.4
+  legacy) to v2 (AAD-bound, AAD = `"dek:v1:<user_id>"`) if it is not
+  already.
+
+  Per-user transaction with `SELECT ... FOR UPDATE` on the user row.
+  Concurrent runs serialize cleanly: the loser sees an already-rebound
+  user and short-circuits to `:skipped`.
+
+  ## When to use
+
+  Only relevant during the T3.6 cutover. After the backfill drains
+  (`SELECT MIN(dek_version) FROM notes ≥ 2` and ditto for attachments /
+  vaults / users), every read path uses constructed AAD and the empty-AAD
+  fallback in the decrypt helpers becomes dead code (kept anyway as a
+  safety net).
+  """
+
+  import Ecto.Query, only: [from: 2]
+  require Logger
+
+  alias Engram.Accounts.User
+  alias Engram.Attachments.Attachment
+  alias Engram.Crypto
+  alias Engram.Crypto.Envelope
+  alias Engram.Crypto.KeyProvider.Resolver
+  alias Engram.Notes.Note
+  alias Engram.Repo
+  alias Engram.Vaults.Vault
+
+  @typedoc "`:ok` on rebind, `:skipped` on no-op, `{:error, reason}` on failure."
+  @type rebind_result :: :ok | :skipped | {:error, term()}
+
+  @typedoc "Aggregate over the user fleet."
+  @type counts :: %{
+          ok: non_neg_integer(),
+          skipped: non_neg_integer(),
+          failed: non_neg_integer()
+        }
+
+  @target_version 2
+
+  @doc "Rebind all users with at least one row below target."
+  @spec rebind_all(keyword()) :: counts()
+  def rebind_all(opts \\ []) do
+    batch_size = Keyword.get(opts, :batch_size, 100)
+    drive_loop(0, batch_size, %{ok: 0, skipped: 0, failed: 0})
+  end
+
+  @doc "Rebind a single user. Idempotent — already-rebound users return `:skipped`."
+  @spec rebind_user(integer() | User.t()) :: rebind_result()
+  def rebind_user(%User{id: id}), do: rebind_user(id)
+
+  def rebind_user(user_id) when is_integer(user_id) do
+    started_at = System.monotonic_time()
+    result = do_rebind(user_id)
+    duration_us = duration_us_since(started_at)
+    emit_telemetry(user_id, result, duration_us)
+
+    case result do
+      {:rebound, _} -> :ok
+      :skipped -> :skipped
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # ── internals ───────────────────────────────────────────────────────────────
+
+  defp do_rebind(user_id) do
+    Repo.transaction(fn ->
+      locked =
+        from(u in User, where: u.id == ^user_id, lock: "FOR UPDATE")
+        |> Repo.one(skip_tenant_check: true)
+
+      cond do
+        is_nil(locked) ->
+          Repo.rollback({:not_found, user_id})
+
+        is_nil(locked.encrypted_dek) ->
+          # Provisioned-on-demand user — nothing to rebind.
+          :skipped
+
+        true ->
+          rebind_locked_user(locked)
+      end
+    end)
+    |> case do
+      {:ok, :skipped} -> :skipped
+      {:ok, {:rebound, _} = ok} -> ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp rebind_locked_user(%User{} = user) do
+    with :ok <- rewrap_user_dek_if_needed(user),
+         :ok <- rebind_user_notes(user),
+         :ok <- rebind_user_attachments(user),
+         :ok <- rebind_user_vaults(user) do
+      {:rebound, user}
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  # 0x01 (or pre-T3.4 60-byte legacy) → 0x02 with AAD = "dek:v1:<user_id>".
+  defp rewrap_user_dek_if_needed(%User{encrypted_dek: blob} = user) do
+    case classify_wrap(blob) do
+      :v2 ->
+        :ok
+
+      :legacy_or_v1 ->
+        provider = Resolver.provider_for(user.id)
+        ctx = %{user_id: user.id}
+
+        with {:ok, dek} <- provider.unwrap_dek(blob, ctx),
+             {:ok, new_wrapped} <- provider.wrap_dek(dek, ctx) do
+          changeset = Ecto.Changeset.change(user, encrypted_dek: new_wrapped)
+
+          case Repo.update(changeset, skip_tenant_check: true) do
+            {:ok, _} ->
+              # Invalidate any cached plaintext DEK keyed off the previous
+              # wrap so the next get_dek/1 re-derives via the new wrap. The
+              # plaintext DEK material is unchanged; only the wrap envelope
+              # changed.
+              Crypto.DekCache.invalidate(user.id)
+              :ok
+
+            {:error, changeset} ->
+              {:error, changeset}
+          end
+        end
+    end
+  end
+
+  defp classify_wrap(<<0x02, 0x01, _rest::binary>>), do: :v2
+  defp classify_wrap(_blob), do: :legacy_or_v1
+
+  defp rebind_user_notes(%User{id: user_id} = user) do
+    {:ok, dek} = Crypto.get_dek(user)
+    legacy_version = Crypto.row_version_legacy()
+
+    rows =
+      from(n in Note,
+        where: n.user_id == ^user_id and n.dek_version == ^legacy_version,
+        select: n
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    Enum.reduce_while(rows, :ok, fn note, _acc ->
+      case rebind_note(note, dek) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:note, note.id, reason}}}
+      end
+    end)
+  end
+
+  defp rebind_note(%Note{id: id} = note, dek) do
+    with {:ok, content} <- decrypt_legacy(note.content_ciphertext, note.content_nonce, dek),
+         {:ok, title} <- decrypt_legacy(note.title_ciphertext, note.title_nonce, dek),
+         {:ok, path} <- decrypt_legacy(note.path_ciphertext, note.path_nonce, dek),
+         {:ok, folder} <- decrypt_legacy(note.folder_ciphertext, note.folder_nonce, dek),
+         {:ok, tags_bin} <- decrypt_legacy(note.tags_ciphertext, note.tags_nonce, dek) do
+      {content_ct, content_n} =
+        Envelope.encrypt(content, dek, Crypto.aad_for_row(:notes, :content, id))
+
+      {title_ct, title_n} =
+        Envelope.encrypt(title, dek, Crypto.aad_for_row(:notes, :title, id))
+
+      {path_ct, path_n} =
+        Envelope.encrypt(path, dek, Crypto.aad_for_row(:notes, :path, id))
+
+      {folder_ct, folder_n} =
+        Envelope.encrypt(folder, dek, Crypto.aad_for_row(:notes, :folder, id))
+
+      {tags_ct, tags_n} =
+        Envelope.encrypt(tags_bin, dek, Crypto.aad_for_row(:notes, :tags, id))
+
+      {1, _} =
+        from(n in Note, where: n.id == ^id)
+        |> Repo.update_all(
+          [
+            set: [
+              content_ciphertext: content_ct,
+              content_nonce: content_n,
+              title_ciphertext: title_ct,
+              title_nonce: title_n,
+              path_ciphertext: path_ct,
+              path_nonce: path_n,
+              folder_ciphertext: folder_ct,
+              folder_nonce: folder_n,
+              tags_ciphertext: tags_ct,
+              tags_nonce: tags_n,
+              dek_version: @target_version
+            ]
+          ],
+          skip_tenant_check: true
+        )
+
+      :ok
+    end
+  end
+
+  defp rebind_user_attachments(%User{id: user_id} = user) do
+    {:ok, dek} = Crypto.get_dek(user)
+    legacy_version = Crypto.row_version_legacy()
+
+    rows =
+      from(a in Attachment,
+        where: a.user_id == ^user_id and a.dek_version == ^legacy_version,
+        select: a
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    Enum.reduce_while(rows, :ok, fn att, _acc ->
+      :ok = rebind_attachment(att, dek)
+      {:cont, :ok}
+    end)
+  end
+
+  # NOTE: attachments hold their content blob in S3, not in Postgres.
+  # T3.6 only re-encrypts the row-resident `path_ciphertext`. The S3
+  # object's content_ciphertext keeps its old AAD (=<<>>) until that
+  # blob is also rotated through `Storage.adapter`. The read path uses
+  # `att.dek_version` to gate the AAD on `path_ciphertext` decrypt;
+  # content decrypt also gates on the same field. After this rebind,
+  # attempting to read the S3 blob would fail because we stamped
+  # dek_version=2 on the row but the blob was written with empty AAD.
+  #
+  # To avoid breaking attachment reads on legacy rows, we DO NOT rebind
+  # attachments in this backfill — only `path_ciphertext` would change
+  # and the dek_version stamp would mismatch the S3 blob's AAD.
+  # Attachments converge naturally on their next write (every
+  # `upsert_attachment` re-encrypts content + path with v2 AAD). Old
+  # blobs that are never re-uploaded stay legacy forever, which is fine
+  # because their content was always written with empty AAD and the
+  # read path honors that via `att.dek_version`.
+  defp rebind_attachment(_att, _dek), do: :ok
+
+  defp rebind_user_vaults(%User{id: user_id} = user) do
+    {:ok, dek} = Crypto.get_dek(user)
+    legacy_version = Crypto.row_version_legacy()
+
+    rows =
+      from(v in Vault,
+        where: v.user_id == ^user_id and v.dek_version == ^legacy_version,
+        select: v
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    Enum.reduce_while(rows, :ok, fn vault, _acc ->
+      case rebind_vault(vault, dek) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:vault, vault.id, reason}}}
+      end
+    end)
+  end
+
+  defp rebind_vault(%Vault{id: id} = vault, dek) do
+    with {:ok, name} <- decrypt_legacy(vault.name_ciphertext, vault.name_nonce, dek) do
+      {ct, n} = Envelope.encrypt(name, dek, Crypto.aad_for_row(:vaults, :name, id))
+
+      {1, _} =
+        from(v in Vault, where: v.id == ^id)
+        |> Repo.update_all(
+          [
+            set: [
+              name_ciphertext: ct,
+              name_nonce: n,
+              dek_version: @target_version
+            ]
+          ],
+          skip_tenant_check: true
+        )
+
+      :ok
+    end
+  end
+
+  defp decrypt_legacy(nil, _nonce, _dek), do: {:ok, nil}
+  defp decrypt_legacy(_ct, nil, _dek), do: {:ok, nil}
+
+  defp decrypt_legacy(ct, nonce, dek) do
+    case Envelope.decrypt(ct, nonce, dek, <<>>) do
+      {:ok, plaintext} -> {:ok, plaintext}
+      :error -> {:error, :legacy_decrypt_failed}
+    end
+  end
+
+  defp drive_loop(last_id, batch_size, acc) do
+    ids =
+      from(u in User,
+        where: not is_nil(u.encrypted_dek) and u.id > ^last_id,
+        select: u.id,
+        order_by: u.id,
+        limit: ^batch_size
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    case ids do
+      [] ->
+        acc
+
+      _ ->
+        acc =
+          Enum.reduce(ids, acc, fn id, a ->
+            case rebind_user(id) do
+              :ok -> Map.update!(a, :ok, &(&1 + 1))
+              :skipped -> Map.update!(a, :skipped, &(&1 + 1))
+              {:error, _} -> Map.update!(a, :failed, &(&1 + 1))
+            end
+          end)
+
+        drive_loop(List.last(ids), batch_size, acc)
+    end
+  end
+
+  defp duration_us_since(started_at) do
+    System.convert_time_unit(
+      System.monotonic_time() - started_at,
+      :native,
+      :microsecond
+    )
+  end
+
+  defp emit_telemetry(user_id, {:rebound, _}, duration_us) do
+    :telemetry.execute(
+      [:engram, :crypto, :aad_rebind, :user],
+      %{duration_us: duration_us, count: 1},
+      %{user_id: user_id, status: :ok}
+    )
+  end
+
+  defp emit_telemetry(user_id, :skipped, duration_us) do
+    :telemetry.execute(
+      [:engram, :crypto, :aad_rebind, :user],
+      %{duration_us: duration_us, count: 1},
+      %{user_id: user_id, status: :skipped}
+    )
+  end
+
+  defp emit_telemetry(user_id, {:error, reason}, duration_us) do
+    :telemetry.execute(
+      [:engram, :crypto, :aad_rebind, :user],
+      %{duration_us: duration_us, count: 1},
+      %{user_id: user_id, status: :failed, reason_label: reason_label(reason)}
+    )
+  end
+
+  defp reason_label({:not_found, _}), do: "not_found"
+  defp reason_label({:note, _, r}), do: "note:" <> reason_label(r)
+  defp reason_label({:vault, _, r}), do: "vault:" <> reason_label(r)
+  defp reason_label({:attachment, _, r}), do: "attachment:" <> reason_label(r)
+  defp reason_label(:legacy_decrypt_failed), do: "legacy_decrypt_failed"
+  defp reason_label(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp reason_label(_), do: "other"
+end

--- a/lib/engram/crypto/boot_canary.ex
+++ b/lib/engram/crypto/boot_canary.ex
@@ -53,7 +53,7 @@ defmodule Engram.Crypto.BootCanary do
         :ok
 
       %{wrapped_dek: blob, dek_sha256: expected_hash} ->
-        case Local.unwrap_dek_current_only(blob) do
+        case Local.unwrap_dek_current_only(blob, user_id: :canary) do
           {:ok, plaintext_dek} ->
             if :crypto.hash(:sha256, plaintext_dek) == expected_hash do
               :telemetry.execute([:engram, :crypto, :boot_canary], %{count: 1}, %{status: :ok})

--- a/lib/engram/crypto/envelope.ex
+++ b/lib/engram/crypto/envelope.ex
@@ -1,24 +1,59 @@
 defmodule Engram.Crypto.Envelope do
   @moduledoc """
-  Stateless AES-256-GCM authenticated encryption.
-  Ciphertext layout returned by encrypt/2 is `ciphertext || tag` (16-byte tag suffix).
-  The nonce is returned separately; callers store it alongside ciphertext.
+  Stateless AES-256-GCM authenticated encryption with associated data (AAD).
+
+  Ciphertext layout returned by `encrypt/3` is `ciphertext || tag` (16-byte
+  tag suffix). The nonce is returned separately; callers store it alongside
+  ciphertext.
+
+  ## AAD (T3.6 / H1)
+
+  Every ciphertext is bound to a context string via AES-GCM's AAD slot.
+  Tampering with AAD on read fails the AEAD tag check, even though AAD
+  itself is not encrypted. Per-row AAD makes within-user cross-row swaps
+  detectable: copying `notes.content_ciphertext + content_nonce` from row
+  42 into row 99 cannot decrypt under row 99's reconstructed AAD.
+
+  AAD shape per call site:
+
+    * Relational rows  — `"<table>:<column>:<row_id>"` (e.g. `"notes:content:42"`)
+    * Qdrant payload   — `"qdrant:<collection>:<qdrant_id>:<field>"`
+    * Wrapped DEK      — `"dek:v1:<user_id>"`
+
+  ## Backwards compatibility
+
+  Pre-T3.6 ciphertext was written with empty AAD (`<<>>`). The 2/3-arity
+  `encrypt/2` / `decrypt/3` clauses delegate to the AAD-aware arity with
+  `<<>>` so legacy reads keep working. Per-row `dek_version` (notes /
+  attachments / vaults) and the wrap-format byte (users.encrypted_dek)
+  signal whether a constructed AAD or `<<>>` should be supplied — that
+  decision lives at the caller, not here.
   """
 
   @cipher :aes_256_gcm
   @nonce_bytes 12
   @tag_bytes 16
 
+  @typedoc "AES-GCM Additional Authenticated Data — bound to ciphertext but not encrypted."
+  @type aad :: binary()
+
   @spec encrypt(binary(), <<_::256>>) :: {binary(), binary()}
-  def encrypt(plaintext, <<_::256>> = dek) when is_binary(plaintext) do
+  def encrypt(plaintext, dek), do: encrypt(plaintext, dek, <<>>)
+
+  @spec encrypt(binary(), <<_::256>>, aad()) :: {binary(), binary()}
+  def encrypt(plaintext, <<_::256>> = dek, aad)
+      when is_binary(plaintext) and is_binary(aad) do
     nonce = :crypto.strong_rand_bytes(@nonce_bytes)
-    {ct, tag} = :crypto.crypto_one_time_aead(@cipher, dek, nonce, plaintext, <<>>, true)
+    {ct, tag} = :crypto.crypto_one_time_aead(@cipher, dek, nonce, plaintext, aad, true)
     {ct <> tag, nonce}
   end
 
   @spec decrypt(binary(), binary(), <<_::256>>) :: {:ok, binary()} | :error
-  def decrypt(ct_with_tag, nonce, <<_::256>> = dek)
-      when is_binary(ct_with_tag) and byte_size(nonce) == @nonce_bytes do
+  def decrypt(ct_with_tag, nonce, dek), do: decrypt(ct_with_tag, nonce, dek, <<>>)
+
+  @spec decrypt(binary(), binary(), <<_::256>>, aad()) :: {:ok, binary()} | :error
+  def decrypt(ct_with_tag, nonce, <<_::256>> = dek, aad)
+      when is_binary(ct_with_tag) and byte_size(nonce) == @nonce_bytes and is_binary(aad) do
     size = byte_size(ct_with_tag) - @tag_bytes
 
     if size < 0 do
@@ -26,12 +61,12 @@ defmodule Engram.Crypto.Envelope do
     else
       <<ct::binary-size(size), tag::binary-size(@tag_bytes)>> = ct_with_tag
 
-      case :crypto.crypto_one_time_aead(@cipher, dek, nonce, ct, <<>>, tag, false) do
+      case :crypto.crypto_one_time_aead(@cipher, dek, nonce, ct, aad, tag, false) do
         plaintext when is_binary(plaintext) -> {:ok, plaintext}
         :error -> :error
       end
     end
   end
 
-  def decrypt(_ct_with_tag, _nonce, <<_::256>>), do: :error
+  def decrypt(_ct_with_tag, _nonce, <<_::256>>, _aad), do: :error
 end

--- a/lib/engram/crypto/key_provider/local.ex
+++ b/lib/engram/crypto/key_provider/local.ex
@@ -4,24 +4,27 @@ defmodule Engram.Crypto.KeyProvider.Local do
   Wraps DEKs with AES-256-GCM using ENCRYPTION_MASTER_KEY.
   Supports one-key-back fallback for rotation via ENCRYPTION_MASTER_KEY_PREVIOUS.
 
-  ## Wrap format (T3.4 / M2)
+  ## Wrap format (T3.4 / M2 + T3.6 / H1)
 
-  New writes use a 2-byte header before nonce + ciphertext:
+  Three coexisting shapes:
 
-      <<0x01, 0x01, nonce::binary-size(12), ct::binary>>
-      # ^^^   ^^^   ^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^
-      #  |     |    |                       AES-GCM ct + 16-byte tag
-      #  |     |    fresh per-encrypt nonce
-      #  |     algorithm id (0x01 = AES-256-GCM)
-      #  wrap-format version (0x01 = first header-bearing version)
+      v2 (T3.6, AAD-bound):
+        <<0x02, 0x01, nonce::binary-size(12), ct::binary>>
+        AAD on encrypt = "dek:v1:<user_id>" (pulled from ctx.user_id).
 
-  Pre-T3.4 rows in DB carry the legacy raw shape `<<nonce::12, ct::binary>>`
-  (no header). `unwrap_dek/2` reads both shapes — the version-byte form
-  matches first, and a 60-byte raw shape falls through to the legacy
-  clause. Disambiguation is by total `byte_size/1`:
+      v1 (T3.4, no AAD):
+        <<0x01, 0x01, nonce::binary-size(12), ct::binary>>
+        AAD = <<>>.
 
-      legacy: 12 (nonce) + 32 (DEK) + 16 (GCM tag) = 60 bytes
-      v1:      2 (header) + 60                     = 62 bytes
+      legacy (pre-T3.4, no AAD, no header):
+        <<nonce::binary-size(12), ct::binary>>
+
+  `wrap_dek/2` always emits v2. `unwrap_dek/2` reads all three based on the
+  leading byte and total `byte_size/1`:
+
+      legacy: 12 (nonce) + 32 (DEK) + 16 (GCM tag) = 60 bytes, no header
+      v1:      2 (header) + 60                     = 62 bytes, header 0x01
+      v2:      2 (header) + 60                     = 62 bytes, header 0x02
   """
 
   @behaviour Engram.Crypto.KeyProvider
@@ -29,8 +32,9 @@ defmodule Engram.Crypto.KeyProvider.Local do
   alias Engram.Crypto.Envelope
   alias Engram.Crypto.Config
 
-  # T3.4 / M2 — wrap-format constants.
+  # T3.4 / M2 + T3.6 / H1 — wrap-format constants.
   @wrap_version_v1 0x01
+  @wrap_version_v2 0x02
   @alg_aes_256_gcm 0x01
 
   @impl true
@@ -40,25 +44,33 @@ defmodule Engram.Crypto.KeyProvider.Local do
   def generate_dek, do: Engram.Crypto.KeyProvider.default_generate_dek()
 
   @impl true
-  def wrap_dek(<<_::256>> = dek, _ctx) do
+  def wrap_dek(<<_::256>> = dek, ctx) do
+    user_id = require_user_id!(ctx)
+    aad = Engram.Crypto.aad_for_wrapped_dek(user_id)
     master = Config.local_master_key!()
-    {ct, nonce} = Envelope.encrypt(dek, master)
+    {ct, nonce} = Envelope.encrypt(dek, master, aad)
 
     {:ok,
-     <<@wrap_version_v1, @alg_aes_256_gcm, nonce::binary-size(12), ct::binary>>}
+     <<@wrap_version_v2, @alg_aes_256_gcm, nonce::binary-size(12), ct::binary>>}
   end
 
   @impl true
   def unwrap_dek(blob, ctx) when is_binary(blob) do
     case blob do
+      <<@wrap_version_v2, @alg_aes_256_gcm, nonce::binary-size(12), ct::binary>>
+      when byte_size(blob) == 62 ->
+        # T3.6 — AAD-bound wrap. AAD = "dek:v1:<user_id>" pulled from ctx.
+        user_id = require_user_id!(ctx)
+        do_unwrap(ct, nonce, ctx, Engram.Crypto.aad_for_wrapped_dek(user_id))
+
       <<@wrap_version_v1, @alg_aes_256_gcm, nonce::binary-size(12), ct::binary>>
       when byte_size(blob) == 62 ->
-        do_unwrap(ct, nonce, ctx)
+        # T3.4 v1 — header present, no AAD.
+        do_unwrap(ct, nonce, ctx, <<>>)
 
       <<nonce::binary-size(12), ct::binary>> when byte_size(blob) == 60 ->
-        # T3.4 — legacy pre-header shape. Kept for backward read so the
-        # wrap-version rollout does not require a backfill pass.
-        do_unwrap(ct, nonce, ctx)
+        # Pre-T3.4 raw shape. No AAD.
+        do_unwrap(ct, nonce, ctx, <<>>)
 
       _ ->
         {:error, :malformed_wrapped_blob}
@@ -66,6 +78,13 @@ defmodule Engram.Crypto.KeyProvider.Local do
   end
 
   def unwrap_dek(_other, _ctx), do: {:error, :malformed_wrapped_blob}
+
+  defp require_user_id!(ctx) do
+    case Map.get(ctx, :user_id) do
+      nil -> raise ArgumentError, "Local KeyProvider requires ctx.user_id for AAD binding"
+      user_id -> user_id
+    end
+  end
 
   # T3.5 / M4 — `_PREVIOUS` fallback is gated on the user's `dek_version`
   # vs the configured `master_key_version`. A user whose dek_version is
@@ -77,19 +96,19 @@ defmodule Engram.Crypto.KeyProvider.Local do
   # Telemetry `[:engram, :crypto, :previous_fallback_hit]` fires
   # whenever the fallback is consulted (whether it rescues or not), so
   # operators can watch the count drop to zero post-rotation.
-  defp do_unwrap(ct, nonce, ctx) do
+  defp do_unwrap(ct, nonce, ctx, aad) do
     current = Config.local_master_key!()
 
-    case Envelope.decrypt(ct, nonce, current) do
+    case Envelope.decrypt(ct, nonce, current, aad) do
       {:ok, <<_::256>> = dek} ->
         {:ok, dek}
 
       :error ->
-        try_previous_fallback(ct, nonce, ctx)
+        try_previous_fallback(ct, nonce, ctx, aad)
     end
   end
 
-  defp try_previous_fallback(ct, nonce, ctx) do
+  defp try_previous_fallback(ct, nonce, ctx, aad) do
     if previous_fallback_allowed?(ctx) do
       case Config.local_master_key_previous() do
         nil ->
@@ -98,7 +117,7 @@ defmodule Engram.Crypto.KeyProvider.Local do
 
         prev ->
           result =
-            case Envelope.decrypt(ct, nonce, prev) do
+            case Envelope.decrypt(ct, nonce, prev, aad) do
               {:ok, <<_::256>> = dek} -> {:ok, dek}
               :error -> {:error, :invalid_wrapping}
             end
@@ -161,25 +180,42 @@ defmodule Engram.Crypto.KeyProvider.Local do
   from `unwrap_dek/2` so production callers cannot accidentally adopt
   this mode and break legitimate rotation reads.
   """
-  @spec unwrap_dek_current_only(binary()) :: {:ok, <<_::256>>} | {:error, term()}
-  def unwrap_dek_current_only(blob) when is_binary(blob) do
+  @spec unwrap_dek_current_only(binary(), keyword()) ::
+          {:ok, <<_::256>>} | {:error, term()}
+  def unwrap_dek_current_only(blob, opts \\ []) when is_binary(blob) do
     current = Config.local_master_key!()
+    user_id = Keyword.get(opts, :user_id)
 
     case blob do
+      <<@wrap_version_v2, @alg_aes_256_gcm, nonce::binary-size(12), ct::binary>>
+      when byte_size(blob) == 62 ->
+        case user_id do
+          nil ->
+            {:error, :missing_user_id_for_aad}
+
+          uid ->
+            decrypt_or_invalid(
+              ct,
+              nonce,
+              current,
+              Engram.Crypto.aad_for_wrapped_dek(uid)
+            )
+        end
+
       <<@wrap_version_v1, @alg_aes_256_gcm, nonce::binary-size(12), ct::binary>>
       when byte_size(blob) == 62 ->
-        decrypt_or_invalid(ct, nonce, current)
+        decrypt_or_invalid(ct, nonce, current, <<>>)
 
       <<nonce::binary-size(12), ct::binary>> when byte_size(blob) == 60 ->
-        decrypt_or_invalid(ct, nonce, current)
+        decrypt_or_invalid(ct, nonce, current, <<>>)
 
       _ ->
         {:error, :malformed_wrapped_blob}
     end
   end
 
-  defp decrypt_or_invalid(ct, nonce, key) do
-    case Envelope.decrypt(ct, nonce, key) do
+  defp decrypt_or_invalid(ct, nonce, key, aad) do
+    case Envelope.decrypt(ct, nonce, key, aad) do
       {:ok, <<_::256>> = dek} -> {:ok, dek}
       :error -> {:error, :invalid_wrapping}
     end

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -173,7 +173,7 @@ defmodule Engram.Indexing do
           tags_hmac: Enum.map(note.tags_hmac || [], &Base.encode64/1)
         }
 
-        case Engram.Crypto.encrypt_qdrant_payload(base_payload, user) do
+        case Engram.Crypto.encrypt_qdrant_payload(base_payload, user, collection(), point_id) do
           {:ok, payload} ->
             row = %{
               note_id: note.id,

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -30,42 +30,55 @@ defmodule Engram.Notes do
          folder = Helpers.extract_folder(sanitized_path),
          tags = Helpers.extract_tags(content),
          {:ok, hash} <- content_hash(user, content),
-         now = DateTime.utc_now(),
-         note_attrs = %{
-           content: content,
-           title: title,
-           tags: tags,
-           content_hash: hash,
-           mtime: mtime,
-           user_id: user.id,
-           vault_id: vault.id,
-           created_at: now,
-           updated_at: now
-         },
-         {:ok, note_attrs} <- Engram.Crypto.encrypt_note_fields(note_attrs, user),
-         note_attrs = inject_phase_b_fields(note_attrs, user, sanitized_path, folder, tags) do
-      changeset = Note.changeset(%Note{}, note_attrs)
+         now = DateTime.utc_now() do
+      base_attrs = %{
+        content: content,
+        title: title,
+        tags: tags,
+        content_hash: hash,
+        mtime: mtime,
+        user_id: user.id,
+        vault_id: vault.id,
+        created_at: now,
+        updated_at: now
+      }
+
       {:ok, lookup_query} = note_by_path_query(user, vault, sanitized_path)
 
       result =
         Repo.with_tenant(user.id, fn ->
           case Repo.one(lookup_query) do
             nil ->
-              case Repo.insert(changeset) do
-                {:ok, note} -> {:ok, {nil, note}}
-                {:error, changeset} -> {:error, changeset}
+              # T3.6 — pre-allocate the row id so the AAD bind string
+              # ("notes:<column>:<id>") can be computed before INSERT.
+              note_id = Engram.Crypto.next_row_id(:notes)
+
+              with {:ok, encrypted} <-
+                     Engram.Crypto.encrypt_note_fields(base_attrs, user, note_id) do
+                phase_b = inject_phase_b_fields(encrypted, user, note_id, sanitized_path, folder, tags)
+                changeset = Note.changeset(%Note{id: note_id}, phase_b)
+
+                case Repo.insert(changeset) do
+                  {:ok, note} -> {:ok, {nil, note}}
+                  {:error, changeset} -> {:error, changeset}
+                end
               end
 
             existing ->
               if client_version != nil and client_version != existing.version do
                 {:conflict, existing}
               else
-                existing
-                |> Note.changeset(Map.put(note_attrs, :version, existing.version + 1))
-                |> Repo.update()
-                |> case do
-                  {:ok, updated} -> {:ok, {existing.content_hash, updated}}
-                  {:error, changeset} -> {:error, changeset}
+                with {:ok, encrypted} <-
+                       Engram.Crypto.encrypt_note_fields(base_attrs, user, existing.id) do
+                  phase_b = inject_phase_b_fields(encrypted, user, existing.id, sanitized_path, folder, tags)
+
+                  existing
+                  |> Note.changeset(Map.put(phase_b, :version, existing.version + 1))
+                  |> Repo.update()
+                  |> case do
+                    {:ok, updated} -> {:ok, {existing.content_hash, updated}}
+                    {:error, changeset} -> {:error, changeset}
+                  end
                 end
               end
           end
@@ -166,19 +179,24 @@ defmodule Engram.Notes do
             decrypted_note = decrypt_or_raise!(note, user)
             new_title = Helpers.extract_title(decrypted_note.content || "", new_path)
 
-            # Rename re-keys path/folder but not tags — preserve existing
-            # tags_hmac/tags_ciphertext on the row.
-            phase_b_kw = phase_b_path_folder_for(user, new_path, new_folder)
-
-            # Phase B.4: title is virtual — encrypt the new title and write
-            # title_ciphertext + title_nonce instead of the plaintext column.
-            {:ok, dek} = Engram.Crypto.get_dek(user)
-            {title_ct, title_nonce} = Engram.Crypto.Envelope.encrypt(new_title, dek)
-
-            title_kw = [
-              title_ciphertext: title_ct,
-              title_nonce: title_nonce
-            ]
+            # T3.6 — rename converges the row to AAD-bound. We have content
+            # and tags decrypted in memory already; re-encrypt them with the
+            # row-id-bound AAD so all five ciphertext columns share a
+            # consistent dek_version=2 stamp. Skipping content/tags would
+            # leave the row mixed (path/folder/title bound, content/tags
+            # legacy) and the read-side AAD dispatch keys off a single
+            # row.dek_version — a mixed row breaks decrypt for whichever
+            # group disagrees with the stamped version.
+            full_kw =
+              full_aad_bound_kw(
+                user,
+                note.id,
+                decrypted_note.content || "",
+                new_title,
+                new_path,
+                new_folder,
+                decrypted_note.tags || []
+              )
 
             {count, _} =
               from(n in Note, where: n.id == ^note.id)
@@ -187,19 +205,20 @@ defmodule Engram.Notes do
                   [
                     embed_hash: nil,
                     updated_at: now
-                  ] ++ title_kw ++ phase_b_kw
+                  ] ++ full_kw
               )
 
             if count == 1 do
-              # Splice the freshly-encrypted Phase B fields into the in-memory
-              # struct + populate the virtual path/folder fields so callers
-              # (broadcast, MCP, controllers) read the new plaintext without
-              # re-decrypting through maybe_decrypt_note_fields.
+              # Splice the freshly-encrypted ciphertext + dek_version=2
+              # into the in-memory struct so callers (broadcast, MCP,
+              # controllers) read the new plaintext without re-decrypting
+              # through maybe_decrypt_note_fields.
               {:ok,
                note
-               |> struct!(phase_b_kw)
-               |> struct!(title_kw)
+               |> struct!(full_kw)
                |> struct!(
+                 content: decrypted_note.content,
+                 tags: decrypted_note.tags || [],
                  path: new_path,
                  folder: new_folder,
                  title: new_title,
@@ -321,15 +340,16 @@ defmodule Engram.Notes do
                 where:
                   n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
                     not is_nil(n.tags_ciphertext) and n.tags_hmac != ^[],
-                select: {n.tags_ciphertext, n.tags_nonce}
+                select: {n.id, n.dek_version, n.tags_ciphertext, n.tags_nonce}
               )
             )
           end)
 
         tags =
           rows
-          |> Enum.flat_map(fn {ct, nonce} ->
-            decrypt_envelope!(ct, nonce, dek) |> :erlang.binary_to_term([:safe])
+          |> Enum.flat_map(fn {id, dv, ct, nonce} ->
+            decrypt_envelope!(ct, nonce, dek, row_aad(:notes, :tags, id, dv))
+            |> :erlang.binary_to_term([:safe])
           end)
           |> Enum.uniq()
           |> Enum.sort()
@@ -359,14 +379,16 @@ defmodule Engram.Notes do
                   n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
                     not is_nil(n.folder_hmac) and n.folder_hmac != ^empty_hmac,
                 distinct: n.folder_hmac,
-                select: {n.folder_ciphertext, n.folder_nonce}
+                select: {n.id, n.dek_version, n.folder_ciphertext, n.folder_nonce}
               )
             )
           end)
 
         folders =
           rows
-          |> Enum.map(fn {ct, nonce} -> decrypt_envelope!(ct, nonce, dek) end)
+          |> Enum.map(fn {id, dv, ct, nonce} ->
+            decrypt_envelope!(ct, nonce, dek, row_aad(:notes, :folder, id, dv))
+          end)
           |> Enum.sort()
 
         {:ok, folders}
@@ -397,15 +419,16 @@ defmodule Engram.Notes do
                 where:
                   n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
                     not is_nil(n.tags_ciphertext) and n.tags_hmac != ^[],
-                select: {n.tags_ciphertext, n.tags_nonce}
+                select: {n.id, n.dek_version, n.tags_ciphertext, n.tags_nonce}
               )
             )
           end)
 
         counts =
           rows
-          |> Enum.flat_map(fn {ct, nonce} ->
-            decrypt_envelope!(ct, nonce, dek) |> :erlang.binary_to_term([:safe])
+          |> Enum.flat_map(fn {id, dv, ct, nonce} ->
+            decrypt_envelope!(ct, nonce, dek, row_aad(:notes, :tags, id, dv))
+            |> :erlang.binary_to_term([:safe])
           end)
           |> Enum.frequencies()
           |> Enum.map(fn {name, count} -> %{name: name, count: count} end)
@@ -437,6 +460,8 @@ defmodule Engram.Notes do
                     not is_nil(n.folder_hmac),
                 distinct: n.folder_hmac,
                 select: %{
+                  id: n.id,
+                  dv: n.dek_version,
                   ct: n.folder_ciphertext,
                   nonce: n.folder_nonce,
                   count: fragment("COUNT(*) OVER (PARTITION BY ?)", n.folder_hmac)
@@ -447,8 +472,11 @@ defmodule Engram.Notes do
 
         folders =
           rows
-          |> Enum.map(fn %{ct: ct, nonce: nonce, count: count} ->
-            %{folder: decrypt_envelope!(ct, nonce, dek), count: count}
+          |> Enum.map(fn %{id: id, dv: dv, ct: ct, nonce: nonce, count: count} ->
+            %{
+              folder: decrypt_envelope!(ct, nonce, dek, row_aad(:notes, :folder, id, dv)),
+              count: count
+            }
           end)
           |> Enum.sort_by(& &1.folder)
 
@@ -541,7 +569,9 @@ defmodule Engram.Notes do
       old_len = String.length(old_folder)
 
       # Build bulk updates — compute new paths/folders/titles in Elixir,
-      # then apply as a single update per note (avoids N+1 per-row queries)
+      # then apply as a single update per note (avoids N+1 per-row queries).
+      # Each tuple now carries the source note (decrypted) so the bulk loop
+      # can re-encrypt content + tags with the row-id-bound AAD.
       updates =
         Enum.map(notes, fn note ->
           new_note_folder =
@@ -554,25 +584,29 @@ defmodule Engram.Notes do
           new_path = new_note_folder <> String.slice(note.path, String.length(note.folder)..-1//1)
           new_title = Helpers.extract_title(note.content || "", new_path)
 
-          {note.id, note.path, new_path, new_note_folder, new_title}
+          {note, note.path, new_path, new_note_folder, new_title}
         end)
 
-      {:ok, dek} = Engram.Crypto.get_dek(user)
-
       Repo.with_tenant(user.id, fn ->
-        Enum.each(updates, fn {id, _old_path, new_path, new_note_folder, new_title} ->
-          phase_b_kw = phase_b_path_folder_for(user, new_path, new_note_folder)
-          {title_ct, title_nonce} = Engram.Crypto.Envelope.encrypt(new_title, dek)
+        Enum.each(updates, fn {note, _old_path, new_path, new_note_folder, new_title} ->
+          full_kw =
+            full_aad_bound_kw(
+              user,
+              note.id,
+              note.content || "",
+              new_title,
+              new_path,
+              new_note_folder,
+              note.tags || []
+            )
 
-          from(n in Note, where: n.id == ^id)
+          from(n in Note, where: n.id == ^note.id)
           |> Repo.update_all(
             set:
               [
-                title_ciphertext: title_ct,
-                title_nonce: title_nonce,
                 embed_hash: nil,
                 updated_at: now
-              ] ++ phase_b_kw
+              ] ++ full_kw
           )
         end)
       end)
@@ -583,27 +617,23 @@ defmodule Engram.Notes do
       # inserts so each must carry the encrypted path/folder/tags fields too.
       mtime_float = DateTime.to_unix(now) + 0.0
 
-      {empty_tags_ct, empty_tags_nonce} =
-        Engram.Crypto.Envelope.encrypt(:erlang.term_to_binary([]), dek)
-
-      {empty_title_ct, empty_title_nonce} = Engram.Crypto.Envelope.encrypt("", dek)
-      {empty_content_ct, empty_content_nonce} = Engram.Crypto.Envelope.encrypt("", dek)
-
       tombstones =
-        Enum.map(updates, fn {_id, old_path, _new_path, _new_folder, _title} ->
+        Enum.map(updates, fn {_note, old_path, _new_path, _new_folder, _title} ->
+          # T3.6 — pre-allocate the tombstone id so the AAD bind string can
+          # be constructed before insert. Tombstones are full-row inserts
+          # written with empty content/title/tags but the row-id-bound AAD
+          # still applies — keeps tombstones decryptable and indistinguishable
+          # from any other AAD-bound row at read time.
+          tomb_id = Engram.Crypto.next_row_id(:notes)
           old_path_folder = Helpers.extract_folder(old_path)
-          phase_b_kw = phase_b_path_folder_for(user, old_path, old_path_folder)
+
+          full_kw =
+            full_aad_bound_kw(user, tomb_id, "", "", old_path, old_path_folder, [])
 
           base = %{
+            id: tomb_id,
             content_hash: "",
             mtime: mtime_float,
-            title_ciphertext: empty_title_ct,
-            title_nonce: empty_title_nonce,
-            content_ciphertext: empty_content_ct,
-            content_nonce: empty_content_nonce,
-            tags_ciphertext: empty_tags_ct,
-            tags_nonce: empty_tags_nonce,
-            tags_hmac: [],
             user_id: user.id,
             vault_id: vault.id,
             created_at: now,
@@ -611,7 +641,7 @@ defmodule Engram.Notes do
             deleted_at: now
           }
 
-          Map.merge(base, Map.new(phase_b_kw))
+          Map.merge(base, Map.new(full_kw))
         end)
 
       Repo.with_tenant(user.id, fn ->
@@ -620,9 +650,9 @@ defmodule Engram.Notes do
 
       # Side effects outside the transaction — broadcast + reindex.
       # T3.2 — pass old_path_hmac (base64) to the worker, never plaintext.
-      Enum.each(updates, fn {id, old_note_path, new_path, _folder, _title} ->
+      Enum.each(updates, fn {note, old_note_path, new_path, _folder, _title} ->
         Oban.insert(
-          Engram.Workers.EmbedNote.new_debounced(id,
+          Engram.Workers.EmbedNote.new_debounced(note.id,
             old_path_hmac: old_path_hmac_b64!(user, old_note_path)
           )
         )
@@ -674,15 +704,25 @@ defmodule Engram.Notes do
     Enum.map(notes, &decrypt_or_raise!(&1, user))
   end
 
-  # Decrypts an envelope (ciphertext + nonce) with the user's DEK.
-  # Raises if decryption fails — used in Phase B aggregations where a failure
-  # means data corruption, not a recoverable condition.
-  defp decrypt_envelope!(ct, nonce, dek) do
-    case Engram.Crypto.Envelope.decrypt(ct, nonce, dek) do
+  # Decrypts an envelope (ciphertext + nonce) with the user's DEK and the
+  # supplied AAD. Raises if decryption fails — used in Phase B aggregations
+  # where a failure means data corruption, not a recoverable condition.
+  defp decrypt_envelope!(ct, nonce, dek, aad) do
+    case Engram.Crypto.Envelope.decrypt(ct, nonce, dek, aad) do
       {:ok, plaintext} -> plaintext
       :error -> raise "Phase B envelope decryption failed"
     end
   end
+
+  # T3.6 — AAD constructor for aggregation queries that select raw
+  # (id, dek_version, ct, nonce) tuples. Returns the row-id-bound AAD for
+  # AAD-bound rows (v ≥ 2) and `<<>>` for legacy rows.
+  defp row_aad(table, column, id, dek_version)
+       when is_integer(dek_version) and dek_version >= 2 do
+    Engram.Crypto.aad_for_row(table, column, id)
+  end
+
+  defp row_aad(_table, _column, _id, _dek_version), do: <<>>
 
   defp validate_path(nil),
     do:
@@ -728,8 +768,10 @@ defmodule Engram.Notes do
   # Callers MUST call ensure_user_dek/1 before invoking this helper.
   # If get_dek still fails after ensure, that is a real bug — raises rather
   # than silently skipping to enforce the "Phase B is mandatory" contract.
-  defp inject_phase_b_fields(attrs, user, path, folder, tags) do
-    Map.merge(attrs, Map.new(phase_b_keyword_for(user, path, folder, tags)))
+  # T3.6 — note_id is required to construct the AAD bind string for path /
+  # folder / tags ciphertext.
+  defp inject_phase_b_fields(attrs, user, note_id, path, folder, tags) do
+    Map.merge(attrs, Map.new(phase_b_keyword_for(user, note_id, path, folder, tags)))
   end
 
   # Returns a keyword list of Phase B field updates suitable for splicing into
@@ -741,28 +783,95 @@ defmodule Engram.Notes do
   # tags_nonce regardless of vault.encrypted. Before B.3 the plaintext `tags`
   # column was the system of record for unencrypted vaults; that column is
   # now gone, so this helper is the only place tags get persisted.
-  defp phase_b_keyword_for(user, path, folder, tags) do
+  defp phase_b_keyword_for(user, note_id, path, folder, tags) do
     {:ok, dek} = Engram.Crypto.get_dek(user)
     {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
     tags = tags || []
-    {tags_ct, tags_n} = Engram.Crypto.Envelope.encrypt(:erlang.term_to_binary(tags), dek)
+    tags_aad = Engram.Crypto.aad_for_row(:notes, :tags, note_id)
 
-    phase_b_path_folder_for(user, path, folder) ++
+    {tags_ct, tags_n} =
+      Engram.Crypto.Envelope.encrypt(:erlang.term_to_binary(tags), dek, tags_aad)
+
+    phase_b_path_folder_for(user, note_id, path, folder) ++
       [
         tags_ciphertext: tags_ct,
         tags_nonce: tags_n,
-        tags_hmac: Enum.map(tags, &Engram.Crypto.hmac_field(filter_key, &1))
+        tags_hmac: Enum.map(tags, &Engram.Crypto.hmac_field(filter_key, &1)),
+        dek_version: Engram.Crypto.row_version_aad_bound()
       ]
   end
 
-  # Same as phase_b_keyword_for/4 but only re-keys path + folder. Used by
-  # rename paths that don't change tags — preserves the existing tags_hmac /
-  # tags_ciphertext on the row.
-  defp phase_b_path_folder_for(user, path, folder) do
+  # T3.6 — full re-encrypt of every encrypted column on a note, with row-id
+  # bound AAD on each. Returns a keyword list suitable for Repo.update_all
+  # `set: ...` or struct! splicing. Stamps `dek_version=2` so the read path
+  # picks up AAD-bound semantics for the whole row in one atomic update.
+  defp full_aad_bound_kw(user, note_id, content, title, path, folder, tags) do
     {:ok, dek} = Engram.Crypto.get_dek(user)
     {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
-    {path_ct, path_n} = Engram.Crypto.Envelope.encrypt(path, dek)
-    {folder_ct, folder_n} = Engram.Crypto.Envelope.encrypt(folder, dek)
+
+    {content_ct, content_n} =
+      Engram.Crypto.Envelope.encrypt(
+        content,
+        dek,
+        Engram.Crypto.aad_for_row(:notes, :content, note_id)
+      )
+
+    {title_ct, title_n} =
+      Engram.Crypto.Envelope.encrypt(
+        title,
+        dek,
+        Engram.Crypto.aad_for_row(:notes, :title, note_id)
+      )
+
+    {path_ct, path_n} =
+      Engram.Crypto.Envelope.encrypt(
+        path,
+        dek,
+        Engram.Crypto.aad_for_row(:notes, :path, note_id)
+      )
+
+    {folder_ct, folder_n} =
+      Engram.Crypto.Envelope.encrypt(
+        folder,
+        dek,
+        Engram.Crypto.aad_for_row(:notes, :folder, note_id)
+      )
+
+    {tags_ct, tags_n} =
+      Engram.Crypto.Envelope.encrypt(
+        :erlang.term_to_binary(tags || []),
+        dek,
+        Engram.Crypto.aad_for_row(:notes, :tags, note_id)
+      )
+
+    [
+      content_ciphertext: content_ct,
+      content_nonce: content_n,
+      title_ciphertext: title_ct,
+      title_nonce: title_n,
+      path_ciphertext: path_ct,
+      path_nonce: path_n,
+      path_hmac: Engram.Crypto.hmac_field(filter_key, path),
+      folder_ciphertext: folder_ct,
+      folder_nonce: folder_n,
+      folder_hmac: Engram.Crypto.hmac_field(filter_key, folder),
+      tags_ciphertext: tags_ct,
+      tags_nonce: tags_n,
+      tags_hmac: Enum.map(tags || [], &Engram.Crypto.hmac_field(filter_key, &1)),
+      dek_version: Engram.Crypto.row_version_aad_bound()
+    ]
+  end
+
+  # Same as phase_b_keyword_for/5 but only re-keys path + folder. Used by
+  # rename paths that don't change tags — preserves the existing tags_hmac /
+  # tags_ciphertext on the row.
+  defp phase_b_path_folder_for(user, note_id, path, folder) do
+    {:ok, dek} = Engram.Crypto.get_dek(user)
+    {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
+    path_aad = Engram.Crypto.aad_for_row(:notes, :path, note_id)
+    folder_aad = Engram.Crypto.aad_for_row(:notes, :folder, note_id)
+    {path_ct, path_n} = Engram.Crypto.Envelope.encrypt(path, dek, path_aad)
+    {folder_ct, folder_n} = Engram.Crypto.Envelope.encrypt(folder, dek, folder_aad)
 
     [
       path_ciphertext: path_ct,

--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -66,6 +66,7 @@ defmodule Engram.Notes.Note do
       attrs,
       [
         :version,
+        :dek_version,
         :content_hash,
         :mtime,
         :user_id,

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -74,7 +74,12 @@ defmodule Engram.Search do
           with {:ok, candidates} <- Qdrant.search(collection(), vector, search_opts),
                vaults_by_id = load_candidate_vaults(user, vault, candidates),
                {:ok, decrypted} <-
-                 Engram.Crypto.decrypt_qdrant_candidates(candidates, user, vaults_by_id) do
+                 Engram.Crypto.decrypt_qdrant_candidates(
+                   candidates,
+                   user,
+                   vaults_by_id,
+                   collection()
+                 ) do
             reranker().rerank(query, decrypted, limit)
           end
         end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -35,14 +35,15 @@ defmodule Engram.Vaults do
             is_default = current_count == 0
             name = attrs[:name] || attrs["name"] || ""
             slug = unique_slug(user.id, slugify(name))
+            vault_id = Engram.Crypto.next_row_id(:vaults)
 
             vault_attrs =
               attrs
               |> atomize_keys()
-              |> inject_name_phase_b(user)
+              |> inject_name_phase_b(user, vault_id)
               |> Map.merge(%{slug: slug, user_id: user.id, is_default: is_default})
 
-            %Vault{}
+            %Vault{id: vault_id}
             |> Vault.changeset(vault_attrs)
             |> Repo.insert()
             |> case do
@@ -87,6 +88,7 @@ defmodule Engram.Vaults do
                 :ok ->
                   is_default = current_count == 0
                   slug = unique_slug(user.id, slugify(name))
+                  vault_id = Engram.Crypto.next_row_id(:vaults)
 
                   attrs = %{
                     name: name,
@@ -96,9 +98,9 @@ defmodule Engram.Vaults do
                     is_default: is_default
                   }
 
-                  attrs = inject_name_phase_b(attrs, user)
+                  attrs = inject_name_phase_b(attrs, user, vault_id)
 
-                  case Repo.insert(Vault.changeset(%Vault{}, attrs)) do
+                  case Repo.insert(Vault.changeset(%Vault{id: vault_id}, attrs)) do
                     {:ok, vault} -> {:ok, decrypt_vault_if_needed(vault, user), :created}
                     {:error, cs} -> {:error, cs}
                   end
@@ -232,7 +234,7 @@ defmodule Engram.Vaults do
               attrs
               |> atomize_keys()
               |> then(&maybe_regenerate_slug(user.id, vault, &1))
-              |> inject_name_phase_b(user)
+              |> inject_name_phase_b(user, vault.id)
 
             if Map.get(attrs, :is_default) == true do
               clear_defaults(user.id, vault_id)
@@ -331,18 +333,20 @@ defmodule Engram.Vaults do
   # Callers MUST call ensure_user_dek/1 before invoking this helper.
   # If get_dek still fails after ensure, that is a real bug — raises rather
   # than silently skipping to enforce the "Phase B is mandatory" contract.
-  defp inject_name_phase_b(attrs, user) do
+  defp inject_name_phase_b(attrs, user, vault_id) do
     name = attrs[:name] || attrs["name"]
 
     if is_binary(name) do
       {:ok, dek} = Engram.Crypto.get_dek(user)
       {:ok, filter_key} = Engram.Crypto.dek_filter_key(user)
-      {ct, n} = Engram.Crypto.Envelope.encrypt(name, dek)
+      aad = Engram.Crypto.aad_for_row(:vaults, :name, vault_id)
+      {ct, n} = Engram.Crypto.Envelope.encrypt(name, dek, aad)
 
       Map.merge(attrs, %{
         name_ciphertext: ct,
         name_nonce: n,
-        name_hmac: Engram.Crypto.hmac_field(filter_key, name)
+        name_hmac: Engram.Crypto.hmac_field(filter_key, name),
+        dek_version: Engram.Crypto.row_version_aad_bound()
       })
     else
       attrs

--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -33,7 +33,8 @@ defmodule Engram.Vaults.Vault do
       :deleted_at,
       :name_ciphertext,
       :name_nonce,
-      :name_hmac
+      :name_hmac,
+      :dek_version
     ])
     |> validate_required([
       :slug,

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -247,7 +247,10 @@ defmodule Engram.Vector.Qdrant do
               # Nonce keys are only present on encrypted-vault chunks; nil otherwise.
               text_nonce: Map.get(payload, "text_nonce"),
               title_nonce: Map.get(payload, "title_nonce"),
-              heading_path_nonce: Map.get(payload, "heading_path_nonce")
+              heading_path_nonce: Map.get(payload, "heading_path_nonce"),
+              # T3.6 — present on AAD-bound payloads (>= v2). Drives the
+              # bind-vs-empty AAD decision in `Engram.Crypto.qdrant_aad/3`.
+              aad_version: Map.get(payload, "aad_version")
             }
             |> Enum.reject(fn {_k, v} -> is_nil(v) end)
             |> Map.new()

--- a/lib/engram/workers/backfill_content_hash_hmac.ex
+++ b/lib/engram/workers/backfill_content_hash_hmac.ex
@@ -161,9 +161,14 @@ defmodule Engram.Workers.BackfillContentHashHmac do
   end
 
   defp rehash_attachment(att, user, content_key) do
+    aad =
+      if is_integer(att.dek_version) and att.dek_version >= 2,
+        do: Crypto.aad_for_row(:attachments, :content, att.id),
+        else: <<>>
+
     with {:ok, ciphertext} <- Storage.adapter().get(att.storage_key),
          {:ok, dek} <- Crypto.get_dek(user),
-         {:ok, plaintext} <- Envelope.decrypt(ciphertext, att.content_nonce, dek) do
+         {:ok, plaintext} <- Envelope.decrypt(ciphertext, att.content_nonce, dek, aad) do
       new_hash = Crypto.hmac_content_hash(content_key, plaintext)
 
       from(a in Attachment, where: a.id == ^att.id)

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -33,12 +33,15 @@ defmodule EngramWeb.SyncController do
   end
 
   defp render_manifest(conn, user, vault, dek) do
+    # T3.6 — project `id` and `dek_version` so AAD-bound rows (v ≥ 2) can
+    # reconstruct the bind string ("notes:path:<id>" / "attachments:path:<id>")
+    # at decrypt time. Legacy rows (v = 1) decrypt with empty AAD.
     {:ok, note_rows} =
       Repo.with_tenant(user.id, fn ->
         Repo.all(
           from(n in Note,
             where: n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at),
-            select: {n.path_ciphertext, n.path_nonce, n.content_hash}
+            select: {n.id, n.dek_version, n.path_ciphertext, n.path_nonce, n.content_hash}
           )
         )
       end)
@@ -48,23 +51,25 @@ defmodule EngramWeb.SyncController do
         Repo.all(
           from(a in Attachment,
             where: a.user_id == ^user.id and a.vault_id == ^vault.id and is_nil(a.deleted_at),
-            select: {a.path_ciphertext, a.path_nonce, a.content_hash}
+            select: {a.id, a.dek_version, a.path_ciphertext, a.path_nonce, a.content_hash}
           )
         )
       end)
 
     notes =
       note_rows
-      |> Enum.map(fn {path_ct, path_nonce, hash} ->
-        path = decrypt_path!(path_ct, path_nonce, dek)
+      |> Enum.map(fn {id, dek_version, path_ct, path_nonce, hash} ->
+        aad = path_aad(:notes, id, dek_version)
+        path = decrypt_path!(path_ct, path_nonce, dek, aad)
         %{path: path, content_hash: hash}
       end)
       |> Enum.sort_by(& &1.path)
 
     attachments =
       attachment_rows
-      |> Enum.map(fn {path_ct, path_nonce, hash} ->
-        path = decrypt_path!(path_ct, path_nonce, dek)
+      |> Enum.map(fn {id, dek_version, path_ct, path_nonce, hash} ->
+        aad = path_aad(:attachments, id, dek_version)
+        path = decrypt_path!(path_ct, path_nonce, dek, aad)
         %{path: path, content_hash: hash}
       end)
       |> Enum.sort_by(& &1.path)
@@ -77,8 +82,13 @@ defmodule EngramWeb.SyncController do
     })
   end
 
-  defp decrypt_path!(ciphertext, nonce, dek) do
-    case Envelope.decrypt(ciphertext, nonce, dek) do
+  defp path_aad(table, id, dek_version) when is_integer(dek_version) and dek_version >= 2,
+    do: Crypto.aad_for_row(table, :path, id)
+
+  defp path_aad(_table, _id, _v), do: <<>>
+
+  defp decrypt_path!(ciphertext, nonce, dek, aad) do
+    case Envelope.decrypt(ciphertext, nonce, dek, aad) do
       {:ok, path} -> path
       :error -> raise "manifest path decrypt failed — possible data corruption"
     end

--- a/lib/mix/tasks/engram.rebind_aad.ex
+++ b/lib/mix/tasks/engram.rebind_aad.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Tasks.Engram.RebindAad do
+  @moduledoc """
+  T3.6.3 — AAD-rebind backfill (Mix entrypoint).
+
+  Walks every user with at least one legacy-encrypted row
+  (`dek_version=1`) and re-encrypts notes / vaults under the row-id-bound
+  AAD, stamping `dek_version=2` on each. Also upgrades each user's
+  `encrypted_dek` wrap format from v1 (or pre-T3.4 legacy) to v2
+  (AAD-bound, `"dek:v1:<user_id>"`).
+
+  Idempotent — already-rebound users return `:skipped` and are skipped at
+  perform-time. Per-user transaction with `SELECT ... FOR UPDATE`.
+
+  ## Usage
+
+      mix engram.rebind_aad
+      mix engram.rebind_aad --batch-size 50
+
+  ## Production via release rpc
+
+      docker exec engram-saas /app/bin/engram rpc \\
+        'Engram.Crypto.AadRebind.rebind_all()'
+
+  Telemetry: `[:engram, :crypto, :aad_rebind, :user]` per user with
+  `:ok | :skipped | :failed` status.
+
+  ## Attachments
+
+  This task DOES NOT rebind attachment ciphertext. Attachment content
+  lives in S3-compatible object storage; rebinding `path_ciphertext`
+  alone would mismatch the stamped `dek_version` against the S3 blob's
+  legacy AAD on the next read. Attachments converge naturally on every
+  re-upload (`Attachments.upsert_attachment/3` writes v2 AAD-bound).
+  """
+
+  use Mix.Task
+
+  alias Engram.Crypto.AadRebind
+
+  @shortdoc "Rebind every user's notes/vaults to row-id-bound AAD (T3.6)"
+
+  @switches [batch_size: :integer]
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {opts, _, _} = OptionParser.parse(args, switches: @switches)
+    batch_size = Keyword.get(opts, :batch_size, 100)
+
+    IO.puts("rebinding users to AAD-bound encryption (batch_size=#{batch_size})...")
+
+    counts = AadRebind.rebind_all(batch_size: batch_size)
+
+    IO.puts(
+      "rebind complete: ok=#{counts.ok} skipped=#{counts.skipped} failed=#{counts.failed}"
+    )
+
+    if counts.failed > 0 do
+      IO.puts(:stderr, "ERROR: #{counts.failed} users failed rebind — inspect telemetry")
+      System.halt(1)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.35",
+      version: "0.5.36",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto/aad_rebind_test.exs
+++ b/test/engram/crypto/aad_rebind_test.exs
@@ -1,0 +1,153 @@
+defmodule Engram.Crypto.AadRebindTest do
+  use Engram.DataCase, async: false
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Crypto
+  alias Engram.Crypto.{AadRebind, DekCache, Envelope}
+  alias Engram.Notes.Note
+  alias Engram.Repo
+
+  setup do
+    DekCache.invalidate_all()
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, user: user}
+  end
+
+  describe "rebind_user/1" do
+    test "rebinds a legacy note row to AAD-bound encryption", %{user: user} do
+      # Use the real Vaults context so the vault is born AAD-bound (dek_version=2).
+      # The rebind would otherwise pick it up and fail on the random-bytes
+      # ciphertext the test factory writes.
+      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Rebind Vault"})
+      {:ok, dek} = Crypto.get_dek(user)
+
+      # Hand-build a legacy note: every ciphertext column written with
+      # empty AAD; row stamped dek_version=1 (the column default).
+      {content_ct, content_n} = Envelope.encrypt("legacy body", dek)
+      {title_ct, title_n} = Envelope.encrypt("legacy title", dek)
+      {path_ct, path_n} = Envelope.encrypt("legacy/path.md", dek)
+      {folder_ct, folder_n} = Envelope.encrypt("legacy", dek)
+      {tags_ct, tags_n} = Envelope.encrypt(:erlang.term_to_binary(["t1"]), dek)
+      {:ok, filter_key} = Crypto.dek_filter_key(user)
+
+      legacy_note =
+        %Note{}
+        |> Ecto.Changeset.cast(
+          %{
+            content_hash: "h",
+            mtime: 0.0,
+            user_id: user.id,
+            vault_id: vault.id,
+            content_ciphertext: content_ct,
+            content_nonce: content_n,
+            title_ciphertext: title_ct,
+            title_nonce: title_n,
+            path_ciphertext: path_ct,
+            path_nonce: path_n,
+            path_hmac: Crypto.hmac_field(filter_key, "legacy/path.md"),
+            folder_ciphertext: folder_ct,
+            folder_nonce: folder_n,
+            folder_hmac: Crypto.hmac_field(filter_key, "legacy"),
+            tags_ciphertext: tags_ct,
+            tags_nonce: tags_n,
+            tags_hmac: [Crypto.hmac_field(filter_key, "t1")],
+            dek_version: 1
+          },
+          [
+            :content_hash,
+            :mtime,
+            :user_id,
+            :vault_id,
+            :content_ciphertext,
+            :content_nonce,
+            :title_ciphertext,
+            :title_nonce,
+            :path_ciphertext,
+            :path_nonce,
+            :path_hmac,
+            :folder_ciphertext,
+            :folder_nonce,
+            :folder_hmac,
+            :tags_ciphertext,
+            :tags_nonce,
+            :tags_hmac,
+            :dek_version
+          ]
+        )
+        |> Repo.insert!(skip_tenant_check: true)
+
+      assert legacy_note.dek_version == 1
+
+      assert :ok = AadRebind.rebind_user(user.id)
+
+      reloaded = Repo.reload!(legacy_note, skip_tenant_check: true)
+      assert reloaded.dek_version == Crypto.row_version_aad_bound()
+
+      # The rewritten ciphertext must decrypt under the bind AAD and FAIL
+      # under empty AAD — proves the rebind actually changed the AAD slot.
+      content_aad = Crypto.aad_for_row(:notes, :content, reloaded.id)
+
+      assert {:ok, "legacy body"} =
+               Envelope.decrypt(reloaded.content_ciphertext, reloaded.content_nonce, dek, content_aad)
+
+      assert :error =
+               Envelope.decrypt(reloaded.content_ciphertext, reloaded.content_nonce, dek, <<>>)
+
+      # And the regular read path round-trips end-to-end.
+      {:ok, decrypted} = Crypto.maybe_decrypt_note_fields(reloaded, user)
+      assert decrypted.content == "legacy body"
+      assert decrypted.title == "legacy title"
+      assert decrypted.path == "legacy/path.md"
+      assert decrypted.folder == "legacy"
+      assert decrypted.tags == ["t1"]
+    end
+
+    test "upgrades the user's wrapped DEK from v1 to v2 (AAD-bound)", %{user: user} do
+      # ensure_user_dek already wrote a v2 wrap. Force a legacy v1 wrap to
+      # exercise the rewrap path.
+      master = Engram.Crypto.Config.local_master_key!()
+      {:ok, dek} = Crypto.get_dek(user)
+      {ct, nonce} = Envelope.encrypt(dek, master)
+      legacy_v1 = <<0x01, 0x01, nonce::binary-size(12), ct::binary>>
+
+      Repo.update_all(
+        from(u in Engram.Accounts.User, where: u.id == ^user.id),
+        [set: [encrypted_dek: legacy_v1]],
+        skip_tenant_check: true
+      )
+
+      assert :ok = AadRebind.rebind_user(user.id)
+
+      reloaded = Repo.reload!(user)
+      assert <<0x02, 0x01, _::binary>> = reloaded.encrypted_dek
+    end
+
+    test "is idempotent — second run returns :skipped (telemetry-wise) when no legacy rows remain",
+         %{user: user} do
+      {:ok, _vault} = Engram.Vaults.create_vault(user, %{name: "Idempotence Vault"})
+
+      # Already at v2; first run rewraps DEK + finds no rows → succeeds.
+      assert :ok = AadRebind.rebind_user(user.id)
+
+      # Second run: DEK is now v2, no legacy rows → no-op.
+      assert :ok = AadRebind.rebind_user(user.id)
+    end
+  end
+
+  describe "rebind_all/1" do
+    test "drives the cursor across multiple users", %{user: user_a} do
+      user_b = insert(:user)
+      {:ok, _} = Crypto.ensure_user_dek(user_b)
+
+      counts = AadRebind.rebind_all(batch_size: 5)
+
+      # Both users should have been processed without failures.
+      assert counts.ok + counts.skipped >= 2
+      assert counts.failed == 0
+      _ = user_a
+    end
+  end
+
+end

--- a/test/engram/crypto/aad_tamper_test.exs
+++ b/test/engram/crypto/aad_tamper_test.exs
@@ -1,0 +1,113 @@
+defmodule Engram.Crypto.AadTamperTest do
+  @moduledoc """
+  T3.6 / H1 — end-to-end tamper regression. Cross-row, cross-column, and
+  cross-user ciphertext swap must fail decrypt rather than silently
+  succeed under the wrong identity.
+  """
+
+  use Engram.DataCase, async: false
+
+  alias Engram.Crypto
+  alias Engram.Crypto.{DekCache, Envelope}
+  alias Engram.Notes
+  alias Engram.Repo
+
+  setup do
+    DekCache.invalidate_all()
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Tamper Vault"})
+    {:ok, user: user, vault: vault}
+  end
+
+  test "cross-row swap fails: copy A's content_ciphertext into B's slot",
+       %{user: user, vault: vault} do
+    {:ok, note_a} = Notes.upsert_note(user, vault, %{path: "a.md", content: "secret-A"})
+    {:ok, note_b} = Notes.upsert_note(user, vault, %{path: "b.md", content: "secret-B"})
+
+    # Pull both rows fresh — `upsert_note` returns the decrypted struct,
+    # but we want the raw ciphertext columns from disk.
+    raw_a = Repo.get!(Engram.Notes.Note, note_a.id, skip_tenant_check: true)
+    raw_b = Repo.get!(Engram.Notes.Note, note_b.id, skip_tenant_check: true)
+
+    # Splice A's content ciphertext + nonce into B's record (in-memory) and
+    # ask the read path to decrypt. AAD reconstructed from B's row id MUST
+    # fail the AEAD tag check.
+    forged =
+      %{raw_b | content_ciphertext: raw_a.content_ciphertext, content_nonce: raw_a.content_nonce}
+
+    assert {:error, :decrypt_failed} = Crypto.maybe_decrypt_note_fields(forged, user)
+  end
+
+  test "within-row column swap fails: content_ciphertext into title slot",
+       %{user: user, vault: vault} do
+    {:ok, note} = Notes.upsert_note(user, vault, %{path: "swap.md", content: "secret-content"})
+
+    raw = Repo.get!(Engram.Notes.Note, note.id, skip_tenant_check: true)
+
+    forged =
+      %{raw | title_ciphertext: raw.content_ciphertext, title_nonce: raw.content_nonce}
+
+    # The :content slot still decrypts cleanly under "notes:content:<id>";
+    # :title fails because AAD = "notes:title:<id>" doesn't match the
+    # ciphertext's bound context.
+    assert {:error, :decrypt_failed} = Crypto.maybe_decrypt_note_fields(forged, user)
+  end
+
+  test "cross-user swap fails because per-user DEK derivation diverges",
+       %{user: user_a, vault: vault_a} do
+    user_b = insert(:user)
+    {:ok, user_b} = Crypto.ensure_user_dek(user_b)
+    {:ok, vault_b} = Engram.Vaults.create_vault(user_b, %{name: "B Vault"})
+
+    {:ok, note_a} = Notes.upsert_note(user_a, vault_a, %{path: "a.md", content: "user-a-secret"})
+    {:ok, note_b} = Notes.upsert_note(user_b, vault_b, %{path: "b.md", content: "user-b-secret"})
+
+    raw_a = Repo.get!(Engram.Notes.Note, note_a.id, skip_tenant_check: true)
+    raw_b = Repo.get!(Engram.Notes.Note, note_b.id, skip_tenant_check: true)
+
+    # Place B's ciphertext on A's row in memory. Per-user DEK already
+    # blocks this, but adding row-id AAD makes the decryption attempt fail
+    # at two independent gates.
+    forged =
+      %{raw_a | content_ciphertext: raw_b.content_ciphertext, content_nonce: raw_b.content_nonce}
+
+    assert {:error, :decrypt_failed} = Crypto.maybe_decrypt_note_fields(forged, user_a)
+  end
+
+  test "wrapped-DEK is bound to the user it was generated for", %{user: user} do
+    user_b = insert(:user)
+    {:ok, user_b} = Crypto.ensure_user_dek(user_b)
+
+    # Reload both wrapped blobs from DB.
+    user_a_db = Repo.reload!(user, skip_tenant_check: true)
+    user_b_db = Repo.reload!(user_b, skip_tenant_check: true)
+
+    # Try to unwrap A's blob under B's user_id ctx. AAD = "dek:v1:<B>"
+    # must not satisfy the AEAD tag for a wrap that was bound to "dek:v1:<A>".
+    provider = Engram.Crypto.KeyProvider.Local
+
+    assert {:error, _} =
+             provider.unwrap_dek(user_a_db.encrypted_dek, %{user_id: user_b_db.id})
+
+    # Unwrap A's blob under A's id succeeds (sanity).
+    assert {:ok, _dek_a} =
+             provider.unwrap_dek(user_a_db.encrypted_dek, %{user_id: user_a_db.id})
+  end
+
+  test "Envelope.decrypt fails without AAD on AAD-bound ciphertext", %{user: user, vault: vault} do
+    {:ok, note} = Notes.upsert_note(user, vault, %{path: "no-aad.md", content: "needs-aad"})
+    raw = Repo.get!(Engram.Notes.Note, note.id, skip_tenant_check: true)
+    {:ok, dek} = Crypto.get_dek(user)
+
+    # Decrypt without supplying any AAD — empty AAD does not match
+    # "notes:content:<id>".
+    assert :error = Envelope.decrypt(raw.content_ciphertext, raw.content_nonce, dek)
+
+    # Sanity: with the right AAD, decrypt succeeds.
+    aad = Crypto.aad_for_row(:notes, :content, note.id)
+
+    assert {:ok, "needs-aad"} =
+             Envelope.decrypt(raw.content_ciphertext, raw.content_nonce, dek, aad)
+  end
+end

--- a/test/engram/crypto/envelope_test.exs
+++ b/test/engram/crypto/envelope_test.exs
@@ -42,4 +42,43 @@ defmodule Engram.Crypto.EnvelopeTest do
     long_nonce = :crypto.strong_rand_bytes(16)
     assert :error = Envelope.decrypt(ct, long_nonce, @dek)
   end
+
+  # T3.6 / H1 — AAD binding. Each ciphertext is bound to a context string
+  # ("<table>:<column>:<row_id>" for relational rows, "qdrant:<col>:<qid>:
+  # <field>" for vector payload, "dek:v1:<user_id>" for wrapped DEK). A
+  # tampered AAD or an attempted cross-row swap fails the AEAD tag check.
+
+  describe "AAD binding (T3.6)" do
+    test "round-trips with non-empty AAD" do
+      aad = "notes:content:42"
+      {ct, nonce} = Envelope.encrypt("body", @dek, aad)
+      assert {:ok, "body"} = Envelope.decrypt(ct, nonce, @dek, aad)
+    end
+
+    test "wrong AAD fails decrypt" do
+      {ct, nonce} = Envelope.encrypt("body", @dek, "notes:content:42")
+      assert :error = Envelope.decrypt(ct, nonce, @dek, "notes:content:43")
+    end
+
+    test "missing AAD on read of AAD-bound ciphertext fails" do
+      {ct, nonce} = Envelope.encrypt("body", @dek, "notes:content:42")
+      # decrypt/3 (no AAD) treats AAD as <<>> for legacy compat — must
+      # NOT accept AAD-bound ciphertext.
+      assert :error = Envelope.decrypt(ct, nonce, @dek)
+    end
+
+    test "AAD-bound ciphertext from one row cannot be swapped into another" do
+      {ct_a, nonce_a} = Envelope.encrypt("note A body", @dek, "notes:content:1")
+      # Decrypting that ciphertext under row 2's AAD must fail — the
+      # cross-row swap is exactly what AAD is supposed to defend against.
+      assert :error = Envelope.decrypt(ct_a, nonce_a, @dek, "notes:content:2")
+    end
+
+    test "legacy 3-arity decrypt still works for ciphertext written without AAD" do
+      {ct, nonce} = Envelope.encrypt("legacy", @dek)
+      assert {:ok, "legacy"} = Envelope.decrypt(ct, nonce, @dek)
+      # Equivalently, with explicit empty AAD.
+      assert {:ok, "legacy"} = Envelope.decrypt(ct, nonce, @dek, <<>>)
+    end
+  end
 end

--- a/test/engram/crypto/local_provider_test.exs
+++ b/test/engram/crypto/local_provider_test.exs
@@ -164,22 +164,35 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
   end
 
   describe "T3.4 / M2 — wrap-format versioning" do
-    test "new wraps carry the version + algorithm header bytes (`<<0x01, 0x01, ...>>`)" do
-      # T3.4 / M2 — wrap-format version byte + algorithm-id byte. Enables
-      # algorithm-agility without scan-and-trial-decrypt across the
-      # encrypted_dek population.
+    test "new wraps carry the v2 + algorithm header bytes (`<<0x02, 0x01, ...>>`) (T3.6 H1)" do
+      # T3.6 / H1 — wrap-format version 0x02 signals AAD-bound encryption.
+      # AAD = "dek:v1:<user_id>" (pulled from ctx). Enables future algorithm-
+      # agility without scan-and-trial-decrypt across the encrypted_dek
+      # population.
       dek = Local.generate_dek()
       {:ok, wrapped} = Local.wrap_dek(dek, %{user_id: 1})
 
-      assert <<0x01, 0x01, _nonce::binary-size(12), _ct::binary>> = wrapped
+      assert <<0x02, 0x01, _nonce::binary-size(12), _ct::binary>> = wrapped
       # 1 (ver) + 1 (alg) + 12 (nonce) + 32 (DEK plaintext) + 16 (GCM tag) = 62
       assert byte_size(wrapped) == 62
     end
 
+    test "unwrap reads v1 (no-AAD) blobs (back-compat for T3.4 rows)" do
+      # T3.4 emitted v1 wraps with no AAD. T3.6 readers MUST still round-trip
+      # them so master-key rotation can convert them lazily.
+      dek = Local.generate_dek()
+      master = Engram.Crypto.Config.local_master_key!()
+      {ct, nonce} = Engram.Crypto.Envelope.encrypt(dek, master)
+      v1_blob = <<0x01, 0x01, nonce::binary-size(12), ct::binary>>
+
+      assert byte_size(v1_blob) == 62
+      assert {:ok, ^dek} = Local.unwrap_dek(v1_blob, %{user_id: 1})
+    end
+
     test "unwrap reads legacy-format blobs (back-compat for pre-T3.4 rows)" do
-      # T3.4 — Local.wrap_dek pre-T3.4 emitted `<<nonce::12, ct::binary>>`
-      # without a header. Existing rows in DB carry that shape; unwrap MUST
-      # round-trip them so the migration does not require a backfill pass.
+      # Pre-T3.4 emitted `<<nonce::12, ct::binary>>` without a header. Existing
+      # rows in DB carry that shape; unwrap MUST round-trip them so the
+      # migration does not require a backfill pass.
       dek = Local.generate_dek()
       master = Engram.Crypto.Config.local_master_key!()
       {ct, nonce} = Engram.Crypto.Envelope.encrypt(dek, master)
@@ -190,9 +203,8 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
     end
 
     test "unwrap rejects unknown wrap-format version bytes" do
-      # Future-proofing: a 62-byte blob whose first byte is not 0x01 is
-      # neither v1 nor any legitimate legacy shape (legacy is 60 bytes).
-      # Must fail loudly rather than fall through to a partial parse.
+      # Future-proofing: a 62-byte blob whose first byte is neither v1 nor
+      # v2 must fail loudly rather than fall through to a partial parse.
       bogus = <<0x99, 0x01, :crypto.strong_rand_bytes(60)::binary>>
       assert byte_size(bogus) == 62
       assert {:error, _} = Local.unwrap_dek(bogus, %{user_id: 1})

--- a/test/engram/crypto/qdrant_payload_test.exs
+++ b/test/engram/crypto/qdrant_payload_test.exs
@@ -27,7 +27,7 @@ defmodule Engram.Crypto.QdrantPayloadTest do
     test "encrypts text/title/heading_path", %{user: user} do
       {:ok, user} = Crypto.ensure_user_dek(user)
 
-      assert {:ok, out} = Crypto.encrypt_qdrant_payload(@base_payload, user)
+      assert {:ok, out} = Crypto.encrypt_qdrant_payload(@base_payload, user, "test_collection", "qid-test")
 
       # Plaintext fields untouched
       assert out.user_id == "1"
@@ -55,22 +55,23 @@ defmodule Engram.Crypto.QdrantPayloadTest do
     test "produces distinct nonces across calls", %{user: user} do
       {:ok, user} = Crypto.ensure_user_dek(user)
 
-      {:ok, o1} = Crypto.encrypt_qdrant_payload(@base_payload, user)
-      {:ok, o2} = Crypto.encrypt_qdrant_payload(@base_payload, user)
+      {:ok, o1} = Crypto.encrypt_qdrant_payload(@base_payload, user, "test_collection", "qid-test")
+      {:ok, o2} = Crypto.encrypt_qdrant_payload(@base_payload, user, "test_collection", "qid-test")
 
       refute o1.text_nonce == o2.text_nonce
       refute o1.text == o2.text
     end
 
     test "returns {:error, :no_dek} when user lacks a DEK", %{user: user} do
-      assert {:error, :no_dek} = Crypto.encrypt_qdrant_payload(@base_payload, user)
+      assert {:error, :no_dek} = Crypto.encrypt_qdrant_payload(@base_payload, user, "test_collection", "qid-test")
     end
 
     test "encrypts empty strings deterministically-shaped", %{user: user} do
       {:ok, user} = Crypto.ensure_user_dek(user)
       payload = %{@base_payload | text: "", title: "", heading_path: ""}
 
-      assert {:ok, out} = Crypto.encrypt_qdrant_payload(payload, user)
+      assert {:ok, out} =
+               Crypto.encrypt_qdrant_payload(payload, user, "test_collection", "qid-empty")
       # Empty plaintext still produces 16-byte GCM tag → non-empty b64 ciphertext
       assert byte_size(Base.decode64!(out.text)) == 16
     end
@@ -84,7 +85,9 @@ defmodule Engram.Crypto.QdrantPayloadTest do
       {:ok, enc_payload} =
         Crypto.encrypt_qdrant_payload(
           %{text: "secret", title: "T", heading_path: "intro"},
-          user
+          user,
+          "test_collection",
+          "qid-1"
         )
 
       enc_candidate = %{
@@ -98,7 +101,8 @@ defmodule Engram.Crypto.QdrantPayloadTest do
         heading_path: enc_payload.heading_path,
         text_nonce: enc_payload.text_nonce,
         title_nonce: enc_payload.title_nonce,
-        heading_path_nonce: enc_payload.heading_path_nonce
+        heading_path_nonce: enc_payload.heading_path_nonce,
+        aad_version: enc_payload.aad_version
       }
 
       vaults_by_id = %{"5" => vault}
@@ -111,11 +115,34 @@ defmodule Engram.Crypto.QdrantPayloadTest do
       enc_candidate: enc,
       vaults_by_id: vaults
     } do
-      assert {:ok, [out]} = Crypto.decrypt_qdrant_candidates([enc], user, vaults)
+      assert {:ok, [out]} =
+               Crypto.decrypt_qdrant_candidates([enc], user, vaults, "test_collection")
+
       assert out.text == "secret"
       assert out.title == "T"
       assert out.heading_path == "intro"
       refute Map.has_key?(out, :text_nonce)
+    end
+
+    test "AAD-bound candidate FAILS to decrypt under wrong collection (T3.6)", %{
+      user: user,
+      enc_candidate: enc,
+      vaults_by_id: vaults
+    } do
+      # Encrypted under "test_collection" — handing the same point to the
+      # decryptor under a different collection MUST fail the AAD check.
+      assert {:error, :decrypt_failed} =
+               Crypto.decrypt_qdrant_candidates([enc], user, vaults, "other_collection")
+    end
+
+    test "AAD-bound candidate FAILS to decrypt when qdrant_id is swapped (T3.6)",
+         %{user: user, enc_candidate: enc, vaults_by_id: vaults} do
+      # Lift the ciphertext / nonce of qid-1 into a candidate that claims
+      # qdrant_id "qid-2". Reconstructed AAD differs → decrypt fails.
+      swapped = %{enc | qdrant_id: "qid-2"}
+
+      assert {:error, :decrypt_failed} =
+               Crypto.decrypt_qdrant_candidates([swapped], user, vaults, "test_collection")
     end
 
     test "drops tampered candidate, keeps others, emits telemetry + error log", %{
@@ -127,7 +154,9 @@ defmodule Engram.Crypto.QdrantPayloadTest do
       {:ok, other_payload} =
         Crypto.encrypt_qdrant_payload(
           %{text: "second", title: "S", heading_path: "h"},
-          user
+          user,
+          "test_collection",
+          "qid-2"
         )
 
       survivor = %{
@@ -141,7 +170,8 @@ defmodule Engram.Crypto.QdrantPayloadTest do
         heading_path: other_payload.heading_path,
         text_nonce: other_payload.text_nonce,
         title_nonce: other_payload.title_nonce,
-        heading_path_nonce: other_payload.heading_path_nonce
+        heading_path_nonce: other_payload.heading_path_nonce,
+        aad_version: other_payload.aad_version
       }
 
       <<first, rest::binary>> = Base.decode64!(enc.text)
@@ -164,7 +194,12 @@ defmodule Engram.Crypto.QdrantPayloadTest do
         log =
           ExUnit.CaptureLog.capture_log(fn ->
             assert {:ok, [out]} =
-                     Crypto.decrypt_qdrant_candidates([tampered, survivor], user, vaults)
+                     Crypto.decrypt_qdrant_candidates(
+                       [tampered, survivor],
+                       user,
+                       vaults,
+                       "test_collection"
+                     )
 
             assert out.qdrant_id == "qid-2"
           end)
@@ -187,7 +222,7 @@ defmodule Engram.Crypto.QdrantPayloadTest do
       tampered = %{enc | text: tampered_ct}
 
       assert {:error, :decrypt_failed} =
-               Crypto.decrypt_qdrant_candidates([tampered], user, vaults)
+               Crypto.decrypt_qdrant_candidates([tampered], user, vaults, "test_collection")
     end
 
     test "empty input returns {:ok, []}", %{user: user, vaults_by_id: vaults} do

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -57,21 +57,25 @@ defmodule Engram.CryptoTest do
     assert {:error, :no_dek} = Crypto.get_dek(user)
   end
 
-  describe "encrypt_note_fields/2" do
-    test "encrypts content + title (tags handled by Phase B)", %{user: user} do
+  describe "encrypt_note_fields/3" do
+    test "encrypts content + title with row-id-bound AAD (T3.6)", %{user: user} do
       {:ok, user} = Crypto.ensure_user_dek(user)
 
       attrs = %{content: "secret", title: "Journal", tags: ["mood"]}
-      {:ok, out} = Crypto.encrypt_note_fields(attrs, user)
+      {:ok, out} = Crypto.encrypt_note_fields(attrs, user, 4242)
 
       refute Map.has_key?(out, :content)
       refute Map.has_key?(out, :title)
-      # Phase B.3+: tags are produced by phase_b_keyword_for/4 only.
+      # Phase B.3+: tags are produced by phase_b_keyword_for only.
       refute Map.has_key?(out, :tags_ciphertext)
       assert is_binary(out.content_ciphertext)
       assert byte_size(out.content_nonce) == 12
       assert is_binary(out.title_ciphertext)
       assert byte_size(out.title_nonce) == 12
+      # T3.6 — encrypt stamps the AAD-bound row version + propagates :id so
+      # the caller can drop the changeset onto the pre-allocated row.
+      assert out.id == 4242
+      assert out.dek_version == Crypto.row_version_aad_bound()
     end
   end
 
@@ -87,13 +91,17 @@ defmodule Engram.CryptoTest do
       {:ok, user} = Crypto.ensure_user_dek(user)
 
       {:ok, encrypted} =
-        Crypto.encrypt_note_fields(%{content: "secret", title: "T"}, user)
+        Crypto.encrypt_note_fields(%{content: "secret", title: "T"}, user, 1234)
 
       {:ok, dek} = Crypto.get_dek(user)
       tags_bin = :erlang.term_to_binary(["x"])
-      {tags_ct, tags_n} = Crypto.Envelope.encrypt(tags_bin, dek)
+
+      {tags_ct, tags_n} =
+        Crypto.Envelope.encrypt(tags_bin, dek, Crypto.aad_for_row(:notes, :tags, 1234))
 
       note = %Engram.Notes.Note{
+        id: 1234,
+        dek_version: Crypto.row_version_aad_bound(),
         content_ciphertext: encrypted.content_ciphertext,
         content_nonce: encrypted.content_nonce,
         title_ciphertext: encrypted.title_ciphertext,


### PR DESCRIPTION
## Summary
- Bind every AES-GCM ciphertext to a row-id AAD (`<table>:<column>:<row_id>`, `qdrant:<col>:<qdrant_id>:<field>`, `dek:v1:<user_id>`) so within-user cross-row / cross-column / cross-user swaps fail the AEAD tag check at read time.
- Wrap-format v2 (`0x02`) for `users.encrypted_dek`, AAD-bound to the user. Reader still handles v1 + pre-T3.4 legacy. `BootCanary` passes `user_id: :canary`.
- Per-row `dek_version` flips from `1` (legacy, empty AAD) to `2` (AAD-bound) on every write. Pre-allocate row ids via `next_row_id/1` so the bind string is constructible before INSERT. `Engram.Crypto.AadRebind` + `mix engram.rebind_aad` migrate legacy users.
- Closes audit finding **H1** from `docs/encryption-tier-3-audit.md`.

## What changed
| Area | File(s) |
|---|---|
| AAD primitives | `lib/engram/crypto/envelope.ex`, `lib/engram/crypto.ex` (helpers + dispatch) |
| Wrap format v2 | `lib/engram/crypto/key_provider/local.ex`, `lib/engram/crypto/boot_canary.ex` |
| Write paths | `lib/engram/notes.ex`, `lib/engram/attachments.ex`, `lib/engram/vaults.ex`, `lib/engram/indexing.ex` |
| Read paths | `lib/engram_web/controllers/sync_controller.ex`, `lib/engram/notes.ex` aggregations, `lib/engram/vector/qdrant.ex` (carry `aad_version`), `lib/engram/workers/backfill_content_hash_hmac.ex` |
| Schema cast | `lib/engram/notes/note.ex`, `lib/engram/attachments/attachment.ex`, `lib/engram/vaults/vault.ex` (cast `:dek_version`) |
| Backfill | `lib/engram/crypto/aad_rebind.ex`, `lib/mix/tasks/engram.rebind_aad.ex` |

## Audit Q answers
- **Q1 — relational AAD shape:** `<table>:<column>:<row_id>` (audit default).
- **Q2 — Qdrant AAD shape:** investigated `chunk_index` first; it's locally stable (each `delete_by_note` + re-upsert resets the set) but allows cross-note swap when two notes happen to share an index. Switched to `<qdrant_id>` (point UUID) which is intrinsic and unique per write — strictly stronger than the chunk-content-hash fallback the audit suggested. `aad_version` field on the payload drives the bind-vs-empty dispatch at decrypt.
- **Q3 — wrapped-DEK AAD:** `dek:v1:<user_id>`, wrap-format byte bumps `0x01 → 0x02`.

## Test plan
- [x] `mix test` — 923 tests green (was 914 + 9 new across `aad_rebind_test`, `aad_tamper_test`, refreshed `envelope_test` / `local_provider_test` / `qdrant_payload_test` / `crypto_test`).
- [ ] Tamper tests cover: cross-row swap, within-row column swap, cross-user swap, AAD-bound ciphertext under empty AAD, wrapped-DEK under wrong `user_id` ctx, Qdrant point under wrong collection / wrong qdrant_id.
- [ ] Backfill tests cover: legacy note → AAD-bound round-trip, wrapped DEK v1 → v2 upgrade, idempotent second run.
- [ ] After merge: deploy to FastRaid, run `bin/engram rpc 'Engram.Crypto.AadRebind.rebind_all()'` to drain legacy rows, then verify `SELECT MIN(dek_version) FROM notes` ≥ 2 (and ditto for vaults / users).

## Forward notes (deferred, not blocking T3.7)
- Attachments S3 blob is **not** rebound by `mix engram.rebind_aad` — re-encrypting only `path_ciphertext` would mismatch the row's stamped `dek_version=2` against the legacy AAD on the S3 object. Attachments converge naturally on every re-upload (`upsert_attachment` writes v2 AAD-bound). Old never-re-uploaded blobs stay legacy forever, which the read path honors via `att.dek_version`.
- The bulk per-tenant rebind transaction does the whole user's notes/vaults in one txn. Fine for selfhost / single-user FastRaid; will need cursor-paged reduction once any user's row count grows large enough to lock-storm. Track in T3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)