### PR TITLE
fix(crypto): T3-audit H2/H4/M5 — crypto observability sweep

### DIFF
--- a/lib/engram/crypto/aad_rebind.ex
+++ b/lib/engram/crypto/aad_rebind.ex
@@ -351,10 +351,21 @@ defmodule Engram.Crypto.AadRebind do
   end
 
   defp emit_telemetry(user_id, {:error, reason}, duration_us) do
+    label = reason_label(reason)
+
+    # T3-audit H4 — telemetry alone leaves operators without per-user
+    # triage during a backfill drain. Logger.error surfaces the user_id +
+    # reason_label in any standard log pipeline so a stuck rebind is
+    # diagnosable, not just countable.
+    Logger.error(
+      "aad rebind failed user_id=#{user_id} reason_label=#{label}",
+      category: :crypto_rebind
+    )
+
     :telemetry.execute(
       [:engram, :crypto, :aad_rebind, :user],
       %{duration_us: duration_us, count: 1},
-      %{user_id: user_id, status: :failed, reason_label: reason_label(reason)}
+      %{user_id: user_id, status: :failed, reason_label: label}
     )
   end
 

--- a/lib/engram/crypto/key_provider/local.ex
+++ b/lib/engram/crypto/key_provider/local.ex
@@ -32,6 +32,8 @@ defmodule Engram.Crypto.KeyProvider.Local do
   alias Engram.Crypto.Envelope
   alias Engram.Crypto.Config
 
+  require Logger
+
   # T3.4 / M2 + T3.6 / H1 — wrap-format constants.
   @wrap_version_v1 0x01
   @wrap_version_v2 0x02
@@ -145,6 +147,22 @@ defmodule Engram.Crypto.KeyProvider.Local do
   end
 
   defp emit_fallback_telemetry(ctx, outcome) do
+    classified = classify_outcome(outcome)
+
+    # T3-audit M5 — a user whose DEK cannot be unwrapped by EITHER the
+    # current master key OR the configured `_PREVIOUS` is in catastrophic
+    # state: their data is unrecoverable. Telemetry-only signaling (which
+    # depends on H2's metric registration AND a scrape pipeline) is not
+    # enough — Logger.error guarantees visibility in any standard log
+    # pipeline so operators page on the failure.
+    if classified == :failed do
+      Logger.error(
+        "dek unwrap failed under both current and _PREVIOUS master keys: " <>
+          "user_id=#{inspect(Map.get(ctx, :user_id))}",
+        category: :crypto_unwrap
+      )
+    end
+
     :telemetry.execute(
       [:engram, :crypto, :previous_fallback_hit],
       %{count: 1},
@@ -153,7 +171,7 @@ defmodule Engram.Crypto.KeyProvider.Local do
         dek_version: Map.get(ctx, :dek_version),
         master_key_version:
           Map.get(ctx, :master_key_version) || Config.master_key_version(),
-        outcome: classify_outcome(outcome)
+        outcome: classified
       }
     )
   end

--- a/lib/engram/crypto/master_rotation.ex
+++ b/lib/engram/crypto/master_rotation.ex
@@ -258,10 +258,22 @@ defmodule Engram.Crypto.MasterRotation do
   end
 
   defp emit_telemetry(user_id, {:error, reason}, duration_us) do
+    label = classify_reason(reason)
+
+    # T3-audit H4 — telemetry alone is invisible during a master-key
+    # cutover (until H2's metrics are scraped, and even then operators
+    # need user-level triage). Logger.error guarantees the failed user
+    # appears in any standard log pipeline so a stuck rotation is
+    # diagnosable, not just countable.
+    Logger.error(
+      "master rotation failed user_id=#{user_id} reason_label=#{label}",
+      category: :crypto_rotation
+    )
+
     :telemetry.execute(
       [:engram, :crypto, :rotate, :user],
       %{duration_us: duration_us, count: 1},
-      %{user_id: user_id, status: :failed, reason_label: classify_reason(reason)}
+      %{user_id: user_id, status: :failed, reason_label: label}
     )
   end
 

--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -79,7 +79,51 @@ defmodule EngramWeb.Telemetry do
       summary("vm.memory.total", unit: {:byte, :kilobyte}),
       summary("vm.total_run_queue_lengths.total"),
       summary("vm.total_run_queue_lengths.cpu"),
-      summary("vm.total_run_queue_lengths.io")
+      summary("vm.total_run_queue_lengths.io"),
+
+      # Crypto / Encryption Metrics — T3-audit H2.
+      #
+      # Every Tier-3 encryption phase emitted telemetry for operationally-
+      # critical signals. Until they are registered here as Telemetry.Metrics
+      # counters, no PromEx/Sentry pipeline can see them. Pinned by
+      # `test/engram_web/telemetry_test.exs` so future drift breaks the build.
+      counter("engram.crypto.rotate.user.count",
+        tags: [:status, :reason_label],
+        description: "MasterRotation per-user outcome (T3.5 master-key cutover)"
+      ),
+      summary("engram.crypto.rotate.user.duration_us",
+        unit: {:native, :microsecond},
+        tags: [:status],
+        description: "MasterRotation per-user duration"
+      ),
+      counter("engram.crypto.aad_rebind.user.count",
+        tags: [:status, :reason_label],
+        description: "AadRebind per-user outcome (T3.6 backfill)"
+      ),
+      summary("engram.crypto.aad_rebind.user.duration_us",
+        unit: {:native, :microsecond},
+        tags: [:status],
+        description: "AadRebind per-user duration"
+      ),
+      counter("engram.crypto.previous_fallback_hit.count",
+        tags: [:outcome],
+        description:
+          "Previous-master fallback hits — should drop to 0 post-rotation; non-zero `:failed` outcome is catastrophic"
+      ),
+      counter("engram.crypto.boot_canary.count",
+        tags: [:status, :reason_label],
+        description: "Boot canary outcomes — `:failed` halts boot via BootCanaryGuard"
+      ),
+      counter("engram.search.decrypt_failed.count",
+        description:
+          "Search candidate decrypt failures — non-zero rate is an alarm signal (key drift, tampering)"
+      ),
+      counter("engram.search.payload_shape_mismatch.count",
+        description: "Qdrant payload shape mismatches — drift between writer and reader"
+      ),
+      counter("engram.indexing.encrypt_failed.count",
+        description: "Indexing-time encrypt failures (e.g. missing DEK at re-embed)"
+      )
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.37",
+      version: "0.5.38",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto/aad_rebind_test.exs
+++ b/test/engram/crypto/aad_rebind_test.exs
@@ -150,4 +150,28 @@ defmodule Engram.Crypto.AadRebindTest do
     end
   end
 
+  describe "Logger on failure (T3-audit H4)" do
+    test "rebind_user logs error with user_id + reason_label when txn fails" do
+      # T3-audit H4 — failed per-user rebinds were emitting telemetry only.
+      # Combined with H2 (no registered telemetry handlers), per-user
+      # failures during a backfill drain were operationally invisible:
+      # operator sees `%{failed: 7}` aggregate with no user_ids and no
+      # reasons, no way to triage stuck users.
+      bogus_id = -42
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:error, {:not_found, ^bogus_id}} = AadRebind.rebind_user(bogus_id)
+        end)
+
+      assert log =~ "aad rebind failed",
+             "expected `aad rebind failed` log line, got: #{log}"
+
+      assert log =~ "user_id=#{bogus_id}",
+             "log must carry user_id for triage, got: #{log}"
+
+      assert log =~ "reason_label=not_found",
+             "log must carry reason_label so operators can group failures, got: #{log}"
+    end
+  end
 end

--- a/test/engram/crypto/local_provider_test.exs
+++ b/test/engram/crypto/local_provider_test.exs
@@ -210,4 +210,37 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
       assert {:error, _} = Local.unwrap_dek(bogus, %{user_id: 1})
     end
   end
+
+  describe "Logger on dual-fallback failure (T3-audit M5)" do
+    test "logs error when neither current nor _PREVIOUS unwraps the DEK" do
+      # T3-audit M5 — a user whose DEK cannot be unwrapped by EITHER the
+      # current master key OR the configured `_PREVIOUS` is in catastrophic
+      # state: their data is unrecoverable. Telemetry-only signaling is
+      # not enough — this should page operators. Logger.error with
+      # user_id + outcome=failed makes the failure surface in any standard
+      # log pipeline regardless of telemetry handler registration.
+      key_a = :crypto.strong_rand_bytes(32)
+      Application.put_env(:engram, :encryption_master_key, Base.encode64(key_a))
+      dek = Local.generate_dek()
+      {:ok, wrapped_with_a} = Local.wrap_dek(dek, %{user_id: 9999})
+
+      # Now point env at TWO different wrong keys — neither can unwrap.
+      key_b = :crypto.strong_rand_bytes(32)
+      key_c = :crypto.strong_rand_bytes(32)
+      Application.put_env(:engram, :encryption_master_key, Base.encode64(key_b))
+      Application.put_env(:engram, :encryption_master_key_previous, Base.encode64(key_c))
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:error, :invalid_wrapping} =
+                   Local.unwrap_dek(wrapped_with_a, %{user_id: 9999})
+        end)
+
+      assert log =~ "dek unwrap failed under both current and _PREVIOUS",
+             "expected error log on dual-key failure, got: #{log}"
+
+      assert log =~ "user_id=9999",
+             "log must carry user_id for triage, got: #{log}"
+    end
+  end
 end

--- a/test/engram/crypto/master_rotation_test.exs
+++ b/test/engram/crypto/master_rotation_test.exs
@@ -176,6 +176,31 @@ defmodule Engram.Crypto.MasterRotationTest do
     end
   end
 
+  describe "Logger on failure (T3-audit H4)" do
+    test "rotate_user logs error with user_id + reason_label when txn fails" do
+      # T3-audit H4 — failed per-user rotations were emitting telemetry only.
+      # Combined with H2 (no registered telemetry handlers), per-user
+      # failures during a master-key cutover were operationally invisible:
+      # operator sees `%{failed: 20}` aggregate with no user_ids, no
+      # reasons. Failed users brick when `_PREVIOUS` is later removed.
+      bogus_id = -42
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:error, {:not_found, ^bogus_id}} = MasterRotation.rotate_user(bogus_id, 2)
+        end)
+
+      assert log =~ "master rotation failed",
+             "expected `master rotation failed` log line, got: #{log}"
+
+      assert log =~ "user_id=#{bogus_id}",
+             "log must carry user_id for triage, got: #{log}"
+
+      assert log =~ "reason_label=not_found",
+             "log must carry reason_label so operators can group failures, got: #{log}"
+    end
+  end
+
   defp refute_in_counts(_counts, _id), do: :ok
 
   import Ecto.Query

--- a/test/engram_web/telemetry_test.exs
+++ b/test/engram_web/telemetry_test.exs
@@ -1,0 +1,63 @@
+defmodule EngramWeb.TelemetryTest do
+  use ExUnit.Case, async: true
+
+  describe "metrics/0 — crypto observability (T3-audit H2)" do
+    setup do
+      # Telemetry.Metrics stores `name` as the atom-list event path with the
+      # measurement appended, e.g. [:engram, :crypto, :rotate, :user, :count].
+      # We compare in dotted-string form for readability in test assertions.
+      metric_names =
+        EngramWeb.Telemetry.metrics()
+        |> Enum.map(fn metric ->
+          metric.name |> Enum.map_join(".", &Atom.to_string/1)
+        end)
+        |> MapSet.new()
+
+      {:ok, names: metric_names}
+    end
+
+    # T3-audit H2 — every Tier-3 PR introduced telemetry events for
+    # operationally-critical crypto signals. Until they're registered as
+    # Telemetry.Metrics counters/summaries, no PromEx/Sentry pipeline can
+    # see them — every "we emit telemetry" defense in T3.5/T3.6 collapses
+    # into "we emit nothing reachable." This test pins each event so the
+    # registration cannot quietly drift.
+
+    test "registers engram.crypto.rotate.user counter (T3.5 master-key rotation)", %{
+      names: names
+    } do
+      assert "engram.crypto.rotate.user.count" in names,
+             "MasterRotation per-user outcome must be counted (status, reason_label)"
+    end
+
+    test "registers engram.crypto.aad_rebind.user counter (T3.6 backfill)", %{names: names} do
+      assert "engram.crypto.aad_rebind.user.count" in names,
+             "AadRebind per-user outcome must be counted (status, reason_label)"
+    end
+
+    test "registers engram.crypto.previous_fallback_hit counter (T3.5 / M4)", %{names: names} do
+      assert "engram.crypto.previous_fallback_hit.count" in names,
+             "Previous-master fallback hits must be counted — should drop to 0 post-rotation"
+    end
+
+    test "registers engram.crypto.boot_canary counter (T3.5 boot guard)", %{names: names} do
+      assert "engram.crypto.boot_canary.count" in names,
+             "Boot canary outcomes must be counted (provisioned, ok, failed:reason_label)"
+    end
+
+    test "registers engram.search.decrypt_failed counter", %{names: names} do
+      assert "engram.search.decrypt_failed.count" in names,
+             "Search decrypt failures must page operators — alarm signal"
+    end
+
+    test "registers engram.search.payload_shape_mismatch counter", %{names: names} do
+      assert "engram.search.payload_shape_mismatch.count" in names,
+             "Payload-shape mismatches indicate Qdrant schema drift"
+    end
+
+    test "registers engram.indexing.encrypt_failed counter", %{names: names} do
+      assert "engram.indexing.encrypt_failed.count" in names,
+             "Indexing encrypt failures (e.g. missing DEK) must be counted"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three observability gaps surfaced by the post-T3 audit. All Tier-3 PRs (#73-#79) emitted telemetry for operationally-critical signals, but none of those signals were reachable to operators.

- **H2 — Crypto telemetry events had zero registered handlers.** Every `[:engram, :crypto, ...]` event was emitted but never declared in `EngramWeb.Telemetry.metrics/0`, so PromEx / Sentry / Telemetry.Metrics.ConsoleReporter saw nothing. Registered 7 counters + 2 summaries for: `crypto.rotate.user`, `crypto.aad_rebind.user`, `crypto.previous_fallback_hit`, `crypto.boot_canary`, `search.decrypt_failed`, `search.payload_shape_mismatch`, `indexing.encrypt_failed`.
- **H4 — MasterRotation + AadRebind emitted telemetry on per-user failure but no Logger.** Combined with H2, a botched cutover/drain produced `%{failed: 7}` with no user_ids and no reasons. Failed users brick when `_PREVIOUS` is later removed. Now `Logger.error("master rotation failed user_id=… reason_label=…")` and `"aad rebind failed user_id=… reason_label=…"`.
- **M5 — KeyProvider.Local emitted telemetry on dual-key unwrap failure but no Logger.** A user whose DEK can be unwrapped by neither the current master nor `_PREVIOUS` is in catastrophic state — should page, not just count. Now `Logger.error("dek unwrap failed under both current and _PREVIOUS master keys: user_id=…")`.

## Test plan

- [x] `test/engram_web/telemetry_test.exs` (NEW) — 7 tests pin each `metric.name` as `<event>.count` so future drift breaks the build.
- [x] `test/engram/crypto/master_rotation_test.exs` — Logger contract on `rotate_user/2` failure (`{:not_found, _}` path).
- [x] `test/engram/crypto/aad_rebind_test.exs` — same for `rebind_user/1`.
- [x] `test/engram/crypto/local_provider_test.exs` — Logger contract on `try_previous_fallback` dual-key failure.
- [x] `mix test` — 939 backend tests, 0 failures (was 929 + 10 new).
- [ ] CI green.

## Forward (still open from audit)

- H1 attachment upload race (concurrent upsert can land mismatched DEK on S3 blob).
- H3 `Oban.insert/1` return values discarded across `notes.ex` (90, 237, 273, 654).
- H5 `AadRebind.rebind_user_attachments/1` returns `:ok` while no-op (operator-misleading drained signal).
- M1 telemetry surface drift between `:rotate, :user` (4-segment, `status:`) and `:previous_fallback_hit` (3-segment, `outcome:`).
- M3 idempotency (rebind already-rebound users reports `:ok` not `:skipped`).
- M4 privatize `Crypto.encrypt_qdrant_payload/2` (legacy 2-arity is a foot-gun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)