### PR TITLE
ci: install tailwind in e2e-browser to recover from :eacces flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -775,6 +775,10 @@ jobs:
           done
           mix ecto.create
           mix ecto.migrate
+          # Ensure Tailwind binary is valid (cache prune can corrupt native deps).
+          # Mirror of unit-tests fix — Playwright's webServer boots Phoenix
+          # which boots Tailwind, and a corrupt :eacces binary kills the boot.
+          mix tailwind.install 2>/dev/null || true
 
       - name: Install frontend deps + Playwright
         working-directory: frontend

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.38",
+      version: "0.5.39",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

PR #81 hit a transient e2e-browser failure where Phoenix (booted by Playwright's webServer) crashed on `Tailwind.start/2` with `ErlangError :eacces` — the cached `_build/tailwind-linux-x64` binary on the self-hosted runner had lost execute perms (cache prune mid-cycle).

The `unit-tests` job already mirrored this fix at line 551 ("cache prune can corrupt native deps"). Mirror the same `mix tailwind.install` recovery step into the e2e-browser setup.

Rerunning the failed job alone made PR #81 pass — confirming the binary was repaired by the next deps cycle. This change prevents the repaired-on-rerun loop entirely.

## Test plan

- [x] CI green (specifically e2e-browser without rerun).
- [x] No code changes; mix.exs version bump only to satisfy version-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)