### PR TITLE
fix(crypto): T3-audit AAD edges + correctness (0.5.40)

### DIFF
--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -33,56 +33,91 @@ defmodule Engram.Attachments do
          {:ok, filter_key} <- Crypto.dek_filter_key(user) do
       path_hmac = Crypto.hmac_field(filter_key, path)
 
-      # Find existing FIRST so we can reuse its id for AAD; otherwise
-      # pre-allocate a fresh attachment id from the bigserial sequence.
-      existing =
-        Repo.with_tenant(user.id, fn ->
-          Repo.one(
-            from(a in Attachment,
-              where:
-                a.path_hmac == ^path_hmac and a.user_id == ^user.id and
-                  a.vault_id == ^vault.id
+      # T3-audit H1 — concurrent upserts to the same path can race: each
+      # reads "no existing row," allocates its own att_id, encrypts the
+      # blob with AAD bound to that id, then PUTs to the same S3 key (last
+      # writer wins on the blob). The unique path_hmac constraint then
+      # picks a winning row whose id may not match the AAD baked into the
+      # surviving blob → reads decrypt-fail. Serialize per (user, path) via
+      # a transaction-scoped advisory lock so the second upsert blocks
+      # until the first commits, then sees the existing row + reuses its
+      # id. The lock auto-releases on commit/rollback.
+      Repo.transaction(fn ->
+        :ok = acquire_path_lock(user.id, path_hmac)
+
+        existing =
+          Repo.with_tenant(user.id, fn ->
+            Repo.one(
+              from(a in Attachment,
+                where:
+                  a.path_hmac == ^path_hmac and a.user_id == ^user.id and
+                    a.vault_id == ^vault.id
+              )
             )
-          )
-        end)
-        |> unwrap_tenant()
+          end)
+          |> unwrap_tenant()
+          |> case do
+            {:ok, att} -> att
+            {:error, _} -> nil
+          end
+
+        att_id =
+          case existing do
+            nil -> Crypto.next_row_id(:attachments)
+            %Attachment{id: id} -> id
+          end
+
+        with {:ok, key, changeset_attrs, ciphertext} <-
+               prepare_upload(
+                 user,
+                 vault,
+                 att_id,
+                 path,
+                 path_hmac,
+                 plaintext,
+                 mtime,
+                 explicit_mime
+               ),
+             :ok <- store_external(key, ciphertext, changeset_attrs.mime_type) do
+          Repo.with_tenant(user.id, fn ->
+            case existing do
+              nil ->
+                %Attachment{id: att_id}
+                |> Attachment.changeset(changeset_attrs)
+                |> Repo.insert()
+
+              att ->
+                att
+                |> Attachment.changeset(changeset_attrs)
+                |> Repo.update()
+            end
+          end)
+          |> unwrap_tenant()
+          |> case do
+            # Phase B.3: path is virtual — splice the plaintext we already
+            # have onto the returned struct so callers can read att.path
+            # without a second decrypt round-trip.
+            {:ok, att} -> {:ok, %{att | path: path}}
+            other -> other
+          end
+        end
         |> case do
           {:ok, att} -> att
-          {:error, _} -> nil
+          {:error, reason} -> Repo.rollback(reason)
         end
-
-      att_id =
-        case existing do
-          nil -> Crypto.next_row_id(:attachments)
-          %Attachment{id: id} -> id
-        end
-
-      with {:ok, key, changeset_attrs, ciphertext} <-
-             prepare_upload(user, vault, att_id, path, path_hmac, plaintext, mtime, explicit_mime),
-           :ok <- store_external(key, ciphertext, changeset_attrs.mime_type) do
-        Repo.with_tenant(user.id, fn ->
-          case existing do
-            nil ->
-              %Attachment{id: att_id}
-              |> Attachment.changeset(changeset_attrs)
-              |> Repo.insert()
-
-            att ->
-              att
-              |> Attachment.changeset(changeset_attrs)
-              |> Repo.update()
-          end
-        end)
-        |> unwrap_tenant()
-        |> case do
-          # Phase B.3: path is virtual — splice the plaintext we already
-          # have onto the returned struct so callers can read att.path
-          # without a second decrypt round-trip.
-          {:ok, att} -> {:ok, %{att | path: path}}
-          other -> other
-        end
-      end
+      end)
     end
+  end
+
+  # T3-audit H1 — txn-scoped advisory lock keyed on (user_id, path_hmac).
+  # Postgres `pg_advisory_xact_lock(bigint)` takes a single 64-bit key; we
+  # derive it from `:erlang.phash2/2` over the (user_id, path_hmac) tuple.
+  # Collisions are tolerable: a hash collision causes an unrelated upload
+  # to wait, which is at most a latency cost, not a correctness issue.
+  defp acquire_path_lock(user_id, path_hmac) do
+    key = :erlang.phash2({user_id, path_hmac}, 2_147_483_647)
+    Repo.query!("SELECT pg_advisory_xact_lock($1)", [key])
+    :ok
   end
 
   @doc """

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -391,32 +391,10 @@ defmodule Engram.Crypto do
   signals a config bug; fail-loud via Oban retry + telemetry is preferable
   to silent lazy-provisioning.
 
-  ## 2-arity vs 4-arity (T3.6)
-
-  The 2-arity form emits non-AAD-bound payloads — kept for tests that mock
-  Qdrant search responses without threading through a stable point id.
-  Production code must use the 4-arity AAD-bound variant; every real point
-  flows through `Engram.Indexing.prepare_index/2` which generates the
-  point UUID before calling `encrypt_qdrant_payload/4`.
+  T3-audit M4 — the legacy 2-arity form (no AAD) was privatized. All
+  production + test callers thread `(collection, qdrant_id)` through this
+  4-arity form, ensuring every emitted point is AAD-bound.
   """
-  @spec encrypt_qdrant_payload(map(), User.t()) :: {:ok, map()} | {:error, term()}
-  def encrypt_qdrant_payload(payload, %User{} = user) do
-    with {:ok, dek} <- get_dek(user) do
-      {text_ct, text_nonce} = Envelope.encrypt(Map.get(payload, :text) || "", dek)
-      {title_ct, title_nonce} = Envelope.encrypt(Map.get(payload, :title) || "", dek)
-      {hp_ct, hp_nonce} = Envelope.encrypt(Map.get(payload, :heading_path) || "", dek)
-
-      {:ok,
-       payload
-       |> Map.put(:text, Base.encode64(text_ct))
-       |> Map.put(:text_nonce, Base.encode64(text_nonce))
-       |> Map.put(:title, Base.encode64(title_ct))
-       |> Map.put(:title_nonce, Base.encode64(title_nonce))
-       |> Map.put(:heading_path, Base.encode64(hp_ct))
-       |> Map.put(:heading_path_nonce, Base.encode64(hp_nonce))}
-    end
-  end
-
   @spec encrypt_qdrant_payload(map(), User.t(), String.t(), String.t()) ::
           {:ok, map()} | {:error, term()}
   def encrypt_qdrant_payload(payload, %User{} = user, collection, qdrant_id)

--- a/lib/engram/crypto/aad_rebind.ex
+++ b/lib/engram/crypto/aad_rebind.ex
@@ -104,21 +104,30 @@ defmodule Engram.Crypto.AadRebind do
   end
 
   defp rebind_locked_user(%User{} = user) do
-    with :ok <- rewrap_user_dek_if_needed(user),
-         :ok <- rebind_user_notes(user),
+    # T3-audit M3 — track whether anything was actually changed so re-runs
+    # of an already-rebound user return :skipped (not :ok). Operator drain
+    # logs can then distinguish real work from no-ops.
+    with {:ok, dek_changed?} <- rewrap_user_dek_if_needed(user),
+         {:ok, notes_count} <- rebind_user_notes(user),
          :ok <- rebind_user_attachments(user),
-         :ok <- rebind_user_vaults(user) do
-      {:rebound, user}
+         {:ok, vaults_count} <- rebind_user_vaults(user) do
+      if dek_changed? or notes_count > 0 or vaults_count > 0 do
+        {:rebound, user}
+      else
+        :skipped
+      end
     else
       {:error, reason} -> Repo.rollback(reason)
     end
   end
 
   # 0x01 (or pre-T3.4 60-byte legacy) → 0x02 with AAD = "dek:v1:<user_id>".
+  # Returns {:ok, true} if the wrap was upgraded, {:ok, false} if it was
+  # already v2 (no-op), or {:error, _} on failure.
   defp rewrap_user_dek_if_needed(%User{encrypted_dek: blob} = user) do
     case classify_wrap(blob) do
       :v2 ->
-        :ok
+        {:ok, false}
 
       :legacy_or_v1 ->
         provider = Resolver.provider_for(user.id)
@@ -135,7 +144,7 @@ defmodule Engram.Crypto.AadRebind do
               # plaintext DEK material is unchanged; only the wrap envelope
               # changed.
               Crypto.DekCache.invalidate(user.id)
-              :ok
+              {:ok, true}
 
             {:error, changeset} ->
               {:error, changeset}
@@ -147,6 +156,8 @@ defmodule Engram.Crypto.AadRebind do
   defp classify_wrap(<<0x02, 0x01, _rest::binary>>), do: :v2
   defp classify_wrap(_blob), do: :legacy_or_v1
 
+  # Returns {:ok, count_rebound} or {:error, reason}. Count drives M3
+  # idempotency — zero rebinds + no DEK rewrap = :skipped.
   defp rebind_user_notes(%User{id: user_id} = user) do
     {:ok, dek} = Crypto.get_dek(user)
     legacy_version = Crypto.row_version_legacy()
@@ -158,9 +169,9 @@ defmodule Engram.Crypto.AadRebind do
       )
       |> Repo.all(skip_tenant_check: true)
 
-    Enum.reduce_while(rows, :ok, fn note, _acc ->
+    Enum.reduce_while(rows, {:ok, 0}, fn note, {:ok, n} ->
       case rebind_note(note, dek) do
-        :ok -> {:cont, :ok}
+        :ok -> {:cont, {:ok, n + 1}}
         {:error, reason} -> {:halt, {:error, {:note, note.id, reason}}}
       end
     end)
@@ -248,6 +259,7 @@ defmodule Engram.Crypto.AadRebind do
   # read path honors that via `att.dek_version`.
   defp rebind_attachment(_att, _dek), do: :ok
 
+  # Returns {:ok, count_rebound} or {:error, reason}.
   defp rebind_user_vaults(%User{id: user_id} = user) do
     {:ok, dek} = Crypto.get_dek(user)
     legacy_version = Crypto.row_version_legacy()
@@ -259,9 +271,9 @@ defmodule Engram.Crypto.AadRebind do
       )
       |> Repo.all(skip_tenant_check: true)
 
-    Enum.reduce_while(rows, :ok, fn vault, _acc ->
+    Enum.reduce_while(rows, {:ok, 0}, fn vault, {:ok, n} ->
       case rebind_vault(vault, dek) do
-        :ok -> {:cont, :ok}
+        :ok -> {:cont, {:ok, n + 1}}
         {:error, reason} -> {:halt, {:error, {:vault, vault.id, reason}}}
       end
     end)

--- a/lib/engram/crypto/aad_rebind.ex
+++ b/lib/engram/crypto/aad_rebind.ex
@@ -28,7 +28,7 @@ defmodule Engram.Crypto.AadRebind do
   safety net).
   """
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query
   require Logger
 
   alias Engram.Accounts.User
@@ -107,10 +107,17 @@ defmodule Engram.Crypto.AadRebind do
     # T3-audit M3 — track whether anything was actually changed so re-runs
     # of an already-rebound user return :skipped (not :ok). Operator drain
     # logs can then distinguish real work from no-ops.
+    #
+    # T3-audit H5 — `rebind_user_attachments/1` is intentionally a no-op
+    # (S3 blobs converge on next upload). We invoke it separately so the
+    # `with` chain only depends on rebinds that touch ciphertext, and
+    # surface the legacy attachment count via telemetry so an operator
+    # drain log isn't silently misleading.
     with {:ok, dek_changed?} <- rewrap_user_dek_if_needed(user),
          {:ok, notes_count} <- rebind_user_notes(user),
-         :ok <- rebind_user_attachments(user),
          {:ok, vaults_count} <- rebind_user_vaults(user) do
+      _ = rebind_user_attachments(user)
+
       if dek_changed? or notes_count > 0 or vaults_count > 0 do
         {:rebound, user}
       else
@@ -223,41 +230,56 @@ defmodule Engram.Crypto.AadRebind do
     end
   end
 
-  defp rebind_user_attachments(%User{id: user_id} = user) do
-    {:ok, dek} = Crypto.get_dek(user)
+  # T3-audit H5 — attachment rebind is intentional no-op (see comment on
+  # rebind_attachment/2). Counts legacy attachments and emits per-user
+  # telemetry + Logger so the operator drain log is honest about what was
+  # NOT rebound. Returns {:skipped, :not_supported, count}.
+  defp rebind_user_attachments(%User{id: user_id} = _user) do
     legacy_version = Crypto.row_version_legacy()
 
-    rows =
+    legacy_count =
       from(a in Attachment,
         where: a.user_id == ^user_id and a.dek_version == ^legacy_version,
-        select: a
+        select: count(a.id)
       )
-      |> Repo.all(skip_tenant_check: true)
+      |> Repo.one(skip_tenant_check: true)
+      |> case do
+        nil -> 0
+        n when is_integer(n) -> n
+      end
 
-    Enum.reduce_while(rows, :ok, fn att, _acc ->
-      :ok = rebind_attachment(att, dek)
-      {:cont, :ok}
-    end)
+    :telemetry.execute(
+      [:engram, :crypto, :aad_rebind, :attachment_skipped],
+      %{count: legacy_count},
+      %{user_id: user_id}
+    )
+
+    if legacy_count > 0 do
+      Logger.info(
+        "aad rebind attachment skipped (intentional) user_id=#{user_id} legacy_count=#{legacy_count} note=converges on next upload",
+        category: :crypto_rebind
+      )
+    end
+
+    {:skipped, :not_supported, legacy_count}
   end
 
   # NOTE: attachments hold their content blob in S3, not in Postgres.
-  # T3.6 only re-encrypts the row-resident `path_ciphertext`. The S3
-  # object's content_ciphertext keeps its old AAD (=<<>>) until that
-  # blob is also rotated through `Storage.adapter`. The read path uses
-  # `att.dek_version` to gate the AAD on `path_ciphertext` decrypt;
-  # content decrypt also gates on the same field. After this rebind,
-  # attempting to read the S3 blob would fail because we stamped
-  # dek_version=2 on the row but the blob was written with empty AAD.
+  # The S3 object's content_ciphertext keeps its old AAD (=<<>>) until
+  # the blob is rotated through `Storage.adapter`. The read path uses
+  # `att.dek_version` to gate the AAD on path + content decrypt. Rebinding
+  # only the row-resident `path_ciphertext` would mismatch the S3 blob's
+  # AAD on next read, so we deliberately skip the rebind. Attachments
+  # converge naturally on their next write — every `upsert_attachment`
+  # re-encrypts content + path with v2 AAD. Old blobs that are never
+  # re-uploaded stay legacy forever, which is fine because their content
+  # was always written with empty AAD and the read path honors that via
+  # `att.dek_version`.
   #
-  # To avoid breaking attachment reads on legacy rows, we DO NOT rebind
-  # attachments in this backfill — only `path_ciphertext` would change
-  # and the dek_version stamp would mismatch the S3 blob's AAD.
-  # Attachments converge naturally on their next write (every
-  # `upsert_attachment` re-encrypts content + path with v2 AAD). Old
-  # blobs that are never re-uploaded stay legacy forever, which is fine
-  # because their content was always written with empty AAD and the
-  # read path honors that via `att.dek_version`.
-  defp rebind_attachment(_att, _dek), do: :ok
+  # T3-audit H5 — `rebind_user_attachments/1` surfaces the count of
+  # unconverged attachments per user via
+  # `[:engram, :crypto, :aad_rebind, :attachment_skipped]` telemetry so
+  # operator drain logs are honest about what was NOT rebound.
 
   # Returns {:ok, count_rebound} or {:error, reason}.
   defp rebind_user_vaults(%User{id: user_id} = user) do

--- a/lib/engram/crypto/key_provider/local.ex
+++ b/lib/engram/crypto/key_provider/local.ex
@@ -171,7 +171,9 @@ defmodule Engram.Crypto.KeyProvider.Local do
         dek_version: Map.get(ctx, :dek_version),
         master_key_version:
           Map.get(ctx, :master_key_version) || Config.master_key_version(),
-        outcome: classified
+        # T3-audit M1 — `:status` matches rotate.user / aad_rebind.user
+        # metadata. Single, consistent dispatch tag across crypto events.
+        status: classified
       }
     )
   end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -9,7 +9,7 @@ defmodule Engram.Notes do
   import Ecto.Query
 
   alias Engram.Repo
-  alias Engram.Notes.{Note, Helpers, PathSanitizer}
+  alias Engram.Notes.{Note, Helpers, PathSanitizer, Enqueue}
   alias Engram.Workers.{DeleteNoteIndex, EmbedNote}
 
   @doc """
@@ -87,7 +87,7 @@ defmodule Engram.Notes do
       case result do
         {:ok, {:ok, {prev_hash, note}}} ->
           if prev_hash != note.content_hash do
-            Oban.insert(EmbedNote.new_debounced(note.id))
+            Enqueue.enqueue(EmbedNote.new_debounced(note.id), "embed_note")
           end
 
           note = decrypt_or_raise!(note, user)
@@ -234,7 +234,10 @@ defmodule Engram.Notes do
     case result do
       {:ok, {:ok, note}} ->
         # T3.2 — pass old_path_hmac (base64) to the worker, never plaintext.
-        Oban.insert(EmbedNote.new_debounced(note.id, old_path_hmac: old_path_hmac_b64!(user, old_path)))
+        Enqueue.enqueue(
+          EmbedNote.new_debounced(note.id, old_path_hmac: old_path_hmac_b64!(user, old_path)),
+          "embed_note"
+        )
         broadcast_change(user.id, vault.id, "delete", old_path)
         decrypted = decrypt_or_raise!(note, user)
         broadcast_change(user.id, vault.id, "upsert", note.path, decrypted)
@@ -270,13 +273,14 @@ defmodule Engram.Notes do
 
       # T3.2 — pass path_hmac (base64), never plaintext path. The note row
       # already carries `path_hmac` raw bytes; base64-encode for JSON safety.
-      Oban.insert(
+      Enqueue.enqueue(
         DeleteNoteIndex.new(%{
           note_id: note.id,
           user_id: note.user_id,
           vault_id: note.vault_id,
           path_hmac: Base.encode64(note.path_hmac)
-        })
+        }),
+        "delete_note_index"
       )
     end
 
@@ -651,10 +655,11 @@ defmodule Engram.Notes do
       # Side effects outside the transaction — broadcast + reindex.
       # T3.2 — pass old_path_hmac (base64) to the worker, never plaintext.
       Enum.each(updates, fn {note, old_note_path, new_path, _folder, _title} ->
-        Oban.insert(
+        Enqueue.enqueue(
           Engram.Workers.EmbedNote.new_debounced(note.id,
             old_path_hmac: old_path_hmac_b64!(user, old_note_path)
-          )
+          ),
+          "embed_note"
         )
 
         broadcast_change(user.id, vault.id, "delete", old_note_path)

--- a/lib/engram/notes/enqueue.ex
+++ b/lib/engram/notes/enqueue.ex
@@ -1,0 +1,52 @@
+defmodule Engram.Notes.Enqueue do
+  @moduledoc """
+  Wraps `Oban.insert/1` so enqueue failures are observable.
+
+  T3-audit H3 — pre-fix, four sites in `Engram.Notes` discarded the
+  `Oban.insert/1` return. A failed enqueue (queue saturated, invalid
+  changeset, Oban migration drift) logged nothing and emitted nothing,
+  so embed/delete jobs could vanish silently. This module logs +
+  emits telemetry on failure while leaving the success path identical.
+
+  ## Telemetry
+
+      [:engram, :notes, :enqueue, :failed]
+        measurements: %{count: 1}
+        metadata:     %{worker: "<label>"}
+  """
+  require Logger
+
+  @type result :: {:ok, term()} | {:error, term()}
+  @type insert_fn :: (term() -> result())
+
+  @doc """
+  Calls `insert_fn.(changeset)` (default `&Oban.insert/1`). On
+  `{:error, _}`, logs at `:error` with the worker label and emits
+  failure telemetry. Always returns the underlying result.
+  """
+  @spec enqueue(term(), String.t(), insert_fn()) :: result()
+  def enqueue(changeset, worker_label, insert_fn \\ &Oban.insert/1)
+      when is_binary(worker_label) and is_function(insert_fn, 1) do
+    case insert_fn.(changeset) do
+      {:ok, _job} = ok ->
+        ok
+
+      {:error, reason} = err ->
+        Logger.error(
+          "oban enqueue failed worker=#{worker_label} reason=#{format_reason(reason)}",
+          category: :notes_enqueue
+        )
+
+        :telemetry.execute(
+          [:engram, :notes, :enqueue, :failed],
+          %{count: 1},
+          %{worker: worker_label}
+        )
+
+        err
+    end
+  end
+
+  defp format_reason(%Ecto.Changeset{errors: errors}), do: inspect(errors)
+  defp format_reason(other), do: inspect(other)
+end

--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -105,6 +105,10 @@ defmodule EngramWeb.Telemetry do
         tags: [:status],
         description: "AadRebind per-user duration"
       ),
+      counter("engram.crypto.aad_rebind.attachment_skipped.count",
+        description:
+          "Attachments NOT rebound by AadRebind (intentional — converge on next upload). Non-zero count means the user has unconverged S3 blobs that still read as legacy AAD."
+      ),
       counter("engram.crypto.previous_fallback_hit.count",
         tags: [:outcome],
         description:

--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -110,9 +110,9 @@ defmodule EngramWeb.Telemetry do
           "Attachments NOT rebound by AadRebind (intentional — converge on next upload). Non-zero count means the user has unconverged S3 blobs that still read as legacy AAD."
       ),
       counter("engram.crypto.previous_fallback_hit.count",
-        tags: [:outcome],
+        tags: [:status],
         description:
-          "Previous-master fallback hits — should drop to 0 post-rotation; non-zero `:failed` outcome is catastrophic"
+          "Previous-master fallback hits — should drop to 0 post-rotation; non-zero `:failed` status is catastrophic"
       ),
       counter("engram.crypto.boot_canary.count",
         tags: [:status, :reason_label],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.39",
+      version: "0.5.40",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -23,6 +23,27 @@ defmodule Engram.AttachmentsTest do
     %{user: user, vault: vault}
   end
 
+  describe "concurrent upsert race (T3-audit H1)" do
+    # T3-audit H1 — pre-fix, two concurrent upserts to the same path could
+    # race: each reads "no existing row," allocates a fresh att_id, encrypts
+    # blob with AAD bound to its own id, and PUTs to the same S3 key (last
+    # writer wins). The DB row that survives the unique-path_hmac constraint
+    # may have an id that doesn't match the AAD baked into the blob → next
+    # GET decrypt fails with `:decrypt_failed`. Fix: serialize same-path
+    # upserts via `pg_advisory_xact_lock` keyed on (user_id, path_hmac).
+    test "upsert_attachment/3 wraps allocation + write in Repo.transaction with advisory lock" do
+      src = File.read!("lib/engram/attachments.ex")
+
+      assert src =~ ~r/pg_advisory_xact_lock/,
+             "upsert_attachment must take a per-(user, path_hmac) advisory lock " <>
+               "to serialize concurrent same-path uploads (T3-audit H1)"
+
+      assert src =~ ~r/Repo\.transaction/,
+             "upsert_attachment must wrap the allocation + insert in a transaction so " <>
+               "the advisory lock auto-releases on commit/rollback (T3-audit H1)"
+    end
+  end
+
   describe "upsert_attachment/3" do
     test "creates attachment with vault_id scoped correctly", %{user: user, vault: vault} do
       expect(Engram.MockStorage, :put, fn _key, _binary, _opts -> :ok end)

--- a/test/engram/crypto/aad_rebind_test.exs
+++ b/test/engram/crypto/aad_rebind_test.exs
@@ -124,15 +124,26 @@ defmodule Engram.Crypto.AadRebindTest do
       assert <<0x02, 0x01, _::binary>> = reloaded.encrypted_dek
     end
 
-    test "is idempotent — second run returns :skipped (telemetry-wise) when no legacy rows remain",
+    test "is idempotent — second run returns :skipped when no legacy rows remain (T3-audit M3)",
          %{user: user} do
+      # T3-audit M3 — pre-fix, every successful run returned :ok regardless
+      # of whether rows were actually rebound. An operator drain log saying
+      # `%{ok: 1000, skipped: 0}` couldn't distinguish "1000 rebinds happened"
+      # from "1000 users had nothing to do." Fix: track whether the wrap was
+      # changed AND whether any rows were rewritten. If neither, return
+      # :skipped so re-runs are honest.
       {:ok, _vault} = Engram.Vaults.create_vault(user, %{name: "Idempotence Vault"})
 
-      # Already at v2; first run rewraps DEK + finds no rows → succeeds.
-      assert :ok = AadRebind.rebind_user(user.id)
+      # First run: DEK wrap upgrades v1→v2 + Idempotence Vault was just
+      # created (post-T3.6 already at v2 if factories track it; the rewrap
+      # itself counts as "did work"). Either way, returns :ok or :skipped
+      # depending on factory state — we tolerate both.
+      first = AadRebind.rebind_user(user.id)
+      assert first in [:ok, :skipped]
 
-      # Second run: DEK is now v2, no legacy rows → no-op.
-      assert :ok = AadRebind.rebind_user(user.id)
+      # Second run: wrap is now v2, no legacy rows remain → MUST be :skipped.
+      assert :skipped = AadRebind.rebind_user(user.id),
+             "rebind_user/1 must return :skipped when nothing changes — operator drain logs depend on it"
     end
   end
 

--- a/test/engram/crypto/aad_rebind_test.exs
+++ b/test/engram/crypto/aad_rebind_test.exs
@@ -147,6 +147,46 @@ defmodule Engram.Crypto.AadRebindTest do
     end
   end
 
+  describe "attachment rebind honesty (T3-audit H5)" do
+    test "emits :attachment_skipped telemetry per user with legacy count", %{user: user} do
+      # T3-audit H5 — attachment rebind is intentionally a no-op (S3 blob's
+      # AAD doesn't get touched here; converges on next upload). Pre-fix,
+      # rebind_user_attachments/1 returned :ok with no signal, so an
+      # operator drain log told them attachments were rebound when they
+      # weren't. Fix: emit per-user telemetry with the count of legacy
+      # attachments that still need natural convergence.
+      legacy_version = Crypto.row_version_legacy()
+
+      # Use the real Vaults context so the vault is born AAD-bound; we want
+      # to isolate this test to the attachment rebind signal, not vault
+      # legacy decrypt.
+      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Attachment Vault"})
+
+      _att1 = insert(:attachment, user: user, vault: vault, dek_version: legacy_version)
+      _att2 = insert(:attachment, user: user, vault: vault, dek_version: legacy_version)
+
+      :telemetry.attach(
+        "att-skipped-test",
+        [:engram, :crypto, :aad_rebind, :attachment_skipped],
+        fn _name, measurements, metadata, _ ->
+          send(self(), {:attachment_skipped, measurements, metadata})
+        end,
+        nil
+      )
+
+      try do
+        AadRebind.rebind_user(user.id)
+
+        assert_received {:attachment_skipped, %{count: count}, %{user_id: uid}}
+        assert uid == user.id
+        assert count >= 2,
+               "telemetry must report legacy attachment count so operators can plan natural convergence; got #{count}"
+      after
+        :telemetry.detach("att-skipped-test")
+      end
+    end
+  end
+
   describe "rebind_all/1" do
     test "drives the cursor across multiple users", %{user: user_a} do
       user_b = insert(:user)

--- a/test/engram/crypto/local_provider_test.exs
+++ b/test/engram/crypto/local_provider_test.exs
@@ -91,7 +91,10 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
                    master_key_version: 2
                  })
 
-        assert_received {:fallback, %{outcome: :gated_by_dek_version}}
+        # T3-audit M1 — metadata key is `:status` (consistent with
+        # rotate.user + aad_rebind.user), not `:outcome`.
+        assert_received {:fallback, %{status: :gated_by_dek_version} = meta}
+        refute Map.has_key?(meta, :outcome), "drop legacy :outcome key"
       after
         :telemetry.detach("fallback-gated")
       end
@@ -123,7 +126,7 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
                    master_key_version: 2
                  })
 
-        assert_received {:fallback, %{outcome: :rescued}}
+        assert_received {:fallback, %{status: :rescued}}
       after
         :telemetry.detach("fallback-rescue")
       end

--- a/test/engram/crypto/qdrant_payload_test.exs
+++ b/test/engram/crypto/qdrant_payload_test.exs
@@ -23,7 +23,28 @@ defmodule Engram.Crypto.QdrantPayloadTest do
     heading_path: "intro"
   }
 
-  describe "encrypt_qdrant_payload/2" do
+  describe "API surface (T3-audit M4)" do
+    test "2-arity encrypt_qdrant_payload is NOT exported — AAD foot-gun privatized" do
+      # T3-audit M4 — the legacy 2-arity form omits AAD binding. Leaving it
+      # public makes it easy for a future caller to inadvertently produce
+      # a non-AAD-bound point, defeating T3.6's per-row binding. Force the
+      # only public surface to be the 4-arity AAD form.
+      Code.ensure_loaded!(Engram.Crypto)
+
+      arities =
+        Engram.Crypto.__info__(:functions)
+        |> Enum.filter(fn {name, _arity} -> name == :encrypt_qdrant_payload end)
+        |> Enum.map(fn {_name, arity} -> arity end)
+        |> Enum.sort()
+
+      refute 2 in arities,
+             "encrypt_qdrant_payload/2 must not be public — use the 4-arity AAD-bound form. Found: #{inspect(arities)}"
+
+      assert 4 in arities, "encrypt_qdrant_payload/4 must remain public"
+    end
+  end
+
+  describe "encrypt_qdrant_payload/4" do
     test "encrypts text/title/heading_path", %{user: user} do
       {:ok, user} = Crypto.ensure_user_dek(user)
 

--- a/test/engram/notes/enqueue_test.exs
+++ b/test/engram/notes/enqueue_test.exs
@@ -1,0 +1,71 @@
+defmodule Engram.Notes.EnqueueTest do
+  # T3-audit H3 — Oban.insert/1 returns {:ok, job} | {:error, changeset}.
+  # Pre-fix, four sites in notes.ex pattern-matched neither and silently
+  # discarded enqueue failures. Operator had no signal when queue was
+  # saturated, when worker validation rejected args, or when Oban migration
+  # drift returned changeset errors. This module wraps the call so failures
+  # log + emit telemetry, while the success path is unaffected.
+  use ExUnit.Case, async: true
+
+  alias Engram.Notes.Enqueue
+
+  describe "enqueue/3 (T3-audit H3)" do
+    test "returns {:ok, job} from underlying insert on success" do
+      stub = fn _changeset -> {:ok, %{id: 42}} end
+      assert {:ok, %{id: 42}} = Enqueue.enqueue(:fake_changeset, "embed_note", stub)
+    end
+
+    test "logs error with worker label + reason on failure and returns {:error, _}" do
+      stub = fn _changeset -> {:error, %{reason: :queue_saturated}} end
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:error, %{reason: :queue_saturated}} =
+                   Enqueue.enqueue(:fake_changeset, "embed_note", stub)
+        end)
+
+      assert log =~ "oban enqueue failed",
+             "expected `oban enqueue failed` log line, got: #{log}"
+
+      assert log =~ "worker=embed_note",
+             "log must carry worker label for triage, got: #{log}"
+    end
+
+    test "emits [:engram, :notes, :enqueue, :failed] telemetry on failure" do
+      :telemetry.attach(
+        "enqueue-test-failed",
+        [:engram, :notes, :enqueue, :failed],
+        fn _name, measurements, metadata, _ ->
+          send(self(), {:enqueue_failed, measurements, metadata})
+        end,
+        nil
+      )
+
+      try do
+        stub = fn _ -> {:error, :nope} end
+        assert {:error, :nope} = Enqueue.enqueue(:fake_changeset, "delete_note_index", stub)
+
+        assert_received {:enqueue_failed, %{count: 1}, %{worker: "delete_note_index"}}
+      after
+        :telemetry.detach("enqueue-test-failed")
+      end
+    end
+
+    test "emits no telemetry on success" do
+      :telemetry.attach(
+        "enqueue-test-success-no-emit",
+        [:engram, :notes, :enqueue, :failed],
+        fn _name, _, _, _ -> send(self(), :should_not_fire) end,
+        nil
+      )
+
+      try do
+        stub = fn _ -> {:ok, :job} end
+        assert {:ok, :job} = Enqueue.enqueue(:fake_changeset, "any", stub)
+        refute_received :should_not_fire
+      after
+        :telemetry.detach("enqueue-test-success-no-emit")
+      end
+    end
+  end
+end

--- a/test/engram/search_test.exs
+++ b/test/engram/search_test.exs
@@ -28,7 +28,9 @@ defmodule Engram.SearchTest do
       {:ok, enc} =
         Engram.Crypto.encrypt_qdrant_payload(
           %{text: "Ferritin levels.", title: "Iron Panel", heading_path: "Iron Panel"},
-          user
+          user,
+          "engram_notes",
+          "uuid-1"
         )
 
       qdrant_result = %{
@@ -43,6 +45,7 @@ defmodule Engram.SearchTest do
               "text_nonce" => enc.text_nonce,
               "title_nonce" => enc.title_nonce,
               "heading_path_nonce" => enc.heading_path_nonce,
+              "aad_version" => enc.aad_version,
               "source_path" => "Health/Iron Panel.md",
               "tags" => ["health"],
               "user_id" => to_string(user.id),
@@ -192,14 +195,18 @@ defmodule Engram.SearchTest do
 
         results =
           for i <- 0..3 do
+            qid = "uuid-#{i}"
+
             {:ok, enc} =
               Engram.Crypto.encrypt_qdrant_payload(
                 %{text: "Result #{i}", title: "Note #{i}", heading_path: "Section"},
-                user
+                user,
+                "engram_notes",
+                qid
               )
 
             %{
-              "id" => "uuid-#{i}",
+              "id" => qid,
               "score" => 0.9 - i * 0.1,
               "payload" => %{
                 "text" => enc.text,
@@ -208,6 +215,7 @@ defmodule Engram.SearchTest do
                 "text_nonce" => enc.text_nonce,
                 "title_nonce" => enc.title_nonce,
                 "heading_path_nonce" => enc.heading_path_nonce,
+                "aad_version" => enc.aad_version,
                 "source_path" => "test/note#{i}.md",
                 "tags" => [],
                 "user_id" => to_string(user.id),
@@ -367,7 +375,9 @@ defmodule Engram.SearchTest do
       {:ok, enc} =
         Engram.Crypto.encrypt_qdrant_payload(
           %{text: "alpha body", title: "Alpha", heading_path: "root"},
-          user
+          user,
+          "engram_notes",
+          "qid-a"
         )
 
       _ = vault
@@ -387,6 +397,7 @@ defmodule Engram.SearchTest do
               "text_nonce" => enc.text_nonce,
               "title_nonce" => enc.title_nonce,
               "heading_path_nonce" => enc.heading_path_nonce,
+              "aad_version" => enc.aad_version,
               "source_path" => "a.md",
               "tags" => [],
               "user_id" => to_string(user.id),
@@ -417,7 +428,9 @@ defmodule Engram.SearchTest do
       {:ok, enc} =
         Engram.Crypto.encrypt_qdrant_payload(
           %{text: "beta body", title: "Beta", heading_path: "root"},
-          user
+          user,
+          "engram_notes",
+          "qid-b"
         )
 
       _ = vault
@@ -441,6 +454,7 @@ defmodule Engram.SearchTest do
               "text_nonce" => enc.text_nonce,
               "title_nonce" => enc.title_nonce,
               "heading_path_nonce" => enc.heading_path_nonce,
+              "aad_version" => enc.aad_version,
               "source_path" => "b.md",
               "tags" => [],
               "user_id" => to_string(user.id),

--- a/test/engram_web/controllers/search_controller_test.exs
+++ b/test/engram_web/controllers/search_controller_test.exs
@@ -28,7 +28,9 @@ defmodule EngramWeb.SearchControllerTest do
       {:ok, enc} =
         Engram.Crypto.encrypt_qdrant_payload(
           %{text: "Ferritin levels.", title: "Iron Panel", heading_path: "Iron Panel"},
-          user
+          user,
+          "engram_notes",
+          "uuid-1"
         )
 
       qdrant_result = %{
@@ -43,6 +45,7 @@ defmodule EngramWeb.SearchControllerTest do
               "text_nonce" => enc.text_nonce,
               "title_nonce" => enc.title_nonce,
               "heading_path_nonce" => enc.heading_path_nonce,
+              "aad_version" => enc.aad_version,
               "source_path" => "Health/Iron Panel.md",
               "tags" => ["health"],
               "user_id" => to_string(user.id),
@@ -244,7 +247,9 @@ defmodule EngramWeb.SearchControllerTest do
     {:ok, enc} =
       Engram.Crypto.encrypt_qdrant_payload(
         %{text: text, title: title, heading_path: title},
-        user
+        user,
+        "engram_notes",
+        id
       )
 
     %{
@@ -257,6 +262,7 @@ defmodule EngramWeb.SearchControllerTest do
         "text_nonce" => enc.text_nonce,
         "title_nonce" => enc.title_nonce,
         "heading_path_nonce" => enc.heading_path_nonce,
+        "aad_version" => enc.aad_version,
         "source_path" => source_path,
         "tags" => [],
         "user_id" => to_string(user.id),

--- a/test/engram_web/telemetry_test.exs
+++ b/test/engram_web/telemetry_test.exs
@@ -35,6 +35,13 @@ defmodule EngramWeb.TelemetryTest do
              "AadRebind per-user outcome must be counted (status, reason_label)"
     end
 
+    test "registers engram.crypto.aad_rebind.attachment_skipped counter (T3-audit H5)", %{
+      names: names
+    } do
+      assert "engram.crypto.aad_rebind.attachment_skipped.count" in names,
+             "Per-user count of unconverged attachments — operator drain log honesty"
+    end
+
     test "registers engram.crypto.previous_fallback_hit counter (T3.5 / M4)", %{names: names} do
       assert "engram.crypto.previous_fallback_hit.count" in names,
              "Previous-master fallback hits must be counted — should drop to 0 post-rotation"


### PR DESCRIPTION
## Summary

Closes the post-T3.6 audit findings on encryption tier-3: H1, H3, H5, M1, M3, M4. One commit per finding, all TDD'd. 947 tests green locally.

- **H1** Concurrent same-path attachment upserts could land mismatched DEK on the S3 blob (winning DB row's id ≠ AAD baked into the surviving blob, decrypt-fail on next read). Fix: wrap `upsert_attachment/3` in `Repo.transaction` + `pg_advisory_xact_lock(phash2(user_id, path_hmac))`. Second upserter blocks until first commits and reuses the existing row id.
- **H3** Four `Oban.insert/1` sites in `Engram.Notes` discarded the `{:ok, _} | {:error, _}` return → silent failures during queue saturation / changeset validation drift. New `Engram.Notes.Enqueue.enqueue/3` wrapper logs + emits `[:engram, :notes, :enqueue, :failed]`.
- **H5** `AadRebind.rebind_user_attachments/1` was an intentional no-op returning `:ok` — operator drain logs were lying about what was rebound. Now counts legacy attachments per user, emits `[:engram, :crypto, :aad_rebind, :attachment_skipped]` + `Logger.info` with count, returns `{:skipped, :not_supported, count}`.
- **M1** Telemetry metadata key drift: `[:engram, :crypto, :previous_fallback_hit]` used `:outcome` while sibling crypto events used `:status`. PromEx/Sentry rules filtering on `status:` would skip fallback hits. Renamed to `:status`.
- **M3** `AadRebind.rebind_user/1` returned `:ok` even when nothing changed. Drain logs showing `%{ok: 1000, skipped: 0}` couldn't distinguish work from no-op. Now tracks DEK rewrap + per-row counts, returns `:skipped` when nothing changed.
- **M4** `Crypto.encrypt_qdrant_payload/2` (legacy non-AAD form) privatized — production already used the 4-arity AAD form, but leaving the 2-arity public was a foot-gun. Test fixtures migrated to 4-arity with `aad_version` propagation.

## Test plan
- [x] H3 — `mix test test/engram/notes/enqueue_test.exs test/engram/notes_test.exs` (66 green)
- [x] M4 — `mix test test/engram/crypto/qdrant_payload_test.exs test/engram/search_test.exs test/engram_web/controllers/search_controller_test.exs test/engram/indexing_test.exs` (47 green; `__info__(:functions)` pin guards drift)
- [x] M3 + H5 — `mix test test/engram/crypto/aad_rebind_test.exs` (6 green; idempotency + attachment_skipped telemetry pin)
- [x] M1 — `mix test test/engram/crypto/local_provider_test.exs test/engram_web/telemetry_test.exs` (25 green; refute on legacy `:outcome` key)
- [x] H1 — `mix test test/engram/attachments_test.exs` (16 green; source-lint asserts `pg_advisory_xact_lock` + `Repo.transaction` in upsert)
- [x] Full suite — `mix test` (947 green, 7 skipped, 1 excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)