### PR TITLE
chore: gate mix format + compile --warnings-as-errors (Phase 2)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -67,7 +67,7 @@ run_check() {
   fi
 }
 
-run_check "mix format"                       informational mix format --check-formatted
-run_check "mix compile --warnings-as-errors" informational mix compile --warnings-as-errors --force
+run_check "mix format"                       fatal         mix format --check-formatted
+run_check "mix compile --warnings-as-errors" fatal         mix compile --warnings-as-errors --force
 run_check "credo"                            informational mix credo --mute-exit-status
 run_check "sobelow"                          informational mix sobelow --exit low --skip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,11 +601,9 @@ jobs:
 
       - name: Format check
         run: mix format --check-formatted
-        continue-on-error: true
 
       - name: Compile warnings-as-errors
         run: mix compile --warnings-as-errors --force
-        continue-on-error: true
 
       - name: Credo (strict)
         run: mix credo --strict --mute-exit-status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,9 @@ Four lints run on every push: `mix format`, `mix compile --warnings-as-errors`, 
 
 | Phase | Tool | Status |
 |-------|------|--------|
-| 1 | All four installed, informational | **active** |
-| 2 | `mix format` + `--warnings-as-errors` fatal | next |
-| 3 | Sobelow ratchet → zero | pending |
+| 1 | All four installed, informational | shipped |
+| 2 | `mix format` + `--warnings-as-errors` fatal | **active** |
+| 3 | Sobelow ratchet → zero | next |
 | 4 | Dialyzer ratchet → zero | pending |
 | 5 | Credo ratchet → zero | pending |
 | 6 | Strict-mode tightening | future |

--- a/docs/context/quality-tooling-baseline.md
+++ b/docs/context/quality-tooling-baseline.md
@@ -8,8 +8,8 @@ Plan: `../../../engram-workspace/docs/superpowers/plans/2026-05-09-quality-tooli
 
 | Tool | Findings | Status | Ratchet target |
 |------|----------|--------|----------------|
-| `mix format` | 0 | informational (Phase 2 → fatal) | 0 (already clean) |
-| `mix compile --warnings-as-errors` | 0 | informational (Phase 2 → fatal) | 0 (already clean) |
+| `mix format` | 0 | **gated** (Phase 2) | 0 (held) |
+| `mix compile --warnings-as-errors` | 0 | **gated** (Phase 2) | 0 (held) |
 | Sobelow (threshold low, exit low, --skip) | 0 | informational (Phase 3 → fatal) | 0 (already clean) |
 | Dialyzer (with `:unmatched_returns`, `:error_handling`, `:underspecs`, `:missing_return`, `:extra_return`) | 81 | informational (Phase 4 → fatal) | 0 |
 | Credo (`--strict`) | 676 | informational (Phase 5 → fatal) | 0 |

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.43",
+      version: "0.5.44",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Phase 2 of the quality-tooling rollout — promote \`mix format\` and \`mix compile --warnings-as-errors\` from **informational** to **fatal** in both the pre-push hook and the CI \`lint\` job. Both already had a zero-finding baseline (PR #85), so this is a pure promotion with no triage.

**Stacked on PR #85.** Merge that one first.

## Why this is a separate small PR

These are the only two checks that were already at zero. Gating them now closes the format-drift hole that motivated the entire rollout (see PR #84 / T3.7 leftovers) without touching Credo, Sobelow, or Dialyzer triage. Future PRs introducing unformatted code or warnings get blocked at push time and again at CI.

## What's in this PR

- \`.githooks/pre-push\` — \`mix format\` + \`mix compile --warnings-as-errors\` flipped from \`informational\` to \`fatal\`. Bypass with \`git push --no-verify\` for emergencies.
- \`.github/workflows/ci.yml\` — \`continue-on-error: true\` removed from the \`Format check\` and \`Compile warnings-as-errors\` steps in the \`lint\` job. Credo / Sobelow / Dialyzer remain informational.
- \`backend/CLAUDE.md\` — Phase 1 marked shipped, Phase 2 marked active.
- \`backend/docs/context/quality-tooling-baseline.md\` — both rows marked **gated**.

## Manual step required after merge

GitHub branch protection on \`main\` → require the \`lint\` status check. Without that, the gate enforces inside CI but \`main\` can still be merged with a failing \`lint\` job. (One-time UI click; can't be done via this PR.)

## Test plan

- [x] Pre-push hook runs in fatal mode without blocking on this branch (verified during \`git push\`)
- [ ] CI \`lint\` job: \`Format check\` and \`Compile warnings-as-errors\` steps run without \`continue-on-error\` and pass
- [ ] CI \`lint\` job overall: success
- [ ] Verify gate by intentionally introducing a format violation on a throwaway branch, watching pre-push reject it, and reverting

🤖 Generated with [Claude Code](https://claude.com/claude-code)