### PR TITLE
chore: gate sobelow (Phase 3)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -70,4 +70,4 @@ run_check() {
 run_check "mix format"                       fatal         mix format --check-formatted
 run_check "mix compile --warnings-as-errors" fatal         mix compile --warnings-as-errors --force
 run_check "credo"                            informational mix credo --mute-exit-status
-run_check "sobelow"                          informational mix sobelow --exit low --skip
+run_check "sobelow"                          fatal         mix sobelow --exit low --skip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,7 +611,6 @@ jobs:
 
       - name: Sobelow
         run: mix sobelow --exit low --skip
-        continue-on-error: true
 
       - name: Dialyzer
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,9 @@ Four lints run on every push: `mix format`, `mix compile --warnings-as-errors`, 
 | Phase | Tool | Status |
 |-------|------|--------|
 | 1 | All four installed, informational | shipped |
-| 2 | `mix format` + `--warnings-as-errors` fatal | **active** |
-| 3 | Sobelow ratchet → zero | next |
-| 4 | Dialyzer ratchet → zero | pending |
+| 2 | `mix format` + `--warnings-as-errors` fatal | shipped |
+| 3 | Sobelow ratchet → zero | **active** |
+| 4 | Dialyzer ratchet → zero | next |
 | 5 | Credo ratchet → zero | pending |
 | 6 | Strict-mode tightening | future |
 

--- a/docs/context/quality-tooling-baseline.md
+++ b/docs/context/quality-tooling-baseline.md
@@ -10,7 +10,7 @@ Plan: `../../../engram-workspace/docs/superpowers/plans/2026-05-09-quality-tooli
 |------|----------|--------|----------------|
 | `mix format` | 0 | **gated** (Phase 2) | 0 (held) |
 | `mix compile --warnings-as-errors` | 0 | **gated** (Phase 2) | 0 (held) |
-| Sobelow (threshold low, exit low, --skip) | 0 | informational (Phase 3 → fatal) | 0 (already clean) |
+| Sobelow (threshold low, exit low, --skip) | 0 | **gated** (Phase 3) | 0 (held) |
 | Dialyzer (with `:unmatched_returns`, `:error_handling`, `:underspecs`, `:missing_return`, `:extra_return`) | 81 | informational (Phase 4 → fatal) | 0 |
 | Credo (`--strict`) | 676 | informational (Phase 5 → fatal) | 0 |
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.44",
+      version: "0.5.45",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Phase 3 of the quality-tooling rollout — promote Sobelow from **informational** to **fatal** in both pre-push and CI \`lint\`. Already at zero baseline (PR #85), so this is a pure promotion with no triage.

**Stacked on PR #86 → PR #85.** Merge in order.

## Why no triage

Sobelow at threshold \`low\`, exit \`low\`, with \`--skip\` (no skips currently configured) — finds 0 XSS, SQL injection, path traversal, RCE, command injection, DoS, or known-vuln-dep issues across the codebase. The strictest meaningful setting is already clean. Gate it so any new finding from a future PR fails the build.

## What's in this PR

- \`.githooks/pre-push\` — Sobelow flipped from \`informational\` to \`fatal\`.
- \`.github/workflows/ci.yml\` — \`continue-on-error: true\` removed from the \`Sobelow\` step in the \`lint\` job.
- \`backend/CLAUDE.md\` — Phase 2 marked shipped, Phase 3 active.
- \`backend/docs/context/quality-tooling-baseline.md\` — Sobelow row marked **gated**.

## Test plan

- [x] Pre-push hook in fatal mode — passes (verified during \`git push\`)
- [ ] CI \`lint\` job: \`Sobelow\` step runs without \`continue-on-error\` and passes
- [ ] No regression in any other CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)