### PR TITLE
feat(oauth): Phase 1 — RFC 8414 + 9728 discovery documents

### DIFF
--- a/lib/engram_web/controllers/well_known_controller.ex
+++ b/lib/engram_web/controllers/well_known_controller.ex
@@ -1,0 +1,45 @@
+defmodule EngramWeb.WellKnownController do
+  @moduledoc """
+  Serves OAuth 2.1 discovery documents per RFC 8414 (authorization server
+  metadata) and RFC 9728 (protected resource metadata).
+
+  Issuer URL is derived from `EngramWeb.Endpoint.url/0`, which resolves
+  per-deployment from `PHX_HOST`. Both saas (`app.engram.page`) and selfhost
+  (`engram.ax`) thus advertise their own canonical host.
+  """
+  use EngramWeb, :controller
+
+  def protected_resource(conn, _params) do
+    base = base_url()
+
+    payload = %{
+      resource: base <> "/api/mcp",
+      authorization_servers: [base],
+      bearer_methods_supported: ["header"],
+      resource_documentation: base <> "/docs"
+    }
+
+    json(conn, payload)
+  end
+
+  def authorization_server(conn, _params) do
+    base = base_url()
+
+    payload = %{
+      issuer: base,
+      authorization_endpoint: base <> "/oauth/authorize",
+      token_endpoint: base <> "/oauth/token",
+      registration_endpoint: base <> "/oauth/register",
+      revocation_endpoint: base <> "/oauth/revoke",
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+      scopes_supported: ["mcp"]
+    }
+
+    json(conn, payload)
+  end
+
+  defp base_url, do: EngramWeb.Endpoint.url()
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -26,6 +26,16 @@ defmodule EngramWeb.Router do
     post "/stripe", WebhookController, :stripe
   end
 
+  # OAuth 2.1 discovery documents — RFC 8414 + RFC 9728. Public, no auth.
+  # MCP clients (Claude Connectors, Cursor, ChatGPT custom GPTs, etc.)
+  # probe these to learn how to negotiate auth against /api/mcp.
+  scope "/.well-known", EngramWeb do
+    pipe_through :api
+
+    get "/oauth-protected-resource", WellKnownController, :protected_resource
+    get "/oauth-authorization-server", WellKnownController, :authorization_server
+  end
+
   # All API routes under /api prefix
   scope "/api", EngramWeb do
     # Public endpoints (no auth required, no rate limit)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.49",
+      version: "0.5.50",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/well_known_controller_test.exs
+++ b/test/engram_web/controllers/well_known_controller_test.exs
@@ -1,0 +1,87 @@
+defmodule EngramWeb.WellKnownControllerTest do
+  use EngramWeb.ConnCase, async: true
+
+  describe "GET /.well-known/oauth-protected-resource" do
+    test "returns RFC 9728 protected resource metadata", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-protected-resource")
+      body = json_response(conn, 200)
+
+      assert is_binary(body["resource"])
+      assert String.ends_with?(body["resource"], "/api/mcp")
+      assert is_list(body["authorization_servers"])
+      assert body["authorization_servers"] != []
+      assert Enum.all?(body["authorization_servers"], &is_binary/1)
+    end
+
+    test "advertises bearer token usage", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-protected-resource")
+      body = json_response(conn, 200)
+
+      assert "header" in body["bearer_methods_supported"]
+    end
+
+    test "responds with application/json content-type", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-protected-resource")
+
+      assert ["application/json" <> _] = get_resp_header(conn, "content-type")
+    end
+  end
+
+  describe "GET /.well-known/oauth-authorization-server" do
+    test "returns RFC 8414 server metadata with required fields", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-authorization-server")
+      body = json_response(conn, 200)
+
+      assert is_binary(body["issuer"])
+      assert String.ends_with?(body["authorization_endpoint"], "/oauth/authorize")
+      assert String.ends_with?(body["token_endpoint"], "/oauth/token")
+      assert String.ends_with?(body["registration_endpoint"], "/oauth/register")
+      assert String.ends_with?(body["revocation_endpoint"], "/oauth/revoke")
+    end
+
+    test "requires PKCE S256 (no plain)", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-authorization-server")
+      body = json_response(conn, 200)
+
+      assert "S256" in body["code_challenge_methods_supported"]
+      refute "plain" in body["code_challenge_methods_supported"]
+    end
+
+    test "advertises authorization_code + refresh_token grants", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-authorization-server")
+      body = json_response(conn, 200)
+
+      assert "authorization_code" in body["grant_types_supported"]
+      assert "refresh_token" in body["grant_types_supported"]
+    end
+
+    test "advertises code response type", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-authorization-server")
+      body = json_response(conn, 200)
+
+      assert "code" in body["response_types_supported"]
+    end
+
+    test "advertises mcp scope", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-authorization-server")
+      body = json_response(conn, 200)
+
+      assert "mcp" in body["scopes_supported"]
+    end
+
+    test "supports public clients via PKCE (token_endpoint_auth_methods includes none)", %{
+      conn: conn
+    } do
+      conn = get(conn, "/.well-known/oauth-authorization-server")
+      body = json_response(conn, 200)
+
+      assert "none" in body["token_endpoint_auth_methods_supported"]
+    end
+
+    test "responds with application/json content-type", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-authorization-server")
+
+      assert ["application/json" <> _] = get_resp_header(conn, "content-type")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Phase 1 of the [MCP OAuth 2.1 + DCR plan](docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md). Adds the two `.well-known/` discovery documents that any standards-compliant OAuth/MCP client probes first to learn how to negotiate auth.
- New `EngramWeb.WellKnownController` serves `GET /.well-known/oauth-protected-resource` (RFC 9728 — points at `/api/mcp` and lists the auth server) and `GET /.well-known/oauth-authorization-server` (RFC 8414 — lists endpoints, grants, PKCE, scopes).
- Issuer URL is derived from `EngramWeb.Endpoint.url/0` so saas (`app.engram.page`) and selfhost (`engram.ax`) each advertise their own canonical host without forking the controller.
- `/oauth/authorize`, `/oauth/token`, `/oauth/register`, `/oauth/revoke` referenced in the metadata return 404 today — those ship in Phases 2-6. Shipping discovery first lets us point Claude Connectors at the URL and capture the next-request shape from real wire traffic instead of guessing.
- Bumps `mix.exs` 0.5.49 → 0.5.50.

**Stacked on #91** (Phase 0 domain cleanup). Once that merges, this rebases onto main cleanly.

## Test plan
- [x] `mix test test/engram_web/controllers/well_known_controller_test.exs` — 10 tests pass (RFC field shape, PKCE S256-only, grant types, response types, mcp scope, public-client `none` auth method, `application/json` content-type)
- [x] `mix test` — 1056/0/7 skipped, no regression
- [x] `mix credo --strict` — clean on new files
- [ ] Once merged + deployed: `curl https://app.engram.page/.well-known/oauth-protected-resource | jq .` returns the expected shape
- [ ] Same against `https://engram.ax/.well-known/oauth-authorization-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)