### PR TITLE
feat(oauth): Phase 3 — authorize endpoint + consent + code mint

### DIFF
--- a/lib/engram/oauth.ex
+++ b/lib/engram/oauth.ex
@@ -2,32 +2,31 @@ defmodule Engram.OAuth do
   @moduledoc """
   High-level context for the OAuth 2.1 authorization server.
 
-  Today: Dynamic Client Registration (RFC 7591). Phases 3-6 of the
-  MCP OAuth plan add authorization codes, tokens, and revocation.
+  Today: DCR (RFC 7591) + authorization-code minting (RFC 6749 §4.1 with
+  PKCE per RFC 7636). Phases 4-6 add token exchange and revocation.
 
-  `oauth_clients` is intentionally not RLS-tenanted — clients self-
-  register pre-login. Lookup is by `client_id` (UUID).
+  `oauth_clients` and `oauth_authorization_codes` are intentionally not
+  RLS-tenanted — the former is shared (clients self-register pre-login),
+  the latter is keyed by hashed code value and looked up before any
+  user identity is established (token exchange comes from the client,
+  not the user).
   """
   import Ecto.Query
-  alias Engram.OAuth.Client
+  alias Engram.OAuth.{AuthorizationCode, Client}
   alias Engram.Repo
 
-  @doc """
-  Register a new OAuth client per RFC 7591. Returns `{:ok, client}` or
-  `{:error, changeset}`. Public clients have no secret; confidential
-  clients aren't issued today (caller can't request `client_secret_post`
-  without us minting + hashing a secret, which we don't yet wire up).
-  """
+  @code_bytes 32
+  @code_ttl_seconds 600
+  @valid_scopes ~w(mcp)
+
+  # ── Clients (Phase 2) ────────────────────────────────────────────
+
   def register_client(attrs) do
     %Client{}
     |> Client.registration_changeset(attrs)
     |> Repo.insert(skip_tenant_check: true)
   end
 
-  @doc """
-  Look up a registered client by `client_id`. Returns `{:ok, client}` or
-  `{:error, :not_found}`. Skips RLS — `oauth_clients` is shared.
-  """
   def get_client(client_id) when is_binary(client_id) do
     case Ecto.UUID.cast(client_id) do
       {:ok, _} ->
@@ -44,4 +43,188 @@ defmodule Engram.OAuth do
   end
 
   def get_client(_), do: {:error, :not_found}
+
+  # ── Authorization codes (Phase 3) ────────────────────────────────
+
+  @doc """
+  Validates the params of an `/oauth/authorize` request per RFC 6749 §4.1.1.
+
+  Returns:
+    * `{:ok, validated}` — map of params safe to round-trip into the consent UI
+    * `{:redirect_error, redirect_uri, error_code, state}` — bad post-client
+      params; caller should 302 to the redirect_uri with `error` query param
+    * `{:client_error, code}` — bad client_id or redirect_uri; render an HTML
+      error page rather than redirect (a redirect would let an attacker
+      exfiltrate codes via a forged redirect_uri)
+  """
+  def validate_authorization_request(params) when is_map(params) do
+    with {:ok, client} <- fetch_client(params["client_id"]),
+         {:ok, redirect_uri} <- match_redirect_uri(client, params["redirect_uri"]),
+         :ok <- check_response_type(params, redirect_uri),
+         :ok <- check_pkce(params, redirect_uri),
+         :ok <- check_scope(params, redirect_uri) do
+      {:ok,
+       %{
+         client: client,
+         client_id: client.client_id,
+         client_name: client.client_name,
+         redirect_uri: redirect_uri,
+         code_challenge: params["code_challenge"],
+         code_challenge_method: params["code_challenge_method"] || "S256",
+         scope: params["scope"] || "mcp",
+         state: params["state"]
+       }}
+    end
+  end
+
+  def validate_authorization_request(_), do: {:client_error, "invalid_request"}
+
+  @doc """
+  Mints an authorization code for a validated request + a vault selection.
+
+  `vault_choice` is `"vault:<id>"` or `"vault:*"`. Vault ownership is
+  verified — a user cannot grant an OAuth client access to a vault they
+  do not own.
+
+  Returns `{:ok, redirect_url}` (caller 302s) or
+  `{:redirect_error, redirect_uri, error_code, state}`.
+  """
+  def mint_authorization_code(user, validated, vault_choice) do
+    case resolve_vault(user, vault_choice) do
+      {:ok, vault_id} ->
+        raw_code =
+          "engram_ac_" <>
+            Base.url_encode64(:crypto.strong_rand_bytes(@code_bytes), padding: false)
+
+        expires_at =
+          DateTime.utc_now()
+          |> DateTime.add(@code_ttl_seconds, :second)
+          |> DateTime.truncate(:second)
+
+        attrs = %{
+          code_hash: hash_code(raw_code),
+          client_id: validated.client_id,
+          user_id: user.id,
+          redirect_uri: validated.redirect_uri,
+          code_challenge: validated.code_challenge,
+          code_challenge_method: validated.code_challenge_method,
+          scope: validated.scope,
+          vault_id: vault_id,
+          state: validated.state,
+          expires_at: expires_at
+        }
+
+        case %AuthorizationCode{}
+             |> AuthorizationCode.changeset(attrs)
+             |> Repo.insert(skip_tenant_check: true) do
+          {:ok, _row} ->
+            {:ok,
+             build_redirect(validated.redirect_uri, %{code: raw_code, state: validated.state})}
+
+          {:error, changeset} ->
+            {:error, changeset}
+        end
+
+      :error ->
+        {:redirect_error, validated.redirect_uri, "access_denied", validated.state}
+    end
+  end
+
+  @doc """
+  Looks up an authorization code by its raw value — used by tests + by
+  the Phase 4 `/oauth/token` exchange.
+  """
+  def get_authorization_code_by_raw(raw_code) when is_binary(raw_code) do
+    hash = hash_code(raw_code)
+
+    case Repo.one(from(ac in AuthorizationCode, where: ac.code_hash == ^hash),
+           skip_tenant_check: true
+         ) do
+      nil -> {:error, :not_found}
+      row -> {:ok, row}
+    end
+  end
+
+  # ── Internal ─────────────────────────────────────────────────────
+
+  defp fetch_client(nil), do: {:client_error, "invalid_client"}
+
+  defp fetch_client(client_id) do
+    case get_client(client_id) do
+      {:ok, client} -> {:ok, client}
+      {:error, :not_found} -> {:client_error, "invalid_client"}
+    end
+  end
+
+  defp match_redirect_uri(_client, nil), do: {:client_error, "invalid_redirect_uri"}
+
+  defp match_redirect_uri(client, uri) do
+    if uri in client.redirect_uris do
+      {:ok, uri}
+    else
+      {:client_error, "invalid_redirect_uri"}
+    end
+  end
+
+  defp check_response_type(%{"response_type" => "code"}, _), do: :ok
+
+  defp check_response_type(params, redirect_uri),
+    do: {:redirect_error, redirect_uri, "unsupported_response_type", params["state"]}
+
+  defp check_pkce(%{"code_challenge" => challenge} = params, redirect_uri)
+       when is_binary(challenge) and challenge != "" do
+    case params["code_challenge_method"] do
+      m when m in [nil, "S256"] -> :ok
+      _ -> {:redirect_error, redirect_uri, "invalid_request", params["state"]}
+    end
+  end
+
+  defp check_pkce(params, redirect_uri),
+    do: {:redirect_error, redirect_uri, "invalid_request", params["state"]}
+
+  defp check_scope(%{"scope" => nil}, _), do: :ok
+  defp check_scope(%{"scope" => ""}, _), do: :ok
+
+  defp check_scope(%{"scope" => scope} = params, redirect_uri) when is_binary(scope) do
+    requested = String.split(scope, " ", trim: true)
+
+    if Enum.all?(requested, &(&1 in @valid_scopes)) do
+      :ok
+    else
+      {:redirect_error, redirect_uri, "invalid_scope", params["state"]}
+    end
+  end
+
+  defp check_scope(_params, _redirect_uri), do: :ok
+
+  defp resolve_vault(_user, "vault:*"), do: {:ok, nil}
+
+  defp resolve_vault(user, "vault:" <> id_str) do
+    case Integer.parse(id_str) do
+      {id, ""} -> verify_vault_ownership(user, id)
+      _ -> :error
+    end
+  end
+
+  defp resolve_vault(_user, _), do: :error
+
+  defp verify_vault_ownership(user, vault_id) do
+    query =
+      from(v in Engram.Vaults.Vault,
+        where: v.id == ^vault_id and v.user_id == ^user.id and is_nil(v.deleted_at)
+      )
+
+    case Repo.one(query, skip_tenant_check: true) do
+      nil -> :error
+      _vault -> {:ok, vault_id}
+    end
+  end
+
+  defp build_redirect(base, params) do
+    cleaned = params |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end) |> Map.new()
+    sep = if String.contains?(base, "?"), do: "&", else: "?"
+    base <> sep <> URI.encode_query(cleaned)
+  end
+
+  defp hash_code(raw), do: :crypto.hash(:sha256, raw) |> Base.encode16(case: :lower)
 end

--- a/lib/engram/oauth/authorization_code.ex
+++ b/lib/engram/oauth/authorization_code.ex
@@ -1,0 +1,39 @@
+defmodule Engram.OAuth.AuthorizationCode do
+  @moduledoc """
+  Short-lived (10-minute) authorization code minted at `/oauth/authorize`
+  consent. Consumed at `/oauth/token` (Phase 4) when the client redeems
+  it for an access + refresh token. PKCE binds the code to the client
+  that initiated the flow — `code_challenge` is stored at mint time, the
+  client sends `code_verifier` at exchange time.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "oauth_authorization_codes" do
+    field :code_hash, :string
+    field :client_id, :binary_id
+    field :user_id, :integer
+    field :redirect_uri, :string
+    field :code_challenge, :string
+    field :code_challenge_method, :string, default: "S256"
+    field :scope, :string
+    field :vault_id, :integer
+    field :state, :string
+    field :expires_at, :utc_datetime
+    field :consumed_at, :utc_datetime
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
+  end
+
+  @cast_fields ~w(code_hash client_id user_id redirect_uri code_challenge
+                  code_challenge_method scope vault_id state expires_at)a
+  @required ~w(code_hash client_id user_id redirect_uri code_challenge
+               code_challenge_method expires_at)a
+
+  def changeset(code, attrs) do
+    code
+    |> cast(attrs, @cast_fields)
+    |> validate_required(@required)
+    |> unique_constraint(:code_hash)
+  end
+end

--- a/lib/engram_web/controllers/oauth_authorize_controller.ex
+++ b/lib/engram_web/controllers/oauth_authorize_controller.ex
@@ -1,0 +1,162 @@
+defmodule EngramWeb.OAuthAuthorizeController do
+  @moduledoc """
+  Authorization endpoint for OAuth 2.1 (RFC 6749 §4.1 + RFC 7636 PKCE).
+
+  GET renders a server-side consent page (vault picker). POST handles
+  the consent submission, mints an authorization code, and 302s back to
+  the client's `redirect_uri` with `code` + `state`.
+
+  Both verbs require an authenticated user (`Authorization: Bearer ...`)
+  via the existing `EngramWeb.Plugs.Auth`. Browser cookie session for
+  unauth'd users is handled in Phase 7 (consent UX iteration); today
+  the SPA acts as the user-agent that mediates this flow.
+  """
+  use EngramWeb, :controller
+
+  alias Engram.OAuth
+  alias Engram.Vaults
+
+  def show(conn, params) do
+    case OAuth.validate_authorization_request(params) do
+      {:ok, validated} ->
+        render_consent(conn, validated)
+
+      {:client_error, code} ->
+        render_client_error(conn, code)
+
+      {:redirect_error, redirect_uri, error, state} ->
+        redirect_with_error(conn, redirect_uri, error, state)
+    end
+  end
+
+  def submit(conn, params) do
+    user = conn.assigns.current_user
+
+    case OAuth.validate_authorization_request(params) do
+      {:ok, validated} ->
+        vault_choice = params["vault_choice"] || "vault:*"
+
+        case OAuth.mint_authorization_code(user, validated, vault_choice) do
+          {:ok, redirect_url} ->
+            conn |> put_status(302) |> redirect(external: redirect_url)
+
+          {:redirect_error, redirect_uri, error, state} ->
+            redirect_with_error(conn, redirect_uri, error, state)
+
+          {:error, _changeset} ->
+            redirect_with_error(conn, validated.redirect_uri, "server_error", validated.state)
+        end
+
+      {:client_error, code} ->
+        render_client_error(conn, code)
+
+      {:redirect_error, redirect_uri, error, state} ->
+        redirect_with_error(conn, redirect_uri, error, state)
+    end
+  end
+
+  defp render_consent(conn, validated) do
+    user = conn.assigns.current_user
+    vaults = Vaults.list_vaults(user)
+
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_resp(200, consent_html(validated, vaults, user))
+  end
+
+  defp consent_html(validated, vaults, user) do
+    """
+    <!doctype html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <title>Authorize #{html_escape(validated.client_name)} — Engram</title>
+      <style>
+        body { font-family: system-ui, sans-serif; max-width: 480px; margin: 4rem auto; padding: 1rem; }
+        h1 { font-size: 1.25rem; }
+        fieldset { border: 1px solid #ccc; padding: 1rem; margin: 1rem 0; }
+        legend { font-weight: 600; }
+        label { display: block; padding: 0.25rem 0; }
+        button { padding: 0.5rem 1rem; font-size: 1rem; cursor: pointer; }
+      </style>
+    </head>
+    <body>
+      <h1>Authorize <strong>#{html_escape(validated.client_name || "this app")}</strong> to access your Engram</h1>
+      <p>Signed in as #{html_escape(user.email)}.</p>
+      <form action="/oauth/authorize" method="post">
+        #{hidden(validated)}
+        <fieldset>
+          <legend>Which vault?</legend>
+          #{vault_radios(vaults)}
+          <label>
+            <input type="radio" name="vault_choice" value="vault:*" checked>
+            All vaults
+          </label>
+        </fieldset>
+        <button type="submit">Approve</button>
+      </form>
+    </body>
+    </html>
+    """
+  end
+
+  defp hidden(validated) do
+    [
+      {"client_id", validated.client_id},
+      {"redirect_uri", validated.redirect_uri},
+      {"response_type", "code"},
+      {"code_challenge", validated.code_challenge},
+      {"code_challenge_method", validated.code_challenge_method},
+      {"scope", validated.scope},
+      {"state", validated.state}
+    ]
+    |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
+    |> Enum.map_join("\n", fn {k, v} ->
+      ~s(<input type="hidden" name="#{k}" value="#{html_escape(v)}">)
+    end)
+  end
+
+  defp vault_radios([]), do: ""
+
+  defp vault_radios(vaults) do
+    Enum.map_join(vaults, "\n", fn v ->
+      ~s(<label><input type="radio" name="vault_choice" value="vault:#{v.id}"> #{html_escape(v.slug)}</label>)
+    end)
+  end
+
+  defp html_escape(nil), do: ""
+
+  defp html_escape(s) when is_binary(s) do
+    s
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'", "&#39;")
+  end
+
+  defp html_escape(other), do: html_escape(to_string(other))
+
+  defp render_client_error(conn, code) do
+    body = """
+    <!doctype html>
+    <html><body>
+    <h1>Authorization error</h1>
+    <p>Error: <code>#{html_escape(code)}</code>.</p>
+    <p>The OAuth client or redirect URI is not recognized. The request was rejected to prevent code-leak attacks.</p>
+    </body></html>
+    """
+
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_resp(400, body)
+  end
+
+  defp redirect_with_error(conn, redirect_uri, error, state) do
+    params = %{error: error, state: state} |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
+    sep = if String.contains?(redirect_uri, "?"), do: "&", else: "?"
+    location = redirect_uri <> sep <> URI.encode_query(params)
+
+    conn |> put_status(302) |> redirect(external: location)
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -49,6 +49,15 @@ defmodule EngramWeb.Router do
     post "/register", OAuthRegisterController, :register
   end
 
+  # OAuth 2.1 user-facing authorize endpoint. Requires an authenticated
+  # session (Bearer JWT today; Phase 7 wires browser cookie session).
+  scope "/oauth", EngramWeb do
+    pipe_through [:api, EngramWeb.Plugs.Auth]
+
+    get "/authorize", OAuthAuthorizeController, :show
+    post "/authorize", OAuthAuthorizeController, :submit
+  end
+
   # All API routes under /api prefix
   scope "/api", EngramWeb do
     # Public endpoints (no auth required, no rate limit)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.51",
+      version: "0.5.52",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260509000002_create_oauth_authorization_codes.exs
+++ b/priv/repo/migrations/20260509000002_create_oauth_authorization_codes.exs
@@ -1,0 +1,26 @@
+defmodule Engram.Repo.Migrations.CreateOauthAuthorizationCodes do
+  use Ecto.Migration
+
+  def change do
+    create table(:oauth_authorization_codes) do
+      add :code_hash, :string, null: false
+      add :client_id, :uuid, null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :redirect_uri, :string, null: false
+      add :code_challenge, :string, null: false
+      add :code_challenge_method, :string, null: false, default: "S256"
+      add :scope, :string
+      add :vault_id, references(:vaults, on_delete: :delete_all)
+      add :state, :string
+      add :expires_at, :utc_datetime, null: false
+      add :consumed_at, :utc_datetime
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    create unique_index(:oauth_authorization_codes, [:code_hash])
+    create index(:oauth_authorization_codes, [:user_id])
+    create index(:oauth_authorization_codes, [:client_id])
+    create index(:oauth_authorization_codes, [:expires_at])
+  end
+end

--- a/priv/static/css/marketing.css
+++ b/priv/static/css/marketing.css
@@ -253,6 +253,9 @@
   .grid {
     display: grid;
   }
+  .hidden {
+    display: none;
+  }
   .inline-block {
     display: inline-block;
   }

--- a/test/engram_web/controllers/oauth_authorize_controller_test.exs
+++ b/test/engram_web/controllers/oauth_authorize_controller_test.exs
@@ -1,0 +1,242 @@
+defmodule EngramWeb.OAuthAuthorizeControllerTest do
+  use EngramWeb.ConnCase, async: true
+
+  alias Engram.OAuth
+  alias Engram.Repo
+
+  defp jwt_authed(conn, user) do
+    user = ensure_external_id(user)
+    {:ok, token} = Engram.Auth.Providers.Local.issue_access_token(user.external_id, user.email)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  defp ensure_external_id(%{external_id: ext} = user) when is_binary(ext) and ext != "", do: user
+
+  defp ensure_external_id(user) do
+    {:ok, updated} =
+      user
+      |> Ecto.Changeset.change(external_id: "test-#{user.id}")
+      |> Repo.update(skip_tenant_check: true)
+
+    updated
+  end
+
+  defp register_client(redirect_uri \\ "https://claude.ai/api/mcp/auth_callback") do
+    {:ok, client} =
+      OAuth.register_client(%{
+        "redirect_uris" => [redirect_uri],
+        "client_name" => "Claude"
+      })
+
+    client
+  end
+
+  defp valid_params(client_id, redirect_uri) do
+    %{
+      "client_id" => client_id,
+      "redirect_uri" => redirect_uri,
+      "response_type" => "code",
+      "code_challenge" => "abc123challenge",
+      "code_challenge_method" => "S256",
+      "state" => "xyz",
+      "scope" => "mcp"
+    }
+  end
+
+  describe "GET /oauth/authorize — unauthenticated" do
+    test "returns 401 when no Authorization header is present", %{conn: conn} do
+      client = register_client()
+      params = valid_params(client.client_id, hd(client.redirect_uris))
+
+      conn = get(conn, "/oauth/authorize", params)
+      assert conn.status == 401
+    end
+  end
+
+  describe "GET /oauth/authorize — invalid client" do
+    test "returns 400 HTML when client_id is unknown", %{conn: conn} do
+      user = insert(:user)
+
+      params =
+        valid_params("00000000-0000-0000-0000-000000000000", "https://x/cb")
+
+      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+
+      assert conn.status == 400
+      assert conn.resp_body =~ "invalid_client"
+    end
+
+    test "returns 400 HTML when redirect_uri does not match registration", %{conn: conn} do
+      user = insert(:user)
+      client = register_client("https://claude.ai/api/mcp/auth_callback")
+
+      params = valid_params(client.client_id, "https://attacker.example/cb")
+
+      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+
+      assert conn.status == 400
+      assert conn.resp_body =~ "invalid_redirect_uri"
+    end
+  end
+
+  describe "GET /oauth/authorize — bad params (redirect with error)" do
+    test "redirects to redirect_uri?error=unsupported_response_type when not code", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("response_type", "token")
+
+      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+
+      assert conn.status == 302
+      [location] = get_resp_header(conn, "location")
+      assert String.starts_with?(location, redirect_uri)
+      assert location =~ "error=unsupported_response_type"
+      assert location =~ "state=xyz"
+    end
+
+    test "redirects with invalid_request when code_challenge missing", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.delete("code_challenge")
+
+      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+
+      assert conn.status == 302
+      [location] = get_resp_header(conn, "location")
+      assert location =~ "error=invalid_request"
+    end
+
+    test "redirects with invalid_request when code_challenge_method is plain", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("code_challenge_method", "plain")
+
+      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+
+      assert conn.status == 302
+      [location] = get_resp_header(conn, "location")
+      assert location =~ "error=invalid_request"
+    end
+  end
+
+  describe "GET /oauth/authorize — happy path" do
+    test "renders consent page with client name and vault picker", %{conn: conn} do
+      user = insert(:user)
+      _vault = insert(:vault, user: user, slug: "personal")
+      client = register_client()
+      params = valid_params(client.client_id, hd(client.redirect_uris))
+
+      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+
+      assert html_response(conn, 200)
+      assert conn.resp_body =~ "Claude"
+      assert conn.resp_body =~ "personal"
+      assert conn.resp_body =~ "All vaults"
+      assert conn.resp_body =~ ~s(action="/oauth/authorize")
+      assert conn.resp_body =~ ~s(method="post")
+    end
+  end
+
+  describe "POST /oauth/authorize — happy path" do
+    test "mints a code and redirects to redirect_uri with code + state", %{conn: conn} do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("vault_choice", "vault:#{vault.id}")
+
+      conn = conn |> jwt_authed(user) |> post("/oauth/authorize", params)
+
+      assert conn.status == 302
+      [location] = get_resp_header(conn, "location")
+      assert String.starts_with?(location, redirect_uri)
+
+      uri = URI.parse(location)
+      query = URI.decode_query(uri.query)
+      assert query["state"] == "xyz"
+      assert is_binary(query["code"]) and byte_size(query["code"]) > 16
+
+      # Code persisted
+      assert {:ok, code_row} = OAuth.get_authorization_code_by_raw(query["code"])
+      assert code_row.user_id == user.id
+      assert code_row.client_id == client.client_id
+      assert code_row.vault_id == vault.id
+      assert code_row.scope == "mcp"
+    end
+
+    test "mints a code with vault_id=nil when vault_choice=all", %{conn: conn} do
+      user = insert(:user)
+      _vault = insert(:vault, user: user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("vault_choice", "vault:*")
+
+      conn = conn |> jwt_authed(user) |> post("/oauth/authorize", params)
+
+      assert conn.status == 302
+      [location] = get_resp_header(conn, "location")
+      uri = URI.parse(location)
+      query = URI.decode_query(uri.query)
+
+      assert {:ok, code_row} = OAuth.get_authorization_code_by_raw(query["code"])
+      assert is_nil(code_row.vault_id)
+    end
+
+    test "rejects vault_choice that does not belong to the user", %{conn: conn} do
+      user = insert(:user)
+      other = insert(:user)
+      other_vault = insert(:vault, user: other)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("vault_choice", "vault:#{other_vault.id}")
+
+      conn = conn |> jwt_authed(user) |> post("/oauth/authorize", params)
+
+      assert conn.status == 302
+      [location] = get_resp_header(conn, "location")
+      assert location =~ "error=access_denied"
+    end
+  end
+
+  describe "POST /oauth/authorize — unauthenticated" do
+    test "returns 401 when no Authorization header is present", %{conn: conn} do
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("vault_choice", "vault:*")
+
+      conn = post(conn, "/oauth/authorize", params)
+      assert conn.status == 401
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Phase 3 of the [MCP OAuth 2.1 + DCR plan](docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md). Adds `/oauth/authorize` (GET + POST) and the underlying authorization-code mint logic.

- `GET /oauth/authorize` validates `client_id` (must be DCR-registered), `redirect_uri` (exact match against `client.redirect_uris`), `response_type=code`, `code_challenge` (required, S256-only — RFC 7636), `scope` (currently `mcp`). On success: server-renders a consent page with a vault picker.
- `POST /oauth/authorize` accepts `vault_choice` (`vault:<id>` or `vault:*`), verifies vault ownership, mints a one-time code (10-min TTL, sha256-hashed), 302s to `redirect_uri?code=...&state=...`.
- Error split per RFC 6749 §4.1.2.1: bad `client_id`/`redirect_uri` → **400 HTML** (NOT redirect — a forged `redirect_uri` is the exact exfil attack we'd be enabling); bad `response_type`/`code_challenge`/`scope` → 302 to `redirect_uri?error=...&state=...`; vault not owned → `error=access_denied`.
- New `oauth_authorization_codes` table (non-RLS, looked up by hashed code before user identity is known — token exchange in Phase 4 comes from the client, not the user). Schema validates required PKCE+code+expires fields. Indexed on `code_hash` (unique), `user_id`, `client_id`, `expires_at`.
- New `Engram.OAuth` context fns: `validate_authorization_request/1`, `mint_authorization_code/3`, `get_authorization_code_by_raw/1` (Phase 4 will add `consume_code`).
- Today both verbs require Bearer auth via the existing `Auth` plug. Browser cookie session for unauth'd users is **deferred to Phase 7** (consent UX iteration); the SPA acts as user-agent in the meantime.
- Bumps `mix.exs` 0.5.51 → 0.5.52.

**Stacked on #93** (Phase 2 DCR). Once that merges, this rebases onto main.

## Test plan
- [x] `mix test test/engram_web/controllers/oauth_authorize_controller_test.exs` — 11 tests pass (unauth → 401 on both verbs, invalid client_id → 400, invalid redirect_uri → 400, unsupported response_type → redirect with error, missing code_challenge → redirect with invalid_request, plain code_challenge_method → redirect with invalid_request, happy GET renders consent + form + vault list, happy POST mints code + 302 with code+state, vault:* → vault_id null, foreign vault → access_denied)
- [x] `mix test` — 1077/0/7 skipped, no regression
- [x] `mix credo --strict` — clean
- [x] `mix format` — clean
- [ ] Once merged + deployed: smoke `curl -i "https://app.engram.page/oauth/authorize?client_id=<dcr>&redirect_uri=...&response_type=code&code_challenge=abc&code_challenge_method=S256&state=xyz" -H "Authorization: Bearer <jwt>"` returns 200 HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)