### PR TITLE
feat(oauth): Phase 4 — token endpoint + refresh rotation w/ family revoke

### DIFF
--- a/lib/engram/accounts.ex
+++ b/lib/engram/accounts.ex
@@ -269,18 +269,28 @@ defmodule Engram.Accounts do
 
   # ── JWT ─────────────────────────────────────────────────────────
 
-  def generate_jwt(user) do
+  def generate_jwt(user, extras \\ %{}) do
     # `sub` + `email` match what the active auth provider's verify_token expects
     # (Local provider rejects tokens missing them with :missing_claims). `user_id`
     # is kept for the internal-JWT fallback in TokenResolver and for any callers
     # that look it up by integer DB id.
-    extra_claims = %{
+    #
+    # `extras` lets OAuth-issued tokens carry `scope` + `vault_id` claims so the
+    # MCP plug (Phase 5) can enforce vault scope without an extra DB lookup.
+    base = %{
       "sub" => user.external_id,
       "email" => user.email,
       "user_id" => user.id
     }
 
-    Engram.Token.generate_and_sign!(extra_claims)
+    Engram.Token.generate_and_sign!(Map.merge(base, stringify_keys(extras)))
+  end
+
+  defp stringify_keys(%{} = map) do
+    Map.new(map, fn
+      {k, v} when is_atom(k) -> {Atom.to_string(k), v}
+      {k, v} -> {k, v}
+    end)
   end
 
   def verify_jwt(token) do

--- a/lib/engram/oauth.ex
+++ b/lib/engram/oauth.ex
@@ -12,11 +12,15 @@ defmodule Engram.OAuth do
   not the user).
   """
   import Ecto.Query
-  alias Engram.OAuth.{AuthorizationCode, Client}
+  alias Engram.Accounts
+  alias Engram.OAuth.{AuthorizationCode, Client, RefreshToken}
   alias Engram.Repo
 
   @code_bytes 32
   @code_ttl_seconds 600
+  @refresh_token_prefix "engram_oauth_rt_"
+  @refresh_token_bytes 32
+  @refresh_token_ttl_days 90
   @valid_scopes ~w(mcp)
 
   # ── Clients (Phase 2) ────────────────────────────────────────────
@@ -143,6 +147,213 @@ defmodule Engram.OAuth do
       nil -> {:error, :not_found}
       row -> {:ok, row}
     end
+  end
+
+  # ── Token exchange (Phase 4) ─────────────────────────────────────
+
+  @doc """
+  Exchanges an authorization code for an access + refresh token pair.
+  Validates: code exists, unconsumed, unexpired, matching client_id,
+  matching redirect_uri, PKCE verifier hashes to stored challenge.
+  """
+  def exchange_authorization_code(params) do
+    with {:ok, code_row} <- find_unconsumed_code(params["code"]),
+         :ok <- check_code_client(code_row, params["client_id"]),
+         :ok <- check_code_redirect_uri(code_row, params["redirect_uri"]),
+         :ok <- check_pkce_verifier(code_row, params["code_verifier"]),
+         {:ok, user} <- fetch_user(code_row.user_id),
+         :ok <- consume_code(code_row),
+         {:ok, refresh_raw, refresh_row} <-
+           insert_refresh_token(%{
+             family_id: Ecto.UUID.generate(),
+             client_id: code_row.client_id,
+             user_id: code_row.user_id,
+             vault_id: code_row.vault_id,
+             scope: code_row.scope
+           }) do
+      {:ok, build_token_response(user, code_row, refresh_raw, refresh_row)}
+    end
+  end
+
+  @doc """
+  Rotates a refresh token: marks the presented one consumed, mints + issues
+  a successor in the same family. If the presented token is already
+  consumed (replay) or revoked, this revokes the entire family per
+  RFC 6749 §10.4.
+  """
+  def rotate_refresh_token(raw_token, client_id) do
+    hash = hash_code(raw_token)
+
+    case Repo.one(from(rt in RefreshToken, where: rt.token_hash == ^hash),
+           skip_tenant_check: true
+         ) do
+      nil ->
+        {:error, :invalid_grant}
+
+      %RefreshToken{} = rt ->
+        rotate_existing(rt, client_id)
+    end
+  end
+
+  defp rotate_existing(%RefreshToken{client_id: actual}, requested) when actual != requested,
+    do: {:error, :invalid_grant}
+
+  defp rotate_existing(%RefreshToken{revoked_at: %DateTime{}} = rt, _client_id) do
+    revoke_family(rt.family_id)
+    {:error, :invalid_grant}
+  end
+
+  defp rotate_existing(%RefreshToken{consumed_at: %DateTime{}} = rt, _client_id) do
+    revoke_family(rt.family_id)
+    {:error, :invalid_grant}
+  end
+
+  defp rotate_existing(%RefreshToken{expires_at: exp} = rt, _client_id) do
+    if DateTime.compare(DateTime.utc_now(), exp) == :gt do
+      {:error, :invalid_grant}
+    else
+      do_rotate(rt)
+    end
+  end
+
+  defp do_rotate(rt) do
+    now = DateTime.utc_now(:second)
+
+    rt
+    |> Ecto.Changeset.change(%{consumed_at: now})
+    |> Repo.update!(skip_tenant_check: true)
+
+    {:ok, refresh_raw, refresh_row} =
+      insert_refresh_token(%{
+        family_id: rt.family_id,
+        client_id: rt.client_id,
+        user_id: rt.user_id,
+        vault_id: rt.vault_id,
+        scope: rt.scope
+      })
+
+    case fetch_user(rt.user_id) do
+      {:ok, user} ->
+        {:ok,
+         %{
+           access_token: issue_access_token(user, rt.scope, rt.vault_id),
+           refresh_token: refresh_raw,
+           token_type: "Bearer",
+           expires_in: Engram.Token.ttl_seconds(),
+           scope: rt.scope
+         }}
+
+      err ->
+        # Roll back the new refresh row if user lookup failed (shouldn't
+        # happen — user_id FK guarantees existence — but keep tidy).
+        Repo.delete!(refresh_row, skip_tenant_check: true)
+        err
+    end
+  end
+
+  defp revoke_family(family_id) do
+    now = DateTime.utc_now(:second)
+
+    from(rt in RefreshToken,
+      where: rt.family_id == ^family_id and is_nil(rt.revoked_at)
+    )
+    |> Repo.update_all([set: [revoked_at: now]], skip_tenant_check: true)
+  end
+
+  defp find_unconsumed_code(nil), do: {:error, :invalid_grant}
+
+  defp find_unconsumed_code(raw_code) do
+    case get_authorization_code_by_raw(raw_code) do
+      {:ok, %AuthorizationCode{consumed_at: nil} = code} ->
+        if DateTime.compare(DateTime.utc_now(), code.expires_at) == :gt,
+          do: {:error, :invalid_grant},
+          else: {:ok, code}
+
+      _ ->
+        {:error, :invalid_grant}
+    end
+  end
+
+  defp check_code_client(%{client_id: actual}, requested) when actual == requested, do: :ok
+  defp check_code_client(_, _), do: {:error, :invalid_grant}
+
+  defp check_code_redirect_uri(%{redirect_uri: actual}, requested) when actual == requested,
+    do: :ok
+
+  defp check_code_redirect_uri(_, _), do: {:error, :invalid_grant}
+
+  defp check_pkce_verifier(_code, nil), do: {:error, :invalid_grant}
+
+  defp check_pkce_verifier(%{code_challenge: challenge}, verifier) when is_binary(verifier) do
+    derived = :crypto.hash(:sha256, verifier) |> Base.url_encode64(padding: false)
+
+    if Plug.Crypto.secure_compare(derived, challenge),
+      do: :ok,
+      else: {:error, :invalid_grant}
+  end
+
+  defp check_pkce_verifier(_, _), do: {:error, :invalid_grant}
+
+  defp consume_code(%AuthorizationCode{} = code) do
+    code
+    |> Ecto.Changeset.change(%{
+      consumed_at: DateTime.utc_now(:second)
+    })
+    |> Repo.update(skip_tenant_check: true)
+    |> case do
+      {:ok, _} -> :ok
+      {:error, _} -> {:error, :server_error}
+    end
+  end
+
+  defp fetch_user(user_id) do
+    case Accounts.get_user(user_id) do
+      %Accounts.User{} = user -> {:ok, user}
+      _ -> {:error, :invalid_grant}
+    end
+  end
+
+  defp insert_refresh_token(attrs) do
+    raw =
+      @refresh_token_prefix <>
+        Base.url_encode64(:crypto.strong_rand_bytes(@refresh_token_bytes), padding: false)
+
+    expires_at =
+      DateTime.utc_now()
+      |> DateTime.add(@refresh_token_ttl_days * 24 * 3600, :second)
+      |> DateTime.truncate(:second)
+
+    case %RefreshToken{}
+         |> RefreshToken.changeset(
+           Map.put(attrs, :token_hash, hash_code(raw))
+           |> Map.put(:expires_at, expires_at)
+         )
+         |> Repo.insert(skip_tenant_check: true) do
+      {:ok, row} -> {:ok, raw, row}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp issue_access_token(user, scope, vault_id) do
+    extras =
+      %{}
+      |> maybe_put("scope", scope)
+      |> maybe_put("vault_id", vault_id)
+
+    Accounts.generate_jwt(user, extras)
+  end
+
+  defp maybe_put(map, _k, nil), do: map
+  defp maybe_put(map, k, v), do: Map.put(map, k, v)
+
+  defp build_token_response(user, code_row, refresh_raw, _refresh_row) do
+    %{
+      access_token: issue_access_token(user, code_row.scope, code_row.vault_id),
+      refresh_token: refresh_raw,
+      token_type: "Bearer",
+      expires_in: Engram.Token.ttl_seconds(),
+      scope: code_row.scope
+    }
   end
 
   # ── Internal ─────────────────────────────────────────────────────

--- a/lib/engram/oauth/refresh_token.ex
+++ b/lib/engram/oauth/refresh_token.ex
@@ -1,0 +1,39 @@
+defmodule Engram.OAuth.RefreshToken do
+  @moduledoc """
+  Refresh token persisted as a sha256 hash. Carries `family_id` so that
+  RFC 6749 §10.4 reuse-detection can revoke the whole family if an old
+  token is replayed after rotation.
+
+  Lifecycle:
+    * fresh — `consumed_at` and `revoked_at` both nil, `expires_at` future
+    * consumed — `consumed_at` set when used to mint a successor; replay
+      after consumption triggers family-wide revocation
+    * revoked — `revoked_at` set; can never mint anything
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "oauth_refresh_tokens" do
+    field :token_hash, :string
+    field :family_id, :binary_id
+    field :client_id, :binary_id
+    field :user_id, :integer
+    field :vault_id, :integer
+    field :scope, :string
+    field :expires_at, :utc_datetime
+    field :revoked_at, :utc_datetime
+    field :consumed_at, :utc_datetime
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
+  end
+
+  @cast ~w(token_hash family_id client_id user_id vault_id scope expires_at)a
+  @required ~w(token_hash family_id client_id user_id expires_at)a
+
+  def changeset(token, attrs) do
+    token
+    |> cast(attrs, @cast)
+    |> validate_required(@required)
+    |> unique_constraint(:token_hash)
+  end
+end

--- a/lib/engram_web/controllers/oauth_token_controller.ex
+++ b/lib/engram_web/controllers/oauth_token_controller.ex
@@ -1,0 +1,59 @@
+defmodule EngramWeb.OAuthTokenController do
+  @moduledoc """
+  RFC 6749 §3.2 token endpoint. Public client + PKCE today; mounted under
+  `:oauth_api` (rate-limited per IP). Accepts both
+  `application/x-www-form-urlencoded` and `application/json` bodies via the
+  endpoint's standard parsers.
+  """
+  use EngramWeb, :controller
+
+  alias Engram.OAuth
+
+  def exchange(conn, %{"grant_type" => "authorization_code"} = params) do
+    case OAuth.exchange_authorization_code(params) do
+      {:ok, response} ->
+        json(conn, response)
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "invalid_grant"})
+    end
+  end
+
+  def exchange(conn, %{"grant_type" => "refresh_token"} = params) do
+    case params["refresh_token"] do
+      raw when is_binary(raw) and raw != "" ->
+        do_refresh(conn, raw, params["client_id"])
+
+      _ ->
+        invalid_request(conn)
+    end
+  end
+
+  def exchange(conn, %{"grant_type" => _other}) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "unsupported_grant_type"})
+  end
+
+  def exchange(conn, _params), do: invalid_request(conn)
+
+  defp do_refresh(conn, raw_token, client_id) do
+    case OAuth.rotate_refresh_token(raw_token, client_id) do
+      {:ok, response} ->
+        json(conn, response)
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "invalid_grant"})
+    end
+  end
+
+  defp invalid_request(conn) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "invalid_request"})
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -47,6 +47,7 @@ defmodule EngramWeb.Router do
     pipe_through :oauth_api
 
     post "/register", OAuthRegisterController, :register
+    post "/token", OAuthTokenController, :exchange
   end
 
   # OAuth 2.1 user-facing authorize endpoint. Requires an authenticated

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.52",
+      version: "0.5.53",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260509000003_create_oauth_refresh_tokens.exs
+++ b/priv/repo/migrations/20260509000003_create_oauth_refresh_tokens.exs
@@ -1,0 +1,24 @@
+defmodule Engram.Repo.Migrations.CreateOauthRefreshTokens do
+  use Ecto.Migration
+
+  def change do
+    create table(:oauth_refresh_tokens) do
+      add :token_hash, :string, null: false
+      add :family_id, :uuid, null: false
+      add :client_id, :uuid, null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :vault_id, references(:vaults, on_delete: :delete_all)
+      add :scope, :string
+      add :expires_at, :utc_datetime, null: false
+      add :revoked_at, :utc_datetime
+      add :consumed_at, :utc_datetime
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    create unique_index(:oauth_refresh_tokens, [:token_hash])
+    create index(:oauth_refresh_tokens, [:family_id])
+    create index(:oauth_refresh_tokens, [:user_id])
+    create index(:oauth_refresh_tokens, [:expires_at])
+  end
+end

--- a/test/engram_web/controllers/oauth_token_controller_test.exs
+++ b/test/engram_web/controllers/oauth_token_controller_test.exs
@@ -1,0 +1,379 @@
+defmodule EngramWeb.OAuthTokenControllerTest do
+  use EngramWeb.ConnCase, async: true
+
+  alias Engram.OAuth
+  alias Engram.Repo
+
+  defp pkce_pair do
+    verifier =
+      :crypto.strong_rand_bytes(48)
+      |> Base.url_encode64(padding: false)
+
+    challenge =
+      :crypto.hash(:sha256, verifier)
+      |> Base.url_encode64(padding: false)
+
+    {verifier, challenge}
+  end
+
+  defp register_client(redirect_uri \\ "https://claude.ai/api/mcp/auth_callback") do
+    {:ok, client} =
+      OAuth.register_client(%{
+        "redirect_uris" => [redirect_uri],
+        "client_name" => "Claude"
+      })
+
+    client
+  end
+
+  defp mint_code(user, client, redirect_uri, challenge, opts \\ []) do
+    state = Keyword.get(opts, :state, "xyz")
+    vault_choice = Keyword.get(opts, :vault_choice, "vault:*")
+
+    {:ok, validated} =
+      OAuth.validate_authorization_request(%{
+        "client_id" => client.client_id,
+        "redirect_uri" => redirect_uri,
+        "response_type" => "code",
+        "code_challenge" => challenge,
+        "code_challenge_method" => "S256",
+        "state" => state,
+        "scope" => "mcp"
+      })
+
+    {:ok, redirect_url} = OAuth.mint_authorization_code(user, validated, vault_choice)
+
+    %{query: query} = URI.parse(redirect_url)
+    URI.decode_query(query)["code"]
+  end
+
+  describe "POST /oauth/token — authorization_code grant" do
+    test "exchanges valid code for access + refresh tokens", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      params = %{
+        "grant_type" => "authorization_code",
+        "code" => code,
+        "redirect_uri" => redirect_uri,
+        "client_id" => client.client_id,
+        "code_verifier" => verifier
+      }
+
+      conn = post(conn, "/oauth/token", params)
+      body = json_response(conn, 200)
+
+      assert is_binary(body["access_token"])
+      assert is_binary(body["refresh_token"])
+      assert String.starts_with?(body["refresh_token"], "engram_oauth_rt_")
+      assert body["token_type"] == "Bearer"
+      assert is_integer(body["expires_in"]) and body["expires_in"] > 0
+      assert body["scope"] == "mcp"
+    end
+
+    test "rejects when code is unknown", %{conn: conn} do
+      client = register_client()
+
+      params = %{
+        "grant_type" => "authorization_code",
+        "code" => "engram_ac_doesnotexist",
+        "redirect_uri" => hd(client.redirect_uris),
+        "client_id" => client.client_id,
+        "code_verifier" => "verifier"
+      }
+
+      conn = post(conn, "/oauth/token", params)
+      body = json_response(conn, 400)
+
+      assert body["error"] == "invalid_grant"
+    end
+
+    test "rejects code reuse (already consumed)", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      params = %{
+        "grant_type" => "authorization_code",
+        "code" => code,
+        "redirect_uri" => redirect_uri,
+        "client_id" => client.client_id,
+        "code_verifier" => verifier
+      }
+
+      assert json_response(post(conn, "/oauth/token", params), 200)
+      conn2 = post(build_conn(), "/oauth/token", params)
+      body = json_response(conn2, 400)
+      assert body["error"] == "invalid_grant"
+    end
+
+    test "rejects when code_verifier does not hash to code_challenge", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {_verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      params = %{
+        "grant_type" => "authorization_code",
+        "code" => code,
+        "redirect_uri" => redirect_uri,
+        "client_id" => client.client_id,
+        "code_verifier" => "wrong_verifier"
+      }
+
+      conn = post(conn, "/oauth/token", params)
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_grant"
+    end
+
+    test "rejects when redirect_uri does not match the one used at /authorize", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, hd(client.redirect_uris), challenge)
+
+      params = %{
+        "grant_type" => "authorization_code",
+        "code" => code,
+        "redirect_uri" => "https://attacker.example/cb",
+        "client_id" => client.client_id,
+        "code_verifier" => verifier
+      }
+
+      conn = post(conn, "/oauth/token", params)
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_grant"
+    end
+
+    test "rejects when client_id does not match the code's client_id", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      other_client = register_client("https://other.example/cb")
+
+      params = %{
+        "grant_type" => "authorization_code",
+        "code" => code,
+        "redirect_uri" => redirect_uri,
+        "client_id" => other_client.client_id,
+        "code_verifier" => verifier
+      }
+
+      conn = post(conn, "/oauth/token", params)
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_grant"
+    end
+
+    test "rejects expired code", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      # Force-expire the row
+      {:ok, row} = OAuth.get_authorization_code_by_raw(code)
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      row
+      |> Ecto.Changeset.change(%{expires_at: past})
+      |> Repo.update!(skip_tenant_check: true)
+
+      params = %{
+        "grant_type" => "authorization_code",
+        "code" => code,
+        "redirect_uri" => redirect_uri,
+        "client_id" => client.client_id,
+        "code_verifier" => verifier
+      }
+
+      conn = post(conn, "/oauth/token", params)
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_grant"
+    end
+  end
+
+  describe "POST /oauth/token — refresh_token grant" do
+    test "rotates refresh token and issues new access token", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      conn1 =
+        post(conn, "/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => redirect_uri,
+          "client_id" => client.client_id,
+          "code_verifier" => verifier
+        })
+
+      %{"refresh_token" => first_refresh, "access_token" => first_access} =
+        json_response(conn1, 200)
+
+      conn2 =
+        post(build_conn(), "/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => first_refresh,
+          "client_id" => client.client_id
+        })
+
+      body = json_response(conn2, 200)
+
+      assert is_binary(body["access_token"])
+      assert is_binary(body["refresh_token"])
+      assert body["refresh_token"] != first_refresh
+      assert body["access_token"] != first_access
+    end
+
+    test "rejects reused refresh token (already rotated)", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      %{"refresh_token" => first_refresh} =
+        json_response(
+          post(conn, "/oauth/token", %{
+            "grant_type" => "authorization_code",
+            "code" => code,
+            "redirect_uri" => redirect_uri,
+            "client_id" => client.client_id,
+            "code_verifier" => verifier
+          }),
+          200
+        )
+
+      # Use it once → rotates
+      assert json_response(
+               post(build_conn(), "/oauth/token", %{
+                 "grant_type" => "refresh_token",
+                 "refresh_token" => first_refresh,
+                 "client_id" => client.client_id
+               }),
+               200
+             )
+
+      # Reuse → reject
+      conn2 =
+        post(build_conn(), "/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => first_refresh,
+          "client_id" => client.client_id
+        })
+
+      body = json_response(conn2, 400)
+      assert body["error"] == "invalid_grant"
+    end
+
+    test "revokes whole family on detected reuse (RFC 6749 §10.4)", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      %{"refresh_token" => rt1} =
+        json_response(
+          post(conn, "/oauth/token", %{
+            "grant_type" => "authorization_code",
+            "code" => code,
+            "redirect_uri" => redirect_uri,
+            "client_id" => client.client_id,
+            "code_verifier" => verifier
+          }),
+          200
+        )
+
+      # Rotate rt1 → rt2
+      %{"refresh_token" => rt2} =
+        json_response(
+          post(build_conn(), "/oauth/token", %{
+            "grant_type" => "refresh_token",
+            "refresh_token" => rt1,
+            "client_id" => client.client_id
+          }),
+          200
+        )
+
+      # Replay rt1 → must reject AND invalidate rt2 (whole family burned)
+      assert json_response(
+               post(build_conn(), "/oauth/token", %{
+                 "grant_type" => "refresh_token",
+                 "refresh_token" => rt1,
+                 "client_id" => client.client_id
+               }),
+               400
+             )
+
+      # rt2 must now be rejected too
+      assert json_response(
+               post(build_conn(), "/oauth/token", %{
+                 "grant_type" => "refresh_token",
+                 "refresh_token" => rt2,
+                 "client_id" => client.client_id
+               }),
+               400
+             )
+    end
+
+    test "rejects refresh token for a different client", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      {verifier, challenge} = pkce_pair()
+      code = mint_code(user, client, redirect_uri, challenge)
+
+      %{"refresh_token" => first_refresh} =
+        json_response(
+          post(conn, "/oauth/token", %{
+            "grant_type" => "authorization_code",
+            "code" => code,
+            "redirect_uri" => redirect_uri,
+            "client_id" => client.client_id,
+            "code_verifier" => verifier
+          }),
+          200
+        )
+
+      other = register_client("https://other.example/cb")
+
+      conn2 =
+        post(build_conn(), "/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => first_refresh,
+          "client_id" => other.client_id
+        })
+
+      body = json_response(conn2, 400)
+      assert body["error"] == "invalid_grant"
+    end
+  end
+
+  describe "POST /oauth/token — invalid input" do
+    test "rejects unsupported grant_type", %{conn: conn} do
+      conn = post(conn, "/oauth/token", %{"grant_type" => "password"})
+      body = json_response(conn, 400)
+      assert body["error"] == "unsupported_grant_type"
+    end
+
+    test "rejects missing grant_type", %{conn: conn} do
+      conn = post(conn, "/oauth/token", %{})
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_request"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Phase 4 of the [MCP OAuth 2.1 + DCR plan](docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md). Adds `POST /oauth/token` so DCR-registered clients can exchange the codes minted in Phase 3 for access tokens, and rotate those tokens on refresh.

- **`grant_type=authorization_code`** — verifies the code is unconsumed + unexpired, that `client_id` and `redirect_uri` match what was used at `/authorize`, and that PKCE `code_verifier` SHA-256s to the stored `code_challenge` (constant-time compare via `Plug.Crypto.secure_compare`). Marks code consumed, mints an internal HS256 access JWT (with new optional `scope` + `vault_id` claims via `Accounts.generate_jwt/2`) and a 90d refresh token (`engram_oauth_rt_<...>`, sha256-hashed at rest).
- **`grant_type=refresh_token`** — rotates: marks the presented token consumed, mints a successor in the same `family_id`. If a consumed-or-revoked token is later presented (replay), the **entire family is revoked** per RFC 6749 §10.4 — the legitimate rotated `rt2` becomes unusable too, forcing the user to re-authorize. This protects against a stolen refresh token whose original is used after legitimate rotation.
- Error semantics per RFC 6749 §5.2: unknown grant → `unsupported_grant_type`, missing grant/refresh → `invalid_request`, **all** auth-code or rotate failures → `invalid_grant` (deliberately indistinct so brute-forcers can't probe).
- New `oauth_refresh_tokens` table (non-RLS), indexed on `token_hash` (unique), `family_id`, `user_id`, `expires_at`.
- Bumps `mix.exs` 0.5.52 → 0.5.53.

**Stacked on #94** (Phase 3 authorize). Once that merges, this rebases onto main.

## Test plan
- [x] `mix test test/engram_web/controllers/oauth_token_controller_test.exs` — 13 tests pass:
  - happy code exchange, unknown code, code reuse, wrong PKCE verifier, mismatched redirect_uri, mismatched client_id, expired code → 400 invalid_grant
  - happy refresh rotation, refresh reuse → 400, **family burn on detected reuse (rt1 then rt1 again invalidates rt2)**, wrong client on refresh → 400
  - unsupported grant_type → 400 unsupported_grant_type, missing grant_type → 400 invalid_request
- [x] `mix test` — 1090/0/7 skipped, no regression
- [x] `mix credo --strict` — clean
- [x] `mix compile --warnings-as-errors` — clean
- [ ] Once merged + deployed: full end-to-end exchange with a real PKCE pair against `/oauth/authorize` → `/oauth/token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)