### PR TITLE
feat(oauth): Phase 5 — MCP scope enforcement on /api/mcp

### DIFF
--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -116,18 +116,31 @@ defmodule EngramWeb.McpController do
   # -- Vault resolution --
 
   defp resolve_mcp_vault(user, args, conn) do
-    case args["vault_id"] do
-      nil ->
+    oauth_bound = conn.assigns[:oauth_scope_vault_id]
+    requested = args["vault_id"]
+
+    cond do
+      is_integer(oauth_bound) and is_nil(requested) ->
+        Engram.Vaults.get_vault(user, oauth_bound)
+
+      is_integer(oauth_bound) and to_string(requested) != to_string(oauth_bound) ->
+        {:error,
+         "OAuth token is bound to vault #{oauth_bound}; tool call requested vault #{requested}"}
+
+      is_integer(oauth_bound) ->
+        Engram.Vaults.get_vault(user, oauth_bound)
+
+      is_nil(requested) ->
         {:ok, conn.assigns.current_vault}
 
-      vault_id ->
-        case Engram.Vaults.get_vault(user, vault_id) do
+      true ->
+        case Engram.Vaults.get_vault(user, requested) do
           {:ok, vault} ->
             api_key = conn.assigns[:current_api_key]
 
             case Engram.Vaults.check_api_key_access(api_key, vault) do
               :ok -> {:ok, vault}
-              :forbidden -> {:error, "API key does not have access to vault #{vault_id}"}
+              :forbidden -> {:error, "API key does not have access to vault #{requested}"}
             end
 
           _ ->

--- a/lib/engram_web/plugs/oauth_scope_enforce.ex
+++ b/lib/engram_web/plugs/oauth_scope_enforce.ex
@@ -1,0 +1,29 @@
+defmodule EngramWeb.Plugs.OAuthScopeEnforce do
+  @moduledoc """
+  Surfaces OAuth scope claims (`vault_id`, `scope`) from an Engram-issued
+  internal HS256 JWT (the kind minted by `/oauth/token`) so downstream
+  controllers can enforce vault-scope locks on the bearer token.
+
+  Mounted only on `/api/mcp`, AFTER `EngramWeb.Plugs.Auth`. Auth has
+  already validated the token, so this plug re-parses to extract the
+  OAuth-specific claims without a second DB hit.
+
+  Sets `conn.assigns.oauth_scope_vault_id` (integer or nil) and
+  `conn.assigns.oauth_scope` (string or nil). Never halts — absence
+  of OAuth claims is the normal case for API-key / Clerk JWT auth.
+  """
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         {:ok, claims} <- Engram.Accounts.verify_jwt(token) do
+      conn
+      |> assign(:oauth_scope_vault_id, claims["vault_id"])
+      |> assign(:oauth_scope, claims["scope"])
+    else
+      _ -> conn
+    end
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -164,8 +164,13 @@ defmodule EngramWeb.Router do
     # Embedding status
     get "/embed-status", EmbedStatusController, :index
 
-    # MCP endpoint (JSON-RPC 2.0 over HTTP POST)
-    post "/mcp", McpController, :handle
+    # MCP endpoint (JSON-RPC 2.0 over HTTP POST). OAuthScopeEnforce surfaces
+    # vault_id/scope claims from OAuth-issued JWTs so the controller can lock
+    # tool calls to the bound vault.
+    scope "/" do
+      pipe_through EngramWeb.Plugs.OAuthScopeEnforce
+      post "/mcp", McpController, :handle
+    end
   end
 
   # Marketing pages — server-rendered HTML, before SPA catch-all

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.53",
+      version: "0.5.54",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/mcp_oauth_scope_test.exs
+++ b/test/engram_web/controllers/mcp_oauth_scope_test.exs
@@ -1,0 +1,117 @@
+defmodule EngramWeb.McpOAuthScopeTest do
+  use EngramWeb.ConnCase, async: true
+
+  # Sanity test for Phase 5: tools called via /api/mcp under an OAuth-issued
+  # JWT carrying a vault_id claim must route to that bound vault, and a
+  # mismatched vault_id arg must be rejected. API-key auth (existing
+  # behavior) and unscoped JWTs are also tested for backward compat.
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    vault_a = insert(:vault, user: user, slug: "vault-a", is_default: true)
+    vault_b = insert(:vault, user: user, slug: "vault-b")
+
+    {:ok, _} =
+      Engram.Notes.upsert_note(user, vault_a, %{
+        "path" => "a.md",
+        "content" => "in vault A",
+        "mtime" => 1.0
+      })
+
+    {:ok, _} =
+      Engram.Notes.upsert_note(user, vault_b, %{
+        "path" => "b.md",
+        "content" => "in vault B",
+        "mtime" => 1.0
+      })
+
+    %{conn: conn, user: user, vault_a: vault_a, vault_b: vault_b}
+  end
+
+  defp ensure_external_id(%{external_id: ext} = user) when is_binary(ext) and ext != "", do: user
+
+  defp ensure_external_id(user) do
+    {:ok, updated} =
+      user
+      |> Ecto.Changeset.change(external_id: "test-#{user.id}")
+      |> Engram.Repo.update(skip_tenant_check: true)
+
+    updated
+  end
+
+  defp oauth_authed(conn, user, vault_id) do
+    user = ensure_external_id(user)
+    token = Engram.Accounts.generate_jwt(user, %{"scope" => "mcp", "vault_id" => vault_id})
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  defp unscoped_jwt(conn, user) do
+    user = ensure_external_id(user)
+    token = Engram.Accounts.generate_jwt(user)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  defp call_tool(conn, name, args) do
+    post(conn, "/api/mcp", %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => "tools/call",
+      "params" => %{"name" => name, "arguments" => args}
+    })
+  end
+
+  test "OAuth-bound vault_id with no args.vault_id routes to bound vault", %{
+    conn: conn,
+    user: user,
+    vault_a: vault_a
+  } do
+    conn = conn |> oauth_authed(user, vault_a.id) |> call_tool("list_folders", %{})
+    body = json_response(conn, 200)
+    assert is_map(body["result"])
+    refute Map.has_key?(body, "error")
+  end
+
+  test "OAuth-bound vault_id matching args.vault_id routes successfully", %{
+    conn: conn,
+    user: user,
+    vault_a: vault_a
+  } do
+    conn =
+      conn
+      |> oauth_authed(user, vault_a.id)
+      |> call_tool("list_folders", %{"vault_id" => vault_a.id})
+
+    body = json_response(conn, 200)
+    refute Map.has_key?(body, "error")
+  end
+
+  test "OAuth-bound vault_id with mismatched args.vault_id is rejected", %{
+    conn: conn,
+    user: user,
+    vault_a: vault_a,
+    vault_b: vault_b
+  } do
+    conn =
+      conn
+      |> oauth_authed(user, vault_a.id)
+      |> call_tool("list_folders", %{"vault_id" => vault_b.id})
+
+    body = json_response(conn, 200)
+
+    # MCP wraps tool errors as a result with isError, OR as a JSON-RPC error.
+    # Either way the response must surface the bound-vault enforcement.
+    response_text = body["result"]["content"] |> Kernel.||([]) |> Enum.map_join(" ", & &1["text"])
+    error_msg = body["error"]["message"] || ""
+    assert response_text <> error_msg =~ "bound to vault"
+  end
+
+  test "unscoped internal JWT (no vault_id claim) keeps existing behavior", %{
+    conn: conn,
+    user: user
+  } do
+    conn = conn |> unscoped_jwt(user) |> call_tool("list_folders", %{})
+    body = json_response(conn, 200)
+    refute Map.has_key?(body, "error")
+  end
+end


### PR DESCRIPTION
## Summary
Phase 5 of the [MCP OAuth 2.1 + DCR plan](docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md). Tokens now flow end-to-end (Phase 4); this PR locks down `/api/mcp` so a `vault:<id>`-bound OAuth JWT cannot call MCP tools against a *different* vault — even if the attacker passes `vault_id` in tool-call args pointing at one of the user's other vaults.

- **New `EngramWeb.Plugs.OAuthScopeEnforce`** mounted only on `/api/mcp`, AFTER `EngramWeb.Plugs.Auth`. Re-parses the bearer token via `Accounts.verify_jwt/1` (HS256-only — provider/Clerk JWTs + API keys fall through silently) and surfaces `vault_id` + `scope` claims on `conn.assigns`. Never halts.
- **`McpController.resolve_mcp_vault/3`** honors `conn.assigns.oauth_scope_vault_id`:
  - bound + no `args.vault_id` → route to bound
  - bound + matching `args.vault_id` → route to bound
  - bound + mismatched → tool error mentioning the bound-vault id
  - no binding → existing default-vault / args.vault_id logic, untouched
- API-key auth + unscoped internal JWTs are unaffected (regression test confirms `Accounts.generate_jwt(user)` with no claims keeps pre-Phase-5 behavior).
- Bumps `mix.exs` 0.5.53 → 0.5.54.

**Stacked on #95** (Phase 4 token endpoint). Once that merges, this rebases onto main.

## Test plan
- [x] `mix test test/engram_web/controllers/mcp_oauth_scope_test.exs` — 4 tests pass:
  - OAuth-bound + no `args.vault_id` → routes to bound
  - OAuth-bound + matching → routes to bound
  - OAuth-bound + mismatched → rejected with "bound to vault" message
  - unscoped internal JWT (no vault_id claim) → backward-compat pass
- [x] `mix test` — 1094/0/7 skipped, no regression in API-key or device-flow auth
- [x] `mix credo --strict` — clean
- [x] `mix compile --warnings-as-errors` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)