### PR TITLE
feat(oauth): Phase 6 — RFC 7009 token revocation + cleanup cron

### DIFF
--- a/lib/engram/oauth.ex
+++ b/lib/engram/oauth.ex
@@ -346,6 +346,63 @@ defmodule Engram.OAuth do
   defp maybe_put(map, _k, nil), do: map
   defp maybe_put(map, k, v), do: Map.put(map, k, v)
 
+  # ── Revocation (Phase 6) ─────────────────────────────────────────
+
+  @doc """
+  Revokes a refresh token if `client_id` matches the token's owner.
+  Returns `:ok` always — leaks no info about token existence per
+  RFC 7009 §2.2.
+  """
+  def revoke_token(nil, _client_id, _hint), do: :ok
+  def revoke_token(_token, nil, _hint), do: :ok
+
+  def revoke_token(raw_token, client_id, _hint) when is_binary(raw_token) do
+    hash = hash_code(raw_token)
+
+    case Repo.one(from(rt in RefreshToken, where: rt.token_hash == ^hash),
+           skip_tenant_check: true
+         ) do
+      %RefreshToken{client_id: ^client_id} = rt ->
+        rt
+        |> Ecto.Changeset.change(%{revoked_at: DateTime.utc_now(:second)})
+        |> Repo.update!(skip_tenant_check: true)
+
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  def revoke_token(_, _, _), do: :ok
+
+  @doc """
+  Drops expired authorization codes and revoked refresh tokens past a
+  7-day grace window. Returns `{count_deleted, nil}`. Called by the
+  hourly Engram.Workers.CleanupDeviceAuthWorker job alongside DeviceFlow
+  cleanup so OAuth state doesn't leak.
+  """
+  def cleanup_expired do
+    code_cutoff = DateTime.utc_now(:second) |> DateTime.add(-3600, :second)
+    revoked_cutoff = DateTime.utc_now(:second) |> DateTime.add(-7 * 24 * 3600, :second)
+
+    {codes, _} =
+      from(ac in AuthorizationCode, where: ac.expires_at < ^code_cutoff)
+      |> Repo.delete_all(skip_tenant_check: true)
+
+    {revoked_tokens, _} =
+      from(rt in RefreshToken,
+        where: not is_nil(rt.revoked_at) and rt.revoked_at < ^revoked_cutoff
+      )
+      |> Repo.delete_all(skip_tenant_check: true)
+
+    {expired_tokens, _} =
+      from(rt in RefreshToken, where: rt.expires_at < ^revoked_cutoff)
+      |> Repo.delete_all(skip_tenant_check: true)
+
+    {codes + revoked_tokens + expired_tokens, nil}
+  end
+
   defp build_token_response(user, code_row, refresh_raw, _refresh_row) do
     %{
       access_token: issue_access_token(user, code_row.scope, code_row.vault_id),

--- a/lib/engram/workers/cleanup_device_auth_worker.ex
+++ b/lib/engram/workers/cleanup_device_auth_worker.ex
@@ -1,12 +1,17 @@
 defmodule Engram.Workers.CleanupDeviceAuthWorker do
-  @moduledoc "Hourly cleanup of expired device authorizations and revoked refresh tokens."
+  @moduledoc """
+  Hourly cleanup of expired auth state — both the legacy device flow
+  (`Engram.Auth.DeviceFlow`) and the OAuth 2.1 server (`Engram.OAuth`).
+  """
   use Oban.Worker, queue: :maintenance
 
   alias Engram.Auth.DeviceFlow
+  alias Engram.OAuth
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
     _ = DeviceFlow.cleanup_expired()
+    _ = OAuth.cleanup_expired()
     :ok
   end
 end

--- a/lib/engram_web/controllers/oauth_revoke_controller.ex
+++ b/lib/engram_web/controllers/oauth_revoke_controller.ex
@@ -1,0 +1,25 @@
+defmodule EngramWeb.OAuthRevokeController do
+  @moduledoc """
+  RFC 7009 token revocation. Always responds 200 (per §2.2) regardless
+  of whether the token existed or was actually revoked — leaking that
+  distinction would help attackers enumerate live tokens.
+
+  Today only refresh tokens are stored server-side, so access-token
+  revocation is silently no-op'd. Mismatched `client_id` is also a
+  silent no-op (200, but the token is left intact).
+  """
+  use EngramWeb, :controller
+
+  alias Engram.OAuth
+
+  def revoke(conn, params) do
+    _ =
+      OAuth.revoke_token(
+        params["token"],
+        params["client_id"],
+        params["token_type_hint"]
+      )
+
+    send_resp(conn, 200, "")
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -48,6 +48,7 @@ defmodule EngramWeb.Router do
 
     post "/register", OAuthRegisterController, :register
     post "/token", OAuthTokenController, :exchange
+    post "/revoke", OAuthRevokeController, :revoke
   end
 
   # OAuth 2.1 user-facing authorize endpoint. Requires an authenticated

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.54",
+      version: "0.5.55",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/oauth_revoke_controller_test.exs
+++ b/test/engram_web/controllers/oauth_revoke_controller_test.exs
@@ -1,0 +1,184 @@
+defmodule EngramWeb.OAuthRevokeControllerTest do
+  use EngramWeb.ConnCase, async: false
+
+  import Ecto.Query
+
+  alias Engram.OAuth
+  alias Engram.OAuth.RefreshToken
+  alias Engram.Repo
+
+  setup_all do
+    on_exit(fn ->
+      Application.put_env(:engram, :rate_limit_override, 10_000)
+    end)
+
+    :ok
+  end
+
+  setup do
+    Hammer.delete_buckets("/oauth/revoke:127.0.0.1")
+    Hammer.delete_buckets("/oauth/token:127.0.0.1")
+    Application.put_env(:engram, :rate_limit_override, 10_000)
+    :ok
+  end
+
+  defp pkce_pair do
+    verifier = Base.url_encode64(:crypto.strong_rand_bytes(48), padding: false)
+    challenge = :crypto.hash(:sha256, verifier) |> Base.url_encode64(padding: false)
+    {verifier, challenge}
+  end
+
+  defp full_flow_refresh_token(conn) do
+    user = insert(:user)
+
+    {:ok, client} =
+      OAuth.register_client(%{
+        "redirect_uris" => ["https://x/cb"],
+        "client_name" => "x"
+      })
+
+    redirect_uri = hd(client.redirect_uris)
+    {verifier, challenge} = pkce_pair()
+
+    {:ok, validated} =
+      OAuth.validate_authorization_request(%{
+        "client_id" => client.client_id,
+        "redirect_uri" => redirect_uri,
+        "response_type" => "code",
+        "code_challenge" => challenge,
+        "code_challenge_method" => "S256",
+        "state" => "s"
+      })
+
+    {:ok, redirect_url} = OAuth.mint_authorization_code(user, validated, "vault:*")
+    code = URI.parse(redirect_url).query |> URI.decode_query() |> Map.fetch!("code")
+
+    %{"refresh_token" => rt} =
+      json_response(
+        post(conn, "/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => redirect_uri,
+          "client_id" => client.client_id,
+          "code_verifier" => verifier
+        }),
+        200
+      )
+
+    {client, rt}
+  end
+
+  describe "POST /oauth/revoke" do
+    test "revokes a refresh token and subsequent refresh fails (RFC 7009)", %{conn: conn} do
+      {client, rt} = full_flow_refresh_token(conn)
+
+      revoke =
+        post(build_conn(), "/oauth/revoke", %{
+          "token" => rt,
+          "token_type_hint" => "refresh_token",
+          "client_id" => client.client_id
+        })
+
+      assert revoke.status == 200
+
+      conn2 =
+        post(build_conn(), "/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => rt,
+          "client_id" => client.client_id
+        })
+
+      assert json_response(conn2, 400)["error"] == "invalid_grant"
+    end
+
+    test "returns 200 for an unknown token (RFC 7009 §2.2)", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/revoke", %{
+          "token" => "engram_oauth_rt_doesnotexist",
+          "client_id" => "00000000-0000-0000-0000-000000000000"
+        })
+
+      assert conn.status == 200
+    end
+
+    test "does NOT revoke when client_id does not own the token (still 200)", %{conn: conn} do
+      {client, rt} = full_flow_refresh_token(conn)
+
+      {:ok, other} =
+        OAuth.register_client(%{
+          "redirect_uris" => ["https://other/cb"],
+          "client_name" => "other"
+        })
+
+      revoke =
+        post(build_conn(), "/oauth/revoke", %{
+          "token" => rt,
+          "client_id" => other.client_id
+        })
+
+      # RFC 7009: always 200, but the token must NOT have been revoked.
+      assert revoke.status == 200
+      assert {:ok, _new_pair} = OAuth.rotate_refresh_token(rt, client.client_id)
+    end
+
+    test "responds 200 with missing token", %{conn: conn} do
+      conn = post(conn, "/oauth/revoke", %{"client_id" => "x"})
+      assert conn.status == 200
+    end
+  end
+
+  describe "OAuth.cleanup_expired/0" do
+    test "deletes authorization codes past expiry + grace" do
+      user = insert(:user)
+
+      {:ok, client} =
+        OAuth.register_client(%{
+          "redirect_uris" => ["https://x/cb"],
+          "client_name" => "c"
+        })
+
+      {:ok, validated} =
+        OAuth.validate_authorization_request(%{
+          "client_id" => client.client_id,
+          "redirect_uri" => hd(client.redirect_uris),
+          "response_type" => "code",
+          "code_challenge" => "abc",
+          "code_challenge_method" => "S256"
+        })
+
+      {:ok, _} = OAuth.mint_authorization_code(user, validated, "vault:*")
+
+      past = DateTime.utc_now(:second) |> DateTime.add(-86_400, :second)
+
+      Repo.update_all(
+        Engram.OAuth.AuthorizationCode,
+        [set: [expires_at: past]],
+        skip_tenant_check: true
+      )
+
+      assert {deleted, _} = OAuth.cleanup_expired()
+      assert deleted >= 1
+    end
+
+    test "deletes refresh tokens revoked >7d ago" do
+      {client, rt} = full_flow_refresh_token(build_conn())
+
+      # Revoke + age out
+      assert post(build_conn(), "/oauth/revoke", %{
+               "token" => rt,
+               "client_id" => client.client_id
+             }).status == 200
+
+      old = DateTime.utc_now(:second) |> DateTime.add(-30 * 24 * 3600, :second)
+
+      Repo.update_all(
+        from(r in RefreshToken, where: not is_nil(r.revoked_at)),
+        [set: [revoked_at: old]],
+        skip_tenant_check: true
+      )
+
+      assert {deleted, _} = OAuth.cleanup_expired()
+      assert deleted >= 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Phase 6 of the [MCP OAuth 2.1 + DCR plan](docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md). Wraps the OAuth server with the bits a production deployment needs to not bleed state forever.

- **`POST /oauth/revoke`** implements RFC 7009 with the spec-mandated 200-always response (§2.2). Leaking whether a token exists would help an attacker enumerate live grants. Refresh tokens that match the request's `client_id` are marked `revoked_at`; mismatched `client_id` is a silent no-op (still 200, token survives). Access-token revocation is silently no-op'd (stateless JWTs, no server-side state to drop).
- **`OAuth.cleanup_expired/0`** sweeps three pools:
  - authorization codes past their 10-min TTL + 1-hour grace
  - refresh tokens revoked >7 days ago (debug window — gives ops time to inspect why something was revoked)
  - refresh tokens past their 90-day TTL
- **`Engram.Workers.CleanupDeviceAuthWorker`** (the existing hourly Oban maintenance job that already calls `DeviceFlow.cleanup_expired`) now also calls `OAuth.cleanup_expired` so the OAuth tables don't bloat in prod.
- Bumps `mix.exs` 0.5.54 → 0.5.55.

**Stacked on #96** (Phase 5 scope enforcement). Once that merges, this rebases onto main.

## Test plan
- [x] `mix test test/engram_web/controllers/oauth_revoke_controller_test.exs` — 6 tests pass:
  - revoke a refresh token → next refresh attempt 400 invalid_grant
  - revoke unknown token → 200
  - revoke with mismatched client_id → 200 but token still rotatable by real owner
  - revoke with missing token → 200
  - cleanup_expired drops codes past expiry+grace
  - cleanup_expired drops refresh tokens revoked >7d ago
- [x] `mix test` — 1100/0/7 skipped, no regression in DeviceFlow cleanup
- [x] `mix credo --strict` — clean
- [x] `mix compile --warnings-as-errors` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)