### PR TITLE
chore(logger): redact OAuth PKCE secrets + bearer tokens (Phase 7 prep)

### DIFF
--- a/lib/engram/logger/redact_filter.ex
+++ b/lib/engram/logger/redact_filter.ex
@@ -43,7 +43,19 @@ defmodule Engram.Logger.RedactFilter do
                     # Filenames
                     :attachment_name,
                     :filename,
-                    :name
+                    :name,
+                    # OAuth 2.1 — PKCE secrets (Phase 7 prep). `code_challenge`
+                    # is an SHA-256 hash but it pairs with `code_verifier`,
+                    # which IS the raw secret. Logging either helps an
+                    # attacker replay an intercepted authorization code.
+                    :code_challenge,
+                    :code_verifier,
+                    # OAuth tokens — never log raw bearer values
+                    :access_token,
+                    :refresh_token,
+                    :authorization_header,
+                    :client_secret,
+                    :client_secret_hash
                   ])
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.56",
+      version: "0.5.57",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/logger/redact_filter_test.exs
+++ b/test/engram/logger/redact_filter_test.exs
@@ -36,7 +36,14 @@ defmodule Engram.Logger.RedactFilterTest do
         :customer_email,
         :attachment_name,
         :filename,
-        :name
+        :name,
+        :code_challenge,
+        :code_verifier,
+        :access_token,
+        :refresh_token,
+        :authorization_header,
+        :client_secret,
+        :client_secret_hash
       ]
 
       meta = Map.new(sensitive, fn k -> {k, @sentinel} end)


### PR DESCRIPTION
## Summary
Phase 7 of the MCP OAuth plan starts with a live walk against Claude Connectors UI on prod, where Phoenix's request log + structured app logs WILL capture metadata from the new `/oauth/*` endpoints. Before pointing real traffic at this, harden `RedactFilter`'s `@sensitive_keys` against the obvious OAuth-shaped leaks.

Added:
- `:code_challenge` — SHA-256 hash but pairs with `code_verifier`; logging either helps an attacker replay an intercepted authorization code (PKCE binding)
- `:code_verifier` — raw PKCE secret
- `:access_token` — bearer JWT
- `:refresh_token` — long-lived, sha256-hashed at rest but raw must never appear in logs
- `:authorization_header` — defense in depth for any structured logging that captures HTTP headers
- `:client_secret` / `:client_secret_hash` — confidential-client secrets aren't issued today but the shape exists in `oauth_clients` and someone might log it later

`RedactFilter` still explicitly does NOT touch message bodies — call sites must keep these values out of interpolated strings. The existing pin-test for that contract is unchanged.

Bumps `mix.exs` 0.5.56 → 0.5.57.

## Test plan
- [x] `mix test test/engram/logger/redact_filter_test.exs` — 9 tests pass; the canonical-keys test now covers the 7 new entries
- [x] `mix credo --strict` on the touched files — clean
- [x] `mix format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)