### PR TITLE
feat(oauth): Phase 7.A — SPA mediation for /oauth/authorize

### DIFF
--- a/docs/context/mcp-oauth.md
+++ b/docs/context/mcp-oauth.md
@@ -10,12 +10,13 @@ Plan: `docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md`. Shipped in PRs #91-#
 1. GET  /.well-known/oauth-protected-resource    → {resource, authorization_servers}
 2. GET  /.well-known/oauth-authorization-server  → endpoints + grant_types + PKCE
 3. POST /oauth/register                          → mints client_id (DCR)
-4. GET  /oauth/authorize?client_id&redirect_uri  → consent UI (vault picker)
-5. POST /oauth/authorize {vault_choice}          → 302 redirect_uri?code&state
-6. POST /oauth/token grant=authorization_code    → access_token + refresh_token
-7. POST /api/mcp Authorization: Bearer ...       → tool calls (vault-locked)
-8. POST /oauth/token grant=refresh_token         → rotated tokens (RFC 6749 §10.4 family)
-9. POST /oauth/revoke                            → 200 always (RFC 7009)
+4. GET  /oauth/authorize?client_id&redirect_uri  → 302 to /app/oauth/authorize (SPA mediation, Phase 7.A)
+5. SPA reads URL params, fetches /api/oauth/clients/:id for client_name, renders consent
+6. POST /api/oauth/authorize/consent {vault_choice} → JSON {redirect_uri: "..."} (SPA window.location)
+7. POST /oauth/token grant=authorization_code    → access_token + refresh_token
+8. POST /api/mcp Authorization: Bearer ...       → tool calls (vault-locked)
+9. POST /oauth/token grant=refresh_token         → rotated tokens (RFC 6749 §10.4 family)
+10. POST /oauth/revoke                           → 200 always (RFC 7009)
 ```
 
 ## Endpoint reference
@@ -25,8 +26,9 @@ Plan: `docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md`. Shipped in PRs #91-#
 | `GET /.well-known/oauth-protected-resource` | none | RFC 9728 — points clients at `/api/mcp` + lists auth server |
 | `GET /.well-known/oauth-authorization-server` | none | RFC 8414 — server metadata (endpoints, grant types, PKCE S256, scopes) |
 | `POST /oauth/register` | none, rate-limited 10/IP/min | RFC 7591 DCR — public PKCE clients only (no `client_secret`) |
-| `GET /oauth/authorize` | Bearer JWT | Validates request, server-renders consent w/ vault picker |
-| `POST /oauth/authorize` | Bearer JWT | Mints code, 302s redirect_uri+code+state |
+| `GET /oauth/authorize` | none, rate-limited 10/IP/min | Validates request, 302s to `/app/oauth/authorize` (SPA mediation, Phase 7.A) |
+| `GET /api/oauth/clients/:client_id` | none, rate-limited 10/IP/min | Public client metadata — `{client_id, client_name}` only, for SPA consent UI |
+| `POST /api/oauth/authorize/consent` | Bearer JWT | SPA submits w/ `vault_choice`. Mints code. JSON `{redirect_uri: "..."}` for SPA `window.location` |
 | `POST /oauth/token` | none, rate-limited 10/IP/min | RFC 6749 §3.2 — auth code → tokens, refresh → rotated tokens |
 | `POST /oauth/revoke` | none, rate-limited 10/IP/min | RFC 7009 — 200 always |
 
@@ -83,7 +85,11 @@ Phases 7-9 of the plan are smoke/conformance tests against:
 - Real Claude desktop Connectors UI (`app.engram.page` + `engram.ax`)
 - Cursor / Continue / ChatGPT custom GPT (cross-client conformance)
 
-These need a live deployment after the PRs land. UX gap: today both `/oauth/authorize` verbs require a Bearer JWT (works in tests, doesn't work for a real browser without the SPA mediating). Phase 7 is when we wire the SPA path or a real cookie session.
+These need a live deployment after the PRs land.
+
+**Phase 7.A (shipped) — SPA mediation:** `GET /oauth/authorize` is now public. It validates client_id + redirect_uri + PKCE then 302s the browser to `/app/oauth/authorize?<all-params-preserved>`. The React SPA reads the URL params, fetches `/api/oauth/clients/:client_id` to display the client name, renders a consent UI under the user's existing Clerk JWT session, and POSTs `/api/oauth/authorize/consent` with `vault_choice` + the full param set. The backend mints the code and returns JSON `{redirect_uri: "..."}` so the SPA does `window.location.assign(json.redirect_uri)`.
+
+**Phase 7.B (in flight)** ships the actual React consent page. **7.C** is the live Connectors walk-through.
 
 ## Failed approaches (none yet)
 

--- a/lib/engram_web/controllers/oauth_authorize_controller.ex
+++ b/lib/engram_web/controllers/oauth_authorize_controller.ex
@@ -114,6 +114,4 @@ defmodule EngramWeb.OAuthAuthorizeController do
     |> String.replace("\"", "&quot;")
     |> String.replace("'", "&#39;")
   end
-
-  defp html_escape(other), do: html_escape(to_string(other))
 end

--- a/lib/engram_web/controllers/oauth_authorize_controller.ex
+++ b/lib/engram_web/controllers/oauth_authorize_controller.ex
@@ -2,24 +2,33 @@ defmodule EngramWeb.OAuthAuthorizeController do
   @moduledoc """
   Authorization endpoint for OAuth 2.1 (RFC 6749 §4.1 + RFC 7636 PKCE).
 
-  GET renders a server-side consent page (vault picker). POST handles
-  the consent submission, mints an authorization code, and 302s back to
-  the client's `redirect_uri` with `code` + `state`.
+  Phase 7.A — SPA mediation:
 
-  Both verbs require an authenticated user (`Authorization: Bearer ...`)
-  via the existing `EngramWeb.Plugs.Auth`. Browser cookie session for
-  unauth'd users is handled in Phase 7 (consent UX iteration); today
-  the SPA acts as the user-agent that mediates this flow.
+    * `GET /oauth/authorize` is **public**. It validates client_id,
+      redirect_uri, response_type, PKCE, and scope, then 302s to
+      `/app/oauth/authorize?<all-params>`. Browsers don't carry
+      `Authorization: Bearer ...` on navigations, so the React SPA
+      mediates consent under the user's existing JWT session.
+
+    * `POST /api/oauth/authorize/consent` is **user-authenticated**
+      (Bearer JWT). The SPA submits the same params plus `vault_choice`
+      after the consent UI is approved, the controller mints an
+      authorization code, and returns JSON `{redirect_uri: "..."}` so
+      the SPA can `window.location.assign` back to the OAuth client.
   """
   use EngramWeb, :controller
 
   alias Engram.OAuth
-  alias Engram.Vaults
+
+  # Params we forward to the SPA consent route. RFC 8707 `resource` is
+  # pass-through (no validation today; deferred per Phase 7.A plan).
+  @forwarded_params ~w(client_id redirect_uri response_type code_challenge
+                       code_challenge_method scope state resource)
 
   def show(conn, params) do
     case OAuth.validate_authorization_request(params) do
       {:ok, validated} ->
-        render_consent(conn, validated)
+        redirect_to_spa(conn, validated, params)
 
       {:client_error, code} ->
         render_client_error(conn, code)
@@ -29,7 +38,7 @@ defmodule EngramWeb.OAuthAuthorizeController do
     end
   end
 
-  def submit(conn, params) do
+  def consent(conn, params) do
     user = conn.assigns.current_user
 
     case OAuth.validate_authorization_request(params) do
@@ -38,104 +47,38 @@ defmodule EngramWeb.OAuthAuthorizeController do
 
         case OAuth.mint_authorization_code(user, validated, vault_choice) do
           {:ok, redirect_url} ->
-            conn |> put_status(302) |> redirect(external: redirect_url)
+            json(conn, %{redirect_uri: redirect_url})
 
           {:redirect_error, redirect_uri, error, state} ->
-            redirect_with_error(conn, redirect_uri, error, state)
+            json(conn, %{redirect_uri: build_error_url(redirect_uri, error, state)})
 
           {:error, _changeset} ->
-            redirect_with_error(conn, validated.redirect_uri, "server_error", validated.state)
+            json(conn, %{
+              redirect_uri:
+                build_error_url(validated.redirect_uri, "server_error", validated.state)
+            })
         end
 
       {:client_error, code} ->
-        render_client_error(conn, code)
+        conn
+        |> put_status(400)
+        |> json(%{error: code})
 
       {:redirect_error, redirect_uri, error, state} ->
-        redirect_with_error(conn, redirect_uri, error, state)
+        json(conn, %{redirect_uri: build_error_url(redirect_uri, error, state)})
     end
   end
 
-  defp render_consent(conn, validated) do
-    user = conn.assigns.current_user
-    vaults = Vaults.list_vaults(user)
+  defp redirect_to_spa(conn, _validated, raw_params) do
+    forwarded =
+      raw_params
+      |> Map.take(@forwarded_params)
+      |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
 
-    conn
-    |> put_resp_content_type("text/html")
-    |> send_resp(200, consent_html(validated, vaults, user))
+    location = "/app/oauth/authorize?" <> URI.encode_query(forwarded)
+
+    conn |> put_status(302) |> redirect(to: location)
   end
-
-  defp consent_html(validated, vaults, user) do
-    """
-    <!doctype html>
-    <html>
-    <head>
-      <meta charset="utf-8">
-      <title>Authorize #{html_escape(validated.client_name)} — Engram</title>
-      <style>
-        body { font-family: system-ui, sans-serif; max-width: 480px; margin: 4rem auto; padding: 1rem; }
-        h1 { font-size: 1.25rem; }
-        fieldset { border: 1px solid #ccc; padding: 1rem; margin: 1rem 0; }
-        legend { font-weight: 600; }
-        label { display: block; padding: 0.25rem 0; }
-        button { padding: 0.5rem 1rem; font-size: 1rem; cursor: pointer; }
-      </style>
-    </head>
-    <body>
-      <h1>Authorize <strong>#{html_escape(validated.client_name || "this app")}</strong> to access your Engram</h1>
-      <p>Signed in as #{html_escape(user.email)}.</p>
-      <form action="/oauth/authorize" method="post">
-        #{hidden(validated)}
-        <fieldset>
-          <legend>Which vault?</legend>
-          #{vault_radios(vaults)}
-          <label>
-            <input type="radio" name="vault_choice" value="vault:*" checked>
-            All vaults
-          </label>
-        </fieldset>
-        <button type="submit">Approve</button>
-      </form>
-    </body>
-    </html>
-    """
-  end
-
-  defp hidden(validated) do
-    [
-      {"client_id", validated.client_id},
-      {"redirect_uri", validated.redirect_uri},
-      {"response_type", "code"},
-      {"code_challenge", validated.code_challenge},
-      {"code_challenge_method", validated.code_challenge_method},
-      {"scope", validated.scope},
-      {"state", validated.state}
-    ]
-    |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
-    |> Enum.map_join("\n", fn {k, v} ->
-      ~s(<input type="hidden" name="#{k}" value="#{html_escape(v)}">)
-    end)
-  end
-
-  defp vault_radios([]), do: ""
-
-  defp vault_radios(vaults) do
-    Enum.map_join(vaults, "\n", fn v ->
-      ~s(<label><input type="radio" name="vault_choice" value="vault:#{v.id}"> #{html_escape(v.slug)}</label>)
-    end)
-  end
-
-  defp html_escape(nil), do: ""
-
-  defp html_escape(s) when is_binary(s) do
-    s
-    |> String.replace("&", "&amp;")
-    |> String.replace("<", "&lt;")
-    |> String.replace(">", "&gt;")
-    |> String.replace("\"", "&quot;")
-    |> String.replace("'", "&#39;")
-  end
-
-  defp html_escape(other), do: html_escape(to_string(other))
 
   defp render_client_error(conn, code) do
     body = """
@@ -153,10 +96,24 @@ defmodule EngramWeb.OAuthAuthorizeController do
   end
 
   defp redirect_with_error(conn, redirect_uri, error, state) do
-    params = %{error: error, state: state} |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
-    sep = if String.contains?(redirect_uri, "?"), do: "&", else: "?"
-    location = redirect_uri <> sep <> URI.encode_query(params)
-
+    location = build_error_url(redirect_uri, error, state)
     conn |> put_status(302) |> redirect(external: location)
   end
+
+  defp build_error_url(redirect_uri, error, state) do
+    params = %{error: error, state: state} |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
+    sep = if String.contains?(redirect_uri, "?"), do: "&", else: "?"
+    redirect_uri <> sep <> URI.encode_query(params)
+  end
+
+  defp html_escape(s) when is_binary(s) do
+    s
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'", "&#39;")
+  end
+
+  defp html_escape(other), do: html_escape(to_string(other))
 end

--- a/lib/engram_web/controllers/oauth_clients_controller.ex
+++ b/lib/engram_web/controllers/oauth_clients_controller.ex
@@ -1,0 +1,27 @@
+defmodule EngramWeb.OAuthClientsController do
+  @moduledoc """
+  Public read-only metadata for registered OAuth clients.
+
+  The SPA consent UI (`/app/oauth/authorize`) calls this to render
+  *"Authorize **<client_name>** to access your Engram"* without
+  exposing the human-readable name in the URL bar.
+
+  Surfaces only `client_id` + `client_name`. Never `client_secret`,
+  `redirect_uris`, or scope metadata. Public — `client_id` is itself
+  public (returned by DCR), and `client_name` is non-secret. Rate
+  limited at the router level to deter enumeration.
+  """
+  use EngramWeb, :controller
+
+  alias Engram.OAuth
+
+  def show(conn, %{"client_id" => client_id}) do
+    case OAuth.get_client(client_id) do
+      {:ok, client} ->
+        json(conn, %{client_id: client.client_id, client_name: client.client_name})
+
+      {:error, :not_found} ->
+        conn |> put_status(404) |> json(%{error: "not_found"})
+    end
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -51,13 +51,15 @@ defmodule EngramWeb.Router do
     post "/revoke", OAuthRevokeController, :revoke
   end
 
-  # OAuth 2.1 user-facing authorize endpoint. Requires an authenticated
-  # session (Bearer JWT today; Phase 7 wires browser cookie session).
+  # OAuth 2.1 user-facing authorize endpoint (RFC 6749 §4.1.1).
+  # PUBLIC: browsers hit this via 302 from the OAuth client and do not
+  # carry Bearer headers on navigation. The controller validates client
+  # credentials + PKCE then 302s to the SPA at /app/oauth/authorize,
+  # which mediates consent under the user's existing JWT session.
   scope "/oauth", EngramWeb do
-    pipe_through [:api, EngramWeb.Plugs.Auth]
+    pipe_through :oauth_api
 
     get "/authorize", OAuthAuthorizeController, :show
-    post "/authorize", OAuthAuthorizeController, :submit
   end
 
   # All API routes under /api prefix
@@ -119,6 +121,21 @@ defmodule EngramWeb.Router do
     get "/billing/status", BillingController, :status
     post "/billing/checkout-session", BillingController, :create_checkout
     get "/billing/portal", BillingController, :customer_portal
+
+    # OAuth consent (Phase 7.A): SPA POSTs here with the user's Bearer
+    # JWT after the React consent UI is approved. Returns JSON
+    # `{redirect_uri: "..."}` so the SPA can `window.location.assign`.
+    post "/oauth/authorize/consent", OAuthAuthorizeController, :consent
+  end
+
+  # OAuth public client metadata — surfaces `client_name` to the SPA
+  # consent UI without exposing it in the redirect URL bar. Public
+  # because client_id is itself public (returned by DCR); client_name
+  # is non-secret. Rate-limited per IP to deter enumeration.
+  scope "/api/oauth", EngramWeb do
+    pipe_through [:api, :rate_limit_auth]
+
+    get "/clients/:client_id", OAuthClientsController, :show
   end
 
   # Vault-scoped authenticated endpoints (VaultPlug resolves current_vault)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.57",
+      version: "0.5.58",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/static/css/marketing.css
+++ b/priv/static/css/marketing.css
@@ -253,9 +253,6 @@
   .grid {
     display: grid;
   }
-  .hidden {
-    display: none;
-  }
   .inline-block {
     display: inline-block;
   }

--- a/test/engram_web/controllers/oauth_authorize_controller_test.exs
+++ b/test/engram_web/controllers/oauth_authorize_controller_test.exs
@@ -43,36 +43,82 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
     }
   end
 
-  describe "GET /oauth/authorize — unauthenticated" do
-    test "returns 401 when no Authorization header is present", %{conn: conn} do
+  # ──────────────────────────────────────────────────────────────────
+  # GET /oauth/authorize — Phase 7.A: now PUBLIC (browser navigation,
+  # no Bearer header on 302). Validates request, then 302s to the SPA
+  # at /app/oauth/authorize?<all-params>. Invalid client/redirect still
+  # returns 400 HTML (no redirect — code-leak prevention).
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "GET /oauth/authorize — happy path (PUBLIC, no auth required)" do
+    test "redirects to /app/oauth/authorize with all params preserved", %{conn: conn} do
       client = register_client()
-      params = valid_params(client.client_id, hd(client.redirect_uris))
+      redirect_uri = hd(client.redirect_uris)
+      params = valid_params(client.client_id, redirect_uri)
 
       conn = get(conn, "/oauth/authorize", params)
-      assert conn.status == 401
+
+      assert conn.status == 302
+      [location] = get_resp_header(conn, "location")
+
+      uri = URI.parse(location)
+      assert uri.path == "/app/oauth/authorize"
+
+      query = URI.decode_query(uri.query)
+      assert query["client_id"] == client.client_id
+      assert query["redirect_uri"] == redirect_uri
+      assert query["response_type"] == "code"
+      assert query["code_challenge"] == "abc123challenge"
+      assert query["code_challenge_method"] == "S256"
+      assert query["state"] == "xyz"
+      assert query["scope"] == "mcp"
+    end
+
+    test "preserves resource param (RFC 8707) pass-through", %{conn: conn} do
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("resource", "https://app.engram.page/api/mcp")
+
+      conn = get(conn, "/oauth/authorize", params)
+
+      assert conn.status == 302
+      [location] = get_resp_header(conn, "location")
+      query = location |> URI.parse() |> Map.get(:query) |> URI.decode_query()
+      assert query["resource"] == "https://app.engram.page/api/mcp"
+    end
+
+    test "does NOT require Authorization: Bearer header", %{conn: conn} do
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      params = valid_params(client.client_id, redirect_uri)
+
+      conn = get(conn, "/oauth/authorize", params)
+
+      refute conn.status == 401
+      assert conn.status == 302
     end
   end
 
   describe "GET /oauth/authorize — invalid client" do
     test "returns 400 HTML when client_id is unknown", %{conn: conn} do
-      user = insert(:user)
+      params = valid_params("00000000-0000-0000-0000-000000000000", "https://x/cb")
 
-      params =
-        valid_params("00000000-0000-0000-0000-000000000000", "https://x/cb")
-
-      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+      conn = get(conn, "/oauth/authorize", params)
 
       assert conn.status == 400
       assert conn.resp_body =~ "invalid_client"
     end
 
     test "returns 400 HTML when redirect_uri does not match registration", %{conn: conn} do
-      user = insert(:user)
       client = register_client("https://claude.ai/api/mcp/auth_callback")
 
       params = valid_params(client.client_id, "https://attacker.example/cb")
 
-      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+      conn = get(conn, "/oauth/authorize", params)
 
       assert conn.status == 400
       assert conn.resp_body =~ "invalid_redirect_uri"
@@ -81,7 +127,6 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
 
   describe "GET /oauth/authorize — bad params (redirect with error)" do
     test "redirects to redirect_uri?error=unsupported_response_type when not code", %{conn: conn} do
-      user = insert(:user)
       client = register_client()
       redirect_uri = hd(client.redirect_uris)
 
@@ -90,7 +135,7 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
         |> valid_params(redirect_uri)
         |> Map.put("response_type", "token")
 
-      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+      conn = get(conn, "/oauth/authorize", params)
 
       assert conn.status == 302
       [location] = get_resp_header(conn, "location")
@@ -100,7 +145,6 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
     end
 
     test "redirects with invalid_request when code_challenge missing", %{conn: conn} do
-      user = insert(:user)
       client = register_client()
       redirect_uri = hd(client.redirect_uris)
 
@@ -109,7 +153,7 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
         |> valid_params(redirect_uri)
         |> Map.delete("code_challenge")
 
-      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+      conn = get(conn, "/oauth/authorize", params)
 
       assert conn.status == 302
       [location] = get_resp_header(conn, "location")
@@ -117,7 +161,6 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
     end
 
     test "redirects with invalid_request when code_challenge_method is plain", %{conn: conn} do
-      user = insert(:user)
       client = register_client()
       redirect_uri = hd(client.redirect_uris)
 
@@ -126,7 +169,7 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
         |> valid_params(redirect_uri)
         |> Map.put("code_challenge_method", "plain")
 
-      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+      conn = get(conn, "/oauth/authorize", params)
 
       assert conn.status == 302
       [location] = get_resp_header(conn, "location")
@@ -134,26 +177,29 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
     end
   end
 
-  describe "GET /oauth/authorize — happy path" do
-    test "renders consent page with client name and vault picker", %{conn: conn} do
-      user = insert(:user)
-      _vault = insert(:vault, user: user, slug: "personal")
+  # ──────────────────────────────────────────────────────────────────
+  # POST /api/oauth/authorize/consent — Phase 7.A: SPA submits this
+  # with the user's Bearer JWT after the consent UI is approved.
+  # Returns JSON {redirect_uri: "..."} so the SPA can window.location.
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "POST /api/oauth/authorize/consent — auth required" do
+    test "returns 401 when no Authorization header is present", %{conn: conn} do
       client = register_client()
-      params = valid_params(client.client_id, hd(client.redirect_uris))
+      redirect_uri = hd(client.redirect_uris)
 
-      conn = conn |> jwt_authed(user) |> get("/oauth/authorize", params)
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("vault_choice", "vault:*")
 
-      assert html_response(conn, 200)
-      assert conn.resp_body =~ "Claude"
-      assert conn.resp_body =~ "personal"
-      assert conn.resp_body =~ "All vaults"
-      assert conn.resp_body =~ ~s(action="/oauth/authorize")
-      assert conn.resp_body =~ ~s(method="post")
+      conn = post(conn, "/api/oauth/authorize/consent", params)
+      assert conn.status == 401
     end
   end
 
-  describe "POST /oauth/authorize — happy path" do
-    test "mints a code and redirects to redirect_uri with code + state", %{conn: conn} do
+  describe "POST /api/oauth/authorize/consent — happy path" do
+    test "mints a code and returns JSON redirect_uri with code + state", %{conn: conn} do
       user = insert(:user)
       vault = insert(:vault, user: user)
       client = register_client()
@@ -164,18 +210,18 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
         |> valid_params(redirect_uri)
         |> Map.put("vault_choice", "vault:#{vault.id}")
 
-      conn = conn |> jwt_authed(user) |> post("/oauth/authorize", params)
+      conn = conn |> jwt_authed(user) |> post("/api/oauth/authorize/consent", params)
 
-      assert conn.status == 302
-      [location] = get_resp_header(conn, "location")
-      assert String.starts_with?(location, redirect_uri)
+      assert conn.status == 200
+      json = Jason.decode!(conn.resp_body)
+      assert is_binary(json["redirect_uri"])
+      assert String.starts_with?(json["redirect_uri"], redirect_uri)
 
-      uri = URI.parse(location)
+      uri = URI.parse(json["redirect_uri"])
       query = URI.decode_query(uri.query)
       assert query["state"] == "xyz"
       assert is_binary(query["code"]) and byte_size(query["code"]) > 16
 
-      # Code persisted
       assert {:ok, code_row} = OAuth.get_authorization_code_by_raw(query["code"])
       assert code_row.user_id == user.id
       assert code_row.client_id == client.client_id
@@ -183,7 +229,7 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
       assert code_row.scope == "mcp"
     end
 
-    test "mints a code with vault_id=nil when vault_choice=all", %{conn: conn} do
+    test "mints code with vault_id=nil when vault_choice=vault:*", %{conn: conn} do
       user = insert(:user)
       _vault = insert(:vault, user: user)
       client = register_client()
@@ -194,18 +240,21 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
         |> valid_params(redirect_uri)
         |> Map.put("vault_choice", "vault:*")
 
-      conn = conn |> jwt_authed(user) |> post("/oauth/authorize", params)
+      conn = conn |> jwt_authed(user) |> post("/api/oauth/authorize/consent", params)
 
-      assert conn.status == 302
-      [location] = get_resp_header(conn, "location")
-      uri = URI.parse(location)
+      assert conn.status == 200
+      json = Jason.decode!(conn.resp_body)
+      uri = URI.parse(json["redirect_uri"])
       query = URI.decode_query(uri.query)
 
       assert {:ok, code_row} = OAuth.get_authorization_code_by_raw(query["code"])
       assert is_nil(code_row.vault_id)
     end
+  end
 
-    test "rejects vault_choice that does not belong to the user", %{conn: conn} do
+  describe "POST /api/oauth/authorize/consent — vault ownership" do
+    test "returns 200 with redirect_uri carrying ?error=access_denied when vault not owned",
+         %{conn: conn} do
       user = insert(:user)
       other = insert(:user)
       other_vault = insert(:vault, user: other)
@@ -217,16 +266,58 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
         |> valid_params(redirect_uri)
         |> Map.put("vault_choice", "vault:#{other_vault.id}")
 
-      conn = conn |> jwt_authed(user) |> post("/oauth/authorize", params)
+      conn = conn |> jwt_authed(user) |> post("/api/oauth/authorize/consent", params)
 
-      assert conn.status == 302
-      [location] = get_resp_header(conn, "location")
-      assert location =~ "error=access_denied"
+      assert conn.status == 200
+      json = Jason.decode!(conn.resp_body)
+      assert String.starts_with?(json["redirect_uri"], redirect_uri)
+      assert json["redirect_uri"] =~ "error=access_denied"
+      assert json["redirect_uri"] =~ "state=xyz"
     end
   end
 
-  describe "POST /oauth/authorize — unauthenticated" do
-    test "returns 401 when no Authorization header is present", %{conn: conn} do
+  describe "POST /api/oauth/authorize/consent — invalid request" do
+    test "invalid client_id returns 400 JSON (no redirect — code-leak prevention)", %{conn: conn} do
+      user = insert(:user)
+
+      params =
+        valid_params("00000000-0000-0000-0000-000000000000", "https://x/cb")
+        |> Map.put("vault_choice", "vault:*")
+
+      conn = conn |> jwt_authed(user) |> post("/api/oauth/authorize/consent", params)
+
+      assert conn.status == 400
+      json = Jason.decode!(conn.resp_body)
+      assert json["error"] == "invalid_client"
+    end
+
+    test "missing code_challenge returns redirect_uri with error in JSON", %{conn: conn} do
+      user = insert(:user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.delete("code_challenge")
+        |> Map.put("vault_choice", "vault:*")
+
+      conn = conn |> jwt_authed(user) |> post("/api/oauth/authorize/consent", params)
+
+      assert conn.status == 200
+      json = Jason.decode!(conn.resp_body)
+      assert String.starts_with?(json["redirect_uri"], redirect_uri)
+      assert json["redirect_uri"] =~ "error=invalid_request"
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────
+  # POST /oauth/authorize — RETIRED in Phase 7.A. The SPA uses
+  # /api/oauth/authorize/consent with Bearer JWT instead.
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "POST /oauth/authorize — retired" do
+    test "old route no longer matches (returns 404)", %{conn: conn} do
       client = register_client()
       redirect_uri = hd(client.redirect_uris)
 
@@ -236,7 +327,7 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
         |> Map.put("vault_choice", "vault:*")
 
       conn = post(conn, "/oauth/authorize", params)
-      assert conn.status == 401
+      assert conn.status == 404
     end
   end
 end

--- a/test/engram_web/controllers/oauth_clients_controller_test.exs
+++ b/test/engram_web/controllers/oauth_clients_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule EngramWeb.OAuthClientsControllerTest do
+  use EngramWeb.ConnCase, async: true
+
+  alias Engram.OAuth
+
+  defp register_client(name \\ "Claude") do
+    {:ok, client} =
+      OAuth.register_client(%{
+        "redirect_uris" => ["https://claude.ai/api/mcp/auth_callback"],
+        "client_name" => name
+      })
+
+    client
+  end
+
+  describe "GET /api/oauth/clients/:client_id" do
+    test "returns client_id + client_name only (no secret, no redirect_uris)", %{conn: conn} do
+      client = register_client("My App")
+
+      conn = get(conn, "/api/oauth/clients/#{client.client_id}")
+
+      assert conn.status == 200
+      json = Jason.decode!(conn.resp_body)
+
+      assert json["client_id"] == client.client_id
+      assert json["client_name"] == "My App"
+      assert Map.keys(json) |> Enum.sort() == ["client_id", "client_name"]
+    end
+
+    test "does not require Authorization header (public endpoint)", %{conn: conn} do
+      client = register_client()
+
+      conn = get(conn, "/api/oauth/clients/#{client.client_id}")
+
+      refute conn.status == 401
+      assert conn.status == 200
+    end
+
+    test "returns 404 for unknown client_id (UUID-shaped)", %{conn: conn} do
+      conn = get(conn, "/api/oauth/clients/00000000-0000-0000-0000-000000000000")
+
+      assert conn.status == 404
+      json = Jason.decode!(conn.resp_body)
+      assert json["error"] == "not_found"
+    end
+
+    test "returns 404 for non-UUID client_id (no enumeration leak)", %{conn: conn} do
+      conn = get(conn, "/api/oauth/clients/not-a-uuid")
+
+      assert conn.status == 404
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Make `GET /oauth/authorize` public (browsers can't send Bearer on 302); validate request and 302 to React SPA at `/app/oauth/authorize?<params>`
- Add `POST /api/oauth/authorize/consent` (Bearer-auth) — SPA submits vault_choice, mints code, returns JSON `{redirect_uri}` for `window.location.assign`
- Add `GET /api/oauth/clients/:client_id` (public, rate-limited) — surfaces `{client_id, client_name}` only, lets SPA render consent UI without leaking name in URL bar
- Retire `POST /oauth/authorize` and the inline server-rendered HTML consent template
- 19 new controller tests; full suite 1108/0 green; `mix credo --strict` + `--warnings-as-errors` clean

## Why this matters

The first real Claude Connectors UI test failed at step 3 (browser redirect to `/oauth/authorize` returned 401) because Phase 3's controller required `Authorization: Bearer ...` on a *user-agent endpoint* per RFC 6749 §4.1.1. Browsers don't carry that header on 302 navigations. Plan + this PR ship the smallest fix that doesn't require building first-party `Plug.Session` infra — SPA mediation under the existing Clerk JWT session.

## Decisions baked in (from plan Q1–Q5)

- **client_name surface:** new public `GET /api/oauth/clients/:id` endpoint
- **`resource` (RFC 8707):** pass-through, no validation
- **Cancel UX:** RFC-compliant `?error=access_denied&state=...` (SPA wires this in 7.B)
- **Dead consent HTML:** deleted

## Deployment risk

`/oauth/authorize` now 302s to `/app/oauth/authorize`, which is the SPA route that ships in **7.B**. If 7.A merges and deploys without 7.B, any in-flight Connectors flow hits a SPA 404 between deploys. **Mitigation: ship 7.A and 7.B back-to-back same day.** Fall back to env-flagged redirect target if 7.B can't ship same day.

## Test plan

- [x] `mix test` — 1108 pass, 0 fail
- [x] `mix credo --strict` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix compile --warnings-as-errors` — clean
- [ ] Live smoke after 7.B deploy: Claude Desktop → Connectors → `https://app.engram.page/api/mcp` → discovery + DCR + browser redirect → SPA consent → approve → token → `list_notes` returns

## Refs

- Plan: `docs/superpowers/plans/2026-05-10-mcp-oauth-phase-7-spa-mediation.md`
- Context doc: `docs/context/mcp-oauth.md` (updated wire flow + endpoint table)
- Failed first attempt observed: 2026-05-10 02:00 UTC, redirect URL captured in plan Context section

🤖 Generated with [Claude Code](https://claude.com/claude-code)