### PR TITLE
feat(oauth): Phase 7.B — React consent page for /app/oauth/authorize

### DIFF
--- a/frontend/src/api/oauth.ts
+++ b/frontend/src/api/oauth.ts
@@ -1,0 +1,37 @@
+import { api } from './client'
+
+export interface OAuthClientMetadata {
+  client_id: string
+  client_name: string
+}
+
+export interface OAuthConsentParams {
+  client_id: string
+  redirect_uri: string
+  response_type: string
+  code_challenge: string
+  code_challenge_method: string
+  state: string
+  scope: string
+  resource?: string
+  vault_choice: string
+}
+
+export interface OAuthConsentResponse {
+  redirect_uri: string
+}
+
+export async function fetchOAuthClient(clientId: string): Promise<OAuthClientMetadata> {
+  return fetch(`/api/oauth/clients/${encodeURIComponent(clientId)}`).then(async (res) => {
+    if (!res.ok) {
+      throw new Error(`oauth client lookup failed: ${res.status}`)
+    }
+    return res.json()
+  })
+}
+
+export async function postOAuthConsent(
+  params: OAuthConsentParams,
+): Promise<OAuthConsentResponse> {
+  return api.post<OAuthConsentResponse>('/oauth/authorize/consent', params)
+}

--- a/frontend/src/auth/auth-guard.tsx
+++ b/frontend/src/auth/auth-guard.tsx
@@ -1,15 +1,21 @@
-import { Navigate, Outlet } from 'react-router'
+import { Navigate, Outlet, useLocation } from 'react-router'
 import { useAuthAdapter } from './use-auth-adapter'
 
 export default function AuthGuard() {
   const { isLoaded, isSignedIn } = useAuthAdapter()
+  const location = useLocation()
 
   if (!isLoaded) {
     return <p>Loading...</p>
   }
 
   if (!isSignedIn) {
-    return <Navigate to="/sign-in" replace />
+    const returnTo = location.pathname + location.search + location.hash
+    const target =
+      returnTo && returnTo !== '/'
+        ? `/sign-in?return_to=${encodeURIComponent(returnTo)}`
+        : '/sign-in'
+    return <Navigate to={target} replace />
   }
 
   return <Outlet />

--- a/frontend/src/auth/local-sign-in.tsx
+++ b/frontend/src/auth/local-sign-in.tsx
@@ -1,10 +1,17 @@
 import { useState, useEffect, type FormEvent } from 'react'
-import { Link, useNavigate } from 'react-router'
+import { Link, useNavigate, useSearchParams } from 'react-router'
 import { useAuthAdapter } from './use-auth-adapter'
+
+function safeReturnTo(raw: string | null): string {
+  if (!raw || !raw.startsWith('/') || raw.startsWith('//')) return '/'
+  return raw
+}
 
 export default function LocalSignIn() {
   const { login, isSignedIn } = useAuthAdapter()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const returnTo = safeReturnTo(searchParams.get('return_to'))
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -12,8 +19,8 @@ export default function LocalSignIn() {
 
   // Navigate after auth state propagates (React 18 batching)
   useEffect(() => {
-    if (isSignedIn) navigate('/', { replace: true })
-  }, [isSignedIn, navigate])
+    if (isSignedIn) navigate(returnTo, { replace: true })
+  }, [isSignedIn, navigate, returnTo])
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()

--- a/frontend/src/auth/sign-in.tsx
+++ b/frontend/src/auth/sign-in.tsx
@@ -1,26 +1,39 @@
 import { lazy, Suspense } from 'react'
+import { useSearchParams } from 'react-router'
 import { config } from '../config'
 
 const isClerk = config.authProvider === 'clerk'
 
+// Reject return_to values that aren't a SPA-relative path. Prevents
+// open-redirect via /app/sign-in?return_to=https://attacker/...
+function safeReturnTo(raw: string | null): string {
+  if (!raw) return '/'
+  if (!raw.startsWith('/')) return '/'
+  if (raw.startsWith('//')) return '/'
+  return raw
+}
+
 const ClerkSignInPage = isClerk
   ? lazy(() =>
       import('@clerk/clerk-react').then((mod) => ({
-        default: () => (
+        default: ({ returnTo }: { returnTo: string }) => (
           <main style={{ display: 'flex', justifyContent: 'center', paddingTop: '4rem' }}>
-            <mod.SignIn routing="hash" forceRedirectUrl="/app" />
+            <mod.SignIn routing="hash" forceRedirectUrl={`/app${returnTo}`} />
           </main>
         ),
-      }))
+      })),
     )
   : null
 
 const LocalSignIn = lazy(() => import('./local-sign-in'))
 
 export default function SignInPage() {
+  const [searchParams] = useSearchParams()
+  const returnTo = safeReturnTo(searchParams.get('return_to'))
+
   return (
     <Suspense fallback={<p>Loading...</p>}>
-      {ClerkSignInPage ? <ClerkSignInPage /> : <LocalSignIn />}
+      {ClerkSignInPage ? <ClerkSignInPage returnTo={returnTo} /> : <LocalSignIn />}
     </Suspense>
   )
 }

--- a/frontend/src/oauth/oauth-authorize-page.tsx
+++ b/frontend/src/oauth/oauth-authorize-page.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import {
+  fetchOAuthClient,
+  postOAuthConsent,
+  type OAuthConsentParams,
+} from '../api/oauth'
+import { useVaults, useMe } from '../api/queries'
+
+const REQUIRED_PARAMS = [
+  'client_id',
+  'redirect_uri',
+  'response_type',
+  'code_challenge',
+  'code_challenge_method',
+  'state',
+  'scope',
+] as const
+
+type RequiredParam = (typeof REQUIRED_PARAMS)[number]
+
+function readParams(search: URLSearchParams): {
+  values: Record<RequiredParam, string>
+  resource: string | null
+  missing: RequiredParam[]
+} {
+  const values = {} as Record<RequiredParam, string>
+  const missing: RequiredParam[] = []
+
+  for (const key of REQUIRED_PARAMS) {
+    const v = search.get(key)
+    if (!v) {
+      missing.push(key)
+    } else {
+      values[key] = v
+    }
+  }
+
+  return { values, resource: search.get('resource'), missing }
+}
+
+function buildCancelUrl(redirectUri: string, state: string): string {
+  const sep = redirectUri.includes('?') ? '&' : '?'
+  return `${redirectUri}${sep}error=access_denied&state=${encodeURIComponent(state)}`
+}
+
+export default function OAuthAuthorizePage() {
+  const [searchParams] = useSearchParams()
+  const { values, resource, missing } = readParams(searchParams)
+
+  const clientQuery = useQuery({
+    queryKey: ['oauth-client', values.client_id],
+    queryFn: () => fetchOAuthClient(values.client_id),
+    enabled: missing.length === 0 && !!values.client_id,
+    retry: false,
+  })
+
+  const meQuery = useMe()
+  const vaultsQuery = useVaults()
+
+  const [vaultChoice, setVaultChoice] = useState<string>('vault:*')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (vaultChoice === 'vault:*' || !vaultsQuery.data) return
+    if (vaultChoice.startsWith('vault:')) {
+      const id = vaultChoice.slice('vault:'.length)
+      const stillExists =
+        id === '*' || vaultsQuery.data.some((v) => String(v.id) === id)
+      if (!stillExists) setVaultChoice('vault:*')
+    }
+  }, [vaultsQuery.data, vaultChoice])
+
+  if (missing.length > 0) {
+    return (
+      <main style={pageStyle}>
+        <h1>Invalid authorization request</h1>
+        <p>Missing required OAuth parameters:</p>
+        <ul>
+          {missing.map((m) => (
+            <li key={m}>
+              <code>{m}</code>
+            </li>
+          ))}
+        </ul>
+        <p>This page should be opened via an OAuth client redirect, not directly.</p>
+      </main>
+    )
+  }
+
+  if (clientQuery.isError) {
+    return (
+      <main style={pageStyle}>
+        <h1>Unknown OAuth client</h1>
+        <p>The client requesting access is not registered with Engram.</p>
+      </main>
+    )
+  }
+
+  const handleApprove = async () => {
+    setSubmitting(true)
+    setSubmitError(null)
+
+    const body: OAuthConsentParams = {
+      client_id: values.client_id,
+      redirect_uri: values.redirect_uri,
+      response_type: values.response_type,
+      code_challenge: values.code_challenge,
+      code_challenge_method: values.code_challenge_method,
+      state: values.state,
+      scope: values.scope,
+      vault_choice: vaultChoice,
+    }
+    if (resource) body.resource = resource
+
+    try {
+      const { redirect_uri } = await postOAuthConsent(body)
+      window.location.assign(redirect_uri)
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Authorization failed'
+      setSubmitError(message)
+      setSubmitting(false)
+    }
+  }
+
+  const handleCancel = () => {
+    window.location.assign(buildCancelUrl(values.redirect_uri, values.state))
+  }
+
+  const clientName = clientQuery.data?.client_name ?? 'this app'
+  const isLoadingShell = clientQuery.isLoading || vaultsQuery.isLoading || meQuery.isLoading
+
+  return (
+    <main style={pageStyle}>
+      <h1>
+        Authorize <strong>{clientName}</strong> to access your Engram
+      </h1>
+      {meQuery.data && <p>Signed in as {meQuery.data.email}.</p>}
+
+      {isLoadingShell ? (
+        <p>Loading…</p>
+      ) : (
+        <>
+          <fieldset style={fieldsetStyle}>
+            <legend>Which vault?</legend>
+            {vaultsQuery.data?.map((v) => (
+              <label key={v.id} style={labelStyle}>
+                <input
+                  type="radio"
+                  name="vault_choice"
+                  value={`vault:${v.id}`}
+                  checked={vaultChoice === `vault:${v.id}`}
+                  onChange={() => setVaultChoice(`vault:${v.id}`)}
+                />{' '}
+                {v.name}
+              </label>
+            ))}
+            <label style={labelStyle}>
+              <input
+                type="radio"
+                name="vault_choice"
+                value="vault:*"
+                checked={vaultChoice === 'vault:*'}
+                onChange={() => setVaultChoice('vault:*')}
+              />{' '}
+              All vaults
+            </label>
+          </fieldset>
+
+          {submitError && (
+            <p style={{ color: 'red' }} role="alert">
+              {submitError}
+            </p>
+          )}
+
+          <section style={{ display: 'flex', gap: '0.75rem', marginTop: '1rem' }}>
+            <button
+              type="button"
+              onClick={handleApprove}
+              disabled={submitting}
+              style={primaryBtn}
+            >
+              {submitting ? 'Approving…' : 'Approve'}
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={submitting}
+              style={secondaryBtn}
+            >
+              Cancel
+            </button>
+          </section>
+        </>
+      )}
+    </main>
+  )
+}
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 480,
+  margin: '4rem auto',
+  padding: '1rem',
+  fontFamily: 'system-ui, sans-serif',
+}
+
+const fieldsetStyle: React.CSSProperties = {
+  border: '1px solid #ccc',
+  padding: '1rem',
+  margin: '1rem 0',
+}
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  padding: '0.25rem 0',
+  cursor: 'pointer',
+}
+
+const primaryBtn: React.CSSProperties = {
+  padding: '0.5rem 1rem',
+  fontSize: '1rem',
+  cursor: 'pointer',
+}
+
+const secondaryBtn: React.CSSProperties = {
+  padding: '0.5rem 1rem',
+  fontSize: '1rem',
+  cursor: 'pointer',
+  background: 'transparent',
+  border: '1px solid #ccc',
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -9,6 +9,7 @@ import ApiKeysPage from './settings/api-keys-page'
 import BillingPlaceholder from './settings/billing-placeholder'
 import EncryptionPage from './settings/encryption-page'
 import SettingsLayout from './settings/settings-layout'
+import OAuthAuthorizePage from './oauth/oauth-authorize-page'
 import Dashboard from './viewer/dashboard'
 import NotePage from './viewer/note-page'
 import SearchPage from './viewer/search-page'
@@ -43,6 +44,7 @@ export const router = createBrowserRouter(
           ],
         },
         { path: '/link', element: <DeviceLinkPage /> },
+        { path: '/oauth/authorize', element: <OAuthAuthorizePage /> },
       ],
     },
   ],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.58",
+      version: "0.5.59",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- New `/app/oauth/authorize` route (under existing `AuthGuard`) renders the consent UI that 7.A's `GET /oauth/authorize` 302s to
- New `frontend/src/api/oauth.ts` — typed wrappers for `/api/oauth/clients/:id` + `/api/oauth/authorize/consent`
- `AuthGuard` now passes `return_to` to `/sign-in` so unauth'd Connectors flows survive the sign-in detour (plan Q4)
- Sign-in (Clerk + local) reads `return_to`, normalizes against open-redirect (must start with `/`, reject `//...`), and routes there post-auth
- Cancel does the RFC 6749 §4.1.2.1 compliant redirect (`?error=access_denied&state=...`)

## Stacked PR

This PR is **stacked on #101 (Phase 7.A)**. Base branch is `feat/oauth-phase-7-a-spa-redirect`. Once #101 merges to `main`, this branch will be rebased onto `main` and the base updated. Together 7.A + 7.B close the deployment-risk gap noted in #101 — same-day ship is the plan.

## Decisions baked in

- **client_name surface (Q1):** SPA fetches `/api/oauth/clients/:id` to render *"Authorize **<name>**..."* without leaking the name into the URL bar
- **`resource` (RFC 8707, Q2):** pass-through (read from URL params, forwarded to consent POST body)
- **Cancel UX (Q3):** RFC-compliant redirect to `redirect_uri?error=access_denied&state=...`
- **Return-to (Q4):** unauth'd users hitting `/app/oauth/authorize` now bounce to `/sign-in?return_to=<encoded>`; safe-listed to SPA-relative paths to block open-redirect

## Test plan

- [x] `bun run build` (tsc --noEmit + vite build) clean
- [ ] Local dev smoke: `bun run dev` + `mix phx.server`, hit `http://localhost:5173/app/oauth/authorize?<fake-params>` against a registered client, verify consent UI renders, vaults populate, Approve POSTs and redirects
- [ ] Live walk after both 7.A + 7.B deploy: Claude Desktop → Connectors → `https://app.engram.page/api/mcp` → discovery + DCR + browser redirect → SPA consent → Approve → token mint → first MCP tool call returns notes
- [ ] Cancel button: redirects back to client with `?error=access_denied&state=...`

## Refs

- Plan: `docs/superpowers/plans/2026-05-10-mcp-oauth-phase-7-spa-mediation.md`
- Stacked on: #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)