### PR TITLE
refactor: SPA hardening (NotFound + CSP)

### DIFF
--- a/frontend/src/not-found.tsx
+++ b/frontend/src/not-found.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router'
+
+export default function NotFoundPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
+      <p className="text-sm font-medium uppercase tracking-wide text-gray-500">404</p>
+      <h1 className="mt-2 text-2xl font-semibold text-gray-900">Page not found</h1>
+      <p className="mt-2 max-w-md text-sm text-gray-600">
+        We couldn’t find what you’re looking for. The link may be broken or the page may have moved.
+      </p>
+      <Link
+        to="/"
+        className="mt-6 inline-block rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+      >
+        Back to home
+      </Link>
+    </main>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,7 @@ import SignUpPage from './auth/sign-up'
 import BillingPage from './billing/billing-page'
 import DeviceLinkPage from './device/device-link-page'
 import AppLayout from './layout/app-layout'
+import NotFoundPage from './not-found'
 import ApiKeysPage from './settings/api-keys-page'
 import BillingPlaceholder from './settings/billing-placeholder'
 import EncryptionPage from './settings/encryption-page'
@@ -47,5 +48,8 @@ export const router = createBrowserRouter(
         { path: '/oauth/consent', element: <OAuthAuthorizePage /> },
       ],
     },
+
+    // Catch-all (public — typos shouldn't trigger Clerk redirect)
+    { path: '*', element: <NotFoundPage /> },
   ],
 )

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -22,12 +22,35 @@ defmodule EngramWeb.Router do
   # SPA shell pipeline — HTML responses with strict browser-security headers.
   # x-frame-options=DENY is critical for /oauth/consent: without it the consent
   # UI could be iframed by an attacker site and the approval click hijacked.
+  #
+  # CSP notes: script-src/style-src use 'unsafe-inline' because SpaController
+  # injects a runtime-config <script> into index.html (see
+  # EngramWeb.SpaController.config_script/0). TODO: upgrade to per-request
+  # nonces and drop 'unsafe-inline' from script-src.
+  @csp_policy Enum.join(
+                [
+                  "default-src 'self'",
+                  "script-src 'self' 'unsafe-inline' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com",
+                  "style-src 'self' 'unsafe-inline'",
+                  "img-src 'self' data: blob: https:",
+                  "font-src 'self' data:",
+                  "connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com",
+                  "frame-src https://challenges.cloudflare.com https://*.clerk.accounts.dev",
+                  "worker-src 'self' blob:",
+                  "form-action 'self'",
+                  "base-uri 'self'",
+                  "frame-ancestors 'none'"
+                ],
+                "; "
+              )
+
   pipeline :spa do
     plug :accepts, ["html"]
 
     plug :put_secure_browser_headers, %{
       "x-content-type-options" => "nosniff",
-      "x-frame-options" => "DENY"
+      "x-frame-options" => "DENY",
+      "content-security-policy" => @csp_policy
     }
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.63",
+      version: "0.5.64",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -53,6 +53,17 @@ defmodule EngramWeb.SpaControllerTest do
     assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
   end
 
+  test "SPA responses include a Content-Security-Policy header", %{conn: conn} do
+    # CSP restricts where injected JS can exfiltrate data even if script-src
+    # is permissive. Critical for /oauth/consent in particular.
+    conn = get(conn, "/oauth/consent")
+    [csp] = get_resp_header(conn, "content-security-policy")
+    assert csp =~ "default-src 'self'"
+    assert csp =~ "frame-ancestors 'none'"
+    assert csp =~ "connect-src"
+    assert csp =~ "clerk"
+  end
+
   test "GET /api/health still returns JSON (API not shadowed by SPA)", %{conn: conn} do
     conn = get(conn, "/api/health")
     assert json_response(conn, 200)


### PR DESCRIPTION
## Summary

Group A from [`docs/context/spa-flatten-followups.md`](https://github.com/Rasbandit/Engram/blob/main/docs/context/spa-flatten-followups.md) — PR #103 follow-ups.

- **NotFound page** (`frontend/src/not-found.tsx`) + top-level catch-all route. SPA typos like `/setting` now render a 404 page instead of a blank outlet. Placed outside `AuthGuard` so 404s don't trigger Clerk redirect.
- **Content-Security-Policy** on the `:spa` pipeline. Restricts `script-src` / `connect-src` / `frame-src` to self + Clerk + Cloudflare Turnstile. `frame-ancestors 'none'` double-belts the existing `x-frame-options: DENY`. `script-src`/`style-src` still allow `'unsafe-inline'` because `SpaController` injects a runtime-config inline `<script>`; nonce upgrade tracked as an inline TODO.

## Test plan

- [ ] `mix test test/engram_web/controllers/spa_controller_test.exs` (13 pass — new test asserts CSP header on `/oauth/consent`)
- [ ] `bun run tsc --noEmit` in `frontend/` (clean)
- [ ] Manually hit `/totally-fake` in built SPA → NotFound page renders, no Clerk redirect
- [ ] Manually hit `/oauth/consent` with Clerk auth → consent UI loads, no console CSP violations
- [ ] DevTools network tab confirms `content-security-policy` header on `/`, `/oauth/consent`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)