### PR TITLE
chore(ci): tighten workflow perms + rotate CI encryption key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: "main"
 
+permissions:
+  contents: read
+
 # Serialize all backend CI runs on the self-hosted runner pool. Two parallel
 # `docker compose build` invocations collide on the shared buildkit cache
 # mounts (`id=mix-deps`, `id=mix-build`) and intermittently abort with
@@ -33,7 +36,7 @@ env:
   # so the key does not protect persistent data. Production deploys must override
   # with a secret via `fly secrets set ENCRYPTION_MASTER_KEY=...`.
   KEY_PROVIDER: "local"
-  ENCRYPTION_MASTER_KEY: "vZ+e130Hffn5T1ljBb3FH1rFIKc42kTK86jmUEusLio="
+  ENCRYPTION_MASTER_KEY: ${{ secrets.CI_ENCRYPTION_MASTER_KEY }}
 
 jobs:
   version-check:

--- a/.github/workflows/obsidian-update.yml
+++ b/.github/workflows/obsidian-update.yml
@@ -14,6 +14,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   update:
     runs-on: [self-hosted, engram]

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 3 * * 0"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     runs-on: [self-hosted, engram]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -42,7 +42,7 @@ services:
       CLERK_ISSUER: ${CLERK_ISSUER:-}
       CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY:-}
       KEY_PROVIDER: ${KEY_PROVIDER:-local}
-      ENCRYPTION_MASTER_KEY: ${ENCRYPTION_MASTER_KEY:-vZ+e130Hffn5T1ljBb3FH1rFIKc42kTK86jmUEusLio=}
+      ENCRYPTION_MASTER_KEY: ${ENCRYPTION_MASTER_KEY:?ENCRYPTION_MASTER_KEY must be set (CI workflow injects from secret, local dev sets via .env)}
       ENCRYPTION_MASTER_KEY_PREVIOUS: ${ENCRYPTION_MASTER_KEY_PREVIOUS:-}
       # S3-compatible attachment storage (MinIO sidecar). STORAGE_BACKEND=s3
       # is required because runtime.exs defaults to the BYTEA `database` adapter

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.67",
+      version: "0.5.68",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Part of a security hardening pass on the CI/CD setup. This PR covers the engram-side changes.

- **Tighten workflow permissions.** Adds explicit `permissions: contents: read` at the top of every workflow yaml (ci, runner-cleanup, obsidian-update, review). The org-level default for engram is now also `read`, but explicit blocks survive setting drift.
- **Rotate CI encryption key.** The previous `ENCRYPTION_MASTER_KEY` value was hardcoded as a literal string in `ci.yml` (line 36) and as a fallback default in `docker-compose.ci.yml` (line 45). Both of those are in a public repo, so the key was effectively burned. Replaced with the new `CI_ENCRYPTION_MASTER_KEY` repo secret. The fallback in `docker-compose.ci.yml` is now `${VAR:?...}` so a missing env fails fast instead of silently using a known-bad value.
- **Version bump** to satisfy `version-check`.

## Risk

- CI databases are recreated per run, so the key never protected persistent data. Production deploys override via `fly secrets`. Rotation has no production blast radius.
- The new key is in the `CI_ENCRYPTION_MASTER_KEY` secret on this repo. If any other env (FastRaid Unraid template, `.env.local`, Fly prod) was reusing the same literal as the workflow yaml, those need separate rotation — flagged to operator.

## Follow-ups (separate PRs)

- Plugin repo: same permissions-block treatment.
- Marketing repo: same.
- Defense-in-depth audit covers more items (reverse-deploy direction, ephemeral runners, fork-PR setting flipped to all_external_contributors, etc).

## Test plan

- [ ] CI passes (unit-tests, lint, e2e-clerk, e2e-local, e2e-browser) — confirms the workflow can read the new secret and that `:?` does not break docker-compose.
- [ ] `gh secret list` shows `CI_ENCRYPTION_MASTER_KEY` (already confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)