### PR TITLE
feat(crypto): AWS KMS Phase 2 — boot canary polymorphism + KMS telemetry

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -23,5 +23,5 @@
   # binary-shape union from the leading three pattern matches, but the spec
   # has to remain `term()` so future callers don't fail type-check at the
   # boundary. Same pattern as the AAD helpers above.
-  {"lib/engram/crypto/key_provider.ex", :contract_supertype, 48}
+  {"lib/engram/crypto/key_provider.ex", :contract_supertype, 71}
 ]

--- a/docs/superpowers/plans/2026-05-11-aws-kms-phase-2-boot-canary-telemetry.md
+++ b/docs/superpowers/plans/2026-05-11-aws-kms-phase-2-boot-canary-telemetry.md
@@ -1,0 +1,743 @@
+# AWS KMS Phase 2 — Boot Canary Polymorphism + KMS Telemetry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `BootCanary.verify!/0` dispatch through the configured `KeyProvider` (Local OR AwsKms), gate AwsKms boots with a `describe_key` ping, and emit `[:engram, :crypto, :kms, :request|:failure]` telemetry on every AWS KMS request so production has observability before Phase 3 migration.
+
+**Architecture:** Two new behaviour callbacks (`boot_check/0`, `unwrap_dek_no_fallback/2`) keep BootCanary provider-agnostic. The `Engram.AwsKms.ExAws` module wraps every AWS call in `:telemetry.span/3`-style request + failure emit. Behaviour is opt-in: `KEY_PROVIDER=local` paths remain bit-for-bit identical so deploy is dead-loaded for SaaS until Phase 3 + 4.
+
+**Tech Stack:** Elixir/Phoenix, ExAws.KMS, `:telemetry`, Mox (via `Engram.AwsKmsMock`), ExUnit + `:telemetry.attach` for event assertions.
+
+---
+
+## File Structure
+
+| File | Why |
+|------|-----|
+| `lib/engram/crypto/key_provider.ex` (modify) | Add `boot_check/0` + `unwrap_dek_no_fallback/2` callbacks. |
+| `lib/engram/crypto/key_provider/local.ex` (modify) | Implement both new callbacks; `unwrap_dek_no_fallback/2` delegates to existing `unwrap_dek_current_only/2`; `boot_check/0` returns `:ok`. |
+| `lib/engram/crypto/key_provider/aws_kms.ex` (modify) | Implement both new callbacks; `boot_check/0` calls `aws_kms().describe_key()`; `unwrap_dek_no_fallback/2` delegates to `unwrap_dek/2`. |
+| `lib/engram/crypto/boot_canary.ex` (modify) | Drop direct `Local.unwrap_dek_current_only/2` call; route through `Resolver.provider()` → `provider.boot_check()` → `provider.unwrap_dek_no_fallback/2`. Tag `[:engram, :crypto, :boot_canary]` telemetry with `provider:`. |
+| `lib/engram/aws_kms/ex_aws.ex` (modify) | Wrap each `ExAws.request/2` in `:telemetry.execute([:engram, :crypto, :kms, :request], ...)` measuring `duration_us`; emit `[:engram, :crypto, :kms, :failure]` on error tuple. |
+| `test/engram/crypto/boot_canary_test.exs` (modify) | New tests: AwsKms branch uses Mox to stub `describe_key`/`decrypt`; assert `provider:` metadata; assert raise when `describe_key` fails. |
+| `test/engram/aws_kms/ex_aws_test.exs` (modify) | Add telemetry assertion tests for `:request` (ok + error) and `:failure` events on each op. |
+| `test/engram/crypto/provider_conformance_test.exs` (modify) | Add `boot_check` + `unwrap_dek_no_fallback` round-trip assertions to the parametrised conformance loop. |
+
+---
+
+## Task 1 — Add `boot_check/0` + `unwrap_dek_no_fallback/2` behaviour callbacks
+
+**Files:**
+- Modify: `lib/engram/crypto/key_provider.ex`
+
+- [ ] **Step 1: Edit behaviour to add the two new callbacks**
+
+```elixir
+# Append inside the `defmodule Engram.Crypto.KeyProvider do … end` block,
+# above the `@doc "Default DEK generator …"` line.
+@doc """
+Provider-specific pre-flight performed once at app boot, BEFORE the
+boot canary unwrap. Implementations that need to validate connectivity
+or credentials with their key source SHOULD do it here.
+
+- `Local` returns `:ok` (no external state).
+- `AwsKms` issues a single `DescribeKey` call against the configured
+  CMK — surfaces wrong-ARN, IAM-denied, wrong-region misconfiguration
+  before the first user request hits the hot path.
+"""
+@callback boot_check() :: :ok | {:error, term()}
+
+@doc """
+Unwrap `wrapped` without any provider-internal fallback. Used by the
+boot canary so that a misconfigured master key cannot be silently
+rescued by a `_PREVIOUS` rotation slot. Providers without a fallback
+concept (e.g. AwsKms) MAY delegate to `unwrap_dek/2`.
+"""
+@callback unwrap_dek_no_fallback(wrapped(), ctx()) ::
+            {:ok, dek()} | {:error, term()}
+```
+
+- [ ] **Step 2: Commit (compile-only — implementations land in next tasks)**
+
+```bash
+git add lib/engram/crypto/key_provider.ex
+git commit -m "feat(crypto): add boot_check + unwrap_dek_no_fallback callbacks"
+```
+
+Expected: `mix compile --warnings-as-errors --force` reports `Engram.Crypto.KeyProvider.Local`/`AwsKms` missing the new callbacks — that's deliberate; next tasks add them.
+
+---
+
+## Task 2 — Implement callbacks on `KeyProvider.Local`
+
+**Files:**
+- Modify: `lib/engram/crypto/key_provider/local.ex`
+- Modify: `test/engram/crypto/key_provider/local_test.exs`
+
+- [ ] **Step 1: Write failing test — `boot_check/0` returns `:ok`**
+
+```elixir
+# test/engram/crypto/key_provider/local_test.exs — add a new describe block
+describe "boot_check/0" do
+  test "returns :ok (Local provider has no external state to verify)" do
+    assert :ok = Engram.Crypto.KeyProvider.Local.boot_check()
+  end
+end
+
+describe "unwrap_dek_no_fallback/2" do
+  setup do
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+
+    :ok
+  end
+
+  test "round-trips a freshly-wrapped DEK" do
+    dek = :crypto.strong_rand_bytes(32)
+    {:ok, wrapped} = Engram.Crypto.KeyProvider.Local.wrap_dek(dek, %{user_id: 7})
+
+    assert {:ok, ^dek} =
+             Engram.Crypto.KeyProvider.Local.unwrap_dek_no_fallback(
+               wrapped,
+               %{user_id: 7}
+             )
+  end
+
+  test "does NOT consult _PREVIOUS — wrong master key returns :invalid_wrapping" do
+    dek = :crypto.strong_rand_bytes(32)
+    {:ok, wrapped} = Engram.Crypto.KeyProvider.Local.wrap_dek(dek, %{user_id: 7})
+
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+
+    assert {:error, :invalid_wrapping} =
+             Engram.Crypto.KeyProvider.Local.unwrap_dek_no_fallback(
+               wrapped,
+               %{user_id: 7}
+             )
+  end
+end
+```
+
+- [ ] **Step 2: Run tests, see them fail**
+
+```bash
+mix test test/engram/crypto/key_provider/local_test.exs --only describe:"boot_check/0" --only describe:"unwrap_dek_no_fallback/2"
+```
+
+Expected: `UndefinedFunctionError: function Engram.Crypto.KeyProvider.Local.boot_check/0 is undefined`.
+
+- [ ] **Step 3: Implement both callbacks**
+
+```elixir
+# lib/engram/crypto/key_provider/local.ex — add near the other @impl true blocks
+@impl true
+def boot_check, do: :ok
+
+@impl true
+def unwrap_dek_no_fallback(blob, %{user_id: uid}) when is_binary(blob) do
+  case unwrap_dek_current_only(blob, user_id: uid) do
+    {:ok, dek} -> {:ok, dek}
+    {:error, reason} -> {:error, reason}
+  end
+end
+```
+
+(`unwrap_dek_current_only/2` accepts `user_id: :canary | integer()`; the behaviour callback narrows it to the ctx map and forwards.)
+
+- [ ] **Step 4: Run tests, see them pass**
+
+```bash
+mix test test/engram/crypto/key_provider/local_test.exs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/crypto/key_provider/local.ex test/engram/crypto/key_provider/local_test.exs
+git commit -m "feat(crypto): implement boot_check + unwrap_dek_no_fallback on Local"
+```
+
+---
+
+## Task 3 — Implement callbacks on `KeyProvider.AwsKms`
+
+**Files:**
+- Modify: `lib/engram/crypto/key_provider/aws_kms.ex`
+- Modify: `test/engram/crypto/key_provider/aws_kms_test.exs`
+
+- [ ] **Step 1: Write failing tests**
+
+```elixir
+# test/engram/crypto/key_provider/aws_kms_test.exs — append inside the existing
+# test module. Mox is already imported and Engram.AwsKmsMock is in test config.
+
+describe "boot_check/0" do
+  test "returns :ok when describe_key succeeds" do
+    expect(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+    assert :ok = Engram.Crypto.KeyProvider.AwsKms.boot_check()
+  end
+
+  test "propagates an error tuple when describe_key fails" do
+    expect(Engram.AwsKmsMock, :describe_key, fn -> {:error, :access_denied} end)
+
+    assert {:error, :access_denied} =
+             Engram.Crypto.KeyProvider.AwsKms.boot_check()
+  end
+end
+
+describe "unwrap_dek_no_fallback/2" do
+  test "delegates to unwrap_dek/2 (AwsKms has no fallback concept)" do
+    dek = :crypto.strong_rand_bytes(32)
+
+    expect(Engram.AwsKmsMock, :decrypt, fn _ct, %{"user_id" => "7", "purpose" => "dek_wrap"} ->
+      {:ok, dek}
+    end)
+
+    blob = <<0xAA, 0x01, :crypto.strong_rand_bytes(48)::binary>>
+
+    assert {:ok, ^dek} =
+             Engram.Crypto.KeyProvider.AwsKms.unwrap_dek_no_fallback(
+               blob,
+               %{user_id: 7}
+             )
+  end
+end
+```
+
+- [ ] **Step 2: Run tests, see them fail**
+
+```bash
+mix test test/engram/crypto/key_provider/aws_kms_test.exs
+```
+
+Expected: `UndefinedFunctionError` for `boot_check/0` and `unwrap_dek_no_fallback/2`.
+
+- [ ] **Step 3: Implement both callbacks**
+
+```elixir
+# lib/engram/crypto/key_provider/aws_kms.ex — alongside the other @impl true clauses
+@impl true
+def boot_check, do: aws_kms().describe_key()
+
+@impl true
+def unwrap_dek_no_fallback(<<@provider_tag, @payload_v1, _::binary>> = blob, ctx),
+  do: unwrap_dek(blob, ctx)
+
+def unwrap_dek_no_fallback(_other, _ctx), do: {:error, :malformed_wrapped_blob}
+```
+
+- [ ] **Step 4: Run tests, see them pass**
+
+```bash
+mix test test/engram/crypto/key_provider/aws_kms_test.exs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/crypto/key_provider/aws_kms.ex test/engram/crypto/key_provider/aws_kms_test.exs
+git commit -m "feat(crypto): implement boot_check + unwrap_dek_no_fallback on AwsKms"
+```
+
+---
+
+## Task 4 — Extend conformance suite
+
+**Files:**
+- Modify: `test/engram/crypto/provider_conformance_test.exs`
+
+- [ ] **Step 1: Add new conformance tests inside the `for provider <- @providers` loop**
+
+```elixir
+test "#{inspect(provider)}: boot_check returns :ok in happy path" do
+  if unquote(provider) == Engram.Crypto.KeyProvider.AwsKms do
+    stub_aws_kms_roundtrip()
+    stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+  end
+
+  assert :ok = unquote(provider).boot_check()
+end
+
+test "#{inspect(provider)}: unwrap_dek_no_fallback round-trips wrapped DEK" do
+  if unquote(provider) == Engram.Crypto.KeyProvider.AwsKms, do: stub_aws_kms_roundtrip()
+
+  dek = unquote(provider).generate_dek()
+  ctx = %{user_id: 1}
+  {:ok, wrapped} = unquote(provider).wrap_dek(dek, ctx)
+  assert {:ok, ^dek} = unquote(provider).unwrap_dek_no_fallback(wrapped, ctx)
+end
+```
+
+- [ ] **Step 2: Run the conformance suite**
+
+```bash
+mix test test/engram/crypto/provider_conformance_test.exs
+```
+
+Expected: PASS (all parametrised tests, both providers).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/engram/crypto/provider_conformance_test.exs
+git commit -m "test(crypto): extend conformance with boot_check + unwrap_dek_no_fallback"
+```
+
+---
+
+## Task 5 — Wire `BootCanary` through the resolved provider
+
+**Files:**
+- Modify: `lib/engram/crypto/boot_canary.ex`
+- Modify: `test/engram/crypto/boot_canary_test.exs`
+
+- [ ] **Step 1: Write failing tests covering AwsKms branch + provider tag**
+
+```elixir
+# test/engram/crypto/boot_canary_test.exs — add a new describe block at the bottom
+
+describe "verify!/0 — AwsKms provider" do
+  import Mox
+  setup :verify_on_exit!
+
+  setup do
+    prev_provider = Application.get_env(:engram, :key_provider)
+    prev_client = Application.get_env(:engram, :aws_kms_client)
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+    Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+
+    on_exit(fn ->
+      Application.put_env(:engram, :key_provider, prev_provider)
+      Application.put_env(:engram, :aws_kms_client, prev_client)
+    end)
+
+    :ok
+  end
+
+  test "raises when boot_check (DescribeKey) fails" do
+    # Insert a placeholder canary blob first so verify! reaches the boot_check path.
+    Engram.Repo.insert_all("system_canaries", [
+      %{
+        wrapped_dek: <<0xAA, 0x01, :crypto.strong_rand_bytes(48)::binary>>,
+        dek_sha256: :crypto.hash(:sha256, <<0>>),
+        inserted_at: DateTime.utc_now(),
+        updated_at: DateTime.utc_now()
+      }
+    ])
+
+    expect(Engram.AwsKmsMock, :describe_key, fn -> {:error, :access_denied} end)
+
+    assert_raise RuntimeError, ~r/describe_key/i, fn ->
+      Engram.Crypto.BootCanary.verify!()
+    end
+  end
+
+  test "tags :ok telemetry with provider: :aws_kms" do
+    dek = :crypto.strong_rand_bytes(32)
+    sha = :crypto.hash(:sha256, dek)
+    blob = <<0xAA, 0x01, :crypto.strong_rand_bytes(48)::binary>>
+
+    Engram.Repo.insert_all("system_canaries", [
+      %{
+        wrapped_dek: blob,
+        dek_sha256: sha,
+        inserted_at: DateTime.utc_now(),
+        updated_at: DateTime.utc_now()
+      }
+    ])
+
+    stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+    stub(Engram.AwsKmsMock, :decrypt, fn _ct, _ctx -> {:ok, dek} end)
+
+    :telemetry.attach(
+      "boot-canary-aws",
+      [:engram, :crypto, :boot_canary],
+      fn _n, _m, meta, _ -> send(self(), {:canary, meta}) end,
+      nil
+    )
+
+    try do
+      assert :ok = Engram.Crypto.BootCanary.verify!()
+      assert_received {:canary, %{status: :ok, provider: :aws_kms}}
+    after
+      :telemetry.detach("boot-canary-aws")
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run tests, see them fail**
+
+```bash
+mix test test/engram/crypto/boot_canary_test.exs
+```
+
+Expected: First test fails because verify! still calls Local directly; second fails because metadata is missing `provider:`.
+
+- [ ] **Step 3: Refactor BootCanary to dispatch via Resolver**
+
+Replace the body of `verify!/0` in `lib/engram/crypto/boot_canary.ex`:
+
+```elixir
+@spec verify!() :: :ok
+def verify! do
+  provider = Engram.Crypto.KeyProvider.Resolver.provider()
+
+  case provider.boot_check() do
+    :ok ->
+      :ok
+
+    {:error, reason} ->
+      :telemetry.execute(
+        [:engram, :crypto, :boot_canary],
+        %{count: 1},
+        %{status: :failed, provider: provider.name(), reason_label: reason_label(reason)}
+      )
+
+      raise """
+      boot canary describe_key/boot_check failed: #{inspect(reason)}.
+      Verify the configured key provider is reachable and the IAM /
+      credentials are correct.
+      """
+  end
+
+  case fetch_latest() do
+    nil ->
+      Logger.warning("boot_canary: no canary row, provisioning fresh", category: :boot_canary)
+      provision!(provider)
+
+      :telemetry.execute(
+        [:engram, :crypto, :boot_canary],
+        %{count: 1},
+        %{status: :provisioned, provider: provider.name()}
+      )
+
+      :ok
+
+    %{wrapped_dek: blob, dek_sha256: expected_hash} ->
+      case provider.unwrap_dek_no_fallback(blob, %{user_id: canary_user_id()}) do
+        {:ok, plaintext_dek} ->
+          if :crypto.hash(:sha256, plaintext_dek) == expected_hash do
+            :telemetry.execute(
+              [:engram, :crypto, :boot_canary],
+              %{count: 1},
+              %{status: :ok, provider: provider.name()}
+            )
+
+            :ok
+          else
+            :telemetry.execute(
+              [:engram, :crypto, :boot_canary],
+              %{count: 1},
+              %{status: :failed, provider: provider.name(), reason_label: "sha_mismatch"}
+            )
+
+            raise """
+            boot canary unwrap returned a plaintext that does not match the
+            recorded SHA256. This indicates a corrupted canary row, not a
+            wrong-key situation. Inspect the system_canaries table.
+            """
+          end
+
+        {:error, reason} ->
+          :telemetry.execute(
+            [:engram, :crypto, :boot_canary],
+            %{count: 1},
+            %{status: :failed, provider: provider.name(), reason_label: reason_label(reason)}
+          )
+
+          raise """
+          boot canary unwrap failed: #{inspect(reason)} via provider #{provider.name()}.
+          Verify env vars and re-run rotation if a master-key cutover is in progress.
+          """
+      end
+  end
+end
+```
+
+Also update `provision!/0` to take the active provider and use a sentinel integer user_id (so AwsKms's `encryption_context` accepts it):
+
+```elixir
+@canary_user_id 0
+
+defp canary_user_id, do: @canary_user_id
+
+@doc false
+@spec provision!(module()) :: :ok
+def provision!(provider \\ Engram.Crypto.KeyProvider.Resolver.provider()) do
+  dek = :crypto.strong_rand_bytes(@canary_dek_size)
+  {:ok, wrapped} = provider.wrap_dek(dek, %{user_id: canary_user_id()})
+  sha = :crypto.hash(:sha256, dek)
+  now = DateTime.utc_now()
+
+  {1, _} =
+    Repo.insert_all(
+      "system_canaries",
+      [
+        %{
+          wrapped_dek: wrapped,
+          dek_sha256: sha,
+          inserted_at: now,
+          updated_at: now
+        }
+      ]
+    )
+
+  :ok
+end
+```
+
+Remove the `alias Engram.Crypto.KeyProvider.Local` and replace it with `alias Engram.Crypto.KeyProvider.Resolver` (only needed inside `provision!/1`'s default arg).
+
+- [ ] **Step 4: Update existing Local-branch tests for the new `provider:` metadata**
+
+```elixir
+# Inside `describe "verify!/0"` — every assert_received now expects provider: :local
+assert_received {:canary, %{status: :provisioned, provider: :local}}
+# … and similarly for :ok / :failed assertions.
+```
+
+- [ ] **Step 5: Run full canary test file, see PASS**
+
+```bash
+mix test test/engram/crypto/boot_canary_test.exs
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/engram/crypto/boot_canary.ex test/engram/crypto/boot_canary_test.exs
+git commit -m "feat(crypto): BootCanary dispatches through configured provider"
+```
+
+---
+
+## Task 6 — Telemetry events on every AWS KMS call
+
+**Files:**
+- Modify: `lib/engram/aws_kms/ex_aws.ex`
+- Modify: `test/engram/aws_kms/ex_aws_test.exs`
+
+- [ ] **Step 1: Write failing telemetry tests**
+
+```elixir
+# test/engram/aws_kms/ex_aws_test.exs — append a new describe block
+
+describe "telemetry" do
+  test "emits :request event with duration_us, op, status on successful encrypt", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/", fn conn ->
+      Plug.Conn.resp(conn, 200, ~s({"CiphertextBlob":"#{Base.encode64("ct")}"}))
+    end)
+
+    :telemetry.attach(
+      "kms-req-ok",
+      [:engram, :crypto, :kms, :request],
+      fn _name, meas, meta, _ -> send(self(), {:tel_req, meas, meta}) end,
+      nil
+    )
+
+    try do
+      assert {:ok, "ct"} =
+               Engram.AwsKms.ExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
+
+      assert_received {:tel_req, %{duration_us: dur}, %{op: :encrypt, status: :ok}}
+      assert is_integer(dur) and dur >= 0
+    after
+      :telemetry.detach("kms-req-ok")
+    end
+  end
+
+  test "emits :failure event with error_class on AccessDenied", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/", fn conn ->
+      Plug.Conn.resp(
+        conn,
+        400,
+        ~s({"__type":"AccessDeniedException","message":"nope"})
+      )
+    end)
+
+    :telemetry.attach_many(
+      "kms-failure",
+      [
+        [:engram, :crypto, :kms, :request],
+        [:engram, :crypto, :kms, :failure]
+      ],
+      fn name, _meas, meta, _ -> send(self(), {name, meta}) end,
+      nil
+    )
+
+    try do
+      assert {:error, :access_denied} =
+               Engram.AwsKms.ExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
+
+      assert_received {[:engram, :crypto, :kms, :request],
+                       %{op: :encrypt, status: :error, error_class: :access_denied}}
+
+      assert_received {[:engram, :crypto, :kms, :failure],
+                       %{op: :encrypt, error_class: :access_denied}}
+    after
+      :telemetry.detach("kms-failure")
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run tests, see them fail**
+
+```bash
+mix test test/engram/aws_kms/ex_aws_test.exs --only describe:telemetry
+```
+
+Expected: assert_received timeouts — no telemetry currently emitted.
+
+- [ ] **Step 3: Add a private telemetry helper + wrap each op**
+
+```elixir
+# lib/engram/aws_kms/ex_aws.ex — add near the top of the module body
+@event_request [:engram, :crypto, :kms, :request]
+@event_failure [:engram, :crypto, :kms, :failure]
+
+defp instrument(op, fun) do
+  start = System.monotonic_time()
+
+  result =
+    try do
+      fun.()
+    rescue
+      e ->
+        emit_failure(op, :crash)
+        reraise e, __STACKTRACE__
+    end
+
+  duration_us = System.convert_time_unit(System.monotonic_time() - start, :native, :microsecond)
+
+  case result do
+    {:ok, _} = ok ->
+      :telemetry.execute(@event_request, %{duration_us: duration_us}, %{op: op, status: :ok})
+      ok
+
+    {:error, reason} = err ->
+      error_class = classify_for_telemetry(reason)
+
+      :telemetry.execute(
+        @event_request,
+        %{duration_us: duration_us},
+        %{op: op, status: :error, error_class: error_class}
+      )
+
+      emit_failure(op, error_class)
+      err
+  end
+end
+
+defp emit_failure(op, error_class) do
+  :telemetry.execute(@event_failure, %{count: 1}, %{op: op, error_class: error_class})
+end
+
+defp classify_for_telemetry(reason) when is_atom(reason), do: reason
+defp classify_for_telemetry({:aws, _code, _msg}), do: :other
+defp classify_for_telemetry(_other), do: :other
+```
+
+Then wrap each public function. Example for `encrypt/2`:
+
+```elixir
+def encrypt(plaintext, enc_ctx) do
+  instrument(:encrypt, fn ->
+    key_id = key_id!()
+
+    key_id
+    |> ExAws.KMS.encrypt(Base.encode64(plaintext), encryption_context: enc_ctx)
+    |> ExAws.request(@ex_aws_opts)
+    |> case do
+      {:ok, %{"CiphertextBlob" => ct_b64}} -> {:ok, Base.decode64!(ct_b64)}
+      {:error, reason} -> {:error, classify(reason)}
+    end
+  end)
+end
+```
+
+Apply the same `instrument(:decrypt, fn -> … end)` / `instrument(:re_encrypt, fn -> … end)` / `instrument(:describe_key, fn -> … end)` wrapper to the other three callbacks.
+
+- [ ] **Step 4: Run tests, see them pass**
+
+```bash
+mix test test/engram/aws_kms/ex_aws_test.exs
+```
+
+Expected: all PASS (existing 8 + new 2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/aws_kms/ex_aws.ex test/engram/aws_kms/ex_aws_test.exs
+git commit -m "feat(crypto): emit :kms :request/:failure telemetry on every AWS call"
+```
+
+---
+
+## Task 7 — Lint + full suite gate
+
+- [ ] **Step 1: Run the full quality stack**
+
+```bash
+mix format --check-formatted && \
+mix compile --warnings-as-errors --force && \
+mix credo --strict --mute-exit-status && \
+mix sobelow --exit low && \
+mix test
+```
+
+Expected: every gate passes; full test suite green.
+
+- [ ] **Step 2: Commit any formatter-only fixups**
+
+If `mix format` rewrote files, commit:
+
+```bash
+git add -A
+git commit -m "chore: mix format"
+```
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin feat/aws-kms-phase-2-boot-canary
+gh pr create --title "feat(crypto): AWS KMS Phase 2 — boot canary polymorphism + KMS telemetry" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `boot_check/0` and `unwrap_dek_no_fallback/2` callbacks to `Engram.Crypto.KeyProvider`.
+- `BootCanary.verify!/0` now dispatches through the configured provider — Local keeps its no-`_PREVIOUS` semantics; AwsKms gates boot with a `DescribeKey` ping.
+- Every `Engram.AwsKms.ExAws` call emits `[:engram, :crypto, :kms, :request]` (duration + status) and `[:engram, :crypto, :kms, :failure]` (error_class).
+- Production behaviour unchanged: `KEY_PROVIDER=local` still default in `config/runtime.exs`; new code is dead-loaded.
+
+## Test plan
+- [ ] `mix test` green (new conformance + canary + telemetry tests).
+- [ ] `mix credo --strict`, `mix sobelow --exit low`, `mix dialyzer` clean (CI).
+- [ ] Boot the app locally with `KEY_PROVIDER=local`; canary telemetry includes `provider: :local`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Phase 2 Out of Scope
+
+- ProviderMigration state machine — Phase 3.
+- IAM policy creation, Fly secrets, KMS cutover runbook — Phase 4.
+- `MasterRotation.rotate_canary/0` extension to wrap via AwsKms — happens implicitly through `Resolver.provider().wrap_dek/2` once Phase 4 flips `KEY_PROVIDER`. No code change required here.

--- a/lib/engram/aws_kms/ex_aws.ex
+++ b/lib/engram/aws_kms/ex_aws.ex
@@ -29,6 +29,9 @@ defmodule Engram.AwsKms.ExAws do
 
   @behaviour Engram.AwsKms
 
+  @event_request [:engram, :crypto, :kms, :request]
+  @event_failure [:engram, :crypto, :kms, :failure]
+
   # Do not retry client errors at the ExAws level — let callers (Oban) handle
   # retry scheduling. Server errors (5xx) retain the ExAws default retry.
   @ex_aws_opts [
@@ -42,54 +45,62 @@ defmodule Engram.AwsKms.ExAws do
 
   @impl true
   def encrypt(plaintext, enc_ctx) when is_binary(plaintext) and is_map(enc_ctx) do
-    key_id = key_id!()
+    instrument(:encrypt, fn ->
+      key_id = key_id!()
 
-    key_id
-    |> ExAws.KMS.encrypt(Base.encode64(plaintext), encryption_context: enc_ctx)
-    |> ExAws.request(@ex_aws_opts)
-    |> case do
-      {:ok, %{"CiphertextBlob" => ct_b64}} -> {:ok, Base.decode64!(ct_b64)}
-      {:error, reason} -> {:error, classify(reason)}
-    end
+      key_id
+      |> ExAws.KMS.encrypt(Base.encode64(plaintext), encryption_context: enc_ctx)
+      |> ExAws.request(@ex_aws_opts)
+      |> case do
+        {:ok, %{"CiphertextBlob" => ct_b64}} -> {:ok, Base.decode64!(ct_b64)}
+        {:error, reason} -> {:error, classify(reason)}
+      end
+    end)
   end
 
   @impl true
   def decrypt(ciphertext, enc_ctx) when is_binary(ciphertext) and is_map(enc_ctx) do
-    Base.encode64(ciphertext)
-    |> ExAws.KMS.decrypt(encryption_context: enc_ctx)
-    |> ExAws.request(@ex_aws_opts)
-    |> case do
-      {:ok, %{"Plaintext" => pt_b64}} -> {:ok, Base.decode64!(pt_b64)}
-      {:error, reason} -> {:error, classify(reason)}
-    end
+    instrument(:decrypt, fn ->
+      Base.encode64(ciphertext)
+      |> ExAws.KMS.decrypt(encryption_context: enc_ctx)
+      |> ExAws.request(@ex_aws_opts)
+      |> case do
+        {:ok, %{"Plaintext" => pt_b64}} -> {:ok, Base.decode64!(pt_b64)}
+        {:error, reason} -> {:error, classify(reason)}
+      end
+    end)
   end
 
   @impl true
   def re_encrypt(ciphertext, source_ctx, dest_ctx)
       when is_binary(ciphertext) and is_map(source_ctx) and is_map(dest_ctx) do
-    key_id = key_id!()
+    instrument(:re_encrypt, fn ->
+      key_id = key_id!()
 
-    Base.encode64(ciphertext)
-    |> ExAws.KMS.re_encrypt(key_id,
-      source_encryption_context: source_ctx,
-      destination_encryption_context: dest_ctx
-    )
-    |> ExAws.request(@ex_aws_opts)
-    |> case do
-      {:ok, %{"CiphertextBlob" => ct_b64}} -> {:ok, Base.decode64!(ct_b64)}
-      {:error, reason} -> {:error, classify(reason)}
-    end
+      Base.encode64(ciphertext)
+      |> ExAws.KMS.re_encrypt(key_id,
+        source_encryption_context: source_ctx,
+        destination_encryption_context: dest_ctx
+      )
+      |> ExAws.request(@ex_aws_opts)
+      |> case do
+        {:ok, %{"CiphertextBlob" => ct_b64}} -> {:ok, Base.decode64!(ct_b64)}
+        {:error, reason} -> {:error, classify(reason)}
+      end
+    end)
   end
 
   @impl true
   def describe_key do
-    key_id!()
-    |> ExAws.KMS.describe_key()
-    |> ExAws.request(@ex_aws_opts)
-    |> case do
-      {:ok, _} -> :ok
-      {:error, reason} -> {:error, classify(reason)}
-    end
+    instrument(:describe_key, fn ->
+      key_id!()
+      |> ExAws.KMS.describe_key()
+      |> ExAws.request(@ex_aws_opts)
+      |> case do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, classify(reason)}
+      end
+    end)
   end
 
   defp key_id! do
@@ -131,4 +142,36 @@ defmodule Engram.AwsKms.ExAws do
       other -> {:aws, other, msg}
     end
   end
+
+  defp instrument(op, fun) do
+    start = System.monotonic_time()
+    result = fun.()
+    duration_us = System.convert_time_unit(System.monotonic_time() - start, :native, :microsecond)
+
+    case result do
+      :ok ->
+        :telemetry.execute(@event_request, %{duration_us: duration_us}, %{op: op, status: :ok})
+        :ok
+
+      {:ok, _} = ok ->
+        :telemetry.execute(@event_request, %{duration_us: duration_us}, %{op: op, status: :ok})
+        ok
+
+      {:error, reason} = err ->
+        error_class = classify_for_telemetry(reason)
+
+        :telemetry.execute(
+          @event_request,
+          %{duration_us: duration_us},
+          %{op: op, status: :error, error_class: error_class}
+        )
+
+        :telemetry.execute(@event_failure, %{count: 1}, %{op: op, error_class: error_class})
+        err
+    end
+  end
+
+  defp classify_for_telemetry(reason) when is_atom(reason), do: reason
+  defp classify_for_telemetry({:aws, _code, _msg}), do: :other
+  defp classify_for_telemetry(_other), do: :other
 end

--- a/lib/engram/aws_kms/ex_aws.ex
+++ b/lib/engram/aws_kms/ex_aws.ex
@@ -145,29 +145,57 @@ defmodule Engram.AwsKms.ExAws do
 
   defp instrument(op, fun) do
     start = System.monotonic_time()
-    result = fun.()
-    duration_us = System.convert_time_unit(System.monotonic_time() - start, :native, :microsecond)
 
-    case result do
-      :ok ->
-        :telemetry.execute(@event_request, %{duration_us: duration_us}, %{op: op, status: :ok})
-        :ok
+    try do
+      result = fun.()
 
-      {:ok, _} = ok ->
-        :telemetry.execute(@event_request, %{duration_us: duration_us}, %{op: op, status: :ok})
-        ok
+      duration_us =
+        System.convert_time_unit(System.monotonic_time() - start, :native, :microsecond)
 
-      {:error, reason} = err ->
-        error_class = classify_for_telemetry(reason)
+      case result do
+        :ok ->
+          :telemetry.execute(@event_request, %{duration_us: duration_us}, %{op: op, status: :ok})
+          :ok
+
+        {:ok, _} = ok ->
+          :telemetry.execute(@event_request, %{duration_us: duration_us}, %{op: op, status: :ok})
+          ok
+
+        {:error, reason} = err ->
+          error_class = classify_for_telemetry(reason)
+
+          :telemetry.execute(
+            @event_request,
+            %{duration_us: duration_us},
+            %{op: op, status: :error, error_class: error_class}
+          )
+
+          :telemetry.execute(
+            @event_failure,
+            %{count: 1, duration_us: duration_us},
+            %{op: op, error_class: error_class}
+          )
+
+          err
+      end
+    rescue
+      e ->
+        duration_us =
+          System.convert_time_unit(System.monotonic_time() - start, :native, :microsecond)
 
         :telemetry.execute(
           @event_request,
           %{duration_us: duration_us},
-          %{op: op, status: :error, error_class: error_class}
+          %{op: op, status: :error, error_class: :exception}
         )
 
-        :telemetry.execute(@event_failure, %{count: 1}, %{op: op, error_class: error_class})
-        err
+        :telemetry.execute(
+          @event_failure,
+          %{count: 1, duration_us: duration_us},
+          %{op: op, error_class: :exception}
+        )
+
+        reraise e, __STACKTRACE__
     end
   end
 

--- a/lib/engram/crypto/boot_canary.ex
+++ b/lib/engram/crypto/boot_canary.ex
@@ -28,6 +28,7 @@ defmodule Engram.Crypto.BootCanary do
   require Logger
 
   @canary_dek_size 32
+  # sentinel — system_canaries has no FK to users; reserved out-of-band from normal user IDs
   @canary_user_id 0
 
   @doc """

--- a/lib/engram/crypto/boot_canary.ex
+++ b/lib/engram/crypto/boot_canary.ex
@@ -1,105 +1,147 @@
 defmodule Engram.Crypto.BootCanary do
   @moduledoc """
-  T3.5.5 / M3 — boot canary for the master encryption key.
+  T3.5.5 / M3 — boot canary for the master encryption key (provider-polymorphic).
 
-  At application boot, attempts to unwrap the most recent canary row's
-  `wrapped_dek` using ONLY the current master key (no `_PREVIOUS`
-  fallback). Two outcomes:
+  At application boot:
 
-  * **No canary row yet** — provisions a fresh canary with the current
-    master key and logs a warning. Subsequent boots will verify against
-    this row.
-  * **Unwrap succeeds + plaintext SHA matches** — emits
-    `[:engram, :crypto, :boot_canary]` with `status: :ok`.
-  * **Unwrap fails OR plaintext SHA mismatch** — raises. Boot stops.
+  1. Resolves the active `KeyProvider` (Local | AwsKms).
+  2. Calls `provider.boot_check/0` — for AwsKms this issues a `DescribeKey`
+     against the configured CMK, surfacing wrong-ARN, IAM-denied, or
+     wrong-region misconfiguration before the first user request hits the
+     hot path. For Local this is a no-op.
+  3. Looks up the most-recent canary row and unwraps via
+     `provider.unwrap_dek_no_fallback/2`. Local refuses to consult its
+     `_PREVIOUS` slot so a misconfigured `ENCRYPTION_MASTER_KEY` cannot be
+     silently rescued. AwsKms has no fallback concept and delegates to
+     `unwrap_dek/2`.
+  4. Hashes the plaintext and compares against the stored SHA256.
 
-  This catches the silent failure mode where an operator points the app
-  at the wrong `ENCRYPTION_MASTER_KEY`: with `_PREVIOUS` set, every
-  in-flight unwrap quietly falls back to the previous key, the app keeps
-  serving, but newly-written wraps are produced with the wrong key. The
-  canary's no-fallback unwrap detects this immediately at boot.
-
-  Updated by `Engram.Crypto.MasterRotation.rotate_canary/0` after the
-  user fleet has been rotated. Operators who skip the canary update will
-  see the next boot fail loudly — which is the desired behavior.
-
-  ## Failure mode reference
-
-      RuntimeError: boot canary unwrap failed: :invalid_wrapping.
-      Current ENCRYPTION_MASTER_KEY does not match the key used to
-      wrap the most recent canary. Verify env vars and re-run rotation
-      if a master-key cutover is in progress.
+  Emits `[:engram, :crypto, :boot_canary]` with `provider:` metadata on
+  every outcome. Boot fails loudly on any unwrap or SHA mismatch.
   """
 
   import Ecto.Query, only: [from: 2]
 
-  alias Engram.Crypto.KeyProvider.Local
+  alias Engram.Crypto.KeyProvider.Resolver
   alias Engram.Repo
 
   require Logger
 
   @canary_dek_size 32
+  @canary_user_id 0
 
   @doc """
-  Verify the boot canary against the current master key. Idempotent.
+  Verify the boot canary against the configured KeyProvider. Idempotent.
   Provisions a fresh canary if none exists.
   """
   @spec verify!() :: :ok
   def verify! do
+    provider = Resolver.provider()
+    :ok = ensure_provider_ready!(provider)
+
     case fetch_latest() do
       nil ->
-        Logger.warning("boot_canary: no canary row, provisioning fresh", category: :boot_canary)
-        provision!()
-        :telemetry.execute([:engram, :crypto, :boot_canary], %{count: 1}, %{status: :provisioned})
+        Logger.warning("boot_canary: no canary row, provisioning fresh",
+          category: :boot_canary
+        )
+
+        provision!(provider)
+
+        :telemetry.execute(
+          [:engram, :crypto, :boot_canary],
+          %{count: 1},
+          %{status: :provisioned, provider: provider.name()}
+        )
+
         :ok
 
       %{wrapped_dek: blob, dek_sha256: expected_hash} ->
-        case Local.unwrap_dek_current_only(blob, user_id: :canary) do
+        case provider.unwrap_dek_no_fallback(blob, %{user_id: @canary_user_id}) do
           {:ok, plaintext_dek} ->
-            if :crypto.hash(:sha256, plaintext_dek) == expected_hash do
-              :telemetry.execute([:engram, :crypto, :boot_canary], %{count: 1}, %{status: :ok})
-              :ok
-            else
-              :telemetry.execute(
-                [:engram, :crypto, :boot_canary],
-                %{count: 1},
-                %{status: :failed, reason_label: "sha_mismatch"}
-              )
-
-              raise """
-              boot canary unwrap returned a plaintext that does not match the
-              recorded SHA256. This indicates a corrupted canary row, not a
-              wrong-key situation. Inspect the system_canaries table.
-              """
-            end
+            verify_sha!(plaintext_dek, expected_hash, provider)
 
           {:error, reason} ->
             :telemetry.execute(
               [:engram, :crypto, :boot_canary],
               %{count: 1},
-              %{status: :failed, reason_label: reason_label(reason)}
+              %{
+                status: :failed,
+                provider: provider.name(),
+                reason_label: reason_label(reason)
+              }
             )
 
             raise """
-            boot canary unwrap failed: #{inspect(reason)}.
-            Current ENCRYPTION_MASTER_KEY does not match the key used to wrap
-            the most recent canary. Verify env vars and re-run rotation if a
-            master-key cutover is in progress.
+            boot canary unwrap failed: #{inspect(reason)} via provider #{provider.name()}.
+            Verify env vars and re-run rotation if a master-key cutover is in
+            progress.
             """
         end
     end
   end
 
+  defp ensure_provider_ready!(provider) do
+    case provider.boot_check() do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        :telemetry.execute(
+          [:engram, :crypto, :boot_canary],
+          %{count: 1},
+          %{
+            status: :failed,
+            provider: provider.name(),
+            reason_label: reason_label(reason)
+          }
+        )
+
+        raise """
+        boot_check failed for provider #{provider.name()}: #{inspect(reason)}.
+        Verify the configured key provider is reachable and the credentials /
+        IAM policy permit DescribeKey on the configured CMK.
+        """
+    end
+  end
+
+  defp verify_sha!(plaintext_dek, expected_hash, provider) do
+    if :crypto.hash(:sha256, plaintext_dek) == expected_hash do
+      :telemetry.execute(
+        [:engram, :crypto, :boot_canary],
+        %{count: 1},
+        %{status: :ok, provider: provider.name()}
+      )
+
+      :ok
+    else
+      :telemetry.execute(
+        [:engram, :crypto, :boot_canary],
+        %{count: 1},
+        %{
+          status: :failed,
+          provider: provider.name(),
+          reason_label: "sha_mismatch"
+        }
+      )
+
+      raise """
+      boot canary unwrap returned a plaintext that does not match the recorded
+      SHA256. This indicates a corrupted canary row, not a wrong-key situation.
+      Inspect the system_canaries table.
+      """
+    end
+  end
+
   @doc """
-  Provision a fresh canary row using the current master key. Used by:
+  Provision a fresh canary row using the active provider. Used by:
 
   * Boot, when the table is empty.
   * `MasterRotation.rotate_canary/0` after rotating the user fleet.
   """
-  @spec provision!() :: :ok
-  def provision! do
+  @spec provision!(module()) :: :ok
+  def provision!(provider \\ Resolver.provider()) do
     dek = :crypto.strong_rand_bytes(@canary_dek_size)
-    {:ok, wrapped} = Local.wrap_dek(dek, %{user_id: :canary})
+    {:ok, wrapped} = provider.wrap_dek(dek, %{user_id: @canary_user_id})
     sha = :crypto.hash(:sha256, dek)
     now = DateTime.utc_now()
 
@@ -136,4 +178,5 @@ defmodule Engram.Crypto.BootCanary do
   defp reason_label(:invalid_wrapping), do: "invalid_wrapping"
   defp reason_label(:malformed_wrapped_blob), do: "malformed_wrapped_blob"
   defp reason_label(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp reason_label(reason), do: inspect(reason)
 end

--- a/lib/engram/crypto/key_provider.ex
+++ b/lib/engram/crypto/key_provider.ex
@@ -31,6 +31,27 @@ defmodule Engram.Crypto.KeyProvider do
   """
   @callback rotate_dek(wrapped(), ctx()) :: {:ok, wrapped(), dek()} | {:error, term()}
 
+  @doc """
+  Provider-specific pre-flight performed once at app boot, BEFORE the
+  boot canary unwrap. Implementations that need to validate connectivity
+  or credentials with their key source SHOULD do it here.
+
+  - `Local` returns `:ok` (no external state).
+  - `AwsKms` issues a single `DescribeKey` call against the configured
+    CMK — surfaces wrong-ARN, IAM-denied, wrong-region misconfiguration
+    before the first user request hits the hot path.
+  """
+  @callback boot_check() :: :ok | {:error, term()}
+
+  @doc """
+  Unwrap `wrapped` without any provider-internal fallback. Used by the
+  boot canary so that a misconfigured master key cannot be silently
+  rescued by a `_PREVIOUS` rotation slot. Providers without a fallback
+  concept (e.g. AwsKms) MAY delegate to `unwrap_dek/2`.
+  """
+  @callback unwrap_dek_no_fallback(wrapped(), ctx()) ::
+              {:ok, dek()} | {:error, term()}
+
   @doc "Default DEK generator — providers may override."
   @spec default_generate_dek() :: dek()
   def default_generate_dek, do: :crypto.strong_rand_bytes(32)

--- a/lib/engram/crypto/key_provider.ex
+++ b/lib/engram/crypto/key_provider.ex
@@ -40,6 +40,8 @@ defmodule Engram.Crypto.KeyProvider do
   - `AwsKms` issues a single `DescribeKey` call against the configured
     CMK — surfaces wrong-ARN, IAM-denied, wrong-region misconfiguration
     before the first user request hits the hot path.
+
+  No `ctx` parameter: boot check is tenant-agnostic, running once at app startup before any user context exists.
   """
   @callback boot_check() :: :ok | {:error, term()}
 

--- a/lib/engram/crypto/key_provider/aws_kms.ex
+++ b/lib/engram/crypto/key_provider/aws_kms.ex
@@ -65,6 +65,15 @@ defmodule Engram.Crypto.KeyProvider.AwsKms do
   def rotate_wrapping(_other, _ctx), do: {:error, :malformed_wrapped_blob}
 
   @impl true
+  def boot_check, do: aws_kms().describe_key()
+
+  @impl true
+  def unwrap_dek_no_fallback(<<@provider_tag, @payload_v1, _::binary>> = blob, ctx),
+    do: unwrap_dek(blob, ctx)
+
+  def unwrap_dek_no_fallback(_other, _ctx), do: {:error, :malformed_wrapped_blob}
+
+  @impl true
   def rotate_dek(_old, %{user_id: _} = ctx) do
     dek = generate_dek()
     with {:ok, wrapped} <- wrap_dek(dek, ctx), do: {:ok, wrapped, dek}

--- a/lib/engram/crypto/key_provider/local.ex
+++ b/lib/engram/crypto/key_provider/local.ex
@@ -202,6 +202,14 @@ defmodule Engram.Crypto.KeyProvider.Local do
     {:ok, new_wrapped, new_dek}
   end
 
+  @impl true
+  def boot_check, do: :ok
+
+  @impl true
+  def unwrap_dek_no_fallback(blob, %{user_id: uid}) when is_binary(blob) do
+    unwrap_dek_current_only(blob, user_id: uid)
+  end
+
   @doc """
   T3.5.5 / M3 — current-master-key-only unwrap, for `BootCanary`. Bypasses
   `_PREVIOUS` fallback so a misconfigured `ENCRYPTION_MASTER_KEY` cannot

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.67",
+      version: "0.5.68",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.68",
+      version: "0.5.69",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/aws_kms/ex_aws_test.exs
+++ b/test/engram/aws_kms/ex_aws_test.exs
@@ -258,5 +258,35 @@ defmodule Engram.AwsKms.ExAwsTest do
         :telemetry.detach("kms-failure")
       end
     end
+
+    test "emits :request and :failure with error_class :exception when the inner call raises" do
+      prev_key_id = Application.get_env(:engram, :aws_kms_key_id)
+      Application.delete_env(:engram, :aws_kms_key_id)
+
+      :telemetry.attach_many(
+        "kms-exception",
+        [
+          [:engram, :crypto, :kms, :request],
+          [:engram, :crypto, :kms, :failure]
+        ],
+        fn name, _meas, meta, _ -> send(self(), {name, meta}) end,
+        nil
+      )
+
+      try do
+        assert_raise ArgumentError, fn ->
+          Engram.AwsKms.ExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
+        end
+
+        assert_received {[:engram, :crypto, :kms, :request],
+                         %{op: :encrypt, status: :error, error_class: :exception}}
+
+        assert_received {[:engram, :crypto, :kms, :failure],
+                         %{op: :encrypt, error_class: :exception}}
+      after
+        :telemetry.detach("kms-exception")
+        if prev_key_id, do: Application.put_env(:engram, :aws_kms_key_id, prev_key_id)
+      end
+    end
   end
 end

--- a/test/engram/aws_kms/ex_aws_test.exs
+++ b/test/engram/aws_kms/ex_aws_test.exs
@@ -199,4 +199,64 @@ defmodule Engram.AwsKms.ExAwsTest do
     ctx = %{"user_id" => "5", "purpose" => "dek_wrap"}
     assert {:ok, <<0xBB, 0xCC>>} = KmsExAws.re_encrypt(<<0xAA>>, ctx, ctx)
   end
+
+  describe "telemetry" do
+    test "emits :request event with duration_us, op, status on successful encrypt", %{
+      bypass: bypass
+    } do
+      Bypass.expect_once(bypass, "POST", "/", fn conn ->
+        Plug.Conn.resp(conn, 200, ~s({"CiphertextBlob":"#{Base.encode64("ct")}"}))
+      end)
+
+      :telemetry.attach(
+        "kms-req-ok",
+        [:engram, :crypto, :kms, :request],
+        fn _name, meas, meta, _ -> send(self(), {:tel_req, meas, meta}) end,
+        nil
+      )
+
+      try do
+        assert {:ok, "ct"} =
+                 Engram.AwsKms.ExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
+
+        assert_received {:tel_req, %{duration_us: dur}, %{op: :encrypt, status: :ok}}
+        assert is_integer(dur) and dur >= 0
+      after
+        :telemetry.detach("kms-req-ok")
+      end
+    end
+
+    test "emits :failure event with error_class on AccessDenied", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          400,
+          ~s({"__type":"AccessDeniedException","message":"nope"})
+        )
+      end)
+
+      :telemetry.attach_many(
+        "kms-failure",
+        [
+          [:engram, :crypto, :kms, :request],
+          [:engram, :crypto, :kms, :failure]
+        ],
+        fn name, _meas, meta, _ -> send(self(), {name, meta}) end,
+        nil
+      )
+
+      try do
+        assert {:error, :access_denied} =
+                 Engram.AwsKms.ExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
+
+        assert_received {[:engram, :crypto, :kms, :request],
+                         %{op: :encrypt, status: :error, error_class: :access_denied}}
+
+        assert_received {[:engram, :crypto, :kms, :failure],
+                         %{op: :encrypt, error_class: :access_denied}}
+      after
+        :telemetry.detach("kms-failure")
+      end
+    end
+  end
 end

--- a/test/engram/aws_kms/ex_aws_test.exs
+++ b/test/engram/aws_kms/ex_aws_test.exs
@@ -217,7 +217,7 @@ defmodule Engram.AwsKms.ExAwsTest do
 
       try do
         assert {:ok, "ct"} =
-                 Engram.AwsKms.ExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
+                 KmsExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
 
         assert_received {:tel_req, %{duration_us: dur}, %{op: :encrypt, status: :ok}}
         assert is_integer(dur) and dur >= 0
@@ -247,7 +247,7 @@ defmodule Engram.AwsKms.ExAwsTest do
 
       try do
         assert {:error, :access_denied} =
-                 Engram.AwsKms.ExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
+                 KmsExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
 
         assert_received {[:engram, :crypto, :kms, :request],
                          %{op: :encrypt, status: :error, error_class: :access_denied}}
@@ -275,7 +275,7 @@ defmodule Engram.AwsKms.ExAwsTest do
 
       try do
         assert_raise ArgumentError, fn ->
-          Engram.AwsKms.ExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
+          KmsExAws.encrypt("pt", %{"user_id" => "1", "purpose" => "dek_wrap"})
         end
 
         assert_received {[:engram, :crypto, :kms, :request],

--- a/test/engram/crypto/boot_canary_test.exs
+++ b/test/engram/crypto/boot_canary_test.exs
@@ -23,7 +23,7 @@ defmodule Engram.Crypto.BootCanaryTest do
 
       try do
         assert :ok = BootCanary.verify!()
-        assert_received {:canary, %{status: :provisioned}}
+        assert_received {:canary, %{status: :provisioned, provider: :local}}
         assert Repo.aggregate("system_canaries", :count) == 1
       after
         :telemetry.detach("boot-canary-provision")
@@ -42,7 +42,7 @@ defmodule Engram.Crypto.BootCanaryTest do
 
       try do
         assert :ok = BootCanary.verify!()
-        assert_received {:canary, %{status: :ok}}
+        assert_received {:canary, %{status: :ok, provider: :local}}
       after
         :telemetry.detach("boot-canary-ok")
       end
@@ -67,7 +67,8 @@ defmodule Engram.Crypto.BootCanaryTest do
           BootCanary.verify!()
         end
 
-        assert_received {:canary, %{status: :failed, reason_label: "invalid_wrapping"}}
+        assert_received {:canary,
+                         %{status: :failed, reason_label: "invalid_wrapping", provider: :local}}
       after
         :telemetry.detach("boot-canary-fail")
         Application.put_env(:engram, :encryption_master_key, original_master)
@@ -91,7 +92,7 @@ defmodule Engram.Crypto.BootCanaryTest do
       try do
         # Sanity: a regular Local.unwrap_dek/2 with fallback DOES succeed.
         canary_blob = Repo.one(from c in "system_canaries", select: c.wrapped_dek)
-        assert {:ok, _dek} = Local.unwrap_dek(canary_blob, %{user_id: :canary})
+        assert {:ok, _dek} = Local.unwrap_dek(canary_blob, %{user_id: 0})
 
         # But boot canary refuses fallback and raises.
         assert_raise RuntimeError, ~r/boot canary unwrap failed/, fn ->
@@ -106,7 +107,7 @@ defmodule Engram.Crypto.BootCanaryTest do
     test "raises with sha_mismatch label when canary plaintext SHA disagrees" do
       # Insert a canary row whose recorded sha256 is wrong on purpose.
       dek = :crypto.strong_rand_bytes(32)
-      {:ok, wrapped} = Local.wrap_dek(dek, %{user_id: :canary})
+      {:ok, wrapped} = Local.wrap_dek(dek, %{user_id: 0})
       bad_sha = :crypto.hash(:sha256, "wrong plaintext")
       now = DateTime.utc_now()
 
@@ -115,7 +116,7 @@ defmodule Engram.Crypto.BootCanaryTest do
         [%{wrapped_dek: wrapped, dek_sha256: bad_sha, inserted_at: now, updated_at: now}]
       )
 
-      assert_raise RuntimeError, ~r/does not match the\s+recorded SHA256/, fn ->
+      assert_raise RuntimeError, ~r/does not match the recorded\s+SHA256/s, fn ->
         BootCanary.verify!()
       end
     end
@@ -126,6 +127,77 @@ defmodule Engram.Crypto.BootCanaryTest do
       BootCanary.provision!()
       BootCanary.provision!()
       assert Repo.aggregate("system_canaries", :count) == 2
+    end
+  end
+
+  describe "verify!/0 — AwsKms provider" do
+    import Mox
+    setup :verify_on_exit!
+
+    setup do
+      prev_provider = Application.get_env(:engram, :key_provider)
+      prev_client = Application.get_env(:engram, :aws_kms_client)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+      Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+
+      on_exit(fn ->
+        restore_env(:engram, :key_provider, prev_provider)
+        restore_env(:engram, :aws_kms_client, prev_client)
+      end)
+
+      :ok
+    end
+
+    defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+    defp restore_env(app, key, value), do: Application.put_env(app, key, value)
+
+    test "raises when boot_check (DescribeKey) fails" do
+      Repo.insert_all("system_canaries", [
+        %{
+          wrapped_dek: <<0xAA, 0x01, :crypto.strong_rand_bytes(48)::binary>>,
+          dek_sha256: :crypto.hash(:sha256, <<0>>),
+          inserted_at: DateTime.utc_now(),
+          updated_at: DateTime.utc_now()
+        }
+      ])
+
+      expect(Engram.AwsKmsMock, :describe_key, fn -> {:error, :access_denied} end)
+
+      assert_raise RuntimeError, ~r/describe_key|boot_check/i, fn ->
+        Engram.Crypto.BootCanary.verify!()
+      end
+    end
+
+    test "tags :ok telemetry with provider: :aws_kms when DEK round-trips" do
+      dek = :crypto.strong_rand_bytes(32)
+      sha = :crypto.hash(:sha256, dek)
+      blob = <<0xAA, 0x01, :crypto.strong_rand_bytes(48)::binary>>
+
+      Repo.insert_all("system_canaries", [
+        %{
+          wrapped_dek: blob,
+          dek_sha256: sha,
+          inserted_at: DateTime.utc_now(),
+          updated_at: DateTime.utc_now()
+        }
+      ])
+
+      stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+      stub(Engram.AwsKmsMock, :decrypt, fn _ct, _ctx -> {:ok, dek} end)
+
+      :telemetry.attach(
+        "boot-canary-aws-ok",
+        [:engram, :crypto, :boot_canary],
+        fn _n, _m, meta, _ -> send(self(), {:canary, meta}) end,
+        nil
+      )
+
+      try do
+        assert :ok = Engram.Crypto.BootCanary.verify!()
+        assert_received {:canary, %{status: :ok, provider: :aws_kms}}
+      after
+        :telemetry.detach("boot-canary-aws-ok")
+      end
     end
   end
 end

--- a/test/engram/crypto/boot_canary_test.exs
+++ b/test/engram/crypto/boot_canary_test.exs
@@ -182,8 +182,8 @@ defmodule Engram.Crypto.BootCanaryTest do
         }
       ])
 
-      stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
-      stub(Engram.AwsKmsMock, :decrypt, fn _ct, _ctx -> {:ok, dek} end)
+      expect(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+      expect(Engram.AwsKmsMock, :decrypt, fn _ct, _ctx -> {:ok, dek} end)
 
       :telemetry.attach(
         "boot-canary-aws-ok",

--- a/test/engram/crypto/key_provider/aws_kms_test.exs
+++ b/test/engram/crypto/key_provider/aws_kms_test.exs
@@ -142,14 +142,14 @@ defmodule Engram.Crypto.KeyProvider.AwsKmsTest do
   describe "boot_check/0" do
     test "returns :ok when describe_key succeeds" do
       expect(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
-      assert :ok = Engram.Crypto.KeyProvider.AwsKms.boot_check()
+      assert :ok = AwsKms.boot_check()
     end
 
     test "propagates an error tuple when describe_key fails" do
       expect(Engram.AwsKmsMock, :describe_key, fn -> {:error, :access_denied} end)
 
       assert {:error, :access_denied} =
-               Engram.Crypto.KeyProvider.AwsKms.boot_check()
+               AwsKms.boot_check()
     end
   end
 
@@ -164,7 +164,7 @@ defmodule Engram.Crypto.KeyProvider.AwsKmsTest do
       blob = <<0xAA, 0x01, :crypto.strong_rand_bytes(48)::binary>>
 
       assert {:ok, ^dek} =
-               Engram.Crypto.KeyProvider.AwsKms.unwrap_dek_no_fallback(
+               AwsKms.unwrap_dek_no_fallback(
                  blob,
                  %{user_id: 7}
                )
@@ -174,7 +174,7 @@ defmodule Engram.Crypto.KeyProvider.AwsKmsTest do
       blob = <<0x42, 0x01, :crypto.strong_rand_bytes(48)::binary>>
 
       assert {:error, :malformed_wrapped_blob} =
-               Engram.Crypto.KeyProvider.AwsKms.unwrap_dek_no_fallback(
+               AwsKms.unwrap_dek_no_fallback(
                  blob,
                  %{user_id: 7}
                )

--- a/test/engram/crypto/key_provider/aws_kms_test.exs
+++ b/test/engram/crypto/key_provider/aws_kms_test.exs
@@ -138,4 +138,46 @@ defmodule Engram.Crypto.KeyProvider.AwsKmsTest do
     assert {:error, :kms_key_not_found} =
              AwsKms.unwrap_dek(<<0xAA, 0x01, 0xDE, 0xAD>>, %{user_id: 7})
   end
+
+  describe "boot_check/0" do
+    test "returns :ok when describe_key succeeds" do
+      expect(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+      assert :ok = Engram.Crypto.KeyProvider.AwsKms.boot_check()
+    end
+
+    test "propagates an error tuple when describe_key fails" do
+      expect(Engram.AwsKmsMock, :describe_key, fn -> {:error, :access_denied} end)
+
+      assert {:error, :access_denied} =
+               Engram.Crypto.KeyProvider.AwsKms.boot_check()
+    end
+  end
+
+  describe "unwrap_dek_no_fallback/2" do
+    test "delegates to unwrap_dek/2 (AwsKms has no fallback concept)" do
+      dek = :crypto.strong_rand_bytes(32)
+
+      expect(Engram.AwsKmsMock, :decrypt, fn _ct, %{"user_id" => "7", "purpose" => "dek_wrap"} ->
+        {:ok, dek}
+      end)
+
+      blob = <<0xAA, 0x01, :crypto.strong_rand_bytes(48)::binary>>
+
+      assert {:ok, ^dek} =
+               Engram.Crypto.KeyProvider.AwsKms.unwrap_dek_no_fallback(
+                 blob,
+                 %{user_id: 7}
+               )
+    end
+
+    test "returns :malformed_wrapped_blob for blob without provider tag" do
+      blob = <<0x42, 0x01, :crypto.strong_rand_bytes(48)::binary>>
+
+      assert {:error, :malformed_wrapped_blob} =
+               Engram.Crypto.KeyProvider.AwsKms.unwrap_dek_no_fallback(
+                 blob,
+                 %{user_id: 7}
+               )
+    end
+  end
 end

--- a/test/engram/crypto/local_provider_test.exs
+++ b/test/engram/crypto/local_provider_test.exs
@@ -248,6 +248,52 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
     end
   end
 
+  describe "boot_check/0" do
+    test "returns :ok (Local provider has no external state to verify)" do
+      assert :ok = Engram.Crypto.KeyProvider.Local.boot_check()
+    end
+  end
+
+  describe "unwrap_dek_no_fallback/2" do
+    setup do
+      Application.put_env(
+        :engram,
+        :encryption_master_key,
+        Base.encode64(:crypto.strong_rand_bytes(32))
+      )
+
+      :ok
+    end
+
+    test "round-trips a freshly-wrapped DEK" do
+      dek = :crypto.strong_rand_bytes(32)
+      {:ok, wrapped} = Engram.Crypto.KeyProvider.Local.wrap_dek(dek, %{user_id: 7})
+
+      assert {:ok, ^dek} =
+               Engram.Crypto.KeyProvider.Local.unwrap_dek_no_fallback(
+                 wrapped,
+                 %{user_id: 7}
+               )
+    end
+
+    test "does NOT consult _PREVIOUS — wrong master key returns :invalid_wrapping" do
+      dek = :crypto.strong_rand_bytes(32)
+      {:ok, wrapped} = Engram.Crypto.KeyProvider.Local.wrap_dek(dek, %{user_id: 7})
+
+      Application.put_env(
+        :engram,
+        :encryption_master_key,
+        Base.encode64(:crypto.strong_rand_bytes(32))
+      )
+
+      assert {:error, :invalid_wrapping} =
+               Engram.Crypto.KeyProvider.Local.unwrap_dek_no_fallback(
+                 wrapped,
+                 %{user_id: 7}
+               )
+    end
+  end
+
   describe "Logger on dual-fallback failure (T3-audit M5)" do
     test "logs error when neither current nor _PREVIOUS unwraps the DEK" do
       # T3-audit M5 — a user whose DEK cannot be unwrapped by EITHER the

--- a/test/engram/crypto/local_provider_test.exs
+++ b/test/engram/crypto/local_provider_test.exs
@@ -250,7 +250,7 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
 
   describe "boot_check/0" do
     test "returns :ok (Local provider has no external state to verify)" do
-      assert :ok = Engram.Crypto.KeyProvider.Local.boot_check()
+      assert :ok = Local.boot_check()
     end
   end
 
@@ -267,10 +267,10 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
 
     test "round-trips a freshly-wrapped DEK" do
       dek = :crypto.strong_rand_bytes(32)
-      {:ok, wrapped} = Engram.Crypto.KeyProvider.Local.wrap_dek(dek, %{user_id: 7})
+      {:ok, wrapped} = Local.wrap_dek(dek, %{user_id: 7})
 
       assert {:ok, ^dek} =
-               Engram.Crypto.KeyProvider.Local.unwrap_dek_no_fallback(
+               Local.unwrap_dek_no_fallback(
                  wrapped,
                  %{user_id: 7}
                )
@@ -278,7 +278,7 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
 
     test "does NOT consult _PREVIOUS — wrong master key returns :invalid_wrapping" do
       dek = :crypto.strong_rand_bytes(32)
-      {:ok, wrapped} = Engram.Crypto.KeyProvider.Local.wrap_dek(dek, %{user_id: 7})
+      {:ok, wrapped} = Local.wrap_dek(dek, %{user_id: 7})
 
       Application.put_env(
         :engram,
@@ -287,7 +287,7 @@ defmodule Engram.Crypto.KeyProvider.LocalTest do
       )
 
       assert {:error, :invalid_wrapping} =
-               Engram.Crypto.KeyProvider.Local.unwrap_dek_no_fallback(
+               Local.unwrap_dek_no_fallback(
                  wrapped,
                  %{user_id: 7}
                )

--- a/test/engram/crypto/provider_conformance_test.exs
+++ b/test/engram/crypto/provider_conformance_test.exs
@@ -113,5 +113,23 @@ defmodule Engram.Crypto.ProviderConformanceTest do
       assert new_wrapped != old_wrapped
       assert {:ok, ^new_dek} = unquote(provider).unwrap_dek(new_wrapped, ctx)
     end
+
+    test "#{inspect(provider)}: boot_check returns :ok in happy path" do
+      if unquote(provider) == Engram.Crypto.KeyProvider.AwsKms do
+        stub_aws_kms_roundtrip()
+        stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+      end
+
+      assert :ok = unquote(provider).boot_check()
+    end
+
+    test "#{inspect(provider)}: unwrap_dek_no_fallback round-trips wrapped DEK" do
+      if unquote(provider) == Engram.Crypto.KeyProvider.AwsKms, do: stub_aws_kms_roundtrip()
+
+      dek = unquote(provider).generate_dek()
+      ctx = %{user_id: 1}
+      {:ok, wrapped} = unquote(provider).wrap_dek(dek, ctx)
+      assert {:ok, ^dek} = unquote(provider).unwrap_dek_no_fallback(wrapped, ctx)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Adds `boot_check/0` and `unwrap_dek_no_fallback/2` callbacks to `Engram.Crypto.KeyProvider` — implemented on both `Local` and `AwsKms`.
- `BootCanary.verify!/0` now dispatches through `Resolver.provider()`. Local keeps its no-`_PREVIOUS` semantics; AwsKms gates boot with a single `DescribeKey` ping so wrong-ARN / IAM-denied / wrong-region misconfiguration crashes the app at startup instead of breaking the first user request.
- Every `Engram.AwsKms.ExAws` call emits `[:engram, :crypto, :kms, :request]` (with `duration_us`, `op`, `status`) and `[:engram, :crypto, :kms, :failure]` (with `error_class`) — including the raise path (`error_class: :exception`).
- Canary `user_id` sentinel migrated from atom `:canary` to integer `0` to satisfy AwsKms's `encryption_context` contract.
- Production behaviour unchanged: `KEY_PROVIDER=local` remains default in `config/runtime.exs`; new KMS code is dead-loaded until Phase 4 cutover.

## Test plan
- [x] `mix test` — 1168 tests, 0 failures, 7 skipped
- [x] `mix format --check-formatted` — clean
- [x] `mix compile --warnings-as-errors --force` — clean
- [x] `mix credo --strict` — no issues
- [x] `mix sobelow --exit low` — pass
- [ ] CI green (lint + unit + e2e + dialyzer)

## Out of scope (next phases)
- Phase 3: `Crypto.ProviderMigration` state machine + Oban backfill worker.
- Phase 4: Fly secrets + IAM policy + production cutover runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)