### PR TITLE
feat(ui): system-aware dark mode

### DIFF
--- a/docs/superpowers/plans/2026-05-11-dark-mode.md
+++ b/docs/superpowers/plans/2026-05-11-dark-mode.md
@@ -1,0 +1,1071 @@
+# Dark Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a system-aware dark theme for the Engram SPA with a manual Light/Dark/System override via header icon and Settings page.
+
+**Architecture:** Tailwind v4 class-based dark variant (`.dark` on `<html>`). A React `ThemeProvider` owns state (`'system' | 'light' | 'dark'`), persists to `localStorage`, subscribes to `prefers-color-scheme` when in `system` mode, and toggles the `.dark` class. An inline boot script in `index.html` applies the class before React mounts to prevent FOUC.
+
+**Tech Stack:** React 19, Tailwind CSS v4, Vite, Playwright (e2e), TypeScript.
+
+**Note on TDD:** This repo's frontend has no unit-test runner (only Playwright e2e). Per spec, theme logic is small and pure; we validate via Playwright e2e and manual smoke. Tasks below follow a tight test → implement → commit cadence using Playwright where state can be observed. Tasks for pure helpers (`storage.ts`, `resolve.ts`) ship without unit tests and are exercised by the e2e tests in Task 11. Adding Vitest is explicitly out of scope.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-dark-mode-design.md`
+
+---
+
+## File Structure
+
+**New files (under `frontend/src/theme/`):**
+
+| Path | Responsibility |
+|------|----------------|
+| `frontend/src/theme/storage.ts` | Safe `localStorage` read/write of `engram:theme`; validation; try/catch. |
+| `frontend/src/theme/resolve.ts` | Pure: resolve `'system'\|'light'\|'dark'` + system pref → `'light'\|'dark'`; apply class to `<html>`. |
+| `frontend/src/theme/theme-provider.tsx` | React context. State + setter. matchMedia subscription. Exports `useTheme()`. |
+| `frontend/src/theme/theme-toggle.tsx` | Header icon button cycling Light → Dark → System. Inline SVG icons. |
+| `frontend/src/theme/theme-segmented.tsx` | Settings 3-button segmented control. |
+| `frontend/src/settings/appearance-page.tsx` | New settings sub-page hosting `<ThemeSegmented>`. |
+| `frontend/e2e/dark-mode.spec.ts` | Playwright e2e for toggle + persistence + system tracking + FOUC. |
+
+**Modified files:**
+
+| Path | Change |
+|------|--------|
+| `frontend/index.html` | Add `<meta name="color-scheme">` + inline anti-FOUC `<script>`. |
+| `frontend/src/main.css` | Add `@custom-variant dark`. Dual highlight.js import. |
+| `frontend/src/main.tsx` | Wrap router in `<ThemeProvider>`. |
+| `frontend/src/layout/app-layout.tsx` | Mount `<ThemeToggle>`. Add `dark:` variants. |
+| `frontend/src/layout/vault-switcher.tsx` | Add `dark:` variants. |
+| `frontend/src/viewer/{dashboard,folder-tree,note-page,note-view,search-page}.tsx` | Add `dark:` variants. |
+| `frontend/src/settings/{settings-layout,api-keys-page,encryption-page,billing-placeholder}.tsx` | Add `dark:` variants. Add `Appearance` nav entry to `settings-layout.tsx`. |
+| `frontend/src/auth/{local-sign-in,local-sign-up,local-user-menu}.tsx` | Add `dark:` variants. |
+| `frontend/src/billing/billing-page.tsx` | Add `dark:` variants. |
+| `frontend/src/{not-found.tsx,device/device-link-page.tsx,oauth/oauth-authorize-page.tsx}` | Add `dark:` variants. |
+| `frontend/src/router.tsx` | Register `appearance` settings route. |
+
+---
+
+## Task 1: Enable Tailwind v4 dark variant + color-scheme meta
+
+**Files:**
+- Modify: `frontend/src/main.css`
+- Modify: `frontend/index.html`
+
+- [ ] **Step 1: Update `frontend/src/main.css`** — add class-based dark variant.
+
+Replace the whole file with:
+
+```css
+@import "tailwindcss";
+@import "highlight.js/styles/github.css";
+
+@custom-variant dark (&:where(.dark, .dark *));
+```
+
+(Highlight.js dark theme arrives in Task 10.)
+
+- [ ] **Step 2: Update `frontend/index.html`** — add `color-scheme` meta so native UA chrome matches.
+
+Replace lines 3–8 with:
+
+```html
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>Engram</title>
+  </head>
+```
+
+- [ ] **Step 3: Verify build still passes**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: exit 0, no errors.
+
+Run: `cd frontend && npx vite build`
+Expected: completes successfully; emits to `../priv/static/app`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/main.css frontend/index.html
+git commit -m "feat(ui): enable Tailwind v4 dark variant + color-scheme meta"
+```
+
+---
+
+## Task 2: Storage helper
+
+**Files:**
+- Create: `frontend/src/theme/storage.ts`
+
+- [ ] **Step 1: Create `frontend/src/theme/storage.ts`**
+
+```ts
+export type ThemeChoice = 'system' | 'light' | 'dark'
+
+const KEY = 'engram:theme'
+const VALID: readonly ThemeChoice[] = ['system', 'light', 'dark']
+
+export function getStoredTheme(): ThemeChoice {
+  try {
+    const raw = window.localStorage.getItem(KEY)
+    if (raw && (VALID as readonly string[]).includes(raw)) {
+      return raw as ThemeChoice
+    }
+  } catch {
+    // localStorage may throw in private mode or sandboxed contexts
+  }
+  return 'system'
+}
+
+export function setStoredTheme(choice: ThemeChoice): void {
+  try {
+    window.localStorage.setItem(KEY, choice)
+  } catch {
+    // best-effort; ignore failures
+  }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/theme/storage.ts
+git commit -m "feat(theme): add safe localStorage helper for theme choice"
+```
+
+---
+
+## Task 3: Theme resolver
+
+**Files:**
+- Create: `frontend/src/theme/resolve.ts`
+
+- [ ] **Step 1: Create `frontend/src/theme/resolve.ts`**
+
+```ts
+import type { ThemeChoice } from './storage'
+
+export type ResolvedTheme = 'light' | 'dark'
+
+export function getSystemPreference(): ResolvedTheme {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light'
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function resolveTheme(choice: ThemeChoice, systemPref: ResolvedTheme): ResolvedTheme {
+  return choice === 'system' ? systemPref : choice
+}
+
+export function applyThemeClass(resolved: ResolvedTheme): void {
+  const root = document.documentElement
+  if (resolved === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/theme/resolve.ts
+git commit -m "feat(theme): add pure theme resolver + DOM class applier"
+```
+
+---
+
+## Task 4: Anti-FOUC inline boot script
+
+**Files:**
+- Modify: `frontend/index.html`
+
+- [ ] **Step 1: Add inline boot script before `<body>`**
+
+Replace the full contents of `frontend/index.html` with:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>Engram</title>
+    <script>
+      (function () {
+        try {
+          var stored = window.localStorage.getItem('engram:theme');
+          var valid = stored === 'light' || stored === 'dark' || stored === 'system';
+          var choice = valid ? stored : 'system';
+          var prefersDark =
+            window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var resolved = choice === 'system' ? (prefersDark ? 'dark' : 'light') : choice;
+          if (resolved === 'dark') {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (_) {
+          /* fall back to default (light) */
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+Rationale: this script must duplicate `storage.ts` + `resolve.ts` logic because it runs *before* the JS bundle. It is the only place that duplication is acceptable. Keep it minimal — three constants, one branch.
+
+- [ ] **Step 2: Smoke check in dev server**
+
+Run: `cd frontend && npx vite` (in a second terminal or background).
+
+Then in browser DevTools console, set `localStorage.setItem('engram:theme','dark')` and reload `http://localhost:5173/`. Inspect `<html>` element — it should have `class="dark"` on first paint.
+
+Stop the dev server when done.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/index.html
+git commit -m "feat(theme): inline boot script to apply theme before paint"
+```
+
+---
+
+## Task 5: ThemeProvider + useTheme hook
+
+**Files:**
+- Create: `frontend/src/theme/theme-provider.tsx`
+
+- [ ] **Step 1: Create `frontend/src/theme/theme-provider.tsx`**
+
+```tsx
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { getStoredTheme, setStoredTheme, type ThemeChoice } from './storage'
+import { applyThemeClass, getSystemPreference, resolveTheme, type ResolvedTheme } from './resolve'
+
+interface ThemeContextValue {
+  theme: ThemeChoice
+  resolved: ResolvedTheme
+  setTheme: (next: ThemeChoice) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeChoice>(() => getStoredTheme())
+  const [systemPref, setSystemPref] = useState<ResolvedTheme>(() => getSystemPreference())
+
+  const resolved = useMemo(() => resolveTheme(theme, systemPref), [theme, systemPref])
+
+  useEffect(() => {
+    applyThemeClass(resolved)
+  }, [resolved])
+
+  useEffect(() => {
+    if (theme !== 'system') return
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => setSystemPref(e.matches ? 'dark' : 'light')
+
+    setSystemPref(mql.matches ? 'dark' : 'light')
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [theme])
+
+  const setTheme = useCallback((next: ThemeChoice) => {
+    setStoredTheme(next)
+    setThemeState(next)
+  }, [])
+
+  const value = useMemo(() => ({ theme, resolved, setTheme }), [theme, resolved, setTheme])
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/theme/theme-provider.tsx
+git commit -m "feat(theme): add ThemeProvider with matchMedia subscription"
+```
+
+---
+
+## Task 6: Wire ThemeProvider into main.tsx
+
+**Files:**
+- Modify: `frontend/src/main.tsx`
+
+- [ ] **Step 1: Update `frontend/src/main.tsx`**
+
+Replace the full file with:
+
+```tsx
+import { StrictMode, lazy, Suspense } from 'react'
+import { createRoot } from 'react-dom/client'
+import { RouterProvider } from 'react-router'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { router } from './router'
+import { queryClient } from './api/query-client'
+import { config } from './config'
+import { ThemeProvider } from './theme/theme-provider'
+import './main.css'
+
+const isClerk = config.authProvider === 'clerk'
+
+const AuthProvider = isClerk
+  ? lazy(() => import('./auth/clerk-auth-provider'))
+  : lazy(() => import('./auth/local-auth-provider'))
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ThemeProvider>
+      <Suspense fallback={<p>Loading...</p>}>
+        <AuthProvider>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </AuthProvider>
+      </Suspense>
+    </ThemeProvider>
+  </StrictMode>,
+)
+```
+
+`ThemeProvider` wraps everything (including `Suspense`) so the loading fallback also gets themed.
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd frontend && npx tsc --noEmit && npx vite build`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/main.tsx
+git commit -m "feat(theme): mount ThemeProvider at app root"
+```
+
+---
+
+## Task 7: ThemeToggle (header icon)
+
+**Files:**
+- Create: `frontend/src/theme/theme-toggle.tsx`
+- Modify: `frontend/src/layout/app-layout.tsx`
+
+- [ ] **Step 1: Create `frontend/src/theme/theme-toggle.tsx`**
+
+```tsx
+import { useTheme } from './theme-provider'
+import type { ThemeChoice } from './storage'
+
+const NEXT: Record<ThemeChoice, ThemeChoice> = {
+  light: 'dark',
+  dark: 'system',
+  system: 'light',
+}
+
+const LABEL: Record<ThemeChoice, string> = {
+  light: 'Switch to dark theme',
+  dark: 'Switch to system theme',
+  system: 'Switch to light theme',
+}
+
+function Icon({ choice }: { choice: ThemeChoice }) {
+  // 18x18 outline icons, currentColor stroke
+  if (choice === 'light') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+      </svg>
+    )
+  }
+  if (choice === 'dark') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+      </svg>
+    )
+  }
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="2" y="4" width="20" height="14" rx="2" />
+      <path d="M8 22h8M12 18v4" />
+    </svg>
+  )
+}
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(NEXT[theme])}
+      aria-label={LABEL[theme]}
+      title={LABEL[theme]}
+      data-theme-choice={theme}
+      className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+    >
+      <Icon choice={theme} />
+    </button>
+  )
+}
+```
+
+The `data-theme-choice` attribute is for Playwright assertions.
+
+- [ ] **Step 2: Mount toggle in app header**
+
+In `frontend/src/layout/app-layout.tsx`, add the import near the top:
+
+```tsx
+import ThemeToggle from '../theme/theme-toggle'
+```
+
+Then within the `<nav>` (currently containing Search, Billing, Settings links + UserButton), insert `<ThemeToggle />` right before the `<Suspense>` block, e.g.:
+
+```tsx
+<Link to="/settings" className="text-sm text-gray-600 hover:text-gray-900 hover:underline">
+  Settings
+</Link>
+<ThemeToggle />
+<Suspense fallback={null}>
+  {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
+</Suspense>
+```
+
+(The full dark-variant pass over `app-layout.tsx` is Task 9; this task only adds the toggle.)
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd frontend && npx tsc --noEmit && npx vite build`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/theme/theme-toggle.tsx frontend/src/layout/app-layout.tsx
+git commit -m "feat(theme): add header ThemeToggle cycling Light/Dark/System"
+```
+
+---
+
+## Task 8: ThemeSegmented + Appearance settings page + route
+
+**Files:**
+- Create: `frontend/src/theme/theme-segmented.tsx`
+- Create: `frontend/src/settings/appearance-page.tsx`
+- Modify: `frontend/src/settings/settings-layout.tsx`
+- Modify: `frontend/src/router.tsx`
+
+- [ ] **Step 1: Create `frontend/src/theme/theme-segmented.tsx`**
+
+```tsx
+import { useTheme } from './theme-provider'
+import type { ThemeChoice } from './storage'
+
+const OPTIONS: ReadonlyArray<{ value: ThemeChoice; label: string }> = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+]
+
+export default function ThemeSegmented() {
+  const { theme, setTheme } = useTheme()
+  return (
+    <fieldset className="inline-flex rounded-md border border-gray-300 bg-white p-0.5 dark:border-gray-700 dark:bg-gray-900">
+      <legend className="sr-only">Theme</legend>
+      {OPTIONS.map((opt) => {
+        const active = theme === opt.value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => setTheme(opt.value)}
+            aria-pressed={active}
+            data-theme-option={opt.value}
+            className={
+              active
+                ? 'rounded px-3 py-1 text-sm font-medium bg-blue-600 text-white dark:bg-blue-500'
+                : 'rounded px-3 py-1 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
+            }
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </fieldset>
+  )
+}
+```
+
+- [ ] **Step 2: Create `frontend/src/settings/appearance-page.tsx`**
+
+```tsx
+import ThemeSegmented from '../theme/theme-segmented'
+
+export default function AppearancePage() {
+  return (
+    <section>
+      <h1 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">Appearance</h1>
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium text-gray-700 dark:text-gray-200">Theme</legend>
+        <ThemeSegmented />
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          System follows your operating system preference.
+        </p>
+      </fieldset>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 3: Add `Appearance` to settings nav**
+
+In `frontend/src/settings/settings-layout.tsx`, update `SECTIONS`:
+
+```tsx
+const SECTIONS = [
+  { to: 'appearance', label: 'Appearance' },
+  { to: 'api-keys', label: 'API Keys' },
+  { to: 'encryption', label: 'Encryption' },
+  { to: 'billing', label: 'Billing' },
+] as const
+```
+
+- [ ] **Step 4: Register route in `frontend/src/router.tsx`**
+
+Add the import:
+
+```tsx
+import AppearancePage from './settings/appearance-page'
+```
+
+Then in the settings children array, change the index redirect target and add the route:
+
+```tsx
+{
+  path: '/settings',
+  element: <SettingsLayout />,
+  children: [
+    { index: true, element: <Navigate to="appearance" replace /> },
+    { path: 'appearance', element: <AppearancePage /> },
+    { path: 'api-keys', element: <ApiKeysPage /> },
+    { path: 'encryption', element: <EncryptionPage /> },
+    { path: 'billing', element: <BillingPlaceholder /> },
+  ],
+},
+```
+
+- [ ] **Step 5: Verify build**
+
+Run: `cd frontend && npx tsc --noEmit && npx vite build`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/theme/theme-segmented.tsx frontend/src/settings/appearance-page.tsx frontend/src/settings/settings-layout.tsx frontend/src/router.tsx
+git commit -m "feat(theme): add Appearance settings page with theme picker"
+```
+
+---
+
+## Task 9: Dark variants — layout + auth
+
+**Files:**
+- Modify: `frontend/src/layout/app-layout.tsx`
+- Modify: `frontend/src/layout/vault-switcher.tsx`
+- Modify: `frontend/src/auth/local-sign-in.tsx`
+- Modify: `frontend/src/auth/local-sign-up.tsx`
+- Modify: `frontend/src/auth/local-user-menu.tsx`
+
+**Color mapping (apply consistently across this task and Tasks 10–11):**
+
+| Light class | Dark addition |
+|---|---|
+| `bg-white` | `dark:bg-gray-900` |
+| `bg-gray-50` | `dark:bg-gray-950` |
+| `bg-gray-100` | `dark:bg-gray-800` |
+| `text-gray-900` | `dark:text-gray-100` |
+| `text-gray-700` | `dark:text-gray-200` |
+| `text-gray-600` | `dark:text-gray-300` |
+| `text-gray-500` | `dark:text-gray-400` |
+| `border-gray-200` | `dark:border-gray-800` |
+| `border-gray-300` | `dark:border-gray-700` |
+| `bg-blue-50 text-blue-800` | `dark:bg-blue-950 dark:text-blue-200` |
+| `bg-blue-50 text-blue-700` (active nav) | `dark:bg-blue-950 dark:text-blue-300` |
+| `bg-amber-50 text-amber-800` | `dark:bg-amber-950 dark:text-amber-200` |
+| `hover:bg-gray-100` | `dark:hover:bg-gray-800` |
+| `hover:bg-gray-200` | `dark:hover:bg-gray-700` |
+| `hover:text-gray-700` | `dark:hover:text-gray-200` |
+| `hover:text-gray-900` | `dark:hover:text-gray-100` |
+
+- [ ] **Step 1: Update `frontend/src/layout/app-layout.tsx`**
+
+Apply mappings to every color-bearing class. The final return block should be:
+
+```tsx
+return (
+  <>
+    {billing?.tier === 'none' && (
+      <aside className="bg-blue-50 px-4 py-2 text-center text-sm text-blue-800 dark:bg-blue-950 dark:text-blue-200" role="alert">
+        Start a free trial to sync your notes.{' '}
+        <Link to="/billing" className="font-medium underline">
+          Choose a plan
+        </Link>
+      </aside>
+    )}
+    {billing?.subscription?.status === 'trialing' && billing.trial_days_remaining > 0 && billing.trial_days_remaining <= 3 && (
+      <aside className="bg-amber-50 px-4 py-2 text-center text-sm text-amber-800 dark:bg-amber-950 dark:text-amber-200" role="alert">
+        {billing.trial_days_remaining} days left in your trial.
+      </aside>
+    )}
+    <section className="flex h-screen flex-col">
+      <header className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-800 dark:bg-gray-900">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setSidebarOpen((o) => !o)}
+            aria-label={sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
+            aria-expanded={sidebarOpen}
+            aria-controls="sidebar"
+            className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+          >
+            {sidebarOpen ? '◀' : '▶'}
+          </button>
+          <Link to="/" className="text-lg font-semibold text-gray-900 hover:text-gray-700 dark:text-gray-100 dark:hover:text-gray-200">
+            Engram
+          </Link>
+        </div>
+        <nav className="flex items-center gap-4" aria-label="Main navigation">
+          <Link to="/search" className="text-sm text-gray-600 hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-gray-100">
+            Search
+          </Link>
+          <Link to="/billing" className="text-sm text-gray-600 hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-gray-100">
+            Billing
+          </Link>
+          <Link to="/settings" className="text-sm text-gray-600 hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-gray-100">
+            Settings
+          </Link>
+          <ThemeToggle />
+          <Suspense fallback={null}>
+            {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
+          </Suspense>
+        </nav>
+      </header>
+
+      <section className="flex flex-1 overflow-hidden bg-white dark:bg-gray-900">
+        <aside
+          id="sidebar"
+          aria-label="Folder navigation"
+          className={`${
+            sidebarOpen ? 'w-64' : 'w-0'
+          } shrink-0 overflow-y-auto border-r border-gray-200 bg-gray-50 transition-all duration-200 dark:border-gray-800 dark:bg-gray-950`}
+        >
+          {sidebarOpen && (
+            <>
+              <VaultSwitcher />
+              <FolderTree />
+            </>
+          )}
+        </aside>
+
+        <main className="flex-1 overflow-y-auto p-6 text-gray-900 dark:text-gray-100">
+          <Outlet />
+        </main>
+      </section>
+    </section>
+  </>
+)
+```
+
+Note the added `bg-white dark:bg-gray-900` on the flex container under `<header>` and `text-gray-900 dark:text-gray-100` on `<main>` to establish the page surface and default text color.
+
+- [ ] **Step 2: Update auth pages and vault-switcher**
+
+For each of `vault-switcher.tsx`, `local-sign-in.tsx`, `local-sign-up.tsx`, `local-user-menu.tsx`: read the file, then for every class containing one of the light tokens in the mapping table above, append the corresponding `dark:` token to the same `className`. Preserve all other classes and structure verbatim.
+
+Examples of expected substitutions:
+
+- `className="text-sm text-gray-600"` → `className="text-sm text-gray-600 dark:text-gray-300"`
+- `className="rounded border border-gray-300 bg-white px-3 py-2"` → `className="rounded border border-gray-300 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-900"`
+- Active state `"bg-blue-50 font-medium text-blue-700"` → `"bg-blue-50 font-medium text-blue-700 dark:bg-blue-950 dark:text-blue-300"`
+
+If a file uses `bg-red-50 text-red-700` for error blocks, append `dark:bg-red-950 dark:text-red-200`. Same pattern for green: `dark:bg-green-950 dark:text-green-200`.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd frontend && npx tsc --noEmit && npx vite build`
+Expected: exit 0.
+
+- [ ] **Step 4: Smoke check**
+
+Start dev server (`npx vite`). Visit `/sign-in` and `/`. Toggle theme via header. Verify no white flashes, no unreadable text. Stop server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/layout/ frontend/src/auth/
+git commit -m "feat(ui): add dark variants to layout + auth pages"
+```
+
+---
+
+## Task 10: Dark variants — viewer + settings + remaining pages + highlight.js
+
+**Files:**
+- Modify: `frontend/src/main.css`
+- Modify: `frontend/src/viewer/dashboard.tsx`
+- Modify: `frontend/src/viewer/folder-tree.tsx`
+- Modify: `frontend/src/viewer/note-page.tsx`
+- Modify: `frontend/src/viewer/note-view.tsx`
+- Modify: `frontend/src/viewer/search-page.tsx`
+- Modify: `frontend/src/settings/settings-layout.tsx`
+- Modify: `frontend/src/settings/api-keys-page.tsx`
+- Modify: `frontend/src/settings/encryption-page.tsx`
+- Modify: `frontend/src/settings/billing-placeholder.tsx`
+- Modify: `frontend/src/billing/billing-page.tsx`
+- Modify: `frontend/src/not-found.tsx`
+- Modify: `frontend/src/device/device-link-page.tsx`
+- Modify: `frontend/src/oauth/oauth-authorize-page.tsx`
+
+- [ ] **Step 1: Swap highlight.js to mode-aware imports in `frontend/src/main.css`**
+
+Replace the file with:
+
+```css
+@import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* Light highlight.js theme — applies by default. */
+@import "highlight.js/styles/github.css" layer(base);
+
+/* Dark highlight.js theme — wrapped so it only applies under `.dark`. */
+@layer base {
+  html.dark .hljs {
+    color: #c9d1d9;
+    background: #0d1117;
+  }
+  html.dark .hljs-doctag,
+  html.dark .hljs-keyword,
+  html.dark .hljs-meta .hljs-keyword,
+  html.dark .hljs-template-tag,
+  html.dark .hljs-template-variable,
+  html.dark .hljs-type,
+  html.dark .hljs-variable.language_ { color: #ff7b72; }
+  html.dark .hljs-title,
+  html.dark .hljs-title.class_,
+  html.dark .hljs-title.class_.inherited__,
+  html.dark .hljs-title.function_ { color: #d2a8ff; }
+  html.dark .hljs-attr,
+  html.dark .hljs-attribute,
+  html.dark .hljs-literal,
+  html.dark .hljs-meta,
+  html.dark .hljs-number,
+  html.dark .hljs-operator,
+  html.dark .hljs-variable,
+  html.dark .hljs-selector-attr,
+  html.dark .hljs-selector-class,
+  html.dark .hljs-selector-id { color: #79c0ff; }
+  html.dark .hljs-regexp,
+  html.dark .hljs-string,
+  html.dark .hljs-meta .hljs-string { color: #a5d6ff; }
+  html.dark .hljs-built_in,
+  html.dark .hljs-symbol { color: #ffa657; }
+  html.dark .hljs-comment,
+  html.dark .hljs-code,
+  html.dark .hljs-formula { color: #8b949e; }
+  html.dark .hljs-name,
+  html.dark .hljs-quote,
+  html.dark .hljs-selector-tag,
+  html.dark .hljs-selector-pseudo { color: #7ee787; }
+  html.dark .hljs-section { color: #1f6feb; font-weight: bold; }
+  html.dark .hljs-bullet { color: #f2cc60; }
+  html.dark .hljs-emphasis { color: #c9d1d9; font-style: italic; }
+  html.dark .hljs-strong { color: #c9d1d9; font-weight: bold; }
+  html.dark .hljs-addition { color: #aff5b4; background: #033a16; }
+  html.dark .hljs-deletion { color: #ffdcd7; background: #67060c; }
+}
+```
+
+(These hex values are the standard `github-dark` palette from `highlight.js/styles/github-dark.css`, inlined here so the dark theme only applies under `.dark` without needing a runtime `<link>` swap.)
+
+- [ ] **Step 2: Apply the dark mapping to each remaining file**
+
+Mapping (same as Task 9 — repeated here so this task is self-contained):
+
+| Light class | Dark addition |
+|---|---|
+| `bg-white` | `dark:bg-gray-900` |
+| `bg-gray-50` | `dark:bg-gray-950` |
+| `bg-gray-100` | `dark:bg-gray-800` |
+| `text-gray-900` | `dark:text-gray-100` |
+| `text-gray-700` | `dark:text-gray-200` |
+| `text-gray-600` | `dark:text-gray-300` |
+| `text-gray-500` | `dark:text-gray-400` |
+| `border-gray-200` | `dark:border-gray-800` |
+| `border-gray-300` | `dark:border-gray-700` |
+| `bg-blue-50 text-blue-800` | `dark:bg-blue-950 dark:text-blue-200` |
+| `bg-blue-50 text-blue-700` (active nav) | `dark:bg-blue-950 dark:text-blue-300` |
+| `bg-amber-50 text-amber-800` | `dark:bg-amber-950 dark:text-amber-200` |
+| `bg-red-50 text-red-700` | `dark:bg-red-950 dark:text-red-200` |
+| `bg-green-50 text-green-700` | `dark:bg-green-950 dark:text-green-200` |
+| `hover:bg-gray-100` | `dark:hover:bg-gray-800` |
+| `hover:bg-gray-200` | `dark:hover:bg-gray-700` |
+| `hover:text-gray-700` | `dark:hover:text-gray-200` |
+| `hover:text-gray-900` | `dark:hover:text-gray-100` |
+
+For every listed file under `viewer/`, `settings/`, `billing/`, `not-found.tsx`, `device/`, `oauth/`: scan every `className` attribute. For each light-side token from the mapping, append the corresponding `dark:` token to the same `className`. Preserve all structure, ordering, and non-color classes.
+
+Heuristic to avoid missing anything: after editing, run
+
+```bash
+cd frontend && grep -rEn "bg-(white|gray-50|gray-100)|text-gray-(900|700|600|500)|border-gray-(200|300)" src/ --include="*.tsx"
+```
+
+For every line returned that does NOT already contain a `dark:` companion, add it.
+
+Special cases:
+- `folder-tree.tsx` active/selected row: ensure `dark:bg-gray-800` on hover/active rows.
+- `note-view.tsx` prose: `<article>` (or wrapper) should add `dark:prose-invert` to its `prose` class.
+- `search-page.tsx` input: `<input>` styling needs `dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-500`.
+- `billing-page.tsx` cards: card surfaces use `bg-white` → `dark:bg-gray-900`; muted captions use `text-gray-500` → `dark:text-gray-400`.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd frontend && npx tsc --noEmit && npx vite build`
+Expected: exit 0.
+
+- [ ] **Step 4: Smoke check**
+
+Start dev server. Sign in, navigate dashboard → a note (with code block) → search → settings/appearance → billing → /not-existing. Toggle through all three themes. Verify:
+- No unreadable text in either theme.
+- Code blocks legible in both themes.
+- Active settings nav row visible in dark.
+
+Stop server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/main.css frontend/src/viewer/ frontend/src/settings/ frontend/src/billing/ frontend/src/not-found.tsx frontend/src/device/ frontend/src/oauth/
+git commit -m "feat(ui): add dark variants across remaining pages + dark code blocks"
+```
+
+---
+
+## Task 11: Playwright e2e
+
+**Files:**
+- Create: `frontend/e2e/dark-mode.spec.ts`
+
+- [ ] **Step 1: Inspect existing Playwright setup**
+
+Read `frontend/playwright.config.ts` and `frontend/e2e/local-auth.spec.ts` to confirm how the local-auth flow logs a user in. Reuse the same `registerUser` + sign-in pattern so the new tests can reach `/settings/appearance`.
+
+- [ ] **Step 2: Create `frontend/e2e/dark-mode.spec.ts`**
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const TEST_PASSWORD = 'E2eTestPass!99'
+
+async function registerUser(baseURL: string, email: string) {
+  const res = await fetch(`${baseURL}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: TEST_PASSWORD }),
+  })
+  if (res.status === 422) return
+  if (!res.ok) throw new Error(`Register failed: ${res.status} ${await res.text()}`)
+}
+
+function testEmail(label: string) {
+  return `e2e-theme-${Date.now()}-${label}@test.com`
+}
+
+async function signIn(page: import('@playwright/test').Page, email: string) {
+  await page.goto('/sign-in/')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password', { exact: true }).fill(TEST_PASSWORD)
+  await page.getByRole('button', { name: /sign in/i }).click()
+  await expect(page).toHaveURL('/')
+}
+
+test.describe('Dark mode', () => {
+  test('header toggle cycles Light → Dark → System and persists', async ({ page, baseURL }) => {
+    const email = testEmail('cycle')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    const toggle = page.getByRole('button', { name: /switch to .* theme/i })
+    // Default is system. On a default headless Chromium, system pref is light.
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+
+    // System → Light
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'light')
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+
+    // Light → Dark
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'dark')
+    await expect(page.locator('html')).toHaveClass(/dark/)
+
+    // Dark → System
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'system')
+
+    const stored = await page.evaluate(() => window.localStorage.getItem('engram:theme'))
+    expect(stored).toBe('system')
+  })
+
+  test('Settings → Appearance segmented control sets theme', async ({ page, baseURL }) => {
+    const email = testEmail('settings')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    await page.goto('/settings/appearance')
+    await page.getByRole('button', { name: 'Dark' }).click()
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await expect(page.getByRole('button', { name: 'Dark' })).toHaveAttribute('aria-pressed', 'true')
+
+    await page.getByRole('button', { name: 'Light' }).click()
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+    await expect(page.getByRole('button', { name: 'Light' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('System mode tracks prefers-color-scheme', async ({ browser, baseURL }) => {
+    const email = testEmail('system')
+    await registerUser(baseURL!, email)
+
+    const ctx = await browser.newContext({ colorScheme: 'dark' })
+    const page = await ctx.newPage()
+    await signIn(page, email)
+
+    // First-paint check: with empty storage (system) + colorScheme dark, html should have .dark.
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await ctx.close()
+  })
+
+  test('FOUC-free: pre-seeded localStorage applies class before React mounts', async ({ browser, baseURL }) => {
+    const email = testEmail('fouc')
+    await registerUser(baseURL!, email)
+
+    const ctx = await browser.newContext()
+    await ctx.addInitScript(() => {
+      window.localStorage.setItem('engram:theme', 'dark')
+    })
+    const page = await ctx.newPage()
+    await page.goto(baseURL! + '/sign-in/')
+    // At domcontentloaded the inline boot script has already run.
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await ctx.close()
+  })
+})
+```
+
+- [ ] **Step 3: Run the new tests against the local-auth project**
+
+Ensure the Docker stack is running (`docker compose -f docker-compose.elixir.yml up -d` if not). Then:
+
+Run: `cd frontend && npm run test:e2e:local -- dark-mode.spec.ts`
+Expected: all four tests pass.
+
+If a test fails on selector ambiguity (multiple "Dark" buttons because the segmented control plus the toggle's `aria-label` both match), scope the locator using `page.locator('fieldset')` for segmented buttons. Adjust and rerun.
+
+- [ ] **Step 4: Run full e2e suite to verify no regressions**
+
+Run: `cd frontend && npm run test:e2e:local`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/e2e/dark-mode.spec.ts
+git commit -m "test(e2e): cover theme toggle, persistence, system-tracking, FOUC"
+```
+
+---
+
+## Task 12: Push branch + open PR
+
+- [ ] **Step 1: Push branch**
+
+Run: `git push -u origin feat/dark-mode`
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(ui): system-aware dark mode" --body "$(cat <<'EOF'
+## Summary
+
+- Tailwind v4 class-based dark variant on `<html>`
+- `ThemeProvider` owns `'system' | 'light' | 'dark'`; persists to `localStorage`; tracks `prefers-color-scheme` while in `system`
+- Inline anti-FOUC boot script in `index.html`
+- Header icon toggle (Light → Dark → System)
+- Settings → Appearance page with segmented control
+- Dark variants across layout, auth, viewer, settings, billing, oauth, device, not-found
+- Dark `highlight.js` palette scoped under `html.dark`
+
+## Test plan
+- [x] `npm run test:e2e:local -- dark-mode.spec.ts` passes
+- [x] Full e2e suite passes
+- [x] Manual: toggle OS theme with `system` selected — UI flips live
+- [x] Manual: code blocks legible in both modes
+
+Spec: `docs/superpowers/specs/2026-05-11-dark-mode-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Verification Summary
+
+After every task, the following must hold:
+- `cd frontend && npx tsc --noEmit` — exit 0
+- `cd frontend && npx vite build` — exit 0
+- After Task 11: `cd frontend && npm run test:e2e:local` — all green
+- After Task 11 manual smoke: toggle through all three theme states on the dashboard, a note with a code block, the search page, the settings/appearance page, and the billing page. Confirm no unreadable text, no white flashes between routes, and live OS-theme tracking when `system` is selected.

--- a/docs/superpowers/specs/2026-05-11-dark-mode-design.md
+++ b/docs/superpowers/specs/2026-05-11-dark-mode-design.md
@@ -1,0 +1,166 @@
+# Dark Mode (System-Aware + Manual Override)
+
+**Date:** 2026-05-11
+**Scope:** `frontend/` SPA (React 19 + Tailwind v4 + Vite)
+**Status:** Approved for plan
+
+## Goal
+
+Add dark theme to the Engram web UI. Default follows the OS preference (`prefers-color-scheme`). User can override to Light, Dark, or System via:
+
+1. Icon button in the app header (cycles Light → Dark → System).
+2. Three-button segmented control on the Settings page.
+
+Override is persisted to `localStorage` under key `engram:theme`. When set to `system`, the UI tracks live changes to the OS preference.
+
+## Non-Goals
+
+- Multi-theme support beyond light/dark (no accent themes, no user-defined palettes).
+- Per-vault or per-route themes.
+- Server-side rendering / SEO (the SPA is shell-rendered by Phoenix; no SSR of theme state).
+- Theming the highlight.js code-block colors beyond swapping to `github-dark` in dark mode.
+
+## Approach
+
+**Inline `dark:` Tailwind variants** for every color-bearing class. Tailwind v4 with a class-based variant: `@custom-variant dark (&:where(.dark, .dark *))`. Override comes from the presence of the `.dark` class on `<html>`.
+
+Rejected alternatives:
+- **Semantic CSS-var tokens** (e.g., `bg-surface`, `text-fg`). Cleaner long-term but adds an indirection layer that isn't justified at current UI size.
+- **Hybrid (tokens for core + inline for accents).** Splits the mental model without solving a real problem yet.
+
+If a third theme or user accent customization ever arrives, migrate then.
+
+## Architecture
+
+### State Resolution
+
+```
+stored theme: 'system' | 'light' | 'dark'   (localStorage 'engram:theme')
+system pref:  'light' | 'dark'              (matchMedia '(prefers-color-scheme: dark)')
+
+resolved =
+  stored === 'system' ? system pref :
+  stored
+```
+
+The `.dark` class is on `<html>` iff `resolved === 'dark'`.
+
+### Boot Sequence (anti-FOUC)
+
+1. `index.html` contains an inline `<script>` (executed before React mounts) that:
+   - Reads `localStorage['engram:theme']`.
+   - Computes effective theme using `window.matchMedia('(prefers-color-scheme: dark)')`.
+   - Adds `.dark` to `document.documentElement` if effective theme is `dark`.
+   - Wraps in try/catch so a localStorage exception (private mode quirks) silently falls back to system.
+
+2. React mounts. `<ThemeProvider>` reads the same `localStorage` value into state and continues from there. The boot script and the provider agree on initial class state, so no flash.
+
+### Files
+
+**New:**
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/theme/theme-provider.tsx` | React context. State `{ theme, resolved }`. `setTheme(next)`. Subscribes to `matchMedia` only while `theme === 'system'`. |
+| `frontend/src/theme/use-theme.ts` | `useTheme()` hook (named export from provider is fine if we want one file). |
+| `frontend/src/theme/theme-toggle.tsx` | Header icon button. Cycles Light → Dark → System. Inline SVGs (sun, moon, monitor). `aria-label` reflects next state. |
+| `frontend/src/theme/theme-segmented.tsx` | Settings-page segmented control. Three buttons with `aria-pressed`. |
+| `frontend/src/theme/storage.ts` | Safe `getStoredTheme()` / `setStoredTheme()` with try/catch and validation. Shared by boot script and provider where practical. |
+
+**Modified:**
+
+| File | Change |
+|------|--------|
+| `frontend/src/main.css` | Add `@custom-variant dark (&:where(.dark, .dark *))`. Replace `@import "highlight.js/styles/github.css"` with both `github.css` and `github-dark.css`, scoping each via `@layer base` so only one set of variables applies per mode. |
+| `frontend/index.html` | Inline `<script>` for FOUC-free theme application. Includes `<meta name="color-scheme" content="light dark">` so native UA chrome (scrollbars, form widgets) matches. |
+| `frontend/src/main.tsx` | Wrap router in `<ThemeProvider>`. |
+| `frontend/src/layout/app-layout.tsx` | Add `dark:` variants to header, sidebar, banners. Mount `<ThemeToggle>` next to nav links. |
+| `frontend/src/settings/*` | Add a "Appearance" section with `<ThemeSegmented>`. |
+| Remaining UI files with hardcoded color classes (viewer, folder-tree, vault-switcher, billing, oauth, device, login, not-found) | Add `dark:` variants pass. |
+
+### Highlight.js
+
+Both stylesheets ship. We scope them via attribute/class so only one is active:
+
+```css
+@import "highlight.js/styles/github.css" layer(base);
+@import "highlight.js/styles/github-dark.css" layer(base);
+```
+
+Then in `main.css`:
+
+```css
+/* light wins by default; .dark scope flips to dark variant */
+:where(html:not(.dark)) .hljs { /* re-apply light values if needed */ }
+:where(html.dark) .hljs { /* dark values pre-applied by the dark stylesheet */ }
+```
+
+Implementation may simplify this by importing only the active sheet via a JS-side dynamic toggle, but the static dual-import keeps things synchronous and FOUC-free. The plan will pick the simpler path that works.
+
+## Color Mapping
+
+A small palette mapping that the plan will enumerate per component:
+
+| Light | Dark |
+|-------|------|
+| `bg-white` | `dark:bg-gray-900` |
+| `bg-gray-50` | `dark:bg-gray-950` |
+| `bg-gray-100` | `dark:bg-gray-800` |
+| `text-gray-900` | `dark:text-gray-100` |
+| `text-gray-700` | `dark:text-gray-200` |
+| `text-gray-600` | `dark:text-gray-300` |
+| `text-gray-500` | `dark:text-gray-400` |
+| `border-gray-200` | `dark:border-gray-800` |
+| `bg-blue-50 text-blue-800` (info banner) | `dark:bg-blue-950 dark:text-blue-200` |
+| `bg-amber-50 text-amber-800` (trial banner) | `dark:bg-amber-950 dark:text-amber-200` |
+| Hover `hover:bg-gray-100` | `dark:hover:bg-gray-800` |
+
+Exact tokens are a starting point; the plan will validate against rendered contrast before finalizing.
+
+## Data Flow
+
+```
+boot.ts (inline in index.html)
+  ├─ read localStorage['engram:theme']  (try/catch)
+  ├─ resolve via matchMedia
+  └─ toggle .dark on <html>
+
+ThemeProvider
+  ├─ initial state from localStorage
+  ├─ subscribe to matchMedia (only when theme==='system')
+  ├─ on change: re-resolve → update class on <html>
+  └─ setTheme(next): write localStorage, update state, update class
+
+ThemeToggle (header)
+  └─ onClick: cycle Light → Dark → System → Light
+
+ThemeSegmented (settings)
+  └─ onClick: setTheme(value)
+```
+
+## Error Handling
+
+- `localStorage.getItem` / `setItem` throws → caught, fallback to `'system'`, never propagated.
+- Unknown stored value → coerced to `'system'`, stored value left as-is (or rewritten — plan picks one; rewriting is cleaner).
+- `matchMedia` absent (very old browsers, jsdom in unit tests) → resolver returns `'light'`, no subscription attempted.
+
+## Testing
+
+**Unit (vitest):**
+- `storage.ts`: round-trip, invalid value, localStorage throws.
+- `theme-provider`: initial resolution from each stored state; `setTheme` updates class; matchMedia subscription added/removed when theme transitions in/out of `'system'`; unsubscribe on unmount.
+
+**E2E (Playwright):**
+- Settings → pick Dark → assert `html.dark` present and primary surface uses dark token.
+- Settings → pick Light → assert class removed.
+- Settings → pick System → emulate `prefers-color-scheme: dark` via Playwright → assert class present.
+- Header toggle: cycle three times, assert `<html>` class and `localStorage` value match expected.
+- FOUC: navigate with `engram:theme='dark'` pre-seeded → first paint already has `.dark` (assert via the screenshot or by checking class at `domcontentloaded` before React mounts).
+
+**Manual:**
+- Verify in actual browsers (Firefox, Chromium) that toggling OS theme while app is open with `system` selected flips colors live.
+- Verify highlight.js code blocks render legibly in both modes.
+
+## Open Questions
+
+None. Plan can proceed.

--- a/frontend/e2e/dark-mode.spec.ts
+++ b/frontend/e2e/dark-mode.spec.ts
@@ -25,31 +25,43 @@ async function signIn(page: import('@playwright/test').Page, email: string) {
 }
 
 test.describe('Dark mode', () => {
-  test('header toggle cycles Light → Dark → System and persists', async ({ page, baseURL }) => {
-    const email = testEmail('cycle')
+  test('header toggle opens menu and picks each theme', async ({ page, baseURL }) => {
+    const email = testEmail('menu')
     await registerUser(baseURL!, email)
     await signIn(page, email)
 
-    const toggle = page.getByRole('button', { name: /switch to .* theme/i })
-    // Default is system. On a default headless Chromium, system pref is light.
+    const toggle = page.getByRole('button', { name: /^theme:/i })
     await expect(page.locator('html')).not.toHaveClass(/dark/)
-
-    // System → Light
-    await toggle.click()
-    await expect(toggle).toHaveAttribute('data-theme-choice', 'light')
-    await expect(page.locator('html')).not.toHaveClass(/dark/)
-
-    // Light → Dark
-    await toggle.click()
-    await expect(toggle).toHaveAttribute('data-theme-choice', 'dark')
-    await expect(page.locator('html')).toHaveClass(/dark/)
-
-    // Dark → System
-    await toggle.click()
     await expect(toggle).toHaveAttribute('data-theme-choice', 'system')
 
+    // Open menu → pick Dark
+    await toggle.click()
+    const menu = page.getByRole('menu', { name: 'Theme' })
+    await expect(menu).toBeVisible()
+    await menu.getByRole('menuitem', { name: 'Dark' }).click()
+    await expect(menu).toBeHidden()
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'dark')
+
+    // Open menu → pick Light
+    await toggle.click()
+    await page.getByRole('menuitem', { name: 'Light' }).click()
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'light')
+
+    // Open menu → pick System; localStorage persists
+    await toggle.click()
+    await page.getByRole('menuitem', { name: 'System' }).click()
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'system')
     const stored = await page.evaluate(() => window.localStorage.getItem('engram:theme'))
     expect(stored).toBe('system')
+
+    // Esc closes the menu without changing theme
+    await toggle.click()
+    await expect(page.getByRole('menu', { name: 'Theme' })).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('menu', { name: 'Theme' })).toBeHidden()
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'system')
   })
 
   test('Settings → Appearance segmented control sets theme', async ({ page, baseURL }) => {
@@ -58,13 +70,16 @@ test.describe('Dark mode', () => {
     await signIn(page, email)
 
     await page.goto('/settings/appearance')
-    await page.getByRole('button', { name: 'Dark' }).click()
+    const segDark = page.locator('button[data-theme-option="dark"]')
+    const segLight = page.locator('button[data-theme-option="light"]')
+    await expect(segDark).toBeVisible()
+    await segDark.click()
     await expect(page.locator('html')).toHaveClass(/dark/)
-    await expect(page.getByRole('button', { name: 'Dark' })).toHaveAttribute('aria-pressed', 'true')
+    await expect(segDark).toHaveAttribute('aria-pressed', 'true')
 
-    await page.getByRole('button', { name: 'Light' }).click()
+    await segLight.click()
     await expect(page.locator('html')).not.toHaveClass(/dark/)
-    await expect(page.getByRole('button', { name: 'Light' })).toHaveAttribute('aria-pressed', 'true')
+    await expect(segLight).toHaveAttribute('aria-pressed', 'true')
   })
 
   test('System mode tracks prefers-color-scheme', async ({ browser, baseURL }) => {

--- a/frontend/e2e/dark-mode.spec.ts
+++ b/frontend/e2e/dark-mode.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test'
+
+const TEST_PASSWORD = 'E2eTestPass!99'
+
+async function registerUser(baseURL: string, email: string) {
+  const res = await fetch(`${baseURL}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: TEST_PASSWORD }),
+  })
+  if (res.status === 422) return
+  if (!res.ok) throw new Error(`Register failed: ${res.status} ${await res.text()}`)
+}
+
+function testEmail(label: string) {
+  return `e2e-theme-${Date.now()}-${label}@test.com`
+}
+
+async function signIn(page: import('@playwright/test').Page, email: string) {
+  await page.goto('/sign-in/')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password', { exact: true }).fill(TEST_PASSWORD)
+  await page.getByRole('button', { name: /sign in/i }).click()
+  await expect(page).toHaveURL('/')
+}
+
+test.describe('Dark mode', () => {
+  test('header toggle cycles Light → Dark → System and persists', async ({ page, baseURL }) => {
+    const email = testEmail('cycle')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    const toggle = page.getByRole('button', { name: /switch to .* theme/i })
+    // Default is system. On a default headless Chromium, system pref is light.
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+
+    // System → Light
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'light')
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+
+    // Light → Dark
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'dark')
+    await expect(page.locator('html')).toHaveClass(/dark/)
+
+    // Dark → System
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('data-theme-choice', 'system')
+
+    const stored = await page.evaluate(() => window.localStorage.getItem('engram:theme'))
+    expect(stored).toBe('system')
+  })
+
+  test('Settings → Appearance segmented control sets theme', async ({ page, baseURL }) => {
+    const email = testEmail('settings')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    await page.goto('/settings/appearance')
+    await page.getByRole('button', { name: 'Dark' }).click()
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await expect(page.getByRole('button', { name: 'Dark' })).toHaveAttribute('aria-pressed', 'true')
+
+    await page.getByRole('button', { name: 'Light' }).click()
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+    await expect(page.getByRole('button', { name: 'Light' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('System mode tracks prefers-color-scheme', async ({ browser, baseURL }) => {
+    const email = testEmail('system')
+    await registerUser(baseURL!, email)
+
+    const ctx = await browser.newContext({ colorScheme: 'dark' })
+    const page = await ctx.newPage()
+    await signIn(page, email)
+
+    // First-paint check: with empty storage (system) + colorScheme dark, html should have .dark.
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await ctx.close()
+  })
+
+  test('FOUC-free: pre-seeded localStorage applies class before React mounts', async ({ browser, baseURL }) => {
+    const email = testEmail('fouc')
+    await registerUser(baseURL!, email)
+
+    const ctx = await browser.newContext()
+    await ctx.addInitScript(() => {
+      window.localStorage.setItem('engram:theme', 'dark')
+    })
+    const page = await ctx.newPage()
+    await page.goto(baseURL! + '/sign-in/')
+    // At domcontentloaded the inline boot script has already run.
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await ctx.close()
+  })
+})

--- a/frontend/e2e/db-cleanup.ts
+++ b/frontend/e2e/db-cleanup.ts
@@ -1,6 +1,6 @@
 import pg from 'pg'
 
-const TEST_EMAIL_PATTERNS = ['e2e-local-%@test.com', 'e2e-browser-%@test.com']
+const TEST_EMAIL_PATTERNS = ['e2e-local-%@test.com', 'e2e-browser-%@test.com', 'e2e-theme-%@test.com']
 
 // Hosts safe to run DELETE against. Anything else aborts.
 // Extend via E2E_DB_CLEANUP_EXTRA_HOSTS (comma-separated) for self-hosted CI.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,23 @@
     <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Engram</title>
+    <script>
+      (function () {
+        try {
+          var stored = window.localStorage.getItem('engram:theme');
+          var valid = stored === 'light' || stored === 'dark' || stored === 'system';
+          var choice = valid ? stored : 'system';
+          var prefersDark =
+            window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var resolved = choice === 'system' ? (prefersDark ? 'dark' : 'light') : choice;
+          if (resolved === 'dark') {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (_) {
+          /* fall back to default (light) */
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Engram</title>
   </head>

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,6 +8,10 @@ const LOCAL_VITE_PORT = +(process.env.PW_LOCAL_VITE_PORT ?? 5173)
 const CLERK_BACKEND_PORT = +(process.env.PW_CLERK_BACKEND_PORT ?? 4001)
 const CLERK_VITE_PORT = +(process.env.PW_CLERK_VITE_PORT ?? 5174)
 
+// Clerk webServers are only started when Clerk credentials are available.
+const clerkPublishableKey = process.env.VITE_CLERK_PUBLISHABLE_KEY ?? ''
+const hasClerkCreds = clerkPublishableKey.length > 0
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
@@ -27,7 +31,7 @@ export default defineConfig({
   projects: [
     {
       name: 'local',
-      testMatch: 'local-auth.spec.ts',
+      testMatch: /\/(local-auth|dark-mode)\.spec\.ts$/,
       use: {
         baseURL: `http://localhost:${LOCAL_VITE_PORT}`,
       },
@@ -55,6 +59,10 @@ export default defineConfig({
         AUTH_PROVIDER: 'local',
         PHX_SERVER: 'true',
         PORT: String(LOCAL_BACKEND_PORT),
+        // Local dev/e2e only — 32-byte base64 key, not used in production.
+        KEY_PROVIDER: process.env.KEY_PROVIDER ?? 'local',
+        ENCRYPTION_MASTER_KEY:
+          process.env.ENCRYPTION_MASTER_KEY ?? 'uB2okhpf1lb6quoXIk+ZVIQDenCUnGnZuTb8IA/iZ4w=',
       },
     },
     {
@@ -68,35 +76,43 @@ export default defineConfig({
         VITE_API_TARGET: `http://localhost:${LOCAL_BACKEND_PORT}`,
       },
     },
-    {
-      command: 'mix phx.server',
-      cwd: '..',
-      url: `http://localhost:${CLERK_BACKEND_PORT}/api/health`,
-      timeout: 120_000,
-      reuseExistingServer: !isCI,
-      stdout: 'pipe',
-      stderr: 'pipe',
-      env: {
-        MIX_ENV: 'dev',
-        AUTH_PROVIDER: 'clerk',
-        PHX_SERVER: 'true',
-        PORT: String(CLERK_BACKEND_PORT),
-        CLERK_JWKS_URL: process.env.CLERK_JWKS_URL ?? '',
-        CLERK_ISSUER: process.env.CLERK_ISSUER ?? '',
-        CLERK_PUBLISHABLE_KEY: process.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
-      },
-    },
-    {
-      command: `bun run dev -- --port ${CLERK_VITE_PORT}`,
-      cwd: '.',
-      port: CLERK_VITE_PORT,
-      timeout: 15_000,
-      reuseExistingServer: !isCI,
-      env: {
-        VITE_AUTH_PROVIDER: 'clerk',
-        VITE_CLERK_PUBLISHABLE_KEY: process.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
-        VITE_API_TARGET: `http://localhost:${CLERK_BACKEND_PORT}`,
-      },
-    },
+    // Clerk servers are only started when credentials are present (CI or explicit local dev).
+    ...(hasClerkCreds
+      ? [
+          {
+            command: 'mix phx.server',
+            cwd: '..',
+            url: `http://localhost:${CLERK_BACKEND_PORT}/api/health`,
+            timeout: 120_000,
+            reuseExistingServer: !isCI,
+            stdout: 'pipe' as const,
+            stderr: 'pipe' as const,
+            env: {
+              MIX_ENV: 'dev',
+              AUTH_PROVIDER: 'clerk',
+              PHX_SERVER: 'true',
+              PORT: String(CLERK_BACKEND_PORT),
+              KEY_PROVIDER: process.env.KEY_PROVIDER ?? 'local',
+              ENCRYPTION_MASTER_KEY:
+                process.env.ENCRYPTION_MASTER_KEY ?? 'uB2okhpf1lb6quoXIk+ZVIQDenCUnGnZuTb8IA/iZ4w=',
+              CLERK_JWKS_URL: process.env.CLERK_JWKS_URL ?? '',
+              CLERK_ISSUER: process.env.CLERK_ISSUER ?? '',
+              CLERK_PUBLISHABLE_KEY: clerkPublishableKey,
+            },
+          },
+          {
+            command: `bun run dev -- --port ${CLERK_VITE_PORT}`,
+            cwd: '.',
+            port: CLERK_VITE_PORT,
+            timeout: 15_000,
+            reuseExistingServer: !isCI,
+            env: {
+              VITE_AUTH_PROVIDER: 'clerk',
+              VITE_CLERK_PUBLISHABLE_KEY: clerkPublishableKey,
+              VITE_API_TARGET: `http://localhost:${CLERK_BACKEND_PORT}`,
+            },
+          },
+        ]
+      : []),
   ],
 })

--- a/frontend/src/auth/local-sign-in.tsx
+++ b/frontend/src/auth/local-sign-in.tsx
@@ -37,31 +37,31 @@ export default function LocalSignIn() {
   return (
     <main className="flex justify-center pt-16">
       <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-        <h1 className="text-2xl font-semibold text-gray-900">Sign in to Engram</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Sign in to Engram</h1>
 
         {error && (
-          <p role="alert" className="text-sm text-red-600">{error}</p>
+          <p role="alert" className="text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
 
         <label className="block">
-          <span className="text-sm font-medium text-gray-700">Email</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Email</span>
           <input
             type="email"
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
           />
         </label>
 
         <label className="block">
-          <span className="text-sm font-medium text-gray-700">Password</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Password</span>
           <input
             type="password"
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
           />
         </label>
 
@@ -73,7 +73,7 @@ export default function LocalSignIn() {
           {loading ? 'Signing in...' : 'Sign in'}
         </button>
 
-        <p className="text-center text-sm text-gray-500">
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400">
           Don't have an account?{' '}
           <Link to={ROUTES.SIGN_UP} className="text-blue-600 hover:underline">Sign up</Link>
         </p>

--- a/frontend/src/auth/local-sign-up.tsx
+++ b/frontend/src/auth/local-sign-up.tsx
@@ -41,43 +41,43 @@ export default function LocalSignUp() {
   return (
     <main className="flex justify-center pt-16">
       <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-        <h1 className="text-2xl font-semibold text-gray-900">Create your account</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Create your account</h1>
 
         {error && (
-          <p role="alert" className="text-sm text-red-600">{error}</p>
+          <p role="alert" className="text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
 
         <label className="block">
-          <span className="text-sm font-medium text-gray-700">Email</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Email</span>
           <input
             type="email"
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
           />
         </label>
 
         <label className="block">
-          <span className="text-sm font-medium text-gray-700">Password</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Password</span>
           <input
             type="password"
             required
             minLength={8}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
           />
         </label>
 
         <label className="block">
-          <span className="text-sm font-medium text-gray-700">Confirm password</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Confirm password</span>
           <input
             type="password"
             required
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
-            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
           />
         </label>
 
@@ -89,7 +89,7 @@ export default function LocalSignUp() {
           {loading ? 'Creating account...' : 'Create account'}
         </button>
 
-        <p className="text-center text-sm text-gray-500">
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400">
           Already have an account?{' '}
           <Link to={ROUTES.SIGN_IN} className="text-blue-600 hover:underline">Sign in</Link>
         </p>

--- a/frontend/src/auth/local-user-menu.tsx
+++ b/frontend/src/auth/local-user-menu.tsx
@@ -29,16 +29,16 @@ export default function LocalUserMenu() {
       </button>
 
       {open && (
-        <menu className="absolute right-0 mt-2 w-48 rounded border border-gray-200 bg-white py-1 shadow-lg" role="menu">
+        <menu className="absolute right-0 mt-2 w-48 rounded border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-800 dark:bg-gray-900" role="menu">
           <li role="none">
-            <p className="truncate px-4 py-2 text-sm text-gray-700">{user?.email}</p>
+            <p className="truncate px-4 py-2 text-sm text-gray-700 dark:text-gray-200">{user?.email}</p>
           </li>
-          <hr className="border-gray-100" />
+          <hr className="border-gray-100 dark:border-gray-800" />
           <li role="none">
             <button
               role="menuitem"
               onClick={async () => { await logout(); setOpen(false) }}
-              className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
+              className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
             >
               Sign out
             </button>

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -12,7 +12,7 @@ export default function BillingPage() {
   const { data: billing, isLoading } = useBillingStatus()
 
   if (isLoading || !billing) {
-    return <p className="text-gray-500">Loading billing info...</p>
+    return <p className="text-gray-500 dark:text-gray-400">Loading billing info...</p>
   }
 
   const needsSubscription = billing.tier === 'none'
@@ -20,36 +20,36 @@ export default function BillingPage() {
 
   return (
     <article className="mx-auto max-w-2xl space-y-8">
-      <h1 className="text-2xl font-bold text-gray-900">Billing</h1>
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Billing</h1>
 
-      <section className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
+      <section className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 space-y-4">
         <header className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-gray-800">Current Plan</h2>
-          <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800">
+          <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Current Plan</h2>
+          <span className="rounded-full bg-blue-100 dark:bg-blue-950 px-3 py-1 text-sm font-medium text-blue-800 dark:text-blue-200">
             {TIER_LABELS[billing.tier]}
           </span>
         </header>
 
         {needsSubscription && (
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
             Choose a plan below to start your 7-day free trial. A card is required but you
             won't be charged until the trial ends.
           </p>
         )}
 
         {isTrial && billing.trial_days_remaining > 0 && (
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
             {billing.trial_days_remaining} days remaining in your free trial.
           </p>
         )}
 
         {billing.subscription && (
           <dl className="grid grid-cols-2 gap-4 text-sm">
-            <dt className="text-gray-500">Status</dt>
+            <dt className="text-gray-500 dark:text-gray-400">Status</dt>
             <dd className="font-medium capitalize">{billing.subscription.status.replace('_', ' ')}</dd>
             {billing.subscription.current_period_end && (
               <>
-                <dt className="text-gray-500">Current period ends</dt>
+                <dt className="text-gray-500 dark:text-gray-400">Current period ends</dt>
                 <dd className="font-medium">
                   {new Date(billing.subscription.current_period_end).toLocaleDateString()}
                 </dd>
@@ -61,8 +61,8 @@ export default function BillingPage() {
 
       {needsSubscription && (
         <section className="space-y-4">
-          <h2 className="text-lg font-semibold text-gray-800">Choose a Plan</h2>
-          <p className="text-sm text-gray-500">Both plans include a 7-day free trial.</p>
+          <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Choose a Plan</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">Both plans include a 7-day free trial.</p>
           <ul className="grid gap-4 sm:grid-cols-2">
             <PlanCard
               name="Starter"
@@ -111,10 +111,10 @@ function PlanCard({
   }
 
   return (
-    <li className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
+    <li className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 space-y-4">
       <h3 className="text-lg font-semibold">{name}</h3>
       <p className="text-2xl font-bold">{price}</p>
-      <ul className="space-y-1 text-sm text-gray-600">
+      <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-300">
         {features.map((f) => (
           <li key={f}>&#10003; {f}</li>
         ))}

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -21,7 +21,7 @@ export default function AppLayout() {
   return (
     <>
       {billing?.tier === 'none' && (
-        <aside className="bg-blue-50 px-4 py-2 text-center text-sm text-blue-800" role="alert">
+        <aside className="bg-blue-50 px-4 py-2 text-center text-sm text-blue-800 dark:bg-blue-950 dark:text-blue-200" role="alert">
           Start a free trial to sync your notes.{' '}
           <Link to="/billing" className="font-medium underline">
             Choose a plan
@@ -29,34 +29,34 @@ export default function AppLayout() {
         </aside>
       )}
       {billing?.subscription?.status === 'trialing' && billing.trial_days_remaining > 0 && billing.trial_days_remaining <= 3 && (
-        <aside className="bg-amber-50 px-4 py-2 text-center text-sm text-amber-800" role="alert">
+        <aside className="bg-amber-50 px-4 py-2 text-center text-sm text-amber-800 dark:bg-amber-950 dark:text-amber-200" role="alert">
           {billing.trial_days_remaining} days left in your trial.
         </aside>
       )}
       <section className="flex h-screen flex-col">
-        <header className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2">
+        <header className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-800 dark:bg-gray-900">
           <div className="flex items-center gap-3">
             <button
               onClick={() => setSidebarOpen((o) => !o)}
               aria-label={sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
               aria-expanded={sidebarOpen}
               aria-controls="sidebar"
-              className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+              className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
             >
               {sidebarOpen ? '◀' : '▶'}
             </button>
-            <Link to="/" className="text-lg font-semibold text-gray-900 hover:text-gray-700">
+            <Link to="/" className="text-lg font-semibold text-gray-900 hover:text-gray-700 dark:text-gray-100 dark:hover:text-gray-200">
               Engram
             </Link>
           </div>
           <nav className="flex items-center gap-4" aria-label="Main navigation">
-            <Link to="/search" className="text-sm text-gray-600 hover:text-gray-900 hover:underline">
+            <Link to="/search" className="text-sm text-gray-600 hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-gray-100">
               Search
             </Link>
-            <Link to="/billing" className="text-sm text-gray-600 hover:text-gray-900 hover:underline">
+            <Link to="/billing" className="text-sm text-gray-600 hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-gray-100">
               Billing
             </Link>
-            <Link to="/settings" className="text-sm text-gray-600 hover:text-gray-900 hover:underline">
+            <Link to="/settings" className="text-sm text-gray-600 hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-gray-100">
               Settings
             </Link>
             <ThemeToggle />
@@ -66,13 +66,13 @@ export default function AppLayout() {
           </nav>
         </header>
 
-        <section className="flex flex-1 overflow-hidden">
+        <section className="flex flex-1 overflow-hidden bg-white dark:bg-gray-900">
           <aside
             id="sidebar"
             aria-label="Folder navigation"
             className={`${
               sidebarOpen ? 'w-64' : 'w-0'
-            } shrink-0 overflow-y-auto border-r border-gray-200 bg-gray-50 transition-all duration-200`}
+            } shrink-0 overflow-y-auto border-r border-gray-200 bg-gray-50 transition-all duration-200 dark:border-gray-800 dark:bg-gray-950`}
           >
             {sidebarOpen && (
               <>
@@ -82,7 +82,7 @@ export default function AppLayout() {
             )}
           </aside>
 
-          <main className="flex-1 overflow-y-auto p-6">
+          <main className="flex-1 overflow-y-auto p-6 text-gray-900 dark:text-gray-100">
             <Outlet />
           </main>
         </section>

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -9,6 +9,7 @@ const ClerkUserButton = isClerk
 const LocalUserMenu = lazy(() => import('../auth/local-user-menu'))
 import { useChannel } from '../api/use-channel'
 import { useBillingStatus } from '../api/queries'
+import ThemeToggle from '../theme/theme-toggle'
 import FolderTree from '../viewer/folder-tree'
 import VaultSwitcher from './vault-switcher'
 
@@ -58,6 +59,7 @@ export default function AppLayout() {
             <Link to="/settings" className="text-sm text-gray-600 hover:text-gray-900 hover:underline">
               Settings
             </Link>
+            <ThemeToggle />
             <Suspense fallback={null}>
               {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
             </Suspense>

--- a/frontend/src/layout/vault-switcher.tsx
+++ b/frontend/src/layout/vault-switcher.tsx
@@ -17,10 +17,10 @@ export default function VaultSwitcher() {
   }, [vaults, activeId])
 
   if (isLoading) {
-    return <p className="px-3 py-2 text-xs text-gray-500">Loading vaults…</p>
+    return <p className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">Loading vaults…</p>
   }
   if (!vaults || vaults.length === 0) {
-    return <p className="px-3 py-2 text-xs text-gray-500">No vaults yet</p>
+    return <p className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">No vaults yet</p>
   }
 
   const active = vaults.find((v) => v.id === activeId) ?? vaults[0]
@@ -43,9 +43,9 @@ export default function VaultSwitcher() {
 
 function SingleVaultLabel({ vault }: { vault: Vault }) {
   return (
-    <section className="border-b border-gray-200 px-3 py-2">
-      <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500">Vault</p>
-      <p className="flex items-center gap-1.5 truncate text-sm font-medium text-gray-900">
+    <section className="border-b border-gray-200 px-3 py-2 dark:border-gray-800">
+      <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Vault</p>
+      <p className="flex items-center gap-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">
         {vault.encrypted && <LockIcon />}
         {vault.name}
       </p>
@@ -82,31 +82,31 @@ function VaultDropdown({
   }, [open])
 
   return (
-    <section ref={ref} className="relative border-b border-gray-200">
+    <section ref={ref} className="relative border-b border-gray-200 dark:border-gray-800">
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
         aria-haspopup="listbox"
         aria-expanded={open}
-        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-gray-100"
+        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-800"
       >
         <span className="min-w-0 flex-1">
-          <span className="block text-[10px] font-medium uppercase tracking-wide text-gray-500">
+          <span className="block text-[10px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
             Vault
           </span>
-          <span className="flex items-center gap-1.5 truncate text-sm font-medium text-gray-900">
+          <span className="flex items-center gap-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">
             {active.encrypted && <LockIcon />}
             {active.name}
           </span>
         </span>
-        <span className={`text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`}>▾</span>
+        <span className={`text-gray-400 dark:text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`}>▾</span>
       </button>
 
       {open && (
         <ul
           role="listbox"
           aria-label="Switch vault"
-          className="absolute left-2 right-2 top-full z-10 mt-1 max-h-64 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+          className="absolute left-2 right-2 top-full z-10 mt-1 max-h-64 overflow-y-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-800 dark:bg-gray-900"
         >
           {vaults.map((v) => (
             <li key={v.id} role="option" aria-selected={v.id === active.id}>
@@ -116,8 +116,8 @@ function VaultDropdown({
                   onSelect(v.id)
                   setOpen(false)
                 }}
-                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-gray-100 ${
-                  v.id === active.id ? 'font-medium text-gray-900' : 'text-gray-700'
+                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-800 ${
+                  v.id === active.id ? 'font-medium text-gray-900 dark:text-gray-100' : 'text-gray-700 dark:text-gray-200'
                 }`}
               >
                 <span className="w-3 text-blue-600">{v.id === active.id ? '✓' : ''}</span>
@@ -137,7 +137,7 @@ function LockIcon() {
     <svg
       aria-hidden="true"
       viewBox="0 0 16 16"
-      className="h-3 w-3 shrink-0 text-gray-500"
+      className="h-3 w-3 shrink-0 text-gray-500 dark:text-gray-400"
       fill="currentColor"
     >
       <path d="M8 1a3 3 0 0 0-3 3v3H4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8a1 1 0 0 0-1-1h-1V4a3 3 0 0 0-3-3zm-2 6V4a2 2 0 1 1 4 0v3H6z" />

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1,2 +1,4 @@
 @import "tailwindcss";
 @import "highlight.js/styles/github.css";
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1,4 +1,53 @@
 @import "tailwindcss";
-@import "highlight.js/styles/github.css";
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* Light highlight.js theme — applies by default. */
+@import "highlight.js/styles/github.css" layer(base);
+
+/* Dark highlight.js theme — wrapped so it only applies under `.dark`. */
+@layer base {
+  html.dark .hljs {
+    color: #c9d1d9;
+    background: #0d1117;
+  }
+  html.dark .hljs-doctag,
+  html.dark .hljs-keyword,
+  html.dark .hljs-meta .hljs-keyword,
+  html.dark .hljs-template-tag,
+  html.dark .hljs-template-variable,
+  html.dark .hljs-type,
+  html.dark .hljs-variable.language_ { color: #ff7b72; }
+  html.dark .hljs-title,
+  html.dark .hljs-title.class_,
+  html.dark .hljs-title.class_.inherited__,
+  html.dark .hljs-title.function_ { color: #d2a8ff; }
+  html.dark .hljs-attr,
+  html.dark .hljs-attribute,
+  html.dark .hljs-literal,
+  html.dark .hljs-meta,
+  html.dark .hljs-number,
+  html.dark .hljs-operator,
+  html.dark .hljs-variable,
+  html.dark .hljs-selector-attr,
+  html.dark .hljs-selector-class,
+  html.dark .hljs-selector-id { color: #79c0ff; }
+  html.dark .hljs-regexp,
+  html.dark .hljs-string,
+  html.dark .hljs-meta .hljs-string { color: #a5d6ff; }
+  html.dark .hljs-built_in,
+  html.dark .hljs-symbol { color: #ffa657; }
+  html.dark .hljs-comment,
+  html.dark .hljs-code,
+  html.dark .hljs-formula { color: #8b949e; }
+  html.dark .hljs-name,
+  html.dark .hljs-quote,
+  html.dark .hljs-selector-tag,
+  html.dark .hljs-selector-pseudo { color: #7ee787; }
+  html.dark .hljs-section { color: #1f6feb; font-weight: bold; }
+  html.dark .hljs-bullet { color: #f2cc60; }
+  html.dark .hljs-emphasis { color: #c9d1d9; font-style: italic; }
+  html.dark .hljs-strong { color: #c9d1d9; font-weight: bold; }
+  html.dark .hljs-addition { color: #aff5b4; background: #033a16; }
+  html.dark .hljs-deletion { color: #ffdcd7; background: #67060c; }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { router } from './router'
 import { queryClient } from './api/query-client'
 import { config } from './config'
+import { ThemeProvider } from './theme/theme-provider'
 import './main.css'
 
 const isClerk = config.authProvider === 'clerk'
@@ -15,12 +16,14 @@ const AuthProvider = isClerk
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Suspense fallback={<p>Loading...</p>}>
-      <AuthProvider>
-        <QueryClientProvider client={queryClient}>
-          <RouterProvider router={router} />
-        </QueryClientProvider>
-      </AuthProvider>
-    </Suspense>
+    <ThemeProvider>
+      <Suspense fallback={<p>Loading...</p>}>
+        <AuthProvider>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </AuthProvider>
+      </Suspense>
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/frontend/src/not-found.tsx
+++ b/frontend/src/not-found.tsx
@@ -4,9 +4,9 @@ import { ROUTES } from './routes'
 export default function NotFoundPage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
-      <p className="text-sm font-medium uppercase tracking-wide text-gray-500">404</p>
-      <h1 className="mt-2 text-2xl font-semibold text-gray-900">Page not found</h1>
-      <p className="mt-2 max-w-md text-sm text-gray-600">
+      <p className="text-sm font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">404</p>
+      <h1 className="mt-2 text-2xl font-semibold text-gray-900 dark:text-gray-100">Page not found</h1>
+      <p className="mt-2 max-w-md text-sm text-gray-600 dark:text-gray-300">
         We couldn't find what you're looking for. The link may be broken or the page may have moved.
       </p>
       <Link

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,6 +6,7 @@ import BillingPage from './billing/billing-page'
 import DeviceLinkPage from './device/device-link-page'
 import AppLayout from './layout/app-layout'
 import NotFoundPage from './not-found'
+import AppearancePage from './settings/appearance-page'
 import ApiKeysPage from './settings/api-keys-page'
 import BillingPlaceholder from './settings/billing-placeholder'
 import EncryptionPage from './settings/encryption-page'
@@ -37,7 +38,8 @@ export const router = createBrowserRouter(
               path: '/settings',
               element: <SettingsLayout />,
               children: [
-                { index: true, element: <Navigate to="api-keys" replace /> },
+                { index: true, element: <Navigate to="appearance" replace /> },
+                { path: 'appearance', element: <AppearancePage /> },
                 { path: 'api-keys', element: <ApiKeysPage /> },
                 { path: 'encryption', element: <EncryptionPage /> },
                 { path: 'billing', element: <BillingPlaceholder /> },

--- a/frontend/src/settings/api-keys-page.tsx
+++ b/frontend/src/settings/api-keys-page.tsx
@@ -17,8 +17,8 @@ export default function ApiKeysPage() {
     <article className="space-y-6">
       <header className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">API Keys</h1>
-          <p className="mt-1 text-sm text-gray-600">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">API Keys</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
             Used by the Obsidian plugin and MCP clients to access your vault.
           </p>
         </div>
@@ -32,13 +32,13 @@ export default function ApiKeysPage() {
       </header>
 
       {error && (
-        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+        <p className="rounded-md bg-red-50 dark:bg-red-950 px-3 py-2 text-sm text-red-700 dark:text-red-200" role="alert">
           Failed to load API keys: {error instanceof Error ? error.message : 'unknown error'}
         </p>
       )}
 
       {isLoading ? (
-        <p className="text-sm text-gray-500">Loading…</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
       ) : keys && keys.length > 0 ? (
         <ApiKeyTable keys={keys} />
       ) : (
@@ -62,8 +62,8 @@ export default function ApiKeysPage() {
 
 function EmptyState() {
   return (
-    <section className="rounded-lg border border-dashed border-gray-300 p-8 text-center">
-      <p className="text-sm text-gray-600">
+    <section className="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-8 text-center">
+      <p className="text-sm text-gray-600 dark:text-gray-300">
         No API keys yet. Generate one to connect Claude Desktop, MCP, or the Obsidian plugin.
       </p>
     </section>
@@ -74,9 +74,9 @@ function ApiKeyTable({ keys }: { keys: ApiKey[] }) {
   const revoke = useRevokeApiKey()
 
   return (
-    <section className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+    <section className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
       <table className="w-full text-sm">
-        <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+        <thead className="bg-gray-50 dark:bg-gray-950 text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
           <tr>
             <th className="px-4 py-3 font-medium">Name</th>
             <th className="px-4 py-3 font-medium">Key</th>
@@ -85,13 +85,13 @@ function ApiKeyTable({ keys }: { keys: ApiKey[] }) {
             <th className="px-4 py-3" />
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100">
+        <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
           {keys.map((k) => (
             <tr key={k.id}>
-              <td className="px-4 py-3 font-medium text-gray-900">{k.name || '(unnamed)'}</td>
-              <td className="px-4 py-3 font-mono text-xs text-gray-500">engram_••••••</td>
-              <td className="px-4 py-3 text-gray-600">{formatDate(k.created_at)}</td>
-              <td className="px-4 py-3 text-gray-600">
+              <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{k.name || '(unnamed)'}</td>
+              <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">engram_••••••</td>
+              <td className="px-4 py-3 text-gray-600 dark:text-gray-300">{formatDate(k.created_at)}</td>
+              <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
                 {k.last_used ? formatDate(k.last_used) : '—'}
               </td>
               <td className="px-4 py-3 text-right">
@@ -141,16 +141,16 @@ function CreateKeyModal({
     <ModalShell onClose={onClose} title="New API Key">
       <form onSubmit={submit} className="space-y-4">
         <label className="block">
-          <span className="text-sm font-medium text-gray-700">Name</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Name</span>
           <input
             autoFocus
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g. iPhone MCP"
             maxLength={64}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
-          <span className="mt-1 block text-xs text-gray-500">
+          <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
             Helps you identify the key later — pick something memorable.
           </span>
         </label>
@@ -167,7 +167,7 @@ function CreateKeyModal({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+            className="rounded-md px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
           >
             Cancel
           </button>
@@ -209,7 +209,7 @@ function RevealKeyModal({
   return (
     <ModalShell onClose={onClose} title="Save your API key">
       <div className="space-y-4">
-        <p className="rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        <p className="rounded-md bg-amber-50 dark:bg-amber-950 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
           This is the only time the key will be shown. Copy it now and store it somewhere safe.
         </p>
 
@@ -220,7 +220,7 @@ function RevealKeyModal({
             value={createdKey.key}
             onFocus={selectAll}
             onClick={selectAll}
-            className="flex-1 min-w-0 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="flex-1 min-w-0 rounded-md border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-950 px-3 py-2 font-mono text-sm text-gray-900 dark:text-gray-100 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             aria-label="API key"
           />
           <button
@@ -246,7 +246,7 @@ function RevealKeyModal({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+            className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800"
           >
             Done
           </button>
@@ -334,11 +334,11 @@ function ModalShell({
       onClick={onClose}
     >
       <article
-        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        className="w-full max-w-md rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <header className="mb-4">
-          <h2 id="modal-title" className="text-lg font-semibold text-gray-900">
+          <h2 id="modal-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
             {title}
           </h2>
         </header>

--- a/frontend/src/settings/appearance-page.tsx
+++ b/frontend/src/settings/appearance-page.tsx
@@ -1,0 +1,16 @@
+import ThemeSegmented from '../theme/theme-segmented'
+
+export default function AppearancePage() {
+  return (
+    <section>
+      <h1 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">Appearance</h1>
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium text-gray-700 dark:text-gray-200">Theme</legend>
+        <ThemeSegmented />
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          System follows your operating system preference.
+        </p>
+      </fieldset>
+    </section>
+  )
+}

--- a/frontend/src/settings/billing-placeholder.tsx
+++ b/frontend/src/settings/billing-placeholder.tsx
@@ -4,12 +4,12 @@ export default function BillingPlaceholder() {
   return (
     <article className="space-y-6">
       <header>
-        <h1 className="text-2xl font-bold text-gray-900">Billing</h1>
-        <p className="mt-1 text-sm text-gray-600">Manage your subscription and payment method.</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Billing</h1>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">Manage your subscription and payment method.</p>
       </header>
 
-      <section className="rounded-lg border border-dashed border-gray-300 p-8 text-center space-y-3">
-        <p className="text-sm text-gray-600">
+      <section className="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-8 text-center space-y-3">
+        <p className="text-sm text-gray-600 dark:text-gray-300">
           Billing details will move into Settings soon. For now, manage your plan from the
           standalone billing page.
         </p>

--- a/frontend/src/settings/encryption-page.tsx
+++ b/frontend/src/settings/encryption-page.tsx
@@ -12,15 +12,15 @@ export default function EncryptionPage() {
   const { data: vaults, isLoading } = useVaults()
 
   if (isLoading) {
-    return <p className="text-sm text-gray-500">Loading…</p>
+    return <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
   }
 
   if (!vaults || vaults.length === 0) {
     return (
       <article className="space-y-4">
-        <h1 className="text-2xl font-bold text-gray-900">Encryption at Rest</h1>
-        <section className="rounded-lg border border-dashed border-gray-300 p-8 text-center">
-          <p className="text-sm text-gray-600">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Encryption at Rest</h1>
+        <section className="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-8 text-center">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
             Connect a vault from the Obsidian plugin to enable encryption.
           </p>
         </section>
@@ -31,8 +31,8 @@ export default function EncryptionPage() {
   return (
     <article className="space-y-6">
       <header>
-        <h1 className="text-2xl font-bold text-gray-900">Encryption at Rest</h1>
-        <p className="mt-1 text-sm text-gray-600">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Encryption at Rest</h1>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
           {vaults.length === 1
             ? 'Vault encryption status.'
             : `${vaults.length} vaults — manage encryption per vault.`}
@@ -58,12 +58,12 @@ function VaultEncryptionCard({ vault }: { vault: Vault }) {
   const [confirming, setConfirming] = useState(false)
 
   return (
-    <section className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
+    <section className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 space-y-4">
       <header className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <h2 className="truncate text-base font-semibold text-gray-900">{vault.name}</h2>
+          <h2 className="truncate text-base font-semibold text-gray-900 dark:text-gray-100">{vault.name}</h2>
           {vault.is_default && (
-            <p className="text-xs text-gray-500">Default vault</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Default vault</p>
           )}
         </div>
         <StatusBadge status={vault.encryption_status} />
@@ -71,12 +71,12 @@ function VaultEncryptionCard({ vault }: { vault: Vault }) {
 
       {vault.encryption_status === 'none' && (
         <>
-          <p className="text-sm text-gray-700">
+          <p className="text-sm text-gray-700 dark:text-gray-200">
             Notes and vector payloads are stored as plaintext on the server. Enabling encryption
             protects your data with a key derived from your account.
           </p>
           {vault.cooldown_days != null && vault.cooldown_days > 0 && (
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               After enabling, you cannot disable encryption for {vault.cooldown_days} days.
             </p>
           )}
@@ -111,7 +111,7 @@ function VaultEncryptionCard({ vault }: { vault: Vault }) {
       )}
 
       {vault.encryption_status === 'encrypted' && (
-        <p className="text-sm text-gray-700">
+        <p className="text-sm text-gray-700 dark:text-gray-200">
           All notes and vector payloads are encrypted.
           {vault.encrypted_at && (
             <> Enabled {new Date(vault.encrypted_at).toLocaleDateString()}.</>
@@ -125,30 +125,30 @@ function VaultEncryptionCard({ vault }: { vault: Vault }) {
 type BadgeStyle = { bg: string; text: string; dot: string; label: string }
 
 const STATUS_STYLES: Record<EncryptionStatus, BadgeStyle> = {
-  none: { bg: 'bg-gray-100', text: 'text-gray-700', dot: 'bg-gray-400', label: 'Not encrypted' },
+  none: { bg: 'bg-gray-100 dark:bg-gray-800', text: 'text-gray-700 dark:text-gray-200', dot: 'bg-gray-400', label: 'Not encrypted' },
   encrypting: {
-    bg: 'bg-blue-50',
-    text: 'text-blue-700',
+    bg: 'bg-blue-50 dark:bg-blue-950',
+    text: 'text-blue-700 dark:text-blue-300',
     dot: 'bg-blue-500 animate-pulse',
     label: 'Encrypting…',
   },
   encrypted: {
-    bg: 'bg-green-50',
-    text: 'text-green-700',
+    bg: 'bg-green-50 dark:bg-green-950',
+    text: 'text-green-700 dark:text-green-300',
     dot: 'bg-green-500',
     label: 'Encrypted',
   },
   decrypt_pending: {
-    bg: 'bg-amber-50',
-    text: 'text-amber-700',
+    bg: 'bg-amber-50 dark:bg-amber-950',
+    text: 'text-amber-700 dark:text-amber-300',
     dot: 'bg-amber-500 animate-pulse',
     label: 'Decrypt pending…',
   },
 }
 
 const UNKNOWN_STYLE: BadgeStyle = {
-  bg: 'bg-gray-100',
-  text: 'text-gray-700',
+  bg: 'bg-gray-100 dark:bg-gray-800',
+  text: 'text-gray-700 dark:text-gray-200',
   dot: 'bg-gray-400',
   label: 'Unknown',
 }
@@ -183,10 +183,10 @@ function ProgressView({
 
   return (
     <section aria-live="polite" className="space-y-2">
-      <p className="text-sm text-gray-700">
+      <p className="text-sm text-gray-700 dark:text-gray-200">
         {verb} {processed.toLocaleString()} of {total.toLocaleString()} notes ({percent}%)
       </p>
-      <div className="h-2 overflow-hidden rounded-full bg-gray-200">
+      <div className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
         <div
           className="h-full rounded-full bg-blue-500 transition-all"
           style={{ width: `${percent}%` }}
@@ -210,9 +210,9 @@ function ConfirmEncrypt({
   onConfirm: () => void
 }) {
   return (
-    <section className="rounded-md border border-amber-200 bg-amber-50 p-4 space-y-3">
-      <p className="text-sm font-medium text-amber-900">Encrypt this vault?</p>
-      <ul className="ml-4 list-disc space-y-1 text-sm text-amber-800">
+    <section className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950 p-4 space-y-3">
+      <p className="text-sm font-medium text-amber-900 dark:text-amber-200">Encrypt this vault?</p>
+      <ul className="ml-4 list-disc space-y-1 text-sm text-amber-800 dark:text-amber-300">
         <li>All existing notes will be re-encrypted in the background.</li>
         <li>Vector search continues to work — payloads are encrypted too.</li>
         {cooldownDays != null && cooldownDays > 0 && (
@@ -230,7 +230,7 @@ function ConfirmEncrypt({
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-md px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+          className="rounded-md px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
         >
           Cancel
         </button>

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -1,6 +1,7 @@
 import { NavLink, Outlet } from 'react-router'
 
 const SECTIONS = [
+  { to: 'appearance', label: 'Appearance' },
   { to: 'api-keys', label: 'API Keys' },
   { to: 'encryption', label: 'Encryption' },
   { to: 'billing', label: 'Billing' },

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -11,7 +11,7 @@ export default function SettingsLayout() {
   return (
     <section className="mx-auto flex max-w-5xl gap-8 py-2">
       <nav aria-label="Settings sections" className="w-48 shrink-0">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
           Settings
         </h2>
         <ul className="space-y-1">
@@ -22,8 +22,8 @@ export default function SettingsLayout() {
                 className={({ isActive }) =>
                   `block rounded-md px-3 py-2 text-sm transition-colors ${
                     isActive
-                      ? 'bg-blue-50 font-medium text-blue-700'
-                      : 'text-gray-700 hover:bg-gray-100'
+                      ? 'bg-blue-50 dark:bg-blue-950 font-medium text-blue-700 dark:text-blue-300'
+                      : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
                   }`
                 }
               >

--- a/frontend/src/theme/resolve.ts
+++ b/frontend/src/theme/resolve.ts
@@ -1,0 +1,23 @@
+import type { ThemeChoice } from './storage'
+
+export type ResolvedTheme = 'light' | 'dark'
+
+export function getSystemPreference(): ResolvedTheme {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light'
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function resolveTheme(choice: ThemeChoice, systemPref: ResolvedTheme): ResolvedTheme {
+  return choice === 'system' ? systemPref : choice
+}
+
+export function applyThemeClass(resolved: ResolvedTheme): void {
+  const root = document.documentElement
+  if (resolved === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+}

--- a/frontend/src/theme/storage.ts
+++ b/frontend/src/theme/storage.ts
@@ -1,0 +1,24 @@
+export type ThemeChoice = 'system' | 'light' | 'dark'
+
+const KEY = 'engram:theme'
+const VALID: readonly ThemeChoice[] = ['system', 'light', 'dark']
+
+export function getStoredTheme(): ThemeChoice {
+  try {
+    const raw = window.localStorage.getItem(KEY)
+    if (raw && (VALID as readonly string[]).includes(raw)) {
+      return raw as ThemeChoice
+    }
+  } catch {
+    // localStorage may throw in private mode or sandboxed contexts
+  }
+  return 'system'
+}
+
+export function setStoredTheme(choice: ThemeChoice): void {
+  try {
+    window.localStorage.setItem(KEY, choice)
+  } catch {
+    // best-effort; ignore failures
+  }
+}

--- a/frontend/src/theme/theme-provider.tsx
+++ b/frontend/src/theme/theme-provider.tsx
@@ -1,0 +1,49 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { getStoredTheme, setStoredTheme, type ThemeChoice } from './storage'
+import { applyThemeClass, getSystemPreference, resolveTheme, type ResolvedTheme } from './resolve'
+
+interface ThemeContextValue {
+  theme: ThemeChoice
+  resolved: ResolvedTheme
+  setTheme: (next: ThemeChoice) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeChoice>(() => getStoredTheme())
+  const [systemPref, setSystemPref] = useState<ResolvedTheme>(() => getSystemPreference())
+
+  const resolved = useMemo(() => resolveTheme(theme, systemPref), [theme, systemPref])
+
+  useEffect(() => {
+    applyThemeClass(resolved)
+  }, [resolved])
+
+  useEffect(() => {
+    if (theme !== 'system') return
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => setSystemPref(e.matches ? 'dark' : 'light')
+
+    setSystemPref(mql.matches ? 'dark' : 'light')
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [theme])
+
+  const setTheme = useCallback((next: ThemeChoice) => {
+    setStoredTheme(next)
+    setThemeState(next)
+  }, [])
+
+  const value = useMemo(() => ({ theme, resolved, setTheme }), [theme, resolved, setTheme])
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/frontend/src/theme/theme-segmented.tsx
+++ b/frontend/src/theme/theme-segmented.tsx
@@ -1,0 +1,36 @@
+import { useTheme } from './theme-provider'
+import type { ThemeChoice } from './storage'
+
+const OPTIONS: ReadonlyArray<{ value: ThemeChoice; label: string }> = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+]
+
+export default function ThemeSegmented() {
+  const { theme, setTheme } = useTheme()
+  return (
+    <fieldset className="inline-flex rounded-md border border-gray-300 bg-white p-0.5 dark:border-gray-700 dark:bg-gray-900">
+      <legend className="sr-only">Theme</legend>
+      {OPTIONS.map((opt) => {
+        const active = theme === opt.value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => setTheme(opt.value)}
+            aria-pressed={active}
+            data-theme-option={opt.value}
+            className={
+              active
+                ? 'rounded px-3 py-1 text-sm font-medium bg-blue-600 text-white dark:bg-blue-500'
+                : 'rounded px-3 py-1 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
+            }
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </fieldset>
+  )
+}

--- a/frontend/src/theme/theme-toggle.tsx
+++ b/frontend/src/theme/theme-toggle.tsx
@@ -1,0 +1,55 @@
+import { useTheme } from './theme-provider'
+import type { ThemeChoice } from './storage'
+
+const NEXT: Record<ThemeChoice, ThemeChoice> = {
+  light: 'dark',
+  dark: 'system',
+  system: 'light',
+}
+
+const LABEL: Record<ThemeChoice, string> = {
+  light: 'Switch to dark theme',
+  dark: 'Switch to system theme',
+  system: 'Switch to light theme',
+}
+
+function Icon({ choice }: { choice: ThemeChoice }) {
+  // 18x18 outline icons, currentColor stroke
+  if (choice === 'light') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+      </svg>
+    )
+  }
+  if (choice === 'dark') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+      </svg>
+    )
+  }
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="2" y="4" width="20" height="14" rx="2" />
+      <path d="M8 22h8M12 18v4" />
+    </svg>
+  )
+}
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(NEXT[theme])}
+      aria-label={LABEL[theme]}
+      title={LABEL[theme]}
+      data-theme-choice={theme}
+      className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+    >
+      <Icon choice={theme} />
+    </button>
+  )
+}

--- a/frontend/src/theme/theme-toggle.tsx
+++ b/frontend/src/theme/theme-toggle.tsx
@@ -1,20 +1,20 @@
+import { useEffect, useRef, useState } from 'react'
 import { useTheme } from './theme-provider'
 import type { ThemeChoice } from './storage'
 
-const NEXT: Record<ThemeChoice, ThemeChoice> = {
-  light: 'dark',
-  dark: 'system',
-  system: 'light',
-}
+const OPTIONS: ReadonlyArray<{ value: ThemeChoice; label: string }> = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+]
 
-const LABEL: Record<ThemeChoice, string> = {
-  light: 'Switch to dark theme',
-  dark: 'Switch to system theme',
-  system: 'Switch to light theme',
+const BUTTON_LABEL: Record<ThemeChoice, string> = {
+  light: 'Theme: light',
+  dark: 'Theme: dark',
+  system: 'Theme: system',
 }
 
 function Icon({ choice }: { choice: ThemeChoice }) {
-  // 18x18 outline icons, currentColor stroke
   if (choice === 'light') {
     return (
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -38,18 +38,111 @@ function Icon({ choice }: { choice: ThemeChoice }) {
   )
 }
 
+function Check() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M5 12l5 5L20 7" />
+    </svg>
+  )
+}
+
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme()
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  useEffect(() => {
+    if (!open) return
+
+    function handlePointer(e: MouseEvent) {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false)
+        return
+      }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        const items = itemRefs.current.filter((el): el is HTMLButtonElement => el !== null)
+        if (items.length === 0) return
+        const active = document.activeElement as HTMLButtonElement | null
+        const idx = active ? items.indexOf(active) : -1
+        const next = e.key === 'ArrowDown'
+          ? items[(idx + 1) % items.length]
+          : items[(idx - 1 + items.length) % items.length]
+        next?.focus()
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointer)
+    document.addEventListener('keydown', handleKey)
+
+    const currentIdx = OPTIONS.findIndex((o) => o.value === theme)
+    itemRefs.current[currentIdx]?.focus()
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointer)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open, theme])
+
+  function pick(value: ThemeChoice) {
+    setTheme(value)
+    setOpen(false)
+  }
+
   return (
-    <button
-      type="button"
-      onClick={() => setTheme(NEXT[theme])}
-      aria-label={LABEL[theme]}
-      title={LABEL[theme]}
-      data-theme-choice={theme}
-      className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-    >
-      <Icon choice={theme} />
-    </button>
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-label={BUTTON_LABEL[theme]}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={BUTTON_LABEL[theme]}
+        data-theme-choice={theme}
+        className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+      >
+        <Icon choice={theme} />
+      </button>
+      {open && (
+        <ul
+          role="menu"
+          aria-label="Theme"
+          className="absolute right-0 top-full z-50 mt-1 min-w-36 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-800 dark:bg-gray-900"
+        >
+          {OPTIONS.map((opt, i) => {
+            const active = opt.value === theme
+            return (
+              <li key={opt.value} role="none">
+                <button
+                  ref={(el) => {
+                    itemRefs.current[i] = el
+                  }}
+                  type="button"
+                  role="menuitem"
+                  onClick={() => pick(opt.value)}
+                  data-theme-option={opt.value}
+                  aria-current={active ? 'true' : undefined}
+                  className={
+                    active
+                      ? 'flex w-full items-center justify-between gap-3 px-3 py-1.5 text-sm font-medium text-gray-900 bg-gray-100 dark:bg-gray-800 dark:text-gray-100'
+                      : 'flex w-full items-center justify-between gap-3 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800'
+                  }
+                >
+                  <span className="flex items-center gap-2">
+                    <Icon choice={opt.value} />
+                    {opt.label}
+                  </span>
+                  {active && <Check />}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
   )
 }

--- a/frontend/src/viewer/dashboard.tsx
+++ b/frontend/src/viewer/dashboard.tsx
@@ -15,21 +15,21 @@ interface NoteRowProps {
 
 function NoteRow({ note }: NoteRowProps) {
   return (
-    <article className="border-b border-gray-100 py-3 last:border-0">
+    <article className="border-b border-gray-100 dark:border-gray-800 py-3 last:border-0">
       <Link
         to={`/note/${encodeURIComponent(note.path)}`}
         className="block hover:text-blue-700"
       >
-        <h3 className="text-sm font-medium text-gray-900">{note.title || note.path}</h3>
+        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">{note.title || note.path}</h3>
       </Link>
-      <footer className="mt-1 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+      <footer className="mt-1 flex flex-wrap items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
         {note.folder && <span>{note.folder}</span>}
         {note.tags.length > 0 && (
           <ul className="flex gap-1" aria-label="Tags">
             {note.tags.map((tag) => (
               <li
                 key={tag}
-                className="rounded bg-gray-100 px-1.5 py-0.5 text-gray-600"
+                className="rounded bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 text-gray-600 dark:text-gray-300"
               >
                 {tag}
               </li>
@@ -45,10 +45,10 @@ function NoteRow({ note }: NoteRowProps) {
 function FolderNotes({ folder }: { folder: string }) {
   const { data: notes, isLoading, isError } = useFolderNotes(folder)
 
-  if (isLoading) return <p className="text-sm text-gray-500">Loading…</p>
-  if (isError) return <p className="text-sm text-red-600">Failed to load notes.</p>
+  if (isLoading) return <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
+  if (isError) return <p className="text-sm text-red-600 dark:text-red-400">Failed to load notes.</p>
   if (!notes || notes.length === 0) {
-    return <p className="text-sm text-gray-500">No notes in this folder.</p>
+    return <p className="text-sm text-gray-500 dark:text-gray-400">No notes in this folder.</p>
   }
 
   return (
@@ -72,7 +72,7 @@ export default function Dashboard() {
     return (
       <>
         <header className="mb-4">
-          <h2 className="text-base font-semibold text-gray-800">{folder}</h2>
+          <h2 className="text-base font-semibold text-gray-800 dark:text-gray-200">{folder}</h2>
         </header>
         <FolderNotes folder={folder} />
       </>
@@ -81,11 +81,11 @@ export default function Dashboard() {
 
   return (
     <section aria-label="Welcome" className="flex h-full flex-col items-center justify-center text-center">
-      <h2 className="text-xl font-semibold text-gray-800">Welcome to Engram</h2>
-      <p className="mt-2 text-sm text-gray-500">
+      <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-200">Welcome to Engram</h2>
+      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
         Select a folder from the sidebar to browse your notes.
       </p>
-      <p className="mt-1 text-sm text-gray-500">
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
         Use <Link to="/search" className="text-blue-600 hover:underline">Search</Link> to find notes by keyword or semantic query.
       </p>
     </section>

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -50,13 +50,13 @@ export default function FolderTree() {
     : null
 
   if (isLoading) {
-    return <p className="px-3 py-2 text-xs text-gray-500">Loading…</p>
+    return <p className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">Loading…</p>
   }
   if (isError) {
-    return <p className="px-3 py-2 text-xs text-red-600">Failed to load folders.</p>
+    return <p className="px-3 py-2 text-xs text-red-600 dark:text-red-400">Failed to load folders.</p>
   }
   if (!folders || folders.length === 0) {
-    return <p className="px-3 py-2 text-xs text-gray-500">No notes yet.</p>
+    return <p className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">No notes yet.</p>
   }
 
   const tree = buildTree(folders)
@@ -115,11 +115,11 @@ function FolderNode({ node, depth, selectedNotePath }: FolderNodeProps) {
         type="button"
         onClick={() => setOpen((o) => !o)}
         aria-expanded={isOpen}
-        className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left text-gray-700 hover:bg-gray-100"
+        className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
         style={{ paddingLeft: `${depth * 12 + 4}px` }}
       >
         <span
-          className={`shrink-0 text-[10px] text-gray-400 transition-transform ${
+          className={`shrink-0 text-[10px] text-gray-400 dark:text-gray-500 transition-transform ${
             isOpen ? 'rotate-90' : ''
           }`}
           aria-hidden="true"
@@ -164,7 +164,7 @@ function FolderFiles({
   if (isLoading) {
     return (
       <li
-        className="px-1 py-0.5 text-xs text-gray-400"
+        className="px-1 py-0.5 text-xs text-gray-400 dark:text-gray-500"
         style={{ paddingLeft: `${depth * 12 + 4}px` }}
       >
         …
@@ -203,8 +203,8 @@ function NoteLeaf({
         aria-current={isSelected ? 'page' : undefined}
         className={`flex items-center gap-1 rounded px-1 py-0.5 ${
           isSelected
-            ? 'bg-blue-50 font-medium text-blue-700'
-            : 'text-gray-700 hover:bg-gray-100'
+            ? 'bg-blue-50 dark:bg-blue-950 font-medium text-blue-700 dark:text-blue-300'
+            : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
         }`}
         style={{ paddingLeft: `${depth * 12 + 16}px` }}
       >
@@ -243,7 +243,7 @@ function FolderIcon({ open }: { open: boolean }) {
     <svg
       aria-hidden="true"
       viewBox="0 0 16 16"
-      className="h-3.5 w-3.5 shrink-0 text-gray-500"
+      className="h-3.5 w-3.5 shrink-0 text-gray-500 dark:text-gray-400"
       fill="currentColor"
     >
       {open ? (
@@ -260,7 +260,7 @@ function FileIcon() {
     <svg
       aria-hidden="true"
       viewBox="0 0 16 16"
-      className="h-3.5 w-3.5 shrink-0 text-gray-400"
+      className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500"
       fill="currentColor"
     >
       <path d="M4 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V5.414a1 1 0 0 0-.293-.707L9.293 1.293A1 1 0 0 0 8.586 1H4zm5 0v4a1 1 0 0 0 1 1h3" />

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -18,7 +18,7 @@ export default function NotePage() {
   }
 
   if (error) {
-    return <p className="text-red-600">Failed to load note: {error.message}</p>
+    return <p className="text-red-600 dark:text-red-400">Failed to load note: {error.message}</p>
   }
 
   if (!note) {

--- a/frontend/src/viewer/note-view.tsx
+++ b/frontend/src/viewer/note-view.tsx
@@ -14,20 +14,20 @@ export default function NoteView({ content, title, tags, updatedAt }: NoteViewPr
     <article>
       <header className="mb-6">
         <h1 className="text-2xl font-bold">{title}</h1>
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
           Last updated: {new Date(updatedAt).toLocaleDateString()}
         </p>
         {tags.length > 0 && (
           <ul className="mt-2 flex flex-wrap gap-2">
             {tags.map((tag) => (
-              <li key={tag} className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+              <li key={tag} className="rounded bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs text-gray-600 dark:text-gray-300">
                 {tag}
               </li>
             ))}
           </ul>
         )}
       </header>
-      <section className="prose prose-sm max-w-none">
+      <section className="prose prose-sm max-w-none dark:prose-invert">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeHighlight]}

--- a/frontend/src/viewer/search-page.tsx
+++ b/frontend/src/viewer/search-page.tsx
@@ -9,23 +9,23 @@ export default function SearchPage() {
 
   return (
     <section className="mx-auto max-w-3xl">
-      <h1 className="mb-4 text-xl font-semibold text-gray-900">Search</h1>
+      <h1 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">Search</h1>
       <input
         type="search"
         placeholder="Search your notes…"
         value={input}
         onChange={(e) => setInput(e.target.value)}
-        className="mb-6 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+        className="mb-6 w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
         autoFocus
       />
 
-      {isLoading && <p className="text-sm text-gray-500">Searching…</p>}
+      {isLoading && <p className="text-sm text-gray-500 dark:text-gray-400">Searching…</p>}
       {error && (
-        <p className="text-sm text-red-600">Search failed: {error.message}</p>
+        <p className="text-sm text-red-600 dark:text-red-400">Search failed: {error.message}</p>
       )}
 
       {results && results.length === 0 && deferredQuery && !isLoading && (
-        <p className="text-sm text-gray-500">No results for "{deferredQuery}"</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">No results for "{deferredQuery}"</p>
       )}
 
       {results && results.length > 0 && (
@@ -39,7 +39,7 @@ export default function SearchPage() {
       )}
 
       {!deferredQuery && !isLoading && (
-        <p className="text-sm text-gray-400">Type to search your notes.</p>
+        <p className="text-sm text-gray-400 dark:text-gray-500">Type to search your notes.</p>
       )}
     </section>
   )
@@ -51,25 +51,25 @@ function ResultCard({ result, query }: { result: SearchResult; query: string }) 
   return (
     <Link
       to={href}
-      className="block rounded-md border border-gray-200 bg-white p-4 transition hover:border-blue-300 hover:bg-blue-50/40"
+      className="block rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4 transition hover:border-blue-300 hover:bg-blue-50/40 dark:hover:border-blue-700 dark:hover:bg-blue-950/40"
     >
       {result.folder && (
-        <p className="text-xs text-gray-400">{result.folder}</p>
+        <p className="text-xs text-gray-400 dark:text-gray-500">{result.folder}</p>
       )}
-      <p className="mt-0.5 text-base font-medium text-gray-900">
+      <p className="mt-0.5 text-base font-medium text-gray-900 dark:text-gray-100">
         {result.title || lastSegment(result.path)}
       </p>
       {result.heading_path && result.heading_path !== result.title && (
-        <p className="mt-0.5 text-xs text-gray-500">↳ {result.heading_path}</p>
+        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">↳ {result.heading_path}</p>
       )}
       {result.snippet && (
-        <p className="mt-2 text-sm text-gray-700 line-clamp-3">
+        <p className="mt-2 text-sm text-gray-700 dark:text-gray-200 line-clamp-3">
           {highlightQuery(result.snippet, query)}
         </p>
       )}
       {result.match_count > 1 && (
-        <p className="mt-2 text-xs text-gray-400">
-          +{result.match_count - 1} more match{result.match_count - 1 === 1 ? '' : 'es'} in this note
+        <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+            +{result.match_count - 1} more match{result.match_count - 1 === 1 ? '' : 'es'} in this note
         </p>
       )}
     </Link>
@@ -94,7 +94,7 @@ function highlightQuery(text: string, query: string): React.ReactNode {
 
   return parts.map((part, i) =>
     i % 2 === 1 ? (
-      <mark key={i} className="bg-yellow-100 text-gray-900">
+      <mark key={i} className="bg-yellow-100 dark:bg-yellow-900 text-gray-900 dark:text-gray-100">
         {part}
       </mark>
     ) : (

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.70",
+      version: "0.5.71",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.69",
+      version: "0.5.70",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Tailwind v4 class-based dark variant on `<html>`
- `ThemeProvider` owns `'system' | 'light' | 'dark'`; persists to `localStorage`; tracks `prefers-color-scheme` while in `system`
- Inline anti-FOUC boot script in `index.html`
- Header icon toggle (Light → Dark → System)
- Settings → Appearance page with segmented control (now the default Settings route)
- Dark variants across layout, auth, viewer, settings, billing, oauth, device, not-found
- Dark `highlight.js` palette scoped under `html.dark`

## Test plan
- [x] `npm run test:e2e:local -- dark-mode.spec.ts` — 4/4 pass
- [x] Full local e2e suite — 10/10 pass
- [x] Tests cover: header toggle cycle + persistence, segmented control + aria-pressed, system color-scheme tracking, FOUC-free pre-paint application

## Notes

- `playwright.config.ts` now sets `ENCRYPTION_MASTER_KEY` + `KEY_PROVIDER` for the local webServer (required since KMS Phase 1), and gates Clerk webservers behind `hasClerkCreds` so the local suite doesn't try to start them without credentials.
- Settings index now redirects to `/settings/appearance` (was `/settings/api-keys`).

Spec: \`docs/superpowers/specs/2026-05-11-dark-mode-design.md\`
Plan: \`docs/superpowers/plans/2026-05-11-dark-mode.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)