### PR TITLE
feat(ui): mobile-friendly document view

### DIFF
--- a/docs/context/followup-show-attachments-in-tree.md
+++ b/docs/context/followup-show-attachments-in-tree.md
@@ -1,0 +1,25 @@
+# Follow-up: show attachments in the file tree
+
+**Status:** Backlog — deferred from the mobile-document-view work (PR #115, 2026-05-12).
+
+## The gap
+
+`FolderTree` (`frontend/src/viewer/folder-tree.tsx`) and `useFolderNotes` (`frontend/src/api/queries.ts`) only call `GET /folders/:path/notes`, which hits `Engram.Notes.list_notes_in_folder/3` and queries the `notes` table only. PDFs, images, and other binaries live in the separate `attachments` table — they never appear in the tree, even when the user has uploaded them via the plugin and they are stored under the same folder path.
+
+The user noticed this while testing the mobile layout: their vault has PDFs that don't show up alongside `.md` files.
+
+## What the tree already does correctly
+
+- Non-`.md` extension chip is wired in `NoteLeaf` (e.g. shows `PNG` on the right). It only fires for files that *do* come back from the notes endpoint — so if/when a vault has non-md files stored as notes, the chip already works.
+
+## What's needed to close the gap
+
+1. **Backend endpoint** to list attachments by folder. Likely shape: `GET /folders/:path/attachments` returning `[{ path, mime, size, mtime }]`. Lives in `lib/engram_web/controllers/folders_controller.ex` (or a new `attachments_in_folder` route on `AttachmentsController`) and `Engram.Attachments.list_attachments_in_folder/3`.
+2. **Frontend hook** `useFolderAttachments(folderPath)` paralleling `useFolderNotes`.
+3. **Merge in `FolderFiles`/`RootFiles`**: combine notes + attachments, stable-sort by display name. Decide whether attachments and notes interleave alphabetically (Obsidian-like) or attachments group at the bottom.
+4. **Different click handler** for attachments — they should open an attachment viewer route or trigger a download, not navigate to `/note/`. The existing `attachment-img.tsx` viewer pattern handles images via `engram-attachment:` URLs; a PDF viewer would need similar.
+5. **Real-time sync** — when an attachment is uploaded/deleted, the tree should refresh. Hook into the existing channel/PubSub plumbing that note CRUD already uses.
+
+## Scope estimate
+
+Small backend slice (~1 hour), small frontend slice (~1 hour), plus design decisions about ordering and the attachment viewer behaviour. Probably one spec + one plan, not bundled into anything else.

--- a/docs/superpowers/plans/2026-05-12-mobile-document-view.md
+++ b/docs/superpowers/plans/2026-05-12-mobile-document-view.md
@@ -1,0 +1,781 @@
+# Mobile Document View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Below `md` (768px), replace the desktop three-column resizable layout with a single-column document view plus left and right `Sheet` drawers (file picker + ToC), and tune the editor + typography for touch.
+
+**Architecture:** Branch at `app-layout.tsx` on a `useMediaQuery('(min-width: 768px)')` hook. Above `md` → existing `ResizablePanelGroup`. Below `md` → a new `MobileLayout` rendering a sticky header with hamburger + ToC triggers, both opening shadcn `Sheet`s carrying the same `VaultSwitcher`/`FolderTree` and `RightSidebarContext.content` already in use. Drawer state is component-local — never persisted.
+
+**Tech Stack:** React 19, Tailwind v4, shadcn/ui (`Sheet` is new — Radix Dialog under the hood), `react-router` `Outlet`, Playwright for verification. Frontend has **no** unit-test runner; verification happens via Playwright + manual viewport resize.
+
+---
+
+## File map
+
+| Path | Status | Responsibility |
+|------|--------|----------------|
+| `frontend/src/hooks/use-media-query.ts` | new | `window.matchMedia` hook, SSR-safe default, listener cleanup |
+| `frontend/src/components/ui/sheet.tsx` | new (via `bunx --bun shadcn add sheet`) | shadcn Sheet primitive (Radix Dialog) |
+| `frontend/src/layout/mobile-layout.tsx` | new | Sticky header + two `Sheet`s + `<Outlet/>` |
+| `frontend/src/layout/app-layout.tsx` | modify | Branch on `useMediaQuery`; render mobile or desktop layout |
+| `frontend/src/viewer/note-view.tsx` | modify | Responsive padding + typography (`px-4 sm:px-8 lg:px-12`, `prose lg:prose-lg`) |
+| `frontend/src/viewer/note-editor.tsx` | modify | CodeMirror theme extension forcing 16px font on `.cm-content` |
+| `frontend/src/main.css` | modify | `html { scroll-padding-top: 4rem }` |
+| `frontend/e2e/mobile.spec.ts` | new | Playwright mobile-viewport smoke test |
+| `mix.exs` | modify | Bump version (pre-push hook requires it) |
+
+---
+
+## Task 1: `use-media-query` hook
+
+**Files:**
+- Create: `frontend/src/hooks/use-media-query.ts`
+
+- [ ] **Step 1: Confirm `frontend/src/hooks/` doesn't exist yet, create directory**
+
+```bash
+ls frontend/src/hooks 2>/dev/null || mkdir -p frontend/src/hooks
+```
+
+- [ ] **Step 2: Write the hook**
+
+```ts
+import { useEffect, useState } from 'react'
+
+/**
+ * SSR-safe matchMedia hook. Returns `false` on the server (no matchMedia),
+ * then re-renders with the real value on mount. Subscribes to changes via
+ * `addEventListener('change')` and cleans up on unmount.
+ */
+export function useMediaQuery(query: string): boolean {
+  const getMatch = () => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false
+    }
+    return window.matchMedia(query).matches
+  }
+
+  const [matches, setMatches] = useState<boolean>(getMatch)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mql = window.matchMedia(query)
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches)
+    // Sync once on mount in case the initial render mismatched (SSR / hydration).
+    setMatches(mql.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [query])
+
+  return matches
+}
+```
+
+- [ ] **Step 3: TypeScript check**
+
+Run: `cd frontend && bun run build`
+Expected: PASS (no TS errors). Note: this also rebuilds Vite — slow but the project's only TS check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/hooks/use-media-query.ts
+git commit -m "feat(frontend): add useMediaQuery hook"
+```
+
+---
+
+## Task 2: shadcn Sheet primitive
+
+**Files:**
+- Create: `frontend/src/components/ui/sheet.tsx` (generated)
+
+- [ ] **Step 1: Install Sheet via shadcn CLI**
+
+Run: `cd frontend && bunx --bun shadcn@latest add sheet`
+Expected: creates `src/components/ui/sheet.tsx`. CLI may prompt to overwrite — say no to anything else.
+
+- [ ] **Step 2: Verify import resolves**
+
+Run: `cd frontend && bun run build`
+Expected: PASS. If `@radix-ui/react-dialog` is missing, install it: `bun add @radix-ui/react-dialog`. The shadcn CLI normally adds this automatically.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ui/sheet.tsx frontend/package.json frontend/bun.lock 2>/dev/null
+git commit -m "feat(frontend): add shadcn Sheet primitive"
+```
+
+---
+
+## Task 3: `MobileLayout` component
+
+**Files:**
+- Create: `frontend/src/layout/mobile-layout.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { Menu, PanelRightOpen } from 'lucide-react'
+import { lazy, Suspense, useState } from 'react'
+import { Link, NavLink, Outlet } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
+import { config } from '../config'
+import ThemeToggle from '../theme/theme-toggle'
+import FolderTree from '../viewer/folder-tree'
+import { useRightSidebar } from './right-sidebar-context'
+import VaultSwitcher from './vault-switcher'
+
+const isClerk = config.authProvider === 'clerk'
+const ClerkUserButton = isClerk
+  ? lazy(() => import('@clerk/clerk-react').then((mod) => ({ default: mod.UserButton })))
+  : null
+const LocalUserMenu = lazy(() => import('../auth/local-user-menu'))
+
+function HeaderLink({ to, label }: { to: string; label: string }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `text-sm transition hover:text-foreground ${
+          isActive ? 'font-medium text-foreground' : 'text-muted-foreground'
+        }`
+      }
+    >
+      {label}
+    </NavLink>
+  )
+}
+
+export default function MobileLayout() {
+  const { content: rightContent } = useRightSidebar()
+  const [leftOpen, setLeftOpen] = useState(false)
+  const [rightOpen, setRightOpen] = useState(false)
+
+  return (
+    <section className="flex h-dvh flex-col bg-background text-foreground">
+      <header className="sticky top-0 z-20 flex shrink-0 items-center justify-between border-b border-border bg-card px-2 py-2">
+        <section className="flex items-center gap-1">
+          <Sheet open={leftOpen} onOpenChange={setLeftOpen}>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="Open files" className="h-11 w-11">
+                <Menu />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-[85vw] max-w-sm p-0">
+              <SheetHeader className="border-b border-border px-3 py-2">
+                <SheetTitle>Files</SheetTitle>
+              </SheetHeader>
+              <ScrollArea className="h-[calc(100dvh-3rem)]" onClick={() => setLeftOpen(false)}>
+                <VaultSwitcher />
+                <FolderTree />
+              </ScrollArea>
+            </SheetContent>
+          </Sheet>
+          <Link to="/" className="text-base font-semibold text-foreground">
+            Engram
+          </Link>
+        </section>
+        <nav className="flex items-center gap-1" aria-label="Main navigation">
+          <HeaderLink to="/search" label="Search" />
+          <HeaderLink to="/settings" label="Settings" />
+          <ThemeToggle />
+          <Suspense fallback={null}>
+            {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
+          </Suspense>
+          {rightContent && (
+            <Sheet open={rightOpen} onOpenChange={setRightOpen}>
+              <SheetTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Open outline"
+                  className="h-11 w-11"
+                >
+                  <PanelRightOpen />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="right" className="w-[85vw] max-w-sm p-0">
+                <SheetHeader className="border-b border-border px-3 py-2">
+                  <SheetTitle>On this page</SheetTitle>
+                </SheetHeader>
+                <ScrollArea className="h-[calc(100dvh-3rem)]" onClick={() => setRightOpen(false)}>
+                  {rightContent}
+                </ScrollArea>
+              </SheetContent>
+            </Sheet>
+          )}
+        </nav>
+      </header>
+      <main className="flex-1 overflow-y-auto bg-muted/40 text-foreground">
+        <Outlet />
+      </main>
+    </section>
+  )
+}
+```
+
+Notes:
+- `onClick={() => setLeft/RightOpen(false)}` on the `ScrollArea` closes the drawer when a list item is clicked. Item-level handlers (like ToC anchor links inside `NoteToc`) keep working; the outer click handler fires after, dismissing the drawer.
+- `h-dvh` uses the modern dynamic viewport unit; iOS Safari shrinks it as the URL bar appears, unlike `h-screen`.
+- 44px touch targets via `h-11 w-11`. Default shadcn `size="icon"` is 36px.
+
+- [ ] **Step 2: TypeScript check**
+
+Run: `cd frontend && bun run build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/layout/mobile-layout.tsx
+git commit -m "feat(frontend): add MobileLayout with file + ToC drawers"
+```
+
+---
+
+## Task 4: Wire `MobileLayout` into `AppLayout`
+
+**Files:**
+- Modify: `frontend/src/layout/app-layout.tsx`
+
+- [ ] **Step 1: Edit `app-layout.tsx` — add imports and branch**
+
+In the existing file, add the import at the top with the other layout imports:
+
+```tsx
+import { useMediaQuery } from '@/hooks/use-media-query'
+import MobileLayout from './mobile-layout'
+```
+
+Then in `AppLayoutInner`, immediately after the `const { data: billing } = useBillingStatus()` line, add:
+
+```tsx
+const isDesktop = useMediaQuery('(min-width: 768px)')
+```
+
+And replace the existing top-level `return (...)` body with:
+
+```tsx
+return (
+  <>
+    {billing?.subscription?.status === 'trialing' && billing.trial_days_remaining > 0 && billing.trial_days_remaining <= 3 && (
+      <aside className="bg-amber-50 px-4 py-2 text-center text-sm text-amber-900 dark:bg-amber-950/40 dark:text-amber-100" role="alert">
+        {billing.trial_days_remaining} days left in your trial.
+      </aside>
+    )}
+    {isDesktop ? <DesktopLayout /> : <MobileLayout />}
+  </>
+)
+```
+
+Then extract the rest (the `<section className="flex h-screen flex-col ..."> ... </section>` block — including header, panel group, and the `toggleLeft`/`toggleRight`/`useEffect`/`hasRight`/`leftRef`/`rightRef`/`leftCollapsed`/`rightCollapsed`/`setRightCollapsed` machinery) into a new component declared in the same file:
+
+```tsx
+function DesktopLayout() {
+  const leftRef = useRef<ImperativePanelHandle>(null)
+  const rightRef = useRef<ImperativePanelHandle>(null)
+  const [leftCollapsed, setLeftCollapsed] = useState(false)
+  const { content: rightContent, collapsed: rightCollapsed, setCollapsed: setRightCollapsed } =
+    useRightSidebar()
+
+  const toggleLeft = () => {
+    const p = leftRef.current
+    if (!p) return
+    if (p.isCollapsed()) p.expand()
+    else p.collapse()
+  }
+
+  const toggleRight = () => {
+    const p = rightRef.current
+    if (!p) return
+    if (p.isCollapsed()) p.expand()
+    else p.collapse()
+  }
+
+  useEffect(() => {
+    if (rightContent == null) {
+      rightRef.current?.collapse()
+    } else if (rightRef.current?.isCollapsed()) {
+      rightRef.current?.expand()
+    }
+  }, [rightContent])
+
+  const hasRight = rightContent != null
+
+  return (
+    <section className="flex h-screen flex-col bg-background text-foreground">
+      <header className="flex items-center justify-between border-b border-border bg-card px-4 py-2">
+        <Link to="/" className="text-lg font-semibold text-foreground hover:text-foreground/80">
+          Engram
+        </Link>
+        <nav className="flex items-center gap-3" aria-label="Main navigation">
+          <HeaderLink to="/search" label="Search" />
+          <HeaderLink to="/billing" label="Billing" />
+          <HeaderLink to="/settings" label="Settings" />
+          <ThemeToggle />
+          <Suspense fallback={null}>
+            {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
+          </Suspense>
+        </nav>
+      </header>
+
+      <ResizablePanelGroup
+        direction="horizontal"
+        autoSaveId="engram:app-layout"
+        className="flex-1"
+      >
+        <ResizablePanel
+          id="sidebar"
+          order={1}
+          ref={leftRef}
+          defaultSize={18}
+          minSize={12}
+          maxSize={40}
+          collapsible
+          collapsedSize={0}
+          onCollapse={() => setLeftCollapsed(true)}
+          onExpand={() => setLeftCollapsed(false)}
+          className="border-r border-border bg-card"
+        >
+          <div className="flex h-full flex-col">
+            <div className="flex shrink-0 items-center justify-end border-b border-border px-1 py-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={toggleLeft}
+                aria-label="Collapse sidebar"
+                title="Collapse sidebar"
+              >
+                <PanelLeftClose />
+              </Button>
+            </div>
+            <ScrollArea className="flex-1">
+              <VaultSwitcher />
+              <FolderTree />
+            </ScrollArea>
+          </div>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel id="main" order={2} defaultSize={60} minSize={30}>
+          <main className="relative h-full overflow-hidden bg-muted/40 p-6 text-foreground">
+            {leftCollapsed && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={toggleLeft}
+                aria-label="Expand sidebar"
+                title="Expand sidebar"
+                className="absolute left-2 top-2 z-10 bg-card/80 backdrop-blur"
+              >
+                <PanelLeftOpen />
+              </Button>
+            )}
+            {hasRight && rightCollapsed && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={toggleRight}
+                aria-label="Expand outline"
+                title="Expand outline"
+                className="absolute right-2 top-2 z-10 bg-card/80 backdrop-blur"
+              >
+                <PanelRightOpen />
+              </Button>
+            )}
+            <Outlet />
+          </main>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel
+          id="right-sidebar"
+          order={3}
+          ref={rightRef}
+          defaultSize={22}
+          minSize={12}
+          maxSize={40}
+          collapsible
+          collapsedSize={0}
+          onCollapse={() => setRightCollapsed(true)}
+          onExpand={() => setRightCollapsed(false)}
+          className="border-l border-border bg-card"
+        >
+          <div className="flex h-full flex-col">
+            <div className="flex shrink-0 items-center justify-start border-b border-border px-1 py-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={toggleRight}
+                aria-label="Collapse outline"
+                title="Collapse outline"
+              >
+                <PanelRightClose />
+              </Button>
+            </div>
+            <ScrollArea className="flex-1">{rightContent}</ScrollArea>
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </section>
+  )
+}
+```
+
+After this refactor, `AppLayoutInner` keeps only:
+- `useChannel()` call
+- `useBillingStatus()` call
+- `useMediaQuery` call
+- The new branched return
+
+`useChannel` belongs at the outer level so it runs in both layouts. `useRightSidebar` moves into `DesktopLayout` (which uses `rightContent`, `rightCollapsed`, `setRightCollapsed`). `MobileLayout` calls `useRightSidebar` internally already.
+
+- [ ] **Step 2: TypeScript check**
+
+Run: `cd frontend && bun run build`
+Expected: PASS.
+
+- [ ] **Step 3: Manual smoke test**
+
+Run dev server (or rely on the running `make dev`); resize Chrome to ~390px wide. The header should swap to compact form with a hamburger; resize handles should disappear. Resize back to >768px; old layout returns.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/layout/app-layout.tsx
+git commit -m "feat(frontend): branch AppLayout on viewport width"
+```
+
+---
+
+## Task 5: Responsive prose padding + typography in `note-view.tsx`
+
+**Files:**
+- Modify: `frontend/src/viewer/note-view.tsx`
+
+- [ ] **Step 1: Edit `note-view.tsx`**
+
+Two replacements in the existing file:
+
+Change the `<article>` className:
+
+```tsx
+<article className="w-full px-8 py-8 lg:px-12 lg:py-10">
+```
+
+to:
+
+```tsx
+<article className="w-full px-4 py-6 sm:px-8 sm:py-8 lg:px-12 lg:py-10">
+```
+
+Change the `<section>` className:
+
+```tsx
+<section className="prose prose-neutral max-w-none dark:prose-invert lg:prose-lg">
+```
+
+to:
+
+```tsx
+<section className="prose prose-neutral max-w-none dark:prose-invert lg:prose-lg">
+```
+
+(unchanged — `prose` already responsive enough; `lg:prose-lg` already gates to desktop). The goal here is only padding.
+
+- [ ] **Step 2: TypeScript check**
+
+Run: `cd frontend && bun run build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/viewer/note-view.tsx
+git commit -m "feat(frontend): tighten note padding on small viewports"
+```
+
+---
+
+## Task 6: 16px CodeMirror font (block iOS focus-zoom)
+
+**Files:**
+- Modify: `frontend/src/viewer/note-editor.tsx`
+
+- [ ] **Step 1: Edit `note-editor.tsx` — add a theme extension**
+
+Replace the body of the component with:
+
+```tsx
+import { markdown } from '@codemirror/lang-markdown'
+import { EditorView } from '@codemirror/view'
+import CodeMirror from '@uiw/react-codemirror'
+import { useTheme } from '../theme/theme-provider'
+
+interface NoteEditorProps {
+  value: string
+  onChange: (next: string) => void
+}
+
+// 16px on .cm-content prevents iOS Safari from auto-zooming when the
+// soft keyboard opens. lineWrapping stays on.
+const mobileSafeTheme = EditorView.theme({
+  '.cm-content': { fontSize: '16px' },
+  '.cm-scroller': { fontFamily: 'inherit' },
+})
+
+export default function NoteEditor({ value, onChange }: NoteEditorProps) {
+  const { resolved } = useTheme()
+
+  return (
+    <CodeMirror
+      value={value}
+      onChange={onChange}
+      theme={resolved}
+      extensions={[markdown(), EditorView.lineWrapping, mobileSafeTheme]}
+      basicSetup={{
+        lineNumbers: false,
+        foldGutter: false,
+        highlightActiveLine: false,
+        highlightActiveLineGutter: false,
+        autocompletion: false,
+      }}
+      className="min-h-[70vh] rounded-md border border-border bg-muted/30"
+    />
+  )
+}
+```
+
+Note: `text-sm` removed from the className because the theme now sets size explicitly. The desktop look stays close (CodeMirror inherits 16px which matches `prose` body anyway).
+
+- [ ] **Step 2: TypeScript check**
+
+Run: `cd frontend && bun run build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/viewer/note-editor.tsx
+git commit -m "feat(frontend): force 16px CodeMirror font to block iOS focus-zoom"
+```
+
+---
+
+## Task 7: `scroll-padding-top` so ToC anchors land below sticky header
+
+**Files:**
+- Modify: `frontend/src/main.css`
+
+- [ ] **Step 1: Locate the top of `main.css` and add a rule**
+
+Add this rule near the existing `html`/`:root` block (after the shadcn token blocks; if uncertain, append to the bottom of the file):
+
+```css
+html {
+  scroll-padding-top: 4rem;
+}
+```
+
+- [ ] **Step 2: Sanity check**
+
+Run: `cd frontend && bun run build`
+Expected: PASS. No CSS warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/main.css
+git commit -m "feat(frontend): scroll-padding-top for ToC anchors under sticky header"
+```
+
+---
+
+## Task 8: Playwright mobile-viewport smoke test
+
+**Files:**
+- Create: `frontend/e2e/mobile.spec.ts`
+
+- [ ] **Step 1: Check existing Playwright config + test helpers**
+
+Run: `cat frontend/playwright.config.ts | head -40` and `cat frontend/e2e/dark-mode.spec.ts | head -30`
+Expected: confirm the existing `signIn` helper pattern (registerUser + signIn) used in `dark-mode.spec.ts`. The new spec reuses the same idiom.
+
+- [ ] **Step 2: Write the spec**
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const TEST_PASSWORD = 'E2eTestPass!99'
+
+async function registerUser(baseURL: string, email: string) {
+  const res = await fetch(`${baseURL}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: TEST_PASSWORD }),
+  })
+  if (res.status === 422) return
+  if (!res.ok) throw new Error(`Register failed: ${res.status} ${await res.text()}`)
+}
+
+function testEmail(label: string) {
+  return `e2e-mobile-${Date.now()}-${label}@test.com`
+}
+
+async function signIn(page: import('@playwright/test').Page, email: string) {
+  await page.goto('/sign-in/')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password', { exact: true }).fill(TEST_PASSWORD)
+  await page.getByRole('button', { name: /sign in/i }).click()
+  await expect(page).toHaveURL('/')
+}
+
+test.describe('Mobile layout', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('header shows hamburger; tapping opens files drawer', async ({ page, baseURL }) => {
+    const email = testEmail('files')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    const filesTrigger = page.getByRole('button', { name: 'Open files' })
+    await expect(filesTrigger).toBeVisible()
+    await filesTrigger.click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Files' })).toBeVisible()
+  })
+
+  test('desktop resize handles are not rendered on mobile', async ({ page, baseURL }) => {
+    const email = testEmail('handles')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    // The desktop layout renders resize handles with role="separator". Mobile
+    // layout renders zero.
+    await expect(page.locator('[data-panel-resize-handle-id]')).toHaveCount(0)
+  })
+
+  test('drawers start closed on every navigation', async ({ page, baseURL }) => {
+    const email = testEmail('reset')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    await page.getByRole('button', { name: 'Open files' }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await page.goto('/settings')
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+  })
+})
+```
+
+- [ ] **Step 3: Run the spec against the local stack**
+
+Run: `cd frontend && bun run test:e2e:local -- mobile.spec.ts`
+Expected: 3 tests pass.
+
+If `mobile.spec.ts` cannot be passed positionally for the project, run `bun run test:e2e:local -- --grep "Mobile layout"` instead.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/e2e/mobile.spec.ts
+git commit -m "test(e2e): mobile viewport smoke for drawer layout"
+```
+
+---
+
+## Task 9: Version bump (pre-push hook requirement)
+
+**Files:**
+- Modify: `mix.exs`
+
+- [ ] **Step 1: Bump patch version**
+
+Edit `mix.exs` line 6 — change `version: "0.5.75"` to `version: "0.5.76"`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add mix.exs
+git commit -m "chore(release): bump to 0.5.76"
+```
+
+---
+
+## Task 10: Push and open PR
+
+- [ ] **Step 1: Push branch**
+
+Run: `git push -u origin feat/mobile-document-view`
+Expected: success; pre-push hook passes (lint, compile, credo, sobelow).
+
+- [ ] **Step 2: Open PR**
+
+Run:
+
+```bash
+gh pr create --title "feat(ui): mobile-friendly document view" --body "$(cat <<'EOF'
+## Summary
+- Below `md` (768px): replace three-column resizable layout with single-column document view + left/right Sheet drawers.
+- Reuses `RightSidebarContext` for ToC injection — no duplicate route content.
+- Tightens prose padding (`px-4` mobile / `px-12` desktop), forces 16px CodeMirror font to block iOS focus-zoom, adds `scroll-padding-top` for ToC anchors under the sticky header.
+
+## Test plan
+- [ ] Resize Chrome to 390px: hamburger + ToC trigger appear, resize handles disappear
+- [ ] Tap hamburger: files drawer slides in; tap a file: drawer closes, note loads
+- [ ] Tap ToC trigger on a note in preview mode: ToC drawer slides in; tap entry: drawer closes, scrolled to heading below header
+- [ ] Switch to Edit on mobile: CodeMirror renders, no iOS auto-zoom on focus
+- [ ] Reload: both drawers start closed
+- [ ] Above 768px: existing desktop layout unchanged
+- [ ] `frontend/e2e/mobile.spec.ts` passes in CI
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI**
+
+Watch the CI run; if green, request review or self-merge per project policy. Deploy auto-runs on merge to main (per `deploy-fastraid` GitHub Actions job).
+
+---
+
+## Self-review
+
+Spec coverage:
+
+| Spec section | Plan task |
+|--------------|-----------|
+| `use-media-query.ts` hook | Task 1 |
+| `components/ui/sheet.tsx` | Task 2 |
+| `mobile-layout.tsx` | Task 3 |
+| `app-layout.tsx` branch | Task 4 |
+| `note-view.tsx` responsive padding | Task 5 |
+| `note-editor.tsx` 16px font | Task 6 |
+| `main.css` scroll-padding-top | Task 7 |
+| Playwright mobile spec | Task 8 |
+| 44px touch targets | Task 3 (`h-11 w-11` on Sheet triggers) |
+| `h-dvh` for iOS viewport | Task 3 (root `section` uses `h-dvh`) |
+| Drawer starts closed each visit | Task 3 (component-local `useState`, no persistence) + Task 8 spec |
+| ToC trigger hidden when no `rightContent` | Task 3 (`{rightContent && <Sheet…>}`) |
+
+Type consistency: `useMediaQuery` returns `boolean` everywhere; `MobileLayout` is the default export consumed by `app-layout.tsx`; the existing `useRightSidebar()` shape is unchanged.
+
+No placeholders; every code block is complete; every command is runnable.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-12-mobile-document-view.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session, batch with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-12-mobile-document-view-design.md
+++ b/docs/superpowers/specs/2026-05-12-mobile-document-view-design.md
@@ -1,0 +1,105 @@
+# Mobile-friendly document view — design
+
+## Context
+
+Desktop document view is a three-column `ResizablePanelGroup`: file picker (left), document body + Edit/Preview tabs (center), "On this page" ToC (right). Below ~768px the three columns become unusable: panels can't shrink below their min sizes, the resize handles are not touch-friendly, and the prose padding (`px-12`) plus `prose-lg` typography leaves no room for content.
+
+Goal: deliver an equally-capable read + edit experience below `md` (`768px`), reusing shadcn primitives, without forking the desktop flow.
+
+User intent confirmed during brainstorming: **equal read + edit** on mobile. ToC and file picker reachable in one tap. Editor must be usable on a touch keyboard.
+
+## Architecture
+
+A single media-query branch in `app-layout.tsx` swaps the panel layout for a drawer layout below `md`. Both modes share:
+
+- The same `<Outlet/>` (document/editor) — no duplicated route content
+- The same `RightSidebarContext` (ToC injection from `note-page.tsx` is unchanged)
+- The same auth, theme, vault state
+
+Above `md`: current `ResizablePanelGroup` with `autoSaveId="engram:app-layout"`.
+
+Below `md`:
+
+```
+┌─────────────────────────────────┐
+│ ☰   <title · vault>      ⋮  ⊟ │  sticky header, h-12
+├─────────────────────────────────┤
+│  [Preview]      [Edit]          │  shadcn Tabs, full-width
+├─────────────────────────────────┤
+│                                 │
+│   document or CodeMirror        │
+│                                 │
+│   prose (not prose-lg)          │
+│   px-4 (not px-12)              │
+│                                 │
+└─────────────────────────────────┘
+```
+
+- ☰ left trigger opens a `Sheet side="left"` carrying the existing `VaultSwitcher` + file tree
+- ⊟ right trigger opens a `Sheet side="right"` carrying `<NoteToc>` (only rendered when `rightContent != null`; hidden when no ToC is available, e.g. on Settings)
+- Both drawers **start closed on every navigation** — open state is component-local, not persisted (matches user direction)
+- Floating "expand" buttons from desktop are hidden below `md`; the drawer triggers replace them
+
+## Components
+
+| Component | Status | Purpose |
+|-----------|--------|---------|
+| `layout/app-layout.tsx` | modify | Branch on `useMediaQuery('(min-width: 768px)')`; render desktop panels or `MobileLayout` |
+| `layout/mobile-layout.tsx` | **new** | Sticky header (hamburger + title + user menu + ToC trigger), `<Outlet/>`, two `Sheet`s |
+| `components/ui/sheet.tsx` | **new** | shadcn primitive (`bunx --bun shadcn@latest add sheet`) |
+| `hooks/use-media-query.ts` | **new** | Tiny `window.matchMedia` hook (~20 LOC) with SSR-safe default and listener cleanup |
+| `viewer/note-view.tsx` | modify | Responsive padding (`px-4 sm:px-8 lg:px-12`) and typography (`prose lg:prose-lg`); `scroll-margin-top` already covered by CSS |
+| `viewer/note-editor.tsx` | modify | CodeMirror theme extension forcing `font-size: 16px` on `.cm-content` to prevent iOS focus-zoom; ensure `EditorView.lineWrapping` stays on (already is) |
+| `main.css` | modify | `html { scroll-padding-top: 4rem }` for ToC anchor jumps under sticky header |
+| `layout/right-sidebar-context.tsx` | no change | Already exposes `content` and `setContent`; mobile reads `content` to decide whether to render the right drawer trigger |
+
+## Data flow
+
+Unchanged from desktop. `note-page.tsx` continues to `setRightContent(<NoteToc/>)` when in preview mode. The mobile `Sheet` renders that same node inside its `SheetContent`.
+
+The desktop right panel currently collapses/expands via `rightRef.current?.collapse()` based on `rightContent`. On mobile there is no panel — the trigger button is conditionally rendered (`{rightContent && <SheetTrigger.../>}`) and the `Sheet`'s `open` state lives in `MobileLayout`'s local `useState`.
+
+## Touch + viewport fixes
+
+| Concern | Fix |
+|---------|-----|
+| iOS auto-zoom on editor focus | CodeMirror theme extension: `'.cm-content': { fontSize: '16px' }` |
+| 100vh ≠ visible viewport on iOS | Replace `h-screen` with `h-dvh` on app shell root |
+| ToC anchor under sticky header | `html { scroll-padding-top: 4rem }` |
+| Touch target size | shadcn default `size="icon"` button is 36px. Header icon buttons get `h-11 w-11` (44px) class override on mobile |
+| Drawer dismissal | Radix Dialog handles backdrop tap + Esc. Swipe-to-dismiss deferred (would need `vaul` dep) |
+| Soft keyboard hides caret | CodeMirror handles via `scrollIntoView` on selection change by default — verify in testing; if broken, add `EditorView.scrollMargins` |
+
+## Breakpoint choice
+
+`md` (768px) is the Tailwind default and the natural break between phone and tablet. Tablets in portrait (~768–1024px) get the desktop panel layout — usable because tablets have room for three narrow columns and a stylus/touchpad. iPad Mini in portrait (744px) lands on mobile mode; acceptable given thumb-reach concerns.
+
+## Out of scope
+
+- Swipe-between-notes gesture
+- Bottom-tab navigation pattern (rejected during brainstorm: steals vertical space, breaks parity with desktop two-sidebar mental model)
+- Persisting drawer state across sessions (rejected by user: "restart on close")
+- PWA install prompt + offline service worker (separate spec)
+- `vaul` swipe-to-dismiss
+
+## Testing
+
+- Unit: `use-media-query.ts` — SSR default, listener attach/detach, change events
+- Playwright: extend `frontend/e2e/` with a mobile viewport spec (`page.setViewportSize({ width: 390, height: 844 })`) that:
+  1. Opens a note, asserts ToC drawer trigger is visible
+  2. Taps trigger, asserts ToC drawer opens
+  3. Taps a ToC entry, asserts drawer closes and page scrolls
+  4. Taps hamburger, asserts file drawer opens
+  5. Switches to Edit tab, asserts CodeMirror renders and is focusable
+- Manual: iOS Safari + Android Chrome smoke test of the editor (font-size zoom, caret visibility, keyboard overlap)
+
+## Verification checklist
+
+1. `cd frontend && bun install` then `bun run dev`
+2. Resize browser below 768px: layout flips to drawer mode; resize handles disappear; padding tightens
+3. Open a note: ToC trigger appears in header; tap reveals drawer with same content as desktop right panel
+4. Navigate to Settings: ToC trigger hidden (no `rightContent`)
+5. Tap Edit: CodeMirror loads, font is 16px+ on iOS, no page zoom
+6. Reload page on mobile: drawers start closed regardless of last state
+7. `bun run build`: clean TypeScript, no new warnings
+8. Playwright mobile spec passes locally and in CI

--- a/frontend/e2e/mobile.spec.ts
+++ b/frontend/e2e/mobile.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+
+const TEST_PASSWORD = 'E2eTestPass!99'
+
+async function registerUser(baseURL: string, email: string) {
+  const res = await fetch(`${baseURL}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: TEST_PASSWORD }),
+  })
+  if (res.status === 422) return
+  if (!res.ok) throw new Error(`Register failed: ${res.status} ${await res.text()}`)
+}
+
+function testEmail(label: string) {
+  return `e2e-mobile-${Date.now()}-${label}@test.com`
+}
+
+async function signIn(page: import('@playwright/test').Page, email: string) {
+  await page.goto('/sign-in/')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password', { exact: true }).fill(TEST_PASSWORD)
+  await page.getByRole('button', { name: /sign in/i }).click()
+  await expect(page).toHaveURL('/')
+}
+
+test.describe('Mobile layout', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('header shows hamburger; tapping opens files drawer', async ({ page, baseURL }) => {
+    const email = testEmail('files')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    const filesTrigger = page.getByRole('button', { name: 'Open files' })
+    await expect(filesTrigger).toBeVisible()
+    await filesTrigger.click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Files' })).toBeVisible()
+  })
+
+  test('desktop resize handles are not rendered on mobile', async ({ page, baseURL }) => {
+    const email = testEmail('handles')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    await expect(page.locator('[data-panel-resize-handle-id]')).toHaveCount(0)
+  })
+
+  test('drawers start closed on every navigation', async ({ page, baseURL }) => {
+    const email = testEmail('reset')
+    await registerUser(baseURL!, email)
+    await signIn(page, email)
+
+    await page.getByRole('button', { name: 'Open files' }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await page.goto('/settings')
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+  })
+})

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
   projects: [
     {
       name: 'local',
-      testMatch: /\/(local-auth|dark-mode)\.spec\.ts$/,
+      testMatch: /\/(local-auth|dark-mode|mobile)\.spec\.ts$/,
       use: {
         baseURL: `http://localhost:${LOCAL_VITE_PORT}`,
       },

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -22,6 +22,7 @@ export interface NoteSummary {
   tags: string[]
   version: number
   mtime: string
+  created_at: string
   updated_at: string
 }
 

--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -16,7 +16,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 [&>div]:!block"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -14,6 +14,11 @@ function ScrollArea({
       className={cn("relative", className)}
       {...props}
     >
+      {/* [&>div]:!block overrides Radix's default `display: table; min-width: 100%`
+          on the viewport's inner wrapper so flex children with `truncate` truncate
+          instead of pushing the wrapper wider than its container. If a future
+          ScrollArea consumer genuinely needs horizontal scrolling, do it locally
+          rather than reverting this. */}
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 [&>div]:!block"

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,0 +1,145 @@
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close data-slot="sheet-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-3 right-3"
+              size="icon-sm"
+            >
+              <XIcon
+              />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn(
+        "font-heading text-base font-medium text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/frontend/src/hooks/use-media-query.ts
+++ b/frontend/src/hooks/use-media-query.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * SSR-safe matchMedia hook. Returns `false` on the server (no matchMedia),
+ * then re-renders with the real value on mount. Subscribes to changes via
+ * `addEventListener('change')` and cleans up on unmount.
+ */
+export function useMediaQuery(query: string): boolean {
+  const getMatch = () => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false
+    }
+    return window.matchMedia(query).matches
+  }
+
+  const [matches, setMatches] = useState<boolean>(getMatch)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mql = window.matchMedia(query)
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches)
+    // Sync once on mount in case the initial render mismatched (SSR / hydration).
+    setMatches(mql.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [query])
+
+  return matches
+}

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -14,6 +14,7 @@ import {
   ResizablePanelGroup,
 } from '@/components/ui/resizable'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { useMediaQuery } from '@/hooks/use-media-query'
 import { config } from '../config'
 
 const isClerk = config.authProvider === 'clerk'
@@ -25,6 +26,7 @@ import { useBillingStatus } from '../api/queries'
 import { useChannel } from '../api/use-channel'
 import ThemeToggle from '../theme/theme-toggle'
 import FolderTree from '../viewer/folder-tree'
+import MobileLayout from './mobile-layout'
 import { RightSidebarProvider, useRightSidebar } from './right-sidebar-context'
 import VaultSwitcher from './vault-switcher'
 
@@ -43,15 +45,12 @@ function HeaderLink({ to, label }: { to: string; label: string }) {
   )
 }
 
-function AppLayoutInner() {
+function DesktopLayout() {
   const leftRef = useRef<ImperativePanelHandle>(null)
   const rightRef = useRef<ImperativePanelHandle>(null)
   const [leftCollapsed, setLeftCollapsed] = useState(false)
   const { content: rightContent, collapsed: rightCollapsed, setCollapsed: setRightCollapsed } =
     useRightSidebar()
-
-  useChannel()
-  const { data: billing } = useBillingStatus()
 
   const toggleLeft = () => {
     const p = leftRef.current
@@ -80,125 +79,135 @@ function AppLayoutInner() {
   const hasRight = rightContent != null
 
   return (
+    <section className="flex h-screen flex-col bg-background text-foreground">
+      <header className="flex items-center justify-between border-b border-border bg-card px-4 py-2">
+        <Link to="/" className="text-lg font-semibold text-foreground hover:text-foreground/80">
+          Engram
+        </Link>
+        <nav className="flex items-center gap-3" aria-label="Main navigation">
+          <HeaderLink to="/search" label="Search" />
+          <HeaderLink to="/billing" label="Billing" />
+          <HeaderLink to="/settings" label="Settings" />
+          <ThemeToggle />
+          <Suspense fallback={null}>
+            {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
+          </Suspense>
+        </nav>
+      </header>
+
+      <ResizablePanelGroup
+        direction="horizontal"
+        autoSaveId="engram:app-layout"
+        className="flex-1"
+      >
+        <ResizablePanel
+          id="sidebar"
+          order={1}
+          ref={leftRef}
+          defaultSize={18}
+          minSize={12}
+          maxSize={40}
+          collapsible
+          collapsedSize={0}
+          onCollapse={() => setLeftCollapsed(true)}
+          onExpand={() => setLeftCollapsed(false)}
+          className="border-r border-border bg-card"
+        >
+          <div className="flex h-full flex-col">
+            <div className="flex shrink-0 items-center justify-end border-b border-border px-1 py-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={toggleLeft}
+                aria-label="Collapse sidebar"
+                title="Collapse sidebar"
+              >
+                <PanelLeftClose />
+              </Button>
+            </div>
+            <ScrollArea className="flex-1">
+              <VaultSwitcher />
+              <FolderTree />
+            </ScrollArea>
+          </div>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel id="main" order={2} defaultSize={60} minSize={30}>
+          <main className="relative h-full overflow-hidden bg-muted/40 p-6 text-foreground">
+            {leftCollapsed && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={toggleLeft}
+                aria-label="Expand sidebar"
+                title="Expand sidebar"
+                className="absolute left-2 top-2 z-10 bg-card/80 backdrop-blur"
+              >
+                <PanelLeftOpen />
+              </Button>
+            )}
+            {hasRight && rightCollapsed && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={toggleRight}
+                aria-label="Expand outline"
+                title="Expand outline"
+                className="absolute right-2 top-2 z-10 bg-card/80 backdrop-blur"
+              >
+                <PanelRightOpen />
+              </Button>
+            )}
+            <Outlet />
+          </main>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel
+          id="right-sidebar"
+          order={3}
+          ref={rightRef}
+          defaultSize={22}
+          minSize={12}
+          maxSize={40}
+          collapsible
+          collapsedSize={0}
+          onCollapse={() => setRightCollapsed(true)}
+          onExpand={() => setRightCollapsed(false)}
+          className="border-l border-border bg-card"
+        >
+          <div className="flex h-full flex-col">
+            <div className="flex shrink-0 items-center justify-start border-b border-border px-1 py-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={toggleRight}
+                aria-label="Collapse outline"
+                title="Collapse outline"
+              >
+                <PanelRightClose />
+              </Button>
+            </div>
+            <ScrollArea className="flex-1">{rightContent}</ScrollArea>
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </section>
+  )
+}
+
+function AppLayoutInner() {
+  useChannel()
+  const { data: billing } = useBillingStatus()
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+
+  return (
     <>
       {billing?.subscription?.status === 'trialing' && billing.trial_days_remaining > 0 && billing.trial_days_remaining <= 3 && (
         <aside className="bg-amber-50 px-4 py-2 text-center text-sm text-amber-900 dark:bg-amber-950/40 dark:text-amber-100" role="alert">
           {billing.trial_days_remaining} days left in your trial.
         </aside>
       )}
-      <section className="flex h-screen flex-col bg-background text-foreground">
-        <header className="flex items-center justify-between border-b border-border bg-card px-4 py-2">
-          <Link to="/" className="text-lg font-semibold text-foreground hover:text-foreground/80">
-            Engram
-          </Link>
-          <nav className="flex items-center gap-3" aria-label="Main navigation">
-            <HeaderLink to="/search" label="Search" />
-            <HeaderLink to="/billing" label="Billing" />
-            <HeaderLink to="/settings" label="Settings" />
-            <ThemeToggle />
-            <Suspense fallback={null}>
-              {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
-            </Suspense>
-          </nav>
-        </header>
-
-        <ResizablePanelGroup
-          direction="horizontal"
-          autoSaveId="engram:app-layout"
-          className="flex-1"
-        >
-          <ResizablePanel
-            id="sidebar"
-            order={1}
-            ref={leftRef}
-            defaultSize={18}
-            minSize={12}
-            maxSize={40}
-            collapsible
-            collapsedSize={0}
-            onCollapse={() => setLeftCollapsed(true)}
-            onExpand={() => setLeftCollapsed(false)}
-            className="border-r border-border bg-card"
-          >
-            <div className="flex h-full flex-col">
-              <div className="flex shrink-0 items-center justify-end border-b border-border px-1 py-1">
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={toggleLeft}
-                  aria-label="Collapse sidebar"
-                  title="Collapse sidebar"
-                >
-                  <PanelLeftClose />
-                </Button>
-              </div>
-              <ScrollArea className="flex-1">
-                <VaultSwitcher />
-                <FolderTree />
-              </ScrollArea>
-            </div>
-          </ResizablePanel>
-          <ResizableHandle withHandle />
-          <ResizablePanel id="main" order={2} defaultSize={60} minSize={30}>
-            <main className="relative h-full overflow-hidden bg-muted/40 p-6 text-foreground">
-              {leftCollapsed && (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={toggleLeft}
-                  aria-label="Expand sidebar"
-                  title="Expand sidebar"
-                  className="absolute left-2 top-2 z-10 bg-card/80 backdrop-blur"
-                >
-                  <PanelLeftOpen />
-                </Button>
-              )}
-              {hasRight && rightCollapsed && (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={toggleRight}
-                  aria-label="Expand outline"
-                  title="Expand outline"
-                  className="absolute right-2 top-2 z-10 bg-card/80 backdrop-blur"
-                >
-                  <PanelRightOpen />
-                </Button>
-              )}
-              <Outlet />
-            </main>
-          </ResizablePanel>
-          <ResizableHandle withHandle />
-          <ResizablePanel
-            id="right-sidebar"
-            order={3}
-            ref={rightRef}
-            defaultSize={22}
-            minSize={12}
-            maxSize={40}
-            collapsible
-            collapsedSize={0}
-            onCollapse={() => setRightCollapsed(true)}
-            onExpand={() => setRightCollapsed(false)}
-            className="border-l border-border bg-card"
-          >
-            <div className="flex h-full flex-col">
-              <div className="flex shrink-0 items-center justify-start border-b border-border px-1 py-1">
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={toggleRight}
-                  aria-label="Collapse outline"
-                  title="Collapse outline"
-                >
-                  <PanelRightClose />
-                </Button>
-              </div>
-              <ScrollArea className="flex-1">{rightContent}</ScrollArea>
-            </div>
-          </ResizablePanel>
-        </ResizablePanelGroup>
-      </section>
+      {isDesktop ? <DesktopLayout /> : <MobileLayout />}
     </>
   )
 }

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -26,6 +26,8 @@ import { useBillingStatus } from '../api/queries'
 import { useChannel } from '../api/use-channel'
 import ThemeToggle from '../theme/theme-toggle'
 import FolderTree from '../viewer/folder-tree'
+import FolderActions from './folder-actions'
+import { FolderTreeProvider } from './folder-tree-context'
 import MobileLayout from './mobile-layout'
 import { RightSidebarProvider, useRightSidebar } from './right-sidebar-context'
 import VaultSwitcher from './vault-switcher'
@@ -113,23 +115,26 @@ function DesktopLayout() {
           onExpand={() => setLeftCollapsed(false)}
           className="border-r border-border bg-card"
         >
-          <div className="flex h-full flex-col">
-            <div className="flex shrink-0 items-center justify-end border-b border-border px-1 py-1">
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={toggleLeft}
-                aria-label="Collapse sidebar"
-                title="Collapse sidebar"
-              >
-                <PanelLeftClose />
-              </Button>
-            </div>
-            <ScrollArea className="flex-1">
+          <FolderTreeProvider>
+            <div className="flex h-full flex-col">
+              <div className="flex shrink-0 items-center justify-end border-b border-border px-1 py-1">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={toggleLeft}
+                  aria-label="Collapse sidebar"
+                  title="Collapse sidebar"
+                >
+                  <PanelLeftClose />
+                </Button>
+              </div>
+              <ScrollArea className="flex-1">
+                <FolderTree />
+              </ScrollArea>
+              <FolderActions />
               <VaultSwitcher />
-              <FolderTree />
-            </ScrollArea>
-          </div>
+            </div>
+          </FolderTreeProvider>
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel id="main" order={2} defaultSize={60} minSize={30}>

--- a/frontend/src/layout/folder-actions.tsx
+++ b/frontend/src/layout/folder-actions.tsx
@@ -1,0 +1,95 @@
+import { ArrowUpDown, FilePlus, FolderPlus, FoldVertical } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { type SortKey, useFolderTreeState } from './folder-tree-context'
+
+const ICON = 'size-5'
+const BUTTON = 'size-10'
+
+type SortSection = {
+  label: string
+  options: ReadonlyArray<{ value: SortKey; label: string }>
+}
+
+const SORT_SECTIONS: ReadonlyArray<SortSection> = [
+  {
+    label: 'File name',
+    options: [
+      { value: 'name-asc', label: 'A to Z' },
+      { value: 'name-desc', label: 'Z to A' },
+    ],
+  },
+  {
+    label: 'Created time',
+    options: [
+      { value: 'created-desc', label: 'Newest first' },
+      { value: 'created-asc', label: 'Oldest first' },
+    ],
+  },
+  {
+    label: 'Modified time',
+    options: [
+      { value: 'modified-desc', label: 'Newest first' },
+      { value: 'modified-asc', label: 'Oldest first' },
+    ],
+  },
+]
+
+export default function FolderActions() {
+  const { collapseAll, sort, setSort } = useFolderTreeState()
+  return (
+    <section
+      aria-label="File actions"
+      className="flex items-center justify-around border-t border-border bg-card px-4 py-0.5"
+    >
+      <Button variant="ghost" size="icon" aria-label="New note" title="New note" disabled className={BUTTON}>
+        <FilePlus className={ICON} />
+      </Button>
+      <Button variant="ghost" size="icon" aria-label="New folder" title="New folder" disabled className={BUTTON}>
+        <FolderPlus className={ICON} />
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" aria-label="Sort" title="Sort" className={BUTTON}>
+            <ArrowUpDown className={ICON} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-[min(95vw,20rem)]">
+          <DropdownMenuRadioGroup value={sort} onValueChange={(v) => setSort(v as SortKey)}>
+            {SORT_SECTIONS.map((section, i) => (
+              <section key={section.label}>
+                {i > 0 && <DropdownMenuSeparator />}
+                <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {section.label}
+                </DropdownMenuLabel>
+                {section.options.map((opt) => (
+                  <DropdownMenuRadioItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </section>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Collapse all folders"
+        title="Collapse all folders"
+        onClick={collapseAll}
+        className={BUTTON}
+      >
+        <FoldVertical className={ICON} />
+      </Button>
+    </section>
+  )
+}

--- a/frontend/src/layout/folder-actions.tsx
+++ b/frontend/src/layout/folder-actions.tsx
@@ -1,4 +1,5 @@
 import { ArrowUpDown, FilePlus, FolderPlus, FoldVertical } from 'lucide-react'
+import { Fragment } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -65,7 +66,10 @@ export default function FolderActions() {
         <DropdownMenuContent align="end" className="w-[min(95vw,20rem)]">
           <DropdownMenuRadioGroup value={sort} onValueChange={(v) => setSort(v as SortKey)}>
             {SORT_SECTIONS.map((section, i) => (
-              <section key={section.label}>
+              // Fragment (not <section>) so Radix's roving keyboard nav across
+              // DropdownMenuRadioItem siblings keeps working — wrapping them in
+              // a real DOM element breaks the radio group.
+              <Fragment key={section.label}>
                 {i > 0 && <DropdownMenuSeparator />}
                 <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
                   {section.label}
@@ -75,7 +79,7 @@ export default function FolderActions() {
                     {opt.label}
                   </DropdownMenuRadioItem>
                 ))}
-              </section>
+              </Fragment>
             ))}
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>

--- a/frontend/src/layout/folder-tree-context.tsx
+++ b/frontend/src/layout/folder-tree-context.tsx
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+
+export type SortKey =
+  | 'name-asc'
+  | 'name-desc'
+  | 'created-desc'
+  | 'created-asc'
+  | 'modified-desc'
+  | 'modified-asc'
+
+type FolderTreeContextValue = {
+  isOpen: (path: string) => boolean
+  toggle: (path: string) => void
+  collapseAll: () => void
+  sort: SortKey
+  setSort: (next: SortKey) => void
+}
+
+const FolderTreeContext = createContext<FolderTreeContextValue | null>(null)
+
+export function FolderTreeProvider({ children }: { children: ReactNode }) {
+  const [openSet, setOpenSet] = useState<Set<string>>(() => new Set())
+  const [sort, setSort] = useState<SortKey>('name-asc')
+
+  const isOpen = useCallback((path: string) => openSet.has(path), [openSet])
+  const toggle = useCallback((path: string) => {
+    setOpenSet((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }, [])
+  const collapseAll = useCallback(() => setOpenSet(new Set()), [])
+
+  const value = useMemo(
+    () => ({ isOpen, toggle, collapseAll, sort, setSort }),
+    [isOpen, toggle, collapseAll, sort],
+  )
+  return <FolderTreeContext.Provider value={value}>{children}</FolderTreeContext.Provider>
+}
+
+export function useFolderTreeState(): FolderTreeContextValue {
+  const v = useContext(FolderTreeContext)
+  if (!v) throw new Error('useFolderTreeState must be used inside FolderTreeProvider')
+  return v
+}

--- a/frontend/src/layout/mobile-layout.tsx
+++ b/frontend/src/layout/mobile-layout.tsx
@@ -1,0 +1,105 @@
+import { Menu, PanelRightOpen } from 'lucide-react'
+import { lazy, Suspense, useState } from 'react'
+import { Link, NavLink, Outlet } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
+import { config } from '../config'
+import ThemeToggle from '../theme/theme-toggle'
+import FolderTree from '../viewer/folder-tree'
+import { useRightSidebar } from './right-sidebar-context'
+import VaultSwitcher from './vault-switcher'
+
+const isClerk = config.authProvider === 'clerk'
+const ClerkUserButton = isClerk
+  ? lazy(() => import('@clerk/clerk-react').then((mod) => ({ default: mod.UserButton })))
+  : null
+const LocalUserMenu = lazy(() => import('../auth/local-user-menu'))
+
+function HeaderLink({ to, label }: { to: string; label: string }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `text-sm transition hover:text-foreground ${
+          isActive ? 'font-medium text-foreground' : 'text-muted-foreground'
+        }`
+      }
+    >
+      {label}
+    </NavLink>
+  )
+}
+
+export default function MobileLayout() {
+  const { content: rightContent } = useRightSidebar()
+  const [leftOpen, setLeftOpen] = useState(false)
+  const [rightOpen, setRightOpen] = useState(false)
+
+  return (
+    <section className="flex h-dvh flex-col bg-background text-foreground">
+      <header className="sticky top-0 z-20 flex shrink-0 items-center justify-between border-b border-border bg-card px-2 py-2">
+        <section className="flex items-center gap-1">
+          <Sheet open={leftOpen} onOpenChange={setLeftOpen}>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="Open files" className="h-11 w-11">
+                <Menu />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-[85vw] max-w-sm p-0">
+              <SheetHeader className="border-b border-border px-3 py-2">
+                <SheetTitle>Files</SheetTitle>
+              </SheetHeader>
+              <ScrollArea className="h-[calc(100dvh-3rem)]" onClick={() => setLeftOpen(false)}>
+                <VaultSwitcher />
+                <FolderTree />
+              </ScrollArea>
+            </SheetContent>
+          </Sheet>
+          <Link to="/" className="text-base font-semibold text-foreground">
+            Engram
+          </Link>
+        </section>
+        <nav className="flex items-center gap-1" aria-label="Main navigation">
+          <HeaderLink to="/search" label="Search" />
+          <HeaderLink to="/settings" label="Settings" />
+          <ThemeToggle />
+          <Suspense fallback={null}>
+            {ClerkUserButton ? <ClerkUserButton /> : <LocalUserMenu />}
+          </Suspense>
+          {rightContent && (
+            <Sheet open={rightOpen} onOpenChange={setRightOpen}>
+              <SheetTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Open outline"
+                  className="h-11 w-11"
+                >
+                  <PanelRightOpen />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="right" className="w-[85vw] max-w-sm p-0">
+                <SheetHeader className="border-b border-border px-3 py-2">
+                  <SheetTitle>On this page</SheetTitle>
+                </SheetHeader>
+                <ScrollArea className="h-[calc(100dvh-3rem)]" onClick={() => setRightOpen(false)}>
+                  {rightContent}
+                </ScrollArea>
+              </SheetContent>
+            </Sheet>
+          )}
+        </nav>
+      </header>
+      <main className="flex-1 overflow-y-auto bg-muted/40 text-foreground">
+        <Outlet />
+      </main>
+    </section>
+  )
+}

--- a/frontend/src/layout/mobile-layout.tsx
+++ b/frontend/src/layout/mobile-layout.tsx
@@ -1,18 +1,20 @@
-import { Menu, PanelRightOpen } from 'lucide-react'
-import { lazy, Suspense, useState } from 'react'
+import { Menu, PanelRightOpen, X } from 'lucide-react'
+import { lazy, type MouseEvent, Suspense, useState } from 'react'
 import { Link, NavLink, Outlet } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Sheet,
+  SheetClose,
   SheetContent,
-  SheetHeader,
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet'
 import { config } from '../config'
 import ThemeToggle from '../theme/theme-toggle'
 import FolderTree from '../viewer/folder-tree'
+import FolderActions from './folder-actions'
+import { FolderTreeProvider } from './folder-tree-context'
 import { useRightSidebar } from './right-sidebar-context'
 import VaultSwitcher from './vault-switcher'
 
@@ -37,6 +39,14 @@ function HeaderLink({ to, label }: { to: string; label: string }) {
   )
 }
 
+// Close the drawer only when the click originated on a navigation link.
+// Buttons (e.g. folder-expand toggles in FolderTree) must keep the drawer open.
+function closeOnLinkClick(close: () => void) {
+  return (event: MouseEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement).closest('a')) close()
+  }
+}
+
 export default function MobileLayout() {
   const { content: rightContent } = useRightSidebar()
   const [leftOpen, setLeftOpen] = useState(false)
@@ -52,14 +62,29 @@ export default function MobileLayout() {
                 <Menu />
               </Button>
             </SheetTrigger>
-            <SheetContent side="left" className="w-[85vw] max-w-sm p-0">
-              <SheetHeader className="border-b border-border px-3 py-2">
-                <SheetTitle>Files</SheetTitle>
-              </SheetHeader>
-              <ScrollArea className="h-[calc(100dvh-3rem)]" onClick={() => setLeftOpen(false)}>
+            <SheetContent
+              side="left"
+              showCloseButton={false}
+              className="flex flex-col gap-0 p-0 data-[side=left]:w-[85vw] sm:max-w-none"
+            >
+              <FolderTreeProvider>
+                <section className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
+                  <SheetTitle className="text-base font-medium">Files</SheetTitle>
+                  <SheetClose asChild>
+                    <Button variant="ghost" size="icon-sm" aria-label="Close">
+                      <X />
+                    </Button>
+                  </SheetClose>
+                </section>
+                <ScrollArea
+                  className="min-h-0 flex-1"
+                  onClick={closeOnLinkClick(() => setLeftOpen(false))}
+                >
+                  <FolderTree />
+                </ScrollArea>
+                <FolderActions />
                 <VaultSwitcher />
-                <FolderTree />
-              </ScrollArea>
+              </FolderTreeProvider>
             </SheetContent>
           </Sheet>
           <Link to="/" className="text-base font-semibold text-foreground">
@@ -85,11 +110,23 @@ export default function MobileLayout() {
                   <PanelRightOpen />
                 </Button>
               </SheetTrigger>
-              <SheetContent side="right" className="w-[85vw] max-w-sm p-0">
-                <SheetHeader className="border-b border-border px-3 py-2">
-                  <SheetTitle>On this page</SheetTitle>
-                </SheetHeader>
-                <ScrollArea className="h-[calc(100dvh-3rem)]" onClick={() => setRightOpen(false)}>
+              <SheetContent
+                side="right"
+                showCloseButton={false}
+                className="flex flex-col gap-0 p-0 data-[side=right]:w-[85vw] sm:max-w-none"
+              >
+                <section className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
+                  <SheetTitle className="text-base font-medium">On this page</SheetTitle>
+                  <SheetClose asChild>
+                    <Button variant="ghost" size="icon-sm" aria-label="Close">
+                      <X />
+                    </Button>
+                  </SheetClose>
+                </section>
+                <ScrollArea
+                  className="min-h-0 flex-1"
+                  onClick={closeOnLinkClick(() => setRightOpen(false))}
+                >
                   {rightContent}
                 </ScrollArea>
               </SheetContent>

--- a/frontend/src/layout/mobile-layout.tsx
+++ b/frontend/src/layout/mobile-layout.tsx
@@ -7,6 +7,7 @@ import {
   Sheet,
   SheetClose,
   SheetContent,
+  SheetDescription,
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet'
@@ -70,6 +71,7 @@ export default function MobileLayout() {
               <FolderTreeProvider>
                 <section className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
                   <SheetTitle className="text-base font-medium">Files</SheetTitle>
+                  <SheetDescription className="sr-only">Folder navigation</SheetDescription>
                   <SheetClose asChild>
                     <Button variant="ghost" size="icon-sm" aria-label="Close">
                       <X />
@@ -117,6 +119,7 @@ export default function MobileLayout() {
               >
                 <section className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
                   <SheetTitle className="text-base font-medium">On this page</SheetTitle>
+                  <SheetDescription className="sr-only">Headings on the current note</SheetDescription>
                   <SheetClose asChild>
                     <Button variant="ghost" size="icon-sm" aria-label="Close">
                       <X />

--- a/frontend/src/layout/vault-switcher.tsx
+++ b/frontend/src/layout/vault-switcher.tsx
@@ -36,7 +36,7 @@ export default function VaultSwitcher() {
   if (vaults.length === 1) return <VaultLabel vault={active} />
 
   return (
-    <section className="border-b border-border">
+    <section className="border-t border-border">
       <DropdownMenu>
         <DropdownMenuTrigger className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left outline-none hover:bg-muted aria-expanded:bg-muted">
           <span className="min-w-0 flex-1">
@@ -48,7 +48,7 @@ export default function VaultSwitcher() {
               {active.name}
             </span>
           </span>
-          <ChevronDown className="size-4 text-muted-foreground transition-transform group-aria-expanded/dropdown-trigger:rotate-180" />
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground transition-transform group-aria-expanded/dropdown-trigger:rotate-180" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-56">
           <DropdownMenuRadioGroup
@@ -73,7 +73,7 @@ export default function VaultSwitcher() {
 
 function VaultLabel({ vault }: { vault: Vault }) {
   return (
-    <section className="border-b border-border px-3 py-2">
+    <section className="border-t border-border px-3 py-2">
       <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Vault</p>
       <p className="flex items-center gap-1.5 truncate text-sm font-medium text-foreground">
         {vault.encrypted && <Lock className="size-3 shrink-0 text-muted-foreground" />}

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -249,3 +249,6 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
 }
+html {
+  scroll-padding-top: 4rem;
+}

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
 import { Link, useLocation } from 'react-router'
 import { type NoteSummary, useFolders, useFolderNotes, type Folder } from '../api/queries'
+import { type SortKey, useFolderTreeState } from '../layout/folder-tree-context'
 
 interface TreeNode {
   name: string
@@ -8,7 +8,7 @@ interface TreeNode {
   children: TreeNode[]
 }
 
-function buildTree(folders: Folder[]): TreeNode[] {
+function buildTree(folders: Folder[], sort: SortKey): TreeNode[] {
   const root: TreeNode[] = []
 
   for (const folder of folders) {
@@ -29,17 +29,31 @@ function buildTree(folders: Folder[]): TreeNode[] {
     }
   }
 
-  sortTree(root)
+  sortTree(root, sort)
   return root
 }
 
-function sortTree(nodes: TreeNode[]) {
-  nodes.sort((a, b) => a.name.localeCompare(b.name))
-  for (const n of nodes) sortTree(n.children)
+function sortTree(nodes: TreeNode[], sort: SortKey) {
+  // Folders always sort by name — modification time doesn't make sense for them.
+  const dir = sort === 'name-desc' ? -1 : 1
+  nodes.sort((a, b) => dir * a.name.localeCompare(b.name))
+  for (const n of nodes) sortTree(n.children, sort)
+}
+
+function sortNotes(notes: NoteSummary[], sort: SortKey): NoteSummary[] {
+  const sign = sort.endsWith('-desc') ? -1 : 1
+  if (sort.startsWith('modified')) {
+    return [...notes].sort((a, b) => sign * (Date.parse(a.updated_at) - Date.parse(b.updated_at)))
+  }
+  if (sort.startsWith('created')) {
+    return [...notes].sort((a, b) => sign * (Date.parse(a.created_at) - Date.parse(b.created_at)))
+  }
+  return [...notes].sort((a, b) => sign * a.title.localeCompare(b.title))
 }
 
 export default function FolderTree() {
   const { data: folders, isLoading, isError } = useFolders()
+  const { sort } = useFolderTreeState()
   const location = useLocation()
   // Note routes: /note/<path>. Read from pathname directly because
   // useParams() in the parent layout doesn't expose the child route's
@@ -59,12 +73,12 @@ export default function FolderTree() {
     return <p className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">No notes yet.</p>
   }
 
-  const tree = buildTree(folders)
+  const tree = buildTree(folders, sort)
   const hasRootFiles = folders.some((f) => f.name === '')
 
   return (
-    <nav aria-label="Files" className="py-2 text-sm">
-      <ul role="list" className="space-y-px">
+    <nav aria-label="Files" className="py-2 text-base">
+      <ul role="list" className="space-y-1">
         {hasRootFiles && (
           <RootFiles selectedNotePath={selectedNotePath} />
         )}
@@ -83,10 +97,11 @@ export default function FolderTree() {
 
 function RootFiles({ selectedNotePath }: { selectedNotePath: string | null }) {
   const { data: notes } = useFolderNotes('', { enabled: true })
+  const { sort } = useFolderTreeState()
   if (!notes || notes.length === 0) return null
   return (
     <>
-      {notes.map((note) => (
+      {sortNotes(notes, sort).map((note) => (
         <NoteLeaf
           key={note.path}
           note={note}
@@ -105,17 +120,17 @@ interface FolderNodeProps {
 }
 
 function FolderNode({ node, depth, selectedNotePath }: FolderNodeProps) {
-  const [open, setOpen] = useState(false)
+  const { isOpen: getIsOpen, toggle } = useFolderTreeState()
   const containsSelected = selectedNotePath?.startsWith(`${node.fullPath}/`) ?? false
-  const isOpen = open || containsSelected
+  const isOpen = getIsOpen(node.fullPath) || containsSelected
 
   return (
     <li>
       <button
         type="button"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => toggle(node.fullPath)}
         aria-expanded={isOpen}
-        className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+        className="flex w-full items-center gap-1 rounded py-0.5 pl-1 pr-3 text-left text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
         style={{ paddingLeft: `${depth * 12 + 4}px` }}
       >
         <span
@@ -127,11 +142,11 @@ function FolderNode({ node, depth, selectedNotePath }: FolderNodeProps) {
           ▶
         </span>
         <FolderIcon open={isOpen} />
-        <span className="truncate">{node.name}</span>
+        <span className="min-w-0 flex-1 truncate">{node.name}</span>
       </button>
 
       {isOpen && (
-        <ul role="list" className="space-y-px">
+        <ul role="list" className="space-y-1">
           {node.children.map((child) => (
             <FolderNode
               key={child.fullPath}
@@ -161,6 +176,7 @@ function FolderFiles({
   selectedNotePath: string | null
 }) {
   const { data: notes, isLoading } = useFolderNotes(folderPath, { enabled: true })
+  const { sort } = useFolderTreeState()
   if (isLoading) {
     return (
       <li
@@ -174,7 +190,7 @@ function FolderFiles({
   if (!notes || notes.length === 0) return null
   return (
     <>
-      {notes.map((note) => (
+      {sortNotes(notes, sort).map((note) => (
         <NoteLeaf
           key={note.path}
           note={note}
@@ -196,12 +212,13 @@ function NoteLeaf({
   selectedNotePath: string | null
 }) {
   const isSelected = selectedNotePath === note.path
+  const extension = nonMdExtension(note.path)
   return (
     <li>
       <Link
         to={`/note/${encodePathForRouter(note.path)}`}
         aria-current={isSelected ? 'page' : undefined}
-        className={`flex items-center gap-1 rounded px-1 py-0.5 ${
+        className={`flex items-center gap-1 rounded py-0.5 pl-1 pr-3 ${
           isSelected
             ? 'bg-blue-50 dark:bg-blue-950 font-medium text-blue-700 dark:text-blue-300'
             : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
@@ -209,7 +226,12 @@ function NoteLeaf({
         style={{ paddingLeft: `${depth * 12 + 16}px` }}
       >
         <FileIcon />
-        <span className="truncate">{noteLabel(note)}</span>
+        <span className="min-w-0 flex-1 truncate">{noteLabel(note)}</span>
+        {extension && (
+          <span className="shrink-0 text-xs uppercase text-gray-400 dark:text-gray-500">
+            {extension}
+          </span>
+        )}
       </Link>
     </li>
   )
@@ -218,7 +240,15 @@ function NoteLeaf({
 function noteLabel(note: NoteSummary): string {
   if (note.title) return note.title
   const last = note.path.split('/').pop() ?? note.path
-  return last.replace(/\.md$/, '')
+  return last.replace(/\.[^.]+$/, '')
+}
+
+function nonMdExtension(path: string): string | null {
+  const last = path.split('/').pop() ?? path
+  const dot = last.lastIndexOf('.')
+  if (dot <= 0) return null
+  const ext = last.slice(dot + 1).toLowerCase()
+  return ext === 'md' ? null : ext
 }
 
 function encodePathForRouter(path: string): string {

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -121,6 +121,9 @@ interface FolderNodeProps {
 
 function FolderNode({ node, depth, selectedNotePath }: FolderNodeProps) {
   const { isOpen: getIsOpen, toggle } = useFolderTreeState()
+  // Force-open the chain leading to the active note so the user can always see
+  // where they are. Side effect: "Collapse all" leaves the active-note chain
+  // open, which matches Obsidian's behaviour — intentional, not a bug.
   const containsSelected = selectedNotePath?.startsWith(`${node.fullPath}/`) ?? false
   const isOpen = getIsOpen(node.fullPath) || containsSelected
 
@@ -240,15 +243,41 @@ function NoteLeaf({
 function noteLabel(note: NoteSummary): string {
   if (note.title) return note.title
   const last = note.path.split('/').pop() ?? note.path
-  return last.replace(/\.[^.]+$/, '')
+  // Only strip recognized extensions, otherwise "archive.tar.gz" loses ".gz"
+  // and the row reads "archive.tar" + "GZ" chip — confusing.
+  const ext = recognizedExtension(last)
+  return ext ? last.slice(0, -(ext.length + 1)) : last
+}
+
+const KNOWN_EXTENSIONS = new Set([
+  'md',
+  'pdf',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'svg',
+  'mp3',
+  'mp4',
+  'webm',
+  'mov',
+  'csv',
+  'json',
+  'txt',
+])
+
+function recognizedExtension(filename: string): string | null {
+  const dot = filename.lastIndexOf('.')
+  if (dot <= 0) return null
+  const ext = filename.slice(dot + 1).toLowerCase()
+  return KNOWN_EXTENSIONS.has(ext) ? ext : null
 }
 
 function nonMdExtension(path: string): string | null {
   const last = path.split('/').pop() ?? path
-  const dot = last.lastIndexOf('.')
-  if (dot <= 0) return null
-  const ext = last.slice(dot + 1).toLowerCase()
-  return ext === 'md' ? null : ext
+  const ext = recognizedExtension(last)
+  return ext && ext !== 'md' ? ext : null
 }
 
 function encodePathForRouter(path: string): string {

--- a/frontend/src/viewer/note-editor.tsx
+++ b/frontend/src/viewer/note-editor.tsx
@@ -8,6 +8,13 @@ interface NoteEditorProps {
   onChange: (next: string) => void
 }
 
+// 16px on .cm-content prevents iOS Safari from auto-zooming when the
+// soft keyboard opens. lineWrapping stays on.
+const mobileSafeTheme = EditorView.theme({
+  '.cm-content': { fontSize: '16px' },
+  '.cm-scroller': { fontFamily: 'inherit' },
+})
+
 export default function NoteEditor({ value, onChange }: NoteEditorProps) {
   const { resolved } = useTheme()
 
@@ -16,7 +23,7 @@ export default function NoteEditor({ value, onChange }: NoteEditorProps) {
       value={value}
       onChange={onChange}
       theme={resolved}
-      extensions={[markdown(), EditorView.lineWrapping]}
+      extensions={[markdown(), EditorView.lineWrapping, mobileSafeTheme]}
       basicSetup={{
         lineNumbers: false,
         foldGutter: false,
@@ -24,7 +31,7 @@ export default function NoteEditor({ value, onChange }: NoteEditorProps) {
         highlightActiveLineGutter: false,
         autocompletion: false,
       }}
-      className="min-h-[70vh] rounded-md border border-border bg-muted/30 text-sm"
+      className="min-h-[70vh] rounded-md border border-border bg-muted/30"
     />
   )
 }

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -75,7 +75,7 @@ export default function NotePage() {
     <Tabs
       value={mode}
       onValueChange={(v) => setMode(v as Mode)}
-      className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl bg-card text-card-foreground shadow-sm ring-1 ring-border/60"
+      className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-card text-card-foreground shadow-sm ring-1 ring-border/60 md:rounded-2xl"
     >
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-2">
         <TabsList variant="line">

--- a/frontend/src/viewer/note-view.tsx
+++ b/frontend/src/viewer/note-view.tsx
@@ -63,7 +63,7 @@ export default function NoteView({ content, title, tags, updatedAt }: NoteViewPr
   const frontmatterEntries = Object.entries(frontmatter).filter(([, v]) => v != null && v !== '')
 
   return (
-    <article className="w-full px-8 py-8 lg:px-12 lg:py-10">
+    <article className="w-full px-4 py-6 sm:px-8 sm:py-8 lg:px-12 lg:py-10">
       <header className="mb-6 border-b border-border pb-4">
         <h1 className="mb-1 text-3xl font-bold tracking-tight text-foreground">{title}</h1>
         <p className="text-xs text-muted-foreground">

--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -45,6 +45,7 @@ defmodule EngramWeb.FoldersController do
       tags: note.tags || [],
       version: note.version,
       mtime: note.mtime,
+      created_at: note.created_at,
       updated_at: note.updated_at
     }
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.76",
+      version: "0.5.77",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.77",
+      version: "0.5.78",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.75",
+      version: "0.5.76",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- Below `md` (768px): three-column resizable layout swapped for single document column + left/right shadcn `Sheet` drawers (files + ToC).
- New `useMediaQuery` hook (`frontend/src/hooks/use-media-query.ts`) drives the branch.
- ToC injection via existing `RightSidebarContext` — no duplicated route content; mobile only renders the ToC trigger when `rightContent != null`.
- Drawer state is component-local — closes on every navigation (per spec).
- Touch fixes: 44px header icon buttons, 16px CodeMirror `.cm-content` font to block iOS focus-zoom, `h-dvh` for iOS dynamic viewport, `scroll-padding-top: 4rem` so ToC anchors land below the sticky header.
- Note prose padding now responsive (`px-4 sm:px-8 lg:px-12`).

Spec: `docs/superpowers/specs/2026-05-12-mobile-document-view-design.md`
Plan: `docs/superpowers/plans/2026-05-12-mobile-document-view.md`

## Test plan
- [ ] Resize Chrome to ~390px: hamburger + ToC trigger appear, resize handles disappear
- [ ] Tap hamburger: files drawer slides in; tap a file: drawer closes, note loads
- [ ] Tap ToC trigger on a note in preview mode: ToC drawer slides in; tap entry: drawer closes, scrolled to heading below header
- [ ] Switch to Edit on mobile: CodeMirror renders, no iOS auto-zoom on focus
- [ ] Reload: both drawers start closed
- [ ] Above 768px: existing desktop layout unchanged
- [ ] `frontend/e2e/mobile.spec.ts` (3 tests) passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)