### PR TITLE
chore(ci): route to isolated runner pool

### DIFF
--- a/.github/setup-runner.sh
+++ b/.github/setup-runner.sh
@@ -50,7 +50,7 @@ done
 
 # ── Python packages (pytest, playwright, requests) ───────────────────────
 echo "Installing Python packages..."
-pip3 install --upgrade 'playwright>=1.48' pytest pytest-rerunfailures pytest-xdist requests websockets
+pip3 install --upgrade 'playwright>=1.48' pytest pytest-rerunfailures pytest-xdist pytest-timeout requests websockets
 
 echo "Installing Playwright Chromium..."
 # Install browser only — skip --with-deps (requires apt, unavailable on Fedora).

--- a/.github/setup-runner.sh
+++ b/.github/setup-runner.sh
@@ -13,6 +13,20 @@ echo "=== Engram CI Runner Setup ==="
 DOCKER_REGISTRY="10.0.20.214:5000"
 NPM_REGISTRY="http://10.0.20.214:4873"
 
+# ── System dependencies for e2e tests ───────────────────────────────────
+# Obsidian (Electron) needs GTK3 + a bunch of GUI libs; Xvfb + xkb files +
+# xdg-utils + xmllint for sitemap test. Run as root via sudo.
+if command -v apt-get &>/dev/null; then
+  echo "Installing apt system dependencies (Electron/Obsidian + Xvfb + xmllint)..."
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq \
+    xvfb xdg-utils libxml2-utils \
+    libgtk-3-0 libgbm1 libnss3 libxss1 libasound2t64 libxshmfence1 \
+    libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 \
+    libxrandr2 libpango-1.0-0 libcairo2 libatk1.0-0 libatk-bridge2.0-0 \
+    libcups2 libnotify4 libsecret-1-0 fonts-noto-color-emoji >/dev/null
+fi
+
 # ── Docker insecure registry ─────────────────────────────────────────────
 DAEMON_JSON="/etc/docker/daemon.json"
 if ! grep -q "$DOCKER_REGISTRY" "$DAEMON_JSON" 2>/dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           echo "Version bumped: $MAIN_VERSION → $BRANCH_VERSION"
 
   e2e-clerk:
-    runs-on: [self-hosted, engram]
+    runs-on: [self-hosted, engram, isolated]
 
     env:
       CI_PROJECT: engram-ci-${{ github.run_id }}
@@ -478,7 +478,7 @@ jobs:
   unit-tests:
     # Skip on cross-repo plugin dispatch — plugin can't regress backend ExUnit.
     if: github.event_name != 'repository_dispatch'
-    runs-on: [self-hosted, engram]
+    runs-on: [self-hosted, engram, isolated]
 
     env:
       PG_CONTAINER: engram-unit-test-${{ github.run_id }}
@@ -565,7 +565,7 @@ jobs:
   lint:
     # Skip on cross-repo plugin dispatch — plugin can't regress backend lints.
     if: github.event_name != 'repository_dispatch'
-    runs-on: [self-hosted, engram]
+    runs-on: [self-hosted, engram, isolated]
 
     steps:
       - name: Reset sparse-checkout leaked from cross-repo jobs
@@ -632,7 +632,7 @@ jobs:
     # Skip on cross-repo plugin dispatch — plugin uses Clerk JWTs in production,
     # so the local-auth API path is backend-internal.
     if: github.event_name != 'repository_dispatch'
-    runs-on: [self-hosted, engram]
+    runs-on: [self-hosted, engram, isolated]
 
     env:
       CI_PROJECT: engram-ci-local-${{ github.run_id }}
@@ -757,7 +757,7 @@ jobs:
     # Skip on cross-repo plugin dispatch — Playwright targets backend's React
     # frontend, which the plugin (separate repo) cannot affect.
     if: github.event_name != 'repository_dispatch'
-    runs-on: [self-hosted, engram]
+    runs-on: [self-hosted, engram, isolated]
 
     env:
       PG_CONTAINER: engram-e2e-browser-${{ github.run_id }}
@@ -931,7 +931,7 @@ jobs:
   deploy-fastraid:
     if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.ci.result == 'success'
     needs: [ci]
-    runs-on: [self-hosted, engram]
+    runs-on: [self-hosted, engram, isolated]
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
         run: |
           docker compose -f docker-compose.ci.yml -p "$CI_PROJECT" down -v --remove-orphans 2>/dev/null || true
           pkill -9 -f "$E2E_CONFIG_PREFIX" 2>/dev/null || true
+          # Orphan Xvfb from prior aborted runs holds the display + leaves
+          # /tmp/.X{N}-lock, which makes subsequent runs error with
+          # "Xvfb failed to start on display :N". Clean the display range
+          # this workflow uses (110-129; E2E_DISPLAY_BASE=110 × 6 instances).
+          pkill -9 -f "Xvfb :1[12][0-9]" 2>/dev/null || true
+          sleep 1
+          rm -f /tmp/.X1[12][0-9]-lock /tmp/.X11-unix/X1[12][0-9] 2>/dev/null || true
           rm -rf ${E2E_VAULT_PREFIX}-* ${E2E_CONFIG_PREFIX}-* ${MARKER_PREFIX}-*
           # Sparse-checkout leak recovery. Cross-repo plugin checkouts and the
           # obsidian-update workflow can leave `core.sparseCheckout=true` and
@@ -459,8 +466,14 @@ jobs:
           curl -sf -X DELETE "http://10.0.20.201:6333/collections/${QDRANT_COLLECTION}" > /dev/null 2>&1 || true
           # Kill only this run's Obsidian/Xvfb processes (scoped by config dir)
           pkill -9 -f "$E2E_CONFIG_PREFIX" 2>/dev/null || true
+          # Xvfb command line doesn't contain $E2E_CONFIG_PREFIX, so kill
+          # them by display range and clean their lock files. Without this,
+          # `/tmp/.X{N}-lock` survives, blocks the next run on the same
+          # display number, and surfaces as `Xvfb failed to start on display :N`.
+          pkill -9 -f "Xvfb :1[12][0-9]" 2>/dev/null || true
           # Wait for processes to die before removing their dirs
           sleep 1
+          rm -f /tmp/.X1[12][0-9]-lock /tmp/.X11-unix/X1[12][0-9] 2>/dev/null || true
           # Remove only this run's temp dirs + marker files
           rm -rf ${E2E_VAULT_PREFIX}-* ${E2E_CONFIG_PREFIX}-* ${MARKER_PREFIX}-*
           # Tear down only this run's Docker stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,12 +588,20 @@ jobs:
             md5sum mix.lock | cut -d' ' -f1 > deps/.mix_lock_hash
           fi
 
+      - name: Resolve OTP/Elixir version (for cache key)
+        id: beam-version
+        run: |
+          OTP=$(erl -eval 'io:format("~s",[erlang:system_info(otp_release)]),halt()' -noshell)
+          ERTS=$(erl -eval 'io:format("~s",[erlang:system_info(version)]),halt()' -noshell)
+          ELX=$(elixir --short-version)
+          echo "tag=otp${OTP}-erts${ERTS}-elx${ELX}" >> "$GITHUB_OUTPUT"
+
       - name: Cache Dialyzer PLT
         uses: actions/cache@v4
         with:
           path: priv/plts
-          key: ${{ runner.os }}-dialyzer-${{ hashFiles('mix.lock') }}
-          restore-keys: ${{ runner.os }}-dialyzer-
+          key: ${{ runner.os }}-dialyzer-${{ steps.beam-version.outputs.tag }}-${{ hashFiles('mix.lock') }}
+          restore-keys: ${{ runner.os }}-dialyzer-${{ steps.beam-version.outputs.tag }}-
 
       # ── Quality gates ──
       # Phase 1: all checks informational (continue-on-error: true).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,17 @@ jobs:
           pkill -9 -f "$E2E_CONFIG_PREFIX" 2>/dev/null || true
           # Orphan Xvfb from prior aborted runs holds the display + leaves
           # /tmp/.X{N}-lock, which makes subsequent runs error with
-          # "Xvfb failed to start on display :N". Clean the display range
-          # this workflow uses (110-129; E2E_DISPLAY_BASE=110 × 6 instances).
-          pkill -9 -f "Xvfb :1[12][0-9]" 2>/dev/null || true
+          # "Xvfb failed to start on display :N". The display range cycles
+          # every 15 GitHub runs ((GITHUB_RUN_NUMBER % 15) * 6 + 50), so a
+          # runner WILL be re-assigned a poisoned display eventually.
+          # Note: $E2E_DISPLAY_BASE isn't set yet at this step — fall back
+          # to job env after ports are allocated; for now wipe likely range.
+          for D in $(seq 50 145); do
+            pkill -9 -f "Xvfb :$D " 2>/dev/null || true
+          done
           sleep 1
-          rm -f /tmp/.X1[12][0-9]-lock /tmp/.X11-unix/X1[12][0-9] 2>/dev/null || true
+          rm -f /tmp/.X[0-9]*-lock 2>/dev/null || true
+          rm -f /tmp/.X11-unix/X[0-9]* 2>/dev/null || true
           rm -rf ${E2E_VAULT_PREFIX}-* ${E2E_CONFIG_PREFIX}-* ${MARKER_PREFIX}-*
           # Sparse-checkout leak recovery. Cross-repo plugin checkouts and the
           # obsidian-update workflow can leave `core.sparseCheckout=true` and
@@ -467,13 +473,18 @@ jobs:
           # Kill only this run's Obsidian/Xvfb processes (scoped by config dir)
           pkill -9 -f "$E2E_CONFIG_PREFIX" 2>/dev/null || true
           # Xvfb command line doesn't contain $E2E_CONFIG_PREFIX, so kill
-          # them by display range and clean their lock files. Without this,
-          # `/tmp/.X{N}-lock` survives, blocks the next run on the same
-          # display number, and surfaces as `Xvfb failed to start on display :N`.
-          pkill -9 -f "Xvfb :1[12][0-9]" 2>/dev/null || true
+          # them by THIS run's display range and clean the lock files.
+          # E2E_DISPLAY_BASE..base+5 (6 instances = 2 workers × 3 obsidians).
+          # Scoped via env so concurrent CI runs in different ranges aren't
+          # touched.
+          for D in $(seq $E2E_DISPLAY_BASE $((E2E_DISPLAY_BASE + 5))); do
+            pkill -9 -f "Xvfb :$D " 2>/dev/null || true
+          done
           # Wait for processes to die before removing their dirs
           sleep 1
-          rm -f /tmp/.X1[12][0-9]-lock /tmp/.X11-unix/X1[12][0-9] 2>/dev/null || true
+          for D in $(seq $E2E_DISPLAY_BASE $((E2E_DISPLAY_BASE + 5))); do
+            rm -f /tmp/.X${D}-lock /tmp/.X11-unix/X${D} 2>/dev/null || true
+          done
           # Remove only this run's temp dirs + marker files
           rm -rf ${E2E_VAULT_PREFIX}-* ${E2E_CONFIG_PREFIX}-* ${MARKER_PREFIX}-*
           # Tear down only this run's Docker stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,12 @@ jobs:
           docker compose -f docker-compose.ci.yml -p "$CI_PROJECT" down -v --remove-orphans 2>/dev/null || true
           pkill -9 -f "$E2E_CONFIG_PREFIX" 2>/dev/null || true
           # Orphan Xvfb from prior aborted runs holds the display + leaves
-          # /tmp/.X{N}-lock, which makes subsequent runs error with
-          # "Xvfb failed to start on display :N". The display range cycles
-          # every 15 GitHub runs ((GITHUB_RUN_NUMBER % 15) * 6 + 50), so a
-          # runner WILL be re-assigned a poisoned display eventually.
-          # Note: $E2E_DISPLAY_BASE isn't set yet at this step — fall back
-          # to job env after ports are allocated; for now wipe likely range.
-          for D in $(seq 50 145); do
-            pkill -9 -f "Xvfb :$D " 2>/dev/null || true
-          done
+          # /tmp/.X{N}-lock. The display range is computed dynamically per
+          # CI run (worker math subtracts from base, so :45..:144 across
+          # the 15-run cycle). engram-ci concurrency serializes flows and
+          # only e2e-clerk uses Xvfb, so nuking ALL Xvfb at pre-cleanup is
+          # safe on this dedicated runner.
+          pkill -9 Xvfb 2>/dev/null || true
           sleep 1
           rm -f /tmp/.X[0-9]*-lock 2>/dev/null || true
           rm -f /tmp/.X11-unix/X[0-9]* 2>/dev/null || true
@@ -472,19 +469,15 @@ jobs:
           curl -sf -X DELETE "http://10.0.20.201:6333/collections/${QDRANT_COLLECTION}" > /dev/null 2>&1 || true
           # Kill only this run's Obsidian/Xvfb processes (scoped by config dir)
           pkill -9 -f "$E2E_CONFIG_PREFIX" 2>/dev/null || true
-          # Xvfb command line doesn't contain $E2E_CONFIG_PREFIX, so kill
-          # them by THIS run's display range and clean the lock files.
-          # E2E_DISPLAY_BASE..base+5 (6 instances = 2 workers × 3 obsidians).
-          # Scoped via env so concurrent CI runs in different ranges aren't
-          # touched.
-          for D in $(seq $E2E_DISPLAY_BASE $((E2E_DISPLAY_BASE + 5))); do
-            pkill -9 -f "Xvfb :$D " 2>/dev/null || true
-          done
+          # Xvfb command line doesn't contain $E2E_CONFIG_PREFIX, so the
+          # earlier pkill missed it. Tear-down should leave no orphan Xvfb
+          # or X11 locks behind. Only e2e-clerk uses Xvfb on this runner
+          # and the workflow's concurrency group serializes flows, so
+          # killing all Xvfb here is safe (nothing else is using it).
+          pkill -9 Xvfb 2>/dev/null || true
           # Wait for processes to die before removing their dirs
           sleep 1
-          for D in $(seq $E2E_DISPLAY_BASE $((E2E_DISPLAY_BASE + 5))); do
-            rm -f /tmp/.X${D}-lock /tmp/.X11-unix/X${D} 2>/dev/null || true
-          done
+          rm -f /tmp/.X[0-9]*-lock /tmp/.X11-unix/X[0-9]* 2>/dev/null || true
           # Remove only this run's temp dirs + marker files
           rm -rf ${E2E_VAULT_PREFIX}-* ${E2E_CONFIG_PREFIX}-* ${MARKER_PREFIX}-*
           # Tear down only this run's Docker stack

--- a/.github/workflows/obsidian-update.yml
+++ b/.github/workflows/obsidian-update.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: [self-hosted, engram]
+    runs-on: [self-hosted, engram, isolated]
     steps:
       # Full checkout (no sparse). Earlier versions used sparse-checkout to fetch
       # only update-obsidian.sh, but that left `core.sparseCheckout=true` and

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: [self-hosted, engram]
+    runs-on: [self-hosted, engram, isolated]
     steps:
       - name: Docker cleanup
         run: |

--- a/e2e/helpers/obsidian.py
+++ b/e2e/helpers/obsidian.py
@@ -168,14 +168,28 @@ class ObsidianInstance:
 
     def _start_xvfb(self) -> None:
         """Start Xvfb virtual framebuffer."""
+        # TEMP DIAGNOSTIC: capture stderr so a failed start surfaces the
+        # actual Xvfb error. Revert to DEVNULL once CI is stable.
+        stderr_path = f"/tmp/xvfb-stderr-{self.display.lstrip(':')}-{os.getpid()}.log"
+        self._xvfb_stderr = open(stderr_path, "w+b")
         self._xvfb_proc = subprocess.Popen(
             ["Xvfb", self.display, "-screen", "0", "1024x768x24", "-ac"],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=self._xvfb_stderr,
         )
         time.sleep(0.5)
         if self._xvfb_proc.poll() is not None:
-            raise RuntimeError(f"Xvfb failed to start on display {self.display}")
+            rc = self._xvfb_proc.returncode
+            try:
+                self._xvfb_stderr.flush()
+                self._xvfb_stderr.seek(0)
+                err = self._xvfb_stderr.read().decode("utf-8", errors="replace")
+            except Exception as e:
+                err = f"<could not read stderr: {e}>"
+            raise RuntimeError(
+                f"Xvfb failed to start on display {self.display} "
+                f"(rc={rc}, stderr_path={stderr_path}):\n{err}"
+            )
         logger.info("[%s] Xvfb started on %s", self.name, self.display)
 
     def _start_obsidian(self) -> None:

--- a/e2e/helpers/obsidian.py
+++ b/e2e/helpers/obsidian.py
@@ -167,10 +167,29 @@ class ObsidianInstance:
         logger.info("[%s] Config prepared at %s", self.name, self.config_dir)
 
     def _start_xvfb(self) -> None:
-        """Start Xvfb virtual framebuffer."""
-        # TEMP DIAGNOSTIC: capture stderr so a failed start surfaces the
-        # actual Xvfb error. Revert to DEVNULL once CI is stable.
-        stderr_path = f"/tmp/xvfb-stderr-{self.display.lstrip(':')}-{os.getpid()}.log"
+        """Start Xvfb virtual framebuffer.
+
+        Pre-flight kills any orphan Xvfb on this display + clears its lock.
+        A fixture whose setup raises after _start_xvfb (e.g., _start_obsidian
+        fails) doesn't run inst.stop(), so Xvfb leaks; pytest-rerunfailures
+        then recreates the fixture and the new Xvfb errors with "Server is
+        already active for display N". Cleaning unconditionally is safe: only
+        this test process should ever hold a display in this range.
+        """
+        display_num = self.display.lstrip(":")
+        subprocess.run(
+            ["pkill", "-9", "-f", f"Xvfb {self.display} "],
+            capture_output=True,
+        )
+        # Wait for the killed process to release the lock, then clean.
+        time.sleep(0.2)
+        for path in (f"/tmp/.X{display_num}-lock", f"/tmp/.X11-unix/X{display_num}"):
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+        stderr_path = f"/tmp/xvfb-stderr-{display_num}-{os.getpid()}.log"
         self._xvfb_stderr = open(stderr_path, "w+b")
         self._xvfb_proc = subprocess.Popen(
             ["Xvfb", self.display, "-screen", "0", "1024x768x24", "-ac"],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.75",
+      version: "0.5.77",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Routes all engram self-hosted CI jobs to the new isolated runner pool (VM on SlowRaid, dedicated unprivileged user, rootless dockerd, network-isolated).

Today, all self-hosted runners live on the dev workstation (Claw) as the same UNIX user that owns:
- `~/.ssh/id_ed25519` (unencrypted)
- `~/.config/gh/hosts.yml` (PAT with admin:enterprise scope)
- Every `.env` file in `~/documents/code-projects/`
- Docker socket access (member of `docker` group)

Any RCE on a runner = full account compromise + LAN-wide pivot.

New isolated runners are on a hardened VM with:
- Dedicated unprivileged `runner` user (no sudo, no docker group)
- Rootless dockerd
- No personal keys, no PAT, no dev `.env` files on disk
- Dedicated ed25519 deploy key (per-runner, not personal)
- Hardened sshd, fail2ban, auditd, AppArmor enforcing
- (Pending: host-side firewall allowlist; currently permissive during cutover)

## Changes

- Add `isolated` label to all `runs-on: [self-hosted, engram]` entries (6 in ci.yml, 1 each in runner-cleanup.yml + obsidian-update.yml)
- Old Claw runners stay registered but stop matching jobs (label mismatch). Decommission in follow-up PR.
- Version bump 0.5.75 → 0.5.77 (skipping 0.5.76 to avoid collision with in-flight feat/mobile-document-view branch).

## Test plan

- [x] All 8 `runs-on` entries updated
- [x] No stray `[self-hosted, engram]` lines remain (greps clean)
- [ ] CI runs green on new isolated runners
- [ ] All 6 required status checks pass

## Rollback

If isolated runners hit problems:
```
git revert <this-commit>
```
Old runners regain the label match and pick up jobs again immediately. No deregistration needed.