### PR TITLE
chore: dual-license under PolyForm SB 1.0.0 + Apache-style CLA

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,114 @@
+# Engram Contributor License Agreement (v1.0)
+
+Thank you for your interest in contributing to Engram (the "**Project**"),
+which is operated by **Rasbandit Software Solutions LLC d/b/a Engram**, a Utah
+limited liability company (the "**Company**"). This Contributor License
+Agreement ("**Agreement**") clarifies the intellectual property license granted
+with Contributions from any person or entity to the Company.
+
+By signing this Agreement — via the CLA Assistant bot on the
+[github.com/Rasbandit/Engram](https://github.com/Rasbandit/Engram) repository
+or by any other written acceptance — You accept and agree to the following
+terms and conditions for Your present and future Contributions submitted to
+the Project.
+
+This Agreement is adapted from the Apache Software Foundation Individual
+Contributor License Agreement v2.0.
+
+## 1. Definitions
+
+- **"You"** (or **"Your"**) shall mean the copyright owner or legal entity
+  authorized by the copyright owner that is making this Agreement with the
+  Company. For legal entities, the entity making a Contribution and all other
+  entities that control, are controlled by, or are under common control with
+  that entity are considered to be a single Contributor.
+
+- **"Contribution"** shall mean any original work of authorship, including any
+  modifications or additions to an existing work, that is intentionally
+  submitted by You to the Company for inclusion in, or documentation of, the
+  Project. "Submitted" means any form of electronic, verbal, or written
+  communication sent to the Company or its representatives, including but not
+  limited to communication on electronic mailing lists, source code control
+  systems, and issue tracking systems that are managed by, or on behalf of,
+  the Company for the purpose of discussing and improving the Project, but
+  excluding communication that is conspicuously marked or otherwise designated
+  in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, and distribute Your Contributions and such derivative
+works.
+
+**You retain ownership of the copyright in Your Contributions.** This Agreement
+is a license grant, not an assignment.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Project, where such license applies
+only to those patent claims licensable by You that are necessarily infringed
+by Your Contribution(s) alone or by combination of Your Contribution(s) with
+the Project to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Project to which You have contributed, constitutes direct
+or contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or the Project shall
+terminate as of the date such litigation is filed.
+
+## 4. Right to Relicense
+
+You acknowledge and agree that the Company may distribute the Project, and
+Your Contributions as part of it, under multiple licenses, including but not
+limited to:
+
+- The [PolyForm Small Business License 1.0.0](../LICENSE), as the public
+  source-available license, and
+- A separate commercial license for organizations that do not satisfy the
+  Small Business threshold (see [LICENSE-COMMERCIAL.md](../LICENSE-COMMERCIAL.md)),
+  on terms determined by the Company.
+
+The Company may update, add, or change the licenses under which the Project is
+distributed at its sole discretion, and Your grants in Sections 2 and 3 cover
+those future licenses.
+
+## 5. Representations
+
+You represent that:
+
+- You are legally entitled to grant the licenses above.
+- Each of Your Contributions is Your original creation, or You have the
+  necessary rights to submit it under the terms of this Agreement.
+- If Your employer(s) has rights to intellectual property that You create,
+  You have received permission to make Contributions on behalf of that
+  employer, that Your employer has waived such rights for Your Contributions
+  to the Company, or that Your employer has executed a separate Corporate CLA
+  with the Company.
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Unless required by applicable law or
+agreed to in writing, You provide Your Contributions on an "**AS IS**" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 6. Notice of Third-Party Rights
+
+You agree to notify the Company of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any respect.
+
+---
+
+**To sign:** comment on your first pull request as instructed by the CLA
+Assistant bot, or include the following line in a pull request comment:
+
+> I have read the Engram Contributor License Agreement v1.0 and I hereby
+> sign the CLA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to Engram
+
+Thanks for your interest. Engram is a small, focused project. Bug reports,
+feature requests, and pull requests are all welcome.
+
+## Reporting bugs
+
+Open an issue on GitHub with:
+
+- What you expected to happen
+- What actually happened
+- Steps to reproduce (commands, payloads, etc.)
+- Engram version (`mix.exs` `version:`) and deployment mode (SaaS / self-hosted)
+- Relevant logs (sanitize secrets first)
+
+## Proposing changes
+
+For non-trivial changes, open an issue first to discuss the approach before
+spending time on a PR. For small bug fixes, a direct PR is fine.
+
+## Contributor License Agreement (CLA)
+
+Engram is dual-licensed: source-available under the
+[PolyForm Small Business License 1.0.0](LICENSE) for the public, and under a
+commercial license for organizations above the Small Business threshold (see
+[LICENSE-COMMERCIAL.md](LICENSE-COMMERCIAL.md)).
+
+To keep this model viable, every contributor must agree to the project's
+**Contributor License Agreement** — see [.github/CLA.md](.github/CLA.md) — the
+first time they open a pull request.
+
+The CLA does **not** transfer copyright. You keep ownership of your
+contribution. You grant Rasbandit Software Solutions LLC d/b/a Engram a broad
+license — including the right to relicense your contribution under the
+commercial license — so the dual-license model works.
+
+Signing is automated: when you open your first PR, the CLA Assistant bot will
+post a comment with a link. Sign once via your GitHub identity and you are
+covered for all future contributions to this repo.
+
+## Development setup
+
+See [README.md](README.md) "Quick Start" for local environment setup, and
+[CLAUDE.md](CLAUDE.md) for architecture and workflow details.
+
+## Pull request expectations
+
+- One concern per PR. Split refactors out from feature changes.
+- All four lint checks pass locally: `mix format --check-formatted`,
+  `mix compile --warnings-as-errors`, `mix credo --strict`,
+  `mix sobelow --exit low`. Dialyzer runs in CI.
+- Tests added for new behavior. See `docs/context/testing-strategy.md`.
+- Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, ...).
+- `mix.exs` `version:` bumped if the change is user-visible (pre-push hook
+  enforces this).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,120 @@
+Required Notice: Copyright 2026 Rasbandit Software Solutions LLC d/b/a Engram (https://engram.page)
+
+Engram is offered under a dual-licensing model:
+
+  1. The PolyForm Small Business License 1.0.0 (text below), for individuals
+     and organizations that satisfy the "Small Business" clause.
+
+  2. A commercial license, available from Rasbandit Software Solutions LLC
+     d/b/a Engram, for organizations that do not satisfy the Small Business
+     clause or that prefer not to be bound by its terms. See
+     LICENSE-COMMERCIAL.md or contact support@engram.page.
+
+---
+
+# PolyForm Small Business License 1.0.0
+
+<https://polyformproject.org/licenses/small-business/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both
+strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything
+you might do with the software that would otherwise infringe the licensor's
+copyright in it for any permitted purpose. However, you may only distribute the
+software according to [Distribution License](#distribution-license) and make
+changes or new works based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of
+the software. Your license to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from
+you also gets a copy of these terms or the URL for them above, as well as
+copies of any plain-text lines beginning with `Required Notice:` that the
+licensor provided with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new
+works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent
+claims the licensor can license, or becomes able to license, that you would
+infringe by using the software.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do
+not limit them.
+
+## Small Business
+
+Use of the software for the benefit of your company is use for a permitted
+purpose if your company has fewer than 100 total individuals working as
+employees and independent contractors, and less than 1,000,000 USD (2019) total
+revenue in the prior tax year. Adjust this revenue threshold for inflation
+according to the United States Bureau of Labor Statistics' consumer price index
+for all urban consumers, U.S. city average, for all items, not seasonally
+adjusted, with 1982–1984=100 reference base.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to
+anyone else, or prevent the licensor from granting licenses to anyone else.
+These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software granted under
+these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these
+terms, or done anything with the software not covered by your licenses, your
+licenses can nonetheless continue if you come into full compliance with these
+terms, and take practical steps to correct past violations, within 32 days of
+receiving notice. Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the
+**software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of an entity, or
+the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -1,0 +1,45 @@
+# Commercial License
+
+Engram source code is offered to the public under the
+[PolyForm Small Business License 1.0.0](LICENSE).
+
+The PolyForm Small Business License limits permitted use to organizations
+with:
+
+- Fewer than **100 total individuals** (employees and independent contractors
+  combined), **and**
+- Less than **1,000,000 USD** (2019 dollars, inflation-adjusted) in total
+  revenue in the prior tax year.
+
+If your organization exceeds either threshold, you must obtain a separate
+commercial license to use Engram.
+
+## Who needs a commercial license
+
+You need a commercial license if any of the following are true:
+
+- Your organization has 100 or more employees and contractors combined
+- Your organization had 1,000,000 USD (inflation-adjusted) or more in revenue
+  in the prior tax year
+- You want to offer Engram (or a derivative) as a hosted or managed service to
+  your customers
+- You want commercial support, indemnification, or terms that are not provided
+  by the PolyForm Small Business License
+
+## How to get a commercial license
+
+Contact **support@engram.page** with:
+
+- Your organization name
+- Approximate employee and contractor count
+- Approximate annual revenue
+- Intended use case (internal tool, customer-facing service, OEM, etc.)
+- Expected number of users / scale
+
+We will respond with pricing and contract terms tailored to your situation.
+
+## Licensor
+
+Commercial licenses are issued by
+**Rasbandit Software Solutions LLC d/b/a Engram**, a Utah limited liability
+company.

--- a/README.md
+++ b/README.md
@@ -307,4 +307,4 @@ Contributions are accepted under the
 [Engram Contributor License Agreement](.github/CLA.md). See
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Copyright 2026 Rasbandit Software Solutions LLC d/b/a Engram.
+Copyright (c) 2026 Rasbandit Software Solutions LLC d/b/a Engram.

--- a/README.md
+++ b/README.md
@@ -293,4 +293,18 @@ See `docs/context/production-deployment.md` for full infrastructure details.
 
 ## License
 
-MIT
+Engram is **dual-licensed**.
+
+- For individuals and organizations that satisfy the Small Business clause
+  (fewer than 100 total employees + contractors, and less than $1M USD
+  inflation-adjusted revenue in the prior tax year), the source code is
+  available under the [PolyForm Small Business License 1.0.0](LICENSE).
+- For all other organizations, a separate commercial license is required.
+  See [LICENSE-COMMERCIAL.md](LICENSE-COMMERCIAL.md) or email
+  `support@engram.page`.
+
+Contributions are accepted under the
+[Engram Contributor License Agreement](.github/CLA.md). See
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+Copyright 2026 Rasbandit Software Solutions LLC d/b/a Engram.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Engram web frontend",
   "main": "index.js",
+  "private": true,
+  "license": "SEE LICENSE IN ../LICENSE",
+  "author": "Rasbandit Software Solutions LLC d/b/a Engram",
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
@@ -12,8 +15,6 @@
     "test:e2e:clerk": "playwright test --project=clerk"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "@clerk/clerk-react": "^5.61.4",
     "@codemirror/lang-markdown": "^6.5.0",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.91",
+      version: "0.5.92",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,12 +4,13 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.90",
+      version: "0.5.91",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
+      package: package(),
       listeners: [Phoenix.CodeReloader],
       dialyzer: [
         ignore_warnings: ".dialyzer_ignore.exs",
@@ -45,6 +46,14 @@ defmodule Engram.MixProject do
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
+
+  defp package do
+    [
+      name: "engram",
+      licenses: ["PolyForm-Small-Business-1.0.0"],
+      links: %{"Source" => "https://github.com/Rasbandit/Engram"}
+    ]
+  end
 
   # Specifies your project dependencies.
   #


### PR DESCRIPTION
## Summary

Attaches the project's first formal license + contributor agreement. Engram is now **dual-licensed**:

- **Public license:** [PolyForm Small Business License 1.0.0](https://polyformproject.org/licenses/small-business/1.0.0) — free use for orgs with <100 employees/contractors **and** <$1M USD revenue (inflation-adjusted from 2019).
- **Commercial license:** required for any org above either threshold. Inquiries to `support@engram.page`.

Adds an Apache-style **Contributor License Agreement** so the dual-license model is enforceable — contributors keep copyright but grant Rasbandit Software Solutions LLC d/b/a Engram an irrevocable license including explicit relicensing rights.

## Why PolyForm SB (and not ELv2 / MIT / AGPL)

After brainstorming the threat model: the real concern is **competitors forking and undercutting on price** + **big-co freeloading on self-hosted**. ELv2 only blocks the former. AGPL doesn't deter unmodified rehosting. PolyForm SB hard-bars both via revenue/headcount ceiling — the cleanest match for the stated concerns.

Full reasoning in `2. Knowledge Vault/Business/Engram/Engram.md` → "Why PolyForm Small Business 1.0.0 + Commercial Dual License".

## Files

| File | Status |
|------|--------|
| `LICENSE` | NEW — PolyForm SB 1.0.0 verbatim + `Required Notice:` line + dual header |
| `LICENSE-COMMERCIAL.md` | NEW — commercial license inquiry doc |
| `CONTRIBUTING.md` | NEW — PR flow + CLA pointer |
| `.github/CLA.md` | NEW — Apache-style CLA (Section 4 grants explicit relicensing right) |
| `README.md` | License section: `MIT` → dual model |
| `frontend/package.json` | `license: "SEE LICENSE IN ../LICENSE"`, `private: true`, author set (PolyForm isn't on npm SPDX list) |
| `mix.exs` | `package/0` block with `licenses: ["PolyForm-Small-Business-1.0.0"]`, version 0.5.79 |

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] Pre-push hook passes (format, compile, credo strict, sobelow)
- [ ] CI green
- [ ] After merge: install [CLA Assistant](https://github.com/apps/cla-assistant) GitHub App, point at `.github/CLA.md`
- [ ] After merge: set up `support@engram.page` forwarding (Cloudflare Email Routing)

## Notes for reviewer

- GitHub's License sidebar will show "Other" because PolyForm SB isn't on the OSI/SPDX approved list. Expected, not a defect.
- The `Required Notice:` line in LICENSE is PolyForm's official mechanism for the copyright line — downstream redistributors must keep it intact.
- CLA Section 4 explicitly lists both PolyForm SB and the commercial license as covered, plus a clause that lets future re-licensing also work without re-signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)