### PR TITLE
fix(ci): write deployer cert under $RUNNER_TEMP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1071,9 +1071,9 @@ jobs:
             echo "Capture from FastRaid: ssh root@10.0.20.214 'cat /boot/config/plugins/engram-deployer/cert.pem'" >&2
             exit 1
           fi
-          printf '%s\n' "$DEPLOYER_CERT_PEM" > /tmp/deployer-cert.pem
+          printf '%s\n' "$DEPLOYER_CERT_PEM" > ${RUNNER_TEMP}/deployer-cert.pem
           # Sanity-check it parses as a cert before we use it for TLS.
-          openssl x509 -in /tmp/deployer-cert.pem -noout -subject -fingerprint -sha256
+          openssl x509 -in ${RUNNER_TEMP}/deployer-cert.pem -noout -subject -fingerprint -sha256
 
       - name: Deploy via engram-deployer
         env:
@@ -1086,16 +1086,16 @@ jobs:
           # for terminal-line status parsing.
           set -o pipefail
           curl -sS -X POST \
-            --cacert /tmp/deployer-cert.pem \
+            --cacert ${RUNNER_TEMP}/deployer-cert.pem \
             --max-time 600 \
             -H "Authorization: Bearer ${OIDC_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{\"version\":\"${VERSION}\",\"sha\":\"${SHA_SHORT}\"}" \
             https://10.0.20.214:8443/deploy \
-            | tee /tmp/deploy-stream.ndjson
+            | tee ${RUNNER_TEMP}/deploy-stream.ndjson
 
           # Last non-empty line is the DeployResult.
-          RESULT=$(grep -v '^$' /tmp/deploy-stream.ndjson | tail -n 1)
+          RESULT=$(grep -v '^$' ${RUNNER_TEMP}/deploy-stream.ndjson | tail -n 1)
           STATUS=$(printf '%s' "$RESULT" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("status",""))')
 
           if [ "$STATUS" != "ok" ]; then

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.79",
+      version: "0.5.80",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
First OIDC deploy after the cutover merge failed in 0s:

> `/tmp/deployer-cert.pem: Permission denied`

Root cause: an earlier interactive smoke test had \`scp\`'d a cert to /tmp on the runner VM as the ssh-user (\`github-runner\`). When the GHA runner process (\`runner\`, uid 1001) later tried to overwrite the same path in the deploy job, kernel denied. \`/tmp\` is shared across users + persistent across jobs on this VM, so any one-time \`scp\` to /tmp leaves a permanent collision for future runs.

Fix: write the cert + stream NDJSON under \`\$RUNNER_TEMP\`, which is the per-job ephemeral dir GitHub Actions creates owned by the runner user.

## Test plan

- [x] Stale /tmp/deployer-cert.pem deleted on VM as belt-and-suspenders.
- [ ] Merge → deploy-fastraid runs end-to-end → engram-deployer daemon logs a /deploy request → status=ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)