### PR TITLE
perf(docker): local buildx cache + hex/rebar/bun cache mounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,6 +1052,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Local FS cache on the self-hosted runner — bounded by disk speed
+      # instead of GHCR latency. The old registry cache fetched every layer
+      # over HTTPS on every build; local cache is ~10× faster for cache hits.
+      - name: Restore buildx cache
+        if: steps.version.outputs.image_exists != 'true'
+        uses: actions/cache@v5
+        with:
+          path: /tmp/buildx-cache
+          key: buildx-${{ runner.os }}-${{ hashFiles('Dockerfile', 'mix.lock', 'frontend/bun.lock') }}
+          restore-keys: |
+            buildx-${{ runner.os }}-
+
       - name: Build and push image
         if: steps.version.outputs.image_exists != 'true'
         uses: docker/build-push-action@v7
@@ -1061,12 +1073,22 @@ jobs:
           provenance: false
           sbom: false
           platforms: linux/amd64
-          cache-from: type=registry,ref=${{ steps.version.outputs.image }}:buildcache
-          cache-to: type=registry,ref=${{ steps.version.outputs.image }}:buildcache,mode=max
+          cache-from: type=local,src=/tmp/buildx-cache
+          cache-to: type=local,dest=/tmp/buildx-cache-new,mode=max
           tags: |
             ${{ steps.version.outputs.image }}:latest
             ${{ steps.version.outputs.image }}:${{ steps.version.outputs.version }}
             ${{ steps.version.outputs.image }}:${{ steps.version.outputs.sha_short }}
+
+      # Atomically swap new cache over old. actions/cache@v5 has no built-in
+      # rotation; without this step the cache grows unbounded across runs.
+      - name: Rotate buildx cache
+        if: steps.version.outputs.image_exists != 'true' && always()
+        run: |
+          if [ -d /tmp/buildx-cache-new ]; then
+            rm -rf /tmp/buildx-cache
+            mv /tmp/buildx-cache-new /tmp/buildx-cache
+          fi
 
       # ── Pull-based deploy via engram-deployer on FastRaid ────────────────
       # Replaces the old "SSH as root + run a shell script" pattern. Runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ FROM oven/bun:1.3 AS frontend
 
 WORKDIR /frontend
 COPY frontend/package.json frontend/bun.lock ./
-RUN bun install --frozen-lockfile
+# Bun global package cache survives across builds on self-hosted runners.
+RUN --mount=type=cache,target=/root/.bun/install/cache,id=bun-cache \
+    bun install --frozen-lockfile
 COPY frontend/ ./
 RUN bun run build
 
@@ -26,13 +28,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 WORKDIR /app
 
-RUN mix local.hex --force && mix local.rebar --force
-
 ENV MIX_ENV="prod"
+# Persist hex + rebar package caches across builds (self-hosted runner disk).
+# Without these mounts, mix.exs invalidation re-downloads every hex tarball.
+RUN --mount=type=cache,target=/root/.hex,id=mix-hex \
+    --mount=type=cache,target=/root/.cache/rebar3,id=mix-rebar \
+    mix local.hex --force && mix local.rebar --force
 
 # Fetch deps — cache mount means only changed deps are re-downloaded
 COPY mix.exs mix.lock ./
 RUN --mount=type=cache,target=/app/deps,id=mix-deps \
+    --mount=type=cache,target=/root/.hex,id=mix-hex \
+    --mount=type=cache,target=/root/.cache/rebar3,id=mix-rebar \
     mix deps.get --only $MIX_ENV
 
 # Compile deps — cache mount preserves compiled artifacts between builds
@@ -40,14 +47,16 @@ RUN mkdir -p config
 COPY config/config.exs config/runtime.exs config/prod.exs config/
 RUN --mount=type=cache,target=/app/deps,id=mix-deps \
     --mount=type=cache,target=/app/_build,id=mix-build \
+    --mount=type=cache,target=/root/.hex,id=mix-hex \
+    --mount=type=cache,target=/root/.cache/rebar3,id=mix-rebar \
     mix deps.compile
 
 # Compile app code — frontend assets not needed for compilation,
 # only for the release. Keeping them separate means frontend-only
 # changes don't invalidate the Elixir compile layer.
+# (runtime.exs already copied above — not re-copied here.)
 COPY lib lib
 COPY priv priv
-COPY config/runtime.exs config/
 COPY --from=frontend /priv/static/app priv/static/app
 # Compile and release in one RUN, no _build cache mount. Splitting the
 # two steps with a shared _build cache produced stale beams in CI —

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.81",
+      version: "0.5.82",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- Self-hosted runner has persistent disk → switch `cache-from/to` from `type=registry` (HTTPS round-trip per layer) to `type=local` on `/tmp/buildx-cache` with `actions/cache@v5` rotation
- Added BuildKit cache mounts in builder stage: `~/.hex`, `~/.cache/rebar3`, `~/.bun/install/cache`
- Drop redundant `COPY config/runtime.exs config/` — first COPY above already includes it
- Bump version to 0.5.82

Expected impact: cold build unchanged (~2-3 min build+push), warm build with same mix.lock drops 30s-2min as deps/_build cache mounts survive across runs.

## Test plan
- [ ] CI green on this PR
- [ ] Post-merge cold build time recorded
- [ ] Second deploy (warm cache) verified faster than cold

🤖 Generated with [Claude Code](https://claude.com/claude-code)