### PR TITLE
test(factory): add insert_user/1 that provisions a DEK

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.89",
+      version: "0.5.90",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/factory_test.exs
+++ b/test/engram/factory_test.exs
@@ -1,0 +1,38 @@
+defmodule Engram.FactoryTest do
+  @moduledoc """
+  Guards the test factory contract: factory-inserted users MUST match
+  prod registration shape so encrypted-column tests don't accidentally
+  exercise the `:no_dek` error path (which spams `vault decrypt_failed`
+  logs and masks real decryption bugs).
+
+  Tests that intentionally exercise the no-DEK path keep using raw
+  `insert(:user)` or override `encrypted_dek: nil` explicitly.
+  """
+  use Engram.DataCase, async: true
+
+  import Engram.Factory
+
+  describe "insert_user/1" do
+    test "returns a user with a wrapped DEK persisted" do
+      user = insert_user()
+      assert is_binary(user.encrypted_dek)
+      assert byte_size(user.encrypted_dek) > 0
+
+      reloaded = Engram.Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
+      assert reloaded.encrypted_dek == user.encrypted_dek
+    end
+
+    test "accepts attribute overrides" do
+      user = insert_user(email: "specific@test.com")
+      assert user.email == "specific@test.com"
+      assert is_binary(user.encrypted_dek)
+    end
+  end
+
+  describe "raw insert(:user)" do
+    test "still produces a user with no DEK (no-DEK opt-out path)" do
+      user = insert(:user)
+      assert is_nil(user.encrypted_dek)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -22,6 +22,22 @@ defmodule Engram.Factory do
     }
   end
 
+  @doc """
+  Insert a user matching prod registration shape — DEK provisioned via
+  `Engram.Crypto.ensure_user_dek/1`. Prefer this over raw `insert(:user)`
+  for tests that touch encrypted columns (notes/vaults/attachments);
+  factory users without a DEK trigger `:no_dek` errors that mask the
+  real assertions and spam test logs.
+
+  Raw `insert(:user)` remains valid for tests that intentionally
+  exercise the no-DEK error path.
+  """
+  def insert_user(attrs \\ []) do
+    user = insert(:user, attrs)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    user
+  end
+
   def note_factory do
     user = build(:user)
 


### PR DESCRIPTION
## Summary
- Adds `Engram.Factory.insert_user/1` — calls `insert(:user, attrs)` then `Crypto.ensure_user_dek/1` so the factory matches prod registration shape
- Test guard: insert_user → DEK populated; raw `insert(:user)` → still no-DEK (opt-out preserved)
- Eliminates `vault decrypt_failed reason=:no_dek` log noise from any test that switches to `insert_user`

## Scope
Primitive only. Does NOT migrate the ~200 existing `insert(:user)` call sites — that's a separate mechanical sweep PR.

Background: PR #120 added `ExUnit.configure(capture_log: true)` which *hides* the no-DEK noise but doesn't fix the source. Tests still ran against an unrealistic user shape where encrypted-column code paths silently no-op'd. This PR closes the source.

## Test plan
- [x] `mix test test/engram/factory_test.exs` green (3/3)
- [ ] Full CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)