### PR TITLE
perf(ci): tighten compose healthchecks for faster stack-up

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -57,11 +57,18 @@ services:
       STORAGE_PORT: "9000"
       STORAGE_REGION: us-east-1
     healthcheck:
+      # 1s interval (was 3s) so docker compose --wait detects "ready" with
+      # finer granularity — BEAM cold boot finishes mid-interval and the
+      # next probe fires within 1s instead of waiting up to 3s.
+      # start_period 10s covers release migrate + Phoenix endpoint listen.
+      # Retry budget: 10s start_period + 60*1s = 70s before docker marks
+      # container failed (was 3s + 15*3s = 48s) — slightly more lenient but
+      # ready-detection is much tighter on the happy path.
       test: ["CMD-SHELL", "curl -sf http://localhost:4000/api/health || exit 1"]
-      start_period: 3s
-      interval: 3s
-      timeout: 3s
-      retries: 15
+      start_period: 10s
+      interval: 1s
+      timeout: 2s
+      retries: 60
     depends_on:
       postgres:
         condition: service_healthy
@@ -79,9 +86,9 @@ services:
       POSTGRES_DB: engram
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U engram"]
-      interval: 3s
-      timeout: 3s
-      retries: 10
+      interval: 1s
+      timeout: 2s
+      retries: 30
     restart: "no"
 
   minio:
@@ -92,9 +99,9 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      interval: 1s
+      timeout: 3s
+      retries: 30
     restart: "no"
 
   minio-init:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.82",
+      version: "0.5.84",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
Engram CI stack \`Start CI stack\` step burned ~10s on coarse healthcheck intervals while BEAM/postgres/minio were already ready mid-interval. Drop interval to 1s on all three services.

| service | before | after |
|---------|--------|-------|
| engram  | start_period 3s, interval 3s, retries 15 (48s budget) | start_period 10s, interval 1s, retries 60 (70s budget) |
| postgres | interval 3s, retries 10 (30s) | interval 1s, retries 30 (30s) |
| minio | interval 5s, retries 5 (25s) | interval 1s, retries 30 (30s) |

Same or slightly larger total retry budget, but \`docker compose --wait\` detects "healthy" within 1s of the service actually being ready (instead of up to 3-5s late).

## Test plan
- [x] mix.exs bumped to 0.5.84
- [ ] CI green
- [ ] Compare \`Start CI stack\` step duration vs prior runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)