### PR TITLE
perf(ci): skip test jobs on main when tree fingerprint already proved green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,60 @@ env:
   ENCRYPTION_MASTER_KEY: ${{ secrets.CI_ENCRYPTION_MASTER_KEY }}
 
 jobs:
+  # Fingerprint: content-hash of every source path that affects test
+  # results. If the same hash already produced a green CI run, downstream
+  # test jobs skip entirely and deploy-fastraid (on main) runs against
+  # the already-validated tree.
+  #
+  # The merge-to-main commit produced by a squash merge has the same
+  # `git ls-tree` output as the PR's head commit — same content, same
+  # fingerprint, same cache key. PR CI proves the tree; main CI doesn't
+  # need to re-run 5+ minutes of e2e for the same bits.
+  fingerprint:
+    # Runs on every trigger (push, repository_dispatch, workflow_dispatch).
+    # Cross-repo plugin dispatch has its own checkout shape but `git ls-tree`
+    # still works as long as the backend repo is checked out.
+    runs-on: [self-hosted, engram, isolated]
+    outputs:
+      hash: ${{ steps.compute.outputs.hash }}
+      cache-hit: ${{ steps.lookup.outputs.cache-hit }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compute content fingerprint
+        id: compute
+        run: |
+          # `git ls-tree -r HEAD -- <paths>` emits `<mode> <type> <sha>\t<path>`
+          # per file. Hashing this is a stable content-digest that ignores
+          # commit metadata (author, date, message). Same content = same hash
+          # even across rebases, squashes, and re-commits.
+          #
+          # Includes the workflow itself so any CI change forces a full run.
+          HASH=$(git ls-tree -r HEAD -- \
+            lib priv config test frontend \
+            Dockerfile entrypoint.sh \
+            mix.exs mix.lock \
+            docker-compose.ci.yml docker-compose.ci-local.yml \
+            .github/workflows/ci.yml \
+            | sha256sum | cut -d' ' -f1)
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "Fingerprint: $HASH"
+
+      - name: Look up prior pass for this fingerprint
+        id: lookup
+        uses: actions/cache/restore@v5
+        with:
+          path: .ci-fingerprint.marker
+          key: ci-pass-${{ steps.compute.outputs.hash }}
+          lookup-only: true
+
+      - name: Report decision
+        run: |
+          if [ "${{ steps.lookup.outputs.cache-hit }}" = "true" ]; then
+            echo "::notice::Fingerprint ${{ steps.compute.outputs.hash }} already proved green — test jobs will skip"
+          else
+            echo "Fingerprint ${{ steps.compute.outputs.hash }} not previously proven — running full test suite"
+          fi
+
   version-check:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -59,6 +113,8 @@ jobs:
           echo "Version bumped: $MAIN_VERSION → $BRANCH_VERSION"
 
   e2e-clerk:
+    needs: fingerprint
+    if: needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -493,8 +549,10 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   unit-tests:
+    needs: fingerprint
     # Skip on cross-repo plugin dispatch — plugin can't regress backend ExUnit.
-    if: github.event_name != 'repository_dispatch'
+    # Also skip when fingerprint already proved green for this content.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -584,8 +642,10 @@ jobs:
         run: find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   lint:
+    needs: fingerprint
     # Skip on cross-repo plugin dispatch — plugin can't regress backend lints.
-    if: github.event_name != 'repository_dispatch'
+    # Also skip when fingerprint already proved green.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     steps:
@@ -658,9 +718,11 @@ jobs:
           mix dialyzer --quiet
 
   e2e-local:
+    needs: fingerprint
     # Skip on cross-repo plugin dispatch — plugin uses Clerk JWTs in production,
     # so the local-auth API path is backend-internal.
-    if: github.event_name != 'repository_dispatch'
+    # Also skip when fingerprint already proved green.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -783,9 +845,11 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   e2e-browser:
+    needs: fingerprint
     # Skip on cross-repo plugin dispatch — Playwright targets backend's React
     # frontend, which the plugin (separate repo) cannot affect.
-    if: github.event_name != 'repository_dispatch'
+    # Also skip when fingerprint already proved green.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -926,8 +990,8 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   ci:
-    if: always()
-    needs: [version-check, unit-tests, lint, e2e-clerk, e2e-local, e2e-browser]
+    if: always() && needs.fingerprint.outputs.cache-hit != 'true'
+    needs: [fingerprint, version-check, unit-tests, lint, e2e-clerk, e2e-local, e2e-browser]
     runs-on: ubuntu-latest
     steps:
       - name: Check required jobs
@@ -963,9 +1027,32 @@ jobs:
             fi
           done
 
+  # Cache the green-CI fingerprint so the *next* run with the same tree
+  # (typically the squash-merge to main) can skip the full test suite.
+  record-pass:
+    if: always() && needs.ci.result == 'success'
+    needs: [fingerprint, ci]
+    runs-on: [self-hosted, engram, isolated]
+    steps:
+      - name: Write fingerprint marker
+        run: echo "passed at $(date -u +%FT%TZ) on ${GITHUB_SHA}" > .ci-fingerprint.marker
+      - name: Save to cache
+        uses: actions/cache/save@v5
+        with:
+          path: .ci-fingerprint.marker
+          key: ci-pass-${{ needs.fingerprint.outputs.hash }}
+
   deploy-fastraid:
-    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.ci.result == 'success'
-    needs: [ci]
+    # Deploy when EITHER (a) full CI just succeeded OR (b) fingerprint
+    # already proved green for this tree. Branch protection should still
+    # require the `ci` check on PRs; this only kicks in on the main push
+    # whose tree has been validated upstream.
+    if: |
+      always()
+      && github.ref == 'refs/heads/main'
+      && github.event_name == 'push'
+      && (needs.ci.result == 'success' || needs.fingerprint.outputs.cache-hit == 'true')
+    needs: [fingerprint, ci]
     runs-on: [self-hosted, engram, isolated]
     permissions:
       packages: write

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.82",
+      version: "0.5.85",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
Squash merges produce a commit whose **tree** is identical to the PR's head. The PR's CI already validated that tree — re-running 5+ min of tests on main is wasted runtime + extra deploy latency. This adds a content-fingerprint short-circuit.

### Mechanism
- **\`fingerprint\` job** (new): hashes every source path that affects test outcomes via \`git ls-tree -r HEAD -- <paths>\`. Paths covered: \`lib priv config test frontend Dockerfile entrypoint.sh mix.exs mix.lock docker-compose.ci*.yml .github/workflows/ci.yml\`.
- **Cache lookup**: \`actions/cache/restore@v5\` with \`lookup-only: true\` and key \`ci-pass-<hash>\`. Sets \`cache-hit\` output.
- **Test jobs** (unit-tests, lint, e2e-clerk, e2e-local, e2e-browser): gated on \`needs.fingerprint.outputs.cache-hit != 'true'\`. Skipped entirely on cache hit.
- **\`ci\` aggregator**: also gated on cache-hit, so it doesn't fail when all upstream jobs are skipped.
- **\`record-pass\` job** (new): on green CI, writes a marker and saves to \`ci-pass-<hash>\`. Next run with same tree → cache hit.
- **\`deploy-fastraid\`**: now accepts EITHER \`needs.ci.result == 'success'\` OR \`needs.fingerprint.outputs.cache-hit == 'true'\`.

### Why this is safe
- Branch protection enforces required checks on the **PR head commit**, not the merge commit. PR's CI runs in full. The merge to main is the only run that skips.
- The fingerprint includes \`ci.yml\` itself, so any workflow change forces a full re-run.
- actions/cache TTL is 7 days untouched — fingerprints older than that fall out and pay one full run.

### Expected impact
- PR push: full CI as today (~3-4 min). Now also saves cache.
- Merge to main: **fingerprint job (~3s) + deploy-fastraid (~3 min)**. Saves 5+ min off every merge.

## Test plan
- [ ] First push to this branch: fingerprint should cache-miss (workflow itself changed), full CI runs
- [ ] Verify \`record-pass\` job completes
- [ ] After merge to main: fingerprint should cache-hit, all test jobs skip, deploy runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)