### PR TITLE
perf(ci): pre-build engram image once, share across e2e-* jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,51 @@ env:
   ENCRYPTION_MASTER_KEY: ${{ secrets.CI_ENCRYPTION_MASTER_KEY }}
 
 jobs:
+  # Build the CI engram image ONCE per CI run. All e2e-* jobs share the
+  # same docker daemon on this VM, so a single `docker tag` here makes
+  # the image visible to every downstream runner without registry push.
+  #
+  # Image tag = content hash of every source path the Dockerfile reads.
+  # Identical trees across runs reuse the same tag → docker image inspect
+  # short-circuits the build entirely.
+  prebuild-ci-image:
+    if: github.event_name != 'repository_dispatch'
+    runs-on: [self-hosted, engram, isolated]
+    outputs:
+      image: ${{ steps.tag.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          # `git ls-tree -r HEAD -- <paths>` is content-stable across
+          # rebases/squashes/timestamps. Hash whatever the Dockerfile copies.
+          HASH=$(git ls-tree -r HEAD -- \
+            Dockerfile entrypoint.sh \
+            mix.exs mix.lock \
+            config lib priv frontend \
+            | sha256sum | cut -c1-12)
+          IMAGE="engram-ci:${HASH}"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "Image tag: $IMAGE"
+
+      - name: Build image (skip if already cached on this daemon)
+        env:
+          IMAGE: ${{ steps.tag.outputs.image }}
+        run: |
+          if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "::notice::Image $IMAGE already cached locally — skipping build"
+            exit 0
+          fi
+
+          # Build through compose to keep one Dockerfile/context definition.
+          # ENGRAM_CI_IMAGE drives the `image:` tag in docker-compose.ci.yml.
+          ENGRAM_CI_IMAGE="$IMAGE" \
+            docker compose -f docker-compose.ci.yml build engram
+          docker image inspect "$IMAGE" >/dev/null
+          echo "Built and tagged $IMAGE"
+
   version-check:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -59,6 +104,7 @@ jobs:
           echo "Version bumped: $MAIN_VERSION → $BRANCH_VERSION"
 
   e2e-clerk:
+    needs: prebuild-ci-image
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -67,6 +113,7 @@ jobs:
       MARKER_PREFIX: /tmp/ci-${{ github.run_id }}
       E2E_VAULT_PREFIX: /tmp/e2e-vault-${{ github.run_id }}
       E2E_CONFIG_PREFIX: /tmp/e2e-obsidian-config-${{ github.run_id }}
+      ENGRAM_CI_IMAGE: ${{ needs.prebuild-ci-image.outputs.image }}
 
     steps:
       # ------------------------------------------------------------------
@@ -197,25 +244,11 @@ jobs:
             # Clean up stale CI collection on SlowRaid Qdrant before starting
             curl -sf -X DELETE "http://10.0.20.201:6333/collections/${QDRANT_COLLECTION}" > /dev/null 2>&1 || true
 
-            # Hash source files that affect the Docker image — skip rebuild if unchanged
-            IMG_HASH=$(find Dockerfile docker-compose.ci.yml mix.exs mix.lock config/ lib/ priv/ frontend/ \
-              -type f 2>/dev/null | sort | xargs md5sum 2>/dev/null | md5sum | cut -d' ' -f1)
-            CACHED_TAG="engram-ci:${IMG_HASH}"
-
-            if docker image inspect "$CACHED_TAG" > /dev/null 2>&1; then
-              echo "Image $CACHED_TAG exists — skipping build"
-              docker tag "$CACHED_TAG" ${CI_PROJECT}-engram:latest
-              docker compose -f docker-compose.ci.yml -p "$CI_PROJECT" up -d --no-build --wait
-            else
-              echo "Image cache miss ($CACHED_TAG) — building"
-              docker compose -f docker-compose.ci.yml -p "$CI_PROJECT" up -d --build --wait
-              # Tag the built image for future cache hits
-              BUILT_IMG=$(docker images --format '{{.ID}}' --filter "reference=${CI_PROJECT}-engram" | head -1)
-              if [ -n "$BUILT_IMG" ]; then
-                docker tag "$BUILT_IMG" "$CACHED_TAG"
-                echo "Tagged $BUILT_IMG as $CACHED_TAG"
-              fi
-            fi
+            # Image was already built by the `prebuild-ci-image` job.
+            # ENGRAM_CI_IMAGE pins docker-compose.ci.yml's `image:` to that
+            # exact tag. `--no-build` makes startup fail loudly if the tag
+            # is missing (regression detector vs a silent rebuild).
+            docker compose -f docker-compose.ci.yml -p "$CI_PROJECT" up -d --no-build --wait
 
             # Quick verification — compose --wait already confirmed healthcheck,
             # this just confirms the port mapping is reachable from the host
@@ -658,6 +691,7 @@ jobs:
           mix dialyzer --quiet
 
   e2e-local:
+    needs: prebuild-ci-image
     # Skip on cross-repo plugin dispatch — plugin uses Clerk JWTs in production,
     # so the local-auth API path is backend-internal.
     if: github.event_name != 'repository_dispatch'
@@ -666,6 +700,7 @@ jobs:
     env:
       CI_PROJECT: engram-ci-local-${{ github.run_id }}
       QDRANT_COLLECTION: ci_local_${{ github.run_id }}
+      ENGRAM_CI_IMAGE: ${{ needs.prebuild-ci-image.outputs.image }}
 
     steps:
       - name: Reset sparse-checkout leaked from cross-repo jobs
@@ -713,24 +748,11 @@ jobs:
           # Clean up stale Qdrant collection
           curl -sf -X DELETE "http://10.0.20.201:6333/collections/${QDRANT_COLLECTION}" > /dev/null 2>&1 || true
 
-          # Reuse cached image if available, otherwise build
-          IMG_HASH=$(find Dockerfile docker-compose.ci.yml mix.exs mix.lock config/ lib/ priv/ frontend/ \
-            -type f 2>/dev/null | sort | xargs md5sum 2>/dev/null | md5sum | cut -d' ' -f1)
-          CACHED_TAG="engram-ci:${IMG_HASH}"
-
-          if docker image inspect "$CACHED_TAG" > /dev/null 2>&1; then
-            echo "Image $CACHED_TAG exists — skipping build"
-            docker tag "$CACHED_TAG" ${CI_PROJECT}-engram:latest
-            docker compose -f docker-compose.ci.yml -f docker-compose.ci-local.yml \
-              -p "$CI_PROJECT" up -d --no-build --wait
-          else
-            docker compose -f docker-compose.ci.yml -f docker-compose.ci-local.yml \
-              -p "$CI_PROJECT" up -d --build --wait
-            BUILT_IMG=$(docker images --format '{{.ID}}' --filter "reference=${CI_PROJECT}-engram" | head -1)
-            if [ -n "$BUILT_IMG" ]; then
-              docker tag "$BUILT_IMG" "$CACHED_TAG"
-            fi
-          fi
+          # Image was already built by `prebuild-ci-image`. ENGRAM_CI_IMAGE
+          # pins docker-compose.ci.yml's `image:` to that tag and --no-build
+          # fails loudly if missing instead of silently rebuilding.
+          docker compose -f docker-compose.ci.yml -f docker-compose.ci-local.yml \
+            -p "$CI_PROJECT" up -d --no-build --wait
 
           # Wait for health
           for i in $(seq 1 60); do

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,6 +18,10 @@ name: engram-ci
 
 services:
   engram:
+    # Pre-built tag from the CI `prebuild-ci-image` job — all e2e-* jobs
+    # share this image via the runner VM's shared docker daemon. Local dev
+    # falls back to `engram-ci:local` (built by `docker compose build`).
+    image: ${ENGRAM_CI_IMAGE:-engram-ci:local}
     build:
       context: .
       args:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.82",
+      version: "0.5.86",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
Replaces 5 parallel \`mix release\` builds with a single prebuilt image shared across e2e-* jobs via the runner VM's shared docker daemon.

### Mechanism
- **\`prebuild-ci-image\` job** (new, runs first): computes content hash of Dockerfile inputs via \`git ls-tree\`, tags as \`engram-ci:<hash>\`. \`docker image inspect\` short-circuits if the tag already exists on this daemon (cross-PR reuse for identical trees).
- **e2e-clerk + e2e-local**: \`needs: prebuild-ci-image\`. Env \`ENGRAM_CI_IMAGE\` set to the prebuilt tag, consumed by \`docker-compose.ci.yml\`'s new \`image:\` directive.
- **\`docker compose up\` invocations**: now \`--no-build\` everywhere in CI (was \`--build\` on cache miss). Fails loudly if the tag is missing instead of silently rebuilding.
- **e2e-browser**: unaffected (uses local \`mix phx.server\`, not docker compose).

### Why this fixes the contention
On a 9-core VM with 5 isolated runners, each e2e-* job spawning \`docker compose --build\` triggers a full \`mix release\` (no \`_build\` cache mount on that step, intentionally — see Dockerfile comment about stale beams). 5 parallel BEAM compiles = ~25 compile workers fighting for 9 cores. Recent run measured 4+ minutes for e2e-clerk's "Wait for CI stack" step, vs ~21s on uncontended runs.

This PR makes that build happen once per CI run. \`prebuild-ci-image\` is a single CPU-bound step; the e2e-* jobs that follow are I/O-bound (docker run + tests).

### Expected impact
- **Single-run wall clock**: -60s to -180s on contended runs (the dominant source of variance)
- **Identical-tree reruns**: \`docker image inspect\` short-circuits build, ~5s prebuild step instead of 60s
- **CPU peak**: ~50% lower during the e2e fan-out window

### Compatibility
- Local dev (\`docker compose up --build\`): unchanged. \`ENGRAM_CI_IMAGE\` defaults to \`engram-ci:local\`, \`build:\` directive preserved.
- Image cleanup: existing teardown step (\`docker images ... | tail -n +4 | xargs -r docker rmi\`) still applies — \`engram-ci:<hash>\` tags rotate at 3 most recent.

## Test plan
- [ ] CI green on this PR
- [ ] Compare e2e-clerk "Wait for CI stack" step time vs prior 4-min run
- [ ] Verify prebuild-ci-image step ran (look for \`Image tag: engram-ci:<hash>\` in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)