### PR TITLE
perf(ci): pipeline tuning — healthchecks + fingerprint skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,62 @@ env:
   ENCRYPTION_MASTER_KEY: ${{ secrets.CI_ENCRYPTION_MASTER_KEY }}
 
 jobs:
-  # Build the CI engram image ONCE per CI run. All e2e-* jobs share the
-  # same docker daemon on this VM, so a single `docker tag` here makes
-  # the image visible to every downstream runner without registry push.
+  # Fingerprint: content-hash of every source path that affects test
+  # results. If the same hash already produced a green CI run, downstream
+  # test jobs AND the image prebuild skip entirely — deploy-fastraid (on
+  # main) runs against the already-validated tree.
   #
-  # Image tag = content hash of every source path the Dockerfile reads.
-  # Identical trees across runs reuse the same tag → docker image inspect
-  # short-circuits the build entirely.
+  # The merge-to-main commit produced by a squash merge has the same
+  # `git ls-tree` output as the PR's head commit — same content, same
+  # fingerprint, same cache key.
+  fingerprint:
+    # Runs on every trigger (push, repository_dispatch, workflow_dispatch).
+    runs-on: [self-hosted, engram, isolated]
+    outputs:
+      hash: ${{ steps.compute.outputs.hash }}
+      cache-hit: ${{ steps.lookup.outputs.cache-hit }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compute content fingerprint
+        id: compute
+        run: |
+          # `git ls-tree -r HEAD -- <paths>` emits `<mode> <type> <sha>\t<path>`
+          # per file. Hashing this is content-stable across rebases/squashes.
+          # Includes the workflow itself so any CI change forces a full run.
+          HASH=$(git ls-tree -r HEAD -- \
+            lib priv config test frontend \
+            Dockerfile entrypoint.sh \
+            mix.exs mix.lock \
+            docker-compose.ci.yml docker-compose.ci-local.yml \
+            .github/workflows/ci.yml \
+            | sha256sum | cut -d' ' -f1)
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "Fingerprint: $HASH"
+
+      - name: Look up prior pass for this fingerprint
+        id: lookup
+        uses: actions/cache/restore@v5
+        with:
+          path: .ci-fingerprint.marker
+          key: ci-pass-${{ steps.compute.outputs.hash }}
+          lookup-only: true
+
+      - name: Report decision
+        run: |
+          if [ "${{ steps.lookup.outputs.cache-hit }}" = "true" ]; then
+            echo "::notice::Fingerprint ${{ steps.compute.outputs.hash }} already proved green — test jobs will skip"
+          else
+            echo "Fingerprint ${{ steps.compute.outputs.hash }} not previously proven — running full test suite"
+          fi
+
+  # Build the CI engram image ONCE per CI run. All e2e-* jobs share the
+  # same docker daemon on this VM, so a single `docker tag` makes the
+  # image visible to every downstream runner without registry push.
+  # Image tag = content-stable hash of Dockerfile inputs; identical trees
+  # short-circuit via `docker image inspect`.
   prebuild-ci-image:
-    if: github.event_name != 'repository_dispatch'
+    needs: fingerprint
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
     outputs:
       image: ${{ steps.tag.outputs.image }}
@@ -57,8 +104,6 @@ jobs:
       - name: Compute image tag
         id: tag
         run: |
-          # `git ls-tree -r HEAD -- <paths>` is content-stable across
-          # rebases/squashes/timestamps. Hash whatever the Dockerfile copies.
           HASH=$(git ls-tree -r HEAD -- \
             Dockerfile entrypoint.sh \
             mix.exs mix.lock \
@@ -76,9 +121,6 @@ jobs:
             echo "::notice::Image $IMAGE already cached locally — skipping build"
             exit 0
           fi
-
-          # Build through compose to keep one Dockerfile/context definition.
-          # ENGRAM_CI_IMAGE drives the `image:` tag in docker-compose.ci.yml.
           ENGRAM_CI_IMAGE="$IMAGE" \
             docker compose -f docker-compose.ci.yml build engram
           docker image inspect "$IMAGE" >/dev/null
@@ -104,7 +146,8 @@ jobs:
           echo "Version bumped: $MAIN_VERSION → $BRANCH_VERSION"
 
   e2e-clerk:
-    needs: prebuild-ci-image
+    needs: [fingerprint, prebuild-ci-image]
+    if: needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -526,8 +569,10 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   unit-tests:
+    needs: fingerprint
     # Skip on cross-repo plugin dispatch — plugin can't regress backend ExUnit.
-    if: github.event_name != 'repository_dispatch'
+    # Also skip when fingerprint already proved green for this content.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -617,8 +662,10 @@ jobs:
         run: find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   lint:
+    needs: fingerprint
     # Skip on cross-repo plugin dispatch — plugin can't regress backend lints.
-    if: github.event_name != 'repository_dispatch'
+    # Also skip when fingerprint already proved green.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     steps:
@@ -691,10 +738,11 @@ jobs:
           mix dialyzer --quiet
 
   e2e-local:
-    needs: prebuild-ci-image
+    needs: [fingerprint, prebuild-ci-image]
     # Skip on cross-repo plugin dispatch — plugin uses Clerk JWTs in production,
     # so the local-auth API path is backend-internal.
-    if: github.event_name != 'repository_dispatch'
+    # Also skip when fingerprint already proved green.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -805,9 +853,11 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   e2e-browser:
+    needs: fingerprint
     # Skip on cross-repo plugin dispatch — Playwright targets backend's React
     # frontend, which the plugin (separate repo) cannot affect.
-    if: github.event_name != 'repository_dispatch'
+    # Also skip when fingerprint already proved green.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.cache-hit != 'true'
     runs-on: [self-hosted, engram, isolated]
 
     env:
@@ -948,8 +998,8 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   ci:
-    if: always()
-    needs: [version-check, unit-tests, lint, e2e-clerk, e2e-local, e2e-browser]
+    if: always() && needs.fingerprint.outputs.cache-hit != 'true'
+    needs: [fingerprint, version-check, unit-tests, lint, e2e-clerk, e2e-local, e2e-browser]
     runs-on: ubuntu-latest
     steps:
       - name: Check required jobs
@@ -985,9 +1035,32 @@ jobs:
             fi
           done
 
+  # Cache the green-CI fingerprint so the *next* run with the same tree
+  # (typically the squash-merge to main) can skip the full test suite.
+  record-pass:
+    if: always() && needs.ci.result == 'success'
+    needs: [fingerprint, ci]
+    runs-on: [self-hosted, engram, isolated]
+    steps:
+      - name: Write fingerprint marker
+        run: echo "passed at $(date -u +%FT%TZ) on ${GITHUB_SHA}" > .ci-fingerprint.marker
+      - name: Save to cache
+        uses: actions/cache/save@v5
+        with:
+          path: .ci-fingerprint.marker
+          key: ci-pass-${{ needs.fingerprint.outputs.hash }}
+
   deploy-fastraid:
-    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.ci.result == 'success'
-    needs: [ci]
+    # Deploy when EITHER (a) full CI just succeeded OR (b) fingerprint
+    # already proved green for this tree. Branch protection should still
+    # require the `ci` check on PRs; this only kicks in on the main push
+    # whose tree has been validated upstream.
+    if: |
+      always()
+      && github.ref == 'refs/heads/main'
+      && github.event_name == 'push'
+      && (needs.ci.result == 'success' || needs.fingerprint.outputs.cache-hit == 'true')
+    needs: [fingerprint, ci]
     runs-on: [self-hosted, engram, isolated]
     permissions:
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,17 +607,31 @@ jobs:
             PG_IMAGE="postgres:16-alpine"
           fi
 
-          # Use -p 0:5432 for a random available host port (parallel-safe)
-          docker run -d --name "$PG_CONTAINER" \
-            -e POSTGRES_USER=engram \
-            -e POSTGRES_PASSWORD=engram \
-            -e POSTGRES_DB=engram_test \
-            -p 0:5432 \
-            --health-cmd "pg_isready -U engram" \
-            --health-interval 3s \
-            --health-timeout 3s \
-            --health-retries 10 \
-            "$PG_IMAGE"
+          # `docker run -p 0:5432` races concurrent runners on the shared VM:
+          # docker auto-allocates an ephemeral port, but between resolve and
+          # bind another runner (or any process) can claim it. Retry the run
+          # up to 5 times; each retry gets a fresh allocation.
+          for attempt in 1 2 3 4 5; do
+            if docker run -d --name "$PG_CONTAINER" \
+                -e POSTGRES_USER=engram \
+                -e POSTGRES_PASSWORD=engram \
+                -e POSTGRES_DB=engram_test \
+                -p 0:5432 \
+                --health-cmd "pg_isready -U engram" \
+                --health-interval 3s \
+                --health-timeout 3s \
+                --health-retries 10 \
+                "$PG_IMAGE"; then
+              break
+            fi
+            echo "Attempt $attempt: docker run failed (likely port race) — cleaning up + retrying"
+            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            sleep 1
+            if [ "$attempt" = "5" ]; then
+              echo "::error::Postgres container failed to start after 5 attempts"
+              exit 1
+            fi
+          done
 
           PG_PORT=$(docker port "$PG_CONTAINER" 5432/tcp | head -1 | cut -d: -f2)
           echo "pg_port=$PG_PORT" >> "$GITHUB_OUTPUT"
@@ -913,16 +927,28 @@ jobs:
           else
             PG_IMAGE="postgres:16-alpine"
           fi
-          docker run -d --name "$PG_CONTAINER" \
-            -e POSTGRES_USER=engram \
-            -e POSTGRES_PASSWORD=engram \
-            -e POSTGRES_DB=engram_dev \
-            -p 0:5432 \
-            --health-cmd "pg_isready -U engram" \
-            --health-interval 3s \
-            --health-timeout 3s \
-            --health-retries 10 \
-            "$PG_IMAGE"
+          # Retry on ephemeral-port race with sibling runners (see unit-tests).
+          for attempt in 1 2 3 4 5; do
+            if docker run -d --name "$PG_CONTAINER" \
+                -e POSTGRES_USER=engram \
+                -e POSTGRES_PASSWORD=engram \
+                -e POSTGRES_DB=engram_dev \
+                -p 0:5432 \
+                --health-cmd "pg_isready -U engram" \
+                --health-interval 3s \
+                --health-timeout 3s \
+                --health-retries 10 \
+                "$PG_IMAGE"; then
+              break
+            fi
+            echo "Attempt $attempt: docker run failed (likely port race) — cleaning up + retrying"
+            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            sleep 1
+            if [ "$attempt" = "5" ]; then
+              echo "::error::Postgres container failed to start after 5 attempts"
+              exit 1
+            fi
+          done
           PG_PORT=$(docker port "$PG_CONTAINER" 5432/tcp | head -1 | cut -d: -f2)
           echo "pg_port=$PG_PORT" >> "$GITHUB_OUTPUT"
           echo "Postgres on port $PG_PORT"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -61,11 +61,18 @@ services:
       STORAGE_PORT: "9000"
       STORAGE_REGION: us-east-1
     healthcheck:
+      # 1s interval (was 3s) so docker compose --wait detects "ready" with
+      # finer granularity — BEAM cold boot finishes mid-interval and the
+      # next probe fires within 1s instead of waiting up to 3s.
+      # start_period 10s covers release migrate + Phoenix endpoint listen.
+      # Retry budget: 10s start_period + 60*1s = 70s before docker marks
+      # container failed (was 3s + 15*3s = 48s) — slightly more lenient but
+      # ready-detection is much tighter on the happy path.
       test: ["CMD-SHELL", "curl -sf http://localhost:4000/api/health || exit 1"]
-      start_period: 3s
-      interval: 3s
-      timeout: 3s
-      retries: 15
+      start_period: 10s
+      interval: 1s
+      timeout: 2s
+      retries: 60
     depends_on:
       postgres:
         condition: service_healthy
@@ -83,9 +90,9 @@ services:
       POSTGRES_DB: engram
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U engram"]
-      interval: 3s
-      timeout: 3s
-      retries: 10
+      interval: 1s
+      timeout: 2s
+      retries: 30
     restart: "no"
 
   minio:
@@ -96,9 +103,9 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      interval: 1s
+      timeout: 3s
+      retries: 30
     restart: "no"
 
   minio-init:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.86",
+      version: "0.5.88",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
Collapses #123 + #124 into a single pipeline tuning PR (closes both).

### Change 1 — tighten compose healthchecks
\`docker compose --wait\` was detecting "ready" up to 3-5s late because healthchecks polled coarsely. Drop interval to 1s on all three services (engram/postgres/minio); start_period bumped to 10s on engram to cover release migrate + Phoenix listen.

### Change 2 — fingerprint-based skip on main
Squash merges produce a commit whose **tree** matches the PR head's. The PR's CI already validated that tree — re-running 5+ minutes of tests on main is wasted runtime + extra deploy latency.

- New \`fingerprint\` job hashes Dockerfile inputs + test paths + workflow itself via \`git ls-tree -r HEAD\`. \`actions/cache/restore\` with \`lookup-only: true\` sets \`cache-hit\` output.
- All test jobs (unit-tests, lint, e2e-*) AND \`prebuild-ci-image\` gate on \`needs.fingerprint.outputs.cache-hit != 'true'\`. Skipped entirely on hit.
- \`ci\` aggregator also skips on cache hit so its tolerance for "all skipped" inputs doesn't fail.
- \`record-pass\` job saves \`ci-pass-<hash>\` to cache after green CI. Next run with same tree → cache hit.
- \`deploy-fastraid\`: accepts either \`needs.ci.result == 'success'\` OR \`needs.fingerprint.outputs.cache-hit == 'true'\`.

### Safety
- Branch protection enforces required checks on the **PR head commit**, not the merge commit. PR runs full CI. Only the post-merge run skips.
- Fingerprint includes \`ci.yml\` itself → any workflow change forces a full re-run.
- actions/cache TTL is 7 days untouched — old fingerprints fall out naturally.

## Closes
- #123 (collapsed)
- #124 (collapsed)

## Test plan
- [ ] This PR's first push: fingerprint cache-miss (workflow changed), full CI runs
- [ ] After merge: post-merge main run shows fingerprint cache-hit, test jobs skipped, deploy runs immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)