### PR TITLE
ci: restrict push trigger to conventional branch prefixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,23 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    # Only fire on conventional branch prefixes + main. Prevents a fork-PR
+    # branch (no prefix) from running on self-hosted runners if someone
+    # ever fetches one and pushes it to the base repo to test.
+    branches:
+      - main
+      - "bump/**"
+      - "chore/**"
+      - "docs/**"
+      - "feat/**"
+      - "fix/**"
+      - "hotfix/**"
+      - "perf/**"
+      - "refactor/**"
+      - "release/**"
+      - "revert/**"
+      - "security/**"
+      - "test/**"
     tags-ignore: ["v*"]
   repository_dispatch:
     types: [plugin-e2e-trigger]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.92",
+      version: "0.5.93",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- Changes \`push.branches\` from \`["**"]\` to a finite list of conventional prefixes (main, bump/, chore/, docs/, feat/, fix/, hotfix/, perf/, refactor/, release/, revert/, security/, test/).
- Closes one of the pre-open-source audit items: prevents a maintainer accidentally pushing a fetched fork PR branch to the base repo and having it execute on self-hosted runners.

## Why
Self-hosted runners now run the ephemeral JIT pattern (state wiped per job), but defense-in-depth still matters. Restricting the push trigger means a fork-named branch (no prefix) silently no-ops instead of firing CI.

## Test plan
- [ ] Push to this branch \`chore/tighten-ci-push-branches\` triggers CI (covered by \`chore/**\`)
- [ ] After merge, main pushes continue to trigger CI
- [ ] \`workflow_dispatch\` continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)