### PR TITLE
chore: wire CLA Assistant Lite workflow

### DIFF
--- a/.github/cla-signatures.json
+++ b/.github/cla-signatures.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}

--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -1,0 +1,43 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Allow only one concurrent CLA run per PR; cancel older runs.
+concurrency:
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-check:
+    # Only run when relevant: PR events, or the recheck / signing comment.
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       (github.event.comment.body == 'recheck' ||
+        github.event.comment.body == 'I have read the Engram Contributor License Agreement v1.0 and I hereby sign the CLA.'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA check
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: .github/cla-signatures.json
+          path-to-document: https://github.com/Rasbandit/Engram/blob/main/.github/CLA.md
+          branch: main
+          allowlist: dependabot[bot],renovate[bot]
+          custom-pr-sign-comment: I have read the Engram Contributor License Agreement v1.0 and I hereby sign the CLA.
+          custom-notsigned-prcomment: |
+            Thank you for your contribution. Before we can merge this pull request, please read the Engram Contributor License Agreement and confirm by posting the following comment exactly:
+          custom-allsigned-prcomment: All contributors have signed the CLA — thanks.
+          lock-pullrequest-aftermerge: false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.93",
+      version: "0.5.94",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Wires the Apache-style CLA from PR #117 into GitHub PR enforcement using **CLA Assistant Lite** (`contributor-assistant/github-action`). No third-party SaaS — signatures are committed to this repo.

## Files

| File | Purpose |
|------|---------|
| `.github/workflows/cla-assistant.yml` | Triggers on PR open/sync and issue-comment events; checks PR author against signed list, posts sign-prompt if missing |
| `.github/cla-signatures.json` | Initial empty signatures registry; the bot appends here on accepted sign comments |

## How signing works

When a new contributor opens a PR, the bot comments with the CLA link and the exact sign-line. To accept, the contributor pastes this comment **verbatim**:

> I have read the Engram Contributor License Agreement v1.0 and I hereby sign the CLA.

The bot validates and commits their GitHub identity + timestamp into `.github/cla-signatures.json` on `main`. They're auto-cleared for all future PRs.

## Trust model

- Uses default `GITHUB_TOKEN` (workflow-scoped, no PAT needed)
- Workflow runs on `pull_request_target` so it has write access even for forked PRs — but only checks out base; never executes PR-supplied code
- `dependabot[bot]` and `renovate[bot]` are allowlisted (no CLA prompt)

## Test plan

- [ ] Workflow file syntax valid (CI parses on push)
- [ ] After merge: open a throwaway PR from a fresh account, confirm bot comments with sign prompt
- [ ] Post the sign comment, confirm bot updates signatures.json and clears the check
- [ ] Open a second PR from same account, confirm no re-prompt

## Notes for reviewer

- If `main` has branch protection requiring PR review, the bot's automated signature commit might be blocked. If so, either (a) add a branch-protection exception for `github-actions[bot]`, or (b) flip the action's `branch` setting to a dedicated `cla-signatures` branch and merge periodically.
- Bumps `mix.exs` 0.5.93 → 0.5.94 per pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)