### PR TITLE
chore(ci): switch app-id → client-id (v3 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.ENGRAM_CI_APP_ID }}
+          client-id: ${{ vars.ENGRAM_CI_CLIENT_ID }}
           private-key: ${{ secrets.ENGRAM_CI_APP_PRIVATE_KEY }}
           owner: engram-app
           repositories: Engram-obsidian-sync
@@ -365,7 +365,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.ENGRAM_CI_APP_ID }}
+          client-id: ${{ vars.ENGRAM_CI_CLIENT_ID }}
           private-key: ${{ secrets.ENGRAM_CI_APP_PRIVATE_KEY }}
           owner: engram-app
           repositories: Engram-obsidian-sync
@@ -1401,7 +1401,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.ENGRAM_CI_APP_ID }}
+          client-id: ${{ vars.ENGRAM_CI_CLIENT_ID }}
           private-key: ${{ secrets.ENGRAM_CI_APP_PRIVATE_KEY }}
           owner: engram-app
           repositories: Engram-obsidian-sync

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.104",
+      version: "0.5.105",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- `actions/create-github-app-token@v3` deprecated `app-id` in favor of `client-id`.
- Adds reference to new org var `ENGRAM_CI_CLIENT_ID` (set: `Iv23liXtAqueYXiDMD1r`).
- Old org var `ENGRAM_CI_APP_ID` can be deleted post-merge.

## Test plan
- [ ] CI green; deprecation warning gone from `fingerprint` + `e2e-clerk` jobs