### PR TITLE
feat(paddle): wire frontend overlay to /api/billing/config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "paddle-docs": {
+      "type": "http",
+      "url": "https://paddlehq.mcp.kapa.ai"
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,111 @@
+.PHONY: help deps dev dev-selfhost dev-stop test backend-build backend-up backend-down frontend-install frontend-build frontend-dev ci-up ci-down ci-e2e e2e bench-dataset bench-quality bench-perf bench-reranking bench-cost bench-all bench-report bench-list parity-mix parity-bash parity-ci-up parity-ci-down gen-master-key
+
+help:              ## List available targets
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# --- Dev (local Phoenix against staging services) ---
+
+deps:              ## Fetch Elixir + frontend deps
+	mix deps.get
+	cd frontend && bun install
+
+dev:               ## Start local Phoenix dev server (SaaS shape: Voyage + Clerk, port 4000)
+	env $$(grep -v '^\#' .env.local | grep -v '^$$' | xargs) mix phx.server
+
+dev-selfhost:      ## Start local Phoenix dev server (selfhost shape: Ollama + local auth, port 4001)
+	env $$(grep -v '^\#' .env.local-selfhost | grep -v '^$$' | xargs) mix phx.server
+
+dev-stop:          ## Stop local Phoenix dev server (and any orphan Vite processes)
+	@pkill -f "mix phx.server" 2>/dev/null && echo "Phoenix stopped" || echo "Phoenix not running"
+	@# Phoenix's watcher spawns node-vite as a Port child. SIGKILL on BEAM
+	@# leaves the OS-level node listening on :5173+, so reap any orphans here.
+	@for port in $$(seq 5173 5199); do \
+	  pid=$$(lsof -t -iTCP:$$port -sTCP:LISTEN 2>/dev/null); \
+	  if [ -n "$$pid" ]; then kill -9 $$pid 2>/dev/null && echo "Killed stray Vite on :$$port (pid $$pid)"; fi; \
+	done
+
+# --- Backend ---
+
+test:              ## Run mix test
+	mix test
+
+backend-build:     ## Build engram_elixir docker image
+	docker compose -f docker-compose.elixir.yml build engram_elixir
+
+backend-up:        ## Start full Elixir stack (Phoenix + Postgres + Qdrant)
+	docker compose -f docker-compose.elixir.yml up -d --wait
+
+backend-down:      ## Stop Elixir stack
+	docker compose -f docker-compose.elixir.yml down
+
+# --- Frontend ---
+
+frontend-install:  ## Install frontend deps via bun
+	cd frontend && bun install
+
+frontend-build:    ## Build frontend (vite → priv/static/app)
+	cd frontend && bun run build
+
+frontend-dev:      ## Run Vite dev server standalone
+	cd frontend && bun run dev
+
+# --- CI Stack ---
+
+ci-up:             ## Start CI stack (port 8100)
+	docker compose -f docker-compose.ci.yml -p engram-ci up -d --build --wait
+
+ci-down:           ## Tear down CI stack
+	docker compose -f docker-compose.ci.yml -p engram-ci down -v --remove-orphans
+
+ci-e2e: ci-up      ## Bring up CI stack and run e2e tests
+	cd e2e && ENGRAM_API_URL=http://localhost:8100 python3 -m pytest tests/ -v
+
+# --- E2E ---
+
+e2e:               ## Run e2e tests against http://localhost:8100
+	cd e2e && ENGRAM_API_URL=http://localhost:8100 python3 -m pytest tests/ -v
+
+# --- Embedding Benchmarks ---
+
+bench-dataset:     ## Build benchmark dataset
+	python3 -m benchmarks build-dataset --save-raw
+
+bench-quality:     ## Run quality benchmarks
+	python3 -m benchmarks run quality
+
+bench-perf:        ## Run performance benchmarks
+	python3 -m benchmarks run performance
+
+bench-reranking:   ## Run reranker benchmarks
+	python3 -m benchmarks run reranking
+
+bench-cost:        ## Run cost benchmarks
+	python3 -m benchmarks run cost
+
+bench-all:         ## Run every benchmark
+	python3 -m benchmarks run all
+
+bench-report:      ## Generate consolidated benchmark report
+	python3 -m benchmarks report
+
+bench-list:        ## List configured embedding models
+	python3 -m benchmarks list models
+
+# --- Parity Validation ---
+
+parity-mix:        ## Run mix parity.validate (internal module validation)
+	env $$(grep -v '^\#' .env.elixir | grep -v '^$$' | xargs) mix parity.validate
+
+parity-bash:       ## Run validate_parity.sh (deployed system validation)
+	VOYAGE_API_KEY=$${VOYAGE_API_KEY} bash validate_parity.sh
+
+parity-ci-up:      ## Start CI stack in parity mode (requires VOYAGE_API_KEY)
+	VOYAGE_API_KEY=$${VOYAGE_API_KEY} docker compose -f docker-compose.ci.yml -f docker-compose.parity.yml -p engram-ci up -d --build --wait
+
+parity-ci-down:    ## Tear down parity CI stack
+	docker compose -f docker-compose.ci.yml -f docker-compose.parity.yml -p engram-ci down -v --remove-orphans
+
+# --- Dev UX ---
+
+gen-master-key:    ## Generate base64 master key
+	@openssl rand -base64 32

--- a/docs/superpowers/plans/2026-05-14-paddle-frontend-overlay.md
+++ b/docs/superpowers/plans/2026-05-14-paddle-frontend-overlay.md
@@ -1,0 +1,73 @@
+# Paddle frontend overlay rewrite — handoff
+
+**Status:** session interrupted before code changes started. No branch cut yet. Working dir on `chore/app-token-client-id` (unrelated CI cleanup).
+
+## Context
+
+Paddle backend cutover is **done and merged on main** (PR #132, 2026-05-14). All Stripe code/cols/deps removed; `Engram.Paddle.Client` behaviour + Req HTTP impl, `Engram.Billing` event upserter, webhook signature verify, three billing endpoints all wired and tested.
+
+The frontend `frontend/src/billing/billing-page.tsx` is **stale** — still calls dead Stripe-style endpoints (`POST /billing/checkout-session`, `GET /billing/portal`) and renders "Manage subscription in Stripe" copy. This blocks revenue.
+
+See `docs/context/paddle-integration.md` for the full backend spec, webhook signature format, `custom_data` contract, and event lifecycle table.
+
+## Backend endpoints the frontend must consume
+
+Defined in `lib/engram_web/router.ex:152-157` (under `/api`, requires auth):
+
+| Method | Path | Returns |
+|--------|------|---------|
+| GET | `/api/billing/status` | `{tier, active, trial_days_remaining, subscription: {status, tier, current_period_end} \| null}` |
+| GET | `/api/billing/config` | `{client_token, environment, price_ids: {starter, pro}, customer_email, custom_data: {user_id}}` |
+| GET | `/api/billing/portal` | `{url}` (controller action `:customer_portal`) |
+
+Note: there is **no** `/billing/checkout-session` endpoint anymore. The whole point of Paddle is the overlay opens client-side after fetching `/api/billing/config`.
+
+## Decisions reached this session
+
+1. **Paddle.js loader:** `@paddle/paddle-js` npm package (typed React-friendly wrapper, version-pinned). Not the CDN script tag.
+2. **PR scope:** full overlay rewrite in one PR — `billing-page.tsx` end-to-end, including config fetch, `Paddle.Initialize`, `Paddle.Checkout.open`, portal handler swap, and Stripe copy strip. Affiliate/utm cookie capture deferred to a follow-up.
+3. **Test path:** ship the rewrite without unit tests, add vitest infra in a separate repo-wide PR. Frontend has zero unit-test infrastructure today (only Playwright e2e in `e2e/`). Backend already has thorough Paddle coverage. Manual verify via Paddle sandbox + `paddle notification simulate` is acceptable for this PR.
+4. **Branch:** cut `feat/paddle-overlay` off `main` (NOT off the current `chore/app-token-client-id` branch).
+
+## Concrete plan (resume here)
+
+1. Restart session so the new `paddle-docs` MCP server (now in repo `.mcp.json`) loads. First call will trigger Kapa.ai OAuth in browser.
+2. **Validate decisions against the MCP** before touching code — especially:
+   - Confirm `@paddle/paddle-js` `initializePaddle({ token, environment })` API signature.
+   - Confirm `Paddle.Checkout.open({ items: [{ priceId, quantity }], customer: { email }, customData, settings: { successUrl } })` is the current shape.
+   - Confirm `customer_portal` is fetched server-side (Paddle API → returns hosted URL) and not opened via paddle.js — this is what `lib/engram/paddle/client/http.ex` already implements.
+   - Look for any newer recommended pattern (e.g. `Paddle.Update`, dynamic price discovery) we should adopt.
+3. From `main`: `git switch main && git pull && git switch -c feat/paddle-overlay`.
+4. `cd frontend && npm install @paddle/paddle-js`.
+5. Add `useBillingConfig()` query in `frontend/src/api/queries.ts` mirroring existing `useBillingStatus()` (line 138).
+6. Rewrite `frontend/src/billing/billing-page.tsx`:
+   - `useEffect` → call `initializePaddle({ token, environment })` once config is loaded; cache the resolved Paddle instance.
+   - `handleCheckout(tier)` → `paddle.Checkout.open({ items: [{ priceId: cfg.price_ids[tier], quantity: 1 }], customer: { email: cfg.customer_email }, customData: cfg.custom_data, settings: { successUrl: window.location.origin + '/billing?status=success' } })`.
+   - `handlePortal()` → keep `GET /billing/portal` (api client base prepends `/api`); confirm path resolves to `/api/billing/portal` not the old `/billing/portal`.
+   - Strip "Manage subscription in **Stripe**" → "Manage subscription".
+7. Manual verify against Paddle sandbox:
+   - Set `PADDLE_*` env vars per `docs/context/paddle-integration.md#sandbox-dev`.
+   - Open `/billing` in dev, click Start free trial → overlay should appear.
+   - `paddle notification simulate --notification-type subscription.created --destination http://localhost:4000/webhooks/paddle` → confirm row inserted with `custom_data.user_id`.
+8. Open PR. Title: `feat(paddle): wire frontend overlay to /api/billing/config`. Body: link to this doc + PR #132.
+
+## Key files to touch
+
+- `frontend/src/billing/billing-page.tsx` — full rewrite
+- `frontend/src/api/queries.ts` — add `useBillingConfig()`
+- `frontend/package.json` / `package-lock.json` — `@paddle/paddle-js` dep
+- (no backend changes)
+
+## Out of scope for this PR
+
+- Affiliate/utm cookie capture (separate PR — needs cookie reader util + customData merge logic)
+- Marketing-site checkout (frontend rewrite owns it)
+- Annual price IDs ($50/yr, $100/yr) — wire when prices exist in Paddle dashboard
+- Vitest infra bootstrap — separate repo-wide PR
+- Production env wiring on Fly + Paddle dashboard webhook URL registration
+
+## Where the truth lives
+
+- Backend integration spec: `docs/context/paddle-integration.md`
+- This handoff: `docs/superpowers/plans/2026-05-14-paddle-frontend-overlay.md`
+- Live Paddle docs: `paddle-docs` MCP server (HTTP, `https://paddlehq.mcp.kapa.ai`, repo `.mcp.json`) — **use this to validate the call shapes above before implementing**

--- a/docs/superpowers/plans/2026-05-15-signup-wizard-design-handoff.md
+++ b/docs/superpowers/plans/2026-05-15-signup-wizard-design-handoff.md
@@ -1,0 +1,79 @@
+# Signup wizard design — session handoff
+
+**Status:** brainstorming paused mid-discovery before /compact. Resume by re-reading this doc, then continue with the clarifying questions in the "Resume here" section.
+
+## What just shipped (background)
+
+- **PR #141** (`feat/paddle-overlay` → `main`): frontend overlay rewrite. Six commits:
+  - `b46c292` feat(paddle): wire frontend overlay to /api/billing/config
+  - `09cc262` chore: paddle-docs MCP + plan doc
+  - `8b3aad7` chore: Makefile ported from engram-workspace
+  - `723a565` feat(paddle): allow Paddle.js in CSP
+  - `f83264d` chore: bump version to 0.5.106
+- Backend cutover already on main as #132 (Paddle MoR end-to-end).
+- Tested end-to-end against Paddle sandbox: real card → transaction → `subscription.created` webhook → DB row → UI flipped. Subscription `sub_01krn5g6t9stkvmkzwq2r1vh50` for user 14 lives in the sandbox.
+
+## Local Paddle sandbox state (live but ephemeral)
+
+| What | Value |
+|---|---|
+| Notification destination | `ntfset_01krn44f739kqzsdpvmac43k4w` (pointed at a cloudflared tunnel URL that dies when the process stops) |
+| Starter product / price | `pro_01krn42qx396agpy5t03tcd140` / `pri_01krn432tn18s0pf2yrx8nr8z2` |
+| Pro product / price | `pro_01krn42r4wgxbay4rrc38hj7pt` / `pri_01krn4330hj8jfespdafc25dqt` |
+| Client-side token | `test_e08f11beb9994342d34323c2f02` |
+| All values | also in `.env.local` (gitignored) |
+
+Tunnel + Phoenix may not be running by the time this doc is read. `make dev` to restart Phoenix; relaunch `cloudflared tunnel --url http://localhost:4000` and `PATCH /notification-settings/{id}` with the new URL if you need real webhook delivery again.
+
+## The next design problem — 3-phase signup wizard
+
+The user (Todd) wants a forced three-step flow before a new user can use the app:
+
+1. **Account creation** — already exists via Clerk (`/sign-up`) or local-auth (`/sign-up` for non-Clerk envs).
+2. **User agreement** — accept TOS / Privacy. Nothing like this exists in the codebase today.
+3. **Payment** — `/billing` already works; user picks Starter or Pro, completes Paddle overlay, lands on `subscription.created` → DB row with `status: trialing`.
+
+Current gating is auth-only. After signup, Clerk redirects to `/` (the dashboard); nothing forces TOS or payment. We need to introduce gating that funnels new users through agreement + payment before they can read/write notes.
+
+## Codebase facts already gathered (skip re-discovery)
+
+- `frontend/src/router.tsx` — `AuthGuard` wraps the app shell; today it only checks `isSignedIn`. No subscription / agreement gate exists.
+- `frontend/src/auth/sign-up.tsx` — Clerk's hosted `<SignUp routing="hash" forceRedirectUrl="/">` widget. Local-auth has its own `<LocalSignUp />` in `frontend/src/auth/local-sign-up.tsx`.
+- `frontend/src/billing/billing-page.tsx` — what PR #141 just rewrote. Renders plan cards when `tier === 'none'`, flips to "Free Trial" badge + Manage button when a subscription exists.
+- `frontend/src/api/queries.ts` — `useBillingStatus()` and `useBillingConfig()` already there; backend exposes `/api/billing/status`, `/api/billing/config`, `/api/billing/portal`.
+- `frontend/src/layout/app-layout.tsx` (not yet read in this session) — the chrome behind `AuthGuard`.
+- **No TOS / Privacy tracking in the codebase.** Grep for `terms`, `tos`, `agreement`, `privacy` only turns up OAuth consent code (unrelated). New migration + new column on `users` (or new `user_agreements` table) needed.
+- Pricing tiers from `CLAUDE.md`: Starter $5/mo, Pro $10/mo, 7-day free trial, card required.
+- `AuthGuard` redirects to `/sign-in?return_to=...` when not signed in. Pattern to extend: add a `BillingGate` / `OnboardingGate` that redirects to `/onboard` when subscription/agreement is missing.
+
+## Resume here — clarifying questions I was about to ask
+
+Ask these one at a time per the brainstorming skill (`superpowers:brainstorming`). The user already **declined the visual companion** for this design session.
+
+1. **Enforcement layer.** Should the gate live in the frontend (route guard) or also in the backend (plug that 403s on every authenticated route until the user has both agreement + active subscription)? Frontend-only is faster to ship and reversible; backend is the only way to be airtight (a determined user can bypass route guards). Tradeoff: speed/iteration vs. genuine enforcement.
+2. **Wizard location.** Dedicated `/onboard` route with a multi-step UI, or inline modal that appears over the dashboard, or three separate pages (`/onboard/welcome`, `/onboard/agreement`, `/onboard/billing`)? Dedicated route is the easiest to bookmark/share and matches the existing routing pattern.
+3. **Existing users.** What happens to current signed-in users on `main` who haven't accepted TOS? Grandfather them in, or force-prompt the agreement step on next login? (Payment isn't a concern for them — most are dev accounts.)
+4. **Free tier / skipping payment.** CLAUDE.md says SaaS-only at launch, but a 7-day trial implies card-required. Is "skip payment" ever allowed (e.g., admin override, comp accounts), or is every account required to enter a card?
+5. **TOS versioning.** Do we need to track which version of the TOS the user accepted, and re-prompt when we publish a new version? If yes, that shapes the data model (`user_agreements` table with `version` column) and adds a "you must re-accept" gate. If no, simpler boolean `agreed_at: datetime` column on `users` is enough.
+6. **Auth providers.** The agreement step needs to work for both Clerk and local-auth. Anything else to consider (SSO, magic links)? Currently only those two.
+
+## Likely shape of the design (preview, not yet validated)
+
+- **Data model**: new `users.terms_accepted_at` (or richer `user_agreements` table if versioning matters). Subscription state is already in `subscriptions`.
+- **Backend gate**: extend `EngramWeb.Plugs.AuthRequired` (or add new `OnboardingRequired` plug) — returns 403 `{error: "onboarding_required", missing: ["terms", "subscription"]}` from `/api/*` routes if either is missing.
+- **Frontend gate**: new `OnboardingGate` component above `AppLayout` in the route tree. Queries `/api/onboarding/status` (new endpoint), redirects to `/onboard/agreement` or `/onboard/billing` as needed.
+- **Onboarding routes**: nested under `AuthGuard` (signed-in only, no `OnboardingGate`). Three pages or three steps in one page.
+- **TOS content**: hosted at `/legal/terms` (new static markdown route) so the agreement page can link to it.
+
+## After answering the clarifying questions
+
+Proceed through the brainstorming checklist:
+
+1. Propose 2–3 approaches with tradeoffs.
+2. Present design in sections, get approval per section.
+3. Write spec to `docs/superpowers/specs/2026-05-15-signup-wizard-design.md`.
+4. Spec self-review (placeholders / contradictions / scope / ambiguity).
+5. Ask Todd to review the spec.
+6. Hand off to `superpowers:writing-plans`.
+
+**Do not implement during brainstorming.** The hard gate is in the brainstorming skill.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -10,6 +10,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.42.1",
         "@fontsource-variable/geist": "^5.2.8",
+        "@paddle/paddle-js": "^1.6.4",
         "@portaljs/remark-callouts": "^1.0.5",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.96.2",
@@ -243,6 +244,8 @@
     "@open-draft/until": ["@open-draft/until@2.1.0", "http://10.0.20.214:4873/@open-draft/until/-/until-2.1.0.tgz", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "http://10.0.20.214:4873/@oxc-project/types/-/types-0.124.0.tgz", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "@paddle/paddle-js": ["@paddle/paddle-js@1.6.4", "http://10.0.20.214:4873/@paddle/paddle-js/-/paddle-js-1.6.4.tgz", {}, "sha512-ncfnS6I8mCX6krZ3Sgz2iAYivGmhdI81yt9mT6prtPj4Ipd9J3M12LCJRUFL4FB7BYeeuV04c33RSEnbZUBCaA=="],
 
     "@playwright/test": ["@playwright/test@1.59.1", "http://10.0.20.214:4873/@playwright/test/-/test-1.59.1.tgz", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.42.1",
     "@fontsource-variable/geist": "^5.2.8",
+    "@paddle/paddle-js": "^1.6.4",
     "@portaljs/remark-callouts": "^1.0.5",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.96.2",

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -142,6 +142,27 @@ export function useBillingStatus() {
   })
 }
 
+export interface BillingConfig {
+  client_token: string
+  environment: 'sandbox' | 'production'
+  price_ids: {
+    starter: string
+    pro: string
+  }
+  customer_email: string
+  custom_data: {
+    user_id: number
+  }
+}
+
+export function useBillingConfig() {
+  return useQuery({
+    queryKey: ['billing', 'config'],
+    queryFn: () => api.get<BillingConfig>('/billing/config'),
+    staleTime: Infinity,
+  })
+}
+
 // API key types
 
 export interface ApiKey {

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -1,4 +1,6 @@
-import { useBillingStatus } from '../api/queries'
+import { useEffect, useState } from 'react'
+import { initializePaddle, type Paddle } from '@paddle/paddle-js'
+import { useBillingStatus, useBillingConfig, type BillingConfig } from '../api/queries'
 import { api } from '../api/client'
 
 const TIER_LABELS = {
@@ -10,6 +12,19 @@ const TIER_LABELS = {
 
 export default function BillingPage() {
   const { data: billing, isLoading } = useBillingStatus()
+  const { data: config } = useBillingConfig()
+  const [paddle, setPaddle] = useState<Paddle>()
+
+  useEffect(() => {
+    if (!config) return
+    initializePaddle({
+      token: config.client_token,
+      environment: config.environment,
+      checkout: { settings: { displayMode: 'overlay', theme: 'light', locale: 'en' } },
+    }).then((instance) => {
+      if (instance) setPaddle(instance)
+    })
+  }, [config])
 
   if (isLoading || !billing) {
     return <p className="text-gray-500 dark:text-gray-400">Loading billing info...</p>
@@ -17,6 +32,7 @@ export default function BillingPage() {
 
   const needsSubscription = billing.tier === 'none'
   const isTrial = billing.subscription?.status === 'trialing'
+  const checkoutReady = Boolean(paddle && config)
 
   return (
     <article className="mx-auto max-w-2xl space-y-8">
@@ -69,12 +85,18 @@ export default function BillingPage() {
               price="$5/mo"
               features={['10 GB storage', '5 devices', 'Standard search']}
               tier="starter"
+              paddle={paddle}
+              config={config}
+              disabled={!checkoutReady}
             />
             <PlanCard
               name="Pro"
               price="$10/mo"
               features={['50 GB storage', 'Unlimited devices', '2x search rate']}
               tier="pro"
+              paddle={paddle}
+              config={config}
+              disabled={!checkoutReady}
             />
           </ul>
         </section>
@@ -86,7 +108,7 @@ export default function BillingPage() {
             onClick={handlePortal}
             className="text-sm text-blue-600 underline hover:text-blue-800"
           >
-            Manage subscription in Stripe
+            Manage subscription
           </button>
         </section>
       )}
@@ -99,15 +121,28 @@ function PlanCard({
   price,
   features,
   tier,
+  paddle,
+  config,
+  disabled,
 }: {
   name: string
   price: string
   features: string[]
   tier: 'starter' | 'pro'
+  paddle: Paddle | undefined
+  config: BillingConfig | undefined
+  disabled: boolean
 }) {
-  async function handleCheckout() {
-    const { url } = await api.post<{ url: string }>('/billing/checkout-session', { tier })
-    window.location.href = url
+  function handleCheckout() {
+    if (!paddle || !config) return
+    paddle.Checkout.open({
+      items: [{ priceId: config.price_ids[tier], quantity: 1 }],
+      customer: { email: config.customer_email },
+      customData: config.custom_data,
+      settings: {
+        successUrl: `${window.location.origin}/billing?status=success`,
+      },
+    })
   }
 
   return (
@@ -121,7 +156,8 @@ function PlanCard({
       </ul>
       <button
         onClick={handleCheckout}
-        className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        disabled={disabled}
+        className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         Start free trial
       </button>

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -30,12 +30,12 @@ defmodule EngramWeb.Router do
   @csp_policy Enum.join(
                 [
                   "default-src 'self'",
-                  "script-src 'self' 'unsafe-inline' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com",
+                  "script-src 'self' 'unsafe-inline' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.paddle.com",
                   "style-src 'self' 'unsafe-inline'",
                   "img-src 'self' data: blob: https:",
                   "font-src 'self' data:",
-                  "connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com",
-                  "frame-src https://challenges.cloudflare.com https://*.clerk.accounts.dev",
+                  "connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://*.paddle.com",
+                  "frame-src https://challenges.cloudflare.com https://*.clerk.accounts.dev https://*.paddle.com",
                   "worker-src 'self' blob:",
                   "form-action 'self'",
                   "base-uri 'self'",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.105",
+      version: "0.5.106",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- Rewrite `billing-page.tsx` around `@paddle/paddle-js` overlay — fetch `/api/billing/config`, `initializePaddle`, `Paddle.Checkout.open` with `customer` / `customData` / `successUrl`.
- Add `useBillingConfig()` React Query hook with `staleTime: Infinity` (per-session immutable).
- Allow `https://*.paddle.com` in the SPA CSP (`script-src`, `connect-src`, `frame-src`) — the overlay loads from `cdn.paddle.com`, renders an iframe on `sandbox-buy.paddle.com`, and calls `sandbox-api.paddle.com`. The previous CSP blocked all three.
- Add repo-root `Makefile` ported from `engram-workspace` (drops `cd backend/` prefixes, swaps `npm`→`bun`, strips plugin-only targets).
- Track repo-local `.mcp.json` (paddle-docs MCP server) and the design handoff plan at `docs/superpowers/plans/2026-05-14-paddle-frontend-overlay.md`.

Backend cutover landed in #132; this PR is the frontend half.

## Test plan
- [x] `bun run build` and `tsc --noEmit` clean.
- [x] `mix compile --warnings-as-errors` clean.
- [x] Manual: `/billing` renders Starter + Pro cards, no "Stripe" copy anywhere.
- [x] Sandbox checkout end-to-end with `4242 4242 4242 4242` — Paddle created `sub_01krn5g6t9stkvmkzwq2r1vh50` for user 14, status `trialing`, period end `2026-05-22`.
- [x] `subscription.created` webhook delivered through cloudflared tunnel → row landed in `subscriptions` (tier=`starter`, status=`trialing`, paddle_customer_id + paddle_subscription_id populated).
- [x] `/billing` flipped to "Free Trial" + "7 days remaining" + "Manage subscription" link.
- [x] `/api/billing/portal` redirected to a Paddle-hosted portal session.

## Out of scope (follow-up PRs)
- Affiliate / utm cookie capture into `customData`.
- Marketing-site checkout (separate frontend).
- Annual price IDs ($50 / $100) when those prices exist in Paddle.
- Vitest infrastructure for the frontend (no unit tests for `billing-page.tsx` yet; backend has full webhook + event coverage in #132).
- Production deployment: Fly env wiring + Paddle live destination URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)