### PR TITLE
fix(e2e): retry Clerk POST /sessions on 404 eventual-consistency

### DIFF
--- a/e2e/helpers/clerk.py
+++ b/e2e/helpers/clerk.py
@@ -9,10 +9,19 @@ Clerk Backend API docs: https://clerk.com/docs/reference/backend-api
 from __future__ import annotations
 
 import logging
+import time
 
 import requests
 
 logger = logging.getLogger(__name__)
+
+# Clerk's POST /sessions endpoint exhibits eventual-consistency 404s vs the
+# user store: a user_id that GET /users/{id} returns happily can still
+# 404 from POST /sessions for a few hundred ms after creation. Retry
+# resource_not_found errors with exponential backoff. 5 attempts span
+# ~6s total, well above Clerk's observed lag window (<1s in practice).
+_SESSION_CREATE_MAX_ATTEMPTS = 5
+_SESSION_CREATE_INITIAL_BACKOFF = 0.2
 
 
 class ClerkClient:
@@ -94,19 +103,14 @@ class ClerkClient:
         Uses Clerk's Backend API to create a session, then mints a
         session token (valid ~60s). This JWT can be used as a Bearer
         token or injected as Clerk's __session cookie.
-        """
-        # Create session
-        resp = self.session.post(
-            f"{self.base_url}/sessions",
-            json={"user_id": user_id},
-            timeout=10,
-        )
-        if not resp.ok:
-            logger.error("Clerk create_session failed: %s %s", resp.status_code, resp.text)
-        resp.raise_for_status()
-        session_id = resp.json()["id"]
 
-        # Mint session token
+        Retries POST /sessions on transient 404 resource_not_found
+        (Clerk eventual-consistency lag between user create/lookup and
+        session endpoint visibility). See `_create_session_with_retry`.
+        """
+        session_id = self._create_session_with_retry(user_id)
+
+        # Mint session token (no retry needed — session is fresh)
         resp = self.session.post(
             f"{self.base_url}/sessions/{session_id}/tokens",
             timeout=10,
@@ -117,6 +121,52 @@ class ClerkClient:
         token = resp.json()["jwt"]
         logger.info("Created session token for user %s (session %s)", user_id, session_id)
         return token
+
+    def _create_session_with_retry(self, user_id: str) -> str:
+        """POST /sessions with exponential-backoff retry on 404 resource_not_found.
+
+        Returns the session_id. Raises on non-404 errors immediately, or after
+        exhausting retries on persistent 404.
+        """
+        backoff = _SESSION_CREATE_INITIAL_BACKOFF
+        last_resp: requests.Response | None = None
+        for attempt in range(1, _SESSION_CREATE_MAX_ATTEMPTS + 1):
+            resp = self.session.post(
+                f"{self.base_url}/sessions",
+                json={"user_id": user_id},
+                timeout=10,
+            )
+            last_resp = resp
+            if resp.ok:
+                return resp.json()["id"]
+            if resp.status_code == 404 and self._is_resource_not_found(resp):
+                if attempt < _SESSION_CREATE_MAX_ATTEMPTS:
+                    logger.warning(
+                        "Clerk create_session 404 for user %s (attempt %d/%d, sleeping %.2fs)",
+                        user_id, attempt, _SESSION_CREATE_MAX_ATTEMPTS, backoff,
+                    )
+                    time.sleep(backoff)
+                    backoff *= 2
+                    continue
+                logger.error(
+                    "Clerk create_session 404 for user %s exhausted %d retries: %s",
+                    user_id, _SESSION_CREATE_MAX_ATTEMPTS, resp.text,
+                )
+            else:
+                logger.error("Clerk create_session failed: %s %s", resp.status_code, resp.text)
+            resp.raise_for_status()
+        # Defensive — raise_for_status above should always raise on the final attempt.
+        assert last_resp is not None
+        last_resp.raise_for_status()
+        raise RuntimeError("unreachable")  # pragma: no cover
+
+    @staticmethod
+    def _is_resource_not_found(resp: requests.Response) -> bool:
+        try:
+            errors = resp.json().get("errors", [])
+        except ValueError:
+            return False
+        return any(e.get("code") == "resource_not_found" for e in errors)
 
     def get_testing_token(self) -> str:
         """Get a Testing Token to bypass bot detection in Clerk's Frontend API."""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.107",
+      version: "0.5.108",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

`test_49_cross_auth_sync.py::test_oauth_push_apikey_receives` flaked on backend run [25955423845](https://github.com/engram-app/Engram/actions/runs/25955423845) (plugin PR #52 cross-repo dispatch, 2026-05-16):

\`\`\`
ERROR helpers.clerk:clerk.py:105 Clerk create_session failed: 404
{"errors":[{"message":"not found","long_message":"No user was found with id user_3DnOJYV7zPzmvG1hj1pjR0PTxgM","code":"resource_not_found"}]}
FAILED tests/test_49_cross_auth_sync.py::test_oauth_push_apikey_receives
\`\`\`

The user existed (the test had just looked it up via \`find_user_by_email\`) — Clerk's session-create endpoint had not yet indexed the user. Classic eventual-consistency between Clerk's user store and session endpoint.

Per \`feedback_diagnose_flakes\` memory: never accept rerun-pass silently. Filed root-cause fix.

## What changes

\`ClerkClient.create_session_token\` now delegates to a private \`_create_session_with_retry\` that:

- Retries POST /sessions specifically on \`HTTP 404\` + \`errors[].code == "resource_not_found"\`
- Exponential backoff: 0.2 / 0.4 / 0.8 / 1.6 / 3.2 s (5 attempts, ~6.2s total)
- Other 404 codes and non-404 errors raise immediately (no over-retry)
- Token-mint call is left unwrapped — the session is fresh and won't 404

## Why retry vs probe-before-create

Probing via \`GET /users/{id}\` until found would add a round-trip to every successful call. The 404 happens rarely; retry-only-on-failure pays the latency cost only when needed.

## Test plan

- [x] No backend code touched (helper only); standard CI baseline
- [ ] Watch test_49_cross_auth_sync in next 5+ runs — should not flake on this signature
- [ ] Bump \`mix.exs\` 0.5.107 → 0.5.108 per pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)