### PR TITLE
chore: defer automated CLA tooling, switch to manual sign flow

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -6,8 +6,9 @@ limited liability company (the "**Company**"). This Contributor License
 Agreement ("**Agreement**") clarifies the intellectual property license granted
 with Contributions from any person or entity to the Company.
 
-By signing this Agreement — via the CLA Assistant bot on the
-[github.com/engram-app/Engram](https://github.com/engram-app/Engram) repository
+By signing this Agreement — by posting the acceptance line specified at the
+end of this document as a comment on Your pull request to the
+[github.com/engram-app/Engram](https://github.com/engram-app/Engram) repository,
 or by any other written acceptance — You accept and agree to the following
 terms and conditions for Your present and future Contributions submitted to
 the Project.
@@ -107,8 +108,12 @@ become aware that would make these representations inaccurate in any respect.
 
 ---
 
-**To sign:** comment on your first pull request as instructed by the CLA
-Assistant bot, or include the following line in a pull request comment:
+**To sign:** post the following line as a comment on Your pull request to
+this repository, verbatim:
 
 > I have read the Engram Contributor License Agreement v1.0 and I hereby
 > sign the CLA.
+
+A maintainer will record Your signature manually. Automated enforcement
+tooling is intentionally deferred until external contributions become
+regular (see [CONTRIBUTING.md](../CONTRIBUTING.md)).

--- a/.github/cla-signatures.json
+++ b/.github/cla-signatures.json
@@ -1,3 +1,0 @@
-{
-  "signedContributors": []
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,20 @@ contribution. You grant Rasbandit Software Solutions LLC d/b/a Engram a broad
 license — including the right to relicense your contribution under the
 commercial license — so the dual-license model works.
 
-Signing is automated: when you open your first PR, the CLA Assistant bot will
-post a comment with a link. Sign once via your GitHub identity and you are
-covered for all future contributions to this repo.
+**How to sign (interim manual flow):** Read [.github/CLA.md](.github/CLA.md),
+then post the following line as a comment on your pull request, verbatim:
+
+> I have read the Engram Contributor License Agreement v1.0 and I hereby sign
+> the CLA.
+
+A maintainer will record your signature and proceed with review.
+
+> **TODO (deferred):** automated CLA enforcement tooling will be wired up
+> when external contributions become regular. The CLA Assistant Lite
+> GitHub Action was archived upstream in March 2026, and the hosted
+> `cla-assistant.io` service has been on maintenance-only mode since late
+> 2023. Choosing tooling against a moving landscape was deferred until a
+> real signal exists.
 
 ## Development setup
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.108",
+      version: "0.5.109",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Replaces stale PR #131 (created 2026-05-13 pre-org-migration). Rebased onto current main (post-#133 + post-#138 org-migration); preserves engram-app/Engram URL (PR #131 regressed it back to Rasbandit/Engram).

CLA Assistant Lite is dead upstream (archived 2026-03-23). Hosted cla-assistant.io is maintenance-only since late 2023. Choosing CLA tooling against a moving landscape is deferred until external contribution volume justifies it.

## What changes

| Path | Action |
|------|--------|
| \`.github/CLA.md\` | Replace "via the CLA Assistant bot" wording with manual-sign-flow language. URL stays at engram-app/Engram. |
| \`.github/cla-signatures.json\` | **Deleted** (vestigial empty file from removed bot) |
| \`CONTRIBUTING.md\` | Replace "Signing is automated... CLA Assistant bot will post a comment" with manual flow + deferred-tooling TODO |
| \`mix.exs\` | 0.5.108 → 0.5.109 |

## How contributors sign now

Post this line as a comment on the PR, verbatim:

> I have read the Engram Contributor License Agreement v1.0 and I hereby sign the CLA.

Maintainer records signature manually. Scales fine at current contribution volume.

## What's intentionally NOT changed

- The CLA document itself (Section 4 relicensing grant) — substance unchanged across PRs #117/#129/#133/#131. Counsel review of Section 4 still TODO before any external contributor signs.

## Test plan

- [x] No source code touched; baseline CI run
- [x] \`mix.exs\` bumped per pre-push hook

Closes #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)