### PR TITLE
feat(crypto): AWS KMS Phase 3 — provider migration (Local↔KMS)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -5,9 +5,11 @@
   # `<<_::N, _::_*8>>` shapes from the literal-string concatenation, but narrowing
   # the spec would leak implementation details to call sites and make any
   # caller-side `binary()` parameter type fail to match.
-  {"lib/engram/crypto.ex", :contract_supertype, 71},
-  {"lib/engram/crypto.ex", :contract_supertype, 82},
-  {"lib/engram/crypto.ex", :contract_supertype, 91},
+  # NOTE: dialyxir 1.4.x line-matches the `@spec` line, not `@doc`. Keep these
+  # in sync if you re-order or add lines above the AAD helpers.
+  {"lib/engram/crypto.ex", :contract_supertype, 72},
+  {"lib/engram/crypto.ex", :contract_supertype, 83},
+  {"lib/engram/crypto.ex", :contract_supertype, 92},
 
   # Dialyzer's success typing for `Path.rootname/1` (and possibly Regex helpers
   # called inside extract_title/2) reports a phantom `{integer(), integer()}`

--- a/docs/superpowers/plans/2026-05-16-aws-kms-phase-3-provider-migration.md
+++ b/docs/superpowers/plans/2026-05-16-aws-kms-phase-3-provider-migration.md
@@ -1,0 +1,1677 @@
+# AWS KMS Phase 3 — Provider Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship per-user, blob-tag-discriminated Local→KMS DEK rewrap on engram-saas, with symmetric rollback (KMS→Local) sharing the same worker.
+
+**Architecture:** Forks `Engram.Crypto.MasterRotation` shape — new module `Engram.Crypto.ProviderMigration` + Oban worker `Engram.Workers.MigrateUserProvider` + Mix task `Mix.Tasks.Engram.MigrateProvider`. Reads dual-route via existing `KeyProvider.identify_from_blob/1`; writes follow `Resolver.provider/0`. `Crypto.get_dek/1` enqueues lazy migration when blob provider ≠ configured provider. No schema migrations.
+
+**Tech Stack:** Elixir/Phoenix, Ecto.Repo with `SELECT ... FOR UPDATE`, Oban (queue `:crypto_backfill` concurrency=1), `:telemetry`, Mox (via `Engram.AwsKmsMock`), ExUnit.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-aws-kms-phase-3-provider-migration-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `lib/engram/crypto/provider_migration.ex` | CREATE | Public API: `migrate_user/2`, `migrate_all/2`, `enqueue_all/2`, `status_counts/0`. Per-user txn + FOR UPDATE + cursor stream. |
+| `lib/engram/workers/migrate_user_provider.ex` | CREATE | Oban worker. Args `%{"user_id", "target_provider"}`. Queue `:crypto_backfill`. Uniqueness `[:user_id, :target_provider]`. |
+| `lib/mix/tasks/engram.migrate_provider.ex` | CREATE | Ops entrypoint. `--target`, `--enqueue`, `--status`, `--batch-size`. Exit codes 0/1/2. |
+| `lib/engram/crypto.ex` | MODIFY (`get_dek/1` ~line 175-201) | Dispatch via `KeyProvider.identify_from_blob/1`. Lazy enqueue on provider mismatch. |
+| `lib/engram_web/telemetry.ex` | MODIFY | Register `[:engram, :crypto, :migrate_provider, :user]` counter + summary. |
+| `test/engram/crypto/provider_migration_test.exs` | CREATE | Unit tests for ProviderMigration API. |
+| `test/engram/workers/migrate_user_provider_test.exs` | CREATE | Worker behavior, retry/discard. |
+| `test/mix/tasks/engram.migrate_provider_test.exs` | CREATE | Mix task arg parsing, exit codes. |
+| `test/engram/crypto_test.exs` | MODIFY | Add `get_dek/1` dual-read quadrant tests. |
+| `test/engram/crypto/provider_conformance_test.exs` | MODIFY | Cross-provider identify_from_blob round-trip. |
+| `test/engram_web/telemetry_test.exs` | MODIFY | Pin `migrate_provider, :user` event registration. |
+
+Branch already created: `docs/aws-kms-phase-3-design` (in `backend/`). Continue committing on this branch.
+
+---
+
+## Task 1 — Scaffold `ProviderMigration` module + first failing test
+
+**Files:**
+- Create: `lib/engram/crypto/provider_migration.ex`
+- Create: `test/engram/crypto/provider_migration_test.exs`
+
+- [ ] **Step 1: Write the failing happy-path test (Local→KMS)**
+
+Create `test/engram/crypto/provider_migration_test.exs`:
+
+```elixir
+defmodule Engram.Crypto.ProviderMigrationTest do
+  use Engram.DataCase, async: false
+
+  import Mox
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Crypto.ProviderMigration
+  alias Engram.Repo
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+
+    prev_provider = Application.get_env(:engram, :key_provider)
+    prev_client = Application.get_env(:engram, :aws_kms_client)
+    Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+
+    on_exit(fn ->
+      Application.put_env(:engram, :key_provider, prev_provider)
+      Application.put_env(:engram, :aws_kms_client, prev_client)
+    end)
+
+    :ok
+  end
+
+  defp stub_kms_roundtrip do
+    table = :ets.new(:mig_kms_stub, [:set, :public])
+
+    stub(Engram.AwsKmsMock, :encrypt, fn pt, _ctx ->
+      ct = :crypto.strong_rand_bytes(48)
+      :ets.insert(table, {ct, pt})
+      {:ok, ct}
+    end)
+
+    stub(Engram.AwsKmsMock, :decrypt, fn ct, _ctx ->
+      case :ets.lookup(table, ct) do
+        [{^ct, pt}] -> {:ok, pt}
+        [] -> {:error, :context_mismatch}
+      end
+    end)
+
+    stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+
+    :ok
+  end
+
+  defp user_with_local_dek!(email \\ "u-#{System.unique_integer([:positive])}@e.test") do
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+    {:ok, u} = Engram.Accounts.create_user(%{email: email, password: "pwpw1234!Z"})
+    {:ok, u} = Crypto.ensure_user_dek(u)
+    u
+  end
+
+  describe "migrate_user/2 Local→KMS" do
+    test "rewraps blob with KMS provider tag and stamps key_provider" do
+      stub_kms_roundtrip()
+      user = user_with_local_dek!()
+      original_blob = user.encrypted_dek
+
+      assert :ok = ProviderMigration.migrate_user(user.id, :aws_kms)
+
+      reloaded = Repo.one!(from(u in User, where: u.id == ^user.id), skip_tenant_check: true)
+
+      assert <<0xAA, 0x01, _ct::binary>> = reloaded.encrypted_dek
+      assert reloaded.encrypted_dek != original_blob
+      assert reloaded.key_provider == "aws_kms"
+      assert reloaded.dek_version == Engram.Crypto.Config.master_key_version()
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test, confirm it fails on module-not-found**
+
+```bash
+cd backend && mix test test/engram/crypto/provider_migration_test.exs --warnings-as-errors
+```
+
+Expected: `** (UndefinedFunctionError) function Engram.Crypto.ProviderMigration.migrate_user/2 is undefined`.
+
+- [ ] **Step 3: Write minimal `ProviderMigration` module**
+
+Create `lib/engram/crypto/provider_migration.ex`:
+
+```elixir
+defmodule Engram.Crypto.ProviderMigration do
+  @moduledoc """
+  Phase 3 — Per-user `KeyProvider` rewrap. Migrates `users.encrypted_dek`
+  from one provider to another (Local↔AwsKms) by unwrapping with the
+  source provider (identified via `KeyProvider.identify_from_blob/1`) and
+  re-wrapping with the target.
+
+  Cheaper than `MasterRotation` / `UserDekRotation`: the *plaintext* DEK
+  is preserved across rewrap, so no tenant data rows need re-encryption.
+  Only `users.encrypted_dek` + `users.key_provider` change per user.
+
+  Telemetry `[:engram, :crypto, :migrate_provider, :user]` per call with
+  `%{duration_us, count}` measurements and
+  `%{user_id, target_provider, status: :ok | :skipped | :failed, reason_label?}`.
+
+  Forward (Local→AwsKms) and reverse (AwsKms→Local) use the same code
+  path — `target_provider` arg flips direction.
+
+  ## Lock + transaction shape
+
+  Each rewrap runs in its own `Repo.transaction` with `SELECT ... FOR UPDATE`
+  on the user row. Concurrent callers (Mix task + Oban job for the same
+  user) serialize cleanly: the loser sees the post-commit `key_provider`
+  and short-circuits to `:skipped`.
+
+  `DekCache.put/2` is deferred until AFTER the transaction commits — a
+  rolled-back txn must NOT leave a cached DEK that no longer matches DB.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Accounts
+  alias Engram.Accounts.User
+  alias Engram.Crypto.{Config, DekCache, KeyProvider}
+  alias Engram.Crypto.KeyProvider.{AwsKms, Local}
+  alias Engram.Repo
+
+  require Logger
+
+  @type provider_atom :: :local | :aws_kms
+  @type migrate_result :: :ok | :skipped | {:error, term()}
+  @type counts :: %{ok: non_neg_integer(), skipped: non_neg_integer(), failed: non_neg_integer()}
+
+  @doc "Migrate one user's wrapped DEK to `target_provider`."
+  @spec migrate_user(integer() | User.t(), provider_atom()) :: migrate_result()
+  def migrate_user(user_or_id, target_provider) when target_provider in [:local, :aws_kms] do
+    user_id =
+      case user_or_id do
+        %User{id: id} -> id
+        id when is_integer(id) -> id
+      end
+
+    started_at = System.monotonic_time()
+    result = do_migrate(user_id, target_provider)
+    duration_us = duration_us_since(started_at)
+    emit_telemetry(user_id, target_provider, result, duration_us)
+
+    case result do
+      {:migrated, _user, _dek} -> :ok
+      {:skipped, _user} -> :skipped
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # ── internals ──────────────────────────────────────────────────────
+
+  defp do_migrate(user_id, target_provider) do
+    target_module = module_for(target_provider)
+    target_name = Atom.to_string(target_provider)
+
+    txn =
+      Repo.transaction(fn ->
+        locked =
+          from(u in User, where: u.id == ^user_id, lock: "FOR UPDATE")
+          |> Repo.one(skip_tenant_check: true)
+
+        cond do
+          is_nil(locked) ->
+            Repo.rollback({:not_found, user_id})
+
+          is_nil(locked.encrypted_dek) ->
+            Repo.rollback(:no_dek)
+
+          locked.key_provider == target_name ->
+            {:skipped, locked}
+
+          true ->
+            rewrap_locked(locked, target_module, target_name)
+        end
+      end)
+
+    case txn do
+      {:ok, {:skipped, user}} -> {:skipped, user}
+      {:ok, {:migrated, user, dek}} -> {:migrated, user, dek}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp rewrap_locked(%User{} = locked, target_module, target_name) do
+    with {:ok, source_module} <- KeyProvider.identify_from_blob(locked.encrypted_dek),
+         ctx = %{user_id: locked.id},
+         {:ok, dek} <- source_module.unwrap_dek(locked.encrypted_dek, ctx),
+         {:ok, new_blob} <- target_module.wrap_dek(dek, ctx),
+         {:ok, updated} <-
+           Accounts.update_user_encryption(locked, %{
+             encrypted_dek: new_blob,
+             key_provider: target_name,
+             dek_version: Config.master_key_version()
+           }) do
+      {:migrated, updated, dek}
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp module_for(:local), do: Local
+  defp module_for(:aws_kms), do: AwsKms
+
+  defp duration_us_since(started_at) do
+    System.convert_time_unit(
+      System.monotonic_time() - started_at,
+      :native,
+      :microsecond
+    )
+  end
+
+  defp emit_telemetry(user_id, target_provider, {:migrated, _, _}, duration_us) do
+    :telemetry.execute(
+      [:engram, :crypto, :migrate_provider, :user],
+      %{duration_us: duration_us, count: 1},
+      %{user_id: user_id, target_provider: target_provider, status: :ok}
+    )
+  end
+
+  defp emit_telemetry(user_id, target_provider, {:skipped, _}, duration_us) do
+    :telemetry.execute(
+      [:engram, :crypto, :migrate_provider, :user],
+      %{duration_us: duration_us, count: 1},
+      %{user_id: user_id, target_provider: target_provider, status: :skipped}
+    )
+  end
+
+  defp emit_telemetry(user_id, target_provider, {:error, reason}, duration_us) do
+    label = classify_reason(reason)
+
+    Logger.error(
+      "provider migration failed user_id=#{user_id} target=#{target_provider} reason_label=#{label}",
+      category: :crypto_migration
+    )
+
+    :telemetry.execute(
+      [:engram, :crypto, :migrate_provider, :user],
+      %{duration_us: duration_us, count: 1},
+      %{
+        user_id: user_id,
+        target_provider: target_provider,
+        status: :failed,
+        reason_label: label
+      }
+    )
+  end
+
+  defp classify_reason(:no_dek), do: "no_dek"
+  defp classify_reason({:not_found, _}), do: "not_found"
+  defp classify_reason(:invalid_wrapping), do: "invalid_wrapping"
+  defp classify_reason(:malformed_wrapped_blob), do: "malformed_wrapped_blob"
+  defp classify_reason(:kms_throttled), do: "kms_throttled"
+  defp classify_reason(:kms_access_denied), do: "kms_access_denied"
+  defp classify_reason(:kms_key_not_found), do: "kms_key_not_found"
+  defp classify_reason({:kms_encrypt_failed, _}), do: "kms_encrypt_failed"
+  defp classify_reason({:kms_decrypt_failed, _}), do: "kms_decrypt_failed"
+  defp classify_reason(:unrecognised_blob), do: "unrecognised_blob"
+  defp classify_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp classify_reason(%Ecto.Changeset{}), do: "changeset_invalid"
+  defp classify_reason(_other), do: "other"
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd backend && mix test test/engram/crypto/provider_migration_test.exs --warnings-as-errors
+```
+
+Expected: 1 test, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add lib/engram/crypto/provider_migration.ex test/engram/crypto/provider_migration_test.exs && git commit -m "feat(crypto): ProviderMigration.migrate_user Local→KMS happy path
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2 — Reverse migration (KMS→Local) + idempotent skip
+
+**Files:**
+- Modify: `test/engram/crypto/provider_migration_test.exs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing test module (before the closing `end`):
+
+```elixir
+  describe "migrate_user/2 KMS→Local reverse" do
+    test "rewraps from KMS blob back to Local with 0x01/0x02 leading byte" do
+      stub_kms_roundtrip()
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+      {:ok, u} = Engram.Accounts.create_user(%{email: "kms-#{System.unique_integer([:positive])}@e.test", password: "pwpw1234!Z"})
+      {:ok, u} = Crypto.ensure_user_dek(u)
+      assert <<0xAA, _::binary>> = u.encrypted_dek
+
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+      assert :ok = ProviderMigration.migrate_user(u.id, :local)
+
+      reloaded = Repo.one!(from(x in User, where: x.id == ^u.id), skip_tenant_check: true)
+      assert <<tag, 0x01, _::binary-size(60)>> = reloaded.encrypted_dek
+      assert tag in [0x01, 0x02]
+      assert reloaded.key_provider == "local"
+    end
+  end
+
+  describe "migrate_user/2 idempotence" do
+    test "returns :skipped when user is already at target_provider, no provider calls made" do
+      stub_kms_roundtrip()
+      user = user_with_local_dek!()
+
+      # First migration: Local→KMS.
+      assert :ok = ProviderMigration.migrate_user(user.id, :aws_kms)
+
+      # Second migration to same target: skipped, zero KMS calls expected
+      # because the cond branch short-circuits before touching providers.
+      expect(Engram.AwsKmsMock, :encrypt, 0, fn _, _ -> :unused end)
+      expect(Engram.AwsKmsMock, :decrypt, 0, fn _, _ -> :unused end)
+
+      assert :skipped = ProviderMigration.migrate_user(user.id, :aws_kms)
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify pass**
+
+```bash
+cd backend && mix test test/engram/crypto/provider_migration_test.exs --warnings-as-errors
+```
+
+Expected: 3 tests, 0 failures. (No production-code change needed — the `cond` branch in `do_migrate/2` already handles both cases.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd backend && git add test/engram/crypto/provider_migration_test.exs && git commit -m "test(crypto): ProviderMigration reverse direction + idempotent skip
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3 — Failure-mode coverage + telemetry assertions
+
+**Files:**
+- Modify: `test/engram/crypto/provider_migration_test.exs`
+
+- [ ] **Step 1: Add telemetry capture helper + failure tests**
+
+First, add a module-level helper. Insert this `defp` **above** the first `describe` block (alongside the existing `stub_kms_roundtrip/0` + `user_with_local_dek!/1` helpers — NOT inside a `describe`, which would be a compile error):
+
+```elixir
+  defp attach_telemetry_capture(test_pid) do
+    handler_id = "test-migrate-provider-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:engram, :crypto, :migrate_provider, :user],
+      fn _name, measurements, metadata, _cfg ->
+        send(test_pid, {:telemetry, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+```
+
+Then append the failure-mode `describe` block:
+
+```elixir
+  describe "migrate_user/2 failure modes" do
+    test ":kms_access_denied surfaces, txn rolls back, blob unchanged, telemetry :failed" do
+      Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+      stub(Engram.AwsKmsMock, :encrypt, fn _, _ -> {:error, :access_denied} end)
+
+      user = user_with_local_dek!()
+      original_blob = user.encrypted_dek
+
+      attach_telemetry_capture(self())
+
+      assert {:error, {:kms_encrypt_failed, :access_denied}} =
+               ProviderMigration.migrate_user(user.id, :aws_kms)
+
+      reloaded = Repo.one!(from(u in User, where: u.id == ^user.id), skip_tenant_check: true)
+      assert reloaded.encrypted_dek == original_blob
+      assert reloaded.key_provider == "local"
+
+      assert_receive {:telemetry, %{count: 1}, %{status: :failed, reason_label: "kms_encrypt_failed"}}
+    end
+
+    test ":kms_throttled surfaces verbatim" do
+      stub(Engram.AwsKmsMock, :encrypt, fn _, _ -> {:error, :throttled} end)
+
+      user = user_with_local_dek!()
+
+      assert {:error, {:kms_encrypt_failed, :throttled}} =
+               ProviderMigration.migrate_user(user.id, :aws_kms)
+    end
+
+    test "user deleted mid-flight returns {:error, {:not_found, uid}}" do
+      stub_kms_roundtrip()
+      missing_id = 99_999_999
+
+      assert {:error, {:not_found, ^missing_id}} =
+               ProviderMigration.migrate_user(missing_id, :aws_kms)
+    end
+
+    test "user with nil encrypted_dek returns {:error, :no_dek}" do
+      stub_kms_roundtrip()
+      {:ok, u} = Engram.Accounts.create_user(%{email: "nodek-#{System.unique_integer([:positive])}@e.test", password: "pwpw1234!Z"})
+
+      assert {:error, :no_dek} = ProviderMigration.migrate_user(u.id, :aws_kms)
+    end
+
+    test "happy path emits :ok telemetry with target_provider metadata" do
+      stub_kms_roundtrip()
+      user = user_with_local_dek!()
+
+      attach_telemetry_capture(self())
+
+      assert :ok = ProviderMigration.migrate_user(user.id, :aws_kms)
+      assert_receive {:telemetry, %{count: 1, duration_us: dur},
+                      %{user_id: uid, target_provider: :aws_kms, status: :ok}}
+                     when is_integer(dur) and dur >= 0
+
+      assert uid == user.id
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify pass**
+
+```bash
+cd backend && mix test test/engram/crypto/provider_migration_test.exs --warnings-as-errors
+```
+
+Expected: 8 tests, 0 failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd backend && git add test/engram/crypto/provider_migration_test.exs && git commit -m "test(crypto): ProviderMigration failure modes + telemetry pins
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4 — Concurrent-rewrap race test (FOR UPDATE serialization)
+
+**Files:**
+- Modify: `test/engram/crypto/provider_migration_test.exs`
+
+- [ ] **Step 1: Add race test**
+
+Append:
+
+```elixir
+  describe "migrate_user/2 concurrent races" do
+    test "4 parallel migrate_user calls for same user → exactly one rewrap, three :skipped" do
+      stub_kms_roundtrip()
+      user = user_with_local_dek!()
+      uid = user.id
+
+      results =
+        1..4
+        |> Task.async_stream(fn _ -> ProviderMigration.migrate_user(uid, :aws_kms) end,
+          max_concurrency: 4,
+          ordered: false,
+          timeout: 10_000
+        )
+        |> Enum.map(fn {:ok, r} -> r end)
+
+      ok_count = Enum.count(results, &(&1 == :ok))
+      skipped_count = Enum.count(results, &(&1 == :skipped))
+
+      assert ok_count == 1, "expected exactly one :ok, got #{ok_count} (results=#{inspect(results)})"
+      assert skipped_count == 3, "expected three :skipped, got #{skipped_count}"
+
+      reloaded = Repo.one!(from(u in User, where: u.id == ^uid), skip_tenant_check: true)
+      assert reloaded.key_provider == "aws_kms"
+    end
+  end
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+cd backend && mix test test/engram/crypto/provider_migration_test.exs --warnings-as-errors
+```
+
+Expected: 9 tests, 0 failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd backend && git add test/engram/crypto/provider_migration_test.exs && git commit -m "test(crypto): ProviderMigration race test (4-parallel FOR UPDATE)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5 — `migrate_all/2`, `enqueue_all/2`, `status_counts/0`
+
+**Files:**
+- Modify: `lib/engram/crypto/provider_migration.ex`
+- Modify: `test/engram/crypto/provider_migration_test.exs`
+
+- [ ] **Step 1: Write failing tests for fleet ops**
+
+Append to test module:
+
+```elixir
+  describe "migrate_all/2" do
+    test "drains every user not at target into the target provider" do
+      stub_kms_roundtrip()
+      u1 = user_with_local_dek!()
+      u2 = user_with_local_dek!()
+      # u3 starts on KMS — must be skipped.
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+      {:ok, u3} = Engram.Accounts.create_user(%{email: "k-#{System.unique_integer([:positive])}@e.test", password: "pwpw1234!Z"})
+      {:ok, _} = Crypto.ensure_user_dek(u3)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+      assert %{ok: 2, skipped: ok_or_skipped, failed: 0} =
+               ProviderMigration.migrate_all(:aws_kms, batch_size: 10)
+
+      # u3 contributes to :skipped. Other already-aws_kms users from prior
+      # tests in this DB sandbox may also contribute.
+      assert ok_or_skipped >= 1
+
+      assert "aws_kms" =
+               Repo.one!(from(u in User, where: u.id == ^u1.id, select: u.key_provider),
+                 skip_tenant_check: true
+               )
+
+      assert "aws_kms" =
+               Repo.one!(from(u in User, where: u.id == ^u2.id, select: u.key_provider),
+                 skip_tenant_check: true
+               )
+    end
+  end
+
+  describe "enqueue_all/2" do
+    test "inserts one Oban job per below-target user" do
+      _u1 = user_with_local_dek!()
+      _u2 = user_with_local_dek!()
+
+      assert %{enqueued: n} = ProviderMigration.enqueue_all(:aws_kms, batch_size: 10)
+      assert n >= 2
+
+      jobs =
+        Oban.Job
+        |> Repo.all(skip_tenant_check: true)
+        |> Enum.filter(&(&1.worker == "Engram.Workers.MigrateUserProvider"))
+
+      assert length(jobs) >= 2
+
+      Enum.each(jobs, fn job ->
+        assert %{"target_provider" => "aws_kms", "user_id" => uid} = job.args
+        assert is_integer(uid)
+      end)
+    end
+  end
+
+  describe "status_counts/0" do
+    test "returns counts grouped by users.key_provider" do
+      _ = user_with_local_dek!()
+      counts = ProviderMigration.status_counts()
+      assert is_map(counts)
+      assert counts[:local] >= 1
+      assert Map.has_key?(counts, :total)
+      assert counts.total == (counts[:local] || 0) + (counts[:aws_kms] || 0)
+    end
+  end
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+cd backend && mix test test/engram/crypto/provider_migration_test.exs --warnings-as-errors
+```
+
+Expected: `migrate_all/2`, `enqueue_all/2`, `status_counts/0` undefined.
+
+- [ ] **Step 3: Implement `migrate_all/2` + `enqueue_all/2` + `status_counts/0`**
+
+Append inside `Engram.Crypto.ProviderMigration` (just below `migrate_user/2`):
+
+```elixir
+  @doc """
+  Migrate every user whose `key_provider` ≠ `target_provider`. Cursor-by-id.
+  Each user runs in its own transaction.
+
+  Returns aggregate counts. `:skipped` includes both already-at-target
+  users and users without an `encrypted_dek` (latter is rare; counted as
+  skipped because the fleet drain semantically completes for them).
+  """
+  @spec migrate_all(provider_atom(), keyword()) :: counts() | {:error, term()}
+  def migrate_all(target_provider, opts \\ []) when target_provider in [:local, :aws_kms] do
+    batch_size = Keyword.get(opts, :batch_size, 100)
+    drive_loop(target_provider, 0, batch_size, %{ok: 0, skipped: 0, failed: 0})
+  end
+
+  @doc """
+  Enqueue one `Engram.Workers.MigrateUserProvider` Oban job per below-target
+  user. Idempotent — Oban uniqueness on `[:user_id, :target_provider]`
+  collapses duplicate inserts; the worker re-checks `:skipped` at perform.
+  """
+  @spec enqueue_all(provider_atom(), keyword()) :: %{enqueued: non_neg_integer()}
+  def enqueue_all(target_provider, opts \\ []) when target_provider in [:local, :aws_kms] do
+    batch_size = Keyword.get(opts, :batch_size, 500)
+    target_name = Atom.to_string(target_provider)
+    %{enqueued: enqueue_loop(target_provider, target_name, 0, batch_size, 0)}
+  end
+
+  @doc "Provider count breakdown: `%{local: N, aws_kms: M, total: N+M}`."
+  @spec status_counts() :: %{atom() => non_neg_integer()}
+  def status_counts do
+    rows =
+      from(u in User,
+        where: not is_nil(u.encrypted_dek),
+        group_by: u.key_provider,
+        select: {u.key_provider, count(u.id)}
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    base = %{local: 0, aws_kms: 0}
+
+    rows
+    |> Enum.reduce(base, fn {provider, n}, acc ->
+      key = if provider in ["local", "aws_kms"], do: String.to_atom(provider), else: :other
+      Map.update(acc, key, n, &(&1 + n))
+    end)
+    |> then(fn counts -> Map.put(counts, :total, counts.local + counts.aws_kms) end)
+  end
+
+  defp drive_loop(target_provider, last_id, batch_size, acc) do
+    target_name = Atom.to_string(target_provider)
+
+    ids =
+      from(u in User,
+        where: not is_nil(u.encrypted_dek) and u.key_provider != ^target_name,
+        where: u.id > ^last_id,
+        select: u.id,
+        order_by: u.id,
+        limit: ^batch_size
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    case ids do
+      [] ->
+        acc
+
+      _ ->
+        acc =
+          Enum.reduce(ids, acc, fn id, a ->
+            case migrate_user(id, target_provider) do
+              :ok -> Map.update!(a, :ok, &(&1 + 1))
+              :skipped -> Map.update!(a, :skipped, &(&1 + 1))
+              {:error, _} -> Map.update!(a, :failed, &(&1 + 1))
+            end
+          end)
+
+        drive_loop(target_provider, List.last(ids), batch_size, acc)
+    end
+  end
+
+  defp enqueue_loop(target_provider, target_name, last_id, batch_size, total) do
+    ids =
+      from(u in User,
+        where: not is_nil(u.encrypted_dek) and u.key_provider != ^target_name,
+        where: u.id > ^last_id,
+        select: u.id,
+        order_by: u.id,
+        limit: ^batch_size
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    case ids do
+      [] ->
+        total
+
+      _ ->
+        jobs =
+          Enum.map(ids, fn id ->
+            Engram.Workers.MigrateUserProvider.new(%{
+              "user_id" => id,
+              "target_provider" => target_name
+            })
+          end)
+
+        {:ok, _} =
+          Ecto.Multi.new()
+          |> Oban.insert_all(:migrate_provider_jobs, jobs)
+          |> Repo.transaction()
+
+        enqueue_loop(target_provider, target_name, List.last(ids), batch_size, total + length(jobs))
+    end
+  end
+```
+
+- [ ] **Step 4: Run test (expect MigrateUserProvider undefined)**
+
+```bash
+cd backend && mix test test/engram/crypto/provider_migration_test.exs --warnings-as-errors
+```
+
+Expected: 10 of 12 tests pass; `enqueue_all` tests fail with `Engram.Workers.MigrateUserProvider` undefined. (Task 6 ships the worker; this is intentional.) `migrate_all/2` + `status_counts/0` tests pass.
+
+- [ ] **Step 5: Commit (partial — worker lands in next task)**
+
+```bash
+cd backend && git add lib/engram/crypto/provider_migration.ex test/engram/crypto/provider_migration_test.exs && git commit -m "feat(crypto): ProviderMigration migrate_all + enqueue_all + status_counts
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6 — `MigrateUserProvider` Oban worker
+
+**Files:**
+- Create: `lib/engram/workers/migrate_user_provider.ex`
+- Create: `test/engram/workers/migrate_user_provider_test.exs`
+
+- [ ] **Step 1: Write failing worker tests**
+
+Create `test/engram/workers/migrate_user_provider_test.exs`:
+
+```elixir
+defmodule Engram.Workers.MigrateUserProviderTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Mox
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Repo
+  alias Engram.Workers.MigrateUserProvider
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+
+    Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+    table = :ets.new(:worker_kms_stub, [:set, :public])
+
+    stub(Engram.AwsKmsMock, :encrypt, fn pt, _ ->
+      ct = :crypto.strong_rand_bytes(48)
+      :ets.insert(table, {ct, pt})
+      {:ok, ct}
+    end)
+
+    stub(Engram.AwsKmsMock, :decrypt, fn ct, _ ->
+      case :ets.lookup(table, ct) do
+        [{^ct, pt}] -> {:ok, pt}
+        [] -> {:error, :context_mismatch}
+      end
+    end)
+
+    stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+    :ok
+  end
+
+  defp user_with_local_dek! do
+    {:ok, u} =
+      Engram.Accounts.create_user(%{
+        email: "w-#{System.unique_integer([:positive])}@e.test",
+        password: "pwpw1234!Z"
+      })
+
+    {:ok, u} = Crypto.ensure_user_dek(u)
+    u
+  end
+
+  test "perform/1 happy path: returns :ok, rewraps user" do
+    user = user_with_local_dek!()
+
+    assert :ok =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => user.id,
+               "target_provider" => "aws_kms"
+             })
+
+    reloaded = Repo.one!(from(u in User, where: u.id == ^user.id), skip_tenant_check: true)
+    assert reloaded.key_provider == "aws_kms"
+  end
+
+  test "perform/1 skipped (already at target) returns :ok" do
+    user = user_with_local_dek!()
+
+    :ok = perform_job(MigrateUserProvider, %{"user_id" => user.id, "target_provider" => "aws_kms"})
+
+    # Second run on same user should also return :ok (skipped collapses to :ok at worker layer).
+    assert :ok =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => user.id,
+               "target_provider" => "aws_kms"
+             })
+  end
+
+  test "perform/1 returns {:discard, :user_deleted} when user is missing" do
+    assert {:discard, :user_deleted} =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => 99_999_999,
+               "target_provider" => "aws_kms"
+             })
+  end
+
+  test "perform/1 returns {:discard, :no_dek} when user has no encrypted_dek" do
+    {:ok, u} =
+      Engram.Accounts.create_user(%{
+        email: "nokmsdek-#{System.unique_integer([:positive])}@e.test",
+        password: "pwpw1234!Z"
+      })
+
+    assert {:discard, :no_dek} =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => u.id,
+               "target_provider" => "aws_kms"
+             })
+  end
+
+  test "perform/1 returns {:error, reason} for retryable KMS errors" do
+    stub(Engram.AwsKmsMock, :encrypt, fn _, _ -> {:error, :throttled} end)
+    user = user_with_local_dek!()
+
+    assert {:error, {:kms_encrypt_failed, :throttled}} =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => user.id,
+               "target_provider" => "aws_kms"
+             })
+  end
+
+  test "perform/1 returns {:discard, {:invalid_args, …}} for malformed args" do
+    assert {:discard, {:invalid_args, _}} = perform_job(MigrateUserProvider, %{"garbage" => 1})
+  end
+
+  test "perform/1 rejects unknown target_provider" do
+    assert {:discard, {:unknown_target, "passphrase"}} =
+             perform_job(MigrateUserProvider, %{"user_id" => 1, "target_provider" => "passphrase"})
+  end
+end
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+cd backend && mix test test/engram/workers/migrate_user_provider_test.exs --warnings-as-errors
+```
+
+Expected: `Engram.Workers.MigrateUserProvider is not loaded`.
+
+- [ ] **Step 3: Implement the worker**
+
+Create `lib/engram/workers/migrate_user_provider.ex`:
+
+```elixir
+defmodule Engram.Workers.MigrateUserProvider do
+  @moduledoc """
+  Phase 3 — Oban worker that rewraps one user's `encrypted_dek` from the
+  source provider (identified by blob tag) to `target_provider`.
+
+  Args:
+
+      %{"user_id" => integer, "target_provider" => "local" | "aws_kms"}
+
+  Idempotent at two layers:
+
+  1. Oban uniqueness on `[:user_id, :target_provider]` for in-flight
+     states prevents duplicate jobs for the same target.
+  2. `ProviderMigration.migrate_user/2` returns `:skipped` when the user
+     is already at target — re-running stale jobs is a no-op.
+
+  Production runs prefer this worker over the long-lived Mix task: jobs
+  survive node restarts via Oban persistence, and the `:crypto_backfill`
+  queue's concurrency=1 serializes against other crypto migrations
+  (master rotation, AAD rebind, DEK rotation).
+  """
+
+  use Oban.Worker,
+    queue: :crypto_backfill,
+    max_attempts: 5,
+    unique: [
+      keys: [:user_id, :target_provider],
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  alias Engram.Crypto.ProviderMigration
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "target_provider" => target}})
+      when is_integer(user_id) and target in ["local", "aws_kms"] do
+    target_atom = String.to_existing_atom(target)
+
+    case ProviderMigration.migrate_user(user_id, target_atom) do
+      :ok -> :ok
+      :skipped -> :ok
+      {:error, {:not_found, _}} -> {:discard, :user_deleted}
+      {:error, :no_dek} -> {:discard, :no_dek}
+      {:error, :malformed_wrapped_blob} -> {:discard, :malformed_wrapped_blob}
+      {:error, :unrecognised_blob} -> {:discard, :unrecognised_blob}
+      {:error, %Ecto.Changeset{errors: errors}} -> {:discard, {:changeset_invalid, errors}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def perform(%Oban.Job{
+        args: %{"user_id" => _user_id, "target_provider" => other}
+      }) do
+    {:discard, {:unknown_target, other}}
+  end
+
+  def perform(%Oban.Job{args: args}) do
+    {:discard, {:invalid_args, Map.keys(args)}}
+  end
+end
+```
+
+- [ ] **Step 4: Run all migration tests**
+
+```bash
+cd backend && mix test test/engram/workers/migrate_user_provider_test.exs test/engram/crypto/provider_migration_test.exs --warnings-as-errors
+```
+
+Expected: 19 tests, 0 failures (12 from provider_migration_test + 7 from worker_test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add lib/engram/workers/migrate_user_provider.ex test/engram/workers/migrate_user_provider_test.exs && git commit -m "feat(crypto): MigrateUserProvider Oban worker
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7 — `Crypto.get_dek/1` dual-read + lazy enqueue
+
+**Files:**
+- Modify: `lib/engram/crypto.ex`
+- Modify: `test/engram/crypto_test.exs`
+
+- [ ] **Step 1: Write the failing dual-read tests**
+
+Find the existing `describe "get_dek/1"` block (if any) in `test/engram/crypto_test.exs` and append a new describe block at the bottom of the file (before the final `end`):
+
+```elixir
+  describe "get_dek/1 dual-read + lazy migration" do
+    import Mox
+    use Oban.Testing, repo: Engram.Repo
+    setup :verify_on_exit!
+
+    setup do
+      Application.put_env(
+        :engram,
+        :encryption_master_key,
+        Base.encode64(:crypto.strong_rand_bytes(32))
+      )
+
+      Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+
+      table = :ets.new(:dual_read_stub, [:set, :public])
+
+      stub(Engram.AwsKmsMock, :encrypt, fn pt, _ ->
+        ct = :crypto.strong_rand_bytes(48)
+        :ets.insert(table, {ct, pt})
+        {:ok, ct}
+      end)
+
+      stub(Engram.AwsKmsMock, :decrypt, fn ct, _ ->
+        case :ets.lookup(table, ct) do
+          [{^ct, pt}] -> {:ok, pt}
+          [] -> {:error, :context_mismatch}
+        end
+      end)
+
+      stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+      :ok
+    end
+
+    defp make_user_with_provider!(provider_module) do
+      Application.put_env(:engram, :key_provider, provider_module)
+
+      {:ok, u} =
+        Engram.Accounts.create_user(%{
+          email: "dual-#{System.unique_integer([:positive])}@e.test",
+          password: "pwpw1234!Z"
+        })
+
+      {:ok, u} = Engram.Crypto.ensure_user_dek(u)
+      Engram.Crypto.DekCache.delete(u.id)
+      u
+    end
+
+    test "Local blob + KEY_PROVIDER=local → succeeds, no enqueue" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.Local)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+      assert {:ok, <<_::256>>} = Engram.Crypto.get_dek(user)
+
+      refute_enqueued(worker: Engram.Workers.MigrateUserProvider, args: %{"user_id" => user.id})
+    end
+
+    test "Local blob + KEY_PROVIDER=aws_kms → succeeds via Local, enqueues lazy migration to KMS" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.Local)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+
+      assert {:ok, <<_::256>>} = Engram.Crypto.get_dek(user)
+
+      assert_enqueued(
+        worker: Engram.Workers.MigrateUserProvider,
+        args: %{"user_id" => user.id, "target_provider" => "aws_kms"}
+      )
+    end
+
+    test "KMS blob + KEY_PROVIDER=aws_kms → succeeds, no enqueue" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.AwsKms)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+
+      assert {:ok, <<_::256>>} = Engram.Crypto.get_dek(user)
+
+      refute_enqueued(worker: Engram.Workers.MigrateUserProvider, args: %{"user_id" => user.id})
+    end
+
+    test "KMS blob + KEY_PROVIDER=local → succeeds via KMS, enqueues reverse migration to local" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.AwsKms)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+      assert {:ok, <<_::256>>} = Engram.Crypto.get_dek(user)
+
+      assert_enqueued(
+        worker: Engram.Workers.MigrateUserProvider,
+        args: %{"user_id" => user.id, "target_provider" => "local"}
+      )
+    end
+
+    test "lazy enqueue is best-effort: an Oban.insert failure does not bubble to caller" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.Local)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+
+      # Cache hit path bypasses lazy enqueue entirely. Prime the cache,
+      # then assert no enqueue (because the unwrap path is short-circuited).
+      Engram.Crypto.DekCache.delete(user.id)
+      {:ok, dek} = Engram.Crypto.get_dek(user)
+      Engram.Crypto.DekCache.put(user.id, dek)
+
+      assert {:ok, ^dek} = Engram.Crypto.get_dek(user)
+      # First call enqueued; second call is a cache hit so no new job.
+      # Oban testing helper counts cumulative — at least one job exists.
+      assert_enqueued(worker: Engram.Workers.MigrateUserProvider, args: %{"user_id" => user.id})
+    end
+  end
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+cd backend && mix test test/engram/crypto_test.exs --warnings-as-errors
+```
+
+Expected: 4 of 5 dual-read tests fail because `get_dek/1` currently dispatches via `Resolver.provider_for/1` instead of `identify_from_blob/1`, and no lazy enqueue exists.
+
+- [ ] **Step 3: Patch `Crypto.get_dek/1`**
+
+In `lib/engram/crypto.ex`, replace the `get_dek/1` implementation (around line 173-201) with:
+
+```elixir
+  def get_dek(%User{encrypted_dek: nil}), do: {:error, :no_dek}
+
+  def get_dek(%User{id: user_id, encrypted_dek: blob, dek_version: dek_version}) do
+    mark_sensitive()
+
+    case DekCache.get(user_id) do
+      {:ok, dek} ->
+        {:ok, dek}
+
+      :miss ->
+        # Phase 3 — dispatch unwrap by blob tag, not by Resolver.provider/0.
+        # Lets mixed-state fleets read seamlessly during Local↔KMS backfill
+        # windows. Writes still follow Resolver (see ensure_user_dek/1).
+        case KeyProvider.identify_from_blob(blob) do
+          {:ok, source_provider} ->
+            ctx = %{
+              user_id: user_id,
+              dek_version: dek_version,
+              master_key_version: Engram.Crypto.Config.master_key_version()
+            }
+
+            case source_provider.unwrap_dek(blob, ctx) do
+              {:ok, dek} ->
+                DekCache.put(user_id, dek)
+                maybe_enqueue_lazy_migration(user_id, source_provider)
+                {:ok, dek}
+
+              {:error, _} = err ->
+                err
+            end
+
+          {:error, :unrecognised_blob} ->
+            {:error, :unrecognised_blob}
+        end
+    end
+  end
+
+  # Phase 3 — fire-and-forget lazy migration. Never blocks the read path,
+  # never raises. Oban uniqueness `[:user_id, :target_provider]` collapses
+  # duplicate enqueues against the active backfill drain.
+  defp maybe_enqueue_lazy_migration(user_id, source_provider) do
+    configured = Engram.Crypto.KeyProvider.Resolver.provider()
+
+    if source_provider != configured do
+      target_atom =
+        case configured do
+          Engram.Crypto.KeyProvider.Local -> :local
+          Engram.Crypto.KeyProvider.AwsKms -> :aws_kms
+          _ -> nil
+        end
+
+      if target_atom do
+        try do
+          %{"user_id" => user_id, "target_provider" => Atom.to_string(target_atom)}
+          |> Engram.Workers.MigrateUserProvider.new()
+          |> Oban.insert()
+        rescue
+          _ -> :ok
+        catch
+          _, _ -> :ok
+        end
+      end
+    end
+
+    :ok
+  end
+```
+
+Add the `alias Engram.Crypto.KeyProvider` near the top of `crypto.ex` if not already present (check the existing `alias` block).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd backend && mix test test/engram/crypto_test.exs --warnings-as-errors
+```
+
+Expected: all 5 dual-read tests pass. Other `crypto_test.exs` tests still green.
+
+- [ ] **Step 5: Run full crypto suite + worker suite**
+
+```bash
+cd backend && mix test test/engram/crypto/ test/engram/crypto_test.exs test/engram/workers/migrate_user_provider_test.exs --warnings-as-errors
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd backend && git add lib/engram/crypto.ex test/engram/crypto_test.exs && git commit -m "feat(crypto): get_dek dual-read via identify_from_blob + lazy migration enqueue
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8 — `engram.migrate_provider` Mix task
+
+**Files:**
+- Create: `lib/mix/tasks/engram.migrate_provider.ex`
+- Create: `test/mix/tasks/engram.migrate_provider_test.exs`
+
+- [ ] **Step 1: Write failing Mix task tests**
+
+Create `test/mix/tasks/engram.migrate_provider_test.exs`:
+
+```elixir
+defmodule Mix.Tasks.Engram.MigrateProviderTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Mox
+  import ExUnit.CaptureIO
+
+  alias Engram.Crypto
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+
+    Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+
+    table = :ets.new(:task_kms_stub, [:set, :public])
+
+    stub(Engram.AwsKmsMock, :encrypt, fn pt, _ ->
+      ct = :crypto.strong_rand_bytes(48)
+      :ets.insert(table, {ct, pt})
+      {:ok, ct}
+    end)
+
+    stub(Engram.AwsKmsMock, :decrypt, fn ct, _ ->
+      case :ets.lookup(table, ct) do
+        [{^ct, pt}] -> {:ok, pt}
+        [] -> {:error, :context_mismatch}
+      end
+    end)
+
+    stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+    :ok
+  end
+
+  defp local_user! do
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+    {:ok, u} =
+      Engram.Accounts.create_user(%{
+        email: "task-#{System.unique_integer([:positive])}@e.test",
+        password: "pwpw1234!Z"
+      })
+
+    {:ok, _} = Crypto.ensure_user_dek(u)
+    u
+  end
+
+  test "--target aws_kms sync drain rewraps every local user" do
+    _u1 = local_user!()
+    _u2 = local_user!()
+
+    out =
+      capture_io(fn ->
+        Mix.Tasks.Engram.MigrateProvider.run(["--target", "aws_kms"])
+      end)
+
+    assert out =~ "migration complete"
+    assert out =~ "ok="
+  end
+
+  test "--target aws_kms --enqueue inserts jobs without performing rewraps" do
+    user = local_user!()
+
+    out =
+      capture_io(fn ->
+        Mix.Tasks.Engram.MigrateProvider.run(["--target", "aws_kms", "--enqueue"])
+      end)
+
+    assert out =~ "enqueued"
+    assert_enqueued(worker: Engram.Workers.MigrateUserProvider, args: %{"user_id" => user.id})
+
+    reloaded =
+      Engram.Repo.one!(Ecto.Query.from(u in Engram.Accounts.User, where: u.id == ^user.id),
+        skip_tenant_check: true
+      )
+
+    # Not rewrapped yet — only enqueued.
+    assert reloaded.key_provider == "local"
+  end
+
+  test "--status prints provider counts" do
+    _ = local_user!()
+
+    out =
+      capture_io(fn ->
+        Mix.Tasks.Engram.MigrateProvider.run(["--status"])
+      end)
+
+    assert out =~ "local="
+    assert out =~ "aws_kms="
+    assert out =~ "total="
+  end
+
+  test "unknown --target exits 2 (catch System.halt)" do
+    assert catch_exit(
+             capture_io(:stderr, fn ->
+               Mix.Tasks.Engram.MigrateProvider.run(["--target", "passphrase"])
+             end)
+           ) == {:shutdown, 2}
+  end
+
+  test "missing required --target without --status exits 2" do
+    assert catch_exit(
+             capture_io(:stderr, fn ->
+               Mix.Tasks.Engram.MigrateProvider.run([])
+             end)
+           ) == {:shutdown, 2}
+  end
+end
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+```bash
+cd backend && mix test test/mix/tasks/engram.migrate_provider_test.exs --warnings-as-errors
+```
+
+Expected: `Mix.Tasks.Engram.MigrateProvider undefined`.
+
+- [ ] **Step 3: Implement the Mix task**
+
+Create `lib/mix/tasks/engram.migrate_provider.ex`:
+
+```elixir
+defmodule Mix.Tasks.Engram.MigrateProvider do
+  @shortdoc "Rewrap user encrypted_dek between KeyProviders (Local↔AwsKms)"
+
+  @moduledoc """
+  Phase 3 — Per-user `KeyProvider` migration entrypoint.
+
+  ## Usage
+
+      # Sync drain (dev / staging) — blocks until done:
+      mix engram.migrate_provider --target aws_kms
+
+      # Production: Oban enqueue (jobs survive node restart):
+      mix engram.migrate_provider --target aws_kms --enqueue
+
+      # Reverse rollback (KMS → Local):
+      mix engram.migrate_provider --target local --enqueue
+
+      # Provider count breakdown:
+      mix engram.migrate_provider --status
+
+  ## Exit codes
+
+  - `0` — clean (all users at target, or `--status` ran successfully).
+  - `1` — partial: at least one per-user failure (telemetry has details).
+  - `2` — misconfig (unknown `--target`, missing required arg).
+
+  ## Pre-cutover checklist
+
+  1. Set Fly secrets: `KEY_PROVIDER=aws_kms`, `AWS_KMS_KEY_ID`,
+     `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`.
+  2. Deploy. `BootCanaryGuard.AwsKms.boot_check/0` verifies CMK reachable.
+  3. Run `mix engram.migrate_provider --target aws_kms --enqueue` (or
+     release-rpc the underlying API: `Engram.Crypto.ProviderMigration.enqueue_all(:aws_kms)`).
+  4. Monitor `[:engram, :crypto, :migrate_provider, :user]` telemetry +
+     `mix engram.migrate_provider --status` until `local` count = 0.
+  """
+
+  use Mix.Task
+
+  alias Engram.Crypto.ProviderMigration
+
+  @switches [target: :string, enqueue: :boolean, status: :boolean, batch_size: :integer]
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {opts, _, _} = OptionParser.parse(args, switches: @switches)
+
+    cond do
+      opts[:status] ->
+        print_status()
+        :ok
+
+      is_nil(opts[:target]) ->
+        IO.puts(:stderr, "ERROR: --target is required (one of: aws_kms, local). Or pass --status.")
+        exit({:shutdown, 2})
+
+      opts[:target] not in ["aws_kms", "local"] ->
+        IO.puts(:stderr, "ERROR: unknown --target #{inspect(opts[:target])}; expected aws_kms | local")
+        exit({:shutdown, 2})
+
+      true ->
+        target_atom = String.to_existing_atom(opts[:target])
+        batch_size = Keyword.get(opts, :batch_size, 100)
+
+        if opts[:enqueue] do
+          run_enqueue(target_atom, batch_size)
+        else
+          run_drain(target_atom, batch_size)
+        end
+    end
+  end
+
+  defp run_drain(target_atom, batch_size) do
+    IO.puts("draining users → #{target_atom} (batch_size=#{batch_size})...")
+
+    counts = ProviderMigration.migrate_all(target_atom, batch_size: batch_size)
+
+    IO.puts(
+      "migration complete: ok=#{counts.ok} skipped=#{counts.skipped} failed=#{counts.failed}"
+    )
+
+    if counts.failed > 0 do
+      IO.puts(:stderr, "ERROR: #{counts.failed} users failed migration — inspect telemetry")
+      exit({:shutdown, 1})
+    end
+  end
+
+  defp run_enqueue(target_atom, batch_size) do
+    IO.puts("enqueueing users → #{target_atom} (batch_size=#{batch_size})...")
+
+    %{enqueued: n} = ProviderMigration.enqueue_all(target_atom, batch_size: batch_size)
+
+    IO.puts("enqueued #{n} MigrateUserProvider jobs on :crypto_backfill")
+  end
+
+  defp print_status do
+    counts = ProviderMigration.status_counts()
+    IO.puts("local=#{counts.local} aws_kms=#{counts.aws_kms} total=#{counts.total}")
+  end
+end
+```
+
+- [ ] **Step 4: Run Mix task tests**
+
+```bash
+cd backend && mix test test/mix/tasks/engram.migrate_provider_test.exs --warnings-as-errors
+```
+
+Expected: 5 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add lib/mix/tasks/engram.migrate_provider.ex test/mix/tasks/engram.migrate_provider_test.exs && git commit -m "feat(crypto): engram.migrate_provider Mix task (sync/enqueue/status)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9 — Telemetry handler registration
+
+**Files:**
+- Modify: `lib/engram_web/telemetry.ex`
+- Modify: `test/engram_web/telemetry_test.exs`
+
+- [ ] **Step 1: Write failing pin test**
+
+Open `test/engram_web/telemetry_test.exs`. Find the existing assertion that enumerates registered metrics (search for `[:engram, :crypto, :rotate, :user]` or similar pin). Append a new test in the same describe block:
+
+```elixir
+    test "registers [:engram, :crypto, :migrate_provider, :user] counter + summary" do
+      metrics = EngramWeb.Telemetry.metrics()
+      names = Enum.map(metrics, & &1.name)
+
+      assert Enum.member?(names, [:engram, :crypto, :migrate_provider, :user, :count])
+      assert Enum.member?(names, [:engram, :crypto, :migrate_provider, :user, :duration_us])
+    end
+```
+
+(If `telemetry_test.exs` does not exist, create it with `use ExUnit.Case` + the single test above.)
+
+- [ ] **Step 2: Run, observe failure**
+
+```bash
+cd backend && mix test test/engram_web/telemetry_test.exs --warnings-as-errors
+```
+
+Expected: assertion fails because the new metric isn't registered yet.
+
+- [ ] **Step 3: Add metrics to `EngramWeb.Telemetry`**
+
+In `lib/engram_web/telemetry.ex`, inside the `defp metrics do [ ... ]` list (alongside the existing `engram.crypto.rotate.user.count` and `engram.crypto.aad_rebind.user.count`), add:
+
+```elixir
+      counter("engram.crypto.migrate_provider.user.count",
+        tags: [:target_provider, :status, :reason_label],
+        description: "Phase 3 per-user provider migration outcome (Local↔AwsKms)"
+      ),
+      summary("engram.crypto.migrate_provider.user.duration_us",
+        unit: {:native, :microsecond},
+        tags: [:target_provider, :status],
+        description: "Phase 3 per-user provider migration duration"
+      ),
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+cd backend && mix test test/engram_web/telemetry_test.exs --warnings-as-errors
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add lib/engram_web/telemetry.ex test/engram_web/telemetry_test.exs && git commit -m "feat(telemetry): register migrate_provider.user counter + summary
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10 — Cross-provider conformance pin
+
+**Files:**
+- Modify: `test/engram/crypto/provider_conformance_test.exs`
+
+- [ ] **Step 1: Append cross-provider identify_from_blob test**
+
+Inside `Engram.Crypto.ProviderConformanceTest`, append (after the existing per-provider loop):
+
+```elixir
+  describe "cross-provider identify_from_blob/1 round-trip" do
+    test "every provider produces a blob that identify_from_blob maps back to itself" do
+      stub_aws_kms_roundtrip()
+
+      for provider <- @providers do
+        dek = provider.generate_dek()
+        {:ok, blob} = provider.wrap_dek(dek, %{user_id: 1})
+        assert {:ok, ^provider} = Engram.Crypto.KeyProvider.identify_from_blob(blob)
+      end
+    end
+  end
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+cd backend && mix test test/engram/crypto/provider_conformance_test.exs --warnings-as-errors
+```
+
+Expected: pass (round-trip works because Phase 1 already shipped `identify_from_blob/1` correctly).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd backend && git add test/engram/crypto/provider_conformance_test.exs && git commit -m "test(crypto): cross-provider identify_from_blob round-trip in conformance
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11 — Full suite + warnings-as-errors gate
+
+**Files:** none modified — quality gate.
+
+- [ ] **Step 1: Run full test suite with strict flags**
+
+```bash
+cd backend && mix test --warnings-as-errors
+```
+
+Expected: all tests pass. No compile warnings.
+
+- [ ] **Step 2: Run quality lints (matches CI gates from PR #90)**
+
+```bash
+cd backend && mix format --check-formatted && mix credo --strict && mix sobelow --config
+```
+
+Expected: all clean. Fix any lints inline before proceeding.
+
+- [ ] **Step 3: Final commit (only if lint fixes were needed)**
+
+If any lint adjustments were required:
+
+```bash
+cd backend && git add -u && git commit -m "chore(crypto): apply mix format + credo strict to Phase 3
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12 — Open PR
+
+**Files:** none — PR opening.
+
+- [ ] **Step 1: Push branch + open PR**
+
+```bash
+cd backend && git push -u origin docs/aws-kms-phase-3-design && gh pr create --title "feat(crypto): AWS KMS Phase 3 — provider migration (Local↔KMS)" --body "$(cat <<'EOF'
+## Summary
+- Per-user `KeyProvider` rewrap via `Engram.Crypto.ProviderMigration` + `Engram.Workers.MigrateUserProvider` + `mix engram.migrate_provider`
+- `Crypto.get_dek/1` now dispatches unwrap by blob tag (`KeyProvider.identify_from_blob/1`) and enqueues lazy migration when provider ≠ configured target
+- Forward (Local→KMS) and reverse (KMS→Local) share the same worker — `--target` arg flips direction
+- Telemetry `[:engram, :crypto, :migrate_provider, :user]` + Logger.error on failure
+- No schema changes — `users.encrypted_dek` + `users.key_provider` already exist
+
+## Spec
+`docs/superpowers/specs/2026-05-16-aws-kms-phase-3-provider-migration-design.md`
+
+## Test plan
+- [x] Unit tests for `migrate_user/2` happy paths, idempotence, race, failure modes
+- [x] Worker tests (retry vs discard classification + uniqueness)
+- [x] Mix task tests (sync, enqueue, status, exit codes)
+- [x] `get_dek/1` dual-read quadrant tests
+- [x] Cross-provider `identify_from_blob` conformance round-trip
+- [x] Telemetry handler registration pin
+
+## Out of scope
+- Phase 4 cutover runbook (separate spec)
+- Terraform templates for AWS account / KMS CMK / IAM (separate spec)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR opens. CI runs the full suite + lints + E2E.
+
+---
+
+## Notes for the executing engineer
+
+- All commits go on branch `docs/aws-kms-phase-3-design` (already created in `backend/`). One PR for the whole feature per the workspace memory `feedback_single_pr_all_changes`.
+- The `:crypto_backfill` Oban queue has concurrency=1 (`config/config.exs:51`) — this serializes the migration against MasterRotation / AadRebind / UserDekRotation. Don't change it.
+- KMS calls in tests go through `Engram.AwsKmsMock` (Mox); never hit AWS from the test suite. The `stub_kms_roundtrip` helper backs encrypt/decrypt with an ETS table so wrap/unwrap pairs are consistent within a test.
+- The `Crypto.get_dek/1` lazy enqueue uses a `try/rescue + catch _` belt-and-suspenders so a transient Oban insert failure (e.g. queue paused) never bubbles to the read caller — read availability is more important than instant migration enqueue.
+- `Repo.one(..., skip_tenant_check: true)` is required for any cross-tenant query (e.g. on `users`) since the codebase uses Ecto RLS scoping. Already used by `MasterRotation` — follow the same pattern.
+- After PR merges, Phase 4 brainstorm covers: Fly secrets sequence, IAM policy YAML, engram-selfhost guard against `KEY_PROVIDER=aws_kms`, production runbook (drain monitoring, abort criteria). Terraform spec follows.

--- a/docs/superpowers/specs/2026-05-16-aws-kms-phase-3-provider-migration-design.md
+++ b/docs/superpowers/specs/2026-05-16-aws-kms-phase-3-provider-migration-design.md
@@ -1,0 +1,206 @@
+# AWS KMS Phase 3 — Provider Migration Design
+
+> **Status:** Design, pending implementation plan.
+> **Predecessors:** PR #110 (Phase 1 — provider behaviour + AwsKms impl + conformance), PR #112 (Phase 2 — BootCanary polymorphism + KMS telemetry).
+> **Successors:** Phase 4 (Fly secrets + IAM cutover runbook), Terraform templates (separate spec).
+
+## Goal
+
+Ship a per-user, blob-tag-discriminated migration path so engram-saas can flip `KEY_PROVIDER=local` → `aws_kms` without downtime, with a symmetric rollback. engram-selfhost stays Local forever.
+
+## Non-Goals
+
+- Per-user opt-in (single fleet-wide flag).
+- Per-tier or per-vault provider selection.
+- Schema changes (`users.encrypted_dek` + `users.key_provider` columns already exist).
+- BootCanary or telemetry plumbing (Phase 2 already shipped).
+- AWS account / IAM / KMS CMK provisioning (Terraform spec covers this).
+- Production cutover runbook (Phase 4 spec covers this).
+
+## Key Insight
+
+Switching providers only rewraps the wrapped DEK blob. The underlying AES-GCM ciphertext rows (notes, attachments, qdrant payloads) are bound to the *plaintext* DEK, which is preserved across rewrap. One row update per user, no row-scan of tenant data. Migration cost is ~10× cheaper than T3.5 master rotation or T3.7 DEK rotation.
+
+## Architecture
+
+```
+                  ┌──────────────────────────────────────┐
+KEY_PROVIDER=aws_kms                                     │
+                  │                                      │
+                  ▼                                      │
+       Resolver.provider() ──► used by:                  │
+                  ├── ensure_user_dek/1 (new users)      │
+                  └── ProviderMigration (wrap target)    │
+                                                         │
+        get_dek/1 ─► KeyProvider.identify_from_blob/1 ──►│
+                     (0xAA → AwsKms, 0x01/0x02 → Local)  │
+                     unwrap dispatched by blob tag,      │
+                     NOT by Resolver.provider/0          │
+                                                         │
+        If blob_provider ≠ Resolver.provider():          │
+          fire-and-forget enqueue MigrateUserProvider ───┘
+```
+
+Read path is provider-agnostic. Write path follows `KEY_PROVIDER`. Mixed state safe by construction during entire backfill window.
+
+Forward (Local→KMS) and reverse (KMS→Local) share the same worker — `--target` arg flips direction. Rollback is symmetric, no extra code path.
+
+## Components
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `lib/engram/crypto/provider_migration.ex` | Public API: `migrate_user/2`, `migrate_all/2`, `enqueue_all/2`. Structural fork of `MasterRotation` (`lib/engram/crypto/master_rotation.ex`). |
+| `lib/engram/workers/migrate_user_provider.ex` | Oban worker. Queue `:crypto_backfill`. Uniqueness `[:user_id, :target_provider]`. |
+| `lib/mix/tasks/engram.migrate_provider.ex` | Ops entry point. Args: `--target aws_kms|local`, `--enqueue`, `--status`. Exit codes mirror `engram.rotate_master_key`. |
+| `test/engram/crypto/provider_migration_test.exs` | Unit tests for `ProviderMigration` API. |
+| `test/engram/workers/migrate_user_provider_test.exs` | Worker behaviour, retry vs discard classification. |
+| `test/mix/tasks/engram.migrate_provider_test.exs` | Mix task arg parsing, exit codes, `--status` output. |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `lib/engram/crypto.ex` (`get_dek/1`, ~line 175-201) | Replace `provider = Resolver.provider_for(user_id)` with `{:ok, provider} = KeyProvider.identify_from_blob(blob)` for the unwrap dispatch. After successful unwrap, if `provider != Resolver.provider()`, enqueue `MigrateUserProvider` async (fire-and-forget; reads never block on rewrap). |
+| `test/engram/crypto_test.exs` | Add dual-read tests covering all four `(blob_provider × configured_provider)` quadrants. |
+| `test/engram/crypto/provider_conformance_test.exs` | Add cross-provider conformance: `wrap_with(A) → identify_from_blob → unwrap_with(B)` asserts `A == B`. |
+| `test/engram_web/telemetry_test.exs` | Pin `[:engram, :crypto, :migrate_provider, :user]` handler registration. |
+
+### Unchanged
+
+- `KeyProvider` behaviour (Phase 1+2 callbacks sufficient).
+- `BootCanary` / `BootCanaryGuard` (Phase 2 already polymorphic).
+- `MasterRotation`, `UserDekRotation`, `AadRebind` (work transparently against either provider via `rotate_wrapping/2` / `unwrap_dek/2`).
+- `users` schema, migrations.
+- `ensure_user_dek/1` — first-write provisioning already uses `Resolver.provider/0` (`lib/engram/crypto.ex:136`).
+
+## Data Flow — Forward Cutover (Local→KMS, engram-saas)
+
+1. Ops sets Fly secrets: `KEY_PROVIDER=aws_kms`, `AWS_KMS_KEY_ID`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`. Deploy.
+2. `BootCanaryGuard` invokes `KeyProvider.AwsKms.boot_check/0` → AWS `DescribeKey` ping. Fails the boot fast on IAM / ARN / region misconfig. (Phase 2.)
+3. New users from this moment provisioned via KMS (`ensure_user_dek/1` → `Resolver.provider()` returns `AwsKms`).
+4. Existing users still have Local-wrapped blobs. Their first read post-cutover:
+   - `get_dek/1` → `identify_from_blob(blob)` → `Local` → unwrap succeeds → DekCache fills.
+   - Provider mismatch detected → `MigrateUserProvider` enqueued async with `target_provider: "aws_kms"`. Zero added latency on the read.
+5. Ops drives the backfill: `mix engram.migrate_provider --target aws_kms --enqueue`. Inserts one Oban job per user with `key_provider = "local"`.
+6. Each worker job, per user:
+   - `Repo.transaction` opens.
+   - `SELECT ... FOR UPDATE` on `users` row.
+   - `source_provider = KeyProvider.identify_from_blob(locked.encrypted_dek)`.
+   - `{:ok, dek} = source_provider.unwrap_dek(blob, ctx)`.
+   - `{:ok, new_blob} = target_provider.wrap_dek(dek, ctx)`.
+   - `Accounts.update_user_encryption(locked, %{encrypted_dek: new_blob, key_provider: "aws_kms", dek_version: Config.master_key_version()})`.
+   - Commit.
+   - `DekCache.put(user_id, dek)` *after* commit (rolled-back txn must not poison cache — matches `ensure_user_dek/1` invariant from T3.1).
+7. Operator monitors `[:engram, :crypto, :migrate_provider, :user]` telemetry + `SELECT key_provider, COUNT(*) FROM users GROUP BY 1`. Backfill done when `local` count = 0.
+
+## Data Flow — Reverse Cutover (KMS→Local, rollback)
+
+1. Flip `KEY_PROVIDER=local`. Redeploy. New writes immediately revert to Local.
+2. Reads remain dual-routed: KMS blobs still unwrap via `KeyProvider.AwsKms` as long as AWS creds + IAM remain valid.
+3. Run `mix engram.migrate_provider --target local --enqueue`. Same worker, target flips. KMS→Local rewraps.
+4. Once `key_provider = "aws_kms"` count = 0, drop AWS secrets from Fly.
+
+## Error Handling
+
+Per-user failure classes mirror `MasterRotation.classify_reason/1`:
+
+| Reason | Source | Worker behavior | Logging |
+|---|---|---|---|
+| `:kms_throttled` | KMS ThrottlingException | `{:error, reason}` → Oban retry w/ backoff | Telemetry only |
+| `:kms_access_denied` | IAM denies Encrypt/Decrypt | `{:error, reason}` → retry | Logger.error + telemetry |
+| `:invalid_wrapping` | EncryptionContext mismatch | `{:error, reason}` → retry (operator may need to investigate) | Logger.error + telemetry |
+| `:kms_key_not_found` | CMK deleted/disabled | `{:error, reason}` → retry | Logger.error + telemetry |
+| `:malformed_wrapped_blob` | Source blob format unexpected | `{:discard, reason}` (no infinite retry on data corruption) | Logger.error + telemetry |
+| `{:not_found, uid}` | User row gone mid-flight | `:ok` (skip silently — user was deleted) | None |
+
+**Atomicity:** rewrap executes entirely inside `Repo.transaction` with `SELECT ... FOR UPDATE`. If `target_provider.wrap_dek` fails after `source_provider.unwrap_dek` succeeds, the txn rolls back and `users.encrypted_dek` is untouched.
+
+**Plaintext DEK hygiene:** `migrate_user/2` calls the same `mark_sensitive/0` primitive (process flag `:sensitive`) used by `Crypto.get_dek/1`. DEK plaintext lives only on the worker process stack during the txn; goes out of scope at txn close. Excluded from any future crash dump.
+
+**Telemetry / log fan-out matches T3-audit H4 pattern (PR #81):** every failure emits both `Logger.error(reason_label=…)` AND `[:engram, :crypto, :migrate_provider, :user]` with `status: :failed, reason_label, provider: <target>`.
+
+## Operator Tooling
+
+```bash
+# Sync drain (dev / staging only — blocks until done):
+mix engram.migrate_provider --target aws_kms
+
+# Production-friendly Oban enqueue (default for ops):
+mix engram.migrate_provider --target aws_kms --enqueue
+
+# Reverse rollback:
+mix engram.migrate_provider --target local --enqueue
+
+# Status:
+mix engram.migrate_provider --status
+# => %{aws_kms: 1240, local: 17, total: 1257}
+# => Pending jobs in :crypto_backfill: 17
+```
+
+Exit codes:
+- `0` — all users at target (or fleet empty).
+- `1` — partial: at least one `:failed` outcome.
+- `2` — misconfig (unknown `--target`, missing AWS env when target=aws_kms, etc.).
+
+## Invariants
+
+1. **`dek_version` stamp:** ProviderMigration writes `users.dek_version = Engram.Crypto.Config.master_key_version()` at rewrap time. A subsequent `MasterRotation` pass correctly skips just-migrated users (their `dek_version` already matches current master).
+2. **Cache safety:** `DekCache.put/2` only after txn commits. Rolled-back txn never poisons cache.
+3. **Idempotence:** `migrate_user/2` on a user already at target returns `:skipped`, no provider calls made. Mix task may be re-run safely.
+4. **Dedup:** Oban uniqueness `[:user_id, :target_provider]` collapses duplicate enqueues from both backfill and lazy paths.
+5. **Read-write split:** reads use `identify_from_blob/1`. Writes use `Resolver.provider/0`. Steady state: both agree. Migration window: they diverge per-user until backfill drains.
+
+## Testing
+
+### Unit (`provider_migration_test.exs`)
+
+| Test | What it pins |
+|---|---|
+| `migrate_user/2 Local→KMS happy path` | Mox `AwsKmsMock.encrypt/2` deterministic ct → blob leading byte = `0xAA`, `key_provider = "aws_kms"`, `dek_version = master_key_version()`. DekCache populated with original plaintext DEK (round-trip identity). |
+| `migrate_user/2 KMS→Local reverse` | Same as above, target = `:local`, blob leading byte = `0x01`/`0x02`. |
+| `idempotent skip` | Second `migrate_user(uid, :aws_kms)` on already-KMS user returns `:skipped`, zero provider calls. |
+| `concurrent rewrap race` | 4 parallel `migrate_user/2` calls for same user (`Task.async_stream`). Assert exactly one rewrap, three `:skipped`. Mirrors PR #74 race test. |
+| `KMS failure modes` | Mox returns `{:error, :access_denied}` / `:throttled` / `:context_mismatch` → txn rolls back, `users.encrypted_dek` unchanged, telemetry emits `status: :failed, reason_label` per class. |
+| `malformed source blob` | User row with junk blob → `{:error, :malformed_wrapped_blob}`, no destructive write. |
+| `not-found user` | User deleted mid-flight → `:ok` (silent skip). |
+| `dek_version stamp` | After Local→KMS, `users.dek_version == Config.master_key_version()`. |
+
+### Worker (`migrate_user_provider_test.exs`)
+
+- `perform/1` happy path delegates to `ProviderMigration.migrate_user/2`.
+- `:kms_throttled` / `:kms_access_denied` → `{:error, ...}` (Oban retries).
+- `:malformed_wrapped_blob` → `{:discard, ...}` (terminal, no infinite retry).
+- Uniqueness `[:user_id, :target_provider]` rejects duplicate insert.
+
+### Mix task (`engram.migrate_provider_test.exs`)
+
+- `--target aws_kms` sync drain returns `%{ok: N, skipped: M, failed: K}`.
+- `--target aws_kms --enqueue` inserts Oban jobs without performing rewraps.
+- `--status` prints provider breakdown to stdout.
+- Exit codes per scenario.
+
+### `get_dek/1` dual-read (`crypto_test.exs`)
+
+Four quadrant cases:
+- Local blob + `KEY_PROVIDER=local` → read succeeds, no enqueue.
+- KMS blob + `KEY_PROVIDER=aws_kms` → read succeeds, no enqueue.
+- Local blob + `KEY_PROVIDER=aws_kms` → read succeeds via `identify_from_blob` Local dispatch, `MigrateUserProvider` job enqueued exactly once per Oban dedup window.
+- KMS blob + `KEY_PROVIDER=local` → read succeeds via `identify_from_blob` KMS dispatch, reverse `MigrateUserProvider` job enqueued (rollback support).
+
+### Conformance (`provider_conformance_test.exs`)
+
+Add cross-provider parametrised case: for each `(source, target)` ∈ `{Local, AwsKms}²`, `wrap_with(source) → identify_from_blob → unwrap_with(identified)` round-trips identity (validates that `identify_from_blob/1` agrees with the producing provider for all blob shapes).
+
+### Telemetry (`telemetry_test.exs`)
+
+Pin `[:engram, :crypto, :migrate_provider, :user]` handler registration in `EngramWeb.Telemetry`. Measurements: `%{duration_us, count: 1}`. Metadata: `%{user_id, target_provider, status: :ok | :skipped | :failed, reason_label?}`.
+
+## Out of Scope (Phase 4 / Terraform specs)
+
+- Fly secrets provisioning sequence + verify steps.
+- IAM policy YAML (with `kms:EncryptionContext:purpose = "dek_wrap"` `StringEquals` condition).
+- Terraform module: AWS account / KMS CMK / IAM role + policy / variables for SaaS vs self-host.
+- engram-selfhost guard (`KEY_PROVIDER=aws_kms` should be unsupported on the self-host image — Phase 4 to gate at boot).
+- Production runbook (pre-flight checks, drain monitoring, abort criteria).

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -226,9 +226,12 @@ defmodule Engram.Crypto do
 
       if target_atom do
         try do
-          %{"user_id" => user_id, "target_provider" => Atom.to_string(target_atom)}
-          |> Engram.Workers.MigrateUserProvider.new()
-          |> Oban.insert()
+          _ =
+            %{"user_id" => user_id, "target_provider" => Atom.to_string(target_atom)}
+            |> Engram.Workers.MigrateUserProvider.new()
+            |> Oban.insert()
+
+          :ok
         rescue
           _ -> :ok
         catch

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -9,7 +9,8 @@ defmodule Engram.Crypto do
 
   alias Engram.Accounts
   alias Engram.Accounts.User
-  alias Engram.Crypto.{DekCache, Envelope, KeyProvider.Resolver}
+  alias Engram.Crypto.{DekCache, Envelope, KeyProvider}
+  alias Engram.Crypto.KeyProvider.Resolver
   alias Engram.Repo
 
   require Logger
@@ -180,24 +181,63 @@ defmodule Engram.Crypto do
         {:ok, dek}
 
       :miss ->
-        provider = Resolver.provider_for(user_id)
-        # T3.5 / M4 — pass user.dek_version + master_key_version so the
-        # provider can gate the `_PREVIOUS` fallback (audit M4).
-        ctx = %{
-          user_id: user_id,
-          dek_version: dek_version,
-          master_key_version: Engram.Crypto.Config.master_key_version()
-        }
+        # Phase 3 — dispatch unwrap by blob tag, not by Resolver.provider/0.
+        # Lets mixed-state fleets read seamlessly during Local↔KMS backfill
+        # windows. Writes still follow Resolver (see ensure_user_dek/1).
+        case KeyProvider.identify_from_blob(blob) do
+          {:ok, source_provider} ->
+            # T3.5 / M4 — pass user.dek_version + master_key_version so the
+            # provider can gate the `_PREVIOUS` fallback (audit M4).
+            ctx = %{
+              user_id: user_id,
+              dek_version: dek_version,
+              master_key_version: Engram.Crypto.Config.master_key_version()
+            }
 
-        case provider.unwrap_dek(blob, ctx) do
-          {:ok, dek} ->
-            DekCache.put(user_id, dek)
-            {:ok, dek}
+            case source_provider.unwrap_dek(blob, ctx) do
+              {:ok, dek} ->
+                DekCache.put(user_id, dek)
+                maybe_enqueue_lazy_migration(user_id, source_provider)
+                {:ok, dek}
 
-          {:error, _} = err ->
-            err
+              {:error, _} = err ->
+                err
+            end
+
+          {:error, :unrecognised_blob} ->
+            {:error, :unrecognised_blob}
         end
     end
+  end
+
+  # Phase 3 — fire-and-forget lazy migration. Never blocks the read path,
+  # never raises. Oban uniqueness `[:user_id, :target_provider]` collapses
+  # duplicate enqueues against the active backfill drain.
+  defp maybe_enqueue_lazy_migration(user_id, source_provider) do
+    configured = Resolver.provider()
+
+    if source_provider != configured do
+      target_atom =
+        case configured do
+          Engram.Crypto.KeyProvider.Local -> :local
+          Engram.Crypto.KeyProvider.AwsKms -> :aws_kms
+          _ -> nil
+        end
+
+      if target_atom do
+        try do
+          %{"user_id" => user_id, "target_provider" => Atom.to_string(target_atom)}
+          |> Engram.Workers.MigrateUserProvider.new()
+          |> Oban.insert()
+        rescue
+          _ -> :ok
+        catch
+          _, _ -> :ok
+        end
+      end
+    end
+
+    :ok
   end
 
   # T3.3 / M9 — mark every caller process that touches a plaintext DEK as

--- a/lib/engram/crypto/dek_cache.ex
+++ b/lib/engram/crypto/dek_cache.ex
@@ -66,6 +66,10 @@ defmodule Engram.Crypto.DekCache do
     GenServer.call(__MODULE__, {:invalidate, user_id})
   end
 
+  @doc "Removes the cached DEK for `user_id`, if any. Alias of `invalidate/1`."
+  @spec delete(user_id :: integer()) :: :ok
+  def delete(user_id), do: invalidate(user_id)
+
   @spec invalidate_all() :: :ok
   def invalidate_all do
     GenServer.call(__MODULE__, :invalidate_all)

--- a/lib/engram/crypto/provider_migration.ex
+++ b/lib/engram/crypto/provider_migration.ex
@@ -75,6 +75,66 @@ defmodule Engram.Crypto.ProviderMigration do
     end
   end
 
+  @doc """
+  Migrate every user whose `key_provider` ≠ `target_provider`. Cursor-by-id.
+  Each user runs in its own transaction.
+
+  Returns aggregate counts. `:skipped` includes both already-at-target
+  users and users without an `encrypted_dek` (latter is rare; counted as
+  skipped because the fleet drain semantically completes for them).
+  """
+  @spec migrate_all(provider_atom(), keyword()) :: counts() | {:error, term()}
+  def migrate_all(target_provider, opts \\ []) when target_provider in [:local, :aws_kms] do
+    batch_size = Keyword.get(opts, :batch_size, 100)
+    target_name = Atom.to_string(target_provider)
+
+    already_at_target =
+      from(u in User,
+        where: not is_nil(u.encrypted_dek) and u.key_provider == ^target_name,
+        select: count(u.id)
+      )
+      |> Repo.one(skip_tenant_check: true)
+
+    drive_loop(target_provider, 0, batch_size, %{
+      ok: 0,
+      skipped: already_at_target || 0,
+      failed: 0
+    })
+  end
+
+  @doc """
+  Enqueue one `Engram.Workers.MigrateUserProvider` Oban job per below-target
+  user. Idempotent — Oban uniqueness on `[:user_id, :target_provider]`
+  collapses duplicate inserts; the worker re-checks `:skipped` at perform.
+  """
+  @spec enqueue_all(provider_atom(), keyword()) :: %{enqueued: non_neg_integer()}
+  def enqueue_all(target_provider, opts \\ []) when target_provider in [:local, :aws_kms] do
+    batch_size = Keyword.get(opts, :batch_size, 500)
+    target_name = Atom.to_string(target_provider)
+    %{enqueued: enqueue_loop(target_provider, target_name, 0, batch_size, 0)}
+  end
+
+  @doc "Provider count breakdown: `%{local: N, aws_kms: M, total: N+M}`."
+  @spec status_counts() :: %{atom() => non_neg_integer()}
+  def status_counts do
+    rows =
+      from(u in User,
+        where: not is_nil(u.encrypted_dek),
+        group_by: u.key_provider,
+        select: {u.key_provider, count(u.id)}
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    base = %{local: 0, aws_kms: 0}
+
+    rows
+    |> Enum.reduce(base, fn {provider, n}, acc ->
+      key = if provider in ["local", "aws_kms"], do: String.to_atom(provider), else: :other
+      Map.update(acc, key, n, &(&1 + n))
+    end)
+    |> then(fn counts -> Map.put(counts, :total, counts.local + counts.aws_kms) end)
+  end
+
   # ── internals ──────────────────────────────────────────────────────
 
   defp do_migrate(user_id, target_provider) do
@@ -194,4 +254,68 @@ defmodule Engram.Crypto.ProviderMigration do
     do: reason.__struct__ |> Module.split() |> List.last()
 
   defp classify_reason(_other), do: "other"
+
+  defp drive_loop(target_provider, last_id, batch_size, acc) do
+    target_name = Atom.to_string(target_provider)
+
+    ids =
+      from(u in User,
+        where: not is_nil(u.encrypted_dek) and u.key_provider != ^target_name,
+        where: u.id > ^last_id,
+        select: u.id,
+        order_by: u.id,
+        limit: ^batch_size
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    case ids do
+      [] ->
+        acc
+
+      _ ->
+        acc =
+          Enum.reduce(ids, acc, fn id, a ->
+            case migrate_user(id, target_provider) do
+              :ok -> Map.update!(a, :ok, &(&1 + 1))
+              :skipped -> Map.update!(a, :skipped, &(&1 + 1))
+              {:error, _} -> Map.update!(a, :failed, &(&1 + 1))
+            end
+          end)
+
+        drive_loop(target_provider, List.last(ids), batch_size, acc)
+    end
+  end
+
+  defp enqueue_loop(target_provider, target_name, last_id, batch_size, total) do
+    ids =
+      from(u in User,
+        where: not is_nil(u.encrypted_dek) and u.key_provider != ^target_name,
+        where: u.id > ^last_id,
+        select: u.id,
+        order_by: u.id,
+        limit: ^batch_size
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    case ids do
+      [] ->
+        total
+
+      _ ->
+        jobs =
+          Enum.map(ids, fn id ->
+            Engram.Workers.MigrateUserProvider.new(%{
+              "user_id" => id,
+              "target_provider" => target_name
+            })
+          end)
+
+        {:ok, _} =
+          Ecto.Multi.new()
+          |> Oban.insert_all(:migrate_provider_jobs, jobs)
+          |> Repo.transaction()
+
+        enqueue_loop(target_provider, target_name, List.last(ids), batch_size, total + length(jobs))
+    end
+  end
 end

--- a/lib/engram/crypto/provider_migration.ex
+++ b/lib/engram/crypto/provider_migration.ex
@@ -1,0 +1,176 @@
+defmodule Engram.Crypto.ProviderMigration do
+  @moduledoc """
+  Phase 3 — Per-user `KeyProvider` rewrap. Migrates `users.encrypted_dek`
+  from one provider to another (Local↔AwsKms) by unwrapping with the
+  source provider (identified via `KeyProvider.identify_from_blob/1`) and
+  re-wrapping with the target.
+
+  Cheaper than `MasterRotation` / `UserDekRotation`: the *plaintext* DEK
+  is preserved across rewrap, so no tenant data rows need re-encryption.
+  Only `users.encrypted_dek` + `users.key_provider` change per user.
+
+  Telemetry `[:engram, :crypto, :migrate_provider, :user]` per call with
+  `%{duration_us, count}` measurements and
+  `%{user_id, target_provider, status: :ok | :skipped | :failed, reason_label?}`.
+
+  Forward (Local→AwsKms) and reverse (AwsKms→Local) use the same code
+  path — `target_provider` arg flips direction.
+
+  ## Lock + transaction shape
+
+  Each rewrap runs in its own `Repo.transaction` with `SELECT ... FOR UPDATE`
+  on the user row. Concurrent callers (Mix task + Oban job for the same
+  user) serialize cleanly: the loser sees the post-commit `key_provider`
+  and short-circuits to `:skipped`.
+
+  `DekCache.put/2` is deferred until AFTER the transaction commits — a
+  rolled-back txn must NOT leave a cached DEK that no longer matches DB.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Accounts
+  alias Engram.Accounts.User
+  alias Engram.Crypto.{Config, KeyProvider}
+  alias Engram.Crypto.KeyProvider.{AwsKms, Local}
+  alias Engram.Repo
+
+  require Logger
+
+  @type provider_atom :: :local | :aws_kms
+  @type migrate_result :: :ok | :skipped | {:error, term()}
+  @type counts :: %{ok: non_neg_integer(), skipped: non_neg_integer(), failed: non_neg_integer()}
+
+  @doc "Migrate one user's wrapped DEK to `target_provider`."
+  @spec migrate_user(integer() | User.t(), provider_atom()) :: migrate_result()
+  def migrate_user(user_or_id, target_provider) when target_provider in [:local, :aws_kms] do
+    user_id =
+      case user_or_id do
+        %User{id: id} -> id
+        id when is_integer(id) -> id
+      end
+
+    started_at = System.monotonic_time()
+    result = do_migrate(user_id, target_provider)
+    duration_us = duration_us_since(started_at)
+    emit_telemetry(user_id, target_provider, result, duration_us)
+
+    case result do
+      {:migrated, _user, _dek} -> :ok
+      {:skipped, _user} -> :skipped
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # ── internals ──────────────────────────────────────────────────────
+
+  defp do_migrate(user_id, target_provider) do
+    target_module = module_for(target_provider)
+    target_name = Atom.to_string(target_provider)
+
+    txn =
+      Repo.transaction(fn ->
+        locked =
+          from(u in User, where: u.id == ^user_id, lock: "FOR UPDATE")
+          |> Repo.one(skip_tenant_check: true)
+
+        cond do
+          is_nil(locked) ->
+            Repo.rollback({:not_found, user_id})
+
+          is_nil(locked.encrypted_dek) ->
+            Repo.rollback(:no_dek)
+
+          locked.key_provider == target_name ->
+            {:skipped, locked}
+
+          true ->
+            rewrap_locked(locked, target_module, target_name)
+        end
+      end)
+
+    case txn do
+      {:ok, {:skipped, user}} -> {:skipped, user}
+      {:ok, {:migrated, user, dek}} -> {:migrated, user, dek}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp rewrap_locked(%User{} = locked, target_module, target_name) do
+    with {:ok, source_module} <- KeyProvider.identify_from_blob(locked.encrypted_dek),
+         ctx = %{user_id: locked.id},
+         {:ok, dek} <- source_module.unwrap_dek(locked.encrypted_dek, ctx),
+         {:ok, new_blob} <- target_module.wrap_dek(dek, ctx),
+         {:ok, updated} <-
+           Accounts.update_user_encryption(locked, %{
+             encrypted_dek: new_blob,
+             key_provider: target_name,
+             dek_version: Config.master_key_version()
+           }) do
+      {:migrated, updated, dek}
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp module_for(:local), do: Local
+  defp module_for(:aws_kms), do: AwsKms
+
+  defp duration_us_since(started_at) do
+    System.convert_time_unit(
+      System.monotonic_time() - started_at,
+      :native,
+      :microsecond
+    )
+  end
+
+  defp emit_telemetry(user_id, target_provider, {:migrated, _, _}, duration_us) do
+    :telemetry.execute(
+      [:engram, :crypto, :migrate_provider, :user],
+      %{duration_us: duration_us, count: 1},
+      %{user_id: user_id, target_provider: target_provider, status: :ok}
+    )
+  end
+
+  defp emit_telemetry(user_id, target_provider, {:skipped, _}, duration_us) do
+    :telemetry.execute(
+      [:engram, :crypto, :migrate_provider, :user],
+      %{duration_us: duration_us, count: 1},
+      %{user_id: user_id, target_provider: target_provider, status: :skipped}
+    )
+  end
+
+  defp emit_telemetry(user_id, target_provider, {:error, reason}, duration_us) do
+    label = classify_reason(reason)
+
+    Logger.error(
+      "provider migration failed user_id=#{user_id} target=#{target_provider} reason_label=#{label}",
+      category: :crypto_migration
+    )
+
+    :telemetry.execute(
+      [:engram, :crypto, :migrate_provider, :user],
+      %{duration_us: duration_us, count: 1},
+      %{
+        user_id: user_id,
+        target_provider: target_provider,
+        status: :failed,
+        reason_label: label
+      }
+    )
+  end
+
+  defp classify_reason(:no_dek), do: "no_dek"
+  defp classify_reason({:not_found, _}), do: "not_found"
+  defp classify_reason(:invalid_wrapping), do: "invalid_wrapping"
+  defp classify_reason(:malformed_wrapped_blob), do: "malformed_wrapped_blob"
+  defp classify_reason(:kms_throttled), do: "kms_throttled"
+  defp classify_reason(:kms_access_denied), do: "kms_access_denied"
+  defp classify_reason(:kms_key_not_found), do: "kms_key_not_found"
+  defp classify_reason({:kms_encrypt_failed, _}), do: "kms_encrypt_failed"
+  defp classify_reason({:kms_decrypt_failed, _}), do: "kms_decrypt_failed"
+  defp classify_reason(:unrecognised_blob), do: "unrecognised_blob"
+  defp classify_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp classify_reason(%Ecto.Changeset{}), do: "changeset_invalid"
+  defp classify_reason(_other), do: "other"
+end

--- a/lib/engram/crypto/provider_migration.ex
+++ b/lib/engram/crypto/provider_migration.ex
@@ -23,8 +23,19 @@ defmodule Engram.Crypto.ProviderMigration do
   user) serialize cleanly: the loser sees the post-commit `key_provider`
   and short-circuits to `:skipped`.
 
-  `DekCache.put/2` is deferred until AFTER the transaction commits — a
-  rolled-back txn must NOT leave a cached DEK that no longer matches DB.
+  The plaintext DEK is unchanged across rewrap (only its wrapping
+  changes), so `DekCache` entries remain valid and do NOT need
+  invalidation. The `:sensitive` process flag is set at entry to keep
+  the DEK out of any crash dump if the wrap call raises.
+
+  ## `dek_version` after migration
+
+  `dek_version` tracks master-key generation, not provider. After
+  rewrap, the new blob is encoded under the current master-key version
+  (Local always; AwsKms ignores it but stamps the column so a
+  subsequent `MasterRotation` pass correctly skips just-migrated rows).
+  Stamping `dek_version: Config.master_key_version()` is the right
+  floor for both providers.
   """
 
   import Ecto.Query, only: [from: 2]
@@ -44,6 +55,8 @@ defmodule Engram.Crypto.ProviderMigration do
   @doc "Migrate one user's wrapped DEK to `target_provider`."
   @spec migrate_user(integer() | User.t(), provider_atom()) :: migrate_result()
   def migrate_user(user_or_id, target_provider) when target_provider in [:local, :aws_kms] do
+    Process.flag(:sensitive, true)
+
     user_id =
       case user_or_id do
         %User{id: id} -> id
@@ -56,7 +69,7 @@ defmodule Engram.Crypto.ProviderMigration do
     emit_telemetry(user_id, target_provider, result, duration_us)
 
     case result do
-      {:migrated, _user, _dek} -> :ok
+      {:migrated, _user} -> :ok
       {:skipped, _user} -> :skipped
       {:error, reason} -> {:error, reason}
     end
@@ -91,14 +104,18 @@ defmodule Engram.Crypto.ProviderMigration do
 
     case txn do
       {:ok, {:skipped, user}} -> {:skipped, user}
-      {:ok, {:migrated, user, dek}} -> {:migrated, user, dek}
+      {:ok, {:migrated, user}} -> {:migrated, user}
       {:error, reason} -> {:error, reason}
     end
   end
 
   defp rewrap_locked(%User{} = locked, target_module, target_name) do
     with {:ok, source_module} <- KeyProvider.identify_from_blob(locked.encrypted_dek),
-         ctx = %{user_id: locked.id},
+         ctx = %{
+           user_id: locked.id,
+           dek_version: locked.dek_version,
+           master_key_version: Engram.Crypto.Config.master_key_version()
+         },
          {:ok, dek} <- source_module.unwrap_dek(locked.encrypted_dek, ctx),
          {:ok, new_blob} <- target_module.wrap_dek(dek, ctx),
          {:ok, updated} <-
@@ -107,7 +124,7 @@ defmodule Engram.Crypto.ProviderMigration do
              key_provider: target_name,
              dek_version: Config.master_key_version()
            }) do
-      {:migrated, updated, dek}
+      {:migrated, updated}
     else
       {:error, reason} -> Repo.rollback(reason)
     end
@@ -124,7 +141,7 @@ defmodule Engram.Crypto.ProviderMigration do
     )
   end
 
-  defp emit_telemetry(user_id, target_provider, {:migrated, _, _}, duration_us) do
+  defp emit_telemetry(user_id, target_provider, {:migrated, _}, duration_us) do
     :telemetry.execute(
       [:engram, :crypto, :migrate_provider, :user],
       %{duration_us: duration_us, count: 1},
@@ -172,5 +189,9 @@ defmodule Engram.Crypto.ProviderMigration do
   defp classify_reason(:unrecognised_blob), do: "unrecognised_blob"
   defp classify_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
   defp classify_reason(%Ecto.Changeset{}), do: "changeset_invalid"
+
+  defp classify_reason(reason) when is_exception(reason),
+    do: reason.__struct__ |> Module.split() |> List.last()
+
   defp classify_reason(_other), do: "other"
 end

--- a/lib/engram/crypto/provider_migration.ex
+++ b/lib/engram/crypto/provider_migration.ex
@@ -129,7 +129,9 @@ defmodule Engram.Crypto.ProviderMigration do
 
     rows
     |> Enum.reduce(base, fn {provider, n}, acc ->
-      key = if provider in ["local", "aws_kms"], do: String.to_atom(provider), else: :other
+      key =
+        if provider in ["local", "aws_kms"], do: String.to_existing_atom(provider), else: :other
+
       Map.update(acc, key, n, &(&1 + n))
     end)
     |> then(fn counts -> Map.put(counts, :total, counts.local + counts.aws_kms) end)
@@ -315,7 +317,13 @@ defmodule Engram.Crypto.ProviderMigration do
           |> Oban.insert_all(:migrate_provider_jobs, jobs)
           |> Repo.transaction()
 
-        enqueue_loop(target_provider, target_name, List.last(ids), batch_size, total + length(jobs))
+        enqueue_loop(
+          target_provider,
+          target_name,
+          List.last(ids),
+          batch_size,
+          total + length(jobs)
+        )
     end
   end
 end

--- a/lib/engram/workers/migrate_user_provider.ex
+++ b/lib/engram/workers/migrate_user_provider.ex
@@ -1,0 +1,59 @@
+defmodule Engram.Workers.MigrateUserProvider do
+  @moduledoc """
+  Phase 3 — Oban worker that rewraps one user's `encrypted_dek` from the
+  source provider (identified by blob tag) to `target_provider`.
+
+  Args:
+
+      %{"user_id" => integer, "target_provider" => "local" | "aws_kms"}
+
+  Idempotent at two layers:
+
+  1. Oban uniqueness on `[:user_id, :target_provider]` for in-flight
+     states prevents duplicate jobs for the same target.
+  2. `ProviderMigration.migrate_user/2` returns `:skipped` when the user
+     is already at target — re-running stale jobs is a no-op.
+
+  Production runs prefer this worker over the long-lived Mix task: jobs
+  survive node restarts via Oban persistence, and the `:crypto_backfill`
+  queue's concurrency=1 serializes against other crypto migrations
+  (master rotation, AAD rebind, DEK rotation).
+  """
+
+  use Oban.Worker,
+    queue: :crypto_backfill,
+    max_attempts: 5,
+    unique: [
+      keys: [:user_id, :target_provider],
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  alias Engram.Crypto.ProviderMigration
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "target_provider" => target}})
+      when is_integer(user_id) and target in ["local", "aws_kms"] do
+    target_atom = String.to_existing_atom(target)
+
+    case ProviderMigration.migrate_user(user_id, target_atom) do
+      :ok -> :ok
+      :skipped -> :ok
+      {:error, {:not_found, _}} -> {:discard, :user_deleted}
+      {:error, :no_dek} -> {:discard, :no_dek}
+      {:error, :malformed_wrapped_blob} -> {:discard, :malformed_wrapped_blob}
+      {:error, :unrecognised_blob} -> {:discard, :unrecognised_blob}
+      {:error, %Ecto.Changeset{errors: errors}} -> {:discard, {:changeset_invalid, errors}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def perform(%Oban.Job{
+        args: %{"user_id" => _user_id, "target_provider" => other}
+      }) do
+    {:discard, {:unknown_target, other}}
+  end
+
+  def perform(%Oban.Job{args: args}) do
+    {:discard, {:invalid_args, Map.keys(args)}}
+  end
+end

--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -105,6 +105,15 @@ defmodule EngramWeb.Telemetry do
         tags: [:status],
         description: "AadRebind per-user duration"
       ),
+      counter("engram.crypto.migrate_provider.user.count",
+        tags: [:target_provider, :status, :reason_label],
+        description: "Phase 3 per-user provider migration outcome (Local↔AwsKms)"
+      ),
+      summary("engram.crypto.migrate_provider.user.duration_us",
+        unit: {:native, :microsecond},
+        tags: [:target_provider, :status],
+        description: "Phase 3 per-user provider migration duration"
+      ),
       counter("engram.crypto.rotate.dek.count",
         tags: [:status, :reason_label],
         description: "UserDekRotation per-DEK outcome (T3.7 per-user DEK rotation)"

--- a/lib/mix/tasks/engram.migrate_provider.ex
+++ b/lib/mix/tasks/engram.migrate_provider.ex
@@ -1,0 +1,116 @@
+defmodule Mix.Tasks.Engram.MigrateProvider do
+  @shortdoc "Rewrap user encrypted_dek between KeyProviders (Local↔AwsKms)"
+
+  @moduledoc """
+  Phase 3 — Per-user `KeyProvider` migration entrypoint.
+
+  ## Usage
+
+      # Sync drain (dev / staging) — blocks until done:
+      mix engram.migrate_provider --target aws_kms
+
+      # Production: Oban enqueue (jobs survive node restart):
+      mix engram.migrate_provider --target aws_kms --enqueue
+
+      # Reverse rollback (KMS → Local):
+      mix engram.migrate_provider --target local --enqueue
+
+      # Provider count breakdown:
+      mix engram.migrate_provider --status
+
+  ## Exit codes
+
+  - `0` — clean (all users at target, or `--status` ran successfully).
+  - `1` — partial: at least one per-user failure (telemetry has details).
+  - `2` — misconfig (unknown `--target`, missing required arg).
+
+  ## Pre-cutover checklist
+
+  1. Set Fly secrets: `KEY_PROVIDER=aws_kms`, `AWS_KMS_KEY_ID`,
+     `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`.
+  2. Deploy. `BootCanaryGuard.AwsKms.boot_check/0` verifies CMK reachable.
+  3. Run `mix engram.migrate_provider --target aws_kms --enqueue` (or
+     release-rpc the underlying API: `Engram.Crypto.ProviderMigration.enqueue_all(:aws_kms)`).
+  4. Monitor `[:engram, :crypto, :migrate_provider, :user]` telemetry +
+     `mix engram.migrate_provider --status` until `local` count = 0.
+  """
+
+  use Mix.Task
+
+  alias Engram.Crypto.ProviderMigration
+
+  @switches [target: :string, enqueue: :boolean, status: :boolean, batch_size: :integer]
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {opts, _, _} = OptionParser.parse(args, switches: @switches)
+
+    cond do
+      opts[:status] ->
+        print_status()
+        :ok
+
+      is_nil(opts[:target]) ->
+        IO.puts(
+          :stderr,
+          "ERROR: --target is required (one of: aws_kms, local). Or pass --status."
+        )
+
+        exit({:shutdown, 2})
+
+      true ->
+        case target_atom(opts[:target]) do
+          {:ok, target_atom} ->
+            batch_size = Keyword.get(opts, :batch_size, 100)
+
+            if opts[:enqueue] do
+              run_enqueue(target_atom, batch_size)
+            else
+              run_drain(target_atom, batch_size)
+            end
+
+          :error ->
+            IO.puts(
+              :stderr,
+              "ERROR: unknown --target #{inspect(opts[:target])}; expected aws_kms | local"
+            )
+
+            exit({:shutdown, 2})
+        end
+    end
+  end
+
+  defp target_atom("aws_kms"), do: {:ok, :aws_kms}
+  defp target_atom("local"), do: {:ok, :local}
+  defp target_atom(_), do: :error
+
+  defp run_drain(target_atom, batch_size) do
+    IO.puts("draining users → #{target_atom} (batch_size=#{batch_size})...")
+
+    counts = ProviderMigration.migrate_all(target_atom, batch_size: batch_size)
+
+    IO.puts(
+      "migration complete: ok=#{counts.ok} skipped=#{counts.skipped} failed=#{counts.failed}"
+    )
+
+    if counts.failed > 0 do
+      IO.puts(:stderr, "ERROR: #{counts.failed} users failed migration — inspect telemetry")
+      exit({:shutdown, 1})
+    end
+  end
+
+  defp run_enqueue(target_atom, batch_size) do
+    IO.puts("enqueueing users → #{target_atom} (batch_size=#{batch_size})...")
+
+    %{enqueued: n} = ProviderMigration.enqueue_all(target_atom, batch_size: batch_size)
+
+    IO.puts("enqueued #{n} MigrateUserProvider jobs on :crypto_backfill")
+  end
+
+  defp print_status do
+    counts = ProviderMigration.status_counts()
+    IO.puts("local=#{counts.local} aws_kms=#{counts.aws_kms} total=#{counts.total}")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.183",
+      version: "0.5.185",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.185",
+      version: "0.5.186",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto/key_provider/aws_kms_test.exs
+++ b/test/engram/crypto/key_provider/aws_kms_test.exs
@@ -111,8 +111,11 @@ defmodule Engram.Crypto.KeyProvider.AwsKmsTest do
   end
 
   test "wrap_dek requires user_id in ctx" do
+    # apply/3 used to defeat Elixir 1.19+ static pattern-match analysis;
+    # the intent is to verify the function-clause guard at runtime.
     assert_raise FunctionClauseError, fn ->
-      AwsKms.wrap_dek(<<1::256>>, %{})
+      # credo:disable-for-next-line Credo.Check.Refactor.Apply
+      apply(AwsKms, :wrap_dek, [<<1::256>>, %{}])
     end
   end
 
@@ -127,8 +130,11 @@ defmodule Engram.Crypto.KeyProvider.AwsKmsTest do
   end
 
   test "rotate_dek requires user_id in ctx" do
+    # apply/3 used to defeat Elixir 1.19+ static pattern-match analysis;
+    # the intent is to verify the function-clause guard at runtime.
     assert_raise FunctionClauseError, fn ->
-      AwsKms.rotate_dek(<<0xAA, 0x01, 0xDE, 0xAD>>, %{})
+      # credo:disable-for-next-line Credo.Check.Refactor.Apply
+      apply(AwsKms, :rotate_dek, [<<0xAA, 0x01, 0xDE, 0xAD>>, %{}])
     end
   end
 

--- a/test/engram/crypto/provider_conformance_test.exs
+++ b/test/engram/crypto/provider_conformance_test.exs
@@ -132,4 +132,16 @@ defmodule Engram.Crypto.ProviderConformanceTest do
       assert {:ok, ^dek} = unquote(provider).unwrap_dek_no_fallback(wrapped, ctx)
     end
   end
+
+  describe "cross-provider identify_from_blob/1 round-trip" do
+    test "every provider produces a blob that identify_from_blob maps back to itself" do
+      stub_aws_kms_roundtrip()
+
+      for provider <- @providers do
+        dek = provider.generate_dek()
+        {:ok, blob} = provider.wrap_dek(dek, %{user_id: 1})
+        assert {:ok, ^provider} = Engram.Crypto.KeyProvider.identify_from_blob(blob)
+      end
+    end
+  end
 end

--- a/test/engram/crypto/provider_migration_test.exs
+++ b/test/engram/crypto/provider_migration_test.exs
@@ -1,0 +1,77 @@
+defmodule Engram.Crypto.ProviderMigrationTest do
+  use Engram.DataCase, async: false
+
+  import Mox
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Crypto.ProviderMigration
+  alias Engram.Repo
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+
+    prev_provider = Application.get_env(:engram, :key_provider)
+    prev_client = Application.get_env(:engram, :aws_kms_client)
+    Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+
+    on_exit(fn ->
+      Application.put_env(:engram, :key_provider, prev_provider)
+      Application.put_env(:engram, :aws_kms_client, prev_client)
+    end)
+
+    :ok
+  end
+
+  defp stub_kms_roundtrip do
+    table = :ets.new(:mig_kms_stub, [:set, :public])
+
+    stub(Engram.AwsKmsMock, :encrypt, fn pt, _ctx ->
+      ct = :crypto.strong_rand_bytes(48)
+      :ets.insert(table, {ct, pt})
+      {:ok, ct}
+    end)
+
+    stub(Engram.AwsKmsMock, :decrypt, fn ct, _ctx ->
+      case :ets.lookup(table, ct) do
+        [{^ct, pt}] -> {:ok, pt}
+        [] -> {:error, :context_mismatch}
+      end
+    end)
+
+    stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+
+    :ok
+  end
+
+  defp user_with_local_dek! do
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    user
+  end
+
+  describe "migrate_user/2 Local→KMS" do
+    test "rewraps blob with KMS provider tag and stamps key_provider" do
+      stub_kms_roundtrip()
+      user = user_with_local_dek!()
+      original_blob = user.encrypted_dek
+
+      assert :ok = ProviderMigration.migrate_user(user.id, :aws_kms)
+
+      reloaded = Repo.one!(from(u in User, where: u.id == ^user.id), skip_tenant_check: true)
+
+      assert <<0xAA, 0x01, _ct::binary>> = reloaded.encrypted_dek
+      assert reloaded.encrypted_dek != original_blob
+      assert reloaded.key_provider == "aws_kms"
+      assert reloaded.dek_version == Engram.Crypto.Config.master_key_version()
+    end
+  end
+end

--- a/test/engram/crypto/provider_migration_test.exs
+++ b/test/engram/crypto/provider_migration_test.exs
@@ -216,4 +216,71 @@ defmodule Engram.Crypto.ProviderMigrationTest do
       assert reloaded.key_provider == "aws_kms"
     end
   end
+
+  describe "migrate_all/2" do
+    test "drains every user not at target into the target provider" do
+      stub_kms_roundtrip()
+      u1 = user_with_local_dek!()
+      u2 = user_with_local_dek!()
+
+      # u3 starts on KMS — must be skipped.
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+      u3 = insert(:user)
+      {:ok, _} = Crypto.ensure_user_dek(u3)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+      assert %{ok: ok_count, skipped: skipped_count, failed: 0} =
+               ProviderMigration.migrate_all(:aws_kms, batch_size: 10)
+
+      # u1 + u2 should rewrap.
+      assert ok_count >= 2
+
+      # u3 contributes to :skipped. Other already-aws_kms users from prior
+      # tests in this DB sandbox may also contribute.
+      assert skipped_count >= 1
+
+      assert "aws_kms" =
+               Repo.one!(from(u in User, where: u.id == ^u1.id, select: u.key_provider),
+                 skip_tenant_check: true
+               )
+
+      assert "aws_kms" =
+               Repo.one!(from(u in User, where: u.id == ^u2.id, select: u.key_provider),
+                 skip_tenant_check: true
+               )
+    end
+  end
+
+  describe "enqueue_all/2" do
+    test "inserts one Oban job per below-target user" do
+      _u1 = user_with_local_dek!()
+      _u2 = user_with_local_dek!()
+
+      assert %{enqueued: n} = ProviderMigration.enqueue_all(:aws_kms, batch_size: 10)
+      assert n >= 2
+
+      jobs =
+        Oban.Job
+        |> Repo.all(skip_tenant_check: true)
+        |> Enum.filter(&(&1.worker == "Engram.Workers.MigrateUserProvider"))
+
+      assert length(jobs) >= 2
+
+      Enum.each(jobs, fn job ->
+        assert %{"target_provider" => "aws_kms", "user_id" => uid} = job.args
+        assert is_integer(uid)
+      end)
+    end
+  end
+
+  describe "status_counts/0" do
+    test "returns counts grouped by users.key_provider" do
+      _ = user_with_local_dek!()
+      counts = ProviderMigration.status_counts()
+      assert is_map(counts)
+      assert counts[:local] >= 1
+      assert Map.has_key?(counts, :total)
+      assert counts.total == (counts[:local] || 0) + (counts[:aws_kms] || 0)
+    end
+  end
 end

--- a/test/engram/crypto/provider_migration_test.exs
+++ b/test/engram/crypto/provider_migration_test.exs
@@ -185,4 +185,35 @@ defmodule Engram.Crypto.ProviderMigrationTest do
       assert uid == user.id
     end
   end
+
+  describe "migrate_user/2 concurrent races" do
+    test "4 parallel migrate_user calls for same user → exactly one rewrap, three :skipped" do
+      stub_kms_roundtrip()
+      user = user_with_local_dek!()
+      uid = user.id
+      parent = self()
+
+      results =
+        1..4
+        |> Task.async_stream(
+          fn _ ->
+            Ecto.Adapters.SQL.Sandbox.allow(Engram.Repo, parent, self())
+            ProviderMigration.migrate_user(uid, :aws_kms)
+          end,
+          max_concurrency: 4,
+          ordered: false,
+          timeout: 10_000
+        )
+        |> Enum.map(fn {:ok, r} -> r end)
+
+      ok_count = Enum.count(results, &(&1 == :ok))
+      skipped_count = Enum.count(results, &(&1 == :skipped))
+
+      assert ok_count == 1, "expected exactly one :ok, got #{ok_count} (results=#{inspect(results)})"
+      assert skipped_count == 3, "expected three :skipped, got #{skipped_count}"
+
+      reloaded = Repo.one!(from(u in User, where: u.id == ^uid), skip_tenant_check: true)
+      assert reloaded.key_provider == "aws_kms"
+    end
+  end
 end

--- a/test/engram/crypto/provider_migration_test.exs
+++ b/test/engram/crypto/provider_migration_test.exs
@@ -142,7 +142,8 @@ defmodule Engram.Crypto.ProviderMigrationTest do
       assert reloaded.encrypted_dek == original_blob
       assert reloaded.key_provider == "local"
 
-      assert_receive {:telemetry, %{count: 1}, %{status: :failed, reason_label: "kms_encrypt_failed"}}
+      assert_receive {:telemetry, %{count: 1},
+                      %{status: :failed, reason_label: "kms_encrypt_failed"}}
     end
 
     test ":kms_throttled surfaces verbatim" do
@@ -178,6 +179,7 @@ defmodule Engram.Crypto.ProviderMigrationTest do
       attach_telemetry_capture(self())
 
       assert :ok = ProviderMigration.migrate_user(user.id, :aws_kms)
+
       assert_receive {:telemetry, %{count: 1, duration_us: dur},
                       %{user_id: uid, target_provider: :aws_kms, status: :ok}}
                      when is_integer(dur) and dur >= 0
@@ -209,7 +211,9 @@ defmodule Engram.Crypto.ProviderMigrationTest do
       ok_count = Enum.count(results, &(&1 == :ok))
       skipped_count = Enum.count(results, &(&1 == :skipped))
 
-      assert ok_count == 1, "expected exactly one :ok, got #{ok_count} (results=#{inspect(results)})"
+      assert ok_count == 1,
+             "expected exactly one :ok, got #{ok_count} (results=#{inspect(results)})"
+
       assert skipped_count == 3, "expected three :skipped, got #{skipped_count}"
 
       reloaded = Repo.one!(from(u in User, where: u.id == ^uid), skip_tenant_check: true)

--- a/test/engram/crypto/provider_migration_test.exs
+++ b/test/engram/crypto/provider_migration_test.exs
@@ -74,4 +74,39 @@ defmodule Engram.Crypto.ProviderMigrationTest do
       assert reloaded.dek_version == Engram.Crypto.Config.master_key_version()
     end
   end
+
+  describe "migrate_user/2 KMS→Local reverse" do
+    test "rewraps from KMS blob back to Local with 0x01/0x02 leading byte" do
+      stub_kms_roundtrip()
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+      user = insert(:user)
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      assert <<0xAA, _::binary>> = user.encrypted_dek
+
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+      assert :ok = ProviderMigration.migrate_user(user.id, :local)
+
+      reloaded = Repo.one!(from(x in User, where: x.id == ^user.id), skip_tenant_check: true)
+      assert <<tag, 0x01, _::binary-size(60)>> = reloaded.encrypted_dek
+      assert tag in [0x01, 0x02]
+      assert reloaded.key_provider == "local"
+    end
+  end
+
+  describe "migrate_user/2 idempotence" do
+    test "returns :skipped when user is already at target_provider, no provider calls made" do
+      stub_kms_roundtrip()
+      user = user_with_local_dek!()
+
+      # First migration: Local→KMS.
+      assert :ok = ProviderMigration.migrate_user(user.id, :aws_kms)
+
+      # Second migration to same target: skipped, zero KMS calls expected
+      # because the cond branch short-circuits before touching providers.
+      expect(Engram.AwsKmsMock, :encrypt, 0, fn _, _ -> :unused end)
+      expect(Engram.AwsKmsMock, :decrypt, 0, fn _, _ -> :unused end)
+
+      assert :skipped = ProviderMigration.migrate_user(user.id, :aws_kms)
+    end
+  end
 end

--- a/test/engram/crypto/provider_migration_test.exs
+++ b/test/engram/crypto/provider_migration_test.exs
@@ -58,6 +58,21 @@ defmodule Engram.Crypto.ProviderMigrationTest do
     user
   end
 
+  defp attach_telemetry_capture(test_pid) do
+    handler_id = "test-migrate-provider-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:engram, :crypto, :migrate_provider, :user],
+      fn _name, measurements, metadata, _cfg ->
+        send(test_pid, {:telemetry, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
   describe "migrate_user/2 Local→KMS" do
     test "rewraps blob with KMS provider tag and stamps key_provider" do
       stub_kms_roundtrip()
@@ -107,6 +122,67 @@ defmodule Engram.Crypto.ProviderMigrationTest do
       expect(Engram.AwsKmsMock, :decrypt, 0, fn _, _ -> :unused end)
 
       assert :skipped = ProviderMigration.migrate_user(user.id, :aws_kms)
+    end
+  end
+
+  describe "migrate_user/2 failure modes" do
+    test ":kms_access_denied surfaces, txn rolls back, blob unchanged, telemetry :failed" do
+      Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+      stub(Engram.AwsKmsMock, :encrypt, fn _, _ -> {:error, :access_denied} end)
+
+      user = user_with_local_dek!()
+      original_blob = user.encrypted_dek
+
+      attach_telemetry_capture(self())
+
+      assert {:error, {:kms_encrypt_failed, :access_denied}} =
+               ProviderMigration.migrate_user(user.id, :aws_kms)
+
+      reloaded = Repo.one!(from(u in User, where: u.id == ^user.id), skip_tenant_check: true)
+      assert reloaded.encrypted_dek == original_blob
+      assert reloaded.key_provider == "local"
+
+      assert_receive {:telemetry, %{count: 1}, %{status: :failed, reason_label: "kms_encrypt_failed"}}
+    end
+
+    test ":kms_throttled surfaces verbatim" do
+      stub(Engram.AwsKmsMock, :encrypt, fn _, _ -> {:error, :throttled} end)
+
+      user = user_with_local_dek!()
+
+      assert {:error, {:kms_encrypt_failed, :throttled}} =
+               ProviderMigration.migrate_user(user.id, :aws_kms)
+    end
+
+    test "user deleted mid-flight returns {:error, {:not_found, uid}}" do
+      stub_kms_roundtrip()
+      missing_id = 99_999_999
+
+      assert {:error, {:not_found, ^missing_id}} =
+               ProviderMigration.migrate_user(missing_id, :aws_kms)
+    end
+
+    test "user with nil encrypted_dek returns {:error, :no_dek}" do
+      stub_kms_roundtrip()
+      user = insert(:user)
+      # Sanity: factory does not auto-provision a wrapped DEK.
+      assert is_nil(user.encrypted_dek)
+
+      assert {:error, :no_dek} = ProviderMigration.migrate_user(user.id, :aws_kms)
+    end
+
+    test "happy path emits :ok telemetry with target_provider metadata" do
+      stub_kms_roundtrip()
+      user = user_with_local_dek!()
+
+      attach_telemetry_capture(self())
+
+      assert :ok = ProviderMigration.migrate_user(user.id, :aws_kms)
+      assert_receive {:telemetry, %{count: 1, duration_us: dur},
+                      %{user_id: uid, target_provider: :aws_kms, status: :ok}}
+                     when is_integer(dur) and dur >= 0
+
+      assert uid == user.id
     end
   end
 end

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -342,4 +342,129 @@ defmodule Engram.CryptoTest do
       assert hash =~ ~r/^[0-9a-f]{64}$/
     end
   end
+
+  describe "get_dek/1 dual-read + lazy migration" do
+    use Oban.Testing, repo: Engram.Repo
+    import Mox
+    setup :verify_on_exit!
+
+    setup do
+      original_master_key = Application.get_env(:engram, :encryption_master_key)
+      original_kms_client = Application.get_env(:engram, :aws_kms_client)
+      original_provider = Application.get_env(:engram, :key_provider)
+
+      on_exit(fn ->
+        if original_master_key,
+          do: Application.put_env(:engram, :encryption_master_key, original_master_key),
+          else: Application.delete_env(:engram, :encryption_master_key)
+
+        if original_kms_client,
+          do: Application.put_env(:engram, :aws_kms_client, original_kms_client),
+          else: Application.delete_env(:engram, :aws_kms_client)
+
+        if original_provider,
+          do: Application.put_env(:engram, :key_provider, original_provider),
+          else: Application.delete_env(:engram, :key_provider)
+      end)
+
+      Application.put_env(
+        :engram,
+        :encryption_master_key,
+        Base.encode64(:crypto.strong_rand_bytes(32))
+      )
+
+      Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+
+      table = :ets.new(:dual_read_stub, [:set, :public])
+
+      stub(Engram.AwsKmsMock, :encrypt, fn pt, _ ->
+        ct = :crypto.strong_rand_bytes(48)
+        :ets.insert(table, {ct, pt})
+        {:ok, ct}
+      end)
+
+      stub(Engram.AwsKmsMock, :decrypt, fn ct, _ ->
+        case :ets.lookup(table, ct) do
+          [{^ct, pt}] -> {:ok, pt}
+          [] -> {:error, :context_mismatch}
+        end
+      end)
+
+      stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+      :ok
+    end
+
+    defp make_user_with_provider!(provider_module) do
+      Application.put_env(:engram, :key_provider, provider_module)
+      user = insert(:user)
+      {:ok, user} = Crypto.ensure_user_dek(user)
+      DekCache.delete(user.id)
+      user
+    end
+
+    test "Local blob + KEY_PROVIDER=local → succeeds, no enqueue" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.Local)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+      assert {:ok, <<_::256>>} = Crypto.get_dek(user)
+
+      refute_enqueued(worker: Engram.Workers.MigrateUserProvider, args: %{"user_id" => user.id})
+    end
+
+    test "Local blob + KEY_PROVIDER=aws_kms → succeeds via Local, enqueues lazy migration to KMS" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.Local)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+
+      assert {:ok, <<_::256>>} = Crypto.get_dek(user)
+
+      assert_enqueued(
+        worker: Engram.Workers.MigrateUserProvider,
+        args: %{"user_id" => user.id, "target_provider" => "aws_kms"}
+      )
+    end
+
+    test "KMS blob + KEY_PROVIDER=aws_kms → succeeds, no enqueue" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.AwsKms)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+
+      assert {:ok, <<_::256>>} = Crypto.get_dek(user)
+
+      refute_enqueued(worker: Engram.Workers.MigrateUserProvider, args: %{"user_id" => user.id})
+    end
+
+    test "KMS blob + KEY_PROVIDER=local → succeeds via KMS, enqueues reverse migration to local" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.AwsKms)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+      assert {:ok, <<_::256>>} = Crypto.get_dek(user)
+
+      assert_enqueued(
+        worker: Engram.Workers.MigrateUserProvider,
+        args: %{"user_id" => user.id, "target_provider" => "local"}
+      )
+    end
+
+    test "cache hit short-circuits identify_from_blob — no lazy enqueue on cache hit" do
+      user = make_user_with_provider!(Engram.Crypto.KeyProvider.Local)
+      Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.AwsKms)
+
+      # First call: miss → unwrap → enqueue.
+      {:ok, dek} = Crypto.get_dek(user)
+      assert_enqueued(worker: Engram.Workers.MigrateUserProvider, args: %{"user_id" => user.id})
+
+      # Snapshot enqueue count, then make a second call — cache hit returns
+      # immediately without calling identify_from_blob, so no second enqueue.
+      first_count =
+        all_enqueued(worker: Engram.Workers.MigrateUserProvider)
+        |> Enum.count(&(&1.args["user_id"] == user.id))
+
+      assert {:ok, ^dek} = Crypto.get_dek(user)
+
+      second_count =
+        all_enqueued(worker: Engram.Workers.MigrateUserProvider)
+        |> Enum.count(&(&1.args["user_id"] == user.id))
+
+      assert first_count == second_count
+    end
+  end
 end

--- a/test/engram/workers/migrate_user_provider_test.exs
+++ b/test/engram/workers/migrate_user_provider_test.exs
@@ -1,0 +1,114 @@
+defmodule Engram.Workers.MigrateUserProviderTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Mox
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Repo
+  alias Engram.Workers.MigrateUserProvider
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+
+    Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+
+    table = :ets.new(:worker_kms_stub, [:set, :public])
+
+    stub(Engram.AwsKmsMock, :encrypt, fn pt, _ ->
+      ct = :crypto.strong_rand_bytes(48)
+      :ets.insert(table, {ct, pt})
+      {:ok, ct}
+    end)
+
+    stub(Engram.AwsKmsMock, :decrypt, fn ct, _ ->
+      case :ets.lookup(table, ct) do
+        [{^ct, pt}] -> {:ok, pt}
+        [] -> {:error, :context_mismatch}
+      end
+    end)
+
+    stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+    :ok
+  end
+
+  defp user_with_local_dek! do
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    user
+  end
+
+  test "perform/1 happy path: returns :ok, rewraps user" do
+    user = user_with_local_dek!()
+
+    assert :ok =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => user.id,
+               "target_provider" => "aws_kms"
+             })
+
+    reloaded = Repo.one!(from(u in User, where: u.id == ^user.id), skip_tenant_check: true)
+    assert reloaded.key_provider == "aws_kms"
+  end
+
+  test "perform/1 skipped (already at target) returns :ok" do
+    user = user_with_local_dek!()
+
+    :ok = perform_job(MigrateUserProvider, %{"user_id" => user.id, "target_provider" => "aws_kms"})
+
+    assert :ok =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => user.id,
+               "target_provider" => "aws_kms"
+             })
+  end
+
+  test "perform/1 returns {:discard, :user_deleted} when user is missing" do
+    assert {:discard, :user_deleted} =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => 99_999_999,
+               "target_provider" => "aws_kms"
+             })
+  end
+
+  test "perform/1 returns {:discard, :no_dek} when user has no encrypted_dek" do
+    user = insert(:user)
+    assert is_nil(user.encrypted_dek)
+
+    assert {:discard, :no_dek} =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => user.id,
+               "target_provider" => "aws_kms"
+             })
+  end
+
+  test "perform/1 returns {:error, reason} for retryable KMS errors" do
+    stub(Engram.AwsKmsMock, :encrypt, fn _, _ -> {:error, :throttled} end)
+    user = user_with_local_dek!()
+
+    assert {:error, {:kms_encrypt_failed, :throttled}} =
+             perform_job(MigrateUserProvider, %{
+               "user_id" => user.id,
+               "target_provider" => "aws_kms"
+             })
+  end
+
+  test "perform/1 returns {:discard, {:invalid_args, …}} for malformed args" do
+    assert {:discard, {:invalid_args, _}} = perform_job(MigrateUserProvider, %{"garbage" => 1})
+  end
+
+  test "perform/1 rejects unknown target_provider" do
+    assert {:discard, {:unknown_target, "passphrase"}} =
+             perform_job(MigrateUserProvider, %{"user_id" => 1, "target_provider" => "passphrase"})
+  end
+end

--- a/test/engram/workers/migrate_user_provider_test.exs
+++ b/test/engram/workers/migrate_user_provider_test.exs
@@ -64,7 +64,8 @@ defmodule Engram.Workers.MigrateUserProviderTest do
   test "perform/1 skipped (already at target) returns :ok" do
     user = user_with_local_dek!()
 
-    :ok = perform_job(MigrateUserProvider, %{"user_id" => user.id, "target_provider" => "aws_kms"})
+    :ok =
+      perform_job(MigrateUserProvider, %{"user_id" => user.id, "target_provider" => "aws_kms"})
 
     assert :ok =
              perform_job(MigrateUserProvider, %{

--- a/test/engram_web/telemetry_test.exs
+++ b/test/engram_web/telemetry_test.exs
@@ -101,5 +101,19 @@ defmodule EngramWeb.TelemetryTest do
       assert "engram.crypto.rotate.dek.gate_blocked.count" in names,
              "T3.7 writes/reads blocked at channel/worker bypass path must be counted"
     end
+
+    # Phase 3 — per-user provider migration telemetry (Local↔AwsKms cutover).
+    test "registers engram.crypto.migrate_provider.user counter (Phase 3 provider migration)", %{
+      names: names
+    } do
+      assert "engram.crypto.migrate_provider.user.count" in names,
+             "ProviderMigration per-user outcome must be counted (target_provider, status, reason_label)"
+    end
+
+    test "registers engram.crypto.migrate_provider.user duration summary (Phase 3 provider migration)",
+         %{names: names} do
+      assert "engram.crypto.migrate_provider.user.duration_us" in names,
+             "ProviderMigration per-user duration must be measured"
+    end
   end
 end

--- a/test/mix/tasks/engram/migrate_provider_test.exs
+++ b/test/mix/tasks/engram/migrate_provider_test.exs
@@ -7,6 +7,7 @@ defmodule Mix.Tasks.Engram.MigrateProviderTest do
   import Ecto.Query, only: [from: 2]
 
   alias Engram.Crypto
+  alias Mix.Tasks.Engram.MigrateProvider
 
   setup :verify_on_exit!
 
@@ -65,7 +66,7 @@ defmodule Mix.Tasks.Engram.MigrateProviderTest do
 
       out =
         capture_io(fn ->
-          Mix.Tasks.Engram.MigrateProvider.run(["--target", "aws_kms"])
+          MigrateProvider.run(["--target", "aws_kms"])
         end)
 
       assert out =~ "migration complete"
@@ -79,7 +80,7 @@ defmodule Mix.Tasks.Engram.MigrateProviderTest do
 
       out =
         capture_io(fn ->
-          Mix.Tasks.Engram.MigrateProvider.run(["--target", "aws_kms", "--enqueue"])
+          MigrateProvider.run(["--target", "aws_kms", "--enqueue"])
         end)
 
       assert out =~ "enqueued"
@@ -101,7 +102,7 @@ defmodule Mix.Tasks.Engram.MigrateProviderTest do
 
       out =
         capture_io(fn ->
-          Mix.Tasks.Engram.MigrateProvider.run(["--status"])
+          MigrateProvider.run(["--status"])
         end)
 
       assert out =~ "local="
@@ -115,7 +116,7 @@ defmodule Mix.Tasks.Engram.MigrateProviderTest do
       exit_result =
         catch_exit(
           capture_io(:stderr, fn ->
-            Mix.Tasks.Engram.MigrateProvider.run(["--target", "passphrase"])
+            MigrateProvider.run(["--target", "passphrase"])
           end)
         )
 
@@ -126,7 +127,7 @@ defmodule Mix.Tasks.Engram.MigrateProviderTest do
       exit_result =
         catch_exit(
           capture_io(:stderr, fn ->
-            Mix.Tasks.Engram.MigrateProvider.run([])
+            MigrateProvider.run([])
           end)
         )
 

--- a/test/mix/tasks/engram/migrate_provider_test.exs
+++ b/test/mix/tasks/engram/migrate_provider_test.exs
@@ -1,0 +1,136 @@
+defmodule Mix.Tasks.Engram.MigrateProviderTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Mox
+  import ExUnit.CaptureIO
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Crypto
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(
+      :engram,
+      :encryption_master_key,
+      Base.encode64(:crypto.strong_rand_bytes(32))
+    )
+
+    prev_provider = Application.get_env(:engram, :key_provider)
+    prev_client = Application.get_env(:engram, :aws_kms_client)
+    Application.put_env(:engram, :aws_kms_client, Engram.AwsKmsMock)
+
+    on_exit(fn ->
+      Application.put_env(:engram, :aws_kms_client, prev_client)
+
+      if prev_provider do
+        Application.put_env(:engram, :key_provider, prev_provider)
+      else
+        Application.delete_env(:engram, :key_provider)
+      end
+    end)
+
+    table = :ets.new(:task_kms_stub, [:set, :public])
+
+    stub(Engram.AwsKmsMock, :encrypt, fn pt, _ctx ->
+      ct = :crypto.strong_rand_bytes(48)
+      :ets.insert(table, {ct, pt})
+      {:ok, ct}
+    end)
+
+    stub(Engram.AwsKmsMock, :decrypt, fn ct, _ctx ->
+      case :ets.lookup(table, ct) do
+        [{^ct, pt}] -> {:ok, pt}
+        [] -> {:error, :context_mismatch}
+      end
+    end)
+
+    stub(Engram.AwsKmsMock, :describe_key, fn -> :ok end)
+
+    :ok
+  end
+
+  defp local_user! do
+    Application.put_env(:engram, :key_provider, Engram.Crypto.KeyProvider.Local)
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    user
+  end
+
+  describe "run/1 — sync drain" do
+    test "--target aws_kms rewraps every local user" do
+      _u1 = local_user!()
+      _u2 = local_user!()
+
+      out =
+        capture_io(fn ->
+          Mix.Tasks.Engram.MigrateProvider.run(["--target", "aws_kms"])
+        end)
+
+      assert out =~ "migration complete"
+      assert out =~ "ok="
+    end
+  end
+
+  describe "run/1 — enqueue" do
+    test "--target aws_kms --enqueue inserts jobs without performing rewraps" do
+      user = local_user!()
+
+      out =
+        capture_io(fn ->
+          Mix.Tasks.Engram.MigrateProvider.run(["--target", "aws_kms", "--enqueue"])
+        end)
+
+      assert out =~ "enqueued"
+      assert_enqueued(worker: Engram.Workers.MigrateUserProvider, args: %{"user_id" => user.id})
+
+      reloaded =
+        Engram.Repo.one!(from(u in Engram.Accounts.User, where: u.id == ^user.id),
+          skip_tenant_check: true
+        )
+
+      # Not rewrapped yet — only enqueued.
+      assert reloaded.key_provider == "local"
+    end
+  end
+
+  describe "run/1 — status" do
+    test "--status prints provider counts" do
+      _ = local_user!()
+
+      out =
+        capture_io(fn ->
+          Mix.Tasks.Engram.MigrateProvider.run(["--status"])
+        end)
+
+      assert out =~ "local="
+      assert out =~ "aws_kms="
+      assert out =~ "total="
+    end
+  end
+
+  describe "run/1 — argument validation" do
+    test "unknown --target exits 2" do
+      exit_result =
+        catch_exit(
+          capture_io(:stderr, fn ->
+            Mix.Tasks.Engram.MigrateProvider.run(["--target", "passphrase"])
+          end)
+        )
+
+      assert exit_result == {:shutdown, 2}
+    end
+
+    test "missing required --target without --status exits 2" do
+      exit_result =
+        catch_exit(
+          capture_io(:stderr, fn ->
+            Mix.Tasks.Engram.MigrateProvider.run([])
+          end)
+        )
+
+      assert exit_result == {:shutdown, 2}
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Per-user `KeyProvider` rewrap via `Engram.Crypto.ProviderMigration` + `Engram.Workers.MigrateUserProvider` + `mix engram.migrate_provider`
- `Crypto.get_dek/1` now dispatches unwrap by blob tag (`KeyProvider.identify_from_blob/1`) and enqueues lazy migration when blob provider ≠ configured target
- Forward (Local→KMS) and reverse (KMS→Local) share the same worker — `--target` arg flips direction
- Telemetry `[:engram, :crypto, :migrate_provider, :user]` (counter + summary) + Logger.error on failure
- No schema changes — `users.encrypted_dek` + `users.key_provider` already exist
- Mixed-state (some users on Local, some on KMS) safe by construction during entire backfill window

## Design

`docs/superpowers/specs/2026-05-16-aws-kms-phase-3-provider-migration-design.md`
`docs/superpowers/plans/2026-05-16-aws-kms-phase-3-provider-migration.md`

## Key insight

Switching providers only rewraps the wrapped DEK blob. Underlying AES-GCM ciphertext rows (notes, attachments, qdrant payloads) are bound to the *plaintext* DEK, which is preserved across rewrap. One row update per user, no row-scan of tenant data. ~10× cheaper than T3.5 master rotation or T3.7 DEK rotation.

## Test plan
- [x] Unit tests for `migrate_user/2` — happy paths, idempotence, race (4-parallel FOR UPDATE), failure modes, telemetry pins
- [x] Worker tests — retry vs discard classification + uniqueness
- [x] Mix task tests — sync drain, enqueue, status, exit codes
- [x] `get_dek/1` dual-read tests — all four `(blob_provider × configured_provider)` quadrants + cache-hit short-circuit
- [x] Cross-provider conformance — `identify_from_blob` round-trip
- [x] Telemetry handler registration pin
- [x] `mix test --warnings-as-errors`: 1254 tests, 0 failures
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] `mix sobelow --config` clean

## Out of scope (separate specs)
- Phase 4 cutover runbook (Fly secrets sequence, IAM policy, selfhost guard)
- Terraform templates for AWS account / KMS CMK / IAM role

🤖 Generated with [Claude Code](https://claude.com/claude-code)