### PR TITLE
fix(e2e): bounded-retry modal dismiss for stacked-view flake

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -255,6 +255,36 @@ class CdpClient:
             f"SyncPreviewModal not mounted after {timeout}s on CDP port {self.port}"
         )
 
+    async def dismiss_modals(
+        self, max_attempts: int = 20, poll: float = 0.1
+    ) -> None:
+        """Dispatch Escape repeatedly until no modal remains in the DOM.
+
+        Obsidian's stacked-modal views (e.g. SyncPreviewModal's destructive
+        confirm view layered on top of the option-pick view) consume one
+        Escape per layer — a single Escape collapses the confirm view back to
+        the option-pick view but the outer modal stays mounted. Looping
+        Escape-and-check is the deterministic dismiss: it bounds in
+        ``max_attempts × poll`` wall time and exits the moment the DOM is
+        actually empty, no animation guesswork needed.
+        """
+        for _ in range(max_attempts):
+            present = await self.evaluate(
+                "Boolean(document.querySelector('.modal-container .modal'))"
+            )
+            if present is False:
+                return
+            await self.evaluate(
+                "document.querySelectorAll('.modal-container .modal').forEach("
+                "m => m.dispatchEvent(new KeyboardEvent('keydown', "
+                "{key: 'Escape', bubbles: true})))"
+            )
+            await asyncio.sleep(poll)
+        raise TimeoutError(
+            f"Modal still mounted after {max_attempts} Escape attempts "
+            f"on CDP port {self.port}"
+        )
+
     async def wait_for_modal_closed(self, timeout: float = 5) -> None:
         """Poll until SyncPreviewModal is gone from the DOM."""
         deadline = time.monotonic() + timeout

--- a/e2e/tests/test_51_sync_preview_modal.py
+++ b/e2e/tests/test_51_sync_preview_modal.py
@@ -47,12 +47,12 @@ async def _require_sync_gate(cdp_a):
 
 
 async def _dismiss_via_escape(cdp) -> None:
-    """Dispatch Escape on any open modal — resolves awaitChoice as 'cancel'."""
-    await cdp.evaluate(
-        "document.querySelectorAll('.modal-container .modal').forEach("
-        "m => m.dispatchEvent(new KeyboardEvent('keydown', "
-        "{key: 'Escape', bubbles: true})))"
-    )
+    """Dispatch Escape until every modal layer is gone.
+
+    Delegates to `cdp.dismiss_modals()` which polls + retries — robust against
+    stacked modal views where a single Escape only collapses one layer.
+    """
+    await cdp.dismiss_modals()
 
 
 async def _seed_local_only(cdp, vault, path: str, content: str) -> None:
@@ -93,7 +93,6 @@ async def test_modal_appears_on_first_sync(vault_a, cdp_a):
         assert await cdp_a.is_sync_blocked()
 
         await _dismiss_via_escape(cdp_a)
-        await cdp_a.wait_for_modal_closed()
     finally:
         await _restore_clean(cdp_a, vault_a, path)
 
@@ -153,7 +152,6 @@ async def test_cancel_keeps_gate_closed(vault_a, cdp_a):
         await cdp_a.wait_for_sync_preview_modal()
 
         await _dismiss_via_escape(cdp_a)
-        await cdp_a.wait_for_modal_closed()
 
         assert await cdp_a.is_sync_blocked(), (
             "Sync gate must stay closed after a cancel"
@@ -225,7 +223,6 @@ async def test_vault_switch_reopens_modal(vault_a, cdp_a):
         )
 
         await _dismiss_via_escape(cdp_a)
-        await cdp_a.wait_for_modal_closed()
     finally:
         await cdp_a.evaluate(
             "app.plugins.plugins['engram-vault-sync'].settings.vaultId = "

--- a/e2e/tests/test_55_sync_preview_destructive.py
+++ b/e2e/tests/test_55_sync_preview_destructive.py
@@ -38,12 +38,13 @@ async def _require_gate(cdp_a):
 
 
 async def _dismiss_via_escape(cdp) -> None:
-    """Dispatch Escape on any open modal — resolves awaitChoice as 'cancel'."""
-    await cdp.evaluate(
-        "document.querySelectorAll('.modal-container .modal').forEach("
-        "m => m.dispatchEvent(new KeyboardEvent('keydown', "
-        "{key: 'Escape', bubbles: true})))"
-    )
+    """Dispatch Escape until no modal remains.
+
+    SyncPreviewModal's destructive view is stacked on top of the option-pick
+    view — a single Escape only collapses the confirm view. Use the helper's
+    bounded retry loop so we peel every layer off without timing guesswork.
+    """
+    await cdp.dismiss_modals()
 
 
 async def _seed_divergent(
@@ -192,9 +193,10 @@ async def test_destructive_submit_locked_until_typed(
         )
 
         # Cancel via Escape — gate must stay closed (no sync dispatched)
-        # and the seed must persist for the next test.
+        # and the seed must persist for the next test. `dismiss_modals` polls
+        # until the DOM is fully empty, so no extra `wait_for_modal_closed`
+        # call is needed.
         await _dismiss_via_escape(cdp_a)
-        await cdp_a.wait_for_modal_closed()
         assert await cdp_a.is_sync_blocked(), (
             "Sync gate must remain blocked after cancel via Escape"
         )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.131",
+      version: "0.5.132",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Post-merge of #148 surfaced one flaky test:

\`\`\`
test_55::test_destructive_submit_locked_until_typed[Push all + delete remote]
→ TimeoutError: SyncPreviewModal still mounted after 5s
\`\`\`

## Root cause

SyncPreviewModal's destructive flow is a **two-layer modal**:
1. Option-pick view (initial)
2. Confirm view (after picking a destructive option, layered on top)

The test dispatches Escape once. That collapses the confirm view back to the option-pick view — the outer modal stays mounted. The subsequent \`wait_for_modal_closed\` then times out at 5s because it's polling for a modal that nothing told to close.

**The fix is not a longer wait.** It's making dismiss actually peel every layer off.

## What changed

- Adds \`CdpClient.dismiss_modals()\` — Escape + poll-DOM loop, bounded by \`max_attempts * poll\` (default 20 × 0.1s = 2s wall-time ceiling). Exits the moment the DOM is empty.
- Updates \`_dismiss_via_escape\` in \`test_51\` and \`test_55\` to delegate to the helper.
- Drops the now-redundant \`wait_for_modal_closed\` calls that followed each dismiss (the helper already polls).
- Reverts the prior commit's default-timeout bump (15s → back to 5s).

## Why this is better than a timeout bump

- **Faster on the happy path:** single Escape + 100ms poll = ~100ms instead of waiting for a stretched ceiling.
- **Deterministic:** bounded retries succeed when the modal is actually gone, not when an animation might be done.
- **Reusable:** future tests with stacked modals get correct dismiss for free.
- **Doesn't mask hangs:** a genuinely stuck modal trips after ~2s instead of 5s/15s.

## Test plan

- [ ] \`backend/e2e\` passes — destructive option Escape flake gone
- [ ] No regressions in other modal-dismiss paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)