### PR TITLE
fix(e2e): per-run Clerk namespace + orphan reaper (#160)

### DIFF
--- a/.github/workflows/clerk-orphans.yml
+++ b/.github/workflows/clerk-orphans.yml
@@ -1,0 +1,44 @@
+name: Clerk Orphan Reaper
+
+# Out-of-band cleanup for stale e2e-* Clerk users left behind by crashed
+# CI runs. The pytest fixture now scopes its sweep to the current run id
+# (issue #160), so users from a run that was cancelled / OOM-killed before
+# its session_cleanup fired would otherwise accumulate forever. This cron
+# mops them up — with a 1h age filter to avoid racing in-flight runs.
+
+on:
+  schedule:
+    # Every hour on the half-hour (offset from the top to avoid colliding
+    # with the burst of scheduled jobs at :00).
+    - cron: "30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clerk-orphans
+  cancel-in-progress: false
+
+jobs:
+  reap:
+    runs-on: [self-hosted, linux, x64, isolated]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            e2e/scripts/cleanup_clerk_users.py
+
+      - name: Ensure requests is available
+        run: python3 -m pip install --user --quiet "requests>=2.31"
+
+      - name: Reap orphan e2e Clerk users older than 1h
+        env:
+          E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
+        run: |
+          if [ -z "${E2E_CLERK_SECRET_KEY}" ]; then
+            echo "E2E_CLERK_SECRET_KEY not set — skipping." >&2
+            exit 0
+          fi
+          python3 e2e/scripts/cleanup_clerk_users.py --older-than 1h

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -339,6 +339,67 @@ def vault_c(obsidian_c):
 # Plugin-surface assertion (replaces per-test has_* skip guards)
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+async def _track_apikey_wipe(request):
+    """After each test, log if apiKey on cdp_a went empty in mem or disk.
+
+    PR #162 surfaced a flake where test_66/69/70 hit `apiKeyLen: 0` on
+    both memory AND disk — meaning a PRIOR test wrote ``apiKey: ""`` via
+    saveSettings. Memory-only diagnostic can't identify the wiper.
+    This hook probes apiKey at teardown and logs WHICH test transitioned
+    it from non-empty → empty. Adds ~30 ms / test that uses cdp_a.
+
+    Skips tests that don't use cdp_a (api_only, etc.).
+    """
+    yield
+    if "cdp_a" not in request.fixturenames:
+        return
+    try:
+        cdp_a_val = request.getfixturevalue("cdp_a")
+    except (pytest.FixtureLookupError, Exception):
+        return
+    try:
+        state = await cdp_a_val.evaluate(
+            """
+            (async () => {
+                const p = app.plugins.plugins['engram-vault-sync'];
+                const memK = (p.settings?.apiKey || '');
+                const memR = (p.settings?.refreshToken || '');
+                let diskK = '', diskR = '';
+                try {
+                    const data = await p.loadData() || {};
+                    const ds = data.settings || {};
+                    diskK = ds.apiKey || '';
+                    diskR = ds.refreshToken || '';
+                } catch (_) {}
+                return {
+                    memApiKeyLen: memK.length,
+                    memRefreshTokenLen: memR.length,
+                    diskApiKeyLen: diskK.length,
+                    diskRefreshTokenLen: diskR.length,
+                };
+            })()
+            """,
+            await_promise=True,
+        )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "apikey-wipe probe failed for %s: %s", request.node.nodeid, e
+        )
+        return
+    if not isinstance(state, dict):
+        return
+    mem_k = state.get("memApiKeyLen", 0)
+    disk_k = state.get("diskApiKeyLen", 0)
+    mem_r = state.get("memRefreshTokenLen", 0)
+    if mem_k == 0 and disk_k == 0 and mem_r == 0:
+        logging.getLogger(__name__).error(
+            "APIKEY-WIPE detected after %s — mem=%d/%d disk=%d/%d",
+            request.node.nodeid, mem_k, mem_r, disk_k,
+            state.get("diskRefreshTokenLen", 0),
+        )
+
+
 @pytest.fixture(scope="session", autouse=True)
 async def _assert_plugin_surfaces(cdp_a):
     """Hard-fail once if the plugin under test lacks required surfaces.

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -95,14 +95,24 @@ if _WORKER > 0:
     CONFIG_PREFIX = f"{CONFIG_PREFIX}-w{_WORKER}"
 
 
+# Per-run namespace. GITHUB_RUN_ID is unique per CI run; "local" outside CI.
+# Embedded in every e2e-* email so cleanup can scope its sweep to just this
+# run instead of nuking sibling runs' users mid-flight (issue #160).
+_RUN_ID = os.environ.get("GITHUB_RUN_ID", "local")
+
+
 # ---------------------------------------------------------------------------
 # Unique timestamp for this test run
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(scope="session")
 def ts():
-    """Per-worker unique timestamp so two workers never pick the same email."""
-    return f"{datetime.now().strftime('%Y%m%d%H%M%S%f')}w{_WORKER}"
+    """Per-worker, per-run unique suffix for e2e-* emails.
+
+    Format: ``{YYYYMMDDHHMMSSffffff}r{RUN_ID}w{WORKER}`` — the ``r{RUN_ID}``
+    segment scopes cleanup to this CI run (see issue #160).
+    """
+    return f"{datetime.now().strftime('%Y%m%d%H%M%S%f')}r{_RUN_ID}w{_WORKER}"
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +131,10 @@ def auth_provider():
     """
     provider = get_auth_provider(API_URL)
     if _WORKER == 0:
-        provider.cleanup_all_e2e_users()
+        # Scope sweep to THIS run's namespace — never touch sibling runs'
+        # users. Orphans from crashed runs are reaped out-of-band by
+        # .github/workflows/clerk-orphans.yml (issue #160).
+        provider.cleanup_all_e2e_users(run_id=_RUN_ID)
     return provider
 
 

--- a/e2e/helpers/auth_provider.py
+++ b/e2e/helpers/auth_provider.py
@@ -44,8 +44,14 @@ class AuthProvider(ABC):
         """Best-effort cleanup of a provisioned user."""
 
     @abstractmethod
-    def cleanup_all_e2e_users(self) -> int:
-        """Nuclear cleanup: find and delete ALL e2e-* users. Returns count."""
+    def cleanup_all_e2e_users(self, run_id: str | None = None) -> int:
+        """Sweep e2e-* users for ``run_id`` (defaults to None = all runs).
+
+        Callers in the pytest session pass the current run id so they only
+        delete their own users — never sibling CI runs' users. The reaper
+        script omits ``run_id`` and pairs the sweep with a time-based filter
+        instead. See issue #160.
+        """
 
 
 class ClerkAuthProvider(AuthProvider):
@@ -90,9 +96,9 @@ class ClerkAuthProvider(AuthProvider):
         except Exception as e:
             logger.warning("Failed to delete Clerk user %s: %s", provider_user_id, e)
 
-    def cleanup_all_e2e_users(self) -> int:
+    def cleanup_all_e2e_users(self, run_id: str | None = None) -> int:
         from helpers.cleanup import cleanup_all_e2e_clerk_users
-        return cleanup_all_e2e_clerk_users(self.clerk_client)
+        return cleanup_all_e2e_clerk_users(self.clerk_client, run_id=run_id)
 
     def get_clerk_auth(self, clerk_user_id: str):
         """Return a ClerkAuth adapter for direct JWT auth (OAuth tests)."""
@@ -140,7 +146,7 @@ class LocalAuthProvider(AuthProvider):
         # Local users are cleaned up via DB cleanup in session teardown
         pass
 
-    def cleanup_all_e2e_users(self) -> int:
+    def cleanup_all_e2e_users(self, run_id: str | None = None) -> int:  # noqa: ARG002
         # No external service to clean — DB cleanup handles it
         return 0
 

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -751,6 +751,41 @@ class CdpClient:
         result = await self.evaluate(js)
         logger.info("Outgoing sync resumed on CDP port %d: %s", self.port, result)
 
+    async def pause_incoming_sync(self) -> None:
+        """Silence incoming WebSocket events by replacing handleStreamEvent.
+
+        Used by setup_conflict_for_a to guarantee that ``pull()`` is the
+        ONLY path that can detect divergence and open ConflictModal —
+        without this, B's full_sync push broadcasts an upsert event to A
+        which races against pull() under resolveConflict's single-flight
+        gate. The race produced the test_54 PerHunk flake on PR #162.
+        """
+        js = f"""
+        (function() {{
+            const se = {ENGINE_PATH};
+            if (se._origHandleStreamEvent) return 'already-paused';
+            se._origHandleStreamEvent = se.handleStreamEvent.bind(se);
+            se.handleStreamEvent = async () => {{}};
+            return 'paused';
+        }})()
+        """
+        result = await self.evaluate(js)
+        logger.info("Incoming sync paused on CDP port %d: %s", self.port, result)
+
+    async def resume_incoming_sync(self) -> None:
+        """Restore the WebSocket event handler saved by pause_incoming_sync()."""
+        js = f"""
+        (function() {{
+            const se = {ENGINE_PATH};
+            if (!se._origHandleStreamEvent) return 'not-paused';
+            se.handleStreamEvent = se._origHandleStreamEvent;
+            delete se._origHandleStreamEvent;
+            return 'resumed';
+        }})()
+        """
+        result = await self.evaluate(js)
+        logger.info("Incoming sync resumed on CDP port %d: %s", self.port, result)
+
     async def rename_file(self, old_path: str, new_path: str) -> None:
         """Rename a file through Obsidian's vault API (triggers handleRename)."""
         escaped_old = json.dumps(old_path)

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -785,6 +785,41 @@ class CdpClient:
         result = await self.evaluate(js)
         logger.info("Outgoing sync resumed on CDP port %d: %s", self.port, result)
 
+    async def vault_write(self, path: str, content: str) -> None:
+        """Write a file via Obsidian's vault API so the index sees it synchronously.
+
+        Plain filesystem writes (helpers.vault.write_note) are picked up only
+        when Obsidian's file watcher fires — async, racy. Code paths that need
+        the file to be in ``app.vault.getFiles()`` immediately (e.g. the
+        ``setup_conflict_for_a`` seed's step-1 trigger_full_sync) must use
+        this helper instead.
+
+        Creates parent folders as needed. Idempotent: modifies if the file
+        already exists, otherwise creates.
+        """
+        escaped_path = json.dumps(path)
+        escaped_content = json.dumps(content)
+        await self.evaluate(
+            f"""
+            (async () => {{
+                const existing = app.vault.getFileByPath({escaped_path});
+                if (existing) {{
+                    await app.vault.modify(existing, {escaped_content});
+                    return;
+                }}
+                const slash = {escaped_path}.lastIndexOf('/');
+                if (slash > 0) {{
+                    const dir = {escaped_path}.slice(0, slash);
+                    if (!app.vault.getAbstractFileByPath(dir)) {{
+                        try {{ await app.vault.createFolder(dir); }} catch (_) {{}}
+                    }}
+                }}
+                await app.vault.create({escaped_path}, {escaped_content});
+            }})()
+            """,
+            await_promise=True,
+        )
+
     async def pause_incoming_sync(self) -> None:
         """Silence incoming WebSocket events by replacing handleStreamEvent.
 

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -180,6 +180,39 @@ class CdpClient:
                         }})()
                         """
                     )
+                    # ── On-disk state ──────────────────────────────────────
+                    # If memory says apiKeyLen=0 but disk says apiKey is
+                    # present, a stale plugin instance is reading wiped
+                    # state. If both empty, something actively wiped disk.
+                    # Distinguishes "plugin reload lost it" from "state
+                    # actively cleared" — critical for tracing apiKey-wipe
+                    # flakes across the test sequence.
+                    diag["disk_state"] = await self.evaluate(
+                        f"""
+                        (async () => {{
+                            try {{
+                                const data = await {PLUGIN_PATH}.loadData() || {{}};
+                                const ds = data.settings || {{}};
+                                const k = ds.apiKey || '';
+                                const r = ds.refreshToken || '';
+                                return {{
+                                    diskApiKeyLen: k.length,
+                                    diskApiKeyPrefix: k.slice(0, 8),
+                                    diskRefreshTokenLen: r.length,
+                                    diskAuthMethod: ds.authMethod || null,
+                                    diskVaultId: ds.vaultId || null,
+                                    diskClientId: ds.clientId || null,
+                                    diskKeysPresent: Object.keys(ds).sort(),
+                                    syncGateAcceptedFor:
+                                        data.syncGateAcceptedFor || null,
+                                }};
+                            }} catch (e) {{
+                                return {{ error: String(e?.message || e) }};
+                            }}
+                        }})()
+                        """,
+                        await_promise=True,
+                    )
                     # ── Backend reachability (no-auth) ──────────────────────
                     diag["health"] = await self.evaluate(
                         f"{PLUGIN_PATH}.api.health()"
@@ -228,6 +261,7 @@ class CdpClient:
         ]
         for k in (
             "plugin_state",
+            "disk_state",
             "health",
             "me",
             "plugin_registerVault",

--- a/e2e/helpers/cleanup.py
+++ b/e2e/helpers/cleanup.py
@@ -95,15 +95,26 @@ def cleanup_clerk_users(clerk_client, clerk_user_ids: list[str]) -> None:
 _E2E_EMAIL_PREFIXES = ("e2e-sync-", "e2e-iso-", "e2e-vault-iso-", "e2e-oauth-", "e2e-clerk-")
 
 
-def cleanup_all_e2e_clerk_users(clerk_client) -> int:
-    """Find and delete ALL e2e-* users in the Clerk instance.
+def cleanup_all_e2e_clerk_users(clerk_client, run_id: str | None = None) -> int:
+    """Find and delete e2e-* users in the Clerk instance.
 
-    This is the nuclear option — it doesn't rely on fixture-tracked IDs,
-    so it catches orphans left by crashed fixtures or failed test runs.
+    By default scopes the sweep to ``run_id`` — only emails containing
+    ``r{run_id}`` are deleted. This prevents the cross-run cascade
+    documented in issue #160: a CI run's worker-0 fixture used to nuke
+    every e2e-* user, including ones being actively used by sibling CI
+    runs, causing HTTP 401 storms in those runs.
+
+    Passing ``run_id=None`` restores the legacy nuclear behavior — useful
+    only from the standalone reaper script (``scripts/cleanup_clerk_users.py``)
+    which adds its own ``--older-than`` time-based safety filter.
+
     Returns the number of users deleted.
     """
     deleted = 0
     offset = 0
+    # Anchor on the trailing ``w`` so that run id "123" never substring-matches
+    # into another run's "r12345w0" segment. Worker suffix is always present.
+    run_marker = f"r{run_id}w" if run_id else None
     while True:
         try:
             batch = clerk_client.list_users(limit=100, offset=offset)
@@ -114,17 +125,22 @@ def cleanup_all_e2e_clerk_users(clerk_client) -> int:
             break
         for user in batch:
             emails = [ea["email_address"] for ea in user.get("email_addresses", [])]
-            if any(e.startswith(pfx) for e in emails for pfx in _E2E_EMAIL_PREFIXES):
-                try:
-                    clerk_client.delete_user(user["id"])
-                    deleted += 1
-                except Exception as exc:
-                    logger.warning("Failed to delete Clerk user %s: %s", user["id"], exc)
+            is_e2e = any(e.startswith(pfx) for e in emails for pfx in _E2E_EMAIL_PREFIXES)
+            if not is_e2e:
+                continue
+            if run_marker is not None and not any(run_marker in e for e in emails):
+                continue
+            try:
+                clerk_client.delete_user(user["id"])
+                deleted += 1
+            except Exception as exc:
+                logger.warning("Failed to delete Clerk user %s: %s", user["id"], exc)
         if len(batch) < 100:
             break
         offset += 100
     if deleted:
-        logger.info("Cleaned up %d orphaned e2e Clerk users", deleted)
+        scope = f"run {run_id}" if run_id else "ALL runs"
+        logger.info("Cleaned up %d orphaned e2e Clerk users (%s)", deleted, scope)
     return deleted
 
 

--- a/e2e/helpers/conflict.py
+++ b/e2e/helpers/conflict.py
@@ -141,8 +141,11 @@ async def setup_conflict_for_a(
     )
 
     # 1. A writes the base content and syncs — establishes syncedHash on A
-    #    and base content on the server.
-    write_note(vault_a, path, base)
+    #    and base content on the server. Use vault_write (Obsidian's vault
+    #    API) instead of write_note so the file is in getFiles() before
+    #    fullSync iterates — raw filesystem writes are picked up only when
+    #    the watcher eventually fires, which races against trigger_full_sync.
+    await cdp_a.vault_write(path, base)
     await cdp_a.trigger_full_sync()
 
     # 2. B pulls so it also records the same base in its syncState. Not strictly
@@ -162,10 +165,13 @@ async def setup_conflict_for_a(
     await cdp_a.pause_incoming_sync()
 
     # 4. A writes local divergence (now: localHash != lastSyncedHash → modified).
-    write_note(vault_a, path, local)
+    #    vault_write ensures pull() in step 6 reads the local content from the
+    #    same path Obsidian's index knows about. handleModify is a no-op while
+    #    paused, so no push leaks out.
+    await cdp_a.vault_write(path, local)
 
     # 5. B writes remote divergence and syncs so the server carries B's version.
-    write_note(vault_b, path, remote)
+    await cdp_b.vault_write(path, remote)
     await cdp_b.trigger_full_sync()
 
     # 6. Resume A's outgoing sync, then pull — divergence is detected and

--- a/e2e/helpers/conflict.py
+++ b/e2e/helpers/conflict.py
@@ -153,6 +153,14 @@ async def setup_conflict_for_a(
     # 3. Pause A's outgoing sync so the local divergent write stays off-server.
     await cdp_a.pause_outgoing_sync()
 
+    # 3b. Pause A's incoming WebSocket events so the broadcast from step 5
+    #     (B's push) cannot race pull() under resolveConflict's single-flight
+    #     gate. Without this, the WS path and the pull path both try to open
+    #     ConflictModal for the same `path`; under specific edit-range
+    #     geometries the interleaving silently auto-resolves and neither
+    #     mounts the modal — the test_54 PerHunk flake on PR #162.
+    await cdp_a.pause_incoming_sync()
+
     # 4. A writes local divergence (now: localHash != lastSyncedHash → modified).
     write_note(vault_a, path, local)
 
@@ -170,7 +178,8 @@ async def setup_conflict_for_a(
     # for the modal click, no test code has run yet to click.
     #
     # Fire-and-forget: dispatch pull() and rely on the modal-mount poll below
-    # to know when the seed has reached the user-interaction point.
+    # to know when the seed has reached the user-interaction point. Incoming
+    # WS handling stays paused — pull is the only conflict-detection path.
     await cdp_a.resume_outgoing_sync()
     # No await_promise — dispatch pull() and return immediately so the seed
     # can poll for the modal that pull() is about to surface.
@@ -187,10 +196,48 @@ async def setup_conflict_for_a(
             "Boolean(document.querySelector('.engram-conflict-modal'))"
         )
         if present:
+            # Modal up. Restore WS handler so the rest of the test (and
+            # restore_after_conflict) observes normal events again.
+            await cdp_a.resume_incoming_sync()
             return
         await asyncio.sleep(0.2)
+
+    # Modal never mounted. Capture the engine's view of the world before
+    # raising so the next flake has actionable evidence. Mirrors the
+    # wait_for_vault_registered diagnostic pattern from PR #159.
+    state = await cdp_a.evaluate(
+        f"""
+        (() => {{
+            const p = app.plugins.plugins['engram-vault-sync'];
+            const se = p.syncEngine;
+            const ss = se.syncState.get({path!r});
+            const bs = p.baseStore?.get?.({path!r});
+            return JSON.stringify({{
+                conflictResolution: p.settings.conflictResolution,
+                syncBlocked: se.syncBlocked,
+                recentlyPushed: se.isRecentlyPushed?.({path!r}) ?? null,
+                pushing: se.pushing?.has?.({path!r}) ?? null,
+                syncState: ss ? {{
+                    hash: ss.hash,
+                    version: ss.version,
+                    hashLen: (ss.hash || '').length,
+                }} : null,
+                baseStorePresent: !!bs,
+                baseLen: bs ? (bs.content || '').length : null,
+                incomingPaused: !!se._origHandleStreamEvent,
+                outgoingPaused: !!se._origHandleModify,
+            }});
+        }})()
+        """
+    )
+    # Best-effort restore so we don't poison downstream cleanup paths.
+    try:
+        await cdp_a.resume_incoming_sync()
+    except Exception:
+        pass
     raise TimeoutError(
-        f"ConflictModal never opened for path '{path}' within 10 s"
+        f"ConflictModal never opened for path '{path}' within 10 s; "
+        f"engine state at timeout: {state}"
     )
 
 

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -2,22 +2,15 @@
 asyncio_mode = auto
 timeout = 180
 testpaths = tests
-# TODO: drop reruns once the auth_provider xdist race is fixed.
+# TODO: drop reruns once main is green on 2-3 consecutive runs with
+# the issue #160 fix in place (per-run Clerk namespace + cron reaper).
 #
-# All deterministic flakes this PR set out to kill ARE fixed
-# (vault-registration self-heal in helpers/cdp.py, echo-expiry
-# acceleration, bounded-retry modal dismiss, test_60 uuid emails,
-# test_71 repr(None) JS bug). But removing reruns surfaced a deeper
-# Clerk-lifecycle race in conftest.py:auth_provider — worker 0's
-# nuclear `cleanup_all_e2e_clerk_users()` can race against worker 1's
-# freshly-provisioned users and delete them mid-run, causing 401 on
-# every subsequent api.registerVault / api.listVaults call (cascades
-# from users → api_keys in the backend). The race is acknowledged in
-# the existing fixture comment but never fixed.
-#
-# Real fix: hoist the nuclear sweep out of the pytest session into a
-# CI pre-step (.github/workflows/ci.yml), so cleanup completes before
-# any worker provisions. That's a separate PR.
+# Deterministic flakes are fixed (PR #159 — vault-registration self-heal,
+# echo-cooldown acceleration, modal-dismiss retry, test_60 uuid emails,
+# test_71 repr(None) JS bug). The remaining cross-run Clerk race is
+# scoped out via ``r{GITHUB_RUN_ID}`` in conftest.py:ts and the hourly
+# reaper at .github/workflows/clerk-orphans.yml. Removing reruns is a
+# one-line follow-up PR once we've banked enough green runs to trust it.
 reruns = 1
 reruns_delay = 2
 # -ra = show short summary for (a)ll non-passing outcomes, including reruns.

--- a/e2e/scripts/cleanup_clerk_users.py
+++ b/e2e/scripts/cleanup_clerk_users.py
@@ -3,9 +3,12 @@
 
 Usage:
     E2E_CLERK_SECRET_KEY=sk_test_... python e2e/scripts/cleanup_clerk_users.py [--dry-run]
+    E2E_CLERK_SECRET_KEY=sk_test_... python e2e/scripts/cleanup_clerk_users.py --older-than 1h
 
 Fetches all Clerk users, filters to e2e-* email patterns, and deletes them.
-Designed to recover from the Clerk dev 100-user quota limit.
+The ``--older-than`` filter is the safety belt for the hourly cron reaper
+(``.github/workflows/clerk-orphans.yml``): without it, the reaper could
+race against an in-flight CI run whose users are still active. See issue #160.
 """
 
 from __future__ import annotations
@@ -13,8 +16,10 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import re
 import sys
 import time
+from datetime import datetime, timedelta, timezone
 
 import requests
 
@@ -56,9 +61,50 @@ def is_e2e_user(user: dict) -> bool:
     return False
 
 
+_DURATION_RE = re.compile(r"^(\d+)([smhd])$")
+
+
+def parse_duration(s: str) -> timedelta:
+    """Parse '30s', '15m', '1h', '2d' into a timedelta. Raises on bad input."""
+    m = _DURATION_RE.match(s.strip().lower())
+    if not m:
+        raise argparse.ArgumentTypeError(
+            f"Invalid duration {s!r}; expected forms like '30s', '15m', '1h', '2d'"
+        )
+    n, unit = int(m.group(1)), m.group(2)
+    return {
+        "s": timedelta(seconds=n),
+        "m": timedelta(minutes=n),
+        "h": timedelta(hours=n),
+        "d": timedelta(days=n),
+    }[unit]
+
+
+def user_age(user: dict, now: datetime) -> timedelta | None:
+    """Return how long ago this Clerk user was created. None if unknown.
+
+    Clerk's ``created_at`` is unix-millis (per Clerk Backend API docs).
+    """
+    raw = user.get("created_at")
+    if raw is None:
+        return None
+    try:
+        created = datetime.fromtimestamp(int(raw) / 1000, tz=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+    return now - created
+
+
 def main():
     parser = argparse.ArgumentParser(description="Delete stale E2E Clerk users")
     parser.add_argument("--dry-run", action="store_true", help="List users without deleting")
+    parser.add_argument(
+        "--older-than",
+        type=parse_duration,
+        default=None,
+        help="Only delete users older than this (e.g. '1h', '30m', '2d'). "
+        "Required by the cron reaper to avoid racing in-flight CI runs.",
+    )
     args = parser.parse_args()
 
     secret = os.environ.get("E2E_CLERK_SECRET_KEY", "")
@@ -77,6 +123,21 @@ def main():
     e2e_users = [u for u in all_users if is_e2e_user(u)]
     non_e2e = len(all_users) - len(e2e_users)
     logger.info("E2E test users: %d | Real users: %d", len(e2e_users), non_e2e)
+
+    if args.older_than is not None:
+        now = datetime.now(timezone.utc)
+        before = len(e2e_users)
+        e2e_users = [
+            u
+            for u in e2e_users
+            if (age := user_age(u, now)) is not None and age >= args.older_than
+        ]
+        logger.info(
+            "Age filter --older-than %s: kept %d / %d e2e users",
+            args.older_than,
+            len(e2e_users),
+            before,
+        )
 
     if not e2e_users:
         logger.info("Nothing to clean up.")

--- a/e2e/tests/api_only/conftest.py
+++ b/e2e/tests/api_only/conftest.py
@@ -28,3 +28,9 @@ async def _assert_plugin_surfaces():
     only fires for tests that actually drive Obsidian.
     """
     return
+
+
+@pytest.fixture(autouse=True)
+async def _track_apikey_wipe():
+    """Override the parent conftest's apiKey-wipe probe — api_only has no cdp_a."""
+    yield


### PR DESCRIPTION
## Summary

Closes #160 — the xdist + cross-run race where worker 0's nuclear `cleanup_all_e2e_clerk_users()` would delete sibling runs' (or sibling workers') freshly-provisioned users, cascading to HTTP 401 storms via the users → api_keys cascade in the backend.

Two halves, one per commit:

1. **In-band fix.** Every e2e-* email now embeds `r{GITHUB_RUN_ID}w{WORKER}`. `cleanup_all_e2e_clerk_users(run_id=...)` only deletes users whose emails contain `r{run_id}w` — anchored on the trailing `w` so short run ids never substring-match longer ones. The pytest session passes its own run id, never touches siblings.

2. **Out-of-band reaper.** New hourly cron at `.github/workflows/clerk-orphans.yml` runs `e2e/scripts/cleanup_clerk_users.py --older-than 1h`. The age filter is the safety belt against racing in-flight CI runs whose `session_cleanup` hasn't yet fired. Crashed / cancelled runs no longer accumulate stale users.

## Why not "hoist sweep into a CI pre-step"

The issue's draft considered moving the nuclear sweep into `ci.yml`'s pre-job stage. That just widens the race from worker-vs-worker (within one run) to run-vs-run (across the org), with the same cascade and a larger blast radius. Per-run namespacing eliminates the race entirely; the reaper handles orphans the namespace doesn't catch.

## What's intentionally NOT in this PR

- `reruns = 1` still on in `e2e/pytest.ini`. Drop is a one-line follow-up after 2-3 main runs prove this stable; the pytest.ini TODO comment now points at that follow-up plan.
- Local-auth email scheme (`e2e-local-...@test.com` in `test_60`) is **not** namespaced. Those users live in ephemeral postgres per-CI-run, not in shared Clerk — no cross-run pollution surface.
- The three unrelated lifecycle flakes (test_46 / test_51 / test_55) are tracked separately in #161.

## Test plan

- [x] Unit smoke: `cleanup_all_e2e_clerk_users` scoped sweep only deletes matching `r{run_id}w` users; nuclear mode (run_id=None) preserved for manual ops.
- [x] Unit smoke: `parse_duration` accepts `1h`/`30m`/`2d`, rejects bad input. `user_age` reads Clerk unix-millis `created_at`.
- [x] Unit smoke: anchor on `w` — run id `123` does NOT match `r12345w0`.
- [ ] One full CI run on this branch passes e2e-clerk job without rerun-only saves.
- [ ] After merge: confirm the scheduled `clerk-orphans` workflow first execution behaves (consider a manual `workflow_dispatch` with `--dry-run` for the very first invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)