### PR TITLE
chore: bump mix.exs to 0.5.141 for deploy

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.140",
+      version: "0.5.141",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

PR #162 merged without a mix.exs bump. The `deploy-fastraid` job checks GHCR for the existing image tag and refuses to redeploy if it already exists — version 0.5.140 was already in GHCR from a prior deploy, so the post-merge deploy aborted at the "Extract and validate version" step.

Bumps to 0.5.141 so a fresh image gets built and pushed, and the per-run Clerk namespace + orphan reaper fixes land in production.

## Verification

- [x] Engram CI on main run 26128075484: `e2e-clerk` + `ci` + `e2e-browser` + `e2e-local` + `unit-tests` all green; only `deploy-fastraid` failed at version validation (the intended gate)
- [ ] This bump makes deploy-fastraid succeed on its next run