### PR TITLE
fix(ci): bump-infra-tfvars — disable checkout persisted credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1645,6 +1645,14 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: engram-infra
           ref: main
+          # peter-evans/create-pull-request@v6 sets its own Authorization
+          # header on push; persist-credentials=true would leave the
+          # checkout's basic-auth extraheader in git config, and the
+          # second header triggers GitHub's "Duplicate header: Authorization"
+          # 400 (observed on first real bot run during the 2026-05-19
+          # cutover). The create-pull-request step still uses the same
+          # app-token via its `token:` input.
+          persist-credentials: false
 
       - name: Rewrite image_tag defaults in variables.tf
         id: rewrite

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.142",
+      version: "0.5.143",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

The `bump-infra-tfvars` bot's first real run (engram PR #164 / 2026-05-19) failed with HTTP 400:

\`\`\`
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/engram-app/engram-infra/':
       The requested URL returned error: 400
\`\`\`

## Root cause

`actions/checkout@v6` (with `persist-credentials` defaulting to `true`) sets an extraheader in git config for github.com:

\`\`\`
http.https://github.com/.extraheader = AUTHORIZATION: basic ***
\`\`\`

When `peter-evans/create-pull-request@v6` later runs `git push`, it adds its own `Authorization` header via the URL credentials — GitHub sees two and 400s. Both steps were intentionally using the same app-token, so this is header-stacking, not a permissions concern.

## Fix

`persist-credentials: false` on the engram-infra checkout step. The create-pull-request action still receives the same app-token via its `token:` input, so auth remains scoped to engram-infra via the same installation token.

Known-good pattern per peter-evans's own guidance: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md

## Side effects

- `mix.exs` bumped 0.5.142 → 0.5.143 (version-check requires delta)
- Merging this PR triggers `build-and-publish-image` → pushes 0.5.143 to GHCR → `bump-infra-tfvars` opens a real engram-infra PR for the first time
- That bot PR will trigger `tf-apply` with the new pre-pull check + health verify (engram-infra PR #46 just merged) — full end-to-end smoke test of the deploy pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)