### PR TITLE
feat(crypto): BOOT_CANARY_ENABLED env override for T3.5 rotation

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -204,6 +204,18 @@ if config_env() != :test do
       String.to_integer(System.get_env("ENCRYPTION_MASTER_KEY_VERSION", "1")),
     dek_cache_ttl_ms: String.to_integer(System.get_env("DEK_CACHE_TTL_MS", "3600000"))
 
+  # T3.5 master-key rotation needs the boot canary disabled during the
+  # window between bumping ENCRYPTION_MASTER_KEY and running
+  # `Engram.Crypto.MasterRotation.rotate_canary/0` (the canary row is
+  # still wrapped under the OLD key and `unwrap_dek_no_fallback/2`
+  # refuses to consult `_PREVIOUS`). Operator sets BOOT_CANARY_ENABLED=false
+  # in the SOPS-managed env, restarts, runs rotation, then removes the
+  # env var. See backend/docs/context/encryption-operations.md
+  # "Tier-3 / T3.5 — Master-key rotation runbook".
+  if System.get_env("BOOT_CANARY_ENABLED") == "false" do
+    config :engram, :boot_canary_enabled, false
+  end
+
   if key_provider_module == Engram.Crypto.KeyProvider.AwsKms do
     config :engram,
       aws_kms_client: Engram.AwsKms.ExAws,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.144",
+      version: "0.5.145",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

3-line plumbing in `config/runtime.exs` that makes the boot-canary guard env-toggleable, exactly as the T3.5 runbook (\`backend/docs/context/encryption-operations.md\`) documented but the codebase never implemented. Bumps mix.exs to 0.5.145.

The runbook says: "set \`:engram, :boot_canary_enabled\` to false (env override) for the duration." But the override didn't exist — only the compile-time \`config.exs\` value (\`true\`) and the test-env override (\`false\`). So running the rotation procedure as-documented crash-looped the container on the first restart, because \`BootCanary.verify!/0\` calls \`unwrap_dek_no_fallback/2\` which refuses to consult \`_PREVIOUS\`.

This PR adds the missing override:

\`\`\`elixir
if System.get_env(\"BOOT_CANARY_ENABLED\") == \"false\" do
  config :engram, :boot_canary_enabled, false
end
\`\`\`

Default behavior unchanged. Env var absent OR set to anything other than the literal string \"false\" → guard stays enabled, boot canary verifies. Strict-match is intentional — only an operator deliberately setting it to disable.

## Why now

Unblocks R5 of the 2026-05-19 secret-rotation wave (workspace memory \`project_secret_rotation_2026_05_19\`). The master encryption key had leaked in committed JSON. R1-R4 + R6 + R7 already shipped today (Voyage + JWT + SECRET_KEY_BASE + DB password + selfhost wipe + redacted spec). R5 (master-key rotation via T3.5 procedure) is the last leak still live.

## Rotation flow (after this lands)

1. This PR merges → 0.5.145 image publishes to GHCR
2. Bot opens engram-infra image-bump PR → merge → tf-apply destroys+creates with 0.5.145 (env unchanged; canary verifies under old key OK)
3. SOPS: set \`encryption_master_key\` to NEW value, add \`encryption_master_key_previous\` = OLD, set \`encryption_master_key_version\` = 2, set \`boot_canary_enabled\` = false
4. engram-infra PR for rotation env → merge → tf-apply destroys+creates with rotation env (boot canary skipped)
5. release rpc: \`Engram.Crypto.MasterRotation.enqueue_all(2)\` — re-wraps every per-user DEK under NEW key
6. Verify \`MIN(dek_version) >= 2\` across users
7. release rpc: \`Engram.Crypto.MasterRotation.rotate_canary()\` — rewraps canary under NEW key
8. SOPS: remove \`encryption_master_key_previous\`, remove \`boot_canary_enabled\` flag
9. engram-infra PR → merge → tf-apply destroys+creates with clean env. Boot canary re-engages.

After step 9, the leaked master key value in git history is dead — no DEK in any user's row is wrapped under it.

## Test plan

- [ ] mix test passes (no test changes needed — runtime.exs is loaded at boot, not exercised by ExUnit)
- [ ] CI builds + publishes 0.5.145 to GHCR
- [ ] Bot opens engram-infra bump PR within ~1min of merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)