### PR TITLE
docs(crypto): mark AWS KMS Phase 2 (BootCanary polymorphism) shipped

### DIFF
--- a/docs/context/aws-kms-provider-integration.md
+++ b/docs/context/aws-kms-provider-integration.md
@@ -1,6 +1,8 @@
 # AWS KMS Provider Integration — Phase 1 Gotchas
 
 > Non-obvious discoveries from Phase 1 (PR #110). Prevents rediscovery in Phase 2 (BootCanary polymorphism) and Phase 3 (ProviderMigration).
+>
+> **Status update 2026-05-20:** Phase 2 quietly shipped — `Engram.Crypto.BootCanary.verify!/0` calls `Resolver.provider()` + `provider.boot_check/0` + `provider.unwrap_dek_no_fallback/2`. `MasterRotation` uses `Resolver.provider_for/1`. Only Phase 3 (cross-provider migration state machine) remains pending. Staging cutover docs in workspace plan `ok-i-think-we-shimmying-duckling.md`.
 
 ## Architecture — Three Layers
 
@@ -176,10 +178,10 @@ From `KeyProvider.AwsKms.unwrap_dek/2`:
 ### Ships
 - Provider + behaviour + Mox seam + conformance suite + `Config.validate!/0` extension + `runtime.exs` opt-in arm + `identify_from_blob/1` primitive.
 
-### Does NOT Ship
-- BootCanary polymorphism (Phase 2) — still hardcoded to Local on boot.
+### Does NOT Ship (at PR #110 — see status update at top)
+- ~~BootCanary polymorphism (Phase 2)~~ — shipped post PR #110; see status update.
 - ProviderMigration state machine (Phase 3).
-- Fly secrets / IAM policy creation (Phase 4 cutover).
-- Changes to `Engram.Crypto.get_dek/1` read paths — still read-only from Local.
+- Fly secrets / IAM policy creation (Phase 4 cutover for prod). Staging cutover lives in the workspace plan, not here.
+- Changes to `Engram.Crypto.get_dek/1` read paths — still read-only from configured provider; no cross-provider blob routing.
 
-Key impl detail: All DEK operations (get/wrap/unwrap) still use the configured provider, but the migration machinery to change provider per-user doesn't exist yet.
+Key impl detail: All DEK operations (get/wrap/unwrap) use the configured provider, but the migration machinery to change provider per-user doesn't exist yet — staging cutover therefore wipes the DB rather than migrating.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.146",
+      version: "0.5.147",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- The Phase 1 gotchas doc still claimed Phase 2 was pending. Code reality: `BootCanary.verify!/0` calls `Resolver.provider()` + `provider.boot_check/0` + `provider.unwrap_dek_no_fallback/2`; `MasterRotation` uses `Resolver.provider_for/1`.
- Add top-of-doc status banner and strike through the Phase 2 entry in "Does NOT Ship" so the staging AWS KMS cutover doesn't tee up duplicate Phase 2 code.
- Version bump 0.5.146 → 0.5.147 (doc-only release).

## Test plan
- [ ] CI green (no code changes; doc + version only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)