### PR TITLE
feat(billing): plans resolver foundation (PR 1 of 3)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -185,21 +185,24 @@ config :engram, :billing_enabled, System.get_env("PADDLE_API_KEY") != nil
 # SaaS default: enforce when Paddle is configured.
 # Self-host default: bypass when no Paddle key.
 # Explicit override: ENGRAM_LIMITS_ENFORCED=true|false
-config :engram, :limits_enforced, case(System.get_env("ENGRAM_LIMITS_ENFORCED")) do
-  "true" ->
-    true
+limits_enforced =
+  case System.get_env("ENGRAM_LIMITS_ENFORCED") do
+    "true" ->
+      true
 
-  "false" ->
-    false
+    "false" ->
+      false
 
-  nil ->
-    System.get_env("PADDLE_API_KEY") != nil
+    nil ->
+      System.get_env("PADDLE_API_KEY") != nil
 
-  other ->
-    raise """
-    ENGRAM_LIMITS_ENFORCED must be 'true', 'false', or unset (got #{inspect(other)}).
-    """
-end
+    other ->
+      raise """
+      ENGRAM_LIMITS_ENFORCED must be 'true', 'false', or unset (got #{inspect(other)}).
+      """
+  end
+
+config :engram, :limits_enforced, limits_enforced
 
 # Current Terms of Service version. Must match the version exported by
 # frontend/src/legal/terms-of-service.tsx. Bumping this re-prompts every

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -205,6 +205,21 @@ if config_env() != :test do
     end
 
   config :engram, :limits_enforced, limits_enforced
+
+  # Plan limit overrides from env vars. Each ENGRAM_<TIER>_<KEY> is parsed at
+  # boot. Bad values raise a fail-fast boot error per EnvLimits.parse!/3.
+  # Test env: tests set :plan_overrides directly via Application.put_env;
+  # do not override here.
+  plan_overrides =
+    for {tier, key, env_name} <- Engram.Billing.LimitKeys.env_var_names(),
+        raw = System.get_env(env_name),
+        raw != nil,
+        into: %{} do
+      typed = Engram.Billing.EnvLimits.parse!(raw, Engram.Billing.LimitKeys.type(key), env_name)
+      {{tier, key}, typed}
+    end
+
+  config :engram, :plan_overrides, plan_overrides
 end
 
 # Current Terms of Service version. Must match the version exported by

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -185,24 +185,27 @@ config :engram, :billing_enabled, System.get_env("PADDLE_API_KEY") != nil
 # SaaS default: enforce when Paddle is configured.
 # Self-host default: bypass when no Paddle key.
 # Explicit override: ENGRAM_LIMITS_ENFORCED=true|false
-limits_enforced =
-  case System.get_env("ENGRAM_LIMITS_ENFORCED") do
-    "true" ->
-      true
+# Test env: config/test.exs hardcodes true; do not override at runtime.
+if config_env() != :test do
+  limits_enforced =
+    case System.get_env("ENGRAM_LIMITS_ENFORCED") do
+      "true" ->
+        true
 
-    "false" ->
-      false
+      "false" ->
+        false
 
-    nil ->
-      System.get_env("PADDLE_API_KEY") != nil
+      nil ->
+        System.get_env("PADDLE_API_KEY") != nil
 
-    other ->
-      raise """
-      ENGRAM_LIMITS_ENFORCED must be 'true', 'false', or unset (got #{inspect(other)}).
-      """
-  end
+      other ->
+        raise """
+        ENGRAM_LIMITS_ENFORCED must be 'true', 'false', or unset (got #{inspect(other)}).
+        """
+    end
 
-config :engram, :limits_enforced, limits_enforced
+  config :engram, :limits_enforced, limits_enforced
+end
 
 # Current Terms of Service version. Must match the version exported by
 # frontend/src/legal/terms-of-service.tsx. Bumping this re-prompts every

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -181,6 +181,26 @@ end
 # disabled in self-host (no PADDLE_API_KEY → no payment → no wizard).
 config :engram, :billing_enabled, System.get_env("PADDLE_API_KEY") != nil
 
+# Plan limits enforcement toggle.
+# SaaS default: enforce when Paddle is configured.
+# Self-host default: bypass when no Paddle key.
+# Explicit override: ENGRAM_LIMITS_ENFORCED=true|false
+config :engram, :limits_enforced, case(System.get_env("ENGRAM_LIMITS_ENFORCED")) do
+  "true" ->
+    true
+
+  "false" ->
+    false
+
+  nil ->
+    System.get_env("PADDLE_API_KEY") != nil
+
+  other ->
+    raise """
+    ENGRAM_LIMITS_ENFORCED must be 'true', 'false', or unset (got #{inspect(other)}).
+    """
+end
+
 # Current Terms of Service version. Must match the version exported by
 # frontend/src/legal/terms-of-service.tsx. Bumping this re-prompts every
 # user on next request via the RequireOnboarding plug.

--- a/config/test.exs
+++ b/config/test.exs
@@ -107,3 +107,6 @@ config :engram,
 # via Application.put_env/3 in their setup blocks.
 config :engram, :billing_enabled, true
 config :engram, :current_tos_version, "2026-05-15"
+
+# Limits enforced by default in test env so existing tests don't bypass.
+config :engram, :limits_enforced, true

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -60,6 +60,12 @@ services:
       STORAGE_HOST: minio
       STORAGE_PORT: "9000"
       STORAGE_REGION: us-east-1
+      # Force plan-limit enforcement in CI. Without this, runtime.exs's
+      # self-host bypass (PADDLE_API_KEY unset → :limits_enforced=false)
+      # would kick in and free-tier limits (e.g. vaults_cap=1) would not
+      # be enforced — breaking e2e tests like test_32 that assert 402 on
+      # over-limit vault creation.
+      ENGRAM_LIMITS_ENFORCED: "true"
     healthcheck:
       # 1s interval (was 3s) so docker compose --wait detects "ready" with
       # finer granularity — BEAM cold boot finishes mid-interval and the

--- a/e2e/tests/api_only/test_32_vault_api_key_isolation.py
+++ b/e2e/tests/api_only/test_32_vault_api_key_isolation.py
@@ -40,12 +40,12 @@ pytestmark = pytest.mark.skipif(
 
 
 def _set_vault_limit(user_id: int, limit: int) -> None:
-    """Insert/update a user_overrides row to set max_vaults via docker exec SQL."""
+    """Insert/update a user_overrides row to set vaults_cap via docker exec SQL."""
     sql = (
         f"INSERT INTO user_overrides (user_id, overrides, reason, created_at, updated_at) "
-        f"VALUES ({user_id}, '{{\"max_vaults\": {limit}}}', 'e2e-test', NOW(), NOW()) "
+        f"VALUES ({user_id}, '{{\"vaults_cap\": {limit}}}', 'e2e-test', NOW(), NOW()) "
         f"ON CONFLICT (user_id) DO UPDATE SET overrides = "
-        f"jsonb_set(user_overrides.overrides, '{{max_vaults}}', '{limit}'), updated_at = NOW()"
+        f"jsonb_set(user_overrides.overrides, '{{vaults_cap}}', '{limit}'), updated_at = NOW()"
     )
     result = subprocess.run(
         ["docker", "exec", "-i", CI_POSTGRES_CONTAINER,
@@ -84,7 +84,7 @@ def vault_setup():
     """Create a Clerk user with two vaults for multi-vault isolation testing.
 
     Workflow:
-    1. Create Clerk user (default: max_vaults=1)
+    1. Create Clerk user (default: vaults_cap=1)
     2. Create vault A (succeeds — first vault)
     3. Verify vault B blocked by limit (402)
     4. Lift limit via user_overrides SQL

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -50,7 +50,7 @@ defmodule Engram.Billing do
   defp enforced?, do: Application.get_env(:engram, :limits_enforced, true)
 
   defp do_effective_limit(user, key) do
-    user_tier = tier_or_free(user)
+    user_tier = tier(user)
     string_key = to_string(key)
 
     with :miss <- user_override_lookup(user.id, string_key),
@@ -59,14 +59,6 @@ defmodule Engram.Billing do
       LimitKeys.default_for(key, user_tier)
     else
       {:hit, v} -> v
-    end
-  end
-
-  # Temporary helper — replaced in Task 10 once tier/1 returns :free directly.
-  defp tier_or_free(user) do
-    case tier(user) do
-      :none -> :free
-      other -> other
     end
   end
 
@@ -136,7 +128,7 @@ defmodule Engram.Billing do
 
   @doc """
   Returns the user's effective tier as an atom.
-  Users without a subscription (or with a canceled one) are :none.
+  Users without a subscription (or with a canceled one) are :free.
   """
   def tier(user) do
     case get_subscription(user) do
@@ -144,7 +136,7 @@ defmodule Engram.Billing do
         String.to_existing_atom(tier)
 
       _ ->
-        :none
+        :free
     end
   end
 

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -7,17 +7,19 @@ defmodule Engram.Billing do
   """
 
   import Ecto.Query
+  alias Engram.Billing.LimitKeys
   alias Engram.Billing.Plan
   alias Engram.Billing.Subscription
   alias Engram.Billing.UserOverride
   alias Engram.Repo
 
-  @default_limits %{
-    "max_vaults" => 1,
-    "max_storage_bytes" => 104_857_600,
-    "cross_vault_search" => false,
-    "vault_scoped_keys" => false
-  }
+  defmodule UnknownLimitKey do
+    @moduledoc "Raised when a limit lookup uses an unknown atom or a string key."
+    defexception [:key]
+
+    def message(%{key: k}),
+      do: "unknown limit key: #{inspect(k)} (atoms only, must be in LimitKeys.all/0)"
+  end
 
   # ── Limits ────────────────────────────────────────────────────────
 
@@ -27,20 +29,37 @@ defmodule Engram.Billing do
   Resolution order:
     1. user_overrides[key]
     2. plans[user.plan_id].limits[key]
-    3. @default_limits[key]
+    3. LimitKeys.default_for(key, tier)
 
   Uses explicit nil-checking (not ||) so that `false` values are honoured.
+  Raises `Engram.Billing.UnknownLimitKey` for string keys or atoms not in
+  `LimitKeys.all/0`.
   """
-  def effective_limit(user, key) do
-    case override_value(user.id, key) do
+  def effective_limit(user, key) when is_atom(key) do
+    unless LimitKeys.defined?(key), do: raise(UnknownLimitKey, key: key)
+    do_effective_limit(user, key)
+  end
+
+  def effective_limit(_user, key), do: raise(UnknownLimitKey, key: key)
+
+  defp do_effective_limit(user, key) do
+    case override_value(user.id, to_string(key)) do
       nil ->
-        case plan_value(user, key) do
-          nil -> Map.get(@default_limits, key)
+        case plan_value(user, to_string(key)) do
+          nil -> LimitKeys.default_for(key, tier_or_free(user))
           val -> val
         end
 
       val ->
         val
+    end
+  end
+
+  # Temporary helper — replaced in Task 10 once tier/1 returns :free directly.
+  defp tier_or_free(user) do
+    case tier(user) do
+      :none -> :free
+      other -> other
     end
   end
 

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -37,10 +37,17 @@ defmodule Engram.Billing do
   """
   def effective_limit(user, key) when is_atom(key) do
     unless LimitKeys.defined?(key), do: raise(UnknownLimitKey, key: key)
-    do_effective_limit(user, key)
+
+    if enforced?() do
+      do_effective_limit(user, key)
+    else
+      :unlimited
+    end
   end
 
   def effective_limit(_user, key), do: raise(UnknownLimitKey, key: key)
+
+  defp enforced?, do: Application.get_env(:engram, :limits_enforced, true)
 
   defp do_effective_limit(user, key) do
     case override_value(user.id, to_string(key)) do
@@ -69,6 +76,8 @@ defmodule Engram.Billing do
   """
   def check_limit(user, key, current_count) do
     case effective_limit(user, key) do
+      :unlimited -> :ok
+      nil -> :ok
       -1 -> :ok
       limit when is_integer(limit) and current_count < limit -> :ok
       _ -> {:error, :limit_reached}
@@ -80,10 +89,10 @@ defmodule Engram.Billing do
   Returns {:error, :feature_not_available} otherwise.
   """
   def check_feature(user, key) do
-    if effective_limit(user, key) do
-      :ok
-    else
-      {:error, :feature_not_available}
+    case effective_limit(user, key) do
+      :unlimited -> :ok
+      true -> :ok
+      _ -> {:error, :feature_not_available}
     end
   end
 

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -50,15 +50,15 @@ defmodule Engram.Billing do
   defp enforced?, do: Application.get_env(:engram, :limits_enforced, true)
 
   defp do_effective_limit(user, key) do
-    case override_value(user.id, to_string(key)) do
-      nil ->
-        case plan_value(user, to_string(key)) do
-          nil -> LimitKeys.default_for(key, tier_or_free(user))
-          val -> val
-        end
+    user_tier = tier_or_free(user)
+    string_key = to_string(key)
 
-      val ->
-        val
+    with :miss <- user_override_lookup(user.id, string_key),
+         :miss <- env_override_lookup(user_tier, key),
+         :miss <- plan_lookup(user, string_key) do
+      LimitKeys.default_for(key, user_tier)
+    else
+      {:hit, v} -> v
     end
   end
 
@@ -98,31 +98,39 @@ defmodule Engram.Billing do
 
   # ── Private Limit Helpers ─────────────────────────────────────────
 
-  defp override_value(user_id, key) do
+  defp user_override_lookup(user_id, string_key) do
     Repo.one(
       from(o in UserOverride,
         where: o.user_id == ^user_id,
-        select: fragment("?->?", o.overrides, ^key)
+        select: fragment("?->?", o.overrides, ^string_key)
       ),
       skip_tenant_check: true
     )
-    |> decode_json_value()
+    |> wrap_lookup()
   end
 
-  defp plan_value(%{plan_id: nil}, _key), do: nil
+  defp env_override_lookup(tier, key) do
+    case Application.get_env(:engram, :plan_overrides, %{}) |> Map.fetch({tier, key}) do
+      {:ok, v} -> {:hit, v}
+      :error -> :miss
+    end
+  end
 
-  defp plan_value(%{plan_id: plan_id}, key) do
+  defp plan_lookup(%{plan_id: nil}, _string_key), do: :miss
+
+  defp plan_lookup(%{plan_id: id}, string_key) do
     Repo.one(
       from(p in Plan,
-        where: p.id == ^plan_id,
-        select: fragment("?->?", p.limits, ^key)
+        where: p.id == ^id,
+        select: fragment("?->?", p.limits, ^string_key)
       ),
       skip_tenant_check: true
     )
-    |> decode_json_value()
+    |> wrap_lookup()
   end
 
-  defp decode_json_value(value), do: value
+  defp wrap_lookup(nil), do: :miss
+  defp wrap_lookup(v), do: {:hit, v}
 
   # ── Tier & Status Queries ──────────────────────────────────────
 

--- a/lib/engram/billing/env_limits.ex
+++ b/lib/engram/billing/env_limits.ex
@@ -1,0 +1,21 @@
+defmodule Engram.Billing.EnvLimits do
+  @moduledoc """
+  Boot-time parser for `ENGRAM_<TIER>_<KEY>` env vars that override
+  per-tier plan limits. Raises with the env-var name on bad input so
+  operators get a fail-fast boot crash rather than silent fallback.
+  """
+
+  @spec parse!(String.t(), :integer | :boolean, String.t()) :: integer() | boolean()
+  def parse!(raw, :integer, env_name) do
+    case Integer.parse(raw) do
+      {n, ""} -> n
+      _ -> raise ArgumentError, "#{env_name}: cannot parse #{inspect(raw)} as integer"
+    end
+  end
+
+  def parse!("true", :boolean, _env_name), do: true
+  def parse!("false", :boolean, _env_name), do: false
+
+  def parse!(raw, :boolean, env_name),
+    do: raise("#{env_name}: cannot parse #{inspect(raw)} as boolean (expected 'true' or 'false')")
+end

--- a/lib/engram/billing/limit_keys.ex
+++ b/lib/engram/billing/limit_keys.ex
@@ -1,0 +1,85 @@
+defmodule Engram.Billing.LimitKeys do
+  @moduledoc """
+  Compile-time catalog of plan limit keys.
+
+  Single source of truth for the per-tier limit matrix. `nil` in
+  defaults means "unlimited" (no enforcement). Use:
+
+    LimitKeys.defined?(:notes_cap)            #=> true
+    LimitKeys.type(:notes_cap)                #=> :integer
+    LimitKeys.default_for(:notes_cap, :free)  #=> 10_000
+    LimitKeys.env_var_names()                 #=> 57 tuples (19 keys × 3 tiers)
+  """
+
+  @catalog %{
+    # Pricing v2 spec §9.2 — 17 keys
+    notes_cap: %{type: :integer, defaults: %{free: 10_000, starter: 50_000, pro: nil}},
+    vaults_cap: %{type: :integer, defaults: %{free: 1, starter: 5, pro: 15}},
+    attachment_bytes_cap: %{
+      type: :integer,
+      defaults: %{free: 1_073_741_824, starter: 3_221_225_472, pro: 16_106_127_360}
+    },
+    max_file_bytes: %{
+      type: :integer,
+      defaults: %{free: 10_485_760, starter: 209_715_200, pro: 524_288_000}
+    },
+    lifetime_embed_token_cap: %{
+      type: :integer,
+      defaults: %{free: 20_000_000, starter: nil, pro: nil}
+    },
+    concurrent_devices: %{type: :integer, defaults: %{free: 1, starter: nil, pro: nil}},
+    device_swap_cooldown_hours: %{type: :integer, defaults: %{free: 12, starter: 0, pro: 0}},
+    realtime_sync_enabled: %{
+      type: :boolean,
+      defaults: %{free: false, starter: true, pro: true}
+    },
+    ai_conversations_per_day: %{type: :integer, defaults: %{free: 5, starter: nil, pro: nil}},
+    ai_queries_per_conversation: %{
+      type: :integer,
+      defaults: %{free: 50, starter: nil, pro: nil}
+    },
+    ai_queries_per_day: %{type: :integer, defaults: %{free: nil, starter: 500, pro: 10_000}},
+    conversation_window_minutes: %{type: :integer, defaults: %{free: 30, starter: 30, pro: 30}},
+    reranker_enabled: %{type: :boolean, defaults: %{free: false, starter: false, pro: true}},
+    api_write_enabled: %{type: :boolean, defaults: %{free: false, starter: true, pro: true}},
+    api_rps_cap: %{type: :integer, defaults: %{free: 0, starter: 10, pro: 30}},
+    inactivity_warn_60_days: %{
+      type: :boolean,
+      defaults: %{free: true, starter: false, pro: false}
+    },
+    inactivity_delete_days: %{type: :integer, defaults: %{free: 90, starter: nil, pro: nil}},
+    # Legacy keys preserved for back-compat with existing call sites
+    cross_vault_search: %{type: :boolean, defaults: %{free: false, starter: false, pro: true}},
+    vault_scoped_keys: %{type: :boolean, defaults: %{free: false, starter: true, pro: true}}
+  }
+
+  @keys Map.keys(@catalog)
+  @tiers [:free, :starter, :pro]
+
+  @spec all() :: [atom()]
+  def all, do: @keys
+
+  @spec tiers() :: [atom()]
+  def tiers, do: @tiers
+
+  @spec defined?(any()) :: boolean()
+  def defined?(key) when is_atom(key), do: key in @keys
+  def defined?(_), do: false
+
+  @spec type(atom()) :: :integer | :boolean
+  def type(key) when key in @keys, do: @catalog |> Map.fetch!(key) |> Map.fetch!(:type)
+
+  @spec default_for(atom(), atom()) :: integer() | boolean() | nil
+  def default_for(key, tier) when key in @keys and tier in @tiers,
+    do: @catalog |> Map.fetch!(key) |> Map.fetch!(:defaults) |> Map.fetch!(tier)
+
+  @spec env_var_names() :: [{atom(), atom(), String.t()}]
+  def env_var_names do
+    for tier <- @tiers, key <- @keys do
+      env =
+        "ENGRAM_#{tier |> to_string() |> String.upcase()}_#{key |> to_string() |> String.upcase()}"
+
+      {tier, key, env}
+    end
+  end
+end

--- a/lib/engram/billing/limit_keys.ex
+++ b/lib/engram/billing/limit_keys.ex
@@ -56,10 +56,10 @@ defmodule Engram.Billing.LimitKeys do
   @keys Map.keys(@catalog)
   @tiers [:free, :starter, :pro]
 
-  @spec all() :: [atom()]
+  @spec all() :: [atom(), ...]
   def all, do: @keys
 
-  @spec tiers() :: [atom()]
+  @spec tiers() :: [:free | :starter | :pro, ...]
   def tiers, do: @tiers
 
   @spec defined?(any()) :: boolean()

--- a/lib/engram/billing/subscription.ex
+++ b/lib/engram/billing/subscription.ex
@@ -27,7 +27,7 @@ defmodule Engram.Billing.Subscription do
       :custom_data
     ])
     |> validate_required([:user_id, :paddle_customer_id, :tier, :status])
-    |> validate_inclusion(:tier, ~w(starter pro))
+    |> validate_inclusion(:tier, ~w(free starter pro))
     |> validate_inclusion(:status, ~w(trialing active past_due paused canceled))
     |> unique_constraint(:user_id)
     |> unique_constraint(:paddle_subscription_id)

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -46,7 +46,7 @@ defmodule Engram.Search do
     cross_vault = Keyword.get(opts, :cross_vault, false)
 
     if cross_vault do
-      case Engram.Billing.check_feature(user, "cross_vault_search") do
+      case Engram.Billing.check_feature(user, :cross_vault_search) do
         :ok -> do_search(user, nil, query, opts)
         {:error, _} = err -> err
       end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -27,7 +27,7 @@ defmodule Engram.Vaults do
       Repo.with_tenant(user.id, fn ->
         current_count = count_vaults(user.id)
 
-        case Billing.check_limit(user, "max_vaults", current_count) do
+        case Billing.check_limit(user, :vaults_cap, current_count) do
           {:error, :limit_reached} ->
             {:error, :vault_limit_reached}
 
@@ -81,7 +81,7 @@ defmodule Engram.Vaults do
             nil ->
               current_count = count_vaults(user.id)
 
-              case Billing.check_limit(user, "max_vaults", current_count) do
+              case Billing.check_limit(user, :vaults_cap, current_count) do
                 {:error, :limit_reached} ->
                   {:error, :vault_limit_reached}
 

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -34,7 +34,7 @@ defmodule EngramWeb.DeviceAuthController do
         do_authorize(conn, user_code, user, vault.id)
 
       {:error, :vault_limit_reached} ->
-        limit = Engram.Billing.effective_limit(user, "max_vaults")
+        limit = Engram.Billing.effective_limit(user, :vaults_cap)
         conn |> put_status(402) |> json(%{error: "vault_limit_reached", limit: limit})
 
       {:error, _changeset} ->

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -24,7 +24,7 @@ defmodule EngramWeb.VaultsController do
         |> json(%{vault: vault_json(vault, user)})
 
       {:error, :vault_limit_reached} ->
-        limit = Billing.effective_limit(user, "max_vaults")
+        limit = Billing.effective_limit(user, :vaults_cap)
 
         conn
         |> put_status(402)
@@ -122,7 +122,7 @@ defmodule EngramWeb.VaultsController do
           json(conn, vault_json(vault, user) |> Map.put(:status, "existing"))
 
         {:error, :vault_limit_reached} ->
-          limit = Billing.effective_limit(user, "max_vaults")
+          limit = Billing.effective_limit(user, :vaults_cap)
 
           conn
           |> put_status(402)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.151",
+      version: "0.5.152",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.147",
+      version: "0.5.148",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.148",
+      version: "0.5.151",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,26 +11,21 @@
 # and so on) as they will fail if something goes wrong.
 
 alias Engram.Repo
-alias Engram.Billing.Plan
+alias Engram.Billing.{LimitKeys, Plan}
 
-for {name, limits} <- [
-      {"free",
-       %{
-         "max_vaults" => 1,
-         "max_storage_bytes" => 104_857_600,
-         "cross_vault_search" => false,
-         "vault_scoped_keys" => false
-       }},
-      {"pro",
-       %{
-         "max_vaults" => -1,
-         "max_storage_bytes" => 1_073_741_824,
-         "cross_vault_search" => true,
-         "vault_scoped_keys" => true
-       }}
-    ] do
-  case Repo.get_by(Plan, name: name) do
-    nil -> Repo.insert!(%Plan{name: name, limits: limits})
-    existing -> Repo.update!(Plan.changeset(existing, %{limits: limits}))
-  end
+# Seed the three pricing tiers from LimitKeys catalog. Idempotent —
+# on_conflict replaces the limits JSONB so re-running ecto.setup drives
+# the matrix back to catalog defaults. To change a tier's limits in
+# production, edit LimitKeys + cut a release; deploy runs seeds.
+for tier <- LimitKeys.tiers() do
+  limits =
+    for key <- LimitKeys.all(), into: %{} do
+      {to_string(key), LimitKeys.default_for(key, tier)}
+    end
+
+  Repo.insert!(
+    %Plan{name: to_string(tier), limits: limits},
+    on_conflict: {:replace, [:limits, :updated_at]},
+    conflict_target: :name
+  )
 end

--- a/test/engram/billing/env_limits_test.exs
+++ b/test/engram/billing/env_limits_test.exs
@@ -1,0 +1,65 @@
+defmodule Engram.Billing.EnvLimitsTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Billing.EnvLimits
+
+  describe "parse!/3 — :integer" do
+    test "parses positive integer" do
+      assert EnvLimits.parse!("10000", :integer, "ENGRAM_FREE_NOTES_CAP") == 10_000
+    end
+
+    test "parses zero" do
+      assert EnvLimits.parse!("0", :integer, "ENGRAM_FREE_API_RPS_CAP") == 0
+    end
+
+    test "raises on non-numeric" do
+      assert_raise ArgumentError, fn ->
+        EnvLimits.parse!("not_a_number", :integer, "ENGRAM_FREE_NOTES_CAP")
+      end
+    end
+
+    test "raises on empty string" do
+      assert_raise ArgumentError, fn ->
+        EnvLimits.parse!("", :integer, "ENGRAM_FREE_NOTES_CAP")
+      end
+    end
+  end
+
+  describe "parse!/3 — :boolean" do
+    test "parses 'true'" do
+      assert EnvLimits.parse!("true", :boolean, "ENGRAM_FREE_RERANKER_ENABLED") == true
+    end
+
+    test "parses 'false'" do
+      assert EnvLimits.parse!("false", :boolean, "ENGRAM_FREE_RERANKER_ENABLED") == false
+    end
+
+    test "raises on 'yes' / '1' / other" do
+      assert_raise RuntimeError, fn ->
+        EnvLimits.parse!("1", :boolean, "ENGRAM_FREE_RERANKER_ENABLED")
+      end
+
+      assert_raise RuntimeError, fn ->
+        EnvLimits.parse!("yes", :boolean, "ENGRAM_FREE_RERANKER_ENABLED")
+      end
+    end
+  end
+
+  describe "parse!/3 — error messages include env name" do
+    test "integer error includes env name" do
+      try do
+        EnvLimits.parse!("oops", :integer, "ENGRAM_FREE_NOTES_CAP")
+      rescue
+        e -> assert Exception.message(e) =~ "ENGRAM_FREE_NOTES_CAP"
+      end
+    end
+
+    test "boolean error includes env name" do
+      try do
+        EnvLimits.parse!("oops", :boolean, "ENGRAM_FREE_RERANKER_ENABLED")
+      rescue
+        e -> assert Exception.message(e) =~ "ENGRAM_FREE_RERANKER_ENABLED"
+      end
+    end
+  end
+end

--- a/test/engram/billing/limit_keys_test.exs
+++ b/test/engram/billing/limit_keys_test.exs
@@ -1,0 +1,33 @@
+defmodule Engram.Billing.LimitKeysTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Billing.LimitKeys
+
+  describe "all/0" do
+    test "returns the 19 catalog keys" do
+      keys = LimitKeys.all()
+      assert length(keys) == 19
+      assert :notes_cap in keys
+      assert :vaults_cap in keys
+      assert :reranker_enabled in keys
+      assert :cross_vault_search in keys
+      assert :vault_scoped_keys in keys
+    end
+  end
+
+  describe "defined?/1" do
+    test "true for every catalog key" do
+      for key <- LimitKeys.all() do
+        assert LimitKeys.defined?(key), "expected #{inspect(key)} to be defined"
+      end
+    end
+
+    test "false for unknown atom" do
+      refute LimitKeys.defined?(:bogus)
+    end
+
+    test "false for non-atom (string)" do
+      refute LimitKeys.defined?("notes_cap")
+    end
+  end
+end

--- a/test/engram/billing/limit_keys_test.exs
+++ b/test/engram/billing/limit_keys_test.exs
@@ -30,4 +30,94 @@ defmodule Engram.Billing.LimitKeysTest do
       refute LimitKeys.defined?("notes_cap")
     end
   end
+
+  describe "type/1" do
+    test "returns :integer for numeric keys" do
+      assert LimitKeys.type(:notes_cap) == :integer
+      assert LimitKeys.type(:vaults_cap) == :integer
+      assert LimitKeys.type(:attachment_bytes_cap) == :integer
+    end
+
+    test "returns :boolean for feature flags" do
+      assert LimitKeys.type(:realtime_sync_enabled) == :boolean
+      assert LimitKeys.type(:reranker_enabled) == :boolean
+      assert LimitKeys.type(:api_write_enabled) == :boolean
+    end
+
+    test "raises FunctionClauseError on unknown key" do
+      assert_raise FunctionClauseError, fn -> LimitKeys.type(:bogus) end
+    end
+  end
+
+  describe "default_for/2 — full matrix pin" do
+    test "free tier matrix matches spec §9.2" do
+      assert LimitKeys.default_for(:notes_cap, :free) == 10_000
+      assert LimitKeys.default_for(:vaults_cap, :free) == 1
+      assert LimitKeys.default_for(:attachment_bytes_cap, :free) == 1_073_741_824
+      assert LimitKeys.default_for(:max_file_bytes, :free) == 10_485_760
+      assert LimitKeys.default_for(:lifetime_embed_token_cap, :free) == 20_000_000
+      assert LimitKeys.default_for(:concurrent_devices, :free) == 1
+      assert LimitKeys.default_for(:device_swap_cooldown_hours, :free) == 12
+      assert LimitKeys.default_for(:realtime_sync_enabled, :free) == false
+      assert LimitKeys.default_for(:ai_conversations_per_day, :free) == 5
+      assert LimitKeys.default_for(:ai_queries_per_conversation, :free) == 50
+      assert LimitKeys.default_for(:ai_queries_per_day, :free) == nil
+      assert LimitKeys.default_for(:conversation_window_minutes, :free) == 30
+      assert LimitKeys.default_for(:reranker_enabled, :free) == false
+      assert LimitKeys.default_for(:api_write_enabled, :free) == false
+      assert LimitKeys.default_for(:api_rps_cap, :free) == 0
+      assert LimitKeys.default_for(:inactivity_warn_60_days, :free) == true
+      assert LimitKeys.default_for(:inactivity_delete_days, :free) == 90
+    end
+
+    test "starter tier matrix matches spec §9.2" do
+      assert LimitKeys.default_for(:notes_cap, :starter) == 50_000
+      assert LimitKeys.default_for(:vaults_cap, :starter) == 5
+      assert LimitKeys.default_for(:attachment_bytes_cap, :starter) == 3_221_225_472
+      assert LimitKeys.default_for(:max_file_bytes, :starter) == 209_715_200
+      assert LimitKeys.default_for(:lifetime_embed_token_cap, :starter) == nil
+      assert LimitKeys.default_for(:realtime_sync_enabled, :starter) == true
+      assert LimitKeys.default_for(:ai_queries_per_day, :starter) == 500
+      assert LimitKeys.default_for(:api_rps_cap, :starter) == 10
+    end
+
+    test "pro tier matrix matches spec §9.2" do
+      assert LimitKeys.default_for(:notes_cap, :pro) == nil
+      assert LimitKeys.default_for(:vaults_cap, :pro) == 15
+      assert LimitKeys.default_for(:attachment_bytes_cap, :pro) == 16_106_127_360
+      assert LimitKeys.default_for(:max_file_bytes, :pro) == 524_288_000
+      assert LimitKeys.default_for(:reranker_enabled, :pro) == true
+      assert LimitKeys.default_for(:ai_queries_per_day, :pro) == 10_000
+      assert LimitKeys.default_for(:api_rps_cap, :pro) == 30
+    end
+
+    test "raises FunctionClauseError on unknown tier" do
+      assert_raise FunctionClauseError, fn -> LimitKeys.default_for(:notes_cap, :enterprise) end
+    end
+
+    test "raises FunctionClauseError on unknown key" do
+      assert_raise FunctionClauseError, fn -> LimitKeys.default_for(:bogus, :free) end
+    end
+  end
+
+  describe "env_var_names/0" do
+    test "emits 57 tuples (19 keys × 3 tiers)" do
+      tuples = LimitKeys.env_var_names()
+      assert length(tuples) == 57
+    end
+
+    test "includes ENGRAM_FREE_NOTES_CAP" do
+      assert {:free, :notes_cap, "ENGRAM_FREE_NOTES_CAP"} in LimitKeys.env_var_names()
+    end
+
+    test "includes ENGRAM_PRO_RERANKER_ENABLED" do
+      assert {:pro, :reranker_enabled, "ENGRAM_PRO_RERANKER_ENABLED"} in LimitKeys.env_var_names()
+    end
+  end
+
+  describe "tiers/0" do
+    test "returns the three tier atoms" do
+      assert LimitKeys.tiers() == [:free, :starter, :pro]
+    end
+  end
 end

--- a/test/engram/billing/limits_test.exs
+++ b/test/engram/billing/limits_test.exs
@@ -246,4 +246,40 @@ defmodule Engram.Billing.LimitsTest do
       assert Billing.effective_limit(user, :vaults_cap) == 5
     end
   end
+
+  describe "env-var override layer (layer 2)" do
+    setup do
+      original = Application.get_env(:engram, :plan_overrides)
+      on_exit(fn -> Application.put_env(:engram, :plan_overrides, original || %{}) end)
+      :ok
+    end
+
+    test "env override wins over plan default" do
+      plan = insert_plan(%{"vaults_cap" => 5})
+      user = user_with_plan(plan)
+
+      Application.put_env(:engram, :plan_overrides, %{{:free, :vaults_cap} => 99})
+
+      assert Billing.effective_limit(user, :vaults_cap) == 99
+    end
+
+    test "user override wins over env override" do
+      plan = insert_plan(%{"vaults_cap" => 5})
+      user = user_with_plan(plan)
+      insert_override(user.id, %{"vaults_cap" => 7})
+
+      Application.put_env(:engram, :plan_overrides, %{{:free, :vaults_cap} => 99})
+
+      assert Billing.effective_limit(user, :vaults_cap) == 7
+    end
+
+    test "env override falls through when key not set" do
+      plan = insert_plan(%{"vaults_cap" => 5})
+      user = user_with_plan(plan)
+
+      Application.put_env(:engram, :plan_overrides, %{{:free, :notes_cap} => 12_345})
+
+      assert Billing.effective_limit(user, :vaults_cap) == 5
+    end
+  end
 end

--- a/test/engram/billing/limits_test.exs
+++ b/test/engram/billing/limits_test.exs
@@ -29,55 +29,57 @@ defmodule Engram.Billing.LimitsTest do
 
   describe "effective_limit/2" do
     test "returns plan default when no override exists" do
-      plan = insert_plan(%{"max_vaults" => 3})
+      plan = insert_plan(%{"vaults_cap" => 3})
       user = user_with_plan(plan)
 
-      assert Billing.effective_limit(user, "max_vaults") == 3
+      assert Billing.effective_limit(user, :vaults_cap) == 3
     end
 
     test "returns user override when it exists" do
-      plan = insert_plan(%{"max_vaults" => 1})
+      plan = insert_plan(%{"vaults_cap" => 1})
       user = user_with_plan(plan)
-      insert_override(user.id, %{"max_vaults" => 10})
+      insert_override(user.id, %{"vaults_cap" => 10})
 
-      assert Billing.effective_limit(user, "max_vaults") == 10
+      assert Billing.effective_limit(user, :vaults_cap) == 10
     end
 
     test "falls through to plan when override key is missing" do
-      plan = insert_plan(%{"max_vaults" => 5})
+      plan = insert_plan(%{"vaults_cap" => 5})
       user = user_with_plan(plan)
       insert_override(user.id, %{"some_other_key" => 99})
 
-      assert Billing.effective_limit(user, "max_vaults") == 5
+      assert Billing.effective_limit(user, :vaults_cap) == 5
     end
 
     test "falls through to default when plan key is also missing" do
       plan = insert_plan(%{})
       user = user_with_plan(plan)
 
-      assert Billing.effective_limit(user, "max_vaults") == 1
+      assert Billing.effective_limit(user, :vaults_cap) == 1
     end
 
-    test "returns nil for unknown key not in defaults" do
+    test "raises UnknownLimitKey for unknown atom key" do
       user = user_without_plan()
 
-      assert Billing.effective_limit(user, "nonexistent_feature") == nil
+      assert_raise Engram.Billing.UnknownLimitKey, fn ->
+        Billing.effective_limit(user, :nonexistent_feature)
+      end
     end
 
     test "returns default limits when user has no plan (nil plan_id)" do
       user = user_without_plan()
 
-      assert Billing.effective_limit(user, "max_vaults") == 1
-      assert Billing.effective_limit(user, "max_storage_bytes") == 104_857_600
-      assert Billing.effective_limit(user, "cross_vault_search") == false
-      assert Billing.effective_limit(user, "vault_scoped_keys") == false
+      assert Billing.effective_limit(user, :vaults_cap) == 1
+      assert Billing.effective_limit(user, :attachment_bytes_cap) == 1_073_741_824
+      assert Billing.effective_limit(user, :cross_vault_search) == false
+      assert Billing.effective_limit(user, :vault_scoped_keys) == false
     end
 
     test "returns false (not nil) for boolean features disabled in plan" do
       plan = insert_plan(%{"cross_vault_search" => false})
       user = user_with_plan(plan)
 
-      result = Billing.effective_limit(user, "cross_vault_search")
+      result = Billing.effective_limit(user, :cross_vault_search)
       assert result == false
       refute is_nil(result)
     end
@@ -87,7 +89,7 @@ defmodule Engram.Billing.LimitsTest do
       user = user_with_plan(plan)
       insert_override(user.id, %{"cross_vault_search" => false})
 
-      assert Billing.effective_limit(user, "cross_vault_search") == false
+      assert Billing.effective_limit(user, :cross_vault_search) == false
     end
   end
 
@@ -95,40 +97,40 @@ defmodule Engram.Billing.LimitsTest do
 
   describe "check_limit/3" do
     test "returns :ok when current count is under the limit" do
-      plan = insert_plan(%{"max_vaults" => 3})
+      plan = insert_plan(%{"vaults_cap" => 3})
       user = user_with_plan(plan)
 
-      assert Billing.check_limit(user, "max_vaults", 2) == :ok
+      assert Billing.check_limit(user, :vaults_cap, 2) == :ok
     end
 
     test "returns :ok when limit is -1 (unlimited)" do
-      plan = insert_plan(%{"max_vaults" => -1})
+      plan = insert_plan(%{"vaults_cap" => -1})
       user = user_with_plan(plan)
 
-      assert Billing.check_limit(user, "max_vaults", 9999) == :ok
+      assert Billing.check_limit(user, :vaults_cap, 9999) == :ok
     end
 
     test "returns error when current count is at the limit" do
-      plan = insert_plan(%{"max_vaults" => 2})
+      plan = insert_plan(%{"vaults_cap" => 2})
       user = user_with_plan(plan)
 
-      assert Billing.check_limit(user, "max_vaults", 2) == {:error, :limit_reached}
+      assert Billing.check_limit(user, :vaults_cap, 2) == {:error, :limit_reached}
     end
 
     test "returns error when current count is over the limit" do
-      plan = insert_plan(%{"max_vaults" => 1})
+      plan = insert_plan(%{"vaults_cap" => 1})
       user = user_with_plan(plan)
 
-      assert Billing.check_limit(user, "max_vaults", 5) == {:error, :limit_reached}
+      assert Billing.check_limit(user, :vaults_cap, 5) == {:error, :limit_reached}
     end
 
     test "uses default limit when user has no plan" do
       user = user_without_plan()
 
-      # default max_vaults is 1, so count 0 is ok
-      assert Billing.check_limit(user, "max_vaults", 0) == :ok
+      # default vaults_cap is 1, so count 0 is ok
+      assert Billing.check_limit(user, :vaults_cap, 0) == :ok
       # count 1 is at limit
-      assert Billing.check_limit(user, "max_vaults", 1) == {:error, :limit_reached}
+      assert Billing.check_limit(user, :vaults_cap, 1) == {:error, :limit_reached}
     end
   end
 
@@ -139,21 +141,21 @@ defmodule Engram.Billing.LimitsTest do
       plan = insert_plan(%{"cross_vault_search" => true})
       user = user_with_plan(plan)
 
-      assert Billing.check_feature(user, "cross_vault_search") == :ok
+      assert Billing.check_feature(user, :cross_vault_search) == :ok
     end
 
     test "returns error when feature is disabled (false)" do
       plan = insert_plan(%{"cross_vault_search" => false})
       user = user_with_plan(plan)
 
-      assert Billing.check_feature(user, "cross_vault_search") == {:error, :feature_not_available}
+      assert Billing.check_feature(user, :cross_vault_search) == {:error, :feature_not_available}
     end
 
     test "returns error when feature defaults to false (no plan)" do
       user = user_without_plan()
 
-      assert Billing.check_feature(user, "cross_vault_search") == {:error, :feature_not_available}
-      assert Billing.check_feature(user, "vault_scoped_keys") == {:error, :feature_not_available}
+      assert Billing.check_feature(user, :cross_vault_search) == {:error, :feature_not_available}
+      assert Billing.check_feature(user, :vault_scoped_keys) == {:error, :feature_not_available}
     end
 
     test "returns :ok when override enables a feature the plan disables" do
@@ -161,7 +163,32 @@ defmodule Engram.Billing.LimitsTest do
       user = user_with_plan(plan)
       insert_override(user.id, %{"cross_vault_search" => true})
 
-      assert Billing.check_feature(user, "cross_vault_search") == :ok
+      assert Billing.check_feature(user, :cross_vault_search) == :ok
+    end
+  end
+
+  describe "atom-only API (Phase A)" do
+    test "raises UnknownLimitKey on string key" do
+      user = user_without_plan()
+
+      assert_raise Engram.Billing.UnknownLimitKey, fn ->
+        Billing.effective_limit(user, "notes_cap")
+      end
+    end
+
+    test "raises UnknownLimitKey on unknown atom" do
+      user = user_without_plan()
+
+      assert_raise Engram.Billing.UnknownLimitKey, fn ->
+        Billing.effective_limit(user, :bogus_key)
+      end
+    end
+
+    test "accepts atom from LimitKeys catalog" do
+      plan = insert_plan(%{"vaults_cap" => 7})
+      user = user_with_plan(plan)
+
+      assert Billing.effective_limit(user, :vaults_cap) == 7
     end
   end
 end

--- a/test/engram/billing/limits_test.exs
+++ b/test/engram/billing/limits_test.exs
@@ -282,4 +282,44 @@ defmodule Engram.Billing.LimitsTest do
       assert Billing.effective_limit(user, :vaults_cap) == 5
     end
   end
+
+  describe "boolean false honored at every layer" do
+    setup do
+      original = Application.get_env(:engram, :plan_overrides)
+      on_exit(fn -> Application.put_env(:engram, :plan_overrides, original || %{}) end)
+      :ok
+    end
+
+    test "false from user override wins (not treated as missing)" do
+      plan = insert_plan(%{"reranker_enabled" => true})
+      user = user_with_plan(plan)
+      insert_override(user.id, %{"reranker_enabled" => false})
+
+      assert Billing.effective_limit(user, :reranker_enabled) == false
+    end
+
+    test "false from env override wins (not treated as missing)" do
+      plan = insert_plan(%{"reranker_enabled" => true})
+      user = user_with_plan(plan)
+
+      Application.put_env(:engram, :plan_overrides, %{{:free, :reranker_enabled} => false})
+
+      assert Billing.effective_limit(user, :reranker_enabled) == false
+    end
+
+    test "false from plan wins (not treated as missing)" do
+      plan = insert_plan(%{"reranker_enabled" => false})
+      user = user_with_plan(plan)
+
+      assert Billing.effective_limit(user, :reranker_enabled) == false
+    end
+
+    test "false from catalog default wins" do
+      # Empty plan + free tier → catalog default = false for :reranker_enabled
+      plan = insert_plan(%{})
+      user = user_with_plan(plan)
+
+      assert Billing.effective_limit(user, :reranker_enabled) == false
+    end
+  end
 end

--- a/test/engram/billing/limits_test.exs
+++ b/test/engram/billing/limits_test.exs
@@ -191,4 +191,59 @@ defmodule Engram.Billing.LimitsTest do
       assert Billing.effective_limit(user, :vaults_cap) == 7
     end
   end
+
+  describe "bypass (self-host) — :limits_enforced=false" do
+    setup do
+      original = Application.get_env(:engram, :limits_enforced)
+      Application.put_env(:engram, :limits_enforced, false)
+      on_exit(fn -> Application.put_env(:engram, :limits_enforced, original) end)
+      :ok
+    end
+
+    test "effective_limit returns :unlimited regardless of plan or override" do
+      plan = insert_plan(%{"vaults_cap" => 1})
+      user = user_with_plan(plan)
+      insert_override(user.id, %{"vaults_cap" => 2})
+
+      assert Billing.effective_limit(user, :vaults_cap) == :unlimited
+    end
+
+    test "check_limit returns :ok for any count" do
+      plan = insert_plan(%{"vaults_cap" => 1})
+      user = user_with_plan(plan)
+
+      assert Billing.check_limit(user, :vaults_cap, 99_999) == :ok
+    end
+
+    test "check_feature returns :ok even when plan disables it" do
+      plan = insert_plan(%{"reranker_enabled" => false})
+      user = user_with_plan(plan)
+
+      assert Billing.check_feature(user, :reranker_enabled) == :ok
+    end
+
+    test "still raises UnknownLimitKey on bad atom (catalog guard fires before bypass)" do
+      user = user_without_plan()
+
+      assert_raise Engram.Billing.UnknownLimitKey, fn ->
+        Billing.effective_limit(user, :bogus_key)
+      end
+    end
+  end
+
+  describe "default (SaaS) — :limits_enforced=true" do
+    setup do
+      original = Application.get_env(:engram, :limits_enforced)
+      Application.put_env(:engram, :limits_enforced, true)
+      on_exit(fn -> Application.put_env(:engram, :limits_enforced, original) end)
+      :ok
+    end
+
+    test "effective_limit runs normal 4-layer resolution" do
+      plan = insert_plan(%{"vaults_cap" => 5})
+      user = user_with_plan(plan)
+
+      assert Billing.effective_limit(user, :vaults_cap) == 5
+    end
+  end
 end

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -9,9 +9,9 @@ defmodule Engram.BillingTest do
   setup :verify_on_exit!
 
   describe "tier/1" do
-    test "returns :none for user with no subscription" do
+    test "returns :free for user with no subscription" do
       user = insert(:user)
-      assert Billing.tier(user) == :none
+      assert Billing.tier(user) == :free
     end
 
     test "returns tier atom for user with active subscription" do
@@ -26,10 +26,10 @@ defmodule Engram.BillingTest do
       assert Billing.tier(user) == :starter
     end
 
-    test "returns :none for user with canceled subscription" do
+    test "returns :free for user with canceled subscription" do
       user = insert(:user)
       insert(:subscription, user: user, tier: "starter", status: "canceled")
-      assert Billing.tier(user) == :none
+      assert Billing.tier(user) == :free
     end
   end
 

--- a/test/engram/crypto/user_dek_rotation_test.exs
+++ b/test/engram/crypto/user_dek_rotation_test.exs
@@ -371,7 +371,7 @@ defmodule Engram.Crypto.UserDekRotationTest do
   describe "rotate_user/1 — production-path bug regression" do
     setup %{user: user} do
       # Grant unlimited vaults so create_vault doesn't hit the billing limit.
-      insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => -1})
       {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "ProdVault"})
       {:ok, user: user, vault: vault}
     end

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -8,8 +8,8 @@ defmodule Engram.NotesTest do
     other_user = insert(:user)
 
     # Allow unlimited vaults so create_vault doesn't hit the billing limit
-    insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
-    insert(:user_override, user: other_user, overrides: %{"max_vaults" => -1})
+    insert(:user_override, user: user, overrides: %{"vaults_cap" => -1})
+    insert(:user_override, user: other_user, overrides: %{"vaults_cap" => -1})
 
     # Phase B reads derive a filter key from the user's DEK. Provision DEK
     # upfront so test users carry encrypted_dek in-struct without a reload.
@@ -186,7 +186,7 @@ defmodule Engram.NotesTest do
 
     test "returns error for missing path", %{vault: vault} do
       user = insert(:user)
-      insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => -1})
 
       assert {:error, changeset} =
                Notes.upsert_note(user, vault, %{"content" => "# Hello", "mtime" => 1_000.0})

--- a/test/engram/search_integration_test.exs
+++ b/test/engram/search_integration_test.exs
@@ -9,7 +9,7 @@ defmodule Engram.SearchIntegrationTest do
     Engram.Crypto.DekCache.invalidate_all()
     user = insert(:user)
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
-    insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
+    insert(:user_override, user: user, overrides: %{"vaults_cap" => -1})
     {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "SearchIntegration"})
 
     # Use a test-isolated Qdrant collection so we can drop it after.

--- a/test/engram/seeds_test.exs
+++ b/test/engram/seeds_test.exs
@@ -1,0 +1,64 @@
+defmodule Engram.SeedsTest do
+  use Engram.DataCase, async: false
+
+  alias Engram.Billing.{LimitKeys, Plan}
+  alias Engram.Repo
+
+  @seeds_path "priv/repo/seeds.exs"
+
+  setup do
+    Repo.delete_all(Plan)
+    :ok
+  end
+
+  defp run_seeds, do: Code.eval_file(@seeds_path)
+
+  describe "seeds.exs" do
+    test "creates exactly three plans named free / starter / pro" do
+      run_seeds()
+
+      names = Plan |> Repo.all() |> Enum.map(& &1.name) |> Enum.sort()
+      assert names == ~w(free pro starter)
+    end
+
+    test "every plan has all 19 catalog keys with catalog defaults" do
+      run_seeds()
+
+      for tier <- LimitKeys.tiers() do
+        plan = Repo.get_by!(Plan, name: to_string(tier))
+
+        for key <- LimitKeys.all() do
+          assert Map.has_key?(plan.limits, to_string(key)),
+                 "plan #{tier} missing key #{key}"
+
+          assert plan.limits[to_string(key)] == LimitKeys.default_for(key, tier),
+                 "plan #{tier} key #{key} drifted from catalog default"
+        end
+      end
+    end
+
+    test "re-running seeds is idempotent — no duplicate rows, count stays at 3" do
+      run_seeds()
+      assert Repo.aggregate(Plan, :count) == 3
+
+      run_seeds()
+      assert Repo.aggregate(Plan, :count) == 3
+    end
+
+    test "re-running seeds restores limits when a plan's matrix is mutated" do
+      run_seeds()
+      free = Repo.get_by!(Plan, name: "free")
+
+      free
+      |> Ecto.Changeset.change(limits: Map.put(free.limits, "notes_cap", 99_999))
+      |> Repo.update!()
+
+      assert Repo.get_by!(Plan, name: "free").limits["notes_cap"] == 99_999
+
+      run_seeds()
+
+      restored = Repo.get_by!(Plan, name: "free").limits["notes_cap"]
+      assert restored == LimitKeys.default_for(:notes_cap, :free)
+    end
+  end
+end

--- a/test/engram/vault_isolation_test.exs
+++ b/test/engram/vault_isolation_test.exs
@@ -9,7 +9,7 @@ defmodule Engram.VaultIsolationTest do
 
   setup do
     user = insert(:user)
-    insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
+    insert(:user_override, user: user, overrides: %{"vaults_cap" => -1})
 
     # Phase B reads derive a filter key from the user's DEK — provision upfront.
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -35,7 +35,7 @@ defmodule Engram.VaultsTest do
 
       # Give the second user unlimited vaults via user_overrides or just test default (1) blocks
       # Override the limit so we can insert a second vault
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 5})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 5})
 
       assert {:ok, vault2} = Vaults.create_vault(user, %{name: "Second"})
       assert vault2.is_default == false
@@ -48,7 +48,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "unlimited override (-1) allows any number of vaults", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => -1})
 
       {:ok, _} = Vaults.create_vault(user, %{name: "First"})
       {:ok, _} = Vaults.create_vault(user, %{name: "Second"})
@@ -56,7 +56,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "specific override enforces that exact limit", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 2})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 2})
 
       {:ok, _} = Vaults.create_vault(user, %{name: "First"})
       {:ok, _} = Vaults.create_vault(user, %{name: "Second"})
@@ -68,14 +68,14 @@ defmodule Engram.VaultsTest do
       assert {:error, :vault_limit_reached} = Vaults.create_vault(user, %{name: "Second"})
 
       # Lift the limit via per-user override
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 5})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 5})
 
       {:ok, _} = Vaults.create_vault(user, %{name: "Second"})
       {:ok, _} = Vaults.create_vault(user, %{name: "Third"})
     end
 
     test "deduplicates slug collision with numeric suffix", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "Notes"})
       {:ok, v2} = Vaults.create_vault(user, %{name: "Notes"})
@@ -85,7 +85,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "slug with triple collision gets -3 suffix", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, _} = Vaults.create_vault(user, %{name: "Notes"})
       {:ok, _} = Vaults.create_vault(user, %{name: "Notes"})
@@ -144,7 +144,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "existing check ignores deleted vaults", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, vault, :created} = Vaults.register_vault(user, "My Vault", "client-1")
       Vaults.delete_vault(user, vault.id)
@@ -177,7 +177,7 @@ defmodule Engram.VaultsTest do
 
   describe "list_vaults/1" do
     test "returns all non-deleted vaults for user", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "A"})
       {:ok, v2} = Vaults.create_vault(user, %{name: "B"})
@@ -189,7 +189,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "excludes soft-deleted vaults", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "Keep"})
       {:ok, v2} = Vaults.create_vault(user, %{name: "Delete"})
@@ -215,7 +215,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "returns vaults ordered by inserted_at ascending", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "Alpha"})
       {:ok, v2} = Vaults.create_vault(user, %{name: "Beta"})
@@ -250,7 +250,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "returns {:error, :not_found} for soft-deleted vault", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, vault} = Vaults.create_vault(user, %{name: "Gone"})
       Vaults.delete_vault(user, vault.id)
@@ -298,7 +298,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "setting is_default clears other defaults", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "First"})
       {:ok, v2} = Vaults.create_vault(user, %{name: "Second"})
@@ -331,7 +331,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "promotes next vault to default when default is deleted", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "First"})
       {:ok, v2} = Vaults.create_vault(user, %{name: "Second"})
@@ -344,7 +344,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "does not promote when non-default vault is deleted", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "First"})
       {:ok, v2} = Vaults.create_vault(user, %{name: "Second"})
@@ -514,7 +514,7 @@ defmodule Engram.VaultsTest do
     # tests flaked. These tests pin that the id tiebreaker is always respected.
 
     test "orders deterministically when created_at ties", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
       same_time = DateTime.utc_now(:second)
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "vault-order-a"})
@@ -535,7 +535,7 @@ defmodule Engram.VaultsTest do
     end
 
     test "id tiebreaker holds for three vaults at the same timestamp", %{user: user} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
       same_time = DateTime.utc_now(:second)
 
       {:ok, v1} = Vaults.create_vault(user, %{name: "alpha"})

--- a/test/engram/workers/backfill_content_hash_hmac_test.exs
+++ b/test/engram/workers/backfill_content_hash_hmac_test.exs
@@ -14,7 +14,7 @@ defmodule Engram.Workers.BackfillContentHashHmacTest do
   setup do
     user = insert(:user)
     {:ok, user} = Crypto.ensure_user_dek(user)
-    insert(:user_override, user: user, overrides: %{"max_vaults" => -1})
+    insert(:user_override, user: user, overrides: %{"vaults_cap" => -1})
     {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "BackfillTest"})
 
     %{user: user, vault: vault}

--- a/test/engram_web/channels/sync_channel_test.exs
+++ b/test/engram_web/channels/sync_channel_test.exs
@@ -107,7 +107,7 @@ defmodule EngramWeb.SyncChannelTest do
     end
 
     test "restricted key cannot join unauthorized vault", %{user: user, vault: vault} do
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
       {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Vault B"})
       {:ok, _raw, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-chan2")
 

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -14,7 +14,7 @@ defmodule EngramWeb.BillingControllerTest do
     test "returns inactive status for new user with no subscription", %{conn: conn} do
       conn = get(conn, "/api/billing/status")
       body = json_response(conn, 200)
-      assert body["tier"] == "none"
+      assert body["tier"] == "free"
       assert body["active"] == false
       assert body["trial_days_remaining"] == 0
       assert body["subscription"] == nil

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -544,7 +544,7 @@ defmodule EngramWeb.McpControllerTest do
       vault_a = insert(:vault, user: user, is_default: true, name: "Vault A")
 
       # Override limit so user can have 2 vaults
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
       {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Vault B"})
 
       {:ok, api_key, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-key")

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -9,7 +9,7 @@ defmodule EngramWeb.VaultsControllerTest do
   setup %{conn: conn} do
     user = insert(:user)
     # Give the user unlimited vaults for most tests
-    insert(:user_override, user: user, overrides: %{"max_vaults" => 10})
+    insert(:user_override, user: user, overrides: %{"vaults_cap" => 10})
     {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
     conn = put_req_header(conn, "authorization", "Bearer #{raw_key}")
     {:ok, conn: conn, user: user}
@@ -32,7 +32,7 @@ defmodule EngramWeb.VaultsControllerTest do
 
     test "does not include vaults of other users", %{conn: conn, user: user} do
       other_user = insert(:user)
-      insert(:user_override, user: other_user, overrides: %{"max_vaults" => 5})
+      insert(:user_override, user: other_user, overrides: %{"vaults_cap" => 5})
       {:ok, other_vault} = Vaults.create_vault(other_user, %{name: "Other Vault"})
       {:ok, _my_vault} = Vaults.create_vault(user, %{name: "My Vault"})
 
@@ -64,7 +64,7 @@ defmodule EngramWeb.VaultsControllerTest do
     test "returns 402 when vault limit reached", %{conn: conn, user: user} do
       # Override to limit of 1
       Engram.Repo.delete_all(from o in Engram.Billing.UserOverride, where: o.user_id == ^user.id)
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 1})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 1})
 
       {:ok, _} = Vaults.create_vault(user, %{name: "First"})
 
@@ -96,7 +96,7 @@ defmodule EngramWeb.VaultsControllerTest do
 
     test "returns 404 for another user's vault", %{conn: conn} do
       other_user = insert(:user)
-      insert(:user_override, user: other_user, overrides: %{"max_vaults" => 5})
+      insert(:user_override, user: other_user, overrides: %{"vaults_cap" => 5})
       {:ok, other_vault} = Vaults.create_vault(other_user, %{name: "Other"})
 
       conn = get(conn, "/api/vaults/#{other_vault.id}")
@@ -155,7 +155,7 @@ defmodule EngramWeb.VaultsControllerTest do
 
     test "returns 402 when vault limit reached", %{conn: conn, user: user} do
       Engram.Repo.delete_all(from o in Engram.Billing.UserOverride, where: o.user_id == ^user.id)
-      insert(:user_override, user: user, overrides: %{"max_vaults" => 1})
+      insert(:user_override, user: user, overrides: %{"vaults_cap" => 1})
 
       {:ok, _} = Vaults.create_vault(user, %{name: "First"})
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -109,7 +109,7 @@ defmodule Engram.Factory do
     %Engram.Billing.Plan{
       name: sequence(:plan_name, &"plan_#{&1}"),
       limits: %{
-        "max_vaults" => 1,
+        "vaults_cap" => 1,
         "cross_vault_search" => false,
         "vault_scoped_keys" => false
       }


### PR DESCRIPTION
## Summary

PR 1 of 3 in the plans-resolver implementation. Closes spec §0.1, §4.1, §4.3, §6, §7, §10 from `docs/superpowers/specs/2026-05-20-plans-resolver-design.md`. Lands the `LimitKeys` catalog, atom-only resolver API, 4-layer resolution, env-var override layer, self-host bypass, and free/starter/pro plan seeds.

PR 2 ships the `user_limit_overrides` migration. PR 3 ships the expiry sweep + lint + CI.

## What's in this PR

- **`Engram.Billing.LimitKeys`** — compile-time catalog of 19 keys (17 spec §9.2 + 2 legacy back-compat: `cross_vault_search`, `vault_scoped_keys`). Per-tier defaults pinned in code.
- **Atom-only `Engram.Billing` API** — `effective_limit/2`, `check_limit/3`, `check_feature/2` reject strings, raise `UnknownLimitKey` on unknown atoms.
- **4-layer resolver** — user override → env override → plan default → catalog default. `{:hit, v} | :miss` sentinel preserves boolean `false` at every layer.
- **Self-host bypass** — `:limits_enforced=false` returns `:unlimited` sentinel for every key. `config/runtime.exs` derives the flag from `ENGRAM_LIMITS_ENFORCED` env override or `PADDLE_API_KEY` presence; gated to non-test env.
- **`Engram.Billing.EnvLimits.parse!`** — fail-fast type parser for `ENGRAM_<TIER>_<KEY>` boot-time overrides.
- **`Subscription` validator** allows `free` tier.
- **`tier/1` returns `:free`** (was `:none`) for users without subscription.
- **`priv/repo/seeds.exs`** seeds idempotent free/starter/pro plan rows from `LimitKeys`.

## Scope notes for reviewers

Plan tasks 12-15 (call-site renames in `lib/engram/search.ex`, `lib/engram/vaults.ex`, controllers, factory) were absorbed into task 3's scope expansion. The atom-only API breaks 193 tests if call sites stay on strings, so the renames had to ship together. No follow-up rename PR needed.

`config/runtime.exs` got two corrective fixes mid-PR: Elixir 1.19 parser refinement (3887488) and a test-env config gate (143f89f) — both worth a quick eyeball.

## Test plan

- [x] `mix test` — 1262 tests, 0 failures, 7 skipped
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — no issues
- [x] `mix compile --warnings-as-errors` — clean
- [x] `sobelow` — clean
- [ ] Smoke seeds against a fresh DB: `mix ecto.reset && mix run -e 'IO.inspect(Engram.Repo.all(Engram.Billing.Plan, ...))'`
- [ ] Smoke env override in dev: `ENGRAM_FREE_NOTES_CAP=42 iex -S mix` → `Engram.Billing.effective_limit(user, :notes_cap)` returns `42`

## Follow-up PRs

- **PR 2** (tasks 17-22): `user_limit_overrides` per-(user, key) migration + schema swap (irreversible drop of `user_overrides`)
- **PR 3** (tasks 23-28): `OverrideExpirySweep` Oban cron + `mix engram.lint.limit_keys` AST scan + CI workflow wire-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)