### PR TITLE
feat(billing): expiry sweep + limit-keys lint + CI (PR 3 of 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1031,6 +1031,9 @@ jobs:
       - name: Credo (strict)
         run: mix credo --strict
 
+      - name: Limit-keys lint
+        run: mix engram.lint.limit_keys
+
       - name: Sobelow
         run: mix sobelow --exit low
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,8 @@ config :engram, Oban,
     {Oban.Plugins.Cron,
      crontab: [
        {"*/15 * * * *", Engram.Workers.ReconcileEmbeddings},
-       {"0 * * * *", Engram.Workers.CleanupDeviceAuthWorker}
+       {"0 * * * *", Engram.Workers.CleanupDeviceAuthWorker},
+       {"0 3 * * *", Engram.Billing.Workers.OverrideExpirySweep}
      ]}
   ]
 

--- a/lib/engram/billing/workers/override_expiry_sweep.ex
+++ b/lib/engram/billing/workers/override_expiry_sweep.ex
@@ -1,0 +1,35 @@
+defmodule Engram.Billing.Workers.OverrideExpirySweep do
+  @moduledoc """
+  Daily Oban cron worker that deletes expired `user_limit_overrides` rows.
+  Emits `[:engram, :billing, :overrides, :expired]` telemetry with the
+  number of rows deleted.
+  """
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 3,
+    unique: [period: 60, fields: [:worker]]
+
+  import Ecto.Query
+
+  alias Engram.Billing.UserLimitOverride
+  alias Engram.Repo
+
+  @impl Oban.Worker
+  def perform(_job) do
+    now = DateTime.utc_now()
+
+    {count, _} =
+      Repo.delete_all(
+        from(o in UserLimitOverride, where: o.expires_at <= ^now),
+        skip_tenant_check: true
+      )
+
+    :telemetry.execute(
+      [:engram, :billing, :overrides, :expired],
+      %{count: count},
+      %{}
+    )
+
+    :ok
+  end
+end

--- a/lib/mix/tasks/engram.lint.limit_keys.ex
+++ b/lib/mix/tasks/engram.lint.limit_keys.ex
@@ -1,0 +1,111 @@
+defmodule Mix.Tasks.Engram.Lint.LimitKeys do
+  @shortdoc "Lints Billing.effective_limit/check_limit/check_feature key args"
+
+  @moduledoc """
+  Lints `Engram.Billing.{effective_limit, check_limit, check_feature}` call sites:
+  the key arg must be an atom literal from `Engram.Billing.LimitKeys.all/0`.
+
+  Fails the build on:
+  - unknown atom (typo against catalog)
+  - string literal (legacy form)
+  - dynamic key (variable or function-call result) — unless preceded by
+    `# lint:limit_keys allow_dynamic`
+
+  Any violation can also be suppressed with `# lint:limit_keys ignore` on the
+  preceding line — useful for negative-path tests that deliberately pass a bad
+  key to assert the catalog guard fires.
+
+  Usage: `mix engram.lint.limit_keys`
+  """
+
+  use Mix.Task
+
+  alias Engram.Billing.LimitKeys
+
+  @target_funs ~w(effective_limit check_limit check_feature)a
+
+  @impl Mix.Task
+  def run(_argv) do
+    Mix.Task.run("compile")
+
+    files = Path.wildcard("lib/**/*.ex") ++ Path.wildcard("test/**/*.exs")
+
+    violations =
+      files
+      |> Enum.flat_map(fn file -> scan_source!(File.read!(file), file) end)
+
+    if violations == [] do
+      Mix.shell().info("limit_keys lint: 0 violations across #{length(files)} files")
+    else
+      Enum.each(violations, fn v -> Mix.shell().error(format(v)) end)
+      Mix.raise("limit_keys lint: #{length(violations)} violation(s)")
+    end
+  end
+
+  @doc """
+  Scans a single source string and returns a list of violation tuples.
+
+  Each tuple: `{file, line, function_atom, kind, value}` where kind is one of
+  `:unknown_atom`, `:string_key`, `:dynamic_key`.
+  """
+  def scan_source!(src, file) do
+    tree = Code.string_to_quoted!(src, columns: true, file: file)
+    lines = String.split(src, "\n")
+
+    {_, acc} =
+      Macro.prewalk(tree, [], fn
+        # Engram.Billing.<fun>(_, key, ...)
+        {{:., _, [{:__aliases__, _, [:Engram, :Billing]}, fun]}, meta, args} = node, acc
+        when fun in @target_funs ->
+          {node, check_args(file, meta, fun, args, lines) ++ acc}
+
+        # Billing.<fun>(_, key, ...)
+        {{:., _, [{:__aliases__, _, [:Billing]}, fun]}, meta, args} = node, acc
+        when fun in @target_funs ->
+          {node, check_args(file, meta, fun, args, lines) ++ acc}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    acc
+  end
+
+  defp check_args(file, meta, fun, [_user, key | _rest], lines) do
+    line = meta[:line]
+
+    cond do
+      ignore?(lines, line) -> []
+      is_atom(key) and LimitKeys.defined?(key) -> []
+      is_atom(key) -> [{file, line, fun, :unknown_atom, key}]
+      is_binary(key) -> [{file, line, fun, :string_key, key}]
+      allow_dynamic?(lines, line) -> []
+      true -> [{file, line, fun, :dynamic_key, Macro.to_string(key)}]
+    end
+  end
+
+  # Arity mismatch (e.g. a Billing.* call with only one arg) — ignore.
+  defp check_args(_file, _meta, _fun, _args, _lines), do: []
+
+  defp allow_dynamic?(lines, line),
+    do: prev_line_matches?(lines, line, ~r/#\s*lint:limit_keys\s+allow_dynamic/)
+
+  defp ignore?(lines, line), do: prev_line_matches?(lines, line, ~r/#\s*lint:limit_keys\s+ignore/)
+
+  defp prev_line_matches?(lines, line, regex) do
+    case Enum.at(lines, line - 2) do
+      nil -> false
+      prev -> prev =~ regex
+    end
+  end
+
+  defp format({file, line, fun, kind, value}) do
+    "#{file}:#{line}: Billing.#{fun}/_ — #{kind_msg(kind, value)}"
+  end
+
+  defp kind_msg(:unknown_atom, key), do: "key #{inspect(key)} not in LimitKeys catalog"
+  defp kind_msg(:string_key, key), do: "string key #{inspect(key)} — use atom :#{key}"
+
+  defp kind_msg(:dynamic_key, _),
+    do: "dynamic key not allowed (add `# lint:limit_keys allow_dynamic` on preceding line)"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.154",
+      version: "0.5.155",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/billing/limits_test.exs
+++ b/test/engram/billing/limits_test.exs
@@ -69,6 +69,7 @@ defmodule Engram.Billing.LimitsTest do
       user = user_without_plan()
 
       assert_raise Engram.Billing.UnknownLimitKey, fn ->
+        # lint:limit_keys ignore
         Billing.effective_limit(user, :nonexistent_feature)
       end
     end
@@ -179,6 +180,7 @@ defmodule Engram.Billing.LimitsTest do
       user = user_without_plan()
 
       assert_raise Engram.Billing.UnknownLimitKey, fn ->
+        # lint:limit_keys ignore
         Billing.effective_limit(user, "notes_cap")
       end
     end
@@ -187,6 +189,7 @@ defmodule Engram.Billing.LimitsTest do
       user = user_without_plan()
 
       assert_raise Engram.Billing.UnknownLimitKey, fn ->
+        # lint:limit_keys ignore
         Billing.effective_limit(user, :bogus_key)
       end
     end
@@ -233,6 +236,7 @@ defmodule Engram.Billing.LimitsTest do
       user = user_without_plan()
 
       assert_raise Engram.Billing.UnknownLimitKey, fn ->
+        # lint:limit_keys ignore
         Billing.effective_limit(user, :bogus_key)
       end
     end

--- a/test/engram/billing/workers/override_expiry_sweep_test.exs
+++ b/test/engram/billing/workers/override_expiry_sweep_test.exs
@@ -64,5 +64,65 @@ defmodule Engram.Billing.Workers.OverrideExpirySweepTest do
 
       assert_received {[:engram, :billing, :overrides, :expired], _ref, %{count: 1}, %{}}
     end
+
+    test "emits count=0 telemetry on empty table" do
+      :telemetry_test.attach_event_handlers(self(), [
+        [:engram, :billing, :overrides, :expired]
+      ])
+
+      assert :ok = perform_job(OverrideExpirySweep, %{})
+
+      assert_received {[:engram, :billing, :overrides, :expired], _ref, %{count: 0}, %{}}
+    end
+
+    test "is idempotent — second run with no new expired rows deletes 0" do
+      user = insert(:user)
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+      future = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+
+      insert_override(user, past)
+      survivor = insert_override(insert(:user), future)
+
+      :telemetry_test.attach_event_handlers(self(), [
+        [:engram, :billing, :overrides, :expired]
+      ])
+
+      assert :ok = perform_job(OverrideExpirySweep, %{})
+      assert_received {[:engram, :billing, :overrides, :expired], _ref, %{count: 1}, %{}}
+
+      assert :ok = perform_job(OverrideExpirySweep, %{})
+      assert_received {[:engram, :billing, :overrides, :expired], _ref, %{count: 0}, %{}}
+
+      assert Repo.get(UserLimitOverride, survivor.id)
+    end
+
+    test "handles mixed past + future + NULL in a single sweep" do
+      now = DateTime.utc_now(:second)
+      past = DateTime.add(now, -3600, :second)
+      future = DateTime.add(now, 3600, :second)
+
+      expired = insert_override(insert(:user), past)
+      future_row = insert_override(insert(:user), future)
+
+      permanent =
+        Repo.insert!(%UserLimitOverride{
+          user_id: insert(:user).id,
+          key: "notes_cap",
+          value: %{"v" => 100},
+          reason: "test",
+          set_by: "test"
+        })
+
+      :telemetry_test.attach_event_handlers(self(), [
+        [:engram, :billing, :overrides, :expired]
+      ])
+
+      assert :ok = perform_job(OverrideExpirySweep, %{})
+      assert_received {[:engram, :billing, :overrides, :expired], _ref, %{count: 1}, %{}}
+
+      refute Repo.get(UserLimitOverride, expired.id)
+      assert Repo.get(UserLimitOverride, future_row.id)
+      assert Repo.get(UserLimitOverride, permanent.id)
+    end
   end
 end

--- a/test/engram/billing/workers/override_expiry_sweep_test.exs
+++ b/test/engram/billing/workers/override_expiry_sweep_test.exs
@@ -1,0 +1,68 @@
+defmodule Engram.Billing.Workers.OverrideExpirySweepTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Billing.UserLimitOverride
+  alias Engram.Billing.Workers.OverrideExpirySweep
+  alias Engram.Repo
+
+  defp insert_override(user, expires_at) do
+    Repo.insert!(%UserLimitOverride{
+      user_id: user.id,
+      key: "notes_cap",
+      value: %{"v" => 100},
+      reason: "test",
+      set_by: "test",
+      expires_at: expires_at
+    })
+  end
+
+  describe "perform/1" do
+    test "deletes rows where expires_at <= now()" do
+      user1 = insert(:user)
+      user2 = insert(:user)
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+      future = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+
+      expired = insert_override(user1, past)
+      not_expired = insert_override(user2, future)
+
+      assert :ok = perform_job(OverrideExpirySweep, %{})
+
+      refute Repo.get(UserLimitOverride, expired.id)
+      assert Repo.get(UserLimitOverride, not_expired.id)
+    end
+
+    test "ignores rows with expires_at IS NULL" do
+      user = insert(:user)
+
+      permanent =
+        Repo.insert!(%UserLimitOverride{
+          user_id: user.id,
+          key: "notes_cap",
+          value: %{"v" => 100},
+          reason: "test",
+          set_by: "test"
+        })
+
+      assert :ok = perform_job(OverrideExpirySweep, %{})
+
+      assert Repo.get(UserLimitOverride, permanent.id)
+    end
+
+    test "emits telemetry event with count" do
+      user = insert(:user)
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+      insert_override(user, past)
+
+      :telemetry_test.attach_event_handlers(self(), [
+        [:engram, :billing, :overrides, :expired]
+      ])
+
+      assert :ok = perform_job(OverrideExpirySweep, %{})
+
+      assert_received {[:engram, :billing, :overrides, :expired], _ref, %{count: 1}, %{}}
+    end
+  end
+end

--- a/test/mix/tasks/engram/lint/limit_keys_test.exs
+++ b/test/mix/tasks/engram/lint/limit_keys_test.exs
@@ -1,0 +1,113 @@
+defmodule Mix.Tasks.Engram.Lint.LimitKeysTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Engram.Lint.LimitKeys, as: Lint
+
+  defp scan(source) do
+    Lint.scan_source!(source, "test.ex")
+  end
+
+  describe "valid call sites" do
+    test "fully qualified Engram.Billing.effective_limit with catalog atom passes" do
+      src = """
+      defmodule X do
+        def f(user), do: Engram.Billing.effective_limit(user, :notes_cap)
+      end
+      """
+
+      assert scan(src) == []
+    end
+
+    test "aliased Billing.check_limit with catalog atom passes" do
+      src = """
+      defmodule X do
+        alias Engram.Billing
+        def f(user), do: Billing.check_limit(user, :vaults_cap, 5)
+      end
+      """
+
+      assert scan(src) == []
+    end
+
+    test "aliased Billing.check_feature with catalog atom passes" do
+      src = """
+      defmodule X do
+        alias Engram.Billing
+        def f(user), do: Billing.check_feature(user, :reranker_enabled)
+      end
+      """
+
+      assert scan(src) == []
+    end
+
+    test "non-billing call (Billing.tier) is ignored" do
+      src = """
+      defmodule X do
+        alias Engram.Billing
+        def f(user), do: Billing.tier(user)
+      end
+      """
+
+      assert scan(src) == []
+    end
+  end
+
+  describe "violations" do
+    test "unknown atom flagged as :unknown_atom" do
+      src = """
+      defmodule X do
+        def f(user), do: Engram.Billing.effective_limit(user, :bogus_key)
+      end
+      """
+
+      assert [{_, _, :effective_limit, :unknown_atom, :bogus_key}] = scan(src)
+    end
+
+    test "string key flagged as :string_key" do
+      src = """
+      defmodule X do
+        def f(user), do: Engram.Billing.effective_limit(user, "notes_cap")
+      end
+      """
+
+      assert [{_, _, :effective_limit, :string_key, "notes_cap"}] = scan(src)
+    end
+
+    test "dynamic variable key flagged as :dynamic_key" do
+      src = """
+      defmodule X do
+        def f(user, key), do: Engram.Billing.effective_limit(user, key)
+      end
+      """
+
+      assert [{_, _, :effective_limit, :dynamic_key, _}] = scan(src)
+    end
+
+    test "dynamic key with `# lint:limit_keys allow_dynamic` annotation passes" do
+      src = """
+      defmodule X do
+        def f(user, key) do
+          # lint:limit_keys allow_dynamic
+          Engram.Billing.effective_limit(user, key)
+        end
+      end
+      """
+
+      assert scan(src) == []
+    end
+  end
+
+  describe "self-scan against engram codebase" do
+    test "lint passes against current lib/ and test/" do
+      violations =
+        (Path.wildcard("lib/**/*.ex") ++ Path.wildcard("test/**/*.exs"))
+        |> Enum.flat_map(fn file ->
+          Lint.scan_source!(File.read!(file), file)
+        end)
+
+      assert violations == [],
+             "Found #{length(violations)} limit-key violations:\n" <>
+               Enum.map_join(violations, "\n", &inspect/1)
+    end
+  end
+end

--- a/test/mix/tasks/engram/lint/limit_keys_test.exs
+++ b/test/mix/tasks/engram/lint/limit_keys_test.exs
@@ -95,6 +95,59 @@ defmodule Mix.Tasks.Engram.Lint.LimitKeysTest do
 
       assert scan(src) == []
     end
+
+    test "`# lint:limit_keys ignore` suppresses :unknown_atom (negative-path tests)" do
+      src = """
+      defmodule X do
+        def f(user) do
+          # lint:limit_keys ignore
+          Engram.Billing.effective_limit(user, :bogus_key)
+        end
+      end
+      """
+
+      assert scan(src) == []
+    end
+
+    test "`# lint:limit_keys ignore` suppresses :string_key" do
+      src = """
+      defmodule X do
+        def f(user) do
+          # lint:limit_keys ignore
+          Engram.Billing.effective_limit(user, "vaults_cap")
+        end
+      end
+      """
+
+      assert scan(src) == []
+    end
+
+    test "`# lint:limit_keys ignore` suppresses :dynamic_key" do
+      src = """
+      defmodule X do
+        def f(user, key) do
+          # lint:limit_keys ignore
+          Engram.Billing.effective_limit(user, key)
+        end
+      end
+      """
+
+      assert scan(src) == []
+    end
+
+    test "ignore annotation must be on the immediately preceding line" do
+      src = """
+      defmodule X do
+        def f(user) do
+          # lint:limit_keys ignore
+          IO.puts("intervening line")
+          Engram.Billing.effective_limit(user, :bogus_key)
+        end
+      end
+      """
+
+      assert [{_, _, :effective_limit, :unknown_atom, :bogus_key}] = scan(src)
+    end
   end
 
   describe "self-scan against engram codebase" do


### PR DESCRIPTION
## Summary

Final PR (3 of 3) in the plans-resolver implementation. Stacks on PR #178.

Closes `docs/superpowers/specs/2026-05-20-plans-resolver-design.md` §4.4 (expiry sweep) and §8 (CI lint rule).

## What's in this PR

- **`Engram.Billing.Workers.OverrideExpirySweep`** — Oban worker (queue `:maintenance`) that deletes `user_limit_overrides` rows where `expires_at <= now()` and emits `[:engram, :billing, :overrides, :expired]` telemetry with count. Uses `unique: [period: 60]` to prevent concurrent enqueues.
- **Cron entry** in `config/config.exs` — daily at 03:00 UTC.
- **`mix engram.lint.limit_keys`** — AST-scan Mix task that walks `lib/**/*.ex` + `test/**/*.exs` for calls to `Engram.Billing.{effective_limit, check_limit, check_feature}` and asserts the key arg is an atom from `LimitKeys.all/0`. Fails the build on:
  - Unknown atom (typo against catalog)
  - String literal (legacy form)
  - Dynamic key (variable) without suppression annotation
- **Suppression annotations** — `# lint:limit_keys allow_dynamic` for variable-key call sites (mirrors T3.0 source-lint precedent), plus `# lint:limit_keys ignore` for tests that deliberately pass bad keys to assert `UnknownLimitKey` raises.
- **Self-scan meta-test** — guards against future drift; if any PR introduces a bad call site, the lint test fails.
- **CI wire-up** — `mix engram.lint.limit_keys` runs in the `lint` job alongside format/credo/sobelow.

## Test plan

- [x] `mix test` — 1283 tests, 0 failures, 7 skipped (4 consecutive clean runs; one earlier transient flake in unrelated `MasterRotation` lock-contention test, pre-existing)
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — 1355 mods/funs, no issues
- [x] `mix engram.lint.limit_keys` — 0 violations across 262 files
- [ ] After merge, monitor 03:00 UTC sweep run via Oban dashboard / logs
- [ ] Telemetry event fires in staging — verify via grep on application logs

## Future operational notes

- Adding a new key to `LimitKeys`: add catalog entry, re-run `mix ecto.reset` (seeds repopulate). All existing call sites pass lint automatically.
- Granting a one-off limit override: `Repo.insert!(%UserLimitOverride{...})` with `set_by` set to admin/ticket reference, `expires_at` optional. Expiry sweep cleans up automatically.
- Self-host operators: bypass is on by default (no `PADDLE_API_KEY`). Opt-in via `ENGRAM_LIMITS_ENFORCED=true`. Tier defaults configurable via `ENGRAM_<TIER>_<KEY>` env vars at boot.

## Done after this PR

All three PRs (#177, #178, this one) close §0 shared infrastructure from `docs/superpowers/specs/2026-05-20-pricing-v2-abuse-defenses-work-order.md`. Per-vector abuse defenses (A-K) can now build on this foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)