### PR TITLE
docs(readme): tighten tagline + add encryption-at-rest callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Engram
 
-Your vault remembers everything.
+Your notes are your AI's memory.
 
-AI-powered personal knowledge base that makes your Obsidian vault queryable by any AI assistant via [MCP](https://modelcontextprotocol.io). Built with Elixir/Phoenix. Notes are stored in PostgreSQL, embedded into vectors via Voyage AI, and searched with semantic similarity through Qdrant.
+The AI memory layer where your notes are the storage — markdown you and your AI assistants both read and write to via [MCP](https://modelcontextprotocol.io). Built with Elixir/Phoenix. Notes are stored in PostgreSQL with per-user AES-GCM encryption at rest, embedded into vectors via Voyage AI, and searched with semantic similarity through Qdrant.
 
 Pairs with the [Engram Obsidian Sync](https://github.com/engram-app/Engram-obsidian) plugin for real-time bidirectional sync between Obsidian and the server via Phoenix Channels (WebSocket).
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.155",
+      version: "0.5.156",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Aligns backend README with workspace-wide messaging consolidation:

- Tagline: "Your vault remembers everything." → **"Your notes are your AI's memory."**
- Opening paragraph: reframes Engram as the AI memory layer where notes are the storage (markdown both human + AI read and write), adds explicit per-user AES-GCM encryption-at-rest callout
- `mix.exs` version bumped 0.5.147 → 0.5.148 (pre-push hook requirement)

Encryption-at-rest mention is intentional — per the 8-tool AI-memory competitive analysis (`engram-workspace/docs/context/competitive-ai-memory-2026-05-20.md`), none of the surveyed competitors (mem0, supermemory, honcho, ByteRover, Hindsight, Holographic, OpenViking, RetainDB) market per-user DEK + AAD-bound encryption at rest. Surfacing it on high-traffic surfaces (README is the GitHub landing) is positioning leverage.

## Test plan

- [ ] README renders correctly on GitHub repo landing
- [ ] No functional code changed — only README.md + mix.exs version
- [ ] Version bump doesn't conflict with active plans-resolver PRs (#177-#179 on 0.5.150 → may need rebase if those merge first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)