### PR TITLE
feat(billing): pricing v2 §B lifetime embed-token budget

### DIFF
--- a/lib/engram/usage_meters.ex
+++ b/lib/engram/usage_meters.ex
@@ -1,0 +1,70 @@
+defmodule Engram.UsageMeters do
+  @moduledoc """
+  Per-user usage counters that drive pricing-v2 abuse defenses.
+
+  Lifetime embed-token counter (§B): monotonic — never decremented on note
+  delete so re-upload cycles can't reset the Free quota.
+
+  Lazy-initialized: rows are inserted on first write via `add_embed_tokens/2`.
+  Reads return zero for users without a row yet.
+  """
+
+  import Ecto.Query
+  alias Engram.Repo
+
+  defmodule Meter do
+    use Ecto.Schema
+
+    @primary_key {:user_id, :id, autogenerate: false}
+    schema "usage_meters" do
+      field :lifetime_embed_tokens, :integer, default: 0
+      field :updated_at, :utc_datetime_usec
+    end
+  end
+
+  @spec lifetime_embed_tokens(integer()) :: non_neg_integer()
+  def lifetime_embed_tokens(user_id) when is_integer(user_id) do
+    Repo.one(
+      from(m in Meter, where: m.user_id == ^user_id, select: m.lifetime_embed_tokens),
+      skip_tenant_check: true
+    ) || 0
+  end
+
+  @doc """
+  Monotonically increments the lifetime embed-token counter. Returns
+  the new total. Uses a single upsert so concurrent embeds can't lose
+  increments to a read-modify-write race.
+  """
+  @spec add_embed_tokens(integer(), non_neg_integer()) :: non_neg_integer()
+  def add_embed_tokens(user_id, count)
+      when is_integer(user_id) and is_integer(count) and count > 0 do
+    now = DateTime.utc_now()
+
+    {1, [%{lifetime_embed_tokens: total}]} =
+      Repo.insert_all(
+        Meter,
+        [%{user_id: user_id, lifetime_embed_tokens: count, updated_at: now}],
+        on_conflict: [inc: [lifetime_embed_tokens: count], set: [updated_at: now]],
+        conflict_target: :user_id,
+        returning: [:lifetime_embed_tokens],
+        skip_tenant_check: true
+      )
+
+    total
+  end
+
+  def add_embed_tokens(_user_id, 0), do: lifetime_embed_tokens(0)
+
+  @doc """
+  Estimates Voyage token count from raw byte size. English averages ~4 bytes
+  per token; we round up so the cap is conservative (we never undercount
+  against the user). Real `usage.total_tokens` from the Voyage response is a
+  follow-up.
+  """
+  @spec estimate_tokens(binary()) :: non_neg_integer()
+  def estimate_tokens(content) when is_binary(content) do
+    div(byte_size(content) + 3, 4)
+  end
+
+  def estimate_tokens(_), do: 0
+end

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -25,11 +25,13 @@ defmodule Engram.Workers.EmbedNote do
   import Ecto.Query
 
   alias Engram.Accounts
+  alias Engram.Billing
   alias Engram.Crypto
   alias Engram.Crypto.RotationGate
   alias Engram.Indexing
   alias Engram.Notes.Note
   alias Engram.Repo
+  alias Engram.UsageMeters
   alias Engram.Vaults.Vault
 
   require Logger
@@ -72,7 +74,20 @@ defmodule Engram.Workers.EmbedNote do
           :ok ->
             case phone_gate(note.user_id) do
               :ok ->
-                run_embed(note, old_path_hmac_b64)
+                case embed_budget_gate(note) do
+                  :ok ->
+                    case run_embed(note, old_path_hmac_b64) do
+                      :ok ->
+                        _ = record_embed_tokens(note)
+                        :ok
+
+                      other ->
+                        other
+                    end
+
+                  {:cancel, reason} ->
+                    {:cancel, reason}
+                end
 
               {:snooze, secs} ->
                 {:snooze, secs}
@@ -105,6 +120,51 @@ defmodule Engram.Workers.EmbedNote do
       :ok
     end
   end
+
+  # Pricing v2 §B — block embeds when the user has exhausted their lifetime
+  # token budget. Resolver returns nil for Starter/Pro (unmetered), so this is
+  # effectively Free-only. Per-user overrides via Billing.UserLimitOverride.
+  defp embed_budget_gate(%Note{user_id: user_id} = note) do
+    user = Accounts.get_user!(user_id)
+    current = UsageMeters.lifetime_embed_tokens(user_id)
+    estimated = estimate_note_tokens(note)
+
+    case Billing.check_limit(user, :lifetime_embed_token_cap, current + estimated - 1) do
+      :ok ->
+        :ok
+
+      {:error, :limit_reached} ->
+        :telemetry.execute(
+          [:engram, :abuse, :embed_budget_exhausted],
+          %{count: 1, lifetime_tokens: current},
+          %{user_id: user_id}
+        )
+
+        Logger.warning("EmbedNote rejected — lifetime embed-token cap reached",
+          user_id: user_id,
+          reason_label: :embed_budget_exhausted
+        )
+
+        {:cancel, :embed_budget_exhausted}
+    end
+  end
+
+  defp record_embed_tokens(%Note{user_id: user_id} = note) do
+    case estimate_note_tokens(note) do
+      0 -> :ok
+      tokens -> UsageMeters.add_embed_tokens(user_id, tokens)
+    end
+  end
+
+  # Token estimate uses the ciphertext byte size. AES-GCM adds a 16-byte
+  # auth tag so we over-count by ~4 tokens per note, which keeps the cap
+  # conservative. Real `usage.total_tokens` from the Voyage response is a
+  # follow-up.
+  defp estimate_note_tokens(%Note{content_ciphertext: ct}) when is_binary(ct) do
+    UsageMeters.estimate_tokens(ct)
+  end
+
+  defp estimate_note_tokens(_), do: 0
 
   defp run_embed(note, old_path_hmac_b64) do
     user = Accounts.get_user!(note.user_id)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.157",
+      version: "0.5.158",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260521050000_create_usage_meters.exs
+++ b/priv/repo/migrations/20260521050000_create_usage_meters.exs
@@ -1,0 +1,18 @@
+defmodule Engram.Repo.Migrations.CreateUsageMeters do
+  use Ecto.Migration
+
+  # Pricing v2 §B (lifetime embed budget) — per-user counters.
+  # Additional columns (conversations_today, queries_today, last_active_at)
+  # land alongside the §C and §D PRs that need them; this migration scopes
+  # to the §B lifetime token counter only.
+  def change do
+    create table(:usage_meters, primary_key: false) do
+      add :user_id,
+          references(:users, on_delete: :delete_all, type: :bigint),
+          primary_key: true
+
+      add :lifetime_embed_tokens, :bigint, null: false, default: 0
+      add :updated_at, :utc_datetime_usec, null: false, default: fragment("now()")
+    end
+  end
+end

--- a/test/engram/usage_meters_test.exs
+++ b/test/engram/usage_meters_test.exs
@@ -1,0 +1,67 @@
+defmodule Engram.UsageMetersTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.UsageMeters
+
+  describe "lifetime_embed_tokens/1" do
+    test "returns 0 for users without a meter row yet" do
+      user = insert(:user)
+      assert UsageMeters.lifetime_embed_tokens(user.id) == 0
+    end
+
+    test "returns the stored count after add_embed_tokens" do
+      user = insert(:user)
+      UsageMeters.add_embed_tokens(user.id, 1500)
+      assert UsageMeters.lifetime_embed_tokens(user.id) == 1500
+    end
+  end
+
+  describe "add_embed_tokens/2" do
+    test "lazy-inits a row on first call" do
+      user = insert(:user)
+      assert UsageMeters.add_embed_tokens(user.id, 100) == 100
+    end
+
+    test "monotonically accumulates across calls" do
+      user = insert(:user)
+      UsageMeters.add_embed_tokens(user.id, 100)
+      UsageMeters.add_embed_tokens(user.id, 250)
+      UsageMeters.add_embed_tokens(user.id, 50)
+      assert UsageMeters.lifetime_embed_tokens(user.id) == 400
+    end
+
+    test "increments are isolated per user" do
+      a = insert(:user)
+      b = insert(:user)
+      UsageMeters.add_embed_tokens(a.id, 500)
+      UsageMeters.add_embed_tokens(b.id, 700)
+      assert UsageMeters.lifetime_embed_tokens(a.id) == 500
+      assert UsageMeters.lifetime_embed_tokens(b.id) == 700
+    end
+
+    test "concurrent increments never lose updates" do
+      user = insert(:user)
+
+      1..20
+      |> Task.async_stream(fn _ -> UsageMeters.add_embed_tokens(user.id, 10) end,
+        max_concurrency: 10
+      )
+      |> Stream.run()
+
+      assert UsageMeters.lifetime_embed_tokens(user.id) == 200
+    end
+  end
+
+  describe "estimate_tokens/1" do
+    test "returns ceil(bytes/4) for ASCII content" do
+      assert UsageMeters.estimate_tokens("hello world") == 3
+      assert UsageMeters.estimate_tokens("a") == 1
+      assert UsageMeters.estimate_tokens("") == 0
+    end
+
+    test "rounds up so the cap remains conservative" do
+      # 5 bytes / 4 = 1.25 → 2 tokens (over-counts slightly, never under)
+      assert UsageMeters.estimate_tokens("abcde") == 2
+    end
+  end
+end

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -297,4 +297,64 @@ defmodule Engram.Workers.EmbedNoteTest do
       assert :ok = perform_job(EmbedNote, %{note_id: note.id})
     end
   end
+
+  describe "perform/1 — lifetime embed-token budget (pricing v2 §B)" do
+    setup do
+      # Users without a Subscription default to :free tier (Billing.tier/1).
+      # Free's lifetime_embed_token_cap = 20M per LimitKeys catalog.
+      prev = Application.get_env(:engram, :limits_enforced)
+      Application.put_env(:engram, :limits_enforced, true)
+
+      on_exit(fn ->
+        if is_nil(prev),
+          do: Application.delete_env(:engram, :limits_enforced),
+          else: Application.put_env(:engram, :limits_enforced, prev)
+      end)
+
+      :ok
+    end
+
+    test "discards job when lifetime_embed_token_cap is exhausted", %{user: user, note: note} do
+      Engram.UsageMeters.add_embed_tokens(user.id, 20_000_000)
+
+      assert {:cancel, _reason} = perform_job(EmbedNote, %{note_id: note.id})
+
+      # No Voyage call should have happened (no Mock expect declared).
+      assert Engram.UsageMeters.lifetime_embed_tokens(user.id) == 20_000_000
+    end
+
+    test "proceeds and increments the counter on success",
+         %{bypass: bypass, user: user, note: note} do
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+      end)
+
+      stub_qdrant(bypass)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      assert Engram.UsageMeters.lifetime_embed_tokens(user.id) > 0
+    end
+
+    test "user override raises the cap above the default",
+         %{bypass: bypass, user: user, note: note} do
+      Engram.UsageMeters.add_embed_tokens(user.id, 20_000_000)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "lifetime_embed_token_cap",
+        value: %{"v" => 100_000_000}
+      )
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+      end)
+
+      stub_qdrant(bypass)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes pricing-v2 abuse-defense vector §B from `docs/superpowers/specs/2026-05-20-pricing-v2-abuse-defenses-work-order.md`. Free user could embed 10k notes (~5M tokens, $0.60 Voyage), delete them, re-upload 100× a day = $60/day Voyage burn that we eat. This PR caps lifetime tokens with a monotonic counter so cycling doesn't reset the budget.

## What ships

- **`usage_meters` table** — `user_id` PK + `lifetime_embed_tokens bigint default 0` + `updated_at`. Other counters from §0.3 spec (conversations_today, queries_today, last_active_at) land alongside §C/§D PRs.
- **`Engram.UsageMeters` context** — `lifetime_embed_tokens/1`, `add_embed_tokens/2` (idempotent upsert with `on_conflict: [inc:]` so concurrent increments never lose updates), `estimate_tokens/1` (ceil bytes ÷ 4).
- **`EmbedNote` pre-flight gate** — `Billing.check_limit(user, :lifetime_embed_token_cap, current + estimate - 1)`. On `:limit_reached`, returns `{:cancel, :embed_budget_exhausted}` (Oban discards the job, no retry) + emits `[:engram, :abuse, :embed_budget_exhausted]` telemetry.
- **Counter increment after successful embed** using estimated tokens from `byte_size(content_ciphertext) ÷ 4`. AES-GCM 16-byte auth tag adds a small over-count which keeps the cap conservative.

## Test state

- 1310 tests, 0 failures, 7 skipped
- mix format / warnings-as-errors / credo --strict all clean
- 11 new tests (8 UsageMeters, 3 EmbedNote budget gate)

## Behaviour matrix

| Tier | `lifetime_embed_token_cap` | Behaviour |
|------|---------------------------|-----------|
| Free | 20_000_000 | Cap enforced; cycling can't reset |
| Starter | nil | Unmetered |
| Pro | nil | Unmetered |
| Per-user override | as set | Highest precedence (e.g. 100M trial bump) |
| `:limits_enforced = false` (self-host default) | — | Resolver returns `:unlimited`, gate is a no-op |

## Notes for §B-adjacent vectors

- §C inactivity cron + §D conversation rotation will share `usage_meters`. This PR ships only the §B columns to keep the migration narrow.
- Real `usage.total_tokens` from Voyage response (vs char-estimate) is a follow-up — requires extending `Engram.Embedder` behaviour signature, touches the Ollama adapter too. Not blocking launch since the estimate is conservative (over-counts ~4-tokens/note from auth-tag, well under measurement noise).

## Test plan

- [ ] CI green
- [ ] Manual smoke on staging: set user lifetime tokens to 19_999_950 via Mix task, attempt to embed a 1KB note → cancelled with `embed_budget_exhausted`
- [ ] Manual smoke: confirm cycling — embed 5 notes (counter +N), delete all 5 (counter unchanged), embed 5 more (counter +2N). No reset.
- [ ] Manual smoke: insert `user_limit_overrides` row with `lifetime_embed_token_cap = 100_000_000` → user at 25M can resume embedding.

## Dependencies

- §0 plans-resolver (`Engram.Billing.check_limit/3`, `LimitKeys` catalog with `lifetime_embed_token_cap`, `user_limit_overrides` table) — already shipped 2026-05-21 via PRs #177/#181/#179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)