### PR TITLE
test: serialize limits_test.exs to stop Application.put_env race (closes #183)

### DIFF
--- a/docs/context/exunit-application-env-races.md
+++ b/docs/context/exunit-application-env-races.md
@@ -1,0 +1,71 @@
+# ExUnit Application.put_env race — async-mutator anti-pattern
+
+Tests that mutate `Application.put_env/3` (or `Application.delete_env/2`) while declared `async: true` are a flake source. `Application` env is a single global ETS table — the Ecto SQL sandbox isolates DB rows per test, but does **nothing** for application env. Concurrent readers in other async modules can observe the temporary value mid-test.
+
+## Symptom shape
+
+A reader test in module A passes in isolation, passes for its own module, passes for the full suite most of the time, then occasionally fails in CI. Failure surface is always "production code branched the wrong way" — e.g. `enforced?()` returned `false` so the limit guard was skipped, or a feature flag flipped, or an HTTP client hit the wrong base URL.
+
+Rerunning passes. Looks like a sandbox / RLS / timing bug. It is not.
+
+## Concrete instance (closed)
+
+[engram-app/engram#183](https://github.com/engram-app/engram/issues/183) — `EngramWeb.VaultsControllerTest` "returns 402 when vault limit reached" returned 201 ~30% of seeds when run alongside `Engram.Billing.LimitsTest`.
+
+- Mutator: `test/engram/billing/limits_test.exs` was `async: true` with a `describe "bypass (self-host) — :limits_enforced=false"` block that called `Application.put_env(:engram, :limits_enforced, false)` in `setup`, restored in `on_exit`.
+- Reader: `Billing.effective_limit/2` consults `Application.get_env(:engram, :limits_enforced, true)` before the 4-layer resolver. During the bypass window, it returns `:unlimited` → `check_limit/3` returns `:ok` → vault insertion proceeds.
+- Visible result: `register_vault` returned `{:ok, vault, :created}` instead of `{:error, :vault_limit_reached}` → controller responded 201 not 402.
+
+Local repro (PR #188 verification):
+```
+mix test test/engram/billing/limits_test.exs \
+  test/engram_web/controllers/vaults_controller_test.exs --seed 5
+```
+yielded a failure on `:159` (`POST /api/vaults/register returns 402`) and `:77` (`POST /api/vaults returns 402`) in roughly 1 of 3 runs across seeds 1-20.
+
+## Fix
+
+The mutator side is the bug. Mark the mutating module `async: false`:
+
+```elixir
+defmodule Engram.Billing.LimitsTest do
+  # async: false — bypass + default describe blocks mutate
+  # Application.put_env(:engram, :limits_enforced, ...), which is global to
+  # the BEAM. Under async, concurrent readers in other modules observe the
+  # bypass mid-test. See engram-app/engram#183.
+  use Engram.DataCase, async: false
+  ...
+end
+```
+
+ExUnit schedules `async: true` cases first, then `async: false` cases serially — so the mutator runs alone, no concurrent reader exists.
+
+**Do not** apply `async: false` to the readers. That hides this race in one consumer at a time while leaving the same trap for the next consumer of the same config key.
+
+## Audit (as of PR #188)
+
+Other async modules that mutate Application env, **not yet known to flake** (no observed CI failure):
+
+- `test/engram/embedders/voyage_test.exs` — `:voyage_url`, `:voyage_api_key`
+- `test/engram_web/endpoint_config_test.exs` — `:websocket_check_origin`
+
+Both are preemptive risks. They survive only because no other async test currently calls into the code that reads those keys during the same window. The moment such a reader is added, they will flake the same way.
+
+## Rule of thumb when reviewing test code
+
+If a test calls `Application.put_env`, check that:
+
+1. The module is `async: false`, **or**
+2. The key being mutated is read by nothing else during tests (e.g. config that only affects this module's behavior).
+
+(2) is fragile — a new code path elsewhere that reads the key turns the test into a flake source. Default to (1).
+
+## Alternative architectures (out of scope for the immediate fix)
+
+If a config flag is read enough that serializing its mutator slows CI noticeably, push the override into a process-scoped mechanism:
+
+- `Process.put/2` inside the call site (only the test process sees the override).
+- A `Mox`-style explicit-set helper that stores per-process state.
+- A `ProcessTree.get/2`-style fallback chain.
+
+None of these were warranted for `:limits_enforced` (one short test module, milliseconds saved). Documented here so the next reviewer doesn't reach for `async: false` reflexively when the right answer is "stop reading from global env."

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.156",
+      version: "0.5.157",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/billing/limits_test.exs
+++ b/test/engram/billing/limits_test.exs
@@ -1,5 +1,10 @@
 defmodule Engram.Billing.LimitsTest do
-  use Engram.DataCase, async: true
+  # async: false — the bypass + default describe blocks mutate
+  # `Application.put_env(:engram, :limits_enforced, ...)`, which is global
+  # to the BEAM. Under async, concurrent readers in other modules
+  # (e.g. VaultsControllerTest) observe the bypass and see `:unlimited`
+  # mid-test, producing 201 where 402 is expected. See engram-app/engram#183.
+  use Engram.DataCase, async: false
 
   alias Engram.Billing
   alias Engram.Billing.Plan


### PR DESCRIPTION
## Summary

- Closes #183 — `VaultsControllerTest` "returns 402 when vault limit reached" was flaking with 201.
- Root cause: `Engram.Billing.LimitsTest` was `async: true` while its bypass block calls `Application.put_env(:engram, :limits_enforced, false)`. Application env is global; the SQL sandbox does nothing for it. Any concurrent async test calling `Billing.effective_limit/2` during the bypass window saw `:unlimited` and skipped the limit guard → 201 where 402 was expected.
- Fix: mark `limits_test.exs` `async: false`. The mutator side is the bug — readers (VaultsControllerTest, future limit consumers) stay async.

## Why the handoff hypothesis didn't surface this

The handoff focused on RLS + tenant-scoping (H1) and counted vaults (H3). Both turned out to be red herrings: `user_limit_overrides` is not in `@tenant_tables` and has no RLS. The actual race was upstream of the resolver — the `enforced?()` flag is read from Application env first, and a single `false` flip from a sibling test poisons the entire window.

## Repro

```
cd backend
for i in $(seq 1 10); do
  mix test test/engram/billing/limits_test.exs \
    test/engram_web/controllers/vaults_controller_test.exs --seed $i
done
```

Before: 3 failures / 10 runs (seeds 5, 6, 10 — both `:159` and `:77` flake; the sibling-create test was just lucky in CI).
After: 20 / 20 green; full suite 2 / 2 green.

## Adjacent risk (not fixed here)

Two other test files mutate Application env while `async: true`:

- `test/engram/embedders/voyage_test.exs` — `:voyage_url`, `:voyage_api_key`
- `test/engram_web/endpoint_config_test.exs` — `:websocket_check_origin`

No flake observed from these yet, so they're out of scope for this PR — happy to file a follow-up issue if preferred.

## Test plan

- [x] 20× combined-seed loop green locally
- [x] Full backend suite green 2× locally
- [ ] CI unit-tests job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)