### PR TITLE
feat(billing): pricing v2 §D conversation-meter gaming defense

### DIFF
--- a/lib/engram/conversation_meter.ex
+++ b/lib/engram/conversation_meter.ex
@@ -1,0 +1,195 @@
+defmodule Engram.ConversationMeter do
+  @moduledoc """
+  Pricing v2 §D — conversation-meter gaming defense.
+
+  Counts MCP queries the same way users intuit "one conversation": a sliding
+  30-minute window of activity. Inside one conversation, queries are capped
+  (50 on Free) so 500-query batches inside a window can't bypass the
+  "5 conversations/day" Free cap.
+
+  Each `tick/1` either:
+
+    - advances the active conversation's query count (still within window
+      AND under per-conversation cap), or
+    - force-rotates to a new conversation (cap hit OR window expired),
+      incrementing `conversations_today`, OR
+    - rejects with `{:rate_limited, reason}` when the day cap is hit or the
+      per-day query cap is hit.
+
+  Concurrent calls from multiple MCP clients are serialized with a Postgres
+  advisory lock keyed off `user_id`, so two clients can't both think they
+  started "the same" new conversation.
+  """
+
+  import Ecto.Query
+  alias Engram.Accounts
+  alias Engram.Billing
+  alias Engram.Repo
+  alias Engram.UsageMeters.Meter
+
+  @advisory_lock_key 2_739_201
+
+  @spec tick(integer()) ::
+          :ok
+          | {:rate_limited, :conversations_per_day | :queries_per_day | :queries_per_conversation}
+  def tick(user_id) when is_integer(user_id) do
+    user = Accounts.get_user!(user_id)
+
+    Repo.transaction(
+      fn ->
+        Ecto.Adapters.SQL.query!(Repo, "SELECT pg_advisory_xact_lock($1, $2)", [
+          @advisory_lock_key,
+          user_id
+        ])
+
+        do_tick(user, ensure_row(user_id))
+      end,
+      skip_tenant_check: true
+    )
+    |> case do
+      {:ok, result} -> result
+      {:error, reason} -> {:rate_limited, reason}
+    end
+  end
+
+  defp ensure_row(user_id) do
+    case Repo.one(from(m in Meter, where: m.user_id == ^user_id), skip_tenant_check: true) do
+      %Meter{} = meter ->
+        meter
+
+      nil ->
+        %Meter{user_id: user_id, updated_at: DateTime.utc_now()}
+        |> Repo.insert!(skip_tenant_check: true, on_conflict: :nothing)
+
+        Repo.one!(from(m in Meter, where: m.user_id == ^user_id), skip_tenant_check: true)
+    end
+  end
+
+  defp do_tick(user, meter) do
+    today = Date.utc_today()
+    now = DateTime.utc_now()
+
+    meter = rollover_day(meter, today)
+
+    {meter, rotated?} = maybe_rotate_conversation(user, meter, now)
+
+    cond do
+      day_cap_exceeded?(user, meter) ->
+        :telemetry.execute(
+          [:engram, :abuse, :conversation_blocked],
+          %{count: 1},
+          %{user_id: user.id, reason: :conversations_per_day}
+        )
+
+        {:rate_limited, :conversations_per_day}
+
+      query_day_cap_exceeded?(user, meter) ->
+        :telemetry.execute(
+          [:engram, :abuse, :conversation_blocked],
+          %{count: 1},
+          %{user_id: user.id, reason: :queries_per_day}
+        )
+
+        {:rate_limited, :queries_per_day}
+
+      true ->
+        meter
+        |> Ecto.Changeset.change(%{
+          active_conversation_query_count: meter.active_conversation_query_count + 1,
+          queries_today: meter.queries_today + 1,
+          updated_at: now
+        })
+        |> Repo.update!(skip_tenant_check: true)
+
+        _ = rotated?
+        :ok
+    end
+  end
+
+  defp rollover_day(%Meter{} = meter, today) do
+    if meter.conversations_day_key == today and meter.queries_day_key == today do
+      meter
+    else
+      # Day flipped — counters reset AND the active conversation closes so
+      # the next tick starts fresh on the new day (counts as conversation #1).
+      meter
+      |> Ecto.Changeset.change(%{
+        conversations_today: 0,
+        conversations_day_key: today,
+        queries_today: 0,
+        queries_day_key: today,
+        active_conversation_started_at: nil,
+        active_conversation_query_count: 0
+      })
+      |> Repo.update!(skip_tenant_check: true)
+    end
+  end
+
+  defp maybe_rotate_conversation(user, %Meter{} = meter, now) do
+    window_minutes =
+      Billing.effective_limit(user, :conversation_window_minutes) |> normalize_int(30)
+
+    per_conv_cap = Billing.effective_limit(user, :ai_queries_per_conversation)
+
+    expired_window? =
+      case meter.active_conversation_started_at do
+        nil -> true
+        ts -> DateTime.diff(now, ts, :second) > window_minutes * 60
+      end
+
+    over_per_conv_cap? =
+      case per_conv_cap do
+        :unlimited -> false
+        nil -> false
+        cap when is_integer(cap) -> meter.active_conversation_query_count >= cap
+        _ -> false
+      end
+
+    if expired_window? or over_per_conv_cap? do
+      meter =
+        meter
+        |> Ecto.Changeset.change(%{
+          active_conversation_started_at: now,
+          active_conversation_query_count: 0,
+          conversations_today: meter.conversations_today + 1
+        })
+        |> Repo.update!(skip_tenant_check: true)
+
+      :telemetry.execute(
+        [:engram, :abuse, :conversation_rotated],
+        %{count: 1},
+        %{user_id: user.id, reason: rotate_reason(expired_window?, over_per_conv_cap?)}
+      )
+
+      {meter, true}
+    else
+      {meter, false}
+    end
+  end
+
+  defp rotate_reason(true, _), do: :window_expired
+  defp rotate_reason(_, true), do: :per_conv_cap
+
+  defp day_cap_exceeded?(user, %Meter{conversations_today: today}) do
+    case Billing.effective_limit(user, :ai_conversations_per_day) do
+      :unlimited -> false
+      nil -> false
+      cap when is_integer(cap) -> today > cap
+      _ -> false
+    end
+  end
+
+  defp query_day_cap_exceeded?(user, %Meter{queries_today: today}) do
+    case Billing.effective_limit(user, :ai_queries_per_day) do
+      :unlimited -> false
+      nil -> false
+      cap when is_integer(cap) -> today >= cap
+      _ -> false
+    end
+  end
+
+  defp normalize_int(:unlimited, default), do: default
+  defp normalize_int(nil, default), do: default
+  defp normalize_int(n, _) when is_integer(n), do: n
+  defp normalize_int(_, default), do: default
+end

--- a/lib/engram/conversation_meter.ex
+++ b/lib/engram/conversation_meter.ex
@@ -37,10 +37,11 @@ defmodule Engram.ConversationMeter do
 
     Repo.transaction(
       fn ->
-        Ecto.Adapters.SQL.query!(Repo, "SELECT pg_advisory_xact_lock($1, $2)", [
-          @advisory_lock_key,
-          user_id
-        ])
+        _ =
+          Ecto.Adapters.SQL.query!(Repo, "SELECT pg_advisory_xact_lock($1, $2)", [
+            @advisory_lock_key,
+            user_id
+          ])
 
         do_tick(user, ensure_row(user_id))
       end,

--- a/lib/engram/usage_meters.ex
+++ b/lib/engram/usage_meters.ex
@@ -19,6 +19,12 @@ defmodule Engram.UsageMeters do
     schema "usage_meters" do
       field :lifetime_embed_tokens, :integer, default: 0
       field :last_active_at, :utc_datetime_usec
+      field :active_conversation_started_at, :utc_datetime_usec
+      field :active_conversation_query_count, :integer, default: 0
+      field :conversations_today, :integer, default: 0
+      field :conversations_day_key, :date
+      field :queries_today, :integer, default: 0
+      field :queries_day_key, :date
       field :updated_at, :utc_datetime_usec
     end
   end

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -5,6 +5,7 @@ defmodule EngramWeb.McpController do
   """
   use EngramWeb, :controller
 
+  alias Engram.ConversationMeter
   alias Engram.MCP.Tools
 
   @server_info %{"name" => "engram", "version" => "0.1.0"}
@@ -50,13 +51,22 @@ defmodule EngramWeb.McpController do
       {:ok, tool} ->
         user = conn.assigns.current_user
 
-        case resolve_mcp_vault(user, args, conn) do
-          {:error, msg} ->
-            {:ok,
-             %{"content" => [%{"type" => "text", "text" => "Error: #{msg}"}], "isError" => true}}
+        case ConversationMeter.tick(user.id) do
+          {:rate_limited, reason} ->
+            {:error, -32_005, "rate_limited: #{reason}"}
 
-          {:ok, vault} ->
-            call_tool(tool, user, vault, args)
+          :ok ->
+            case resolve_mcp_vault(user, args, conn) do
+              {:error, msg} ->
+                {:ok,
+                 %{
+                   "content" => [%{"type" => "text", "text" => "Error: #{msg}"}],
+                   "isError" => true
+                 }}
+
+              {:ok, vault} ->
+                call_tool(tool, user, vault, args)
+            end
         end
 
       :error ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.159",
+      version: "0.5.160",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260521070000_conversation_meter_columns.exs
+++ b/priv/repo/migrations/20260521070000_conversation_meter_columns.exs
@@ -1,0 +1,25 @@
+defmodule Engram.Repo.Migrations.ConversationMeterColumns do
+  use Ecto.Migration
+
+  # Pricing v2 §D — conversation gaming defense. Extends usage_meters with
+  # per-user counters that drive the rotate-on-cap logic:
+  #
+  #   - active_conversation_started_at    — when current conversation began
+  #   - active_conversation_query_count   — queries in current conversation
+  #   - conversations_today               — conversations counted today
+  #   - conversations_day_key             — date for the conversations_today
+  #                                         counter (auto-rolls at UTC day flip)
+  #   - queries_today                     — total queries today (for the
+  #                                         ai_queries_per_day cap at Pro tier)
+  #   - queries_day_key                   — date for queries_today
+  def change do
+    alter table(:usage_meters) do
+      add :active_conversation_started_at, :utc_datetime_usec
+      add :active_conversation_query_count, :integer, null: false, default: 0
+      add :conversations_today, :integer, null: false, default: 0
+      add :conversations_day_key, :date
+      add :queries_today, :integer, null: false, default: 0
+      add :queries_day_key, :date
+    end
+  end
+end

--- a/test/engram/conversation_meter_test.exs
+++ b/test/engram/conversation_meter_test.exs
@@ -1,0 +1,165 @@
+defmodule Engram.ConversationMeterTest do
+  use Engram.DataCase, async: false
+
+  alias Engram.ConversationMeter
+  alias Engram.Repo
+  alias Engram.UsageMeters.Meter
+
+  setup do
+    prev = Application.get_env(:engram, :limits_enforced)
+    Application.put_env(:engram, :limits_enforced, true)
+
+    on_exit(fn ->
+      if is_nil(prev),
+        do: Application.delete_env(:engram, :limits_enforced),
+        else: Application.put_env(:engram, :limits_enforced, prev)
+    end)
+
+    :ok
+  end
+
+  defp meter(user_id) do
+    Repo.one!(from(m in Meter, where: m.user_id == ^user_id), skip_tenant_check: true)
+  end
+
+  describe "tick/1 — Free tier (defaults)" do
+    test "first call opens a conversation and counts query #1" do
+      user = insert(:user)
+      assert :ok = ConversationMeter.tick(user.id)
+
+      m = meter(user.id)
+      assert m.conversations_today == 1
+      assert m.active_conversation_query_count == 1
+      assert m.queries_today == 1
+    end
+
+    test "50 queries inside one window stay in one conversation" do
+      user = insert(:user)
+
+      Enum.each(1..50, fn _ -> assert :ok = ConversationMeter.tick(user.id) end)
+
+      m = meter(user.id)
+      assert m.conversations_today == 1
+      assert m.active_conversation_query_count == 50
+    end
+
+    test "query 51 force-rotates to a new conversation (per-conv cap)" do
+      user = insert(:user)
+      Enum.each(1..50, fn _ -> ConversationMeter.tick(user.id) end)
+
+      assert :ok = ConversationMeter.tick(user.id)
+
+      m = meter(user.id)
+      assert m.conversations_today == 2
+      # Rotation resets to 0, then this query bumps to 1
+      assert m.active_conversation_query_count == 1
+    end
+
+    test "6th conversation in a day is rate-limited" do
+      user = insert(:user)
+
+      # Drive 5 forced rotations: 5 conversations × 50 queries = 250 queries
+      Enum.each(1..250, fn _ -> ConversationMeter.tick(user.id) end)
+
+      # Next tick would rotate to 6th conversation, which exceeds Free's
+      # ai_conversations_per_day=5.
+      assert {:rate_limited, :conversations_per_day} = ConversationMeter.tick(user.id)
+    end
+  end
+
+  describe "tick/1 — window expiry" do
+    test "rotates conversation when 30-min window expires" do
+      user = insert(:user)
+      ConversationMeter.tick(user.id)
+
+      # Push active_conversation_started_at to 31 minutes ago
+      thirty_one_min_ago = DateTime.utc_now() |> DateTime.add(-31 * 60, :second)
+
+      Repo.update_all(
+        from(m in Meter, where: m.user_id == ^user.id),
+        [set: [active_conversation_started_at: thirty_one_min_ago]],
+        skip_tenant_check: true
+      )
+
+      assert :ok = ConversationMeter.tick(user.id)
+
+      m = meter(user.id)
+      assert m.conversations_today == 2
+      assert m.active_conversation_query_count == 1
+    end
+  end
+
+  describe "tick/1 — paid tier" do
+    setup do
+      # Pro user — nil cap on per-conv + per-day conversation count;
+      # ai_queries_per_day capped at 10_000.
+      user = insert(:user)
+      insert(:subscription, user: user, tier: "pro", status: "active")
+      %{user: user}
+    end
+
+    test "Pro user can run 200 queries inside one conversation without rotating",
+         %{user: user} do
+      Enum.each(1..200, fn _ -> assert :ok = ConversationMeter.tick(user.id) end)
+
+      m = meter(user.id)
+      assert m.active_conversation_query_count == 200
+      assert m.conversations_today == 1
+    end
+
+    test "Pro user is rate-limited at 10_000 queries per day", %{user: user} do
+      # Seed the meter row, then force the per-day counter near the cap.
+      ConversationMeter.tick(user.id)
+
+      Repo.update_all(
+        from(m in Meter, where: m.user_id == ^user.id),
+        [
+          set: [
+            queries_today: 9_999,
+            queries_day_key: Date.utc_today(),
+            conversations_today: 1,
+            conversations_day_key: Date.utc_today(),
+            active_conversation_started_at: DateTime.utc_now(),
+            active_conversation_query_count: 9_999
+          ]
+        ],
+        skip_tenant_check: true
+      )
+
+      # 10_000th query — accepted (10k cap, < not <=)
+      assert :ok = ConversationMeter.tick(user.id)
+      # 10_001st — rejected
+      assert {:rate_limited, :queries_per_day} = ConversationMeter.tick(user.id)
+    end
+  end
+
+  describe "tick/1 — day rollover" do
+    test "counters reset when usage_meters day_key rolls forward" do
+      user = insert(:user)
+      ConversationMeter.tick(user.id)
+
+      yesterday = Date.utc_today() |> Date.add(-1)
+
+      Repo.update_all(
+        from(m in Meter, where: m.user_id == ^user.id),
+        [
+          set: [
+            conversations_today: 5,
+            conversations_day_key: yesterday,
+            queries_today: 250,
+            queries_day_key: yesterday
+          ]
+        ],
+        skip_tenant_check: true
+      )
+
+      assert :ok = ConversationMeter.tick(user.id)
+
+      m = meter(user.id)
+      # Yesterday's counters reset; today opens fresh.
+      assert m.conversations_today == 1
+      assert m.queries_today == 1
+      assert m.conversations_day_key == Date.utc_today()
+    end
+  end
+end


### PR DESCRIPTION
**Reopen of #187** (auto-closed when parent branch `feat/embed-budget` was deleted on #185 merge). Same diff, rebased onto main.

## Summary

Closes pricing-v2 abuse-defense vector §D from `docs/superpowers/specs/2026-05-20-pricing-v2-abuse-defenses-work-order.md`. Free's "5 conversations/day" cap defined as "30-min sliding window of MCP queries = 1 conversation" was trivially bypassable by batching 500 queries inside one window. This PR caps query count inside a conversation and force-rotates when the cap is hit, so the daily conversation budget is the real ceiling.

## What ships

- **Migration** — extends `usage_meters` with `active_conversation_started_at`, `active_conversation_query_count`, `conversations_today`, `conversations_day_key`, `queries_today`, `queries_day_key`.
- **`Engram.ConversationMeter.tick/1`** — single entry point called from the MCP `tools/call` dispatch. Returns `:ok | {:rate_limited, reason}`. Inside a Postgres advisory-lock per user_id.
- **MCP controller wiring** — `tools/call` checks `ConversationMeter.tick(user.id)` before running the tool; rate-limit responses surface to clients as JSON-RPC -32_005.
- **Rate-limit reasons** — `:conversations_per_day`, `:queries_per_day`, `:queries_per_conversation`.
- **Telemetry** — `[:engram, :abuse, :conversation_blocked]` on reject, `[:engram, :abuse, :conversation_rotated]` on every rotation.

## Tier matrix (driven by `Engram.Billing.LimitKeys`)

| Tier | conv_window_min | queries_per_conv | conversations_per_day | queries_per_day |
|------|-----------------|------------------|------------------------|------------------|
| Free | 30 | 50 | 5 | nil |
| Starter | 30 | nil | nil | 500 |
| Pro | 30 | nil | nil | 10_000 |

## Dependencies

- §0 plans-resolver shipped 2026-05-21.
- §B `usage_meters` table now on main (#185 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)