### PR TITLE
fix(router): wire BumpActivity + AccountDeleted into vault pipeline

### DIFF
--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -186,9 +186,11 @@ defmodule EngramWeb.Router do
     pipe_through [
       :api,
       EngramWeb.Plugs.Auth,
+      EngramWeb.Plugs.AccountDeleted,
       EngramWeb.Plugs.DeviceFingerprint,
       EngramWeb.Plugs.RotationLockCheck,
       EngramWeb.Plugs.RequireOnboarding,
+      EngramWeb.Plugs.BumpActivity,
       EngramWeb.Plugs.VaultPlug
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.161",
+      version: "0.5.162",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/router_pipeline_test.exs
+++ b/test/engram_web/router_pipeline_test.exs
@@ -1,0 +1,50 @@
+defmodule EngramWeb.RouterPipelineTest do
+  @moduledoc """
+  Vault-scoped pipeline wiring smoke tests.
+
+  Closes #194 — guards against regression where §C plugs (BumpActivity +
+  AccountDeleted) were defined but never added to the router pipeline.
+  These tests fail if either plug is removed from the pipeline.
+  """
+  use EngramWeb.ConnCase, async: false
+
+  alias Engram.UsageMeters
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    _vault = insert(:vault, user: user, is_default: true)
+    {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
+    %{conn: authed, user: user}
+  end
+
+  describe "AccountDeleted plug wiring" do
+    test "soft-deleted user gets 410 Gone on a vault-scoped endpoint", %{conn: conn, user: user} do
+      user
+      |> Ecto.Changeset.change(%{deleted_at: DateTime.utc_now()})
+      |> Engram.Repo.update!(skip_tenant_check: true)
+
+      conn = get(conn, "/api/notes/changes")
+
+      assert conn.status == 410
+      assert %{"error" => "account_deleted"} = json_response(conn, 410)
+    end
+
+    test "non-deleted user proceeds past AccountDeleted", %{conn: conn} do
+      conn = get(conn, "/api/notes/changes")
+      # Any status other than 410 proves AccountDeleted didn't halt
+      refute conn.status == 410
+    end
+  end
+
+  describe "BumpActivity plug wiring" do
+    test "stamps last_active_at on first authenticated vault-scoped request",
+         %{conn: conn, user: user} do
+      assert is_nil(UsageMeters.last_active_at(user.id))
+
+      _ = get(conn, "/api/notes/changes")
+
+      assert %DateTime{} = UsageMeters.last_active_at(user.id)
+    end
+  end
+end


### PR DESCRIPTION
**Closes #194 — pricing-v2 launch-blocker.**

## Summary

Both plugs landed in #189 (§C inactivity cleanup) but were never added to the router. Net effect:

- \`usage_meters.last_active_at\` would never be stamped → \`InactivityCleanup\` cron treats every user as inactive → 60-day mass warning emails post pricing-v2 launch.
- Soft-deleted users (\`users.deleted_at\` set) kept hitting \`/api/notes\` etc instead of getting 410 Gone.

## Diff

\`\`\`elixir
# lib/engram_web/router.ex — vault-scoped pipeline
pipe_through [
  :api,
  EngramWeb.Plugs.Auth,
  EngramWeb.Plugs.AccountDeleted,       # NEW — early reject for soft-deleted
  EngramWeb.Plugs.DeviceFingerprint,
  EngramWeb.Plugs.RotationLockCheck,
  EngramWeb.Plugs.RequireOnboarding,
  EngramWeb.Plugs.BumpActivity,         # NEW — stamp last_active_at
  EngramWeb.Plugs.VaultPlug
]
\`\`\`

**Order rationale:**
- \`AccountDeleted\` early — reject before doing any work.
- \`BumpActivity\` after \`RequireOnboarding\` — only stamp fully-onboarded vault traffic (avoids stamping during signup flow that bails out).

## Tests

New \`test/engram_web/router_pipeline_test.exs\` — regression guard so neither plug can go missing again without a test failure. Verifies:

1. Soft-deleted user gets 410 on \`/api/notes/changes\`.
2. Non-deleted user is not blocked by AccountDeleted.
3. First authenticated vault-scoped request stamps \`last_active_at\`.

## Test plan

- [ ] CI green
- [ ] Manual smoke on staging: soft-delete a test user (\`UPDATE users SET deleted_at = now() WHERE id = ...\`), hit \`/api/notes/changes\` with their token → expect 410.
- [ ] Manual smoke: fresh user hits any \`/api\` endpoint → confirm \`usage_meters.last_active_at\` is populated within 1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)