### PR TITLE
feat(billing): pricing v2 §F founder-code one-time redemption flag

### DIFF
--- a/lib/engram/accounts/user.ex
+++ b/lib/engram/accounts/user.ex
@@ -22,6 +22,8 @@ defmodule Engram.Accounts.User do
     field :deleted_at, :utc_datetime_usec
     field :inactivity_warning_60_at, :utc_datetime_usec
     field :inactivity_warning_80_at, :utc_datetime_usec
+    field :founder_code_redeemed_at, :utc_datetime_usec
+    field :og_grandfather_redeemed_at, :utc_datetime_usec
 
     belongs_to :plan, Engram.Billing.Plan
     has_many :notes, Engram.Notes.Note

--- a/lib/engram/billing/founder_codes.ex
+++ b/lib/engram/billing/founder_codes.ex
@@ -1,0 +1,73 @@
+defmodule Engram.Billing.FounderCodes do
+  @moduledoc """
+  Pricing v2 §F — one-time-per-Clerk-identity redemption guard for promotional
+  codes that we don't want chained across churn-and-resubscribe.
+
+  Two codes are tracked:
+
+    - `:founder` — 30%-off-12-months waitlist code. Stamps
+      `users.founder_code_redeemed_at`.
+    - `:og_grandfather` — locks an OG waitlist signup to v1 prices ($5/$10).
+      Stamps `users.og_grandfather_redeemed_at`.
+
+  A returning user (churned + resubscribed) sees v2 prices, not the founder
+  rate — explicit and predictable per the work-order acceptance criteria.
+
+  Multi-account farming via email aliases is closed by §A's normalizer; the
+  per-user flag here closes the second half (alias-replay against the SAME
+  Clerk identity).
+  """
+
+  alias Engram.Accounts.User
+  alias Engram.Repo
+
+  @type code :: :founder | :og_grandfather
+  @type error_reason :: :already_redeemed | :unknown_code
+
+  @doc """
+  Redeems a one-time promotional code for the user.
+
+  Returns `{:ok, %User{}}` with the updated stamp on first redemption,
+  `{:error, :already_redeemed}` on any subsequent attempt, or
+  `{:error, :unknown_code}` for an unrecognized code atom.
+
+  Stamp is set via `Repo.update_all` with a `WHERE field IS NULL` guard so
+  two concurrent redemption attempts can't both succeed — exactly one row
+  updates and the other returns `:already_redeemed`.
+  """
+  @spec redeem(User.t(), code()) :: {:ok, User.t()} | {:error, error_reason()}
+  def redeem(%User{} = user, code) when code in [:founder, :og_grandfather] do
+    field = stamp_field(code)
+    now = DateTime.utc_now()
+
+    {count, _} =
+      Repo.update_all(
+        guard_query(user.id, field),
+        [set: [{field, now}]],
+        skip_tenant_check: true
+      )
+
+    case count do
+      1 -> {:ok, %{user | field => now}}
+      0 -> {:error, :already_redeemed}
+    end
+  end
+
+  def redeem(%User{}, _), do: {:error, :unknown_code}
+
+  @doc """
+  Returns true if the user has already redeemed the given code.
+  """
+  @spec redeemed?(User.t(), code()) :: boolean()
+  def redeemed?(%User{founder_code_redeemed_at: %DateTime{}}, :founder), do: true
+  def redeemed?(%User{og_grandfather_redeemed_at: %DateTime{}}, :og_grandfather), do: true
+  def redeemed?(%User{}, code) when code in [:founder, :og_grandfather], do: false
+
+  defp stamp_field(:founder), do: :founder_code_redeemed_at
+  defp stamp_field(:og_grandfather), do: :og_grandfather_redeemed_at
+
+  defp guard_query(user_id, field) do
+    import Ecto.Query
+    from u in User, where: u.id == ^user_id and is_nil(field(u, ^field))
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.162",
+      version: "0.5.163",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260521080000_add_founder_code_flags_to_users.exs
+++ b/priv/repo/migrations/20260521080000_add_founder_code_flags_to_users.exs
@@ -1,0 +1,13 @@
+defmodule Engram.Repo.Migrations.AddFounderCodeFlagsToUsers do
+  use Ecto.Migration
+
+  # Pricing v2 §F — one-time-per-Clerk-identity founder-code redemption
+  # and OG-waitlist grandfather redemption. Both stamped once, never reset,
+  # so churn-and-resubscribe can't claim either rate twice.
+  def change do
+    alter table(:users) do
+      add :founder_code_redeemed_at, :utc_datetime_usec
+      add :og_grandfather_redeemed_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/engram/billing/founder_codes_test.exs
+++ b/test/engram/billing/founder_codes_test.exs
@@ -1,0 +1,86 @@
+defmodule Engram.Billing.FounderCodesTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Accounts.User
+  alias Engram.Billing.FounderCodes
+  alias Engram.Repo
+
+  describe "redeem/2 — :founder" do
+    test "first call stamps founder_code_redeemed_at" do
+      user = insert(:user)
+
+      assert {:ok, %User{founder_code_redeemed_at: %DateTime{}}} =
+               FounderCodes.redeem(user, :founder)
+
+      reloaded = Repo.get!(User, user.id, skip_tenant_check: true)
+      assert %DateTime{} = reloaded.founder_code_redeemed_at
+    end
+
+    test "second call refuses" do
+      user = insert(:user)
+      {:ok, _} = FounderCodes.redeem(user, :founder)
+
+      assert {:error, :already_redeemed} = FounderCodes.redeem(user, :founder)
+    end
+
+    test "concurrent redemption: exactly one succeeds" do
+      user = insert(:user)
+
+      results =
+        1..10
+        |> Task.async_stream(
+          fn _ -> FounderCodes.redeem(user, :founder) end,
+          max_concurrency: 10
+        )
+        |> Enum.map(fn {:ok, r} -> r end)
+
+      assert Enum.count(results, &match?({:ok, _}, &1)) == 1
+      assert Enum.count(results, &match?({:error, :already_redeemed}, &1)) == 9
+    end
+  end
+
+  describe "redeem/2 — :og_grandfather" do
+    test "first call stamps og_grandfather_redeemed_at" do
+      user = insert(:user)
+
+      assert {:ok, %User{og_grandfather_redeemed_at: %DateTime{}}} =
+               FounderCodes.redeem(user, :og_grandfather)
+    end
+
+    test "second call refuses" do
+      user = insert(:user)
+      {:ok, _} = FounderCodes.redeem(user, :og_grandfather)
+
+      assert {:error, :already_redeemed} = FounderCodes.redeem(user, :og_grandfather)
+    end
+
+    test "founder + og_grandfather are independent" do
+      user = insert(:user)
+      {:ok, _} = FounderCodes.redeem(user, :founder)
+
+      # OG slot still open
+      assert {:ok, _} = FounderCodes.redeem(user, :og_grandfather)
+      # Founder slot still closed
+      assert {:error, :already_redeemed} = FounderCodes.redeem(user, :founder)
+    end
+  end
+
+  describe "redeem/2 — unknown code" do
+    test "returns :unknown_code error" do
+      user = insert(:user)
+      assert {:error, :unknown_code} = FounderCodes.redeem(user, :bogus)
+    end
+  end
+
+  describe "redeemed?/2" do
+    test "reflects stamped state" do
+      user = insert(:user)
+      refute FounderCodes.redeemed?(user, :founder)
+      refute FounderCodes.redeemed?(user, :og_grandfather)
+
+      {:ok, user} = FounderCodes.redeem(user, :founder)
+      assert FounderCodes.redeemed?(user, :founder)
+      refute FounderCodes.redeemed?(user, :og_grandfather)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes pricing-v2 §F from \`docs/superpowers/specs/2026-05-20-pricing-v2-abuse-defenses-work-order.md\`. Without a per-Clerk-identity flag, a user could claim the 30%-off-12-months founder code, churn, resubscribe, and claim it again indefinitely. Same hole exists for the OG-waitlist v1-prices grandfather code.

## What ships

- **Migration** — \`users.founder_code_redeemed_at\` + \`users.og_grandfather_redeemed_at\` (utc_datetime_usec, both NULL).
- **\`Engram.Billing.FounderCodes.redeem(user, :founder | :og_grandfather)\`** — guards via \`UPDATE ... WHERE field IS NULL\`, so two concurrent redemption attempts race-safely (exactly one wins; the other returns \`{:error, :already_redeemed}\`).
- **\`Engram.Billing.FounderCodes.redeemed?/2\`** — convenience predicate.

## Behaviour matrix

| Path | Result |
|------|--------|
| First \`redeem(user, :founder)\` | \`{:ok, user_with_stamp}\` |
| Second \`redeem(user, :founder)\` | \`{:error, :already_redeemed}\` |
| \`redeem(user, :og_grandfather)\` after founder | \`{:ok, user}\` — independent slot |
| \`redeem(user, :bogus)\` | \`{:error, :unknown_code}\` |
| 10 concurrent redemptions on same user | exactly 1 \`:ok\`, 9 \`:already_redeemed\` |

## Acceptance criteria

From the work order:
- [x] User redeems founder code on subscription #1. Cancels. Subscribes again — refused. (\`already_redeemed\` is the runtime answer.)
- [x] User with \`a+x@gmail.com\` redeems. Tries on \`a+y@gmail.com\` — §A normalizer blocks signup first (covered in #184).
- [x] OG-grandfather is a distinct flow with its own one-time flag.

## Test state

- mix format / warnings-as-errors / credo --strict / sobelow all clean (pre-push hook)
- 8 new tests across founder + og_grandfather paths + concurrency race + unknown-code + redeemed? predicate

## Ops follow-up (not code)

- Wire the Paddle promotion-code flow to call \`FounderCodes.redeem/2\` before applying the discount. Concrete integration point depends on whether we expose a pre-checkout endpoint or hook into the existing \`/webhooks/paddle\` handler — to be decided in the Paddle launch runbook (\`docs/context/paddle-v2-launch-runbook.md\`).

## Test plan

- [ ] CI green
- [ ] After merge: confirm migration runs cleanly on staging
- [ ] Smoke: \`Engram.Billing.FounderCodes.redeem(user, :founder)\` twice via iex on a staging user → second returns \`{:error, :already_redeemed}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)