### PR TITLE
feat(abuse): pricing v2 §H attachment MIME / extension whitelist

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -192,6 +192,26 @@ if System.get_env("REALTIME_SYNC_GATE_ENABLED") in ["1", "true"] do
   config :engram, :realtime_sync_gate_enabled, true
 end
 
+# Pricing v2 §H — attachment MIME / extension whitelist self-host knobs.
+# Default: gate is ON. Operators who want to allow executables (e.g.
+# distributing an internal tool from a self-hosted vault) set
+# ATTACHMENT_MIME_BYPASS=true. To extend the allowlist with a couple of
+# extra MIMEs without disabling the gate, use
+# ATTACHMENT_MIME_ALLOWLIST_EXTRA=mime1,mime2.
+if System.get_env("ATTACHMENT_MIME_BYPASS") in ["1", "true"] do
+  config :engram, :attachment_mime_bypass, true
+end
+
+if extras = System.get_env("ATTACHMENT_MIME_ALLOWLIST_EXTRA") do
+  list =
+    extras
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+
+  if list != [], do: config(:engram, :attachment_mime_allowlist_extra, list)
+end
+
 # Paddle billing (Merchant-of-Record). Secret/server keys are required only
 # when actually calling the Paddle API; the public client_token + price_ids
 # are required for the frontend overlay. PADDLE_ENV chooses sandbox vs prod.

--- a/docs/context/attachment-mime-whitelist.md
+++ b/docs/context/attachment-mime-whitelist.md
@@ -1,0 +1,89 @@
+# Attachment MIME / Extension Whitelist (Pricing v2 §H)
+
+Two-phase abuse defense against using Free vault storage as a malware /
+illegal-content cache. Phase 1 ships at pricing v2 launch; Phase 2 is
+deferred but the milestone trigger is documented here.
+
+## Phase 1 — shipped
+
+**Module:** `Engram.Storage.MimeWhitelist`
+**Wired into:** `EngramWeb.AttachmentsController.upload/2`
+**Rejection status:** HTTP 415 with `{"error": "mime_not_allowed", "mime_type": "..."}` or `{"error": "extension_not_allowed", "extension": "..."}`
+
+### What's allowed
+
+- Prefix-allowed: `image/*`, `audio/*`, `video/*`, `text/*`
+- Explicitly allowed: `application/pdf`, `application/json`, Office formats
+  (`.docx` / `.xlsx` / `.pptx` MIMEs + legacy `application/msword`,
+  `application/vnd.ms-excel`, `application/vnd.ms-powerpoint`),
+  OpenDocument formats, `application/rtf`.
+
+### What's blocked
+
+- MIME: `application/octet-stream` (the malware default), `application/zip`,
+  `application/x-msdownload`, `application/x-dosexec`,
+  `application/x-mach-binary`, `application/x-elf`, `application/x-sh`,
+  anything not on the allowlist.
+- Extension (belt-and-braces, applied even when MIME claims something
+  allowlisted): `.exe`, `.dll`, `.com`, `.scr`, `.bat`, `.cmd`, `.vbs`,
+  `.vbe`, `.ps1`, `.psm1`, `.msi`, `.msp`, `.app`, `.dmg`, `.pkg`, `.deb`,
+  `.rpm`, `.apk`, `.ipa`, `.jar`, `.class`, `.sh`, `.bash`, `.zsh`, `.fish`,
+  `.so`, `.dylib`, `.lnk`, `.reg`, `.hta`, `.cpl`, `.gadget`, `.iso`.
+
+### Self-host operator knobs
+
+- `ATTACHMENT_MIME_BYPASS=true` — disables the gate entirely. Use case:
+  internal tool distribution from a self-hosted vault.
+- `ATTACHMENT_MIME_ALLOWLIST_EXTRA=mime1,mime2` — extend the MIME
+  allowlist without bypassing extension checks. Use case: archive-heavy
+  team wants `application/zip` allowed.
+
+Both default off. SaaS (`app.engram.page`) does not set either.
+
+## Phase 2 — deferred
+
+**Trigger:** schedule PhotoDNA / DMCA review when active Free users
+crosses ~500. Below that threshold, the legal-risk surface is small
+enough that Phase 1 + Paddle's MoR ToS coverage is sufficient.
+
+**Tasks at trigger:**
+
+1. Legal counsel review — CSAM scanning carries NCMEC reporting
+   obligations in the US.
+2. Apply to Microsoft PhotoDNA Cloud Service (free for qualifying orgs).
+3. Wire image upload path to PhotoDNA hash check on the way in;
+   maintain a write-side queue if the API is rate-limited.
+4. DMCA response procedure documented + designated agent registered
+   with the US Copyright Office.
+
+**Decision owner:** founder + counsel. Not a launch blocker.
+
+## Why not content sniffing in Phase 1?
+
+The launch gate is intentionally cheap and conservative: extension +
+client-declared MIME, no magic-byte sniffing. A client lying about MIME
+and extension *can* slip a non-allowlisted payload past Phase 1, but the
+attacker's blob also has to be opened by a victim who clicked through —
+which means the extension is what the OS uses, which means our blocklist
+catches it. Phase 2 PhotoDNA addresses the residual image-payload case.
+
+## Operator launch checklist
+
+1. Decide policy for SaaS: gate ON by default. No env vars needed on
+   Fly — module defaults match the SaaS posture.
+2. For self-host docs, add a note to `engram.ax` quick-start docs that
+   `ATTACHMENT_MIME_BYPASS=true` is available for operators who need to
+   distribute executables from their personal vault.
+3. Re-evaluate the deny list quarterly — new RCE-bearing extensions
+   appear (`.lnk` joined recently; `.url` and `.scf` are emerging).
+
+## Test surface
+
+- Unit: `test/engram/storage/mime_whitelist_test.exs` — 20 cases
+  covering prefix allow, explicit allow, MIME reject, extension reject,
+  bypass, operator extras.
+- Controller: `test/engram_web/controllers/attachments_controller_test.exs`
+  — added 3 cases (`.exe` belt-and-braces, `x-msdownload`, unknown
+  extension defaults).
+- E2E: `e2e/tests/api_only/test_70_attachment_mime_whitelist.py` — full
+  API round-trip including PDF accept.

--- a/e2e/helpers/api.py
+++ b/e2e/helpers/api.py
@@ -164,16 +164,19 @@ class ApiClient:
         )
         return resp.status_code
 
-    def upload_attachment(self, path: str, data: bytes) -> int:
+    def upload_attachment(self, path: str, data: bytes, mime_type: str | None = None) -> int:
         """POST /attachments. Returns HTTP status code."""
         import base64
+        payload = {
+            "path": path,
+            "content_base64": base64.b64encode(data).decode(),
+            "mtime": time.time(),
+        }
+        if mime_type is not None:
+            payload["mime_type"] = mime_type
         resp = self.session.post(
             f"{self.base_url}/attachments",
-            json={
-                "path": path,
-                "content_base64": base64.b64encode(data).decode(),
-                "mtime": time.time(),
-            },
+            json=payload,
             timeout=10,
         )
         return resp.status_code

--- a/e2e/tests/api_only/test_40_storage_endpoint.py
+++ b/e2e/tests/api_only/test_40_storage_endpoint.py
@@ -25,10 +25,11 @@ async def test_storage_endpoint(api_sync):
     initial_used = baseline["used_bytes"]
     initial_count = baseline["file_count"]
 
-    # Upload a small attachment
+    # Upload a small attachment. Use .png so the MIME whitelist (pricing-v2
+    # §H) accepts it; this test cares about byte accounting, not MIME.
     data = b"x" * 1024  # 1KB
     status = api_sync.upload_attachment(
-        f"E2E/attachments/storage40-{int(time.time())}.bin",
+        f"E2E/attachments/storage40-{int(time.time())}.png",
         data,
     )
     assert status in (200, 201), f"Upload should succeed, got {status}"

--- a/e2e/tests/api_only/test_70_attachment_mime_whitelist.py
+++ b/e2e/tests/api_only/test_70_attachment_mime_whitelist.py
@@ -1,0 +1,52 @@
+"""Test 70: Pricing v2 §H — MIME / extension whitelist on attachment upload.
+
+API-only. Verifies that the launch-day Phase 1 gate rejects executable
+MIME types and dangerous extensions, while accepting legitimate file
+formats.
+"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_rejects_exe_extension_via_belt_and_braces(api_sync):
+    """Client claims image/png but uploads a .exe — extension gate kicks."""
+    status = api_sync.upload_attachment(
+        "E2E/attachments/trojan.exe",
+        b"MZ\x00\x00",  # PE header bytes, harmless inert
+        mime_type="image/png",
+    )
+    assert status == 415, f"Expected 415 for .exe, got {status}"
+
+
+@pytest.mark.asyncio
+async def test_rejects_dosexec_mime(api_sync):
+    """Explicit application/x-dosexec MIME is rejected even with safe extension."""
+    status = api_sync.upload_attachment(
+        "E2E/attachments/installer",
+        b"\x00" * 64,
+        mime_type="application/x-dosexec",
+    )
+    assert status == 415, f"Expected 415 for x-dosexec, got {status}"
+
+
+@pytest.mark.asyncio
+async def test_rejects_octet_stream_default(api_sync):
+    """Unknown extension → detected as octet-stream → rejected."""
+    status = api_sync.upload_attachment(
+        "E2E/attachments/mystery.xyz",
+        b"opaque",
+    )
+    assert status == 415, f"Expected 415 for unknown .xyz, got {status}"
+
+
+@pytest.mark.asyncio
+async def test_accepts_pdf(api_sync):
+    """Legitimate PDF passes the whitelist."""
+    # Minimal valid PDF header — enough to satisfy size + MIME, not parsed
+    pdf_bytes = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj\n<<>>\nendobj\n%%EOF\n"
+    status = api_sync.upload_attachment(
+        "E2E/attachments/doc70.pdf",
+        pdf_bytes,
+    )
+    assert status in (200, 201), f"Expected 2xx for .pdf, got {status}"

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -16,6 +16,7 @@ defmodule Engram.Attachments do
   alias Engram.Notes.PathSanitizer
   alias Engram.Repo
   alias Engram.Storage
+  alias Engram.Storage.MimeWhitelist
 
   @doc """
   Upserts an attachment. Decodes base64 content, detects MIME type, computes hash.
@@ -317,7 +318,7 @@ defmodule Engram.Attachments do
   end
 
   defp prepare_upload(user, vault, att_id, path, path_hmac, plaintext, mtime, explicit_mime) do
-    mime = explicit_mime || detect_mime(path)
+    mime = explicit_mime || MimeWhitelist.detect_mime(path)
     key = Storage.key(user.id, vault.id, path)
 
     with {:ok, dek} <- Crypto.get_dek(user),
@@ -383,31 +384,6 @@ defmodule Engram.Attachments do
     case Base.decode64(b64) do
       {:ok, binary} -> {:ok, binary}
       :error -> {:error, :invalid_base64}
-    end
-  end
-
-  defp detect_mime(path) do
-    case Path.extname(path) |> String.downcase() do
-      ".png" -> "image/png"
-      ".jpg" -> "image/jpeg"
-      ".jpeg" -> "image/jpeg"
-      ".gif" -> "image/gif"
-      ".webp" -> "image/webp"
-      ".svg" -> "image/svg+xml"
-      ".pdf" -> "application/pdf"
-      ".mp3" -> "audio/mpeg"
-      ".mp4" -> "video/mp4"
-      ".wav" -> "audio/wav"
-      ".txt" -> "text/plain"
-      ".md" -> "text/markdown"
-      ".json" -> "application/json"
-      ".css" -> "text/css"
-      ".js" -> "application/javascript"
-      ".html" -> "text/html"
-      ".zip" -> "application/zip"
-      ".tar" -> "application/x-tar"
-      ".gz" -> "application/gzip"
-      _ -> "application/octet-stream"
     end
   end
 

--- a/lib/engram/storage/mime_whitelist.ex
+++ b/lib/engram/storage/mime_whitelist.ex
@@ -1,0 +1,132 @@
+defmodule Engram.Storage.MimeWhitelist do
+  @moduledoc """
+  Pricing v2 §H Phase 1 — attachment MIME / extension gate.
+
+  Two-layer check on every attachment upload:
+
+    1. MIME allowlist (prefix + explicit set). `application/octet-stream`
+       and `application/zip` are NOT allowed by default — they are common
+       malware delivery vectors and not justified by Obsidian's normal
+       attachment use case (images, audio, video, docs, text).
+    2. Extension blocklist. Belt-and-braces: a client can lie about
+       `mime_type`, but the file's stored extension is what the OS opens.
+       Reject known-executable extensions even if MIME claims `image/png`.
+
+  Self-host operators can bypass entirely (`ATTACHMENT_MIME_BYPASS=true`)
+  or extend the allowlist (`ATTACHMENT_MIME_ALLOWLIST_EXTRA=mime1,mime2`).
+  See `backend/docs/context/paddle-v2-launch-runbook.md` for the deferred
+  Phase 2 (PhotoDNA / DMCA) milestone trigger.
+  """
+
+  @mime_prefixes ~w(image/ audio/ video/ text/)
+
+  @mime_explicit MapSet.new(~w(
+    application/pdf
+    application/json
+    application/msword
+    application/vnd.ms-excel
+    application/vnd.ms-powerpoint
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+    application/vnd.oasis.opendocument.text
+    application/vnd.oasis.opendocument.spreadsheet
+    application/vnd.oasis.opendocument.presentation
+    application/rtf
+  ))
+
+  @blocked_extensions MapSet.new(~w(
+    .exe .dll .com .scr .bat .cmd .vbs .vbe .ps1 .psm1 .msi .msp
+    .app .dmg .pkg .deb .rpm .apk .ipa
+    .jar .class
+    .sh .bash .zsh .fish .so .dylib
+    .lnk .reg .hta .cpl .gadget
+    .iso
+  ))
+
+  @doc """
+  Validates an upload's claimed MIME and filename. Returns:
+
+    * `:ok` — upload may proceed.
+    * `{:error, {:mime_not_allowed, mime}}` — MIME failed the allowlist.
+    * `{:error, {:extension_not_allowed, ext}}` — extension is blocklisted.
+
+  Order: bypass check first, then MIME (cheapest fail-fast), then
+  extension. Extension is the second line of defence specifically to
+  catch a lying client — running it after the MIME pass is correct.
+  """
+  @spec check(String.t() | nil, String.t() | nil) ::
+          :ok
+          | {:error, {:mime_not_allowed, String.t()}}
+          | {:error, {:extension_not_allowed, String.t()}}
+  def check(mime, filename) do
+    cond do
+      bypass?() -> :ok
+      not mime_allowed?(mime) -> {:error, {:mime_not_allowed, mime || ""}}
+      ext = blocked_extension(filename) -> {:error, {:extension_not_allowed, ext}}
+      true -> :ok
+    end
+  end
+
+  defp bypass?, do: Application.get_env(:engram, :attachment_mime_bypass, false) == true
+
+  defp mime_allowed?(nil), do: false
+
+  defp mime_allowed?(mime) when is_binary(mime) do
+    mime = String.downcase(mime)
+
+    Enum.any?(@mime_prefixes, &String.starts_with?(mime, &1)) or
+      MapSet.member?(@mime_explicit, mime) or
+      MapSet.member?(extra_allowlist(), mime)
+  end
+
+  defp extra_allowlist do
+    case Application.get_env(:engram, :attachment_mime_allowlist_extra) do
+      list when is_list(list) -> MapSet.new(Enum.map(list, &String.downcase/1))
+      _ -> MapSet.new()
+    end
+  end
+
+  defp blocked_extension(nil), do: nil
+
+  defp blocked_extension(filename) when is_binary(filename) do
+    ext = filename |> Path.extname() |> String.downcase()
+
+    if MapSet.member?(@blocked_extensions, ext), do: ext, else: nil
+  end
+
+  @doc """
+  Detects MIME type from filename extension. Mirrors the lookup table
+  previously private to `Engram.Attachments`. Returns
+  `application/octet-stream` for unknown extensions — which then fails
+  `check/2` by design (forces client to send an explicit, allowlisted
+  `mime_type` for non-standard files).
+  """
+  @spec detect_mime(String.t() | nil) :: String.t()
+  def detect_mime(nil), do: "application/octet-stream"
+
+  def detect_mime(path) when is_binary(path) do
+    case path |> Path.extname() |> String.downcase() do
+      ".png" -> "image/png"
+      ".jpg" -> "image/jpeg"
+      ".jpeg" -> "image/jpeg"
+      ".gif" -> "image/gif"
+      ".webp" -> "image/webp"
+      ".svg" -> "image/svg+xml"
+      ".pdf" -> "application/pdf"
+      ".mp3" -> "audio/mpeg"
+      ".mp4" -> "video/mp4"
+      ".wav" -> "audio/wav"
+      ".txt" -> "text/plain"
+      ".md" -> "text/markdown"
+      ".json" -> "application/json"
+      ".css" -> "text/css"
+      ".js" -> "application/javascript"
+      ".html" -> "text/html"
+      ".zip" -> "application/zip"
+      ".tar" -> "application/x-tar"
+      ".gz" -> "application/gzip"
+      _ -> "application/octet-stream"
+    end
+  end
+end

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -2,11 +2,32 @@ defmodule EngramWeb.AttachmentsController do
   use EngramWeb, :controller
 
   alias Engram.Attachments
+  alias Engram.Storage.MimeWhitelist
 
   def upload(conn, params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
+    path = params["path"] || params[:path]
+    explicit_mime = params["mime_type"] || params[:mime_type]
+    effective_mime = explicit_mime || MimeWhitelist.detect_mime(path)
 
+    case MimeWhitelist.check(effective_mime, path) do
+      {:error, {:mime_not_allowed, mime}} ->
+        conn
+        |> put_status(415)
+        |> json(%{error: "mime_not_allowed", mime_type: mime})
+
+      {:error, {:extension_not_allowed, ext}} ->
+        conn
+        |> put_status(415)
+        |> json(%{error: "extension_not_allowed", extension: ext})
+
+      :ok ->
+        do_upload(conn, user, vault, params)
+    end
+  end
+
+  defp do_upload(conn, user, vault, params) do
     case Attachments.upsert_attachment(user, vault, params) do
       {:ok, att} ->
         json(conn, %{attachment: serialize_metadata(att)})

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.165",
+      version: "0.5.166",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/storage/mime_whitelist_test.exs
+++ b/test/engram/storage/mime_whitelist_test.exs
@@ -1,0 +1,174 @@
+defmodule Engram.Storage.MimeWhitelistTest do
+  # async: false — toggles :attachment_mime_bypass and
+  # :attachment_mime_allowlist_extra in app env.
+  use ExUnit.Case, async: false
+
+  alias Engram.Storage.MimeWhitelist
+
+  setup do
+    prev_bypass = Application.get_env(:engram, :attachment_mime_bypass)
+    prev_extra = Application.get_env(:engram, :attachment_mime_allowlist_extra)
+
+    on_exit(fn ->
+      restore(:attachment_mime_bypass, prev_bypass)
+      restore(:attachment_mime_allowlist_extra, prev_extra)
+    end)
+
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:engram, key)
+  defp restore(key, value), do: Application.put_env(:engram, key, value)
+
+  describe "check/2 — allow by MIME prefix" do
+    test "allows any image/* type" do
+      assert :ok = MimeWhitelist.check("image/png", "photo.png")
+      assert :ok = MimeWhitelist.check("image/jpeg", "p.jpg")
+      assert :ok = MimeWhitelist.check("image/svg+xml", "p.svg")
+      assert :ok = MimeWhitelist.check("image/webp", "p.webp")
+    end
+
+    test "allows any audio/* type" do
+      assert :ok = MimeWhitelist.check("audio/mpeg", "song.mp3")
+      assert :ok = MimeWhitelist.check("audio/wav", "x.wav")
+    end
+
+    test "allows any video/* type" do
+      assert :ok = MimeWhitelist.check("video/mp4", "clip.mp4")
+      assert :ok = MimeWhitelist.check("video/webm", "x.webm")
+    end
+
+    test "allows any text/* type" do
+      assert :ok = MimeWhitelist.check("text/plain", "a.txt")
+      assert :ok = MimeWhitelist.check("text/markdown", "a.md")
+      assert :ok = MimeWhitelist.check("text/csv", "a.csv")
+    end
+  end
+
+  describe "check/2 — allow by explicit MIME" do
+    test "allows application/pdf" do
+      assert :ok = MimeWhitelist.check("application/pdf", "doc.pdf")
+    end
+
+    test "allows application/json" do
+      assert :ok = MimeWhitelist.check("application/json", "data.json")
+    end
+
+    test "allows Office document MIME types" do
+      assert :ok =
+               MimeWhitelist.check(
+                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                 "doc.docx"
+               )
+
+      assert :ok =
+               MimeWhitelist.check(
+                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                 "sheet.xlsx"
+               )
+
+      assert :ok =
+               MimeWhitelist.check(
+                 "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                 "deck.pptx"
+               )
+
+      assert :ok = MimeWhitelist.check("application/msword", "doc.doc")
+    end
+  end
+
+  describe "check/2 — reject MIME" do
+    test "rejects Windows executable mime types" do
+      assert {:error, {:mime_not_allowed, "application/x-msdownload"}} =
+               MimeWhitelist.check("application/x-msdownload", "tool.bin")
+
+      assert {:error, {:mime_not_allowed, "application/x-dosexec"}} =
+               MimeWhitelist.check("application/x-dosexec", "tool.bin")
+    end
+
+    test "rejects mach-o / ELF binaries" do
+      assert {:error, {:mime_not_allowed, _}} =
+               MimeWhitelist.check("application/x-mach-binary", "tool.bin")
+
+      assert {:error, {:mime_not_allowed, _}} =
+               MimeWhitelist.check("application/x-elf", "tool.bin")
+    end
+
+    test "rejects application/octet-stream by default (unknown/binary catch-all)" do
+      assert {:error, {:mime_not_allowed, "application/octet-stream"}} =
+               MimeWhitelist.check("application/octet-stream", "thing.bin")
+    end
+
+    test "rejects application/zip by default" do
+      assert {:error, {:mime_not_allowed, "application/zip"}} =
+               MimeWhitelist.check("application/zip", "archive.zip")
+    end
+
+    test "rejects shell script MIME types" do
+      assert {:error, {:mime_not_allowed, _}} =
+               MimeWhitelist.check("application/x-sh", "run.sh")
+    end
+  end
+
+  describe "check/2 — extension belt-and-braces" do
+    test "rejects .exe even when MIME claims image/png" do
+      assert {:error, {:extension_not_allowed, ".exe"}} =
+               MimeWhitelist.check("image/png", "trojan.exe")
+    end
+
+    test "rejects .dll, .scr, .bat, .cmd, .com, .vbs, .ps1, .msi" do
+      for ext <- ~w(.dll .scr .bat .cmd .com .vbs .ps1 .msi) do
+        assert {:error, {:extension_not_allowed, ^ext}} =
+                 MimeWhitelist.check("image/png", "f#{ext}"),
+               "expected #{ext} to be rejected"
+      end
+    end
+
+    test "rejects .app, .dmg, .deb, .rpm, .jar, .sh, .so" do
+      for ext <- ~w(.app .dmg .deb .rpm .jar .sh .so) do
+        assert {:error, {:extension_not_allowed, ^ext}} =
+                 MimeWhitelist.check("image/png", "f#{ext}"),
+               "expected #{ext} to be rejected"
+      end
+    end
+
+    test "extension check is case-insensitive" do
+      assert {:error, {:extension_not_allowed, ".exe"}} =
+               MimeWhitelist.check("image/png", "trojan.EXE")
+    end
+  end
+
+  describe "check/2 — self-host bypass" do
+    test "ATTACHMENT_MIME_BYPASS=true short-circuits all checks" do
+      Application.put_env(:engram, :attachment_mime_bypass, true)
+
+      assert :ok = MimeWhitelist.check("application/x-msdownload", "tool.exe")
+      assert :ok = MimeWhitelist.check("application/octet-stream", "anything.xyz")
+    end
+
+    test "bypass disabled by default" do
+      Application.delete_env(:engram, :attachment_mime_bypass)
+
+      assert {:error, _} = MimeWhitelist.check("application/x-msdownload", "tool.bin")
+    end
+  end
+
+  describe "check/2 — operator extra allowlist" do
+    test "ATTACHMENT_MIME_ALLOWLIST_EXTRA permits additional MIMEs" do
+      Application.put_env(:engram, :attachment_mime_allowlist_extra, [
+        "application/zip",
+        "application/x-tar"
+      ])
+
+      assert :ok = MimeWhitelist.check("application/zip", "archive.zip")
+      assert :ok = MimeWhitelist.check("application/x-tar", "archive.tar")
+    end
+
+    test "extras do not unblock dangerous extensions" do
+      Application.put_env(:engram, :attachment_mime_allowlist_extra, ["application/x-msdownload"])
+
+      assert {:error, {:extension_not_allowed, ".exe"}} =
+               MimeWhitelist.check("application/x-msdownload", "tool.exe")
+    end
+  end
+end

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -52,7 +52,9 @@ defmodule EngramWeb.AttachmentsControllerTest do
       assert att["mime_type"] == "application/pdf"
     end
 
-    test "defaults to application/octet-stream for unknown extension", %{conn: conn} do
+    test "rejects unknown extension with 415 (defaults to non-allowlisted octet-stream)", %{
+      conn: conn
+    } do
       conn =
         post(conn, "/api/attachments", %{
           path: "files/data.xyz",
@@ -60,8 +62,39 @@ defmodule EngramWeb.AttachmentsControllerTest do
           mtime: 1_000.0
         })
 
-      assert %{"attachment" => att} = json_response(conn, 200)
-      assert att["mime_type"] == "application/octet-stream"
+      assert json_response(conn, 415) == %{
+               "error" => "mime_not_allowed",
+               "mime_type" => "application/octet-stream"
+             }
+    end
+
+    test "rejects .exe extension even with whitelisted MIME claim (belt-and-braces)", %{
+      conn: conn
+    } do
+      conn =
+        post(conn, "/api/attachments", %{
+          path: "tools/trojan.exe",
+          content_base64: @sample_base64,
+          mime_type: "image/png",
+          mtime: 1_000.0
+        })
+
+      assert json_response(conn, 415) == %{
+               "error" => "extension_not_allowed",
+               "extension" => ".exe"
+             }
+    end
+
+    test "rejects application/x-msdownload MIME", %{conn: conn} do
+      conn =
+        post(conn, "/api/attachments", %{
+          path: "tools/installer",
+          content_base64: @sample_base64,
+          mime_type: "application/x-msdownload",
+          mtime: 1_000.0
+        })
+
+      assert %{"error" => "mime_not_allowed"} = json_response(conn, 415)
     end
 
     test "allows explicit MIME type override", %{conn: conn} do
@@ -135,7 +168,8 @@ defmodule EngramWeb.AttachmentsControllerTest do
 
       conn =
         post(conn, "/api/attachments", %{
-          path: "huge.bin",
+          # png so MIME whitelist passes; size limit is the gate under test
+          path: "huge.png",
           content_base64: huge,
           mtime: 1_000.0
         })


### PR DESCRIPTION
## Summary

Closes the last backend launch-gate box for pricing v2 abuse defenses. Two-layer check on every attachment upload to keep Free vault storage from becoming a malware / illegal-content cache.

- MIME allowlist (prefix-based for `image/* audio/* video/* text/*` + explicit set for PDF / JSON / Office). `application/octet-stream` and `application/zip` are NOT allowed by default.
- Extension blocklist (belt-and-braces): rejects `.exe .dll .scr .bat .ps1 .msi .app .dmg .jar .sh .so .lnk …` even when MIME claims `image/png`.
- Rejection: HTTP 415 with `{"error": "mime_not_allowed" | "extension_not_allowed", ...}`.

## Self-host operator knobs

- `ATTACHMENT_MIME_BYPASS=true` — disable entirely (internal-tool distribution).
- `ATTACHMENT_MIME_ALLOWLIST_EXTRA=mime1,mime2` — extend without bypassing.

SaaS uses defaults; no env required.

## Phase 2 trigger

PhotoDNA + DMCA deferred until ~500 active Free users. Documented in `backend/docs/context/attachment-mime-whitelist.md`.

## Test plan

- [x] `mix test test/engram/storage/mime_whitelist_test.exs` — 20 unit tests (prefix allow, explicit allow, MIME reject, extension reject, bypass, extras)
- [x] `mix test test/engram_web/controllers/attachments_controller_test.exs` — 3 new controller cases (`.exe` belt-and-braces, `x-msdownload` MIME, unknown extension); existing huge-file test re-pathed to `.png`
- [x] `e2e/tests/api_only/test_70_attachment_mime_whitelist.py` — full API round-trip including PDF accept
- [x] `e2e/tests/api_only/test_40_storage_endpoint.py` re-pathed to `.png` (was `.bin`)
- [x] `mix test` full suite — 1437 tests, 0 failures, 7 skipped
- [x] `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer`, `mix sobelow` all clean
- [x] `mix engram.lint.limit_keys` + `mix engram.lint.no_client_only_rate_limits` — 0 violations

## Closes

Pricing v2 §H — work order at `engram-workspace/docs/superpowers/specs/2026-05-20-pricing-v2-abuse-defenses-work-order.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)