### PR TITLE
feat(billing): pricing v2 §G reranker_enabled per-plan gate

### DIFF
--- a/docs/context/pricing-v2-server-side-enforcement-audit.md
+++ b/docs/context/pricing-v2-server-side-enforcement-audit.md
@@ -20,7 +20,7 @@ Closes pricing-v2 §G's audit criterion: walk every `LimitKeys` catalog key and 
 | `ai_queries_per_conversation` | 50 | `Engram.ConversationMeter.maybe_rotate_conversation/3` |
 | `ai_queries_per_day` | nil (Free unmetered via conv cap) | `Engram.ConversationMeter.query_day_cap_exceeded?/2` |
 | `conversation_window_minutes` | 30 | `Engram.ConversationMeter.maybe_rotate_conversation/3` |
-| `reranker_enabled` | false | ⏳ opt-out (`SearchController` needs reranker-path gate) |
+| `reranker_enabled` | false | `Engram.Search.do_search/4` — per-user check via `Billing.check_feature/2`; Free/Starter route through `Engram.Rerankers.None` even when Jina is globally configured |
 | `api_write_enabled` | false | ⏳ opt-out (write controllers need plan gate) |
 | `api_rps_cap` | 0 | ⏳ opt-out (RateLimit plug should pull per-plan cap) |
 | `inactivity_warn_60_days` | true | ⏳ opt-out — `InactivityCleanup` cron uses `Billing.tier/1` rather than reading the key directly |
@@ -36,7 +36,7 @@ The lint task allows a catalog key to skip server-side enforcement IFF it is lis
 
 Each ⏳ opt-out above is a follow-up PR. Suggested order, smallest-first:
 
-1. **`reranker_enabled`** — search controller adds a single guard before invoking the reranker. ~10 LOC.
+1. ~~**`reranker_enabled`**~~ — ✅ SHIPPED (see audit table above). `Engram.Search.reranker_active_for?/1` gates per-user via `Billing.check_feature/2`.
 2. **`api_write_enabled`** — flag check in the existing API key auth path. ~15 LOC.
 3. **`api_rps_cap`** — `EngramWeb.Plugs.RateLimit` reads per-plan cap from `LimitKeys` instead of a hardcoded ceiling. ~30 LOC.
 4. **`max_file_bytes`** — `AttachmentController.create/2` checks `byte_size(file)` against the per-plan cap. ~10 LOC.

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -20,6 +20,15 @@ defmodule Engram.Search do
 
   defp reranker_active?, do: reranker() != Engram.Rerankers.None
 
+  # Pricing-v2 §G — rerank is a Pro-only feature. Even when an operator
+  # has globally configured Jina, Free + Starter users get the passthrough
+  # path (no extra candidate fetch, no Jina HTTP call). This is the
+  # server-side enforcement that lets the lint task remove
+  # `reranker_enabled` from its `@opt_outs`.
+  defp reranker_active_for?(user) do
+    reranker_active?() and Engram.Billing.check_feature(user, :reranker_enabled) == :ok
+  end
+
   defp query_embed_model, do: Application.get_env(:engram, :query_embed_model)
 
   defp embed_for_search(query) do
@@ -60,8 +69,9 @@ defmodule Engram.Search do
     tags = Keyword.get(opts, :tags)
     folder = Keyword.get(opts, :folder)
 
-    # Fetch more candidates when reranking is active
-    fetch_limit = if reranker_active?(), do: max(limit * 4, @min_candidates), else: limit
+    # Fetch more candidates when reranking is active for THIS user (per-plan).
+    rerank_for_user? = reranker_active_for?(user)
+    fetch_limit = if rerank_for_user?, do: max(limit * 4, @min_candidates), else: limit
 
     case translate_phase_b_filters(user, folder, tags) do
       {:ok, phase_b_kw} ->
@@ -80,7 +90,8 @@ defmodule Engram.Search do
                    vaults_by_id,
                    collection()
                  ) do
-            reranker().rerank(query, decrypted, limit)
+            rerank_module = if rerank_for_user?, do: reranker(), else: Engram.Rerankers.None
+            rerank_module.rerank(query, decrypted, limit)
           end
         end
 

--- a/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
+++ b/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
@@ -49,9 +49,7 @@ defmodule Mix.Tasks.Engram.Lint.NoClientOnlyRateLimits do
     concurrent_devices: "TODO follow-up: DeviceAuthController needs per-user device count check",
     device_swap_cooldown_hours:
       "TODO follow-up: DeviceAuthController needs cooldown check on revoke + re-add",
-    # Feature flags — TODO follow-up. Search controller must reject reranker
-    # request when Free; API write controllers must reject write when Free.
-    reranker_enabled: "TODO follow-up: SearchController must gate reranker path on this flag",
+    # Feature flag — API write controllers must reject write when Free.
     api_write_enabled: "TODO follow-up: write controllers must gate on this flag",
     # API RPS cap — TODO follow-up. RateLimit plug currently uses a flat
     # per-user ceiling; should pull api_rps_cap per-plan.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.166",
+      version: "0.5.167",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/search_test.exs
+++ b/test/engram/search_test.exs
@@ -179,6 +179,13 @@ defmodule Engram.SearchTest do
       Application.put_env(:engram, :reranker, Engram.Rerankers.Jina)
       Application.put_env(:engram, :jina_url, "http://localhost:#{jina_bypass.port}")
 
+      # Grant reranker_enabled — pricing-v2 §G now gates rerank per-plan.
+      insert(:user_limit_override,
+        user: user,
+        key: "reranker_enabled",
+        value: %{"v" => true}
+      )
+
       on_exit(fn ->
         Application.put_env(:engram, :reranker, Engram.Rerankers.None)
         Application.delete_env(:engram, :jina_url)
@@ -248,6 +255,72 @@ defmodule Engram.SearchTest do
       assert length(results) == 2
       # Result 3 should be first (highest reranker score)
       assert hd(results).source_path == "test/note3.md"
+    end
+
+    test "skips rerank for Free user even when reranker is globally configured (§G)",
+         %{bypass: bypass, user: user, vault: vault} do
+      # Globally configure a Jina reranker — but DO NOT grant the user the
+      # reranker_enabled feature flag. Pricing-v2 §G demands per-plan gating
+      # on the server, not just client-side opt-in.
+      jina_bypass = Bypass.open()
+      Application.put_env(:engram, :reranker, Engram.Rerankers.Jina)
+      Application.put_env(:engram, :jina_url, "http://localhost:#{jina_bypass.port}")
+
+      on_exit(fn ->
+        Application.put_env(:engram, :reranker, Engram.Rerankers.None)
+        Application.delete_env(:engram, :jina_url)
+      end)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      # Free user → reranker_enabled=false → fetch_limit should equal the
+      # requested limit (2), NOT 4× / @min_candidates. Verifies that Qdrant
+      # isn't being asked for the rerank-sized candidate set.
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+        assert decoded["limit"] == 2
+
+        qid = "uuid-free"
+
+        {:ok, enc} =
+          Engram.Crypto.encrypt_qdrant_payload(
+            %{text: "Plain", title: "Plain", heading_path: "Plain"},
+            user,
+            "engram_notes",
+            qid
+          )
+
+        result = %{
+          "id" => qid,
+          "score" => 0.5,
+          "payload" => %{
+            "text" => enc.text,
+            "title" => enc.title,
+            "heading_path" => enc.heading_path,
+            "text_nonce" => enc.text_nonce,
+            "title_nonce" => enc.title_nonce,
+            "heading_path_nonce" => enc.heading_path_nonce,
+            "aad_version" => enc.aad_version,
+            "source_path" => "test/free.md",
+            "tags" => [],
+            "user_id" => to_string(user.id),
+            "vault_id" => to_string(vault.id)
+          }
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"result" => [result]}))
+      end)
+
+      # Jina MUST NOT be called for a Free user — Bypass.expect_once would
+      # fail if the bypass receives a request; here we use Bypass.stub with
+      # no expectation, and the test inherently fails Mox/Bypass if Jina is
+      # hit (jina_bypass has no expect set up).
+      assert {:ok, [result]} = Search.search(user, vault, "test query", limit: 2)
+      assert result.source_path == "test/free.md"
     end
 
     test "uses query embed model when configured", %{bypass: bypass, user: user, vault: vault} do


### PR DESCRIPTION
## Summary

First of the 9 pricing-v2 §G follow-up opt-outs. Removes `reranker_enabled` from `Mix.Tasks.Engram.Lint.NoClientOnlyRateLimits.@opt_outs` by wiring an actual server-side enforcement site.

`Engram.Search.do_search/4` now ANDs the global `:reranker` config with `Billing.check_feature(user, :reranker_enabled)`. Free + Starter users always route through `Engram.Rerankers.None` — no candidate amplification, no Jina HTTP call.

## Why

Without this gate, an operator who configured Jina globally would pay Jina costs for every Free user query. Pricing v2 §G demands per-plan server enforcement, not just client-side opt-in.

## Test plan

- [x] New `Engram.SearchTest` case "skips rerank for Free user even when reranker is globally configured" — asserts Qdrant `limit == requested` (not 4×) and Jina bypass never called.
- [x] Existing "fetches 4x candidates when reranker is configured" test gets a `user_limit_override(reranker_enabled=true)` to represent the Pro grant.
- [x] `mix engram.lint.no_client_only_rate_limits` — green with 1 fewer opt-out.
- [x] Full suite — 1438 tests, 0 failures.

## Closes

1 of 9 §G opt-out follow-ups from `backend/docs/context/pricing-v2-server-side-enforcement-audit.md`. Audit table updated to mark the row ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)