### PR TITLE
feat(billing): pricing v2 §G api_write_enabled per-plan gate

### DIFF
--- a/docs/context/pricing-v2-server-side-enforcement-audit.md
+++ b/docs/context/pricing-v2-server-side-enforcement-audit.md
@@ -21,7 +21,7 @@ Closes pricing-v2 §G's audit criterion: walk every `LimitKeys` catalog key and 
 | `ai_queries_per_day` | nil (Free unmetered via conv cap) | `Engram.ConversationMeter.query_day_cap_exceeded?/2` |
 | `conversation_window_minutes` | 30 | `Engram.ConversationMeter.maybe_rotate_conversation/3` |
 | `reranker_enabled` | false | `Engram.Search.do_search/4` — per-user check via `Billing.check_feature/2`; Free/Starter route through `Engram.Rerankers.None` even when Jina is globally configured |
-| `api_write_enabled` | false | ⏳ opt-out (write controllers need plan gate) |
+| `api_write_enabled` | false | `EngramWeb.Plugs.RequireApiWriteEnabled` on the vault-scoped pipeline — gates non-GET requests when authed via API key (JWT path exempt). POST `/api/search` exempt as a read-via-POST. 402 with `api_write_not_available` |
 | `api_rps_cap` | 0 | ⏳ opt-out (RateLimit plug should pull per-plan cap) |
 | `inactivity_warn_60_days` | true | ⏳ opt-out — `InactivityCleanup` cron uses `Billing.tier/1` rather than reading the key directly |
 | `inactivity_delete_days` | 90 | ⏳ opt-out — same as above |
@@ -36,8 +36,8 @@ The lint task allows a catalog key to skip server-side enforcement IFF it is lis
 
 Each ⏳ opt-out above is a follow-up PR. Suggested order, smallest-first:
 
-1. ~~**`reranker_enabled`**~~ — ✅ SHIPPED (see audit table above). `Engram.Search.reranker_active_for?/1` gates per-user via `Billing.check_feature/2`.
-2. **`api_write_enabled`** — flag check in the existing API key auth path. ~15 LOC.
+1. ~~**`reranker_enabled`**~~ — ✅ SHIPPED. `Engram.Search.reranker_active_for?/1` gates per-user via `Billing.check_feature/2`.
+2. ~~**`api_write_enabled`**~~ — ✅ SHIPPED. `EngramWeb.Plugs.RequireApiWriteEnabled` on vault pipeline; API-key-only with JWT exemption + `/api/search` carve-out.
 3. **`api_rps_cap`** — `EngramWeb.Plugs.RateLimit` reads per-plan cap from `LimitKeys` instead of a hardcoded ceiling. ~30 LOC.
 4. **`max_file_bytes`** — `AttachmentController.create/2` checks `byte_size(file)` against the per-plan cap. ~10 LOC.
 5. **`attachment_bytes_cap`** — `AttachmentController.create/2` sums existing per-user attachment bytes and checks the new file against the cap. ~30 LOC, requires a `count_user_attachment_bytes/1` helper.

--- a/lib/engram_web/plugs/require_api_write_enabled.ex
+++ b/lib/engram_web/plugs/require_api_write_enabled.ex
@@ -1,0 +1,54 @@
+defmodule EngramWeb.Plugs.RequireApiWriteEnabled do
+  @moduledoc """
+  Pricing v2 §G — gate non-GET API requests on the user's
+  `api_write_enabled` plan flag, but only when the request was authed via
+  API key. JWT-authed (web app) requests bypass this gate; the web UI is
+  expected to disable write affordances for tiers that lack the feature.
+
+  Free's default is `api_write_enabled = false` — Starter and Pro both
+  default `true`. Rejection: HTTP 402 with
+  `{"error": "api_write_not_available", "upgrade_url": "/billing"}`.
+
+  POST `/api/search` is explicitly exempt: it's a read despite being a
+  POST (encrypted query body). All other non-GET routes on the
+  vault-scoped pipeline are gated.
+  """
+
+  import Plug.Conn
+
+  alias Engram.Billing
+
+  @read_post_paths ~w(/api/search)
+
+  def init(opts), do: opts
+
+  # Reads are never gated.
+  def call(%Plug.Conn{method: m} = conn, _opts) when m in ["GET", "HEAD"], do: conn
+
+  # JWT-authed (no API key resolved) → web app path → exempt.
+  def call(%Plug.Conn{assigns: assigns} = conn, _opts)
+      when not is_map_key(assigns, :current_api_key) do
+    conn
+  end
+
+  def call(%Plug.Conn{request_path: path} = conn, _opts) when path in @read_post_paths, do: conn
+
+  def call(%Plug.Conn{assigns: %{current_user: user}} = conn, _opts) do
+    case Billing.check_feature(user, :api_write_enabled) do
+      :ok ->
+        conn
+
+      _ ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(
+          402,
+          Jason.encode!(%{
+            error: "api_write_not_available",
+            upgrade_url: "/billing"
+          })
+        )
+        |> halt()
+    end
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -191,6 +191,7 @@ defmodule EngramWeb.Router do
       EngramWeb.Plugs.RotationLockCheck,
       EngramWeb.Plugs.RequireOnboarding,
       EngramWeb.Plugs.BumpActivity,
+      EngramWeb.Plugs.RequireApiWriteEnabled,
       EngramWeb.Plugs.VaultPlug
     ]
 

--- a/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
+++ b/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
@@ -49,8 +49,6 @@ defmodule Mix.Tasks.Engram.Lint.NoClientOnlyRateLimits do
     concurrent_devices: "TODO follow-up: DeviceAuthController needs per-user device count check",
     device_swap_cooldown_hours:
       "TODO follow-up: DeviceAuthController needs cooldown check on revoke + re-add",
-    # Feature flag — API write controllers must reject write when Free.
-    api_write_enabled: "TODO follow-up: write controllers must gate on this flag",
     # API RPS cap — TODO follow-up. RateLimit plug currently uses a flat
     # per-user ceiling; should pull api_rps_cap per-plan.
     api_rps_cap: "TODO follow-up: RateLimit plug should pull per-plan cap from LimitKeys"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.167",
+      version: "0.5.168",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -15,6 +15,7 @@ defmodule EngramWeb.AttachmentsControllerTest do
     user = insert(:user)
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
     %{conn: authed, user: user}
   end
@@ -345,6 +346,7 @@ defmodule EngramWeb.AttachmentsControllerTest do
       user_b = insert(:user)
       insert(:vault, user: user_b, is_default: true)
       {:ok, api_key_b, _} = Engram.Accounts.create_api_key(user_b, "b-key")
+      grant_api_write!(user_b)
 
       conn_b =
         build_conn()
@@ -365,6 +367,7 @@ defmodule EngramWeb.AttachmentsControllerTest do
       user_b = insert(:user)
       insert(:vault, user: user_b, is_default: true)
       {:ok, api_key_b, _} = Engram.Accounts.create_api_key(user_b, "b-key")
+      grant_api_write!(user_b)
 
       conn_b =
         build_conn()

--- a/test/engram_web/controllers/logs_controller_test.exs
+++ b/test/engram_web/controllers/logs_controller_test.exs
@@ -5,6 +5,7 @@ defmodule EngramWeb.LogsControllerTest do
     user = insert(:user)
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
     %{conn: authed, user: user}
   end
@@ -156,6 +157,7 @@ defmodule EngramWeb.LogsControllerTest do
       user_b = insert(:user)
       insert(:vault, user: user_b, is_default: true)
       {:ok, api_key_b, _} = Engram.Accounts.create_api_key(user_b, "b-key")
+      grant_api_write!(user_b)
 
       conn_b =
         build_conn()

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -12,6 +12,7 @@ defmodule EngramWeb.McpControllerTest do
     # decrypts back to "Test Vault" — not random factory bytes.
     {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test Vault"})
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
 
     # Seed some notes for read tool tests
@@ -548,6 +549,7 @@ defmodule EngramWeb.McpControllerTest do
       {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Vault B"})
 
       {:ok, api_key, api_key_record} = Engram.Accounts.create_api_key(user, "restricted-key")
+      grant_api_write!(user)
 
       # Restrict key to vault_a only
       Engram.Repo.insert_all("api_key_vaults", [

--- a/test/engram_web/controllers/missing_features_test.exs
+++ b/test/engram_web/controllers/missing_features_test.exs
@@ -9,6 +9,7 @@ defmodule EngramWeb.MissingFeaturesTest do
     user = insert(:user)
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
     %{conn: authed, user: user}
   end

--- a/test/engram_web/controllers/multi_tenant_test.exs
+++ b/test/engram_web/controllers/multi_tenant_test.exs
@@ -10,7 +10,9 @@ defmodule EngramWeb.MultiTenantTest do
     insert(:vault, user: user1, is_default: true)
     insert(:vault, user: user2, is_default: true)
     {:ok, key1, _} = Engram.Accounts.create_api_key(user1, "user1-key")
+    grant_api_write!(user1)
     {:ok, key2, _} = Engram.Accounts.create_api_key(user2, "user2-key")
+    grant_api_write!(user2)
 
     conn1 = put_req_header(conn, "authorization", "Bearer #{key1}")
     conn2 = put_req_header(conn, "authorization", "Bearer #{key2}")

--- a/test/engram_web/controllers/notes_controller_test.exs
+++ b/test/engram_web/controllers/notes_controller_test.exs
@@ -5,6 +5,7 @@ defmodule EngramWeb.NotesControllerTest do
     user = insert(:user)
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
     %{conn: authed, user: user}
   end

--- a/test/engram_web/controllers/notes_edge_cases_test.exs
+++ b/test/engram_web/controllers/notes_edge_cases_test.exs
@@ -8,6 +8,7 @@ defmodule EngramWeb.NotesEdgeCasesTest do
     user = insert(:user)
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
     %{conn: authed, user: user}
   end

--- a/test/engram_web/controllers/storage_controller_test.exs
+++ b/test/engram_web/controllers/storage_controller_test.exs
@@ -5,6 +5,7 @@ defmodule EngramWeb.StorageControllerTest do
     user = insert(:user)
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
     %{conn: authed, user: user}
   end

--- a/test/engram_web/controllers/sync_controller_test.exs
+++ b/test/engram_web/controllers/sync_controller_test.exs
@@ -5,6 +5,7 @@ defmodule EngramWeb.SyncControllerTest do
     user = insert(:user)
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
     %{conn: authed, user: user}
   end

--- a/test/engram_web/controllers/tags_folders_controller_test.exs
+++ b/test/engram_web/controllers/tags_folders_controller_test.exs
@@ -5,6 +5,7 @@ defmodule EngramWeb.TagsFoldersControllerTest do
     user = insert(:user)
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
     %{conn: authed, user: user}
   end

--- a/test/engram_web/onboarding_gate_integration_test.exs
+++ b/test/engram_web/onboarding_gate_integration_test.exs
@@ -17,6 +17,7 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
     user = insert_user()
     _vault = insert(:vault, user: user, is_default: true)
     {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
+    grant_api_write!(user)
     conn = put_req_header(conn, "authorization", "Bearer #{raw_key}")
     {:ok, conn: conn, user: user}
   end

--- a/test/engram_web/plugs/require_api_write_enabled_test.exs
+++ b/test/engram_web/plugs/require_api_write_enabled_test.exs
@@ -1,0 +1,145 @@
+defmodule EngramWeb.Plugs.RequireApiWriteEnabledTest do
+  # async: false — flips Application env :limits_enforced inside one branch.
+  use EngramWeb.ConnCase, async: false
+
+  alias EngramWeb.Plugs.RequireApiWriteEnabled
+
+  setup do
+    user = insert(:user)
+    api_key = %Engram.Accounts.ApiKey{id: 1, user_id: user.id, name: "test"}
+    %{user: user, api_key: api_key}
+  end
+
+  describe "GET / HEAD (read paths)" do
+    test "passes through GET without auth check", %{conn: conn, user: user, api_key: api_key} do
+      conn =
+        conn
+        |> Map.put(:method, "GET")
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiWriteEnabled.call([])
+
+      refute conn.halted
+    end
+
+    test "passes through HEAD without auth check", %{conn: conn, user: user, api_key: api_key} do
+      conn =
+        conn
+        |> Map.put(:method, "HEAD")
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiWriteEnabled.call([])
+
+      refute conn.halted
+    end
+  end
+
+  describe "JWT-authed (no current_api_key) writes" do
+    test "passes through — web app is exempt from this gate", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/notes")
+        |> assign(:current_user, user)
+        |> RequireApiWriteEnabled.call([])
+
+      refute conn.halted
+    end
+  end
+
+  describe "API-key-authed writes — Free user (api_write_enabled=false)" do
+    test "halts 402 on POST /api/notes", %{conn: conn, user: user, api_key: api_key} do
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/notes")
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiWriteEnabled.call([])
+
+      assert conn.halted
+      assert conn.status == 402
+      body = Phoenix.ConnTest.json_response(conn, 402)
+      assert body["error"] == "api_write_not_available"
+      assert body["upgrade_url"] == "/billing"
+    end
+
+    test "halts 402 on DELETE /api/notes/foo", %{conn: conn, user: user, api_key: api_key} do
+      conn =
+        conn
+        |> Map.put(:method, "DELETE")
+        |> Map.put(:request_path, "/api/notes/foo")
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiWriteEnabled.call([])
+
+      assert conn.halted
+      assert conn.status == 402
+    end
+
+    test "halts 402 on POST /api/attachments", %{conn: conn, user: user, api_key: api_key} do
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/attachments")
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiWriteEnabled.call([])
+
+      assert conn.halted
+      assert conn.status == 402
+    end
+
+    test "passes through POST /api/search (read-via-POST exemption)",
+         %{conn: conn, user: user, api_key: api_key} do
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/search")
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiWriteEnabled.call([])
+
+      refute conn.halted
+    end
+  end
+
+  describe "API-key-authed writes — Starter / Pro user (api_write_enabled=true)" do
+    test "passes through when override grants the feature",
+         %{conn: conn, user: user, api_key: api_key} do
+      insert(:user_limit_override,
+        user: user,
+        key: "api_write_enabled",
+        value: %{"v" => true}
+      )
+
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/notes")
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiWriteEnabled.call([])
+
+      refute conn.halted
+    end
+  end
+
+  describe "self-host bypass" do
+    test "passes through when limits_enforced=false (Paddle key unset)",
+         %{conn: conn, user: user, api_key: api_key} do
+      Application.put_env(:engram, :limits_enforced, false)
+      on_exit(fn -> Application.put_env(:engram, :limits_enforced, true) end)
+
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/notes")
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiWriteEnabled.call([])
+
+      refute conn.halted
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -36,4 +36,23 @@ defmodule EngramWeb.ConnCase do
     Engram.DataCase.setup_sandbox(tags)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
+
+  @doc """
+  Grants the user the `api_write_enabled` feature via a
+  `user_limit_overrides` row. Use in setup blocks for tests that exercise
+  API-key write paths — pricing v2 §G gates non-GET requests on this flag
+  when the request is authed via API key, so any test minting a key for a
+  write-side controller must represent a paid user.
+
+  Returns `user` unchanged for pipe-friendliness.
+  """
+  def grant_api_write!(%Engram.Accounts.User{} = user) do
+    Engram.Factory.insert(:user_limit_override,
+      user: user,
+      key: "api_write_enabled",
+      value: %{"v" => true}
+    )
+
+    user
+  end
 end


### PR DESCRIPTION
## Summary

Second §G follow-up opt-out. Wires server-side enforcement for the `api_write_enabled` plan flag.

New `EngramWeb.Plugs.RequireApiWriteEnabled` runs on the vault-scoped pipeline. Rejects non-GET requests with **402 `api_write_not_available`** when:

- request was authed via API key (JWT path is exempt — web app handles tier UX in the UI)
- AND path is not `/api/search` (read-via-POST exemption)
- AND `Billing.check_feature(user, :api_write_enabled) != :ok`

Free defaults `api_write_enabled = false`; Starter / Pro default `true`. Self-host with `ENGRAM_LIMITS_ENFORCED=false` bypasses transparently.

## Why API key path only

Per pricing-v2 design §4.3, the API write gate is specifically about the API surface (plugin + MCP + scripts). The web app receives full UX based on plan via UI affordances, not server rejection — that's the JWT exemption.

## Test plan

- [x] New `RequireApiWriteEnabledTest` — 9 cases (read passthrough, JWT exemption, search carve-out, 402 on Free POST/DELETE, override grant, self-host bypass)
- [x] `EngramWeb.ConnCase.grant_api_write!/1` helper added; bulk-inserted into 11 existing controller test files that mint API keys for write-side tests
- [x] `mix engram.lint.no_client_only_rate_limits` green with 1 fewer opt-out
- [x] Full suite — 1446 passing, 0 regressions; 1 pre-existing flake (`Engram.VaultsTest` §J vault_count telemetry race — passes in isolation, race between concurrent test processes' telemetry handlers, not introduced by this PR)

## Closes

1 of 8 remaining §G opt-out follow-ups from `backend/docs/context/pricing-v2-server-side-enforcement-audit.md`. After merge: 5 left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)