### PR TITLE
feat(billing): pricing v2 §G api_rps_cap per-plan gate

### DIFF
--- a/docs/context/pricing-v2-server-side-enforcement-audit.md
+++ b/docs/context/pricing-v2-server-side-enforcement-audit.md
@@ -22,7 +22,7 @@ Closes pricing-v2 §G's audit criterion: walk every `LimitKeys` catalog key and 
 | `conversation_window_minutes` | 30 | `Engram.ConversationMeter.maybe_rotate_conversation/3` |
 | `reranker_enabled` | false | `Engram.Search.do_search/4` — per-user check via `Billing.check_feature/2`; Free/Starter route through `Engram.Rerankers.None` even when Jina is globally configured |
 | `api_write_enabled` | false | `EngramWeb.Plugs.RequireApiWriteEnabled` on the vault-scoped pipeline — gates non-GET requests when authed via API key (JWT path exempt). POST `/api/search` exempt as a read-via-POST. 402 with `api_write_not_available` |
-| `api_rps_cap` | 0 | ⏳ opt-out (RateLimit plug should pull per-plan cap) |
+| `api_rps_cap` | 0 | `EngramWeb.Plugs.RequireApiRpsBudget` on user-scoped + vault-scoped pipelines — Hammer-backed, 1-sec window keyed on `api_rps:user_id`. JWT path exempt. 429 with `api_rps_exceeded`. Free=0 → instant 429 |
 | `inactivity_warn_60_days` | true | ⏳ opt-out — `InactivityCleanup` cron uses `Billing.tier/1` rather than reading the key directly |
 | `inactivity_delete_days` | 90 | ⏳ opt-out — same as above |
 | `cross_vault_search` | false | ⏳ opt-out (legacy UX flag) |
@@ -38,7 +38,7 @@ Each ⏳ opt-out above is a follow-up PR. Suggested order, smallest-first:
 
 1. ~~**`reranker_enabled`**~~ — ✅ SHIPPED. `Engram.Search.reranker_active_for?/1` gates per-user via `Billing.check_feature/2`.
 2. ~~**`api_write_enabled`**~~ — ✅ SHIPPED. `EngramWeb.Plugs.RequireApiWriteEnabled` on vault pipeline; API-key-only with JWT exemption + `/api/search` carve-out.
-3. **`api_rps_cap`** — `EngramWeb.Plugs.RateLimit` reads per-plan cap from `LimitKeys` instead of a hardcoded ceiling. ~30 LOC.
+3. ~~**`api_rps_cap`**~~ — ✅ SHIPPED. `EngramWeb.Plugs.RequireApiRpsBudget` on user-scoped + vault-scoped pipelines; API-key-only; Hammer-backed 1-sec window.
 4. **`max_file_bytes`** — `AttachmentController.create/2` checks `byte_size(file)` against the per-plan cap. ~10 LOC.
 5. **`attachment_bytes_cap`** — `AttachmentController.create/2` sums existing per-user attachment bytes and checks the new file against the cap. ~30 LOC, requires a `count_user_attachment_bytes/1` helper.
 6. **`inactivity_warn_60_days` + `inactivity_delete_days`** — migrate `InactivityCleanup` cron to read the catalog so per-user overrides take effect. ~40 LOC.

--- a/lib/engram_web/plugs/require_api_rps_budget.ex
+++ b/lib/engram_web/plugs/require_api_rps_budget.ex
@@ -1,0 +1,61 @@
+defmodule EngramWeb.Plugs.RequireApiRpsBudget do
+  @moduledoc """
+  Pricing v2 §G — per-plan RPS cap on authenticated API requests.
+
+  Looks up the user's `api_rps_cap` from `Engram.Billing` and rate-limits
+  via Hammer with a 1-second window. JWT-authed requests (web app) are
+  exempt; the gate only fires for API-key-authed traffic, mirroring the
+  policy shape in `RequireApiWriteEnabled`.
+
+  Free defaults to `0` (no API access). Starter `10`, Pro `30`. When the
+  cap is exhausted within the window, responds 429 with
+  `{"error": "api_rps_exceeded", "limit": N, "period_ms": 1000}`.
+
+  Self-host with `ENGRAM_LIMITS_ENFORCED=false` short-circuits to
+  `:unlimited` via `Billing.effective_limit/2` — no Hammer call.
+  """
+
+  import Plug.Conn
+
+  alias Engram.Billing
+
+  @period_ms 1_000
+
+  def init(opts), do: opts
+
+  # JWT-authed (no API key) is exempt — web app is not subject to this gate.
+  def call(%Plug.Conn{assigns: assigns} = conn, _opts)
+      when not is_map_key(assigns, :current_api_key),
+      do: conn
+
+  def call(%Plug.Conn{assigns: %{current_user: user}} = conn, _opts) do
+    case Billing.effective_limit(user, :api_rps_cap) do
+      :unlimited -> conn
+      nil -> conn
+      0 -> deny(conn, 0)
+      limit when is_integer(limit) and limit > 0 -> check_hammer(conn, user, limit)
+      _ -> conn
+    end
+  end
+
+  defp check_hammer(conn, user, limit) do
+    case Hammer.check_rate("api_rps:#{user.id}", @period_ms, limit) do
+      {:allow, _count} -> conn
+      {:deny, _limit} -> deny(conn, limit)
+    end
+  end
+
+  defp deny(conn, limit) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(
+      429,
+      Jason.encode!(%{
+        error: "api_rps_exceeded",
+        limit: limit,
+        period_ms: @period_ms
+      })
+    )
+    |> halt()
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -123,7 +123,12 @@ defmodule EngramWeb.Router do
 
   # User-scoped authenticated endpoints (no vault context needed)
   scope "/api", EngramWeb do
-    pipe_through [:api, EngramWeb.Plugs.Auth, EngramWeb.Plugs.RotationLockCheck]
+    pipe_through [
+      :api,
+      EngramWeb.Plugs.Auth,
+      EngramWeb.Plugs.RotationLockCheck,
+      EngramWeb.Plugs.RequireApiRpsBudget
+    ]
 
     # User info
     get "/user/storage", StorageController, :index
@@ -191,6 +196,7 @@ defmodule EngramWeb.Router do
       EngramWeb.Plugs.RotationLockCheck,
       EngramWeb.Plugs.RequireOnboarding,
       EngramWeb.Plugs.BumpActivity,
+      EngramWeb.Plugs.RequireApiRpsBudget,
       EngramWeb.Plugs.RequireApiWriteEnabled,
       EngramWeb.Plugs.VaultPlug
     ]

--- a/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
+++ b/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
@@ -48,10 +48,7 @@ defmodule Mix.Tasks.Engram.Lint.NoClientOnlyRateLimits do
     # vaults_cap; needs explicit concurrent_devices + cooldown checks.
     concurrent_devices: "TODO follow-up: DeviceAuthController needs per-user device count check",
     device_swap_cooldown_hours:
-      "TODO follow-up: DeviceAuthController needs cooldown check on revoke + re-add",
-    # API RPS cap — TODO follow-up. RateLimit plug currently uses a flat
-    # per-user ceiling; should pull api_rps_cap per-plan.
-    api_rps_cap: "TODO follow-up: RateLimit plug should pull per-plan cap from LimitKeys"
+      "TODO follow-up: DeviceAuthController needs cooldown check on revoke + re-add"
   }
 
   # Exposed for the self-scan meta-test in

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.168",
+      version: "0.5.169",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/auth_controller_test.exs
+++ b/test/engram_web/controllers/auth_controller_test.exs
@@ -28,6 +28,7 @@ defmodule EngramWeb.AuthControllerTest do
 
   defp api_key_authed(conn, user) do
     {:ok, raw_key, _} = Engram.Accounts.create_api_key(user, "auth-test-key")
+    grant_api_write!(user)
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
   end
 
@@ -51,11 +52,16 @@ defmodule EngramWeb.AuthControllerTest do
       assert is_integer(id)
     end
 
-    test "created key can authenticate vault-scoped requests", %{conn: conn} do
+    test "created key can authenticate vault-scoped requests", %{conn: conn, user: user} do
       %{"key" => new_key} =
         conn
         |> post("/api/api-keys", %{name: "usable-key"})
         |> json_response(200)
+
+      # Newly-minted API keys for Free users hit api_rps_cap=0 — grant the
+      # paid-tier overrides so this test exercises the auth flow, not the
+      # gate.
+      grant_api_write!(user)
 
       conn2 =
         build_conn()
@@ -89,11 +95,13 @@ defmodule EngramWeb.AuthControllerTest do
       user = insert(:user)
       insert(:vault, user: user, is_default: true)
       {:ok, _raw, _} = Engram.Accounts.create_api_key(user, "setup-key")
+      grant_api_write!(user)
       %{conn: jwt_authed(conn, user), user: user}
     end
 
     test "lists keys belonging to the current user", %{conn: conn, user: user} do
       {:ok, _, _} = Engram.Accounts.create_api_key(user, "second-key")
+      grant_api_write!(user)
 
       conn = get(conn, "/api/api-keys")
       assert %{"keys" => keys} = json_response(conn, 200)
@@ -114,6 +122,7 @@ defmodule EngramWeb.AuthControllerTest do
     test "does not return keys from other users", %{conn: conn} do
       other = insert(:user)
       {:ok, _, _} = Engram.Accounts.create_api_key(other, "other-key")
+      grant_api_write!(other)
 
       conn = get(conn, "/api/api-keys")
       %{"keys" => keys} = json_response(conn, 200)
@@ -145,6 +154,7 @@ defmodule EngramWeb.AuthControllerTest do
       user = insert(:user)
       insert(:vault, user: user, is_default: true)
       {:ok, _raw, target_key} = Engram.Accounts.create_api_key(user, "to-be-revoked")
+      grant_api_write!(user)
       %{conn: jwt_authed(conn, user), user: user, target_key_id: target_key.id}
     end
 

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -6,6 +6,7 @@ defmodule EngramWeb.BillingControllerTest do
   setup %{conn: conn} do
     user = insert(:user)
     {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
+    grant_api_write!(user)
     conn = put_req_header(conn, "authorization", "Bearer #{raw_key}")
     {:ok, conn: conn, user: user}
   end

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -6,6 +6,7 @@ defmodule EngramWeb.DeviceAuthControllerTest do
   defp create_authed_conn(%{conn: conn}) do
     user = insert(:user)
     {:ok, raw_key, _api_key} = Engram.Accounts.create_api_key(user, "test")
+    grant_api_write!(user)
     authed_conn = put_req_header(conn, "authorization", "Bearer #{raw_key}")
 
     %{conn: conn, authed_conn: authed_conn, user: user}

--- a/test/engram_web/controllers/embed_status_controller_test.exs
+++ b/test/engram_web/controllers/embed_status_controller_test.exs
@@ -6,6 +6,7 @@ defmodule EngramWeb.EmbedStatusControllerTest do
       user = insert(:user)
       insert(:vault, user: user, is_default: true)
       {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+      grant_api_write!(user)
       conn = put_req_header(conn, "authorization", "Bearer #{api_key}")
 
       # 2 indexed, 1 pending (nil), 1 stale
@@ -25,6 +26,7 @@ defmodule EngramWeb.EmbedStatusControllerTest do
       user = insert(:user)
       insert(:vault, user: user, is_default: true)
       {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+      grant_api_write!(user)
       conn = put_req_header(conn, "authorization", "Bearer #{api_key}")
 
       insert(:note, user: user, content_hash: "aaa", embed_hash: "aaa")

--- a/test/engram_web/controllers/onboarding_controller_test.exs
+++ b/test/engram_web/controllers/onboarding_controller_test.exs
@@ -16,6 +16,7 @@ defmodule EngramWeb.OnboardingControllerTest do
 
     user = insert(:user)
     {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
+    grant_api_write!(user)
     conn = put_req_header(conn, "authorization", "Bearer #{raw_key}")
     {:ok, conn: conn, user: user}
   end

--- a/test/engram_web/controllers/search_controller_test.exs
+++ b/test/engram_web/controllers/search_controller_test.exs
@@ -11,6 +11,7 @@ defmodule EngramWeb.SearchControllerTest do
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
 
     bypass = Bypass.open()

--- a/test/engram_web/controllers/users_controller_test.exs
+++ b/test/engram_web/controllers/users_controller_test.exs
@@ -5,6 +5,7 @@ defmodule EngramWeb.UsersControllerTest do
     setup %{conn: conn} do
       user = insert(:user)
       {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+      grant_api_write!(user)
       authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
       %{conn: authed, user: user}
     end

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -11,6 +11,7 @@ defmodule EngramWeb.VaultsControllerTest do
     # Give the user unlimited vaults for most tests
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
     {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
+    grant_api_write!(user)
     conn = put_req_header(conn, "authorization", "Bearer #{raw_key}")
     {:ok, conn: conn, user: user}
   end
@@ -68,6 +69,8 @@ defmodule EngramWeb.VaultsControllerTest do
       )
 
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 1})
+      # Re-grant API access after wiping all overrides above.
+      grant_api_write!(user)
 
       {:ok, _} = Vaults.create_vault(user, %{name: "First"})
 
@@ -162,6 +165,8 @@ defmodule EngramWeb.VaultsControllerTest do
       )
 
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 1})
+      # Re-grant API access after wiping all overrides above.
+      grant_api_write!(user)
 
       {:ok, _} = Vaults.create_vault(user, %{name: "First"})
 

--- a/test/engram_web/plugs/require_api_rps_budget_test.exs
+++ b/test/engram_web/plugs/require_api_rps_budget_test.exs
@@ -1,0 +1,131 @@
+defmodule EngramWeb.Plugs.RequireApiRpsBudgetTest do
+  # async: false — Hammer's bucket store is global; tests delete buckets in setup.
+  use EngramWeb.ConnCase, async: false
+
+  alias EngramWeb.Plugs.RequireApiRpsBudget
+
+  setup do
+    user = insert(:user)
+    api_key = %Engram.Accounts.ApiKey{id: 1, user_id: user.id, name: "test"}
+    Hammer.delete_buckets("api_rps:#{user.id}")
+    %{user: user, api_key: api_key}
+  end
+
+  describe "JWT-authed (no current_api_key)" do
+    test "passes through — web app is not subject to API RPS cap", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> RequireApiRpsBudget.call([])
+
+      refute conn.halted
+    end
+  end
+
+  describe "API-key-authed — Free (api_rps_cap=0)" do
+    test "halts 429 immediately on every request", %{conn: conn, user: user, api_key: api_key} do
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiRpsBudget.call([])
+
+      assert conn.halted
+      assert conn.status == 429
+      body = Phoenix.ConnTest.json_response(conn, 429)
+      assert body["error"] == "api_rps_exceeded"
+      assert body["limit"] == 0
+    end
+  end
+
+  describe "API-key-authed — Starter / Pro (positive cap)" do
+    setup %{user: user} do
+      insert(:user_limit_override,
+        user: user,
+        key: "api_rps_cap",
+        value: %{"v" => 3}
+      )
+
+      :ok
+    end
+
+    test "allows requests under the per-second cap", %{conn: conn, user: user, api_key: api_key} do
+      for _ <- 1..3 do
+        c =
+          conn
+          |> assign(:current_user, user)
+          |> assign(:current_api_key, api_key)
+          |> RequireApiRpsBudget.call([])
+
+        refute c.halted
+      end
+    end
+
+    test "halts 429 once cap is exceeded within the same second",
+         %{conn: conn, user: user, api_key: api_key} do
+      for _ <- 1..3 do
+        conn
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiRpsBudget.call([])
+      end
+
+      denied =
+        conn
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiRpsBudget.call([])
+
+      assert denied.halted
+      assert denied.status == 429
+      body = Phoenix.ConnTest.json_response(denied, 429)
+      assert body["error"] == "api_rps_exceeded"
+      assert body["limit"] == 3
+    end
+  end
+
+  describe "self-host bypass" do
+    test "passes through when limits_enforced=false (Paddle key unset)",
+         %{conn: conn, user: user, api_key: api_key} do
+      Application.put_env(:engram, :limits_enforced, false)
+      on_exit(fn -> Application.put_env(:engram, :limits_enforced, true) end)
+
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiRpsBudget.call([])
+
+      refute conn.halted
+    end
+  end
+
+  describe "per-user isolation" do
+    test "user A's budget exhaustion does not affect user B",
+         %{conn: conn, user: user, api_key: api_key} do
+      # Grant a small cap to user A
+      insert(:user_limit_override, user: user, key: "api_rps_cap", value: %{"v" => 2})
+
+      for _ <- 1..3 do
+        conn
+        |> assign(:current_user, user)
+        |> assign(:current_api_key, api_key)
+        |> RequireApiRpsBudget.call([])
+      end
+
+      # User B with a separate cap
+      user_b = insert(:user)
+      insert(:user_limit_override, user: user_b, key: "api_rps_cap", value: %{"v" => 2})
+      api_key_b = %Engram.Accounts.ApiKey{id: 2, user_id: user_b.id, name: "b"}
+      Hammer.delete_buckets("api_rps:#{user_b.id}")
+
+      conn_b =
+        build_conn()
+        |> assign(:current_user, user_b)
+        |> assign(:current_api_key, api_key_b)
+        |> RequireApiRpsBudget.call([])
+
+      refute conn_b.halted
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -38,21 +38,34 @@ defmodule EngramWeb.ConnCase do
   end
 
   @doc """
-  Grants the user the `api_write_enabled` feature via a
-  `user_limit_overrides` row. Use in setup blocks for tests that exercise
-  API-key write paths — pricing v2 §G gates non-GET requests on this flag
-  when the request is authed via API key, so any test minting a key for a
-  write-side controller must represent a paid user.
+  Grants the user paid-tier API access via `user_limit_overrides` rows:
+  `api_write_enabled=true` and a generous `api_rps_cap=1000`. Use in
+  setup blocks for tests that exercise API-key write paths — pricing v2
+  §G gates non-GET requests on the write flag AND every API-key request
+  on the RPS cap when authed via API key, so any test minting a key for
+  controller use must represent a paid user.
 
   Returns `user` unchanged for pipe-friendliness.
   """
   def grant_api_write!(%Engram.Accounts.User{} = user) do
-    Engram.Factory.insert(:user_limit_override,
-      user: user,
-      key: "api_write_enabled",
-      value: %{"v" => true}
-    )
-
+    upsert_override!(user, "api_write_enabled", true)
+    upsert_override!(user, "api_rps_cap", 1_000)
     user
+  end
+
+  # Idempotent insert — the helper may be called multiple times against the
+  # same user when a test exercises more than one `create_api_key` flow.
+  defp upsert_override!(user, key, value) do
+    case Engram.Repo.get_by(Engram.Billing.UserLimitOverride, user_id: user.id, key: key) do
+      nil ->
+        Engram.Factory.insert(:user_limit_override,
+          user: user,
+          key: key,
+          value: %{"v" => value}
+        )
+
+      _existing ->
+        :noop
+    end
   end
 end


### PR DESCRIPTION
## Summary

Third §G follow-up. Wires server-side enforcement for the `api_rps_cap` plan flag.

New `EngramWeb.Plugs.RequireApiRpsBudget` rate-limits authenticated API traffic against per-plan `api_rps_cap` (Free=0 → instant 429, Starter=10/sec, Pro=30/sec). Backed by Hammer with a 1-second window keyed on `api_rps:#{user_id}`.

Mounted on both pipelines that carry `current_user`:
- user-scoped (`/api/me`, `/api/vaults`, `/api/billing/*`, …)
- vault-scoped (`/api/notes`, `/api/attachments`, `/api/search`, …)

JWT-authed requests are exempt — the web app uses the same API but isn't subject to this gate; the policy is about the programmatic surface. Self-host with `ENGRAM_LIMITS_ENFORCED=false` short-circuits via `Billing.effective_limit/2` returning `:unlimited`.

## Test plan

- [x] New `RequireApiRpsBudgetTest` — 6 cases (JWT exempt, Free=0 instant 429, allow-then-deny within window, self-host bypass, per-user isolation)
- [x] `EngramWeb.ConnCase.grant_api_write!/1` extended to also insert `api_rps_cap=1000` and made idempotent (existence pre-check) so it can be safely re-called
- [x] 8 more controller test files received `grant_api_write!(user)` via the same perl one-liner: auth, billing, device_auth, embed_status, onboarding, search, users, vaults
- [x] 3 explicit grant insertions where tests wipe overrides via `delete_all` + reinsert (vaults_controller 402-tests, auth_controller fresh-key test)
- [x] `mix engram.lint.no_client_only_rate_limits` green with 1 fewer opt-out (4 remain)
- [x] Full suite — 1453 tests, 0 failures

## Closes

1 of 7 §G opt-out follow-ups from `backend/docs/context/pricing-v2-server-side-enforcement-audit.md`. After merge: 4 left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)