### PR TITLE
feat(billing): pricing v2 §G max_file_bytes per-plan gate

### DIFF
--- a/docs/context/pricing-v2-server-side-enforcement-audit.md
+++ b/docs/context/pricing-v2-server-side-enforcement-audit.md
@@ -11,7 +11,7 @@ Closes pricing-v2 §G's audit criterion: walk every `LimitKeys` catalog key and 
 | `notes_cap` | 10_000 | `Engram.Notes.insert_new_note/5` → `Billing.check_limit/3` → 402 (NEW in this PR) |
 | `vaults_cap` | 1 | `Engram.Vaults.create_vault/2` + `register_vault/3` |
 | `attachment_bytes_cap` | 1 GB | ⏳ opt-out (`AttachmentController.create/2` needs per-user lifetime quota check) |
-| `max_file_bytes` | 10 MB | ⏳ opt-out (`AttachmentController.create/2` needs per-file size check) |
+| `max_file_bytes` | 10 MB | `Engram.Attachments.validate_size/2` — `Billing.effective_limit(user, :max_file_bytes)` checked against decoded byte_size; 413 with `limit` in body. `StorageController.index/2` exposes the same per-plan number. Schema-level hardcoded 5 MB removed |
 | `lifetime_embed_token_cap` | 20 M | `Engram.Workers.EmbedNote.embed_budget_gate/1` |
 | `concurrent_devices` | 1 | ⏳ opt-out (`DeviceAuthController` needs explicit count check) |
 | `device_swap_cooldown_hours` | 12 | ⏳ opt-out (`DeviceAuthController` needs cooldown check) |
@@ -39,7 +39,7 @@ Each ⏳ opt-out above is a follow-up PR. Suggested order, smallest-first:
 1. ~~**`reranker_enabled`**~~ — ✅ SHIPPED. `Engram.Search.reranker_active_for?/1` gates per-user via `Billing.check_feature/2`.
 2. ~~**`api_write_enabled`**~~ — ✅ SHIPPED. `EngramWeb.Plugs.RequireApiWriteEnabled` on vault pipeline; API-key-only with JWT exemption + `/api/search` carve-out.
 3. ~~**`api_rps_cap`**~~ — ✅ SHIPPED. `EngramWeb.Plugs.RequireApiRpsBudget` on user-scoped + vault-scoped pipelines; API-key-only; Hammer-backed 1-sec window.
-4. **`max_file_bytes`** — `AttachmentController.create/2` checks `byte_size(file)` against the per-plan cap. ~10 LOC.
+4. ~~**`max_file_bytes`**~~ — ✅ SHIPPED. `Engram.Attachments.validate_size/2` pulls per-plan cap from `Billing.effective_limit/2`; schema-level hardcoded 5 MB removed; `StorageController` surfaces per-plan ceiling.
 5. **`attachment_bytes_cap`** — `AttachmentController.create/2` sums existing per-user attachment bytes and checks the new file against the cap. ~30 LOC, requires a `count_user_attachment_bytes/1` helper.
 6. **`inactivity_warn_60_days` + `inactivity_delete_days`** — migrate `InactivityCleanup` cron to read the catalog so per-user overrides take effect. ~40 LOC.
 7. **`concurrent_devices` + `device_swap_cooldown_hours`** — `DeviceAuthController` checks per-user device count + swap cooldown. ~50 LOC.

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -11,6 +11,7 @@ defmodule Engram.Attachments do
   import Ecto.Query
 
   alias Engram.Attachments.Attachment
+  alias Engram.Billing
   alias Engram.Crypto
   alias Engram.Crypto.Envelope
   alias Engram.Notes.PathSanitizer
@@ -29,7 +30,7 @@ defmodule Engram.Attachments do
     explicit_mime = attrs["mime_type"] || attrs[:mime_type]
 
     with {:ok, plaintext} <- decode_base64(content_b64),
-         :ok <- validate_size(plaintext),
+         :ok <- validate_size(plaintext, user),
          {:ok, user} <- Crypto.ensure_user_dek(user),
          {:ok, filter_key} <- Crypto.dek_filter_key(user) do
       path_hmac = Crypto.hmac_field(filter_key, path)
@@ -311,10 +312,14 @@ defmodule Engram.Attachments do
 
   # -- Private helpers --
 
-  defp validate_size(binary) do
-    if byte_size(binary) > Attachment.max_attachment_bytes(),
-      do: {:error, :too_large},
-      else: :ok
+  # Pricing v2 §G — per-plan max_file_bytes via `Engram.Billing`. When
+  # limits aren't enforced (self-host without Paddle), `effective_limit`
+  # returns `:unlimited` and uploads are unbounded — operator's call.
+  defp validate_size(binary, user) do
+    case Billing.effective_limit(user, :max_file_bytes) do
+      n when is_integer(n) and byte_size(binary) > n -> {:error, {:too_large, n}}
+      _ -> :ok
+    end
   end
 
   defp prepare_upload(user, vault, att_id, path, path_hmac, plaintext, mtime, explicit_mime) do

--- a/lib/engram/attachments/attachment.ex
+++ b/lib/engram/attachments/attachment.ex
@@ -2,8 +2,6 @@ defmodule Engram.Attachments.Attachment do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @max_attachment_bytes 5 * 1024 * 1024
-
   @type t :: %__MODULE__{}
 
   schema "attachments" do
@@ -66,12 +64,9 @@ defmodule Engram.Attachments.Attachment do
       :path_hmac
     ])
     |> validate_inclusion(:encryption_version, [1])
-    |> validate_number(:size_bytes, less_than_or_equal_to: @max_attachment_bytes)
     |> validate_required(:content_nonce)
     |> unique_constraint([:user_id, :vault_id, :path_hmac],
       name: :attachments_user_id_vault_id_path_hmac_index
     )
   end
-
-  def max_attachment_bytes, do: @max_attachment_bytes
 end

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -38,8 +38,10 @@ defmodule EngramWeb.AttachmentsController do
       {:error, :missing_content} ->
         conn |> put_status(422) |> json(%{error: "content_base64 is required"})
 
-      {:error, :too_large} ->
-        conn |> put_status(413) |> json(%{error: "attachment exceeds size limit"})
+      {:error, {:too_large, limit}} ->
+        conn
+        |> put_status(413)
+        |> json(%{error: "attachment exceeds size limit", limit: limit})
 
       {:error, {:storage, _reason}} ->
         conn |> put_status(502) |> json(%{error: "failed to upload to storage backend"})

--- a/lib/engram_web/controllers/storage_controller.ex
+++ b/lib/engram_web/controllers/storage_controller.ex
@@ -2,8 +2,12 @@ defmodule EngramWeb.StorageController do
   use EngramWeb, :controller
 
   alias Engram.Attachments
-  alias Engram.Attachments.Attachment
+  alias Engram.Billing
 
+  # Self-host (limits not enforced) sees Pro's per-file cap as the displayed
+  # ceiling — operators get an unsurprising number, and the actual gate is
+  # unbounded (Billing.effective_limit returns :unlimited).
+  @selfhost_max_file_bytes 524_288_000
   @max_storage_bytes 1_073_741_824
 
   def index(conn, _params) do
@@ -14,7 +18,14 @@ defmodule EngramWeb.StorageController do
       used_bytes: usage.used_bytes,
       file_count: usage.file_count,
       max_bytes: @max_storage_bytes,
-      max_attachment_bytes: Attachment.max_attachment_bytes()
+      max_attachment_bytes: max_attachment_bytes(user)
     })
+  end
+
+  defp max_attachment_bytes(user) do
+    case Billing.effective_limit(user, :max_file_bytes) do
+      n when is_integer(n) -> n
+      _ -> @selfhost_max_file_bytes
+    end
   end
 end

--- a/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
+++ b/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
@@ -38,12 +38,10 @@ defmodule Mix.Tasks.Engram.Lint.NoClientOnlyRateLimits do
     inactivity_warn_60_days:
       "TODO follow-up: InactivityCleanup hardcodes 60d/80d/90d windows; migrate to LimitKeys",
     inactivity_delete_days: "TODO follow-up: same as inactivity_warn_60_days",
-    # Attachment / file caps — TODO follow-up. AttachmentController.create/2
-    # must call Billing.check_limit(user, :attachment_bytes_cap, current_total)
-    # and Billing.check_limit(user, :max_file_bytes, byte_size).
+    # Attachment lifetime quota — TODO follow-up. AttachmentController.create/2
+    # must call Billing.check_limit(user, :attachment_bytes_cap, current_total).
     attachment_bytes_cap:
       "TODO follow-up: AttachmentController.create/2 needs per-user lifetime quota check",
-    max_file_bytes: "TODO follow-up: AttachmentController.create/2 needs per-file size check",
     # Device-auth caps — TODO follow-up. DeviceAuthController already enforces
     # vaults_cap; needs explicit concurrent_devices + cooldown checks.
     concurrent_devices: "TODO follow-up: DeviceAuthController needs per-user device count check",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.169",
+      version: "0.5.170",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -60,10 +60,17 @@ defmodule Engram.AttachmentsTest do
       assert att.size_bytes == byte_size("test image content")
     end
 
-    test "rejects attachment over max size", %{user: user, vault: vault} do
-      oversized = Base.encode64(:binary.copy("x", 6 * 1024 * 1024))
+    test "rejects attachment over per-plan max_file_bytes (§G)",
+         %{user: user, vault: vault} do
+      Engram.Factory.insert(:user_limit_override,
+        user: user,
+        key: "max_file_bytes",
+        value: %{"v" => 1_048_576}
+      )
 
-      assert {:error, :too_large} =
+      oversized = Base.encode64(:binary.copy("x", 1_048_576 + 1))
+
+      assert {:error, {:too_large, 1_048_576}} =
                Attachments.upsert_attachment(user, vault, %{
                  "path" => @path,
                  "content_base64" => oversized

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -164,8 +164,16 @@ defmodule EngramWeb.AttachmentsControllerTest do
       assert json_response(conn, 400)
     end
 
-    test "rejects oversized attachment (> 5MB)", %{conn: conn} do
-      huge = Base.encode64(:crypto.strong_rand_bytes(5 * 1024 * 1024 + 1))
+    test "rejects oversized attachment against per-plan max_file_bytes (§G)",
+         %{conn: conn, user: user} do
+      # Pin a 1 MB per-file cap for this user; upload 1 MB + 1 byte.
+      insert(:user_limit_override,
+        user: user,
+        key: "max_file_bytes",
+        value: %{"v" => 1_048_576}
+      )
+
+      huge = Base.encode64(:crypto.strong_rand_bytes(1_048_576 + 1))
 
       conn =
         post(conn, "/api/attachments", %{
@@ -176,6 +184,9 @@ defmodule EngramWeb.AttachmentsControllerTest do
         })
 
       assert conn.status == 413
+      body = json_response(conn, 413)
+      assert body["error"] == "attachment exceeds size limit"
+      assert body["limit"] == 1_048_576
     end
 
     test "returns 401 without auth", %{conn: conn} do


### PR DESCRIPTION
## Summary

Fourth §G follow-up. Replaces the hardcoded 5 MB per-file attachment ceiling with a per-plan `max_file_bytes` lookup (Free 10 MB / Starter 200 MB / Pro 500 MB).

- `Engram.Attachments.validate_size/2` consults `Billing.effective_limit(user, :max_file_bytes)`; rejection shape `{:error, {:too_large, n}}` so the controller can surface the cap.
- `AttachmentsController.upload/2` 413 body now includes `limit`.
- Schema-level 5 MB validation removed from `Engram.Attachments.Attachment` — upstream `validate_size/2` is the single gate. Self-host with `ENGRAM_LIMITS_ENFORCED=false` → `:unlimited` (operator's call).
- `StorageController.index/2` exposes the per-user cap via `max_attachment_bytes`. Self-host sees Pro's 500 MB.

## Test plan

- [x] `attachments_test.exs` "rejects over max size" pinned to a 1 MB override + new `{:error, {:too_large, _}}` shape
- [x] `attachments_controller_test.exs` "rejects oversized attachment" rewritten with 1 MB override → asserts 413 + `limit`
- [x] Full suite — 1453 tests, 0 failures
- [x] `mix engram.lint.no_client_only_rate_limits` green with 1 fewer opt-out (3 remain)
- [x] `mix format`, `mix credo --strict`, `--warnings-as-errors` all clean

## Closes

1 of 6 §G opt-out follow-ups from `backend/docs/context/pricing-v2-server-side-enforcement-audit.md`. After merge: 3 left (`attachment_bytes_cap`, `concurrent_devices` + `device_swap_cooldown_hours`, `inactivity_*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)