### PR TITLE
feat(billing): pricing v2 §G attachment_bytes_cap lifetime quota

### DIFF
--- a/docs/context/pricing-v2-server-side-enforcement-audit.md
+++ b/docs/context/pricing-v2-server-side-enforcement-audit.md
@@ -10,7 +10,7 @@ Closes pricing-v2 §G's audit criterion: walk every `LimitKeys` catalog key and 
 |-----|--------------|-------------------------|
 | `notes_cap` | 10_000 | `Engram.Notes.insert_new_note/5` → `Billing.check_limit/3` → 402 (NEW in this PR) |
 | `vaults_cap` | 1 | `Engram.Vaults.create_vault/2` + `register_vault/3` |
-| `attachment_bytes_cap` | 1 GB | ⏳ opt-out (`AttachmentController.create/2` needs per-user lifetime quota check) |
+| `attachment_bytes_cap` | 1 GB | `Engram.Attachments.validate_storage_cap/3` inside the per-path advisory lock — sums non-deleted bytes via `storage_usage/1`, subtracts existing row size on upsert, rejects with 402 `storage_cap_reached` (body carries `used` + `limit`) |
 | `max_file_bytes` | 10 MB | `Engram.Attachments.validate_size/2` — `Billing.effective_limit(user, :max_file_bytes)` checked against decoded byte_size; 413 with `limit` in body. `StorageController.index/2` exposes the same per-plan number. Schema-level hardcoded 5 MB removed |
 | `lifetime_embed_token_cap` | 20 M | `Engram.Workers.EmbedNote.embed_budget_gate/1` |
 | `concurrent_devices` | 1 | ⏳ opt-out (`DeviceAuthController` needs explicit count check) |
@@ -40,7 +40,7 @@ Each ⏳ opt-out above is a follow-up PR. Suggested order, smallest-first:
 2. ~~**`api_write_enabled`**~~ — ✅ SHIPPED. `EngramWeb.Plugs.RequireApiWriteEnabled` on vault pipeline; API-key-only with JWT exemption + `/api/search` carve-out.
 3. ~~**`api_rps_cap`**~~ — ✅ SHIPPED. `EngramWeb.Plugs.RequireApiRpsBudget` on user-scoped + vault-scoped pipelines; API-key-only; Hammer-backed 1-sec window.
 4. ~~**`max_file_bytes`**~~ — ✅ SHIPPED. `Engram.Attachments.validate_size/2` pulls per-plan cap from `Billing.effective_limit/2`; schema-level hardcoded 5 MB removed; `StorageController` surfaces per-plan ceiling.
-5. **`attachment_bytes_cap`** — `AttachmentController.create/2` sums existing per-user attachment bytes and checks the new file against the cap. ~30 LOC, requires a `count_user_attachment_bytes/1` helper.
+5. ~~**`attachment_bytes_cap`**~~ — ✅ SHIPPED. `Engram.Attachments.validate_storage_cap/3` sums non-deleted bytes (subtracts existing on upsert), 402 `storage_cap_reached` with `used` + `limit` in body.
 6. **`inactivity_warn_60_days` + `inactivity_delete_days`** — migrate `InactivityCleanup` cron to read the catalog so per-user overrides take effect. ~40 LOC.
 7. **`concurrent_devices` + `device_swap_cooldown_hours`** — `DeviceAuthController` checks per-user device count + swap cooldown. ~50 LOC.
 

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -69,7 +69,8 @@ defmodule Engram.Attachments do
             %Attachment{id: id} -> id
           end
 
-        with {:ok, key, changeset_attrs, ciphertext} <-
+        with :ok <- validate_storage_cap(user, existing, byte_size(plaintext)),
+             {:ok, key, changeset_attrs, ciphertext} <-
                prepare_upload(
                  user,
                  vault,
@@ -319,6 +320,26 @@ defmodule Engram.Attachments do
     case Billing.effective_limit(user, :max_file_bytes) do
       n when is_integer(n) and byte_size(binary) > n -> {:error, {:too_large, n}}
       _ -> :ok
+    end
+  end
+
+  # Pricing v2 §G — per-plan attachment_bytes_cap (lifetime quota).
+  # Compute the net new total: current sum minus the existing row's
+  # size (if upserting) plus the new payload size. Sum is scoped to
+  # non-deleted rows via storage_usage/1. Runs inside the per-path
+  # advisory lock for consistency with the writer's view of `existing`.
+  defp validate_storage_cap(user, existing, new_size) do
+    case Billing.effective_limit(user, :attachment_bytes_cap) do
+      n when is_integer(n) ->
+        {:ok, %{used_bytes: current}} = storage_usage(user)
+        prior = if existing, do: existing.size_bytes, else: 0
+
+        if current - prior + new_size > n,
+          do: {:error, {:storage_cap_reached, current, n}},
+          else: :ok
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -43,6 +43,11 @@ defmodule EngramWeb.AttachmentsController do
         |> put_status(413)
         |> json(%{error: "attachment exceeds size limit", limit: limit})
 
+      {:error, {:storage_cap_reached, used, limit}} ->
+        conn
+        |> put_status(402)
+        |> json(%{error: "storage_cap_reached", used: used, limit: limit})
+
       {:error, {:storage, _reason}} ->
         conn |> put_status(502) |> json(%{error: "failed to upload to storage backend"})
 

--- a/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
+++ b/lib/mix/tasks/engram.lint.no_client_only_rate_limits.ex
@@ -38,10 +38,6 @@ defmodule Mix.Tasks.Engram.Lint.NoClientOnlyRateLimits do
     inactivity_warn_60_days:
       "TODO follow-up: InactivityCleanup hardcodes 60d/80d/90d windows; migrate to LimitKeys",
     inactivity_delete_days: "TODO follow-up: same as inactivity_warn_60_days",
-    # Attachment lifetime quota — TODO follow-up. AttachmentController.create/2
-    # must call Billing.check_limit(user, :attachment_bytes_cap, current_total).
-    attachment_bytes_cap:
-      "TODO follow-up: AttachmentController.create/2 needs per-user lifetime quota check",
     # Device-auth caps — TODO follow-up. DeviceAuthController already enforces
     # vaults_cap; needs explicit concurrent_devices + cooldown checks.
     concurrent_devices: "TODO follow-up: DeviceAuthController needs per-user device count check",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.170",
+      version: "0.5.171",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -164,6 +164,67 @@ defmodule EngramWeb.AttachmentsControllerTest do
       assert json_response(conn, 400)
     end
 
+    test "rejects upload that exceeds per-plan attachment_bytes_cap (§G)",
+         %{conn: conn, user: user} do
+      # 2 MB total quota; 1.5 MB already used; uploading 800 KB more → over.
+      insert(:user_limit_override,
+        user: user,
+        key: "attachment_bytes_cap",
+        value: %{"v" => 2 * 1_048_576}
+      )
+
+      first = Base.encode64(:crypto.strong_rand_bytes(1_500_000))
+
+      conn1 =
+        post(conn, "/api/attachments", %{
+          path: "first.png",
+          content_base64: first,
+          mtime: 1.0
+        })
+
+      assert json_response(conn1, 200)
+
+      second = Base.encode64(:crypto.strong_rand_bytes(800_000))
+
+      conn2 =
+        post(conn, "/api/attachments", %{
+          path: "second.png",
+          content_base64: second,
+          mtime: 2.0
+        })
+
+      body = json_response(conn2, 402)
+      assert body["error"] == "storage_cap_reached"
+      assert body["limit"] == 2 * 1_048_576
+      assert body["used"] == 1_500_000
+    end
+
+    test "upsert subtracts existing path's size from the lifetime total (§G)",
+         %{conn: conn, user: user} do
+      insert(:user_limit_override,
+        user: user,
+        key: "attachment_bytes_cap",
+        value: %{"v" => 2 * 1_048_576}
+      )
+
+      big = Base.encode64(:crypto.strong_rand_bytes(1_500_000))
+      small = Base.encode64(:crypto.strong_rand_bytes(500_000))
+
+      # Upload 1.5 MB at the cap-near.
+      assert %{} =
+               post(conn, "/api/attachments", %{path: "f.png", content_base64: big, mtime: 1.0})
+               |> json_response(200)
+
+      # Replace same path with 500 KB — delta is negative, must succeed.
+      assert %{} =
+               post(conn, "/api/attachments", %{
+                 path: "f.png",
+                 content_base64: small,
+                 mtime: 2.0
+               })
+               |> json_response(200)
+    end
+
     test "rejects oversized attachment against per-plan max_file_bytes (§G)",
          %{conn: conn, user: user} do
       # Pin a 1 MB per-file cap for this user; upload 1 MB + 1 byte.


### PR DESCRIPTION
## Summary

Fifth §G follow-up. Caps per-user lifetime attachment storage against `attachment_bytes_cap` (Free 1 GB / Starter 3 GB / Pro 15 GB).

- `Engram.Attachments.validate_storage_cap/3` runs inside the per-path advisory lock alongside the `existing` row lookup. Sums non-deleted bytes via `storage_usage/1` and subtracts the existing row's size on upsert so net-zero / net-shrinking replacements always pass.
- Rejection: `{:error, {:storage_cap_reached, used, limit}}` → 402 with `used` + `limit` so clients can render "X of Y MB used".
- Self-host with `ENGRAM_LIMITS_ENFORCED=false` returns `:unlimited` → no `storage_usage/1` query, no cap.

## Test plan

- [x] "rejects upload that exceeds per-plan attachment_bytes_cap" — 2 MB cap, 1.5 MB then 800 KB → 402 with body assertions
- [x] "upsert subtracts existing path's size from the lifetime total" — 1.5 MB at near-cap, replace same path with 500 KB → 200
- [x] Full suite — 1455 tests, 0 failures
- [x] `mix engram.lint.no_client_only_rate_limits` green with 1 fewer opt-out (2 remain)
- [x] `mix format`, `mix credo --strict`, `--warnings-as-errors` all clean

## Closes

1 of 5 §G opt-out follow-ups from `backend/docs/context/pricing-v2-server-side-enforcement-audit.md`. After merge: 2 left (device-auth pair, inactivity pair).

🤖 Generated with [Claude Code](https://claude.com/claude-code)