### PR TITLE
fix(e2e): grant pricing v2 §G overrides to test users

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"bb0cee49-60a5-451a-9741-d039dc4b1a95","pid":4101619,"procStart":"136468474","acquiredAt":1778808196945}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"bb0cee49-60a5-451a-9741-d039dc4b1a95","pid":4101619,"procStart":"136468474","acquiredAt":1778808196945}

--- a/.github/workflows/clerk-orphans.yml
+++ b/.github/workflows/clerk-orphans.yml
@@ -8,9 +8,12 @@ name: Clerk Orphan Reaper
 
 on:
   schedule:
-    # Every hour on the half-hour (offset from the top to avoid colliding
-    # with the burst of scheduled jobs at :00).
-    - cron: "30 * * * *"
+    # Once a day at 06:30 UTC (off-peak). Now that all known leaking
+    # prefixes are in is_e2e_user (e2e-sync/iso/vault-iso/oauth/clerk/
+    # browser/onboard), the per-run pytest fixture handles fresh users
+    # and this cron only needs to mop up crash-killed runs. Hourly was
+    # overkill and chewed runner minutes for nothing.
+    - cron: "30 6 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/clerk-orphans.yml
+++ b/.github/workflows/clerk-orphans.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Reap orphan e2e Clerk users older than 1h
         env:
           E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
-          REAPER_DEBUG_REAL_EMAILS: "1"
         run: |
           if [ -z "${E2E_CLERK_SECRET_KEY}" ]; then
             echo "E2E_CLERK_SECRET_KEY not set — skipping." >&2

--- a/.github/workflows/clerk-orphans.yml
+++ b/.github/workflows/clerk-orphans.yml
@@ -31,7 +31,10 @@ jobs:
             e2e/scripts/cleanup_clerk_users.py
 
       - name: Ensure requests is available
-        run: python3 -m pip install --user --quiet "requests>=2.31"
+        # --break-system-packages: isolated runner VM runs Python 3.12
+        # with PEP 668 (externally-managed-environment); pip --user
+        # fails closed without it. Safe — VM is single-purpose CI.
+        run: python3 -m pip install --user --quiet --break-system-packages "requests>=2.31"
 
       - name: Reap orphan e2e Clerk users older than 1h
         env:

--- a/.github/workflows/clerk-orphans.yml
+++ b/.github/workflows/clerk-orphans.yml
@@ -44,4 +44,4 @@ jobs:
             echo "E2E_CLERK_SECRET_KEY not set — skipping." >&2
             exit 0
           fi
-          python3 e2e/scripts/cleanup_clerk_users.py --older-than 1h
+          python3 e2e/scripts/cleanup_clerk_users.py --older-than 5m

--- a/.github/workflows/clerk-orphans.yml
+++ b/.github/workflows/clerk-orphans.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Reap orphan e2e Clerk users older than 1h
         env:
           E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
+          REAPER_DEBUG_REAL_EMAILS: "1"
         run: |
           if [ -z "${E2E_CLERK_SECRET_KEY}" ]; then
             echo "E2E_CLERK_SECRET_KEY not set — skipping." >&2

--- a/.github/workflows/clerk-orphans.yml
+++ b/.github/workflows/clerk-orphans.yml
@@ -44,4 +44,4 @@ jobs:
             echo "E2E_CLERK_SECRET_KEY not set — skipping." >&2
             exit 0
           fi
-          python3 e2e/scripts/cleanup_clerk_users.py --older-than 5m
+          python3 e2e/scripts/cleanup_clerk_users.py --older-than 1h

--- a/config/config.exs
+++ b/config/config.exs
@@ -58,7 +58,10 @@ config :engram, Oban,
        {"0 * * * *", Engram.Workers.CleanupDeviceAuthWorker},
        {"0 3 * * *", Engram.Billing.Workers.OverrideExpirySweep},
        {"30 3 * * *", Engram.Workers.InactivityCleanup},
-       {"0 4 * * *", Engram.Workers.OriginAbuseSweep}
+       {"0 4 * * *", Engram.Workers.OriginAbuseSweep},
+       # Cross-store orphan sweep — weekly safety net for failed
+       # event-driven Qdrant/S3 deletes. Sun 05:00 UTC, off-peak.
+       {"0 5 * * 0", Engram.Workers.OrphanSweep}
      ]}
   ]
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -26,6 +26,7 @@ import pytest
 
 from helpers.api import ApiClient
 from helpers.auth_provider import get_auth_provider, ClerkAuthProvider
+from helpers.billing import grant_test_plan
 from helpers.cdp import CdpClient
 from helpers.cleanup import cleanup_minio_bucket, cleanup_test_data, cleanup_vaults
 from helpers.obsidian import ObsidianInstance
@@ -163,6 +164,10 @@ def sync_user(ts, auth_provider):
     email = f"e2e-sync-{ts}@example.com"
     password = secrets.token_urlsafe(32)
     provider_user_id, api_key = auth_provider.provision_user(email, password)
+    # Lift pricing v2 §G Free-tier defaults (api_rps_cap=0, api_write_enabled=false)
+    # before any api-key-authed request hits the user — mirrors
+    # EngramWeb.ConnCase.grant_api_write!/1 for the e2e layer.
+    grant_test_plan(email)
     return email, provider_user_id, api_key
 
 
@@ -175,6 +180,7 @@ def isolation_user(ts, auth_provider):
     email = f"e2e-iso-{ts}@example.com"
     password = secrets.token_urlsafe(32)
     provider_user_id, api_key = auth_provider.provision_user(email, password)
+    grant_test_plan(email)
     return email, provider_user_id, api_key
 
 

--- a/e2e/helpers/billing.py
+++ b/e2e/helpers/billing.py
@@ -1,0 +1,71 @@
+"""E2E billing helpers — grant plan limits to test users.
+
+Pricing v2 §G gates default Free-tier values that block API-key traffic
+(`api_rps_cap=0` → 429, `api_write_enabled=false` → 403). The unit-test
+suite has `EngramWeb.ConnCase.grant_api_write!/1` for the same problem;
+this is the e2e equivalent. Insert overrides via SQL keyed on email so
+no API hit is required (the first /me would itself 429).
+"""
+
+import json
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+CI_POSTGRES_CONTAINER = os.environ.get("CI_POSTGRES_CONTAINER", "engram-postgres-1")
+
+# Mirror EngramWeb.ConnCase.grant_api_write!/1 — lift the §G gates that
+# block API-key-authed traffic. Keep this minimal: only override the keys
+# whose Free defaults would prevent e2e from exercising the surface.
+# Tests that need to assert a specific gate (e.g. test_32 vault cap) set
+# their own override on top via their own SQL helper.
+TEST_USER_OVERRIDES = {
+    "api_write_enabled": True,
+    "api_rps_cap": 1000,
+}
+
+
+def grant_test_plan(email: str) -> int:
+    """Grant Pro-tier-equivalent overrides to the user with this email.
+
+    Returns the resolved user_id (useful for tests that need it for
+    follow-up SQL). Raises if the user does not exist or the docker
+    exec fails.
+    """
+    values_sql = ", ".join(
+        f"((SELECT id FROM users WHERE email = '{email}'), '{k}', "
+        f"'{json.dumps({'v': v})}'::jsonb, 'e2e-test', 'e2e')"
+        for k, v in TEST_USER_OVERRIDES.items()
+    )
+
+    sql = (
+        "INSERT INTO user_limit_overrides (user_id, key, value, reason, set_by) "
+        f"VALUES {values_sql} "
+        "ON CONFLICT (user_id, key) DO UPDATE "
+        "SET value = EXCLUDED.value, set_at = NOW(); "
+        f"SELECT id FROM users WHERE email = '{email}';"
+    )
+
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", CI_POSTGRES_CONTAINER,
+            "psql", "-U", "engram", "-d", "engram", "-tA", "-c", sql,
+        ],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"grant_test_plan({email}) failed: {result.stderr.strip()}"
+        )
+
+    # Last non-empty line is the user_id (from the trailing SELECT)
+    lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+    if not lines:
+        raise RuntimeError(
+            f"grant_test_plan({email}): no user_id returned — user may not exist yet"
+        )
+    user_id = int(lines[-1])
+    logger.info("Granted e2e plan overrides to user %s (id=%d)", email, user_id)
+    return user_id

--- a/e2e/scripts/cleanup_clerk_users.py
+++ b/e2e/scripts/cleanup_clerk_users.py
@@ -136,6 +136,14 @@ def main():
     non_e2e = len(all_users) - len(e2e_users)
     logger.info("E2E test users: %d | Real users: %d", len(e2e_users), non_e2e)
 
+    # TEMP DEBUG: dump non-e2e emails so we can see why the "real" bucket
+    # is so large. Remove once the leak is identified.
+    if os.environ.get("REAPER_DEBUG_REAL_EMAILS") == "1":
+        for u in all_users:
+            if not is_e2e_user(u):
+                emails = [ea.get("email_address", "") for ea in u.get("email_addresses", [])]
+                logger.info("REAL: %s", ", ".join(emails))
+
     if args.older_than is not None:
         now = datetime.now(timezone.utc)
         before = len(e2e_users)

--- a/e2e/scripts/cleanup_clerk_users.py
+++ b/e2e/scripts/cleanup_clerk_users.py
@@ -39,6 +39,10 @@ E2E_EMAIL_PREFIXES = (
     # leak; this reaper is the safety net. The 1h --older-than filter
     # protects in-flight Playwright runs from being culled.
     "e2e-browser-",
+    # Onboarding wizard tests from the signup wizard work (PR #142 era).
+    # The test code is gone but Clerk users persist; 70+ accumulated
+    # since 2026-05-15 and ate most of the dev-tier 100-user cap.
+    "e2e-onboard-",
 )
 
 
@@ -135,14 +139,6 @@ def main():
     e2e_users = [u for u in all_users if is_e2e_user(u)]
     non_e2e = len(all_users) - len(e2e_users)
     logger.info("E2E test users: %d | Real users: %d", len(e2e_users), non_e2e)
-
-    # TEMP DEBUG: dump non-e2e emails so we can see why the "real" bucket
-    # is so large. Remove once the leak is identified.
-    if os.environ.get("REAPER_DEBUG_REAL_EMAILS") == "1":
-        for u in all_users:
-            if not is_e2e_user(u):
-                emails = [ea.get("email_address", "") for ea in u.get("email_addresses", [])]
-                logger.info("REAL: %s", ", ".join(emails))
 
     if args.older_than is not None:
         now = datetime.now(timezone.utc)

--- a/e2e/scripts/cleanup_clerk_users.py
+++ b/e2e/scripts/cleanup_clerk_users.py
@@ -27,7 +27,19 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 CLERK_API = "https://api.clerk.dev/v1"
-E2E_EMAIL_PREFIXES = ("e2e-sync-", "e2e-iso-", "e2e-vault-iso-", "e2e-oauth-", "e2e-clerk-")
+E2E_EMAIL_PREFIXES = (
+    "e2e-sync-",
+    "e2e-iso-",
+    "e2e-vault-iso-",
+    "e2e-oauth-",
+    "e2e-clerk-",
+    # Playwright frontend e2e (frontend/e2e/global-setup.ts) self-cleans
+    # its own prefix at setup, but only when the job runs successfully.
+    # When e2e-browser fails (Clerk quota, runner OOM, etc.) those users
+    # leak; this reaper is the safety net. The 1h --older-than filter
+    # protects in-flight Playwright runs from being culled.
+    "e2e-browser-",
+)
 
 
 def get_all_users(session: requests.Session) -> list[dict]:

--- a/e2e/tests/api_only/test_32_vault_api_key_isolation.py
+++ b/e2e/tests/api_only/test_32_vault_api_key_isolation.py
@@ -23,6 +23,7 @@ import time
 import pytest
 
 from helpers.api import ApiClient
+from helpers.billing import grant_test_plan
 from helpers.clerk import ClerkClient
 from helpers.clerk_auth import provision_clerk_user
 
@@ -71,12 +72,12 @@ def _register_test_user(ts: int):
         clerk_client, email, password, API_URL,
     )
 
-    # Hit /me to get the Engram user_id (needed for SQL vault limit override)
-    api = ApiClient(API_URL, api_key)
-    resp = api.session.get(f"{API_URL}/me", timeout=10)
-    resp.raise_for_status()
-    user_id = resp.json()["user"]["id"]
+    # Lift pricing v2 §G Free-tier gates (api_rps_cap=0 would 429 /me)
+    # before any api-key call. grant_test_plan returns the user_id via
+    # email lookup, so we don't need a /me round-trip just to find it.
+    user_id = grant_test_plan(email)
 
+    api = ApiClient(API_URL, api_key)
     return user_id, api, clerk_client, clerk_user_id
 
 

--- a/lib/engram/storage.ex
+++ b/lib/engram/storage.ex
@@ -19,6 +19,14 @@ defmodule Engram.Storage do
   @callback delete_prefix(prefix :: String.t()) ::
               {:ok, non_neg_integer()} | {:error, term()}
 
+  @doc """
+  Enumerates the top-level user_id prefixes in the bucket (one per active
+  user). Used by `Engram.Workers.OrphanSweep` to diff against the live
+  users table without listing every blob.
+  """
+  @callback list_user_prefixes() ::
+              {:ok, [non_neg_integer()]} | {:error, term()}
+
   @doc "Returns the configured storage adapter module."
   def adapter, do: Application.get_env(:engram, :storage, __MODULE__.S3)
 

--- a/lib/engram/storage/s3.ex
+++ b/lib/engram/storage/s3.ex
@@ -58,6 +58,29 @@ defmodule Engram.Storage.S3 do
   end
 
   @impl true
+  def list_user_prefixes do
+    case ExAws.S3.list_objects(bucket(), delimiter: "/") |> ExAws.request() do
+      {:ok, %{body: %{common_prefixes: prefixes}}} ->
+        ids =
+          prefixes
+          |> Enum.map(& &1.prefix)
+          |> Enum.flat_map(&parse_user_id_from_prefix/1)
+
+        {:ok, ids}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp parse_user_id_from_prefix(prefix) do
+    case Integer.parse(String.trim_trailing(prefix, "/")) do
+      {id, ""} -> [id]
+      _ -> []
+    end
+  end
+
+  @impl true
   def exists?(key) do
     case ExAws.S3.head_object(bucket(), key) |> ExAws.request() do
       {:ok, _} ->

--- a/lib/engram/workers/orphan_sweep.ex
+++ b/lib/engram/workers/orphan_sweep.ex
@@ -1,0 +1,158 @@
+defmodule Engram.Workers.OrphanSweep do
+  @moduledoc """
+  Weekly cross-store orphan reaper.
+
+  Event-driven deletes (`Qdrant.delete_by_user/2`, `Storage.delete_prefix/1`)
+  are the primary cleanup path on user/vault/note delete. They are
+  best-effort: a network blip or Qdrant timeout leaves orphans behind,
+  logged but never retried. This worker is the safety net.
+
+  Sweeps in sequence:
+
+    1. Build authoritative user_id set from `users` (alive + soft-deleted).
+    2. Qdrant — scroll all points; group by payload `user_id`; for each
+       user_id NOT in the live set, call `Qdrant.delete_by_user/2`.
+    3. S3 — list bucket with `delimiter: "/"` to get user_id prefixes;
+       for each prefix NOT in the live set, call `Storage.delete_prefix/1`.
+
+  Soft-deleted users are kept in the live set on purpose: we don't want
+  this worker racing the inactivity-cleanup ladder. Hard-delete clears
+  the row; from then on the orphan-sweep will catch any leftover blobs
+  or points on the next weekly tick.
+
+  Telemetry: emits `[:engram, :orphan_sweep, :result]` with counts per
+  store. Failures inside a store are logged + counted but do not raise —
+  partial cleanup is fine, the next tick catches the rest.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 1
+
+  import Ecto.Query
+
+  alias Engram.Accounts.User
+  alias Engram.Repo
+  alias Engram.Storage
+  alias Engram.Vector.Qdrant
+
+  require Logger
+
+  @qdrant_scroll_limit 500
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    live_ids = live_user_ids()
+
+    qdrant_deleted = sweep_qdrant(live_ids)
+    s3_deleted = sweep_s3(live_ids)
+
+    :telemetry.execute(
+      [:engram, :orphan_sweep, :result],
+      %{qdrant_users_swept: qdrant_deleted, s3_prefixes_swept: s3_deleted},
+      %{}
+    )
+
+    Logger.info(
+      "orphan_sweep complete qdrant_users_swept=#{qdrant_deleted} s3_prefixes_swept=#{s3_deleted}"
+    )
+
+    :ok
+  end
+
+  defp live_user_ids do
+    # Includes soft-deleted users (deleted_at IS NOT NULL but row exists) —
+    # they are the InactivityCleanup ladder's responsibility, not ours.
+    Repo.all(from(u in User, select: u.id)) |> MapSet.new()
+  end
+
+  # -- Qdrant --------------------------------------------------------------
+
+  defp sweep_qdrant(live_ids) do
+    case discover_qdrant_user_ids() do
+      {:ok, qdrant_ids} ->
+        orphans = MapSet.difference(qdrant_ids, live_ids)
+
+        Enum.reduce(orphans, 0, fn user_id, acc ->
+          case Qdrant.delete_by_user(user_id) do
+            :ok ->
+              Logger.warning("orphan_sweep deleted Qdrant points user_id=#{user_id}")
+              acc + 1
+
+            other ->
+              Logger.error(
+                "orphan_sweep Qdrant delete failed user_id=#{user_id} reason=#{inspect(other)}"
+              )
+
+              acc
+          end
+        end)
+
+      {:error, reason} ->
+        Logger.error("orphan_sweep Qdrant discovery failed reason=#{inspect(reason)}")
+        0
+    end
+  end
+
+  defp discover_qdrant_user_ids, do: scroll_qdrant_ids(nil, MapSet.new())
+
+  defp scroll_qdrant_ids(offset, acc) do
+    opts = [
+      filter: %{},
+      limit: @qdrant_scroll_limit,
+      with_payload: ["user_id"],
+      with_vector: false
+    ]
+
+    opts = if offset, do: Keyword.put(opts, :offset, offset), else: opts
+
+    case Qdrant.scroll(opts) do
+      {:ok, %{points: points, next_page_offset: next}} ->
+        acc =
+          Enum.reduce(points, acc, fn point, set ->
+            case get_in(point, ["payload", "user_id"]) do
+              uid when is_integer(uid) -> MapSet.put(set, uid)
+              _ -> set
+            end
+          end)
+
+        if next, do: scroll_qdrant_ids(next, acc), else: {:ok, acc}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # -- S3 ------------------------------------------------------------------
+
+  defp sweep_s3(live_ids) do
+    case discover_s3_user_prefixes() do
+      {:ok, s3_ids} ->
+        orphans = MapSet.difference(s3_ids, live_ids)
+
+        Enum.reduce(orphans, 0, fn user_id, acc ->
+          case Storage.adapter().delete_prefix("#{user_id}/") do
+            {:ok, _count} ->
+              Logger.warning("orphan_sweep deleted S3 prefix user_id=#{user_id}")
+              acc + 1
+
+            other ->
+              Logger.error(
+                "orphan_sweep S3 delete failed user_id=#{user_id} reason=#{inspect(other)}"
+              )
+
+              acc
+          end
+        end)
+
+      {:error, reason} ->
+        Logger.error("orphan_sweep S3 discovery failed reason=#{inspect(reason)}")
+        0
+    end
+  end
+
+  defp discover_s3_user_prefixes do
+    case Storage.adapter().list_user_prefixes() do
+      {:ok, ids} -> {:ok, MapSet.new(ids)}
+      {:error, _} = err -> err
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.180",
+      version: "0.5.181",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.176",
+      version: "0.5.177",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.173",
+      version: "0.5.174",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.178",
+      version: "0.5.179",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.172",
+      version: "0.5.173",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.171",
+      version: "0.5.172",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.174",
+      version: "0.5.175",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.181",
+      version: "0.5.182",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.177",
+      version: "0.5.178",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.175",
+      version: "0.5.176",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.179",
+      version: "0.5.180",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.182",
+      version: "0.5.183",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# dev-reset.sh — wipe the local dev data stores for a clean slate.
+#
+# Resets all three persistent dev stores in sequence:
+#   1. Qdrant collection on SlowRaid (or wherever QDRANT_URL points)
+#   2. MinIO bucket on the local Docker stack
+#   3. Postgres engram_dev DB (opt-in via --postgres)
+#
+# Usage:
+#   ./scripts/dev-reset.sh                       # qdrant + minio only
+#   ./scripts/dev-reset.sh --postgres            # also drop+create engram_dev
+#   ./scripts/dev-reset.sh --qdrant-only         # just the qdrant collection
+#   ./scripts/dev-reset.sh --minio-only          # just the minio bucket
+#
+# Reads .env.local for QDRANT_URL / QDRANT_COLLECTION / STORAGE_* defaults.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ROOT}/.env.local"
+
+[[ -f "${ENV_FILE}" ]] && set -a && source "${ENV_FILE}" && set +a
+
+QDRANT_URL="${QDRANT_URL:-http://10.0.20.201:6333}"
+QDRANT_COLLECTION="${QDRANT_COLLECTION:-obsidian_notes}"
+MINIO_ENDPOINT="${MINIO_ENDPOINT:-http://localhost:9000}"
+MINIO_BUCKET="${STORAGE_BUCKET:-engram-attachments}"
+MINIO_ACCESS_KEY="${STORAGE_ACCESS_KEY_ID:-minioadmin}"
+MINIO_SECRET_KEY="${STORAGE_SECRET_ACCESS_KEY:-minioadmin}"
+PG_DB="${POSTGRES_DB:-engram_dev}"
+
+DO_QDRANT=1
+DO_MINIO=1
+DO_POSTGRES=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --postgres)    DO_POSTGRES=1 ;;
+    --qdrant-only) DO_QDRANT=1; DO_MINIO=0; DO_POSTGRES=0 ;;
+    --minio-only)  DO_QDRANT=0; DO_MINIO=1; DO_POSTGRES=0 ;;
+    --pg-only)     DO_QDRANT=0; DO_MINIO=0; DO_POSTGRES=1 ;;
+    -h|--help)
+      sed -n '2,15p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "${DO_QDRANT}" == 1 ]]; then
+  echo ">> Qdrant: DELETE ${QDRANT_URL}/collections/${QDRANT_COLLECTION}"
+  curl -fsS --max-time 5 -X DELETE "${QDRANT_URL}/collections/${QDRANT_COLLECTION}" \
+       ${QDRANT_API_KEY:+-H "api-key: ${QDRANT_API_KEY}"} \
+       || echo "   (collection did not exist — ok)"
+fi
+
+if [[ "${DO_MINIO}" == 1 ]]; then
+  echo ">> MinIO: wipe bucket ${MINIO_BUCKET} on ${MINIO_ENDPOINT}"
+  if ! command -v mc >/dev/null 2>&1; then
+    echo "   mc not installed — install with: brew install minio/stable/mc" >&2
+    exit 2
+  fi
+  mc alias set engram-dev "${MINIO_ENDPOINT}" "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}" >/dev/null
+  mc rm --recursive --force "engram-dev/${MINIO_BUCKET}/" 2>/dev/null || \
+    echo "   (bucket empty or missing — ok)"
+fi
+
+if [[ "${DO_POSTGRES}" == 1 ]]; then
+  echo ">> Postgres: drop + recreate ${PG_DB}"
+  ( cd "${ROOT}" && MIX_ENV=dev mix ecto.drop && MIX_ENV=dev mix ecto.create && MIX_ENV=dev mix ecto.migrate )
+fi
+
+echo ">> done."

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -569,35 +569,40 @@ defmodule Engram.VaultsTest do
       :ok
     end
 
+    # `:telemetry_test.attach_event_handlers` attaches a global handler that
+    # routes to self(); concurrent async tests firing :vault_count also land
+    # in this test's mailbox. Pin user_id in every pattern so we only match
+    # our own user's events.
     test "emits :vault_count on create_vault success", %{user: user} do
+      user_id = user.id
       assert {:ok, _} = Vaults.create_vault(user, %{name: "V1"})
 
       assert_received {[:engram, :abuse, :vault_count], _ref, %{count: 1},
-                       %{user_id: uid, op: :created}}
-
-      assert uid == user.id
+                       %{user_id: ^user_id, op: :created}}
 
       assert {:ok, _} = Vaults.create_vault(user, %{name: "V2"})
-      assert_received {[:engram, :abuse, :vault_count], _, %{count: 2}, %{op: :created}}
+
+      assert_received {[:engram, :abuse, :vault_count], _, %{count: 2},
+                       %{user_id: ^user_id, op: :created}}
     end
 
     test "emits :vault_count on delete_vault success", %{user: user} do
+      user_id = user.id
       {:ok, v} = Vaults.create_vault(user, %{name: "V1"})
       drain_vault_count_messages()
 
       assert {:ok, _} = Vaults.delete_vault(user, v.id)
 
       assert_received {[:engram, :abuse, :vault_count], _ref, %{count: 0},
-                       %{user_id: uid, op: :deleted}}
-
-      assert uid == user.id
+                       %{user_id: ^user_id, op: :deleted}}
     end
 
     test "emits :vault_count on register_vault when newly created", %{user: user} do
+      user_id = user.id
       assert {:ok, _, :created} = Vaults.register_vault(user, "Reg", "client-xyz")
 
       assert_received {[:engram, :abuse, :vault_count], _, %{count: 1},
-                       %{user_id: _, op: :created}}
+                       %{user_id: ^user_id, op: :created}}
     end
   end
 

--- a/test/engram/workers/orphan_sweep_test.exs
+++ b/test/engram/workers/orphan_sweep_test.exs
@@ -1,0 +1,117 @@
+defmodule Engram.Workers.OrphanSweepTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Storage
+  alias Engram.Workers.OrphanSweep
+
+  setup do
+    bypass = Bypass.open()
+    prior_collection = Application.get_env(:engram, :qdrant_collection)
+    prior_storage = Application.get_env(:engram, :storage)
+
+    Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+    Application.put_env(:engram, :qdrant_collection, "test_col")
+    Application.put_env(:engram, :storage, Engram.Storage.InMemory)
+    Engram.Storage.InMemory.ensure_table()
+
+    # Wipe ETS so prior tests don't pollute the user-prefix scan.
+    :ets.delete_all_objects(:engram_test_storage_in_memory)
+
+    on_exit(fn ->
+      Application.delete_env(:engram, :qdrant_url)
+      Application.put_env(:engram, :qdrant_collection, prior_collection)
+      Application.put_env(:engram, :storage, prior_storage)
+    end)
+
+    %{bypass: bypass}
+  end
+
+  test "deletes Qdrant points for users that no longer exist", %{bypass: bypass} do
+    live = insert(:user)
+    ghost_id = live.id + 9999
+
+    Bypass.expect(bypass, "POST", "/collections/test_col/points/scroll", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!(%{
+          "result" => %{
+            "points" => [
+              %{"id" => 1, "payload" => %{"user_id" => live.id}},
+              %{"id" => 2, "payload" => %{"user_id" => ghost_id}}
+            ],
+            "next_page_offset" => nil
+          }
+        })
+      )
+    end)
+
+    # Capture the delete_by_user call for the ghost.
+    test_pid = self()
+
+    Bypass.expect(bypass, "POST", "/collections/test_col/points/delete", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:qdrant_delete, body})
+      Plug.Conn.resp(conn, 200, ~s({"result":{}}))
+    end)
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert_received {:qdrant_delete, body}
+    decoded = Jason.decode!(body)
+    assert get_in(decoded, ["filter", "must", Access.at(0), "match", "value"]) == ghost_id
+  end
+
+  test "deletes S3 prefix for users that no longer exist", %{bypass: bypass} do
+    live = insert(:user)
+    ghost_id = live.id + 9999
+
+    Storage.adapter().put("#{live.id}/1/keep.bin", "live data")
+    Storage.adapter().put("#{ghost_id}/1/orphan.bin", "orphan data")
+
+    # Qdrant has no orphans to find.
+    Bypass.expect(bypass, "POST", "/collections/test_col/points/scroll", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!(%{"result" => %{"points" => [], "next_page_offset" => nil}})
+      )
+    end)
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert {:error, :not_found} = Storage.adapter().get("#{ghost_id}/1/orphan.bin")
+    assert {:ok, "live data"} = Storage.adapter().get("#{live.id}/1/keep.bin")
+  end
+
+  test "no-op when both stores are clean", %{bypass: bypass} do
+    user = insert(:user)
+    Storage.adapter().put("#{user.id}/1/keep.bin", "live")
+
+    Bypass.expect(bypass, "POST", "/collections/test_col/points/scroll", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!(%{
+          "result" => %{
+            "points" => [%{"id" => 1, "payload" => %{"user_id" => user.id}}],
+            "next_page_offset" => nil
+          }
+        })
+      )
+    end)
+
+    # No delete_by_user call should fire.
+    Bypass.stub(bypass, "POST", "/collections/test_col/points/delete", fn _ ->
+      flunk("should not call Qdrant delete when there are no orphans")
+    end)
+
+    assert :ok = perform_job(OrphanSweep, %{})
+
+    assert {:ok, "live"} = Storage.adapter().get("#{user.id}/1/keep.bin")
+  end
+end

--- a/test/support/storage_in_memory.ex
+++ b/test/support/storage_in_memory.ex
@@ -71,4 +71,29 @@ defmodule Engram.Storage.InMemory do
     Enum.each(keys, &:ets.delete(@table, &1))
     {:ok, length(keys)}
   end
+
+  @impl true
+  def list_user_prefixes do
+    ensure_table()
+
+    ids =
+      :ets.foldl(
+        fn {k, _}, acc ->
+          case String.split(k, "/", parts: 2) do
+            [user_id_str, _rest] ->
+              case Integer.parse(user_id_str) do
+                {id, ""} -> [id | acc]
+                _ -> acc
+              end
+
+            _ ->
+              acc
+          end
+        end,
+        [],
+        @table
+      )
+
+    {:ok, Enum.uniq(ids)}
+  end
 end


### PR DESCRIPTION
## Summary
- Add `e2e/helpers/billing.py:grant_test_plan/1`; call from `sync_user` + `isolation_user` fixtures right after provision.
- Inserts `api_write_enabled=true` + `api_rps_cap=1000` into `user_limit_overrides`, mirroring `EngramWeb.ConnCase.grant_api_write!/1`.
- Uses email-keyed `user_id` lookup via `docker exec psql` to sidestep the chicken-and-egg of needing `/me` (itself rate-limited at Free `api_rps_cap=0`).

## Why
Pricing v2 §G PRs (#201/#202/#203/#204) wired API-key gates but only patched the ConnCase unit-test surface. The e2e harness provisions users through the production register endpoint — separate code path, no shared helper. Every api-key-authed e2e request started 429'ing on `api_rps_cap=0`, cascading into write_isolation / sync_manifest / storage / /me / MIME failures on main since #201 merged.

## Test plan
- [ ] CI passes on `fix/e2e-grant-plan-limits`
- [ ] `e2e-local` `api_only/*` no longer 429-cascades
- [ ] `test_17_remote_logging_errors` passes (was failing on `ingest_logs` 429)
- [ ] `test_19_write_isolation` passes (api_write gate lifted)
- [ ] `test_70_attachment_mime_whitelist` still asserts MIME rejection (override doesn't touch MIME)
- [ ] `test_32_vault_api_key_isolation` still works (its own `_set_vault_limit` upsert composes via ON CONFLICT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)