### PR TITLE
ci(bump-bot): enable auto-merge on engram-infra image-bump PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1716,6 +1716,7 @@ jobs:
           fi
 
       - name: Open / update PR in engram-infra
+        id: open-pr
         if: steps.rewrite.outputs.bumped == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
@@ -1747,3 +1748,19 @@ jobs:
           labels: |
             automated
             tf-image-bump
+
+      - name: Enable auto-merge on bot PR
+        # Auto-merge queues the PR for merge once required checks
+        # (CODEOWNERS review + status checks) pass. Without this the bot
+        # PR sits open waiting for a human click — that's how the
+        # 2026-05-22 cascade started (4-day-old bot PR carrying stale
+        # template env). Engram-infra has `allow_auto_merge=true` set
+        # in repos.tf so the GraphQL mutation succeeds. Reuses the same
+        # App token; needs `pull_requests: write` (already granted for
+        # create-pull-request).
+        if: steps.open-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.open-pr.outputs.pull-request-number }}
+        run: |
+          gh pr merge --auto --squash --repo engram-app/engram-infra "$PR_NUMBER"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.183",
+      version: "0.5.184",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Add `gh pr merge --auto --squash` step after the existing `peter-evans/create-pull-request@v6` in the post-release tf image-bump job.
- Bot PR still requires CODEOWNERS review + green status checks; auto-merge only removes the human "click merge" step once both gates pass.
- Engram-infra has `allow_auto_merge=true` set in `repos.tf`, so the GraphQL mutation lands cleanly.

## Why now

Root cause of the 2026-05-22 cascade: a 4-day-old bot PR in engram-infra (carrying stale Unraid template env) sat unmerged. By the time it landed, the deploy daemon's snapshot was misaligned with R5+KMS env switches and engram-saas boot-crashed for ~36h. Auto-merge closes that window.

## Test plan

- [ ] Next post-release run on main opens / updates the bump PR and the new step succeeds (idempotent on already-queued PRs).
- [ ] Verify the queued PR auto-merges once `terraform (staging)` + `terraform (prod)` + `terraform (github)` + `lint (tflint)` go green AND the PR has one CODEOWNERS approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)