### PR TITLE
fix(ci): tolerate existing image when fingerprints cache-hit

### DIFF
--- a/.github/setup-runner.sh
+++ b/.github/setup-runner.sh
@@ -83,23 +83,28 @@ else
 fi
 
 # ── Multiple runner instances ────────────────────────────────────────────
-# For parallel CI jobs, register additional runner instances on this machine.
-# Each runner is an independent agent process with its own work directory.
+# Current topology: 7 generic, org-scoped runner agents on this host
+# (runner-1 … runner-7). All advertise the same label set and drain the
+# same `[self-hosted, linux, x64, isolated]` pool — any runner can pick
+# up any workflow across any repo in the engram-app org. No purpose-named
+# or per-repo runners.
+#
+# Each runner is an independent agent process with its own work directory
+# (~/actions-runner-N). To add another instance, increment N and:
 #
 # Setup (run as open-claw, not root):
-#   mkdir ~/actions-runner-engram-2
-#   cd ~/actions-runner-engram-2
+#   N=8
+#   mkdir ~/actions-runner-$N && cd ~/actions-runner-$N
 #   curl -o actions-runner-linux-x64.tar.gz -L \
 #     https://github.com/actions/runner/releases/download/v2.323.0/actions-runner-linux-x64-2.323.0.tar.gz
 #   tar xzf actions-runner-linux-x64.tar.gz
-#   ./config.sh --url https://github.com/engram-app/Engram \
-#     --labels self-hosted,engram --name engram-runner-2
+#   ./config.sh --url https://github.com/engram-app \
+#     --labels isolated --name runner-$N
 #   sudo ./svc.sh install && sudo ./svc.sh start
 #
-# Existing runners:
-#   ~/actions-runner-engram     (primary — CI + E2E)
-#   ~/actions-runner-plugin     (plugin repo CI)
-#   ~/actions-runner-engram-2   (parallel job capacity)
+# `self-hosted`, `linux`, `x64` are added automatically by the runner agent;
+# only `isolated` needs to be passed via --labels. Registering at the org
+# URL (not a repo URL) is what lets any repo in engram-app schedule onto it.
 
 # ── Obsidian AppImage (download + pre-extract latest) ────────────────────
 # Obsidian's --appimage-extract-and-run re-extracts squashfs on every launch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1477,6 +1477,14 @@ jobs:
 
       - name: Extract and validate version
         id: version
+        env:
+          # True when both fingerprints already proved green for this content
+          # — i.e. an identical backend tree + plugin SHA has already shipped.
+          # In that state an existing image at the current `mix.exs` version
+          # is expected, not a developer-forgot-to-bump error. This is the
+          # path TF-driven pushes to `.github/CODEOWNERS` (and any other
+          # admin file outside the BACKEND_HASH input set) take.
+          CACHE_HIT_BOTH: ${{ needs.fingerprint.outputs.backend-cache-hit == 'true' && needs.fingerprint.outputs.e2e-cache-hit == 'true' }}
         run: |
           VERSION=$(grep 'version:' mix.exs | head -1 | sed 's/.*"\(.*\)".*/\1/')
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -1490,13 +1498,27 @@ jobs:
           # Check whether this version already exists in GHCR.
           #
           # Policy:
-          #   first-attempt + exists  → ERROR (developer forgot to bump version)
-          #   rerun        + exists  → SKIP build, proceed straight to deploy
-          #                            (this is the recovery path when an
-          #                            earlier attempt built+pushed but failed
-          #                            at deploy time — e.g. the IP-allowlist
-          #                            NAT issue, a transient daemon outage)
-          #   first or rerun + missing → BUILD + PUSH + DEPLOY as normal
+          #   first-attempt + exists + NOT cache-hit → ERROR (developer forgot
+          #                                            to bump version)
+          #   first-attempt + exists + cache-hit     → SKIP build, jump to
+          #                                            deploy (TF-driven push
+          #                                            to .github/** or any
+          #                                            file outside the
+          #                                            BACKEND_HASH input set
+          #                                            — content unchanged, so
+          #                                            the existing image IS
+          #                                            the right one and no
+          #                                            version bump is needed)
+          #   rerun + exists                         → SKIP build, jump to
+          #                                            deploy (recovery path
+          #                                            when an earlier attempt
+          #                                            built+pushed but failed
+          #                                            at deploy time — e.g.
+          #                                            IP-allowlist NAT
+          #                                            issue, transient daemon
+          #                                            outage)
+          #   first or rerun + missing               → BUILD + PUSH + DEPLOY
+          #                                            as normal
           #
           # github.run_attempt is 1 on the first push-triggered run, 2+ on
           # any `gh run rerun` invocation. Cleanly distinguishes "operator
@@ -1504,11 +1526,11 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin > /dev/null
           IMAGE_EXISTS=false
           if docker manifest inspect "${IMAGE_LC}:${VERSION}" > /dev/null 2>&1; then
-            if [ "${{ github.run_attempt }}" = "1" ]; then
+            if [ "${{ github.run_attempt }}" = "1" ] && [ "$CACHE_HIT_BOTH" != "true" ]; then
               echo "ERROR: Version ${VERSION} already exists in GHCR. Bump the version in mix.exs before merging." >&2
               exit 1
             fi
-            echo "::notice::Image ${IMAGE_LC}:${VERSION} already in GHCR (run_attempt=${{ github.run_attempt }}); skipping build, jumping to deploy."
+            echo "::notice::Image ${IMAGE_LC}:${VERSION} already in GHCR (run_attempt=${{ github.run_attempt }}, cache_hit_both=${CACHE_HIT_BOTH}); skipping build, jumping to deploy."
             IMAGE_EXISTS=true
           fi
 

--- a/.github/workflows/runner-diagnostics.yml
+++ b/.github/workflows/runner-diagnostics.yml
@@ -1,0 +1,153 @@
+name: Runner Diagnostics
+
+# Read-only audit of the self-hosted runner host: surfaces the things that
+# bit the local dev box (FUSE mount_max, coredump pile-on, ABRT bloat,
+# OOM history, concurrent chromium/obsidian footprint).
+#
+# Manual trigger only — run after suspected runner instability or before
+# making host-config changes. Output goes to the workflow log; nothing
+# is modified.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: [self-hosted, linux, x64, isolated]
+    timeout-minutes: 5
+    steps:
+      - name: Host identity
+        run: |
+          echo "=== Host ==="
+          hostname
+          uname -a
+          uptime
+          echo "Runner: ${RUNNER_NAME:-unset}"
+
+      - name: Memory + swap
+        run: |
+          echo "=== Memory ==="
+          free -h
+          echo "--- /proc/meminfo (key fields) ---"
+          grep -E '^(MemTotal|MemAvailable|SwapTotal|SwapFree|Committed_AS):' /proc/meminfo
+
+      - name: Load + top RSS consumers
+        run: |
+          echo "=== Load average ==="
+          cat /proc/loadavg
+          echo "=== Top 20 by RSS ==="
+          ps -eo pid,user,rss,pcpu,etime,comm --sort=-rss | head -21
+
+      - name: Concurrent browser/runtime footprint
+        run: |
+          echo "=== Live obsidian/chromium/xvfb/playwright procs ==="
+          ps -eo pid,rss,etime,cmd 2>/dev/null \
+            | grep -iE 'obsidian|chromium|chrome|xvfb|playwright|node.*plugin' \
+            | grep -v grep \
+            | awk '{
+                rss=$2; total+=rss;
+                # Truncate cmd for readability
+                cmd=""; for (i=4;i<=NF;i++) cmd=cmd" "$i;
+                if (length(cmd)>140) cmd=substr(cmd,1,137)"...";
+                printf "%8s  %8dK  %10s %s\n", $1, rss, $3, cmd
+              }
+              END { printf "TOTAL RSS across matched procs: %d MB\n", total/1024 }'
+
+      - name: FUSE config (mount_max + current mounts)
+        run: |
+          echo "=== /etc/fuse.conf ==="
+          cat /etc/fuse.conf 2>/dev/null || echo "(not present)"
+          echo "--- Current FUSE mounts ---"
+          fuse_count=$(mount -t fuse,fuse.portal,fuse.gvfsd-fuse,fuse3 2>/dev/null | wc -l)
+          all_count=$(mount | wc -l)
+          echo "fuse mounts: $fuse_count   total mounts: $all_count"
+          echo "--- max_user_namespaces / mount limits (kernel) ---"
+          sysctl -a 2>/dev/null | grep -E 'fs\.mount-max|user\.max_mnt_namespaces' || true
+
+      - name: Coredump config + storage
+        run: |
+          echo "=== /etc/systemd/coredump.conf ==="
+          cat /etc/systemd/coredump.conf 2>/dev/null || echo "(default)"
+          for d in /etc/systemd/coredump.conf.d; do
+            if [ -d "$d" ]; then
+              echo "--- $d/* ---"
+              for f in "$d"/*.conf; do [ -f "$f" ] && { echo "# $f"; cat "$f"; }; done
+            fi
+          done
+          echo "--- Coredump disk usage ---"
+          du -sh /var/lib/systemd/coredump 2>/dev/null || echo "(no spool dir)"
+          echo "--- Coredumps in last 7d ---"
+          coredumpctl list --since=-7d 2>/dev/null | tail -20 || echo "coredumpctl unavailable"
+
+      - name: ABRT presence + config
+        run: |
+          echo "=== ABRT installed? ==="
+          if command -v abrtd >/dev/null 2>&1 || systemctl list-unit-files 'abrt*' 2>/dev/null | grep -q abrt; then
+            echo "ABRT is installed."
+            systemctl list-unit-files 'abrt*' --no-pager 2>/dev/null | head -20
+            for f in /etc/abrt/abrt.conf /etc/abrt/plugins/CCpp.conf; do
+              [ -f "$f" ] && { echo "--- $f ---"; cat "$f"; }
+            done
+            echo "--- ABRT spool size ---"
+            du -sh /var/spool/abrt /var/tmp/abrt 2>/dev/null || true
+          else
+            echo "ABRT not installed — good (no pile-on risk)."
+          fi
+
+      - name: OOM history (this boot + previous)
+        run: |
+          echo "=== Boots ==="
+          journalctl --list-boots --no-pager 2>/dev/null | tail -5 || true
+          echo "=== OOM events, last 7d ==="
+          journalctl --no-pager --since=-7d 2>/dev/null \
+            | grep -E 'invoked oom-killer|Out of memory: Killed|oom_reaper' \
+            | tail -30 \
+            || echo "No OOM events in last 7d."
+
+      - name: User systemd services on runner host
+        run: |
+          echo "=== --user services (running) ==="
+          systemctl --user list-units --type=service --state=running --no-pager 2>/dev/null \
+            | head -40 \
+            || echo "(no --user manager for this UID — runner likely runs as system service)"
+          echo "=== --user units with Restart= (risk of crash-loop) ==="
+          for unit in $(systemctl --user list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}'); do
+            r=$(systemctl --user show "$unit" -p Restart --value 2>/dev/null || echo "")
+            if [ -n "$r" ] && [ "$r" != "no" ]; then
+              rs=$(systemctl --user show "$unit" -p RestartSec --value 2>/dev/null || echo "?")
+              slb=$(systemctl --user show "$unit" -p StartLimitBurst --value 2>/dev/null || echo "?")
+              sli=$(systemctl --user show "$unit" -p StartLimitIntervalUSec --value 2>/dev/null || echo "?")
+              printf "  %s  Restart=%s RestartSec=%s StartLimitBurst=%s StartLimitInterval=%s\n" \
+                "$unit" "$r" "$rs" "$slb" "$sli"
+            fi
+          done
+
+      - name: Disk + tmp usage
+        run: |
+          echo "=== Filesystems ==="
+          df -h -x tmpfs -x devtmpfs 2>/dev/null | head -15
+          echo "=== /tmp size + Bun .ff*.node count ==="
+          du -sh /tmp 2>/dev/null || true
+          find /tmp -maxdepth 1 -name '.ff*.node' 2>/dev/null | wc -l | xargs printf "  .ff*.node files: %s\n"
+          echo "=== Docker disk ==="
+          docker system df 2>/dev/null || echo "(docker not reachable)"
+
+      - name: Obsidian install state
+        run: |
+          echo "=== ~/Applications ==="
+          ls -la "$HOME/Applications" 2>/dev/null | grep -iE 'obsidian|extracted' || echo "(no Obsidian artifacts)"
+          if [ -f "$HOME/Applications/.obsidian-version" ]; then
+            echo "Installed Obsidian: $(cat "$HOME/Applications/.obsidian-version")"
+          fi
+          echo "--- Stray AppImage FUSE mount-points (should be 0 between jobs) ---"
+          mount | grep -i obsidian || echo "  none"
+
+      - name: Runner agents on this host
+        run: |
+          echo "=== Active runner processes ==="
+          pgrep -af 'Runner.Listener|Runner.Worker' 2>/dev/null || echo "(none — this output should never print, runner is executing this!)"
+          echo "=== Runner work dirs ==="
+          ls -ld "$HOME"/actions-runner* 2>/dev/null || echo "(no actions-runner* dirs in HOME)"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.186",
+      version: "0.5.187",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Closes the collision between **TF-managed `.github/` pushes** (CODEOWNERS, Dependabot config, allowed-actions allowlists) and the **version-bump policy** in `build-and-publish-image`. Also bumps `mix.exs` once to unblock the current head.

## Why the previous run failed

[Run 26274117864](https://github.com/engram-app/Engram/actions/runs/26274117864) failed on commit `748c9e4` (`chore: TF-managed CODEOWNERS`). That commit only touched `.github/CODEOWNERS`, which is NOT part of `BACKEND_HASH`:

```
lib/ priv/ config/ test/ frontend/ Dockerfile entrypoint.sh
mix.exs mix.lock docker-compose.ci*.yml .github/workflows/ci.yml
```

So both fingerprints cache-hit → `ci` job skipped → `build-and-publish-image` still ran (its `if:` includes the both-cache-hit branch) → version check found `0.5.186` already in GHCR → `run_attempt=1` → ERROR.

## What changes

1. **`mix.exs`** → 0.5.186 → 0.5.187 (one-time bump to unblock the current head; the prior build job for `748c9e4` failed and no artifact exists yet for that hash).
2. **`.github/workflows/ci.yml` → `build-and-publish-image`**: add `CACHE_HIT_BOTH` env to the version step, refine policy:

```
first-attempt + exists + NOT cache-hit → ERROR  (developer forgot to bump)
first-attempt + exists + cache-hit     → SKIP build, jump to deploy
rerun + exists                         → SKIP build, jump to deploy
first or rerun + missing               → BUILD + PUSH + DEPLOY as normal
```

The "developer forgot to bump" check stays intact on real code merges. It only relaxes on the path where both fingerprints already proved this exact content green — meaning the existing image IS the right image, and a duplicate push would just churn a version number for identical content.

## Future TF-driven pushes

CODEOWNERS, Dependabot, allowed-actions, and any other `.github/` admin file outside `BACKEND_HASH` will now ride the cache-hit branch silently → `image_exists=true` → all subsequent build steps short-circuit on `if: steps.version.outputs.image_exists != 'true'` → job finishes green → `bump-infra-tfvars` runs as normal but with the same tag → no-op.

## Test plan

- [ ] PR CI passes on this branch (full run since `ci.yml` changes invalidate `BACKEND_HASH`)
- [ ] Squash-merge to main triggers a fresh CI run that builds and publishes `0.5.187`
- [ ] `engram-infra` opens a bump PR to `staging-fastraid` for `0.5.187` automatically (`bump-infra-tfvars` job)
- [ ] Next TF-driven CODEOWNERS push to `main`: build-and-publish-image runs, sees both fingerprints cache-hit + image exists, emits the `::notice::` "skipping build, jumping to deploy" line, exits green (no ERROR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)