### PR TITLE
ci: allow dependabot/** branches to trigger CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - main
       - "bump/**"
       - "chore/**"
+      - "dependabot/**"
       - "docs/**"
       - "feat/**"
       - "fix/**"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.187",
+      version: "0.5.188",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Add `dependabot/**` to the `push:` branch allowlist in `ci.yml`.
- Closes the gating bug that left PRs #207–#216 with zero status checks.

## Root cause

`ci.yml` triggers only on push to a fixed branch-prefix allowlist (`main`, `bump/**`, `chore/**`, `docs/**`, `feat/**`, …). Dependabot pushes to `dependabot/<eco>/<spec>` — that prefix wasn't listed, so push events were dropped on the floor. With branch-protection requiring green checks on `main`, the 10 open Dependabot PRs cannot merge.

The header comment explains the allowlist: prevent fork-PR branches from running on self-hosted runners. Dependabot pushes into the base repo, not a fork, so admitting `dependabot/**` doesn't expand the fork-runner attack surface.

## Test plan

- [ ] CI runs green on this PR (validates the existing `chore/**` slot still fires).
- [ ] After merge, comment `@dependabot rebase` on #207–#216 and confirm CI fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)