### PR TITLE
ci: submit Hex dependency graph to GitHub

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,56 @@
+name: Dependency submission
+
+# Pushes our Hex dependency graph to GitHub's dependency-submission API
+# so Dependabot can see what Hex packages we actually use. GitHub's static
+# mix.lock parser silently fails on this repo (verified 2026-05-22: the
+# repo's SBOM contains 0 `pkg:hex` packages despite 200+ Hex deps in
+# mix.lock), which is why Dependabot security alerts never surfaced the 8
+# known CVEs that mix_audit caught in PR #220.
+#
+# Why this fixes it: GitHub merges submitted graphs with its (broken)
+# static parsing. Once we submit a complete Hex SBOM, Dependabot's
+# scanner has accurate data and will surface security alerts + open
+# auto-PRs for CVEs we don't already track.
+#
+# Trigger: push to main only. The repository dependency graph reflects
+# the default branch's state — submitting from PR branches would pollute
+# it with unmerged deps and create false-positive alerts. PR-time scanning
+# of *introduced* deps is a separate concern (would use
+# actions/dependency-review-action, not added here).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mix.exs"
+      - "mix.lock"
+      - ".github/workflows/dependency-submission.yml"
+  schedule:
+    # Weekly refresh so the graph stays accurate even when main is quiet
+    # (e.g. catches a transitive bump from a Hex retire/replace event
+    # outside our own commits). Saturday 03:00 UTC — off-peak.
+    - cron: "0 3 * * 6"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    runs-on: [self-hosted, linux, x64, isolated]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch deps
+        # The action's own `install-deps: true` runs `mix deps.get`, but
+        # we run it here as a separate step so the action's failure mode
+        # (transient hex.pm timeout, etc.) is easier to diagnose.
+        run: mix deps.get
+
+      - name: Submit Hex SBOM to GitHub
+        uses: erlef/mix-dependency-submission@v1
+        with:
+          # install-deps=true ensures a complete transitive graph.
+          # Without it, only direct deps appear — and most CVEs live in
+          # transitive deps (cowboy_telemetry, mime, etc.).
+          install-deps: true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.192",
+      version: "0.5.193",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Adds a workflow that submits our Hex dependency graph to GitHub's dependency-submission API via `erlef/mix-dependency-submission@v1`. Fixes the root-cause silence that hid the 8 known CVEs from Dependabot (caught by mix_audit in #220).

## Root cause confirmed

```
$ gh api '/repos/engram-app/Engram/dependency-graph/sbom' \
    --jq '.sbom.packages[]?.externalRefs[0]?.referenceLocator' \
    | grep -o '^pkg:[a-z]*' | sort -u
pkg:github
pkg:githubactions
pkg:npm
pkg:pypi
```

Zero `pkg:hex` packages despite 200+ Hex deps in `mix.lock`. GitHub's static parser silently fails on this repo. For comparison, `engram-deployer`'s SBOM correctly contains `pkg:golang` packages.

Result: `dependabot/alerts` returns 0 alerts (any state, all severities), so Dependabot never opened security PRs for `plug_cowboy 2.8.0`, `postgrex 0.22.0`, `phoenix 1.8.5`, or any of the 6 bandit CVEs.

## How this fixes it

GitHub merges submitted graphs with its (broken) static parsing. Once we submit a complete Hex SBOM:
1. The repo's SBOM gains `pkg:hex/<pkg>@<ver>` entries for all transitive deps
2. Dependabot's scanner reconciles against GHSA on its normal cadence (minutes to hours)
3. Existing CVEs surface as alerts; Dependabot opens security PRs for any new ones automatically

## Trigger choice

Push to main only, on `mix.{exs,lock}` or this workflow. Reasoning:
- Repo dependency graph reflects default-branch state. Submitting from PRs creates transient deps/alerts that vanish on PR close.
- PR-time scanning of *introduced* deps is a separate concern (`actions/dependency-review-action`, deferred).
- Plus weekly cron (Saturday 03:00 UTC) to refresh in case of upstream retire/replace events outside our commits.

## Permissions

`contents: write` (per erlef README — the submission API writes a graph snapshot to the repo's dependency graph). Default `GITHUB_TOKEN` is enough; no PAT.

## Expected alert wave

Once this lands on main, expect ~8 Dependabot alerts to appear within an hour (the same CVEs mix_audit caught — most will be auto-closed because they're already patched by the bumps in #220, but the decimal/cowlib ignores will still surface). This is the system working as intended, not a regression.

## Test plan

- [ ] Workflow run on PR merge succeeds.
- [ ] After ~5 min: `gh api /repos/engram-app/Engram/dependency-graph/sbom | jq '[.sbom.packages[] | select(.externalRefs[]?.referenceLocator | startswith("pkg:hex/"))] | length'` returns non-zero (expect 80-150 for a Phoenix app).
- [ ] After ~1 hr: `gh api /repos/engram-app/Engram/dependabot/alerts | jq length` shows non-zero. Triage and dismiss the ones already patched by #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)