### PR TITLE
fix(ci): unblock Dependabot PRs in version-check + fingerprint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
+        # Dependabot PRs don't receive workflow secrets by GitHub policy,
+        # so create-github-app-token errors with "private-key must be set
+        # to a non-empty string". Skip this step on Dependabot — the
+        # plugin SHA resolution below falls back to unauthenticated calls
+        # against the public Engram-obsidian repo, which works fine for
+        # Dependabot's low PR volume.
+        if: github.actor != 'dependabot[bot]'
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.ENGRAM_CI_CLIENT_ID }}
@@ -108,7 +115,15 @@ jobs:
           # Uses curl (not gh CLI) — the engram-isolated runners don't ship gh
           # on the default PATH for the fingerprint runner image.
           API="https://api.github.com/repos/engram-app/Engram-obsidian"
-          AUTH=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
+          # GH_TOKEN is empty on Dependabot PRs (App-token step skipped).
+          # Engram-obsidian is public, so unauthenticated GET works; only
+          # downside is lower rate limit, which doesn't matter for the
+          # weekly Dependabot wave.
+          if [ -n "$GH_TOKEN" ]; then
+            AUTH=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
+          else
+            AUTH=(-H "Accept: application/vnd.github+json")
+          fi
 
           resolve_sha() {
             curl -fsS "${AUTH[@]}" "${API}/commits/$1" | jq -r '.sha'
@@ -339,7 +354,9 @@ jobs:
           mix compile --warnings-as-errors
 
   version-check:
-    if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+    # Skip on Dependabot PRs — they can't bump app version, and the `ci`
+    # aggregate already treats `skipped` as OK for version-check.
+    if: github.event_name == 'push' && github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.193",
+      version: "0.5.194",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Two latent CI design issues exposed by #92's grouping rollout. Once grouped Dependabot PRs (#222 gha-all, #223 hammer) started actually reaching CI, both jobs failed deterministically.

## Issues + fixes

### 1. `version-check` requires mix.exs version bump

Dependabot doesn't bump app version. All Dependabot PRs will fail version-check unless bypassed.

**Fix:** add `github.actor != 'dependabot[bot]'` to the job's `if:`. The `ci` aggregate already treats `skipped` as OK for this check (line 1438), so no downstream change needed.

### 2. `fingerprint` job's App-token step needs secrets that Dependabot can't access

GitHub's intentional safety: Dependabot PRs don't receive workflow secrets to prevent exfiltration via malicious deps. `actions/create-github-app-token` errors with:
```
The 'private-key' input must be set to a non-empty string. If using a
secret or variable, ensure it is available in this workflow context.
```

**Fix:** skip the App-token step on Dependabot (`if: github.actor != 'dependabot[bot]'`), and have the plugin SHA resolution fall back to unauthenticated `curl`. Engram-obsidian is public so unauthenticated GET works; the rate limit doesn't matter for the weekly Dependabot wave.

## What gets unblocked

After this lands, the grouped Dependabot PRs flow end-to-end:

| # | What | Action after this lands |
|---|------|--------------------------|
| 222 | gha-all 5-update group | Rebase → CI passes → auto-merge fires (per dependabot_automerge.yml) |
| 223 | hammer major | Rebase → CI passes → sits open for human review (major, no auto-merge) |
| Next | Weekly Dependabot wave | All grouped PRs work end-to-end without intervention |

## Test plan

- [ ] CI passes on this PR (non-Dependabot context, App-token step still runs, version-check still required).
- [ ] After merge: `gh pr comment 222 --body "@dependabot rebase"` triggers rebase → CI passes → auto-merge fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)