### PR TITLE
ci(bump-bot): enable auto-merge on engram-infra image-bump PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1857,6 +1857,7 @@ jobs:
           fi
 
       - name: Open / update PR in engram-infra
+        id: open-pr
         if: steps.rewrite.outputs.bumped == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -1888,3 +1889,20 @@ jobs:
           labels: |
             automated
             tf-image-bump
+
+      - name: Enable auto-merge on bot PR
+        # Auto-merge queues the PR for merge once required checks
+        # (CODEOWNERS review + status checks) pass. Without this the bot
+        # PR sits open waiting for a human click — that's how the
+        # 2026-05-22 cascade started (4-day-old bot PR carrying stale
+        # template env on engram-infra). Engram-infra has
+        # `allow_auto_merge=true` set in repos.tf so the GraphQL
+        # mutation succeeds. Reuses the existing engram-infra-tf App
+        # token; `pull_requests: write` is already granted for the
+        # create-pull-request step.
+        if: steps.open-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.open-pr.outputs.pull-request-number }}
+        run: |
+          gh pr merge --auto --squash --repo engram-app/engram-infra "$PR_NUMBER"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.197",
+      version: "0.5.199",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Recreated fresh from current main. Supersedes #217 which had a ~3.6k-line stale diff after tonight's PR session (#217 was branched before the dependabot-auto-merge.yml, dependency-submission.yml, runner-diagnostics.yml, AWS KMS Phase 3 spec, and provider-migration code landed).

The actual change is tiny: 18 lines in `ci.yml` adding `id: open-pr` to the existing peter-evans step + a new "Enable auto-merge on bot PR" step.

## Why

Root cause from 2026-05-22 cascade: a 4-day-old bot PR carrying stale Unraid template env sat unmerged in engram-infra. By the time it landed, the deploy daemon's snapshot was already misaligned with R5+KMS env, and engram-saas boot-crashed for ~36 hours. Documented in `docs/context/fastraid-template-drift-2026-05-22.md`.

## What this does

After the post-release `bump-infra-tfvars` job opens a tf image-bump PR in engram-infra, also `gh pr merge --auto --squash` it. PR still gates on CODEOWNERS review + status checks — auto-merge only removes the human "click merge" step once both pass.

## Test plan

- [ ] Close #217 with reference to this PR.
- [ ] Next release that fires `bump-infra-tfvars`: confirm the bot PR shows "Auto-merge enabled" state in engram-infra.

## Action: close #217

```
gh pr close 217 --comment "Superseded by #228 (recreated from current main; original baseline was ~3.6k lines stale)."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)