### PR TITLE
chore: canonical issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,34 @@
+name: Bug
+description: Something is broken or behaving incorrectly.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: source
+    attributes:
+      label: Source
+      description: Where did this bug surface? (file path, log, dashboard, user report, etc.)
+      placeholder: e.g. backend/lib/engram/sync.ex, Sentry alert ID, CI run #...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is happening, what should happen, and any reproduction steps.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: How will we know this is fixed? Concrete, checkable criteria.
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related issues, PRs, docs, memory entries.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/decision.yml
+++ b/.github/ISSUE_TEMPLATE/decision.yml
@@ -1,0 +1,33 @@
+name: Decision
+description: A product or technical decision needing input before work proceeds.
+title: "[decision] "
+labels: ["decision", "needs-decision"]
+body:
+  - type: textarea
+    id: source
+    attributes:
+      label: Source
+      description: Where did this decision point surface? (spec, retro, blocker on issue/PR, memory entry)
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is being decided, what are the options, what are the trade-offs.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: What does "decided" look like? (option chosen + recorded where)
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related issues, PRs, docs, memory entries.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,33 @@
+name: Enhancement
+description: A new feature, improvement, or scoped piece of work.
+title: "[enhancement] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: source
+    attributes:
+      label: Source
+      description: Where did this come from? (spec doc, retro, user feedback, prior issue, memory entry)
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is the change, why does it matter, what is the rough shape.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: How will we know this is done? Concrete, checkable criteria.
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related issues, PRs, specs, plans, memory entries.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/runbook.yml
+++ b/.github/ISSUE_TEMPLATE/runbook.yml
@@ -1,0 +1,33 @@
+name: Runbook
+description: An operational runbook or step-by-step procedure to author or update.
+title: "[runbook] "
+labels: ["runbook"]
+body:
+  - type: textarea
+    id: source
+    attributes:
+      label: Source
+      description: Where did this need surface? (incident, on-call gap, audit finding, missing doc)
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What operation does this cover, who runs it, what is currently missing.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: What does the finished runbook need to contain? Where does it live?
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related issues, PRs, docs, memory entries.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- 1-3 bullets: what changed and why. -->
+
+## Test plan
+
+<!-- Checklist of how this was verified or how the reviewer should verify. -->
+
+Closes #

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.203",
+      version: "0.5.204",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- 4 issue forms (bug/enhancement/decision/runbook) using `Source/Context/Acceptance/Links` shape
- Minimal PR template (`## Summary` + `## Test plan`)
- `blank_issues_enabled: false`
- mix.exs version bump 0.5.203 → 0.5.204 (required by pre-push hook)

Mirror of engram-workspace#16. Part of workspace maturity item #1.

## Test plan

- [x] YAML lints clean
- [x] mix format passes (pre-push hook ran)
- [ ] After merge: open a test issue via UI to confirm forms render