### PR TITLE
ci: CLAUDE.md staleness lint + fix stale pricing block

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,101 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  todo-drift:
+    name: TODO drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Forbid TODO*.md files
+        run: |
+          set -euo pipefail
+          # TODOs belong in GitHub Issues, not markdown checklists.
+          # Audit context: 2026-05-22 doc-audit migrated 34 TODOs out of MD scrum-style.
+          # See [[project_doc_audit_migration]] memory + project_workspace_maturity_wave.
+          matches=$(find . -type f \( -name 'TODO.md' -o -name 'TODO-*.md' \) -not -path './.git/*' || true)
+          if [ -n "$matches" ]; then
+            echo "::error::Found TODO*.md files. File TODOs as GitHub Issues instead:"
+            echo "$matches"
+            exit 1
+          fi
+          echo "OK — no TODO*.md files."
+
+      - name: Forbid checkbox-as-TODO in repo-root markdown
+        run: |
+          set -euo pipefail
+          # Block `^- [ ]` and `^- [x]` checkbox patterns in repo-root markdown
+          # (CLAUDE.md, README.md, etc.). Legitimate checklist locations
+          # (runbooks under docs/context/, plans+specs under docs/superpowers/)
+          # are intentionally not linted — they use checkboxes as a format.
+          mapfile -t files < <(find . -maxdepth 1 -name '*.md' -type f)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "OK — no root markdown files to check."
+            exit 0
+          fi
+          violations=$(grep -lE '^- \[[ x]\]' "${files[@]}" 2>/dev/null || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Found checkbox-as-TODO patterns in root markdown. File issues or move to a runbook/plan instead:"
+            echo "$violations"
+            grep -nE '^- \[[ x]\]' $violations || true
+            exit 1
+          fi
+          echo "OK — no checkbox-as-TODO in root markdown."
+
+  claude-md-staleness:
+    name: CLAUDE.md staleness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan CLAUDE.md files for known-stale facts
+        run: |
+          set -euo pipefail
+          # CLAUDE.md should reflect CURRENT product state. Patterns below are
+          # known-dead facts per workspace memory entries:
+          #   - dead domains  → [[project_domain]]
+          #   - dead pricing  → [[project_pricing_model]] (v2 reanchored $10/$20)
+          #   - dead org refs → [[project_engram_app_org_complete]]
+          # Stripe references are intentionally NOT linted — too noisy
+          # against legitimate "Stripe removed" historical context.
+          mapfile -t files < <(find . -name 'CLAUDE.md' -type f -not -path './.git/*')
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "OK — no CLAUDE.md files in repo."
+            exit 0
+          fi
+          echo "Scanning: ${files[*]}"
+
+          patterns=(
+            'engram-sync\.app'
+            'engram\.ras\.band'
+            '\bengram\.com\b'
+            'Starter[^\n]{0,30}\$5\b'
+            'Pro[^\n]{0,30}\$10\b'
+            'Starter[^\n]{0,30}\$6\b'
+            'Pro[^\n]{0,30}\$12\b'
+            'Rasbandit/[Ee]ngram'
+          )
+
+          fail=0
+          for p in "${patterns[@]}"; do
+            hits=$(grep -nPH "$p" "${files[@]}" 2>/dev/null || true)
+            if [ -n "$hits" ]; then
+              echo "::error::Stale pattern '${p}' found in CLAUDE.md:"
+              echo "$hits"
+              fail=1
+            fi
+          done
+          if [ $fail -eq 1 ]; then
+            echo
+            echo "Replace with current state per workspace memory:"
+            echo "  - Domains: app.engram.page (saas), engram.ax (selfhost)"
+            echo "  - Pricing: Free / Starter \$10 / Pro \$20 (v2 reanchored)"
+            echo "  - Org:     engram-app/<repo>"
+            exit 1
+          fi
+          echo "OK — no known-stale facts in CLAUDE.md files."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Workspace:** For cross-project work, open `../engram-workspace/` instead. It provides unified context for both plugin and backend.
 
-Engram — AI-powered personal knowledge base built on Obsidian. Your vault remembers everything. Makes your notes queryable by any AI assistant via MCP. SaaS-only at launch: Starter $5/mo, Pro $10/mo. Pricing rationale in `../engram-workspace/docs/context/pricing-strategy.md`; billing integration details in `docs/context/paddle-integration.md`.
+Engram — AI-powered personal knowledge base built on Obsidian. Your vault remembers everything. Makes your notes queryable by any AI assistant via MCP. SaaS pricing: Free / Starter $10/mo / Pro $20/mo (v2 reanchored 2026-05-20). Pricing rationale in `../engram-workspace/docs/context/pricing-strategy.md` + `docs/superpowers/specs/2026-05-20-pricing-tiers-v2-design.md`; billing integration details in `docs/context/paddle-integration.md`.
 
 ## Issue Tracker
 
@@ -139,10 +139,11 @@ mix dialyzer                              # slow first run (~5-10 min PLT build)
 
 | Tier | Price | Features |
 |------|-------|----------|
-| **Starter** | $5/mo ($50/yr) | Text search, MCP, WebSocket sync, 5 devices, 10GB storage |
-| **Pro** | $10/mo ($100/yr) | + unlimited devices, 50GB, 2x rate limit, multimodal (future) |
+| **Free** | $0 | 1 vault, 1 device (12h swap cooldown), 1GB attachments, manual sync, 10k notes, 5 AI conversations/day, MCP enabled, 90-day inactivity auto-delete |
+| **Starter** | $10/mo ($100/yr) | 5 vaults, unlimited devices, 3GB attachments, real-time SSE sync, 50k notes, 500 AI queries/day, API write access |
+| **Pro** | $20/mo ($200/yr) | 15 vaults, unlimited devices, 15GB attachments, real-time sync, unlimited notes, unlimited AI (10k/day fair-use), priority support, higher API rate |
 
-14-day free trial (card required). Self-host (no `PADDLE_API_KEY`): free, no billing wiring. See `docs/context/paddle-integration.md`.
+Self-host (no `PADDLE_API_KEY`): free, no billing wiring. See `docs/context/paddle-integration.md` + `../engram-workspace/docs/superpowers/specs/2026-05-20-pricing-tiers-v2-design.md` for the canonical v2 design.
 
 ## Context Docs
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.205",
+      version: "0.5.206",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- New `.github/workflows/lint.yml` mirrors engram-workspace#19 — scans `CLAUDE.md` for known-stale facts (domains, prices, org refs) per workspace memory
- Pre-fixes backend `CLAUDE.md` v1 pricing to current v2:
  - Intro: Starter \$5 / Pro \$10 → **Free / Starter \$10 / Pro \$20**
  - Product Tiers: full table rewritten to v2 three-tier shape with vault/device/AI/storage limits per `[[project_pricing_model]]`
- `mix.exs` 0.5.205 → 0.5.206 (pre-push hook)

Workspace maturity item #7.2.

## Test plan

- [x] Dry-run lint locally on this branch: clean (0 stale patterns)
- [x] `mix format` passes (pre-push hook ran clean)
- [ ] CI `lint` job green after merge