### PR TITLE
test(mcp): expand DCR endpoint coverage per #278

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.207",
+      version: "0.5.208",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/oauth_register_controller_test.exs
+++ b/test/engram_web/controllers/oauth_register_controller_test.exs
@@ -78,6 +78,37 @@ defmodule EngramWeb.OAuthRegisterControllerTest do
       assert client.client_name == "test"
       assert client.redirect_uris == ["https://example.com/cb"]
     end
+
+    test "accepts multiple https redirect_uris", %{conn: conn} do
+      uris = [
+        "https://app.example.com/oauth/cb",
+        "https://app.example.com/oauth/cb2",
+        "https://other.example.com/cb"
+      ]
+
+      conn = post(conn, "/oauth/register", %{"redirect_uris" => uris})
+      body = json_response(conn, 201)
+
+      assert body["redirect_uris"] == uris
+      assert {:ok, client} = Engram.OAuth.get_client(body["client_id"])
+      assert client.redirect_uris == uris
+    end
+
+    test "persists software_id and software_version when provided", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["https://example.com/cb"],
+          "client_name" => "Cursor",
+          "software_id" => "com.cursor.app",
+          "software_version" => "1.42.0"
+        })
+
+      body = json_response(conn, 201)
+
+      assert {:ok, client} = Engram.OAuth.get_client(body["client_id"])
+      assert client.software_id == "com.cursor.app"
+      assert client.software_version == "1.42.0"
+    end
   end
 
   describe "POST /oauth/register — invalid input" do
@@ -124,6 +155,25 @@ defmodule EngramWeb.OAuthRegisterControllerTest do
 
       body = json_response(conn, 400)
       assert body["error"] == "invalid_client_metadata"
+    end
+
+    test "rejects malformed JSON body with 400", %{conn: conn} do
+      assert_error_sent(400, fn ->
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/oauth/register", "{not valid json")
+      end)
+    end
+
+    test "rejects oversized body with 413", %{conn: conn} do
+      # Endpoint's Plug.Parsers length cap is 11_000_000 bytes — push past it.
+      oversized = String.duplicate("a", 11_000_001)
+
+      assert_error_sent(413, fn ->
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/oauth/register", ~s({"redirect_uris":["https://x/cb"],"pad":"#{oversized}"}))
+      end)
     end
   end
 


### PR DESCRIPTION
## Summary

Adds ExUnit coverage for `POST /oauth/register` (MCP OAuth 2.1 Dynamic Client Registration) — fills part of the v1-launch checklist in #278. Test-only PR.

New cases:
- Multi https `redirect_uris` accepted
- `software_id` / `software_version` persisted (via `Engram.OAuth.get_client/1`)
- Malformed JSON body → 400 (`assert_error_sent`)
- Oversized body → 413 (`assert_error_sent`, validates the `length: 11_000_000` cap in `endpoint.ex`)

## Out of scope (filed as #282)

Writing tests surfaced real impl gaps:
- 500 crash on non-array `redirect_uris` (cast-error formatter chokes on tuple opts)
- Missing telemetry event `[:engram, :mcp, :dcr, :register]`
- `token_endpoint_auth_method` validation accepts `client_secret_post`/`basic` but no secret minting exists
- Serializer drops `software_id` / `software_version`
- Schema has no `logo_uri` / `tos_uri` / `policy_uri` columns

These are tracked in #282 to keep this PR test-only.

## Version

Bumped `mix.exs` 0.5.207 → 0.5.208 (required by pre-push hook).

## Test plan

- [x] `mix test test/engram_web/controllers/oauth_register_controller_test.exs` — 14 tests, 0 failures
- [ ] CI green

Refs #278 #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)