### PR TITLE
fix(embed): snooze EmbedNote on Voyage 429 (layer 1 of 3)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -81,6 +81,13 @@ if config_env() != :test do
     config :engram, :query_embed_model, query_model
   end
 
+  # Voyage 429 → snooze duration (seconds). Tune as Voyage RPM grows: lower
+  # values churn jobs faster once budget is restored; higher values are gentler
+  # on a small bucket. Default 60s suits both free-tier (3 RPM) and paid.
+  if secs = System.get_env("EMBED_429_SNOOZE_SECONDS") do
+    config :engram, :embed_429_snooze_seconds, String.to_integer(secs)
+  end
+
   if System.get_env("QDRANT_URL") do
     config :engram, :qdrant_url, System.get_env("QDRANT_URL")
   end

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -166,6 +166,13 @@ defmodule Engram.Workers.EmbedNote do
 
   defp estimate_note_tokens(_), do: 0
 
+  # Snooze duration after Voyage 429. Env-driven via `EMBED_429_SNOOZE_SECONDS`
+  # (wired in runtime.exs) so we can tune as Voyage RPM allotment grows. 60s is
+  # the right default for free-tier (3 RPM) and a safe ceiling for paid tier.
+  defp snooze_seconds_on_429 do
+    Application.get_env(:engram, :embed_429_snooze_seconds, 60)
+  end
+
   defp run_embed(note, old_path_hmac_b64) do
     user = Accounts.get_user!(note.user_id)
 
@@ -189,6 +196,19 @@ defmodule Engram.Workers.EmbedNote do
               {:ok, _count} ->
                 stamp_embed_hash(note)
                 :ok
+
+              # Voyage 429 — back off without burning an Oban attempt. Voyage's
+              # paid-tier RPM is finite; without this guard five consecutive
+              # rate-limit hits discard the job entirely. See
+              # docs/context/embed-rate-limit-defenses.md.
+              {:error, {429, _body}} ->
+                :telemetry.execute(
+                  [:engram, :embed, :rate_limited],
+                  %{count: 1},
+                  %{user_id: note.user_id, note_id: note.id}
+                )
+
+                {:snooze, snooze_seconds_on_429()}
 
               {:error, reason} ->
                 {:error, reason}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.208",
+      version: "0.5.209",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -110,6 +110,33 @@ defmodule Engram.Workers.EmbedNoteTest do
       assert {:discard, _} = perform_job(EmbedNote, %{note_id: 999_999})
     end
 
+    # Voyage rate-limit (429) must not burn an Oban attempt. Five 429s in a
+    # row would otherwise discard the job (see handoff
+    # 2026-05-24-embed-rate-limit-defenses.md: 1167 discards from free-tier
+    # 3-RPM bucket).
+    test "snoozes job when Voyage returns 429 rate-limit error", %{bypass: bypass, note: note} do
+      stub_qdrant(bypass)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts ->
+        {:error, {429, %{"detail" => "rate limit exceeded"}}}
+      end)
+
+      assert {:snooze, 60} = perform_job(EmbedNote, %{note_id: note.id})
+    end
+
+    test "returns {:error, _} for non-429 embed failures (preserves retry behavior)",
+         %{bypass: bypass, note: note} do
+      stub_qdrant(bypass)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts ->
+        {:error, {500, %{"detail" => "internal error"}}}
+      end)
+
+      assert {:error, {500, _}} = perform_job(EmbedNote, %{note_id: note.id})
+    end
+
     test "discards job when note is soft-deleted", %{user: user} do
       note = insert(:note, user: user, deleted_at: DateTime.utc_now())
       assert {:discard, _} = perform_job(EmbedNote, %{note_id: note.id})


### PR DESCRIPTION
## Summary

- Pattern-match `{:error, {429, _}}` from `Indexing.index_note/2` in `EmbedNote.run_embed/2` and return `{:snooze, N}` instead of `{:error, _}`. Oban's `:snooze` backs the job off WITHOUT incrementing `attempt`, so rate-limit pressure stops burning through `max_attempts: 5`.
- Snooze duration env-driven via `EMBED_429_SNOOZE_SECONDS` (default `60`) — tune as Voyage RPM allotment grows.
- Emits `[:engram, :embed, :rate_limited]` telemetry so layer 3 can hang an alert off it.

## Why

A recent incident produced 1167 discarded `EmbedNote` jobs against a free-tier 3-RPM Voyage bucket. The `ReconcileEmbeddings` 15-min cron eventually re-queued them once paid tier kicked in, but the failure mode is intrinsic to the worker — any future spike (large import, Voyage outage, noisy minute) reproduces it. Background in [`/tmp/handoff-2026-05-24-embed-rate-limit-defenses.md`](#).

## Layer 1 of 3 (each its own PR)

1. **This PR** — root-cause fix: snooze on 429, stop burning Oban attempts.
2. Preventative rate limiter in front of Voyage adapter (RPM via env, `hammer` already a dep).
3. Telemetry alert on Oban discard rate (after verifying PromEx state).

## Test plan

- [x] New unit test: `MockEmbedder` returns `{:error, {429, _}}` → assert `{:snooze, 60}` from `perform_job/2`.
- [x] New unit test: non-429 errors still return `{:error, _}` (preserves existing retry behavior).
- [x] Full suite: 1496 tests, 0 failures, 7 skipped.
- [x] `mix format --check-formatted` clean.
- [x] `mix credo --strict` clean for `embed_note.ex`.
- [ ] Manual smoke after merge: rely on prod telemetry — there's no good way to synthesize a Voyage 429 in staging without breaking real users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)