### PR TITLE
docs: add SECURITY.md (vulnerability disclosure policy)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+We take security seriously. If you've found a vulnerability in Engram, please
+report it privately so we can fix it before public disclosure.
+
+## Reporting a vulnerability
+
+Email **security@engram.page** with:
+
+- A description of the issue and its impact
+- Steps to reproduce (proof-of-concept if possible)
+- The version, commit SHA, or URL where you observed it
+- Whether you've shared this with anyone else
+
+We aim to acknowledge reports within **48 hours** and to provide a status
+update or fix within **14 days** for confirmed issues. Critical-severity
+issues are handled out-of-band.
+
+If you'd like to encrypt, ask in your first email and we'll arrange a key.
+
+## In scope
+
+- **SaaS production** — `app.engram.page` (web app + REST API + WebSocket +
+  MCP server)
+- **Backend** — this repository (`engram-app/engram`) when running a tagged
+  release
+- **Plugin** — `engram-app/Engram-obsidian` (Engram Vault Sync) when running
+  a tagged release. See its
+  [SECURITY.md](https://github.com/engram-app/Engram-obsidian/blob/main/SECURITY.md)
+  for plugin-specific scope.
+
+## Out of scope
+
+- Older releases superseded by a newer tagged version
+- Self-host deployments running on a private LAN (e.g., `engram.ax`,
+  user-operated docker-compose) — security depends on the operator's
+  network and infra
+- Third-party services we integrate with — please report directly upstream:
+  - Clerk (auth) — `security@clerk.com`
+  - Paddle (billing) — Paddle's responsible disclosure program
+  - Fly.io, Qdrant Cloud, Voyage AI, AWS — their respective programs
+- Findings that require physical access, a compromised endpoint, or social
+  engineering of an Engram employee
+- Denial-of-service from sustained load against shared infrastructure (a
+  heads-up is welcome, but it's not a vulnerability report)
+- Missing security headers, cookie attributes, or framework defaults without
+  a demonstrated impact
+- Vulnerabilities in unmaintained dependencies without a working exploit
+  path
+
+## Safe harbor
+
+We will not pursue legal action against good-faith research that:
+
+- Avoids privacy violations, data destruction, and service degradation
+- Stops at the minimum proof needed to demonstrate the issue
+- Does not access, modify, or exfiltrate other users' data beyond what's
+  strictly necessary to demonstrate the issue
+- Reports the issue to us privately before any public disclosure
+- Gives us reasonable time to fix before disclosing
+
+If in doubt about whether your testing falls under safe harbor, email us
+first and ask.
+
+## Bounty
+
+No paid bounty at launch. We will publicly credit researchers (with their
+permission) in release notes and in this file once we've shipped a fix.
+
+## Recent advisories
+
+None yet.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.208",
+      version: "0.5.209",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Adds canonical `SECURITY.md` with `security@engram.page` reporting address, 48h ack / 14d fix-or-status SLA.
- Scopes in `app.engram.page` SaaS + tagged backend/plugin releases; routes third-party (Clerk, Paddle, Fly, Qdrant, Voyage, AWS) to upstream programs.
- Safe-harbor language + no-bounty + credit-in-release-notes policy.
- Excludes `engram.ax` and operator-deployed self-host LANs (security depends on operator infra).
- Paired plugin PR: engram-app/Engram-obsidian#78.

Partial resolution of #273 — remaining acceptance items still open:
- [ ] `security@engram.page` DNS MX + mailbox (folds with #251)
- [ ] Footer link on `engram.page` (marketing-repo follow-up)

mix.exs bumped 0.5.208 → 0.5.209 to pass the pre-push hook.

## Test plan

- [ ] Confirm rendered markdown + cross-repo link to plugin SECURITY.md resolve.
- [ ] After merge, verify GitHub surfaces the file at `/engram-app/engram/security/policy`.
- [ ] Follow-up issue: track DNS MX + marketing footer link separately so #273 can close cleanly once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)