### PR TITLE
feat(embed): client-side Voyage rate limiter (layer 2 of 3)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -81,6 +81,14 @@ if config_env() != :test do
     config :engram, :query_embed_model, query_model
   end
 
+  # Client-side Voyage rate limit. Unset = no throttle (self-host default).
+  # Set to your Voyage paid-tier RPM (e.g. 2000) to fail fast with a synthetic
+  # 429 before burning real API calls. EmbedNote snoozes on the synthetic 429
+  # just like a real one. Bump this as the Voyage allotment grows.
+  if rpm = System.get_env("VOYAGE_RPM") do
+    config :engram, :voyage_rpm, String.to_integer(rpm)
+  end
+
   if System.get_env("QDRANT_URL") do
     config :engram, :qdrant_url, System.get_env("QDRANT_URL")
   end

--- a/lib/engram/embedders/voyage.ex
+++ b/lib/engram/embedders/voyage.ex
@@ -22,6 +22,12 @@ defmodule Engram.Embedders.Voyage do
 
   @impl true
   def embed_texts(texts, opts) when is_list(texts) do
+    with :ok <- throttle_check() do
+      do_embed_texts(texts, opts)
+    end
+  end
+
+  defp do_embed_texts(texts, opts) do
     url = Application.get_env(:engram, :voyage_url, @default_url)
     model = Keyword.get(opts, :model, Application.get_env(:engram, :embed_model, @default_model))
 
@@ -53,6 +59,39 @@ defmodule Engram.Embedders.Voyage do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  # Client-side rate limit. Enabled when `:voyage_rpm` is set (env: VOYAGE_RPM).
+  # When the bucket is empty we synthesize the same `{:error, {429, body}}`
+  # shape Voyage returns on a real rate-limit response, so callers (notably
+  # `Engram.Workers.EmbedNote`) handle both paths identically — the
+  # snooze-on-429 logic fires for either case.
+  #
+  # Bucket key is `:voyage_throttle_key` (default "voyage_embed") so tests can
+  # use per-test keys to avoid collisions on the shared ETS limiter table.
+  defp throttle_check do
+    case Application.get_env(:engram, :voyage_rpm) do
+      nil ->
+        :ok
+
+      rpm when is_integer(rpm) and rpm > 0 ->
+        key = Application.get_env(:engram, :voyage_throttle_key, "voyage_embed")
+
+        case EngramWeb.RateLimiter.hit(key, 60_000, rpm) do
+          {:allow, _count} ->
+            :ok
+
+          {:deny, retry_after_ms} ->
+            :telemetry.execute(
+              [:engram, :embed, :client_rate_limited],
+              %{count: 1, retry_after_ms: retry_after_ms},
+              %{rpm: rpm}
+            )
+
+            {:error,
+             {429, %{"detail" => "client_rate_limited", "retry_after_ms" => retry_after_ms}}}
+        end
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.208",
+      version: "0.5.210",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/embedders/voyage_test.exs
+++ b/test/engram/embedders/voyage_test.exs
@@ -73,6 +73,69 @@ defmodule Engram.Embedders.VoyageTest do
     end
   end
 
+  describe "client-side rate limit (VOYAGE_RPM)" do
+    setup do
+      # Per-test bucket key prevents cross-pollination between async tests
+      # sharing the EngramWeb.RateLimiter ETS table.
+      key = "voyage_embed_test_#{:erlang.unique_integer([:positive])}"
+      Application.put_env(:engram, :voyage_throttle_key, key)
+      on_exit(fn -> Application.delete_env(:engram, :voyage_throttle_key) end)
+      :ok
+    end
+
+    test "no throttle when VOYAGE_RPM is unset (default)", %{bypass: bypass} do
+      refute Application.get_env(:engram, :voyage_rpm)
+
+      Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->
+        resp = %{"data" => [%{"embedding" => [0.1]}]}
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _} = Voyage.embed_texts(["hello"])
+    end
+
+    test "returns synthetic 429 once bucket is exhausted, without hitting HTTP", %{bypass: bypass} do
+      Application.put_env(:engram, :voyage_rpm, 1)
+      on_exit(fn -> Application.delete_env(:engram, :voyage_rpm) end)
+
+      Bypass.expect(bypass, "POST", "/v1/embeddings", fn conn ->
+        resp = %{"data" => [%{"embedding" => [0.1]}]}
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(resp))
+      end)
+
+      # First call consumes the only token.
+      assert {:ok, _} = Voyage.embed_texts(["hello"])
+
+      # Second call must NOT hit Bypass — synthetic 429 instead.
+      assert {:error, {429, body}} = Voyage.embed_texts(["world"])
+      assert body["detail"] == "client_rate_limited"
+      assert is_integer(body["retry_after_ms"])
+    end
+
+    test "allows calls when bucket has tokens", %{bypass: bypass} do
+      Application.put_env(:engram, :voyage_rpm, 10)
+      on_exit(fn -> Application.delete_env(:engram, :voyage_rpm) end)
+
+      Bypass.expect(bypass, "POST", "/v1/embeddings", fn conn ->
+        resp = %{"data" => [%{"embedding" => [0.1]}]}
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _} = Voyage.embed_texts(["a"])
+      assert {:ok, _} = Voyage.embed_texts(["b"])
+      assert {:ok, _} = Voyage.embed_texts(["c"])
+    end
+  end
+
   describe "embed_texts/2" do
     test "uses model override when provided", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->


### PR DESCRIPTION
## Summary

- Wraps `Engram.Embedders.Voyage.embed_texts/2` with a token-bucket check against the already-supervised `EngramWeb.RateLimiter` (Hammer/ETS) before the HTTP call.
- Enabled when `VOYAGE_RPM` env var is set. Unset = no throttle — self-host default; nothing changes for users without the env var.
- When the bucket is empty, returns `{:error, {429, %{\"detail\" => \"client_rate_limited\", \"retry_after_ms\" => N}}}` — **the exact same shape** Voyage returns on a real 429, so Layer 1's `EmbedNote` snooze pattern fires identically for either source. No new branches in the worker.
- Bucket key configurable via `:voyage_throttle_key` so async tests use unique keys and don't collide on the shared ETS table.
- Emits `[:engram, :embed, :client_rate_limited]` telemetry for Layer 3.

## Why

Layer 1 (#284) handles the response side — if Voyage 429s, we snooze. Layer 2 prevents most of those 429s from ever happening: fail fast locally against a known bucket size before burning a real API call. Self-tuning is deferred — `VOYAGE_RPM` is env-driven so it can be bumped as the Voyage paid-tier allotment grows.

## Layer 2 of 3

1. ~~Layer 1: snooze on real Voyage 429~~ — #284
2. **This PR** — preventative client-side throttle
3. Layer 3: telemetry alert on Oban discard rate (next)

## Test plan

- [x] New test: `VOYAGE_RPM` unset → no throttle, real HTTP hit.
- [x] New test: bucket exhausted → synthetic 429 returned WITHOUT hitting HTTP.
- [x] New test: under-bucket calls all succeed.
- [x] Existing voyage_test.exs assertions unchanged.
- [x] Full suite: 1497 tests, 0 failures, 7 skipped.
- [x] `mix format --check-formatted` clean.
- [x] `mix credo --strict` clean for `voyage.ex`.
- [ ] Manual smoke after merge: set `VOYAGE_RPM=1` in a staging container, watch `[:engram, :embed, :client_rate_limited]` telemetry fire and EmbedNote jobs snooze cleanly.

## Config

```sh
VOYAGE_RPM=2000   # paid-tier RPM; unset for no throttle
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)