### PR TITLE
feat(legal): add §5 support/privacy/security SLA to ToS placeholder

### DIFF
--- a/frontend/src/legal/terms-of-service.tsx
+++ b/frontend/src/legal/terms-of-service.tsx
@@ -1,4 +1,4 @@
-export const TERMS_VERSION = '2026-05-15'
+export const TERMS_VERSION = '2026-05-24'
 
 export function TermsContent() {
   return (
@@ -32,7 +32,32 @@ export function TermsContent() {
         You may cancel at any time from your account settings. We may suspend accounts that
         violate these Terms or applicable law.
       </p>
-      <h3>5. Changes</h3>
+      <h3>5. Support and response times</h3>
+      <p>
+        For account, billing, or service issues, email{' '}
+        <a href="mailto:support@engram.page">support@engram.page</a>. We aim to acknowledge
+        support requests within two business days. Billing disputes (refunds, double charges,
+        cancellation problems) are handled through Paddle as our Merchant of Record; you may
+        contact us directly or use Paddle's buyer support per their terms.
+      </p>
+      <p>
+        For privacy or data-protection requests (access, deletion, export), email{' '}
+        <a href="mailto:privacy@engram.page">privacy@engram.page</a>. We respond within thirty
+        days as required by GDPR Article 12.
+      </p>
+      <p>
+        For security vulnerabilities, please report privately to{' '}
+        <a href="mailto:security@engram.page">security@engram.page</a> following our{' '}
+        <a
+          href="https://github.com/engram-app/engram/blob/main/SECURITY.md"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          security policy
+        </a>
+        .
+      </p>
+      <h3>6. Changes</h3>
       <p>
         We may update these Terms; the version date at the top reflects the current revision.
         Continued use after a revision constitutes acceptance.
@@ -40,7 +65,10 @@ export function TermsContent() {
       <p>
         <em>
           Placeholder content. Replace with reviewed legal text before launch — coordination item
-          tracked in the spec at docs/superpowers/specs/2026-05-15-signup-wizard-design.md.
+          tracked in the spec at docs/superpowers/specs/2026-05-15-signup-wizard-design.md. The
+          Support / Privacy / Security contact paragraphs in §5 are intentionally launch-ready
+          even before lawyer review (they document operational reality and are tracked in #251 /
+          #273) — leave them in place when the rest of this file is replaced.
         </em>
       </p>
     </>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.209",
+      version: "0.5.210",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Closes #251 (code half).

Adds three operational contact clauses to the ToS placeholder in `frontend/src/legal/terms-of-service.tsx`:

- **support@engram.page** — 2-business-day SLA for account / billing / service issues
- **privacy@engram.page** — 30-day GDPR Article 12 response window for data-subject requests
- **security@engram.page** — points to `SECURITY.md` (#273) for vuln reports

Bumps `TERMS_VERSION` `2026-05-15` → `2026-05-24` so `RequireOnboarding` re-triggers acceptance for existing onboarded users.

Trailing placeholder note flags §5 as launch-ready and instructs the lawyer-review rewrite (#248) NOT to drop these clauses.

Paired runbook: `engram-app/engram-workspace#29` (merged) documents the ProtonMail-dashboard alias steps + inbound test procedure.

mix.exs 0.5.209 → 0.5.210.

## Test plan

- [ ] Render the rendered ToS page in `/legal/terms` — verify the three `mailto:` links + the SECURITY.md GitHub link.
- [ ] Confirm `RequireOnboarding` re-acceptance fires for a previously onboarded test user.
- [ ] After ProtonMail aliases are wired, run the inbound test from the paired runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)