### PR TITLE
docs(README): add Self-Host section pointing to public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,25 @@ Any AI assistant that speaks MCP can query your vault:
 - **Behaviour-based adapters** — swap embedding backends (Voyage AI / Ollama) without touching search logic
 - **No Redis required** — PubSub via Erlang distribution, caching via ETS
 
-## Quick Start
+## Self-Host
+
+Most operators should follow the **public docs** — they're more complete than this README and stay up-to-date with each release:
+
+- **[Quickstart](https://engram.page/docs/self-host/quickstart/)** — Docker Compose install, fewest steps to a running instance
+- **[Environment Variables](https://engram.page/docs/self-host/environment-variables/)** — full env reference
+- **[Encryption Setup](https://engram.page/docs/self-host/encryption/)** — master-key management, rotation, recovery
+- **[Backup & Restore](https://engram.page/docs/self-host/backup-restore/)** — what to back up, how to restore
+- **[Upgrade Path](https://engram.page/docs/self-host/upgrade/)** — moving between Engram versions safely
+- **[Troubleshooting](https://engram.page/docs/self-host/troubleshooting/)** — Qdrant unreachable, encryption-key errors, port conflicts, MinIO password
+- **[Why Self-Host](https://engram.page/docs/self-host/why-self-host/)** — when self-hosting makes sense
+
+**License:** Engram self-host is **PolyForm Small Business 1.0.0** — free for organizations with ≤ $1M/year in revenue/funding. Larger orgs need a commercial license (`support@engram.page`). See [`LICENSE`](./LICENSE) for the full terms + manual CLA flow for external contributors.
+
+**Security:** see [`SECURITY.md`](./SECURITY.md) for vuln disclosure. Self-host LAN deployments are out of scope of our published SLA — security depends on the operator's network and infra.
+
+The **Development Quick Start** below is for people *contributing to Engram itself* — not for running a production self-host instance.
+
+## Development Quick Start
 
 ### Prerequisites
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.210",
+      version: "0.5.211",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Closes engram-app/Engram#257 (README half — marketing half is engram-app/engram-marketing#89 merged).

- Inserts `## Self-Host` between Architecture and Quick Start in `README.md`
- Renames `## Quick Start` → `## Development Quick Start` so contributors and self-host operators don't conflate the two
- Pointers to the 7 public docs pages on engram.page (quickstart, env vars, encryption, backup-restore, upgrade, **new troubleshooting page** from #89, why-self-host)
- License (PolyForm SBL) + SECURITY.md cross-links up front so operators see them before the dev quickstart
- mix.exs 0.5.210 → 0.5.211

## Why pointers instead of inlined content

Backend README and marketing docs site drift the moment they say the same thing twice. One canonical source (docs site, kept current per-release) + one navigational pointer (README) is the durable arrangement.

## Test plan

- [ ] Render README on GitHub — verify all 7 docs links resolve to engram.page (they will once #89 lands; troubleshooting is the only new path).
- [ ] Confirm contributors aren't surprised by the Quick Start rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)