### PR TITLE
feat(telemetry): declare counters for embed rate-limit events

### DIFF
--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -170,6 +170,28 @@ defmodule EngramWeb.Telemetry do
         tags: [:gate_path, :op],
         description:
           "T3.7 writes/reads blocked by RotationGate (channel/worker bypass path). Tags: gate_path (:channel | :worker), op (handler/worker name)"
+      ),
+
+      # PR #289 — embed rate-limit defense surfaces.
+      #
+      # Three events emitted by the Voyage rate-limit defense-in-depth layers.
+      # Declared here so a future reporter (PromEx / telemetry_metrics_prometheus
+      # / StatsD / OTel) picks them up without a second PR. Pinned by
+      # `test/engram_web/telemetry_test.exs`.
+      counter("engram.embed.rate_limited.count",
+        tags: [:vault_id],
+        description:
+          "Real Voyage 429 (post-network) — each event = one snoozed EmbedNote job. Layer 1 surface. Non-zero = either real Voyage rate-limit hits OR Layer 2 leaking; use `engram.embed.client_rate_limited.count` to distinguish."
+      ),
+      counter("engram.embed.client_rate_limited.count",
+        tags: [:purpose],
+        description:
+          "Synthetic 429 from local Hammer throttle (Layer 2). Tag `:purpose` (:query | :index) is the signal for rebalancing VOYAGE_RPM vs VOYAGE_QUERY_RPM from facts."
+      ),
+      counter("engram.oban.discarded.count",
+        tags: [:worker, :queue],
+        description:
+          "Jobs that exhausted max_attempts and were dropped by Oban. Layer 3 surface — non-zero is a triage signal."
       )
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.212",
+      version: "0.5.213",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/telemetry_test.exs
+++ b/test/engram_web/telemetry_test.exs
@@ -116,4 +116,47 @@ defmodule EngramWeb.TelemetryTest do
              "ProviderMigration per-user duration must be measured"
     end
   end
+
+  describe "metrics/0 — embed rate-limit observability (PR #289)" do
+    # Same pinning rationale as the crypto block: PR #289 introduced three
+    # telemetry events as defense-in-depth against Voyage rate-limit cascades
+    # (Layer 1 snooze on real 429, Layer 2 synthetic 429 from local throttle,
+    # Layer 3 Oban discard surface). Without Telemetry.Metrics declarations,
+    # any future reporter (PromEx / telemetry_metrics_prometheus / StatsD)
+    # silently ignores them — the "we emit telemetry" defense in PR #289
+    # collapses into "we emit nothing reachable." This block keeps each
+    # event declared so the registration cannot quietly drift.
+
+    setup do
+      names =
+        EngramWeb.Telemetry.metrics()
+        |> Enum.map(fn metric ->
+          metric.name |> Enum.map_join(".", &Atom.to_string/1)
+        end)
+        |> MapSet.new()
+
+      {:ok, names: names}
+    end
+
+    test "registers engram.embed.rate_limited counter (Layer 1 — real Voyage 429)", %{
+      names: names
+    } do
+      assert "engram.embed.rate_limited.count" in names,
+             "Real Voyage 429 (post-network) snoozes must be counted — primary signal that Voyage's actual rate-limit is hitting us"
+    end
+
+    test "registers engram.embed.client_rate_limited counter (Layer 2 — local throttle)", %{
+      names: names
+    } do
+      assert "engram.embed.client_rate_limited.count" in names,
+             "Synthetic 429 from local Hammer throttle must be counted — tag :purpose (:query | :index) is the signal for rebalancing VOYAGE_RPM vs VOYAGE_QUERY_RPM"
+    end
+
+    test "registers engram.oban.discarded counter (Layer 3 — terminal job drops)", %{
+      names: names
+    } do
+      assert "engram.oban.discarded.count" in names,
+             "Oban jobs that exhausted max_attempts must be counted — non-zero is a triage signal"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

PR #289 introduced three telemetry events as defense-in-depth against Voyage rate-limit cascades but did NOT declare them as `Telemetry.Metrics` in `EngramWeb.Telemetry`. `Telemetry.Metrics` only forwards events that are declared — so any future reporter (PromEx / `telemetry_metrics_prometheus` / StatsD / OTel) silently ignores them. This PR closes that gap.

**Definitions-only.** No new dep, no reporter, no supervisor change. Just three `counter(...)` entries.

## Why now

When you eventually wire a reporter, the data flows through with zero extra work. Without these declarations, you'd ship the reporter and immediately need a second PR to make the rate-limit signals visible.

## Counters added

| Counter | Tags | Source event | Use |
|---------|------|--------------|-----|
| `engram.embed.rate_limited.count` | `:vault_id` | `[:engram, :embed, :rate_limited]` (Layer 1) | Real Voyage 429 (post-network). Non-zero = either Voyage's actual cap is hitting us OR Layer 2 is leaking. |
| `engram.embed.client_rate_limited.count` | `:purpose` | `[:engram, :embed, :client_rate_limited]` (Layer 2) | Synthetic 429 from local Hammer throttle. **`:purpose` tag (`:query \| :index`) is the exact signal needed to rebalance `VOYAGE_RPM` vs `VOYAGE_QUERY_RPM` from facts.** |
| `engram.oban.discarded.count` | `:worker`, `:queue` | `[:engram, :oban, :discarded]` (Layer 3) | Terminal job drops. Non-zero = triage signal. |

## Open follow-up (NOT this PR)

Choose a reporter (PromEx → Grafana is the workspace's stated intent per `[[project_saas_architecture]]` memory; lightweight `telemetry_metrics_prometheus` if a `/metrics` endpoint is enough). Separate PR + dep + supervisor wiring. Tracked here only as a note.

## Test plan

- [x] New describe block in `test/engram_web/telemetry_test.exs` mirrors the existing crypto pinning pattern — one assertion per counter, so future drift breaks the build.
- [x] `mix test test/engram_web/telemetry_test.exs` — 18 tests, 0 failures.
- [x] Full suite — 1506 tests, 0 failures, 7 skipped.
- [x] `mix format --check-formatted` clean.
- [x] `mix credo --strict lib/engram_web/telemetry.ex` clean.

## References

- PR #289 (event origins) — https://github.com/engram-app/Engram/pull/289
- engram-infra #132 (env vars activating the throttle) — https://github.com/engram-app/engram-infra/pull/132

🤖 Generated with [Claude Code](https://claude.com/claude-code)