### PR TITLE
ci(bump-bot): sign commits via GraphQL so engram-infra ruleset accepts them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1865,6 +1865,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           branch: bot/bump-engram-staging-fastraid
           delete-branch: true
+          # engram-infra's ruleset enforces required_signatures = true.
+          # sign-commits routes the commit through the GraphQL
+          # createCommitOnBranch mutation, which GitHub auto-signs on
+          # behalf of the engram-infra-tf App. Without this the bot's
+          # branch commit is unsigned and the PR blocks at merge time
+          # with "Commits must have verified signatures."
+          sign-commits: true
           commit-message: |
             chore(staging-fastraid): bump engram image to ${{ steps.version.outputs.version }}
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.213",
+      version: "0.5.214",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Add \`sign-commits: true\` to the \`peter-evans/create-pull-request@v8\` step in \`bump-infra-tfvars\` job
- Routes the commit through GitHub's \`createCommitOnBranch\` GraphQL mutation, which GitHub auto-signs on behalf of the engram-infra-tf App identity (same mechanism that makes Dependabot commits show as Verified — no bot-side key needed)

## Why

engram-infra's \`protect-main\` ruleset requires verified signatures. The bumper's branch commit was created via git-CLI push (unsigned), so auto-merge sits on \"Commits must have verified signatures.\" even though the engram-infra-tf App has \`bypass_mode: always\` on the ruleset — GitHub's auto-merge state machine evaluates the requirement up-front and refuses to advance regardless of bypass (same pattern as the REVIEW_REQUIRED issue that engram-app/engram-infra#134 just fixed).

## Test plan

- [ ] Next release fires \`bump-infra-tfvars\` → bot opens PR with signed commit (green \"Verified\" badge on the commit)
- [ ] Auto-merge fires once CI green, no manual click needed
- [ ] Current stuck PR (engram-app/engram-infra#111) handled one-off with \`gh pr merge 111 --admin --squash -R engram-app/engram-infra\`

## Refs

- Companion: engram-app/engram-infra#134 (ruleset loosening — review-count → 0)
- peter-evans \`sign-commits\` docs: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)