### PR TITLE
ci: mint engram-infra-tf token via client-id, not deprecated app-id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1760,7 +1760,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: engram-app
           repositories: engram-infra

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.217",
+      version: "0.5.218",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
Migrates the last `create-github-app-token@v3` job still on the deprecated `app-id` input — the **Generate engram-infra App installation token** step — to the recommended `client-id`. The other three app-token jobs in this workflow already use `client-id`.

Removes this from every release run:
> `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`

## Changes
- `app-id: ${{ secrets.GH_APP_ID }}` → `client-id: ${{ vars.GH_APP_CLIENT_ID }}`
- New repo **variable** `GH_APP_CLIENT_ID = Iv23liWnpcVYV0fnjGw1` (the `engram-infra-tf` App's client id). Stored as a variable, not a secret — client IDs are non-sensitive and this matches the existing `vars.ENGRAM_CI_CLIENT_ID` convention.
- `private-key` / `owner` / `repositories: engram-infra` scope unchanged.
- `mix.exs` 0.5.217 → 0.5.218 (repo pre-push policy).

## Context
Companion to engram-infra#136, which fixed the same warning in the engram-infra repo and traced an earlier `iss must be Integer` failure to a wrong `GH_APP_CLIENT_ID` **secret** value there. This repo uses the verified-correct client id from the start, so no such risk.

## Verification
- [ ] The engram-infra-token job mints via `client-id` with no `iss` error and no `app-id deprecated` warning (note: this job runs on the release path; confirm on a run that exercises it).