### PR TITLE
feat(selfhost): canonical docker-compose.yml + .env.example (#171)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,14 @@ ENCRYPTION_MASTER_KEY=
 # Examples: localhost  |  engram.example.com  |  engram.example.com,10.0.20.5:4000
 PHX_HOST=localhost
 
+# Scheme + port used when BUILDING advertised URLs (OAuth/MCP discovery
+# documents, device-flow links, email links). The release runs in prod mode,
+# which defaults these to https / 443 — correct when you're behind a TLS
+# reverse proxy (the normal setup). For a plain-http trial on localhost, set
+# both so the advertised URLs match where the app actually listens:
+#   PHX_SCHEME=http
+#   PHX_PORT=4000
+
 # ─── Auth ──────────────────────────────────────────────────────────────────
 # local = built-in email/password (zero third-party config). clerk = SaaS JWKS.
 AUTH_PROVIDER=local

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,79 @@
+# Engram self-host configuration. Copy to .env and fill in the three secrets
+# below. Defaults are wired for the docker-compose.yml stack and work as-is.
+#
+#   cp .env.example .env
+#
+# Do NOT commit .env — it holds your secrets.
+#
+# Service addressing (DATABASE_URL, QDRANT_URL, OLLAMA_URL, STORAGE_HOST) is
+# set by docker-compose.yml to match the container network; you don't set it
+# here.
+
+# ─── Required secrets ───────────────────────────────────────────────────────
+# Generate each with the command shown, then paste the value.
+
+# openssl rand -base64 48
+SECRET_KEY_BASE=
+
+# openssl rand -base64 48
+JWT_SECRET=
+
+# 32-byte key, base64-encoded:  openssl rand -base64 32
+# Losing this makes every encrypted note unrecoverable — back it up.
+ENCRYPTION_MASTER_KEY=
+
+# ─── Host ────────────────────────────────────────────────────────────────────
+# Public hostname. The first entry is canonical (URLs, emails); all entries are
+# added to the CORS + WebSocket allowlist. Comma-separated, ports allowed.
+# Examples: localhost  |  engram.example.com  |  engram.example.com,10.0.20.5:4000
+PHX_HOST=localhost
+
+# ─── Auth ──────────────────────────────────────────────────────────────────
+# local = built-in email/password (zero third-party config). clerk = SaaS JWKS.
+AUTH_PROVIDER=local
+
+# ─── Encryption key provider ─────────────────────────────────────────────────
+# local = ENCRYPTION_MASTER_KEY above. aws_kms = managed CMK (needs AWS_* vars).
+KEY_PROVIDER=local
+
+# ─── Embedding ───────────────────────────────────────────────────────────────
+# Default: local Ollama (no API key, runs in the stack). The ollama-init
+# service pulls nomic-embed-text on first `up`.
+EMBED_BACKEND=ollama
+EMBED_MODEL=nomic-embed-text
+EMBED_DIMS=768
+
+# To use Voyage AI instead (better quality, needs an API key + outbound calls):
+#   EMBED_BACKEND=voyage
+#   EMBED_MODEL=voyage-4-large
+#   EMBED_DIMS=1024
+#   VOYAGE_API_KEY=
+#   DOC_EMBED_MODEL=voyage-4-large    # optional asymmetric retrieval
+#   QUERY_EMBED_MODEL=voyage-4-lite
+
+# ─── Vector store (Qdrant) ───────────────────────────────────────────────────
+QDRANT_COLLECTION=obsidian_notes
+# Binary quantization needs an AVX2-capable CPU. Disable on older hardware:
+#   QDRANT_BINARY_QUANTIZATION=false
+
+# ─── Attachment storage (MinIO, S3-compatible) ───────────────────────────────
+# Only "s3" is supported. The minio service uses these same creds.
+STORAGE_BACKEND=s3
+STORAGE_BUCKET=engram-attachments
+STORAGE_ACCESS_KEY_ID=minioadmin
+STORAGE_SECRET_ACCESS_KEY=minioadmin
+STORAGE_REGION=us-east-1
+
+# ─── Optional: reranker (Jina) ───────────────────────────────────────────────
+#   RERANKER_BACKEND=jina
+#   JINA_URL=
+
+# ─── Optional: transactional email (Resend) ──────────────────────────────────
+#   RESEND_API_KEY=
+#   EMAIL_FROM=you@example.com
+
+# ─── Optional: AWS KMS key provider (KEY_PROVIDER=aws_kms) ────────────────────
+#   AWS_KMS_KEY_ID=
+#   AWS_REGION=
+#   AWS_ACCESS_KEY_ID=
+#   AWS_SECRET_ACCESS_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ plugin/
 priv/static/app/
 
 .env*
+!.env.example
 frontend/.vite/
 .worktrees/
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ Most operators should follow the **public docs** — they're more complete than 
 - **[Troubleshooting](https://engram.page/docs/self-host/troubleshooting/)** — Qdrant unreachable, encryption-key errors, port conflicts, MinIO password
 - **[Why Self-Host](https://engram.page/docs/self-host/why-self-host/)** — when self-hosting makes sense
 
+### Quickstart (Docker Compose)
+
+The repo root ships a canonical [`docker-compose.yml`](./docker-compose.yml) (app + Postgres + Qdrant + Ollama + MinIO) and [`.env.example`](./.env.example):
+
+```bash
+git clone https://github.com/engram-app/engram
+cd engram
+cp .env.example .env
+# generate the three secrets and paste them into .env:
+#   openssl rand -base64 48   # SECRET_KEY_BASE
+#   openssl rand -base64 48   # JWT_SECRET
+#   openssl rand -base64 32   # ENCRYPTION_MASTER_KEY  (back this up!)
+docker compose up --build     # first build compiles the release (~few min)
+```
+
+The app comes up on `http://localhost:4000` (the only host-exposed port; everything else stays on the private network). Migrations run automatically on boot, and `ollama-init` pulls the default `nomic-embed-text` embedding model on first start.
+
 **License:** Engram self-host is **PolyForm Small Business 1.0.0** — free for organizations with ≤ $1M/year in revenue/funding. Larger orgs need a commercial license (`support@engram.page`). See [`LICENSE`](./LICENSE) for the full terms + manual CLA flow for external contributors.
 
 **Security:** see [`SECURITY.md`](./SECURITY.md) for vuln disclosure. Self-host LAN deployments are out of scope of our published SLA — security depends on the operator's network and infra.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,23 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      qdrant:
+        condition: service_started
+      ollama:
+        condition: service_healthy
       minio-init:
         condition: service_completed_successfully
       ollama-init:
         condition: service_completed_successfully
+    healthcheck:
+      # So `docker compose up` reports ready only after the release has booted
+      # + migrated and the endpoint is listening — not the instant the process
+      # forks. start_period covers release migrate + Phoenix listen.
+      test: ["CMD-SHELL", "curl -sf http://localhost:4000/api/health || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 10
     restart: unless-stopped
 
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,117 @@
+# Engram self-host stack — canonical quickstart.
+#
+#   cp .env.example .env      # then fill in the three generated secrets
+#   docker compose up --build # first build compiles the release (~few min)
+#
+# Only `engram` publishes a port to the host (4000). Postgres, Qdrant,
+# Ollama, and MinIO stay on the private `engram` network. The app runs
+# database migrations on boot (see entrypoint.sh) before serving.
+#
+# Service-to-service addressing (DATABASE_URL, *_URL, STORAGE_HOST) is fixed
+# in `environment:` below because it must match the service names on this
+# network — do not move it to .env. Everything a self-hoster actually tunes
+# (secrets, embedding backend, storage creds) lives in .env.
+
+services:
+  engram:
+    build: .
+    env_file: .env
+    environment:
+      # Docker-internal wiring — points at the service names on this network.
+      DATABASE_URL: postgresql://engram:engram@postgres:5432/engram
+      QDRANT_URL: http://qdrant:6333
+      OLLAMA_URL: http://ollama:11434
+      STORAGE_SCHEME: "http://"
+      STORAGE_HOST: minio
+      STORAGE_PORT: "9000"
+    ports:
+      - "4000:4000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+      ollama-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: engram
+      POSTGRES_PASSWORD: engram
+      POSTGRES_DB: engram
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U engram"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:v1.17.1
+    volumes:
+      - qdrant_data:/qdrant/storage
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  # One-shot: pull the default self-host embedding model so the first note
+  # indexes without a manual step. Exits 0 once the model is present.
+  ollama-init:
+    image: ollama/ollama:latest
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["ollama pull nomic-embed-text"]
+    restart: "no"
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      # Kept in sync with the engram app's STORAGE_* creds via .env defaults.
+      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY_ID:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_ACCESS_KEY:-minioadmin}
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # One-shot: create the attachments bucket, then exit.
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${STORAGE_ACCESS_KEY_ID:-minioadmin} ${STORAGE_SECRET_ACCESS_KEY:-minioadmin};
+      mc mb --ignore-existing local/${STORAGE_BUCKET:-engram-attachments};
+      exit 0;
+      "
+    restart: "no"
+
+volumes:
+  pg_data:
+  qdrant_data:
+  ollama_data:
+  minio_data:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.217",
+      version: "0.5.218",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.218",
+      version: "0.5.219",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.219",
+      version: "0.5.220",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
The public docs [self-host quickstart](https://engram.page/docs/self-host/quickstart) tells operators to `git clone && cp .env.example .env && docker compose up`, but neither file existed at the repo root — only CI/dev compose variants. This ships the canonical artifacts.

- **`docker-compose.yml`** — full self-host stack: `engram` (build from Dockerfile) + `postgres:16-alpine` + `qdrant` + `ollama` + `minio`. On a private network; **only `engram` publishes a host port (4000)**. Migrations run on boot via `entrypoint.sh`. An `ollama-init` one-shot pulls the default `nomic-embed-text` model so the first note indexes with no manual step; `minio-init` creates the attachments bucket.
- **`.env.example`** — the three required secrets with generation commands, embedding (Ollama default, Voyage commented), S3/MinIO storage, Qdrant, plus commented optionals (Jina reranker, Resend email, AWS KMS). Docker-internal addressing (`DATABASE_URL`, `*_URL`, `STORAGE_HOST`) is fixed in the compose file, not `.env`, since it must match service names.
- **README** — Self-Host section gets a concrete Docker Compose quickstart block pointing at both files.
- **.gitignore** — negate `.env.example` from the `.env*` ignore so the canonical file tracks (the older `.env*.example` files were force-added historically).

## Test plan
- [x] `docker compose config` validates; resolved config exposes only port 4000 and interpolates MinIO creds from `.env`
- [x] `mix format --check-formatted` clean
- [ ] Manual: `cp .env.example .env`, fill secrets, `docker compose up --build`, confirm app reachable on :4000 and a note indexes (Ollama path)

## Follow-up
- Marketing docs preview banner (engram-marketing#40) can be dropped once this merges.

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)