### PR TITLE
fix(e2e): wait on last-written region in test_54 per-hunk assert

### DIFF
--- a/e2e/tests/test_54_conflict_modal_ui.py
+++ b/e2e/tests/test_54_conflict_modal_ui.py
@@ -228,11 +228,14 @@ async def test_per_hunk_choices_mixed_then_accept(vault_a, vault_b, cdp_a, cdp_b
         await cdp_a.click_conflict_accept()
         await cdp_a.wait_for_conflict_modal_closed()
 
-        # Poll for the async vault.modify() flush; the file is written
-        # atomically so once hunk-0's content lands, hunk-1's is present too.
-        merged = wait_for_content(vault_a, path, "local-region-A", timeout=10)
-        assert "remote-region-B" in merged, (
-            f"Expected 'remote-region-B' (hunk 1 remote choice) in merged; "
+        # Poll for the async vault.modify() flush. Wait on the LAST-written
+        # region (hunk 1, end of file): vault.modify writes front-to-back, so
+        # if 'remote-region-B' is visible the earlier 'local-region-A' is too.
+        # Waiting on the leading region instead would leave a truncated-read
+        # window where hunk 0 is present but hunk 1 isn't yet flushed.
+        merged = wait_for_content(vault_a, path, "remote-region-B", timeout=10)
+        assert "local-region-A" in merged, (
+            f"Expected 'local-region-A' (hunk 0 local choice) in merged; "
             f"got: {merged[:400]!r}"
         )
     finally:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.222",
+      version: "0.5.223",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
Code-review hardening follow-up to #299. In `test_per_hunk_choices_mixed_then_accept`, `wait_for_content` polled for `local-region-A` (hunk 0, start of file) then asserted `remote-region-B` (hunk 1, end). `vault.modify()` writes the full content front-to-back, so a truncated read could observe the leading region before the trailing one is flushed — a residual (low-probability) race.

**Fix:** wait on the **last-written** region (`remote-region-B`) and assert the earlier one. If the trailing region is visible, the leading region is necessarily already written.

Pure test hardening; the write is single-shot so the window was theoretical, but it costs nothing to close. Identified in an independent review of #299. mix.exs 0.5.222 → 0.5.223.