### PR TITLE
feat(selfhost): optional Postgres bytea storage backend (#297)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,8 +64,13 @@ QDRANT_COLLECTION=obsidian_notes
 # Binary quantization needs an AVX2-capable CPU. Disable on older hardware:
 #   QDRANT_BINARY_QUANTIZATION=false
 
-# ─── Attachment storage (MinIO, S3-compatible) ───────────────────────────────
-# Only "s3" is supported. The minio service uses these same creds.
+# ─── Attachment storage ──────────────────────────────────────────────────────
+# "s3" (default): S3-compatible object store. The bundled minio service uses
+#   the STORAGE_* creds below.
+# "database": store attachments in Postgres as bytea — minified stack, no MinIO.
+#   Set STORAGE_BACKEND=database and comment out the minio + minio-init services
+#   in docker-compose.yml (see the note there). The STORAGE_* creds below are
+#   then unused. Fine for modest self-host vaults; not for scale.
 STORAGE_BACKEND=s3
 STORAGE_BUCKET=engram-attachments
 STORAGE_ACCESS_KEY_ID=minioadmin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
             lib priv config test frontend \
             Dockerfile entrypoint.sh \
             mix.exs mix.lock \
-            docker-compose.ci.yml docker-compose.ci-local.yml \
+            docker-compose.ci.yml docker-compose.ci-local.yml docker-compose.ci-database.yml \
             .github/workflows/ci.yml \
             | sha256sum | cut -d' ' -f1)
           # The e2e harness tree (helpers, fixtures, tests). Including it in
@@ -983,6 +983,83 @@ jobs:
         if: always()
         run: find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
+  storage-database:
+    needs: [fingerprint, prebuild-ci-image]
+    # Minified self-host path (#297): boot the release with STORAGE_BACKEND=database
+    # (Postgres bytea, no MinIO) and round-trip attachment bytes through the
+    # storage adapter via `bin/engram rpc`. This is the only job that exercises
+    # the no-MinIO boot path — the rest of CI runs STORAGE_BACKEND=s3. Skipped on
+    # cross-repo plugin dispatch (can't regress backend) and when the backend
+    # fingerprint already proved green.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true'
+    runs-on: [self-hosted, linux, x64, isolated]
+
+    env:
+      CI_PROJECT: engram-ci-db-${{ github.run_id }}
+      ENGRAM_CI_IMAGE: ${{ needs.prebuild-ci-image.outputs.image }}
+
+    steps:
+      - name: Reset sparse-checkout leaked from cross-repo jobs
+        run: |
+          if [ -d .git ] && { [ -f .git/info/sparse-checkout ] || [ "$(git config --get core.sparseCheckout 2>/dev/null)" = "true" ]; }; then
+            echo "::warning::Sparse-checkout leak detected — removing .git for fresh clone"
+            rm -rf .git
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          clean: false
+
+      - name: Allocate dynamic ports
+        id: ports
+        run: |
+          # Host-port publish is parallel-unsafe on the shared runner VM; pick
+          # free ports per run. (The round-trip uses `compose exec`, not the
+          # host port, but the compose file still publishes one.)
+          get_free_port() { python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()"; }
+          echo "engram_port=$(get_free_port)" >> "$GITHUB_OUTPUT"
+          echo "pg_port=$(get_free_port)" >> "$GITHUB_OUTPUT"
+
+      - name: Boot minified stack (bytea storage, no MinIO)
+        env:
+          CI_ENGRAM_PORT: ${{ steps.ports.outputs.engram_port }}
+          CI_PG_PORT: ${{ steps.ports.outputs.pg_port }}
+        run: |
+          docker compose -f docker-compose.ci-database.yml -p "$CI_PROJECT" down -v --remove-orphans 2>/dev/null || true
+          # --no-build: reuse the image the prebuild-ci-image job already built.
+          docker compose -f docker-compose.ci-database.yml -p "$CI_PROJECT" up -d --no-build --wait
+
+      - name: Round-trip attachment bytes through Postgres
+        run: |
+          # rpc runs on the booted node, so it proves runtime.exs selected the
+          # Database adapter AND the on-boot migration created storage_objects.
+          # Any failed match raises; the sentinel grep is the authoritative gate.
+          OUT=$(docker compose -f docker-compose.ci-database.yml -p "$CI_PROJECT" exec -T engram \
+            /app/bin/engram rpc '
+              key = "999/1/ci-smoke.bin"
+              data = :crypto.strong_rand_bytes(64)
+              Engram.Storage.Database = Engram.Storage.adapter()
+              :ok = Engram.Storage.adapter().put(key, data)
+              {:ok, ^data} = Engram.Storage.adapter().get(key)
+              true = Engram.Storage.adapter().exists?(key)
+              {:ok, 1} = Engram.Storage.adapter().delete_prefix("999/")
+              {:error, :not_found} = Engram.Storage.adapter().get(key)
+              IO.puts("STORAGE_DATABASE_ROUNDTRIP_OK")
+            ')
+          echo "$OUT"
+          echo "$OUT" | grep -q STORAGE_DATABASE_ROUNDTRIP_OK
+
+      - name: Collect logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.ci-database.yml -p "$CI_PROJECT" logs || true
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker compose -f docker-compose.ci-database.yml -p "$CI_PROJECT" down -v --remove-orphans --rmi local 2>/dev/null || true
+          docker image prune -f 2>/dev/null || true
+          docker volume prune -f 2>/dev/null || true
+
   lint:
     needs: [fingerprint, prebuild-mix]
     # Skip on cross-repo plugin dispatch — plugin can't regress backend lints.
@@ -1453,7 +1530,7 @@ jobs:
 
   ci:
     if: always() && (needs.fingerprint.outputs.backend-cache-hit != 'true' || needs.fingerprint.outputs.e2e-cache-hit != 'true')
-    needs: [fingerprint, version-check, unit-tests, lint, e2e-clerk, e2e-local, e2e-browser]
+    needs: [fingerprint, version-check, unit-tests, lint, storage-database, e2e-clerk, e2e-local, e2e-browser]
     runs-on: ubuntu-latest
     steps:
       - name: Check required jobs
@@ -1461,6 +1538,7 @@ jobs:
           VC="${{ needs.version-check.result }}"
           UT="${{ needs.unit-tests.result }}"
           LN="${{ needs.lint.result }}"
+          SD="${{ needs.storage-database.result }}"
           EC="${{ needs.e2e-clerk.result }}"
           EL="${{ needs.e2e-local.result }}"
           EB="${{ needs.e2e-browser.result }}"
@@ -1484,7 +1562,7 @@ jobs:
           # On cross-repo plugin dispatch (plugin-e2e-trigger), unit-tests / lint /
           # e2e-local / e2e-browser are intentionally skipped — plugin cannot regress
           # backend internals. Only assert success when those jobs actually ran.
-          for pair in "unit-tests=$UT" "lint=$LN" "e2e-local=$EL" "e2e-browser=$EB"; do
+          for pair in "unit-tests=$UT" "lint=$LN" "storage-database=$SD" "e2e-local=$EL" "e2e-browser=$EB"; do
             name="${pair%=*}"; result="${pair#*=}"
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "::error::$name failed: $result"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,9 +24,12 @@ config :engram, EngramWeb.Endpoint,
   http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 
 if config_env() != :test do
-  # Storage backend — S3-compatible only (A.5, PR #62). The legacy BYTEA
-  # `Storage.Database` adapter is gone; STORAGE_BACKEND is informational and
-  # only "s3" is accepted (default).
+  # Storage backend. Default "s3" is the SaaS/prod path (Fly Tigris) and the
+  # standard self-host path (MinIO). "database" is a self-host-only convenience
+  # (#297) that stores attachment bytes in Postgres `bytea` so a minified stack
+  # can drop MinIO — not for scale (that's why BYTEA was removed for SaaS in
+  # A.5/PR #62); it stores opaque ciphertext in a generic `storage_objects`
+  # table, NOT the old `attachments.content` column.
   case System.get_env("STORAGE_BACKEND", "s3") do
     "s3" ->
       config :engram, :storage, Engram.Storage.S3
@@ -42,11 +45,14 @@ if config_env() != :test do
         host: System.get_env("STORAGE_HOST"),
         port: String.to_integer(System.get_env("STORAGE_PORT", "443"))
 
+    "database" ->
+      config :engram, :storage, Engram.Storage.Database
+
     other ->
       raise """
-      Unknown STORAGE_BACKEND=#{inspect(other)} — only \"s3\" is supported
-      since A.5 (PR #62). The BYTEA Storage.Database adapter was removed
-      along with the `attachments.content` column.
+      Unknown STORAGE_BACKEND=#{inspect(other)} — supported values are
+      "s3" (default; SaaS Tigris / self-host MinIO) and "database"
+      (self-host-only Postgres bytea, #297).
       """
   end
 

--- a/docker-compose.ci-database.yml
+++ b/docker-compose.ci-database.yml
@@ -1,0 +1,59 @@
+# Minified self-host stack for CI (#297) — proves STORAGE_BACKEND=database
+# boots and round-trips attachment bytes through Postgres with NO MinIO.
+#
+# Only engram + postgres: AUTH_PROVIDER defaults to "local" (no Clerk child),
+# and the supervision tree starts no Qdrant/Ollama client, so this is the
+# smallest stack the release can boot in. The `storage-database` CI job runs
+#   bin/engram rpc <put/get/delete round-trip>
+# against this stack to exercise the bytea adapter end-to-end.
+#
+#   ENGRAM_CI_IMAGE=<tag> docker compose -f docker-compose.ci-database.yml \
+#     -p engram-ci-db up -d --no-build --wait
+
+name: engram-ci-db
+
+services:
+  engram:
+    image: ${ENGRAM_CI_IMAGE:-engram-ci:local}
+    build:
+      context: .
+      args:
+        NODE_IMAGE: ${LOCAL_REGISTRY:-docker.io}/node:20-slim
+        BUILDER_IMAGE: ${LOCAL_REGISTRY:-docker.io}/hexpm/elixir:1.17.3-erlang-27.1.2-debian-bookworm-20241202-slim
+        RUNNER_IMAGE: ${LOCAL_REGISTRY:-docker.io}/debian:bookworm-20241202-slim
+    ports:
+      - "${CI_ENGRAM_PORT:-8110}:4000"
+    environment:
+      SECRET_KEY_BASE: "ci-test-secret-base-not-for-production-at-least-64-bytes-long-enough-for-phoenix"
+      DATABASE_URL: postgresql://engram:engram@postgres:5432/engram
+      JWT_SECRET: ci-test-secret-not-for-production
+      PHX_SERVER: "true"
+      KEY_PROVIDER: ${KEY_PROVIDER:-local}
+      ENCRYPTION_MASTER_KEY: ${ENCRYPTION_MASTER_KEY:?ENCRYPTION_MASTER_KEY must be set (CI workflow injects from secret)}
+      # The whole point of this stack: bytea storage, no MinIO sidecar.
+      STORAGE_BACKEND: database
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4000/api/health || exit 1"]
+      start_period: 10s
+      interval: 1s
+      timeout: 2s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  postgres:
+    image: ${LOCAL_REGISTRY:-docker.io}/postgres:16-alpine
+    ports:
+      - "${CI_PG_PORT:-5443}:5432"
+    environment:
+      POSTGRES_USER: engram
+      POSTGRES_PASSWORD: engram
+      POSTGRES_DB: engram
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U engram"]
+      interval: 1s
+      timeout: 2s
+      retries: 30
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@
 # in `environment:` below because it must match the service names on this
 # network — do not move it to .env. Everything a self-hoster actually tunes
 # (secrets, embedding backend, storage creds) lives in .env.
+#
+# Minified stack (no MinIO): set STORAGE_BACKEND=database in .env to store
+# attachments in Postgres bytea, then delete/comment out the `minio` and
+# `minio-init` services below, the `minio_data` volume, the `minio-init`
+# entry under engram's `depends_on:`, and engram's STORAGE_SCHEME/HOST/PORT
+# environment lines. (Suited to modest vaults — see #297.)
 
 services:
   engram:

--- a/lib/engram/storage/database.ex
+++ b/lib/engram/storage/database.ex
@@ -29,15 +29,16 @@ defmodule Engram.Storage.Database do
   def put(key, binary, _opts \\ []) when is_binary(key) and is_binary(binary) do
     now = DateTime.utc_now(:microsecond)
 
-    Repo.query!(
-      """
-      INSERT INTO storage_objects (storage_key, data, byte_size, inserted_at)
-      VALUES ($1, $2, $3, $4)
-      ON CONFLICT (storage_key)
-      DO UPDATE SET data = EXCLUDED.data, byte_size = EXCLUDED.byte_size
-      """,
-      [key, binary, byte_size(binary), now]
-    )
+    _ =
+      Repo.query!(
+        """
+        INSERT INTO storage_objects (storage_key, data, byte_size, inserted_at)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (storage_key)
+        DO UPDATE SET data = EXCLUDED.data, byte_size = EXCLUDED.byte_size
+        """,
+        [key, binary, byte_size(binary), now]
+      )
 
     :ok
   rescue
@@ -56,7 +57,7 @@ defmodule Engram.Storage.Database do
 
   @impl true
   def delete(key) when is_binary(key) do
-    Repo.query!("DELETE FROM storage_objects WHERE storage_key = $1", [key])
+    _ = Repo.query!("DELETE FROM storage_objects WHERE storage_key = $1", [key])
     :ok
   rescue
     e -> {:error, e}

--- a/lib/engram/storage/database.ex
+++ b/lib/engram/storage/database.ex
@@ -1,0 +1,114 @@
+defmodule Engram.Storage.Database do
+  @moduledoc """
+  Postgres `bytea` storage adapter for the minified self-host stack (#297).
+
+  Opt-in via `STORAGE_BACKEND=database`. Stores attachment bytes in the
+  `storage_objects` table keyed by the same `user_id/vault_id/path` storage_key
+  the S3 adapter uses, so a self-hoster can drop MinIO. SaaS/prod is unchanged
+  (stays `Engram.Storage.S3` on Fly Tigris).
+
+  Values are opaque — the caller already hands `put/3` ciphertext, so at-rest
+  encryption is inherited for free. `storage_objects` is intentionally NOT a
+  tenant-scoped table (see `Engram.Repo`); scoping is by storage_key prefix,
+  matching S3, and these calls run outside any tenant transaction.
+
+  Suited to modest self-host vaults only — large blobs bloat Postgres + WAL
+  (bytea TOAST caps ~1 GB/value), which is why bytea was removed for SaaS
+  (A.5 / PR #62).
+  """
+
+  @behaviour Engram.Storage
+
+  alias Engram.Repo
+
+  # Escape char for LIKE patterns so a storage_key containing `_`/`%` (paths
+  # may) is matched literally in delete_prefix/1.
+  @like_escape "\\"
+
+  @impl true
+  def put(key, binary, _opts \\ []) when is_binary(key) and is_binary(binary) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    Repo.query!(
+      """
+      INSERT INTO storage_objects (storage_key, data, byte_size, inserted_at)
+      VALUES ($1, $2, $3, $4)
+      ON CONFLICT (storage_key)
+      DO UPDATE SET data = EXCLUDED.data, byte_size = EXCLUDED.byte_size
+      """,
+      [key, binary, byte_size(binary), now]
+    )
+
+    :ok
+  rescue
+    e -> {:error, e}
+  end
+
+  @impl true
+  def get(key) when is_binary(key) do
+    case Repo.query!("SELECT data FROM storage_objects WHERE storage_key = $1", [key]) do
+      %{rows: [[data]]} -> {:ok, data}
+      %{rows: []} -> {:error, :not_found}
+    end
+  rescue
+    e -> {:error, e}
+  end
+
+  @impl true
+  def delete(key) when is_binary(key) do
+    Repo.query!("DELETE FROM storage_objects WHERE storage_key = $1", [key])
+    :ok
+  rescue
+    e -> {:error, e}
+  end
+
+  @impl true
+  def exists?(key) when is_binary(key) do
+    case Repo.query!("SELECT 1 FROM storage_objects WHERE storage_key = $1 LIMIT 1", [key]) do
+      %{rows: [[1]]} -> true
+      %{rows: []} -> false
+    end
+  rescue
+    _ -> false
+  end
+
+  @impl true
+  def delete_prefix(prefix) when is_binary(prefix) and prefix != "" do
+    pattern = escape_like(prefix) <> "%"
+
+    %{num_rows: count} =
+      Repo.query!(
+        "DELETE FROM storage_objects WHERE storage_key LIKE $1 ESCAPE $2",
+        [pattern, @like_escape]
+      )
+
+    {:ok, count}
+  rescue
+    e -> {:error, e}
+  end
+
+  @impl true
+  def list_user_prefixes do
+    %{rows: rows} =
+      Repo.query!("SELECT DISTINCT split_part(storage_key, '/', 1) FROM storage_objects", [])
+
+    ids =
+      Enum.flat_map(rows, fn [segment] ->
+        case Integer.parse(segment) do
+          {id, ""} -> [id]
+          _ -> []
+        end
+      end)
+
+    {:ok, ids}
+  rescue
+    e -> {:error, e}
+  end
+
+  defp escape_like(value) do
+    value
+    |> String.replace(@like_escape, @like_escape <> @like_escape)
+    |> String.replace("%", @like_escape <> "%")
+    |> String.replace("_", @like_escape <> "_")
+  end
+end

--- a/lib/engram/storage/database.ex
+++ b/lib/engram/storage/database.ex
@@ -27,7 +27,7 @@ defmodule Engram.Storage.Database do
 
   @impl true
   def put(key, binary, _opts \\ []) when is_binary(key) and is_binary(binary) do
-    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    now = DateTime.utc_now(:microsecond)
 
     Repo.query!(
       """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.221",
+      version: "0.5.222",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260524120000_create_storage_objects.exs
+++ b/priv/repo/migrations/20260524120000_create_storage_objects.exs
@@ -1,0 +1,17 @@
+defmodule Engram.Repo.Migrations.CreateStorageObjects do
+  use Ecto.Migration
+
+  # Self-host bytea storage backend (#297). Generic opaque-blob store keyed by
+  # the same `user_id/vault_id/path` storage_key the S3 adapter uses, letting a
+  # minified self-host stack drop MinIO. NOT a revival of the old
+  # `attachments.content` column (removed in A.5/PR #62) — values are already
+  # ciphertext from the caller, so this table stores encrypted bytes.
+  def change do
+    create table(:storage_objects, primary_key: false) do
+      add :storage_key, :text, primary_key: true
+      add :data, :binary, null: false
+      add :byte_size, :bigint, null: false
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+  end
+end

--- a/test/engram/storage/database_test.exs
+++ b/test/engram/storage/database_test.exs
@@ -1,0 +1,86 @@
+defmodule Engram.Storage.DatabaseTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Storage.Database
+
+  @binary <<137, 80, 78, 71, 13, 10, 26, 10>>
+
+  describe "put/3 and get/1" do
+    test "stores and retrieves a binary" do
+      assert :ok = Database.put("1/2/a.png", @binary)
+      assert {:ok, @binary} = Database.get("1/2/a.png")
+    end
+
+    test "get returns :not_found for a missing key" do
+      assert {:error, :not_found} = Database.get("nope/missing")
+    end
+
+    test "put overwrites an existing key (upsert)" do
+      assert :ok = Database.put("1/2/a.png", @binary)
+      assert :ok = Database.put("1/2/a.png", <<0, 1, 2>>)
+      assert {:ok, <<0, 1, 2>>} = Database.get("1/2/a.png")
+    end
+
+    test "ignores content_type opt" do
+      assert :ok = Database.put("1/2/a.png", @binary, content_type: "image/png")
+      assert {:ok, @binary} = Database.get("1/2/a.png")
+    end
+  end
+
+  describe "exists?/1" do
+    test "true when present, false when absent" do
+      assert :ok = Database.put("1/2/a.png", @binary)
+      assert Database.exists?("1/2/a.png") == true
+      assert Database.exists?("1/2/missing.png") == false
+    end
+  end
+
+  describe "delete/1" do
+    test "removes a stored key" do
+      assert :ok = Database.put("1/2/a.png", @binary)
+      assert :ok = Database.delete("1/2/a.png")
+      assert {:error, :not_found} = Database.get("1/2/a.png")
+    end
+
+    test "is a no-op (:ok) for a missing key" do
+      assert :ok = Database.delete("1/2/missing.png")
+    end
+  end
+
+  describe "delete_prefix/1" do
+    test "deletes only keys under the prefix and returns the count" do
+      assert :ok = Database.put("1/2/a.png", @binary)
+      assert :ok = Database.put("1/2/b.png", @binary)
+      assert :ok = Database.put("2/2/c.png", @binary)
+
+      assert {:ok, 2} = Database.delete_prefix("1/")
+
+      assert {:error, :not_found} = Database.get("1/2/a.png")
+      assert {:error, :not_found} = Database.get("1/2/b.png")
+      assert {:ok, @binary} = Database.get("2/2/c.png")
+    end
+
+    test "treats LIKE metacharacters in the prefix literally" do
+      assert :ok = Database.put("1_0/x.png", @binary)
+      assert :ok = Database.put("100/x.png", @binary)
+
+      # "1_" must not match "10" — the underscore is escaped.
+      assert {:ok, 1} = Database.delete_prefix("1_0/")
+
+      assert {:error, :not_found} = Database.get("1_0/x.png")
+      assert {:ok, @binary} = Database.get("100/x.png")
+    end
+  end
+
+  describe "list_user_prefixes/0" do
+    test "returns distinct integer first segments" do
+      assert :ok = Database.put("1/2/a.png", @binary)
+      assert :ok = Database.put("1/3/b.png", @binary)
+      assert :ok = Database.put("2/2/c.png", @binary)
+      assert :ok = Database.put("notanint/d.png", @binary)
+
+      assert {:ok, ids} = Database.list_user_prefixes()
+      assert Enum.sort(ids) == [1, 2]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds an opt-in `STORAGE_BACKEND=database` adapter (`Engram.Storage.Database`) that stores attachment bytes in Postgres `bytea`, so a minified self-host stack can drop MinIO. **SaaS/prod is unchanged** — `s3` stays the default (Fly Tigris). This is a self-host-only convenience, not a revival of the removed `attachments.content` column: bytes live in a generic `storage_objects` table keyed by the same `user_id/vault_id/path` storage_key the S3 adapter uses, and values are opaque ciphertext from the caller (at-rest encryption inherited for free).

- `storage_objects` migration (`storage_key` pk, `data` bytea, `byte_size`)
- 6 `Engram.Storage` callbacks; `delete_prefix/1` escapes LIKE metacharacters
- `runtime.exs` gains a `"database"` branch; `"s3"` remains default
- `.env.example` + `docker-compose.yml` document the minified (no-MinIO) stack
- new `storage-database` CI job boots the release with **no MinIO** and round-trips bytes via `bin/engram rpc`; wired into the `ci` aggregate gate

Closes #297.

## Test plan
- [x] `mix test test/engram/storage/database_test.exs` — 10 tests (put/get/overwrite/exists/delete/delete_prefix incl. LIKE-escape/list_user_prefixes) against real Postgres
- [x] full storage suite green (44 tests), `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`
- [ ] CI `storage-database` job: release boots with `STORAGE_BACKEND=database`, no MinIO, attachment bytes round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)