### PR TITLE
perf: cut per-request DB round trips (subscription/onboarding/activity/plan caches + notes_cap counter)

### DIFF
--- a/lib/engram/accounts/user.ex
+++ b/lib/engram/accounts/user.ex
@@ -26,6 +26,7 @@ defmodule Engram.Accounts.User do
     field :og_grandfather_redeemed_at, :utc_datetime_usec
 
     belongs_to :plan, Engram.Billing.Plan
+    has_one :subscription, Engram.Billing.Subscription
     has_many :notes, Engram.Notes.Note
     has_many :api_keys, Engram.Accounts.ApiKey
     has_many :vaults, Engram.Vaults.Vault

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -23,6 +23,7 @@ defmodule Engram.Application do
         EngramWeb.Presence,
         Engram.Crypto.DekCache,
         Engram.UsageMeters.ActivityCache,
+        Engram.Onboarding.TermsCache,
         {EngramWeb.RateLimiter, [clean_period: :timer.minutes(2)]},
         {Oban, Application.fetch_env!(:engram, Oban)},
         clerk_strategy_child(),

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -22,6 +22,7 @@ defmodule Engram.Application do
         {Phoenix.PubSub, name: Engram.PubSub},
         EngramWeb.Presence,
         Engram.Crypto.DekCache,
+        Engram.UsageMeters.ActivityCache,
         {EngramWeb.RateLimiter, [clean_period: :timer.minutes(2)]},
         {Oban, Application.fetch_env!(:engram, Oban)},
         clerk_strategy_child(),

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -8,7 +8,7 @@ defmodule Engram.Billing do
 
   import Ecto.Query
   alias Engram.Billing.LimitKeys
-  alias Engram.Billing.Plan
+  alias Engram.Billing.PlanCache
   alias Engram.Billing.Subscription
   alias Engram.Billing.UserLimitOverride
   alias Engram.Repo
@@ -116,13 +116,9 @@ defmodule Engram.Billing do
   defp plan_lookup(%{plan_id: nil}, _string_key), do: :miss
 
   defp plan_lookup(%{plan_id: id}, string_key) do
-    Repo.one(
-      from(p in Plan,
-        where: p.id == ^id,
-        select: fragment("?->?", p.limits, ^string_key)
-      ),
-      skip_tenant_check: true
-    )
+    id
+    |> PlanCache.limits()
+    |> Map.get(string_key)
     |> wrap_lookup()
   end
 

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -160,6 +160,15 @@ defmodule Engram.Billing do
     end
   end
 
+  @doc """
+  Loads the user's subscription (or nil). Reuses an already-preloaded
+  `:subscription` association when present so the auth pipeline can load it
+  once per request and have `tier/1`, `active?/1`, and `effective_limit/2`
+  share that single read instead of each issuing its own query.
+  """
+  def get_subscription(%{subscription: %Subscription{} = sub}), do: sub
+  def get_subscription(%{subscription: nil}), do: nil
+
   def get_subscription(user) do
     Repo.one(
       from(s in Subscription, where: s.user_id == ^user.id),

--- a/lib/engram/billing/plan_cache.ex
+++ b/lib/engram/billing/plan_cache.ex
@@ -41,6 +41,20 @@ defmodule Engram.Billing.PlanCache do
     :ok
   end
 
+  @doc """
+  Drops every cached plan. Call after a bulk plan-limit change (e.g. re-running
+  seeds) so the next lookup reloads from the DB. A fresh deploy starts with a
+  cold cache, so this is only needed when limits change without a restart.
+  """
+  @spec invalidate_all() :: :ok
+  def invalidate_all do
+    for {{__MODULE__, _plan_id} = k, _v} <- :persistent_term.get() do
+      :persistent_term.erase(k)
+    end
+
+    :ok
+  end
+
   defp load(plan_id) do
     Repo.one(
       from(p in Plan, where: p.id == ^plan_id, select: p.limits),

--- a/lib/engram/billing/plan_cache.ex
+++ b/lib/engram/billing/plan_cache.ex
@@ -56,10 +56,16 @@ defmodule Engram.Billing.PlanCache do
   end
 
   defp load(plan_id) do
-    Repo.one(
-      from(p in Plan, where: p.id == ^plan_id, select: p.limits),
-      skip_tenant_check: true
-    ) || %{}
+    case Repo.one(
+           from(p in Plan, where: p.id == ^plan_id, select: p.limits),
+           skip_tenant_check: true
+         ) do
+      limits when is_map(limits) -> limits
+      # Unknown plan id, or a malformed (non-map) limits column. Resolve to an
+      # empty map so `plan_lookup` falls through to tier defaults rather than
+      # raising BadMapError on the request path.
+      _ -> %{}
+    end
   end
 
   defp key(plan_id), do: {__MODULE__, plan_id}

--- a/lib/engram/billing/plan_cache.ex
+++ b/lib/engram/billing/plan_cache.ex
@@ -1,0 +1,52 @@
+defmodule Engram.Billing.PlanCache do
+  @moduledoc """
+  Caches each plan's `limits` map in `:persistent_term`, keyed by plan id.
+
+  Plan rows are seeded and effectively static at runtime (no code path writes
+  them), so the per-request `plan_lookup` query in `Engram.Billing` is pure
+  repetition for API-key traffic. `:persistent_term` is the right store for
+  rarely-changing global data: reads are lock-free with zero copying, and the
+  expensive global rebuild on write only happens on a cold miss (a handful of
+  plans over the node's lifetime).
+
+  If plans are ever edited at runtime (e.g. an admin/catalog task), call
+  `invalidate/1` for the changed plan id (or `invalidate_all/0`) so the next
+  read reloads from the DB.
+  """
+
+  import Ecto.Query
+  alias Engram.Billing.Plan
+  alias Engram.Repo
+
+  @doc """
+  Returns the cached limits map for `plan_id`, loading and caching it on a
+  miss. An unknown plan id resolves to an empty map (no limits).
+  """
+  @spec limits(plan_id :: integer()) :: map()
+  def limits(plan_id) do
+    case :persistent_term.get(key(plan_id), :__miss__) do
+      :__miss__ ->
+        loaded = load(plan_id)
+        :persistent_term.put(key(plan_id), loaded)
+        loaded
+
+      cached ->
+        cached
+    end
+  end
+
+  @spec invalidate(plan_id :: integer()) :: :ok
+  def invalidate(plan_id) do
+    _ = :persistent_term.erase(key(plan_id))
+    :ok
+  end
+
+  defp load(plan_id) do
+    Repo.one(
+      from(p in Plan, where: p.id == ^plan_id, select: p.limits),
+      skip_tenant_check: true
+    ) || %{}
+  end
+
+  defp key(plan_id), do: {__MODULE__, plan_id}
+end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -11,6 +11,7 @@ defmodule Engram.Notes do
   alias Engram.Crypto.Envelope
   alias Engram.Notes.{Enqueue, Helpers, Note, PathSanitizer}
   alias Engram.Repo
+  alias Engram.UsageMeters
   alias Engram.Workers.{DeleteNoteIndex, EmbedNote}
 
   require Logger
@@ -100,8 +101,11 @@ defmodule Engram.Notes do
   defp insert_new_note(base_attrs, user, sanitized_path, folder, tags) do
     # Pricing v2 §G — server-side notes_cap enforcement. Free tier defaults
     # to 10k notes; Starter to 50k; Pro unlimited. Resolver returns nil for
-    # the unlimited case, in which check_limit is a no-op.
-    current_count = count_user_notes(user.id)
+    # the unlimited case, in which check_limit is a no-op. The current count is
+    # a maintained counter (usage_meters.notes_count), not a per-insert
+    # COUNT(*); we increment it inside this tenant transaction so it stays
+    # atomic with the INSERT.
+    current_count = UsageMeters.notes_count(user.id)
 
     case Billing.check_limit(user, :notes_cap, current_count) do
       {:error, :limit_reached} ->
@@ -117,18 +121,15 @@ defmodule Engram.Notes do
           changeset = Note.changeset(%Note{id: note_id}, phase_b)
 
           case Repo.insert(changeset) do
-            {:ok, note} -> {:ok, {nil, note}}
-            {:error, changeset} -> {:error, changeset}
+            {:ok, note} ->
+              :ok = UsageMeters.inc_notes_count(user.id, 1)
+              {:ok, {nil, note}}
+
+            {:error, changeset} ->
+              {:error, changeset}
           end
         end
     end
-  end
-
-  defp count_user_notes(user_id) do
-    Repo.one(
-      from(n in Note, where: n.user_id == ^user_id and is_nil(n.deleted_at), select: count(n.id)),
-      skip_tenant_check: true
-    ) || 0
   end
 
   defp update_existing_note(
@@ -324,8 +325,13 @@ defmodule Engram.Notes do
       if note do
         _ =
           Repo.with_tenant(user.id, fn ->
-            from(n in Note, where: n.id == ^note.id)
-            |> Repo.update_all(set: [deleted_at: now, updated_at: now])
+            {updated, _} =
+              from(n in Note, where: n.id == ^note.id and is_nil(n.deleted_at))
+              |> Repo.update_all(set: [deleted_at: now, updated_at: now])
+
+            # Decrement by rows actually transitioned live → deleted, so a
+            # concurrent delete (already-nil deleted_at) can't double-count.
+            :ok = UsageMeters.dec_notes_count(user.id, updated)
           end)
 
         # T3.2 — pass path_hmac (base64), never plaintext path. The note row

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -105,6 +105,12 @@ defmodule Engram.Notes do
     # a maintained counter (usage_meters.notes_count), not a per-insert
     # COUNT(*); we increment it inside this tenant transaction so it stays
     # atomic with the INSERT.
+    #
+    # The check itself is best-effort, not a hard guarantee: read-then-insert
+    # is non-atomic, so concurrent inserts can land slightly over the cap. This
+    # matches the COUNT(*) approach it replaced (same TOCTOU window) and is fine
+    # for a soft abuse-deterrent cap. A hard cap would need a conditional
+    # UPDATE ... WHERE notes_count < limit gating the insert.
     current_count = UsageMeters.notes_count(user.id)
 
     case Billing.check_limit(user, :notes_cap, current_count) do

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -9,6 +9,7 @@ defmodule Engram.Onboarding do
 
   alias Engram.Billing
   alias Engram.Onboarding.Agreement
+  alias Engram.Onboarding.TermsCache
   alias Engram.Repo
 
   @terms_document "terms_of_service"
@@ -73,6 +74,16 @@ defmodule Engram.Onboarding do
   end
 
   defp terms_accepted?(user, current_version) do
+    if TermsCache.accepted?(user.id, current_version) do
+      true
+    else
+      accepted = query_terms_accepted?(user, current_version)
+      if accepted, do: TermsCache.mark_accepted(user.id, current_version)
+      accepted
+    end
+  end
+
+  defp query_terms_accepted?(user, current_version) do
     import Ecto.Query
 
     latest =

--- a/lib/engram/onboarding/terms_cache.ex
+++ b/lib/engram/onboarding/terms_cache.ex
@@ -1,0 +1,51 @@
+defmodule Engram.Onboarding.TermsCache do
+  @moduledoc """
+  Per-node ETS cache recording that a user has accepted a given TOS version.
+
+  TOS acceptance is append-only and monotonic per version: once a user has
+  accepted the current version it can never become un-accepted for that
+  version. So we cache positive results only, keyed by `{user_id, version}`.
+  A version bump changes the key, which misses naturally and forces a fresh
+  check against the new version — no explicit invalidation required.
+
+  Negative results are never cached: a user who hasn't accepted yet will soon,
+  and the next check (post-acceptance) reads through and caches the positive.
+
+  The table is `:public` (the value is a non-secret boolean), so request
+  processes read and write directly with no GenServer hop. This process exists
+  only to own the table for the application's lifetime.
+  """
+
+  use GenServer
+
+  @table :engram_terms_cache
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec accepted?(user_id :: integer(), version :: String.t()) :: boolean()
+  def accepted?(user_id, version) do
+    :ets.member(@table, {user_id, version})
+  end
+
+  @spec mark_accepted(user_id :: integer(), version :: String.t()) :: :ok
+  def mark_accepted(user_id, version) do
+    :ets.insert(@table, {{user_id, version}})
+    :ok
+  end
+
+  @impl true
+  def init(:ok) do
+    _ =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    {:ok, %{}}
+  end
+end

--- a/lib/engram/onboarding/terms_cache.ex
+++ b/lib/engram/onboarding/terms_cache.ex
@@ -14,6 +14,11 @@ defmodule Engram.Onboarding.TermsCache do
   The table is `:public` (the value is a non-secret boolean), so request
   processes read and write directly with no GenServer hop. This process exists
   only to own the table for the application's lifetime.
+
+  If the owning process is down and the table is absent, `accepted?/2` returns
+  `false` (forcing a DB read-through — never a false-positive accept) and
+  `mark_accepted/2` is a no-op, so a cache outage degrades to the authoritative
+  agreement query instead of raising.
   """
 
   use GenServer
@@ -27,12 +32,18 @@ defmodule Engram.Onboarding.TermsCache do
   @spec accepted?(user_id :: integer(), version :: String.t()) :: boolean()
   def accepted?(user_id, version) do
     :ets.member(@table, {user_id, version})
+  rescue
+    # Table absent → report not-cached so the caller re-queries the DB.
+    # Fails safe: never a false-positive acceptance.
+    ArgumentError -> false
   end
 
   @spec mark_accepted(user_id :: integer(), version :: String.t()) :: :ok
   def mark_accepted(user_id, version) do
     :ets.insert(@table, {{user_id, version}})
     :ok
+  rescue
+    ArgumentError -> :ok
   end
 
   @impl true

--- a/lib/engram/usage_meters.ex
+++ b/lib/engram/usage_meters.ex
@@ -18,6 +18,7 @@ defmodule Engram.UsageMeters do
     @primary_key {:user_id, :id, autogenerate: false}
     schema "usage_meters" do
       field :lifetime_embed_tokens, :integer, default: 0
+      field :notes_count, :integer, default: 0
       field :last_active_at, :utc_datetime_usec
       field :active_conversation_started_at, :utc_datetime_usec
       field :active_conversation_query_count, :integer, default: 0
@@ -74,6 +75,94 @@ defmodule Engram.UsageMeters do
   end
 
   def estimate_tokens(_), do: 0
+
+  # ── Notes counter (pricing v2 §G) ─────────────────────────────
+
+  @doc "Returns the maintained live-note count for the user (0 if no row yet)."
+  @spec notes_count(integer()) :: non_neg_integer()
+  def notes_count(user_id) when is_integer(user_id) do
+    Repo.one(
+      from(m in Meter, where: m.user_id == ^user_id, select: m.notes_count),
+      skip_tenant_check: true
+    ) || 0
+  end
+
+  @doc """
+  Adds `delta` to the user's live-note count, lazy-initialising the row. Use a
+  positive `delta` when notes become live (insert/restore). Single upsert so
+  concurrent writes can't lose increments to a read-modify-write race.
+  """
+  @spec inc_notes_count(integer(), integer()) :: :ok
+  def inc_notes_count(user_id, delta)
+      when is_integer(user_id) and is_integer(delta) and delta > 0 do
+    now = DateTime.utc_now()
+
+    {_, _} =
+      Repo.insert_all(
+        Meter,
+        [%{user_id: user_id, notes_count: delta, updated_at: now}],
+        on_conflict: [inc: [notes_count: delta], set: [updated_at: now]],
+        conflict_target: :user_id,
+        skip_tenant_check: true
+      )
+
+    :ok
+  end
+
+  @doc """
+  Subtracts `delta` from the user's live-note count, clamped at zero so drift
+  or a missing row can never produce a negative. Use when notes leave the live
+  set (soft-delete, bulk hard-delete). No-op when no meter row exists.
+  """
+  @spec dec_notes_count(integer(), non_neg_integer()) :: :ok
+  def dec_notes_count(_user_id, 0), do: :ok
+
+  def dec_notes_count(user_id, delta)
+      when is_integer(user_id) and is_integer(delta) and delta > 0 do
+    now = DateTime.utc_now()
+
+    {_, _} =
+      from(m in Meter,
+        where: m.user_id == ^user_id,
+        update: [
+          set: [
+            notes_count: fragment("GREATEST(0, ? - ?)", m.notes_count, ^delta),
+            updated_at: ^now
+          ]
+        ]
+      )
+      |> Repo.update_all([], skip_tenant_check: true)
+
+    :ok
+  end
+
+  @doc """
+  Recomputes the live-note count from the notes table and upserts it. Repair
+  primitive for reconciling drift; not on any hot path.
+  """
+  @spec recount_notes!(integer()) :: non_neg_integer()
+  def recount_notes!(user_id) when is_integer(user_id) do
+    count =
+      Repo.one(
+        from(n in Engram.Notes.Note,
+          where: n.user_id == ^user_id and is_nil(n.deleted_at),
+          select: count(n.id)
+        ),
+        skip_tenant_check: true
+      ) || 0
+
+    now = DateTime.utc_now()
+
+    Repo.insert_all(
+      Meter,
+      [%{user_id: user_id, notes_count: count, updated_at: now}],
+      on_conflict: [set: [notes_count: count, updated_at: now]],
+      conflict_target: :user_id,
+      skip_tenant_check: true
+    )
+
+    count
+  end
 
   # ── Activity tracking (pricing v2 §C) ─────────────────────────
 

--- a/lib/engram/usage_meters.ex
+++ b/lib/engram/usage_meters.ex
@@ -92,7 +92,7 @@ defmodule Engram.UsageMeters do
   positive `delta` when notes become live (insert/restore). Single upsert so
   concurrent writes can't lose increments to a read-modify-write race.
   """
-  @spec inc_notes_count(integer(), integer()) :: :ok
+  @spec inc_notes_count(integer(), pos_integer()) :: :ok
   def inc_notes_count(user_id, delta)
       when is_integer(user_id) and is_integer(delta) and delta > 0 do
     now = DateTime.utc_now()
@@ -153,13 +153,14 @@ defmodule Engram.UsageMeters do
 
     now = DateTime.utc_now()
 
-    Repo.insert_all(
-      Meter,
-      [%{user_id: user_id, notes_count: count, updated_at: now}],
-      on_conflict: [set: [notes_count: count, updated_at: now]],
-      conflict_target: :user_id,
-      skip_tenant_check: true
-    )
+    {_, _} =
+      Repo.insert_all(
+        Meter,
+        [%{user_id: user_id, notes_count: count, updated_at: now}],
+        on_conflict: [set: [notes_count: count, updated_at: now]],
+        conflict_target: :user_id,
+        skip_tenant_check: true
+      )
 
     count
   end

--- a/lib/engram/usage_meters/activity_cache.ex
+++ b/lib/engram/usage_meters/activity_cache.ex
@@ -13,6 +13,10 @@ defmodule Engram.UsageMeters.ActivityCache do
 
   On node restart the table is empty, so each user triggers one cold-path
   meter read again — harmless and self-healing.
+
+  If the owning process is down and the table is absent, reads/writes degrade
+  to `:miss`/no-op rather than raising, so a cache outage falls back to the
+  authoritative DB read instead of failing the request.
   """
 
   use GenServer
@@ -29,12 +33,17 @@ defmodule Engram.UsageMeters.ActivityCache do
       [{^user_id, %DateTime{} = ts}] -> {:ok, ts}
       [] -> :miss
     end
+  rescue
+    # Table absent (owner crashed/not yet started) → degrade to the DB path.
+    ArgumentError -> :miss
   end
 
   @spec put(user_id :: integer(), last_active_at :: DateTime.t()) :: :ok
   def put(user_id, %DateTime{} = last_active_at) do
     :ets.insert(@table, {user_id, last_active_at})
     :ok
+  rescue
+    ArgumentError -> :ok
   end
 
   @impl true

--- a/lib/engram/usage_meters/activity_cache.ex
+++ b/lib/engram/usage_meters/activity_cache.ex
@@ -1,0 +1,53 @@
+defmodule Engram.UsageMeters.ActivityCache do
+  @moduledoc """
+  Per-node ETS cache of the last time we stamped `usage_meters.last_active_at`
+  for a user. Lets `EngramWeb.Plugs.BumpActivity` skip the per-request meter
+  read once it knows (from this node) that the user was bumped within the
+  debounce window.
+
+  The table is `:public` — the cached value is a non-secret timestamp, so
+  request processes read and write it directly with no GenServer hop. This
+  process exists only to own the table for the application's lifetime. Entries
+  are tiny (`{user_id, %DateTime{}}`) and bounded by the active-user count, so
+  no sweep is needed; staleness is decided by the caller comparing timestamps.
+
+  On node restart the table is empty, so each user triggers one cold-path
+  meter read again — harmless and self-healing.
+  """
+
+  use GenServer
+
+  @table :engram_activity_cache
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec get(user_id :: integer()) :: {:ok, DateTime.t()} | :miss
+  def get(user_id) do
+    case :ets.lookup(@table, user_id) do
+      [{^user_id, %DateTime{} = ts}] -> {:ok, ts}
+      [] -> :miss
+    end
+  end
+
+  @spec put(user_id :: integer(), last_active_at :: DateTime.t()) :: :ok
+  def put(user_id, %DateTime{} = last_active_at) do
+    :ets.insert(@table, {user_id, last_active_at})
+    :ok
+  end
+
+  @impl true
+  def init(:ok) do
+    _ =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    {:ok, %{}}
+  end
+end

--- a/lib/engram/workers/cleanup_vault.ex
+++ b/lib/engram/workers/cleanup_vault.ex
@@ -19,6 +19,7 @@ defmodule Engram.Workers.CleanupVault do
   alias Engram.Attachments.Attachment
   alias Engram.Notes.{Chunk, Note}
   alias Engram.Repo
+  alias Engram.UsageMeters
   alias Engram.Vaults.Vault
 
   require Logger
@@ -74,6 +75,18 @@ defmodule Engram.Workers.CleanupVault do
     Repo.transaction(fn ->
       vault_id = vault.id
 
+      # Drop the owner's live-note counter by the notes this vault still holds
+      # as live (deleted_at IS NULL). Soft-deleted notes were already
+      # decremented at soft-delete time, so only the live set counts here.
+      live_notes =
+        Repo.one(
+          from(n in Note,
+            where: n.vault_id == ^vault_id and is_nil(n.deleted_at),
+            select: count(n.id)
+          ),
+          skip_tenant_check: true
+        ) || 0
+
       Chunk
       |> where(vault_id: ^vault_id)
       |> Repo.delete_all(skip_tenant_check: true)
@@ -81,6 +94,8 @@ defmodule Engram.Workers.CleanupVault do
       Note
       |> where(vault_id: ^vault_id)
       |> Repo.delete_all(skip_tenant_check: true)
+
+      :ok = UsageMeters.dec_notes_count(vault.user_id, live_notes)
 
       Attachment
       |> where(vault_id: ^vault_id)

--- a/lib/engram_web/plugs/auth.ex
+++ b/lib/engram_web/plugs/auth.ex
@@ -19,11 +19,11 @@ defmodule EngramWeb.Plugs.Auth do
   def call(conn, _opts) do
     case authenticate(conn) do
       {:ok, user} ->
-        assign(conn, :current_user, user)
+        assign(conn, :current_user, with_billing_assoc(user))
 
       {:ok, user, api_key} ->
         conn
-        |> assign(:current_user, user)
+        |> assign(:current_user, with_billing_assoc(user))
         |> assign(:current_api_key, api_key)
 
       {:error, reason} ->
@@ -43,6 +43,18 @@ defmodule EngramWeb.Plugs.Auth do
     case get_req_header(conn, "authorization") do
       ["Bearer " <> token] -> Engram.Auth.TokenResolver.resolve(token)
       _ -> {:error, :no_auth}
+    end
+  end
+
+  # Load the subscription once here so the downstream billing gates
+  # (RequireOnboarding, RequireApiRpsBudget, RequireApiWriteEnabled) reuse the
+  # preloaded assoc instead of each re-querying. Skipped in self-host mode,
+  # where no billing gate runs and the extra read would be pure waste.
+  defp with_billing_assoc(user) do
+    if Application.get_env(:engram, :billing_enabled, false) do
+      Engram.Repo.preload(user, :subscription)
+    else
+      user
     end
   end
 

--- a/lib/engram_web/plugs/bump_activity.ex
+++ b/lib/engram_web/plugs/bump_activity.ex
@@ -5,25 +5,45 @@ defmodule EngramWeb.Plugs.BumpActivity do
 
   Debounced: only writes when the stored value is stale by > 1h, since
   every API call and SSE keepalive otherwise hammers the meter row.
+
+  An `ActivityCache` (per-node ETS) holds the last-known stamp so that, once
+  warm, a request within the debounce window skips the meter read entirely —
+  the common steady-state path no longer touches the DB at all. On a cache
+  miss we fall back to the authoritative DB read, then warm the cache.
   """
 
   alias Engram.UsageMeters
+  alias Engram.UsageMeters.ActivityCache
 
   @debounce_seconds 3600
 
   def init(opts), do: opts
 
   def call(%Plug.Conn{assigns: %{current_user: %{id: user_id}}} = conn, _opts) do
-    last = UsageMeters.last_active_at(user_id)
+    case ActivityCache.get(user_id) do
+      {:ok, ts} ->
+        if needs_bump?(ts), do: bump(user_id)
 
-    if needs_bump?(last) do
-      UsageMeters.bump_last_active(user_id)
+      :miss ->
+        last = UsageMeters.last_active_at(user_id)
+
+        if needs_bump?(last) do
+          bump(user_id)
+        else
+          ActivityCache.put(user_id, last)
+        end
     end
 
     conn
   end
 
   def call(conn, _opts), do: conn
+
+  defp bump(user_id) do
+    now = DateTime.utc_now()
+    UsageMeters.bump_last_active(user_id)
+    ActivityCache.put(user_id, now)
+  end
 
   defp needs_bump?(nil), do: true
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.225",
+      version: "0.5.226",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260525001318_add_notes_count_to_usage_meters.exs
+++ b/priv/repo/migrations/20260525001318_add_notes_count_to_usage_meters.exs
@@ -1,0 +1,49 @@
+defmodule Engram.Repo.Migrations.AddNotesCountToUsageMeters do
+  use Ecto.Migration
+
+  @moduledoc """
+  Pricing v2 §G — replace the per-insert `COUNT(*)` notes_cap check with a
+  maintained counter on usage_meters. Backfills the live-note count (deleted_at
+  IS NULL) for every user: updates existing meter rows and inserts rows for
+  users who have notes but no meter yet.
+  """
+
+  def up do
+    alter table(:usage_meters) do
+      add :notes_count, :bigint, null: false, default: 0
+    end
+
+    flush()
+
+    # Existing meter rows → set to current live-note count.
+    execute """
+    UPDATE usage_meters m
+    SET notes_count = COALESCE(c.cnt, 0)
+    FROM (
+      SELECT user_id, COUNT(*) AS cnt
+      FROM notes
+      WHERE deleted_at IS NULL
+      GROUP BY user_id
+    ) c
+    WHERE c.user_id = m.user_id
+    """
+
+    # Users with live notes but no meter row yet → create one. Other columns
+    # rely on their DB defaults (updated_at default now(), counters default 0,
+    # last_active_at stays NULL so we don't falsely mark them active).
+    execute """
+    INSERT INTO usage_meters (user_id, notes_count)
+    SELECT n.user_id, COUNT(*)
+    FROM notes n
+    WHERE n.deleted_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM usage_meters m WHERE m.user_id = n.user_id)
+    GROUP BY n.user_id
+    """
+  end
+
+  def down do
+    alter table(:usage_meters) do
+      remove :notes_count
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,7 +11,7 @@
 # and so on) as they will fail if something goes wrong.
 
 alias Engram.Repo
-alias Engram.Billing.{LimitKeys, Plan}
+alias Engram.Billing.{LimitKeys, Plan, PlanCache}
 
 # Seed the three pricing tiers from LimitKeys catalog. Idempotent —
 # on_conflict replaces the limits JSONB so re-running ecto.setup drives
@@ -29,3 +29,8 @@ for tier <- LimitKeys.tiers() do
     conflict_target: :name
   )
 end
+
+# Drop any cached plan limits so a node that's already running (e.g. seeds
+# re-run over a remote console) picks up the new limits instead of serving a
+# stale :persistent_term entry. No-op on a cold boot.
+PlanCache.invalidate_all()

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -413,6 +413,12 @@ defmodule Engram.BillingTest do
 
       assert Billing.effective_limit(user, :vaults_cap) == 42
     end
+
+    test "an unknown plan id resolves to an empty limits map (falls to defaults)" do
+      missing_id = 2_000_000_000
+      PlanCache.invalidate(missing_id)
+      assert PlanCache.limits(missing_id) == %{}
+    end
   end
 
   defp with_subscription_query_count(fun), do: with_query_count("subscriptions", fun)

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -4,7 +4,11 @@ defmodule Engram.BillingTest do
   import Mox
 
   alias Engram.Billing
+  alias Engram.Billing.LimitKeys
+  alias Engram.Billing.Plan
+  alias Engram.Billing.PlanCache
   alias Engram.Billing.Subscription
+  alias Engram.Repo
 
   setup :verify_on_exit!
 
@@ -299,7 +303,7 @@ defmodule Engram.BillingTest do
     test "get_subscription/1 reuses a preloaded :subscription assoc without querying" do
       user = insert(:user)
       insert(:subscription, user: user, tier: "pro", status: "active")
-      user = Engram.Repo.preload(user, :subscription)
+      user = Repo.preload(user, :subscription)
 
       {result, queries} = with_subscription_query_count(fn -> Billing.get_subscription(user) end)
 
@@ -308,7 +312,7 @@ defmodule Engram.BillingTest do
     end
 
     test "get_subscription/1 returns nil from a preloaded-but-empty assoc without querying" do
-      user = insert(:user) |> Engram.Repo.preload(:subscription)
+      user = insert(:user) |> Repo.preload(:subscription)
 
       {result, queries} = with_subscription_query_count(fn -> Billing.get_subscription(user) end)
 
@@ -319,7 +323,7 @@ defmodule Engram.BillingTest do
     test "active?/1 and tier/1 reuse a preloaded subscription (zero extra queries)" do
       user = insert(:user)
       insert(:subscription, user: user, tier: "pro", status: "active")
-      user = Engram.Repo.preload(user, :subscription)
+      user = Repo.preload(user, :subscription)
 
       {_, queries} =
         with_subscription_query_count(fn ->
@@ -344,18 +348,18 @@ defmodule Engram.BillingTest do
   describe "plan limit caching" do
     setup do
       plan =
-        Engram.Repo.insert!(%Engram.Billing.Plan{
+        Repo.insert!(%Plan{
           name: "pro_#{System.unique_integer([:positive])}",
           limits: %{"vaults_cap" => 7, "cross_vault_search" => false}
         })
 
-      user = insert(:user) |> Ecto.Changeset.change(plan_id: plan.id) |> Engram.Repo.update!()
-      on_exit(fn -> Engram.Billing.PlanCache.invalidate(plan.id) end)
+      user = insert(:user) |> Ecto.Changeset.change(plan_id: plan.id) |> Repo.update!()
+      on_exit(fn -> PlanCache.invalidate(plan.id) end)
       %{plan: plan, user: user}
     end
 
     test "resolves plan limits and caches them after the first lookup", %{plan: plan, user: user} do
-      Engram.Billing.PlanCache.invalidate(plan.id)
+      PlanCache.invalidate(plan.id)
 
       {first, q1} =
         with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
@@ -378,12 +382,12 @@ defmodule Engram.BillingTest do
     test "missing plan key falls through to the default", %{user: user} do
       # vault_scoped_keys is not set on this plan → default for tier.
       assert Billing.effective_limit(user, :vault_scoped_keys) ==
-               Engram.Billing.LimitKeys.default_for(:vault_scoped_keys, :free)
+               LimitKeys.default_for(:vault_scoped_keys, :free)
     end
 
     test "invalidate/1 forces a re-read", %{plan: plan, user: user} do
       Billing.effective_limit(user, :vaults_cap)
-      Engram.Billing.PlanCache.invalidate(plan.id)
+      PlanCache.invalidate(plan.id)
 
       {_, q} = with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
       assert q == 1

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -397,9 +397,11 @@ defmodule Engram.BillingTest do
   defp with_subscription_query_count(fun), do: with_query_count("subscriptions", fun)
 
   # Counts Repo queries against `source` emitted while `fun` runs. Telemetry
-  # fires synchronously in the calling process under the SQL sandbox, so a
-  # plain Agent counter is safe.
+  # handlers run synchronously in the process that emitted the query, so we
+  # scope counting to this test's pid — otherwise concurrent async tests
+  # (running in their own processes) leak into the count.
   defp with_query_count(source, fun) do
+    test_pid = self()
     {:ok, counter} = Agent.start_link(fn -> 0 end)
     handler_id = {__MODULE__, make_ref()}
 
@@ -407,7 +409,7 @@ defmodule Engram.BillingTest do
       handler_id,
       [:engram, :repo, :query],
       fn _event, _measurements, %{source: src}, _config ->
-        if src == source, do: Agent.update(counter, &(&1 + 1))
+        if src == source and self() == test_pid, do: Agent.update(counter, &(&1 + 1))
       end,
       nil
     )

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -341,18 +341,69 @@ defmodule Engram.BillingTest do
     end
   end
 
-  # Counts Repo queries against the `subscriptions` source emitted while `fun`
-  # runs. Telemetry fires synchronously in the calling process under the SQL
-  # sandbox, so a plain Agent counter is safe.
-  defp with_subscription_query_count(fun) do
+  describe "plan limit caching" do
+    setup do
+      plan =
+        Engram.Repo.insert!(%Engram.Billing.Plan{
+          name: "pro_#{System.unique_integer([:positive])}",
+          limits: %{"vaults_cap" => 7, "cross_vault_search" => false}
+        })
+
+      user = insert(:user) |> Ecto.Changeset.change(plan_id: plan.id) |> Engram.Repo.update!()
+      on_exit(fn -> Engram.Billing.PlanCache.invalidate(plan.id) end)
+      %{plan: plan, user: user}
+    end
+
+    test "resolves plan limits and caches them after the first lookup", %{plan: plan, user: user} do
+      Engram.Billing.PlanCache.invalidate(plan.id)
+
+      {first, q1} =
+        with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
+
+      assert first == 7
+      assert q1 == 1
+
+      {second, q2} =
+        with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
+
+      assert second == 7
+      assert q2 == 0
+    end
+
+    test "cached lookup preserves false plan values (not treated as missing)", %{user: user} do
+      assert Billing.effective_limit(user, :cross_vault_search) == false
+      assert Billing.effective_limit(user, :cross_vault_search) == false
+    end
+
+    test "missing plan key falls through to the default", %{user: user} do
+      # vault_scoped_keys is not set on this plan → default for tier.
+      assert Billing.effective_limit(user, :vault_scoped_keys) ==
+               Engram.Billing.LimitKeys.default_for(:vault_scoped_keys, :free)
+    end
+
+    test "invalidate/1 forces a re-read", %{plan: plan, user: user} do
+      Billing.effective_limit(user, :vaults_cap)
+      Engram.Billing.PlanCache.invalidate(plan.id)
+
+      {_, q} = with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
+      assert q == 1
+    end
+  end
+
+  defp with_subscription_query_count(fun), do: with_query_count("subscriptions", fun)
+
+  # Counts Repo queries against `source` emitted while `fun` runs. Telemetry
+  # fires synchronously in the calling process under the SQL sandbox, so a
+  # plain Agent counter is safe.
+  defp with_query_count(source, fun) do
     {:ok, counter} = Agent.start_link(fn -> 0 end)
     handler_id = {__MODULE__, make_ref()}
 
     :telemetry.attach(
       handler_id,
       [:engram, :repo, :query],
-      fn _event, _measurements, %{source: source}, _config ->
-        if source == "subscriptions", do: Agent.update(counter, &(&1 + 1))
+      fn _event, _measurements, %{source: src}, _config ->
+        if src == source, do: Agent.update(counter, &(&1 + 1))
       end,
       nil
     )

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -392,6 +392,27 @@ defmodule Engram.BillingTest do
       {_, q} = with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
       assert q == 1
     end
+
+    test "invalidate/1 reflects a runtime limit change (not just a re-query)",
+         %{plan: plan, user: user} do
+      assert Billing.effective_limit(user, :vaults_cap) == 7
+
+      plan |> Ecto.Changeset.change(limits: %{"vaults_cap" => 99}) |> Repo.update!()
+      # Still cached → stale value until invalidated.
+      assert Billing.effective_limit(user, :vaults_cap) == 7
+
+      PlanCache.invalidate(plan.id)
+      assert Billing.effective_limit(user, :vaults_cap) == 99
+    end
+
+    test "invalidate_all/0 drops every cached plan", %{plan: plan, user: user} do
+      assert Billing.effective_limit(user, :vaults_cap) == 7
+
+      plan |> Ecto.Changeset.change(limits: %{"vaults_cap" => 42}) |> Repo.update!()
+      PlanCache.invalidate_all()
+
+      assert Billing.effective_limit(user, :vaults_cap) == 42
+    end
   end
 
   defp with_subscription_query_count(fun), do: with_query_count("subscriptions", fun)

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -294,4 +294,75 @@ defmodule Engram.BillingTest do
       assert {:ok, :ignored} = Billing.upsert_from_paddle_event(event)
     end
   end
+
+  describe "subscription memoization" do
+    test "get_subscription/1 reuses a preloaded :subscription assoc without querying" do
+      user = insert(:user)
+      insert(:subscription, user: user, tier: "pro", status: "active")
+      user = Engram.Repo.preload(user, :subscription)
+
+      {result, queries} = with_subscription_query_count(fn -> Billing.get_subscription(user) end)
+
+      assert %Subscription{tier: "pro"} = result
+      assert queries == 0
+    end
+
+    test "get_subscription/1 returns nil from a preloaded-but-empty assoc without querying" do
+      user = insert(:user) |> Engram.Repo.preload(:subscription)
+
+      {result, queries} = with_subscription_query_count(fn -> Billing.get_subscription(user) end)
+
+      assert result == nil
+      assert queries == 0
+    end
+
+    test "active?/1 and tier/1 reuse a preloaded subscription (zero extra queries)" do
+      user = insert(:user)
+      insert(:subscription, user: user, tier: "pro", status: "active")
+      user = Engram.Repo.preload(user, :subscription)
+
+      {_, queries} =
+        with_subscription_query_count(fn ->
+          assert Billing.active?(user)
+          assert Billing.tier(user) == :pro
+        end)
+
+      assert queries == 0
+    end
+
+    test "get_subscription/1 still queries when the assoc is not loaded" do
+      user = insert(:user)
+      insert(:subscription, user: user, tier: "pro", status: "active")
+
+      {result, queries} = with_subscription_query_count(fn -> Billing.get_subscription(user) end)
+
+      assert %Subscription{} = result
+      assert queries == 1
+    end
+  end
+
+  # Counts Repo queries against the `subscriptions` source emitted while `fun`
+  # runs. Telemetry fires synchronously in the calling process under the SQL
+  # sandbox, so a plain Agent counter is safe.
+  defp with_subscription_query_count(fun) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    handler_id = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:engram, :repo, :query],
+      fn _event, _measurements, %{source: source}, _config ->
+        if source == "subscriptions", do: Agent.update(counter, &(&1 + 1))
+      end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, Agent.get(counter, & &1)}
+    after
+      :telemetry.detach(handler_id)
+      Agent.stop(counter)
+    end
+  end
 end

--- a/test/engram/notes_cap_test.exs
+++ b/test/engram/notes_cap_test.exs
@@ -1,0 +1,79 @@
+defmodule Engram.NotesCapTest do
+  @moduledoc """
+  Pins the maintained `usage_meters.notes_count` counter that replaced the
+  per-insert `COUNT(*)` for notes_cap enforcement. Every path that changes a
+  user's live-note count must keep the counter consistent.
+  """
+  use Engram.DataCase, async: true
+
+  alias Engram.Notes
+  alias Engram.UsageMeters
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  defp upsert(user, vault, path, content \\ "# Note\nbody") do
+    Notes.upsert_note(user, vault, %{"path" => path, "content" => content, "mtime" => 1_000.0})
+  end
+
+  test "starts at zero for a fresh user", %{user: user} do
+    assert UsageMeters.notes_count(user.id) == 0
+  end
+
+  test "increments on create, decrements on soft-delete", %{user: user, vault: vault} do
+    {:ok, _} = upsert(user, vault, "A.md")
+    {:ok, _} = upsert(user, vault, "B.md")
+    assert UsageMeters.notes_count(user.id) == 2
+
+    :ok = Notes.delete_note(user, vault, "A.md")
+    assert UsageMeters.notes_count(user.id) == 1
+  end
+
+  test "updating an existing note does not change the counter", %{user: user, vault: vault} do
+    {:ok, _} = upsert(user, vault, "A.md", "v1")
+    assert UsageMeters.notes_count(user.id) == 1
+
+    {:ok, _} = upsert(user, vault, "A.md", "v2 updated body")
+    assert UsageMeters.notes_count(user.id) == 1
+  end
+
+  test "soft-delete is idempotent for the counter", %{user: user, vault: vault} do
+    {:ok, _} = upsert(user, vault, "A.md")
+    :ok = Notes.delete_note(user, vault, "A.md")
+    :ok = Notes.delete_note(user, vault, "A.md")
+    assert UsageMeters.notes_count(user.id) == 0
+  end
+
+  test "never drops below zero", %{user: user, vault: vault} do
+    :ok = Notes.delete_note(user, vault, "does-not-exist.md")
+    assert UsageMeters.notes_count(user.id) == 0
+  end
+
+  test "enforces notes_cap from the maintained counter", %{user: user, vault: vault} do
+    insert(:user_limit_override, user: user, key: "notes_cap", value: %{"v" => 2})
+
+    {:ok, _} = upsert(user, vault, "A.md")
+    {:ok, _} = upsert(user, vault, "B.md")
+    assert {:error, :notes_cap_reached} = upsert(user, vault, "C.md")
+
+    # The rejected insert must not have bumped the counter.
+    assert UsageMeters.notes_count(user.id) == 2
+  end
+
+  test "deleting under the cap frees a slot", %{user: user, vault: vault} do
+    insert(:user_limit_override, user: user, key: "notes_cap", value: %{"v" => 2})
+
+    {:ok, _} = upsert(user, vault, "A.md")
+    {:ok, _} = upsert(user, vault, "B.md")
+    assert {:error, :notes_cap_reached} = upsert(user, vault, "C.md")
+
+    :ok = Notes.delete_note(user, vault, "A.md")
+    assert {:ok, _} = upsert(user, vault, "C.md")
+    assert UsageMeters.notes_count(user.id) == 2
+  end
+end

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -138,5 +138,53 @@ defmodule Engram.OnboardingTest do
       assert %{terms_ok: true, subscription_ok: true, next_step: :done} =
                Onboarding.status(user)
     end
+
+    test "caches a positive terms check so repeat calls skip the agreement query" do
+      user = insert(:user)
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+
+      # First call warms the cache.
+      assert %{terms_ok: true} = Onboarding.status(user)
+
+      {status, queries} =
+        with_agreement_query_count(fn -> Onboarding.status(user) end)
+
+      assert %{terms_ok: true} = status
+      assert queries == 0
+    end
+
+    test "does not cache a negative terms check (re-queries until accepted)" do
+      user = insert(:user)
+
+      assert %{terms_ok: false} = Onboarding.status(user)
+
+      {status, queries} =
+        with_agreement_query_count(fn -> Onboarding.status(user) end)
+
+      assert %{terms_ok: false} = status
+      assert queries >= 1
+    end
+  end
+
+  defp with_agreement_query_count(fun) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    handler_id = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:engram, :repo, :query],
+      fn _event, _measurements, %{source: source}, _config ->
+        if source == "user_agreements", do: Agent.update(counter, &(&1 + 1))
+      end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, Agent.get(counter, & &1)}
+    after
+      :telemetry.detach(handler_id)
+      Agent.stop(counter)
+    end
   end
 end

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -167,6 +167,9 @@ defmodule Engram.OnboardingTest do
   end
 
   defp with_agreement_query_count(fun) do
+    # Scope to this test's pid: telemetry handlers run in the emitting process,
+    # so without this a concurrent async test could leak into the count.
+    test_pid = self()
     {:ok, counter} = Agent.start_link(fn -> 0 end)
     handler_id = {__MODULE__, make_ref()}
 
@@ -174,7 +177,8 @@ defmodule Engram.OnboardingTest do
       handler_id,
       [:engram, :repo, :query],
       fn _event, _measurements, %{source: source}, _config ->
-        if source == "user_agreements", do: Agent.update(counter, &(&1 + 1))
+        if source == "user_agreements" and self() == test_pid,
+          do: Agent.update(counter, &(&1 + 1))
       end,
       nil
     )

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -3,6 +3,7 @@ defmodule Engram.OnboardingTest do
 
   alias Engram.Onboarding
   alias Engram.Onboarding.Agreement
+  alias Engram.Onboarding.TermsCache
 
   describe "accept_terms/3" do
     test "inserts an agreement row for the user and version" do
@@ -163,6 +164,20 @@ defmodule Engram.OnboardingTest do
 
       assert %{terms_ok: false} = status
       assert queries >= 1
+    end
+
+    test "degrades to a DB read when the terms cache is unavailable" do
+      user = insert(:user)
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+
+      # Drop the cache owner (and its table). accepted?/2 must report not-cached
+      # (false) rather than raise, and status/1 must still read the DB and work.
+      :ok = Supervisor.terminate_child(Engram.Supervisor, TermsCache)
+      on_exit(fn -> Supervisor.restart_child(Engram.Supervisor, TermsCache) end)
+
+      assert TermsCache.accepted?(user.id, "2026-05-15") == false
+      assert :ok = TermsCache.mark_accepted(user.id, "2026-05-15")
+      assert %{terms_ok: true} = Onboarding.status(user)
     end
   end
 

--- a/test/engram/repo/migrations/usage_meters_notes_count_backfill_test.exs
+++ b/test/engram/repo/migrations/usage_meters_notes_count_backfill_test.exs
@@ -1,0 +1,87 @@
+defmodule Engram.Repo.Migrations.UsageMetersNotesCountBackfillTest do
+  @moduledoc """
+  Pins the notes_count backfill SQL embedded in the
+  20260525001318_add_notes_count_to_usage_meters migration. The migration
+  already ran in test DB setup; here we re-exercise the same SQL against
+  synthetic users/notes inside a DataCase transaction (rolled back).
+  """
+  use Engram.DataCase, async: false
+
+  alias Engram.Repo
+  alias Engram.UsageMeters
+  alias Engram.UsageMeters.Meter
+
+  @update_sql """
+  UPDATE usage_meters m
+  SET notes_count = COALESCE(c.cnt, 0)
+  FROM (
+    SELECT user_id, COUNT(*) AS cnt
+    FROM notes
+    WHERE deleted_at IS NULL
+    GROUP BY user_id
+  ) c
+  WHERE c.user_id = m.user_id
+  """
+
+  @insert_sql """
+  INSERT INTO usage_meters (user_id, notes_count)
+  SELECT n.user_id, COUNT(*)
+  FROM notes n
+  WHERE n.deleted_at IS NULL
+    AND NOT EXISTS (SELECT 1 FROM usage_meters m WHERE m.user_id = n.user_id)
+  GROUP BY n.user_id
+  """
+
+  defp run_backfill do
+    Repo.query!(@update_sql)
+    Repo.query!(@insert_sql)
+  end
+
+  test "updates an existing meter row to the live-note count (ignoring soft-deleted)" do
+    user = insert(:user)
+    Repo.insert!(%Meter{user_id: user.id, notes_count: 0})
+
+    vault = insert(:vault, user: user)
+    insert(:note, user: user, vault: vault)
+    insert(:note, user: user, vault: vault)
+    insert(:note, user: user, vault: vault, deleted_at: DateTime.utc_now())
+
+    run_backfill()
+
+    assert UsageMeters.notes_count(user.id) == 2
+  end
+
+  test "inserts a meter row for a user with notes but no existing meter" do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+    insert(:note, user: user, vault: vault)
+    insert(:note, user: user, vault: vault)
+
+    refute Repo.get(Meter, user.id)
+
+    run_backfill()
+
+    assert UsageMeters.notes_count(user.id) == 2
+  end
+
+  test "leaves a zero-note user's meter row at zero" do
+    user = insert(:user)
+    Repo.insert!(%Meter{user_id: user.id, notes_count: 0})
+
+    run_backfill()
+
+    assert UsageMeters.notes_count(user.id) == 0
+  end
+
+  test "is idempotent — a second run does not double-count" do
+    user = insert(:user)
+    vault = insert(:vault, user: user)
+    insert(:note, user: user, vault: vault)
+    insert(:note, user: user, vault: vault)
+
+    run_backfill()
+    run_backfill()
+
+    assert UsageMeters.notes_count(user.id) == 2
+  end
+end

--- a/test/engram/usage_meters_test.exs
+++ b/test/engram/usage_meters_test.exs
@@ -64,4 +64,48 @@ defmodule Engram.UsageMetersTest do
       assert UsageMeters.estimate_tokens("abcde") == 2
     end
   end
+
+  describe "notes_count counter (pricing v2 §G)" do
+    test "returns 0 for a user with no meter row" do
+      user = insert(:user)
+      assert UsageMeters.notes_count(user.id) == 0
+    end
+
+    test "inc_notes_count lazy-inits and accumulates across calls" do
+      user = insert(:user)
+      Enum.each(1..5, fn _ -> :ok = UsageMeters.inc_notes_count(user.id, 1) end)
+      assert UsageMeters.notes_count(user.id) == 5
+    end
+
+    test "dec_notes_count clamps at zero (never negative)" do
+      user = insert(:user)
+      :ok = UsageMeters.inc_notes_count(user.id, 2)
+      :ok = UsageMeters.dec_notes_count(user.id, 5)
+      assert UsageMeters.notes_count(user.id) == 0
+    end
+
+    test "dec_notes_count with a zero delta is a no-op" do
+      user = insert(:user)
+      :ok = UsageMeters.inc_notes_count(user.id, 3)
+      :ok = UsageMeters.dec_notes_count(user.id, 0)
+      assert UsageMeters.notes_count(user.id) == 3
+    end
+
+    test "dec_notes_count on a missing meter row is a safe no-op" do
+      user = insert(:user)
+      assert UsageMeters.dec_notes_count(user.id, 1) == :ok
+      assert UsageMeters.notes_count(user.id) == 0
+    end
+
+    test "recount_notes! recomputes the live count from notes (ignoring soft-deleted)" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      insert(:note, user: user, vault: vault)
+      insert(:note, user: user, vault: vault)
+      insert(:note, user: user, vault: vault, deleted_at: DateTime.utc_now())
+
+      assert UsageMeters.recount_notes!(user.id) == 2
+      assert UsageMeters.notes_count(user.id) == 2
+    end
+  end
 end

--- a/test/engram/workers/cleanup_vault_test.exs
+++ b/test/engram/workers/cleanup_vault_test.exs
@@ -11,6 +11,7 @@ defmodule Engram.Workers.CleanupVaultTest do
   alias Engram.Attachments.Attachment
   alias Engram.Notes.{Chunk, Note}
   alias Engram.Repo
+  alias Engram.UsageMeters
   alias Engram.Vaults
   alias Engram.Vaults.Vault
   alias Engram.Workers.CleanupVault
@@ -87,6 +88,25 @@ defmodule Engram.Workers.CleanupVaultTest do
       refute Repo.get(Note, note.id, skip_tenant_check: true)
       refute Repo.get(Attachment, attachment.id, skip_tenant_check: true)
       refute Repo.get(Vault, vault.id, skip_tenant_check: true)
+    end
+
+    test "decrements the owner's notes_count by the vault's live notes", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
+      stub_qdrant(bypass)
+
+      # A soft-deleted note in the same vault must NOT be double-counted.
+      insert(:note, user: user, vault: vault, deleted_at: DateTime.utc_now())
+
+      # Setup seeded one live note; sync the counter to reality.
+      assert UsageMeters.recount_notes!(user.id) == 1
+      assert UsageMeters.notes_count(user.id) == 1
+
+      assert :ok = CleanupVault.perform_cleanup(vault.id, user.id)
+
+      assert UsageMeters.notes_count(user.id) == 0
     end
 
     test "hard-deletes chunks associated with notes", %{

--- a/test/engram/workers/inactivity_cleanup_test.exs
+++ b/test/engram/workers/inactivity_cleanup_test.exs
@@ -149,6 +149,25 @@ defmodule Engram.Workers.InactivityCleanupTest do
       refute InMemory.exists?("#{user.id}/vault1/file.png")
     end
 
+    test "cascades the usage_meters row (notes_count counter) on hard-delete" do
+      # The notes_count counter relies on the meter row vanishing with the user
+      # rather than an explicit decrement. Pin that FK cascade so a future
+      # on_delete change can't silently strand the counter.
+      user = insert(:user)
+      Repo.insert!(%Meter{user_id: user.id, notes_count: 5})
+      assert UsageMeters.notes_count(user.id) == 5
+
+      thirty_one_days_ago = DateTime.utc_now() |> DateTime.add(-31 * 86_400, :second)
+
+      user
+      |> Ecto.Changeset.change(%{deleted_at: thirty_one_days_ago})
+      |> Repo.update!(skip_tenant_check: true)
+
+      InactivityCleanup.__sweep_hard__()
+
+      refute Repo.get(Meter, user.id, skip_tenant_check: true)
+    end
+
     test "leaves soft-deleted users <30 days alone" do
       user = insert(:user)
       ten_days_ago = DateTime.utc_now() |> DateTime.add(-10 * 86_400, :second)

--- a/test/engram_web/plugs/auth_test.exs
+++ b/test/engram_web/plugs/auth_test.exs
@@ -22,6 +22,23 @@ defmodule EngramWeb.Plugs.AuthTest do
     refute conn.halted
   end
 
+  test "preloads the subscription assoc when billing is enabled", %{user: user, raw_key: raw_key} do
+    prev_enabled = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, true)
+    on_exit(fn -> Application.put_env(:engram, :billing_enabled, prev_enabled) end)
+
+    insert(:subscription, user: user, tier: "pro", status: "active")
+
+    conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{raw_key}")
+      |> Auth.call([])
+
+    sub = conn.assigns.current_user.subscription
+    refute match?(%Ecto.Association.NotLoaded{}, sub)
+    assert sub.tier == "pro"
+  end
+
   test "authenticates with valid local JWT" do
     Application.put_env(:engram, :auth_provider, :local)
 

--- a/test/engram_web/plugs/auth_test.exs
+++ b/test/engram_web/plugs/auth_test.exs
@@ -39,6 +39,24 @@ defmodule EngramWeb.Plugs.AuthTest do
     assert sub.tier == "pro"
   end
 
+  test "does not preload the subscription in self-host mode (billing disabled)", %{
+    user: user,
+    raw_key: raw_key
+  } do
+    prev_enabled = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, false)
+    on_exit(fn -> Application.put_env(:engram, :billing_enabled, prev_enabled) end)
+
+    insert(:subscription, user: user, tier: "pro", status: "active")
+
+    conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{raw_key}")
+      |> Auth.call([])
+
+    assert match?(%Ecto.Association.NotLoaded{}, conn.assigns.current_user.subscription)
+  end
+
   test "authenticates with valid local JWT" do
     Application.put_env(:engram, :auth_provider, :local)
 

--- a/test/engram_web/plugs/bump_activity_test.exs
+++ b/test/engram_web/plugs/bump_activity_test.exs
@@ -94,6 +94,21 @@ defmodule EngramWeb.Plugs.BumpActivityTest do
       assert {:ok, cached} = ActivityCache.get(user.id)
       assert DateTime.diff(DateTime.utc_now(), cached, :second) < 60
     end
+
+    test "degrades to the DB path when the cache table is unavailable", %{conn: conn} do
+      user = insert(:user)
+
+      # Drop the cache owner (and its table). With the degrade in place this must
+      # NOT 500 the request — it falls back to the authoritative meter read.
+      :ok = Supervisor.terminate_child(Engram.Supervisor, ActivityCache)
+      on_exit(fn -> Supervisor.restart_child(Engram.Supervisor, ActivityCache) end)
+
+      assert ActivityCache.get(user.id) == :miss
+      assert ActivityCache.put(user.id, DateTime.utc_now()) == :ok
+
+      conn |> Plug.Conn.assign(:current_user, user) |> BumpActivity.call([])
+      assert %DateTime{} = UsageMeters.last_active_at(user.id)
+    end
   end
 
   # Counts Repo queries against the `usage_meters` source while `fun` runs.

--- a/test/engram_web/plugs/bump_activity_test.exs
+++ b/test/engram_web/plugs/bump_activity_test.exs
@@ -4,6 +4,8 @@ defmodule EngramWeb.Plugs.BumpActivityTest do
   import Ecto.Query
   alias Engram.Repo
   alias Engram.UsageMeters
+  alias Engram.UsageMeters.ActivityCache
+  alias Engram.UsageMeters.Meter
   alias EngramWeb.Plugs.BumpActivity
 
   describe "call/2" do
@@ -67,6 +69,30 @@ defmodule EngramWeb.Plugs.BumpActivityTest do
 
       bumped = UsageMeters.last_active_at(user.id)
       assert DateTime.diff(bumped, two_hours_ago, :second) > 7000
+    end
+
+    test "a warm cache holding a stale stamp still bumps and re-warms", %{conn: conn} do
+      user = insert(:user)
+      conn |> Plug.Conn.assign(:current_user, user) |> BumpActivity.call([])
+
+      # Force both the cache and the DB to look stale (> 1h).
+      two_hours_ago = DateTime.utc_now() |> DateTime.add(-7200, :second)
+      ActivityCache.put(user.id, two_hours_ago)
+
+      Repo.update_all(
+        from(m in Meter, where: m.user_id == ^user.id),
+        [set: [last_active_at: two_hours_ago]],
+        skip_tenant_check: true
+      )
+
+      conn |> Plug.Conn.assign(:current_user, user) |> BumpActivity.call([])
+
+      bumped = UsageMeters.last_active_at(user.id)
+      assert DateTime.diff(bumped, two_hours_ago, :second) > 7000
+
+      # Cache must be re-warmed to ~now so the next request short-circuits.
+      assert {:ok, cached} = ActivityCache.get(user.id)
+      assert DateTime.diff(DateTime.utc_now(), cached, :second) < 60
     end
   end
 

--- a/test/engram_web/plugs/bump_activity_test.exs
+++ b/test/engram_web/plugs/bump_activity_test.exs
@@ -72,6 +72,9 @@ defmodule EngramWeb.Plugs.BumpActivityTest do
 
   # Counts Repo queries against the `usage_meters` source while `fun` runs.
   defp count_meter_queries(fun) do
+    # Scope to this test's pid: telemetry handlers run in the emitting process,
+    # so without this a concurrent test could leak into the count.
+    test_pid = self()
     {:ok, counter} = Agent.start_link(fn -> 0 end)
     handler_id = {__MODULE__, make_ref()}
 
@@ -79,7 +82,8 @@ defmodule EngramWeb.Plugs.BumpActivityTest do
       handler_id,
       [:engram, :repo, :query],
       fn _event, _measurements, %{source: source}, _config ->
-        if source == "usage_meters", do: Agent.update(counter, &(&1 + 1))
+        if source == "usage_meters" and self() == test_pid,
+          do: Agent.update(counter, &(&1 + 1))
       end,
       nil
     )

--- a/test/engram_web/plugs/bump_activity_test.exs
+++ b/test/engram_web/plugs/bump_activity_test.exs
@@ -34,6 +34,21 @@ defmodule EngramWeb.Plugs.BumpActivityTest do
       assert UsageMeters.last_active_at(user.id) == first_stamp
     end
 
+    test "warm cache hit within the window issues no meter query", %{conn: conn} do
+      user = insert(:user)
+
+      # First request: cold cache → reads (+writes) the meter and warms the cache.
+      conn |> Plug.Conn.assign(:current_user, user) |> BumpActivity.call([])
+
+      # Second request: warm cache → must not touch the DB at all.
+      queries =
+        count_meter_queries(fn ->
+          conn |> Plug.Conn.assign(:current_user, user) |> BumpActivity.call([])
+        end)
+
+      assert queries == 0
+    end
+
     test "bumps when last_active_at is older than 1h", %{conn: conn} do
       user = insert(:user)
       UsageMeters.bump_last_active(user.id)
@@ -52,6 +67,29 @@ defmodule EngramWeb.Plugs.BumpActivityTest do
 
       bumped = UsageMeters.last_active_at(user.id)
       assert DateTime.diff(bumped, two_hours_ago, :second) > 7000
+    end
+  end
+
+  # Counts Repo queries against the `usage_meters` source while `fun` runs.
+  defp count_meter_queries(fun) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    handler_id = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:engram, :repo, :query],
+      fn _event, _measurements, %{source: source}, _config ->
+        if source == "usage_meters", do: Agent.update(counter, &(&1 + 1))
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+      Agent.get(counter, & &1)
+    after
+      :telemetry.detach(handler_id)
+      Agent.stop(counter)
     end
   end
 end


### PR DESCRIPTION
## Summary

Reduces the DB round trips on every authenticated request. Steady-state authenticated read path drops from ~5 sequential round trips toward ~1-2; the write path loses its per-insert full `COUNT(*)`. All caches are per-node (ETS / `:persistent_term`), matching the Redis-free architecture.

Five independently-scoped commits:

- **P2 — subscription memoization** (`1fe6364`): `has_one :subscription`; `Billing.get_subscription/1` reuses a preloaded assoc; `Auth` plug preloads it once (guarded on `billing_enabled`, so self-host skips). Collapses the 2-4 per-request subscription queries (RequireOnboarding + the two limit plugs) to a single load.
- **P4 — BumpActivity ETS fast-path** (`494137d`): per-node `ActivityCache` holds the last stamp; a request inside the 1h debounce window skips the `usage_meters` read entirely. Cache miss falls back to the authoritative DB read.
- **P5 — plan-limit cache** (`75b4a49`): plan rows are seeded and static at runtime, so cache each plan's `limits` map in `:persistent_term`. `plan_lookup` no longer queries `plans` for API-key traffic. `invalidate/1` exposed for the rare runtime plan edit. Resolution semantics preserved (JSON `false` vs missing key).
- **P3 — TOS-acceptance cache** (`7c4d655`): acceptance is append-only and monotonic per version, so a positive-only `{user_id, version}` ETS cache removes the `user_agreements` read for onboarded users — **no PubSub invalidation needed** (a version bump changes the key).
- **P1 — maintained `notes_count`** (`a2ff68b`): replaces the per-insert `COUNT(*)` with a counter on `usage_meters`. `+1` on insert, `-1` on soft-delete (both atomic in the tenant transaction), bulk `-N` on vault hard-delete. User hard-delete needs no decrement (meter row cascades). Migration backfills live counts for existing users; `recount_notes/1` reconciles drift.

## Migration

`20260525001318_add_notes_count_to_usage_meters` adds `notes_count bigint NOT NULL DEFAULT 0` and backfills (updates existing meter rows + inserts missing ones). Additive and idempotent.

## Test plan

- [x] `mix test` — full suite green (1538 tests, 0 failures)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean
- [x] New coverage: subscription/plan-cache query-count assertions (telemetry), BumpActivity warm-hit no-query, TOS positive/negative caching, notes_count inc/dec/idempotency/cap-enforcement, vault-cleanup decrement, backfill SQL pinned
- [ ] Post-merge: run the migration on FastRaid and smoke-check notes_cap enforcement + onboarding gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)