### PR TITLE
docs(ci): fix stale storage-backend comment in docker-compose.ci.yml

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -48,10 +48,11 @@ services:
       KEY_PROVIDER: ${KEY_PROVIDER:-local}
       ENCRYPTION_MASTER_KEY: ${ENCRYPTION_MASTER_KEY:?ENCRYPTION_MASTER_KEY must be set (CI workflow injects from secret, local dev sets via .env)}
       ENCRYPTION_MASTER_KEY_PREVIOUS: ${ENCRYPTION_MASTER_KEY_PREVIOUS:-}
-      # S3-compatible attachment storage (MinIO sidecar). STORAGE_BACKEND=s3
-      # is required because runtime.exs defaults to the BYTEA `database` adapter
-      # otherwise — without this, attachments would land in Postgres BYTEA and
-      # the ciphertext-at-rest probe would find no MinIO object.
+      # S3-compatible attachment storage (MinIO sidecar). This stack tests the
+      # S3 path, so STORAGE_BACKEND is pinned to s3 — the e2e ciphertext-at-rest
+      # probe expects a MinIO object. (The bytea `database` backend, #297, is
+      # exercised separately by the storage-database CI job; runtime.exs
+      # defaults to s3.)
       STORAGE_BACKEND: s3
       STORAGE_BUCKET: engram-attachments
       STORAGE_ACCESS_KEY_ID: minioadmin

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.224",
+      version: "0.5.225",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
The `engram` service comment in `docker-compose.ci.yml` claimed `runtime.exs` "defaults to the BYTEA `database` adapter" — that was already wrong (default is `s3`) and is now extra-misleading since #297 reintroduced `STORAGE_BACKEND=database` as a real value. Rewords it to explain accurately why this stack pins `s3` (it tests the S3/MinIO ciphertext-at-rest path) and points at the `storage-database` job that covers the bytea backend.

Comment-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)