### PR TITLE
chore(dev): make dev-ui-staging — iterate UI against staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help deps dev dev-selfhost dev-stop test backend-build backend-up backend-down frontend-install frontend-build frontend-dev ci-up ci-down ci-e2e e2e bench-dataset bench-quality bench-perf bench-reranking bench-cost bench-all bench-report bench-list parity-mix parity-bash parity-ci-up parity-ci-down gen-master-key
+.PHONY: help deps dev dev-selfhost dev-stop test backend-build backend-up backend-down frontend-install frontend-build frontend-dev dev-ui-staging ci-up ci-down ci-e2e e2e bench-dataset bench-quality bench-perf bench-reranking bench-cost bench-all bench-report bench-list parity-mix parity-bash parity-ci-up parity-ci-down gen-master-key
 
 help:              ## List available targets
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -48,6 +48,13 @@ frontend-build:    ## Build frontend (vite → priv/static/app)
 
 frontend-dev:      ## Run Vite dev server standalone
 	cd frontend && bun run dev
+
+dev-ui-staging:    ## Vite (:5173, LAN) against staging backend — UI-only, no local Phoenix/Oban
+	@# Must run under node (not bun): the IPv4 fix in vite.config.ts uses node DNS
+	@# APIs bun ignores, and node needs VITE_API_TARGET passed inline (it doesn't
+	@# auto-load .env.local into process.env). Clerk vars come from frontend/.env.local.
+	@# See docs/context/dev-iteration-loop.md → "Iterating against the staging backend".
+	cd frontend && VITE_API_TARGET=https://staging.engram.page node node_modules/.bin/vite --host 0.0.0.0
 
 # --- CI Stack ---
 

--- a/docs/context/dev-iteration-loop.md
+++ b/docs/context/dev-iteration-loop.md
@@ -13,8 +13,102 @@ How to make changes show up in a browser when iterating locally on this VM. Patt
 | Frontend hot-reload while editing   | `http://localhost:5173/`         | `make frontend-dev` running                 |
 | Test prod bundle locally            | `http://localhost:4000/`         | `make dev` running + `bun run build`        |
 | Share with friends / external test  | `https://app.engram.page/`       | `make dev` running + `bun run build`        |
+| **UI-only iteration, real Clerk + data, no local backend** | `http://localhost:5173/` (or `http://10.0.20.172:5173/` from LAN) | Vite pointed at staging — see "Iterating against staging" below |
 
 > **Important:** `app.engram.page` only sees what Phoenix serves. To make changes visible there during dev, you must run `bun run build` inside `backend/frontend/` so Phoenix has the new static bundle to ship.
+
+## Iterating against the staging backend (no local Phoenix)
+
+_Added 2026-05-26._
+
+For **pure frontend/UI work** (e.g. the onboarding wizard) you can skip running
+Phoenix entirely and point the Vite dev server at the live **staging** backend.
+You get HMR on your branch's UI, real Clerk auth, and real data — and crucially
+**no local node joins the shared Oban queue** (see the Oban hazard below).
+
+### Why not just `make dev` against the FastRaid DB?
+
+`backend/.env.local` already points `DATABASE_URL` at FastRaid Postgres
+(`10.0.20.214:35432/engram`) and Qdrant at `10.0.20.201:6333`. But Oban starts
+unconditionally in `lib/engram/application.ex` with live queues
+(`embed/reindex/maintenance/crypto_backfill` + Cron, see `config/config.exs`) and
+there is **no dev/env override to disable it**. So a local `mix phx.server`
+against that DB becomes a worker on the shared job queue — it will pull and run
+real embedding jobs (Voyage cost), crypto_backfill, and cron against shared
+Qdrant/data. The staging-proxy approach below sidesteps this completely.
+
+### Setup
+
+In `backend/frontend/.env.local` (gitignored):
+
+```
+VITE_AUTH_PROVIDER=clerk
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_a2V5LWxvbmdob3JuLTc5LmNsZXJrLmFjY291bnRzLmRldiQ
+VITE_API_TARGET=https://staging.engram.page
+```
+
+The publishable key MUST be **staging's** Clerk instance. Get the current one with:
+
+```
+curl -s https://staging.engram.page/ | grep -o '__ENGRAM_CONFIG__[^<]*'
+```
+
+As of 2026-05-26 staging is Clerk instance **longhorn-79** (the key above). The
+local backend's `.env.local` uses a *different* instance (`rare-kingfish-16`) —
+using the wrong key gives 401s because staging won't validate JWTs minted by a
+different instance.
+
+`vite.config.ts` already carries the two changes this needs (committed): proxy
+entries with `changeOrigin: true` + `secure: true`, and an IPv4-forcing preamble
+(`dns.setDefaultResultOrder('ipv4first')` + `net.setDefaultAutoSelectFamily(false)`).
+
+### Run it (under node, not bun)
+
+```
+make dev-ui-staging          # from backend/ — binds 0.0.0.0 for LAN access
+```
+
+That target expands to (run from `backend/frontend/`):
+
+```
+VITE_API_TARGET=https://staging.engram.page node node_modules/.bin/vite          # localhost only
+VITE_API_TARGET=https://staging.engram.page node node_modules/.bin/vite --host 0.0.0.0   # reachable on LAN
+```
+
+Verify the proxy reaches staging (401 = reached backend, just unauthenticated):
+
+```
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:5173/api/billing/config   # expect 401
+```
+
+Then open `http://localhost:5173/` (or `http://10.0.20.172:5173/` from another LAN
+machine) and sign in via Clerk.
+
+### LAN access from another machine
+
+- Bind with `--host 0.0.0.0` (default bind is `localhost` only).
+- Open the VM firewall: `sudo firewall-cmd --add-port=5173/tcp` (runtime-only, no
+  `--permanent`, auto-closes on reboot/reload). Tighter: scope to the subnet with a
+  rich rule `source address="10.0.20.0/24"`. This VM's LAN IP is **10.0.20.172**.
+- Connect by **IP**, not a hostname — Vite's `allowedHosts` permits IP literals but
+  blocks unknown domain names ("Blocked request. This host is not allowed.").
+
+### Failed approaches / dead ends
+
+- **`bun run dev` against a remote https target → 502.** This VM has no IPv6
+  route, staging's DNS returns AAAA records, and the proxy's happy-eyeballs races
+  a dead IPv6 connect (`ENETUNREACH`), surfacing as `502 Bad Gateway` /
+  `AggregateError [ECONNREFUSED]`. Bun **ignores** `NODE_OPTIONS`,
+  `--dns-result-order`, and `net.setDefaultAutoSelectFamily`, so the config-level
+  IPv4 fix doesn't take effect under bun. **Run under `node`.**
+- **Passing the proxy a `family:4` https agent via the vite proxy `agent` option** —
+  did not help (Vite 8's proxy ignored it). The working fix is the process-level
+  `dns`/`net` preamble in `vite.config.ts`, which only applies under node.
+- **Relying on `.env.local` for `VITE_API_TARGET` under node** — node does NOT
+  auto-load `.env.local` into `process.env` (bun does), and `vite.config.ts` reads
+  `process.env.VITE_API_TARGET`. So pass it inline on the node command. (Client
+  vars like `VITE_AUTH_PROVIDER` still load fine — Vite reads `.env.*` into
+  `import.meta.env` regardless of runtime.)
 
 ## The white-page gotcha (and the fix)
 

--- a/docs/context/dev-iteration-loop.md
+++ b/docs/context/dev-iteration-loop.md
@@ -93,6 +93,60 @@ machine) and sign in via Clerk.
 - Connect by **IP**, not a hostname — Vite's `allowedHosts` permits IP literals but
   blocks unknown domain names ("Blocked request. This host is not allowed.").
 
+### Sharing the browser view with the AI (CDP over reverse tunnel)
+
+_Added 2026-05-26._
+
+Problem: you're on a laptop SSH'd into this VM, viewing the Vite page in your
+**laptop** browser. The `chrome-devtools` MCP, by default, drives a *separate*
+headless-ish Chromium running **on the VM** (port `9224`) — so the AI and you are
+looking at two different browsers. To co-drive **the exact tab you're watching**,
+expose your laptop Chrome's CDP to the VM and point the MCP at it.
+
+**Steps that worked:**
+
+1. **Laptop** — fully quit Chrome first (or the debug flag is silently ignored
+   and it just opens a tab in the running instance), then launch pinned to a
+   throwaway profile:
+   ```
+   google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/engram-cdp http://10.0.20.172:5173
+   ```
+2. **Laptop** — reverse-forward that CDP port into the VM (add `-R` to your
+   existing SSH session or open a second one):
+   ```
+   ssh -R 9222:localhost:9222 <this-vm>
+   ```
+3. **VM** — confirm the tunnel reaches your laptop browser:
+   ```
+   curl -s --max-time 2 http://localhost:9222/json/version    # Browser: Chrome/...
+   curl -s http://localhost:9222/json/list                    # should list YOUR tab
+   ```
+4. **Point the MCP at it.** `~/.claude.json` → `mcpServers.chrome-devtools.args`
+   carries `--browserUrl=http://127.0.0.1:<port>`. Set it to the tunnel port,
+   then reconnect the server (`/mcp` → chrome-devtools → reconnect). Verify with
+   the MCP `list_pages` — it should show **only** your laptop tab.
+
+**Gotchas / why it's fiddly:**
+
+- **CDP binds localhost only.** `--remote-debugging-port` never listens on the
+  LAN, by design. The reverse SSH tunnel is mandatory; do **not** try to expose
+  9222 on `0.0.0.0` — it won't, and you shouldn't (unauthenticated full browser
+  control).
+- **Port collision with the VM's own debug Chrome.** A persistent Chromium runs
+  on the VM at **`9224`** (that's the MCP's default `--browserUrl`). You therefore
+  cannot reverse-tunnel *onto* 9224 (address in use). Two clean options:
+  - **Repoint the MCP** to the tunnel port (e.g. `9222`) + reconnect. Simplest
+    per-session; **remember to revert `--browserUrl` to `9224`** afterward (or
+    your next solo session attaches to a dead tunnel).
+  - **Free `9224`** (stop the VM-local Chromium) and tunnel your laptop onto
+    `9224` instead — zero config edit, but kills whatever else uses that browser.
+- **Recommended convention:** dedicate **`9222` = "the shared/laptop tab"** and
+  leave `9224` = "VM-local solo browser". Flip `--browserUrl` between them per
+  session. (If we end up sharing often, standardize the MCP on `9222`
+  permanently and run the VM-local browser there too.)
+- Confirm the tunnel listens on both `127.0.0.1:9222` and `[::1]:9222`
+  (`ss -ltn | grep 9222`); the MCP uses `127.0.0.1`, so IPv4 is what matters.
+
 ### Failed approaches / dead ends
 
 - **`bun run dev` against a remote https target → 502.** This VM has no IPv6

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,25 @@
+import dns from 'node:dns'
+import net from 'node:net'
+import https from 'node:https'
 import { fileURLToPath } from 'node:url'
+
+// This host has no IPv6 route; staging's DNS returns AAAA records, so the
+// proxy's happy-eyeballs races a dead IPv6 connect and 502s. Prefer IPv4 and
+// disable family auto-selection so connects use the first (IPv4) address only.
+dns.setDefaultResultOrder('ipv4first')
+net.setDefaultAutoSelectFamily?.(false)
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 /// <reference types="vitest" />
 
 const apiTarget = process.env.VITE_API_TARGET ?? 'http://localhost:4000'
+
+// Pin the proxy to IPv4. When VITE_API_TARGET is a remote origin whose DNS
+// returns AAAA records (e.g. staging behind Cloudflare), Node's happy-eyeballs
+// races an IPv6 connect that fails on hosts without IPv6 routing, surfacing as
+// a 502 ECONNREFUSED. Only relevant for https targets.
+const proxyAgent = apiTarget.startsWith('https') ? new https.Agent({ family: 4 }) : undefined
 
 export default defineConfig({
   test: {
@@ -29,10 +44,16 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': apiTarget,
+      // changeOrigin rewrites the Host header to the target — required when
+      // VITE_API_TARGET is a remote, host-routed origin (e.g. staging behind
+      // Cloudflare); harmless for the localhost default.
+      '/api': { target: apiTarget, changeOrigin: true, secure: true, agent: proxyAgent },
       '/socket': {
         target: apiTarget,
+        changeOrigin: true,
+        secure: true,
         ws: true,
+        agent: proxyAgent,
       },
     },
   },

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.226",
+      version: "0.5.227",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
Adds a dev loop for **pure frontend/UI work** that points Vite at the live **staging** backend — HMR on your branch, real Clerk + data, and **no local Phoenix node joining the shared Oban queue**.

- `make dev-ui-staging` — runs Vite under **node** with `--host` and `VITE_API_TARGET=https://staging.engram.page`.
- `vite.config.ts` — proxy `changeOrigin`/`secure` + an IPv4-forcing preamble.
- `docs/context/dev-iteration-loop.md` — full setup, gotchas, and dead ends.

## Why the IPv4 hack
This VM has no IPv6 route, but staging's DNS returns AAAA records, so Vite's proxy happy-eyeballs raced a dead IPv6 connect → `502 Bad Gateway`. Forcing IPv4 (`dns.setDefaultResultOrder('ipv4first')` + `net.setDefaultAutoSelectFamily(false)`) fixes it. **Must run under node** — bun ignores those node DNS APIs, and node needs `VITE_API_TARGET` inline (it doesn't auto-load `.env.local` into `process.env`).

## Setup (one-time, gitignored)
`backend/frontend/.env.local` needs `VITE_AUTH_PROVIDER=clerk` + staging's `VITE_CLERK_PUBLISHABLE_KEY` (instance `longhorn-79`). See the context doc.

## Test plan
- [x] `make dev-ui-staging` serves :5173; `curl :5173/api/billing/config` → 401 (proxy reaches staging)
- [ ] Sign in via Clerk from a browser and confirm authed requests succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)