### PR TITLE
feat(legal): binding-grade ToS/Privacy acceptance (hash-verified, min_required gate)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -314,20 +314,24 @@ end
 #
 # content hashes pin the exact accepted document text; min_required_tos_version
 # is the floor below which an acceptance is no longer considered binding.
-config :engram,
-  current_tos_version: System.get_env("CURRENT_TOS_VERSION", "2026-05-19"),
-  min_required_tos_version: System.get_env("MIN_REQUIRED_TOS_VERSION", "2026-05-19"),
-  current_tos_hash:
-    System.get_env(
-      "CURRENT_TOS_HASH",
-      "6785e725e9900d5f87a90eca362c388d3254dac0e5b7105ba5da29d316551e5c"
-    ),
-  current_privacy_version: System.get_env("CURRENT_PRIVACY_VERSION", "2026-05-19"),
-  current_privacy_hash:
-    System.get_env(
-      "CURRENT_PRIVACY_HASH",
-      "87e117552f1ab05acadb04cc50b3b18e37dba5b6a82a3c3e480286f587af2708"
-    )
+# Guarded out of :test so config/test.exs provides deterministic values;
+# tests override per-case via Application.put_env.
+if config_env() != :test do
+  config :engram,
+    current_tos_version: System.get_env("CURRENT_TOS_VERSION", "2026-05-19"),
+    min_required_tos_version: System.get_env("MIN_REQUIRED_TOS_VERSION", "2026-05-19"),
+    current_tos_hash:
+      System.get_env(
+        "CURRENT_TOS_HASH",
+        "6785e725e9900d5f87a90eca362c388d3254dac0e5b7105ba5da29d316551e5c"
+      ),
+    current_privacy_version: System.get_env("CURRENT_PRIVACY_VERSION", "2026-05-19"),
+    current_privacy_hash:
+      System.get_env(
+        "CURRENT_PRIVACY_HASH",
+        "87e117552f1ab05acadb04cc50b3b18e37dba5b6a82a3c3e480286f587af2708"
+      )
+end
 
 # Key provider — skip in :test so test.exs stable key is not overwritten by a nil env read.
 # Dev and prod (including Docker CI containers) read from KEY_PROVIDER / ENCRYPTION_MASTER_KEY.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -311,7 +311,23 @@ end
 # Current Terms of Service version. Must match the version exported by
 # frontend/src/legal/terms-of-service.tsx. Bumping this re-prompts every
 # user on next request via the RequireOnboarding plug.
-config :engram, :current_tos_version, System.get_env("CURRENT_TOS_VERSION", "2026-05-15")
+#
+# content hashes pin the exact accepted document text; min_required_tos_version
+# is the floor below which an acceptance is no longer considered binding.
+config :engram,
+  current_tos_version: System.get_env("CURRENT_TOS_VERSION", "2026-05-19"),
+  min_required_tos_version: System.get_env("MIN_REQUIRED_TOS_VERSION", "2026-05-19"),
+  current_tos_hash:
+    System.get_env(
+      "CURRENT_TOS_HASH",
+      "6785e725e9900d5f87a90eca362c388d3254dac0e5b7105ba5da29d316551e5c"
+    ),
+  current_privacy_version: System.get_env("CURRENT_PRIVACY_VERSION", "2026-05-19"),
+  current_privacy_hash:
+    System.get_env(
+      "CURRENT_PRIVACY_HASH",
+      "87e117552f1ab05acadb04cc50b3b18e37dba5b6a82a3c3e480286f587af2708"
+    )
 
 # Key provider — skip in :test so test.exs stable key is not overwritten by a nil env read.
 # Dev and prod (including Docker CI containers) read from KEY_PROVIDER / ENCRYPTION_MASTER_KEY.

--- a/config/test.exs
+++ b/config/test.exs
@@ -117,6 +117,10 @@ config :engram,
 # via Application.put_env/3 in their setup blocks.
 config :engram, :billing_enabled, true
 config :engram, :current_tos_version, "2026-05-15"
+config :engram, :min_required_tos_version, "2026-05-15"
+config :engram, :current_tos_hash, "test-tos-hash"
+config :engram, :current_privacy_version, "2026-05-15"
+config :engram, :current_privacy_hash, "test-privacy-hash"
 
 # Limits enforced by default in test env so existing tests don't bypass.
 config :engram, :limits_enforced, true

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -13,29 +13,80 @@ defmodule Engram.Onboarding do
   alias Engram.Repo
 
   @terms_document "terms_of_service"
+  @privacy_document "privacy_policy"
 
   @doc """
-  Record that `user` accepted document version `version`. `meta` may carry
-  `:ip_address` (string) and `:user_agent` (string) for audit purposes.
-  Returns `{:ok, %Agreement{}}` or `{:error, %Ecto.Changeset{}}`.
+  Record that `user` accepted Terms of Service version `tos_version` (pinned by
+  `tos_hash`) and Privacy Policy version `privacy_version` (pinned by
+  `privacy_hash`). Both rows share the same `accepted_at`/ip/ua audit metadata.
+  `meta` may carry `:ip_address` (string) and `:user_agent` (string).
+
+  Returns `{:ok, %Agreement{}}` (the ToS row) when both inserts succeed, or
+  `{:error, %Ecto.Changeset{}}` for the first row that fails.
+  """
+  def accept_terms(user, tos_version, tos_hash, privacy_version, privacy_hash, meta)
+      when is_binary(tos_version) and is_binary(privacy_version) do
+    accepted_at = DateTime.utc_now(:second)
+    ip = Map.get(meta, :ip_address)
+    ua = Map.get(meta, :user_agent)
+
+    base = %{
+      user_id: user.id,
+      accepted_at: accepted_at,
+      ip_address: ip,
+      user_agent: ua
+    }
+
+    # Atomic: a ToS row without its paired Privacy row is an incomplete audit
+    # record, so roll back the first insert if the second fails.
+    Repo.transaction(fn ->
+      with {:ok, tos_row} <-
+             insert_agreement(
+               Map.merge(base, %{
+                 document: @terms_document,
+                 version: tos_version,
+                 content_hash: tos_hash
+               })
+             ),
+           {:ok, _privacy_row} <-
+             insert_agreement(
+               Map.merge(base, %{
+                 document: @privacy_document,
+                 version: privacy_version,
+                 content_hash: privacy_hash
+               })
+             ) do
+        tos_row
+      else
+        {:error, changeset} -> Repo.rollback(changeset)
+      end
+    end)
+  end
+
+  @doc """
+  Record that `user` accepted Terms of Service version `version` (no content
+  hash, no Privacy row). Retained for the existing controller/tests until the
+  controller is migrated to the 6-arity form. Delegates to `insert_agreement/1`.
   """
   def accept_terms(user, version, meta) when is_binary(version) do
-    attrs = %{
+    insert_agreement(%{
       user_id: user.id,
       document: @terms_document,
       version: version,
       accepted_at: DateTime.utc_now(:second),
       ip_address: Map.get(meta, :ip_address),
       user_agent: Map.get(meta, :user_agent)
-    }
+    })
+  end
 
-    # Upsert on (user_id, document, version) so re-accepts of the same version
-    # refresh the audit fields instead of inserting duplicate rows. Unique
-    # index `user_agreements_user_document_version_unique` enforces this at DB.
+  # Upsert on (user_id, document, version) so re-accepts of the same version
+  # refresh the audit fields instead of inserting duplicate rows. Unique
+  # index `user_agreements_user_document_version_unique` enforces this at DB.
+  defp insert_agreement(attrs) do
     %Agreement{}
     |> Agreement.changeset(attrs)
     |> Repo.insert(
-      on_conflict: {:replace, [:accepted_at, :ip_address, :user_agent]},
+      on_conflict: {:replace, [:accepted_at, :ip_address, :user_agent, :content_hash]},
       conflict_target: [:user_id, :document, :version],
       returning: true,
       skip_tenant_check: true
@@ -57,7 +108,8 @@ defmodule Engram.Onboarding do
   def status(user) do
     if Application.get_env(:engram, :billing_enabled, false) do
       current_version = Application.get_env(:engram, :current_tos_version)
-      terms_ok = terms_accepted?(user, current_version)
+      min_required = Application.get_env(:engram, :min_required_tos_version)
+      terms_ok = terms_accepted?(user, min_required)
       subscription_ok = Billing.active?(user)
       next = next_step(terms_ok, subscription_ok)
 
@@ -66,6 +118,7 @@ defmodule Engram.Onboarding do
         terms_ok: terms_ok,
         subscription_ok: subscription_ok,
         current_tos_version: current_version,
+        current_privacy_version: Application.get_env(:engram, :current_privacy_version),
         next_step: next
       }
     else
@@ -73,17 +126,19 @@ defmodule Engram.Onboarding do
     end
   end
 
-  defp terms_accepted?(user, current_version) do
-    if TermsCache.accepted?(user.id, current_version) do
+  # Gate on `min_required_tos_version`: a bump to `current_tos_version` alone
+  # (minor edit) must NOT force re-accept — only a `min_required` bump does.
+  defp terms_accepted?(user, min_required) do
+    if TermsCache.accepted?(user.id, min_required) do
       true
     else
-      accepted = query_terms_accepted?(user, current_version)
-      if accepted, do: TermsCache.mark_accepted(user.id, current_version)
+      accepted = query_terms_accepted?(user, min_required)
+      if accepted, do: TermsCache.mark_accepted(user.id, min_required)
       accepted
     end
   end
 
-  defp query_terms_accepted?(user, current_version) do
+  defp query_terms_accepted?(user, min_required) do
     import Ecto.Query
 
     latest =
@@ -97,7 +152,7 @@ defmodule Engram.Onboarding do
 
     case latest do
       nil -> false
-      accepted -> accepted >= current_version
+      accepted -> accepted >= min_required
     end
   end
 

--- a/lib/engram/onboarding/agreement.ex
+++ b/lib/engram/onboarding/agreement.ex
@@ -22,7 +22,15 @@ defmodule Engram.Onboarding.Agreement do
 
   def changeset(agreement, attrs) do
     agreement
-    |> cast(attrs, [:user_id, :document, :version, :accepted_at, :ip_address, :user_agent, :content_hash])
+    |> cast(attrs, [
+      :user_id,
+      :document,
+      :version,
+      :accepted_at,
+      :ip_address,
+      :user_agent,
+      :content_hash
+    ])
     |> validate_required([:user_id, :document, :version, :accepted_at])
   end
 end

--- a/lib/engram/onboarding/agreement.ex
+++ b/lib/engram/onboarding/agreement.ex
@@ -15,13 +15,14 @@ defmodule Engram.Onboarding.Agreement do
     field :accepted_at, :utc_datetime
     field :ip_address, :string
     field :user_agent, :string
+    field :content_hash, :string
 
     belongs_to :user, Engram.Accounts.User
   end
 
   def changeset(agreement, attrs) do
     agreement
-    |> cast(attrs, [:user_id, :document, :version, :accepted_at, :ip_address, :user_agent])
+    |> cast(attrs, [:user_id, :document, :version, :accepted_at, :ip_address, :user_agent, :content_hash])
     |> validate_required([:user_id, :document, :version, :accepted_at])
   end
 end

--- a/lib/engram_web/controllers/onboarding_controller.ex
+++ b/lib/engram_web/controllers/onboarding_controller.ex
@@ -31,17 +31,28 @@ defmodule EngramWeb.OnboardingController do
     json(conn, payload)
   end
 
-  def accept_terms(conn, %{"version" => version}) do
-    user = conn.assigns.current_user
-    current_version = Application.get_env(:engram, :current_tos_version)
+  def accept_terms(conn, %{
+        "tos_version" => tv,
+        "tos_hash" => th,
+        "privacy_version" => pv,
+        "privacy_hash" => ph
+      }) do
+    # Verify BOTH documents' version + content hash against the canonical config.
+    # Any mismatch means the app is showing different text than the backend
+    # expects (drift) — refuse with 409 instead of recording bad consent.
+    ok =
+      tv == Application.get_env(:engram, :current_tos_version) and
+        th == Application.get_env(:engram, :current_tos_hash) and
+        pv == Application.get_env(:engram, :current_privacy_version) and
+        ph == Application.get_env(:engram, :current_privacy_hash)
 
-    if version == current_version do
+    if ok do
       meta = %{
         ip_address: format_ip(conn.remote_ip),
         user_agent: get_user_agent(conn)
       }
 
-      case Onboarding.accept_terms(user, version, meta) do
+      case Onboarding.accept_terms(conn.assigns.current_user, tv, th, pv, ph, meta) do
         {:ok, agreement} ->
           conn
           |> put_status(:created)
@@ -51,12 +62,12 @@ defmodule EngramWeb.OnboardingController do
           conn |> put_status(422) |> json(%{error: "invalid"})
       end
     else
-      conn |> put_status(422) |> json(%{error: "version_mismatch"})
+      conn |> put_status(409) |> json(%{error: "stale"})
     end
   end
 
   def accept_terms(conn, _params) do
-    conn |> put_status(422) |> json(%{error: "missing_version"})
+    conn |> put_status(422) |> json(%{error: "missing_fields"})
   end
 
   defp format_ip({a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"

--- a/lib/engram_web/controllers/onboarding_controller.ex
+++ b/lib/engram_web/controllers/onboarding_controller.ex
@@ -17,6 +17,7 @@ defmodule EngramWeb.OnboardingController do
           terms_ok: terms_ok,
           subscription_ok: sub_ok,
           current_tos_version: version,
+          current_privacy_version: privacy_version,
           next_step: next
         } ->
           %{
@@ -24,6 +25,7 @@ defmodule EngramWeb.OnboardingController do
             terms_ok: terms_ok,
             subscription_ok: sub_ok,
             current_tos_version: version,
+            current_privacy_version: privacy_version,
             next_step: Atom.to_string(next)
           }
       end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.226",
+      version: "0.5.227",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260526211254_add_content_hash_to_user_agreements.exs
+++ b/priv/repo/migrations/20260526211254_add_content_hash_to_user_agreements.exs
@@ -1,0 +1,9 @@
+defmodule Engram.Repo.Migrations.AddContentHashToUserAgreements do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_agreements) do
+      add :content_hash, :text
+    end
+  end
+end

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -82,12 +82,17 @@ defmodule Engram.OnboardingTest do
     setup do
       prev_enabled = Application.get_env(:engram, :billing_enabled)
       prev_version = Application.get_env(:engram, :current_tos_version)
+      prev_min = Application.get_env(:engram, :min_required_tos_version)
       Application.put_env(:engram, :billing_enabled, true)
       Application.put_env(:engram, :current_tos_version, "2026-05-15")
+      # Default min_required tracks current here so the pre-existing tests keep
+      # their original "accepted >= current" semantics.
+      Application.put_env(:engram, :min_required_tos_version, "2026-05-15")
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
         Application.put_env(:engram, :current_tos_version, prev_version)
+        Application.put_env(:engram, :min_required_tos_version, prev_min)
       end)
 
       :ok
@@ -178,6 +183,81 @@ defmodule Engram.OnboardingTest do
       assert TermsCache.accepted?(user.id, "2026-05-15") == false
       assert :ok = TermsCache.mark_accepted(user.id, "2026-05-15")
       assert %{terms_ok: true} = Onboarding.status(user)
+    end
+  end
+
+  describe "accept_terms/6 + min_required gate" do
+    setup do
+      prev_enabled = Application.get_env(:engram, :billing_enabled)
+      prev_current = Application.get_env(:engram, :current_tos_version)
+      prev_min = Application.get_env(:engram, :min_required_tos_version)
+      prev_priv = Application.get_env(:engram, :current_privacy_version)
+      Application.put_env(:engram, :billing_enabled, true)
+
+      on_exit(fn ->
+        Application.put_env(:engram, :billing_enabled, prev_enabled)
+        Application.put_env(:engram, :current_tos_version, prev_current)
+        Application.put_env(:engram, :min_required_tos_version, prev_min)
+        Application.put_env(:engram, :current_privacy_version, prev_priv)
+      end)
+
+      :ok
+    end
+
+    test "terms_accepted? true when accepted >= min_required even if below current" do
+      Application.put_env(:engram, :min_required_tos_version, "2026-05-19")
+      Application.put_env(:engram, :current_tos_version, "2026-06-01")
+
+      user = insert(:user)
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{})
+
+      assert Onboarding.status(user).terms_ok
+    end
+
+    test "terms_accepted? false when accepted below min_required" do
+      Application.put_env(:engram, :min_required_tos_version, "2026-06-01")
+      Application.put_env(:engram, :current_tos_version, "2026-06-01")
+
+      user = insert(:user)
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{})
+
+      refute Onboarding.status(user).terms_ok
+    end
+
+    test "accept_terms stores content_hash and writes a privacy_policy row" do
+      Application.put_env(:engram, :min_required_tos_version, "2026-05-19")
+      Application.put_env(:engram, :current_tos_version, "2026-05-19")
+
+      user = insert(:user)
+
+      {:ok, %Agreement{} = tos} =
+        Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{
+          ip_address: "10.0.0.1",
+          user_agent: "UA"
+        })
+
+      assert tos.document == "terms_of_service"
+      assert tos.content_hash == "h_tos"
+
+      {:ok, rows} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          Engram.Repo.all(Agreement)
+        end)
+
+      privacy = Enum.find(rows, &(&1.document == "privacy_policy"))
+      assert privacy
+      assert privacy.version == "2026-05-19"
+      assert privacy.content_hash == "h_priv"
+    end
+
+    test "status returns current_privacy_version" do
+      Application.put_env(:engram, :min_required_tos_version, "2026-05-19")
+      Application.put_env(:engram, :current_tos_version, "2026-05-19")
+      Application.put_env(:engram, :current_privacy_version, "2026-05-19")
+
+      user = insert(:user)
+
+      assert Onboarding.status(user).current_privacy_version == "2026-05-19"
     end
   end
 

--- a/test/engram_web/controllers/onboarding_controller_test.exs
+++ b/test/engram_web/controllers/onboarding_controller_test.exs
@@ -6,12 +6,16 @@ defmodule EngramWeb.OnboardingControllerTest do
   setup %{conn: conn} do
     prev_enabled = Application.get_env(:engram, :billing_enabled)
     prev_version = Application.get_env(:engram, :current_tos_version)
+    prev_min = Application.get_env(:engram, :min_required_tos_version)
     Application.put_env(:engram, :billing_enabled, true)
     Application.put_env(:engram, :current_tos_version, "2026-05-15")
+    # min_required tracks current here so accepting "2026-05-15" satisfies the gate.
+    Application.put_env(:engram, :min_required_tos_version, "2026-05-15")
 
     on_exit(fn ->
       Application.put_env(:engram, :billing_enabled, prev_enabled)
       Application.put_env(:engram, :current_tos_version, prev_version)
+      Application.put_env(:engram, :min_required_tos_version, prev_min)
     end)
 
     user = insert(:user)
@@ -51,31 +55,94 @@ defmodule EngramWeb.OnboardingControllerTest do
   end
 
   describe "POST /api/onboarding/accept-terms" do
-    test "201 records acceptance with ip + user_agent", %{conn: conn, user: user} do
-      conn =
-        conn
-        |> put_req_header("user-agent", "Mozilla/5.0 (test)")
-        |> post("/api/onboarding/accept-terms", %{"version" => "2026-05-15"})
+    # Pin all four canonical config values these tests assert against. test.exs
+    # pins only current_tos_version, so set the rest here with on_exit restore.
+    setup do
+      prev = %{
+        tos_version: Application.get_env(:engram, :current_tos_version),
+        tos_hash: Application.get_env(:engram, :current_tos_hash),
+        privacy_version: Application.get_env(:engram, :current_privacy_version),
+        privacy_hash: Application.get_env(:engram, :current_privacy_hash)
+      }
 
-      body = json_response(conn, 201)
-      assert body["version"] == "2026-05-15"
-      assert body["accepted_at"] != nil
+      Application.put_env(:engram, :current_tos_version, "2026-05-19")
+      Application.put_env(:engram, :current_tos_hash, "canonical")
+      Application.put_env(:engram, :current_privacy_version, "2026-05-19")
+      Application.put_env(:engram, :current_privacy_hash, "p")
 
-      # Verify the row was actually inserted
-      {:ok, [agreement]} =
+      on_exit(fn ->
+        Application.put_env(:engram, :current_tos_version, prev.tos_version)
+        Application.put_env(:engram, :current_tos_hash, prev.tos_hash)
+        Application.put_env(:engram, :current_privacy_version, prev.privacy_version)
+        Application.put_env(:engram, :current_privacy_hash, prev.privacy_hash)
+      end)
+
+      :ok
+    end
+
+    defp agreements_for(user) do
+      {:ok, rows} =
         Engram.Repo.with_tenant(user.id, fn ->
           Engram.Repo.all(Engram.Onboarding.Agreement)
         end)
 
-      assert agreement.user_id == user.id
-      assert agreement.version == "2026-05-15"
-      assert agreement.user_agent == "Mozilla/5.0 (test)"
+      rows
     end
 
-    test "422 when version does not match current_tos_version", %{conn: conn} do
-      conn = post(conn, "/api/onboarding/accept-terms", %{"version" => "2099-01-01"})
-      body = json_response(conn, 422)
-      assert body["error"] == "version_mismatch"
+    test "returns 409 when the ToS hash mismatches canonical", %{conn: conn, user: user} do
+      conn =
+        post(conn, "/api/onboarding/accept-terms", %{
+          "tos_version" => "2026-05-19",
+          "tos_hash" => "WRONG",
+          "privacy_version" => "2026-05-19",
+          "privacy_hash" => "p"
+        })
+
+      assert json_response(conn, 409)["error"] == "stale"
+      assert agreements_for(user) == []
+    end
+
+    test "returns 409 when the privacy hash mismatches", %{conn: conn, user: user} do
+      conn =
+        post(conn, "/api/onboarding/accept-terms", %{
+          "tos_version" => "2026-05-19",
+          "tos_hash" => "canonical",
+          "privacy_version" => "2026-05-19",
+          "privacy_hash" => "WRONG"
+        })
+
+      assert json_response(conn, 409)["error"] == "stale"
+      assert agreements_for(user) == []
+    end
+
+    test "returns 201 and records both rows when all match", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> put_req_header("user-agent", "Mozilla/5.0 (test)")
+        |> post("/api/onboarding/accept-terms", %{
+          "tos_version" => "2026-05-19",
+          "tos_hash" => "canonical",
+          "privacy_version" => "2026-05-19",
+          "privacy_hash" => "p"
+        })
+
+      body = json_response(conn, 201)
+      assert body["version"] == "2026-05-19"
+
+      rows = agreements_for(user)
+
+      tos = Enum.find(rows, &(&1.document == "terms_of_service"))
+      privacy = Enum.find(rows, &(&1.document == "privacy_policy"))
+
+      assert tos.content_hash == "canonical"
+      assert tos.version == "2026-05-19"
+      assert privacy.content_hash == "p"
+      assert privacy.version == "2026-05-19"
+    end
+
+    test "returns 422 when fields are missing", %{conn: conn} do
+      conn = post(conn, "/api/onboarding/accept-terms", %{"tos_version" => "2026-05-19"})
+      assert json_response(conn, 422)["error"] == "missing_fields"
     end
   end
 end

--- a/test/engram_web/controllers/onboarding_controller_test.exs
+++ b/test/engram_web/controllers/onboarding_controller_test.exs
@@ -34,6 +34,7 @@ defmodule EngramWeb.OnboardingControllerTest do
       assert body["subscription_ok"] == false
       assert body["next_step"] == "agreement"
       assert body["current_tos_version"] == "2026-05-15"
+      assert body["current_privacy_version"] == "2026-05-15"
     end
 
     test "returns next_step=done for fully onboarded user", %{conn: conn, user: user} do


### PR DESCRIPTION
## Summary
Phase B of binding-grade legal agreement (spec: engram-workspace#32; depends on marketing engram-marketing#95 for canonical hashes).
- `user_agreements.content_hash` column + schema field.
- `Onboarding.accept_terms/6` atomically records ToS + Privacy rows, each with `content_hash` (wrapped in `Repo.transaction` — a ToS row without its paired Privacy row would be an incomplete audit record).
- Gate moved from `current_tos_version` to **`min_required_tos_version`**: a minor (display-only) version bump no longer re-prompts users; only a material bump (raising the floor) does.
- `POST /api/onboarding/accept-terms` now requires `tos_version`, `tos_hash`, `privacy_version`, `privacy_hash` and **verifies each against canonical config hashes — 409 `stale` on any mismatch**, so app/backend drift fails loud instead of recording unverifiable consent.
- `status` exposes `current_privacy_version`.
- Config keys (`runtime.exs`, guarded out of `:test`): `current_tos_version`, `min_required_tos_version`, `current_tos_hash`, `current_privacy_version`, `current_privacy_hash`. Defaults match marketing's manifest hashes.

## Notes
- Frontend (Phase C) will send the new request shape + the `?raw`-hashed `.md` bytes; until it ships, the old single-`version` POST is replaced (coordinated deploy: marketing → backend → app).
- v1 text is provisional pending counsel.

## Test plan
- [x] `mix test` — 1568 tests, 0 failures
- [x] Context TDD: min_required gate (accept between min_required and current still valid; below min_required re-accepts), content_hash + privacy row recorded
- [x] Controller TDD: 409 on ToS hash mismatch, 409 on privacy hash mismatch, 201 + both rows on full match
- [x] Root-caused a config-precedence regression (legal block ran in :test, overriding test.exs) — fixed via the `config_env() != :test` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)