### PR TITLE
fix(ci): reconcile deps in prod build RUN so prebuild survives cache prune

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,17 @@ COPY --from=frontend /priv/static/app priv/static/app
 # saw old beam files. Single-step build is correct; the extra minute
 # of compile time is worth the guarantee that the release matches the
 # current source.
+# deps.get here reconciles the shared mix-deps cache mount to THIS image's
+# mix.lock before compiling. The earlier deps.get (~line 46) is layer-cached and
+# skipped when mix.lock is unchanged, so it can't repair a mount that another
+# branch's build (different lock) mutated — and the CI `docker builder prune
+# --keep-storage=2gb` step can evict deps from the mount. Without this, compile
+# fails with "Unchecked dependencies ... lock mismatch". Keeps the cache mounts
+# intact (no caching disabled) while making the build robust to mount drift.
 RUN --mount=type=cache,target=/app/deps,id=mix-deps,sharing=locked \
+    --mount=type=cache,target=/root/.hex,id=mix-hex,sharing=locked \
+    --mount=type=cache,target=/root/.cache/rebar3,id=mix-rebar,sharing=locked \
+    mix deps.get --only $MIX_ENV && \
     mix compile --force && \
     mix release && \
     cp -r /app/_build/prod/rel/engram /app/_release

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.226",
+      version: "0.5.227",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- `prebuild-ci-image` is failing **repo-wide** (seen on #309 and #253) with `Unchecked dependencies for environment prod: mint, finch, req … lock mismatch`.
- Root cause: the prod release step (`Dockerfile`) runs `mix compile --force && mix release` against the shared `--mount=type=cache,id=mix-deps` buildkit cache mount **without running `deps.get`**. The earlier `deps.get` layer (~line 46) is layer-cached and skipped when `mix.lock` is unchanged, so it can't repair a mount that another branch's build (different lock) mutated. The CI `docker builder prune --all --keep-storage=2gb` step also evicts deps from the mount (the runner VM's build cache sits right at the 2GB keep line).
- Fix: run `mix deps.get --only $MIX_ENV` inside the compile RUN to reconcile the mount to **this** image's lock before compiling. **Keeps all cache mounts intact** — nothing disabled — just removes the fragility.

## Why this is the right fix
- The branch lock was identical to `main`; `mix deps.get` is a local no-op. The failure was purely stale shared-mount state, not a dependency problem (not Dependabot).
- Self-validating: this PR's own `prebuild-ci-image` run exercises the new step and repopulates the mount.

## Test plan
- [ ] `prebuild-ci-image` green on this PR
- [ ] e2e jobs green (consume the rebuilt image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)