### PR TITLE
feat(legal): terms_versions foundation — DB/effective-date-driven re-acceptance (P1)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -315,30 +315,7 @@ if config_env() != :test do
   config :engram, :plan_overrides, plan_overrides
 end
 
-# Current Terms of Service version. Must match the version exported by
-# frontend/src/legal/terms-of-service.tsx. Bumping this re-prompts every
-# user on next request via the RequireOnboarding plug.
-#
-# content hashes pin the exact accepted document text; min_required_tos_version
-# is the floor below which an acceptance is no longer considered binding.
-# Guarded out of :test so config/test.exs provides deterministic values;
-# tests override per-case via Application.put_env.
-if config_env() != :test do
-  config :engram,
-    current_tos_version: System.get_env("CURRENT_TOS_VERSION", "2026-05-19"),
-    min_required_tos_version: System.get_env("MIN_REQUIRED_TOS_VERSION", "2026-05-19"),
-    current_tos_hash:
-      System.get_env(
-        "CURRENT_TOS_HASH",
-        "6785e725e9900d5f87a90eca362c388d3254dac0e5b7105ba5da29d316551e5c"
-      ),
-    current_privacy_version: System.get_env("CURRENT_PRIVACY_VERSION", "2026-05-19"),
-    current_privacy_hash:
-      System.get_env(
-        "CURRENT_PRIVACY_HASH",
-        "87e117552f1ab05acadb04cc50b3b18e37dba5b6a82a3c3e480286f587af2708"
-      )
-end
+# Legal versions/hashes now live in the terms_versions table (Engram.Legal), seeded from priv/legal/legal-manifest.json at boot.
 
 # Key provider — skip in :test so test.exs stable key is not overwritten by a nil env read.
 # Dev and prod (including Docker CI containers) read from KEY_PROVIDER / ENCRYPTION_MASTER_KEY.

--- a/config/test.exs
+++ b/config/test.exs
@@ -128,3 +128,6 @@ config :engram, :current_privacy_hash, "test-privacy-hash"
 
 # Limits enforced by default in test env so existing tests don't bypass.
 config :engram, :limits_enforced, true
+
+# Legal seeder skipped at boot in tests — SeederTest seeds per-case.
+config :engram, :seed_legal_on_boot, false

--- a/config/test.exs
+++ b/config/test.exs
@@ -120,11 +120,6 @@ config :engram,
 # Onboarding wizard defaults for tests. Individual tests can override
 # via Application.put_env/3 in their setup blocks.
 config :engram, :billing_enabled, true
-config :engram, :current_tos_version, "2026-05-15"
-config :engram, :min_required_tos_version, "2026-05-15"
-config :engram, :current_tos_hash, "test-tos-hash"
-config :engram, :current_privacy_version, "2026-05-15"
-config :engram, :current_privacy_hash, "test-privacy-hash"
 
 # Limits enforced by default in test env so existing tests don't bypass.
 config :engram, :limits_enforced, true

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -46,8 +46,14 @@ defmodule Engram.Application do
   # Seed + verify terms_versions from the vendored manifest, then warm the
   # version cache. Skipped in :test (tests seed per-case). Fail-loud verify
   # runs in prod so a manifest/db drift halts boot instead of 409-ing signups.
+  #
+  # Also skipped in self-host (billing_enabled=false): the onboarding gate is
+  # bypassed there, so seeding an unused legal table — and turning the vendored
+  # manifest into a hard, fail-loud boot dependency — buys nothing. If a self-host
+  # operator later enables billing, the seed runs on that boot.
   defp maybe_seed_legal do
-    if Application.get_env(:engram, :seed_legal_on_boot, true) do
+    if Application.get_env(:engram, :seed_legal_on_boot, true) and
+         Application.get_env(:engram, :billing_enabled, false) do
       Engram.Legal.Seeder.seed()
       Engram.Legal.Seeder.verify()
       Engram.Legal.VersionCache.invalidate_all()

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -32,7 +32,26 @@ defmodule Engram.Application do
       |> Enum.reject(&is_nil/1)
 
     opts = [strategy: :one_for_one, name: Engram.Supervisor]
-    Supervisor.start_link(children, opts)
+
+    case Supervisor.start_link(children, opts) do
+      {:ok, pid} ->
+        maybe_seed_legal()
+        {:ok, pid}
+
+      other ->
+        other
+    end
+  end
+
+  # Seed + verify terms_versions from the vendored manifest, then warm the
+  # version cache. Skipped in :test (tests seed per-case). Fail-loud verify
+  # runs in prod so a manifest/db drift halts boot instead of 409-ing signups.
+  defp maybe_seed_legal do
+    if Application.get_env(:engram, :seed_legal_on_boot, true) do
+      Engram.Legal.Seeder.seed()
+      Engram.Legal.Seeder.verify()
+      Engram.Legal.VersionCache.invalidate_all()
+    end
   end
 
   # T3-audit C2 — runs BootCanary.verify!/0 synchronously in a GenServer's

--- a/lib/engram/legal.ex
+++ b/lib/engram/legal.ex
@@ -14,6 +14,10 @@ defmodule Engram.Legal do
   alias Engram.Legal.TermsVersion
   alias Engram.Repo
 
+  # Version ordering is lexicographic on the version string. This is load-bearing:
+  # it only equals calendar ordering because versions are constrained to
+  # YYYY-MM-DD by TermsVersion's validate_format. Keep that constraint.
+
   @spec required_floor(document :: String.t()) :: String.t() | nil
   def required_floor(document) do
     today = Date.utc_today()

--- a/lib/engram/legal.ex
+++ b/lib/engram/legal.ex
@@ -1,0 +1,56 @@
+defmodule Engram.Legal do
+  @moduledoc """
+  Canonical legal-document versions and the computed gate inputs.
+
+  `required_floor/1` is the latest MATERIAL version whose effective_date has
+  arrived (nil = effective immediately) — the version below which an acceptance
+  is no longer binding. `current_version/1` is the latest published version (what
+  the app renders / asks the user to accept), regardless of effective_date.
+
+  These read the DB directly; callers on the hot path go through
+  `Engram.Legal.VersionCache`, which memoizes them in :persistent_term.
+  """
+  import Ecto.Query
+  alias Engram.Legal.TermsVersion
+  alias Engram.Repo
+
+  @spec required_floor(document :: String.t()) :: String.t() | nil
+  def required_floor(document) do
+    today = Date.utc_today()
+
+    from(v in TermsVersion,
+      where: v.document == ^document and v.material == true,
+      where: is_nil(v.effective_date) or v.effective_date <= ^today,
+      order_by: [desc: v.version],
+      limit: 1,
+      select: v.version
+    )
+    |> Repo.one(skip_tenant_check: true)
+  end
+
+  @spec current_version(document :: String.t()) :: String.t() | nil
+  def current_version(document) do
+    from(v in TermsVersion,
+      where: v.document == ^document,
+      order_by: [desc: v.version],
+      limit: 1,
+      select: v.version
+    )
+    |> Repo.one(skip_tenant_check: true)
+  end
+
+  @spec hash_for(document :: String.t(), version :: String.t()) :: String.t() | nil
+  def hash_for(document, version) do
+    from(v in TermsVersion,
+      where: v.document == ^document and v.version == ^version,
+      select: v.content_hash
+    )
+    |> Repo.one(skip_tenant_check: true)
+  end
+
+  @doc "The full row for a version, or nil. Used for changelog/effective_date in the notice."
+  @spec get(document :: String.t(), version :: String.t()) :: TermsVersion.t() | nil
+  def get(document, version) do
+    Repo.get_by(TermsVersion, [document: document, version: version], skip_tenant_check: true)
+  end
+end

--- a/lib/engram/legal/seeder.ex
+++ b/lib/engram/legal/seeder.ex
@@ -1,0 +1,81 @@
+defmodule Engram.Legal.Seeder do
+  @moduledoc """
+  Seeds + verifies `terms_versions` from the vendored
+  `priv/legal/legal-manifest.json` (the #318 single source of truth: same bytes
+  the frontend vendors). The manifest carries version→hash only; the
+  effective_date/material/changelog for known versions live in @version_meta.
+
+  `seed/0` upserts a row per manifest entry. `verify/0` raises if any DB row's
+  hash diverges from the manifest (fail loud rather than silently 409 every
+  signup). Both run at boot (Application), then VersionCache is invalidated.
+  """
+  import Ecto.Query
+  alias Engram.Legal.TermsVersion
+  alias Engram.Repo
+
+  # document => version => %{material, effective_date, changelog}
+  @version_meta %{
+    "terms_of_service" => %{
+      "2026-05-19" => %{material: true, effective_date: nil, changelog: "Initial version."}
+    },
+    "privacy_policy" => %{
+      "2026-05-19" => %{material: true, effective_date: nil, changelog: "Initial version."}
+    }
+  }
+
+  @spec seed() :: :ok
+  def seed do
+    for {document, versions} <- manifest(),
+        {version, hash} <- versions do
+      meta = meta!(document, version)
+
+      %TermsVersion{}
+      |> TermsVersion.changeset(%{
+        document: document,
+        version: version,
+        content_hash: hash,
+        material: meta.material,
+        effective_date: meta.effective_date,
+        changelog: meta.changelog
+      })
+      |> Repo.insert(
+        on_conflict: {:replace, [:content_hash, :material, :effective_date, :changelog]},
+        conflict_target: [:document, :version],
+        skip_tenant_check: true
+      )
+    end
+
+    :ok
+  end
+
+  @spec verify() :: :ok
+  def verify do
+    for {document, versions} <- manifest(), {version, hash} <- versions do
+      row =
+        Repo.one(
+          from(v in TermsVersion,
+            where: v.document == ^document and v.version == ^version,
+            select: v.content_hash
+          ),
+          skip_tenant_check: true
+        )
+
+      if row != hash do
+        raise "legal: hash drift for #{document} #{version} " <>
+                "(manifest=#{hash} db=#{inspect(row)}) — terms_versions out of sync with manifest"
+      end
+    end
+
+    :ok
+  end
+
+  defp manifest do
+    path = Application.app_dir(:engram, "priv/legal/legal-manifest.json")
+    path |> File.read!() |> Jason.decode!()
+  end
+
+  defp meta!(document, version) do
+    get_in(@version_meta, [document, version]) ||
+      raise "legal: no seed meta (material/effective_date/changelog) for #{document} #{version}"
+  end
+end

--- a/lib/engram/legal/seeder.ex
+++ b/lib/engram/legal/seeder.ex
@@ -38,7 +38,7 @@ defmodule Engram.Legal.Seeder do
         effective_date: meta.effective_date,
         changelog: meta.changelog
       })
-      |> Repo.insert(
+      |> Repo.insert!(
         on_conflict: {:replace, [:content_hash, :material, :effective_date, :changelog]},
         conflict_target: [:document, :version],
         skip_tenant_check: true

--- a/lib/engram/legal/seeder.ex
+++ b/lib/engram/legal/seeder.ex
@@ -14,6 +14,11 @@ defmodule Engram.Legal.Seeder do
   alias Engram.Repo
 
   # document => version => %{material, effective_date, changelog}
+  #
+  # IMPORTANT: every version present in the vendored manifest MUST have an entry
+  # here, or `meta!/2` raises at boot (fail-loud). So a legal bump is a TWO-file
+  # change: add the version→hash to priv/legal/legal-manifest.json AND its
+  # material/effective_date/changelog here. (P5 will automate this cross-repo.)
   @version_meta %{
     "terms_of_service" => %{
       "2026-05-19" => %{material: true, effective_date: nil, changelog: "Initial version."}

--- a/lib/engram/legal/terms_version.ex
+++ b/lib/engram/legal/terms_version.ex
@@ -28,5 +28,6 @@ defmodule Engram.Legal.TermsVersion do
     |> validate_inclusion(:document, @documents)
     |> validate_format(:version, ~r/^\d{4}-\d{2}-\d{2}$/)
     |> unique_constraint([:document, :version])
+    |> check_constraint(:document, name: :document_must_be_valid)
   end
 end

--- a/lib/engram/legal/terms_version.ex
+++ b/lib/engram/legal/terms_version.ex
@@ -1,0 +1,32 @@
+defmodule Engram.Legal.TermsVersion do
+  @moduledoc """
+  A canonical legal-document version. Global (non-tenant). Rows are immutable
+  once published — a correction is a new version. See `Engram.Legal`.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @documents ~w(terms_of_service privacy_policy)
+
+  schema "terms_versions" do
+    field :document, :string
+    field :version, :string
+    field :content_hash, :string
+    field :material, :boolean, default: true
+    field :effective_date, :date
+    field :changelog, :string
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
+  end
+
+  def changeset(version, attrs) do
+    version
+    |> cast(attrs, [:document, :version, :content_hash, :material, :effective_date, :changelog])
+    |> validate_required([:document, :version, :content_hash])
+    |> validate_inclusion(:document, @documents)
+    |> validate_format(:version, ~r/^\d{4}-\d{2}-\d{2}$/)
+    |> unique_constraint([:document, :version])
+  end
+end

--- a/lib/engram/legal/version_cache.ex
+++ b/lib/engram/legal/version_cache.ex
@@ -1,0 +1,44 @@
+defmodule Engram.Legal.VersionCache do
+  @moduledoc """
+  Caches the computed gate inputs (`required_floor`, `current_version`, and
+  per-version `hash_for`) in :persistent_term, mirroring
+  `Engram.Billing.PlanCache`. Terms versions are seeded at boot and change only
+  on a publish, so per-request reads should never touch the DB. Call
+  `invalidate_all/0` after seeding or a publish so the next read reloads.
+  """
+  alias Engram.Legal
+
+  @spec required_floor(String.t()) :: String.t() | nil
+  def required_floor(document), do: fetch({:floor, document}, fn -> Legal.required_floor(document) end)
+
+  @spec current_version(String.t()) :: String.t() | nil
+  def current_version(document),
+    do: fetch({:current, document}, fn -> Legal.current_version(document) end)
+
+  @spec hash_for(String.t(), String.t()) :: String.t() | nil
+  def hash_for(document, version),
+    do: fetch({:hash, document, version}, fn -> Legal.hash_for(document, version) end)
+
+  @spec invalidate_all() :: :ok
+  def invalidate_all do
+    for {{__MODULE__, _} = k, _v} <- :persistent_term.get() do
+      :persistent_term.erase(k)
+    end
+
+    :ok
+  end
+
+  defp fetch(subkey, loader) do
+    key = {__MODULE__, subkey}
+
+    case :persistent_term.get(key, :__miss__) do
+      :__miss__ ->
+        loaded = loader.()
+        :persistent_term.put(key, loaded)
+        loaded
+
+      cached ->
+        cached
+    end
+  end
+end

--- a/lib/engram/legal/version_cache.ex
+++ b/lib/engram/legal/version_cache.ex
@@ -9,7 +9,8 @@ defmodule Engram.Legal.VersionCache do
   alias Engram.Legal
 
   @spec required_floor(String.t()) :: String.t() | nil
-  def required_floor(document), do: fetch({:floor, document}, fn -> Legal.required_floor(document) end)
+  def required_floor(document),
+    do: fetch({:floor, document}, fn -> Legal.required_floor(document) end)
 
   @spec current_version(String.t()) :: String.t() | nil
   def current_version(document),

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -8,6 +8,8 @@ defmodule Engram.Onboarding do
   """
 
   alias Engram.Billing
+  alias Engram.Legal
+  alias Engram.Legal.VersionCache
   alias Engram.Onboarding.Agreement
   alias Engram.Onboarding.TermsCache
   alias Engram.Repo
@@ -39,28 +41,39 @@ defmodule Engram.Onboarding do
 
     # Atomic: a ToS row without its paired Privacy row is an incomplete audit
     # record, so roll back the first insert if the second fails.
-    Repo.transaction(fn ->
-      with {:ok, tos_row} <-
-             insert_agreement(
-               Map.merge(base, %{
-                 document: @terms_document,
-                 version: tos_version,
-                 content_hash: tos_hash
-               })
-             ),
-           {:ok, _privacy_row} <-
-             insert_agreement(
-               Map.merge(base, %{
-                 document: @privacy_document,
-                 version: privacy_version,
-                 content_hash: privacy_hash
-               })
-             ) do
-        tos_row
-      else
-        {:error, changeset} -> Repo.rollback(changeset)
-      end
-    end)
+    result =
+      Repo.transaction(fn ->
+        with {:ok, tos_row} <-
+               insert_agreement(
+                 Map.merge(base, %{
+                   document: @terms_document,
+                   version: tos_version,
+                   content_hash: tos_hash
+                 })
+               ),
+             {:ok, _privacy_row} <-
+               insert_agreement(
+                 Map.merge(base, %{
+                   document: @privacy_document,
+                   version: privacy_version,
+                   content_hash: privacy_hash
+                 })
+               ) do
+          tos_row
+        else
+          {:error, changeset} -> Repo.rollback(changeset)
+        end
+      end)
+
+    case result do
+      {:ok, tos_row} ->
+        TermsCache.put_accepted(user.id, @terms_document, tos_version)
+        TermsCache.put_accepted(user.id, @privacy_document, privacy_version)
+        {:ok, tos_row}
+
+      other ->
+        other
+    end
   end
 
   @doc """
@@ -97,19 +110,30 @@ defmodule Engram.Onboarding do
   Compute the onboarding state for a user. Returns a map with:
 
     * `:enabled` — true when billing (and therefore the wizard) is active
-    * `:terms_ok` — current TOS version accepted
+    * `:terms_ok` — latest accepted ToS version satisfies the computed floor
     * `:subscription_ok` — user has trialing/active/past_due subscription
-    * `:current_tos_version` — string from config
+    * `:current_tos_version` — latest published ToS version (from `terms_versions`)
+    * `:current_privacy_version` — latest published Privacy version
+    * `:terms_notice` — map describing a not-yet-accepted current version
+      (during the notice window), or `nil` when the user is current
     * `:next_step` — one of `:agreement | :billing | :done`
+
+  The gate is computed from the `terms_versions` table via
+  `Engram.Legal.VersionCache`: `terms_ok` compares the user's latest accepted
+  version against the required floor (latest MATERIAL version effective now),
+  while `:terms_notice` reflects any newer published version not yet accepted.
 
   When `billing_enabled` is false (self-host), returns `{enabled: false,
   next_step: :done}` immediately so callers can skip all gates.
   """
   def status(user) do
     if Application.get_env(:engram, :billing_enabled, false) do
-      current_version = Application.get_env(:engram, :current_tos_version)
-      min_required = Application.get_env(:engram, :min_required_tos_version)
-      terms_ok = terms_accepted?(user, min_required)
+      floor = VersionCache.required_floor(@terms_document)
+      current_tos = VersionCache.current_version(@terms_document)
+      current_privacy = VersionCache.current_version(@privacy_document)
+
+      accepted_tos = accepted_version(user, @terms_document)
+      terms_ok = accepted_satisfies?(accepted_tos, floor)
       subscription_ok = Billing.active?(user)
       next = next_step(terms_ok, subscription_ok)
 
@@ -117,8 +141,9 @@ defmodule Engram.Onboarding do
         enabled: true,
         terms_ok: terms_ok,
         subscription_ok: subscription_ok,
-        current_tos_version: current_version,
-        current_privacy_version: Application.get_env(:engram, :current_privacy_version),
+        current_tos_version: current_tos,
+        current_privacy_version: current_privacy,
+        terms_notice: notice(@terms_document, current_tos, accepted_tos),
         next_step: next
       }
     else
@@ -126,34 +151,56 @@ defmodule Engram.Onboarding do
     end
   end
 
-  # Gate on `min_required_tos_version`: a bump to `current_tos_version` alone
-  # (minor edit) must NOT force re-accept — only a `min_required` bump does.
-  defp terms_accepted?(user, min_required) do
-    if TermsCache.accepted?(user.id, min_required) do
-      true
-    else
-      accepted = query_terms_accepted?(user, min_required)
-      if accepted, do: TermsCache.mark_accepted(user.id, min_required)
-      accepted
+  # Cache-first read of the user's latest accepted version for a document.
+  defp accepted_version(user, document) do
+    case TermsCache.accepted_version(user.id, document) do
+      nil ->
+        v = query_accepted_version(user, document)
+        if v, do: TermsCache.put_accepted(user.id, document, v)
+        v
+
+      cached ->
+        cached
     end
   end
 
-  defp query_terms_accepted?(user, min_required) do
+  defp accepted_satisfies?(nil, _floor), do: false
+  defp accepted_satisfies?(_accepted, nil), do: true
+  defp accepted_satisfies?(accepted, floor), do: accepted >= floor
+
+  # A notice is due when there is a current version the user hasn't accepted yet.
+  defp notice(_document, nil, _accepted), do: nil
+
+  defp notice(document, current, accepted)
+       when is_nil(accepted) or current > accepted do
+    case Legal.get(document, current) do
+      nil ->
+        nil
+
+      row ->
+        %{
+          document: document,
+          version: row.version,
+          effective_date: row.effective_date,
+          material: row.material,
+          changelog: row.changelog,
+          accept_url: "https://app.engram.page/onboard/agreement"
+        }
+    end
+  end
+
+  defp notice(_document, _current, _accepted), do: nil
+
+  defp query_accepted_version(user, document) do
     import Ecto.Query
 
-    latest =
-      from(a in Agreement,
-        where: a.user_id == ^user.id and a.document == ^@terms_document,
-        order_by: [desc: a.accepted_at],
-        limit: 1,
-        select: a.version
-      )
-      |> Repo.one(skip_tenant_check: true)
-
-    case latest do
-      nil -> false
-      accepted -> accepted >= min_required
-    end
+    from(a in Agreement,
+      where: a.user_id == ^user.id and a.document == ^document,
+      order_by: [desc: a.accepted_at],
+      limit: 1,
+      select: a.version
+    )
+    |> Repo.one(skip_tenant_check: true)
   end
 
   defp next_step(false, _), do: :agreement

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -114,14 +114,20 @@ defmodule Engram.Onboarding do
     * `:subscription_ok` — user has trialing/active/past_due subscription
     * `:current_tos_version` — latest published ToS version (from `terms_versions`)
     * `:current_privacy_version` — latest published Privacy version
-    * `:terms_notice` — map describing a not-yet-accepted current version
-      (during the notice window), or `nil` when the user is current
+    * `:terms_notice` — metadata for the newest published ToS version the user
+      has not yet accepted (version/effective_date/material/changelog/accept_url),
+      or `nil` when the user is already on the current version
     * `:next_step` — one of `:agreement | :billing | :done`
 
   The gate is computed from the `terms_versions` table via
   `Engram.Legal.VersionCache`: `terms_ok` compares the user's latest accepted
-  version against the required floor (latest MATERIAL version effective now),
-  while `:terms_notice` reflects any newer published version not yet accepted.
+  version against the required floor (latest MATERIAL version effective now).
+
+  `:terms_notice` is independent of `:terms_ok`: it carries the pending version's
+  metadata whenever a newer published version exists unaccepted, and is the same
+  payload the client renders both as the non-blocking notice (while `terms_ok`
+  is still true, before the version's `effective_date`) and as the accept prompt
+  once the version is effective and `terms_ok` has flipped false.
 
   When `billing_enabled` is false (self-host), returns `{enabled: false,
   next_step: :done}` immediately so callers can skip all gates.

--- a/lib/engram/onboarding/terms_cache.ex
+++ b/lib/engram/onboarding/terms_cache.ex
@@ -1,24 +1,9 @@
 defmodule Engram.Onboarding.TermsCache do
   @moduledoc """
-  Per-node ETS cache recording that a user has accepted a given TOS version.
-
-  TOS acceptance is append-only and monotonic per version: once a user has
-  accepted the current version it can never become un-accepted for that
-  version. So we cache positive results only, keyed by `{user_id, version}`.
-  A version bump changes the key, which misses naturally and forces a fresh
-  check against the new version — no explicit invalidation required.
-
-  Negative results are never cached: a user who hasn't accepted yet will soon,
-  and the next check (post-acceptance) reads through and caches the positive.
-
-  The table is `:public` (the value is a non-secret boolean), so request
-  processes read and write directly with no GenServer hop. This process exists
-  only to own the table for the application's lifetime.
-
-  If the owning process is down and the table is absent, `accepted?/2` returns
-  `false` (forcing a DB read-through — never a false-positive accept) and
-  `mark_accepted/2` is a no-op, so a cache outage degrades to the authoritative
-  agreement query instead of raising.
+  Per-node ETS cache of each user's latest accepted version per document, keyed
+  by `{user_id, document}`. Invalidated explicitly on accept (monotonic — only
+  ever advances). A cache miss falls through to the authoritative agreement
+  query.
   """
 
   use GenServer
@@ -29,18 +14,20 @@ defmodule Engram.Onboarding.TermsCache do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
-  @spec accepted?(user_id :: integer(), version :: String.t()) :: boolean()
-  def accepted?(user_id, version) do
-    :ets.member(@table, {user_id, version})
+  @spec accepted_version(user_id :: integer(), document :: String.t()) :: String.t() | nil
+  def accepted_version(user_id, document) do
+    case :ets.lookup(@table, {user_id, document}) do
+      [{{^user_id, ^document}, version}] -> version
+      _ -> nil
+    end
   rescue
-    # Table absent → report not-cached so the caller re-queries the DB.
-    # Fails safe: never a false-positive acceptance.
-    ArgumentError -> false
+    # Table absent → report nothing cached so the caller re-queries the DB.
+    ArgumentError -> nil
   end
 
-  @spec mark_accepted(user_id :: integer(), version :: String.t()) :: :ok
-  def mark_accepted(user_id, version) do
-    :ets.insert(@table, {{user_id, version}})
+  @spec put_accepted(user_id :: integer(), document :: String.t(), version :: String.t()) :: :ok
+  def put_accepted(user_id, document, version) do
+    :ets.insert(@table, {{user_id, document}, version})
     :ok
   rescue
     ArgumentError -> :ok

--- a/lib/engram/onboarding/terms_cache.ex
+++ b/lib/engram/onboarding/terms_cache.ex
@@ -1,9 +1,14 @@
 defmodule Engram.Onboarding.TermsCache do
   @moduledoc """
   Per-node ETS cache of each user's latest accepted version per document, keyed
-  by `{user_id, document}`. Invalidated explicitly on accept (monotonic — only
-  ever advances). A cache miss falls through to the authoritative agreement
-  query.
+  by `{user_id, document}`. Written on accept (monotonic — versions only ever
+  advance). A cache miss falls through to the authoritative agreement query and
+  back-fills.
+
+  Writes are node-local: an accept on one node does not push to others, so a
+  peer node may hold a stale (older) accepted version until its own read-through
+  refreshes it. This only ever over-gates (shows a notice / withholds access a
+  little longer) — never a false accept, since the floor comparison is `>=`.
   """
 
   use GenServer

--- a/lib/engram_web/controllers/onboarding_controller.ex
+++ b/lib/engram_web/controllers/onboarding_controller.ex
@@ -5,33 +5,24 @@ defmodule EngramWeb.OnboardingController do
 
   def status(conn, _params) do
     user = conn.assigns.current_user
-    state = Onboarding.status(user)
 
     payload =
-      case state do
-        %{enabled: false} ->
-          %{enabled: false, next_step: "done"}
+      case Onboarding.status(user) do
+        %{enabled: false} = s ->
+          %{enabled: false, next_step: Atom.to_string(s.next_step)}
 
-        %{
-          enabled: true,
-          terms_ok: terms_ok,
-          subscription_ok: sub_ok,
-          current_tos_version: version,
-          current_privacy_version: privacy_version,
-          next_step: next
-        } ->
-          %{
-            enabled: true,
-            terms_ok: terms_ok,
-            subscription_ok: sub_ok,
-            current_tos_version: version,
-            current_privacy_version: privacy_version,
-            next_step: Atom.to_string(next)
-          }
+        %{enabled: true} = s ->
+          s
+          |> Map.update!(:next_step, &Atom.to_string/1)
+          |> reject_nil_notice()
       end
 
     json(conn, payload)
   end
+
+  # Drop terms_notice from the wire when there's nothing to notify.
+  defp reject_nil_notice(%{terms_notice: nil} = s), do: Map.delete(s, :terms_notice)
+  defp reject_nil_notice(s), do: s
 
   def accept_terms(conn, %{
         "tos_version" => tv,
@@ -39,14 +30,15 @@ defmodule EngramWeb.OnboardingController do
         "privacy_version" => pv,
         "privacy_hash" => ph
       }) do
-    # Verify BOTH documents' version + content hash against the canonical config.
-    # Any mismatch means the app is showing different text than the backend
-    # expects (drift) — refuse with 409 instead of recording bad consent.
+    # Verify BOTH documents' version + content hash against the canonical
+    # terms_versions table (via the cache). Any mismatch means the app is
+    # showing different text than the backend expects (drift) — refuse with 409
+    # instead of recording bad consent.
     ok =
-      tv == Application.get_env(:engram, :current_tos_version) and
-        th == Application.get_env(:engram, :current_tos_hash) and
-        pv == Application.get_env(:engram, :current_privacy_version) and
-        ph == Application.get_env(:engram, :current_privacy_hash)
+      th == Engram.Legal.VersionCache.hash_for("terms_of_service", tv) and th != nil and
+        ph == Engram.Legal.VersionCache.hash_for("privacy_policy", pv) and ph != nil and
+        tv == Engram.Legal.VersionCache.current_version("terms_of_service") and
+        pv == Engram.Legal.VersionCache.current_version("privacy_policy")
 
     if ok do
       meta = %{

--- a/lib/engram_web/controllers/onboarding_controller.ex
+++ b/lib/engram_web/controllers/onboarding_controller.ex
@@ -1,6 +1,7 @@
 defmodule EngramWeb.OnboardingController do
   use EngramWeb, :controller
 
+  alias Engram.Legal.VersionCache
   alias Engram.Onboarding
 
   def status(conn, _params) do
@@ -35,10 +36,10 @@ defmodule EngramWeb.OnboardingController do
     # showing different text than the backend expects (drift) — refuse with 409
     # instead of recording bad consent.
     ok =
-      th == Engram.Legal.VersionCache.hash_for("terms_of_service", tv) and th != nil and
-        ph == Engram.Legal.VersionCache.hash_for("privacy_policy", pv) and ph != nil and
-        tv == Engram.Legal.VersionCache.current_version("terms_of_service") and
-        pv == Engram.Legal.VersionCache.current_version("privacy_policy")
+      th == VersionCache.hash_for("terms_of_service", tv) and th != nil and
+        ph == VersionCache.hash_for("privacy_policy", pv) and ph != nil and
+        tv == VersionCache.current_version("terms_of_service") and
+        pv == VersionCache.current_version("privacy_policy")
 
     if ok do
       meta = %{

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.229",
+      version: "0.5.230",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/legal/legal-manifest.json
+++ b/priv/legal/legal-manifest.json
@@ -1,0 +1,8 @@
+{
+	"terms_of_service": {
+		"2026-05-19": "6785e725e9900d5f87a90eca362c388d3254dac0e5b7105ba5da29d316551e5c"
+	},
+	"privacy_policy": {
+		"2026-05-19": "87e117552f1ab05acadb04cc50b3b18e37dba5b6a82a3c3e480286f587af2708"
+	}
+}

--- a/priv/repo/migrations/20260527031333_create_terms_versions.exs
+++ b/priv/repo/migrations/20260527031333_create_terms_versions.exs
@@ -1,0 +1,30 @@
+defmodule Engram.Repo.Migrations.CreateTermsVersions do
+  use Ecto.Migration
+
+  @moduledoc """
+  Canonical legal-document versions. Single source for the content hash the
+  accept endpoint verifies against, plus the effective_date that drives the
+  non-blocking notice window vs hard cutoff. Append-only/immutable in practice:
+  a correction is a new version, never an edit. Global (non-tenant), like
+  email_suppressions.
+  """
+
+  def change do
+    create table(:terms_versions) do
+      add :document, :string, null: false
+      add :version, :string, null: false
+      add :content_hash, :string, null: false
+      add :material, :boolean, null: false, default: true
+      add :effective_date, :date
+      add :changelog, :text
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    create unique_index(:terms_versions, [:document, :version])
+
+    create constraint(:terms_versions, :document_must_be_valid,
+             check: "document IN ('terms_of_service', 'privacy_policy')"
+           )
+  end
+end

--- a/test/engram/legal/seeder_test.exs
+++ b/test/engram/legal/seeder_test.exs
@@ -1,0 +1,33 @@
+defmodule Engram.Legal.SeederTest do
+  use Engram.DataCase, async: false
+  alias Engram.Legal
+  alias Engram.Legal.Seeder
+
+  test "seed/0 inserts a row per manifest entry with the manifest hash + seed meta" do
+    assert :ok = Seeder.seed()
+    # v1 terms row exists with the manifest hash and is effective now (material).
+    assert Legal.required_floor("terms_of_service") == "2026-05-19"
+    assert Legal.hash_for("terms_of_service", "2026-05-19") ==
+             "6785e725e9900d5f87a90eca362c388d3254dac0e5b7105ba5da29d316551e5c"
+    assert Legal.required_floor("privacy_policy") == "2026-05-19"
+  end
+
+  test "seed/0 is idempotent" do
+    assert :ok = Seeder.seed()
+    assert :ok = Seeder.seed()
+    rows = Engram.Repo.all(Engram.Legal.TermsVersion, skip_tenant_check: true)
+    assert length(rows) == 2
+  end
+
+  test "verify/0 raises when a DB row's hash diverges from the manifest" do
+    Seeder.seed()
+
+    Engram.Repo.update_all(
+      Engram.Legal.TermsVersion,
+      [set: [content_hash: "tampered"]],
+      skip_tenant_check: true
+    )
+
+    assert_raise RuntimeError, ~r/hash drift/i, fn -> Seeder.verify() end
+  end
+end

--- a/test/engram/legal/seeder_test.exs
+++ b/test/engram/legal/seeder_test.exs
@@ -7,8 +7,10 @@ defmodule Engram.Legal.SeederTest do
     assert :ok = Seeder.seed()
     # v1 terms row exists with the manifest hash and is effective now (material).
     assert Legal.required_floor("terms_of_service") == "2026-05-19"
+
     assert Legal.hash_for("terms_of_service", "2026-05-19") ==
              "6785e725e9900d5f87a90eca362c388d3254dac0e5b7105ba5da29d316551e5c"
+
     assert Legal.required_floor("privacy_policy") == "2026-05-19"
     # seed→verify round-trips cleanly when the DB matches the manifest.
     assert :ok = Seeder.verify()

--- a/test/engram/legal/seeder_test.exs
+++ b/test/engram/legal/seeder_test.exs
@@ -10,6 +10,8 @@ defmodule Engram.Legal.SeederTest do
     assert Legal.hash_for("terms_of_service", "2026-05-19") ==
              "6785e725e9900d5f87a90eca362c388d3254dac0e5b7105ba5da29d316551e5c"
     assert Legal.required_floor("privacy_policy") == "2026-05-19"
+    # seed→verify round-trips cleanly when the DB matches the manifest.
+    assert :ok = Seeder.verify()
   end
 
   test "seed/0 is idempotent" do

--- a/test/engram/legal/terms_version_test.exs
+++ b/test/engram/legal/terms_version_test.exs
@@ -1,0 +1,24 @@
+defmodule Engram.Legal.TermsVersionTest do
+  use Engram.DataCase, async: true
+  alias Engram.Legal.TermsVersion
+
+  test "changeset requires document, version, content_hash" do
+    cs = TermsVersion.changeset(%TermsVersion{}, %{})
+    refute cs.valid?
+    assert %{document: _, version: _, content_hash: _} = errors_on(cs)
+  end
+
+  test "changeset accepts a full row" do
+    cs =
+      TermsVersion.changeset(%TermsVersion{}, %{
+        document: "terms_of_service",
+        version: "2026-05-19",
+        content_hash: "abc",
+        material: true,
+        effective_date: nil,
+        changelog: "Initial version."
+      })
+
+    assert cs.valid?
+  end
+end

--- a/test/engram/legal/terms_version_test.exs
+++ b/test/engram/legal/terms_version_test.exs
@@ -21,4 +21,28 @@ defmodule Engram.Legal.TermsVersionTest do
 
     assert cs.valid?
   end
+
+  test "changeset rejects an unknown document" do
+    cs =
+      TermsVersion.changeset(%TermsVersion{}, %{
+        document: "cookie_policy",
+        version: "2026-05-19",
+        content_hash: "abc"
+      })
+
+    refute cs.valid?
+    assert %{document: _} = errors_on(cs)
+  end
+
+  test "changeset rejects a malformed version" do
+    cs =
+      TermsVersion.changeset(%TermsVersion{}, %{
+        document: "terms_of_service",
+        version: "v1.2.3",
+        content_hash: "abc"
+      })
+
+    refute cs.valid?
+    assert %{version: _} = errors_on(cs)
+  end
 end

--- a/test/engram/legal/version_cache_test.exs
+++ b/test/engram/legal/version_cache_test.exs
@@ -1,0 +1,29 @@
+defmodule Engram.Legal.VersionCacheTest do
+  use Engram.DataCase, async: false
+  import Engram.LegalFixtures
+  alias Engram.Legal.VersionCache
+
+  setup do
+    on_exit(&VersionCache.invalidate_all/0)
+    VersionCache.invalidate_all()
+    :ok
+  end
+
+  test "memoizes required_floor and reflects invalidation" do
+    insert_version(version: "2026-05-19", material: true, effective_date: nil)
+    assert VersionCache.required_floor("terms_of_service") == "2026-05-19"
+
+    insert_version(version: "2026-06-01", material: true, effective_date: ~D[2000-01-01])
+    # still cached at the old value until invalidated
+    assert VersionCache.required_floor("terms_of_service") == "2026-05-19"
+
+    VersionCache.invalidate_all()
+    assert VersionCache.required_floor("terms_of_service") == "2026-06-01"
+  end
+
+  test "caches current_version and hash_for" do
+    insert_version(version: "2026-05-19", content_hash: "h")
+    assert VersionCache.current_version("terms_of_service") == "2026-05-19"
+    assert VersionCache.hash_for("terms_of_service", "2026-05-19") == "h"
+  end
+end

--- a/test/engram/legal_test.exs
+++ b/test/engram/legal_test.exs
@@ -1,0 +1,40 @@
+defmodule Engram.LegalTest do
+  use Engram.DataCase, async: true
+  import Engram.LegalFixtures
+  alias Engram.Legal
+
+  describe "required_floor/1" do
+    test "is the latest material version effective now" do
+      insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      insert_version(version: "2026-06-01", material: true, effective_date: ~D[2099-01-01])
+      # 2026-06-01 is material but not yet effective → floor stays 2026-05-19
+      assert Legal.required_floor("terms_of_service") == "2026-05-19"
+    end
+
+    test "a minor (non-material) version never raises the floor" do
+      insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      insert_version(version: "2026-06-01", material: false, effective_date: nil)
+      assert Legal.required_floor("terms_of_service") == "2026-05-19"
+    end
+
+    test "a material version becomes the floor once effective_date passes" do
+      insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      insert_version(version: "2026-06-01", material: true, effective_date: ~D[2000-01-01])
+      assert Legal.required_floor("terms_of_service") == "2026-06-01"
+    end
+  end
+
+  describe "current_version/1 and hash_for/2" do
+    test "current_version is the latest published regardless of effective_date" do
+      insert_version(version: "2026-05-19", effective_date: nil)
+      insert_version(version: "2026-06-01", material: true, effective_date: ~D[2099-01-01])
+      assert Legal.current_version("terms_of_service") == "2026-06-01"
+    end
+
+    test "hash_for returns the content_hash for a version, nil if unknown" do
+      insert_version(version: "2026-05-19", content_hash: "deadbeef")
+      assert Legal.hash_for("terms_of_service", "2026-05-19") == "deadbeef"
+      assert Legal.hash_for("terms_of_service", "1999-01-01") == nil
+    end
+  end
+end

--- a/test/engram/onboarding/terms_cache_test.exs
+++ b/test/engram/onboarding/terms_cache_test.exs
@@ -2,10 +2,6 @@ defmodule Engram.Onboarding.TermsCacheTest do
   use ExUnit.Case, async: false
   alias Engram.Onboarding.TermsCache
 
-  setup do
-    :ok
-  end
-
   test "stores and returns the accepted version per (user, document)" do
     assert TermsCache.accepted_version(7, "terms_of_service") == nil
     TermsCache.put_accepted(7, "terms_of_service", "2026-05-19")

--- a/test/engram/onboarding/terms_cache_test.exs
+++ b/test/engram/onboarding/terms_cache_test.exs
@@ -1,0 +1,21 @@
+defmodule Engram.Onboarding.TermsCacheTest do
+  use ExUnit.Case, async: false
+  alias Engram.Onboarding.TermsCache
+
+  setup do
+    :ok
+  end
+
+  test "stores and returns the accepted version per (user, document)" do
+    assert TermsCache.accepted_version(7, "terms_of_service") == nil
+    TermsCache.put_accepted(7, "terms_of_service", "2026-05-19")
+    assert TermsCache.accepted_version(7, "terms_of_service") == "2026-05-19"
+    assert TermsCache.accepted_version(7, "privacy_policy") == nil
+  end
+
+  test "put_accepted overwrites with a newer version" do
+    TermsCache.put_accepted(8, "terms_of_service", "2026-05-19")
+    TermsCache.put_accepted(8, "terms_of_service", "2026-06-01")
+    assert TermsCache.accepted_version(8, "terms_of_service") == "2026-06-01"
+  end
+end

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -261,6 +261,54 @@ defmodule Engram.OnboardingTest do
     end
   end
 
+  describe "computed floor gate + terms_notice" do
+    setup do
+      Engram.Legal.VersionCache.invalidate_all()
+      Application.put_env(:engram, :billing_enabled, true)
+      on_exit(fn -> Engram.Legal.VersionCache.invalidate_all() end)
+      :ok
+    end
+
+    test "terms_ok true and no notice when accepted == current, effective now" do
+      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      Engram.Legal.VersionCache.invalidate_all()
+      user = insert(:user)
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
+
+      status = Onboarding.status(user)
+      assert status.terms_ok
+      refute Map.has_key?(status, :terms_notice) and status.terms_notice != nil
+    end
+
+    test "notice present but terms_ok still true during the window (new material version, future effective_date)" do
+      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      user = insert(:user)
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
+
+      Engram.LegalFixtures.insert_version(version: "2026-06-01", material: true, effective_date: ~D[2099-01-01])
+      Engram.Legal.VersionCache.invalidate_all()
+
+      status = Onboarding.status(user)
+      assert status.terms_ok
+      assert status.terms_notice.version == "2026-06-01"
+      assert status.terms_notice.effective_date == ~D[2099-01-01]
+    end
+
+    test "terms_ok false once the new material version is effective and unaccepted" do
+      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      user = insert(:user)
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
+
+      Engram.LegalFixtures.insert_version(version: "2026-06-01", material: true, effective_date: ~D[2000-01-01])
+      Engram.Legal.VersionCache.invalidate_all()
+
+      refute Onboarding.status(user).terms_ok
+    end
+  end
+
   defp with_agreement_query_count(fun) do
     # Scope to this test's pid: telemetry handlers run in the emitting process,
     # so without this a concurrent async test could leak into the count.

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -303,7 +303,7 @@ defmodule Engram.OnboardingTest do
 
       status = Onboarding.status(user)
       assert status.terms_ok
-      refute Map.has_key?(status, :terms_notice) and status.terms_notice != nil
+      assert status.terms_notice == nil
     end
 
     test "notice present but terms_ok still true during the window (new material version, future effective_date)" do

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -288,9 +288,15 @@ defmodule Engram.OnboardingTest do
 
   describe "computed floor gate + terms_notice" do
     setup do
+      prev_enabled = Application.get_env(:engram, :billing_enabled)
       Engram.Legal.VersionCache.invalidate_all()
       Application.put_env(:engram, :billing_enabled, true)
-      on_exit(fn -> Engram.Legal.VersionCache.invalidate_all() end)
+
+      on_exit(fn ->
+        Application.put_env(:engram, :billing_enabled, prev_enabled)
+        Engram.Legal.VersionCache.invalidate_all()
+      end)
+
       :ok
     end
 

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -215,7 +215,11 @@ defmodule Engram.OnboardingTest do
     test "terms_accepted? true when accepted >= floor even if below current" do
       # Floor = 2026-05-19 (material, effective now); current = 2026-06-01
       # (material, future effective_date so it stays out of the floor).
-      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(
+        version: "2026-05-19",
+        material: true,
+        effective_date: nil
+      )
 
       Engram.LegalFixtures.insert_version(
         version: "2026-06-01",
@@ -249,7 +253,12 @@ defmodule Engram.OnboardingTest do
     end
 
     test "accept_terms stores content_hash and writes a privacy_policy row" do
-      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(
+        version: "2026-05-19",
+        material: true,
+        effective_date: nil
+      )
+
       Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
       Engram.Legal.VersionCache.invalidate_all()
 
@@ -276,7 +285,12 @@ defmodule Engram.OnboardingTest do
     end
 
     test "status returns current_privacy_version" do
-      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(
+        version: "2026-05-19",
+        material: true,
+        effective_date: nil
+      )
+
       Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
       Engram.Legal.VersionCache.invalidate_all()
 
@@ -301,7 +315,12 @@ defmodule Engram.OnboardingTest do
     end
 
     test "terms_ok true and no notice when accepted == current, effective now" do
-      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(
+        version: "2026-05-19",
+        material: true,
+        effective_date: nil
+      )
+
       Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
       Engram.Legal.VersionCache.invalidate_all()
       user = insert(:user)
@@ -313,12 +332,22 @@ defmodule Engram.OnboardingTest do
     end
 
     test "notice present but terms_ok still true during the window (new material version, future effective_date)" do
-      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(
+        version: "2026-05-19",
+        material: true,
+        effective_date: nil
+      )
+
       Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
 
-      Engram.LegalFixtures.insert_version(version: "2026-06-01", material: true, effective_date: ~D[2099-01-01])
+      Engram.LegalFixtures.insert_version(
+        version: "2026-06-01",
+        material: true,
+        effective_date: ~D[2099-01-01]
+      )
+
       Engram.Legal.VersionCache.invalidate_all()
 
       status = Onboarding.status(user)
@@ -328,12 +357,22 @@ defmodule Engram.OnboardingTest do
     end
 
     test "terms_ok false once the new material version is effective and unaccepted" do
-      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(
+        version: "2026-05-19",
+        material: true,
+        effective_date: nil
+      )
+
       Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
 
-      Engram.LegalFixtures.insert_version(version: "2026-06-01", material: true, effective_date: ~D[2000-01-01])
+      Engram.LegalFixtures.insert_version(
+        version: "2026-06-01",
+        material: true,
+        effective_date: ~D[2000-01-01]
+      )
+
       Engram.Legal.VersionCache.invalidate_all()
 
       refute Onboarding.status(user).terms_ok

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -60,13 +60,10 @@ defmodule Engram.OnboardingTest do
   describe "status/1 when billing is disabled (self-host)" do
     setup do
       prev_enabled = Application.get_env(:engram, :billing_enabled)
-      prev_version = Application.get_env(:engram, :current_tos_version)
       Application.put_env(:engram, :billing_enabled, false)
-      Application.put_env(:engram, :current_tos_version, "2026-05-15")
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
-        Application.put_env(:engram, :current_tos_version, prev_version)
       end)
 
       :ok
@@ -81,18 +78,31 @@ defmodule Engram.OnboardingTest do
   describe "status/1 when billing is enabled" do
     setup do
       prev_enabled = Application.get_env(:engram, :billing_enabled)
-      prev_version = Application.get_env(:engram, :current_tos_version)
-      prev_min = Application.get_env(:engram, :min_required_tos_version)
       Application.put_env(:engram, :billing_enabled, true)
-      Application.put_env(:engram, :current_tos_version, "2026-05-15")
-      # Default min_required tracks current here so the pre-existing tests keep
-      # their original "accepted >= current" semantics.
-      Application.put_env(:engram, :min_required_tos_version, "2026-05-15")
+
+      # Seed the canonical floor/current both at "2026-05-15" (material, effective
+      # now) so an acceptance of "2026-05-15" satisfies the gate.
+      Engram.LegalFixtures.insert_version(
+        document: "terms_of_service",
+        version: "2026-05-15",
+        content_hash: "canonical",
+        material: true,
+        effective_date: nil
+      )
+
+      Engram.LegalFixtures.insert_version(
+        document: "privacy_policy",
+        version: "2026-05-15",
+        content_hash: "p",
+        material: true,
+        effective_date: nil
+      )
+
+      Engram.Legal.VersionCache.invalidate_all()
+      on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
-        Application.put_env(:engram, :current_tos_version, prev_version)
-        Application.put_env(:engram, :min_required_tos_version, prev_min)
       end)
 
       :ok
@@ -175,13 +185,14 @@ defmodule Engram.OnboardingTest do
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
 
-      # Drop the cache owner (and its table). accepted?/2 must report not-cached
-      # (false) rather than raise, and status/1 must still read the DB and work.
+      # Drop the cache owner (and its table). accepted_version/2 must report
+      # nothing cached (nil) rather than raise, put_accepted/3 must be a no-op,
+      # and status/1 must still read the DB and work.
       :ok = Supervisor.terminate_child(Engram.Supervisor, TermsCache)
       on_exit(fn -> Supervisor.restart_child(Engram.Supervisor, TermsCache) end)
 
-      assert TermsCache.accepted?(user.id, "2026-05-15") == false
-      assert :ok = TermsCache.mark_accepted(user.id, "2026-05-15")
+      assert TermsCache.accepted_version(user.id, "terms_of_service") == nil
+      assert :ok = TermsCache.put_accepted(user.id, "terms_of_service", "2026-05-15")
       assert %{terms_ok: true} = Onboarding.status(user)
     end
   end
@@ -189,24 +200,30 @@ defmodule Engram.OnboardingTest do
   describe "accept_terms/6 + min_required gate" do
     setup do
       prev_enabled = Application.get_env(:engram, :billing_enabled)
-      prev_current = Application.get_env(:engram, :current_tos_version)
-      prev_min = Application.get_env(:engram, :min_required_tos_version)
-      prev_priv = Application.get_env(:engram, :current_privacy_version)
       Application.put_env(:engram, :billing_enabled, true)
+
+      Engram.Legal.VersionCache.invalidate_all()
+      on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
-        Application.put_env(:engram, :current_tos_version, prev_current)
-        Application.put_env(:engram, :min_required_tos_version, prev_min)
-        Application.put_env(:engram, :current_privacy_version, prev_priv)
       end)
 
       :ok
     end
 
-    test "terms_accepted? true when accepted >= min_required even if below current" do
-      Application.put_env(:engram, :min_required_tos_version, "2026-05-19")
-      Application.put_env(:engram, :current_tos_version, "2026-06-01")
+    test "terms_accepted? true when accepted >= floor even if below current" do
+      # Floor = 2026-05-19 (material, effective now); current = 2026-06-01
+      # (material, future effective_date so it stays out of the floor).
+      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+
+      Engram.LegalFixtures.insert_version(
+        version: "2026-06-01",
+        material: true,
+        effective_date: ~D[2099-01-01]
+      )
+
+      Engram.Legal.VersionCache.invalidate_all()
 
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{})
@@ -214,9 +231,16 @@ defmodule Engram.OnboardingTest do
       assert Onboarding.status(user).terms_ok
     end
 
-    test "terms_accepted? false when accepted below min_required" do
-      Application.put_env(:engram, :min_required_tos_version, "2026-06-01")
-      Application.put_env(:engram, :current_tos_version, "2026-06-01")
+    test "terms_accepted? false when accepted below floor" do
+      # Floor = 2026-06-01 (material, effective now); acceptance of 2026-05-19
+      # is below the floor.
+      Engram.LegalFixtures.insert_version(
+        version: "2026-06-01",
+        material: true,
+        effective_date: ~D[2000-01-01]
+      )
+
+      Engram.Legal.VersionCache.invalidate_all()
 
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{})
@@ -225,8 +249,9 @@ defmodule Engram.OnboardingTest do
     end
 
     test "accept_terms stores content_hash and writes a privacy_policy row" do
-      Application.put_env(:engram, :min_required_tos_version, "2026-05-19")
-      Application.put_env(:engram, :current_tos_version, "2026-05-19")
+      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      Engram.Legal.VersionCache.invalidate_all()
 
       user = insert(:user)
 
@@ -251,9 +276,9 @@ defmodule Engram.OnboardingTest do
     end
 
     test "status returns current_privacy_version" do
-      Application.put_env(:engram, :min_required_tos_version, "2026-05-19")
-      Application.put_env(:engram, :current_tos_version, "2026-05-19")
-      Application.put_env(:engram, :current_privacy_version, "2026-05-19")
+      Engram.LegalFixtures.insert_version(version: "2026-05-19", material: true, effective_date: nil)
+      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      Engram.Legal.VersionCache.invalidate_all()
 
       user = insert(:user)
 

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -1,6 +1,8 @@
 defmodule Engram.OnboardingTest do
   use Engram.DataCase, async: false
 
+  alias Engram.Legal.VersionCache
+  alias Engram.LegalFixtures
   alias Engram.Onboarding
   alias Engram.Onboarding.Agreement
   alias Engram.Onboarding.TermsCache
@@ -82,7 +84,7 @@ defmodule Engram.OnboardingTest do
 
       # Seed the canonical floor/current both at "2026-05-15" (material, effective
       # now) so an acceptance of "2026-05-15" satisfies the gate.
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         document: "terms_of_service",
         version: "2026-05-15",
         content_hash: "canonical",
@@ -90,7 +92,7 @@ defmodule Engram.OnboardingTest do
         effective_date: nil
       )
 
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         document: "privacy_policy",
         version: "2026-05-15",
         content_hash: "p",
@@ -98,8 +100,8 @@ defmodule Engram.OnboardingTest do
         effective_date: nil
       )
 
-      Engram.Legal.VersionCache.invalidate_all()
-      on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
+      VersionCache.invalidate_all()
+      on_exit(&VersionCache.invalidate_all/0)
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
@@ -202,8 +204,8 @@ defmodule Engram.OnboardingTest do
       prev_enabled = Application.get_env(:engram, :billing_enabled)
       Application.put_env(:engram, :billing_enabled, true)
 
-      Engram.Legal.VersionCache.invalidate_all()
-      on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
+      VersionCache.invalidate_all()
+      on_exit(&VersionCache.invalidate_all/0)
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
@@ -215,19 +217,19 @@ defmodule Engram.OnboardingTest do
     test "terms_accepted? true when accepted >= floor even if below current" do
       # Floor = 2026-05-19 (material, effective now); current = 2026-06-01
       # (material, future effective_date so it stays out of the floor).
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-05-19",
         material: true,
         effective_date: nil
       )
 
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-06-01",
         material: true,
         effective_date: ~D[2099-01-01]
       )
 
-      Engram.Legal.VersionCache.invalidate_all()
+      VersionCache.invalidate_all()
 
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{})
@@ -238,13 +240,13 @@ defmodule Engram.OnboardingTest do
     test "terms_accepted? false when accepted below floor" do
       # Floor = 2026-06-01 (material, effective now); acceptance of 2026-05-19
       # is below the floor.
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-06-01",
         material: true,
         effective_date: ~D[2000-01-01]
       )
 
-      Engram.Legal.VersionCache.invalidate_all()
+      VersionCache.invalidate_all()
 
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{})
@@ -253,14 +255,14 @@ defmodule Engram.OnboardingTest do
     end
 
     test "accept_terms stores content_hash and writes a privacy_policy row" do
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-05-19",
         material: true,
         effective_date: nil
       )
 
-      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
-      Engram.Legal.VersionCache.invalidate_all()
+      LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      VersionCache.invalidate_all()
 
       user = insert(:user)
 
@@ -285,14 +287,14 @@ defmodule Engram.OnboardingTest do
     end
 
     test "status returns current_privacy_version" do
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-05-19",
         material: true,
         effective_date: nil
       )
 
-      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
-      Engram.Legal.VersionCache.invalidate_all()
+      LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      VersionCache.invalidate_all()
 
       user = insert(:user)
 
@@ -303,26 +305,26 @@ defmodule Engram.OnboardingTest do
   describe "computed floor gate + terms_notice" do
     setup do
       prev_enabled = Application.get_env(:engram, :billing_enabled)
-      Engram.Legal.VersionCache.invalidate_all()
+      VersionCache.invalidate_all()
       Application.put_env(:engram, :billing_enabled, true)
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
-        Engram.Legal.VersionCache.invalidate_all()
+        VersionCache.invalidate_all()
       end)
 
       :ok
     end
 
     test "terms_ok true and no notice when accepted == current, effective now" do
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-05-19",
         material: true,
         effective_date: nil
       )
 
-      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
-      Engram.Legal.VersionCache.invalidate_all()
+      LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      VersionCache.invalidate_all()
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
 
@@ -332,23 +334,23 @@ defmodule Engram.OnboardingTest do
     end
 
     test "notice present but terms_ok still true during the window (new material version, future effective_date)" do
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-05-19",
         material: true,
         effective_date: nil
       )
 
-      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
 
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-06-01",
         material: true,
         effective_date: ~D[2099-01-01]
       )
 
-      Engram.Legal.VersionCache.invalidate_all()
+      VersionCache.invalidate_all()
 
       status = Onboarding.status(user)
       assert status.terms_ok
@@ -357,23 +359,23 @@ defmodule Engram.OnboardingTest do
     end
 
     test "terms_ok false once the new material version is effective and unaccepted" do
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-05-19",
         material: true,
         effective_date: nil
       )
 
-      Engram.LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
+      LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
       user = insert(:user)
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
 
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         version: "2026-06-01",
         material: true,
         effective_date: ~D[2000-01-01]
       )
 
-      Engram.Legal.VersionCache.invalidate_all()
+      VersionCache.invalidate_all()
 
       refute Onboarding.status(user).terms_ok
     end

--- a/test/engram_web/controllers/onboarding_controller_test.exs
+++ b/test/engram_web/controllers/onboarding_controller_test.exs
@@ -2,12 +2,14 @@ defmodule EngramWeb.OnboardingControllerTest do
   use EngramWeb.ConnCase, async: false
 
   alias Engram.Accounts
+  alias Engram.Legal.VersionCache
+  alias Engram.LegalFixtures
 
   setup %{conn: conn} do
     prev_enabled = Application.get_env(:engram, :billing_enabled)
     Application.put_env(:engram, :billing_enabled, true)
 
-    Engram.LegalFixtures.insert_version(
+    LegalFixtures.insert_version(
       document: "terms_of_service",
       version: "2026-05-15",
       content_hash: "canonical",
@@ -15,7 +17,7 @@ defmodule EngramWeb.OnboardingControllerTest do
       effective_date: nil
     )
 
-    Engram.LegalFixtures.insert_version(
+    LegalFixtures.insert_version(
       document: "privacy_policy",
       version: "2026-05-15",
       content_hash: "p",
@@ -23,8 +25,8 @@ defmodule EngramWeb.OnboardingControllerTest do
       effective_date: nil
     )
 
-    Engram.Legal.VersionCache.invalidate_all()
-    on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
+    VersionCache.invalidate_all()
+    on_exit(&VersionCache.invalidate_all/0)
 
     on_exit(fn ->
       Application.put_env(:engram, :billing_enabled, prev_enabled)
@@ -59,7 +61,7 @@ defmodule EngramWeb.OnboardingControllerTest do
     end
 
     test "status forwards terms_notice when present", %{conn: conn} do
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         document: "terms_of_service",
         version: "2026-06-01",
         content_hash: "h2",
@@ -67,7 +69,7 @@ defmodule EngramWeb.OnboardingControllerTest do
         effective_date: ~D[2099-01-01]
       )
 
-      Engram.Legal.VersionCache.invalidate_all()
+      VersionCache.invalidate_all()
 
       conn = get(conn, "/api/onboarding/status")
       body = json_response(conn, 200)
@@ -88,7 +90,7 @@ defmodule EngramWeb.OnboardingControllerTest do
     # setup already seeded "2026-05-15"; adding "2026-05-19" rows makes that the
     # current version, with content hashes "canonical"/"p".
     setup do
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         document: "terms_of_service",
         version: "2026-05-19",
         content_hash: "canonical",
@@ -96,7 +98,7 @@ defmodule EngramWeb.OnboardingControllerTest do
         effective_date: nil
       )
 
-      Engram.LegalFixtures.insert_version(
+      LegalFixtures.insert_version(
         document: "privacy_policy",
         version: "2026-05-19",
         content_hash: "p",
@@ -104,7 +106,7 @@ defmodule EngramWeb.OnboardingControllerTest do
         effective_date: nil
       )
 
-      Engram.Legal.VersionCache.invalidate_all()
+      VersionCache.invalidate_all()
 
       :ok
     end

--- a/test/engram_web/controllers/onboarding_controller_test.exs
+++ b/test/engram_web/controllers/onboarding_controller_test.exs
@@ -5,17 +5,29 @@ defmodule EngramWeb.OnboardingControllerTest do
 
   setup %{conn: conn} do
     prev_enabled = Application.get_env(:engram, :billing_enabled)
-    prev_version = Application.get_env(:engram, :current_tos_version)
-    prev_min = Application.get_env(:engram, :min_required_tos_version)
     Application.put_env(:engram, :billing_enabled, true)
-    Application.put_env(:engram, :current_tos_version, "2026-05-15")
-    # min_required tracks current here so accepting "2026-05-15" satisfies the gate.
-    Application.put_env(:engram, :min_required_tos_version, "2026-05-15")
+
+    Engram.LegalFixtures.insert_version(
+      document: "terms_of_service",
+      version: "2026-05-15",
+      content_hash: "canonical",
+      material: true,
+      effective_date: nil
+    )
+
+    Engram.LegalFixtures.insert_version(
+      document: "privacy_policy",
+      version: "2026-05-15",
+      content_hash: "p",
+      material: true,
+      effective_date: nil
+    )
+
+    Engram.Legal.VersionCache.invalidate_all()
+    on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
 
     on_exit(fn ->
       Application.put_env(:engram, :billing_enabled, prev_enabled)
-      Application.put_env(:engram, :current_tos_version, prev_version)
-      Application.put_env(:engram, :min_required_tos_version, prev_min)
     end)
 
     user = insert(:user)
@@ -46,6 +58,22 @@ defmodule EngramWeb.OnboardingControllerTest do
       assert body["next_step"] == "done"
     end
 
+    test "status forwards terms_notice when present", %{conn: conn} do
+      Engram.LegalFixtures.insert_version(
+        document: "terms_of_service",
+        version: "2026-06-01",
+        content_hash: "h2",
+        material: true,
+        effective_date: ~D[2099-01-01]
+      )
+
+      Engram.Legal.VersionCache.invalidate_all()
+
+      conn = get(conn, "/api/onboarding/status")
+      body = json_response(conn, 200)
+      assert body["terms_notice"]["version"] == "2026-06-01"
+    end
+
     test "returns enabled=false in self-host mode", %{conn: conn} do
       Application.put_env(:engram, :billing_enabled, false)
       conn = get(conn, "/api/onboarding/status")
@@ -56,27 +84,27 @@ defmodule EngramWeb.OnboardingControllerTest do
   end
 
   describe "POST /api/onboarding/accept-terms" do
-    # Pin all four canonical config values these tests assert against. test.exs
-    # pins only current_tos_version, so set the rest here with on_exit restore.
+    # Seed the canonical current versions these tests accept against. The outer
+    # setup already seeded "2026-05-15"; adding "2026-05-19" rows makes that the
+    # current version, with content hashes "canonical"/"p".
     setup do
-      prev = %{
-        tos_version: Application.get_env(:engram, :current_tos_version),
-        tos_hash: Application.get_env(:engram, :current_tos_hash),
-        privacy_version: Application.get_env(:engram, :current_privacy_version),
-        privacy_hash: Application.get_env(:engram, :current_privacy_hash)
-      }
+      Engram.LegalFixtures.insert_version(
+        document: "terms_of_service",
+        version: "2026-05-19",
+        content_hash: "canonical",
+        material: true,
+        effective_date: nil
+      )
 
-      Application.put_env(:engram, :current_tos_version, "2026-05-19")
-      Application.put_env(:engram, :current_tos_hash, "canonical")
-      Application.put_env(:engram, :current_privacy_version, "2026-05-19")
-      Application.put_env(:engram, :current_privacy_hash, "p")
+      Engram.LegalFixtures.insert_version(
+        document: "privacy_policy",
+        version: "2026-05-19",
+        content_hash: "p",
+        material: true,
+        effective_date: nil
+      )
 
-      on_exit(fn ->
-        Application.put_env(:engram, :current_tos_version, prev.tos_version)
-        Application.put_env(:engram, :current_tos_hash, prev.tos_hash)
-        Application.put_env(:engram, :current_privacy_version, prev.privacy_version)
-        Application.put_env(:engram, :current_privacy_hash, prev.privacy_hash)
-      end)
+      Engram.Legal.VersionCache.invalidate_all()
 
       :ok
     end

--- a/test/engram_web/controllers/search_controller_test.exs
+++ b/test/engram_web/controllers/search_controller_test.exs
@@ -4,7 +4,37 @@ defmodule EngramWeb.SearchControllerTest do
   import ExUnit.CaptureLog
   import Mox
 
+  alias Engram.Onboarding
+
   setup :verify_on_exit!
+
+  # Seed terms_versions so the VersionCache gate has a real floor to check.
+  # The cache is :persistent_term-backed (process-global), so if another
+  # async: false test seeded versions earlier and those rows were rolled back
+  # with the sandbox, the stale cached floor would gate these users.
+  # Seeding + invalidating here ensures a consistent cache for the test and
+  # cleans up on exit so later tests start fresh.
+  setup do
+    Engram.LegalFixtures.insert_version(
+      document: "terms_of_service",
+      version: "2026-05-15",
+      content_hash: "canonical-tos",
+      material: true,
+      effective_date: nil
+    )
+
+    Engram.LegalFixtures.insert_version(
+      document: "privacy_policy",
+      version: "2026-05-15",
+      content_hash: "canonical-pp",
+      material: true,
+      effective_date: nil
+    )
+
+    Engram.Legal.VersionCache.invalidate_all()
+    on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
+    :ok
+  end
 
   setup %{conn: conn} do
     user = insert(:user)
@@ -12,6 +42,8 @@ defmodule EngramWeb.SearchControllerTest do
     vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
     grant_api_write!(user)
+    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+    insert(:subscription, user: user, status: "active")
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
 
     bypass = Bypass.open()

--- a/test/engram_web/controllers/search_controller_test.exs
+++ b/test/engram_web/controllers/search_controller_test.exs
@@ -4,37 +4,7 @@ defmodule EngramWeb.SearchControllerTest do
   import ExUnit.CaptureLog
   import Mox
 
-  alias Engram.Onboarding
-
   setup :verify_on_exit!
-
-  # Seed terms_versions so the VersionCache gate has a real floor to check.
-  # The cache is :persistent_term-backed (process-global), so if another
-  # async: false test seeded versions earlier and those rows were rolled back
-  # with the sandbox, the stale cached floor would gate these users.
-  # Seeding + invalidating here ensures a consistent cache for the test and
-  # cleans up on exit so later tests start fresh.
-  setup do
-    Engram.LegalFixtures.insert_version(
-      document: "terms_of_service",
-      version: "2026-05-15",
-      content_hash: "canonical-tos",
-      material: true,
-      effective_date: nil
-    )
-
-    Engram.LegalFixtures.insert_version(
-      document: "privacy_policy",
-      version: "2026-05-15",
-      content_hash: "canonical-pp",
-      material: true,
-      effective_date: nil
-    )
-
-    Engram.Legal.VersionCache.invalidate_all()
-    on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
-    :ok
-  end
 
   setup %{conn: conn} do
     user = insert(:user)
@@ -42,8 +12,6 @@ defmodule EngramWeb.SearchControllerTest do
     vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
     grant_api_write!(user)
-    {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
-    insert(:subscription, user: user, status: "active")
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
 
     bypass = Bypass.open()

--- a/test/engram_web/onboarding_gate_integration_test.exs
+++ b/test/engram_web/onboarding_gate_integration_test.exs
@@ -2,12 +2,14 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
   use EngramWeb.ConnCase, async: false
 
   alias Engram.Accounts
+  alias Engram.Legal.VersionCache
+  alias Engram.LegalFixtures
 
   setup %{conn: conn} do
     prev_enabled = Application.get_env(:engram, :billing_enabled)
     Application.put_env(:engram, :billing_enabled, true)
 
-    Engram.LegalFixtures.insert_version(
+    LegalFixtures.insert_version(
       document: "terms_of_service",
       version: "2026-05-15",
       content_hash: "canonical",
@@ -15,7 +17,7 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
       effective_date: nil
     )
 
-    Engram.LegalFixtures.insert_version(
+    LegalFixtures.insert_version(
       document: "privacy_policy",
       version: "2026-05-15",
       content_hash: "p",
@@ -23,8 +25,8 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
       effective_date: nil
     )
 
-    Engram.Legal.VersionCache.invalidate_all()
-    on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
+    VersionCache.invalidate_all()
+    on_exit(&VersionCache.invalidate_all/0)
 
     on_exit(fn ->
       Application.put_env(:engram, :billing_enabled, prev_enabled)

--- a/test/engram_web/onboarding_gate_integration_test.exs
+++ b/test/engram_web/onboarding_gate_integration_test.exs
@@ -5,13 +5,29 @@ defmodule EngramWeb.OnboardingGateIntegrationTest do
 
   setup %{conn: conn} do
     prev_enabled = Application.get_env(:engram, :billing_enabled)
-    prev_version = Application.get_env(:engram, :current_tos_version)
     Application.put_env(:engram, :billing_enabled, true)
-    Application.put_env(:engram, :current_tos_version, "2026-05-15")
+
+    Engram.LegalFixtures.insert_version(
+      document: "terms_of_service",
+      version: "2026-05-15",
+      content_hash: "canonical",
+      material: true,
+      effective_date: nil
+    )
+
+    Engram.LegalFixtures.insert_version(
+      document: "privacy_policy",
+      version: "2026-05-15",
+      content_hash: "p",
+      material: true,
+      effective_date: nil
+    )
+
+    Engram.Legal.VersionCache.invalidate_all()
+    on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
 
     on_exit(fn ->
       Application.put_env(:engram, :billing_enabled, prev_enabled)
-      Application.put_env(:engram, :current_tos_version, prev_version)
     end)
 
     user = insert_user()

--- a/test/engram_web/plugs/require_onboarding_test.exs
+++ b/test/engram_web/plugs/require_onboarding_test.exs
@@ -1,6 +1,8 @@
 defmodule EngramWeb.Plugs.RequireOnboardingTest do
   use EngramWeb.ConnCase, async: false
 
+  alias Engram.Legal.VersionCache
+  alias Engram.LegalFixtures
   alias Engram.Onboarding
   alias EngramWeb.Plugs.RequireOnboarding
 
@@ -8,7 +10,7 @@ defmodule EngramWeb.Plugs.RequireOnboardingTest do
     prev_enabled = Application.get_env(:engram, :billing_enabled)
     Application.put_env(:engram, :billing_enabled, true)
 
-    Engram.LegalFixtures.insert_version(
+    LegalFixtures.insert_version(
       document: "terms_of_service",
       version: "2026-05-15",
       content_hash: "canonical",
@@ -16,7 +18,7 @@ defmodule EngramWeb.Plugs.RequireOnboardingTest do
       effective_date: nil
     )
 
-    Engram.LegalFixtures.insert_version(
+    LegalFixtures.insert_version(
       document: "privacy_policy",
       version: "2026-05-15",
       content_hash: "p",
@@ -24,8 +26,8 @@ defmodule EngramWeb.Plugs.RequireOnboardingTest do
       effective_date: nil
     )
 
-    Engram.Legal.VersionCache.invalidate_all()
-    on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
+    VersionCache.invalidate_all()
+    on_exit(&VersionCache.invalidate_all/0)
 
     on_exit(fn ->
       Application.put_env(:engram, :billing_enabled, prev_enabled)

--- a/test/engram_web/plugs/require_onboarding_test.exs
+++ b/test/engram_web/plugs/require_onboarding_test.exs
@@ -6,13 +6,29 @@ defmodule EngramWeb.Plugs.RequireOnboardingTest do
 
   setup do
     prev_enabled = Application.get_env(:engram, :billing_enabled)
-    prev_version = Application.get_env(:engram, :current_tos_version)
     Application.put_env(:engram, :billing_enabled, true)
-    Application.put_env(:engram, :current_tos_version, "2026-05-15")
+
+    Engram.LegalFixtures.insert_version(
+      document: "terms_of_service",
+      version: "2026-05-15",
+      content_hash: "canonical",
+      material: true,
+      effective_date: nil
+    )
+
+    Engram.LegalFixtures.insert_version(
+      document: "privacy_policy",
+      version: "2026-05-15",
+      content_hash: "p",
+      material: true,
+      effective_date: nil
+    )
+
+    Engram.Legal.VersionCache.invalidate_all()
+    on_exit(&Engram.Legal.VersionCache.invalidate_all/0)
 
     on_exit(fn ->
       Application.put_env(:engram, :billing_enabled, prev_enabled)
-      Application.put_env(:engram, :current_tos_version, prev_version)
     end)
 
     :ok

--- a/test/support/legal_fixtures.ex
+++ b/test/support/legal_fixtures.ex
@@ -1,0 +1,24 @@
+defmodule Engram.LegalFixtures do
+  @moduledoc "Insert terms_versions rows in tests."
+  alias Engram.Legal.TermsVersion
+  alias Engram.Repo
+
+  @doc """
+  Insert a version row. Defaults: terms_of_service, material, effective now.
+  Pass `effective_date:` a `~D[]` in the future for the notice-window case.
+  """
+  def insert_version(attrs \\ %{}) do
+    defaults = %{
+      document: "terms_of_service",
+      version: "2026-05-19",
+      content_hash: "hash-" <> (attrs[:version] || "2026-05-19"),
+      material: true,
+      effective_date: nil,
+      changelog: "test"
+    }
+
+    %TermsVersion{}
+    |> TermsVersion.changeset(Map.merge(defaults, Map.new(attrs)))
+    |> Repo.insert!(skip_tenant_check: true)
+  end
+end

--- a/test/support/legal_fixtures.ex
+++ b/test/support/legal_fixtures.ex
@@ -8,6 +8,8 @@ defmodule Engram.LegalFixtures do
   Pass `effective_date:` a `~D[]` in the future for the notice-window case.
   """
   def insert_version(attrs \\ %{}) do
+    attrs = Map.new(attrs)
+
     defaults = %{
       document: "terms_of_service",
       version: "2026-05-19",
@@ -18,7 +20,7 @@ defmodule Engram.LegalFixtures do
     }
 
     %TermsVersion{}
-    |> TermsVersion.changeset(Map.merge(defaults, Map.new(attrs)))
+    |> TermsVersion.changeset(Map.merge(defaults, attrs))
     |> Repo.insert!(skip_tenant_check: true)
   end
 end


### PR DESCRIPTION
## Summary

P1 of the non-blocking terms re-acceptance design (engram-workspace#33). Replaces the config-lever TOS gate (`min_required_tos_version` + friends) with a DB-backed, cached, `effective_date`-driven model.

- **`terms_versions` table** (global/non-tenant): `document`, `version` (YYYY-MM-DD), `content_hash`, `material`, `effective_date`, `changelog`; unique on `(document, version)` + a CHECK constraint on `document`.
- **`Engram.Legal` context**: `required_floor/1` (latest MATERIAL version effective now), `current_version/1`, `hash_for/2`, `get/2`. Ordering is lexicographic on the YYYY-MM-DD string (enforced by the changeset format).
- **`Engram.Legal.VersionCache`**: `:persistent_term` memoization mirroring `Engram.Billing.PlanCache`, with `invalidate_all/0`.
- **`Engram.Legal.Seeder`**: seeds + fail-loud-verifies from a vendored `priv/legal/legal-manifest.json` (byte-identical to the frontend's). Wired into boot after the supervisor, gated by `:seed_legal_on_boot` (false in test). **Folds #318** (hash drift → single manifest source of truth).
- **`Engram.Onboarding`**: `status/1` computes the gate from the cache (`terms_ok = accepted >= required_floor`) and adds a `terms_notice` payload (newest unaccepted version's metadata — doubles as the non-blocking notice during the window and the accept prompt after effective). `TermsCache` refactored from `{user_id, version}→bool` to `{user_id, document}→version`; warmed on accept.
- **Controller**: `status/2` is now a passthrough (stringifies `next_step`, drops nil `terms_notice`) — **folds #320** (status serialization). Accept-check reads hash/current-version from the cache (nil-guarded) instead of config.
- Removes the dead legal config keys; migrates onboarding/controller/plug tests to seed `terms_versions` rows.

## Notes / follow-ups
- A legal version bump is a **two-file change**: add `version→hash` to `priv/legal/legal-manifest.json` AND its `material`/`effective_date`/`changelog` to `Seeder.@version_meta` (commented in-code). P5 will automate the cross-repo sync.
- Boot hard-depends on `priv/legal/legal-manifest.json` shipping in the release (Mix bundles `priv/` by default); recommend one real-release boot to confirm before first prod deploy, since `seed_legal_on_boot` is off in test.
- Privacy is **notice-only** in P1 (gate reads ToS floor only); privacy hard-cutoff deferred to #312.

## Test plan
- [x] `mix test` full suite green (1635 tests, 0 failures), **order-stable across seeds 0 / 424242 / 99999** (a leaked `billing_enabled` in a new describe block was the only ordering hazard — fixed).
- [x] `mix compile --warnings-as-errors`, `mix format`, `mix credo --strict`, `sobelow` all clean (pre-push gate).
- [ ] One real-release boot confirms the vendored manifest seeds + verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)