### PR TITLE
DB advisor fixes + splinter/squawk CI linting + dev seeder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -975,6 +975,21 @@ jobs:
           # job; this extends the same bar to test/**.
           mix test --warnings-as-errors
 
+      - name: Lint DB schema (splinter)
+        run: |
+          # splinter (priv/repo/splinter.sql) references Supabase's API roles,
+          # so stub them — without them the linter aborts on a plain Postgres.
+          # Our tables aren't granted to these roles, so the API-exposure lints
+          # (rls_disabled_in_public, *_table_exposed) stay silent; only genuine
+          # schema/security findings surface. unused_index is filtered by the
+          # gate (no scan stats on a fresh CI database).
+          docker exec "$PG_CONTAINER" psql -U engram -d engram_test -q -v ON_ERROR_STOP=1 -c "
+            DO \$\$ BEGIN CREATE ROLE anon NOLOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
+            DO \$\$ BEGIN CREATE ROLE authenticated NOLOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
+            DO \$\$ BEGIN CREATE ROLE service_role NOLOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;"
+          docker exec -i "$PG_CONTAINER" psql -U engram -d engram_test -At -F'|' \
+            < priv/repo/splinter.sql | bash priv/repo/lint_schema.sh
+
       - name: Stop ephemeral postgres
         if: always()
         run: docker rm -fv "$PG_CONTAINER" 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,6 +1006,16 @@ jobs:
           docker exec "$PG_CONTAINER" createdb -U engram squawk_lint
           SQUAWK_BIN=/tmp/squawk bash priv/repo/lint_migrations.sh
 
+      - name: Test new migrations roll back (ecto.rollback)
+        env:
+          DATABASE_URL: postgresql://engram:engram@localhost:${{ steps.pg.outputs.pg_port }}/rollback_test
+          MIX_ENV: test
+          BASE_REF: origin/main
+        run: |
+          git fetch -q --depth=1 origin main || true
+          docker exec "$PG_CONTAINER" createdb -U engram rollback_test
+          bash priv/repo/test_rollback.sh
+
       - name: Stop ephemeral postgres
         if: always()
         run: docker rm -fv "$PG_CONTAINER" 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -990,6 +990,22 @@ jobs:
           docker exec -i "$PG_CONTAINER" psql -U engram -d engram_test -At -F'|' \
             < priv/repo/splinter.sql | bash priv/repo/lint_schema.sh
 
+      - name: Lint new migrations (squawk)
+        env:
+          DATABASE_URL: postgresql://engram:engram@localhost:${{ steps.pg.outputs.pg_port }}/squawk_lint
+          MIX_ENV: test
+          BASE_REF: origin/main
+        run: |
+          # Need origin/main locally to detect which migrations are new.
+          git fetch -q --depth=1 origin main || true
+          # squawk (Rust, baseline x86-64), pinned.
+          curl -fsSL -o /tmp/squawk \
+            https://github.com/sbdchd/squawk/releases/download/v2.54.0/squawk-linux-x64
+          chmod +x /tmp/squawk
+          # Fresh DB to render the new migrations' DDL from scratch.
+          docker exec "$PG_CONTAINER" createdb -U engram squawk_lint
+          SQUAWK_BIN=/tmp/squawk bash priv/repo/lint_migrations.sh
+
       - name: Stop ephemeral postgres
         if: always()
         run: docker rm -fv "$PG_CONTAINER" 2>/dev/null || true

--- a/.squawk.toml
+++ b/.squawk.toml
@@ -1,0 +1,13 @@
+# squawk lints the DDL of migrations new on each branch
+# (see priv/repo/lint_migrations.sh). These two rules structurally conflict
+# with Ecto's generated migration SQL, so they're excluded — everything else
+# (ban-drop-column, adding-required-field, renaming-column, changing-column-type,
+# disallowed-unique-constraint, etc.) still gates the build.
+#
+#   require-timeout-settings — Ecto migrations never emit `SET lock_timeout` /
+#     `SET statement_timeout`; those are managed outside the migration SQL.
+#   prefer-robust-stmts      — Ecto wraps each migration in a transaction
+#     (invisible once the SQL is flattened) and reruns via the schema_migrations
+#     table, and this rule also flags every `CREATE INDEX CONCURRENTLY` for a
+#     missing `IF NOT EXISTS` that Ecto does not generate.
+excluded_rules = ["require-timeout-settings", "prefer-robust-stmts"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ Self-host (no `PADDLE_API_KEY`): free, no billing wiring. See `docs/context/padd
 | `docs/context/oidc-deploy-cutover.md` | OIDC pull-based deploy daemon, legacy SSH-as-root retirement |
 | `docs/context/aws-kms-provider-integration.md` | Tier-4 / Phase F roadmap for KMS provider routing |
 | `docs/context/followup-show-attachments-in-tree.md` | One-feature follow-up tracker |
+| `docs/context/local-supabase-audit.md` | Throwaway local Supabase stack to run Studio Security/Performance Advisors against the Engram schema (AVX2 CLI build, encrypted-seed, RLS role grant, boot-canary gotchas) |
 | `../engram-workspace/docs/context/pricing-strategy.md` | Cross-workspace SaaS pricing model (lives in workspace repo) |
 
 ## Life OS

--- a/docs/context/local-supabase-audit.md
+++ b/docs/context/local-supabase-audit.md
@@ -1,0 +1,101 @@
+# Context Doc: Local Supabase Schema Audit Stack
+
+_Last verified: 2026-05-26_
+
+## Status
+Working (throwaway / off-roadmap). The Engram backend does NOT run on Supabase — this is a disposable local stack used only to point Supabase Studio's Security/Performance Advisors at a real copy of the Engram schema.
+
+## What This Is
+A local Supabase stack whose Postgres is loaded with the Engram backend schema (via Ecto migrations) + synthetic data, so Supabase Studio's Security and Performance Advisors can flag missing indexes, RLS gaps, unindexed FKs, etc. Disposable DB — never holds real user data.
+
+## Environment
+- Host: Claw (Fedora, `10.0.20.172`). CPU is a **Xeon E5-2650 v2 (Ivy Bridge)** — has AVX but **no AVX2** (load-bearing, see Gotcha 1).
+- Supabase CLI built from source → `~/.local/bin/supabase`.
+- Stack project dir: `~/supabase-engram-audit` (`supabase init` + `supabase start`).
+- Backend repo: `engram` (this repo).
+
+## Connection
+Default Supabase local ports (Docker-published on `0.0.0.0`):
+- **Studio GUI:** `127.0.0.1:54323`
+- **Postgres:** `127.0.0.1:54322` — user `postgres`, pass `postgres`, db `postgres`
+- **API / Kong:** `54321`
+
+Studio is loopback-only by intent. Reach it via:
+- SSH tunnel: `ssh -L 54323:127.0.0.1:54323 claw` then open `http://127.0.0.1:54323`, OR
+- Since Docker publishes on `0.0.0.0`, the LAN IP directly: `http://10.0.20.172:54323` (firewalld may need `firewall-cmd --add-port=54323/tcp`).
+- Advisors: `/project/default/advisors/security` and `/project/default/advisors/performance`.
+
+## Auth
+- Postgres: `postgres`/`postgres` (local default).
+- Encryption master key for the Engram app: persisted at `~/supabase-engram-audit/.master_key` (chmod 600). MUST be stable across runs (see Gotcha 3). Pass it as `ENCRYPTION_MASTER_KEY="$(cat ~/supabase-engram-audit/.master_key)"`.
+
+## Key Commands / Patterns
+
+### Build the CLI (one-time, AVX2 workaround)
+```bash
+# Prebuilt CLI SIGILLs on this host (no AVX2). Build from source with GOAMD64=v1.
+# The package lives at apps/cli-go/ in the monorepo; `go install .../cli@TAG` does NOT work.
+git clone --branch <TAG> https://github.com/supabase/cli
+cd cli/apps/cli-go && GOAMD64=v1 go build -o ~/.local/bin/supabase .
+supabase services    # NOT `supabase --version` — that flag doesn't exist
+supabase status
+```
+
+### Stand up the stack
+```bash
+mkdir -p ~/supabase-engram-audit && cd ~/supabase-engram-audit
+supabase init
+supabase start
+```
+
+### Load the Engram schema (from the backend repo)
+`backend/config/dev.exs` honors `DATABASE_URL`. Point Ecto at the Supabase Postgres:
+```bash
+cd backend
+mix deps.get
+DATABASE_URL="postgres://postgres:postgres@127.0.0.1:54322/postgres" mix ecto.migrate
+```
+
+### Grant the RLS app role to postgres (see Gotcha 4)
+```bash
+docker exec supabase_db_supabase-engram-audit \
+  psql -U postgres -d postgres -c 'GRANT engram_app TO postgres;'
+```
+
+### Seed synthetic data
+Use the committed Elixir seed script (NOT raw SQL/CSV — see Gotcha 2):
+```bash
+cd backend
+DATABASE_URL="postgres://postgres:postgres@127.0.0.1:54322/postgres" \
+KEY_PROVIDER=local \
+ENCRYPTION_MASTER_KEY="$(cat ~/supabase-engram-audit/.master_key)" \
+mix run priv/repo/dev_seeds.exs
+```
+Defaults: 10 users / 2000 notes. Tunable via `SEED_USERS`, `SEED_NOTES_PER_USER`, `SEED_PREFIX`.
+
+### Lifecycle
+```bash
+supabase stop  --workdir ~/supabase-engram-audit
+supabase start --workdir ~/supabase-engram-audit
+```
+
+## Failed Approaches / Dead Ends
+- **Prebuilt Supabase CLI binary** — SIGILLs with "Illegal instruction" on this host. Root cause: official binary is compiled `GOAMD64=v3` (requires AVX2); the Xeon E5-2650 v2 has AVX but not AVX2. Must build from source with `GOAMD64=v1`.
+- **`go install github.com/supabase/cli@TAG`** — fails with "+incompatible / does not contain package". The CLI is a monorepo; the main package is at `apps/cli-go/`. Clone the tag and `cd apps/cli-go && go build` instead.
+- **`supabase --version`** — not a valid flag. Use `supabase services` / `supabase status`.
+- **Seeding notes via raw SQL / CSV import** — impossible. Plaintext `content`/`title`/`path` columns were DROPPED in the phase-B encryption migrations; only encrypted blobs + HMAC lookup columns remain. You MUST go through the Engram contexts (`Notes.upsert_note/3`, `Vaults.create_vault/2`, `Accounts.find_or_create_by_external_id/2`, `Crypto.ensure_user_dek/1`). That's why `dev_seeds.exs` is Elixir, not CSVs.
+
+## Gotchas
+1. **No AVX2 on this CPU** — see Failed Approaches. Build CLI with `GOAMD64=v1`.
+2. **Encryption at rest** — notes/vaults are per-user-DEK, AAD-bound AES-GCM with HMAC lookup columns; plaintext columns are gone. Seed only through the app contexts.
+3. **Boot canary** — the app boots `BootCanaryGuard`, which wraps/unwraps a canary row in `system_canaries` using `ENCRYPTION_MASTER_KEY`. Seed once with key A then re-run with key B → boot fails: `boot canary unwrap failed: :invalid_wrapping`. Fix: pin ONE stable master key (`~/supabase-engram-audit/.master_key`). If the canary is already wrapped under a lost key on this throwaway DB (no real encrypted data to protect): `DELETE FROM system_canaries;` then re-run.
+4. **RLS role grant** — `Repo.with_tenant/2` does `SET LOCAL ROLE engram_app` + `SET LOCAL app.current_tenant`. Supabase's `postgres` user is not a true superuser and isn't a member of `engram_app`, so writes fail with `42501 permission denied to set role "engram_app"`. The `engram_app` role itself already exists (created by migration `20260403000846_add_rls_policies`). Fix: `GRANT engram_app TO postgres;` (run as postgres via the `docker exec ... psql` above).
+5. **Embeddings / Oban** — `upsert_note` enqueues Oban `:embed` jobs that would call Voyage AI + Qdrant (external/cloud). `dev_seeds.exs` pauses the `:embed` and `:reindex` queues before inserting, so nothing fires; jobs stay queued in `oban_jobs` (harmless, and realistic queue data for the audit).
+6. **Studio is loopback-only** — reach via SSH tunnel or the LAN IP (Docker publishes on `0.0.0.0`); firewalld may need port 54323 opened.
+
+## References
+- Seed script: `backend/priv/repo/dev_seeds.exs`
+- Dev config honoring `DATABASE_URL`: `backend/config/dev.exs`
+- RLS migration creating `engram_app`: `backend/priv/repo/migrations/20260403000846_add_rls_policies.exs`
+- Schema/RLS background: `backend/docs/context/database-schema-rls.md`
+- Supabase CLI monorepo: https://github.com/supabase/cli (`apps/cli-go/`)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.232",
+      version: "0.5.233",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.231",
+      version: "0.5.232",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.230",
+      version: "0.5.231",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/dev_seeds.exs
+++ b/priv/repo/dev_seeds.exs
@@ -37,7 +37,9 @@ defmodule DevSeed do
 
   def words(n), do: 1..n |> Enum.map(fn _ -> Enum.random(@words) end) |> Enum.join(" ")
 
-  def paragraph, do: 1..(:rand.uniform(4) + 2) |> Enum.map(fn _ -> sentence() end) |> Enum.join(" ")
+  def paragraph,
+    do: 1..(:rand.uniform(4) + 2) |> Enum.map(fn _ -> sentence() end) |> Enum.join(" ")
+
   defp sentence, do: String.capitalize(words(:rand.uniform(10) + 4)) <> "."
 
   def folder, do: Enum.random(@folders)

--- a/priv/repo/dev_seeds.exs
+++ b/priv/repo/dev_seeds.exs
@@ -1,0 +1,103 @@
+# Dev/staging data seeder.
+#
+# Populates users, vaults, and notes through the real Engram contexts so the
+# encryption layer runs: per-user DEK provisioning, AAD-bound AES-GCM on note
+# fields, and the HMAC lookup columns (path/folder/tags/content_hash). Raw SQL
+# or CSV imports CANNOT seed these tables — the plaintext content/title/path
+# columns were dropped in the phase-B migrations, leaving only ciphertext +
+# HMAC columns that are meaningless without going through Engram.Crypto.
+#
+# Idempotent: users keyed by deterministic external_id (SEED_PREFIX), notes
+# keyed by path via upsert_note/3. Re-running updates in place instead of
+# duplicating.
+#
+# Usage (against the local Supabase audit DB):
+#
+#   DATABASE_URL="postgres://postgres:postgres@127.0.0.1:54322/postgres" \
+#   KEY_PROVIDER=local ENCRYPTION_MASTER_KEY="$(openssl rand -base64 32)" \
+#   mix run priv/repo/dev_seeds.exs
+#
+# Tunables (env vars):
+#   SEED_USERS           number of users          (default 10)
+#   SEED_NOTES_PER_USER  notes per user/vault     (default 200)
+#   SEED_PREFIX          external_id/email prefix (default "seed")
+#
+# Embeddings: the :embed and :reindex Oban queues are paused before inserts so
+# no Voyage AI / Qdrant calls fire. The enqueued jobs remain in oban_jobs
+# (useful as realistic queue data); they never execute under this script.
+
+alias Engram.{Accounts, Crypto, Notes, Vaults}
+
+defmodule DevSeed do
+  @folders ["Projects", "Daily", "Reference", "Archive/2026", "Inbox", "Areas/Health"]
+  @tag_pool ~w(elixir phoenix obsidian sync crypto billing infra research idea todo meeting)
+  @words ~w(system vault note index search vector embedding query tenant policy
+            migration schema encryption pipeline channel worker cache token plan
+            limit usage meter audit advisor postgres docker cluster region payload)
+
+  def words(n), do: 1..n |> Enum.map(fn _ -> Enum.random(@words) end) |> Enum.join(" ")
+
+  def paragraph, do: 1..(:rand.uniform(4) + 2) |> Enum.map(fn _ -> sentence() end) |> Enum.join(" ")
+  defp sentence, do: String.capitalize(words(:rand.uniform(10) + 4)) <> "."
+
+  def folder, do: Enum.random(@folders)
+
+  def note_content(i) do
+    tags = Enum.take_random(@tag_pool, :rand.uniform(3))
+    frontmatter = "---\ntitle: Seed Note #{i}\ntags: [#{Enum.join(tags, ", ")}]\n---\n\n"
+    body = 1..(:rand.uniform(3) + 1) |> Enum.map(fn _ -> paragraph() end) |> Enum.join("\n\n")
+    link = "\n\nRelated: [[#{folder()}/note_#{:rand.uniform(max(i, 1))}]]"
+    inline_tags = "\n\n" <> Enum.map_join(tags, " ", &("#" <> &1))
+    "#{frontmatter}# Seed Note #{i}\n\n#{body}#{link}#{inline_tags}"
+  end
+end
+
+users_n = String.to_integer(System.get_env("SEED_USERS") || "10")
+notes_per = String.to_integer(System.get_env("SEED_NOTES_PER_USER") || "200")
+prefix = System.get_env("SEED_PREFIX") || "seed"
+
+# Stop background processing so seeding never reaches out to Voyage AI / Qdrant.
+for q <- [:embed, :reindex] do
+  try do
+    Oban.pause_queue(queue: q)
+  rescue
+    e -> IO.puts("  warn: could not pause #{q} queue: #{inspect(e)}")
+  end
+end
+
+IO.puts("Seeding #{users_n} users x #{notes_per} notes (prefix=#{prefix})...")
+
+{users_created, notes_created} =
+  Enum.reduce(1..users_n, {0, 0}, fn u, {uc, nc} ->
+    ext_id = "#{prefix}_user_#{String.pad_leading(Integer.to_string(u), 4, "0")}"
+    email = "#{ext_id}@seed.local"
+
+    {:ok, user} = Accounts.find_or_create_by_external_id(ext_id, %{email: email})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+
+    vault =
+      case Vaults.create_vault(user, %{name: "#{prefix} vault #{u}"}) do
+        {:ok, v} -> v
+        {:error, :vault_limit_reached} -> hd(Vaults.list_vaults(user))
+      end
+
+    note_count =
+      Enum.reduce(1..notes_per, 0, fn n, acc ->
+        path = "#{DevSeed.folder()}/note_#{n}.md"
+
+        case Notes.upsert_note(user, vault, %{
+               "path" => path,
+               "content" => DevSeed.note_content(n),
+               "mtime" => System.system_time(:second)
+             }) do
+          {:ok, _note} -> acc + 1
+          {:error, :notes_cap_reached} -> acc
+          other -> IO.puts("  note error (#{path}): #{inspect(other)}") && acc
+        end
+      end)
+
+    if rem(u, 5) == 0, do: IO.puts("  ...#{u}/#{users_n} users done")
+    {uc + 1, nc + note_count}
+  end)
+
+IO.puts("Done. #{users_created} users, #{notes_created} notes.")

--- a/priv/repo/lint_migrations.sh
+++ b/priv/repo/lint_migrations.sh
@@ -56,7 +56,8 @@ mix ecto.migrate --log-migrations-sql 2>/dev/null \
   | awk '{ t=$0; sub(/[ \t]+$/,"",t);
            if (t=="[]") { if(buf!=""){print buf ";"; buf=""} }
            else if (t ~ / \[\]$/) { sub(/ \[\]$/,"",t); buf=(buf==""?t:buf"\n"t); print buf ";"; buf="" }
-           else { buf=(buf==""?t:buf"\n"t) } }' > "$tmp_sql"
+           else { buf=(buf==""?t:buf"\n"t) } }
+       END { if (buf!="") print buf ";" }' > "$tmp_sql"
 
 if [ ! -s "$tmp_sql" ]; then
   echo "squawk: rendered no SQL — nothing to lint"

--- a/priv/repo/lint_migrations.sh
+++ b/priv/repo/lint_migrations.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Lints the DDL of migrations new on this branch with squawk
+# (https://squawk.dev), catching unsafe migration patterns (dropping columns,
+# adding NOT NULL columns, type changes, blocking constraints, etc.) before
+# they merge. Ecto-incompatible rules are excluded in .squawk.toml.
+#
+# Ecto migrations are imperative Elixir, so the DDL is rendered by migrating a
+# throwaway database to the latest version present on BASE_REF and then running
+# the new migrations with --log-migrations-sql, capturing only their SQL.
+#
+# Caller must provide:
+#   DATABASE_URL  — a FRESH, EMPTY database to render against (it gets migrated)
+#   MIX_ENV=test  — reuses the compiled _build/test (no dev recompile in CI)
+#   BASE_REF      — git ref to diff against (default origin/main); must be fetched
+#   SQUAWK_BIN    — path to the squawk binary (default: squawk on PATH)
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+SQUAWK="${SQUAWK_BIN:-squawk}"
+MIG_DIR="priv/repo/migrations"
+
+# Highest migration version already on the base branch.
+base_version=$(git ls-tree -r --name-only "$BASE_REF" -- "$MIG_DIR" 2>/dev/null \
+  | grep -oE '[0-9]{14}' | sort -u | tail -1 || true)
+
+if [ -z "$base_version" ]; then
+  echo "::error::squawk: could not read migrations from '$BASE_REF' (is it fetched?)"
+  exit 1
+fi
+
+# Migrations in the working tree newer than the base branch's tip.
+mapfile -t new_versions < <(
+  find "$MIG_DIR" -maxdepth 1 -name '*.exs' -printf '%f\n' \
+    | grep -oE '^[0-9]{14}' | sort -u | awk -v b="$base_version" '$0 > b'
+)
+
+if [ "${#new_versions[@]}" -eq 0 ]; then
+  echo "squawk: no migrations newer than $BASE_REF — nothing to lint"
+  exit 0
+fi
+
+echo "squawk: linting new migrations: ${new_versions[*]}"
+
+# Bring the throwaway DB up to the base branch state, then render only the new
+# migrations' SQL. The clean SQL lines have no timestamp prefix; each statement
+# is terminated by a params marker (` []` inline, or a lone `[]` line).
+mix ecto.migrate --to "$base_version" >/dev/null
+
+tmp_sql="$(mktemp --suffix=.sql)"
+trap 'rm -f "$tmp_sql"' EXIT
+
+mix ecto.migrate --log-migrations-sql 2>/dev/null \
+  | grep -vE '^[0-9]{2}:[0-9]{2}:[0-9]{2}' \
+  | grep -vE '^\s*$' \
+  | awk '{ t=$0; sub(/[ \t]+$/,"",t);
+           if (t=="[]") { if(buf!=""){print buf ";"; buf=""} }
+           else if (t ~ / \[\]$/) { sub(/ \[\]$/,"",t); buf=(buf==""?t:buf"\n"t); print buf ";"; buf="" }
+           else { buf=(buf==""?t:buf"\n"t) } }' > "$tmp_sql"
+
+if [ ! -s "$tmp_sql" ]; then
+  echo "squawk: rendered no SQL — nothing to lint"
+  exit 0
+fi
+
+echo "── rendered DDL ──"
+cat "$tmp_sql"
+echo "──────────────────"
+
+"$SQUAWK" "$tmp_sql"

--- a/priv/repo/lint_schema.sh
+++ b/priv/repo/lint_schema.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Schema linter gate for CI. Runs Supabase's splinter
+# (https://github.com/supabase/splinter, vendored as splinter.sql) against an
+# already-migrated database and fails if it reports any actionable finding.
+#
+# On a plain Postgres (no pg_graphql extension, no anon/authenticated roles)
+# the Supabase-API-specific lints (table-exposed, rls_disabled_in_public) do
+# not fire, so this surfaces only genuine schema issues: per-row RLS policies
+# (auth_rls_initplan), unindexed foreign keys, duplicate indexes, missing
+# primary keys, security-definer views, etc.
+#
+# `unused_index` is ignored: it depends on pg_stat scan counts, which are
+# empty on a freshly-migrated CI database, so every index would false-positive.
+#
+# Usage: pipe splinter's pipe-delimited rows on stdin, e.g.
+#   docker exec -i "$PG" psql -U engram -d engram_test -At -F'|' \
+#     < priv/repo/splinter.sql | bash priv/repo/lint_schema.sh
+set -euo pipefail
+
+IGNORE='^(unused_index)$'
+
+findings=$(awk -F'|' -v ig="$IGNORE" \
+  'NF > 3 && $3 != "" && $1 !~ ig { printf "  [%s] %s — %s\n", $3, $1, $7 }')
+
+if [ -n "$findings" ]; then
+  echo "::error::splinter reported schema advisories (fix or justify):"
+  echo "$findings"
+  exit 1
+fi
+
+echo "splinter: no actionable schema findings"

--- a/priv/repo/migrations/20260527050000_rls_initplan_and_pk_fixes.exs
+++ b/priv/repo/migrations/20260527050000_rls_initplan_and_pk_fixes.exs
@@ -1,0 +1,48 @@
+defmodule Engram.Repo.Migrations.RlsInitplanAndPkFixes do
+  use Ecto.Migration
+
+  # Tenant-isolation policies whose `current_setting('app.current_tenant')`
+  # call must be wrapped in a scalar subquery so the planner evaluates it once
+  # per statement (initplan) instead of once per row. Behaviour is identical;
+  # this is purely a query-plan optimization (Supabase advisor: auth_rls_initplan).
+  @tenant_tables ~w(notes chunks attachments api_keys vaults user_agreements)
+
+  def up do
+    for table <- @tenant_tables do
+      execute "DROP POLICY IF EXISTS tenant_isolation_#{table} ON #{table}"
+
+      execute """
+      CREATE POLICY tenant_isolation_#{table} ON #{table}
+        USING (user_id::text = (SELECT current_setting('app.current_tenant', true)))
+        WITH CHECK (user_id::text = (SELECT current_setting('app.current_tenant', true)))
+      """
+    end
+
+    # client_origin_stats was created with primary_key: false; its composite
+    # unique index already enforces the natural key, so promote it in place to
+    # the primary key (no rebuild) rather than adding a surrogate column.
+    execute """
+    ALTER TABLE client_origin_stats
+      ADD PRIMARY KEY USING INDEX client_origin_stats_user_id_day_fingerprint_class_index
+    """
+  end
+
+  def down do
+    for table <- @tenant_tables do
+      execute "DROP POLICY IF EXISTS tenant_isolation_#{table} ON #{table}"
+
+      execute """
+      CREATE POLICY tenant_isolation_#{table} ON #{table}
+        USING (user_id::text = current_setting('app.current_tenant', true))
+        WITH CHECK (user_id::text = current_setting('app.current_tenant', true))
+      """
+    end
+
+    execute "ALTER TABLE client_origin_stats DROP CONSTRAINT client_origin_stats_pkey"
+
+    execute """
+    CREATE UNIQUE INDEX client_origin_stats_user_id_day_fingerprint_class_index
+      ON client_origin_stats (user_id, day, fingerprint_class)
+    """
+  end
+end

--- a/priv/repo/migrations/20260527050000_rls_initplan_and_pk_fixes.exs
+++ b/priv/repo/migrations/20260527050000_rls_initplan_and_pk_fixes.exs
@@ -38,7 +38,13 @@ defmodule Engram.Repo.Migrations.RlsInitplanAndPkFixes do
       """
     end
 
-    execute "ALTER TABLE client_origin_stats DROP CONSTRAINT client_origin_stats_pkey"
+    # ADD PRIMARY KEY USING INDEX keeps the source index's name as the
+    # constraint name (not <table>_pkey). Dropping the constraint also drops
+    # the backing index; recreate it as a plain unique index.
+    execute """
+    ALTER TABLE client_origin_stats
+      DROP CONSTRAINT client_origin_stats_user_id_day_fingerprint_class_index
+    """
 
     execute """
     CREATE UNIQUE INDEX client_origin_stats_user_id_day_fingerprint_class_index

--- a/priv/repo/migrations/20260527050001_add_fk_indexes_drop_duplicate.exs
+++ b/priv/repo/migrations/20260527050001_add_fk_indexes_drop_duplicate.exs
@@ -26,10 +26,10 @@ defmodule Engram.Repo.Migrations.AddFkIndexesDropDuplicate do
 
   def down do
     create index(:api_key_vaults, [:api_key_id, :vault_id],
-      name: "api_key_vaults_api_key_id_vault_id_index",
-      unique: true,
-      concurrently: true
-    )
+             name: "api_key_vaults_api_key_id_vault_id_index",
+             unique: true,
+             concurrently: true
+           )
 
     drop index(:api_keys, [:user_id], concurrently: true)
     drop index(:api_key_vaults, [:vault_id], concurrently: true)

--- a/priv/repo/migrations/20260527050001_add_fk_indexes_drop_duplicate.exs
+++ b/priv/repo/migrations/20260527050001_add_fk_indexes_drop_duplicate.exs
@@ -1,0 +1,43 @@
+defmodule Engram.Repo.Migrations.AddFkIndexesDropDuplicate do
+  use Ecto.Migration
+
+  # Concurrent index builds can't run inside a transaction.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # Covering indexes for foreign keys flagged by the advisor
+    # (unindexed_foreign_keys) — speeds up joins and cascade deletes.
+    create index(:api_keys, [:user_id], concurrently: true)
+    create index(:api_key_vaults, [:vault_id], concurrently: true)
+    create index(:device_authorizations, [:user_id], concurrently: true)
+    create index(:device_authorizations, [:vault_id], concurrently: true)
+    create index(:device_refresh_tokens, [:vault_id], concurrently: true)
+    create index(:oauth_authorization_codes, [:vault_id], concurrently: true)
+    create index(:oauth_refresh_tokens, [:vault_id], concurrently: true)
+    create index(:users, [:plan_id], concurrently: true)
+
+    # Redundant: identical to api_key_vaults_pkey (api_key_id, vault_id).
+    drop_if_exists index(:api_key_vaults, [:api_key_id, :vault_id],
+                     name: "api_key_vaults_api_key_id_vault_id_index",
+                     concurrently: true
+                   )
+  end
+
+  def down do
+    create index(:api_key_vaults, [:api_key_id, :vault_id],
+      name: "api_key_vaults_api_key_id_vault_id_index",
+      unique: true,
+      concurrently: true
+    )
+
+    drop index(:api_keys, [:user_id], concurrently: true)
+    drop index(:api_key_vaults, [:vault_id], concurrently: true)
+    drop index(:device_authorizations, [:user_id], concurrently: true)
+    drop index(:device_authorizations, [:vault_id], concurrently: true)
+    drop index(:device_refresh_tokens, [:vault_id], concurrently: true)
+    drop index(:oauth_authorization_codes, [:vault_id], concurrently: true)
+    drop index(:oauth_refresh_tokens, [:vault_id], concurrently: true)
+    drop index(:users, [:plan_id], concurrently: true)
+  end
+end

--- a/priv/repo/splinter.sql
+++ b/priv/repo/splinter.sql
@@ -1,0 +1,1813 @@
+set local search_path = '';
+
+(
+with foreign_keys as (
+    select
+        cl.relnamespace::regnamespace::text as schema_name,
+        cl.relname as table_name,
+        cl.oid as table_oid,
+        ct.conname as fkey_name,
+        ct.conkey as col_attnums
+    from
+        pg_catalog.pg_constraint ct
+        join pg_catalog.pg_class cl -- fkey owning table
+            on ct.conrelid = cl.oid
+        left join pg_catalog.pg_depend d
+            on d.objid = cl.oid
+            and d.deptype = 'e'
+    where
+        ct.contype = 'f' -- foreign key constraints
+        and d.objid is null -- exclude tables that are dependencies of extensions
+        and cl.relnamespace::regnamespace::text not in (
+            'pg_catalog', 'information_schema', 'auth', 'storage', 'vault', 'extensions'
+        )
+),
+index_ as (
+    select
+        pi.indrelid as table_oid,
+        indexrelid::regclass as index_,
+        string_to_array(indkey::text, ' ')::smallint[] as col_attnums
+    from
+        pg_catalog.pg_index pi
+    where
+        indisvalid
+)
+select
+    'unindexed_foreign_keys' as name,
+    'Unindexed foreign keys' as title,
+    'INFO' as level,
+    'EXTERNAL' as facing,
+    array['PERFORMANCE'] as categories,
+    'Identifies foreign key constraints without a covering index, which can impact database performance.' as description,
+    format(
+        'Table \`%s.%s\` has a foreign key \`%s\` without a covering index. This can lead to suboptimal query performance.',
+        fk.schema_name,
+        fk.table_name,
+        fk.fkey_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys' as remediation,
+    jsonb_build_object(
+        'schema', fk.schema_name,
+        'name', fk.table_name,
+        'type', 'table',
+        'fkey_name', fk.fkey_name,
+        'fkey_columns', fk.col_attnums
+    ) as metadata,
+    format('unindexed_foreign_keys_%s_%s_%s', fk.schema_name, fk.table_name, fk.fkey_name) as cache_key
+from
+    foreign_keys fk
+    left join index_ idx
+        on fk.table_oid = idx.table_oid
+        and fk.col_attnums = idx.col_attnums[1:array_length(fk.col_attnums, 1)]
+    left join pg_catalog.pg_depend dep
+        on idx.table_oid = dep.objid
+        and dep.deptype = 'e'
+where
+    idx.index_ is null
+    and fk.schema_name not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and dep.objid is null -- exclude tables owned by extensions
+order by
+    fk.schema_name,
+    fk.table_name,
+    fk.fkey_name)
+union all
+(
+select
+    'auth_users_exposed' as name,
+    'Exposed Auth Users' as title,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects if auth.users is exposed to anon or authenticated roles via a view or materialized view in schemas exposed to PostgREST, potentially compromising user data security.' as description,
+    format(
+        'View/Materialized View "%s" in the public schema may expose \`auth.users\` data to anon or authenticated roles.',
+        c.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0002_auth_users_exposed' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'view',
+        'exposed_to', array_remove(array_agg(DISTINCT case when pg_catalog.has_table_privilege('anon', c.oid, 'SELECT') then 'anon' when pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT') then 'authenticated' end), null)
+    ) as metadata,
+    format('auth_users_exposed_%s_%s', n.nspname, c.relname) as cache_key
+from
+    -- Identify the oid for auth.users
+    pg_catalog.pg_class auth_users_pg_class
+    join pg_catalog.pg_namespace auth_users_pg_namespace
+        on auth_users_pg_class.relnamespace = auth_users_pg_namespace.oid
+        and auth_users_pg_class.relname = 'users'
+        and auth_users_pg_namespace.nspname = 'auth'
+    -- Depends on auth.users
+    join pg_catalog.pg_depend d
+        on d.refobjid = auth_users_pg_class.oid
+    join pg_catalog.pg_rewrite r
+        on r.oid = d.objid
+    join pg_catalog.pg_class c
+        on c.oid = r.ev_class
+    join pg_catalog.pg_namespace n
+        on n.oid = c.relnamespace
+    join pg_catalog.pg_class pg_class_auth_users
+        on d.refobjid = pg_class_auth_users.oid
+where
+    d.deptype = 'n'
+    and (
+      pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+      or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
+    )
+    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    -- Exclude self
+    and c.relname <> '0002_auth_users_exposed'
+    -- There are 3 insecure configurations
+    and
+    (
+        -- Materialized views don't support RLS so this is insecure by default
+        (c.relkind in ('m')) -- m for materialized view
+        or
+        -- Standard View, accessible to anon or authenticated that is security_definer
+        (
+            c.relkind = 'v' -- v for view
+            -- Exclude security invoker views
+            and not (
+                lower(coalesce(c.reloptions::text,'{}'))::text[]
+                && array[
+                    'security_invoker=1',
+                    'security_invoker=true',
+                    'security_invoker=yes',
+                    'security_invoker=on'
+                ]
+            )
+        )
+        or
+        -- Standard View, security invoker, but no RLS enabled on auth.users
+        (
+            c.relkind in ('v') -- v for view
+            -- is security invoker
+            and (
+                lower(coalesce(c.reloptions::text,'{}'))::text[]
+                && array[
+                    'security_invoker=1',
+                    'security_invoker=true',
+                    'security_invoker=yes',
+                    'security_invoker=on'
+                ]
+            )
+            and not pg_class_auth_users.relrowsecurity
+        )
+    )
+group by
+    n.nspname,
+    c.relname,
+    c.oid)
+union all
+(
+with policies as (
+    select
+        nsp.nspname as schema_name,
+        pb.tablename as table_name,
+        pc.relrowsecurity as is_rls_active,
+        polname as policy_name,
+        polpermissive as is_permissive, -- if not, then restrictive
+        (select array_agg(r::regrole) from unnest(polroles) as x(r)) as roles,
+        case polcmd
+            when 'r' then 'SELECT'
+            when 'a' then 'INSERT'
+            when 'w' then 'UPDATE'
+            when 'd' then 'DELETE'
+            when '*' then 'ALL'
+        end as command,
+        qual,
+        with_check
+    from
+        pg_catalog.pg_policy pa
+        join pg_catalog.pg_class pc
+            on pa.polrelid = pc.oid
+        join pg_catalog.pg_namespace nsp
+            on pc.relnamespace = nsp.oid
+        join pg_catalog.pg_policies pb
+            on pc.relname = pb.tablename
+            and nsp.nspname = pb.schemaname
+            and pa.polname = pb.policyname
+)
+select
+    'auth_rls_initplan' as name,
+    'Auth RLS Initialization Plan' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['PERFORMANCE'] as categories,
+    'Detects if calls to \`current_setting()\` and \`auth.<function>()\` in RLS policies are being unnecessarily re-evaluated for each row' as description,
+    format(
+        'Table \`%s.%s\` has a row level security policy \`%s\` that re-evaluates current_setting() or auth.<function>() for each row. This produces suboptimal query performance at scale. Resolve the issue by replacing \`auth.<function>()\` with \`(select auth.<function>())\`. See [docs](https://supabase.com/docs/guides/database/postgres/row-level-security#call-functions-with-select) for more info.',
+        schema_name,
+        table_name,
+        policy_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0003_auth_rls_initplan' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', table_name,
+        'type', 'table'
+    ) as metadata,
+    format('auth_rls_init_plan_%s_%s_%s', schema_name, table_name, policy_name) as cache_key
+from
+    policies
+where
+    is_rls_active
+    -- NOTE: does not include realtime in support of monitoring policies on realtime.messages
+    and schema_name not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and (
+        -- Example: auth.uid()
+        (
+            qual like '%auth.uid()%'
+            and lower(qual) not like '%select auth.uid()%'
+        )
+        or (
+            qual like '%auth.jwt()%'
+            and lower(qual) not like '%select auth.jwt()%'
+        )
+        or (
+            qual like '%auth.role()%'
+            and lower(qual) not like '%select auth.role()%'
+        )
+        or (
+            qual like '%auth.email()%'
+            and lower(qual) not like '%select auth.email()%'
+        )
+        or (
+            qual like '%current\_setting(%)%'
+            and lower(qual) not like '%select current\_setting(%)%'
+        )
+        or (
+            with_check like '%auth.uid()%'
+            and lower(with_check) not like '%select auth.uid()%'
+        )
+        or (
+            with_check like '%auth.jwt()%'
+            and lower(with_check) not like '%select auth.jwt()%'
+        )
+        or (
+            with_check like '%auth.role()%'
+            and lower(with_check) not like '%select auth.role()%'
+        )
+        or (
+            with_check like '%auth.email()%'
+            and lower(with_check) not like '%select auth.email()%'
+        )
+        or (
+            with_check like '%current\_setting(%)%'
+            and lower(with_check) not like '%select current\_setting(%)%'
+        )
+    ))
+union all
+(
+select
+    'no_primary_key' as name,
+    'No Primary Key' as title,
+    'INFO' as level,
+    'EXTERNAL' as facing,
+    array['PERFORMANCE'] as categories,
+    'Detects if a table does not have a primary key. Tables without a primary key can be inefficient to interact with at scale.' as description,
+    format(
+        'Table \`%s.%s\` does not have a primary key',
+        pgns.nspname,
+        pgc.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0004_no_primary_key' as remediation,
+     jsonb_build_object(
+        'schema', pgns.nspname,
+        'name', pgc.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'no_primary_key_%s_%s',
+        pgns.nspname,
+        pgc.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class pgc
+    join pg_catalog.pg_namespace pgns
+        on pgns.oid = pgc.relnamespace
+    left join pg_catalog.pg_index pgi
+        on pgi.indrelid = pgc.oid
+    left join pg_catalog.pg_depend dep
+        on pgc.oid = dep.objid
+        and dep.deptype = 'e'
+where
+    pgc.relkind = 'r' -- regular tables
+    and pgns.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and dep.objid is null -- exclude tables owned by extensions
+group by
+    pgc.oid,
+    pgns.nspname,
+    pgc.relname
+having
+    max(coalesce(pgi.indisprimary, false)::int) = 0)
+union all
+(
+select
+    'unused_index' as name,
+    'Unused Index' as title,
+    'INFO' as level,
+    'EXTERNAL' as facing,
+    array['PERFORMANCE'] as categories,
+    'Detects if an index has never been used and may be a candidate for removal.' as description,
+    format(
+        'Index \`%s\` on table \`%s.%s\` has not been used',
+        psui.indexrelname,
+        psui.schemaname,
+        psui.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index' as remediation,
+    jsonb_build_object(
+        'schema', psui.schemaname,
+        'name', psui.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'unused_index_%s_%s_%s',
+        psui.schemaname,
+        psui.relname,
+        psui.indexrelname
+    ) as cache_key
+
+from
+    pg_catalog.pg_stat_user_indexes psui
+    join pg_catalog.pg_index pi
+        on psui.indexrelid = pi.indexrelid
+    left join pg_catalog.pg_depend dep
+        on psui.relid = dep.objid
+        and dep.deptype = 'e'
+where
+    psui.idx_scan = 0
+    and not pi.indisunique
+    and not pi.indisprimary
+    and dep.objid is null -- exclude tables owned by extensions
+    and psui.schemaname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    ))
+union all
+(
+select
+    'multiple_permissive_policies' as name,
+    'Multiple Permissive Policies' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['PERFORMANCE'] as categories,
+    'Detects if multiple permissive row level security policies are present on a table for the same \`role\` and \`action\` (e.g. insert). Multiple permissive policies are suboptimal for performance as each policy must be executed for every relevant query.' as description,
+    format(
+        'Table \`%s.%s\` has multiple permissive policies for role \`%s\` for action \`%s\`. Policies include \`%s\`',
+        n.nspname,
+        c.relname,
+        r.rolname,
+        act.cmd,
+        array_agg(p.polname order by p.polname)
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'multiple_permissive_policies_%s_%s_%s_%s',
+        n.nspname,
+        c.relname,
+        r.rolname,
+        act.cmd
+    ) as cache_key
+from
+    pg_catalog.pg_policy p
+    join pg_catalog.pg_class c
+        on p.polrelid = c.oid
+    join pg_catalog.pg_namespace n
+        on c.relnamespace = n.oid
+    join pg_catalog.pg_roles r
+        on p.polroles @> array[r.oid]
+        or p.polroles = array[0::oid]
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e',
+    lateral (
+        select x.cmd
+        from unnest((
+            select
+                case p.polcmd
+                    when 'r' then array['SELECT']
+                    when 'a' then array['INSERT']
+                    when 'w' then array['UPDATE']
+                    when 'd' then array['DELETE']
+                    when '*' then array['SELECT', 'INSERT', 'UPDATE', 'DELETE']
+                    else array['ERROR']
+                end as actions
+        )) x(cmd)
+    ) act(cmd)
+where
+    c.relkind = 'r' -- regular tables
+    and p.polpermissive -- policy is permissive
+    and n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and r.rolname not like 'pg_%'
+    and r.rolname not like 'supabase%admin'
+    and not r.rolbypassrls
+    and dep.objid is null -- exclude tables owned by extensions
+group by
+    n.nspname,
+    c.relname,
+    r.rolname,
+    act.cmd
+having
+    count(1) > 1)
+union all
+(
+select
+    'policy_exists_rls_disabled' as name,
+    'Policy Exists RLS Disabled' as title,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects cases where row level security (RLS) policies have been created, but RLS has not been enabled for the underlying table.' as description,
+    format(
+        'Table \`%s.%s\` has RLS policies but RLS is not enabled on the table. Policies include %s.',
+        n.nspname,
+        c.relname,
+        array_agg(p.polname order by p.polname)
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0007_policy_exists_rls_disabled' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'policy_exists_rls_disabled_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_policy p
+    join pg_catalog.pg_class c
+        on p.polrelid = c.oid
+    join pg_catalog.pg_namespace n
+        on c.relnamespace = n.oid
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
+where
+    c.relkind = 'r' -- regular tables
+    and n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    -- RLS is disabled
+    and not c.relrowsecurity
+    and dep.objid is null -- exclude tables owned by extensions
+group by
+    n.nspname,
+    c.relname)
+union all
+(
+select
+    'rls_enabled_no_policy' as name,
+    'RLS Enabled No Policy' as title,
+    'INFO' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects cases where row level security (RLS) has been enabled on a table but no RLS policies have been created.' as description,
+    format(
+        'Table \`%s.%s\` has RLS enabled, but no policies exist',
+        n.nspname,
+        c.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0008_rls_enabled_no_policy' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'rls_enabled_no_policy_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class c
+    left join pg_catalog.pg_policy p
+        on p.polrelid = c.oid
+    join pg_catalog.pg_namespace n
+        on c.relnamespace = n.oid
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
+where
+    c.relkind = 'r' -- regular tables
+    and n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    -- RLS is enabled
+    and c.relrowsecurity
+    and p.polname is null
+    and dep.objid is null -- exclude tables owned by extensions
+group by
+    n.nspname,
+    c.relname)
+union all
+(
+select
+    'duplicate_index' as name,
+    'Duplicate Index' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['PERFORMANCE'] as categories,
+    'Detects cases where two ore more identical indexes exist.' as description,
+    format(
+        'Table \`%s.%s\` has identical indexes %s. Drop all except one of them',
+        n.nspname,
+        c.relname,
+        array_agg(pi.indexname order by pi.indexname)
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0009_duplicate_index' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', case
+            when c.relkind = 'r' then 'table'
+            when c.relkind = 'm' then 'materialized view'
+            else 'ERROR'
+        end,
+        'indexes', array_agg(pi.indexname order by pi.indexname)
+    ) as metadata,
+    format(
+        'duplicate_index_%s_%s_%s',
+        n.nspname,
+        c.relname,
+        array_agg(pi.indexname order by pi.indexname)
+    ) as cache_key
+from
+    pg_catalog.pg_indexes pi
+    join pg_catalog.pg_namespace n
+        on n.nspname  = pi.schemaname
+    join pg_catalog.pg_class c
+        on pi.tablename = c.relname
+        and n.oid = c.relnamespace
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
+where
+    c.relkind in ('r', 'm') -- tables and materialized views
+    and n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and dep.objid is null -- exclude tables owned by extensions
+group by
+    n.nspname,
+    c.relkind,
+    c.relname,
+    replace(pi.indexdef, pi.indexname, '')
+having
+    count(*) > 1)
+union all
+(
+select
+    'security_definer_view' as name,
+    'Security Definer View' as title,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects views defined with the SECURITY DEFINER property. These views enforce Postgres permissions and row level security policies (RLS) of the view creator, rather than that of the querying user' as description,
+    format(
+        'View \`%s.%s\` is defined with the SECURITY DEFINER property',
+        n.nspname,
+        c.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0010_security_definer_view' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'view'
+    ) as metadata,
+    format(
+        'security_definer_view_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n
+        on n.oid = c.relnamespace
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
+where
+    c.relkind = 'v'
+    and (
+        pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
+    )
+    and substring(pg_catalog.version() from 'PostgreSQL ([0-9]+)') >= '15' -- security invoker was added in pg15
+    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and dep.objid is null -- exclude views owned by extensions
+    and not (
+        lower(coalesce(c.reloptions::text,'{}'))::text[]
+        && array[
+            'security_invoker=1',
+            'security_invoker=true',
+            'security_invoker=yes',
+            'security_invoker=on'
+        ]
+    ))
+union all
+(
+select
+    'function_search_path_mutable' as name,
+    'Function Search Path Mutable' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects functions where the search_path parameter is not set.' as description,
+    format(
+        'Function \`%s.%s\` has a role mutable search_path',
+        n.nspname,
+        p.proname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0011_function_search_path_mutable' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', p.proname,
+        'type', 'function'
+    ) as metadata,
+    format(
+        'function_search_path_mutable_%s_%s_%s',
+        n.nspname,
+        p.proname,
+        md5(p.prosrc) -- required when function is polymorphic
+    ) as cache_key
+from
+    pg_catalog.pg_proc p
+    join pg_catalog.pg_namespace n
+        on p.pronamespace = n.oid
+    left join pg_catalog.pg_depend dep
+        on p.oid = dep.objid
+        and dep.deptype = 'e'
+where
+    n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and dep.objid is null -- exclude functions owned by extensions
+    -- Search path not set
+    and not exists (
+        select 1
+        from unnest(coalesce(p.proconfig, '{}')) as config
+        where config like 'search_path=%'
+    ))
+union all
+(
+select
+    'rls_disabled_in_public' as name,
+    'RLS Disabled in Public' as title,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects cases where row level security (RLS) has not been enabled on tables in schemas exposed to PostgREST' as description,
+    format(
+        'Table \`%s.%s\` is public, but RLS has not been enabled.',
+        n.nspname,
+        c.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0013_rls_disabled_in_public' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'rls_disabled_in_public_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n
+        on c.relnamespace = n.oid
+where
+    c.relkind = 'r' -- regular tables
+    -- RLS is disabled
+    and not c.relrowsecurity
+    and (
+        pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
+    )
+    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    ))
+union all
+(
+select
+    'extension_in_public' as name,
+    'Extension in Public' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects extensions installed in the \`public\` schema.' as description,
+    format(
+        'Extension \`%s\` is installed in the public schema. Move it to another schema.',
+        pe.extname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0014_extension_in_public' as remediation,
+    jsonb_build_object(
+        'schema', pe.extnamespace::regnamespace,
+        'name', pe.extname,
+        'type', 'extension'
+    ) as metadata,
+    format(
+        'extension_in_public_%s',
+        pe.extname
+    ) as cache_key
+from
+    pg_catalog.pg_extension pe
+where
+    -- plpgsql is installed by default in public and outside user control
+    -- confirmed safe
+    pe.extname not in ('plpgsql')
+    -- Scoping this to public is not optimal. Ideally we would use the postgres
+    -- search path. That currently isn't available via SQL. In other lints
+    -- we have used has_schema_privilege('anon', 'extensions', 'USAGE') but that
+    -- is not appropriate here as it would evaluate true for the extensions schema
+    and pe.extnamespace::regnamespace::text = 'public')
+union all
+(
+with policies as (
+    select
+        nsp.nspname as schema_name,
+        pb.tablename as table_name,
+        polname as policy_name,
+        qual,
+        with_check
+    from
+        pg_catalog.pg_policy pa
+        join pg_catalog.pg_class pc
+            on pa.polrelid = pc.oid
+        join pg_catalog.pg_namespace nsp
+            on pc.relnamespace = nsp.oid
+        join pg_catalog.pg_policies pb
+            on pc.relname = pb.tablename
+            and nsp.nspname = pb.schemaname
+            and pa.polname = pb.policyname
+)
+select
+    'rls_references_user_metadata' as name,
+    'RLS references user metadata' as title,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects when Supabase Auth user_metadata is referenced insecurely in a row level security (RLS) policy.' as description,
+    format(
+        'Table \`%s.%s\` has a row level security policy \`%s\` that references Supabase Auth \`user_metadata\`. \`user_metadata\` is editable by end users and should never be used in a security context.',
+        schema_name,
+        table_name,
+        policy_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0015_rls_references_user_metadata' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', table_name,
+        'type', 'table'
+    ) as metadata,
+    format('rls_references_user_metadata_%s_%s_%s', schema_name, table_name, policy_name) as cache_key
+from
+    policies
+where
+    schema_name not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and (
+        -- Example: auth.jwt() -> 'user_metadata'
+        -- False positives are possible, but it isn't practical to string match
+        -- If false positive rate is too high, this expression can iterate
+        qual like '%auth.jwt()%user_metadata%'
+        or qual like '%current_setting(%request.jwt.claims%)%user_metadata%'
+        or with_check like '%auth.jwt()%user_metadata%'
+        or with_check like '%current_setting(%request.jwt.claims%)%user_metadata%'
+    ))
+union all
+(
+select
+    'materialized_view_in_api' as name,
+    'Materialized View in API' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects materialized views that are accessible over the Data APIs.' as description,
+    format(
+        'Materialized view \`%s.%s\` is selectable by anon or authenticated roles',
+        n.nspname,
+        c.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0016_materialized_view_in_api' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'materialized view'
+    ) as metadata,
+    format(
+        'materialized_view_in_api_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n
+        on n.oid = c.relnamespace
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
+where
+    c.relkind = 'm'
+    and (
+        pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
+    )
+    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and dep.objid is null)
+union all
+(
+select
+    'foreign_table_in_api' as name,
+    'Foreign Table in API' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects foreign tables that are accessible over APIs. Foreign tables do not respect row level security policies.' as description,
+    format(
+        'Foreign table \`%s.%s\` is accessible over APIs',
+        n.nspname,
+        c.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0017_foreign_table_in_api' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'foreign table'
+    ) as metadata,
+    format(
+        'foreign_table_in_api_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n
+        on n.oid = c.relnamespace
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
+where
+    c.relkind = 'f'
+    and (
+        pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
+    )
+    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname not in (
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and dep.objid is null)
+union all
+(
+select
+    'unsupported_reg_types' as name,
+    'Unsupported reg types' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Identifies columns using unsupported reg* types outside pg_catalog schema, which prevents database upgrades using pg_upgrade.' as description,
+    format(
+        'Table \`%s.%s\` has a column \`%s\` with unsupported reg* type \`%s\`.',
+        n.nspname,
+        c.relname,
+        a.attname,
+        t.typname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=unsupported_reg_types' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'column', a.attname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'unsupported_reg_types_%s_%s_%s',
+        n.nspname,
+        c.relname,
+        a.attname
+    ) AS cache_key
+from
+    pg_catalog.pg_attribute a
+    join pg_catalog.pg_class c
+        on a.attrelid = c.oid
+    join pg_catalog.pg_namespace n
+        on c.relnamespace = n.oid
+    join pg_catalog.pg_type t
+        on a.atttypid = t.oid
+    join pg_catalog.pg_namespace tn
+        on t.typnamespace = tn.oid
+where
+    tn.nspname = 'pg_catalog'
+    and t.typname in ('regcollation', 'regconfig', 'regdictionary', 'regnamespace', 'regoper', 'regoperator', 'regproc', 'regprocedure')
+    and n.nspname not in ('pg_catalog', 'information_schema', 'pgsodium'))
+union all
+(
+select
+    'insecure_queue_exposed_in_api' as name,
+    'Insecure Queue Exposed in API' as title,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects cases where an insecure Queue is exposed over Data APIs' as description,
+    format(
+        'Table \`%s.%s\` is public, but RLS has not been enabled.',
+        n.nspname,
+        c.relname
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0019_insecure_queue_exposed_in_api' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'rls_disabled_in_public_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n
+        on c.relnamespace = n.oid
+where
+    c.relkind in ('r', 'I') -- regular or partitioned tables
+    and not c.relrowsecurity -- RLS is disabled
+    and (
+        pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
+    )
+    and n.nspname = 'pgmq' -- tables in the pgmq schema
+    and c.relname like 'q_%' -- only queue tables
+    -- Constant requirements
+    and 'pgmq_public' = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ','))))))
+union all
+(
+with constants as (
+    select current_setting('block_size')::numeric as bs, 23 as hdr, 4 as ma
+),
+
+bloat_info as (
+    select
+        ma,
+        bs,
+        schemaname,
+        tablename,
+        (datawidth + (hdr + ma - (case when hdr % ma = 0 then ma else hdr % ma end)))::numeric as datahdr,
+        (maxfracsum * (nullhdr + ma - (case when nullhdr % ma = 0 then ma else nullhdr % ma end))) as nullhdr2
+    from (
+        select
+            schemaname,
+            tablename,
+            hdr,
+            ma,
+            bs,
+            sum((1 - null_frac) * avg_width) as datawidth,
+            max(null_frac) as maxfracsum,
+            hdr + (
+                select 1 + count(*) / 8
+                from pg_stats s2
+                where
+                    null_frac <> 0
+                    and s2.schemaname = s.schemaname
+                    and s2.tablename = s.tablename
+            ) as nullhdr
+        from pg_stats s, constants
+        group by 1, 2, 3, 4, 5
+    ) as foo
+),
+
+table_bloat as (
+    select
+        schemaname,
+        tablename,
+        cc.relpages,
+        bs,
+        ceil((cc.reltuples * ((datahdr + ma -
+          (case when datahdr % ma = 0 then ma else datahdr % ma end)) + nullhdr2 + 4)) / (bs - 20::float)) as otta
+    from
+        bloat_info
+        join pg_class cc
+            on cc.relname = bloat_info.tablename
+        join pg_namespace nn
+            on cc.relnamespace = nn.oid
+            and nn.nspname = bloat_info.schemaname
+            and nn.nspname <> 'information_schema'
+        where
+            cc.relkind = 'r'
+            and cc.relam = (select oid from pg_am where amname = 'heap')
+),
+
+bloat_data as (
+    select
+        'table' as type,
+        schemaname,
+        tablename as object_name,
+        round(case when otta = 0 then 0.0 else table_bloat.relpages / otta::numeric end, 1) as bloat,
+        case when relpages < otta then 0 else (bs * (table_bloat.relpages - otta)::bigint)::bigint end as raw_waste
+    from
+        table_bloat
+)
+
+select
+    'table_bloat' as name,
+    'Table Bloat' as title,
+    'INFO' as level,
+    'EXTERNAL' as facing,
+    array['PERFORMANCE'] as categories,
+    'Detects if a table has excess bloat and may benefit from maintenance operations like vacuum full or cluster.' as description,
+    format(
+        'Table `%s`.`%s` has excessive bloat',
+        bloat_data.schemaname,
+        bloat_data.object_name
+    ) as detail,
+    'Consider running vacuum full (WARNING: incurs downtime) and tweaking autovacuum settings to reduce bloat.' as remediation,
+    jsonb_build_object(
+        'schema', bloat_data.schemaname,
+        'name', bloat_data.object_name,
+        'type', bloat_data.type
+    ) as metadata,
+    format(
+        'table_bloat_%s_%s',
+        bloat_data.schemaname,
+        bloat_data.object_name
+    ) as cache_key
+from
+    bloat_data
+where
+    bloat > 70.0
+    and raw_waste > (20 * 1024 * 1024) -- filter for waste > 200 MB
+order by
+    schemaname,
+    object_name)
+union all
+(
+select
+    'fkey_to_auth_unique' as name,
+    'Foreign Key to Auth Unique Constraint' as title,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects user defined foreign keys to unique constraints in the auth schema.' as description,
+    format(
+        'Table `%s`.`%s` has a foreign key `%s` referencing an auth unique constraint',
+        n.nspname, -- referencing schema
+        c_rel.relname, -- referencing table
+        c.conname -- fkey name
+    ) as detail,
+    'Drop the foreign key constraint that references the auth schema.' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c_rel.relname,
+        'foreign_key', c.conname
+    ) as metadata,
+    format(
+        'fkey_to_auth_unique_%s_%s_%s',
+        n.nspname, -- referencing schema
+        c_rel.relname, -- referencing table
+        c.conname
+    ) as cache_key
+from
+    pg_catalog.pg_constraint c
+    join pg_catalog.pg_class c_rel
+        on c.conrelid = c_rel.oid
+    join pg_catalog.pg_namespace n
+        on c_rel.relnamespace = n.oid
+    join pg_catalog.pg_class ref_rel
+        on c.confrelid = ref_rel.oid
+    join pg_catalog.pg_namespace cn
+        on ref_rel.relnamespace = cn.oid
+    join pg_catalog.pg_index i
+        on c.conindid = i.indexrelid
+where c.contype = 'f'
+    and cn.nspname = 'auth'
+    and i.indisunique
+    and not i.indisprimary)
+union all
+(
+select
+    'extension_versions_outdated' as name,
+    'Extension Versions Outdated' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects extensions that are not using the default (recommended) version.' as description,
+    format(
+        'Extension `%s` is using version `%s` but version `%s` is available. Using outdated extension versions may expose the database to security vulnerabilities.',
+        ext.name,
+        ext.installed_version,
+        ext.default_version
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0022_extension_versions_outdated' as remediation,
+    jsonb_build_object(
+        'extension_name', ext.name,
+        'installed_version', ext.installed_version,
+        'default_version', ext.default_version
+    ) as metadata,
+    format(
+        'extension_versions_outdated_%s_%s',
+        ext.name,
+        ext.installed_version
+    ) as cache_key
+from
+    pg_catalog.pg_available_extensions ext
+join
+    -- ignore versions not in pg_available_extension_versions
+    -- e.g. residue of pg_upgrade
+    pg_catalog.pg_available_extension_versions extv
+    on extv.name = ext.name and extv.installed
+where
+    ext.installed_version is not null
+    and ext.default_version is not null
+    and ext.installed_version != ext.default_version
+order by
+    ext.name)
+union all
+(
+-- Detects tables exposed via API that contain columns with sensitive names
+-- Inspired by patterns from security scanners that detect PII/credential exposure
+with sensitive_patterns as (
+    select unnest(array[
+        -- Authentication & Credentials
+        'password', 'passwd', 'pwd', 'passphrase',
+        'secret', 'secret_key', 'private_key', 'api_key', 'apikey',
+        'auth_key', 'token', 'jwt', 'access_token', 'refresh_token',
+        'oauth_token', 'session_token', 'bearer_token', 'auth_code',
+        'session_id', 'session_key', 'session_secret',
+        'recovery_code', 'backup_code', 'verification_code',
+        'otp', 'two_factor', '2fa_secret', '2fa_code',
+        -- Personal Identifiers
+        'ssn', 'social_security', 'social_security_number',
+        'driver_license', 'drivers_license', 'license_number',
+        'passport_number', 'passport_id', 'national_id', 'tax_id',
+        -- Financial Information
+        'credit_card', 'card_number', 'cvv', 'cvc', 'cvn',
+        'bank_account', 'account_number', 'routing_number',
+        'iban', 'swift_code', 'bic',
+        -- Health & Medical
+        'health_record', 'medical_record', 'patient_id',
+        'insurance_number', 'health_insurance', 'medical_insurance',
+        'treatment',
+        -- Device Identifiers
+        'mac_address', 'macaddr', 'imei', 'device_uuid',
+        -- Digital Keys & Certificates
+        'pgp_key', 'gpg_key', 'ssh_key', 'certificate',
+        'license_key', 'activation_key',
+        -- Biometric Data
+        'facial_recognition'
+    ]) as pattern
+),
+exposed_tables as (
+    select
+        n.nspname as schema_name,
+        c.relname as table_name,
+        c.oid as table_oid
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        c.relkind = 'r' -- regular tables
+        and (
+            pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+            or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
+        )
+        and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+        and n.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+        -- Only flag tables without RLS enabled
+        and not c.relrowsecurity
+),
+sensitive_columns as (
+    select
+        et.schema_name,
+        et.table_name,
+        a.attname as column_name,
+        sp.pattern as matched_pattern
+    from
+        exposed_tables et
+        join pg_catalog.pg_attribute a
+            on a.attrelid = et.table_oid
+            and a.attnum > 0
+            and not a.attisdropped
+        cross join sensitive_patterns sp
+    where
+        -- Match column name against sensitive patterns (case insensitive), allowing '-'/'_' variants
+        replace(lower(a.attname), '-', '_') = sp.pattern
+)
+select
+    'sensitive_columns_exposed' as name,
+    'Sensitive Columns Exposed' as title,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects tables exposed via API that contain columns with potentially sensitive data (PII, credentials, financial info) without RLS protection.' as description,
+    format(
+        'Table `%s.%s` is exposed via API without RLS and contains potentially sensitive column(s): %s. This may lead to data exposure.',
+        schema_name,
+        table_name,
+        string_agg(distinct column_name, ', ' order by column_name)
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0023_sensitive_columns_exposed' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', table_name,
+        'type', 'table',
+        'sensitive_columns', array_agg(distinct column_name order by column_name),
+        'matched_patterns', array_agg(distinct matched_pattern order by matched_pattern)
+    ) as metadata,
+    format(
+        'sensitive_columns_exposed_%s_%s',
+        schema_name,
+        table_name
+    ) as cache_key
+from
+    sensitive_columns
+group by
+    schema_name,
+    table_name
+order by
+    schema_name,
+    table_name)
+union all
+(
+-- Detects RLS policies that are overly permissive (e.g., USING (true), USING (1=1))
+-- These policies effectively disable row-level security while giving a false sense of security
+with policies as (
+    select
+        nsp.nspname as schema_name,
+        pb.tablename as table_name,
+        pc.relrowsecurity as is_rls_active,
+        pa.polname as policy_name,
+        pa.polpermissive as is_permissive,
+        pa.polroles as role_oids,
+        (select array_agg(r::regrole::text) from unnest(pa.polroles) as x(r)) as roles,
+        case pa.polcmd
+            when 'r' then 'SELECT'
+            when 'a' then 'INSERT'
+            when 'w' then 'UPDATE'
+            when 'd' then 'DELETE'
+            when '*' then 'ALL'
+        end as command,
+        pb.qual,
+        pb.with_check,
+        -- Normalize expressions by removing whitespace and lowercasing
+        replace(replace(replace(lower(coalesce(pb.qual, '')), ' ', ''), E'\n', ''), E'\t', '') as normalized_qual,
+        replace(replace(replace(lower(coalesce(pb.with_check, '')), ' ', ''), E'\n', ''), E'\t', '') as normalized_with_check
+    from
+        pg_catalog.pg_policy pa
+        join pg_catalog.pg_class pc
+            on pa.polrelid = pc.oid
+        join pg_catalog.pg_namespace nsp
+            on pc.relnamespace = nsp.oid
+        join pg_catalog.pg_policies pb
+            on pc.relname = pb.tablename
+            and nsp.nspname = pb.schemaname
+            and pa.polname = pb.policyname
+    where
+        pc.relkind = 'r' -- regular tables
+        and nsp.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+),
+permissive_patterns as (
+    select
+        p.*,
+        -- Check for always-true USING clause patterns
+        -- Note: SELECT with (true) is often intentional and documented, so we only flag UPDATE/DELETE
+        case when (
+            command in ('UPDATE', 'DELETE', 'ALL')
+            and (
+                normalized_qual in ('true', '(true)', '1=1', '(1=1)')
+                -- Empty or null qual on permissive policy means allow all
+                or (qual is null and is_permissive)
+            )
+        ) then true else false end as has_permissive_using,
+        -- Check for always-true WITH CHECK clause patterns
+        case when (
+            normalized_with_check in ('true', '(true)', '1=1', '(1=1)')
+            -- Empty with_check on INSERT means allow all (INSERT has no USING to fall back on)
+            or (with_check is null and is_permissive and command = 'INSERT')
+            -- Empty with_check on UPDATE/ALL with permissive USING means allow all writes
+            or (with_check is null and is_permissive and command in ('UPDATE', 'ALL')
+                and normalized_qual in ('true', '(true)', '1=1', '(1=1)'))
+        ) then true else false end as has_permissive_with_check
+    from
+        policies p
+    where
+        -- Only check tables with RLS enabled (otherwise it's a different lint)
+        is_rls_active
+        -- Only check permissive policies (restrictive policies with true are less dangerous)
+        and is_permissive
+        -- Only flag policies that apply to anon or authenticated roles (or public/all roles)
+        and (
+            role_oids = array[0::oid] -- public (all roles)
+            or exists (
+                select 1
+                from unnest(role_oids) as r
+                where r::regrole::text in ('anon', 'authenticated')
+            )
+        )
+)
+select
+    'rls_policy_always_true' as name,
+    'RLS Policy Always True' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects RLS policies that use overly permissive expressions like \`USING (true)\` or \`WITH CHECK (true)\` for UPDATE, DELETE, or INSERT operations. SELECT policies with \`USING (true)\` are intentionally excluded as this pattern is often used deliberately for public read access.' as description,
+    format(
+        'Table `%s.%s` has an RLS policy `%s` for `%s` that allows unrestricted access%s. This effectively bypasses row-level security for %s.',
+        schema_name,
+        table_name,
+        policy_name,
+        command,
+        case
+            when has_permissive_using and has_permissive_with_check then ' (both USING and WITH CHECK are always true)'
+            when has_permissive_using then ' (USING clause is always true)'
+            when has_permissive_with_check then ' (WITH CHECK clause is always true)'
+            else ''
+        end,
+        array_to_string(roles, ', ')
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0024_permissive_rls_policy' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', table_name,
+        'type', 'table',
+        'policy_name', policy_name,
+        'command', command,
+        'roles', roles,
+        'qual', qual,
+        'with_check', with_check,
+        'permissive_using', has_permissive_using,
+        'permissive_with_check', has_permissive_with_check
+    ) as metadata,
+    format(
+        'rls_policy_always_true_%s_%s_%s',
+        schema_name,
+        table_name,
+        policy_name
+    ) as cache_key
+from
+    permissive_patterns
+where
+    has_permissive_using or has_permissive_with_check
+order by
+    schema_name,
+    table_name,
+    policy_name)
+union all
+(
+with public_buckets as (
+    -- Read storage.buckets at runtime so the lint can load even when storage is not installed.
+    select
+        (xpath('/row/id/text()', bucket_xml))[1]::text as bucket_id,
+        (xpath('/row/name/text()', bucket_xml))[1]::text as bucket_name
+    from unnest(
+        case when pg_catalog.to_regclass('storage.buckets') is not null
+            then xpath(
+                '/table/row',
+                pg_catalog.query_to_xml(
+                    'select id, name from storage.buckets where public = true order by id',
+                    false,
+                    false,
+                    ''
+                )
+            )
+            else array[]::xml[]
+        end
+    ) as bucket_xml
+),
+matching_policies as (
+    select
+        b.bucket_id,
+        b.bucket_name,
+        p.policyname
+    from
+        public_buckets b
+        join pg_catalog.pg_policies p
+            on p.schemaname = 'storage'
+            and p.tablename = 'objects'
+            and p.cmd in ('SELECT', 'ALL')
+            and p.permissive = 'PERMISSIVE'
+            and p.roles && array['public'::name, 'anon'::name, 'authenticated'::name]
+    where
+        (
+            p.qual is null
+            or replace(replace(replace(lower(p.qual), ' ', ''), E'\n', ''), E'\t', '')
+                in ('true', '(true)', '1=1', '(1=1)')
+            or exists (
+                select
+                    1
+                from
+                    pg_catalog.regexp_match(
+                        p.qual,
+                        $re$\A\s*\(*\s*bucket_id\s*=\s*('(?:[^']|'')*')(\s*::\s*[[:alnum:]_\.]+)?\s*\)*\s*\Z$re$,
+                        'i'
+                    ) as bucket_match(matches)
+                where
+                    bucket_match.matches[1] = '''' || replace(b.bucket_id, '''', '''''') || ''''
+            )
+        )
+),
+affected_buckets as (
+    select
+        bucket_id,
+        bucket_name,
+        array_agg(policyname order by policyname) as policy_names,
+        count(*)::int as policy_count
+    from
+        matching_policies
+    group by
+        bucket_id,
+        bucket_name
+)
+select
+    'public_bucket_allows_listing' as name,
+    'Public Bucket Allows Listing' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects public storage buckets with a broad SELECT policy on `storage.objects`, which allows clients to list all files in the bucket.' as description,
+    format(
+        'Public bucket `%s` has %s broad SELECT %s on `storage.objects` (%s), allowing clients to list all files. Public buckets don''t need this for object URL access and it may expose more data than intended.',
+        bucket_name,
+        policy_count,
+        case
+            when policy_count = 1 then 'policy'
+            else 'policies'
+        end,
+        array_to_string(policy_names, ', ')
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0025_public_bucket_allows_listing' as remediation,
+    jsonb_build_object(
+        'schema', 'storage',
+        'name', bucket_name,
+        'type', 'bucket',
+        'bucket_id', bucket_id,
+        'bucket_name', bucket_name,
+        'policy_names', policy_names,
+        'policy_count', policy_count
+    ) as metadata,
+    format('public_bucket_allows_listing_%s', bucket_id) as cache_key
+from
+    affected_buckets
+order by
+    bucket_id)
+union all
+(
+-- Detects tables, views, materialized views, and foreign tables whose
+-- schema is visible to the `anon` role through pg_graphql introspection.
+-- pg_graphql introspection reflects the calling role's Postgres
+-- privileges: if `anon` can SELECT an object, its name, columns, and
+-- relationships are visible via /graphql/v1 to anyone with the public
+-- anon key, even when RLS is enabled.
+--
+-- See lint 0027 for the equivalent check against the `authenticated`
+-- role. In default Supabase projects the two roles share the same
+-- default-privilege grants, so revoking from `anon` alone often leaves
+-- the introspection response served to any signed-up user unchanged.
+--
+-- The privilege check uses has_column_privilege rather than
+-- has_table_privilege so that column-level grants such as
+-- `GRANT SELECT (some_col) ON t TO anon` are also caught: pg_graphql
+-- exposes a relation in introspection if any column is selectable to
+-- the calling role (`load_sql_context.sql:327`,
+-- `is_column_selectable`).
+--
+-- The relkind set ('r','v','m','f') matches pg_graphql's own filter in
+-- load_sql_context.sql. Partitioned table roots ('p') are excluded
+-- because pg_graphql does not expose them their leaf partitions ('r')
+-- are still picked up.
+with graphql_installed as (
+    select 1 as installed
+    from pg_catalog.pg_extension
+    where extname = 'pg_graphql'
+),
+exposed_objects as (
+    select
+        n.nspname as schema_name,
+        c.relname as object_name,
+        c.relkind as object_relkind,
+        case c.relkind
+            when 'r' then 'table'
+            when 'v' then 'view'
+            when 'm' then 'materialized view'
+            when 'f' then 'foreign table'
+        end as object_type
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        c.relkind in ('r', 'v', 'm', 'f') -- tables, views, materialized views, foreign tables matches pg_graphql
+        and exists (
+            -- Any selectable column (table-level or column-level grant)
+            select 1
+            from pg_catalog.pg_attribute a
+            where a.attrelid = c.oid
+                and a.attnum > 0
+                and not a.attisdropped
+                and pg_catalog.has_column_privilege('anon', c.oid, a.attnum, 'SELECT')
+        )
+        and exists (select 1 from graphql_installed)
+        and n.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+)
+select
+    'pg_graphql_anon_table_exposed' as name,
+    'Public Can See Object in GraphQL Schema' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects tables, views, materialized views, and foreign tables that are visible in the GraphQL schema to anyone using your public anon key. Revoke `SELECT` from `anon` for objects that should not be discoverable before sign-in, and check lint 0027 for the matching signed-in-user exposure.' as description,
+    format(
+        '%s `%s.%s` is visible in the GraphQL schema because the `anon` role can `SELECT` it. Revoke `SELECT` from `anon` if it should not be discoverable without signing in.',
+        object_type,
+        schema_name,
+        object_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0026_pg_graphql_anon_table_exposed' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', object_name,
+        'type', object_type
+    ) as metadata,
+    format(
+        'pg_graphql_anon_table_exposed_%s_%s',
+        schema_name,
+        object_name
+    ) as cache_key
+from
+    exposed_objects
+order by
+    schema_name,
+    object_name)
+union all
+(
+-- Detects tables, views, materialized views, and foreign tables whose
+-- schema is visible to the `authenticated` role through pg_graphql
+-- introspection. pg_graphql introspection reflects the calling role's
+-- Postgres privileges: if `authenticated` can SELECT an object, its
+-- name, columns, and relationships are visible via /graphql/v1 to any
+-- signed-up user, even when RLS is enabled.
+--
+-- See lint 0026 for the equivalent check against the `anon` role. In
+-- default Supabase projects the two roles share the same
+-- default-privilege grants — `ALTER DEFAULT PRIVILEGES FOR ROLE
+-- supabase_admin ... TO anon, authenticated, service_role` — so an
+-- object readable by `anon` is typically also readable by
+-- `authenticated`. If signup is open or auto-confirm, "authenticated"
+-- is in practice anyone with a throwaway email rather than a
+-- meaningfully smaller audience.
+--
+-- The privilege check uses has_column_privilege rather than
+-- has_table_privilege so that column-level grants such as
+-- `GRANT SELECT (some_col) ON t TO authenticated` are also caught:
+-- pg_graphql exposes a relation in introspection if any column is
+-- selectable to the calling role (`load_sql_context.sql:327`,
+-- `is_column_selectable`).
+--
+-- The relkind set ('r','v','m','f') matches pg_graphql's own filter in
+-- load_sql_context.sql. Partitioned table roots ('p') are excluded
+-- because pg_graphql does not expose them their leaf partitions ('r')
+-- are still picked up.
+with graphql_installed as (
+    select 1 as installed
+    from pg_catalog.pg_extension
+    where extname = 'pg_graphql'
+),
+exposed_objects as (
+    select
+        n.nspname as schema_name,
+        c.relname as object_name,
+        c.relkind as object_relkind,
+        case c.relkind
+            when 'r' then 'table'
+            when 'v' then 'view'
+            when 'm' then 'materialized view'
+            when 'f' then 'foreign table'
+        end as object_type
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        c.relkind in ('r', 'v', 'm', 'f') -- tables, views, materialized views, foreign tables matches pg_graphql
+        and exists (
+            -- Any selectable column (table-level or column-level grant)
+            select 1
+            from pg_catalog.pg_attribute a
+            where a.attrelid = c.oid
+                and a.attnum > 0
+                and not a.attisdropped
+                and pg_catalog.has_column_privilege('authenticated', c.oid, a.attnum, 'SELECT')
+        )
+        and exists (select 1 from graphql_installed)
+        and n.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+)
+select
+    'pg_graphql_authenticated_table_exposed' as name,
+    'Signed-In Users Can See Object in GraphQL Schema' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects tables, views, materialized views, and foreign tables that are visible in the GraphQL schema to signed-in users. Revoke `SELECT` from `authenticated` for objects that signed-in users should not discover, and check lint 0026 for the matching public exposure.' as description,
+    format(
+        '%s `%s.%s` is visible in the GraphQL schema to signed-in users because the `authenticated` role can `SELECT` it. Revoke `SELECT` from `authenticated` if it should not be discoverable to every account.',
+        object_type,
+        schema_name,
+        object_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0027_pg_graphql_authenticated_table_exposed' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', object_name,
+        'type', object_type
+    ) as metadata,
+    format(
+        'pg_graphql_authenticated_table_exposed_%s_%s',
+        schema_name,
+        object_name
+    ) as cache_key
+from
+    exposed_objects
+order by
+    schema_name,
+    object_name)
+union all
+(
+-- Detects SECURITY DEFINER functions that the `anon` role has EXECUTE
+-- on. SECURITY DEFINER functions run with the privileges of their
+-- owner (typically a superuser-equivalent role) rather than the
+-- caller, so they bypass RLS on every table they read or write.
+-- Granting EXECUTE to `anon` therefore lets any holder of the public
+-- anon key invoke a privileged operation through PostgREST
+-- `/rest/v1/rpc/<name>`, and through `/graphql/v1` Query/Mutation
+-- fields when pg_graphql is installed and the return type is
+-- supported.
+--
+-- See lint 0029 for the equivalent check against the `authenticated`
+-- role. Together with 0026/0027 they cover the four direct
+-- exposure paths: anon-vs-authenticated × table-vs-function.
+--
+-- This lint deliberately does not gate on pg_graphql being installed:
+-- PostgREST exposes `/rest/v1/rpc` independently and is the more
+-- commonly deployed surface for the same risk.
+select
+    'anon_security_definer_function_executable' as name,
+    'Public Can Execute SECURITY DEFINER Function' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects `SECURITY DEFINER` functions that are callable without signing in. Revoke `EXECUTE`, switch the function to `SECURITY INVOKER`, or move it out of your exposed API schema if it is not meant to be public.' as description,
+    format(
+        'Function `%s.%s(%s)` can be executed by the `anon` role as a `SECURITY DEFINER` function via `/rest/v1/rpc/%s`. Revoke `EXECUTE` or switch it to `SECURITY INVOKER` if that is not intentional.',
+        schema_name,
+        function_name,
+        function_args,
+        function_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', function_name,
+        'arguments', function_args,
+        'language', function_language,
+        'security_definer', true
+    ) as metadata,
+    format(
+        'anon_security_definer_function_executable_%s_%s_%s',
+        schema_name,
+        function_name,
+        function_args
+    ) as cache_key
+from
+    (
+        select
+            n.nspname as schema_name,
+            p.proname as function_name,
+            pg_catalog.pg_get_function_identity_arguments(p.oid) as function_args,
+            l.lanname as function_language
+        from
+            pg_catalog.pg_proc p
+            join pg_catalog.pg_namespace n
+                on p.pronamespace = n.oid
+            join pg_catalog.pg_language l
+                on p.prolang = l.oid
+        where
+            p.prosecdef = true
+            and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
+            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+            and n.nspname not in (
+                '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            )
+    ) exposed_functions
+order by
+    schema_name,
+    function_name,
+    function_args)
+union all
+(
+-- Detects SECURITY DEFINER functions that the `authenticated` role
+-- has EXECUTE on. SECURITY DEFINER functions run with the privileges
+-- of their owner (typically a superuser-equivalent role) rather than
+-- the caller, so they bypass RLS on every table they read or write.
+-- Granting EXECUTE to `authenticated` therefore lets any signed-up
+-- user invoke a privileged operation through PostgREST
+-- `/rest/v1/rpc/<name>`, and through `/graphql/v1` Query/Mutation
+-- fields when pg_graphql is installed and the return type is
+-- supported. Under open or auto-confirm signup, "authenticated" is in
+-- practice anyone with a throwaway email.
+--
+-- See lint 0028 for the equivalent check against the `anon` role.
+-- Together with 0026/0027 they cover the four direct exposure paths:
+-- anon-vs-authenticated × table-vs-function.
+--
+-- This lint deliberately does not gate on pg_graphql being installed:
+-- PostgREST exposes `/rest/v1/rpc` independently and is the more
+-- commonly deployed surface for the same risk.
+select
+    'authenticated_security_definer_function_executable' as name,
+    'Signed-In Users Can Execute SECURITY DEFINER Function' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects `SECURITY DEFINER` functions that are callable by signed-in users. Revoke `EXECUTE`, switch the function to `SECURITY INVOKER`, or move it out of your exposed API schema if signed-in users should not call it.' as description,
+    format(
+        'Function `%s.%s(%s)` can be executed by the `authenticated` role as a `SECURITY DEFINER` function via `/rest/v1/rpc/%s`. Revoke `EXECUTE` or switch it to `SECURITY INVOKER` if that is not intentional.',
+        schema_name,
+        function_name,
+        function_args,
+        function_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', function_name,
+        'arguments', function_args,
+        'language', function_language,
+        'security_definer', true
+    ) as metadata,
+    format(
+        'authenticated_security_definer_function_executable_%s_%s_%s',
+        schema_name,
+        function_name,
+        function_args
+    ) as cache_key
+from
+    (
+        select
+            n.nspname as schema_name,
+            p.proname as function_name,
+            pg_catalog.pg_get_function_identity_arguments(p.oid) as function_args,
+            l.lanname as function_language
+        from
+            pg_catalog.pg_proc p
+            join pg_catalog.pg_namespace n
+                on p.pronamespace = n.oid
+            join pg_catalog.pg_language l
+                on p.prolang = l.oid
+        where
+            p.prosecdef = true
+            and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
+            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+            and n.nspname not in (
+                '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            )
+    ) exposed_functions
+order by
+    schema_name,
+    function_name,
+    function_args)

--- a/priv/repo/test_rollback.sh
+++ b/priv/repo/test_rollback.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Verifies the migrations new on this branch roll back AND re-apply cleanly —
+# i.e. their `down` blocks actually work. Full-history `rollback --all` is not
+# possible: some legacy migrations are intentionally irreversible (e.g. the
+# encryption phase-B plaintext drops raise in `down`), so this scopes to the
+# migrations this branch is responsible for.
+#
+# Caller must provide:
+#   DATABASE_URL  — a FRESH, EMPTY database (it gets migrated + rolled back)
+#   MIX_ENV=test  — reuses the compiled _build/test
+#   BASE_REF      — git ref to diff against (default origin/main); must be fetched
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+MIG_DIR="priv/repo/migrations"
+
+base_version=$(git ls-tree -r --name-only "$BASE_REF" -- "$MIG_DIR" 2>/dev/null \
+  | grep -oE '[0-9]{14}' | sort -u | tail -1 || true)
+
+if [ -z "$base_version" ]; then
+  echo "::error::rollback test: could not read migrations from '$BASE_REF' (is it fetched?)"
+  exit 1
+fi
+
+n=$(find "$MIG_DIR" -maxdepth 1 -name '*.exs' -printf '%f\n' \
+  | grep -oE '^[0-9]{14}' | sort -u | awk -v b="$base_version" '$0 > b' | wc -l)
+
+if [ "$n" -eq 0 ]; then
+  echo "rollback test: no migrations newer than $BASE_REF — nothing to check"
+  exit 0
+fi
+
+echo "rollback test: $n new migration(s) — migrate → rollback → re-migrate"
+mix ecto.migrate
+mix ecto.rollback --step "$n"
+mix ecto.migrate
+echo "rollback test: new migrations reverse and re-apply cleanly ✓"

--- a/test/engram/rls_coverage_test.exs
+++ b/test/engram/rls_coverage_test.exs
@@ -27,7 +27,7 @@ defmodule Engram.RlsCoverageTest do
   defp user_scoped_tables do
     %{rows: rows} =
       Repo.query!("""
-      SELECT c.relname, c.relrowsecurity,
+      SELECT c.relname, c.relrowsecurity, c.relforcerowsecurity,
              (SELECT count(*) FROM pg_policy p WHERE p.polrelid = c.oid)
       FROM pg_class c
       JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -42,25 +42,28 @@ defmodule Engram.RlsCoverageTest do
   end
 
   test "every user-scoped table has an RLS policy or is explicitly allowlisted" do
+    # A table is protected only if RLS is both ENABLED and FORCED (the table
+    # owner / migration role bypasses non-forced RLS) and at least one policy
+    # exists.
     unprotected =
-      for [table, rls_enabled, policy_count] <- user_scoped_tables(),
-          not (rls_enabled and policy_count > 0),
+      for [table, rls_enabled, rls_forced, policy_count] <- user_scoped_tables(),
+          not (rls_enabled and rls_forced and policy_count > 0),
           table not in @no_rls_allowlist,
           do: table
 
     assert unprotected == [],
            """
-           User-scoped tables with neither an RLS policy nor an allowlist entry: \
+           User-scoped tables without FORCEd RLS + a policy, and not allowlisted: \
            #{Enum.join(unprotected, ", ")}.
-           Either enable RLS (ENABLE ROW LEVEL SECURITY + a tenant_isolation policy),
-           or, if application-layer scoping is intentional, add the table to
+           Either enable RLS (ENABLE + FORCE ROW LEVEL SECURITY + a tenant_isolation
+           policy), or, if application-layer scoping is intentional, add the table to
            @no_rls_allowlist in this test.
            """
   end
 
   test "no stale allowlist entries (each still exists and lacks RLS)" do
     no_rls_tables =
-      for [table, rls_enabled, _policy_count] <- user_scoped_tables(),
+      for [table, rls_enabled, _rls_forced, _policy_count] <- user_scoped_tables(),
           not rls_enabled,
           do: table
 

--- a/test/engram/rls_coverage_test.exs
+++ b/test/engram/rls_coverage_test.exs
@@ -1,0 +1,72 @@
+defmodule Engram.RlsCoverageTest do
+  @moduledoc """
+  Guards multi-tenant isolation at the schema level: every table with a
+  `user_id` column must either enforce a row-level-security policy or be
+  explicitly listed as relying on application-layer scoping. Adding a new
+  user-scoped table forces that decision instead of silently shipping a table
+  with no database-level tenant backstop.
+  """
+  use Engram.DataCase, async: true
+
+  # User-scoped tables that deliberately rely on application-layer `user_id`
+  # filtering rather than a database RLS policy. Adding an entry here is a
+  # conscious decision — prefer enabling RLS for anything holding tenant data.
+  @no_rls_allowlist ~w(
+    client_logs
+    client_origin_stats
+    device_authorizations
+    device_refresh_tokens
+    oauth_authorization_codes
+    oauth_refresh_tokens
+    refresh_tokens
+    subscriptions
+    usage_meters
+    user_limit_overrides
+  )
+
+  defp user_scoped_tables do
+    %{rows: rows} =
+      Repo.query!("""
+      SELECT c.relname, c.relrowsecurity,
+             (SELECT count(*) FROM pg_policy p WHERE p.polrelid = c.oid)
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind = 'r'
+        AND EXISTS (
+          SELECT 1 FROM pg_attribute a
+          WHERE a.attrelid = c.oid AND a.attname = 'user_id' AND NOT a.attisdropped
+        )
+      """)
+
+    rows
+  end
+
+  test "every user-scoped table has an RLS policy or is explicitly allowlisted" do
+    unprotected =
+      for [table, rls_enabled, policy_count] <- user_scoped_tables(),
+          not (rls_enabled and policy_count > 0),
+          table not in @no_rls_allowlist,
+          do: table
+
+    assert unprotected == [],
+           """
+           User-scoped tables with neither an RLS policy nor an allowlist entry: \
+           #{Enum.join(unprotected, ", ")}.
+           Either enable RLS (ENABLE ROW LEVEL SECURITY + a tenant_isolation policy),
+           or, if application-layer scoping is intentional, add the table to
+           @no_rls_allowlist in this test.
+           """
+  end
+
+  test "no stale allowlist entries (each still exists and lacks RLS)" do
+    no_rls_tables =
+      for [table, rls_enabled, _policy_count] <- user_scoped_tables(),
+          not rls_enabled,
+          do: table
+
+    stale = @no_rls_allowlist -- no_rls_tables
+
+    assert stale == [],
+           "Stale @no_rls_allowlist entries (now RLS-protected or removed): #{Enum.join(stale, ", ")}"
+  end
+end

--- a/test/engram/rls_policy_form_test.exs
+++ b/test/engram/rls_policy_form_test.exs
@@ -1,0 +1,35 @@
+defmodule Engram.RlsPolicyFormTest do
+  @moduledoc """
+  Guards the `auth_rls_initplan` advisory: tenant-isolation policies must wrap
+  `current_setting('app.current_tenant', ...)` in a scalar subquery so Postgres
+  evaluates it once per statement instead of once per row.
+
+  Isolation behaviour itself is covered by RepoTenantTest /
+  RepoUserAgreementsTenantTest — this only asserts the optimized policy shape.
+  """
+  use Engram.DataCase, async: true
+
+  @tenant_tables ~w(notes chunks attachments api_keys vaults user_agreements)
+
+  test "tenant_isolation policies wrap current_setting in (SELECT ...)" do
+    for table <- @tenant_tables do
+      %{rows: [[using_expr, check_expr]]} =
+        Repo.query!(
+          """
+          SELECT pg_get_expr(p.polqual, p.polrelid),
+                 pg_get_expr(p.polwithcheck, p.polrelid)
+          FROM pg_policy p
+          JOIN pg_class c ON c.oid = p.polrelid
+          WHERE c.relname = $1 AND p.polname = $2
+          """,
+          [table, "tenant_isolation_#{table}"]
+        )
+
+      assert using_expr =~ ~r/\(\s*SELECT current_setting/i,
+             "USING clause on #{table} must wrap current_setting in (SELECT ...); got: #{using_expr}"
+
+      assert check_expr =~ ~r/\(\s*SELECT current_setting/i,
+             "WITH CHECK clause on #{table} must wrap current_setting in (SELECT ...); got: #{check_expr}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Off-roadmap DB-tooling work that came out of auditing the schema in a local Supabase stack. One PR, three related pieces:

### 1. Schema fixes (splinter advisories)
- **RLS `auth_rls_initplan`**: rewrote all 6 `tenant_isolation_*` policies (notes, chunks, attachments, api_keys, vaults, user_agreements) to wrap `current_setting('app.current_tenant', true)` in a scalar subquery — planner evaluates once per statement instead of per row. Behaviour-preserving.
- **8 unindexed foreign keys**: added covering indexes (`CONCURRENTLY`).
- **Duplicate index**: dropped `api_key_vaults_api_key_id_vault_id_index` (identical to the PK).
- **Missing primary key**: promoted `client_origin_stats`'s composite unique index to its PK (no new column, no rebuild).

TDD: new `rls_policy_form_test.exs` asserts the optimized policy shape; existing tenant-isolation tests guard against a security regression. Full suite green (1636 tests, 0 failures).

### 2. CI DB linting (we had none)
- **splinter** (`priv/repo/splinter.sql` + `lint_schema.sh`): runs against the migrated ephemeral Postgres in the `unit-tests` job. Stubs the `anon`/`authenticated`/`service_role` roles so splinter runs on plain PG; tables aren't granted to them, so Supabase-API-only lints stay silent — only real schema/security findings fail the build. `unused_index` is ignored (no scan stats on a fresh CI DB). Verified: fails on a per-row RLS policy, passes when fixed.
- **squawk** (`.squawk.toml` + `lint_migrations.sh`): renders the DDL of migrations *new on the branch* (migrate-to-base then `--log-migrations-sql`) and lints for unsafe patterns. Excludes the two rules that structurally conflict with Ecto's codegen (`require-timeout-settings`, `prefer-robust-stmts`); the dangerous-DDL rules (drop column, add NOT NULL, type change, etc.) still gate. Verified teeth + clean pass on this PR's migrations.

### 3. Dev data seeder
- `priv/repo/dev_seeds.exs`: parameterized, idempotent seeder that goes through the real contexts so encryption (per-user DEK, AAD-bound AES-GCM, HMAC columns) is produced correctly — raw SQL/CSV can't, since the plaintext columns were dropped in the phase-B migrations. Pauses embed/reindex queues so no Voyage/Qdrant calls fire.
- `docs/context/local-supabase-audit.md`: how to stand up the local Supabase audit stack + the gotchas (AVX2-less CPU CLI build, stable master key for the boot canary, `GRANT engram_app TO postgres` for RLS).

## Test plan
- [x] `mix test` — 1636 passing, 0 failures
- [x] splinter gate: fails on regression, passes on fixed schema
- [x] squawk: passes on this PR's migrations, fails on unsafe DDL
- [ ] CI green on the new `unit-tests` splinter + squawk steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)