### PR TITLE
feat(auth): style Clerk pages + surface duplicate-signup rejection

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -6,6 +6,7 @@
       "name": "engram-frontend",
       "dependencies": {
         "@clerk/clerk-react": "^5.61.4",
+        "@clerk/themes": "^2.4.57",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.42.1",
@@ -139,6 +140,8 @@
     "@clerk/shared": ["@clerk/shared@4.8.0", "http://10.0.20.214:4873/@clerk/shared/-/shared-4.8.0.tgz", { "dependencies": { "@tanstack/query-core": "5.90.16", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-RLIs8gqSmciALkJ5caAed0+Xb38b0itW+lTwhZ2arqOcbY/nfJboZbfXKU5VDUbs4ivMD0xKKy6tHQTbpKgqmA=="],
 
     "@clerk/testing": ["@clerk/testing@2.0.14", "http://10.0.20.214:4873/@clerk/testing/-/testing-2.0.14.tgz", { "dependencies": { "@clerk/backend": "^3.2.10", "@clerk/shared": "^4.8.0", "dotenv": "17.2.2" }, "peerDependencies": { "@playwright/test": "^1", "cypress": "^13 || ^14" }, "optionalPeers": ["@playwright/test", "cypress"] }, "sha512-HClHsj9yOVTzH8amOiDBLif4lSeoSdAooH5crFaancprpqVssMhGm+MaFZvoTfTFNzUeLxDxoFcf0frFhLPeXQ=="],
+
+    "@clerk/themes": ["@clerk/themes@2.4.57", "http://10.0.20.214:4873/@clerk/themes/-/themes-2.4.57.tgz", { "dependencies": { "@clerk/shared": "^3.47.2", "tslib": "2.8.1" } }, "sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.2", "http://10.0.20.214:4873/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ=="],
 
@@ -1718,6 +1721,8 @@
 
     "@clerk/shared/std-env": ["std-env@3.10.0", "http://10.0.20.214:4873/std-env/-/std-env-3.10.0.tgz", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "@clerk/themes/@clerk/shared": ["@clerk/shared@3.47.3", "http://10.0.20.214:4873/@clerk/shared/-/shared-3.47.3.tgz", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "http://10.0.20.214:4873/commander/-/commander-11.1.0.tgz", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "http://10.0.20.214:4873/execa/-/execa-5.1.1.tgz", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -1975,6 +1980,10 @@
     "@clerk/clerk-react/@clerk/shared/csstype": ["csstype@3.1.3", "http://10.0.20.214:4873/csstype/-/csstype-3.1.3.tgz", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "@clerk/clerk-react/@clerk/shared/std-env": ["std-env@3.10.0", "http://10.0.20.214:4873/std-env/-/std-env-3.10.0.tgz", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@clerk/themes/@clerk/shared/csstype": ["csstype@3.1.3", "http://10.0.20.214:4873/csstype/-/csstype-3.1.3.tgz", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@clerk/themes/@clerk/shared/std-env": ["std-env@3.10.0", "http://10.0.20.214:4873/std-env/-/std-env-3.10.0.tgz", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "http://10.0.20.214:4873/get-stream/-/get-stream-6.0.1.tgz", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   "keywords": [],
   "dependencies": {
     "@clerk/clerk-react": "^5.61.4",
+    "@clerk/themes": "^2.4.57",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.42.1",

--- a/frontend/src/auth/auth-layout.tsx
+++ b/frontend/src/auth/auth-layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background text-foreground">
+      <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden" aria-hidden="true">
+        <div className="absolute inset-0 grid-overlay opacity-30" />
+        <div className="absolute -left-32 -top-32 h-96 w-96 neural-glow-purple opacity-60" />
+        <div className="absolute -bottom-32 -right-32 h-96 w-96 neural-glow-cyan opacity-60" />
+      </div>
+      <div className="relative z-10 flex w-full items-center justify-center px-4 py-12">
+        {children}
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/auth/clerk-auth-provider.tsx
+++ b/frontend/src/auth/clerk-auth-provider.tsx
@@ -1,11 +1,36 @@
 import { ClerkProvider, useAuth, useClerk } from '@clerk/clerk-react'
+import { dark } from '@clerk/themes'
 import { useCallback, useEffect, useMemo } from 'react'
 import { AuthContext, type AuthAdapter } from './auth-context'
+import { rememberSignupUser } from './signup-rejection'
 import { setTokenGetter } from '../api/client'
 import { config } from '../config'
 import { ROUTES } from '../routes'
+import { useTheme } from '../theme/theme-provider'
 
 const clerkPubKey = config.clerkPublishableKey
+
+// Map Clerk onto Engram's CSS design tokens. The Clerk React components render
+// in-DOM (not an iframe), so these var() references resolve against the document.
+// The dark baseTheme (applied reactively below) is what flips Clerk's own
+// surface/brand-glyph handling — colorPrimary etc. then re-skin it to brand.
+const clerkVariables = {
+  colorPrimary: 'var(--primary)',
+  colorText: 'var(--foreground)',
+  colorTextSecondary: 'var(--muted-foreground)',
+  colorBackground: 'var(--card)',
+  colorInputBackground: 'var(--background)',
+  colorInputText: 'var(--foreground)',
+  colorNeutral: 'var(--foreground)',
+  borderRadius: 'var(--radius)',
+  fontFamily: "'Inter Variable', system-ui, sans-serif",
+}
+
+const clerkElements = {
+  cardBox: 'border border-border shadow-2xl shadow-primary/10',
+  card: 'bg-card',
+  footer: 'bg-transparent',
+}
 
 function ClerkAdapterInner({ children }: { children: React.ReactNode }) {
   const { isLoaded, isSignedIn, getToken } = useAuth()
@@ -16,6 +41,13 @@ function ClerkAdapterInner({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     setTokenGetter(tokenGetter)
   }, [tokenGetter])
+
+  // Remember the Clerk user id while we still have it. If the multi-account
+  // block deletes this user moments later, the sign-in bounce can look up why.
+  const clerkUserId = clerk.user?.id
+  useEffect(() => {
+    if (clerkUserId) rememberSignupUser(clerkUserId)
+  }, [clerkUserId])
 
   const email = clerk.user?.primaryEmailAddress?.emailAddress
   const adapter: AuthAdapter = useMemo(
@@ -34,6 +66,17 @@ function ClerkAdapterInner({ children }: { children: React.ReactNode }) {
 }
 
 export default function ClerkAuthProvider({ children }: { children: React.ReactNode }) {
+  const { resolved } = useTheme()
+
+  const appearance = useMemo(
+    () => ({
+      baseTheme: resolved === 'dark' ? dark : undefined,
+      variables: clerkVariables,
+      elements: clerkElements,
+    }),
+    [resolved],
+  )
+
   if (!clerkPubKey) {
     throw new Error('CLERK_PUBLISHABLE_KEY is required when AUTH_PROVIDER=clerk')
   }
@@ -41,6 +84,7 @@ export default function ClerkAuthProvider({ children }: { children: React.ReactN
   return (
     <ClerkProvider
       publishableKey={clerkPubKey}
+      appearance={appearance}
       signInUrl={ROUTES.SIGN_IN}
       signUpUrl={ROUTES.SIGN_UP}
       afterSignOutUrl={ROUTES.SIGN_IN}

--- a/frontend/src/auth/sign-in.tsx
+++ b/frontend/src/auth/sign-in.tsx
@@ -1,17 +1,17 @@
 import { lazy, Suspense } from 'react'
 import { useSearchParams } from 'react-router'
 import { config } from '../config'
+import AuthLayout from './auth-layout'
+import SignupRejectionNotice from './signup-rejection-notice'
 import { safeReturnTo } from './safe-return-to'
 
 const isClerk = config.authProvider === 'clerk'
 
-const ClerkSignInPage = isClerk
+const ClerkSignIn = isClerk
   ? lazy(() =>
       import('@clerk/clerk-react').then((mod) => ({
         default: ({ returnTo }: { returnTo: string }) => (
-          <main style={{ display: 'flex', justifyContent: 'center', paddingTop: '4rem' }}>
-            <mod.SignIn routing="hash" forceRedirectUrl={returnTo} />
-          </main>
+          <mod.SignIn routing="hash" forceRedirectUrl={returnTo} />
         ),
       })),
     )
@@ -23,9 +23,22 @@ export default function SignInPage() {
   const [searchParams] = useSearchParams()
   const returnTo = safeReturnTo(searchParams.get('return_to'))
 
+  if (ClerkSignIn) {
+    return (
+      <AuthLayout>
+        <div className="flex w-full flex-col items-center">
+          <SignupRejectionNotice />
+          <Suspense fallback={<p>Loading...</p>}>
+            <ClerkSignIn returnTo={returnTo} />
+          </Suspense>
+        </div>
+      </AuthLayout>
+    )
+  }
+
   return (
     <Suspense fallback={<p>Loading...</p>}>
-      {ClerkSignInPage ? <ClerkSignInPage returnTo={returnTo} /> : <LocalSignIn />}
+      <LocalSignIn />
     </Suspense>
   )
 }

--- a/frontend/src/auth/sign-up.tsx
+++ b/frontend/src/auth/sign-up.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react'
 import { config } from '../config'
+import AuthLayout from './auth-layout'
 
 const isClerk = config.authProvider === 'clerk'
 
@@ -7,9 +8,9 @@ const ClerkSignUpPage = isClerk
   ? lazy(() =>
       import('@clerk/clerk-react').then((mod) => ({
         default: () => (
-          <main style={{ display: 'flex', justifyContent: 'center', paddingTop: '4rem' }}>
+          <AuthLayout>
             <mod.SignUp routing="hash" forceRedirectUrl="/" />
-          </main>
+          </AuthLayout>
         ),
       }))
     )

--- a/frontend/src/auth/signup-rejection-notice.test.tsx
+++ b/frontend/src/auth/signup-rejection-notice.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import SignupRejectionNotice from './signup-rejection-notice'
+
+const KEY = 'engram:pending-signup'
+
+function setPending(id: string, ts = Date.now()) {
+  sessionStorage.setItem(KEY, JSON.stringify({ id, ts }))
+}
+
+describe('SignupRejectionNotice', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows the duplicate-account message when the backend reports a rejection', async () => {
+    setPending('user_dup')
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ reason: 'duplicate_identity' }), { status: 200 }),
+    )
+
+    render(<SignupRejectionNotice />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/already exists/i)
+  })
+
+  it('renders nothing when there is no pending sign-up', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const { container } = render(<SignupRejectionNotice />)
+
+    await waitFor(() => expect(fetchSpy).not.toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the backend has no rejection recorded (404)', async () => {
+    setPending('user_clean')
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ reason: null }), { status: 404 }),
+    )
+
+    const { container } = render(<SignupRejectionNotice />)
+
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('clears the pending entry so it does not fire twice', async () => {
+    setPending('user_dup')
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ reason: 'duplicate_identity' }), { status: 200 }),
+    )
+
+    render(<SignupRejectionNotice />)
+    await screen.findByRole('alert')
+
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+})

--- a/frontend/src/auth/signup-rejection-notice.tsx
+++ b/frontend/src/auth/signup-rejection-notice.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { fetchSignupRejection, takePendingSignupUser } from './signup-rejection'
+
+// Shown on the sign-in page after a sign-up was rejected server-side by the
+// multi-account block. Self-contained: renders nothing unless a recent pending
+// sign-up resolves to a known rejection reason.
+export default function SignupRejectionNotice() {
+  const [rejected, setRejected] = useState(false)
+
+  useEffect(() => {
+    const id = takePendingSignupUser()
+    if (!id) return
+    let active = true
+    fetchSignupRejection(id).then((reason) => {
+      if (active && reason === 'duplicate_identity') setRejected(true)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  if (!rejected) return null
+
+  return (
+    <div
+      role="alert"
+      className="mb-4 w-full max-w-sm rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-sm"
+    >
+      <p className="font-medium text-foreground">An account with this email already exists</p>
+      <p className="mt-1 text-muted-foreground">
+        We couldn’t create a new account because one already exists for this email (or an alias of
+        it). Please sign in below instead.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/auth/signup-rejection.ts
+++ b/frontend/src/auth/signup-rejection.ts
@@ -1,0 +1,51 @@
+// Bridges the gap between Clerk's client-side sign-up and the server-side
+// multi-account block. When a sign-up trips the block, the backend deletes the
+// Clerk user ~1s after creation, orphaning the session and bouncing the app to
+// /sign-in with no explanation. We remember the just-created Clerk user id here
+// so the sign-in page can ask the backend why, and show a real message.
+
+const KEY = 'engram:pending-signup'
+const WINDOW_MS = 2 * 60 * 1000
+
+export type SignupRejectionReason = 'duplicate_identity'
+
+export function rememberSignupUser(clerkUserId: string): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify({ id: clerkUserId, ts: Date.now() }))
+  } catch {
+    // sessionStorage unavailable (private mode / SSR) — non-fatal.
+  }
+}
+
+// Returns the recent pending sign-up id and clears it, so the lookup runs at
+// most once per bounce. Stale entries (older than the window) are dropped.
+export function takePendingSignupUser(): string | null {
+  try {
+    const raw = sessionStorage.getItem(KEY)
+    if (!raw) return null
+    sessionStorage.removeItem(KEY)
+    const { id, ts } = JSON.parse(raw) as { id?: string; ts?: number }
+    if (!id || !ts || Date.now() - ts > WINDOW_MS) return null
+    return id
+  } catch {
+    return null
+  }
+}
+
+// Public, unauthenticated endpoint — the session is gone by now, so this is a
+// plain fetch with no auth coupling. 404 means "not rejected".
+export async function fetchSignupRejection(
+  clerkUserId: string,
+): Promise<SignupRejectionReason | null> {
+  try {
+    const res = await fetch(`/api/auth/signup-rejection?clerk_id=${encodeURIComponent(clerkUserId)}`)
+    if (!res.ok) return null
+    const body = (await res.json()) as { reason?: SignupRejectionReason | null }
+    return body.reason ?? null
+  } catch (err) {
+    // A transport failure (network/DNS/CORS) is distinct from a 404 "not
+    // rejected" — we still degrade to null for UX, but surface it for debugging.
+    console.warn('signup-rejection lookup failed', err)
+    return null
+  }
+}

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -1,8 +1,23 @@
-import { useEffect, useState } from 'react'
-import { initializePaddle, type Paddle } from '@paddle/paddle-js'
-import { useBillingStatus, useBillingConfig, type BillingConfig } from '../api/queries'
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { CheckoutEventNames, initializePaddle, type Paddle } from '@paddle/paddle-js'
+import {
+  useBillingStatus,
+  useBillingConfig,
+  type BillingConfig,
+  type OnboardingStatus,
+} from '../api/queries'
 import { api } from '../api/client'
+import { useTheme } from '../theme/theme-provider'
 import { cn } from '@/lib/utils'
+
+// Paddle confirms checkout client-side (checkout.completed) before its webhook
+// reaches our backend and flips the subscription active, so a single refetch
+// races the webhook and reads stale state. Poll the onboarding gate until it
+// catches up (or we give up), writing each result into the query cache so the
+// onboarding redirect fires without a manual reload.
+const ACTIVATION_POLL_MS = 2000
+const ACTIVATION_POLL_TIMEOUT_MS = 30000
 
 const TIER_LABELS = {
   free: 'Free',
@@ -15,18 +30,70 @@ const TIER_LABELS = {
 export default function BillingPage({ hideHeading = false }: { hideHeading?: boolean }) {
   const { data: billing, isLoading } = useBillingStatus()
   const { data: config } = useBillingConfig()
+  const { resolved } = useTheme()
+  const qc = useQueryClient()
   const [paddle, setPaddle] = useState<Paddle>()
+  const [activationStuck, setActivationStuck] = useState(false)
+  const pollTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const activeRef = useRef(true)
+
+  useEffect(() => {
+    activeRef.current = true
+    return () => {
+      activeRef.current = false
+      clearTimeout(pollTimer.current)
+    }
+  }, [])
 
   useEffect(() => {
     if (!config) return
+
+    function pollUntilActive(deadline: number) {
+      clearTimeout(pollTimer.current)
+      pollTimer.current = setTimeout(async () => {
+        try {
+          const status = await api.get<OnboardingStatus>('/onboarding/status')
+          if (!activeRef.current) return
+          qc.setQueryData(['onboarding', 'status'], status)
+          qc.invalidateQueries({ queryKey: ['billing', 'status'] })
+          if (status.next_step === 'done') return
+        } catch (err) {
+          // A transient 401 (token refresh mid-checkout), 429, or 5xx must not
+          // kill the poll — log and fall through to retry within the deadline.
+          console.error('billing activation poll request failed; retrying', err)
+        }
+        if (!activeRef.current) return
+        if (Date.now() < deadline) {
+          pollUntilActive(deadline)
+        } else {
+          // Paid, but the webhook hasn't flipped us active in time. Surface it
+          // rather than silently stranding the user on the plan page.
+          console.error('billing activation timed out before subscription became active')
+          setActivationStuck(true)
+        }
+      }, ACTIVATION_POLL_MS)
+    }
+
     initializePaddle({
       token: config.client_token,
       environment: config.environment,
-      checkout: { settings: { displayMode: 'overlay', theme: 'light', locale: 'en' } },
+      eventCallback: (event) => {
+        if (event.name === CheckoutEventNames.CHECKOUT_COMPLETED) {
+          setActivationStuck(false)
+          pollUntilActive(Date.now() + ACTIVATION_POLL_TIMEOUT_MS)
+        }
+      },
+      checkout: {
+        settings: {
+          displayMode: 'overlay',
+          theme: resolved === 'dark' ? 'dark' : 'light',
+          locale: 'en',
+        },
+      },
     }).then((instance) => {
       if (instance) setPaddle(instance)
     })
-  }, [config])
+  }, [config, resolved, qc])
 
   if (isLoading || !billing) {
     return <p className="text-muted-foreground">Loading billing info...</p>
@@ -39,6 +106,16 @@ export default function BillingPage({ hideHeading = false }: { hideHeading?: boo
   return (
     <article className="mx-auto max-w-2xl space-y-8">
       {!hideHeading && <h1 className="text-2xl font-bold text-foreground">Billing</h1>}
+
+      {activationStuck && (
+        <div role="alert" className="rounded-lg border border-border bg-card p-4 text-sm">
+          <p className="font-medium text-foreground">Payment received — finishing activation</p>
+          <p className="mt-1 text-muted-foreground">
+            This is taking longer than usual. Refresh the page in a moment; if it persists,
+            contact support and we’ll sort it out.
+          </p>
+        </div>
+      )}
 
       {!hideHeading && (
         <section className="space-y-4 rounded-lg border border-border bg-card p-6">

--- a/frontend/src/onboarding/agreement-page.tsx
+++ b/frontend/src/onboarding/agreement-page.tsx
@@ -4,6 +4,7 @@ import { useAcceptTerms, useOnboardingStatus } from '../api/queries'
 import { loadVersion, sha256Hex } from '../legal/load'
 import { LegalDoc } from '../legal/legal-doc'
 import { Checkbox } from '@/components/ui/checkbox'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
 
 const PRIVACY_URL = 'https://engram.page/privacy'
@@ -88,9 +89,11 @@ export default function AgreementPage() {
         ) : (
           <>
             {tosText ? (
-              <div className="max-h-96 overflow-y-auto rounded-lg border border-border bg-background p-4">
-                <LegalDoc source={tosText} />
-              </div>
+              <ScrollArea className="h-80 rounded-lg border border-border bg-background lg:h-[60vh]">
+                <div className="p-4">
+                  <LegalDoc source={tosText} />
+                </div>
+              </ScrollArea>
             ) : null}
             <label
               className={cn(

--- a/frontend/src/onboarding/onboard-billing-page.test.tsx
+++ b/frontend/src/onboarding/onboard-billing-page.test.tsx
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider } from '../theme/theme-provider'
 import OnboardBillingPage from './onboard-billing-page'
 
 vi.mock('@paddle/paddle-js', () => ({
   initializePaddle: vi.fn().mockResolvedValue(undefined),
+  CheckoutEventNames: { CHECKOUT_COMPLETED: 'checkout.completed' },
 }))
 
 vi.mock('../api/queries', () => ({
@@ -32,9 +34,11 @@ function renderPage() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter>
-        <OnboardBillingPage />
-      </MemoryRouter>
+      <ThemeProvider>
+        <MemoryRouter>
+          <OnboardBillingPage />
+        </MemoryRouter>
+      </ThemeProvider>
     </QueryClientProvider>,
   )
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -29,9 +29,16 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': apiTarget,
+      // changeOrigin rewrites the Host header to the target — required when
+      // VITE_API_TARGET points at a remote host routed by Host (e.g. Cloudflare);
+      // harmless against localhost.
+      '/api': {
+        target: apiTarget,
+        changeOrigin: true,
+      },
       '/socket': {
         target: apiTarget,
+        changeOrigin: true,
         ws: true,
       },
     },

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -24,6 +24,7 @@ defmodule Engram.Application do
         Engram.Crypto.DekCache,
         Engram.UsageMeters.ActivityCache,
         Engram.Onboarding.TermsCache,
+        Engram.Auth.SignupRejections,
         {EngramWeb.RateLimiter, [clean_period: :timer.minutes(2)]},
         {Oban, Application.fetch_env!(:engram, Oban)},
         clerk_strategy_child(),

--- a/lib/engram/auth/clerk/http_api.ex
+++ b/lib/engram/auth/clerk/http_api.ex
@@ -18,10 +18,13 @@ defmodule Engram.Auth.Clerk.HttpApi do
     url = "#{@base_url}/users/#{URI.encode_www_form(clerk_user_id)}"
 
     case Application.get_env(:engram, :clerk_secret_key) do
-      nil ->
-        {:error, :missing_secret}
+      blank when blank in [nil, ""] ->
+        # A missing secret silently disables the §A multi-account block — the
+        # duplicate user can't be revoked. This is a config defect, not a no-op.
+        Logger.error("Clerk delete_user skipped — CLERK_SECRET_KEY not configured",
+          clerk_user_id: clerk_user_id
+        )
 
-      "" ->
         {:error, :missing_secret}
 
       secret ->

--- a/lib/engram/auth/clerk/webhook.ex
+++ b/lib/engram/auth/clerk/webhook.ex
@@ -14,6 +14,7 @@ defmodule Engram.Auth.Clerk.Webhook do
 
   alias Engram.Accounts
   alias Engram.Auth.EmailNormalizer
+  alias Engram.Auth.SignupRejections
   alias Engram.Repo
 
   require Logger
@@ -45,23 +46,46 @@ defmodule Engram.Auth.Clerk.Webhook do
   defp apply_user_created(clerk_id, email, normalized) do
     case Accounts.find_by_normalized_email(normalized) do
       {:ok, _existing} ->
+        Logger.warning("Clerk signup rejected — normalized email already exists",
+          clerk_user_id: clerk_id,
+          normalized_email_hash: hash(normalized)
+        )
+
+        # Stash the reason before the delete orphans the session, so the web app
+        # can fetch it and explain the bounce instead of failing silently.
+        SignupRejections.record(clerk_id, :duplicate_identity)
+        revoke_duplicate(clerk_id, normalized)
+        :ok
+
+      {:error, :user_not_found} ->
+        _ = Accounts.find_or_create_by_external_id(clerk_id, %{email: email})
+        :ok
+    end
+  end
+
+  # The block is only real if Clerk actually revokes the duplicate. A failed
+  # delete (e.g. missing CLERK_SECRET_KEY) leaves the duplicate account live and
+  # signed in — count the outcome, not the intent, and make a failure alertable.
+  defp revoke_duplicate(clerk_id, normalized) do
+    case clerk_api().delete_user(clerk_id) do
+      :ok ->
         :telemetry.execute(
           [:engram, :abuse, :multi_account_blocked],
           %{count: 1},
           %{normalized_email_hash: hash(normalized)}
         )
 
-        Logger.warning("Clerk signup rejected — normalized email already exists",
-          clerk_user_id: clerk_id,
-          normalized_email_hash: hash(normalized)
+      {:error, reason} ->
+        :telemetry.execute(
+          [:engram, :abuse, :multi_account_block_failed],
+          %{count: 1},
+          %{normalized_email_hash: hash(normalized), reason: inspect(reason)}
         )
 
-        _ = clerk_api().delete_user(clerk_id)
-        :ok
-
-      {:error, :user_not_found} ->
-        _ = Accounts.find_or_create_by_external_id(clerk_id, %{email: email})
-        :ok
+        Logger.error("Clerk delete_user did not revoke duplicate signup — account still live",
+          clerk_user_id: clerk_id,
+          reason: inspect(reason)
+        )
     end
   end
 

--- a/lib/engram/auth/signup_rejections.ex
+++ b/lib/engram/auth/signup_rejections.ex
@@ -56,7 +56,7 @@ defmodule Engram.Auth.SignupRejections do
 
   @impl true
   def init(_opts) do
-    :ets.new(@table, [:named_table, :set, :public, read_concurrency: true])
+    _table = :ets.new(@table, [:named_table, :set, :public, read_concurrency: true])
     schedule_sweep()
     {:ok, %{}}
   end

--- a/lib/engram/auth/signup_rejections.ex
+++ b/lib/engram/auth/signup_rejections.ex
@@ -1,0 +1,73 @@
+defmodule Engram.Auth.SignupRejections do
+  @moduledoc """
+  Short-lived record of sign-ups rejected server-side, keyed by Clerk user id.
+
+  The `user.created` webhook deletes the Clerk user when a sign-up trips the
+  multi-account block (see `Engram.Auth.Clerk.Webhook`). That delete orphans the
+  freshly-created session, so the web app bounces to sign-in with no idea why.
+  We stash the reason here *before* the delete, and the app fetches it via a
+  public endpoint to show an accurate "account already exists" message.
+
+  ETS-backed, single-node — same shape as `EngramWeb.RateLimiter`. Records are
+  ephemeral by nature (a few seconds of life is enough); a periodic sweep drops
+  anything past its TTL so the table can't grow unbounded.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+  # Only read once, on the sign-in bounce moments after the delete. A short TTL
+  # keeps the (low-risk, opaque-id) lookup oracle from lingering. The frontend's
+  # own freshness window is 2 min; 5 gives comfortable slack without persisting.
+  @default_ttl_ms :timer.minutes(5)
+  @sweep_interval_ms :timer.minutes(10)
+
+  @type reason :: :duplicate_identity
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc "Record a rejection reason for a Clerk user id. TTL is in milliseconds."
+  @spec record(String.t(), reason(), non_neg_integer() | integer()) :: :ok
+  def record(clerk_user_id, reason, ttl_ms \\ @default_ttl_ms)
+      when is_binary(clerk_user_id) and is_atom(reason) do
+    expires_at = System.monotonic_time(:millisecond) + ttl_ms
+    :ets.insert(@table, {clerk_user_id, reason, expires_at})
+    :ok
+  end
+
+  @doc "Fetch a live (unexpired) rejection reason for a Clerk user id."
+  @spec fetch(String.t()) :: {:ok, reason()} | :error
+  def fetch(clerk_user_id) when is_binary(clerk_user_id) do
+    case :ets.lookup(@table, clerk_user_id) do
+      [{^clerk_user_id, reason, expires_at}] ->
+        if System.monotonic_time(:millisecond) < expires_at do
+          {:ok, reason}
+        else
+          :ets.delete(@table, clerk_user_id)
+          :error
+        end
+
+      [] ->
+        :error
+    end
+  end
+
+  @impl true
+  def init(_opts) do
+    :ets.new(@table, [:named_table, :set, :public, read_concurrency: true])
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    now = System.monotonic_time(:millisecond)
+    :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:<, :"$1", now}], [true]}])
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_interval_ms)
+end

--- a/lib/engram_web/controllers/signup_rejection_controller.ex
+++ b/lib/engram_web/controllers/signup_rejection_controller.ex
@@ -1,0 +1,31 @@
+defmodule EngramWeb.SignupRejectionController do
+  @moduledoc """
+  Public lookup for why a just-completed sign-up was rejected server-side.
+
+  Unauthenticated by necessity: the multi-account block deletes the Clerk user,
+  so the caller no longer holds a valid session. The web app passes the orphaned
+  Clerk user id to learn the reason and show an accurate message instead of a
+  silent bounce to sign-in. Rate-limited; ids are opaque and short-lived.
+  """
+  use EngramWeb, :controller
+
+  alias Engram.Auth.SignupRejections
+
+  def show(conn, %{"clerk_id" => clerk_id}) when is_binary(clerk_id) and clerk_id != "" do
+    case SignupRejections.fetch(clerk_id) do
+      {:ok, reason} ->
+        json(conn, %{reason: Atom.to_string(reason)})
+
+      :error ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{reason: nil})
+    end
+  end
+
+  def show(conn, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "clerk_id is required"})
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -110,6 +110,10 @@ defmodule EngramWeb.Router do
     post "/auth/device", DeviceAuthController, :start
     post "/auth/device/token", DeviceAuthController, :token
     post "/auth/token/refresh", DeviceAuthController, :refresh
+
+    # Public: explain why a just-completed sign-up was rejected (multi-account
+    # block deletes the Clerk user, so there is no session to authenticate with).
+    get "/auth/signup-rejection", SignupRejectionController, :show
   end
 
   # Local auth endpoints — always compiled, guarded at runtime by RequireLocalAuth plug

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.233",
+      version: "0.5.234",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/auth/signup_rejections_test.exs
+++ b/test/engram/auth/signup_rejections_test.exs
@@ -1,0 +1,34 @@
+defmodule Engram.Auth.SignupRejectionsTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Auth.SignupRejections
+
+  defp uniq, do: "user_" <> Integer.to_string(System.unique_integer([:positive]))
+
+  describe "record/3 and fetch/1" do
+    test "fetch returns the recorded reason" do
+      id = uniq()
+      :ok = SignupRejections.record(id, :duplicate_identity)
+      assert {:ok, :duplicate_identity} = SignupRejections.fetch(id)
+    end
+
+    test "fetch returns :error for an unknown id" do
+      assert :error = SignupRejections.fetch(uniq())
+    end
+
+    test "an expired record is not returned" do
+      id = uniq()
+      # negative ttl => already expired the instant it is written
+      :ok = SignupRejections.record(id, :duplicate_identity, -1)
+      assert :error = SignupRejections.fetch(id)
+    end
+
+    test "records are isolated by id" do
+      a = uniq()
+      b = uniq()
+      :ok = SignupRejections.record(a, :duplicate_identity)
+      assert :error = SignupRejections.fetch(b)
+      assert {:ok, :duplicate_identity} = SignupRejections.fetch(a)
+    end
+  end
+end

--- a/test/engram_web/controllers/clerk_webhook_test.exs
+++ b/test/engram_web/controllers/clerk_webhook_test.exs
@@ -103,6 +103,33 @@ defmodule EngramWeb.ClerkWebhookTest do
 
       assert json_response(conn, 200)["status"] == "ok"
       assert {:error, :user_not_found} = Accounts.find_by_external_id("user_dup1")
+      # Reason is stashed so the web app can explain the bounce.
+      assert {:ok, :duplicate_identity} = Engram.Auth.SignupRejections.fetch("user_dup1")
+    end
+
+    test "emits block_failed telemetry and still acks when Clerk delete fails", %{conn: conn} do
+      _existing = insert(:user, email: "dupf@gmail.com", normalized_email: "dupf@gmail.com")
+
+      # Simulate a misconfigured/unreachable Clerk — the duplicate stays live.
+      expect(Engram.Auth.Clerk.ApiMock, :delete_user, fn "user_dupf" ->
+        {:error, :missing_secret}
+      end)
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:engram, :abuse, :multi_account_block_failed]
+        ])
+
+      payload = clerk_user_created_payload("user_dupf", "dupf@gmail.com")
+      conn = post_clerk(conn, "evt_dupf", payload)
+
+      # Still ack the webhook (200) and stash the reason, but loudly count the
+      # failed revocation so the silent-no-op bypass is observable.
+      assert json_response(conn, 200)["status"] == "ok"
+      assert {:ok, :duplicate_identity} = Engram.Auth.SignupRejections.fetch("user_dupf")
+      assert_received {[:engram, :abuse, :multi_account_block_failed], ^ref, %{count: 1}, _meta}
+
+      :telemetry.detach(ref)
     end
 
     test "ignores duplicate event when local user already exists for same external_id",

--- a/test/engram_web/controllers/signup_rejection_controller_test.exs
+++ b/test/engram_web/controllers/signup_rejection_controller_test.exs
@@ -1,0 +1,30 @@
+defmodule EngramWeb.SignupRejectionControllerTest do
+  use EngramWeb.ConnCase, async: true
+
+  alias Engram.Auth.SignupRejections
+
+  defp uniq, do: "user_" <> Integer.to_string(System.unique_integer([:positive]))
+
+  describe "GET /api/auth/signup-rejection" do
+    test "returns the reason for a recorded rejection", %{conn: conn} do
+      id = uniq()
+      :ok = SignupRejections.record(id, :duplicate_identity)
+
+      conn = get(conn, "/api/auth/signup-rejection", %{"clerk_id" => id})
+
+      assert json_response(conn, 200) == %{"reason" => "duplicate_identity"}
+    end
+
+    test "returns 404 when no rejection is recorded", %{conn: conn} do
+      conn = get(conn, "/api/auth/signup-rejection", %{"clerk_id" => uniq()})
+
+      assert json_response(conn, 404)["reason"] == nil
+    end
+
+    test "returns 400 when clerk_id is missing", %{conn: conn} do
+      conn = get(conn, "/api/auth/signup-rejection")
+
+      assert json_response(conn, 400)["error"] =~ "clerk_id"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **Clerk auth pages styling** — neural-glow `AuthLayout`, theme-reactive Clerk appearance, dark `baseTheme`. Colors via design tokens; no `!important`.
- **Paddle checkout** follows app light/dark theme, and the onboarding wizard now **auto-advances after checkout** without a reload: on `checkout.completed` we poll the onboarding gate until the backend webhook flips the sub active (bounded 30s, retries transient 401/429/5xx, shows a "finishing activation" state on timeout instead of stranding a paying user).
- **Terms agreement page** uses a shadcn `ScrollArea`, taller on desktop.
- **Duplicate-signup UX (main feature)** — the `user.created` webhook deletes the Clerk user when the multi-account block (§A) trips, which orphaned the session and bounced the app to `/sign-in` with no explanation. We now record the reason first (`SignupRejections` ETS store, 5-min TTL), expose a public rate-limited lookup (`GET /api/auth/signup-rejection`), and show **"an account with this email already exists — sign in"** on the bounce.
- **Webhook hardening** — count the delete *outcome*: `multi_account_block_failed` telemetry + `Logger.error` on a failed revoke, and log a missing `CLERK_SECRET_KEY`, instead of discarding the result (a failed delete silently left the duplicate account live and signed in).

## Review notes (from pre-merge audit)
- The public lookup is a membership oracle, but gated by needing the exact ephemeral, high-entropy Clerk id and TTL'd to 5 min — deliberate, low-risk tradeoff.
- `SignupRejections` is single-node ETS (same pattern as `RateLimiter`); on multi-node it degrades gracefully to the old no-notice behavior. Confirm single-node-at-launch holds.
- `vite.config.ts` adds a **dev-server-only** proxy `changeOrigin` (lets `VITE_API_TARGET` point at a remote Host-routed backend); no production-build effect.

## Known follow-up (not in this PR)
- **Trial mismatch:** plan cards say "7-day free trial — won't be charged," but Paddle (sandbox Pro price) charges immediately. The price needs a trial period configured, or the copy fixed.

## Test plan
- [x] Backend full suite green (`mix test`, 1643/0)
- [x] Frontend `vitest` green + `tsc --noEmit` clean + Biome clean
- [x] New tests: ETS store (hit/miss/expiry/isolation), lookup endpoint (200/404/400), webhook stash + `block_failed` telemetry on delete failure, notice component (all branches)
- [ ] Post-deploy to staging: verify the duplicate-signup notice renders end-to-end (needs these backend changes deployed; staging currently runs the old backend)
- [ ] Manual: dark-mode Paddle overlay + onboarding auto-advance on a fresh distinct-base test account

🤖 Generated with [Claude Code](https://claude.com/claude-code)