### PR TITLE
fix(rate-limiter): pass only :url to Hammer.Redis start opts

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -436,16 +436,12 @@ if config_env() == :prod do
   if redis_url = System.get_env("REDIS_URL") do
     config :engram, EngramWeb.RateLimiter, backend: :redis
 
-    # `:url` + `:key_prefix` are the documented Hammer.Redis 7.x start options.
-    # `:timeout` bounds each Redis command so fail-open stays fast even under a
-    # silent network partition (Hammer.Redis/Redix default is :infinity).
-    # VERIFY exact option names against hammer_backend_redis 7.1 README before
-    # first deploy, and confirm :timeout is a supported Hammer.Redis option;
-    # adjust here only (call sites + façade are option-agnostic).
-    config :engram, EngramWeb.RateLimiter.Redis,
-      url: redis_url,
-      key_prefix: "engram_rl:",
-      timeout: 250
+    # `:url` is the only valid runtime start option for the Hammer.Redis backend
+    # (Redix rejects unknown start keys). The key prefix and command timeout are
+    # compile-time `use Hammer` opts on the limiter module — see start_opts/1.
+    config :engram,
+           EngramWeb.RateLimiter.Redis,
+           EngramWeb.RateLimiter.Redis.start_opts(redis_url)
   end
 
   config :engram, EngramWeb.Endpoint,

--- a/lib/engram_web/rate_limiter/redis.ex
+++ b/lib/engram_web/rate_limiter/redis.ex
@@ -4,6 +4,22 @@ defmodule EngramWeb.RateLimiter.Redis do
   engram-infra#158) so per-plan/§G and Voyage-quota counters are exact across
   all nodes instead of N×-per-node. Started only when configured; the façade
   fails open if the store is unreachable.
+
+  `:prefix` and `:timeout` are `use Hammer` (compile-time) options, not Redix
+  start options — the only valid runtime start option is `:url` (see
+  `start_opts/1`). The 250ms command timeout keeps the façade's fail-open fast
+  when Redis is partitioned (Hammer/Redix default is `:infinity`).
   """
-  use Hammer, backend: Hammer.Redis
+  use Hammer, backend: Hammer.Redis, prefix: "engram_rl:", timeout: 250
+
+  @doc """
+  Runtime start options for the limiter, derived from `REDIS_URL`.
+
+  Only `:url` is a valid `Hammer.Redis` start option; everything else is popped
+  and forwarded to `Redix.start_link/1`, which validates its schema strictly and
+  rejects unknown keys (a bad option crashes the limiter on boot). The key
+  prefix and command timeout are compiled in via the `use` opts above.
+  """
+  @spec start_opts(String.t()) :: [{:url, String.t()}]
+  def start_opts(redis_url) when is_binary(redis_url), do: [url: redis_url]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.235",
+      version: "0.5.236",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/rate_limiter_test.exs
+++ b/test/engram_web/rate_limiter_test.exs
@@ -64,4 +64,35 @@ defmodule EngramWeb.RateLimiterTest do
 
     :telemetry.detach("fail-open-raise-#{inspect(ref)}")
   end
+
+  describe "Redis backend start options" do
+    alias EngramWeb.RateLimiter.Redis, as: RedisLimiter
+
+    test "start_opts/1 passes only :url through to Redix" do
+      # :prefix and :timeout are compile-time `use Hammer` options, NOT Redix
+      # start options. Only :url is a valid runtime start option for the
+      # Hammer.Redis backend, so the runtime config must pass nothing else.
+      assert RedisLimiter.start_opts("redis://localhost:6379") == [url: "redis://localhost:6379"]
+    end
+
+    test "limiter starts under a supervisor with the production opt shape" do
+      # Redix connects asynchronously (sync_connect: false), so this validates
+      # the option schema without needing a live Redis server.
+      opts = RedisLimiter.start_opts("redis://localhost:6379")
+      assert {:ok, pid} = start_supervised({RedisLimiter, opts})
+      assert is_pid(pid)
+    end
+
+    test ":key_prefix is rejected as a runtime start option (regression guard)" do
+      # Documents why the prefix had to move to compile-time `use` opts: passing
+      # it as a start option crashes the limiter on boot because Redix validates
+      # its option schema strictly and has no :key_prefix key.
+      Process.flag(:trap_exit, true)
+
+      assert {:error, _reason} =
+               start_supervised(
+                 {RedisLimiter, [url: "redis://localhost:6379", key_prefix: "engram_rl:"]}
+               )
+    end
+  end
 end


### PR DESCRIPTION
## Summary

PR #327 wired a runtime-pluggable rate limiter, but the `REDIS_URL` config block in `config/runtime.exs` passes **invalid start options** to the Hammer.Redis backend. This would crash `engram-saas` on boot the moment `REDIS_URL` is set — blocking the planned FastRaid/AWS Redis cutover.

### Root cause (verified against `hammer_backend_redis` 7.1.1 + `redix` 1.5.3 source)

`runtime.exs` set:
```elixir
config :engram, EngramWeb.RateLimiter.Redis,
  url: redis_url, key_prefix: "engram_rl:", timeout: 250
```
`application.ex` passes that keyword list straight into the supervised Redis child's `start_link/1`. But in `Hammer.Redis`:

- `start_link/1` accepts only `{:url, ...} | {:name, ...}`. It pops `:url`, then **forwards every remaining key to `Redix.start_link/1`**.
- `Redix.StartOptions.sanitize/2` runs `NimbleOptions.validate!` against a fixed schema with **no `:key_prefix` key → it raises**. The limiter is a supervised child, so the app fails to boot. Hard crash-loop.
- `prefix` and `timeout` are `use Hammer` **compile-time** options, not runtime start options. Even without the crash, keys would have been prefixed with the module name (`EngramWeb.RateLimiter.Redis:`), never `engram_rl:`, and `timeout: 250` would have set Redix's *connection* timeout, not the per-command timeout the façade's fail-open depends on.

### Fix

- Move `prefix: "engram_rl:"` and `timeout: 250` to the `use Hammer` opts on `EngramWeb.RateLimiter.Redis` (they're static, not secrets).
- Add `start_opts/1` owning the runtime option contract (`[url: redis_url]`), called from `runtime.exs`. Removes the untested inline literal.

### Tests (TDD — red → green)

- `start_opts/1` returns only `[url: ...]`.
- Limiter starts under a supervisor with the production opt shape (Redix connects async, so no live Redis needed).
- Regression guard: `:key_prefix` as a start option crashes the child — documents why the prefix had to move to compile-time.

All 7 rate-limiter tests pass; `mix format`, `mix compile --warnings-as-errors`, and `mix credo` are clean.

> Note: the `engram_rl:` prefix value can only be observed against a live Redis, so that assertion is deferred to the deploy-time check (`redis-cli KEYS 'engram_rl:*'`) — see test plan.

## Test plan

- [ ] CI: unit tests + lints green
- [ ] Deploy with `REDIS_URL` set: `engram-saas` boots (no `NimbleOptions.ValidationError`)
- [ ] Under API traffic, `redis-cli KEYS 'engram_rl:*'` is populated
- [ ] No `[:engram, :rate_limiter, :backend_error]` telemetry under normal operation
- [ ] Stop Redis briefly → app keeps serving (fail-open holds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)