### PR TITLE
Billing settings revamp: in-app management surface (#333)

### DIFF
--- a/docs/context/local-dev-preview-stack.md
+++ b/docs/context/local-dev-preview-stack.md
@@ -1,0 +1,90 @@
+# Local dev preview stack (frontend changes vs. real backend)
+
+_Last verified: 2026-05-28_
+
+## Status
+Working. How to preview frontend changes against a locally-running backend
+without booting against the shared FastRaid Postgres (which fails the boot
+canary). Repeatable.
+
+## The problem
+Sourcing the repo's `.env.local` as-is points `DATABASE_URL` at the **shared
+FastRaid Postgres** (`10.0.20.214:35432`) with `KEY_PROVIDER=local`. Phoenix
+then fails to boot:
+
+```
+** (RuntimeError) boot canary unwrap failed: :malformed_wrapped_blob via provider local
+```
+
+(from `lib/engram/crypto/boot_canary.ex`).
+
+**Root cause:** that shared DB's `system_canaries` row was wrapped with a
+different master key than the `ENCRYPTION_MASTER_KEY` in the local `.env.local`
+(stale after a master-key rotation / KMS work). The boot canary is a security
+guard — **do NOT bypass it.**
+
+## The solution
+Stand up a **fresh empty local Postgres** and reuse everything else from
+`.env.local`. `Engram.Crypto.BootCanary.verify!/0` auto-provisions a fresh
+canary when `system_canaries` is empty (see `boot_canary.ex` ~lines 44-49), so a
+brand-new empty DB boots clean under whatever local `ENCRYPTION_MASTER_KEY` is
+set — no mismatch.
+
+So the **only** override needed is `DATABASE_URL` → fresh local PG. Reuse the
+rest of `.env.local` as-is: Clerk vars, Paddle sandbox vars, shared
+`QDRANT_URL` / `OLLAMA_URL` / MinIO, and the same `ENCRYPTION_MASTER_KEY`.
+
+## Steps
+
+### 1. Fresh local Postgres (one-time; `docker start engram-dev-pg` after)
+```bash
+docker run -d --name engram-dev-pg \
+  -e POSTGRES_USER=engram -e POSTGRES_PASSWORD=engram -e POSTGRES_DB=engram \
+  -p 55432:5432 postgres:16-alpine
+```
+
+### 2. Backend (Phoenix on :4000)
+```bash
+set -a; source .env.local; set +a
+export DATABASE_URL="postgresql://engram:engram@localhost:55432/engram"
+mix ecto.migrate
+mix phx.server
+```
+
+### 3. Frontend (Vite)
+Worktree env files are gitignored, so copy them from the main checkout first:
+```bash
+cp ../../.env.local .env.local
+cp ../../frontend/.env.local frontend/.env.local
+```
+Append to `frontend/.env.local`:
+```
+VITE_AUTH_PROVIDER=clerk
+VITE_BILLING_ENABLED=true
+```
+Start Vite (proxies `/api` → `http://localhost:4000` per `vite.config`):
+```bash
+bunx vite --host 0.0.0.0 --port 5174
+```
+Use a non-default port if `:5173` is taken by another worktree's stale Vite.
+
+## Gotchas
+- **A git worktree does NOT carry gitignored env files** (`.env.local`,
+  `frontend/.env.local`). Copy them from the main checkout (step 3).
+- **Onboarding gate blocks the vault + `/settings`** when `billing_enabled=true`
+  (`PADDLE_API_KEY` set) until the user accepts terms (click through the
+  agreement screen) AND has an active subscription. Seed one directly:
+  ```bash
+  docker exec engram-dev-pg psql -U engram -d engram -c \
+  "INSERT INTO subscriptions (user_id, tier, status, current_period_end, paddle_customer_id, paddle_subscription_id, custom_data, created_at, updated_at) VALUES (<user_id>, 'pro', 'active', now() at time zone 'utc' + interval '30 days', 'ctm_dev_seed', 'sub_dev_seed', '{}'::jsonb, now() at time zone 'utc', now() at time zone 'utc');"
+  ```
+- **Seeded row has FAKE Paddle ids.** Any endpoint that calls Paddle live
+  (`GET /api/billing/subscription`, `/transactions`, payment-update-transaction)
+  will 404 at Paddle → 502. The DB-only `/api/billing/status` endpoint works
+  fine. To exercise the live Paddle-backed UI you need a **real sandbox
+  checkout** so the ids are real.
+
+## References
+- Boot canary auto-provision: `lib/engram/crypto/boot_canary.ex` (`verify!/0`, ~lines 44-49)
+- Dev iteration loop (Phoenix :4000 vs Vite :5173, prod-bundle rebuild): `docs/context/dev-iteration-loop.md`
+- Boot-canary / master-key gotcha on a throwaway DB: `docs/context/local-supabase-audit.md` (Gotcha 3)

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -163,6 +163,54 @@ export function useBillingConfig() {
   })
 }
 
+export interface SubscriptionDetail {
+  next_billed_at: string | null
+  amount: string | null
+  currency: string | null
+  billing_cycle: { interval: string; frequency: number } | null
+  scheduled_change: { action: string; effective_at: string } | null
+}
+
+export interface PaymentMethod {
+  type: string | null
+  card_brand: string | null
+  last4: string | null
+  exp_month: number | null
+  exp_year: number | null
+}
+
+export interface BillingTransaction {
+  id: string
+  billed_at: string | null
+  amount: string | null
+  currency: string | null
+  status: string
+  invoice_id: string | null
+}
+
+export interface BillingHistory {
+  payment_method: PaymentMethod | null
+  transactions: BillingTransaction[]
+}
+
+// Live read-through endpoints — only meaningful for users with a Paddle
+// subscription (they 404 otherwise), so callers gate with `enabled`.
+export function useBillingSubscriptionDetail(enabled: boolean) {
+  return useQuery({
+    queryKey: ['billing', 'subscription'],
+    queryFn: () => api.get<SubscriptionDetail>('/billing/subscription'),
+    enabled,
+  })
+}
+
+export function useBillingHistory(enabled: boolean) {
+  return useQuery({
+    queryKey: ['billing', 'transactions'],
+    queryFn: () => api.get<BillingHistory>('/billing/transactions'),
+    enabled,
+  })
+}
+
 // Onboarding types
 
 export interface OnboardingStatus {

--- a/frontend/src/billing/billing-history-table.test.tsx
+++ b/frontend/src/billing/billing-history-table.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import BillingHistoryTable from './billing-history-table'
+import type { BillingTransaction } from '../api/queries'
+
+const txns: BillingTransaction[] = [
+  {
+    id: 'txn_2',
+    billed_at: '2026-05-27T07:00:00Z',
+    amount: '2000',
+    currency: 'USD',
+    status: 'completed',
+    invoice_id: 'inv_2',
+  },
+  {
+    id: 'txn_1',
+    billed_at: '2026-04-27T07:00:00Z',
+    amount: '2000',
+    currency: 'USD',
+    status: 'past_due',
+    invoice_id: 'inv_1',
+  },
+]
+
+describe('BillingHistoryTable', () => {
+  it('renders a row per transaction with formatted amount and status', () => {
+    render(<BillingHistoryTable transactions={txns} onDownload={() => {}} />)
+    expect(screen.getAllByText('$20.00')).toHaveLength(2)
+    expect(screen.getByText(/completed/i)).toBeInTheDocument()
+    expect(screen.getByText(/past due/i)).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no transactions', () => {
+    render(<BillingHistoryTable transactions={[]} onDownload={() => {}} />)
+    expect(screen.getByText(/no transactions/i)).toBeInTheDocument()
+  })
+
+  it('calls onDownload with the transaction id', async () => {
+    const onDownload = vi.fn()
+    render(<BillingHistoryTable transactions={txns} onDownload={onDownload} />)
+    const [firstDownload] = screen.getAllByRole('button', { name: /download/i })
+    fireEvent.click(firstDownload as HTMLElement)
+    expect(onDownload).toHaveBeenCalledWith('txn_2')
+  })
+})

--- a/frontend/src/billing/billing-history-table.tsx
+++ b/frontend/src/billing/billing-history-table.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@/components/ui/button'
+import type { BillingTransaction } from '../api/queries'
+import { formatMoney } from './format'
+
+export default function BillingHistoryTable({
+  transactions,
+  onDownload,
+  downloadingId = null,
+}: {
+  transactions: BillingTransaction[]
+  onDownload: (id: string) => void
+  downloadingId?: string | null
+}) {
+  return (
+    <section className="space-y-4 rounded-lg border border-border bg-card p-6">
+      <h2 className="text-lg font-semibold text-foreground">Billing history</h2>
+
+      {transactions.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No transactions yet.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="pb-2 font-medium">Date</th>
+              <th className="pb-2 font-medium">Amount</th>
+              <th className="pb-2 font-medium">Status</th>
+              <th className="pb-2 text-right font-medium">Invoice</th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((t) => (
+              <tr key={t.id} className="border-t border-border">
+                <td className="py-2">
+                  {t.billed_at ? new Date(t.billed_at).toLocaleDateString() : '—'}
+                </td>
+                <td className="py-2">{formatMoney(t.amount, t.currency) ?? '—'}</td>
+                <td className="py-2 capitalize">{t.status.replace('_', ' ')}</td>
+                <td className="py-2 text-right">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onDownload(t.id)}
+                    disabled={downloadingId === t.id}
+                  >
+                    Download
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -10,6 +10,7 @@ import {
 import { api } from '../api/client'
 import { useTheme } from '../theme/theme-provider'
 import { cn } from '@/lib/utils'
+import CurrentPlanCard from './current-plan-card'
 
 // Paddle confirms checkout client-side (checkout.completed) before its webhook
 // reaches our backend and flips the subscription active, so a single refetch
@@ -18,14 +19,6 @@ import { cn } from '@/lib/utils'
 // onboarding redirect fires without a manual reload.
 const ACTIVATION_POLL_MS = 2000
 const ACTIVATION_POLL_TIMEOUT_MS = 30000
-
-const TIER_LABELS = {
-  free: 'Free',
-  none: 'No Plan',
-  trial: 'Free Trial',
-  starter: 'Starter',
-  pro: 'Pro',
-} as const
 
 export default function BillingPage({ hideHeading = false }: { hideHeading?: boolean }) {
   const { data: billing, isLoading } = useBillingStatus()
@@ -100,7 +93,6 @@ export default function BillingPage({ hideHeading = false }: { hideHeading?: boo
   }
 
   const needsSubscription = !billing.active
-  const isTrial = billing.subscription?.status === 'trialing'
   const checkoutReady = Boolean(paddle && config)
 
   return (
@@ -124,44 +116,7 @@ export default function BillingPage({ hideHeading = false }: { hideHeading?: boo
         </div>
       )}
 
-      {!hideHeading && (
-        <section className="space-y-4 rounded-lg border border-border bg-card p-6">
-          <header className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-foreground">Current Plan</h2>
-            <span className="rounded-full bg-secondary px-3 py-1 text-sm font-medium text-secondary-foreground">
-              {TIER_LABELS[billing.tier]}
-            </span>
-          </header>
-
-          {needsSubscription && (
-            <p className="text-sm text-muted-foreground">
-              Choose a plan below to start your 7-day free trial. A card is required but you
-              won't be charged until the trial ends.
-            </p>
-          )}
-
-          {isTrial && billing.trial_days_remaining > 0 && (
-            <p className="text-sm text-muted-foreground">
-              {billing.trial_days_remaining} days remaining in your free trial.
-            </p>
-          )}
-
-          {billing.subscription && (
-            <dl className="grid grid-cols-2 gap-4 text-sm">
-              <dt className="text-muted-foreground">Status</dt>
-              <dd className="font-medium capitalize">{billing.subscription.status.replace('_', ' ')}</dd>
-              {billing.subscription.current_period_end && (
-                <>
-                  <dt className="text-muted-foreground">Current period ends</dt>
-                  <dd className="font-medium">
-                    {new Date(billing.subscription.current_period_end).toLocaleDateString()}
-                  </dd>
-                </>
-              )}
-            </dl>
-          )}
-        </section>
-      )}
+      {!hideHeading && <CurrentPlanCard billing={billing} />}
 
       {needsSubscription && (
         <section className="space-y-4">

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -1,16 +1,42 @@
 import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { CheckoutEventNames, initializePaddle, type Paddle } from '@paddle/paddle-js'
+import { toast } from 'sonner'
 import {
   useBillingStatus,
   useBillingConfig,
+  useBillingSubscriptionDetail,
+  useBillingHistory,
   type BillingConfig,
   type OnboardingStatus,
 } from '../api/queries'
 import { api } from '../api/client'
 import { useTheme } from '../theme/theme-provider'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import CurrentPlanCard from './current-plan-card'
+import PaymentMethodCard from './payment-method-card'
+import BillingHistoryTable from './billing-history-table'
+import PendingChangeBanner from './pending-change-banner'
+
+async function openPortal(action?: string) {
+  try {
+    const path = action ? `/billing/portal?action=${action}` : '/billing/portal'
+    const { url } = await api.get<{ url: string }>(path)
+    window.location.href = url
+  } catch {
+    toast.error('Could not open the billing portal. Please try again.')
+  }
+}
+
+async function downloadInvoice(transactionId: string) {
+  try {
+    const { url } = await api.get<{ url: string }>(`/billing/transactions/${transactionId}/invoice`)
+    window.open(url, '_blank', 'noopener')
+  } catch {
+    toast.error('Could not fetch that invoice. Please try again.')
+  }
+}
 
 // Paddle confirms checkout client-side (checkout.completed) before its webhook
 // reaches our backend and flips the subscription active, so a single refetch
@@ -23,6 +49,9 @@ const ACTIVATION_POLL_TIMEOUT_MS = 30000
 export default function BillingPage({ hideHeading = false }: { hideHeading?: boolean }) {
   const { data: billing, isLoading } = useBillingStatus()
   const { data: config } = useBillingConfig()
+  const hasSubscription = Boolean(billing?.subscription)
+  const { data: detail } = useBillingSubscriptionDetail(hasSubscription)
+  const { data: history } = useBillingHistory(hasSubscription)
   const { resolved } = useTheme()
   const qc = useQueryClient()
   const [paddle, setPaddle] = useState<Paddle>()
@@ -150,15 +179,28 @@ export default function BillingPage({ hideHeading = false }: { hideHeading?: boo
         </section>
       )}
 
-      {billing.subscription && billing.subscription.status !== 'canceled' && (
-        <section>
-          <button
-            onClick={handlePortal}
-            className="text-sm text-primary underline hover:text-primary/80"
-          >
-            Manage subscription
-          </button>
-        </section>
+      {!hideHeading && billing.subscription && (
+        <>
+          <PendingChangeBanner scheduledChange={detail?.scheduled_change ?? null} />
+          <PaymentMethodCard
+            paymentMethod={history?.payment_method ?? null}
+            onUpdate={() => openPortal('update_payment')}
+          />
+          <BillingHistoryTable
+            transactions={history?.transactions ?? []}
+            onDownload={downloadInvoice}
+          />
+          <section className="flex flex-wrap gap-3">
+            <Button variant="outline" onClick={() => openPortal()}>
+              Manage in Paddle
+            </Button>
+            {billing.subscription.status !== 'canceled' && (
+              <Button variant="ghost" onClick={() => openPortal('cancel')}>
+                Cancel subscription
+              </Button>
+            )}
+          </section>
+        </>
       )}
     </article>
   )
@@ -233,9 +275,4 @@ function PlanCard({
       </button>
     </li>
   )
-}
-
-async function handlePortal() {
-  const { url } = await api.get<{ url: string }>('/billing/portal')
-  window.location.href = url
 }

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -102,6 +102,11 @@ export default function BillingPage({ hideHeading = false }: { hideHeading?: boo
       eventCallback: (event) => {
         if (event.name === CheckoutEventNames.CHECKOUT_COMPLETED) {
           setActivationStuck(false)
+          // Refresh the live billing surface so an updated card / plan shows
+          // without a reload. The subscription-activation poll handles the
+          // separate onboarding-gate race below.
+          qc.invalidateQueries({ queryKey: ['billing', 'subscription'] })
+          qc.invalidateQueries({ queryKey: ['billing', 'transactions'] })
           pollUntilActive(Date.now() + ACTIVATION_POLL_TIMEOUT_MS)
         }
       },
@@ -123,6 +128,24 @@ export default function BillingPage({ hideHeading = false }: { hideHeading?: boo
 
   const needsSubscription = !billing.active
   const checkoutReady = Boolean(paddle && config)
+
+  async function handleUpdatePayment() {
+    // No initialized Paddle.js yet — fall back to the hosted portal so the
+    // action still works rather than silently no-opping.
+    if (!paddle) {
+      openPortal('update_payment')
+      return
+    }
+
+    try {
+      const { transaction_id } = await api.get<{ transaction_id: string }>(
+        '/billing/payment-update-transaction',
+      )
+      paddle.Checkout.open({ transactionId: transaction_id })
+    } catch {
+      toast.error('Could not start the payment update. Please try again.')
+    }
+  }
 
   return (
     <article className="space-y-6">
@@ -184,7 +207,7 @@ export default function BillingPage({ hideHeading = false }: { hideHeading?: boo
           <PendingChangeBanner scheduledChange={detail?.scheduled_change ?? null} />
           <PaymentMethodCard
             paymentMethod={history?.payment_method ?? null}
-            onUpdate={() => openPortal('update_payment')}
+            onUpdate={handleUpdatePayment}
           />
           <BillingHistoryTable
             transactions={history?.transactions ?? []}

--- a/frontend/src/billing/current-plan-card.test.tsx
+++ b/frontend/src/billing/current-plan-card.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CurrentPlanCard from './current-plan-card'
+import type { BillingStatus } from '../api/queries'
+
+function status(overrides: Partial<BillingStatus> = {}): BillingStatus {
+  return {
+    tier: 'starter',
+    active: true,
+    trial_days_remaining: 0,
+    subscription: { status: 'active', tier: 'starter', current_period_end: '2026-07-01T12:00:00Z' },
+    ...overrides,
+  }
+}
+
+describe('CurrentPlanCard', () => {
+  it('shows the tier label and active status', () => {
+    render(<CurrentPlanCard billing={status()} />)
+    expect(screen.getByText('Starter')).toBeInTheDocument()
+    expect(screen.getByText(/active/i)).toBeInTheDocument()
+  })
+
+  it('labels the period-end date as a renewal when the subscription is active', () => {
+    render(<CurrentPlanCard billing={status()} />)
+    expect(screen.getByText(/renews on/i)).toBeInTheDocument()
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+  })
+
+  it('labels the period-end date as access-ending when canceled', () => {
+    render(
+      <CurrentPlanCard
+        billing={status({
+          active: false,
+          subscription: { status: 'canceled', tier: 'pro', current_period_end: '2026-07-01T12:00:00Z' },
+        })}
+      />,
+    )
+    expect(screen.getByText(/access ends on/i)).toBeInTheDocument()
+    expect(screen.queryByText(/renews on/i)).not.toBeInTheDocument()
+  })
+
+  it('surfaces remaining trial days while trialing', () => {
+    render(
+      <CurrentPlanCard
+        billing={status({
+          tier: 'trial',
+          trial_days_remaining: 5,
+          subscription: { status: 'trialing', tier: 'starter', current_period_end: '2026-07-01T12:00:00Z' },
+        })}
+      />,
+    )
+    expect(screen.getByText(/5 days/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/billing/current-plan-card.tsx
+++ b/frontend/src/billing/current-plan-card.tsx
@@ -1,0 +1,51 @@
+import type { BillingStatus } from '../api/queries'
+
+const TIER_LABELS: Record<BillingStatus['tier'], string> = {
+  free: 'Free',
+  none: 'No Plan',
+  trial: 'Free Trial',
+  starter: 'Starter',
+  pro: 'Pro',
+}
+
+export default function CurrentPlanCard({ billing }: { billing: BillingStatus }) {
+  const sub = billing.subscription
+  const canceled = sub?.status === 'canceled'
+  const trialing = sub?.status === 'trialing'
+  const periodEnd = sub?.current_period_end
+    ? new Date(sub.current_period_end).toLocaleDateString()
+    : null
+  // A canceled subscription keeps access until the period ends, so the same
+  // date means "renews" while live and "access ends" once cancellation is set.
+  const periodLabel = canceled ? 'Access ends on' : 'Renews on'
+
+  return (
+    <section className="space-y-4 rounded-lg border border-border bg-card p-6">
+      <header className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-foreground">Current Plan</h2>
+        <span className="rounded-full bg-secondary px-3 py-1 text-sm font-medium text-secondary-foreground">
+          {TIER_LABELS[billing.tier]}
+        </span>
+      </header>
+
+      {trialing && billing.trial_days_remaining > 0 && (
+        <p className="text-sm text-muted-foreground">
+          {billing.trial_days_remaining} days remaining in your free trial.
+        </p>
+      )}
+
+      {sub && (
+        <dl className="grid grid-cols-2 gap-4 text-sm">
+          <dt className="text-muted-foreground">Status</dt>
+          <dd className="font-medium capitalize">{sub.status.replace('_', ' ')}</dd>
+          {periodEnd && (
+            <>
+              <dt className="text-muted-foreground">{periodLabel}</dt>
+              <dd className="font-medium">{periodEnd}</dd>
+            </>
+          )}
+        </dl>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/billing/format.test.ts
+++ b/frontend/src/billing/format.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { formatMoney } from './format'
+
+describe('formatMoney', () => {
+  it('formats two-decimal currencies from minor units', () => {
+    expect(formatMoney('2000', 'USD', 'en-US')).toBe('$20.00')
+    expect(formatMoney('1234', 'USD', 'en-US')).toBe('$12.34')
+  })
+
+  it('formats zero-decimal currencies without dividing', () => {
+    // JPY has no minor unit — 2000 minor units is ¥2,000, not ¥20.
+    expect(formatMoney('2000', 'JPY', 'en-US')).toBe('¥2,000')
+  })
+
+  it('returns null for a missing amount', () => {
+    expect(formatMoney(null, 'USD')).toBeNull()
+    expect(formatMoney(undefined, 'USD')).toBeNull()
+  })
+
+  it('returns null when currency is missing', () => {
+    expect(formatMoney('2000', null)).toBeNull()
+  })
+})

--- a/frontend/src/billing/format.ts
+++ b/frontend/src/billing/format.ts
@@ -1,0 +1,22 @@
+// Paddle returns money as a string in the currency's minor units ("2000" =
+// $20.00 for USD, but ¥2000 for the zero-decimal JPY). Derive the minor-unit
+// digit count from Intl so we handle 0-, 2-, and 3-decimal currencies without
+// a hardcoded table, then format in the caller's locale.
+export function formatMoney(
+  minorUnits: string | null | undefined,
+  currency: string | null | undefined,
+  locale?: string,
+): string | null {
+  if (minorUnits == null || currency == null) return null
+
+  const amount = Number(minorUnits)
+  if (Number.isNaN(amount)) return null
+
+  const digits =
+    new Intl.NumberFormat('en', { style: 'currency', currency }).resolvedOptions()
+      .maximumFractionDigits ?? 2
+
+  const major = amount / 10 ** digits
+
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(major)
+}

--- a/frontend/src/billing/payment-method-card.test.tsx
+++ b/frontend/src/billing/payment-method-card.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import PaymentMethodCard from './payment-method-card'
+
+describe('PaymentMethodCard', () => {
+  it('renders the card brand, last4, and expiry', () => {
+    render(
+      <PaymentMethodCard
+        paymentMethod={{
+          type: 'card',
+          card_brand: 'visa',
+          last4: '4242',
+          exp_month: 3,
+          exp_year: 2027,
+        }}
+        onUpdate={() => {}}
+      />,
+    )
+    expect(screen.getByText(/visa/i)).toBeInTheDocument()
+    expect(screen.getByText(/4242/)).toBeInTheDocument()
+    expect(screen.getByText(/03\/2027/)).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no method is on file', () => {
+    render(<PaymentMethodCard paymentMethod={null} onUpdate={() => {}} />)
+    expect(screen.getByText(/no payment method/i)).toBeInTheDocument()
+  })
+
+  it('calls onUpdate when the Update button is clicked', async () => {
+    const onUpdate = vi.fn()
+    render(<PaymentMethodCard paymentMethod={null} onUpdate={onUpdate} />)
+    fireEvent.click(screen.getByRole('button', { name: /update/i }))
+    expect(onUpdate).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/billing/payment-method-card.tsx
+++ b/frontend/src/billing/payment-method-card.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@/components/ui/button'
+import type { PaymentMethod } from '../api/queries'
+
+function formatExpiry(month: number | null, year: number | null): string | null {
+  if (!month || !year) return null
+  return `${String(month).padStart(2, '0')}/${year}`
+}
+
+export default function PaymentMethodCard({
+  paymentMethod,
+  onUpdate,
+  updating = false,
+}: {
+  paymentMethod: PaymentMethod | null
+  onUpdate: () => void
+  updating?: boolean
+}) {
+  const expiry = formatExpiry(paymentMethod?.exp_month ?? null, paymentMethod?.exp_year ?? null)
+
+  return (
+    <section className="space-y-4 rounded-lg border border-border bg-card p-6">
+      <header className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-foreground">Payment method</h2>
+        <Button variant="outline" size="sm" onClick={onUpdate} disabled={updating}>
+          Update
+        </Button>
+      </header>
+
+      {paymentMethod?.last4 ? (
+        <p className="text-sm text-muted-foreground">
+          <span className="font-medium capitalize text-foreground">{paymentMethod.card_brand}</span>
+          {' •••• '}
+          {paymentMethod.last4}
+          {expiry && <span> · expires {expiry}</span>}
+        </p>
+      ) : (
+        <p className="text-sm text-muted-foreground">No payment method on file.</p>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/billing/pending-change-banner.test.tsx
+++ b/frontend/src/billing/pending-change-banner.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import PendingChangeBanner from './pending-change-banner'
+
+describe('PendingChangeBanner', () => {
+  it('announces a scheduled cancellation with its effective date', () => {
+    render(
+      <PendingChangeBanner
+        scheduledChange={{ action: 'cancel', effective_at: '2026-06-27T07:00:00Z' }}
+      />,
+    )
+    expect(screen.getByText(/cancels/i)).toBeInTheDocument()
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no scheduled change', () => {
+    const { container } = render(<PendingChangeBanner scheduledChange={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/billing/pending-change-banner.tsx
+++ b/frontend/src/billing/pending-change-banner.tsx
@@ -1,0 +1,26 @@
+import type { SubscriptionDetail } from '../api/queries'
+
+const ACTION_LABELS: Record<string, string> = {
+  cancel: 'Your plan cancels',
+  pause: 'Your plan pauses',
+  resume: 'Your plan resumes',
+}
+
+export default function PendingChangeBanner({
+  scheduledChange,
+}: {
+  scheduledChange: SubscriptionDetail['scheduled_change']
+}) {
+  if (!scheduledChange) return null
+
+  const label = ACTION_LABELS[scheduledChange.action] ?? 'Your plan changes'
+  const date = new Date(scheduledChange.effective_at).toLocaleDateString()
+
+  return (
+    <aside role="status" className="rounded-lg border border-border bg-secondary/50 p-4 text-sm">
+      <p className="font-medium text-foreground">
+        {label} on {date}
+      </p>
+    </aside>
+  )
+}

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { loadConfig } from './config'
+
+type InjectedConfig = Record<string, unknown>
+
+function inject(value: InjectedConfig | undefined) {
+  ;(window as unknown as { __ENGRAM_CONFIG__?: InjectedConfig }).__ENGRAM_CONFIG__ = value
+}
+
+describe('loadConfig', () => {
+  afterEach(() => {
+    inject(undefined)
+  })
+
+  it('reads billingEnabled=true from injected config', () => {
+    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', billingEnabled: true })
+    expect(loadConfig().billingEnabled).toBe(true)
+  })
+
+  it('treats a missing billingEnabled as false', () => {
+    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test' })
+    expect(loadConfig().billingEnabled).toBe(false)
+  })
+
+  it('coerces non-boolean billingEnabled to false (never truthy-by-accident)', () => {
+    inject({ authProvider: 'local', clerkPublishableKey: '', billingEnabled: 'yes' })
+    expect(loadConfig().billingEnabled).toBe(false)
+  })
+})

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,11 +1,12 @@
 export interface EngramConfig {
   authProvider: 'local' | 'clerk'
   clerkPublishableKey: string
+  billingEnabled: boolean
 }
 
 const VALID_PROVIDERS = ['local', 'clerk'] as const
 
-function loadConfig(): EngramConfig {
+export function loadConfig(): EngramConfig {
   const injected = (window as unknown as { __ENGRAM_CONFIG__?: Record<string, unknown> })
     .__ENGRAM_CONFIG__
 
@@ -13,6 +14,7 @@ function loadConfig(): EngramConfig {
     return {
       authProvider: injected.authProvider as 'local' | 'clerk',
       clerkPublishableKey: (injected.clerkPublishableKey as string) ?? '',
+      billingEnabled: injected.billingEnabled === true,
     }
   }
 
@@ -27,6 +29,7 @@ function loadConfig(): EngramConfig {
   return {
     authProvider: (import.meta.env.VITE_AUTH_PROVIDER as 'local' | 'clerk') ?? 'local',
     clerkPublishableKey: import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
+    billingEnabled: import.meta.env.VITE_BILLING_ENABLED === 'true',
   }
 }
 

--- a/frontend/src/onboarding/onboard-billing-page.test.tsx
+++ b/frontend/src/onboarding/onboard-billing-page.test.tsx
@@ -28,6 +28,8 @@ vi.mock('../api/queries', () => ({
       custom_data: { user_id: 1 },
     },
   }),
+  useBillingSubscriptionDetail: () => ({ data: undefined }),
+  useBillingHistory: () => ({ data: undefined }),
 }))
 
 function renderPage() {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -87,7 +87,9 @@ export const router = createBrowserRouter(
                     ]
                   : []),
                 { path: 'api-keys', element: <ApiKeysPage /> },
-                { path: 'billing', element: <BillingPage /> },
+                ...(config.billingEnabled
+                  ? [{ path: 'billing', element: <BillingPage /> }]
+                  : []),
               ],
             },
             { path: ROUTES.DEVICE_LINK, element: <DeviceLinkPage /> },

--- a/frontend/src/settings/sections.test.ts
+++ b/frontend/src/settings/sections.test.ts
@@ -3,13 +3,24 @@ import { buildSettingsSections } from './sections'
 
 describe('buildSettingsSections', () => {
   it('prepends Account for clerk auth', () => {
-    const sections = buildSettingsSections('clerk')
+    const sections = buildSettingsSections('clerk', true)
     expect(sections.map((s) => s.to)).toEqual(['account', 'api-keys', 'billing'])
   })
 
   it('omits Account for local auth', () => {
-    const sections = buildSettingsSections('local')
+    const sections = buildSettingsSections('local', true)
     expect(sections.map((s) => s.to)).toEqual(['api-keys', 'billing'])
     expect(sections.some((s) => s.to === 'account')).toBe(false)
+  })
+
+  it('omits Billing when billing is disabled (self-host)', () => {
+    const sections = buildSettingsSections('local', false)
+    expect(sections.map((s) => s.to)).toEqual(['api-keys'])
+    expect(sections.some((s) => s.to === 'billing')).toBe(false)
+  })
+
+  it('keeps Account but drops Billing for clerk auth with billing disabled', () => {
+    const sections = buildSettingsSections('clerk', false)
+    expect(sections.map((s) => s.to)).toEqual(['account', 'api-keys'])
   })
 })

--- a/frontend/src/settings/sections.ts
+++ b/frontend/src/settings/sections.ts
@@ -5,16 +5,16 @@ export interface SettingsSection {
   label: string
 }
 
-const BASE_SECTIONS: SettingsSection[] = [
-  { to: 'api-keys', label: 'API Keys' },
-  { to: 'billing', label: 'Billing' },
-]
-
 export function buildSettingsSections(
   authProvider: EngramConfig['authProvider'],
+  billingEnabled: boolean,
 ): SettingsSection[] {
-  if (authProvider === 'clerk') {
-    return [{ to: 'account', label: 'Account' }, ...BASE_SECTIONS]
+  const sections: SettingsSection[] = [{ to: 'api-keys', label: 'API Keys' }]
+  if (billingEnabled) {
+    sections.push({ to: 'billing', label: 'Billing' })
   }
-  return BASE_SECTIONS
+  if (authProvider === 'clerk') {
+    return [{ to: 'account', label: 'Account' }, ...sections]
+  }
+  return sections
 }

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -5,7 +5,9 @@ import SettingsLayout from './settings-layout'
 
 vi.mock('../theme/theme-toggle', () => ({ default: () => null }))
 vi.mock('../layout/user-menu', () => ({ default: () => null }))
-vi.mock('../config', () => ({ config: { authProvider: 'clerk', clerkPublishableKey: '' } }))
+vi.mock('../config', () => ({
+  config: { authProvider: 'clerk', clerkPublishableKey: '', billingEnabled: true },
+}))
 
 function renderAt(path: string) {
   return render(

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -45,7 +45,7 @@ function SettingsNavList({
 }
 
 export default function SettingsLayout() {
-  const sections = buildSettingsSections(config.authProvider)
+  const sections = buildSettingsSections(config.authProvider, config.billingEnabled)
   const [navOpen, setNavOpen] = useState(false)
 
   return (

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -11,6 +11,7 @@ defmodule Engram.Billing do
   alias Engram.Billing.PlanCache
   alias Engram.Billing.Subscription
   alias Engram.Billing.UserLimitOverride
+  alias Engram.Paddle.Client
   alias Engram.Repo
 
   defmodule UnknownLimitKey do
@@ -195,12 +196,163 @@ defmodule Engram.Billing do
   def create_portal_session(user) do
     case get_subscription(user) do
       %Subscription{paddle_customer_id: customer_id} when is_binary(customer_id) ->
-        Engram.Paddle.Client.impl().create_customer_portal_session(customer_id)
+        Client.impl().create_customer_portal_session(customer_id)
 
       _ ->
         {:error, :no_subscription}
     end
   end
+
+  # ── Live Paddle Read-Through (billing settings surface) ────────
+  #
+  # The subscription detail, payment method, and invoice history are fetched
+  # live from Paddle per page load rather than persisted — the webhook row
+  # only carries tier/status/period-end, and mirroring the rest would couple
+  # us to stale data. All of these short-circuit to {:error, :no_subscription}
+  # for users without a Paddle subscription.
+
+  @doc """
+  Fetch and normalize the user's live subscription detail: next bill, amount
+  (Paddle minor units + currency for the frontend to format), billing cycle,
+  and any pending `scheduled_change` (cancel/pause/plan change).
+  """
+  def subscription_detail(user) do
+    with_paddle_subscription(user, fn sub ->
+      case Client.impl().get_subscription(sub.paddle_subscription_id) do
+        {:ok, raw} -> {:ok, normalize_subscription(raw)}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
+  end
+
+  @doc """
+  Fetch the user's transaction history plus the card behind the most recent
+  card payment. Returns `%{payment_method: pm | nil, transactions: [...]}`.
+  """
+  def billing_history(user) do
+    with_paddle_subscription(user, fn sub ->
+      case Client.impl().list_transactions(sub.paddle_subscription_id) do
+        {:ok, txns} ->
+          {:ok,
+           %{
+             payment_method: payment_method_from(txns),
+             transactions: Enum.map(txns, &normalize_transaction/1)
+           }}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end)
+  end
+
+  @doc """
+  Mint the hosted invoice URL for one of the user's transactions. Verifies the
+  transaction belongs to the user's subscription before minting (IDOR guard) —
+  Paddle transaction IDs are otherwise enumerable across customers.
+  """
+  def transaction_invoice_url(user, transaction_id) do
+    with_paddle_subscription(user, fn sub ->
+      case Client.impl().list_transactions(sub.paddle_subscription_id) do
+        {:ok, txns} ->
+          if Enum.any?(txns, &(&1["id"] == transaction_id)) do
+            Client.impl().get_transaction_invoice(transaction_id)
+          else
+            {:error, :not_found}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end)
+  end
+
+  @doc """
+  Resolve a customer-portal deep link for a given action: `"cancel"`,
+  `"update_payment"`, or anything else (→ the general overview URL).
+  """
+  def portal_action_url(user, action) do
+    case get_subscription(user) do
+      %Subscription{paddle_customer_id: customer_id} = sub when is_binary(customer_id) ->
+        case Client.impl().get_portal_session(customer_id) do
+          {:ok, urls} -> {:ok, pick_portal_url(urls, action, sub.paddle_subscription_id)}
+          {:error, reason} -> {:error, reason}
+        end
+
+      _ ->
+        {:error, :no_subscription}
+    end
+  end
+
+  defp with_paddle_subscription(user, fun) do
+    case get_subscription(user) do
+      %Subscription{paddle_subscription_id: sub_id} = sub when is_binary(sub_id) ->
+        fun.(sub)
+
+      _ ->
+        {:error, :no_subscription}
+    end
+  end
+
+  defp normalize_subscription(raw) do
+    %{
+      next_billed_at: raw["next_billed_at"],
+      amount: get_in(raw, ["recurring_transaction_details", "totals", "total"]),
+      currency: raw["currency_code"],
+      billing_cycle: normalize_cycle(raw["billing_cycle"]),
+      scheduled_change: normalize_scheduled_change(raw["scheduled_change"])
+    }
+  end
+
+  defp normalize_cycle(%{"interval" => interval, "frequency" => frequency}),
+    do: %{interval: interval, frequency: frequency}
+
+  defp normalize_cycle(_), do: nil
+
+  defp normalize_scheduled_change(%{"action" => action, "effective_at" => effective_at}),
+    do: %{action: action, effective_at: effective_at}
+
+  defp normalize_scheduled_change(_), do: nil
+
+  defp normalize_transaction(t) do
+    %{
+      id: t["id"],
+      billed_at: t["billed_at"] || t["created_at"],
+      amount: get_in(t, ["details", "totals", "grand_total"]),
+      currency: get_in(t, ["details", "totals", "currency_code"]),
+      status: t["status"],
+      invoice_id: t["invoice_id"]
+    }
+  end
+
+  defp payment_method_from(txns) do
+    Enum.find_value(txns, fn t ->
+      case t["payments"] do
+        [%{"method_details" => %{"card" => card} = md} | _] when is_map(card) ->
+          %{
+            type: md["type"],
+            card_brand: card["type"],
+            last4: card["last4"],
+            exp_month: card["expiry_month"],
+            exp_year: card["expiry_year"]
+          }
+
+        _ ->
+          nil
+      end
+    end)
+  end
+
+  defp pick_portal_url(urls, action, sub_id) do
+    sub_urls = Enum.find(urls["subscriptions"] || [], &(&1["id"] == sub_id)) || %{}
+
+    case action do
+      "cancel" -> sub_urls["cancel_subscription"] || overview_url(urls)
+      "update_payment" -> sub_urls["update_subscription_payment_method"] || overview_url(urls)
+      _ -> overview_url(urls)
+    end
+  end
+
+  defp overview_url(urls), do: get_in(urls, ["general", "overview"])
 
   # ── Webhook Event Processing ───────────────────────────────────
 

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -283,6 +283,20 @@ defmodule Engram.Billing do
     end
   end
 
+  @doc """
+  Mint a transaction for an in-app payment-method update. Returns the Paddle
+  transaction id for `Paddle.Checkout.open({ transactionId })`.
+  """
+  def update_payment_transaction(user) do
+    with_paddle_subscription(user, fn sub ->
+      case Client.impl().get_update_payment_transaction(sub.paddle_subscription_id) do
+        {:ok, %{"id" => transaction_id}} -> {:ok, transaction_id}
+        {:ok, _} -> {:error, :invalid_response}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
+  end
+
   defp with_paddle_subscription(user, fun) do
     case get_subscription(user) do
       %Subscription{paddle_subscription_id: sub_id} = sub when is_binary(sub_id) ->

--- a/lib/engram/paddle/client.ex
+++ b/lib/engram/paddle/client.ex
@@ -19,6 +19,47 @@ defmodule Engram.Paddle.Client do
   @callback create_customer_portal_session(customer_id :: String.t()) ::
               {:ok, url :: String.t()} | {:error, term()}
 
+  @doc """
+  Fetch the raw Paddle subscription object.
+
+  Paddle endpoint: `GET /subscriptions/{id}`. Returns the decoded `data` map
+  verbatim (`next_billed_at`, `billing_cycle`, `scheduled_change`,
+  `recurring_transaction_details`, `currency_code`, …) — normalization is the
+  caller's job so this stays a thin transport.
+  """
+  @callback get_subscription(subscription_id :: String.t()) ::
+              {:ok, map()} | {:error, term()}
+
+  @doc """
+  List the transactions for a subscription, most recent first.
+
+  Paddle endpoint: `GET /transactions?subscription_id={id}`. Returns the
+  decoded `data` list verbatim. Pagination beyond the first page is not
+  followed — the billing-history view shows the most recent page.
+  """
+  @callback list_transactions(subscription_id :: String.t()) ::
+              {:ok, [map()]} | {:error, term()}
+
+  @doc """
+  Fetch the hosted invoice/receipt URL for a completed transaction.
+
+  Paddle endpoint: `GET /transactions/{id}/invoice`. The URL is short-lived,
+  so it is minted on demand rather than persisted.
+  """
+  @callback get_transaction_invoice(transaction_id :: String.t()) ::
+              {:ok, url :: String.t()} | {:error, term()}
+
+  @doc """
+  Create a customer-portal session and return its full `urls` map.
+
+  Paddle endpoint: `POST /customers/{customer_id}/portal-sessions`. Unlike
+  `create_customer_portal_session/1` (which returns only the overview URL),
+  this returns the whole `data.urls` structure including the per-subscription
+  `cancel_subscription` and `update_subscription_payment_method` deep links.
+  """
+  @callback get_portal_session(customer_id :: String.t()) ::
+              {:ok, map()} | {:error, term()}
+
   @default_impl Engram.Paddle.Client.HTTP
 
   @doc "Returns the configured client implementation module."

--- a/lib/engram/paddle/client.ex
+++ b/lib/engram/paddle/client.ex
@@ -60,6 +60,16 @@ defmodule Engram.Paddle.Client do
   @callback get_portal_session(customer_id :: String.t()) ::
               {:ok, map()} | {:error, term()}
 
+  @doc """
+  Fetch a transaction for updating the subscription's payment method in-app.
+
+  Paddle endpoint: `GET /subscriptions/{id}/update-payment-method-transaction`.
+  Returns the decoded `data` map; the `id` feeds `Paddle.Checkout.open({
+  transactionId })` so the card is updated in an overlay without leaving the app.
+  """
+  @callback get_update_payment_transaction(subscription_id :: String.t()) ::
+              {:ok, map()} | {:error, term()}
+
   @default_impl Engram.Paddle.Client.HTTP
 
   @doc "Returns the configured client implementation module."

--- a/lib/engram/paddle/client/http.ex
+++ b/lib/engram/paddle/client/http.ex
@@ -39,6 +39,88 @@ defmodule Engram.Paddle.Client.HTTP do
     end
   end
 
+  @impl true
+  def get_subscription(subscription_id) when is_binary(subscription_id) do
+    with {:ok, api_key} <- fetch_api_key() do
+      url = base_url() <> "/subscriptions/" <> subscription_id
+
+      case Req.get(url, headers: headers(api_key), receive_timeout: 10_000) do
+        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+          {:ok, data}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          log_non_2xx("subscription", status, body)
+          {:error, {:paddle_error, status}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_transactions(subscription_id) when is_binary(subscription_id) do
+    with {:ok, api_key} <- fetch_api_key() do
+      url = base_url() <> "/transactions"
+
+      params = [subscription_id: subscription_id, order_by: "billed_at[DESC]", per_page: 50]
+
+      case Req.get(url, headers: headers(api_key), params: params, receive_timeout: 10_000) do
+        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} when is_list(data) ->
+          {:ok, data}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          log_non_2xx("transactions", status, body)
+          {:error, {:paddle_error, status}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def get_transaction_invoice(transaction_id) when is_binary(transaction_id) do
+    with {:ok, api_key} <- fetch_api_key() do
+      url = base_url() <> "/transactions/" <> transaction_id <> "/invoice"
+
+      case Req.get(url, headers: headers(api_key), receive_timeout: 10_000) do
+        {:ok, %Req.Response{status: 200, body: %{"data" => %{"url" => invoice_url}}}} ->
+          {:ok, invoice_url}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          log_non_2xx("transaction-invoice", status, body)
+          {:error, {:paddle_error, status}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def get_portal_session(customer_id) when is_binary(customer_id) do
+    with {:ok, api_key} <- fetch_api_key() do
+      url = base_url() <> "/customers/" <> customer_id <> "/portal-sessions"
+
+      case Req.post(url, headers: headers(api_key), json: %{}, receive_timeout: 10_000) do
+        {:ok, %Req.Response{status: 201, body: %{"data" => %{"urls" => urls}}}} ->
+          {:ok, urls}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          log_non_2xx("portal-session", status, body)
+          {:error, {:paddle_error, status}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp log_non_2xx(label, status, body) do
+    Logger.warning("Paddle #{label} non-2xx", status: status, reason_label: inspect(body))
+  end
+
   defp fetch_api_key do
     case Application.get_env(:engram, :paddle_api_key) do
       nil -> {:error, :paddle_not_configured}

--- a/lib/engram/paddle/client/http.ex
+++ b/lib/engram/paddle/client/http.ex
@@ -117,6 +117,27 @@ defmodule Engram.Paddle.Client.HTTP do
     end
   end
 
+  @impl true
+  def get_update_payment_transaction(subscription_id) when is_binary(subscription_id) do
+    with {:ok, api_key} <- fetch_api_key() do
+      url =
+        base_url() <>
+          "/subscriptions/" <> subscription_id <> "/update-payment-method-transaction"
+
+      case Req.get(url, headers: headers(api_key), receive_timeout: 10_000) do
+        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+          {:ok, data}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          log_non_2xx("update-payment-transaction", status, body)
+          {:error, {:paddle_error, status}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
   defp log_non_2xx(label, status, body) do
     Logger.warning("Paddle #{label} non-2xx", status: status, reason_label: inspect(body))
   end

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -44,19 +44,77 @@ defmodule EngramWeb.BillingController do
     })
   end
 
-  def customer_portal(conn, _params) do
-    user = conn.assigns.current_user
+  @doc """
+  Customer-portal redirect. Without an `action` param this returns the generic
+  overview URL; with `action=cancel` / `action=update_payment` it returns the
+  matching per-subscription deep link so the UI can offer distinct buttons.
+  """
+  def customer_portal(conn, params) do
+    with_billing(conn, fn ->
+      user = conn.assigns.current_user
 
-    case Billing.create_portal_session(user) do
-      {:ok, url} ->
-        json(conn, %{url: url})
+      result =
+        case params["action"] do
+          nil -> Billing.create_portal_session(user)
+          action -> Billing.portal_action_url(user, action)
+        end
 
-      {:error, :no_subscription} ->
-        conn |> put_status(404) |> json(%{error: "no subscription"})
+      respond_with_url(conn, result)
+    end)
+  end
 
-      {:error, reason} ->
-        Logger.error("Paddle portal error", reason_label: inspect(reason))
-        conn |> put_status(502) |> json(%{error: "payment provider error"})
+  @doc "Live subscription detail (next bill, billing cycle, scheduled change)."
+  def subscription_detail(conn, _params) do
+    with_billing(conn, fn ->
+      case Billing.subscription_detail(conn.assigns.current_user) do
+        {:ok, detail} -> json(conn, detail)
+        {:error, :no_subscription} -> not_found(conn, "no subscription")
+        {:error, reason} -> paddle_error(conn, reason)
+      end
+    end)
+  end
+
+  @doc "Transaction history plus the card behind the latest card payment."
+  def transactions(conn, _params) do
+    with_billing(conn, fn ->
+      case Billing.billing_history(conn.assigns.current_user) do
+        {:ok, history} -> json(conn, history)
+        {:error, :no_subscription} -> not_found(conn, "no subscription")
+        {:error, reason} -> paddle_error(conn, reason)
+      end
+    end)
+  end
+
+  @doc "Mint the hosted invoice URL for one of the user's own transactions."
+  def transaction_invoice(conn, %{"id" => transaction_id}) do
+    with_billing(conn, fn ->
+      case Billing.transaction_invoice_url(conn.assigns.current_user, transaction_id) do
+        {:ok, url} -> json(conn, %{url: url})
+        {:error, :no_subscription} -> not_found(conn, "no subscription")
+        {:error, :not_found} -> not_found(conn, "transaction not found")
+        {:error, reason} -> paddle_error(conn, reason)
+      end
+    end)
+  end
+
+  # Self-host (billing_enabled=false) never reaches Paddle: the page is hidden
+  # client-side, but gate here too so a direct request 404s instead of erroring.
+  defp with_billing(conn, fun) do
+    if Application.get_env(:engram, :billing_enabled, false) == true do
+      fun.()
+    else
+      not_found(conn, "billing disabled")
     end
+  end
+
+  defp respond_with_url(conn, {:ok, url}), do: json(conn, %{url: url})
+  defp respond_with_url(conn, {:error, :no_subscription}), do: not_found(conn, "no subscription")
+  defp respond_with_url(conn, {:error, reason}), do: paddle_error(conn, reason)
+
+  defp not_found(conn, message), do: conn |> put_status(404) |> json(%{error: message})
+
+  defp paddle_error(conn, reason) do
+    Logger.error("Paddle billing error", reason_label: inspect(reason))
+    conn |> put_status(502) |> json(%{error: "payment provider error"})
   end
 end

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -97,6 +97,17 @@ defmodule EngramWeb.BillingController do
     end)
   end
 
+  @doc "Mint a transaction id for the in-app Paddle.js payment-method overlay."
+  def payment_update_transaction(conn, _params) do
+    with_billing(conn, fn ->
+      case Billing.update_payment_transaction(conn.assigns.current_user) do
+        {:ok, transaction_id} -> json(conn, %{transaction_id: transaction_id})
+        {:error, :no_subscription} -> not_found(conn, "no subscription")
+        {:error, reason} -> paddle_error(conn, reason)
+      end
+    end)
+  end
+
   # Self-host (billing_enabled=false) never reaches Paddle: the page is hidden
   # client-side, but gate here too so a direct request 404s instead of erroring.
   defp with_billing(conn, fun) do

--- a/lib/engram_web/controllers/spa_controller.ex
+++ b/lib/engram_web/controllers/spa_controller.ex
@@ -66,7 +66,8 @@ defmodule EngramWeb.SpaController do
 
     config = %{
       authProvider: provider,
-      clerkPublishableKey: Application.get_env(:engram, :clerk_publishable_key, "")
+      clerkPublishableKey: Application.get_env(:engram, :clerk_publishable_key, ""),
+      billingEnabled: Application.get_env(:engram, :billing_enabled, false) == true
     }
 
     json =

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -166,6 +166,9 @@ defmodule EngramWeb.Router do
     get "/billing/status", BillingController, :status
     get "/billing/config", BillingController, :config
     get "/billing/portal", BillingController, :customer_portal
+    get "/billing/subscription", BillingController, :subscription_detail
+    get "/billing/transactions", BillingController, :transactions
+    get "/billing/transactions/:id/invoice", BillingController, :transaction_invoice
 
     # Onboarding wizard — status + TOS acceptance. Exempt from
     # RequireOnboarding (the plug is only on the vault-scoped pipeline)

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -169,6 +169,7 @@ defmodule EngramWeb.Router do
     get "/billing/subscription", BillingController, :subscription_detail
     get "/billing/transactions", BillingController, :transactions
     get "/billing/transactions/:id/invoice", BillingController, :transaction_invoice
+    get "/billing/payment-update-transaction", BillingController, :payment_update_transaction
 
     # Onboarding wizard — status + TOS acceptance. Exempt from
     # RequireOnboarding (the plug is only on the vault-scoped pipeline)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.240",
+      version: "0.5.241",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -143,6 +143,226 @@ defmodule Engram.BillingTest do
     end
   end
 
+  describe "subscription_detail/1" do
+    test "normalizes the Paddle subscription for the user" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :get_subscription, fn "sub_dev" ->
+        {:ok,
+         %{
+           "id" => "sub_dev",
+           "status" => "active",
+           "currency_code" => "USD",
+           "next_billed_at" => "2026-06-27T07:00:00Z",
+           "billing_cycle" => %{"interval" => "month", "frequency" => 1},
+           "scheduled_change" => nil,
+           "recurring_transaction_details" => %{"totals" => %{"total" => "2000"}}
+         }}
+      end)
+
+      assert {:ok, detail} = Billing.subscription_detail(user)
+      assert detail.next_billed_at == "2026-06-27T07:00:00Z"
+      assert detail.amount == "2000"
+      assert detail.currency == "USD"
+      assert detail.billing_cycle == %{interval: "month", frequency: 1}
+      assert detail.scheduled_change == nil
+    end
+
+    test "surfaces a scheduled cancellation" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_cancel")
+
+      expect(Engram.Paddle.ClientMock, :get_subscription, fn "sub_cancel" ->
+        {:ok,
+         %{
+           "id" => "sub_cancel",
+           "status" => "active",
+           "currency_code" => "USD",
+           "scheduled_change" => %{
+             "action" => "cancel",
+             "effective_at" => "2026-06-27T07:00:00Z"
+           }
+         }}
+      end)
+
+      assert {:ok, detail} = Billing.subscription_detail(user)
+      assert detail.scheduled_change == %{action: "cancel", effective_at: "2026-06-27T07:00:00Z"}
+    end
+
+    test "returns :no_subscription when the user has none" do
+      assert {:error, :no_subscription} = Billing.subscription_detail(insert(:user))
+    end
+
+    test "propagates client errors" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_err")
+
+      expect(Engram.Paddle.ClientMock, :get_subscription, fn _ ->
+        {:error, {:paddle_error, 500}}
+      end)
+
+      assert {:error, {:paddle_error, 500}} = Billing.subscription_detail(user)
+    end
+  end
+
+  describe "billing_history/1" do
+    test "normalizes transactions and extracts the card from the latest payment" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :list_transactions, fn "sub_dev" ->
+        {:ok,
+         [
+           %{
+             "id" => "txn_2",
+             "status" => "completed",
+             "billed_at" => "2026-05-27T07:00:00Z",
+             "invoice_id" => "inv_2",
+             "details" => %{"totals" => %{"grand_total" => "2000", "currency_code" => "USD"}},
+             "payments" => [
+               %{
+                 "method_details" => %{
+                   "type" => "card",
+                   "card" => %{
+                     "type" => "visa",
+                     "last4" => "4242",
+                     "expiry_month" => 12,
+                     "expiry_year" => 2027
+                   }
+                 }
+               }
+             ]
+           },
+           %{
+             "id" => "txn_1",
+             "status" => "completed",
+             "billed_at" => "2026-04-27T07:00:00Z",
+             "invoice_id" => "inv_1",
+             "details" => %{"totals" => %{"grand_total" => "2000", "currency_code" => "USD"}},
+             "payments" => []
+           }
+         ]}
+      end)
+
+      assert {:ok, %{payment_method: pm, transactions: txns}} = Billing.billing_history(user)
+      assert pm.card_brand == "visa"
+      assert pm.last4 == "4242"
+      assert pm.exp_month == 12
+      assert pm.exp_year == 2027
+      assert length(txns) == 2
+      assert hd(txns).id == "txn_2"
+      assert hd(txns).amount == "2000"
+      assert hd(txns).currency == "USD"
+      assert hd(txns).status == "completed"
+    end
+
+    test "payment_method is nil when no card payment is present" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_nopm")
+
+      expect(Engram.Paddle.ClientMock, :list_transactions, fn _ ->
+        {:ok, [%{"id" => "txn_x", "status" => "completed", "payments" => []}]}
+      end)
+
+      assert {:ok, %{payment_method: nil, transactions: [_]}} = Billing.billing_history(user)
+    end
+
+    test "returns :no_subscription when the user has none" do
+      assert {:error, :no_subscription} = Billing.billing_history(insert(:user))
+    end
+  end
+
+  describe "transaction_invoice_url/2" do
+    test "returns the invoice URL when the transaction belongs to the user" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :list_transactions, fn "sub_dev" ->
+        {:ok, [%{"id" => "txn_2", "payments" => []}, %{"id" => "txn_1", "payments" => []}]}
+      end)
+
+      expect(Engram.Paddle.ClientMock, :get_transaction_invoice, fn "txn_2" ->
+        {:ok, "https://paddle.com/invoice/txn_2.pdf"}
+      end)
+
+      assert {:ok, "https://paddle.com/invoice/txn_2.pdf"} =
+               Billing.transaction_invoice_url(user, "txn_2")
+    end
+
+    test "rejects a transaction id that does not belong to the user (IDOR guard)" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :list_transactions, fn "sub_dev" ->
+        {:ok, [%{"id" => "txn_2", "payments" => []}]}
+      end)
+
+      # get_transaction_invoice must NOT be called for a foreign id.
+      assert {:error, :not_found} = Billing.transaction_invoice_url(user, "txn_999")
+    end
+  end
+
+  describe "portal_action_url/2" do
+    setup do
+      urls = %{
+        "general" => %{"overview" => "https://p/overview"},
+        "subscriptions" => [
+          %{
+            "id" => "sub_dev",
+            "cancel_subscription" => "https://p/cancel",
+            "update_subscription_payment_method" => "https://p/update"
+          }
+        ]
+      }
+
+      {:ok, urls: urls}
+    end
+
+    test "returns the cancel deep link", %{urls: urls} do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_customer_id: "ctm_dev",
+        paddle_subscription_id: "sub_dev"
+      )
+
+      expect(Engram.Paddle.ClientMock, :get_portal_session, fn "ctm_dev" -> {:ok, urls} end)
+      assert {:ok, "https://p/cancel"} = Billing.portal_action_url(user, "cancel")
+    end
+
+    test "returns the update-payment deep link", %{urls: urls} do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_customer_id: "ctm_dev",
+        paddle_subscription_id: "sub_dev"
+      )
+
+      expect(Engram.Paddle.ClientMock, :get_portal_session, fn "ctm_dev" -> {:ok, urls} end)
+      assert {:ok, "https://p/update"} = Billing.portal_action_url(user, "update_payment")
+    end
+
+    test "falls back to the overview URL for the overview action", %{urls: urls} do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_customer_id: "ctm_dev",
+        paddle_subscription_id: "sub_dev"
+      )
+
+      expect(Engram.Paddle.ClientMock, :get_portal_session, fn "ctm_dev" -> {:ok, urls} end)
+      assert {:ok, "https://p/overview"} = Billing.portal_action_url(user, "overview")
+    end
+
+    test "returns :no_subscription when the user has none" do
+      assert {:error, :no_subscription} = Billing.portal_action_url(insert(:user), "cancel")
+    end
+  end
+
   describe "upsert_from_paddle_event/1" do
     test "subscription.created inserts a new row with custom_data" do
       user = insert(:user)

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -363,6 +363,34 @@ defmodule Engram.BillingTest do
     end
   end
 
+  describe "update_payment_transaction/1" do
+    test "returns the Paddle transaction id for the in-app overlay" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :get_update_payment_transaction, fn "sub_dev" ->
+        {:ok, %{"id" => "txn_update_1", "checkout" => %{"url" => "https://pay.paddle.com/x"}}}
+      end)
+
+      assert {:ok, "txn_update_1"} = Billing.update_payment_transaction(user)
+    end
+
+    test "returns :no_subscription when the user has none" do
+      assert {:error, :no_subscription} = Billing.update_payment_transaction(insert(:user))
+    end
+
+    test "propagates client errors" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_err")
+
+      expect(Engram.Paddle.ClientMock, :get_update_payment_transaction, fn _ ->
+        {:error, {:paddle_error, 500}}
+      end)
+
+      assert {:error, {:paddle_error, 500}} = Billing.update_payment_transaction(user)
+    end
+  end
+
   describe "upsert_from_paddle_event/1" do
     test "subscription.created inserts a new row with custom_data" do
       user = insert(:user)

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -172,6 +172,23 @@ defmodule EngramWeb.BillingControllerTest do
     end
   end
 
+  describe "GET /api/billing/payment-update-transaction" do
+    test "returns the transaction id for the overlay", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :get_update_payment_transaction, fn "sub_dev" ->
+        {:ok, %{"id" => "txn_update_1"}}
+      end)
+
+      body = conn |> get("/api/billing/payment-update-transaction") |> json_response(200)
+      assert body["transaction_id"] == "txn_update_1"
+    end
+
+    test "returns 404 when the user has no subscription", %{conn: conn} do
+      assert json_response(get(conn, "/api/billing/payment-update-transaction"), 404)
+    end
+  end
+
   describe "GET /api/billing/portal?action=" do
     test "returns the cancel deep link", %{conn: conn, user: user} do
       insert(:subscription,

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -1,7 +1,20 @@
 defmodule EngramWeb.BillingControllerTest do
   use EngramWeb.ConnCase, async: true
 
+  import Mox
+
   alias Engram.Accounts
+
+  setup :verify_on_exit!
+
+  # runtime.exs derives billing_enabled from PADDLE_API_KEY (unset in test → false),
+  # so enable it explicitly for the Paddle-backed endpoints under test.
+  setup do
+    prev = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, true)
+    on_exit(fn -> Application.put_env(:engram, :billing_enabled, prev) end)
+    :ok
+  end
 
   setup %{conn: conn} do
     user = insert(:user)
@@ -52,6 +65,133 @@ defmodule EngramWeb.BillingControllerTest do
     test "returns 401 without auth" do
       conn = build_conn() |> get("/api/billing/config")
       assert json_response(conn, 401)
+    end
+  end
+
+  describe "GET /api/billing/subscription" do
+    test "returns normalized detail for a subscribed user", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :get_subscription, fn "sub_dev" ->
+        {:ok,
+         %{
+           "currency_code" => "USD",
+           "next_billed_at" => "2026-06-27T07:00:00Z",
+           "billing_cycle" => %{"interval" => "month", "frequency" => 1},
+           "scheduled_change" => nil,
+           "recurring_transaction_details" => %{"totals" => %{"total" => "2000"}}
+         }}
+      end)
+
+      body = conn |> get("/api/billing/subscription") |> json_response(200)
+      assert body["next_billed_at"] == "2026-06-27T07:00:00Z"
+      assert body["amount"] == "2000"
+      assert body["currency"] == "USD"
+      assert body["billing_cycle"] == %{"interval" => "month", "frequency" => 1}
+    end
+
+    test "returns 404 when the user has no subscription", %{conn: conn} do
+      conn = get(conn, "/api/billing/subscription")
+      assert json_response(conn, 404)["error"] == "no subscription"
+    end
+
+    test "returns 401 without auth" do
+      conn = build_conn() |> get("/api/billing/subscription")
+      assert json_response(conn, 401)
+    end
+  end
+
+  describe "GET /api/billing/transactions" do
+    test "returns history and the latest card", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :list_transactions, fn "sub_dev" ->
+        {:ok,
+         [
+           %{
+             "id" => "txn_2",
+             "status" => "completed",
+             "billed_at" => "2026-05-27T07:00:00Z",
+             "invoice_id" => "inv_2",
+             "details" => %{"totals" => %{"grand_total" => "2000", "currency_code" => "USD"}},
+             "payments" => [
+               %{
+                 "method_details" => %{
+                   "type" => "card",
+                   "card" => %{
+                     "type" => "visa",
+                     "last4" => "4242",
+                     "expiry_month" => 12,
+                     "expiry_year" => 2027
+                   }
+                 }
+               }
+             ]
+           }
+         ]}
+      end)
+
+      body = conn |> get("/api/billing/transactions") |> json_response(200)
+      assert body["payment_method"]["card_brand"] == "visa"
+      assert body["payment_method"]["last4"] == "4242"
+      assert [txn] = body["transactions"]
+      assert txn["id"] == "txn_2"
+      assert txn["amount"] == "2000"
+    end
+
+    test "returns 404 when the user has no subscription", %{conn: conn} do
+      assert json_response(get(conn, "/api/billing/transactions"), 404)
+    end
+  end
+
+  describe "GET /api/billing/transactions/:id/invoice" do
+    test "returns the invoice URL for the user's own transaction", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :list_transactions, fn "sub_dev" ->
+        {:ok, [%{"id" => "txn_2", "payments" => []}]}
+      end)
+
+      expect(Engram.Paddle.ClientMock, :get_transaction_invoice, fn "txn_2" ->
+        {:ok, "https://paddle.com/invoice/txn_2.pdf"}
+      end)
+
+      body = conn |> get("/api/billing/transactions/txn_2/invoice") |> json_response(200)
+      assert body["url"] == "https://paddle.com/invoice/txn_2.pdf"
+    end
+
+    test "returns 404 for a transaction not belonging to the user", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_dev")
+
+      expect(Engram.Paddle.ClientMock, :list_transactions, fn "sub_dev" ->
+        {:ok, [%{"id" => "txn_2", "payments" => []}]}
+      end)
+
+      conn = get(conn, "/api/billing/transactions/txn_999/invoice")
+      assert json_response(conn, 404)["error"] == "transaction not found"
+    end
+  end
+
+  describe "GET /api/billing/portal?action=" do
+    test "returns the cancel deep link", %{conn: conn, user: user} do
+      insert(:subscription,
+        user: user,
+        paddle_customer_id: "ctm_dev",
+        paddle_subscription_id: "sub_dev"
+      )
+
+      expect(Engram.Paddle.ClientMock, :get_portal_session, fn "ctm_dev" ->
+        {:ok,
+         %{
+           "general" => %{"overview" => "https://p/overview"},
+           "subscriptions" => [
+             %{"id" => "sub_dev", "cancel_subscription" => "https://p/cancel"}
+           ]
+         }}
+      end)
+
+      body = conn |> get("/api/billing/portal?action=cancel") |> json_response(200)
+      assert body["url"] == "https://p/cancel"
     end
   end
 end

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -1,5 +1,9 @@
 defmodule EngramWeb.BillingControllerTest do
-  use EngramWeb.ConnCase, async: true
+  # async: false — this suite flips the global :billing_enabled app env, which
+  # toggles RequireOnboarding on the vault-scoped pipeline. Running concurrently
+  # would intermittently gate unrelated async controller tests. Matches the
+  # other billing_enabled-flipping suites (onboarding_controller_test, etc.).
+  use EngramWeb.ConnCase, async: false
 
   import Mox
 

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -40,6 +40,11 @@ defmodule EngramWeb.SpaControllerTest do
     assert body =~ ~s("authProvider":)
   end
 
+  test "GET / injects billingEnabled flag so the SPA can gate the billing page", %{conn: conn} do
+    body = conn |> get("/") |> response(200)
+    assert body =~ ~s("billingEnabled":)
+  end
+
   test "GET /oauth/consent renders SPA (consent UI route)", %{conn: conn} do
     conn = get(conn, "/oauth/consent")
     assert conn.status == 200


### PR DESCRIPTION
## Summary
Replaces the bare billing page (a Current-Plan card + one "Manage subscription" link that punted everything to Paddle's hosted portal) with a rich in-app billing surface, and hides the page entirely for self-hosters.

Closes #333. Built in three independently-shippable phases:

- **Phase A — gating + richer current plan** (`7eac604`): inject `billingEnabled` into the SPA runtime config; hide the Billing nav entry + route when billing is disabled (self-host), mirroring the existing `authProvider` gating. Extract a presentational `CurrentPlanCard` that labels the period-end date "Renews on" while live and "Access ends on" once canceled. The onboarding plan-picker (`hideHeading`) is untouched.
- **Phase B — Paddle read-through** (`396224c` backend, `01cdcd3` frontend): new `Engram.Paddle.Client` callbacks + HTTP impls (`get_subscription`, `list_transactions`, `get_transaction_invoice`, `get_portal_session`); `Billing` context functions with normalization; endpoints `GET /api/billing/{subscription,transactions,transactions/:id/invoice}` + an `action` param on `/billing/portal` for cancel / update-payment deep links. UI: `PaymentMethodCard`, `BillingHistoryTable` (per-row invoice download), `PendingChangeBanner` (from `scheduled_change`), and a `formatMoney` util that derives minor-unit digits from `Intl` (handles 0-/2-/3-decimal currencies).
- **Phase C — in-app card update** (`ae05c08`): `GET /api/billing/payment-update-transaction` → `Paddle.Checkout.open({ transactionId })` overlay so the card is updated without leaving the app; falls back to the hosted portal if Paddle.js isn't ready; invalidates the live billing queries on `checkout.completed`.

### Notes
- **Self-host never reaches Paddle**: all new endpoints are gated on `billing_enabled`, and the context layer short-circuits to `:no_subscription` (no Paddle call) for users without a subscription.
- **IDOR guard**: `transaction_invoice_url/2` verifies the transaction belongs to the user's subscription before minting the hosted URL.
- Amounts pass through as Paddle minor units + currency for the frontend to format.
- Out of scope (flagged): the onboarding plan-picker shows stale prices ($5/$10 vs the live $10/$20 model) — left untouched per request.

## Test plan
- [x] Backend: `mix test test/engram/billing_test.exs test/engram_web/controllers/billing_controller_test.exs` — 68 tests, 0 failures
- [x] Backend: `mix credo --strict` clean + `mix format --check-formatted` on changed files
- [x] Frontend: `bunx vitest run` — 67 tests, 0 failures; `tsc --noEmit` + `biome check` clean
- [ ] **Live sandbox end-to-end** (not yet done): real Paddle sandbox checkout to exercise payment-method card, invoice download, scheduled-change banner, and the in-app card-update overlay with real data
- [ ] Self-host smoke: confirm Billing nav/route hidden when `billing_enabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)