### PR TITLE
fix: sync Clerk primary email on user.updated webhook

### DIFF
--- a/lib/engram/auth/clerk/webhook.ex
+++ b/lib/engram/auth/clerk/webhook.ex
@@ -6,8 +6,10 @@ defmodule Engram.Auth.Clerk.Webhook do
   Handles:
   - `user.created` — dup-check against normalized_email; revoke via Clerk API if
     duplicate, otherwise insert local user row.
-  - `user.updated` — sets `users.phone_verified_at` when a verified phone
-    appears (drives the §A.3 EmbedNote pre-flight gate).
+  - `user.updated` — mirrors the Clerk primary email into `users.email` +
+    `normalized_email`, and sets `users.phone_verified_at` when a verified phone
+    appears (drives the §A.3 EmbedNote pre-flight gate). Email and phone sync are
+    independent.
 
   All other event types no-op.
   """
@@ -90,18 +92,68 @@ defmodule Engram.Auth.Clerk.Webhook do
   end
 
   defp handle_user_updated(%{"id" => clerk_id} = data) do
-    with {:ok, user} <- Accounts.find_by_external_id(clerk_id),
-         true <- has_verified_phone?(data),
-         nil <- user.phone_verified_at do
+    case Accounts.find_by_external_id(clerk_id) do
+      {:ok, user} ->
+        # Email and phone sync are independent — a no-op on one must not skip the
+        # other. They touch disjoint columns, so order doesn't matter.
+        sync_primary_email(user, data)
+        sync_verified_phone(user, data)
+        :ok
+
+      {:error, :user_not_found} ->
+        :ok
+    end
+  end
+
+  # Mirror the Clerk primary email into users.email + normalized_email. Idempotent
+  # (user.updated fires on any profile change). On a normalized-email collision
+  # with another account, keep the stored values — losing the §A anti-farming key
+  # is worse than cosmetic drift — and emit abuse telemetry instead of raising
+  # (a raise → 500 → Clerk retries forever).
+  defp sync_primary_email(user, data) do
+    with {:ok, email} <- primary_email(data),
+         normalized = EmailNormalizer.normalize(email),
+         true <- email != user.email or normalized != user.normalized_email do
+      user
+      |> Ecto.Changeset.change(%{email: email, normalized_email: normalized})
+      |> Ecto.Changeset.unique_constraint(:email, name: :users_email_lower_index)
+      |> Ecto.Changeset.unique_constraint(:normalized_email,
+        name: :users_normalized_email_index
+      )
+      |> Repo.update(skip_tenant_check: true)
+      |> case do
+        {:ok, _user} ->
+          :ok
+
+        {:error, _changeset} ->
+          :telemetry.execute(
+            [:engram, :abuse, :email_sync_collision],
+            %{count: 1},
+            %{user_id: user.id, normalized_email_hash: hash(normalized)}
+          )
+
+          Logger.warning("Clerk email sync skipped — normalized email collides with another user",
+            user_id: user.id,
+            normalized_email_hash: hash(normalized)
+          )
+
+          :ok
+      end
+    else
+      _ -> :ok
+    end
+  end
+
+  defp sync_verified_phone(user, data) do
+    if has_verified_phone?(data) and is_nil(user.phone_verified_at) do
       user
       |> Ecto.Changeset.change(%{phone_verified_at: DateTime.utc_now()})
       |> Repo.update(skip_tenant_check: true)
 
       :telemetry.execute([:engram, :auth, :phone_verified], %{count: 1}, %{user_id: user.id})
-      :ok
-    else
-      _ -> :ok
     end
+
+    :ok
   end
 
   defp primary_email(%{"primary_email_address_id" => pid, "email_addresses" => addrs})

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.241",
+      version: "0.5.242",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/clerk_webhook_test.exs
+++ b/test/engram_web/controllers/clerk_webhook_test.exs
@@ -176,6 +176,74 @@ defmodule EngramWeb.ClerkWebhookTest do
     end
   end
 
+  describe "POST /webhooks/clerk — user.updated email sync" do
+    setup do
+      user = insert(:user, email: "old@gmail.com", normalized_email: "old@gmail.com")
+
+      user
+      |> Ecto.Changeset.change(%{external_id: "user_email"})
+      |> Repo.update!(skip_tenant_check: true)
+
+      %{user: user}
+    end
+
+    test "mirrors changed primary email into email + normalized_email",
+         %{conn: conn, user: user} do
+      payload = clerk_user_updated_payload("user_email", email: "New.Primary+tag@gmail.com")
+      conn = post_clerk(conn, "evt_email1", payload)
+
+      assert json_response(conn, 200)["status"] == "ok"
+      reloaded = Repo.reload!(user)
+      assert reloaded.email == "New.Primary+tag@gmail.com"
+      assert reloaded.normalized_email == "newprimary@gmail.com"
+    end
+
+    test "is a no-op when primary email is unchanged", %{conn: conn, user: user} do
+      before = Repo.reload!(user)
+      payload = clerk_user_updated_payload("user_email", email: "old@gmail.com")
+      conn = post_clerk(conn, "evt_email_noop", payload)
+
+      assert json_response(conn, 200)["status"] == "ok"
+      reloaded = Repo.reload!(user)
+      assert reloaded.email == "old@gmail.com"
+      assert reloaded.normalized_email == "old@gmail.com"
+      assert reloaded.updated_at == before.updated_at
+    end
+
+    test "skips mirror and emits telemetry when normalized email collides with another account",
+         %{conn: conn, user: user} do
+      _other = insert(:user, email: "taken@gmail.com", normalized_email: "taken@gmail.com")
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:engram, :abuse, :email_sync_collision]
+        ])
+
+      # "Ta.ken@gmail.com" normalizes to "taken@gmail.com" — collides with _other.
+      payload = clerk_user_updated_payload("user_email", email: "Ta.ken@gmail.com")
+      conn = post_clerk(conn, "evt_email_coll", payload)
+
+      assert json_response(conn, 200)["status"] == "ok"
+      reloaded = Repo.reload!(user)
+      assert reloaded.email == "old@gmail.com"
+      assert reloaded.normalized_email == "old@gmail.com"
+
+      assert_received {[:engram, :abuse, :email_sync_collision], ^ref, %{count: 1}, _meta}
+    end
+
+    test "syncs email and phone independently in one event", %{conn: conn, user: user} do
+      payload =
+        clerk_user_updated_payload("user_email", email: "both@gmail.com", phone_verified: true)
+
+      conn = post_clerk(conn, "evt_email_phone", payload)
+
+      assert json_response(conn, 200)["status"] == "ok"
+      reloaded = Repo.reload!(user)
+      assert reloaded.email == "both@gmail.com"
+      assert %DateTime{} = reloaded.phone_verified_at
+    end
+  end
+
   describe "POST /webhooks/clerk — other events" do
     test "returns 200 and no-ops for unknown event type", %{conn: conn} do
       payload = Jason.encode!(%{"type" => "session.created", "data" => %{}})
@@ -205,7 +273,10 @@ defmodule EngramWeb.ClerkWebhookTest do
     })
   end
 
-  defp clerk_user_updated_payload(clerk_id, phone_verified: verified) do
+  defp clerk_user_updated_payload(clerk_id, opts) do
+    verified = Keyword.get(opts, :phone_verified, false)
+    email = Keyword.get(opts, :email, "phone@gmail.com")
+
     phones =
       if verified do
         [
@@ -226,7 +297,7 @@ defmodule EngramWeb.ClerkWebhookTest do
         "email_addresses" => [
           %{
             "id" => "email_1",
-            "email_address" => "phone@gmail.com",
+            "email_address" => email,
             "verification" => %{"status" => "verified"}
           }
         ],


### PR DESCRIPTION
## Summary
- Mirror the Clerk **primary email** into `users.email` + `users.normalized_email` on the `user.updated` webhook. Previously email was captured only at signup and never re-synced, so a Clerk primary-email change left both columns stale — weakening the §A multi-account-farming key (`normalized_email`).
- Email sync is **independent** of the phone-verified path (old `with`-chain short-circuit meant an unchanged phone would skip email and vice-versa).
- **Idempotent** — no-op when the primary email is unchanged (`user.updated` fires on any profile change).
- **Collision-safe** — on a `normalized_email` unique-constraint collision with another account, keep the stored values (preserve the anti-farming key) and emit `[:engram, :abuse, :email_sync_collision]` telemetry + a warning, rather than letting `Repo.update` raise (a raise → 500 → Clerk retries forever).

Identity/billing are unaffected: both key on the Clerk `sub` (`users.external_id`), never on email.

Closes #329

## Test plan
- [x] `mix test test/engram_web/controllers/clerk_webhook_test.exs` — 17/17 green
- [x] New cases: changed email mirrors; unchanged email is a no-op (asserts `updated_at` unchanged); normalized collision skips + emits telemetry + retains old values; phone + email sync independently in one event
- [x] `mix credo` clean, `mix format` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)