### PR TITLE
fix: unblock staging MCP OAuth — GET/DELETE /api/mcp 405 + per-host discovery metadata

### DIFF
--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -27,6 +27,16 @@ defmodule EngramWeb.McpController do
     send_jsonrpc_error(conn, nil, -32_600, "Invalid Request")
   end
 
+  # Streamable-HTTP clients may open a GET for a server-initiated SSE stream,
+  # or DELETE to terminate a session. This server is POST-only JSON-RPC and
+  # offers neither, so respond 405 with Allow per the MCP spec — not 404,
+  # which clients treat as a missing endpoint and abort the connection.
+  def unsupported_transport(conn, _params) do
+    conn
+    |> put_resp_header("allow", "POST")
+    |> send_resp(405, "")
+  end
+
   # -- Method dispatch --
 
   defp dispatch(_conn, "initialize", _params) do

--- a/lib/engram_web/controllers/well_known_controller.ex
+++ b/lib/engram_web/controllers/well_known_controller.ex
@@ -3,29 +3,33 @@ defmodule EngramWeb.WellKnownController do
   Serves OAuth 2.1 discovery documents per RFC 8414 (authorization server
   metadata) and RFC 9728 (protected resource metadata).
 
-  Issuer URL is derived from `EngramWeb.Endpoint.url/0`, which resolves
-  per-deployment from `PHX_HOST`. Both saas (`app.engram.page`) and selfhost
-  (`engram.ax`) thus advertise their own canonical host.
+  The base URL is derived from the host the client actually dialed, *when*
+  that host is in the configured origin allowlist (`:cors_origin`, populated
+  from `PHX_HOST`). This lets a single backend that fronts multiple canonical
+  domains (e.g. `app.engram.page` and `staging.engram.page`) advertise the
+  matching issuer instead of a hardcoded one — otherwise a client connecting
+  to one domain gets metadata pointing at the other and aborts on the RFC 9728
+  resource self-check. Hosts outside the allowlist fall back to the canonical
+  `EngramWeb.Endpoint.url/0`; we never reflect an unvetted Host header into the
+  issuer, which would let a spoofed Host poison discovery.
   """
   use EngramWeb, :controller
 
   def protected_resource(conn, _params) do
-    base = base_url()
+    base = base_url(conn)
 
-    payload = %{
+    json(conn, %{
       resource: base <> "/api/mcp",
       authorization_servers: [base],
       bearer_methods_supported: ["header"],
       resource_documentation: base <> "/docs"
-    }
-
-    json(conn, payload)
+    })
   end
 
   def authorization_server(conn, _params) do
-    base = base_url()
+    base = base_url(conn)
 
-    payload = %{
+    json(conn, %{
       issuer: base,
       authorization_endpoint: base <> "/oauth/authorize",
       token_endpoint: base <> "/oauth/token",
@@ -36,10 +40,17 @@ defmodule EngramWeb.WellKnownController do
       code_challenge_methods_supported: ["S256"],
       token_endpoint_auth_methods_supported: ["none"],
       scopes_supported: ["mcp"]
-    }
-
-    json(conn, payload)
+    })
   end
 
-  defp base_url, do: EngramWeb.Endpoint.url()
+  defp base_url(conn) do
+    canonical = EngramWeb.Endpoint.url()
+    candidate = "#{URI.parse(canonical).scheme}://#{conn.host}"
+
+    if candidate in Application.get_env(:engram, :cors_origin, []) do
+      candidate
+    else
+      canonical
+    end
+  end
 end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -252,6 +252,18 @@ defmodule EngramWeb.Router do
     end
   end
 
+  # MCP transport is POST-only JSON-RPC (see the authed scope above).
+  # Streamable-HTTP clients open a GET on the endpoint for a server→client
+  # SSE stream, and DELETE to end a session — we offer neither. Answer 405 +
+  # Allow here rather than letting GET/DELETE fall through to Phoenix's 404,
+  # which clients treat as a missing endpoint and abort. Auth-free on
+  # purpose: an unsupported method is a method-level fact, not an authz one.
+  scope "/api", EngramWeb do
+    pipe_through :api
+    get "/mcp", McpController, :unsupported_transport
+    delete "/mcp", McpController, :unsupported_transport
+  end
+
   # SPA routes — every path here mounts the React app. Whitelisted (not a
   # blanket /*path catch-all) so unknown URLs hit Phoenix's default 404
   # instead of silently rendering an HTML 200 over a typo'd API/OAuth/asset

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.242",
+      version: "0.5.243",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/mcp_transport_test.exs
+++ b/test/engram_web/controllers/mcp_transport_test.exs
@@ -1,0 +1,21 @@
+defmodule EngramWeb.McpTransportTest do
+  use EngramWeb.ConnCase, async: true
+
+  # The MCP endpoint is POST-only JSON-RPC. Streamable-HTTP clients open a
+  # GET on the endpoint for a server→client SSE stream (and DELETE to end a
+  # session). We offer neither, so the spec-correct answer is 405 + Allow —
+  # not a 404, which clients treat as a missing endpoint and abort.
+  describe "unsupported transport methods on /api/mcp" do
+    test "GET returns 405 with Allow: POST (no auth required)", %{conn: conn} do
+      conn = get(conn, "/api/mcp")
+      assert conn.status == 405
+      assert get_resp_header(conn, "allow") == ["POST"]
+    end
+
+    test "DELETE returns 405 with Allow: POST (no auth required)", %{conn: conn} do
+      conn = delete(conn, "/api/mcp")
+      assert conn.status == 405
+      assert get_resp_header(conn, "allow") == ["POST"]
+    end
+  end
+end

--- a/test/engram_web/controllers/well_known_host_test.exs
+++ b/test/engram_web/controllers/well_known_host_test.exs
@@ -1,0 +1,57 @@
+defmodule EngramWeb.WellKnownHostTest do
+  # async: false — these mutate the global :cors_origin app env.
+  use EngramWeb.ConnCase, async: false
+
+  setup do
+    prev = Application.get_env(:engram, :cors_origin)
+
+    on_exit(fn ->
+      if prev,
+        do: Application.put_env(:engram, :cors_origin, prev),
+        else: Application.delete_env(:engram, :cors_origin)
+    end)
+
+    :ok
+  end
+
+  describe "multi-domain host derivation" do
+    test "advertises the dialed host when it is an allowlisted origin", %{conn: conn} do
+      Application.put_env(:engram, :cors_origin, [
+        "https://app.engram.page",
+        "http://app.engram.page"
+      ])
+
+      body =
+        %{conn | host: "app.engram.page"}
+        |> get("/.well-known/oauth-protected-resource")
+        |> json_response(200)
+
+      assert body["resource"] == "http://app.engram.page/api/mcp"
+      assert body["authorization_servers"] == ["http://app.engram.page"]
+    end
+
+    test "issuer reflects the dialed allowlisted host", %{conn: conn} do
+      Application.put_env(:engram, :cors_origin, ["http://app.engram.page"])
+
+      body =
+        %{conn | host: "app.engram.page"}
+        |> get("/.well-known/oauth-authorization-server")
+        |> json_response(200)
+
+      assert body["issuer"] == "http://app.engram.page"
+      assert body["authorization_endpoint"] == "http://app.engram.page/oauth/authorize"
+    end
+
+    test "falls back to canonical for a non-allowlisted host (no Host reflection)", %{conn: conn} do
+      Application.put_env(:engram, :cors_origin, ["http://app.engram.page"])
+
+      body =
+        %{conn | host: "evil.example.com"}
+        |> get("/.well-known/oauth-protected-resource")
+        |> json_response(200)
+
+      refute body["resource"] =~ "evil.example.com"
+      assert String.ends_with?(body["resource"], "/api/mcp")
+    end
+  end
+end


### PR DESCRIPTION
Two fixes found while getting MCP OAuth working end-to-end on staging.engram.page (Claude Code CLI connect). Bundled — same concern, one deploy.

## 1. GET/DELETE /api/mcp → 405 (was 404)
Streamable-HTTP clients open a **GET** on the endpoint for the server→client SSE stream right after OAuth. The router defined only `POST /mcp`, so GET fell through to Phoenix's catch-all **404** and the client aborted with `reconnecting failed: HTTP 404`. This server is POST-only JSON-RPC with no SSE stream, so answer GET/DELETE with **405 + `Allow: POST`** per the MCP spec; clients then proceed POST-only. Added in a minimal `:api`-only scope (auth-free — an unsupported method is method-level, not authz).

## 2. Discovery metadata host derived from the dialed domain
`WellKnownController` hardcoded issuer/resource to `Endpoint.url()` (`PHX_HOST`). With one backend fronting multiple domains, `app.engram.page` advertised `staging.engram.page`, so clients aborted on the RFC 9728 resource self-check. Now advertise the host the client actually dialed **when it's in the `:cors_origin` allowlist** (from `PHX_HOST`); otherwise fall back to canonical. Never reflects an unvetted Host header.

> Note: #2 takes effect for a given domain only once that domain is in the container's `PHX_HOST` list. To advertise `app.engram.page` from the staging container pre-launch, set `PHX_HOST=staging.engram.page,app.engram.page` (engram-infra). At prod launch `PHX_HOST=app.engram.page` makes it canonical anyway.

## Test plan
- [x] `mcp_transport_test.exs`: GET/DELETE `/api/mcp` → 405 + `Allow: POST`
- [x] `well_known_host_test.exs`: allowlisted dialed host reflected; non-allowlisted host falls back (no reflection)
- [x] Existing MCP + WellKnown suites green
- [ ] Deploy to staging-fastraid → `claude mcp add --transport http engram https://staging.engram.page/api/mcp` connects cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)