### PR TITLE
feat: refresh-token reuse detection (token families + leeway)

### DIFF
--- a/docs/context/refresh-token-reuse-detection.md
+++ b/docs/context/refresh-token-reuse-detection.md
@@ -1,0 +1,92 @@
+# Refresh token rotation — reuse detection + leeway (build plan)
+
+_Status: built 2026-05-28 on `fix/refresh-token-grace-window` (Engram PR #341),
+v0.5.245. Backend repo (`engram`)._
+
+## Why
+
+Device refresh tokens (`DeviceFlow`) are single-use rotating, 90-day TTL, 15-min
+access tokens. The Obsidian plugin previously held only the access token in
+memory, so every reload forced a refresh that rotated the single-use token; a
+lost rotation save (BRAT reload mid-refresh, etc.) bricked the session → forced
+re-login. Two fixes:
+
+- **Plugin (Engram-obsidian PR #84, shipped):** persist the access token so
+  reloads within its 15-min life skip the refresh entirely (no rotation).
+- **Backend (this plan):** make rotation robust + secure per RFC 9700.
+
+## Research verdict (RFC 9700 §4.14.2 + Auth0/Okta docs)
+
+Best practice for public clients without sender-constrained tokens is **refresh
+token rotation + reuse detection with token-family revocation**, layered with a
+**short leeway/overlap window** for benign retries/concurrency:
+
+- On reuse of an *already-invalidated* token **outside** the leeway → breach →
+  **revoke the entire token family** → force re-login. (RFC 9700 MUST; Auth0
+  "Automatic Reuse Detection"; Okta "grace period".)
+- **Within** the leeway window, accept the immediately-previous token, issue a
+  new one, skip breach detection. (Auth0 `leeway` / "Rotation Overlap Period";
+  default 0, "shortest amount of time" recommended.)
+
+PR #341 added the leeway half (`@refresh_grace_seconds 60`) but **not** the
+family-revocation half — that is the gap to close. Keep the leeway; add families.
+
+Sources: RFC 9700 §4.14.2 (ietf.org/rfc/rfc9700.html); Auth0 "Refresh Token
+Rotation" + "Configure Refresh Token Rotation" (`leeway` attr); WorkOS "We read
+RFC 9700".
+
+## Current state
+
+- `lib/engram/auth/device_flow.ex` — `refresh_access_token/1` accepts a token
+  revoked within `@refresh_grace_seconds` (60s); stamps `revoked_at` only on
+  first use. **No family tracking, no reuse-detection revocation.**
+- `Engram.Auth.DeviceRefreshToken` schema — no `family_id` column.
+- PR #341 (`fix/refresh-token-grace-window`) open with the leeway-only change +
+  tests; CI green. Decide: extend this PR with families, or supersede it.
+
+## Build plan (TDD, one step per commit)
+
+1. **Migration** — add `family_id :uuid` to `device_refresh_tokens` (+ index).
+   Backfill: give every existing row its own fresh `family_id` (each existing
+   token = its own family). Add to the schema + changeset.
+2. **`create_refresh_token/3`** — accept an optional `family_id`; generate a new
+   uuid when nil (new login), inherit it on rotation. Device authorize/exchange
+   path mints a new family; `refresh_access_token` passes the old token's family.
+3. **`refresh_access_token/1` reuse detection** — look up by hash where
+   `expires_at > now` (regardless of `revoked_at`). Then:
+   - not found → `{:error, :invalid_refresh_token}`
+   - active (`revoked_at` nil) → rotate: revoke it, issue child in same family.
+   - revoked **within** leeway → benign retry: issue child in same family, no
+     revocation (this is the existing grace path).
+   - revoked **outside** leeway (or an older token) → **reuse detected**:
+     **hard-`delete_all` the entire family** (`where family_id == ^fid`), return
+     `{:error, :invalid_refresh_token}`. **Delete, not `update_all` set
+     `revoked_at`** — a freshly-revoked current token would land *inside* the
+     leeway window and be misclassified as a benign retry on its next
+     presentation, defeating the revocation. Deleting removes that ambiguity;
+     `Logger.warning` the breach (family_id + user_id) so the audit trail
+     survives the row deletion.
+   - Renamed `@refresh_grace_seconds` → `@refresh_leeway_seconds`; trimmed 60s →
+     30s (Auth0 recommends shortest; plugin reload races resolve in <1s).
+4. **Tests** (`test/engram/auth/device_flow_test.exs` +
+   `test/engram_web/controllers/device_auth_controller_test.exs`):
+   - normal rotation chain still works;
+   - reuse within leeway → ok (exists);
+   - **reuse outside leeway → family revoked**: after reuse, the *valid current*
+     token in that family is also rejected (the security-defining test);
+   - boundary at exactly the leeway cutoff; expired-AND-revoked still rejected;
+   - unknown token → invalid (exists).
+5. Version bump `mix.exs` (pre-push hook enforces it). Format + credo. CI green.
+
+## Notes / gotchas
+
+- `skip_tenant_check: true` is fine here — lookup is keyed on the 256-bit
+  `token_hash`; issued tokens inherit `old_token.user_id`/`vault_id`, so a token
+  can only mint tokens for its own owner. Family invalidation `delete_all` is
+  scoped by `family_id`, also owner-bound (a family never crosses users).
+- Concurrency: two concurrent refreshes of the same active token both pass the
+  lookup before either stamps `revoked_at`. Acceptable within leeway (both are
+  the "previous token"); they fork into the same family, and the unused branch
+  ages out. Document it; don't try to serialize at the DB layer unless it bites.
+- Client (plugin) already: persists access token (PR #84), dedups concurrent
+  refreshes via `inflightRefresh`, awaits rotation persistence before use.

--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -6,19 +6,24 @@ defmodule Engram.Auth.DeviceFlow do
   """
 
   import Ecto.Query
+
   alias Engram.{Accounts, Vaults}
   alias Engram.Auth.{DeviceAuthorization, DeviceRefreshToken}
   alias Engram.Repo
+
+  require Logger
 
   @device_code_bytes 32
   @refresh_token_prefix "engram_rt_"
   @refresh_token_bytes 32
   @refresh_token_ttl_days 90
   @device_code_ttl_seconds 300
-  # Grace window after a refresh token is rotated during which the old token is
+  # Leeway window after a refresh token is rotated during which the old token is
   # still accepted, so a client that loses the rotated token (e.g. a plugin
-  # reload mid-refresh) can recover instead of being forced to re-login.
-  @refresh_grace_seconds 60
+  # reload mid-refresh, or a brief concurrent retry) can recover instead of
+  # being forced to re-login. Auth0 calls this the "rotation overlap period" and
+  # recommends the shortest viable value; plugin reload races resolve in <1s.
+  @refresh_leeway_seconds 30
 
   # Characters excluding ambiguous: 0, O, 1, I, L
   @user_code_chars ~c"ABCDEFGHJKMNPQRSTUVWXYZ2345679"
@@ -102,17 +107,14 @@ defmodule Engram.Auth.DeviceFlow do
   def refresh_access_token(raw_refresh_token) do
     token_hash = hash_token(raw_refresh_token)
     now = DateTime.utc_now()
-    grace_cutoff = DateTime.add(now, -@refresh_grace_seconds, :second)
+    leeway_cutoff = DateTime.add(now, -@refresh_leeway_seconds, :second)
 
-    # Rotation is single-use, but a token revoked within the grace window is
-    # still accepted. This lets a client that lost the rotated token (a plugin
-    # reload mid-refresh, a quit right after, or a brief concurrent retry)
-    # recover, instead of being bricked for the token's full 90-day life.
+    # Look the token up regardless of revocation state — a *revoked* token still
+    # has to be classified (benign retry within leeway vs. reuse breach), not
+    # silently rejected. Expired tokens are out of scope entirely.
     query =
       from(rt in DeviceRefreshToken,
-        where:
-          rt.token_hash == ^token_hash and rt.expires_at > ^now and
-            (is_nil(rt.revoked_at) or rt.revoked_at > ^grace_cutoff),
+        where: rt.token_hash == ^token_hash and rt.expires_at > ^now,
         preload: [:user]
       )
 
@@ -120,24 +122,27 @@ defmodule Engram.Auth.DeviceFlow do
       nil ->
         {:error, :invalid_refresh_token}
 
+      %{revoked_at: nil} = old_token ->
+        # Active token: normal single-use rotation. Stamp revoked_at so the
+        # leeway is measured from this first rotation and can't be slid forward.
+        old_token
+        |> Ecto.Changeset.change(%{revoked_at: DateTime.truncate(now, :second)})
+        |> Repo.update!(skip_tenant_check: true)
+
+        issue_child(old_token)
+
       old_token ->
-        # Stamp revoked_at only on first use, so the grace window is measured
-        # from the first rotation and can't be slid forward by repeated retries.
-        if is_nil(old_token.revoked_at) do
-          old_token
-          |> Ecto.Changeset.change(%{revoked_at: DateTime.truncate(now, :second)})
-          |> Repo.update!(skip_tenant_check: true)
+        if DateTime.compare(old_token.revoked_at, leeway_cutoff) == :gt do
+          # Revoked within the leeway: benign retry (lost rotation, concurrent
+          # request). Issue a child in the same family without re-revoking.
+          issue_child(old_token)
+        else
+          # Reuse of a token revoked outside the leeway → breach (RFC 9700
+          # §4.14.2). Invalidate the whole family so the legitimate holder of
+          # the current token is forced to re-authenticate.
+          invalidate_family(old_token)
+          {:error, :invalid_refresh_token}
         end
-
-        access_token = Accounts.generate_jwt(old_token.user)
-        {raw_refresh, _hash} = create_refresh_token(old_token.user_id, old_token.vault_id)
-
-        {:ok,
-         %{
-           access_token: access_token,
-           refresh_token: raw_refresh,
-           expires_in: Engram.Token.ttl_seconds()
-         }}
     end
   end
 
@@ -179,7 +184,41 @@ defmodule Engram.Auth.DeviceFlow do
      }}
   end
 
-  defp create_refresh_token(user_id, vault_id) do
+  # Rotate the verified old token into a fresh one within its family, minting a
+  # new access token. Inherits the old token's owner, so a token can only ever
+  # mint tokens for its own user/vault.
+  defp issue_child(old_token) do
+    access_token = Accounts.generate_jwt(old_token.user)
+
+    {raw_refresh, _hash} =
+      create_refresh_token(old_token.user_id, old_token.vault_id, old_token.family_id)
+
+    {:ok,
+     %{
+       access_token: access_token,
+       refresh_token: raw_refresh,
+       expires_in: Engram.Token.ttl_seconds()
+     }}
+  end
+
+  # Reuse breach: hard-delete the entire family. Deleting (rather than stamping
+  # revoked_at) is deliberate — a freshly-revoked current token would otherwise
+  # fall inside the leeway window and be mistaken for a benign retry, defeating
+  # the revocation. Scoped by family_id (owner-bound, a family never crosses
+  # users), so only the compromised lineage is touched.
+  defp invalidate_family(old_token) do
+    Logger.warning(
+      "device refresh-token reuse detected; revoking family " <>
+        "family_id=#{old_token.family_id} user_id=#{old_token.user_id}"
+    )
+
+    from(rt in DeviceRefreshToken, where: rt.family_id == ^old_token.family_id)
+    |> Repo.delete_all(skip_tenant_check: true)
+  end
+
+  # A nil family_id starts a new family (fresh login); rotation passes the old
+  # token's family_id to keep the lineage together.
+  defp create_refresh_token(user_id, vault_id, family_id \\ nil) do
     raw =
       @refresh_token_prefix <>
         Base.url_encode64(:crypto.strong_rand_bytes(@refresh_token_bytes), padding: false)
@@ -194,6 +233,7 @@ defmodule Engram.Auth.DeviceFlow do
     %DeviceRefreshToken{}
     |> DeviceRefreshToken.changeset(%{
       token_hash: token_hash,
+      family_id: family_id || Ecto.UUID.generate(),
       user_id: user_id,
       vault_id: vault_id,
       expires_at: expires_at

--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -15,6 +15,10 @@ defmodule Engram.Auth.DeviceFlow do
   @refresh_token_bytes 32
   @refresh_token_ttl_days 90
   @device_code_ttl_seconds 300
+  # Grace window after a refresh token is rotated during which the old token is
+  # still accepted, so a client that loses the rotated token (e.g. a plugin
+  # reload mid-refresh) can recover instead of being forced to re-login.
+  @refresh_grace_seconds 60
 
   # Characters excluding ambiguous: 0, O, 1, I, L
   @user_code_chars ~c"ABCDEFGHJKMNPQRSTUVWXYZ2345679"
@@ -98,10 +102,17 @@ defmodule Engram.Auth.DeviceFlow do
   def refresh_access_token(raw_refresh_token) do
     token_hash = hash_token(raw_refresh_token)
     now = DateTime.utc_now()
+    grace_cutoff = DateTime.add(now, -@refresh_grace_seconds, :second)
 
+    # Rotation is single-use, but a token revoked within the grace window is
+    # still accepted. This lets a client that lost the rotated token (a plugin
+    # reload mid-refresh, a quit right after, or a brief concurrent retry)
+    # recover, instead of being bricked for the token's full 90-day life.
     query =
       from(rt in DeviceRefreshToken,
-        where: rt.token_hash == ^token_hash and rt.expires_at > ^now and is_nil(rt.revoked_at),
+        where:
+          rt.token_hash == ^token_hash and rt.expires_at > ^now and
+            (is_nil(rt.revoked_at) or rt.revoked_at > ^grace_cutoff),
         preload: [:user]
       )
 
@@ -110,9 +121,13 @@ defmodule Engram.Auth.DeviceFlow do
         {:error, :invalid_refresh_token}
 
       old_token ->
-        old_token
-        |> Ecto.Changeset.change(%{revoked_at: DateTime.truncate(now, :second)})
-        |> Repo.update!(skip_tenant_check: true)
+        # Stamp revoked_at only on first use, so the grace window is measured
+        # from the first rotation and can't be slid forward by repeated retries.
+        if is_nil(old_token.revoked_at) do
+          old_token
+          |> Ecto.Changeset.change(%{revoked_at: DateTime.truncate(now, :second)})
+          |> Repo.update!(skip_tenant_check: true)
+        end
 
         access_token = Accounts.generate_jwt(old_token.user)
         {raw_refresh, _hash} = create_refresh_token(old_token.user_id, old_token.vault_id)

--- a/lib/engram/auth/device_refresh_token.ex
+++ b/lib/engram/auth/device_refresh_token.ex
@@ -4,6 +4,7 @@ defmodule Engram.Auth.DeviceRefreshToken do
 
   schema "device_refresh_tokens" do
     field :token_hash, :string
+    field :family_id, Ecto.UUID
     field :expires_at, :utc_datetime
     field :revoked_at, :utc_datetime
 
@@ -15,8 +16,8 @@ defmodule Engram.Auth.DeviceRefreshToken do
 
   def changeset(token, attrs) do
     token
-    |> cast(attrs, [:token_hash, :user_id, :vault_id, :expires_at])
-    |> validate_required([:token_hash, :user_id, :vault_id, :expires_at])
+    |> cast(attrs, [:token_hash, :family_id, :user_id, :vault_id, :expires_at])
+    |> validate_required([:token_hash, :family_id, :user_id, :vault_id, :expires_at])
     |> unique_constraint(:token_hash)
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:vault_id)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.244",
+      version: "0.5.245",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260528000000_add_family_id_to_device_refresh_tokens.exs
+++ b/priv/repo/migrations/20260528000000_add_family_id_to_device_refresh_tokens.exs
@@ -1,24 +1,39 @@
 defmodule Engram.Repo.Migrations.AddFamilyIdToDeviceRefreshTokens do
   use Ecto.Migration
 
+  # CONCURRENTLY index creation and the online-safe NOT NULL path (add the CHECK
+  # NOT VALID, then VALIDATE separately) both require running outside a
+  # transaction.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   def up do
     alter table(:device_refresh_tokens) do
       add :family_id, :uuid
     end
 
     # Each existing token becomes its own family, so legacy tokens keep working
-    # (reuse detection only nukes siblings, and they have none).
+    # (reuse detection only nukes siblings, and a lone token has none).
     execute "UPDATE device_refresh_tokens SET family_id = gen_random_uuid() WHERE family_id IS NULL"
 
-    alter table(:device_refresh_tokens) do
-      modify :family_id, :uuid, null: false
-    end
+    # Enforce presence without a blocking full-table rewrite: add the constraint
+    # NOT VALID (no scan, brief lock), then VALIDATE under a lighter lock. The
+    # app always sets family_id; this is the DB-level backstop.
+    execute """
+    ALTER TABLE device_refresh_tokens
+    ADD CONSTRAINT device_refresh_tokens_family_id_not_null
+    CHECK (family_id IS NOT NULL) NOT VALID
+    """
 
-    create index(:device_refresh_tokens, [:family_id])
+    execute "ALTER TABLE device_refresh_tokens VALIDATE CONSTRAINT device_refresh_tokens_family_id_not_null"
+
+    create index(:device_refresh_tokens, [:family_id], concurrently: true)
   end
 
   def down do
     drop index(:device_refresh_tokens, [:family_id])
+
+    execute "ALTER TABLE device_refresh_tokens DROP CONSTRAINT device_refresh_tokens_family_id_not_null"
 
     alter table(:device_refresh_tokens) do
       remove :family_id

--- a/priv/repo/migrations/20260528000000_add_family_id_to_device_refresh_tokens.exs
+++ b/priv/repo/migrations/20260528000000_add_family_id_to_device_refresh_tokens.exs
@@ -1,0 +1,27 @@
+defmodule Engram.Repo.Migrations.AddFamilyIdToDeviceRefreshTokens do
+  use Ecto.Migration
+
+  def up do
+    alter table(:device_refresh_tokens) do
+      add :family_id, :uuid
+    end
+
+    # Each existing token becomes its own family, so legacy tokens keep working
+    # (reuse detection only nukes siblings, and they have none).
+    execute "UPDATE device_refresh_tokens SET family_id = gen_random_uuid() WHERE family_id IS NULL"
+
+    alter table(:device_refresh_tokens) do
+      modify :family_id, :uuid, null: false
+    end
+
+    create index(:device_refresh_tokens, [:family_id])
+  end
+
+  def down do
+    drop index(:device_refresh_tokens, [:family_id])
+
+    alter table(:device_refresh_tokens) do
+      remove :family_id
+    end
+  end
+end

--- a/test/engram/auth/device_flow_test.exs
+++ b/test/engram/auth/device_flow_test.exs
@@ -185,6 +185,121 @@ defmodule Engram.Auth.DeviceFlowTest do
     test "rejects unknown refresh token" do
       assert {:error, :invalid_refresh_token} = DeviceFlow.refresh_access_token("engram_rt_fake")
     end
+
+    test "rotation keeps the new token in the same family" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+      {:ok, initial} = DeviceFlow.exchange_device_code(auth.device_code)
+      {:ok, _} = DeviceFlow.refresh_access_token(initial.refresh_token)
+
+      families =
+        Repo.all(from(rt in DeviceRefreshToken, select: rt.family_id), skip_tenant_check: true)
+
+      assert length(families) == 2
+      assert length(Enum.uniq(families)) == 1
+    end
+
+    test "a fresh login starts a distinct family" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+
+      {:ok, a} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(a.user_code, user, vault.id)
+      {:ok, _} = DeviceFlow.exchange_device_code(a.device_code)
+
+      {:ok, b} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(b.user_code, user, vault.id)
+      {:ok, _} = DeviceFlow.exchange_device_code(b.device_code)
+
+      families =
+        Repo.all(from(rt in DeviceRefreshToken, select: rt.family_id), skip_tenant_check: true)
+
+      assert length(Enum.uniq(families)) == 2
+    end
+
+    test "reuse outside the leeway revokes the entire token family" do
+      # The security-defining case (RFC 9700 §4.14.2): replaying a rotated token
+      # after the leeway is treated as a breach. The whole family is invalidated,
+      # so even the *current, still-valid* token is rejected and the user must
+      # re-authenticate.
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+      {:ok, initial} = DeviceFlow.exchange_device_code(auth.device_code)
+
+      # initial -> current, both in the same family.
+      {:ok, current} = DeviceFlow.refresh_access_token(initial.refresh_token)
+
+      # Age the old token's revocation past the leeway so its replay is a breach.
+      stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(rt in DeviceRefreshToken, where: not is_nil(rt.revoked_at)),
+        [set: [revoked_at: stale]],
+        skip_tenant_check: true
+      )
+
+      assert {:error, :invalid_refresh_token} =
+               DeviceFlow.refresh_access_token(initial.refresh_token)
+
+      # Family nuked: the current valid token no longer works.
+      assert {:error, :invalid_refresh_token} =
+               DeviceFlow.refresh_access_token(current.refresh_token)
+    end
+
+    test "a breach only revokes the offending family, not other families" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+
+      # Family A: rotate then breach.
+      {:ok, a} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(a.user_code, user, vault.id)
+      {:ok, a0} = DeviceFlow.exchange_device_code(a.device_code)
+      {:ok, _a1} = DeviceFlow.refresh_access_token(a0.refresh_token)
+
+      # Family B: independent, healthy login.
+      {:ok, b} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(b.user_code, user, vault.id)
+      {:ok, b0} = DeviceFlow.exchange_device_code(b.device_code)
+
+      stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(rt in DeviceRefreshToken, where: not is_nil(rt.revoked_at)),
+        [set: [revoked_at: stale]],
+        skip_tenant_check: true
+      )
+
+      # Breach family A.
+      assert {:error, :invalid_refresh_token} = DeviceFlow.refresh_access_token(a0.refresh_token)
+
+      # Family B is untouched.
+      assert {:ok, _} = DeviceFlow.refresh_access_token(b0.refresh_token)
+    end
+
+    test "an expired token is rejected and never triggers family revocation" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+      {:ok, initial} = DeviceFlow.exchange_device_code(auth.device_code)
+      {:ok, current} = DeviceFlow.refresh_access_token(initial.refresh_token)
+
+      # Expire the whole family.
+      past = DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(rt in DeviceRefreshToken),
+        [set: [expires_at: past]],
+        skip_tenant_check: true
+      )
+
+      assert {:error, :invalid_refresh_token} =
+               DeviceFlow.refresh_access_token(current.refresh_token)
+    end
   end
 
   describe "cleanup_expired/0" do

--- a/test/engram/auth/device_flow_test.exs
+++ b/test/engram/auth/device_flow_test.exs
@@ -1,7 +1,10 @@
 defmodule Engram.Auth.DeviceFlowTest do
   use Engram.DataCase, async: true
 
-  alias Engram.Auth.DeviceFlow
+  import Ecto.Query
+
+  alias Engram.Auth.{DeviceFlow, DeviceRefreshToken}
+  alias Engram.Repo
 
   describe "start_device_flow/1" do
     test "creates a pending device authorization" do
@@ -142,13 +145,38 @@ defmodule Engram.Auth.DeviceFlowTest do
       assert refreshed.expires_in == Engram.Token.ttl_seconds()
     end
 
-    test "old refresh token is revoked after rotation" do
+    test "old refresh token still works within the grace window" do
+      # Rotation is single-use, but a short grace window lets a client that lost
+      # the rotated token (e.g. a plugin reload mid-refresh) recover instead of
+      # being bricked for the token's full 90-day life.
       user = insert(:user)
       vault = insert(:vault, user: user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1")
       {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
       {:ok, initial} = DeviceFlow.exchange_device_code(auth.device_code)
       {:ok, _} = DeviceFlow.refresh_access_token(initial.refresh_token)
+
+      # Immediate reuse (well within the grace window) still succeeds.
+      assert {:ok, refreshed} = DeviceFlow.refresh_access_token(initial.refresh_token)
+      assert is_binary(refreshed.access_token)
+    end
+
+    test "old refresh token is rejected after the grace window expires" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+      {:ok, initial} = DeviceFlow.exchange_device_code(auth.device_code)
+      {:ok, _} = DeviceFlow.refresh_access_token(initial.refresh_token)
+
+      # Age the revocation past the grace window.
+      stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(rt in DeviceRefreshToken, where: not is_nil(rt.revoked_at)),
+        [set: [revoked_at: stale]],
+        skip_tenant_check: true
+      )
 
       assert {:error, :invalid_refresh_token} =
                DeviceFlow.refresh_access_token(initial.refresh_token)

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -1,7 +1,10 @@
 defmodule EngramWeb.DeviceAuthControllerTest do
   use EngramWeb.ConnCase, async: true
 
-  alias Engram.Auth.DeviceFlow
+  import Ecto.Query
+
+  alias Engram.Auth.{DeviceFlow, DeviceRefreshToken}
+  alias Engram.Repo
 
   defp create_authed_conn(%{conn: conn}) do
     user = insert(:user)
@@ -118,13 +121,22 @@ defmodule EngramWeb.DeviceAuthControllerTest do
       assert resp["expires_in"] == Engram.Token.ttl_seconds()
     end
 
-    test "rejects revoked refresh token", %{conn: conn} do
+    test "rejects a refresh token reused after the grace window", %{conn: conn} do
       user = insert(:user)
       vault = insert(:vault, user: user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1")
       {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
       {:ok, tokens} = DeviceFlow.exchange_device_code(auth.device_code)
       {:ok, _} = DeviceFlow.refresh_access_token(tokens.refresh_token)
+
+      # Age the revocation past the grace window so reuse is genuinely rejected.
+      stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(rt in DeviceRefreshToken, where: not is_nil(rt.revoked_at)),
+        [set: [revoked_at: stale]],
+        skip_tenant_check: true
+      )
 
       conn = post(conn, "/api/auth/token/refresh", %{refresh_token: tokens.refresh_token})
       assert json_response(conn, 401)

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -141,5 +141,33 @@ defmodule EngramWeb.DeviceAuthControllerTest do
       conn = post(conn, "/api/auth/token/refresh", %{refresh_token: tokens.refresh_token})
       assert json_response(conn, 401)
     end
+
+    test "a reuse breach revokes the family so the current token also 401s", %{conn: conn} do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+      {:ok, tokens} = DeviceFlow.exchange_device_code(auth.device_code)
+      {:ok, current} = DeviceFlow.refresh_access_token(tokens.refresh_token)
+
+      # Age the old token's revocation past the leeway so replay is a breach.
+      stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(rt in DeviceRefreshToken, where: not is_nil(rt.revoked_at)),
+        [set: [revoked_at: stale]],
+        skip_tenant_check: true
+      )
+
+      # Replay triggers the breach.
+      breach = post(conn, "/api/auth/token/refresh", %{refresh_token: tokens.refresh_token})
+      assert json_response(breach, 401)
+
+      # The current, previously-valid token is now rejected too.
+      after_breach =
+        post(conn, "/api/auth/token/refresh", %{refresh_token: current.refresh_token})
+
+      assert json_response(after_breach, 401)
+    end
   end
 end


### PR DESCRIPTION
## What

Device refresh tokens are single-use rotating (90-day TTL). This makes rotation **robust + secure** per RFC 9700 §4.14.2: refresh-token **reuse detection with token-family revocation**, layered on a short leeway window.

Supersedes the leeway-only first commit (which a review correctly flagged: leeway *without* reuse detection lets a stolen token fork an undetected, indefinitely-renewable family).

## How

Each refresh-token lineage shares a `family_id`. Rotation inherits it; a fresh login mints a new one. `refresh_access_token/1` classifies the presented token:

- **active** → rotate (single-use), issue child in same family
- **revoked ≤ leeway** → benign retry (lost rotation / concurrent request) → issue child, no re-revoke
- **revoked > leeway** → **reuse breach** → hard-delete the whole family → `401`

**Breach hard-deletes the family (not `set revoked_at`) on purpose:** a freshly-revoked *current* token would otherwise land inside the leeway window and be misclassified as a benign retry on its next presentation, defeating the revocation. `Logger.warning` preserves the audit trail past the row deletion.

Renamed `@refresh_grace_seconds` → `@refresh_leeway_seconds`, trimmed 60s → 30s (Auth0 recommends shortest; plugin reload races resolve <1s). Migration backfills each existing token its own `family_id`.

## Tests

`device_flow_test.exs` + `device_auth_controller_test.exs` — 32 green:
- rotation chain works; rotation keeps same family; fresh login = distinct family
- reuse within leeway → ok
- **reuse outside leeway → whole family revoked (current valid token also rejected)** — security-defining
- breach isolates to the offending family only
- expired token rejected, never triggers family revocation
- unknown token → invalid

Design + RFC/Auth0 citations: `docs/context/refresh-token-reuse-detection.md`.