### PR TITLE
feat: vault management settings — soft-delete, restore, purge, email

### DIFF
--- a/docs/superpowers/plans/2026-05-28-vault-management.md
+++ b/docs/superpowers/plans/2026-05-28-vault-management.md
@@ -1,0 +1,1755 @@
+# Vault Management Settings Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Vaults settings page where users list, rename, set-default, create, and soft-delete vaults (30-day grace), restore from trash, or purge immediately — plus a deletion-notice email.
+
+**Architecture:** Reuse the existing `deleted_at` soft-delete + `CleanupVault` 30-day machinery. Add backend context functions (`list_deleted_vaults`, `restore_vault`, `purge_vault`), an idempotency age-guard on `CleanupVault`, three controller actions + routes, and an Oban-driven deletion email. Build the React settings section against the existing TanStack Query + shadcn/ui patterns.
+
+**Tech Stack:** Elixir/Phoenix (Ecto, Oban, ExUnit), React + TypeScript (TanStack Query, vitest + Testing Library), Tailwind.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-vault-management-design.md`
+
+**Repo:** `engram-app/engram`. Backend paths are repo-root-relative; frontend paths are under `frontend/`.
+
+**Baseline before starting:** run `mix test` and (in `frontend/`) `bun run test` once to confirm a green tree.
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `lib/engram/workers/vault_deleted_email.ex` — Oban worker that sends the deletion notice.
+
+**Backend (modify):**
+- `lib/engram/vaults.ex` — add `list_deleted_vaults/1`, `restore_vault/2`, `purge_vault/2`, `fetch_deleted/2`; enqueue email in `delete_vault/2`.
+- `lib/engram/workers/cleanup_vault.ex` — age-guard + `enqueue_now/2` (force purge).
+- `lib/engram/mailer.ex` — `send_vault_deletion_notice/4`.
+- `lib/engram_web/controllers/vaults_controller.ex` — `index` deleted branch, `restore`, `purge`, `deleted_vault_json`.
+- `lib/engram_web/router.ex` — `POST /vaults/:id/restore`, `POST /vaults/:id/purge`.
+
+**Frontend (create):**
+- `frontend/src/settings/vaults-page.tsx`
+- `frontend/src/settings/vaults/active-vaults-section.tsx`
+- `frontend/src/settings/vaults/deleted-vaults-section.tsx`
+- `frontend/src/layout/empty-vault-state.tsx`
+- matching `*.test.tsx` for each.
+
+**Frontend (modify):**
+- `frontend/src/api/client.ts` — add `api.patch`.
+- `frontend/src/api/queries.ts` — `Vault` fields + 6 hooks.
+- `frontend/src/settings/sections.ts` — register Vaults.
+- `frontend/src/router.tsx` — `/settings/vaults` route.
+
+---
+
+## PHASE 1 — BACKEND
+
+### Task 1: `Vaults.list_deleted_vaults/1` + `fetch_deleted/2`
+
+**Files:**
+- Modify: `lib/engram/vaults.ex`
+- Test: `test/engram/vaults_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/engram/vaults_test.exs` inside the module:
+
+```elixir
+describe "list_deleted_vaults/1" do
+  setup %{user: user} do
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    :ok
+  end
+
+  test "returns only soft-deleted vaults, newest-deleted first", %{user: user} do
+    {:ok, keep} = Vaults.create_vault(user, %{name: "Keep"})
+    {:ok, gone} = Vaults.create_vault(user, %{name: "Gone"})
+    {:ok, _} = Vaults.delete_vault(user, gone.id)
+
+    deleted = Vaults.list_deleted_vaults(user)
+
+    assert Enum.map(deleted, & &1.id) == [gone.id]
+    assert keep.id not in Enum.map(deleted, & &1.id)
+    assert hd(deleted).name == "Gone"
+  end
+
+  test "excludes other users' deleted vaults", %{user: user, other_user: other} do
+    insert(:user_limit_override, user: other, key: "vaults_cap", value: %{"v" => 10})
+    {:ok, mine} = Vaults.create_vault(user, %{name: "Mine"})
+    {:ok, theirs} = Vaults.create_vault(other, %{name: "Theirs"})
+    {:ok, _} = Vaults.delete_vault(user, mine.id)
+    {:ok, _} = Vaults.delete_vault(other, theirs.id)
+
+    assert Enum.map(Vaults.list_deleted_vaults(user), & &1.id) == [mine.id]
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram/vaults_test.exs -o "list_deleted_vaults/1"`
+Expected: FAIL with `function Engram.Vaults.list_deleted_vaults/1 is undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/engram/vaults.ex`, after `list_vaults/1` (around line 156) add:
+
+```elixir
+  @doc """
+  Returns all soft-deleted vaults for a user, newest-deleted first.
+  """
+  def list_deleted_vaults(user) do
+    user = fresh_user(user)
+
+    {:ok, vaults} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(
+          from v in Vault,
+            where: v.user_id == ^user.id and not is_nil(v.deleted_at),
+            order_by: [desc: v.deleted_at, desc: v.id]
+        )
+      end)
+
+    Enum.map(vaults, &decrypt_vault_if_needed(&1, user))
+  end
+```
+
+And in the private helpers section (near `fetch_active/2`, ~line 388) add:
+
+```elixir
+  defp fetch_deleted(user_id, vault_id) do
+    Repo.one(
+      from v in Vault,
+        where: v.user_id == ^user_id and v.id == ^vault_id and not is_nil(v.deleted_at)
+    )
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/engram/vaults_test.exs -o "list_deleted_vaults/1"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/vaults.ex test/engram/vaults_test.exs
+git commit -m "feat(vaults): list_deleted_vaults + fetch_deleted helper"
+```
+
+---
+
+### Task 2: `Vaults.restore_vault/2`
+
+**Files:**
+- Modify: `lib/engram/vaults.ex`
+- Test: `test/engram/vaults_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+describe "restore_vault/2" do
+  test "clears deleted_at and returns the vault", %{user: user} do
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    {:ok, v} = Vaults.create_vault(user, %{name: "Temp"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    assert {:ok, restored} = Vaults.restore_vault(user, v.id)
+    assert restored.id == v.id
+    assert restored.deleted_at == nil
+    assert Enum.map(Vaults.list_vaults(user), & &1.id) |> Enum.member?(v.id)
+    assert Vaults.list_deleted_vaults(user) == []
+  end
+
+  test "blocks restore when it would exceed the vault cap", %{user: user} do
+    # Cap of 1: create one, delete it, create a replacement, then try to restore.
+    {:ok, first} = Vaults.create_vault(user, %{name: "First"})
+    {:ok, _} = Vaults.delete_vault(user, first.id)
+    {:ok, _replacement} = Vaults.create_vault(user, %{name: "Replacement"})
+
+    assert {:error, :limit_reached} = Vaults.restore_vault(user, first.id)
+    assert restored_ids(user) == []
+  end
+
+  test "returns :not_found for an active vault", %{user: user} do
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+    assert {:error, :not_found} = Vaults.restore_vault(user, v.id)
+  end
+
+  test "returns :not_found for another user's deleted vault", %{user: user, other_user: other} do
+    insert(:user_limit_override, user: other, key: "vaults_cap", value: %{"v" => 10})
+    {:ok, v} = Vaults.create_vault(other, %{name: "Theirs"})
+    {:ok, _} = Vaults.delete_vault(other, v.id)
+    assert {:error, :not_found} = Vaults.restore_vault(user, v.id)
+  end
+
+  defp restored_ids(user), do: Enum.map(Vaults.list_deleted_vaults(user), & &1.id)
+end
+```
+
+(Place the `defp restored_ids/1` helper at module level if your test module rejects describe-local defs; ExUnit allows module-level `defp`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram/vaults_test.exs -o "restore_vault/2"`
+Expected: FAIL with `function Engram.Vaults.restore_vault/2 is undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/engram/vaults.ex`, after `delete_vault/2` (around line 324) add:
+
+```elixir
+  @doc """
+  Restores a soft-deleted vault by clearing deleted_at.
+
+  Refuses (`{:error, :limit_reached}`) if restoring would exceed the user's
+  vault cap. The vault is restored as non-default; the user re-sets default
+  explicitly. The pending CleanupVault job becomes a no-op once deleted_at is nil.
+
+  Returns {:ok, vault}, {:error, :limit_reached}, or {:error, :not_found}.
+  """
+  def restore_vault(user, vault_id) do
+    user = fresh_user(user)
+
+    Repo.with_tenant(user.id, fn ->
+      case fetch_deleted(user.id, vault_id) do
+        nil ->
+          {:error, :not_found}
+
+        vault ->
+          active_count = count_vaults(user.id)
+
+          case Billing.check_limit(user, :vaults_cap, active_count) do
+            {:error, :limit_reached} ->
+              {:error, :limit_reached}
+
+            :ok ->
+              vault
+              |> Vault.changeset(%{deleted_at: nil})
+              |> Repo.update()
+              |> case do
+                {:ok, v} ->
+                  emit_vault_count(user.id, :restored)
+                  {:ok, decrypt_vault_if_needed(v, user)}
+
+                other ->
+                  other
+              end
+          end
+      end
+    end)
+    |> unwrap_transaction()
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/engram/vaults_test.exs -o "restore_vault/2"`
+Expected: PASS. (If `Vault.changeset` rejects `deleted_at: nil`, add `:deleted_at` to its `cast` list — it is already cast by `delete_vault`, so this should pass.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/vaults.ex test/engram/vaults_test.exs
+git commit -m "feat(vaults): restore_vault with cap guard"
+```
+
+---
+
+### Task 3: `CleanupVault` age-guard + `enqueue_now/2`
+
+**Files:**
+- Modify: `lib/engram/workers/cleanup_vault.ex`
+- Test: `test/engram/workers/cleanup_vault_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add (or create) `test/engram/workers/cleanup_vault_test.exs`:
+
+```elixir
+defmodule Engram.Workers.CleanupVaultTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Repo
+  alias Engram.Vaults
+  alias Engram.Vaults.Vault
+  alias Engram.Workers.CleanupVault
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    %{user: user}
+  end
+
+  defp backdate_deleted_at(vault_id, days) do
+    ts = DateTime.add(DateTime.utc_now(), -days * 86_400, :second) |> DateTime.truncate(:second)
+    from(v in Vault, where: v.id == ^vault_id)
+    |> Repo.update_all(set: [deleted_at: ts])
+  end
+
+  test "skips when the vault was restored (deleted_at nil)", %{user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+    assert :ok = CleanupVault.perform_cleanup(v.id, user.id)
+    assert Repo.get(Vault, v.id, skip_tenant_check: true)
+  end
+
+  test "snoozes when deleted_at is younger than 30 days", %{user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+    backdate_deleted_at(v.id, 5)
+
+    assert {:snooze, secs} = CleanupVault.perform_cleanup(v.id, user.id)
+    assert secs > 0
+    assert Repo.get(Vault, v.id, skip_tenant_check: true)
+  end
+
+  test "purges when deleted_at is older than 30 days", %{user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+    backdate_deleted_at(v.id, 31)
+
+    assert :ok = CleanupVault.perform_cleanup(v.id, user.id)
+    refute Repo.get(Vault, v.id, skip_tenant_check: true)
+  end
+
+  test "force purges immediately regardless of age", %{user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+    # freshly deleted (age ~0) but force=true
+
+    assert :ok = CleanupVault.perform_cleanup(v.id, user.id, force: true)
+    refute Repo.get(Vault, v.id, skip_tenant_check: true)
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram/workers/cleanup_vault_test.exs`
+Expected: FAIL — the snooze test fails (current code purges young vaults) and `perform_cleanup/3` is undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/engram/workers/cleanup_vault.ex`:
+
+Add an `enqueue_now/2` after `enqueue/2`:
+
+```elixir
+  @doc """
+  Enqueues an immediate (unscheduled) force-purge. Used by the "delete
+  permanently now" path — bypasses the retention age guard.
+  """
+  def enqueue_now(vault_id, user_id) do
+    %{vault_id: vault_id, user_id: user_id, force: true}
+    |> new()
+    |> Oban.insert()
+  end
+```
+
+Replace `perform/1` and `perform_cleanup/2` with:
+
+```elixir
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"vault_id" => vault_id, "user_id" => user_id} = args}) do
+    perform_cleanup(vault_id, user_id, force: Map.get(args, "force", false))
+  end
+
+  @doc false
+  def perform_cleanup(vault_id, user_id, opts \\ []) do
+    force = Keyword.get(opts, :force, false)
+    vault = Repo.get(Vault, vault_id, skip_tenant_check: true)
+    _ = user_id
+
+    cond do
+      is_nil(vault) ->
+        Logger.info("CleanupVault: vault #{vault_id} not found — skipping")
+        :ok
+
+      is_nil(vault.deleted_at) ->
+        Logger.info("CleanupVault: vault #{vault_id} was restored — skipping")
+        :ok
+
+      not force and (age = retention_age_secs(vault)) < @retention_secs ->
+        snooze = @retention_secs - age
+        Logger.info("CleanupVault: vault #{vault_id} not yet at retention — snoozing #{snooze}s")
+        {:snooze, snooze}
+
+      true ->
+        Logger.info("CleanupVault: starting hard-delete for vault #{vault_id}")
+        run_cleanup(vault)
+    end
+  end
+
+  @retention_secs @retention_days * 86_400
+
+  defp retention_age_secs(vault) do
+    DateTime.diff(DateTime.utc_now(), vault.deleted_at, :second)
+  end
+```
+
+(Keep the existing `@retention_days 30` attribute; the `@retention_secs` module attribute must appear after it — place it just above the `perform/1` clause or with the other attributes.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/engram/workers/cleanup_vault_test.exs`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/workers/cleanup_vault.ex test/engram/workers/cleanup_vault_test.exs
+git commit -m "fix(cleanup_vault): retention age guard + force purge path"
+```
+
+---
+
+### Task 4: `Vaults.purge_vault/2`
+
+**Files:**
+- Modify: `lib/engram/vaults.ex`
+- Test: `test/engram/vaults_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+describe "purge_vault/2" do
+  use Oban.Testing, repo: Engram.Repo
+
+  test "enqueues an immediate force cleanup for a soft-deleted vault", %{user: user} do
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    {:ok, v} = Vaults.create_vault(user, %{name: "Doomed"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    assert {:ok, vault} = Vaults.purge_vault(user, v.id)
+    assert vault.id == v.id
+
+    assert_enqueued(
+      worker: Engram.Workers.CleanupVault,
+      args: %{vault_id: v.id, user_id: user.id, force: true}
+    )
+  end
+
+  test "returns :not_found for an active vault", %{user: user} do
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+    assert {:error, :not_found} = Vaults.purge_vault(user, v.id)
+  end
+end
+```
+
+(If `use Oban.Testing` inside a `describe` is rejected, move it to the top of the module under `use Engram.DataCase`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram/vaults_test.exs -o "purge_vault/2"`
+Expected: FAIL with `function Engram.Vaults.purge_vault/2 is undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/engram/vaults.ex`, after `restore_vault/2` add:
+
+```elixir
+  @doc """
+  Immediately hard-deletes a soft-deleted vault by enqueuing a force CleanupVault
+  job. Only soft-deleted vaults can be purged.
+
+  Returns {:ok, vault} or {:error, :not_found}.
+  """
+  def purge_vault(user, vault_id) do
+    user = fresh_user(user)
+
+    Repo.with_tenant(user.id, fn ->
+      case fetch_deleted(user.id, vault_id) do
+        nil ->
+          {:error, :not_found}
+
+        vault ->
+          {:ok, _job} = Engram.Workers.CleanupVault.enqueue_now(vault.id, vault.user_id)
+          {:ok, vault}
+      end
+    end)
+    |> unwrap_transaction()
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/engram/vaults_test.exs -o "purge_vault/2"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/vaults.ex test/engram/vaults_test.exs
+git commit -m "feat(vaults): purge_vault force-cleanup path"
+```
+
+---
+
+### Task 5: Controller actions + routes + `purge_at`
+
+**Files:**
+- Modify: `lib/engram_web/controllers/vaults_controller.ex`
+- Modify: `lib/engram_web/router.ex`
+- Test: `test/engram_web/controllers/vaults_controller_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/engram_web/controllers/vaults_controller_test.exs`:
+
+```elixir
+describe "GET /api/vaults?deleted=true" do
+  test "lists soft-deleted vaults with a purge_at", %{conn: conn, user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Trashed"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    body = conn |> get("/api/vaults?deleted=true") |> json_response(200)
+    [item] = body["vaults"]
+    assert item["id"] == v.id
+    assert item["deleted_at"]
+    assert item["purge_at"]
+  end
+
+  test "active listing excludes deleted vaults", %{conn: conn, user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Trashed"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    body = conn |> get("/api/vaults") |> json_response(200)
+    assert body["vaults"] == []
+  end
+end
+
+describe "POST /api/vaults/:id/restore" do
+  test "restores a deleted vault", %{conn: conn, user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Back"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    body = conn |> post("/api/vaults/#{v.id}/restore") |> json_response(200)
+    assert body["vault"]["id"] == v.id
+  end
+
+  test "returns 402 when over cap", %{conn: conn} do
+    # fresh user with default cap (1), no override
+    other = insert(:user)
+    {:ok, raw_key, _} = Engram.Accounts.create_api_key(other, "k")
+    grant_api_write!(other)
+    oconn = build_conn() |> put_req_header("authorization", "Bearer #{raw_key}")
+
+    {:ok, first} = Vaults.create_vault(other, %{name: "First"})
+    {:ok, _} = Vaults.delete_vault(other, first.id)
+    {:ok, _} = Vaults.create_vault(other, %{name: "Replacement"})
+
+    body = oconn |> post("/api/vaults/#{first.id}/restore") |> json_response(402)
+    assert body["error"] == "vault_limit_reached"
+  end
+
+  test "returns 404 for an active vault", %{conn: conn, user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+    conn |> post("/api/vaults/#{v.id}/restore") |> json_response(404)
+  end
+end
+
+describe "POST /api/vaults/:id/purge" do
+  test "purges a deleted vault", %{conn: conn, user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Doomed"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    body = conn |> post("/api/vaults/#{v.id}/purge") |> json_response(200)
+    assert body["purged"] == true
+    assert body["id"] == v.id
+  end
+
+  test "returns 404 for an active vault", %{conn: conn, user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+    conn |> post("/api/vaults/#{v.id}/purge") |> json_response(404)
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram_web/controllers/vaults_controller_test.exs`
+Expected: FAIL — routes not found (Phoenix raises `no route found` → 404/500) and `?deleted=true` returns the active listing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/engram_web/router.ex`, find the vaults routes block (the `get/post/patch/delete "/vaults"...` lines, ~155-161) and add two routes immediately after the existing `delete "/vaults/:id"`:
+
+```elixir
+    post "/vaults/:id/restore", VaultsController, :restore
+    post "/vaults/:id/purge", VaultsController, :purge
+```
+
+In `lib/engram_web/controllers/vaults_controller.ex`, replace `index/2` and add the two actions + JSON helper. New `index`:
+
+```elixir
+  def index(conn, %{"deleted" => "true"}) do
+    user = conn.assigns.current_user
+    vaults = Vaults.list_deleted_vaults(user)
+    json(conn, %{vaults: Enum.map(vaults, &deleted_vault_json(&1, user))})
+  end
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    vaults = Vaults.list_vaults(user)
+    json(conn, %{vaults: Enum.map(vaults, &vault_json(&1, user))})
+  end
+```
+
+Add after `delete/2` (before the `register` section or near it):
+
+```elixir
+  # ── restore ──────────────────────────────────────────────────────────────────
+
+  def restore(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case parse_id(id) do
+      {:ok, vault_id} ->
+        case Vaults.restore_vault(user, vault_id) do
+          {:ok, vault} ->
+            json(conn, %{vault: vault_json(vault, user)})
+
+          {:error, :limit_reached} ->
+            limit = Billing.effective_limit(user, :vaults_cap)
+
+            conn
+            |> put_status(402)
+            |> json(%{error: "vault_limit_reached", limit: limit})
+
+          {:error, :not_found} ->
+            not_found(conn)
+        end
+
+      :error ->
+        not_found(conn)
+    end
+  end
+
+  # ── purge (immediate hard delete) ──────────────────────────────────────────────
+
+  def purge(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case parse_id(id) do
+      {:ok, vault_id} ->
+        case Vaults.purge_vault(user, vault_id) do
+          {:ok, _vault} -> json(conn, %{purged: true, id: vault_id})
+          {:error, :not_found} -> not_found(conn)
+        end
+
+      :error ->
+        not_found(conn)
+    end
+  end
+```
+
+Add the deleted-vault JSON helper in the private section, next to `vault_json/2`:
+
+```elixir
+  defp deleted_vault_json(vault, user) do
+    vault
+    |> vault_json(user)
+    |> Map.merge(%{
+      deleted_at: vault.deleted_at,
+      purge_at: purge_at(vault.deleted_at)
+    })
+  end
+
+  defp purge_at(nil), do: nil
+  defp purge_at(deleted_at), do: DateTime.add(deleted_at, 30 * 86_400, :second)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/engram_web/controllers/vaults_controller_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram_web/controllers/vaults_controller.ex lib/engram_web/router.ex test/engram_web/controllers/vaults_controller_test.exs
+git commit -m "feat(vaults): restore/purge endpoints + deleted listing"
+```
+
+---
+
+### Task 6: Deletion-notice email (Mailer + worker + enqueue)
+
+**Files:**
+- Modify: `lib/engram/mailer.ex`
+- Create: `lib/engram/workers/vault_deleted_email.ex`
+- Modify: `lib/engram/vaults.ex` (`delete_vault/2`)
+- Test: `test/engram/mailer_test.exs`, `test/engram/workers/vault_deleted_email_test.exs`
+
+- [ ] **Step 1: Write the failing test (mailer)**
+
+Add to `test/engram/mailer_test.exs` (create if absent, mirroring existing mailer tests; the test provider is configured in `config/test.exs`):
+
+```elixir
+defmodule Engram.MailerVaultNoticeTest do
+  use Engram.DataCase, async: true
+  alias Engram.Mailer
+
+  test "send_vault_deletion_notice returns :ok and includes the manage link" do
+    user = insert(:user, email: "u@example.com")
+    assert :ok =
+             Mailer.send_vault_deletion_notice(
+               user,
+               "My Vault",
+               "June 27, 2026",
+               "https://app.engram.page/settings/vaults?highlight=1"
+             )
+  end
+end
+```
+
+(If the test provider captures the sent body, additionally assert the body contains the URL. Match the assertion style of the existing `mailer_test.exs`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mix test test/engram/mailer_test.exs`
+Expected: FAIL with `function Engram.Mailer.send_vault_deletion_notice/4 is undefined`.
+
+- [ ] **Step 3: Implement the mailer function**
+
+In `lib/engram/mailer.ex`, add after `send_account_deleted_notice/1`:
+
+```elixir
+  @doc """
+  Notifies a user that a vault was soft-deleted and will be purged on
+  `purge_date` (a preformatted string). `manage_url` deep-links to the vault
+  settings page where they can restore or purge immediately.
+  """
+  def send_vault_deletion_notice(%User{email: email}, vault_name, purge_date, manage_url) do
+    vault_name = Template.esc(vault_name)
+    purge_date = Template.esc(purge_date)
+
+    body = """
+    <mj-text>Your Engram vault "#{vault_name}" has been deleted.</mj-text>
+    <mj-text>It will be permanently removed on #{purge_date}. Until then you can
+    restore it — or, if you meant to delete it, remove it permanently now — from
+    your vault settings.</mj-text>
+    <mj-button href="#{manage_url}" background-color="#5b5bd6">Manage vault</mj-button>
+    <mj-text>No action is needed if you want it gone; it will be cleaned up
+    automatically.</mj-text>
+    """
+
+    render_and_deliver(email, "Your Engram vault was deleted", body)
+  end
+```
+
+- [ ] **Step 4: Run to verify the mailer test passes**
+
+Run: `mix test test/engram/mailer_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test (worker)**
+
+Create `test/engram/workers/vault_deleted_email_test.exs`:
+
+```elixir
+defmodule Engram.Workers.VaultDeletedEmailTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Vaults
+  alias Engram.Workers.VaultDeletedEmail
+
+  setup do
+    user = insert(:user, email: "u@example.com")
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    %{user: user}
+  end
+
+  test "perform sends the notice for a soft-deleted vault", %{user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Gone"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    job = %Oban.Job{args: %{"user_id" => user.id, "vault_id" => v.id}}
+    assert :ok = VaultDeletedEmail.perform(job)
+  end
+
+  test "perform is a no-op when the vault is missing", %{user: user} do
+    job = %Oban.Job{args: %{"user_id" => user.id, "vault_id" => 999_999}}
+    assert :ok = VaultDeletedEmail.perform(job)
+  end
+end
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `mix test test/engram/workers/vault_deleted_email_test.exs`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 7: Implement the worker**
+
+Create `lib/engram/workers/vault_deleted_email.ex`:
+
+```elixir
+defmodule Engram.Workers.VaultDeletedEmail do
+  @moduledoc """
+  Oban worker: emails a user that a vault was soft-deleted, with a link to the
+  vault settings page (restore / purge-now). Self-host installs no-op via the
+  NoOp mail provider. Sends asynchronously so the DELETE request is never
+  blocked on mail delivery.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Mailer
+  alias Engram.Repo
+  alias Engram.Vaults.Vault
+
+  require Logger
+
+  @retention_days 30
+
+  def enqueue(user_id, vault_id) do
+    %{user_id: user_id, vault_id: vault_id}
+    |> new()
+    |> Oban.insert()
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "vault_id" => vault_id}}) do
+    user = Repo.get(User, user_id, skip_tenant_check: true)
+    vault = Repo.get(Vault, vault_id, skip_tenant_check: true)
+
+    cond do
+      is_nil(user) or is_nil(vault) ->
+        :ok
+
+      is_nil(vault.deleted_at) ->
+        :ok
+
+      true ->
+        purge_at = DateTime.add(vault.deleted_at, @retention_days * 86_400, :second)
+        purge_date = Calendar.strftime(purge_at, "%B %-d, %Y")
+        manage_url = EngramWeb.Endpoint.url() <> "/settings/vaults?highlight=#{vault.id}"
+        _ = Mailer.send_vault_deletion_notice(user, vault_name(vault, user), purge_date, manage_url)
+        :ok
+    end
+  end
+
+  defp vault_name(vault, user) do
+    case Crypto.maybe_decrypt_vault_fields(vault, user) do
+      {:ok, decrypted} -> decrypted.name
+      _ -> vault.slug
+    end
+  end
+end
+```
+
+- [ ] **Step 8: Run to verify the worker test passes**
+
+Run: `mix test test/engram/workers/vault_deleted_email_test.exs`
+Expected: PASS.
+
+- [ ] **Step 9: Enqueue the email from `delete_vault/2`**
+
+In `lib/engram/vaults.ex`, in the `{:ok, deleted}` branch of `delete_vault/2` (right after the existing `CleanupVault.enqueue` line, ~line 314):
+
+```elixir
+            {:ok, deleted} ->
+              _ = Engram.Workers.CleanupVault.enqueue(deleted.id, deleted.user_id)
+              _ = Engram.Workers.VaultDeletedEmail.enqueue(deleted.user_id, deleted.id)
+              emit_vault_count(deleted.user_id, :deleted)
+              result
+```
+
+- [ ] **Step 10: Verify delete enqueues the email**
+
+Add to the `delete_vault/2` describe in `test/engram/vaults_test.exs`:
+
+```elixir
+  test "delete_vault enqueues the deletion-notice email", %{user: user} do
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    {:ok, v} = Vaults.create_vault(user, %{name: "Bye"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    assert_enqueued(worker: Engram.Workers.VaultDeletedEmail, args: %{vault_id: v.id, user_id: user.id})
+  end
+```
+
+(Ensure `use Oban.Testing, repo: Engram.Repo` is present at the top of the test module.)
+
+Run: `mix test test/engram/vaults_test.exs`
+Expected: PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add lib/engram/mailer.ex lib/engram/workers/vault_deleted_email.ex lib/engram/vaults.ex test/engram/mailer_test.exs test/engram/workers/vault_deleted_email_test.exs test/engram/vaults_test.exs
+git commit -m "feat(vaults): deletion-notice email on soft-delete"
+```
+
+- [ ] **Step 12: Run the full backend suite**
+
+Run: `mix test`
+Expected: PASS. Fix any regressions before moving to the frontend.
+
+---
+
+## PHASE 2 — FRONTEND
+
+All commands below run from `frontend/`.
+
+### Task 7: `api.patch` + `Vault` fields + query hooks
+
+**Files:**
+- Modify: `frontend/src/api/client.ts`
+- Modify: `frontend/src/api/queries.ts`
+
+- [ ] **Step 1: Add `api.patch`**
+
+In `frontend/src/api/client.ts`, add to the `api` object (after `post`):
+
+```typescript
+  async patch<T>(path: string, body?: unknown): Promise<T> {
+    const res = await authFetch(path, {
+      method: 'PATCH',
+      body: body ? JSON.stringify(body) : undefined,
+    })
+    return res.json()
+  },
+```
+
+- [ ] **Step 2: Extend the `Vault` type**
+
+In `frontend/src/api/queries.ts`, add to the `Vault` interface:
+
+```typescript
+  deleted_at?: string | null
+  purge_at?: string | null
+```
+
+- [ ] **Step 3: Add the hooks**
+
+In `frontend/src/api/queries.ts`, after the existing vault hooks add:
+
+```typescript
+export function useDeletedVaults() {
+  return useQuery({
+    queryKey: ['vaults', 'deleted'],
+    queryFn: () => api.get<{ vaults: Vault[] }>('/vaults?deleted=true'),
+    select: (data) => data.vaults,
+  })
+}
+
+export function useDeleteVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => api.del<{ deleted: boolean }>(`/vaults/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+
+export function useRestoreVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => api.post<{ vault: Vault }>(`/vaults/${id}/restore`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+
+export function usePurgeVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => api.post<{ purged: boolean }>(`/vaults/${id}/purge`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+
+export function useUpdateVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, ...attrs }: { id: number; name?: string; description?: string; is_default?: boolean }) =>
+      api.patch<{ vault: Vault }>(`/vaults/${id}`, attrs),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+
+export function useCreateVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (attrs: { name: string; description?: string }) =>
+      api.post<{ vault: Vault }>('/vaults', attrs),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+```
+
+> Note: `invalidateQueries({ queryKey: ['vaults'] })` matches `['vaults','deleted']` by prefix, so both active and trash lists refetch — no separate invalidation needed.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bun run build` (or `bunx tsc --noEmit` if defined)
+Expected: no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/client.ts src/api/queries.ts
+git commit -m "feat(frontend): vault management api hooks"
+```
+
+---
+
+### Task 8: Active vaults section (list, rename, set default, delete)
+
+**Files:**
+- Create: `frontend/src/settings/vaults/active-vaults-section.tsx`
+- Test: `frontend/src/settings/vaults/active-vaults-section.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/settings/vaults/active-vaults-section.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const deleteMutate = vi.fn()
+const updateMutate = vi.fn()
+const vaults = [
+  { id: 1, name: 'Work', description: null, slug: 'work', is_default: true, created_at: '', encrypted: true },
+  { id: 2, name: 'Personal', description: null, slug: 'personal', is_default: false, created_at: '', encrypted: true },
+]
+
+vi.mock('@/api/queries', () => ({
+  useVaults: () => ({ data: vaults, isLoading: false }),
+  useDeleteVault: () => ({ mutate: deleteMutate, isPending: false }),
+  useUpdateVault: () => ({ mutate: updateMutate, isPending: false }),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { ActiveVaultsSection } from './active-vaults-section'
+
+describe('ActiveVaultsSection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('lists vaults and marks the default', () => {
+    render(<ActiveVaultsSection />)
+    expect(screen.getByText('Work')).toBeInTheDocument()
+    expect(screen.getByText('Personal')).toBeInTheDocument()
+    expect(screen.getByText(/default/i)).toBeInTheDocument()
+  })
+
+  it('keeps delete disabled until the vault name is typed', async () => {
+    render(<ActiveVaultsSection />)
+    fireEvent.click(screen.getAllByRole('button', { name: /^delete$/i })[0])
+    const confirmBtn = screen.getByRole('button', { name: /delete vault/i })
+    expect(confirmBtn).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/type .*work.* to confirm/i), { target: { value: 'Work' } })
+    expect(confirmBtn).toBeEnabled()
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith(1, expect.anything()))
+  })
+
+  it('sets a non-default vault as default', () => {
+    render(<ActiveVaultsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /set default/i }))
+    expect(updateMutate).toHaveBeenCalledWith({ id: 2, is_default: true }, expect.anything())
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun run test active-vaults-section`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/settings/vaults/active-vaults-section.tsx`:
+
+```tsx
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { SettingsSectionCard } from '@/settings/account/section-card'
+import { useVaults, useDeleteVault, useUpdateVault, type Vault } from '@/api/queries'
+
+const inputClass =
+  'mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
+
+export function ActiveVaultsSection() {
+  const { data: vaults, isLoading } = useVaults()
+
+  return (
+    <SettingsSectionCard title="Vaults" description="Rename, set a default, or delete your vaults.">
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      <ul className="divide-y divide-border">
+        {(vaults ?? []).map((v) => (
+          <VaultRow key={v.id} vault={v} />
+        ))}
+      </ul>
+    </SettingsSectionCard>
+  )
+}
+
+function VaultRow({ vault }: { vault: Vault }) {
+  const update = useUpdateVault()
+  const del = useDeleteVault()
+  const [renaming, setRenaming] = useState(false)
+  const [name, setName] = useState(vault.name)
+  const [confirming, setConfirming] = useState(false)
+  const [phrase, setPhrase] = useState('')
+
+  function saveName() {
+    const next = name.trim()
+    if (next && next !== vault.name) {
+      update.mutate({ id: vault.id, name: next }, { onError: () => toast.error('Rename failed') })
+    }
+    setRenaming(false)
+  }
+
+  return (
+    <li className="py-3">
+      <div className="flex items-center justify-between gap-3">
+        {renaming ? (
+          <input
+            autoFocus
+            className={inputClass}
+            value={name}
+            aria-label={`Rename ${vault.name}`}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={saveName}
+            onKeyDown={(e) => e.key === 'Enter' && saveName()}
+          />
+        ) : (
+          <button type="button" className="text-sm font-medium text-foreground" onClick={() => setRenaming(true)}>
+            {vault.name}
+          </button>
+        )}
+        <div className="flex items-center gap-2">
+          {vault.is_default ? (
+            <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">Default</span>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                update.mutate({ id: vault.id, is_default: true }, { onError: () => toast.error('Could not set default') })
+              }
+            >
+              Set default
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" onClick={() => setConfirming((c) => !c)}>
+            Delete
+          </Button>
+        </div>
+      </div>
+      {confirming && (
+        <form
+          className="mt-3 rounded-md border border-destructive/40 bg-destructive/5 p-3"
+          onSubmit={(e) => {
+            e.preventDefault()
+            del.mutate(vault.id, {
+              onSuccess: () => toast.success('Vault deleted'),
+              onError: () => toast.error('Delete failed'),
+            })
+          }}
+        >
+          <label className="block text-sm text-foreground">
+            Type "{vault.name}" to confirm
+            <input
+              className={inputClass}
+              aria-label={`Type ${vault.name} to confirm`}
+              value={phrase}
+              onChange={(e) => setPhrase(e.target.value)}
+            />
+          </label>
+          <Button className="mt-3" type="submit" variant="destructive" size="sm" disabled={phrase !== vault.name}>
+            Delete vault
+          </Button>
+        </form>
+      )}
+    </li>
+  )
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun run test active-vaults-section`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/settings/vaults/active-vaults-section.tsx src/settings/vaults/active-vaults-section.test.tsx
+git commit -m "feat(frontend): active vaults section with rename/default/delete"
+```
+
+---
+
+### Task 9: Recently deleted section (restore, purge, over-cap)
+
+**Files:**
+- Create: `frontend/src/settings/vaults/deleted-vaults-section.tsx`
+- Test: `frontend/src/settings/vaults/deleted-vaults-section.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/settings/vaults/deleted-vaults-section.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const restoreMutate = vi.fn()
+const purgeMutate = vi.fn()
+let deleted = [
+  { id: 5, name: 'Old', description: null, slug: 'old', is_default: false, created_at: '', encrypted: true, deleted_at: '2026-05-28T00:00:00Z', purge_at: '2026-06-27T00:00:00Z' },
+]
+let activeCount = 1
+const cap = 1
+
+vi.mock('@/api/queries', () => ({
+  useDeletedVaults: () => ({ data: deleted, isLoading: false }),
+  useVaults: () => ({ data: new Array(activeCount).fill({ id: 99 }) }),
+  useRestoreVault: () => ({ mutate: restoreMutate, isPending: false }),
+  usePurgeVault: () => ({ mutate: purgeMutate, isPending: false }),
+  useBillingConfig: () => ({ data: { vaults_cap: cap } }),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { DeletedVaultsSection } from './deleted-vaults-section'
+
+describe('DeletedVaultsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    activeCount = 1
+  })
+
+  it('shows the purge date', () => {
+    render(<DeletedVaultsSection />)
+    expect(screen.getByText('Old')).toBeInTheDocument()
+    expect(screen.getByText(/purges/i)).toBeInTheDocument()
+  })
+
+  it('disables restore when at the cap', () => {
+    activeCount = 1 // cap is 1, so restoring would exceed
+    render(<DeletedVaultsSection />)
+    expect(screen.getByRole('button', { name: /restore/i })).toBeDisabled()
+  })
+
+  it('restores when under cap', async () => {
+    activeCount = 0
+    render(<DeletedVaultsSection />)
+    const btn = screen.getByRole('button', { name: /restore/i })
+    expect(btn).toBeEnabled()
+    fireEvent.click(btn)
+    await waitFor(() => expect(restoreMutate).toHaveBeenCalledWith(5, expect.anything()))
+  })
+})
+```
+
+> The cap source: this test mocks a `useBillingConfig` hook returning `{ vaults_cap }`. If the app already exposes the cap differently (e.g. on the config endpoint or a billing hook), use that real hook name in both the component and the mock. Confirm the actual hook in `src/api/queries.ts` / `src/config.ts` before implementing; the over-cap *logic* (disable when `activeCount >= cap`) is what matters.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun run test deleted-vaults-section`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/settings/vaults/deleted-vaults-section.tsx`:
+
+```tsx
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { SettingsSectionCard } from '@/settings/account/section-card'
+import {
+  useDeletedVaults,
+  useVaults,
+  useRestoreVault,
+  usePurgeVault,
+  useBillingConfig,
+  type Vault,
+} from '@/api/queries'
+
+export function DeletedVaultsSection() {
+  const { data: deleted } = useDeletedVaults()
+  if (!deleted || deleted.length === 0) return null
+
+  return (
+    <SettingsSectionCard
+      title="Recently deleted"
+      description="Deleted vaults are kept for 30 days. Restore them, or remove them permanently."
+    >
+      <ul className="divide-y divide-border">
+        {deleted.map((v) => (
+          <DeletedRow key={v.id} vault={v} />
+        ))}
+      </ul>
+    </SettingsSectionCard>
+  )
+}
+
+function DeletedRow({ vault }: { vault: Vault }) {
+  const { data: active } = useVaults()
+  const { data: billing } = useBillingConfig()
+  const restore = useRestoreVault()
+  const purge = usePurgeVault()
+
+  const cap = billing?.vaults_cap ?? Infinity
+  const activeCount = active?.length ?? 0
+  const overCap = activeCount >= cap
+  const purgeDate = vault.purge_at ? new Date(vault.purge_at).toLocaleDateString() : null
+
+  return (
+    <li className="flex items-center justify-between gap-3 py-3">
+      <div>
+        <p className="text-sm font-medium text-foreground">{vault.name}</p>
+        {purgeDate && <p className="text-xs text-muted-foreground">Purges {purgeDate}</p>}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={overCap || restore.isPending}
+          title={overCap ? 'Restoring would exceed your vault limit. Upgrade or delete another vault first.' : undefined}
+          onClick={() =>
+            restore.mutate(vault.id, {
+              onSuccess: () => toast.success('Vault restored'),
+              onError: () => toast.error('Could not restore (vault limit reached?)'),
+            })
+          }
+        >
+          Restore
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          disabled={purge.isPending}
+          onClick={() => {
+            if (window.confirm(`Permanently delete "${vault.name}"? This cannot be undone.`)) {
+              purge.mutate(vault.id, {
+                onSuccess: () => toast.success('Vault permanently deleted'),
+                onError: () => toast.error('Could not delete'),
+              })
+            }
+          }}
+        >
+          Delete permanently
+        </Button>
+      </div>
+    </li>
+  )
+}
+```
+
+> If a `useBillingConfig` hook does not exist, add a minimal one in `queries.ts` that reads `GET /billing/config` (which `CLAUDE.md` documents) and exposes `vaults_cap`, or derive the cap from the existing config object. Keep the disable logic identical.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun run test deleted-vaults-section`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/settings/vaults/deleted-vaults-section.tsx src/settings/vaults/deleted-vaults-section.test.tsx
+git commit -m "feat(frontend): recently-deleted section with restore/purge"
+```
+
+---
+
+### Task 10: Vaults page (create + compose sections + highlight)
+
+**Files:**
+- Create: `frontend/src/settings/vaults-page.tsx`
+- Test: `frontend/src/settings/vaults-page.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/settings/vaults-page.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const createMutate = vi.fn()
+vi.mock('./vaults/active-vaults-section', () => ({ ActiveVaultsSection: () => <div>active-section</div> }))
+vi.mock('./vaults/deleted-vaults-section', () => ({ DeletedVaultsSection: () => <div>deleted-section</div> }))
+vi.mock('@/api/queries', () => ({ useCreateVault: () => ({ mutate: createMutate, isPending: false }) }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import VaultsPage from './vaults-page'
+
+describe('VaultsPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders both sections and a header', () => {
+    render(<VaultsPage />)
+    expect(screen.getByRole('heading', { name: /vaults/i })).toBeInTheDocument()
+    expect(screen.getByText('active-section')).toBeInTheDocument()
+    expect(screen.getByText('deleted-section')).toBeInTheDocument()
+  })
+
+  it('creates a new vault', async () => {
+    render(<VaultsPage />)
+    fireEvent.click(screen.getByRole('button', { name: /new vault/i }))
+    fireEvent.change(screen.getByLabelText(/vault name/i), { target: { value: 'Research' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => expect(createMutate).toHaveBeenCalledWith({ name: 'Research' }, expect.anything()))
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun run test vaults-page`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the page**
+
+Create `frontend/src/settings/vaults-page.tsx`:
+
+```tsx
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { useCreateVault } from '@/api/queries'
+import { ActiveVaultsSection } from './vaults/active-vaults-section'
+import { DeletedVaultsSection } from './vaults/deleted-vaults-section'
+
+const inputClass =
+  'mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
+
+export default function VaultsPage() {
+  const create = useCreateVault()
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault()
+    const next = name.trim()
+    if (!next) return
+    create.mutate(
+      { name: next },
+      {
+        onSuccess: () => {
+          toast.success('Vault created')
+          setName('')
+          setOpen(false)
+        },
+        onError: () => toast.error('Could not create vault (limit reached?)'),
+      },
+    )
+  }
+
+  return (
+    <article className="space-y-6">
+      <header className="flex items-start justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Vaults</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Manage, create, and recover your vaults.</p>
+        </div>
+        <Button onClick={() => setOpen((o) => !o)}>New vault</Button>
+      </header>
+
+      {open && (
+        <form className="rounded-lg border border-border bg-card p-4" onSubmit={submit}>
+          <label className="block text-sm font-medium text-foreground">
+            Vault name
+            <input className={inputClass} aria-label="Vault name" value={name} onChange={(e) => setName(e.target.value)} />
+          </label>
+          <div className="mt-3 flex gap-2">
+            <Button type="submit" size="sm" disabled={create.isPending}>
+              Create
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
+
+      <ActiveVaultsSection />
+      <DeletedVaultsSection />
+    </article>
+  )
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun run test vaults-page`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/settings/vaults-page.tsx src/settings/vaults-page.test.tsx
+git commit -m "feat(frontend): vaults settings page with create"
+```
+
+---
+
+### Task 11: Register the section + route
+
+**Files:**
+- Modify: `frontend/src/settings/sections.ts`
+- Modify: `frontend/src/router.tsx`
+- Test: `frontend/src/settings/sections.test.ts` (if present; otherwise add one)
+
+- [ ] **Step 1: Write/extend the failing test**
+
+If `frontend/src/settings/sections.test.ts` exists, add:
+
+```ts
+it('includes the Vaults section', () => {
+  const labels = buildSettingsSections('clerk', true).map((s) => s.label)
+  expect(labels).toContain('Vaults')
+})
+```
+
+If it does not exist, create `frontend/src/settings/sections.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { buildSettingsSections } from './sections'
+
+describe('buildSettingsSections', () => {
+  it('includes the Vaults section for clerk + billing', () => {
+    const labels = buildSettingsSections('clerk', true).map((s) => s.label)
+    expect(labels).toContain('Vaults')
+  })
+
+  it('includes the Vaults section for self-host', () => {
+    const labels = buildSettingsSections('local', false).map((s) => s.label)
+    expect(labels).toContain('Vaults')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun run test sections`
+Expected: FAIL — no 'Vaults' label.
+
+- [ ] **Step 3: Register the section**
+
+In `frontend/src/settings/sections.ts`, add Vaults to the always-shown base list:
+
+```typescript
+  const sections: SettingsSection[] = [
+    { to: 'vaults', label: 'Vaults' },
+    { to: 'api-keys', label: 'API Keys' },
+  ]
+```
+
+- [ ] **Step 4: Add the route**
+
+In `frontend/src/router.tsx`, import the page near the other settings imports:
+
+```typescript
+import VaultsPage from '@/settings/vaults-page'
+```
+
+Add a child route inside the `/settings` `children` array, alongside `api-keys`:
+
+```typescript
+                { path: 'vaults', element: <VaultsPage /> },
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `bun run test sections`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/settings/sections.ts src/settings/sections.test.ts src/router.tsx
+git commit -m "feat(frontend): register Vaults settings section + route"
+```
+
+---
+
+### Task 12: Highlight deep-link from email
+
+**Files:**
+- Modify: `frontend/src/settings/vaults-page.tsx`
+- Modify: `frontend/src/settings/vaults/deleted-vaults-section.tsx`
+- Test: extend `frontend/src/settings/vaults/deleted-vaults-section.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `deleted-vaults-section.test.tsx`:
+
+```tsx
+it('highlights the row matching ?highlight=<id>', () => {
+  // jsdom: set the query param the component reads
+  window.history.pushState({}, '', '/settings/vaults?highlight=5')
+  render(<DeletedVaultsSection />)
+  expect(screen.getByText('Old').closest('li')).toHaveAttribute('data-highlighted', 'true')
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun run test deleted-vaults-section`
+Expected: FAIL — no `data-highlighted` attribute.
+
+- [ ] **Step 3: Implement**
+
+In `deleted-vaults-section.tsx`, read the param and tag the row. At the top of `DeletedRow` add:
+
+```tsx
+  const highlightId = new URLSearchParams(window.location.search).get('highlight')
+  const highlighted = highlightId === String(vault.id)
+```
+
+Change the `<li>` opening tag to:
+
+```tsx
+    <li
+      data-highlighted={highlighted}
+      className={`flex items-center justify-between gap-3 py-3 ${highlighted ? 'rounded-md bg-accent/40 ring-1 ring-ring' : ''}`}
+    >
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun run test deleted-vaults-section`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/settings/vaults/deleted-vaults-section.tsx src/settings/vaults/deleted-vaults-section.test.tsx
+git commit -m "feat(frontend): highlight deep-linked vault row"
+```
+
+---
+
+### Task 13: Zero-vault empty state
+
+**Context:** Because deleting the last vault is allowed, the app can have zero active vaults. Audit how the dashboard/note browser consumes the active vault before wiring this in.
+
+**Files:**
+- Create: `frontend/src/layout/empty-vault-state.tsx`
+- Test: `frontend/src/layout/empty-vault-state.test.tsx`
+- Modify: the dashboard/note-browser entry that renders when there is no active vault (identify by reading `src/layout/vault-switcher.tsx`, `src/api/active-vault.ts`, and the `Dashboard` component referenced in `router.tsx`).
+
+- [ ] **Step 1: Read the consumers**
+
+Run: open `src/layout/vault-switcher.tsx`, `src/api/active-vault.ts`, and the `Dashboard` component. Identify where `useVaults()` returns an empty list / `useActiveVaultId()` is null and confirm nothing crashes. Note the render branch to guard.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `frontend/src/layout/empty-vault-state.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { EmptyVaultState } from './empty-vault-state'
+
+describe('EmptyVaultState', () => {
+  it('prompts the user to create a vault and links to settings', () => {
+    render(
+      <MemoryRouter>
+        <EmptyVaultState />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/no vaults/i)).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /create a vault/i })
+    expect(link).toHaveAttribute('href', '/settings/vaults')
+  })
+})
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `bun run test empty-vault-state`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 4: Implement the component**
+
+Create `frontend/src/layout/empty-vault-state.tsx`:
+
+```tsx
+import { Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+
+export function EmptyVaultState() {
+  return (
+    <section className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+      <h2 className="text-lg font-semibold text-foreground">No vaults</h2>
+      <p className="max-w-sm text-sm text-muted-foreground">
+        You don't have any vaults right now. Create one to start syncing and searching your notes.
+      </p>
+      <Button asChild>
+        <Link to="/settings/vaults">Create a vault</Link>
+      </Button>
+    </section>
+  )
+}
+```
+
+> If `Button` does not support `asChild`, render `<Link>` styled as a button (reuse the `buttonVariants` export if present) — keep the accessible name "Create a vault" and `href="/settings/vaults"`.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `bun run test empty-vault-state`
+Expected: PASS.
+
+- [ ] **Step 6: Wire it into the no-vault render branch**
+
+In the dashboard/note-browser component identified in Step 1, render `<EmptyVaultState />` when `useVaults()` resolves to an empty array (and there is no active vault) instead of the normal note browser. Keep the change minimal and guard against `undefined` while loading.
+
+- [ ] **Step 7: Typecheck + run the relevant tests**
+
+Run: `bun run build && bun run test empty-vault-state`
+Expected: no type errors; test passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/layout/empty-vault-state.tsx src/layout/empty-vault-state.test.tsx <modified dashboard file>
+git commit -m "feat(frontend): zero-vault empty state"
+```
+
+---
+
+### Task 14: Full suite + manual smoke
+
+- [ ] **Step 1: Run all backend tests**
+
+Run (repo root): `mix test`
+Expected: PASS.
+
+- [ ] **Step 2: Run all frontend tests + typecheck**
+
+Run (`frontend/`): `bun run test && bun run build`
+Expected: PASS, no type errors.
+
+- [ ] **Step 3: Manual smoke (dev server)**
+
+Start the app, sign in, go to `/settings/vaults`. Verify: create a vault; rename; set default; delete (type-to-confirm) → appears under Recently deleted with a purge date; restore; delete again then "Delete permanently". With a Free-cap user, confirm Restore is disabled when a replacement exists. Delete the last vault and confirm the empty state renders (no crash). Confirm the deletion email is logged locally (NoOp) or received (if `RESEND_API_KEY` set).
+
+- [ ] **Step 4: Commit any smoke fixes, then finish the branch**
+
+Use `superpowers:finishing-a-development-branch` to open the PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- List trash → Tasks 1, 5. Restore (+cap) → Tasks 2, 5. Purge-now → Tasks 3, 4, 5. Age-guard bug → Task 3. Email (+self-host no-op) → Task 6. Rename/set-default/create → Tasks 7, 8, 10 (reuse `update_vault`/`create_vault`). Two-section page → Tasks 8-10. Type-to-confirm → Task 8 (soft delete) + Task 9 (purge via confirm). Over-cap disable → Task 9. Deep-link highlight → Task 12. Zero-vault state → Task 13. All spec sections map to tasks.
+- Out-of-scope items (note counts, archive-forever, bulk, tokened one-click) are correctly absent.
+
+**Placeholder scan:** No TBD/TODO. Two soft spots are explicitly bounded with concrete fallback instructions: the billing-cap hook name (Task 9) and `Button asChild` support (Task 13) and the dashboard wiring point (Task 13 Step 1). These require reading one named file at execution time, not inventing behavior.
+
+**Type consistency:** Hook names (`useDeletedVaults`, `useDeleteVault`, `useRestoreVault`, `usePurgeVault`, `useUpdateVault`, `useCreateVault`) are consistent across Tasks 7-12. `purge_at`/`deleted_at` consistent backend (Task 5) ↔ type (Task 7) ↔ UI (Task 9). `perform_cleanup/3` with `force:` consistent across Tasks 3, 4, 6. Endpoint paths consistent: `POST /vaults/:id/restore`, `POST /vaults/:id/purge`, `GET /vaults?deleted=true`.

--- a/docs/superpowers/specs/2026-05-28-vault-management-design.md
+++ b/docs/superpowers/specs/2026-05-28-vault-management-design.md
@@ -1,0 +1,256 @@
+# Vault Management Settings Page — Design
+
+- **Date:** 2026-05-28
+- **Status:** Design (pending user review)
+- **Repo:** `engram-app/engram` (Phoenix backend + React frontend at `frontend/`)
+- **Branch:** `feat/vault-management-settings`
+
+## Summary
+
+Add a **Vaults** section to the web app settings page where a user can see all
+their vaults and manage them: rename, set default, create, and delete. Delete is
+a **soft delete with a 30-day grace window**, after which the vault is permanently
+purged. Soft-deleted vaults appear in a "Recently deleted" list with their purge
+date and a Restore action. On soft-delete the user is emailed a notice with a link
+back to the page, where they can optionally **purge immediately** instead of waiting
+out the grace window.
+
+The backend already implements the soft-delete + 30-day scheduled cleanup. This
+feature fills the gaps around it (list trash, restore, purge-now, email) and builds
+the entire frontend surface.
+
+## Context: what already exists
+
+- `Engram.Vaults.Vault` schema has a `deleted_at` column (soft delete) — no new
+  column needed. (`lib/engram/vaults/vault.ex`)
+- `Vaults.delete_vault/2` soft-sets `deleted_at`, clears `is_default`, promotes the
+  next oldest vault to default, and **enqueues `CleanupVault` scheduled 30 days out**.
+  (`lib/engram/vaults.ex:291`)
+- `Engram.Workers.CleanupVault` hard-deletes the vault's data (Qdrant points, DB rows,
+  storage blobs) and **self-skips if `deleted_at` is nil** (i.e. restored).
+  (`lib/engram/workers/cleanup_vault.ex`, `@retention_days 30`)
+- `Vaults.list_vaults/1` returns only non-deleted vaults (filters `is_nil(deleted_at)`).
+- `Vaults.update_vault/3` already supports rename / description / `is_default` — covers
+  rename + set-default with **no backend change**.
+- `Vaults.create_vault/2` exists with a billing cap check — covers create with no change.
+- Email subsystem (`Engram.Mailer`) funnels through a provider that defaults to
+  `Engram.Email.NoOp` (logs + returns `:ok`) and switches to Resend only when
+  `RESEND_API_KEY` is set. **Self-host email gating is therefore automatic** — calling
+  the mailer on a self-host install is a safe no-op; no new flag required.
+- Existing settings sections are registered in `frontend/src/settings/sections.ts` and
+  routed in `frontend/src/router.tsx`; section pages follow the
+  `SettingsSectionCard` pattern (see `account-page.tsx`).
+- A vault switcher already exists at `frontend/src/layout/vault-switcher.tsx`; active
+  vault state in `frontend/src/api/active-vault.ts`; vault queries in
+  `frontend/src/api/queries.ts`.
+
+## Decisions (from brainstorming)
+
+1. **Delete-only with a 30-day grace** (not a separate archive-forever state). Reuses
+   the existing `deleted_at` + `CleanupVault` machinery.
+2. **Page scope:** list vaults; delete (soft); restore from trash; rename/edit;
+   create / set default. All on one page.
+3. **Trash UX:** one page, two sections — *Active vaults* on top, *Recently deleted*
+   below (with purge date + Restore).
+4. **Guardrails:**
+   - **Block restore when over plan cap** — if restoring would exceed the user's vault
+     cap, refuse with a clear message (upgrade / delete another).
+   - **Type-to-confirm delete** — destructive actions require typing the vault name.
+   - **Last-vault delete is allowed** (NOT blocked) — so the zero-vault state must
+     degrade gracefully (see below).
+5. **Email on soft-delete** with an optional **purge-now** path. The email button is a
+   **navigational link to the authed settings page**, not a destructive link —
+   industry-standard pattern that avoids email-scanner prefetch nuking data. The actual
+   purge is a `POST` behind type-to-confirm in the app.
+6. **Self-host:** no special branching — the `NoOp` mail provider already suppresses
+   email when no provider is configured.
+
+## Backend design
+
+All endpoints live behind the existing `authenticated` pipeline alongside the other
+`/vaults` routes (`router.ex` ~155-161). Controller: `VaultsController`.
+
+### 1. List soft-deleted vaults
+
+- **Context:** `Vaults.list_deleted_vaults(user)` — mirror of `list_vaults/1` but
+  `where: not is_nil(v.deleted_at)`, decrypt names, order by `deleted_at` desc.
+- **Endpoint:** `GET /vaults?deleted=true` — `VaultsController.index` branches on the
+  `deleted` param. Default (no param) is unchanged (active vaults only).
+- **JSON:** deleted-vault payload includes `deleted_at` and a computed
+  `purge_at = deleted_at + 30 days` so the UI can show the purge date without
+  duplicating the retention constant.
+
+### 2. Restore
+
+- **Endpoint:** `POST /vaults/:id/restore` → `VaultsController.restore`.
+- **Context:** `Vaults.restore_vault(user, vault_id)`:
+  1. Fetch a **soft-deleted** vault owned by the user; otherwise `{:error, :not_found}`.
+  2. **Billing cap check:** count active vaults; if `active_count + 1` exceeds the
+     vault cap, return `{:error, :limit_exceeded}`.
+  3. Clear `deleted_at` (set nil). Leave `is_default = false` (the user re-sets default
+     explicitly; another vault was promoted on delete).
+  4. Emit vault-count telemetry (`:restored`).
+  - The pending `CleanupVault` job becomes a no-op once `deleted_at` is nil — no need to
+    cancel the Oban job.
+- **Controller mapping:** `:limit_exceeded → 403` with a JSON error message;
+  `:not_found → 404`; success `200` with the restored vault JSON.
+
+### 3. Purge now (immediate hard delete)
+
+- **Endpoint:** `POST /vaults/:id/purge` → `VaultsController.purge`.
+- **Context:** `Vaults.purge_vault(user, vault_id)`:
+  1. Fetch a **soft-deleted** vault owned by the user; otherwise `{:error, :not_found}`.
+     (Only already-soft-deleted vaults can be purged — you cannot skip the soft-delete
+     step.)
+  2. Run cleanup immediately by enqueuing `CleanupVault` with `scheduled_at: now`
+     (preferred over calling `perform_cleanup` inline, so the destructive work runs in
+     the `:cleanup` queue with retries, off the request path).
+- **Controller mapping:** `:not_found → 404`; success `200`.
+
+### 4. CleanupVault age guard (restore→re-delete bug fix)
+
+Today `CleanupVault.perform_cleanup` checks only `is_nil(deleted_at)`. A
+restore-then-re-delete cycle leaves an **earlier-scheduled** job that would fire at
+`delete₁ + 30d` and purge early. Fix the guard:
+
+```
+cond do
+  is_nil(vault.deleted_at)                                  -> :ok        # restored
+  DateTime.diff(now, vault.deleted_at, :second) < retention -> {:snooze, secs_until_due}
+  true                                                      -> run_cleanup(vault)
+end
+```
+
+`{:snooze, secs}` reschedules the same Oban job until the *current* `deleted_at` is
+genuinely ≥30 days old, making cleanup idempotent across restore/re-delete cycles.
+The explicit purge-now path bypasses this because it enqueues a fresh job whose intent
+is immediate; the snooze only protects the auto-scheduled path. (Implementation note:
+purge-now sets the same retention math to zero by scheduling `now` — verify the age
+guard does not snooze a deliberate purge. Simplest: purge enqueues with a flag/arg, e.g.
+`%{force: true}`, that skips the age check.)
+
+### 5. Deletion-notice email
+
+- **Template:** `Engram.Mailer.send_vault_deletion_notice(user, vault_name, purge_date, manage_url)`
+  — MJML body following the existing template pattern (see `send_inactivity_warning_*`).
+  Content: "Your vault *<name>* was deleted and will be permanently removed on
+  *<purge_date>*. Changed your mind? Restore it. Want it gone now? Delete it
+  permanently." with a single button linking to `manage_url`.
+- **`manage_url`:** `https://app.engram.page/settings/vaults?highlight=<vault_id>` (host
+  from existing app-URL config). Navigational only — no token, no destructive GET.
+- **Trigger:** enqueue a small Oban worker (`VaultDeletedEmail`, queue `:mailers` or the
+  existing mailer queue) from `delete_vault/2` after the soft-delete commits, so email
+  send latency/failure never affects the DELETE response. The worker resolves the user
+  email and calls the mailer; on self-host the `NoOp` provider drops it.
+
+## Frontend design (`frontend/src/`)
+
+### Nav + routing
+
+- Add a `vaults` entry to `settings/sections.ts` (always shown, like `api-keys`), with a
+  label "Vaults" and an icon.
+- Add `/settings/vaults` → `VaultsPage` in `router.tsx`.
+
+### `settings/vaults-page.tsx`
+
+`<article>` header ("Vaults" + description), then two `SettingsSectionCard`s:
+
+- **Active vaults**
+  - Row per active vault: name (inline-editable → `useUpdateVault`), a default badge or
+    a "Set default" action (`useUpdateVault` with `is_default: true`), and a **Delete**
+    button (opens type-to-confirm dialog).
+  - A **"New vault"** button → create dialog (name + optional description → `useCreateVault`).
+- **Recently deleted** (rendered only when non-empty)
+  - Row per soft-deleted vault: name, "Purges \<formatted purge_at\>", a **Restore**
+    button (disabled with tooltip when restoring would exceed the cap), and a **Delete
+    permanently** button (type-to-confirm → `usePurgeVault`).
+
+### Dialogs
+
+- **Delete (soft):** `AlertDialog` requiring the user to type the vault name to enable
+  the confirm button → `useDeleteVault`.
+- **Delete permanently (purge):** same type-to-confirm component, stronger copy
+  ("This cannot be undone") → `usePurgeVault`.
+- **Create:** small form `Dialog` (name + optional description).
+
+### Deep-link from email
+
+- `VaultsPage` reads `?highlight=<vaultId>` and scrolls to / briefly highlights the
+  matching row (likely in the Recently deleted section). Purely cosmetic; no action runs
+  automatically.
+
+### React Query hooks (`api/queries.ts`)
+
+| Hook | Call | Invalidates |
+|------|------|-------------|
+| `useDeletedVaults()` | `GET /vaults?deleted=true` | — (query key `['vaults','deleted']`) |
+| `useDeleteVault()` | `DELETE /vaults/:id` | `['vaults']`, `['vaults','deleted']` |
+| `useRestoreVault()` | `POST /vaults/:id/restore` | `['vaults']`, `['vaults','deleted']`; toast on 403 `limit_exceeded` |
+| `usePurgeVault()` | `POST /vaults/:id/purge` | `['vaults','deleted']` |
+| `useUpdateVault()` | `PATCH /vaults/:id` | `['vaults']` |
+| `useCreateVault()` | `POST /vaults` | `['vaults']` |
+
+`Vault` type gains optional `deleted_at?: string | null` and `purge_at?: string` (present
+only in the deleted listing).
+
+### Zero-vault state (last-vault delete is allowed)
+
+Because deleting the only vault is permitted, the app can reach an active-vault-count of
+zero. Audit `vault-switcher.tsx` + the main layout / note browser and the
+`active-vault.ts` store so that:
+
+- a null active vault does not crash any view, and
+- the note browser / switcher shows a clear empty state ("No vaults — create one") with a
+  CTA to the create-vault dialog (or `/settings/vaults`).
+
+This is the main new non-obvious risk introduced by not blocking last-vault delete.
+
+## API contract additions
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `GET` | `/vaults?deleted=true` | authenticated | List soft-deleted vaults (+`purge_at`) |
+| `POST` | `/vaults/:id/restore` | authenticated | Clear `deleted_at` (cap-checked) |
+| `POST` | `/vaults/:id/purge` | authenticated | Immediate hard delete of a soft-deleted vault |
+
+(Existing: `GET/POST /vaults`, `GET/PATCH/DELETE /vaults/:id`, `POST /vaults/register`.)
+
+## Testing (TDD — tests written first)
+
+### Backend (ExUnit)
+
+- `list_deleted_vaults/1` returns only soft-deleted vaults, decrypted, with `purge_at`.
+- `restore_vault/2`: clears `deleted_at`; returns `:limit_exceeded` when over cap;
+  `:not_found` for an active vault, a missing vault, or another user's vault.
+- `purge_vault/2`: enqueues immediate cleanup for a soft-deleted vault; `:not_found`
+  otherwise.
+- `CleanupVault`: **snoozes** when `deleted_at` is <30d old (restore→re-delete cycle does
+  not purge early); **purges** when ≥30d; **skips** when restored (`deleted_at` nil);
+  **force-purges** immediately when invoked via the purge path.
+- Controller: `GET /vaults?deleted=true` (shape + `purge_at`); `POST /restore`
+  (200 / 403 over cap / 404); `POST /purge` (200 / 404).
+- Mailer: `send_vault_deletion_notice` renders and routes through the provider;
+  no-ops under `NoOp`; suppressed addresses skipped.
+
+### Frontend (match existing test conventions)
+
+- `VaultsPage` renders Active + Recently deleted sections from query data.
+- Delete confirm button is disabled until the vault name is typed correctly.
+- Restore button is disabled (with tooltip) when over cap; enabled otherwise.
+- Hooks invalidate the correct query keys on success.
+- `?highlight=<id>` scrolls to / highlights the row.
+
+## Out of scope (YAGNI)
+
+- Per-vault note counts (backend does not return them yet).
+- Archive-forever state (explicitly rejected in favor of delete-with-grace).
+- Bulk select / bulk delete.
+- Tokened one-click purge from email (rejected for the safer link-to-app pattern).
+- Configurable retention window (fixed at 30 days, the existing constant).
+
+## Risks / notes
+
+- **Zero-vault state** is the primary new risk — must be handled in the layout audit.
+- **Force-purge vs age-guard interaction** — ensure the deliberate purge path is not
+  snoozed by the age guard (use an explicit `force` arg).
+- Email host/URL must come from the existing app-URL config, not be hardcoded.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -51,6 +51,14 @@ export const api = {
     return res.json()
   },
 
+  async patch<T>(path: string, body?: unknown): Promise<T> {
+    const res = await authFetch(path, {
+      method: 'PATCH',
+      body: body ? JSON.stringify(body) : undefined,
+    })
+    return res.json()
+  },
+
   async del<T>(path: string): Promise<T> {
     const res = await authFetch(path, { method: 'DELETE' })
     return res.json()

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -306,6 +306,8 @@ export interface Vault {
   decrypt_requested_at: string | null
   last_toggle_at: string | null
   cooldown_days: number | null
+  deleted_at?: string | null
+  purge_at?: string | null
 }
 
 export interface EncryptionProgress {
@@ -342,5 +344,55 @@ export function useEncryptionProgress(vaultId: number | undefined, enabled: bool
     queryFn: () => api.get<EncryptionProgress>(`/vaults/${vaultId}/encryption_progress`),
     enabled: enabled && vaultId !== undefined,
     refetchInterval: enabled ? 3000 : false,
+  })
+}
+
+export function useDeletedVaults() {
+  return useQuery({
+    queryKey: ['vaults', 'deleted'],
+    queryFn: () => api.get<{ vaults: Vault[] }>('/vaults?deleted=true'),
+    select: (data) => data.vaults,
+  })
+}
+
+export function useDeleteVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => api.del<{ deleted: boolean }>(`/vaults/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+
+export function useRestoreVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => api.post<{ vault: Vault }>(`/vaults/${id}/restore`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+
+export function usePurgeVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => api.post<{ purged: boolean }>(`/vaults/${id}/purge`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+
+export function useUpdateVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, ...attrs }: { id: number; name?: string; description?: string; is_default?: boolean }) =>
+      api.patch<{ vault: Vault }>(`/vaults/${id}`, attrs),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
+  })
+}
+
+export function useCreateVault() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (attrs: { name: string; description?: string }) =>
+      api.post<{ vault: Vault }>('/vaults', attrs),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['vaults'] }),
   })
 }

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -153,6 +153,8 @@ export interface BillingConfig {
   custom_data: {
     user_id: number
   }
+  // Maximum number of active vaults the user may have, or null for unlimited.
+  vaults_cap: number | null
 }
 
 export function useBillingConfig() {

--- a/frontend/src/layout/empty-vault-state.test.tsx
+++ b/frontend/src/layout/empty-vault-state.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router'
+import { EmptyVaultState } from './empty-vault-state'
+
+describe('EmptyVaultState', () => {
+  it('prompts the user to create a vault and links to settings', () => {
+    render(
+      <MemoryRouter>
+        <EmptyVaultState />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/no vaults/i)).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /create a vault/i })
+    expect(link).toHaveAttribute('href', '/settings/vaults')
+  })
+})

--- a/frontend/src/layout/empty-vault-state.tsx
+++ b/frontend/src/layout/empty-vault-state.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router'
+import { Button } from '@/components/ui/button'
+
+export function EmptyVaultState() {
+  return (
+    <section className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+      <h2 className="text-lg font-semibold text-foreground">No vaults</h2>
+      <p className="max-w-sm text-sm text-muted-foreground">
+        You don't have any vaults right now. Create one to start syncing and searching your notes.
+      </p>
+      <Button asChild>
+        <Link to="/settings/vaults">Create a vault</Link>
+      </Button>
+    </section>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import AppLayout from './layout/app-layout'
 import NotFoundPage from './not-found'
 import ApiKeysPage from './settings/api-keys-page'
 import SettingsLayout from './settings/settings-layout'
+import VaultsPage from './settings/vaults-page'
 import OAuthAuthorizePage from './oauth/oauth-authorize-page'
 import { ROUTES } from './routes'
 import Dashboard from './viewer/dashboard'
@@ -86,6 +87,7 @@ export const router = createBrowserRouter(
                       },
                     ]
                   : []),
+                { path: 'vaults', element: <VaultsPage /> },
                 { path: 'api-keys', element: <ApiKeysPage /> },
                 ...(config.billingEnabled
                   ? [{ path: 'billing', element: <BillingPage /> }]

--- a/frontend/src/settings/sections.test.ts
+++ b/frontend/src/settings/sections.test.ts
@@ -4,23 +4,33 @@ import { buildSettingsSections } from './sections'
 describe('buildSettingsSections', () => {
   it('prepends Account for clerk auth', () => {
     const sections = buildSettingsSections('clerk', true)
-    expect(sections.map((s) => s.to)).toEqual(['account', 'api-keys', 'billing'])
+    expect(sections.map((s) => s.to)).toEqual(['account', 'vaults', 'api-keys', 'billing'])
   })
 
   it('omits Account for local auth', () => {
     const sections = buildSettingsSections('local', true)
-    expect(sections.map((s) => s.to)).toEqual(['api-keys', 'billing'])
+    expect(sections.map((s) => s.to)).toEqual(['vaults', 'api-keys', 'billing'])
     expect(sections.some((s) => s.to === 'account')).toBe(false)
   })
 
   it('omits Billing when billing is disabled (self-host)', () => {
     const sections = buildSettingsSections('local', false)
-    expect(sections.map((s) => s.to)).toEqual(['api-keys'])
+    expect(sections.map((s) => s.to)).toEqual(['vaults', 'api-keys'])
     expect(sections.some((s) => s.to === 'billing')).toBe(false)
   })
 
   it('keeps Account but drops Billing for clerk auth with billing disabled', () => {
     const sections = buildSettingsSections('clerk', false)
-    expect(sections.map((s) => s.to)).toEqual(['account', 'api-keys'])
+    expect(sections.map((s) => s.to)).toEqual(['account', 'vaults', 'api-keys'])
+  })
+
+  it('includes the Vaults section for clerk + billing', () => {
+    const labels = buildSettingsSections('clerk', true).map((s) => s.label)
+    expect(labels).toContain('Vaults')
+  })
+
+  it('includes the Vaults section for self-host', () => {
+    const labels = buildSettingsSections('local', false).map((s) => s.label)
+    expect(labels).toContain('Vaults')
   })
 })

--- a/frontend/src/settings/sections.ts
+++ b/frontend/src/settings/sections.ts
@@ -9,7 +9,10 @@ export function buildSettingsSections(
   authProvider: EngramConfig['authProvider'],
   billingEnabled: boolean,
 ): SettingsSection[] {
-  const sections: SettingsSection[] = [{ to: 'api-keys', label: 'API Keys' }]
+  const sections: SettingsSection[] = [
+    { to: 'vaults', label: 'Vaults' },
+    { to: 'api-keys', label: 'API Keys' },
+  ]
   if (billingEnabled) {
     sections.push({ to: 'billing', label: 'Billing' })
   }

--- a/frontend/src/settings/vaults-page.test.tsx
+++ b/frontend/src/settings/vaults-page.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const createMutate = vi.fn()
+vi.mock('./vaults/active-vaults-section', () => ({ ActiveVaultsSection: () => <div>active-section</div> }))
+vi.mock('./vaults/deleted-vaults-section', () => ({ DeletedVaultsSection: () => <div>deleted-section</div> }))
+vi.mock('@/api/queries', () => ({ useCreateVault: () => ({ mutate: createMutate, isPending: false }) }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import VaultsPage from './vaults-page'
+
+describe('VaultsPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders both sections and a header', () => {
+    render(<VaultsPage />)
+    expect(screen.getByRole('heading', { name: /vaults/i })).toBeInTheDocument()
+    expect(screen.getByText('active-section')).toBeInTheDocument()
+    expect(screen.getByText('deleted-section')).toBeInTheDocument()
+  })
+
+  it('creates a new vault', async () => {
+    render(<VaultsPage />)
+    fireEvent.click(screen.getByRole('button', { name: /new vault/i }))
+    fireEvent.change(screen.getByLabelText(/vault name/i), { target: { value: 'Research' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => expect(createMutate).toHaveBeenCalledWith({ name: 'Research' }, expect.anything()))
+  })
+})

--- a/frontend/src/settings/vaults-page.tsx
+++ b/frontend/src/settings/vaults-page.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { useCreateVault } from '@/api/queries'
+import { ActiveVaultsSection } from './vaults/active-vaults-section'
+import { DeletedVaultsSection } from './vaults/deleted-vaults-section'
+
+const inputClass =
+  'mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
+
+export default function VaultsPage() {
+  const create = useCreateVault()
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault()
+    const next = name.trim()
+    if (!next) return
+    create.mutate(
+      { name: next },
+      {
+        onSuccess: () => {
+          toast.success('Vault created')
+          setName('')
+          setOpen(false)
+        },
+        onError: () => toast.error('Could not create vault (limit reached?)'),
+      },
+    )
+  }
+
+  return (
+    <article className="space-y-6">
+      <header className="flex items-start justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Vaults</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Manage, create, and recover your vaults.</p>
+        </div>
+        <Button onClick={() => setOpen((o) => !o)}>New vault</Button>
+      </header>
+
+      {open && (
+        <form className="rounded-lg border border-border bg-card p-4" onSubmit={submit}>
+          <label className="block text-sm font-medium text-foreground">
+            Vault name
+            <input className={inputClass} aria-label="Vault name" value={name} onChange={(e) => setName(e.target.value)} />
+          </label>
+          <div className="mt-3 flex gap-2">
+            <Button type="submit" size="sm" disabled={create.isPending}>
+              Create
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
+
+      <ActiveVaultsSection />
+      <DeletedVaultsSection />
+    </article>
+  )
+}

--- a/frontend/src/settings/vaults/active-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const deleteMutate = vi.fn()
+const updateMutate = vi.fn()
+const vaults = [
+  { id: 1, name: 'Work', description: null, slug: 'work', is_default: true, created_at: '', encrypted: true },
+  { id: 2, name: 'Personal', description: null, slug: 'personal', is_default: false, created_at: '', encrypted: true },
+]
+
+vi.mock('@/api/queries', () => ({
+  useVaults: () => ({ data: vaults, isLoading: false }),
+  useDeleteVault: () => ({ mutate: deleteMutate, isPending: false }),
+  useUpdateVault: () => ({ mutate: updateMutate, isPending: false }),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { ActiveVaultsSection } from './active-vaults-section'
+
+describe('ActiveVaultsSection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('lists vaults and marks the default', () => {
+    render(<ActiveVaultsSection />)
+    expect(screen.getByText('Work')).toBeInTheDocument()
+    expect(screen.getByText('Personal')).toBeInTheDocument()
+    expect(screen.getByText('Default')).toBeInTheDocument()
+  })
+
+  it('keeps delete disabled until the vault name is typed', async () => {
+    render(<ActiveVaultsSection />)
+    const workRow = within(screen.getByText('Work').closest('li') as HTMLElement)
+    fireEvent.click(workRow.getByRole('button', { name: /^delete$/i }))
+    const confirmBtn = screen.getByRole('button', { name: /delete vault/i })
+    expect(confirmBtn).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/type .*work.* to confirm/i), { target: { value: 'Work' } })
+    expect(confirmBtn).toBeEnabled()
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith(1, expect.anything()))
+  })
+
+  it('sets a non-default vault as default', () => {
+    render(<ActiveVaultsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /set default/i }))
+    expect(updateMutate).toHaveBeenCalledWith({ id: 2, is_default: true }, expect.anything())
+  })
+})

--- a/frontend/src/settings/vaults/active-vaults-section.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { SettingsSectionCard } from '@/settings/account/section-card'
+import { useVaults, useDeleteVault, useUpdateVault, type Vault } from '@/api/queries'
+
+const inputClass =
+  'mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
+
+export function ActiveVaultsSection() {
+  const { data: vaults, isLoading } = useVaults()
+
+  return (
+    <SettingsSectionCard title="Vaults" description="Rename, set a default, or delete your vaults.">
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      <ul className="divide-y divide-border">
+        {(vaults ?? []).map((v) => (
+          <VaultRow key={v.id} vault={v} />
+        ))}
+      </ul>
+    </SettingsSectionCard>
+  )
+}
+
+function VaultRow({ vault }: { vault: Vault }) {
+  const update = useUpdateVault()
+  const del = useDeleteVault()
+  const [renaming, setRenaming] = useState(false)
+  const [name, setName] = useState(vault.name)
+  const [confirming, setConfirming] = useState(false)
+  const [phrase, setPhrase] = useState('')
+
+  function saveName() {
+    const next = name.trim()
+    if (next && next !== vault.name) {
+      update.mutate({ id: vault.id, name: next }, { onError: () => toast.error('Rename failed') })
+    }
+    setRenaming(false)
+  }
+
+  return (
+    <li className="py-3">
+      <div className="flex items-center justify-between gap-3">
+        {renaming ? (
+          <input
+            autoFocus
+            className={inputClass}
+            value={name}
+            aria-label={`Rename ${vault.name}`}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={saveName}
+            onKeyDown={(e) => e.key === 'Enter' && saveName()}
+          />
+        ) : (
+          <button type="button" className="text-sm font-medium text-foreground" onClick={() => setRenaming(true)}>
+            {vault.name}
+          </button>
+        )}
+        <div className="flex items-center gap-2">
+          {vault.is_default ? (
+            <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">Default</span>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                update.mutate({ id: vault.id, is_default: true }, { onError: () => toast.error('Could not set default') })
+              }
+            >
+              Set default
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" onClick={() => setConfirming((c) => !c)}>
+            Delete
+          </Button>
+        </div>
+      </div>
+      {confirming && (
+        <form
+          className="mt-3 rounded-md border border-destructive/40 bg-destructive/5 p-3"
+          onSubmit={(e) => {
+            e.preventDefault()
+            del.mutate(vault.id, {
+              onSuccess: () => toast.success('Vault deleted'),
+              onError: () => toast.error('Delete failed'),
+            })
+          }}
+        >
+          <label className="block text-sm text-foreground">
+            Type "{vault.name}" to confirm
+            <input
+              className={inputClass}
+              aria-label={`Type ${vault.name} to confirm`}
+              value={phrase}
+              onChange={(e) => setPhrase(e.target.value)}
+            />
+          </label>
+          <Button className="mt-3" type="submit" variant="destructive" size="sm" disabled={phrase !== vault.name}>
+            Delete vault
+          </Button>
+        </form>
+      )}
+    </li>
+  )
+}

--- a/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
@@ -34,6 +34,8 @@ describe('DeletedVaultsSection', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     activeCount = 1
+    // Reset the URL so ?highlight from one test doesn't leak into others.
+    window.history.pushState({}, '', '/settings/vaults')
   })
 
   it('shows the purge date', () => {
@@ -69,5 +71,12 @@ describe('DeletedVaultsSection', () => {
     render(<DeletedVaultsSection />)
     fireEvent.click(screen.getByRole('button', { name: /delete permanently/i }))
     expect(purgeMutate).not.toHaveBeenCalled()
+  })
+
+  it('highlights the row matching ?highlight=<id>', () => {
+    // jsdom: set the query param the component reads
+    window.history.pushState({}, '', '/settings/vaults?highlight=5')
+    render(<DeletedVaultsSection />)
+    expect(screen.getByText('Old').closest('li')).toHaveAttribute('data-highlighted', 'true')
   })
 })

--- a/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router'
 
 const restoreMutate = vi.fn()
 const purgeMutate = vi.fn()
@@ -30,29 +32,31 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { DeletedVaultsSection } from './deleted-vaults-section'
 
+function renderWithRouter(ui: ReactElement, { route = '/settings/vaults' } = {}) {
+  return render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>)
+}
+
 describe('DeletedVaultsSection', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     activeCount = 1
-    // Reset the URL so ?highlight from one test doesn't leak into others.
-    window.history.pushState({}, '', '/settings/vaults')
   })
 
   it('shows the purge date', () => {
-    render(<DeletedVaultsSection />)
+    renderWithRouter(<DeletedVaultsSection />)
     expect(screen.getByText('Old')).toBeInTheDocument()
     expect(screen.getByText(/purges/i)).toBeInTheDocument()
   })
 
   it('disables restore when at the cap', () => {
     activeCount = 1 // cap is 1, so restoring would exceed
-    render(<DeletedVaultsSection />)
+    renderWithRouter(<DeletedVaultsSection />)
     expect(screen.getByRole('button', { name: /restore/i })).toBeDisabled()
   })
 
   it('restores when under cap', async () => {
     activeCount = 0
-    render(<DeletedVaultsSection />)
+    renderWithRouter(<DeletedVaultsSection />)
     const btn = screen.getByRole('button', { name: /restore/i })
     expect(btn).toBeEnabled()
     fireEvent.click(btn)
@@ -61,22 +65,20 @@ describe('DeletedVaultsSection', () => {
 
   it('purges permanently when confirmed', async () => {
     window.confirm = vi.fn().mockReturnValue(true)
-    render(<DeletedVaultsSection />)
+    renderWithRouter(<DeletedVaultsSection />)
     fireEvent.click(screen.getByRole('button', { name: /delete permanently/i }))
     await waitFor(() => expect(purgeMutate).toHaveBeenCalledWith(5, expect.anything()))
   })
 
   it('does not purge when confirmation is dismissed', () => {
     window.confirm = vi.fn().mockReturnValue(false)
-    render(<DeletedVaultsSection />)
+    renderWithRouter(<DeletedVaultsSection />)
     fireEvent.click(screen.getByRole('button', { name: /delete permanently/i }))
     expect(purgeMutate).not.toHaveBeenCalled()
   })
 
   it('highlights the row matching ?highlight=<id>', () => {
-    // jsdom: set the query param the component reads
-    window.history.pushState({}, '', '/settings/vaults?highlight=5')
-    render(<DeletedVaultsSection />)
+    renderWithRouter(<DeletedVaultsSection />, { route: '/settings/vaults?highlight=5' })
     expect(screen.getByText('Old').closest('li')).toHaveAttribute('data-highlighted', 'true')
   })
 })

--- a/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const restoreMutate = vi.fn()
+const purgeMutate = vi.fn()
+const deleted = [
+  {
+    id: 5,
+    name: 'Old',
+    description: null,
+    slug: 'old',
+    is_default: false,
+    created_at: '',
+    encrypted: true,
+    deleted_at: '2026-05-28T00:00:00Z',
+    purge_at: '2026-06-27T00:00:00Z',
+  },
+]
+let activeCount = 1
+const cap = 1
+
+vi.mock('@/api/queries', () => ({
+  useDeletedVaults: () => ({ data: deleted, isLoading: false }),
+  useVaults: () => ({ data: new Array(activeCount).fill({ id: 99 }) }),
+  useRestoreVault: () => ({ mutate: restoreMutate, isPending: false }),
+  usePurgeVault: () => ({ mutate: purgeMutate, isPending: false }),
+  useBillingConfig: () => ({ data: { vaults_cap: cap } }),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { DeletedVaultsSection } from './deleted-vaults-section'
+
+describe('DeletedVaultsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    activeCount = 1
+  })
+
+  it('shows the purge date', () => {
+    render(<DeletedVaultsSection />)
+    expect(screen.getByText('Old')).toBeInTheDocument()
+    expect(screen.getByText(/purges/i)).toBeInTheDocument()
+  })
+
+  it('disables restore when at the cap', () => {
+    activeCount = 1 // cap is 1, so restoring would exceed
+    render(<DeletedVaultsSection />)
+    expect(screen.getByRole('button', { name: /restore/i })).toBeDisabled()
+  })
+
+  it('restores when under cap', async () => {
+    activeCount = 0
+    render(<DeletedVaultsSection />)
+    const btn = screen.getByRole('button', { name: /restore/i })
+    expect(btn).toBeEnabled()
+    fireEvent.click(btn)
+    await waitFor(() => expect(restoreMutate).toHaveBeenCalledWith(5, expect.anything()))
+  })
+})

--- a/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
@@ -56,4 +56,18 @@ describe('DeletedVaultsSection', () => {
     fireEvent.click(btn)
     await waitFor(() => expect(restoreMutate).toHaveBeenCalledWith(5, expect.anything()))
   })
+
+  it('purges permanently when confirmed', async () => {
+    window.confirm = vi.fn().mockReturnValue(true)
+    render(<DeletedVaultsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /delete permanently/i }))
+    await waitFor(() => expect(purgeMutate).toHaveBeenCalledWith(5, expect.anything()))
+  })
+
+  it('does not purge when confirmation is dismissed', () => {
+    window.confirm = vi.fn().mockReturnValue(false)
+    render(<DeletedVaultsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /delete permanently/i }))
+    expect(purgeMutate).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/settings/vaults/deleted-vaults-section.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.tsx
@@ -1,4 +1,5 @@
 import { toast } from 'sonner'
+import { useSearchParams } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { SettingsSectionCard } from '@/settings/account/section-card'
 import {
@@ -39,12 +40,13 @@ function DeletedRow({ vault }: { vault: Vault }) {
   const overCap = activeCount >= cap
   const purgeDate = vault.purge_at ? new Date(vault.purge_at).toLocaleDateString() : null
 
-  const highlightId = new URLSearchParams(window.location.search).get('highlight')
+  const [searchParams] = useSearchParams()
+  const highlightId = searchParams.get('highlight')
   const highlighted = highlightId === String(vault.id)
 
   return (
     <li
-      data-highlighted={highlighted}
+      data-highlighted={highlighted || undefined}
       className={`flex items-center justify-between gap-3 py-3 ${
         highlighted ? 'rounded-md bg-accent/40 ring-1 ring-ring' : ''
       }`}

--- a/frontend/src/settings/vaults/deleted-vaults-section.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.tsx
@@ -39,8 +39,16 @@ function DeletedRow({ vault }: { vault: Vault }) {
   const overCap = activeCount >= cap
   const purgeDate = vault.purge_at ? new Date(vault.purge_at).toLocaleDateString() : null
 
+  const highlightId = new URLSearchParams(window.location.search).get('highlight')
+  const highlighted = highlightId === String(vault.id)
+
   return (
-    <li className="flex items-center justify-between gap-3 py-3">
+    <li
+      data-highlighted={highlighted}
+      className={`flex items-center justify-between gap-3 py-3 ${
+        highlighted ? 'rounded-md bg-accent/40 ring-1 ring-ring' : ''
+      }`}
+    >
       <div>
         <p className="text-sm font-medium text-foreground">{vault.name}</p>
         {purgeDate && <p className="text-xs text-muted-foreground">Purges {purgeDate}</p>}

--- a/frontend/src/settings/vaults/deleted-vaults-section.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.tsx
@@ -1,0 +1,85 @@
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { SettingsSectionCard } from '@/settings/account/section-card'
+import {
+  useDeletedVaults,
+  useVaults,
+  useRestoreVault,
+  usePurgeVault,
+  useBillingConfig,
+  type Vault,
+} from '@/api/queries'
+
+export function DeletedVaultsSection() {
+  const { data: deleted } = useDeletedVaults()
+  if (!deleted || deleted.length === 0) return null
+
+  return (
+    <SettingsSectionCard
+      title="Recently deleted"
+      description="Deleted vaults are kept for 30 days. Restore them, or remove them permanently."
+    >
+      <ul className="divide-y divide-border">
+        {deleted.map((v) => (
+          <DeletedRow key={v.id} vault={v} />
+        ))}
+      </ul>
+    </SettingsSectionCard>
+  )
+}
+
+function DeletedRow({ vault }: { vault: Vault }) {
+  const { data: active } = useVaults()
+  const { data: billing } = useBillingConfig()
+  const restore = useRestoreVault()
+  const purge = usePurgeVault()
+
+  const cap = billing?.vaults_cap ?? Infinity
+  const activeCount = active?.length ?? 0
+  const overCap = activeCount >= cap
+  const purgeDate = vault.purge_at ? new Date(vault.purge_at).toLocaleDateString() : null
+
+  return (
+    <li className="flex items-center justify-between gap-3 py-3">
+      <div>
+        <p className="text-sm font-medium text-foreground">{vault.name}</p>
+        {purgeDate && <p className="text-xs text-muted-foreground">Purges {purgeDate}</p>}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={overCap || restore.isPending}
+          title={
+            overCap
+              ? 'Restoring would exceed your vault limit. Upgrade or delete another vault first.'
+              : undefined
+          }
+          onClick={() =>
+            restore.mutate(vault.id, {
+              onSuccess: () => toast.success('Vault restored'),
+              onError: () => toast.error('Could not restore (vault limit reached?)'),
+            })
+          }
+        >
+          Restore
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          disabled={purge.isPending}
+          onClick={() => {
+            if (window.confirm(`Permanently delete "${vault.name}"? This cannot be undone.`)) {
+              purge.mutate(vault.id, {
+                onSuccess: () => toast.success('Vault permanently deleted'),
+                onError: () => toast.error('Could not delete'),
+              })
+            }
+          }}
+        >
+          Delete permanently
+        </Button>
+      </div>
+    </li>
+  )
+}

--- a/frontend/src/viewer/dashboard.tsx
+++ b/frontend/src/viewer/dashboard.tsx
@@ -1,5 +1,6 @@
 import { Link, useSearchParams } from 'react-router'
-import { useFolderNotes, type NoteSummary } from '../api/queries'
+import { useFolderNotes, useVaults, type NoteSummary } from '../api/queries'
+import { EmptyVaultState } from '../layout/empty-vault-state'
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, {
@@ -67,6 +68,15 @@ function FolderNotes({ folder }: { folder: string }) {
 export default function Dashboard() {
   const [searchParams] = useSearchParams()
   const folder = searchParams.get('folder') ?? ''
+  const { data: vaults } = useVaults()
+
+  // Deleting the last vault leaves zero active vaults. Show a create-a-vault
+  // prompt instead of the (empty) note browser. Guard against the loading
+  // state (vaults === undefined) so the empty state doesn't flash while the
+  // vault list is still in flight.
+  if (vaults && vaults.length === 0) {
+    return <EmptyVaultState />
+  }
 
   if (folder) {
     return (

--- a/lib/engram/mailer.ex
+++ b/lib/engram/mailer.ex
@@ -11,6 +11,7 @@ defmodule Engram.Mailer do
   - `send_inactivity_warning_60/1`
   - `send_inactivity_warning_80/1`
   - `send_account_deleted_notice/1`
+  - `send_vault_deletion_notice/4`
   """
 
   alias Engram.Accounts.User
@@ -160,6 +161,28 @@ defmodule Engram.Mailer do
       """,
       []
     )
+  end
+
+  @doc """
+  Notifies a user that a vault was soft-deleted and will be purged on
+  `purge_date` (a preformatted string). `manage_url` deep-links to the vault
+  settings page where they can restore or purge immediately.
+  """
+  def send_vault_deletion_notice(%User{email: email}, vault_name, purge_date, manage_url) do
+    vault_name = Template.esc(vault_name)
+    purge_date = Template.esc(purge_date)
+
+    body = """
+    <mj-text>Your Engram vault "#{vault_name}" has been deleted.</mj-text>
+    <mj-text>It will be permanently removed on #{purge_date}. Until then you can
+    restore it — or, if you meant to delete it, remove it permanently now — from
+    your vault settings.</mj-text>
+    <mj-button href="#{manage_url}" background-color="#5b5bd6">Manage vault</mj-button>
+    <mj-text>No action is needed if you want it gone; it will be cleaned up
+    automatically.</mj-text>
+    """
+
+    render_and_deliver(email, "Your Engram vault was deleted", body)
   end
 
   # Render an MJML body to HTML, then deliver. A render failure becomes a

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -341,6 +341,50 @@ defmodule Engram.Vaults do
     |> unwrap_transaction()
   end
 
+  # ── Restore (soft-delete reversal) ──────────────────────────────────────────
+
+  @doc """
+  Restores a soft-deleted vault by clearing deleted_at.
+
+  Refuses (`{:error, :limit_reached}`) if restoring would exceed the user's
+  vault cap. The vault is restored as non-default; the user re-sets default
+  explicitly. The pending CleanupVault job becomes a no-op once deleted_at is nil.
+
+  Returns {:ok, vault}, {:error, :limit_reached}, or {:error, :not_found}.
+  """
+  def restore_vault(user, vault_id) do
+    user = fresh_user(user)
+
+    Repo.with_tenant(user.id, fn ->
+      case fetch_deleted(user.id, vault_id) do
+        nil ->
+          {:error, :not_found}
+
+        vault ->
+          active_count = count_vaults(user.id)
+
+          case Billing.check_limit(user, :vaults_cap, active_count) do
+            {:error, :limit_reached} ->
+              {:error, :limit_reached}
+
+            :ok ->
+              vault
+              |> Vault.changeset(%{deleted_at: nil})
+              |> Repo.update()
+              |> case do
+                {:ok, v} ->
+                  emit_vault_count(user.id, :restored)
+                  {:ok, decrypt_vault_if_needed(v, user)}
+
+                other ->
+                  other
+              end
+          end
+      end
+    end)
+    |> unwrap_transaction()
+  end
+
   # ── API key access check ────────────────────────────────────────────────
 
   @doc """

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -330,6 +330,7 @@ defmodule Engram.Vaults do
           case result do
             {:ok, deleted} ->
               _ = Engram.Workers.CleanupVault.enqueue(deleted.id, deleted.user_id)
+              _ = Engram.Workers.VaultDeletedEmail.enqueue(deleted.user_id, deleted.id)
               emit_vault_count(deleted.user_id, :deleted)
               result
 

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -156,6 +156,24 @@ defmodule Engram.Vaults do
   end
 
   @doc """
+  Returns all soft-deleted vaults for a user, newest-deleted first.
+  """
+  def list_deleted_vaults(user) do
+    user = fresh_user(user)
+
+    {:ok, vaults} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(
+          from v in Vault,
+            where: v.user_id == ^user.id and not is_nil(v.deleted_at),
+            order_by: [desc: v.deleted_at, desc: v.id]
+        )
+      end)
+
+    Enum.map(vaults, &decrypt_vault_if_needed(&1, user))
+  end
+
+  @doc """
   Loads vaults owned by `user` whose IDs appear in `vault_ids`.
 
   `vault_ids` is a list of strings (as they arrive from Qdrant payload JSON).
@@ -389,6 +407,13 @@ defmodule Engram.Vaults do
     Repo.one(
       from v in Vault,
         where: v.user_id == ^user_id and v.id == ^vault_id and is_nil(v.deleted_at)
+    )
+  end
+
+  defp fetch_deleted(user_id, vault_id) do
+    Repo.one(
+      from v in Vault,
+        where: v.user_id == ^user_id and v.id == ^vault_id and not is_nil(v.deleted_at)
     )
   end
 

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -385,6 +385,28 @@ defmodule Engram.Vaults do
     |> unwrap_transaction()
   end
 
+  @doc """
+  Immediately hard-deletes a soft-deleted vault by enqueuing a force CleanupVault
+  job. Only soft-deleted vaults can be purged.
+
+  Returns {:ok, vault} or {:error, :not_found}.
+  """
+  def purge_vault(user, vault_id) do
+    user = fresh_user(user)
+
+    Repo.with_tenant(user.id, fn ->
+      case fetch_deleted(user.id, vault_id) do
+        nil ->
+          {:error, :not_found}
+
+        vault ->
+          {:ok, _job} = Engram.Workers.CleanupVault.enqueue_now(vault.id, vault.user_id)
+          {:ok, vault}
+      end
+    end)
+    |> unwrap_transaction()
+  end
+
   # ── API key access check ────────────────────────────────────────────────
 
   @doc """

--- a/lib/engram/workers/cleanup_vault.ex
+++ b/lib/engram/workers/cleanup_vault.ex
@@ -25,6 +25,7 @@ defmodule Engram.Workers.CleanupVault do
   require Logger
 
   @retention_days 30
+  @retention_secs @retention_days * 86_400
 
   @doc """
   Enqueues a CleanupVault job scheduled 30 days from now.
@@ -35,14 +36,26 @@ defmodule Engram.Workers.CleanupVault do
     |> Oban.insert()
   end
 
+  @doc """
+  Enqueues an immediate (unscheduled) force-purge. Used by the "delete
+  permanently now" path — bypasses the retention age guard.
+  """
+  def enqueue_now(vault_id, user_id) do
+    %{vault_id: vault_id, user_id: user_id, force: true}
+    |> new()
+    |> Oban.insert()
+  end
+
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"vault_id" => vault_id, "user_id" => user_id}}) do
-    perform_cleanup(vault_id, user_id)
+  def perform(%Oban.Job{args: %{"vault_id" => vault_id, "user_id" => user_id} = args}) do
+    perform_cleanup(vault_id, user_id, force: Map.get(args, "force", false))
   end
 
   @doc false
-  def perform_cleanup(vault_id, _user_id) do
+  def perform_cleanup(vault_id, user_id, opts \\ []) do
+    force = Keyword.get(opts, :force, false)
     vault = Repo.get(Vault, vault_id, skip_tenant_check: true)
+    _ = user_id
 
     cond do
       is_nil(vault) ->
@@ -53,10 +66,19 @@ defmodule Engram.Workers.CleanupVault do
         Logger.info("CleanupVault: vault #{vault_id} was restored — skipping")
         :ok
 
+      not force and retention_age_secs(vault) < @retention_secs ->
+        snooze = @retention_secs - retention_age_secs(vault)
+        Logger.info("CleanupVault: vault #{vault_id} not yet at retention — snoozing #{snooze}s")
+        {:snooze, snooze}
+
       true ->
         Logger.info("CleanupVault: starting hard-delete for vault #{vault_id}")
         run_cleanup(vault)
     end
+  end
+
+  defp retention_age_secs(vault) do
+    DateTime.diff(DateTime.utc_now(), vault.deleted_at, :second)
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/engram/workers/vault_deleted_email.ex
+++ b/lib/engram/workers/vault_deleted_email.ex
@@ -49,8 +49,10 @@ defmodule Engram.Workers.VaultDeletedEmail do
   end
 
   defp vault_name(vault, user) do
-    case Crypto.maybe_decrypt_vault_fields(vault, user) do
-      {:ok, %{name: name}} when is_binary(name) and name != "" -> name
+    with {:ok, decrypted} <- Crypto.maybe_decrypt_vault_fields(vault, user),
+         label when is_binary(label) and label != "" <- decrypted.name do
+      label
+    else
       _ -> vault.slug
     end
   end

--- a/lib/engram/workers/vault_deleted_email.ex
+++ b/lib/engram/workers/vault_deleted_email.ex
@@ -1,0 +1,57 @@
+defmodule Engram.Workers.VaultDeletedEmail do
+  @moduledoc """
+  Oban worker: emails a user that a vault was soft-deleted, with a link to the
+  vault settings page (restore / purge-now). Self-host installs no-op via the
+  NoOp mail provider. Sends asynchronously so the DELETE request is never
+  blocked on mail delivery.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Mailer
+  alias Engram.Repo
+  alias Engram.Vaults.Vault
+
+  require Logger
+
+  @retention_days 30
+
+  def enqueue(user_id, vault_id) do
+    %{user_id: user_id, vault_id: vault_id}
+    |> new()
+    |> Oban.insert()
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "vault_id" => vault_id}}) do
+    user = Repo.get(User, user_id, skip_tenant_check: true)
+    vault = Repo.get(Vault, vault_id, skip_tenant_check: true)
+
+    cond do
+      is_nil(user) or is_nil(vault) ->
+        :ok
+
+      is_nil(vault.deleted_at) ->
+        :ok
+
+      true ->
+        purge_at = DateTime.add(vault.deleted_at, @retention_days * 86_400, :second)
+        purge_date = Calendar.strftime(purge_at, "%B %-d, %Y")
+        manage_url = EngramWeb.Endpoint.url() <> "/settings/vaults?highlight=#{vault.id}"
+
+        _ =
+          Mailer.send_vault_deletion_notice(user, vault_name(vault, user), purge_date, manage_url)
+
+        :ok
+    end
+  end
+
+  defp vault_name(vault, user) do
+    case Crypto.maybe_decrypt_vault_fields(vault, user) do
+      {:ok, %{name: name}} when is_binary(name) and name != "" -> name
+      _ -> vault.slug
+    end
+  end
+end

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -52,6 +52,9 @@ defmodule EngramWeb.BillingController do
   defp cap_json(nil), do: nil
   defp cap_json(-1), do: nil
   defp cap_json(limit) when is_integer(limit), do: limit
+  # Unknown/malformed override (e.g. a non-integer value) → treat as no cap
+  # rather than 500 the endpoint.
+  defp cap_json(_), do: nil
 
   @doc """
   Customer-portal redirect. Without an `action` param this returns the generic

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -40,9 +40,18 @@ defmodule EngramWeb.BillingController do
         pro: Application.get_env(:engram, :paddle_pro_price_id)
       },
       customer_email: user.email,
-      custom_data: %{user_id: user.id}
+      custom_data: %{user_id: user.id},
+      vaults_cap: cap_json(Billing.effective_limit(user, :vaults_cap))
     })
   end
+
+  # Normalizes an effective limit to a JSON-friendly value: a positive integer
+  # cap, or `null` for "unlimited" (`:unlimited` / `nil` / `-1`). The frontend
+  # treats `null` as no cap.
+  defp cap_json(:unlimited), do: nil
+  defp cap_json(nil), do: nil
+  defp cap_json(-1), do: nil
+  defp cap_json(limit) when is_integer(limit), do: limit
 
   @doc """
   Customer-portal redirect. Without an `action` param this returns the generic

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -6,6 +6,12 @@ defmodule EngramWeb.VaultsController do
 
   # ── index ──────────────────────────────────────────────────────────────────
 
+  def index(conn, %{"deleted" => "true"}) do
+    user = conn.assigns.current_user
+    vaults = Vaults.list_deleted_vaults(user)
+    json(conn, %{vaults: Enum.map(vaults, &deleted_vault_json(&1, user))})
+  end
+
   def index(conn, _params) do
     user = conn.assigns.current_user
     vaults = Vaults.list_vaults(user)
@@ -97,6 +103,50 @@ defmodule EngramWeb.VaultsController do
     end
   end
 
+  # ── restore ──────────────────────────────────────────────────────────────────
+
+  def restore(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case parse_id(id) do
+      {:ok, vault_id} ->
+        case Vaults.restore_vault(user, vault_id) do
+          {:ok, vault} ->
+            json(conn, %{vault: vault_json(vault, user)})
+
+          {:error, :limit_reached} ->
+            limit = Billing.effective_limit(user, :vaults_cap)
+
+            conn
+            |> put_status(402)
+            |> json(%{error: "vault_limit_reached", limit: limit})
+
+          {:error, :not_found} ->
+            not_found(conn)
+        end
+
+      :error ->
+        not_found(conn)
+    end
+  end
+
+  # ── purge (immediate hard delete) ──────────────────────────────────────────────
+
+  def purge(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case parse_id(id) do
+      {:ok, vault_id} ->
+        case Vaults.purge_vault(user, vault_id) do
+          {:ok, _vault} -> json(conn, %{purged: true, id: vault_id})
+          {:error, :not_found} -> not_found(conn)
+        end
+
+      :error ->
+        not_found(conn)
+    end
+  end
+
   # Phase B.4: encrypt/decrypt toggle actions are retired. Every vault is
   # encrypted at rest by definition; per-note reads decrypt on demand.
 
@@ -147,6 +197,18 @@ defmodule EngramWeb.VaultsController do
       encrypted: true
     }
   end
+
+  defp deleted_vault_json(vault, user) do
+    vault
+    |> vault_json(user)
+    |> Map.merge(%{
+      deleted_at: vault.deleted_at,
+      purge_at: purge_at(vault.deleted_at)
+    })
+  end
+
+  defp purge_at(nil), do: nil
+  defp purge_at(deleted_at), do: DateTime.add(deleted_at, 30 * 86_400, :second)
 
   defp not_found(conn) do
     conn

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -159,6 +159,8 @@ defmodule EngramWeb.Router do
     get "/vaults/:id", VaultsController, :show
     patch "/vaults/:id", VaultsController, :update
     delete "/vaults/:id", VaultsController, :delete
+    post "/vaults/:id/restore", VaultsController, :restore
+    post "/vaults/:id/purge", VaultsController, :purge
 
     # Billing — Paddle checkout opens client-side via paddle.js, so the
     # backend only exposes status, the public client config, and a portal

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.246",
+      version: "0.5.247",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.245",
+      version: "0.5.246",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/mailer_test.exs
+++ b/test/engram/mailer_test.exs
@@ -119,6 +119,47 @@ defmodule Engram.MailerTest do
     end
   end
 
+  describe "send_vault_deletion_notice/4" do
+    test "returns :ok and includes the manage link, vault name, and purge date" do
+      user = insert(:user, email: "u@example.com")
+
+      expect(Engram.Email.ProviderMock, :send, fn to, subject, html, _opts ->
+        assert to == "u@example.com"
+        assert subject =~ "vault was deleted"
+        assert html =~ "My Vault"
+        assert html =~ "June 27, 2026"
+        assert html =~ "https://app.engram.page/settings/vaults?highlight=1"
+        :ok
+      end)
+
+      assert :ok =
+               Mailer.send_vault_deletion_notice(
+                 user,
+                 "My Vault",
+                 "June 27, 2026",
+                 "https://app.engram.page/settings/vaults?highlight=1"
+               )
+    end
+
+    test "escapes HTML in the vault name" do
+      user = insert(:user, email: "u@example.com")
+
+      expect(Engram.Email.ProviderMock, :send, fn _to, _subject, html, _opts ->
+        refute html =~ "<script>alert(1)</script>"
+        assert html =~ "&lt;script&gt;"
+        :ok
+      end)
+
+      assert :ok =
+               Mailer.send_vault_deletion_notice(
+                 user,
+                 "<script>alert(1)</script>",
+                 "June 27, 2026",
+                 "https://app.engram.page/settings/vaults?highlight=1"
+               )
+    end
+  end
+
   defp og_recipient(name) do
     {:ok, r} = Engram.Email.Recipient.new("og@example.com", name)
     r

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -457,6 +457,17 @@ defmodule Engram.VaultsTest do
     test "returns {:error, :not_found} for missing vault", %{user: user} do
       assert {:error, :not_found} = Vaults.delete_vault(user, 0)
     end
+
+    test "delete_vault enqueues the deletion-notice email", %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, v} = Vaults.create_vault(user, %{name: "Bye"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+
+      assert_enqueued(
+        worker: Engram.Workers.VaultDeletedEmail,
+        args: %{vault_id: v.id, user_id: user.id}
+      )
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -226,6 +226,35 @@ defmodule Engram.VaultsTest do
     end
   end
 
+  describe "list_deleted_vaults/1" do
+    setup %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      :ok
+    end
+
+    test "returns only soft-deleted vaults, newest-deleted first", %{user: user} do
+      {:ok, keep} = Vaults.create_vault(user, %{name: "Keep"})
+      {:ok, gone} = Vaults.create_vault(user, %{name: "Gone"})
+      {:ok, _} = Vaults.delete_vault(user, gone.id)
+
+      deleted = Vaults.list_deleted_vaults(user)
+
+      assert Enum.map(deleted, & &1.id) == [gone.id]
+      assert keep.id not in Enum.map(deleted, & &1.id)
+      assert hd(deleted).name == "Gone"
+    end
+
+    test "excludes other users' deleted vaults", %{user: user, other_user: other} do
+      insert(:user_limit_override, user: other, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, mine} = Vaults.create_vault(user, %{name: "Mine"})
+      {:ok, theirs} = Vaults.create_vault(other, %{name: "Theirs"})
+      {:ok, _} = Vaults.delete_vault(user, mine.id)
+      {:ok, _} = Vaults.delete_vault(other, theirs.id)
+
+      assert Enum.map(Vaults.list_deleted_vaults(user), & &1.id) == [mine.id]
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # get_vault/2
   # ---------------------------------------------------------------------------

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -277,7 +277,7 @@ defmodule Engram.VaultsTest do
       assert {:error, :limit_reached} = Vaults.restore_vault(user, first.id)
       # Blocked restore leaves the vault soft-deleted: it stays in the trash
       # list and is NOT promoted back into the active list.
-      assert first.id in restored_ids(user)
+      assert first.id in deleted_ids(user)
       assert first.id not in Enum.map(Vaults.list_vaults(user), & &1.id)
     end
 
@@ -294,7 +294,7 @@ defmodule Engram.VaultsTest do
       assert {:error, :not_found} = Vaults.restore_vault(user, v.id)
     end
 
-    defp restored_ids(user), do: Enum.map(Vaults.list_deleted_vaults(user), & &1.id)
+    defp deleted_ids(user), do: Enum.map(Vaults.list_deleted_vaults(user), & &1.id)
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -321,6 +321,7 @@ defmodule Engram.VaultsTest do
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
       {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
       assert {:error, :not_found} = Vaults.purge_vault(user, v.id)
+      refute_enqueued(worker: Engram.Workers.CleanupVault)
     end
   end
 

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -1,5 +1,6 @@
 defmodule Engram.VaultsTest do
   use Engram.DataCase, async: true
+  use Oban.Testing, repo: Engram.Repo
 
   alias Engram.Vaults
 
@@ -295,6 +296,32 @@ defmodule Engram.VaultsTest do
     end
 
     defp deleted_ids(user), do: Enum.map(Vaults.list_deleted_vaults(user), & &1.id)
+  end
+
+  # ---------------------------------------------------------------------------
+  # purge_vault/2
+  # ---------------------------------------------------------------------------
+
+  describe "purge_vault/2" do
+    test "enqueues an immediate force cleanup for a soft-deleted vault", %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, v} = Vaults.create_vault(user, %{name: "Doomed"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+
+      assert {:ok, vault} = Vaults.purge_vault(user, v.id)
+      assert vault.id == v.id
+
+      assert_enqueued(
+        worker: Engram.Workers.CleanupVault,
+        args: %{vault_id: v.id, user_id: user.id, force: true}
+      )
+    end
+
+    test "returns :not_found for an active vault", %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+      assert {:error, :not_found} = Vaults.purge_vault(user, v.id)
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -255,6 +255,48 @@ defmodule Engram.VaultsTest do
     end
   end
 
+  describe "restore_vault/2" do
+    test "clears deleted_at and returns the vault", %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, v} = Vaults.create_vault(user, %{name: "Temp"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+
+      assert {:ok, restored} = Vaults.restore_vault(user, v.id)
+      assert restored.id == v.id
+      assert restored.deleted_at == nil
+      assert Enum.map(Vaults.list_vaults(user), & &1.id) |> Enum.member?(v.id)
+      assert Vaults.list_deleted_vaults(user) == []
+    end
+
+    test "blocks restore when it would exceed the vault cap", %{user: user} do
+      # Cap of 1: create one, delete it, create a replacement, then try to restore.
+      {:ok, first} = Vaults.create_vault(user, %{name: "First"})
+      {:ok, _} = Vaults.delete_vault(user, first.id)
+      {:ok, _replacement} = Vaults.create_vault(user, %{name: "Replacement"})
+
+      assert {:error, :limit_reached} = Vaults.restore_vault(user, first.id)
+      # Blocked restore leaves the vault soft-deleted: it stays in the trash
+      # list and is NOT promoted back into the active list.
+      assert first.id in restored_ids(user)
+      assert first.id not in Enum.map(Vaults.list_vaults(user), & &1.id)
+    end
+
+    test "returns :not_found for an active vault", %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+      assert {:error, :not_found} = Vaults.restore_vault(user, v.id)
+    end
+
+    test "returns :not_found for another user's deleted vault", %{user: user, other_user: other} do
+      insert(:user_limit_override, user: other, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, v} = Vaults.create_vault(other, %{name: "Theirs"})
+      {:ok, _} = Vaults.delete_vault(other, v.id)
+      assert {:error, :not_found} = Vaults.restore_vault(user, v.id)
+    end
+
+    defp restored_ids(user), do: Enum.map(Vaults.list_deleted_vaults(user), & &1.id)
+  end
+
   # ---------------------------------------------------------------------------
   # get_vault/2
   # ---------------------------------------------------------------------------

--- a/test/engram/workers/cleanup_vault_test.exs
+++ b/test/engram/workers/cleanup_vault_test.exs
@@ -66,6 +66,7 @@ defmodule Engram.Workers.CleanupVaultTest do
           user: user,
           deleted_at: DateTime.add(DateTime.utc_now(), -31, :day) |> DateTime.truncate(:second)
         )
+
       note = insert(:note, user: user, vault: vault)
       attachment = insert(:attachment, user: user, vault: vault)
 
@@ -185,6 +186,7 @@ defmodule Engram.Workers.CleanupVaultTest do
           user: user,
           deleted_at: DateTime.add(DateTime.utc_now(), -31, :day) |> DateTime.truncate(:second)
         )
+
       note = insert(:note, user: user, vault: vault)
       attachment = insert(:attachment, user: user, vault: vault, storage_key: "test/blob.png")
 

--- a/test/engram/workers/cleanup_vault_test.exs
+++ b/test/engram/workers/cleanup_vault_test.exs
@@ -59,7 +59,13 @@ defmodule Engram.Workers.CleanupVaultTest do
       on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
 
       user = insert(:user)
-      vault = insert(:vault, user: user, deleted_at: DateTime.utc_now())
+      # Aged past the 30-day retention window so perform_cleanup hard-deletes
+      # rather than snoozing on the age guard.
+      vault =
+        insert(:vault,
+          user: user,
+          deleted_at: DateTime.add(DateTime.utc_now(), -31, :day) |> DateTime.truncate(:second)
+        )
       note = insert(:note, user: user, vault: vault)
       attachment = insert(:attachment, user: user, vault: vault)
 
@@ -172,7 +178,13 @@ defmodule Engram.Workers.CleanupVaultTest do
       on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
 
       user = insert(:user)
-      vault = insert(:vault, user: user, deleted_at: DateTime.utc_now())
+      # Aged past the 30-day retention window so perform_cleanup hard-deletes
+      # rather than snoozing on the age guard.
+      vault =
+        insert(:vault,
+          user: user,
+          deleted_at: DateTime.add(DateTime.utc_now(), -31, :day) |> DateTime.truncate(:second)
+        )
       note = insert(:note, user: user, vault: vault)
       attachment = insert(:attachment, user: user, vault: vault, storage_key: "test/blob.png")
 
@@ -232,6 +244,77 @@ defmodule Engram.Workers.CleanupVaultTest do
 
       # Vault still exists
       assert Repo.get(Vault, vault.id, skip_tenant_check: true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # perform_cleanup/3 — retention age guard + force purge
+  # ---------------------------------------------------------------------------
+
+  describe "perform_cleanup/3 — age guard" do
+    setup do
+      bypass = Bypass.open()
+      Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+      on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
+
+      user = insert(:user)
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+
+      %{bypass: bypass, user: user}
+    end
+
+    defp stub_qdrant_ack(bypass) do
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": {"status": "acknowledged"}}))
+      end)
+    end
+
+    defp backdate_deleted_at(vault_id, days) do
+      ts =
+        DateTime.utc_now()
+        |> DateTime.add(-days * 86_400, :second)
+        |> DateTime.truncate(:second)
+
+      from(v in Vault, where: v.id == ^vault_id)
+      |> Repo.update_all([set: [deleted_at: ts]], skip_tenant_check: true)
+    end
+
+    test "skips when the vault was restored (deleted_at nil)", %{user: user} do
+      {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+      assert :ok = CleanupVault.perform_cleanup(v.id, user.id)
+      assert Repo.get(Vault, v.id, skip_tenant_check: true)
+    end
+
+    test "snoozes when deleted_at is younger than 30 days", %{user: user} do
+      {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+      backdate_deleted_at(v.id, 5)
+
+      assert {:snooze, secs} = CleanupVault.perform_cleanup(v.id, user.id)
+      assert secs > 0
+      assert Repo.get(Vault, v.id, skip_tenant_check: true)
+    end
+
+    test "purges when deleted_at is older than 30 days", %{bypass: bypass, user: user} do
+      stub_qdrant_ack(bypass)
+      {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+      backdate_deleted_at(v.id, 31)
+
+      assert :ok = CleanupVault.perform_cleanup(v.id, user.id)
+      refute Repo.get(Vault, v.id, skip_tenant_check: true)
+    end
+
+    test "force purges immediately regardless of age", %{bypass: bypass, user: user} do
+      stub_qdrant_ack(bypass)
+      {:ok, v} = Vaults.create_vault(user, %{name: "V"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+      # freshly deleted (age ~0) but force=true
+
+      assert :ok = CleanupVault.perform_cleanup(v.id, user.id, force: true)
+      refute Repo.get(Vault, v.id, skip_tenant_check: true)
     end
   end
 end

--- a/test/engram/workers/vault_deleted_email_test.exs
+++ b/test/engram/workers/vault_deleted_email_test.exs
@@ -1,0 +1,25 @@
+defmodule Engram.Workers.VaultDeletedEmailTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Vaults
+  alias Engram.Workers.VaultDeletedEmail
+
+  setup do
+    user = insert(:user, email: "u@example.com")
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+    %{user: user}
+  end
+
+  test "perform sends the notice for a soft-deleted vault", %{user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Gone"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    job = %Oban.Job{args: %{"user_id" => user.id, "vault_id" => v.id}}
+    assert :ok = VaultDeletedEmail.perform(job)
+  end
+
+  test "perform is a no-op when the vault is missing", %{user: user} do
+    job = %Oban.Job{args: %{"user_id" => user.id, "vault_id" => 999_999}}
+    assert :ok = VaultDeletedEmail.perform(job)
+  end
+end

--- a/test/engram/workers/vault_deleted_email_test.exs
+++ b/test/engram/workers/vault_deleted_email_test.exs
@@ -1,10 +1,25 @@
 defmodule Engram.Workers.VaultDeletedEmailTest do
-  use Engram.DataCase, async: true
+  use Engram.DataCase, async: false
 
+  import Mox
+
+  alias Engram.Repo
   alias Engram.Vaults
+  alias Engram.Vaults.Vault
   alias Engram.Workers.VaultDeletedEmail
 
+  setup :verify_on_exit!
+
   setup do
+    prev_provider = Application.get_env(:engram, :email_provider)
+    Application.put_env(:engram, :email_provider, Engram.Email.ProviderMock)
+
+    on_exit(fn ->
+      if is_nil(prev_provider),
+        do: Application.delete_env(:engram, :email_provider),
+        else: Application.put_env(:engram, :email_provider, prev_provider)
+    end)
+
     user = insert(:user, email: "u@example.com")
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
     %{user: user}
@@ -14,6 +29,29 @@ defmodule Engram.Workers.VaultDeletedEmailTest do
     {:ok, v} = Vaults.create_vault(user, %{name: "Gone"})
     {:ok, _} = Vaults.delete_vault(user, v.id)
 
+    expect(Engram.Email.ProviderMock, :send, 1, fn to, subject, _html, _opts ->
+      assert to == "u@example.com"
+      assert subject =~ "vault was deleted"
+      :ok
+    end)
+
+    job = %Oban.Job{args: %{"user_id" => user.id, "vault_id" => v.id}}
+    assert :ok = VaultDeletedEmail.perform(job)
+  end
+
+  test "perform is a no-op when the vault was restored before send", %{user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Restored"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    # Restore the vault (clear deleted_at) before the job runs.
+    {1, _} =
+      Repo.update_all(
+        from(vault in Vault, where: vault.id == ^v.id),
+        [set: [deleted_at: nil]],
+        skip_tenant_check: true
+      )
+
+    # No expect/0 set → if the provider is called, Mox raises on verify.
     job = %Oban.Job{args: %{"user_id" => user.id, "vault_id" => v.id}}
     assert :ok = VaultDeletedEmail.perform(job)
   end

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -66,6 +66,22 @@ defmodule EngramWeb.BillingControllerTest do
       assert body["custom_data"]["user_id"] == user.id
     end
 
+    test "exposes the tier-default vaults_cap when the user has no override", %{conn: conn} do
+      # limits_enforced is true in test (config/test.exs), so effective_limit
+      # resolves the free-tier default for a new user with no subscription:
+      # LimitKeys vaults_cap default for :free is 1.
+      conn = get(conn, "/api/billing/config")
+      body = json_response(conn, 200)
+      assert body["vaults_cap"] == 1
+    end
+
+    test "exposes an explicit integer vaults_cap override", %{conn: conn, user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
+      conn = get(conn, "/api/billing/config")
+      body = json_response(conn, 200)
+      assert body["vaults_cap"] == 5
+    end
+
     test "returns 401 without auth" do
       conn = build_conn() |> get("/api/billing/config")
       assert json_response(conn, 401)

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -82,6 +82,16 @@ defmodule EngramWeb.BillingControllerTest do
       assert body["vaults_cap"] == 5
     end
 
+    test "stays resilient (200, null cap) when the override value is malformed", %{
+      conn: conn,
+      user: user
+    } do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => "lots"})
+      conn = get(conn, "/api/billing/config")
+      body = json_response(conn, 200)
+      assert body["vaults_cap"] == nil
+    end
+
     test "returns 401 without auth" do
       conn = build_conn() |> get("/api/billing/config")
       assert json_response(conn, 401)

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -147,6 +147,73 @@ defmodule EngramWeb.VaultsControllerTest do
     end
   end
 
+  describe "GET /api/vaults?deleted=true" do
+    test "lists soft-deleted vaults with a purge_at", %{conn: conn, user: user} do
+      {:ok, v} = Vaults.create_vault(user, %{name: "Trashed"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+
+      body = conn |> get("/api/vaults?deleted=true") |> json_response(200)
+      [item] = body["vaults"]
+      assert item["id"] == v.id
+      assert item["deleted_at"]
+      assert item["purge_at"]
+    end
+
+    test "active listing excludes deleted vaults", %{conn: conn, user: user} do
+      {:ok, v} = Vaults.create_vault(user, %{name: "Trashed"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+
+      body = conn |> get("/api/vaults") |> json_response(200)
+      assert body["vaults"] == []
+    end
+  end
+
+  describe "POST /api/vaults/:id/restore" do
+    test "restores a deleted vault", %{conn: conn, user: user} do
+      {:ok, v} = Vaults.create_vault(user, %{name: "Back"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+
+      body = conn |> post("/api/vaults/#{v.id}/restore") |> json_response(200)
+      assert body["vault"]["id"] == v.id
+    end
+
+    test "returns 402 when over cap", %{conn: _conn} do
+      # fresh user with default cap (1), no override
+      other = insert(:user)
+      {:ok, raw_key, _} = Engram.Accounts.create_api_key(other, "k")
+      grant_api_write!(other)
+      oconn = build_conn() |> put_req_header("authorization", "Bearer #{raw_key}")
+
+      {:ok, first} = Vaults.create_vault(other, %{name: "First"})
+      {:ok, _} = Vaults.delete_vault(other, first.id)
+      {:ok, _} = Vaults.create_vault(other, %{name: "Replacement"})
+
+      body = oconn |> post("/api/vaults/#{first.id}/restore") |> json_response(402)
+      assert body["error"] == "vault_limit_reached"
+    end
+
+    test "returns 404 for an active vault", %{conn: conn, user: user} do
+      {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+      conn |> post("/api/vaults/#{v.id}/restore") |> json_response(404)
+    end
+  end
+
+  describe "POST /api/vaults/:id/purge" do
+    test "purges a deleted vault", %{conn: conn, user: user} do
+      {:ok, v} = Vaults.create_vault(user, %{name: "Doomed"})
+      {:ok, _} = Vaults.delete_vault(user, v.id)
+
+      body = conn |> post("/api/vaults/#{v.id}/purge") |> json_response(200)
+      assert body["purged"] == true
+      assert body["id"] == v.id
+    end
+
+    test "returns 404 for an active vault", %{conn: conn, user: user} do
+      {:ok, v} = Vaults.create_vault(user, %{name: "Active"})
+      conn |> post("/api/vaults/#{v.id}/purge") |> json_response(404)
+    end
+  end
+
   describe "POST /api/vaults/register" do
     test "creates vault on first call (201)", %{conn: conn} do
       conn = post(conn, "/api/vaults/register", %{name: "My Mac", client_id: "mac-001"})


### PR DESCRIPTION
## Summary

Adds a **Vaults** settings page where users manage their vaults, backed by a soft-delete + 30-day-grace lifecycle.

**Backend**
- `Vaults.list_deleted_vaults/1`, `restore_vault/2` (cap-guarded), `purge_vault/2`
- `CleanupVault` retention **age-guard** + force-purge path — fixes a restore→re-delete early-purge bug (a stale 30-day job could purge a re-deleted vault early)
- Endpoints: `GET /vaults?deleted=true` (with computed `purge_at`), `POST /vaults/:id/restore` (402 over-cap), `POST /vaults/:id/purge`
- Deletion-notice email via `VaultDeletedEmail` Oban worker → links to `/settings/vaults` (no destructive link in the email); self-host no-ops automatically via the `NoOp` mail provider
- `vaults_cap` exposed on `GET /api/billing/config` (with `cap_json/1` fallback so a malformed override can't 500 the endpoint)

**Frontend**
- `api.patch` + 6 TanStack Query hooks
- Vaults page: **Active** (inline rename, set-default, type-to-confirm delete) + **Recently deleted** (restore — disabled when over cap — and delete-permanently)
- Settings nav entry + `/settings/vaults` route, `?highlight=<id>` deep-link (via `useSearchParams`), and a **zero-vault empty state** (last-vault delete is allowed)

Design: `docs/superpowers/specs/2026-05-28-vault-management-design.md` · Plan: `docs/superpowers/plans/2026-05-28-vault-management.md`

Built TDD task-by-task; each task passed spec-compliance + code-quality review, plus a final holistic cross-cutting review.

## Test plan

- [x] Backend `mix test` — 1752 tests, 0 failures (includes merged `main`/#341)
- [x] Frontend `bun run test` — 98 tests, 0 failures
- [x] `bunx tsc --noEmit` clean
- [ ] **Manual browser smoke (not yet done):** create → rename → set-default → delete (type-to-confirm) → appears in Recently deleted with purge date → restore → delete again → Delete permanently; Free-cap user sees Restore disabled when a replacement exists; delete last vault → empty state renders; deletion email logged locally (NoOp) / received (Resend)

## Notes / follow-ups
- Purge shows optimistic success (~1 refetch before the row clears) — fine for v1
- Bare `/settings` still defaults self-host to `api-keys`, though Vaults is now first in the nav — left intentionally; flag if you'd prefer Vaults as the landing
- Pre-existing dead `Vault` encryption fields/hooks in `queries.ts` (Phase B.4 retired) noted but out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)