### PR TITLE
Vault settings: tables + content counts + educational delete modal

### DIFF
--- a/docs/superpowers/plans/2026-05-28-vault-settings-refinements.md
+++ b/docs/superpowers/plans/2026-05-28-vault-settings-refinements.md
@@ -1,0 +1,1064 @@
+# Vault Settings Refinements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface per-vault file/attachment counts, render the vault settings lists as tables, and replace the inline delete confirm with an educational modal (30-day window, remote-only, type-to-confirm, red trash action).
+
+**Architecture:** Backend adds batched per-vault content counts to the vault JSON (active + trash). Frontend gains a `dialog.tsx` primitive and a `DeleteVaultDialog`, and both vault sections become tables.
+
+**Tech Stack:** Elixir/Phoenix + Ecto (backend), React + TypeScript + TanStack Query + shadcn/ui + `radix-ui` Dialog + `lucide-react` (frontend). Tests: ExUnit + ex_machina factories (backend), Vitest + Testing Library (frontend).
+
+**Worktree:** `engram/.worktrees/vault-settings-refinements` on branch `feat/vault-settings-refinements`.
+
+**Note on test filtering:** This ExUnit setup filters by tag, not describe name. Run a single test with `mix test path:LINE` or `-n "tag"`, NOT `-o "name"`.
+
+---
+
+## File Structure
+
+**Backend**
+- Modify `lib/engram/vaults.ex` — add `content_counts_for/2` + `content_counts/2`.
+- Modify `lib/engram_web/controllers/vaults_controller.ex` — thread counts into `vault_json` / `deleted_vault_json`.
+- Test `test/engram/vaults_test.exs` — counts behavior.
+- Test `test/engram_web/controllers/vaults_controller_test.exs` — JSON carries counts.
+
+**Frontend**
+- Modify `frontend/src/api/queries.ts` — add count fields to `Vault`.
+- Create `frontend/src/components/ui/dialog.tsx` — Dialog primitive.
+- Create `frontend/src/settings/vaults/delete-vault-dialog.tsx` + test.
+- Modify `frontend/src/settings/vaults/active-vaults-section.tsx` + test — table + dialog wiring.
+- Modify `frontend/src/settings/vaults/deleted-vaults-section.tsx` + test — table + counts.
+- Modify `mix.exs` — version bump.
+
+---
+
+## Task 1: Backend — per-vault content counts
+
+**Files:**
+- Modify: `lib/engram/vaults.ex` (add functions near the `# ── List ──` region, after `list_for_ids/2`)
+- Test: `test/engram/vaults_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/engram/vaults_test.exs` (new describe block, place after the create_vault describe):
+
+```elixir
+  describe "content_counts_for/2 and content_counts/2" do
+    setup %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, a} = Vaults.create_vault(user, %{name: "Alpha"})
+      {:ok, b} = Vaults.create_vault(user, %{name: "Beta"})
+      %{a: a, b: b}
+    end
+
+    test "counts active notes and attachments per vault", %{user: user, a: a, b: b} do
+      insert_pair(:note, user: user, vault: a)
+      insert(:note, user: user, vault: b)
+      insert(:attachment, user: user, vault: a)
+
+      counts = Vaults.content_counts_for(user, [a, b])
+
+      assert counts[a.id] == %{notes: 2, attachments: 1}
+      assert counts[b.id] == %{notes: 1, attachments: 0}
+    end
+
+    test "excludes soft-deleted notes and attachments", %{user: user, a: a} do
+      insert(:note, user: user, vault: a)
+      insert(:note, user: user, vault: a, deleted_at: DateTime.utc_now(:second))
+      insert(:attachment, user: user, vault: a, deleted_at: DateTime.utc_now(:second))
+
+      assert Vaults.content_counts_for(user, [a])[a.id] == %{notes: 1, attachments: 0}
+    end
+
+    test "does not bleed across users", %{user: user, other_user: other, a: a} do
+      insert(:note, user: other, vault: build(:vault, user: other))
+      insert(:note, user: user, vault: a)
+
+      assert Vaults.content_counts_for(user, [a])[a.id] == %{notes: 1, attachments: 0}
+    end
+
+    test "empty vault list returns empty map", %{user: user} do
+      assert Vaults.content_counts_for(user, []) == %{}
+    end
+
+    test "content_counts/2 returns a single vault's counts", %{user: user, a: a} do
+      insert(:note, user: user, vault: a)
+      assert Vaults.content_counts(user, a.id) == %{notes: 1, attachments: 0}
+    end
+
+    test "content_counts/2 returns zeros for an empty vault", %{user: user, b: b} do
+      assert Vaults.content_counts(user, b.id) == %{notes: 0, attachments: 0}
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && mix test test/engram/vaults_test.exs -n content_counts` (or just the file)
+Expected: FAIL — `Vaults.content_counts_for/2` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/engram/vaults.ex`, after `list_for_ids/2` (before the `# ── Get ──` region), add:
+
+```elixir
+  # ── Content counts ───────────────────────────────────────────────────────
+
+  @zero_counts %{notes: 0, attachments: 0}
+
+  @doc """
+  Returns a map of `%{vault_id => %{notes: n, attachments: m}}` for the given
+  vaults, counting only non-deleted notes/attachments owned by `user`.
+
+  Two batched GROUP BY queries (one per table) — no N+1. Tenant scoping is the
+  explicit `user_id == ^user_id` clause; RLS is bypassed (`skip_tenant_check:
+  true`) for performance, matching `list_for_ids/2`. The clause MUST stay.
+  """
+  @spec content_counts_for(Engram.Accounts.User.t(), [Vault.t()]) ::
+          %{integer() => %{notes: integer(), attachments: integer()}}
+  def content_counts_for(%Engram.Accounts.User{id: user_id}, vaults) when is_list(vaults) do
+    ids = Enum.map(vaults, & &1.id)
+    do_content_counts(user_id, ids)
+  end
+
+  @doc """
+  Returns `%{notes: n, attachments: m}` for a single vault id owned by `user`.
+  """
+  @spec content_counts(Engram.Accounts.User.t(), integer()) :: %{
+          notes: integer(),
+          attachments: integer()
+        }
+  def content_counts(%Engram.Accounts.User{id: user_id}, vault_id) do
+    Map.get(do_content_counts(user_id, [vault_id]), vault_id, @zero_counts)
+  end
+
+  defp do_content_counts(_user_id, []), do: %{}
+
+  defp do_content_counts(user_id, ids) do
+    note_counts =
+      from(n in Engram.Notes.Note,
+        where: n.user_id == ^user_id and n.vault_id in ^ids and is_nil(n.deleted_at),
+        group_by: n.vault_id,
+        select: {n.vault_id, count(n.id)}
+      )
+      |> Repo.all(skip_tenant_check: true)
+      |> Map.new()
+
+    attachment_counts =
+      from(a in Engram.Attachments.Attachment,
+        where: a.user_id == ^user_id and a.vault_id in ^ids and is_nil(a.deleted_at),
+        group_by: a.vault_id,
+        select: {a.vault_id, count(a.id)}
+      )
+      |> Repo.all(skip_tenant_check: true)
+      |> Map.new()
+
+    Map.new(ids, fn id ->
+      {id, %{notes: Map.get(note_counts, id, 0), attachments: Map.get(attachment_counts, id, 0)}}
+    end)
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && mix test test/engram/vaults_test.exs`
+Expected: PASS (all, including the new describe).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/vaults.ex test/engram/vaults_test.exs
+git commit -m "feat: per-vault note + attachment counts"
+```
+
+---
+
+## Task 2: Backend — expose counts on vault JSON
+
+**Files:**
+- Modify: `lib/engram_web/controllers/vaults_controller.ex`
+- Test: `test/engram_web/controllers/vaults_controller_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/engram_web/controllers/vaults_controller_test.exs` (inside the existing `describe "index"` block — match the existing auth/setup conventions in that file; if a logged-in `conn` + `user` are provided by `setup`, reuse them):
+
+```elixir
+    test "index includes note_count and attachment_count", %{conn: conn, user: user} do
+      vault = Engram.Repo.one!(from v in Engram.Vaults.Vault, where: v.user_id == ^user.id)
+      insert(:note, user: user, vault: vault)
+      insert(:note, user: user, vault: vault)
+      insert(:attachment, user: user, vault: vault)
+
+      resp = conn |> get(~p"/api/vaults") |> json_response(200)
+      row = Enum.find(resp["vaults"], &(&1["id"] == vault.id))
+
+      assert row["note_count"] == 2
+      assert row["attachment_count"] == 1
+    end
+```
+
+> If the test file lacks `import Ecto.Query` / factory imports, add them at the top following the file's existing style. If the setup doesn't already create a vault for `user`, create one with `insert(:vault, user: user)` and use that.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && mix test test/engram_web/controllers/vaults_controller_test.exs -n index`
+Expected: FAIL — `note_count` is nil (key absent).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/engram_web/controllers/vaults_controller.ex`:
+
+Replace the two `index/2` clauses (lines ~9-19) with:
+
+```elixir
+  def index(conn, %{"deleted" => "true"}) do
+    user = conn.assigns.current_user
+    vaults = Vaults.list_deleted_vaults(user)
+    counts = Vaults.content_counts_for(user, vaults)
+
+    json(conn, %{
+      vaults: Enum.map(vaults, &deleted_vault_json(&1, Map.get(counts, &1.id, @zero_counts)))
+    })
+  end
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    vaults = Vaults.list_vaults(user)
+    counts = Vaults.content_counts_for(user, vaults)
+
+    json(conn, %{
+      vaults: Enum.map(vaults, &vault_json(&1, Map.get(counts, &1.id, @zero_counts)))
+    })
+  end
+```
+
+Add the module attribute near the top of the module (after `alias Engram.Vaults`):
+
+```elixir
+  @zero_counts %{notes: 0, attachments: 0}
+```
+
+Replace each single-vault call site so counts come from `Vaults.content_counts/2`. The call sites are at lines ~30, 54, 73, 115, 169, 172. In each, change `vault_json(vault, user)` to `vault_json(vault, Vaults.content_counts(user, vault.id))`. For example, in `create`:
+
+```elixir
+      {:ok, vault} ->
+        conn
+        |> put_status(201)
+        |> json(%{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
+```
+
+Apply the same substitution to `show` (line ~54), the update success (line ~73), the encrypt/restore success (line ~115), and the register clauses (lines ~169 and ~172):
+
+```elixir
+          |> json(vault_json(vault, Vaults.content_counts(user, vault.id)) |> Map.put(:status, "created"))
+```
+```elixir
+          json(conn, vault_json(vault, Vaults.content_counts(user, vault.id)) |> Map.put(:status, "existing"))
+```
+
+Rewrite the JSON builders (lines ~186-208) so they take a counts map instead of `user`:
+
+```elixir
+  defp vault_json(vault, counts) do
+    %{
+      id: vault.id,
+      name: vault.name,
+      description: vault.description,
+      slug: vault.slug,
+      is_default: vault.is_default,
+      created_at: vault.created_at,
+      encrypted: true,
+      note_count: counts.notes,
+      attachment_count: counts.attachments
+    }
+  end
+
+  defp deleted_vault_json(vault, counts) do
+    vault
+    |> vault_json(counts)
+    |> Map.merge(%{
+      deleted_at: vault.deleted_at,
+      purge_at: purge_at(vault.deleted_at)
+    })
+  end
+```
+
+> Verify no other call site passes `user` to `vault_json`/`deleted_vault_json` after this change: `grep -n "vault_json(" lib/engram_web/controllers/vaults_controller.ex`. Every call must now pass a counts map.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && mix test test/engram_web/controllers/vaults_controller_test.exs`
+Expected: PASS (new test + all pre-existing).
+
+Also run `cd backend && mix compile --warnings-as-errors` — must be clean (no unused `user` warning).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram_web/controllers/vaults_controller.ex test/engram_web/controllers/vaults_controller_test.exs
+git commit -m "feat: surface vault content counts on vault JSON"
+```
+
+---
+
+## Task 3: Frontend — add count fields to the Vault type
+
+**Files:**
+- Modify: `frontend/src/api/queries.ts:298-313` (the `Vault` interface)
+
+- [ ] **Step 1: Edit the type**
+
+In the `Vault` interface, add after `purge_at?`:
+
+```ts
+  note_count?: number
+  attachment_count?: number
+```
+
+(Optional fields — older cached responses and the encryption endpoints predate them; the UI defaults to `0`.)
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `cd backend/frontend && bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/queries.ts
+git commit -m "feat: add note_count/attachment_count to Vault type"
+```
+
+---
+
+## Task 4: Frontend — Dialog primitive
+
+**Files:**
+- Create: `frontend/src/components/ui/dialog.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & { showCloseButton?: boolean }) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border bg-popover bg-clip-padding p-6 text-sm text-popover-foreground shadow-lg duration-200 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button variant="ghost" className="absolute top-3 right-3" size="icon-sm">
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="dialog-header" className={cn("flex flex-col gap-1", className)} {...props} />
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("font-heading text-base font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogClose,
+  DialogPortal,
+  DialogOverlay,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `cd backend/frontend && bunx tsc --noEmit`
+Expected: PASS. (If `size="icon-sm"` is not a valid Button size, use `size="icon"` — check `button.tsx` variants.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ui/dialog.tsx
+git commit -m "feat: add shadcn Dialog primitive"
+```
+
+---
+
+## Task 5: Frontend — DeleteVaultDialog
+
+**Files:**
+- Create: `frontend/src/settings/vaults/delete-vault-dialog.tsx`
+- Test: `frontend/src/settings/vaults/delete-vault-dialog.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const deleteMutate = vi.fn()
+vi.mock('@/api/queries', () => ({
+  useDeleteVault: () => ({ mutate: deleteMutate, isPending: false }),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { DeleteVaultDialog } from './delete-vault-dialog'
+
+const vault = {
+  id: 7,
+  name: 'Work',
+  description: null,
+  slug: 'work',
+  is_default: false,
+  created_at: '',
+  encrypted: true,
+  note_count: 142,
+  attachment_count: 3,
+}
+
+describe('DeleteVaultDialog', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('educates about the 30-day window and remote-only scope', () => {
+    render(<DeleteVaultDialog vault={vault} open onOpenChange={() => {}} />)
+    expect(screen.getByText(/30 days/i)).toBeInTheDocument()
+    expect(screen.getByText(/synced to your devices/i)).toBeInTheDocument()
+    expect(screen.getByText(/142/)).toBeInTheDocument()
+  })
+
+  it('keeps the delete button disabled until the name is typed', async () => {
+    render(<DeleteVaultDialog vault={vault} open onOpenChange={() => {}} />)
+    const confirmBtn = screen.getByRole('button', { name: /delete vault/i })
+    expect(confirmBtn).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/type .*work.* to confirm/i), { target: { value: 'Work' } })
+    expect(confirmBtn).toBeEnabled()
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith(7, expect.anything()))
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bunx vitest run src/settings/vaults/delete-vault-dialog.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+import { useEffect, useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useDeleteVault, type Vault } from '@/api/queries'
+
+const inputClass =
+  'mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
+
+export function DeleteVaultDialog({
+  vault,
+  open,
+  onOpenChange,
+}: {
+  vault: Vault
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const del = useDeleteVault()
+  const [phrase, setPhrase] = useState('')
+
+  useEffect(() => {
+    if (!open) setPhrase('')
+  }, [open])
+
+  const noteCount = vault.note_count ?? 0
+  const attachmentCount = vault.attachment_count ?? 0
+
+  function confirmDelete() {
+    del.mutate(vault.id, {
+      onSuccess: () => {
+        toast.success('Vault moved to trash')
+        onOpenChange(false)
+      },
+      onError: () => toast.error('Delete failed'),
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete "{vault.name}"?</DialogTitle>
+          <DialogDescription>
+            This vault holds {noteCount} {noteCount === 1 ? 'note' : 'notes'} and {attachmentCount}{' '}
+            {attachmentCount === 1 ? 'attachment' : 'attachments'}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>
+            It moves to trash and is <strong className="text-foreground">recoverable for 30 days</strong>, then
+            permanently deleted.
+          </li>
+          <li>
+            This only deletes the copy stored on Engram. Files already{' '}
+            <strong className="text-foreground">synced to your devices</strong> stay where they are.
+          </li>
+        </ul>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            confirmDelete()
+          }}
+        >
+          <label className="block text-sm text-foreground">
+            Type "{vault.name}" to confirm
+            <input
+              autoFocus
+              className={inputClass}
+              aria-label={`Type ${vault.name} to confirm`}
+              value={phrase}
+              onChange={(e) => setPhrase(e.target.value)}
+            />
+          </label>
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="destructive"
+              size="sm"
+              disabled={phrase !== vault.name || del.isPending}
+            >
+              <Trash2 />
+              Delete vault
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend/frontend && bunx vitest run src/settings/vaults/delete-vault-dialog.test.tsx`
+Expected: PASS.
+
+> If radix Dialog content doesn't render in jsdom without a portal target, the test still works because `DialogPortal` mounts to `document.body`. If `screen.getByText` can't find content, ensure the test asserts after `open` is true (it is).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/settings/vaults/delete-vault-dialog.tsx frontend/src/settings/vaults/delete-vault-dialog.test.tsx
+git commit -m "feat: educational delete-vault confirmation dialog"
+```
+
+---
+
+## Task 6: Frontend — Active vaults table
+
+**Files:**
+- Modify: `frontend/src/settings/vaults/active-vaults-section.tsx`
+- Test: `frontend/src/settings/vaults/active-vaults-section.test.tsx`
+
+- [ ] **Step 1: Update the test**
+
+Replace the file body's tests with table-aware + dialog-aware versions. Update the mock to include the dialog hook usage (already `useDeleteVault`) and add counts to the fixtures:
+
+```tsx
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const deleteMutate = vi.fn()
+const updateMutate = vi.fn()
+const vaults = [
+  { id: 1, name: 'Work', description: null, slug: 'work', is_default: true, created_at: '', encrypted: true, note_count: 12, attachment_count: 3 },
+  { id: 2, name: 'Personal', description: null, slug: 'personal', is_default: false, created_at: '', encrypted: true, note_count: 0, attachment_count: 0 },
+]
+
+vi.mock('@/api/queries', () => ({
+  useVaults: () => ({ data: vaults, isLoading: false }),
+  useDeleteVault: () => ({ mutate: deleteMutate, isPending: false }),
+  useUpdateVault: () => ({ mutate: updateMutate, isPending: false }),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { ActiveVaultsSection } from './active-vaults-section'
+
+describe('ActiveVaultsSection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('lists vaults with counts and marks the default', () => {
+    render(<ActiveVaultsSection />)
+    const workRow = within(screen.getByText('Work').closest('tr') as HTMLElement)
+    expect(workRow.getByText('12')).toBeInTheDocument()
+    expect(workRow.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('Default')).toBeInTheDocument()
+  })
+
+  it('opens the delete dialog and deletes after typing the name', async () => {
+    render(<ActiveVaultsSection />)
+    const workRow = within(screen.getByText('Work').closest('tr') as HTMLElement)
+    fireEvent.click(workRow.getByRole('button', { name: /delete .*work/i }))
+    const confirmBtn = screen.getByRole('button', { name: /delete vault/i })
+    expect(confirmBtn).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/type .*work.* to confirm/i), { target: { value: 'Work' } })
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith(1, expect.anything()))
+  })
+
+  it('sets a non-default vault as default', () => {
+    render(<ActiveVaultsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /set .*personal.* as default|set default/i }))
+    expect(updateMutate).toHaveBeenCalledWith({ id: 2, is_default: true }, expect.anything())
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bunx vitest run src/settings/vaults/active-vaults-section.test.tsx`
+Expected: FAIL — no `tr`, delete button label changed.
+
+- [ ] **Step 3: Rewrite the component as a table**
+
+```tsx
+import { useState } from 'react'
+import { Pencil, Star, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { SettingsSectionCard } from '@/settings/account/section-card'
+import { useVaults, useUpdateVault, type Vault } from '@/api/queries'
+import { DeleteVaultDialog } from './delete-vault-dialog'
+
+const inputClass =
+  'block w-full rounded-md border border-input bg-card px-2 py-1 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
+
+export function ActiveVaultsSection() {
+  const { data: vaults, isLoading } = useVaults()
+  const [deleteTarget, setDeleteTarget] = useState<Vault | null>(null)
+
+  return (
+    <SettingsSectionCard title="Vaults" description="Rename, set a default, or delete your vaults.">
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-left text-xs text-muted-foreground">
+            <th className="py-2 font-medium">Name</th>
+            <th className="py-2 text-right font-medium">Files</th>
+            <th className="py-2 text-right font-medium">Attachments</th>
+            <th className="py-2" aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {(vaults ?? []).map((v) => (
+            <VaultRow key={v.id} vault={v} onDelete={() => setDeleteTarget(v)} />
+          ))}
+          {!isLoading && (vaults ?? []).length === 0 && (
+            <tr>
+              <td colSpan={4} className="py-3 text-muted-foreground">
+                No vaults yet.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+
+      {deleteTarget && (
+        <DeleteVaultDialog
+          vault={deleteTarget}
+          open={deleteTarget !== null}
+          onOpenChange={(open) => !open && setDeleteTarget(null)}
+        />
+      )}
+    </SettingsSectionCard>
+  )
+}
+
+function VaultRow({ vault, onDelete }: { vault: Vault; onDelete: () => void }) {
+  const update = useUpdateVault()
+  const [renaming, setRenaming] = useState(false)
+  const [name, setName] = useState(vault.name)
+
+  function saveName() {
+    const next = name.trim()
+    if (next && next !== vault.name) {
+      update.mutate({ id: vault.id, name: next }, { onError: () => toast.error('Rename failed') })
+    }
+    setRenaming(false)
+  }
+
+  return (
+    <tr>
+      <td className="py-3">
+        {renaming ? (
+          <input
+            autoFocus
+            className={inputClass}
+            value={name}
+            aria-label={`Rename ${vault.name}`}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={saveName}
+            onKeyDown={(e) => e.key === 'Enter' && saveName()}
+          />
+        ) : (
+          <span className="flex items-center gap-2">
+            <span className="font-medium text-foreground">{vault.name}</span>
+            {vault.is_default && (
+              <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">Default</span>
+            )}
+          </span>
+        )}
+      </td>
+      <td className="py-3 text-right tabular-nums text-muted-foreground">{vault.note_count ?? 0}</td>
+      <td className="py-3 text-right tabular-nums text-muted-foreground">{vault.attachment_count ?? 0}</td>
+      <td className="py-3">
+        <span className="flex items-center justify-end gap-1">
+          {!vault.is_default && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              title={`Set ${vault.name} as default`}
+              aria-label={`Set ${vault.name} as default`}
+              onClick={() =>
+                update.mutate(
+                  { id: vault.id, is_default: true },
+                  { onError: () => toast.error('Could not set default') },
+                )
+              }
+            >
+              <Star />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            title={`Rename ${vault.name}`}
+            aria-label={`Rename ${vault.name}`}
+            onClick={() => setRenaming(true)}
+          >
+            <Pencil />
+          </Button>
+          <Button
+            variant="destructive"
+            size="icon-sm"
+            title={`Delete ${vault.name}`}
+            aria-label={`Delete ${vault.name}`}
+            onClick={onDelete}
+          >
+            <Trash2 />
+          </Button>
+        </span>
+      </td>
+    </tr>
+  )
+}
+```
+
+> If `size="icon-sm"` is not in `button.tsx`, use `size="icon"`. Verify with `grep "icon" src/components/ui/button.tsx`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend/frontend && bunx vitest run src/settings/vaults/active-vaults-section.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/settings/vaults/active-vaults-section.tsx frontend/src/settings/vaults/active-vaults-section.test.tsx
+git commit -m "feat: render active vaults as a table with counts + modal delete"
+```
+
+---
+
+## Task 7: Frontend — Trash table
+
+**Files:**
+- Modify: `frontend/src/settings/vaults/deleted-vaults-section.tsx`
+- Test: `frontend/src/settings/vaults/deleted-vaults-section.test.tsx`
+
+- [ ] **Step 1: Update the test**
+
+Read the existing `deleted-vaults-section.test.tsx` first to preserve its mocks (`useDeletedVaults`, `useVaults`, `useBillingConfig`, `useRestoreVault`, `usePurgeVault`, `react-router`). Add counts to fixtures and assert table cells. Add/keep:
+
+```tsx
+  it('shows counts and purge date in the trash table', () => {
+    render(<DeletedVaultsSection />)
+    const row = within(screen.getByText('Old').closest('tr') as HTMLElement)
+    expect(row.getByText('5')).toBeInTheDocument()       // note_count
+    expect(row.getByText('2')).toBeInTheDocument()       // attachment_count
+    expect(row.getByText(/purge/i)).toBeInTheDocument()
+  })
+```
+
+Ensure the deleted fixture includes `note_count: 5, attachment_count: 2, purge_at: <ISO>` and is named `Old`. Keep the existing restore-disabled-when-over-cap test, adapting selectors to `tr`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bunx vitest run src/settings/vaults/deleted-vaults-section.test.tsx`
+Expected: FAIL — no `tr` / counts not shown.
+
+- [ ] **Step 3: Rewrite as a table**
+
+```tsx
+import { toast } from 'sonner'
+import { RotateCcw, Trash2 } from 'lucide-react'
+import { useSearchParams } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { SettingsSectionCard } from '@/settings/account/section-card'
+import {
+  useDeletedVaults,
+  useVaults,
+  useRestoreVault,
+  usePurgeVault,
+  useBillingConfig,
+  type Vault,
+} from '@/api/queries'
+
+export function DeletedVaultsSection() {
+  const { data: deleted } = useDeletedVaults()
+  if (!deleted || deleted.length === 0) return null
+
+  return (
+    <SettingsSectionCard
+      title="Recently deleted"
+      description="Deleted vaults are kept for 30 days. Restore them, or remove them permanently."
+    >
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-left text-xs text-muted-foreground">
+            <th className="py-2 font-medium">Name</th>
+            <th className="py-2 text-right font-medium">Files</th>
+            <th className="py-2 text-right font-medium">Attachments</th>
+            <th className="py-2 font-medium">Purges</th>
+            <th className="py-2" aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {deleted.map((v) => (
+            <DeletedRow key={v.id} vault={v} />
+          ))}
+        </tbody>
+      </table>
+    </SettingsSectionCard>
+  )
+}
+
+function DeletedRow({ vault }: { vault: Vault }) {
+  const { data: active } = useVaults()
+  const { data: billing } = useBillingConfig()
+  const restore = useRestoreVault()
+  const purge = usePurgeVault()
+
+  const cap = billing?.vaults_cap ?? Infinity
+  const activeCount = active?.length ?? 0
+  const overCap = activeCount >= cap
+  const purgeDate = vault.purge_at ? new Date(vault.purge_at).toLocaleDateString() : '—'
+
+  const [searchParams] = useSearchParams()
+  const highlighted = searchParams.get('highlight') === String(vault.id)
+
+  return (
+    <tr
+      data-highlighted={highlighted || undefined}
+      className={highlighted ? 'bg-accent/40 ring-1 ring-ring' : ''}
+    >
+      <td className="py-3 font-medium text-foreground">{vault.name}</td>
+      <td className="py-3 text-right tabular-nums text-muted-foreground">{vault.note_count ?? 0}</td>
+      <td className="py-3 text-right tabular-nums text-muted-foreground">{vault.attachment_count ?? 0}</td>
+      <td className="py-3 text-muted-foreground">{purgeDate}</td>
+      <td className="py-3">
+        <span className="flex items-center justify-end gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={overCap || restore.isPending}
+            title={
+              overCap
+                ? 'Restoring would exceed your vault limit. Upgrade or delete another vault first.'
+                : undefined
+            }
+            onClick={() =>
+              restore.mutate(vault.id, {
+                onSuccess: () => toast.success('Vault restored'),
+                onError: () => toast.error('Could not restore (vault limit reached?)'),
+              })
+            }
+          >
+            <RotateCcw />
+            Restore
+          </Button>
+          <Button
+            variant="destructive"
+            size="icon-sm"
+            title={`Permanently delete ${vault.name}`}
+            aria-label={`Permanently delete ${vault.name}`}
+            disabled={purge.isPending}
+            onClick={() => {
+              if (window.confirm(`Permanently delete "${vault.name}"? This cannot be undone.`)) {
+                purge.mutate(vault.id, {
+                  onSuccess: () => toast.success('Vault permanently deleted'),
+                  onError: () => toast.error('Could not delete'),
+                })
+              }
+            }}
+          >
+            <Trash2 />
+          </Button>
+        </span>
+      </td>
+    </tr>
+  )
+}
+```
+
+> Use `size="icon"` if `icon-sm` is absent. Keep `RotateCcw` text on Restore so the existing "Restore" label assertions still match.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend/frontend && bunx vitest run src/settings/vaults/deleted-vaults-section.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/settings/vaults/deleted-vaults-section.tsx frontend/src/settings/vaults/deleted-vaults-section.test.tsx
+git commit -m "feat: render trash as a table with counts + purge date"
+```
+
+---
+
+## Task 8: Version bump + full verification
+
+**Files:**
+- Modify: `mix.exs:7` (version)
+
+- [ ] **Step 1: Bump version**
+
+In `mix.exs`, bump `version:` by one patch (e.g. `0.5.247` → `0.5.248`). Check the current value first; if main moved, bump from the latest.
+
+- [ ] **Step 2: Run the full frontend suite + typecheck**
+
+Run: `cd backend/frontend && bunx tsc --noEmit && bunx vitest run`
+Expected: PASS.
+
+- [ ] **Step 3: Run backend format + the touched test files**
+
+Run:
+```bash
+cd backend && mix format && mix test test/engram/vaults_test.exs test/engram_web/controllers/vaults_controller_test.exs
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mix.exs
+git commit -m "chore: bump version for vault settings refinements"
+```
+
+---
+
+## Self-Review Checklist (controller covered all call sites?)
+
+After Task 2, confirm `grep -n "vault_json(" lib/engram_web/controllers/vaults_controller.ex` shows every call passing a counts map (none passing `user`). A missed site is a compile error (the `user`-arity clause no longer exists) — that's the safety net.

--- a/docs/superpowers/specs/2026-05-28-vault-settings-refinements-design.md
+++ b/docs/superpowers/specs/2026-05-28-vault-settings-refinements-design.md
@@ -1,0 +1,90 @@
+# Vault Settings Refinements — Design
+
+> Refinement of the shipped vault-management feature (PR #345). See
+> `2026-05-28-vault-management-design.md` for the base design.
+
+**Goal:** Make the vault settings screen more scannable (table layout with file +
+attachment counts) and make destructive delete clearer (modal that educates about
+the 30-day soft-delete window, remote-only scope, with type-to-confirm + red trash
+action).
+
+## Motivation
+
+The shipped page renders vaults as stacked rows with an inline type-to-confirm
+delete. Two problems:
+
+1. **Low scannability** — no at-a-glance sense of how much each vault holds.
+2. **Delete clarity** — inline confirm doesn't explain consequences. Users don't
+   know (a) it's recoverable for 30 days, (b) it only deletes the *remote* copy,
+   not files already synced to their machines.
+
+## Scope
+
+### Backend
+
+Surface per-vault content counts on the vault JSON (active + deleted lists).
+
+- **Counts are active-only:** `notes.deleted_at IS NULL` and
+  `attachments.deleted_at IS NULL`, scoped to `user_id` + `vault_id`. A
+  soft-deleted vault keeps its child rows until purge, so trash counts honestly
+  reflect "N files that will be permanently deleted."
+- **Batched, no N+1:** one `GROUP BY vault_id` query per table over the listed
+  vault ids, merged into a `%{vault_id => %{notes: n, attachments: m}}` map.
+- `vault_json/2` gains a counts argument; `index` (both the default and
+  `deleted=true` clauses) computes the batched map and passes per-vault counts.
+- Single-vault responses (`create`, `update`, `restore`) compute counts for that
+  one vault. A freshly created vault is `0/0`; this keeps the JSON shape uniform
+  and the row correct before the list refetch lands.
+- JSON fields: `note_count` (integer), `attachment_count` (integer).
+
+### Frontend
+
+**Dialog primitive.** Add `frontend/src/components/ui/dialog.tsx` — a shadcn
+Dialog mirroring the existing `sheet.tsx` (both wrap `radix-ui`'s `Dialog`). No
+new dependency.
+
+**Active vaults → table.** Columns: Name (with default star + inline rename),
+Files, Attachments, Actions. Actions: set-default (when not default), rename
+(pencil), delete (red `Trash2` icon button, `variant="destructive"`,
+`size="icon"`). Delete opens the modal instead of the old inline confirm.
+
+**Trash → table.** Columns: Name, Files, Attachments, Deleted, Purges in,
+Actions. Actions: restore (disabled when active count ≥ cap, existing rule),
+delete permanently (red trash, `window.confirm` stays — it's already irreversible
+and not the focus of this change).
+
+**Delete modal** (`frontend/src/settings/vaults/delete-vault-dialog.tsx`):
+- Title: `Delete "<vault name>"?`
+- Body educates, in plain language:
+  - Moves to trash; **recoverable for 30 days**, then permanently deleted.
+  - States the file/attachment count being moved to trash.
+  - **Remote-only:** "This only deletes the copy stored on Engram. Files already
+    synced to your devices stay where they are."
+- Type-to-confirm: an input that must match the vault name; the red
+  **Delete vault** button (`Trash2` icon, destructive) stays disabled until it
+  matches. Reuses the existing delete mutation.
+- Cancel closes without action.
+
+## Data Flow
+
+1. `GET /api/vaults` and `GET /api/vaults?deleted=true` now return
+   `note_count` + `attachment_count` per vault.
+2. Table rows render counts directly from the query data.
+3. Delete: trash icon → modal → type name → confirm → existing
+   `useDeleteVault` mutation → list invalidates → row moves to trash table.
+
+## Testing
+
+- **Backend:** counts exclude soft-deleted children; counts scoped per-vault and
+  per-user (no cross-tenant bleed); empty vault returns `0/0`; `deleted=true`
+  list carries counts.
+- **Frontend:** table renders counts; delete button disabled until typed name
+  matches; matching name enables it and firing it calls the mutation; modal shows
+  the remote-only + 30-day copy; trash table renders counts + purge date.
+
+## Out of Scope
+
+- Live-updating counts via websocket (counts are snapshot-at-fetch; list
+  refetch on mutation is enough).
+- Sorting/pagination of the vault table.
+- Changing the permanent-delete (purge) confirm — stays `window.confirm`.

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -310,6 +310,8 @@ export interface Vault {
   cooldown_days: number | null
   deleted_at?: string | null
   purge_at?: string | null
+  note_count?: number
+  attachment_count?: number
 }
 
 export interface EncryptionProgress {

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & { showCloseButton?: boolean }) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border bg-popover bg-clip-padding p-6 text-sm text-popover-foreground shadow-lg duration-200 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-3 right-3"
+              size="icon-sm"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="dialog-header" className={cn("flex flex-col gap-1", className)} {...props} />
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("font-heading text-base font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogClose,
+  DialogPortal,
+  DialogOverlay,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/frontend/src/settings/vaults/active-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.test.tsx
@@ -4,8 +4,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const deleteMutate = vi.fn()
 const updateMutate = vi.fn()
 const vaults = [
-  { id: 1, name: 'Work', description: null, slug: 'work', is_default: true, created_at: '', encrypted: true },
-  { id: 2, name: 'Personal', description: null, slug: 'personal', is_default: false, created_at: '', encrypted: true },
+  { id: 1, name: 'Work', description: null, slug: 'work', is_default: true, created_at: '', encrypted: true, encryption_status: 'none', encrypted_at: null, decrypt_requested_at: null, last_toggle_at: null, cooldown_days: null, note_count: 12, attachment_count: 3 },
+  { id: 2, name: 'Personal', description: null, slug: 'personal', is_default: false, created_at: '', encrypted: true, encryption_status: 'none', encrypted_at: null, decrypt_requested_at: null, last_toggle_at: null, cooldown_days: null, note_count: 0, attachment_count: 0 },
 ]
 
 vi.mock('@/api/queries', () => ({
@@ -20,28 +20,28 @@ import { ActiveVaultsSection } from './active-vaults-section'
 describe('ActiveVaultsSection', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('lists vaults and marks the default', () => {
+  it('lists vaults with counts and marks the default', () => {
     render(<ActiveVaultsSection />)
-    expect(screen.getByText('Work')).toBeInTheDocument()
-    expect(screen.getByText('Personal')).toBeInTheDocument()
+    const workRow = within(screen.getByText('Work').closest('tr') as HTMLElement)
+    expect(workRow.getByText('12')).toBeInTheDocument()
+    expect(workRow.getByText('3')).toBeInTheDocument()
     expect(screen.getByText('Default')).toBeInTheDocument()
   })
 
-  it('keeps delete disabled until the vault name is typed', async () => {
+  it('opens the delete dialog and deletes after typing the name', async () => {
     render(<ActiveVaultsSection />)
-    const workRow = within(screen.getByText('Work').closest('li') as HTMLElement)
-    fireEvent.click(workRow.getByRole('button', { name: /^delete$/i }))
+    const workRow = within(screen.getByText('Work').closest('tr') as HTMLElement)
+    fireEvent.click(workRow.getByRole('button', { name: /delete .*work/i }))
     const confirmBtn = screen.getByRole('button', { name: /delete vault/i })
     expect(confirmBtn).toBeDisabled()
     fireEvent.change(screen.getByLabelText(/type .*work.* to confirm/i), { target: { value: 'Work' } })
-    expect(confirmBtn).toBeEnabled()
     fireEvent.click(confirmBtn)
     await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith(1, expect.anything()))
   })
 
   it('sets a non-default vault as default', () => {
     render(<ActiveVaultsSection />)
-    fireEvent.click(screen.getByRole('button', { name: /set default/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set .*personal.* as default/i }))
     expect(updateMutate).toHaveBeenCalledWith({ id: 2, is_default: true }, expect.anything())
   })
 })

--- a/frontend/src/settings/vaults/active-vaults-section.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.tsx
@@ -1,34 +1,59 @@
 import { useState } from 'react'
+import { Pencil, Star, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { SettingsSectionCard } from '@/settings/account/section-card'
-import { useVaults, useDeleteVault, useUpdateVault, type Vault } from '@/api/queries'
+import { useVaults, useUpdateVault, type Vault } from '@/api/queries'
+import { DeleteVaultDialog } from './delete-vault-dialog'
 
 const inputClass =
-  'mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
+  'block w-full rounded-md border border-input bg-card px-2 py-1 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
 
 export function ActiveVaultsSection() {
   const { data: vaults, isLoading } = useVaults()
+  const [deleteTarget, setDeleteTarget] = useState<Vault | null>(null)
 
   return (
     <SettingsSectionCard title="Vaults" description="Rename, set a default, or delete your vaults.">
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
-      <ul className="divide-y divide-border">
-        {(vaults ?? []).map((v) => (
-          <VaultRow key={v.id} vault={v} />
-        ))}
-      </ul>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-left text-xs text-muted-foreground">
+            <th className="py-2 font-medium">Name</th>
+            <th className="py-2 text-right font-medium">Files</th>
+            <th className="py-2 text-right font-medium">Attachments</th>
+            <th className="py-2" aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {(vaults ?? []).map((v) => (
+            <VaultRow key={v.id} vault={v} onDelete={() => setDeleteTarget(v)} />
+          ))}
+          {!isLoading && (vaults ?? []).length === 0 && (
+            <tr>
+              <td colSpan={4} className="py-3 text-muted-foreground">
+                No vaults yet.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+
+      {deleteTarget && (
+        <DeleteVaultDialog
+          vault={deleteTarget}
+          open={deleteTarget !== null}
+          onOpenChange={(open) => !open && setDeleteTarget(null)}
+        />
+      )}
     </SettingsSectionCard>
   )
 }
 
-function VaultRow({ vault }: { vault: Vault }) {
+function VaultRow({ vault, onDelete }: { vault: Vault; onDelete: () => void }) {
   const update = useUpdateVault()
-  const del = useDeleteVault()
   const [renaming, setRenaming] = useState(false)
   const [name, setName] = useState(vault.name)
-  const [confirming, setConfirming] = useState(false)
-  const [phrase, setPhrase] = useState('')
 
   function saveName() {
     const next = name.trim()
@@ -39,8 +64,8 @@ function VaultRow({ vault }: { vault: Vault }) {
   }
 
   return (
-    <li className="py-3">
-      <div className="flex items-center justify-between gap-3">
+    <tr>
+      <td className="py-3">
         {renaming ? (
           <input
             autoFocus
@@ -52,54 +77,54 @@ function VaultRow({ vault }: { vault: Vault }) {
             onKeyDown={(e) => e.key === 'Enter' && saveName()}
           />
         ) : (
-          <button type="button" className="text-sm font-medium text-foreground" onClick={() => setRenaming(true)}>
-            {vault.name}
-          </button>
+          <span className="flex items-center gap-2">
+            <span className="font-medium text-foreground">{vault.name}</span>
+            {vault.is_default && (
+              <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">Default</span>
+            )}
+          </span>
         )}
-        <div className="flex items-center gap-2">
-          {vault.is_default ? (
-            <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">Default</span>
-          ) : (
+      </td>
+      <td className="py-3 text-right tabular-nums text-muted-foreground">{vault.note_count ?? 0}</td>
+      <td className="py-3 text-right tabular-nums text-muted-foreground">{vault.attachment_count ?? 0}</td>
+      <td className="py-3">
+        <span className="flex items-center justify-end gap-1">
+          {!vault.is_default && (
             <Button
               variant="ghost"
-              size="sm"
+              size="icon-sm"
+              title={`Set ${vault.name} as default`}
+              aria-label={`Set ${vault.name} as default`}
               onClick={() =>
-                update.mutate({ id: vault.id, is_default: true }, { onError: () => toast.error('Could not set default') })
+                update.mutate(
+                  { id: vault.id, is_default: true },
+                  { onError: () => toast.error('Could not set default') },
+                )
               }
             >
-              Set default
+              <Star />
             </Button>
           )}
-          <Button variant="ghost" size="sm" onClick={() => setConfirming((c) => !c)}>
-            Delete
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            title={`Rename ${vault.name}`}
+            aria-label={`Rename ${vault.name}`}
+            onClick={() => setRenaming(true)}
+          >
+            <Pencil />
           </Button>
-        </div>
-      </div>
-      {confirming && (
-        <form
-          className="mt-3 rounded-md border border-destructive/40 bg-destructive/5 p-3"
-          onSubmit={(e) => {
-            e.preventDefault()
-            del.mutate(vault.id, {
-              onSuccess: () => toast.success('Vault deleted'),
-              onError: () => toast.error('Delete failed'),
-            })
-          }}
-        >
-          <label className="block text-sm text-foreground">
-            Type "{vault.name}" to confirm
-            <input
-              className={inputClass}
-              aria-label={`Type ${vault.name} to confirm`}
-              value={phrase}
-              onChange={(e) => setPhrase(e.target.value)}
-            />
-          </label>
-          <Button className="mt-3" type="submit" variant="destructive" size="sm" disabled={phrase !== vault.name}>
-            Delete vault
+          <Button
+            variant="destructive"
+            size="icon-sm"
+            title={`Delete ${vault.name}`}
+            aria-label={`Delete ${vault.name}`}
+            onClick={onDelete}
+          >
+            <Trash2 />
           </Button>
-        </form>
-      )}
-    </li>
+        </span>
+      </td>
+    </tr>
   )
 }

--- a/frontend/src/settings/vaults/delete-vault-dialog.test.tsx
+++ b/frontend/src/settings/vaults/delete-vault-dialog.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const deleteMutate = vi.fn()
+vi.mock('@/api/queries', () => ({
+  useDeleteVault: () => ({ mutate: deleteMutate, isPending: false }),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { DeleteVaultDialog } from './delete-vault-dialog'
+
+const vault = {
+  id: 7,
+  name: 'Work',
+  description: null,
+  slug: 'work',
+  is_default: false,
+  created_at: '',
+  encrypted: true,
+  encryption_status: 'encrypted' as const,
+  encrypted_at: null,
+  decrypt_requested_at: null,
+  last_toggle_at: null,
+  cooldown_days: null,
+  note_count: 142,
+  attachment_count: 3,
+}
+
+describe('DeleteVaultDialog', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('educates about the 30-day window and remote-only scope', () => {
+    render(<DeleteVaultDialog vault={vault} open onOpenChange={() => {}} />)
+    expect(screen.getByText(/30 days/i)).toBeInTheDocument()
+    expect(screen.getByText(/synced to your devices/i)).toBeInTheDocument()
+    expect(screen.getByText(/142/)).toBeInTheDocument()
+  })
+
+  it('keeps the delete button disabled until the name is typed', async () => {
+    render(<DeleteVaultDialog vault={vault} open onOpenChange={() => {}} />)
+    const confirmBtn = screen.getByRole('button', { name: /delete vault/i })
+    expect(confirmBtn).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/type .*work.* to confirm/i), { target: { value: 'Work' } })
+    expect(confirmBtn).toBeEnabled()
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith(7, expect.anything()))
+  })
+})

--- a/frontend/src/settings/vaults/delete-vault-dialog.tsx
+++ b/frontend/src/settings/vaults/delete-vault-dialog.tsx
@@ -77,7 +77,6 @@ export function DeleteVaultDialog({
             <input
               autoFocus
               className={inputClass}
-              aria-label={`Type ${vault.name} to confirm`}
               value={phrase}
               onChange={(e) => setPhrase(e.target.value)}
             />

--- a/frontend/src/settings/vaults/delete-vault-dialog.tsx
+++ b/frontend/src/settings/vaults/delete-vault-dialog.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useDeleteVault, type Vault } from '@/api/queries'
+
+const inputClass =
+  'mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring'
+
+export function DeleteVaultDialog({
+  vault,
+  open,
+  onOpenChange,
+}: {
+  vault: Vault
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const del = useDeleteVault()
+  const [phrase, setPhrase] = useState('')
+
+  useEffect(() => {
+    if (!open) setPhrase('')
+  }, [open])
+
+  const noteCount = vault.note_count ?? 0
+  const attachmentCount = vault.attachment_count ?? 0
+
+  function confirmDelete() {
+    del.mutate(vault.id, {
+      onSuccess: () => {
+        toast.success('Vault moved to trash')
+        onOpenChange(false)
+      },
+      onError: () => toast.error('Delete failed'),
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete "{vault.name}"?</DialogTitle>
+          <DialogDescription>
+            This vault holds {noteCount} {noteCount === 1 ? 'note' : 'notes'} and {attachmentCount}{' '}
+            {attachmentCount === 1 ? 'attachment' : 'attachments'}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>
+            It moves to trash and is <strong className="text-foreground">recoverable for 30 days</strong>, then
+            permanently deleted.
+          </li>
+          <li>
+            This only deletes the copy stored on Engram. Files already{' '}
+            <strong className="text-foreground">synced to your devices</strong> stay where they are.
+          </li>
+        </ul>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            confirmDelete()
+          }}
+        >
+          <label className="block text-sm text-foreground">
+            Type "{vault.name}" to confirm
+            <input
+              autoFocus
+              className={inputClass}
+              aria-label={`Type ${vault.name} to confirm`}
+              value={phrase}
+              onChange={(e) => setPhrase(e.target.value)}
+            />
+          </label>
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="destructive"
+              size="sm"
+              disabled={phrase !== vault.name || del.isPending}
+            >
+              <Trash2 />
+              Delete vault
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router'
@@ -16,6 +16,8 @@ const deleted = [
     encrypted: true,
     deleted_at: '2026-05-28T00:00:00Z',
     purge_at: '2026-06-27T00:00:00Z',
+    note_count: 5,
+    attachment_count: 2,
   },
 ]
 let activeCount = 1
@@ -42,14 +44,16 @@ describe('DeletedVaultsSection', () => {
     activeCount = 1
   })
 
-  it('shows the purge date', () => {
+  it('shows counts and the purge date', () => {
     renderWithRouter(<DeletedVaultsSection />)
-    expect(screen.getByText('Old')).toBeInTheDocument()
+    const row = within(screen.getByText('Old').closest('tr') as HTMLElement)
+    expect(row.getByText('5')).toBeInTheDocument()
+    expect(row.getByText('2')).toBeInTheDocument()
     expect(screen.getByText(/purges/i)).toBeInTheDocument()
   })
 
   it('disables restore when at the cap', () => {
-    activeCount = 1 // cap is 1, so restoring would exceed
+    activeCount = 1
     renderWithRouter(<DeletedVaultsSection />)
     expect(screen.getByRole('button', { name: /restore/i })).toBeDisabled()
   })
@@ -66,19 +70,19 @@ describe('DeletedVaultsSection', () => {
   it('purges permanently when confirmed', async () => {
     window.confirm = vi.fn().mockReturnValue(true)
     renderWithRouter(<DeletedVaultsSection />)
-    fireEvent.click(screen.getByRole('button', { name: /delete permanently/i }))
+    fireEvent.click(screen.getByRole('button', { name: /permanently delete .*old/i }))
     await waitFor(() => expect(purgeMutate).toHaveBeenCalledWith(5, expect.anything()))
   })
 
   it('does not purge when confirmation is dismissed', () => {
     window.confirm = vi.fn().mockReturnValue(false)
     renderWithRouter(<DeletedVaultsSection />)
-    fireEvent.click(screen.getByRole('button', { name: /delete permanently/i }))
+    fireEvent.click(screen.getByRole('button', { name: /permanently delete .*old/i }))
     expect(purgeMutate).not.toHaveBeenCalled()
   })
 
   it('highlights the row matching ?highlight=<id>', () => {
     renderWithRouter(<DeletedVaultsSection />, { route: '/settings/vaults?highlight=5' })
-    expect(screen.getByText('Old').closest('li')).toHaveAttribute('data-highlighted', 'true')
+    expect(screen.getByText('Old').closest('tr')).toHaveAttribute('data-highlighted', 'true')
   })
 })

--- a/frontend/src/settings/vaults/deleted-vaults-section.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.tsx
@@ -1,4 +1,5 @@
 import { toast } from 'sonner'
+import { RotateCcw, Trash2 } from 'lucide-react'
 import { useSearchParams } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { SettingsSectionCard } from '@/settings/account/section-card'
@@ -20,11 +21,22 @@ export function DeletedVaultsSection() {
       title="Recently deleted"
       description="Deleted vaults are kept for 30 days. Restore them, or remove them permanently."
     >
-      <ul className="divide-y divide-border">
-        {deleted.map((v) => (
-          <DeletedRow key={v.id} vault={v} />
-        ))}
-      </ul>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-left text-xs text-muted-foreground">
+            <th className="py-2 font-medium">Name</th>
+            <th className="py-2 text-right font-medium">Files</th>
+            <th className="py-2 text-right font-medium">Attachments</th>
+            <th className="py-2 font-medium">Purges</th>
+            <th className="py-2" aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {deleted.map((v) => (
+            <DeletedRow key={v.id} vault={v} />
+          ))}
+        </tbody>
+      </table>
     </SettingsSectionCard>
   )
 }
@@ -38,58 +50,60 @@ function DeletedRow({ vault }: { vault: Vault }) {
   const cap = billing?.vaults_cap ?? Infinity
   const activeCount = active?.length ?? 0
   const overCap = activeCount >= cap
-  const purgeDate = vault.purge_at ? new Date(vault.purge_at).toLocaleDateString() : null
+  const purgeDate = vault.purge_at ? new Date(vault.purge_at).toLocaleDateString() : '—'
 
   const [searchParams] = useSearchParams()
-  const highlightId = searchParams.get('highlight')
-  const highlighted = highlightId === String(vault.id)
+  const highlighted = searchParams.get('highlight') === String(vault.id)
 
   return (
-    <li
+    <tr
       data-highlighted={highlighted || undefined}
-      className={`flex items-center justify-between gap-3 py-3 ${
-        highlighted ? 'rounded-md bg-accent/40 ring-1 ring-ring' : ''
-      }`}
+      className={highlighted ? 'bg-accent/40 ring-1 ring-ring' : ''}
     >
-      <div>
-        <p className="text-sm font-medium text-foreground">{vault.name}</p>
-        {purgeDate && <p className="text-xs text-muted-foreground">Purges {purgeDate}</p>}
-      </div>
-      <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={overCap || restore.isPending}
-          title={
-            overCap
-              ? 'Restoring would exceed your vault limit. Upgrade or delete another vault first.'
-              : undefined
-          }
-          onClick={() =>
-            restore.mutate(vault.id, {
-              onSuccess: () => toast.success('Vault restored'),
-              onError: () => toast.error('Could not restore (vault limit reached?)'),
-            })
-          }
-        >
-          Restore
-        </Button>
-        <Button
-          variant="destructive"
-          size="sm"
-          disabled={purge.isPending}
-          onClick={() => {
-            if (window.confirm(`Permanently delete "${vault.name}"? This cannot be undone.`)) {
-              purge.mutate(vault.id, {
-                onSuccess: () => toast.success('Vault permanently deleted'),
-                onError: () => toast.error('Could not delete'),
+      <td className="py-3 font-medium text-foreground">{vault.name}</td>
+      <td className="py-3 text-right tabular-nums text-muted-foreground">{vault.note_count ?? 0}</td>
+      <td className="py-3 text-right tabular-nums text-muted-foreground">{vault.attachment_count ?? 0}</td>
+      <td className="py-3 text-muted-foreground">{purgeDate}</td>
+      <td className="py-3">
+        <span className="flex items-center justify-end gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={overCap || restore.isPending}
+            title={
+              overCap
+                ? 'Restoring would exceed your vault limit. Upgrade or delete another vault first.'
+                : undefined
+            }
+            onClick={() =>
+              restore.mutate(vault.id, {
+                onSuccess: () => toast.success('Vault restored'),
+                onError: () => toast.error('Could not restore (vault limit reached?)'),
               })
             }
-          }}
-        >
-          Delete permanently
-        </Button>
-      </div>
-    </li>
+          >
+            <RotateCcw />
+            Restore
+          </Button>
+          <Button
+            variant="destructive"
+            size="icon-sm"
+            title={`Permanently delete ${vault.name}`}
+            aria-label={`Permanently delete ${vault.name}`}
+            disabled={purge.isPending}
+            onClick={() => {
+              if (window.confirm(`Permanently delete "${vault.name}"? This cannot be undone.`)) {
+                purge.mutate(vault.id, {
+                  onSuccess: () => toast.success('Vault permanently deleted'),
+                  onError: () => toast.error('Could not delete'),
+                })
+              }
+            }}
+          >
+            <Trash2 />
+          </Button>
+        </span>
+      </td>
+    </tr>
   )
 }

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -207,6 +207,62 @@ defmodule Engram.Vaults do
     end
   end
 
+  # ── Content counts ───────────────────────────────────────────────────────
+
+  @zero_counts %{notes: 0, attachments: 0}
+
+  @doc """
+  Returns a map of `%{vault_id => %{notes: n, attachments: m}}` for the given
+  vaults, counting only non-deleted notes/attachments owned by `user`.
+
+  Two batched GROUP BY queries (one per table) — no N+1. Tenant scoping is the
+  explicit `user_id == ^user_id` clause; RLS is bypassed (`skip_tenant_check:
+  true`) for performance, matching `list_for_ids/2`. The clause MUST stay.
+  """
+  @spec content_counts_for(Engram.Accounts.User.t(), [Vault.t()]) ::
+          %{integer() => %{notes: integer(), attachments: integer()}}
+  def content_counts_for(%Engram.Accounts.User{id: user_id}, vaults) when is_list(vaults) do
+    ids = Enum.map(vaults, & &1.id)
+    do_content_counts(user_id, ids)
+  end
+
+  @doc """
+  Returns `%{notes: n, attachments: m}` for a single vault id owned by `user`.
+  """
+  @spec content_counts(Engram.Accounts.User.t(), integer()) :: %{
+          notes: integer(),
+          attachments: integer()
+        }
+  def content_counts(%Engram.Accounts.User{id: user_id}, vault_id) do
+    Map.get(do_content_counts(user_id, [vault_id]), vault_id, @zero_counts)
+  end
+
+  defp do_content_counts(_user_id, []), do: %{}
+
+  defp do_content_counts(user_id, ids) do
+    note_counts =
+      from(n in Engram.Notes.Note,
+        where: n.user_id == ^user_id and n.vault_id in ^ids and is_nil(n.deleted_at),
+        group_by: n.vault_id,
+        select: {n.vault_id, count(n.id)}
+      )
+      |> Repo.all(skip_tenant_check: true)
+      |> Map.new()
+
+    attachment_counts =
+      from(a in Engram.Attachments.Attachment,
+        where: a.user_id == ^user_id and a.vault_id in ^ids and is_nil(a.deleted_at),
+        group_by: a.vault_id,
+        select: {a.vault_id, count(a.id)}
+      )
+      |> Repo.all(skip_tenant_check: true)
+      |> Map.new()
+
+    Map.new(ids, fn id ->
+      {id, %{notes: Map.get(note_counts, id, 0), attachments: Map.get(attachment_counts, id, 0)}}
+    end)
+  end
+
   # ── Get ─────────────────────────────────────────────────────────────────────
 
   @doc """

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -4,18 +4,28 @@ defmodule EngramWeb.VaultsController do
   alias Engram.Billing
   alias Engram.Vaults
 
+  @zero_counts %{notes: 0, attachments: 0}
+
   # ── index ──────────────────────────────────────────────────────────────────
 
   def index(conn, %{"deleted" => "true"}) do
     user = conn.assigns.current_user
     vaults = Vaults.list_deleted_vaults(user)
-    json(conn, %{vaults: Enum.map(vaults, &deleted_vault_json(&1, user))})
+    counts = Vaults.content_counts_for(user, vaults)
+
+    json(conn, %{
+      vaults: Enum.map(vaults, &deleted_vault_json(&1, Map.get(counts, &1.id, @zero_counts)))
+    })
   end
 
   def index(conn, _params) do
     user = conn.assigns.current_user
     vaults = Vaults.list_vaults(user)
-    json(conn, %{vaults: Enum.map(vaults, &vault_json(&1, user))})
+    counts = Vaults.content_counts_for(user, vaults)
+
+    json(conn, %{
+      vaults: Enum.map(vaults, &vault_json(&1, Map.get(counts, &1.id, @zero_counts)))
+    })
   end
 
   # ── create ─────────────────────────────────────────────────────────────────
@@ -27,7 +37,7 @@ defmodule EngramWeb.VaultsController do
       {:ok, vault} ->
         conn
         |> put_status(201)
-        |> json(%{vault: vault_json(vault, user)})
+        |> json(%{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
 
       {:error, :vault_limit_reached} ->
         limit = Billing.effective_limit(user, :vaults_cap)
@@ -51,7 +61,7 @@ defmodule EngramWeb.VaultsController do
     case parse_id(id) do
       {:ok, vault_id} ->
         case Vaults.get_vault(user, vault_id) do
-          {:ok, vault} -> json(conn, %{vault: vault_json(vault, user)})
+          {:ok, vault} -> json(conn, %{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
           {:error, :not_found} -> not_found(conn)
         end
 
@@ -70,7 +80,7 @@ defmodule EngramWeb.VaultsController do
       {:ok, vault_id} ->
         case Vaults.update_vault(user, vault_id, attrs) do
           {:ok, vault} ->
-            json(conn, %{vault: vault_json(vault, user)})
+            json(conn, %{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
 
           {:error, :not_found} ->
             not_found(conn)
@@ -112,7 +122,7 @@ defmodule EngramWeb.VaultsController do
       {:ok, vault_id} ->
         case Vaults.restore_vault(user, vault_id) do
           {:ok, vault} ->
-            json(conn, %{vault: vault_json(vault, user)})
+            json(conn, %{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
 
           {:error, :limit_reached} ->
             limit = Billing.effective_limit(user, :vaults_cap)
@@ -166,10 +176,10 @@ defmodule EngramWeb.VaultsController do
         {:ok, vault, :created} ->
           conn
           |> put_status(201)
-          |> json(vault_json(vault, user) |> Map.put(:status, "created"))
+          |> json(vault_json(vault, Vaults.content_counts(user, vault.id)) |> Map.put(:status, "created"))
 
         {:ok, vault, :existing} ->
-          json(conn, vault_json(vault, user) |> Map.put(:status, "existing"))
+          json(conn, vault_json(vault, Vaults.content_counts(user, vault.id)) |> Map.put(:status, "existing"))
 
         {:error, :vault_limit_reached} ->
           limit = Billing.effective_limit(user, :vaults_cap)
@@ -183,7 +193,7 @@ defmodule EngramWeb.VaultsController do
 
   # ── Private ────────────────────────────────────────────────────────────────
 
-  defp vault_json(vault, _user) do
+  defp vault_json(vault, counts) do
     %{
       id: vault.id,
       name: vault.name,
@@ -194,13 +204,15 @@ defmodule EngramWeb.VaultsController do
       # Phase B.4: encryption is mandatory and one-way. Surfaced as a
       # constant `true` for clients still consuming this field; the toggle
       # is gone.
-      encrypted: true
+      encrypted: true,
+      note_count: counts.notes,
+      attachment_count: counts.attachments
     }
   end
 
-  defp deleted_vault_json(vault, user) do
+  defp deleted_vault_json(vault, counts) do
     vault
-    |> vault_json(user)
+    |> vault_json(counts)
     |> Map.merge(%{
       deleted_at: vault.deleted_at,
       purge_at: purge_at(vault.deleted_at)

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -61,8 +61,11 @@ defmodule EngramWeb.VaultsController do
     case parse_id(id) do
       {:ok, vault_id} ->
         case Vaults.get_vault(user, vault_id) do
-          {:ok, vault} -> json(conn, %{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
-          {:error, :not_found} -> not_found(conn)
+          {:ok, vault} ->
+            json(conn, %{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
+
+          {:error, :not_found} ->
+            not_found(conn)
         end
 
       :error ->
@@ -176,10 +179,17 @@ defmodule EngramWeb.VaultsController do
         {:ok, vault, :created} ->
           conn
           |> put_status(201)
-          |> json(vault_json(vault, Vaults.content_counts(user, vault.id)) |> Map.put(:status, "created"))
+          |> json(
+            vault_json(vault, Vaults.content_counts(user, vault.id))
+            |> Map.put(:status, "created")
+          )
 
         {:ok, vault, :existing} ->
-          json(conn, vault_json(vault, Vaults.content_counts(user, vault.id)) |> Map.put(:status, "existing"))
+          json(
+            conn,
+            vault_json(vault, Vaults.content_counts(user, vault.id))
+            |> Map.put(:status, "existing")
+          )
 
         {:error, :vault_limit_reached} ->
           limit = Billing.effective_limit(user, :vaults_cap)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.247",
+      version: "0.5.248",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -128,6 +128,58 @@ defmodule Engram.VaultsTest do
   end
 
   # ---------------------------------------------------------------------------
+  # content_counts_for/2 and content_counts/2
+  # ---------------------------------------------------------------------------
+
+  describe "content_counts_for/2 and content_counts/2" do
+    setup %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, a} = Vaults.create_vault(user, %{name: "Alpha"})
+      {:ok, b} = Vaults.create_vault(user, %{name: "Beta"})
+      %{a: a, b: b}
+    end
+
+    test "counts active notes and attachments per vault", %{user: user, a: a, b: b} do
+      insert_pair(:note, user: user, vault: a)
+      insert(:note, user: user, vault: b)
+      insert(:attachment, user: user, vault: a)
+
+      counts = Vaults.content_counts_for(user, [a, b])
+
+      assert counts[a.id] == %{notes: 2, attachments: 1}
+      assert counts[b.id] == %{notes: 1, attachments: 0}
+    end
+
+    test "excludes soft-deleted notes and attachments", %{user: user, a: a} do
+      insert(:note, user: user, vault: a)
+      insert(:note, user: user, vault: a, deleted_at: DateTime.utc_now(:second))
+      insert(:attachment, user: user, vault: a, deleted_at: DateTime.utc_now(:second))
+
+      assert Vaults.content_counts_for(user, [a])[a.id] == %{notes: 1, attachments: 0}
+    end
+
+    test "does not bleed across users", %{user: user, other_user: other, a: a} do
+      insert(:note, user: other, vault: build(:vault, user: other))
+      insert(:note, user: user, vault: a)
+
+      assert Vaults.content_counts_for(user, [a])[a.id] == %{notes: 1, attachments: 0}
+    end
+
+    test "empty vault list returns empty map", %{user: user} do
+      assert Vaults.content_counts_for(user, []) == %{}
+    end
+
+    test "content_counts/2 returns a single vault's counts", %{user: user, a: a} do
+      insert(:note, user: user, vault: a)
+      assert Vaults.content_counts(user, a.id) == %{notes: 1, attachments: 0}
+    end
+
+    test "content_counts/2 returns zeros for an empty vault", %{user: user, b: b} do
+      assert Vaults.content_counts(user, b.id) == %{notes: 0, attachments: 0}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # register_vault/3
   # ---------------------------------------------------------------------------
 

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -165,6 +165,20 @@ defmodule Engram.VaultsTest do
       assert Vaults.content_counts_for(user, [a])[a.id] == %{notes: 1, attachments: 0}
     end
 
+    # Structurally proves the user_id guard fires: this note shares vault a's id
+    # but belongs to `other`. Vault-id filtering alone would count it; only the
+    # explicit user_id clause excludes it.
+    test "user_id guard excludes another user's row on the same vault_id", %{
+      user: user,
+      other_user: other,
+      a: a
+    } do
+      insert(:note, user: other, vault: a)
+      insert(:note, user: user, vault: a)
+
+      assert Vaults.content_counts_for(user, [a])[a.id] == %{notes: 1, attachments: 0}
+    end
+
     test "empty vault list returns empty map", %{user: user} do
       assert Vaults.content_counts_for(user, []) == %{}
     end

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -56,6 +56,19 @@ defmodule EngramWeb.VaultsControllerTest do
 
       assert json_response(conn, 401)
     end
+
+    test "index includes note_count and attachment_count", %{conn: conn, user: user} do
+      vault = insert(:vault, user: user)
+      insert(:note, user: user, vault: vault)
+      insert(:note, user: user, vault: vault)
+      insert(:attachment, user: user, vault: vault)
+
+      resp = conn |> get(~p"/api/vaults") |> json_response(200)
+      row = Enum.find(resp["vaults"], &(&1["id"] == vault.id))
+
+      assert row["note_count"] == 2
+      assert row["attachment_count"] == 1
+    end
   end
 
   describe "POST /api/vaults" do

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -161,8 +161,10 @@ defmodule EngramWeb.VaultsControllerTest do
   end
 
   describe "GET /api/vaults?deleted=true" do
-    test "lists soft-deleted vaults with a purge_at", %{conn: conn, user: user} do
+    test "lists soft-deleted vaults with a purge_at and content counts", %{conn: conn, user: user} do
       {:ok, v} = Vaults.create_vault(user, %{name: "Trashed"})
+      insert(:note, user: user, vault: v)
+      insert(:attachment, user: user, vault: v)
       {:ok, _} = Vaults.delete_vault(user, v.id)
 
       body = conn |> get("/api/vaults?deleted=true") |> json_response(200)
@@ -170,6 +172,8 @@ defmodule EngramWeb.VaultsControllerTest do
       assert item["id"] == v.id
       assert item["deleted_at"]
       assert item["purge_at"]
+      assert item["note_count"] == 1
+      assert item["attachment_count"] == 1
     end
 
     test "active listing excludes deleted vaults", %{conn: conn, user: user} do


### PR DESCRIPTION
## Summary
Refines the vault settings page (follow-up to #345):
- **Per-vault content counts** — backend exposes `note_count` + `attachment_count` on the vault JSON for the active list, trash list, and single-vault responses. Counts are active-only (`deleted_at IS NULL`), batched via one `GROUP BY` per table (no N+1), tenant-scoped with an explicit `user_id` clause (`skip_tenant_check: true`, matching `list_for_ids/2`).
- **Tables** — the active-vaults list and the "Recently deleted" trash list are now semantic `<table>`s with Files / Attachments columns (trash adds a Purges column).
- **Educational delete modal** — new shadcn `Dialog` primitive + `DeleteVaultDialog` replaces the old inline confirm. It explains the 30-day soft-delete recovery window, calls out that deletion is **remote-only** (files synced to the user's devices are untouched), shows the content count, and keeps a type-to-confirm gate behind a red `Trash2` destructive button. Permanent purge of trashed vaults still uses `window.confirm`.

Version: 0.5.247 → 0.5.248.

## Test plan
- [x] Backend `mix test` — 1760 tests, 0 failures (incl. new count tests + a test proving the `user_id` guard fires on a shared `vault_id`)
- [x] Frontend `bunx vitest run` — 100 tests pass
- [x] `bunx tsc --noEmit` clean · `mix format` clean
- [ ] Manual browser smoke on staging: create → rename → set-default → delete (modal) → restore → permanent delete; verify counts render and the empty-vault state still degrades gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)