### PR TITLE
fix(billing): InactivityCleanup → effective_limit (#232)

### DIFF
--- a/lib/engram/workers/inactivity_cleanup.ex
+++ b/lib/engram/workers/inactivity_cleanup.ex
@@ -34,6 +34,11 @@ defmodule Engram.Workers.InactivityCleanup do
   @days_90 90
   @hard_delete_after_days 30
 
+  # Conservative SQL pre-filter for the soft-delete sweep. Per-user
+  # `inactivity_delete_days` is then applied in Elixir; this floor just
+  # avoids loading every user with a usage_meters row.
+  @soft_delete_sql_floor_days 30
+
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
     sweep_60_day_warning()
@@ -62,7 +67,7 @@ defmodule Engram.Workers.InactivityCleanup do
       )
 
     Enum.each(users, fn user ->
-      if free?(user) do
+      if warn_enabled?(user) do
         _ = Mailer.send_inactivity_warning_60(user)
 
         user
@@ -97,7 +102,7 @@ defmodule Engram.Workers.InactivityCleanup do
       )
 
     Enum.each(users, fn user ->
-      if free?(user) do
+      if warn_enabled?(user) do
         _ = Mailer.send_inactivity_warning_80(user)
 
         user
@@ -114,24 +119,39 @@ defmodule Engram.Workers.InactivityCleanup do
   end
 
   defp sweep_soft_delete do
-    cutoff = days_ago(@days_90)
+    floor_cutoff = days_ago(@soft_delete_sql_floor_days)
+    now = DateTime.utc_now()
 
-    users =
+    candidates =
       Repo.all(
         from(u in User,
           join: m in "usage_meters",
           on: m.user_id == u.id,
-          where: is_nil(u.deleted_at) and m.last_active_at < ^cutoff
+          where: is_nil(u.deleted_at) and m.last_active_at < ^floor_cutoff,
+          select: {u, m.last_active_at}
         ),
         skip_tenant_check: true
       )
 
-    Enum.each(users, fn user ->
-      if free?(user) do
-        soft_delete(user)
+    Enum.each(candidates, fn {user, last_active_at} ->
+      case delete_after_days(user) do
+        days when is_integer(days) and days > 0 ->
+          cutoff = DateTime.add(now, -days * 86_400, :second)
+          if compare_lt?(last_active_at, cutoff), do: soft_delete(user)
+
+        _ ->
+          :skip
       end
     end)
   end
+
+  # Raw column lands as NaiveDateTime when joined via string table name;
+  # coerce to DateTime so the comparison works regardless of how the row
+  # was selected.
+  defp compare_lt?(%DateTime{} = a, %DateTime{} = b), do: DateTime.compare(a, b) == :lt
+
+  defp compare_lt?(%NaiveDateTime{} = a, %DateTime{} = b),
+    do: DateTime.compare(DateTime.from_naive!(a, "Etc/UTC"), b) == :lt
 
   defp soft_delete(user) do
     # Drop Qdrant points — vault rows survive so the audit trail stays.
@@ -223,7 +243,13 @@ defmodule Engram.Workers.InactivityCleanup do
       :error
   end
 
-  defp free?(user), do: Billing.tier(user) == :free
+  defp warn_enabled?(user) do
+    Billing.effective_limit(user, :inactivity_warn_60_days) == true
+  end
+
+  defp delete_after_days(user) do
+    Billing.effective_limit(user, :inactivity_delete_days)
+  end
 
   defp days_ago(days) do
     DateTime.utc_now() |> DateTime.add(-days * 86_400, :second)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.256",
+      version: "0.5.257",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/workers/inactivity_cleanup_test.exs
+++ b/test/engram/workers/inactivity_cleanup_test.exs
@@ -181,4 +181,73 @@ defmodule Engram.Workers.InactivityCleanupTest do
       refute is_nil(Accounts.get_user(user.id))
     end
   end
+
+  describe "per-user limit overrides" do
+    test "inactivity_warn_60_days=false override suppresses 60-day warning" do
+      user = insert(:user)
+      set_last_active(user.id, 65)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "inactivity_warn_60_days",
+        value: %{"v" => false}
+      )
+
+      # No Mox expect — send/4 must not be called.
+      InactivityCleanup.__sweep_60__()
+
+      reloaded = Accounts.get_user!(user.id)
+      assert is_nil(reloaded.inactivity_warning_60_at)
+    end
+
+    test "inactivity_warn_60_days=false override suppresses 80-day warning" do
+      user = insert(:user)
+      set_last_active(user.id, 85)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "inactivity_warn_60_days",
+        value: %{"v" => false}
+      )
+
+      InactivityCleanup.__sweep_80__()
+
+      reloaded = Accounts.get_user!(user.id)
+      assert is_nil(reloaded.inactivity_warning_80_at)
+    end
+
+    test "inactivity_delete_days=180 override defers soft-delete past Free default" do
+      user = insert(:user)
+      set_last_active(user.id, 95)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "inactivity_delete_days",
+        value: %{"v" => 180}
+      )
+
+      InactivityCleanup.__sweep_soft__()
+
+      reloaded = Accounts.get_user!(user.id)
+      assert is_nil(reloaded.deleted_at)
+    end
+
+    test "inactivity_delete_days=60 override soft-deletes earlier than Free default" do
+      user = insert(:user)
+      set_last_active(user.id, 65)
+
+      insert(:user_limit_override,
+        user: user,
+        key: "inactivity_delete_days",
+        value: %{"v" => 60}
+      )
+
+      expect(Engram.Email.ProviderMock, :send, fn _to, _subject, _html, _opts -> :ok end)
+
+      InactivityCleanup.__sweep_soft__()
+
+      reloaded = Accounts.get_user!(user.id)
+      assert %DateTime{} = reloaded.deleted_at
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Migrate `InactivityCleanup` cron to read `:inactivity_warn_60_days` and `:inactivity_delete_days` via `Billing.effective_limit/2` so per-user `user_limit_overrides` take effect. Closes #232.

## Changes

- 60-day + 80-day warning sweeps now gate on `effective_limit(:inactivity_warn_60_days) == true` instead of `tier == :free`. Paid defaults (`false`) → no warns sent, behavior preserved.
- Soft-delete sweep computes per-user threshold from `effective_limit(:inactivity_delete_days)`. Paid defaults (`nil`) → exempt, behavior preserved. Free default `90` → exact prior behavior.
- SQL pre-filter relaxed to a 30-day floor; per-user threshold applied in Elixir (avoids loading every user with a usage_meters row, but supports overrides as low as 30 days).
- `Billing.tier(user) == :free` helper removed; replaced by `warn_enabled?/1` and `delete_after_days/1`.

## Tests

4 new tests in `inactivity_cleanup_test.exs` under `describe "per-user limit overrides"`:

- `inactivity_warn_60_days=false` → 60-day warning skipped
- `inactivity_warn_60_days=false` → 80-day warning skipped
- `inactivity_delete_days=180` → not soft-deleted at 95 days idle (deferred)
- `inactivity_delete_days=60` → soft-deleted at 65 days idle (earlier than Free default)

All 13 tests in the file pass. `mix engram.lint.limit_keys` clean.

## Test plan

- [x] `mix test test/engram/workers/inactivity_cleanup_test.exs` — 13/13 pass
- [x] `mix engram.lint.limit_keys` clean
- [x] `mix credo --strict lib/engram/workers/inactivity_cleanup.ex` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)