### PR TITLE
feat(mcp): DCR — add RFC 7591 §2 logo_uri/tos_uri/policy_uri (#282)

### DIFF
--- a/lib/engram/oauth/client.ex
+++ b/lib/engram/oauth/client.ex
@@ -29,11 +29,19 @@ defmodule Engram.OAuth.Client do
     field :software_id, :string
     field :software_version, :string
 
+    # RFC 7591 §2 optional metadata. HTTPS-only per #282.
+    field :logo_uri, :string
+    field :tos_uri, :string
+    field :policy_uri, :string
+
     timestamps(type: :utc_datetime_usec)
   end
 
   @cast_fields ~w(redirect_uris client_name scope grant_types response_types
-                  token_endpoint_auth_method software_id software_version)a
+                  token_endpoint_auth_method software_id software_version
+                  logo_uri tos_uri policy_uri)a
+
+  @metadata_uri_fields ~w(logo_uri tos_uri policy_uri)a
 
   def registration_changeset(client, attrs) do
     client
@@ -55,7 +63,31 @@ defmodule Engram.OAuth.Client do
     # persisted and emitted in DCR telemetry, so cap to bound row/metadata size.
     |> validate_length(:software_id, max: 255)
     |> validate_length(:software_version, max: 255)
+    |> validate_metadata_uris()
   end
+
+  defp validate_metadata_uris(changeset) do
+    Enum.reduce(@metadata_uri_fields, changeset, fn field, acc ->
+      validate_change(acc, field, fn ^field, value ->
+        case parse_https_uri(value) do
+          :ok -> []
+          {:error, msg} -> [{field, msg}]
+        end
+      end)
+    end)
+  end
+
+  defp parse_https_uri(value) when is_binary(value) do
+    case URI.new(value) do
+      {:ok, %URI{scheme: "https", host: host}} when is_binary(host) and host != "" -> :ok
+      {:ok, %URI{scheme: "https"}} -> {:error, "missing host"}
+      {:ok, %URI{scheme: nil}} -> {:error, "missing scheme"}
+      {:ok, %URI{scheme: scheme}} -> {:error, "scheme must be https, got #{scheme}"}
+      {:error, _} -> {:error, "invalid URI"}
+    end
+  end
+
+  defp parse_https_uri(_), do: {:error, "must be a string"}
 
   defp ensure_redirect_uris_present(changeset) do
     case get_field(changeset, :redirect_uris) do

--- a/lib/engram_web/controllers/oauth_register_controller.ex
+++ b/lib/engram_web/controllers/oauth_register_controller.ex
@@ -52,7 +52,10 @@ defmodule EngramWeb.OAuthRegisterController do
       response_types: client.response_types,
       token_endpoint_auth_method: client.token_endpoint_auth_method,
       software_id: client.software_id,
-      software_version: client.software_version
+      software_version: client.software_version,
+      logo_uri: client.logo_uri,
+      tos_uri: client.tos_uri,
+      policy_uri: client.policy_uri
     }
     |> Map.reject(fn {_k, v} -> is_nil(v) end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.254",
+      version: "0.5.256",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260530000010_add_dcr_metadata_to_oauth_clients.exs
+++ b/priv/repo/migrations/20260530000010_add_dcr_metadata_to_oauth_clients.exs
@@ -1,0 +1,11 @@
+defmodule Engram.Repo.Migrations.AddDcrMetadataToOauthClients do
+  use Ecto.Migration
+
+  def change do
+    alter table(:oauth_clients) do
+      add :logo_uri, :text
+      add :tos_uri, :text
+      add :policy_uri, :text
+    end
+  end
+end

--- a/test/engram_web/controllers/oauth_register_controller_test.exs
+++ b/test/engram_web/controllers/oauth_register_controller_test.exs
@@ -272,6 +272,98 @@ defmodule EngramWeb.OAuthRegisterControllerTest do
     end
   end
 
+  describe "POST /oauth/register — RFC 7591 §2 metadata URIs (#282)" do
+    test "persists + echoes logo_uri, tos_uri, policy_uri when all three are HTTPS", %{conn: conn} do
+      params = %{
+        "redirect_uris" => ["https://x/cb"],
+        "client_name" => "Claude",
+        "logo_uri" => "https://cdn.example.com/logo.png",
+        "tos_uri" => "https://example.com/terms",
+        "policy_uri" => "https://example.com/privacy"
+      }
+
+      conn = post(conn, "/oauth/register", params)
+      body = json_response(conn, 201)
+
+      assert body["logo_uri"] == params["logo_uri"]
+      assert body["tos_uri"] == params["tos_uri"]
+      assert body["policy_uri"] == params["policy_uri"]
+
+      assert {:ok, client} = Engram.OAuth.get_client(body["client_id"])
+      assert client.logo_uri == params["logo_uri"]
+      assert client.tos_uri == params["tos_uri"]
+      assert client.policy_uri == params["policy_uri"]
+    end
+
+    test "all three URI fields are optional (nullable)", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["https://x/cb"],
+          "client_name" => "Claude"
+        })
+
+      body = json_response(conn, 201)
+      refute Map.has_key?(body, "logo_uri")
+      refute Map.has_key?(body, "tos_uri")
+      refute Map.has_key?(body, "policy_uri")
+    end
+
+    test "rejects http logo_uri (HTTPS required)", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["https://x/cb"],
+          "logo_uri" => "http://example.com/logo.png"
+        })
+
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_client_metadata"
+    end
+
+    test "rejects http tos_uri (HTTPS required)", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["https://x/cb"],
+          "tos_uri" => "http://example.com/terms"
+        })
+
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_client_metadata"
+    end
+
+    test "rejects http policy_uri (HTTPS required)", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["https://x/cb"],
+          "policy_uri" => "http://example.com/privacy"
+        })
+
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_client_metadata"
+    end
+
+    test "rejects javascript: scheme on any metadata URI", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["https://x/cb"],
+          "logo_uri" => "javascript:alert(1)"
+        })
+
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_client_metadata"
+    end
+
+    test "rejects garbage non-URI string", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["https://x/cb"],
+          "tos_uri" => "not a url"
+        })
+
+      body = json_response(conn, 400)
+      assert body["error"] == "invalid_client_metadata"
+    end
+  end
+
   describe "POST /oauth/register — rate limit" do
     test "returns 429 after 10 registrations from same IP in a minute", %{conn: conn} do
       Application.put_env(:engram, :rate_limit_override, 10)


### PR DESCRIPTION
## Summary

Closes the last of five DCR gaps tracked in #282 — adds the three optional RFC 7591 §2 client-metadata URI fields. Pairs with #271 (customer-facing MCP docs).

## Changes

- **Migration** `priv/repo/migrations/20260530000010_add_dcr_metadata_to_oauth_clients.exs` — adds `logo_uri`, `tos_uri`, `policy_uri` text columns to `oauth_clients` (all nullable).
- **`Engram.OAuth.Client`** — casts all three fields, validates HTTPS scheme + host. Loopback/native-scheme rules apply only to `redirect_uris`; these metadata fields are public-facing brand URLs, so HTTPS-only is correct.
- **`OAuthRegisterController.serialize/1`** — echoes the three back. The existing `Map.reject(is_nil)` keeps absent fields out of the response.

## Tests

7 new tests under `describe "POST /oauth/register — RFC 7591 §2 metadata URIs (#282)"`:

- Happy: all three persisted + echoed
- Nullable: all three omitted → 201 ok, fields absent in response
- Rejection: `http://` for each of `logo_uri`, `tos_uri`, `policy_uri`
- Rejection: `javascript:` scheme
- Rejection: garbage non-URI string

29/29 controller tests pass. Credo strict clean on touched files.

## Test plan

- [x] `mix test test/engram_web/controllers/oauth_register_controller_test.exs` — 29/29 pass
- [x] `mix credo --strict` clean on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)