### PR TITLE
fix(oauth): convert first_ip/last_used_ip from inet to text on prod DBs

### DIFF
--- a/lib/engram/connections.ex
+++ b/lib/engram/connections.ex
@@ -270,7 +270,7 @@ defmodule Engram.Connections do
     end)
   end
 
-  # first_ip is stored as :text (migration 20260530000005 converted from :inet).
+  # first_ip is stored as :text (migration 20260530000020 converted from :inet).
   defp format_inet(nil), do: nil
   defp format_inet(s) when is_binary(s), do: s
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.274",
+      version: "0.5.275",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260530000020_convert_oauth_ip_columns_to_text.exs
+++ b/priv/repo/migrations/20260530000020_convert_oauth_ip_columns_to_text.exs
@@ -1,0 +1,49 @@
+defmodule Engram.Repo.Migrations.ConvertOauthIpColumnsToText do
+  use Ecto.Migration
+
+  # Migrations 20260530000002 / 000003 originally added `first_ip` and
+  # `last_used_ip` as `:inet`, then were edited in place to `:text` after the
+  # `:inet` versions had already run on prod. Fresh DBs get `:text`; prod DBs
+  # still hold `:inet`, which crashes DCR registration with
+  # `Postgrex.EncodeError` because the controller now stamps a plain string.
+  # Idempotent: only ALTER when the column is still `inet`.
+
+  def up do
+    execute """
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'oauth_clients'
+          AND column_name = 'first_ip'
+          AND udt_name = 'inet'
+      ) THEN
+        ALTER TABLE oauth_clients
+          ALTER COLUMN first_ip TYPE text USING first_ip::text;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'oauth_refresh_tokens'
+          AND column_name = 'last_used_ip'
+          AND udt_name = 'inet'
+      ) THEN
+        ALTER TABLE oauth_refresh_tokens
+          ALTER COLUMN last_used_ip TYPE text USING last_used_ip::text;
+      END IF;
+    END $$;
+    """
+  end
+
+  def down do
+    execute """
+    ALTER TABLE oauth_clients
+      ALTER COLUMN first_ip TYPE inet USING first_ip::inet
+    """
+
+    execute """
+    ALTER TABLE oauth_refresh_tokens
+      ALTER COLUMN last_used_ip TYPE inet USING last_used_ip::inet
+    """
+  end
+end


### PR DESCRIPTION
## Summary
- PR #368 added DCR provenance stamping (`first_ip`, `last_used_ip`) but migrations 20260530000002/000003 originally created the columns as `:inet`, ran on FastRaid prod, and were then edited in place to `:text` in commit bd0faad.
- Fresh DBs now provision `:text`; prod DB still holds `:inet`.
- Result: `POST /oauth/register` (DCR) crashes with `Postgrex.EncodeError: expected %Postgrex.INET{}, got "::ffff:10.0.20.252"` — friend can't connect MCP / OAuth clients to `app.engram.page`.

This migration converts both columns where still `inet`. Idempotent via `udt_name='inet'` guard, so it's a no-op where the column is already text (fresh DBs, also `last_used_ip` on FastRaid prod which somehow already converted).

Also fixes a stale migration-number comment in `connections.ex` (`20260530000005` → `20260530000020`).

## Test plan
- [ ] CI: unit + e2e pass
- [ ] Deploy 0.5.275 → migration runs at boot
- [ ] `\d oauth_clients` on prod shows `first_ip | text`
- [ ] friend's MCP client registers without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)