### PR TITLE
ci: block in-place edits to already-applied migrations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,3 +99,57 @@ jobs:
             exit 1
           fi
           echo "OK — no known-stale facts in CLAUDE.md files."
+
+  migrations-immutable:
+    name: migrations immutable
+    runs-on: ubuntu-latest
+    # Block in-place edits to already-applied migrations. Triggering incident:
+    # 2026-05-30 PR #368 edited migration 20260530000002 in place from :inet
+    # to :text after FastRaid prod had already run the :inet version, leaving
+    # prod's oauth_clients.first_ip column as inet while CI's fresh DB
+    # provisioned text — DCR endpoint crashed with Postgrex.EncodeError on
+    # every register. Spec: workspace docs/superpowers/specs/2026-05-30-deploy-guardrails-design.md
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need history to diff against origin/main. depth=50 is plenty for
+          # PR-sized diffs and avoids the full clone cost.
+          fetch-depth: 50
+
+      - name: Check migrations are not modified in place
+        env:
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          # Genuine emergency bypass: PR carries the 'allow-migration-edit' label.
+          # Use only when fixing a migration that has NOT reached any deployed
+          # environment (rare; deliberately friction-y).
+          if echo "$PR_LABELS" | grep -q '"allow-migration-edit"'; then
+            echo "::notice::Bypass label 'allow-migration-edit' present — skipping immutable-migrations check."
+            exit 0
+          fi
+
+          # On push-to-main runs (no PR context), nothing to compare. Skip.
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "Not a pull_request event — nothing to check."
+            exit 0
+          fi
+
+          git fetch origin "${GITHUB_BASE_REF}" --depth=50 >/dev/null 2>&1
+
+          failed=0
+          # --diff-filter=MTD: catch modifications, type changes, deletions.
+          # Renames surface as add+delete so the delete half is still flagged.
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            if git cat-file -e "origin/${GITHUB_BASE_REF}:$file" 2>/dev/null; then
+              echo "::error file=$file::Migration was modified in place. Applied migrations are immutable — write a NEW migration to amend the schema. (Bypass with PR label 'allow-migration-edit'.)"
+              failed=1
+            fi
+          done < <(git diff --name-only --diff-filter=MTD "origin/${GITHUB_BASE_REF}...HEAD" -- 'priv/repo/migrations/*.exs')
+
+          if [ "$failed" -eq 0 ]; then
+            echo "OK — no applied migrations modified in place."
+          fi
+          exit $failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,18 +136,28 @@ jobs:
             exit 0
           fi
 
-          git fetch origin "${GITHUB_BASE_REF}" --depth=50 >/dev/null 2>&1
+          # Fail loud on fetch errors — silencing stderr would let a transient
+          # network failure produce a false-negative green run (the subsequent
+          # process-substitution `< <(git diff ...)` would silently see no
+          # input under `set -e` and the loop would report "OK").
+          if ! git fetch origin "${GITHUB_BASE_REF}" --depth=50 >/dev/null; then
+            echo "::error::Failed to fetch base ref origin/${GITHUB_BASE_REF}"
+            exit 1
+          fi
 
           failed=0
-          # --diff-filter=MTD: catch modifications, type changes, deletions.
-          # Renames surface as add+delete so the delete half is still flagged.
+          # --diff-filter=MTD catches modifications, type changes, and deletions.
+          # --no-renames disables git's default rename detection so a `git mv` of
+          # an already-applied migration decomposes into add+delete; the delete
+          # half then matches the filter and gets flagged. Without --no-renames,
+          # renames surface as status R and slip the check silently.
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             if git cat-file -e "origin/${GITHUB_BASE_REF}:$file" 2>/dev/null; then
               echo "::error file=$file::Migration was modified in place. Applied migrations are immutable — write a NEW migration to amend the schema. (Bypass with PR label 'allow-migration-edit'.)"
               failed=1
             fi
-          done < <(git diff --name-only --diff-filter=MTD "origin/${GITHUB_BASE_REF}...HEAD" -- 'priv/repo/migrations/*.exs')
+          done < <(git diff --name-only --no-renames --diff-filter=MTD "origin/${GITHUB_BASE_REF}...HEAD" -- 'priv/repo/migrations/*.exs')
 
           if [ "$failed" -eq 0 ]; then
             echo "OK — no applied migrations modified in place."

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.275",
+      version: "0.5.276",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
New `migrations-immutable` lint job in `.github/workflows/lint.yml` that fails any PR modifying a `priv/repo/migrations/*.exs` file already present on the base branch.

**Triggering incident** (2026-05-30): PR #368 edited migration `20260530000002` in place from `:inet` → `:text` after FastRaid prod had already applied the `:inet` version. CI's fresh DB provisioned `:text`; prod stayed `:inet`; DCR endpoint crashed with `Postgrex.EncodeError` on every register.

**Bypass:** PR label `allow-migration-edit` short-circuits the check, with a `::notice::` paper-trail in the workflow log. Use only when fixing a migration that hasn't reached any deployed environment.

Spec: [`docs/superpowers/specs/2026-05-30-deploy-guardrails-design.md`](https://github.com/engram-app/engram-workspace/blob/main/docs/superpowers/specs/2026-05-30-deploy-guardrails-design.md) (engram-workspace PR #48)

## Test plan
- [ ] CI's own `migrations-immutable` job passes (this PR adds no migrations)
- [ ] Verify failure path: open a throwaway PR after merge that touches `priv/repo/migrations/20260530000020_*`; confirm it blocks
- [ ] Verify bypass: add `allow-migration-edit` label to the throwaway PR; confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)