### PR TITLE
feat(billing): paddle webhook reliability monitoring (#244)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -45,6 +45,7 @@ config :engram, Oban,
      crontab: [
        {"*/15 * * * *", Engram.Workers.ReconcileEmbeddings},
        {"0 * * * *", Engram.Workers.CleanupDeviceAuthWorker},
+       {"0 2 * * *", Engram.Billing.Workers.PaddleReconcile},
        {"0 3 * * *", Engram.Billing.Workers.OverrideExpirySweep},
        {"30 3 * * *", Engram.Workers.InactivityCleanup},
        {"0 4 * * *", Engram.Workers.OriginAbuseSweep},
@@ -71,6 +72,8 @@ config :logger, :default_formatter,
     :category,
     :clerk_user_id,
     :column,
+    :drift_kind,
+    :duration_ms,
     :event_id,
     :event_type,
     :exception,
@@ -83,6 +86,8 @@ config :logger, :default_formatter,
     :method,
     :new_dek_version,
     :normalized_email_hash,
+    :paddle_price_id,
+    :paddle_subscription_id,
     :payload_keys,
     :phase,
     :price_id,
@@ -93,6 +98,7 @@ config :logger, :default_formatter,
     :request_id,
     :request_path,
     :request_query,
+    :result,
     :row_id,
     :status,
     :storage_key,
@@ -117,6 +123,14 @@ config :engram, :boot_canary_enabled, true
 # Rate limiter backend. Default ETS (per-node, single-node correct, no deps).
 # SaaS prod flips to :redis in runtime.exs when REDIS_URL is set (cluster-shared).
 config :engram, EngramWeb.RateLimiter, backend: :ets
+
+# Sentry PII scrubber. Compile-time so it applies wherever Sentry captures,
+# including the no-DSN dev/test case if a future test exercises a Sentry stub.
+# DSN, release tag, environment_name, and source-context flags live in
+# runtime.exs (gated on SENTRY_DSN).
+config :sentry,
+  context_lines: 5,
+  before_send: {Engram.Sentry.Scrubber, :scrub}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/docs/context/paddle-integration.md
+++ b/docs/context/paddle-integration.md
@@ -116,6 +116,58 @@ For end-to-end frontend testing point Paddle.js at the sandbox by passing `envir
 - `test/engram_web/controllers/webhook_controller_test.exs` — full signature flow including replay protection.
 - `test/engram_web/controllers/billing_controller_test.exs` — `/api/billing/config` payload shape.
 
+## Monitoring (added 2026-05-31, #244)
+
+Four observability layers on the webhook + a daily reconciliation. Each is independent — losing one still gives signal from the other three.
+
+1. **Structured logs.** `Logger.metadata(category: :paddle_webhook, event_type:, event_id:)` is stamped on every webhook in `EngramWeb.WebhookController.paddle/2`. Entry + success log at `:info`; the swallowed-`{:error, _}` path (where we still 200 so Paddle stops retrying) logs at `:error` so Sentry's LoggerHandler captures it.
+
+2. **`:telemetry` span.** `:telemetry.span/3` wraps `Billing.upsert_from_paddle_event/1` and emits `[:engram, :paddle, :webhook, :start | :stop | :exception]` with `event_type`, `event_id`, and (on `:stop`) `result: :ok | :error`. Declared in `EngramWeb.Telemetry.metrics/0` so a future PromEx attach picks them up automatically.
+
+3. **Sentry capture.** DSN comes from `SENTRY_DSN`; unset disables (self-host + dev + test stay no-op). `Engram.Sentry.Scrubber` is wired as `:before_send` — strips `Sentry.Interfaces.Request.data` and recursively redacts any `extra`-map key matching email/phone/address/card/iban/pan/ssn. Smoke-test the pipeline on staging after deploy:
+
+       mix engram.sentry.smoke
+
+   Then look in the Sentry project for an event tagged `smoke_marker=engram.sentry.smoke`.
+
+4. **Daily reconciliation.** `Engram.Billing.Workers.PaddleReconcile` runs at 02:00 UTC and calls `Engram.Billing.Reconciliation.run(7)`. The module fetches `Engram.Paddle.Client.list_subscriptions/1` (Paddle API, paginated) and diffs every subscription updated in the last 7 days against the local `subscriptions` table. Detects four drift kinds:
+
+   | Kind | Meaning |
+   |------|---------|
+   | `:missing_local` | Paddle has the subscription, we don't (most likely silent-200 swallowed-error or a missed webhook). |
+   | `:status_mismatch` | `paddle.status != local.status`. |
+   | `:tier_mismatch` | Price ID maps to a different tier than `local.tier`. |
+   | `:period_mismatch` | `current_billing_period.ends_at` disagrees by more than 120 seconds. |
+
+   Each entry logs at `:error` (Sentry-captured). Worker always returns `:ok` — drift is *signal*, not job failure, so Oban shouldn't retry it.
+
+   Manual one-off:
+
+       mix engram.billing.reconcile --days 30
+
+   In a release shell (`bin/engram rpc`), Mix isn't available — inline the call: `Engram.Billing.Reconciliation.run(7)`.
+
+### Drift response runbook
+
+When you see `paddle_reconciliation_drift` in Sentry or the logs:
+
+1. Note `paddle_subscription_id` and `drift_kind`.
+2. `paddle get /subscriptions/<id>` (or the Paddle dashboard) to confirm Paddle's current state.
+3. Replay the missed webhook event:
+   - Paddle dashboard → Notifications → search by `subscription_id`.
+   - Click "Replay" on the relevant event. `Billing.upsert_from_paddle_event/1` is idempotent — replays are safe.
+4. Re-run `mix engram.billing.reconcile --days 7` to confirm the drift is resolved.
+
+If a replay doesn't clear the drift, the upserter itself is failing — pull its log (search `paddle_webhook_handler_error`, same `event_id`) for the root cause.
+
+### Self-host
+
+Both Sentry (`SENTRY_DSN` unset) and reconciliation (`:billing_enabled` false) no-op cleanly on self-host.
+
+### Follow-up (engram-infra)
+
+PromEx + Prometheus + alert rules are tracked separately on the engram-infra repo. When Prometheus exists, attaching PromEx will pick up the metric declarations in `EngramWeb.Telemetry` automatically.
+
 ## What this doc deliberately does not cover
 
 - Frontend wiring of Paddle.js (marketing site + app). Owned by the frontend rewrite.

--- a/docs/superpowers/plans/2026-05-31-paddle-webhook-monitoring.md
+++ b/docs/superpowers/plans/2026-05-31-paddle-webhook-monitoring.md
@@ -1,0 +1,1389 @@
+# Paddle Webhook Reliability Monitoring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship four observability layers on the Paddle webhook + daily Paddle↔DB reconciliation so silent money-loss drift surfaces within 24 h.
+
+**Architecture:** Wrap webhook handler in `:telemetry.span/3` + structured logs; add Sentry capture wired via LoggerBackend with PII scrubber; add a Paddle-list-subscriptions client callback feeding a daily reconciliation Oban cron that diffs Paddle state against the local `subscriptions` table and logs/Sentry-captures any drift. PromEx/Prometheus deferred to follow-up infra ticket.
+
+**Tech Stack:** Elixir 1.17+, Phoenix 1.8+, Oban, `:telemetry`, `sentry-elixir ~> 10.0`, ExUnit + Mox.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-paddle-webhook-monitoring-design.md`
+
+**Ticket:** engram-app/Engram#244
+
+**Worktree:** `/home/open-claw/documents/code-projects/engram/.worktrees/paddle-webhook-monitoring` on branch `feat/paddle-webhook-monitoring` (branched from `origin/main`).
+
+---
+
+## File Map
+
+### New files
+
+- `lib/engram/paddle/client/mock.ex` — extend existing Mox mock if needed (verify state during implementation; if mock already defined inline in `test_helper.exs` no new file required).
+- `lib/engram/billing/reconciliation.ex` — drift detection logic.
+- `lib/engram/billing/workers/paddle_reconcile.ex` — Oban worker.
+- `lib/engram/sentry/scrubber.ex` — PII before_send callback.
+- `lib/mix/tasks/engram.billing.reconcile.ex` — Mix task wrapper.
+- `lib/mix/tasks/engram.sentry.smoke.ex` — Sentry pipeline smoke test.
+- `test/engram/billing/reconciliation_test.exs` — drift kinds.
+- `test/engram/billing/workers/paddle_reconcile_test.exs` — Oban worker.
+- `test/engram/sentry/scrubber_test.exs` — scrubber unit tests.
+
+### Modified files
+
+- `lib/engram_web/controllers/webhook_controller.ex` — wrap in `:telemetry.span/3`; bump swallowed-error log to `:error`; structured log on entry/exit; add `Logger.metadata`.
+- `lib/engram_web/telemetry.ex` — declare new metric names for forward-compat.
+- `lib/engram/paddle/client.ex` — add `@callback list_subscriptions/1`.
+- `lib/engram/paddle/client/http.ex` — implement `list_subscriptions/1` with `updated_at[GTE]` filter + pagination.
+- `lib/engram/application.ex` — attach `Sentry.LoggerBackend`.
+- `mix.exs` — add `{:sentry, "~> 10.0"}`.
+- `config/config.exs` — Sentry block; add Logger metadata keys (`:duration_ms`, `:drift_kind`, `:paddle_subscription_id`, `:result`); add crontab entry for `PaddleReconcile`.
+- `config/runtime.exs` — wire `SENTRY_DSN` from env.
+- `test/engram_web/controllers/webhook_controller_test.exs` — add telemetry + log assertions.
+- `test/test_helper.exs` — extend Paddle ClientMock if needed.
+- `docs/context/paddle-integration.md` — add "Monitoring" section linking layers.
+
+### Paired workspace PR (separate)
+
+- `docs/context/paddle-v2-launch-runbook.md` (workspace repo) — add "Reconciliation drift response" + manual replay procedure.
+
+---
+
+## Task 1: Structured logs + `:telemetry` span on webhook handler
+
+**Files:**
+- Modify: `lib/engram_web/controllers/webhook_controller.ex:28-53`
+- Modify: `config/config.exs:78-104` (Logger metadata list)
+- Test: `test/engram_web/controllers/webhook_controller_test.exs`
+
+- [ ] **Step 1.1: Add new Logger metadata keys to config**
+
+Edit `config/config.exs` Logger metadata list (alphabetical position). Add:
+
+```elixir
+    :drift_kind,
+    :duration_ms,
+    :paddle_subscription_id,
+    :result,
+```
+
+Place each in alphabetical order within the existing list (`drift_kind` after `column`, `duration_ms` after `drift_kind`, `paddle_subscription_id` after `normalized_email_hash`, `result` after `request_query`).
+
+- [ ] **Step 1.2: Write failing telemetry-event test**
+
+Add to `test/engram_web/controllers/webhook_controller_test.exs` inside the `describe "POST /webhooks/paddle"` block:
+
+```elixir
+test "emits :telemetry.span events on success", %{conn: conn} do
+  user = insert(:user)
+  ref = :telemetry_test.attach_event_handlers(
+    self(),
+    [
+      [:engram, :paddle, :webhook, :start],
+      [:engram, :paddle, :webhook, :stop]
+    ]
+  )
+
+  payload =
+    Jason.encode!(%{
+      "event_type" => "subscription.created",
+      "event_id" => "ntf_wh_telemetry",
+      "data" => %{
+        "id" => "sub_wh_telemetry",
+        "status" => "trialing",
+        "customer_id" => "ctm_wh_telemetry",
+        "items" => [%{"price" => %{"id" => "pri_starter_test"}}],
+        "current_billing_period" => %{"ends_at" => "2026-05-20T00:00:00Z"},
+        "custom_data" => %{"user_id" => user.id}
+      }
+    })
+
+  ts = System.system_time(:second)
+  sig_header = "ts=#{ts};h1=#{sign(ts, payload)}"
+
+  conn
+  |> put_req_header("content-type", "application/json")
+  |> put_req_header("paddle-signature", sig_header)
+  |> post("/webhooks/paddle", payload)
+
+  assert_received {[:engram, :paddle, :webhook, :start], ^ref, _measurements,
+                   %{event_type: "subscription.created", event_id: "ntf_wh_telemetry"}}
+
+  assert_received {[:engram, :paddle, :webhook, :stop], ^ref, %{duration: _},
+                   %{event_type: "subscription.created", event_id: "ntf_wh_telemetry",
+                     result: :ok}}
+end
+```
+
+- [ ] **Step 1.3: Run test to verify failure**
+
+```bash
+mix test test/engram_web/controllers/webhook_controller_test.exs:NNN
+```
+
+Expected: FAIL — `assert_received` timeouts. No start/stop events emitted.
+
+- [ ] **Step 1.4: Implement telemetry span in webhook handler**
+
+Replace `webhook_controller.ex:28-53` (the `def paddle/2`) with:
+
+```elixir
+def paddle(conn, _params) do
+  with {:ok, sig_header} <- get_signature(conn),
+       {:ok, payload} <- read_body_once(conn),
+       :ok <- verify_signature(payload, sig_header) do
+    event = Jason.decode!(payload)
+    event_type = event["event_type"]
+    event_id = event["event_id"]
+
+    Logger.metadata(
+      category: :paddle_webhook,
+      event_type: event_type,
+      event_id: event_id
+    )
+
+    Logger.info("paddle_webhook_received")
+
+    {response, result} =
+      :telemetry.span(
+        [:engram, :paddle, :webhook],
+        %{event_type: event_type, event_id: event_id},
+        fn ->
+          case Billing.upsert_from_paddle_event(event) do
+            {:ok, _} = ok ->
+              {{:ok, :handled}, %{event_type: event_type, event_id: event_id, result: :ok}}
+
+            {:error, reason} = err ->
+              Logger.error("paddle_webhook_handler_error",
+                reason: format_reason(reason)
+              )
+
+              {{:error, reason}, %{event_type: event_type, event_id: event_id, result: :error}}
+          end
+        end
+      )
+
+    _ = result
+
+    case response do
+      {:ok, _} ->
+        Logger.info("paddle_webhook_ok")
+        json(conn, %{status: "ok"})
+
+      {:error, _} ->
+        json(conn, %{status: "ok"})
+    end
+  else
+    {:error, reason} ->
+      conn
+      |> put_status(400)
+      |> json(%{error: to_string(reason)})
+  end
+end
+```
+
+Notes:
+- `:telemetry.span/3` returns `{result, stop_metadata}` per its spec. We discard `stop_metadata` (already passed in) — kept only because the macro returns it.
+- Swallowed-error path now `Logger.error` (was `Logger.warning`) so Sentry's logger backend will capture it in Task 3.
+- Still returns 200 on swallowed error — reconciliation catches the drift.
+
+- [ ] **Step 1.5: Run telemetry test to verify pass**
+
+```bash
+mix test test/engram_web/controllers/webhook_controller_test.exs
+```
+
+Expected: PASS, all tests in file.
+
+- [ ] **Step 1.6: Write failing exception-event test**
+
+Add another test asserting the `:exception` event fires when `Billing.upsert_from_paddle_event/1` raises. Note this requires arranging an event that breaks parsing — use a payload missing required fields that would crash. Practical pattern:
+
+```elixir
+test "emits :exception event when handler raises", %{conn: conn} do
+  ref = :telemetry_test.attach_event_handlers(
+    self(),
+    [[:engram, :paddle, :webhook, :exception]]
+  )
+
+  # Payload structure Billing.upsert_from_paddle_event/1 will MatchError on:
+  # missing `data` key.
+  payload = ~s({"event_type":"subscription.created","event_id":"ntf_wh_raise"})
+
+  ts = System.system_time(:second)
+  sig_header = "ts=#{ts};h1=#{sign(ts, payload)}"
+
+  assert_raise FunctionClauseError, fn ->
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("paddle-signature", sig_header)
+    |> post("/webhooks/paddle", payload)
+  end
+
+  assert_received {[:engram, :paddle, :webhook, :exception], ^ref, %{duration: _},
+                   %{event_type: "subscription.created", kind: :error}}
+end
+```
+
+If `Billing.upsert_from_paddle_event/1` doesn't actually raise on missing data (returns `{:error, _}` instead) — change this test to use `Mox.expect(Engram.BillingMock, ...)` to inject a raise, or skip and document the gap.
+
+**Verification step before continuing:** before writing this test, grep `Billing.upsert_from_paddle_event/1` to confirm whether it raises or returns `{:error, _}` on malformed input. Adjust test setup to actually trigger an exception path.
+
+- [ ] **Step 1.7: Run + verify exception test passes**
+
+If raise path not reachable in handler chain, **delete this test and proceed.** `:telemetry.span/3` documentation guarantees the `:exception` event fires on raise; if no raise path exists today, no test value.
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add config/config.exs lib/engram_web/controllers/webhook_controller.ex test/engram_web/controllers/webhook_controller_test.exs
+git commit -m "feat(paddle): wrap webhook in telemetry span + structured logs
+
+Wrap Billing.upsert_from_paddle_event/1 call in :telemetry.span/3 so
+[:engram, :paddle, :webhook, :{start,stop,exception}] events fire on
+every webhook. Bump swallowed-error log level from warning to error so
+Sentry (next commit) captures the silent-200 path. Add Logger metadata
+keys :duration_ms / :result / :drift_kind / :paddle_subscription_id.
+
+Part of #244."
+```
+
+---
+
+## Task 2: Declare metric names in `EngramWeb.Telemetry`
+
+**Files:**
+- Modify: `lib/engram_web/telemetry.ex`
+
+- [ ] **Step 2.1: Open telemetry.ex and locate the `metrics/0` function**
+
+```bash
+grep -n "def metrics" lib/engram_web/telemetry.ex
+```
+
+- [ ] **Step 2.2: Add metric declarations**
+
+In the `metrics/0` list, append (preserve existing entries):
+
+```elixir
+import Telemetry.Metrics
+
+# Paddle webhook reliability (declared for future PromEx attach; emitted
+# via :telemetry.span/3 in EngramWeb.WebhookController.paddle/2).
+counter("engram.paddle.webhook.start.count",
+  event_name: [:engram, :paddle, :webhook, :start],
+  measurement: :system_time,
+  tags: [:event_type]
+),
+summary("engram.paddle.webhook.stop.duration",
+  event_name: [:engram, :paddle, :webhook, :stop],
+  measurement: :duration,
+  unit: {:native, :millisecond},
+  tags: [:event_type, :result]
+),
+counter("engram.paddle.webhook.exception.count",
+  event_name: [:engram, :paddle, :webhook, :exception],
+  measurement: :duration,
+  tags: [:event_type, :kind]
+)
+```
+
+If `import Telemetry.Metrics` is already at the top, omit duplicate import.
+
+- [ ] **Step 2.3: Run mix compile to verify no warnings**
+
+```bash
+mix compile --warnings-as-errors
+```
+
+Expected: clean compile.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add lib/engram_web/telemetry.ex
+git commit -m "feat(paddle): declare paddle webhook metrics for PromEx attach
+
+Forward-compat: when PromEx lands (engram-infra follow-up ticket) it
+finds these declarations and attaches automatically.
+
+Part of #244."
+```
+
+---
+
+## Task 3: Add Sentry dep + base configuration
+
+**Files:**
+- Modify: `mix.exs`
+- Modify: `config/config.exs`
+- Modify: `config/runtime.exs`
+- Modify: `lib/engram/application.ex`
+
+- [ ] **Step 3.1: Add Sentry dep to mix.exs**
+
+In the `deps/0` list:
+
+```elixir
+{:sentry, "~> 10.0"},
+```
+
+- [ ] **Step 3.2: Fetch deps**
+
+```bash
+mix deps.get
+```
+
+Expected: `sentry` + transitive deps downloaded; lockfile updated.
+
+- [ ] **Step 3.3: Add Sentry config block to config/config.exs**
+
+Append after the existing `config :engram, EngramWeb.RateLimiter, …` block (before `import_config`):
+
+```elixir
+# Paddle webhook + general exception capture. DSN comes from env at
+# runtime; unset DSN disables capture (safe for self-host + dev).
+config :sentry,
+  environment_name: Mix.env(),
+  enable_source_code_context: true,
+  root_source_code_paths: [File.cwd!()],
+  context_lines: 5,
+  included_environments: [:prod, :staging],
+  before_send: {Engram.Sentry.Scrubber, :scrub}
+```
+
+- [ ] **Step 3.4: Wire DSN in config/runtime.exs**
+
+Inside the `if config_env() == :prod do` block (and any staging branch), add:
+
+```elixir
+config :sentry, dsn: System.get_env("SENTRY_DSN")
+```
+
+If the file separates prod and staging via env var rather than block, locate the right spot — search for `config :engram,` blocks in runtime.exs and place near the bottom of the matching block.
+
+- [ ] **Step 3.5: Attach Sentry.LoggerBackend in Application.start/2**
+
+In `lib/engram/application.ex`, locate `def start/2`. Before the `Supervisor.start_link(...)` call, add:
+
+```elixir
+:logger.add_handler(:sentry_handler, Sentry.LoggerHandler, %{
+  config: %{
+    metadata: [:category, :event_type, :event_id, :paddle_subscription_id, :drift_kind, :reason]
+  }
+})
+```
+
+Note: Sentry 10.x uses `Sentry.LoggerHandler` (`:logger` handler, not Backend). Verify name vs version after `mix deps.get`.
+
+- [ ] **Step 3.6: Compile + verify**
+
+```bash
+mix compile --warnings-as-errors
+```
+
+Expected: clean.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add mix.exs mix.lock config/config.exs config/runtime.exs lib/engram/application.ex
+git commit -m "feat(sentry): add sentry-elixir dep + base config + logger handler
+
+DSN unset → captures disabled (self-host + dev). before_send scrubber
+in next commit. Part of #244."
+```
+
+---
+
+## Task 4: Sentry PII scrubber
+
+**Files:**
+- Create: `lib/engram/sentry/scrubber.ex`
+- Create: `test/engram/sentry/scrubber_test.exs`
+
+- [ ] **Step 4.1: Write failing scrubber test**
+
+Create `test/engram/sentry/scrubber_test.exs`:
+
+```elixir
+defmodule Engram.Sentry.ScrubberTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Sentry.Scrubber
+
+  describe "scrub/1" do
+    test "drops request body" do
+      event = %Sentry.Event{request: %{data: "secret"}}
+      assert %Sentry.Event{request: %{data: nil}} = Scrubber.scrub(event)
+    end
+
+    test "redacts email/phone/address fields in extra map" do
+      event = %Sentry.Event{
+        extra: %{
+          customer_email: "u@example.com",
+          billing_phone: "+15551234",
+          address_line1: "1 Main St",
+          unrelated: "keep"
+        }
+      }
+
+      scrubbed = Scrubber.scrub(event)
+
+      assert scrubbed.extra.customer_email == "[redacted]"
+      assert scrubbed.extra.billing_phone == "[redacted]"
+      assert scrubbed.extra.address_line1 == "[redacted]"
+      assert scrubbed.extra.unrelated == "keep"
+    end
+
+    test "redacts nested maps recursively" do
+      event = %Sentry.Event{
+        extra: %{customer: %{email: "u@example.com", id: "cus_1"}}
+      }
+
+      scrubbed = Scrubber.scrub(event)
+      assert scrubbed.extra.customer.email == "[redacted]"
+      assert scrubbed.extra.customer.id == "cus_1"
+    end
+
+    test "returns event unchanged when no scrubbable fields present" do
+      event = %Sentry.Event{extra: %{just_ids: "ok"}}
+      assert Scrubber.scrub(event) == event
+    end
+  end
+end
+```
+
+- [ ] **Step 4.2: Run scrubber test to verify failure**
+
+```bash
+mix test test/engram/sentry/scrubber_test.exs
+```
+
+Expected: FAIL — `Engram.Sentry.Scrubber` not defined.
+
+- [ ] **Step 4.3: Implement scrubber**
+
+Create `lib/engram/sentry/scrubber.ex`:
+
+```elixir
+defmodule Engram.Sentry.Scrubber do
+  @moduledoc """
+  Sentry `:before_send` callback. Strips PII from event payloads before
+  they leave the process for Sentry's API.
+
+  Paddle webhooks echo customer email/address/phone — make sure none of
+  that reaches Sentry. The conservative default is to drop the raw request
+  body entirely; structured logger metadata supplies the actionable
+  context.
+  """
+
+  @pii_substrings ~w(email phone address card iban pan ssn)
+
+  @spec scrub(Sentry.Event.t()) :: Sentry.Event.t()
+  def scrub(%Sentry.Event{} = event) do
+    event
+    |> drop_request_data()
+    |> redact_extra()
+  end
+
+  defp drop_request_data(%Sentry.Event{request: %{data: _} = req} = event) do
+    %{event | request: %{req | data: nil}}
+  end
+
+  defp drop_request_data(event), do: event
+
+  defp redact_extra(%Sentry.Event{extra: extra} = event) when is_map(extra) do
+    %{event | extra: redact_map(extra)}
+  end
+
+  defp redact_extra(event), do: event
+
+  defp redact_map(map) when is_map(map) do
+    Map.new(map, fn {k, v} ->
+      cond do
+        pii_key?(k) -> {k, "[redacted]"}
+        is_map(v) -> {k, redact_map(v)}
+        is_list(v) -> {k, redact_list(v)}
+        true -> {k, v}
+      end
+    end)
+  end
+
+  defp redact_list(list) when is_list(list) do
+    Enum.map(list, fn
+      v when is_map(v) -> redact_map(v)
+      v when is_list(v) -> redact_list(v)
+      v -> v
+    end)
+  end
+
+  defp pii_key?(key) when is_atom(key), do: pii_key?(Atom.to_string(key))
+
+  defp pii_key?(key) when is_binary(key) do
+    downcased = String.downcase(key)
+    Enum.any?(@pii_substrings, &String.contains?(downcased, &1))
+  end
+
+  defp pii_key?(_), do: false
+end
+```
+
+- [ ] **Step 4.4: Run scrubber test to verify pass**
+
+```bash
+mix test test/engram/sentry/scrubber_test.exs
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add lib/engram/sentry/scrubber.ex test/engram/sentry/scrubber_test.exs
+git commit -m "feat(sentry): add PII before_send scrubber
+
+Drops request body, redacts any extra key matching email/phone/address/
+card/iban/pan/ssn (atom or string), recurses into maps + lists.
+
+Part of #244."
+```
+
+---
+
+## Task 5: `mix engram.sentry.smoke` task
+
+**Files:**
+- Create: `lib/mix/tasks/engram.sentry.smoke.ex`
+
+- [ ] **Step 5.1: Implement smoke task (no test — staging verification only)**
+
+Create `lib/mix/tasks/engram.sentry.smoke.ex`:
+
+```elixir
+defmodule Mix.Tasks.Engram.Sentry.Smoke do
+  @moduledoc """
+  Smoke-test the Sentry pipeline end-to-end. Captures one event with a
+  known marker so an operator can confirm the project ID + DSN + scrubber
+  + ingestion all work.
+
+  Run on staging:
+
+      mix engram.sentry.smoke
+
+  Then check the Sentry project for an event with
+  `tags.smoke_marker = "engram.sentry.smoke"`.
+  """
+  use Mix.Task
+
+  @shortdoc "Send one synthetic Sentry capture to verify the pipeline"
+
+  @impl true
+  def run(_argv) do
+    Mix.Task.run("app.start")
+
+    Sentry.capture_message(
+      "engram.sentry.smoke — pipeline test",
+      level: :error,
+      tags: %{smoke_marker: "engram.sentry.smoke"}
+    )
+
+    Process.sleep(1_500)
+    IO.puts("Sentry smoke event dispatched. Check the project for tag smoke_marker=engram.sentry.smoke.")
+  end
+end
+```
+
+- [ ] **Step 5.2: Compile + verify**
+
+```bash
+mix compile --warnings-as-errors
+mix help engram.sentry.smoke
+```
+
+Expected: clean compile, `mix help` shows the task.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add lib/mix/tasks/engram.sentry.smoke.ex
+git commit -m "feat(sentry): add mix engram.sentry.smoke task
+
+One-shot capture with smoke_marker tag — operator runs on staging after
+deploy to confirm DSN + scrubber + Sentry ingestion all work.
+
+Part of #244."
+```
+
+---
+
+## Task 6: Add `list_subscriptions/1` callback to Paddle Client
+
+**Files:**
+- Modify: `lib/engram/paddle/client.ex`
+- Modify: `lib/engram/paddle/client/http.ex`
+- Modify: `test/support/mocks.ex` (or wherever `Engram.Paddle.ClientMock` is defined — verify)
+
+- [ ] **Step 6.1: Locate ClientMock definition**
+
+```bash
+grep -rn "Engram.Paddle.ClientMock\|defmock.*Paddle" test/ lib/
+```
+
+Confirm whether mock is generated via `Mox.defmock` in `test/test_helper.exs` or a support file. The mock auto-picks up new callbacks from the behaviour, so no manual edit usually required.
+
+- [ ] **Step 6.2: Add behaviour callback to client.ex**
+
+In `lib/engram/paddle/client.ex`, after the existing callbacks:
+
+```elixir
+@doc """
+List subscriptions updated since the given DateTime, paginated.
+
+Paddle endpoint: `GET /subscriptions?updated_at[GTE]={iso}&per_page=200`.
+Follows pagination via `meta.pagination.next` until exhausted. Returns
+the flattened list of decoded subscription `data` maps.
+"""
+@callback list_subscriptions(since :: DateTime.t()) ::
+            {:ok, [map()]} | {:error, term()}
+```
+
+- [ ] **Step 6.3: Write failing test for HTTP impl**
+
+Add to `test/engram/paddle/client/http_test.exs` (or matching file — confirm naming):
+
+```elixir
+test "list_subscriptions paginates updated_at[GTE] filter" do
+  # Stub Req to return two pages then a terminator.
+  bypass = Bypass.open()
+  # ... configure base_url to bypass + assert URL contains `updated_at[GTE]`
+  # Implementation detail: stub two responses with meta.pagination.next set,
+  # then nil. Assert flattened return.
+end
+```
+
+**Pragmatic note:** if the codebase already has a pattern for stubbing Req (Bypass, Req.Test, Plug-based mock), follow that pattern verbatim — look at existing `*_test.exs` files for `Engram.Paddle.Client.HTTP` and copy the harness setup. Do NOT invent a new mocking style.
+
+- [ ] **Step 6.4: Implement list_subscriptions in HTTP impl**
+
+Add to `lib/engram/paddle/client/http.ex` (signature must match callback):
+
+```elixir
+@impl Engram.Paddle.Client
+def list_subscriptions(%DateTime{} = since) do
+  iso = DateTime.to_iso8601(since)
+  list_page("/subscriptions?updated_at[GTE]=#{URI.encode(iso)}&per_page=200", [])
+end
+
+defp list_page(path, acc) do
+  case request(:get, path) do
+    {:ok, %{"data" => data, "meta" => %{"pagination" => %{"next" => nil}}}} ->
+      {:ok, Enum.reverse([data | acc] |> List.flatten())}
+
+    {:ok, %{"data" => data, "meta" => %{"pagination" => %{"next" => next_url}}}} ->
+      next_path = next_url |> URI.parse() |> Map.get(:path)
+      next_query = next_url |> URI.parse() |> Map.get(:query)
+      list_page("#{next_path}?#{next_query}", [data | acc])
+
+    {:ok, %{"data" => data}} ->
+      {:ok, List.flatten([data | acc])}
+
+    {:error, _} = err ->
+      err
+  end
+end
+```
+
+If existing `Engram.Paddle.Client.HTTP` exposes a private `request/2` use it; otherwise mirror the helper pattern used by sibling functions in that file.
+
+- [ ] **Step 6.5: Run HTTP impl test to verify pass**
+
+```bash
+mix test test/engram/paddle/client/http_test.exs
+```
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add lib/engram/paddle/client.ex lib/engram/paddle/client/http.ex test/engram/paddle/client/http_test.exs
+git commit -m "feat(paddle): list_subscriptions/1 callback with pagination
+
+Returns every subscription updated since the given DateTime, flattened
+across pages. Feeds Engram.Billing.Reconciliation in next commit.
+
+Part of #244."
+```
+
+---
+
+## Task 7: Reconciliation drift detection
+
+**Files:**
+- Create: `lib/engram/billing/reconciliation.ex`
+- Create: `test/engram/billing/reconciliation_test.exs`
+
+- [ ] **Step 7.1: Write failing tests for each drift kind**
+
+Create `test/engram/billing/reconciliation_test.exs`:
+
+```elixir
+defmodule Engram.Billing.ReconciliationTest do
+  use Engram.DataCase, async: false
+
+  import Mox
+
+  alias Engram.Billing.Reconciliation
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  describe "run/1" do
+    test "no drift when Paddle and local match" do
+      user = insert(:user)
+      _sub = insert(:subscription,
+        user_id: user.id,
+        paddle_subscription_id: "sub_ok",
+        paddle_customer_id: "ctm_ok",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           %{
+             "id" => "sub_ok",
+             "status" => "active",
+             "customer_id" => "ctm_ok",
+             "items" => [%{"price" => %{"id" => "pri_starter_test"}}],
+             "current_billing_period" => %{"ends_at" => "2026-06-30T00:00:00Z"}
+           }
+         ]}
+      end)
+
+      assert %{drift: []} = Reconciliation.run(7)
+    end
+
+    test "detects :missing_local when Paddle has a subscription we don't" do
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           %{
+             "id" => "sub_ghost",
+             "status" => "active",
+             "customer_id" => "ctm_ghost",
+             "items" => [%{"price" => %{"id" => "pri_starter_test"}}],
+             "current_billing_period" => %{"ends_at" => "2026-06-30T00:00:00Z"}
+           }
+         ]}
+      end)
+
+      assert %{drift: [%{kind: :missing_local, subscription_id: "sub_ghost"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "detects :status_mismatch" do
+      user = insert(:user)
+      insert(:subscription,
+        user_id: user.id,
+        paddle_subscription_id: "sub_status",
+        paddle_customer_id: "ctm_status",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           %{
+             "id" => "sub_status",
+             "status" => "past_due",
+             "customer_id" => "ctm_status",
+             "items" => [%{"price" => %{"id" => "pri_starter_test"}}],
+             "current_billing_period" => %{"ends_at" => "2026-06-30T00:00:00Z"}
+           }
+         ]}
+      end)
+
+      assert %{drift: [%{kind: :status_mismatch, subscription_id: "sub_status"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "detects :tier_mismatch" do
+      user = insert(:user)
+      insert(:subscription,
+        user_id: user.id,
+        paddle_subscription_id: "sub_tier",
+        paddle_customer_id: "ctm_tier",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           %{
+             "id" => "sub_tier",
+             "status" => "active",
+             "customer_id" => "ctm_tier",
+             "items" => [%{"price" => %{"id" => "pri_pro_test"}}],
+             "current_billing_period" => %{"ends_at" => "2026-06-30T00:00:00Z"}
+           }
+         ]}
+      end)
+
+      assert %{drift: [%{kind: :tier_mismatch, subscription_id: "sub_tier"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "detects :period_mismatch beyond 2-minute skew" do
+      user = insert(:user)
+      insert(:subscription,
+        user_id: user.id,
+        paddle_subscription_id: "sub_period",
+        paddle_customer_id: "ctm_period",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           %{
+             "id" => "sub_period",
+             "status" => "active",
+             "customer_id" => "ctm_period",
+             "items" => [%{"price" => %{"id" => "pri_starter_test"}}],
+             "current_billing_period" => %{"ends_at" => "2026-07-31T00:00:00Z"}
+           }
+         ]}
+      end)
+
+      assert %{drift: [%{kind: :period_mismatch, subscription_id: "sub_period"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "no-ops when paddle disabled (PADDLE_API_KEY unset)" do
+      original = Application.get_env(:engram, :billing_enabled)
+      Application.put_env(:engram, :billing_enabled, false)
+      on_exit(fn -> Application.put_env(:engram, :billing_enabled, original) end)
+
+      assert %{drift: [], paddle_total: 0, local_total: 0, skipped: :billing_disabled} =
+               Reconciliation.run(7)
+    end
+  end
+end
+```
+
+- [ ] **Step 7.2: Run tests to verify failure**
+
+```bash
+mix test test/engram/billing/reconciliation_test.exs
+```
+
+Expected: FAIL — `Engram.Billing.Reconciliation` undefined.
+
+- [ ] **Step 7.3: Implement Reconciliation**
+
+Create `lib/engram/billing/reconciliation.ex`:
+
+```elixir
+defmodule Engram.Billing.Reconciliation do
+  @moduledoc """
+  Diff Paddle subscription state against the local `subscriptions` table.
+
+  Ground truth: Paddle. Anything we have that Paddle doesn't, or vice
+  versa, is drift. Drift gets logged at `:error` level so Sentry's
+  LoggerHandler captures it. Returns a summary map; does not raise.
+
+  Self-host (`:billing_enabled` config false) short-circuits to a no-op.
+  """
+
+  require Logger
+
+  alias Engram.Repo
+  alias Engram.Billing.Subscription
+
+  import Ecto.Query
+
+  @period_skew_seconds 120
+
+  @type drift_entry :: %{
+          subscription_id: String.t(),
+          kind: :missing_local | :status_mismatch | :tier_mismatch | :period_mismatch,
+          paddle: term(),
+          local: term() | nil
+        }
+
+  @type result :: %{
+          paddle_total: non_neg_integer(),
+          local_total: non_neg_integer(),
+          drift: [drift_entry()],
+          skipped: nil | :billing_disabled
+        }
+
+  @spec run(pos_integer()) :: result()
+  def run(days_back) when is_integer(days_back) and days_back > 0 do
+    if Application.get_env(:engram, :billing_enabled, false) do
+      do_run(days_back)
+    else
+      Logger.info("paddle_reconcile_skipped", reason: "billing_disabled")
+      %{paddle_total: 0, local_total: 0, drift: [], skipped: :billing_disabled}
+    end
+  end
+
+  defp do_run(days_back) do
+    since = DateTime.utc_now() |> DateTime.add(-days_back * 86_400, :second)
+
+    case Engram.Paddle.Client.impl().list_subscriptions(since) do
+      {:ok, paddle_subs} ->
+        local_subs = recent_local_subscriptions(since)
+        local_by_paddle_id = Map.new(local_subs, &{&1.paddle_subscription_id, &1})
+        drift = Enum.flat_map(paddle_subs, &classify(&1, local_by_paddle_id))
+
+        log_summary(paddle_subs, local_subs, drift)
+
+        Enum.each(drift, &Logger.error("paddle_reconciliation_drift",
+          category: :paddle_reconcile,
+          drift_kind: &1.kind,
+          paddle_subscription_id: &1.subscription_id
+        ))
+
+        %{
+          paddle_total: length(paddle_subs),
+          local_total: length(local_subs),
+          drift: drift,
+          skipped: nil
+        }
+
+      {:error, reason} ->
+        Logger.error("paddle_reconcile_fetch_failed", reason: inspect(reason))
+        %{paddle_total: 0, local_total: 0, drift: [], skipped: nil}
+    end
+  end
+
+  defp recent_local_subscriptions(since) do
+    from(s in Subscription, where: s.updated_at >= ^since)
+    |> Repo.all()
+  end
+
+  defp classify(paddle_sub, local_by_id) do
+    id = paddle_sub["id"]
+    local = Map.get(local_by_id, id)
+
+    cond do
+      is_nil(local) ->
+        [%{subscription_id: id, kind: :missing_local, paddle: paddle_sub, local: nil}]
+
+      paddle_sub["status"] != local.status ->
+        [%{
+          subscription_id: id,
+          kind: :status_mismatch,
+          paddle: paddle_sub["status"],
+          local: local.status
+        }]
+
+      paddle_tier(paddle_sub) != local.tier ->
+        [%{
+          subscription_id: id,
+          kind: :tier_mismatch,
+          paddle: paddle_tier(paddle_sub),
+          local: local.tier
+        }]
+
+      period_mismatch?(paddle_sub, local) ->
+        [%{
+          subscription_id: id,
+          kind: :period_mismatch,
+          paddle: paddle_sub["current_billing_period"]["ends_at"],
+          local: local.current_period_end
+        }]
+
+      true ->
+        []
+    end
+  end
+
+  defp paddle_tier(paddle_sub) do
+    price_id =
+      paddle_sub
+      |> Map.get("items", [])
+      |> List.first()
+      |> case do
+        %{"price" => %{"id" => id}} -> id
+        _ -> nil
+      end
+
+    Engram.Billing.tier_from_price_id(price_id)
+  end
+
+  defp period_mismatch?(paddle_sub, local) do
+    with %{"ends_at" => paddle_ends_at} <- paddle_sub["current_billing_period"],
+         {:ok, paddle_dt, _} <- DateTime.from_iso8601(paddle_ends_at),
+         %DateTime{} = local_dt <- local.current_period_end do
+      abs(DateTime.diff(paddle_dt, local_dt, :second)) > @period_skew_seconds
+    else
+      _ -> false
+    end
+  end
+
+  defp log_summary(paddle, local, drift) do
+    Logger.info("paddle_reconcile_summary",
+      category: :paddle_reconcile,
+      reason: "summary",
+      message:
+        "paddle=#{length(paddle)} local=#{length(local)} drift=#{length(drift)}"
+    )
+  end
+end
+```
+
+**Dependency:** the implementation calls `Engram.Billing.tier_from_price_id/1`. Verify this function exists by `grep tier_from_price_id lib/engram/billing.ex`. If it doesn't but a different price-id → tier mapper does (e.g. `Engram.Billing.Plan.from_price_id/1`), update the call site accordingly. If no such function exists, add a thin one inside `Engram.Billing` first.
+
+- [ ] **Step 7.4: Run tests to verify pass**
+
+```bash
+mix test test/engram/billing/reconciliation_test.exs
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add lib/engram/billing/reconciliation.ex test/engram/billing/reconciliation_test.exs
+git commit -m "feat(billing): reconciliation module — paddle vs local diff
+
+Returns {paddle_total, local_total, drift, skipped}. Detects four drift
+kinds: missing_local, status_mismatch, tier_mismatch, period_mismatch
+(2-minute skew tolerance). Each drift entry logged at error so Sentry
+captures. Self-host no-ops when :billing_enabled is false.
+
+Part of #244."
+```
+
+---
+
+## Task 8: `mix engram.billing.reconcile` task
+
+**Files:**
+- Create: `lib/mix/tasks/engram.billing.reconcile.ex`
+
+- [ ] **Step 8.1: Implement Mix task**
+
+Create `lib/mix/tasks/engram.billing.reconcile.ex`:
+
+```elixir
+defmodule Mix.Tasks.Engram.Billing.Reconcile do
+  @moduledoc """
+  Reconcile the local `subscriptions` table against Paddle.
+
+      mix engram.billing.reconcile          # 7 days
+      mix engram.billing.reconcile --days 30
+
+  Prints a summary map. Drift entries are also written to the structured
+  log at `:error` level so Sentry captures them.
+  """
+  use Mix.Task
+
+  @shortdoc "Reconcile local subscriptions against Paddle"
+
+  @impl true
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [days: :integer])
+    days = Keyword.get(opts, :days, 7)
+
+    Mix.Task.run("app.start")
+
+    days
+    |> Engram.Billing.Reconciliation.run()
+    |> IO.inspect(label: "reconciliation result")
+  end
+end
+```
+
+Per `feedback_mix_task_in_release`: when invoking from a release shell, do **not** call `Mix.Tasks.Engram.Billing.Reconcile.run/1` — inline the body. The Oban worker in Task 9 is the production path.
+
+- [ ] **Step 8.2: Compile + verify task registered**
+
+```bash
+mix compile --warnings-as-errors
+mix help engram.billing.reconcile
+```
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add lib/mix/tasks/engram.billing.reconcile.ex
+git commit -m "feat(billing): mix engram.billing.reconcile task
+
+Local + dev-shell entrypoint to Reconciliation.run/1. Oban worker (next
+commit) is the production path.
+
+Part of #244."
+```
+
+---
+
+## Task 9: Oban worker + crontab entry
+
+**Files:**
+- Create: `lib/engram/billing/workers/paddle_reconcile.ex`
+- Create: `test/engram/billing/workers/paddle_reconcile_test.exs`
+- Modify: `config/config.exs` (crontab block)
+
+- [ ] **Step 9.1: Write failing worker test**
+
+Create `test/engram/billing/workers/paddle_reconcile_test.exs`:
+
+```elixir
+defmodule Engram.Billing.Workers.PaddleReconcileTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Mox
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  test "perform/1 calls Reconciliation.run/1 with 7-day default" do
+    original = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, true)
+    on_exit(fn -> Application.put_env(:engram, :billing_enabled, original) end)
+
+    Engram.Paddle.ClientMock
+    |> expect(:list_subscriptions, fn _since -> {:ok, []} end)
+
+    assert :ok = perform_job(Engram.Billing.Workers.PaddleReconcile, %{})
+  end
+end
+```
+
+- [ ] **Step 9.2: Run test to verify failure**
+
+```bash
+mix test test/engram/billing/workers/paddle_reconcile_test.exs
+```
+
+Expected: FAIL — module undefined.
+
+- [ ] **Step 9.3: Implement worker**
+
+Create `lib/engram/billing/workers/paddle_reconcile.ex`:
+
+```elixir
+defmodule Engram.Billing.Workers.PaddleReconcile do
+  @moduledoc """
+  Daily Oban cron worker. Calls `Engram.Billing.Reconciliation.run/1` with
+  a 7-day window. Drift is logged at :error and captured by Sentry — the
+  worker itself always returns :ok so Oban doesn't mark the job failed
+  for data drift (which is signal, not job failure).
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 1
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    _ = Engram.Billing.Reconciliation.run(7)
+    :ok
+  end
+end
+```
+
+- [ ] **Step 9.4: Add crontab entry to config/config.exs**
+
+In the `Oban.Plugins.Cron` crontab list (config/config.exs around line 45), append after `OverrideExpirySweep`:
+
+```elixir
+{"0 2 * * *", Engram.Billing.Workers.PaddleReconcile},
+```
+
+Place between `OverrideExpirySweep` (`"0 3 * * *"`) and the others, ordered by time.
+
+- [ ] **Step 9.5: Run worker test to verify pass**
+
+```bash
+mix test test/engram/billing/workers/paddle_reconcile_test.exs
+```
+
+Expected: PASS.
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add lib/engram/billing/workers/paddle_reconcile.ex test/engram/billing/workers/paddle_reconcile_test.exs config/config.exs
+git commit -m "feat(billing): Oban cron worker for daily paddle reconcile
+
+Runs Reconciliation.run(7) daily at 02:00 UTC. Worker returns :ok
+regardless of drift — Oban shouldn't mark drift as job failure. Drift
+surfaces via Sentry from the Logger backend.
+
+Part of #244."
+```
+
+---
+
+## Task 10: Update backend docs/context with monitoring section
+
+**Files:**
+- Modify: `docs/context/paddle-integration.md`
+
+- [ ] **Step 10.1: Locate paddle-integration.md and read existing structure**
+
+```bash
+head -40 docs/context/paddle-integration.md
+```
+
+- [ ] **Step 10.2: Append "Monitoring" section**
+
+Append to `docs/context/paddle-integration.md`:
+
+```markdown
+## Monitoring (added 2026-05-31, PR #244)
+
+Four observability layers on the webhook + a daily reconciliation:
+
+1. **Structured logs** — `Logger.metadata(category: :paddle_webhook, event_type:, event_id:)` stamped on every webhook. Entry/success log `:info`; swallowed-error path bumped to `:error` so Sentry's LoggerHandler captures it. See `EngramWeb.WebhookController.paddle/2`.
+2. **`:telemetry` span** — `[:engram, :paddle, :webhook, :{start,stop,exception}]` emitted by `:telemetry.span/3` wrap. Declared in `EngramWeb.Telemetry.metrics/0` for forward-compat with PromEx (see follow-up infra ticket).
+3. **Sentry capture** — DSN from `SENTRY_DSN`; unset disables. `Engram.Sentry.Scrubber` strips email/phone/address/card/iban/pan/ssn fields from extra/request payloads before send. Smoke-test the pipeline: `mix engram.sentry.smoke`.
+4. **Daily reconciliation** — `Engram.Billing.Workers.PaddleReconcile` runs at 02:00 UTC, calls `Engram.Billing.Reconciliation.run(7)`. Detects four drift kinds: `:missing_local`, `:status_mismatch`, `:tier_mismatch`, `:period_mismatch` (±2 min skew tolerance). Manual run: `mix engram.billing.reconcile --days N`.
+
+### Drift response
+
+When reconciliation logs `paddle_reconciliation_drift`:
+
+1. Note `paddle_subscription_id` + `drift_kind` from Sentry/log.
+2. `paddle get /subscriptions/<id>` to confirm current Paddle state.
+3. Manually upsert the local row OR replay the webhook event:
+   - Find the event in Paddle dashboard → Notifications → search by `subscription_id`.
+   - Use Paddle's "Replay" button to re-send. Webhook handler is idempotent (`upsert_from_paddle_event/1`).
+4. Re-run `mix engram.billing.reconcile` to confirm drift resolved.
+
+### Self-host
+
+Both Sentry (`SENTRY_DSN` unset) and reconciliation (`:billing_enabled` false) no-op cleanly on self-host.
+```
+
+- [ ] **Step 10.3: Commit**
+
+```bash
+git add docs/context/paddle-integration.md
+git commit -m "docs(paddle): monitoring section + drift response procedure
+
+Part of #244."
+```
+
+---
+
+## Task 11: Final verification + push
+
+- [ ] **Step 11.1: Run full mix test suite**
+
+```bash
+mix test
+```
+
+Expected: all tests pass. If any pre-existing test fails, surface to user — per `feedback_diagnose_flakes` don't accept silent reruns.
+
+- [ ] **Step 11.2: Run mix compile with warnings-as-errors**
+
+```bash
+mix compile --warnings-as-errors
+```
+
+- [ ] **Step 11.3: Run credo + format check**
+
+```bash
+mix credo --strict
+mix format --check-formatted
+```
+
+Fix any findings before pushing.
+
+- [ ] **Step 11.4: Push branch**
+
+```bash
+git push -u origin feat/paddle-webhook-monitoring
+```
+
+- [ ] **Step 11.5: Open PR**
+
+```bash
+gh pr create --title "feat(billing): paddle webhook reliability monitoring (#244)" --body "$(cat <<'EOF'
+Closes #244.
+
+Ships four observability layers + daily Paddle↔DB reconciliation:
+
+1. Structured logs on every webhook entry/exit/error
+2. `:telemetry` span events (PromEx-ready)
+3. Sentry capture with PII before_send scrubber + `mix engram.sentry.smoke` for pipeline verification
+4. Daily reconciliation Oban cron (`Engram.Billing.Workers.PaddleReconcile`) that diffs Paddle subscriptions against the local table and logs/captures any drift
+
+Drops Prometheus alert rules from ticket acceptance — moved to engram-infra follow-up (we have no Prometheus deployed; wiring PromEx alone would be a dead pipe). Spec: `docs/superpowers/specs/2026-05-31-paddle-webhook-monitoring-design.md`.
+
+## Test plan
+
+- [x] Unit tests pass: `mix test`
+- [x] Compile clean: `mix compile --warnings-as-errors`
+- [x] Lint clean: `mix credo --strict && mix format --check-formatted`
+- [ ] Staging deploy: run `mix engram.sentry.smoke` and confirm Sentry receives the marker event
+- [ ] Staging deploy: trigger a test webhook (Paddle dashboard) and confirm logs + telemetry events emit
+- [ ] Staging deploy: take backend offline 5 min during a webhook delivery, verify Paddle retries land + reconciliation flags any persistent drift
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 11.6: Workspace PR for runbook update**
+
+Switch to engram-workspace repo (different worktree — coordinate with user; this is OUT of the backend worktree). Create branch + edit `docs/context/paddle-v2-launch-runbook.md` adding a "Reconciliation drift response" section that links to `backend/docs/context/paddle-integration.md` for the procedure (avoid duplication — point to the backend doc).
+
+- [ ] **Step 11.7: File follow-up issue on engram-infra**
+
+```bash
+gh issue create -R engram-app/engram-infra \
+  --title "Deploy Prometheus/Grafana stack + wire PromEx for paddle webhook alerts" \
+  --body "$(cat <<'EOF'
+Follow-up to engram-app/Engram#244.
+
+That ticket shipped structured logs + `:telemetry` events + Sentry + daily reconciliation, but left out the original "alert rules deployed (5xx rate, exception rate)" acceptance because we have no Prometheus deployment to wire PromEx into.
+
+Scope:
+
+- Deploy Prometheus on FastRaid (and later AWS, per #266) with scrape config pointed at engram backend `/metrics` (PromEx exposes once wired).
+- Add `:prom_ex` Hex dep to engram + wire it into `EngramWeb.Telemetry`. The metric *declarations* for paddle webhook are already there.
+- Alertmanager rules:
+  - `engram_paddle_webhook_stop_count{result="error"}` rate > 0 over 5 min → page
+  - `engram_paddle_webhook_exception_count` rate > 0 → page
+  - HTTP 5xx rate on `/webhooks/paddle` > 1% over 5 min → page
+- Grafana dashboard.
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Plan covers spec sections:
+- §Goals 1-5 ✓ (Tasks 1-9)
+- §Non-Goals respected (no Prometheus deploy in this PR; reconciliation table not added; no auto-heal)
+- §Architecture all four layers ✓ (Tasks 1-9)
+- §Schema changes "none" ✓
+- §Config changes both env vars handled ✓
+- §Acceptance items mapped to tasks ✓
+- §Follow-up issues — Step 11.7 files the infra ticket
+- §Open questions — left for user to resolve at PR review time (env-name decision is just a config-string choice; window-default is in code)
+
+Type consistency: `Engram.Billing.tier_from_price_id/1` referenced in Task 7 must exist; flagged with verification step. `Engram.Paddle.Client.impl/0` used per existing pattern. Oban worker queue `:maintenance` matches existing config (`queues: [embed: 5, reindex: 1, maintenance: 2, crypto_backfill: 1]`).

--- a/docs/superpowers/specs/2026-05-31-paddle-webhook-monitoring-design.md
+++ b/docs/superpowers/specs/2026-05-31-paddle-webhook-monitoring-design.md
@@ -1,0 +1,240 @@
+# Paddle Webhook Reliability Monitoring — Design
+
+Date: 2026-05-31
+Status: Draft (pending user review)
+Repos touched: `engram-app/engram` (backend), `engram-app/engram-workspace` (runbook update)
+Ticket: engram-app/Engram#244 (milestone `v1-launch`, p1)
+
+## Problem
+
+Paddle posts billing events to `POST /webhooks/paddle`. The handler verifies the signature, parses the body, then calls `Billing.upsert_from_paddle_event/1`. Today the handler has four silent-failure modes that lose money or paid-but-unupgraded customers:
+
+1. Handler raises → Phoenix returns 5xx → Paddle retries ~72h → eventually gives up → event lost forever. No alert.
+2. **Handler swallows the upserter error and returns 200** (`webhook_controller.ex:38-45`). Paddle thinks delivery worked. Customer paid, never got upgraded. No alert.
+3. Signature verification edge case → 401/400 → Paddle treats as failure → eventual give-up. No alert.
+4. DB write succeeds partial / wrong-tier / wrong-period → 200 returned → ghost row. No alert.
+
+None of these surface as fast complaints. They surface weeks later as "I paid and never got Pro" emails or as chargebacks.
+
+We want monitoring that catches all four modes, gives best forensic info, and is forward-compatible with the metrics stack we don't have yet.
+
+## Goals
+
+1. **Catch every money-loss drift mode**, including #2/#4 where the response code is healthy.
+2. Best forensic info on every webhook event: structured log trail + exception capture.
+3. Daily ground-truth reconciliation against Paddle API (the only layer that doesn't trust our own observations).
+4. Forward-compat with PromEx/Prometheus when that infra is deployed (separate ticket, separate repo).
+5. Single PR (`feedback_single_pr_all_changes`); runbook updates allowed as a paired workspace PR since they live in a different repo.
+
+## Non-Goals (v1)
+
+- Deploying Prometheus / Grafana / Alertmanager. PromEx alone wired into a void is dead pipe. Filed as follow-up infra ticket — see "Follow-up issues" below.
+- Configurable alert windows (ticket explicitly drops this).
+- Deadman switch for "no webhook received for >24h" (ticket drops this — operator watches dashboard manually first weeks).
+- Auto-heal on drift. Reconciliation reports and exits. Replay is a manual runbook step.
+- Persisting reconciliation runs to a DB table. Logs are sufficient v1; revisit if trend analysis becomes valuable.
+
+## Architecture
+
+Four observability layers, lowest to highest abstraction:
+
+| Layer | Purpose | Ships v1? |
+|-------|---------|-----------|
+| Structured log | Forensic trail per event (entry/exit/error) | yes |
+| `:telemetry` events | Forward-compat for PromEx attach later | yes |
+| Sentry capture | Exception forensics (stack + breadcrumbs, deduped) | yes |
+| Reconciliation | Daily ground-truth diff Paddle ↔ local DB | yes |
+| PromEx + Prometheus + alert rules | Time-series trend + paging alerts | **no** — follow-up ticket on engram-infra |
+
+### Layer 1 — Structured log per event
+
+Modify `EngramWeb.WebhookController.paddle/2` to:
+
+- Stamp `Logger.metadata(category: :paddle_webhook, event_type:, event_id:)` immediately after JSON decode.
+- Log at `:info` on entry with the metadata only (no payload — Paddle echoes customer email/address).
+- Log at `:info` on `:ok` exit with `duration_ms`.
+- Log at `:error` on the swallowed `{:error, reason}` path — change current `Logger.warning` to `error` so it routes to Sentry's logger backend.
+- Keep the 200 response on swallowed-error (we still want Paddle to stop retrying — reconciliation will catch the drift). The log level change makes the failure loud internally.
+
+Existing `format_reason/1` already redacts PII; reuse.
+
+### Layer 2 — `:telemetry` events
+
+Wrap the upsert call in `:telemetry.span/3`:
+
+```
+:telemetry.span(
+  [:engram, :paddle, :webhook],
+  %{event_type: event["event_type"], event_id: event["event_id"]},
+  fn ->
+    case Billing.upsert_from_paddle_event(event) do
+      {:ok, _} = ok   -> {ok, %{result: :ok}}
+      {:error, _} = e -> {e,  %{result: :error}}
+    end
+  end
+)
+```
+
+That emits three events automatically:
+
+- `[:engram, :paddle, :webhook, :start]` — measurements `%{monotonic_time}`, metadata `%{event_type, event_id}`
+- `[:engram, :paddle, :webhook, :stop]` — measurements `%{duration}`, metadata `%{event_type, event_id, result}`
+- `[:engram, :paddle, :webhook, :exception]` — measurements `%{duration}`, metadata `%{event_type, event_id, kind, reason, stacktrace}`
+
+Declare them in `EngramWeb.Telemetry` (already the home for `:telemetry_metrics` declarations — pinned forward, see comment at line 88) so when PromEx lands it just attaches.
+
+### Layer 3 — Sentry
+
+Add `:sentry` Hex dep (latest stable, currently `~> 10.0`).
+
+`config/config.exs`:
+
+```elixir
+config :sentry,
+  dsn: System.get_env("SENTRY_DSN"),
+  environment_name: config_env(),
+  enable_source_code_context: true,
+  root_source_code_paths: [File.cwd!()],
+  context_lines: 5,
+  included_environments: [:prod, :staging]
+```
+
+`config/runtime.exs` — wire `SENTRY_DSN` from env, falling back to nil (disables capture in dev/test without crashing).
+
+`Application.start/2` — attach `Sentry.LoggerBackend` so `Logger.error` calls auto-capture. Configure `:capture_log_messages` true with `:level :error`.
+
+**PII scrubbing.** Paddle webhook payloads contain customer email + sometimes billing address. Configure `:sentry` `:before_send` callback to scrub:
+
+- `event.request.data` — drop entirely if present (handler doesn't pass request body to Sentry context, but defense in depth).
+- Strip any string field matching `email:`, `address`, `phone`, `card`, `iban`.
+
+Verify capture by injecting `raise "smoke test"` behind a `MIX_ENV=staging` mix task (`mix engram.sentry.smoke`) and watching the Sentry project receive it.
+
+### Layer 4 — Daily reconciliation
+
+New module `Engram.Billing.Reconciliation`:
+
+```
+@spec run(days_back :: pos_integer()) :: %{
+  paddle_total: non_neg_integer(),
+  local_total: non_neg_integer(),
+  drift: [%{subscription_id: String.t(), kind: atom(), paddle: term(), local: term()}]
+}
+```
+
+**Algorithm:**
+
+1. Compute `since = DateTime.utc_now() |> DateTime.add(-days_back, :day)`.
+2. Paginate Paddle `GET /subscriptions?updated_at[GTE]=<since>` (Paddle SDK or HTTP — see "Paddle client" below). Collect every subscription updated in the window.
+3. For each Paddle row, look up the local `subscriptions` row by `paddle_subscription_id`.
+4. Classify drift:
+   - `:missing_local` — Paddle has it, we don't
+   - `:status_mismatch` — `paddle.status != local.status`
+   - `:tier_mismatch` — Paddle's active price ID maps to a different tier than `local.tier`
+   - `:period_mismatch` — `paddle.current_billing_period.ends_at != local.current_period_end` (allow ±2 min skew)
+5. Also forward-pass: every local `subscriptions` row updated in the window that the Paddle list didn't return → `:missing_remote` (treat as soft warning — could be eventual consistency).
+6. Return summary + drift list.
+
+**Reporting:**
+
+- Each drift entry emits `Logger.error("paddle_reconciliation_drift", category: :paddle_reconcile, …)`. Sentry backend captures.
+- Final summary logs at `:info` with totals.
+- Exit code (Mix task): 0 always (Oban worker treats raise as failure; we don't want false-positive Oban failures from drift — drift is data, not a job failure).
+
+**Mix task wrapper:**
+
+```
+defmodule Mix.Tasks.Engram.Billing.Reconcile do
+  use Mix.Task
+  @shortdoc "Reconcile local subscriptions against Paddle"
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [days: :integer])
+    days = Keyword.get(opts, :days, 7)
+    Mix.Task.run("app.start")
+    Engram.Billing.Reconciliation.run(days) |> IO.inspect()
+  end
+end
+```
+
+Per `feedback_mix_task_in_release`: when invoking via `rpc` from release shell, inline the call body — do **not** `Mix.Tasks…run`.
+
+**Oban worker:**
+
+```
+defmodule Engram.Billing.Workers.PaddleReconcile do
+  use Oban.Worker, queue: :default, max_attempts: 1
+  @impl true
+  def perform(%Oban.Job{}) do
+    Engram.Billing.Reconciliation.run(7)
+    :ok
+  end
+end
+```
+
+Schedule in `config/config.exs` crontab block (already exists at line 45). Run daily at `"0 2 * * *"` UTC (matches `OverrideExpirySweep` cadence).
+
+**Paddle client.** The existing `Engram.Paddle.Client` may not have a `list_subscriptions` method yet — check during implementation. If absent, add a thin function with `updated_at[GTE]` filter + cursor pagination (Paddle uses `Paginator` with `.next()`). Self-host (`PADDLE_API_KEY` unset) → reconciliation is a no-op (log `"billing_disabled, skipping"` and return).
+
+## Schema changes
+
+None. Reconciliation reads existing `subscriptions` table; no new columns or tables.
+
+## Config changes
+
+| Var | Where | Purpose |
+|-----|-------|---------|
+| `SENTRY_DSN` | env (staging + prod only) | Sentry project DSN |
+| `SENTRY_ENV` | env (optional override) | label in Sentry |
+
+Self-host: `SENTRY_DSN` unset → Sentry no-ops. Reconciliation no-ops when `PADDLE_API_KEY` unset. Both safe by default.
+
+## Sequencing & PR shape
+
+Single backend PR. Recommended commit order:
+
+1. **Structured log + telemetry span** in `webhook_controller.ex` (no new deps). Tests: webhook controller test asserts `[:engram, :paddle, :webhook, :stop]` emitted with `:ok`/`:error` result + log lines present.
+2. **Sentry dep + config + LoggerBackend + before_send scrubber.** Tests: scrubber unit tests for PII fields.
+3. **Reconciliation module + tests** (mocked Paddle client; verify all four drift kinds detected).
+4. **Mix task + Oban worker + crontab entry.** Tests: Oban worker test runs against mocked Paddle client.
+5. **Smoke task `mix engram.sentry.smoke`** (raises on demand to verify capture pipeline end-to-end in staging).
+
+Paired workspace PR (separate, must accompany):
+
+- Update `docs/context/paddle-v2-launch-runbook.md`: add "Reconciliation drift response" section with manual replay procedure.
+- Update `backend/docs/context/paddle-integration.md`: add "Monitoring" section linking layers.
+
+## Acceptance (mapped to ticket #244)
+
+Original ticket acceptance items rewritten to reflect this design — ticket should be updated:
+
+- [ ] Structured logs on webhook entry/exit/error with redacted metadata
+- [ ] `:telemetry` events `[:engram, :paddle, :webhook, :*]` emitted (PromEx-ready)
+- [ ] Sentry capture wired with PII `before_send` scrubber; staging smoke task verifies pipeline
+- [ ] `Engram.Billing.Reconciliation.run/1` detects all four drift kinds
+- [ ] `mix engram.billing.reconcile [--days N]` runs locally + in release
+- [ ] `Engram.Billing.Workers.PaddleReconcile` scheduled daily 02:00 UTC
+- [ ] `paddle-v2-launch-runbook.md` updated with drift response + manual replay
+- [ ] `backend/docs/context/paddle-integration.md` updated with monitoring section
+- [ ] Manual smoke (staging): take backend offline 5 min during webhook delivery, verify Paddle retries + reconciliation catches drift if any persists
+
+Dropped from original acceptance (ticket-level update required):
+
+- ~~"Alert rules deployed (5xx rate, exception rate)"~~ — moves to follow-up Prometheus ticket.
+
+## Follow-up issues to file
+
+1. **engram-app/engram-infra** — "Deploy Prometheus/Grafana stack + wire PromEx + alert rules for Paddle webhook". Requires Prometheus scrape target (we have none today). Carries the dropped acceptance item.
+2. **engram-app/Engram** — "Reconciliation: persist runs to `reconciliation_runs` table for trend analysis". Defer until we have a need (after first month of operating).
+
+## Open questions
+
+1. Sentry DSN — staging + prod use the same project with `environment_name` distinguishing, or two projects? Default: one project, environment label.
+2. Reconciliation window default: 7 days. Reasonable? Paddle retries for ~72h so a 7-day window catches any retry that eventually succeeds + a buffer.
+3. `:missing_remote` (local has, Paddle window doesn't return) — log as warn or info? Default: warn but no Sentry capture (could be benign eventual consistency).
+
+## Risks
+
+- Sentry adoption is a new external service to monitor + a new ENV secret in two envs. Mitigated: defaults disabled when DSN unset; smoke task verifies end-to-end before relying on it.
+- `:before_send` PII scrubber bug could leak customer email/address to Sentry. Mitigated: unit tests for scrubber; manual inspection of first 5 captures in staging.
+- Reconciliation that hits Paddle API frequently could rate-limit. Mitigated: daily cadence + paginated. Paddle rate limit is generous (300 req/min).
+- Changing the swallowed-error log from `warning` to `error` will start triggering Sentry on every existing transient upsert failure. May surface noise on day one — accept this; tune via Sentry's grouping/ignore rules if any one fires hot.

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -5,6 +5,8 @@ defmodule Engram.Application do
 
   use Application
 
+  require Logger
+
   @impl true
   def start(_type, _args) do
     Engram.Crypto.Config.validate!()
@@ -109,14 +111,40 @@ defmodule Engram.Application do
 
   # Attach Sentry's :logger handler. When :sentry has no DSN configured
   # (dev, test, self-host) the handler is a no-op — every report is
-  # short-circuited before any network call. Idempotent against ExUnit's
-  # per-suite restart for the same reason as the redact filter above.
+  # short-circuited before any network call, so attaching is safe everywhere.
+  # Idempotent against ExUnit's per-suite restart for the same reason as the
+  # redact filter above.
+  #
+  # Metadata allowlist controls cardinality on the Sentry side — every key
+  # here is one that may appear on `Logger.error/2` calls we want surfaced
+  # (paddle webhook, paddle reconcile, crypto rotation, request context).
   defp attach_sentry_logger_handler do
     _ = :logger.remove_handler(:engram_sentry)
 
     :ok =
       :logger.add_handler(:engram_sentry, Sentry.LoggerHandler, %{
-        config: %{metadata: [:request_id, :user_id, :module, :function, :file, :line]}
+        config: %{
+          metadata: [
+            :category,
+            :drift_kind,
+            :event_id,
+            :event_type,
+            :file,
+            :function,
+            :kind,
+            :line,
+            :module,
+            :paddle_price_id,
+            :paddle_subscription_id,
+            :queue,
+            :reason,
+            :reason_label,
+            :request_id,
+            :status,
+            :user_id,
+            :worker
+          ]
+        }
       })
   end
 

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -455,10 +455,18 @@ defmodule Engram.Billing do
 
   defp extract_user_id(_), do: :error
 
-  defp tier_from_subscription(%{"items" => [%{"price" => %{"id" => price_id}} | _]}),
+  @doc """
+  Resolve a tier name (`"free"` | `"starter"` | `"pro"`) from a Paddle
+  subscription data map. Defaults to `"free"` for unknown or missing
+  prices (logged loudly via `Logger.error`) so a bogus payload can't
+  silently grant paid features — reconciliation surfaces the mismatch
+  separately.
+  """
+  @spec tier_from_subscription(map()) :: String.t()
+  def tier_from_subscription(%{"items" => [%{"price" => %{"id" => price_id}} | _]}),
     do: tier_from_price_id(price_id)
 
-  defp tier_from_subscription(other) do
+  def tier_from_subscription(other) do
     Logger.error("paddle subscription missing items[0].price.id; defaulting to free",
       payload_keys: Map.keys(other || %{})
     )
@@ -481,11 +489,28 @@ defmodule Engram.Billing do
         "pro"
 
       true ->
-        Logger.error("unknown paddle price_id; defaulting to free",
-          price_id: price_id
-        )
-
+        log_unknown_price_id_once(price_id)
         "free"
+    end
+  end
+
+  # Dedupe per-process. Reconciliation iterates every Paddle sub and
+  # webhook handlers run in their own request process — without this
+  # guard, a misconfigured PADDLE_*_PRICE_ID env var would fire N logs
+  # per reconciliation cycle (one per Paddle sub) and burn Sentry quota.
+  # With the guard: one log per unique unknown price ID per process,
+  # which is the actionable signal.
+  defp log_unknown_price_id_once(price_id) do
+    seen = Process.get(:engram_unknown_price_ids_seen, MapSet.new())
+
+    unless MapSet.member?(seen, price_id) do
+      Logger.error("paddle_unknown_price_id",
+        category: :paddle,
+        reason_label: :unknown_price_id,
+        paddle_price_id: price_id
+      )
+
+      Process.put(:engram_unknown_price_ids_seen, MapSet.put(seen, price_id))
     end
   end
 

--- a/lib/engram/billing/reconciliation.ex
+++ b/lib/engram/billing/reconciliation.ex
@@ -80,7 +80,7 @@ defmodule Engram.Billing.Reconciliation do
 
     case Engram.Paddle.Client.impl().list_subscriptions(since) do
       {:ok, paddle_subs} ->
-        diff(paddle_subs, since, nil)
+        diff(paddle_subs, nil)
 
       {:partial, paddle_subs, reason} when reason in [:max_pages_exceeded, :pagination_loop] ->
         # HTTP layer truncated the list (page cap hit or Paddle returned a
@@ -93,7 +93,7 @@ defmodule Engram.Billing.Reconciliation do
           reason_label: reason
         )
 
-        diff(paddle_subs, since, reason)
+        diff(paddle_subs, reason)
 
       {:error, reason} ->
         Logger.error("paddle_reconcile_fetch_failed",
@@ -115,8 +115,9 @@ defmodule Engram.Billing.Reconciliation do
     end
   end
 
-  defp diff(paddle_subs, since, skipped_reason) do
-    local_subs = recent_local_subscriptions(since)
+  defp diff(paddle_subs, skipped_reason) do
+    paddle_ids = Enum.map(paddle_subs, & &1["id"])
+    local_subs = local_subscriptions_for(paddle_ids)
     local_by_paddle_id = Map.new(local_subs, &{&1.paddle_subscription_id, &1})
 
     drift =
@@ -141,8 +142,18 @@ defmodule Engram.Billing.Reconciliation do
     }
   end
 
-  defp recent_local_subscriptions(since) do
-    from(s in Subscription, where: s.updated_at >= ^since)
+  # Look up local rows by the paddle IDs Paddle just returned, NOT by
+  # local `updated_at`. Paddle's `updated_at[GTE]` filter happily returns
+  # subs whose local row hasn't been touched in months (e.g. Paddle ticks
+  # its own `updated_at` for an internal reindex or `scheduled_change`
+  # processing). Filtering local by `updated_at` would miss those rows
+  # and falsely flag them `:missing_local`. `paddle_subscription_id` is
+  # the indexed unique key — bounded by paddle's page cap (`@max_pages *
+  # per_page`) and safe to send IN-list.
+  defp local_subscriptions_for([]), do: []
+
+  defp local_subscriptions_for(paddle_ids) do
+    from(s in Subscription, where: s.paddle_subscription_id in ^paddle_ids)
     |> Repo.all(skip_tenant_check: true)
   end
 

--- a/lib/engram/billing/reconciliation.ex
+++ b/lib/engram/billing/reconciliation.ex
@@ -1,0 +1,218 @@
+defmodule Engram.Billing.Reconciliation do
+  @moduledoc """
+  Diff Paddle subscription state against the local `subscriptions` table.
+
+  Ground truth: Paddle. Anything Paddle has that we don't (or vice versa,
+  or a field that disagrees) is drift. Drift gets logged at `:error`
+  level so Sentry's LoggerHandler captures it. Returns a summary map;
+  does not raise.
+
+  Self-host (`:billing_enabled` config false) short-circuits to a no-op
+  so the Oban cron is harmless when Paddle isn't wired.
+
+  Drift kinds:
+
+    * `:missing_local` — Paddle has the subscription, we don't.
+    * `:status_mismatch` — `paddle.status != local.status`.
+    * `:tier_mismatch` — `tier_from_subscription(paddle) != local.tier`.
+    * `:period_mismatch` — `paddle.current_billing_period.ends_at` differs
+      from `local.current_period_end` by more than `@period_skew_seconds`.
+  """
+
+  import Ecto.Query
+
+  alias Engram.Billing.Subscription
+  alias Engram.Repo
+
+  require Logger
+
+  # 2-minute tolerance covers NTP drift + Paddle → webhook → DB write
+  # propagation (parse_period_end/1 also truncates to seconds). Tighter
+  # values produced false-positive period_mismatch entries during
+  # sandbox smoke testing 2026-05-23.
+  @period_skew_seconds 120
+
+  @type drift_kind ::
+          :missing_local | :status_mismatch | :tier_mismatch | :period_mismatch
+
+  @type drift_entry :: %{
+          subscription_id: String.t(),
+          kind: drift_kind(),
+          paddle: term(),
+          local: term() | nil
+        }
+
+  @type result :: %{
+          paddle_total: non_neg_integer(),
+          local_total: non_neg_integer(),
+          drift: [drift_entry()],
+          skipped:
+            nil
+            | :billing_disabled
+            | :fetch_failed
+            | :max_pages_exceeded
+            | :pagination_loop,
+          error: nil | term()
+        }
+
+  @spec run(pos_integer()) :: result()
+  def run(days_back) when is_integer(days_back) and days_back > 0 do
+    if Application.get_env(:engram, :billing_enabled, false) do
+      do_run(days_back)
+    else
+      Logger.info("paddle_reconcile_skipped",
+        category: :paddle_reconcile,
+        reason: :billing_disabled
+      )
+
+      %{
+        paddle_total: 0,
+        local_total: 0,
+        drift: [],
+        skipped: :billing_disabled,
+        error: nil
+      }
+    end
+  end
+
+  defp do_run(days_back) do
+    since = DateTime.utc_now() |> DateTime.add(-days_back * 86_400, :second)
+
+    case Engram.Paddle.Client.impl().list_subscriptions(since) do
+      {:ok, paddle_subs} ->
+        diff(paddle_subs, since, nil)
+
+      {:partial, paddle_subs, reason} when reason in [:max_pages_exceeded, :pagination_loop] ->
+        # HTTP layer truncated the list (page cap hit or Paddle returned a
+        # next URL we'd seen before). Diff what we have but surface the
+        # truncation so the Mix task printer doesn't show a clean-looking
+        # result — silent-truncation is the exact failure mode this PR
+        # exists to surface.
+        Logger.error("paddle_reconcile_partial_list",
+          category: :paddle_reconcile,
+          reason_label: reason
+        )
+
+        diff(paddle_subs, since, reason)
+
+      {:error, reason} ->
+        Logger.error("paddle_reconcile_fetch_failed",
+          category: :paddle_reconcile,
+          reason: inspect(reason)
+        )
+
+        # Distinguish a fetch failure from a clean run in the return
+        # shape so the Mix task printer + future callers can branch.
+        # Without this, drift: [] + paddle_total: 0 looks identical to
+        # 'Paddle has no recently-updated subs' to a half-asleep on-call.
+        %{
+          paddle_total: 0,
+          local_total: 0,
+          drift: [],
+          skipped: :fetch_failed,
+          error: reason
+        }
+    end
+  end
+
+  defp diff(paddle_subs, since, skipped_reason) do
+    local_subs = recent_local_subscriptions(since)
+    local_by_paddle_id = Map.new(local_subs, &{&1.paddle_subscription_id, &1})
+
+    drift =
+      Enum.flat_map(paddle_subs, &classify(&1, local_by_paddle_id))
+
+    log_summary(paddle_subs, local_subs, drift)
+
+    Enum.each(drift, fn entry ->
+      Logger.error("paddle_reconciliation_drift",
+        category: :paddle_reconcile,
+        drift_kind: entry.kind,
+        paddle_subscription_id: entry.subscription_id
+      )
+    end)
+
+    %{
+      paddle_total: length(paddle_subs),
+      local_total: length(local_subs),
+      drift: drift,
+      skipped: skipped_reason,
+      error: nil
+    }
+  end
+
+  defp recent_local_subscriptions(since) do
+    from(s in Subscription, where: s.updated_at >= ^since)
+    |> Repo.all(skip_tenant_check: true)
+  end
+
+  defp classify(paddle_sub, local_by_id) do
+    id = paddle_sub["id"]
+    local = Map.get(local_by_id, id)
+
+    cond do
+      is_nil(local) ->
+        [%{subscription_id: id, kind: :missing_local, paddle: paddle_sub, local: nil}]
+
+      paddle_sub["status"] != local.status ->
+        [
+          %{
+            subscription_id: id,
+            kind: :status_mismatch,
+            paddle: paddle_sub["status"],
+            local: local.status
+          }
+        ]
+
+      Engram.Billing.tier_from_subscription(paddle_sub) != local.tier ->
+        [
+          %{
+            subscription_id: id,
+            kind: :tier_mismatch,
+            paddle: Engram.Billing.tier_from_subscription(paddle_sub),
+            local: local.tier
+          }
+        ]
+
+      period_mismatch?(paddle_sub, local) ->
+        [
+          %{
+            subscription_id: id,
+            kind: :period_mismatch,
+            paddle: get_in(paddle_sub, ["current_billing_period", "ends_at"]),
+            local: local.current_period_end
+          }
+        ]
+
+      true ->
+        []
+    end
+  end
+
+  defp period_mismatch?(paddle_sub, local) do
+    with %{"ends_at" => ts} <- paddle_sub["current_billing_period"],
+         {:ok, paddle_dt, _offset} <- DateTime.from_iso8601(ts),
+         %DateTime{} = local_dt <- local.current_period_end do
+      abs(DateTime.diff(paddle_dt, local_dt, :second)) > @period_skew_seconds
+    else
+      other ->
+        # Couldn't parse — treat as no-drift to avoid spamming Sentry
+        # on every reconciliation cycle when Paddle returns an
+        # unexpected shape, but warn so a contract change is visible.
+        Logger.warning("paddle_reconcile_period_unparseable",
+          category: :paddle_reconcile,
+          paddle_subscription_id: paddle_sub["id"],
+          reason: inspect(other)
+        )
+
+        false
+    end
+  end
+
+  defp log_summary(paddle, local, drift) do
+    Logger.info(
+      "paddle_reconcile_summary paddle=#{length(paddle)} local=#{length(local)} drift=#{length(drift)}",
+      category: :paddle_reconcile
+    )
+  end
+end

--- a/lib/engram/billing/workers/paddle_reconcile.ex
+++ b/lib/engram/billing/workers/paddle_reconcile.ex
@@ -1,0 +1,36 @@
+defmodule Engram.Billing.Workers.PaddleReconcile do
+  @moduledoc """
+  Daily Oban cron worker. Calls `Engram.Billing.Reconciliation.run/1` with
+  a 7-day window. Drift is logged at `:error` and captured by Sentry —
+  the worker itself always returns `:ok` so Oban doesn't mark the job
+  failed for data drift (which is signal, not job failure).
+
+  `max_attempts: 2` so a transient Repo / Paddle blip on the first run
+  doesn't have to wait 24h for the next cron tick. `Reconciliation.run/1`
+  catches expected `{:error, _}` from the Paddle client internally; the
+  retry is for unexpected raises (DBConnection.ConnectionError, etc).
+
+  Emits `[:engram, :paddle, :reconcile, :run]` per execution with the
+  result's `:skipped` field tagged as `outcome` (`:ok` when nil). Lets a
+  future Prometheus alert fire on truncation/fetch-fail rate without
+  parsing logs.
+  """
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 2,
+    unique: [period: 60, fields: [:worker]]
+
+  @impl Oban.Worker
+  def perform(_job) do
+    result = Engram.Billing.Reconciliation.run(7)
+    outcome = result.skipped || :ok
+
+    :telemetry.execute(
+      [:engram, :paddle, :reconcile, :run],
+      %{paddle_total: result.paddle_total, drift_count: length(result.drift)},
+      %{outcome: outcome}
+    )
+
+    :ok
+  end
+end

--- a/lib/engram/paddle/client.ex
+++ b/lib/engram/paddle/client.ex
@@ -70,6 +70,29 @@ defmodule Engram.Paddle.Client do
   @callback get_update_payment_transaction(subscription_id :: String.t()) ::
               {:ok, map()} | {:error, term()}
 
+  @doc """
+  List subscriptions updated since the given DateTime, paginated.
+
+  Paddle endpoint: `GET /subscriptions?updated_at[GTE]={iso}&per_page=200`.
+  Follows `meta.pagination.next` until exhausted.
+
+  Returns:
+    * `{:ok, list}` — full pagination consumed
+    * `{:partial, list, :max_pages_exceeded}` — hard page-count cap hit;
+      list is whatever was collected. Callers MUST treat this as drift
+      signal, not a clean read.
+    * `{:partial, list, :pagination_loop}` — Paddle returned a `next` URL
+      we'd already fetched; broke the loop. Same caller contract.
+    * `{:error, reason}` — transport / non-2xx.
+
+  Feeds the daily reconciliation Oban worker
+  (`Engram.Billing.Workers.PaddleReconcile`).
+  """
+  @callback list_subscriptions(since :: DateTime.t()) ::
+              {:ok, [map()]}
+              | {:partial, [map()], :max_pages_exceeded | :pagination_loop}
+              | {:error, term()}
+
   @default_impl Engram.Paddle.Client.HTTP
 
   @doc "Returns the configured client implementation module."

--- a/lib/engram/paddle/client/http.ex
+++ b/lib/engram/paddle/client/http.ex
@@ -118,6 +118,81 @@ defmodule Engram.Paddle.Client.HTTP do
   end
 
   @impl true
+  def list_subscriptions(%DateTime{} = since) do
+    with {:ok, api_key} <- fetch_api_key() do
+      iso = DateTime.to_iso8601(since)
+      url = base_url() <> "/subscriptions"
+      params = [{"updated_at[GTE]", iso}, {"per_page", 200}]
+      list_pages(url, params, headers(api_key), [], MapSet.new([url]), 1)
+    end
+  end
+
+  # Hard cap on pagination to bound the daily Oban worker even if Paddle
+  # misbehaves. At per_page=200 this allows 10k subscriptions per
+  # reconciliation window — comfortably past current scale and easy to
+  # bump if we ever approach it.
+  @max_pages 50
+
+  defp list_pages(_url, _params, _headers, acc, _seen, page) when page > @max_pages do
+    Logger.error("Paddle subscriptions-list page cap exceeded",
+      category: :paddle,
+      reason_label: :max_pages_exceeded
+    )
+
+    {:partial, Enum.reverse(acc) |> List.flatten(), :max_pages_exceeded}
+  end
+
+  defp list_pages(url, params, headers, acc, seen, page) do
+    case Req.get(url, params: params, headers: headers, receive_timeout: 15_000) do
+      {:ok, %Req.Response{status: 200, body: %{"data" => data} = body}} when is_list(data) ->
+        case get_in(body, ["meta", "pagination", "next"]) do
+          nil ->
+            {:ok, Enum.reverse([data | acc]) |> List.flatten()}
+
+          "" ->
+            {:ok, Enum.reverse([data | acc]) |> List.flatten()}
+
+          next_url when is_binary(next_url) ->
+            if MapSet.member?(seen, next_url) do
+              # Paddle returned a `next` URL we've already fetched — would
+              # be an infinite loop. Stop and surface what we have, tagged
+              # so the caller treats it as drift signal, not a clean read.
+              Logger.error("Paddle subscriptions-list pagination loop detected",
+                category: :paddle,
+                reason_label: :pagination_loop
+              )
+
+              {:partial, Enum.reverse([data | acc]) |> List.flatten(), :pagination_loop}
+            else
+              # Paddle's `next` is a fully-qualified URL with all query params
+              # encoded — don't pass `params:` again or Req appends them.
+              list_pages(
+                next_url,
+                [],
+                headers,
+                [data | acc],
+                MapSet.put(seen, next_url),
+                page + 1
+              )
+            end
+        end
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        log_non_2xx("subscriptions-list", status, body)
+        {:error, {:paddle_error, status}}
+
+      {:error, reason} ->
+        Logger.warning("Paddle subscriptions-list transport error",
+          category: :paddle,
+          reason: inspect(reason),
+          reason_label: :transport
+        )
+
+        {:error, reason}
+    end
+  end
+
+  @impl true
   def get_update_payment_transaction(subscription_id) when is_binary(subscription_id) do
     with {:ok, api_key} <- fetch_api_key() do
       url =
@@ -151,9 +226,15 @@ defmodule Engram.Paddle.Client.HTTP do
   end
 
   defp base_url do
-    case Application.get_env(:engram, :paddle_env, "sandbox") do
-      "production" -> @production_base
-      _ -> @sandbox_base
+    case Application.get_env(:engram, :paddle_api_base_url) do
+      url when is_binary(url) and url != "" ->
+        url
+
+      _ ->
+        case Application.get_env(:engram, :paddle_env, "sandbox") do
+          "production" -> @production_base
+          _ -> @sandbox_base
+        end
     end
   end
 

--- a/lib/engram/sentry/scrubber.ex
+++ b/lib/engram/sentry/scrubber.ex
@@ -1,0 +1,88 @@
+defmodule Engram.Sentry.Scrubber do
+  @moduledoc """
+  Sentry `:before_send` callback. Strips PII from event payloads before
+  they leave the process for Sentry's API.
+
+  Paddle webhooks echo customer email/address/phone — make sure none of
+  that reaches Sentry. The conservative posture is:
+
+    * **Drop `event.request` entirely.** Auto-instrumentation from
+      `Sentry.PlugContext` populates Authorization headers, session
+      cookies, and query strings with embedded tokens/emails — none of
+      it carries signal you can't get from structured logger metadata.
+    * **Recurse through `event.extra`, `event.user`, `event.tags`,
+      `event.contexts`, and `event.breadcrumbs[*].data`**, redacting any
+      key whose name contains an `@pii_substrings` token.
+
+  Deeper redaction (e.g. regex-scanning `event.message` /
+  `event.exception[*].value`) is out of scope here — logs upstream of
+  this scrubber already pass through `Engram.Logger.RedactFilter`, so
+  message strings reaching Sentry should already be redacted. The
+  scrubber is the last line of defense for *structured* payload fields.
+  """
+
+  @pii_substrings ~w(email phone address card iban pan ssn)
+  @redacted "[redacted]"
+
+  @spec scrub(Sentry.Event.t()) :: Sentry.Event.t()
+  def scrub(%Sentry.Event{} = event) do
+    %{
+      event
+      | request: nil,
+        extra: redact_map(event.extra),
+        user: redact_map(event.user),
+        tags: redact_map(event.tags),
+        contexts: redact_map(event.contexts),
+        breadcrumbs: redact_breadcrumbs(event.breadcrumbs)
+    }
+  end
+
+  defp redact_map(nil), do: nil
+
+  defp redact_map(map) when is_map(map) and not is_struct(map) do
+    Map.new(map, fn {k, v} ->
+      cond do
+        pii_key?(k) -> {k, @redacted}
+        is_map(v) and not is_struct(v) -> {k, redact_map(v)}
+        is_list(v) -> {k, redact_list(v)}
+        true -> {k, v}
+      end
+    end)
+  end
+
+  defp redact_map(other), do: other
+
+  defp redact_list(list) when is_list(list) do
+    Enum.map(list, fn
+      v when is_map(v) and not is_struct(v) -> redact_map(v)
+      v when is_list(v) -> redact_list(v)
+      v -> v
+    end)
+  end
+
+  defp redact_breadcrumbs(nil), do: nil
+  defp redact_breadcrumbs([]), do: []
+
+  defp redact_breadcrumbs(crumbs) when is_list(crumbs) do
+    Enum.map(crumbs, &redact_breadcrumb/1)
+  end
+
+  defp redact_breadcrumb(%Sentry.Interfaces.Breadcrumb{} = crumb) do
+    %{crumb | data: redact_map(crumb.data)}
+  end
+
+  defp redact_breadcrumb(%{data: data} = crumb) when is_map(crumb) do
+    %{crumb | data: redact_map(data)}
+  end
+
+  defp redact_breadcrumb(other), do: other
+
+  defp pii_key?(key) when is_atom(key), do: pii_key?(Atom.to_string(key))
+
+  defp pii_key?(key) when is_binary(key) do
+    downcased = String.downcase(key)
+    Enum.any?(@pii_substrings, &String.contains?(downcased, &1))
+  end
+
+  defp pii_key?(_), do: false
+end

--- a/lib/engram_web/controllers/webhook_controller.ex
+++ b/lib/engram_web/controllers/webhook_controller.ex
@@ -32,19 +32,70 @@ defmodule EngramWeb.WebhookController do
          {:ok, payload} <- read_body_once(conn),
          :ok <- verify_signature(payload, sig_header) do
       event = Jason.decode!(payload)
+      event_type = event["event_type"]
+      event_id = event["event_id"]
 
-      case Billing.upsert_from_paddle_event(event) do
-        {:ok, result} ->
-          _ = PostHogForwarder.forward_paddle_event(event, result)
+      Logger.metadata(
+        category: :paddle_webhook,
+        event_type: event_type,
+        event_id: event_id
+      )
+
+      Logger.info("paddle_webhook_received")
+
+      response =
+        :telemetry.span(
+          [:engram, :paddle, :webhook],
+          %{event_type: event_type, event_id: event_id},
+          fn ->
+            try do
+              case Billing.upsert_from_paddle_event(event) do
+                {:ok, result} = ok ->
+                  _ = PostHogForwarder.forward_paddle_event(event, result)
+                  {ok, %{event_type: event_type, event_id: event_id, result: :ok}}
+
+                {:error, reason} = err ->
+                  Logger.error("paddle_webhook_handler_error",
+                    reason: format_reason(reason)
+                  )
+
+                  {err, %{event_type: event_type, event_id: event_id, result: :error}}
+              end
+            rescue
+              error ->
+                # If upsert_from_paddle_event/1 raises (Repo down, behaviour
+                # mis-wired, malformed payload that escapes pattern match):
+                # log structurally with stacktrace, capture in Sentry, then
+                # surface as {:error, :exception} so the :telemetry stop
+                # event fires with result: :error (instead of :exception,
+                # which dashboards built on stop.duration miss). Silent-200
+                # ack still goes to Paddle; reconciliation catches any
+                # resulting drift within 24h.
+                stacktrace = __STACKTRACE__
+
+                Logger.error("paddle_webhook_handler_exception",
+                  reason: Exception.message(error),
+                  kind: error.__struct__
+                )
+
+                _ =
+                  Sentry.capture_exception(error,
+                    stacktrace: stacktrace,
+                    extra: %{event_type: event_type, event_id: event_id}
+                  )
+
+                {{:error, :exception},
+                 %{event_type: event_type, event_id: event_id, result: :error}}
+            end
+          end
+        )
+
+      case response do
+        {:ok, _} ->
+          Logger.info("paddle_webhook_ok")
           json(conn, %{status: "ok"})
 
-        {:error, reason} ->
-          Logger.warning("Paddle webhook processing failed",
-            event_type: event["event_type"],
-            event_id: event["event_id"],
-            reason: format_reason(reason)
-          )
-
+        {:error, _} ->
           json(conn, %{status: "ok"})
       end
     else

--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -218,6 +218,40 @@ defmodule EngramWeb.Telemetry do
         tags: [:cache, :op],
         description:
           "Per-user cache (Redis/Valkey) store error — façade failed open to the DB read-through. Non-zero means the shared cache is degraded; investigate the store."
+      ),
+
+      # PR #244 — Paddle webhook reliability surfaces.
+      #
+      # Emitted via :telemetry.span/3 in EngramWeb.WebhookController.paddle/2.
+      # Declared here so a future reporter (PromEx) picks them up automatically.
+      counter("engram.paddle.webhook.start.count",
+        event_name: [:engram, :paddle, :webhook, :start],
+        measurement: :system_time,
+        tags: [:event_type],
+        description:
+          "One per Paddle webhook entry. Tag `:event_type` is the Paddle event name (e.g. `subscription.created`)."
+      ),
+      summary("engram.paddle.webhook.stop.duration",
+        event_name: [:engram, :paddle, :webhook, :stop],
+        measurement: :duration,
+        unit: {:native, :millisecond},
+        tags: [:event_type, :result],
+        description:
+          "Webhook handler latency. Tag `:result` (:ok | :error) distinguishes successful upsert from swallowed `{:error, _}` (silent-200 path)."
+      ),
+      counter("engram.paddle.webhook.exception.count",
+        event_name: [:engram, :paddle, :webhook, :exception],
+        measurement: :duration,
+        tags: [:event_type, :kind],
+        description:
+          "Webhook handler raised. Non-zero = Paddle will retry; investigate via Sentry trace + reconciliation drift."
+      ),
+      counter("engram.paddle.reconcile.run.count",
+        event_name: [:engram, :paddle, :reconcile, :run],
+        measurement: :paddle_total,
+        tags: [:outcome],
+        description:
+          "Daily reconciliation runs by outcome. `outcome` is :ok | :billing_disabled | :fetch_failed | :max_pages_exceeded | :pagination_loop. Non-:ok counts = silent-truncation rate; page if sustained."
       )
     ]
   end

--- a/lib/mix/tasks/engram.billing.reconcile.ex
+++ b/lib/mix/tasks/engram.billing.reconcile.ex
@@ -1,0 +1,31 @@
+defmodule Mix.Tasks.Engram.Billing.Reconcile do
+  @shortdoc "Reconcile local subscriptions against Paddle"
+
+  @moduledoc """
+  Reconcile the local `subscriptions` table against Paddle.
+
+      mix engram.billing.reconcile          # 7 days
+      mix engram.billing.reconcile --days 30
+
+  Prints a summary map. Drift entries are also written to the structured
+  log at `:error` level so Sentry captures them.
+
+  In a release shell (`bin/engram rpc`), do NOT call this task — Mix
+  isn't available. Inline the body:
+
+      Engram.Billing.Reconciliation.run(7)
+  """
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [days: :integer])
+    days = Keyword.get(opts, :days, 7)
+
+    Mix.Task.run("app.start")
+
+    result = Engram.Billing.Reconciliation.run(days)
+    Mix.shell().info("reconciliation result: " <> inspect(result, pretty: true))
+  end
+end

--- a/lib/mix/tasks/engram.sentry.smoke.ex
+++ b/lib/mix/tasks/engram.sentry.smoke.ex
@@ -1,0 +1,36 @@
+defmodule Mix.Tasks.Engram.Sentry.Smoke do
+  @shortdoc "Send one synthetic Sentry capture to verify the pipeline"
+
+  @moduledoc """
+  Smoke-test the Sentry pipeline end-to-end. Captures one event with a
+  known marker so an operator can confirm the project ID + DSN + scrubber
+  + ingestion all work.
+
+  Run on staging:
+
+      mix engram.sentry.smoke
+
+  Then check the Sentry project for an event with
+  `tags.smoke_marker = "engram.sentry.smoke"`.
+  """
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_argv) do
+    Mix.Task.run("app.start")
+
+    _ =
+      Sentry.capture_message(
+        "engram.sentry.smoke — pipeline test",
+        level: :error,
+        tags: %{smoke_marker: "engram.sentry.smoke"}
+      )
+
+    Process.sleep(1_500)
+
+    Mix.shell().info(
+      "Sentry smoke event dispatched. Check the project for tag smoke_marker=engram.sentry.smoke."
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.326",
+      version: "0.5.327",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/billing/reconciliation_test.exs
+++ b/test/engram/billing/reconciliation_test.exs
@@ -1,6 +1,7 @@
 defmodule Engram.Billing.ReconciliationTest do
   use Engram.DataCase, async: false
 
+  import Ecto.Query
   import Mox
 
   alias Engram.Billing.Reconciliation
@@ -258,6 +259,40 @@ defmodule Engram.Billing.ReconciliationTest do
       end)
 
       assert %{skipped: :pagination_loop, paddle_total: 0} = Reconciliation.run(7)
+    end
+
+    test "does NOT report :missing_local for an idle local row Paddle just re-ticked" do
+      # Regression: local was created long ago (updated_at older than the
+      # reconciliation window) but Paddle re-emitted it (their `updated_at`
+      # advanced — e.g. scheduled_change processing). Lookup by
+      # paddle_subscription_id, not local updated_at, so the match holds.
+      user = insert(:user)
+
+      sub =
+        insert(:subscription,
+          user: user,
+          paddle_subscription_id: "sub_idle_local",
+          paddle_customer_id: "ctm_idle_local",
+          tier: "starter",
+          status: "active",
+          current_period_end: ~U[2026-06-30 00:00:00Z]
+        )
+
+      # Backdate local updated_at to 30 days ago — well outside the 7-day window.
+      stale_at = DateTime.utc_now() |> DateTime.add(-30 * 86_400, :second)
+
+      Engram.Repo.update_all(
+        from(s in Engram.Billing.Subscription, where: s.id == ^sub.id),
+        [set: [updated_at: stale_at]],
+        skip_tenant_check: true
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok, [paddle_sub(%{"id" => "sub_idle_local", "customer_id" => "ctm_idle_local"})]}
+      end)
+
+      assert %{drift: [], paddle_total: 1, local_total: 1} = Reconciliation.run(7)
     end
 
     test "tolerates period skew in both directions (symmetric ±2 minutes)" do

--- a/test/engram/billing/reconciliation_test.exs
+++ b/test/engram/billing/reconciliation_test.exs
@@ -1,0 +1,291 @@
+defmodule Engram.Billing.ReconciliationTest do
+  use Engram.DataCase, async: false
+
+  import Mox
+
+  alias Engram.Billing.Reconciliation
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    original = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, true)
+    on_exit(fn -> Application.put_env(:engram, :billing_enabled, original) end)
+    :ok
+  end
+
+  defp paddle_sub(overrides) do
+    Map.merge(
+      %{
+        "id" => "sub_default",
+        "status" => "active",
+        "customer_id" => "ctm_default",
+        "items" => [%{"price" => %{"id" => "pri_starter_monthly_test"}}],
+        "current_billing_period" => %{"ends_at" => "2026-06-30T00:00:00Z"}
+      },
+      overrides
+    )
+  end
+
+  describe "run/1" do
+    test "no drift when Paddle and local match" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_ok",
+        paddle_customer_id: "ctm_ok",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok, [paddle_sub(%{"id" => "sub_ok", "customer_id" => "ctm_ok"})]}
+      end)
+
+      assert %{drift: [], paddle_total: 1, local_total: 1} = Reconciliation.run(7)
+    end
+
+    test "detects :missing_local when Paddle has a subscription we don't" do
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok, [paddle_sub(%{"id" => "sub_ghost", "customer_id" => "ctm_ghost"})]}
+      end)
+
+      assert %{drift: [%{kind: :missing_local, subscription_id: "sub_ghost"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "detects :status_mismatch" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_status",
+        paddle_customer_id: "ctm_status",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           paddle_sub(%{
+             "id" => "sub_status",
+             "customer_id" => "ctm_status",
+             "status" => "past_due"
+           })
+         ]}
+      end)
+
+      assert %{drift: [%{kind: :status_mismatch, subscription_id: "sub_status"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "detects :tier_mismatch" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_tier",
+        paddle_customer_id: "ctm_tier",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           paddle_sub(%{
+             "id" => "sub_tier",
+             "customer_id" => "ctm_tier",
+             "items" => [%{"price" => %{"id" => "pri_pro_monthly_test"}}]
+           })
+         ]}
+      end)
+
+      assert %{drift: [%{kind: :tier_mismatch, subscription_id: "sub_tier"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "detects :period_mismatch beyond 2-minute skew" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_period",
+        paddle_customer_id: "ctm_period",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           paddle_sub(%{
+             "id" => "sub_period",
+             "customer_id" => "ctm_period",
+             "current_billing_period" => %{"ends_at" => "2026-07-31T00:00:00Z"}
+           })
+         ]}
+      end)
+
+      assert %{drift: [%{kind: :period_mismatch, subscription_id: "sub_period"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "tolerates period skew within 2 minutes" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_skew",
+        paddle_customer_id: "ctm_skew",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           paddle_sub(%{
+             "id" => "sub_skew",
+             "customer_id" => "ctm_skew",
+             # 1 minute later — within 2-minute tolerance
+             "current_billing_period" => %{"ends_at" => "2026-06-30T00:01:00Z"}
+           })
+         ]}
+      end)
+
+      assert %{drift: []} = Reconciliation.run(7)
+    end
+
+    test "no-ops when billing disabled (self-host)" do
+      Application.put_env(:engram, :billing_enabled, false)
+
+      assert %{
+               drift: [],
+               paddle_total: 0,
+               local_total: 0,
+               skipped: :billing_disabled,
+               error: nil
+             } = Reconciliation.run(7)
+    end
+
+    test "returns skipped: :fetch_failed with reason when Paddle list_subscriptions errors" do
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since -> {:error, :timeout} end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert %{
+                   drift: [],
+                   paddle_total: 0,
+                   local_total: 0,
+                   skipped: :fetch_failed,
+                   error: :timeout
+                 } = Reconciliation.run(7)
+        end)
+
+      assert log =~ "paddle_reconcile_fetch_failed"
+      assert log =~ "[error]"
+    end
+
+    test "reports only the highest-priority drift kind when multiple apply (status > tier > period)" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_multi",
+        paddle_customer_id: "ctm_multi",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           paddle_sub(%{
+             "id" => "sub_multi",
+             "customer_id" => "ctm_multi",
+             # status drift
+             "status" => "past_due",
+             # tier drift
+             "items" => [%{"price" => %{"id" => "pri_pro_monthly_test"}}],
+             # period drift
+             "current_billing_period" => %{"ends_at" => "2027-01-01T00:00:00Z"}
+           })
+         ]}
+      end)
+
+      # cond ordering in classify/2 stops at status_mismatch first.
+      assert %{drift: [%{kind: :status_mismatch, subscription_id: "sub_multi"}]} =
+               Reconciliation.run(7)
+    end
+
+    test "surfaces :partial truncation as skipped: :max_pages_exceeded" do
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        # HTTP layer truncated the list at the page cap.
+        {:partial, [paddle_sub(%{"id" => "sub_partial", "customer_id" => "ctm_partial"})],
+         :max_pages_exceeded}
+      end)
+
+      assert %{
+               drift: [%{kind: :missing_local, subscription_id: "sub_partial"}],
+               skipped: :max_pages_exceeded,
+               paddle_total: 1
+             } = Reconciliation.run(7)
+    end
+
+    test "surfaces :pagination_loop as skipped: :pagination_loop" do
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:partial, [], :pagination_loop}
+      end)
+
+      assert %{skipped: :pagination_loop, paddle_total: 0} = Reconciliation.run(7)
+    end
+
+    test "tolerates period skew in both directions (symmetric ±2 minutes)" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_skew_back",
+        paddle_customer_id: "ctm_skew_back",
+        tier: "starter",
+        status: "active",
+        current_period_end: ~U[2026-06-30 00:00:00Z]
+      )
+
+      Engram.Paddle.ClientMock
+      |> expect(:list_subscriptions, fn _since ->
+        {:ok,
+         [
+           paddle_sub(%{
+             "id" => "sub_skew_back",
+             "customer_id" => "ctm_skew_back",
+             # 1 minute EARLIER — also within tolerance (abs())
+             "current_billing_period" => %{"ends_at" => "2026-06-29T23:59:00Z"}
+           })
+         ]}
+      end)
+
+      assert %{drift: []} = Reconciliation.run(7)
+    end
+  end
+end

--- a/test/engram/billing/workers/paddle_reconcile_test.exs
+++ b/test/engram/billing/workers/paddle_reconcile_test.exs
@@ -1,0 +1,75 @@
+defmodule Engram.Billing.Workers.PaddleReconcileTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Mox
+
+  alias Engram.Billing.Workers.PaddleReconcile
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    original = Application.get_env(:engram, :billing_enabled)
+    Application.put_env(:engram, :billing_enabled, true)
+    on_exit(fn -> Application.put_env(:engram, :billing_enabled, original) end)
+    :ok
+  end
+
+  test "perform/1 calls Reconciliation.run/1 and returns :ok" do
+    Engram.Paddle.ClientMock
+    |> expect(:list_subscriptions, fn _since -> {:ok, []} end)
+
+    assert :ok = perform_job(PaddleReconcile, %{})
+  end
+
+  test "perform/1 emits [:engram, :paddle, :reconcile, :run] with outcome tag" do
+    ref =
+      :telemetry_test.attach_event_handlers(
+        self(),
+        [[:engram, :paddle, :reconcile, :run]]
+      )
+
+    Engram.Paddle.ClientMock
+    |> expect(:list_subscriptions, fn _since -> {:ok, []} end)
+
+    assert :ok = perform_job(PaddleReconcile, %{})
+
+    assert_received {[:engram, :paddle, :reconcile, :run], ^ref,
+                     %{paddle_total: 0, drift_count: 0}, %{outcome: :ok}}
+  end
+
+  test "perform/1 surfaces :partial outcome via telemetry" do
+    ref =
+      :telemetry_test.attach_event_handlers(
+        self(),
+        [[:engram, :paddle, :reconcile, :run]]
+      )
+
+    Engram.Paddle.ClientMock
+    |> expect(:list_subscriptions, fn _since -> {:partial, [], :max_pages_exceeded} end)
+
+    assert :ok = perform_job(PaddleReconcile, %{})
+
+    assert_received {[:engram, :paddle, :reconcile, :run], ^ref, _,
+                     %{outcome: :max_pages_exceeded}}
+  end
+
+  test "perform/1 returns :ok even when drift is detected (drift is signal, not failure)" do
+    Engram.Paddle.ClientMock
+    |> expect(:list_subscriptions, fn _since ->
+      {:ok,
+       [
+         %{
+           "id" => "sub_ghost",
+           "status" => "active",
+           "customer_id" => "ctm_ghost",
+           "items" => [%{"price" => %{"id" => "pri_starter_monthly_test"}}],
+           "current_billing_period" => %{"ends_at" => "2026-06-30T00:00:00Z"}
+         }
+       ]}
+    end)
+
+    assert :ok = perform_job(PaddleReconcile, %{})
+  end
+end

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -12,6 +12,59 @@ defmodule Engram.BillingTest do
 
   setup :verify_on_exit!
 
+  describe "tier_from_subscription/1" do
+    setup do
+      # Wipe any per-process dedupe state from previous tests.
+      Process.delete(:engram_unknown_price_ids_seen)
+      :ok
+    end
+
+    test "logs paddle_unknown_price_id once per unknown price per process" do
+      paddle_sub_unknown = fn id ->
+        %{"items" => [%{"price" => %{"id" => id}}]}
+      end
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          # Three calls with the same unknown price ID — must log only once.
+          # Unknown defaults to "free" (pricing v3) so a bogus payload can't
+          # silently grant paid features.
+          assert "free" == Billing.tier_from_subscription(paddle_sub_unknown.("pri_unknown_a"))
+          assert "free" == Billing.tier_from_subscription(paddle_sub_unknown.("pri_unknown_a"))
+          assert "free" == Billing.tier_from_subscription(paddle_sub_unknown.("pri_unknown_a"))
+
+          # A different unknown price → should also log once.
+          assert "free" == Billing.tier_from_subscription(paddle_sub_unknown.("pri_unknown_b"))
+        end)
+
+      occurrences = log |> String.split("paddle_unknown_price_id") |> length() |> Kernel.-(1)
+
+      assert occurrences == 2,
+             "expected 2 error logs (one per unique unknown id), got #{occurrences}"
+
+      assert log =~ "pri_unknown_a"
+      assert log =~ "pri_unknown_b"
+    end
+
+    test "does NOT log for known price IDs" do
+      starter_id = Application.get_env(:engram, :paddle_starter_monthly_price_id)
+      pro_id = Application.get_env(:engram, :paddle_pro_monthly_price_id)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert "starter" ==
+                   Billing.tier_from_subscription(%{
+                     "items" => [%{"price" => %{"id" => starter_id}}]
+                   })
+
+          assert "pro" ==
+                   Billing.tier_from_subscription(%{"items" => [%{"price" => %{"id" => pro_id}}]})
+        end)
+
+      refute log =~ "paddle_unknown_price_id"
+    end
+  end
+
   describe "tier/1" do
     test "returns :free for user with no subscription" do
       user = insert(:user)

--- a/test/engram/paddle/client/http_test.exs
+++ b/test/engram/paddle/client/http_test.exs
@@ -1,0 +1,152 @@
+defmodule Engram.Paddle.Client.HTTPTest do
+  use ExUnit.Case, async: false
+
+  alias Engram.Paddle.Client.HTTP
+
+  @since ~U[2026-01-01 00:00:00Z]
+
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(:engram, :paddle_api_key, "test-key")
+    Application.put_env(:engram, :paddle_api_base_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.delete_env(:engram, :paddle_api_key)
+      Application.delete_env(:engram, :paddle_api_base_url)
+    end)
+
+    %{bypass: bypass}
+  end
+
+  describe "list_subscriptions/1 pagination" do
+    test "returns single-page flattened list when no next", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/subscriptions", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{
+            "data" => [%{"id" => "sub_1"}],
+            "meta" => %{"pagination" => %{"next" => nil}}
+          })
+        )
+      end)
+
+      assert {:ok, [%{"id" => "sub_1"}]} = HTTP.list_subscriptions(@since)
+    end
+
+    test "follows meta.pagination.next URL with empty params on follow-up", %{bypass: bypass} do
+      next_url = "http://localhost:#{bypass.port}/subscriptions?after=sub_1"
+
+      Bypass.expect(bypass, "GET", "/subscriptions", fn conn ->
+        body =
+          case conn.query_string do
+            "after=sub_1" ->
+              %{"data" => [%{"id" => "sub_2"}], "meta" => %{"pagination" => %{"next" => nil}}}
+
+            _ ->
+              %{
+                "data" => [%{"id" => "sub_1"}],
+                "meta" => %{"pagination" => %{"next" => next_url}}
+              }
+          end
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end)
+
+      assert {:ok, [%{"id" => "sub_1"}, %{"id" => "sub_2"}]} = HTTP.list_subscriptions(@since)
+    end
+
+    test "treats empty-string next as terminator", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/subscriptions", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{
+            "data" => [%{"id" => "sub_1"}],
+            "meta" => %{"pagination" => %{"next" => ""}}
+          })
+        )
+      end)
+
+      assert {:ok, [%{"id" => "sub_1"}]} = HTTP.list_subscriptions(@since)
+    end
+
+    test "returns :partial with :pagination_loop tag when same next URL is returned twice",
+         %{bypass: bypass} do
+      # Paddle returns the same next URL every time → would otherwise
+      # infinite-recurse. The seen-URL guard must stop, return :partial
+      # tagged with :pagination_loop, and surface what we've collected.
+      loop_url = "http://localhost:#{bypass.port}/subscriptions?cursor=loop"
+
+      Bypass.expect(bypass, "GET", "/subscriptions", fn conn ->
+        body = %{
+          "data" => [%{"id" => "sub_loop_" <> (conn.query_string || "first")}],
+          "meta" => %{"pagination" => %{"next" => loop_url}}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end)
+
+      assert {:partial, results, :pagination_loop} = HTTP.list_subscriptions(@since)
+      assert results != []
+      # And critically — it terminates.
+    end
+
+    test "returns :partial with :max_pages_exceeded when Paddle keeps returning fresh next URLs",
+         %{bypass: bypass} do
+      # Bypass always returns a fresh next URL with the page number — the
+      # seen-URL guard never trips. The @max_pages 50 cap MUST stop it
+      # so the daily Oban worker can't be DoS'd by Paddle misbehavior.
+      base = "http://localhost:#{bypass.port}"
+      counter = :counters.new(1, [])
+
+      Bypass.expect(bypass, "GET", "/subscriptions", fn conn ->
+        n = :counters.get(counter, 1)
+        :counters.add(counter, 1, 1)
+
+        body = %{
+          "data" => [%{"id" => "sub_p#{n}"}],
+          "meta" => %{"pagination" => %{"next" => "#{base}/subscriptions?cursor=p#{n}"}}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end)
+
+      assert {:partial, results, :max_pages_exceeded} = HTTP.list_subscriptions(@since)
+      # Cap is @max_pages 50 — should hit it and stop.
+      assert length(results) >= 50
+    end
+
+    test "returns {:error, {:paddle_error, status}} on non-200", %{bypass: bypass} do
+      # Req's default retry policy retries 5xx up to 4 attempts. Use a
+      # 400 (non-retried) so the test doesn't spend 7s in backoff.
+      Bypass.expect_once(bypass, "GET", "/subscriptions", fn conn ->
+        Plug.Conn.send_resp(conn, 400, ~s({"error": "bad request"}))
+      end)
+
+      assert {:error, {:paddle_error, 400}} = HTTP.list_subscriptions(@since)
+    end
+
+    test "sends updated_at[GTE] filter and per_page=200 on first request", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/subscriptions", fn conn ->
+        assert conn.query_string =~ "updated_at"
+        assert conn.query_string =~ "per_page=200"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => [], "meta" => %{}}))
+      end)
+
+      assert {:ok, []} = HTTP.list_subscriptions(@since)
+    end
+  end
+end

--- a/test/engram/sentry/scrubber_test.exs
+++ b/test/engram/sentry/scrubber_test.exs
@@ -1,0 +1,157 @@
+defmodule Engram.Sentry.ScrubberTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Sentry.Scrubber
+
+  defp event(fields) do
+    fields
+    |> Map.new()
+    |> Map.put_new(:event_id, "00000000000000000000000000000000")
+    |> Map.put_new(:timestamp, "2026-01-01T00:00:00Z")
+    |> then(&struct!(Sentry.Event, &1))
+  end
+
+  defp request(fields), do: struct!(Sentry.Interfaces.Request, fields)
+  defp breadcrumb(fields), do: struct!(Sentry.Interfaces.Breadcrumb, fields)
+
+  describe "scrub/1 — request" do
+    test "drops event.request entirely (headers, cookies, query_string, data all gone)" do
+      e =
+        event(%{
+          request:
+            request(
+              data: %{"customer_email" => "u@example.com"},
+              headers: %{"authorization" => "Bearer secret-token"},
+              cookies: "session=abc123",
+              query_string: "email=u@example.com"
+            )
+        })
+
+      assert %Sentry.Event{request: nil} = Scrubber.scrub(e)
+    end
+
+    test "tolerates nil request" do
+      e = event(%{request: nil, extra: %{ok: "kept"}})
+      assert %Sentry.Event{request: nil, extra: %{ok: "kept"}} = Scrubber.scrub(e)
+    end
+  end
+
+  describe "scrub/1 — extra" do
+    test "redacts email/phone/address fields in extra map" do
+      e =
+        event(%{
+          extra: %{
+            customer_email: "u@example.com",
+            billing_phone: "+15551234",
+            address_line1: "1 Main St",
+            unrelated: "keep"
+          }
+        })
+
+      scrubbed = Scrubber.scrub(e)
+      assert scrubbed.extra.customer_email == "[redacted]"
+      assert scrubbed.extra.billing_phone == "[redacted]"
+      assert scrubbed.extra.address_line1 == "[redacted]"
+      assert scrubbed.extra.unrelated == "keep"
+    end
+
+    test "redacts nested maps recursively" do
+      e = event(%{extra: %{customer: %{email: "u@example.com", id: "cus_1"}}})
+      scrubbed = Scrubber.scrub(e)
+      assert scrubbed.extra.customer.email == "[redacted]"
+      assert scrubbed.extra.customer.id == "cus_1"
+    end
+
+    test "redacts string-keyed PII fields" do
+      e = event(%{extra: %{"customer" => %{"email" => "u@example.com", "id" => "cus_1"}}})
+      scrubbed = Scrubber.scrub(e)
+      assert scrubbed.extra["customer"]["email"] == "[redacted]"
+      assert scrubbed.extra["customer"]["id"] == "cus_1"
+    end
+
+    test "recurses into lists" do
+      e = event(%{extra: %{recipients: [%{email: "a@b.com"}, %{email: "c@d.com"}]}})
+      scrubbed = Scrubber.scrub(e)
+      assert Enum.map(scrubbed.extra.recipients, & &1.email) == ["[redacted]", "[redacted]"]
+    end
+
+    test "redacts card/iban/pan/ssn variants" do
+      e =
+        event(%{
+          extra: %{
+            card_last4: "1234",
+            iban_partial: "DE00",
+            pan_token: "abc",
+            ssn_hint: "XXX"
+          }
+        })
+
+      scrubbed = Scrubber.scrub(e)
+      assert scrubbed.extra.card_last4 == "[redacted]"
+      assert scrubbed.extra.iban_partial == "[redacted]"
+      assert scrubbed.extra.pan_token == "[redacted]"
+      assert scrubbed.extra.ssn_hint == "[redacted]"
+    end
+  end
+
+  describe "scrub/1 — user/tags/contexts" do
+    test "redacts PII in event.user" do
+      e = event(%{user: %{email: "u@example.com", id: "user_1"}})
+      scrubbed = Scrubber.scrub(e)
+      assert scrubbed.user.email == "[redacted]"
+      assert scrubbed.user.id == "user_1"
+    end
+
+    test "redacts PII in event.tags" do
+      e = event(%{tags: %{customer_email: "u@example.com", env: "prod"}})
+      scrubbed = Scrubber.scrub(e)
+      assert scrubbed.tags.customer_email == "[redacted]"
+      assert scrubbed.tags.env == "prod"
+    end
+
+    test "redacts PII in event.contexts (nested)" do
+      e = event(%{contexts: %{runtime: %{name: "elixir"}, customer: %{email: "u@x.com"}}})
+      scrubbed = Scrubber.scrub(e)
+      assert scrubbed.contexts.customer.email == "[redacted]"
+      assert scrubbed.contexts.runtime.name == "elixir"
+    end
+  end
+
+  describe "scrub/1 — breadcrumbs" do
+    test "redacts PII in breadcrumb data" do
+      e =
+        event(%{
+          breadcrumbs: [
+            breadcrumb(category: "auth", data: %{user_email: "u@x.com", id: "u_1"}),
+            breadcrumb(category: "http", data: %{url: "/api/notes"})
+          ]
+        })
+
+      scrubbed = Scrubber.scrub(e)
+      [auth, http] = scrubbed.breadcrumbs
+      assert auth.data.user_email == "[redacted]"
+      assert auth.data.id == "u_1"
+      assert http.data.url == "/api/notes"
+    end
+
+    test "tolerates breadcrumbs as plain maps (defensive)" do
+      e = event(%{breadcrumbs: [%{category: "x", data: %{email: "u@x.com"}}]})
+      scrubbed = Scrubber.scrub(e)
+      [crumb] = scrubbed.breadcrumbs
+      assert crumb.data.email == "[redacted]"
+    end
+
+    test "tolerates empty breadcrumbs list" do
+      e = event(%{breadcrumbs: []})
+      assert Scrubber.scrub(e).breadcrumbs == []
+    end
+  end
+
+  test "leaves event unchanged when nothing PII-bearing is present" do
+    e = event(%{extra: %{just_ids: "ok"}, user: %{id: "u_1"}, tags: %{env: "prod"}})
+    scrubbed = Scrubber.scrub(e)
+    assert scrubbed.extra == e.extra
+    assert scrubbed.user == e.user
+    assert scrubbed.tags == e.tags
+  end
+end

--- a/test/engram_web/controllers/webhook_controller_test.exs
+++ b/test/engram_web/controllers/webhook_controller_test.exs
@@ -232,6 +232,86 @@ defmodule EngramWeb.WebhookControllerTest do
       assert sub.status == "active"
     end
 
+    test "emits :telemetry.span events on success", %{conn: conn} do
+      user = insert(:user)
+
+      ref =
+        :telemetry_test.attach_event_handlers(
+          self(),
+          [
+            [:engram, :paddle, :webhook, :start],
+            [:engram, :paddle, :webhook, :stop]
+          ]
+        )
+
+      payload =
+        Jason.encode!(%{
+          "event_type" => "subscription.created",
+          "event_id" => "ntf_wh_telemetry",
+          "data" => %{
+            "id" => "sub_wh_telemetry",
+            "status" => "trialing",
+            "customer_id" => "ctm_wh_telemetry",
+            "items" => [%{"price" => %{"id" => "pri_starter_monthly_test"}}],
+            "current_billing_period" => %{"ends_at" => "2026-05-20T00:00:00Z"},
+            "custom_data" => %{"user_id" => user.id}
+          }
+        })
+
+      ts = System.system_time(:second)
+      sig_header = "ts=#{ts};h1=#{sign(ts, payload)}"
+
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("paddle-signature", sig_header)
+      |> post("/webhooks/paddle", payload)
+
+      assert_received {[:engram, :paddle, :webhook, :start], ^ref, _measurements,
+                       %{event_type: "subscription.created", event_id: "ntf_wh_telemetry"}}
+
+      assert_received {[:engram, :paddle, :webhook, :stop], ^ref, %{duration: _},
+                       %{
+                         event_type: "subscription.created",
+                         event_id: "ntf_wh_telemetry",
+                         result: :ok
+                       }}
+    end
+
+    test "emits :telemetry.span with result: :error on handler failure", %{conn: conn} do
+      ref =
+        :telemetry_test.attach_event_handlers(
+          self(),
+          [[:engram, :paddle, :webhook, :stop]]
+        )
+
+      payload =
+        Jason.encode!(%{
+          "event_type" => "subscription.created",
+          "event_id" => "ntf_err_result",
+          "data" => %{
+            "id" => "sub_err_result",
+            "status" => "trialing",
+            "customer_id" => "ctm_err_result",
+            "items" => [%{"price" => %{"id" => "pri_starter_monthly_test"}}],
+            "current_billing_period" => %{"ends_at" => "2026-05-20T00:00:00Z"},
+            # Missing user_id → Billing.upsert_from_paddle_event/1 returns
+            # {:error, :missing_user_id} → :stop fires with result: :error.
+            "custom_data" => %{}
+          }
+        })
+
+      ts = System.system_time(:second)
+      sig_header = "ts=#{ts};h1=#{sign(ts, payload)}"
+
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("paddle-signature", sig_header)
+      |> post("/webhooks/paddle", payload)
+
+      assert_received {[:engram, :paddle, :webhook, :stop], ^ref, %{duration: _},
+                       %{event_id: "ntf_err_result", result: :error}}
+    end
+
     test "subscription.created with missing custom_data.user_id returns 200 and creates no row",
          %{conn: conn} do
       payload =

--- a/test/engram_web/telemetry_test.exs
+++ b/test/engram_web/telemetry_test.exs
@@ -158,5 +158,25 @@ defmodule EngramWeb.TelemetryTest do
       assert "engram.oban.discarded.count" in names,
              "Oban jobs that exhausted max_attempts must be counted — non-zero is a triage signal"
     end
+
+    test "registers engram.paddle.webhook.start counter (#244)", %{names: names} do
+      assert "engram.paddle.webhook.start.count" in names,
+             "Each Paddle webhook entry must be counted so PromEx can attach"
+    end
+
+    test "registers engram.paddle.webhook.stop summary (#244)", %{names: names} do
+      assert "engram.paddle.webhook.stop.duration" in names,
+             "Webhook latency + result must be summarised so a PromEx histogram exposes the silent-200 path"
+    end
+
+    test "registers engram.paddle.webhook.exception counter (#244)", %{names: names} do
+      assert "engram.paddle.webhook.exception.count" in names,
+             "Webhook raises must be counted so PromEx + Sentry both see them"
+    end
+
+    test "registers engram.paddle.reconcile.run counter with :outcome tag (#244)", %{names: names} do
+      assert "engram.paddle.reconcile.run.count" in names,
+             "Daily reconciliation outcome must be counted so silent truncation is alertable without log parsing"
+    end
   end
 end


### PR DESCRIPTION
Closes #244.

Ships four observability layers + daily Paddle↔DB reconciliation:

1. **Structured logs** on every webhook entry/exit/error (`category: :paddle_webhook`). Swallowed-200-error path bumped from warn → error so Sentry catches it.
2. **`:telemetry` span** events `[:engram, :paddle, :webhook, :{start,stop,exception}]` declared in `EngramWeb.Telemetry` (PromEx-ready).
3. **Sentry** capture wired via `Sentry.LoggerHandler`. `Engram.Sentry.Scrubber` PII `before_send` strips email/phone/address/card/iban/pan/ssn from extra + drops request body. `mix engram.sentry.smoke` verifies pipeline on staging.
4. **Daily reconciliation** — `Engram.Billing.Workers.PaddleReconcile` runs at 02:00 UTC, calls `Engram.Billing.Reconciliation.run(7)`, detects four drift kinds (`:missing_local`, `:status_mismatch`, `:tier_mismatch`, `:period_mismatch`). Each drift entry logs at error so Sentry captures. Worker returns `:ok` regardless of drift (drift is signal, not job failure).

## Scope changes vs original ticket

- **Drops "alert rules deployed (5xx rate, exception rate)"** — Engram has no Prometheus deployment yet, so PromEx alone would be a dead pipe. Filed as engram-app/engram-infra follow-up to deploy Prometheus + wire PromEx + alert rules (carries the dropped acceptance item).
- All other acceptance items satisfied.

## Self-host

Sentry no-ops when `SENTRY_DSN` unset; reconciliation no-ops when `:billing_enabled` is false. Both safe defaults.

## Refs

- Spec: `docs/superpowers/specs/2026-05-31-paddle-webhook-monitoring-design.md`
- Plan: `docs/superpowers/plans/2026-05-31-paddle-webhook-monitoring.md`
- Drift response runbook: `docs/context/paddle-integration.md` → Monitoring section

## Test plan

- [x] `mix test` — 1973 tests, 0 failures, 7 skipped
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — 0 findings
- [ ] Staging deploy: run `mix engram.sentry.smoke` and confirm Sentry receives marker event
- [ ] Staging deploy: trigger a test webhook (Paddle dashboard) and confirm logs + `:telemetry` events emit
- [ ] Staging deploy: take backend offline 5 min during webhook delivery, verify Paddle retries and reconciliation surfaces any persistent drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)