### PR TITLE
feat(socket): no-auth origin probe socket for post-deploy smoke

### DIFF
--- a/lib/engram_web/channels/origin_probe_socket.ex
+++ b/lib/engram_web/channels/origin_probe_socket.ex
@@ -1,0 +1,26 @@
+defmodule EngramWeb.OriginProbeSocket do
+  @moduledoc """
+  No-auth socket used by the post-deploy WebSocket smoke
+  (engram-infra `ops/post-apply-smoke/ws.sh`). `connect/3` always returns
+  `{:ok, socket}` and no channels are attached, so the only gate is
+  `Phoenix.Socket.check_origin` — the smoke can distinguish origin-allowed
+  (101 Switching Protocols) from origin-rejected (403) at the HTTP layer
+  without minting an auth token.
+
+  The main `/socket` (EngramWeb.UserSocket) requires a `"token"` param and
+  returns 403 on its absence, which is indistinguishable from a
+  `check_origin` 403 — that's why this dedicated probe socket exists
+  rather than smoking the main socket.
+
+  Security: an attacker that opens this socket can do nothing with it (no
+  channels to join, no messages to send). It exists purely as a probe for
+  the origin allowlist.
+  """
+  use Phoenix.Socket
+
+  @impl true
+  def connect(_params, socket, _connect_info), do: {:ok, socket}
+
+  @impl true
+  def id(_socket), do: nil
+end

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -7,6 +7,16 @@ defmodule EngramWeb.Endpoint do
     ],
     longpoll: false
 
+  # Origin-allowlist probe — no auth, no channels. Reuses the same
+  # check_origin MFA as the main socket so the smoke validates the
+  # exact allowlist used by UserSocket. See EngramWeb.OriginProbeSocket
+  # moduledoc and engram-infra ops/post-apply-smoke/ws.sh.
+  socket "/socket/origin-probe", EngramWeb.OriginProbeSocket,
+    websocket: [
+      check_origin: {__MODULE__, :check_origin, []}
+    ],
+    longpoll: false
+
   @doc false
   # Phoenix.Socket.Transport invokes this MFA with `URI.parse(origin)`, so we must
   # normalize the URI back to a `scheme://host[:port]` string before comparing

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.275",
+      version: "0.5.276",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/channels/origin_probe_socket_test.exs
+++ b/test/engram_web/channels/origin_probe_socket_test.exs
@@ -1,0 +1,21 @@
+defmodule EngramWeb.OriginProbeSocketTest do
+  use ExUnit.Case, async: true
+
+  test "connect/3 always returns {:ok, socket} with no params" do
+    assert {:ok, %Phoenix.Socket{}} =
+             EngramWeb.OriginProbeSocket.connect(%{}, %Phoenix.Socket{}, %{})
+  end
+
+  test "connect/3 ignores any params" do
+    assert {:ok, %Phoenix.Socket{}} =
+             EngramWeb.OriginProbeSocket.connect(
+               %{"anything" => "anyvalue", "token" => "ignored"},
+               %Phoenix.Socket{},
+               %{}
+             )
+  end
+
+  test "id/1 returns nil (no identity, no broadcast routing)" do
+    assert is_nil(EngramWeb.OriginProbeSocket.id(%Phoenix.Socket{}))
+  end
+end


### PR DESCRIPTION
## Summary
Adds `EngramWeb.OriginProbeSocket` mounted at `/socket/origin-probe` — no-auth, no channels, only gate is `Phoenix.Socket.check_origin`. Consumed by the new post-deploy WebSocket smoke in engram-infra (`ops/post-apply-smoke/ws.sh`).

**Why:** the main `/socket` (UserSocket) requires a `"token"` param and returns 403 on its absence — indistinguishable at the HTTP layer from a `check_origin` 403. The original smoke design assumed the main socket could be probed directly; live validation on 2026-05-31 showed every host always 403'd from auth, not from origin reject, so the smoke would have always alerted and defeated its own purpose. This probe socket fixes that.

**Security:** an attacker that opens this socket can do nothing with it (no channels to join, no messages to send). Public WebSocket connection that accomplishes nothing.

Spec: [`docs/superpowers/specs/2026-05-30-deploy-guardrails-design.md`](https://github.com/engram-app/engram-workspace/blob/main/docs/superpowers/specs/2026-05-30-deploy-guardrails-design.md) → "Backend prerequisite" under Guardrail #2 (engram-workspace PR #48).

## Test plan
- [ ] `mix test test/engram_web/channels/origin_probe_socket_test.exs` — 3 tests, all pass
- [ ] After deploy: WS upgrade with valid Origin to `/socket/origin-probe/websocket?vsn=2.0.0` → `HTTP 101`
- [ ] After deploy: same WS upgrade with `Origin: https://attacker.example` → `HTTP 403` (confirms check_origin still gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)