### PR TITLE
fix(onboarding): two cache races causing 'all over the place' signup flow

### DIFF
--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }))
+vi.mock('./client', () => ({
+  api: { get: vi.fn(), post, patch: vi.fn(), del: vi.fn() },
+  setTokenGetter: vi.fn(),
+}))
+
+import { useAcceptTerms } from './queries'
+
+let qc: QueryClient
+
+beforeEach(() => {
+  post.mockReset()
+  qc = new QueryClient()
+})
+
+afterEach(() => {
+  qc.clear()
+})
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+describe('useAcceptTerms', () => {
+  it('awaits onboarding/status refetch before mutateAsync resolves', async () => {
+    // Seed the cache so invalidate triggers a refetch instead of a no-op.
+    qc.setQueryData(['onboarding', 'status'], { next_step: 'agreement', enabled: true })
+
+    let invalidateResolved = false
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries').mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 20))
+      invalidateResolved = true
+    })
+
+    post.mockResolvedValue({ version: 'v2.0', accepted_at: '2026-06-01T00:00:00Z' })
+
+    const { result } = renderHook(() => useAcceptTerms(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        tos_version: 'v2.0',
+        tos_hash: 'th',
+        privacy_version: 'v1.0',
+        privacy_hash: 'ph',
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['onboarding', 'status'] })
+    // If onSuccess fires-and-forgets, this would still be false when mutateAsync resolves
+    // and the user would be navigated with a stale cache (bug: double-accept).
+    expect(invalidateResolved).toBe(true)
+  })
+})

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -272,8 +272,14 @@ export function useAcceptTerms() {
       privacy_version: string
       privacy_hash: string
     }) => api.post<{ version: string; accepted_at: string }>('/onboarding/accept-terms', body),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['onboarding', 'status'] })
+    // `await` is load-bearing: callers (agreement-page) navigate to /onboard
+    // immediately after the mutation resolves, and OnboardRedirect reads cached
+    // status to pick the next step. Without awaiting the refetch, the stale
+    // `next_step: 'agreement'` bounces the user back to the same page and
+    // they're forced to accept twice. invalidateQueries returns a Promise that
+    // settles when active queries have refetched — await it.
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['onboarding', 'status'] })
     },
   })
 }

--- a/frontend/src/auth/clerk-auth-provider.tsx
+++ b/frontend/src/auth/clerk-auth-provider.tsx
@@ -3,7 +3,9 @@ import { dark } from "@clerk/themes"
 import { useCallback, useEffect, useMemo } from 'react'
 import { AuthContext, type AuthAdapter } from './auth-context'
 import { rememberSignupUser } from './signup-rejection'
+import { useClearQueryCacheOnUserChange } from './use-clear-query-cache-on-user-change'
 import { setTokenGetter } from '../api/client'
+import { queryClient } from '../api/query-client'
 import { config } from '../config'
 import { router } from '../router'
 import { ROUTES } from '../routes'
@@ -49,6 +51,8 @@ function ClerkAdapterInner({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (clerkUserId) rememberSignupUser(clerkUserId)
   }, [clerkUserId])
+
+  useClearQueryCacheOnUserChange(queryClient, clerkUserId)
 
   const email = clerk.user?.primaryEmailAddress?.emailAddress
   const imageUrl = clerk.user?.imageUrl

--- a/frontend/src/auth/use-clear-query-cache-on-user-change.test.tsx
+++ b/frontend/src/auth/use-clear-query-cache-on-user-change.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
+import { useClearQueryCacheOnUserChange } from './use-clear-query-cache-on-user-change'
+
+type Props = { userId: string | undefined }
+
+let qc: QueryClient
+let clearSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  qc = new QueryClient()
+  clearSpy = vi.spyOn(qc, 'clear')
+})
+
+afterEach(() => {
+  clearSpy.mockRestore()
+  qc.clear()
+})
+
+function mount(initial: Props['userId']) {
+  return renderHook<void, Props>(({ userId }) => useClearQueryCacheOnUserChange(qc, userId), {
+    initialProps: { userId: initial },
+  })
+}
+
+describe('useClearQueryCacheOnUserChange', () => {
+  it('does not clear on initial mount with no signed-in user', () => {
+    mount(undefined)
+    expect(clearSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not clear on first sign-in (undefined -> A)', () => {
+    const { rerender } = mount(undefined)
+    rerender({ userId: 'user_A' })
+    expect(clearSpy).not.toHaveBeenCalled()
+  })
+
+  it('clears on sign-out (A -> undefined)', () => {
+    const { rerender } = mount('user_A')
+    rerender({ userId: undefined })
+    expect(clearSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears on cross-account swap in same tab (A -> B)', () => {
+    const { rerender } = mount('user_A')
+    rerender({ userId: 'user_B' })
+    expect(clearSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not clear when userId is stable across renders', () => {
+    const { rerender } = mount('user_A')
+    rerender({ userId: 'user_A' })
+    rerender({ userId: 'user_A' })
+    expect(clearSpy).not.toHaveBeenCalled()
+  })
+
+  it('clears once per transition (A -> undefined -> B)', () => {
+    const { rerender } = mount('user_A')
+    rerender({ userId: undefined })
+    rerender({ userId: 'user_B' })
+    expect(clearSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/auth/use-clear-query-cache-on-user-change.ts
+++ b/frontend/src/auth/use-clear-query-cache-on-user-change.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react'
+import type { QueryClient } from '@tanstack/react-query'
+
+// Wipe the React Query cache whenever the signed-in user changes. The cache is
+// a module singleton (api/query-client.ts) and survives Clerk sign-out, so
+// without this, a sign-out → sign-up in the same tab serves the previous
+// account's cached `/api/onboarding/status` (`staleTime: Infinity`) to the new
+// user and the onboarding gate lets them straight into the vault. Only clear
+// on transitions away from a previously-known identity; first-mount and
+// first-sign-in shouldn't fire (there's nothing to wipe).
+export function useClearQueryCacheOnUserChange(
+  queryClient: QueryClient,
+  userId: string | undefined,
+): void {
+  const prevRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    if (prevRef.current === userId) return
+    if (prevRef.current !== undefined) queryClient.clear()
+    prevRef.current = userId
+  }, [queryClient, userId])
+}

--- a/frontend/src/onboarding/agreement-page.flow.test.tsx
+++ b/frontend/src/onboarding/agreement-page.flow.test.tsx
@@ -1,0 +1,120 @@
+import { useEffect } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+} from 'react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const { get, post } = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }))
+vi.mock('../api/client', () => ({
+  api: { get, post, patch: vi.fn(), del: vi.fn() },
+  setTokenGetter: vi.fn(),
+}))
+
+// Stub the legal doc loaders so this test doesn't depend on which version
+// strings are bundled in the build.
+vi.mock('../legal/load', () => ({
+  loadVersion: () => '# Terms\n\nMock terms content.',
+  sha256Hex: async () => 'a'.repeat(64),
+}))
+
+import AgreementPage from './agreement-page'
+import { useOnboardingStatus } from '../api/queries'
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="path">{loc.pathname}</div>
+}
+
+// Mimic the real OnboardRedirect — reads cached status and immediately navigates
+// to the indicated next step. The whole race lives in step 4 of submit-then-navigate:
+// `OnboardRedirect` runs while the post-mutation refetch is still in flight,
+// and routes the user wherever the *current cache value* says.
+function OnboardRedirect() {
+  const { data, isLoading } = useOnboardingStatus()
+  if (isLoading || !data) return null
+  return <Navigate to={`/onboard/${data.next_step}`} replace />
+}
+
+let agreementMounts = 0
+function CountingAgreementPage() {
+  useEffect(() => {
+    agreementMounts++
+  }, [])
+  return <AgreementPage />
+}
+
+const STATUS_BEFORE = {
+  enabled: true,
+  next_step: 'agreement',
+  current_tos_version: 'v2.0',
+  current_privacy_version: 'v1.0',
+  terms_ok: false,
+  subscription_ok: false,
+}
+const STATUS_AFTER = {
+  ...STATUS_BEFORE,
+  next_step: 'billing',
+  terms_ok: true,
+}
+
+describe('AgreementPage accept-then-redirect flow', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+    agreementMounts = 0
+  })
+
+  it('lands on /onboard/billing after one accept (no double-accept loop)', async () => {
+    let accepted = false
+    let statusGetCalls = 0
+    get.mockImplementation(async (url: string) => {
+      if (url !== '/onboarding/status') throw new Error(`unexpected GET ${url}`)
+      statusGetCalls++
+      // The initial mount fetch returns instantly so the page renders. The
+      // refetch that invalidation triggers takes 80ms — long enough that
+      // OnboardRedirect would observably read a stale cache if onSuccess
+      // didn't await invalidation.
+      if (statusGetCalls > 1) await new Promise((r) => setTimeout(r, 80))
+      return accepted ? STATUS_AFTER : STATUS_BEFORE
+    })
+    post.mockImplementation(async (url: string) => {
+      if (url !== '/onboarding/accept-terms') throw new Error(`unexpected POST ${url}`)
+      await new Promise((r) => setTimeout(r, 20))
+      accepted = true
+      return { version: 'v2.0', accepted_at: 'now' }
+    })
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/onboard/agreement']}>
+          <LocationProbe />
+          <Routes>
+            <Route path="/onboard/agreement" element={<CountingAgreementPage />} />
+            <Route path="/onboard" element={<OnboardRedirect />} />
+            <Route path="/onboard/billing" element={<div data-testid="billing-landed" />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: /agree/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+
+    // With the fix, the mutation only resolves after the cache is refreshed,
+    // so OnboardRedirect reads STATUS_AFTER and routes to /onboard/billing.
+    // Without the fix, OnboardRedirect reads STATUS_BEFORE (stale) and routes
+    // back to /onboard/agreement, re-mounting CountingAgreementPage.
+    await waitFor(() => expect(screen.getByTestId('billing-landed')).toBeInTheDocument())
+
+    expect(screen.getByTestId('path').textContent).toBe('/onboard/billing')
+    expect(agreementMounts).toBe(1)
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+})

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.277",
+      version: "0.5.278",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Staging users reported post-signup onboarding behaving inconsistently — sometimes no terms prompt at all, sometimes the same Terms of Service prompt twice in a row. Two separate cache bugs in the SPA, neither dependent on backend changes.

### Bug 1: cross-account cache bleed (commit 1)

- `queryClient` is a module-level singleton (`api/query-client.ts`) and survives `clerk.signOut()`. `useOnboardingStatus` is `staleTime: Infinity`.
- Same-tab sign-out → sign-up serves the prior account's cached `{next_step: 'done'}` to the new user; `OnboardingGate` passes them through to the vault with no terms prompt. A later window-focus refetch yanks them into `/onboard/agreement` mid-session.
- **Fix:** new `useClearQueryCacheOnUserChange(queryClient, userId)` hook tracks Clerk `user.id` and calls `queryClient.clear()` on any transition where the previous id was defined. Wired into `ClerkAdapterInner`. First-mount and first-sign-in don't fire (nothing to wipe); cold-load `undefined → A` while `isLoaded` flips is also skipped.
- The hook receives `queryClient` as a parameter rather than via `useQueryClient()` because `ClerkAdapterInner` is rendered outside `QueryClientProvider` in `main.tsx` (auth wraps query, not the reverse).

### Bug 2: double Terms-of-Service prompt (commit 3)

- `useAcceptTerms.onSuccess` called `qc.invalidateQueries(...)` without awaiting.
- After accept, `AgreementPage` immediately `navigate('/onboard', { replace: true })`. `OnboardRedirect` reads cached status (still `next_step: 'agreement'`) and bounces back to `/onboard/agreement`. The user reads + accepts the same ToS document a second time before the in-flight refetch lands.
- **Fix:** `await qc.invalidateQueries({ queryKey: ['onboarding', 'status'] })` inside `onSuccess`. `invalidateQueries` resolves when active queries finish refetching, so `mutateAsync` doesn't resolve (and the page doesn't navigate) until the cache reflects the new state.

Verified against staging before patching: `billing_enabled=true`, `terms_versions=2` — ruled out the self-host short-circuit and the empty-floor hypotheses.

## Test plan

- [x] 6 new vitest cases on `useClearQueryCacheOnUserChange` cover: initial mount with no user, first sign-in, sign-out, cross-account swap, stable userId, A → undefined → B sequence.
- [x] 1 new vitest case on `useAcceptTerms` asserts that the invalidate Promise settles before `mutateAsync` resolves (would fail under the fire-and-forget behavior).
- [x] `bun run test` — 142/142 pass.
- [x] `bunx tsc --noEmit` clean.
- [ ] Staging smoke — sign up as a new user in a tab where a previous account was signed in → confirm new user lands on `/onboard/agreement` (not the vault).
- [ ] Staging smoke — on `/onboard/agreement`, accept once → confirm advance to `/onboard/billing` without seeing the Terms a second time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)