### PR TITLE
fix(auth): clear React Query cache on local-auth identity change

### DIFF
--- a/frontend/src/auth/local-auth-provider.tsx
+++ b/frontend/src/auth/local-auth-provider.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { AuthContext, type AuthAdapter } from './auth-context'
+import { useClearQueryCacheOnUserChange } from './use-clear-query-cache-on-user-change'
 import { setTokenGetter } from '../api/client'
+import { queryClient } from '../api/query-client'
 
 function parseJwtPayload(token: string): Record<string, unknown> | null {
   try {
@@ -69,6 +71,8 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
   useEffect(() => {
     setTokenGetter(getToken)
   }, [getToken])
+
+  useClearQueryCacheOnUserChange(queryClient, user?.email)
 
   const login = useCallback(async (email: string, password: string) => {
     const res = await fetch('/api/auth/login', {

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.278",
+      version: "0.5.279",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Mirror of #384's Clerk fix for the local-auth (self-host) path. The module-level `queryClient` survives `LocalAuthProvider`'s `logout`; on a multi-user self-host instance, if user A signs out and user B signs in/up on the same browser, user B sees user A's cached `/api/notes`, `/api/onboarding/status`, etc. — a real data-leak risk even though self-host is usually single-tenant.

## Change

One hook call inside `LocalAuthProvider`, identical shape to the Clerk wiring:

```ts
useClearQueryCacheOnUserChange(queryClient, user?.email)
```

Hook semantics are already proven by the 6 unit cases in #384:
- No clear on first mount or first sign-in (nothing cached to wipe).
- Clears on sign-out (`email → undefined`) and cross-account swap (`A → B`).
- No clear on stable identity — token refresh doesn't change `user.email`, so the silent-refresh path is a no-op as expected.

## Test plan

- [x] `bun run test` — 143/143 pass.
- [x] `bunx tsc --noEmit` clean.
- [ ] Self-host smoke: register user A, browse, sign out. Register user B in same tab → confirm B sees no cached state from A (vault loads empty for B, onboarding wizard fires if applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)