### PR TITLE
feat(auth): validate Clerk azp claim against allowlist (#388)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -226,6 +226,24 @@ if auth_provider == :clerk do
   if wh_secret = System.get_env("CLERK_WEBHOOK_SECRET") do
     config :engram, :clerk_webhook_secret, String.trim(wh_secret)
   end
+
+  # Optional `azp` (Authorized Party) allowlist. Comma-separated origins, e.g.
+  # "https://app.engram.page,https://staging.engram.page". Empty/unset →
+  # passthrough — mirrors @clerk/backend's `assertAuthorizedPartiesClaim` so
+  # self-host Clerk users aren't forced to configure it just to get auth working.
+  clerk_authorized_parties =
+    case System.get_env("CLERK_AUTHORIZED_PARTIES") do
+      nil ->
+        []
+
+      raw ->
+        raw
+        |> String.split(",", trim: true)
+        |> Enum.map(&String.trim/1)
+        |> Enum.reject(&(&1 == ""))
+    end
+
+  config :engram, :clerk_authorized_parties, clerk_authorized_parties
 end
 
 # Pricing v2 §A — phone-verification gate on EmbedNote worker. Default off so

--- a/lib/engram/auth/clerk_token.ex
+++ b/lib/engram/auth/clerk_token.ex
@@ -3,7 +3,8 @@ defmodule Engram.Auth.ClerkToken do
   Verifies Clerk JWTs using JWKS-fetched public keys.
 
   Uses joken_jwks to automatically fetch and cache Clerk's public signing keys.
-  Validates: signature (RS256 via JWKS), expiry, not-before, issuer.
+  Validates: signature (RS256 via JWKS), expiry, not-before, issuer, and
+  (when configured) the `azp` (Authorized Party) claim against an allowlist.
   """
 
   use Joken.Config
@@ -25,8 +26,29 @@ defmodule Engram.Auth.ClerkToken do
   Verifies a Clerk JWT and returns `{:ok, claims}` or `{:error, reason}`.
   """
   def verify_clerk_jwt(token) do
-    verify_and_validate(token)
+    with {:ok, claims} <- verify_and_validate(token),
+         :ok <- validate_authorized_party(claims) do
+      {:ok, claims}
+    end
   rescue
     _ -> {:error, :invalid_token}
+  end
+
+  # Mirrors @clerk/backend's `assertAuthorizedPartiesClaim`: empty allowlist
+  # is passthrough; otherwise the `azp` claim must be present and a member.
+  defp validate_authorized_party(claims) do
+    case Application.get_env(:engram, :clerk_authorized_parties, []) do
+      [] ->
+        :ok
+
+      parties when is_list(parties) ->
+        case Map.get(claims, "azp") do
+          azp when is_binary(azp) ->
+            if azp in parties, do: :ok, else: {:error, :invalid_azp}
+
+          _ ->
+            {:error, :invalid_azp}
+        end
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.280",
+      version: "0.5.281",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/auth/clerk_token_test.exs
+++ b/test/engram/auth/clerk_token_test.exs
@@ -10,8 +10,12 @@ defmodule Engram.Auth.ClerkTokenTest do
     prev_url = Application.get_env(:engram, :clerk_jwks_url)
     prev_issuer = Application.get_env(:engram, :clerk_issuer)
 
+    prev_azp = Application.get_env(:engram, :clerk_authorized_parties)
+
     Application.put_env(:engram, :clerk_jwks_url, jwks_url)
     Application.put_env(:engram, :clerk_issuer, Engram.ClerkHelpers.issuer())
+    # Default: empty allowlist → azp validation is passthrough.
+    Application.put_env(:engram, :clerk_authorized_parties, [])
 
     # Start the ClerkStrategy GenServer pointed at our Bypass.
     # first_fetch_sync: true ensures JWKS is in ETS before any test runs.
@@ -25,6 +29,10 @@ defmodule Engram.Auth.ClerkTokenTest do
       if prev_issuer,
         do: Application.put_env(:engram, :clerk_issuer, prev_issuer),
         else: Application.delete_env(:engram, :clerk_issuer)
+
+      if prev_azp,
+        do: Application.put_env(:engram, :clerk_authorized_parties, prev_azp),
+        else: Application.delete_env(:engram, :clerk_authorized_parties)
     end)
 
     %{bypass: bypass}
@@ -58,6 +66,56 @@ defmodule Engram.Auth.ClerkTokenTest do
 
   test "rejects a completely invalid token" do
     assert {:error, _reason} = ClerkToken.verify_clerk_jwt("not.a.jwt")
+  end
+
+  describe "azp (Authorized Party) validation" do
+    test "accepts JWT when allowlist is empty (passthrough), even without azp claim" do
+      Application.put_env(:engram, :clerk_authorized_parties, [])
+
+      claims = Engram.ClerkHelpers.clerk_claims("clerk_user_azp_empty")
+      token = Engram.ClerkHelpers.sign_clerk_jwt(claims)
+
+      assert {:ok, verified} = ClerkToken.verify_clerk_jwt(token)
+      assert verified["sub"] == "clerk_user_azp_empty"
+    end
+
+    test "accepts JWT when azp matches an entry in the allowlist" do
+      Application.put_env(:engram, :clerk_authorized_parties, [
+        "https://app.engram.page",
+        "https://staging.engram.page"
+      ])
+
+      claims =
+        Engram.ClerkHelpers.clerk_claims("clerk_user_azp_ok", azp: "https://app.engram.page")
+
+      token = Engram.ClerkHelpers.sign_clerk_jwt(claims)
+
+      assert {:ok, verified} = ClerkToken.verify_clerk_jwt(token)
+      assert verified["sub"] == "clerk_user_azp_ok"
+    end
+
+    test "rejects JWT when azp is not in the non-empty allowlist" do
+      Application.put_env(:engram, :clerk_authorized_parties, ["https://app.engram.page"])
+
+      claims =
+        Engram.ClerkHelpers.clerk_claims("clerk_user_azp_bad",
+          azp: "https://evil.engram.page"
+        )
+
+      token = Engram.ClerkHelpers.sign_clerk_jwt(claims)
+
+      assert {:error, _reason} = ClerkToken.verify_clerk_jwt(token)
+    end
+
+    test "rejects JWT missing azp claim when allowlist is non-empty" do
+      Application.put_env(:engram, :clerk_authorized_parties, ["https://app.engram.page"])
+
+      claims = Engram.ClerkHelpers.clerk_claims("clerk_user_azp_missing")
+      refute Map.has_key?(claims, "azp")
+      token = Engram.ClerkHelpers.sign_clerk_jwt(claims)
+
+      assert {:error, _reason} = ClerkToken.verify_clerk_jwt(token)
+    end
   end
 
   test "rejects a JWT signed with a different key" do

--- a/test/support/clerk_helpers.ex
+++ b/test/support/clerk_helpers.ex
@@ -42,7 +42,7 @@ defmodule Engram.ClerkHelpers do
   def clerk_claims(clerk_user_id, opts \\ []) do
     now = :os.system_time(:second)
 
-    %{
+    base = %{
       "sub" => clerk_user_id,
       "iss" => Keyword.get(opts, :issuer, @issuer),
       "iat" => now - 10,
@@ -50,6 +50,11 @@ defmodule Engram.ClerkHelpers do
       "nbf" => now - 10,
       "email" => Keyword.get(opts, :email, "clerk-user@example.com")
     }
+
+    case Keyword.fetch(opts, :azp) do
+      {:ok, azp} -> Map.put(base, "azp", azp)
+      :error -> base
+    end
   end
 
   @doc """


### PR DESCRIPTION
## Summary

Closes #388. Adds defense-in-depth `azp` (Authorized Party) validation to `Engram.Auth.ClerkToken.verify_clerk_jwt/1`. Mirrors `@clerk/backend`'s `assertAuthorizedPartiesClaim`:

- Empty / unset allowlist → passthrough (self-host Clerk users aren't forced to configure it just to get auth working).
- Non-empty allowlist → JWT's `azp` MUST be present and a member, else `{:error, :invalid_azp}`.

Threat model recap (full in #388): Clerk's Frontend API edge already blocks unallowed third-party origins via CORS, so this is not load-bearing for the third-party-domain case. Residual risk it closes is **internal**: XSS or DNS-takeover on a `*.engram.page` subdomain → attacker mints tokens with an unexpected `azp` → backend would previously accept them. P2.

## Changes

- `lib/engram/auth/clerk_token.ex` — `validate_authorized_party/1` post-validate gate. Implemented as a wrapper around `verify_and_validate/1` rather than `add_claim("azp", ...)` because Joken's claim validators are skipped when the claim is absent — we need to reject missing-`azp` when the allowlist is non-empty.
- `config/runtime.exs` — parse comma-separated `CLERK_AUTHORIZED_PARTIES` env under the existing `auth_provider == :clerk` block. Default `[]` → passthrough.
- `test/engram/auth/clerk_token_test.exs` — 4 new cases under `describe "azp (Authorized Party) validation"`: empty-allowlist passthrough, match, mismatch, missing-when-required.
- `test/support/clerk_helpers.ex` — `clerk_claims/2` accepts an `:azp` opt.

## Test plan

- [x] `mix test test/engram/auth/clerk_token_test.exs` — 9/9 (4 new + 5 existing)
- [x] `mix test test/engram/auth/` — 98/98
- [x] `mix test` (full suite) — 1933/0/7 skipped/3 excluded
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict lib/engram/auth/clerk_token.ex` clean
- [ ] CI green

## Follow-up (not in this PR)

- SOPS prod: add `clerk_authorized_parties` after confirming whether prod's allowlist should include staging during the FastRaid→AWS parallel-run window.
- TF env block: wire `CLERK_AUTHORIZED_PARTIES` into FastRaid prod stack (and AWS env when #266 lands), mirroring the `CLERK_WEBHOOK_SECRET` shape at `engram-infra/main/envs/staging-fastraid/env.tf:96-98`.
- Self-host docs note for users opting into Clerk mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)