### PR TITLE
feat(auth): wire Clerk waitlist mode UI (CLERK_WAITLIST_MODE)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -244,6 +244,17 @@ if auth_provider == :clerk do
     end
 
   config :engram, :clerk_authorized_parties, clerk_authorized_parties
+
+  # Waitlist mode mirrors the Clerk Dashboard sign-up mode (Restrictions →
+  # Waitlist). The dashboard flag is the actual gate — Clerk's API rejects
+  # non-approved signups regardless of frontend. This var only adjusts the
+  # SPA UI: replaces the "Sign up" CTA with a /waitlist route and tells
+  # <SignIn /> where the waitlist lives (Clerk requires waitlistUrl). Keep
+  # in sync with the dashboard; flipping one without the other = broken UX
+  # but never an open signup hole.
+  if System.get_env("CLERK_WAITLIST_MODE") in ["1", "true"] do
+    config :engram, :clerk_waitlist_mode, true
+  end
 end
 
 # Pricing v2 §A — phone-verification gate on EmbedNote worker. Default off so

--- a/frontend/src/auth/clerk-auth-provider.tsx
+++ b/frontend/src/auth/clerk-auth-provider.tsx
@@ -87,12 +87,20 @@ export default function ClerkAuthProvider({ children }: { children: React.ReactN
     throw new Error('CLERK_PUBLISHABLE_KEY is required when AUTH_PROVIDER=clerk')
   }
 
+  // Waitlist mode (Dashboard → Restrictions → Waitlist): point Clerk's
+  // "sign up" CTAs at /waitlist so non-approved users land on the join
+  // form instead of <SignUp />'s "you need to join the waitlist" message.
+  // /sign-up stays alive for invited users following the email ticket.
+  const signUpUrl = config.clerkWaitlistMode ? ROUTES.WAITLIST : ROUTES.SIGN_UP
+  const waitlistUrl = config.clerkWaitlistMode ? ROUTES.WAITLIST : undefined
+
   return (
     <ClerkProvider
       publishableKey={clerkPubKey}
       appearance={appearance}
       signInUrl={ROUTES.SIGN_IN}
-      signUpUrl={ROUTES.SIGN_UP}
+      signUpUrl={signUpUrl}
+      waitlistUrl={waitlistUrl}
       afterSignOutUrl={ROUTES.SIGN_IN}
       routerPush={(to) => router.navigate(to)}
       routerReplace={(to) => router.navigate(to, { replace: true })}

--- a/frontend/src/auth/waitlist.tsx
+++ b/frontend/src/auth/waitlist.tsx
@@ -1,0 +1,31 @@
+import { lazy, Suspense } from 'react'
+import { Navigate } from 'react-router'
+import { config } from '../config'
+import { ROUTES } from '../routes'
+import AuthLayout from './auth-layout'
+
+const isClerk = config.authProvider === 'clerk'
+
+const ClerkWaitlistPage = isClerk
+  ? lazy(() =>
+      import('@clerk/react').then((mod) => ({
+        default: () => (
+          <AuthLayout>
+            <mod.Waitlist signInUrl={ROUTES.SIGN_IN} />
+          </AuthLayout>
+        ),
+      })),
+    )
+  : null
+
+export default function WaitlistPage() {
+  if (!ClerkWaitlistPage || !config.clerkWaitlistMode) {
+    return <Navigate to={ROUTES.SIGN_UP} replace />
+  }
+
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <ClerkWaitlistPage />
+    </Suspense>
+  )
+}

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -26,4 +26,19 @@ describe('loadConfig', () => {
     inject({ authProvider: 'local', clerkPublishableKey: '', billingEnabled: 'yes' })
     expect(loadConfig().billingEnabled).toBe(false)
   })
+
+  it('reads clerkWaitlistMode=true from injected config', () => {
+    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', clerkWaitlistMode: true })
+    expect(loadConfig().clerkWaitlistMode).toBe(true)
+  })
+
+  it('treats a missing clerkWaitlistMode as false', () => {
+    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test' })
+    expect(loadConfig().clerkWaitlistMode).toBe(false)
+  })
+
+  it('coerces non-boolean clerkWaitlistMode to false (never truthy-by-accident)', () => {
+    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', clerkWaitlistMode: 'yes' })
+    expect(loadConfig().clerkWaitlistMode).toBe(false)
+  })
 })

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -2,6 +2,10 @@ export interface EngramConfig {
   authProvider: 'local' | 'clerk'
   clerkPublishableKey: string
   billingEnabled: boolean
+  // Mirrors Clerk Dashboard "Waitlist" sign-up mode. UI flips "Sign up"
+  // CTAs to /waitlist and passes waitlistUrl to <SignIn />. The dashboard
+  // flag is the actual enforcement; this is presentational only.
+  clerkWaitlistMode: boolean
   // Self-host SSR-injected bootstrap state. `null` under Clerk; `undefined`
   // when the config script didn't ship one (Vite dev, older Phoenix build),
   // in which case useBootstrap() falls back to fetching /api/auth/bootstrap.
@@ -22,6 +26,7 @@ export function loadConfig(): EngramConfig {
       authProvider: injected.authProvider as 'local' | 'clerk',
       clerkPublishableKey: (injected.clerkPublishableKey as string) ?? '',
       billingEnabled: injected.billingEnabled === true,
+      clerkWaitlistMode: injected.clerkWaitlistMode === true,
       bootstrap: injected.bootstrap as EngramConfig['bootstrap'],
     }
   }
@@ -38,6 +43,7 @@ export function loadConfig(): EngramConfig {
     authProvider: (import.meta.env.VITE_AUTH_PROVIDER as 'local' | 'clerk') ?? 'local',
     clerkPublishableKey: import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
     billingEnabled: import.meta.env.VITE_BILLING_ENABLED === 'true',
+    clerkWaitlistMode: import.meta.env.VITE_CLERK_WAITLIST_MODE === 'true',
   }
 }
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,6 +3,7 @@ import { Navigate, createBrowserRouter } from 'react-router'
 import AuthGuard from './auth/auth-guard'
 import SignInPage from './auth/sign-in'
 import SignUpPage from './auth/sign-up'
+import WaitlistPage from './auth/waitlist'
 import BillingPage from './billing/billing-page'
 import { config } from './config'
 import AdminPanel from './features/admin/AdminPanel'
@@ -37,6 +38,7 @@ export const router = createBrowserRouter(
     // Public routes
     { path: ROUTES.SIGN_IN, element: <SignInPage /> },
     { path: ROUTES.SIGN_UP, element: <SignUpPage /> },
+    { path: ROUTES.WAITLIST, element: <WaitlistPage /> },
     // Public reset — the one-time token IS the credential.
     { path: '/reset-password', element: <ResetPasswordPage /> },
 

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
   HOME: '/',
   SIGN_IN: '/sign-in',
   SIGN_UP: '/sign-up',
+  WAITLIST: '/waitlist',
   DEVICE_LINK: '/link',
   OAUTH_CONSENT: '/oauth/consent',
 } as const

--- a/lib/engram_web/controllers/spa_controller.ex
+++ b/lib/engram_web/controllers/spa_controller.ex
@@ -81,6 +81,7 @@ defmodule EngramWeb.SpaController do
       authProvider: provider,
       clerkPublishableKey: Application.get_env(:engram, :clerk_publishable_key, ""),
       billingEnabled: Application.get_env(:engram, :billing_enabled, false) == true,
+      clerkWaitlistMode: Application.get_env(:engram, :clerk_waitlist_mode, false) == true,
       bootstrap: bootstrap
     }
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -318,6 +318,7 @@ defmodule EngramWeb.Router do
     get "/", SpaController, :index
     get "/sign-in", SpaController, :index
     get "/sign-up", SpaController, :index
+    get "/waitlist", SpaController, :index
     get "/link", SpaController, :index
     get "/search", SpaController, :index
     get "/billing", SpaController, :index

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.281",
+      version: "0.5.282",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.282",
+      version: "0.5.283",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -90,6 +90,16 @@ defmodule EngramWeb.SpaControllerTest do
     assert response(conn, 200) =~ "<!DOCTYPE html>"
   end
 
+  test "GET /waitlist renders SPA (Clerk waitlist UI route)", %{conn: conn} do
+    # /waitlist is reachable from outside the app (Clerk waitlist invitation
+    # emails, marketing CTAs, bookmarks). The router uses an explicit SPA
+    # whitelist, so /waitlist must be listed or external links 404.
+    conn = get(conn, "/waitlist")
+    assert conn.status == 200
+    assert response(conn, 200) =~ "<!DOCTYPE html>"
+    assert response(conn, 200) =~ "<div id=\"root\">"
+  end
+
   test "SPA responses include x-frame-options: DENY (clickjacking guard)", %{conn: conn} do
     # Critical for /oauth/consent — the consent UI must not be embeddable.
     conn = get(conn, "/oauth/consent")

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -66,6 +66,24 @@ defmodule EngramWeb.SpaControllerTest do
     assert body =~ ~s("bootstrap":null)
   end
 
+  test "GET / injects clerkWaitlistMode=false by default", %{conn: conn} do
+    prev = Application.get_env(:engram, :clerk_waitlist_mode)
+    Application.delete_env(:engram, :clerk_waitlist_mode)
+    on_exit(fn -> Application.put_env(:engram, :clerk_waitlist_mode, prev) end)
+
+    body = conn |> get("/") |> response(200)
+    assert body =~ ~s("clerkWaitlistMode":false)
+  end
+
+  test "GET / injects clerkWaitlistMode=true when configured", %{conn: conn} do
+    prev = Application.get_env(:engram, :clerk_waitlist_mode)
+    Application.put_env(:engram, :clerk_waitlist_mode, true)
+    on_exit(fn -> Application.put_env(:engram, :clerk_waitlist_mode, prev) end)
+
+    body = conn |> get("/") |> response(200)
+    assert body =~ ~s("clerkWaitlistMode":true)
+  end
+
   test "GET /oauth/consent renders SPA (consent UI route)", %{conn: conn} do
     conn = get(conn, "/oauth/consent")
     assert conn.status == 200


### PR DESCRIPTION
## Summary

- Adds `/waitlist` route rendering Clerk's `<Waitlist />`; flips Clerk's `signUpUrl` + `waitlistUrl` to `/waitlist` when `CLERK_WAITLIST_MODE=true` so non-approved users see a join form instead of `<SignUp />`'s "you need to join the waitlist" message.
- Backend env (`CLERK_WAITLIST_MODE`) → `:clerk_waitlist_mode` → `window.__ENGRAM_CONFIG__.clerkWaitlistMode`. Lives inside the existing `if auth_provider == :clerk` block — meaningless under self-host.
- `/sign-up` keeps rendering `<SignUp />` so invited users following Clerk's email-ticket link aren't blocked. `WaitlistPage` redirects to `/sign-up` when the flag is off or under local auth.

## Why this is safe (the "is a frontend env var really the gate?" question)

The real gate is the **Clerk Dashboard** (Restrictions → Sign-up mode → Waitlist). Clerk's API rejects non-approved signups regardless of which component the frontend renders. This PR only aligns the UI — flipping the dashboard without this PR shows users a rejection message; flipping this PR's env without the dashboard shows users a form that submits successfully. **Neither order opens a signup hole.**

Verified against [Clerk's restrictions docs](https://clerk.com/docs/guides/secure/restricting-access#waitlist): `waitlistUrl` is required on `<ClerkProvider>` or `<SignIn />` when using `<Waitlist />`, default `pathRoot` is `/waitlist`, and `<SignUp />` must stay reachable for invited users following the email ticket.

## Rollout (when ready to enable)

1. Clerk Dashboard → Waitlist → "Enable waitlist" on prod instance `s4xfjkjnj4np`.
2. Verify **Email** is enabled in Clerk (required for invitation emails).
3. Set `CLERK_WAITLIST_MODE=true` on FastRaid prod env.
4. Deploy.
5. Approve self via Dashboard → smoke test → bulk-approve waitlist as desired.

## Test plan

- [x] `mix test test/engram_web/controllers/spa_controller_test.exs` — 18/18 pass (2 new: default-false + true-when-configured)
- [x] `bun run test` in `frontend/` — 146/146 pass (3 new in `config.test.ts`)
- [x] `bun run build` — clean
- [ ] Manual on staging: flip dashboard + env, hit `/sign-in` → "Sign up" link → lands on `/waitlist` with `<Waitlist />`
- [ ] Manual on staging: invited user follows email link → `/sign-up` completes signup
- [ ] Manual on self-host build: `/waitlist` redirects to `/sign-up` (regression guard)

## Operational note

Dashboard "Waitlist" sign-up mode is dashboard-only — not in Terraform / Backend API. Joining Account Portal Paths + session-token `email` claim as the third Clerk drift item. See `feedback_clerk_instance_swap_gaps` memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)