### PR TITLE
feat(deploy): tag-gated AWS prod deploy pipeline

### DIFF
--- a/.github/workflows/build-ecr.yml
+++ b/.github/workflows/build-ecr.yml
@@ -1,0 +1,79 @@
+name: Build & push prod image to ECR
+
+# Every push to main builds the prod image and pushes it to ECR
+# tagged `sha-<7chars>`. The image lives in ECR but nothing is rolled.
+# Deploy happens separately when an operator pushes a `release-v*`
+# git tag — see deploy-prod.yml.
+#
+# Tagging strategy:
+#   - sha-<7chars>: always present, deterministic, used by deploy.
+#   - v<X.Y.Z>:     only when HEAD has a `v*` annotated git tag (not
+#                   `release-v*` — that's for the deploy workflow).
+#                   Useful for marketing-style milestone audits in ECR.
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: build-ecr-${{ github.ref }}
+  # Don't cancel an in-flight push — we want every main commit to
+  # produce its own sha-tagged image. Lifecycle policy in TF
+  # (ecr.tf) caps tagged images at 20 + expires untagged after 7 days.
+  cancel-in-progress: false
+
+permissions:
+  id-token: write  # required for aws-actions/configure-aws-credentials OIDC
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: [self-hosted, linux, x64, isolated]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # need tags for git describe
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHA=$(git rev-parse --short=7 HEAD)
+          echo "sha=sha-$SHA" >> "$GITHUB_OUTPUT"
+          # `v*` exact-match tag → add it as a second image tag.
+          # Ignore `release-v*` (that's the deploy trigger, not an
+          # image marker).
+          if VTAG=$(git describe --tags --exact-match 2>/dev/null) && [[ "$VTAG" =~ ^v[0-9] ]]; then
+            echo "vtag=$VTAG" >> "$GITHUB_OUTPUT"
+            echo "Tagging with: sha-$SHA, $VTAG"
+          else
+            echo "Tagging with: sha-$SHA"
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ECR_PUSH_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 \
+            | docker login --username AWS --password-stdin \
+              "${{ vars.AWS_ECR_REPOSITORY }}"
+
+      - name: Build & push
+        env:
+          REPO: ${{ vars.AWS_ECR_REPOSITORY }}
+          SHA_TAG: ${{ steps.tags.outputs.sha }}
+          VTAG: ${{ steps.tags.outputs.vtag }}
+          # Plain progress writer — see ci.yml prebuild-ci-image for
+          # the docker/buildx race rationale (#334).
+          BUILDKIT_PROGRESS: plain
+        run: |
+          TAGS=(--tag "$REPO:$SHA_TAG")
+          if [ -n "$VTAG" ]; then
+            TAGS+=(--tag "$REPO:$VTAG")
+          fi
+          docker buildx build \
+            "${TAGS[@]}" \
+            --push \
+            .

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,120 @@
+name: Deploy prod
+
+# Pushing a `release-v*` git tag triggers this workflow, which
+# registers a new ECS task definition pinning the image built for
+# the tagged commit and rolls the service to that revision.
+#
+# Release recipe:
+#   git tag release-v0.5.234 <commit>   # commit must already be on main
+#   git push origin release-v0.5.234
+#
+# Rollback recipe (same trigger, points at older commit):
+#   git tag release-v0.5.234-rollback <last-known-good-sha>
+#   git push origin release-v0.5.234-rollback
+#
+# OIDC trust on the ecs_deploy role is scoped to refs/tags/release-v*
+# only — neither main nor feature branches can assume it.
+on:
+  push:
+    tags: ['release-v*']
+
+concurrency:
+  group: deploy-prod
+  # Never abort a deploy mid-flight. Tags queue serially.
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  CLUSTER: engram-prod
+  SERVICE: engram-saas-prod
+  TASK_FAMILY: engram-saas-prod
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, linux, x64, isolated]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute image tag from tagged commit
+        id: tags
+        run: |
+          # github.sha is the commit the release tag points at.
+          SHA=$(git rev-parse --short=7 "${{ github.sha }}")
+          echo "image_tag=sha-$SHA" >> "$GITHUB_OUTPUT"
+          echo "release=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Deploying $GITHUB_REF_NAME → image sha-$SHA"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ECS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify image exists in ECR
+        env:
+          IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}
+        run: |
+          # Fail loudly if build-ecr.yml hasn't run for this commit
+          # yet (e.g. tag pushed before main CI finished).
+          aws ecr describe-images \
+            --repository-name engram-saas-prod \
+            --image-ids "imageTag=$IMAGE_TAG" \
+            --query 'imageDetails[0].imagePushedAt' --output text
+
+      - name: Register new task definition pinning the image
+        id: register
+        env:
+          IMAGE: ${{ vars.AWS_ECR_REPOSITORY }}:${{ steps.tags.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          # Clone the live task def, mutate the image, drop the
+          # response-only fields that register-task-definition rejects
+          # on input.
+          aws ecs describe-task-definition \
+            --task-definition "$TASK_FAMILY" \
+            --query 'taskDefinition' \
+            > /tmp/td.json
+          jq --arg img "$IMAGE" '
+            .containerDefinitions[0].image = $img
+            | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                  .compatibilities, .registeredAt, .registeredBy)
+          ' /tmp/td.json > /tmp/td-new.json
+          NEW_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "file:///tmp/td-new.json" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "task_def_arn=$NEW_ARN" >> "$GITHUB_OUTPUT"
+          echo "Registered: $NEW_ARN"
+
+      - name: Update service
+        env:
+          NEW_TD: ${{ steps.register.outputs.task_def_arn }}
+        run: |
+          aws ecs update-service \
+            --cluster "$CLUSTER" \
+            --service "$SERVICE" \
+            --task-definition "$NEW_TD" \
+            --query 'service.deployments[0].id' --output text
+
+      - name: Wait for service stable
+        run: |
+          # Default timeout is 10min (40 polls × 15s). For a 2-task
+          # service that's plenty; if it blows past, the deploy is
+          # genuinely broken and the operator should investigate.
+          aws ecs wait services-stable \
+            --cluster "$CLUSTER" \
+            --services "$SERVICE"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Deploy succeeded"
+            echo ""
+            echo "- Release tag: \`${{ steps.tags.outputs.release }}\`"
+            echo "- Commit: ${{ github.sha }}"
+            echo "- Image: \`${{ vars.AWS_ECR_REPOSITORY }}:${{ steps.tags.outputs.image_tag }}\`"
+            echo "- Task def: \`${{ steps.register.outputs.task_def_arn }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/context/deploy-prod.md
+++ b/docs/context/deploy-prod.md
@@ -1,0 +1,76 @@
+# Deploy to AWS prod
+
+When to read this: shipping code to `app.engram.page`, rolling back a bad deploy, or debugging the deploy pipeline.
+
+## How it works
+
+Two-stage pipeline split into two GitHub Actions workflows in this repo:
+
+1. **`build-ecr.yml`** — runs on every push to `main`. Builds the Docker image and pushes to ECR tagged `sha-<7chars>`. The image sits in ECR; **nothing rolls.**
+2. **`deploy-prod.yml`** — runs only when a `release-v*` git tag is pushed. Clones the live task definition, swaps in the image for the tagged commit, registers a new revision, and `update-service` rolls the cluster.
+
+OIDC IAM trust enforces the boundary: the build role (`engram-saas-prod-ecr-push`) trusts `refs/heads/main` + `refs/tags/v*` only; the deploy role (`engram-saas-prod-ecs-deploy`) trusts `refs/tags/release-v*` only. Build can never accidentally roll, deploy can never accidentally push an image.
+
+## Release recipe
+
+```bash
+# Pull latest main, confirm CI is green, confirm the image is in ECR
+git checkout main && git pull
+SHA=$(git rev-parse --short=7 HEAD)
+aws ecr describe-images --repository-name engram-saas-prod \
+  --image-ids imageTag=sha-$SHA \
+  --query 'imageDetails[0].imagePushedAt' --output text
+
+# Tag + push. Convention: bump the patch from the previous release.
+git tag release-v0.5.234
+git push origin release-v0.5.234
+```
+
+The deploy workflow takes ~3-5 min: register task def → update-service → `wait services-stable`. Watch in the Actions tab.
+
+## Rollback recipe
+
+Rollback is a forward-roll to a known-good image. Same trigger mechanism — push a release tag pointing at the older commit:
+
+```bash
+# Find the last good commit (whichever sha-<7> image you want back live)
+GOOD_SHA=abc1234
+
+# Tag with a -rollback suffix for audit clarity (any release-v* matches)
+git tag release-v0.5.234-rollback $GOOD_SHA
+git push origin release-v0.5.234-rollback
+```
+
+The workflow registers a fresh task def revision pinning that old image and rolls the service. Task def history in ECS becomes the deploy log — `aws ecs list-task-definitions --family-prefix engram-saas-prod` shows every deploy in order.
+
+## Inspect deploy state
+
+```bash
+# Active task definition + image
+aws ecs describe-services --cluster engram-prod --services engram-saas-prod \
+  --query 'services[0].{taskDef:taskDefinition,running:runningCount,desired:desiredCount}'
+
+# Image of the active task def
+aws ecs describe-task-definition --task-definition engram-saas-prod \
+  --query 'taskDefinition.containerDefinitions[0].image' --output text
+
+# Recent revisions (most recent first)
+aws ecs list-task-definitions --family-prefix engram-saas-prod --sort DESC --max-items 10
+
+# Image inventory in ECR
+aws ecr describe-images --repository-name engram-saas-prod \
+  --query 'sort_by(imageDetails,&imagePushedAt)[-10:].[imageTags[0],imagePushedAt]' \
+  --output table
+```
+
+Operator AWS profile is `engram-infra-operator` (read-only — `operator-cheatsheet.md` in engram-infra). For deploy/rollback CLI access (write), use the IAM Roles Anywhere break-glass path documented there.
+
+## Failure modes
+
+- **`deploy-prod.yml` step "Verify image exists in ECR" fails** — `build-ecr.yml` hasn't finished for that commit yet, or the commit was never on main. Wait for build to finish, or check the commit is reachable from `origin/main`.
+- **`wait services-stable` times out (10 min)** — task is crash-looping. Check CloudWatch Logs `/ecs/engram-saas-prod`, then roll back via the rollback recipe.
+- **`Register new task definition` fails with `iam:PassRole`** — the ecs_deploy role's PassRole permission is conditional on `iam:PassedToService = ecs-tasks.amazonaws.com`. If the task def's `executionRoleArn` or `taskRoleArn` references a role outside `engram-saas-prod-ecs-{execution,task}`, fix the upstream TF in engram-infra `main/envs/prod/ecs_iam.tf`.
+
+## Why not merge-to-deploy?
+
+Pre-revenue, merge-to-deploy is fine. Post-launch, every PR shipping immediately creates pressure: tests pass means deploy, no human gate, no batch-windowing. Tag-gated lets the operator (a) batch multiple merges into one release, (b) hold deploys during incident windows, (c) audit exactly what shipped when via `git tag --list 'release-v*'`. The cost is one extra step per release (`git tag && git push`) — worth it for a paid product.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.281",
+      version: "0.5.282",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Two-workflow pipeline that deploys to AWS ECS prod when an operator pushes a `release-v*` git tag — not on every main merge.

- **`build-ecr.yml`** — every push to `main` builds the Docker image + pushes to ECR tagged `sha-<7chars>`. Image sits in ECR; nothing rolls.
- **`deploy-prod.yml`** — push of `release-v*` tag → clone live task def, swap in the image for the tagged commit, register new revision, `update-service`, `wait services-stable`.
- **`docs/context/deploy-prod.md`** — release recipe, rollback-via-release-tag recipe, inspection commands, failure-mode lookup.

## OIDC trust boundary

- `engram-saas-prod-ecr-push` (existing, engram-infra ecr.tf) — trusts `refs/heads/main` + `refs/tags/v*`. Push-only.
- `engram-saas-prod-ecs-deploy` (new, engram-infra#217) — trusts `refs/tags/release-v*` only. RegisterTaskDefinition + UpdateService + PassRole on the ECS roles.

Build workflows can never roll the service; deploy workflows can never push images. Two IAM identities = two distinct release gates.

## Repo vars wired (out-of-band from terraform output)

- `AWS_ECR_PUSH_ROLE_ARN` = `arn:aws:iam::751667630925:role/engram-saas-prod-ecr-push`
- `AWS_ECS_DEPLOY_ROLE_ARN` = `arn:aws:iam::751667630925:role/engram-saas-prod-ecs-deploy`
- `AWS_ECR_REPOSITORY` = `751667630925.dkr.ecr.us-east-1.amazonaws.com/engram-saas-prod`

## Rollback

Same `release-v*` trigger, pointed at an older known-good commit:

```bash
git tag release-v0.5.234-rollback $OLD_SHA
git push origin release-v0.5.234-rollback
```

Task def revision history in ECS = deploy log. No separate workflow needed.

## Test plan

- [x] `yaml.safe_load` parses both workflows
- [ ] First merge to main triggers `build-ecr.yml`; image lands in ECR as `sha-<sha>`
- [ ] Pushing `release-v0.5.282` triggers `deploy-prod.yml`; service rolls to a new task def revision
- [ ] Service reaches `RUNNING` count = desired

Refs engram-app/Engram#266

🤖 Generated with [Claude Code](https://claude.com/claude-code)