### PR TITLE
fix(deploy): install AWS CLI on self-hosted runner

### DIFF
--- a/.github/workflows/build-ecr.yml
+++ b/.github/workflows/build-ecr.yml
@@ -48,6 +48,19 @@ jobs:
             echo "Tagging with: sha-$SHA"
           fi
 
+      - name: Install AWS CLI v2 if missing
+        # Self-hosted runner pool doesn't ship awscli by default.
+        # Idempotent via command -v check — persists across runs since
+        # the isolated runner VM keeps /usr/local/aws-cli between jobs.
+        run: |
+          if ! command -v aws >/dev/null 2>&1; then
+            curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp/awscli
+            sudo /tmp/awscli/aws/install
+            rm -rf /tmp/awscliv2.zip /tmp/awscli
+          fi
+          aws --version
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -48,6 +48,16 @@ jobs:
           echo "release=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           echo "Deploying $GITHUB_REF_NAME → image sha-$SHA"
 
+      - name: Install AWS CLI v2 if missing
+        run: |
+          if ! command -v aws >/dev/null 2>&1; then
+            curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp/awscli
+            sudo /tmp/awscli/aws/install
+            rm -rf /tmp/awscliv2.zip /tmp/awscli
+          fi
+          aws --version
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.284",
+      version: "0.5.285",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Self-hosted runner pool doesn't ship awscli. \`aws-actions/configure-aws-credentials\` works (pure JS SDK) but subsequent \`aws ecr ...\` / \`aws ecs ...\` calls fail with \`aws: command not found\`. Added an idempotent install step (curl official v2 bundle, sudo install) gated on \`command -v aws\`. After first run on each runner VM, the binary persists at \`/usr/local/aws-cli\` and the check short-circuits.

First build-ecr run on PR #391 merge failed at this step. This fix unblocks it.

Long-term: bake awscli into the runner image setup script (engram-infra runner-vm-setup). In-workflow install is fine for v1.

Refs engram-app/Engram#266