### PR TITLE
fix(deploy): userspace AWS CLI install (no sudo on runner)

### DIFF
--- a/.github/workflows/build-ecr.yml
+++ b/.github/workflows/build-ecr.yml
@@ -49,17 +49,23 @@ jobs:
           fi
 
       - name: Install AWS CLI v2 if missing
-        # Self-hosted runner pool doesn't ship awscli by default.
+        # Self-hosted runner pool doesn't ship awscli by default and
+        # the runner user has no passwordless sudo. Install into
+        # $HOME/.aws-cli (userspace) and add the bin dir to GITHUB_PATH.
         # Idempotent via command -v check — persists across runs since
-        # the isolated runner VM keeps /usr/local/aws-cli between jobs.
+        # the isolated runner VM keeps $HOME between jobs.
         run: |
           if ! command -v aws >/dev/null 2>&1; then
             curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
             unzip -q /tmp/awscliv2.zip -d /tmp/awscli
-            sudo /tmp/awscli/aws/install
+            /tmp/awscli/aws/install \
+              --install-dir "$HOME/.aws-cli" \
+              --bin-dir "$HOME/.aws-cli/bin"
             rm -rf /tmp/awscliv2.zip /tmp/awscli
           fi
-          aws --version
+          # GITHUB_PATH prepends to PATH for all subsequent steps.
+          echo "$HOME/.aws-cli/bin" >> "$GITHUB_PATH"
+          "$HOME/.aws-cli/bin/aws" --version
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -49,14 +49,18 @@ jobs:
           echo "Deploying $GITHUB_REF_NAME → image sha-$SHA"
 
       - name: Install AWS CLI v2 if missing
+        # Userspace install — runner user has no passwordless sudo.
         run: |
           if ! command -v aws >/dev/null 2>&1; then
             curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
             unzip -q /tmp/awscliv2.zip -d /tmp/awscli
-            sudo /tmp/awscli/aws/install
+            /tmp/awscli/aws/install \
+              --install-dir "$HOME/.aws-cli" \
+              --bin-dir "$HOME/.aws-cli/bin"
             rm -rf /tmp/awscliv2.zip /tmp/awscli
           fi
-          aws --version
+          echo "$HOME/.aws-cli/bin" >> "$GITHUB_PATH"
+          "$HOME/.aws-cli/bin/aws" --version
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.287",
+      version: "0.5.290",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Self-hosted runner user has no passwordless sudo. \`sudo /tmp/awscli/aws/install\` in #392 failed with \`sudo: a password is required\`. Switch to userspace install via the AWS CLI v2 installer's \`--install-dir\` + \`--bin-dir\` flags, then echo the bin dir to \`\$GITHUB_PATH\` so subsequent steps pick it up.

Affects both \`build-ecr.yml\` and \`deploy-prod.yml\`.

Idempotent + persists across runs since \$HOME survives on the isolated runner VM (post-first-run, \`command -v aws\` short-circuits the install).

## Test plan

- [x] \`yaml.safe_load\` parses both workflows
- [ ] Next push to main triggers \`build-ecr\` and the install step exits 0
- [ ] First \`release-v*\` tag fires \`deploy-prod\` cleanly

Refs engram-app/Engram#266