### PR TITLE
fix(deploy): clear /tmp/awscli before unzipping (overwrite race)

### DIFF
--- a/.github/workflows/build-ecr.yml
+++ b/.github/workflows/build-ecr.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           if ! command -v aws >/dev/null 2>&1; then
             curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            rm -rf /tmp/awscli
             unzip -q /tmp/awscliv2.zip -d /tmp/awscli
             /tmp/awscli/aws/install \
               --install-dir "$HOME/.aws-cli" \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           if ! command -v aws >/dev/null 2>&1; then
             curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            rm -rf /tmp/awscli
             unzip -q /tmp/awscliv2.zip -d /tmp/awscli
             /tmp/awscli/aws/install \
               --install-dir "$HOME/.aws-cli" \

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.290",
+      version: "0.5.291",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Build-ecr on the #394 merge commit failed:

\`\`\`
replace /tmp/awscli/aws/install? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
##[error]Process completed with exit code 1.
\`\`\`

Prior failed install runs left \`/tmp/awscli\` behind on the runner VM. \`unzip -q\` doesn't auto-skip the overwrite prompt — it just suppresses non-prompt chatter. \`rm -rf /tmp/awscli\` before unzip clears the stale dir.

Applies same fix to deploy-prod.yml.

## Test plan

- [ ] Merge → \`build-ecr\` succeeds on the merge commit → image lands in ECR as \`sha-<7chars>\`
- [ ] Tag \`release-v0.5.291\` → \`deploy-prod\` registers task def + rolls service

Refs engram-app/Engram#266