### PR TITLE
fix(hooks): skip pre-push when pushing only tag refs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,9 +7,30 @@
 
 set -euo pipefail
 
+# Skip the whole hook when the push contains only tag refs. Tag pushes
+# target already-merged commits (release-v* triggers prod deploys), so
+# the branch version-bump policy below doesn't apply.
+#
+# pre-push receives one line per ref on stdin:
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+# Empty stdin means no refs are being pushed — also safe to skip.
+pushing_only_tags=true
+have_any_ref=false
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  have_any_ref=true
+  if [[ "$remote_ref" != refs/tags/* ]]; then
+    pushing_only_tags=false
+    break
+  fi
+done
+
+if [ "$have_any_ref" = "true" ] && [ "$pushing_only_tags" = "true" ]; then
+  exit 0
+fi
+
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
-# Allow main, tags, and detached HEAD to push freely.
+# Allow main and detached HEAD to push freely.
 if [ "$current_branch" = "main" ] || [ "$current_branch" = "HEAD" ]; then
   exit 0
 fi

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.291",
+      version: "0.5.292",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Pre-push hook reads \`current_branch\` and applies version-bump policy universally. \`git push origin release-v0.5.291\` is blocked because the worktree's \`mix.exs\` version still matches \`origin/main\` — which is **correct** for a tag pointing at an already-merged commit.

Fix: read stdin for the refs being pushed. If every ref is \`refs/tags/*\`, skip the version check + the quality gates entirely. Branch-vs-main version policy doesn't apply to tag pushes.

## Why

Unblocks the first \`release-v0.5.291\` tag for the AWS prod deploy smoke test (engram-app/Engram#266). Without this, every \`release-v*\` deploy trigger would require \`--no-verify\` — which the repo's broader policy says we shouldn't routinely use.

## Test plan

- [x] \`bash -n .githooks/pre-push\` (syntax OK)
- [ ] Push \`release-v0.5.291\` after merge — hook skips, tag lands, \`deploy-prod\` fires.

Refs engram-app/Engram#266