### PR TITLE
fix(deploy): path-based aws-cli check + --update flag

### DIFF
--- a/.github/workflows/build-ecr.yml
+++ b/.github/workflows/build-ecr.yml
@@ -48,25 +48,34 @@ jobs:
             echo "Tagging with: sha-$SHA"
           fi
 
-      - name: Install AWS CLI v2 if missing
-        # Self-hosted runner pool doesn't ship awscli by default and
-        # the runner user has no passwordless sudo. Install into
-        # $HOME/.aws-cli (userspace) and add the bin dir to GITHUB_PATH.
-        # Idempotent via command -v check — persists across runs since
-        # the isolated runner VM keeps $HOME between jobs.
+      - name: Install AWS CLI v2 (idempotent)
+        # Self-hosted runner pool doesn't ship awscli + the runner user
+        # has no passwordless sudo. Install into $HOME/.aws-cli (userspace)
+        # and add the bin dir to GITHUB_PATH every run.
+        #
+        # The `[ ! -x "$BIN" ]` path-based check is more reliable than
+        # `command -v aws` — GITHUB_PATH additions don't persist across
+        # runs, so a PATH-shaped check fails even on a runner where
+        # awscli is already present at the expected $HOME/.aws-cli path.
+        #
+        # `--update` makes `aws/install` idempotent even when an existing
+        # install is present (otherwise it errors with "Found preexisting
+        # AWS CLI installation"). The path check above keeps the fast
+        # path; --update is the safety net for race conditions.
         run: |
-          if ! command -v aws >/dev/null 2>&1; then
+          BIN="$HOME/.aws-cli/bin/aws"
+          if [ ! -x "$BIN" ]; then
             curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
             rm -rf /tmp/awscli
             unzip -q /tmp/awscliv2.zip -d /tmp/awscli
             /tmp/awscli/aws/install \
               --install-dir "$HOME/.aws-cli" \
-              --bin-dir "$HOME/.aws-cli/bin"
+              --bin-dir "$HOME/.aws-cli/bin" \
+              --update
             rm -rf /tmp/awscliv2.zip /tmp/awscli
           fi
-          # GITHUB_PATH prepends to PATH for all subsequent steps.
           echo "$HOME/.aws-cli/bin" >> "$GITHUB_PATH"
-          "$HOME/.aws-cli/bin/aws" --version
+          "$BIN" --version
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -48,20 +48,22 @@ jobs:
           echo "release=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           echo "Deploying $GITHUB_REF_NAME → image sha-$SHA"
 
-      - name: Install AWS CLI v2 if missing
-        # Userspace install — runner user has no passwordless sudo.
+      - name: Install AWS CLI v2 (idempotent)
+        # See build-ecr.yml for the rationale on path-based check + --update.
         run: |
-          if ! command -v aws >/dev/null 2>&1; then
+          BIN="$HOME/.aws-cli/bin/aws"
+          if [ ! -x "$BIN" ]; then
             curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
             rm -rf /tmp/awscli
             unzip -q /tmp/awscliv2.zip -d /tmp/awscli
             /tmp/awscli/aws/install \
               --install-dir "$HOME/.aws-cli" \
-              --bin-dir "$HOME/.aws-cli/bin"
+              --bin-dir "$HOME/.aws-cli/bin" \
+              --update
             rm -rf /tmp/awscliv2.zip /tmp/awscli
           fi
           echo "$HOME/.aws-cli/bin" >> "$GITHUB_PATH"
-          "$HOME/.aws-cli/bin/aws" --version
+          "$BIN" --version
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.292",
+      version: "0.5.293",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Deploy-prod failed on a runner that already had \`$HOME/.aws-cli\` populated from a prior build-ecr install:

\`\`\`
Found preexisting AWS CLI installation: /home/runner/.aws-cli/v2/current.
Please rerun install script with --update flag.
\`\`\`

Two compounding issues:

1. \`command -v aws\` returns false because GITHUB_PATH additions don't persist across runs — the install branch fired even though the binary was already at the expected path.
2. Without \`--update\`, \`aws/install\` refuses to overwrite a prior install.

Switch the check to \`[ ! -x "\$HOME/.aws-cli/bin/aws" ]\` (path-based, reliable across runs) and add \`--update\` to make the install idempotent if the path check ever races with another job.

## Test plan

- [ ] Merge → main's \`build-ecr\` succeeds (already proved with prior install; reverify after path-check change)
- [ ] Re-push \`release-v0.5.291\` → \`deploy-prod\` runs through end-to-end → ECS service rolls

Refs engram-app/Engram#266