### PR TITLE
fix(ci): skip CI workflow on release-v* tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,12 @@ on:
       - "revert/**"
       - "security/**"
       - "test/**"
-    tags-ignore: ["v*"]
+    # `v*` covers semver release tags applied for marketing/audit.
+    # `release-v*` is the deploy trigger — CI already ran on the
+    # merge commit the tag points at, no need to rerun (and the
+    # version-check job mistakenly fires on the tag because the
+    # mix.exs version still matches main).
+    tags-ignore: ["v*", "release-v*"]
   repository_dispatch:
     types: [plugin-e2e-trigger]
   workflow_dispatch:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.295",
+      version: "0.5.296",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

\`tags-ignore: [\"v*\"]\` doesn't catch \`release-v*\` (different prefix), so the entire CI workflow fires on every \`release-v*\` deploy tag and the version-check job fails — correctly: the tag points at an already-merged commit, so \`mix.exs\` version matches main by design.

Add \`release-v*\` to \`tags-ignore\`. CI already ran on the merge commit the tag points at; no reason to rerun. Deploy-prod is the workflow that handles release tags.

Refs engram-app/Engram#266