### PR TITLE
chore(deploy): GitOps prod via engram-infra PR (drop imperative ECS path)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,43 +1,42 @@
 name: Deploy prod
 
-# Pushing a `release-v*` git tag triggers this workflow, which
-# registers a new ECS task definition pinning the image built for
-# the tagged commit and rolls the service to that revision.
+# Pushing a `release-v*` git tag triggers this workflow, which opens a
+# PR in engram-app/engram-infra rewriting the `engram_image_tag`
+# default in `main/envs/prod/variables.tf` to the `sha-<7>` of the
+# tagged commit. On merge, engram-infra's CI `terraform (prod)` job
+# applies the change: a new ECS task definition is registered with the
+# pinned image, and the engram-saas-prod service rolls onto it.
+#
+# This is the GitOps mirror of the staging-fastraid `bump-infra-tfvars`
+# pattern (engram/.github/workflows/ci.yml). Image tag = desired state
+# in git; engram-infra is the reconciler.
 #
 # Release recipe:
 #   git tag release-v0.5.234 <commit>   # commit must already be on main
 #   git push origin release-v0.5.234
 #
-# Rollback recipe (same trigger, points at older commit):
-#   git tag release-v0.5.234-rollback <last-known-good-sha>
-#   git push origin release-v0.5.234-rollback
-#
-# OIDC trust on the ecs_deploy role is scoped to refs/tags/release-v*
-# only — neither main nor feature branches can assume it.
+# Rollback recipe (forward-roll — no separate workflow):
+#   git tag release-v0.5.235 <last-known-good-sha-on-main>
+#   git push origin release-v0.5.235
 on:
   push:
     tags: ['release-v*']
 
 concurrency:
+  # Serialize deploys globally so two release tags can't race the same
+  # bot-PR branch in engram-infra.
   group: deploy-prod
-  # Never abort a deploy mid-flight. Tags queue serially.
   cancel-in-progress: false
 
 permissions:
-  id-token: write
   contents: read
 
-env:
-  AWS_REGION: us-east-1
-  CLUSTER: engram-prod
-  SERVICE: engram-saas-prod
-  TASK_FAMILY: engram-saas-prod
-
 jobs:
-  deploy:
+  open-infra-pr:
     runs-on: [self-hosted, linux, x64, isolated]
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout engram (tagged commit)
+        uses: actions/checkout@v6
 
       - name: Compute image tag from tagged commit
         id: tags
@@ -48,90 +47,136 @@ jobs:
           echo "release=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           echo "Deploying $GITHUB_REF_NAME → image sha-$SHA"
 
-      - name: Install AWS CLI v2 (idempotent)
-        # See build-ecr.yml for the rationale on path-based check + --update.
-        run: |
-          BIN="$HOME/.aws-cli/bin/aws"
-          if [ ! -x "$BIN" ]; then
-            curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-            rm -rf /tmp/awscli
-            unzip -q /tmp/awscliv2.zip -d /tmp/awscli
-            /tmp/awscli/aws/install \
-              --install-dir "$HOME/.aws-cli" \
-              --bin-dir "$HOME/.aws-cli/bin" \
-              --update
-            rm -rf /tmp/awscliv2.zip /tmp/awscli
-          fi
-          echo "$HOME/.aws-cli/bin" >> "$GITHUB_PATH"
-          "$BIN" --version
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+      # Mint a short-lived installation token for the engram-infra-tf
+      # GitHub App, scoped to engram-app/engram-infra only. Required
+      # permissions on engram-infra:
+      #   - contents: read & write   (push branch)
+      #   - pull-requests: read & write   (open PR + auto-merge)
+      # Same App + secrets already used by the staging `bump-infra-tfvars`
+      # job in ci.yml.
+      - name: Generate engram-infra App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
         with:
-          role-to-assume: ${{ vars.AWS_ECS_DEPLOY_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: engram-app
+          repositories: engram-infra
 
-      - name: Verify image exists in ECR
+      - name: Checkout engram-infra
+        uses: actions/checkout@v6
+        with:
+          repository: engram-app/engram-infra
+          token: ${{ steps.app-token.outputs.token }}
+          path: engram-infra
+          ref: main
+          # peter-evans/create-pull-request@v8 sets its own
+          # Authorization header on push; persist-credentials=true would
+          # leave the checkout's basic-auth extraheader in git config,
+          # and the second header triggers GitHub's "Duplicate header:
+          # Authorization" 400. See the matching note in ci.yml's
+          # bump-infra-tfvars job.
+          persist-credentials: false
+
+      - name: Rewrite engram_image_tag default in variables.tf
+        id: rewrite
         env:
           IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}
         run: |
-          # Fail loudly if build-ecr.yml hasn't run for this commit
-          # yet (e.g. tag pushed before main CI finished).
-          aws ecr describe-images \
-            --repository-name engram-saas-prod \
-            --image-ids "imageTag=$IMAGE_TAG" \
-            --query 'imageDetails[0].imagePushedAt' --output text
+          python3 - <<'PY'
+          import os
+          import re
 
-      - name: Register new task definition pinning the image
-        id: register
+          path = "engram-infra/main/envs/prod/variables.tf"
+          image_tag = os.environ["IMAGE_TAG"]
+          gh_output = os.environ["GITHUB_OUTPUT"]
+
+          text = open(path).read()
+          # Anchored on the variable block name so adding other
+          # `default = ` lines elsewhere in the file is safe.
+          pattern = re.compile(
+              r'(variable\s+"engram_image_tag"[^}]*?default\s*=\s*)"[^"]+"',
+              re.DOTALL,
+          )
+          new, count = pattern.subn(rf'\g<1>"{image_tag}"', text)
+          if count != 1:
+              raise SystemExit(
+                  f"expected exactly 1 engram_image_tag block, got {count}; "
+                  "variables.tf shape changed — adjust the regex"
+              )
+          open(path, "w").write(new)
+          with open(gh_output, "a") as f:
+              f.write("rewrote=true\n")
+          print(f"rewrote engram_image_tag default → {image_tag}")
+          PY
+
+          echo "::group::variables.tf after rewrite"
+          cat engram-infra/main/envs/prod/variables.tf
+          echo "::endgroup::"
+
+      - name: Open / update PR in engram-infra
+        id: open-pr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          path: engram-infra
+          token: ${{ steps.app-token.outputs.token }}
+          # Branch is reused across deploys (matches staging pattern).
+          # Each new release force-pushes the branch with the latest
+          # sha-tag; a still-open PR is updated in place rather than
+          # piling up duplicates.
+          branch: bot/bump-engram-prod
+          delete-branch: true
+          # engram-infra's ruleset enforces required_signatures = true.
+          # sign-commits routes through the GraphQL createCommitOnBranch
+          # mutation so GitHub auto-signs on behalf of the App.
+          sign-commits: true
+          commit-message: |
+            chore(prod): bump engram image to ${{ steps.tags.outputs.image_tag }}
+
+            Automated bump from engram-app/Engram release ${{ steps.tags.outputs.release }}.
+          title: "chore(prod): bump engram image to ${{ steps.tags.outputs.image_tag }}"
+          body: |
+            Automated bump from engram-app/Engram release `${{ steps.tags.outputs.release }}`.
+
+            Source commit: ${{ github.repository }}@${{ github.sha }}
+
+            Bumps `engram_image_tag` default in `main/envs/prod/variables.tf` to **`${{ steps.tags.outputs.image_tag }}`**.
+
+            ## What this triggers
+
+            On merge, `.github/workflows/ci.yml` `terraform (prod)` runs `terraform apply -auto-approve`. The new task definition revision pins the engram-saas-prod container image to `${{ vars.AWS_ECR_REPOSITORY || 'engram-saas-prod' }}:${{ steps.tags.outputs.image_tag }}`, and the ECS service rolls onto it.
+
+            ## Review
+
+            Auto-generated; if `variables.tf` has any non-image diff, treat as a regex regression and investigate before merging.
+          labels: |
+            automated
+            tf-image-bump
+
+      - name: Enable auto-merge on bot PR
+        # Auto-merge queues the PR for merge once required checks pass.
+        # engram-infra has `allow_auto_merge=true` in repos.tf.
+        if: steps.open-pr.outputs.pull-request-number != ''
         env:
-          IMAGE: ${{ vars.AWS_ECR_REPOSITORY }}:${{ steps.tags.outputs.image_tag }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.open-pr.outputs.pull-request-number }}
         run: |
-          set -euo pipefail
-          # Clone the live task def, mutate the image, drop the
-          # response-only fields that register-task-definition rejects
-          # on input.
-          aws ecs describe-task-definition \
-            --task-definition "$TASK_FAMILY" \
-            --query 'taskDefinition' \
-            > /tmp/td.json
-          jq --arg img "$IMAGE" '
-            .containerDefinitions[0].image = $img
-            | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
-                  .compatibilities, .registeredAt, .registeredBy)
-          ' /tmp/td.json > /tmp/td-new.json
-          NEW_ARN=$(aws ecs register-task-definition \
-            --cli-input-json "file:///tmp/td-new.json" \
-            --query 'taskDefinition.taskDefinitionArn' --output text)
-          echo "task_def_arn=$NEW_ARN" >> "$GITHUB_OUTPUT"
-          echo "Registered: $NEW_ARN"
-
-      - name: Update service
-        env:
-          NEW_TD: ${{ steps.register.outputs.task_def_arn }}
-        run: |
-          aws ecs update-service \
-            --cluster "$CLUSTER" \
-            --service "$SERVICE" \
-            --task-definition "$NEW_TD" \
-            --query 'service.deployments[0].id' --output text
-
-      - name: Wait for service stable
-        run: |
-          # Default timeout is 10min (40 polls × 15s). For a 2-task
-          # service that's plenty; if it blows past, the deploy is
-          # genuinely broken and the operator should investigate.
-          aws ecs wait services-stable \
-            --cluster "$CLUSTER" \
-            --services "$SERVICE"
+          gh pr merge --auto --squash --repo engram-app/engram-infra "$PR_NUMBER"
 
       - name: Summary
+        env:
+          PR_NUMBER: ${{ steps.open-pr.outputs.pull-request-number }}
+          PR_URL: ${{ steps.open-pr.outputs.pull-request-url }}
         run: |
           {
-            echo "## Deploy succeeded"
+            echo "## GitOps PR opened"
             echo ""
             echo "- Release tag: \`${{ steps.tags.outputs.release }}\`"
             echo "- Commit: ${{ github.sha }}"
-            echo "- Image: \`${{ vars.AWS_ECR_REPOSITORY }}:${{ steps.tags.outputs.image_tag }}\`"
-            echo "- Task def: \`${{ steps.register.outputs.task_def_arn }}\`"
+            echo "- Image tag: \`${{ steps.tags.outputs.image_tag }}\`"
+            if [ -n "$PR_NUMBER" ]; then
+              echo "- engram-infra PR: [#${PR_NUMBER}](${PR_URL}) (auto-merge enabled)"
+            else
+              echo "- No PR opened (no diff — image already at this tag)."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/context/deploy-prod.md
+++ b/docs/context/deploy-prod.md
@@ -2,14 +2,17 @@
 
 When to read this: shipping code to `app.engram.page`, rolling back a bad deploy, or debugging the deploy pipeline.
 
-## How it works
+## How it works (GitOps)
 
-Two-stage pipeline split into two GitHub Actions workflows in this repo:
+Two-stage pipeline. Image build lives in this repo; image-tag selection lives in [engram-infra](https://github.com/engram-app/engram-infra). **The live image tag is reconcilable from git** — `var.engram_image_tag` in `engram-infra/main/envs/prod/variables.tf` is the source of truth.
 
-1. **`build-ecr.yml`** — runs on every push to `main`. Builds the Docker image and pushes to ECR tagged `sha-<7chars>`. The image sits in ECR; **nothing rolls.**
-2. **`deploy-prod.yml`** — runs only when a `release-v*` git tag is pushed. Clones the live task definition, swaps in the image for the tagged commit, registers a new revision, and `update-service` rolls the cluster.
+1. **`build-ecr.yml`** (this repo) — runs on every push to `main`. Builds the Docker image and pushes to ECR tagged `sha-<7>`. The image sits in ECR; **nothing rolls.**
 
-OIDC IAM trust enforces the boundary: the build role (`engram-saas-prod-ecr-push`) trusts `refs/heads/main` + `refs/tags/v*` only; the deploy role (`engram-saas-prod-ecs-deploy`) trusts `refs/tags/release-v*` only. Build can never accidentally roll, deploy can never accidentally push an image.
+2. **`deploy-prod.yml`** (this repo) — runs only when a `release-v*` git tag is pushed. Opens a PR in engram-infra rewriting `engram_image_tag` default to the `sha-<7>` of the tagged commit, enables auto-merge.
+
+3. **engram-infra `terraform (prod)`** (engram-infra `.github/workflows/ci.yml`, `matrix: env: [staging, prod]`) — runs `terraform apply -auto-approve` on push to main. The new image tag flows into `aws_ecs_task_definition.engram`; a new revision is registered; `aws_ecs_service.engram` rolls onto it.
+
+The OIDC build role (`engram-saas-prod-ecr-push`) trusts `refs/heads/main` + `refs/tags/v*` only — build can never accidentally roll. The deploy workflow no longer assumes any AWS role: it only opens a cross-repo PR via the `engram-infra-tf` GitHub App.
 
 ## Release recipe
 
@@ -26,22 +29,28 @@ git tag release-v0.5.234
 git push origin release-v0.5.234
 ```
 
-The deploy workflow takes ~3-5 min: register task def → update-service → `wait services-stable`. Watch in the Actions tab.
+The deploy workflow takes ~30 seconds to open the engram-infra PR. End-to-end (PR open → auto-merge after CI → `terraform apply` → service stable) is typically ~5-8 min depending on engram-infra CI latency.
+
+Watch the chain:
+
+1. **engram** Actions tab → `Deploy prod` → link to bot PR in step summary
+2. **engram-infra** PR → CI greenlights → auto-merge fires
+3. **engram-infra** Actions tab → `terraform (prod)` → apply log
+4. **AWS** → `aws ecs describe-services` shows new task def revision
 
 ## Rollback recipe
 
-Rollback is a forward-roll to a known-good image. Same trigger mechanism — push a release tag pointing at the older commit:
+Rollback is a forward-roll: push a new release tag pointing at the older commit. Same workflow, no special path.
 
 ```bash
-# Find the last good commit (whichever sha-<7> image you want back live)
+# Find the last good commit
 GOOD_SHA=abc1234
 
-# Tag with a -rollback suffix for audit clarity (any release-v* matches)
-git tag release-v0.5.234-rollback $GOOD_SHA
-git push origin release-v0.5.234-rollback
+git tag release-v0.5.235 $GOOD_SHA
+git push origin release-v0.5.235
 ```
 
-The workflow registers a fresh task def revision pinning that old image and rolls the service. Task def history in ECS becomes the deploy log — `aws ecs list-task-definitions --family-prefix engram-saas-prod` shows every deploy in order.
+The workflow opens an engram-infra PR bumping the var to that older `sha-<7>`. On merge, TF registers a fresh revision pinning the old image and the service rolls back. Task def history in ECS becomes the deploy log — `aws ecs list-task-definitions --family-prefix engram-saas-prod` shows every revision in order.
 
 ## Inspect deploy state
 
@@ -61,16 +70,36 @@ aws ecs list-task-definitions --family-prefix engram-saas-prod --sort DESC --max
 aws ecr describe-images --repository-name engram-saas-prod \
   --query 'sort_by(imageDetails,&imagePushedAt)[-10:].[imageTags[0],imagePushedAt]' \
   --output table
+
+# Current source of truth for live image:
+gh api repos/engram-app/engram-infra/contents/main/envs/prod/variables.tf \
+  --jq '.content' | base64 -d | grep -A2 engram_image_tag
 ```
 
-Operator AWS profile is `engram-infra-operator` (read-only — `operator-cheatsheet.md` in engram-infra). For deploy/rollback CLI access (write), use the IAM Roles Anywhere break-glass path documented there.
+Operator AWS profile is `engram-infra-operator` (read-only — `operator-cheatsheet.md` in engram-infra).
 
 ## Failure modes
 
-- **`deploy-prod.yml` step "Verify image exists in ECR" fails** — `build-ecr.yml` hasn't finished for that commit yet, or the commit was never on main. Wait for build to finish, or check the commit is reachable from `origin/main`.
-- **`wait services-stable` times out (10 min)** — task is crash-looping. Check CloudWatch Logs `/ecs/engram-saas-prod`, then roll back via the rollback recipe.
-- **`Register new task definition` fails with `iam:PassRole`** — the ecs_deploy role's PassRole permission is conditional on `iam:PassedToService = ecs-tasks.amazonaws.com`. If the task def's `executionRoleArn` or `taskRoleArn` references a role outside `engram-saas-prod-ecs-{execution,task}`, fix the upstream TF in engram-infra `main/envs/prod/ecs_iam.tf`.
+- **`deploy-prod.yml` step "Rewrite engram_image_tag default" fails** — regex regression. Check `main/envs/prod/variables.tf` shape in engram-infra; the workflow expects exactly one `variable "engram_image_tag"` block with a `default = "..."` line.
+- **Bot PR opens but doesn't auto-merge** — engram-infra CI failing (typically tflint or terraform plan). Open the PR, read the failing check, fix root cause in engram-infra. The bot will reuse the `bot/bump-engram-prod` branch on the next release tag.
+- **`terraform apply` on engram-infra fails on `ResourceNotFoundException`** — `sha-<7>` image isn't in ECR. `build-ecr.yml` for that commit hasn't finished (or never ran). Confirm with `aws ecr describe-images`; rerun build-ecr if needed.
+- **Service crash-loops after deploy** — task running but health checks fail. Check CloudWatch Logs `/ecs/engram-saas-prod`, then forward-roll to the last-known-good `sha-<7>` via a new release tag.
+- **App token mint step 403s** — `engram-infra-tf` App permissions changed. Required: `contents: read & write` + `pull-requests: read & write` on engram-infra. Adjust at https://github.com/organizations/engram-app/settings/apps/engram-infra-tf.
 
-## Why not merge-to-deploy?
+## Break-glass: manual AWS deploy
+
+The GitOps path is the only sanctioned route. If engram-infra CI is wedged AND a deploy must ship NOW, an operator with prod admin credentials (Roles Anywhere break-glass — see `operator-cheatsheet.md` in engram-infra) can `aws ecs register-task-definition` + `update-service` directly. After the incident, **immediately** open an engram-infra PR bumping `engram_image_tag` to match what's live, otherwise the next routine `terraform apply` reverts the service.
+
+The dedicated `engram-saas-prod-ecs-deploy` IAM role was removed when the workflow migrated to GitOps (engram-infra PR — TODO). No CI workflow needs ECS-write OIDC anymore.
+
+## Why GitOps (not imperative)
+
+The previous shape called `aws ecs register-task-definition` + `update-service` directly from this workflow. That stored the live image tag only in ECS state, never in git, which:
+
+1. **Broke GitOps.** Desired state must be in git.
+2. **Caused real TF drift.** `aws_ecs_service.engram` has `lifecycle.ignore_changes = [desired_count]` only — not `task_definition`. The next routine `tf apply` on engram-infra would have reverted the service to revision 1 (the TF-managed task def pointing at the old default).
+3. **Was asymmetric with staging.** Staging-fastraid already runs the var-bump-PR pattern via engram-infra's `tf-apply` daemon. Prod now mirrors it.
+
+## Why tag-gated (not merge-to-deploy)
 
 Pre-revenue, merge-to-deploy is fine. Post-launch, every PR shipping immediately creates pressure: tests pass means deploy, no human gate, no batch-windowing. Tag-gated lets the operator (a) batch multiple merges into one release, (b) hold deploys during incident windows, (c) audit exactly what shipped when via `git tag --list 'release-v*'`. The cost is one extra step per release (`git tag && git push`) — worth it for a paid product.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.296",
+      version: "0.5.298",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- `release-v*` tag now opens a PR in `engram-app/engram-infra` rewriting `engram_image_tag` default in `main/envs/prod/variables.tf` to the `sha-<7>` of the tagged commit. Auto-merge fires after engram-infra CI greenlights; the `terraform (prod)` matrix job applies, registers a new task def revision, and the ECS service rolls.
- Drops the imperative `aws ecs register-task-definition` / `update-service` path entirely — the workflow no longer assumes any AWS role.
- Rewrites `docs/context/deploy-prod.md` to describe the GitOps flow + new failure modes + a documented break-glass.

Mirrors the existing staging `bump-infra-tfvars` pattern in this repo's `ci.yml` (engram-infra-tf GitHub App, `peter-evans/create-pull-request@v8` with `sign-commits: true`, `gh pr merge --auto --squash`).

## Why

The previous shape stored the live image tag only in ECS state, never in git:

1. **Broke GitOps.** Desired state must be in git.
2. **Real TF drift.** `aws_ecs_service.engram` has `lifecycle.ignore_changes = [desired_count]` only — not `task_definition`. The next routine `terraform apply` on engram-infra would have reverted the service to revision 1 (the TF-managed task def pointing at the placeholder default `"prod-latest"` that doesn't exist in ECR).
3. **Asymmetric with staging.** Staging-fastraid already runs the var-bump-PR pattern via the engram-infra tf-apply daemon.

## Follow-ups (separate PRs in engram-infra)

- Update docstring on `engram_image_tag` in `main/envs/prod/variables.tf` to describe the GitOps flow.
- Bump the `engram_image_tag` default to the current live `sha-<7>` so a defaults-only `tf apply` no longer points at a nonexistent `prod-latest` (drift bomb).
- Delete `engram-saas-prod-ecs-deploy` IAM role (`main/envs/prod/ecs_deploy.tf`) + `AWS_ECS_DEPLOY_ROLE_ARN` repo var — both unused now.

## Test plan

- [ ] Visual review of the new `deploy-prod.yml` flow.
- [ ] Land this PR, then land the engram-infra follow-up that bumps the default to current live `sha-aaa5904` (drift fix). **Order matters** — until the default matches what's live, any unrelated engram-infra prod apply could revert the service.
- [ ] Push `release-v0.5.<next>` at HEAD of engram main and watch the chain:
  - [ ] Engram `Deploy prod` opens a bot PR at engram-app/engram-infra
  - [ ] engram-infra CI greenlights → auto-merge fires
  - [ ] engram-infra `terraform (prod)` apply succeeds
  - [ ] `aws ecs describe-services --cluster engram-prod --services engram-saas-prod` shows the new task def revision running (desired=2)
  - [ ] `app.engram.page` `/api/health` returns 200
- [ ] Delete failed `release-v0.5.291` + `release-v0.5.293` tags (`git push origin :release-v0.5.291 :release-v0.5.293`) — neither deployed anything.