### PR TITLE
fix(runtime): use ex_aws default credentials chain on ECS

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,15 +35,29 @@ if config_env() != :test do
       config :engram, :storage, Engram.Storage.S3
       config :engram, :storage_bucket, System.get_env("STORAGE_BUCKET", "engram-attachments")
 
-      config :ex_aws,
-        access_key_id: System.get_env("STORAGE_ACCESS_KEY_ID"),
-        secret_access_key: System.get_env("STORAGE_SECRET_ACCESS_KEY"),
-        region: System.get_env("STORAGE_REGION", "auto")
+      # Explicit static creds (Tigris, MinIO, self-host) — only set
+      # when STORAGE_ACCESS_KEY_ID is present. On AWS ECS Fargate
+      # leaving these unset lets ex_aws fall back to the task role via
+      # the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI metadata endpoint.
+      if System.get_env("STORAGE_ACCESS_KEY_ID") do
+        config :ex_aws,
+          access_key_id: System.fetch_env!("STORAGE_ACCESS_KEY_ID"),
+          secret_access_key: System.fetch_env!("STORAGE_SECRET_ACCESS_KEY"),
+          region: System.get_env("STORAGE_REGION", "auto")
+      else
+        config :ex_aws,
+          region: System.get_env("STORAGE_REGION", System.get_env("AWS_REGION", "us-east-1"))
+      end
 
-      config :ex_aws, :s3,
-        scheme: System.get_env("STORAGE_SCHEME", "https://"),
-        host: System.get_env("STORAGE_HOST"),
-        port: String.to_integer(System.get_env("STORAGE_PORT", "443"))
+      # Endpoint override (Tigris, MinIO) — only when STORAGE_HOST is
+      # set. AWS-native S3 leaves this unset so ex_aws uses its default
+      # regional endpoint.
+      if System.get_env("STORAGE_HOST") do
+        config :ex_aws, :s3,
+          scheme: System.get_env("STORAGE_SCHEME", "https://"),
+          host: System.fetch_env!("STORAGE_HOST"),
+          port: String.to_integer(System.get_env("STORAGE_PORT", "443"))
+      end
 
     "database" ->
       config :engram, :storage, Engram.Storage.Database
@@ -413,13 +427,22 @@ if config_env() != :test do
       aws_kms_key_id: System.fetch_env!("AWS_KMS_KEY_ID"),
       aws_kms_region: System.fetch_env!("AWS_REGION")
 
-    # Scoped to :ex_aws, :kms so we don't overwrite the global :ex_aws creds
-    # that the S3 storage backend (Fly Tigris) configured above with
-    # STORAGE_ACCESS_KEY_ID/STORAGE_SECRET_ACCESS_KEY/STORAGE_REGION.
-    config :ex_aws, :kms,
-      access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
-      secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
-      region: System.fetch_env!("AWS_REGION")
+    # Scoped to :ex_aws, :kms so KMS creds don't overwrite the global
+    # :ex_aws creds that the S3 storage backend (Fly Tigris / MinIO)
+    # may have configured above.
+    #
+    # Explicit static creds (Fly with an AWS access key for KMS, local
+    # dev) — only set when AWS_ACCESS_KEY_ID is present. On AWS ECS
+    # Fargate leaving these unset lets ex_aws fall back to the task
+    # role via AWS_CONTAINER_CREDENTIALS_RELATIVE_URI.
+    if System.get_env("AWS_ACCESS_KEY_ID") do
+      config :ex_aws, :kms,
+        access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
+        secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
+        region: System.fetch_env!("AWS_REGION")
+    else
+      config :ex_aws, :kms, region: System.fetch_env!("AWS_REGION")
+    end
   end
 end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.293",
+      version: "0.5.295",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Drops hardcoded `System.fetch_env!("AWS_ACCESS_KEY_ID")` / `AWS_SECRET_ACCESS_KEY` in both the storage backend block and the KMS provider block of `config/runtime.exs`. On AWS ECS Fargate, no static IAM-user creds are passed to the task — ECS injects task-role credentials via the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` metadata endpoint, and ex_aws's default credentials provider chain picks them up automatically when no `access_key_id` / `secret_access_key` is configured.

## Context

This is the second of three stacked fixes for the engram-saas-prod outage discovered today (2026-06-02):

1. **engram-infra#229** (MERGED) — ECS task trust policy bug: `sts:AssumeRoleWithWebIdentity` → `sts:AssumeRole`. Trust fix unblocked task launch.
2. **THIS PR** — runtime.exs creds. Tasks now launched but crashed at boot with `System.EnvError`. This is the actual fix.
3. **engram-app/Engram#399** — GitOps deploy workflow rewrite. Independent of (1) and (2).

The error trace post-#229:

```
ERROR! Config provider Config.Reader failed with:
** (System.EnvError) could not fetch environment variable "AWS_ACCESS_KEY_ID" because it is not set
    /app/releases/0.5.293/runtime.exs:420
```

## Behavior matrix

| Scenario                   | STORAGE_*  | AWS_ACCESS_KEY_ID | Creds source                |
|----------------------------|------------|-------------------|-----------------------------|
| AWS ECS prod (`app.engram.page`) | unset      | unset             | ECS task role (NEW)         |
| Fly (Tigris + KMS via IAM) | set        | set               | Static (unchanged)          |
| Self-host MinIO + local KMS | set        | n/a (`KEY_PROVIDER=local`) | Static (unchanged)   |
| Local dev                  | unset      | unset             | ex_aws default chain        |

The `:ex_aws` and `:ex_aws, :kms` config blocks now only set explicit `access_key_id` / `secret_access_key` when env vars are present; when unset, ex_aws's default provider chain handles credential lookup (which on ECS hits the metadata endpoint).

Also fixes a latent bug where `:ex_aws, :s3` had `host: nil` when `STORAGE_HOST` was unset — the `:s3` endpoint override is now skipped entirely when no `STORAGE_HOST` is provided, so ex_aws uses its default regional AWS S3 endpoint.

## Test plan

- [ ] `mix test` — local CI gate (no behavior change in default test config).
- [ ] CI green (full E2E suite includes Tigris/MinIO scenarios; should not regress).
- [ ] Merge → `build-ecr.yml` pushes a new `sha-<7>`.
- [ ] Tag `release-v0.5.295` → confirm:
  - engram-saas-prod ECS service rolls onto the new task def revision
  - Tasks reach `RUNNING` (not crash-looping)
  - `curl -fsS https://app.engram.page/api/health` returns 200
  - CloudWatch `/ecs/engram-saas-prod` shows no `(System.EnvError)` lines

## Follow-up after this lands green

Drop `module.app_iam` (the IAM user `engram-saas-prod`) + the `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` SSM secrets in engram-infra — entirely dead code under ECS task-role auth.