### PR TITLE
fix(prod): DATABASE_SSL env toggle for Repo TLS

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -478,17 +478,33 @@ if config_env() == :prod do
 
   maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
 
-  config :engram, Engram.Repo,
-    # ssl: true,
-    url: database_url,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    # For machines with several cores, consider starting multiple pools of `pool_size`
-    # pool_count: 4,
-    socket_options: maybe_ipv6,
-    # T3.0.2 — defense-in-depth. Prevents Ecto SQL params (path, folder,
-    # tags, wrapped DEK on UPDATE) from hitting :debug logs if anyone
-    # bumps prod log level. Audit-only; prod log level today is :info.
-    log: false
+  # DATABASE_SSL=true enables TLS to the Postgres server. Required by
+  # AWS RDS (pg_hba.conf rejects "no encryption" connections);
+  # self-host MinIO/local Postgres typically has no SSL configured so
+  # default is false. `verify: :verify_none` skips peer cert chain
+  # validation — the RDS root CA isn't bundled into the Alpine image
+  # and traffic is already inside the prod VPC, so peer auth adds no
+  # meaningful confidentiality beyond what TLS-on-the-wire provides.
+  database_ssl_opts =
+    if System.get_env("DATABASE_SSL") in ~w(true 1) do
+      [ssl: true, ssl_opts: [verify: :verify_none]]
+    else
+      []
+    end
+
+  config :engram,
+         Engram.Repo,
+         [
+           url: database_url,
+           pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+           # For machines with several cores, consider starting multiple pools of `pool_size`
+           # pool_count: 4,
+           socket_options: maybe_ipv6,
+           # T3.0.2 — defense-in-depth. Prevents Ecto SQL params (path, folder,
+           # tags, wrapped DEK on UPDATE) from hitting :debug logs if anyone
+           # bumps prod log level. Audit-only; prod log level today is :info.
+           log: false
+         ] ++ database_ssl_opts
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.301",
+      version: "0.5.302",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Adds opt-in TLS for Engram.Repo via a \`DATABASE_SSL\` env var. When truthy (\`"true"\`/\`"1"\`), Repo connects with \`ssl: true\` + \`ssl_opts: [verify: :verify_none]\`. Default off — self-host (MinIO / local) Postgres typically has no SSL configured.

## Why

AWS RDS Postgres rejects unencrypted connections:

\`\`\`
FATAL 28000 (invalid_authorization_specification)
no pg_hba.conf entry for host "10.30.2.191", user "engram_admin",
database "engram_saas_prod", no encryption
\`\`\`

Boot crash on rev 7 (sha-69f4259) after #234 fixed DATABASE_URL urlencode + #233 wired JWT_SECRET. This should be the last unwired requirement.

## Why verify_none

The RDS root CA bundle isn't in the Alpine release image, so peer cert chain validation would fail. Traffic is already inside the prod VPC (ECS tasks → RDS within the same VPC's private security group); the encryption is in-band protection against bus snooping, not peer-auth. Adding the cert bundle is a follow-up nice-to-have, not a blocker.

## Companion PR

engram-app/engram-infra (forthcoming) adds \`{ name = "DATABASE_SSL", value = "true" }\` to the prod ECS task def env block.

## Test plan

- [ ] Unit tests + E2E green.
- [ ] After merge: build-ecr pushes a new \`sha-<7>\`.
- [ ] Tag \`release-v0.5.302\` → GitOps PR → tf apply → service rolls.
- [ ] CloudWatch shows no \`(Postgrex.Error) FATAL 28000\` lines.
- [ ] App boots, runs the baseline migration, reaches RUNNING.