### PR TITLE
feat(release): split cluster bootstrap from migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -989,6 +989,11 @@ jobs:
             sleep 1
           done
           MIX_ENV=test mix ecto.create
+          # Idempotent cluster bootstrap (engram_app role + DEFAULT
+          # PRIVILEGES). Must run BEFORE migrate — baseline migration's
+          # structure dump references engram_app in GRANT statements.
+          # Mirrors prod entrypoint.sh ordering.
+          MIX_ENV=test mix engram.prepare_database
           MIX_ENV=test mix ecto.migrate
           # Ensure Tailwind binary is valid (cache prune can corrupt native deps)
           mix tailwind.install 2>/dev/null || true
@@ -1539,6 +1544,8 @@ jobs:
             sleep 1
           done
           mix ecto.create
+          # See unit-tests job comment — prepare_database must precede migrate.
+          mix engram.prepare_database
           mix ecto.migrate
           # Ensure Tailwind binary is valid (cache prune can corrupt native deps).
           # Mirror of unit-tests fix — Playwright's webServer boots Phoenix

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,22 @@
 #!/bin/sh
-# Container entrypoint: run migrations, then exec the release.
+# Container entrypoint: cluster bootstrap → migrations → exec the release.
 #
-# `exec "$@"` replaces this shell with the BEAM so SIGTERM/SIGINT reach
-# the runtime directly (graceful shutdown). Without `exec`, signals
-# would terminate the shell while leaving BEAM as a zombied child.
+# `prepare_database` is cluster-scoped + idempotent: creates the
+# `engram_app` role and sets DEFAULT PRIVILEGES on CURRENT_USER's
+# future objects. Must run before migrate because the baseline
+# migration's structure dump references engram_app in GRANT
+# statements.
 #
-# `set -e` aborts on migrate failure — we'd rather fail-fast than start
-# a Phoenix node against an unmigrated schema.
+# `exec "$@"` replaces this shell with the BEAM so SIGTERM/SIGINT
+# reach the runtime directly (graceful shutdown). Without `exec`,
+# signals would terminate the shell while leaving BEAM as a zombied
+# child.
+#
+# `set -e` aborts on any failure — better to crash-loop visibly than
+# start a Phoenix node against a half-prepared cluster.
 set -e
 
+/app/bin/engram eval "Engram.Release.prepare_database()"
 /app/bin/engram eval "Engram.Release.migrate()"
 
 exec "$@"

--- a/lib/engram/release.ex
+++ b/lib/engram/release.ex
@@ -1,10 +1,90 @@
 defmodule Engram.Release do
   @moduledoc """
-  Used for executing DB release tasks when run in production without Mix installed.
-  Called via: /app/bin/engram eval "Engram.Release.migrate"
+  DB release tasks for production (no Mix available in release).
+
+  Two layers, run in order from `/entrypoint.sh`:
+
+    1. `prepare_database/0` — idempotent cluster-level bootstrap.
+       Creates the `engram_app` low-privilege role and wires
+       DEFAULT PRIVILEGES so future-created tables/sequences auto-grant
+       to it. Runs as the connecting role (typically the cluster
+       master). Cluster-scoped concerns belong here, not in Ecto
+       migrations — migrations stay pure schema and don't bake in
+       env-specific role names.
+
+    2. `migrate/0` — runs Ecto migrations. The baseline migration
+       assumes `engram_app` already exists (prepare_database created
+       it) so its GRANT statements resolve.
+
+  Both tasks are invoked from `entrypoint.sh`:
+
+      /app/bin/engram eval "Engram.Release.prepare_database()"
+      /app/bin/engram eval "Engram.Release.migrate()"
+
+  Local dev / CI reach the same code path via the `ecto.setup` Mix
+  alias (`mix.exs`).
   """
 
   @app :engram
+
+  # NOINHERIT + LOGIN matches the historical baseline shape (preserved
+  # for envs that rely on `engram_app` connecting directly).
+  # PASSWORD intentionally absent — privilege separation (app
+  # DATABASE_URL using engram_app creds) is a separate concern wired
+  # via DATABASE_URL itself; this task only guarantees the role
+  # exists.
+  @create_engram_app_role_sql """
+  DO $$
+  BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'engram_app') THEN
+      CREATE ROLE engram_app NOINHERIT LOGIN;
+    END IF;
+  END
+  $$;
+  """
+
+  @grant_schema_usage_sql "GRANT USAGE ON SCHEMA public TO engram_app;"
+
+  # DEFAULT PRIVILEGES are bound to the role that creates the object.
+  # CURRENT_USER means the rule applies to whichever migrator role is
+  # running this task — portable across AWS (engram_admin), FastRaid
+  # (engram), and local dev (cluster superuser). Without this, every
+  # new migration would need explicit GRANT statements to engram_app.
+  @default_priv_tables_sql """
+  ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO engram_app;
+  """
+
+  @default_priv_sequences_sql """
+  ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER IN SCHEMA public
+    GRANT SELECT, USAGE ON SEQUENCES TO engram_app;
+  """
+
+  @doc """
+  Idempotent cluster bootstrap. Run BEFORE `migrate/0`.
+
+  Creates the `engram_app` role and configures DEFAULT PRIVILEGES so
+  the connecting role's future objects auto-grant CRUD on tables +
+  SELECT/USAGE on sequences to `engram_app`. Existing objects are
+  granted explicitly by the baseline migration's structure.sql dump.
+
+  Requires the connecting role to have CREATEROLE + GRANT privileges.
+  On AWS RDS this means the master user (`engram_admin`); locally /
+  on FastRaid it's the cluster superuser.
+
+  Safe to re-run: every statement is naturally idempotent (`IF NOT
+  EXISTS` guard on role create, DEFAULT PRIVILEGES on the same target
+  collapses, GRANT USAGE is no-op when already granted).
+  """
+  def prepare_database do
+    _ = load_app()
+
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &do_prepare_database/1)
+    end
+
+    :ok
+  end
 
   def migrate do
     _ = load_app()
@@ -17,6 +97,14 @@ defmodule Engram.Release do
   def rollback(repo, version) do
     _ = load_app()
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  defp do_prepare_database(repo) do
+    repo.query!(@create_engram_app_role_sql, [])
+    repo.query!(@grant_schema_usage_sql, [])
+    repo.query!(@default_priv_tables_sql, [])
+    repo.query!(@default_priv_sequences_sql, [])
+    :ok
   end
 
   defp repos do

--- a/lib/mix/tasks/engram.prepare_database.ex
+++ b/lib/mix/tasks/engram.prepare_database.ex
@@ -1,0 +1,23 @@
+defmodule Mix.Tasks.Engram.PrepareDatabase do
+  @shortdoc "Idempotent cluster bootstrap (engram_app role + DEFAULT PRIVILEGES)"
+
+  @moduledoc """
+  Mix task wrapper around `Engram.Release.prepare_database/0`.
+
+  Used by the `ecto.setup` and `test` aliases in `mix.exs` so dev/CI
+  reach the same cluster-bootstrap code path as prod (where
+  `entrypoint.sh` calls the release task directly).
+
+      mix engram.prepare_database
+  """
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    # Don't ensure_all_started — that boots Phoenix/Oban/etc, which
+    # `mix test` and ecto aliases do not want. Engram.Release uses
+    # `Ecto.Migrator.with_repo/2` to start just the Repo for the
+    # duration of the task.
+    Engram.Release.prepare_database()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.302",
+      version: "0.5.303",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -129,9 +129,22 @@ defmodule Engram.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup"],
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      # `engram.prepare_database` mirrors the prod `entrypoint.sh`:
+      # cluster-level role/grant bootstrap runs BEFORE migrations so
+      # the baseline dump's GRANT statements to engram_app resolve.
+      "ecto.setup": [
+        "ecto.create",
+        "engram.prepare_database",
+        "ecto.migrate",
+        "run priv/repo/seeds.exs"
+      ],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      test: [
+        "ecto.create --quiet",
+        "engram.prepare_database",
+        "ecto.migrate --quiet",
+        "test"
+      ],
       precommit: ["compile --warnings-as-errors", "deps.unlock --unused", "format", "test"],
       "assets.deploy": ["phx.digest"]
     ]

--- a/priv/repo/migrations/20260602000000_baseline.exs
+++ b/priv/repo/migrations/20260602000000_baseline.exs
@@ -19,27 +19,18 @@ defmodule Engram.Repo.Migrations.Baseline do
   Running against a non-empty schema fails because every `CREATE TABLE` in
   structure.sql is unconditional.
 
-  The `engram_app` runtime role (used by `Repo.with_tenant/2` to enforce RLS)
-  is created here idempotently. In dev/CI the role survives `mix ecto.drop`
-  (cluster-level), but a fresh CI postgres container has no roles and needs
-  this step to succeed before the dumped GRANT statements can reference it.
+  Prerequisite: `Engram.Release.prepare_database/0` must run first.
+  It creates the `engram_app` runtime role that the structure dump's
+  GRANT statements reference. Cluster-scoped bootstrap was moved out
+  of this migration so envs don't bake in role names (release task is
+  CURRENT_USER-portable; the prior `ALTER DEFAULT PRIVILEGES FOR ROLE
+  engram` in the dump assumed the dev superuser was named `engram`,
+  which broke on RDS where the master is `engram_admin`).
   """
 
   use Ecto.Migration
 
-  @engram_app_role_sql """
-  DO $$
-  BEGIN
-    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'engram_app') THEN
-      CREATE ROLE engram_app NOINHERIT LOGIN PASSWORD 'engram_app';
-    END IF;
-  END
-  $$;
-  """
-
   def up do
-    repo().query!(@engram_app_role_sql, [])
-
     path = Path.join(:code.priv_dir(:engram), "repo/structure.sql")
 
     path

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2596,18 +2596,12 @@ GRANT SELECT,USAGE ON SEQUENCE public.vaults_id_seq TO engram_app;
 
 
 --
--- Name: DEFAULT PRIVILEGES FOR SEQUENCES; Type: DEFAULT ACL; Schema: public; Owner: -
+-- DEFAULT PRIVILEGES are wired by Engram.Release.prepare_database/0
+-- (CURRENT_USER-bound) instead of being baked into the dump. The
+-- prior `ALTER DEFAULT PRIVILEGES FOR ROLE engram` form assumed the
+-- dev superuser was named `engram`, which breaks on RDS where the
+-- master is `engram_admin`. Keep this dump role-name-portable.
 --
-
-ALTER DEFAULT PRIVILEGES FOR ROLE engram IN SCHEMA public GRANT SELECT,USAGE ON SEQUENCES TO engram_app;
-
-
---
--- Name: DEFAULT PRIVILEGES FOR TABLES; Type: DEFAULT ACL; Schema: public; Owner: -
---
-
-ALTER DEFAULT PRIVILEGES FOR ROLE engram IN SCHEMA public GRANT SELECT,INSERT,DELETE,UPDATE ON TABLES TO engram_app;
-
 
 --
 -- PostgreSQL database dump complete


### PR DESCRIPTION
## Summary

Proper long-term DB lifecycle architecture. Three layers, clean separation:

| Layer | Concern | Where it lives | When it runs |
|-------|---------|----------------|--------------|
| 1 | Cluster topology (master user, network, encryption) | TF (engram-infra) | TF apply |
| 2 | **Role provisioning + GRANTs** | **\`Engram.Release.prepare_database/0\` (NEW)** | Every container boot |
| 3 | App schema (tables, indexes, constraints) | Ecto migrations | After prepare |

## Why

Collapsed baseline (#401) crashed on AWS RDS with \`(Postgrex.Error) ERROR 42704 (undefined_object) role "engram" does not exist\`. \`pg_dump\` from a dev DB baked two \`ALTER DEFAULT PRIVILEGES FOR ROLE engram\` lines into \`structure.sql\` — that assumes the dev superuser is named \`engram\` (true locally + FastRaid, false on RDS where master = \`engram_admin\`).

Stripping the two lines + recreating the rule via \`ALTER DEFAULT PRIVILEGES FOR ROLE CURRENT_USER\` in a release task makes the dump role-name-portable. Same baseline runs unchanged across local, CI, FastRaid, AWS prod.

## What changed

- \`lib/engram/release.ex\` — adds \`prepare_database/0\`. Four idempotent SQL blocks: \`CREATE ROLE engram_app IF NOT EXISTS\` (DO $$ block), \`GRANT USAGE ON SCHEMA public\`, \`ALTER DEFAULT PRIVILEGES ... GRANT ... ON TABLES\`, same for sequences. All bound to \`CURRENT_USER\` so the connecting role is the owner of future objects.
- \`lib/mix/tasks/engram.prepare_database.ex\` — Mix wrapper so dev/CI hit the same code path. Mirrors release.ex (no \`ensure_all_started\` — would boot Phoenix/Oban, too heavy for ecto.setup/test).
- \`priv/repo/migrations/20260602000000_baseline.exs\` — drops the \`@engram_app_role_sql\` create-role block. Pure schema-restore now.
- \`priv/repo/structure.sql\` — drops the two \`ALTER DEFAULT PRIVILEGES FOR ROLE engram\` lines.
- \`entrypoint.sh\` — \`prepare_database\` runs before \`migrate\`.
- \`mix.exs\` — \`engram.prepare_database\` wired into \`ecto.setup\` and \`test\` aliases.

## Behavior across envs

| Env | Connecting role | prepare_database creates engram_app? |
|-----|----------------|--------------------------------------|
| Local dev | engram (superuser) | Idempotent — usually no-op (survives \`mix ecto.drop\`) |
| CI E2E | engram (superuser) | Yes on fresh ephemeral postgres |
| FastRaid staging | engram (superuser) | Idempotent |
| AWS RDS prod | engram_admin (rds_superuser) | Yes on first deploy |

## Follow-up (separate engram-infra PR — not blocking)

Actual privilege separation: generate \`engram_app\` password (sops-set), build \`DATABASE_URL\` from \`engram_app\` creds (low-priv), add \`DATABASE_MIGRATOR_URL\` from \`engram_admin\` (master) for the release tasks. This PR makes the architecture support the split cleanly; runtime.exs change to use distinct URLs comes next.

## Test plan

- [ ] Unit + E2E green (CI exercises prepare_database via test alias).
- [ ] After merge: tag \`release-v0.5.303\` → GitOps PR → tf apply rolls service onto sha-<7> of this commit.
- [ ] Tasks reach RUNNING. CloudWatch shows no \`undefined_object\` errors.
- [ ] \`psql\` to RDS as master: \`\\du\` shows \`engram_app\` exists; \`\\ddp\` shows DEFAULT PRIVILEGES.

Refs the 2026-06-02 prod-launch series: engram-infra#229+#233+#234+#238, engram-app/Engram#400+#404, prod outage post-#401 collapse.