### PR TITLE
fix(csp): derive Clerk custom-domain host from CLERK_ISSUER at request time

### DIFF
--- a/lib/engram_web/csp.ex
+++ b/lib/engram_web/csp.ex
@@ -1,0 +1,180 @@
+defmodule EngramWeb.CSP do
+  @moduledoc """
+  Content-Security-Policy header builder, computed from runtime config.
+
+  Each external integration (Clerk auth, Paddle billing, Cloudflare
+  Turnstile) contributes its own host allowlist via a private builder
+  function. The aggregator dedups + flattens into the final header
+  string. Adding a new integration = adding one builder function and
+  one entry in `extra_directives/0`. No CSP edit required when a
+  Clerk custom-domain operator deploys to a new tenant zone — the
+  host is derived from `:engram, :clerk_issuer` at request time.
+
+  ## Why runtime, not compile-time
+
+  The legacy implementation stored the full CSP string in a module
+  attribute (`@csp_policy`) so it was baked into the BEAM at compile
+  time. That made custom-domain Clerk impossible: the issuer host
+  isn't known until `runtime.exs` reads `CLERK_ISSUER` at boot, after
+  modules are already compiled. Pulling the lookup into `header/0`
+  costs ~µs per request — Phoenix's existing header pipeline does
+  similar map merges on every response.
+
+  ## Test contract
+
+  - `EngramWeb.CSPTest` asserts the function-of-env-var behaviour:
+    given `:clerk_issuer`, the rendered header contains the host in
+    `script-src` / `connect-src` / `frame-src`. The test does not
+    pin the literal CSP string — that would fossilize the policy.
+  """
+
+  @static %{
+    "default-src" => ["'self'"],
+    "script-src" => ["'self'", "'unsafe-inline'"],
+    "style-src" => ["'self'", "'unsafe-inline'"],
+    "img-src" => ["'self'", "data:", "blob:", "https:"],
+    "font-src" => ["'self'", "data:"],
+    "connect-src" => ["'self'"],
+    "frame-src" => [],
+    "worker-src" => ["'self'", "blob:"],
+    "form-action" => ["'self'"],
+    "base-uri" => ["'self'"],
+    "frame-ancestors" => ["'none'"]
+  }
+
+  @directive_order [
+    "default-src",
+    "script-src",
+    "style-src",
+    "img-src",
+    "font-src",
+    "connect-src",
+    "frame-src",
+    "worker-src",
+    "form-action",
+    "base-uri",
+    "frame-ancestors"
+  ]
+
+  @doc """
+  Render the full Content-Security-Policy header value.
+
+  Returns a single-line string suitable for `put_resp_header/3`.
+  Empty directives (e.g. `frame-src` with no integrations contributing)
+  are dropped from the output entirely.
+  """
+  @spec header() :: String.t()
+  def header do
+    extra_directives()
+    |> Enum.reduce(@static, &merge_directives/2)
+    |> render()
+  end
+
+  # ── Aggregation ────────────────────────────────────────────────────
+
+  defp extra_directives do
+    [
+      clerk_directives(),
+      paddle_directives(),
+      turnstile_directives()
+    ]
+  end
+
+  defp merge_directives(addition, acc) do
+    Map.merge(acc, addition, fn _directive, base, more ->
+      Enum.uniq(base ++ more)
+    end)
+  end
+
+  defp render(directives) do
+    @directive_order
+    |> Enum.map_join("; ", fn name ->
+      sources = Map.get(directives, name, [])
+
+      case sources do
+        [] -> ""
+        list -> name <> " " <> Enum.join(list, " ")
+      end
+    end)
+    |> String.replace(~r/; +;/, ";")
+    |> String.replace(~r/;\s*$/, "")
+    |> String.replace(~r/^;\s*/, "")
+    |> String.replace(~r/(?:^|; )(; )+/, "; ")
+  end
+
+  # ── Integrations ───────────────────────────────────────────────────
+
+  # Clerk auth (Frontend API).
+  #
+  # Static hosts cover Clerk's dev instances (`*.clerk.accounts.dev`)
+  # and the legacy multi-tenant Clerk frontend (`*.clerk.com`). The
+  # `custom` entry derives the host from `:engram, :clerk_issuer`
+  # which `runtime.exs:223` populates from `CLERK_ISSUER` — supports
+  # Clerk's "custom domain" feature where each tenant gets a
+  # `clerk.<their-zone>` Frontend API host (e.g. `clerk.engram.page`
+  # for prod). Without this derivation the prod SPA cannot load
+  # `clerk.browser.js` and Clerk auth silently fails.
+  defp clerk_directives do
+    static = ["https://*.clerk.accounts.dev", "https://*.clerk.com"]
+    custom = clerk_custom_domain_host()
+    hosts = static ++ custom
+
+    %{
+      "script-src" => hosts,
+      "connect-src" => hosts,
+      "frame-src" => hosts
+    }
+  end
+
+  defp clerk_custom_domain_host do
+    case Application.get_env(:engram, :clerk_issuer) do
+      nil ->
+        []
+
+      "" ->
+        []
+
+      url when is_binary(url) ->
+        url
+        |> String.trim()
+        |> String.trim_trailing("/")
+        |> URI.parse()
+        |> case do
+          %URI{host: host, scheme: scheme}
+          when is_binary(host) and host != "" and scheme in ["http", "https"] ->
+            ["https://#{host}"]
+
+          _ ->
+            []
+        end
+    end
+  end
+
+  # Paddle billing (Checkout overlay + Frontend SDK).
+  # Both sandbox and live Paddle environments serve from `*.paddle.com`.
+  # PADDLE_ENV (read in runtime.exs:341) selects which Paddle backend
+  # API the server calls; the browser-facing CDN hosts are stable.
+  defp paddle_directives do
+    hosts = ["https://*.paddle.com"]
+
+    %{
+      "script-src" => hosts,
+      "connect-src" => hosts,
+      "frame-src" => hosts
+    }
+  end
+
+  # Cloudflare Turnstile (Clerk's integrated bot protection).
+  # When Clerk is configured to require Turnstile on sign-up/sign-in,
+  # the widget loads its frame + script from challenges.cloudflare.com.
+  # No `connect-src` entry — the widget reports verification status
+  # through Clerk's Frontend API, not directly to Cloudflare.
+  defp turnstile_directives do
+    hosts = ["https://challenges.cloudflare.com"]
+
+    %{
+      "script-src" => hosts,
+      "frame-src" => hosts
+    }
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -31,31 +31,25 @@ defmodule EngramWeb.Router do
   # injects a runtime-config <script> into index.html (see
   # EngramWeb.SpaController.config_script/0). TODO: upgrade to per-request
   # nonces and drop 'unsafe-inline' from script-src.
-  @csp_policy Enum.join(
-                [
-                  "default-src 'self'",
-                  "script-src 'self' 'unsafe-inline' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.paddle.com",
-                  "style-src 'self' 'unsafe-inline'",
-                  "img-src 'self' data: blob: https:",
-                  "font-src 'self' data:",
-                  "connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://*.paddle.com",
-                  "frame-src https://challenges.cloudflare.com https://*.clerk.accounts.dev https://*.paddle.com",
-                  "worker-src 'self' blob:",
-                  "form-action 'self'",
-                  "base-uri 'self'",
-                  "frame-ancestors 'none'"
-                ],
-                "; "
-              )
-
+  #
+  # The CSP allowlist is built at request time by `EngramWeb.CSP.header/0`
+  # so per-tenant Clerk custom domains (CLERK_ISSUER=https://clerk.<zone>)
+  # flow into script-src / connect-src / frame-src without code edits.
+  # Adding a new external integration = one builder function in
+  # `EngramWeb.CSP`, not a router diff.
   pipeline :spa do
     plug :accepts, ["html"]
 
     plug :put_secure_browser_headers, %{
       "x-content-type-options" => "nosniff",
-      "x-frame-options" => "DENY",
-      "content-security-policy" => @csp_policy
+      "x-frame-options" => "DENY"
     }
+
+    plug :put_csp_header
+  end
+
+  defp put_csp_header(conn, _opts) do
+    Plug.Conn.put_resp_header(conn, "content-security-policy", EngramWeb.CSP.header())
   end
 
   # Paddle webhooks — no auth, raw body for signature verification

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.304",
+      version: "0.5.305",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/csp_pipeline_test.exs
+++ b/test/engram_web/csp_pipeline_test.exs
@@ -1,0 +1,34 @@
+defmodule EngramWeb.CSPPipelineTest do
+  @moduledoc """
+  Confirms the `:spa` pipeline actually wires `EngramWeb.CSP` — guards
+  against the regression where `CSP.header/0` is correct but the plug
+  was dropped from `pipeline :spa`. The unit tests in `csp_test.exs`
+  prove the builder; this test proves the wiring.
+  """
+  use EngramWeb.ConnCase, async: false
+
+  setup do
+    prior = Application.get_env(:engram, :clerk_issuer)
+    on_exit(fn -> Application.put_env(:engram, :clerk_issuer, prior) end)
+    :ok
+  end
+
+  test "GET / emits content-security-policy header containing the Clerk custom-domain host",
+       %{conn: conn} do
+    Application.put_env(:engram, :clerk_issuer, "https://clerk.engram.page")
+
+    conn = get(conn, "/")
+
+    [csp] = get_resp_header(conn, "content-security-policy")
+    assert csp =~ "https://clerk.engram.page"
+    assert csp =~ "default-src 'self'"
+  end
+
+  test "GET / on the SPA pipeline still sets the static security headers",
+       %{conn: conn} do
+    conn = get(conn, "/")
+
+    assert get_resp_header(conn, "x-frame-options") == ["DENY"]
+    assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+  end
+end

--- a/test/engram_web/csp_test.exs
+++ b/test/engram_web/csp_test.exs
@@ -1,0 +1,175 @@
+defmodule EngramWeb.CSPTest do
+  @moduledoc """
+  CSP is built from runtime config so a Clerk custom-domain
+  (`CLERK_ISSUER=https://clerk.engram.page`) or self-host operator's
+  own Clerk tenant flows into `script-src` / `connect-src` / `frame-src`
+  without needing a code change.
+
+  Pure unit tests on `EngramWeb.CSP.header/0`. Each test sets the
+  relevant `Application` env, asserts on the rendered header, and
+  restores prior state on exit.
+  """
+  use ExUnit.Case, async: false
+
+  alias EngramWeb.CSP
+
+  setup do
+    prior_issuer = Application.get_env(:engram, :clerk_issuer)
+    on_exit(fn -> Application.put_env(:engram, :clerk_issuer, prior_issuer) end)
+    :ok
+  end
+
+  describe "static directives" do
+    test "always present regardless of integration config" do
+      Application.put_env(:engram, :clerk_issuer, nil)
+
+      header = CSP.header()
+
+      assert header =~ "default-src 'self'"
+      assert header =~ "style-src 'self' 'unsafe-inline'"
+      assert header =~ "img-src 'self' data: blob: https:"
+      assert header =~ "font-src 'self' data:"
+      assert header =~ "worker-src 'self' blob:"
+      assert header =~ "form-action 'self'"
+      assert header =~ "base-uri 'self'"
+      assert header =~ "frame-ancestors 'none'"
+    end
+
+    test "always whitelists Cloudflare Turnstile (Clerk bot-protection)" do
+      Application.put_env(:engram, :clerk_issuer, nil)
+
+      header = CSP.header()
+
+      assert script_src(header) =~ "https://challenges.cloudflare.com"
+      assert frame_src(header) =~ "https://challenges.cloudflare.com"
+    end
+
+    test "always whitelists Paddle (billing overlay)" do
+      Application.put_env(:engram, :clerk_issuer, nil)
+
+      header = CSP.header()
+
+      assert script_src(header) =~ "https://*.paddle.com"
+      assert connect_src(header) =~ "https://*.paddle.com"
+      assert frame_src(header) =~ "https://*.paddle.com"
+    end
+  end
+
+  describe "Clerk integration — dev/test instance (CLERK_ISSUER under *.clerk.accounts.dev)" do
+    test "whitelists *.clerk.accounts.dev + *.clerk.com on script-src / connect-src / frame-src" do
+      Application.put_env(:engram, :clerk_issuer, "https://example.clerk.accounts.dev")
+
+      header = CSP.header()
+
+      assert script_src(header) =~ "https://*.clerk.accounts.dev"
+      assert script_src(header) =~ "https://*.clerk.com"
+      assert connect_src(header) =~ "https://*.clerk.accounts.dev"
+      assert connect_src(header) =~ "https://*.clerk.com"
+      assert frame_src(header) =~ "https://*.clerk.accounts.dev"
+    end
+  end
+
+  describe "Clerk integration — prod custom domain (CLERK_ISSUER on tenant zone)" do
+    test "issuer host is allowed on script-src" do
+      Application.put_env(:engram, :clerk_issuer, "https://clerk.engram.page")
+
+      assert script_src(CSP.header()) =~ "https://clerk.engram.page"
+    end
+
+    test "issuer host is allowed on connect-src" do
+      Application.put_env(:engram, :clerk_issuer, "https://clerk.engram.page")
+
+      assert connect_src(CSP.header()) =~ "https://clerk.engram.page"
+    end
+
+    test "issuer host is allowed on frame-src" do
+      Application.put_env(:engram, :clerk_issuer, "https://clerk.engram.page")
+
+      assert frame_src(CSP.header()) =~ "https://clerk.engram.page"
+    end
+
+    test "operator-supplied custom domain (e.g. self-host) flows in identically" do
+      Application.put_env(:engram, :clerk_issuer, "https://auth.example.com")
+
+      header = CSP.header()
+
+      assert script_src(header) =~ "https://auth.example.com"
+      assert connect_src(header) =~ "https://auth.example.com"
+      assert frame_src(header) =~ "https://auth.example.com"
+    end
+
+    test "trailing slash + whitespace in issuer is normalized" do
+      Application.put_env(:engram, :clerk_issuer, "  https://clerk.engram.page/  ")
+
+      header = CSP.header()
+
+      assert script_src(header) =~ "https://clerk.engram.page"
+      refute script_src(header) =~ "https://clerk.engram.page/"
+    end
+  end
+
+  describe "Clerk integration — degenerate config" do
+    test "nil clerk_issuer does NOT inject a stray host" do
+      Application.put_env(:engram, :clerk_issuer, nil)
+
+      header = CSP.header()
+
+      refute header =~ "https://nil"
+      refute header =~ "https://\""
+    end
+
+    test "empty-string clerk_issuer does NOT inject a stray host" do
+      Application.put_env(:engram, :clerk_issuer, "")
+
+      header = CSP.header()
+
+      refute header =~ "https:// "
+      refute header =~ "https:// ;"
+    end
+
+    test "issuer without scheme falls back gracefully (no malformed entry)" do
+      Application.put_env(:engram, :clerk_issuer, "clerk.engram.page")
+
+      header = CSP.header()
+
+      # Either the host is added (if the impl tolerates schemeless input)
+      # or it's dropped — both are valid; what matters is no malformed
+      # `https://nil` or stray-token leak into the directive.
+      refute header =~ "https://nil"
+      refute header =~ ~r/script-src[^;]*\s;/
+    end
+  end
+
+  describe "directive shape" do
+    test "header is a single line with directives separated by `; `" do
+      header = CSP.header()
+
+      refute header =~ "\n"
+      assert header =~ "; "
+    end
+
+    test "no directive contains duplicate hosts" do
+      Application.put_env(:engram, :clerk_issuer, "https://clerk.engram.page")
+
+      for directive <- String.split(CSP.header(), "; ", trim: true) do
+        tokens = String.split(directive, " ", trim: true)
+
+        assert tokens == Enum.uniq(tokens),
+               "duplicate token in directive: #{inspect(directive)}"
+      end
+    end
+  end
+
+  # ── Helpers ────────────────────────────────────────────────────────
+
+  defp script_src(header), do: directive(header, "script-src")
+  defp connect_src(header), do: directive(header, "connect-src")
+  defp frame_src(header), do: directive(header, "frame-src")
+
+  defp directive(header, name) do
+    header
+    |> String.split("; ", trim: true)
+    |> Enum.find(fn d -> String.starts_with?(d, name <> " ") end)
+    |> Kernel.||("")
+  end
+end


### PR DESCRIPTION
## TL;DR

Prod auth is broken — browser CSP block on `clerk.engram.page/.../clerk.browser.js`. The legacy `@csp_policy` module attribute hardcoded `*.clerk.accounts.dev` / `*.clerk.com`, which doesn't match Clerk's prod **custom-domain** feature where the Frontend API + JS CDN serve from the tenant's own zone. This PR replaces compile-time CSP with a runtime builder that derives the host from `CLERK_ISSUER`.

## Repro

```
Open https://app.engram.page
DevTools → Console
> Loading the script 'https://clerk.engram.page/npm/@clerk/clerk-js@6/dist/clerk.browser.js'
> violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'
> https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.paddle.com"
> e: Clerk: Failed to load Clerk JS (code="failed_to_load_clerk_js")
```

`curl -D - https://app.engram.page/` confirms the header. CSP wildcards bind one label only — `*.clerk.com` does not match `clerk.engram.page` (different registrable domain).

## What this changes

| Before | After |
|---|---|
| `router.ex:34` `@csp_policy` (compile-time, hardcoded) | `EngramWeb.CSP.header/0` (runtime, derived) |
| Adding a new integration = edit a long string literal | Adding a new integration = one builder function + one `extra_directives/0` entry |
| Custom Clerk domain → CSP edit per tenant | Custom Clerk domain → automatic from `CLERK_ISSUER` |

## Architecture

```
EngramWeb.CSP (lib/engram_web/csp.ex)
├── @static            — directives that never depend on integration config
├── clerk_directives   — *.clerk.accounts.dev + *.clerk.com + URI.parse(CLERK_ISSUER).host
├── paddle_directives  — *.paddle.com (stable across sandbox/live)
├── turnstile_directives — challenges.cloudflare.com (Clerk bot-protection)
└── header/0           — merges + renders single-line, dedups tokens
```

Plug in `pipeline :spa`:

```elixir
plug :put_csp_header   # calls EngramWeb.CSP.header/0 per request
```

## Tests

| File | Count | What it locks in |
|---|---|---|
| `test/engram_web/csp_test.exs` | 14 | Function-of-env-var behaviour: given `CLERK_ISSUER=X`, header contains `URI.parse(X).host`. Plus edge cases (nil, empty, trailing slash, schemeless, dup detection, single-line shape). |
| `test/engram_web/csp_pipeline_test.exs` | 2 | Plug is actually wired in `:spa`. Guards against "builder is correct but pipeline forgot the plug" regression. |
| Existing `spa_controller_test.exs` | 19 | Already asserted on header properties (`default-src 'self'`, `frame-ancestors 'none'`, `connect-src`, `clerk` substring). All still pass — none of those assertions were tied to the literal string. |

Full suite: **1952 tests, 0 failures, 7 skipped**. Credo clean. `mix format --check-formatted` clean.

## Why the tests don't pin the literal CSP string

A test that asserts `csp == "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.clerk.accounts.dev ..."` is fossilized — every CSP change becomes a coordinated test edit, and the test catches *changes* rather than *bugs*. The tests here pin the contract (`given X env, the host derived from X is in the right directives`) so the policy can evolve without breaking the test suite, while real regressions (a future PR drops `clerk_directives/0`) fail fast.

## Effect by environment

| Env | `CLERK_ISSUER` | Result |
|---|---|---|
| AWS prod | `https://clerk.engram.page` | `clerk.engram.page` added to script-src / connect-src / frame-src → Clerk JS loads ✅ |
| staging-fastraid | `https://key-longhorn-79.clerk.accounts.dev` | Already matches `*.clerk.accounts.dev` wildcard → no effective change |
| Self-host (operator's own Clerk tenant) | `https://clerk.<their-zone>` | Auto-included → works out of the box |
| Self-host (no Clerk) | unset | Only the static `*.clerk.*` wildcards present (harmless; Clerk just isn't used) |

## Out of scope (tracked separately)

- Per-request `nonce-…` on script-src → drop `'unsafe-inline'`. Orthogonal — host allowlisting and inline-script policy are independent problems. Existing TODO in `router.ex:30-33`.
- Post-deploy CI smoke (in `engram-infra`) that hits `/` on prod, parses the CSP header, asserts `URI.parse(CLERK_ISSUER).host` is in `script-src`. Catches future env/app drift.

## Test plan (manual, post-deploy)

- [ ] Image bump in engram-infra → `terraform (prod)` applies new task def
- [ ] Open `https://app.engram.page` in fresh browser tab
- [ ] DevTools → Console: no `failed_to_load_clerk_js`
- [ ] DevTools → Network: `clerk.browser.js` shows **200** (not `blocked:csp`)
- [ ] Sign-in flow: Clerk widget renders + accepts credentials
- [ ] `curl -D - https://app.engram.page/ | grep -i content-security-policy` shows `clerk.engram.page` in script-src + connect-src + frame-src

🤖 Generated with [Claude Code](https://claude.com/claude-code)