### PR TITLE
fix(csp): whitelist Cloudflare Web Analytics beacon (static.cloudflareinsights.com)

### DIFF
--- a/lib/engram_web/csp.ex
+++ b/lib/engram_web/csp.ex
@@ -76,7 +76,8 @@ defmodule EngramWeb.CSP do
     [
       clerk_directives(),
       paddle_directives(),
-      turnstile_directives()
+      turnstile_directives(),
+      cloudflare_insights_directives()
     ]
   end
 
@@ -175,6 +176,31 @@ defmodule EngramWeb.CSP do
     %{
       "script-src" => hosts,
       "frame-src" => hosts
+    }
+  end
+
+  # Cloudflare Web Analytics (cookieless, edge-injected).
+  #
+  # When the Cloudflare dashboard's Web Analytics toggle is on, the
+  # orange-cloud edge proxy injects a `<script src="https://static.
+  # cloudflareinsights.com/beacon.min.js/...">` tag into HTML responses
+  # — without ever touching the backend. The beacon then POSTs page-view
+  # events back to the same host, so CSP needs both `script-src` (load)
+  # and `connect-src` (telemetry POST).
+  #
+  # This is unconditionally on because (a) the source-of-truth is a CF
+  # dashboard toggle, not a backend env var, and (b) workspace memory
+  # [[project_observability_stack_plan]] and the cookie-audit decision
+  # [[cookie-audit-2026-05-24]] both rely on cookieless CF Insights
+  # working in prod as the foundation of the no-banner launch posture.
+  # Self-host operators who don't front their app with Cloudflare see
+  # no traffic to this host; the extra CSP entry is harmless dead air.
+  defp cloudflare_insights_directives do
+    hosts = ["https://static.cloudflareinsights.com"]
+
+    %{
+      "script-src" => hosts,
+      "connect-src" => hosts
     }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.305",
+      version: "0.5.306",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/csp_test.exs
+++ b/test/engram_web/csp_test.exs
@@ -53,6 +53,22 @@ defmodule EngramWeb.CSPTest do
       assert connect_src(header) =~ "https://*.paddle.com"
       assert frame_src(header) =~ "https://*.paddle.com"
     end
+
+    test "always whitelists Cloudflare Web Analytics (edge-injected beacon)" do
+      # CF Web Analytics injects `<script src="https://static.cloudflareinsights.com/
+      # beacon.min.js/...">` at edge time when the dashboard toggle is on. The
+      # beacon also POSTs telemetry back to the same host, so it needs both
+      # script-src + connect-src. Without this allowlist, prod analytics breaks
+      # silently (no console error from the beacon itself — CSP blocks the script
+      # load before it can run). See workspace memory cookie-audit-2026-05-24
+      # for why this matters for the no-banner launch posture.
+      Application.put_env(:engram, :clerk_issuer, nil)
+
+      header = CSP.header()
+
+      assert script_src(header) =~ "https://static.cloudflareinsights.com"
+      assert connect_src(header) =~ "https://static.cloudflareinsights.com"
+    end
   end
 
   describe "Clerk integration — dev/test instance (CLERK_ISSUER under *.clerk.accounts.dev)" do


### PR DESCRIPTION
## Repro

After PR #407 fixed Clerk JS load, sign-in page on prod (`app.engram.page/sign-in`) shows in browser console:

\`\`\`
Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/v833ccba57c9e4d2798f2e76cebdd09a11778172276447'
violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'
https://*.clerk.accounts.dev https://*.clerk.com https://clerk.engram.page https://*.paddle.com
https://challenges.cloudflare.com"
\`\`\`

## Cause

Cloudflare's orange-cloud edge auto-injects the Web Analytics `<script>` tag into HTML responses when the dashboard Web Analytics toggle is on. The injection happens at the edge — the backend never sees the tag, but CSP still applies. `static.cloudflareinsights.com` is missing from `script-src` → load blocked → analytics silently broken.

## Why this matters for launch

Per workspace memory `cookie-audit-2026-05-24` and `project_observability_stack_plan`: **cookieless Cloudflare Web Analytics is part of the no-banner launch decision**. The reasoning was "we have web analytics (cookieless via CF), so we don't need a consent banner." With Insights blocked, that assumption silently regresses to "we have no web analytics" — and the banner-vs-no-banner trade has lost one side of its premise.

## Fix

New `cloudflare_insights_directives/0` in `EngramWeb.CSP`:

\`\`\`elixir
defp cloudflare_insights_directives do
  hosts = [\"https://static.cloudflareinsights.com\"]

  %{
    \"script-src\" => hosts,
    \"connect-src\" => hosts
  }
end
\`\`\`

`connect-src` is included because the beacon POSTs page-view telemetry back to the same host after load.

Same per-integration pattern shipped in PR #407.

## Tests

`test/engram_web/csp_test.exs` — new test in the \"static directives\" describe block:

\`\`\`elixir
test \"always whitelists Cloudflare Web Analytics (edge-injected beacon)\" do
  ...
  assert script_src(header) =~ \"https://static.cloudflareinsights.com\"
  assert connect_src(header) =~ \"https://static.cloudflareinsights.com\"
end
\`\`\`

Full mix test: **1953 tests, 0 failures, 7 skipped**. Credo clean. Formatter clean.

## Why unconditional, not env-gated

Source of truth for whether Web Analytics is on lives in the Cloudflare dashboard, not in any backend env var. Adding `CF_INSIGHTS_ENABLED` would just duplicate state — the *real* gate is whether CF injects the script, which we observe by traffic to the host, not by config. The CSP entry costs nothing when the beacon isn't injected (no traffic to the host → CSP doesn't enforce anything), so on-by-default is the safer baseline.

## Self-host effect

Self-hosters not fronting their app with Cloudflare see zero traffic to `static.cloudflareinsights.com` — the allowlist entry is harmless dead air. Their own analytics stack (if any) needs its own entry, same pattern.

## Test plan (manual, post-deploy)

- [ ] Image bump in engram-infra → `terraform (prod)` applies new task def
- [ ] Open `https://app.engram.page/sign-in` in fresh browser tab
- [ ] DevTools → Console: no `static.cloudflareinsights.com` CSP violation
- [ ] DevTools → Network: `beacon.min.js` shows **200** (not `blocked:csp`)
- [ ] `curl -D - https://app.engram.page/ | grep -i content-security-policy` shows `static.cloudflareinsights.com` in script-src + connect-src
- [ ] CF dashboard → Web Analytics → page-view count starts incrementing

🤖 Generated with [Claude Code](https://claude.com/claude-code)