### PR TITLE
fix(auth): unstick Clerk post-OAuth redirect on /sign-in

### DIFF
--- a/frontend/src/auth/clerk-auth-provider.test.ts
+++ b/frontend/src/auth/clerk-auth-provider.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { toRelativeUrl } from './clerk-auth-provider'
+
+describe('toRelativeUrl', () => {
+  const origin = window.location.origin
+
+  it('strips same-origin absolute URLs to path', () => {
+    expect(toRelativeUrl(`${origin}/`)).toBe('/')
+    expect(toRelativeUrl(`${origin}/dashboard`)).toBe('/dashboard')
+  })
+
+  it('preserves search and hash on same-origin URLs', () => {
+    expect(toRelativeUrl(`${origin}/x?a=1#b`)).toBe('/x?a=1#b')
+  })
+
+  it('passes off-origin URLs through untouched (full-page nav)', () => {
+    const off = 'https://accounts.google.com/oauth/x'
+    expect(toRelativeUrl(off)).toBe(off)
+  })
+
+  it('passes already-relative paths through untouched', () => {
+    expect(toRelativeUrl('/sign-in')).toBe('/sign-in')
+    expect(toRelativeUrl('/onboard/billing?step=2')).toBe('/onboard/billing?step=2')
+  })
+})

--- a/frontend/src/auth/clerk-auth-provider.tsx
+++ b/frontend/src/auth/clerk-auth-provider.tsx
@@ -13,6 +13,22 @@ import { useTheme } from '../theme/theme-provider'
 
 const clerkPubKey = config.clerkPublishableKey
 
+// Clerk passes the post-auth redirect target as an ABSOLUTE URL when it crosses
+// (or might cross) origins — including the in-origin case after an OAuth
+// callback completes. React Router's `navigate("https://app.engram.page/")`
+// silently no-ops on absolute URLs (treats it as a path), leaving the user
+// stuck on `/sign-in#/?sign_in_force_redirect_url=...` after Google return.
+// Strip same-origin targets back to a path so the SPA router actually moves.
+// Off-origin URLs pass through untouched for full-page navigation.
+export function toRelativeUrl(to: string): string {
+  try {
+    const u = new URL(to, window.location.origin)
+    return u.origin === window.location.origin ? u.pathname + u.search + u.hash : to
+  } catch {
+    return to
+  }
+}
+
 // Map Clerk onto Engram's CSS design tokens. The Clerk React components render
 // in-DOM (not an iframe), so these var() references resolve against the document.
 // The dark baseTheme (applied reactively below) is what flips Clerk's own
@@ -102,8 +118,8 @@ export default function ClerkAuthProvider({ children }: { children: React.ReactN
       signUpUrl={signUpUrl}
       waitlistUrl={waitlistUrl}
       afterSignOutUrl={ROUTES.SIGN_IN}
-      routerPush={(to) => router.navigate(to)}
-      routerReplace={(to) => router.navigate(to, { replace: true })}
+      routerPush={(to) => router.navigate(toRelativeUrl(to))}
+      routerReplace={(to) => router.navigate(toRelativeUrl(to), { replace: true })}
     >
       <ClerkAdapterInner>{children}</ClerkAdapterInner>
     </ClerkProvider>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.306",
+      version: "0.5.307",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Clerk passes the post-auth redirect target to `routerPush` as an absolute URL (e.g. `https://app.engram.page/`) when an OAuth callback completes. React Router's `navigate(\"https://...\")` silently no-ops on absolute URLs (treats them as a path).
- User ends up stuck on `/sign-in#/?sign_in_force_redirect_url=https%3A%2F%2Fapp.engram.page%2F` after Google return — infinite Clerk spinner, query params persist across SPA navigation.
- Strip same-origin absolute URLs to a path before handing to `router.navigate`. Off-origin URLs pass through untouched so full-page nav still works.

## Repro / why "refresh fixes it"

Manual refresh on the stuck URL works because ClerkProvider boots fresh, sees the session cookie, and `<SignIn forceRedirectUrl>` triggers a path-relative push that the SPA router does accept. Only the in-page post-OAuth handoff was broken.

Surfaced while testing Clerk waitlist mode (PR #390) on prod with a non-approved email + Google OAuth.

## Test plan

- [x] `bun run test src/auth/clerk-auth-provider.test.ts` — 4 new tests pass
- [x] `bun run test` — 150/150 pass
- [x] `bun run build` — clean
- [ ] Manual on prod after deploy: Google OAuth with non-approved email returns to app root (not stuck on /sign-in hash)
- [ ] Manual on prod: Google OAuth with approved email returns to / (regression)
- [ ] Manual on prod: email/password sign-in still redirects (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)