### PR TITLE
fix(auth): redirect OAuth-on-waitlist signups to /waitlist instead of hanging

### DIFF
--- a/frontend/src/auth/clerk-sign-in.test.tsx
+++ b/frontend/src/auth/clerk-sign-in.test.tsx
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import ClerkSignIn from './clerk-sign-in'
+
+const navigate = vi.fn()
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return { ...actual, useNavigate: () => navigate }
+})
+
+const useSignInMock = vi.fn()
+
+vi.mock('@clerk/react', () => ({
+  SignIn: ({ forceRedirectUrl }: { forceRedirectUrl: string }) => (
+    <div data-testid="clerk-signin">{forceRedirectUrl}</div>
+  ),
+}))
+
+vi.mock('@clerk/react/legacy', () => ({
+  useSignIn: () => useSignInMock(),
+}))
+
+function renderAt(returnTo = '/') {
+  return render(
+    <MemoryRouter>
+      <ClerkSignIn returnTo={returnTo} />
+    </MemoryRouter>,
+  )
+}
+
+describe('ClerkSignIn waitlist redirect', () => {
+  beforeEach(() => {
+    navigate.mockReset()
+    useSignInMock.mockReset()
+  })
+
+  it('navigates to /waitlist when OAuth verification reports sign_up_restricted_waitlist', async () => {
+    useSignInMock.mockReturnValue({
+      isLoaded: true,
+      signIn: {
+        firstFactorVerification: {
+          status: 'verified',
+          strategy: 'oauth_google',
+          error: { code: 'sign_up_restricted_waitlist' },
+        },
+      },
+    })
+
+    renderAt()
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/waitlist', { replace: true }))
+  })
+
+  it('does not navigate before Clerk has loaded', () => {
+    useSignInMock.mockReturnValue({
+      isLoaded: false,
+      signIn: {
+        firstFactorVerification: {
+          error: { code: 'sign_up_restricted_waitlist' },
+        },
+      },
+    })
+
+    renderAt()
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate when there is no verification error', () => {
+    useSignInMock.mockReturnValue({
+      isLoaded: true,
+      signIn: { firstFactorVerification: { status: 'verified' } },
+    })
+
+    renderAt()
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate on unrelated verification errors', () => {
+    useSignInMock.mockReturnValue({
+      isLoaded: true,
+      signIn: {
+        firstFactorVerification: {
+          error: { code: 'oauth_access_denied' },
+        },
+      },
+    })
+
+    renderAt()
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('renders the Clerk SignIn component with forceRedirectUrl', () => {
+    useSignInMock.mockReturnValue({ isLoaded: true, signIn: null })
+
+    const { getByTestId } = renderAt('/dashboard')
+
+    expect(getByTestId('clerk-signin').textContent).toBe('/dashboard')
+  })
+})

--- a/frontend/src/auth/clerk-sign-in.tsx
+++ b/frontend/src/auth/clerk-sign-in.tsx
@@ -1,0 +1,27 @@
+import { SignIn } from '@clerk/react'
+// Legacy hook returns `{ isLoaded, signIn }` with `signIn.firstFactorVerification`.
+// The root `@clerk/react` `useSignIn` now returns the signal-based shape, which
+// doesn't expose that field — we only need to read post-OAuth verification errors.
+import { useSignIn } from '@clerk/react/legacy'
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router'
+import { ROUTES } from '../routes'
+
+// Clerk's <SignIn /> has no built-in UI for the OAuth-then-waitlist-blocked
+// state: when Google verifies the identity but Clerk's restriction kills the
+// implicit sign-up (`signIn.firstFactorVerification.error.code ===
+// 'sign_up_restricted_waitlist'`), the component just spins. ClerkProvider's
+// `waitlistUrl` only governs the "Sign up" CTA, not OAuth recovery. Detect
+// the error reactively via useSignIn() and route to /waitlist ourselves.
+export default function ClerkSignIn({ returnTo }: { returnTo: string }) {
+  const { signIn, isLoaded } = useSignIn()
+  const navigate = useNavigate()
+  const restricted =
+    signIn?.firstFactorVerification?.error?.code === 'sign_up_restricted_waitlist'
+
+  useEffect(() => {
+    if (isLoaded && restricted) navigate(ROUTES.WAITLIST, { replace: true })
+  }, [isLoaded, restricted, navigate])
+
+  return <SignIn routing="hash" forceRedirectUrl={returnTo} />
+}

--- a/frontend/src/auth/sign-in.tsx
+++ b/frontend/src/auth/sign-in.tsx
@@ -7,15 +7,7 @@ import { safeReturnTo } from './safe-return-to'
 
 const isClerk = config.authProvider === 'clerk'
 
-const ClerkSignIn = isClerk
-  ? lazy(() =>
-      import('@clerk/react').then((mod) => ({
-        default: ({ returnTo }: { returnTo: string }) => (
-          <mod.SignIn routing="hash" forceRedirectUrl={returnTo} />
-        ),
-      })),
-    )
-  : null
+const ClerkSignIn = isClerk ? lazy(() => import('./clerk-sign-in')) : null
 
 const LocalSignIn = lazy(() => import('./local-sign-in'))
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.308",
+      version: "0.5.309",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

When Clerk's restriction is set to Waitlist mode and a user signs in via Google with a non-approved email, the OAuth callback verifies the identity but Clerk rejects the implicit sign-up with `signIn.firstFactorVerification.error.code === 'sign_up_restricted_waitlist'`. The mounted `<SignIn />` has no UI for this state and just spins on `/sign-in#/?sign_in_force_redirect_url=...`.

Confirmed live on prod via CDP after #411 deployed. Inspection at the stuck URL showed `hasSession=false`, `signIn.status='needs_identifier'`, and the `sign_up_restricted_waitlist` error on `firstFactorVerification`. ClerkProvider's `waitlistUrl` only governs the "Sign up" CTA, not OAuth recovery.

Wrap `<SignIn />` in a small component that watches the legacy `useSignIn` hook for this specific error and routes to `/waitlist` ourselves.

## Why @clerk/react/legacy

The root `useSignIn` returns the new signal-based shape (`{ errors, fetchStatus, signIn }`) which doesn't expose `firstFactorVerification` directly. Legacy returns the documented `{ isLoaded, signIn }` shape we need.

## Test plan

- [x] `bun run test src/auth/clerk-sign-in.test.tsx` — 5 new tests
- [x] `bun run test` — 155/155 pass
- [x] `bun run build` — clean
- [ ] Manual on prod: Google OAuth with non-approved email → lands on /waitlist
- [ ] Manual on prod: approved-email OAuth still redirects to / (regression)
- [ ] Manual on prod: email/password sign-in still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)