### PR TITLE
fix(e2e): concentrate Clerk readiness wait into fixture (#193)

### DIFF
--- a/e2e/helpers/clerk.py
+++ b/e2e/helpers/clerk.py
@@ -9,19 +9,36 @@ Clerk Backend API docs: https://clerk.com/docs/reference/backend-api
 from __future__ import annotations
 
 import logging
+import random
 import time
 
 import requests
 
 logger = logging.getLogger(__name__)
 
-# Clerk's POST /sessions endpoint exhibits eventual-consistency 404s vs the
-# user store: a user_id that GET /users/{id} returns happily can still
-# 404 from POST /sessions for a few hundred ms after creation. Retry
-# resource_not_found errors with exponential backoff. 5 attempts span
-# ~6s total, well above Clerk's observed lag window (<1s in practice).
+# Clerk's POST /sessions endpoint is eventually consistent vs POST /users:
+# a user_id Clerk just returned can 404 from POST /sessions for a while.
+# Observed window today (issue #193) is up to ~6s in degraded periods;
+# in normal operation it's sub-second.
+#
+# Strategy (revised after #193 reopened):
+#   - create_user() blocks until POST /sessions stops 404'ing (readiness
+#     probe). Concentrates the wait at one site instead of every caller
+#     racing the propagation.
+#   - _create_session_with_retry stays as a defensive backstop for the
+#     unlikely case where someone reuses an old user_id mid-flight, but
+#     its budget is tight — readiness was already proven upstream.
+_SESSION_READY_MAX_WAIT_SECONDS = 60.0
+_SESSION_READY_INITIAL_BACKOFF = 0.5
+_SESSION_READY_MAX_BACKOFF = 8.0
+
 _SESSION_CREATE_MAX_ATTEMPTS = 5
 _SESSION_CREATE_INITIAL_BACKOFF = 0.2
+
+
+class ClerkPropagationTimeout(RuntimeError):
+    """Raised when Clerk's POST /sessions still 404s the user after the
+    readiness probe's wall-clock budget."""
 
 
 class ClerkClient:
@@ -87,7 +104,67 @@ class ClerkClient:
         resp.raise_for_status()
         user_id = resp.json()["id"]
         logger.info("Created Clerk user %s (%s)", user_id, email)
+        # Block until Clerk's session endpoint can see this user. Without
+        # this, every downstream caller (create_session_token, JWT mint,
+        # etc.) races Clerk's propagation lag — see #193.
+        self._wait_until_session_ready(user_id)
         return user_id
+
+    def _wait_until_session_ready(self, user_id: str) -> None:
+        """Block until Clerk's POST /sessions stops 404'ing the given user.
+
+        Eventual consistency: a user just created via POST /users can be
+        invisible to POST /sessions for seconds (up to ~6s observed; #193).
+        This probe creates one Clerk session and discards it — once it
+        succeeds, the user is queryable from the session endpoint and
+        subsequent legitimate session creation will not race.
+
+        Raises ClerkPropagationTimeout when Clerk doesn't propagate
+        within _SESSION_READY_MAX_WAIT_SECONDS. Other errors (auth,
+        rate-limit, etc.) raise immediately — we only loop on the
+        specific 404 resource_not_found signal.
+        """
+        deadline = time.monotonic() + _SESSION_READY_MAX_WAIT_SECONDS
+        backoff = _SESSION_READY_INITIAL_BACKOFF
+        attempt = 0
+        while True:
+            attempt += 1
+            resp = self.session.post(
+                f"{self.base_url}/sessions",
+                json={"user_id": user_id},
+                timeout=10,
+            )
+            if resp.ok:
+                session_id = resp.json()["id"]
+                logger.info(
+                    "Clerk session-ready probe succeeded for %s on attempt %d (session %s discarded)",
+                    user_id, attempt, session_id,
+                )
+                return
+            if not (resp.status_code == 404 and self._is_resource_not_found(resp)):
+                logger.error(
+                    "Clerk session-ready probe failed (non-404): %s %s",
+                    resp.status_code, resp.text,
+                )
+                resp.raise_for_status()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ClerkPropagationTimeout(
+                    f"Clerk POST /sessions still 404 for user {user_id} after "
+                    f"{_SESSION_READY_MAX_WAIT_SECONDS}s ({attempt} attempts)"
+                )
+            # ±20% jitter avoids thundering-herd on Clerk when many tests
+            # provision users in parallel during a degraded window.
+            sleep_for = min(
+                backoff + random.uniform(-0.2 * backoff, 0.2 * backoff),
+                remaining,
+            )
+            logger.warning(
+                "Clerk session-ready probe 404 for %s (attempt %d, sleeping %.2fs, %.1fs remaining)",
+                user_id, attempt, sleep_for, remaining,
+            )
+            time.sleep(sleep_for)
+            backoff = min(backoff * 2, _SESSION_READY_MAX_BACKOFF)
 
     @staticmethod
     def _is_identifier_taken(resp: requests.Response) -> bool:

--- a/frontend/e2e/clerk-auth.spec.ts
+++ b/frontend/e2e/clerk-auth.spec.ts
@@ -21,27 +21,16 @@ const USER_MENU = { role: 'button' as const, name: 'User menu' }
  * Sign in via Clerk Backend API ticket — bypasses form + bot detection entirely.
  * Creates a sign-in token server-side, then uses it client-side via strategy: 'ticket'.
  * Requires CLERK_SECRET_KEY env var (set in global-setup).
+ *
+ * No retry on "No user found" here — global-setup probes POST /sign_in_tokens
+ * until it stops 404'ing before writing .auth-state.json, so any 404 at this
+ * point indicates a real problem (user deleted mid-run, instance swap, etc.)
+ * and should surface immediately. See #193 + global-setup.ts waitUntilSignInReady.
  */
 async function clerkSignIn(page: Page, email: string) {
   // Navigate first so Clerk JS SDK loads on the page
   await page.goto('/sign-in/')
-  // Clerk user creation in global-setup is eventually consistent: the
-  // backend sign-in-token call here can briefly 404 the freshly-created user
-  // ("No user found with email") before replication settles. Retry a few
-  // times before giving up (issue #193); rethrow any other error immediately.
-  let lastErr: unknown
-  for (let attempt = 0; attempt < 5; attempt++) {
-    try {
-      await clerk.signIn({ page, emailAddress: email })
-      lastErr = undefined
-      break
-    } catch (err) {
-      if (!/No user found/i.test(String(err))) throw err
-      lastErr = err
-      await page.waitForTimeout(1_000)
-    }
-  }
-  if (lastErr) throw lastErr
+  await clerk.signIn({ page, emailAddress: email })
   await page.goto('/')
   await expect(page).toHaveURL(/\/$/, { timeout: 15_000 })
 }

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -51,6 +51,12 @@ export default async function globalSetup() {
   const user = await resp.json()
   console.log(`Clerk test user created: ${email} (${user.id})`)
 
+  // Block until Clerk's sign-in-tokens endpoint can see this user.
+  // Without this, the first test calling clerk.signIn() races Clerk's
+  // propagation lag (issue #193). Concentrates the wait into one site
+  // so test code doesn't need retries.
+  await waitUntilSignInReady(user.id, secretKey)
+
   fs.writeFileSync(
     AUTH_STATE_PATH,
     JSON.stringify({
@@ -60,6 +66,72 @@ export default async function globalSetup() {
       skipped: false,
     }),
   )
+}
+
+const SIGN_IN_READY_MAX_WAIT_MS = 60_000
+const SIGN_IN_READY_INITIAL_BACKOFF_MS = 500
+const SIGN_IN_READY_MAX_BACKOFF_MS = 8_000
+
+/**
+ * Block until Clerk's POST /sign_in_tokens stops 404'ing the given user.
+ *
+ * Same eventual-consistency story as the Python helper's _wait_until_session_ready
+ * (POST /sessions), but for the endpoint @clerk/testing's clerk.signIn uses
+ * under the hood. Both endpoints share Clerk's user-lookup propagation lag;
+ * probing each one separately means we don't assume they're backed by the
+ * same read replica.
+ *
+ * Throws on non-404 errors or when the wall-clock budget is exhausted.
+ */
+async function waitUntilSignInReady(userId: string, secretKey: string): Promise<void> {
+  const headers = {
+    Authorization: `Bearer ${secretKey}`,
+    'Content-Type': 'application/json',
+  }
+  const deadline = Date.now() + SIGN_IN_READY_MAX_WAIT_MS
+  let backoff = SIGN_IN_READY_INITIAL_BACKOFF_MS
+  let attempt = 0
+  // ±20% jitter avoids thundering-herd on Clerk when multiple e2e jobs
+  // provision users in parallel during a degraded window.
+  const jittered = (ms: number) => ms + ms * (Math.random() * 0.4 - 0.2)
+
+  while (true) {
+    attempt++
+    const resp = await fetch(`${CLERK_API}/sign_in_tokens`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ user_id: userId, expires_in_seconds: 60 }),
+    })
+    if (resp.ok) {
+      console.log(`Clerk sign-in-tokens probe succeeded for ${userId} on attempt ${attempt} (token discarded)`)
+      return
+    }
+    const body = await resp.text()
+    let is404NotFound = false
+    if (resp.status === 404) {
+      try {
+        const parsed = JSON.parse(body) as { errors?: Array<{ code?: string }> }
+        is404NotFound = (parsed.errors ?? []).some((e) => e.code === 'resource_not_found')
+      } catch {
+        // Non-JSON 404 — fall through to the non-propagation error path.
+      }
+    }
+    if (!is404NotFound) {
+      throw new Error(`Clerk sign-in-tokens probe failed (non-404 or non-propagation): ${resp.status} ${body}`)
+    }
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) {
+      throw new Error(
+        `Clerk POST /sign_in_tokens still 404 for user ${userId} after ${SIGN_IN_READY_MAX_WAIT_MS}ms (${attempt} attempts)`,
+      )
+    }
+    const sleepFor = Math.min(jittered(backoff), remaining)
+    console.warn(
+      `Clerk sign-in-tokens probe 404 for ${userId} (attempt ${attempt}, sleeping ${Math.round(sleepFor)}ms, ${remaining}ms remaining)`,
+    )
+    await new Promise((r) => setTimeout(r, sleepFor))
+    backoff = Math.min(backoff * 2, SIGN_IN_READY_MAX_BACKOFF_MS)
+  }
 }
 
 // Only clean up browser-e2e's own users — other prefixes belong to the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.309",
+      version: "0.5.310",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Closes #193 (pending verification — flake can't be reproduced locally).

## Root cause (re-investigated)

Clerk Backend API's `POST /v1/users` (write) is eventually consistent vs the session-creation endpoints (`POST /v1/sessions` Python, `POST /v1/sign_in_tokens` Playwright via `@clerk/testing`). The just-returned `user_id` can 404 from these endpoints for seconds — observed at **>6s today, twice within 3 hours** on PRs #412 and #414.

Prior fix #335 added a 4s retry loop in `clerk-auth.spec.ts` only; today's recurrences exhausted both that retry AND the Python helper's ~6s exponential backoff. The retry budget was structurally in the wrong place: each test consumer fought the propagation race independently, so multiple tests using the same fresh user would burn through their independent budgets in the same degraded window.

## Fix shape

Concentrate the wait into the fixture path — where the user was just created — so test code never sees the race.

### Python (`e2e/helpers/clerk.py`)

- `ClerkClient.create_user` now calls `_wait_until_session_ready` before returning. Probes `POST /sessions` with exponential backoff + ±20% jitter; 60s wall-clock budget; discards the session_id.
- After `create_user` returns, the user is proven queryable from the session endpoint. Subsequent `create_session_token` calls don't race.
- Raises `ClerkPropagationTimeout` when Clerk doesn't propagate in 60s — fails loud during fixture, not deep in a test.
- `_create_session_with_retry` stays as a defensive backstop (cheap to keep, won't normally fire).

### Playwright (`frontend/e2e/global-setup.ts`)

- New `waitUntilSignInReady` probes `POST /sign_in_tokens` after the fresh user is created. Same shape as Python: exponential backoff + jitter, 60s budget, throws on non-404 errors.
- `.auth-state.json` is written only after probe success.

### Playwright (`frontend/e2e/clerk-auth.spec.ts`)

- `clerkSignIn` no longer retries on `"No user found"` — `global-setup` proves readiness, so a 404 here is a real bug surface.

### Why both endpoints (not just one)

`@clerk/testing`'s `clerk.signIn` uses `POST /sign_in_tokens`; the Python helper uses `POST /sessions`. Both 404 the just-created user, but their backing read replicas may be independent. Probing each path separately avoids assuming they share infrastructure — small extra cost (one extra HTTP call in fixture), much higher confidence.

## Verification

Cannot deterministically reproduce Clerk's degraded windows locally. Verification is CI behavior over the next weeks:

- [ ] CI passes on this PR
- [ ] Watch CI runs on subsequent PRs for ~2 weeks; no `No user found` / `resource_not_found` 404 recurrences
- [ ] On the rare Clerk degradation, observe the probe absorbing the lag (fixture takes longer; tests still pass)

If the 60s budget proves insufficient (Clerk outage), the fixture fails loud with `ClerkPropagationTimeout` / explicit timeout message — easier to triage than today's flaky test errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)