### PR TITLE
ci: rename ci.yml → verify.yml (file-only)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -474,7 +474,7 @@ jobs:
           echo "=== Runner work dirs ==="
           ls -ld "$HOME"/actions-runner* 2>/dev/null || echo "(no actions-runner* dirs in HOME)"
 
-  # ── Weekly Hex SBOM refresh. The push-on-main path lives in ci.yml
+  # ── Weekly Hex SBOM refresh. The push-on-main path lives in verify.yml
   # (submit-dep-graph job) and fires when mix.exs / mix.lock changes;
   # this cron path catches transitive bumps from Hex retire/replace
   # events that happen outside our own commits. Saturday 03:00 UTC.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,7 +8,7 @@ name: Deploy prod
 # pinned image, and the engram-saas-prod service rolls onto it.
 #
 # This is the GitOps mirror of the staging-fastraid `bump-infra-tfvars`
-# pattern (engram/.github/workflows/ci.yml). Image tag = desired state
+# pattern (engram/.github/workflows/verify.yml). Image tag = desired state
 # in git; engram-infra is the reconciler.
 #
 # Release recipe:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -185,7 +185,7 @@ jobs:
               Dockerfile entrypoint.sh \
               mix.lock \
               docker-compose.ci.yml docker-compose.ci-local.yml docker-compose.ci-database.yml \
-              .github/workflows/ci.yml
+              .github/workflows/verify.yml
             echo "mix.exs-no-version:$MIX_EXS_NO_VERSION"
           } | sha256sum | cut -d' ' -f1)
           # The e2e harness tree (helpers, fixtures, tests). Including it in
@@ -1448,7 +1448,7 @@ jobs:
             exit 0
           fi
 
-          # ci.yml fires on `push`, not `pull_request`, so the label check
+          # verify.yml fires on `push`, not `pull_request`, so the label check
           # above is dead on most runs (github.event.pull_request is null).
           # Fallback bypass via [allow-migration-edit] tag in the head
           # commit message — same friction-y semantic, push-compatible.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.312",
+      version: "0.5.313",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Naming cleanup. The workflow long ago grew beyond test-only into the verify + full deploy chain — `verify.yml` is more honest than `ci.yml`.

**File-only rename.** Aggregator job key stays `ci:`, so:

- Branch protection ruleset 16309248 (required checks: `ci`, `unit-tests`, `lint`) is **unchanged**. No engram-infra TF PR needed.
- Plugin dispatch is unaffected — `POST /repos/engram-app/Engram/dispatches` with `event_type=plugin-e2e-trigger` routes by event type, not filename.

Cosmetic wart: `verify.yml` contains a job called `ci`. Full file + job rename (with ruleset update via engram-infra TF PR) stays open as a follow-up if anyone finds the wart annoying.

## Changes

- `git mv .github/workflows/ci.yml verify.yml`
- BACKEND_HASH path bumped: `.github/workflows/ci.yml` → `verify.yml` (**load-bearing** — without this, the rename invalidates the fingerprint cache despite content being unchanged)
- 3 inline comments updated (`verify.yml`, `cron.yml`, `deploy-prod.yml`) for consistency

`deploy-prod.yml:147` keeps its `.github/workflows/ci.yml` reference — that line lives in the PR body opened against **engram-infra**, where the path correctly resolves to engram-infra's own CI workflow.

## Net workflow files: 5 → 5 (rename only)

```
verify.yml                   ← was ci.yml
cron.yml
deploy-prod.yml
dependabot-auto-merge.yml
dependabot-lockfile-fix.yml
```

## Test plan

- [ ] CI passes on this PR (the renamed workflow runs as `verify.yml`; aggregator check still appears as `ci`, satisfying ruleset)
- [ ] On merge to main, fingerprint cache hits for subsequent unchanged-tree pushes (BACKEND_HASH bump preserves cache continuity)
- [ ] Plugin repository_dispatch from engram-app/Engram-obsidian still fires `e2e-clerk` (event-type routing, not filename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)