### PR TITLE
feat(ci): bake VITE_SENTRY_DSN into prod image + tag Sentry releases on deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -180,3 +180,51 @@ jobs:
               echo "- No PR opened (no diff — image already at this tag)."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Notify Discord on success. "Deploy initiated" — not "deploy
+      # complete" — since the actual ECS rollout happens later in
+      # engram-infra's `terraform (prod)` apply (~3-5 min after the
+      # bot PR auto-merges). Complete-rollout notify is a future
+      # observability item (Tier 3); this catches the operator's
+      # "did the tag push do anything?" question. Silently no-ops
+      # when DISCORD_DEPLOY_WEBHOOK_URL is unset.
+      - name: Notify Discord (deploy initiated)
+        if: success() && env.WEBHOOK != ''
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
+          RELEASE: ${{ steps.tags.outputs.release }}
+          IMAGE: ${{ steps.tags.outputs.image_tag }}
+          PR_NUMBER: ${{ steps.open-pr.outputs.pull-request-number }}
+          PR_URL: ${{ steps.open-pr.outputs.pull-request-url }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            CONTENT="[DEPLOY-INITIATED] \`${RELEASE}\` → \`${IMAGE}\`
+          engram-infra PR: ${PR_URL}
+          Tagged by: ${ACTOR}"
+          else
+            CONTENT="[DEPLOY-NOOP] \`${RELEASE}\` → \`${IMAGE}\` (image already at this tag; no PR opened)
+          Tagged by: ${ACTOR}"
+          fi
+          curl -sS -X POST -H 'Content-Type: application/json' \
+            --max-time 5 \
+            --data "$(jq -nc --arg c "$CONTENT" '{content:$c}')" \
+            "$WEBHOOK"
+
+      # Failure path — same webhook, different framing. `failure()`
+      # fires when an earlier step exited non-zero.
+      - name: Notify Discord (deploy failed)
+        if: failure() && env.WEBHOOK != ''
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
+          RELEASE: ${{ steps.tags.outputs.release || github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          CONTENT="[DEPLOY-FAILED] \`${RELEASE}\`
+          Run: ${RUN_URL}
+          Tagged by: ${ACTOR}"
+          curl -sS -X POST -H 'Content-Type: application/json' \
+            --max-time 5 \
+            --data "$(jq -nc --arg c "$CONTENT" '{content:$c}')" \
+            "$WEBHOOK"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2467,16 +2467,31 @@ jobs:
             --secret "id=sentry_auth_token,env=SENTRY_AUTH_TOKEN" \
             .
 
+      # Lift SENTRY_AUTH_TOKEN into a step env so the next two steps
+      # can gate on `env.HAS_TOKEN`. GH Actions doesn't allow the
+      # `secrets` context in step-level `if:` conditions, so the
+      # env-indirection is the documented workaround.
+      - name: Detect Sentry auth token
+        id: sentry-token
+        env:
+          TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::SENTRY_AUTH_TOKEN unset — skipping Sentry release steps. Stack traces will ship un-symbolicated until the secret lands."
+          fi
+
       # Create + finalize a Sentry release tagged with the commit SHA.
       # action-release uploads no source maps itself (the Vite plugin
       # in the frontend stage of Dockerfile already pushed them under
       # the same release name) — it just registers the release in
       # Sentry's UI and associates commits, so the "Releases" view
       # shows what's running and the "Suspect Commits" feature can
-      # finger a likely-culprit commit on a new error. Self-disables
-      # when SENTRY_AUTH_TOKEN is empty.
+      # finger a likely-culprit commit on a new error.
       - name: Sentry frontend release
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' }}
+        if: steps.sentry-token.outputs.has_token == 'true'
         uses: getsentry/action-release@v3
         env:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
@@ -2489,7 +2504,7 @@ jobs:
           sourcemaps: ''
 
       - name: Sentry backend release
-        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' }}
+        if: steps.sentry-token.outputs.has_token == 'true'
         uses: getsentry/action-release@v3
         env:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2437,15 +2437,69 @@ jobs:
           # Plain progress writer — see ci.yml prebuild-ci-image for the
           # docker/buildx race rationale (#334).
           BUILDKIT_PROGRESS: plain
+          # Sentry frontend wiring (no-op when SENTRY_* secrets unset).
+          # VITE_GIT_SHA is the 7-char tag from the step above without
+          # the `sha-` prefix so Sentry release names match the values
+          # passed to action-release below + to the runtime SDK's
+          # release option.
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_GIT_SHA: ${{ github.sha }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT_FRONTEND: ${{ vars.SENTRY_PROJECT_FRONTEND }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           TAGS=(--tag "$REPO:$SHA_TAG")
           if [ -n "$VTAG" ]; then
             TAGS+=(--tag "$REPO:$VTAG")
           fi
+          # --secret pipes SENTRY_AUTH_TOKEN to the build via a tmpfs
+          # mount, never written to image layers. The Vite plugin
+          # self-disables if the token isn't present, so an empty
+          # secret is a graceful no-op (degraded UX: stack traces
+          # ship un-symbolicated until the token lands).
           docker buildx build \
             "${TAGS[@]}" \
             --push \
+            --build-arg "VITE_SENTRY_DSN=${VITE_SENTRY_DSN}" \
+            --build-arg "VITE_GIT_SHA=${VITE_GIT_SHA}" \
+            --build-arg "SENTRY_ORG=${SENTRY_ORG}" \
+            --build-arg "SENTRY_PROJECT=${SENTRY_PROJECT_FRONTEND}" \
+            --secret "id=sentry_auth_token,env=SENTRY_AUTH_TOKEN" \
             .
+
+      # Create + finalize a Sentry release tagged with the commit SHA.
+      # action-release uploads no source maps itself (the Vite plugin
+      # in the frontend stage of Dockerfile already pushed them under
+      # the same release name) — it just registers the release in
+      # Sentry's UI and associates commits, so the "Releases" view
+      # shows what's running and the "Suspect Commits" feature can
+      # finger a likely-culprit commit on a new error. Self-disables
+      # when SENTRY_AUTH_TOKEN is empty.
+      - name: Sentry frontend release
+        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' }}
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_FRONTEND }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        with:
+          environment: prod
+          version: ${{ github.sha }}
+          finalize: true
+          sourcemaps: ''
+
+      - name: Sentry backend release
+        if: ${{ secrets.SENTRY_AUTH_TOKEN != '' }}
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_BACKEND }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        with:
+          environment: prod
+          version: ${{ github.sha }}
+          finalize: true
+          sourcemaps: ''
 
   # Submit the Hex SBOM to GitHub's dependency-submission API after merge.
   # GitHub's static mix.lock parser silently fails on this repo (verified

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,38 @@ ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 # ─── Frontend build ──────────────────────────────────────────────────────
 FROM oven/bun:1.3 AS frontend
 
+# Build-args propagated from CI for Sentry wiring. All optional; the
+# Sentry React SDK + Vite plugin no-op when their env vars are unset,
+# so a build without these (local `docker build`, self-host) still
+# works.
+#   VITE_SENTRY_DSN — baked into the bundle; turns on Sentry.init in
+#       the browser.
+#   VITE_GIT_SHA    — release tag used by Sentry to symbolicate stack
+#       traces against the right source-map upload.
+#   SENTRY_ORG / SENTRY_PROJECT — used by @sentry/vite-plugin to
+#       address the right project when uploading source maps.
+ARG VITE_SENTRY_DSN
+ARG VITE_GIT_SHA
+ARG SENTRY_ORG
+ARG SENTRY_PROJECT
+ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN} \
+    VITE_GIT_SHA=${VITE_GIT_SHA} \
+    SENTRY_ORG=${SENTRY_ORG} \
+    SENTRY_PROJECT=${SENTRY_PROJECT}
+
 WORKDIR /frontend
 COPY frontend/package.json frontend/bun.lock ./
 # Bun global package cache survives across builds on self-hosted runners.
 RUN --mount=type=cache,target=/root/.bun/install/cache,id=bun-cache \
     bun install --frozen-lockfile
 COPY frontend/ ./
-RUN bun run build
+# `--mount=type=secret` is the leak-safe path for SENTRY_AUTH_TOKEN —
+# exposed as a tmpfs file readable only inside this RUN, never
+# persisted in image layers or `docker history`. The Vite plugin
+# self-disables if the token is missing, so this same `bun run build`
+# line is the no-op branch for builds without the secret.
+RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+    bun run build
 
 # ─── Elixir build ────────────────────────────────────────────────────────
 FROM ${BUILDER_IMAGE} AS builder

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.315",
+      version: "0.5.316",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Closes the Sentry plumbing started in #418 (backend SDK) + #420 (frontend SDK). Without this PR, the frontend SDK on prod has no DSN baked in and stays silent.

This PR:
- Bakes `VITE_SENTRY_DSN` + `VITE_GIT_SHA` into the prod frontend bundle via Docker build args
- Routes `SENTRY_AUTH_TOKEN` to the Vite plugin via `--mount=type=secret` so it never lands in image metadata
- Registers a Sentry release per project (frontend + backend) on every push to main, tagged with the commit SHA, so Suspect Commits + "what's running" views are accurate
- Posts a Discord ping to the existing `#alerts` webhook on `release-v*` deploys (success + failure)

## Files

| File | Change |
|---|---|
| `Dockerfile` (frontend stage) | new ARGs + ENVs for `VITE_SENTRY_DSN`, `VITE_GIT_SHA`, `SENTRY_ORG`, `SENTRY_PROJECT`; `--mount=type=secret` for `SENTRY_AUTH_TOKEN` |
| `.github/workflows/verify.yml` (`build-and-push-ecr`) | passes the four build-args + the secret to buildx; two `getsentry/action-release@v3` steps register releases. Both gated on `secrets.SENTRY_AUTH_TOKEN != ''` |
| `.github/workflows/deploy-prod.yml` | Discord notify on `success()` and `failure()` paths, gated on `DISCORD_DEPLOY_WEBHOOK_URL` being set |
| `mix.exs` | version bump |

## Required secrets / vars

| Name | Type | Status |
|---|---|---|
| `VITE_SENTRY_DSN` | secret | ✓ set |
| `DISCORD_DEPLOY_WEBHOOK_URL` | secret | ✓ set (reuses `#alerts` webhook; split into `#deploys` later) |
| `SENTRY_AUTH_TOKEN` | secret | **operator must add** — Sentry → Settings → Account → User Auth Tokens → scopes: `project:read`, `project:write`, `release:write`, `project:releases` |
| `SENTRY_ORG` | var | ✓ `engram-app` |
| `SENTRY_PROJECT_FRONTEND` | var | ✓ `engram-frontend` |
| `SENTRY_PROJECT_BACKEND` | var | ✓ `engram-backend` |

Until `SENTRY_AUTH_TOKEN` is added, the build succeeds but source maps are not uploaded (stack traces ship un-symbolicated) and no Sentry release is created. Both paths gracefully degrade.

## What this does NOT do

- **End-of-rollout notify.** Discord pings fire at "deploy initiated" (the engram-infra PR opens). Actual ECS rollout completes ~3-5 min later when `terraform (prod)` apply runs. End-of-rollout notify is Tier 3.
- **Backend release tagging at runtime.** Release record is created in Sentry, but the Elixir SDK doesn't read `RELEASE_SHA` yet, so backend events go in the "unknown release" bucket until a small follow-up adds `release: System.get_env("RELEASE_SHA")` to the prod block in `config/runtime.exs`. The release record itself is still useful (Suspect Commits, deploy markers).

## Test plan

- [ ] CI green.
- [ ] After merge + a `release-v*` tag push: Discord posts `[DEPLOY-INITIATED] release-vX.Y.Z → sha-xxx`.
- [ ] Pull ECR image, grep for `ingest.sentry.io` in `priv/static/app/assets/*.js` — should match the frontend DSN.
- [ ] After `SENTRY_AUTH_TOKEN` lands + next deploy: Sentry → Releases shows the SHA; sourcemaps uploaded; synthetic exception surfaces with a deminified stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)