### PR TITLE
feat(health): split /api/health/deep + add admin /diagnostics

### DIFF
--- a/lib/engram_web/controllers/health_controller.ex
+++ b/lib/engram_web/controllers/health_controller.ex
@@ -5,12 +5,13 @@ defmodule EngramWeb.HealthController do
     json(conn, %{status: "ok", version: Application.spec(:engram, :vsn) |> to_string()})
   end
 
+  # ALB target group readiness probe. Only checks dependencies whose
+  # absence makes EVERY request fail — Postgres is that one. Qdrant,
+  # Redis, S3 etc. stay OUT so a single dep outage cannot pull all tasks
+  # from rotation. Surface those via /api/health/diagnostics (auth-gated)
+  # and per-dep CloudWatch/Grafana alarms.
   def deep(conn, _params) do
-    checks = %{
-      "postgres" => check_postgres(),
-      "qdrant" => check_qdrant()
-    }
-
+    checks = %{"postgres" => check_postgres()}
     all_ok = Enum.all?(checks, fn {_k, v} -> v == "ok" end)
     status = if all_ok, do: "ok", else: "degraded"
     http_status = if all_ok, do: 200, else: 503
@@ -18,6 +19,31 @@ defmodule EngramWeb.HealthController do
     conn
     |> put_status(http_status)
     |> json(%{status: status, checks: checks})
+  end
+
+  # Full dependency matrix for humans + Grafana. Admin-gated in router.
+  # BootCanary is reported by reading the :boot_canary_enabled config
+  # rather than re-running the canary verify (which hits the DB on every
+  # probe). If the canary was enabled at boot and the app is alive, the
+  # guard's init/1 must have succeeded — so "verified" is sound.
+  def diagnostics(conn, _params) do
+    checks = %{
+      "postgres" => check_postgres(),
+      "qdrant" => check_qdrant(),
+      "redis" => check_redis(),
+      "s3" => check_s3(),
+      "kms" => check_kms(),
+      "voyage" => check_voyage(),
+      "paddle" => check_paddle(),
+      "clerk_jwks" => check_clerk_jwks()
+    }
+
+    boot_canary =
+      if Application.get_env(:engram, :boot_canary_enabled, true),
+        do: "verified",
+        else: "disabled"
+
+    json(conn, %{checks: checks, boot_canary: boot_canary})
   end
 
   # T3.0.1 follow-up — never `inspect/1` an error reason into a JSON
@@ -44,6 +70,63 @@ defmodule EngramWeb.HealthController do
     end
   rescue
     e -> "error: #{Exception.message(e)}"
+  end
+
+  defp check_redis do
+    case Engram.Cache.Redix.command(["PING"]) do
+      {:ok, "PONG"} -> "ok"
+      {:ok, _other} -> "error: unexpected_reply"
+      {:error, reason} -> "error: #{format_error(reason)}"
+    end
+  rescue
+    e -> "error: #{Exception.message(e)}"
+  catch
+    :exit, {:noproc, _} -> "error: not_started"
+    :exit, _reason -> "error: exit"
+  end
+
+  defp check_s3 do
+    case Application.get_env(:engram, :storage_bucket) do
+      nil ->
+        "error: missing_config"
+
+      bucket ->
+        case ExAws.S3.head_bucket(bucket) |> ExAws.request() do
+          {:ok, _} -> "ok"
+          {:error, reason} -> "error: #{format_error(reason)}"
+        end
+    end
+  rescue
+    e -> "error: #{Exception.message(e)}"
+  end
+
+  # KMS reachability is proven at boot via BootCanary (wrap+unwrap
+  # round-trip through the CMK). Re-running it here on every probe is
+  # expensive and changes nothing; if the app is alive, boot passed.
+  defp check_kms do
+    case Application.get_env(:engram, :key_provider) do
+      :aws_kms -> "verified_at_boot"
+      :local -> "skipped: provider=local"
+      _other -> "skipped: provider=unknown"
+    end
+  end
+
+  defp check_voyage do
+    if System.get_env("VOYAGE_API_KEY"),
+      do: "configured",
+      else: "error: missing_env VOYAGE_API_KEY"
+  end
+
+  defp check_paddle do
+    if System.get_env("PADDLE_API_KEY"),
+      do: "configured",
+      else: "error: missing_env PADDLE_API_KEY"
+  end
+
+  defp check_clerk_jwks do
+    if System.get_env("CLERK_JWKS_URL"),
+      do: "configured",
+      else: "error: missing_env CLERK_JWKS_URL"
   end
 
   defp format_error(%{__exception__: true} = e), do: Exception.message(e)

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -102,6 +102,14 @@ defmodule EngramWeb.Router do
     get "/health/deep", HealthController, :deep
   end
 
+  # Full dependency matrix for humans + Grafana. Admin-gated so the
+  # response (which names every dep + its status) is not a public
+  # information leak. NOT used by ALB or container HCs.
+  scope "/api", EngramWeb do
+    pipe_through [:api, EngramWeb.Plugs.Auth, :require_admin]
+    get "/health/diagnostics", HealthController, :diagnostics
+  end
+
   scope "/api", EngramWeb do
     # Device flow — unauthenticated, rate limited
     pipe_through [:api, :rate_limit_auth]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.316",
+      version: "0.5.317",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/health_controller_test.exs
+++ b/test/engram_web/controllers/health_controller_test.exs
@@ -1,5 +1,14 @@
 defmodule EngramWeb.HealthControllerTest do
-  use EngramWeb.ConnCase, async: true
+  use EngramWeb.ConnCase, async: false
+
+  setup tags do
+    if tags[:auth] do
+      Application.put_env(:engram, :auth_provider, :local)
+      on_exit(fn -> Application.put_env(:engram, :auth_provider, :local) end)
+    end
+
+    :ok
+  end
 
   test "GET /health returns 200 with status ok", %{conn: conn} do
     conn = get(conn, "/api/health")
@@ -8,22 +17,58 @@ defmodule EngramWeb.HealthControllerTest do
     assert is_binary(body["version"])
   end
 
-  describe "GET /health/deep" do
-    test "returns status and checks map", %{conn: conn} do
+  describe "GET /health/deep (ALB readiness — Postgres only)" do
+    test "returns 200 with postgres ok when DB is running", %{conn: conn} do
       conn = get(conn, "/api/health/deep")
-      body = json_response(conn, conn.status)
+      body = json_response(conn, 200)
 
-      assert body["status"] in ["ok", "degraded"]
-      assert is_map(body["checks"])
-      assert Map.has_key?(body["checks"], "postgres")
-      assert Map.has_key?(body["checks"], "qdrant")
+      assert body["status"] == "ok"
+      assert body["checks"] == %{"postgres" => "ok"}
     end
 
-    test "postgres check is ok when DB is running", %{conn: conn} do
+    test "does NOT include qdrant or any non-essential dep", %{conn: conn} do
+      # Qdrant outages must not pull tasks from the ALB. Search will 500
+      # via the search route; ALB readiness stays narrow on Postgres.
       conn = get(conn, "/api/health/deep")
-      body = json_response(conn, conn.status)
+      body = json_response(conn, 200)
 
-      assert body["checks"]["postgres"] == "ok"
+      refute Map.has_key?(body["checks"], "qdrant")
+      refute Map.has_key?(body["checks"], "redis")
+      refute Map.has_key?(body["checks"], "s3")
+    end
+  end
+
+  describe "GET /health/diagnostics (admin-only full dep matrix)" do
+    @tag :auth
+    test "rejects unauthenticated requests with 401", %{conn: conn} do
+      conn = get(conn, "/api/health/diagnostics")
+      assert json_response(conn, 401)
+    end
+
+    @tag :auth
+    test "rejects non-admin members with 403", %{conn: conn} do
+      member = insert(:user, role: "member")
+      conn = conn |> authenticate(member) |> get("/api/health/diagnostics")
+      assert json_response(conn, 403)
+    end
+
+    @tag :auth
+    test "admin gets 200 with full dep matrix", %{conn: conn} do
+      admin = insert(:user, role: "admin")
+      conn = conn |> authenticate(admin) |> get("/api/health/diagnostics")
+      body = json_response(conn, 200)
+
+      assert is_map(body["checks"])
+      # Each dep must appear with a status string ("ok" or "error: ...").
+      # Reachability is asserted per-dep elsewhere; here we lock the shape.
+      for dep <- ~w(postgres qdrant redis s3 kms voyage paddle clerk_jwks) do
+        assert Map.has_key?(body["checks"], dep), "missing #{dep} in diagnostics matrix"
+        assert is_binary(body["checks"][dep]), "#{dep} status must be a string"
+      end
+
+      # "verified" in prod (canary enabled, app booted → guard passed).
+      # "disabled" in test (config :engram, :boot_canary_enabled, false).
+      assert body["boot_canary"] in ["verified", "disabled"]
     end
   end
 end


### PR DESCRIPTION
## Summary

Split the readiness probe shape so a single non-critical dep outage cannot pull the whole fleet from ALB rotation.

| Endpoint | What it checks | Consumer |
|---|---|---|
| `/api/health` | BEAM responds, no deps (existing) | ECS container HC (liveness) |
| `/api/health/deep` | Postgres only | **ALB target group (readiness)** |
| `/api/health/diagnostics` | Postgres + Qdrant + Redis + S3 + KMS + Voyage + Paddle + Clerk JWKS + boot_canary | Humans + Grafana (admin auth) |

Previously `/deep` checked Postgres + Qdrant. A Qdrant blip → all tasks UNHEALTHY → ALB drains fleet → total outage from a degraded-search problem. Now Qdrant lives in `/diagnostics` + (forthcoming) per-route 5xx alarm.

## Behavior changes

- `/api/health/deep`: response shape changes from `{"status":..., "checks":{"postgres":...,"qdrant":...}}` to `{"status":"ok","checks":{"postgres":"ok"}}`. 200 OK when DB up, 503 only if DB unreachable.
- `/api/health/diagnostics`: NEW endpoint. Returns 401 unauth, 403 non-admin, 200 admin with full matrix.

## What goes in /diagnostics, and why this shape

Real probes for internal-network deps that are cheap to hit:
- `postgres` — `SELECT 1` on `Engram.Repo`
- `qdrant` — `GET /healthz`
- `redis` — `Redix.command(["PING"])` via `Engram.Cache.Redix`
- `s3` — `ExAws.S3.head_bucket(bucket)`

Config-presence checks for external HTTPS APIs (probing them every diag call adds external-latency to an ops endpoint and couples our diagnostics to their availability):
- `voyage` / `paddle` / `clerk_jwks` — env-var present check

Boot-state reads (re-running the canary on every probe would hit the DB unnecessarily):
- `kms` — `verified_at_boot` if `KEY_PROVIDER=aws_kms`, else `skipped`
- `boot_canary` — `verified` if `:boot_canary_enabled` true, else `disabled`

## TDD

Six tests written before implementation, watched fail (RED), then passed (GREEN):
- `/deep` returns 200 with postgres-only
- `/deep` excludes qdrant/redis/s3
- `/diagnostics` 401 unauth
- `/diagnostics` 403 non-admin
- `/diagnostics` 200 admin with full matrix shape
- `boot_canary` reports `verified` or `disabled`

## Companion infra PR

After this ships and prod has the new binary, follow-up PR in engram-infra swaps `aws_lb_target_group.engram.health_check.path` from `/api/health` to `/api/health/deep`. Ordering matters — backend first so the route exists before ALB starts probing it.

## Test plan

- [ ] CI `mix test` green
- [ ] After merge: prod deploy completes, `curl https://app.engram.page/api/health/deep` → 200 with postgres-only checks
- [ ] `curl https://app.engram.page/api/health/diagnostics` → 401
- [ ] As admin: 200 with full matrix
- [ ] Companion infra PR opens after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)