### PR TITLE
feat(observability): Cloudflare Web Analytics beacon + close CSP gap for Sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,3 +101,9 @@ STORAGE_REGION=us-east-1
 #     SENTRY_AUTH_TOKEN=
 #     SENTRY_ORG=engram-app
 #     SENTRY_PROJECT=engram-frontend
+
+# ─── Optional: Cloudflare Web Analytics (cookieless RUM) ─────────────────────
+#   Vite build env (no-op when unset; baked into bundle):
+#     VITE_CF_BEACON_TOKEN=<32-char hex from CF dashboard>
+#   Self-host builds leave it unset → no beacon, no telemetry to engram's CF
+#   account.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2447,6 +2447,11 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT_FRONTEND: ${{ vars.SENTRY_PROJECT_FRONTEND }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Cloudflare Web Analytics beacon — cookieless RUM. Public
+          # per-site identifier, so a plain build-arg is fine; the
+          # secret name is set to keep self-host bundles from shipping
+          # the SaaS token.
+          VITE_CF_BEACON_TOKEN: ${{ secrets.VITE_CF_BEACON_TOKEN }}
         run: |
           TAGS=(--tag "$REPO:$SHA_TAG")
           if [ -n "$VTAG" ]; then
@@ -2464,6 +2469,7 @@ jobs:
             --build-arg "VITE_GIT_SHA=${VITE_GIT_SHA}" \
             --build-arg "SENTRY_ORG=${SENTRY_ORG}" \
             --build-arg "SENTRY_PROJECT=${SENTRY_PROJECT_FRONTEND}" \
+            --build-arg "VITE_CF_BEACON_TOKEN=${VITE_CF_BEACON_TOKEN}" \
             --secret "id=sentry_auth_token,env=SENTRY_AUTH_TOKEN" \
             .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,14 @@ ARG VITE_SENTRY_DSN
 ARG VITE_GIT_SHA
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT
+# Cloudflare Web Analytics beacon — public per-site identifier.
+# Build-arg so self-host bundles don't ship the SaaS-side token.
+ARG VITE_CF_BEACON_TOKEN
 ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN} \
     VITE_GIT_SHA=${VITE_GIT_SHA} \
     SENTRY_ORG=${SENTRY_ORG} \
-    SENTRY_PROJECT=${SENTRY_PROJECT}
+    SENTRY_PROJECT=${SENTRY_PROJECT} \
+    VITE_CF_BEACON_TOKEN=${VITE_CF_BEACON_TOKEN}
 
 WORKDIR /frontend
 COPY frontend/package.json frontend/bun.lock ./

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -29,6 +29,21 @@ if (sentryDsn) {
   })
 }
 
+// Cloudflare Web Analytics — cookieless RUM beacon. Opt-in via
+// VITE_CF_BEACON_TOKEN at build time; no-op when unset so dev /
+// self-host builds don't ping the SaaS-side CF analytics account.
+// Injected dynamically rather than as a static <script> in
+// index.html because the token only exists on the SaaS build path
+// (self-host's same bundle would otherwise embed it as a literal).
+const cfBeaconToken = import.meta.env.VITE_CF_BEACON_TOKEN
+if (cfBeaconToken) {
+  const s = document.createElement('script')
+  s.defer = true
+  s.src = 'https://static.cloudflareinsights.com/beacon.min.js'
+  s.setAttribute('data-cf-beacon', JSON.stringify({ token: cfBeaconToken }))
+  document.head.appendChild(s)
+}
+
 const isClerk = config.authProvider === 'clerk'
 
 const AuthProvider = isClerk

--- a/lib/engram_web/csp.ex
+++ b/lib/engram_web/csp.ex
@@ -77,7 +77,8 @@ defmodule EngramWeb.CSP do
       clerk_directives(),
       paddle_directives(),
       turnstile_directives(),
-      cloudflare_insights_directives()
+      cloudflare_insights_directives(),
+      sentry_directives()
     ]
   end
 
@@ -200,6 +201,29 @@ defmodule EngramWeb.CSP do
 
     %{
       "script-src" => hosts,
+      "connect-src" => hosts
+    }
+  end
+
+  # Sentry error reporting (browser SDK).
+  #
+  # The SDK itself ships bundled in the SPA (no extra script-src host),
+  # but every captured event POSTs to the project's ingest host on
+  # `*.ingest.sentry.io`, and Sentry uses regional shards (us / eu) so
+  # the wildcard is necessary. Without this `connect-src` entry the
+  # browser blocks the POST and exceptions never reach Sentry — a
+  # silent-success failure mode where the SDK reports "queued" but the
+  # event evaporates at the CSP gate.
+  #
+  # Unconditionally on because the frontend bundle is the same for
+  # SaaS + self-host; the actual `Sentry.init` call is gated on
+  # `VITE_SENTRY_DSN`, and self-host builds without the DSN never
+  # produce any traffic to this host. CSP is a static allow-list and
+  # gains nothing from runtime gating.
+  defp sentry_directives do
+    hosts = ["https://*.ingest.sentry.io"]
+
+    %{
       "connect-src" => hosts
     }
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.317",
+      version: "0.5.318",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/csp_test.exs
+++ b/test/engram_web/csp_test.exs
@@ -69,6 +69,19 @@ defmodule EngramWeb.CSPTest do
       assert script_src(header) =~ "https://static.cloudflareinsights.com"
       assert connect_src(header) =~ "https://static.cloudflareinsights.com"
     end
+
+    test "always whitelists Sentry ingest hosts on connect-src" do
+      # Sentry browser SDK is bundled (no script-src host needed) but
+      # captured events POST to `*.ingest.sentry.io`. Without this
+      # entry the SDK silently fails — the network POST returns blocked
+      # by CSP, no error reaches `Sentry.captureException`'s caller,
+      # and prod errors evaporate at the CSP gate.
+      Application.put_env(:engram, :clerk_issuer, nil)
+
+      header = CSP.header()
+
+      assert connect_src(header) =~ "https://*.ingest.sentry.io"
+    end
   end
 
   describe "Clerk integration — dev/test instance (CLERK_ISSUER under *.clerk.accounts.dev)" do


### PR DESCRIPTION
## Summary

PR6 of the Tier 1 observability rollout. Two related changes:
1. Cloudflare Web Analytics beacon (cookieless RUM) on the SaaS build.
2. **Critical follow-up to #420 / #421:** closes the CSP gap that was silently dropping Sentry browser events at the CSP gate — the SDK reported queued but the POST was blocked.

## Files

| File | Change |
|---|---|
| `frontend/src/main.tsx` | Dynamic `<script>` inject when `VITE_CF_BEACON_TOKEN` is set at build time. Mirrors the `VITE_SENTRY_DSN` no-op pattern from #420. |
| `Dockerfile` (frontend stage) | New `ARG VITE_CF_BEACON_TOKEN` + ENV. |
| `.github/workflows/verify.yml` (build-and-push-ecr) | New `--build-arg "VITE_CF_BEACON_TOKEN=…"`. |
| `lib/engram_web/csp.ex` | New `sentry_directives/0` adds `https://*.ingest.sentry.io` to `connect-src`. The CF Insights directives function was already in place from a prior CSP pass. |
| `test/engram_web/csp_test.exs` | Regression test: `connect_src(header) =~ "https://*.ingest.sentry.io"`. Function-of-env-var, not literal-pin, per the module's test contract. |

## Why the Sentry CSP fix matters

Sentry browser SDK was shipped in #420 and the DSN was baked into the bundle in #421. Both PRs deployed to prod with `release-v0.5.316` — but `connect-src` didn't include `*.ingest.sentry.io`, so every event POST was silently blocked by CSP. Errors evaporated; the SDK never threw because POST failures in fetch don't surface to `Sentry.captureException`'s caller.

Without this PR, "Sentry is wired" is technically true but functionally false.

## Required secrets

| Name | Type | Status |
|---|---|---|
| `VITE_CF_BEACON_TOKEN` | secret | ✓ set (32-char hex from CF dashboard) |

## What this does NOT do

- **No proxy-mode upgrade.** `app.engram.page` stays DNS-only on Cloudflare. Switching to proxied (orange-cloud) would auto-inject the beacon + unlock WAF / edge cache, but it's a separate decision with WebSocket + ACM cert implications.
- **No PostHog yet.** That's PR7.

## Test plan

- [ ] CI green (lint, unit-tests, e2e, frontend audit).
- [ ] After merge + deploy: load `app.engram.page`, DevTools → Network → `beacon.min.js` from `static.cloudflareinsights.com` shows 200, plus a follow-up POST to `cloudflareinsights.com`.
- [ ] DevTools → Console: no `Refused to connect` CSP errors for `*.ingest.sentry.io`.
- [ ] Trigger a synthetic exception in prod (browser console: `throw new Error("smoke")` inside the React tree) → Sentry receives it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)