### PR TITLE
feat(observability): PostHog SDK (frontend + backend) + Clerk identify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,3 +107,14 @@ STORAGE_REGION=us-east-1
 #     VITE_CF_BEACON_TOKEN=<32-char hex from CF dashboard>
 #   Self-host builds leave it unset → no beacon, no telemetry to engram's CF
 #   account.
+
+# ─── Optional: PostHog product analytics ─────────────────────────────────────
+#   Backend (Elixir wrapper; no-op when unset):
+#     POSTHOG_API_KEY=phc_…            # project token (write-only ingest)
+#     POSTHOG_HOST=https://us.i.posthog.com   # or https://eu.i.posthog.com
+#   Frontend (Vite build env; no-op when unset, baked into bundle):
+#     VITE_POSTHOG_KEY=phc_…
+#     VITE_POSTHOG_HOST=https://us.i.posthog.com
+#   Self-host leaves all four unset → no telemetry to engram's PostHog account.
+#   Autocapture is hard-coded OFF; explicit events only (note_created,
+#   search_performed, vault_opened, subscription_started — see PR8).

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2452,6 +2452,11 @@ jobs:
           # secret name is set to keep self-host bundles from shipping
           # the SaaS token.
           VITE_CF_BEACON_TOKEN: ${{ secrets.VITE_CF_BEACON_TOKEN }}
+          # PostHog product analytics — public project token (write-only
+          # event ingest, per-project). Host defaults to us.i.posthog.com
+          # in main.tsx if VITE_POSTHOG_HOST is unset.
+          VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
         run: |
           TAGS=(--tag "$REPO:$SHA_TAG")
           if [ -n "$VTAG" ]; then
@@ -2470,6 +2475,8 @@ jobs:
             --build-arg "SENTRY_ORG=${SENTRY_ORG}" \
             --build-arg "SENTRY_PROJECT=${SENTRY_PROJECT_FRONTEND}" \
             --build-arg "VITE_CF_BEACON_TOKEN=${VITE_CF_BEACON_TOKEN}" \
+            --build-arg "VITE_POSTHOG_KEY=${VITE_POSTHOG_KEY}" \
+            --build-arg "VITE_POSTHOG_HOST=${VITE_POSTHOG_HOST}" \
             --secret "id=sentry_auth_token,env=SENTRY_AUTH_TOKEN" \
             .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,17 @@ ARG SENTRY_PROJECT
 # Cloudflare Web Analytics beacon — public per-site identifier.
 # Build-arg so self-host bundles don't ship the SaaS-side token.
 ARG VITE_CF_BEACON_TOKEN
+# PostHog — public project token (write-only event ingest, per-project).
+# Same self-host-shouldn't-emit-to-SaaS rationale as the CF beacon.
+ARG VITE_POSTHOG_KEY
+ARG VITE_POSTHOG_HOST
 ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN} \
     VITE_GIT_SHA=${VITE_GIT_SHA} \
     SENTRY_ORG=${SENTRY_ORG} \
     SENTRY_PROJECT=${SENTRY_PROJECT} \
-    VITE_CF_BEACON_TOKEN=${VITE_CF_BEACON_TOKEN}
+    VITE_CF_BEACON_TOKEN=${VITE_CF_BEACON_TOKEN} \
+    VITE_POSTHOG_KEY=${VITE_POSTHOG_KEY} \
+    VITE_POSTHOG_HOST=${VITE_POSTHOG_HOST}
 
 WORKDIR /frontend
 COPY frontend/package.json frontend/bun.lock ./

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -614,3 +614,15 @@ if dsn = System.get_env("SENTRY_DSN") do
     # ignore transaction telemetry entirely.
     traces_sample_rate: nil
 end
+
+# PostHog server-side capture (Engram.Observability.PostHog).
+# Same opt-in shape as Sentry: no-op when POSTHOG_API_KEY is unset,
+# so dev/test/self-host emit no telemetry and the wrapper module
+# short-circuits before any network call. distinct_id matches the
+# frontend's posthog.identify(clerk_user_id) so funnels join across
+# the user timeline.
+if key = System.get_env("POSTHOG_API_KEY") do
+  config :engram,
+    posthog_key: key,
+    posthog_host: System.get_env("POSTHOG_HOST", "https://us.i.posthog.com")
+end

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -30,6 +30,7 @@
         "mermaid": "^11.15.0",
         "next-themes": "^0.4.6",
         "phoenix": "^1.8.7",
+        "posthog-js": "^1.379.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -264,6 +265,28 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "http://10.0.20.214:4873/@open-draft/until/-/until-2.1.0.tgz", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "http://10.0.20.214:4873/@opentelemetry/api/-/api-1.9.1.tgz", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.208.0", "http://10.0.20.214:4873/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.2.0", "http://10.0.20.214:4873/@opentelemetry/core/-/core-2.2.0.tgz", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.208.0", "http://10.0.20.214:4873/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/sdk-logs": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.208.0", "http://10.0.20.214:4873/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.208.0", "http://10.0.20.214:4873/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.208.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "http://10.0.20.214:4873/@opentelemetry/resources/-/resources-2.7.1.tgz", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.208.0", "http://10.0.20.214:4873/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "http://10.0.20.214:4873/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "http://10.0.20.214:4873/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "http://10.0.20.214:4873/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
     "@oxc-project/types": ["@oxc-project/types@0.132.0", "http://10.0.20.214:4873/@oxc-project/types/-/types-0.132.0.tgz", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
 
     "@paddle/paddle-js": ["@paddle/paddle-js@1.6.4", "http://10.0.20.214:4873/@paddle/paddle-js/-/paddle-js-1.6.4.tgz", {}, "sha512-ncfnS6I8mCX6krZ3Sgz2iAYivGmhdI81yt9mT6prtPj4Ipd9J3M12LCJRUFL4FB7BYeeuV04c33RSEnbZUBCaA=="],
@@ -273,6 +296,30 @@
     "@polka/url": ["@polka/url@1.0.0-next.29", "http://10.0.20.214:4873/@polka/url/-/url-1.0.0-next.29.tgz", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@portaljs/remark-callouts": ["@portaljs/remark-callouts@1.0.5", "http://10.0.20.214:4873/@portaljs/remark-callouts/-/remark-callouts-1.0.5.tgz", { "dependencies": { "mdast-util-from-markdown": "^1.2.0", "svg-parser": "^2.0.4", "unist-util-visit": "^4.1.0" } }, "sha512-KMjr44isEvQzpNBBCP3s5/3TCmI/ce4xRvbOk6h9xicVZqE6BPTH9rhfOGvop9cchyAWgj9gmJXhQk+Bd+t5bg=="],
+
+    "@posthog/core": ["@posthog/core@1.30.3", "http://10.0.20.214:4873/@posthog/core/-/core-1.30.3.tgz", { "dependencies": { "@posthog/types": "1.379.0" } }, "sha512-mGIN4Du1a8fKxV5WfnEtogq3VOQLa4PfWMUg5uMIMDD+fp5bhTA4QG4oYAea4vBTZ1ZOanQbjXcX4b5k2X93Qw=="],
+
+    "@posthog/types": ["@posthog/types@1.379.0", "http://10.0.20.214:4873/@posthog/types/-/types-1.379.0.tgz", {}, "sha512-QJLzyV22iZKy5eEXKn9IB1swSVo2JigIawebBha+BmsePsY3XA0HAcq2B+D8Km5BHnbE+SGm5aHxFG3DlVE1yg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "http://10.0.20.214:4873/@protobufjs/aspromise/-/aspromise-1.1.2.tgz", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "http://10.0.20.214:4873/@protobufjs/base64/-/base64-1.1.2.tgz", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "http://10.0.20.214:4873/@protobufjs/codegen/-/codegen-2.0.5.tgz", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "http://10.0.20.214:4873/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "http://10.0.20.214:4873/@protobufjs/fetch/-/fetch-1.1.1.tgz", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "http://10.0.20.214:4873/@protobufjs/float/-/float-1.0.2.tgz", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "http://10.0.20.214:4873/@protobufjs/inquire/-/inquire-1.1.2.tgz", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "http://10.0.20.214:4873/@protobufjs/path/-/path-1.1.2.tgz", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "http://10.0.20.214:4873/@protobufjs/pool/-/pool-1.1.0.tgz", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "http://10.0.20.214:4873/@protobufjs/utf8/-/utf8-1.1.1.tgz", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "http://10.0.20.214:4873/@radix-ui/number/-/number-1.1.1.tgz", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -818,6 +865,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "http://10.0.20.214:4873/cookie-signature/-/cookie-signature-1.2.2.tgz", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.49.0", "http://10.0.20.214:4873/core-js/-/core-js-3.49.0.tgz", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "core-util-is": ["core-util-is@1.0.3", "http://10.0.20.214:4873/core-util-is/-/core-util-is-1.0.3.tgz", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cors": ["cors@2.8.6", "http://10.0.20.214:4873/cors/-/cors-2.8.6.tgz", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
@@ -1348,6 +1397,8 @@
 
     "log-symbols": ["log-symbols@6.0.0", "http://10.0.20.214:4873/log-symbols/-/log-symbols-6.0.0.tgz", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
+    "long": ["long@5.3.2", "http://10.0.20.214:4873/long/-/long-5.3.2.tgz", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "longest-streak": ["longest-streak@3.1.0", "http://10.0.20.214:4873/longest-streak/-/longest-streak-3.1.0.tgz", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lowercase-keys": ["lowercase-keys@1.0.1", "http://10.0.20.214:4873/lowercase-keys/-/lowercase-keys-1.0.1.tgz", {}, "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="],
@@ -1648,7 +1699,11 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "http://10.0.20.214:4873/postgres-interval/-/postgres-interval-1.2.0.tgz", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "posthog-js": ["posthog-js@1.379.0", "http://10.0.20.214:4873/posthog-js/-/posthog-js-1.379.0.tgz", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.30.3", "@posthog/types": "1.379.0", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-cSESmnPvIaY/pyhV5a6pF00q8tqmXlJBQWX9T7dbBh9TXhVM5oQVi7g77vWGD9G8wq4iNF5ZOxqeAK9dpOSOYg=="],
+
     "powershell-utils": ["powershell-utils@0.1.0", "http://10.0.20.214:4873/powershell-utils/-/powershell-utils-0.1.0.tgz", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "preact": ["preact@10.29.2", "http://10.0.20.214:4873/preact/-/preact-10.29.2.tgz", {}, "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="],
 
     "prepend-http": ["prepend-http@1.0.4", "http://10.0.20.214:4873/prepend-http/-/prepend-http-1.0.4.tgz", {}, "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg=="],
 
@@ -1666,6 +1721,8 @@
 
     "proto-list": ["proto-list@1.2.4", "http://10.0.20.214:4873/proto-list/-/proto-list-1.2.4.tgz", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
+    "protobufjs": ["protobufjs@7.6.2", "http://10.0.20.214:4873/protobufjs/-/protobufjs-7.6.2.tgz", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
+
     "proxy-addr": ["proxy-addr@2.0.7", "http://10.0.20.214:4873/proxy-addr/-/proxy-addr-2.0.7.tgz", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "http://10.0.20.214:4873/proxy-from-env/-/proxy-from-env-1.1.0.tgz", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -1675,6 +1732,8 @@
     "pump": ["pump@3.0.4", "http://10.0.20.214:4873/pump/-/pump-3.0.4.tgz", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "qs": ["qs@6.15.2", "http://10.0.20.214:4873/qs/-/qs-6.15.2.tgz", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "http://10.0.20.214:4873/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "query-string": ["query-string@5.1.1", "http://10.0.20.214:4873/query-string/-/query-string-5.1.1.tgz", { "dependencies": { "decode-uri-component": "^0.2.0", "object-assign": "^4.1.0", "strict-uri-encode": "^1.0.0" } }, "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw=="],
 
@@ -2012,6 +2071,8 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "http://10.0.20.214:4873/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
+    "web-vitals": ["web-vitals@5.3.0", "http://10.0.20.214:4873/web-vitals/-/web-vitals-5.3.0.tgz", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
+
     "webidl-conversions": ["webidl-conversions@3.0.1", "http://10.0.20.214:4873/webidl-conversions/-/webidl-conversions-3.0.1.tgz", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "http://10.0.20.214:4873/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
@@ -2067,6 +2128,16 @@
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "http://10.0.20.214:4873/execa/-/execa-5.1.1.tgz", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "http://10.0.20.214:4873/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "http://10.0.20.214:4873/@opentelemetry/resources/-/resources-2.2.0.tgz", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "http://10.0.20.214:4873/@opentelemetry/core/-/core-2.7.1.tgz", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "http://10.0.20.214:4873/@opentelemetry/resources/-/resources-2.2.0.tgz", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "http://10.0.20.214:4873/@opentelemetry/resources/-/resources-2.2.0.tgz", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "http://10.0.20.214:4873/@opentelemetry/resources/-/resources-2.2.0.tgz", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
     "@sentry/bundler-plugin-core/dotenv": ["dotenv@16.6.1", "http://10.0.20.214:4873/dotenv/-/dotenv-16.6.1.tgz", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -2321,6 +2392,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "http://10.0.20.214:4873/lru-cache/-/lru-cache-11.5.1.tgz", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "http://10.0.20.214:4873/fsevents/-/fsevents-2.3.2.tgz", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "posthog-js/fflate": ["fflate@0.4.8", "http://10.0.20.214:4873/fflate/-/fflate-0.4.8.tgz", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "http://10.0.20.214:4873/kleur/-/kleur-3.0.3.tgz", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "mermaid": "^11.15.0",
     "next-themes": "^0.4.6",
     "phoenix": "^1.8.7",
+    "posthog-js": "^1.379.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/frontend/src/auth/clerk-auth-provider.tsx
+++ b/frontend/src/auth/clerk-auth-provider.tsx
@@ -1,6 +1,7 @@
 import { ClerkProvider, useAuth, useClerk } from "@clerk/react"
 import { dark } from "@clerk/themes"
 import { useCallback, useEffect, useMemo } from 'react'
+import posthog from 'posthog-js'
 import { AuthContext, type AuthAdapter } from './auth-context'
 import { rememberSignupUser } from './signup-rejection'
 import { useClearQueryCacheOnUserChange } from './use-clear-query-cache-on-user-change'
@@ -72,6 +73,20 @@ function ClerkAdapterInner({ children }: { children: React.ReactNode }) {
 
   const email = clerk.user?.primaryEmailAddress?.emailAddress
   const imageUrl = clerk.user?.imageUrl
+
+  // PostHog identify on auth resolved, reset on sign-out. Firing
+  // `identify` is what binds the anonymous device's prior events to
+  // the real user — missing this step is the single most-common
+  // PostHog integration bug per [[project_observability_stack_plan]].
+  // No-op when PostHog isn't initialized (VITE_POSTHOG_KEY unset).
+  useEffect(() => {
+    if (!isLoaded) return
+    if (isSignedIn && clerkUserId) {
+      posthog.identify(clerkUserId, email ? { email } : undefined)
+    } else if (!isSignedIn) {
+      posthog.reset()
+    }
+  }, [isLoaded, isSignedIn, clerkUserId, email])
   const adapter: AuthAdapter = useMemo(
     () => ({
       isLoaded,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router'
 import { QueryClientProvider } from '@tanstack/react-query'
 import * as Sentry from '@sentry/react'
+import posthog from 'posthog-js'
 import { Toaster } from '@/components/ui/sonner'
 import { router } from './router'
 import { queryClient } from './api/query-client'
@@ -42,6 +43,28 @@ if (cfBeaconToken) {
   s.src = 'https://static.cloudflareinsights.com/beacon.min.js'
   s.setAttribute('data-cf-beacon', JSON.stringify({ token: cfBeaconToken }))
   document.head.appendChild(s)
+}
+
+// PostHog — product analytics. Cookieless by `persistence: 'memory'`
+// per [[reference_cookie_audit_2026_05_24]] so the no-banner launch
+// posture holds. Autocapture is OFF — explicit events only (see PR8)
+// is the single biggest cost lever on the free tier, per
+// [[project_observability_stack_plan]]. The identify call happens in
+// the Clerk auth provider as soon as the user resolves, NOT here —
+// firing it pre-auth would burn a permanent anonymous distinct_id.
+const posthogKey = import.meta.env.VITE_POSTHOG_KEY
+const posthogHost = import.meta.env.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com'
+if (posthogKey) {
+  posthog.init(posthogKey, {
+    api_host: posthogHost,
+    persistence: 'memory',
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    disable_session_recording: true,
+    // Honor the browser's DNT signal as belt-and-suspenders.
+    respect_dnt: true,
+  })
 }
 
 const isClerk = config.authProvider === 'clerk'

--- a/lib/engram/observability/posthog.ex
+++ b/lib/engram/observability/posthog.ex
@@ -34,8 +34,11 @@ defmodule Engram.Observability.PostHog do
         # Task.start/1 — detached, no supervisor wiring needed.
         # Failure here must not propagate to the caller (a webhook
         # handler, a request pipeline, an Oban worker), so we don't
-        # link the spawn.
-        Task.start(fn -> do_capture(key, host, distinct_id, event, properties) end)
+        # link the spawn. The `{:ok, pid}` is intentionally ignored;
+        # explicit underscore so Dialyzer's `unmatched_returns` is
+        # satisfied (the value is never useful to a fire-and-forget
+        # caller).
+        _ = Task.start(fn -> do_capture(key, host, distinct_id, event, properties) end)
         :ok
 
       :disabled ->

--- a/lib/engram/observability/posthog.ex
+++ b/lib/engram/observability/posthog.ex
@@ -1,0 +1,80 @@
+defmodule Engram.Observability.PostHog do
+  @moduledoc """
+  Server-side PostHog event emitter. Thin wrapper around the
+  capture endpoint; no Hex dep — Req is already in the tree.
+
+  No-op when `:engram, :posthog_key` is unset (self-host, dev, test).
+  Fire-and-forget: the caller never blocks on the POST, and failures
+  are logged at `:warning` but don't propagate. Missing analytics
+  events must never break the request that emitted them.
+
+  The frontend's `posthog.identify(clerk_user_id, ...)` (see
+  `auth/clerk-auth-provider.tsx`) binds anonymous device events to
+  the user's distinct_id. Server-side events use the same
+  distinct_id so funnels join across the timeline. PR8 wires the
+  call sites (`note_created`, `search_performed`,
+  `vault_opened`, `subscription_started`) and the Clerk/Paddle
+  webhook forwarders that depend on this module.
+  """
+
+  require Logger
+
+  @capture_path "/capture/"
+
+  @doc """
+  Send an event to PostHog. `distinct_id` should match the
+  frontend's `posthog.identify(...)` value — for SaaS users that's
+  the Clerk user id; for anonymous flows pass `:anon` and PostHog
+  buckets the event under a fallback id.
+  """
+  @spec capture(String.t() | :anon, String.t(), map()) :: :ok
+  def capture(distinct_id, event, properties \\ %{}) when is_binary(event) do
+    case config() do
+      {key, host} ->
+        # Task.start/1 — detached, no supervisor wiring needed.
+        # Failure here must not propagate to the caller (a webhook
+        # handler, a request pipeline, an Oban worker), so we don't
+        # link the spawn.
+        Task.start(fn -> do_capture(key, host, distinct_id, event, properties) end)
+        :ok
+
+      :disabled ->
+        :ok
+    end
+  end
+
+  defp config do
+    case Application.get_env(:engram, :posthog_key) do
+      key when is_binary(key) and byte_size(key) > 0 ->
+        host = Application.get_env(:engram, :posthog_host, "https://us.i.posthog.com")
+        {key, host}
+
+      _ ->
+        :disabled
+    end
+  end
+
+  defp do_capture(key, host, distinct_id, event, properties) do
+    body = %{
+      api_key: key,
+      event: event,
+      distinct_id: to_distinct_id(distinct_id),
+      properties: properties,
+      timestamp: DateTime.utc_now()
+    }
+
+    case Req.post(host <> @capture_path, json: body, receive_timeout: 5_000) do
+      {:ok, %{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.warning("posthog capture rejected: status=#{status} body=#{inspect(body)}")
+
+      {:error, reason} ->
+        Logger.warning("posthog capture failed: #{inspect(reason)}")
+    end
+  end
+
+  defp to_distinct_id(:anon), do: "anonymous"
+  defp to_distinct_id(id) when is_binary(id), do: id
+end

--- a/lib/engram_web/csp.ex
+++ b/lib/engram_web/csp.ex
@@ -78,7 +78,8 @@ defmodule EngramWeb.CSP do
       paddle_directives(),
       turnstile_directives(),
       cloudflare_insights_directives(),
-      sentry_directives()
+      sentry_directives(),
+      posthog_directives()
     ]
   end
 
@@ -222,6 +223,27 @@ defmodule EngramWeb.CSP do
   # gains nothing from runtime gating.
   defp sentry_directives do
     hosts = ["https://*.ingest.sentry.io"]
+
+    %{
+      "connect-src" => hosts
+    }
+  end
+
+  # PostHog product analytics (browser SDK).
+  #
+  # SDK is bundled (no script-src host). Events POST to the project's
+  # regional host — `us.i.posthog.com` for US-hosted projects,
+  # `eu.i.posthog.com` for EU. The `.i.` subdomain is PostHog's
+  # documented ingest path; wildcard covers both regions without
+  # hard-coding which one this account uses (configured at build via
+  # VITE_POSTHOG_HOST).
+  #
+  # Same silent-failure trap as Sentry: without this `connect-src`
+  # entry, `posthog.capture(...)` looks like it succeeded — the SDK
+  # queues the event and the network POST returns blocked, swallowed
+  # by the fetch promise. No backend funnel data, no clue why.
+  defp posthog_directives do
+    hosts = ["https://*.i.posthog.com", "https://*.posthog.com"]
 
     %{
       "connect-src" => hosts

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.318",
+      version: "0.5.319",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/observability/posthog_test.exs
+++ b/test/engram/observability/posthog_test.exs
@@ -1,0 +1,87 @@
+defmodule Engram.Observability.PostHogTest do
+  @moduledoc """
+  Function-of-env-var contract: the wrapper is a no-op when
+  `:posthog_key` is unset, and emits to the configured host when it
+  is. We intentionally don't pin the wire format — PostHog's
+  capture endpoint accepts a small range of shapes — but we do
+  assert the two structural invariants:
+
+    1. `api_key` matches the configured key (else PostHog rejects).
+    2. `distinct_id` matches the caller's value (else the funnel
+       can't join with the frontend identify call).
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Engram.Observability.PostHog
+
+  setup do
+    prior_key = Application.get_env(:engram, :posthog_key)
+    prior_host = Application.get_env(:engram, :posthog_host)
+
+    on_exit(fn ->
+      Application.put_env(:engram, :posthog_key, prior_key)
+      Application.put_env(:engram, :posthog_host, prior_host)
+    end)
+
+    :ok
+  end
+
+  describe "capture/3" do
+    test "is a no-op when posthog_key is unset" do
+      Application.delete_env(:engram, :posthog_key)
+
+      # The contract is "never raises, never blocks, always returns
+      # :ok". No process spawned, no Req call, no Bypass needed —
+      # if config returns :disabled the function returns immediately.
+      assert :ok = PostHog.capture("user-1", "note_created")
+    end
+
+    test "is a no-op when posthog_key is an empty string" do
+      Application.put_env(:engram, :posthog_key, "")
+
+      assert :ok = PostHog.capture("user-1", "note_created")
+    end
+
+    test "POSTs to the configured host when key is set" do
+      bypass = Bypass.open()
+      Application.put_env(:engram, :posthog_key, "phc_test_token")
+      Application.put_env(:engram, :posthog_host, "http://localhost:#{bypass.port}")
+
+      parent = self()
+
+      Bypass.expect_once(bypass, "POST", "/capture/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(parent, {:posthog_body, Jason.decode!(body)})
+        Plug.Conn.resp(conn, 200, "1")
+      end)
+
+      assert :ok = PostHog.capture("clerk_user_abc", "note_created", %{vault: "v1"})
+
+      assert_receive {:posthog_body, body}, 1_000
+      assert body["api_key"] == "phc_test_token"
+      assert body["distinct_id"] == "clerk_user_abc"
+      assert body["event"] == "note_created"
+      assert body["properties"]["vault"] == "v1"
+    end
+
+    test "maps :anon to a stable 'anonymous' distinct_id" do
+      bypass = Bypass.open()
+      Application.put_env(:engram, :posthog_key, "phc_test_token")
+      Application.put_env(:engram, :posthog_host, "http://localhost:#{bypass.port}")
+
+      parent = self()
+
+      Bypass.expect_once(bypass, "POST", "/capture/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(parent, {:posthog_body, Jason.decode!(body)})
+        Plug.Conn.resp(conn, 200, "1")
+      end)
+
+      assert :ok = PostHog.capture(:anon, "waitlist_signup")
+
+      assert_receive {:posthog_body, body}, 1_000
+      assert body["distinct_id"] == "anonymous"
+    end
+  end
+end

--- a/test/engram_web/csp_test.exs
+++ b/test/engram_web/csp_test.exs
@@ -82,6 +82,20 @@ defmodule EngramWeb.CSPTest do
 
       assert connect_src(header) =~ "https://*.ingest.sentry.io"
     end
+
+    test "always whitelists PostHog ingest hosts on connect-src" do
+      # Same silent-failure trap as Sentry. PostHog SDK is bundled, so
+      # only connect-src needs the wildcard regional ingest hosts
+      # (us.i.posthog.com, eu.i.posthog.com). Without this entry
+      # `posthog.capture(...)` returns successfully but the network
+      # POST is blocked by CSP and no funnel data lands.
+      Application.put_env(:engram, :clerk_issuer, nil)
+
+      header = CSP.header()
+
+      assert connect_src(header) =~ "https://*.i.posthog.com"
+      assert connect_src(header) =~ "https://*.posthog.com"
+    end
   end
 
   describe "Clerk integration — dev/test instance (CLERK_ISSUER under *.clerk.accounts.dev)" do


### PR DESCRIPTION
## Summary

PR7 of the Tier 1 observability rollout. Wires PostHog on both ends without forcing dev/test/self-host to depend on it.

**Frontend init is cookieless** (per [[reference_cookie_audit_2026_05_24]] — no banner required), with **autocapture OFF** (single biggest cost lever per [[project_observability_stack_plan]]; explicit events come in PR8). The backend wrapper is **fire-and-forget** so a PostHog outage can never break a request that emitted the event.

## Files

| File | Change |
|---|---|
| `frontend/package.json` + `bun.lock` | `posthog-js` |
| `frontend/src/main.tsx` | gated `posthog.init` — `persistence: 'memory'`, `autocapture: false`, `capture_pageview: false`, `disable_session_recording: true`. Host defaults to `us.i.posthog.com`; overridable via `VITE_POSTHOG_HOST` |
| `frontend/src/auth/clerk-auth-provider.tsx` | useEffect calls `posthog.identify(clerkUserId, {email})` on auth resolved + `posthog.reset()` on signout. **Missing this is the most-common PostHog integration bug** — without it events bind to anonymous device id and never join with backend events |
| `Dockerfile` + `verify.yml` | `VITE_POSTHOG_KEY` + `VITE_POSTHOG_HOST` build-args |
| `lib/engram_web/csp.ex` | New `posthog_directives/0` adds `https://*.i.posthog.com` + `https://*.posthog.com` to `connect-src`. Same silent-failure trap as Sentry — without it `posthog.capture` returns success but the POST is CSP-blocked |
| `test/engram_web/csp_test.exs` | Regression test |
| `lib/engram/observability/posthog.ex` | Server wrapper. Thin Req-based POST to `/capture/`, no Hex dep. `Task.start/1` so the caller never blocks. No-op when `:posthog_key` is unset |
| `test/engram/observability/posthog_test.exs` | Bypass-driven tests — no-op-when-disabled + wire-shape (api_key, distinct_id) |
| `config/runtime.exs` | Opt-in `:engram, posthog_key:` from `POSTHOG_API_KEY` env; host defaults to `us.i.posthog.com` |
| `mix.exs` | version bump |

## What this does NOT do

- **No explicit events fired yet.** That's PR8 — wires the call sites (`note_created`, `search_performed`, `vault_opened`, `subscription_started`) and the Clerk + Paddle webhook forwarders that depend on this module.
- **No backend `POSTHOG_API_KEY` env wiring on prod ECS.** That comes with PR8 (backend wrapper stays silent until events fire). Frontend already has `VITE_POSTHOG_KEY` as a repo secret here.

## Required secrets / vars

| Name | Type | Status |
|---|---|---|
| `VITE_POSTHOG_KEY` | secret | ✓ set |
| `POSTHOG_HOST` | var | ✓ `https://us.i.posthog.com` |

## Test plan

- [ ] CI green.
- [ ] After merge + deploy + Clerk sign-in: PostHog → Activity → Live events shows an `$identify` event with `distinct_id` matching the Clerk user id.
- [ ] After signout: a `$reset` followed by no further events under that distinct_id.
- [ ] DevTools → Console: no `Refused to connect` CSP errors for `*.posthog.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)