### PR TITLE
feat(observability): explicit PostHog events + Clerk/Paddle webhook forwarders (PR8)

### DIFF
--- a/lib/engram/billing/subscription.ex
+++ b/lib/engram/billing/subscription.ex
@@ -2,6 +2,8 @@ defmodule Engram.Billing.Subscription do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   schema "subscriptions" do
     field :paddle_customer_id, :string
     field :paddle_subscription_id, :string

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -82,6 +82,19 @@ defmodule Engram.Notes do
 
           note = decrypt_or_raise!(note, user)
           :ok = broadcast_change(user.id, vault.id, "upsert", note.path, note)
+          # prev_hash == nil iff insert_new_note returned a freshly inserted
+          # row (see insert_new_note/5). Updates carry the prior content_hash.
+          # Emit only on real creation so the funnel doesn't double-count
+          # idempotent re-pushes of unchanged notes.
+          if is_nil(prev_hash) do
+            :ok =
+              Engram.Observability.PostHog.capture(
+                Engram.Observability.PostHog.distinct_id_for(user),
+                "note_created",
+                %{vault_id: vault.id}
+              )
+          end
+
           {:ok, note}
 
         {:ok, {:conflict, existing}} ->

--- a/lib/engram/observability/posthog.ex
+++ b/lib/engram/observability/posthog.ex
@@ -80,4 +80,17 @@ defmodule Engram.Observability.PostHog do
 
   defp to_distinct_id(:anon), do: "anonymous"
   defp to_distinct_id(id) when is_binary(id), do: id
+
+  @doc """
+  Resolve the PostHog distinct_id for a user. Must equal the frontend's
+  `posthog.identify(clerk.user.id)` value (see
+  frontend/src/auth/clerk-auth-provider.tsx) or funnels won't join across
+  the client/server timeline.
+
+  Users without a Clerk external_id (self-host, internal flows) fall back
+  to `:anon` — bucketed under a stable "anonymous" id on PostHog's side.
+  """
+  @spec distinct_id_for(map() | struct() | nil) :: String.t() | :anon
+  def distinct_id_for(%{external_id: ext}) when is_binary(ext) and byte_size(ext) > 0, do: ext
+  def distinct_id_for(_), do: :anon
 end

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -55,16 +55,38 @@ defmodule Engram.Search do
   """
   def search(user, vault, query, opts \\ []) do
     cross_vault = Keyword.get(opts, :cross_vault, false)
+    started_at = System.monotonic_time(:millisecond)
 
-    if cross_vault do
-      case Engram.Billing.check_feature(user, :cross_vault_search) do
-        :ok -> do_search(user, nil, query, opts)
-        {:error, _} = err -> err
+    result =
+      if cross_vault do
+        case Engram.Billing.check_feature(user, :cross_vault_search) do
+          :ok -> do_search(user, nil, query, opts)
+          {:error, _} = err -> err
+        end
+      else
+        do_search(user, vault, query, opts)
       end
-    else
-      do_search(user, vault, query, opts)
-    end
+
+    emit_search_performed(user, result, started_at, cross_vault)
+    result
   end
+
+  defp emit_search_performed(user, {:ok, results}, started_at, cross_vault)
+       when is_list(results) do
+    latency_ms = System.monotonic_time(:millisecond) - started_at
+
+    Engram.Observability.PostHog.capture(
+      Engram.Observability.PostHog.distinct_id_for(user),
+      "search_performed",
+      %{
+        result_count: length(results),
+        latency_ms: latency_ms,
+        cross_vault: cross_vault
+      }
+    )
+  end
+
+  defp emit_search_performed(_user, _other, _started_at, _cross_vault), do: :ok
 
   defp do_search(user, vault, query, opts) do
     limit = Keyword.get(opts, :limit, 5)

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -62,6 +62,16 @@ defmodule EngramWeb.VaultsController do
       {:ok, vault_id} ->
         case Vaults.get_vault(user, vault_id) do
           {:ok, vault} ->
+            # Fires once per SPA navigation to /v/:id. The list endpoint
+            # /vaults (index/2) is the picker fetch — emitting there would
+            # conflate browsing with opening, so the event stays on show/2.
+            _ =
+              Engram.Observability.PostHog.capture(
+                Engram.Observability.PostHog.distinct_id_for(user),
+                "vault_opened",
+                %{vault_id: vault.id}
+              )
+
             json(conn, %{vault: vault_json(vault, Vaults.content_counts(user, vault.id))})
 
           {:error, :not_found} ->

--- a/lib/engram_web/controllers/webhook_controller.ex
+++ b/lib/engram_web/controllers/webhook_controller.ex
@@ -5,6 +5,7 @@ defmodule EngramWeb.WebhookController do
   alias Engram.Billing
   alias Engram.Email.Suppression
   alias Engram.Webhooks.Svix
+  alias EngramWeb.Webhooks.PostHogForwarder
 
   require Logger
 
@@ -18,6 +19,7 @@ defmodule EngramWeb.WebhookController do
          :ok <- Svix.verify(id, ts, payload, sig_header, clerk_webhook_secret()) do
       event = Jason.decode!(payload)
       _ = ClerkWebhook.handle(event)
+      _ = PostHogForwarder.forward_clerk_event(event)
       json(conn, %{status: "ok"})
     else
       {:error, reason} ->
@@ -32,7 +34,8 @@ defmodule EngramWeb.WebhookController do
       event = Jason.decode!(payload)
 
       case Billing.upsert_from_paddle_event(event) do
-        {:ok, _} ->
+        {:ok, result} ->
+          _ = PostHogForwarder.forward_paddle_event(event, result)
           json(conn, %{status: "ok"})
 
         {:error, reason} ->

--- a/lib/engram_web/webhooks/posthog_forwarder.ex
+++ b/lib/engram_web/webhooks/posthog_forwarder.ex
@@ -51,7 +51,7 @@ defmodule EngramWeb.Webhooks.PostHogForwarder do
   other event types either map to a different funnel step (handled
   elsewhere) or are pure state-sync we don't expose to product analytics.
   """
-  @spec forward_paddle_event(map(), Engram.Billing.Subscription.t() | atom() | term()) :: :ok
+  @spec forward_paddle_event(map(), struct() | term()) :: :ok
   def forward_paddle_event(
         %{"event_type" => "subscription.activated", "data" => data},
         %Engram.Billing.Subscription{} = sub

--- a/lib/engram_web/webhooks/posthog_forwarder.ex
+++ b/lib/engram_web/webhooks/posthog_forwarder.ex
@@ -1,0 +1,82 @@
+defmodule EngramWeb.Webhooks.PostHogForwarder do
+  @moduledoc """
+  Maps verified inbound Clerk + Paddle webhook events to PostHog product
+  events. Lives next to the controller (not in the contexts) because the
+  mapping is an integration concern — what Clerk/Paddle call an event vs.
+  what the funnel calls a step. The contexts shouldn't know about either
+  vendor's payload shape.
+
+  All forwarders run AFTER the underlying handler completes, so a PostHog
+  failure can never roll back business state. `PostHog.capture/3` is itself
+  fire-and-forget (Task.start) — these helpers never block on network I/O
+  and always return `:ok`.
+
+  distinct_id MUST equal the frontend's `posthog.identify(clerk.user.id)`
+  value (see frontend/src/auth/clerk-auth-provider.tsx) or the funnel
+  silently fails to join across the client/server boundary:
+
+  - Clerk events carry the Clerk user id in the payload (`data.id` for
+    user.created, `data.user_id` for session.created — they're not the
+    same key, Clerk's session row references the user it belongs to).
+  - Paddle events carry an *internal* `custom_data.user_id`; we resolve
+    through the Subscription row to the user's `external_id`.
+  """
+
+  alias Engram.Observability.PostHog
+
+  @doc """
+  Forward a verified Clerk webhook event. Returns `:ok` for every input
+  shape — unhandled event types are a no-op so adding a new Clerk webhook
+  destination doesn't accidentally break this handler.
+  """
+  @spec forward_clerk_event(map()) :: :ok
+  def forward_clerk_event(%{"type" => "user.created", "data" => %{"id" => clerk_id}})
+      when is_binary(clerk_id) do
+    _ = PostHog.capture(clerk_id, "user_signed_up", %{})
+    :ok
+  end
+
+  def forward_clerk_event(%{"type" => "session.created", "data" => %{"user_id" => clerk_id}})
+      when is_binary(clerk_id) do
+    _ = PostHog.capture(clerk_id, "user_signed_in", %{})
+    :ok
+  end
+
+  def forward_clerk_event(_event), do: :ok
+
+  @doc """
+  Forward a verified Paddle webhook event paired with the result of
+  `Engram.Billing.upsert_from_paddle_event/1`. Only `subscription.activated`
+  with a freshly-upserted Subscription row produces a PostHog event today —
+  other event types either map to a different funnel step (handled
+  elsewhere) or are pure state-sync we don't expose to product analytics.
+  """
+  @spec forward_paddle_event(map(), Engram.Billing.Subscription.t() | atom() | term()) :: :ok
+  def forward_paddle_event(
+        %{"event_type" => "subscription.activated", "data" => data},
+        %Engram.Billing.Subscription{} = sub
+      ) do
+    case Engram.Accounts.get_user(sub.user_id) do
+      %{external_id: ext_id} when is_binary(ext_id) and byte_size(ext_id) > 0 ->
+        price_id = data |> Map.get("items", []) |> List.first(%{}) |> get_in(["price", "id"])
+
+        _ =
+          PostHog.capture(ext_id, "subscription_started", %{
+            tier: sub.tier,
+            price_id: price_id,
+            paddle_subscription_id: sub.paddle_subscription_id
+          })
+
+        :ok
+
+      _ ->
+        # Self-host installs and pre-Clerk legacy rows have no external_id.
+        # Without a Clerk identify call on the frontend there's nothing to
+        # join against — drop silently rather than emit an :anon event that
+        # would land in PostHog as un-funnelable noise.
+        :ok
+    end
+  end
+
+  def forward_paddle_event(_event, _result), do: :ok
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.319",
+      version: "0.5.320",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/observability/emitters_test.exs
+++ b/test/engram/observability/emitters_test.exs
@@ -1,0 +1,284 @@
+defmodule Engram.Observability.EmittersTest do
+  @moduledoc """
+  Per-emitter Bypass tests for PR8. Each test exercises the production
+  code path (Notes context, Search context, controller, or forwarder
+  module) and asserts the PostHog capture body landed with the expected
+  event name + distinct_id + properties.
+
+  These tests are NOT a contract on the wire format (PostHog accepts a
+  range of shapes — see Engram.Observability.PostHogTest); they pin the
+  funnel-join invariant: `distinct_id` MUST be the Clerk user id, so the
+  server-emitted events join with the frontend's `posthog.identify` call.
+
+  `async: false` because every test mutates the global Application env
+  (:posthog_key, :posthog_host) — Bypass setup is per-test but the env
+  is process-global.
+  """
+
+  use EngramWeb.ConnCase, async: false
+
+  import Mox
+
+  alias Engram.Notes
+  alias Engram.Search
+  alias EngramWeb.Webhooks.PostHogForwarder
+
+  setup :verify_on_exit!
+
+  setup do
+    bypass = Bypass.open()
+    prior_key = Application.get_env(:engram, :posthog_key)
+    prior_host = Application.get_env(:engram, :posthog_host)
+    Application.put_env(:engram, :posthog_key, "phc_emitters_test")
+    Application.put_env(:engram, :posthog_host, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.put_env(:engram, :posthog_key, prior_key)
+      Application.put_env(:engram, :posthog_host, prior_host)
+    end)
+
+    %{bypass: bypass}
+  end
+
+  # PostHog.capture spawns Task.start — assert_receive needs the bypass to
+  # send to *this* process. Wire it through self() captured at expect-time.
+  defp expect_capture(bypass) do
+    parent = self()
+
+    Bypass.expect_once(bypass, "POST", "/capture/", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(parent, {:posthog_body, Jason.decode!(body)})
+      Plug.Conn.resp(conn, 200, "1")
+    end)
+  end
+
+  defp user_with_clerk_id(opts \\ []) do
+    ext_id = Keyword.get(opts, :external_id, "user_clerk_#{System.unique_integer([:positive])}")
+
+    user =
+      insert(:user, external_id: ext_id)
+      |> tap(fn u ->
+        insert(:user_limit_override, user: u, key: "vaults_cap", value: %{"v" => -1})
+      end)
+
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    user
+  end
+
+  describe "note_created" do
+    test "fires on new note insert with vault_id property", %{bypass: bypass} do
+      user = user_with_clerk_id()
+      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+      expect_capture(bypass)
+
+      assert {:ok, _note} =
+               Notes.upsert_note(user, vault, %{
+                 "path" => "Hello.md",
+                 "content" => "# Hello",
+                 "mtime" => 1_000.0
+               })
+
+      assert_receive {:posthog_body, body}, 1_500
+      assert body["event"] == "note_created"
+      assert body["distinct_id"] == user.external_id
+      assert body["properties"]["vault_id"] == vault.id
+    end
+
+    test "does NOT fire on an update to an existing note (idempotent re-push)",
+         %{bypass: bypass} do
+      user = user_with_clerk_id()
+      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+
+      # First insert — burn the single Bypass expectation so a second emit
+      # would fail the test (Bypass.expect_once raises on extra calls).
+      expect_capture(bypass)
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Hello.md",
+          "content" => "# v1",
+          "mtime" => 1_000.0
+        })
+
+      assert_receive {:posthog_body, body}, 1_500
+      assert body["event"] == "note_created"
+
+      # Second upsert at the same path — update branch (prev_hash != nil).
+      # If the emitter mis-fires we'd see a second POST → Bypass.expect_once
+      # raises "expected 1 request, got 2" on test exit.
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Hello.md",
+          "content" => "# v2",
+          "mtime" => 2_000.0
+        })
+
+      # Give any errant fire-and-forget Task a beat to reach Bypass.
+      refute_receive {:posthog_body, _}, 200
+    end
+  end
+
+  describe "search_performed" do
+    test "fires after Qdrant returns with result_count + latency_ms",
+         %{bypass: bypass} do
+      user = user_with_clerk_id()
+      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+
+      # Re-route Qdrant to the same Bypass under a distinct path so we can
+      # serve the search response inline.
+      Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+      on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _, _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      parent = self()
+
+      Bypass.expect(bypass, fn conn ->
+        case conn.request_path do
+          "/capture/" ->
+            {:ok, body, conn} = Plug.Conn.read_body(conn)
+            send(parent, {:posthog_body, Jason.decode!(body)})
+            Plug.Conn.resp(conn, 200, "1")
+
+          _ ->
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(200, Jason.encode!(%{"result" => []}))
+        end
+      end)
+
+      assert {:ok, []} = Search.search(user, vault, "anything")
+
+      assert_receive {:posthog_body, body}, 1_500
+      assert body["event"] == "search_performed"
+      assert body["distinct_id"] == user.external_id
+      assert body["properties"]["result_count"] == 0
+      assert is_integer(body["properties"]["latency_ms"])
+      assert body["properties"]["cross_vault"] == false
+    end
+  end
+
+  describe "vault_opened" do
+    test "fires on GET /vaults/:id success", %{conn: conn, bypass: bypass} do
+      user = user_with_clerk_id()
+      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+      expect_capture(bypass)
+
+      conn = conn |> authenticate(user) |> get("/api/vaults/#{vault.id}")
+
+      assert %{"vault" => %{"id" => _}} = json_response(conn, 200)
+
+      assert_receive {:posthog_body, body}, 1_500
+      assert body["event"] == "vault_opened"
+      assert body["distinct_id"] == user.external_id
+      assert body["properties"]["vault_id"] == vault.id
+    end
+  end
+
+  describe "PostHogForwarder.forward_clerk_event/1" do
+    test "user.created → user_signed_up keyed by data.id", %{bypass: bypass} do
+      expect_capture(bypass)
+
+      :ok =
+        PostHogForwarder.forward_clerk_event(%{
+          "type" => "user.created",
+          "data" => %{"id" => "user_2nXyZclerk"}
+        })
+
+      assert_receive {:posthog_body, body}, 1_500
+      assert body["event"] == "user_signed_up"
+      assert body["distinct_id"] == "user_2nXyZclerk"
+    end
+
+    # The session.created key is `data.user_id`, NOT `data.id` — they're
+    # different fields in Clerk's payload (session-vs-user resource). A
+    # mismatched key here would silently break the funnel.
+    test "session.created → user_signed_in keyed by data.user_id",
+         %{bypass: bypass} do
+      expect_capture(bypass)
+
+      :ok =
+        PostHogForwarder.forward_clerk_event(%{
+          "type" => "session.created",
+          "data" => %{"id" => "sess_xyz", "user_id" => "user_2nXyZclerk"}
+        })
+
+      assert_receive {:posthog_body, body}, 1_500
+      assert body["event"] == "user_signed_in"
+      assert body["distinct_id"] == "user_2nXyZclerk"
+    end
+
+    test "unhandled event type is a no-op" do
+      # No Bypass.expect — any POST would fail the test on exit.
+      :ok =
+        PostHogForwarder.forward_clerk_event(%{
+          "type" => "user.deleted",
+          "data" => %{"id" => "user_x"}
+        })
+
+      refute_receive {:posthog_body, _}, 100
+    end
+  end
+
+  describe "PostHogForwarder.forward_paddle_event/2" do
+    test "subscription.activated resolves the user via Subscription.user_id and emits with tier + price_id",
+         %{bypass: bypass} do
+      user = user_with_clerk_id(external_id: "user_paddle_resolve")
+      sub = insert(:subscription, user: user, tier: "starter", paddle_subscription_id: "sub_ABC")
+
+      expect_capture(bypass)
+
+      :ok =
+        PostHogForwarder.forward_paddle_event(
+          %{
+            "event_type" => "subscription.activated",
+            "data" => %{
+              "items" => [%{"price" => %{"id" => "pri_starter_monthly"}}]
+            }
+          },
+          sub
+        )
+
+      assert_receive {:posthog_body, body}, 1_500
+      assert body["event"] == "subscription_started"
+      assert body["distinct_id"] == "user_paddle_resolve"
+      assert body["properties"]["tier"] == "starter"
+      assert body["properties"]["price_id"] == "pri_starter_monthly"
+      assert body["properties"]["paddle_subscription_id"] == "sub_ABC"
+    end
+
+    test "user without external_id is dropped silently (self-host path)" do
+      user = insert(:user, external_id: nil)
+      sub = insert(:subscription, user: user, tier: "starter")
+
+      :ok =
+        PostHogForwarder.forward_paddle_event(
+          %{
+            "event_type" => "subscription.activated",
+            "data" => %{"items" => [%{"price" => %{"id" => "pri_x"}}]}
+          },
+          sub
+        )
+
+      refute_receive {:posthog_body, _}, 100
+    end
+
+    test "non-activated event types no-op (subscription.updated, subscription.canceled, ignored)" do
+      user = user_with_clerk_id()
+      sub = insert(:subscription, user: user)
+
+      for event_type <- ~w(subscription.updated subscription.canceled subscription.past_due) do
+        :ok =
+          PostHogForwarder.forward_paddle_event(
+            %{"event_type" => event_type, "data" => %{"items" => []}},
+            sub
+          )
+      end
+
+      :ok = PostHogForwarder.forward_paddle_event(%{"event_type" => "transaction.paid"}, :ignored)
+
+      refute_receive {:posthog_body, _}, 100
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR7 (#427) shipped the `Engram.Observability.PostHog` wrapper + the frontend `posthog.identify(clerk.user.id)` call. Nothing actually emitted from the backend. This PR closes that gap so the `signed_up → opened_vault → created_note → subscription_started` funnel populates after the next prod deploy. Final code-side Tier 1 item from `~/.claude/plans/ok-we-are-in-parallel-teapot.md`.

## Events wired

| Event | Where | distinct_id source |
|---|---|---|
| `note_created` | `Engram.Notes.upsert_note/3` (insert branch only) | `users.external_id` |
| `search_performed` | `Engram.Search.search/4` success path | `users.external_id` |
| `vault_opened` | `EngramWeb.VaultsController.show/2` | `users.external_id` |
| `subscription_started` | Paddle webhook → `PostHogForwarder.forward_paddle_event/2` (only on `subscription.activated`) | `Subscription.user_id` → `users.external_id` |
| `user_signed_up` | Clerk webhook → `PostHogForwarder.forward_clerk_event/1` (`user.created`) | `data.id` (Clerk user id) |
| `user_signed_in` | Clerk webhook → same forwarder (`session.created`) | `data.user_id` (Clerk's session-vs-user shape) |

## Key constraints honored

- **distinct_id must equal Clerk user id** — funnel join key with the frontend `posthog.identify` call. `PostHog.distinct_id_for/1` centralizes resolution and falls back to `:anon` for users without `external_id` (self-host without Clerk).
- **Fire-and-forget** — every emit goes through `PostHog.capture/3` which internally `Task.start`s the HTTP POST. A PostHog outage cannot block any webhook handler, request, or worker.
- **`note_created` only on inserts** — gated on `prev_hash == nil` so idempotent re-pushes of unchanged notes don't double-count.
- **`subscription_started` only on `subscription.activated`** — other Paddle event types are pure state-sync, not funnel-worthy.
- **Forwarders extracted** to a dedicated `EngramWeb.Webhooks.PostHogForwarder` module — vendor-payload-mapping is an integration concern, and the dedicated module is unit testable without spinning up Svix signature verification.

## Pairing PR

This is a no-op in prod until engram-infra [#274](https://github.com/engram-app/engram-infra/pull/274) lands `POSTHOG_API_KEY` into ECS SSM + bumps `deploy_nonce v2→v3`. Either PR can ship first — the backend wrapper documents the no-op path when `:posthog_key` is unset.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — no issues
- [x] `mix sobelow --exit low` — clean
- [x] `mix test test/engram/observability/emitters_test.exs` — 10 tests, 0 failures
- [x] Regression on touched call-site tests — 119 tests, 0 failures (notes / search / vaults_controller / webhook_controller / posthog)
- [ ] After merge + infra #274 + deploy: PostHog Activity → Live shows `$identify → user_signed_up → vault_opened → note_created → subscription_started`, all with the same `distinct_id` = clerk user id
- [ ] Build the 4-step funnel in PostHog and confirm conversion math

## Out of scope

- Backend Sentry release tagging at runtime (deferred from #421; events still land in "unknown release" bucket — small follow-up)
- `SENTRY_AUTH_TOKEN` operator secret on engram-app/Engram (separate operator step, see #421 body)
- Pre-existing flake on `test_50_qdrant_binary_quantization::test_embed_and_search` (#428) — not in this PR's code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)