### PR TITLE
feat(observability): backend Sentry release tag from RELEASE_SHA env

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -43,9 +43,17 @@ jobs:
         run: |
           # github.sha is the commit the release tag points at.
           SHA=$(git rev-parse --short=7 "${{ github.sha }}")
+          FULL_SHA="${{ github.sha }}"
           echo "image_tag=sha-$SHA" >> "$GITHUB_OUTPUT"
+          # Backend Sentry SDK release tag — must match what
+          # `getsentry/action-release@v3` registers in verify.yml
+          # (`version: ${{ github.sha }}` — full 40-char SHA). Sourced as
+          # an ECS env var via the engram_release_sha TF variable so the
+          # backend SDK's `release` matches the frontend SDK + the Sentry
+          # UI release entry exactly.
+          echo "release_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
           echo "release=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          echo "Deploying $GITHUB_REF_NAME → image sha-$SHA"
+          echo "Deploying $GITHUB_REF_NAME → image sha-$SHA (release=$FULL_SHA)"
 
       # Mint a short-lived installation token for the engram-infra-tf
       # GitHub App, scoped to engram-app/engram-infra only. Required
@@ -78,10 +86,11 @@ jobs:
           # bump-infra-tfvars job.
           persist-credentials: false
 
-      - name: Rewrite engram_image_tag default in variables.tf
+      - name: Rewrite engram_image_tag + engram_release_sha defaults in variables.tf
         id: rewrite
         env:
           IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}
+          RELEASE_SHA: ${{ steps.tags.outputs.release_sha }}
         run: |
           python3 - <<'PY'
           import os
@@ -89,25 +98,35 @@ jobs:
 
           path = "engram-infra/main/envs/prod/variables.tf"
           image_tag = os.environ["IMAGE_TAG"]
+          release_sha = os.environ["RELEASE_SHA"]
           gh_output = os.environ["GITHUB_OUTPUT"]
 
           text = open(path).read()
-          # Anchored on the variable block name so adding other
-          # `default = ` lines elsewhere in the file is safe.
-          pattern = re.compile(
-              r'(variable\s+"engram_image_tag"[^}]*?default\s*=\s*)"[^"]+"',
-              re.DOTALL,
-          )
-          new, count = pattern.subn(rf'\g<1>"{image_tag}"', text)
-          if count != 1:
-              raise SystemExit(
-                  f"expected exactly 1 engram_image_tag block, got {count}; "
-                  "variables.tf shape changed — adjust the regex"
+
+          # Each rewrite is anchored on the variable block name + must match
+          # exactly once. Adding other `default = ` lines elsewhere is safe.
+          # Hard-fail on count != 1 — silent shape changes are how the prod
+          # task def would diverge from the GitOps source of truth.
+          def rewrite(text, var_name, value):
+              pattern = re.compile(
+                  rf'(variable\s+"{var_name}"[^}}]*?default\s*=\s*)"[^"]*"',
+                  re.DOTALL,
               )
-          open(path, "w").write(new)
+              new, count = pattern.subn(rf'\g<1>"{value}"', text)
+              if count != 1:
+                  raise SystemExit(
+                      f"expected exactly 1 {var_name} block, got {count}; "
+                      "variables.tf shape changed — adjust the regex"
+                  )
+              print(f"rewrote {var_name} default → {value}")
+              return new
+
+          text = rewrite(text, "engram_image_tag", image_tag)
+          text = rewrite(text, "engram_release_sha", release_sha)
+
+          open(path, "w").write(text)
           with open(gh_output, "a") as f:
               f.write("rewrote=true\n")
-          print(f"rewrote engram_image_tag default → {image_tag}")
           PY
 
           echo "::group::variables.tf after rewrite"
@@ -140,7 +159,9 @@ jobs:
 
             Source commit: ${{ github.repository }}@${{ github.sha }}
 
-            Bumps `engram_image_tag` default in `main/envs/prod/variables.tf` to **`${{ steps.tags.outputs.image_tag }}`**.
+            Bumps two defaults in `main/envs/prod/variables.tf`:
+            - `engram_image_tag` → **`${{ steps.tags.outputs.image_tag }}`** (ECR tag rolled by `terraform (prod)`)
+            - `engram_release_sha` → **`${{ steps.tags.outputs.release_sha }}`** (full git SHA — backend Sentry SDK release tag, must match `getsentry/action-release@v3` registration)
 
             ## What this triggers
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -603,11 +603,29 @@ end
 # SOPS (`sentry_dsn_backend`); follow-up engram-infra PR wires the
 # `aws_ssm_parameter` and `ecs_secrets.tf` mapping.
 if dsn = System.get_env("SENTRY_DSN") do
+  # `release` MUST equal what `getsentry/action-release@v3` registers in
+  # verify.yml — currently `version: ${{ github.sha }}` (full 40-char
+  # commit SHA). Frontend Sentry SDK uses the same value via VITE_GIT_SHA
+  # at build time. Backend ECS injects RELEASE_SHA from
+  # `var.engram_release_sha` (engram-infra) so all three sources agree
+  # on the same string and the Sentry "Releases" view + suspect-commits
+  # + cross-event grouping work.
+  #
+  # Empty-string would register events under release "" — a real Sentry
+  # release that clutters the picker — so coerce blank → nil to mirror
+  # the "unset" semantic.
+  release =
+    case System.get_env("RELEASE_SHA") do
+      v when is_binary(v) and v != "" -> v
+      _ -> nil
+    end
+
   config :sentry,
     dsn: dsn,
     environment_name: to_string(config_env()),
     enable_source_code_context: true,
     root_source_code_paths: [File.cwd!()],
+    release: release,
     tags: %{env: to_string(config_env())},
     # Tracing off in Tier 1 — OpenTelemetry → Tempo lands in Tier 2 with
     # a 10% sample rate. Setting traces_sample_rate: nil makes Sentry

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.320",
+      version: "0.5.321",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Closes the last operational gap on Sentry — backend SDK now tags every event with the same release identifier that:
- `getsentry/action-release@v3` registers in `verify.yml` (`version: \${{ github.sha }}`)
- the frontend SDK uses via `VITE_GIT_SHA` at build time

So backend + frontend events join under one release entry in Sentry's UI, suspect-commit detection works across both, and the Releases view shows actual deploys instead of accumulating events under "unknown".

Pairs with engram-infra **#276** which adds the `engram_release_sha` TF variable (full 40-char SHA, defaulting to `""`) and threads it into the ECS task env as `RELEASE_SHA`. Either PR can ship first — backend SDK case-branch coerces blank → nil so a missing env is a clean fallback.

## Changes

| File | Change |
|---|---|
| `config/runtime.exs:605` | Add `release:` to Sentry config block, sourced from `RELEASE_SHA` env. Blank → nil coercion so Sentry never registers under literal `""` |
| `.github/workflows/deploy-prod.yml` | New `release_sha` step output (full `\${{ github.sha }}`). Extend variables.tf rewrite step to bump TWO vars (`engram_image_tag` + `engram_release_sha`) anchored on per-variable block names, same hard-fail-on-count-mismatch invariant per-var. Bot PR body lists both var changes |
| `mix.exs` | `0.5.319 → 0.5.321` (PR #429 is taking 0.5.320) |

## Why a second TF variable instead of reusing engram_image_tag

`engram_image_tag` is `sha-<7char>` (short, prefixed) — convenient for ECR but doesn't match the full-SHA format `action-release` already registers. Aligning everything on the short form would require touching `verify.yml` in 3 places + `frontend/src/main.tsx`'s release option — more churn, more historical Sentry release noise. A second var routed through the same bot is cheaper.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [ ] After merge + infra #276 + next `release-v*` tag → bot PR rewrites both vars → tf-apply rolls task → IEx console `Sentry.capture_exception(...)` on prod lands in Sentry tagged with the deploy SHA, matching the entry created by `action-release`

## Out of scope

- Source-map upload (already wired in #421; gated on `SENTRY_AUTH_TOKEN` repo secret which is now set)
- Tracing / OpenTelemetry (Tier 2 of `~/.claude/plans/ok-we-are-in-parallel-teapot.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)