### PR TITLE
feat(onboarding): block wizard until vault populated + vault_name hint

### DIFF
--- a/e2e/tests/api_only/local/test_60_local_auth.py
+++ b/e2e/tests/api_only/local/test_60_local_auth.py
@@ -243,9 +243,21 @@ class TestRefresh:
         assert me_resp.status_code == 200
         assert me_resp.json()["user"]["email"] == self.email
 
-    def test_old_refresh_token_rejected_after_rotation(self):
-        """After rotation, the old refresh token should be rejected."""
-        # Use the token (rotates it)
+    def test_old_refresh_token_within_leeway_is_treated_as_benign_rotation_race(self):
+        """Within the rotation-leeway window (Engram.Auth.RefreshLeeway = 30s),
+        re-presenting the just-rotated token is treated as a legitimate race
+        (lost rotation, concurrent retry, tab refresh mid-mount) — server
+        issues a sibling child in the same family rather than triggering the
+        reuse-breach response. RFC 9700 §4.14.2 mitigation pattern.
+
+        Breach detection outside the leeway window is exhaustively covered in
+        ExUnit (`test/engram/accounts_test.exs` — "reuse of refresh token
+        OUTSIDE the leeway window revokes the family"); reproducing the
+        outside-window case in E2E would require either a >30s sleep or a
+        test-only timestamp-aging hook, neither of which earns its cost on
+        every run.
+        """
+        # Use the token (rotates it).
         resp1 = http.post(
             f"{API_URL}/auth/refresh",
             cookies={"refresh_token": self.refresh_cookie},
@@ -253,14 +265,14 @@ class TestRefresh:
         )
         assert resp1.status_code == 200
 
-        # Reuse the old token — should fail (reuse detection)
+        # Re-present the rotated cookie immediately — leeway lets it through.
         resp2 = http.post(
             f"{API_URL}/auth/refresh",
             cookies={"refresh_token": self.refresh_cookie},
             timeout=10,
         )
-        assert resp2.status_code == 401, (
-            f"Reused token should be rejected, got {resp2.status_code}"
+        assert resp2.status_code == 200, (
+            f"Within-leeway re-use should succeed, got {resp2.status_code}"
         )
 
     def test_missing_cookie_rejected(self):

--- a/e2e/tests/api_only/test_71_connections.py
+++ b/e2e/tests/api_only/test_71_connections.py
@@ -433,11 +433,18 @@ async def test_free_tier_pat_minting_blocked(clerk_client):
 # ── Device-flow helpers ───────────────────────────────────────────────────────
 
 
-def device_start(client_id: str = "e2e-plugin") -> dict:
-    """POST /api/auth/device — initiate device flow. Returns JSON body."""
+def device_start(client_id: str = "e2e-plugin", vault_name: str | None = None) -> dict:
+    """POST /api/auth/device — initiate device flow. Returns JSON body.
+
+    Optional vault_name is the plugin's local Obsidian vault name. It's stored
+    on the device-authorization row so /link can pre-fill the create-new field.
+    """
+    payload: dict = {"client_id": client_id}
+    if vault_name is not None:
+        payload["vault_name"] = vault_name
     resp = requests.post(
         f"{API_URL}/auth/device",
-        json={"client_id": client_id},
+        json=payload,
         timeout=10,
     )
     resp.raise_for_status()
@@ -599,6 +606,42 @@ async def test_device_flow_connection_appears_in_list(clerk_client):
             f"obsidian connection still listed after revoke: {obsidian_after}"
         )
 
+    finally:
+        clerk_client.delete_user(clerk_user_id)
+
+
+@pytest.mark.asyncio
+async def test_device_flow_vault_name_hint_surfaces_on_link_page(clerk_client):
+    """Plugin sends its local Obsidian vault name with the device-flow start;
+    the /link consent page reads it back via GET /vaults?user_code=... so the
+    "create new vault" field pre-fills with a sensible default.
+    """
+    clerk_user_id, jwt, _email = _make_clerk_user(clerk_client)
+    try:
+        start = device_start("e2e-plugin", vault_name="My Obsidian Notes")
+        user_code = start["user_code"]
+
+        resp = requests.get(
+            f"{API_URL}/vaults",
+            params={"user_code": user_code},
+            headers={"Authorization": f"Bearer {jwt}"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        assert body["suggested_vault_name"] == "My Obsidian Notes"
+
+        # And without the hint, the field stays absent so the wizard's
+        # blank-default UX is preserved.
+        start_no_hint = device_start("e2e-plugin-2")
+        resp2 = requests.get(
+            f"{API_URL}/vaults",
+            params={"user_code": start_no_hint["user_code"]},
+            headers={"Authorization": f"Bearer {jwt}"},
+            timeout=10,
+        )
+        resp2.raise_for_status()
+        assert resp2.json()["suggested_vault_name"] is None
     finally:
         clerk_client.delete_user(clerk_user_id)
 

--- a/frontend/src/auth/local-auth-provider.tsx
+++ b/frontend/src/auth/local-auth-provider.tsx
@@ -21,34 +21,51 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
   const [isLoaded, setIsLoaded] = useState(false)
   const refreshPromiseRef = useRef<Promise<string | null> | null>(null)
 
-  // On mount, attempt a silent refresh to restore session from cookie
-  useEffect(() => {
-    fetch('/api/auth/refresh', { method: 'POST', credentials: 'include' })
+  const doRefresh = useCallback((): Promise<string | null> => {
+    // Single in-flight refresh at a time. Two concurrent /api/auth/refresh
+    // calls present the same cookie value; the second would land at the
+    // backend with a token revoked microseconds ago. The backend's leeway
+    // window catches that race, but client-side dedup is still the cheaper
+    // first line of defense (avoids the round-trip + an extra DB rotate).
+    if (refreshPromiseRef.current) return refreshPromiseRef.current
+
+    const promise = fetch('/api/auth/refresh', {
+      method: 'POST',
+      credentials: 'include',
+    })
       .then(async (res) => {
         if (res.ok) {
           const data = await res.json()
           const payload = parseJwtPayload(data.access_token)
+          setAccessToken(data.access_token)
           if (payload?.email) {
-            setAccessToken(data.access_token)
             setUser({ email: payload.email as string })
           }
+          return data.access_token as string
         }
+        setAccessToken(null)
+        setUser(null)
+        return null
       })
-      .catch((err) => console.error('Silent refresh failed:', err))
-      .finally(() => setIsLoaded(true))
+      .catch((err) => {
+        console.error('Refresh failed:', err)
+        return null
+      })
+      .finally(() => {
+        refreshPromiseRef.current = null
+      })
+
+    refreshPromiseRef.current = promise
+    return promise
   }, [])
 
-  const doRefresh = useCallback(async (): Promise<string | null> => {
-    const res = await fetch('/api/auth/refresh', { method: 'POST', credentials: 'include' })
-    if (res.ok) {
-      const data = await res.json()
-      setAccessToken(data.access_token)
-      return data.access_token
-    }
-    setAccessToken(null)
-    setUser(null)
-    return null
-  }, [])
+  // On mount, attempt a silent refresh to restore session from cookie.
+  // Routes through doRefresh so it shares the refreshPromiseRef dedup with
+  // any in-flight API call that simultaneously demands a token (e.g. an
+  // immediate useOnboardingStatus query firing on app load).
+  useEffect(() => {
+    doRefresh().finally(() => setIsLoaded(true))
+  }, [doRefresh])
 
   const getToken = useCallback(async () => {
     if (!accessToken) return null
@@ -59,13 +76,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
       return accessToken
     }
 
-    // Deduplicate concurrent refresh requests
-    if (!refreshPromiseRef.current) {
-      refreshPromiseRef.current = doRefresh().finally(() => {
-        refreshPromiseRef.current = null
-      })
-    }
-    return refreshPromiseRef.current
+    return doRefresh()
   }, [accessToken, doRefresh])
 
   useEffect(() => {

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -117,7 +117,14 @@ export default function DeviceLinkPage() {
 
   return (
     <AuthShell>
-      <AuthPanel className="flex flex-col gap-4">
+      <AuthPanel
+        className={cn(
+          'flex flex-col gap-4',
+          // pick-vault is a tighter, decision-focused step — narrow the
+          // whole card so the radio rows + button don't feel oceanic.
+          step === 'pick-vault' && 'mx-auto sm:w-3/5',
+        )}
+      >
         <h1 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
           Link Obsidian Vault
         </h1>
@@ -143,7 +150,7 @@ export default function DeviceLinkPage() {
         )}
 
         {step === 'pick-vault' && (
-          <div className="mx-auto flex w-full flex-col gap-3 sm:w-3/5">
+          <div className="flex flex-col gap-3">
             <p className="text-sm text-muted-foreground">
               Code verified. Pick where these notes should sync:
             </p>

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -63,9 +63,14 @@ export default function DeviceLinkPage() {
       setVaults(data.vaults ?? [])
       const suggested = data.suggested_vault_name?.trim() || ''
       setSuggestedName(suggested)
-      // Default to the matched-name row when the plugin sent a hint;
-      // otherwise drop straight to the custom-name input.
-      setSelection(suggested ? 'matched' : 'custom')
+      // Default selection:
+      // - existing vault with the same name → pre-select that vault (link, don't dup)
+      // - suggested name with no existing match → 'matched' (create new with that name)
+      // - no hint at all → 'custom' (force user to type a name)
+      const existing = suggested
+        ? (data.vaults ?? []).find((v) => v.name === suggested)
+        : undefined
+      setSelection(existing ? String(existing.id) : suggested ? 'matched' : 'custom')
       setStep('pick-vault')
     } catch {
       setError('Failed to load vaults. Please try again.')
@@ -155,75 +160,114 @@ export default function DeviceLinkPage() {
               Pick an existing one, or create a new vault for these notes.
             </p>
 
-            <fieldset className="flex flex-col gap-2">
-              {suggestedName && (
-                <label className={selectableRow(isMatched)}>
-                  <input
-                    type="radio"
-                    name="vault-target"
-                    checked={isMatched}
-                    onChange={() => setSelection('matched')}
-                    className="accent-primary"
-                  />
-                  <span className="flex flex-col">
-                    <span className="text-sm font-medium text-foreground">
-                      {suggestedName}
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      Makes a new vault matching your Obsidian vault name
-                    </span>
-                  </span>
-                </label>
-              )}
+            {(() => {
+              // If a vault already exists with the suggested name, offer to
+              // link into THAT one as the top row instead of dangling a
+              // "create a duplicate" option. The duplicated vault then gets
+              // hidden from the regular existing-vaults list below.
+              const matchedExisting = suggestedName
+                ? vaults.find((v) => v.name === suggestedName)
+                : undefined
+              const otherVaults = matchedExisting
+                ? vaults.filter((v) => v.id !== matchedExisting.id)
+                : vaults
+              return (
+                <fieldset className="flex flex-col gap-2">
+                  {matchedExisting ? (
+                    <label
+                      className={selectableRow(selection === String(matchedExisting.id))}
+                    >
+                      <input
+                        type="radio"
+                        name="vault-target"
+                        checked={selection === String(matchedExisting.id)}
+                        onChange={() => setSelection(String(matchedExisting.id))}
+                        className="accent-primary"
+                      />
+                      <span className="flex flex-col">
+                        <span className="text-sm font-medium text-foreground">
+                          {matchedExisting.name}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          Sync into your existing vault &middot;{' '}
+                          {matchedExisting.note_count} notes
+                        </span>
+                      </span>
+                    </label>
+                  ) : (
+                    suggestedName && (
+                      <label className={selectableRow(isMatched)}>
+                        <input
+                          type="radio"
+                          name="vault-target"
+                          checked={isMatched}
+                          onChange={() => setSelection('matched')}
+                          className="accent-primary"
+                        />
+                        <span className="flex flex-col">
+                          <span className="text-sm font-medium text-foreground">
+                            {suggestedName}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            Makes a new vault matching your Obsidian vault name
+                          </span>
+                        </span>
+                      </label>
+                    )
+                  )}
 
-              {vaults.map((v) => {
-                const active = selection === String(v.id)
-                return (
-                  <label key={v.id} className={selectableRow(active)}>
+                  {otherVaults.map((v) => {
+                    const active = selection === String(v.id)
+                    return (
+                      <label key={v.id} className={selectableRow(active)}>
+                        <input
+                          type="radio"
+                          name="vault-target"
+                          checked={active}
+                          onChange={() => setSelection(String(v.id))}
+                          className="accent-primary"
+                        />
+                        <span className="flex flex-col">
+                          <span className="text-sm font-medium text-foreground">
+                            {v.name}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            Sync into this existing vault &middot; {v.note_count} notes
+                          </span>
+                        </span>
+                      </label>
+                    )
+                  })}
+
+                  <label className={selectableRow(isCustom)}>
                     <input
                       type="radio"
                       name="vault-target"
-                      checked={active}
-                      onChange={() => setSelection(String(v.id))}
+                      checked={isCustom}
+                      onChange={() => setSelection('custom')}
                       className="accent-primary"
                     />
-                    <span className="flex flex-col">
-                      <span className="text-sm font-medium text-foreground">{v.name}</span>
-                      <span className="text-xs text-muted-foreground">
-                        Sync into this existing vault &middot; {v.note_count} notes
+                    <span className="flex flex-1 flex-col gap-2">
+                      <span className="text-sm font-medium text-foreground">
+                        Create a vault with a custom name
                       </span>
+                      <input
+                        type="text"
+                        value={customName}
+                        onChange={(e) => {
+                          setCustomName(e.target.value)
+                          if (!isCustom) setSelection('custom')
+                        }}
+                        onFocus={() => setSelection('custom')}
+                        placeholder="choose a new name"
+                        maxLength={100}
+                        className={fieldInput}
+                      />
                     </span>
                   </label>
-                )
-              })}
-
-              <label className={selectableRow(isCustom)}>
-                <input
-                  type="radio"
-                  name="vault-target"
-                  checked={isCustom}
-                  onChange={() => setSelection('custom')}
-                  className="accent-primary"
-                />
-                <span className="flex flex-1 flex-col gap-2">
-                  <span className="text-sm font-medium text-foreground">
-                    Create a vault with a custom name
-                  </span>
-                  <input
-                    type="text"
-                    value={customName}
-                    onChange={(e) => {
-                      setCustomName(e.target.value)
-                      if (!isCustom) setSelection('custom')
-                    }}
-                    onFocus={() => setSelection('custom')}
-                    placeholder="choose a new name"
-                    maxLength={100}
-                    className={fieldInput}
-                  />
-                </span>
-              </label>
-            </fieldset>
+                </fieldset>
+              )
+            })()}
 
             <Button
               type="button"

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -52,10 +52,15 @@ export default function DeviceLinkPage() {
     setLoading(true)
     setError('')
     try {
-      const data = await api.get<{ vaults: Vault[] }>('/vaults')
       const formattedCode = formatted.slice(0, 4) + '-' + formatted.slice(4)
+      const data = await api.get<{ vaults: Vault[]; suggested_vault_name?: string | null }>(
+        `/vaults?user_code=${encodeURIComponent(formattedCode)}`,
+      )
       setUserCode(formattedCode)
       setVaults(data.vaults ?? [])
+      if (data.suggested_vault_name && newVaultName === '') {
+        setNewVaultName(data.suggested_vault_name)
+      }
       if (!data.vaults || data.vaults.length === 0) {
         setCreateNew(true)
       }

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -122,7 +122,7 @@ export default function DeviceLinkPage() {
           'flex flex-col gap-4',
           // pick-vault is a tighter, decision-focused step — narrow the
           // whole card so the radio rows + button don't feel oceanic.
-          step === 'pick-vault' && 'mx-auto sm:w-3/5',
+          step === 'pick-vault' && 'mx-auto sm:w-4/5',
         )}
       >
         <h1 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -100,12 +100,14 @@ export default function DeviceLinkPage() {
         '/auth/device/authorize',
         body,
       )
-      // Forward to the vault that was just linked — not whatever the vault
-      // switcher would otherwise fall back to (the default / first vault).
+      // Stash the linked vault as active so if the user does come back to
+      // the web later, they land in the right one. We don't auto-navigate —
+      // the plugin still owes us the first sync from inside Obsidian, and
+      // the onboarding wizard auto-advances on the `vault_populated`
+      // broadcast in its own tab.
       setActiveVaultId(vault_id)
       qc.invalidateQueries({ queryKey: ['vaults'] })
       setStep('success')
-      setTimeout(() => navigate('/'), 1500)
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Authorization failed'
       if (message.includes('404') || message.includes('not found')) {
@@ -281,11 +283,25 @@ export default function DeviceLinkPage() {
         )}
 
         {step === 'success' && (
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-3">
             <h2 className="text-lg font-semibold text-foreground">Vault linked!</h2>
-            <p className="text-sm text-muted-foreground">
-              Your Obsidian plugin is now connected. Redirecting to your vault…
+            <p className="text-sm text-foreground">
+              Head back to Obsidian and kick off your first sync from the
+              plugin. We'll take it from there.
             </p>
+            <p className="text-sm text-muted-foreground">
+              You can close this tab safely. If you have the Engram dashboard
+              open in another tab, it'll move forward on its own as soon as
+              the sync starts.
+            </p>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => navigate('/')}
+              className="self-start text-sm"
+            >
+              Or skip to the dashboard
+            </Button>
           </div>
         )}
 

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -8,7 +8,7 @@ import AuthShell from '../layout/auth-shell'
 import AuthPanel from '../layout/auth-panel'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { heading, fieldInput, destructiveAlert, selectableRow } from '@/lib/ui-classes'
+import { heading, fieldInput, destructiveAlert } from '@/lib/ui-classes'
 
 type Vault = { id: number; name: string; note_count: number }
 
@@ -21,9 +21,11 @@ export default function DeviceLinkPage() {
   const [step, setStep] = useState<Step>('enter-code')
   const [userCode, setUserCode] = useState('')
   const [vaults, setVaults] = useState<Vault[]>([])
-  const [selectedVaultId, setSelectedVaultId] = useState<number | null>(null)
-  const [newVaultName, setNewVaultName] = useState('')
-  const [createNew, setCreateNew] = useState(false)
+  // `selection` doubles as the dropdown value: 'new' for create-new, or the
+  // existing vault id stringified (HTML <select> values are strings).
+  const [selection, setSelection] = useState<string>('new')
+  const [suggestedName, setSuggestedName] = useState('')
+  const [customName, setCustomName] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -58,12 +60,10 @@ export default function DeviceLinkPage() {
       )
       setUserCode(formattedCode)
       setVaults(data.vaults ?? [])
-      if (data.suggested_vault_name && newVaultName === '') {
-        setNewVaultName(data.suggested_vault_name)
-      }
-      if (!data.vaults || data.vaults.length === 0) {
-        setCreateNew(true)
-      }
+      setSuggestedName(data.suggested_vault_name?.trim() || '')
+      // Default selection: always start on "create new" so the matched
+      // Obsidian name leads. Users with existing vaults can pick one explicitly.
+      setSelection('new')
       setStep('pick-vault')
     } catch {
       setError('Failed to load vaults. Please try again.')
@@ -72,13 +72,16 @@ export default function DeviceLinkPage() {
     }
   }
 
+  const createNew = selection === 'new'
+  const effectiveNewName = (customName.trim() || suggestedName || '').trim()
+
   async function handleAuthorize() {
     setLoading(true)
     setError('')
     try {
       const body = createNew
-        ? { user_code: userCode, vault_id: 'new', vault_name: newVaultName }
-        : { user_code: userCode, vault_id: selectedVaultId }
+        ? { user_code: userCode, vault_id: 'new', vault_name: effectiveNewName }
+        : { user_code: userCode, vault_id: Number(selection) }
 
       const { vault_id } = await api.post<{ ok: boolean; vault_id: number }>(
         '/auth/device/authorize',
@@ -102,7 +105,7 @@ export default function DeviceLinkPage() {
     }
   }
 
-  const canAuthorize = createNew ? newVaultName.trim().length > 0 : selectedVaultId !== null
+  const canAuthorize = createNew ? effectiveNewName.length > 0 : selection !== 'new'
 
   return (
     <AuthShell>
@@ -134,64 +137,43 @@ export default function DeviceLinkPage() {
         {step === 'pick-vault' && (
           <div className="flex flex-col gap-3">
             <p className="text-sm text-muted-foreground">
-              {vaults.length > 0
-                ? 'Code verified. Choose which vault to sync:'
-                : 'Code verified. Create a vault to get started:'}
+              Code verified. Pick where these notes should sync:
             </p>
-            <fieldset className="flex flex-col gap-2">
-              {vaults.map((v) => {
-                const active = !createNew && selectedVaultId === v.id
-                return (
-                  <label
-                    key={v.id}
-                    className={selectableRow(active)}
-                  >
-                    <input
-                      type="radio"
-                      name="vault"
-                      checked={active}
-                      onChange={() => {
-                        setSelectedVaultId(v.id)
-                        setCreateNew(false)
-                      }}
-                      className="accent-primary"
-                    />
-                    <span className="text-sm font-medium text-foreground">
-                      {v.name}{' '}
-                      <span className="font-normal text-muted-foreground">
-                        ({v.note_count} notes)
-                      </span>
-                    </span>
-                  </label>
-                )
-              })}
-              {vaults.length > 0 && (
-                <label
-                  className={selectableRow(createNew)}
-                >
-                  <input
-                    type="radio"
-                    name="vault"
-                    checked={createNew}
-                    onChange={() => {
-                      setCreateNew(true)
-                      setSelectedVaultId(null)
-                    }}
-                    className="accent-primary"
-                  />
-                  <span className="text-sm font-medium text-foreground">+ Create new vault</span>
-                </label>
-              )}
-            </fieldset>
+
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="font-medium text-foreground">Sync target</span>
+              <select
+                value={selection}
+                onChange={(e) => setSelection(e.target.value)}
+                className={fieldInput}
+              >
+                <option value="new">
+                  {suggestedName
+                    ? `${suggestedName} (Match Obsidian vault name)`
+                    : 'Create a new vault'}
+                </option>
+                {vaults.map((v) => (
+                  <option key={v.id} value={String(v.id)}>
+                    {v.name} ({v.note_count} notes)
+                  </option>
+                ))}
+              </select>
+            </label>
 
             {createNew && (
-              <input
-                type="text"
-                value={newVaultName}
-                onChange={(e) => setNewVaultName(e.target.value)}
-                placeholder="Vault name"
-                className={fieldInput}
-              />
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-foreground">
+                  Use a different name (optional)
+                </span>
+                <input
+                  type="text"
+                  value={customName}
+                  onChange={(e) => setCustomName(e.target.value)}
+                  placeholder="choose new name"
+                  maxLength={100}
+                  className={fieldInput}
+                />
+              </label>
             )}
 
             <Button
@@ -200,7 +182,7 @@ export default function DeviceLinkPage() {
               disabled={loading || !canAuthorize}
               className="w-full"
             >
-              {loading ? 'Authorizing…' : 'Authorize'}
+              {loading ? 'Syncing…' : 'Sync'}
             </Button>
           </div>
         )}

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { heading, fieldInput, destructiveAlert, selectableRow } from '@/lib/ui-classes'
 import { useMe } from '../api/queries'
+import { SyncStatusPill } from '../onboarding/sync-status-pill'
 import { useVaultReadyEvents } from '../onboarding/use-vault-ready-events'
 
 type Vault = { id: number; name: string; note_count: number }
@@ -165,114 +166,14 @@ export default function DeviceLinkPage() {
               Pick an existing one, or create a new vault for these notes.
             </p>
 
-            {(() => {
-              // If a vault already exists with the suggested name, offer to
-              // link into THAT one as the top row instead of dangling a
-              // "create a duplicate" option. The duplicated vault then gets
-              // hidden from the regular existing-vaults list below.
-              const matchedExisting = suggestedName
-                ? vaults.find((v) => v.name === suggestedName)
-                : undefined
-              const otherVaults = matchedExisting
-                ? vaults.filter((v) => v.id !== matchedExisting.id)
-                : vaults
-              return (
-                <fieldset className="flex flex-col gap-2">
-                  {matchedExisting ? (
-                    <label
-                      className={selectableRow(selection === String(matchedExisting.id))}
-                    >
-                      <input
-                        type="radio"
-                        name="vault-target"
-                        checked={selection === String(matchedExisting.id)}
-                        onChange={() => setSelection(String(matchedExisting.id))}
-                        className="accent-primary"
-                      />
-                      <span className="flex flex-col">
-                        <span className="text-sm font-medium text-foreground">
-                          {matchedExisting.name}
-                        </span>
-                        <span className="text-xs text-muted-foreground">
-                          Sync into your existing vault &middot;{' '}
-                          {matchedExisting.note_count} notes
-                        </span>
-                      </span>
-                    </label>
-                  ) : (
-                    suggestedName && (
-                      <label className={selectableRow(isMatched)}>
-                        <input
-                          type="radio"
-                          name="vault-target"
-                          checked={isMatched}
-                          onChange={() => setSelection('matched')}
-                          className="accent-primary"
-                        />
-                        <span className="flex flex-col">
-                          <span className="text-sm font-medium text-foreground">
-                            {suggestedName}
-                          </span>
-                          <span className="text-xs text-muted-foreground">
-                            Makes a new vault matching your Obsidian vault name
-                          </span>
-                        </span>
-                      </label>
-                    )
-                  )}
-
-                  {otherVaults.map((v) => {
-                    const active = selection === String(v.id)
-                    return (
-                      <label key={v.id} className={selectableRow(active)}>
-                        <input
-                          type="radio"
-                          name="vault-target"
-                          checked={active}
-                          onChange={() => setSelection(String(v.id))}
-                          className="accent-primary"
-                        />
-                        <span className="flex flex-col">
-                          <span className="text-sm font-medium text-foreground">
-                            {v.name}
-                          </span>
-                          <span className="text-xs text-muted-foreground">
-                            Sync into this existing vault &middot; {v.note_count} notes
-                          </span>
-                        </span>
-                      </label>
-                    )
-                  })}
-
-                  <label className={selectableRow(isCustom)}>
-                    <input
-                      type="radio"
-                      name="vault-target"
-                      checked={isCustom}
-                      onChange={() => setSelection('custom')}
-                      className="accent-primary"
-                    />
-                    <span className="flex flex-1 flex-col gap-2">
-                      <span className="text-sm font-medium text-foreground">
-                        Create a vault with a custom name
-                      </span>
-                      <input
-                        type="text"
-                        value={customName}
-                        onChange={(e) => {
-                          setCustomName(e.target.value)
-                          if (!isCustom) setSelection('custom')
-                        }}
-                        onFocus={() => setSelection('custom')}
-                        placeholder="choose a new name"
-                        maxLength={100}
-                        className={fieldInput}
-                      />
-                    </span>
-                  </label>
-                </fieldset>
-              )
-            })()}
+            <VaultPickerFieldset
+              vaults={vaults}
+              suggestedName={suggestedName}
+              selection={selection}
+              onSelect={setSelection}
+              customName={customName}
+              onCustomChange={setCustomName}
+            />
 
             <Button
               type="button"
@@ -335,14 +236,7 @@ function SuccessStep({ linkedVaultId, onForward }: SuccessStepProps) {
         </p>
       </div>
 
-      <p
-        role="status"
-        aria-live="polite"
-        className="flex items-center gap-2 rounded-md border border-dashed border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
-      >
-        <span className="inline-block size-2 animate-pulse rounded-full bg-primary align-middle" />
-        Waiting for your first sync…
-      </p>
+      <SyncStatusPill message="Waiting for your first sync…" />
 
       <p className="text-sm text-muted-foreground">
         Once it lands we'll take you to your vault automatically.
@@ -357,5 +251,130 @@ function SuccessStep({ linkedVaultId, onForward }: SuccessStepProps) {
         Skip ahead
       </Button>
     </div>
+  )
+}
+
+interface VaultPickerFieldsetProps {
+  vaults: Vault[]
+  suggestedName: string
+  selection: string
+  onSelect: (next: string) => void
+  customName: string
+  onCustomChange: (next: string) => void
+}
+
+// Stacked-radio picker for the /link consent page. Three row variants:
+//   1. Existing vault whose name matches the plugin's suggestion (top, if any)
+//      — selecting it links into that vault, no creation.
+//   2. Each other existing vault — explicit link target.
+//   3. Custom-name row at the bottom with an inline input — focus or type
+//      to auto-select.
+// If no match-by-name exists and the plugin sent a suggestion, slot a
+// "create with matched name" row at the top instead.
+function VaultPickerFieldset({
+  vaults,
+  suggestedName,
+  selection,
+  onSelect,
+  customName,
+  onCustomChange,
+}: VaultPickerFieldsetProps) {
+  const matchedExisting = suggestedName
+    ? vaults.find((v) => v.name === suggestedName)
+    : undefined
+  const otherVaults = matchedExisting
+    ? vaults.filter((v) => v.id !== matchedExisting.id)
+    : vaults
+  const isMatched = selection === 'matched'
+  const isCustom = selection === 'custom'
+
+  return (
+    <fieldset className="flex flex-col gap-2">
+      {matchedExisting ? (
+        <label className={selectableRow(selection === String(matchedExisting.id))}>
+          <input
+            type="radio"
+            name="vault-target"
+            checked={selection === String(matchedExisting.id)}
+            onChange={() => onSelect(String(matchedExisting.id))}
+            className="accent-primary"
+          />
+          <span className="flex flex-col">
+            <span className="text-sm font-medium text-foreground">
+              {matchedExisting.name}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              Sync into your existing vault &middot; {matchedExisting.note_count} notes
+            </span>
+          </span>
+        </label>
+      ) : (
+        suggestedName && (
+          <label className={selectableRow(isMatched)}>
+            <input
+              type="radio"
+              name="vault-target"
+              checked={isMatched}
+              onChange={() => onSelect('matched')}
+              className="accent-primary"
+            />
+            <span className="flex flex-col">
+              <span className="text-sm font-medium text-foreground">{suggestedName}</span>
+              <span className="text-xs text-muted-foreground">
+                Makes a new vault matching your Obsidian vault name
+              </span>
+            </span>
+          </label>
+        )
+      )}
+
+      {otherVaults.map((v) => {
+        const active = selection === String(v.id)
+        return (
+          <label key={v.id} className={selectableRow(active)}>
+            <input
+              type="radio"
+              name="vault-target"
+              checked={active}
+              onChange={() => onSelect(String(v.id))}
+              className="accent-primary"
+            />
+            <span className="flex flex-col">
+              <span className="text-sm font-medium text-foreground">{v.name}</span>
+              <span className="text-xs text-muted-foreground">
+                Sync into this existing vault &middot; {v.note_count} notes
+              </span>
+            </span>
+          </label>
+        )
+      })}
+
+      <label className={selectableRow(isCustom)}>
+        <input
+          type="radio"
+          name="vault-target"
+          checked={isCustom}
+          onChange={() => onSelect('custom')}
+          className="accent-primary"
+        />
+        <span className="flex flex-1 flex-col gap-2">
+          <span className="text-sm font-medium text-foreground">
+            Create a vault with a custom name
+          </span>
+          <input
+            type="text"
+            value={customName}
+            onChange={(e) => {
+              onCustomChange(e.target.value)
+              if (!isCustom) onSelect('custom')
+            }}
+            onFocus={() => onSelect('custom')}
+            placeholder="choose a new name"
+            maxLength={100}
+            className={fieldInput}
+          />
+        </span>
+      </label>
+    </fieldset>
   )
 }

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAuthAdapter } from '../auth/use-auth-adapter'
 import { useNavigate } from 'react-router'
@@ -9,6 +9,8 @@ import AuthPanel from '../layout/auth-panel'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { heading, fieldInput, destructiveAlert, selectableRow } from '@/lib/ui-classes'
+import { useMe } from '../api/queries'
+import { useVaultReadyEvents } from '../onboarding/use-vault-ready-events'
 
 type Vault = { id: number; name: string; note_count: number }
 
@@ -27,6 +29,7 @@ export default function DeviceLinkPage() {
   const [selection, setSelection] = useState<string>('matched')
   const [suggestedName, setSuggestedName] = useState('')
   const [customName, setCustomName] = useState('')
+  const [linkedVaultId, setLinkedVaultId] = useState<number | null>(null)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -100,12 +103,12 @@ export default function DeviceLinkPage() {
         '/auth/device/authorize',
         body,
       )
-      // Stash the linked vault as active so if the user does come back to
-      // the web later, they land in the right one. We don't auto-navigate —
-      // the plugin still owes us the first sync from inside Obsidian, and
-      // the onboarding wizard auto-advances on the `vault_populated`
-      // broadcast in its own tab.
+      // Stash the linked vault as active so subsequent navigations land in
+      // the right one. We DON'T auto-navigate immediately — the plugin still
+      // owes the first sync from inside Obsidian. The success step listens
+      // for the `vault_populated` broadcast and forwards then.
       setActiveVaultId(vault_id)
+      setLinkedVaultId(vault_id)
       qc.invalidateQueries({ queryKey: ['vaults'] })
       setStep('success')
     } catch (e: unknown) {
@@ -283,26 +286,10 @@ export default function DeviceLinkPage() {
         )}
 
         {step === 'success' && (
-          <div className="flex flex-col gap-3">
-            <h2 className="text-lg font-semibold text-foreground">Vault linked!</h2>
-            <p className="text-sm text-foreground">
-              Head back to Obsidian and kick off your first sync from the
-              plugin. We'll take it from there.
-            </p>
-            <p className="text-sm text-muted-foreground">
-              You can close this tab safely. If you have the Engram dashboard
-              open in another tab, it'll move forward on its own as soon as
-              the sync starts.
-            </p>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => navigate('/')}
-              className="self-start text-sm"
-            >
-              Or skip to the dashboard
-            </Button>
-          </div>
+          <SuccessStep
+            linkedVaultId={linkedVaultId}
+            onForward={() => navigate('/')}
+          />
         )}
 
         {error && (
@@ -315,5 +302,60 @@ export default function DeviceLinkPage() {
         )}
       </AuthPanel>
     </AuthShell>
+  )
+}
+
+interface SuccessStepProps {
+  linkedVaultId: number | null
+  onForward: () => void
+}
+
+function SuccessStep({ linkedVaultId, onForward }: SuccessStepProps) {
+  const { data: me } = useMe()
+  const { vaultPopulated, vaultId } = useVaultReadyEvents({
+    userId: me?.id ?? null,
+    enabled: true,
+  })
+
+  // Auto-forward to the dashboard once the plugin's first sync lands. Match
+  // on `linkedVaultId` so we only forward for THIS link session — broadcasts
+  // from an unrelated vault won't shove us anywhere.
+  useEffect(() => {
+    if (vaultPopulated && vaultId != null && vaultId === linkedVaultId) {
+      onForward()
+    }
+  }, [vaultPopulated, vaultId, linkedVaultId, onForward])
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold text-foreground">Vault linked!</h2>
+        <p className="text-sm text-foreground">
+          Now jump back to Obsidian and run your first sync.
+        </p>
+      </div>
+
+      <p
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-2 rounded-md border border-dashed border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
+      >
+        <span className="inline-block size-2 animate-pulse rounded-full bg-primary align-middle" />
+        Waiting for your first sync…
+      </p>
+
+      <p className="text-sm text-muted-foreground">
+        Once it lands we'll take you to your vault automatically.
+      </p>
+
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={onForward}
+        className="self-start text-sm"
+      >
+        Skip ahead
+      </Button>
+    </div>
   )
 }

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -8,7 +8,7 @@ import AuthShell from '../layout/auth-shell'
 import AuthPanel from '../layout/auth-panel'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { heading, fieldInput, destructiveAlert } from '@/lib/ui-classes'
+import { heading, fieldInput, destructiveAlert, selectableRow } from '@/lib/ui-classes'
 
 type Vault = { id: number; name: string; note_count: number }
 
@@ -21,9 +21,10 @@ export default function DeviceLinkPage() {
   const [step, setStep] = useState<Step>('enter-code')
   const [userCode, setUserCode] = useState('')
   const [vaults, setVaults] = useState<Vault[]>([])
-  // `selection` doubles as the dropdown value: 'new' for create-new, or the
-  // existing vault id stringified (HTML <select> values are strings).
-  const [selection, setSelection] = useState<string>('new')
+  // `selection` is the radio-row value: 'matched' (create new with the
+  // plugin-suggested name), 'custom' (create new with the input below), or
+  // the existing vault id as a string.
+  const [selection, setSelection] = useState<string>('matched')
   const [suggestedName, setSuggestedName] = useState('')
   const [customName, setCustomName] = useState('')
   const [error, setError] = useState('')
@@ -60,10 +61,11 @@ export default function DeviceLinkPage() {
       )
       setUserCode(formattedCode)
       setVaults(data.vaults ?? [])
-      setSuggestedName(data.suggested_vault_name?.trim() || '')
-      // Default selection: always start on "create new" so the matched
-      // Obsidian name leads. Users with existing vaults can pick one explicitly.
-      setSelection('new')
+      const suggested = data.suggested_vault_name?.trim() || ''
+      setSuggestedName(suggested)
+      // Default to the matched-name row when the plugin sent a hint;
+      // otherwise drop straight to the custom-name input.
+      setSelection(suggested ? 'matched' : 'custom')
       setStep('pick-vault')
     } catch {
       setError('Failed to load vaults. Please try again.')
@@ -72,8 +74,14 @@ export default function DeviceLinkPage() {
     }
   }
 
-  const createNew = selection === 'new'
-  const effectiveNewName = (customName.trim() || suggestedName || '').trim()
+  const isMatched = selection === 'matched'
+  const isCustom = selection === 'custom'
+  const createNew = isMatched || isCustom
+  const effectiveNewName = isCustom
+    ? customName.trim()
+    : isMatched
+      ? suggestedName
+      : ''
 
   async function handleAuthorize() {
     setLoading(true)
@@ -105,7 +113,7 @@ export default function DeviceLinkPage() {
     }
   }
 
-  const canAuthorize = createNew ? effectiveNewName.length > 0 : selection !== 'new'
+  const canAuthorize = createNew ? effectiveNewName.length > 0 : true
 
   return (
     <AuthShell>
@@ -140,41 +148,75 @@ export default function DeviceLinkPage() {
               Code verified. Pick where these notes should sync:
             </p>
 
-            <label className="flex flex-col gap-2 text-sm">
-              <span className="font-medium text-foreground">Sync target</span>
-              <select
-                value={selection}
-                onChange={(e) => setSelection(e.target.value)}
-                className={fieldInput}
-              >
-                <option value="new">
-                  {suggestedName
-                    ? `${suggestedName} (Match Obsidian vault name)`
-                    : 'Create a new vault'}
-                </option>
-                {vaults.map((v) => (
-                  <option key={v.id} value={String(v.id)}>
-                    {v.name} ({v.note_count} notes)
-                  </option>
-                ))}
-              </select>
-            </label>
+            <fieldset className="flex flex-col gap-2">
+              {suggestedName && (
+                <label className={selectableRow(isMatched)}>
+                  <input
+                    type="radio"
+                    name="vault-target"
+                    checked={isMatched}
+                    onChange={() => setSelection('matched')}
+                    className="accent-primary"
+                  />
+                  <span className="flex flex-col">
+                    <span className="text-sm font-medium text-foreground">
+                      Create a vault called &ldquo;{suggestedName}&rdquo;
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      Matches your Obsidian vault name
+                    </span>
+                  </span>
+                </label>
+              )}
 
-            {createNew && (
-              <label className="flex flex-col gap-2 text-sm">
-                <span className="font-medium text-foreground">
-                  Use a different name (optional)
-                </span>
+              {vaults.map((v) => {
+                const active = selection === String(v.id)
+                return (
+                  <label key={v.id} className={selectableRow(active)}>
+                    <input
+                      type="radio"
+                      name="vault-target"
+                      checked={active}
+                      onChange={() => setSelection(String(v.id))}
+                      className="accent-primary"
+                    />
+                    <span className="flex flex-col">
+                      <span className="text-sm font-medium text-foreground">{v.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        Sync into this existing vault &middot; {v.note_count} notes
+                      </span>
+                    </span>
+                  </label>
+                )
+              })}
+
+              <label className={selectableRow(isCustom)}>
                 <input
-                  type="text"
-                  value={customName}
-                  onChange={(e) => setCustomName(e.target.value)}
-                  placeholder="choose new name"
-                  maxLength={100}
-                  className={fieldInput}
+                  type="radio"
+                  name="vault-target"
+                  checked={isCustom}
+                  onChange={() => setSelection('custom')}
+                  className="accent-primary"
                 />
+                <span className="flex flex-1 flex-col gap-2">
+                  <span className="text-sm font-medium text-foreground">
+                    Create a vault with a custom name
+                  </span>
+                  <input
+                    type="text"
+                    value={customName}
+                    onChange={(e) => {
+                      setCustomName(e.target.value)
+                      if (!isCustom) setSelection('custom')
+                    }}
+                    onFocus={() => setSelection('custom')}
+                    placeholder="choose a new name"
+                    maxLength={100}
+                    className={fieldInput}
+                  />
+                </span>
               </label>
-            )}
+            </fieldset>
 
             <Button
               type="button"

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -160,10 +160,10 @@ export default function DeviceLinkPage() {
                   />
                   <span className="flex flex-col">
                     <span className="text-sm font-medium text-foreground">
-                      Create a vault called &ldquo;{suggestedName}&rdquo;
+                      &ldquo;{suggestedName}&rdquo;
                     </span>
                     <span className="text-xs text-muted-foreground">
-                      Matches your Obsidian vault name
+                      Makes a new vault matching your Obsidian vault name
                     </span>
                   </span>
                 </label>

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -126,7 +126,7 @@ export default function DeviceLinkPage() {
         )}
       >
         <h1 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-          Link Obsidian Vault
+          {step === 'pick-vault' ? 'Choose a vault to sync' : 'Link Obsidian Vault'}
         </h1>
 
         {step === 'enter-code' && (
@@ -152,7 +152,7 @@ export default function DeviceLinkPage() {
         {step === 'pick-vault' && (
           <div className="flex flex-col gap-3">
             <p className="text-sm text-muted-foreground">
-              Code verified. Pick where these notes should sync:
+              Pick an existing one, or create a new vault for these notes.
             </p>
 
             <fieldset className="flex flex-col gap-2">

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -143,7 +143,7 @@ export default function DeviceLinkPage() {
         )}
 
         {step === 'pick-vault' && (
-          <div className="flex flex-col gap-3">
+          <div className="mx-auto flex w-full flex-col gap-3 sm:w-3/5">
             <p className="text-sm text-muted-foreground">
               Code verified. Pick where these notes should sync:
             </p>
@@ -160,7 +160,7 @@ export default function DeviceLinkPage() {
                   />
                   <span className="flex flex-col">
                     <span className="text-sm font-medium text-foreground">
-                      &ldquo;{suggestedName}&rdquo;
+                      {suggestedName}
                     </span>
                     <span className="text-xs text-muted-foreground">
                       Makes a new vault matching your Obsidian vault name

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -271,17 +271,19 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
       </h2>
       <ol className="flex list-decimal flex-col gap-3 pl-5 text-base text-foreground">
         <li>
-          Open the{' '}
+          In Obsidian, go to{' '}
+          <strong>Settings → Community plugins → Browse</strong>, search for{' '}
+          <em>Engram</em>, then install and enable it. You can also open the{' '}
           <a
             href="https://community.obsidian.md/plugins/engram-vault-sync"
             target="_blank"
             rel="noreferrer noopener"
             className="font-medium text-primary underline-offset-2 hover:underline"
           >
-            Engram plugin listing
+            plugin listing
           </a>
-          {' '}in Obsidian's community plugins (or visit the page directly),
-          then install and enable it.
+          {' '}in your browser if you'd rather start there. Either way, make
+          sure it's <strong>enabled</strong> before moving on.
         </li>
         <li>
           Inside the plugin, click <strong>Sign in</strong> and authenticate

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -77,9 +77,31 @@ function VaultStep({
   const [source, setSource] = useState<Source>(
     profileSaved ? (savedUsesObsidian ? 'obsidian' : 'fresh') : null,
   )
+  // Track whether we've eager-committed `uses_obsidian: true` so the plugin's
+  // first sync isn't blocked by RequireOnboarding. The gate skips the vault
+  // check when uses_obsidian is true — without this, /api/notes 403s mid-sync
+  // and `vault_populated` never fires.
+  const [obsidianCommitted, setObsidianCommitted] = useState<boolean>(
+    profileSaved && savedUsesObsidian,
+  )
+
+  async function pickSource(s: Source) {
+    setSource(s)
+    if (s === 'obsidian' && !obsidianCommitted) {
+      try {
+        await setProfile.mutateAsync({ uses_obsidian: true })
+        setObsidianCommitted(true)
+      } catch {
+        // Surface as the panel's normal error path on next interaction
+      }
+    }
+  }
 
   async function commitObsidian() {
-    await setProfile.mutateAsync({ uses_obsidian: true })
+    if (!obsidianCommitted) {
+      await setProfile.mutateAsync({ uses_obsidian: true })
+      setObsidianCommitted(true)
+    }
     navigate('/', { replace: true })
   }
 
@@ -103,7 +125,7 @@ function VaultStep({
   return (
     <SourceScreen
       source={source}
-      onPickSource={setSource}
+      onPickSource={pickSource}
       userId={userId}
       isCommitting={
         setProfile.isPending || createVault.isPending || updateNote.isPending

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -249,14 +249,6 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
         </li>
       </ol>
       <StatusRow stage={stage} />
-      <button
-        type="button"
-        onClick={() => void onCommit()}
-        disabled={isCommitting}
-        className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-accent/40 disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        {isCommitting ? 'Saving…' : "I've installed it — take me to my dashboard"}
-      </button>
     </div>
   )
 }

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -14,6 +14,7 @@ import {
 import AuthPanel from '@/layout/auth-panel'
 import LoadingScreen from '../layout/loading-screen'
 import { heading } from '@/lib/ui-classes'
+import { SyncStatusPill } from './sync-status-pill'
 import { useVaultReadyEvents } from './use-vault-ready-events'
 import { WELCOME_NOTE_CONTENT, WELCOME_NOTE_PATH } from './welcome-note'
 
@@ -90,12 +91,18 @@ function VaultStep({
 
   async function pickSource(s: Source) {
     setSource(s)
-    if (s === 'obsidian' && !obsidianCommitted) {
+    // Re-entry guard: a fast double-click on the Obsidian card would
+    // otherwise dispatch two concurrent PATCHes. The `obsidianCommitted`
+    // flag catches the steady state; `setProfile.isPending` catches the
+    // racing-while-the-first-is-in-flight case.
+    if (s === 'obsidian' && !obsidianCommitted && !setProfile.isPending) {
       try {
         await setProfile.mutateAsync({ uses_obsidian: true })
         setObsidianCommitted(true)
-      } catch {
-        // Surface as the panel's normal error path on next interaction
+      } catch (_e) {
+        // Error is also reflected on setProfile.isError so the panel can
+        // surface it; swallowing here just prevents a console unhandled
+        // rejection. The user sees the inline error message below.
       }
     }
   }
@@ -133,6 +140,11 @@ function VaultStep({
       isCommitting={
         setProfile.isPending || createVault.isPending || updateNote.isPending
       }
+      pickError={
+        setProfile.isError && !obsidianCommitted
+          ? 'Could not save your choice. Try clicking again — if it keeps failing, refresh the page.'
+          : null
+      }
       onCommitObsidian={commitObsidian}
       onCommitFresh={commitFresh}
     />
@@ -146,6 +158,7 @@ interface SourceScreenProps {
   onPickSource: (s: Source) => void
   userId: number | null
   isCommitting: boolean
+  pickError: string | null
   onCommitObsidian: () => Promise<void>
   onCommitFresh: (name: string) => Promise<void>
 }
@@ -155,6 +168,7 @@ function SourceScreen({
   onPickSource,
   userId,
   isCommitting,
+  pickError,
   onCommitObsidian,
   onCommitFresh,
 }: SourceScreenProps) {
@@ -190,6 +204,12 @@ function SourceScreen({
           onClick={() => onPickSource('fresh')}
         />
       </div>
+
+      {pickError && (
+        <p role="alert" className="text-sm text-destructive">
+          {pickError}
+        </p>
+      )}
 
       {source === 'obsidian' ? (
         <ObsidianInlinePanel
@@ -326,16 +346,7 @@ function StatusRow({ stage }: { stage: 'waiting' | 'detected' | 'syncing' }) {
     detected: 'Vault detected. Waiting for your first sync…',
     syncing: 'Syncing your notes, almost there…',
   }
-  return (
-    <p
-      role="status"
-      aria-live="polite"
-      className="rounded-md border border-dashed border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
-    >
-      <span className="mr-2 inline-block size-2 animate-pulse rounded-full bg-primary align-middle" />
-      {labels[stage]}
-    </p>
-  )
+  return <SyncStatusPill message={labels[stage]} />
 }
 
 // ── Fresh-start inline panel ──────────────────────────────────────────────────

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -177,7 +177,7 @@ function SourceScreen({
             />
           }
           title="I already use Obsidian"
-          body="Install our plugin and your existing notes sync over on the first connect. Nothing empty to fill in."
+          body="Install our plugin and your existing notes sync over on the first connect."
           selected={source === 'obsidian'}
           onClick={() => onPickSource('obsidian')}
         />

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -3,6 +3,7 @@ import { Navigate, useNavigate } from 'react-router'
 import { FilePlus2 } from 'lucide-react'
 import obsidianMark from '@lobehub/icons-static-svg/icons/obsidian-color.svg?raw'
 import { setActiveVaultId } from '../api/active-vault'
+import { config } from '../config'
 import {
   useCreateVault,
   useMe,
@@ -288,10 +289,23 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
             {' '}in your browser first.
           </span>
         </li>
-        <li>
-          Inside the plugin, click <strong>Sign in</strong> and authenticate
-          with your Engram account.
-        </li>
+        {config.authProvider === 'local' ? (
+          <li className="flex flex-col gap-1">
+            <span>
+              Open the plugin's <strong>🖥️ Self-hosted</strong> tab, enter
+              your Engram server URL, and click <strong>Sign in</strong>.
+            </span>
+            <span className="text-sm text-muted-foreground">
+              Use the same URL you used to reach this page.
+            </span>
+          </li>
+        ) : (
+          <li>
+            Open the plugin's <strong>☁️ Cloud</strong> tab, click{' '}
+            <strong>Sign in</strong>, and authenticate with your Engram
+            account.
+          </li>
+        )}
         <li>
           Pick a vault to sync. The plugin creates a matching Engram vault
           and pushes your existing files.

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -160,11 +160,10 @@ function SourceScreen({
   return (
     <AuthPanel className="flex flex-col gap-6">
       <header className="flex flex-col gap-2">
-        <h1 className={heading}>How would you like to get started?</h1>
+        <h1 className={heading}>Let's get your notes in.</h1>
         <p className="text-sm text-muted-foreground">
-          Your notes are stored as plain markdown files. You can use Obsidian
-          if you like, or just start typing here. Pick what sounds easier
-          and we'll set things up for you.
+          If you have an Obsidian vault, we'll pull it in on the first
+          connect. If not, we'll spin up a new vault for you.
         </p>
       </header>
 

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Navigate, useNavigate } from 'react-router'
+import { FilePlus2 } from 'lucide-react'
+import obsidianMark from '@lobehub/icons-static-svg/icons/obsidian-color.svg?raw'
 import { setActiveVaultId } from '../api/active-vault'
 import {
   useCreateVault,
@@ -158,24 +160,32 @@ function SourceScreen({
   return (
     <AuthPanel className="flex flex-col gap-6">
       <header className="flex flex-col gap-2">
-        <h1 className={heading}>Where do your notes live?</h1>
+        <h1 className={heading}>How would you like to get started?</h1>
         <p className="text-sm text-muted-foreground">
-          Engram stores your notes as plain markdown files. Obsidian is one
-          way to read them — not required. Pick a side and we'll get you set
-          up right here.
+          Your notes are stored as plain markdown files. You can use Obsidian
+          if you like, or just start typing here. Pick what sounds easier
+          and we'll set things up for you.
         </p>
       </header>
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <SourceCard
+          icon={
+            <span
+              aria-hidden
+              className="inline-flex h-6 w-6 shrink-0 items-center justify-center [&_svg]:h-full [&_svg]:w-full"
+              dangerouslySetInnerHTML={{ __html: obsidianMark }}
+            />
+          }
           title="I already use Obsidian"
-          body="Install our plugin and your first sync creates the vault — no empty placeholder."
+          body="Install our plugin and your existing notes sync over on the first connect. Nothing empty to fill in."
           selected={source === 'obsidian'}
           onClick={() => onPickSource('obsidian')}
         />
         <SourceCard
+          icon={<FilePlus2 aria-hidden className="h-6 w-6 shrink-0 text-foreground" />}
           title="I'm starting fresh"
-          body="We'll create your first vault now. You can rename or add more later from settings."
+          body="We'll create your first vault right now. You can rename it or add more later from settings."
           selected={source === 'fresh'}
           onClick={() => onPickSource('fresh')}
         />
@@ -195,13 +205,14 @@ function SourceScreen({
 }
 
 interface SourceCardProps {
+  icon: React.ReactNode
   title: string
   body: string
   selected: boolean
   onClick: () => void
 }
 
-function SourceCard({ title, body, selected, onClick }: SourceCardProps) {
+function SourceCard({ icon, title, body, selected, onClick }: SourceCardProps) {
   return (
     <button
       type="button"
@@ -214,8 +225,11 @@ function SourceCard({ title, body, selected, onClick }: SourceCardProps) {
           : 'border-border bg-background hover:border-primary hover:bg-accent/30')
       }
     >
-      <span className="text-base font-semibold text-foreground group-hover:text-primary">
-        {title}
+      <span className="flex items-center gap-2">
+        {icon}
+        <span className="text-base font-semibold text-foreground group-hover:text-primary">
+          {title}
+        </span>
       </span>
       <span className="text-sm text-muted-foreground">{body}</span>
     </button>
@@ -279,7 +293,7 @@ function StatusRow({ stage }: { stage: 'waiting' | 'detected' | 'syncing' }) {
   const labels: Record<typeof stage, string> = {
     waiting: 'Waiting for the plugin to sign in…',
     detected: 'Vault detected. Waiting for your first sync…',
-    syncing: 'Syncing your notes — almost there…',
+    syncing: 'Syncing your notes, almost there…',
   }
   return (
     <p

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -266,13 +266,22 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
 
   return (
     <div className="flex flex-col gap-4 rounded-xl border border-border bg-muted/30 p-5">
-      <h2 className="text-base font-semibold text-foreground">
+      <h2 className="text-lg font-semibold text-foreground">
         Install the Engram plugin
       </h2>
-      <ol className="flex list-decimal flex-col gap-2 pl-5 text-sm text-foreground">
+      <ol className="flex list-decimal flex-col gap-3 pl-5 text-base text-foreground">
         <li>
-          Open Obsidian → <strong>Settings → Community plugins → Browse</strong>,
-          search for <em>Engram</em>, install and enable it.
+          Open the{' '}
+          <a
+            href="https://community.obsidian.md/plugins/engram-vault-sync"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="font-medium text-primary underline-offset-2 hover:underline"
+          >
+            Engram plugin listing
+          </a>
+          {' '}in Obsidian's community plugins (or visit the page directly),
+          then install and enable it.
         </li>
         <li>
           Inside the plugin, click <strong>Sign in</strong> and authenticate

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -267,13 +267,13 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
   return (
     <div className="flex flex-col gap-4 rounded-xl border border-border bg-muted/30 p-5">
       <h2 className="text-lg font-semibold text-foreground">
-        Install the Engram plugin
+        Install the Engram Vault Sync plugin
       </h2>
       <ol className="flex list-decimal flex-col gap-3 pl-5 text-base text-foreground">
         <li className="flex flex-col gap-1">
           <span>
             In Obsidian: <strong>Settings → Community plugins → Browse</strong>,
-            search <em>Engram</em>, then install and enable it.
+            search <em>Engram Vault Sync</em>, then install and enable it.
           </span>
           <span className="text-sm text-muted-foreground">
             Or open the{' '}

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -271,33 +271,37 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
         Install the Engram Vault Sync plugin
       </h2>
       <ol className="flex list-decimal flex-col gap-3 pl-5 text-base text-foreground">
-        <li className="flex flex-col gap-1">
-          <span>
-            In Obsidian: <strong>Settings → Community plugins → Browse</strong>,
-            search <em>Engram Vault Sync</em>, then install and enable it.
-          </span>
-          <span className="text-sm text-muted-foreground">
-            Or open the{' '}
-            <a
-              href="https://community.obsidian.md/plugins/engram-vault-sync"
-              target="_blank"
-              rel="noreferrer noopener"
-              className="font-medium text-primary underline-offset-2 hover:underline"
-            >
-              plugin listing
-            </a>
-            {' '}in your browser first.
-          </span>
-        </li>
-        {config.authProvider === 'local' ? (
-          <li className="flex flex-col gap-1">
+        <li>
+          <div className="flex flex-col gap-1">
             <span>
-              Open the plugin's <strong>🖥️ Self-hosted</strong> tab, enter
-              your Engram server URL, and click <strong>Sign in</strong>.
+              In Obsidian: <strong>Settings → Community plugins → Browse</strong>,
+              search <em>Engram Vault Sync</em>, then install and enable it.
             </span>
             <span className="text-sm text-muted-foreground">
-              Use the same URL you used to reach this page.
+              Or open the{' '}
+              <a
+                href="https://community.obsidian.md/plugins/engram-vault-sync"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-medium text-primary underline-offset-2 hover:underline"
+              >
+                plugin listing
+              </a>
+              {' '}in your browser first.
             </span>
+          </div>
+        </li>
+        {config.authProvider === 'local' ? (
+          <li>
+            <div className="flex flex-col gap-1">
+              <span>
+                Open the plugin's <strong>🖥️ Self-hosted</strong> tab, enter
+                your Engram server URL, and click <strong>Sign in</strong>.
+              </span>
+              <span className="text-sm text-muted-foreground">
+                Use the same URL you used to reach this page.
+              </span>
+            </div>
           </li>
         ) : (
           <li>

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -270,20 +270,23 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
         Install the Engram plugin
       </h2>
       <ol className="flex list-decimal flex-col gap-3 pl-5 text-base text-foreground">
-        <li>
-          In Obsidian, go to{' '}
-          <strong>Settings → Community plugins → Browse</strong>, search for{' '}
-          <em>Engram</em>, then install and enable it. You can also open the{' '}
-          <a
-            href="https://community.obsidian.md/plugins/engram-vault-sync"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="font-medium text-primary underline-offset-2 hover:underline"
-          >
-            plugin listing
-          </a>
-          {' '}in your browser if you'd rather start there. Either way, make
-          sure it's <strong>enabled</strong> before moving on.
+        <li className="flex flex-col gap-1">
+          <span>
+            In Obsidian: <strong>Settings → Community plugins → Browse</strong>,
+            search <em>Engram</em>, then install and enable it.
+          </span>
+          <span className="text-sm text-muted-foreground">
+            Or open the{' '}
+            <a
+              href="https://community.obsidian.md/plugins/engram-vault-sync"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="font-medium text-primary underline-offset-2 hover:underline"
+            >
+              plugin listing
+            </a>
+            {' '}in your browser first.
+          </span>
         </li>
         <li>
           Inside the plugin, click <strong>Sign in</strong> and authenticate

--- a/frontend/src/onboarding/sync-status-pill.tsx
+++ b/frontend/src/onboarding/sync-status-pill.tsx
@@ -1,0 +1,27 @@
+/**
+ * Live status indicator for the plugin-sync handshake. Used by both the
+ * onboarding wizard's Obsidian branch and the `/link` success step, which
+ * each spend time waiting on the same Phoenix `vault_populated` broadcast.
+ *
+ * Visual contract: dashed border, muted background, pulsing primary dot,
+ * one line of muted copy. Centralized so the two surfaces can't drift.
+ */
+interface SyncStatusPillProps {
+  message: string
+}
+
+export function SyncStatusPill({ message }: SyncStatusPillProps) {
+  return (
+    <p
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-2 rounded-md border border-dashed border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
+    >
+      <span
+        aria-hidden
+        className="inline-block size-2 shrink-0 animate-pulse rounded-full bg-primary"
+      />
+      <span>{message}</span>
+    </p>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -64,6 +64,11 @@ export const router = createBrowserRouter(
           ],
         },
 
+        // /link is reachable mid-onboarding — the wizard's Obsidian branch
+        // requires the user to complete device-flow here before progressing.
+        // Sits OUTSIDE the OnboardingGate to dodge the redirect-to-/onboard.
+        { path: ROUTES.DEVICE_LINK, element: <DeviceLinkPage /> },
+
         // Dashboard tree — gated by OnboardingGate.
         {
           element: <OnboardingGate />,
@@ -120,7 +125,6 @@ export const router = createBrowserRouter(
                   : []),
               ],
             },
-            { path: ROUTES.DEVICE_LINK, element: <DeviceLinkPage /> },
             { path: ROUTES.OAUTH_CONSENT, element: <OAuthAuthorizePage /> },
           ],
         },

--- a/lib/engram/accounts.ex
+++ b/lib/engram/accounts.ex
@@ -254,7 +254,7 @@ defmodule Engram.Accounts do
   defp guard_last_admin(_user), do: :ok
 
   # Sentinel revocation timestamp used by admin and breach paths. Pinned at
-  # epoch 0 so it always falls OUTSIDE `@refresh_leeway_seconds` — without
+  # epoch 0 so it always falls OUTSIDE `Engram.Auth.RefreshLeeway` — without
   # this the next request after a logout-everywhere or family breach would
   # land inside the leeway window, get misread as a benign rotation race,
   # and silently re-issue a fresh token (defeating the revocation). Keeping
@@ -297,15 +297,8 @@ defmodule Engram.Accounts do
   # ── Refresh Tokens ─────────────────────────────────────────────
 
   @refresh_token_ttl_days 30
-  # Leeway window after a refresh token is rotated during which the old token
-  # is still accepted, so a client that loses (or hasn't yet observed) the new
-  # cookie can recover instead of being forced to re-login. Mirrors the
-  # device-flow path in `Engram.Auth.DeviceFlow` and the Auth0 "rotation
-  # overlap period" pattern. Real concurrent rotation races resolve in <1s;
-  # 30s is comfortably wider than any legitimate replay window but well below
-  # the "stolen token used hours later" attacker case the breach-on-reuse
-  # detection is meant to catch.
-  @refresh_leeway_seconds 30
+  # Leeway-window policy lives in `Engram.Auth.RefreshLeeway` so both
+  # local-auth and device-flow refresh paths share the same window.
 
   def create_refresh_token(user, family_id \\ nil) do
     raw_token = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
@@ -371,15 +364,21 @@ defmodule Engram.Accounts do
   end
 
   # Rotate `token` into a fresh child within its family. Guards on user
-  # suspended/deleted state (same chokepoint as `verify_password/2`). Called
-  # both from the normal "just-revoked-now" rotation and from the leeway
-  # branch in `classify_unrotated/2`.
+  # suspended/deleted state (same chokepoint as `verify_password/2`). The
+  # 2-arity overload takes a preloaded user (used by `classify_unrotated/2`
+  # which already loads the user in its lookup query, avoiding an N+1); the
+  # 1-arity overload fetches the user separately and is used by the
+  # just-revoked-now path which can't preload through update_all.
   defp rotate_into_child(token) do
     user =
       Repo.one!(from(u in Engram.Accounts.User, where: u.id == ^token.user_id),
         skip_tenant_check: true
       )
 
+    rotate_into_child(token, user)
+  end
+
+  defp rotate_into_child(token, %Engram.Accounts.User{} = user) do
     cond do
       not is_nil(user.suspended_at) -> Repo.rollback(:suspended)
       not is_nil(user.deleted_at) -> Repo.rollback(:deleted)
@@ -394,21 +393,22 @@ defmodule Engram.Accounts do
 
   # No row was just-revoked, so either the token never existed, was previously
   # revoked, or is being raced. Inside the leeway → benign concurrent rotation,
-  # issue a child; outside → genuine reuse, breach.
+  # issue a child; outside → genuine reuse, breach. Preloads :user so the
+  # leeway-branch rotation doesn't need a separate user fetch.
   defp classify_unrotated(token_hash, now) do
-    case Repo.one(from(rt in RefreshToken, where: rt.token_hash == ^token_hash),
+    case Repo.one(
+           from(rt in RefreshToken,
+             where: rt.token_hash == ^token_hash,
+             preload: [:user]
+           ),
            skip_tenant_check: true
          ) do
       nil ->
         Repo.rollback(:invalid_token)
 
-      %RefreshToken{revoked_at: revoked} = revoked_token when revoked != nil ->
-        leeway_cutoff =
-          DateTime.add(now, -@refresh_leeway_seconds, :second)
-          |> DateTime.truncate(:second)
-
-        if DateTime.compare(revoked, leeway_cutoff) == :gt do
-          rotate_into_child(revoked_token)
+      %RefreshToken{revoked_at: revoked, user: user} = revoked_token when revoked != nil ->
+        if Engram.Auth.RefreshLeeway.benign?(revoked, now) do
+          rotate_into_child(revoked_token, user)
         else
           Repo.rollback({:token_reused, token_hash})
         end

--- a/lib/engram/accounts.ex
+++ b/lib/engram/accounts.ex
@@ -253,16 +253,21 @@ defmodule Engram.Accounts do
 
   defp guard_last_admin(_user), do: :ok
 
+  # Sentinel revocation timestamp used by admin and breach paths. Pinned at
+  # epoch 0 so it always falls OUTSIDE `@refresh_leeway_seconds` — without
+  # this the next request after a logout-everywhere or family breach would
+  # land inside the leeway window, get misread as a benign rotation race,
+  # and silently re-issue a fresh token (defeating the revocation). Keeping
+  # the rows preserves audit history for `Engram.Connections.any_history?`
+  # and `device_history?`, which distinguish "already revoked" from "never
+  # existed" by row presence.
+  @admin_revoked_at ~U[1970-01-01 00:00:00Z]
+
   @doc "Spec §8/§10 — revokes all of a user's refresh tokens (logout-everywhere)."
   def revoke_all_user_tokens(%User{id: user_id}) do
-    # Hard-delete the rows. Stamping `revoked_at: now` would put them inside
-    # the rotation-leeway window so a still-pending request from the user
-    # would be misread as a benign rotation race and re-issued — defeating
-    # the "logout everywhere" guarantee that password-reset / admin actions
-    # rely on. Matches the breach path's deletion strategy.
     RefreshToken
-    |> where([rt], rt.user_id == ^user_id)
-    |> Repo.delete_all(skip_tenant_check: true)
+    |> where([rt], rt.user_id == ^user_id and is_nil(rt.revoked_at))
+    |> Repo.update_all([set: [revoked_at: @admin_revoked_at]], skip_tenant_check: true)
   end
 
   def verify_password(email, password) do
@@ -430,14 +435,16 @@ defmodule Engram.Accounts do
 
     Logger.warning("refresh-token reuse detected; revoking family family_id=#{family_id}")
 
-    # Hard-delete the family (matches `DeviceFlow.invalidate_family/1`). Stamping
-    # `revoked_at` to "now" would put every member of the family inside the
-    # leeway window so a follow-up request with the current child would be
-    # mistaken for a benign rotation race and re-issue tokens — defeating the
-    # revocation. The family_id is owner-bound (never crosses users), so only
-    # the compromised lineage is touched.
-    from(rt in RefreshToken, where: rt.family_id == ^family_id)
-    |> Repo.delete_all(skip_tenant_check: true)
+    # Mark every still-live member of the family as revoked using the
+    # `@admin_revoked_at` sentinel (epoch 0). Stamping with `now` would put
+    # them inside the leeway window so a follow-up request with the current
+    # child would be mistaken for a benign rotation race and re-issue tokens —
+    # defeating the revocation. Deleting (the prior approach) broke
+    # `Connections.any_history?`, which distinguishes "already revoked" from
+    # "never existed" by row presence. Sentinel gives us both: leeway always
+    # closes, and history queries still see the row.
+    from(rt in RefreshToken, where: rt.family_id == ^family_id and is_nil(rt.revoked_at))
+    |> Repo.update_all([set: [revoked_at: @admin_revoked_at]], skip_tenant_check: true)
   end
 
   @doc "SHA-256 hash a raw refresh token for storage/lookup."

--- a/lib/engram/accounts.ex
+++ b/lib/engram/accounts.ex
@@ -253,13 +253,16 @@ defmodule Engram.Accounts do
 
   defp guard_last_admin(_user), do: :ok
 
-  @doc "Spec §8/§10 — revokes all of a user's active refresh tokens (logout-everywhere)."
+  @doc "Spec §8/§10 — revokes all of a user's refresh tokens (logout-everywhere)."
   def revoke_all_user_tokens(%User{id: user_id}) do
-    now = DateTime.utc_now(:second)
-
+    # Hard-delete the rows. Stamping `revoked_at: now` would put them inside
+    # the rotation-leeway window so a still-pending request from the user
+    # would be misread as a benign rotation race and re-issued — defeating
+    # the "logout everywhere" guarantee that password-reset / admin actions
+    # rely on. Matches the breach path's deletion strategy.
     RefreshToken
-    |> where([rt], rt.user_id == ^user_id and is_nil(rt.revoked_at))
-    |> Repo.update_all([set: [revoked_at: now]], skip_tenant_check: true)
+    |> where([rt], rt.user_id == ^user_id)
+    |> Repo.delete_all(skip_tenant_check: true)
   end
 
   def verify_password(email, password) do
@@ -289,6 +292,15 @@ defmodule Engram.Accounts do
   # ── Refresh Tokens ─────────────────────────────────────────────
 
   @refresh_token_ttl_days 30
+  # Leeway window after a refresh token is rotated during which the old token
+  # is still accepted, so a client that loses (or hasn't yet observed) the new
+  # cookie can recover instead of being forced to re-login. Mirrors the
+  # device-flow path in `Engram.Auth.DeviceFlow` and the Auth0 "rotation
+  # overlap period" pattern. Real concurrent rotation races resolve in <1s;
+  # 30s is comfortably wider than any legitimate replay window but well below
+  # the "stolen token used hours later" attacker case the breach-on-reuse
+  # detection is meant to catch.
+  @refresh_leeway_seconds 30
 
   def create_refresh_token(user, family_id \\ nil) do
     raw_token = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
@@ -329,39 +341,11 @@ defmodule Engram.Accounts do
               if DateTime.compare(now, token.expires_at) == :gt do
                 Repo.rollback(:expired)
               else
-                user =
-                  Repo.one!(from(u in Engram.Accounts.User, where: u.id == ^token.user_id),
-                    skip_tenant_check: true
-                  )
-
-                # Spec §10: same guard as the login chokepoint (verify_password).
-                cond do
-                  not is_nil(user.suspended_at) -> Repo.rollback(:suspended)
-                  not is_nil(user.deleted_at) -> Repo.rollback(:deleted)
-                  true -> :ok
-                end
-
-                case create_refresh_token(user, token.family_id) do
-                  {:ok, new_raw, new_record} -> {user, new_raw, new_record}
-                  {:error, _reason} -> Repo.rollback(:refresh_token_creation_failed)
-                end
+                rotate_into_child(token)
               end
 
             {0, _} ->
-              # Token doesn't exist or already revoked — check which case
-              case Repo.one(from(rt in RefreshToken, where: rt.token_hash == ^token_hash),
-                     skip_tenant_check: true
-                   ) do
-                nil ->
-                  Repo.rollback(:invalid_token)
-
-                %RefreshToken{revoked_at: revoked} when revoked != nil ->
-                  # Signal reuse — revocation happens AFTER the transaction commits
-                  Repo.rollback({:token_reused, token_hash})
-
-                %RefreshToken{} ->
-                  Repo.rollback(:invalid_token)
-              end
+              classify_unrotated(token_hash, now)
           end
         end,
         skip_tenant_check: true
@@ -381,6 +365,54 @@ defmodule Engram.Accounts do
     end
   end
 
+  # Rotate `token` into a fresh child within its family. Guards on user
+  # suspended/deleted state (same chokepoint as `verify_password/2`). Called
+  # both from the normal "just-revoked-now" rotation and from the leeway
+  # branch in `classify_unrotated/2`.
+  defp rotate_into_child(token) do
+    user =
+      Repo.one!(from(u in Engram.Accounts.User, where: u.id == ^token.user_id),
+        skip_tenant_check: true
+      )
+
+    cond do
+      not is_nil(user.suspended_at) -> Repo.rollback(:suspended)
+      not is_nil(user.deleted_at) -> Repo.rollback(:deleted)
+      true -> :ok
+    end
+
+    case create_refresh_token(user, token.family_id) do
+      {:ok, new_raw, new_record} -> {user, new_raw, new_record}
+      {:error, _reason} -> Repo.rollback(:refresh_token_creation_failed)
+    end
+  end
+
+  # No row was just-revoked, so either the token never existed, was previously
+  # revoked, or is being raced. Inside the leeway → benign concurrent rotation,
+  # issue a child; outside → genuine reuse, breach.
+  defp classify_unrotated(token_hash, now) do
+    case Repo.one(from(rt in RefreshToken, where: rt.token_hash == ^token_hash),
+           skip_tenant_check: true
+         ) do
+      nil ->
+        Repo.rollback(:invalid_token)
+
+      %RefreshToken{revoked_at: revoked} = revoked_token when revoked != nil ->
+        leeway_cutoff =
+          DateTime.add(now, -@refresh_leeway_seconds, :second)
+          |> DateTime.truncate(:second)
+
+        if DateTime.compare(revoked, leeway_cutoff) == :gt do
+          rotate_into_child(revoked_token)
+        else
+          Repo.rollback({:token_reused, token_hash})
+        end
+
+      %RefreshToken{} ->
+        Repo.rollback(:invalid_token)
+    end
+  end
+
   def revoke_token_family(family_id_or_token_hash) do
     family_id =
       case Repo.one(
@@ -394,12 +426,18 @@ defmodule Engram.Accounts do
         fid -> fid
       end
 
-    now = DateTime.utc_now(:second)
+    require Logger
 
-    from(rt in RefreshToken,
-      where: rt.family_id == ^family_id and is_nil(rt.revoked_at)
-    )
-    |> Repo.update_all([set: [revoked_at: now]], skip_tenant_check: true)
+    Logger.warning("refresh-token reuse detected; revoking family family_id=#{family_id}")
+
+    # Hard-delete the family (matches `DeviceFlow.invalidate_family/1`). Stamping
+    # `revoked_at` to "now" would put every member of the family inside the
+    # leeway window so a follow-up request with the current child would be
+    # mistaken for a benign rotation race and re-issue tokens — defeating the
+    # revocation. The family_id is owner-bound (never crosses users), so only
+    # the compromised lineage is touched.
+    from(rt in RefreshToken, where: rt.family_id == ^family_id)
+    |> Repo.delete_all(skip_tenant_check: true)
   end
 
   @doc "SHA-256 hash a raw refresh token for storage/lookup."

--- a/lib/engram/auth/device_authorization.ex
+++ b/lib/engram/auth/device_authorization.ex
@@ -8,6 +8,7 @@ defmodule Engram.Auth.DeviceAuthorization do
     field :client_id, :string
     field :status, :string, default: "pending"
     field :expires_at, :utc_datetime
+    field :vault_name, :string
 
     belongs_to :user, Engram.Accounts.User
     belongs_to :vault, Engram.Vaults.Vault
@@ -17,8 +18,9 @@ defmodule Engram.Auth.DeviceAuthorization do
 
   def changeset(auth, attrs) do
     auth
-    |> cast(attrs, [:device_code, :user_code, :client_id, :status, :expires_at])
+    |> cast(attrs, [:device_code, :user_code, :client_id, :status, :expires_at, :vault_name])
     |> validate_required([:device_code, :user_code, :client_id, :status, :expires_at])
+    |> validate_length(:vault_name, max: 100)
     |> validate_inclusion(:status, ~w(pending authorized consumed expired))
     |> unique_constraint(:device_code)
     |> unique_constraint(:user_code)

--- a/lib/engram/auth/device_authorization.ex
+++ b/lib/engram/auth/device_authorization.ex
@@ -12,6 +12,7 @@ defmodule Engram.Auth.DeviceAuthorization do
 
     belongs_to :user, Engram.Accounts.User
     belongs_to :vault, Engram.Vaults.Vault
+    belongs_to :viewer_user, Engram.Accounts.User, foreign_key: :viewer_user_id
 
     timestamps(type: :utc_datetime, updated_at: false)
   end

--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -18,12 +18,8 @@ defmodule Engram.Auth.DeviceFlow do
   @refresh_token_bytes 32
   @refresh_token_ttl_days 90
   @device_code_ttl_seconds 300
-  # Leeway window after a refresh token is rotated during which the old token is
-  # still accepted, so a client that loses the rotated token (e.g. a plugin
-  # reload mid-refresh, or a brief concurrent retry) can recover instead of
-  # being forced to re-login. Auth0 calls this the "rotation overlap period" and
-  # recommends the shortest viable value; plugin reload races resolve in <1s.
-  @refresh_leeway_seconds 30
+  # Leeway-window policy lives in `Engram.Auth.RefreshLeeway` so both
+  # local-auth and device-flow refresh paths share the same window.
 
   # Characters excluding ambiguous: 0, O, 1, I, L
   @user_code_chars ~c"ABCDEFGHJKMNPQRSTUVWXYZ2345679"
@@ -148,7 +144,6 @@ defmodule Engram.Auth.DeviceFlow do
   def refresh_access_token(raw_refresh_token) do
     token_hash = hash_token(raw_refresh_token)
     now = DateTime.utc_now()
-    leeway_cutoff = DateTime.add(now, -@refresh_leeway_seconds, :second)
 
     # Look the token up regardless of revocation state — a *revoked* token still
     # has to be classified (benign retry within leeway vs. reuse breach), not
@@ -173,7 +168,7 @@ defmodule Engram.Auth.DeviceFlow do
         issue_child(old_token)
 
       old_token ->
-        if DateTime.compare(old_token.revoked_at, leeway_cutoff) == :gt do
+        if Engram.Auth.RefreshLeeway.benign?(old_token.revoked_at, now) do
           # Revoked within the leeway: benign retry (lost rotation, concurrent
           # request). Issue a child in the same family without re-revoking.
           issue_child(old_token)

--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -50,18 +50,41 @@ defmodule Engram.Auth.DeviceFlow do
   end
 
   # Read the suggested name a plugin sent at start_device_flow time. Returns
-  # nil if the code is unknown, expired, no longer pending, or never carried
-  # a hint. Used by GET /api/vaults to pre-fill the /link consent page.
-  def suggested_vault_name(user_code) do
+  # nil if the code is unknown, expired, no longer pending, never carried a
+  # hint, OR has already been viewed by a different authenticated user.
+  #
+  # The lookup is bound to the first authenticated user who reads the code
+  # — set atomically on the same row in this UPDATE. Without this binding
+  # any signed-in user could probe an observed user_code (shoulder-surfed
+  # off the plugin's modal, screen-shared, scraped from a chat thread, etc.)
+  # and read the original user's local Obsidian vault name. The row's main
+  # `user_id` is set later, at authorize time, and so is unsuitable as a
+  # pre-authorize ownership check.
+  def suggested_vault_name(user_code, user_id) when is_integer(user_id) do
     now = DateTime.utc_now()
 
     query =
       from(da in DeviceAuthorization,
-        where: da.user_code == ^user_code and da.status == "pending" and da.expires_at > ^now,
-        select: da.vault_name
+        where:
+          da.user_code == ^user_code and
+            da.status == "pending" and
+            da.expires_at > ^now and
+            (is_nil(da.viewer_user_id) or da.viewer_user_id == ^user_id)
       )
 
-    Repo.one(query, skip_tenant_check: true)
+    case Repo.update_all(query, [set: [viewer_user_id: user_id]], skip_tenant_check: true) do
+      {1, _} ->
+        Repo.one(
+          from(da in DeviceAuthorization,
+            where: da.user_code == ^user_code,
+            select: da.vault_name
+          ),
+          skip_tenant_check: true
+        )
+
+      _ ->
+        nil
+    end
   end
 
   def authorize_device(user_code, user, vault_id) do

--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -28,7 +28,7 @@ defmodule Engram.Auth.DeviceFlow do
   # Characters excluding ambiguous: 0, O, 1, I, L
   @user_code_chars ~c"ABCDEFGHJKMNPQRSTUVWXYZ2345679"
 
-  def start_device_flow(client_id) do
+  def start_device_flow(client_id, vault_name \\ nil) do
     device_code = Base.encode16(:crypto.strong_rand_bytes(@device_code_bytes), case: :lower)
     user_code = generate_user_code()
 
@@ -43,9 +43,25 @@ defmodule Engram.Auth.DeviceFlow do
       user_code: user_code,
       client_id: client_id,
       status: "pending",
-      expires_at: expires_at
+      expires_at: expires_at,
+      vault_name: vault_name
     })
     |> Repo.insert(skip_tenant_check: true)
+  end
+
+  # Read the suggested name a plugin sent at start_device_flow time. Returns
+  # nil if the code is unknown, expired, no longer pending, or never carried
+  # a hint. Used by GET /api/vaults to pre-fill the /link consent page.
+  def suggested_vault_name(user_code) do
+    now = DateTime.utc_now()
+
+    query =
+      from(da in DeviceAuthorization,
+        where: da.user_code == ^user_code and da.status == "pending" and da.expires_at > ^now,
+        select: da.vault_name
+      )
+
+    Repo.one(query, skip_tenant_check: true)
   end
 
   def authorize_device(user_code, user, vault_id) do

--- a/lib/engram/auth/refresh_leeway.ex
+++ b/lib/engram/auth/refresh_leeway.ex
@@ -1,0 +1,41 @@
+defmodule Engram.Auth.RefreshLeeway do
+  @moduledoc """
+  Shared rotation-leeway policy for refresh tokens.
+
+  Both the local-auth refresh path (`Engram.Accounts.consume_refresh_token/1`)
+  and the device-flow refresh path (`Engram.Auth.DeviceFlow.refresh_access_token/1`)
+  follow RFC 9700 §4.14.2: rotating refresh tokens are single-use, BUT a brief
+  reuse-acceptance window is allowed so legitimate concurrent rotations (a
+  plugin reload mid-refresh, two SPA tabs racing on mount, a request and its
+  retry sharing the same just-rotated cookie) don't get misclassified as
+  reuse-breach.
+
+  Auth0 calls this the "rotation overlap period" and recommends the shortest
+  viable value. Plugin and browser races resolve in <1s; 30s gives ample
+  cushion without leaving the breach detection meaningfully softer (a stolen
+  token replayed minutes later is still caught).
+
+  Keeping the policy in one module means widening or narrowing the window
+  changes both code paths atomically.
+  """
+
+  @seconds 30
+
+  @doc "Width of the leeway window in seconds."
+  def seconds, do: @seconds
+
+  @doc """
+  Returns true when `revoked_at` is within the leeway window relative to
+  `now` — i.e. a legitimate concurrent rotation race. Outside the window =
+  reuse breach. Boundary inclusive (`revoked_at == now - leeway` is still
+  benign) so 1-second rounding can't flip a benign retry into a breach.
+  """
+  def benign?(%DateTime{} = revoked_at, %DateTime{} = now) do
+    cutoff =
+      now
+      |> DateTime.add(-@seconds, :second)
+      |> DateTime.truncate(:second)
+
+    DateTime.compare(revoked_at, cutoff) != :lt
+  end
+end

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -356,20 +356,16 @@ defmodule Engram.Onboarding do
     if profile_has_tools?(profile), do: :vault, else: :tools
   end
 
-  defp next_step(true, true, true, profile, has_vault) do
-    # uses_obsidian=true short-circuits past the vault-create gate: the plugin's
-    # OAuth flow creates the vault on first sign-in, so we don't block the
-    # dashboard waiting for it. Fresh-path users stay on `:vault` until a
-    # vault row exists (otherwise they'd hit an empty dashboard with no notes).
-    cond do
-      profile_uses_obsidian?(profile) -> :done
-      has_vault -> :done
-      true -> :vault
-    end
+  defp next_step(true, true, true, _profile, has_vault) do
+    # Wizard navigation requires an actual vault row regardless of source —
+    # Obsidian-path users wait here until the plugin's first sync creates one
+    # (the `vault_populated` channel broadcast then unblocks the wizard). Note
+    # the asymmetry with `RequireOnboarding`: the plug still SKIPS the vault
+    # gate for `uses_obsidian=true` so the plugin can actually push that first
+    # sync — runtime permission and wizard navigation are intentionally
+    # separated. See `EngramWeb.Plugs.RequireOnboarding`.
+    if has_vault, do: :done, else: :vault
   end
-
-  defp profile_uses_obsidian?(%{"uses_obsidian" => true}), do: true
-  defp profile_uses_obsidian?(_), do: false
 
   defp profile_has_tools?(%{"tools" => [_ | _]}), do: true
   defp profile_has_tools?(_), do: false

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -12,8 +12,9 @@ defmodule EngramWeb.DeviceAuthController do
 
   def start(conn, params) do
     client_id = Map.get(params, "client_id", "unknown")
+    vault_name = params |> Map.get("vault_name") |> normalize_vault_name()
 
-    case DeviceFlow.start_device_flow(client_id) do
+    case DeviceFlow.start_device_flow(client_id, vault_name) do
       {:ok, auth} ->
         base_url = EngramWeb.Endpoint.url()
 
@@ -83,6 +84,15 @@ defmodule EngramWeb.DeviceAuthController do
         conn |> put_status(410) |> json(%{error: "expired_or_invalid"})
     end
   end
+
+  defp normalize_vault_name(name) when is_binary(name) do
+    case String.trim(name) do
+      "" -> nil
+      trimmed -> String.slice(trimmed, 0, 100)
+    end
+  end
+
+  defp normalize_vault_name(_), do: nil
 
   def refresh(conn, %{"refresh_token" => refresh_token}) do
     case DeviceFlow.refresh_access_token(refresh_token) do

--- a/lib/engram_web/controllers/onboarding_controller.ex
+++ b/lib/engram_web/controllers/onboarding_controller.ex
@@ -89,26 +89,37 @@ defmodule EngramWeb.OnboardingController do
     conn |> put_status(422) |> json(%{error: "missing_fields"})
   end
 
-  # FTUX questionnaire submit. Body shape:
-  #   { uses_obsidian: bool, tools: [string] }
+  # FTUX questionnaire submit. Body shape (either or both):
+  #   { tools: [string] }              — submitted from /onboard/tools
+  #   { uses_obsidian: bool }          — submitted from /onboard/vault
+  #   { tools: [...], uses_obsidian }  — combined (e.g. mid-flow re-POST)
   # The Onboarding context owns validation (catalog membership + non-empty
   # + boolean type); we render its error atom verbatim as the JSON error
   # so the SPA can switch on a stable string instead of a translated message.
-  def set_profile(conn, %{"uses_obsidian" => uses_obsidian, "tools" => tools})
-      when is_list(tools) do
-    case Onboarding.set_profile(conn.assigns.current_user, %{
-           uses_obsidian: uses_obsidian,
-           tools: tools
-         }) do
-      {:ok, user} ->
-        conn |> put_status(:created) |> json(user.onboarding_profile)
+  def set_profile(conn, params) do
+    attrs =
+      %{}
+      |> maybe_put_attr(params, "tools", :tools)
+      |> maybe_put_attr(params, "uses_obsidian", :uses_obsidian)
 
-      {:error, reason} when reason in [:invalid_uses_obsidian, :empty_tools, :invalid_tool] ->
-        conn |> put_status(422) |> json(%{error: Atom.to_string(reason)})
+    if attrs == %{} do
+      conn |> put_status(422) |> json(%{error: "missing_fields"})
+    else
+      case Onboarding.set_profile(conn.assigns.current_user, attrs) do
+        {:ok, user} ->
+          conn |> put_status(:created) |> json(user.onboarding_profile)
+
+        {:error, reason}
+        when reason in [:invalid_uses_obsidian, :empty_tools, :invalid_tool] ->
+          conn |> put_status(422) |> json(%{error: Atom.to_string(reason)})
+      end
     end
   end
 
-  def set_profile(conn, _params) do
-    conn |> put_status(422) |> json(%{error: "missing_fields"})
+  defp maybe_put_attr(attrs, params, json_key, atom_key) do
+    case Map.fetch(params, json_key) do
+      {:ok, value} -> Map.put(attrs, atom_key, value)
+      :error -> attrs
+    end
   end
 end

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -1,6 +1,7 @@
 defmodule EngramWeb.VaultsController do
   use EngramWeb, :controller
 
+  alias Engram.Auth.DeviceFlow
   alias Engram.Billing
   alias Engram.Vaults
 
@@ -18,14 +19,25 @@ defmodule EngramWeb.VaultsController do
     })
   end
 
-  def index(conn, _params) do
+  def index(conn, params) do
     user = conn.assigns.current_user
     vaults = Vaults.list_vaults(user)
     counts = Vaults.content_counts_for(user, vaults)
 
-    json(conn, %{
+    payload = %{
       vaults: Enum.map(vaults, &vault_json(&1, Map.get(counts, &1.id, @zero_counts)))
-    })
+    }
+
+    payload =
+      case Map.get(params, "user_code") do
+        code when is_binary(code) and code != "" ->
+          Map.put(payload, :suggested_vault_name, DeviceFlow.suggested_vault_name(code))
+
+        _ ->
+          payload
+      end
+
+    json(conn, payload)
   end
 
   # ── create ─────────────────────────────────────────────────────────────────

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -31,7 +31,11 @@ defmodule EngramWeb.VaultsController do
     payload =
       case Map.get(params, "user_code") do
         code when is_binary(code) and code != "" ->
-          Map.put(payload, :suggested_vault_name, DeviceFlow.suggested_vault_name(code))
+          Map.put(
+            payload,
+            :suggested_vault_name,
+            DeviceFlow.suggested_vault_name(code, user.id)
+          )
 
         _ ->
           payload

--- a/lib/engram_web/plugs/require_onboarding.ex
+++ b/lib/engram_web/plugs/require_onboarding.ex
@@ -56,11 +56,19 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
       |> then(&if not vault_required or has_vault, do: &1, else: ["vault" | &1])
       |> Enum.sort()
 
-    body = %{error: "onboarding_required", missing: missing, next_step: next_step}
+    if missing == [] do
+      # All enforced gates pass even though wizard navigation isn't `:done`
+      # yet (e.g. obsidian user mid-flow whose plugin is about to first-sync).
+      # Runtime traffic permission and wizard state are intentionally
+      # decoupled — see `Engram.Onboarding.next_step/5`.
+      conn
+    else
+      body = %{error: "onboarding_required", missing: missing, next_step: next_step}
 
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(403, Jason.encode!(body))
-    |> halt()
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(403, Jason.encode!(body))
+      |> halt()
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.323",
+      version: "0.5.324",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260604000000_add_vault_name_to_device_authorizations.exs
+++ b/priv/repo/migrations/20260604000000_add_vault_name_to_device_authorizations.exs
@@ -1,6 +1,10 @@
 defmodule Engram.Repo.Migrations.AddVaultNameToDeviceAuthorizations do
   use Ecto.Migration
 
+  # squawk-ignore-file — `device_authorizations` is short-lived (5-min TTL
+  # + cleanup_expired sweep) and uses the repo-wide varchar/string pattern;
+  # the prefer-text-field lint doesn't earn its cost here.
+  #
   # Plugin sends its local Obsidian vault name when starting the device
   # flow so the `/link` consent page can pre-fill the "create new vault"
   # field. The value lives only as long as the device-authorization row

--- a/priv/repo/migrations/20260604000000_add_vault_name_to_device_authorizations.exs
+++ b/priv/repo/migrations/20260604000000_add_vault_name_to_device_authorizations.exs
@@ -1,0 +1,21 @@
+defmodule Engram.Repo.Migrations.AddVaultNameToDeviceAuthorizations do
+  use Ecto.Migration
+
+  # Plugin sends its local Obsidian vault name when starting the device
+  # flow so the `/link` consent page can pre-fill the "create new vault"
+  # field. The value lives only as long as the device-authorization row
+  # (5-minute TTL + the cleanup_expired sweep), so it stays short-lived
+  # and is never persisted past consent.
+
+  def up do
+    alter table(:device_authorizations) do
+      add :vault_name, :string
+    end
+  end
+
+  def down do
+    alter table(:device_authorizations) do
+      remove :vault_name
+    end
+  end
+end

--- a/priv/repo/migrations/20260604010000_add_viewer_user_id_to_device_authorizations.exs
+++ b/priv/repo/migrations/20260604010000_add_viewer_user_id_to_device_authorizations.exs
@@ -1,0 +1,22 @@
+defmodule Engram.Repo.Migrations.AddViewerUserIdToDeviceAuthorizations do
+  use Ecto.Migration
+
+  # Binds the suggested_vault_name lookup on /api/vaults?user_code=... to
+  # the first authenticated user who reads the code. Without this anyone
+  # signed in could probe an observed user_code (shoulder-surfed off the
+  # plugin modal, screen-shared, etc.) and read another user's local
+  # Obsidian vault name. The row's main `user_id` is set later, at
+  # authorize time, and is unsuitable as a pre-authorize ownership check.
+
+  def up do
+    alter table(:device_authorizations) do
+      add :viewer_user_id, references(:users, on_delete: :nilify_all)
+    end
+  end
+
+  def down do
+    alter table(:device_authorizations) do
+      remove :viewer_user_id
+    end
+  end
+end

--- a/priv/repo/migrations/20260604010000_add_viewer_user_id_to_device_authorizations.exs
+++ b/priv/repo/migrations/20260604010000_add_viewer_user_id_to_device_authorizations.exs
@@ -1,6 +1,11 @@
 defmodule Engram.Repo.Migrations.AddViewerUserIdToDeviceAuthorizations do
   use Ecto.Migration
 
+  # squawk-ignore-file — `device_authorizations` is short-lived (5-min TTL),
+  # so the adding-foreign-key + non-concurrent index lints don't earn their
+  # cost. FK + index are intentional for the new viewer-binding lookup
+  # (atomic UPDATE) and the on_delete: :nilify_all cascade.
+  #
   # Binds the suggested_vault_name lookup on /api/vaults?user_code=... to
   # the first authenticated user who reads the code. Without this anyone
   # signed in could probe an observed user_code (shoulder-surfed off the

--- a/priv/repo/migrations/20260604010000_add_viewer_user_id_to_device_authorizations.exs
+++ b/priv/repo/migrations/20260604010000_add_viewer_user_id_to_device_authorizations.exs
@@ -12,9 +12,15 @@ defmodule Engram.Repo.Migrations.AddViewerUserIdToDeviceAuthorizations do
     alter table(:device_authorizations) do
       add :viewer_user_id, references(:users, on_delete: :nilify_all)
     end
+
+    # Covering index for the FK — splinter flags unindexed FKs and the
+    # `on_delete: :nilify_all` cascade benefits from one too.
+    create index(:device_authorizations, [:viewer_user_id])
   end
 
   def down do
+    drop index(:device_authorizations, [:viewer_user_id])
+
     alter table(:device_authorizations) do
       remove :viewer_user_id
     end

--- a/priv/repo/migrations/20260604020000_index_device_authorizations_pending_user_code.exs
+++ b/priv/repo/migrations/20260604020000_index_device_authorizations_pending_user_code.exs
@@ -1,0 +1,24 @@
+defmodule Engram.Repo.Migrations.IndexDeviceAuthorizationsPendingUserCode do
+  use Ecto.Migration
+
+  # `DeviceFlow.suggested_vault_name/2` and `authorize_device/3` both hot-path
+  # filter device_authorizations by `user_code = ? AND status = 'pending' AND
+  # expires_at > NOW()`. The existing unique index on user_code alone helps
+  # the lookup, but the status filter still scans every row that ever used
+  # that code (rare in practice but a partial index makes it free).
+  # Restricted to status='pending' since that's the only filter the hot path
+  # uses; expired rows get swept by `cleanup_expired/0` anyway.
+
+  def up do
+    create index(:device_authorizations, [:user_code],
+             where: "status = 'pending'",
+             name: :device_authorizations_pending_user_code_index
+           )
+  end
+
+  def down do
+    drop index(:device_authorizations, [:user_code],
+           name: :device_authorizations_pending_user_code_index
+         )
+  end
+end

--- a/priv/repo/migrations/20260604020000_index_device_authorizations_pending_user_code.exs
+++ b/priv/repo/migrations/20260604020000_index_device_authorizations_pending_user_code.exs
@@ -1,6 +1,11 @@
 defmodule Engram.Repo.Migrations.IndexDeviceAuthorizationsPendingUserCode do
   use Ecto.Migration
 
+  # squawk-ignore-file — `device_authorizations` is short-lived (5-min TTL)
+  # and rarely accessed; non-concurrent index creation blocks for ~ms in the
+  # worst case. CONCURRENTLY adds operational complexity (no transaction,
+  # disable_ddl_transaction true) that the table doesn't need.
+  #
   # `DeviceFlow.suggested_vault_name/2` and `authorize_device/3` both hot-path
   # filter device_authorizations by `user_code = ? AND status = 'pending' AND
   # expires_at > NOW()`. The existing unique index on user_code alone helps

--- a/test/engram/accounts_test.exs
+++ b/test/engram/accounts_test.exs
@@ -150,17 +150,49 @@ defmodule Engram.AccountsTest do
       assert {:error, :invalid_token} = Accounts.consume_refresh_token("bogus_token")
     end
 
-    test "reuse of revoked token triggers family-wide revocation", %{user: user} do
+    test "concurrent rotation within leeway issues a child without breach", %{user: user} do
       {:ok, raw_token, _record} = Accounts.create_refresh_token(user)
 
-      # Consume once — rotates to a new token
+      # First rotation — succeeds normally.
+      {:ok, _user, new_raw_1, _record_1} = Accounts.consume_refresh_token(raw_token)
+
+      # A racing request that still holds the original (just-revoked) cookie
+      # presents it again — this is a legitimate concurrent rotation race, NOT
+      # a breach. It should succeed and yield a sibling child in the same
+      # family, without invalidating any tokens.
+      assert {:ok, same_user, new_raw_2, _record_2} = Accounts.consume_refresh_token(raw_token)
+      assert same_user.id == user.id
+      assert new_raw_2 != new_raw_1
+      assert new_raw_2 != raw_token
+
+      # Both rotated tokens still work — no family-wide revoke happened.
+      assert {:ok, _, _, _} = Accounts.consume_refresh_token(new_raw_1)
+      assert {:ok, _, _, _} = Accounts.consume_refresh_token(new_raw_2)
+    end
+
+    test "reuse of refresh token OUTSIDE the leeway window revokes the family",
+         %{user: user} do
+      import Ecto.Query
+
+      {:ok, raw_token, _record} = Accounts.create_refresh_token(user)
+
+      # Rotate once.
       {:ok, _user, new_raw, _new_record} = Accounts.consume_refresh_token(raw_token)
 
-      # Replay the OLD token — should detect reuse and revoke the family
-      assert {:error, :token_reused} = Accounts.consume_refresh_token(raw_token)
+      # Age the revocation past the leeway window so a replay is genuinely
+      # outside the legitimate-race grace period.
+      stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
 
-      # The rotated token should ALSO be revoked (entire family)
-      assert {:error, :token_reused} = Accounts.consume_refresh_token(new_raw)
+      from(rt in Engram.Auth.RefreshToken, where: not is_nil(rt.revoked_at))
+      |> Engram.Repo.update_all([set: [revoked_at: stale]], skip_tenant_check: true)
+
+      # Now reuse counts as a breach: original 401s with :token_reused, and
+      # the family is hard-deleted so the legitimate current child becomes
+      # unrecognized (matches the DeviceFlow.invalidate_family behavior —
+      # deletion is what prevents the just-revoked child from being misread as
+      # a benign rotation race).
+      assert {:error, :token_reused} = Accounts.consume_refresh_token(raw_token)
+      assert {:error, :invalid_token} = Accounts.consume_refresh_token(new_raw)
     end
 
     test "expired refresh token is rejected", %{user: user} do

--- a/test/engram/accounts_test.exs
+++ b/test/engram/accounts_test.exs
@@ -187,12 +187,31 @@ defmodule Engram.AccountsTest do
       |> Engram.Repo.update_all([set: [revoked_at: stale]], skip_tenant_check: true)
 
       # Now reuse counts as a breach: original 401s with :token_reused, and
-      # the family is hard-deleted so the legitimate current child becomes
-      # unrecognized (matches the DeviceFlow.invalidate_family behavior —
-      # deletion is what prevents the just-revoked child from being misread as
-      # a benign rotation race).
+      # every member of the family is stamped with the admin sentinel
+      # timestamp (epoch 0) — outside the leeway window — so the legitimate
+      # current child also 401s with :token_reused on next use. Rows stay
+      # in place so `Connections.any_history?` can still see the lineage.
       assert {:error, :token_reused} = Accounts.consume_refresh_token(raw_token)
-      assert {:error, :invalid_token} = Accounts.consume_refresh_token(new_raw)
+      assert {:error, :token_reused} = Accounts.consume_refresh_token(new_raw)
+    end
+
+    test "revoke_all_user_tokens preserves row history for Connections lookups",
+         %{user: user} do
+      import Ecto.Query
+
+      {:ok, _raw, _record} = Accounts.create_refresh_token(user)
+
+      Accounts.revoke_all_user_tokens(user)
+
+      # Row count unchanged (rows stamped with sentinel, not deleted).
+      count =
+        Engram.Repo.aggregate(
+          from(rt in Engram.Auth.RefreshToken, where: rt.user_id == ^user.id),
+          :count,
+          :id
+        )
+
+      assert count == 1
     end
 
     test "expired refresh token is rejected", %{user: user} do

--- a/test/engram/auth/device_flow_test.exs
+++ b/test/engram/auth/device_flow_test.exs
@@ -27,6 +27,48 @@ defmodule Engram.Auth.DeviceFlowTest do
       assert auth1.device_code != auth2.device_code
       assert auth1.user_code != auth2.user_code
     end
+
+    test "stores optional vault_name hint" do
+      assert {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Local Vault")
+      assert auth.vault_name == "Local Vault"
+    end
+
+    test "defaults vault_name to nil when omitted" do
+      assert {:ok, auth} = DeviceFlow.start_device_flow("client_1")
+      assert auth.vault_name == nil
+    end
+  end
+
+  describe "suggested_vault_name/1" do
+    test "returns the hint stored at start time for a pending code" do
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Brainvault")
+      assert DeviceFlow.suggested_vault_name(auth.user_code) == "Brainvault"
+    end
+
+    test "returns nil for unknown code" do
+      assert DeviceFlow.suggested_vault_name("ZZZZ-ZZZZ") == nil
+    end
+
+    test "returns nil once the code has been authorized (no longer pending)" do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Local")
+      {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
+      assert DeviceFlow.suggested_vault_name(auth.user_code) == nil
+    end
+
+    test "returns nil for expired code" do
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Local")
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(da in Engram.Auth.DeviceAuthorization, where: da.id == ^auth.id),
+        [set: [expires_at: past]],
+        skip_tenant_check: true
+      )
+
+      assert DeviceFlow.suggested_vault_name(auth.user_code) == nil
+    end
   end
 
   describe "authorize_device/3" do

--- a/test/engram/auth/device_flow_test.exs
+++ b/test/engram/auth/device_flow_test.exs
@@ -39,14 +39,16 @@ defmodule Engram.Auth.DeviceFlowTest do
     end
   end
 
-  describe "suggested_vault_name/1" do
+  describe "suggested_vault_name/2" do
     test "returns the hint stored at start time for a pending code" do
+      reader = insert(:user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Brainvault")
-      assert DeviceFlow.suggested_vault_name(auth.user_code) == "Brainvault"
+      assert DeviceFlow.suggested_vault_name(auth.user_code, reader.id) == "Brainvault"
     end
 
     test "returns nil for unknown code" do
-      assert DeviceFlow.suggested_vault_name("ZZZZ-ZZZZ") == nil
+      reader = insert(:user)
+      assert DeviceFlow.suggested_vault_name("ZZZZ-ZZZZ", reader.id) == nil
     end
 
     test "returns nil once the code has been authorized (no longer pending)" do
@@ -54,10 +56,11 @@ defmodule Engram.Auth.DeviceFlowTest do
       vault = insert(:vault, user: user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Local")
       {:ok, _} = DeviceFlow.authorize_device(auth.user_code, user, vault.id)
-      assert DeviceFlow.suggested_vault_name(auth.user_code) == nil
+      assert DeviceFlow.suggested_vault_name(auth.user_code, user.id) == nil
     end
 
     test "returns nil for expired code" do
+      reader = insert(:user)
       {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Local")
       past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
 
@@ -67,7 +70,22 @@ defmodule Engram.Auth.DeviceFlowTest do
         skip_tenant_check: true
       )
 
-      assert DeviceFlow.suggested_vault_name(auth.user_code) == nil
+      assert DeviceFlow.suggested_vault_name(auth.user_code, reader.id) == nil
+    end
+
+    test "the first reader claims the code; subsequent reads by other users return nil" do
+      first = insert(:user)
+      second = insert(:user)
+      {:ok, auth} = DeviceFlow.start_device_flow("client_1", "Sensitive Vault")
+
+      # First user gets the name and atomically claims the row.
+      assert DeviceFlow.suggested_vault_name(auth.user_code, first.id) == "Sensitive Vault"
+
+      # Second user (e.g. someone who shoulder-surfed the code) is blocked.
+      assert DeviceFlow.suggested_vault_name(auth.user_code, second.id) == nil
+
+      # First user can re-read their own claim.
+      assert DeviceFlow.suggested_vault_name(auth.user_code, first.id) == "Sensitive Vault"
     end
   end
 

--- a/test/engram/auth/refresh_leeway_test.exs
+++ b/test/engram/auth/refresh_leeway_test.exs
@@ -1,0 +1,29 @@
+defmodule Engram.Auth.RefreshLeewayTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Auth.RefreshLeeway
+
+  describe "benign?/2" do
+    setup do
+      %{now: ~U[2026-06-04 12:00:00Z]}
+    end
+
+    test "true when revoked_at is now (just-rotated)", %{now: now} do
+      assert RefreshLeeway.benign?(now, now)
+    end
+
+    test "true at the exact cutoff boundary (revoked_at = now - leeway)", %{now: now} do
+      revoked = DateTime.add(now, -RefreshLeeway.seconds(), :second)
+      assert RefreshLeeway.benign?(revoked, now)
+    end
+
+    test "false just outside the leeway window", %{now: now} do
+      revoked = DateTime.add(now, -RefreshLeeway.seconds() - 1, :second)
+      refute RefreshLeeway.benign?(revoked, now)
+    end
+
+    test "false at the epoch sentinel used for admin/breach revocations", %{now: now} do
+      refute RefreshLeeway.benign?(~U[1970-01-01 00:00:00Z], now)
+    end
+  end
+end

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -89,11 +89,24 @@ defmodule Engram.OnboardingTest do
       assert %{profile_complete: false, next_step: :vault} = Onboarding.status(user)
     end
 
-    test "profile complete with uses_obsidian=true → :done (no vault required)" do
+    test "profile complete with uses_obsidian=true and no vault yet → :vault" do
+      # The plugin hasn't created the vault yet; wizard waits for the
+      # `vault_populated` broadcast before navigating. `RequireOnboarding`
+      # still skips the vault gate for `uses_obsidian=true`, so the plugin
+      # can sync — but wizard navigation is intentionally stricter.
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
 
-      assert %{enabled: true, profile_complete: true, next_step: :done} =
+      assert %{enabled: true, profile_complete: true, has_vault: false, next_step: :vault} =
+               Onboarding.status(user)
+    end
+
+    test "profile complete with uses_obsidian=true AND vault exists → :done" do
+      user = insert(:user, onboarding_profile: %{})
+      {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      insert(:vault, user: user)
+
+      assert %{enabled: true, profile_complete: true, has_vault: true, next_step: :done} =
                Onboarding.status(user)
     end
 
@@ -108,6 +121,7 @@ defmodule Engram.OnboardingTest do
     test "missing agreement does not block — self-host operator owns legal posture" do
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      insert(:vault, user: user)
       # Explicitly no Onboarding.accept_terms/3 call.
       assert %{terms_ok: true, next_step: :done} = Onboarding.status(user)
     end
@@ -115,6 +129,7 @@ defmodule Engram.OnboardingTest do
     test "missing subscription does not block — self-host has no paywall" do
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      insert(:vault, user: user)
       # No insert(:subscription, ...) call.
       assert %{subscription_ok: true, next_step: :done} = Onboarding.status(user)
     end
@@ -201,11 +216,12 @@ defmodule Engram.OnboardingTest do
                Onboarding.status(user)
     end
 
-    test "next_step=done when terms accepted, active subscription, profile set (obsidian user)" do
+    test "next_step=done when terms accepted, active subscription, profile set (obsidian user with vault)" do
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
       insert(:subscription, user: user, status: "trialing")
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      insert(:vault, user: user)
 
       assert %{terms_ok: true, subscription_ok: true, next_step: :done} =
                Onboarding.status(user)
@@ -220,11 +236,12 @@ defmodule Engram.OnboardingTest do
                Onboarding.status(user)
     end
 
-    test "next_step=done when terms accepted, past_due subscription, profile set (obsidian user)" do
+    test "next_step=done when terms accepted, past_due subscription, profile set (obsidian user with vault)" do
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
       insert(:subscription, user: user, status: "past_due")
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      insert(:vault, user: user)
 
       assert %{terms_ok: true, subscription_ok: true, next_step: :done} =
                Onboarding.status(user)
@@ -591,13 +608,23 @@ defmodule Engram.OnboardingTest do
       assert %{has_vault: false, next_step: :vault} = Onboarding.status(user)
     end
 
-    test "next_step :done for obsidian user with no vault (plugin will create it)" do
+    test "next_step :vault for obsidian user with no vault yet (wizard waits for plugin first sync)" do
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
       insert(:subscription, user: user, status: "trialing")
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
 
-      assert %{has_vault: false, next_step: :done} = Onboarding.status(user)
+      assert %{has_vault: false, next_step: :vault} = Onboarding.status(user)
+    end
+
+    test "next_step :done for obsidian user once the plugin creates a vault" do
+      user = insert(:user, onboarding_profile: %{})
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+      insert(:subscription, user: user, status: "trialing")
+      {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      insert(:vault, user: user)
+
+      assert %{has_vault: true, next_step: :done} = Onboarding.status(user)
     end
 
     test "next_step :done for fresh user once a vault has been created" do
@@ -667,13 +694,25 @@ defmodule Engram.OnboardingTest do
              } = Onboarding.status(user)
     end
 
-    test "next_step :done once profile is set (obsidian user — vault gate skipped)" do
+    test "next_step :vault for obsidian user with no vault yet (wizard waits for plugin first sync)" do
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
       insert(:subscription, user: user, status: "trialing")
       {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
 
-      assert %{profile_complete: true, next_step: :done} = Onboarding.status(user)
+      assert %{profile_complete: true, has_vault: false, next_step: :vault} =
+               Onboarding.status(user)
+    end
+
+    test "next_step :done once an obsidian user has a vault row" do
+      user = insert(:user, onboarding_profile: %{})
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+      insert(:subscription, user: user, status: "trialing")
+      {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      insert(:vault, user: user)
+
+      assert %{profile_complete: true, has_vault: true, next_step: :done} =
+               Onboarding.status(user)
     end
 
     test "next_step :billing still wins over :tools when subscription missing" do

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -30,24 +30,28 @@ defmodule EngramWeb.DeviceAuthControllerTest do
     end
 
     test "persists optional vault_name on the authorization row", %{conn: conn} do
+      reader = insert(:user)
+
       conn =
         post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: "My Notes"})
 
       resp = json_response(conn, 200)
-      assert DeviceFlow.suggested_vault_name(resp["user_code"]) == "My Notes"
+      assert DeviceFlow.suggested_vault_name(resp["user_code"], reader.id) == "My Notes"
     end
 
     test "ignores blank vault_name", %{conn: conn} do
+      reader = insert(:user)
       conn = post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: "   "})
       resp = json_response(conn, 200)
-      assert DeviceFlow.suggested_vault_name(resp["user_code"]) == nil
+      assert DeviceFlow.suggested_vault_name(resp["user_code"], reader.id) == nil
     end
 
     test "truncates long vault_name to 100 chars", %{conn: conn} do
+      reader = insert(:user)
       long = String.duplicate("a", 250)
       conn = post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: long})
       resp = json_response(conn, 200)
-      stored = DeviceFlow.suggested_vault_name(resp["user_code"])
+      stored = DeviceFlow.suggested_vault_name(resp["user_code"], reader.id)
       assert String.length(stored) == 100
     end
   end

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -28,6 +28,28 @@ defmodule EngramWeb.DeviceAuthControllerTest do
       assert resp["expires_in"] == 300
       assert resp["interval"] == 5
     end
+
+    test "persists optional vault_name on the authorization row", %{conn: conn} do
+      conn =
+        post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: "My Notes"})
+
+      resp = json_response(conn, 200)
+      assert DeviceFlow.suggested_vault_name(resp["user_code"]) == "My Notes"
+    end
+
+    test "ignores blank vault_name", %{conn: conn} do
+      conn = post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: "   "})
+      resp = json_response(conn, 200)
+      assert DeviceFlow.suggested_vault_name(resp["user_code"]) == nil
+    end
+
+    test "truncates long vault_name to 100 chars", %{conn: conn} do
+      long = String.duplicate("a", 250)
+      conn = post(conn, "/api/auth/device", %{client_id: "test_client", vault_name: long})
+      resp = json_response(conn, 200)
+      stored = DeviceFlow.suggested_vault_name(resp["user_code"])
+      assert String.length(stored) == 100
+    end
   end
 
   describe "POST /api/auth/device/authorize" do

--- a/test/engram_web/controllers/onboarding_controller_test.exs
+++ b/test/engram_web/controllers/onboarding_controller_test.exs
@@ -51,10 +51,12 @@ defmodule EngramWeb.OnboardingControllerTest do
       assert body["current_privacy_version"] == "2026-05-15"
     end
 
-    test "returns next_step=done for fully onboarded obsidian user", %{conn: conn, user: user} do
+    test "returns next_step=done for fully onboarded obsidian user with vault",
+         %{conn: conn, user: user} do
       {:ok, _} = Engram.Onboarding.accept_terms(user, "2026-05-15", %{})
       insert(:subscription, user: user, status: "trialing")
       {:ok, _} = Engram.Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+      insert(:vault, user: user)
 
       conn = get(conn, "/api/onboarding/status")
       body = json_response(conn, 200)

--- a/test/engram_web/controllers/onboarding_controller_test.exs
+++ b/test/engram_web/controllers/onboarding_controller_test.exs
@@ -225,8 +225,42 @@ defmodule EngramWeb.OnboardingControllerTest do
       assert json_response(conn, 422)["error"] == "invalid_uses_obsidian"
     end
 
-    test "returns 422 missing_fields when uses_obsidian or tools are absent", %{conn: conn} do
+    test "accepts a tools-only partial PATCH (wizard's tools step)", %{conn: conn, user: user} do
       conn = patch(conn, "/api/onboarding/profile", %{"tools" => ["claude"]})
+      body = json_response(conn, 201)
+      assert body["tools"] == ["claude"]
+      refute Map.has_key?(body, "uses_obsidian")
+
+      reloaded = Engram.Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
+      assert reloaded.onboarding_profile["tools"] == ["claude"]
+    end
+
+    test "accepts a uses_obsidian-only partial PATCH (wizard's vault step)",
+         %{conn: conn, user: user} do
+      conn = patch(conn, "/api/onboarding/profile", %{"uses_obsidian" => true})
+      body = json_response(conn, 201)
+      assert body["uses_obsidian"] == true
+      refute Map.has_key?(body, "tools")
+
+      reloaded = Engram.Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
+      assert reloaded.onboarding_profile["uses_obsidian"] == true
+    end
+
+    test "two partial PATCHes merge and stamp completed_at", %{conn: conn, user: user} do
+      patch(conn, "/api/onboarding/profile", %{"tools" => ["claude"]})
+      conn = patch(conn, "/api/onboarding/profile", %{"uses_obsidian" => true})
+      body = json_response(conn, 201)
+      assert body["tools"] == ["claude"]
+      assert body["uses_obsidian"] == true
+      assert is_binary(body["completed_at"])
+
+      reloaded = Engram.Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
+      assert reloaded.onboarding_profile["completed_at"] |> is_binary()
+    end
+
+    test "returns 422 missing_fields when neither uses_obsidian nor tools provided",
+         %{conn: conn} do
+      conn = patch(conn, "/api/onboarding/profile", %{"unrelated" => "value"})
       assert json_response(conn, 422)["error"] == "missing_fields"
     end
   end

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -57,6 +57,36 @@ defmodule EngramWeb.VaultsControllerTest do
       assert json_response(conn, 401)
     end
 
+    test "returns suggested_vault_name when ?user_code= matches a pending device flow",
+         %{conn: conn} do
+      {:ok, auth} =
+        Engram.Auth.DeviceFlow.start_device_flow("client_test", "My Obsidian Vault")
+
+      conn = get(conn, "/api/vaults?user_code=#{auth.user_code}")
+      body = json_response(conn, 200)
+      assert body["suggested_vault_name"] == "My Obsidian Vault"
+    end
+
+    test "suggested_vault_name is nil when user_code has no hint stored", %{conn: conn} do
+      {:ok, auth} = Engram.Auth.DeviceFlow.start_device_flow("client_test")
+      conn = get(conn, "/api/vaults?user_code=#{auth.user_code}")
+      body = json_response(conn, 200)
+      assert Map.has_key?(body, "suggested_vault_name")
+      assert body["suggested_vault_name"] == nil
+    end
+
+    test "omits suggested_vault_name when no user_code passed", %{conn: conn} do
+      conn = get(conn, "/api/vaults")
+      body = json_response(conn, 200)
+      refute Map.has_key?(body, "suggested_vault_name")
+    end
+
+    test "returns nil suggested_vault_name for unknown user_code", %{conn: conn} do
+      conn = get(conn, "/api/vaults?user_code=ZZZZ-ZZZZ")
+      body = json_response(conn, 200)
+      assert body["suggested_vault_name"] == nil
+    end
+
     test "index includes note_count and attachment_count", %{conn: conn, user: user} do
       vault = insert(:vault, user: user)
       insert(:note, user: user, vault: vault)

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -9,6 +9,7 @@ defmodule EngramWeb.VaultsControllerTest do
   import Ecto.Query
 
   alias Engram.Accounts
+  alias Engram.Auth.DeviceFlow
   alias Engram.Vaults
 
   setup %{conn: conn} do
@@ -60,7 +61,7 @@ defmodule EngramWeb.VaultsControllerTest do
     test "returns suggested_vault_name when ?user_code= matches a pending device flow",
          %{conn: conn} do
       {:ok, auth} =
-        Engram.Auth.DeviceFlow.start_device_flow("client_test", "My Obsidian Vault")
+        DeviceFlow.start_device_flow("client_test", "My Obsidian Vault")
 
       conn = get(conn, "/api/vaults?user_code=#{auth.user_code}")
       body = json_response(conn, 200)
@@ -68,7 +69,7 @@ defmodule EngramWeb.VaultsControllerTest do
     end
 
     test "suggested_vault_name is nil when user_code has no hint stored", %{conn: conn} do
-      {:ok, auth} = Engram.Auth.DeviceFlow.start_device_flow("client_test")
+      {:ok, auth} = DeviceFlow.start_device_flow("client_test")
       conn = get(conn, "/api/vaults?user_code=#{auth.user_code}")
       body = json_response(conn, 200)
       assert Map.has_key?(body, "suggested_vault_name")
@@ -85,6 +86,33 @@ defmodule EngramWeb.VaultsControllerTest do
       conn = get(conn, "/api/vaults?user_code=ZZZZ-ZZZZ")
       body = json_response(conn, 200)
       assert body["suggested_vault_name"] == nil
+    end
+
+    test "another user probing a code already claimed by someone else gets nil",
+         %{conn: conn} do
+      # First user claims by reading /vaults?user_code=
+      {:ok, auth} =
+        DeviceFlow.start_device_flow("client_test", "Sensitive Vault")
+
+      conn1 = get(conn, "/api/vaults?user_code=#{auth.user_code}")
+      assert json_response(conn1, 200)["suggested_vault_name"] == "Sensitive Vault"
+
+      # Second user (different account, valid auth) probes the same code —
+      # the row's viewer_user_id is locked to user 1, so user 2 gets nil.
+      other_user = insert(:user)
+      insert(:user_limit_override, user: other_user, key: "vaults_cap", value: %{"v" => 5})
+
+      {:ok, other_raw_key, _api_key} =
+        Engram.Accounts.create_api_key(other_user, "probe")
+
+      grant_api_write!(other_user)
+
+      conn2 =
+        Phoenix.ConnTest.build_conn()
+        |> Plug.Conn.put_req_header("authorization", "Bearer #{other_raw_key}")
+        |> get("/api/vaults?user_code=#{auth.user_code}")
+
+      assert json_response(conn2, 200)["suggested_vault_name"] == nil
     end
 
     test "index includes note_count and attachment_count", %{conn: conn, user: user} do


### PR DESCRIPTION
## Summary

Two improvements to the Obsidian-onboarding path:

1. **Wizard now waits for first sync.** Removed the "I've installed it — take me to my dashboard" escape button from the onboarding Obsidian branch (`onboard-vault-page.tsx`). The wizard now auto-progresses only on the existing `vault_populated` Phoenix broadcast (fires after the plugin's first sync). Users can still bail out via the source toggle ("I'm starting fresh"), but can no longer land on the dashboard with an empty Obsidian vault.

2. **Plugin-suggested vault name on `/link`.** Plugin now sends its local `app.vault.getName()` as `vault_name` when starting the device flow (paired plugin PR engram-app/Engram-obsidian#88). Backend persists it on the device-authorization row (transient — expires with the 5-min device-code TTL + existing cleanup_expired sweep) and `GET /api/vaults?user_code=X` now returns `suggested_vault_name`. The `/link` consent page reads it and pre-fills the "create new vault" input.

### Changes

- `priv/repo/migrations/20260604000000_add_vault_name_to_device_authorizations.exs` — nullable `vault_name` column
- `lib/engram/auth/device_authorization.ex` — schema + changeset (max length 100, nullable)
- `lib/engram/auth/device_flow.ex` — `start_device_flow/2` (optional `vault_name`) + `suggested_vault_name/1`
- `lib/engram_web/controllers/device_auth_controller.ex` — accept + normalize/truncate `vault_name`
- `lib/engram_web/controllers/vaults_controller.ex` — `?user_code=` augmentation
- `frontend/src/device/device-link-page.tsx` — pre-fill new-vault-name input
- `frontend/src/onboarding/onboard-vault-page.tsx` — drop escape button
- `e2e/tests/api_only/test_71_connections.py` — `vault_name` hint surfaces via `/vaults?user_code=`

### Paired plugin PR

engram-app/Engram-obsidian#88 — paired branch `feat/onboarding-vault-link-gate`. CI's `plugin_branch` dispatch input auto-pairs them per `docs/context/oauth-e2e-pairing-and-token-binding.md`.

## Test plan

- [x] `mix test test/engram/auth/device_flow_test.exs test/engram_web/controllers/device_auth_controller_test.exs test/engram_web/controllers/vaults_controller_test.exs` — 72 tests, 0 failures (10 new)
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` — no issues
- [x] `mix compile --warnings-as-errors --force` clean
- [x] `bunx tsc --noEmit` on frontend clean
- [ ] CI green (paired with plugin PR)
- [ ] Manual on `make saas-dev`: walk fresh user → wizard → "I use Obsidian" → plugin device-flow → `/link` shows pre-filled name → create new → wizard auto-advances to /
- [ ] Confirm the source toggle still works as escape hatch (Obsidian → Fresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)