### PR TITLE
Tier 2.D: SCHEMA-IMPACT release notes

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -249,3 +249,68 @@ jobs:
             --max-time 5 \
             --data "$(jq -nc --arg c "$CONTENT" '{content:$c}')" \
             "$WEBHOOK"
+
+  create-release-notes:
+    # Auto-create a GitHub Release for the release-v* tag with a
+    # SCHEMA-IMPACT prepend when any merged PR in the release range
+    # carries a phase/* label. Self-hosters read this on the release
+    # page before pulling the new image. When no phase/* labels exist
+    # in the range, no Release is created (empty notes are not useful).
+    runs-on: [self-hosted, linux, x64, isolated]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release range
+        id: range
+        run: |
+          tag="${{ github.ref_name }}"
+          # Previous release-v* tag, sorted by version. Exclude the current
+          # tag in case sort returns it first (defensive).
+          prev=$(git tag -l 'release-v*' --sort=-v:refname | grep -v "^${tag}\$" | head -1)
+          if [ -z "$prev" ]; then
+            # First release ever — compare against repo root commit.
+            prev=$(git rev-list --max-parents=0 HEAD | head -1)
+            echo "::notice::No prior release-v* tag — comparing against repo root commit $prev"
+          fi
+          echo "base_sha=$(git rev-parse "$prev")" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse "$tag")" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=$prev" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SCHEMA-IMPACT block
+        id: impact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          notes=$(bash scripts/generate_schema_impact_notes.sh \
+            "${{ steps.range.outputs.base_sha }}" \
+            "${{ steps.range.outputs.head_sha }}")
+          if [ -z "$notes" ]; then
+            echo "has_impact=false" >> "$GITHUB_OUTPUT"
+            echo "No phase/* labels in release range — skipping release-notes creation."
+            exit 0
+          fi
+          echo "has_impact=true" >> "$GITHUB_OUTPUT"
+          # Stash notes for the next step (multiline outputs need EOF delimiter).
+          {
+            echo "notes<<NOTES_EOF"
+            echo "$notes"
+            echo ""
+            echo "---"
+            echo ""
+            echo "**Full Changelog:** https://github.com/${{ github.repository }}/compare/${{ steps.range.outputs.prev_tag }}...${{ github.ref_name }}"
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: steps.impact.outputs.has_impact == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes "${{ steps.impact.outputs.notes }}" \
+            --target "${{ github.sha }}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -309,8 +309,14 @@ jobs:
         if: steps.impact.outputs.has_impact == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTES: ${{ steps.impact.outputs.notes }}
         run: |
+          # Pass notes via env var to avoid bash arg-parsing issues with
+          # double quotes in PR titles. --notes-file is the canonical form.
+          notes_file=$(mktemp)
+          trap 'rm -f "$notes_file"' EXIT
+          printf '%s' "$NOTES" > "$notes_file"
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --notes "${{ steps.impact.outputs.notes }}" \
+            --notes-file "$notes_file" \
             --target "${{ github.sha }}"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.323",
+      version: "0.5.324",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/generate_schema_impact_notes.sh
+++ b/scripts/generate_schema_impact_notes.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scripts/generate_schema_impact_notes.sh
+#
+# Emit a SCHEMA-IMPACT markdown block for a release range when any merged
+# PR in that range carries a phase/* label. Empty output (and exit 0) means
+# no schema impact — caller should skip prepending anything.
+#
+# Usage:
+#   generate_schema_impact_notes.sh <base-sha> <head-sha>
+#
+# Test mode:
+#   GH_OUTPUT_OVERRIDE=<json>   — pre-canned PR list (skip gh call)
+#   IRREVERSIBLE_OVERRIDE=true|false — skip git-grep for # rollback-irreversible
+set -euo pipefail
+
+BASE_SHA="${1:?base sha required}"
+HEAD_SHA="${2:?head sha required}"
+
+# Resolve PR list. Live mode uses `gh search`; test mode uses override.
+if [ -n "${GH_OUTPUT_OVERRIDE:-}" ]; then
+  prs="$GH_OUTPUT_OVERRIDE"
+else
+  prs=$(gh search prs --repo "${GITHUB_REPOSITORY:-engram-app/Engram}" \
+        --merged \
+        --base main \
+        --json number,labels,title \
+        --limit 100 \
+        2>/dev/null || echo '[]')
+fi
+
+# Filter to PRs carrying any phase/* label.
+phase_prs=$(echo "$prs" | jq '[.[] | select(.labels[]?.name | startswith("phase/"))]')
+
+# Empty? Nothing to emit — caller skips the block entirely.
+if [ "$(echo "$phase_prs" | jq 'length')" -eq 0 ]; then
+  exit 0
+fi
+
+# Detect any irreversible migration in the range. Test override wins;
+# else grep the migration files changed between BASE and HEAD for the marker.
+if [ -n "${IRREVERSIBLE_OVERRIDE:-}" ]; then
+  irreversible="$IRREVERSIBLE_OVERRIDE"
+else
+  irreversible=false
+  if git diff --name-only "$BASE_SHA...$HEAD_SHA" -- 'priv/repo/migrations/*.exs' 2>/dev/null \
+     | xargs -r grep -l '# rollback-irreversible' >/dev/null 2>&1; then
+    irreversible=true
+  fi
+fi
+
+# Emit the SCHEMA-IMPACT block.
+{
+  echo "## SCHEMA-IMPACT"
+  echo ""
+  echo "This release modifies the database schema. **Take a database backup before upgrading.**"
+  echo ""
+  echo "### Upgrade procedure (self-host)"
+  echo ""
+  echo '```bash'
+  echo "docker compose down"
+  echo "docker compose pull"
+  echo "docker compose up -d"
+  echo "# The container's entrypoint runs migrations before Phoenix boots."
+  echo '```'
+  echo ""
+  echo "### Schema-impacting PRs in this release"
+  echo ""
+  echo "$phase_prs" | jq -r '.[] | "- #\(.number) (`" + ([.labels[] | select(.name | startswith("phase/")) | .name] | join(", ")) + "`) — \(.title)"'
+  echo ""
+  if [ "$irreversible" = "true" ]; then
+    echo "### ⚠️ IRREVERSIBLE"
+    echo ""
+    echo "One or more migrations in this release are marked \`# rollback-irreversible\`."
+    echo "**There is no automatic rollback path.** Restore from a database backup taken before the upgrade if you need to revert."
+  else
+    echo "### Rollback (optional)"
+    echo ""
+    echo "If you need to revert to the previous release, run from inside the container:"
+    echo '```bash'
+    echo "bin/engram eval 'Engram.Release.rollback(Engram.Repo, <previous-version>)'"
+    echo '```'
+    echo ""
+    echo "Then pin the previous image tag in your compose file."
+  fi
+}

--- a/scripts/generate_schema_impact_notes.sh
+++ b/scripts/generate_schema_impact_notes.sh
@@ -20,12 +20,19 @@ HEAD_SHA="${2:?head sha required}"
 if [ -n "${GH_OUTPUT_OVERRIDE:-}" ]; then
   prs="$GH_OUTPUT_OVERRIDE"
 else
-  prs=$(gh search prs --repo "${GITHUB_REPOSITORY:-engram-app/Engram}" \
-        --merged \
-        --base main \
-        --json number,labels,title \
-        --limit 100 \
-        2>/dev/null || echo '[]')
+  # Capture gh output and exit separately. A gh failure (auth, network,
+  # rate limit) silently dropping the phase-PR list would skip the
+  # SCHEMA-IMPACT block for a release that actually changes the schema —
+  # defeating the entire feature. Surface gh failures via ::error:: so CI
+  # fails fast instead of producing a misleading release page.
+  if ! prs=$(gh search prs --repo "${GITHUB_REPOSITORY:-engram-app/Engram}" \
+          --merged \
+          --base main \
+          --json number,labels,title \
+          --limit 500 2>&1); then
+    echo "::error::generate_schema_impact_notes: gh search prs failed — cannot determine phase-labeled PRs in release range. Output: $prs" >&2
+    exit 1
+  fi
 fi
 
 # Filter to PRs carrying any phase/* label.

--- a/test/scripts/generate_schema_impact_notes_test.sh
+++ b/test/scripts/generate_schema_impact_notes_test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# test/scripts/generate_schema_impact_notes_test.sh
+#
+# Tests scripts/generate_schema_impact_notes.sh via env-var overrides
+# (GH_OUTPUT_OVERRIDE, IRREVERSIBLE_OVERRIDE) — no `gh` binary needed.
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/../../scripts/generate_schema_impact_notes.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- Test 1: phase/expand PR present, all reversible ---
+output=$(GH_OUTPUT_OVERRIDE='[{"number":100,"labels":[{"name":"phase/expand"}],"title":"Add users.timezone column"}]' \
+         IRREVERSIBLE_OVERRIDE='false' \
+         bash "$SCRIPT" abc123 def456)
+
+echo "$output" | grep -q 'SCHEMA-IMPACT'           || fail "Test 1: missing SCHEMA-IMPACT header"
+echo "$output" | grep -q 'phase/expand'            || fail "Test 1: missing phase label citation"
+echo "$output" | grep -q '#100'                    || fail "Test 1: missing PR number"
+echo "$output" | grep -q 'docker compose down'     || fail "Test 1: missing downtime procedure"
+echo "$output" | grep -q 'Engram.Release.rollback' || fail "Test 1: missing rollback hint (should be present when reversible)"
+
+# --- Test 2: no phase-labeled PRs → empty output ---
+output_empty=$(GH_OUTPUT_OVERRIDE='[]' IRREVERSIBLE_OVERRIDE='false' bash "$SCRIPT" abc123 def456)
+[ -z "$output_empty" ] || fail "Test 2: expected empty output when no phase PRs; got: $output_empty"
+
+# --- Test 3: only non-phase PRs → empty output ---
+output_non_phase=$(GH_OUTPUT_OVERRIDE='[{"number":50,"labels":[{"name":"bug"}],"title":"Unrelated fix"}]' \
+                   IRREVERSIBLE_OVERRIDE='false' \
+                   bash "$SCRIPT" abc123 def456)
+[ -z "$output_non_phase" ] || fail "Test 3: expected empty output when no phase/* labels; got: $output_non_phase"
+
+# --- Test 4: irreversible migration → rollback hint omitted, IRREVERSIBLE warning emitted ---
+output_irrev=$(GH_OUTPUT_OVERRIDE='[{"number":200,"labels":[{"name":"phase/contract"}],"title":"Drop users.legacy_flag"}]' \
+               IRREVERSIBLE_OVERRIDE='true' \
+               bash "$SCRIPT" abc123 def456)
+
+echo "$output_irrev" | grep -q 'Engram.Release.rollback' && \
+  fail "Test 4: rollback hint should be omitted when irreversible" || true
+echo "$output_irrev" | grep -qi 'IRREVERSIBLE' || fail "Test 4: missing IRREVERSIBLE marker"
+echo "$output_irrev" | grep -q 'phase/contract' || fail "Test 4: missing phase/contract label citation"
+
+# --- Test 5: multiple phase PRs, multiple labels per PR ---
+output_multi=$(GH_OUTPUT_OVERRIDE='[
+  {"number":100,"labels":[{"name":"phase/expand"}],"title":"Add column"},
+  {"number":101,"labels":[{"name":"phase/contract"},{"name":"bug"}],"title":"Drop column"},
+  {"number":102,"labels":[{"name":"feature"}],"title":"Unrelated"}
+]' IRREVERSIBLE_OVERRIDE='false' bash "$SCRIPT" abc123 def456)
+
+echo "$output_multi" | grep -q '#100' || fail "Test 5: missing #100"
+echo "$output_multi" | grep -q '#101' || fail "Test 5: missing #101"
+echo "$output_multi" | grep -q '#102' && fail "Test 5: should NOT include #102 (no phase label)" || true
+echo "$output_multi" | grep -q 'phase/expand' || fail "Test 5: missing phase/expand"
+echo "$output_multi" | grep -q 'phase/contract' || fail "Test 5: missing phase/contract"
+echo "$output_multi" | grep -q '"bug"' && fail "Test 5: should NOT cite non-phase labels" || true
+
+echo "All tests passed (5)."


### PR DESCRIPTION
## Summary

Adds a `create-release-notes` job to `deploy-prod.yml` that auto-creates a GitHub Release for every `release-v*` tag whose range contains a `phase/*`-labeled PR. Release notes include the downtime upgrade procedure, list of impacted PRs, and a conditional rollback hint (omitted when any migration in the range is marked `# rollback-irreversible`).

Helper `scripts/generate_schema_impact_notes.sh` is unit-tested via `test/scripts/generate_schema_impact_notes_test.sh` (5 scenarios covering empty, phase-labeled, non-phase, irreversible, multi-label cases).

Self-hosters see the SCHEMA-IMPACT block on the release page before pulling the image — single source of truth for downtime windows and rollback procedures, no need to read individual PR descriptions.

## Plan reference

`docs/superpowers/plans/2026-06-04-migration-safety-tier-2.md` § Tier 2.D — Tier 2 of the migration-safety roadmap. Tier 1 shipped as #432.

## Test plan

- [x] Helper unit tests pass locally (`bash test/scripts/generate_schema_impact_notes_test.sh` — 5/5)
- [x] Dry-run against most-recent release range produces empty output (no phase-labeled merged PRs between `release-v0.5.320` and `release-v0.5.321` — expected; phase labels were only just created on PR #432)
- [ ] Live validation: on the next `release-v*` tag that contains a `phase/*` PR, the workflow should auto-create a Release with the SCHEMA-IMPACT block