### PR TITLE
fix(ci): apply RATE_LIMIT_AUTH_OVERRIDE to clerk e2e stack

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -67,6 +67,12 @@ services:
       # be enforced — breaking e2e tests like test_32 that assert 402 on
       # over-limit vault creation.
       ENGRAM_LIMITS_ENFORCED: "true"
+      # OAuth e2e tests (test_44/47/48/49) collectively call
+      # POST /api/auth/device + /auth/device/authorize + /auth/token/refresh
+      # well above the prod default 10 req/60s/IP from the test runner's
+      # single source IP — collisions yield flaky 429 "rate_limited" failures.
+      # Mirrors the override in docker-compose.ci-local.yml.
+      RATE_LIMIT_AUTH_OVERRIDE: "1000"
     healthcheck:
       # 1s interval (was 3s) so docker compose --wait detects "ready" with
       # finer granularity — BEAM cold boot finishes mid-interval and the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.324",
+      version: "0.5.325",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

OAuth e2e tests (`test_44/47/48/49`) collectively call `/api/auth/device`, `/auth/device/authorize`, and `/auth/token/refresh` more than 10× in a 60s window from the runner's single source IP — the prod default on the `:rate_limit_auth` pipeline. The local-auth stack already overrides this via `docker-compose.ci-local.yml`; the clerk stack was missing the same override.

Result: flaky HTTP 429 `rate_limited` failures, observed on the post-merge run [26973152099](https://github.com/engram-app/Engram/actions/runs/26973152099) (`test_48_oauth_reconnect_catchup.py::test_oauth_reconnect_catches_up`).

Fix: mirror `RATE_LIMIT_AUTH_OVERRIDE: "1000"` from the local-auth + Playwright stacks in `docker-compose.ci.yml`.

## Test plan
- [ ] CI e2e-clerk passes on this branch
- [ ] Re-run e2e-clerk on this branch to confirm stability across reruns