### PR TITLE
docs(self-host): correct paths + stack variants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,11 @@ PHX_HOST=localhost
 # local = built-in email/password (zero third-party config). clerk = SaaS JWKS.
 AUTH_PROVIDER=local
 
+# Registration mode. Default is invite_only — first user becomes admin, then
+# subsequent signups need an invite. Set "open" for a public instance or to
+# let a friend self-serve during a demo. "closed" disables signup entirely.
+ENGRAM_DEFAULT_REGISTRATION_MODE=open
+
 # ─── Encryption key provider ─────────────────────────────────────────────────
 # local = ENCRYPTION_MASTER_KEY above. aws_kms = managed CMK (needs AWS_* vars).
 KEY_PROVIDER=local

--- a/.env.lite.example
+++ b/.env.lite.example
@@ -1,0 +1,49 @@
+# Engram self-host — LITE variant.
+# Ollama embeddings (in-stack) + Postgres bytea attachments (no MinIO).
+#
+#   cp .env.lite.example .env
+#   docker compose -f docker-compose.lite.yml up --build
+
+# ─── Required secrets ───────────────────────────────────────────────────────
+# openssl rand -base64 48
+SECRET_KEY_BASE=
+
+# openssl rand -base64 48
+JWT_SECRET=
+
+# 32-byte key, base64-encoded:  openssl rand -base64 32
+# Losing this makes every encrypted note unrecoverable — back it up.
+ENCRYPTION_MASTER_KEY=
+
+# ─── Host ────────────────────────────────────────────────────────────────────
+PHX_HOST=localhost
+# For a plain-http trial on localhost, uncomment:
+#   PHX_SCHEME=http
+#   PHX_PORT=4000
+
+# ─── Auth ────────────────────────────────────────────────────────────────────
+AUTH_PROVIDER=local
+
+# Registration mode. Default is invite_only — first user becomes admin, then
+# subsequent signups need an invite. Set "open" for a public instance or to
+# let a friend self-serve during a demo. "closed" disables signup entirely.
+ENGRAM_DEFAULT_REGISTRATION_MODE=open
+
+# ─── Encryption key provider ─────────────────────────────────────────────────
+KEY_PROVIDER=local
+
+# ─── Embedding (Ollama — in-stack) ───────────────────────────────────────────
+EMBED_BACKEND=ollama
+EMBED_MODEL=nomic-embed-text
+EMBED_DIMS=768
+
+# ─── Vector store ────────────────────────────────────────────────────────────
+QDRANT_COLLECTION=obsidian_notes
+# Binary quantization needs an AVX2-capable CPU. Disable on older hardware:
+#   QDRANT_BINARY_QUANTIZATION=false
+
+# ─── Attachment storage (Postgres bytea, no MinIO) ───────────────────────────
+STORAGE_BACKEND=database
+
+# ─── Optional: Sentry error reporting ────────────────────────────────────────
+# SENTRY_DSN=

--- a/.env.voyage.example
+++ b/.env.voyage.example
@@ -1,0 +1,51 @@
+# Engram self-host — VOYAGE variant.
+# Voyage embeddings (cloud API) + MinIO attachments (in-stack).
+#
+#   cp .env.voyage.example .env
+#   docker compose -f docker-compose.voyage.yml up --build
+
+# ─── Required secrets ───────────────────────────────────────────────────────
+# openssl rand -base64 48
+SECRET_KEY_BASE=
+
+# openssl rand -base64 48
+JWT_SECRET=
+
+# 32-byte key, base64-encoded:  openssl rand -base64 32
+# Losing this makes every encrypted note unrecoverable — back it up.
+ENCRYPTION_MASTER_KEY=
+
+# Voyage API key — https://voyageai.com/
+VOYAGE_API_KEY=
+
+# ─── Host ────────────────────────────────────────────────────────────────────
+PHX_HOST=localhost
+
+# ─── Auth ────────────────────────────────────────────────────────────────────
+AUTH_PROVIDER=local
+
+# Registration mode. Default is invite_only — first user becomes admin, then
+# subsequent signups need an invite. Set "open" for a public instance or to
+# let a friend self-serve during a demo. "closed" disables signup entirely.
+ENGRAM_DEFAULT_REGISTRATION_MODE=open
+
+# ─── Encryption key provider ─────────────────────────────────────────────────
+KEY_PROVIDER=local
+
+# ─── Embedding (Voyage) ──────────────────────────────────────────────────────
+EMBED_BACKEND=voyage
+EMBED_MODEL=voyage-4-large
+EMBED_DIMS=1024
+# Optional asymmetric retrieval (different models for docs vs queries):
+#   DOC_EMBED_MODEL=voyage-4-large
+#   QUERY_EMBED_MODEL=voyage-4-lite
+
+# ─── Vector store ────────────────────────────────────────────────────────────
+QDRANT_COLLECTION=obsidian_notes
+
+# ─── Attachment storage (MinIO) ──────────────────────────────────────────────
+STORAGE_BACKEND=s3
+STORAGE_BUCKET=engram-attachments
+STORAGE_ACCESS_KEY_ID=minioadmin
+STORAGE_SECRET_ACCESS_KEY=minioadmin
+STORAGE_REGION=us-east-1

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ priv/static/app/
 
 .env*
 !.env.example
+!.env.lite.example
+!.env.voyage.example
 frontend/.vite/
 .worktrees/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 > **For AI agents:** See `AGENTS.md` for migration-safety rules — every migration PR must carry a `phase/*` label, and contract-phase drops are CI-gated against surviving `lib/` references.
 
-Engram — AI-powered personal knowledge base built on Obsidian. Your vault remembers everything. Makes your notes queryable by any AI assistant via MCP. SaaS pricing: Free / Starter $10/mo / Pro $20/mo (v2 reanchored 2026-05-20). Pricing rationale in `../engram-workspace/docs/context/pricing-strategy.md` + `docs/superpowers/specs/2026-05-20-pricing-tiers-v2-design.md`; billing integration details in `docs/context/paddle-integration.md`.
+Engram — AI-powered personal knowledge base built on Obsidian. Your vault remembers everything. Makes your notes queryable by any AI assistant via MCP. SaaS pricing: Free / Starter $7/mo / Pro $14/mo (v3 reanchored 2026-05-31). Pricing rationale in `../engram-workspace/docs/context/pricing-strategy.md` + `docs/superpowers/specs/2026-05-20-pricing-tiers-v2-design.md`; billing integration details in `docs/context/paddle-integration.md`.
 
 ## Issue Tracker
 
@@ -142,8 +142,8 @@ mix dialyzer                              # slow first run (~5-10 min PLT build)
 | Tier | Price | Features |
 |------|-------|----------|
 | **Free** | $0 | 1 vault, 1 device (12h swap cooldown), 1GB attachments, manual sync, 10k notes, 5 AI conversations/day, MCP enabled, 90-day inactivity auto-delete |
-| **Starter** | $10/mo ($100/yr) | 5 vaults, unlimited devices, 3GB attachments, real-time SSE sync, 50k notes, 500 AI queries/day, API write access |
-| **Pro** | $20/mo ($200/yr) | 15 vaults, unlimited devices, 15GB attachments, real-time sync, unlimited notes, unlimited AI (10k/day fair-use), priority support, higher API rate |
+| **Starter** | $7/mo ($70/yr) | 5 vaults, unlimited devices, 3GB attachments, real-time SSE sync, 50k notes, 500 AI queries/day, API write access |
+| **Pro** | $14/mo ($140/yr) | 15 vaults, unlimited devices, 15GB attachments, real-time sync, unlimited notes, unlimited AI (10k/day fair-use), priority support, higher API rate |
 
 Self-host (no `PADDLE_API_KEY`): free, no billing wiring. See `docs/context/paddle-integration.md` + `../engram-workspace/docs/superpowers/specs/2026-05-20-pricing-tiers-v2-design.md` for the canonical v2 design.
 

--- a/README.md
+++ b/README.md
@@ -90,20 +90,23 @@ Most operators should follow the **public docs** — they're more complete than 
 
 ### Quickstart (Docker Compose)
 
-The repo root ships a canonical [`docker-compose.yml`](./docker-compose.yml) (app + Postgres + Qdrant + Ollama + MinIO) and [`.env.example`](./.env.example):
+Three preset stacks ship in the repo. Pick the one that matches what you want:
+
+| You want | Copy | Run |
+|---|---|---|
+| Default — Ollama embeds + MinIO attachments (no API keys) | `cp .env.example .env` | `docker compose up --build` |
+| Smaller — Ollama embeds + Postgres-bytea attachments (drops MinIO, #297) | `cp .env.lite.example .env` | `docker compose -f docker-compose.lite.yml up --build` |
+| Better embeds — Voyage API + MinIO attachments (needs a Voyage key) | `cp .env.voyage.example .env` | `docker compose -f docker-compose.voyage.yml up --build` |
+
+After copying, open `.env` and fill in the three generated secrets:
 
 ```bash
-git clone https://github.com/engram-app/engram
-cd engram
-cp .env.example .env
-# generate the three secrets and paste them into .env:
-#   openssl rand -base64 48   # SECRET_KEY_BASE
-#   openssl rand -base64 48   # JWT_SECRET
-#   openssl rand -base64 32   # ENCRYPTION_MASTER_KEY  (back this up!)
-docker compose up --build     # first build compiles the release (~few min)
+openssl rand -base64 48   # SECRET_KEY_BASE
+openssl rand -base64 48   # JWT_SECRET
+openssl rand -base64 32   # ENCRYPTION_MASTER_KEY  (back this up!)
 ```
 
-The app comes up on `http://localhost:4000` (the only host-exposed port; everything else stays on the private network). Migrations run automatically on boot, and `ollama-init` pulls the default `nomic-embed-text` embedding model on first start.
+The app comes up on `http://localhost:4000`. Only port 4000 is host-exposed; Postgres, Qdrant, Ollama (if present), and MinIO (if present) stay on the private Docker network. Migrations run automatically on boot.
 
 **License:** Engram self-host is **PolyForm Small Business 1.0.0** — free for organizations with ≤ $1M/year in revenue/funding. Larger orgs need a commercial license (`support@engram.page`). See [`LICENSE`](./LICENSE) for the full terms + manual CLA flow for external contributors.
 
@@ -162,18 +165,18 @@ docker compose -f docker-compose.elixir.yml up --build
 
 ```bash
 # Register
-curl -X POST http://localhost:4000/register \
+curl -X POST http://localhost:4000/api/auth/register \
   -H "Content-Type: application/json" \
   -d '{"email": "you@example.com", "password": "your-password"}'
 
 # Login
-TOKEN=$(curl -s -X POST http://localhost:4000/login \
+TOKEN=$(curl -s -X POST http://localhost:4000/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email": "you@example.com", "password": "your-password"}' \
   | jq -r '.token')
 
 # Create API key
-curl -X POST http://localhost:4000/api-keys \
+curl -X POST http://localhost:4000/api/api-keys \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "my-key"}'
@@ -184,7 +187,7 @@ Save the returned API key — it starts with `engram_` and is only shown once.
 ### 5. Push a Note
 
 ```bash
-curl -X POST http://localhost:4000/notes \
+curl -X POST http://localhost:4000/api/notes \
   -H "Authorization: Bearer engram_your_key_here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -197,7 +200,7 @@ curl -X POST http://localhost:4000/notes \
 ### 6. Search
 
 ```bash
-curl -X POST http://localhost:4000/search \
+curl -X POST http://localhost:4000/api/search \
   -H "Authorization: Bearer engram_your_key_here" \
   -H "Content-Type: application/json" \
   -d '{"query": "hello", "limit": 5}'
@@ -221,7 +224,7 @@ The plugin handles full vault sync, live WebSocket updates, offline queueing, an
   "mcpServers": {
     "engram": {
       "type": "sse",
-      "url": "http://your-server:4000/mcp",
+      "url": "http://your-server:4000/api/mcp",
       "headers": {
         "Authorization": "Bearer engram_your_key_here"
       }
@@ -236,7 +239,7 @@ The plugin handles full vault sync, live WebSocket updates, offline queueing, an
 {
   "mcpServers": {
     "engram": {
-      "url": "http://your-server:4000/mcp",
+      "url": "http://your-server:4000/api/mcp",
       "transport": "sse",
       "headers": {
         "Authorization": "Bearer engram_your_key_here"
@@ -252,38 +255,38 @@ The plugin handles full vault sync, live WebSocket updates, offline queueing, an
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/notes` | Upsert a note (creates or updates, triggers async indexing) |
-| `GET` | `/notes/{path}` | Get full note by path |
-| `DELETE` | `/notes/{path}` | Soft-delete a note |
-| `GET` | `/notes/changes?since=<timestamp>` | Notes changed since timestamp (for sync) |
+| `POST` | `/api/notes` | Upsert a note (creates or updates, triggers async indexing) |
+| `GET` | `/api/notes/{path}` | Get full note by path |
+| `DELETE` | `/api/notes/{path}` | Soft-delete a note |
+| `GET` | `/api/notes/changes?since=<timestamp>` | Notes changed since timestamp (for sync) |
 
 ### Search
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/search` | Semantic search with optional tag/folder filtering |
-| `GET` | `/tags` | All tags with document counts |
-| `GET` | `/folders` | Folder tree with note counts |
+| `POST` | `/api/search` | Semantic search with optional tag/folder filtering |
+| `GET` | `/api/tags` | All tags with document counts |
+| `GET` | `/api/folders` | Folder tree with note counts |
 
 ### Attachments
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/attachments` | Upsert binary file (base64-encoded) |
-| `GET` | `/attachments/{path}` | Get attachment |
-| `DELETE` | `/attachments/{path}` | Soft-delete attachment |
-| `GET` | `/attachments/changes?since=<timestamp>` | Attachment changes (for sync) |
-| `GET` | `/user/storage` | Storage usage stats |
+| `POST` | `/api/attachments` | Upsert binary file (base64-encoded) |
+| `GET` | `/api/attachments/{path}` | Get attachment |
+| `DELETE` | `/api/attachments/{path}` | Soft-delete attachment |
+| `GET` | `/api/attachments/changes?since=<timestamp>` | Attachment changes (for sync) |
+| `GET` | `/api/user/storage` | Storage usage stats |
 
 ### Auth
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/register` | Register a new user |
-| `POST` | `/login` | Login, returns JWT |
-| `POST` | `/api-keys` | Create an API key (JWT auth) |
-| `DELETE` | `/api-keys/{id}` | Revoke an API key |
-| `GET` | `/api-keys` | List API keys |
+| `POST` | `/api/auth/register` | Register a new user (when `AUTH_PROVIDER=local`) |
+| `POST` | `/api/auth/login` | Login, returns JWT |
+| `POST` | `/api/api-keys` | Create an API key (JWT auth) |
+| `DELETE` | `/api/api-keys/{id}` | Revoke an API key |
+| `GET` | `/api/api-keys` | List API keys |
 
 ### Real-time Sync
 
@@ -295,10 +298,10 @@ The plugin handles full vault sync, live WebSocket updates, offline queueing, an
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/health` | Liveness check |
-| `GET` | `/health/deep` | Checks PostgreSQL, Qdrant, embedding backend |
+| `GET` | `/api/health` | Liveness check |
+| `GET` | `/api/health/deep` | Checks PostgreSQL, Qdrant, embedding backend |
 
-All endpoints except `/health`, `/register`, and `/login` require `Authorization: Bearer <api_key>` header.
+All endpoints except `/api/health`, `/api/auth/register`, and `/api/auth/login` require `Authorization: Bearer <api_key>` header.
 
 ## Testing
 
@@ -314,17 +317,7 @@ See `docs/context/testing-strategy.md` for the full testing strategy.
 
 ## Production Deployment
 
-Engram deploys to [Fly.io](https://fly.io) with first-class Phoenix support:
-
-```bash
-fly launch              # Auto-detects Phoenix, generates Dockerfile + fly.toml
-fly postgres create     # Managed PostgreSQL with daily snapshots
-fly storage create      # Tigris S3 for attachments
-fly secrets set ...     # Voyage API key, Qdrant URL, JWT secret
-fly deploy              # Runs migrations, rolling deploy
-```
-
-See `docs/context/production-deployment.md` for full infrastructure details.
+SaaS production (`app.engram.page`) is operator-internal — infrastructure-as-code, secrets, and deploy pipeline live in a private repo. For self-hosting, see the **Self-Host** section above and the [public docs](https://engram.page/docs/self-host/).
 
 ## License
 

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -1,0 +1,84 @@
+# Engram self-host — LITE variant.
+# Ollama embeddings (in-stack) + Postgres bytea attachments. Drops MinIO.
+# Suited to modest vaults (#297). Trade-off: bytea TOAST caps ~1 GB/blob
+# and bloats WAL — for large/many attachments use the default stack.
+#
+#   cp .env.lite.example .env
+#   docker compose -f docker-compose.lite.yml up --build
+
+services:
+  engram:
+    build: .
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://engram:engram@postgres:5432/engram
+      QDRANT_URL: http://qdrant:6333
+      OLLAMA_URL: http://ollama:11434
+    ports:
+      - "4000:4000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      qdrant:
+        condition: service_started
+      ollama:
+        condition: service_healthy
+      ollama-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4000/api/health || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: engram
+      POSTGRES_PASSWORD: engram
+      POSTGRES_DB: engram
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U engram"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:v1.17.1
+    volumes:
+      - qdrant_data:/qdrant/storage
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  # One-shot: pull the default self-host embedding model so the first note
+  # indexes without a manual step. Exits 0 once the model is present.
+  ollama-init:
+    image: ollama/ollama:latest
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["ollama pull nomic-embed-text"]
+    restart: "no"
+
+volumes:
+  pg_data:
+  qdrant_data:
+  ollama_data:

--- a/docker-compose.voyage.yml
+++ b/docker-compose.voyage.yml
@@ -1,0 +1,90 @@
+# Engram self-host — VOYAGE variant.
+# Voyage API embeddings (better retrieval quality, requires API key) +
+# MinIO attachments. Drops Ollama from the stack.
+# Get a Voyage key at https://voyageai.com/ — set VOYAGE_API_KEY in .env.
+#
+#   cp .env.voyage.example .env
+#   # fill in VOYAGE_API_KEY + the three secrets
+#   docker compose -f docker-compose.voyage.yml up --build
+
+services:
+  engram:
+    build: .
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://engram:engram@postgres:5432/engram
+      QDRANT_URL: http://qdrant:6333
+      STORAGE_SCHEME: "http://"
+      STORAGE_HOST: minio
+      STORAGE_PORT: "9000"
+    ports:
+      - "4000:4000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      qdrant:
+        condition: service_started
+      minio-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4000/api/health || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: engram
+      POSTGRES_PASSWORD: engram
+      POSTGRES_DB: engram
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U engram"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:v1.17.1
+    volumes:
+      - qdrant_data:/qdrant/storage
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY_ID:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_ACCESS_KEY:-minioadmin}
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # One-shot: create the attachments bucket, then exit.
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${STORAGE_ACCESS_KEY_ID:-minioadmin} ${STORAGE_SECRET_ACCESS_KEY:-minioadmin};
+      mc mb --ignore-existing local/${STORAGE_BUCKET:-engram-attachments};
+      exit 0;
+      "
+    restart: "no"
+
+volumes:
+  pg_data:
+  qdrant_data:
+  minio_data:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.328",
+      version: "0.5.329",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- **README** — prefix every backend route with `/api/` (curl examples, MCP JSON blocks, API reference tables, header-required exceptions). Bare paths 404'd against `router.ex` scopes. Replaces the single Quickstart block with a 3-stack picker (default / lite / voyage). Strips Fly.io §Production Deployment — prod is AWS ECS Fargate since 2026-06-02 and operator-internal anyway.
- **CLAUDE.md** — reanchor pricing $10/$20 monthly + $100/$200 annual → $7/$14 + $70/$140 (v3 locked 2026-05-31).
- **`.env.example`** — add `ENGRAM_DEFAULT_REGISTRATION_MODE` block. Code default is `invite_only` (runtime.exs:175). A fresh self-host instance rejects the operator's signup until they flip it. Demo footgun.
- **New compose variants** + matching `.env.*.example`:
  - `docker-compose.lite.yml` — Ollama embed + Postgres bytea attachments (#297). Drops MinIO + minio-init.
  - `docker-compose.voyage.yml` — Voyage API embed + MinIO attachments. Drops Ollama + ollama-init.
- `.gitignore` — exceptions for the two new env example files.

All three composes verified with \`docker compose -f <file> config --quiet\`.

## Audit basis

Audit cross-checked README + marketing self-host docs against router.ex, runtime.exs, and the staging-fastraid TF stack. Findings beyond this PR (marketing-side typos + fictional env vars, deeper architecture drift) tracked separately — this PR fixes what's most likely to break a self-host operator following the repo README end-to-end.

## Test plan

- [ ] `cp .env.example .env`, fill 3 secrets, `docker compose up --build` — verify migrations apply, app comes up on :4000, signup via `/api/auth/register` works with `ENGRAM_DEFAULT_REGISTRATION_MODE=open`
- [ ] `cp .env.lite.example .env`, `docker compose -f docker-compose.lite.yml up --build` — no MinIO, attachment upload writes to `storage_objects` table
- [ ] `cp .env.voyage.example .env` with real `VOYAGE_API_KEY`, `docker compose -f docker-compose.voyage.yml up --build` — embed jobs hit Voyage, MinIO attachments work
- [ ] Connect Claude Desktop MCP at `http://localhost:4000/api/mcp` — handshake succeeds (path was `/mcp` before, would have 404'd)
- [ ] Check rendered README on the PR page reads cleanly — picker table, no broken curl, no Fly.io block

🤖 Generated with [Claude Code](https://claude.com/claude-code)