### PR TITLE
fix(ci): mark Sentry release-tagging non-blocking (#444)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2679,8 +2679,18 @@ jobs:
       # UI and associates commits, so the "Releases" view shows what's
       # running and "Suspect Commits" can finger a likely-culprit commit
       # on a new error.
+      #
+      # continue-on-error: true — Sentry release-tagging is UI-only
+      # nicety, NOT a deploy gate. After the 2026-06-04 project rename
+      # (#284 / sentry-ops.md), the existing SENTRY_AUTH_TOKEN may have
+      # been scoped to the pre-rename project slugs and now hits "API
+      # request failed" on finalize. The deploy itself (build → ECR
+      # push → tf bump → ECS rolling) must not get blocked by a stale
+      # Sentry token. Tracked in #444; rotate the token in the Sentry
+      # dashboard then remove this `continue-on-error`.
       - name: Sentry frontend release
         if: steps.version.outputs.image_exists != 'true' && steps.sentry-token.outputs.has_token == 'true'
+        continue-on-error: true
         uses: getsentry/action-release@v3
         env:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
@@ -2694,6 +2704,7 @@ jobs:
 
       - name: Sentry backend release
         if: steps.version.outputs.image_exists != 'true' && steps.sentry-token.outputs.has_token == 'true'
+        continue-on-error: true
         uses: getsentry/action-release@v3
         env:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.329",
+      version: "0.5.330",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Sentry release-finalize steps in `verify.yml` started failing today with `error: API request failed` after engram-infra #284 renamed the Sentry projects (`elixir`/`javascript-react` → `engram-backend`/`engram-frontend`).

Sentry release-tagging is **UI-only** — source maps are already uploaded by the Vite plugin during the Dockerfile frontend build, keyed by the same release name. The release-tagging step exists so Sentry's "Releases" view shows the running version and "Suspect Commits" can flag a probable culprit on a new error. Neither feature is on the deploy critical path.

Add `continue-on-error: true` to both Sentry steps so the deploy chain (build → ECR push → `bump-infra-tfvars` → ECS rolling) proceeds even when release-tagging fails.

## Root cause (not fixed here)

The existing `SENTRY_AUTH_TOKEN` was likely scoped to the pre-rename project slugs. Sentry tokens don't automatically follow project renames — the operator needs to either rotate the token or extend its scope to cover the new slugs. Tracking under #444; removing `continue-on-error` is the close-out for that issue.

## Test plan

- [ ] CI passes (sentry steps may still fail, but `build-and-publish-image` job completes successfully)
- [ ] After merge, ECR push + tf-bump PR fire as expected
- [ ] Follow-up: rotate `SENTRY_AUTH_TOKEN` in Sentry dashboard; re-enable strict mode by removing `continue-on-error`

Closes part of #444 (deploy unblocked); leaves the token-rotation follow-up open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)