### PR TITLE
fix(ci): restore strict Sentry release-tag step (closes #444)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2679,18 +2679,8 @@ jobs:
       # UI and associates commits, so the "Releases" view shows what's
       # running and "Suspect Commits" can finger a likely-culprit commit
       # on a new error.
-      #
-      # continue-on-error: true — Sentry release-tagging is UI-only
-      # nicety, NOT a deploy gate. After the 2026-06-04 project rename
-      # (#284 / sentry-ops.md), the existing SENTRY_AUTH_TOKEN may have
-      # been scoped to the pre-rename project slugs and now hits "API
-      # request failed" on finalize. The deploy itself (build → ECR
-      # push → tf bump → ECS rolling) must not get blocked by a stale
-      # Sentry token. Tracked in #444; rotate the token in the Sentry
-      # dashboard then remove this `continue-on-error`.
       - name: Sentry frontend release
         if: steps.version.outputs.image_exists != 'true' && steps.sentry-token.outputs.has_token == 'true'
-        continue-on-error: true
         uses: getsentry/action-release@v3
         env:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
@@ -2704,7 +2694,6 @@ jobs:
 
       - name: Sentry backend release
         if: steps.version.outputs.image_exists != 'true' && steps.sentry-token.outputs.has_token == 'true'
-        continue-on-error: true
         uses: getsentry/action-release@v3
         env:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.332",
+      version: "0.5.333",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Closes #444.

Token rotated 2026-06-04 with the right scopes (`org:read` + `project:read` + `project:releases`). Drop the `continue-on-error: true` workaround from PR #445 and restore the original comment block.

If the new token is wrong-scoped or expired in the future, the deploy will now fail loudly instead of silently losing the release in Sentry's UI — that's the correct behavior for a working credential.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the post-merge CI run on `main` shows `Sentry frontend release` and `Sentry backend release` steps passing
- [ ] A new release appears in https://rasbandit-software-solutions-l.sentry.io/releases/ for both projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)