### PR TITLE
fix(billing): dismiss Paddle overlay on CHECKOUT_COMPLETED

### DIFF
--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -126,6 +126,75 @@ describe('BillingPage — Paddle effect cleanup', () => {
     ).not.toThrow()
   })
 
+  it('closes Paddle overlay on CHECKOUT_COMPLETED so activation overlay is visible', async () => {
+    get.mockImplementation(async (url: string) => {
+      if (url === '/billing/status')
+        return {
+          tier: 'free',
+          active: false,
+          trial_days_remaining: 0,
+          subscription: null,
+          caps: {},
+        }
+      if (url === '/billing/config')
+        return {
+          client_token: 'tok',
+          environment: 'sandbox',
+          price_ids: {
+            starter: { monthly: 'p1', annual: 'p2' },
+            pro: { monthly: 'p3', annual: 'p4' },
+          },
+          customer_email: 'u@example.com',
+          custom_data: { user_id: '1' },
+          vaults_cap: null,
+        }
+      if (url === '/me') return { user: ME }
+      throw new Error(`unexpected GET ${url}`)
+    })
+
+    const closeMock = vi.fn()
+    let captured: ((event: { name: string; data?: unknown }) => void) | undefined
+    initializePaddleMock.mockImplementation(async (opts: { eventCallback?: typeof captured }) => {
+      captured = opts.eventCallback
+      return { Checkout: { open: vi.fn(), close: closeMock } }
+    })
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <AuthContext.Provider value={authAdapter}>
+          <ThemeProvider>
+            <MemoryRouter>
+              <BillingPage onActivated={() => {}} />
+            </MemoryRouter>
+          </ThemeProvider>
+        </AuthContext.Provider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => expect(captured).toBeDefined())
+    // Let the initializePaddle .then() resolve so the paddle instance ref is
+    // populated before the event callback fires.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      captured!({ name: 'checkout.payment.initiated', data: { transaction_id: 'txn_1' } })
+      await Promise.resolve()
+    })
+    // PAYMENT_INITIATED is still mid-checkout (3DS, etc) — must NOT close
+    expect(closeMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      captured!({ name: 'checkout.completed', data: { transaction_id: 'txn_1' } })
+      await Promise.resolve()
+    })
+
+    expect(closeMock).toHaveBeenCalledTimes(1)
+  })
+
   it('invalidates billing/status on subscription_activated channel event (settings flow)', async () => {
     let billingActive = false
     get.mockImplementation(async (url: string) => {

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -63,6 +63,9 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
   const { resolved } = useTheme()
   const qc = useQueryClient()
   const [paddle, setPaddle] = useState<Paddle>()
+  // Ref mirror of `paddle` so the eventCallback (captured pre-instance) can
+  // call Checkout.close() on CHECKOUT_COMPLETED without re-initializing.
+  const paddleRef = useRef<Paddle | undefined>(undefined)
   const [cadence, setCadence] = useState<BillingCadence>('monthly')
 
   const [overlayVisible, setOverlayVisible] = useState(false)
@@ -155,6 +158,10 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
             break
           }
           case CheckoutEventNames.CHECKOUT_COMPLETED: {
+            // Paddle's own success screen would otherwise sit on top of our
+            // ActivationOverlay until the user clicks X — looks like the
+            // checkout hung. Dismiss it so the activation stepper is visible.
+            paddleRef.current?.Checkout.close()
             // Belt-and-suspenders: PAYMENT_INITIATED may drop on trial-signup
             // redirects. Don't reset the cooldown timestamp if it's already set.
             setOverlayVisible(true)
@@ -185,10 +192,14 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
       },
     }).then((instance) => {
       if (cancelled) return
-      if (instance) setPaddle(instance)
+      if (instance) {
+        paddleRef.current = instance
+        setPaddle(instance)
+      }
     })
     return () => {
       cancelled = true
+      paddleRef.current = undefined
       setPaddle(undefined)
     }
   }, [config, resolved, qc])

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.333",
+      version: "0.5.334",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Fixes the post-#440 UX where the Paddle modal appears stuck after a successful checkout, and the user has to click X to see anything happen.

When `successUrl` was dropped in #440 (intentional — the activation overlay was meant to take over), Paddle's built-in "Payment successful" screen now sits on top of our `ActivationOverlay` waiting for a manual close. The activation IS in fact progressing behind it; the user just can't see it.

Fix: programmatically call `paddle.Checkout.close()` on `CHECKOUT_COMPLETED` so the handoff is clean — Paddle dismisses immediately, our overlay (which correctly distinguishes payment-received → subscription-activated → account-ready) becomes the single source of truth.

## Behavior

| Event | Pre-PR | Post-PR |
|---|---|---|
| `CHECKOUT_PAYMENT_INITIATED` | overlay shows, Paddle still open (3DS etc) | unchanged |
| `CHECKOUT_COMPLETED` | overlay shows BEHIND Paddle's success screen; user must click X | Paddle dismisses; overlay visible |
| `CHECKOUT_PAYMENT_FAILED` | overlay hides, Paddle shows its own retry UI | unchanged — Paddle handles retry |

## Why a ref

The eventCallback closure is captured before `initializePaddle` resolves, so it can't read `paddle` from useState. Mirror the instance into a ref alongside the existing `setPaddle` call so the callback can dismiss the overlay without re-initialization. Cleared in the effect cleanup alongside `cancelled` / `setPaddle(undefined)`.

## Test plan

- [x] Added `closes Paddle overlay on CHECKOUT_COMPLETED` to `billing-page.test.tsx`. Asserts `CHECKOUT_PAYMENT_INITIATED` does NOT close, `CHECKOUT_COMPLETED` does (once).
- [x] Existing tests still pass: `bunx vitest run src/billing/billing-page.test.tsx` → 3/3.
- [x] Full frontend suite: 198 passing. 2 pre-existing failures in `device-link-page.test.tsx` already tracked as #442 (verified red on `origin/main`).
- [x] `tsc --noEmit` clean.
- [ ] Manual smoke on staging-fastraid after the sandbox Paddle webhook URL is restored (engram-infra#119) — until then the overlay will sit at "Activating subscription" past the 15s cooldown because the broadcast can't arrive. This PR is purely about the Paddle-modal handoff; the missing-webhook UX is independent.

## Related

- Regression introduced by #440 (drop of successUrl + new ActivationOverlay).
- Staging webhook gap: engram-infra#119.