### PR TITLE
fix(auth): disconnect live sockets on revocation/downgrade

### DIFF
--- a/lib/engram/accounts.ex
+++ b/lib/engram/accounts.ex
@@ -8,6 +8,7 @@ defmodule Engram.Accounts do
   alias Engram.Accounts.{ApiKey, User}
   alias Engram.Auth.EmailNormalizer
   alias Engram.Auth.RefreshToken
+  alias Engram.Auth.SessionInvalidator
   alias Engram.Repo
 
   @api_key_prefix "engram_"
@@ -265,9 +266,13 @@ defmodule Engram.Accounts do
 
   @doc "Spec §8/§10 — revokes all of a user's refresh tokens (logout-everywhere)."
   def revoke_all_user_tokens(%User{id: user_id}) do
-    RefreshToken
-    |> where([rt], rt.user_id == ^user_id and is_nil(rt.revoked_at))
-    |> Repo.update_all([set: [revoked_at: @admin_revoked_at]], skip_tenant_check: true)
+    result =
+      RefreshToken
+      |> where([rt], rt.user_id == ^user_id and is_nil(rt.revoked_at))
+      |> Repo.update_all([set: [revoked_at: @admin_revoked_at]], skip_tenant_check: true)
+
+    SessionInvalidator.disconnect_user(user_id)
+    result
   end
 
   def verify_password(email, password) do
@@ -443,8 +448,25 @@ defmodule Engram.Accounts do
     # `Connections.any_history?`, which distinguishes "already revoked" from
     # "never existed" by row presence. Sentinel gives us both: leeway always
     # closes, and history queries still see the row.
-    from(rt in RefreshToken, where: rt.family_id == ^family_id and is_nil(rt.revoked_at))
-    |> Repo.update_all([set: [revoked_at: @admin_revoked_at]], skip_tenant_check: true)
+    # Snapshot the distinct user_ids in the family BEFORE revoke so we can
+    # force-disconnect every affected user's live sockets — the realtime
+    # gate in UserSocket is connect-time only.
+    affected_user_ids =
+      Repo.all(
+        from(rt in RefreshToken,
+          where: rt.family_id == ^family_id and is_nil(rt.revoked_at),
+          select: rt.user_id,
+          distinct: true
+        ),
+        skip_tenant_check: true
+      )
+
+    result =
+      from(rt in RefreshToken, where: rt.family_id == ^family_id and is_nil(rt.revoked_at))
+      |> Repo.update_all([set: [revoked_at: @admin_revoked_at]], skip_tenant_check: true)
+
+    Enum.each(affected_user_ids, &SessionInvalidator.disconnect_user/1)
+    result
   end
 
   @doc "SHA-256 hash a raw refresh token for storage/lookup."
@@ -550,9 +572,15 @@ defmodule Engram.Accounts do
       end)
 
     case result do
-      {:ok, {:ok, _}} -> :ok
-      {:ok, {:error, :not_found}} -> {:error, :not_found}
-      {:ok, {:error, changeset}} -> {:error, changeset}
+      {:ok, {:ok, _}} ->
+        SessionInvalidator.disconnect_user(user.id)
+        :ok
+
+      {:ok, {:error, :not_found}} ->
+        {:error, :not_found}
+
+      {:ok, {:error, changeset}} ->
+        {:error, changeset}
     end
   end
 
@@ -608,20 +636,23 @@ defmodule Engram.Accounts do
 
   @doc "Suspends a user (blocks login + refresh). Refuses the last active admin."
   def suspend(%User{} = user) do
-    with_admin_lock(fn ->
-      user = Repo.reload!(user, skip_tenant_check: true)
+    result =
+      with_admin_lock(fn ->
+        user = Repo.reload!(user, skip_tenant_check: true)
 
-      if would_orphan_admins?(user) do
-        Repo.rollback(:last_admin)
-      else
-        case user
-             |> Ecto.Changeset.change(suspended_at: DateTime.utc_now())
-             |> Repo.update(skip_tenant_check: true) do
-          {:ok, u} -> u
-          {:error, cs} -> Repo.rollback(cs)
+        if would_orphan_admins?(user) do
+          Repo.rollback(:last_admin)
+        else
+          case user
+               |> Ecto.Changeset.change(suspended_at: DateTime.utc_now())
+               |> Repo.update(skip_tenant_check: true) do
+            {:ok, u} -> u
+            {:error, cs} -> Repo.rollback(cs)
+          end
         end
-      end
-    end)
+      end)
+
+    disconnect_on_commit(result)
   end
 
   @doc "Clears suspension."
@@ -633,21 +664,33 @@ defmodule Engram.Accounts do
 
   @doc "Soft-deletes a user. Refuses the last active admin."
   def soft_delete_user(%User{} = user) do
-    with_admin_lock(fn ->
-      user = Repo.reload!(user, skip_tenant_check: true)
+    result =
+      with_admin_lock(fn ->
+        user = Repo.reload!(user, skip_tenant_check: true)
 
-      if would_orphan_admins?(user) do
-        Repo.rollback(:last_admin)
-      else
-        case user
-             |> Ecto.Changeset.change(deleted_at: DateTime.utc_now())
-             |> Repo.update(skip_tenant_check: true) do
-          {:ok, u} -> u
-          {:error, cs} -> Repo.rollback(cs)
+        if would_orphan_admins?(user) do
+          Repo.rollback(:last_admin)
+        else
+          case user
+               |> Ecto.Changeset.change(deleted_at: DateTime.utc_now())
+               |> Repo.update(skip_tenant_check: true) do
+            {:ok, u} -> u
+            {:error, cs} -> Repo.rollback(cs)
+          end
         end
-      end
-    end)
+      end)
+
+    disconnect_on_commit(result)
   end
+
+  # Fire SessionInvalidator only after the admin-lock transaction COMMITS so
+  # a rolled-back suspend/soft-delete does not spuriously kick live sockets.
+  defp disconnect_on_commit({:ok, %User{id: user_id}} = ok) do
+    SessionInvalidator.disconnect_user(user_id)
+    ok
+  end
+
+  defp disconnect_on_commit(other), do: other
 
   # Serializes admin-count-sensitive ops (set_role/suspend/soft_delete) against
   # each other via the same advisory lock that gates bootstrap. Without it,

--- a/lib/engram/auth/clerk/webhook.ex
+++ b/lib/engram/auth/clerk/webhook.ex
@@ -26,7 +26,28 @@ defmodule Engram.Auth.Clerk.Webhook do
   @spec handle(event()) :: :ok
   def handle(%{"type" => "user.created", "data" => data}), do: handle_user_created(data)
   def handle(%{"type" => "user.updated", "data" => data}), do: handle_user_updated(data)
+  def handle(%{"type" => "user.deleted", "data" => data}), do: handle_user_deleted(data)
   def handle(_), do: :ok
+
+  # Clerk fires `user.deleted` when an admin deletes a user from the Clerk
+  # dashboard, when Clerk itself revokes a user (e.g. the duplicate-signup
+  # branch in `apply_user_created/3`), or when a user self-deletes via the
+  # Clerk account portal. Mirror the deletion locally so the user can no
+  # longer auth — and force-disconnect any live sockets, since the JWT
+  # cached in `socket.assigns.current_user` would otherwise keep streaming
+  # data until the connection drops.
+  defp handle_user_deleted(%{"id" => clerk_id}) when is_binary(clerk_id) do
+    case Accounts.find_by_external_id(clerk_id) do
+      {:ok, user} ->
+        _ = Accounts.soft_delete_user(user)
+        :ok
+
+      {:error, :user_not_found} ->
+        :ok
+    end
+  end
+
+  defp handle_user_deleted(_), do: :ok
 
   defp handle_user_created(%{"id" => clerk_id} = data) do
     case Accounts.find_by_external_id(clerk_id) do

--- a/lib/engram/auth/session_invalidator.ex
+++ b/lib/engram/auth/session_invalidator.ex
@@ -1,0 +1,25 @@
+defmodule Engram.Auth.SessionInvalidator do
+  @moduledoc """
+  Force-disconnect every live WebSocket for a user.
+
+  Phoenix sockets identify themselves via the `id/1` callback in
+  `EngramWeb.UserSocket` — `"user_socket:\#{user_id}"`. Broadcasting the
+  `"disconnect"` event on that topic tears down every socket assigned to
+  that user, regardless of which token they connected with.
+
+  Call this from any path that invalidates auth or alters entitlements
+  that channels gate on:
+
+    * API key revoke, refresh-token-family revoke, OAuth revoke
+    * account self-delete, admin soft-delete, admin suspend
+    * Clerk `user.deleted` webhook
+    * Paddle subscription cancel / tier downgrade
+
+  Fire-and-forget. If no sockets are listening, `Phoenix.PubSub` drops it.
+  """
+
+  def disconnect_user(user_id) when is_integer(user_id) or is_binary(user_id) do
+    _ = EngramWeb.Endpoint.broadcast("user_socket:#{user_id}", "disconnect", %{})
+    :ok
+  end
+end

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -436,7 +436,7 @@ defmodule Engram.Billing do
            from(s in Subscription, where: s.paddle_subscription_id == ^subscription_id),
            skip_tenant_check: true
          ) do
-      %Subscription{} = sub ->
+      %Subscription{tier: prev_tier, status: prev_status} = sub ->
         result =
           sub
           |> Subscription.changeset(%{
@@ -452,6 +452,15 @@ defmodule Engram.Billing do
             # listener re-fetches /onboarding/status to decide what to do,
             # so plan changes and trial→active flips both push downstream UI.
             broadcast_subscription_activated(updated.user_id, updated)
+
+            # Realtime sync (and other tier-gated features) are evaluated at
+            # channel-join, so an open SyncChannel keeps streaming after a
+            # tier or status change. Force-disconnect when either changed so
+            # the next reconnect re-runs the gate with the fresh subscription.
+            if updated.tier != prev_tier or updated.status != prev_status do
+              Engram.Auth.SessionInvalidator.disconnect_user(updated.user_id)
+            end
+
             {:ok, updated}
 
           err ->

--- a/lib/engram/oauth.ex
+++ b/lib/engram/oauth.ex
@@ -369,11 +369,16 @@ defmodule Engram.OAuth do
     case Repo.one(from(rt in RefreshToken, where: rt.token_hash == ^hash),
            skip_tenant_check: true
          ) do
-      %RefreshToken{client_id: ^client_id} = rt ->
+      %RefreshToken{client_id: ^client_id, user_id: user_id} = rt ->
         rt
         |> Ecto.Changeset.change(%{revoked_at: DateTime.utc_now(:second)})
         |> Repo.update!(skip_tenant_check: true)
 
+        # The matching access JWT lives outside our DB (Joken-signed, stateless)
+        # and remains technically valid until exp. Force-disconnect live sockets
+        # so any session still riding that access token loses its push channel
+        # immediately rather than at exp.
+        Engram.Auth.SessionInvalidator.disconnect_user(user_id)
         :ok
 
       _ ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.334",
+      version: "0.5.335",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/accounts/profile_test.exs
+++ b/test/engram/accounts/profile_test.exs
@@ -104,6 +104,18 @@ defmodule Engram.Accounts.ProfileTest do
       assert Accounts.list_api_keys(reloaded) == []
     end
 
+    test "force-disconnects live sockets" do
+      {:ok, _admin} = Accounts.create_user_with_password("keep-admin2@example.com", "password123")
+      {:ok, user} = Accounts.create_user_with_password("kick@example.com", "password123")
+
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      assert :ok = Accounts.delete_self(user, "password123")
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+    end
+
     test "returns :invalid_password when password is wrong" do
       {:ok, _admin} = Accounts.create_user_with_password("admin3@example.com", "password123")
       {:ok, user} = Accounts.create_user_with_password("wrong@example.com", "password123")

--- a/test/engram/accounts_admin_test.exs
+++ b/test/engram/accounts_admin_test.exs
@@ -46,6 +46,38 @@ defmodule Engram.AccountsAdminTest do
     assert {:error, :last_admin} = Accounts.soft_delete_user(admin)
   end
 
+  test "suspend/1 force-disconnects live sockets" do
+    _admin = insert(:user, role: "admin")
+    m = insert(:user, role: "member")
+    topic = "user_socket:#{m.id}"
+    EngramWeb.Endpoint.subscribe(topic)
+
+    assert {:ok, _} = Accounts.suspend(m)
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+  end
+
+  test "suspend/1 does NOT broadcast disconnect when rolled back as last_admin" do
+    admin = insert(:user, role: "admin")
+    topic = "user_socket:#{admin.id}"
+    EngramWeb.Endpoint.subscribe(topic)
+
+    assert {:error, :last_admin} = Accounts.suspend(admin)
+
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}, 50
+  end
+
+  test "soft_delete_user/1 force-disconnects live sockets" do
+    _admin = insert(:user, role: "admin")
+    m = insert(:user, role: "member")
+    topic = "user_socket:#{m.id}"
+    EngramWeb.Endpoint.subscribe(topic)
+
+    assert {:ok, _} = Accounts.soft_delete_user(m)
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+  end
+
   # Spec §7 — admin DELETE on a user purges vault data, not just the user row.
   test "purge_user_vaults/1 enqueues a forced CleanupVault per owned vault" do
     user = insert(:user, role: "member")

--- a/test/engram/accounts_test.exs
+++ b/test/engram/accounts_test.exs
@@ -38,6 +38,25 @@ defmodule Engram.AccountsTest do
       assert :ok = Accounts.revoke_api_key(user, api_key.id)
       assert Accounts.list_api_keys(user) == []
     end
+
+    test "revoke_api_key force-disconnects live sockets for the user", %{user: user} do
+      {:ok, _raw, api_key} = Accounts.create_api_key(user, "to revoke + kick")
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      assert :ok = Accounts.revoke_api_key(user, api_key.id)
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+    end
+
+    test "revoke_api_key does NOT broadcast disconnect when key not found", %{user: user} do
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      assert {:error, :not_found} = Accounts.revoke_api_key(user, 999_999)
+
+      refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}, 50
+    end
   end
 
   describe "find_or_create_by_external_id/2" do
@@ -193,6 +212,27 @@ defmodule Engram.AccountsTest do
       # in place so `Connections.any_history?` can still see the lineage.
       assert {:error, :token_reused} = Accounts.consume_refresh_token(raw_token)
       assert {:error, :token_reused} = Accounts.consume_refresh_token(new_raw)
+    end
+
+    test "revoke_all_user_tokens force-disconnects live sockets", %{user: user} do
+      {:ok, _raw, _record} = Accounts.create_refresh_token(user)
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      Accounts.revoke_all_user_tokens(user)
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+    end
+
+    test "revoke_token_family force-disconnects live sockets for affected users",
+         %{user: user} do
+      {:ok, _raw, record} = Accounts.create_refresh_token(user)
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      Accounts.revoke_token_family(record.family_id)
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
     end
 
     test "revoke_all_user_tokens preserves row history for Connections lookups",

--- a/test/engram/auth/clerk/webhook_test.exs
+++ b/test/engram/auth/clerk/webhook_test.exs
@@ -1,0 +1,49 @@
+defmodule Engram.Auth.Clerk.WebhookTest do
+  use Engram.DataCase, async: false
+
+  alias Engram.Accounts
+  alias Engram.Auth.Clerk.Webhook
+
+  describe "user.deleted" do
+    test "soft-deletes local user and force-disconnects live sockets" do
+      # Need another admin so soft_delete_user does not refuse this as last admin.
+      _other = insert(:user, role: "admin")
+      user = insert(:user, role: "member", external_id: "clerk_user_kick_1")
+
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      assert :ok =
+               Webhook.handle(%{"type" => "user.deleted", "data" => %{"id" => user.external_id}})
+
+      reloaded = Engram.Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
+      refute is_nil(reloaded.deleted_at)
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+    end
+
+    test "no-op when local user does not exist (e.g. duplicate-signup path)" do
+      assert :ok =
+               Webhook.handle(%{
+                 "type" => "user.deleted",
+                 "data" => %{"id" => "clerk_user_never_existed"}
+               })
+    end
+
+    test "no-op when payload missing id" do
+      assert :ok = Webhook.handle(%{"type" => "user.deleted", "data" => %{}})
+    end
+
+    test "refuses to soft-delete the last active admin" do
+      admin = insert(:user, role: "admin", external_id: "clerk_user_solo_admin")
+
+      assert :ok =
+               Webhook.handle(%{"type" => "user.deleted", "data" => %{"id" => admin.external_id}})
+
+      reloaded = Engram.Repo.get!(Engram.Accounts.User, admin.id, skip_tenant_check: true)
+      assert is_nil(reloaded.deleted_at)
+
+      assert {:ok, _} = Accounts.find_by_external_id(admin.external_id)
+    end
+  end
+end

--- a/test/engram/auth/session_invalidator_test.exs
+++ b/test/engram/auth/session_invalidator_test.exs
@@ -1,0 +1,31 @@
+defmodule Engram.Auth.SessionInvalidatorTest do
+  use Engram.DataCase, async: false
+
+  alias Engram.Auth.SessionInvalidator
+
+  test "disconnect_user/1 broadcasts disconnect on user_socket:{id}" do
+    user_id = 12_345
+    topic = "user_socket:#{user_id}"
+    EngramWeb.Endpoint.subscribe(topic)
+
+    assert :ok = SessionInvalidator.disconnect_user(user_id)
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      topic: ^topic,
+      event: "disconnect",
+      payload: %{}
+    }
+  end
+
+  test "disconnect_user/1 accepts integer or string user id" do
+    EngramWeb.Endpoint.subscribe("user_socket:42")
+
+    assert :ok = SessionInvalidator.disconnect_user("42")
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: "user_socket:42", event: "disconnect"}
+  end
+
+  test "disconnect_user/1 returns :ok even when no subscribers" do
+    assert :ok = SessionInvalidator.disconnect_user(99_999_999)
+  end
+end

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -666,6 +666,94 @@ defmodule Engram.BillingTest do
       assert payload.status == "active"
       assert payload.subscription_id == "sub_upd_broadcast_1"
     end
+
+    test "subscription.canceled force-disconnects live sockets" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_kick_cancel",
+        status: "active",
+        tier: "pro"
+      )
+
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      event = %{
+        "event_type" => "subscription.canceled",
+        "data" => %{
+          "id" => "sub_kick_cancel",
+          "status" => "canceled",
+          "customer_id" => "ctm_x",
+          "items" => [%{"price" => %{"id" => "pri_pro_monthly_test"}}],
+          "current_billing_period" => %{"ends_at" => "2026-07-01T00:00:00Z"}
+        }
+      }
+
+      assert {:ok, _} = Billing.upsert_from_paddle_event(event)
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+    end
+
+    test "subscription tier downgrade force-disconnects live sockets" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_kick_downgrade",
+        status: "active",
+        tier: "pro"
+      )
+
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      event = %{
+        "event_type" => "subscription.updated",
+        "data" => %{
+          "id" => "sub_kick_downgrade",
+          "status" => "active",
+          "customer_id" => "ctm_x",
+          "items" => [%{"price" => %{"id" => "pri_starter_monthly_test"}}],
+          "current_billing_period" => %{"ends_at" => "2026-07-01T00:00:00Z"}
+        }
+      }
+
+      assert {:ok, updated} = Billing.upsert_from_paddle_event(event)
+      assert updated.tier == "starter"
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+    end
+
+    test "subscription update with identical tier+status does NOT broadcast disconnect" do
+      user = insert(:user)
+
+      insert(:subscription,
+        user: user,
+        paddle_subscription_id: "sub_noop_update",
+        status: "active",
+        tier: "pro"
+      )
+
+      topic = "user_socket:#{user.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      event = %{
+        "event_type" => "subscription.updated",
+        "data" => %{
+          "id" => "sub_noop_update",
+          "status" => "active",
+          "customer_id" => "ctm_x",
+          "items" => [%{"price" => %{"id" => "pri_pro_monthly_test"}}],
+          "current_billing_period" => %{"ends_at" => "2026-08-01T00:00:00Z"}
+        }
+      }
+
+      assert {:ok, _} = Billing.upsert_from_paddle_event(event)
+
+      refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}, 50
+    end
   end
 
   describe "subscription memoization" do

--- a/test/engram_web/controllers/oauth_revoke_controller_test.exs
+++ b/test/engram_web/controllers/oauth_revoke_controller_test.exs
@@ -90,6 +90,27 @@ defmodule EngramWeb.OAuthRevokeControllerTest do
       assert json_response(conn2, 400)["error"] == "invalid_grant"
     end
 
+    test "force-disconnects live sockets for the token's owner", %{conn: conn} do
+      {client, rt} = full_flow_refresh_token(conn)
+      hash = :crypto.hash(:sha256, rt) |> Base.encode16(case: :lower)
+
+      user_id =
+        Repo.one!(
+          from(r in RefreshToken, where: r.token_hash == ^hash, select: r.user_id),
+          skip_tenant_check: true
+        )
+
+      topic = "user_socket:#{user_id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      assert post(build_conn(), "/oauth/revoke", %{
+               "token" => rt,
+               "client_id" => client.client_id
+             }).status == 200
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect"}
+    end
+
     test "returns 200 for an unknown token (RFC 7009 §2.2)", %{conn: conn} do
       conn =
         post(conn, "/oauth/revoke", %{


### PR DESCRIPTION
## Summary

Phoenix Channel auth + tier gates were evaluated only at connect/join time. A revoked JWT/API key or a billing-tier downgrade left already-joined sockets streaming until the TCP connection dropped. Closes audit findings **A7** (token revoke) + **A8** (billing downgrade) — both Important, neither a cross-tenant leak.

- New `Engram.Auth.SessionInvalidator.disconnect_user/1` broadcasts the `"disconnect"` event on the `user_socket:{id}` topic exposed by `EngramWeb.UserSocket.id/1` and Phoenix tears down every live socket for that user.
- Wired at every external-state-change boundary: API-key revoke, logout-everywhere, refresh-token-family breach revoke, admin suspend, admin soft-delete, self-delete (transitive), Clerk `user.deleted` webhook (new handler), OAuth RFC-7009 revoke, and Paddle subscription tier/status change.
- Admin lock paths (`suspend`/`soft_delete_user`) fire the broadcast only after the `with_admin_lock` transaction COMMITS via `disconnect_on_commit/1` — a `:last_admin` rollback does not spuriously kick sockets.

## Test plan

- [x] `mix test` — 2182 tests, 0 failures (one new + many tightened: SessionInvalidator unit, revoke_api_key + revoke_all_user_tokens + revoke_token_family disconnect assertions, delete_self disconnect, suspend rollback-does-NOT-broadcast, soft_delete_user disconnect, Clerk `user.deleted` handler + last-admin refusal, OAuth revoke disconnect, Paddle cancel + downgrade + no-op cases)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — no issues
- [ ] Manual: revoke a key in the UI while a vault tab is open → tab loses sync immediately, not on next request
- [ ] Manual: cancel a Pro sub via Paddle webhook simulator → live SyncChannel disconnects and reconnect re-runs the `realtime_sync_enabled` gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)