### PR TITLE
fix(billing): arm cooldown timer on CHECKOUT_PAYMENT_INITIATED too

### DIFF
--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { act, render, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router'
 import { ThemeProvider } from '../theme/theme-provider'
@@ -248,6 +248,45 @@ describe('BillingPage — Paddle effect cleanup', () => {
     // Mount target gone, plan cards back
     expect(container.querySelector('.paddle-checkout')).toBeNull()
     expect(queryByText('Starter')).toBeInTheDocument()
+  })
+
+  it('onboarding (inline): cooldown arms on CHECKOUT_PAYMENT_INITIATED so a dropped COMPLETED still surfaces the recovery banner', async () => {
+    // Pre-#440 belt-and-suspenders: PAYMENT_INITIATED may drop on trial-signup
+    // redirects (and so may COMPLETED). The cooldown timer must be anchored
+    // to whichever event fires first, otherwise a missing COMPLETED leaves
+    // the user stuck on Paddle's inline frame forever with no recovery.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    mockBillingApi()
+    let captured: ((event: { name: string; data?: unknown }) => void) | undefined
+    initializePaddleMock.mockImplementation(async (opts: { eventCallback?: typeof captured }) => {
+      captured = opts.eventCallback
+      return { Checkout: { open: vi.fn(), close: vi.fn() } }
+    })
+
+    renderBilling({ inline: true })
+
+    await waitFor(() => expect(captured).toBeDefined())
+    // Let the initializePaddle .then() resolve.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // PAYMENT_INITIATED fires; COMPLETED never does (the drop case).
+    await act(async () => {
+      captured!({ name: 'checkout.payment.initiated', data: { transaction_id: 'txn_drop_99' } })
+      await Promise.resolve()
+    })
+
+    // Past the 15s cooldown window, recovery banner must appear.
+    await act(async () => {
+      vi.advanceTimersByTime(15_500)
+      await Promise.resolve()
+    })
+
+    await waitFor(() =>
+      expect(screen.queryByText(/Payment received\. We're finishing your activation/i)).toBeInTheDocument(),
+    )
   })
 
   it('onboarding (inline): closes Paddle and fires onActivated when subscription_activated push arrives', async () => {

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -166,8 +166,14 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
         if (cancelled) return
         switch (event.name) {
           case CheckoutEventNames.CHECKOUT_PAYMENT_INITIATED: {
+            // Belt-and-suspenders: either PAYMENT_INITIATED or COMPLETED may
+            // drop on trial-signup redirects. Arm the cooldown timer on
+            // whichever fires first (`?? Date.now()` guards against reset)
+            // so a dropped COMPLETED still surfaces the recovery banner
+            // instead of stranding the user on Paddle's inline frame.
             const txn = (event.data as { transaction_id?: string } | undefined)?.transaction_id ?? null
             setTransactionId(txn)
+            setCompletedAt((prev) => prev ?? Date.now())
             qc.invalidateQueries({ queryKey: ['billing', 'subscription'] })
             qc.invalidateQueries({ queryKey: ['billing', 'transactions'] })
             break
@@ -176,7 +182,8 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
             // Don't close Paddle — its built-in "Payment successful" screen
             // is the visible confirmation while we wait for the backend
             // webhook to fire the subscription_activated push. The cooldown
-            // timer is the fallback if the push never arrives.
+            // timer is the fallback if the push never arrives (and is also
+            // armed here in case PAYMENT_INITIATED dropped).
             setCompletedAt((prev) => prev ?? Date.now())
             qc.invalidateQueries({ queryKey: ['billing', 'subscription'] })
             qc.invalidateQueries({ queryKey: ['billing', 'transactions'] })

--- a/frontend/src/onboarding/onboard-billing-page.test.tsx
+++ b/frontend/src/onboarding/onboard-billing-page.test.tsx
@@ -201,8 +201,8 @@ describe('OnboardBillingPage — push activation', () => {
     // Channel must be wired by now.
     await waitFor(() => expect(channelHandlers['subscription_activated']).toBeDefined())
 
-    // User clicks "Start free trial" — Paddle overlay opens, then payment
-    // initiates. The activation overlay appears.
+    // Simulate the post-Start-trial flow: payment initiates inside Paddle's
+    // inline frame (which here is mocked — we just drive the event directly).
     await waitFor(() => expect(capturedEventCallback).toBeDefined())
     await act(async () => {
       capturedEventCallback!({

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.336",
+      version: "0.5.337",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Code-review follow-up from #452. The inline-checkout rewrite moved the cooldown timer anchor from `CHECKOUT_PAYMENT_INITIATED` to `CHECKOUT_COMPLETED`, unintentionally removing the belt-and-suspenders protection that commit `2ba4fc8` (PR #443) added on purpose:

> "Belt-and-suspenders: PAYMENT_INITIATED may drop on trial-signup redirects. Don't reset the cooldown timestamp if it's already set."

Either event may drop on a trial-signup redirect, so the timer must arm on whichever fires first. Without this, a dropped `COMPLETED` leaves the user stuck on Paddle's inline frame with no recovery banner.

## Fix

Add `setCompletedAt((prev) => prev ?? Date.now())` to the `PAYMENT_INITIATED` handler. The `?? Date.now()` guard means the cooldown anchors to whichever event arrives first; the normal path (both fire) still arms on `PAYMENT_INITIATED`, matching pre-#452 behavior.

## Test plan

- [x] New TDD test: drives `PAYMENT_INITIATED` only (COMPLETED dropped), advances fake timers 15.5s, asserts `SlowActivationBanner` renders
- [x] Existing inline + overlay tests still pass (12/12)
- [x] `tsc --noEmit` clean

## Also

- Drops a stale code comment in `onboard-billing-page.test.tsx:204-205` that referenced "Paddle overlay opens" and "the activation overlay appears" — both deprecated by #452's inline mode + ActivationOverlay deletion. (Other review finding from #452 comment.)

## Related

- Regression introduced by #452 (inline checkout)
- Original belt-and-suspenders: #443 commit `2ba4fc8`
- Code review: https://github.com/engram-app/Engram/pull/452#issuecomment-4628640847