### PR TITLE
fix(test): drain VersionCache invalidator broadcast to fix flake

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.339",
+      version: "0.5.340",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/legal/version_cache_test.exs
+++ b/test/engram/legal/version_cache_test.exs
@@ -4,8 +4,8 @@ defmodule Engram.Legal.VersionCacheTest do
   alias Engram.Legal.VersionCache
 
   setup do
-    on_exit(&VersionCache.invalidate_all/0)
-    VersionCache.invalidate_all()
+    on_exit(&reset_version_cache/0)
+    reset_version_cache()
     :ok
   end
 
@@ -17,7 +17,7 @@ defmodule Engram.Legal.VersionCacheTest do
     # still cached at the old value until invalidated
     assert VersionCache.required_floor("terms_of_service") == "2026-05-19"
 
-    VersionCache.invalidate_all()
+    reset_version_cache()
     assert VersionCache.required_floor("terms_of_service") == "2026-06-01"
   end
 

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -1,7 +1,6 @@
 defmodule Engram.OnboardingTest do
   use Engram.DataCase, async: false
 
-  alias Engram.Legal.VersionCache
   alias Engram.LegalFixtures
   alias Engram.Onboarding
   alias Engram.Onboarding.Agreement

--- a/test/engram/onboarding_test.exs
+++ b/test/engram/onboarding_test.exs
@@ -173,8 +173,8 @@ defmodule Engram.OnboardingTest do
         effective_date: nil
       )
 
-      VersionCache.invalidate_all()
-      on_exit(&VersionCache.invalidate_all/0)
+      LegalFixtures.reset_version_cache()
+      on_exit(&LegalFixtures.reset_version_cache/0)
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
@@ -294,8 +294,8 @@ defmodule Engram.OnboardingTest do
       prev_enabled = Application.get_env(:engram, :billing_enabled)
       Application.put_env(:engram, :billing_enabled, true)
 
-      VersionCache.invalidate_all()
-      on_exit(&VersionCache.invalidate_all/0)
+      LegalFixtures.reset_version_cache()
+      on_exit(&LegalFixtures.reset_version_cache/0)
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
@@ -319,7 +319,7 @@ defmodule Engram.OnboardingTest do
         effective_date: ~D[2099-01-01]
       )
 
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{})
@@ -336,7 +336,7 @@ defmodule Engram.OnboardingTest do
         effective_date: ~D[2000-01-01]
       )
 
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h_tos", "2026-05-19", "h_priv", %{})
@@ -352,7 +352,7 @@ defmodule Engram.OnboardingTest do
       )
 
       LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       user = insert(:user, onboarding_profile: %{})
 
@@ -384,7 +384,7 @@ defmodule Engram.OnboardingTest do
       )
 
       LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       user = insert(:user, onboarding_profile: %{})
 
@@ -395,12 +395,12 @@ defmodule Engram.OnboardingTest do
   describe "computed floor gate + terms_notice" do
     setup do
       prev_enabled = Application.get_env(:engram, :billing_enabled)
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
       Application.put_env(:engram, :billing_enabled, true)
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
-        VersionCache.invalidate_all()
+        LegalFixtures.reset_version_cache()
       end)
 
       :ok
@@ -414,7 +414,7 @@ defmodule Engram.OnboardingTest do
       )
 
       LegalFixtures.insert_version(document: "privacy_policy", version: "2026-05-19")
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
       user = insert(:user, onboarding_profile: %{})
       {:ok, _} = Onboarding.accept_terms(user, "2026-05-19", "h", "2026-05-19", "h", %{})
 
@@ -440,7 +440,7 @@ defmodule Engram.OnboardingTest do
         effective_date: ~D[2099-01-01]
       )
 
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       status = Onboarding.status(user)
       assert status.terms_ok
@@ -465,7 +465,7 @@ defmodule Engram.OnboardingTest do
         effective_date: ~D[2000-01-01]
       )
 
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       refute Onboarding.status(user).terms_ok
     end
@@ -490,11 +490,11 @@ defmodule Engram.OnboardingTest do
         effective_date: nil
       )
 
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
-        VersionCache.invalidate_all()
+        LegalFixtures.reset_version_cache()
       end)
 
       :ok
@@ -589,11 +589,11 @@ defmodule Engram.OnboardingTest do
         effective_date: nil
       )
 
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
-        VersionCache.invalidate_all()
+        LegalFixtures.reset_version_cache()
       end)
 
       :ok
@@ -657,11 +657,11 @@ defmodule Engram.OnboardingTest do
         effective_date: nil
       )
 
-      VersionCache.invalidate_all()
+      LegalFixtures.reset_version_cache()
 
       on_exit(fn ->
         Application.put_env(:engram, :billing_enabled, prev_enabled)
-        VersionCache.invalidate_all()
+        LegalFixtures.reset_version_cache()
       end)
 
       :ok

--- a/test/support/legal_fixtures.ex
+++ b/test/support/legal_fixtures.ex
@@ -1,7 +1,22 @@
 defmodule Engram.LegalFixtures do
   @moduledoc "Insert terms_versions rows in tests."
   alias Engram.Legal.TermsVersion
+  alias Engram.Legal.VersionCache
   alias Engram.Repo
+
+  @doc """
+  Reset the version cache for a test and wait for any in-flight broadcast to
+  drain. `VersionCache.invalidate_all/0` clears `:persistent_term` synchronously
+  AND fires an async PubSub broadcast; the local `Invalidator` GenServer
+  receives that broadcast and clears again. Without the barrier, the loopback
+  can land mid-test and erase cache rows the test just wrote, surfacing as
+  intermittent failures of memoization assertions.
+  """
+  def reset_version_cache do
+    VersionCache.invalidate_all()
+    _ = :sys.get_state(VersionCache.Invalidator)
+    :ok
+  end
 
   @doc """
   Insert a version row. Defaults: terms_of_service, material, effective now.


### PR DESCRIPTION
## Summary

`VersionCache.invalidate_all/0` clears `:persistent_term` synchronously **and** fires an async PubSub broadcast. The local `Invalidator` GenServer receives that broadcast and clears again. When tests call `invalidate_all/0` and immediately write to the cache (loader miss populating it), the loopback message can land mid-test and erase the just-written entry — surfacing as the intermittent

```
VersionCacheTest "memoizes required_floor and reflects invalidation"
left:  "2026-06-01"
right: "2026-05-19"
```

failure caught on main CI run [26999169359](https://github.com/engram-app/Engram/actions/runs/26999169359).

## Change

- Added `LegalFixtures.reset_version_cache/0` — does `invalidate_all/0` then `:sys.get_state(Invalidator)` as a barrier to drain its mailbox before returning.
- Replaced the 20 in-test sites that called `invalidate_all/0` for state reset (`version_cache_test.exs` setup + onboarding setup blocks + on_exit + body resets) with the new helper.
- Left the one assertion that tests the broadcast itself (`version_cache_test.exs:36`) unchanged.

## Why this fixes it

`:sys.get_state` is queued after the broadcast in the GenServer's mailbox. By the time it returns, the broadcast handler has run, the loopback eviction has happened, and the cache is in a known-clean state. Any cache write after `reset_version_cache/0` returns can't be racily clobbered by a pending broadcast.

## Test plan

- [x] `mix test test/engram/legal/version_cache_test.exs test/engram/onboarding_test.exs` × 5 seeds — 56/56 pass, no flake
- [ ] Full CI green