### PR TITLE
fix(ci): fingerprint root-config gap + sentry-cli install env

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -183,11 +183,18 @@ jobs:
           # decision on whether the new image tag already exists in GHCR —
           # version bump → new tag → fresh image, regardless of cache state.
           MIX_EXS_NO_VERSION=$(grep -vE '^[[:space:]]*version: "[0-9]+\.[0-9]+\.[0-9]+"' mix.exs | sha256sum | cut -d' ' -f1)
+          # Root-level lint/format configs are NOT under lib/priv/config/test/frontend,
+          # so they need to be listed explicitly. Without them, editing (e.g.)
+          # `.credo.exs` to disable a check produces no fingerprint change → the
+          # next push hits the cache → `lint` skips → loosened rule rides in
+          # without ever being re-validated. `.dockerignore` affects what's
+          # in the Docker build context, which can change image bytes.
           BACKEND_HASH=$({
             git ls-tree -r HEAD -- \
               lib priv config test frontend \
-              Dockerfile entrypoint.sh \
+              Dockerfile entrypoint.sh .dockerignore \
               mix.lock \
+              .formatter.exs .credo.exs .dialyzer_ignore.exs .sobelow-conf \
               docker-compose.ci.yml docker-compose.ci-local.yml docker-compose.ci-database.yml \
               .github/workflows/verify.yml
             echo "mix.exs-no-version:$MIX_EXS_NO_VERSION"
@@ -2765,7 +2772,10 @@ jobs:
           BACKEND_PROJECT: ${{ vars.SENTRY_PROJECT_BACKEND }}
           VERSION: ${{ github.sha }}
         run: |
-          INSTALL_DIR="${RUNNER_TEMP}" curl -sL https://sentry.io/get-cli/ | bash
+          # `INSTALL_DIR=` belongs on the `bash` side of the pipe — the env on
+          # the curl side stays with the curl process and the install script
+          # falls back to /usr/local/bin, which then needs sudo on this runner.
+          curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="${RUNNER_TEMP}" bash
           CLI="${RUNNER_TEMP}/sentry-cli"
 
           # Single release name (commit SHA) associated with BOTH projects via

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.342",
+      version: "0.5.343",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Two small follow-ups to the recent fingerprint + sentry-cli work:

### 1. Fingerprint hash gap (false-skip closure)

The hash currently includes `lib priv config test frontend Dockerfile entrypoint.sh mix.lock` + 3 compose files + `verify.yml`. Root-level lint/format configs are NOT under any of those paths, so editing them produced no hash change → cache hit → `lint` skipped → loosened rule rides into main with zero re-validation.

Add to the hash:
- `.formatter.exs` — `mix format --check-formatted` rules
- `.credo.exs` — Credo lint config
- `.dialyzer_ignore.exs` — Dialyzer suppressions
- `.sobelow-conf` — Sobelow security checks
- `.dockerignore` — Docker build context contents (image bytes)

### 2. `sentry-cli` install fix

Today's #459 launch surfaced `sudo: a password is required` — the `INSTALL_DIR=` env was on the wrong side of the `curl ... | bash` pipe (scoped to the curl process). The install script fell back to `/usr/local/bin`, which needs sudo on the isolated runners.

Move `INSTALL_DIR=` to the `bash` invocation so the script honors it.

## Test plan

- [ ] CI green on this PR
- [ ] Squash-merge → push on main → `build-and-publish-image` completes, sentry-cli step logs install path under `$RUNNER_TEMP`, releases appear in Sentry UI
- [ ] Future edit to `.credo.exs` (alone) on a branch produces fingerprint miss → `lint` actually runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)