### PR TITLE
chore(ci): silence VITE_* secret false-positive + bump aws-actions to v6

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2663,7 +2663,9 @@ jobs:
 
       - name: Configure AWS credentials (OIDC)
         if: steps.version.outputs.image_exists != 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        # v6 (Node 24). v4 used Node 20, which GH deprecates 2026-09-16.
+        # Inputs `role-to-assume` and `aws-region` are stable across both.
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ECR_PUSH_ROLE_ARN }}
           aws-region: us-east-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
 # syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+#
+# `check=skip=SecretsUsedInArgOrEnv`: BuildKit's lint flags any ARG/ENV whose
+# name contains KEY/TOKEN/SECRET. Our `VITE_CF_BEACON_TOKEN` and
+# `VITE_POSTHOG_KEY` trip this heuristic but are NOT secrets — Vite bakes
+# `import.meta.env.VITE_*` into the JS bundle that ships to every browser.
+# Both are public per-site identifiers (CF beacon: rate-limited per-site;
+# PostHog: write-only event ingest per project). They cannot be hidden by
+# any build-time mechanism. The check is a true false-positive; skipping
+# the rule for the whole Dockerfile keeps the build clean without changing
+# real risk posture. Real secrets in this Dockerfile use `RUN
+# --mount=type=secret` (see `sentry_auth_token` usage in the frontend stage).
+#
 # Multi-stage build: compile release in builder, run in minimal image
 # cache-bust: 2026-04-18-encryption-auto-provision
 ARG ELIXIR_VERSION=1.17.3

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.344",
+      version: "0.5.345",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Clean up the five warnings now appearing on `build-and-publish-image`:

### 1. `SecretsUsedInArgOrEnv` (×4) — false positives, suppress

BuildKit's lint flags any ARG/ENV whose name contains `KEY`/`TOKEN`/`SECRET`. Both `VITE_POSTHOG_KEY` and `VITE_CF_BEACON_TOKEN` are **Vite client-side env vars** — Vite bakes them into the JS bundle that ships to every browser, BY DESIGN. There is no build-time mechanism that can hide them from a SPA. Both are public per-site identifiers (rate-limited, write-only event ingest). Real secrets in this Dockerfile use `RUN --mount=type=secret` (see frontend stage `sentry_auth_token`).

Add `# check=skip=SecretsUsedInArgOrEnv` at the top of the Dockerfile with a comment block explaining the rationale.

### 2. `aws-actions/configure-aws-credentials@v4` → `@v6`

v4 runs on Node 20, which GH Actions deprecates 2026-09-16. v6 runs on Node 24. The only inputs we use (`role-to-assume`, `aws-region`) are stable across both — drop-in.

## Test plan

- [ ] CI green on this PR
- [ ] Squash-merge → next main push: `build-and-publish-image` runs without any of the 5 warnings; OIDC ECR push still succeeds (verifies v6 wired correctly)
- [ ] Sentry, PostHog, CF Web Analytics still beacon from the prod bundle (verifies the suppressed VITE_* vars still flow through into the build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)