### PR TITLE
perf(dev): pre-push fast-path skips compile when no .ex changed

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -79,6 +79,13 @@ echo "✓ pre-push: mix.exs version differs from main (main=$main_version, branc
 # printed in declaration order so logs read deterministically even
 # though the work was interleaved.
 #
+# Fast path: if NO Elixir-affecting files (*.ex / *.exs / mix.lock /
+# .credo.exs / .sobelow-conf) changed vs origin/main, the existing
+# _build + the rules captured by main's last green CI run are
+# authoritative — skip compile/credo/sobelow entirely and just run
+# `mix format --check-formatted` to catch top-level formatting drift.
+# Pushes touching only YAML/docs/configs go from ~2min to a few seconds.
+#
 # Dialyzer is skipped from pre-push (too slow for the dev loop). CI runs it.
 #
 # Bypass any check with: git push --no-verify
@@ -109,6 +116,24 @@ report() {
 }
 
 FAILED=0
+
+# Fast path: skip compile/credo/sobelow if nothing Elixir-affecting changed.
+# `git diff --name-only origin/main...HEAD` lists files touched by commits on
+# this branch but not on main. Empty list (or no matches in the pattern) =>
+# main's CI already validated this exact code path. We still run format
+# because (a) it's fast (~5s) and (b) it catches formatter-rule drift
+# someone might have introduced in .formatter.exs without re-running.
+ELIXIR_AFFECTING_REGEX='\.(ex|exs)$|^mix\.lock$|^\.credo\.exs$|^\.sobelow-conf$'
+CHANGED_AFFECTING="$(git diff --name-only origin/main...HEAD 2>/dev/null | grep -E "$ELIXIR_AFFECTING_REGEX" || true)"
+
+if [ -z "$CHANGED_AFFECTING" ]; then
+  echo "▸ Fast path: no Elixir-affecting files changed vs origin/main — running format only"
+  run_bg format mix format --check-formatted
+  wait
+  report "mix format" format || FAILED=1
+  [ "$FAILED" = "0" ] || exit 1
+  exit 0
+fi
 
 echo "▸ Stage A (parallel): mix format, mix compile..."
 run_bg format  mix format --check-formatted

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.346",
+      version: "0.5.347",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Add a fast path at the top of the pre-push quality-gates section. If no Elixir-affecting files differ vs `origin/main`, skip `mix compile` / `credo` / `sobelow` entirely and only run `mix format --check-formatted` (~5s).

**Trigger set** (anything in this list → full check, otherwise fast path):
- `*.ex`, `*.exs` (app, test, config, migrations)
- `mix.lock` (dep change)
- `.credo.exs`, `.sobelow-conf` (lint config — if loosened, want fresh validation)

Doc-only / YAML / `.github/workflows/*` / `frontend/` / Dockerfile-only PRs go from **~2min to ~5sec**.

## Why this is safe

- `_build` is hardlinked from canonical (per the post-checkout hook). Canonical tracks main, which last passed CI with its compile/credo/sobelow checks green.
- If no `.ex` / `.exs` was edited, the existing BEAMs are still valid by construction — main's CI vouched for them.
- `mix.lock` is in the trigger set → any dep upgrade goes through the full flow.
- Lint configs are in the trigger set → loosening a credo rule can't ride the fast path silently.

## Test plan

- [x] This PR itself triggers FULL flow (`.exs` changed via the version bump) — verifies the slow path still works. Pushed in ~2m20s, two stages reported.
- [ ] CI green on this PR
- [ ] Squash-merge → next push that touches only docs/YAML logs `▸ Fast path: no Elixir-affecting files changed vs origin/main — running format only` and completes in seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)