### PR TITLE
perf(dev): pre-push fast-path also strips mix.exs version-line change

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -123,8 +123,29 @@ FAILED=0
 # main's CI already validated this exact code path. We still run format
 # because (a) it's fast (~5s) and (b) it catches formatter-rule drift
 # someone might have introduced in .formatter.exs without re-running.
+#
+# Special case: mix.exs is `.exs` (matches the regex), but every PR must bump
+# its version line per the pre-push policy. A version-line-only change is
+# semantically a no-op for the compiler (mirrors how CI's fingerprint job
+# strips the version line before hashing). If mix.exs is the ONLY affecting
+# file AND the diff touches only the version line, drop it from the trigger
+# set so doc-only PRs (which still need a version bump) hit the fast path.
 ELIXIR_AFFECTING_REGEX='\.(ex|exs)$|^mix\.lock$|^\.credo\.exs$|^\.sobelow-conf$'
 CHANGED_AFFECTING="$(git diff --name-only origin/main...HEAD 2>/dev/null | grep -E "$ELIXIR_AFFECTING_REGEX" || true)"
+
+# Strip mix.exs from the trigger set if the only changed lines are the version line.
+# `git diff --unified=0` gives strict +/- lines; filter out diff headers (+++/---/@@),
+# then check if anything non-version-line remains.
+if [ "$(echo "$CHANGED_AFFECTING" | tr -d '\n ')" = "mix.exs" ]; then
+  NON_VERSION_DIFF="$(git diff --unified=0 origin/main...HEAD -- mix.exs 2>/dev/null \
+    | grep -E '^[+-]' \
+    | grep -vE '^(\+\+\+|---) ' \
+    | grep -vE '^[+-][[:space:]]*version: "[0-9]+\.[0-9]+\.[0-9]+",?[[:space:]]*$' \
+    || true)"
+  if [ -z "$NON_VERSION_DIFF" ]; then
+    CHANGED_AFFECTING=""
+  fi
+fi
 
 if [ -z "$CHANGED_AFFECTING" ]; then
   echo "▸ Fast path: no Elixir-affecting files changed vs origin/main — running format only"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.347",
+      version: "0.5.348",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

PR #464 added a fast-path that skips compile/credo/sobelow when no Elixir-affecting files differ vs main. But every PR is required to bump `mix.exs`'s version line per the version-check policy — and `mix.exs` is `.exs` — so the fast path never fired for doc/YAML/frontend-only PRs in practice.

Mirror what CI's fingerprint job already does: if the only `.exs`-pattern file in the diff is `mix.exs` AND the diff touches only the version line, drop it from the trigger set.

## Dogfooding result

This PR's own pre-push:

```
✓ pre-push: mix.exs version differs from main (main=0.5.347, branch=0.5.348)
▸ Fast path: no Elixir-affecting files changed vs origin/main — running format only
  ✓ mix format
real    0m5.992s
```

Down from ~2m20s on PR #464 (which had to run the full flow because of the same version bump).

## Diff detection details

```bash
git diff --unified=0 origin/main...HEAD -- mix.exs \
  | grep -E '^[+-]' \
  | grep -vE '^(\+\+\+|---) ' \                              # drop file headers
  | grep -vE '^[+-][[:space:]]*version: "[0-9]+\.[0-9]+\.[0-9]+",?[[:space:]]*$'
```

Non-empty result → mix.exs has non-version-line changes → keep in trigger set. Empty → strip.

## Test plan

- [x] Dogfooded — fast-path fires for this PR (mix.exs version-only)
- [ ] CI green
- [ ] Squash-merge → next doc/YAML push hits fast-path in seconds, not minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)