### PR TITLE
chore: add GitHub Sponsors + Ko-fi funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [engram-app]
+ko_fi: engrams_sync

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.348",
+      version: "0.5.349",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` so GitHub renders a "Sponsor" button on the repo home
- Points at the **engram-app** GitHub Sponsors profile and the **engrams_sync** Ko-fi
- Version bump 0.5.348 -> 0.5.349 to satisfy `version-check` hook

## Test plan
- [ ] CI green
- [ ] After merge, repo home shows the Sponsor button (GitHub-rendered, no app deploy needed)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>