### PR TITLE
feat(dev): honor PORT env in dev endpoint (default 4000)

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -32,7 +32,8 @@ config :engram,
 config :engram, EngramWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {0, 0, 0, 0}],
+  # PORT defaults to 4000 (saas-dev contract); honor env override only.
+  http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT", "4000"))],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.348",
+      version: "0.5.349",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- `config/dev.exs` reads `PORT` from env (default `4000`). No behavior change for anyone not setting `PORT`.
- Pairs with the **engram-app/engram-workspace** port-hardening PR which pins `PORT=4000` in the resolved env so the contract is visible.

## Test plan
- [x] Boot with no env: binds `:4000`
- [x] Boot with `PORT=4002`: binds `:4002`, nothing on `:4000`
- [x] `mix compile` clean