### PR TITLE
fix(ci): point LOCAL_REGISTRY at LocalCIRegistry :5001

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,13 +50,16 @@ permissions:
 env:
   DOCKER_BUILDKIT: "1"
   COMPOSE_DOCKER_CLI_BUILD: "1"
-  # LOCAL_REGISTRY = FastRaid distribution/registry on the engram LAN.
-  # Hard-coded at workflow level so every job — including JIT/ephemeral
-  # isolated runners that never ran setup-runner.sh — gets the value.
-  # The fingerprint marker store (ci-pass / ci-e2e-pass tags) requires it;
+  # LOCAL_REGISTRY = FastRaid push-capable OCI distribution registry
+  # (LocalCIRegistry, registry:2) on host :5001. NOT the rpardini
+  # pull-through proxy on :5000 — that's a MITM cache and cannot accept
+  # pushes. See engram-infra#321 for the long diagnosis. Hard-coded at
+  # workflow level so every job — including JIT/ephemeral isolated
+  # runners that never ran setup-runner.sh — gets the value. The
+  # fingerprint marker store (ci-pass / ci-e2e-pass tags) requires it;
   # downstream callers (line ~929, ~2165) used to tolerate unset via shell
   # fallback to Docker Hub — that fallback path is now dead.
-  LOCAL_REGISTRY: "10.0.20.214:5000"
+  LOCAL_REGISTRY: "10.0.20.214:5001"
 
   # CI-only encryption master key. Ephemeral — CI databases are recreated per run,
   # so the key does not protect persistent data. Production deploys must override

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.354",
+      version: "0.5.355",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

One-line env flip: `LOCAL_REGISTRY: 10.0.20.214:5000` → `:5001`.

## Why

`record-pass` has been UNSTABLE every CI run for ~3 days: `docker push` returned `unexpected HTTP status: 200 OK` because `:5000` is `rpardini/docker-registry-proxy` (pull-through cache, push-incapable). The fingerprint cache-hit optimization in `verify.yml` (skip e2e when same backend+plugin SHA pair previously passed) silently never fired — every PR re-ran full e2e.

See engram-app/engram-infra#321 for the full diagnosis.

## Prereqs (already shipped)

- ✅ FastRaid: `LocalCIRegistry` container (`registry:2`) running on host `:5001` with bind mount `/mnt/cache/appdata/local-ci-registry`. Unraid XML template installed; `managed=dockerman`.
- ✅ Runner VM (`gh-runner` on SlowRaid): `10.0.20.214:5001` added to rootless dockerd `insecure-registries`; `10.0.20.214` added to `NO_PROXY` in `http-proxy.conf`; user dockerd restarted.
- ✅ SlowRaid: `/boot/config/iptables.runner.sh` multiport rule allows port 5001 from `10.20.99.0/24` → `10.0.20.214`. Live + persisted.

Smoke push from runner: `docker push 10.0.20.214:5001/probe:1` → `1: digest: sha256:... size: 527`. Catalog after cleanup: `{"repositories":[]}`.

## Verification (after merge)

1. Push commit → `record-pass` should pass with logs `Saved backend marker 10.0.20.214:5001/ci-pass:<hash>` and `Saved e2e marker 10.0.20.214:5001/ci-e2e-pass:<hash>`.
2. Push a second commit that doesn't change Elixir code → fingerprint should short-circuit e2e via marker probe.
3. SSH FastRaid: `curl -s http://localhost:5001/v2/_catalog` lists the `ci-pass` / `ci-e2e-pass` repos.

## Notes

- Postgres-pull lines at ~972 and ~2208 (`PG_IMAGE="${LOCAL_REGISTRY}/postgres:16-alpine"`) will continue to fall back to Docker Hub via `||` (the new registry has no postgres either, same as before — net behavior unchanged). Cleanup of those dead branches is separate scope.

Closes engram-app/engram-infra#321 (cross-repo issue, will close it manually after merge).