### PR TITLE
chore: smoke test CI marker save on :5001 (will close)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@ docs
 # plaintext DEKs / master key from process heap at the moment of crash.
 erl_crash.dump
 **/erl_crash.dump
+# marker-smoke 2026-06-06

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.355",
+      version: "0.5.356",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
**Smoke test — do not merge.**

Verifies engram-infra#321 fix end-to-end. Version bump 0.5.355 → 0.5.356 flips BACKEND_HASH so fingerprint misses, full pipeline runs, `record-pass` pushes markers to `LocalCIRegistry` at `10.0.20.214:5001`.

Expected:
- `record-pass` logs `Saved backend marker 10.0.20.214:5001/ci-pass:<HASH>` + `Saved e2e marker 10.0.20.214:5001/ci-e2e-pass:<HASH>`
- `curl http://10.0.20.214:5001/v2/ci-pass/tags/list` includes the new hash

Will close without merging.