### PR TITLE
feat(billing): Account Lifecycle Gate 2 — inline cancel + plan-change (#479)

### DIFF
--- a/frontend/components.json
+++ b/frontend/components.json
@@ -21,5 +21,7 @@
   },
   "menuColor": "default",
   "menuAccent": "subtle",
-  "registries": {}
+  "registries": {
+    "@paddle": "https://developer.paddle.com/r/{name}.json"
+  }
 }

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -9,7 +9,13 @@ vi.mock('./client', () => ({
   setTokenGetter: vi.fn(),
 }))
 
-import { useAcceptTerms } from './queries'
+import {
+  useAcceptTerms,
+  useCancelSubscription,
+  useConfirmPlanChange,
+  usePlanChangePreview,
+  useReverseCancel,
+} from './queries'
 
 let qc: QueryClient
 
@@ -54,5 +60,56 @@ describe('useAcceptTerms', () => {
     // If onSuccess fires-and-forgets, this would still be false when mutateAsync resolves
     // and the user would be navigated with a stale cache (bug: double-accept).
     expect(invalidateResolved).toBe(true)
+  })
+})
+
+describe('inline billing mutations', () => {
+  it('useCancelSubscription POSTs and invalidates billing caches', async () => {
+    post.mockResolvedValue({ scheduled_change: { effective_at: '2026-07-01T00:00:00Z' } })
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCancelSubscription(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync()
+    })
+
+    expect(post).toHaveBeenCalledWith('/billing/cancel-subscription')
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['billing', 'status'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['billing', 'subscription'] })
+  })
+
+  it('useReverseCancel POSTs and invalidates billing caches', async () => {
+    post.mockResolvedValue({ scheduled_change: null })
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+
+    const { result } = renderHook(() => useReverseCancel(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync()
+    })
+
+    expect(post).toHaveBeenCalledWith('/billing/reverse-cancel')
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['billing', 'status'] })
+  })
+
+  it('useConfirmPlanChange forwards target_price_id and invalidates caches', async () => {
+    post.mockResolvedValue({ transaction_id: 'txn_xyz' })
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+
+    const { result } = renderHook(() => useConfirmPlanChange(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync('pri_new')
+    })
+
+    expect(post).toHaveBeenCalledWith('/billing/plan-change/confirm', {
+      target_price_id: 'pri_new',
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['billing', 'subscription'] })
+  })
+
+  it('usePlanChangePreview stays disabled until a target is selected', () => {
+    const { result } = renderHook(() => usePlanChangePreview(null), { wrapper })
+    // No fetch happens for null target — query is disabled.
+    expect(post).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
   })
 })

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { api, ApiError } from './client'
@@ -775,5 +775,59 @@ export function useCreateVault() {
       // refresh /status so the onboarding checklist ticks immediately.
       qc.invalidateQueries({ queryKey: ['onboarding', 'status'] })
     },
+  })
+}
+
+// Inline billing mutations replacing the portal redirect — each invalidates
+// /billing/status + /billing/subscription so the StatusCard reflects the
+// new scheduled change immediately, before webhook sync catches up.
+
+function invalidateBilling(qc: QueryClient) {
+  qc.invalidateQueries({ queryKey: ['billing', 'status'] })
+  qc.invalidateQueries({ queryKey: ['billing', 'subscription'] })
+}
+
+export function useCancelSubscription() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => api.post<Record<string, unknown>>('/billing/cancel-subscription'),
+    onSuccess: () => invalidateBilling(qc),
+  })
+}
+
+export function useReverseCancel() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => api.post<Record<string, unknown>>('/billing/reverse-cancel'),
+    onSuccess: () => invalidateBilling(qc),
+  })
+}
+
+export interface PlanChangePreview {
+  old_total: number
+  new_total: number
+  immediate_charge_or_credit: number
+  next_billed_at: string
+}
+
+export function usePlanChangePreview(targetPriceId: string | null) {
+  return useQuery({
+    queryKey: ['billing', 'plan-change', 'preview', targetPriceId],
+    enabled: targetPriceId !== null,
+    queryFn: () =>
+      api.post<PlanChangePreview>('/billing/plan-change/preview', {
+        target_price_id: targetPriceId,
+      }),
+  })
+}
+
+export function useConfirmPlanChange() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (targetPriceId: string) =>
+      api.post<Record<string, unknown>>('/billing/plan-change/confirm', {
+        target_price_id: targetPriceId,
+      }),
+    onSuccess: () => invalidateBilling(qc),
   })
 }

--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -404,4 +404,92 @@ describe('BillingPage — Paddle effect cleanup', () => {
       expect(billingStatusInvalidations.length).toBeGreaterThan(0)
     })
   })
+
+  it('subscribed flow: Cancel button opens CancelPanel inline (no portal redirect)', async () => {
+    initializePaddleMock.mockResolvedValue({ Checkout: { open: vi.fn(), close: vi.fn() } })
+
+    get.mockImplementation(async (url: string) => {
+      if (url === '/billing/status')
+        return {
+          tier: 'pro',
+          active: true,
+          trial_days_remaining: 0,
+          subscription: { status: 'active', tier: 'pro', current_period_end: '2026-07-01T00:00:00Z' },
+          caps: {},
+        }
+      if (url === '/billing/config')
+        return {
+          client_token: 'tok',
+          environment: 'sandbox',
+          price_ids: {
+            starter: { monthly: 'p1', annual: 'p2' },
+            pro: { monthly: 'p3', annual: 'p4' },
+          },
+          customer_email: 'u@example.com',
+          custom_data: { user_id: '1' },
+          vaults_cap: null,
+        }
+      if (url === '/me') return { user: ME }
+      if (url === '/billing/subscription')
+        return { next_billed_at: '2026-07-01T00:00:00Z', scheduled_change: null }
+      if (url === '/billing/transactions') return { payment_method: null, transactions: [] }
+      throw new Error(`unexpected GET ${url}`)
+    })
+
+    renderBilling({ inline: false })
+
+    const cancelButton = await screen.findByRole('button', { name: /cancel subscription/i })
+    await act(async () => {
+      cancelButton.click()
+    })
+
+    // CancelPanel header is visible; button row collapses.
+    await screen.findByRole('region', { name: /cancel subscription/i })
+    expect(screen.getByRole('button', { name: /cancel at period end/i })).toBeInTheDocument()
+  })
+
+  it('subscribed flow: Change plan button opens PlanChangePanel inline', async () => {
+    initializePaddleMock.mockResolvedValue({ Checkout: { open: vi.fn(), close: vi.fn() } })
+
+    get.mockImplementation(async (url: string) => {
+      if (url === '/billing/status')
+        return {
+          tier: 'starter',
+          active: true,
+          trial_days_remaining: 0,
+          subscription: {
+            status: 'active',
+            tier: 'starter',
+            current_period_end: '2026-07-01T00:00:00Z',
+          },
+          caps: {},
+        }
+      if (url === '/billing/config')
+        return {
+          client_token: 'tok',
+          environment: 'sandbox',
+          price_ids: {
+            starter: { monthly: 'p1', annual: 'p2' },
+            pro: { monthly: 'p3', annual: 'p4' },
+          },
+          customer_email: 'u@example.com',
+          custom_data: { user_id: '1' },
+          vaults_cap: 5,
+        }
+      if (url === '/me') return { user: ME }
+      if (url === '/billing/subscription')
+        return { next_billed_at: '2026-07-01T00:00:00Z', scheduled_change: null }
+      if (url === '/billing/transactions') return { payment_method: null, transactions: [] }
+      throw new Error(`unexpected GET ${url}`)
+    })
+
+    renderBilling({ inline: false })
+
+    const changeButton = await screen.findByRole('button', { name: /change plan/i })
+    await act(async () => {
+      changeButton.click()
+    })
+
+    await screen.findByRole('region', { name: /change plan/i })
+  })
 })

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -374,18 +374,14 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
                   </Button>
                 )}
               </div>
-              {/* Tertiary escape hatch: if the inline panels fail for any
-                  reason (Paddle UI bug, network blip, an action we don't
-                  yet support inline) the user can still self-serve through
-                  Paddle's hosted portal. Worded so the relationship is
-                  obvious — Paddle, not us, is the payment processor. */}
-              <button
-                type="button"
-                onClick={() => openPortal()}
-                className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-              >
-                Or manage payment directly in Paddle, our payment processor
-              </button>
+              {/* Escape hatch: if the inline panels fail (Paddle UI bug,
+                  network blip, an action we don't yet support inline) the
+                  user can still self-serve through Paddle's hosted portal.
+                  Worded so the relationship is obvious — Paddle, not us,
+                  is the payment processor. */}
+              <Button variant="outline" onClick={() => openPortal()}>
+                Manage payment in Paddle (our payment processor)
+              </Button>
             </section>
           )}
           {panel === 'change' && (

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -292,7 +292,47 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
         </header>
       )}
 
-      {!hideHeading && <CurrentPlanCard billing={billing} />}
+      {!hideHeading && (
+        <CurrentPlanCard billing={billing}>
+          {billing.subscription && panel === null && (
+            <div className="space-y-3">
+              <div className="flex flex-wrap gap-3">
+                <Button onClick={() => setPanel('change')}>Change plan</Button>
+                {billing.subscription.status !== 'canceled' && (
+                  <Button variant="ghost" onClick={() => setPanel('cancel')}>
+                    Cancel subscription
+                  </Button>
+                )}
+              </div>
+              {/* Escape hatch: if the inline panels fail (Paddle UI bug,
+                  network blip, an action we don't yet support inline) the
+                  user can still self-serve through Paddle's hosted portal.
+                  Worded so the relationship is obvious — Paddle, not us,
+                  is the payment processor. */}
+              <Button variant="outline" onClick={() => openPortal()}>
+                Manage payment in Paddle (our payment processor)
+              </Button>
+            </div>
+          )}
+          {billing.subscription && panel === 'change' && (
+            <PlanChangePanel billing={billing} onClose={() => setPanel(null)} />
+          )}
+          {billing.subscription && panel === 'cancel' && (
+            <CancelPanel
+              detail={
+                detail ?? {
+                  next_billed_at: billing.subscription.current_period_end,
+                  amount: null,
+                  currency: null,
+                  billing_cycle: null,
+                  scheduled_change: null,
+                }
+              }
+              onClose={() => setPanel(null)}
+            />
+          )}
+        </CurrentPlanCard>
+      )}
 
       {needsSubscription && (
         <section className="space-y-4">
@@ -364,43 +404,6 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
             transactions={history?.transactions ?? []}
             onDownload={downloadInvoice}
           />
-          {panel === null && (
-            <section className="space-y-3">
-              <div className="flex flex-wrap gap-3">
-                <Button onClick={() => setPanel('change')}>Change plan</Button>
-                {billing.subscription.status !== 'canceled' && (
-                  <Button variant="ghost" onClick={() => setPanel('cancel')}>
-                    Cancel subscription
-                  </Button>
-                )}
-              </div>
-              {/* Escape hatch: if the inline panels fail (Paddle UI bug,
-                  network blip, an action we don't yet support inline) the
-                  user can still self-serve through Paddle's hosted portal.
-                  Worded so the relationship is obvious — Paddle, not us,
-                  is the payment processor. */}
-              <Button variant="outline" onClick={() => openPortal()}>
-                Manage payment in Paddle (our payment processor)
-              </Button>
-            </section>
-          )}
-          {panel === 'change' && (
-            <PlanChangePanel billing={billing} onClose={() => setPanel(null)} />
-          )}
-          {panel === 'cancel' && (
-            <CancelPanel
-              detail={
-                detail ?? {
-                  next_billed_at: billing.subscription.current_period_end,
-                  amount: null,
-                  currency: null,
-                  billing_cycle: null,
-                  scheduled_change: null,
-                }
-              }
-              onClose={() => setPanel(null)}
-            />
-          )}
         </>
       )}
     </article>

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -365,13 +365,27 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
             onDownload={downloadInvoice}
           />
           {panel === null && (
-            <section className="flex flex-wrap gap-3">
-              <Button onClick={() => setPanel('change')}>Change plan</Button>
-              {billing.subscription.status !== 'canceled' && (
-                <Button variant="ghost" onClick={() => setPanel('cancel')}>
-                  Cancel subscription
-                </Button>
-              )}
+            <section className="space-y-3">
+              <div className="flex flex-wrap gap-3">
+                <Button onClick={() => setPanel('change')}>Change plan</Button>
+                {billing.subscription.status !== 'canceled' && (
+                  <Button variant="ghost" onClick={() => setPanel('cancel')}>
+                    Cancel subscription
+                  </Button>
+                )}
+              </div>
+              {/* Tertiary escape hatch: if the inline panels fail for any
+                  reason (Paddle UI bug, network blip, an action we don't
+                  yet support inline) the user can still self-serve through
+                  Paddle's hosted portal. Worded so the relationship is
+                  obvious — Paddle, not us, is the payment processor. */}
+              <button
+                type="button"
+                onClick={() => openPortal()}
+                className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                Or manage payment directly in Paddle, our payment processor
+              </button>
             </section>
           )}
           {panel === 'change' && (

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -19,6 +19,8 @@ import CurrentPlanCard from './current-plan-card'
 import PaymentMethodCard from './payment-method-card'
 import BillingHistoryTable from './billing-history-table'
 import PendingChangeBanner from './pending-change-banner'
+import CancelPanel from './cancel-panel'
+import PlanChangePanel from './plan-change-panel'
 import { useSubscriptionActivatedEvents } from './use-subscription-activated-events'
 
 // Time after CHECKOUT_COMPLETED we keep Paddle's own "Payment successful"
@@ -83,6 +85,9 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
   const [completedAt, setCompletedAt] = useState<number | null>(null)
   const [slow, setSlow] = useState(false)
   const [transactionId, setTransactionId] = useState<string | null>(null)
+  // Inline panel state for the in-app cancel + plan-change flows (replaces
+  // the previous openPortal('cancel') / portal-redirect path).
+  const [panel, setPanel] = useState<'cancel' | 'change' | null>(null)
 
   // Latch — onActivated must fire at most once even if the broadcast lands
   // multiple times (subscription.created followed by subscription.activated
@@ -359,16 +364,22 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
             transactions={history?.transactions ?? []}
             onDownload={downloadInvoice}
           />
-          <section className="flex flex-wrap gap-3">
-            <Button variant="outline" onClick={() => openPortal()}>
-              Manage in Paddle
-            </Button>
-            {billing.subscription.status !== 'canceled' && (
-              <Button variant="ghost" onClick={() => openPortal('cancel')}>
-                Cancel subscription
-              </Button>
-            )}
-          </section>
+          {panel === null && (
+            <section className="flex flex-wrap gap-3">
+              <Button onClick={() => setPanel('change')}>Change plan</Button>
+              {billing.subscription.status !== 'canceled' && (
+                <Button variant="ghost" onClick={() => setPanel('cancel')}>
+                  Cancel subscription
+                </Button>
+              )}
+            </section>
+          )}
+          {panel === 'change' && (
+            <PlanChangePanel billing={billing} onClose={() => setPanel(null)} />
+          )}
+          {panel === 'cancel' && detail && (
+            <CancelPanel detail={detail} onClose={() => setPanel(null)} />
+          )}
         </>
       )}
     </article>

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -295,23 +295,13 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
       {!hideHeading && (
         <CurrentPlanCard billing={billing}>
           {billing.subscription && panel === null && (
-            <div className="space-y-3">
-              <div className="flex flex-wrap gap-3">
-                <Button onClick={() => setPanel('change')}>Change plan</Button>
-                {billing.subscription.status !== 'canceled' && (
-                  <Button variant="ghost" onClick={() => setPanel('cancel')}>
-                    Cancel subscription
-                  </Button>
-                )}
-              </div>
-              {/* Escape hatch: if the inline panels fail (Paddle UI bug,
-                  network blip, an action we don't yet support inline) the
-                  user can still self-serve through Paddle's hosted portal.
-                  Worded so the relationship is obvious — Paddle, not us,
-                  is the payment processor. */}
-              <Button variant="outline" onClick={() => openPortal()}>
-                Manage payment in Paddle (our payment processor)
-              </Button>
+            <div className="flex flex-wrap gap-3">
+              <Button onClick={() => setPanel('change')}>Change plan</Button>
+              {billing.subscription.status !== 'canceled' && (
+                <Button variant="destructive" onClick={() => setPanel('cancel')}>
+                  Cancel subscription
+                </Button>
+              )}
             </div>
           )}
           {billing.subscription && panel === 'change' && (
@@ -404,6 +394,20 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
             transactions={history?.transactions ?? []}
             onDownload={downloadInvoice}
           />
+          {/* Escape hatch: if the inline panels above fail (Paddle UI bug,
+              network blip, an action we don't yet support inline) the user
+              can still self-serve through Paddle's hosted portal. Sits
+              outside the cards so it reads as a fallback option, not as
+              one of the primary plan actions. */}
+          <div className="flex justify-center pt-2">
+            <button
+              type="button"
+              onClick={() => openPortal()}
+              className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            >
+              Manage payment in Paddle, our payment processor
+            </button>
+          </div>
         </>
       )}
     </article>

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -13,8 +13,8 @@ import {
 } from '../api/queries'
 import { api } from '../api/client'
 import { useTheme } from '../theme/theme-provider'
-import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { CadenceToggle, PLAN_CATALOG, PlanCard } from './plan-cards'
 import CurrentPlanCard from './current-plan-card'
 import PaymentMethodCard from './payment-method-card'
 import BillingHistoryTable from './billing-history-table'
@@ -327,23 +327,23 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
               <CadenceToggle cadence={cadence} onChange={setCadence} />
               <ul className="grid items-stretch gap-4 sm:grid-cols-2">
                 <PlanCard
-                  name="Starter"
+                  name={PLAN_CATALOG.starter.name}
                   cadence={cadence}
-                  monthlyPrice={7}
-                  annualPrice={70}
-                  features={['5 vaults', 'Unlimited devices', '3 GB attachments', '500 AI queries/day']}
+                  monthlyPrice={PLAN_CATALOG.starter.monthlyPrice}
+                  annualPrice={PLAN_CATALOG.starter.annualPrice}
+                  features={PLAN_CATALOG.starter.features}
                   tier="starter"
-                  onStart={handleStartCheckout}
+                  onAction={handleStartCheckout}
                   disabled={!checkoutReady}
                 />
                 <PlanCard
-                  name="Pro"
+                  name={PLAN_CATALOG.pro.name}
                   cadence={cadence}
-                  monthlyPrice={14}
-                  annualPrice={140}
-                  features={['15 vaults', 'Unlimited devices', '15 GB attachments', 'Unlimited AI', 'Smart retrieval (coming)']}
+                  monthlyPrice={PLAN_CATALOG.pro.monthlyPrice}
+                  annualPrice={PLAN_CATALOG.pro.annualPrice}
+                  features={PLAN_CATALOG.pro.features}
                   tier="pro"
-                  onStart={handleStartCheckout}
+                  onAction={handleStartCheckout}
                   disabled={!checkoutReady}
                   recommended
                 />
@@ -448,112 +448,3 @@ function SlowActivationBanner({
   )
 }
 
-function CadenceToggle({
-  cadence,
-  onChange,
-}: {
-  cadence: BillingCadence
-  onChange: (next: BillingCadence) => void
-}) {
-  return (
-    <div role="radiogroup" aria-label="Billing cadence" className="flex justify-center">
-      <div className="inline-flex rounded-full border border-border bg-muted p-1 text-sm">
-        <button
-          role="radio"
-          aria-checked={cadence === 'monthly'}
-          onClick={() => onChange('monthly')}
-          className={cn(
-            'rounded-full px-4 py-1.5 font-medium transition',
-            cadence === 'monthly'
-              ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground',
-          )}
-        >
-          Monthly
-        </button>
-        <button
-          role="radio"
-          aria-checked={cadence === 'annual'}
-          onClick={() => onChange('annual')}
-          className={cn(
-            'rounded-full px-4 py-1.5 font-medium transition',
-            cadence === 'annual'
-              ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground',
-          )}
-        >
-          Annual <span className="ml-1 text-xs text-primary">save 17%</span>
-        </button>
-      </div>
-    </div>
-  )
-}
-
-function PlanCard({
-  name,
-  cadence,
-  monthlyPrice,
-  annualPrice,
-  features,
-  tier,
-  onStart,
-  disabled,
-  recommended = false,
-}: {
-  name: string
-  cadence: BillingCadence
-  monthlyPrice: number
-  annualPrice: number
-  features: string[]
-  tier: 'starter' | 'pro'
-  onStart: (tier: 'starter' | 'pro') => void
-  disabled: boolean
-  recommended?: boolean
-}) {
-  const price =
-    cadence === 'monthly' ? `$${monthlyPrice}/mo` : `$${annualPrice}/yr`
-  const subPrice =
-    cadence === 'annual'
-      ? `$${(annualPrice / 12).toFixed(2)}/mo billed yearly`
-      : `$${monthlyPrice * 12}/yr billed monthly`
-
-  return (
-    <li
-      className={cn(
-        'relative flex flex-col gap-4 rounded-lg border bg-card p-6 transition duration-150 hover:-translate-y-0.5',
-        recommended
-          ? 'border-primary ring-1 ring-primary'
-          : 'border-border hover:border-primary/60',
-      )}
-    >
-      {recommended && (
-        <span className="absolute -top-3 left-6 rounded-full bg-primary px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-primary-foreground">
-          Most popular
-        </span>
-      )}
-      <h3 className="text-lg font-semibold">{name}</h3>
-      <p className="text-2xl font-bold">{price}</p>
-      <p className="-mt-3 text-xs text-muted-foreground">{subPrice}</p>
-      <ul className="flex-1 space-y-1 text-sm text-muted-foreground">
-        {features.map((f) => (
-          <li key={f} className="flex items-center gap-2">
-            <span className="text-primary" aria-hidden="true">&#10003;</span>
-            {f}
-          </li>
-        ))}
-      </ul>
-      <button
-        onClick={() => onStart(tier)}
-        disabled={disabled}
-        className={cn(
-          'w-full rounded-lg px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50',
-          recommended
-            ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-            : 'border border-input bg-transparent text-foreground hover:bg-accent',
-        )}
-      >
-        Start free trial
-      </button>
-    </li>
-  )
-}

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -295,7 +295,7 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
       {!hideHeading && (
         <CurrentPlanCard billing={billing}>
           {billing.subscription && panel === null && (
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap justify-end gap-3">
               <Button onClick={() => setPanel('change')}>Change plan</Button>
               {billing.subscription.status !== 'canceled' && (
                 <Button variant="destructive" onClick={() => setPanel('cancel')}>

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -377,8 +377,19 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
           {panel === 'change' && (
             <PlanChangePanel billing={billing} onClose={() => setPanel(null)} />
           )}
-          {panel === 'cancel' && detail && (
-            <CancelPanel detail={detail} onClose={() => setPanel(null)} />
+          {panel === 'cancel' && (
+            <CancelPanel
+              detail={
+                detail ?? {
+                  next_billed_at: billing.subscription.current_period_end,
+                  amount: null,
+                  currency: null,
+                  billing_cycle: null,
+                  scheduled_change: null,
+                }
+              }
+              onClose={() => setPanel(null)}
+            />
           )}
         </>
       )}

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -297,11 +297,18 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
           {billing.subscription && panel === null && (
             <div className="flex flex-wrap justify-end gap-3">
               <Button onClick={() => setPanel('change')}>Change plan</Button>
-              {billing.subscription.status !== 'canceled' && (
-                <Button variant="destructive" onClick={() => setPanel('cancel')}>
-                  Cancel subscription
-                </Button>
-              )}
+              {/* Hide Cancel when (a) the subscription is already canceled,
+                  OR (b) a scheduled cancel is in flight — Paddle keeps
+                  status='active' until the effective date, so without the
+                  scheduled_change check the button stays clickable and the
+                  second click 5xx's ('subscription already scheduled to
+                  cancel') with a vague 'Could not cancel' toast. */}
+              {billing.subscription.status !== 'canceled' &&
+                detail?.scheduled_change?.action !== 'cancel' && (
+                  <Button variant="destructive" onClick={() => setPanel('cancel')}>
+                    Cancel subscription
+                  </Button>
+                )}
             </div>
           )}
           {billing.subscription && panel === 'change' && (
@@ -318,6 +325,7 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
                   scheduled_change: null,
                 }
               }
+              tier={billing.tier}
               onClose={() => setPanel(null)}
             />
           )}

--- a/frontend/src/billing/cancel-panel.test.tsx
+++ b/frontend/src/billing/cancel-panel.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }))
+vi.mock('../api/client', () => ({
+  api: { get: vi.fn(), post, patch: vi.fn(), del: vi.fn() },
+  setTokenGetter: vi.fn(),
+}))
+
+import CancelPanel from './cancel-panel'
+import type { SubscriptionDetail } from '../api/queries'
+
+let qc: QueryClient
+
+beforeEach(() => {
+  post.mockReset()
+  qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+})
+
+afterEach(() => {
+  qc.clear()
+})
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+function detail(overrides: Partial<SubscriptionDetail> = {}): SubscriptionDetail {
+  return {
+    next_billed_at: '2026-07-01T00:00:00Z',
+    amount: '14.00',
+    currency: 'USD',
+    billing_cycle: { interval: 'month', frequency: 1 },
+    scheduled_change: null,
+    ...overrides,
+  }
+}
+
+describe('CancelPanel', () => {
+  it('renders the access-end date pulled from next_billed_at', () => {
+    render(<CancelPanel detail={detail()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    expect(screen.getByText(/keep pro access/i)).toBeInTheDocument()
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+  })
+
+  it('confirm calls cancel mutation and onClose on success', async () => {
+    post.mockResolvedValue({ scheduled_change: { effective_at: '2026-07-01T00:00:00Z' } })
+    const onClose = vi.fn()
+
+    render(<CancelPanel detail={detail()} onClose={onClose} />, { wrapper: Wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /cancel at period end/i }))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(post).toHaveBeenCalledWith('/billing/cancel-subscription')
+  })
+
+  it('keep button calls onClose without firing the mutation', () => {
+    const onClose = vi.fn()
+    render(<CancelPanel detail={detail()} onClose={onClose} />, { wrapper: Wrapper })
+
+    fireEvent.click(screen.getByRole('button', { name: /keep my subscription/i }))
+
+    expect(post).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('falls back to generic copy when next_billed_at is null', () => {
+    render(<CancelPanel detail={detail({ next_billed_at: null })} onClose={vi.fn()} />, {
+      wrapper: Wrapper,
+    })
+    expect(
+      screen.getByText(/keep paid access through the end of your current billing period/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/billing/cancel-panel.test.tsx
+++ b/frontend/src/billing/cancel-panel.test.tsx
@@ -39,17 +39,23 @@ function detail(overrides: Partial<SubscriptionDetail> = {}): SubscriptionDetail
 }
 
 describe('CancelPanel', () => {
-  it('renders the access-end date pulled from next_billed_at', () => {
-    render(<CancelPanel detail={detail()} onClose={vi.fn()} />, { wrapper: Wrapper })
-    expect(screen.getByText(/keep pro access/i)).toBeInTheDocument()
+  it('renders Pro tier copy for a pro subscriber', () => {
+    render(<CancelPanel detail={detail()} tier="pro" onClose={vi.fn()} />, { wrapper: Wrapper })
+    expect(screen.getByText(/keep your pro plan/i)).toBeInTheDocument()
     expect(screen.getByText(/2026/)).toBeInTheDocument()
+  })
+
+  it('renders Starter tier copy for a starter subscriber (no Pro mislabel)', () => {
+    render(<CancelPanel detail={detail()} tier="starter" onClose={vi.fn()} />, { wrapper: Wrapper })
+    expect(screen.getByText(/keep your starter plan/i)).toBeInTheDocument()
+    expect(screen.queryByText(/keep your pro plan/i)).not.toBeInTheDocument()
   })
 
   it('confirm calls cancel mutation and onClose on success', async () => {
     post.mockResolvedValue({ scheduled_change: { effective_at: '2026-07-01T00:00:00Z' } })
     const onClose = vi.fn()
 
-    render(<CancelPanel detail={detail()} onClose={onClose} />, { wrapper: Wrapper })
+    render(<CancelPanel detail={detail()} tier="pro" onClose={onClose} />, { wrapper: Wrapper })
     fireEvent.click(screen.getByRole('button', { name: /cancel at period end/i }))
 
     await waitFor(() => expect(onClose).toHaveBeenCalled())
@@ -58,7 +64,7 @@ describe('CancelPanel', () => {
 
   it('keep button calls onClose without firing the mutation', () => {
     const onClose = vi.fn()
-    render(<CancelPanel detail={detail()} onClose={onClose} />, { wrapper: Wrapper })
+    render(<CancelPanel detail={detail()} tier="pro" onClose={onClose} />, { wrapper: Wrapper })
 
     fireEvent.click(screen.getByRole('button', { name: /keep my subscription/i }))
 
@@ -67,9 +73,10 @@ describe('CancelPanel', () => {
   })
 
   it('falls back to generic copy when next_billed_at is null', () => {
-    render(<CancelPanel detail={detail({ next_billed_at: null })} onClose={vi.fn()} />, {
-      wrapper: Wrapper,
-    })
+    render(
+      <CancelPanel detail={detail({ next_billed_at: null })} tier="pro" onClose={vi.fn()} />,
+      { wrapper: Wrapper },
+    )
     expect(
       screen.getByText(/keep paid access through the end of your current billing period/i),
     ).toBeInTheDocument()

--- a/frontend/src/billing/cancel-panel.tsx
+++ b/frontend/src/billing/cancel-panel.tsx
@@ -1,14 +1,21 @@
 import { Button } from '@/components/ui/button'
-import { useCancelSubscription } from '../api/queries'
+import { useCancelSubscription, type BillingStatus } from '../api/queries'
 import type { SubscriptionDetail } from '../api/queries'
 import { toast } from 'sonner'
 
+const TIER_LABELS: Partial<Record<BillingStatus['tier'], string>> = {
+  starter: 'Starter',
+  pro: 'Pro',
+  trial: 'Trial',
+}
+
 interface CancelPanelProps {
   detail: SubscriptionDetail
+  tier: BillingStatus['tier']
   onClose: () => void
 }
 
-export default function CancelPanel({ detail, onClose }: CancelPanelProps) {
+export default function CancelPanel({ detail, tier, onClose }: CancelPanelProps) {
   const cancel = useCancelSubscription()
 
   // next_billed_at is the natural cancel-effective date when canceling
@@ -17,6 +24,11 @@ export default function CancelPanel({ detail, onClose }: CancelPanelProps) {
   const effective = detail.next_billed_at
     ? new Date(detail.next_billed_at).toLocaleDateString()
     : null
+
+  // Use the user's actual tier label in copy instead of hardcoding 'Pro' —
+  // a Starter subscriber clicking cancel was reading 'You'll keep Pro
+  // access' which looks like a tier-mismatch bug.
+  const tierLabel = TIER_LABELS[tier] ?? 'paid'
 
   async function confirm() {
     try {
@@ -39,7 +51,7 @@ export default function CancelPanel({ detail, onClose }: CancelPanelProps) {
         <p className="mt-2 text-sm text-muted-foreground">
           {effective ? (
             <>
-              You'll keep Pro access until <strong>{effective}</strong>, then drop to Free.
+              You'll keep your {tierLabel} plan until <strong>{effective}</strong>, then drop to Free.
             </>
           ) : (
             <>You'll keep paid access through the end of your current billing period.</>

--- a/frontend/src/billing/cancel-panel.tsx
+++ b/frontend/src/billing/cancel-panel.tsx
@@ -32,7 +32,7 @@ export default function CancelPanel({ detail, onClose }: CancelPanelProps) {
     <section
       role="region"
       aria-label="Cancel subscription"
-      className="space-y-4 rounded-lg border border-border bg-card p-6"
+      className="space-y-4 pt-2"
     >
       <header>
         <h2 className="text-base font-semibold text-foreground">Cancel subscription</h2>

--- a/frontend/src/billing/cancel-panel.tsx
+++ b/frontend/src/billing/cancel-panel.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@/components/ui/button'
+import { useCancelSubscription } from '../api/queries'
+import type { SubscriptionDetail } from '../api/queries'
+import { toast } from 'sonner'
+
+interface CancelPanelProps {
+  detail: SubscriptionDetail
+  onClose: () => void
+}
+
+export default function CancelPanel({ detail, onClose }: CancelPanelProps) {
+  const cancel = useCancelSubscription()
+
+  // next_billed_at is the natural cancel-effective date when canceling
+  // at-period-end. Falls back to a generic line if the backend has not yet
+  // populated it (newly-subscribed user mid-webhook-sync).
+  const effective = detail.next_billed_at
+    ? new Date(detail.next_billed_at).toLocaleDateString()
+    : null
+
+  async function confirm() {
+    try {
+      await cancel.mutateAsync()
+      toast.success('Subscription scheduled to cancel.')
+      onClose()
+    } catch {
+      toast.error('Could not cancel subscription. Please try again.')
+    }
+  }
+
+  return (
+    <section
+      role="region"
+      aria-label="Cancel subscription"
+      className="space-y-4 rounded-lg border border-border bg-card p-6"
+    >
+      <header>
+        <h2 className="text-base font-semibold text-foreground">Cancel subscription</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {effective ? (
+            <>
+              You'll keep Pro access until <strong>{effective}</strong>, then drop to Free.
+            </>
+          ) : (
+            <>You'll keep paid access through the end of your current billing period.</>
+          )}
+        </p>
+      </header>
+      <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+        <li>Your notes stay. Sync still works for vaults within Free limits.</li>
+        <li>Vaults or notes that exceed Free limits become read-only.</li>
+        <li>You can reverse this any time before the effective date.</li>
+      </ul>
+      <div className="flex gap-2">
+        <Button
+          variant="destructive"
+          onClick={confirm}
+          disabled={cancel.isPending}
+        >
+          Cancel at period end
+        </Button>
+        <Button variant="ghost" onClick={onClose} disabled={cancel.isPending}>
+          Keep my subscription
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/billing/current-plan-card.tsx
+++ b/frontend/src/billing/current-plan-card.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { BillingStatus } from '../api/queries'
 
 const TIER_LABELS: Record<BillingStatus['tier'], string> = {
@@ -8,7 +9,13 @@ const TIER_LABELS: Record<BillingStatus['tier'], string> = {
   pro: 'Pro',
 }
 
-export default function CurrentPlanCard({ billing }: { billing: BillingStatus }) {
+export default function CurrentPlanCard({
+  billing,
+  children,
+}: {
+  billing: BillingStatus
+  children?: ReactNode
+}) {
   const sub = billing.subscription
   const canceled = sub?.status === 'canceled'
   const trialing = sub?.status === 'trialing'
@@ -46,6 +53,8 @@ export default function CurrentPlanCard({ billing }: { billing: BillingStatus })
           )}
         </dl>
       )}
+
+      {children && <div className="border-t border-border pt-4">{children}</div>}
     </section>
   )
 }

--- a/frontend/src/billing/pending-change-banner.test.tsx
+++ b/frontend/src/billing/pending-change-banner.test.tsx
@@ -1,6 +1,32 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }))
+vi.mock('../api/client', () => ({
+  api: { get: vi.fn(), post, patch: vi.fn(), del: vi.fn() },
+  setTokenGetter: vi.fn(),
+}))
+
 import PendingChangeBanner from './pending-change-banner'
+
+let qc: QueryClient
+
+beforeEach(() => {
+  post.mockReset()
+  qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+})
+
+afterEach(() => {
+  qc.clear()
+})
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
 
 describe('PendingChangeBanner', () => {
   it('announces a scheduled cancellation with its effective date', () => {
@@ -8,13 +34,40 @@ describe('PendingChangeBanner', () => {
       <PendingChangeBanner
         scheduledChange={{ action: 'cancel', effective_at: '2026-06-27T07:00:00Z' }}
       />,
+      { wrapper: Wrapper },
     )
     expect(screen.getByText(/cancels/i)).toBeInTheDocument()
     expect(screen.getByText(/2026/)).toBeInTheDocument()
   })
 
   it('renders nothing when there is no scheduled change', () => {
-    const { container } = render(<PendingChangeBanner scheduledChange={null} />)
+    const { container } = render(<PendingChangeBanner scheduledChange={null} />, {
+      wrapper: Wrapper,
+    })
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows a Keep my subscription button on a scheduled cancel that fires reverse-cancel', async () => {
+    post.mockResolvedValue({ scheduled_change: null })
+
+    render(
+      <PendingChangeBanner
+        scheduledChange={{ action: 'cancel', effective_at: '2026-06-27T07:00:00Z' }}
+      />,
+      { wrapper: Wrapper },
+    )
+    fireEvent.click(screen.getByRole('button', { name: /keep my subscription/i }))
+
+    await waitFor(() => expect(post).toHaveBeenCalledWith('/billing/reverse-cancel'))
+  })
+
+  it('does NOT show the reverse-cancel button for non-cancel scheduled changes (e.g. pause)', () => {
+    render(
+      <PendingChangeBanner
+        scheduledChange={{ action: 'pause', effective_at: '2026-06-27T07:00:00Z' }}
+      />,
+      { wrapper: Wrapper },
+    )
+    expect(screen.queryByRole('button', { name: /keep my subscription/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/billing/pending-change-banner.tsx
+++ b/frontend/src/billing/pending-change-banner.tsx
@@ -1,4 +1,6 @@
-import type { SubscriptionDetail } from '../api/queries'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { useReverseCancel, type SubscriptionDetail } from '../api/queries'
 
 const ACTION_LABELS: Record<string, string> = {
   cancel: 'Your plan cancels',
@@ -11,16 +13,35 @@ export default function PendingChangeBanner({
 }: {
   scheduledChange: SubscriptionDetail['scheduled_change']
 }) {
+  const reverseCancel = useReverseCancel()
+
   if (!scheduledChange) return null
 
   const label = ACTION_LABELS[scheduledChange.action] ?? 'Your plan changes'
   const date = new Date(scheduledChange.effective_at).toLocaleDateString()
 
+  async function onReverse() {
+    try {
+      await reverseCancel.mutateAsync()
+      toast.success('Cancellation reversed. Your subscription will keep renewing.')
+    } catch {
+      toast.error('Could not reverse the cancellation. Please try again.')
+    }
+  }
+
   return (
-    <aside role="status" className="rounded-lg border border-border bg-secondary/50 p-4 text-sm">
+    <aside
+      role="status"
+      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-secondary/50 p-4 text-sm"
+    >
       <p className="font-medium text-foreground">
         {label} on {date}
       </p>
+      {scheduledChange.action === 'cancel' && (
+        <Button size="sm" onClick={onReverse} disabled={reverseCancel.isPending}>
+          Keep my subscription
+        </Button>
+      )}
     </aside>
   )
 }

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -140,7 +140,7 @@ export function PlanCard({
           'border-primary ring-1 ring-primary hover:-translate-y-0.5',
         state === 'selected' &&
           'border-primary ring-2 ring-primary shadow-sm',
-        state === 'current' && 'border-muted-foreground/30 bg-muted/30',
+        state === 'current' && 'border-border bg-muted',
       )}
     >
       {badgeText && (
@@ -148,7 +148,7 @@ export function PlanCard({
           className={cn(
             'absolute -top-3 left-6 rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide',
             state === 'current'
-              ? 'bg-muted-foreground/20 text-foreground'
+              ? 'bg-secondary text-secondary-foreground'
               : 'bg-primary text-primary-foreground',
           )}
         >

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -1,0 +1,190 @@
+import { cn } from '@/lib/utils'
+import type { BillingCadence } from '../api/queries'
+
+export type PlanTier = 'starter' | 'pro'
+
+export interface PlanCardCatalog {
+  name: string
+  monthlyPrice: number
+  annualPrice: number
+  features: string[]
+}
+
+// Single catalog source-of-truth: both onboarding (trial signup) and the
+// change-plan panel read display prices from here. Keep in sync with the
+// pricing model lock (Free / $7 / $14 monthly + $70/$140 annual — see
+// memory project_pricing_model). Updating Paddle prices means updating here.
+export const PLAN_CATALOG: Record<PlanTier, PlanCardCatalog> = {
+  starter: {
+    name: 'Starter',
+    monthlyPrice: 7,
+    annualPrice: 70,
+    features: ['5 vaults', 'Unlimited devices', '3 GB attachments', '500 AI queries/day'],
+  },
+  pro: {
+    name: 'Pro',
+    monthlyPrice: 14,
+    annualPrice: 140,
+    features: [
+      '15 vaults',
+      'Unlimited devices',
+      '15 GB attachments',
+      'Unlimited AI',
+      'Smart retrieval (coming)',
+    ],
+  },
+}
+
+export function CadenceToggle({
+  cadence,
+  onChange,
+}: {
+  cadence: BillingCadence
+  onChange: (next: BillingCadence) => void
+}) {
+  return (
+    <div role="radiogroup" aria-label="Billing cadence" className="flex justify-center">
+      <div className="inline-flex rounded-full border border-border bg-muted p-1 text-sm">
+        <button
+          role="radio"
+          aria-checked={cadence === 'monthly'}
+          onClick={() => onChange('monthly')}
+          className={cn(
+            'rounded-full px-4 py-1.5 font-medium transition',
+            cadence === 'monthly'
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          Monthly
+        </button>
+        <button
+          role="radio"
+          aria-checked={cadence === 'annual'}
+          onClick={() => onChange('annual')}
+          className={cn(
+            'rounded-full px-4 py-1.5 font-medium transition',
+            cadence === 'annual'
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          Annual <span className="ml-1 text-xs text-primary">save 17%</span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+interface PlanCardProps {
+  name: string
+  cadence: BillingCadence
+  monthlyPrice: number
+  annualPrice: number
+  features: string[]
+  tier: PlanTier
+  onAction: (tier: PlanTier) => void
+  disabled?: boolean
+  // Visual states — pick at most one (current beats selected which beats
+  // recommended). Only one card per panel should render any of these.
+  recommended?: boolean
+  selected?: boolean
+  current?: boolean
+  ctaLabel?: string
+  // ctaSubLabel is shown under the CTA only on the selected card — used by
+  // PlanChangePanel to surface inline proration without a separate strip.
+  ctaSubLabel?: string
+}
+
+export function PlanCard({
+  name,
+  cadence,
+  monthlyPrice,
+  annualPrice,
+  features,
+  tier,
+  onAction,
+  disabled = false,
+  recommended = false,
+  selected = false,
+  current = false,
+  ctaLabel = 'Start free trial',
+  ctaSubLabel,
+}: PlanCardProps) {
+  const price = cadence === 'monthly' ? `$${monthlyPrice}/mo` : `$${annualPrice}/yr`
+  const subPrice =
+    cadence === 'annual'
+      ? `$${(annualPrice / 12).toFixed(2)}/mo billed yearly`
+      : `$${monthlyPrice * 12}/yr billed monthly`
+
+  // Effective state precedence — current beats selected beats recommended.
+  // Avoids the "everything is highlighted" failure mode if a parent passes
+  // multiple truthy flags by mistake.
+  const state: 'current' | 'selected' | 'recommended' | 'idle' = current
+    ? 'current'
+    : selected
+      ? 'selected'
+      : recommended
+        ? 'recommended'
+        : 'idle'
+
+  const badgeText =
+    state === 'current' ? 'Current plan' : state === 'recommended' ? 'Most popular' : null
+
+  return (
+    <li
+      className={cn(
+        'relative flex flex-col gap-4 rounded-lg border bg-card p-6 transition duration-150',
+        state === 'idle' && 'border-border hover:-translate-y-0.5 hover:border-primary/60',
+        state === 'recommended' &&
+          'border-primary ring-1 ring-primary hover:-translate-y-0.5',
+        state === 'selected' &&
+          'border-primary ring-2 ring-primary shadow-sm',
+        state === 'current' && 'border-muted-foreground/30 bg-muted/30',
+      )}
+    >
+      {badgeText && (
+        <span
+          className={cn(
+            'absolute -top-3 left-6 rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide',
+            state === 'current'
+              ? 'bg-muted-foreground/20 text-foreground'
+              : 'bg-primary text-primary-foreground',
+          )}
+        >
+          {badgeText}
+        </span>
+      )}
+      <h3 className="text-lg font-semibold">{name}</h3>
+      <p className="text-2xl font-bold">{price}</p>
+      <p className="-mt-3 text-xs text-muted-foreground">{subPrice}</p>
+      <ul className="flex-1 space-y-1 text-sm text-muted-foreground">
+        {features.map((f) => (
+          <li key={f} className="flex items-center gap-2">
+            <span className="text-primary" aria-hidden="true">
+              &#10003;
+            </span>
+            {f}
+          </li>
+        ))}
+      </ul>
+      <div className="flex flex-col gap-1">
+        <button
+          onClick={() => onAction(tier)}
+          disabled={disabled || current}
+          className={cn(
+            'w-full rounded-lg px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50',
+            state === 'recommended' || state === 'selected'
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+              : 'border border-input bg-transparent text-foreground hover:bg-accent',
+          )}
+        >
+          {current ? 'Current plan' : ctaLabel}
+        </button>
+        {selected && ctaSubLabel && (
+          <p className="text-center text-xs text-muted-foreground">{ctaSubLabel}</p>
+        )}
+      </div>
+    </li>
+  )
+}

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -174,9 +174,16 @@ export function PlanCard({
           disabled={disabled || current}
           className={cn(
             'w-full rounded-lg px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50',
+            // recommended (onboarding's Pro) and selected (change-plan's
+            // chosen target) get the filled-primary CTA so the actionable
+            // card has visible weight against neighbors. current renders a
+            // muted outline since the button is inert. idle keeps a clean
+            // outline (onboarding's Starter, change-plan's other tier).
             state === 'recommended' || state === 'selected'
               ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-              : 'border border-input bg-transparent text-foreground hover:bg-accent',
+              : state === 'current'
+                ? 'border border-input bg-transparent text-muted-foreground'
+                : 'border border-input bg-transparent text-foreground hover:bg-accent',
           )}
         >
           {current ? 'Current plan' : ctaLabel}

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -129,7 +129,7 @@ export function PlanCard({
         : 'idle'
 
   const badgeText =
-    state === 'current' ? 'Current plan' : state === 'recommended' ? 'Most popular' : null
+    state === 'current' ? 'Your plan' : state === 'recommended' ? 'Most popular' : null
 
   return (
     <li
@@ -140,17 +140,15 @@ export function PlanCard({
           'border-primary ring-1 ring-primary hover:-translate-y-0.5',
         state === 'selected' &&
           'border-primary ring-2 ring-primary shadow-sm',
-        state === 'current' && 'border-border bg-muted',
+        // 'current' reads as "you've got this" — primary accent ring, no
+        // muted bg. Diminished-grey treatment made the card feel locked
+        // out; this leans into the card visually instead.
+        state === 'current' && 'border-primary/60 ring-1 ring-primary/30 shadow-sm',
       )}
     >
       {badgeText && (
         <span
-          className={cn(
-            'absolute -top-3 left-6 rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide',
-            state === 'current'
-              ? 'bg-secondary text-secondary-foreground'
-              : 'bg-primary text-primary-foreground',
-          )}
+          className="absolute -top-3 left-6 rounded-full bg-primary px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-primary-foreground"
         >
           {badgeText}
         </span>
@@ -169,27 +167,39 @@ export function PlanCard({
         ))}
       </ul>
       <div className="flex flex-col gap-1">
-        <button
-          onClick={() => onAction(tier)}
-          disabled={disabled || current}
-          className={cn(
-            'w-full rounded-lg px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50',
-            // recommended (onboarding's Pro) and selected (change-plan's
-            // chosen target) get the filled-primary CTA so the actionable
-            // card has visible weight against neighbors. current renders a
-            // muted outline since the button is inert. idle keeps a clean
-            // outline (onboarding's Starter, change-plan's other tier).
-            state === 'recommended' || state === 'selected'
-              ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-              : state === 'current'
-                ? 'border border-input bg-transparent text-muted-foreground'
-                : 'border border-input bg-transparent text-foreground hover:bg-accent',
-          )}
-        >
-          {current ? 'Current plan' : ctaLabel}
-        </button>
-        {selected && ctaSubLabel && (
-          <p className="text-center text-xs text-muted-foreground">{ctaSubLabel}</p>
+        {current ? (
+          // Inert positive indicator instead of a disabled button: same
+          // height as the CTA so card layout stays consistent, but
+          // visually reads as confirmation, not as a denied action.
+          <div
+            role="status"
+            aria-label="Your current plan"
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-medium text-primary"
+          >
+            <span aria-hidden="true">&#10003;</span>
+            <span>You're on this plan</span>
+          </div>
+        ) : (
+          <>
+            <button
+              onClick={() => onAction(tier)}
+              disabled={disabled}
+              className={cn(
+                'w-full rounded-lg px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50',
+                // recommended (onboarding's Pro) and selected (change-plan's
+                // chosen target) get filled-primary CTA so the actionable
+                // card has weight. idle stays a clean outline.
+                state === 'recommended' || state === 'selected'
+                  ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'border border-input bg-transparent text-foreground hover:bg-accent',
+              )}
+            >
+              {ctaLabel}
+            </button>
+            {selected && ctaSubLabel && (
+              <p className="text-center text-xs text-muted-foreground">{ctaSubLabel}</p>
+            )}
+          </>
         )}
       </div>
     </li>

--- a/frontend/src/billing/plan-change-panel.test.tsx
+++ b/frontend/src/billing/plan-change-panel.test.tsx
@@ -63,11 +63,11 @@ describe('PlanChangePanel', () => {
     expect(screen.getByText('$14/mo')).toBeInTheDocument()
   })
 
-  it('marks the user current tier and disables that cards Select button', () => {
+  it('marks the user current tier and shows the inert You are on this plan indicator', () => {
     render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
-    // Starter is current → "Current plan" badge + disabled button
-    const currentBadges = screen.getAllByText(/current plan/i)
-    expect(currentBadges.length).toBeGreaterThan(0)
+    // Starter is current → 'Your plan' badge + inert "You're on this plan" status
+    expect(screen.getAllByText(/your plan/i).length).toBeGreaterThan(0)
+    expect(screen.getByRole('status', { name: /your current plan/i })).toBeInTheDocument()
   })
 
   it('fetches preview when a target is selected and shows proration', async () => {

--- a/frontend/src/billing/plan-change-panel.test.tsx
+++ b/frontend/src/billing/plan-change-panel.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+const { get, post } = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }))
+vi.mock('../api/client', () => ({
+  api: { get, post, patch: vi.fn(), del: vi.fn() },
+  setTokenGetter: vi.fn(),
+}))
+
+import PlanChangePanel from './plan-change-panel'
+import type { BillingStatus } from '../api/queries'
+
+let qc: QueryClient
+
+const config = {
+  client_token: 'tok',
+  environment: 'sandbox' as const,
+  price_ids: {
+    starter: { monthly: 'pri_s_m', annual: 'pri_s_a' },
+    pro: { monthly: 'pri_p_m', annual: 'pri_p_a' },
+  },
+  customer_email: 'a@b.test',
+  custom_data: { user_id: 1 },
+  vaults_cap: 5,
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  qc.setQueryData(['billing', 'config'], config)
+})
+
+afterEach(() => {
+  qc.clear()
+})
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+function billing(overrides: Partial<BillingStatus> = {}): BillingStatus {
+  return {
+    tier: 'starter',
+    active: true,
+    trial_days_remaining: 0,
+    subscription: { status: 'active', tier: 'starter', current_period_end: '2026-07-01' },
+    caps: { obsidian_connections: 1, mcp_connections: 1, api_write_enabled: true },
+    ...overrides,
+  }
+}
+
+describe('PlanChangePanel', () => {
+  it('renders Starter + Pro cards for the current cadence', () => {
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    expect(screen.getByText('Starter')).toBeInTheDocument()
+    expect(screen.getByText('Pro')).toBeInTheDocument()
+  })
+
+  it('fetches preview when a target is selected and exposes proration', async () => {
+    post.mockResolvedValue({
+      old_total: 700,
+      new_total: 1400,
+      immediate_charge_or_credit: 350,
+      next_billed_at: '2026-07-01T00:00:00Z',
+    })
+
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    // Click the Pro card (selecting via the underlying RadioGroupItem)
+    const proCard = screen.getByText('Pro').closest('[data-slot="radio-group-item"], [role="radio"]')
+    if (!proCard) throw new Error('Pro card not found')
+    fireEvent.click(proCard)
+
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/billing/plan-change/preview', {
+        target_price_id: 'pri_p_m',
+      }),
+    )
+    expect(await screen.findByText(/charged today/i)).toBeInTheDocument()
+    expect(screen.getByText(/\$3\.50/)).toBeInTheDocument()
+  })
+
+  it('confirm fires the mutation and onClose on success', async () => {
+    post
+      .mockResolvedValueOnce({
+        old_total: 700,
+        new_total: 1400,
+        immediate_charge_or_credit: 350,
+        next_billed_at: '2026-07-01T00:00:00Z',
+      })
+      .mockResolvedValueOnce({ transaction_id: 'txn_xyz' })
+
+    const onClose = vi.fn()
+    render(<PlanChangePanel billing={billing()} onClose={onClose} />, { wrapper: Wrapper })
+    const proCard = screen.getByText('Pro').closest('[data-slot="radio-group-item"], [role="radio"]')
+    if (!proCard) throw new Error('Pro card not found')
+    fireEvent.click(proCard)
+
+    await screen.findByText(/charged today/i)
+    fireEvent.click(screen.getByRole('button', { name: /confirm change/i }))
+
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/billing/plan-change/confirm', {
+        target_price_id: 'pri_p_m',
+      }),
+    )
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  it('Cancel button closes without firing a mutation', () => {
+    const onClose = vi.fn()
+    render(<PlanChangePanel billing={billing()} onClose={onClose} />, { wrapper: Wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(post).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/billing/plan-change-panel.test.tsx
+++ b/frontend/src/billing/plan-change-panel.test.tsx
@@ -55,13 +55,22 @@ function billing(overrides: Partial<BillingStatus> = {}): BillingStatus {
 }
 
 describe('PlanChangePanel', () => {
-  it('renders Starter + Pro cards for the current cadence', () => {
+  it('renders Starter + Pro cards using shared PlanCard styling', () => {
     render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
     expect(screen.getByText('Starter')).toBeInTheDocument()
     expect(screen.getByText('Pro')).toBeInTheDocument()
+    expect(screen.getByText('$7/mo')).toBeInTheDocument()
+    expect(screen.getByText('$14/mo')).toBeInTheDocument()
   })
 
-  it('fetches preview when a target is selected and exposes proration', async () => {
+  it('marks the user current tier and disables that cards Select button', () => {
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    // Starter is current → "Current plan" badge + disabled button
+    const currentBadges = screen.getAllByText(/current plan/i)
+    expect(currentBadges.length).toBeGreaterThan(0)
+  })
+
+  it('fetches preview when a target is selected and shows proration', async () => {
     post.mockResolvedValue({
       old_total: 700,
       new_total: 1400,
@@ -70,18 +79,14 @@ describe('PlanChangePanel', () => {
     })
 
     render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
-    // Click the Pro card (selecting via the underlying RadioGroupItem)
-    const proCard = screen.getByText('Pro').closest('[data-slot="radio-group-item"], [role="radio"]')
-    if (!proCard) throw new Error('Pro card not found')
-    fireEvent.click(proCard)
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }))
 
     await waitFor(() =>
       expect(post).toHaveBeenCalledWith('/billing/plan-change/preview', {
         target_price_id: 'pri_p_m',
       }),
     )
-    expect(await screen.findByText(/charged today/i)).toBeInTheDocument()
-    expect(screen.getByText(/\$3\.50/)).toBeInTheDocument()
+    expect(await screen.findByText(/charged \$3\.50 today/i)).toBeInTheDocument()
   })
 
   it('confirm fires the mutation and onClose on success', async () => {
@@ -96,11 +101,8 @@ describe('PlanChangePanel', () => {
 
     const onClose = vi.fn()
     render(<PlanChangePanel billing={billing()} onClose={onClose} />, { wrapper: Wrapper })
-    const proCard = screen.getByText('Pro').closest('[data-slot="radio-group-item"], [role="radio"]')
-    if (!proCard) throw new Error('Pro card not found')
-    fireEvent.click(proCard)
-
-    await screen.findByText(/charged today/i)
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }))
+    await screen.findByText(/charged \$3\.50 today/i)
     fireEvent.click(screen.getByRole('button', { name: /confirm change/i }))
 
     await waitFor(() =>

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { RadioGroup } from '@/components/ui/radio-group'
 import { Button } from '@/components/ui/button'
-import { PricingSelectCardGrid } from '@/components/pricing-select-card-grid'
-import { BillingIntervalToggle } from '@/components/billing-interval-toggle'
 import {
   useBillingConfig,
   useConfirmPlanChange,
@@ -11,54 +8,36 @@ import {
   type BillingCadence,
   type BillingStatus,
 } from '../api/queries'
+import { CadenceToggle, PLAN_CATALOG, PlanCard, type PlanTier } from './plan-cards'
 
 interface PlanChangePanelProps {
   billing: BillingStatus
   onClose: () => void
 }
 
-// Display catalog — mirrors the live-paddle prices in BillingConfig.price_ids.
-// Hardcoded display strings are fine here: PricingSelectCardGrid renders raw
-// pre-formatted strings (see paddle-types.ts PriceData), no PricePreview SDK
-// call needed. If prices ever change in Paddle, update here and in PlanCard
-// (billing-page.tsx) — both share the same source-of-truth catalog.
-const CATALOG = {
-  starter: {
-    name: 'Starter',
-    description: '5 vaults · 3 GB · 500 AI queries/day',
-    prices: {
-      monthly: { total: '$7', interval: 'month' },
-      annual: { total: '$70', interval: 'year' },
-    },
-  },
-  pro: {
-    name: 'Pro',
-    description: '15 vaults · 15 GB · Unlimited AI',
-    prices: {
-      monthly: { total: '$14', interval: 'month' },
-      annual: { total: '$140', interval: 'year' },
-    },
-  },
-} as const
-
-type Tier = keyof typeof CATALOG
-
 function formatCents(cents: number | null | undefined): string {
   if (cents === null || cents === undefined) return '—'
-  // Paddle returns totals in lowest-unit decimal strings or integers; we treat
-  // them as raw cents here. JPY/KRW/CLP zero-decimal currencies would need a
-  // separate code path — defer that until the proration UI supports non-USD.
+  // Paddle returns totals as raw cents (USD only for now). Zero-decimal
+  // currencies (JPY/KRW/CLP) would need a separate code path — defer until
+  // the proration UI supports non-USD.
   const sign = cents < 0 ? '-' : ''
   const abs = Math.abs(cents)
   return `${sign}$${(abs / 100).toFixed(2)}`
 }
 
+function deriveCurrentTier(billing: BillingStatus): PlanTier | null {
+  const tier = billing.subscription?.tier
+  return tier === 'starter' || tier === 'pro' ? tier : null
+}
+
 export default function PlanChangePanel({ billing, onClose }: PlanChangePanelProps) {
   const { data: config } = useBillingConfig()
-  const [cadence, setCadence] = useState<BillingCadence>(
-    billing.subscription?.tier === 'pro' || billing.subscription?.tier === 'starter' ? 'monthly' : 'monthly',
-  )
-  const [targetPriceId, setTargetPriceId] = useState<string | null>(null)
+  const [cadence, setCadence] = useState<BillingCadence>('monthly')
+  const [selectedTier, setSelectedTier] = useState<PlanTier | null>(null)
+
+  const targetPriceId =
+    selectedTier && config ? (config.price_ids[selectedTier][cadence] ?? null) : null
+
   const preview = usePlanChangePreview(targetPriceId)
   const confirm = useConfirmPlanChange()
 
@@ -74,7 +53,7 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
     )
   }
 
-  const currentPriceId = priceIdForCurrent(config.price_ids, billing.subscription?.tier, cadence)
+  const currentTier = deriveCurrentTier(billing)
 
   async function onConfirm() {
     if (!targetPriceId) return
@@ -96,58 +75,59 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
       <header>
         <h2 className="text-base font-semibold text-foreground">Change your plan</h2>
         <p className="mt-2 text-sm text-muted-foreground">
-          Proration applies immediately. You can preview the charge or credit before confirming.
+          Proration applies immediately. The selected card shows what'll be charged or credited
+          before you confirm.
         </p>
       </header>
 
-      <BillingIntervalToggle
-        intervals={['monthly', 'annual']}
-        value={cadence}
-        onValueChange={(v) => {
-          setCadence(v as BillingCadence)
-          setTargetPriceId(null)
+      <CadenceToggle
+        cadence={cadence}
+        onChange={(next) => {
+          setCadence(next)
+          setSelectedTier(null)
         }}
       />
 
-      <RadioGroup
-        value={targetPriceId ?? ''}
-        onValueChange={setTargetPriceId}
-        className="grid grid-cols-1 gap-3 sm:grid-cols-2"
-      >
-        {(Object.keys(CATALOG) as Tier[]).map((tier) => {
-          const priceId = config.price_ids[tier][cadence]
-          const meta = CATALOG[tier]
+      <ul className="grid items-stretch gap-4 sm:grid-cols-2">
+        {(Object.keys(PLAN_CATALOG) as PlanTier[]).map((tier) => {
+          const meta = PLAN_CATALOG[tier]
+          const isCurrent = tier === currentTier
+          const isSelected = tier === selectedTier
           return (
-            <PricingSelectCardGrid
-              key={priceId}
-              priceId={priceId}
+            <PlanCard
+              key={tier}
               name={meta.name}
-              description={meta.description}
-              priceData={meta.prices[cadence]}
-              isCurrent={priceId !== null && priceId === currentPriceId}
-              currentPlanLabel="Current plan"
+              cadence={cadence}
+              monthlyPrice={meta.monthlyPrice}
+              annualPrice={meta.annualPrice}
+              features={meta.features}
+              tier={tier}
+              onAction={(t) => setSelectedTier(t)}
+              current={isCurrent}
+              selected={isSelected}
+              ctaLabel={isSelected ? 'Selected' : 'Select'}
+              ctaSubLabel={
+                isSelected && preview.isFetching
+                  ? 'Loading proration…'
+                  : isSelected && preview.data
+                    ? formatProration(preview.data)
+                    : undefined
+              }
             />
           )
         })}
-      </RadioGroup>
-
-      {targetPriceId && preview.isFetching && (
-        <div role="status" className="h-20 animate-pulse rounded-md bg-muted/50" />
-      )}
-
-      {targetPriceId && preview.data && !preview.isFetching && (
-        <PreviewLines
-          credit={preview.data.immediate_charge_or_credit < 0 ? -preview.data.immediate_charge_or_credit : 0}
-          charge={preview.data.immediate_charge_or_credit > 0 ? preview.data.immediate_charge_or_credit : 0}
-          newTotal={preview.data.new_total}
-          nextBilledAt={preview.data.next_billed_at}
-        />
-      )}
+      </ul>
 
       <div className="flex gap-2">
         <Button
           onClick={onConfirm}
-          disabled={!targetPriceId || preview.isFetching || confirm.isPending || !preview.data}
+          disabled={
+            !selectedTier ||
+            !targetPriceId ||
+            preview.isFetching ||
+            !preview.data ||
+            confirm.isPending
+          }
         >
           Confirm change
         </Button>
@@ -159,49 +139,13 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
   )
 }
 
-function PreviewLines({
-  credit,
-  charge,
-  newTotal,
-  nextBilledAt,
-}: {
-  credit: number
-  charge: number
-  newTotal: number
-  nextBilledAt: string
-}) {
-  const renewalDate = new Date(nextBilledAt).toLocaleDateString()
-  return (
-    <dl
-      role="status"
-      aria-label="Plan change preview"
-      className="grid gap-2 rounded-md border border-border bg-muted/30 p-4 text-sm"
-    >
-      {charge > 0 && (
-        <div className="flex justify-between">
-          <dt className="text-muted-foreground">Charged today</dt>
-          <dd className="font-medium text-foreground">{formatCents(charge)}</dd>
-        </div>
-      )}
-      {credit > 0 && (
-        <div className="flex justify-between">
-          <dt className="text-muted-foreground">Credited today</dt>
-          <dd className="font-medium text-foreground">{formatCents(credit)}</dd>
-        </div>
-      )}
-      <div className="flex justify-between">
-        <dt className="text-muted-foreground">Next bill on {renewalDate}</dt>
-        <dd className="font-medium text-foreground">{formatCents(newTotal)}</dd>
-      </div>
-    </dl>
-  )
-}
-
-function priceIdForCurrent(
-  priceIds: { starter: { monthly: string; annual: string }; pro: { monthly: string; annual: string } },
-  tier: string | undefined,
-  cadence: BillingCadence,
-): string | null {
-  if (tier === 'starter' || tier === 'pro') return priceIds[tier][cadence]
-  return null
+function formatProration(data: {
+  immediate_charge_or_credit: number
+  new_total: number
+  next_billed_at: string
+}): string {
+  const direction = data.immediate_charge_or_credit > 0 ? 'Charged' : 'Credited'
+  const amount = formatCents(Math.abs(data.immediate_charge_or_credit))
+  const renewal = new Date(data.next_billed_at).toLocaleDateString()
+  return `${direction} ${amount} today; next bill ${formatCents(data.new_total)} on ${renewal}`
 }

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -3,10 +3,12 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
   useBillingConfig,
+  useBillingSubscriptionDetail,
   useConfirmPlanChange,
   usePlanChangePreview,
   type BillingCadence,
   type BillingStatus,
+  type SubscriptionDetail,
 } from '../api/queries'
 import { CadenceToggle, PLAN_CATALOG, PlanCard, type PlanTier } from './plan-cards'
 
@@ -30,9 +32,22 @@ function deriveCurrentTier(billing: BillingStatus): PlanTier | null {
   return tier === 'starter' || tier === 'pro' ? tier : null
 }
 
+// Cadence comes from /billing/subscription's billing_cycle.interval; if the
+// detail hasn't loaded (or never resolves for sideloaded dev subs), default
+// to monthly so the panel still renders. The toggle is the user's lever to
+// override regardless.
+function deriveCurrentCadence(detail: SubscriptionDetail | undefined): BillingCadence {
+  return detail?.billing_cycle?.interval === 'year' ? 'annual' : 'monthly'
+}
+
 export default function PlanChangePanel({ billing, onClose }: PlanChangePanelProps) {
   const { data: config } = useBillingConfig()
-  const [cadence, setCadence] = useState<BillingCadence>('monthly')
+  const { data: detail } = useBillingSubscriptionDetail(Boolean(billing.subscription))
+  const currentTier = deriveCurrentTier(billing)
+  const currentCadence = deriveCurrentCadence(detail)
+  // Open the toggle on the user's existing cadence so the first card grid
+  // they see reflects 'what would change' rather than always-Monthly.
+  const [cadence, setCadence] = useState<BillingCadence>(currentCadence)
   const [selectedTier, setSelectedTier] = useState<PlanTier | null>(null)
 
   const targetPriceId =
@@ -43,17 +58,11 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
 
   if (!config) {
     return (
-      <section
-        role="region"
-        aria-label="Change plan"
-        className="rounded-lg border border-border bg-card p-6"
-      >
+      <section role="region" aria-label="Change plan" className="py-2">
         <p className="text-sm text-muted-foreground">Loading plan options…</p>
       </section>
     )
   }
-
-  const currentTier = deriveCurrentTier(billing)
 
   async function onConfirm() {
     if (!targetPriceId) return
@@ -67,11 +76,8 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
   }
 
   return (
-    <section
-      role="region"
-      aria-label="Change plan"
-      className="space-y-5 rounded-lg border border-border bg-card p-6"
-    >
+    <section role="region" aria-label="Change plan" className="space-y-5 pt-2">
+
       <header>
         <h2 className="text-base font-semibold text-foreground">Change your plan</h2>
         <p className="mt-2 text-sm text-muted-foreground">
@@ -91,8 +97,18 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
       <ul className="grid items-stretch gap-4 sm:grid-cols-2">
         {(Object.keys(PLAN_CATALOG) as PlanTier[]).map((tier) => {
           const meta = PLAN_CATALOG[tier]
-          const isCurrent = tier === currentTier
+          // 'Current' only matches when the toggle is on the user's
+          // existing cadence — flipping to Annual surfaces Pro again as a
+          // selectable upgrade target so monthly→annual is a real path.
+          const isCurrent = tier === currentTier && cadence === currentCadence
           const isSelected = tier === selectedTier
+          // Visual focal-point hint: when the toggle puts both cards on
+          // non-current cadence, the page has TWO selectable cards and
+          // neither should auto-highlight. When toggle is on current
+          // cadence, exactly one alternative exists — highlight it.
+          const availableCount = Object.keys(PLAN_CATALOG).length - (cadence === currentCadence && currentTier ? 1 : 0)
+          const isDefaultTarget =
+            selectedTier === null && !isCurrent && availableCount === 1
           return (
             <PlanCard
               key={tier}
@@ -104,7 +120,7 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
               tier={tier}
               onAction={(t) => setSelectedTier(t)}
               current={isCurrent}
-              selected={isSelected}
+              selected={isSelected || isDefaultTarget}
               ctaLabel={isSelected ? 'Selected' : 'Select'}
               ctaSubLabel={
                 isSelected && preview.isFetching

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -124,7 +124,7 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
               name={meta.name}
               description={meta.description}
               priceData={meta.prices[cadence]}
-              isCurrent={priceId === currentPriceId}
+              isCurrent={priceId !== null && priceId === currentPriceId}
               currentPlanLabel="Current plan"
             />
           )

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -1,0 +1,207 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { RadioGroup } from '@/components/ui/radio-group'
+import { Button } from '@/components/ui/button'
+import { PricingSelectCardGrid } from '@/components/pricing-select-card-grid'
+import { BillingIntervalToggle } from '@/components/billing-interval-toggle'
+import {
+  useBillingConfig,
+  useConfirmPlanChange,
+  usePlanChangePreview,
+  type BillingCadence,
+  type BillingStatus,
+} from '../api/queries'
+
+interface PlanChangePanelProps {
+  billing: BillingStatus
+  onClose: () => void
+}
+
+// Display catalog — mirrors the live-paddle prices in BillingConfig.price_ids.
+// Hardcoded display strings are fine here: PricingSelectCardGrid renders raw
+// pre-formatted strings (see paddle-types.ts PriceData), no PricePreview SDK
+// call needed. If prices ever change in Paddle, update here and in PlanCard
+// (billing-page.tsx) — both share the same source-of-truth catalog.
+const CATALOG = {
+  starter: {
+    name: 'Starter',
+    description: '5 vaults · 3 GB · 500 AI queries/day',
+    prices: {
+      monthly: { total: '$7', interval: 'month' },
+      annual: { total: '$70', interval: 'year' },
+    },
+  },
+  pro: {
+    name: 'Pro',
+    description: '15 vaults · 15 GB · Unlimited AI',
+    prices: {
+      monthly: { total: '$14', interval: 'month' },
+      annual: { total: '$140', interval: 'year' },
+    },
+  },
+} as const
+
+type Tier = keyof typeof CATALOG
+
+function formatCents(cents: number | null | undefined): string {
+  if (cents === null || cents === undefined) return '—'
+  // Paddle returns totals in lowest-unit decimal strings or integers; we treat
+  // them as raw cents here. JPY/KRW/CLP zero-decimal currencies would need a
+  // separate code path — defer that until the proration UI supports non-USD.
+  const sign = cents < 0 ? '-' : ''
+  const abs = Math.abs(cents)
+  return `${sign}$${(abs / 100).toFixed(2)}`
+}
+
+export default function PlanChangePanel({ billing, onClose }: PlanChangePanelProps) {
+  const { data: config } = useBillingConfig()
+  const [cadence, setCadence] = useState<BillingCadence>(
+    billing.subscription?.tier === 'pro' || billing.subscription?.tier === 'starter' ? 'monthly' : 'monthly',
+  )
+  const [targetPriceId, setTargetPriceId] = useState<string | null>(null)
+  const preview = usePlanChangePreview(targetPriceId)
+  const confirm = useConfirmPlanChange()
+
+  if (!config) {
+    return (
+      <section
+        role="region"
+        aria-label="Change plan"
+        className="rounded-lg border border-border bg-card p-6"
+      >
+        <p className="text-sm text-muted-foreground">Loading plan options…</p>
+      </section>
+    )
+  }
+
+  const currentPriceId = priceIdForCurrent(config.price_ids, billing.subscription?.tier, cadence)
+
+  async function onConfirm() {
+    if (!targetPriceId) return
+    try {
+      await confirm.mutateAsync(targetPriceId)
+      toast.success('Plan change confirmed.')
+      onClose()
+    } catch {
+      toast.error('Could not change plan. Please try again.')
+    }
+  }
+
+  return (
+    <section
+      role="region"
+      aria-label="Change plan"
+      className="space-y-5 rounded-lg border border-border bg-card p-6"
+    >
+      <header>
+        <h2 className="text-base font-semibold text-foreground">Change your plan</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Proration applies immediately. You can preview the charge or credit before confirming.
+        </p>
+      </header>
+
+      <BillingIntervalToggle
+        intervals={['monthly', 'annual']}
+        value={cadence}
+        onValueChange={(v) => {
+          setCadence(v as BillingCadence)
+          setTargetPriceId(null)
+        }}
+      />
+
+      <RadioGroup
+        value={targetPriceId ?? ''}
+        onValueChange={setTargetPriceId}
+        className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+      >
+        {(Object.keys(CATALOG) as Tier[]).map((tier) => {
+          const priceId = config.price_ids[tier][cadence]
+          const meta = CATALOG[tier]
+          return (
+            <PricingSelectCardGrid
+              key={priceId}
+              priceId={priceId}
+              name={meta.name}
+              description={meta.description}
+              priceData={meta.prices[cadence]}
+              isCurrent={priceId === currentPriceId}
+              currentPlanLabel="Current plan"
+            />
+          )
+        })}
+      </RadioGroup>
+
+      {targetPriceId && preview.isFetching && (
+        <div role="status" className="h-20 animate-pulse rounded-md bg-muted/50" />
+      )}
+
+      {targetPriceId && preview.data && !preview.isFetching && (
+        <PreviewLines
+          credit={preview.data.immediate_charge_or_credit < 0 ? -preview.data.immediate_charge_or_credit : 0}
+          charge={preview.data.immediate_charge_or_credit > 0 ? preview.data.immediate_charge_or_credit : 0}
+          newTotal={preview.data.new_total}
+          nextBilledAt={preview.data.next_billed_at}
+        />
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          onClick={onConfirm}
+          disabled={!targetPriceId || preview.isFetching || confirm.isPending || !preview.data}
+        >
+          Confirm change
+        </Button>
+        <Button variant="ghost" onClick={onClose} disabled={confirm.isPending}>
+          Cancel
+        </Button>
+      </div>
+    </section>
+  )
+}
+
+function PreviewLines({
+  credit,
+  charge,
+  newTotal,
+  nextBilledAt,
+}: {
+  credit: number
+  charge: number
+  newTotal: number
+  nextBilledAt: string
+}) {
+  const renewalDate = new Date(nextBilledAt).toLocaleDateString()
+  return (
+    <dl
+      role="status"
+      aria-label="Plan change preview"
+      className="grid gap-2 rounded-md border border-border bg-muted/30 p-4 text-sm"
+    >
+      {charge > 0 && (
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Charged today</dt>
+          <dd className="font-medium text-foreground">{formatCents(charge)}</dd>
+        </div>
+      )}
+      {credit > 0 && (
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Credited today</dt>
+          <dd className="font-medium text-foreground">{formatCents(credit)}</dd>
+        </div>
+      )}
+      <div className="flex justify-between">
+        <dt className="text-muted-foreground">Next bill on {renewalDate}</dt>
+        <dd className="font-medium text-foreground">{formatCents(newTotal)}</dd>
+      </div>
+    </dl>
+  )
+}
+
+function priceIdForCurrent(
+  priceIds: { starter: { monthly: string; annual: string }; pro: { monthly: string; annual: string } },
+  tier: string | undefined,
+  cadence: BillingCadence,
+): string | null {
+  if (tier === 'starter' || tier === 'pro') return priceIds[tier][cadence]
+  return null
+}

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -102,13 +102,6 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
           // selectable upgrade target so monthly→annual is a real path.
           const isCurrent = tier === currentTier && cadence === currentCadence
           const isSelected = tier === selectedTier
-          // Visual focal-point hint: when the toggle puts both cards on
-          // non-current cadence, the page has TWO selectable cards and
-          // neither should auto-highlight. When toggle is on current
-          // cadence, exactly one alternative exists — highlight it.
-          const availableCount = Object.keys(PLAN_CATALOG).length - (cadence === currentCadence && currentTier ? 1 : 0)
-          const isDefaultTarget =
-            selectedTier === null && !isCurrent && availableCount === 1
           return (
             <PlanCard
               key={tier}
@@ -120,7 +113,7 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
               tier={tier}
               onAction={(t) => setSelectedTier(t)}
               current={isCurrent}
-              selected={isSelected || isDefaultTarget}
+              selected={isSelected}
               ctaLabel={isSelected ? 'Selected' : 'Select'}
               ctaSubLabel={
                 isSelected && preview.isFetching

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
@@ -49,6 +49,18 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
   // they see reflects 'what would change' rather than always-Monthly.
   const [cadence, setCadence] = useState<BillingCadence>(currentCadence)
   const [selectedTier, setSelectedTier] = useState<PlanTier | null>(null)
+  // useState only captures currentCadence at mount. If the panel opens
+  // before /billing/subscription resolves (common: detail is fetched lazily
+  // when billing.subscription is truthy), currentCadence flips from the
+  // monthly default to the real value AFTER mount — and our cadence state
+  // would silently keep the stale default, mislabeling a Pro Annual user's
+  // panel as Pro Monthly. Sync once when detail resolves, BUT only if the
+  // user hasn't already touched the toggle themselves (don't clobber a
+  // deliberate cadence pick mid-interaction).
+  const userToggledRef = useRef(false)
+  useEffect(() => {
+    if (!userToggledRef.current) setCadence(currentCadence)
+  }, [currentCadence])
 
   const targetPriceId =
     selectedTier && config ? (config.price_ids[selectedTier][cadence] ?? null) : null
@@ -89,6 +101,7 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
       <CadenceToggle
         cadence={cadence}
         onChange={(next) => {
+          userToggledRef.current = true
           setCadence(next)
           setSelectedTier(null)
         }}

--- a/frontend/src/components/billing-interval-toggle.tsx
+++ b/frontend/src/components/billing-interval-toggle.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { cn } from "@/lib/utils"
 import { formatIntervalLabel } from "@/lib/paddle-format"

--- a/frontend/src/components/billing-interval-toggle.tsx
+++ b/frontend/src/components/billing-interval-toggle.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { cn } from "@/lib/utils"
+import { formatIntervalLabel } from "@/lib/paddle-format"
+
+export type BillingIntervalToggleProps = {
+  intervals: string[]
+  value: string
+  onValueChange: (value: string) => void
+  className?: string
+}
+
+export function BillingIntervalToggle({
+  intervals,
+  value,
+  onValueChange,
+  className,
+}: BillingIntervalToggleProps) {
+  return (
+    <Tabs value={value} onValueChange={onValueChange} className={cn("w-full", className)}>
+      <TabsList className="mx-auto flex w-fit">
+        {intervals.map((interval) => (
+          <TabsTrigger key={interval} value={interval}>
+            {formatIntervalLabel(interval)}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  )
+}

--- a/frontend/src/components/checkout-summary.tsx
+++ b/frontend/src/components/checkout-summary.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+import type { CheckoutSummaryData } from "@/lib/paddle-types"
+import {
+  formatMoney,
+  formatBillingCycle,
+} from "@/lib/paddle-format"
+
+/** Props for the `CheckoutSummary` component. */
+export type CheckoutSummaryProps = {
+  summary?: CheckoutSummaryData
+  policyUrl?: string
+  policyLabel?: string
+  className?: string
+}
+
+export function CheckoutSummary({
+  summary,
+  policyUrl,
+  policyLabel = "Refund policy",
+  className,
+}: CheckoutSummaryProps) {
+  if (!summary) {
+    return <CheckoutSummarySkeleton className={className} />
+  }
+
+  const {
+    items,
+    subtotal,
+    tax,
+    total,
+    discount,
+    currency,
+    recurringTotal,
+    recurringInterval,
+    recurringFrequency,
+    trialPeriod,
+  } = summary
+
+  const recurringInfo =
+    recurringTotal !== undefined && recurringInterval
+      ? (() => {
+          const cycleLabel = formatBillingCycle({
+            frequency: recurringFrequency ?? 1,
+            interval: recurringInterval,
+          })
+          const recurringAmount = formatMoney(recurringTotal, currency)
+          return cycleLabel ? `${recurringAmount} / ${cycleLabel}` : recurringAmount
+        })()
+      : undefined
+
+  return (
+    <Card className={cn("gap-4", className)}>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Order summary</CardTitle>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4">
+        <ul className="space-y-3">
+          {items.map((item, index) => (
+            <li key={index} className="flex items-start justify-between gap-4 text-sm">
+              <div className="min-w-0 flex-1">
+                <span className="font-medium">{item.name}</span>
+                {item.priceName && (
+                  <span className="text-muted-foreground"> — {item.priceName}</span>
+                )}
+                {item.quantity > 1 && (
+                  <span className="text-muted-foreground"> × {item.quantity}</span>
+                )}
+              </div>
+              <span className="shrink-0 tabular-nums">{formatMoney(item.lineTotal, currency)}</span>
+            </li>
+          ))}
+        </ul>
+
+        <Separator />
+
+        <dl className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">Subtotal</dt>
+            <dd className="tabular-nums">{formatMoney(subtotal, currency)}</dd>
+          </div>
+
+          {discount != null && discount > 0 && (
+            <div className="flex justify-between text-success-foreground">
+              <dt>Discount</dt>
+              <dd className="tabular-nums">−{formatMoney(discount, currency)}</dd>
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">Tax</dt>
+            <dd className="tabular-nums">{formatMoney(tax, currency)}</dd>
+          </div>
+
+          <Separator />
+
+          <div className="flex justify-between font-semibold">
+            <dt>Total</dt>
+            <dd className="tabular-nums">{formatMoney(total, currency)}</dd>
+          </div>
+        </dl>
+
+        {(recurringInfo || trialPeriod) && (
+          <p className="text-muted-foreground text-xs">
+            {trialPeriod && <span>{trialPeriod} free trial. </span>}
+            {recurringInfo && <span>Then {recurringInfo}.</span>}
+          </p>
+        )}
+
+        {policyUrl && (
+          <a
+            href={policyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground text-xs underline transition-colors"
+          >
+            {policyLabel}
+          </a>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function CheckoutSummarySkeleton({ className }: { className?: string }) {
+  return (
+    <Card className={cn("gap-4", className)}>
+      <CardHeader>
+        <Skeleton className="h-4 w-28" />
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="space-y-3">
+          <div className="flex justify-between gap-4">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+          <div className="flex justify-between gap-4">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </div>
+        <Separator />
+        <div className="space-y-2">
+          <div className="flex justify-between gap-4">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-14" />
+          </div>
+          <div className="flex justify-between gap-4">
+            <Skeleton className="h-4 w-8" />
+            <Skeleton className="h-4 w-14" />
+          </div>
+          <Separator />
+          <div className="flex justify-between gap-4">
+            <Skeleton className="h-4 w-10" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </div>
+        <Skeleton className="h-3 w-48" />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/inline-checkout.tsx
+++ b/frontend/src/components/inline-checkout.tsx
@@ -1,0 +1,245 @@
+import * as React from "react"
+"use client"
+
+import { CheckoutSummary } from "@/components/checkout-summary"
+import { useCheckout } from "@/hooks/use-checkout"
+import { addPaddleEventListener } from "@/lib/paddle-instance"
+import { mapCheckoutEventsToSummary } from "@/lib/checkout-summary-utils"
+import { cn } from "@/lib/utils"
+import {
+  CheckoutEventNames,
+  type Environments,
+  type CheckoutCustomer,
+  type CheckoutEventsData,
+  type PaddleEventData,
+  type CheckoutOpenLineItem,
+} from "@/lib/paddle-sdk-types"
+import type {
+  CheckoutCompleteData,
+  CheckoutSummaryData,
+} from "@/lib/paddle-types"
+
+const INLINE_CHECKOUT_FRAME_TARGET = "paddle-inline-checkout-frame"
+
+const SUMMARY_EVENT_NAMES = new Set([
+  CheckoutEventNames.CHECKOUT_LOADED,
+  CheckoutEventNames.CHECKOUT_UPDATED,
+  CheckoutEventNames.CHECKOUT_ITEMS_UPDATED,
+  CheckoutEventNames.CHECKOUT_CUSTOMER_CREATED,
+  CheckoutEventNames.CHECKOUT_CUSTOMER_UPDATED,
+  CheckoutEventNames.CHECKOUT_DISCOUNT_APPLIED,
+  CheckoutEventNames.CHECKOUT_DISCOUNT_REMOVED,
+])
+
+/** Props for the `InlineCheckout` component. */
+export type InlineCheckoutProps = {
+  clientToken: string
+  environment?: Environments
+  items: CheckoutOpenLineItem[]
+
+  variant?: "one-page" | "multi-page"
+  theme?: "light" | "dark"
+  locale?: string
+  /** Must be an absolute URL (starting with `https://` or `http://`) */
+  successUrl?: string
+  /** Controls where the order summary appears relative to the checkout frame. Defaults to "start" (summary on the left). */
+  summaryPosition?: "start" | "end" | "top" | "bottom"
+
+  customer?: CheckoutCustomer
+  customerAuthToken?: string
+  discountCode?: string
+  discountId?: string
+  customData?: Record<string, unknown>
+
+  policyUrl?: string
+  policyLabel?: string
+
+  /** Called when the Paddle checkout completes successfully */
+  onComplete?: (data: CheckoutCompleteData) => void
+  /** Called for every Paddle.js event emitted during checkout */
+  onEvent?: (event: PaddleEventData) => void
+  /** Called when the Paddle checkout fails to initialize or encounters an error */
+  onError?: (error: Error) => void
+
+  className?: string
+}
+
+export function InlineCheckout({
+  clientToken,
+  environment = "production",
+  items,
+  variant = "one-page",
+  theme,
+  locale,
+  successUrl,
+  summaryPosition = "start",
+  customer,
+  customerAuthToken,
+  discountCode,
+  discountId,
+  customData,
+  policyUrl,
+  policyLabel,
+  onComplete,
+  onEvent,
+  onError,
+  className,
+}: InlineCheckoutProps) {
+  const [summaryData, setSummaryData] = React.useState<CheckoutSummaryData | undefined>(undefined)
+  const [initError, setInitError] = React.useState<Error | null>(null)
+
+  // Ref avoids stale closure in event listener
+  const onEventRef = React.useRef(onEvent)
+  React.useEffect(() => {
+    onEventRef.current = onEvent
+  }, [onEvent])
+
+  const { openCheckout, updateItems, isReady } = useCheckout({
+    clientToken,
+    environment,
+    theme,
+    locale,
+    checkoutSettings: {
+      displayMode: "inline",
+      variant,
+      frameTarget: INLINE_CHECKOUT_FRAME_TARGET,
+      frameInitialHeight: 450,
+      frameStyle: "width: 100%; min-width: 312px; background-color: transparent; border: none;",
+    },
+    onComplete,
+    onError: (error) => {
+      setInitError(error)
+      onError?.(error)
+    },
+  })
+
+  // Stable ref — effects re-run only when actual values change
+  const stableCustomer = React.useMemo(
+    () => customer,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      customer?.id,
+      customer?.email,
+      customer?.address?.id,
+      customer?.address?.countryCode,
+      customer?.address?.postalCode,
+      customer?.address?.region,
+      customer?.address?.city,
+      customer?.address?.firstLine,
+      customer?.business?.id,
+      customer?.business?.name,
+      customer?.business?.taxIdentifier,
+    ]
+  )
+
+  const stableCustomData = React.useMemo(
+    () => customData,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(customData)]
+  )
+
+  const itemsKey = React.useMemo(
+    () => items.map((i) => `${i.priceId}:${i.quantity ?? 1}`).join(","),
+    [items]
+  )
+
+  const isOpenRef = React.useRef(false)
+  // Tracks the last itemsKey applied to the open checkout so we can skip the
+  // redundant updateItems call that would otherwise fire on the same render
+  // cycle as openCheckout when isReady first becomes true.
+  const prevItemsKeyRef = React.useRef<string | null>(null)
+
+  // Open checkout once Paddle is ready
+  React.useEffect(() => {
+    if (!isReady || items.length === 0) return
+
+    if (!isOpenRef.current) {
+      isOpenRef.current = true
+      openCheckout({
+        priceId: items[0]!.priceId,
+        items,
+        ...(stableCustomer && { customer: stableCustomer }),
+        ...(customerAuthToken && { customerAuthToken }),
+        ...(discountCode ? { discountCode } : discountId ? { discountId } : {}),
+        ...(stableCustomData && { customData: stableCustomData }),
+        ...(successUrl && { successUrl }),
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isReady])
+
+  // Update items reactively after mount
+  React.useEffect(() => {
+    if (!isReady || !isOpenRef.current) return
+
+    // First run after openCheckout — record the baseline key and skip the call.
+    // openCheckout already applied these items; calling updateItems immediately
+    // after would be a redundant SDK call.
+    if (prevItemsKeyRef.current === null) {
+      prevItemsKeyRef.current = itemsKey
+      return
+    }
+
+    if (prevItemsKeyRef.current === itemsKey) return
+    prevItemsKeyRef.current = itemsKey
+    updateItems(items.map((i) => ({ priceId: i.priceId, quantity: i.quantity ?? 1 })))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemsKey, isReady])
+
+  // Subscribe to all Paddle events: update summary + forward to onEvent
+  React.useEffect(() => {
+    const unsubscribe = addPaddleEventListener((event: PaddleEventData) => {
+      if (onEventRef.current) {
+        onEventRef.current(event)
+      }
+
+      if (event.name && SUMMARY_EVENT_NAMES.has(event.name) && event.data) {
+        setSummaryData(mapCheckoutEventsToSummary(event.data as CheckoutEventsData))
+      }
+    })
+
+    return unsubscribe
+  }, [])
+
+  if (initError) {
+    return (
+      <div
+        className={cn(
+          "rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive",
+          className
+        )}
+      >
+        Failed to open checkout. Please refresh and try again.
+      </div>
+    )
+  }
+
+  const isHorizontal = summaryPosition === "start" || summaryPosition === "end"
+  const summaryFirst = summaryPosition === "start" || summaryPosition === "top"
+
+  return (
+    <div
+      className={cn(
+        "flex gap-6",
+        isHorizontal ? "flex-col lg:flex-row lg:items-start" : "flex-col",
+        className
+      )}
+    >
+      {summaryFirst && (
+        <div className={cn("w-full", isHorizontal && "lg:w-72 lg:shrink-0")}>
+          <CheckoutSummary summary={summaryData} policyUrl={policyUrl} policyLabel={policyLabel} />
+        </div>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <div className={cn(INLINE_CHECKOUT_FRAME_TARGET, "w-full min-h-[450px]")} />
+      </div>
+
+      {!summaryFirst && (
+        <div className={cn("w-full", isHorizontal && "lg:w-72 lg:shrink-0")}>
+          <CheckoutSummary summary={summaryData} policyUrl={policyUrl} policyLabel={policyLabel} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/paddle-checkout-summary.tsx
+++ b/frontend/src/components/paddle-checkout-summary.tsx
@@ -1,0 +1,33 @@
+import { mapCheckoutEventsToSummary } from "@/lib/checkout-summary-utils"
+import { CheckoutSummary, type CheckoutSummaryProps } from "./checkout-summary"
+
+type CheckoutEventsInput = Parameters<typeof mapCheckoutEventsToSummary>[0]
+
+export type PaddleCheckoutSummaryProps = {
+  /**
+   * Raw `CheckoutEventsData` from a Paddle.js checkout event callback
+   * (e.g. `checkout.loaded`, `checkout.updated`).
+   */
+  checkoutData?: CheckoutEventsInput
+} & Omit<CheckoutSummaryProps, "summary">
+
+/**
+ * Paddle-aware wrapper for `CheckoutSummary`.
+ *
+ * Accepts raw `CheckoutEventsData` from Paddle.js checkout event callbacks,
+ * maps it to `CheckoutSummaryData`, and renders the order summary UI.
+ *
+ * Pass `undefined` to render the skeleton loading state.
+ *
+ * @example
+ * const [checkoutData, setCheckoutData] = useState<CheckoutEventsData>()
+ *
+ * <PaddleCheckoutSummary
+ *   checkoutData={checkoutData}
+ *   policyUrl="/legal/refunds"
+ * />
+ */
+export function PaddleCheckoutSummary({ checkoutData, ...uiProps }: PaddleCheckoutSummaryProps) {
+  const summary = checkoutData ? mapCheckoutEventsToSummary(checkoutData) : undefined
+  return <CheckoutSummary summary={summary} {...uiProps} />
+}

--- a/frontend/src/components/paddle-plan-change-breakdown.tsx
+++ b/frontend/src/components/paddle-plan-change-breakdown.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { mapPreviewToBreakdownData } from "@/lib/plan-change-breakdown-utils"
 import { PlanChangeBreakdown, type PlanChangeBreakdownProps } from "./plan-change-breakdown"
 

--- a/frontend/src/components/paddle-plan-change-breakdown.tsx
+++ b/frontend/src/components/paddle-plan-change-breakdown.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+import { mapPreviewToBreakdownData } from "@/lib/plan-change-breakdown-utils"
+import { PlanChangeBreakdown, type PlanChangeBreakdownProps } from "./plan-change-breakdown"
+
+type BreakdownPreviewResponse = Parameters<typeof mapPreviewToBreakdownData>[0]
+
+export type PaddlePlanChangeBreakdownProps = {
+  /** Subscription update preview response with the proposed changes */
+  previewResponse: BreakdownPreviewResponse
+} & Omit<PlanChangeBreakdownProps, "breakdown">
+
+/**
+ * Paddle-aware wrapper for `PlanChangeBreakdown`.
+ *
+ * Accepts the response from the Paddle preview update endpoint, maps it to
+ * `PlanChangeBreakdownData`, and renders the detailed financial breakdown UI.
+ *
+ * Pass `collectionMode` from the subscription to control billing terminology
+ * (e.g. "Invoice created" vs "Charged today").
+ *
+ * @example
+ * <PaddlePlanChangeBreakdown
+ *   previewResponse={previewResponse}
+ *   prorationBillingMode="prorated_immediately"
+ *   collectionMode={subscription.collectionMode}
+ * />
+ */
+export function PaddlePlanChangeBreakdown({
+  previewResponse,
+  ...uiProps
+}: PaddlePlanChangeBreakdownProps) {
+  const breakdown = mapPreviewToBreakdownData(previewResponse)
+  return <PlanChangeBreakdown breakdown={breakdown} {...uiProps} />
+}

--- a/frontend/src/components/paddle-plan-change-preview.tsx
+++ b/frontend/src/components/paddle-plan-change-preview.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { mapPreviewToPlanChangeData } from "@/lib/plan-change-preview-utils"
 import { PlanChangePreview, type PlanChangePreviewProps } from "./plan-change-preview"
 

--- a/frontend/src/components/paddle-plan-change-preview.tsx
+++ b/frontend/src/components/paddle-plan-change-preview.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { mapPreviewToPlanChangeData } from "@/lib/plan-change-preview-utils"
+import { PlanChangePreview, type PlanChangePreviewProps } from "./plan-change-preview"
+
+type PaddleSubscription = Parameters<typeof mapPreviewToPlanChangeData>[0]
+type PreviewResponse = Parameters<typeof mapPreviewToPlanChangeData>[1]
+type PaddleDiscount = Parameters<typeof mapPreviewToPlanChangeData>[2]
+
+export type PaddlePlanChangePreviewProps = {
+  /** Current Paddle Subscription (before the change) */
+  subscription: PaddleSubscription
+  /** Subscription update preview response with the proposed changes */
+  previewResponse: PreviewResponse
+  /** Paddle Discount for enriched discount display */
+  discount?: PaddleDiscount
+} & Omit<PlanChangePreviewProps, "preview">
+
+/**
+ * Paddle-aware wrapper for `PlanChangePreview`.
+ *
+ * Accepts the current subscription entity and the Paddle preview update response,
+ * maps them to `PlanChangePreviewData`, and renders the UI component.
+ *
+ * Pass `prorationBillingMode` through to control which billing row and label
+ * the component displays.
+ *
+ * `subscription.items[].price.unit_price` must be present for the current plan
+ * price to display correctly — fetch with full price details, not a list response.
+ *
+ * @example
+ * <PaddlePlanChangePreview
+ *   subscription={subscription}
+ *   previewResponse={previewResponse}
+ *   discount={discount}
+ *   prorationBillingMode="prorated_immediately"
+ * />
+ */
+export function PaddlePlanChangePreview({
+  subscription,
+  previewResponse,
+  discount,
+  ...uiProps
+}: PaddlePlanChangePreviewProps) {
+  const preview = mapPreviewToPlanChangeData(subscription, previewResponse, discount)
+  return <PlanChangePreview preview={preview} {...uiProps} />
+}

--- a/frontend/src/components/paddle-subscription-alert.tsx
+++ b/frontend/src/components/paddle-subscription-alert.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { mapSubscriptionToAlertData } from "@/lib/subscription-alert-utils"
 import { SubscriptionAlert, type SubscriptionAlertProps } from "./subscription-alert"
 

--- a/frontend/src/components/paddle-subscription-alert.tsx
+++ b/frontend/src/components/paddle-subscription-alert.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { mapSubscriptionToAlertData } from "@/lib/subscription-alert-utils"
+import { SubscriptionAlert, type SubscriptionAlertProps } from "./subscription-alert"
+
+type PaddleSubscription = Parameters<typeof mapSubscriptionToAlertData>[0]
+
+export type PaddleSubscriptionAlertProps = {
+  subscription: PaddleSubscription
+} & Omit<SubscriptionAlertProps, "subscription">
+
+/**
+ * Paddle-aware wrapper for `SubscriptionAlert`.
+ *
+ * Accepts the raw Paddle subscription entity, maps it to `SubscriptionAlertData`,
+ * and renders the UI component. All display-only props are passed through directly.
+ *
+ * @example
+ * <PaddleSubscriptionAlert
+ *   subscription={subscription}
+ *   className="mb-4"
+ * />
+ */
+export function PaddleSubscriptionAlert({
+  subscription,
+  ...uiProps
+}: PaddleSubscriptionAlertProps) {
+  const data = mapSubscriptionToAlertData(subscription)
+  return <SubscriptionAlert subscription={data} {...uiProps} />
+}

--- a/frontend/src/components/paddle-subscription-payment-card.tsx
+++ b/frontend/src/components/paddle-subscription-payment-card.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import {
   mapSubscriptionToNextPayment,
   mapTransactionToPaymentMethod,

--- a/frontend/src/components/paddle-subscription-payment-card.tsx
+++ b/frontend/src/components/paddle-subscription-payment-card.tsx
@@ -1,0 +1,63 @@
+import * as React from "react"
+import {
+  mapSubscriptionToNextPayment,
+  mapTransactionToPaymentMethod,
+  getUpdatePaymentMethodUrl,
+} from "@/lib/subscription-payment-card-utils"
+import {
+  SubscriptionPaymentCard,
+  type SubscriptionPaymentCardProps,
+} from "./subscription-payment-card"
+
+type SubscriptionInput = Parameters<typeof mapSubscriptionToNextPayment>[0]
+type NextTransactionInput = Parameters<typeof mapSubscriptionToNextPayment>[1]
+
+export type PaddleSubscriptionPaymentCardProps = {
+  /** Paddle Subscription */
+  subscription: SubscriptionInput
+  /**
+   * `next_transaction` include from the subscription fetch.
+   * Required for accurate next-bill amount. Fetch with:
+   * `paddle.subscriptions.get(id, { include: ["next_transaction"] })`
+   */
+  nextTransaction?: NextTransactionInput
+  /**
+   * Most recent completed transaction for the subscription.
+   * Used to determine the stored payment method. Fetch with:
+   * `paddle.transactions.list({ subscriptionId, status: ["completed"], perPage: 1 })`
+   */
+  lastTransaction?: NextTransactionInput
+} & Omit<SubscriptionPaymentCardProps, "nextPayment" | "paymentMethod" | "updatePaymentMethodUrl">
+
+/**
+ * Paddle-aware wrapper for `SubscriptionPaymentCard`.
+ *
+ * Accepts raw Paddle subscription and transaction entities, maps them to
+ * `NextPaymentData` and `PaymentMethodData`, and renders the UI component.
+ *
+ * @example
+ * <PaddleSubscriptionPaymentCard
+ *   subscription={subscription}
+ *   nextTransaction={subscription.nextTransaction}
+ *   lastTransaction={transactions.data[0]}
+ * />
+ */
+export function PaddleSubscriptionPaymentCard({
+  subscription,
+  nextTransaction,
+  lastTransaction,
+  ...uiProps
+}: PaddleSubscriptionPaymentCardProps) {
+  const nextPayment = mapSubscriptionToNextPayment(subscription, nextTransaction)
+  const paymentMethod = mapTransactionToPaymentMethod(lastTransaction)
+  const updatePaymentMethodUrl = getUpdatePaymentMethodUrl(subscription)
+
+  return (
+    <SubscriptionPaymentCard
+      nextPayment={nextPayment}
+      paymentMethod={paymentMethod}
+      updatePaymentMethodUrl={updatePaymentMethodUrl}
+      {...uiProps}
+    />
+  )
+}

--- a/frontend/src/components/paddle-subscription-status-card.tsx
+++ b/frontend/src/components/paddle-subscription-status-card.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { mapSubscriptionToStatusData } from "@/lib/subscription-status-card-utils"
 import {
   SubscriptionStatusCard,

--- a/frontend/src/components/paddle-subscription-status-card.tsx
+++ b/frontend/src/components/paddle-subscription-status-card.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { mapSubscriptionToStatusData } from "@/lib/subscription-status-card-utils"
+import {
+  SubscriptionStatusCard,
+  type SubscriptionStatusCardProps,
+} from "./subscription-status-card"
+
+type PaddleSubscription = Parameters<typeof mapSubscriptionToStatusData>[0]
+type RecurringTransactionDetails = Parameters<typeof mapSubscriptionToStatusData>[1]
+type PaddleDiscount = Parameters<typeof mapSubscriptionToStatusData>[2]
+
+export type PaddleSubscriptionStatusCardProps = {
+  subscription: PaddleSubscription
+  recurringTransactionDetails: RecurringTransactionDetails
+  discount?: PaddleDiscount
+} & Omit<SubscriptionStatusCardProps, "subscription">
+
+/**
+ * Paddle-aware wrapper for `SubscriptionStatusCard`.
+ *
+ * Accepts the raw Paddle subscription entity and `recurringTransactionDetails`
+ * (from `GET /subscriptions/{id}?include=recurring_transaction_details`),
+ * maps them to `SubscriptionStatusData`, and renders the UI component.
+ *
+ * Optionally pass a Paddle `Discount` to
+ * enrich the discount display with a code and derived description label.
+ *
+ * All display-only props (`onChangePlan`, `onManageSubscription`, etc.) are
+ * passed through directly.
+ *
+ * @example
+ * <PaddleSubscriptionStatusCard
+ *   subscription={subscription}
+ *   recurringTransactionDetails={subscription.recurringTransactionDetails}
+ *   onChangePlan={() => setShowPlanChange(true)}
+ * />
+ */
+export function PaddleSubscriptionStatusCard({
+  subscription,
+  recurringTransactionDetails,
+  discount,
+  ...uiProps
+}: PaddleSubscriptionStatusCardProps) {
+  const data = mapSubscriptionToStatusData(subscription, recurringTransactionDetails, discount)
+  return <SubscriptionStatusCard subscription={data} {...uiProps} />
+}

--- a/frontend/src/components/plan-change-breakdown.tsx
+++ b/frontend/src/components/plan-change-breakdown.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { TrendingDown, TrendingUp, Minus } from "lucide-react"
 import {
   Card,

--- a/frontend/src/components/plan-change-breakdown.tsx
+++ b/frontend/src/components/plan-change-breakdown.tsx
@@ -1,0 +1,361 @@
+"use client"
+
+import * as React from "react"
+import { TrendingDown, TrendingUp, Minus } from "lucide-react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+import type {
+  PlanChangeBreakdownData,
+  PlanChangeTransactionSectionData,
+} from "@/lib/paddle-types"
+import {
+  formatMoney,
+  formatDate,
+} from "@/lib/paddle-format"
+
+/** Props for the `PlanChangeBreakdown` component. */
+export type PlanChangeBreakdownProps = {
+  breakdown?: PlanChangeBreakdownData
+  /**
+   * Payment collection mode. From `subscription.collection_mode`.
+   * Affects section titles: "Charged Today" vs "Invoice Created" for immediate transactions.
+   */
+  collectionMode?: "automatic" | "manual"
+  className?: string
+}
+
+const SECTION_TITLES: Record<
+  "immediate" | "next" | "recurring",
+  { automatic: string; manual: string }
+> = {
+  immediate: { automatic: "Charged today", manual: "Invoice created" },
+  next: { automatic: "Next invoice", manual: "Next invoice" },
+  recurring: { automatic: "Ongoing billing", manual: "Ongoing billing" },
+}
+
+function TransactionSection({
+  section,
+  kind,
+  collectionMode = "automatic",
+  currency,
+}: {
+  section: PlanChangeTransactionSectionData
+  kind: "immediate" | "next" | "recurring"
+  collectionMode?: "automatic" | "manual"
+  currency: string
+}) {
+  const title = SECTION_TITLES[kind][collectionMode]
+
+  const description =
+    kind === "immediate"
+      ? collectionMode === "manual"
+        ? "An invoice will be created for this amount"
+        : "This amount will be charged immediately"
+      : kind === "next"
+        ? section.billingDate
+          ? `Charged on ${formatDate(section.billingDate)}`
+          : undefined
+        : "Recurring amount after this change"
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <h4 className="text-sm font-medium">{title}</h4>
+        {description && <p className="text-xs text-muted-foreground">{description}</p>}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {section.lineItems.map((item, index) => (
+          <div key={index} className="flex items-start justify-between gap-4 text-sm">
+            <div className="flex flex-col gap-0.5 min-w-0">
+              <span className="font-medium truncate">{item.productName}</span>
+              <span className="text-xs text-muted-foreground">
+                {item.quantity > 1 && `${item.quantity} \u00d7 `}
+                {formatMoney(item.unitPrice, currency)}
+                {item.isProrated && (
+                  <Badge variant="secondary" className="ml-1 text-[10px] px-1 py-0">
+                    Prorated
+                  </Badge>
+                )}
+              </span>
+              {item.prorationPeriod && (
+                <span className="text-xs text-muted-foreground">{item.prorationPeriod}</span>
+              )}
+            </div>
+            <span className="tabular-nums shrink-0">{formatMoney(item.total, currency)}</span>
+          </div>
+        ))}
+      </div>
+
+      <Separator />
+
+      <dl className="flex flex-col gap-1.5 text-sm">
+        <div className="flex justify-between gap-4">
+          <dt className="text-muted-foreground">Subtotal</dt>
+          <dd className="tabular-nums">{formatMoney(section.totals.subtotal, currency)}</dd>
+        </div>
+        {section.totals.discount !== undefined && (
+          <div className="flex justify-between gap-4">
+            <dt className="text-success-foreground">Discount</dt>
+            <dd className="tabular-nums text-success-foreground">
+              −{formatMoney(section.totals.discount, currency)}
+            </dd>
+          </div>
+        )}
+        <div className="flex justify-between gap-4">
+          <dt className="text-muted-foreground">Tax</dt>
+          <dd className="tabular-nums">{formatMoney(section.totals.tax, currency)}</dd>
+        </div>
+        {section.totals.credit !== undefined && (
+          <div className="flex justify-between gap-4">
+            <dt className="text-success-foreground">Credit applied</dt>
+            <dd className="tabular-nums text-success-foreground">
+              −{formatMoney(section.totals.credit, currency)}
+            </dd>
+          </div>
+        )}
+        {section.totals.creditToBalance !== undefined && (
+          <div className="flex justify-between gap-4">
+            <dt className="text-success-foreground">Credit to balance</dt>
+            <dd className="tabular-nums text-success-foreground">
+              {formatMoney(section.totals.creditToBalance, currency)}
+            </dd>
+          </div>
+        )}
+        <div className="flex justify-between gap-4 pt-1.5 border-t font-medium">
+          <dt>Total</dt>
+          <dd className="tabular-nums">{formatMoney(section.totals.total, currency)}</dd>
+        </div>
+      </dl>
+    </div>
+  )
+}
+
+export function PlanChangeBreakdown({
+  breakdown,
+  collectionMode,
+  className,
+}: PlanChangeBreakdownProps) {
+  if (!breakdown) {
+    return <PlanChangeBreakdownSkeleton className={className} />
+  }
+
+  const {
+    currency,
+    result,
+    breakdown: summaryBreakdown,
+    immediateTransaction,
+    nextTransaction,
+    recurringTransaction,
+  } = breakdown
+  const isCredit = result.direction === "credit"
+  const isNone = result.direction === "none"
+
+  const resultLabel = isNone
+    ? "No charge"
+    : isCredit
+      ? "Credit to account"
+      : immediateTransaction
+        ? "Amount due"
+        : "Added to next bill"
+
+  return (
+    <Card className={cn("flex flex-col", className)}>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Change summary</CardTitle>
+        <CardDescription>Review the financial impact of this change</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <div
+          className={cn(
+            "flex items-center justify-between rounded-lg p-4",
+            isCredit ? "bg-success/10" : "bg-muted"
+          )}
+        >
+          <div className="flex items-center gap-2">
+            {isCredit ? (
+              <TrendingDown className="size-5 text-success-foreground" />
+            ) : isNone ? (
+              <Minus className="size-5 text-muted-foreground" />
+            ) : (
+              <TrendingUp className="size-5 text-foreground" />
+            )}
+            <span className="font-medium">{resultLabel}</span>
+          </div>
+          <span
+            className={cn("text-lg font-bold tabular-nums", isCredit && "text-success-foreground")}
+          >
+            {isCredit
+              ? `−${formatMoney(result.amount, currency)}`
+              : formatMoney(result.amount, currency)}
+          </span>
+        </div>
+
+        {/* Credit/charge breakdown from update_summary */}
+        {summaryBreakdown &&
+          (summaryBreakdown.credit !== undefined || summaryBreakdown.charge !== undefined) && (
+            <div className="flex flex-col gap-2 text-sm">
+              {summaryBreakdown.credit !== undefined && (
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-muted-foreground">Credit from current plan</span>
+                  <span className="text-success-foreground tabular-nums">
+                    −{formatMoney(summaryBreakdown.credit, currency)}
+                  </span>
+                </div>
+              )}
+              {summaryBreakdown.charge !== undefined && (
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-muted-foreground">Charge for new plan</span>
+                  <span className="tabular-nums">
+                    {formatMoney(summaryBreakdown.charge, currency)}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
+        {immediateTransaction && (
+          <>
+            <Separator />
+            <TransactionSection
+              section={immediateTransaction}
+              kind="immediate"
+              collectionMode={collectionMode}
+              currency={currency}
+            />
+          </>
+        )}
+
+        {nextTransaction && (
+          <>
+            <Separator />
+            <TransactionSection
+              section={nextTransaction}
+              kind="next"
+              collectionMode={collectionMode}
+              currency={currency}
+            />
+          </>
+        )}
+
+        {recurringTransaction && (
+          <>
+            <Separator />
+            <TransactionSection
+              section={recurringTransaction}
+              kind="recurring"
+              collectionMode={collectionMode}
+              currency={currency}
+            />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function PlanChangeBreakdownSkeleton({ className }: { className?: string }) {
+  return (
+    <Card className={cn("flex flex-col", className)}>
+      <CardHeader>
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-3 w-56" />
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <div className="rounded-lg bg-muted p-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-5 w-5 rounded" />
+            <Skeleton className="h-4 w-28" />
+          </div>
+          <Skeleton className="h-6 w-16" />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex justify-between gap-4">
+            <Skeleton className="h-3 w-36" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+          <div className="flex justify-between gap-4">
+            <Skeleton className="h-3 w-32" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+          <div className="space-y-2">
+            <div className="flex justify-between gap-4">
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+              <Skeleton className="h-4 w-14" />
+            </div>
+          </div>
+          <Separator />
+          <div className="space-y-1.5">
+            <div className="flex justify-between gap-4">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-3 w-14" />
+            </div>
+            <div className="flex justify-between gap-4">
+              <Skeleton className="h-3 w-8" />
+              <Skeleton className="h-3 w-10" />
+            </div>
+            <div className="flex justify-between gap-4 pt-1.5 border-t">
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-14" />
+            </div>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-3 w-52" />
+          </div>
+          <div className="space-y-2">
+            <div className="flex justify-between gap-4">
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+              <Skeleton className="h-4 w-14" />
+            </div>
+          </div>
+          <Separator />
+          <div className="space-y-1.5">
+            <div className="flex justify-between gap-4">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-3 w-14" />
+            </div>
+            <div className="flex justify-between gap-4">
+              <Skeleton className="h-3 w-8" />
+              <Skeleton className="h-3 w-10" />
+            </div>
+            <div className="flex justify-between gap-4 pt-1.5 border-t">
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-14" />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/plan-change-preview.tsx
+++ b/frontend/src/components/plan-change-preview.tsx
@@ -1,0 +1,323 @@
+"use client"
+
+import * as React from "react"
+import { ArrowRight, AlertCircle } from "lucide-react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { cn } from "@/lib/utils"
+import type { PlanChangePreviewData } from "@/lib/paddle-types"
+import {
+  formatMoney,
+  formatDate,
+  formatBillingCycle,
+  formatProrationMode,
+} from "@/lib/paddle-format"
+
+/** Props for the `PlanChangePreview` component. */
+export type PlanChangePreviewProps = {
+  preview?: PlanChangePreviewData
+  /**
+   * Paddle proration billing mode passed to `PATCH /subscriptions/{id}/preview`.
+   * The component derives the billing row label and effective date from this value.
+   */
+  prorationBillingMode?:
+    | "prorated_immediately"
+    | "full_immediately"
+    | "prorated_next_billing_period"
+    | "full_next_billing_period"
+    | "do_not_bill"
+  className?: string
+}
+
+export function PlanChangePreview({
+  preview,
+  prorationBillingMode,
+  className,
+}: PlanChangePreviewProps) {
+  if (!preview) {
+    return <PlanChangePreviewSkeleton className={className} />
+  }
+
+  const {
+    currency,
+    currentPlan,
+    newPlan,
+    costImpact,
+    discount,
+    scheduledChange,
+    subscriptionStatus,
+    collectionMode,
+  } = preview
+  const isCharge = costImpact.resultDirection === "charge"
+  const isCredit = costImpact.resultDirection === "credit"
+  const isNeutral = costImpact.resultDirection === "none"
+  const isManual = collectionMode === "manual"
+  const isTrialing = subscriptionStatus === "trialing"
+
+  const changeType = isCharge ? "upgrade" : isCredit ? "downgrade" : "change"
+
+  const prorationLabel = prorationBillingMode
+    ? formatProrationMode(prorationBillingMode)
+    : undefined
+
+  const isImmediate =
+    prorationBillingMode?.includes("immediately") || prorationBillingMode === "do_not_bill"
+
+  function resolveEffectiveDate(): string | undefined {
+    if (prorationBillingMode) {
+      if (isImmediate) return "Immediately"
+      return costImpact.nextBillDate ? formatDate(costImpact.nextBillDate) : undefined
+    }
+    if (costImpact.immediateAmount !== undefined) return "Immediately"
+    return costImpact.nextBillDate ? formatDate(costImpact.nextBillDate) : undefined
+  }
+  const effectiveDate = resolveEffectiveDate()
+
+  function resolveScheduledChangeMessage(): string | undefined {
+    if (!scheduledChange) return undefined
+    if (scheduledChange.action === "resume") return undefined
+    const actionLabel = scheduledChange.action === "cancel" ? "Cancellation" : "Pause"
+    return `${actionLabel} scheduled for ${formatDate(scheduledChange.effectiveAt)}. Billing options may be restricted.`
+  }
+  const scheduledChangeMessage = resolveScheduledChangeMessage()
+
+  const hasBreakdownRows = costImpact.credit !== undefined || costImpact.charge !== undefined
+
+  const totalLabel = isCredit
+    ? "Credit to account"
+    : isNeutral
+      ? "No charge"
+      : isManual
+        ? "Invoice amount"
+        : costImpact.immediateAmount !== undefined
+          ? "Amount due now"
+          : "Amount at next billing"
+
+  const currentIntervalLabel =
+    formatBillingCycle({
+      interval: currentPlan.interval,
+      frequency: currentPlan.billingFrequency ?? 1,
+    }) ?? currentPlan.interval
+
+  const newIntervalLabel =
+    formatBillingCycle({
+      interval: newPlan.interval,
+      frequency: newPlan.billingFrequency ?? 1,
+    }) ?? newPlan.interval
+
+  return (
+    <Card className={cn("gap-4", className)}>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Change summary</CardTitle>
+        <CardDescription>Review the overview of this change</CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {scheduledChangeMessage && (
+          <Alert>
+            <AlertCircle className="size-4" />
+            <AlertDescription>{scheduledChangeMessage}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex items-stretch gap-3">
+          <div className="flex-1 min-w-0 rounded-lg border bg-muted/40 p-3">
+            <div className="text-xs text-muted-foreground mb-1">Current plan</div>
+            <div className="font-medium text-sm truncate">{currentPlan.productName}</div>
+            <div className="text-muted-foreground text-sm">
+              {formatMoney(currentPlan.price, currency)}
+              <span className="text-xs"> / {currentIntervalLabel}</span>
+            </div>
+          </div>
+
+          <div className="flex items-center shrink-0">
+            <ArrowRight className="size-4 text-muted-foreground" />
+          </div>
+
+          <div className="flex-1 min-w-0 rounded-lg border bg-primary/5 border-primary/20 p-3">
+            <div className="text-xs text-muted-foreground mb-1">New plan</div>
+            <div className="font-medium text-sm truncate">{newPlan.productName}</div>
+            <div className="text-muted-foreground text-sm">
+              {formatMoney(newPlan.price, currency)}
+              <span className="text-xs"> / {newIntervalLabel}</span>
+            </div>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Change type</span>
+            <Badge
+              variant={
+                changeType === "upgrade"
+                  ? "default"
+                  : changeType === "downgrade"
+                    ? "secondary"
+                    : "outline"
+              }
+            >
+              {changeType === "upgrade"
+                ? "Upgrade"
+                : changeType === "downgrade"
+                  ? "Downgrade"
+                  : "Change"}
+            </Badge>
+          </div>
+
+          {prorationLabel && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">Billing</span>
+              <span className="text-right">{prorationLabel}</span>
+            </div>
+          )}
+
+          {effectiveDate && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">Effective</span>
+              <span>{effectiveDate}</span>
+            </div>
+          )}
+
+          {discount && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">Discount</span>
+              <span className="text-right">
+                <span className="text-success-foreground">{discount.description}</span>
+                {discount.endsAt && (
+                  <span className="text-muted-foreground text-xs block">
+                    until {formatDate(discount.endsAt)}
+                  </span>
+                )}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <Separator />
+
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Current</span>
+            <span>
+              {formatMoney(currentPlan.price, currency)}
+              <span className="text-muted-foreground text-xs"> / {currentIntervalLabel}</span>
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">New</span>
+            <span>
+              {formatMoney(newPlan.price, currency)}
+              <span className="text-muted-foreground text-xs"> / {newIntervalLabel}</span>
+            </span>
+          </div>
+        </div>
+
+        {/* Financial summary — credit/charge breakdown + total row */}
+        {(hasBreakdownRows || !isNeutral) && (
+          <>
+            <Separator />
+            <div className="space-y-1.5">
+              {costImpact.credit !== undefined && (
+                <div className="flex items-center justify-between text-sm text-success-foreground">
+                  <span>Credit</span>
+                  <span>−{formatMoney(costImpact.credit, currency)}</span>
+                </div>
+              )}
+              {costImpact.charge !== undefined && (
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Charge</span>
+                  <span>{formatMoney(costImpact.charge, currency)}</span>
+                </div>
+              )}
+              <div
+                className={cn(
+                  "flex items-center justify-between font-medium",
+                  hasBreakdownRows && "pt-1.5 border-t"
+                )}
+              >
+                <span>{totalLabel}</span>
+                <span className={cn(isCredit && "text-success-foreground")}>
+                  {isCredit ? "−" : ""}
+                  {formatMoney(costImpact.resultAmount, currency)}
+                </span>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Contextual notes derived from subscription state */}
+        {isTrialing && isNeutral && (
+          <p className="text-xs text-muted-foreground">
+            No charges during your trial. Billing begins when your trial ends.
+          </p>
+        )}
+        {isManual && isCharge && (
+          <p className="text-xs text-muted-foreground">
+            An invoice will be created for this amount.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function PlanChangePreviewSkeleton({ className }: { className?: string }) {
+  return (
+    <Card className={cn("gap-4", className)}>
+      <CardHeader>
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-3 w-52" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-stretch gap-3">
+          <div className="flex-1 rounded-lg border bg-muted/40 p-3 space-y-2">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+          <div className="flex items-center">
+            <Skeleton className="h-4 w-4 rounded" />
+          </div>
+          <div className="flex-1 rounded-lg border p-3 space-y-2">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
+        <Separator />
+        <div className="space-y-2">
+          <div className="flex justify-between">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-5 w-16" />
+          </div>
+          <div className="flex justify-between">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+        </div>
+        <Separator />
+        <div className="space-y-1.5">
+          <div className="flex justify-between">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+          <div className="flex justify-between">
+            <Skeleton className="h-4 w-8" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/plan-change-preview.tsx
+++ b/frontend/src/components/plan-change-preview.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { ArrowRight, AlertCircle } from "lucide-react"
 import {
   Card,

--- a/frontend/src/components/pricing-select-card-grid.tsx
+++ b/frontend/src/components/pricing-select-card-grid.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"

--- a/frontend/src/components/pricing-select-card-grid.tsx
+++ b/frontend/src/components/pricing-select-card-grid.tsx
@@ -1,0 +1,105 @@
+import * as React from "react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+import { CheckIcon } from "lucide-react"
+import type { PriceData } from "@/lib/paddle-types"
+
+export type PricingSelectCardGridProps = {
+  priceId: string
+  name: string
+  priceData?: PriceData
+  description?: string
+  badge?: string
+  badgePosition?: "left" | "center" | "right"
+  isCurrent?: boolean
+  currentPlanLabel?: string
+  showInterval?: boolean
+  loading?: boolean
+  className?: string
+}
+
+export function PricingSelectCardGrid({
+  priceId,
+  name,
+  priceData,
+  description,
+  badge,
+  badgePosition = "center",
+  isCurrent = false,
+  currentPlanLabel = "Current plan",
+  showInterval = true,
+  loading = false,
+  className,
+}: PricingSelectCardGridProps) {
+  const { total, originalTotal, interval, trialPeriod } = priceData ?? {}
+
+  const showBadges = badge || isCurrent
+
+  if (loading) {
+    return (
+      <Card className={cn("relative p-5 text-center", className)}>
+        <Skeleton className="mx-auto mb-2 h-5 w-20" />
+        <Skeleton className="mx-auto mb-6 h-8 w-24" />
+        <Skeleton className="mx-auto h-5 w-5 rounded-full" />
+      </Card>
+    )
+  }
+
+  return (
+    <RadioGroupPrimitive.Item value={priceId} disabled={isCurrent} asChild>
+      <Card
+        className={cn(
+          "relative flex cursor-pointer flex-col items-center justify-center overflow-visible rounded-lg border p-5 shadow-none transition-all hover:shadow-md",
+          "data-[state=checked]:border-2 data-[state=checked]:border-primary data-[state=checked]:bg-primary/5",
+          isCurrent && "cursor-default border-muted bg-muted/30 hover:shadow-none",
+          className
+        )}
+      >
+        {showBadges && (
+          <div
+            className={cn(
+              "absolute -top-3 z-10 flex gap-1.5",
+              badgePosition === "left" && "left-4",
+              badgePosition === "center" && "left-1/2 -translate-x-1/2",
+              badgePosition === "right" && "right-4"
+            )}
+          >
+            {badge && <Badge className="bg-primary text-primary-foreground">{badge}</Badge>}
+            {isCurrent && <Badge variant="secondary">{currentPlanLabel}</Badge>}
+          </div>
+        )}
+
+        <CardHeader className="flex-1 p-0 flex flex-col items-center justify-center text-center">
+          <CardTitle className="text-base font-medium">{name}</CardTitle>
+          {description && <div className="text-muted-foreground text-xs mt-0.5">{description}</div>}
+          {originalTotal && (
+            <div className="text-muted-foreground text-sm line-through mt-2">{originalTotal}</div>
+          )}
+          <div className="text-2xl font-bold mt-2">{total}</div>
+          {showInterval && interval && (
+            <div className="text-muted-foreground text-xs">per {interval}</div>
+          )}
+          {trialPeriod && (
+            <div className="text-muted-foreground text-xs mt-1">{trialPeriod} free trial</div>
+          )}
+        </CardHeader>
+
+        <CardContent className="mt-6 flex items-center justify-center p-0">
+          <RadioGroupPrimitive.Indicator asChild forceMount>
+            <div
+              className={cn(
+                "group flex aspect-square size-5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                "border-input data-[state=checked]:border-primary data-[state=checked]:bg-primary"
+              )}
+            >
+              <CheckIcon className="size-4 text-primary-foreground opacity-0 group-data-[state=checked]:opacity-100 transition-opacity" />
+            </div>
+          </RadioGroupPrimitive.Indicator>
+        </CardContent>
+      </Card>
+    </RadioGroupPrimitive.Item>
+  )
+}

--- a/frontend/src/components/pricing-select-card-group.tsx
+++ b/frontend/src/components/pricing-select-card-group.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import * as React from "react"
+import { RadioGroup } from "@/components/ui/radio-group"
+import { cn } from "@/lib/utils"
+
+export type PricingSelectCardGroupProps = {
+  children: React.ReactNode
+  value: string
+  onValueChange: (value: string) => void
+  layout?: "stacked" | "grid"
+  className?: string
+}
+
+export function PricingSelectCardGroup({
+  children,
+  value,
+  onValueChange,
+  layout = "stacked",
+  className,
+}: PricingSelectCardGroupProps) {
+  const layoutClasses = {
+    stacked: "flex flex-col gap-3",
+    grid: "grid grid-cols-2 gap-4",
+  }
+
+  return (
+    <RadioGroup
+      value={value}
+      onValueChange={onValueChange}
+      className={cn(layoutClasses[layout], className)}
+    >
+      {children}
+    </RadioGroup>
+  )
+}

--- a/frontend/src/components/pricing-select-card-stacked.tsx
+++ b/frontend/src/components/pricing-select-card-stacked.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import * as React from "react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+import { Card, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+import type { PriceData } from "@/lib/paddle-types"
+
+export type PricingSelectCardStackedProps = {
+  priceId: string
+  name: string
+  priceData?: PriceData
+  description?: string
+  badge?: string
+  badgePosition?: "left" | "center" | "right"
+  icon?: React.ReactNode
+  isCurrent?: boolean
+  currentPlanLabel?: string
+  showInterval?: boolean
+  loading?: boolean
+  className?: string
+}
+
+export function PricingSelectCardStacked({
+  priceId,
+  name,
+  priceData,
+  description,
+  badge,
+  badgePosition = "center",
+  icon,
+  isCurrent = false,
+  currentPlanLabel = "Current plan",
+  showInterval = true,
+  loading = false,
+  className,
+}: PricingSelectCardStackedProps) {
+  const { total, originalTotal, interval, trialPeriod } = priceData ?? {}
+
+  const showBadges = badge || isCurrent
+
+  if (loading) {
+    return (
+      <Card className={cn("relative p-6", className)}>
+        <Skeleton className="mb-2 h-4 w-24" />
+        <Skeleton className="mb-1 h-8 w-32" />
+        <Skeleton className="h-3 w-16" />
+        {icon && <Skeleton className="absolute top-6 right-6 h-12 w-12 rounded-lg" />}
+      </Card>
+    )
+  }
+
+  return (
+    <RadioGroupPrimitive.Item value={priceId} disabled={isCurrent} asChild>
+      <Card
+        className={cn(
+          "relative flex cursor-pointer flex-col overflow-visible rounded-lg border p-6 shadow-sm transition-all hover:shadow-md",
+          "data-[state=checked]:border-2 data-[state=checked]:border-primary data-[state=checked]:bg-primary/5",
+          isCurrent && "cursor-default border-muted bg-muted/30 hover:shadow-sm",
+          className
+        )}
+      >
+        {showBadges && (
+          <div
+            className={cn(
+              "absolute -top-3 z-10 flex gap-1.5",
+              badgePosition === "left" && "left-4",
+              badgePosition === "center" && "left-1/2 -translate-x-1/2",
+              badgePosition === "right" && "right-4"
+            )}
+          >
+            {badge && <Badge className="bg-primary text-primary-foreground">{badge}</Badge>}
+            {isCurrent && <Badge variant="secondary">{currentPlanLabel}</Badge>}
+          </div>
+        )}
+
+        <div className="flex items-start justify-between">
+          <CardHeader className="p-0">
+            <div className="text-muted-foreground mb-1 text-sm">{description || name}</div>
+            {originalTotal && (
+              <div className="text-muted-foreground text-sm line-through">{originalTotal}</div>
+            )}
+            <CardTitle className="text-3xl font-bold">{total}</CardTitle>
+            {showInterval && interval && (
+              <div className="text-muted-foreground text-sm">per {interval}</div>
+            )}
+            {trialPeriod && (
+              <div className="text-muted-foreground text-xs mt-1">{trialPeriod} free trial</div>
+            )}
+          </CardHeader>
+
+          {icon && <div className="h-12 w-12 shrink-0 rounded-lg">{icon}</div>}
+        </div>
+      </Card>
+    </RadioGroupPrimitive.Item>
+  )
+}

--- a/frontend/src/components/pricing-select-card.tsx
+++ b/frontend/src/components/pricing-select-card.tsx
@@ -1,0 +1,22 @@
+export {
+  PricingSelectCardStacked,
+  type PricingSelectCardStackedProps,
+} from "./pricing-select-card-stacked"
+export { PricingSelectCardGrid, type PricingSelectCardGridProps } from "./pricing-select-card-grid"
+export {
+  PricingSelectCardGroup,
+  type PricingSelectCardGroupProps,
+} from "./pricing-select-card-group"
+
+/**
+ * Plan configuration for use with PricingSelectCardGroup and ExpressCheckout.
+ * Maps to a single Paddle price ID — pass an array of these to describe
+ * the selectable plans in a checkout or pricing selector.
+ */
+export type PricingSelectPlan = {
+  priceId: string
+  name: string
+  description?: string
+  badge?: string
+  icon?: React.ReactNode
+}

--- a/frontend/src/components/subscription-alert.tsx
+++ b/frontend/src/components/subscription-alert.tsx
@@ -1,0 +1,74 @@
+import * as React from "react"
+import { AlertCircle, Info, TriangleAlert, X } from "lucide-react"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { cn } from "@/lib/utils"
+import type { SubscriptionAlertData } from "@/lib/paddle-types"
+import {
+  deriveSubscriptionAlert,
+  type AlertVariant,
+} from "@/lib/subscription-alert-utils"
+
+/** Props for the `SubscriptionAlert` component. */
+export type SubscriptionAlertProps = {
+  subscription?: SubscriptionAlertData
+  onDismiss?: () => void
+  className?: string
+}
+
+const VARIANT_CONFIG: Record<AlertVariant, { icon: React.ElementType; className: string }> = {
+  destructive: {
+    icon: AlertCircle,
+    className: "border-destructive/50 bg-destructive/15 text-destructive [&>svg]:text-destructive",
+  },
+  warning: {
+    icon: TriangleAlert,
+    className:
+      "border-warning/40 bg-warning/15 text-warning-foreground [&>svg]:text-warning-foreground",
+  },
+  info: {
+    icon: Info,
+    className: "border-info/40 bg-info/15 text-info-foreground [&>svg]:text-info-foreground",
+  },
+}
+
+export function SubscriptionAlert({ subscription, onDismiss, className }: SubscriptionAlertProps) {
+  const alert = deriveSubscriptionAlert(subscription)
+
+  if (!alert) return null
+
+  const config = VARIANT_CONFIG[alert.variant]
+  const Icon = config.icon
+
+  return (
+    <Alert className={cn("relative", config.className, className)}>
+      <Icon className="size-4" />
+      <AlertDescription className="flex items-center justify-between gap-4 text-inherit">
+        <span>
+          {alert.message}
+          {alert.actionUrl && alert.actionLabel && (
+            <>
+              {" "}
+              <a
+                href={alert.actionUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline underline-offset-2 hover:no-underline"
+              >
+                {alert.actionLabel}
+              </a>
+            </>
+          )}
+        </span>
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            aria-label="Dismiss alert"
+            className="shrink-0 rounded-sm opacity-60 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/frontend/src/components/subscription-payment-card.tsx
+++ b/frontend/src/components/subscription-payment-card.tsx
@@ -1,0 +1,182 @@
+"use client"
+
+import * as React from "react"
+import { CreditCard, Calendar, ExternalLink } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+import type {
+  NextPaymentData,
+  PaymentMethodData,
+} from "@/lib/paddle-types"
+import { getPaymentMethodDisplay } from "@/lib/paddle-payment-method-display"
+import { getPaymentMethodIcon } from "@/lib/payment-method-icons"
+import {
+  formatMoney,
+  formatDate,
+} from "@/lib/paddle-format"
+
+export type SubscriptionPaymentCardProps = {
+  /**
+   * Next payment details. Absent when subscription is paused or canceled.
+   *
+   * Pass `undefined` for all three data props (`nextPayment`, `paymentMethod`,
+   * `updatePaymentMethodUrl`) to render the skeleton loading state.
+   */
+  nextPayment?: NextPaymentData
+  /**
+   * Payment method details. Pass raw fields from `transaction.payments[0].method_details`
+   * — the component resolves the display label automatically.
+   * Absent when not available from transaction history.
+   */
+  paymentMethod?: PaymentMethodData
+  /** Portal deep link to update payment method. Absent for manual collection. */
+  updatePaymentMethodUrl?: string
+  className?: string
+}
+
+export function SubscriptionPaymentCard({
+  nextPayment,
+  paymentMethod,
+  updatePaymentMethodUrl,
+  className,
+}: SubscriptionPaymentCardProps) {
+  const isLoading =
+    nextPayment === undefined && paymentMethod === undefined && updatePaymentMethodUrl === undefined
+
+  if (isLoading) {
+    return <SubscriptionPaymentCardSkeleton className={className} />
+  }
+
+  const displayLabel = paymentMethod
+    ? (paymentMethod.label ??
+      getPaymentMethodDisplay(paymentMethod.type, paymentMethod.cardBrand, paymentMethod.last4))
+    : undefined
+
+  const PaymentMethodIcon = paymentMethod
+    ? (getPaymentMethodIcon(paymentMethod.type, paymentMethod.cardBrand) ?? CreditCard)
+    : CreditCard
+
+  const expiryLabel =
+    paymentMethod?.expiryMonth !== undefined && paymentMethod?.expiryYear !== undefined
+      ? `Expires ${String(paymentMethod.expiryMonth).padStart(2, "0")}/${String(paymentMethod.expiryYear).slice(-2)}`
+      : undefined
+
+  return (
+    <Card className={cn("gap-4", className)}>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Payment</CardTitle>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4">
+        <PaymentInfoRow icon={Calendar} label="Next payment">
+          {nextPayment ? (
+            <>
+              <div className="font-semibold">
+                {formatMoney(nextPayment.amount, nextPayment.currency)}
+              </div>
+              <div className="text-sm text-muted-foreground">{formatDate(nextPayment.date)}</div>
+            </>
+          ) : (
+            <div className="text-sm font-medium text-muted-foreground">No upcoming payment</div>
+          )}
+        </PaymentInfoRow>
+
+        {displayLabel && (
+          <>
+            <Separator />
+            <div className="flex items-center justify-between gap-4">
+              <PaymentInfoRow icon={PaymentMethodIcon} label="Payment method">
+                <div className="text-sm font-medium truncate">{displayLabel}</div>
+                {expiryLabel && <div className="text-xs text-muted-foreground">{expiryLabel}</div>}
+              </PaymentInfoRow>
+
+              {updatePaymentMethodUrl && (
+                <a
+                  href={updatePaymentMethodUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-sm font-medium text-primary hover:underline shrink-0"
+                >
+                  Update
+                  <ExternalLink className="size-3" />
+                </a>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Update link when no payment method but URL is available */}
+        {!displayLabel && updatePaymentMethodUrl && (
+          <>
+            <Separator />
+            <a
+              href={updatePaymentMethodUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+            >
+              <CreditCard className="size-4" />
+              Update payment method
+              <ExternalLink className="size-3 ml-0.5" />
+            </a>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function PaymentInfoRow({
+  icon: Icon,
+  label,
+  children,
+}: {
+  icon: React.ElementType
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
+        <Icon className="size-4 text-muted-foreground" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-sm text-muted-foreground">{label}</div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function SubscriptionPaymentCardSkeleton({ className }: { className?: string }) {
+  return (
+    <Card className={cn("gap-4", className)}>
+      <CardHeader>
+        <Skeleton className="h-4 w-20" />
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex items-start gap-3">
+          <Skeleton className="size-8 rounded-md shrink-0" />
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+        </div>
+        <Separator />
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Skeleton className="size-8 rounded-md shrink-0" />
+            <div className="space-y-1.5">
+              <Skeleton className="h-3 w-28" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          </div>
+          <Skeleton className="h-4 w-14" />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/subscription-status-card.tsx
+++ b/frontend/src/components/subscription-status-card.tsx
@@ -1,0 +1,466 @@
+"use client"
+
+import * as React from "react"
+import {
+  CheckCircle2,
+  Clock,
+  AlertCircle,
+  PauseCircle,
+  MinusCircle,
+  Sparkles,
+  CalendarIcon,
+  CreditCardIcon,
+  FileTextIcon,
+} from "lucide-react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+import type { SubscriptionStatusData } from "@/lib/paddle-types"
+import {
+  formatMoney,
+  formatDate,
+  formatBillingCycle,
+} from "@/lib/paddle-format"
+
+export type SubscriptionStatusCardProps = {
+  subscription?: SubscriptionStatusData
+  /** Override the card title. Defaults to the first item's product name (single-item) or "Subscription" (multi-item). */
+  title?: string
+  /** Position of the status badge: "inline" next to name, or "end" aligned to card end */
+  statusBadgePosition?: "inline" | "end"
+  /**
+   * Called when the user clicks "Change plan".
+   * Only rendered when status is not `paused` or `canceled` — paused
+   * subscriptions must be resumed before items can be changed, and canceled
+   * is a terminal state.
+   */
+  onChangePlan?: () => void
+  /**
+   * Called when the user clicks "Update payment method".
+   * Only rendered for automatically-collected subscriptions that are not
+   * `paused` or `canceled` — manual subscriptions are invoice-based (no saved
+   * payment method), paused subscriptions have no active billing, and canceled
+   * is terminal.
+   */
+  onUpdatePaymentMethod?: () => void
+  /**
+   * Called when the user clicks "Manage". Always rendered when provided —
+   * the action is consumer-defined (portal link, modal, resubscribe flow, etc.)
+   * and not restricted by Paddle subscription status.
+   */
+  onManageSubscription?: () => void
+  className?: string
+}
+
+// --- Status badge ---
+
+type SubscriptionStatus = "active" | "canceled" | "past_due" | "paused" | "trialing"
+
+const STATUS_CONFIG: Record<
+  SubscriptionStatus,
+  { label: string; icon: React.ElementType; className: string }
+> = {
+  active: {
+    label: "Active",
+    icon: CheckCircle2,
+    className: "bg-success/15 text-success-foreground border-success/30",
+  },
+  trialing: {
+    label: "Trial",
+    icon: Sparkles,
+    className: "bg-info/15 text-info-foreground border-info/30",
+  },
+  past_due: {
+    label: "Past due",
+    icon: AlertCircle,
+    className: "bg-destructive/15 text-destructive border-destructive/30",
+  },
+  paused: {
+    label: "Paused",
+    icon: PauseCircle,
+    className: "bg-warning/15 text-warning-foreground border-warning/30",
+  },
+  canceled: {
+    label: "Canceled",
+    icon: MinusCircle,
+    className: "bg-muted text-muted-foreground border-border",
+  },
+}
+
+function StatusBadge({ status }: { status: SubscriptionStatus }) {
+  const config = STATUS_CONFIG[status] ?? {
+    label: status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+    icon: AlertCircle,
+    className: "bg-muted text-muted-foreground border-border",
+  }
+  const Icon = config.icon
+  return (
+    <Badge variant="outline" className={cn("gap-1 font-medium", config.className)}>
+      <Icon className="size-3" />
+      {config.label}
+    </Badge>
+  )
+}
+
+// --- Scheduled change validity ---
+
+/**
+ * Returns the scheduledChange only when it is valid for the given status.
+ * Impossible combinations (e.g. resume on active, cancel on paused, any
+ * scheduled change on canceled) are suppressed so the component never
+ * renders misleading alerts.
+ */
+function getValidScheduledChange(
+  status: SubscriptionStatus,
+  scheduledChange?: SubscriptionStatusData["scheduledChange"]
+): SubscriptionStatusData["scheduledChange"] | undefined {
+  if (!scheduledChange) return undefined
+  switch (status) {
+    case "canceled":
+      return undefined
+    case "paused":
+      return scheduledChange.action === "resume" ? scheduledChange : undefined
+    default:
+      return scheduledChange.action === "resume" ? undefined : scheduledChange
+  }
+}
+
+// --- Footer billing label ---
+
+function getNextBillingLabel(
+  status: SubscriptionStatus,
+  scheduledChange?: SubscriptionStatusData["scheduledChange"]
+): string | undefined {
+  if (scheduledChange?.action === "cancel" || scheduledChange?.action === "pause") {
+    return undefined
+  }
+  switch (status) {
+    case "trialing":
+      return "First billing"
+    case "past_due":
+      return "Payment due"
+    case "active":
+      return "Next billing"
+    default:
+      return undefined
+  }
+}
+
+// --- Button visibility rules ---
+
+/**
+ * "Change plan" is available for active, trialing, and past_due subscriptions.
+ * Paused subscriptions must be resumed before items can be changed.
+ * Canceled is a terminal state.
+ */
+function canShowChangePlan(status: SubscriptionStatus): boolean {
+  return status !== "paused" && status !== "canceled"
+}
+
+/**
+ * "Update payment method" requires automatic collection and an active billing
+ * relationship. Manual subscriptions are invoice-based — no saved payment
+ * method exists. Paused subscriptions have no active billing. Canceled is
+ * terminal.
+ */
+function canShowUpdatePaymentMethod(
+  status: SubscriptionStatus,
+  collectionMode?: "automatic" | "manual"
+): boolean {
+  return status !== "canceled" && status !== "paused" && collectionMode !== "manual"
+}
+
+// --- Main component ---
+
+export function SubscriptionStatusCard({
+  subscription,
+  title: titleOverride,
+  statusBadgePosition = "end",
+  onChangePlan,
+  onUpdatePaymentMethod,
+  onManageSubscription,
+  className,
+}: SubscriptionStatusCardProps) {
+  if (!subscription) {
+    return <SubscriptionStatusCardSkeleton className={className} />
+  }
+
+  const {
+    items,
+    totalAmount,
+    currency,
+    interval,
+    billingFrequency,
+    status,
+    nextBilledAt,
+    canceledAt,
+    collectionMode,
+    scheduledChange,
+    discount,
+  } = subscription
+
+  const isSingleItem = items.length === 1
+  const primaryItem = items[0]
+  const isPastDue = status === "past_due"
+
+  const effectiveScheduledChange = getValidScheduledChange(status, scheduledChange)
+
+  const showChangePlan = !!onChangePlan && canShowChangePlan(status)
+  const showUpdatePayment =
+    !!onUpdatePaymentMethod && canShowUpdatePaymentMethod(status, collectionMode)
+  const showManage = !!onManageSubscription
+  const hasActions = showChangePlan || showUpdatePayment || showManage
+
+  const cardTitle =
+    titleOverride ?? (isSingleItem ? primaryItem?.productName : undefined) ?? "Subscription"
+
+  const billingIntervalLabel =
+    formatBillingCycle({ interval, frequency: billingFrequency ?? 1 }) ?? interval
+
+  const scheduledChangeNote = effectiveScheduledChange
+    ? effectiveScheduledChange.action === "cancel"
+      ? `Cancels on ${formatDate(effectiveScheduledChange.effectiveAt)}`
+      : effectiveScheduledChange.action === "pause"
+        ? `Pauses on ${formatDate(effectiveScheduledChange.effectiveAt)}`
+        : effectiveScheduledChange.action === "resume"
+          ? `Resumes on ${formatDate(effectiveScheduledChange.effectiveAt)}`
+          : undefined
+    : undefined
+
+  const nextBillingLabel = getNextBillingLabel(status, effectiveScheduledChange)
+
+  return (
+    <Card
+      className={cn("gap-4", className)}
+      data-status={status}
+      data-past-due={isPastDue || undefined}
+    >
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <CardTitle className="truncate">{cardTitle}</CardTitle>
+              {statusBadgePosition === "inline" && <StatusBadge status={status} />}
+            </div>
+            {isSingleItem && primaryItem?.priceName && (
+              <CardDescription>{primaryItem.priceName}</CardDescription>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {statusBadgePosition === "end" && <StatusBadge status={status} />}
+            {isSingleItem && primaryItem?.productImageUrl && (
+              <img
+                src={primaryItem.productImageUrl}
+                alt={primaryItem.productName}
+                className="size-12 rounded-md object-cover"
+              />
+            )}
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        {isPastDue && (
+          <Alert variant="destructive">
+            <AlertCircle className="size-4" />
+            <AlertTitle>
+              {collectionMode === "manual" ? "Invoice overdue" : "Payment required"}
+            </AlertTitle>
+            <AlertDescription>
+              {collectionMode === "manual"
+                ? "Pay your outstanding invoice to avoid disruption."
+                : "Your subscription is past due. Update your payment method to avoid disruption."}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {scheduledChangeNote && (
+          <Alert>
+            <Clock className="size-4" />
+            <AlertTitle>Scheduled change</AlertTitle>
+            <AlertDescription>{scheduledChangeNote}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-2">
+          {items.map((item, index) => (
+            <div
+              key={index}
+              className={cn(
+                "flex items-center justify-between gap-4",
+                index > 0 && "pt-2 border-t"
+              )}
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                {item.productImageUrl && items.length > 1 && (
+                  <img
+                    src={item.productImageUrl}
+                    alt={item.productName}
+                    className="size-6 rounded object-cover shrink-0"
+                  />
+                )}
+                <div className="min-w-0 space-y-0.5">
+                  <p className="text-sm font-medium truncate">{item.productName}</p>
+                  {item.quantity > 1 && item.unitPrice !== undefined && (
+                    <p className="text-sm text-muted-foreground">
+                      {item.quantity} &times; {formatMoney(item.unitPrice, currency)}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <p className="text-sm font-medium shrink-0 tabular-nums">
+                {formatMoney(item.lineTotal, currency)}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <Separator />
+
+        <div className="space-y-1.5">
+          {discount && (
+            <div className="flex items-center justify-between text-success-foreground">
+              <span className="text-sm flex items-center gap-1.5">
+                Discount
+                {discount.code && (
+                  <span className="text-xs bg-success/10 px-1.5 py-0.5 rounded">
+                    {discount.code}
+                  </span>
+                )}
+                {discount.endsAt && (
+                  <span className="text-xs text-muted-foreground">
+                    until {formatDate(discount.endsAt)}
+                  </span>
+                )}
+              </span>
+              <span className="text-sm tabular-nums">
+                {discount.description ?? `\u2212${formatMoney(discount.savingsAmount, currency)}`}
+              </span>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between font-medium">
+            <span className="text-sm">Total</span>
+            <span className="text-sm tabular-nums">
+              {formatMoney(totalAmount, currency)}
+              <span className="text-muted-foreground font-normal"> / {billingIntervalLabel}</span>
+            </span>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+          {nextBilledAt && nextBillingLabel && (
+            <div className="flex items-center gap-1.5">
+              <CalendarIcon className="size-3.5" />
+              <span>
+                {nextBillingLabel} {formatDate(nextBilledAt)}
+              </span>
+            </div>
+          )}
+          {collectionMode && !effectiveScheduledChange && status !== "past_due" && (
+            <div className="flex items-center gap-1.5">
+              {collectionMode === "automatic" ? (
+                <>
+                  <CreditCardIcon className="size-3.5" />
+                  <span>Auto-renews</span>
+                </>
+              ) : (
+                <>
+                  <FileTextIcon className="size-3.5" />
+                  <span>Invoiced</span>
+                </>
+              )}
+            </div>
+          )}
+          {canceledAt && (
+            <div className="flex items-center gap-1.5">
+              <span>Canceled {formatDate(canceledAt)}</span>
+            </div>
+          )}
+        </div>
+
+        {hasActions && (
+          <div className="flex flex-wrap gap-2 pt-1">
+            {showChangePlan && (
+              <Button onClick={onChangePlan} size="sm">
+                Change plan
+              </Button>
+            )}
+            {showUpdatePayment && (
+              <Button
+                variant={isPastDue ? "default" : "outline"}
+                size="sm"
+                onClick={onUpdatePaymentMethod}
+              >
+                Update payment method
+              </Button>
+            )}
+            {showManage && (
+              <Button variant="outline" size="sm" onClick={onManageSubscription}>
+                Manage
+              </Button>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function SubscriptionStatusCardSkeleton({ className }: { className?: string }) {
+  return (
+    <Card className={cn("gap-4", className)}>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-6 w-32" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+            <Skeleton className="h-4 w-20" />
+          </div>
+          <Skeleton className="size-12 rounded-md" />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-16" />
+            </div>
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </div>
+        <Separator />
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        </div>
+        <Separator />
+        <div className="flex items-center gap-4">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+        <div className="flex gap-2 pt-1">
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="h-8 w-20" />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction }

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-(--card-spacing)", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid w-full gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="flex size-4 items-center justify-center"
+      >
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/frontend/src/hooks/use-checkout.tsx
+++ b/frontend/src/hooks/use-checkout.tsx
@@ -1,0 +1,154 @@
+import { type Environments, type Theme, type Paddle } from "@paddle/paddle-js"
+import { useEffect, useState, useCallback, useRef } from "react"
+import {
+  CheckoutEventNames,
+  type OpenCheckoutOptions,
+  type CheckoutSettings,
+} from "@/lib/paddle-sdk-types"
+import type { CheckoutCompleteData } from "@/lib/paddle-types"
+import {
+  getOrCreatePaddle,
+  addPaddleEventListener,
+} from "@/lib/paddle-instance"
+
+export type UseCheckoutArgs = {
+  clientToken: string
+  environment?: Environments
+  theme?: Theme
+  locale?: string
+  showNonExpressPaymentMethods?: boolean
+  checkoutSettings: CheckoutSettings
+  onComplete?: (data: CheckoutCompleteData) => void
+  onError?: (error: Error) => void
+}
+
+export function useCheckout(args: UseCheckoutArgs) {
+  const {
+    clientToken,
+    environment = "production",
+    theme,
+    locale,
+    showNonExpressPaymentMethods,
+    checkoutSettings,
+    onComplete,
+    onError,
+  } = args
+
+  const [paddle, setPaddle] = useState<Paddle | null>(null)
+  const [isReady, setIsReady] = useState(false)
+
+  // Refs avoid stale closures in event listeners
+  const onCompleteRef = useRef(onComplete)
+  const onErrorRef = useRef(onError)
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+    onErrorRef.current = onError
+  }, [onComplete, onError])
+
+  // Subscribe to checkout.completed events
+  useEffect(() => {
+    const unsubscribe = addPaddleEventListener((event) => {
+      if (event.name === CheckoutEventNames.CHECKOUT_COMPLETED && onCompleteRef.current) {
+        onCompleteRef.current({
+          transactionId: event.data?.transaction_id ?? "",
+          customerId: event.data?.customer?.id ?? "",
+          customerEmail: event.data?.customer?.email ?? "",
+        })
+      }
+    })
+
+    return unsubscribe
+  }, [])
+
+  // Initialize Paddle
+  useEffect(() => {
+    if (paddle || !clientToken) return
+
+    getOrCreatePaddle(clientToken, environment)
+      .then((paddleInstance) => {
+        if (paddleInstance) {
+          setPaddle(paddleInstance)
+          setIsReady(true)
+        }
+      })
+      .catch((error) => {
+        if (onErrorRef.current) {
+          onErrorRef.current(
+            error instanceof Error ? error : new Error("Failed to initialize Paddle")
+          )
+        }
+      })
+  }, [clientToken, environment, paddle])
+
+  const openCheckout = useCallback(
+    (options: OpenCheckoutOptions) => {
+      if (!paddle || !isReady) {
+        console.warn("Paddle not initialized yet")
+        return
+      }
+
+      // Normalise to items array — support both items[] and legacy priceId
+      const items =
+        options.items && options.items.length > 0
+          ? options.items.map((item) => ({ priceId: item.priceId, quantity: item.quantity ?? 1 }))
+          : [{ priceId: options.priceId, quantity: 1 }]
+
+      paddle.Checkout.open({
+        items,
+        ...(options.customerAuthToken
+          ? { customerAuthToken: options.customerAuthToken }
+          : options.customer
+            ? { customer: options.customer }
+            : {}),
+        ...(options.discountCode
+          ? { discountCode: options.discountCode }
+          : options.discountId
+            ? { discountId: options.discountId }
+            : {}),
+        ...(options.customData && { customData: options.customData }),
+        ...(options.successUrl && { successUrl: options.successUrl }),
+        settings: {
+          displayMode: checkoutSettings.displayMode,
+          variant: checkoutSettings.variant,
+          frameTarget: checkoutSettings.frameTarget,
+          frameInitialHeight: checkoutSettings.frameInitialHeight,
+          frameStyle: checkoutSettings.frameStyle ?? "width: 100%; border: 0;",
+          ...(theme && { theme }),
+          ...(locale && { locale }),
+          // Not yet in @paddle/paddle-js SDK types, landing soon
+          ...(showNonExpressPaymentMethods !== undefined && {
+            showNonExpressPaymentMethods,
+          }),
+        } as Record<string, unknown>,
+      })
+    },
+    [paddle, isReady, checkoutSettings, theme, locale, showNonExpressPaymentMethods]
+  )
+
+  const closeCheckout = useCallback(() => {
+    if (paddle?.Checkout) {
+      paddle.Checkout.close()
+    }
+  }, [paddle])
+
+  const updateItems = useCallback(
+    (items: Array<{ priceId: string; quantity: number }>) => {
+      if (!paddle || !isReady) {
+        console.warn("Paddle not initialized yet")
+        return
+      }
+      ;(
+        paddle.Checkout as Record<string, unknown> & { updateItems?: (items: unknown) => void }
+      ).updateItems?.(items)
+    },
+    [paddle, isReady]
+  )
+
+  return {
+    openCheckout,
+    closeCheckout,
+    updateItems,
+    isReady,
+  }
+}

--- a/frontend/src/hooks/use-paddle-prices.tsx
+++ b/frontend/src/hooks/use-paddle-prices.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import {
+  type Environments,
+  type Paddle,
+  type PricePreviewParams,
+  type PricePreviewResponse,
+} from "@paddle/paddle-js"
+import { useEffect, useState, useRef, useCallback } from "react"
+import {
+  formatBillingCycle,
+  formatTrialPeriod,
+} from "@/lib/paddle-format"
+import { getOrCreatePaddle } from "@/lib/paddle-instance"
+import type { PriceData } from "@/lib/paddle-types"
+
+export type UsePaddlePricesArgs = {
+  clientToken: string
+  environment?: Environments
+  priceIds: string[]
+  countryCode?: string
+  discountId?: string
+}
+
+type PaddlePrices = Record<string, PriceData>
+
+function getPriceAmounts(prices: PricePreviewResponse): PaddlePrices {
+  return prices.data.details.lineItems.reduce((acc, item) => {
+    const hasDiscount = item.discounts.length > 0
+    acc[item.price.id] = {
+      total: item.formattedTotals.total,
+      originalTotal: hasDiscount ? item.formattedTotals.subtotal : undefined,
+      interval: formatBillingCycle(item.price.billingCycle),
+      trialPeriod: item.price.trialPeriod ? formatTrialPeriod(item.price.trialPeriod) : undefined,
+    }
+    return acc
+  }, {} as PaddlePrices)
+}
+
+export function usePaddlePrices(args: UsePaddlePricesArgs): {
+  prices: PaddlePrices
+  loading: boolean
+  error: Error | null
+} {
+  const { clientToken, environment = "production", priceIds, countryCode, discountId } = args
+  const [paddle, setPaddle] = useState<Paddle | null>(null)
+  const [prices, setPrices] = useState<PaddlePrices>({})
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  // Stable keys — prevent unnecessary re-fetches
+  const priceIdsKey = priceIds.join(",")
+  const discountIdKey = discountId ?? ""
+
+  // Initialize Paddle once
+  useEffect(() => {
+    if (paddle || !clientToken) return
+
+    getOrCreatePaddle(clientToken, environment)
+      .then((paddleInstance) => {
+        if (paddleInstance) {
+          setPaddle(paddleInstance)
+        }
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err : new Error("Failed to initialize Paddle"))
+        setLoading(false)
+      })
+  }, [clientToken, environment, paddle])
+
+  // Fetch prices when Paddle is ready or inputs change
+  const fetchedRef = useRef<string | null>(null)
+
+  const fetchPrices = useCallback(async () => {
+    if (!paddle) return
+
+    const fetchKey = `${priceIdsKey}:${countryCode ?? ""}:${discountIdKey}`
+    if (fetchedRef.current === fetchKey) return
+    fetchedRef.current = fetchKey
+
+    const priceIdList = priceIdsKey.split(",").filter(Boolean)
+    if (priceIdList.length === 0) return
+
+    const paddlePricePreviewRequest: Partial<PricePreviewParams> = {
+      items: priceIdList.map((priceId) => ({ priceId, quantity: 1 })),
+      ...(countryCode && { address: { countryCode } }),
+      ...(discountId && { discountId }),
+    }
+
+    setLoading(true)
+
+    try {
+      const priceResponse = await paddle.PricePreview(
+        paddlePricePreviewRequest as PricePreviewParams
+      )
+      setPrices(getPriceAmounts(priceResponse))
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Failed to fetch prices"))
+    } finally {
+      setLoading(false)
+    }
+  }, [paddle, priceIdsKey, countryCode, discountIdKey])
+
+  useEffect(() => {
+    fetchPrices()
+  }, [fetchPrices])
+
+  return { prices, loading, error }
+}

--- a/frontend/src/lib/checkout-summary-utils.ts
+++ b/frontend/src/lib/checkout-summary-utils.ts
@@ -1,0 +1,102 @@
+import type { CheckoutSummaryData } from "@/lib/paddle-types"
+import { formatTrialPeriod } from "@/lib/paddle-format"
+
+// ---
+// Input shapes — minimal types matching the Paddle.js CheckoutEventsData shape.
+// Field names use snake_case (Paddle.js convention). Pass the raw checkout event
+// payload or any object matching this shape.
+// ---
+
+type TimePeriodLike = {
+  interval: string
+  frequency: number
+}
+
+type CheckoutEventItem = {
+  product?: { name?: string | null } | null
+  price_name?: string | null
+  quantity?: number | null
+  totals?: { subtotal?: number | null } | null
+  billing_cycle?: TimePeriodLike | null
+  trial_period?: TimePeriodLike | null
+}
+
+type CheckoutEventsInput = {
+  currency_code?: string | null
+  items?: CheckoutEventItem[] | null
+  totals?: {
+    subtotal?: number | null
+    tax?: number | null
+    total?: number | null
+    discount?: number | null
+  } | null
+  recurring_totals?: {
+    total?: number | null
+  } | null
+}
+
+/**
+ * Maps a Paddle.js checkout event payload to the `CheckoutSummaryData`
+ * display contract consumed by `CheckoutSummary`.
+ *
+ * Paddle.js checkout event totals are already decimal numbers (not lowest-denomination),
+ * so no cents-to-decimal conversion is needed here. For Paddle API amounts, use
+ * `parseAmount()` from `paddle-format` — those are returned in lowest denomination.
+ *
+ * @param data - Paddle.js checkout event data (e.g. from `checkout.loaded` / `checkout.updated`)
+ * @returns Mapped summary data for `<CheckoutSummary />`
+ *
+ * @example
+ * paddle.Update({ eventCallback: (event) => {
+ *   const summary = mapCheckoutEventsToSummary(event.data)
+ * }})
+ */
+export function mapCheckoutEventsToSummary(data: CheckoutEventsInput): CheckoutSummaryData {
+  const currency = data.currency_code ?? ""
+
+  const items = (data.items ?? []).map((item) => ({
+    name: item.product?.name ?? "",
+    priceName: item.price_name ?? undefined,
+    quantity: item.quantity ?? 1,
+    lineTotal: item.totals?.subtotal ?? 0,
+  }))
+
+  const totals = data.totals
+  const recurringTotals = data.recurring_totals
+
+  const discount = totals?.discount && totals.discount > 0 ? totals.discount : undefined
+
+  // Build recurring billing info from the first item that has a billing cycle.
+  // Using find() rather than [0] handles mixed carts (e.g. one-time setup fee
+  // followed by a recurring subscription) where the first item may not recur.
+  let recurringTotal: number | undefined
+  let recurringInterval: string | undefined
+  let recurringFrequency: number | undefined
+  const firstRecurringItem = data.items?.find((item) => item.billing_cycle != null)
+  const billingCycle = firstRecurringItem?.billing_cycle
+  if (billingCycle && recurringTotals?.total != null) {
+    recurringTotal = recurringTotals.total
+    recurringInterval = billingCycle.interval
+    recurringFrequency = billingCycle.frequency
+  }
+
+  // Build trial period label from the first item that has a trial period.
+  let trialPeriod: string | undefined
+  const firstTrialItem = data.items?.find((item) => item.trial_period != null)
+  if (firstTrialItem?.trial_period) {
+    trialPeriod = formatTrialPeriod(firstTrialItem.trial_period)
+  }
+
+  return {
+    items,
+    subtotal: totals?.subtotal ?? 0,
+    tax: totals?.tax ?? 0,
+    total: totals?.total ?? 0,
+    discount,
+    currency,
+    recurringTotal,
+    recurringInterval,
+    recurringFrequency,
+    trialPeriod,
+  }
+}

--- a/frontend/src/lib/paddle-format.ts
+++ b/frontend/src/lib/paddle-format.ts
@@ -1,0 +1,150 @@
+export function formatDate(isoString: string, locale: string = "en-US"): string {
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(isoString))
+}
+
+// Structural alias — accepts both CheckoutEventsTimePeriod and TimePeriod
+type TimePeriodLike = {
+  frequency: number
+  interval: string
+}
+
+/**
+ * Formats a billing cycle for display.
+ * @param billingCycle - The billing cycle to format
+ * @returns Formatted string like "month", "year", or "3 months", or undefined if no billing cycle
+ *
+ * @example
+ * formatBillingCycle({ frequency: 1, interval: "month" }) // "month"
+ * formatBillingCycle({ frequency: 3, interval: "month" }) // "3 months"
+ */
+export function formatBillingCycle(
+  billingCycle: TimePeriodLike | null | undefined
+): string | undefined {
+  if (!billingCycle) {
+    return undefined
+  }
+
+  const { frequency, interval } = billingCycle
+  return frequency === 1 ? interval : `${frequency} ${interval}s`
+}
+
+/**
+ * Formats a trial period for display.
+ * @param trialPeriod - The trial period to format
+ * @returns Formatted string like "7 days" or "1 month"
+ *
+ * @example
+ * formatTrialPeriod({ frequency: 7, interval: "day" }) // "7 days"
+ * formatTrialPeriod({ frequency: 1, interval: "month" }) // "1 month"
+ */
+export function formatTrialPeriod(trialPeriod: TimePeriodLike): string {
+  const interval = trialPeriod.frequency === 1 ? trialPeriod.interval : `${trialPeriod.interval}s`
+
+  return `${trialPeriod.frequency} ${interval}`
+}
+
+/**
+ * Formats a numeric monetary amount as a localised currency string.
+ *
+ * @param amount - Raw numeric amount (e.g. from Paddle checkout event totals)
+ * @param currencyCode - ISO 4217 currency code (e.g. "USD", "GBP")
+ * @param locale - Optional BCP 47 locale tag (e.g. "en-GB"). Defaults to "en-US" so SSR
+ *   and client produce identical output (required for React hydration).
+ * @returns Formatted currency string, e.g. "$29.99" or "£12.00"
+ *
+ * @example
+ * formatMoney(29.99, "USD") // "$29.99"
+ * formatMoney(12, "GBP", "en-GB") // "£12.00"
+ */
+export function formatMoney(
+  amount: number,
+  currencyCode: string,
+  locale: string = "en-US"
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: currencyCode,
+  }).format(amount)
+}
+
+// Paddle-supported zero-decimal currencies — amounts are already whole units.
+// https://developer.paddle.com/concepts/payment-methods/currencies
+const ZERO_DECIMAL_CURRENCIES = new Set(["JPY", "KRW", "VND", "CLP"])
+
+/**
+ * Parses a Paddle API monetary amount string (lowest denomination, e.g. "1500")
+ * to a decimal number suitable for `formatMoney` (e.g. 15.00).
+ *
+ * Paddle returns amounts as strings in the lowest denomination of the currency.
+ * Standard currencies (USD, EUR, GBP, etc.) use cents — divide by 100.
+ * Zero-decimal currencies (JPY, KRW, VND, CLP) are already whole units — no division.
+ *
+ * @param raw - Amount string in lowest denomination (e.g. "1500" for $15.00 USD or ¥1500 JPY)
+ * @param currencyCode - ISO 4217 currency code used to determine decimal handling
+ * @returns Decimal number ready for `formatMoney`
+ *
+ * @example
+ * parseAmount("1500", "USD") // 15
+ * parseAmount("999", "USD")  // 9.99
+ * parseAmount("1500", "JPY") // 1500
+ */
+export function parseAmount(raw: string, currencyCode: string): number {
+  const value = parseInt(raw, 10)
+  if (ZERO_DECIMAL_CURRENCIES.has(currencyCode.toUpperCase())) {
+    return value
+  }
+  return value / 100
+}
+
+/**
+ * Returns a human-readable label for a Paddle proration billing mode.
+ *
+ * @param mode - Paddle `proration_billing_mode` value
+ * @returns Display label, e.g. "Charge prorated amount now"
+ *
+ * @example
+ * formatProrationMode("prorated_immediately") // "Charge prorated amount now"
+ * formatProrationMode("full_next_billing_period") // "Full charge at next billing"
+ */
+export function formatProrationMode(mode: string): string {
+  const labels: Record<string, string> = {
+    prorated_immediately: "Charge prorated amount now",
+    full_immediately: "Charge full amount now",
+    prorated_next_billing_period: "Prorated at next billing",
+    full_next_billing_period: "Full charge at next billing",
+    do_not_bill: "No charge",
+  }
+  return labels[mode] ?? mode
+}
+
+const INTERVAL_LABELS: Record<string, { noun: string; adjective: string }> = {
+  day: { noun: "Daily", adjective: "daily" },
+  week: { noun: "Weekly", adjective: "weekly" },
+  month: { noun: "Monthly", adjective: "monthly" },
+  year: { noun: "Annually", adjective: "annual" },
+}
+
+/**
+ * Returns a human-readable label for a Paddle billing interval.
+ *
+ * @param interval - Paddle interval key, e.g. "month", "year"
+ * @param style - "noun" for toggle labels ("Monthly"), "adjective" for inline labels ("monthly")
+ * @returns Display label, e.g. "Monthly" or "monthly"
+ *
+ * @example
+ * formatIntervalLabel("month")             // "Monthly"
+ * formatIntervalLabel("year", "adjective") // "annual"
+ * formatIntervalLabel("month", "noun")     // "Monthly"
+ */
+export function formatIntervalLabel(
+  interval: string,
+  style: "noun" | "adjective" = "noun"
+): string {
+  const entry = INTERVAL_LABELS[interval]
+  if (entry) return entry[style]
+  return interval.charAt(0).toUpperCase() + interval.slice(1)
+}

--- a/frontend/src/lib/paddle-instance.ts
+++ b/frontend/src/lib/paddle-instance.ts
@@ -1,0 +1,45 @@
+import {
+  initializePaddle,
+  type Environments,
+  type Paddle,
+  type PaddleEventData,
+} from "@paddle/paddle-js"
+
+type PaddleEventListener = (event: PaddleEventData) => void
+
+// Module-level singleton state
+let paddlePromise: Promise<Paddle | undefined> | null = null
+let currentToken: string | null = null
+const eventListeners = new Set<PaddleEventListener>()
+
+/**
+ * Returns a shared Paddle instance, initializing once per token.
+ * Uses a dispatcher eventCallback so multiple hooks can subscribe to events.
+ */
+export function getOrCreatePaddle(
+  token: string,
+  environment: Environments
+): Promise<Paddle | undefined> {
+  if (paddlePromise && currentToken === token) {
+    return paddlePromise
+  }
+
+  currentToken = token
+  paddlePromise = initializePaddle({
+    token,
+    environment,
+    eventCallback: (event) => {
+      eventListeners.forEach((listener) => listener(event))
+    },
+  })
+
+  return paddlePromise
+}
+
+/** Subscribe to Paddle events. Returns an unsubscribe function. */
+export function addPaddleEventListener(listener: PaddleEventListener): () => void {
+  eventListeners.add(listener)
+  return () => {
+    eventListeners.delete(listener)
+  }
+}

--- a/frontend/src/lib/paddle-payment-method-display.ts
+++ b/frontend/src/lib/paddle-payment-method-display.ts
@@ -1,0 +1,115 @@
+export type PaddlePaymentMethodType =
+  | "alipay"
+  | "apple_pay"
+  | "bancontact"
+  | "blik"
+  | "card"
+  | "google_pay"
+  | "ideal"
+  | "kakao_pay"
+  | "south_korea_local_card"
+  | "mb_way"
+  | "naver_pay"
+  | "offline"
+  | "payco"
+  | "paypal"
+  | "pix"
+  | "samsung_pay"
+  | "unknown"
+  | "upi"
+  | "wechat_pay"
+  | "wire_transfer"
+  /** @deprecated Returned on historical transactions but replaced by `south_korea_local_card` in newer transactions */
+  | "korea_local"
+  | (string & {})
+
+/** All Paddle card brand types from `transaction.payments[0].method_details.card.type` */
+export type PaddleCardType =
+  | "american_express"
+  | "diners_club"
+  | "discover"
+  | "jcb"
+  | "mada"
+  | "maestro"
+  | "mastercard"
+  | "union_pay"
+  | "unknown"
+  | "visa"
+  | (string & {})
+
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  alipay: "Alipay",
+  apple_pay: "Apple Pay",
+  bancontact: "Bancontact",
+  blik: "BLIK",
+  card: "Card",
+  google_pay: "Google Pay",
+  ideal: "iDEAL",
+  kakao_pay: "Kakao Pay",
+  south_korea_local_card: "Korea local card",
+  mb_way: "MB WAY",
+  naver_pay: "Naver Pay",
+  offline: "Offline",
+  payco: "PAYCO",
+  paypal: "PayPal",
+  pix: "Pix",
+  samsung_pay: "Samsung Pay",
+  unknown: "Payment method",
+  upi: "UPI",
+  wechat_pay: "WeChat Pay",
+  wire_transfer: "Wire transfer",
+  korea_local: "Korean payment methods",
+}
+
+const CARD_BRAND_LABELS: Record<string, string> = {
+  american_express: "American Express",
+  diners_club: "Diners Club",
+  discover: "Discover",
+  jcb: "JCB",
+  mada: "Mada",
+  maestro: "Maestro",
+  mastercard: "Mastercard",
+  union_pay: "UnionPay",
+  unknown: "Card",
+  visa: "Visa",
+}
+
+function formatUnknownType(type: string): string {
+  return type
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+/**
+ * Returns the full display label for a Paddle payment method.
+ *
+ * For card payments, pass `cardBrand` (from `method_details.card.type`) to
+ * get the brand name, and `last4` (from `method_details.card.last4`) to
+ * append the masked number. Both are optional — the label degrades gracefully.
+ *
+ * @param type - Paddle payment method type from `method_details.type`
+ * @param cardBrand - Card brand from `method_details.card.type` (card payments only)
+ * @param last4 - Last 4 digits from `method_details.card.last4` (card payments only)
+ * @returns Human-readable payment method label
+ *
+ * @example
+ * getPaymentMethodDisplay("card", "visa", "4242")    // "Visa ending 4242"
+ * getPaymentMethodDisplay("card", "mastercard")       // "Mastercard"
+ * getPaymentMethodDisplay("card")                     // "Card"
+ * getPaymentMethodDisplay("paypal")                   // "PayPal"
+ * getPaymentMethodDisplay("apple_pay")                // "Apple Pay"
+ */
+export function getPaymentMethodDisplay(
+  type: PaddlePaymentMethodType,
+  cardBrand?: PaddleCardType,
+  last4?: string
+): string {
+  if (type === "card") {
+    const brand = cardBrand
+      ? (CARD_BRAND_LABELS[cardBrand] ?? formatUnknownType(cardBrand))
+      : "Card"
+    return last4 ? `${brand} ending ${last4}` : brand
+  }
+  return PAYMENT_METHOD_LABELS[type] ?? formatUnknownType(type)
+}

--- a/frontend/src/lib/paddle-sdk-types.ts
+++ b/frontend/src/lib/paddle-sdk-types.ts
@@ -1,0 +1,49 @@
+export type {
+  Paddle,
+  Environments,
+  PaddleEventData,
+  PricePreviewParams,
+  PricePreviewResponse,
+  CheckoutEventsData,
+  CheckoutCustomer,
+  TimePeriod,
+  CheckoutOpenLineItem,
+} from "@paddle/paddle-js"
+
+export { CheckoutEventNames } from "@paddle/paddle-js"
+
+// CheckoutSettings from the SDK, widened to include "express" in the variant
+// union. The express variant is a valid Paddle.js variant not yet reflected in
+// the SDK's Variant type ('multi-page' | 'one-page').
+import type { CheckoutSettings as SDKCheckoutSettings, CheckoutCustomer } from "@paddle/paddle-js"
+export type CheckoutSettings = Omit<SDKCheckoutSettings, "variant"> & {
+  variant?: SDKCheckoutSettings["variant"] | "express"
+}
+
+// ---
+// Hook API types
+// Used by the hooks in this library. You generally won't need to use these
+// directly unless you're building a custom integration on top of the hooks.
+// ---
+
+/**
+ * Options for opening a Paddle inline checkout.
+ *
+ * Passed to `openCheckout()` returned by `useCheckout`. Accepts either a
+ * `priceId` (legacy, mapped to a single-item checkout) or an `items` array
+ * for multi-item checkouts. When both are provided, `items` takes precedence.
+ *
+ * Note: this is a simplified wrapper over the raw Paddle SDK `CheckoutOpenOptions`.
+ * For full control over the checkout, use `paddle.Checkout.open()` directly.
+ */
+export type OpenCheckoutOptions = {
+  priceId: string
+  items?: Array<{ priceId: string; quantity?: number }>
+  customer?: CheckoutCustomer
+  customerAuthToken?: string
+  discountCode?: string
+  discountId?: string
+  customData?: Record<string, unknown>
+  /** Must be an absolute URL (starting with `https://` or `http://`) */
+  successUrl?: string
+}

--- a/frontend/src/lib/paddle-types.ts
+++ b/frontend/src/lib/paddle-types.ts
@@ -1,0 +1,448 @@
+export type PriceData = {
+  /** Formatted price string, e.g. "$9.99" or "£12.00" */
+  total: string
+  /** Pre-discount price, e.g. "$12.99". Present only when a discount is applied. */
+  originalTotal?: string
+  /** Billing frequency, e.g. "month", "year", "3 months" */
+  interval?: string
+  /** Trial period length, e.g. "7 days", "1 month" */
+  trialPeriod?: string
+}
+
+/**
+ * Normalized payload delivered to the `onComplete` callback when a Paddle
+ * checkout transaction completes successfully.
+ *
+ * This is a subset of the full Paddle checkout event data, containing the
+ * fields most commonly needed for post-purchase handling (e.g. sending to
+ * your backend, showing a confirmation screen).
+ */
+export type CheckoutCompleteData = {
+  transactionId: string
+  customerId: string
+  customerEmail: string
+}
+
+/**
+ * A single line item in the checkout order summary.
+ *
+ * Monetary values are raw decimal numbers — the component formats them using
+ * the parent `CheckoutSummaryData.currency`.
+ * Produced by `mapCheckoutEventsToSummary` from `CheckoutEventsData`.
+ */
+export type CheckoutSummaryItem = {
+  name: string
+  priceName?: string
+  quantity: number
+  lineTotal: number
+}
+
+/**
+ * Display contract for the `CheckoutSummary` component.
+ *
+ * Monetary amounts are raw decimal numbers — the component formats them using `currency`.
+ * Produced by `mapCheckoutEventsToSummary` from the `CheckoutEventsData` payload
+ * emitted by Paddle.js checkout events.
+ */
+export type CheckoutSummaryData = {
+  items: CheckoutSummaryItem[]
+  subtotal: number
+  tax: number
+  total: number
+  discount?: number
+  /** ISO 4217 currency code, e.g. "USD" */
+  currency: string
+  /** Recurring total amount as a decimal number */
+  recurringTotal?: number
+  /** Recurring billing interval, e.g. "month" */
+  recurringInterval?: string
+  /** Recurring billing frequency, e.g. 1 */
+  recurringFrequency?: number
+  /** Trial period label, e.g. "7 days" or "1 month" */
+  trialPeriod?: string
+}
+
+// ---
+// Subscription display types
+// Display contracts for subscription management components. Monetary amounts
+// are raw decimal numbers; date values are ISO 8601 strings. Populate from
+// Paddle's subscription API responses combined with formatting utilities.
+// ---
+
+/** Paddle subscription statuses. From `subscription.status`. */
+export type SubscriptionStatus = "active" | "canceled" | "past_due" | "paused" | "trialing"
+
+/**
+ * A single line item within a subscription.
+ *
+ * Represents one product/price combination in the subscription.
+ * `lineTotal` should come from `recurring_transaction_details.line_items[n].totals.subtotal`
+ * as a decimal number (e.g. 29.99).
+ */
+export type SubscriptionStatusItemData = {
+  /** Product name, e.g. "Pro Plan" */
+  productName: string
+  /** Optional product description */
+  productDescription?: string
+  /** Optional product image URL */
+  productImageUrl?: string
+  /** Price/tier name, e.g. "Monthly" or "Annual". From `items[n].price.name`. */
+  priceName?: string
+  quantity: number
+  /**
+   * Unit price as a decimal number, e.g. 99.99.
+   * From `items[n].price.unit_price.amount`. Only rendered when quantity > 1.
+   */
+  unitPrice?: number
+  /**
+   * Line item subtotal as a decimal number (before discount, before tax), e.g. 29.99.
+   * From `recurring_transaction_details.line_items[n].totals.subtotal`.
+   * Discounts are shown as a separate summary line — this field should NOT include them.
+   */
+  lineTotal: number
+}
+
+/**
+ * Display contract for the `SubscriptionStatusCard` component.
+ *
+ * Pass `undefined` to render a skeleton loading state.
+ * Monetary amounts are raw decimal numbers — the component formats them using `currency`.
+ * Date values are ISO 8601 strings — the component formats them for display.
+ *
+ * `totalAmount` should come from `recurring_transaction_details.totals.total` —
+ * this is the steady-state recurring amount (after discounts and tax).
+ */
+export type SubscriptionStatusData = {
+  /** Paddle subscription ID, e.g. "sub_01abc..." */
+  id?: string
+  /** Subscription line items — auto-adapts layout for single vs multi-item */
+  items: SubscriptionStatusItemData[]
+  /** Recurring total as a decimal number, e.g. 49.99 */
+  totalAmount: number
+  /** ISO 4217 currency code, e.g. "USD" */
+  currency: string
+  /** Billing interval, e.g. "month" or "year" */
+  interval: string
+  /** Billing frequency. Defaults to 1. E.g. 3 for "every 3 months". */
+  billingFrequency?: number
+  status: SubscriptionStatus
+  /** ISO 8601 subscription start date */
+  startedAt: string
+  /** ISO 8601 next billing date. Absent when paused or canceled. */
+  nextBilledAt?: string
+  /** ISO 8601 cancellation date. Present only when status is "canceled". */
+  canceledAt?: string
+  /**
+   * Payment collection mode. From `subscription.collection_mode`.
+   * "automatic" = auto-renew via saved payment method, "manual" = invoiced.
+   */
+  collectionMode?: "automatic" | "manual"
+  scheduledChange?: {
+    /** Type of scheduled change */
+    action: "cancel" | "pause" | "resume"
+    /** ISO 8601 date when the change takes effect */
+    effectiveAt: string
+    /** ISO 8601 date when the subscription resumes, only for pause actions with a set resume date */
+    resumeAt?: string
+  }
+  /** Active discount, if any */
+  discount?: {
+    /** Discount savings amount as a decimal number, e.g. 5.00 */
+    savingsAmount: number
+    /** ISO 8601 date when the discount expires. Absent if discount recurs forever. */
+    endsAt?: string
+    /** Discount code, e.g. "SAVE20". From `discount.code`. */
+    code?: string
+    /** Discount description for billing summary, e.g. "-15%" or "-$5.00". API-provided or derived. */
+    description?: string
+  }
+}
+
+/**
+ * Display contract for the `SubscriptionAlert` component.
+ *
+ * The component derives which alert to render from these fields.
+ * Date values are ISO 8601 strings — the component formats them for display.
+ * Pass `undefined` to render nothing.
+ *
+ * `updatePaymentMethodUrl` comes from `subscription.management_urls.update_payment_method`.
+ * `trialEndsAt` comes from `subscription.items[0].trial_dates.ends_at`.
+ */
+export type SubscriptionAlertData = {
+  status: SubscriptionStatus
+  /** ISO 8601 cancellation date. Present when status is "canceled". */
+  canceledAt?: string
+  scheduledChange?: {
+    /** Type of scheduled change */
+    action: "cancel" | "pause" | "resume"
+    /** ISO 8601 date when the change takes effect */
+    effectiveAt: string
+    /** ISO 8601 date when the subscription resumes, only for pause with a set resume date */
+    resumeAt?: string
+  }
+  /** ISO 8601 trial end date. Present when status is "trialing". */
+  trialEndsAt?: string
+  /** Portal deep link to update payment method. Null for manual collection. */
+  updatePaymentMethodUrl?: string
+}
+
+/**
+ * Next payment details for the `SubscriptionPaymentCard` component.
+ *
+ * `amount` should come from `next_transaction.details.totals.grand_total`
+ * (accounts for credits and adjustments) — pass as a decimal number (e.g. 29.99).
+ * `currency` should come from `subscription.currency_code`.
+ * `date` should come from `subscription.next_billed_at` as an ISO 8601 string.
+ */
+export type NextPaymentData = {
+  /** Payment amount as a decimal number, e.g. 29.99 */
+  amount: number
+  /** ISO 4217 currency code, e.g. "USD" */
+  currency: string
+  /** ISO 8601 date string for the next billing date, e.g. "2025-02-01T00:00:00Z" */
+  date: string
+}
+
+/**
+ * Payment method details for the `SubscriptionPaymentCard` component.
+ *
+ * Pass the raw fields from `transaction.payments[0].method_details` directly —
+ * the component resolves the display label automatically via `getPaymentMethodDisplay`.
+ *
+ * Sourced from the most recent completed transaction for the subscription
+ * (not the saved payment methods API — see spec for sourcing details).
+ *
+ * @example
+ * // From a completed Paddle transaction:
+ * const payment = transaction.payments[0].methodDetails
+ * paymentMethod={payment ? {
+ *   type: payment.type,
+ *   cardBrand: payment.card?.type,
+ *   last4: payment.card?.last4,
+ * } : undefined}
+ */
+export type PaymentMethodData = {
+  /** Paddle payment method type from `method_details.type`, e.g. "card", "paypal", "apple_pay" */
+  type: string
+  /** Card brand from `method_details.card.type`, e.g. "visa", "mastercard". Card payments only. */
+  cardBrand?: string
+  /** Last 4 digits from `method_details.card.last4`, e.g. "4242". Card payments only. */
+  last4?: string
+  /** Card expiry month (1–12) from `method_details.card.expiry_month`. Card payments only. */
+  expiryMonth?: number
+  /** Card expiry year (4-digit) from `method_details.card.expiry_year`. Card payments only. */
+  expiryYear?: number
+  /**
+   * Optional display label override. When provided, renders as-is instead of
+   * auto-resolving from `type`/`cardBrand`/`last4`. Use for custom formats
+   * (e.g. "Visa •••• 4242") or when you've already formatted the label upstream.
+   */
+  label?: string
+}
+
+/**
+ * Display contract for the `PlanChangePreview` component.
+ *
+ * Sourced from the current subscription entity and the response from
+ * `PATCH /subscriptions/{id}/preview`. Pass `undefined` to render a skeleton.
+ *
+ * Monetary amounts are raw decimal numbers — the component formats them using `currency`.
+ * Date values are ISO 8601 strings — the component formats them for display.
+ * UI labels and contextual messages belong on component props, not here.
+ */
+export type PlanChangePreviewData = {
+  /** ISO 4217 currency code, e.g. "USD" */
+  currency: string
+  /** The plan being replaced */
+  currentPlan: {
+    /** Product name of the current plan */
+    productName: string
+    /** Current recurring total as a decimal number, e.g. 9.99 */
+    price: number
+    /** Current billing interval, e.g. "month" */
+    interval: string
+    /** Current billing frequency, defaults to 1 */
+    billingFrequency?: number
+  }
+  /** The plan being switched to */
+  newPlan: {
+    /** Product name of the new plan */
+    productName: string
+    /** New recurring total as a decimal number, e.g. 29.99 */
+    price: number
+    /** New billing interval, e.g. "month" */
+    interval: string
+    /** New billing frequency, defaults to 1 */
+    billingFrequency?: number
+  }
+  /** Financial impact of the plan change */
+  costImpact: {
+    /**
+     * Direction of the net financial impact.
+     * - `"charge"` — customer owes money (upgrade)
+     * - `"credit"` — customer receives credit (downgrade)
+     * - `"none"` — no financial movement (e.g. `do_not_bill` proration mode,
+     *   trial upgrade, or paused subscription change)
+     */
+    resultDirection: "credit" | "charge" | "none"
+    /** Net financial impact as a decimal number, e.g. 20.00. From `update_summary.result.amount`. */
+    resultAmount: number
+    /** Prorated credit for unused time on old plan as a decimal number. From `update_summary.credit.amount`. */
+    credit?: number
+    /** Prorated charge for new plan as a decimal number. From `update_summary.charge.amount`. */
+    charge?: number
+    /**
+     * Amount charged immediately as a decimal number.
+     * Present for `*_immediately` proration modes. From `immediate_transaction.details.totals.grand_total`.
+     */
+    immediateAmount?: number
+    /**
+     * Next bill total as a decimal number.
+     * Present for `*_next_billing_period` proration modes. From `next_transaction.details.totals.grand_total`.
+     */
+    nextBillAmount?: number
+    /** ISO 8601 next bill date. From `next_transaction.billing_period.starts_at`. */
+    nextBillDate?: string
+    /**
+     * New steady-state recurring total as a decimal number after the change settles.
+     * From `recurring_transaction_details.totals.total`.
+     */
+    newRecurringTotal: number
+    /** New billing interval. From `billing_cycle.interval`. */
+    newBillingInterval: string
+    /** New billing frequency. From `billing_cycle.frequency`. Defaults to 1. */
+    newBillingFrequency?: number
+  }
+  /** Active discount on the subscription. From `subscription.discount`. */
+  discount?: {
+    /** Discount description, e.g. "20% off" or "-$5.00". From `subscription.discount.description`. */
+    description: string
+    /** ISO 8601 expiry date. Absent if discount recurs forever. From `subscription.discount.ends_at`. */
+    endsAt?: string
+  }
+  /** Pending scheduled change. From `subscription.scheduled_change`. */
+  scheduledChange?: {
+    /** Type of scheduled change */
+    action: "cancel" | "pause" | "resume"
+    /** ISO 8601 date when the change takes effect */
+    effectiveAt: string
+  }
+  /**
+   * Subscription status. From `subscription.status`.
+   * Used by the component to render contextual messaging — e.g. a trial notice
+   * when `status === "trialing"` and there is no immediate charge.
+   */
+  subscriptionStatus?: SubscriptionStatus
+  /**
+   * Payment collection mode. From `subscription.collection_mode`.
+   * Used by the component to adapt labels — e.g. "Invoice amount" instead of
+   * "Amount due now" when `collectionMode === "manual"`.
+   */
+  collectionMode?: "automatic" | "manual"
+}
+
+// ---
+// Plan change breakdown types
+// Display contract for the detailed financial breakdown component.
+// Shows per-transaction line items, tax, proration, and totals.
+// ---
+
+/**
+ * A single line item within a transaction preview.
+ * Monetary amounts are raw decimal numbers — the component formats them
+ * using the parent `PlanChangeBreakdownData.currency`.
+ *
+ * Maps to `details.line_items[]` (immediate/next transaction) or
+ * `line_items[]` (recurring_transaction_details) in the preview response.
+ */
+export type PlanChangeLineItemData = {
+  /** Product name, e.g. "Pro Plan". From `line_items[].product.name`. */
+  productName: string
+  /** Item quantity. From `line_items[].quantity`. */
+  quantity: number
+  /** Unit price as a decimal number, e.g. 49.00. From `line_items[].unit_totals.subtotal`. */
+  unitPrice: number
+  /** Line total as a decimal number, e.g. 26.95. From `line_items[].totals.total`. */
+  total: number
+  /** Whether this line item is prorated. Derived from `line_items[].proration !== null`. */
+  isProrated?: boolean
+  /** Proration period label, e.g. "15 of 31 days". Derived from `proration.rate` and `proration.billing_period`. */
+  prorationPeriod?: string
+}
+
+/**
+ * Totals breakdown for a single transaction section.
+ * All values are raw decimal numbers — the component formats them using
+ * the parent `PlanChangeBreakdownData.currency`.
+ *
+ * Maps to `details.totals` (immediate/next) or `totals` (recurring) in the preview response.
+ */
+export type PlanChangeTransactionTotalsData = {
+  /** Subtotal as a decimal number (before discount, tax, and deductions). From `totals.subtotal`. */
+  subtotal: number
+  /** Discount amount as a decimal number. Present when a discount is active. From `totals.discount`. */
+  discount?: number
+  /** Tax amount as a decimal number. From `totals.tax`. */
+  tax: number
+  /** Credit applied to this transaction as a decimal number. From `totals.credit`. */
+  credit?: number
+  /** Surplus credit added to customer balance as a decimal number. From `totals.credit_to_balance`. */
+  creditToBalance?: number
+  /** Total due as a decimal number (after credits). From `totals.grand_total`. */
+  total: number
+}
+
+/**
+ * A complete transaction section (immediate, next, or recurring).
+ * The section's position within `PlanChangeBreakdownData` determines its
+ * role — the component derives titles and descriptions from that context.
+ */
+export type PlanChangeTransactionSectionData = {
+  /**
+   * ISO 8601 billing date for this transaction period.
+   * Only relevant for `nextTransaction` — sourced from `billing_period.starts_at`.
+   * Omitted for immediate and recurring sections.
+   */
+  billingDate?: string
+  lineItems: PlanChangeLineItemData[]
+  totals: PlanChangeTransactionTotalsData
+}
+
+/**
+ * Display contract for the `PlanChangeBreakdown` component.
+ *
+ * Sourced from `PATCH /subscriptions/{id}/preview`. Pass `undefined` to render a skeleton.
+ * Shows the full financial detail: per-transaction line items, tax, proration, and totals.
+ */
+export type PlanChangeBreakdownData = {
+  /** ISO 4217 currency code, e.g. "USD" */
+  currency: string
+  /** Net financial result of the change. From `update_summary.result`. */
+  result: {
+    /**
+     * Direction of the net result.
+     * - `"charge"` — customer owes money (upgrade)
+     * - `"credit"` — customer receives credit (downgrade)
+     * - `"none"` — no financial movement
+     */
+    direction: "charge" | "credit" | "none"
+    /** Net amount as a decimal number, e.g. 17.45. From `update_summary.result.amount`. */
+    amount: number
+  }
+  /** Credit/charge breakdown from `update_summary` */
+  breakdown?: {
+    /** Credit from current plan as a decimal number. From `update_summary.credit`. */
+    credit?: number
+    /** Charge for new plan as a decimal number. From `update_summary.charge`. */
+    charge?: number
+  }
+  /**
+   * Immediate transaction details.
+   * Present for `*_immediately` proration modes. From `immediate_transaction`.
+   */
+  immediateTransaction?: PlanChangeTransactionSectionData
+  /** Next billing period transaction details. From `next_transaction`. */
+  nextTransaction?: PlanChangeTransactionSectionData
+  /** Recurring (steady-state) billing details. From `recurring_transaction_details`. */
+  recurringTransaction?: PlanChangeTransactionSectionData
+}

--- a/frontend/src/lib/payment-method-icons.tsx
+++ b/frontend/src/lib/payment-method-icons.tsx
@@ -1,0 +1,124 @@
+import * as React from "react"
+import type { PaddlePaymentMethodType, PaddleCardType } from "./paddle-payment-method-display"
+
+// --- Brand icon components ---
+
+function VisaIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 38 24" className={className} aria-hidden="true">
+      <rect width="38" height="24" rx="4" fill="currentColor" fillOpacity="0.08" />
+      <path
+        d="M16.5 7.5L14.1 16.5H11.7L14.1 7.5H16.5ZM26.4 13.5L27.6 10.1L28.3 13.5H26.4ZM29.1 16.5H31.3L29.4 7.5H27.4C26.9 7.5 26.5 7.8 26.3 8.2L22.8 16.5H25.3L25.8 15.1H28.8L29.1 16.5ZM23.1 13.5C23.1 11.1 19.7 11 19.7 9.9C19.7 9.6 20 9.2 20.7 9.1C21 9.1 22 9 23.1 9.5L23.5 7.8C22.9 7.6 22.1 7.4 21.1 7.4C18.7 7.4 17.1 8.7 17.1 10.5C17.1 11.9 18.4 12.6 19.3 13.1C20.3 13.5 20.6 13.8 20.6 14.2C20.6 14.8 19.9 15.1 19.2 15.1C18 15.1 17.3 14.8 16.7 14.5L16.3 16.3C16.9 16.6 18 16.8 19.1 16.8C21.6 16.8 23.1 15.5 23.1 13.5Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+function MastercardIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 38 24" className={className} aria-hidden="true">
+      <rect width="38" height="24" rx="4" fill="currentColor" fillOpacity="0.08" />
+      <circle cx="15" cy="12" r="5" fill="currentColor" fillOpacity="0.6" />
+      <circle cx="23" cy="12" r="5" fill="currentColor" fillOpacity="0.4" />
+    </svg>
+  )
+}
+
+function AmexIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 38 24" className={className} aria-hidden="true">
+      <rect width="38" height="24" rx="4" fill="currentColor" fillOpacity="0.08" />
+      <text
+        x="19"
+        y="16"
+        textAnchor="middle"
+        fontSize="8"
+        fontWeight="700"
+        fill="currentColor"
+        fontFamily="sans-serif"
+      >
+        AMEX
+      </text>
+    </svg>
+  )
+}
+
+function PayPalIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 38 24" className={className} aria-hidden="true">
+      <rect width="38" height="24" rx="4" fill="currentColor" fillOpacity="0.08" />
+      <text
+        x="19"
+        y="16"
+        textAnchor="middle"
+        fontSize="7"
+        fontWeight="700"
+        fill="currentColor"
+        fontFamily="sans-serif"
+      >
+        PayPal
+      </text>
+    </svg>
+  )
+}
+
+function ApplePayIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 38 24" className={className} aria-hidden="true">
+      <rect width="38" height="24" rx="4" fill="currentColor" fillOpacity="0.08" />
+      <path
+        d="M19 7.5C18 7.5 17.2 8 16.7 8.7C16.2 8.1 15.4 7.5 14.4 7.5C12.6 7.5 11.2 9 11.2 11C11.2 14 14.4 16.5 15.6 16.5C16.1 16.5 16.6 16.2 17 16.2C17.4 16.2 17.9 16.5 18.4 16.5C19.6 16.5 22.8 14 22.8 11C22.8 9 21.4 7.5 19 7.5Z"
+        fill="currentColor"
+        fillOpacity="0.7"
+      />
+    </svg>
+  )
+}
+
+function GooglePayIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 38 24" className={className} aria-hidden="true">
+      <rect width="38" height="24" rx="4" fill="currentColor" fillOpacity="0.08" />
+      <text
+        x="19"
+        y="16"
+        textAnchor="middle"
+        fontSize="7"
+        fontWeight="700"
+        fill="currentColor"
+        fontFamily="sans-serif"
+      >
+        GPay
+      </text>
+    </svg>
+  )
+}
+
+// --- Lookup ---
+
+const CARD_BRAND_ICONS: Record<string, React.ElementType> = {
+  visa: VisaIcon,
+  mastercard: MastercardIcon,
+  american_express: AmexIcon,
+}
+
+const PAYMENT_METHOD_ICONS: Record<string, React.ElementType> = {
+  paypal: PayPalIcon,
+  apple_pay: ApplePayIcon,
+  google_pay: GooglePayIcon,
+}
+
+/**
+ * Returns an icon component for the given Paddle payment method type and optional card brand.
+ * Returns `null` when no branded icon is available — callers should fall back to a generic icon.
+ */
+export function getPaymentMethodIcon(
+  type: PaddlePaymentMethodType,
+  cardBrand?: PaddleCardType
+): React.ElementType | null {
+  if (type === "card" && cardBrand) {
+    return CARD_BRAND_ICONS[cardBrand] ?? null
+  }
+  return PAYMENT_METHOD_ICONS[type] ?? null
+}

--- a/frontend/src/lib/plan-change-breakdown-utils.ts
+++ b/frontend/src/lib/plan-change-breakdown-utils.ts
@@ -1,0 +1,212 @@
+import type {
+  PlanChangeBreakdownData,
+  PlanChangeLineItemData,
+  PlanChangeTransactionSectionData,
+  PlanChangeTransactionTotalsData,
+} from "@/lib/paddle-types"
+import { parseAmount } from "@/lib/paddle-format"
+
+// ---
+// Input shapes — matching Paddle Node SDK / API response structures.
+// `immediate_transaction` and `next_transaction` share a shape with
+// `details.line_items` and `details.totals`. `recurring_transaction_details`
+// has `line_items` and `totals` at the top level (no `details` wrapper)
+// and omits `billing_period`.
+// ---
+
+type AmountWithCurrency = {
+  amount: string
+  currencyCode: string
+}
+
+type LineItemTotals = {
+  subtotal: string
+  total: string
+  tax: string
+  discount: string
+}
+
+type Proration = {
+  rate: string
+  billingPeriod: {
+    startsAt: string
+    endsAt: string
+  }
+} | null
+
+type LineItem = {
+  product: { name: string }
+  quantity: number
+  unitTotals: { subtotal: string }
+  totals: LineItemTotals
+  proration?: Proration
+}
+
+type TransactionTotals = {
+  subtotal: string
+  discount: string
+  tax: string
+  total: string
+  grandTotal: string
+  credit: string
+  creditToBalance?: string
+}
+
+type TransactionPreview = {
+  billingPeriod?: { startsAt?: string | null; endsAt?: string | null } | null
+  details: {
+    totals: TransactionTotals
+    lineItems: LineItem[]
+  }
+}
+
+type RecurringTransactionDetails = {
+  totals: TransactionTotals & { currencyCode: string }
+  lineItems: LineItem[]
+}
+
+type UpdateSummary = {
+  credit: AmountWithCurrency
+  charge: AmountWithCurrency
+  result: {
+    action: "credit" | "charge"
+    amount: string
+    currencyCode: string
+  }
+}
+
+type BreakdownPreviewResponse = {
+  currencyCode: string
+  updateSummary: UpdateSummary
+  immediateTransaction?: TransactionPreview | null
+  nextTransaction?: TransactionPreview | null
+  recurringTransactionDetails?: RecurringTransactionDetails | null
+}
+
+function mapLineItems(items: LineItem[], currencyCode: string): PlanChangeLineItemData[] {
+  return items.map((item) => {
+    const hasProration = item.proration != null
+    let prorationPeriod: string | undefined
+
+    if (hasProration && item.proration) {
+      const rate = parseFloat(item.proration.rate)
+      if (!isNaN(rate) && rate > 0 && rate < 1) {
+        const start = new Date(item.proration.billingPeriod.startsAt)
+        const end = new Date(item.proration.billingPeriod.endsAt)
+        const totalDays = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))
+        const proratedDays = Math.round(totalDays * rate)
+        prorationPeriod = `${proratedDays} of ${totalDays} days`
+      }
+    }
+
+    return {
+      productName: item.product.name,
+      quantity: item.quantity,
+      unitPrice: parseAmount(item.unitTotals.subtotal, currencyCode),
+      total: parseAmount(item.totals.total, currencyCode),
+      isProrated: hasProration || undefined,
+      prorationPeriod,
+    }
+  })
+}
+
+function mapTotals(
+  totals: TransactionTotals,
+  currencyCode: string
+): PlanChangeTransactionTotalsData {
+  const discount = parseAmount(totals.discount, currencyCode)
+  const credit = parseAmount(totals.credit, currencyCode)
+  const creditToBalance = totals.creditToBalance
+    ? parseAmount(totals.creditToBalance, currencyCode)
+    : 0
+
+  return {
+    subtotal: parseAmount(totals.subtotal, currencyCode),
+    discount: discount > 0 ? discount : undefined,
+    tax: parseAmount(totals.tax, currencyCode),
+    credit: credit > 0 ? credit : undefined,
+    creditToBalance: creditToBalance > 0 ? creditToBalance : undefined,
+    total: parseAmount(totals.grandTotal, currencyCode),
+  }
+}
+
+/**
+ * Maps a Paddle subscription preview API response to the `PlanChangeBreakdownData`
+ * display contract consumed by `PlanChangeBreakdown`.
+ *
+ * Provides full financial detail — line items, tax, proration periods, and totals.
+ * Pass `collectionMode` directly to `<PlanChangeBreakdown>` as a prop.
+ *
+ * @param preview - Subscription update preview response
+ * @returns Mapped breakdown data for `<PlanChangeBreakdown />`
+ *
+ * @example
+ * const preview = await paddle.subscriptions.previewUpdate(subscriptionId, {
+ *   items: [{ priceId: newPriceId, quantity: 1 }],
+ *   prorationBillingMode: "prorated_immediately",
+ * })
+ * const data = mapPreviewToBreakdownData(preview)
+ */
+export function mapPreviewToBreakdownData(
+  preview: BreakdownPreviewResponse
+): PlanChangeBreakdownData {
+  const {
+    currencyCode,
+    updateSummary,
+    immediateTransaction,
+    nextTransaction,
+    recurringTransactionDetails,
+  } = preview
+
+  const resultAmount = parseAmount(updateSummary.result.amount, currencyCode)
+  const creditAmount = parseAmount(updateSummary.credit.amount, currencyCode)
+  const chargeAmount = parseAmount(updateSummary.charge.amount, currencyCode)
+  const isNone = resultAmount === 0
+
+  const result: PlanChangeBreakdownData["result"] = {
+    direction: isNone ? "none" : updateSummary.result.action,
+    amount: resultAmount,
+  }
+
+  const breakdown: PlanChangeBreakdownData["breakdown"] =
+    creditAmount > 0 || chargeAmount > 0
+      ? {
+          credit: creditAmount > 0 ? creditAmount : undefined,
+          charge: chargeAmount > 0 ? chargeAmount : undefined,
+        }
+      : undefined
+
+  let immediateSectionData: PlanChangeTransactionSectionData | undefined
+  if (immediateTransaction) {
+    immediateSectionData = {
+      lineItems: mapLineItems(immediateTransaction.details.lineItems, currencyCode),
+      totals: mapTotals(immediateTransaction.details.totals, currencyCode),
+    }
+  }
+
+  let nextSectionData: PlanChangeTransactionSectionData | undefined
+  if (nextTransaction) {
+    nextSectionData = {
+      billingDate: nextTransaction.billingPeriod?.startsAt ?? undefined,
+      lineItems: mapLineItems(nextTransaction.details.lineItems, currencyCode),
+      totals: mapTotals(nextTransaction.details.totals, currencyCode),
+    }
+  }
+
+  let recurringSectionData: PlanChangeTransactionSectionData | undefined
+  if (recurringTransactionDetails) {
+    recurringSectionData = {
+      lineItems: mapLineItems(recurringTransactionDetails.lineItems, currencyCode),
+      totals: mapTotals(recurringTransactionDetails.totals, currencyCode),
+    }
+  }
+
+  return {
+    currency: currencyCode,
+    result,
+    breakdown,
+    immediateTransaction: immediateSectionData,
+    nextTransaction: nextSectionData,
+    recurringTransaction: recurringSectionData,
+  }
+}

--- a/frontend/src/lib/plan-change-preview-utils.ts
+++ b/frontend/src/lib/plan-change-preview-utils.ts
@@ -1,0 +1,183 @@
+import type { PlanChangePreviewData } from "@/lib/paddle-types"
+import { parseAmount } from "@/lib/paddle-format"
+
+// ---
+// Input shapes — minimal types matching the Paddle Node SDK / API response.
+// The preview endpoint (PATCH /subscriptions/{id}/preview) returns a full
+// subscription snapshot plus update_summary and transaction previews.
+// ---
+
+type AmountWithCurrency = {
+  amount: string
+  currencyCode: string
+}
+
+type UpdateSummary = {
+  credit: AmountWithCurrency
+  charge: AmountWithCurrency
+  result: {
+    action: "credit" | "charge"
+    amount: string
+    currencyCode: string
+  }
+}
+
+type TransactionPreview = {
+  billingPeriod?: { startsAt?: string | null } | null
+  details?: {
+    totals?: {
+      grandTotal?: string | null
+    } | null
+  } | null
+} | null
+
+type RecurringDetails = {
+  totals: { total: string; currencyCode: string }
+  lineItems?: Array<{ totals: { total: string } }> | null
+}
+
+type PlanItem = {
+  product: { name: string }
+  price: {
+    unitPrice?: { amount: string; currencyCode: string } | null
+    billingCycle?: { interval: string; frequency: number } | null
+  }
+}
+
+type SubscriptionPreviewResponse = {
+  currencyCode: string
+  billingCycle: { interval: string; frequency: number }
+  updateSummary: UpdateSummary
+  immediateTransaction?: TransactionPreview
+  nextTransaction?: TransactionPreview
+  recurringTransactionDetails: RecurringDetails
+  items: PlanItem[]
+}
+
+// Matches SDK SubscriptionDiscount — subscription.discount only has id + dates
+type SubscriptionDiscountField = {
+  id: string
+  startsAt?: string | null
+  endsAt?: string | null
+} | null
+
+type PaddleSubscription = {
+  currencyCode: string
+  billingCycle: { interval: string; frequency: number }
+  items: PlanItem[]
+  status?: "active" | "canceled" | "past_due" | "paused" | "trialing"
+  collectionMode?: "automatic" | "manual"
+  scheduledChange?: {
+    action: "cancel" | "pause" | "resume"
+    effectiveAt: string
+  } | null
+  discount?: SubscriptionDiscountField
+}
+
+// Full Discount catalog entity — fetched separately via paddle.discounts.get(id)
+type PaddleDiscount = {
+  id: string
+  description: string
+  code?: string | null
+  type: "flat" | "flat_per_seat" | "percentage"
+  amount: string
+}
+
+/**
+ * Maps a Paddle subscription preview API response to the `PlanChangePreviewData`
+ * display contract consumed by `PlanChangePreview`.
+ *
+ * Pass `prorationBillingMode` directly to the `<PlanChangePreview>` component as a prop.
+ * Optionally pass a Paddle `Discount` to enrich the discount display.
+ *
+ * @param subscription - Current Paddle Subscription (before the change)
+ * @param preview - Subscription update preview response
+ * @param discount - Paddle Discount for enriched discount display
+ * @returns Mapped preview data for `<PlanChangePreview />`
+ *
+ * @example
+ * const subscription = await paddle.subscriptions.get(subscriptionId)
+ * const preview = await paddle.subscriptions.previewUpdate(subscriptionId, {
+ *   items: [{ priceId: newPriceId, quantity: 1 }],
+ *   prorationBillingMode: "prorated_immediately",
+ * })
+ * const data = mapPreviewToPlanChangeData(subscription, preview)
+ */
+export function mapPreviewToPlanChangeData(
+  subscription: PaddleSubscription,
+  preview: SubscriptionPreviewResponse,
+  discount?: PaddleDiscount | null
+): PlanChangePreviewData {
+  const currencyCode = preview.currencyCode
+  const { updateSummary, immediateTransaction, nextTransaction, recurringTransactionDetails } =
+    preview
+
+  const resultAmount = parseAmount(updateSummary.result.amount, currencyCode)
+  const creditAmount = parseAmount(updateSummary.credit.amount, currencyCode)
+  const chargeAmount = parseAmount(updateSummary.charge.amount, currencyCode)
+
+  const resultDirection: PlanChangePreviewData["costImpact"]["resultDirection"] =
+    resultAmount === 0 ? "none" : updateSummary.result.action
+
+  const immediateAmount = immediateTransaction?.details?.totals?.grandTotal
+    ? parseAmount(immediateTransaction.details.totals.grandTotal, currencyCode)
+    : undefined
+
+  const nextBillAmount = nextTransaction?.details?.totals?.grandTotal
+    ? parseAmount(nextTransaction.details.totals.grandTotal, currencyCode)
+    : undefined
+
+  const nextBillDate = nextTransaction?.billingPeriod?.startsAt ?? undefined
+
+  const currentItem = subscription.items[0]
+  const newItem = preview.items[0]
+
+  // description is required by PlanChangePreviewData.discount — only set when full entity provided
+  const discountOutput: PlanChangePreviewData["discount"] = discount
+    ? {
+        description: discount.description,
+        endsAt: subscription.discount?.endsAt ?? undefined,
+      }
+    : undefined
+
+  const scheduledChange: PlanChangePreviewData["scheduledChange"] = subscription.scheduledChange
+    ? {
+        action: subscription.scheduledChange.action,
+        effectiveAt: subscription.scheduledChange.effectiveAt,
+      }
+    : undefined
+
+  return {
+    currency: currencyCode,
+    currentPlan: {
+      productName: currentItem.product.name,
+      price: currentItem.price.unitPrice
+        ? parseAmount(currentItem.price.unitPrice.amount, currencyCode)
+        : 0,
+      interval: subscription.billingCycle.interval,
+      billingFrequency: subscription.billingCycle.frequency,
+    },
+    newPlan: {
+      productName: newItem.product.name,
+      price: parseAmount(recurringTransactionDetails.totals.total, currencyCode),
+      interval: preview.billingCycle.interval,
+      billingFrequency: preview.billingCycle.frequency,
+    },
+    costImpact: {
+      resultDirection,
+      resultAmount,
+      credit: creditAmount > 0 ? creditAmount : undefined,
+      charge: chargeAmount > 0 ? chargeAmount : undefined,
+      immediateAmount,
+      nextBillAmount,
+      nextBillDate,
+      newRecurringTotal: parseAmount(recurringTransactionDetails.totals.total, currencyCode),
+      newBillingInterval: preview.billingCycle.interval,
+      newBillingFrequency: preview.billingCycle.frequency,
+    },
+    discount: discountOutput,
+    scheduledChange,
+    subscriptionStatus: subscription.status,
+    collectionMode: subscription.collectionMode,
+  }
+}

--- a/frontend/src/lib/plan-change-preview-utils.ts
+++ b/frontend/src/lib/plan-change-preview-utils.ts
@@ -129,8 +129,8 @@ export function mapPreviewToPlanChangeData(
 
   const nextBillDate = nextTransaction?.billingPeriod?.startsAt ?? undefined
 
-  const currentItem = subscription.items[0]
-  const newItem = preview.items[0]
+  const currentItem = subscription.items[0]!
+  const newItem = preview.items[0]!
 
   // description is required by PlanChangePreviewData.discount — only set when full entity provided
   const discountOutput: PlanChangePreviewData["discount"] = discount

--- a/frontend/src/lib/subscription-alert-utils.ts
+++ b/frontend/src/lib/subscription-alert-utils.ts
@@ -1,0 +1,184 @@
+import type { SubscriptionAlertData } from "@/lib/paddle-types"
+import { formatDate } from "@/lib/paddle-format"
+
+export type AlertVariant = "destructive" | "warning" | "info"
+
+/**
+ * Machine-readable reason identifier for the derived alert.
+ *
+ * Use this to key i18n translations, apply custom rendering logic, or
+ * conditionally render additional UI without parsing the default English message.
+ *
+ * @example
+ * const alert = deriveSubscriptionAlert(data)
+ * if (alert) {
+ *   const translated = t(`subscription.alert.${alert.reason}`, { date: ... })
+ * }
+ */
+export type AlertReason =
+  | "past_due" // P1: status === "past_due"
+  | "canceled" // P2: status === "canceled"
+  | "scheduled_cancel" // P3: scheduledChange.action === "cancel"
+  | "scheduled_pause" // P4: scheduledChange.action === "pause"
+  | "paused_resuming" // P5: status === "paused" + scheduledChange.action === "resume"
+  | "paused" // P6: status === "paused", no scheduled resume
+  | "trialing" // P7: status === "trialing" + trialEndsAt present
+
+export type DerivedAlert = {
+  variant: AlertVariant
+  /**
+   * Machine-readable reason for this alert. Stable across versions — use to
+   * key i18n translations or apply custom logic without parsing `message`.
+   */
+  reason: AlertReason
+  /** Default English message. Sufficient for most consumers out of the box. */
+  message: string
+  actionLabel?: string
+  actionUrl?: string
+} | null
+
+/**
+ * Derives the contextual alert for a subscription state.
+ *
+ * Evaluated in priority order; first match wins.
+ * Returns `null` for healthy active subscriptions.
+ *
+ * @param data - Subscription alert data
+ * @returns Alert descriptor with `reason` + default `message`, or null
+ *
+ * @example
+ * deriveSubscriptionAlert({ status: "past_due", updatePaymentMethodUrl: "https://..." })
+ * // { reason: "past_due", variant: "destructive", message: "Payment failed...", ... }
+ *
+ * @example i18n usage
+ * const alert = deriveSubscriptionAlert(data)
+ * if (alert) {
+ *   const message = t(`subscription.alert.${alert.reason}`, { effectiveAt: data.scheduledChange?.effectiveAt })
+ * }
+ */
+export function deriveSubscriptionAlert(data: SubscriptionAlertData | undefined): DerivedAlert {
+  if (!data) return null
+
+  const { status, canceledAt, scheduledChange, trialEndsAt, updatePaymentMethodUrl } = data
+
+  // Priority 1: past_due
+  if (status === "past_due") {
+    return {
+      reason: "past_due",
+      variant: "destructive",
+      message: updatePaymentMethodUrl
+        ? "Payment failed. Please update your payment method to avoid losing access."
+        : "Payment failed. Please contact support to resolve your billing issue.",
+      actionLabel: updatePaymentMethodUrl ? "Update payment method" : undefined,
+      actionUrl: updatePaymentMethodUrl,
+    }
+  }
+
+  // Priority 2: canceled
+  if (status === "canceled") {
+    return {
+      reason: "canceled",
+      variant: "destructive",
+      message: canceledAt
+        ? `This subscription was canceled on ${formatDate(canceledAt)}.`
+        : "This subscription has been canceled.",
+    }
+  }
+
+  // Priority 3: scheduled_cancel
+  if (scheduledChange?.action === "cancel") {
+    return {
+      reason: "scheduled_cancel",
+      variant: "warning",
+      message: `This subscription is scheduled to cancel on ${formatDate(scheduledChange.effectiveAt)}.`,
+    }
+  }
+
+  // Priority 4: scheduled_pause
+  if (scheduledChange?.action === "pause") {
+    const message = scheduledChange.resumeAt
+      ? `This subscription will pause on ${formatDate(scheduledChange.effectiveAt)} and resume on ${formatDate(scheduledChange.resumeAt)}.`
+      : `This subscription will pause on ${formatDate(scheduledChange.effectiveAt)}.`
+    return { reason: "scheduled_pause", variant: "warning", message }
+  }
+
+  // Priority 5: paused_resuming
+  if (status === "paused" && scheduledChange?.action === "resume") {
+    return {
+      reason: "paused_resuming",
+      variant: "info",
+      message: `This subscription is paused. It will resume on ${formatDate(scheduledChange.effectiveAt)}.`,
+    }
+  }
+
+  // Priority 6: paused
+  if (status === "paused") {
+    return {
+      reason: "paused",
+      variant: "info",
+      message: "This subscription is paused.",
+    }
+  }
+
+  // Priority 7: trialing
+  if (status === "trialing" && trialEndsAt) {
+    return {
+      reason: "trialing",
+      variant: "info",
+      message: `Your trial ends on ${formatDate(trialEndsAt)}.`,
+    }
+  }
+
+  // Priority 8: active — no alert
+  return null
+}
+
+// ---
+// Mapping utility — Paddle API → SubscriptionAlertData display contract
+// ---
+
+type PaddleSubscription = {
+  status: "active" | "canceled" | "past_due" | "paused" | "trialing"
+  canceledAt?: string | null
+  scheduledChange?: {
+    action: "cancel" | "pause" | "resume"
+    effectiveAt: string
+    resumeAt?: string | null
+  } | null
+  items?: Array<{
+    trialDates?: { endsAt?: string | null } | null
+  }>
+  managementUrls?: {
+    updatePaymentMethod?: string | null
+  } | null
+}
+
+/**
+ * Maps a Paddle subscription API response to the `SubscriptionAlertData`
+ * display contract consumed by `SubscriptionAlert`.
+ *
+ * @param subscription - Paddle Subscription
+ * @returns Mapped alert data for `<SubscriptionAlert />`
+ *
+ * @example
+ * const data = await paddle.subscriptions.get(subscriptionId)
+ * const alertData = mapSubscriptionToAlertData(data)
+ */
+export function mapSubscriptionToAlertData(
+  subscription: PaddleSubscription
+): SubscriptionAlertData {
+  return {
+    status: subscription.status,
+    canceledAt: subscription.canceledAt ?? undefined,
+    scheduledChange: subscription.scheduledChange
+      ? {
+          action: subscription.scheduledChange.action,
+          effectiveAt: subscription.scheduledChange.effectiveAt,
+          resumeAt: subscription.scheduledChange.resumeAt ?? undefined,
+        }
+      : undefined,
+    // Trial end date comes from the first item's trial dates
+    trialEndsAt: subscription.items?.[0]?.trialDates?.endsAt ?? undefined,
+    updatePaymentMethodUrl: subscription.managementUrls?.updatePaymentMethod ?? undefined,
+  }
+}

--- a/frontend/src/lib/subscription-payment-card-utils.ts
+++ b/frontend/src/lib/subscription-payment-card-utils.ts
@@ -1,0 +1,124 @@
+import type {
+  NextPaymentData,
+  PaymentMethodData,
+} from "@/lib/paddle-types"
+import { parseAmount } from "@/lib/paddle-format"
+
+// ---
+// Input shapes — minimal types matching the Paddle Node SDK / API response.
+// ---
+
+type MethodDetails = {
+  type: string
+  card?: {
+    type?: string | null
+    last4?: string | null
+    expiryMonth?: number | null
+    expiryYear?: number | null
+  } | null
+}
+
+type PaymentEntry = {
+  methodDetails?: MethodDetails | null
+}
+
+type PaddleTransaction = {
+  payments?: PaymentEntry[] | null
+  details?: {
+    totals?: {
+      grandTotal?: string | null
+    } | null
+  } | null
+}
+
+type PaddleSubscription = {
+  currencyCode: string
+  nextBilledAt?: string | null
+  managementUrls?: {
+    updatePaymentMethod?: string | null
+  } | null
+}
+
+/**
+ * Extracts the `NextPaymentData` display contract from a Paddle subscription.
+ *
+ * Requires the `next_transaction` include on the subscription fetch for the
+ * accurate next-bill amount (which may differ from the recurring total if
+ * there are prorations or one-time charges). Falls back to the subscription's
+ * `next_billed_at` for the date. Returns `undefined` when `next_billed_at`
+ * is absent (paused or canceled subscriptions).
+ *
+ * @param subscription - Paddle Subscription
+ * @param nextTransaction - `subscription.nextTransaction` from the `next_transaction` include
+ * @returns Next payment display data, or `undefined` if no upcoming payment
+ *
+ * @example
+ * const data = await paddle.subscriptions.get(subscriptionId, {
+ *   include: ["next_transaction"],
+ * })
+ * const nextPayment = mapSubscriptionToNextPayment(data, data.nextTransaction)
+ */
+export function mapSubscriptionToNextPayment(
+  subscription: PaddleSubscription,
+  nextTransaction?: PaddleTransaction | null
+): NextPaymentData | undefined {
+  if (!subscription.nextBilledAt) return undefined
+
+  const amount = nextTransaction?.details?.totals?.grandTotal
+    ? parseAmount(nextTransaction.details.totals.grandTotal, subscription.currencyCode)
+    : 0
+
+  return {
+    amount,
+    currency: subscription.currencyCode,
+    date: subscription.nextBilledAt,
+  }
+}
+
+/**
+ * Extracts the `PaymentMethodData` display contract from the most recent
+ * completed Paddle transaction for a subscription.
+ *
+ * Sourced from `transaction.payments[0].method_details` — the last recorded
+ * payment method. Returns `undefined` if no payment entry is present.
+ *
+ * @param transaction - Most recent completed Paddle Transaction for the subscription
+ * @returns Payment method display data, or `undefined` if unavailable
+ *
+ * @example
+ * // Fetch the most recent completed transaction for the subscription
+ * const transactions = await paddle.transactions.list({
+ *   subscriptionId,
+ *   status: ["completed"],
+ *   perPage: 1,
+ * })
+ * const paymentMethod = mapTransactionToPaymentMethod(transactions.data[0])
+ */
+export function mapTransactionToPaymentMethod(
+  transaction?: PaddleTransaction | null
+): PaymentMethodData | undefined {
+  const methodDetails = transaction?.payments?.[0]?.methodDetails
+  if (!methodDetails) return undefined
+
+  return {
+    type: methodDetails.type,
+    cardBrand: methodDetails.card?.type ?? undefined,
+    last4: methodDetails.card?.last4 ?? undefined,
+    expiryMonth: methodDetails.card?.expiryMonth ?? undefined,
+    expiryYear: methodDetails.card?.expiryYear ?? undefined,
+  }
+}
+
+/**
+ * Returns the `updatePaymentMethodUrl` prop value from a subscription's
+ * management URLs.
+ *
+ * Returns `undefined` for manually-collected subscriptions (where the portal
+ * URL is `null`) so the update link is hidden.
+ *
+ * @param subscription - Paddle Subscription
+ * @returns Portal URL, or `undefined` if unavailable
+ */
+export function getUpdatePaymentMethodUrl(subscription: PaddleSubscription): string | undefined {
+  return subscription.managementUrls?.updatePaymentMethod ?? undefined
+}

--- a/frontend/src/lib/subscription-status-card-utils.ts
+++ b/frontend/src/lib/subscription-status-card-utils.ts
@@ -1,0 +1,152 @@
+import type { SubscriptionStatusData } from "@/lib/paddle-types"
+import { parseAmount } from "@/lib/paddle-format"
+
+// ---
+// Input shapes — minimal types matching the Paddle Node SDK / API response.
+// Field names use camelCase (Node SDK convention). Pass the raw API response
+// or destructure these fields from your own subscription fetch.
+// ---
+
+type SubscriptionItem = {
+  product: {
+    name: string
+    description?: string | null
+    imageUrl?: string | null
+  }
+  price?: {
+    name?: string | null
+    unitPrice?: { amount: string; currencyCode: string } | null
+  } | null
+  quantity: number
+}
+
+type RecurringLineItem = {
+  totals: { subtotal: string; total: string }
+}
+
+type ScheduledChange = {
+  action: "cancel" | "pause" | "resume"
+  effectiveAt: string
+  resumeAt?: string | null
+} | null
+
+// Matches SDK SubscriptionDiscount — subscription.discount only has id + dates
+type SubscriptionDiscountField = {
+  id: string
+  startsAt?: string | null
+  endsAt?: string | null
+} | null
+
+// Full Discount catalog entity — fetched separately via paddle.discounts.get(id)
+type PaddleDiscount = {
+  id: string
+  description: string
+  code?: string | null
+  type: "flat" | "flat_per_seat" | "percentage"
+  amount: string
+}
+
+type PaddleSubscription = {
+  id: string
+  status: "active" | "canceled" | "past_due" | "paused" | "trialing"
+  currencyCode: string
+  billingCycle: { interval: string; frequency: number }
+  collectionMode?: "automatic" | "manual"
+  startedAt: string
+  nextBilledAt?: string | null
+  canceledAt?: string | null
+  scheduledChange?: ScheduledChange
+  discount?: SubscriptionDiscountField
+  items: SubscriptionItem[]
+}
+
+type RecurringTransactionDetails = {
+  totals: { total: string; discount?: string }
+  lineItems: RecurringLineItem[]
+}
+
+/**
+ * Maps a Paddle subscription API response to the `SubscriptionStatusData`
+ * display contract consumed by `SubscriptionStatusCard`.
+ *
+ * Pass the raw Paddle subscription and the
+ * `recurring_transaction_details` include (required for accurate totals).
+ * Optionally pass a Paddle `Discount` to enrich the discount display
+ * with `code` and a derived description label.
+ *
+ * @param subscription - Paddle Subscription
+ * @param recurringTransactionDetails - `subscription.recurringTransactionDetails` from the same response
+ * @param discount - Paddle Discount for enriched discount display
+ * @returns Mapped status data for `<SubscriptionStatusCard />`
+ *
+ * @example
+ * const data = await paddle.subscriptions.get(subscriptionId, {
+ *   include: ["recurring_transaction_details"],
+ * })
+ * const statusData = mapSubscriptionToStatusData(data, data.recurringTransactionDetails)
+ */
+export function mapSubscriptionToStatusData(
+  subscription: PaddleSubscription,
+  recurringTransactionDetails: RecurringTransactionDetails,
+  discount?: PaddleDiscount | null
+): SubscriptionStatusData {
+  const { currencyCode } = subscription
+
+  const items = subscription.items.map((item, i) => ({
+    productName: item.product.name,
+    productDescription: item.product.description ?? undefined,
+    productImageUrl: item.product.imageUrl ?? undefined,
+    priceName: item.price?.name ?? undefined,
+    quantity: item.quantity,
+    unitPrice: item.price?.unitPrice
+      ? parseAmount(item.price.unitPrice.amount, currencyCode)
+      : undefined,
+    lineTotal: parseAmount(
+      recurringTransactionDetails.lineItems[i]?.totals.subtotal ?? "0",
+      currencyCode
+    ),
+  }))
+
+  const discountAmount = recurringTransactionDetails.totals.discount
+    ? parseAmount(recurringTransactionDetails.totals.discount, currencyCode)
+    : 0
+
+  // Percentage discounts produce e.g. "-15%"; flat discounts leave description
+  // undefined so the component formats it from savingsAmount + currency.
+  const discountDescription =
+    discount?.type === "percentage" ? `-${discount.description}` : undefined
+
+  const discountOutput: SubscriptionStatusData["discount"] =
+    subscription.discount && discountAmount > 0
+      ? {
+          savingsAmount: discountAmount,
+          endsAt: subscription.discount.endsAt ?? undefined,
+          code: discount?.code ?? undefined,
+          description: discountDescription,
+        }
+      : undefined
+
+  const scheduledChange: SubscriptionStatusData["scheduledChange"] = subscription.scheduledChange
+    ? {
+        action: subscription.scheduledChange.action,
+        effectiveAt: subscription.scheduledChange.effectiveAt,
+        resumeAt: subscription.scheduledChange.resumeAt ?? undefined,
+      }
+    : undefined
+
+  return {
+    id: subscription.id,
+    items,
+    totalAmount: parseAmount(recurringTransactionDetails.totals.total, currencyCode),
+    currency: currencyCode,
+    interval: subscription.billingCycle.interval,
+    billingFrequency: subscription.billingCycle.frequency,
+    status: subscription.status,
+    collectionMode: subscription.collectionMode,
+    startedAt: subscription.startedAt,
+    nextBilledAt: subscription.nextBilledAt ?? undefined,
+    canceledAt: subscription.canceledAt ?? undefined,
+    scheduledChange,
+    discount: discountOutput,
+  }
+}

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -216,6 +216,12 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+  --color-info-foreground: var(--info-foreground);
+  --color-info: var(--info);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning: var(--warning);
+  --color-success-foreground: var(--success-foreground);
+  --color-success: var(--success);
 }
 
 :root {
@@ -254,6 +260,12 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --warning: oklch(0.769 0.163 70);
+  --warning-foreground: oklch(0.286 0.066 53);
+  --info: oklch(0.623 0.163 255);
+  --info-foreground: oklch(0.235 0.063 258);
+  --success: oklch(0.723 0.157 150);
+  --success-foreground: oklch(0.266 0.065 152);
 }
 
 .dark {
@@ -291,6 +303,12 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --warning: oklch(0.437 0.096 54);
+  --warning-foreground: oklch(0.94 0.034 82);
+  --info: oklch(0.423 0.095 258);
+  --info-foreground: oklch(0.92 0.042 252);
+  --success: oklch(0.423 0.095 152);
+  --success-foreground: oklch(0.92 0.042 154);
 }
 html {
   scroll-padding-top: 4rem;

--- a/lib/engram/billing/subscriptions.ex
+++ b/lib/engram/billing/subscriptions.ex
@@ -1,0 +1,62 @@
+defmodule Engram.Billing.Subscriptions do
+  @moduledoc """
+  User-initiated subscription operations on top of `Engram.Paddle.Client`.
+
+  Distinct from `Engram.Billing` (which exposes read-side helpers like
+  `get_subscription/1`, `tier/1`, `active?/1`) and from
+  `Engram.Accounts.Lifecycle` (which cancels Paddle as a side-effect of
+  account deletion using `effective_from: :immediately`). This module is
+  for explicit user actions on their own subscription — the `/api/billing`
+  cancel/update endpoints route here.
+
+  Each call to Paddle carries a deterministic `idempotency_key` so retries
+  (network blips, user re-clicks) cannot double-cancel.
+  """
+
+  alias Engram.Accounts.User
+  alias Engram.Billing
+  alias Engram.Billing.Subscription
+  alias Engram.Paddle.Client
+
+  @doc """
+  Cancel the user's Paddle subscription.
+
+  Defaults to `:next_billing_period` so the user keeps service through the
+  end of the current paid period — the user-facing cancel flow. Pass
+  `:immediately` only when the caller has its own reason to terminate now
+  (rare in user-initiated paths; account hard-delete has its own helper).
+
+  Returns:
+    * `{:ok, paddle_data}` — Paddle accepted the cancel; payload is the
+      decoded Paddle subscription. Webhook-driven sync (`PaddleWebhook`)
+      mirrors the resulting state into our DB; callers don't need to write
+      anything here.
+    * `{:error, :no_active_subscription}` — no `paddle_subscription_id` on
+      file. Self-host users + users who have never paid land here.
+    * `{:error, :paddle_unavailable}` — Paddle returned non-2xx or the
+      transport failed. Surface as 503 at the controller boundary.
+  """
+  @spec cancel(User.t(), :immediately | :next_billing_period) ::
+          {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
+  def cancel(user, effective_from \\ :next_billing_period)
+      when effective_from in [:immediately, :next_billing_period] do
+    case Billing.get_subscription(user) do
+      %Subscription{paddle_subscription_id: sub_id} when is_binary(sub_id) ->
+        do_cancel(user, sub_id, effective_from)
+
+      _ ->
+        {:error, :no_active_subscription}
+    end
+  end
+
+  defp do_cancel(user, sub_id, effective_from) do
+    idempotency_key = "cancel-#{user.id}-#{sub_id}-#{System.unique_integer([:positive])}"
+
+    case Client.impl().cancel_subscription(sub_id, effective_from,
+           idempotency_key: idempotency_key
+         ) do
+      {:ok, data} -> {:ok, data}
+      {:error, _reason} -> {:error, :paddle_unavailable}
+    end
+  end
+end

--- a/lib/engram/billing/subscriptions.ex
+++ b/lib/engram/billing/subscriptions.ex
@@ -105,6 +105,28 @@ defmodule Engram.Billing.Subscriptions do
     end)
   end
 
+  @doc """
+  Reverse a scheduled cancel by clearing Paddle's `scheduled_change`.
+
+  Patches the subscription with `scheduled_change: nil` and no item changes.
+  Returns `{:ok, paddle_data}` or `{:error, :no_active_subscription | :paddle_unavailable}`.
+  """
+  @spec reverse_cancel(User.t()) ::
+          {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
+  def reverse_cancel(user) do
+    with_active_sub(user, fn sub_id ->
+      idempotency_key =
+        "reverse-cancel-#{user.id}-#{sub_id}-#{System.unique_integer([:positive])}"
+
+      Client.impl().update_subscription(
+        sub_id,
+        [],
+        idempotency_key: idempotency_key,
+        scheduled_change: nil
+      )
+    end)
+  end
+
   defp with_active_sub(user, fun) do
     case Billing.get_subscription(user) do
       %Subscription{paddle_subscription_id: sub_id} when is_binary(sub_id) ->

--- a/lib/engram/billing/subscriptions.ex
+++ b/lib/engram/billing/subscriptions.ex
@@ -59,4 +59,62 @@ defmodule Engram.Billing.Subscriptions do
       {:error, _reason} -> {:error, :paddle_unavailable}
     end
   end
+
+  @doc """
+  Preview a plan change without committing.
+
+  Paddle proration mode is `prorated_immediately` — the inline panel renders
+  `old_total`, `new_total`, `immediate_charge_or_credit`, `next_billed_at`
+  for the user to confirm. Read-only on Paddle's side.
+
+  Returns `{:ok, preview}` or `{:error, :no_active_subscription | :paddle_unavailable}`.
+  """
+  @spec preview_plan_change(User.t(), String.t()) ::
+          {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
+  def preview_plan_change(user, new_price_id) when is_binary(new_price_id) do
+    with_active_sub(user, fn sub_id ->
+      Client.impl().preview_subscription_update(
+        sub_id,
+        [%{price_id: new_price_id, quantity: 1}],
+        proration_billing_mode: "prorated_immediately"
+      )
+    end)
+  end
+
+  @doc """
+  Commit a plan change.
+
+  Idempotency key prevents double-apply on retry. Webhook mirror reflects
+  the new plan into our DB; callers don't write here.
+
+  Returns `{:ok, paddle_data}` or `{:error, :no_active_subscription | :paddle_unavailable}`.
+  """
+  @spec confirm_plan_change(User.t(), String.t()) ::
+          {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
+  def confirm_plan_change(user, new_price_id) when is_binary(new_price_id) do
+    with_active_sub(user, fn sub_id ->
+      idempotency_key =
+        "plan-change-#{user.id}-#{sub_id}-#{System.unique_integer([:positive])}"
+
+      Client.impl().update_subscription(
+        sub_id,
+        [%{price_id: new_price_id, quantity: 1}],
+        idempotency_key: idempotency_key,
+        proration_billing_mode: "prorated_immediately"
+      )
+    end)
+  end
+
+  defp with_active_sub(user, fun) do
+    case Billing.get_subscription(user) do
+      %Subscription{paddle_subscription_id: sub_id} when is_binary(sub_id) ->
+        case fun.(sub_id) do
+          {:ok, data} -> {:ok, data}
+          {:error, _reason} -> {:error, :paddle_unavailable}
+        end
+
+      _ ->
+        {:error, :no_active_subscription}
+    end
+  end
 end

--- a/lib/engram/billing/subscriptions.ex
+++ b/lib/engram/billing/subscriptions.ex
@@ -50,14 +50,27 @@ defmodule Engram.Billing.Subscriptions do
   end
 
   defp do_cancel(user, sub_id, effective_from) do
-    idempotency_key = "cancel-#{user.id}-#{sub_id}-#{System.unique_integer([:positive])}"
-
     case Client.impl().cancel_subscription(sub_id, effective_from,
-           idempotency_key: idempotency_key
+           idempotency_key: idempotency_key(:cancel, user, sub_id, effective_from)
          ) do
       {:ok, data} -> {:ok, data}
       {:error, _reason} -> {:error, :paddle_unavailable}
     end
+  end
+
+  # Idempotency keys MUST be deterministic per logical request — Paddle's
+  # `Paddle-IK` header is the dedup signal for retries (network blip, React
+  # Query auto-retry, user double-click). A counter or timestamp produces a
+  # fresh key every call, defeating dedup; Paddle then accepts both calls as
+  # distinct requests and we double-cancel / double-charge.
+  #
+  # phash2 of (verb, user_id, sub_id, target_state) is stable across BEAM
+  # restarts and process boundaries while still varying per distinct logical
+  # action — switching cadence later mints a different key (target_state
+  # changes), so legitimate re-tries collapse but legitimate re-cancels don't.
+  defp idempotency_key(verb, user, sub_id, target_state) do
+    hash = :erlang.phash2({verb, user.id, sub_id, target_state})
+    "#{verb}-#{user.id}-#{sub_id}-#{hash}"
   end
 
   @doc """
@@ -93,13 +106,10 @@ defmodule Engram.Billing.Subscriptions do
           {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
   def confirm_plan_change(user, new_price_id) when is_binary(new_price_id) do
     with_active_sub(user, fn sub_id ->
-      idempotency_key =
-        "plan-change-#{user.id}-#{sub_id}-#{System.unique_integer([:positive])}"
-
       Client.impl().update_subscription(
         sub_id,
         [%{price_id: new_price_id, quantity: 1}],
-        idempotency_key: idempotency_key,
+        idempotency_key: idempotency_key(:plan_change, user, sub_id, new_price_id),
         proration_billing_mode: "prorated_immediately"
       )
     end)
@@ -115,13 +125,10 @@ defmodule Engram.Billing.Subscriptions do
           {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
   def reverse_cancel(user) do
     with_active_sub(user, fn sub_id ->
-      idempotency_key =
-        "reverse-cancel-#{user.id}-#{sub_id}-#{System.unique_integer([:positive])}"
-
       Client.impl().update_subscription(
         sub_id,
         [],
-        idempotency_key: idempotency_key,
+        idempotency_key: idempotency_key(:reverse_cancel, user, sub_id, :clear),
         scheduled_change: nil
       )
     end)

--- a/lib/engram/paddle/client.ex
+++ b/lib/engram/paddle/client.ex
@@ -115,6 +115,36 @@ defmodule Engram.Paddle.Client do
               opts :: keyword()
             ) :: {:ok, map()} | {:error, term()}
 
+  @doc """
+  Preview a subscription plan change without committing it.
+
+  Paddle endpoint: `PATCH /subscriptions/{id}/preview` with body
+  `{"items": [...], "proration_billing_mode": "..."}`. Returns the decoded
+  `data` map; surfaces `old_total`, `new_total`, `immediate_charge_or_credit`,
+  `next_billed_at` for the inline PlanChangePanel to render. Read-only on
+  Paddle's side — safe to call freely.
+  """
+  @callback preview_subscription_update(
+              subscription_id :: String.t(),
+              items :: [map()],
+              opts :: keyword()
+            ) :: {:ok, map()} | {:error, term()}
+
+  @doc """
+  Apply a subscription update (plan change).
+
+  Paddle endpoint: `PATCH /subscriptions/{id}` with body
+  `{"items": [...], "proration_billing_mode": "..."}` (and optionally
+  `"scheduled_change": null` to reverse a scheduled cancel). Optional
+  `:idempotency_key` opt is forwarded as the `Paddle-IK` header. Webhook
+  mirror syncs the resulting state into our DB; callers don't write here.
+  """
+  @callback update_subscription(
+              subscription_id :: String.t(),
+              items :: [map()],
+              opts :: keyword()
+            ) :: {:ok, map()} | {:error, term()}
+
   @default_impl Engram.Paddle.Client.HTTP
 
   @doc "Returns the configured client implementation module."

--- a/lib/engram/paddle/client/http.ex
+++ b/lib/engram/paddle/client/http.ex
@@ -241,6 +241,69 @@ defmodule Engram.Paddle.Client.HTTP do
     end
   end
 
+  @impl true
+  def preview_subscription_update(subscription_id, items, opts \\ [])
+      when is_binary(subscription_id) and is_list(items) do
+    with {:ok, api_key} <- fetch_api_key() do
+      url = base_url() <> "/subscriptions/" <> subscription_id <> "/preview"
+      body = subscription_update_body(items, opts)
+
+      case Req.patch(url, headers: headers(api_key), json: body, receive_timeout: 10_000) do
+        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+          {:ok, data}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          log_non_2xx("subscription-preview", status, body)
+          {:error, {:paddle_error, status}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def update_subscription(subscription_id, items, opts \\ [])
+      when is_binary(subscription_id) and is_list(items) do
+    with {:ok, api_key} <- fetch_api_key() do
+      url = base_url() <> "/subscriptions/" <> subscription_id
+      body = subscription_update_body(items, opts)
+
+      req_headers =
+        case Keyword.get(opts, :idempotency_key) do
+          key when is_binary(key) -> headers(api_key) ++ [{"paddle-ik", key}]
+          _ -> headers(api_key)
+        end
+
+      case Req.patch(url, headers: req_headers, json: body, receive_timeout: 10_000) do
+        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+          {:ok, data}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          log_non_2xx("subscription-update", status, body)
+          {:error, {:paddle_error, status}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp subscription_update_body(items, opts) do
+    base = %{items: items}
+
+    base =
+      case Keyword.get(opts, :proration_billing_mode) do
+        mode when is_binary(mode) -> Map.put(base, :proration_billing_mode, mode)
+        _ -> base
+      end
+
+    case Keyword.get(opts, :scheduled_change, :unset) do
+      :unset -> base
+      value -> Map.put(base, :scheduled_change, value)
+    end
+  end
+
   defp log_non_2xx(label, status, body) do
     Logger.warning("Paddle #{label} non-2xx", status: status, reason_label: inspect(body))
   end

--- a/lib/engram/paddle/client/http.ex
+++ b/lib/engram/paddle/client/http.ex
@@ -289,8 +289,17 @@ defmodule Engram.Paddle.Client.HTTP do
     end
   end
 
+  # Paddle PATCH /subscriptions/{id} treats `items` as REPLACE (not merge), so
+  # an empty list either 422s ('items must be non-empty') or wipes the
+  # subscription. Omit the key entirely when the caller passes [] — the only
+  # path that does is reverse_cancel/1, which only needs to clear
+  # scheduled_change without altering items.
   defp subscription_update_body(items, opts) do
-    base = %{items: items}
+    base =
+      case items do
+        [] -> %{}
+        list when is_list(list) -> %{items: list}
+      end
 
     base =
       case Keyword.get(opts, :proration_billing_mode) do

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -152,6 +152,22 @@ defmodule EngramWeb.BillingController do
     end)
   end
 
+  @doc "Reverse a scheduled cancel before its effective date."
+  def reverse_cancel(conn, _params) do
+    with_billing(conn, fn ->
+      case Subscriptions.reverse_cancel(conn.assigns.current_user) do
+        {:ok, data} ->
+          conn |> put_status(202) |> json(data)
+
+        {:error, :no_active_subscription} ->
+          conn |> put_status(422) |> json(%{error: "no_active_subscription"})
+
+        {:error, :paddle_unavailable} ->
+          conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
+      end
+    end)
+  end
+
   @doc """
   Preview the proration shape of a plan change. Read-only; safe to call as
   the user picks a target plan.

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -2,6 +2,7 @@ defmodule EngramWeb.BillingController do
   use EngramWeb, :controller
 
   alias Engram.Billing
+  alias Engram.Billing.Subscriptions
 
   require Logger
 
@@ -125,6 +126,73 @@ defmodule EngramWeb.BillingController do
         {:error, reason} -> paddle_error(conn, reason)
       end
     end)
+  end
+
+  @doc """
+  Cancel the user's subscription at the end of the current billing period.
+
+  Maps the `Subscriptions.cancel/2` result to:
+    * 202 — Paddle accepted, scheduled-change is in flight; webhook will
+      mirror it back into our DB
+    * 422 `no_active_subscription` — user has no Paddle subscription id
+    * 503 `paddle_unavailable` — Paddle non-2xx / transport error
+  """
+  def cancel_subscription(conn, _params) do
+    with_billing(conn, fn ->
+      case Subscriptions.cancel(conn.assigns.current_user) do
+        {:ok, data} ->
+          conn |> put_status(202) |> json(data)
+
+        {:error, :no_active_subscription} ->
+          conn |> put_status(422) |> json(%{error: "no_active_subscription"})
+
+        {:error, :paddle_unavailable} ->
+          conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
+      end
+    end)
+  end
+
+  @doc """
+  Preview the proration shape of a plan change. Read-only; safe to call as
+  the user picks a target plan.
+  """
+  def plan_change_preview(conn, %{"target_price_id" => price_id}) when is_binary(price_id) do
+    with_billing(conn, fn ->
+      case Subscriptions.preview_plan_change(conn.assigns.current_user, price_id) do
+        {:ok, preview} ->
+          json(conn, preview)
+
+        {:error, :no_active_subscription} ->
+          conn |> put_status(422) |> json(%{error: "no_active_subscription"})
+
+        {:error, :paddle_unavailable} ->
+          conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
+      end
+    end)
+  end
+
+  def plan_change_preview(conn, _params) do
+    conn |> put_status(422) |> json(%{error: "target_price_id required"})
+  end
+
+  @doc "Commit a plan change after the user confirmed the inline preview."
+  def plan_change_confirm(conn, %{"target_price_id" => price_id}) when is_binary(price_id) do
+    with_billing(conn, fn ->
+      case Subscriptions.confirm_plan_change(conn.assigns.current_user, price_id) do
+        {:ok, data} ->
+          conn |> put_status(202) |> json(data)
+
+        {:error, :no_active_subscription} ->
+          conn |> put_status(422) |> json(%{error: "no_active_subscription"})
+
+        {:error, :paddle_unavailable} ->
+          conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
+      end
+    end)
+  end
+
+  def plan_change_confirm(conn, _params) do
+    conn |> put_status(422) |> json(%{error: "target_price_id required"})
   end
 
   @doc "Mint a transaction id for the in-app Paddle.js payment-method overlay."

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -174,15 +174,19 @@ defmodule EngramWeb.BillingController do
   """
   def plan_change_preview(conn, %{"target_price_id" => price_id}) when is_binary(price_id) do
     with_billing(conn, fn ->
-      case Subscriptions.preview_plan_change(conn.assigns.current_user, price_id) do
-        {:ok, preview} ->
-          json(conn, preview)
+      if valid_catalog_price_id?(price_id) do
+        case Subscriptions.preview_plan_change(conn.assigns.current_user, price_id) do
+          {:ok, preview} ->
+            json(conn, preview)
 
-        {:error, :no_active_subscription} ->
-          conn |> put_status(422) |> json(%{error: "no_active_subscription"})
+          {:error, :no_active_subscription} ->
+            conn |> put_status(422) |> json(%{error: "no_active_subscription"})
 
-        {:error, :paddle_unavailable} ->
-          conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
+          {:error, :paddle_unavailable} ->
+            conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
+        end
+      else
+        conn |> put_status(422) |> json(%{error: "invalid_price_id"})
       end
     end)
   end
@@ -194,21 +198,42 @@ defmodule EngramWeb.BillingController do
   @doc "Commit a plan change after the user confirmed the inline preview."
   def plan_change_confirm(conn, %{"target_price_id" => price_id}) when is_binary(price_id) do
     with_billing(conn, fn ->
-      case Subscriptions.confirm_plan_change(conn.assigns.current_user, price_id) do
-        {:ok, data} ->
-          conn |> put_status(202) |> json(data)
+      if valid_catalog_price_id?(price_id) do
+        case Subscriptions.confirm_plan_change(conn.assigns.current_user, price_id) do
+          {:ok, data} ->
+            conn |> put_status(202) |> json(data)
 
-        {:error, :no_active_subscription} ->
-          conn |> put_status(422) |> json(%{error: "no_active_subscription"})
+          {:error, :no_active_subscription} ->
+            conn |> put_status(422) |> json(%{error: "no_active_subscription"})
 
-        {:error, :paddle_unavailable} ->
-          conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
+          {:error, :paddle_unavailable} ->
+            conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
+        end
+      else
+        conn |> put_status(422) |> json(%{error: "invalid_price_id"})
       end
     end)
   end
 
   def plan_change_confirm(conn, _params) do
     conn |> put_status(422) |> json(%{error: "target_price_id required"})
+  end
+
+  # Allow-list: only the 4 catalog price IDs surfaced by /billing/config are
+  # valid plan-change targets. Without this guard a caller could submit an
+  # arbitrary Paddle price (sibling product, archived $0, deprecated tier) and
+  # Paddle might accept the swap, letting users escape the catalog.
+  defp valid_catalog_price_id?(price_id) do
+    catalog =
+      [
+        Application.get_env(:engram, :paddle_starter_monthly_price_id),
+        Application.get_env(:engram, :paddle_starter_annual_price_id),
+        Application.get_env(:engram, :paddle_pro_monthly_price_id),
+        Application.get_env(:engram, :paddle_pro_annual_price_id)
+      ]
+      |> Enum.filter(&is_binary/1)
+
+    price_id in catalog
   end
 
   @doc "Mint a transaction id for the in-app Paddle.js payment-method overlay."

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -214,6 +214,9 @@ defmodule EngramWeb.Router do
     get "/billing/transactions", BillingController, :transactions
     get "/billing/transactions/:id/invoice", BillingController, :transaction_invoice
     get "/billing/payment-update-transaction", BillingController, :payment_update_transaction
+    post "/billing/cancel-subscription", BillingController, :cancel_subscription
+    post "/billing/plan-change/preview", BillingController, :plan_change_preview
+    post "/billing/plan-change/confirm", BillingController, :plan_change_confirm
 
     # Onboarding wizard — status + TOS acceptance. Exempt from
     # RequireOnboarding (the plug is only on the vault-scoped pipeline)

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -215,6 +215,7 @@ defmodule EngramWeb.Router do
     get "/billing/transactions/:id/invoice", BillingController, :transaction_invoice
     get "/billing/payment-update-transaction", BillingController, :payment_update_transaction
     post "/billing/cancel-subscription", BillingController, :cancel_subscription
+    post "/billing/reverse-cancel", BillingController, :reverse_cancel
     post "/billing/plan-change/preview", BillingController, :plan_change_preview
     post "/billing/plan-change/confirm", BillingController, :plan_change_confirm
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.364",
+      version: "0.5.365",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/billing/subscriptions_test.exs
+++ b/test/engram/billing/subscriptions_test.exs
@@ -70,7 +70,9 @@ defmodule Engram.Billing.SubscriptionsTest do
 
     test "no active subscription returns {:error, :no_active_subscription}" do
       user = insert(:user)
-      assert {:error, :no_active_subscription} = Subscriptions.preview_plan_change(user, "pri_new")
+
+      assert {:error, :no_active_subscription} =
+               Subscriptions.preview_plan_change(user, "pri_new")
     end
 
     test "Paddle error returns {:error, :paddle_unavailable}" do
@@ -137,7 +139,9 @@ defmodule Engram.Billing.SubscriptionsTest do
 
     test "no active subscription returns {:error, :no_active_subscription}" do
       user = insert(:user)
-      assert {:error, :no_active_subscription} = Subscriptions.confirm_plan_change(user, "pri_new")
+
+      assert {:error, :no_active_subscription} =
+               Subscriptions.confirm_plan_change(user, "pri_new")
     end
 
     test "Paddle error returns {:error, :paddle_unavailable}" do

--- a/test/engram/billing/subscriptions_test.exs
+++ b/test/engram/billing/subscriptions_test.exs
@@ -1,0 +1,47 @@
+defmodule Engram.Billing.SubscriptionsTest do
+  use Engram.DataCase, async: true
+
+  import Mox
+
+  alias Engram.Billing.Subscriptions
+
+  setup :verify_on_exit!
+
+  describe "cancel/2" do
+    test "calls Paddle with effective_from: :next_billing_period by default and an idempotency key" do
+      user = insert(:user)
+      sub = insert(:subscription, user: user, paddle_subscription_id: "sub_cancel_default")
+
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn sub_id, effective_from, opts ->
+        assert sub_id == sub.paddle_subscription_id
+        assert effective_from == :next_billing_period
+        assert is_binary(Keyword.get(opts, :idempotency_key))
+        {:ok, %{effective_at: ~U[2026-07-01 00:00:00Z]}}
+      end)
+
+      assert {:ok, %{effective_at: %DateTime{}}} = Subscriptions.cancel(user)
+    end
+
+    test "returns {:error, :no_active_subscription} when user has no paddle_subscription_id" do
+      user = insert(:user)
+      assert {:error, :no_active_subscription} = Subscriptions.cancel(user)
+    end
+
+    test "returns {:error, :no_active_subscription} when subscription row exists but paddle_subscription_id is nil" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: nil)
+      assert {:error, :no_active_subscription} = Subscriptions.cancel(user)
+    end
+
+    test "Paddle error returns {:error, :paddle_unavailable}" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_cancel_err")
+
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
+        {:error, :http_500}
+      end)
+
+      assert {:error, :paddle_unavailable} = Subscriptions.cancel(user)
+    end
+  end
+end

--- a/test/engram/billing/subscriptions_test.exs
+++ b/test/engram/billing/subscriptions_test.exs
@@ -44,4 +44,79 @@ defmodule Engram.Billing.SubscriptionsTest do
       assert {:error, :paddle_unavailable} = Subscriptions.cancel(user)
     end
   end
+
+  describe "preview_plan_change/2" do
+    test "calls Paddle preview with items + prorated_immediately mode" do
+      user = insert(:user)
+      sub = insert(:subscription, user: user, paddle_subscription_id: "sub_preview_ok")
+
+      expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn sub_id, items, opts ->
+        assert sub_id == sub.paddle_subscription_id
+        assert [%{price_id: "pri_new", quantity: 1}] = items
+        assert Keyword.get(opts, :proration_billing_mode) == "prorated_immediately"
+
+        {:ok,
+         %{
+           old_total: 1400,
+           new_total: 700,
+           immediate_charge_or_credit: -700,
+           next_billed_at: ~U[2026-07-01 00:00:00Z]
+         }}
+      end)
+
+      assert {:ok, %{immediate_charge_or_credit: -700}} =
+               Subscriptions.preview_plan_change(user, "pri_new")
+    end
+
+    test "no active subscription returns {:error, :no_active_subscription}" do
+      user = insert(:user)
+      assert {:error, :no_active_subscription} = Subscriptions.preview_plan_change(user, "pri_new")
+    end
+
+    test "Paddle error returns {:error, :paddle_unavailable}" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_preview_err")
+
+      expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn _, _, _ ->
+        {:error, :http_500}
+      end)
+
+      assert {:error, :paddle_unavailable} =
+               Subscriptions.preview_plan_change(user, "pri_new")
+    end
+  end
+
+  describe "confirm_plan_change/2" do
+    test "calls Paddle update with idempotency key + items" do
+      user = insert(:user)
+      sub = insert(:subscription, user: user, paddle_subscription_id: "sub_confirm_ok")
+
+      expect(Engram.Paddle.ClientMock, :update_subscription, fn sub_id, items, opts ->
+        assert sub_id == sub.paddle_subscription_id
+        assert [%{price_id: "pri_new", quantity: 1}] = items
+        assert is_binary(Keyword.get(opts, :idempotency_key))
+        {:ok, %{transaction_id: "txn_abc"}}
+      end)
+
+      assert {:ok, %{transaction_id: "txn_abc"}} =
+               Subscriptions.confirm_plan_change(user, "pri_new")
+    end
+
+    test "no active subscription returns {:error, :no_active_subscription}" do
+      user = insert(:user)
+      assert {:error, :no_active_subscription} = Subscriptions.confirm_plan_change(user, "pri_new")
+    end
+
+    test "Paddle error returns {:error, :paddle_unavailable}" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_confirm_err")
+
+      expect(Engram.Paddle.ClientMock, :update_subscription, fn _, _, _ ->
+        {:error, :http_500}
+      end)
+
+      assert {:error, :paddle_unavailable} =
+               Subscriptions.confirm_plan_change(user, "pri_new")
+    end
+  end
 end

--- a/test/engram/billing/subscriptions_test.exs
+++ b/test/engram/billing/subscriptions_test.exs
@@ -86,6 +86,39 @@ defmodule Engram.Billing.SubscriptionsTest do
     end
   end
 
+  describe "reverse_cancel/1" do
+    test "calls Paddle update with scheduled_change: nil + idempotency key" do
+      user = insert(:user)
+      sub = insert(:subscription, user: user, paddle_subscription_id: "sub_reverse_ok")
+
+      expect(Engram.Paddle.ClientMock, :update_subscription, fn sub_id, items, opts ->
+        assert sub_id == sub.paddle_subscription_id
+        assert items == []
+        assert Keyword.fetch!(opts, :scheduled_change) == nil
+        assert is_binary(Keyword.fetch!(opts, :idempotency_key))
+        {:ok, %{scheduled_change: nil}}
+      end)
+
+      assert {:ok, %{scheduled_change: nil}} = Subscriptions.reverse_cancel(user)
+    end
+
+    test "no active subscription returns {:error, :no_active_subscription}" do
+      user = insert(:user)
+      assert {:error, :no_active_subscription} = Subscriptions.reverse_cancel(user)
+    end
+
+    test "Paddle error returns {:error, :paddle_unavailable}" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_reverse_err")
+
+      expect(Engram.Paddle.ClientMock, :update_subscription, fn _, _, _ ->
+        {:error, :http_500}
+      end)
+
+      assert {:error, :paddle_unavailable} = Subscriptions.reverse_cancel(user)
+    end
+  end
+
   describe "confirm_plan_change/2" do
     test "calls Paddle update with idempotency key + items" do
       user = insert(:user)

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -334,7 +334,7 @@ defmodule EngramWeb.BillingControllerTest do
       expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn "sub_preview",
                                                                         items,
                                                                         _opts ->
-        assert [%{price_id: "pri_new", quantity: 1}] = items
+        assert [%{price_id: "pri_pro_monthly_test", quantity: 1}] = items
 
         {:ok,
          %{
@@ -347,7 +347,7 @@ defmodule EngramWeb.BillingControllerTest do
 
       body =
         conn
-        |> post("/api/billing/plan-change/preview", %{"target_price_id" => "pri_new"})
+        |> post("/api/billing/plan-change/preview", %{"target_price_id" => "pri_pro_monthly_test"})
         |> json_response(200)
 
       assert body["old_total"] == 1400
@@ -362,10 +362,25 @@ defmodule EngramWeb.BillingControllerTest do
     test "no active sub returns 422", %{conn: conn} do
       body =
         conn
-        |> post("/api/billing/plan-change/preview", %{"target_price_id" => "pri_new"})
+        |> post("/api/billing/plan-change/preview", %{"target_price_id" => "pri_pro_monthly_test"})
         |> json_response(422)
 
       assert body["error"] == "no_active_subscription"
+    end
+
+    test "off-catalog price_id returns 422 invalid_price_id without hitting Paddle", %{
+      conn: conn,
+      user: user
+    } do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_evil")
+
+      # No ClientMock expect — Paddle must NOT be called.
+      body =
+        conn
+        |> post("/api/billing/plan-change/preview", %{"target_price_id" => "pri_arbitrary_zero"})
+        |> json_response(422)
+
+      assert body["error"] == "invalid_price_id"
     end
   end
 
@@ -374,14 +389,14 @@ defmodule EngramWeb.BillingControllerTest do
       insert(:subscription, user: user, paddle_subscription_id: "sub_confirm")
 
       expect(Engram.Paddle.ClientMock, :update_subscription, fn "sub_confirm", items, opts ->
-        assert [%{price_id: "pri_new", quantity: 1}] = items
+        assert [%{price_id: "pri_pro_monthly_test", quantity: 1}] = items
         assert is_binary(Keyword.fetch!(opts, :idempotency_key))
         {:ok, %{"transaction_id" => "txn_xyz"}}
       end)
 
       body =
         conn
-        |> post("/api/billing/plan-change/confirm", %{"target_price_id" => "pri_new"})
+        |> post("/api/billing/plan-change/confirm", %{"target_price_id" => "pri_pro_monthly_test"})
         |> json_response(202)
 
       assert body["transaction_id"] == "txn_xyz"
@@ -396,7 +411,7 @@ defmodule EngramWeb.BillingControllerTest do
 
       body =
         conn
-        |> post("/api/billing/plan-change/confirm", %{"target_price_id" => "pri_new"})
+        |> post("/api/billing/plan-change/confirm", %{"target_price_id" => "pri_pro_monthly_test"})
         |> json_response(503)
 
       assert body["error"] == "paddle_unavailable"

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -306,6 +306,26 @@ defmodule EngramWeb.BillingControllerTest do
     end
   end
 
+  describe "POST /api/billing/reverse-cancel" do
+    test "happy path returns 202", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_reverse")
+
+      expect(Engram.Paddle.ClientMock, :update_subscription, fn "sub_reverse", [], opts ->
+        assert Keyword.fetch!(opts, :scheduled_change) == nil
+        assert is_binary(Keyword.fetch!(opts, :idempotency_key))
+        {:ok, %{"scheduled_change" => nil}}
+      end)
+
+      body = conn |> post("/api/billing/reverse-cancel") |> json_response(202)
+      assert body["scheduled_change"] == nil
+    end
+
+    test "no active sub returns 422", %{conn: conn} do
+      body = conn |> post("/api/billing/reverse-cancel") |> json_response(422)
+      assert body["error"] == "no_active_subscription"
+    end
+  end
+
   describe "POST /api/billing/plan-change/preview" do
     test "returns Paddle proration preview shape", %{conn: conn, user: user} do
       insert(:subscription, user: user, paddle_subscription_id: "sub_preview")

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -279,7 +279,8 @@ defmodule EngramWeb.BillingControllerTest do
     test "happy path returns 202 with Paddle payload", %{conn: conn, user: user} do
       insert(:subscription, user: user, paddle_subscription_id: "sub_cancel")
 
-      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn "sub_cancel", :next_billing_period,
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn "sub_cancel",
+                                                                :next_billing_period,
                                                                 opts ->
         assert is_binary(Keyword.fetch!(opts, :idempotency_key))
         {:ok, %{"scheduled_change" => %{"effective_at" => "2026-07-01T00:00:00Z"}}}

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -274,4 +274,111 @@ defmodule EngramWeb.BillingControllerTest do
       assert body["url"] == "https://p/cancel"
     end
   end
+
+  describe "POST /api/billing/cancel-subscription" do
+    test "happy path returns 202 with Paddle payload", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_cancel")
+
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn "sub_cancel", :next_billing_period,
+                                                                opts ->
+        assert is_binary(Keyword.fetch!(opts, :idempotency_key))
+        {:ok, %{"scheduled_change" => %{"effective_at" => "2026-07-01T00:00:00Z"}}}
+      end)
+
+      body = conn |> post("/api/billing/cancel-subscription") |> json_response(202)
+      assert body["scheduled_change"]["effective_at"] == "2026-07-01T00:00:00Z"
+    end
+
+    test "no active sub returns 422", %{conn: conn} do
+      body = conn |> post("/api/billing/cancel-subscription") |> json_response(422)
+      assert body["error"] == "no_active_subscription"
+    end
+
+    test "Paddle error returns 503", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_err")
+
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
+        {:error, :http_500}
+      end)
+
+      body = conn |> post("/api/billing/cancel-subscription") |> json_response(503)
+      assert body["error"] == "paddle_unavailable"
+    end
+  end
+
+  describe "POST /api/billing/plan-change/preview" do
+    test "returns Paddle proration preview shape", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_preview")
+
+      expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn "sub_preview",
+                                                                        items,
+                                                                        _opts ->
+        assert [%{price_id: "pri_new", quantity: 1}] = items
+
+        {:ok,
+         %{
+           "old_total" => 1400,
+           "new_total" => 700,
+           "immediate_charge_or_credit" => -700,
+           "next_billed_at" => "2026-07-01T00:00:00Z"
+         }}
+      end)
+
+      body =
+        conn
+        |> post("/api/billing/plan-change/preview", %{"target_price_id" => "pri_new"})
+        |> json_response(200)
+
+      assert body["old_total"] == 1400
+      assert body["new_total"] == 700
+    end
+
+    test "missing target_price_id returns 422", %{conn: conn} do
+      body = conn |> post("/api/billing/plan-change/preview", %{}) |> json_response(422)
+      assert body["error"] == "target_price_id required"
+    end
+
+    test "no active sub returns 422", %{conn: conn} do
+      body =
+        conn
+        |> post("/api/billing/plan-change/preview", %{"target_price_id" => "pri_new"})
+        |> json_response(422)
+
+      assert body["error"] == "no_active_subscription"
+    end
+  end
+
+  describe "POST /api/billing/plan-change/confirm" do
+    test "happy path returns 202 with Paddle payload", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_confirm")
+
+      expect(Engram.Paddle.ClientMock, :update_subscription, fn "sub_confirm", items, opts ->
+        assert [%{price_id: "pri_new", quantity: 1}] = items
+        assert is_binary(Keyword.fetch!(opts, :idempotency_key))
+        {:ok, %{"transaction_id" => "txn_xyz"}}
+      end)
+
+      body =
+        conn
+        |> post("/api/billing/plan-change/confirm", %{"target_price_id" => "pri_new"})
+        |> json_response(202)
+
+      assert body["transaction_id"] == "txn_xyz"
+    end
+
+    test "Paddle error returns 503", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_confirm_err")
+
+      expect(Engram.Paddle.ClientMock, :update_subscription, fn _, _, _ ->
+        {:error, :http_500}
+      end)
+
+      body =
+        conn
+        |> post("/api/billing/plan-change/confirm", %{"target_price_id" => "pri_new"})
+        |> json_response(503)
+
+      assert body["error"] == "paddle_unavailable"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes Gate 2 of the account-lifecycle umbrella (#281). Replaces the Settings → Billing portal-redirect surface with inline Paddle UI for cancel + plan-change. **All four ops endpoints land server-side; CancelPanel + PlanChangePanel render in-app.** No more leaving the app to manage a subscription.

Builds on Gate 1 (PR #476 — immediate cascade lifecycle + export pipeline scaffold). Gate 3 (export user-visible + in-app delete UI) tracked in #480.

## Scope deviation from plan

Plan tasks 25-29 assumed Paddle's shadcn-registry vendor components (`PaddlePlanChangePreview`, `PaddleSubscriptionStatusCard`, …) accept simplified inputs. Audit revealed they require **verbatim Paddle SDK responses** (full `Subscription` object with `items[].price.unitPrice`, full `PATCH /subscriptions/{id}/preview` body with `updateSummary.{credit,charge,result}`).

Shipping the vendor wrappers as-designed would have required either (a) refactoring `/billing/subscription` + `/billing/plan-change/preview` into thin Paddle proxies (cascades into existing `SubscriptionDetail` consumers across CurrentPlanCard, PendingChangeBanner, etc.) or (b) expanding the backend projection with ~8-10 derived fields just to feed the lower-level vendor components.

**Path A — Hybrid:** use the vendor surfaces that accept plain pre-formatted strings (`PricingSelectCardGrid` + `BillingIntervalToggle`); roll our own plain-text proration display from the four-field response. Ships the user-facing goal (no portal redirect) without the verbatim-Paddle backend refactor. Full vendor wiring stays available as a follow-up if richer Paddle UI surfaces ever warrant it; the 11 installed components stay in `frontend/src/components/` ready to wire.

## What lands

**Backend** (`lib/engram/billing/subscriptions.ex` + `Engram.Paddle.Client` behaviour):
- `Subscriptions.cancel/2` — at-period-end default, idempotency key
- `Subscriptions.preview_plan_change/2` — `prorated_immediately` mode, read-only on Paddle's side
- `Subscriptions.confirm_plan_change/2` — idempotency key
- `Subscriptions.reverse_cancel/1` — clears `scheduled_change`
- Paddle behaviour gains `preview_subscription_update/3` + `update_subscription/3` callbacks + HTTP impls (PATCH `/subscriptions/{id}/preview` + PATCH `/subscriptions/{id}`)

**Controller** (`lib/engram_web/controllers/billing_controller.ex` + router):
- `POST /api/billing/cancel-subscription` → 202 / 422 / 503
- `POST /api/billing/reverse-cancel` → 202 / 422 / 503
- `POST /api/billing/plan-change/preview` → 200 / 422 / 503
- `POST /api/billing/plan-change/confirm` → 202 / 422 / 503

All four route through the existing `with_billing/2` guard so self-host (`billing_enabled=false`) 404s instead of erroring.

**Frontend hooks** (`frontend/src/api/queries.ts`):
- `useCancelSubscription`, `useReverseCancel`, `usePlanChangePreview`, `useConfirmPlanChange` — each invalidates `['billing','status']` + `['billing','subscription']` on success so the StatusCard reflects the scheduled change before webhook sync catches up

**Components** (`frontend/src/billing/`):
- `CancelPanel` — confirms cancel-at-period-end inline, shows the cutoff date
- `PlanChangePanel` — `PricingSelectCardGrid` for tier × cadence + proration strip (credit/charge today + new bill amount + renewal date) + confirm button

**Wiring** (`frontend/src/billing/billing-page.tsx`):
- Old "Cancel subscription" → portal redirect, now → inline CancelPanel
- New "Change plan" button → inline PlanChangePanel
- Existing checkout/trial-signup flow untouched (overlay/inline modes, push events, slow-activation banner, history, payment method card)

**Vendor install** (`@paddle` shadcn registry):
- `subscription-{status-card,alert,payment-card}`, `plan-change-{preview,breakdown}`, `billing-interval-toggle`, `pricing-select-cards`, `inline-checkout` — only PricingSelectCardGrid + BillingIntervalToggle wired in Gate 2; rest installed for follow-up

## Tests

- Backend: 17 new tests in `subscriptions_test.exs` (cancel × 4, preview × 3, confirm × 3, reverse_cancel × 3 plus 4 existing) + 11 new in `billing_controller_test.exs`. Full suite 2252+/0.
- Frontend: 5 new tests in `queries.test.tsx` (hooks), 4 new in `cancel-panel.test.tsx`, 4 new in `plan-change-panel.test.tsx`, 2 new in `billing-page.test.tsx` (button → panel wiring). Gated suites 44/44.
- `bun run build` green (vendor files needed unused-`React` strips + a few non-null assertions to clear strict tsc; called out in commit `00cb996a`).

## Test plan

- [ ] CI green
- [ ] Manual: sandbox user with active subscription clicks Change plan → picks alternate tier → preview renders → confirm → Paddle webhook flips DB → StatusCard updates within 5s
- [ ] Manual: sandbox user clicks Cancel subscription → CancelPanel renders with correct effective date → confirms → `scheduled_change` populated → reverse-cancel button appears next session
- [ ] Self-host smoke: all four POST endpoints return 404 with `billing_enabled=false`

## Refs

- Umbrella: #281
- Issue: #479
- Plan: `docs/superpowers/plans/2026-06-06-account-lifecycle.md` (engram-workspace)
- Spec: `docs/superpowers/specs/2026-06-06-account-lifecycle-design.md` (engram-workspace)
- Gate 1 PR: #476
- Gate 3 issue: #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)