### PR TITLE
obs(deploy): annotate release-initiated in Grafana

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -232,6 +232,40 @@ jobs:
             --data "$(jq -nc --arg c "$CONTENT" '{content:$c}')" \
             "$WEBHOOK"
 
+      # Mark "release initiated" in Grafana so the operator sees a vertical
+      # line on every Engram-folder dashboard. The matching "applied"
+      # annotation lands ~3-5 min later when engram-infra's
+      # `terraform (prod)` apply rolls the ECS service onto the new task
+      # def. SAT is mirrored from SOPS to a repo secret here (see comment
+      # in engram-infra `main/envs/prod/grafana.tf`); rotation requires
+      # updating both. Best-effort: a failed annotation doesn't fail the
+      # deploy. Skipped silently if the secret isn't set (e.g. on a fork).
+      - name: Annotate release-initiated in Grafana
+        if: success() && steps.open-pr.outputs.pull-request-number != '' && env.GRAFANA_SAT != ''
+        env:
+          GRAFANA_SAT: ${{ secrets.GRAFANA_SAT_CLAUDE_CODE }}
+          RELEASE: ${{ steps.tags.outputs.release }}
+          IMAGE: ${{ steps.tags.outputs.image_tag }}
+          PR_URL: ${{ steps.open-pr.outputs.pull-request-url }}
+          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          NOW_MS=$(( $(date +%s%N) / 1000000 ))
+          TEXT=$(printf 'release initiated: `%s` → `%s`\nengram-infra PR: %s\n[run](%s)' \
+            "$RELEASE" "$IMAGE" "$PR_URL" "$GH_RUN_URL")
+          BODY=$(jq -nc \
+            --arg time "$NOW_MS" \
+            --arg text "$TEXT" \
+            '{time:($time|tonumber), text:$text, tags:["deploy","initiated","engram","prod"]}')
+          curl -sS --fail-with-body --max-time 10 \
+            -X POST \
+            -H "Authorization: Bearer $GRAFANA_SAT" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            https://calmeucalyptus520.grafana.net/api/annotations \
+            | jq -r '"annotation id: \(.id)"' \
+            || echo "::warning::Grafana annotation failed — deploy unaffected"
+
       # Failure path — same webhook, different framing. `failure()`
       # fires when an earlier step exited non-zero.
       - name: Notify Discord (deploy failed)

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,6 +14,7 @@ on:
       - "feat/**"
       - "fix/**"
       - "hotfix/**"
+      - "obs/**"
       - "perf/**"
       - "refactor/**"
       - "release/**"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.361",
+      version: "0.5.363",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Closes part of engram-app/engram-infra#339. Pairs with engram-app/engram-infra#349 (infra side: annotates every TF apply post-success).

## Summary

- After `open-infra-pr` opens the bot PR in engram-infra, POST a global annotation to Grafana Cloud tagged `deploy,initiated,engram,prod`.
- Marks the "release initiated" moment on every Engram-folder dashboard; the matching "applied" annotation lands ~3-5 min later from engram-infra's `terraform (prod)` apply.
- Best-effort: a Grafana 5xx or network error logs a warning but does NOT fail the deploy. The bot PR is already open by the time this runs; the rollout happens in engram-infra regardless.
- SAT lives in repo secret `GRAFANA_SAT_CLAUDE_CODE` (mirrored from engram-infra SOPS `main/envs/prod/secrets/prod.enc.yaml`). Step skips silently if the secret isn't set (forks).

## Test plan

- [ ] CI green.
- [ ] After merge + a real `release-v*` tag push, an annotation appears on Engram-folder dashboards within seconds of the bot PR being opened.
- [ ] Annotation text shows release tag + image tag + engram-infra PR URL.
- [ ] A second annotation (`applied`) lands minutes later from engram-infra side after the prod apply.