### PR TITLE
test(e2e): tag emails with +clerk_test to stop Resend deliveries

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -161,7 +161,7 @@ def sync_user(ts, auth_provider):
 
     Returns: (email, provider_user_id, api_key)
     """
-    email = f"e2e-sync-{ts}@example.com"
+    email = f"e2e-sync-{ts}+clerk_test@example.com"
     password = secrets.token_urlsafe(32)
     provider_user_id, api_key = auth_provider.provision_user(email, password)
     # Lift pricing v2 §G Free-tier defaults (api_rps_cap=0, api_write_enabled=false)
@@ -177,7 +177,7 @@ def isolation_user(ts, auth_provider):
 
     Returns: (email, provider_user_id, api_key)
     """
-    email = f"e2e-iso-{ts}@example.com"
+    email = f"e2e-iso-{ts}+clerk_test@example.com"
     password = secrets.token_urlsafe(32)
     provider_user_id, api_key = auth_provider.provision_user(email, password)
     grant_test_plan(email)
@@ -489,10 +489,12 @@ def session_cleanup(request, auth_provider):
         auth_provider.cleanup_user(uid)
     # DB cleanup: scoped to THIS worker's users via the w{N} ts suffix
     # so a worker finishing early doesn't delete another worker's users
-    # mid-run. Emails look like e2e-sync-20260416...w{N}@example.com, so
-    # `%w{N}@example.com` matches only this worker's rows.
+    # mid-run. Emails look like e2e-sync-20260416...w{N}+clerk_test@example.com
+    # (the `+clerk_test` plus-tag tells Clerk dev to skip outbound email
+    # delivery — see docs/context/clerk-instance-swap-gaps.md), so
+    # `%w{N}+clerk_test@example.com` matches only this worker's rows.
     for domain in ("example.com", "test.local", "test.com"):
-        pattern = f"e2e-%w{_WORKER}@{domain}"
+        pattern = f"e2e-%w{_WORKER}+clerk_test@{domain}"
         try:
             cleanup_test_data(pattern)
         except Exception as e:

--- a/e2e/helpers/clerk.py
+++ b/e2e/helpers/clerk.py
@@ -77,7 +77,11 @@ class ClerkClient:
         network hiccup) failed mid-setup, causing pytest-rerunfailures
         to re-invoke provision_user with the same email.
         """
-        username = email.split("@")[0]
+        # Strip the `+clerk_test` plus-tag (or any plus-tag) before deriving
+        # the username — Clerk rejects `+` in usernames with 422
+        # form_username_invalid, which would otherwise surface as a
+        # confusing "create_user failed" error.
+        username = email.split("@")[0].split("+")[0]
         resp = self.session.post(
             f"{self.base_url}/users",
             json={

--- a/e2e/helpers/oauth.py
+++ b/e2e/helpers/oauth.py
@@ -34,7 +34,7 @@ async def provision_oauth_tokens(
     The label is used in the email prefix for log traceability.
     """
     ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
-    email = f"e2e-oauth-{label}-{ts}@example.com"
+    email = f"e2e-oauth-{label}-{ts}+clerk_test@example.com"
     password = secrets.token_urlsafe(32)
 
     clerk_user_id = clerk_client.create_user(email, password)

--- a/e2e/tests/api_only/test_32_vault_api_key_isolation.py
+++ b/e2e/tests/api_only/test_32_vault_api_key_isolation.py
@@ -65,7 +65,7 @@ def _register_test_user(ts: int):
     in Engram via the real auth pipeline (Clerk JWT → find_or_create).
     """
     clerk_client = ClerkClient(CLERK_SECRET)
-    email = f"e2e-vault-iso-{ts}@example.com"
+    email = f"e2e-vault-iso-{ts}+clerk_test@example.com"
     password = secrets.token_urlsafe(32)
 
     clerk_user_id, clerk_auth, api_key = provision_clerk_user(

--- a/e2e/tests/api_only/test_71_connections.py
+++ b/e2e/tests/api_only/test_71_connections.py
@@ -167,7 +167,7 @@ def _make_clerk_user(clerk_client) -> tuple[str, str, str]:
     `grant_test_plan(email)` themselves.
     """
     ts = _ts()
-    email = f"e2e-conn-{ts}@example.com"
+    email = f"e2e-conn-{ts}+clerk_test@example.com"
     password = secrets.token_urlsafe(32)
 
     clerk_user_id = clerk_client.create_user(email, password)

--- a/e2e/tests/test_44_oauth_device_flow.py
+++ b/e2e/tests/test_44_oauth_device_flow.py
@@ -43,7 +43,7 @@ _P = "app.plugins.plugins['engram-vault-sync']"
 @pytest.fixture
 def test_email():
     ts = datetime.now().strftime("%Y%m%d%H%M%S")
-    return f"e2e-clerk-{ts}@example.com"
+    return f"e2e-clerk-{ts}+clerk_test@example.com"
 
 
 @pytest.fixture

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.363",
+      version: "0.5.364",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Every CI E2E run was firing Clerk welcome/verification emails to fake `e2e-{role}-{ts}w{N}@example.com` addresses through Clerk's Resend integration — burned Resend quota and bounced against `@example.com`.
- Backend Mailer is already NoOp in CI (no `RESEND_API_KEY` in `docker-compose.ci.yml`); this PR mutes the Clerk side too.
- Inject the `+clerk_test` plus-tag at every E2E test-user email construction site. Clerk dev instances recognize the tag and skip outbound delivery (per `docs/context/clerk-instance-swap-gaps.md`).
- Strip `+tag` before deriving the Clerk `username` field — Clerk rejects `+` in usernames with 422 `form_username_invalid` distinct from the `form_identifier_exists` path already handled.
- Widen the worker-scoped cleanup LIKE pattern to match the new email shape so per-worker DB sweeps still scope correctly.

## Test plan

- [ ] CI green — `verify` workflow passes (unit + e2e + api_only).
- [ ] Resend dashboard shows zero new emails for `e2e-*@example.com` after this lands.
- [ ] Spot-check a CI run's Clerk audit log: `email_address` ends in `+clerk_test@example.com`; users are deleted in teardown (`cleanup_all_e2e_clerk_users` still finds them via `run_marker = r{run_id}w` substring).
- [ ] Manual smoke against a worktree: `make e2e-unit` + a single `pytest e2e/tests/api_only/test_71_connections.py` to confirm Clerk user creation still succeeds with the stripped username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)