### PR TITLE
fix(billing): loading spinners + preview error UX

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -818,6 +818,13 @@ export function usePlanChangePreview(targetPriceId: string | null) {
       api.post<PlanChangePreview>('/billing/plan-change/preview', {
         target_price_id: targetPriceId,
       }),
+    // Preview hits Paddle. Without these, every window focus/refocus
+    // (alt-tab back to the picker tab) re-POSTs to Paddle. The data
+    // is stable for the lifetime of the picker session — proration
+    // math only changes when the user picks a different target or
+    // a webhook flips their subscription (both invalidate the key).
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
   })
 }
 

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -13,6 +13,7 @@ import {
 } from '../api/queries'
 import { api } from '../api/client'
 import { useTheme } from '../theme/theme-provider'
+import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { CadenceToggle, PLAN_CATALOG, PlanCard } from './plan-cards'
 import CurrentPlanCard from './current-plan-card'
@@ -30,16 +31,6 @@ import { useSubscriptionActivatedEvents } from './use-subscription-activated-eve
 const COOLDOWN_MS = 15_000
 
 const INLINE_FRAME_TARGET = 'paddle-checkout'
-
-async function openPortal(action?: string) {
-  try {
-    const path = action ? `/billing/portal?action=${action}` : '/billing/portal'
-    const { url } = await api.get<{ url: string }>(path)
-    window.location.href = url
-  } catch {
-    toast.error('Could not open the billing portal. Please try again.')
-  }
-}
 
 async function downloadInvoice(transactionId: string) {
   try {
@@ -88,6 +79,11 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
   // Inline panel state for the in-app cancel + plan-change flows (replaces
   // the previous openPortal('cancel') / portal-redirect path).
   const [panel, setPanel] = useState<'cancel' | 'change' | null>(null)
+  // Shared latch for any click that does an api.get → Paddle round-trip
+  // before navigating away or opening the overlay. The portal-redirect and
+  // payment-update flows both incur the same backend round-trip, so the
+  // user needs immediate feedback that the click registered.
+  const [portalLoading, setPortalLoading] = useState(false)
 
   // Latch — onActivated must fire at most once even if the broadcast lands
   // multiple times (subscription.created followed by subscription.activated
@@ -265,12 +261,25 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
   const needsSubscription = !billing.active
   const checkoutReady = Boolean(paddle && config)
 
+  async function openPortal(action?: string) {
+    setPortalLoading(true)
+    try {
+      const path = action ? `/billing/portal?action=${action}` : '/billing/portal'
+      const { url } = await api.get<{ url: string }>(path)
+      window.location.href = url
+    } catch {
+      toast.error('Could not open the billing portal. Please try again.')
+      setPortalLoading(false)
+    }
+  }
+
   async function handleUpdatePayment() {
     if (!paddle) {
       openPortal('update_payment')
       return
     }
 
+    setPortalLoading(true)
     try {
       const { transaction_id } = await api.get<{ transaction_id: string }>(
         '/billing/payment-update-transaction',
@@ -278,6 +287,8 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
       paddle.Checkout.open({ transactionId: transaction_id })
     } catch {
       toast.error('Could not start the payment update. Please try again.')
+    } finally {
+      setPortalLoading(false)
     }
   }
 
@@ -397,6 +408,7 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
           <PaymentMethodCard
             paymentMethod={history?.payment_method ?? null}
             onUpdate={handleUpdatePayment}
+            updating={portalLoading}
           />
           <BillingHistoryTable
             transactions={history?.transactions ?? []}
@@ -407,14 +419,19 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
               can still self-serve through Paddle's hosted portal. Sits
               outside the cards so it reads as a fallback option, not as
               one of the primary plan actions. */}
-          <div className="flex justify-center pt-2">
-            <button
+          <div className="flex flex-col items-center gap-1.5 pt-2">
+            <Button
               type="button"
+              variant="outline"
               onClick={() => openPortal()}
-              className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+              disabled={portalLoading}
             >
-              Manage payment in Paddle, our payment processor
-            </button>
+              {portalLoading && <Loader2 aria-hidden className="size-4 animate-spin" />}
+              {portalLoading ? 'Opening Paddle…' : 'Open Paddle billing portal'}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              Paddle is our payment processor. Use this if the controls above don't cover what you need.
+            </p>
           </div>
         </>
       )}

--- a/frontend/src/billing/cancel-panel.tsx
+++ b/frontend/src/billing/cancel-panel.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useCancelSubscription, type BillingStatus } from '../api/queries'
 import type { SubscriptionDetail } from '../api/queries'
@@ -69,7 +70,8 @@ export default function CancelPanel({ detail, tier, onClose }: CancelPanelProps)
           onClick={confirm}
           disabled={cancel.isPending}
         >
-          Cancel at period end
+          {cancel.isPending && <Loader2 aria-hidden className="size-4 animate-spin" />}
+          {cancel.isPending ? 'Canceling…' : 'Cancel at period end'}
         </Button>
         <Button variant="ghost" onClick={onClose} disabled={cancel.isPending}>
           Keep my subscription

--- a/frontend/src/billing/current-plan-card.tsx
+++ b/frontend/src/billing/current-plan-card.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react'
+import { Sparkles } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import type { BillingStatus } from '../api/queries'
 
 const TIER_LABELS: Record<BillingStatus['tier'], string> = {
@@ -8,6 +10,10 @@ const TIER_LABELS: Record<BillingStatus['tier'], string> = {
   starter: 'Starter',
   pro: 'Pro',
 }
+
+// Paid + trial tiers get the flashier pill — gradient, ring, sparkle.
+// Free/none stay muted; promoting an absent plan would mis-signal.
+const FLASHY_TIERS: BillingStatus['tier'][] = ['starter', 'pro', 'trial']
 
 export default function CurrentPlanCard({
   billing,
@@ -30,7 +36,17 @@ export default function CurrentPlanCard({
     <section className="space-y-4 rounded-lg border border-border bg-card p-6">
       <header className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-foreground">Current Plan</h2>
-        <span className="rounded-full bg-secondary px-3 py-1 text-sm font-medium text-secondary-foreground">
+        <span
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold',
+            FLASHY_TIERS.includes(billing.tier)
+              ? 'bg-gradient-to-r from-primary via-primary to-primary/75 text-primary-foreground shadow-sm ring-1 ring-primary/40'
+              : 'bg-secondary text-secondary-foreground',
+          )}
+        >
+          {FLASHY_TIERS.includes(billing.tier) && (
+            <Sparkles aria-hidden className="size-3.5" />
+          )}
           {TIER_LABELS[billing.tier]}
         </span>
       </header>

--- a/frontend/src/billing/payment-method-card.tsx
+++ b/frontend/src/billing/payment-method-card.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import type { PaymentMethod } from '../api/queries'
 
@@ -22,7 +23,8 @@ export default function PaymentMethodCard({
       <header className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-foreground">Payment method</h2>
         <Button variant="outline" size="sm" onClick={onUpdate} disabled={updating}>
-          Update
+          {updating && <Loader2 aria-hidden className="size-3 animate-spin" />}
+          {updating ? 'Opening…' : 'Update'}
         </Button>
       </header>
 

--- a/frontend/src/billing/pending-change-banner.tsx
+++ b/frontend/src/billing/pending-change-banner.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useReverseCancel, type SubscriptionDetail } from '../api/queries'
@@ -39,7 +40,8 @@ export default function PendingChangeBanner({
       </p>
       {scheduledChange.action === 'cancel' && (
         <Button size="sm" onClick={onReverse} disabled={reverseCancel.isPending}>
-          Keep my subscription
+          {reverseCancel.isPending && <Loader2 aria-hidden className="size-3.5 animate-spin" />}
+          {reverseCancel.isPending ? 'Reversing…' : 'Keep my subscription'}
         </Button>
       )}
     </aside>

--- a/frontend/src/billing/pending-change-banner.tsx
+++ b/frontend/src/billing/pending-change-banner.tsx
@@ -14,12 +14,30 @@ export default function PendingChangeBanner({
 }: {
   scheduledChange: SubscriptionDetail['scheduled_change']
 }) {
-  const reverseCancel = useReverseCancel()
-
   if (!scheduledChange) return null
 
   const label = ACTION_LABELS[scheduledChange.action] ?? 'Your plan changes'
   const date = new Date(scheduledChange.effective_at).toLocaleDateString()
+
+  return (
+    <aside
+      role="status"
+      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-secondary/50 p-4 text-sm"
+    >
+      <p className="font-medium text-foreground">
+        {label} on {date}
+      </p>
+      {scheduledChange.action === 'cancel' && <ReverseCancelButton />}
+    </aside>
+  )
+}
+
+// Hook isolated to its own component so the mutation state isn't allocated
+// for non-cancel scheduled changes (pause/resume) where the button never
+// renders. Tiny gain alone — pattern matters when the parent is in the
+// always-mounted billing surface.
+function ReverseCancelButton() {
+  const reverseCancel = useReverseCancel()
 
   async function onReverse() {
     try {
@@ -31,19 +49,9 @@ export default function PendingChangeBanner({
   }
 
   return (
-    <aside
-      role="status"
-      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-secondary/50 p-4 text-sm"
-    >
-      <p className="font-medium text-foreground">
-        {label} on {date}
-      </p>
-      {scheduledChange.action === 'cancel' && (
-        <Button size="sm" onClick={onReverse} disabled={reverseCancel.isPending}>
-          {reverseCancel.isPending && <Loader2 aria-hidden className="size-3.5 animate-spin" />}
-          {reverseCancel.isPending ? 'Reversing…' : 'Keep my subscription'}
-        </Button>
-      )}
-    </aside>
+    <Button size="sm" onClick={onReverse} disabled={reverseCancel.isPending}>
+      {reverseCancel.isPending && <Loader2 aria-hidden className="size-3.5 animate-spin" />}
+      {reverseCancel.isPending ? 'Reversing…' : 'Keep my subscription'}
+    </Button>
   )
 }

--- a/frontend/src/billing/plan-change-panel.test.tsx
+++ b/frontend/src/billing/plan-change-panel.test.tsx
@@ -113,6 +113,22 @@ describe('PlanChangePanel', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled())
   })
 
+  it('preview error: surfaces inline message and keeps Confirm clickable', async () => {
+    // Backend bucketed Paddle errors as :paddle_unavailable (503) or
+    // :no_active_subscription (422) — both surface as ApiError.throw, query
+    // → isError. Without the inline message + open-confirm fix, the user
+    // saw "Loading proration…" flash then disappear with a permanently
+    // disabled Confirm and no clue why.
+    post.mockRejectedValue(new Error('paddle_unavailable'))
+
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }))
+
+    expect(await screen.findByText(/could not load proration/i)).toBeInTheDocument()
+    const confirmBtn = screen.getByRole('button', { name: /confirm change/i })
+    await waitFor(() => expect(confirmBtn).not.toBeDisabled())
+  })
+
   it('Cancel button closes without firing a mutation', () => {
     const onClose = vi.fn()
     render(<PlanChangePanel billing={billing()} onClose={onClose} />, { wrapper: Wrapper })

--- a/frontend/src/billing/plan-change-panel.test.tsx
+++ b/frontend/src/billing/plan-change-panel.test.tsx
@@ -129,6 +129,20 @@ describe('PlanChangePanel', () => {
     await waitFor(() => expect(confirmBtn).not.toBeDisabled())
   })
 
+  it('proration $0: shows "No charge today" instead of Credited $0.00', async () => {
+    post.mockResolvedValue({
+      old_total: 700,
+      new_total: 700,
+      immediate_charge_or_credit: 0,
+      next_billed_at: '2026-07-01T00:00:00Z',
+    })
+
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }))
+    expect(await screen.findByText(/no charge today/i)).toBeInTheDocument()
+    expect(screen.queryByText(/credited \$0\.00/i)).not.toBeInTheDocument()
+  })
+
   it('Cancel button closes without firing a mutation', () => {
     const onClose = vi.fn()
     render(<PlanChangePanel billing={billing()} onClose={onClose} />, { wrapper: Wrapper })

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
@@ -133,7 +134,9 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
                   ? 'Loading proration…'
                   : isSelected && preview.data
                     ? formatProration(preview.data)
-                    : undefined
+                    : isSelected && preview.isError
+                      ? 'Could not load proration. You can still confirm — final charge applies on confirm.'
+                      : undefined
               }
             />
           )
@@ -147,11 +150,11 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
             !selectedTier ||
             !targetPriceId ||
             preview.isFetching ||
-            !preview.data ||
             confirm.isPending
           }
         >
-          Confirm change
+          {confirm.isPending && <Loader2 aria-hidden className="size-4 animate-spin" />}
+          {confirm.isPending ? 'Applying…' : 'Confirm change'}
         </Button>
         <Button variant="ghost" onClick={onClose} disabled={confirm.isPending}>
           Cancel

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -169,8 +169,15 @@ function formatProration(data: {
   new_total: number
   next_billed_at: string
 }): string {
+  const renewal = new Date(data.next_billed_at).toLocaleDateString()
+  const newTotal = formatCents(data.new_total)
+  // Exact-cadence flips (e.g. monthly→monthly mid-cycle of the same
+  // tier) come back as 0 — "Credited $0.00 today" reads as a billing
+  // mistake. Make the no-op explicit.
+  if (data.immediate_charge_or_credit === 0) {
+    return `No charge today; next bill ${newTotal} on ${renewal}`
+  }
   const direction = data.immediate_charge_or_credit > 0 ? 'Charged' : 'Credited'
   const amount = formatCents(Math.abs(data.immediate_charge_or_credit))
-  const renewal = new Date(data.next_billed_at).toLocaleDateString()
-  return `${direction} ${amount} today; next bill ${formatCents(data.new_total)} on ${renewal}`
+  return `${direction} ${amount} today; next bill ${newTotal} on ${renewal}`
 }

--- a/lib/engram/billing/subscriptions.ex
+++ b/lib/engram/billing/subscriptions.ex
@@ -33,11 +33,16 @@ defmodule Engram.Billing.Subscriptions do
       anything here.
     * `{:error, :no_active_subscription}` — no `paddle_subscription_id` on
       file. Self-host users + users who have never paid land here.
-    * `{:error, :paddle_unavailable}` — Paddle returned non-2xx or the
-      transport failed. Surface as 503 at the controller boundary.
+    * `{:error, {:paddle_error, status}}` — Paddle returned a non-2xx
+      response. Status preserved so the controller can map 4xx (user-
+      caused, e.g. swapping to the current price) to 422 and 5xx (Paddle
+      outage) to 502 distinctly.
+    * `{:error, :paddle_unavailable}` — transport failure (Req error,
+      timeout, DNS, etc. — no HTTP response). Surface as 503.
   """
   @spec cancel(User.t(), :immediately | :next_billing_period) ::
-          {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
+          {:ok, map()}
+          | {:error, :no_active_subscription | :paddle_unavailable | {:paddle_error, integer()}}
   def cancel(user, effective_from \\ :next_billing_period)
       when effective_from in [:immediately, :next_billing_period] do
     case Billing.get_subscription(user) do
@@ -50,13 +55,23 @@ defmodule Engram.Billing.Subscriptions do
   end
 
   defp do_cancel(user, sub_id, effective_from) do
-    case Client.impl().cancel_subscription(sub_id, effective_from,
-           idempotency_key: idempotency_key(:cancel, user, sub_id, effective_from)
-         ) do
-      {:ok, data} -> {:ok, data}
-      {:error, _reason} -> {:error, :paddle_unavailable}
-    end
+    Client.impl().cancel_subscription(sub_id, effective_from,
+      idempotency_key: idempotency_key(:cancel, user, sub_id, effective_from)
+    )
+    |> normalize_paddle_result()
   end
+
+  # Paddle HTTP layer returns `{:error, {:paddle_error, status}}` for non-2xx
+  # responses and `{:error, transport_reason}` for connection failures.
+  # Preserve the status for the controller; collapse transport errors to a
+  # single `:paddle_unavailable` since callers can't act on transport detail.
+  defp normalize_paddle_result({:ok, data}), do: {:ok, data}
+
+  defp normalize_paddle_result({:error, {:paddle_error, status}}),
+    do: {:error, {:paddle_error, status}}
+
+  defp normalize_paddle_result({:error, _transport_reason}),
+    do: {:error, :paddle_unavailable}
 
   # Idempotency keys MUST be deterministic per logical request — Paddle's
   # `Paddle-IK` header is the dedup signal for retries (network blip, React
@@ -83,7 +98,8 @@ defmodule Engram.Billing.Subscriptions do
   Returns `{:ok, preview}` or `{:error, :no_active_subscription | :paddle_unavailable}`.
   """
   @spec preview_plan_change(User.t(), String.t()) ::
-          {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
+          {:ok, map()}
+          | {:error, :no_active_subscription | :paddle_unavailable | {:paddle_error, integer()}}
   def preview_plan_change(user, new_price_id) when is_binary(new_price_id) do
     with_active_sub(user, fn sub_id ->
       Client.impl().preview_subscription_update(
@@ -103,7 +119,8 @@ defmodule Engram.Billing.Subscriptions do
   Returns `{:ok, paddle_data}` or `{:error, :no_active_subscription | :paddle_unavailable}`.
   """
   @spec confirm_plan_change(User.t(), String.t()) ::
-          {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
+          {:ok, map()}
+          | {:error, :no_active_subscription | :paddle_unavailable | {:paddle_error, integer()}}
   def confirm_plan_change(user, new_price_id) when is_binary(new_price_id) do
     with_active_sub(user, fn sub_id ->
       Client.impl().update_subscription(
@@ -122,7 +139,8 @@ defmodule Engram.Billing.Subscriptions do
   Returns `{:ok, paddle_data}` or `{:error, :no_active_subscription | :paddle_unavailable}`.
   """
   @spec reverse_cancel(User.t()) ::
-          {:ok, map()} | {:error, :no_active_subscription | :paddle_unavailable}
+          {:ok, map()}
+          | {:error, :no_active_subscription | :paddle_unavailable | {:paddle_error, integer()}}
   def reverse_cancel(user) do
     with_active_sub(user, fn sub_id ->
       Client.impl().update_subscription(
@@ -137,10 +155,7 @@ defmodule Engram.Billing.Subscriptions do
   defp with_active_sub(user, fun) do
     case Billing.get_subscription(user) do
       %Subscription{paddle_subscription_id: sub_id} when is_binary(sub_id) ->
-        case fun.(sub_id) do
-          {:ok, data} -> {:ok, data}
-          {:error, _reason} -> {:error, :paddle_unavailable}
-        end
+        sub_id |> fun.() |> normalize_paddle_result()
 
       _ ->
         {:error, :no_active_subscription}

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -135,36 +135,25 @@ defmodule EngramWeb.BillingController do
     * 202 — Paddle accepted, scheduled-change is in flight; webhook will
       mirror it back into our DB
     * 422 `no_active_subscription` — user has no Paddle subscription id
-    * 503 `paddle_unavailable` — Paddle non-2xx / transport error
+    * 422 `paddle_rejected` — Paddle returned 4xx (user-caused, e.g. sub
+      already canceled or replaced). `paddle_status` in body.
+    * 502 `paddle_upstream_error` — Paddle returned 5xx
+    * 503 `paddle_unavailable` — transport failure (no HTTP response)
   """
   def cancel_subscription(conn, _params) do
     with_billing(conn, fn ->
-      case Subscriptions.cancel(conn.assigns.current_user) do
-        {:ok, data} ->
-          conn |> put_status(202) |> json(data)
-
-        {:error, :no_active_subscription} ->
-          conn |> put_status(422) |> json(%{error: "no_active_subscription"})
-
-        {:error, :paddle_unavailable} ->
-          conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
-      end
+      conn.assigns.current_user
+      |> Subscriptions.cancel()
+      |> respond_paddle(conn, ok_status: 202)
     end)
   end
 
   @doc "Reverse a scheduled cancel before its effective date."
   def reverse_cancel(conn, _params) do
     with_billing(conn, fn ->
-      case Subscriptions.reverse_cancel(conn.assigns.current_user) do
-        {:ok, data} ->
-          conn |> put_status(202) |> json(data)
-
-        {:error, :no_active_subscription} ->
-          conn |> put_status(422) |> json(%{error: "no_active_subscription"})
-
-        {:error, :paddle_unavailable} ->
-          conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
-      end
+      conn.assigns.current_user
+      |> Subscriptions.reverse_cancel()
+      |> respond_paddle(conn, ok_status: 202)
     end)
   end
 
@@ -175,16 +164,9 @@ defmodule EngramWeb.BillingController do
   def plan_change_preview(conn, %{"target_price_id" => price_id}) when is_binary(price_id) do
     with_billing(conn, fn ->
       if valid_catalog_price_id?(price_id) do
-        case Subscriptions.preview_plan_change(conn.assigns.current_user, price_id) do
-          {:ok, preview} ->
-            json(conn, preview)
-
-          {:error, :no_active_subscription} ->
-            conn |> put_status(422) |> json(%{error: "no_active_subscription"})
-
-          {:error, :paddle_unavailable} ->
-            conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
-        end
+        conn.assigns.current_user
+        |> Subscriptions.preview_plan_change(price_id)
+        |> respond_paddle(conn, ok_status: 200)
       else
         conn |> put_status(422) |> json(%{error: "invalid_price_id"})
       end
@@ -199,16 +181,9 @@ defmodule EngramWeb.BillingController do
   def plan_change_confirm(conn, %{"target_price_id" => price_id}) when is_binary(price_id) do
     with_billing(conn, fn ->
       if valid_catalog_price_id?(price_id) do
-        case Subscriptions.confirm_plan_change(conn.assigns.current_user, price_id) do
-          {:ok, data} ->
-            conn |> put_status(202) |> json(data)
-
-          {:error, :no_active_subscription} ->
-            conn |> put_status(422) |> json(%{error: "no_active_subscription"})
-
-          {:error, :paddle_unavailable} ->
-            conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
-        end
+        conn.assigns.current_user
+        |> Subscriptions.confirm_plan_change(price_id)
+        |> respond_paddle(conn, ok_status: 202)
       else
         conn |> put_status(422) |> json(%{error: "invalid_price_id"})
       end
@@ -217,6 +192,36 @@ defmodule EngramWeb.BillingController do
 
   def plan_change_confirm(conn, _params) do
     conn |> put_status(422) |> json(%{error: "target_price_id required"})
+  end
+
+  # Single response mapper for the four user-initiated subscription actions.
+  # Distinguishes Paddle 4xx (user-caused) from 5xx (upstream outage) from
+  # transport failure (`:paddle_unavailable`) so log dashboards and support
+  # can triage without re-parsing strings — and so the frontend can show a
+  # 'try again' message for 5xx but a 'this won't work' message for 4xx.
+  defp respond_paddle({:ok, data}, conn, opts) do
+    conn |> put_status(Keyword.fetch!(opts, :ok_status)) |> json(data)
+  end
+
+  defp respond_paddle({:error, :no_active_subscription}, conn, _opts) do
+    conn |> put_status(422) |> json(%{error: "no_active_subscription"})
+  end
+
+  defp respond_paddle({:error, {:paddle_error, status}}, conn, _opts)
+       when status >= 400 and status < 500 do
+    conn
+    |> put_status(422)
+    |> json(%{error: "paddle_rejected", paddle_status: status})
+  end
+
+  defp respond_paddle({:error, {:paddle_error, status}}, conn, _opts) do
+    conn
+    |> put_status(502)
+    |> json(%{error: "paddle_upstream_error", paddle_status: status})
+  end
+
+  defp respond_paddle({:error, :paddle_unavailable}, conn, _opts) do
+    conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
   end
 
   # Allow-list: only the 4 catalog price IDs surfaced by /billing/config are

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.365",
+      version: "0.5.366",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/billing/subscriptions_test.exs
+++ b/test/engram/billing/subscriptions_test.exs
@@ -43,6 +43,17 @@ defmodule Engram.Billing.SubscriptionsTest do
 
       assert {:error, :paddle_unavailable} = Subscriptions.cancel(user)
     end
+
+    test "Paddle 4xx bubbles as {:error, {:paddle_error, status}}" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_cancel_422")
+
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
+        {:error, {:paddle_error, 422}}
+      end)
+
+      assert {:error, {:paddle_error, 422}} = Subscriptions.cancel(user)
+    end
   end
 
   describe "preview_plan_change/2" do
@@ -84,6 +95,30 @@ defmodule Engram.Billing.SubscriptionsTest do
       end)
 
       assert {:error, :paddle_unavailable} =
+               Subscriptions.preview_plan_change(user, "pri_new")
+    end
+
+    test "Paddle 4xx bubbles as {:error, {:paddle_error, status}}" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_preview_422")
+
+      expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn _, _, _ ->
+        {:error, {:paddle_error, 400}}
+      end)
+
+      assert {:error, {:paddle_error, 400}} =
+               Subscriptions.preview_plan_change(user, "pri_new")
+    end
+
+    test "Paddle 5xx bubbles as {:error, {:paddle_error, status}}" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_preview_503")
+
+      expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn _, _, _ ->
+        {:error, {:paddle_error, 503}}
+      end)
+
+      assert {:error, {:paddle_error, 503}} =
                Subscriptions.preview_plan_change(user, "pri_new")
     end
   end

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -305,6 +305,30 @@ defmodule EngramWeb.BillingControllerTest do
       body = conn |> post("/api/billing/cancel-subscription") |> json_response(503)
       assert body["error"] == "paddle_unavailable"
     end
+
+    test "Paddle 4xx maps to 422 paddle_rejected with status in body", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_422")
+
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
+        {:error, {:paddle_error, 422}}
+      end)
+
+      body = conn |> post("/api/billing/cancel-subscription") |> json_response(422)
+      assert body["error"] == "paddle_rejected"
+      assert body["paddle_status"] == 422
+    end
+
+    test "Paddle 5xx maps to 502 paddle_upstream_error", %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_502")
+
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
+        {:error, {:paddle_error, 502}}
+      end)
+
+      body = conn |> post("/api/billing/cancel-subscription") |> json_response(502)
+      assert body["error"] == "paddle_upstream_error"
+      assert body["paddle_status"] == 502
+    end
   end
 
   describe "POST /api/billing/reverse-cancel" do


### PR DESCRIPTION
## Summary

Polish pass on Gate 2 (#483 / #479) from staging walk-through + all 4 non-blocking follow-ups from #483's code review folded in.

### UX (commit 1)
- **Loading spinners** on Update-payment, Paddle-portal escape link, Cancel, reverse-cancel, and Confirm-change — Loader2 + verb-form label ("Opening…", "Canceling…", "Applying…"). Shared `portalLoading` covers both payment-update paths (overlay + redirect).
- **Plan-change preview errors no longer silently lock Confirm.** Confirm ungated on `preview.data`; preview errors surface inline as the selected card's `ctaSubLabel`.
- **Escape link → real outline button** with a helper-text subtitle keeping the third-party-processor disclosure.
- **Current Plan pill** gets primary gradient + ring + Sparkles + font-semibold for `starter` / `pro` / `trial`. `free` / `none` stay muted.

### Backend + minor frontend (commit 2)
- **Paddle 4xx vs 5xx vs transport** now distinct at the controller:
  - 4xx → 422 `paddle_rejected` + `paddle_status` in body
  - 5xx → 502 `paddle_upstream_error` + `paddle_status`
  - transport → 503 `paddle_unavailable`
  - Single `normalize_paddle_result/1` in `Subscriptions` and single `respond_paddle/3` in the controller — eliminates the 4× duplicated pattern.
- **`usePlanChangePreview`** gets `staleTime: 5m` + `refetchOnWindowFocus: false` — no more re-POST to Paddle on alt-tab.
- **`formatProration` $0 case** → "No charge today" instead of "Credited $0.00 today" (exact-cadence flips).
- **`PendingChangeBanner` always-on hook**: `useReverseCancel()` moved into an inner `ReverseCancelButton` component so the mutation state isn't allocated for non-cancel scheduled changes.

mix.exs 0.5.365 → 0.5.366.

## Test plan

- [ ] Update payment: spinner appears immediately, persists through Paddle overlay open (or until redirect unloads).
- [ ] Paddle billing portal button: spinner persists through `/billing/portal` round-trip.
- [ ] Cancel subscription: spinner on "Cancel at period end".
- [ ] Reverse cancel: spinner on "Keep my subscription" in the PendingChangeBanner.
- [ ] Plan change → Select → Confirm: spinner on "Confirm change".
- [ ] Plan change with a Paddle preview error (force backend 503 or 422): inline "Could not load proration…" appears under the selected card; Confirm button stays clickable; on confirm-attempt failure the toast distinguishes 4xx-vs-5xx via the new error names if you check the network tab.
- [ ] Plan change with same tier+cadence (Paddle returns `immediate_charge_or_credit: 0`): card shows "No charge today; next bill $X on …" — not "Credited $0.00".
- [ ] Current Plan pill: Pro / Starter / Trial → gradient + sparkle; Free → muted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)