### PR TITLE
fix(csp,billing): unblock Sentry+Paddle CSS; surface Paddle error code

### DIFF
--- a/lib/engram/billing/subscriptions.ex
+++ b/lib/engram/billing/subscriptions.ex
@@ -33,16 +33,23 @@ defmodule Engram.Billing.Subscriptions do
       anything here.
     * `{:error, :no_active_subscription}` — no `paddle_subscription_id` on
       file. Self-host users + users who have never paid land here.
-    * `{:error, {:paddle_error, status}}` — Paddle returned a non-2xx
-      response. Status preserved so the controller can map 4xx (user-
-      caused, e.g. swapping to the current price) to 422 and 5xx (Paddle
-      outage) to 502 distinctly.
+    * `{:error, {:paddle_error, status, body}}` — Paddle returned a
+      non-2xx response. Status preserved so the controller can map 4xx
+      (user-caused, e.g. swapping to the current price) to 422 and 5xx
+      (Paddle outage) to 502 distinctly. `body` is Paddle's decoded
+      error envelope (`%{"error" => %{"code" => ..., "detail" => ...}}`);
+      preserved so the controller can surface Paddle's own error code in
+      the API response — without it, "422 paddle_rejected" gave no clue
+      what was actually wrong.
     * `{:error, :paddle_unavailable}` — transport failure (Req error,
       timeout, DNS, etc. — no HTTP response). Surface as 503.
   """
   @spec cancel(User.t(), :immediately | :next_billing_period) ::
           {:ok, map()}
-          | {:error, :no_active_subscription | :paddle_unavailable | {:paddle_error, integer()}}
+          | {:error,
+             :no_active_subscription
+             | :paddle_unavailable
+             | {:paddle_error, integer(), map()}}
   def cancel(user, effective_from \\ :next_billing_period)
       when effective_from in [:immediately, :next_billing_period] do
     case Billing.get_subscription(user) do
@@ -61,14 +68,22 @@ defmodule Engram.Billing.Subscriptions do
     |> normalize_paddle_result()
   end
 
-  # Paddle HTTP layer returns `{:error, {:paddle_error, status}}` for non-2xx
-  # responses and `{:error, transport_reason}` for connection failures.
-  # Preserve the status for the controller; collapse transport errors to a
-  # single `:paddle_unavailable` since callers can't act on transport detail.
+  # Paddle HTTP layer returns `{:error, {:paddle_error, status, body}}`
+  # for non-2xx responses and `{:error, transport_reason}` for connection
+  # failures. Preserve status + body for the controller; collapse
+  # transport errors to a single `:paddle_unavailable` since callers
+  # can't act on transport detail.
+  #
+  # The 2-tuple `{:paddle_error, status}` clause is back-compat for older
+  # test mocks (BillingTest predates the body bubble-up); maps to
+  # 3-tuple with empty body so downstream code only matches one shape.
   defp normalize_paddle_result({:ok, data}), do: {:ok, data}
 
+  defp normalize_paddle_result({:error, {:paddle_error, status, body}}),
+    do: {:error, {:paddle_error, status, body}}
+
   defp normalize_paddle_result({:error, {:paddle_error, status}}),
-    do: {:error, {:paddle_error, status}}
+    do: {:error, {:paddle_error, status, %{}}}
 
   defp normalize_paddle_result({:error, _transport_reason}),
     do: {:error, :paddle_unavailable}
@@ -99,7 +114,10 @@ defmodule Engram.Billing.Subscriptions do
   """
   @spec preview_plan_change(User.t(), String.t()) ::
           {:ok, map()}
-          | {:error, :no_active_subscription | :paddle_unavailable | {:paddle_error, integer()}}
+          | {:error,
+             :no_active_subscription
+             | :paddle_unavailable
+             | {:paddle_error, integer(), map()}}
   def preview_plan_change(user, new_price_id) when is_binary(new_price_id) do
     with_active_sub(user, fn sub_id ->
       Client.impl().preview_subscription_update(
@@ -120,7 +138,10 @@ defmodule Engram.Billing.Subscriptions do
   """
   @spec confirm_plan_change(User.t(), String.t()) ::
           {:ok, map()}
-          | {:error, :no_active_subscription | :paddle_unavailable | {:paddle_error, integer()}}
+          | {:error,
+             :no_active_subscription
+             | :paddle_unavailable
+             | {:paddle_error, integer(), map()}}
   def confirm_plan_change(user, new_price_id) when is_binary(new_price_id) do
     with_active_sub(user, fn sub_id ->
       Client.impl().update_subscription(
@@ -140,7 +161,10 @@ defmodule Engram.Billing.Subscriptions do
   """
   @spec reverse_cancel(User.t()) ::
           {:ok, map()}
-          | {:error, :no_active_subscription | :paddle_unavailable | {:paddle_error, integer()}}
+          | {:error,
+             :no_active_subscription
+             | :paddle_unavailable
+             | {:paddle_error, integer(), map()}}
   def reverse_cancel(user) do
     with_active_sub(user, fn sub_id ->
       Client.impl().update_subscription(

--- a/lib/engram/paddle/client/http.ex
+++ b/lib/engram/paddle/client/http.ex
@@ -31,7 +31,7 @@ defmodule Engram.Paddle.Client.HTTP do
             reason_label: inspect(body)
           )
 
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}
@@ -50,7 +50,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
         {:ok, %Req.Response{status: status, body: body}} ->
           log_non_2xx("subscription", status, body)
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}
@@ -71,7 +71,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
         {:ok, %Req.Response{status: status, body: body}} ->
           log_non_2xx("transactions", status, body)
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}
@@ -90,7 +90,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
         {:ok, %Req.Response{status: status, body: body}} ->
           log_non_2xx("transaction-invoice", status, body)
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}
@@ -109,7 +109,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
         {:ok, %Req.Response{status: status, body: body}} ->
           log_non_2xx("portal-session", status, body)
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}
@@ -179,7 +179,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
       {:ok, %Req.Response{status: status, body: body}} ->
         log_non_2xx("subscriptions-list", status, body)
-        {:error, {:paddle_error, status}}
+        {:error, {:paddle_error, status, body}}
 
       {:error, reason} ->
         Logger.warning("Paddle subscriptions-list transport error",
@@ -205,7 +205,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
         {:ok, %Req.Response{status: status, body: body}} ->
           log_non_2xx("update-payment-transaction", status, body)
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}
@@ -233,7 +233,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
         {:ok, %Req.Response{status: status, body: body}} ->
           log_non_2xx("subscription-cancel", status, body)
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}
@@ -254,7 +254,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
         {:ok, %Req.Response{status: status, body: body}} ->
           log_non_2xx("subscription-preview", status, body)
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}
@@ -281,7 +281,7 @@ defmodule Engram.Paddle.Client.HTTP do
 
         {:ok, %Req.Response{status: status, body: body}} ->
           log_non_2xx("subscription-update", status, body)
-          {:error, {:paddle_error, status}}
+          {:error, {:paddle_error, status, body}}
 
         {:error, reason} ->
           {:error, reason}

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -207,22 +207,46 @@ defmodule EngramWeb.BillingController do
     conn |> put_status(422) |> json(%{error: "no_active_subscription"})
   end
 
-  defp respond_paddle({:error, {:paddle_error, status}}, conn, _opts)
+  defp respond_paddle({:error, {:paddle_error, status, body}}, conn, _opts)
        when status >= 400 and status < 500 do
     conn
     |> put_status(422)
-    |> json(%{error: "paddle_rejected", paddle_status: status})
+    |> json(paddle_error_payload("paddle_rejected", status, body))
   end
 
-  defp respond_paddle({:error, {:paddle_error, status}}, conn, _opts) do
+  defp respond_paddle({:error, {:paddle_error, status, body}}, conn, _opts) do
     conn
     |> put_status(502)
-    |> json(%{error: "paddle_upstream_error", paddle_status: status})
+    |> json(paddle_error_payload("paddle_upstream_error", status, body))
   end
 
   defp respond_paddle({:error, :paddle_unavailable}, conn, _opts) do
     conn |> put_status(503) |> json(%{error: "paddle_unavailable"})
   end
+
+  # Paddle errors come back as `%{"error" => %{"code" => ..., "detail" => ...,
+  # "documentation_url" => ...}}`. Surface the code + detail in our API
+  # response so the user can see WHY Paddle rejected the request without
+  # SSH-ing to the backend. Fall back to bare status if the body shape
+  # doesn't match — older Paddle endpoints sometimes return plain text.
+  defp paddle_error_payload(error, status, body) do
+    base = %{error: error, paddle_status: status}
+
+    case body do
+      %{"error" => %{"code" => code} = err} when is_binary(code) ->
+        base
+        |> Map.put(:paddle_code, code)
+        |> maybe_put(:paddle_detail, Map.get(err, "detail"))
+
+      _ ->
+        base
+    end
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value) when is_binary(value), do: Map.put(map, key, value)
+  defp maybe_put(map, _key, _other), do: map
 
   # Allow-list: only the 4 catalog price IDs surfaced by /billing/config are
   # valid plan-change targets. Without this guard a caller could submit an

--- a/lib/engram_web/csp.ex
+++ b/lib/engram_web/csp.ex
@@ -157,11 +157,18 @@ defmodule EngramWeb.CSP do
   # Both sandbox and live Paddle environments serve from `*.paddle.com`.
   # PADDLE_ENV (read in runtime.exs:341) selects which Paddle backend
   # API the server calls; the browser-facing CDN hosts are stable.
+  #
+  # `style-src` is required because Paddle Checkout injects a `<link>`
+  # to `sandbox-cdn.paddle.com/paddle/v2/assets/css/paddle.css` (the
+  # live CDN equivalent in production). Without it the overlay renders
+  # unstyled and the browser console shows a `style-src` CSP violation
+  # — the exact failure mode that surfaced on staging 2026-06-06.
   defp paddle_directives do
     hosts = ["https://*.paddle.com"]
 
     %{
       "script-src" => hosts,
+      "style-src" => hosts,
       "connect-src" => hosts,
       "frame-src" => hosts
     }
@@ -209,20 +216,32 @@ defmodule EngramWeb.CSP do
   # Sentry error reporting (browser SDK).
   #
   # The SDK itself ships bundled in the SPA (no extra script-src host),
-  # but every captured event POSTs to the project's ingest host on
-  # `*.ingest.sentry.io`, and Sentry uses regional shards (us / eu) so
-  # the wildcard is necessary. Without this `connect-src` entry the
-  # browser blocks the POST and exceptions never reach Sentry — a
-  # silent-success failure mode where the SDK reports "queued" but the
-  # event evaporates at the CSP gate.
+  # but every captured event POSTs to the project's ingest host. Sentry
+  # uses regional shards — the actual ingest hostname is
+  # `<orgId>.ingest.<region>.sentry.io` (e.g.
+  # `o4511498169942016.ingest.us.sentry.io`), four labels after the org
+  # prefix. CSP wildcards match exactly ONE label, so the single
+  # `*.ingest.sentry.io` did NOT cover regional shards even though
+  # Sentry's docs imply it does. Listing both `*.ingest.<region>.
+  # sentry.io` and the bare `*.ingest.sentry.io` covers projects on the
+  # legacy non-sharded ingest plus US/EU regions.
+  #
+  # Without these entries the browser blocks the POST and exceptions
+  # never reach Sentry — a silent-success failure mode where the SDK
+  # reports "queued" but the event evaporates at the CSP gate. This
+  # exact failure surfaced on staging 2026-06-06: DSN was correct,
+  # ingest was on us-region, CSP only listed the unsharded wildcard.
   #
   # Unconditionally on because the frontend bundle is the same for
   # SaaS + self-host; the actual `Sentry.init` call is gated on
   # `VITE_SENTRY_DSN`, and self-host builds without the DSN never
-  # produce any traffic to this host. CSP is a static allow-list and
-  # gains nothing from runtime gating.
+  # produce any traffic to this host.
   defp sentry_directives do
-    hosts = ["https://*.ingest.sentry.io"]
+    hosts = [
+      "https://*.ingest.sentry.io",
+      "https://*.ingest.us.sentry.io",
+      "https://*.ingest.de.sentry.io"
+    ]
 
     %{
       "connect-src" => hosts

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.366",
+      version: "0.5.367",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/billing/subscriptions_test.exs
+++ b/test/engram/billing/subscriptions_test.exs
@@ -44,15 +44,19 @@ defmodule Engram.Billing.SubscriptionsTest do
       assert {:error, :paddle_unavailable} = Subscriptions.cancel(user)
     end
 
-    test "Paddle 4xx bubbles as {:error, {:paddle_error, status}}" do
+    test "Paddle 4xx bubbles as {:error, {:paddle_error, status, body}}" do
       user = insert(:user)
       insert(:subscription, user: user, paddle_subscription_id: "sub_cancel_422")
 
+      body = %{
+        "error" => %{"code" => "subscription_locked", "detail" => "Subscription is locked"}
+      }
+
       expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
-        {:error, {:paddle_error, 422}}
+        {:error, {:paddle_error, 422, body}}
       end)
 
-      assert {:error, {:paddle_error, 422}} = Subscriptions.cancel(user)
+      assert {:error, {:paddle_error, 422, ^body}} = Subscriptions.cancel(user)
     end
   end
 
@@ -98,27 +102,41 @@ defmodule Engram.Billing.SubscriptionsTest do
                Subscriptions.preview_plan_change(user, "pri_new")
     end
 
-    test "Paddle 4xx bubbles as {:error, {:paddle_error, status}}" do
+    test "Paddle 4xx bubbles as {:error, {:paddle_error, status, body}}" do
       user = insert(:user)
       insert(:subscription, user: user, paddle_subscription_id: "sub_preview_422")
 
+      body = %{"error" => %{"code" => "invalid_field", "detail" => "items is invalid"}}
+
       expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn _, _, _ ->
-        {:error, {:paddle_error, 400}}
+        {:error, {:paddle_error, 400, body}}
       end)
 
-      assert {:error, {:paddle_error, 400}} =
+      assert {:error, {:paddle_error, 400, ^body}} =
                Subscriptions.preview_plan_change(user, "pri_new")
     end
 
-    test "Paddle 5xx bubbles as {:error, {:paddle_error, status}}" do
+    test "Paddle 5xx bubbles as {:error, {:paddle_error, status, body}}" do
       user = insert(:user)
       insert(:subscription, user: user, paddle_subscription_id: "sub_preview_503")
 
       expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn _, _, _ ->
-        {:error, {:paddle_error, 503}}
+        {:error, {:paddle_error, 503, %{}}}
       end)
 
-      assert {:error, {:paddle_error, 503}} =
+      assert {:error, {:paddle_error, 503, %{}}} =
+               Subscriptions.preview_plan_change(user, "pri_new")
+    end
+
+    test "back-compat: 2-tuple {:paddle_error, status} normalizes to 3-tuple with empty body" do
+      user = insert(:user)
+      insert(:subscription, user: user, paddle_subscription_id: "sub_preview_legacy")
+
+      expect(Engram.Paddle.ClientMock, :preview_subscription_update, fn _, _, _ ->
+        {:error, {:paddle_error, 422}}
+      end)
+
+      assert {:error, {:paddle_error, 422, %{}}} =
                Subscriptions.preview_plan_change(user, "pri_new")
     end
   end

--- a/test/engram/paddle/client/http_test.exs
+++ b/test/engram/paddle/client/http_test.exs
@@ -126,14 +126,16 @@ defmodule Engram.Paddle.Client.HTTPTest do
       assert length(results) >= 50
     end
 
-    test "returns {:error, {:paddle_error, status}} on non-200", %{bypass: bypass} do
+    test "returns {:error, {:paddle_error, status, body}} on non-200", %{bypass: bypass} do
       # Req's default retry policy retries 5xx up to 4 attempts. Use a
       # 400 (non-retried) so the test doesn't spend 7s in backoff.
       Bypass.expect_once(bypass, "GET", "/subscriptions", fn conn ->
         Plug.Conn.send_resp(conn, 400, ~s({"error": "bad request"}))
       end)
 
-      assert {:error, {:paddle_error, 400}} = HTTP.list_subscriptions(@since)
+      # body is opaque here — Req may decode JSON if content-type is set,
+      # otherwise pass through raw string. Match on status only.
+      assert {:error, {:paddle_error, 400, _body}} = HTTP.list_subscriptions(@since)
     end
 
     test "sends updated_at[GTE] filter and per_page=200 on first request", %{bypass: bypass} do
@@ -168,12 +170,12 @@ defmodule Engram.Paddle.Client.HTTPTest do
                )
     end
 
-    test "returns {:error, {:paddle_error, status}} on non-200", %{bypass: bypass} do
+    test "returns {:error, {:paddle_error, status, body}} on non-200", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/subscriptions/sub_x/cancel", fn conn ->
         Plug.Conn.send_resp(conn, 400, ~s({"error":"bad"}))
       end)
 
-      assert {:error, {:paddle_error, 400}} =
+      assert {:error, {:paddle_error, 400, _body}} =
                HTTP.cancel_subscription("sub_x", :next_billing_period, [])
     end
   end

--- a/test/engram_web/controllers/billing_controller_test.exs
+++ b/test/engram_web/controllers/billing_controller_test.exs
@@ -306,23 +306,48 @@ defmodule EngramWeb.BillingControllerTest do
       assert body["error"] == "paddle_unavailable"
     end
 
-    test "Paddle 4xx maps to 422 paddle_rejected with status in body", %{conn: conn, user: user} do
+    test "Paddle 4xx maps to 422 paddle_rejected with code + detail surfaced from body",
+         %{conn: conn, user: user} do
       insert(:subscription, user: user, paddle_subscription_id: "sub_422")
 
+      paddle_body = %{
+        "error" => %{
+          "code" => "subscription_locked_renewal",
+          "detail" => "Subscription is locked because it's currently renewing.",
+          "documentation_url" => "https://developer.paddle.com/errors/x"
+        }
+      }
+
       expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
-        {:error, {:paddle_error, 422}}
+        {:error, {:paddle_error, 422, paddle_body}}
       end)
 
       body = conn |> post("/api/billing/cancel-subscription") |> json_response(422)
       assert body["error"] == "paddle_rejected"
       assert body["paddle_status"] == 422
+      assert body["paddle_code"] == "subscription_locked_renewal"
+      assert body["paddle_detail"] =~ "currently renewing"
+    end
+
+    test "Paddle 4xx with no parseable body returns paddle_rejected without code",
+         %{conn: conn, user: user} do
+      insert(:subscription, user: user, paddle_subscription_id: "sub_422_thin")
+
+      expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
+        {:error, {:paddle_error, 422, "plain text upstream"}}
+      end)
+
+      body = conn |> post("/api/billing/cancel-subscription") |> json_response(422)
+      assert body["error"] == "paddle_rejected"
+      assert body["paddle_status"] == 422
+      refute Map.has_key?(body, "paddle_code")
     end
 
     test "Paddle 5xx maps to 502 paddle_upstream_error", %{conn: conn, user: user} do
       insert(:subscription, user: user, paddle_subscription_id: "sub_502")
 
       expect(Engram.Paddle.ClientMock, :cancel_subscription, fn _, _, _ ->
-        {:error, {:paddle_error, 502}}
+        {:error, {:paddle_error, 502, %{}}}
       end)
 
       body = conn |> post("/api/billing/cancel-subscription") |> json_response(502)

--- a/test/engram_web/csp_test.exs
+++ b/test/engram_web/csp_test.exs
@@ -50,6 +50,7 @@ defmodule EngramWeb.CSPTest do
       header = CSP.header()
 
       assert script_src(header) =~ "https://*.paddle.com"
+      assert style_src(header) =~ "https://*.paddle.com"
       assert connect_src(header) =~ "https://*.paddle.com"
       assert frame_src(header) =~ "https://*.paddle.com"
     end
@@ -70,17 +71,23 @@ defmodule EngramWeb.CSPTest do
       assert connect_src(header) =~ "https://static.cloudflareinsights.com"
     end
 
-    test "always whitelists Sentry ingest hosts on connect-src" do
+    test "always whitelists Sentry ingest hosts including regional shards on connect-src" do
       # Sentry browser SDK is bundled (no script-src host needed) but
-      # captured events POST to `*.ingest.sentry.io`. Without this
-      # entry the SDK silently fails — the network POST returns blocked
-      # by CSP, no error reaches `Sentry.captureException`'s caller,
-      # and prod errors evaporate at the CSP gate.
+      # captured events POST to `<orgId>.ingest.<region>.sentry.io`. CSP
+      # wildcards match exactly ONE label, so `*.ingest.sentry.io` does
+      # NOT cover regional shards (us / eu / etc.). Listing both the
+      # bare wildcard AND the regional wildcards covers projects on any
+      # ingest topology Sentry has shipped. Without these the SDK
+      # silently fails on us-region projects — the network POST returns
+      # blocked by CSP and prod errors evaporate at the gate. This
+      # exact failure surfaced on staging 2026-06-06.
       Application.put_env(:engram, :clerk_issuer, nil)
 
       header = CSP.header()
 
       assert connect_src(header) =~ "https://*.ingest.sentry.io"
+      assert connect_src(header) =~ "https://*.ingest.us.sentry.io"
+      assert connect_src(header) =~ "https://*.ingest.de.sentry.io"
     end
 
     test "always whitelists PostHog ingest hosts on connect-src" do
@@ -206,6 +213,7 @@ defmodule EngramWeb.CSPTest do
   # ── Helpers ────────────────────────────────────────────────────────
 
   defp script_src(header), do: directive(header, "script-src")
+  defp style_src(header), do: directive(header, "style-src")
   defp connect_src(header), do: directive(header, "connect-src")
   defp frame_src(header), do: directive(header, "frame-src")
 


### PR DESCRIPTION
## Summary

Two CSP bugs + one error-surfacing fix that landed from exercising PR #486 on staging 2026-06-06.

### CSP (`lib/engram_web/csp.ex`)
1. **Sentry regional shard ingest was blocked.** `*.ingest.sentry.io` matches one label — does NOT cover `<orgId>.ingest.us.sentry.io` (Sentry's actual US ingest hostname). The module comment claimed coverage the policy didn't deliver. Added `*.ingest.us.sentry.io` + `*.ingest.de.sentry.io` alongside the bare wildcard.
2. **Paddle Checkout CSS was blocked.** `paddle_directives/0` contributed to script/connect/frame only. Added `*.paddle.com` to `style-src` too — Paddle injects `sandbox-cdn.paddle.com/.../paddle.css`.

### Paddle error body bubbled to API response
PR #486's `paddle_rejected` 422 was opaque — no clue what Paddle actually rejected. Threaded the response body through HTTP → `Subscriptions` → controller. API response now includes:
- `paddle_code` — Paddle's standard error code (e.g. `subscription_locked_renewal`)
- `paddle_detail` — Paddle's human-readable explanation

Read it in DevTools network tab, no SSH required.

Tuple shape change `{:paddle_error, status}` → `{:paddle_error, status, body}` at the HTTP layer; `normalize_paddle_result/1` keeps back-compat for the 2-tuple form so older `Billing.*` test mocks continue to pass.

mix.exs 0.5.366 → 0.5.367.

## Test plan

- [ ] Reload `staging.engram.page/settings/billing` — no more Sentry `ERR_BLOCKED_BY_CLIENT` / CSP violations.
- [ ] Open Paddle Update-payment overlay — no more `style-src` violation; CSS applies.
- [ ] Trigger a Paddle 422 (e.g. swap to current plan / change while in lock state). Inspect `/api/billing/plan-change/preview` response — body now includes `paddle_code` + `paddle_detail`.
- [ ] Older Billing tests still pass (back-compat 2-tuple path).
- [ ] `mix test test/engram_web/csp_test.exs` confirms new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)