### PR TITLE
fix(billing): block plan change during Paddle trial, surface why

### DIFF
--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -323,7 +323,11 @@ export default function BillingPage({ hideHeading = false, onActivated }: Billin
             </div>
           )}
           {billing.subscription && panel === 'change' && (
-            <PlanChangePanel billing={billing} onClose={() => setPanel(null)} />
+            <PlanChangePanel
+              billing={billing}
+              onClose={() => setPanel(null)}
+              onSwitchToCancel={() => setPanel('cancel')}
+            />
           )}
           {billing.subscription && panel === 'cancel' && (
             <CancelPanel

--- a/frontend/src/billing/plan-change-panel.test.tsx
+++ b/frontend/src/billing/plan-change-panel.test.tsx
@@ -56,7 +56,7 @@ function billing(overrides: Partial<BillingStatus> = {}): BillingStatus {
 
 describe('PlanChangePanel', () => {
   it('renders Starter + Pro cards using shared PlanCard styling', () => {
-    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
     expect(screen.getByText('Starter')).toBeInTheDocument()
     expect(screen.getByText('Pro')).toBeInTheDocument()
     expect(screen.getByText('$7/mo')).toBeInTheDocument()
@@ -64,7 +64,7 @@ describe('PlanChangePanel', () => {
   })
 
   it('marks the user current tier and shows the inert You are on this plan indicator', () => {
-    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
     // Starter is current → 'Your plan' badge + inert "You're on this plan" status
     expect(screen.getAllByText(/your plan/i).length).toBeGreaterThan(0)
     expect(screen.getByRole('status', { name: /your current plan/i })).toBeInTheDocument()
@@ -78,7 +78,7 @@ describe('PlanChangePanel', () => {
       next_billed_at: '2026-07-01T00:00:00Z',
     })
 
-    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
     fireEvent.click(screen.getByRole('button', { name: /^select$/i }))
 
     await waitFor(() =>
@@ -100,7 +100,7 @@ describe('PlanChangePanel', () => {
       .mockResolvedValueOnce({ transaction_id: 'txn_xyz' })
 
     const onClose = vi.fn()
-    render(<PlanChangePanel billing={billing()} onClose={onClose} />, { wrapper: Wrapper })
+    render(<PlanChangePanel billing={billing()} onClose={onClose} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
     fireEvent.click(screen.getByRole('button', { name: /^select$/i }))
     await screen.findByText(/charged \$3\.50 today/i)
     fireEvent.click(screen.getByRole('button', { name: /confirm change/i }))
@@ -121,7 +121,7 @@ describe('PlanChangePanel', () => {
     // disabled Confirm and no clue why.
     post.mockRejectedValue(new Error('paddle_unavailable'))
 
-    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
     fireEvent.click(screen.getByRole('button', { name: /^select$/i }))
 
     expect(await screen.findByText(/could not load proration/i)).toBeInTheDocument()
@@ -137,7 +137,7 @@ describe('PlanChangePanel', () => {
       next_billed_at: '2026-07-01T00:00:00Z',
     })
 
-    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} />, { wrapper: Wrapper })
+    render(<PlanChangePanel billing={billing()} onClose={vi.fn()} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
     fireEvent.click(screen.getByRole('button', { name: /^select$/i }))
     expect(await screen.findByText(/no charge today/i)).toBeInTheDocument()
     expect(screen.queryByText(/credited \$0\.00/i)).not.toBeInTheDocument()
@@ -145,9 +145,41 @@ describe('PlanChangePanel', () => {
 
   it('Cancel button closes without firing a mutation', () => {
     const onClose = vi.fn()
-    render(<PlanChangePanel billing={billing()} onClose={onClose} />, { wrapper: Wrapper })
+    render(<PlanChangePanel billing={billing()} onClose={onClose} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
     fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
     expect(post).not.toHaveBeenCalled()
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('trial subscription: shows TrialNotice instead of picker; no preview POST', () => {
+    // Paddle rejects items-array mutations on a trialing subscription
+    // (`subscription_trialing_items_update_invalid_options` for tier swaps,
+    // `subscription_new_items_not_valid` for cadence swaps). The picker
+    // would 422 on every selection — render the notice instead.
+    const trial = billing({
+      tier: 'trial',
+      trial_days_remaining: 4,
+      subscription: { status: 'trialing', tier: 'pro', current_period_end: '2026-06-11' },
+    })
+
+    render(<PlanChangePanel billing={trial} onClose={vi.fn()} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
+
+    expect(screen.getByText(/payment processor.*doesn't allow plan changes/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel free trial/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^select$/i })).not.toBeInTheDocument()
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it('trial: "Cancel free trial" button invokes onSwitchToCancel', () => {
+    const onSwitchToCancel = vi.fn()
+    const trial = billing({
+      tier: 'trial',
+      subscription: { status: 'trialing', tier: 'pro', current_period_end: '2026-06-11' },
+    })
+
+    render(<PlanChangePanel billing={trial} onClose={vi.fn()} onSwitchToCancel={onSwitchToCancel} />, { wrapper: Wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /cancel free trial/i }))
+
+    expect(onSwitchToCancel).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -16,6 +16,10 @@ import { CadenceToggle, PLAN_CATALOG, PlanCard, type PlanTier } from './plan-car
 interface PlanChangePanelProps {
   billing: BillingStatus
   onClose: () => void
+  // Trial users can't change plan shape via Paddle (see TrialNotice). The
+  // panel offers a "Cancel free trial" path instead — parent owns the
+  // panel-swap so we don't reach into siblings.
+  onSwitchToCancel: () => void
 }
 
 function formatCents(cents: number | null | undefined): string {
@@ -41,7 +45,24 @@ function deriveCurrentCadence(detail: SubscriptionDetail | undefined): BillingCa
   return detail?.billing_cycle?.interval === 'year' ? 'annual' : 'monthly'
 }
 
-export default function PlanChangePanel({ billing, onClose }: PlanChangePanelProps) {
+export default function PlanChangePanel({
+  billing,
+  onClose,
+  onSwitchToCancel,
+}: PlanChangePanelProps) {
+  // Paddle refuses any items-array mutation on a trialing subscription —
+  // both tier swaps (`subscription_trialing_items_update_invalid_options`)
+  // AND cadence swaps (`subscription_new_items_not_valid`). We can't work
+  // around it client-side; the trial has to end first. Render an
+  // explanatory state instead of a picker that's guaranteed to 422.
+  if (billing.subscription?.status === 'trialing') {
+    return <TrialNotice billing={billing} onClose={onClose} onSwitchToCancel={onSwitchToCancel} />
+  }
+
+  return <PlanChangePicker billing={billing} onClose={onClose} />
+}
+
+function PlanChangePicker({ billing, onClose }: { billing: BillingStatus; onClose: () => void }) {
   const { data: config } = useBillingConfig()
   const { data: detail } = useBillingSubscriptionDetail(Boolean(billing.subscription))
   const currentTier = deriveCurrentTier(billing)
@@ -158,6 +179,54 @@ export default function PlanChangePanel({ billing, onClose }: PlanChangePanelPro
         </Button>
         <Button variant="ghost" onClick={onClose} disabled={confirm.isPending}>
           Cancel
+        </Button>
+      </div>
+    </section>
+  )
+}
+
+// Renders when the user is on a Paddle free trial. Paddle won't accept
+// items-array mutations on a trialing subscription, so a picker would
+// just produce 422s for every selection (verified on staging 2026-06-06:
+// `subscription_trialing_items_update_invalid_options` for tier swaps,
+// `subscription_new_items_not_valid` for cadence swaps). Surface the
+// constraint honestly instead of pretending the picker works.
+function TrialNotice({
+  billing,
+  onClose,
+  onSwitchToCancel,
+}: {
+  billing: BillingStatus
+  onClose: () => void
+  onSwitchToCancel: () => void
+}) {
+  const renewsAt = billing.subscription?.current_period_end
+    ? new Date(billing.subscription.current_period_end).toLocaleDateString()
+    : null
+
+  return (
+    <section role="region" aria-label="Change plan" className="space-y-4 pt-2">
+      <header>
+        <h2 className="text-base font-semibold text-foreground">Change your plan</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You're on a free trial. Paddle, our payment processor, doesn't allow plan changes while a
+          subscription is in trial
+          {renewsAt ? <> — your trial converts on <strong>{renewsAt}</strong></> : null}.
+        </p>
+      </header>
+      <div className="rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">Want a different plan?</p>
+        <p className="mt-1">
+          Cancel the free trial below — you won't be charged. You can subscribe to the plan you want
+          at any time.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button variant="destructive" onClick={onSwitchToCancel}>
+          Cancel free trial
+        </Button>
+        <Button variant="ghost" onClick={onClose}>
+          Close
         </Button>
       </div>
     </section>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.367",
+      version: "0.5.368",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Diagnosed live on staging via the `paddle_code` field PR #487 added:

| Target | Paddle code | Reason |
|---|---|---|
| Tier swap (Pro Trial → Starter) | `subscription_trialing_items_update_invalid_options` | Paddle policy: can't add/remove items on a trialing subscription |
| Cadence swap (Pro Monthly Trial → Pro Annual) | `subscription_new_items_not_valid` | Same root: cadence swap = new items = blocked during trial |

Paddle's hint about \`do_not_bill\` proration mode only applies to **quantity** updates of existing items, not item replacement — there's no client-side workaround.

PlanChangePanel now detects \`billing.subscription?.status === 'trialing'\` and renders a TrialNotice instead of the picker. Explains the constraint, offers a "Cancel free trial" button that flows to the existing CancelPanel via a new \`onSwitchToCancel\` prop the parent owns (CancelPanel already supports trial cancellation).

mix.exs 0.5.367 → 0.5.368.

## Test plan

- [ ] Trial user opens Change plan → sees TrialNotice with trial-end date, no picker, no preview POST fires.
- [ ] "Cancel free trial" button on the notice → opens CancelPanel inline.
- [ ] Non-trial subscriber: picker still renders + behaves as before.

## Follow-ups (not in this PR)

- Trial users might still want to *queue* a tier change for trial conversion. That's a defer-target backend change (store \`pending_tier_change\`, apply at trial-end webhook). Worth doing if users feel locked out; for now the explanatory state ships the constraint honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)