### PR TITLE
fix(billing): trial — hide Cancel button when cancel already scheduled

### DIFF
--- a/frontend/src/billing/plan-change-panel.test.tsx
+++ b/frontend/src/billing/plan-change-panel.test.tsx
@@ -182,4 +182,30 @@ describe('PlanChangePanel', () => {
 
     expect(onSwitchToCancel).toHaveBeenCalledOnce()
   })
+
+  it('trial with cancel already scheduled: hides Cancel button, points at PendingChangeBanner', () => {
+    // Without this guard, a second click on Cancel free trial calls
+    // Paddle's cancel endpoint again and gets a 422
+    // (`subscription_locked_renewal` or similar) — the user has no way
+    // to know they already canceled.
+    const trial = billing({
+      tier: 'trial',
+      subscription: { status: 'trialing', tier: 'pro', current_period_end: '2026-06-11' },
+    })
+
+    qc.setQueryData(['billing', 'subscription'], {
+      currency: 'USD',
+      amount: null,
+      billing_cycle: { interval: 'month', frequency: 1 },
+      next_billed_at: null,
+      scheduled_change: { action: 'cancel', effective_at: '2026-06-11T20:56:02Z' },
+    })
+
+    render(<PlanChangePanel billing={trial} onClose={vi.fn()} onSwitchToCancel={vi.fn()} />, { wrapper: Wrapper })
+
+    expect(screen.getByText(/already scheduled to cancel/i)).toBeInTheDocument()
+    expect(screen.getByText(/Keep my subscription/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /cancel free trial/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument()
+  })
 })

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -191,6 +191,13 @@ function PlanChangePicker({ billing, onClose }: { billing: BillingStatus; onClos
 // `subscription_trialing_items_update_invalid_options` for tier swaps,
 // `subscription_new_items_not_valid` for cadence swaps). Surface the
 // constraint honestly instead of pretending the picker works.
+//
+// Two states:
+//   1. Trial active, no cancel scheduled — offer Cancel free trial.
+//   2. Trial active, cancel already scheduled — point at the existing
+//      PendingChangeBanner ("Keep my subscription") at the top of the
+//      page; do NOT offer another Cancel button (a second cancel call
+//      would 422 with `subscription_locked_renewal` or similar).
 function TrialNotice({
   billing,
   onClose,
@@ -200,9 +207,41 @@ function TrialNotice({
   onClose: () => void
   onSwitchToCancel: () => void
 }) {
+  const { data: detail } = useBillingSubscriptionDetail(Boolean(billing.subscription))
+  const alreadyCanceled = detail?.scheduled_change?.action === 'cancel'
+  const cancelAt = detail?.scheduled_change?.effective_at
+    ? new Date(detail.scheduled_change.effective_at).toLocaleDateString()
+    : null
   const renewsAt = billing.subscription?.current_period_end
     ? new Date(billing.subscription.current_period_end).toLocaleDateString()
     : null
+
+  if (alreadyCanceled) {
+    return (
+      <section role="region" aria-label="Change plan" className="space-y-4 pt-2">
+        <header>
+          <h2 className="text-base font-semibold text-foreground">Change your plan</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Your free trial is already scheduled to cancel
+            {cancelAt ? <> on <strong>{cancelAt}</strong></> : null}. You won't be charged. You can
+            subscribe to the plan you want once your trial ends.
+          </p>
+        </header>
+        <div className="rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">Changed your mind?</p>
+          <p className="mt-1">
+            Use <strong>Keep my subscription</strong> at the top of this page to reverse the
+            cancellation.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </section>
+    )
+  }
 
   return (
     <section role="region" aria-label="Change plan" className="space-y-4 pt-2">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.368",
+      version: "0.5.369",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Caught live during cdp-laptop staging walkthrough: trial user with `scheduled_change.action === 'cancel'` could still click "Cancel free trial" in TrialNotice (PR #488). A second cancel call hits Paddle's already-canceled subscription and 422s — and the user has no way to know they already canceled because the action is still offered.

TrialNotice now reads `useBillingSubscriptionDetail()` and renders a second variant when cancel is already scheduled:

> "Your free trial is already scheduled to cancel on MM/DD/YYYY. You won't be charged. You can subscribe to the plan you want once your trial ends."
>
> *Changed your mind?* Use **Keep my subscription** at the top of this page to reverse the cancellation.
>
> [Close]

No second Cancel button — points at the existing PendingChangeBanner ("Keep my subscription") for reversal.

mix.exs 0.5.368 → 0.5.369.

## Test plan

- [ ] Trial user with no scheduled cancel: TrialNotice shows "Cancel free trial" (unchanged).
- [ ] Trial user with `scheduled_change.action='cancel'`: TrialNotice shows "already scheduled" copy + only Close button; no Cancel button.
- [ ] Same user clicks Keep my subscription in PendingChangeBanner at top → reverse-cancel flows, then re-opens Change plan → original TrialNotice content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)