### PR TITLE
feat(obs): ship continuous BEAM CPU profiles to Grafana Cloud Pyroscope

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -674,3 +674,29 @@ if key = System.get_env("POSTHOG_API_KEY") do
     posthog_key: key,
     posthog_host: System.get_env("POSTHOG_HOST", "https://us.i.posthog.com")
 end
+
+# Pyroscope continuous CPU profiling. Same opt-in shape as Sentry/PostHog:
+# the worker's child_spec/1 returns :ignore when any of the three required
+# env vars is missing, so dev/test/self-host emit no profiling traffic and
+# the supervisor silently drops the child from the start order.
+#
+# Wired infra-side via engram-infra/main/envs/prod/ecs_secrets.tf:
+#   GRAFANA_PYROSCOPE_URL       → grafana_pyroscope_url       (SOPS)
+#   GRAFANA_PYROSCOPE_USERNAME  → grafana_pyroscope_username  (SOPS)
+#   GRAFANA_AGENT_TOKEN         → grafana_agent_token         (SOPS)
+# (The token is shared with Loki/Tempo/Prom remote_write — same Grafana
+#  Cloud access policy, scoped to "metrics:write logs:write traces:write
+#  profiles:write".)
+if pyroscope_url = System.get_env("GRAFANA_PYROSCOPE_URL") do
+  config :engram, :pyroscope,
+    url: pyroscope_url,
+    username:
+      System.get_env("GRAFANA_PYROSCOPE_USERNAME") ||
+        raise("GRAFANA_PYROSCOPE_USERNAME required when GRAFANA_PYROSCOPE_URL is set"),
+    token:
+      System.get_env("GRAFANA_AGENT_TOKEN") ||
+        raise("GRAFANA_AGENT_TOKEN required when GRAFANA_PYROSCOPE_URL is set"),
+    app_name: System.get_env("PYROSCOPE_APP_NAME", "engram-saas-prod"),
+    env: to_string(config_env()),
+    instance: System.get_env("HOSTNAME", System.get_env("ECS_TASK_ID", "unknown"))
+end

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -40,6 +40,9 @@ defmodule Engram.Application do
         rate_limiter_child(),
         {Oban, Application.fetch_env!(:engram, Oban)},
         clerk_strategy_child(),
+        # Pyroscope continuous CPU profiler. Returns nil when GRAFANA_PYROSCOPE_URL
+        # is unset (dev, test, self-host), and Enum.reject below filters it out.
+        pyroscope_child(),
         EngramWeb.Endpoint
       ]
       |> Enum.reject(&is_nil/1)
@@ -153,6 +156,16 @@ defmodule Engram.Application do
     if Application.get_env(:engram, :auth_provider) == :clerk &&
          Application.get_env(:engram, :clerk_jwks_url) do
       {Engram.Auth.ClerkStrategy, time_interval: 60_000, first_fetch_sync: true}
+    end
+  end
+
+  # Continuous BEAM CPU profiler. Started only when the three SOPS-wired
+  # env vars (GRAFANA_PYROSCOPE_URL/USERNAME + GRAFANA_AGENT_TOKEN) are
+  # all present at runtime — see config/runtime.exs. Dev/test/self-host
+  # leave them unset and the supervisor never sees the child.
+  defp pyroscope_child do
+    if Engram.Observability.Pyroscope.configured?() do
+      Engram.Observability.Pyroscope
     end
   end
 

--- a/lib/engram/observability/pyroscope.ex
+++ b/lib/engram/observability/pyroscope.ex
@@ -1,0 +1,350 @@
+defmodule Engram.Observability.Pyroscope do
+  @moduledoc """
+  Continuous BEAM CPU profiler that pushes collapsed-stack samples to
+  Grafana Cloud Pyroscope.
+
+  ## Why a custom sampler, not a Hex package
+
+  There is no maintained Hex package for BEAM → Pyroscope in 2026:
+
+    * `hauleth/pyroscope_otp` / `erlang-pyroscope` are unmaintained
+      (no commits in years) and predate Pyroscope's current ingest API.
+    * Grafana ships official agents for Go/Java/Python/Ruby/.NET/Node/Rust
+      and an eBPF profiler, but no BEAM-native client.
+    * `eflambe` is BEAM-aware but designed for ad-hoc profiling, not
+      continuous push — wrapping it would mean tearing down/restoring
+      tracing every push interval.
+
+  So we walk the same path the unmaintained libs did, talking to the
+  Pyroscope HTTP `/ingest` endpoint directly. The implementation is
+  tiny — a sampler GenServer, no NIF, no extra deps (Req is already
+  in the tree).
+
+  ## How it samples
+
+  Every 10ms we walk `Process.list/0` and grab each process's
+  `:current_stacktrace`. For every sample we increment a counter
+  keyed by the collapsed stack (`mod:fun/arity;mod:fun/arity;...`).
+  After a configurable window (default 10s) we serialize the
+  accumulator as Pyroscope's `folded` (collapsed-stack) text format
+  and POST it to `${GRAFANA_PYROSCOPE_URL}/ingest`. Counters reset
+  on push.
+
+  Sampling at 100Hz across N processes yields N×100 samples/sec.
+  Pyroscope normalizes via the `sampleRate=100` query param so flame
+  widths read as wall-clock proportions, not raw counts.
+
+  ## What's profiled
+
+  * Wall-clock CPU (`process_info(:current_stacktrace)` returns the
+    process's instantaneous frame whether it's running on a scheduler
+    or parked in a receive — Pyroscope's flame graphs treat them
+    uniformly).
+
+  Off-CPU and memory profiles are deferred (not landed in v1). They
+  need different sampling strategies (`erlang:process_info(:memory)`
+  diff for memory, separate scheduler-state filter for off-CPU) and
+  separate `name=engram.{cpu,memory,offcpu}` series; track in a
+  follow-up.
+
+  ## Tags / labels
+
+  Pushed as `name=engram-saas-prod{service=engram,env=prod,instance=<hostname>}`.
+  We deliberately do NOT tag per-tenant — profile storage cardinality
+  explodes on high-cardinality labels and Grafana Cloud charges for it.
+
+  ## No-op when unconfigured
+
+  When `GRAFANA_PYROSCOPE_URL` is unset (dev, test, self-host), the
+  GenServer is not added to the supervision tree at all (see
+  `Engram.Application`). The `child_spec/1` callback returns
+  `:ignore` to make that decision composable.
+  """
+
+  use GenServer
+
+  require Logger
+
+  # 100Hz CPU sampling — matches the convention every Pyroscope agent
+  # uses, so flame widths read directly as a fraction of wall-clock
+  # CPU time (1 sample ≈ 10ms of work).
+  @default_sample_interval_ms 10
+
+  # Push every 10s. Pyroscope's UI buckets profiles at this granularity
+  # by default; shorter pushes increase ingest volume without UI win.
+  @default_push_interval_ms 10_000
+
+  @default_app_name "engram-saas-prod"
+  @default_spy_name "elixirspy"
+  @default_units "samples"
+
+  # Profile types we ship in v1 (CPU only). Off-CPU + memory deferred.
+  @profile_kind "cpu"
+
+  defstruct [
+    :url,
+    :username,
+    :token,
+    :app_name,
+    :tags,
+    :sample_interval_ms,
+    :push_interval_ms,
+    :spy_name,
+    :sample_rate,
+    :window_started_at_ms,
+    :sample_timer_ref,
+    :push_timer_ref,
+    counters: %{}
+  ]
+
+  # ── Public API ────────────────────────────────────────────────────
+
+  @doc """
+  Build a child spec. Returns `:ignore` (a valid supervisor child
+  result) when the URL is unset, so `Engram.Application` can just
+  list us unconditionally.
+  """
+  @spec child_spec(keyword()) :: Supervisor.child_spec() | :ignore
+  def child_spec(opts) do
+    if configured?() do
+      %{
+        id: __MODULE__,
+        start: {__MODULE__, :start_link, [opts]},
+        restart: :permanent,
+        shutdown: 5_000,
+        type: :worker
+      }
+    else
+      :ignore
+    end
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Returns true when the prod env vars are present. Used by
+  `Engram.Application` to decide whether to add the worker.
+  """
+  @spec configured?() :: boolean()
+  def configured? do
+    case Application.get_env(:engram, :pyroscope) do
+      cfg when is_list(cfg) ->
+        is_binary(Keyword.get(cfg, :url)) and
+          Keyword.get(cfg, :url) != "" and
+          is_binary(Keyword.get(cfg, :username)) and
+          is_binary(Keyword.get(cfg, :token))
+
+      _ ->
+        false
+    end
+  end
+
+  # ── GenServer callbacks ───────────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    cfg = Application.get_env(:engram, :pyroscope, [])
+
+    sample_interval =
+      Keyword.get(
+        opts,
+        :sample_interval_ms,
+        Keyword.get(cfg, :sample_interval_ms, @default_sample_interval_ms)
+      )
+
+    push_interval =
+      Keyword.get(
+        opts,
+        :push_interval_ms,
+        Keyword.get(cfg, :push_interval_ms, @default_push_interval_ms)
+      )
+
+    state = %__MODULE__{
+      url: String.trim_trailing(Keyword.fetch!(cfg, :url), "/"),
+      username: Keyword.fetch!(cfg, :username),
+      token: Keyword.fetch!(cfg, :token),
+      app_name: Keyword.get(cfg, :app_name, @default_app_name),
+      tags: build_tags(cfg),
+      sample_interval_ms: sample_interval,
+      push_interval_ms: push_interval,
+      spy_name: Keyword.get(cfg, :spy_name, @default_spy_name),
+      sample_rate: div(1_000, sample_interval),
+      window_started_at_ms: now_ms(),
+      sample_timer_ref: nil,
+      push_timer_ref: nil,
+      counters: %{}
+    }
+
+    Logger.info(
+      "pyroscope profiler started: app=#{state.app_name} sample_interval_ms=#{sample_interval} push_interval_ms=#{push_interval}"
+    )
+
+    {:ok, schedule_both(state)}
+  end
+
+  @impl true
+  def handle_info(:sample, state) do
+    counters = take_sample(state.counters)
+    {:noreply, %{state | counters: counters, sample_timer_ref: schedule_sample(state)}}
+  end
+
+  @impl true
+  def handle_info(:push, state) do
+    {counters_to_push, window_started_at_ms} = {state.counters, state.window_started_at_ms}
+    push_window_end_ms = now_ms()
+
+    spawn(fn ->
+      do_push(state, counters_to_push, window_started_at_ms, push_window_end_ms)
+    end)
+
+    new_state = %{
+      state
+      | counters: %{},
+        window_started_at_ms: push_window_end_ms,
+        push_timer_ref: schedule_push(state)
+    }
+
+    {:noreply, new_state}
+  end
+
+  # ── Sampling ──────────────────────────────────────────────────────
+
+  @doc false
+  # Snapshot every process's current stacktrace and increment the
+  # counter keyed by the collapsed stack. We skip our own pid so the
+  # sampler doesn't profile itself dominating its own flame.
+  @spec take_sample(map()) :: map()
+  def take_sample(counters) do
+    self_pid = self()
+
+    Enum.reduce(Process.list(), counters, fn pid, acc ->
+      if pid == self_pid do
+        acc
+      else
+        case Process.info(pid, :current_stacktrace) do
+          {:current_stacktrace, [_ | _] = stack} ->
+            key = collapse(stack)
+            Map.update(acc, key, 1, &(&1 + 1))
+
+          _ ->
+            acc
+        end
+      end
+    end)
+  end
+
+  # Pyroscope "folded" / "collapsed stack" format: each *line* is one
+  # stack, frames separated by ';', root frame on the left, leaf on
+  # the right, followed by ' <count>'. We invert the BEAM stack so the
+  # entry point reads first.
+  @doc false
+  @spec collapse([tuple()]) :: String.t()
+  def collapse(stack) do
+    stack
+    |> Enum.reverse()
+    |> Enum.map_join(";", &format_frame/1)
+  end
+
+  defp format_frame({mod, fun, arity, _loc}) when is_integer(arity) do
+    "#{inspect(mod)}.#{fun}/#{arity}"
+  end
+
+  defp format_frame({mod, fun, args, _loc}) when is_list(args) do
+    "#{inspect(mod)}.#{fun}/#{length(args)}"
+  end
+
+  defp format_frame(other), do: inspect(other)
+
+  # ── Push to Pyroscope ─────────────────────────────────────────────
+
+  @doc false
+  @spec render_folded(map()) :: iodata()
+  def render_folded(counters) do
+    counters
+    |> Enum.map(fn {stack, count} -> [stack, ?\s, Integer.to_string(count), ?\n] end)
+  end
+
+  defp do_push(_state, counters, _from, _until) when map_size(counters) == 0 do
+    # Empty window — nothing to push. Happens during startup before
+    # the first sample fires, or if every Process.list/0 frame was
+    # filtered (unlikely outside tests).
+    :ok
+  end
+
+  defp do_push(state, counters, from_ms, until_ms) do
+    body = render_folded(counters)
+    name_with_tags = "#{state.app_name}{#{state.tags}}"
+
+    query = [
+      {"name", name_with_tags},
+      {"from", to_seconds(from_ms)},
+      {"until", to_seconds(until_ms)},
+      {"format", "folded"},
+      {"spyName", state.spy_name},
+      {"sampleRate", state.sample_rate},
+      {"units", @default_units},
+      {"aggregationType", "sum"},
+      {"profileType", @profile_kind}
+    ]
+
+    url = state.url <> "/ingest"
+
+    case Req.post(url,
+           params: query,
+           body: IO.iodata_to_binary(body),
+           headers: [{"content-type", "text/plain"}],
+           auth: {:basic, "#{state.username}:#{state.token}"},
+           receive_timeout: 10_000,
+           retry: false
+         ) do
+      {:ok, %{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, %{status: status, body: resp_body}} ->
+        Logger.warning("pyroscope ingest rejected: status=#{status} body=#{inspect(resp_body)}")
+
+      {:error, reason} ->
+        Logger.warning("pyroscope ingest failed: #{inspect(reason)}")
+    end
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────
+
+  defp build_tags(cfg) do
+    base = [
+      {"service", "engram"},
+      {"env", to_string(Keyword.get(cfg, :env, "prod"))},
+      {"instance", Keyword.get(cfg, :instance, hostname())}
+    ]
+
+    Enum.map_join(base, ",", fn {k, v} -> ~s(#{k}="#{v}") end)
+  end
+
+  defp hostname do
+    case :inet.gethostname() do
+      {:ok, name} -> List.to_string(name)
+      _ -> "unknown"
+    end
+  end
+
+  defp schedule_both(state) do
+    %{
+      state
+      | sample_timer_ref: schedule_sample(state),
+        push_timer_ref: schedule_push(state)
+    }
+  end
+
+  defp schedule_sample(state),
+    do: Process.send_after(self(), :sample, state.sample_interval_ms)
+
+  defp schedule_push(state),
+    do: Process.send_after(self(), :push, state.push_interval_ms)
+
+  defp now_ms, do: System.system_time(:millisecond)
+
+  defp to_seconds(ms), do: div(ms, 1_000)
+end

--- a/lib/engram/observability/pyroscope.ex
+++ b/lib/engram/observability/pyroscope.ex
@@ -261,7 +261,7 @@ defmodule Engram.Observability.Pyroscope do
   # ── Push to Pyroscope ─────────────────────────────────────────────
 
   @doc false
-  @spec render_folded(map()) :: iodata()
+  @spec render_folded(map()) :: iolist()
   def render_folded(counters) do
     counters
     |> Enum.map(fn {stack, count} -> [stack, ?\s, Integer.to_string(count), ?\n] end)
@@ -326,7 +326,6 @@ defmodule Engram.Observability.Pyroscope do
   defp hostname do
     case :inet.gethostname() do
       {:ok, name} -> List.to_string(name)
-      _ -> "unknown"
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.372",
+      version: "0.5.373",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/observability/pyroscope_test.exs
+++ b/test/engram/observability/pyroscope_test.exs
@@ -1,0 +1,210 @@
+defmodule Engram.Observability.PyroscopeTest do
+  @moduledoc """
+  Function-of-env contract for the Pyroscope sampler:
+
+    1. `configured?/0` and `child_spec/1` are no-ops when any of the
+       three SOPS-wired env vars is unset — supervisor silently
+       drops the child.
+    2. Sampling produces collapsed-stack keys in the
+       "Mod.fun/arity;..." shape Pyroscope's `format=folded` ingest
+       expects (root → leaf, separated by `;`).
+    3. Periodic push hits `/ingest` with the right query params and
+       Basic auth header, and resets the counters.
+
+  We deliberately don't pin Pyroscope's exact response — Grafana
+  Cloud accepts 200/204 across releases — but we do pin the
+  structural invariants (URL path, format param, auth shape) since
+  those are what would silently drop our profiles if they regressed.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Engram.Observability.Pyroscope
+
+  setup do
+    prior = Application.get_env(:engram, :pyroscope)
+
+    on_exit(fn ->
+      if prior do
+        Application.put_env(:engram, :pyroscope, prior)
+      else
+        Application.delete_env(:engram, :pyroscope)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "configured?/0" do
+    test "false when :pyroscope config is unset" do
+      Application.delete_env(:engram, :pyroscope)
+      refute Pyroscope.configured?()
+    end
+
+    test "false when :url is missing" do
+      Application.put_env(:engram, :pyroscope, username: "u", token: "t")
+      refute Pyroscope.configured?()
+    end
+
+    test "false when :url is empty string" do
+      Application.put_env(:engram, :pyroscope, url: "", username: "u", token: "t")
+      refute Pyroscope.configured?()
+    end
+
+    test "true when url+username+token all present" do
+      Application.put_env(:engram, :pyroscope,
+        url: "https://pyroscope.example",
+        username: "1234",
+        token: "tok"
+      )
+
+      assert Pyroscope.configured?()
+    end
+  end
+
+  describe "child_spec/1" do
+    test "returns :ignore when not configured (no supervisor child added)" do
+      Application.delete_env(:engram, :pyroscope)
+      assert :ignore == Pyroscope.child_spec([])
+    end
+
+    test "returns a child spec map when configured" do
+      Application.put_env(:engram, :pyroscope,
+        url: "https://pyroscope.example",
+        username: "1234",
+        token: "tok"
+      )
+
+      assert %{id: Pyroscope, start: {Pyroscope, :start_link, [_]}} = Pyroscope.child_spec([])
+    end
+  end
+
+  describe "collapse/1" do
+    test "renders {mod, fun, arity, loc} frames root-first, separated by `;`" do
+      stack = [
+        # leaf (top of stack, deepest call)
+        {SomeMod, :inner, 2, [file: ~c"some.ex", line: 10]},
+        {SomeMod, :middle, 1, []},
+        # root (entry point)
+        {SomeMod, :root, 0, []}
+      ]
+
+      assert Pyroscope.collapse(stack) ==
+               "SomeMod.root/0;SomeMod.middle/1;SomeMod.inner/2"
+    end
+
+    test "renders {mod, fun, args, loc} frames by using length(args) as arity" do
+      stack = [{Mod, :f, [1, 2, 3], []}]
+      assert Pyroscope.collapse(stack) == "Mod.f/3"
+    end
+  end
+
+  describe "take_sample/1" do
+    test "increments the count for each collapsed stack seen this tick" do
+      # The real Process.list/0 sweep is hard to make deterministic in
+      # a unit test (any GenServer in the VM contributes a frame), so
+      # we just assert the invariant: counter values are non-negative
+      # integers and the keyset is non-empty when other processes exist.
+      counters = Pyroscope.take_sample(%{})
+      assert is_map(counters)
+      assert map_size(counters) > 0
+
+      Enum.each(counters, fn {k, v} ->
+        assert is_binary(k)
+        assert is_integer(v) and v >= 1
+      end)
+
+      # Running another tick on top of the first should never decrease
+      # any existing counter — it's monotonic until the next push.
+      counters2 = Pyroscope.take_sample(counters)
+      assert map_size(counters2) >= map_size(counters)
+    end
+
+    test "skips the calling process so the sampler can't dominate its own flame" do
+      # Drive a sample from a known pid. The collapsed stack for *that*
+      # pid will mention this test process and ExUnit framework code;
+      # it must NOT appear in the counters because we filter `self()`.
+      counters = Pyroscope.take_sample(%{})
+
+      # No counter key should contain the test module name in the leaf
+      # position (the test runner's current frame at sample time).
+      refute Enum.any?(counters, fn {k, _} ->
+               String.contains?(k, "PyroscopeTest")
+             end)
+    end
+  end
+
+  describe "render_folded/1" do
+    test "emits one line per stack as 'collapsed_stack <count>\\n'" do
+      out =
+        %{
+          "Mod.a/0;Mod.b/1" => 3,
+          "Mod.c/2" => 1
+        }
+        |> Pyroscope.render_folded()
+        |> IO.iodata_to_binary()
+
+      lines = out |> String.split("\n", trim: true) |> Enum.sort()
+
+      assert lines == ["Mod.a/0;Mod.b/1 3", "Mod.c/2 1"]
+    end
+
+    test "empty input emits empty output" do
+      assert IO.iodata_to_binary(Pyroscope.render_folded(%{})) == ""
+    end
+  end
+
+  describe "push lifecycle (integration)" do
+    test "after push_interval, POSTs to /ingest with the right params and resets counters" do
+      bypass = Bypass.open()
+
+      Application.put_env(:engram, :pyroscope,
+        url: "http://localhost:#{bypass.port}",
+        username: "user-1234",
+        token: "tok-abc",
+        app_name: "engram-test",
+        env: "test",
+        instance: "test-host",
+        # Tight intervals so the test finishes quickly. 5ms sampling
+        # × 50ms push = 10 samples per window.
+        sample_interval_ms: 5,
+        push_interval_ms: 50
+      )
+
+      parent = self()
+
+      Bypass.expect(bypass, "POST", "/ingest", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        send(parent, {:pyroscope_push, conn.query_string, conn.req_headers, body})
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      {:ok, pid} = Pyroscope.start_link([])
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid, :normal, 1_000) end)
+
+      assert_receive {:pyroscope_push, query, headers, body}, 2_000
+
+      assert query =~ "name=engram-test"
+      assert query =~ "format=folded"
+      assert query =~ "spyName=elixirspy"
+      # 1000ms / 5ms sample = 200Hz
+      assert query =~ "sampleRate=200"
+      assert query =~ ~r/from=\d+/
+      assert query =~ ~r/until=\d+/
+
+      # Basic auth: user-1234:tok-abc base64 = dXNlci0xMjM0OnRvay1hYmM=
+      auth = Enum.find_value(headers, fn {k, v} -> if k == "authorization", do: v end)
+      assert auth == "Basic dXNlci0xMjM0OnRvay1hYmM="
+
+      # Body is folded format: "stack count\n" lines.
+      assert is_binary(body)
+
+      if byte_size(body) > 0 do
+        first_line = body |> String.split("\n", trim: true) |> hd()
+        # Either ends with a space + digits, OR is a frame chain — both shapes valid.
+        assert first_line =~ ~r/ \d+$/
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Wires continuous BEAM CPU profiling for the prod backend → Grafana Cloud Pyroscope (`grafanacloud-profiles` datasource). Picks up `engram-app/engram-infra#347` on the code side.

- **New module:** `Engram.Observability.Pyroscope` — a small GenServer that samples every BEAM process's `:current_stacktrace` at 100Hz, collapses frames to Pyroscope's `folded` text format (`Module.fun/arity;...`), and POSTs the accumulated window to `${GRAFANA_PYROSCOPE_URL}/ingest` every 10s with Basic auth (`GRAFANA_PYROSCOPE_USERNAME:GRAFANA_AGENT_TOKEN`).
- **Wired in:** `lib/engram/application.ex` adds `pyroscope_child/0` to the supervision tree; `config/runtime.exs` reads the three env vars.
- **No new deps.** Uses `Req` which is already in the tree.

## Library decision (the "what's profiled" + "config knobs" the prompt asks for)

**Picked: custom periodic sampler talking to Pyroscope's HTTP `/ingest` API directly.**

There is no maintained Hex package in 2026:
- `hauleth/pyroscope_otp`, `hauleth/erlang-pyroscope`: no commits in years; predate the current ingest API.
- `Stratus3D/eflambe` (last push 2025-09-27): BEAM-aware, but built for ad-hoc profiling — wrapping it for continuous push means tearing down/restoring `:erlang.trace_pattern` every push interval.
- Grafana ships official agents for Go/Java/Python/Ruby/.NET/Node/Rust + eBPF, but **no BEAM-native client**.

The Pyroscope `/ingest` API is stable and dead-simple (URL params + Basic auth + a folded-stack body). A ~250-line GenServer is cheaper to maintain than rebasing onto a stale third-party NIF.

### What's profiled

| Profile | v1? | Notes |
|---------|-----|-------|
| Wall-clock CPU | yes | `Process.info(pid, :current_stacktrace)` swept across `Process.list/0`. Captures all schedulable processes regardless of whether they're running on a scheduler or parked in a receive — Pyroscope flame widths read as wall-clock proportions. |
| Off-CPU | deferred | Needs a separate sampler that filters by scheduler state. Track as a follow-up. |
| Memory / heap | deferred | Needs `process_info(:memory)` diff series + `name=engram-saas-prod.memory`. Track as a follow-up. |

### Config knobs

All optional, sensible defaults baked in:

| Setting | Default | Source |
|---|---|---|
| `:sample_interval_ms` | 10ms (= 100Hz) | `config :engram, :pyroscope` |
| `:push_interval_ms` | 10_000ms (10s window) | `config :engram, :pyroscope` |
| `:app_name` | `engram-saas-prod` | env `PYROSCOPE_APP_NAME` |
| `:env` | `to_string(config_env())` | runtime.exs |
| `:instance` | `${HOSTNAME}`, then `${ECS_TASK_ID}`, then `unknown` | env |
| `:spy_name` | `elixirspy` | hardcoded |

Tags pushed: `service=engram, env=prod, instance=<host>`. **No per-tenant tags** — profile-store cardinality kills both UX and Grafana Cloud billing.

## Safety / opt-in

Mirrors the Sentry + PostHog shape. `configured?/0` is false when any of the three env vars is missing; `Engram.Application.pyroscope_child/0` returns `nil` in that case and the supervisor's `Enum.reject(&is_nil/1)` drops it before start. So dev / test / self-host:
- emit no profiling traffic,
- don't fail boot,
- and don't need any config changes.

## Deferred / follow-up

- **Off-CPU and memory profile series** (separate `name=engram-saas-prod.{offcpu,memory}` series). Not blocking the issue's "done when" — CPU flames alone identify hotspots within 5 min of opening Explore.
- **Spot-check runbook** (the issue's third "done when"): once profiles are landing in `grafanacloud-profiles`, write a short `docs/context/pyroscope-spot-check.md` that documents the 30-sec flow (Explore → Profiles → service filter → diff against previous deploy). Track as `engram-app/engram-infra` follow-up; not gated by this PR since the data has to be live first.
- **No infra-side change required.** The three env vars (`GRAFANA_PYROSCOPE_URL`, `GRAFANA_PYROSCOPE_USERNAME`, `GRAFANA_AGENT_TOKEN`) are already wired through `engram-infra/main/envs/prod/ecs_secrets.tf` (lines 133-135) from SOPS. If the agent shows authn failures in prod, the token's Grafana Cloud access policy may need a `profiles:write` scope added — that's a SOPS-only change with no Terraform diff.

## Test plan

- [x] `mix test test/engram/observability/pyroscope_test.exs` — 13 tests passing locally (collapse format, configured? gating, child_spec :ignore vs map, periodic push hitting Bypass with right query + auth, counters reset after push).
- [x] `mix test test/engram/observability/` — 27 tests passing (no regressions in adjacent modules).
- [x] `mix credo --strict lib/engram/observability/pyroscope.ex lib/engram/application.ex` — clean.
- [x] `mix format --check-formatted` — clean.
- [ ] After deploy: confirm `engram-saas-prod` series appears in Grafana → Explore → Profiles within ~30s. If 401/403, check `GRAFANA_AGENT_TOKEN` has profiles:write.

Refs: `engram-app/engram-infra#347`