### PR TITLE
feat(promex): custom subscribers for Voyage / Qdrant / sync / search / MCP (engram-infra#340)

### DIFF
--- a/lib/engram/embedders/voyage.ex
+++ b/lib/engram/embedders/voyage.ex
@@ -57,7 +57,10 @@ defmodule Engram.Embedders.Voyage do
 
   defp status_label({:ok, _}), do: :ok
   defp status_label({:error, {429, %{"detail" => "client_rate_limited"}}}), do: :throttled
-  defp status_label({:error, {status, _}}) when is_integer(status) and status >= 500, do: :server_error
+
+  defp status_label({:error, {status, _}}) when is_integer(status) and status >= 500,
+    do: :server_error
+
   defp status_label({:error, {status, _}}) when is_integer(status), do: :client_error
   defp status_label({:error, _}), do: :error
 

--- a/lib/engram/embedders/voyage.ex
+++ b/lib/engram/embedders/voyage.ex
@@ -34,10 +34,32 @@ defmodule Engram.Embedders.Voyage do
 
   @impl true
   def embed_texts(texts, opts) when is_list(texts) do
-    with :ok <- throttle_check(opts) do
-      do_embed_texts(texts, opts)
-    end
+    purpose = Keyword.get(opts, :purpose, :index)
+
+    # Span tracks every request reaching the network OR fast-failing the
+    # client-side throttle. The synthetic-429 path emits its own
+    # `[:engram, :embed, :client_rate_limited]` counter (handled by the
+    # PromEx Voyage plugin); here we still flag it `status: :throttled` so
+    # the Voyage `embed_total` rate isn't dragged down by silent drops.
+    :telemetry.span(
+      [:engram, :voyage, :embed],
+      %{purpose: purpose, text_count: length(texts)},
+      fn ->
+        result =
+          with :ok <- throttle_check(opts) do
+            do_embed_texts(texts, opts)
+          end
+
+        {result, %{purpose: purpose, status: status_label(result)}}
+      end
+    )
   end
+
+  defp status_label({:ok, _}), do: :ok
+  defp status_label({:error, {429, %{"detail" => "client_rate_limited"}}}), do: :throttled
+  defp status_label({:error, {status, _}}) when is_integer(status) and status >= 500, do: :server_error
+  defp status_label({:error, {status, _}}) when is_integer(status), do: :client_error
+  defp status_label({:error, _}), do: :error
 
   defp do_embed_texts(texts, opts) do
     url = Application.get_env(:engram, :voyage_url, @default_url)

--- a/lib/engram/prom_ex.ex
+++ b/lib/engram/prom_ex.ex
@@ -19,7 +19,14 @@ defmodule Engram.PromEx do
       Plugins.Beam,
       {Plugins.Phoenix, router: EngramWeb.Router, endpoint: EngramWeb.Endpoint},
       Plugins.Ecto,
-      Plugins.Oban
+      Plugins.Oban,
+      # engram-app/engram-infra#340 — custom subscribers for in-house
+      # telemetry events that the bundled plugins don't cover.
+      Engram.PromEx.Voyage,
+      Engram.PromEx.Qdrant,
+      Engram.PromEx.Sync,
+      Engram.PromEx.Search,
+      Engram.PromEx.Mcp
     ]
   end
 

--- a/lib/engram/prom_ex/mcp.ex
+++ b/lib/engram/prom_ex/mcp.ex
@@ -1,0 +1,67 @@
+defmodule Engram.PromEx.Mcp do
+  @moduledoc """
+  PromEx plugin for the MCP layer (`EngramWeb.McpController`).
+
+  Subscribes to:
+
+    * `[:engram, :mcp, :tool, :stop]` — `%{duration: native,
+      result_bytes: integer}`, metadata `%{tool: atom, status: :ok |
+      :error}`.
+
+  Metrics:
+
+    * `engram_prom_ex_mcp_tool_duration_milliseconds` — distribution
+      tagged by `:tool` + `:status`.
+    * `engram_prom_ex_mcp_tool_total` — counter for per-tool error rate.
+    * `engram_prom_ex_mcp_tool_result_bytes` — distribution measuring
+      response payload size; useful for capacity planning (LLM context
+      consumption).
+
+  Cardinality contract: `:tool` is a closed-set atom (~16 tools, see
+  `Engram.MCP.Tools.list/0`). `:status` is `:ok | :error`. NEVER add
+  user_id or args.
+  """
+
+  use PromEx.Plugin
+
+  @stop_event [:engram, :mcp, :tool, :stop]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :mcp)
+
+    Event.build(
+      :engram_mcp_event_metrics,
+      [
+        distribution(
+          metric_prefix ++ [:tool, :duration, :milliseconds],
+          event_name: @stop_event,
+          measurement: :duration,
+          description: "MCP tool dispatch latency by tool.",
+          reporter_options: [
+            buckets: [5, 10, 25, 50, 100, 250, 500, 1_000, 5_000]
+          ],
+          tags: [:tool, :status],
+          unit: {:native, :millisecond}
+        ),
+        counter(
+          metric_prefix ++ [:tool, :total],
+          event_name: @stop_event,
+          description: "MCP tool calls by tool + status.",
+          tags: [:tool, :status]
+        ),
+        distribution(
+          metric_prefix ++ [:tool, :result_bytes],
+          event_name: @stop_event,
+          measurement: :result_bytes,
+          description: "MCP tool result payload size in bytes (LLM context cost).",
+          reporter_options: [
+            buckets: [64, 256, 1_024, 4_096, 16_384, 65_536, 262_144]
+          ],
+          tags: [:tool]
+        )
+      ]
+    )
+  end
+end

--- a/lib/engram/prom_ex/qdrant.ex
+++ b/lib/engram/prom_ex/qdrant.ex
@@ -1,0 +1,56 @@
+defmodule Engram.PromEx.Qdrant do
+  @moduledoc """
+  PromEx plugin for the Qdrant HTTP client (`Engram.Vector.Qdrant`).
+
+  Subscribes to telemetry events emitted by the Qdrant adapter:
+
+    * `[:engram, :qdrant, :request, :start]`
+    * `[:engram, :qdrant, :request, :stop]` — `%{duration: native}`,
+      metadata `%{op: atom, status: :ok | :error}` where `op` is one of
+      `:search | :upsert | :delete | :scroll | :ensure_collection | :set_payload | :collection_info`.
+
+  Metrics:
+
+    * `engram_prom_ex_qdrant_request_duration_milliseconds` — distribution
+      tagged by `:op` + `:status`. Buckets tuned to Qdrant local + Cloud
+      latency (~5-100ms typical, fall-back up to 5s).
+    * `engram_prom_ex_qdrant_request_total` — counter for ops/sec by op +
+      status (error-rate derivable).
+
+  Cardinality contract: only `:op` (closed enum) + `:status`. NEVER add
+  user_id, vault_id, point ids, or collection names.
+  """
+
+  use PromEx.Plugin
+
+  @stop_event [:engram, :qdrant, :request, :stop]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :qdrant)
+
+    Event.build(
+      :engram_qdrant_event_metrics,
+      [
+        distribution(
+          metric_prefix ++ [:request, :duration, :milliseconds],
+          event_name: @stop_event,
+          measurement: :duration,
+          description: "Qdrant HTTP request latency by operation.",
+          reporter_options: [
+            buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000]
+          ],
+          tags: [:op, :status],
+          unit: {:native, :millisecond}
+        ),
+        counter(
+          metric_prefix ++ [:request, :total],
+          event_name: @stop_event,
+          description: "Qdrant requests by operation + status.",
+          tags: [:op, :status]
+        )
+      ]
+    )
+  end
+end

--- a/lib/engram/prom_ex/search.ex
+++ b/lib/engram/prom_ex/search.ex
@@ -1,0 +1,71 @@
+defmodule Engram.PromEx.Search do
+  @moduledoc """
+  PromEx plugin for the search pipeline (`Engram.Search.search/4`).
+
+  Subscribes to:
+
+    * `[:engram, :search, :request, :stop]` — `%{duration: native,
+      result_count: integer}`, metadata `%{status: :ok | :error,
+      cross_vault: boolean, rerank: :on | :off}`.
+    * `[:engram, :search, :decrypt_failed]` — already registered as a
+      Telemetry.Metrics counter in `EngramWeb.Telemetry`; mirroring it
+      here so the metric also lands in the PromEx registry without
+      double-emitting (telemetry_metrics is fan-out safe — same event
+      can drive multiple registries).
+
+  Metrics:
+
+    * `engram_prom_ex_search_request_duration_milliseconds`
+    * `engram_prom_ex_search_request_total` — tags `[:status,
+      :cross_vault, :rerank]`.
+    * `engram_prom_ex_search_results_returned` — distribution on the
+      `result_count` measurement so the cardinality of returned results
+      is observable.
+
+  Cardinality contract: only the booleans/atoms above. NEVER add
+  user_id, vault_id, or the query string.
+  """
+
+  use PromEx.Plugin
+
+  @stop_event [:engram, :search, :request, :stop]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :search)
+
+    Event.build(
+      :engram_search_event_metrics,
+      [
+        distribution(
+          metric_prefix ++ [:request, :duration, :milliseconds],
+          event_name: @stop_event,
+          measurement: :duration,
+          description: "End-to-end search request latency (embed + Qdrant + rerank).",
+          reporter_options: [
+            buckets: [10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000]
+          ],
+          tags: [:status, :cross_vault, :rerank],
+          unit: {:native, :millisecond}
+        ),
+        counter(
+          metric_prefix ++ [:request, :total],
+          event_name: @stop_event,
+          description: "Search requests by status, cross-vault, rerank.",
+          tags: [:status, :cross_vault, :rerank]
+        ),
+        distribution(
+          metric_prefix ++ [:results, :returned],
+          event_name: @stop_event,
+          measurement: :result_count,
+          description: "Number of search results returned per request.",
+          reporter_options: [
+            buckets: [0, 1, 5, 10, 25, 50]
+          ],
+          tags: [:status]
+        )
+      ]
+    )
+  end
+end

--- a/lib/engram/prom_ex/sync.ex
+++ b/lib/engram/prom_ex/sync.ex
@@ -1,0 +1,54 @@
+defmodule Engram.PromEx.Sync do
+  @moduledoc """
+  PromEx plugin for the SyncEngine fan-out path (`EngramWeb.SyncChannel`).
+
+  Subscribes to telemetry events emitted by the channel handlers:
+
+    * `[:engram, :sync, :event, :stop]` — `%{duration: native}`, metadata
+      `%{op: :push_note | :pull_changes | :delete_note | :rename_note,
+         status: :ok | :error}`.
+
+  Metrics:
+
+    * `engram_prom_ex_sync_event_duration_milliseconds` — distribution
+      tagged by `:op` + `:status`.
+    * `engram_prom_ex_sync_event_total` — counter per op + status; the
+      pull-vs-push ratio + error rate are derivable.
+
+  Cardinality contract: bounded `:op` enum + `:status`. NEVER add
+  user_id, vault_id, device_id, or path.
+  """
+
+  use PromEx.Plugin
+
+  @stop_event [:engram, :sync, :event, :stop]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :sync)
+
+    Event.build(
+      :engram_sync_event_metrics,
+      [
+        distribution(
+          metric_prefix ++ [:event, :duration, :milliseconds],
+          event_name: @stop_event,
+          measurement: :duration,
+          description: "SyncChannel handler latency by operation.",
+          reporter_options: [
+            buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000]
+          ],
+          tags: [:op, :status],
+          unit: {:native, :millisecond}
+        ),
+        counter(
+          metric_prefix ++ [:event, :total],
+          event_name: @stop_event,
+          description: "SyncChannel events by operation + status.",
+          tags: [:op, :status]
+        )
+      ]
+    )
+  end
+end

--- a/lib/engram/prom_ex/voyage.ex
+++ b/lib/engram/prom_ex/voyage.ex
@@ -1,0 +1,68 @@
+defmodule Engram.PromEx.Voyage do
+  @moduledoc """
+  PromEx plugin for the Voyage AI embedding client (`Engram.Embedders.Voyage`).
+
+  Subscribes to telemetry events emitted by the Voyage adapter:
+
+    * `[:engram, :voyage, :embed, :start]`
+    * `[:engram, :voyage, :embed, :stop]` — `%{duration: native}`, metadata
+      `%{status: :ok | :error, purpose: :index | :query}`
+
+  Metrics:
+
+    * `engram_prom_ex_voyage_embed_duration_milliseconds` — distribution,
+      tags `[:status, :purpose]`. Buckets tuned to observed Voyage latency
+      (~100ms-3s).
+    * `engram_prom_ex_voyage_embed_total` — counter (one per request); the
+      `:status` tag lets `rate({status="error"}) / rate(*)` derive the
+      error rate.
+    * `engram_prom_ex_voyage_client_rate_limited_total` — counter for the
+      synthetic-429 path (`[:engram, :embed, :client_rate_limited]`,
+      already emitted by the adapter), tagged by `:purpose`.
+
+  Cardinality contract: only bounded labels (`status`, `purpose`). NEVER
+  add `user_id`, `vault_id`, model strings, or any per-tenant identifier
+  — Voyage RPS × user count would explode the time series.
+  """
+
+  use PromEx.Plugin
+
+  @embed_stop_event [:engram, :voyage, :embed, :stop]
+  @client_rate_limited_event [:engram, :embed, :client_rate_limited]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :voyage)
+
+    Event.build(
+      :engram_voyage_event_metrics,
+      [
+        distribution(
+          metric_prefix ++ [:embed, :duration, :milliseconds],
+          event_name: @embed_stop_event,
+          measurement: :duration,
+          description: "Voyage embedding request latency.",
+          reporter_options: [
+            buckets: [50, 100, 250, 500, 1_000, 2_000, 3_000, 5_000, 10_000]
+          ],
+          tags: [:status, :purpose],
+          unit: {:native, :millisecond}
+        ),
+        counter(
+          metric_prefix ++ [:embed, :total],
+          event_name: @embed_stop_event,
+          description: "Voyage embedding requests by status + purpose.",
+          tags: [:status, :purpose]
+        ),
+        counter(
+          metric_prefix ++ [:client_rate_limited, :total],
+          event_name: @client_rate_limited_event,
+          description:
+            "Synthetic 429s from the local Hammer throttle — purpose-tagged for tuning :voyage_rpm vs :voyage_query_rpm.",
+          tags: [:purpose]
+        )
+      ]
+    )
+  end
+end

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -57,6 +57,21 @@ defmodule Engram.Search do
     cross_vault = Keyword.get(opts, :cross_vault, false)
     started_at = System.monotonic_time(:millisecond)
 
+    # engram-app/engram-infra#340 — emit
+    # [:engram, :search, :request, :start/:stop] for the PromEx Search plugin.
+    # Hand-rolled (not `:telemetry.span/3`) so result_count is a measurement
+    # — `:telemetry.span` only allows extra metadata, not measurements.
+    # Cardinality contract: no user_id, vault_id, or query string.
+    rerank = rerank_label(user)
+    start_mono = System.monotonic_time()
+    start_meta = %{cross_vault: cross_vault, rerank: rerank}
+
+    :telemetry.execute(
+      [:engram, :search, :request, :start],
+      %{system_time: System.system_time(), monotonic_time: start_mono},
+      start_meta
+    )
+
     result =
       if cross_vault do
         case Engram.Billing.check_feature(user, :cross_vault_search) do
@@ -68,7 +83,34 @@ defmodule Engram.Search do
       end
 
     emit_search_performed(user, result, started_at, cross_vault)
+
+    :telemetry.execute(
+      [:engram, :search, :request, :stop],
+      %{
+        duration: System.monotonic_time() - start_mono,
+        result_count: result_count(result)
+      },
+      %{
+        status: search_status(result),
+        cross_vault: cross_vault,
+        rerank: rerank
+      }
+    )
+
     result
+  end
+
+  defp search_status({:ok, _}), do: :ok
+  defp search_status({:error, _}), do: :error
+
+  defp result_count({:ok, results}) when is_list(results), do: length(results)
+  defp result_count(_), do: 0
+
+  defp rerank_label(user) do
+    case Engram.Billing.check_feature(user, :reranker_enabled) do
+      :ok -> if reranker_active?(), do: :on, else: :off
+      {:error, _} -> :off
+    end
   end
 
   defp emit_search_performed(user, {:ok, results}, started_at, cross_vault)

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -20,6 +20,22 @@ defmodule Engram.Vector.Qdrant do
   defp binary_quantization_enabled?,
     do: Application.get_env(:engram, :qdrant_binary_quantization, true)
 
+  # Wrap an HTTP call in a `:telemetry.span` so the PromEx Qdrant plugin
+  # (engram-app/engram-infra#340) sees per-op latency + status. `op` is
+  # a bounded atom (`:search`, `:upsert`, etc.); status is derived from
+  # the result tuple. NEVER include collection name, point ids, or
+  # user/vault context — cardinality contract.
+  defp instrument(op, fun) when is_atom(op) and is_function(fun, 0) do
+    :telemetry.span([:engram, :qdrant, :request], %{op: op}, fn ->
+      result = fun.()
+      {result, %{op: op, status: qdrant_status(result)}}
+    end)
+  end
+
+  defp qdrant_status(:ok), do: :ok
+  defp qdrant_status({:ok, _}), do: :ok
+  defp qdrant_status({:error, _}), do: :error
+
   defp req_opts do
     {retry, max_retries} =
       case Application.get_env(:engram, :qdrant_retry, :transient) do
@@ -63,11 +79,13 @@ defmodule Engram.Vector.Qdrant do
 
     opts = [json: body] ++ req_opts()
 
-    case Req.put("#{base_url()}/collections/#{col}", opts) do
-      {:ok, %{status: status}} when status in [200, 201, 409] -> :ok
-      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
-      {:error, reason} -> {:error, reason}
-    end
+    instrument(:ensure_collection, fn ->
+      case Req.put("#{base_url()}/collections/#{col}", opts) do
+        {:ok, %{status: status}} when status in [200, 201, 409] -> :ok
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -76,11 +94,13 @@ defmodule Engram.Vector.Qdrant do
   def delete_collection(col) do
     opts = req_opts()
 
-    case Req.delete("#{base_url()}/collections/#{col}", opts) do
-      {:ok, %{status: status}} when status in [200, 404] -> :ok
-      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
-      {:error, reason} -> {:error, reason}
-    end
+    instrument(:delete_collection, fn ->
+      case Req.delete("#{base_url()}/collections/#{col}", opts) do
+        {:ok, %{status: status}} when status in [200, 404] -> :ok
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -90,11 +110,13 @@ defmodule Engram.Vector.Qdrant do
   def collection_info(col) do
     opts = req_opts()
 
-    case Req.get("#{base_url()}/collections/#{col}", opts) do
-      {:ok, %{status: 200, body: %{"result" => result}}} -> {:ok, result}
-      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
-      {:error, reason} -> {:error, reason}
-    end
+    instrument(:collection_info, fn ->
+      case Req.get("#{base_url()}/collections/#{col}", opts) do
+        {:ok, %{status: 200, body: %{"result" => result}}} -> {:ok, result}
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -106,11 +128,13 @@ defmodule Engram.Vector.Qdrant do
     serialized = Enum.map(points, fn p -> %{id: p.id, vector: p.vector, payload: p.payload} end)
     opts = [json: %{points: serialized}] ++ req_opts()
 
-    case Req.put("#{base_url()}/collections/#{col}/points", opts) do
-      {:ok, %{status: 200}} -> :ok
-      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
-      {:error, reason} -> {:error, reason}
-    end
+    instrument(:upsert, fn ->
+      case Req.put("#{base_url()}/collections/#{col}/points", opts) do
+        {:ok, %{status: 200}} -> :ok
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -125,11 +149,13 @@ defmodule Engram.Vector.Qdrant do
     col = col || collection()
     opts = [json: %{points: point_ids, payload: payload}] ++ req_opts()
 
-    case Req.post("#{base_url()}/collections/#{col}/points/payload", opts) do
-      {:ok, %{status: 200}} -> :ok
-      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
-      {:error, reason} -> {:error, reason}
-    end
+    instrument(:set_payload, fn ->
+      case Req.post("#{base_url()}/collections/#{col}/points/payload", opts) do
+        {:ok, %{status: 200}} -> :ok
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -152,11 +178,13 @@ defmodule Engram.Vector.Qdrant do
 
     opts = [json: %{filter: filter}] ++ req_opts()
 
-    case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
-      {:ok, %{status: 200}} -> :ok
-      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
-      {:error, reason} -> {:error, reason}
-    end
+    instrument(:delete, fn ->
+      case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
+        {:ok, %{status: 200}} -> :ok
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -170,11 +198,13 @@ defmodule Engram.Vector.Qdrant do
     filter = %{must: [%{key: "user_id", match: %{value: user_id}}]}
     opts = [json: %{filter: filter}] ++ req_opts()
 
-    case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
-      {:ok, %{status: 200}} -> :ok
-      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
-      {:error, reason} -> {:error, reason}
-    end
+    instrument(:delete, fn ->
+      case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
+        {:ok, %{status: 200}} -> :ok
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -192,11 +222,13 @@ defmodule Engram.Vector.Qdrant do
 
     opts = [json: %{filter: filter}] ++ req_opts()
 
-    case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
-      {:ok, %{status: 200}} -> :ok
-      {:ok, %{status: status, body: body}} -> {:error, {status, body}}
-      {:error, reason} -> {:error, reason}
-    end
+    instrument(:delete, fn ->
+      case Req.post("#{base_url()}/collections/#{col}/points/delete", opts) do
+        {:ok, %{status: 200}} -> :ok
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -230,20 +262,22 @@ defmodule Engram.Vector.Qdrant do
         offset -> Map.put(body, :offset, offset)
       end
 
-    case Req.post(url, [json: body] ++ req_opts()) do
-      {:ok,
-       %Req.Response{
-         status: 200,
-         body: %{"result" => %{"points" => points, "next_page_offset" => next}}
-       }} ->
-        {:ok, %{points: points, next_page_offset: next}}
+    instrument(:scroll, fn ->
+      case Req.post(url, [json: body] ++ req_opts()) do
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"result" => %{"points" => points, "next_page_offset" => next}}
+         }} ->
+          {:ok, %{points: points, next_page_offset: next}}
 
-      {:ok, %Req.Response{status: status, body: body}} ->
-        {:error, {:qdrant_scroll, status, body}}
+        {:ok, %Req.Response{status: status, body: body}} ->
+          {:error, {:qdrant_scroll, status, body}}
 
-      {:error, reason} ->
-        {:error, reason}
-    end
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end)
   end
 
   @doc """
@@ -295,6 +329,12 @@ defmodule Engram.Vector.Qdrant do
 
     opts = [json: body] ++ req_opts()
 
+    instrument(:search, fn ->
+      do_search(col, opts)
+    end)
+  end
+
+  defp do_search(col, opts) do
     case Req.post("#{base_url()}/collections/#{col}/points/query", opts) do
       {:ok, %{status: 200, body: %{"result" => result}}} ->
         points = if is_list(result), do: result, else: result["points"] || []

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -97,6 +97,47 @@ defmodule EngramWeb.SyncChannel do
 
   @impl true
   def handle_in("push_note", params, socket) do
+    span_sync(:push_note, fn -> do_push_note(params, socket) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # delete_note
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def handle_in("delete_note", %{"path" => path}, socket) do
+    span_sync(:delete_note, fn -> do_delete_note(path, socket) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # rename_note
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def handle_in("rename_note", %{"old_path" => old_path, "new_path" => new_path}, socket) do
+    span_sync(:rename_note, fn -> do_rename_note(old_path, new_path, socket) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # pull_changes
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def handle_in("pull_changes", %{"since" => since_str}, socket) do
+    span_sync(:pull_changes, fn -> do_pull_changes(since_str, socket) end)
+  end
+
+  def handle_in("pull_changes", _params, socket) do
+    # T3.7 — missing `since` key; no need to gate (no DEK access before param parse).
+    # The since-required check is purely structural validation — not a DEK write path.
+    {:reply, {:error, %{"reason" => "since is required"}}, socket}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Per-op implementations
+  # ---------------------------------------------------------------------------
+
+  defp do_push_note(params, socket) do
     # T3.7 — re-read the lock state; socket.assigns.current_user is a stale
     # snapshot from connect/3 and will not reflect a lock acquired after join.
     case RotationGate.check(socket.assigns.current_user.id) do
@@ -131,12 +172,7 @@ defmodule EngramWeb.SyncChannel do
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # delete_note
-  # ---------------------------------------------------------------------------
-
-  @impl true
-  def handle_in("delete_note", %{"path" => path}, socket) do
+  defp do_delete_note(path, socket) do
     # T3.7 — re-read the lock state; stale snapshot from connect/3.
     case RotationGate.check(socket.assigns.current_user.id) do
       {:error, :rotation_in_progress} ->
@@ -160,12 +196,7 @@ defmodule EngramWeb.SyncChannel do
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # rename_note
-  # ---------------------------------------------------------------------------
-
-  @impl true
-  def handle_in("rename_note", %{"old_path" => old_path, "new_path" => new_path}, socket) do
+  defp do_rename_note(old_path, new_path, socket) do
     # T3.7 — re-read the lock state; stale snapshot from connect/3.
     case RotationGate.check(socket.assigns.current_user.id) do
       {:error, :rotation_in_progress} ->
@@ -194,12 +225,7 @@ defmodule EngramWeb.SyncChannel do
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # pull_changes
-  # ---------------------------------------------------------------------------
-
-  @impl true
-  def handle_in("pull_changes", %{"since" => since_str}, socket) do
+  defp do_pull_changes(since_str, socket) do
     # T3.7 — re-read the lock state; stale snapshot from connect/3. Reads are
     # also blocked: between a sweep batch writing dek_version=new and final_flip
     # invalidating the DekCache, the old DEK in cache cannot decrypt the new
@@ -252,11 +278,24 @@ defmodule EngramWeb.SyncChannel do
     end
   end
 
-  def handle_in("pull_changes", _params, socket) do
-    # T3.7 — missing `since` key; no need to gate (no DEK access before param parse).
-    # The since-required check is purely structural validation — not a DEK write path.
-    {:reply, {:error, %{"reason" => "since is required"}}, socket}
+  # ---------------------------------------------------------------------------
+  # Telemetry helpers — engram-app/engram-infra#340
+  # ---------------------------------------------------------------------------
+
+  # Wrap a sync handler in `:telemetry.span` so the PromEx Sync subscriber
+  # sees per-op latency + status. Status is derived from the `{:reply,
+  # {:ok | :error, _}, _}` Phoenix Channel reply tuple. NEVER include
+  # user_id/vault_id/path in metadata — cardinality contract.
+  defp span_sync(op, fun) when is_atom(op) and is_function(fun, 0) do
+    :telemetry.span([:engram, :sync, :event], %{op: op}, fn ->
+      reply = fun.()
+      {reply, %{op: op, status: sync_status(reply)}}
+    end)
   end
+
+  defp sync_status({:reply, {:ok, _}, _}), do: :ok
+  defp sync_status({:reply, {:error, _}, _}), do: :error
+  defp sync_status(_), do: :ok
 
   # ---------------------------------------------------------------------------
   # Private helpers

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -151,7 +151,10 @@ defmodule EngramWeb.McpController do
         {result, :ok, byte_size_safe(text)}
 
       {:error, msg} ->
-        result = {:ok, %{"content" => [%{"type" => "text", "text" => "Error: #{msg}"}], "isError" => true}}
+        result =
+          {:ok,
+           %{"content" => [%{"type" => "text", "text" => "Error: #{msg}"}], "isError" => true}}
+
         {result, :error, byte_size_safe(msg)}
     end
   catch

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -13,6 +13,30 @@ defmodule EngramWeb.McpController do
   @capabilities %{"tools" => %{"listChanged" => false}}
   @protocol_version "2025-03-26"
 
+  # engram-app/engram-infra#340 — closed-set map from tool name strings to
+  # atoms, used as the cardinality-bounded `:tool` tag on MCP PromEx
+  # metrics. Keeps `String.to_atom/1` (atom-table pollution) out of the
+  # hot path while keeping the tag stable.
+  @tool_atoms %{
+    "list_vaults" => :list_vaults,
+    "set_vault" => :set_vault,
+    "search_notes" => :search_notes,
+    "list_tags" => :list_tags,
+    "list_folders" => :list_folders,
+    "list_folder" => :list_folder,
+    "create_folder" => :create_folder,
+    "suggest_folder" => :suggest_folder,
+    "get_note" => :get_note,
+    "create_note" => :create_note,
+    "write_note" => :write_note,
+    "append_to_note" => :append_to_note,
+    "patch_note" => :patch_note,
+    "update_section" => :update_section,
+    "rename_note" => :rename_note,
+    "rename_folder" => :rename_folder,
+    "delete_note" => :delete_note
+  }
+
   def handle(conn, %{"jsonrpc" => "2.0", "id" => id, "method" => method} = params) do
     result = dispatch(conn, method, params["params"] || %{})
     send_jsonrpc(conn, id, result)
@@ -96,12 +120,39 @@ defmodule EngramWeb.McpController do
   end
 
   defp call_tool(tool, user, vault, args) do
+    # engram-app/engram-infra#340 — span emits
+    # [:engram, :mcp, :tool, :stop] for the PromEx Mcp plugin.
+    # Cardinality contract: only `:tool` (bounded enum from
+    # `Engram.MCP.Tools.list/0`, ~16 tools) + `:status`.
+    tool_atom = Map.get(@tool_atoms, tool.name, :unknown)
+    start_mono = System.monotonic_time()
+
+    :telemetry.execute(
+      [:engram, :mcp, :tool, :start],
+      %{system_time: System.system_time(), monotonic_time: start_mono},
+      %{tool: tool_atom}
+    )
+
+    {result, status, result_bytes} = run_tool_handler(tool, user, vault, args)
+
+    :telemetry.execute(
+      [:engram, :mcp, :tool, :stop],
+      %{duration: System.monotonic_time() - start_mono, result_bytes: result_bytes},
+      %{tool: tool_atom, status: status}
+    )
+
+    result
+  end
+
+  defp run_tool_handler(tool, user, vault, args) do
     case tool.handler.(user, vault, args) do
       {:ok, text} ->
-        {:ok, %{"content" => [%{"type" => "text", "text" => text}], "isError" => false}}
+        result = {:ok, %{"content" => [%{"type" => "text", "text" => text}], "isError" => false}}
+        {result, :ok, byte_size_safe(text)}
 
       {:error, msg} ->
-        {:ok, %{"content" => [%{"type" => "text", "text" => "Error: #{msg}"}], "isError" => true}}
+        result = {:ok, %{"content" => [%{"type" => "text", "text" => "Error: #{msg}"}], "isError" => true}}
+        {result, :error, byte_size_safe(msg)}
     end
   catch
     kind, reason ->
@@ -124,12 +175,18 @@ defmodule EngramWeb.McpController do
           :throw -> "Unexpected throw"
         end
 
-      {:ok,
-       %{
-         "content" => [%{"type" => "text", "text" => "Error: #{message}"}],
-         "isError" => true
-       }}
+      result =
+        {:ok,
+         %{
+           "content" => [%{"type" => "text", "text" => "Error: #{message}"}],
+           "isError" => true
+         }}
+
+      {result, :error, byte_size_safe(message)}
   end
+
+  defp byte_size_safe(s) when is_binary(s), do: byte_size(s)
+  defp byte_size_safe(_), do: 0
 
   defp classify_throw_reason(reason) when is_atom(reason), do: reason
   defp classify_throw_reason(%{__exception__: true} = e), do: e.__struct__

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.373",
+      version: "0.5.374",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/prom_ex/mcp_test.exs
+++ b/test/engram/prom_ex/mcp_test.exs
@@ -21,14 +21,23 @@ defmodule Engram.PromEx.McpTest do
     end
 
     test "declares distribution + counter on [:engram, :mcp, :tool, :stop]" do
-      metrics = McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       target = [:engram, :mcp, :tool, :stop]
-      assert Enum.any?(metrics, fn m -> match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target end)
-      assert Enum.any?(metrics, fn m -> match?(%Telemetry.Metrics.Counter{}, m) and m.event_name == target end)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target
+             end)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Counter{}, m) and m.event_name == target
+             end)
     end
 
     test "declares a result_bytes distribution" do
-      metrics = McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
 
       assert Enum.any?(metrics, fn m ->
                match?(%Telemetry.Metrics.Distribution{}, m) and m.measurement == :result_bytes
@@ -36,7 +45,9 @@ defmodule Engram.PromEx.McpTest do
     end
 
     test "no per-tenant tags" do
-      metrics = McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       banned = [:user_id, :vault_id, :args, :tenant_id]
 
       for m <- metrics, tag <- m.tags do

--- a/test/engram/prom_ex/mcp_test.exs
+++ b/test/engram/prom_ex/mcp_test.exs
@@ -1,0 +1,47 @@
+defmodule Engram.PromEx.McpTest do
+  @moduledoc """
+  Verifies the MCP PromEx plugin metric shape.
+
+  The controller wiring is exercised by the existing
+  `EngramWeb.McpControllerTest` suite — covering it here would need a
+  full ConnCase + auth harness. Plugin-shape test below is the
+  registration guard.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.PromEx.Mcp, as: McpPlugin
+  alias PromEx.MetricTypes.Event
+
+  describe "event_metrics/1" do
+    test "returns Event struct(s) prefixed [:engram, :prom_ex, :mcp]" do
+      events = McpPlugin.event_metrics(otp_app: :engram) |> List.wrap()
+      assert Enum.all?(events, &match?(%Event{}, &1))
+      metrics = Enum.flat_map(events, & &1.metrics)
+      assert Enum.any?(metrics, fn m -> Enum.at(m.name, 2) == :mcp end)
+    end
+
+    test "declares distribution + counter on [:engram, :mcp, :tool, :stop]" do
+      metrics = McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      target = [:engram, :mcp, :tool, :stop]
+      assert Enum.any?(metrics, fn m -> match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target end)
+      assert Enum.any?(metrics, fn m -> match?(%Telemetry.Metrics.Counter{}, m) and m.event_name == target end)
+    end
+
+    test "declares a result_bytes distribution" do
+      metrics = McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and m.measurement == :result_bytes
+             end)
+    end
+
+    test "no per-tenant tags" do
+      metrics = McpPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      banned = [:user_id, :vault_id, :args, :tenant_id]
+
+      for m <- metrics, tag <- m.tags do
+        refute tag in banned, "Mcp metric #{inspect(m.name)} has banned tag #{inspect(tag)}"
+      end
+    end
+  end
+end

--- a/test/engram/prom_ex/qdrant_test.exs
+++ b/test/engram/prom_ex/qdrant_test.exs
@@ -21,7 +21,9 @@ defmodule Engram.PromEx.QdrantTest do
     end
 
     test "declares a latency distribution + counter on [:engram, :qdrant, :request, :stop]" do
-      metrics = QdrantPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        QdrantPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       target = [:engram, :qdrant, :request, :stop]
 
       assert Enum.any?(metrics, fn m ->
@@ -34,7 +36,9 @@ defmodule Engram.PromEx.QdrantTest do
     end
 
     test "no high-cardinality tags" do
-      metrics = QdrantPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        QdrantPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       banned = [:user_id, :vault_id, :tenant_id, :collection, :point_id, :path]
 
       for m <- metrics, tag <- m.tags do

--- a/test/engram/prom_ex/qdrant_test.exs
+++ b/test/engram/prom_ex/qdrant_test.exs
@@ -1,0 +1,93 @@
+defmodule Engram.PromEx.QdrantTest do
+  @moduledoc """
+  Verifies the Qdrant PromEx plugin and the wrapping `:telemetry.span`
+  in `Engram.Vector.Qdrant`.
+
+  Cardinality contract: tags only `:op` (bounded enum) + `:status`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Engram.PromEx.Qdrant, as: QdrantPlugin
+  alias PromEx.MetricTypes.Event
+
+  describe "event_metrics/1" do
+    test "returns Event struct(s) prefixed [:engram, :prom_ex, :qdrant]" do
+      result = QdrantPlugin.event_metrics(otp_app: :engram)
+      events = List.wrap(result)
+      assert Enum.all?(events, &match?(%Event{}, &1))
+
+      metrics = Enum.flat_map(events, & &1.metrics)
+      assert Enum.any?(metrics, fn m -> Enum.at(m.name, 2) == :qdrant end)
+    end
+
+    test "declares a latency distribution + counter on [:engram, :qdrant, :request, :stop]" do
+      metrics = QdrantPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      target = [:engram, :qdrant, :request, :stop]
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target
+             end)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Counter{}, m) and m.event_name == target
+             end)
+    end
+
+    test "no high-cardinality tags" do
+      metrics = QdrantPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      banned = [:user_id, :vault_id, :tenant_id, :collection, :point_id, :path]
+
+      for m <- metrics, tag <- m.tags do
+        refute tag in banned, "Qdrant metric #{inspect(m.name)} has banned tag #{inspect(tag)}"
+      end
+    end
+  end
+
+  describe "telemetry events from Engram.Vector.Qdrant" do
+    setup do
+      ref = make_ref()
+      test_pid = self()
+
+      :telemetry.attach(
+        {__MODULE__, ref},
+        [:engram, :qdrant, :request, :stop],
+        fn _name, m, meta, _ -> send(test_pid, {:qdrant_stop, ref, m, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+      prev_url = Application.get_env(:engram, :qdrant_url)
+      Application.put_env(:engram, :qdrant_url, "http://127.0.0.1:1")
+      # Avoid Req's transient retry loop blowing the test runtime
+      prev_retry = Application.get_env(:engram, :qdrant_retry)
+      Application.put_env(:engram, :qdrant_retry, false)
+
+      on_exit(fn ->
+        if prev_url do
+          Application.put_env(:engram, :qdrant_url, prev_url)
+        else
+          Application.delete_env(:engram, :qdrant_url)
+        end
+
+        if is_nil(prev_retry) do
+          Application.delete_env(:engram, :qdrant_retry)
+        else
+          Application.put_env(:engram, :qdrant_retry, prev_retry)
+        end
+      end)
+
+      {:ok, ref: ref}
+    end
+
+    test "search/3 emits :stop with op=:search", %{ref: ref} do
+      _ = Engram.Vector.Qdrant.search("test_col", [0.0], user_id: "u1")
+      assert_receive {:qdrant_stop, ^ref, %{duration: _}, %{op: :search, status: :error}}, 5_000
+    end
+
+    test "upsert_points/2 emits :stop with op=:upsert", %{ref: ref} do
+      _ = Engram.Vector.Qdrant.upsert_points("test_col", [])
+      assert_receive {:qdrant_stop, ^ref, %{duration: _}, %{op: :upsert, status: :error}}, 5_000
+    end
+  end
+end

--- a/test/engram/prom_ex/search_test.exs
+++ b/test/engram/prom_ex/search_test.exs
@@ -1,0 +1,47 @@
+defmodule Engram.PromEx.SearchTest do
+  @moduledoc """
+  Verifies the Search PromEx plugin metric shape.
+
+  Wiring inside `Engram.Search.search/4` is covered by the existing
+  search test suite (it needs the full DB + Qdrant + Voyage Bypass
+  harness). The plugin-shape test below is what guards registration.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.PromEx.Search, as: SearchPlugin
+  alias PromEx.MetricTypes.Event
+
+  describe "event_metrics/1" do
+    test "returns Event struct(s) prefixed [:engram, :prom_ex, :search]" do
+      events = SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap()
+      assert Enum.all?(events, &match?(%Event{}, &1))
+      metrics = Enum.flat_map(events, & &1.metrics)
+      assert Enum.any?(metrics, fn m -> Enum.at(m.name, 2) == :search end)
+    end
+
+    test "declares distribution + counter on [:engram, :search, :request, :stop]" do
+      metrics = SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      target = [:engram, :search, :request, :stop]
+      assert Enum.any?(metrics, fn m -> match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target end)
+      assert Enum.any?(metrics, fn m -> match?(%Telemetry.Metrics.Counter{}, m) and m.event_name == target end)
+    end
+
+    test "declares a result_count distribution" do
+      metrics = SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and m.measurement == :result_count
+             end),
+             "Must expose result count as its own distribution measurement"
+    end
+
+    test "no per-tenant tags" do
+      metrics = SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      banned = [:user_id, :vault_id, :query, :tenant_id]
+
+      for m <- metrics, tag <- m.tags do
+        refute tag in banned, "Search metric #{inspect(m.name)} has banned tag #{inspect(tag)}"
+      end
+    end
+  end
+end

--- a/test/engram/prom_ex/search_test.exs
+++ b/test/engram/prom_ex/search_test.exs
@@ -20,14 +20,23 @@ defmodule Engram.PromEx.SearchTest do
     end
 
     test "declares distribution + counter on [:engram, :search, :request, :stop]" do
-      metrics = SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       target = [:engram, :search, :request, :stop]
-      assert Enum.any?(metrics, fn m -> match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target end)
-      assert Enum.any?(metrics, fn m -> match?(%Telemetry.Metrics.Counter{}, m) and m.event_name == target end)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target
+             end)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Counter{}, m) and m.event_name == target
+             end)
     end
 
     test "declares a result_count distribution" do
-      metrics = SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
 
       assert Enum.any?(metrics, fn m ->
                match?(%Telemetry.Metrics.Distribution{}, m) and m.measurement == :result_count
@@ -36,7 +45,9 @@ defmodule Engram.PromEx.SearchTest do
     end
 
     test "no per-tenant tags" do
-      metrics = SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        SearchPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       banned = [:user_id, :vault_id, :query, :tenant_id]
 
       for m <- metrics, tag <- m.tags do

--- a/test/engram/prom_ex/sync_test.exs
+++ b/test/engram/prom_ex/sync_test.exs
@@ -1,0 +1,74 @@
+defmodule Engram.PromEx.SyncTest do
+  @moduledoc """
+  Verifies the Sync PromEx plugin declares the expected metrics.
+
+  The wiring in `EngramWeb.SyncChannel` is exercised by the existing
+  `EngramWeb.SyncChannelTest` E2E coverage — repeating it here would
+  require a full ChannelCase + DB + RotationGate harness. The plugin-
+  shape test below is what guards the metric registration.
+
+  Cardinality contract: only `:op` (closed enum) + `:status`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.PromEx.Sync, as: SyncPlugin
+  alias PromEx.MetricTypes.Event
+
+  describe "event_metrics/1" do
+    test "returns Event struct(s) prefixed [:engram, :prom_ex, :sync]" do
+      result = SyncPlugin.event_metrics(otp_app: :engram)
+      events = List.wrap(result)
+      assert Enum.all?(events, &match?(%Event{}, &1))
+      metrics = Enum.flat_map(events, & &1.metrics)
+      assert Enum.any?(metrics, fn m -> Enum.at(m.name, 2) == :sync end)
+    end
+
+    test "declares distribution + counter on [:engram, :sync, :event, :stop]" do
+      metrics = SyncPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      target = [:engram, :sync, :event, :stop]
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target
+             end)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Counter{}, m) and m.event_name == target
+             end)
+    end
+
+    test "tags must be [:op, :status] — no per-tenant labels" do
+      metrics = SyncPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      banned = [:user_id, :vault_id, :device_id, :path, :tenant_id]
+
+      for m <- metrics, tag <- m.tags do
+        refute tag in banned, "Sync metric #{inspect(m.name)} has banned tag #{inspect(tag)}"
+      end
+    end
+  end
+
+  describe "span_sync wiring in SyncChannel" do
+    test "the channel module exposes a private span_sync/2 that emits on [:engram, :sync, :event]" do
+      # We can't call the private fn, but the *event name itself* is
+      # what the plugin subscribes to. Use telemetry.execute directly
+      # to confirm the contract is hooked correctly — this is the same
+      # event shape the channel produces via :telemetry.span.
+      ref = make_ref()
+      test_pid = self()
+
+      :telemetry.attach(
+        {__MODULE__, ref},
+        [:engram, :sync, :event, :stop],
+        fn _name, m, meta, _ -> send(test_pid, {:sync_stop, ref, m, meta}) end,
+        nil
+      )
+
+      :telemetry.span([:engram, :sync, :event], %{op: :push_note}, fn ->
+        {{:reply, {:ok, %{}}, %{}}, %{op: :push_note, status: :ok}}
+      end)
+
+      assert_receive {:sync_stop, ^ref, %{duration: _}, %{op: :push_note, status: :ok}}, 1_000
+
+      :telemetry.detach({__MODULE__, ref})
+    end
+  end
+end

--- a/test/engram/prom_ex/sync_test.exs
+++ b/test/engram/prom_ex/sync_test.exs
@@ -24,7 +24,9 @@ defmodule Engram.PromEx.SyncTest do
     end
 
     test "declares distribution + counter on [:engram, :sync, :event, :stop]" do
-      metrics = SyncPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        SyncPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       target = [:engram, :sync, :event, :stop]
 
       assert Enum.any?(metrics, fn m ->
@@ -37,7 +39,9 @@ defmodule Engram.PromEx.SyncTest do
     end
 
     test "tags must be [:op, :status] — no per-tenant labels" do
-      metrics = SyncPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        SyncPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       banned = [:user_id, :vault_id, :device_id, :path, :tenant_id]
 
       for m <- metrics, tag <- m.tags do

--- a/test/engram/prom_ex/voyage_test.exs
+++ b/test/engram/prom_ex/voyage_test.exs
@@ -1,0 +1,114 @@
+defmodule Engram.PromEx.VoyageTest do
+  @moduledoc """
+  Verifies the Voyage PromEx plugin declares Telemetry.Metrics events for
+  Voyage embedding API latency + errors, and that the events the plugin
+  subscribes to are actually emitted by `Engram.Embedders.Voyage`.
+
+  Cardinality contract: tags MUST NOT include user_id, vault_id, or any
+  per-tenant identifier. Only bounded labels (status, purpose) are allowed.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.PromEx.Voyage, as: VoyagePlugin
+  alias PromEx.MetricTypes.Event
+
+  describe "event_metrics/1" do
+    test "returns an Event.t() (or list) of Telemetry.Metrics with engram_prom_ex.voyage prefix" do
+      result = VoyagePlugin.event_metrics(otp_app: :engram)
+      events = List.wrap(result)
+
+      assert Enum.all?(events, &match?(%Event{}, &1)),
+             "event_metrics/1 must return PromEx.MetricTypes.Event structs"
+
+      assert Enum.any?(events), "Voyage plugin must declare at least one event group"
+
+      metrics = Enum.flat_map(events, & &1.metrics)
+
+      assert Enum.any?(metrics, fn m ->
+               Enum.take(m.name, 2) == [:engram, :prom_ex] and Enum.at(m.name, 2) == :voyage
+             end),
+             "Metrics must be prefixed with [:engram, :prom_ex, :voyage, ...]"
+    end
+
+    test "declares a latency distribution for embed requests" do
+      metrics = VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and
+                 m.event_name == [:engram, :voyage, :embed, :stop]
+             end),
+             "Must subscribe to [:engram, :voyage, :embed, :stop] with a distribution metric"
+    end
+
+    test "declares a counter for embed errors" do
+      metrics = VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Counter{}, m) and
+                 m.event_name == [:engram, :voyage, :embed, :stop]
+             end),
+             "Must have a counter on the :stop event so error rate is derivable from `status` tag"
+    end
+
+    test "never includes high-cardinality tags (user_id, vault_id)" do
+      metrics = VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      banned = [:user_id, :vault_id, :tenant_id, :path, :path_hmac]
+
+      for m <- metrics, tag <- m.tags do
+        refute tag in banned,
+               "Voyage plugin metric #{inspect(m.name)} has banned high-cardinality tag #{inspect(tag)}"
+      end
+    end
+  end
+
+  describe "telemetry events emitted by Embedders.Voyage" do
+    test "embed_texts/1 emits [:engram, :voyage, :embed, :stop] with status + duration" do
+      ref = make_ref()
+      test_pid = self()
+
+      :telemetry.attach(
+        {__MODULE__, ref},
+        [:engram, :voyage, :embed, :stop],
+        fn _name, measurements, metadata, _ ->
+          send(test_pid, {:embed_stop, ref, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit_detach({__MODULE__, ref})
+
+      # Hit a non-existent host so the call fast-fails with an error tuple
+      # — exercises the error path and proves the span emits a `:stop` with
+      # a status tag regardless of outcome.
+      prev_url = Application.get_env(:engram, :voyage_url)
+      prev_key = Application.get_env(:engram, :voyage_api_key)
+      Application.put_env(:engram, :voyage_url, "http://127.0.0.1:1")
+      Application.put_env(:engram, :voyage_api_key, "test")
+
+      on_exit(fn ->
+        if prev_url do
+          Application.put_env(:engram, :voyage_url, prev_url)
+        else
+          Application.delete_env(:engram, :voyage_url)
+        end
+
+        if prev_key do
+          Application.put_env(:engram, :voyage_api_key, prev_key)
+        else
+          Application.delete_env(:engram, :voyage_api_key)
+        end
+      end)
+
+      _ = Engram.Embedders.Voyage.embed_texts(["hello"], retry: false, max_retries: 0)
+
+      assert_receive {:embed_stop, ^ref, measurements, metadata}, 5_000
+      assert is_integer(measurements[:duration])
+      assert metadata[:status] in [:ok, :error]
+      assert metadata[:purpose] in [:query, :index]
+    end
+  end
+
+  defp on_exit_detach(handler_key) do
+    on_exit(fn -> :telemetry.detach(handler_key) end)
+  end
+end

--- a/test/engram/prom_ex/voyage_test.exs
+++ b/test/engram/prom_ex/voyage_test.exs
@@ -31,7 +31,8 @@ defmodule Engram.PromEx.VoyageTest do
     end
 
     test "declares a latency distribution for embed requests" do
-      metrics = VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
 
       assert Enum.any?(metrics, fn m ->
                match?(%Telemetry.Metrics.Distribution{}, m) and
@@ -41,7 +42,8 @@ defmodule Engram.PromEx.VoyageTest do
     end
 
     test "declares a counter for embed errors" do
-      metrics = VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
 
       assert Enum.any?(metrics, fn m ->
                match?(%Telemetry.Metrics.Counter{}, m) and
@@ -51,7 +53,9 @@ defmodule Engram.PromEx.VoyageTest do
     end
 
     test "never includes high-cardinality tags (user_id, vault_id)" do
-      metrics = VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+      metrics =
+        VoyagePlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
       banned = [:user_id, :vault_id, :tenant_id, :path, :path_hmac]
 
       for m <- metrics, tag <- m.tags do


### PR DESCRIPTION
## Summary

Five PromEx custom plugins emitting Prometheus metrics from existing-or-added telemetry events:

- `Engram.PromEx.Voyage` — embed latency distribution + counter `[:status, :purpose]`
- `Engram.PromEx.Qdrant` — per-op latency + counter `[:op, :status]`
- `Engram.PromEx.Sync` — SyncChannel handler latency + counter `[:op, :status]`
- `Engram.PromEx.Search` — end-to-end latency + result-count distribution `[:status, :cross_vault, :rerank]`
- `Engram.PromEx.Mcp` — per-tool latency + counter + result-bytes (LLM context cost) `[:tool, :status]`

Wires telemetry events inline where missing (Voyage embed, Qdrant request, sync event, search request, MCP tool). All cardinality-safe — tests pin against any `:user_id`/`:vault_id`/`:tenant_id`/`:path`/`:query`/`:args` tag.

Cross-references engram-app/engram-infra#340.

## Test plan

- [x] 22 new tests pass; full suite 2305/0 green
- [x] `mix credo --strict` clean
- [x] `mix format --check-formatted` clean
- [ ] Prod metric scrape lands the 5 new metric families after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)