### PR TITLE
fix(billing): TrialNotice canceled-state copy + button style

### DIFF
--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -230,14 +230,12 @@ function TrialNotice({
         <div className="rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
           <p className="font-medium text-foreground">Changed your mind?</p>
           <p className="mt-1">
-            Use <strong>Keep my subscription</strong> at the top of this page to reverse the
-            cancellation.
+            Use <strong>Keep my subscription</strong> right below the Current Plan section to
+            reverse the cancellation.
           </p>
         </div>
-        <div className="flex gap-2">
-          <Button variant="ghost" onClick={onClose}>
-            Close
-          </Button>
+        <div className="flex justify-end gap-2">
+          <Button onClick={onClose}>Close</Button>
         </div>
       </section>
     )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.370",
+      version: "0.5.371",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Two staging walkthrough nits on the trial-already-canceled TrialNotice state (PR #489):

- **Copy:** "at the top of this page" → "right below the Current Plan section" (PendingChangeBanner actually sits between CurrentPlanCard and PaymentMethodCard, not at the top).
- **Close button:** ghost variant → default variant, right-aligned. Reads as the primary action since it's the only one in this state.

mix.exs 0.5.370 → 0.5.371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)