### PR TITLE
fix(cache,rate-limiter): wildcard hostname check for ElastiCache/Valkey TLS

### DIFF
--- a/lib/engram/cache/redix.ex
+++ b/lib/engram/cache/redix.ex
@@ -18,10 +18,31 @@ defmodule Engram.Cache.Redix do
 
     %{
       id: __MODULE__,
-      start: {Redix, :start_link, [url, [name: @conn, sync_connect: false]]}
+      start: {Redix, :start_link, [url, redix_opts()]}
     }
   end
 
   @spec command([String.t()]) :: {:ok, term()} | {:error, term()}
   def command(args), do: Redix.command(@conn, args, timeout: @timeout)
+
+  # `customize_hostname_check` is required for `rediss://` URLs whose server
+  # presents a wildcard cert (e.g. AWS ElastiCache/Valkey:
+  # `*.cluster.cache.amazonaws.com`). Erlang `:ssl`'s default match_fun is
+  # strict literal — it rejects wildcard SANs on leftmost-label hosts like
+  # `master.cluster.cache.amazonaws.com` and emits
+  # `CLIENT ALERT: Fatal - Handshake Failure` every reconnect (silent cache
+  # fail-open in prod). The `:https`-shape match_fun applies RFC 6125
+  # wildcard rules. Ignored for plain-tcp `redis://` URLs (no TLS
+  # handshake), so unconditional is safe for selfhost.
+  defp redix_opts do
+    [
+      name: @conn,
+      sync_connect: false,
+      socket_opts: [
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    ]
+  end
 end

--- a/lib/engram_web/rate_limiter/redis.ex
+++ b/lib/engram_web/rate_limiter/redis.ex
@@ -15,11 +15,31 @@ defmodule EngramWeb.RateLimiter.Redis do
   @doc """
   Runtime start options for the limiter, derived from `REDIS_URL`.
 
-  Only `:url` is a valid `Hammer.Redis` start option; everything else is popped
-  and forwarded to `Redix.start_link/1`, which validates its schema strictly and
-  rejects unknown keys (a bad option crashes the limiter on boot). The key
-  prefix and command timeout are compiled in via the `use` opts above.
+  Only `:url` is a `Hammer.Redis`-specific start option; everything else is
+  popped and forwarded to `Redix.start_link/1`, which validates its schema
+  strictly and rejects unknown keys (a bad option crashes the limiter on
+  boot). The key prefix and command timeout are compiled in via the `use`
+  opts above.
+
+  `:socket_opts` carries `customize_hostname_check` so `rediss://` URLs
+  against wildcard certs (AWS ElastiCache/Valkey:
+  `*.cluster.cache.amazonaws.com`) negotiate TLS successfully. Erlang
+  `:ssl`'s default match_fun is strict literal — it rejects wildcard SANs
+  on leftmost-label hosts like `master.cluster.cache.amazonaws.com` and
+  emits `CLIENT ALERT: Fatal - Handshake Failure` every reconnect (silent
+  rate-limiter fail-open in prod). The `:https`-shape match_fun applies
+  RFC 6125 wildcard rules. Ignored for plain-tcp `redis://` URLs (no TLS
+  handshake), so unconditional is safe for selfhost.
   """
-  @spec start_opts(String.t()) :: [{:url, String.t()}]
-  def start_opts(redis_url) when is_binary(redis_url), do: [url: redis_url]
+  @spec start_opts(String.t()) :: keyword()
+  def start_opts(redis_url) when is_binary(redis_url) do
+    [
+      url: redis_url,
+      socket_opts: [
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    ]
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.375",
+      version: "0.5.376",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/cache_test.exs
+++ b/test/engram/cache_test.exs
@@ -96,6 +96,26 @@ defmodule Engram.CacheTest do
     end
   end
 
+  describe "Engram.Cache.Redix child_spec" do
+    test "passes the :https-shape hostname match_fun to Redix via :socket_opts" do
+      # Mirrors EngramWeb.RateLimiter.Redis: ElastiCache/Valkey wildcard certs
+      # (`*.cluster.cache.amazonaws.com`) fail Erlang's default strict literal
+      # hostname check against leftmost-label hosts. The match_fun is ignored
+      # for plain-tcp `redis://` URLs (no TLS handshake) so passing
+      # unconditionally is safe for selfhost.
+      spec = Engram.Cache.Redix.child_spec(url: "rediss://master.example:6379")
+      assert {Redix, :start_link, [_url, opts]} = spec.start
+
+      assert [
+               name: :engram_cache_redix,
+               sync_connect: false,
+               socket_opts: [customize_hostname_check: [match_fun: match_fun]]
+             ] = opts
+
+      assert is_function(match_fun)
+    end
+  end
+
   defp attach do
     ref = make_ref()
     name = "cache-degraded-#{inspect(ref)}"

--- a/test/engram_web/rate_limiter_test.exs
+++ b/test/engram_web/rate_limiter_test.exs
@@ -68,11 +68,21 @@ defmodule EngramWeb.RateLimiterTest do
   describe "Redis backend start options" do
     alias EngramWeb.RateLimiter.Redis, as: RedisLimiter
 
-    test "start_opts/1 passes only :url through to Redix" do
-      # :prefix and :timeout are compile-time `use Hammer` options, NOT Redix
-      # start options. Only :url is a valid runtime start option for the
-      # Hammer.Redis backend, so the runtime config must pass nothing else.
-      assert RedisLimiter.start_opts("redis://localhost:6379") == [url: "redis://localhost:6379"]
+    test "start_opts/1 passes :url and TLS-wildcard hostname-match fun through to Redix" do
+      # :prefix and :timeout are compile-time `use Hammer` options. Runtime
+      # start options must include :url plus :socket_opts carrying the
+      # :https-shape hostname match_fun — Erlang's default hostname check
+      # is strict literal, which rejects ElastiCache/Valkey wildcard certs
+      # (`*.cluster.cache.amazonaws.com`) on connections to leftmost-label
+      # hosts like `master.cluster.cache.amazonaws.com`. The match_fun is
+      # ignored for plain-tcp `redis://` URLs (no TLS handshake), so passing
+      # it unconditionally is safe for selfhost.
+      assert [
+               url: "redis://localhost:6379",
+               socket_opts: [customize_hostname_check: [match_fun: match_fun]]
+             ] = RedisLimiter.start_opts("redis://localhost:6379")
+
+      assert is_function(match_fun)
     end
 
     test "limiter starts under a supervisor with the production opt shape" do


### PR DESCRIPTION
## Summary

- Add `socket_opts: [customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]]` to both Redix call sites: \`Engram.Cache.Redix\` and \`EngramWeb.RateLimiter.Redis\`.
- Unit tests on \`child_spec/1\` + \`start_opts/1\` assert the wired option shape.
- Bump 0.5.375 → 0.5.376.

## Why

Caught 2026-06-07 via Grafana Loki Explore as soon as the FireLens pipeline came online (engram-infra#389 + #390). Every ~30s on both prod tasks, a fatal TLS alert pair:

\`\`\`
[notice] TLS :client: In state :wait_cert_cr at ssl_handshake.erl:2180
  generated CLIENT ALERT: Fatal - Handshake Failure
{:bad_cert,
  {:hostname_check_failed,
    {:requested, ~c"master.engram-prod.fhuknl.use1.cache.amazonaws.com"},
    {:received,  [dNSName: ~c"*.engram-prod.fhuknl.use1.cache.amazonaws.com"]}}}
\`\`\`

By RFC 6125, the wildcard \`*.X\` SAN matches the single-leftmost-label host \`master.X\`. Erlang \`:ssl\`'s **default** \`:public_key.pkix_verify_hostname/2\` uses a STRICT LITERAL match — wildcards are rejected unless the caller opts into the \`:https\`-shape match_fun. Classic Erlang/Elixir TLS gotcha (same shape that hits Postgrex/Mint/Tortoise users).

Both clients run with \`sync_connect: false\` and fail-open semantics in the request path: cache degrades to ETS, rate-limiter degrades to "allow." So Valkey was effectively offline in prod with **zero observable surface** until Loki came online. Cache hit rate, rate-limiter exactness, and Voyage quota counter accuracy were all degraded.

## Fix shape

- \`Engram.Cache.Redix.child_spec/1\` — pulls Redix start opts into a private \`redix_opts/0\` returning \`[name:, sync_connect:, socket_opts: [customize_hostname_check: ...]]\`.
- \`EngramWeb.RateLimiter.Redis.start_opts/1\` — same socket_opts appended; Hammer.Redis pops \`:url\` and forwards the rest to \`Redix.start_link/1\`.
- Match_fun is ignored for plain-tcp \`redis://\` URLs (no TLS handshake at all), so the change is safe for selfhost.

## Test plan

- [x] \`mix test test/engram/cache_test.exs test/engram_web/rate_limiter_test.exs\` — 17 tests, 0 failures (TDD'd; both new assertions red pre-fix, green post-fix).
- [x] \`mix format --check-formatted\` (pre-push hook).
- [ ] Merge → image build → tf-apply image-tag bump in engram-infra → ECS rolloutState=COMPLETED on new revision.
- [ ] Loki Explore: \`{service="engram", env="prod"} |~ "Handshake Failure"\` → zero hits within ~1 min of rollover.
- [ ] PromEx Hammer + Cache backend metrics show real cache traffic instead of fail-open misses.

## Related

- The two engram-infra fixes that made this visible: #389 (FireLens task-role IAM) + #390 (engram \`enable-ecs-log-metadata\` on null OUTPUT). Both were no-op-shaped in the deploy gate (\`essential = false\` log_router) and let log dark go silent.
- This is a layer below those — even with logs flowing, Valkey was disconnected. Same silent-failure pattern (\`sync_connect: false\` + fail-open). Should file follow-ups for cache-hit-rate + rate-limiter-fail-open alerting once Prom queries against the new Loki/PromEx stream are wired (handoff items #6/#7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)