### PR TITLE
fix(cache,rate-limiter): gate :socket_opts on rediss:// scheme (hotfix #496)

### DIFF
--- a/lib/engram/cache/redix.ex
+++ b/lib/engram/cache/redix.ex
@@ -18,7 +18,7 @@ defmodule Engram.Cache.Redix do
 
     %{
       id: __MODULE__,
-      start: {Redix, :start_link, [url, redix_opts()]}
+      start: {Redix, :start_link, [url, redix_opts(url)]}
     }
   end
 
@@ -30,14 +30,22 @@ defmodule Engram.Cache.Redix do
   # `*.cluster.cache.amazonaws.com`). Erlang `:ssl`'s default match_fun is
   # strict literal — it rejects wildcard SANs on leftmost-label hosts like
   # `master.cluster.cache.amazonaws.com` and emits
-  # `CLIENT ALERT: Fatal - Handshake Failure` every reconnect (silent cache
-  # fail-open in prod). The `:https`-shape match_fun applies RFC 6125
-  # wildcard rules. Ignored for plain-tcp `redis://` URLs (no TLS
-  # handshake), so unconditional is safe for selfhost.
-  defp redix_opts do
+  # `CLIENT ALERT: Fatal - Handshake Failure` every reconnect.
+  #
+  # MUST be gated on the `rediss://` scheme: for plain-tcp `redis://` URLs
+  # Redix passes `socket_opts` directly to `:gen_tcp.connect/4`, which
+  # validates strictly and rejects `customize_hostname_check` (an `:ssl`
+  # option) with ArgumentError → boot-loops the cache/limiter process →
+  # crashes the app supervisor on staging-fastraid + selfhost.
+  # The original `Pull #496` claimed "unconditional is safe" — wrong.
+  defp redix_opts(url) do
+    base = [name: @conn, sync_connect: false]
+
+    if String.starts_with?(url, "rediss://"), do: base ++ tls_opts(), else: base
+  end
+
+  defp tls_opts do
     [
-      name: @conn,
-      sync_connect: false,
       socket_opts: [
         customize_hostname_check: [
           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)

--- a/lib/engram_web/rate_limiter/redis.ex
+++ b/lib/engram_web/rate_limiter/redis.ex
@@ -21,20 +21,29 @@ defmodule EngramWeb.RateLimiter.Redis do
   boot). The key prefix and command timeout are compiled in via the `use`
   opts above.
 
-  `:socket_opts` carries `customize_hostname_check` so `rediss://` URLs
-  against wildcard certs (AWS ElastiCache/Valkey:
+  For `rediss://` URLs ONLY: append `:socket_opts` with
+  `customize_hostname_check` so wildcard certs (AWS ElastiCache/Valkey:
   `*.cluster.cache.amazonaws.com`) negotiate TLS successfully. Erlang
   `:ssl`'s default match_fun is strict literal — it rejects wildcard SANs
   on leftmost-label hosts like `master.cluster.cache.amazonaws.com` and
-  emits `CLIENT ALERT: Fatal - Handshake Failure` every reconnect (silent
-  rate-limiter fail-open in prod). The `:https`-shape match_fun applies
-  RFC 6125 wildcard rules. Ignored for plain-tcp `redis://` URLs (no TLS
-  handshake), so unconditional is safe for selfhost.
+  emits `CLIENT ALERT: Fatal - Handshake Failure` every reconnect.
+
+  MUST be gated on the `rediss://` scheme: for plain-tcp `redis://` URLs
+  Redix passes `socket_opts` directly to `:gen_tcp.connect/4`, which
+  validates strictly and rejects `customize_hostname_check` (an `:ssl`
+  option) with ArgumentError → boot-loops the limiter → crashes the app
+  supervisor on staging-fastraid + selfhost. The original `Pull #496`
+  claimed "unconditional is safe" — wrong.
   """
   @spec start_opts(String.t()) :: keyword()
   def start_opts(redis_url) when is_binary(redis_url) do
+    base = [url: redis_url]
+
+    if String.starts_with?(redis_url, "rediss://"), do: base ++ tls_opts(), else: base
+  end
+
+  defp tls_opts do
     [
-      url: redis_url,
       socket_opts: [
         customize_hostname_check: [
           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.376",
+      version: "0.5.377",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/cache_test.exs
+++ b/test/engram/cache_test.exs
@@ -97,12 +97,19 @@ defmodule Engram.CacheTest do
   end
 
   describe "Engram.Cache.Redix child_spec" do
-    test "passes the :https-shape hostname match_fun to Redix via :socket_opts" do
-      # Mirrors EngramWeb.RateLimiter.Redis: ElastiCache/Valkey wildcard certs
-      # (`*.cluster.cache.amazonaws.com`) fail Erlang's default strict literal
-      # hostname check against leftmost-label hosts. The match_fun is ignored
-      # for plain-tcp `redis://` URLs (no TLS handshake) so passing
-      # unconditionally is safe for selfhost.
+    test "omits :socket_opts for plain-tcp redis:// URLs" do
+      # `customize_hostname_check` is `:ssl`-only. Redix passes
+      # `:socket_opts` to `:gen_tcp.connect/4` for `redis://` which barfs
+      # ArgumentError → boot-loop. MUST be omitted entirely on plain-tcp.
+      spec = Engram.Cache.Redix.child_spec(url: "redis://localhost:6379")
+      assert {Redix, :start_link, [_url, opts]} = spec.start
+      assert opts == [name: :engram_cache_redix, sync_connect: false]
+    end
+
+    test "appends the :https-shape hostname match_fun via :socket_opts for rediss:// URLs" do
+      # AWS ElastiCache/Valkey wildcard certs (`*.cluster.cache.amazonaws.com`)
+      # fail Erlang's default strict literal hostname check on leftmost-label
+      # hosts. The `:https`-shape match_fun applies RFC 6125 wildcard rules.
       spec = Engram.Cache.Redix.child_spec(url: "rediss://master.example:6379")
       assert {Redix, :start_link, [_url, opts]} = spec.start
 

--- a/test/engram_web/rate_limiter_test.exs
+++ b/test/engram_web/rate_limiter_test.exs
@@ -68,19 +68,24 @@ defmodule EngramWeb.RateLimiterTest do
   describe "Redis backend start options" do
     alias EngramWeb.RateLimiter.Redis, as: RedisLimiter
 
-    test "start_opts/1 passes :url and TLS-wildcard hostname-match fun through to Redix" do
-      # :prefix and :timeout are compile-time `use Hammer` options. Runtime
-      # start options must include :url plus :socket_opts carrying the
-      # :https-shape hostname match_fun — Erlang's default hostname check
-      # is strict literal, which rejects ElastiCache/Valkey wildcard certs
-      # (`*.cluster.cache.amazonaws.com`) on connections to leftmost-label
-      # hosts like `master.cluster.cache.amazonaws.com`. The match_fun is
-      # ignored for plain-tcp `redis://` URLs (no TLS handshake), so passing
-      # it unconditionally is safe for selfhost.
+    test "start_opts/1 omits :socket_opts for plain-tcp redis:// URLs" do
+      # `customize_hostname_check` is an `:ssl`-only option. Redix passes
+      # `:socket_opts` to `:gen_tcp.connect/4` for `redis://` URLs which
+      # validates strictly and rejects it with ArgumentError, boot-looping
+      # the limiter. MUST be omitted entirely on plain-tcp.
+      assert RedisLimiter.start_opts("redis://localhost:6379") == [url: "redis://localhost:6379"]
+    end
+
+    test "start_opts/1 appends TLS-wildcard hostname-match fun for rediss:// URLs" do
+      # AWS ElastiCache/Valkey TLS endpoints present wildcard certs
+      # (`*.cluster.cache.amazonaws.com`). Erlang's default match_fun is
+      # strict literal — it rejects them on leftmost-label hosts like
+      # `master.cluster.cache.amazonaws.com`. The `:https`-shape match_fun
+      # applies RFC 6125 wildcard rules.
       assert [
-               url: "redis://localhost:6379",
+               url: "rediss://master.example:6379",
                socket_opts: [customize_hostname_check: [match_fun: match_fun]]
-             ] = RedisLimiter.start_opts("redis://localhost:6379")
+             ] = RedisLimiter.start_opts("rediss://master.example:6379")
 
       assert is_function(match_fun)
     end


### PR DESCRIPTION
## Summary

Hotfix for #496. Gates the new \`:socket_opts\` block on \`String.starts_with?(url, "rediss://")\` so plain-tcp \`redis://\` paths get their original opt list back.

## Regression

#496 added \`socket_opts: [customize_hostname_check: [match_fun: ...]]\` to both Redix call sites with the (incorrect) note "ignored for plain-tcp URLs (no TLS handshake), so unconditional is safe for selfhost." That's false:

- Redix passes \`:socket_opts\` to \`:ssl.connect\` for \`rediss://\` (where \`:customize_hostname_check\` is a valid option) — works.
- Redix passes \`:socket_opts\` to \`:gen_tcp.connect/4\` for \`redis://\` — \`:gen_tcp\` validates strictly and rejects \`:customize_hostname_check\` with ArgumentError.

The cache/limiter then boot-loop. Engram supervisor exhausts retries. App exits during \`Application.start\`:

\`\`\`
** (ArgumentError) argument error
    (kernel 10.1.1) gen_tcp.erl:578: :gen_tcp.connect/4
    (redix 1.5.3) lib/redix/connector.ex:33: Redix.Connector.connect_directly/3
    (redix 1.5.3) lib/redix/socket_owner.ex:43: Redix.SocketOwner.handle_info/2
...
** (EXIT) ** (ArgumentError) unknown registry: Engram.PubSub. Either the registry name is invalid or the registry is not running, possibly because its application isn't started
    (elixir 1.17.3) lib/registry.ex:1086: Registry.meta/2
    (phoenix_pubsub 2.2.0) lib/phoenix/pubsub.ex:232: Phoenix.PubSub.broadcast/4
    (engram 0.5.376) lib/engram/cluster/cache_sync.ex:30: Engram.Cluster.CacheSync.broadcast/1
    (engram 0.5.376) lib/engram/application.ex:54: Engram.Application.start/2
\`\`\`

Caught on staging-fastraid (uses plain \`redis://\` against the FastRaid Redis sidecar).

Prod (AWS ElastiCache, \`rediss://\`) is UNAFFECTED — Redix takes the \`:ssl.connect\` path there and \`:customize_hostname_check\` is honored, so 0.5.376 actually fixed the original wildcard-cert bug on prod (verified via Grafana Explore: zero \"Handshake Failure\" lines post-rollover on revision 44).

## Fix

\`\`\`elixir
defp redix_opts(url) do
  base = [name: @conn, sync_connect: false]
  if String.starts_with?(url, "rediss://"), do: base ++ tls_opts(), else: base
end
\`\`\`

Same shape for \`EngramWeb.RateLimiter.Redis.start_opts/1\`.

## Test plan

- [x] Tests split per scheme:
  - \`redis://localhost:6379\` → \`[url: ..., name:, sync_connect:]\` only (no socket_opts).
  - \`rediss://master.example:6379\` → opts ++ \`[socket_opts: [customize_hostname_check: [match_fun: <fun>]]]\`.
- [x] \`mix test test/engram/cache_test.exs test/engram_web/rate_limiter_test.exs\` — 19 tests, 0 failures.
- [ ] Merge → engram CI builds image → bot auto-bumps staging-fastraid → staging app boots clean.
- [ ] Cut \`release-v0.5.377\` to bring the gate fix to prod (prod isn't broken but version should advance past the buggy 0.5.376 baseline).

## Followups

- The Engram supervisor's boot-loop on a Redix init crash didn't trip any deploy health gate. On staging-fastraid the FastRaid health check has no startup-probe gate distinct from the runtime health endpoint, so the bad image moved into service. Worth a separate issue: cheap startup probe (e.g. one synchronous \`Engram.Cache.Redix.command([\"PING\"])\` at boot before \`{:ok, sup}\` returns) would have failed the deploy at the container-HC layer instead of in Loki.
- The engram-infra#387 ECS deploy-health gate also wouldn't have caught this (it only watches \`rolloutState\` on AWS prod, not FastRaid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)