### PR TITLE
fix(prod/db): rename :ssl_opts → :ssl for Postgrex 0.20+ deprecation

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -506,9 +506,15 @@ if config_env() == :prod do
   # validation — the RDS root CA isn't bundled into the Alpine image
   # and traffic is already inside the prod VPC, so peer auth adds no
   # meaningful confidentiality beyond what TLS-on-the-wire provides.
+  #
+  # Postgrex 0.20+ accepts the SSL opt list directly under `:ssl` (a
+  # keyword list both enables TLS and supplies the opts); the older
+  # `:ssl_opts` companion key was deprecated and emits one
+  # `:ssl_opts is deprecated, pass opts to :ssl instead` warning per
+  # connection start.
   database_ssl_opts =
     if System.get_env("DATABASE_SSL") in ~w(true 1) do
-      [ssl: true, ssl_opts: [verify: :verify_none]]
+      [ssl: [verify: :verify_none]]
     else
       []
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.377",
+      version: "0.5.378",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

\`config/runtime.exs\` Repo config: rename \`[ssl: true, ssl_opts: [verify: :verify_none]]\` → \`[ssl: [verify: :verify_none]]\`. Bumps 0.5.377 → 0.5.378 (0.5.377 is the in-flight release tag from #497).

## Why

Caught in Grafana Loki on prod revision 44 (the first revision whose logs reached Loki end-to-end). Once per Repo connection start:

\`\`\`
[warning] :ssl_opts is deprecated, pass opts to :ssl instead
\`\`\`

Source: \`deps/postgrex/lib/postgrex/protocol.ex:103\`. Postgrex 0.20+ accepts the SSL opt list directly under \`:ssl\` (a keyword list both enables TLS and supplies the opts).

## Behavioral change

Zero. Same \`verify: :verify_none\` reaches Postgrex's SSL handshake; just under the new key.

## Out of scope

The broader security gap (still on \`:verify_none\` against AWS RDS — no peer auth) is tracked separately in #499. Out of scope here — this PR only clears the deprecation warning without touching trust semantics.

## Test plan

- [x] \`mix format --check-formatted\` (pre-push hook).
- [x] runtime.exs change is mechanical key rename inside the same \`if\` branch.
- [ ] Merge → image build → cut \`release-v0.5.378\` → tf-apply rolls prod → confirm \`:ssl_opts is deprecated\` lines stop landing in Loki within 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)