### PR TITLE
fix(ci): use valid base64 fallback for ENCRYPTION_MASTER_KEY in verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -69,10 +69,12 @@ env:
   # The `||` fallback covers Dependabot PRs, which by GitHub policy don't receive
   # workflow secrets. Without it, `secrets.CI_ENCRYPTION_MASTER_KEY` evaluates to
   # empty string and Phoenix boot crashes with "ENCRYPTION_MASTER_KEY is required
-  # when KEY_PROVIDER=local". The fallback is a known constant — no secret value
-  # since the CI DB is recreated per run.
+  # when KEY_PROVIDER=local". The fallback must base64-decode to exactly 32 bytes
+  # (Engram.Crypto.Config.decode_master_key!/2) — using 32 zero bytes here so the
+  # value is unambiguously a CI fixture, not a leaked key. Per the doc above the
+  # CI database is recreated per run; nothing the fallback wraps survives.
   KEY_PROVIDER: "local"
-  ENCRYPTION_MASTER_KEY: ${{ secrets.CI_ENCRYPTION_MASTER_KEY || 'ci-dependabot-fallback-key-ephemeral-only-not-secret' }}
+  ENCRYPTION_MASTER_KEY: ${{ secrets.CI_ENCRYPTION_MASTER_KEY || 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' }}
 
 jobs:
   # Fingerprint: content-hash of every source path that affects test

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.379",
+      version: "0.5.380",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Replaces the dependabot-PR fallback for `ENCRYPTION_MASTER_KEY` in `.github/workflows/verify.yml` with a string that actually base64-decodes to 32 bytes. Bumps mix.exs 0.5.379 → 0.5.380.

## Why

Dependabot PRs can't access `secrets.CI_ENCRYPTION_MASTER_KEY` per GitHub policy, so the `||` fallback fires. The previous literal (`ci-dependabot-fallback-key-ephemeral-only-not-secret`) is NOT valid base64. `Engram.Crypto.Config.decode_master_key!/2` raises `must be valid base64`, the engram container crashes on boot, and the `storage-database` job fails before any test runs.

Repro from PR #501 (dependabot sentry 10 → 13.1):
```
engram-1 | ** (RuntimeError) ENCRYPTION_MASTER_KEY must be valid base64
storage-database  ##[error]Process completed with exit code 1.
```

This presumably affects every dependabot PR since the validator landed — the storage-database job is a silent always-fail for them, hiding any real boot regression a dep bump might introduce.

## What this is NOT

- Not a security change. The CI database is recreated per run, no persistent data is wrapped with this key, and the value is committed in plaintext so it's unambiguously a fixture.
- Not a sentry-bump fix. PR #501 is still subject to whatever real boot/runtime issues sentry 13 may bring; this just lets us see them instead of hiding behind the wrong-format error.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, re-run PR #501's `storage-database` job — should reach actual test phase. If sentry 13 has real boot issues they'll surface there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)