### PR TITLE
feat(voyage): capture usage.total_tokens for billing telemetry

### DIFF
--- a/lib/engram/embedders/voyage.ex
+++ b/lib/engram/embedders/voyage.ex
@@ -7,6 +7,21 @@ defmodule Engram.Embedders.Voyage do
   bulk indexing burst cannot starve synchronous user search. Callers should
   pass `purpose: :query` for search/RAG paths; everything else (EmbedNote
   worker, parity validation, future batch jobs) is treated as `:index`.
+
+  ## Telemetry
+
+    * `[:engram, :voyage, :embed, :start | :stop | :exception]` — request
+      span. Stop metadata: `%{status: ..., purpose: ...}`.
+    * `[:engram, :voyage, :embed, :tokens]` — emitted on a successful 200
+      response when the Voyage payload includes `usage.total_tokens`.
+      Measurements: `%{total_tokens: pos_integer()}`. Metadata:
+      `%{purpose: :index | :query}`. Drives the
+      `engram_prom_ex_voyage_embed_tokens_total` sum metric used by the
+      Grafana cost / tokens-per-minute panels. Voyage publishes no usage
+      API, so this is the only telemetry path for billing reconciliation.
+    * `[:engram, :embed, :client_rate_limited]` — synthetic-429s emitted
+      when the in-process Hammer throttle fast-fails a request before
+      reaching Voyage.
   """
 
   @behaviour Engram.Embedder
@@ -87,8 +102,9 @@ defmodule Engram.Embedders.Voyage do
       )
 
     case result do
-      {:ok, %{status: 200, body: %{"data" => data}}} ->
+      {:ok, %{status: 200, body: %{"data" => data} = body}} ->
         vectors = Enum.map(data, & &1["embedding"])
+        emit_token_telemetry(body, Keyword.get(opts, :purpose, :index))
         {:ok, vectors}
 
       {:ok, %{status: status, body: body}} ->
@@ -98,6 +114,23 @@ defmodule Engram.Embedders.Voyage do
         {:error, reason}
     end
   end
+
+  # Voyage's `/v1/embeddings` 200 response always carries a `usage` object
+  # with `total_tokens`. The field is the only billing-relevant signal — no
+  # public usage API exists — so we lift it into a telemetry event for the
+  # PromEx `tokens_total` sum metric. Absence-of-event is the contract when
+  # the field is missing: a future endpoint shape change should not surface
+  # as silently-zero tokens.
+  defp emit_token_telemetry(%{"usage" => %{"total_tokens" => total}}, purpose)
+       when is_integer(total) do
+    :telemetry.execute(
+      [:engram, :voyage, :embed, :tokens],
+      %{total_tokens: total},
+      %{purpose: purpose}
+    )
+  end
+
+  defp emit_token_telemetry(_body, _purpose), do: :ok
 
   # Client-side rate limit. Enabled when `:voyage_rpm` is set (env: VOYAGE_RPM).
   # When the bucket is empty we synthesize the same `{:error, {429, body}}`

--- a/lib/engram/prom_ex/voyage.ex
+++ b/lib/engram/prom_ex/voyage.ex
@@ -7,6 +7,9 @@ defmodule Engram.PromEx.Voyage do
     * `[:engram, :voyage, :embed, :start]`
     * `[:engram, :voyage, :embed, :stop]` — `%{duration: native}`, metadata
       `%{status: :ok | :error, purpose: :index | :query}`
+    * `[:engram, :voyage, :embed, :tokens]` — `%{total_tokens: integer}`,
+      metadata `%{purpose: :index | :query}`. Only emitted on a successful
+      200 with `usage.total_tokens` present in the Voyage payload.
 
   Metrics:
 
@@ -19,6 +22,11 @@ defmodule Engram.PromEx.Voyage do
     * `engram_prom_ex_voyage_client_rate_limited_total` — counter for the
       synthetic-429 path (`[:engram, :embed, :client_rate_limited]`,
       already emitted by the adapter), tagged by `:purpose`.
+    * `engram_prom_ex_voyage_embed_tokens_total` — sum of `total_tokens`
+      per request, tagged by `:purpose`. Drives the Grafana tokens/min +
+      estimated-cost panels (the dashboard expr multiplies by the
+      per-1M-token price as a Grafana constant). NOT per-tenant — see
+      `Engram.UsageMeters` for tenant-attributed token accounting.
 
   Cardinality contract: only bounded labels (`status`, `purpose`). NEVER
   add `user_id`, `vault_id`, model strings, or any per-tenant identifier
@@ -28,6 +36,7 @@ defmodule Engram.PromEx.Voyage do
   use PromEx.Plugin
 
   @embed_stop_event [:engram, :voyage, :embed, :stop]
+  @embed_tokens_event [:engram, :voyage, :embed, :tokens]
   @client_rate_limited_event [:engram, :embed, :client_rate_limited]
 
   @impl true
@@ -60,6 +69,14 @@ defmodule Engram.PromEx.Voyage do
           event_name: @client_rate_limited_event,
           description:
             "Synthetic 429s from the local Hammer throttle — purpose-tagged for tuning :voyage_rpm vs :voyage_query_rpm.",
+          tags: [:purpose]
+        ),
+        sum(
+          metric_prefix ++ [:embed, :tokens, :total],
+          event_name: @embed_tokens_event,
+          measurement: :total_tokens,
+          description:
+            "Voyage embedding tokens billed, summed per request. Drives tokens/min and estimated-cost dashboard panels. Not per-tenant — see Engram.UsageMeters.",
           tags: [:purpose]
         )
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.381",
+      version: "0.5.382",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/embedders/voyage_test.exs
+++ b/test/engram/embedders/voyage_test.exs
@@ -136,6 +136,133 @@ defmodule Engram.Embedders.VoyageTest do
     end
   end
 
+  describe "token usage telemetry" do
+    test "emits [:engram, :voyage, :embed, :tokens] when response includes usage", %{
+      bypass: bypass
+    } do
+      Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->
+        body = %{
+          "data" => [%{"embedding" => [0.1, 0.2]}],
+          "model" => "voyage-4-large",
+          "usage" => %{"total_tokens" => 42}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end)
+
+      handler_id = {__MODULE__, :tokens_handler, System.unique_integer()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :voyage, :embed, :tokens],
+        fn _event, measurements, meta, _ ->
+          send(test_pid, {:voyage_tokens, measurements, meta})
+        end,
+        nil
+      )
+
+      try do
+        assert {:ok, _vectors} = Voyage.embed_texts(["hello"], purpose: :query)
+
+        assert_received {:voyage_tokens, %{total_tokens: 42}, %{purpose: :query}}
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
+
+    test "defaults purpose tag to :index when caller omits opts", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->
+        body = %{
+          "data" => [%{"embedding" => [0.1]}],
+          "usage" => %{"total_tokens" => 7}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end)
+
+      handler_id = {__MODULE__, :tokens_default_handler, System.unique_integer()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :voyage, :embed, :tokens],
+        fn _event, measurements, meta, _ ->
+          send(test_pid, {:voyage_tokens, measurements, meta})
+        end,
+        nil
+      )
+
+      try do
+        assert {:ok, _} = Voyage.embed_texts(["hello"])
+        assert_received {:voyage_tokens, %{total_tokens: 7}, %{purpose: :index}}
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
+
+    test "does NOT emit tokens event when response omits usage field", %{bypass: bypass} do
+      # Defensive: Voyage's documented embedding response always includes
+      # usage, but we should not crash or emit a 0-token event if a future
+      # endpoint shape drops it. Absence-of-event is the contract.
+      Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->
+        body = %{"data" => [%{"embedding" => [0.1]}]}
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end)
+
+      handler_id = {__MODULE__, :tokens_absent_handler, System.unique_integer()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :voyage, :embed, :tokens],
+        fn _event, measurements, meta, _ ->
+          send(test_pid, {:voyage_tokens, measurements, meta})
+        end,
+        nil
+      )
+
+      try do
+        assert {:ok, _} = Voyage.embed_texts(["hello"])
+        refute_received {:voyage_tokens, _, _}
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
+
+    test "does NOT emit tokens event on non-200 response", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->
+        Plug.Conn.send_resp(conn, 500, ~s({"error": "server"}))
+      end)
+
+      handler_id = {__MODULE__, :tokens_error_handler, System.unique_integer()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :voyage, :embed, :tokens],
+        fn _event, measurements, meta, _ ->
+          send(test_pid, {:voyage_tokens, measurements, meta})
+        end,
+        nil
+      )
+
+      try do
+        assert {:error, _} = Voyage.embed_texts(["hello"], retry: false)
+        refute_received {:voyage_tokens, _, _}
+      after
+        :telemetry.detach(handler_id)
+      end
+    end
+  end
+
   describe "embed_texts/2" do
     test "uses model override when provided", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->


### PR DESCRIPTION
## Summary

- Captures `usage.total_tokens` from Voyage's `/v1/embeddings` 200 response — previously discarded.
- Emits new telemetry event `[:engram, :voyage, :embed, :tokens]` with `%{total_tokens: integer}` measurement + `%{purpose: :index | :query}` metadata.
- Adds PromEx sum metric `engram_prom_ex_voyage_embed_tokens_total{purpose}` to `Engram.PromEx.Voyage` plugin.
- Bumps version 0.5.380 → 0.5.381.

Refs engram-app/engram-infra#345 — Voyage AI subtask follow-up.

## Why this exists

The Voyage v1 Grafana dashboard (engram-app/engram-infra#441) shows RPS / latency / error rate / synthetic-429 rate today, but cannot show **token spend** because the adapter discards the `usage` field. Voyage publishes no public usage/billing API, so this in-app capture is the only telemetry path for tokens/min + estimated-cost dashboard panels.

Next infra PR layers the tokens/min + estimated-\$/mo rows onto the dashboard using a per-1M-token-price Grafana constant.

## Contract

Absence-of-event when `usage` is missing — a future endpoint shape change should NOT silently emit zero-token events. The two defensive tests below pin this:

- Non-200 response → no event
- 200 response without `usage` field → no event

Cardinality preserved at the existing subscriber contract: `purpose` only (closed enum). No per-tenant labels — `Engram.UsageMeters` owns tenant-attributed accounting separately.

## Test plan

4 new tests in `test/engram/embedders/voyage_test.exs` under `describe \"token usage telemetry\"`:

- [x] Emits event with correct `total_tokens` measurement + `purpose: :query` metadata when caller passes `purpose: :query`.
- [x] Defaults `purpose` to `:index` when caller omits opts.
- [x] Does NOT emit event when response omits `usage` field.
- [x] Does NOT emit event on non-200 response.

`mix test test/engram/embedders/` + `test/engram/prom_ex/` → 35/35 pass. Consumers `test/engram/indexing_test.exs` + `test/engram/search_test.exs` → 26/26 pass. `mix format --check-formatted` + `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)