### PR TITLE
feat(host-rewrite): api./mcp.engram.page path rewrite plug + saas-only guard

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -594,9 +594,20 @@ if config_env() == :prod do
   # current `app.engram.page` host until DNS cutover) leave this unset
   # and the plug is a strict no-op. See EngramWeb.Plugs.HostRewrite.
   if System.get_env("ENGRAM_HOST_REWRITE_ENABLED") == "true" do
+    saas_only? = System.get_env("ENGRAM_SAAS_ONLY") == "true"
+
+    extra_hosts =
+      case System.get_env("ENGRAM_ALLOWED_EXTRA_HOSTS") do
+        nil -> []
+        "" -> []
+        s -> String.split(s, ",", trim: true)
+      end
+
     config :engram, :host_rewrite,
       api_host: System.get_env("ENGRAM_HOST_REWRITE_API_HOST", "api.engram.page"),
-      mcp_host: System.get_env("ENGRAM_HOST_REWRITE_MCP_HOST", "mcp.engram.page")
+      mcp_host: System.get_env("ENGRAM_HOST_REWRITE_MCP_HOST", "mcp.engram.page"),
+      reject_unknown_hosts: saas_only?,
+      allowed_extra_hosts: extra_hosts
   end
 
   # ## SSL Support

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -589,6 +589,16 @@ if config_env() == :prod do
     config :engram, :websocket_check_origin, phx_hosts.origins
   end
 
+  # Host-driven path rewrite for the dedicated `api.engram.page` and
+  # `mcp.engram.page` saas hosts. Opt-in: selfhost releases (and the
+  # current `app.engram.page` host until DNS cutover) leave this unset
+  # and the plug is a strict no-op. See EngramWeb.Plugs.HostRewrite.
+  if System.get_env("ENGRAM_HOST_REWRITE_ENABLED") == "true" do
+    config :engram, :host_rewrite,
+      api_host: System.get_env("ENGRAM_HOST_REWRITE_API_HOST", "api.engram.page"),
+      mcp_host: System.get_env("ENGRAM_HOST_REWRITE_MCP_HOST", "mcp.engram.page")
+  end
+
   # ## SSL Support
   #
   # To get SSL working, you will need to add the `https` key

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -68,6 +68,12 @@ defmodule EngramWeb.Endpoint do
   end
 
   plug Plug.RequestId
+  # The plug itself reads `Application.get_env(:engram, :host_rewrite, [])`
+  # at request time (NOT compile time) so the runtime env flag actually
+  # takes effect on a saas release and tests can mutate it via
+  # `Application.put_env`. When unset (default), the plug is a strict
+  # no-op — selfhost releases never touch the rewrite path.
+  plug EngramWeb.Plugs.HostRewrite
   # `log: false` suppresses Phoenix.Logger's default request log emission,
   # which interpolates conn.method + conn.request_path into the message body
   # (past the metadata-only RedactFilter). EngramWeb.RequestLogger replaces

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -44,6 +44,22 @@ defmodule EngramWeb.Endpoint do
 
   defp normalize_origin(origin) when is_binary(origin), do: origin
 
+  # RequestId runs FIRST so request_id is attached to every response —
+  # including 404/410 rejections from HostRewrite — for log correlation.
+  plug Plug.RequestId
+
+  # HostRewrite runs BEFORE Plug.Static so saas-only host rejection (410
+  # Gone on app.engram.page after the saas-only cutover) covers static
+  # assets too — otherwise `app.engram.page/favicon.ico` and
+  # `app.engram.page/assets/*.js` would be served by Plug.Static and
+  # leak stale bundles past the rewrite contract. The plug itself reads
+  # `Application.get_env(:engram, :host_rewrite, [])` at request time
+  # (NOT compile time) so the runtime env flag actually takes effect on
+  # a saas release and tests can mutate it via `Application.put_env`.
+  # When unset (default), the plug is a strict no-op — selfhost releases
+  # never touch the rewrite path.
+  plug EngramWeb.Plugs.HostRewrite
+
   # Serve SPA hashed assets at "/assets/*" from priv/static/app/assets.
   # Vite outputs hashed filenames so these can be served with long-lived
   # cache headers (handled by Plug.Static's default).
@@ -67,13 +83,6 @@ defmodule EngramWeb.Endpoint do
     plug Phoenix.Ecto.CheckRepoStatus, otp_app: :engram
   end
 
-  plug Plug.RequestId
-  # The plug itself reads `Application.get_env(:engram, :host_rewrite, [])`
-  # at request time (NOT compile time) so the runtime env flag actually
-  # takes effect on a saas release and tests can mutate it via
-  # `Application.put_env`. When unset (default), the plug is a strict
-  # no-op — selfhost releases never touch the rewrite path.
-  plug EngramWeb.Plugs.HostRewrite
   # `log: false` suppresses Phoenix.Logger's default request log emission,
   # which interpolates conn.method + conn.request_path into the message body
   # (past the metadata-only RedactFilter). EngramWeb.RequestLogger replaces

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -59,7 +59,21 @@ defmodule EngramWeb.Plugs.HostRewrite do
     end
   end
 
-  defp handle_mcp_host(conn), do: conn
+  @mcp_wellknown_prefixes [
+    "/.well-known/oauth-protected-resource",
+    "/.well-known/oauth-authorization-server"
+  ]
+
+  defp handle_mcp_host(conn) do
+    path = conn.request_path
+
+    cond do
+      Enum.any?(@mcp_wellknown_prefixes, &String.starts_with?(path, &1)) -> conn
+      String.starts_with?(path, "/api/mcp") -> conn
+      path == "/" or path == "" -> rewrite_path(conn, "/api/mcp/")
+      true -> reject(conn)
+    end
+  end
 
   defp under_any?(path, prefixes), do: Enum.any?(prefixes, &is_under?(path, &1))
 

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -44,8 +44,13 @@ defmodule EngramWeb.Plugs.HostRewrite do
   def init([]), do: :runtime
   def init(:runtime), do: :runtime
 
-  def init(opts) when is_list(opts),
-    do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
+  def init(opts) when is_list(opts) do
+    opts
+    |> Keyword.put_new(:api_host, nil)
+    |> Keyword.put_new(:mcp_host, nil)
+    |> Keyword.put_new(:reject_unknown_hosts, false)
+    |> Keyword.put_new(:allowed_extra_hosts, [])
+  end
 
   def call(conn, :runtime) do
     case Application.get_env(:engram, :host_rewrite, []) do
@@ -63,8 +68,35 @@ defmodule EngramWeb.Plugs.HostRewrite do
     cond do
       api_host && conn.host == api_host -> handle_api_host(conn)
       mcp_host && conn.host == mcp_host -> handle_mcp_host(conn)
-      true -> conn
+      true -> handle_unknown_host(conn, opts)
     end
+  end
+
+  # When `:reject_unknown_hosts` is true AND the request host is not on the
+  # explicit allowlist, return 410 Gone with a pointer to `api_host`. This
+  # guards saas AWS Phoenix from serving the stale bundled SPA on hosts like
+  # `app.engram.page` (which after DNS cutover should resolve to Cloudflare
+  # Pages, not the ALB). Selfhost never sets this flag — defaults to false.
+  defp handle_unknown_host(conn, opts) do
+    if opts[:reject_unknown_hosts] && conn.host not in opts[:allowed_extra_hosts] do
+      reject_unknown(conn, opts[:api_host])
+    else
+      conn
+    end
+  end
+
+  defp reject_unknown(conn, api_host) do
+    body =
+      Jason.encode!(%{
+        error: "gone",
+        message: "This host no longer serves the web app. Use #{api_host} for API access.",
+        api_host: api_host
+      })
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(410, body)
+    |> halt()
   end
 
   defp handle_api_host(conn) do

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -35,9 +35,28 @@ defmodule EngramWeb.Plugs.HostRewrite do
     embed-status
   )
 
-  def init(opts), do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
+  # `init/1` normalizes opts to a keyword list with `:api_host` and
+  # `:mcp_host` keys. The endpoint mounts this plug without explicit opts,
+  # so `init([])` yields the runtime-read sentinel `:runtime`; `call/2`
+  # then looks up `Application.get_env(:engram, :host_rewrite, [])`
+  # per-request. Direct unit tests pass an explicit opts list (which
+  # always has at least one key here) and short-circuit the runtime read.
+  def init([]), do: :runtime
+  def init(:runtime), do: :runtime
 
-  def call(conn, opts) do
+  def init(opts) when is_list(opts),
+    do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
+
+  def call(conn, :runtime) do
+    case Application.get_env(:engram, :host_rewrite, []) do
+      # Strict no-op when unset — selfhost releases never touch the
+      # rewrite path.
+      [] -> conn
+      opts when is_list(opts) -> call(conn, init(opts))
+    end
+  end
+
+  def call(conn, opts) when is_list(opts) do
     api_host = opts[:api_host]
     mcp_host = opts[:mcp_host]
 

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -1,0 +1,31 @@
+defmodule EngramWeb.Plugs.HostRewrite do
+  @moduledoc """
+  Host-driven path rewrite for the dedicated `api.engram.page` and
+  `mcp.engram.page` saas hosts. The same Phoenix endpoint also serves
+  selfhost (`engram.ax`) and the canonical `app.engram.page` host without
+  any rewrite. Behavior:
+
+    * `api.engram.page` — prefix `/api` if the path doesn't already start
+      with `/api`, `/socket`, `/webhooks`, or `/.well-known`. After rewrite,
+      reject anything that would have resolved outside those scopes.
+    * `mcp.engram.page` — pass `/.well-known/oauth-*` through unmodified;
+      otherwise prefix `/api/mcp` if not already prefixed; reject anything
+      that would resolve outside `/api/mcp/*` or `/.well-known/oauth-*`.
+    * Any other host — passthrough.
+
+  Config-driven via `Application.get_env(:engram, :host_rewrite)`:
+
+      config :engram, :host_rewrite, api_host: "api.engram.page", mcp_host: "mcp.engram.page"
+
+  When unset (default), the plug is a strict no-op — selfhost releases never
+  touch the rewrite path.
+  """
+  import Plug.Conn
+
+  def init(opts), do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
+
+  def call(conn, opts) do
+    _ = opts
+    conn
+  end
+end

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -35,6 +35,12 @@ defmodule EngramWeb.Plugs.HostRewrite do
     embed-status
   )
 
+  # Test-only accessor exposing the @api_top_segments allowlist so the
+  # router-derived regression test can compare against router.__routes__/0.
+  # Underscored name signals "do not call from production code".
+  @doc false
+  def __api_top_segments__, do: @api_top_segments
+
   # `init/1` normalizes opts to a keyword list with `:api_host` and
   # `:mcp_host` keys. The endpoint mounts this plug without explicit opts,
   # so `init([])` yields the runtime-read sentinel `:runtime`; `call/2`

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -23,7 +23,7 @@ defmodule EngramWeb.Plugs.HostRewrite do
   import Plug.Conn
 
   # Allowed top-level scopes that should pass through unmodified on
-  # `api.engram.page`. Matched with `is_under?/2` (exact match OR followed
+  # `api.engram.page`. Matched with `under?/2` (exact match OR followed
   # by `/`) so `/api-keys` does NOT match `/api` — `/api-keys` is a known
   # API segment that needs rewriting to `/api/api-keys`.
   @api_allowed_prefixes ~w(/api /socket /webhooks /.well-known)
@@ -132,11 +132,11 @@ defmodule EngramWeb.Plugs.HostRewrite do
     end
   end
 
-  defp under_any?(path, prefixes), do: Enum.any?(prefixes, &is_under?(path, &1))
+  defp under_any?(path, prefixes), do: Enum.any?(prefixes, &under?(path, &1))
 
   # True when `path` equals `prefix` or starts with `prefix <> "/"`.
   # Distinguishes `/api/...` (true) from `/api-keys` (false).
-  defp is_under?(path, prefix),
+  defp under?(path, prefix),
     do: path == prefix or String.starts_with?(path, prefix <> "/")
 
   defp known_api_segment?(path) do

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -147,7 +147,8 @@ defmodule EngramWeb.Plugs.HostRewrite do
 
   defp reject(conn) do
     conn
-    |> send_resp(404, "Not Found")
+    |> put_resp_content_type("application/json")
+    |> send_resp(404, ~s({"error":"not_found"}))
     |> halt()
   end
 end

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -22,10 +22,67 @@ defmodule EngramWeb.Plugs.HostRewrite do
   """
   import Plug.Conn
 
+  # Allowed top-level scopes that should pass through unmodified on
+  # `api.engram.page`. Matched with `is_under?/2` (exact match OR followed
+  # by `/`) so `/api-keys` does NOT match `/api` — `/api-keys` is a deep
+  # API candidate that needs rewriting to `/api/api-keys`.
+  @api_allowed_prefixes ~w(/api /socket /webhooks /.well-known)
+  # Every top-level segment under `scope "/api", EngramWeb` in router.ex.
+  # Missing entries silently 404 in prod — guarded by a regression test.
+  @api_top_segments ~w(
+    notes folders search vaults attachments oauth mcp auth admin billing
+    tasks health user me onboarding api-keys connections tags sync logs
+    embed-status
+  )
+
   def init(opts), do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
 
   def call(conn, opts) do
-    _ = opts
+    api_host = opts[:api_host]
+    mcp_host = opts[:mcp_host]
+
+    cond do
+      api_host && conn.host == api_host -> handle_api_host(conn)
+      mcp_host && conn.host == mcp_host -> handle_mcp_host(conn)
+      true -> conn
+    end
+  end
+
+  defp handle_api_host(conn) do
+    path = conn.request_path
+
+    cond do
+      path == "/" or path == "" -> reject(conn)
+      under_any?(path, @api_allowed_prefixes) -> conn
+      not deep_api_candidate?(path) -> reject(conn)
+      true -> rewrite_path(conn, "/api" <> path)
+    end
+  end
+
+  defp handle_mcp_host(conn), do: conn
+
+  defp under_any?(path, prefixes), do: Enum.any?(prefixes, &is_under?(path, &1))
+
+  # True when `path` equals `prefix` or starts with `prefix <> "/"`.
+  # Distinguishes `/api/...` (true) from `/api-keys` (false).
+  defp is_under?(path, prefix),
+    do: path == prefix or String.starts_with?(path, prefix <> "/")
+
+  defp deep_api_candidate?(path) do
+    case String.split(path, "/", trim: true) do
+      [head | _] -> head in @api_top_segments
+      _ -> false
+    end
+  end
+
+  defp rewrite_path(conn, new_path) do
+    new_info = new_path |> String.trim_leading("/") |> String.split("/", trim: true)
+    %{conn | request_path: new_path, path_info: new_info}
+  end
+
+  defp reject(conn) do
     conn
+    |> send_resp(404, "Not Found")
+    |> halt()
   end
 end

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -24,8 +24,8 @@ defmodule EngramWeb.Plugs.HostRewrite do
 
   # Allowed top-level scopes that should pass through unmodified on
   # `api.engram.page`. Matched with `is_under?/2` (exact match OR followed
-  # by `/`) so `/api-keys` does NOT match `/api` — `/api-keys` is a deep
-  # API candidate that needs rewriting to `/api/api-keys`.
+  # by `/`) so `/api-keys` does NOT match `/api` — `/api-keys` is a known
+  # API segment that needs rewriting to `/api/api-keys`.
   @api_allowed_prefixes ~w(/api /socket /webhooks /.well-known)
   # Every top-level segment under `scope "/api", EngramWeb` in router.ex.
   # Missing entries silently 404 in prod — guarded by a regression test.
@@ -105,7 +105,7 @@ defmodule EngramWeb.Plugs.HostRewrite do
     cond do
       path == "/" or path == "" -> reject(conn)
       under_any?(path, @api_allowed_prefixes) -> conn
-      not deep_api_candidate?(path) -> reject(conn)
+      not known_api_segment?(path) -> reject(conn)
       true -> rewrite_path(conn, "/api" <> path)
     end
   end
@@ -133,7 +133,7 @@ defmodule EngramWeb.Plugs.HostRewrite do
   defp is_under?(path, prefix),
     do: path == prefix or String.starts_with?(path, prefix <> "/")
 
-  defp deep_api_candidate?(path) do
+  defp known_api_segment?(path) do
     case String.split(path, "/", trim: true) do
       [head | _] -> head in @api_top_segments
       _ -> false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.383",
+      version: "0.5.384",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/host_rewrite_integration_test.exs
+++ b/test/engram_web/host_rewrite_integration_test.exs
@@ -3,7 +3,11 @@ defmodule EngramWeb.HostRewriteIntegrationTest do
 
   setup do
     prior = Application.get_env(:engram, :host_rewrite)
-    Application.put_env(:engram, :host_rewrite, api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+
+    Application.put_env(:engram, :host_rewrite,
+      api_host: "api.engram.page",
+      mcp_host: "mcp.engram.page"
+    )
 
     on_exit(fn ->
       case prior do

--- a/test/engram_web/host_rewrite_integration_test.exs
+++ b/test/engram_web/host_rewrite_integration_test.exs
@@ -26,4 +26,33 @@ defmodule EngramWeb.HostRewriteIntegrationTest do
     assert conn.status == 200
     assert Jason.decode!(conn.resp_body)["resource"]
   end
+
+  describe "saas-only mode" do
+    setup do
+      prior = Application.get_env(:engram, :host_rewrite)
+
+      Application.put_env(:engram, :host_rewrite,
+        api_host: "api.engram.page",
+        mcp_host: "mcp.engram.page",
+        reject_unknown_hosts: true,
+        allowed_extra_hosts: []
+      )
+
+      on_exit(fn -> Application.put_env(:engram, :host_rewrite, prior) end)
+      :ok
+    end
+
+    test "GET app.engram.page/anything returns 410 with api host pointer", %{conn: conn} do
+      conn = %{conn | host: "app.engram.page"} |> get("/anything")
+      assert conn.status == 410
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"] == "gone"
+      assert body["api_host"] == "api.engram.page"
+    end
+
+    test "GET api.engram.page/notes still rewrites under saas-only mode", %{conn: conn} do
+      conn = %{conn | host: "api.engram.page"} |> get("/notes")
+      assert conn.status in [401, 403]
+    end
+  end
 end

--- a/test/engram_web/host_rewrite_integration_test.exs
+++ b/test/engram_web/host_rewrite_integration_test.exs
@@ -1,0 +1,29 @@
+defmodule EngramWeb.HostRewriteIntegrationTest do
+  use EngramWeb.ConnCase, async: false
+
+  setup do
+    prior = Application.get_env(:engram, :host_rewrite)
+    Application.put_env(:engram, :host_rewrite, api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+
+    on_exit(fn ->
+      case prior do
+        nil -> Application.delete_env(:engram, :host_rewrite)
+        _ -> Application.put_env(:engram, :host_rewrite, prior)
+      end
+    end)
+
+    :ok
+  end
+
+  test "GET api.engram.page/notes hits the same controller as /api/notes", %{conn: conn} do
+    conn = %{conn | host: "api.engram.page"} |> get("/notes")
+    # 401/403 acceptable (unauth). 404 would mean the rewrite didn't land.
+    assert conn.status in [401, 403]
+  end
+
+  test "GET mcp.engram.page/.well-known/oauth-protected-resource succeeds", %{conn: conn} do
+    conn = %{conn | host: "mcp.engram.page"} |> get("/.well-known/oauth-protected-resource")
+    assert conn.status == 200
+    assert Jason.decode!(conn.resp_body)["resource"]
+  end
+end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -93,4 +93,55 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       end
     end
   end
+
+  describe "mcp.engram.page" do
+    setup do
+      opts = HostRewrite.init(api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+      {:ok, opts: opts}
+    end
+
+    test "passes /.well-known/oauth-* through unchanged", %{opts: opts} do
+      for path <- ["/.well-known/oauth-protected-resource",
+                   "/.well-known/oauth-protected-resource/api/mcp",
+                   "/.well-known/oauth-authorization-server"] do
+        conn =
+          conn(:get, path)
+          |> Map.put(:host, "mcp.engram.page")
+          |> HostRewrite.call(opts)
+
+        assert conn.request_path == path
+        refute conn.halted, "#{path} should not be halted"
+      end
+    end
+
+    test "prefixes /api/mcp on bare paths", %{opts: opts} do
+      conn =
+        conn(:post, "/")
+        |> Map.put(:host, "mcp.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.request_path == "/api/mcp/"
+      refute conn.halted
+    end
+
+    test "passes through paths already prefixed /api/mcp", %{opts: opts} do
+      conn =
+        conn(:post, "/api/mcp/foo")
+        |> Map.put(:host, "mcp.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.request_path == "/api/mcp/foo"
+      refute conn.halted
+    end
+
+    test "rejects anything else with 404", %{opts: opts} do
+      conn =
+        conn(:get, "/notes")
+        |> Map.put(:host, "mcp.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.halted
+      assert conn.status == 404
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -1,0 +1,26 @@
+defmodule EngramWeb.Plugs.HostRewriteTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias EngramWeb.Plugs.HostRewrite
+
+  describe "selfhost / unconfigured passthrough" do
+    test "with no config, leaves conn untouched regardless of host" do
+      conn =
+        conn(:get, "/api/notes")
+        |> Map.put(:host, "engram.ax")
+
+      assert HostRewrite.call(conn, HostRewrite.init([])) == conn
+    end
+
+    test "with config but unmatched host, leaves conn untouched" do
+      opts = HostRewrite.init(api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+
+      conn =
+        conn(:get, "/api/notes")
+        |> Map.put(:host, "engram.ax")
+
+      assert HostRewrite.call(conn, opts) == conn
+    end
+  end
+end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -23,4 +23,74 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       assert HostRewrite.call(conn, opts) == conn
     end
   end
+
+  describe "api.engram.page" do
+    setup do
+      opts = HostRewrite.init(api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+      {:ok, opts: opts}
+    end
+
+    test "prefixes /api on bare path", %{opts: opts} do
+      conn =
+        conn(:get, "/notes/abc")
+        |> Map.put(:host, "api.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.request_path == "/api/notes/abc"
+      assert conn.path_info == ["api", "notes", "abc"]
+      refute conn.halted
+    end
+
+    test "passes through paths already prefixed /api", %{opts: opts} do
+      conn =
+        conn(:get, "/api/notes/abc")
+        |> Map.put(:host, "api.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.request_path == "/api/notes/abc"
+      refute conn.halted
+    end
+
+    test "passes through /socket, /webhooks, /.well-known", %{opts: opts} do
+      for path <- ["/socket/websocket", "/webhooks/paddle", "/.well-known/oauth-authorization-server"] do
+        conn =
+          conn(:get, path)
+          |> Map.put(:host, "api.engram.page")
+          |> HostRewrite.call(opts)
+
+        assert conn.request_path == path
+        refute conn.halted, "#{path} should not be halted"
+      end
+    end
+
+    test "rejects paths under SPA root with 404", %{opts: opts} do
+      conn =
+        conn(:get, "/login")
+        |> Map.put(:host, "api.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.halted
+      assert conn.status == 404
+    end
+
+    # Regression: every top-level segment under `scope "/api"` in router.ex
+    # must be in @api_top_segments — missing entries = silent 404 in prod.
+    test "rewrites all router-known /api top segments", %{opts: opts} do
+      segments = ~w(
+        notes folders search vaults attachments oauth mcp auth admin billing
+        tasks health user me onboarding api-keys connections tags sync logs
+        embed-status
+      )
+
+      for seg <- segments do
+        conn =
+          conn(:get, "/" <> seg)
+          |> Map.put(:host, "api.engram.page")
+          |> HostRewrite.call(opts)
+
+        refute conn.halted, "/#{seg} on api.engram.page should be rewritten, not rejected"
+        assert conn.request_path == "/api/" <> seg
+      end
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -217,4 +217,27 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       refute out.halted
     end
   end
+
+  describe "router/@api_top_segments coherence" do
+    test "@api_top_segments covers every router-registered /api top segment" do
+      # Walk the router and confirm every distinct /api/<seg> top-level
+      # segment is present in @api_top_segments. A missing entry would
+      # silently 404 on api.engram.page in prod — this test fails loudly
+      # the moment a new /api scope is added without updating the plug.
+      router_segments =
+        EngramWeb.Router.__routes__()
+        |> Enum.filter(&String.starts_with?(&1.path, "/api/"))
+        |> Enum.map(&(&1.path |> String.split("/", trim: true) |> Enum.at(1)))
+        |> Enum.reject(&is_nil/1)
+        |> MapSet.new()
+
+      plug_segments = MapSet.new(HostRewrite.__api_top_segments__())
+
+      missing = MapSet.difference(router_segments, plug_segments)
+
+      assert MapSet.size(missing) == 0,
+             "Router has /api routes for segments [#{Enum.join(Enum.to_list(missing), ", ")}] but " <>
+               "plug @api_top_segments doesn't list them — silent 404 in prod"
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -52,7 +52,11 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
     end
 
     test "passes through /socket, /webhooks, /.well-known", %{opts: opts} do
-      for path <- ["/socket/websocket", "/webhooks/paddle", "/.well-known/oauth-authorization-server"] do
+      for path <- [
+            "/socket/websocket",
+            "/webhooks/paddle",
+            "/.well-known/oauth-authorization-server"
+          ] do
         conn =
           conn(:get, path)
           |> Map.put(:host, "api.engram.page")
@@ -101,9 +105,11 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
     end
 
     test "passes /.well-known/oauth-* through unchanged", %{opts: opts} do
-      for path <- ["/.well-known/oauth-protected-resource",
-                   "/.well-known/oauth-protected-resource/api/mcp",
-                   "/.well-known/oauth-authorization-server"] do
+      for path <- [
+            "/.well-known/oauth-protected-resource",
+            "/.well-known/oauth-protected-resource/api/mcp",
+            "/.well-known/oauth-authorization-server"
+          ] do
         conn =
           conn(:get, path)
           |> Map.put(:host, "mcp.engram.page")

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -144,4 +144,77 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       assert conn.status == 404
     end
   end
+
+  describe "reject_unknown_hosts" do
+    test "with reject_unknown_hosts=false (default), unknown host passes through" do
+      opts = HostRewrite.init(api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+      conn = conn(:get, "/anything") |> Map.put(:host, "app.engram.page")
+      out = HostRewrite.call(conn, opts)
+
+      assert out == conn
+      refute out.halted
+    end
+
+    test "with reject_unknown_hosts=true, unknown host returns 410 Gone" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true
+        )
+
+      conn = conn(:get, "/anything") |> Map.put(:host, "app.engram.page")
+      out = HostRewrite.call(conn, opts)
+
+      assert out.halted
+      assert out.status == 410
+      body = Jason.decode!(out.resp_body)
+      assert body["error"] == "gone"
+      assert body["api_host"] == "api.engram.page"
+      assert body["message"] =~ "api.engram.page"
+    end
+
+    test "with reject_unknown_hosts=true, api_host still rewrites normally" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true
+        )
+
+      conn = conn(:get, "/notes") |> Map.put(:host, "api.engram.page")
+      out = HostRewrite.call(conn, opts)
+
+      assert out.request_path == "/api/notes"
+      refute out.halted
+    end
+
+    test "with reject_unknown_hosts=true and allowed_extra_hosts, listed host passes through" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true,
+          allowed_extra_hosts: ["health.internal", "alb-probe.local"]
+        )
+
+      conn = conn(:get, "/health") |> Map.put(:host, "health.internal")
+      out = HostRewrite.call(conn, opts)
+
+      refute out.halted
+      assert out == conn
+    end
+
+    test "with reject_unknown_hosts=true, selfhost-style empty config remains passthrough" do
+      # This proves the no-op contract: passing [] (selfhost) ignores the
+      # reject_unknown_hosts setting because api_host is nil → dispatch skips
+      # the rejection branch.
+      opts = HostRewrite.init([])
+      conn = conn(:get, "/anything") |> Map.put(:host, "engram.ax")
+      out = HostRewrite.call(conn, opts)
+
+      assert out == conn
+      refute out.halted
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -1,6 +1,6 @@
 defmodule EngramWeb.Plugs.HostRewriteTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+  import Plug.Test
 
   alias EngramWeb.Plugs.HostRewrite
 


### PR DESCRIPTION
## Summary

Phase A of the Frontend Eject to Cloudflare Pages migration (spec + plan in workspace `2026-06-10-frontend-eject-cloudflare-pages-*`).

New `EngramWeb.Plugs.HostRewrite` plug rewrites `api.engram.page/notes` → `/api/notes` and `mcp.engram.page/` → `/api/mcp/` for the upcoming saas FE eject to Cloudflare Pages. Includes a saas-only guard (`ENGRAM_SAAS_ONLY=true`) that returns 410 Gone with JSON pointing at `api.engram.page` for any unknown host hitting the AWS Phoenix release — defense against direct ALB hits after `app.engram.page` DNS moves to CF Pages.

**Disabled by default.** Selfhost releases never set `ENGRAM_HOST_REWRITE_ENABLED` so the plug is a strict no-op via a `:runtime` sentinel pattern — zero behavior change on selfhost.

## Env vars (all opt-in, none required for selfhost)

| Var | Default | Effect |
|---|---|---|
| `ENGRAM_HOST_REWRITE_ENABLED` | unset | When `true`, populates `config :engram, :host_rewrite` keyword list and activates the plug. |
| `ENGRAM_HOST_REWRITE_API_HOST` | `api.engram.page` | Host that triggers `/api/*` path prefix |
| `ENGRAM_HOST_REWRITE_MCP_HOST` | `mcp.engram.page` | Host that triggers `/api/mcp/*` path prefix |
| `ENGRAM_SAAS_ONLY` | unset | When `true`, unknown hosts get 410 Gone |
| `ENGRAM_ALLOWED_EXTRA_HOSTS` | unset | Comma-separated exceptions to saas-only rejection |

## Plug pipeline order

`Plug.RequestId` → `EngramWeb.Plugs.HostRewrite` → `Plug.Static (×2)` → `Plug.Telemetry` → ...

HostRewrite runs BEFORE `Plug.Static` so saas-only 410 also covers `/favicon.ico` + `/assets/*.js`. RequestId still covers rejections for log correlation.

## Tests

- 17 plug unit tests covering: selfhost passthrough, api.engram.page rewrite + restrict, mcp.engram.page rewrite + well-known, reject_unknown_hosts (410), router-derived coherence check for `@api_top_segments`
- 4 integration tests through the full endpoint pipeline
- Full suite: 2491 tests passing

## Test plan

- [x] `mix test test/engram_web/plugs/host_rewrite_test.exs` — 17 pass
- [x] `mix test test/engram_web/host_rewrite_integration_test.exs` — 4 pass
- [x] `mix test` full suite — 2491 pass, 0 failures
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format` / Credo / Sobelow — clean
- [ ] Manual: verify env-var-unset = no behavior change on staging (no env flips this PR)

## Notes

- WellKnownController already derives host from `conn.host` against `:cors_origin` allowlist (PR #340) — Phase B will add `mcp.engram.page` + `api.engram.page` to that allowlist, which makes MCP discovery on the new host work automatically.
- Phase F will set the env vars in ECS prod. This PR is dormant code until then.
- One pre-existing flake in `accounts_suspend_auth_test.exs` (Ecto sandbox contention, passes in isolation) — orthogonal, will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)