### PR TITLE
feat(cors): ENGRAM_SAAS_FRONTEND_ORIGINS env for CF Pages allowlist

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -584,9 +584,29 @@ if config_env() == :prod do
   # CORS and WebSocket origin — only lock down when PHX_HOST is explicitly set.
   # Without it (CI, local dev), defaults apply: CORS allows "*", WS allows all.
   # See Engram.HostOrigins for parsing rules (CSV, scheme expansion, dedup).
+  #
+  # ENGRAM_SAAS_FRONTEND_ORIGINS appends extra origins (comma-separated) for the
+  # Cloudflare Pages saas frontend at app.engram.page + its preview deploys at
+  # *.engram-frontend.pages.dev. Unset on selfhost (same-origin) → no-op.
   if phx_hosts do
-    config :engram, :cors_origin, phx_hosts.origins
-    config :engram, :websocket_check_origin, phx_hosts.origins
+    extra_origins =
+      case System.get_env("ENGRAM_SAAS_FRONTEND_ORIGINS") do
+        nil ->
+          []
+
+        "" ->
+          []
+
+        s ->
+          s
+          |> String.split(",", trim: true)
+          |> Enum.map(&String.trim/1)
+          |> Enum.reject(&(&1 == ""))
+      end
+
+    cors_origins = phx_hosts.origins ++ extra_origins
+    config :engram, :cors_origin, cors_origins
+    config :engram, :websocket_check_origin, cors_origins
   end
 
   # ## SSL Support

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.383",
+      version: "0.5.385",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/plugs/cors_test.exs
+++ b/test/engram_web/plugs/cors_test.exs
@@ -73,4 +73,72 @@ defmodule EngramWeb.Plugs.CORSTest do
 
     assert get_resp_header(conn, "access-control-allow-origin") == ["http://engram.ax"]
   end
+
+  describe "ENGRAM_SAAS_FRONTEND_ORIGINS extras (Cloudflare Pages saas frontend)" do
+    # These tests simulate the post-cutover allowlist shape: the original
+    # phx_hosts origins PLUS the saas frontend origin (app.engram.page) and
+    # the Cloudflare Pages preview-deploy origin. ENGRAM_SAAS_FRONTEND_ORIGINS
+    # is consumed in config/runtime.exs at boot; here we set the final merged
+    # allowlist directly via :cors_origin to assert the plug's runtime behavior.
+
+    setup do
+      Application.put_env(:engram, :cors_origin, [
+        "https://api.engram.page",
+        "https://app.engram.page",
+        "https://engram-frontend.pages.dev"
+      ])
+
+      on_exit(fn -> Application.delete_env(:engram, :cors_origin) end)
+      :ok
+    end
+
+    test "echoes Origin for app.engram.page (saas frontend)" do
+      conn =
+        build_conn()
+        |> put_req_header("origin", "https://app.engram.page")
+        |> options("/api/health")
+
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               "https://app.engram.page"
+             ]
+    end
+
+    test "echoes Origin for Cloudflare Pages preview-deploy origin" do
+      conn =
+        build_conn()
+        |> put_req_header("origin", "https://engram-frontend.pages.dev")
+        |> options("/api/health")
+
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               "https://engram-frontend.pages.dev"
+             ]
+    end
+
+    test "rejects (does not echo) Origin not in extended allowlist" do
+      conn =
+        build_conn()
+        |> put_req_header("origin", "https://evil.example.com")
+        |> options("/api/health")
+
+      refute get_resp_header(conn, "access-control-allow-origin") == [
+               "https://evil.example.com"
+             ]
+
+      # Falls back to first allowlist entry instead.
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               "https://api.engram.page"
+             ]
+    end
+
+    test "still echoes original phx_hosts origin (api.engram.page)" do
+      conn =
+        build_conn()
+        |> put_req_header("origin", "https://api.engram.page")
+        |> options("/api/health")
+
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               "https://api.engram.page"
+             ]
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Phase B of the Frontend Eject to Cloudflare Pages migration (spec + plan in workspace `2026-06-10-frontend-eject-cloudflare-pages-*`).

New `ENGRAM_SAAS_FRONTEND_ORIGINS` env var (comma-separated) appends extra origins to BOTH the CORS allowlist (`:cors_origin`) and the WebSocket origin check (`:websocket_check_origin`) — same merged list, no drift. After Phase M cutover, prod will set this to `https://app.engram.page,https://engram-frontend.pages.dev` so the CF-Pages-hosted SPA can call the AWS-hosted API cross-origin.

**No-op when unset.** Selfhost releases never set this env var → behavior unchanged.

## Changes

- `config/runtime.exs` — replace existing `:cors_origin` and `:websocket_check_origin` assignments with a single `cors_origins = phx_hosts.origins ++ extra_origins` list fed to both. Robust comma parse: `"  ,, "` → `[]`.
- `test/engram_web/plugs/cors_test.exs` — 4 new tests in a new `describe` block: app.engram.page echo, pages.dev echo, evil-origin reject (verifies first-allowlist fallback), original phx_hosts origin still echoed.

## Test plan

- [x] `mix test test/engram_web/plugs/cors_test.exs` — 10 tests pass (was 6)
- [x] `mix test --max-failures 5` — 2474 pass, 0 failures
- [x] `mix compile --warnings-as-errors` — clean
- [ ] Manual: env-unset on staging produces no behavior change (no env flip this PR)

## Depends on

Independent of Phase A PR #512 (HostRewrite). Both must merge before Phase F sets the env vars in ECS prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)