### PR TITLE
feat(frontend): async config + apiBase/wsBase + /config.json fallback

### DIFF
--- a/frontend/src/api/base.test.tsx
+++ b/frontend/src/api/base.test.tsx
@@ -1,0 +1,99 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ConfigProvider } from '@/config-context'
+import { useApiUrl, useWsUrl, joinApiUrl, joinWsUrl } from './base'
+import type { EngramConfig } from '@/config'
+
+function makeConfig(apiBase: string, wsBase = ''): EngramConfig {
+  return {
+    authProvider: 'local',
+    clerkPublishableKey: '',
+    billingEnabled: false,
+    clerkWaitlistMode: false,
+    apiBase,
+    wsBase,
+  }
+}
+
+function ApiUrlProbe({ path }: { path: string }) {
+  const apiUrl = useApiUrl()
+  return <span data-testid="out">{apiUrl(path)}</span>
+}
+
+function WsUrlProbe({ path }: { path: string }) {
+  const wsUrl = useWsUrl()
+  return <span data-testid="out">{wsUrl(path)}</span>
+}
+
+describe('joinApiUrl (pure)', () => {
+  it('selfhost (apiBase=""): leaves /api/notes intact', () => {
+    expect(joinApiUrl('', '/api/notes')).toBe('/api/notes')
+  })
+
+  it('saas: strips /api prefix and prepends apiBase', () => {
+    expect(joinApiUrl('https://api.engram.page', '/api/notes')).toBe('https://api.engram.page/notes')
+  })
+
+  it('saas: leaves a non-/api path intact under apiBase', () => {
+    expect(joinApiUrl('https://api.engram.page', '/health')).toBe('https://api.engram.page/health')
+  })
+})
+
+describe('joinWsUrl (pure)', () => {
+  it('selfhost (wsBase=""): returns path unchanged', () => {
+    expect(joinWsUrl('', '/socket')).toBe('/socket')
+  })
+
+  it('saas: prepends wsBase', () => {
+    expect(joinWsUrl('wss://api.engram.page', '/socket')).toBe('wss://api.engram.page/socket')
+  })
+})
+
+describe('useApiUrl', () => {
+  it('selfhost (apiBase=""): leaves /api/notes intact', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('')}>
+        <ApiUrlProbe path="/api/notes" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('/api/notes')
+  })
+
+  it('saas: strips /api prefix and prepends apiBase', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('https://api.engram.page')}>
+        <ApiUrlProbe path="/api/notes" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('https://api.engram.page/notes')
+  })
+
+  it('saas: passes a non-/api path through unchanged after prepending', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('https://api.engram.page')}>
+        <ApiUrlProbe path="/health" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('https://api.engram.page/health')
+  })
+})
+
+describe('useWsUrl', () => {
+  it('selfhost (wsBase=""): returns path unchanged', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('', '')}>
+        <WsUrlProbe path="/socket" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('/socket')
+  })
+
+  it('saas: prepends wsBase', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('', 'wss://api.engram.page')}>
+        <WsUrlProbe path="/socket" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('wss://api.engram.page/socket')
+  })
+})

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -25,11 +25,10 @@ export function useWsUrl(): (path: string) => string {
 }
 
 // Module-level base setters — parallel the existing setTokenGetter
-// pattern in `./client`. A small <ConfigBaseInstaller> component (mounted
-// once at app root inside ConfigProvider) wires apiBase/wsBase from the
-// resolved config so non-React utilities like the singleton `api` object
-// and `connectChannel(...)` can compose URLs without dragging a hook
-// dependency into every call site.
+// pattern in `./client`. `BootstrapGate` in main.tsx wires apiBase/wsBase
+// inline from the resolved config so non-React utilities like the singleton
+// `api` object and `connectChannel(...)` can compose URLs without dragging
+// a hook dependency into every call site.
 let _apiBase = ''
 let _wsBase = ''
 

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -1,0 +1,50 @@
+import { useConfig } from '@/config-context'
+
+// Combines the configured apiBase with a path. Strips the `/api` prefix
+// on saas (where apiBase = `https://api.engram.page` and the host-rewrite
+// plug prefixes `/api` server-side) and keeps it on selfhost (apiBase
+// = "", same-origin Phoenix-hosted SPA).
+export function joinApiUrl(apiBase: string, path: string): string {
+  if (!apiBase) return path
+  const stripped = path.startsWith('/api/') ? path.slice(4) : path
+  return apiBase + stripped
+}
+
+export function joinWsUrl(wsBase: string, path: string): string {
+  return wsBase ? wsBase + path : path
+}
+
+export function useApiUrl(): (path: string) => string {
+  const { apiBase } = useConfig()
+  return (path: string) => joinApiUrl(apiBase, path)
+}
+
+export function useWsUrl(): (path: string) => string {
+  const { wsBase } = useConfig()
+  return (path: string) => joinWsUrl(wsBase, path)
+}
+
+// Module-level base setters — parallel the existing setTokenGetter
+// pattern in `./client`. A small <ConfigBaseInstaller> component (mounted
+// once at app root inside ConfigProvider) wires apiBase/wsBase from the
+// resolved config so non-React utilities like the singleton `api` object
+// and `connectChannel(...)` can compose URLs without dragging a hook
+// dependency into every call site.
+let _apiBase = ''
+let _wsBase = ''
+
+export function setApiBase(v: string) {
+  _apiBase = v
+}
+
+export function setWsBase(v: string) {
+  _wsBase = v
+}
+
+export function getApiBase(): string {
+  return _apiBase
+}
+
+export function getWsBase(): string {
+  return _wsBase
+}

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -1,5 +1,6 @@
 import { Socket, Channel } from 'phoenix'
 import type { QueryClient } from '@tanstack/react-query'
+import { getWsBase, joinWsUrl } from './base'
 
 let socket: Socket | null = null
 let channel: Channel | null = null
@@ -65,7 +66,7 @@ export async function connectChannel({ userId, vaultId, getToken, queryClient }:
 
   const token = await getToken()
 
-  socket = new Socket('/socket', {
+  socket = new Socket(joinWsUrl(getWsBase(), '/socket'), {
     params: { token: token ?? '' },
   })
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import { getActiveVaultId } from './active-vault'
+import { getApiBase, joinApiUrl } from './base'
 
 // Module-level token getter — set by AuthTokenProvider component
 let tokenGetter: (() => Promise<string | null>) | null = null
@@ -50,7 +51,11 @@ async function authFetch(path: string, options: RequestInit = {}): Promise<Respo
     headers.set('X-Vault-ID', String(vaultId))
   }
 
-  const response = await fetch(`/api${path}`, { ...options, headers })
+  // joinApiUrl handles both same-origin (selfhost) and cross-origin
+  // (saas, `https://api.engram.page`). For selfhost apiBase is "" so
+  // this composes to `/api${path}` identically to the pre-eject shape.
+  const url = joinApiUrl(getApiBase(), `/api${path}`)
+  const response = await fetch(url, { ...options, headers })
 
   if (!response.ok) {
     const body = await response.json().catch(() => ({}))

--- a/frontend/src/api/oauth.ts
+++ b/frontend/src/api/oauth.ts
@@ -1,4 +1,5 @@
 import { api } from './client'
+import { getApiBase, joinApiUrl } from './base'
 
 export interface OAuthClientMetadata {
   client_id: string
@@ -26,7 +27,8 @@ export interface OAuthConsentResponse {
 }
 
 export async function fetchOAuthClient(clientId: string): Promise<OAuthClientMetadata> {
-  return fetch(`/api/oauth/clients/${encodeURIComponent(clientId)}`).then(async (res) => {
+  const url = joinApiUrl(getApiBase(), `/api/oauth/clients/${encodeURIComponent(clientId)}`)
+  return fetch(url).then(async (res) => {
     if (!res.ok) {
       throw new Error(`oauth client lookup failed: ${res.status}`)
     }

--- a/frontend/src/auth/clerk-auth-provider.tsx
+++ b/frontend/src/auth/clerk-auth-provider.tsx
@@ -7,12 +7,10 @@ import { rememberSignupUser } from './signup-rejection'
 import { useClearQueryCacheOnUserChange } from './use-clear-query-cache-on-user-change'
 import { setTokenGetter } from '../api/client'
 import { queryClient } from '../api/query-client'
-import { config } from '../config'
-import { router } from '../router'
+import { useConfig } from '../config-context'
+import { getAppRouter } from '../router'
 import { ROUTES } from '../routes'
 import { useTheme } from '../theme/theme-provider'
-
-const clerkPubKey = config.clerkPublishableKey
 
 // Clerk passes the post-auth redirect target as an ABSOLUTE URL when it crosses
 // (or might cross) origins — including the in-origin case after an OAuth
@@ -104,6 +102,8 @@ function ClerkAdapterInner({ children }: { children: React.ReactNode }) {
 
 export default function ClerkAuthProvider({ children }: { children: React.ReactNode }) {
   const { resolved } = useTheme()
+  const config = useConfig()
+  const clerkPubKey = config.clerkPublishableKey
 
   const appearance = useMemo(
     () => ({
@@ -133,8 +133,8 @@ export default function ClerkAuthProvider({ children }: { children: React.ReactN
       signUpUrl={signUpUrl}
       waitlistUrl={waitlistUrl}
       afterSignOutUrl={ROUTES.SIGN_IN}
-      routerPush={(to) => router.navigate(toRelativeUrl(to))}
-      routerReplace={(to) => router.navigate(toRelativeUrl(to), { replace: true })}
+      routerPush={(to) => getAppRouter().navigate(toRelativeUrl(to))}
+      routerReplace={(to) => getAppRouter().navigate(toRelativeUrl(to), { replace: true })}
     >
       <ClerkAdapterInner>{children}</ClerkAdapterInner>
     </ClerkProvider>

--- a/frontend/src/auth/local-auth-provider.tsx
+++ b/frontend/src/auth/local-auth-provider.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { AuthContext, type AuthAdapter } from './auth-context'
 import { useClearQueryCacheOnUserChange } from './use-clear-query-cache-on-user-change'
 import { setTokenGetter } from '../api/client'
+import { getApiBase, joinApiUrl } from '../api/base'
 import { queryClient } from '../api/query-client'
 
 function parseJwtPayload(token: string): Record<string, unknown> | null {
@@ -29,7 +30,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
     // first line of defense (avoids the round-trip + an extra DB rotate).
     if (refreshPromiseRef.current) return refreshPromiseRef.current
 
-    const promise = fetch('/api/auth/refresh', {
+    const promise = fetch(joinApiUrl(getApiBase(), '/api/auth/refresh'), {
       method: 'POST',
       credentials: 'include',
     })
@@ -86,7 +87,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
   useClearQueryCacheOnUserChange(queryClient, user?.email)
 
   const login = useCallback(async (email: string, password: string) => {
-    const res = await fetch('/api/auth/login', {
+    const res = await fetch(joinApiUrl(getApiBase(), '/api/auth/login'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -108,7 +109,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
     // arrived via `/signup?invite=…` we pass the token here so the backend
     // can atomically redeem it.
     const body = invite ? { email, password, invite } : { email, password }
-    const res = await fetch('/api/auth/register', {
+    const res = await fetch(joinApiUrl(getApiBase(), '/api/auth/register'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -126,7 +127,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
   }, [])
 
   const logout = useCallback(async () => {
-    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch((err) => console.error('Logout request failed:', err))
+    await fetch(joinApiUrl(getApiBase(), '/api/auth/logout'), { method: 'POST', credentials: 'include' }).catch((err) => console.error('Logout request failed:', err))
     setAccessToken(null)
     setUser(null)
   }, [])

--- a/frontend/src/auth/local-sign-up.tsx
+++ b/frontend/src/auth/local-sign-up.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FormEvent } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router'
 import { ROUTES } from '../routes'
+import { getApiBase, joinApiUrl } from '../api/base'
 import { useAuthAdapter } from './use-auth-adapter'
 import { useBootstrap } from './use-bootstrap'
 import AuthLayout from './auth-layout'
@@ -37,7 +38,7 @@ export default function LocalSignUp() {
       setInvitePreview(null)
       return
     }
-    fetch(`/api/auth/invite/${encodeURIComponent(invite)}`)
+    fetch(joinApiUrl(getApiBase(), `/api/auth/invite/${encodeURIComponent(invite)}`))
       .then((r) => r.json())
       .then((p: InvitePreview) => setInvitePreview(p))
       .catch(() => setInvitePreview({ valid: false }))

--- a/frontend/src/auth/sign-in.tsx
+++ b/frontend/src/auth/sign-in.tsx
@@ -1,21 +1,22 @@
 import { lazy, Suspense } from 'react'
 import { useSearchParams } from 'react-router'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import AuthLayout from './auth-layout'
 import SignupRejectionNotice from './signup-rejection-notice'
 import { safeReturnTo } from './safe-return-to'
 
-const isClerk = config.authProvider === 'clerk'
-
-const ClerkSignIn = isClerk ? lazy(() => import('./clerk-sign-in')) : null
-
+// Both lazy refs are declared at module scope so React preserves the lazy
+// component identity across renders. Only one is actually rendered per
+// run — the auth provider is resolved at config load and never changes.
+const ClerkSignIn = lazy(() => import('./clerk-sign-in'))
 const LocalSignIn = lazy(() => import('./local-sign-in'))
 
 export default function SignInPage() {
   const [searchParams] = useSearchParams()
   const returnTo = safeReturnTo(searchParams.get('return_to'))
+  const config = useConfig()
 
-  if (ClerkSignIn) {
+  if (config.authProvider === 'clerk') {
     return (
       <AuthLayout>
         <div className="flex w-full flex-col items-center">

--- a/frontend/src/auth/sign-up.tsx
+++ b/frontend/src/auth/sign-up.tsx
@@ -1,27 +1,25 @@
 import { lazy, Suspense } from 'react'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import AuthLayout from './auth-layout'
 
-const isClerk = config.authProvider === 'clerk'
-
-const ClerkSignUpPage = isClerk
-  ? lazy(() =>
-      import('@clerk/react').then((mod) => ({
-        default: () => (
-          <AuthLayout>
-            <mod.SignUp routing="hash" forceRedirectUrl="/" />
-          </AuthLayout>
-        ),
-      }))
-    )
-  : null
+const ClerkSignUpPage = lazy(() =>
+  import('@clerk/react').then((mod) => ({
+    default: () => (
+      <AuthLayout>
+        <mod.SignUp routing="hash" forceRedirectUrl="/" />
+      </AuthLayout>
+    ),
+  })),
+)
 
 const LocalSignUp = lazy(() => import('./local-sign-up'))
 
 export default function SignUpPage() {
+  const config = useConfig()
+  const isClerk = config.authProvider === 'clerk'
   return (
     <Suspense fallback={<p>Loading...</p>}>
-      {ClerkSignUpPage ? <ClerkSignUpPage /> : <LocalSignUp />}
+      {isClerk ? <ClerkSignUpPage /> : <LocalSignUp />}
     </Suspense>
   )
 }

--- a/frontend/src/auth/signup-rejection.ts
+++ b/frontend/src/auth/signup-rejection.ts
@@ -4,6 +4,8 @@
 // /sign-in with no explanation. We remember the just-created Clerk user id here
 // so the sign-in page can ask the backend why, and show a real message.
 
+import { getApiBase, joinApiUrl } from '../api/base'
+
 const KEY = 'engram:pending-signup'
 const WINDOW_MS = 2 * 60 * 1000
 
@@ -38,7 +40,9 @@ export async function fetchSignupRejection(
   clerkUserId: string,
 ): Promise<SignupRejectionReason | null> {
   try {
-    const res = await fetch(`/api/auth/signup-rejection?clerk_id=${encodeURIComponent(clerkUserId)}`)
+    const res = await fetch(
+      joinApiUrl(getApiBase(), `/api/auth/signup-rejection?clerk_id=${encodeURIComponent(clerkUserId)}`),
+    )
     if (!res.ok) return null
     const body = (await res.json()) as { reason?: SignupRejectionReason | null }
     return body.reason ?? null

--- a/frontend/src/auth/use-bootstrap.ts
+++ b/frontend/src/auth/use-bootstrap.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { config } from '../config'
+import { useContext, useEffect, useState } from 'react'
+import { ConfigContext } from '../config-context'
 
 export interface Bootstrap {
   bootstrap_pending: boolean
@@ -13,11 +13,11 @@ export interface Bootstrap {
 // resolves, avoiding the default→correct flash on every navigation.
 export type BootstrapState = Bootstrap | null | undefined
 
-// Seed from Phoenix's SSR-injected runtime config when available. In prod
-// this means useBootstrap() is synchronous on first paint — no fetch, no
-// flash. In dev (Vite serves index.html, no injection) `config.bootstrap`
-// is undefined and we fall back to fetching the public endpoint.
-let cached: Bootstrap | null | undefined = config.bootstrap
+// Module-level cache so concurrent hook callers share one fetch + result.
+// Seeded from config.bootstrap on first hook invocation (the seed is
+// stable per page load — config is resolved once during Suspense gate).
+let cached: Bootstrap | null | undefined = undefined
+let seeded = false
 let inflight: Promise<Bootstrap | null> | null = null
 
 function fetchBootstrap(): Promise<Bootstrap | null> {
@@ -33,6 +33,20 @@ function fetchBootstrap(): Promise<Bootstrap | null> {
 }
 
 export function useBootstrap(): BootstrapState {
+  // Read context directly (not via useConfig()) so test environments that
+  // mount LocalSignIn / signup flows without a ConfigProvider don't crash.
+  // Bootstrap is a soft hint — a missing config just means "no seed, fetch".
+  const config = useContext(ConfigContext)
+
+  // Seed once from the SSR-injected config (selfhost-prod fast path: no
+  // fetch on first paint). On CF Pages /config.json typically omits this
+  // block — `config.bootstrap` is undefined and we drop through to the
+  // public /api/auth/bootstrap endpoint.
+  if (!seeded) {
+    cached = config?.bootstrap
+    seeded = true
+  }
+
   const [state, setState] = useState<BootstrapState>(cached)
 
   useEffect(() => {

--- a/frontend/src/auth/use-bootstrap.ts
+++ b/frontend/src/auth/use-bootstrap.ts
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState } from 'react'
 import { ConfigContext } from '../config-context'
+import { getApiBase, joinApiUrl } from '../api/base'
 
 export interface Bootstrap {
   bootstrap_pending: boolean
@@ -22,7 +23,7 @@ let inflight: Promise<Bootstrap | null> | null = null
 
 function fetchBootstrap(): Promise<Bootstrap | null> {
   if (inflight) return inflight
-  inflight = fetch('/api/auth/bootstrap')
+  inflight = fetch(joinApiUrl(getApiBase(), '/api/auth/bootstrap'))
     .then((r) => (r.ok ? r.json() : null))
     .catch(() => null)
     .then((b: Bootstrap | null) => {

--- a/frontend/src/auth/waitlist.tsx
+++ b/frontend/src/auth/waitlist.tsx
@@ -1,25 +1,22 @@
 import { lazy, Suspense } from 'react'
 import { Navigate } from 'react-router'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import { ROUTES } from '../routes'
 import AuthLayout from './auth-layout'
 
-const isClerk = config.authProvider === 'clerk'
-
-const ClerkWaitlistPage = isClerk
-  ? lazy(() =>
-      import('@clerk/react').then((mod) => ({
-        default: () => (
-          <AuthLayout>
-            <mod.Waitlist signInUrl={ROUTES.SIGN_IN} />
-          </AuthLayout>
-        ),
-      })),
-    )
-  : null
+const ClerkWaitlistPage = lazy(() =>
+  import('@clerk/react').then((mod) => ({
+    default: () => (
+      <AuthLayout>
+        <mod.Waitlist signInUrl={ROUTES.SIGN_IN} />
+      </AuthLayout>
+    ),
+  })),
+)
 
 export default function WaitlistPage() {
-  if (!ClerkWaitlistPage || !config.clerkWaitlistMode) {
+  const config = useConfig()
+  if (config.authProvider !== 'clerk' || !config.clerkWaitlistMode) {
     return <Navigate to={ROUTES.SIGN_UP} replace />
   }
 

--- a/frontend/src/billing/use-subscription-activated-events.ts
+++ b/frontend/src/billing/use-subscription-activated-events.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Socket } from 'phoenix'
 import { useAuthAdapter } from '../auth/use-auth-adapter'
+import { getWsBase, joinWsUrl } from '../api/base'
 
 export interface SubscriptionActivatedPayload {
   tier: string
@@ -40,7 +41,7 @@ export function useSubscriptionActivatedEvents({
       const token = await getToken()
       if (cancelled || !token) return
 
-      socket = new Socket('/socket', { params: { token } })
+      socket = new Socket(joinWsUrl(getWsBase(), '/socket'), { params: { token } })
       socket.connect()
 
       const channel = socket.channel(`user:${userId}`)

--- a/frontend/src/config-context.tsx
+++ b/frontend/src/config-context.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { EngramConfig } from './config'
+
+// Exported so non-component utilities (or test helpers) can read the raw
+// context without the throw-on-missing-provider guard `useConfig()` has.
+// 99% of consumers should use `useConfig()` — only reach for this when
+// you genuinely have a fallback path for the missing-provider case.
+export const ConfigContext = createContext<EngramConfig | null>(null)
+
+export function ConfigProvider({ config, children }: { config: EngramConfig; children: ReactNode }) {
+  return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+}
+
+// Throws if invoked outside <ConfigProvider> rather than returning a
+// silent default — a missing provider is a wiring bug, and a real value
+// here is load-bearing for auth provider selection / api-base URL
+// composition. Better to crash loud at the offending component than to
+// silently route through "selfhost defaults" in saas builds.
+export function useConfig(): EngramConfig {
+  const ctx = useContext(ConfigContext)
+  if (!ctx) {
+    throw new Error('useConfig() called outside <ConfigProvider>. Mount ConfigProvider at the app root.')
+  }
+  return ctx
+}

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -1,44 +1,83 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { loadConfig } from './config'
 
-type InjectedConfig = Record<string, unknown>
-
-function inject(value: InjectedConfig | undefined) {
-  ;(window as unknown as { __ENGRAM_CONFIG__?: InjectedConfig }).__ENGRAM_CONFIG__ = value
-}
-
 describe('loadConfig', () => {
-  afterEach(() => {
-    inject(undefined)
+  beforeEach(() => {
+    delete (window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__
+    vi.restoreAllMocks()
   })
 
-  it('reads billingEnabled=true from injected config', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', billingEnabled: true })
-    expect(loadConfig().billingEnabled).toBe(true)
+  it('reads apiBase + wsBase from window injection when present', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'clerk',
+      clerkPublishableKey: 'pk_test_x',
+      billingEnabled: true,
+      clerkWaitlistMode: false,
+      apiBase: '',
+      wsBase: '',
+    }
+
+    const config = await loadConfig()
+    expect(config.apiBase).toBe('')
+    expect(config.wsBase).toBe('')
+    expect(config.authProvider).toBe('clerk')
   })
 
-  it('treats a missing billingEnabled as false', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test' })
-    expect(loadConfig().billingEnabled).toBe(false)
+  it('fetches /config.json when window injection absent', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          authProvider: 'clerk',
+          clerkPublishableKey: 'pk_live_x',
+          billingEnabled: true,
+          clerkWaitlistMode: false,
+          apiBase: 'https://api.engram.page',
+          wsBase: 'wss://api.engram.page',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+
+    const config = await loadConfig()
+    expect(fetchMock).toHaveBeenCalledWith('/config.json', expect.objectContaining({ cache: 'no-cache' }))
+    expect(config.apiBase).toBe('https://api.engram.page')
+    expect(config.wsBase).toBe('wss://api.engram.page')
   })
 
-  it('coerces non-boolean billingEnabled to false (never truthy-by-accident)', () => {
-    inject({ authProvider: 'local', clerkPublishableKey: '', billingEnabled: 'yes' })
-    expect(loadConfig().billingEnabled).toBe(false)
+  it('falls back to local defaults when both window + /config.json fail', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network'))
+
+    const config = await loadConfig()
+    expect(config.authProvider).toBe('local')
+    expect(config.apiBase).toBe('')
   })
 
-  it('reads clerkWaitlistMode=true from injected config', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', clerkWaitlistMode: true })
-    expect(loadConfig().clerkWaitlistMode).toBe(true)
+  it('coerces non-boolean billingEnabled to false from window injection', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'local',
+      clerkPublishableKey: '',
+      billingEnabled: 'yes',
+    }
+    const config = await loadConfig()
+    expect(config.billingEnabled).toBe(false)
   })
 
-  it('treats a missing clerkWaitlistMode as false', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test' })
-    expect(loadConfig().clerkWaitlistMode).toBe(false)
+  it('coerces non-boolean clerkWaitlistMode to false from window injection', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'clerk',
+      clerkPublishableKey: 'pk_test',
+      clerkWaitlistMode: 'yes',
+    }
+    const config = await loadConfig()
+    expect(config.clerkWaitlistMode).toBe(false)
   })
 
-  it('coerces non-boolean clerkWaitlistMode to false (never truthy-by-accident)', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', clerkWaitlistMode: 'yes' })
-    expect(loadConfig().clerkWaitlistMode).toBe(false)
+  it('falls back to local provider when window has invalid authProvider', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'rogue',
+      clerkPublishableKey: '',
+    }
+    const config = await loadConfig()
+    expect(config.authProvider).toBe('local')
   })
 })

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -24,7 +24,7 @@ describe('loadConfig', () => {
   })
 
   it('fetches /config.json when window injection absent', async () => {
-    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
         JSON.stringify({
           authProvider: 'clerk',
@@ -45,7 +45,7 @@ describe('loadConfig', () => {
   })
 
   it('falls back to local defaults when both window + /config.json fail', async () => {
-    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network'))
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'))
 
     const config = await loadConfig()
     expect(config.authProvider).toBe('local')

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -72,6 +72,21 @@ describe('loadConfig', () => {
     expect(config.clerkWaitlistMode).toBe(false)
   })
 
+  it('coerces non-string apiBase/wsBase to empty string', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'clerk',
+      clerkPublishableKey: 'pk_test_x',
+      billingEnabled: true,
+      clerkWaitlistMode: false,
+      apiBase: 123,                          // wrong type
+      wsBase: { url: 'wss://x' },            // wrong type
+    }
+
+    const config = await loadConfig()
+    expect(config.apiBase).toBe('')
+    expect(config.wsBase).toBe('')
+  })
+
   it('falls back to local provider when window has invalid authProvider', async () => {
     ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
       authProvider: 'rogue',

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -32,11 +32,11 @@ function normalize(raw: Record<string, unknown>): EngramConfig {
 
   return {
     authProvider: provider,
-    clerkPublishableKey: (raw.clerkPublishableKey as string) ?? '',
+    clerkPublishableKey: typeof raw.clerkPublishableKey === 'string' ? raw.clerkPublishableKey : '',
     billingEnabled: raw.billingEnabled === true,
     clerkWaitlistMode: raw.clerkWaitlistMode === true,
-    apiBase: (raw.apiBase as string) ?? '',
-    wsBase: (raw.wsBase as string) ?? '',
+    apiBase: typeof raw.apiBase === 'string' ? raw.apiBase : '',
+    wsBase: typeof raw.wsBase === 'string' ? raw.wsBase : '',
     bootstrap: raw.bootstrap as EngramConfig['bootstrap'],
   }
 }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -6,9 +6,17 @@ export interface EngramConfig {
   // CTAs to /waitlist and passes waitlistUrl to <SignIn />. The dashboard
   // flag is the actual enforcement; this is presentational only.
   clerkWaitlistMode: boolean
+  // Runtime API base URL. Empty string = same-origin (selfhost, Phoenix
+  // serves both API and SPA). A full URL = saas (CF Pages serves SPA,
+  // backend hosted elsewhere — e.g. https://api.engram.page).
+  apiBase: string
+  // Runtime WebSocket base URL. Empty string = same-origin (selfhost).
+  // A full wss:// URL points Phoenix Socket at the cross-origin backend.
+  wsBase: string
   // Self-host SSR-injected bootstrap state. `null` under Clerk; `undefined`
-  // when the config script didn't ship one (Vite dev, older Phoenix build),
-  // in which case useBootstrap() falls back to fetching /api/auth/bootstrap.
+  // when the config didn't ship one (CF Pages serves static config.json
+  // without a bootstrap block; Vite dev; older Phoenix build), in which
+  // case useBootstrap() falls back to fetching /api/auth/bootstrap.
   bootstrap?: {
     bootstrap_pending: boolean
     registration_mode: 'open' | 'invite_only' | 'closed'
@@ -17,34 +25,65 @@ export interface EngramConfig {
 
 const VALID_PROVIDERS = ['local', 'clerk'] as const
 
-export function loadConfig(): EngramConfig {
-  const injected = (window as unknown as { __ENGRAM_CONFIG__?: Record<string, unknown> })
-    .__ENGRAM_CONFIG__
+function normalize(raw: Record<string, unknown>): EngramConfig {
+  const provider = VALID_PROVIDERS.includes(raw.authProvider as typeof VALID_PROVIDERS[number])
+    ? (raw.authProvider as 'local' | 'clerk')
+    : 'local'
 
-  if (injected && VALID_PROVIDERS.includes(injected.authProvider as typeof VALID_PROVIDERS[number])) {
-    return {
-      authProvider: injected.authProvider as 'local' | 'clerk',
-      clerkPublishableKey: (injected.clerkPublishableKey as string) ?? '',
-      billingEnabled: injected.billingEnabled === true,
-      clerkWaitlistMode: injected.clerkWaitlistMode === true,
-      bootstrap: injected.bootstrap as EngramConfig['bootstrap'],
-    }
+  return {
+    authProvider: provider,
+    clerkPublishableKey: (raw.clerkPublishableKey as string) ?? '',
+    billingEnabled: raw.billingEnabled === true,
+    clerkWaitlistMode: raw.clerkWaitlistMode === true,
+    apiBase: (raw.apiBase as string) ?? '',
+    wsBase: (raw.wsBase as string) ?? '',
+    bootstrap: raw.bootstrap as EngramConfig['bootstrap'],
   }
+}
 
-  // Vite dev server fallback — not served by Phoenix
-  if (import.meta.env.PROD && !injected) {
-    console.error(
-      '[engram] window.__ENGRAM_CONFIG__ not found. ' +
-      'Server may have failed to inject runtime config. Falling back to local auth.',
-    )
-  }
-
+function defaultConfig(): EngramConfig {
   return {
     authProvider: (import.meta.env.VITE_AUTH_PROVIDER as 'local' | 'clerk') ?? 'local',
     clerkPublishableKey: import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
     billingEnabled: import.meta.env.VITE_BILLING_ENABLED === 'true',
     clerkWaitlistMode: import.meta.env.VITE_CLERK_WAITLIST_MODE === 'true',
+    apiBase: import.meta.env.VITE_API_BASE ?? '',
+    wsBase: import.meta.env.VITE_WS_BASE ?? '',
   }
 }
 
-export const config = loadConfig()
+// Selfhost no-op contract: when Phoenix SSR-injects __ENGRAM_CONFIG__ this
+// resolves synchronously on first microtask (no fetch). Only the CF Pages
+// path (no injection) hits /config.json. Falls through to env-driven
+// defaults if both fail — emit a single console error in prod so a missing
+// /config.json deploy is loud rather than silently broken.
+export async function loadConfig(): Promise<EngramConfig> {
+  const injected = (window as unknown as { __ENGRAM_CONFIG__?: Record<string, unknown> })
+    .__ENGRAM_CONFIG__
+
+  if (injected) return normalize(injected)
+
+  try {
+    const res = await fetch('/config.json', { cache: 'no-cache' })
+    if (res.ok) {
+      const raw = await res.json()
+      return normalize(raw)
+    }
+  } catch {
+    // Fall through to defaults below.
+  }
+
+  if (import.meta.env.PROD) {
+    console.error(
+      '[engram] no window.__ENGRAM_CONFIG__ and /config.json unreachable. Falling back to defaults.',
+    )
+  }
+
+  return defaultConfig()
+}
+
+// Module-level promise — kicked off once at import time. `BootstrapGate`
+// awaits this via React 19's `use()` so the SPA mounts only after config
+// resolves. Re-imports get the same promise (module cache), so the fetch
+// fires at most once per page load.
+export const configPromise = loadConfig()

--- a/frontend/src/features/admin/AdminPanel.tsx
+++ b/frontend/src/features/admin/AdminPanel.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { useMe } from '@/api/queries'
-import { config } from '@/config'
+import { useConfig } from '@/config-context'
 import InvitesTab from './InvitesTab'
 import MembersTab from './MembersTab'
 import RegistrationTab from './RegistrationTab'
 
 export default function AdminPanel() {
+  const config = useConfig()
   const { data: me, isLoading } = useMe()
   // Lifted from MembersTab so the one-time reset link sits OUTSIDE the
   // Members card — its own standalone block above the table.

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { heading, fieldInput, destructiveAlert } from '@/lib/ui-classes'
 import { cn } from '@/lib/utils'
 import { ROUTES } from '@/routes'
+import { getApiBase, joinApiUrl } from '@/api/base'
 
 export default function ResetPasswordPage() {
   const [params] = useSearchParams()
@@ -32,7 +33,7 @@ export default function ResetPasswordPage() {
 
     setLoading(true)
     try {
-      const res = await fetch('/api/auth/password/reset', {
+      const res = await fetch(joinApiUrl(getApiBase(), '/api/auth/password/reset'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token, password }),

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import posthog from 'posthog-js'
 import { Toaster } from '@/components/ui/sonner'
 import { createAppRouter, installAppRouter } from './router'
 import { queryClient } from './api/query-client'
+import { setApiBase, setWsBase } from './api/base'
 import { configPromise, type EngramConfig } from './config'
 import { ConfigProvider } from './config-context'
 import { ThemeProvider } from './theme/theme-provider'
@@ -127,6 +128,12 @@ function AppShell({ config }: { config: EngramConfig }) {
 
 function BootstrapGate() {
   const config = use(configPromise)
+  // Install module-level apiBase/wsBase BEFORE any child component mounts.
+  // The singleton `api` object in src/api/client.ts and the WebSocket call
+  // sites read these via getApiBase()/getWsBase(); they need a value
+  // populated before AuthGuard fires its first fetch on mount.
+  setApiBase(config.apiBase)
+  setWsBase(config.wsBase)
   return <AppShell config={config} />
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,14 @@
-import { StrictMode, lazy, Suspense } from 'react'
+import { StrictMode, lazy, Suspense, use, useMemo } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router'
 import { QueryClientProvider } from '@tanstack/react-query'
 import * as Sentry from '@sentry/react'
 import posthog from 'posthog-js'
 import { Toaster } from '@/components/ui/sonner'
-import { router } from './router'
+import { createAppRouter, installAppRouter } from './router'
 import { queryClient } from './api/query-client'
-import { config } from './config'
+import { configPromise, type EngramConfig } from './config'
+import { ConfigProvider } from './config-context'
 import { ThemeProvider } from './theme/theme-provider'
 import LoadingScreen from './layout/loading-screen'
 import './main.css'
@@ -67,11 +68,10 @@ if (posthogKey) {
   })
 }
 
-const isClerk = config.authProvider === 'clerk'
-
-const AuthProvider = isClerk
-  ? lazy(() => import('./auth/clerk-auth-provider'))
-  : lazy(() => import('./auth/local-auth-provider'))
+// Both auth providers are declared lazy at module scope; only one is
+// instantiated per page load based on resolved config (BootstrapGate).
+const ClerkAuthProvider = lazy(() => import('./auth/clerk-auth-provider'))
+const LocalAuthProvider = lazy(() => import('./auth/local-auth-provider'))
 
 function ErrorFallback() {
   return (
@@ -94,9 +94,23 @@ function ErrorFallback() {
   )
 }
 
-createRoot(document.getElementById('root')!).render(
-  <Sentry.ErrorBoundary fallback={ErrorFallback}>
-    <StrictMode>
+// Bootstrap chain: `use(configPromise)` suspends until config resolves
+// (window injection → /config.json → defaults). Once resolved, build the
+// runtime router (route shape depends on auth provider + billingEnabled)
+// and install it so module-level consumers like clerk-auth-provider can
+// imperatively navigate via `getAppRouter()`.
+function AppShell({ config }: { config: EngramConfig }) {
+  const AuthProvider = config.authProvider === 'clerk' ? ClerkAuthProvider : LocalAuthProvider
+  // Memoize so StrictMode's double-render + any future ConfigProvider
+  // updates don't blow away the router instance + its history stack.
+  const router = useMemo(() => {
+    const r = createAppRouter(config)
+    installAppRouter(r)
+    return r
+  }, [config])
+
+  return (
+    <ConfigProvider config={config}>
       <ThemeProvider>
         <Suspense fallback={<LoadingScreen />}>
           <AuthProvider>
@@ -107,6 +121,21 @@ createRoot(document.getElementById('root')!).render(
           </AuthProvider>
         </Suspense>
       </ThemeProvider>
+    </ConfigProvider>
+  )
+}
+
+function BootstrapGate() {
+  const config = use(configPromise)
+  return <AppShell config={config} />
+}
+
+createRoot(document.getElementById('root')!).render(
+  <Sentry.ErrorBoundary fallback={ErrorFallback}>
+    <StrictMode>
+      <Suspense fallback={<LoadingScreen />}>
+        <BootstrapGate />
+      </Suspense>
     </StrictMode>
   </Sentry.ErrorBoundary>,
 )

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -3,7 +3,7 @@ import { Navigate, useNavigate } from 'react-router'
 import { FilePlus2 } from 'lucide-react'
 import obsidianMark from '@lobehub/icons-static-svg/icons/obsidian-color.svg?raw'
 import { setActiveVaultId } from '../api/active-vault'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import {
   useCreateVault,
   useMe,
@@ -265,6 +265,7 @@ interface ObsidianInlinePanelProps {
 }
 
 function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlinePanelProps) {
+  const config = useConfig()
   const { vaultCreated, vaultPopulated, vaultId } = useVaultReadyEvents({
     userId,
     enabled: true,

--- a/frontend/src/onboarding/tour/demo-vault-provider.tsx
+++ b/frontend/src/onboarding/tour/demo-vault-provider.tsx
@@ -47,6 +47,7 @@ export function DemoVaultProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState<DemoVaultData | null>(null)
 
   const activate = useCallback(async () => {
+    // Static SPA asset, not an API call — served from same origin on both selfhost and CF Pages.
     const res = await fetch('/demo-vault.json')
     if (!res.ok) throw new Error('demo fixture missing')
     const json = (await res.json()) as DemoVaultData

--- a/frontend/src/onboarding/use-vault-ready-events.ts
+++ b/frontend/src/onboarding/use-vault-ready-events.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Socket } from 'phoenix'
 import { useAuthAdapter } from '../auth/use-auth-adapter'
+import { getWsBase, joinWsUrl } from '../api/base'
 
 interface State {
   vaultCreated: boolean
@@ -40,7 +41,7 @@ export function useVaultReadyEvents({ userId, enabled }: Options): State {
       const token = await getToken()
       if (cancelled || !token) return
 
-      socket = new Socket('/socket', { params: { token } })
+      socket = new Socket(joinWsUrl(getWsBase(), '/socket'), { params: { token } })
       socket.connect()
 
       const channel = socket.channel(`user:${userId}`)

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,7 +6,7 @@ import SignUpPage from './auth/sign-up'
 import WaitlistPage from './auth/waitlist'
 import BillingPage from './billing/billing-page'
 import { UpgradeDialogProvider } from './billing/upgrade-dialog-provider'
-import { config } from './config'
+import type { EngramConfig } from './config'
 import AdminPanel from './features/admin/AdminPanel'
 import ResetPasswordPage from './features/auth/ResetPasswordPage'
 import DeviceLinkPage from './device/device-link-page'
@@ -29,14 +29,6 @@ import OnboardVaultPage from './onboarding/onboard-vault-page'
 import { OnboardingShell } from './onboarding/onboarding-shell'
 import { Outlet } from 'react-router'
 
-// Lazy so Clerk-only code (the account page pulls in @clerk/react hooks)
-// stays out of the main chunk for local self-host builds.
-const AccountPage = lazy(() =>
-  config.authProvider === 'clerk'
-    ? import('./settings/account-page')
-    : import('./settings/account-page-local'),
-)
-
 // Root layout — mounts the UpgradeDialogProvider INSIDE the router so the
 // dialog's `useNavigate` works, and so any nested API call that 402s opens
 // the modal via the module-level handler. Wrapping `RouterProvider` from
@@ -49,7 +41,36 @@ function RootLayout() {
   )
 }
 
-export const router = createBrowserRouter(
+// Router is constructed inside `createAppRouter(config)` so the auth-provider
+// and billing-enabled branches can read runtime config. Module-level
+// consumers (e.g. clerk-auth-provider's `routerPush`) read `appRouter`,
+// which BootstrapGate populates BEFORE first render via `installAppRouter`.
+type AppRouter = ReturnType<typeof createBrowserRouter>
+
+let _appRouter: AppRouter | null = null
+
+export function installAppRouter(r: AppRouter) {
+  _appRouter = r
+}
+
+// Lazy getter used by code paths that need to imperatively navigate
+// (e.g. Clerk's routerPush). Throws if invoked before BootstrapGate
+// mounted — that would be a wiring regression worth surfacing loudly.
+export function getAppRouter(): AppRouter {
+  if (!_appRouter) throw new Error('Router accessed before installAppRouter() ran')
+  return _appRouter
+}
+
+export function createAppRouter(config: EngramConfig): AppRouter {
+  // Lazy so Clerk-only code (the account page pulls in @clerk/react hooks)
+  // stays out of the main chunk for local self-host builds.
+  const AccountPage = lazy(() =>
+    config.authProvider === 'clerk'
+      ? import('./settings/account-page')
+      : import('./settings/account-page-local'),
+  )
+
+  return createBrowserRouter(
   [
     {
       element: <RootLayout />,
@@ -151,4 +172,5 @@ export const router = createBrowserRouter(
       ],
     },
   ],
-)
+  )
+}

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -4,30 +4,40 @@ import { MemoryRouter, Routes, Route } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import SettingsLayout from './settings-layout'
 import { ThemeProvider } from '../theme/theme-provider'
+import { ConfigProvider } from '../config-context'
+import type { EngramConfig } from '../config'
 
 vi.mock('../auth/use-auth-adapter', () => ({
   useAuthAdapter: () => ({ user: { email: 'todd@example.com' }, logout: vi.fn() }),
 }))
-vi.mock('../config', () => ({
-  config: { authProvider: 'clerk', clerkPublishableKey: '', billingEnabled: true },
-}))
+
+const testConfig: EngramConfig = {
+  authProvider: 'clerk',
+  clerkPublishableKey: '',
+  billingEnabled: true,
+  clerkWaitlistMode: false,
+  apiBase: '',
+  wsBase: '',
+}
 
 function renderAt(path: string) {
   // SettingsLayout now calls useMe(); give it a query client with retry off so
   // an unmocked /api/me fetch fails fast rather than retrying through the test.
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={client}>
-      <ThemeProvider>
-        <MemoryRouter initialEntries={[path]}>
-          <Routes>
-            <Route path="/settings" element={<SettingsLayout />}>
-              <Route path="api-keys" element={<p>api keys body</p>} />
-            </Route>
-          </Routes>
-        </MemoryRouter>
-      </ThemeProvider>
-    </QueryClientProvider>,
+    <ConfigProvider config={testConfig}>
+      <QueryClientProvider client={client}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={[path]}>
+            <Routes>
+              <Route path="/settings" element={<SettingsLayout />}>
+                <Route path="api-keys" element={<p>api keys body</p>} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </ConfigProvider>,
   )
 }
 

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -18,7 +18,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import { useMe } from '../api/queries'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import { buildSettingsSections, type SettingsSection } from './sections'
 
 function SettingsNavList({
@@ -52,6 +52,7 @@ function SettingsNavList({
 }
 
 export default function SettingsLayout() {
+  const config = useConfig()
   const { data: me } = useMe()
   const isAdmin = me?.role === 'admin'
   const sections = buildSettingsSections(config.authProvider, config.billingEnabled, isAdmin)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.383",
+      version: "0.5.386",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Phase C of the Frontend Eject to Cloudflare Pages migration (spec + plan in workspace `2026-06-10-frontend-eject-cloudflare-pages-*`).

Refactor the saas web frontend so config loading is async, base URLs (`apiBase`, `wsBase`) are runtime-configurable, and all consumers migrate from a sync `config` named export to a `useConfig()` hook. Foundational work for serving the SPA from Cloudflare Pages while preserving selfhost behavior.

## What changes

- **`EngramConfig`** gains `apiBase: string` + `wsBase: string`. Defaults `""` (selfhost = same-origin).
- **`loadConfig()`** is now async: window injection → `/config.json` fetch → `import.meta.env` defaults.
- **`<ConfigProvider>` + `useConfig()`** replace the sync `config` named export.
- **React mount** Suspense-gated on `configPromise` via React 19's `use()`.
- **API client + Phoenix Socket** thread `apiBase`/`wsBase`. Path strip on saas: `/api/notes` → `apiBase + /notes` (the Phase A `HostRewrite` plug re-adds `/api`).
- **9 consumer files** migrated from `import { config }` to `useConfig()`.

## Selfhost = zero behavior change

- Phoenix `SpaController` still injects `window.__ENGRAM_CONFIG__` unchanged.
- Window injection wins synchronously; never reaches `/config.json` fetch.
- `apiBase=""` and `wsBase=""` → `joinApiUrl/joinWsUrl` return path unchanged → same-origin.

## Architectural deviations from plan (reviewed + accepted)

1. **`router.tsx` became a factory.** `createAppRouter(config)` + `installAppRouter`/`getAppRouter`. Was module-level singleton.
2. **`api/client.ts` uses singleton setters.** `setApiBase`/`getApiBase` mirrors the existing `setTokenGetter` pattern. Avoids dragging `useApi()` hooks into module-level utilities.
3. **`useBootstrap` reads `ConfigContext` directly.** Avoids breaking `local-sign-in.test.tsx` which mounts without ConfigProvider.

## Test plan

- [x] `bun test` — 441 pass, 0 failures
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — clean
- [x] Vite dev server boots
- [ ] Manual: selfhost still loads + auth + notes (via existing E2E once merged)
- [ ] Manual: in saas-mode build (Phase D), `/config.json` controls runtime config

## Depends on

Independent of Phases A (PR #512), B (PR #513). All three can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)