### PR TITLE
feat(build): split frontend build into selfhost + saas variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ COPY frontend/ ./
 # self-disables if the token is missing, so this same `bun run build`
 # line is the no-op branch for builds without the secret.
 RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
-    bun run build
+    bun run build:selfhost
 
 # ─── Elixir build ────────────────────────────────────────────────────────
 FROM ${BUILDER_IMAGE} AS builder

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "dev": "vite",
     "build": "bun run build:selfhost",
     "build:selfhost": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build",
-    "build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build && bun scripts/write-config-json.ts dist/config.json",
+    "build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build --outDir dist --emptyOutDir && bun scripts/write-config-json.ts dist/config.json",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
   "author": "Rasbandit Software Solutions LLC d/b/a Engram",
   "scripts": {
     "dev": "vite",
-    "build": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build",
+    "build": "bun run build:selfhost",
+    "build:selfhost": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build",
+    "build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build && bun scripts/write-config-json.ts dist/config.json",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/frontend/scripts/write-config-json.ts
+++ b/frontend/scripts/write-config-json.ts
@@ -1,0 +1,30 @@
+// frontend/scripts/write-config-json.ts
+// Writes dist/config.json from VITE_*-style env vars at build time.
+// Used by `bun run build:saas`. Selfhost build does NOT call this.
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const target = process.argv[2] ?? 'dist/config.json'
+
+const config = {
+  authProvider: process.env.VITE_AUTH_PROVIDER ?? 'clerk',
+  clerkPublishableKey: process.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
+  billingEnabled: process.env.VITE_BILLING_ENABLED === 'true',
+  clerkWaitlistMode: process.env.VITE_CLERK_WAITLIST_MODE === 'true',
+  apiBase: process.env.VITE_API_BASE ?? '',
+  wsBase: process.env.VITE_WS_BASE ?? '',
+}
+
+if (!config.clerkPublishableKey) {
+  console.error('[write-config-json] VITE_CLERK_PUBLISHABLE_KEY required for saas build')
+  process.exit(1)
+}
+
+if (!config.apiBase || !config.wsBase) {
+  console.error('[write-config-json] VITE_API_BASE and VITE_WS_BASE required for saas build')
+  process.exit(1)
+}
+
+mkdirSync(dirname(target), { recursive: true })
+writeFileSync(target, JSON.stringify(config, null, 2))
+console.log(`[write-config-json] wrote ${target}`)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.383",
+      version: "0.5.387",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Phase D of the Frontend Eject to Cloudflare Pages migration. Splits the frontend build into two variants:

- **`bun run build:selfhost`** (Dockerfile uses this) — current behavior. Bundle lands in `priv/static/app/` per `vite.config.ts` for Phoenix release.
- **`bun run build:saas`** (Cloudflare Pages will use this) — bundle + `config.json` both land in `frontend/dist/` via `--outDir dist`.
- **`bun run build`** aliases `build:selfhost` for backward compat.

New `scripts/write-config-json.ts` emits `dist/config.json` from `VITE_*` env vars. Validates required env (Clerk publishable key, apiBase, wsBase) and exits non-zero with a clear message if missing.

## Changes

- `frontend/package.json` — new `build:saas` + `build:selfhost` scripts; `build` aliases selfhost
- `frontend/scripts/write-config-json.ts` — new (Bun runtime script)
- `Dockerfile` — call `bun run build:selfhost` explicitly

## Test plan

- [x] `bun run build:selfhost` — assets land in `priv/static/app/`, no `frontend/dist/`
- [x] `bun run build:saas` with env — assets + config.json in `frontend/dist/`
- [x] `bun run build:saas` without env — exits 1 with clear error
- [x] Dockerfile build path unchanged in effect (aliased through `build:selfhost`)

## Depends on

Independent of Phases A/B/C (PRs #512, #513, #514).

🤖 Generated with [Claude Code](https://claude.com/claude-code)