### PR TITLE
feat: frontend eject — HostRewrite + CORS + async config + build split

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ COPY frontend/ ./
 # self-disables if the token is missing, so this same `bun run build`
 # line is the no-op branch for builds without the secret.
 RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
-    bun run build
+    bun run build:selfhost
 
 # ─── Elixir build ────────────────────────────────────────────────────────
 FROM ${BUILDER_IMAGE} AS builder

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -594,9 +594,20 @@ if config_env() == :prod do
   # current `app.engram.page` host until DNS cutover) leave this unset
   # and the plug is a strict no-op. See EngramWeb.Plugs.HostRewrite.
   if System.get_env("ENGRAM_HOST_REWRITE_ENABLED") == "true" do
+    saas_only? = System.get_env("ENGRAM_SAAS_ONLY") == "true"
+
+    extra_hosts =
+      case System.get_env("ENGRAM_ALLOWED_EXTRA_HOSTS") do
+        nil -> []
+        "" -> []
+        s -> String.split(s, ",", trim: true)
+      end
+
     config :engram, :host_rewrite,
       api_host: System.get_env("ENGRAM_HOST_REWRITE_API_HOST", "api.engram.page"),
-      mcp_host: System.get_env("ENGRAM_HOST_REWRITE_MCP_HOST", "mcp.engram.page")
+      mcp_host: System.get_env("ENGRAM_HOST_REWRITE_MCP_HOST", "mcp.engram.page"),
+      reject_unknown_hosts: saas_only?,
+      allowed_extra_hosts: extra_hosts
   end
 
   # ## SSL Support

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -589,6 +589,16 @@ if config_env() == :prod do
     config :engram, :websocket_check_origin, phx_hosts.origins
   end
 
+  # Host-driven path rewrite for the dedicated `api.engram.page` and
+  # `mcp.engram.page` saas hosts. Opt-in: selfhost releases (and the
+  # current `app.engram.page` host until DNS cutover) leave this unset
+  # and the plug is a strict no-op. See EngramWeb.Plugs.HostRewrite.
+  if System.get_env("ENGRAM_HOST_REWRITE_ENABLED") == "true" do
+    config :engram, :host_rewrite,
+      api_host: System.get_env("ENGRAM_HOST_REWRITE_API_HOST", "api.engram.page"),
+      mcp_host: System.get_env("ENGRAM_HOST_REWRITE_MCP_HOST", "mcp.engram.page")
+  end
+
   # ## SSL Support
   #
   # To get SSL working, you will need to add the `https` key

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -584,9 +584,29 @@ if config_env() == :prod do
   # CORS and WebSocket origin — only lock down when PHX_HOST is explicitly set.
   # Without it (CI, local dev), defaults apply: CORS allows "*", WS allows all.
   # See Engram.HostOrigins for parsing rules (CSV, scheme expansion, dedup).
+  #
+  # ENGRAM_SAAS_FRONTEND_ORIGINS appends extra origins (comma-separated) for the
+  # Cloudflare Pages saas frontend at app.engram.page + its preview deploys at
+  # *.engram-frontend.pages.dev. Unset on selfhost (same-origin) → no-op.
   if phx_hosts do
-    config :engram, :cors_origin, phx_hosts.origins
-    config :engram, :websocket_check_origin, phx_hosts.origins
+    extra_origins =
+      case System.get_env("ENGRAM_SAAS_FRONTEND_ORIGINS") do
+        nil ->
+          []
+
+        "" ->
+          []
+
+        s ->
+          s
+          |> String.split(",", trim: true)
+          |> Enum.map(&String.trim/1)
+          |> Enum.reject(&(&1 == ""))
+      end
+
+    cors_origins = phx_hosts.origins ++ extra_origins
+    config :engram, :cors_origin, cors_origins
+    config :engram, :websocket_check_origin, cors_origins
   end
 
   # Host-driven path rewrite for the dedicated `api.engram.page` and

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "dev": "vite",
     "build": "bun run build:selfhost",
     "build:selfhost": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build",
-    "build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build && bun scripts/write-config-json.ts dist/config.json",
+    "build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build --outDir dist --emptyOutDir && bun scripts/write-config-json.ts dist/config.json",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
   "author": "Rasbandit Software Solutions LLC d/b/a Engram",
   "scripts": {
     "dev": "vite",
-    "build": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build",
+    "build": "bun run build:selfhost",
+    "build:selfhost": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build",
+    "build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build && bun scripts/write-config-json.ts dist/config.json",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/frontend/scripts/write-config-json.ts
+++ b/frontend/scripts/write-config-json.ts
@@ -1,0 +1,30 @@
+// frontend/scripts/write-config-json.ts
+// Writes dist/config.json from VITE_*-style env vars at build time.
+// Used by `bun run build:saas`. Selfhost build does NOT call this.
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const target = process.argv[2] ?? 'dist/config.json'
+
+const config = {
+  authProvider: process.env.VITE_AUTH_PROVIDER ?? 'clerk',
+  clerkPublishableKey: process.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
+  billingEnabled: process.env.VITE_BILLING_ENABLED === 'true',
+  clerkWaitlistMode: process.env.VITE_CLERK_WAITLIST_MODE === 'true',
+  apiBase: process.env.VITE_API_BASE ?? '',
+  wsBase: process.env.VITE_WS_BASE ?? '',
+}
+
+if (!config.clerkPublishableKey) {
+  console.error('[write-config-json] VITE_CLERK_PUBLISHABLE_KEY required for saas build')
+  process.exit(1)
+}
+
+if (!config.apiBase || !config.wsBase) {
+  console.error('[write-config-json] VITE_API_BASE and VITE_WS_BASE required for saas build')
+  process.exit(1)
+}
+
+mkdirSync(dirname(target), { recursive: true })
+writeFileSync(target, JSON.stringify(config, null, 2))
+console.log(`[write-config-json] wrote ${target}`)

--- a/frontend/src/api/base.test.tsx
+++ b/frontend/src/api/base.test.tsx
@@ -1,0 +1,99 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ConfigProvider } from '@/config-context'
+import { useApiUrl, useWsUrl, joinApiUrl, joinWsUrl } from './base'
+import type { EngramConfig } from '@/config'
+
+function makeConfig(apiBase: string, wsBase = ''): EngramConfig {
+  return {
+    authProvider: 'local',
+    clerkPublishableKey: '',
+    billingEnabled: false,
+    clerkWaitlistMode: false,
+    apiBase,
+    wsBase,
+  }
+}
+
+function ApiUrlProbe({ path }: { path: string }) {
+  const apiUrl = useApiUrl()
+  return <span data-testid="out">{apiUrl(path)}</span>
+}
+
+function WsUrlProbe({ path }: { path: string }) {
+  const wsUrl = useWsUrl()
+  return <span data-testid="out">{wsUrl(path)}</span>
+}
+
+describe('joinApiUrl (pure)', () => {
+  it('selfhost (apiBase=""): leaves /api/notes intact', () => {
+    expect(joinApiUrl('', '/api/notes')).toBe('/api/notes')
+  })
+
+  it('saas: strips /api prefix and prepends apiBase', () => {
+    expect(joinApiUrl('https://api.engram.page', '/api/notes')).toBe('https://api.engram.page/notes')
+  })
+
+  it('saas: leaves a non-/api path intact under apiBase', () => {
+    expect(joinApiUrl('https://api.engram.page', '/health')).toBe('https://api.engram.page/health')
+  })
+})
+
+describe('joinWsUrl (pure)', () => {
+  it('selfhost (wsBase=""): returns path unchanged', () => {
+    expect(joinWsUrl('', '/socket')).toBe('/socket')
+  })
+
+  it('saas: prepends wsBase', () => {
+    expect(joinWsUrl('wss://api.engram.page', '/socket')).toBe('wss://api.engram.page/socket')
+  })
+})
+
+describe('useApiUrl', () => {
+  it('selfhost (apiBase=""): leaves /api/notes intact', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('')}>
+        <ApiUrlProbe path="/api/notes" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('/api/notes')
+  })
+
+  it('saas: strips /api prefix and prepends apiBase', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('https://api.engram.page')}>
+        <ApiUrlProbe path="/api/notes" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('https://api.engram.page/notes')
+  })
+
+  it('saas: passes a non-/api path through unchanged after prepending', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('https://api.engram.page')}>
+        <ApiUrlProbe path="/health" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('https://api.engram.page/health')
+  })
+})
+
+describe('useWsUrl', () => {
+  it('selfhost (wsBase=""): returns path unchanged', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('', '')}>
+        <WsUrlProbe path="/socket" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('/socket')
+  })
+
+  it('saas: prepends wsBase', () => {
+    const { getByTestId } = render(
+      <ConfigProvider config={makeConfig('', 'wss://api.engram.page')}>
+        <WsUrlProbe path="/socket" />
+      </ConfigProvider>,
+    )
+    expect(getByTestId('out').textContent).toBe('wss://api.engram.page/socket')
+  })
+})

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -25,11 +25,10 @@ export function useWsUrl(): (path: string) => string {
 }
 
 // Module-level base setters — parallel the existing setTokenGetter
-// pattern in `./client`. A small <ConfigBaseInstaller> component (mounted
-// once at app root inside ConfigProvider) wires apiBase/wsBase from the
-// resolved config so non-React utilities like the singleton `api` object
-// and `connectChannel(...)` can compose URLs without dragging a hook
-// dependency into every call site.
+// pattern in `./client`. `BootstrapGate` in main.tsx wires apiBase/wsBase
+// inline from the resolved config so non-React utilities like the singleton
+// `api` object and `connectChannel(...)` can compose URLs without dragging
+// a hook dependency into every call site.
 let _apiBase = ''
 let _wsBase = ''
 

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -1,0 +1,50 @@
+import { useConfig } from '@/config-context'
+
+// Combines the configured apiBase with a path. Strips the `/api` prefix
+// on saas (where apiBase = `https://api.engram.page` and the host-rewrite
+// plug prefixes `/api` server-side) and keeps it on selfhost (apiBase
+// = "", same-origin Phoenix-hosted SPA).
+export function joinApiUrl(apiBase: string, path: string): string {
+  if (!apiBase) return path
+  const stripped = path.startsWith('/api/') ? path.slice(4) : path
+  return apiBase + stripped
+}
+
+export function joinWsUrl(wsBase: string, path: string): string {
+  return wsBase ? wsBase + path : path
+}
+
+export function useApiUrl(): (path: string) => string {
+  const { apiBase } = useConfig()
+  return (path: string) => joinApiUrl(apiBase, path)
+}
+
+export function useWsUrl(): (path: string) => string {
+  const { wsBase } = useConfig()
+  return (path: string) => joinWsUrl(wsBase, path)
+}
+
+// Module-level base setters — parallel the existing setTokenGetter
+// pattern in `./client`. A small <ConfigBaseInstaller> component (mounted
+// once at app root inside ConfigProvider) wires apiBase/wsBase from the
+// resolved config so non-React utilities like the singleton `api` object
+// and `connectChannel(...)` can compose URLs without dragging a hook
+// dependency into every call site.
+let _apiBase = ''
+let _wsBase = ''
+
+export function setApiBase(v: string) {
+  _apiBase = v
+}
+
+export function setWsBase(v: string) {
+  _wsBase = v
+}
+
+export function getApiBase(): string {
+  return _apiBase
+}
+
+export function getWsBase(): string {
+  return _wsBase
+}

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -1,5 +1,6 @@
 import { Socket, Channel } from 'phoenix'
 import type { QueryClient } from '@tanstack/react-query'
+import { getWsBase, joinWsUrl } from './base'
 
 let socket: Socket | null = null
 let channel: Channel | null = null
@@ -65,7 +66,7 @@ export async function connectChannel({ userId, vaultId, getToken, queryClient }:
 
   const token = await getToken()
 
-  socket = new Socket('/socket', {
+  socket = new Socket(joinWsUrl(getWsBase(), '/socket'), {
     params: { token: token ?? '' },
   })
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import { getActiveVaultId } from './active-vault'
+import { getApiBase, joinApiUrl } from './base'
 
 // Module-level token getter — set by AuthTokenProvider component
 let tokenGetter: (() => Promise<string | null>) | null = null
@@ -50,7 +51,11 @@ async function authFetch(path: string, options: RequestInit = {}): Promise<Respo
     headers.set('X-Vault-ID', String(vaultId))
   }
 
-  const response = await fetch(`/api${path}`, { ...options, headers })
+  // joinApiUrl handles both same-origin (selfhost) and cross-origin
+  // (saas, `https://api.engram.page`). For selfhost apiBase is "" so
+  // this composes to `/api${path}` identically to the pre-eject shape.
+  const url = joinApiUrl(getApiBase(), `/api${path}`)
+  const response = await fetch(url, { ...options, headers })
 
   if (!response.ok) {
     const body = await response.json().catch(() => ({}))

--- a/frontend/src/api/oauth.ts
+++ b/frontend/src/api/oauth.ts
@@ -1,4 +1,5 @@
 import { api } from './client'
+import { getApiBase, joinApiUrl } from './base'
 
 export interface OAuthClientMetadata {
   client_id: string
@@ -26,7 +27,8 @@ export interface OAuthConsentResponse {
 }
 
 export async function fetchOAuthClient(clientId: string): Promise<OAuthClientMetadata> {
-  return fetch(`/api/oauth/clients/${encodeURIComponent(clientId)}`).then(async (res) => {
+  const url = joinApiUrl(getApiBase(), `/api/oauth/clients/${encodeURIComponent(clientId)}`)
+  return fetch(url).then(async (res) => {
     if (!res.ok) {
       throw new Error(`oauth client lookup failed: ${res.status}`)
     }

--- a/frontend/src/auth/clerk-auth-provider.tsx
+++ b/frontend/src/auth/clerk-auth-provider.tsx
@@ -7,12 +7,10 @@ import { rememberSignupUser } from './signup-rejection'
 import { useClearQueryCacheOnUserChange } from './use-clear-query-cache-on-user-change'
 import { setTokenGetter } from '../api/client'
 import { queryClient } from '../api/query-client'
-import { config } from '../config'
-import { router } from '../router'
+import { useConfig } from '../config-context'
+import { getAppRouter } from '../router'
 import { ROUTES } from '../routes'
 import { useTheme } from '../theme/theme-provider'
-
-const clerkPubKey = config.clerkPublishableKey
 
 // Clerk passes the post-auth redirect target as an ABSOLUTE URL when it crosses
 // (or might cross) origins — including the in-origin case after an OAuth
@@ -104,6 +102,8 @@ function ClerkAdapterInner({ children }: { children: React.ReactNode }) {
 
 export default function ClerkAuthProvider({ children }: { children: React.ReactNode }) {
   const { resolved } = useTheme()
+  const config = useConfig()
+  const clerkPubKey = config.clerkPublishableKey
 
   const appearance = useMemo(
     () => ({
@@ -133,8 +133,8 @@ export default function ClerkAuthProvider({ children }: { children: React.ReactN
       signUpUrl={signUpUrl}
       waitlistUrl={waitlistUrl}
       afterSignOutUrl={ROUTES.SIGN_IN}
-      routerPush={(to) => router.navigate(toRelativeUrl(to))}
-      routerReplace={(to) => router.navigate(toRelativeUrl(to), { replace: true })}
+      routerPush={(to) => getAppRouter().navigate(toRelativeUrl(to))}
+      routerReplace={(to) => getAppRouter().navigate(toRelativeUrl(to), { replace: true })}
     >
       <ClerkAdapterInner>{children}</ClerkAdapterInner>
     </ClerkProvider>

--- a/frontend/src/auth/local-auth-provider.tsx
+++ b/frontend/src/auth/local-auth-provider.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { AuthContext, type AuthAdapter } from './auth-context'
 import { useClearQueryCacheOnUserChange } from './use-clear-query-cache-on-user-change'
 import { setTokenGetter } from '../api/client'
+import { getApiBase, joinApiUrl } from '../api/base'
 import { queryClient } from '../api/query-client'
 
 function parseJwtPayload(token: string): Record<string, unknown> | null {
@@ -29,7 +30,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
     // first line of defense (avoids the round-trip + an extra DB rotate).
     if (refreshPromiseRef.current) return refreshPromiseRef.current
 
-    const promise = fetch('/api/auth/refresh', {
+    const promise = fetch(joinApiUrl(getApiBase(), '/api/auth/refresh'), {
       method: 'POST',
       credentials: 'include',
     })
@@ -86,7 +87,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
   useClearQueryCacheOnUserChange(queryClient, user?.email)
 
   const login = useCallback(async (email: string, password: string) => {
-    const res = await fetch('/api/auth/login', {
+    const res = await fetch(joinApiUrl(getApiBase(), '/api/auth/login'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -108,7 +109,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
     // arrived via `/signup?invite=…` we pass the token here so the backend
     // can atomically redeem it.
     const body = invite ? { email, password, invite } : { email, password }
-    const res = await fetch('/api/auth/register', {
+    const res = await fetch(joinApiUrl(getApiBase(), '/api/auth/register'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -126,7 +127,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
   }, [])
 
   const logout = useCallback(async () => {
-    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }).catch((err) => console.error('Logout request failed:', err))
+    await fetch(joinApiUrl(getApiBase(), '/api/auth/logout'), { method: 'POST', credentials: 'include' }).catch((err) => console.error('Logout request failed:', err))
     setAccessToken(null)
     setUser(null)
   }, [])

--- a/frontend/src/auth/local-sign-up.tsx
+++ b/frontend/src/auth/local-sign-up.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FormEvent } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router'
 import { ROUTES } from '../routes'
+import { getApiBase, joinApiUrl } from '../api/base'
 import { useAuthAdapter } from './use-auth-adapter'
 import { useBootstrap } from './use-bootstrap'
 import AuthLayout from './auth-layout'
@@ -37,7 +38,7 @@ export default function LocalSignUp() {
       setInvitePreview(null)
       return
     }
-    fetch(`/api/auth/invite/${encodeURIComponent(invite)}`)
+    fetch(joinApiUrl(getApiBase(), `/api/auth/invite/${encodeURIComponent(invite)}`))
       .then((r) => r.json())
       .then((p: InvitePreview) => setInvitePreview(p))
       .catch(() => setInvitePreview({ valid: false }))

--- a/frontend/src/auth/sign-in.tsx
+++ b/frontend/src/auth/sign-in.tsx
@@ -1,21 +1,22 @@
 import { lazy, Suspense } from 'react'
 import { useSearchParams } from 'react-router'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import AuthLayout from './auth-layout'
 import SignupRejectionNotice from './signup-rejection-notice'
 import { safeReturnTo } from './safe-return-to'
 
-const isClerk = config.authProvider === 'clerk'
-
-const ClerkSignIn = isClerk ? lazy(() => import('./clerk-sign-in')) : null
-
+// Both lazy refs are declared at module scope so React preserves the lazy
+// component identity across renders. Only one is actually rendered per
+// run — the auth provider is resolved at config load and never changes.
+const ClerkSignIn = lazy(() => import('./clerk-sign-in'))
 const LocalSignIn = lazy(() => import('./local-sign-in'))
 
 export default function SignInPage() {
   const [searchParams] = useSearchParams()
   const returnTo = safeReturnTo(searchParams.get('return_to'))
+  const config = useConfig()
 
-  if (ClerkSignIn) {
+  if (config.authProvider === 'clerk') {
     return (
       <AuthLayout>
         <div className="flex w-full flex-col items-center">

--- a/frontend/src/auth/sign-up.tsx
+++ b/frontend/src/auth/sign-up.tsx
@@ -1,27 +1,25 @@
 import { lazy, Suspense } from 'react'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import AuthLayout from './auth-layout'
 
-const isClerk = config.authProvider === 'clerk'
-
-const ClerkSignUpPage = isClerk
-  ? lazy(() =>
-      import('@clerk/react').then((mod) => ({
-        default: () => (
-          <AuthLayout>
-            <mod.SignUp routing="hash" forceRedirectUrl="/" />
-          </AuthLayout>
-        ),
-      }))
-    )
-  : null
+const ClerkSignUpPage = lazy(() =>
+  import('@clerk/react').then((mod) => ({
+    default: () => (
+      <AuthLayout>
+        <mod.SignUp routing="hash" forceRedirectUrl="/" />
+      </AuthLayout>
+    ),
+  })),
+)
 
 const LocalSignUp = lazy(() => import('./local-sign-up'))
 
 export default function SignUpPage() {
+  const config = useConfig()
+  const isClerk = config.authProvider === 'clerk'
   return (
     <Suspense fallback={<p>Loading...</p>}>
-      {ClerkSignUpPage ? <ClerkSignUpPage /> : <LocalSignUp />}
+      {isClerk ? <ClerkSignUpPage /> : <LocalSignUp />}
     </Suspense>
   )
 }

--- a/frontend/src/auth/signup-rejection.ts
+++ b/frontend/src/auth/signup-rejection.ts
@@ -4,6 +4,8 @@
 // /sign-in with no explanation. We remember the just-created Clerk user id here
 // so the sign-in page can ask the backend why, and show a real message.
 
+import { getApiBase, joinApiUrl } from '../api/base'
+
 const KEY = 'engram:pending-signup'
 const WINDOW_MS = 2 * 60 * 1000
 
@@ -38,7 +40,9 @@ export async function fetchSignupRejection(
   clerkUserId: string,
 ): Promise<SignupRejectionReason | null> {
   try {
-    const res = await fetch(`/api/auth/signup-rejection?clerk_id=${encodeURIComponent(clerkUserId)}`)
+    const res = await fetch(
+      joinApiUrl(getApiBase(), `/api/auth/signup-rejection?clerk_id=${encodeURIComponent(clerkUserId)}`),
+    )
     if (!res.ok) return null
     const body = (await res.json()) as { reason?: SignupRejectionReason | null }
     return body.reason ?? null

--- a/frontend/src/auth/use-bootstrap.ts
+++ b/frontend/src/auth/use-bootstrap.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { config } from '../config'
+import { useContext, useEffect, useState } from 'react'
+import { ConfigContext } from '../config-context'
 
 export interface Bootstrap {
   bootstrap_pending: boolean
@@ -13,11 +13,11 @@ export interface Bootstrap {
 // resolves, avoiding the default→correct flash on every navigation.
 export type BootstrapState = Bootstrap | null | undefined
 
-// Seed from Phoenix's SSR-injected runtime config when available. In prod
-// this means useBootstrap() is synchronous on first paint — no fetch, no
-// flash. In dev (Vite serves index.html, no injection) `config.bootstrap`
-// is undefined and we fall back to fetching the public endpoint.
-let cached: Bootstrap | null | undefined = config.bootstrap
+// Module-level cache so concurrent hook callers share one fetch + result.
+// Seeded from config.bootstrap on first hook invocation (the seed is
+// stable per page load — config is resolved once during Suspense gate).
+let cached: Bootstrap | null | undefined = undefined
+let seeded = false
 let inflight: Promise<Bootstrap | null> | null = null
 
 function fetchBootstrap(): Promise<Bootstrap | null> {
@@ -33,6 +33,20 @@ function fetchBootstrap(): Promise<Bootstrap | null> {
 }
 
 export function useBootstrap(): BootstrapState {
+  // Read context directly (not via useConfig()) so test environments that
+  // mount LocalSignIn / signup flows without a ConfigProvider don't crash.
+  // Bootstrap is a soft hint — a missing config just means "no seed, fetch".
+  const config = useContext(ConfigContext)
+
+  // Seed once from the SSR-injected config (selfhost-prod fast path: no
+  // fetch on first paint). On CF Pages /config.json typically omits this
+  // block — `config.bootstrap` is undefined and we drop through to the
+  // public /api/auth/bootstrap endpoint.
+  if (!seeded) {
+    cached = config?.bootstrap
+    seeded = true
+  }
+
   const [state, setState] = useState<BootstrapState>(cached)
 
   useEffect(() => {

--- a/frontend/src/auth/use-bootstrap.ts
+++ b/frontend/src/auth/use-bootstrap.ts
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState } from 'react'
 import { ConfigContext } from '../config-context'
+import { getApiBase, joinApiUrl } from '../api/base'
 
 export interface Bootstrap {
   bootstrap_pending: boolean
@@ -22,7 +23,7 @@ let inflight: Promise<Bootstrap | null> | null = null
 
 function fetchBootstrap(): Promise<Bootstrap | null> {
   if (inflight) return inflight
-  inflight = fetch('/api/auth/bootstrap')
+  inflight = fetch(joinApiUrl(getApiBase(), '/api/auth/bootstrap'))
     .then((r) => (r.ok ? r.json() : null))
     .catch(() => null)
     .then((b: Bootstrap | null) => {

--- a/frontend/src/auth/waitlist.tsx
+++ b/frontend/src/auth/waitlist.tsx
@@ -1,25 +1,22 @@
 import { lazy, Suspense } from 'react'
 import { Navigate } from 'react-router'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import { ROUTES } from '../routes'
 import AuthLayout from './auth-layout'
 
-const isClerk = config.authProvider === 'clerk'
-
-const ClerkWaitlistPage = isClerk
-  ? lazy(() =>
-      import('@clerk/react').then((mod) => ({
-        default: () => (
-          <AuthLayout>
-            <mod.Waitlist signInUrl={ROUTES.SIGN_IN} />
-          </AuthLayout>
-        ),
-      })),
-    )
-  : null
+const ClerkWaitlistPage = lazy(() =>
+  import('@clerk/react').then((mod) => ({
+    default: () => (
+      <AuthLayout>
+        <mod.Waitlist signInUrl={ROUTES.SIGN_IN} />
+      </AuthLayout>
+    ),
+  })),
+)
 
 export default function WaitlistPage() {
-  if (!ClerkWaitlistPage || !config.clerkWaitlistMode) {
+  const config = useConfig()
+  if (config.authProvider !== 'clerk' || !config.clerkWaitlistMode) {
     return <Navigate to={ROUTES.SIGN_UP} replace />
   }
 

--- a/frontend/src/billing/use-subscription-activated-events.ts
+++ b/frontend/src/billing/use-subscription-activated-events.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Socket } from 'phoenix'
 import { useAuthAdapter } from '../auth/use-auth-adapter'
+import { getWsBase, joinWsUrl } from '../api/base'
 
 export interface SubscriptionActivatedPayload {
   tier: string
@@ -40,7 +41,7 @@ export function useSubscriptionActivatedEvents({
       const token = await getToken()
       if (cancelled || !token) return
 
-      socket = new Socket('/socket', { params: { token } })
+      socket = new Socket(joinWsUrl(getWsBase(), '/socket'), { params: { token } })
       socket.connect()
 
       const channel = socket.channel(`user:${userId}`)

--- a/frontend/src/config-context.tsx
+++ b/frontend/src/config-context.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { EngramConfig } from './config'
+
+// Exported so non-component utilities (or test helpers) can read the raw
+// context without the throw-on-missing-provider guard `useConfig()` has.
+// 99% of consumers should use `useConfig()` — only reach for this when
+// you genuinely have a fallback path for the missing-provider case.
+export const ConfigContext = createContext<EngramConfig | null>(null)
+
+export function ConfigProvider({ config, children }: { config: EngramConfig; children: ReactNode }) {
+  return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+}
+
+// Throws if invoked outside <ConfigProvider> rather than returning a
+// silent default — a missing provider is a wiring bug, and a real value
+// here is load-bearing for auth provider selection / api-base URL
+// composition. Better to crash loud at the offending component than to
+// silently route through "selfhost defaults" in saas builds.
+export function useConfig(): EngramConfig {
+  const ctx = useContext(ConfigContext)
+  if (!ctx) {
+    throw new Error('useConfig() called outside <ConfigProvider>. Mount ConfigProvider at the app root.')
+  }
+  return ctx
+}

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -1,44 +1,83 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { loadConfig } from './config'
 
-type InjectedConfig = Record<string, unknown>
-
-function inject(value: InjectedConfig | undefined) {
-  ;(window as unknown as { __ENGRAM_CONFIG__?: InjectedConfig }).__ENGRAM_CONFIG__ = value
-}
-
 describe('loadConfig', () => {
-  afterEach(() => {
-    inject(undefined)
+  beforeEach(() => {
+    delete (window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__
+    vi.restoreAllMocks()
   })
 
-  it('reads billingEnabled=true from injected config', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', billingEnabled: true })
-    expect(loadConfig().billingEnabled).toBe(true)
+  it('reads apiBase + wsBase from window injection when present', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'clerk',
+      clerkPublishableKey: 'pk_test_x',
+      billingEnabled: true,
+      clerkWaitlistMode: false,
+      apiBase: '',
+      wsBase: '',
+    }
+
+    const config = await loadConfig()
+    expect(config.apiBase).toBe('')
+    expect(config.wsBase).toBe('')
+    expect(config.authProvider).toBe('clerk')
   })
 
-  it('treats a missing billingEnabled as false', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test' })
-    expect(loadConfig().billingEnabled).toBe(false)
+  it('fetches /config.json when window injection absent', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          authProvider: 'clerk',
+          clerkPublishableKey: 'pk_live_x',
+          billingEnabled: true,
+          clerkWaitlistMode: false,
+          apiBase: 'https://api.engram.page',
+          wsBase: 'wss://api.engram.page',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+
+    const config = await loadConfig()
+    expect(fetchMock).toHaveBeenCalledWith('/config.json', expect.objectContaining({ cache: 'no-cache' }))
+    expect(config.apiBase).toBe('https://api.engram.page')
+    expect(config.wsBase).toBe('wss://api.engram.page')
   })
 
-  it('coerces non-boolean billingEnabled to false (never truthy-by-accident)', () => {
-    inject({ authProvider: 'local', clerkPublishableKey: '', billingEnabled: 'yes' })
-    expect(loadConfig().billingEnabled).toBe(false)
+  it('falls back to local defaults when both window + /config.json fail', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network'))
+
+    const config = await loadConfig()
+    expect(config.authProvider).toBe('local')
+    expect(config.apiBase).toBe('')
   })
 
-  it('reads clerkWaitlistMode=true from injected config', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', clerkWaitlistMode: true })
-    expect(loadConfig().clerkWaitlistMode).toBe(true)
+  it('coerces non-boolean billingEnabled to false from window injection', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'local',
+      clerkPublishableKey: '',
+      billingEnabled: 'yes',
+    }
+    const config = await loadConfig()
+    expect(config.billingEnabled).toBe(false)
   })
 
-  it('treats a missing clerkWaitlistMode as false', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test' })
-    expect(loadConfig().clerkWaitlistMode).toBe(false)
+  it('coerces non-boolean clerkWaitlistMode to false from window injection', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'clerk',
+      clerkPublishableKey: 'pk_test',
+      clerkWaitlistMode: 'yes',
+    }
+    const config = await loadConfig()
+    expect(config.clerkWaitlistMode).toBe(false)
   })
 
-  it('coerces non-boolean clerkWaitlistMode to false (never truthy-by-accident)', () => {
-    inject({ authProvider: 'clerk', clerkPublishableKey: 'pk_test', clerkWaitlistMode: 'yes' })
-    expect(loadConfig().clerkWaitlistMode).toBe(false)
+  it('falls back to local provider when window has invalid authProvider', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'rogue',
+      clerkPublishableKey: '',
+    }
+    const config = await loadConfig()
+    expect(config.authProvider).toBe('local')
   })
 })

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -24,7 +24,7 @@ describe('loadConfig', () => {
   })
 
   it('fetches /config.json when window injection absent', async () => {
-    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
         JSON.stringify({
           authProvider: 'clerk',
@@ -45,7 +45,7 @@ describe('loadConfig', () => {
   })
 
   it('falls back to local defaults when both window + /config.json fail', async () => {
-    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network'))
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'))
 
     const config = await loadConfig()
     expect(config.authProvider).toBe('local')

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -72,6 +72,21 @@ describe('loadConfig', () => {
     expect(config.clerkWaitlistMode).toBe(false)
   })
 
+  it('coerces non-string apiBase/wsBase to empty string', async () => {
+    ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
+      authProvider: 'clerk',
+      clerkPublishableKey: 'pk_test_x',
+      billingEnabled: true,
+      clerkWaitlistMode: false,
+      apiBase: 123,                          // wrong type
+      wsBase: { url: 'wss://x' },            // wrong type
+    }
+
+    const config = await loadConfig()
+    expect(config.apiBase).toBe('')
+    expect(config.wsBase).toBe('')
+  })
+
   it('falls back to local provider when window has invalid authProvider', async () => {
     ;(window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__ = {
       authProvider: 'rogue',

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -32,11 +32,11 @@ function normalize(raw: Record<string, unknown>): EngramConfig {
 
   return {
     authProvider: provider,
-    clerkPublishableKey: (raw.clerkPublishableKey as string) ?? '',
+    clerkPublishableKey: typeof raw.clerkPublishableKey === 'string' ? raw.clerkPublishableKey : '',
     billingEnabled: raw.billingEnabled === true,
     clerkWaitlistMode: raw.clerkWaitlistMode === true,
-    apiBase: (raw.apiBase as string) ?? '',
-    wsBase: (raw.wsBase as string) ?? '',
+    apiBase: typeof raw.apiBase === 'string' ? raw.apiBase : '',
+    wsBase: typeof raw.wsBase === 'string' ? raw.wsBase : '',
     bootstrap: raw.bootstrap as EngramConfig['bootstrap'],
   }
 }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -6,9 +6,17 @@ export interface EngramConfig {
   // CTAs to /waitlist and passes waitlistUrl to <SignIn />. The dashboard
   // flag is the actual enforcement; this is presentational only.
   clerkWaitlistMode: boolean
+  // Runtime API base URL. Empty string = same-origin (selfhost, Phoenix
+  // serves both API and SPA). A full URL = saas (CF Pages serves SPA,
+  // backend hosted elsewhere — e.g. https://api.engram.page).
+  apiBase: string
+  // Runtime WebSocket base URL. Empty string = same-origin (selfhost).
+  // A full wss:// URL points Phoenix Socket at the cross-origin backend.
+  wsBase: string
   // Self-host SSR-injected bootstrap state. `null` under Clerk; `undefined`
-  // when the config script didn't ship one (Vite dev, older Phoenix build),
-  // in which case useBootstrap() falls back to fetching /api/auth/bootstrap.
+  // when the config didn't ship one (CF Pages serves static config.json
+  // without a bootstrap block; Vite dev; older Phoenix build), in which
+  // case useBootstrap() falls back to fetching /api/auth/bootstrap.
   bootstrap?: {
     bootstrap_pending: boolean
     registration_mode: 'open' | 'invite_only' | 'closed'
@@ -17,34 +25,65 @@ export interface EngramConfig {
 
 const VALID_PROVIDERS = ['local', 'clerk'] as const
 
-export function loadConfig(): EngramConfig {
-  const injected = (window as unknown as { __ENGRAM_CONFIG__?: Record<string, unknown> })
-    .__ENGRAM_CONFIG__
+function normalize(raw: Record<string, unknown>): EngramConfig {
+  const provider = VALID_PROVIDERS.includes(raw.authProvider as typeof VALID_PROVIDERS[number])
+    ? (raw.authProvider as 'local' | 'clerk')
+    : 'local'
 
-  if (injected && VALID_PROVIDERS.includes(injected.authProvider as typeof VALID_PROVIDERS[number])) {
-    return {
-      authProvider: injected.authProvider as 'local' | 'clerk',
-      clerkPublishableKey: (injected.clerkPublishableKey as string) ?? '',
-      billingEnabled: injected.billingEnabled === true,
-      clerkWaitlistMode: injected.clerkWaitlistMode === true,
-      bootstrap: injected.bootstrap as EngramConfig['bootstrap'],
-    }
+  return {
+    authProvider: provider,
+    clerkPublishableKey: (raw.clerkPublishableKey as string) ?? '',
+    billingEnabled: raw.billingEnabled === true,
+    clerkWaitlistMode: raw.clerkWaitlistMode === true,
+    apiBase: (raw.apiBase as string) ?? '',
+    wsBase: (raw.wsBase as string) ?? '',
+    bootstrap: raw.bootstrap as EngramConfig['bootstrap'],
   }
+}
 
-  // Vite dev server fallback — not served by Phoenix
-  if (import.meta.env.PROD && !injected) {
-    console.error(
-      '[engram] window.__ENGRAM_CONFIG__ not found. ' +
-      'Server may have failed to inject runtime config. Falling back to local auth.',
-    )
-  }
-
+function defaultConfig(): EngramConfig {
   return {
     authProvider: (import.meta.env.VITE_AUTH_PROVIDER as 'local' | 'clerk') ?? 'local',
     clerkPublishableKey: import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
     billingEnabled: import.meta.env.VITE_BILLING_ENABLED === 'true',
     clerkWaitlistMode: import.meta.env.VITE_CLERK_WAITLIST_MODE === 'true',
+    apiBase: import.meta.env.VITE_API_BASE ?? '',
+    wsBase: import.meta.env.VITE_WS_BASE ?? '',
   }
 }
 
-export const config = loadConfig()
+// Selfhost no-op contract: when Phoenix SSR-injects __ENGRAM_CONFIG__ this
+// resolves synchronously on first microtask (no fetch). Only the CF Pages
+// path (no injection) hits /config.json. Falls through to env-driven
+// defaults if both fail — emit a single console error in prod so a missing
+// /config.json deploy is loud rather than silently broken.
+export async function loadConfig(): Promise<EngramConfig> {
+  const injected = (window as unknown as { __ENGRAM_CONFIG__?: Record<string, unknown> })
+    .__ENGRAM_CONFIG__
+
+  if (injected) return normalize(injected)
+
+  try {
+    const res = await fetch('/config.json', { cache: 'no-cache' })
+    if (res.ok) {
+      const raw = await res.json()
+      return normalize(raw)
+    }
+  } catch {
+    // Fall through to defaults below.
+  }
+
+  if (import.meta.env.PROD) {
+    console.error(
+      '[engram] no window.__ENGRAM_CONFIG__ and /config.json unreachable. Falling back to defaults.',
+    )
+  }
+
+  return defaultConfig()
+}
+
+// Module-level promise — kicked off once at import time. `BootstrapGate`
+// awaits this via React 19's `use()` so the SPA mounts only after config
+// resolves. Re-imports get the same promise (module cache), so the fetch
+// fires at most once per page load.
+export const configPromise = loadConfig()

--- a/frontend/src/features/admin/AdminPanel.tsx
+++ b/frontend/src/features/admin/AdminPanel.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { useMe } from '@/api/queries'
-import { config } from '@/config'
+import { useConfig } from '@/config-context'
 import InvitesTab from './InvitesTab'
 import MembersTab from './MembersTab'
 import RegistrationTab from './RegistrationTab'
 
 export default function AdminPanel() {
+  const config = useConfig()
   const { data: me, isLoading } = useMe()
   // Lifted from MembersTab so the one-time reset link sits OUTSIDE the
   // Members card — its own standalone block above the table.

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { heading, fieldInput, destructiveAlert } from '@/lib/ui-classes'
 import { cn } from '@/lib/utils'
 import { ROUTES } from '@/routes'
+import { getApiBase, joinApiUrl } from '@/api/base'
 
 export default function ResetPasswordPage() {
   const [params] = useSearchParams()
@@ -32,7 +33,7 @@ export default function ResetPasswordPage() {
 
     setLoading(true)
     try {
-      const res = await fetch('/api/auth/password/reset', {
+      const res = await fetch(joinApiUrl(getApiBase(), '/api/auth/password/reset'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token, password }),

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import posthog from 'posthog-js'
 import { Toaster } from '@/components/ui/sonner'
 import { createAppRouter, installAppRouter } from './router'
 import { queryClient } from './api/query-client'
+import { setApiBase, setWsBase } from './api/base'
 import { configPromise, type EngramConfig } from './config'
 import { ConfigProvider } from './config-context'
 import { ThemeProvider } from './theme/theme-provider'
@@ -127,6 +128,12 @@ function AppShell({ config }: { config: EngramConfig }) {
 
 function BootstrapGate() {
   const config = use(configPromise)
+  // Install module-level apiBase/wsBase BEFORE any child component mounts.
+  // The singleton `api` object in src/api/client.ts and the WebSocket call
+  // sites read these via getApiBase()/getWsBase(); they need a value
+  // populated before AuthGuard fires its first fetch on mount.
+  setApiBase(config.apiBase)
+  setWsBase(config.wsBase)
   return <AppShell config={config} />
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,14 @@
-import { StrictMode, lazy, Suspense } from 'react'
+import { StrictMode, lazy, Suspense, use, useMemo } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router'
 import { QueryClientProvider } from '@tanstack/react-query'
 import * as Sentry from '@sentry/react'
 import posthog from 'posthog-js'
 import { Toaster } from '@/components/ui/sonner'
-import { router } from './router'
+import { createAppRouter, installAppRouter } from './router'
 import { queryClient } from './api/query-client'
-import { config } from './config'
+import { configPromise, type EngramConfig } from './config'
+import { ConfigProvider } from './config-context'
 import { ThemeProvider } from './theme/theme-provider'
 import LoadingScreen from './layout/loading-screen'
 import './main.css'
@@ -67,11 +68,10 @@ if (posthogKey) {
   })
 }
 
-const isClerk = config.authProvider === 'clerk'
-
-const AuthProvider = isClerk
-  ? lazy(() => import('./auth/clerk-auth-provider'))
-  : lazy(() => import('./auth/local-auth-provider'))
+// Both auth providers are declared lazy at module scope; only one is
+// instantiated per page load based on resolved config (BootstrapGate).
+const ClerkAuthProvider = lazy(() => import('./auth/clerk-auth-provider'))
+const LocalAuthProvider = lazy(() => import('./auth/local-auth-provider'))
 
 function ErrorFallback() {
   return (
@@ -94,9 +94,23 @@ function ErrorFallback() {
   )
 }
 
-createRoot(document.getElementById('root')!).render(
-  <Sentry.ErrorBoundary fallback={ErrorFallback}>
-    <StrictMode>
+// Bootstrap chain: `use(configPromise)` suspends until config resolves
+// (window injection → /config.json → defaults). Once resolved, build the
+// runtime router (route shape depends on auth provider + billingEnabled)
+// and install it so module-level consumers like clerk-auth-provider can
+// imperatively navigate via `getAppRouter()`.
+function AppShell({ config }: { config: EngramConfig }) {
+  const AuthProvider = config.authProvider === 'clerk' ? ClerkAuthProvider : LocalAuthProvider
+  // Memoize so StrictMode's double-render + any future ConfigProvider
+  // updates don't blow away the router instance + its history stack.
+  const router = useMemo(() => {
+    const r = createAppRouter(config)
+    installAppRouter(r)
+    return r
+  }, [config])
+
+  return (
+    <ConfigProvider config={config}>
       <ThemeProvider>
         <Suspense fallback={<LoadingScreen />}>
           <AuthProvider>
@@ -107,6 +121,21 @@ createRoot(document.getElementById('root')!).render(
           </AuthProvider>
         </Suspense>
       </ThemeProvider>
+    </ConfigProvider>
+  )
+}
+
+function BootstrapGate() {
+  const config = use(configPromise)
+  return <AppShell config={config} />
+}
+
+createRoot(document.getElementById('root')!).render(
+  <Sentry.ErrorBoundary fallback={ErrorFallback}>
+    <StrictMode>
+      <Suspense fallback={<LoadingScreen />}>
+        <BootstrapGate />
+      </Suspense>
     </StrictMode>
   </Sentry.ErrorBoundary>,
 )

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -3,7 +3,7 @@ import { Navigate, useNavigate } from 'react-router'
 import { FilePlus2 } from 'lucide-react'
 import obsidianMark from '@lobehub/icons-static-svg/icons/obsidian-color.svg?raw'
 import { setActiveVaultId } from '../api/active-vault'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import {
   useCreateVault,
   useMe,
@@ -265,6 +265,7 @@ interface ObsidianInlinePanelProps {
 }
 
 function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlinePanelProps) {
+  const config = useConfig()
   const { vaultCreated, vaultPopulated, vaultId } = useVaultReadyEvents({
     userId,
     enabled: true,

--- a/frontend/src/onboarding/tour/demo-vault-provider.tsx
+++ b/frontend/src/onboarding/tour/demo-vault-provider.tsx
@@ -47,6 +47,7 @@ export function DemoVaultProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState<DemoVaultData | null>(null)
 
   const activate = useCallback(async () => {
+    // Static SPA asset, not an API call — served from same origin on both selfhost and CF Pages.
     const res = await fetch('/demo-vault.json')
     if (!res.ok) throw new Error('demo fixture missing')
     const json = (await res.json()) as DemoVaultData

--- a/frontend/src/onboarding/use-vault-ready-events.ts
+++ b/frontend/src/onboarding/use-vault-ready-events.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Socket } from 'phoenix'
 import { useAuthAdapter } from '../auth/use-auth-adapter'
+import { getWsBase, joinWsUrl } from '../api/base'
 
 interface State {
   vaultCreated: boolean
@@ -40,7 +41,7 @@ export function useVaultReadyEvents({ userId, enabled }: Options): State {
       const token = await getToken()
       if (cancelled || !token) return
 
-      socket = new Socket('/socket', { params: { token } })
+      socket = new Socket(joinWsUrl(getWsBase(), '/socket'), { params: { token } })
       socket.connect()
 
       const channel = socket.channel(`user:${userId}`)

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,7 +6,7 @@ import SignUpPage from './auth/sign-up'
 import WaitlistPage from './auth/waitlist'
 import BillingPage from './billing/billing-page'
 import { UpgradeDialogProvider } from './billing/upgrade-dialog-provider'
-import { config } from './config'
+import type { EngramConfig } from './config'
 import AdminPanel from './features/admin/AdminPanel'
 import ResetPasswordPage from './features/auth/ResetPasswordPage'
 import DeviceLinkPage from './device/device-link-page'
@@ -29,14 +29,6 @@ import OnboardVaultPage from './onboarding/onboard-vault-page'
 import { OnboardingShell } from './onboarding/onboarding-shell'
 import { Outlet } from 'react-router'
 
-// Lazy so Clerk-only code (the account page pulls in @clerk/react hooks)
-// stays out of the main chunk for local self-host builds.
-const AccountPage = lazy(() =>
-  config.authProvider === 'clerk'
-    ? import('./settings/account-page')
-    : import('./settings/account-page-local'),
-)
-
 // Root layout — mounts the UpgradeDialogProvider INSIDE the router so the
 // dialog's `useNavigate` works, and so any nested API call that 402s opens
 // the modal via the module-level handler. Wrapping `RouterProvider` from
@@ -49,7 +41,36 @@ function RootLayout() {
   )
 }
 
-export const router = createBrowserRouter(
+// Router is constructed inside `createAppRouter(config)` so the auth-provider
+// and billing-enabled branches can read runtime config. Module-level
+// consumers (e.g. clerk-auth-provider's `routerPush`) read `appRouter`,
+// which BootstrapGate populates BEFORE first render via `installAppRouter`.
+type AppRouter = ReturnType<typeof createBrowserRouter>
+
+let _appRouter: AppRouter | null = null
+
+export function installAppRouter(r: AppRouter) {
+  _appRouter = r
+}
+
+// Lazy getter used by code paths that need to imperatively navigate
+// (e.g. Clerk's routerPush). Throws if invoked before BootstrapGate
+// mounted — that would be a wiring regression worth surfacing loudly.
+export function getAppRouter(): AppRouter {
+  if (!_appRouter) throw new Error('Router accessed before installAppRouter() ran')
+  return _appRouter
+}
+
+export function createAppRouter(config: EngramConfig): AppRouter {
+  // Lazy so Clerk-only code (the account page pulls in @clerk/react hooks)
+  // stays out of the main chunk for local self-host builds.
+  const AccountPage = lazy(() =>
+    config.authProvider === 'clerk'
+      ? import('./settings/account-page')
+      : import('./settings/account-page-local'),
+  )
+
+  return createBrowserRouter(
   [
     {
       element: <RootLayout />,
@@ -151,4 +172,5 @@ export const router = createBrowserRouter(
       ],
     },
   ],
-)
+  )
+}

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -4,30 +4,40 @@ import { MemoryRouter, Routes, Route } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import SettingsLayout from './settings-layout'
 import { ThemeProvider } from '../theme/theme-provider'
+import { ConfigProvider } from '../config-context'
+import type { EngramConfig } from '../config'
 
 vi.mock('../auth/use-auth-adapter', () => ({
   useAuthAdapter: () => ({ user: { email: 'todd@example.com' }, logout: vi.fn() }),
 }))
-vi.mock('../config', () => ({
-  config: { authProvider: 'clerk', clerkPublishableKey: '', billingEnabled: true },
-}))
+
+const testConfig: EngramConfig = {
+  authProvider: 'clerk',
+  clerkPublishableKey: '',
+  billingEnabled: true,
+  clerkWaitlistMode: false,
+  apiBase: '',
+  wsBase: '',
+}
 
 function renderAt(path: string) {
   // SettingsLayout now calls useMe(); give it a query client with retry off so
   // an unmocked /api/me fetch fails fast rather than retrying through the test.
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={client}>
-      <ThemeProvider>
-        <MemoryRouter initialEntries={[path]}>
-          <Routes>
-            <Route path="/settings" element={<SettingsLayout />}>
-              <Route path="api-keys" element={<p>api keys body</p>} />
-            </Route>
-          </Routes>
-        </MemoryRouter>
-      </ThemeProvider>
-    </QueryClientProvider>,
+    <ConfigProvider config={testConfig}>
+      <QueryClientProvider client={client}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={[path]}>
+            <Routes>
+              <Route path="/settings" element={<SettingsLayout />}>
+                <Route path="api-keys" element={<p>api keys body</p>} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </ConfigProvider>,
   )
 }
 

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -18,7 +18,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import { useMe } from '../api/queries'
-import { config } from '../config'
+import { useConfig } from '../config-context'
 import { buildSettingsSections, type SettingsSection } from './sections'
 
 function SettingsNavList({
@@ -52,6 +52,7 @@ function SettingsNavList({
 }
 
 export default function SettingsLayout() {
+  const config = useConfig()
   const { data: me } = useMe()
   const isAdmin = me?.role === 'admin'
   const sections = buildSettingsSections(config.authProvider, config.billingEnabled, isAdmin)

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -68,6 +68,12 @@ defmodule EngramWeb.Endpoint do
   end
 
   plug Plug.RequestId
+  # The plug itself reads `Application.get_env(:engram, :host_rewrite, [])`
+  # at request time (NOT compile time) so the runtime env flag actually
+  # takes effect on a saas release and tests can mutate it via
+  # `Application.put_env`. When unset (default), the plug is a strict
+  # no-op — selfhost releases never touch the rewrite path.
+  plug EngramWeb.Plugs.HostRewrite
   # `log: false` suppresses Phoenix.Logger's default request log emission,
   # which interpolates conn.method + conn.request_path into the message body
   # (past the metadata-only RedactFilter). EngramWeb.RequestLogger replaces

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -44,6 +44,22 @@ defmodule EngramWeb.Endpoint do
 
   defp normalize_origin(origin) when is_binary(origin), do: origin
 
+  # RequestId runs FIRST so request_id is attached to every response —
+  # including 404/410 rejections from HostRewrite — for log correlation.
+  plug Plug.RequestId
+
+  # HostRewrite runs BEFORE Plug.Static so saas-only host rejection (410
+  # Gone on app.engram.page after the saas-only cutover) covers static
+  # assets too — otherwise `app.engram.page/favicon.ico` and
+  # `app.engram.page/assets/*.js` would be served by Plug.Static and
+  # leak stale bundles past the rewrite contract. The plug itself reads
+  # `Application.get_env(:engram, :host_rewrite, [])` at request time
+  # (NOT compile time) so the runtime env flag actually takes effect on
+  # a saas release and tests can mutate it via `Application.put_env`.
+  # When unset (default), the plug is a strict no-op — selfhost releases
+  # never touch the rewrite path.
+  plug EngramWeb.Plugs.HostRewrite
+
   # Serve SPA hashed assets at "/assets/*" from priv/static/app/assets.
   # Vite outputs hashed filenames so these can be served with long-lived
   # cache headers (handled by Plug.Static's default).
@@ -67,13 +83,6 @@ defmodule EngramWeb.Endpoint do
     plug Phoenix.Ecto.CheckRepoStatus, otp_app: :engram
   end
 
-  plug Plug.RequestId
-  # The plug itself reads `Application.get_env(:engram, :host_rewrite, [])`
-  # at request time (NOT compile time) so the runtime env flag actually
-  # takes effect on a saas release and tests can mutate it via
-  # `Application.put_env`. When unset (default), the plug is a strict
-  # no-op — selfhost releases never touch the rewrite path.
-  plug EngramWeb.Plugs.HostRewrite
   # `log: false` suppresses Phoenix.Logger's default request log emission,
   # which interpolates conn.method + conn.request_path into the message body
   # (past the metadata-only RedactFilter). EngramWeb.RequestLogger replaces

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -59,7 +59,21 @@ defmodule EngramWeb.Plugs.HostRewrite do
     end
   end
 
-  defp handle_mcp_host(conn), do: conn
+  @mcp_wellknown_prefixes [
+    "/.well-known/oauth-protected-resource",
+    "/.well-known/oauth-authorization-server"
+  ]
+
+  defp handle_mcp_host(conn) do
+    path = conn.request_path
+
+    cond do
+      Enum.any?(@mcp_wellknown_prefixes, &String.starts_with?(path, &1)) -> conn
+      String.starts_with?(path, "/api/mcp") -> conn
+      path == "/" or path == "" -> rewrite_path(conn, "/api/mcp/")
+      true -> reject(conn)
+    end
+  end
 
   defp under_any?(path, prefixes), do: Enum.any?(prefixes, &is_under?(path, &1))
 

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -44,8 +44,13 @@ defmodule EngramWeb.Plugs.HostRewrite do
   def init([]), do: :runtime
   def init(:runtime), do: :runtime
 
-  def init(opts) when is_list(opts),
-    do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
+  def init(opts) when is_list(opts) do
+    opts
+    |> Keyword.put_new(:api_host, nil)
+    |> Keyword.put_new(:mcp_host, nil)
+    |> Keyword.put_new(:reject_unknown_hosts, false)
+    |> Keyword.put_new(:allowed_extra_hosts, [])
+  end
 
   def call(conn, :runtime) do
     case Application.get_env(:engram, :host_rewrite, []) do
@@ -63,8 +68,35 @@ defmodule EngramWeb.Plugs.HostRewrite do
     cond do
       api_host && conn.host == api_host -> handle_api_host(conn)
       mcp_host && conn.host == mcp_host -> handle_mcp_host(conn)
-      true -> conn
+      true -> handle_unknown_host(conn, opts)
     end
+  end
+
+  # When `:reject_unknown_hosts` is true AND the request host is not on the
+  # explicit allowlist, return 410 Gone with a pointer to `api_host`. This
+  # guards saas AWS Phoenix from serving the stale bundled SPA on hosts like
+  # `app.engram.page` (which after DNS cutover should resolve to Cloudflare
+  # Pages, not the ALB). Selfhost never sets this flag — defaults to false.
+  defp handle_unknown_host(conn, opts) do
+    if opts[:reject_unknown_hosts] && conn.host not in opts[:allowed_extra_hosts] do
+      reject_unknown(conn, opts[:api_host])
+    else
+      conn
+    end
+  end
+
+  defp reject_unknown(conn, api_host) do
+    body =
+      Jason.encode!(%{
+        error: "gone",
+        message: "This host no longer serves the web app. Use #{api_host} for API access.",
+        api_host: api_host
+      })
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(410, body)
+    |> halt()
   end
 
   defp handle_api_host(conn) do

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -35,9 +35,28 @@ defmodule EngramWeb.Plugs.HostRewrite do
     embed-status
   )
 
-  def init(opts), do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
+  # `init/1` normalizes opts to a keyword list with `:api_host` and
+  # `:mcp_host` keys. The endpoint mounts this plug without explicit opts,
+  # so `init([])` yields the runtime-read sentinel `:runtime`; `call/2`
+  # then looks up `Application.get_env(:engram, :host_rewrite, [])`
+  # per-request. Direct unit tests pass an explicit opts list (which
+  # always has at least one key here) and short-circuit the runtime read.
+  def init([]), do: :runtime
+  def init(:runtime), do: :runtime
 
-  def call(conn, opts) do
+  def init(opts) when is_list(opts),
+    do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
+
+  def call(conn, :runtime) do
+    case Application.get_env(:engram, :host_rewrite, []) do
+      # Strict no-op when unset — selfhost releases never touch the
+      # rewrite path.
+      [] -> conn
+      opts when is_list(opts) -> call(conn, init(opts))
+    end
+  end
+
+  def call(conn, opts) when is_list(opts) do
     api_host = opts[:api_host]
     mcp_host = opts[:mcp_host]
 

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -1,0 +1,31 @@
+defmodule EngramWeb.Plugs.HostRewrite do
+  @moduledoc """
+  Host-driven path rewrite for the dedicated `api.engram.page` and
+  `mcp.engram.page` saas hosts. The same Phoenix endpoint also serves
+  selfhost (`engram.ax`) and the canonical `app.engram.page` host without
+  any rewrite. Behavior:
+
+    * `api.engram.page` — prefix `/api` if the path doesn't already start
+      with `/api`, `/socket`, `/webhooks`, or `/.well-known`. After rewrite,
+      reject anything that would have resolved outside those scopes.
+    * `mcp.engram.page` — pass `/.well-known/oauth-*` through unmodified;
+      otherwise prefix `/api/mcp` if not already prefixed; reject anything
+      that would resolve outside `/api/mcp/*` or `/.well-known/oauth-*`.
+    * Any other host — passthrough.
+
+  Config-driven via `Application.get_env(:engram, :host_rewrite)`:
+
+      config :engram, :host_rewrite, api_host: "api.engram.page", mcp_host: "mcp.engram.page"
+
+  When unset (default), the plug is a strict no-op — selfhost releases never
+  touch the rewrite path.
+  """
+  import Plug.Conn
+
+  def init(opts), do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
+
+  def call(conn, opts) do
+    _ = opts
+    conn
+  end
+end

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -35,6 +35,12 @@ defmodule EngramWeb.Plugs.HostRewrite do
     embed-status
   )
 
+  # Test-only accessor exposing the @api_top_segments allowlist so the
+  # router-derived regression test can compare against router.__routes__/0.
+  # Underscored name signals "do not call from production code".
+  @doc false
+  def __api_top_segments__, do: @api_top_segments
+
   # `init/1` normalizes opts to a keyword list with `:api_host` and
   # `:mcp_host` keys. The endpoint mounts this plug without explicit opts,
   # so `init([])` yields the runtime-read sentinel `:runtime`; `call/2`

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -23,7 +23,7 @@ defmodule EngramWeb.Plugs.HostRewrite do
   import Plug.Conn
 
   # Allowed top-level scopes that should pass through unmodified on
-  # `api.engram.page`. Matched with `is_under?/2` (exact match OR followed
+  # `api.engram.page`. Matched with `under?/2` (exact match OR followed
   # by `/`) so `/api-keys` does NOT match `/api` — `/api-keys` is a known
   # API segment that needs rewriting to `/api/api-keys`.
   @api_allowed_prefixes ~w(/api /socket /webhooks /.well-known)
@@ -132,11 +132,11 @@ defmodule EngramWeb.Plugs.HostRewrite do
     end
   end
 
-  defp under_any?(path, prefixes), do: Enum.any?(prefixes, &is_under?(path, &1))
+  defp under_any?(path, prefixes), do: Enum.any?(prefixes, &under?(path, &1))
 
   # True when `path` equals `prefix` or starts with `prefix <> "/"`.
   # Distinguishes `/api/...` (true) from `/api-keys` (false).
-  defp is_under?(path, prefix),
+  defp under?(path, prefix),
     do: path == prefix or String.starts_with?(path, prefix <> "/")
 
   defp known_api_segment?(path) do

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -147,7 +147,8 @@ defmodule EngramWeb.Plugs.HostRewrite do
 
   defp reject(conn) do
     conn
-    |> send_resp(404, "Not Found")
+    |> put_resp_content_type("application/json")
+    |> send_resp(404, ~s({"error":"not_found"}))
     |> halt()
   end
 end

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -22,10 +22,67 @@ defmodule EngramWeb.Plugs.HostRewrite do
   """
   import Plug.Conn
 
+  # Allowed top-level scopes that should pass through unmodified on
+  # `api.engram.page`. Matched with `is_under?/2` (exact match OR followed
+  # by `/`) so `/api-keys` does NOT match `/api` — `/api-keys` is a deep
+  # API candidate that needs rewriting to `/api/api-keys`.
+  @api_allowed_prefixes ~w(/api /socket /webhooks /.well-known)
+  # Every top-level segment under `scope "/api", EngramWeb` in router.ex.
+  # Missing entries silently 404 in prod — guarded by a regression test.
+  @api_top_segments ~w(
+    notes folders search vaults attachments oauth mcp auth admin billing
+    tasks health user me onboarding api-keys connections tags sync logs
+    embed-status
+  )
+
   def init(opts), do: opts |> Keyword.put_new(:api_host, nil) |> Keyword.put_new(:mcp_host, nil)
 
   def call(conn, opts) do
-    _ = opts
+    api_host = opts[:api_host]
+    mcp_host = opts[:mcp_host]
+
+    cond do
+      api_host && conn.host == api_host -> handle_api_host(conn)
+      mcp_host && conn.host == mcp_host -> handle_mcp_host(conn)
+      true -> conn
+    end
+  end
+
+  defp handle_api_host(conn) do
+    path = conn.request_path
+
+    cond do
+      path == "/" or path == "" -> reject(conn)
+      under_any?(path, @api_allowed_prefixes) -> conn
+      not deep_api_candidate?(path) -> reject(conn)
+      true -> rewrite_path(conn, "/api" <> path)
+    end
+  end
+
+  defp handle_mcp_host(conn), do: conn
+
+  defp under_any?(path, prefixes), do: Enum.any?(prefixes, &is_under?(path, &1))
+
+  # True when `path` equals `prefix` or starts with `prefix <> "/"`.
+  # Distinguishes `/api/...` (true) from `/api-keys` (false).
+  defp is_under?(path, prefix),
+    do: path == prefix or String.starts_with?(path, prefix <> "/")
+
+  defp deep_api_candidate?(path) do
+    case String.split(path, "/", trim: true) do
+      [head | _] -> head in @api_top_segments
+      _ -> false
+    end
+  end
+
+  defp rewrite_path(conn, new_path) do
+    new_info = new_path |> String.trim_leading("/") |> String.split("/", trim: true)
+    %{conn | request_path: new_path, path_info: new_info}
+  end
+
+  defp reject(conn) do
     conn
+    |> send_resp(404, "Not Found")
+    |> halt()
   end
 end

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -24,8 +24,8 @@ defmodule EngramWeb.Plugs.HostRewrite do
 
   # Allowed top-level scopes that should pass through unmodified on
   # `api.engram.page`. Matched with `is_under?/2` (exact match OR followed
-  # by `/`) so `/api-keys` does NOT match `/api` — `/api-keys` is a deep
-  # API candidate that needs rewriting to `/api/api-keys`.
+  # by `/`) so `/api-keys` does NOT match `/api` — `/api-keys` is a known
+  # API segment that needs rewriting to `/api/api-keys`.
   @api_allowed_prefixes ~w(/api /socket /webhooks /.well-known)
   # Every top-level segment under `scope "/api", EngramWeb` in router.ex.
   # Missing entries silently 404 in prod — guarded by a regression test.
@@ -105,7 +105,7 @@ defmodule EngramWeb.Plugs.HostRewrite do
     cond do
       path == "/" or path == "" -> reject(conn)
       under_any?(path, @api_allowed_prefixes) -> conn
-      not deep_api_candidate?(path) -> reject(conn)
+      not known_api_segment?(path) -> reject(conn)
       true -> rewrite_path(conn, "/api" <> path)
     end
   end
@@ -133,7 +133,7 @@ defmodule EngramWeb.Plugs.HostRewrite do
   defp is_under?(path, prefix),
     do: path == prefix or String.starts_with?(path, prefix <> "/")
 
-  defp deep_api_candidate?(path) do
+  defp known_api_segment?(path) do
     case String.split(path, "/", trim: true) do
       [head | _] -> head in @api_top_segments
       _ -> false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.383",
+      version: "0.5.387",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/host_rewrite_integration_test.exs
+++ b/test/engram_web/host_rewrite_integration_test.exs
@@ -3,7 +3,11 @@ defmodule EngramWeb.HostRewriteIntegrationTest do
 
   setup do
     prior = Application.get_env(:engram, :host_rewrite)
-    Application.put_env(:engram, :host_rewrite, api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+
+    Application.put_env(:engram, :host_rewrite,
+      api_host: "api.engram.page",
+      mcp_host: "mcp.engram.page"
+    )
 
     on_exit(fn ->
       case prior do

--- a/test/engram_web/host_rewrite_integration_test.exs
+++ b/test/engram_web/host_rewrite_integration_test.exs
@@ -26,4 +26,33 @@ defmodule EngramWeb.HostRewriteIntegrationTest do
     assert conn.status == 200
     assert Jason.decode!(conn.resp_body)["resource"]
   end
+
+  describe "saas-only mode" do
+    setup do
+      prior = Application.get_env(:engram, :host_rewrite)
+
+      Application.put_env(:engram, :host_rewrite,
+        api_host: "api.engram.page",
+        mcp_host: "mcp.engram.page",
+        reject_unknown_hosts: true,
+        allowed_extra_hosts: []
+      )
+
+      on_exit(fn -> Application.put_env(:engram, :host_rewrite, prior) end)
+      :ok
+    end
+
+    test "GET app.engram.page/anything returns 410 with api host pointer", %{conn: conn} do
+      conn = %{conn | host: "app.engram.page"} |> get("/anything")
+      assert conn.status == 410
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"] == "gone"
+      assert body["api_host"] == "api.engram.page"
+    end
+
+    test "GET api.engram.page/notes still rewrites under saas-only mode", %{conn: conn} do
+      conn = %{conn | host: "api.engram.page"} |> get("/notes")
+      assert conn.status in [401, 403]
+    end
+  end
 end

--- a/test/engram_web/host_rewrite_integration_test.exs
+++ b/test/engram_web/host_rewrite_integration_test.exs
@@ -1,0 +1,29 @@
+defmodule EngramWeb.HostRewriteIntegrationTest do
+  use EngramWeb.ConnCase, async: false
+
+  setup do
+    prior = Application.get_env(:engram, :host_rewrite)
+    Application.put_env(:engram, :host_rewrite, api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+
+    on_exit(fn ->
+      case prior do
+        nil -> Application.delete_env(:engram, :host_rewrite)
+        _ -> Application.put_env(:engram, :host_rewrite, prior)
+      end
+    end)
+
+    :ok
+  end
+
+  test "GET api.engram.page/notes hits the same controller as /api/notes", %{conn: conn} do
+    conn = %{conn | host: "api.engram.page"} |> get("/notes")
+    # 401/403 acceptable (unauth). 404 would mean the rewrite didn't land.
+    assert conn.status in [401, 403]
+  end
+
+  test "GET mcp.engram.page/.well-known/oauth-protected-resource succeeds", %{conn: conn} do
+    conn = %{conn | host: "mcp.engram.page"} |> get("/.well-known/oauth-protected-resource")
+    assert conn.status == 200
+    assert Jason.decode!(conn.resp_body)["resource"]
+  end
+end

--- a/test/engram_web/plugs/cors_test.exs
+++ b/test/engram_web/plugs/cors_test.exs
@@ -73,4 +73,72 @@ defmodule EngramWeb.Plugs.CORSTest do
 
     assert get_resp_header(conn, "access-control-allow-origin") == ["http://engram.ax"]
   end
+
+  describe "ENGRAM_SAAS_FRONTEND_ORIGINS extras (Cloudflare Pages saas frontend)" do
+    # These tests simulate the post-cutover allowlist shape: the original
+    # phx_hosts origins PLUS the saas frontend origin (app.engram.page) and
+    # the Cloudflare Pages preview-deploy origin. ENGRAM_SAAS_FRONTEND_ORIGINS
+    # is consumed in config/runtime.exs at boot; here we set the final merged
+    # allowlist directly via :cors_origin to assert the plug's runtime behavior.
+
+    setup do
+      Application.put_env(:engram, :cors_origin, [
+        "https://api.engram.page",
+        "https://app.engram.page",
+        "https://engram-frontend.pages.dev"
+      ])
+
+      on_exit(fn -> Application.delete_env(:engram, :cors_origin) end)
+      :ok
+    end
+
+    test "echoes Origin for app.engram.page (saas frontend)" do
+      conn =
+        build_conn()
+        |> put_req_header("origin", "https://app.engram.page")
+        |> options("/api/health")
+
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               "https://app.engram.page"
+             ]
+    end
+
+    test "echoes Origin for Cloudflare Pages preview-deploy origin" do
+      conn =
+        build_conn()
+        |> put_req_header("origin", "https://engram-frontend.pages.dev")
+        |> options("/api/health")
+
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               "https://engram-frontend.pages.dev"
+             ]
+    end
+
+    test "rejects (does not echo) Origin not in extended allowlist" do
+      conn =
+        build_conn()
+        |> put_req_header("origin", "https://evil.example.com")
+        |> options("/api/health")
+
+      refute get_resp_header(conn, "access-control-allow-origin") == [
+               "https://evil.example.com"
+             ]
+
+      # Falls back to first allowlist entry instead.
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               "https://api.engram.page"
+             ]
+    end
+
+    test "still echoes original phx_hosts origin (api.engram.page)" do
+      conn =
+        build_conn()
+        |> put_req_header("origin", "https://api.engram.page")
+        |> options("/api/health")
+
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               "https://api.engram.page"
+             ]
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -93,4 +93,55 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       end
     end
   end
+
+  describe "mcp.engram.page" do
+    setup do
+      opts = HostRewrite.init(api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+      {:ok, opts: opts}
+    end
+
+    test "passes /.well-known/oauth-* through unchanged", %{opts: opts} do
+      for path <- ["/.well-known/oauth-protected-resource",
+                   "/.well-known/oauth-protected-resource/api/mcp",
+                   "/.well-known/oauth-authorization-server"] do
+        conn =
+          conn(:get, path)
+          |> Map.put(:host, "mcp.engram.page")
+          |> HostRewrite.call(opts)
+
+        assert conn.request_path == path
+        refute conn.halted, "#{path} should not be halted"
+      end
+    end
+
+    test "prefixes /api/mcp on bare paths", %{opts: opts} do
+      conn =
+        conn(:post, "/")
+        |> Map.put(:host, "mcp.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.request_path == "/api/mcp/"
+      refute conn.halted
+    end
+
+    test "passes through paths already prefixed /api/mcp", %{opts: opts} do
+      conn =
+        conn(:post, "/api/mcp/foo")
+        |> Map.put(:host, "mcp.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.request_path == "/api/mcp/foo"
+      refute conn.halted
+    end
+
+    test "rejects anything else with 404", %{opts: opts} do
+      conn =
+        conn(:get, "/notes")
+        |> Map.put(:host, "mcp.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.halted
+      assert conn.status == 404
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -1,0 +1,26 @@
+defmodule EngramWeb.Plugs.HostRewriteTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias EngramWeb.Plugs.HostRewrite
+
+  describe "selfhost / unconfigured passthrough" do
+    test "with no config, leaves conn untouched regardless of host" do
+      conn =
+        conn(:get, "/api/notes")
+        |> Map.put(:host, "engram.ax")
+
+      assert HostRewrite.call(conn, HostRewrite.init([])) == conn
+    end
+
+    test "with config but unmatched host, leaves conn untouched" do
+      opts = HostRewrite.init(api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+
+      conn =
+        conn(:get, "/api/notes")
+        |> Map.put(:host, "engram.ax")
+
+      assert HostRewrite.call(conn, opts) == conn
+    end
+  end
+end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -23,4 +23,74 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       assert HostRewrite.call(conn, opts) == conn
     end
   end
+
+  describe "api.engram.page" do
+    setup do
+      opts = HostRewrite.init(api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+      {:ok, opts: opts}
+    end
+
+    test "prefixes /api on bare path", %{opts: opts} do
+      conn =
+        conn(:get, "/notes/abc")
+        |> Map.put(:host, "api.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.request_path == "/api/notes/abc"
+      assert conn.path_info == ["api", "notes", "abc"]
+      refute conn.halted
+    end
+
+    test "passes through paths already prefixed /api", %{opts: opts} do
+      conn =
+        conn(:get, "/api/notes/abc")
+        |> Map.put(:host, "api.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.request_path == "/api/notes/abc"
+      refute conn.halted
+    end
+
+    test "passes through /socket, /webhooks, /.well-known", %{opts: opts} do
+      for path <- ["/socket/websocket", "/webhooks/paddle", "/.well-known/oauth-authorization-server"] do
+        conn =
+          conn(:get, path)
+          |> Map.put(:host, "api.engram.page")
+          |> HostRewrite.call(opts)
+
+        assert conn.request_path == path
+        refute conn.halted, "#{path} should not be halted"
+      end
+    end
+
+    test "rejects paths under SPA root with 404", %{opts: opts} do
+      conn =
+        conn(:get, "/login")
+        |> Map.put(:host, "api.engram.page")
+        |> HostRewrite.call(opts)
+
+      assert conn.halted
+      assert conn.status == 404
+    end
+
+    # Regression: every top-level segment under `scope "/api"` in router.ex
+    # must be in @api_top_segments — missing entries = silent 404 in prod.
+    test "rewrites all router-known /api top segments", %{opts: opts} do
+      segments = ~w(
+        notes folders search vaults attachments oauth mcp auth admin billing
+        tasks health user me onboarding api-keys connections tags sync logs
+        embed-status
+      )
+
+      for seg <- segments do
+        conn =
+          conn(:get, "/" <> seg)
+          |> Map.put(:host, "api.engram.page")
+          |> HostRewrite.call(opts)
+
+        refute conn.halted, "/#{seg} on api.engram.page should be rewritten, not rejected"
+        assert conn.request_path == "/api/" <> seg
+      end
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -217,4 +217,27 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       refute out.halted
     end
   end
+
+  describe "router/@api_top_segments coherence" do
+    test "@api_top_segments covers every router-registered /api top segment" do
+      # Walk the router and confirm every distinct /api/<seg> top-level
+      # segment is present in @api_top_segments. A missing entry would
+      # silently 404 on api.engram.page in prod — this test fails loudly
+      # the moment a new /api scope is added without updating the plug.
+      router_segments =
+        EngramWeb.Router.__routes__()
+        |> Enum.filter(&String.starts_with?(&1.path, "/api/"))
+        |> Enum.map(&(&1.path |> String.split("/", trim: true) |> Enum.at(1)))
+        |> Enum.reject(&is_nil/1)
+        |> MapSet.new()
+
+      plug_segments = MapSet.new(HostRewrite.__api_top_segments__())
+
+      missing = MapSet.difference(router_segments, plug_segments)
+
+      assert MapSet.size(missing) == 0,
+             "Router has /api routes for segments [#{Enum.join(Enum.to_list(missing), ", ")}] but " <>
+               "plug @api_top_segments doesn't list them — silent 404 in prod"
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -52,7 +52,11 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
     end
 
     test "passes through /socket, /webhooks, /.well-known", %{opts: opts} do
-      for path <- ["/socket/websocket", "/webhooks/paddle", "/.well-known/oauth-authorization-server"] do
+      for path <- [
+            "/socket/websocket",
+            "/webhooks/paddle",
+            "/.well-known/oauth-authorization-server"
+          ] do
         conn =
           conn(:get, path)
           |> Map.put(:host, "api.engram.page")
@@ -101,9 +105,11 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
     end
 
     test "passes /.well-known/oauth-* through unchanged", %{opts: opts} do
-      for path <- ["/.well-known/oauth-protected-resource",
-                   "/.well-known/oauth-protected-resource/api/mcp",
-                   "/.well-known/oauth-authorization-server"] do
+      for path <- [
+            "/.well-known/oauth-protected-resource",
+            "/.well-known/oauth-protected-resource/api/mcp",
+            "/.well-known/oauth-authorization-server"
+          ] do
         conn =
           conn(:get, path)
           |> Map.put(:host, "mcp.engram.page")

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -144,4 +144,77 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       assert conn.status == 404
     end
   end
+
+  describe "reject_unknown_hosts" do
+    test "with reject_unknown_hosts=false (default), unknown host passes through" do
+      opts = HostRewrite.init(api_host: "api.engram.page", mcp_host: "mcp.engram.page")
+      conn = conn(:get, "/anything") |> Map.put(:host, "app.engram.page")
+      out = HostRewrite.call(conn, opts)
+
+      assert out == conn
+      refute out.halted
+    end
+
+    test "with reject_unknown_hosts=true, unknown host returns 410 Gone" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true
+        )
+
+      conn = conn(:get, "/anything") |> Map.put(:host, "app.engram.page")
+      out = HostRewrite.call(conn, opts)
+
+      assert out.halted
+      assert out.status == 410
+      body = Jason.decode!(out.resp_body)
+      assert body["error"] == "gone"
+      assert body["api_host"] == "api.engram.page"
+      assert body["message"] =~ "api.engram.page"
+    end
+
+    test "with reject_unknown_hosts=true, api_host still rewrites normally" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true
+        )
+
+      conn = conn(:get, "/notes") |> Map.put(:host, "api.engram.page")
+      out = HostRewrite.call(conn, opts)
+
+      assert out.request_path == "/api/notes"
+      refute out.halted
+    end
+
+    test "with reject_unknown_hosts=true and allowed_extra_hosts, listed host passes through" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true,
+          allowed_extra_hosts: ["health.internal", "alb-probe.local"]
+        )
+
+      conn = conn(:get, "/health") |> Map.put(:host, "health.internal")
+      out = HostRewrite.call(conn, opts)
+
+      refute out.halted
+      assert out == conn
+    end
+
+    test "with reject_unknown_hosts=true, selfhost-style empty config remains passthrough" do
+      # This proves the no-op contract: passing [] (selfhost) ignores the
+      # reject_unknown_hosts setting because api_host is nil → dispatch skips
+      # the rejection branch.
+      opts = HostRewrite.init([])
+      conn = conn(:get, "/anything") |> Map.put(:host, "engram.ax")
+      out = HostRewrite.call(conn, opts)
+
+      assert out == conn
+      refute out.halted
+    end
+  end
 end

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -1,6 +1,6 @@
 defmodule EngramWeb.Plugs.HostRewriteTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+  import Plug.Test
 
   alias EngramWeb.Plugs.HostRewrite
 


### PR DESCRIPTION
## Summary

Bundles Phases A–D of the Frontend Eject to Cloudflare Pages migration into one PR (per workspace spec + plan `2026-06-10-frontend-eject-cloudflare-pages-*`).

This PR adds all the **dormant** code the saas frontend eject needs. Nothing changes runtime behavior on prod until the engram-infra side (Phase F) sets the env vars in ECS. Selfhost is unaffected by construction in every commit — verified across 2495 backend tests + 441 frontend tests + selfhost build smoke.

## What's in here

### Phase A — HostRewrite plug
- New `EngramWeb.Plugs.HostRewrite` rewrites `api.engram.page/notes` → `/api/notes` and `mcp.engram.page/` → `/api/mcp/`.
- `ENGRAM_SAAS_ONLY=true` returns 410 Gone with JSON `{"error":"gone","api_host":"..."}` for unknown hosts. Defense for direct ALB hits after the DNS cutover.
- HostRewrite placed BEFORE `Plug.Static` so saas-only 410 also covers `/favicon.ico` + `/assets/*.js`.
- Router-derived coherence test catches new `/api/<seg>` scopes that aren't in `@api_top_segments`.
- 17 unit + 4 integration tests.

### Phase B — CORS + WS allowlist
- New `ENGRAM_SAAS_FRONTEND_ORIGINS` env (comma-separated) appends extra origins to BOTH `:cors_origin` and `:websocket_check_origin`. Same merged list, no drift.
- 4 new CORS tests.

### Phase C — Async frontend config + apiBase/wsBase
- `EngramConfig` gains `apiBase: string` + `wsBase: string`.
- `loadConfig()` async: window injection → `/config.json` fetch → `import.meta.env` defaults.
- `<ConfigProvider>` + `useConfig()` hook replace sync `config` named export.
- React 19 `use(configPromise)` Suspense gate at mount.
- 9 consumer files migrated; `router.tsx` becomes factory; `api/client.ts` uses `setApiBase`/`getApiBase` singleton (mirrors existing `setTokenGetter`).
- Type-guards on `apiBase`/`wsBase` (silent prod failure mitigation).

### Phase D — Build split
- `bun run build:saas` writes to `frontend/dist/` (`--outDir dist --emptyOutDir`) + emits `dist/config.json` from `VITE_*` env.
- `bun run build:selfhost` keeps writing to `../priv/static/app/` per Vite config (Phoenix release path).
- `bun run build` aliases `build:selfhost`. Dockerfile calls `build:selfhost` explicitly.

## Selfhost = zero behavior change

- HostRewrite plug is no-op when `ENGRAM_HOST_REWRITE_ENABLED` unset
- CORS allowlist unchanged when `ENGRAM_SAAS_FRONTEND_ORIGINS` unset
- Phoenix `SpaController` continues injecting `window.__ENGRAM_CONFIG__`; sync short-circuit wins before `/config.json` fetch path
- `apiBase=""` + `wsBase=""` → same-origin (selfhost default)
- Dockerfile selfhost build unchanged (Phoenix priv/static/app)

## Test posture

- **Backend:** `mix test` 2495 pass, 0 failures, 7 skipped, 3 excluded
- **Frontend:** `bun run test` 441 pass + 1 skip across 93 files (2 pre-existing async-teardown errors in `device-link-page.test.tsx`, unrelated — same shape as on main)
- **Builds:** `bun run build:selfhost` clean → `priv/static/app/`; `bun run build:saas` with env → `frontend/dist/{index.html,config.json,assets/*}`
- **Typecheck:** `bunx tsc --noEmit` clean
- **Lint:** `mix format` + Credo + Sobelow all green
- **Selfhost regression check:** `make dev-selfhost` boot smoke passes

## Env vars added (all opt-in, none required for selfhost)

| Var | When | Default | Effect |
|---|---|---|---|
| `ENGRAM_HOST_REWRITE_ENABLED` | Phase F | unset | Activates HostRewrite plug |
| `ENGRAM_HOST_REWRITE_API_HOST` | Phase F | `api.engram.page` | api host that triggers `/api/*` prefix |
| `ENGRAM_HOST_REWRITE_MCP_HOST` | Phase F | `mcp.engram.page` | mcp host that triggers `/api/mcp/*` prefix |
| `ENGRAM_SAAS_ONLY` | Phase F | unset | Unknown hosts get 410 Gone |
| `ENGRAM_ALLOWED_EXTRA_HOSTS` | Phase F | unset | Comma-separated allowlist exceptions |
| `ENGRAM_SAAS_FRONTEND_ORIGINS` | Phase F | unset | Comma-separated extra CORS/WS origins |

## Supersedes

Closes #512 #513 #514 #515 (bundled).

## Next

Phase E + F (engram-infra: ACM SANs + Route53 + CF Pages project + ECS env flip) and Phase M (DNS cutover) happen in the engram-infra repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)