### PR TITLE
feat(cutover): serve app.engram.page from the Worker (Phase M)

### DIFF
--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -4,18 +4,21 @@
 	"compatibility_date": "2026-06-10",
 	// Pure static SPA — no Worker script (`main`), just edge-served assets.
 	// `bun run build:saas` emits the bundle + config.json into ./dist.
-	"workers_dev": true,
+	"workers_dev": false,
+	// CUTOVER (Phase M): serve app.engram.page from this Worker via a ROUTE,
+	// not a custom domain. A route shadows the existing proxied
+	// app.engram.page → ALB DNS record (CF runs Worker routes before the
+	// origin), so there's no DNS change, no conflict, and no outage — and
+	// reverting is just removing this route + redeploying. The TF-managed
+	// app_engram_page CNAME stays (the route needs a proxied record to exist).
+	// The deploy token carries Zone → Workers Routes:Edit on engram.page.
+	"routes": [
+		{ "pattern": "app.engram.page/*", "zone_name": "engram.page" }
+	],
 	"assets": {
 		"directory": "./dist",
 		// Serve index.html (200) for any path that isn't a built asset, so
 		// React Router client-side routes (deep links, /settings, etc.) work.
 		"not_found_handling": "single-page-application"
 	}
-	// NOTE: the app.engram.page custom domain is intentionally NOT here yet.
-	// Until the Phase M cutover this Worker is reachable only at its
-	// *.workers.dev URL (for smoke testing); app.engram.page keeps serving
-	// from the AWS ALB (TF-managed CNAME in engram-infra). At cutover, add:
-	//   "routes": [{ "pattern": "app.engram.page", "custom_domain": true }]
-	// and remove the TF app_engram_page DNS record (they can't both own the
-	// hostname). See docs/context/frontend-eject-cloudflare-pages.md.
 }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.390",
+      version: "0.5.391",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Phase M cutover. Adds a Worker route `app.engram.page/*` (zone `engram.page`) to `frontend/wrangler.jsonc` so the `engram-frontend` Worker serves the live domain.

**Route, not custom domain** — deliberately. A route shadows the existing proxied `app.engram.page` → ALB record (CF runs Worker routes before the origin), so:
- No DNS change, no record conflict, **no outage**
- Instantly revertable (remove the route + redeploy, or delete the route in CF)
- The TF-managed `app_engram_page` CNAME stays in place (the route needs a proxied record to exist) — no engram-infra change, no Grafana-blocked apply

`workers_dev` off (don't expose the `*.workers.dev` URL post-cutover). The deploy bakes the prod `pk_live` Clerk key (valid on `app.engram.page`).

## On merge
The `deploy-frontend` job (in verify.yml) builds `build:saas` + `wrangler deploy`, which registers the route → `app.engram.page` starts serving from the Worker.

## Verified pre-merge
- `bun run build:saas` + `wrangler deploy --dry-run` — valid (267 files, route config parses)
- Backend already live + verified: `api.engram.page` (401 on /notes), `mcp.engram.page` discovery, CORS for app.engram.page, AOP, 3-name cert

## Rollback
Remove the route from wrangler.jsonc + redeploy (or delete the route via CF API) → `app.engram.page` falls back to the ALB-served SPA within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)