### PR TITLE
fix(ci): deploy-frontend runs when ci is cache-skipped

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3054,12 +3054,18 @@ jobs:
   # secrets.CLOUDFLARE_ACCOUNT_ID + secrets.VITE_CLERK_PUBLISHABLE_KEY.
   deploy-frontend:
     name: Deploy frontend (Cloudflare Workers)
-    needs: [ci]
+    needs: [ci, fingerprint]
     # Auto-deploy on main push (path-guarded below); also manually triggerable
     # via the "CI" workflow's "Run workflow" button (workflow_dispatch) for
     # on-demand smoke / the Phase M cutover.
+    #
+    # `ci` is SKIPPED (not success) when the fingerprint cache shows this exact
+    # content already passed — so accept that case too, matching the
+    # build-and-publish-image / submit-dep-graph gate convention in this file.
     if: >-
-      always() && needs.ci.result == 'success' &&
+      always() &&
+      (needs.ci.result == 'success' ||
+       (needs.fingerprint.outputs.backend-cache-hit == 'true' && needs.fingerprint.outputs.e2e-cache-hit == 'true')) &&
       (github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'push' && github.ref == 'refs/heads/main'))
     runs-on: [self-hosted, linux, x64, isolated]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.391",
+      version: "0.5.392",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

The `deploy-frontend` job (added in #520) gated on `needs.ci.result == 'success'`. But `ci` is **skipped** (not success) when the fingerprint cache shows the content already passed — which is exactly what happened on the #525 cutover merge (frontend-only change → backend cache-hit → `ci` skipped → deploy skipped, so the route never registered).

Fix: accept the cache-skipped case too, mirroring the `build-and-publish-image` / `submit-dep-graph` gate convention already in this file:

```
needs.ci.result == 'success' ||
(fingerprint.backend-cache-hit == 'true' && fingerprint.e2e-cache-hit == 'true')
```

(adds `fingerprint` to `needs` for the outputs.)

After this merges I'll `workflow_dispatch` the CI workflow on main to run the (already-merged, #525) cutover deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)