### PR TITLE
fix(mcp-oauth): OAuth pairing on the ejected mcp.engram.page host

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -630,6 +630,15 @@ if config_env() == :prod do
       allowed_extra_hosts: extra_hosts
   end
 
+  # Absolute base URL of the frontend (SPA) host. After the saas eject the SPA
+  # lives on a different origin (app.engram.page) than the backend it reaches
+  # on api./mcp.engram.page, so the OAuth /authorize flow must 302 the consent
+  # page there absolutely instead of relative. Unset on self-host (same-origin
+  # → relative redirect). See EngramWeb.OAuthAuthorizeController.redirect_to_spa.
+  if url = System.get_env("ENGRAM_FRONTEND_URL") do
+    config :engram, :frontend_base_url, url
+  end
+
   # ## SSL Support
   #
   # To get SSL working, you will need to add the `https` key

--- a/lib/engram_web/controllers/oauth_authorize_controller.ex
+++ b/lib/engram_web/controllers/oauth_authorize_controller.ex
@@ -77,9 +77,23 @@ defmodule EngramWeb.OAuthAuthorizeController do
       |> Map.take(@forwarded_params)
       |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
 
-    location = "/oauth/consent?" <> URI.encode_query(forwarded)
+    query = URI.encode_query(forwarded)
 
-    conn |> put_status(302) |> redirect(to: location)
+    # The SPA consent page lives on the frontend host. Same-origin on self-host
+    # (relative `/oauth/consent` resolves correctly), but after the saas eject
+    # this controller is reached on api./mcp.engram.page while the SPA is on
+    # app.engram.page — a relative redirect would resolve to the wrong host and
+    # 404. When `:frontend_base_url` is configured, redirect there absolutely;
+    # otherwise stay relative (self-host / dev).
+    conn = put_status(conn, 302)
+
+    case Application.get_env(:engram, :frontend_base_url) do
+      url when is_binary(url) and url != "" ->
+        redirect(conn, external: "#{String.trim_trailing(url, "/")}/oauth/consent?#{query}")
+
+      _ ->
+        redirect(conn, to: "/oauth/consent?#{query}")
+    end
   end
 
   defp render_client_error(conn, code) do

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -127,6 +127,11 @@ defmodule EngramWeb.Plugs.HostRewrite do
     cond do
       Enum.any?(@mcp_wellknown_prefixes, &String.starts_with?(path, &1)) -> conn
       String.starts_with?(path, "/api/mcp") -> conn
+      # OAuth 2.1 + DCR endpoints (/oauth/authorize|token|register|revoke). The
+      # MCP discovery doc advertises mcp.engram.page/oauth/* as the auth server,
+      # so these must reach the backend's top-level /oauth routes unchanged —
+      # without this they 404 and no client can pair on the dedicated host.
+      String.starts_with?(path, "/oauth") -> conn
       path == "/" or path == "" -> rewrite_path(conn, "/api/mcp/")
       true -> reject(conn)
     end

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -83,11 +83,23 @@ defmodule EngramWeb.Plugs.HostRewrite do
   # guards saas AWS Phoenix from serving the stale bundled SPA on hosts like
   # `app.engram.page` (which after DNS cutover should resolve to Cloudflare
   # Pages, not the ALB). Selfhost never sets this flag — defaults to false.
+  # Health probes hit this plug on hosts that are neither api_host nor
+  # mcp_host: the ALB target-group HC (`/api/health/deep`, Host = task IP)
+  # and the ECS container HC (`curl localhost:4000/api/health`). They MUST
+  # pass through on any host — otherwise reject_unknown_hosts=true would 410
+  # them, tasks go unhealthy, and the deployment circuit breaker rolls back.
+  @health_paths ~w(/api/health /api/health/deep)
+
   defp handle_unknown_host(conn, opts) do
-    if opts[:reject_unknown_hosts] && conn.host not in opts[:allowed_extra_hosts] do
-      reject_unknown(conn, opts[:api_host])
-    else
-      conn
+    cond do
+      conn.request_path in @health_paths ->
+        conn
+
+      opts[:reject_unknown_hosts] && conn.host not in opts[:allowed_extra_hosts] ->
+        reject_unknown(conn, opts[:api_host])
+
+      true ->
+        conn
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.392",
+      version: "0.5.393",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.393",
+      version: "0.5.394",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -120,6 +120,18 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       end
     end
 
+    test "passes /oauth/* (DCR + authorize/token) through unchanged", %{opts: opts} do
+      for path <- ["/oauth/authorize", "/oauth/token", "/oauth/register", "/oauth/revoke"] do
+        conn =
+          conn(:get, path)
+          |> Map.put(:host, "mcp.engram.page")
+          |> HostRewrite.call(opts)
+
+        assert conn.request_path == path
+        refute conn.halted, "#{path} should not be halted"
+      end
+    end
+
     test "prefixes /api/mcp on bare paths", %{opts: opts} do
       conn =
         conn(:post, "/")

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -223,6 +223,54 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       assert out == conn
     end
 
+    # The ALB target-group HC (/api/health/deep, Host = task IP) and the ECS
+    # container HC (`curl localhost:4000/api/health`, Host = localhost) hit
+    # this plug on hosts that are neither api_host nor mcp_host. Without an
+    # exemption, reject_unknown_hosts=true would 410 them → unhealthy tasks →
+    # circuit-breaker rollback. Health probes must pass through on ANY host.
+    test "with reject_unknown_hosts=true, /api/health passes through on localhost (container HC)" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true
+        )
+
+      conn = conn(:get, "/api/health") |> Map.put(:host, "localhost")
+      out = HostRewrite.call(conn, opts)
+
+      refute out.halted
+    end
+
+    test "with reject_unknown_hosts=true, /api/health/deep passes through on a task-IP host (ALB HC)" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true
+        )
+
+      conn = conn(:get, "/api/health/deep") |> Map.put(:host, "10.0.3.41")
+      out = HostRewrite.call(conn, opts)
+
+      refute out.halted
+    end
+
+    test "with reject_unknown_hosts=true, non-health /api path on unknown host still 410s" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true
+        )
+
+      conn = conn(:get, "/api/notes") |> Map.put(:host, "10.0.3.41")
+      out = HostRewrite.call(conn, opts)
+
+      assert out.halted
+      assert out.status == 410
+    end
+
     test "with reject_unknown_hosts=true, selfhost-style empty config remains passthrough" do
       # This proves the no-op contract: passing [] (selfhost) ignores the
       # reject_unknown_hosts setting because api_host is nil → dispatch skips


### PR DESCRIPTION
## Summary

The eject left MCP OAuth pairing broken on `mcp.engram.page` (the transport works — 401 — but no client can authenticate). Two causes:

1. **HostRewrite rejected `/oauth/*`** on the mcp host (only `/api/mcp` + `/.well-known/oauth-*` passed). The discovery doc advertises `mcp.engram.page/oauth/{authorize,token,register}` → all **404**.
2. **`redirect_to_spa` used a relative** `/oauth/consent` redirect. Pre-eject that resolved to the same-host SPA; post-eject `/oauth/authorize` runs on `mcp.engram.page` while the SPA is on `app.engram.page`, so it resolved to the wrong host.

## Fixes
- HostRewrite mcp handler: pass `/oauth/*` through unchanged.
- `redirect_to_spa`: when `:frontend_base_url` is set, 302 consent to that absolute host; else relative (self-host, same-origin).
- `runtime.exs`: `:frontend_base_url` from `ENGRAM_FRONTEND_URL`.

## Self-host unaffected
`ENGRAM_FRONTEND_URL` unset → relative redirect (same-origin), HostRewrite no-op.

## ⚠️ Deploy dependencies
1. Set `ENGRAM_FRONTEND_URL=https://app.engram.page` in the prod ECS task (engram-infra) — separate small PR, **deliberately not bundled** because infra applies are currently failing on the unrelated PG18/UUIDv7 + Grafana drift.
2. A clean backend release — **blocked until the PG18/UUIDv7 rollout (#524/#474/#476) is fixed** (its image crash-loops; prod is held on the prior healthy image by the circuit breaker).

Until both land, new MCP clients can't pair on `mcp.engram.page`. The rest of the eject (web app on `app.engram.page`, `api.engram.page`) is live and unaffected.

## Tests
- `mix test test/engram_web/plugs/host_rewrite_test.exs` — 18 pass (added `/oauth/*` passthrough case)
- `mix compile --warnings-as-errors` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)