### PR TITLE
perf: read-path decrypt batching + telemetry + folder query trims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ Self-host (no `PADDLE_API_KEY`): free, no billing wiring. See `docs/context/padd
 | `docs/context/local-supabase-audit.md` | Throwaway local Supabase stack to run Studio Security/Performance Advisors against the Engram schema (AVX2 CLI build, encrypted-seed, RLS role grant, boot-canary gotchas) |
 | `docs/context/spa-state-injection.md` | How Phoenix ships server-known state into `window.__ENGRAM_CONFIG__` so the React SPA can render first-paint-correct UI without a fetch round-trip — the recipe for adding new injected fields, dev vs prod behavior, gotchas (NOT real SSR; see #353) |
 | `docs/context/pg18-uuidv7-prod-crashloop-2026-06-11.md` | PG18/UUIDv7 prod crash-loop root cause: in-place RDS engine bump preserved data instead of the specced taint+recreate, so the wreck-and-recreate baseline never replayed → integer PKs vs `Ecto.UUID` schemas → boot ArgumentError. Includes the guarded `reset_baseline/0` fix |
+| `docs/context/read-path-decrypt-perf.md` | Read-path decrypt perf: parallel_map economics (3.6× on 50KB content, SLOWER on path-sized payloads — keep those sequential), local test DB needs PG18 on :5433 post-uuidv7 (symptom table), why manifest needs no `(user_id, vault_id, kind)` index, decrypt_batch/dek_cache telemetry to check first |
 | `../engram-workspace/docs/context/pricing-strategy.md` | Cross-workspace SaaS pricing model (lives in workspace repo) |
 
 ## Life OS

--- a/docs/context/read-path-decrypt-perf.md
+++ b/docs/context/read-path-decrypt-perf.md
@@ -1,0 +1,54 @@
+Title: Read-path decrypt performance — parallel decrypt economics, test-DB PG18 requirement, manifest indexing
+
+_Last verified: 2026-06-12 (discovered during PR #530, `perf/read-path-decrypt-batching`)_
+
+## Local test DB now requires PostgreSQL 18 on port 5433
+
+Since the PG18 + UUIDv7 PK rework (PR #524, see `pg18-uuidv7-prod-crashloop-2026-06-11.md`), `mix test` against the default `localhost:5432` (the old `backend-postgres-1` container) fails massively.
+
+| Symptom | Cause |
+|---------|-------|
+| ~1631 test failures: `Postgrex expected an integer ... got <<16-byte uuid binary>>` | Stale bigint-PK schema in the old 5432 DB; schemas now declare `Ecto.UUID` PKs |
+| Migrations fail: `unrecognized configuration parameter "transaction_timeout"` | `transaction_timeout` is PG17+; the 5432 container is older |
+
+Fix:
+
+```bash
+export DATABASE_URL=postgres://engram:engram@localhost:5433/engram_test  # engram-dev-postgres, postgres:18.4
+MIX_ENV=test mix ecto.drop && MIX_ENV=test mix ecto.create && MIX_ENV=test mix ecto.migrate
+```
+
+## Parallel decrypt economics (benchmarked, 10 schedulers)
+
+`Crypto.parallel_map/2` — chunked `Task.async_stream`, one chunk per scheduler, ≤32 items run inline.
+
+- 1k × 50KB payloads: **3.6× faster** than sequential.
+- 1k × 5KB payloads: **1.9× faster**.
+- 10k × 120B (path-sized) payloads: **SLOWER than sequential** — copying results back to the caller heap rivals the AES-GCM work itself (~4µs/path).
+
+**Rule: parallelize content-sized decrypt batches; keep path/HMAC-sized loops sequential.** Don't "fix" the sequential path loops by parallelizing them.
+
+Why fan-out is cheap on the input side: ciphertexts are refc binaries, so they aren't copied to worker heaps. Workers self-mark `:sensitive` via `get_dek` (T3.3/M9), preserving the DEK-hygiene invariant.
+
+## Manifest query needs no extra index
+
+The partial unique index `(user_id, vault_id, path_hmac) WHERE deleted_at IS NULL` already serves the manifest access path. `kind = 'note'` is non-selective (~all rows), so an extra `(user_id, vault_id, kind)` index is pure write amplification with zero read win. **Don't re-propose it.** Revisit only if `[:engram, :crypto, :decrypt_batch]` / repo query telemetry shows manifest DB time hot.
+
+## Telemetry to check before optimizing further
+
+Registered in PromEx, flows to Grafana:
+
+- `engram.crypto.dek_cache.count` — tagged by outcome (hit/miss)
+- `engram.crypto.decrypt_batch.duration_us` + `.count` — tagged `kind` (`:notes` | `:manifest_notes` | `:manifest_attachments`)
+
+Check these before adding more read-path optimization.
+
+## Gotchas
+
+- **Worktree deps can still be stale.** The `.githooks/post-checkout` hook hardlinks `deps/_build/node_modules` from the main checkout, but if the main checkout's lockfiles are stale vs `origin/main` you still need `mix deps.get` / `bun install` in the worktree. Hit both this session: `uuidv7` hex dep missing, `@headless-tree/*` node modules missing.
+
+## References
+
+- PR #530 (`perf/read-path-decrypt-batching`)
+- `docs/context/pg18-uuidv7-prod-crashloop-2026-06-11.md` — why the schema is wreck-and-recreate
+- `docs/context/encryption-operations.md` — DEK/crypto invariants (T3.x)

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -83,6 +83,11 @@ export function useFolders() {
       api.get<{ folders: Array<Folder & { id: string | null }> }>('/folders'),
     select: selectFolders,
     enabled: !demo?.active,
+    // Folder listing decrypts every marker row server-side; without a
+    // staleTime each remount/window-focus refetches it. Mutations and the
+    // sync channel (channel.ts) invalidate this key, so 60s of staleness
+    // only spans gaps nothing else would catch anyway.
+    staleTime: FOLDER_NOTES_STALE_MS,
   })
   if (demo?.active) {
     // Demo folders use string ids; synthesize stable sentinel ids
@@ -117,6 +122,9 @@ export function useFolderNotes(folder: string, options?: { enabled?: boolean }) 
       api.get<{ notes: NoteSummary[] }>(`/folders/list?folder=${encodeURIComponent(folder)}`),
     select: selectNotes,
     enabled: !demo?.active && (options?.enabled ?? folder.length > 0),
+    // Same contract as useFolderNotesById: mutations + channel events
+    // invalidate; staleness only spans gaps those already don't cover.
+    staleTime: FOLDER_NOTES_STALE_MS,
   })
   if (demo?.active) {
     const matchFolder = demo.folders.find((f) => f.path === folder)

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -372,6 +372,50 @@ defmodule Engram.Crypto do
   end
 
   @doc """
+  Decrypts a list of notes as one instrumented batch. Returns per-note
+  result tuples in input order — a corrupt row yields `{:error, reason}`
+  in place without aborting the rest of the batch.
+
+  The user's DEK is warmed into the cache once up front, so the per-note
+  `get_dek/1` calls inside `maybe_decrypt_note_fields/2` are pure ETS hits
+  even when the batch is the first crypto touch of the request.
+  """
+  @spec decrypt_notes_batch([Engram.Notes.Note.t()], User.t()) ::
+          [{:ok, Engram.Notes.Note.t()} | {:error, term()}]
+  def decrypt_notes_batch([], _user), do: []
+
+  def decrypt_notes_batch(notes, %User{} = user) when is_list(notes) do
+    _ = get_dek(user)
+
+    measure_decrypt_batch(:notes, length(notes), fn ->
+      Enum.map(notes, &maybe_decrypt_note_fields(&1, user))
+    end)
+  end
+
+  @doc """
+  Runs `fun` and emits one `[:engram, :crypto, :decrypt_batch]` event with
+  `%{count: count, duration_us: ...}` tagged `%{kind: kind}`. Count-zero
+  batches run untimed — they'd only skew the duration summaries.
+  """
+  @spec measure_decrypt_batch(atom(), non_neg_integer(), (-> result)) :: result
+        when result: var
+  def measure_decrypt_batch(_kind, 0, fun), do: fun.()
+
+  def measure_decrypt_batch(kind, count, fun) when is_atom(kind) and is_integer(count) do
+    start = System.monotonic_time(:microsecond)
+    result = fun.()
+    duration_us = System.monotonic_time(:microsecond) - start
+
+    :telemetry.execute(
+      [:engram, :crypto, :decrypt_batch],
+      %{count: count, duration_us: duration_us},
+      %{kind: kind}
+    )
+
+    result
+  end
+
+  @doc """
   Decrypts the Phase B `path_ciphertext` on an attachment into the virtual
   `path` field. No-op when ciphertext is nil (legacy pre-B.1 row).
   """

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -388,7 +388,48 @@ defmodule Engram.Crypto do
     _ = get_dek(user)
 
     measure_decrypt_batch(:notes, length(notes), fn ->
-      Enum.map(notes, &maybe_decrypt_note_fields(&1, user))
+      parallel_map(notes, &maybe_decrypt_note_fields(&1, user))
+    end)
+  end
+
+  # Below this size the per-task spawn/copy overhead rivals the AES-GCM
+  # work itself (path-sized payloads decrypt in ~µs), so small batches
+  # stay inline on the caller.
+  @parallel_map_threshold 32
+
+  @doc """
+  Chunked parallel map for CPU-bound crypto batches. Splits `items` into
+  one chunk per scheduler and decrypts chunks concurrently, preserving
+  input order. Batches at or below #{@parallel_map_threshold} items run
+  inline — task overhead beats the win there.
+
+  Ciphertext binaries are refc (heap-shared), so fan-out does not copy
+  payload bytes. Workers touching the DEK mark themselves `:sensitive`
+  via `get_dek/1` exactly like the caller (T3.3 / M9).
+
+  A worker exit (timeout, raise inside `fun`) re-raises in the caller,
+  matching the sequential behavior where the exception propagates.
+  """
+  @spec parallel_map([item], (item -> result)) :: [result]
+        when item: var, result: var
+  def parallel_map(items, fun) when length(items) <= @parallel_map_threshold do
+    Enum.map(items, fun)
+  end
+
+  def parallel_map(items, fun) do
+    schedulers = System.schedulers_online()
+    chunk_size = items |> length() |> Kernel./(schedulers) |> ceil() |> max(1)
+
+    items
+    |> Enum.chunk_every(chunk_size)
+    |> Task.async_stream(fn chunk -> Enum.map(chunk, fun) end,
+      max_concurrency: schedulers,
+      ordered: true,
+      timeout: :timer.seconds(60)
+    )
+    |> Enum.flat_map(fn
+      {:ok, results} -> results
+      {:exit, reason} -> exit(reason)
     end)
   end
 

--- a/lib/engram/crypto/dek_cache.ex
+++ b/lib/engram/crypto/dek_cache.ex
@@ -37,6 +37,7 @@ defmodule Engram.Crypto.DekCache do
     case :ets.lookup(@table, user_id) do
       [{^user_id, dek, expires_at}] ->
         if :erlang.system_time(:millisecond) < expires_at do
+          emit_lookup(:hit)
           {:ok, dek}
         else
           # T3.3 — eviction of an expired entry must go through the owner
@@ -44,12 +45,21 @@ defmodule Engram.Crypto.DekCache do
           # table directly. Cast is fine: a stale entry living for one
           # extra request is harmless (decrypt under the same key).
           GenServer.cast(__MODULE__, {:expire, user_id})
+          emit_lookup(:miss)
           :miss
         end
 
       [] ->
+        emit_lookup(:miss)
         :miss
     end
+  end
+
+  # A miss is paired with a provider unwrap (Local ~µs, AWS KMS a network
+  # RPC), so the hit/miss ratio is the cheapest leading indicator of
+  # read-path crypto cost.
+  defp emit_lookup(outcome) do
+    :telemetry.execute([:engram, :crypto, :dek_cache], %{count: 1}, %{outcome: outcome})
   end
 
   @spec put(user_id :: integer(), dek :: <<_::256>>, ttl_ms :: non_neg_integer() | nil) :: :ok

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1013,21 +1013,34 @@ defmodule Engram.Notes do
 
   @doc """
   Returns hydrated folder marker rows (kind="folder", non-deleted) for the
-  user/vault, with `.folder` decrypted. Used by Materialization to compute
-  the existing-marker set and by callers that need full marker structs
-  (vs. `list_explicit_folders/2` which only returns sorted names).
+  user/vault, with `.folder` decrypted. Structs are sparsely loaded — only
+  `.id`, `.folder` and `.folder_hmac` are populated (plus the decrypt
+  inputs); callers needing other columns must fetch the row themselves. Used by
+  Materialization to compute the existing-marker set and by the folders
+  index for the path→id map (vs. `list_explicit_folders/2` which only
+  returns sorted names).
   """
   @spec list_folder_markers(map(), map()) :: [Note.t()]
   def list_folder_markers(user, vault) do
     with {:ok, user} <- Crypto.ensure_user_dek(user),
          {:ok, dek} <- Crypto.get_dek(user) do
+      # Callers only consume `.id` + `.folder` (hydrated below) — project
+      # just the decrypt inputs instead of full rows so a marker-heavy
+      # vault doesn't pay for ~20 unused columns per row.
       {:ok, markers} =
         Repo.with_tenant(user.id, fn ->
           Repo.all(
             from(n in Note,
               where:
                 n.user_id == ^user.id and n.vault_id == ^vault.id and
-                  is_nil(n.deleted_at) and n.kind == "folder"
+                  is_nil(n.deleted_at) and n.kind == "folder",
+              select: %Note{
+                id: n.id,
+                dek_version: n.dek_version,
+                folder_ciphertext: n.folder_ciphertext,
+                folder_nonce: n.folder_nonce,
+                folder_hmac: n.folder_hmac
+              }
             )
           )
         end)

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1802,7 +1802,20 @@ defmodule Engram.Notes do
   end
 
   defp decrypt_or_raise!(notes, user) when is_list(notes) do
-    Enum.map(notes, &decrypt_or_raise!(&1, user))
+    notes
+    |> Crypto.decrypt_notes_batch(user)
+    |> Enum.zip(notes)
+    |> Enum.map(fn
+      {{:ok, decrypted}, _note} ->
+        decrypted
+
+      {{:error, reason}, note} ->
+        Logger.error(
+          "decrypt_failed user_id=#{user.id} note_id=#{note.id} reason=#{inspect(reason)}"
+        )
+
+        raise "Phase B note decryption failed: user_id=#{user.id} note_id=#{note.id} reason=#{inspect(reason)}"
+    end)
   end
 
   # Decrypts an envelope (ciphertext + nonce) with the user's DEK and the

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -58,6 +58,10 @@ defmodule EngramWeb.SyncController do
         )
       end)
 
+    # Path-sized payloads decrypt in ~4µs each — measured 10k sequential at
+    # ~43ms while chunked parallel came out *slower* (result copy-back to the
+    # caller's heap rivals the AES-GCM work). Keep these loops sequential;
+    # the batch telemetry tells us if a real-world vault disagrees.
     notes =
       Crypto.measure_decrypt_batch(:manifest_notes, length(note_rows), fn ->
         Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, hash} ->

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -59,20 +59,22 @@ defmodule EngramWeb.SyncController do
       end)
 
     notes =
-      note_rows
-      |> Enum.map(fn {id, dek_version, path_ct, path_nonce, hash} ->
-        aad = path_aad(:notes, id, dek_version)
-        path = decrypt_path!(path_ct, path_nonce, dek, aad)
-        %{path: path, content_hash: hash}
+      Crypto.measure_decrypt_batch(:manifest_notes, length(note_rows), fn ->
+        Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, hash} ->
+          aad = path_aad(:notes, id, dek_version)
+          path = decrypt_path!(path_ct, path_nonce, dek, aad)
+          %{path: path, content_hash: hash}
+        end)
       end)
       |> Enum.sort_by(& &1.path)
 
     attachments =
-      attachment_rows
-      |> Enum.map(fn {id, dek_version, path_ct, path_nonce, hash} ->
-        aad = path_aad(:attachments, id, dek_version)
-        path = decrypt_path!(path_ct, path_nonce, dek, aad)
-        %{path: path, content_hash: hash}
+      Crypto.measure_decrypt_batch(:manifest_attachments, length(attachment_rows), fn ->
+        Enum.map(attachment_rows, fn {id, dek_version, path_ct, path_nonce, hash} ->
+          aad = path_aad(:attachments, id, dek_version)
+          path = decrypt_path!(path_ct, path_nonce, dek, aad)
+          %{path: path, content_hash: hash}
+        end)
       end)
       |> Enum.sort_by(& &1.path)
 

--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -163,6 +163,24 @@ defmodule EngramWeb.Telemetry do
         tags: [:status, :reason_label],
         description: "Boot canary outcomes — `:failed` halts boot via BootCanaryGuard"
       ),
+      # Read-path crypto cost (perf wave 2026-06-12). dek_cache hit/miss is
+      # the leading indicator of unwrap cost (a miss pairs with a provider
+      # unwrap — network RPC under AwsKms); decrypt_batch sizes the
+      # per-request decrypt fan-out on list endpoints + sync manifest.
+      counter("engram.crypto.dek_cache.count",
+        tags: [:outcome],
+        description: "DekCache lookups by outcome (:hit | :miss)"
+      ),
+      summary("engram.crypto.decrypt_batch.duration_us",
+        tags: [:kind],
+        description:
+          "Batch decrypt wall-time in µs per kind (:notes | :manifest_notes | :manifest_attachments)"
+      ),
+      summary("engram.crypto.decrypt_batch.count",
+        measurement: :count,
+        tags: [:kind],
+        description: "Rows decrypted per batch, per kind"
+      ),
       counter("engram.search.decrypt_failed.count",
         description:
           "Search candidate decrypt failures — non-zero rate is an alarm signal (key drift, tampering)"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.394",
+      version: "0.5.395",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto/dek_cache_test.exs
+++ b/test/engram/crypto/dek_cache_test.exs
@@ -39,6 +39,28 @@ defmodule Engram.Crypto.DekCacheTest do
     assert :miss = DekCache.get(1)
   end
 
+  describe "telemetry" do
+    test "get/1 emits hit and miss outcomes" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:engram, :crypto, :dek_cache]])
+
+      assert :miss = DekCache.get(999_001)
+      assert_receive {[:engram, :crypto, :dek_cache], ^ref, %{count: 1}, %{outcome: :miss}}
+
+      DekCache.put(999_001, @dek)
+      assert {:ok, _} = DekCache.get(999_001)
+      assert_receive {[:engram, :crypto, :dek_cache], ^ref, %{count: 1}, %{outcome: :hit}}
+    end
+
+    test "expired entry counts as miss" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:engram, :crypto, :dek_cache]])
+
+      DekCache.put(999_002, @dek, _ttl_ms = 1)
+      Process.sleep(10)
+      assert :miss = DekCache.get(999_002)
+      assert_receive {[:engram, :crypto, :dek_cache], ^ref, %{count: 1}, %{outcome: :miss}}
+    end
+  end
+
   describe "cross-node invalidation (PubSub round-trip)" do
     alias Engram.Cluster.CacheSync
 

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -225,6 +225,66 @@ defmodule Engram.CryptoTest do
     end
   end
 
+  defp build_encrypted_note(user, content, title) do
+    note_id = Ecto.UUID.generate()
+
+    {:ok, enc} =
+      Crypto.encrypt_note_fields(%{content: content, title: title}, user, note_id)
+
+    %Engram.Notes.Note{
+      id: note_id,
+      dek_version: Crypto.row_version_aad_bound(),
+      content_ciphertext: enc.content_ciphertext,
+      content_nonce: enc.content_nonce,
+      title_ciphertext: enc.title_ciphertext,
+      title_nonce: enc.title_nonce
+    }
+  end
+
+  describe "decrypt_notes_batch/2" do
+    test "decrypts notes preserving order and emits batch telemetry", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [[:engram, :crypto, :decrypt_batch]])
+
+      notes = for i <- 1..3, do: build_encrypted_note(user, "c#{i}", "t#{i}")
+
+      results = Crypto.decrypt_notes_batch(notes, user)
+
+      assert [
+               {:ok, %{content: "c1", title: "t1"}},
+               {:ok, %{content: "c2", title: "t2"}},
+               {:ok, %{content: "c3", title: "t3"}}
+             ] = results
+
+      assert_receive {[:engram, :crypto, :decrypt_batch], ^ref, measurements, %{kind: :notes}}
+      assert measurements.count == 3
+      assert is_integer(measurements.duration_us) and measurements.duration_us >= 0
+    end
+
+    test "corrupt note yields an error tuple in place, others still decrypt", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+
+      good = build_encrypted_note(user, "good", "g")
+      bad = build_encrypted_note(user, "bad", "b")
+      bad = %{bad | content_ciphertext: :crypto.strong_rand_bytes(32)}
+
+      assert [{:ok, %{content: "good"}}, {:error, :decrypt_failed}] =
+               Crypto.decrypt_notes_batch([good, bad], user)
+    end
+
+    test "empty list returns empty without telemetry noise", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [[:engram, :crypto, :decrypt_batch]])
+
+      assert [] = Crypto.decrypt_notes_batch([], user)
+      refute_receive {[:engram, :crypto, :decrypt_batch], ^ref, _, _}, 50
+    end
+  end
+
   describe "dek_filter_key/1" do
     test "returns a deterministic 32-byte key for the same user" do
       user = insert(:user)

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -274,6 +274,24 @@ defmodule Engram.CryptoTest do
                Crypto.decrypt_notes_batch([good, bad], user)
     end
 
+    test "large batch decrypts in order with errors contained (parallel path)", %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+
+      notes = for i <- 1..40, do: build_encrypted_note(user, "c#{i}", "t#{i}")
+      corrupt = %{Enum.at(notes, 17) | content_ciphertext: :crypto.strong_rand_bytes(32)}
+      notes = List.replace_at(notes, 17, corrupt)
+
+      results = Crypto.decrypt_notes_batch(notes, user)
+
+      assert length(results) == 40
+      assert {:error, :decrypt_failed} = Enum.at(results, 17)
+
+      for {result, i} <- Enum.with_index(results), i != 17 do
+        assert {:ok, %{content: content}} = result
+        assert content == "c#{i + 1}"
+      end
+    end
+
     test "empty list returns empty without telemetry noise", %{user: user} do
       {:ok, user} = Crypto.ensure_user_dek(user)
 

--- a/test/engram_web/controllers/sync_controller_test.exs
+++ b/test/engram_web/controllers/sync_controller_test.exs
@@ -55,6 +55,23 @@ defmodule EngramWeb.SyncControllerTest do
       assert is_binary(att["content_hash"])
     end
 
+    test "emits decrypt-batch telemetry for manifest paths", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Tel/A.md", content: "# A", mtime: 1_000.0})
+      post(conn, "/api/notes", %{path: "Tel/B.md", content: "# B", mtime: 1_000.0})
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [[:engram, :crypto, :decrypt_batch]])
+
+      conn2 = get(conn, "/api/sync/manifest")
+      assert json_response(conn2, 200)["total_notes"] == 2
+
+      assert_receive {[:engram, :crypto, :decrypt_batch], ^ref, measurements,
+                      %{kind: :manifest_notes}}
+
+      assert measurements.count == 2
+      assert is_integer(measurements.duration_us)
+    end
+
     test "excludes deleted notes and attachments", %{conn: conn} do
       post(conn, "/api/notes", %{path: "Test/Del.md", content: "# Del", mtime: 1_000.0})
       delete(conn, "/api/notes/Test/Del.md")


### PR DESCRIPTION
## What

Read-path performance wave targeting the two suspected hot spots: per-row decryption on list endpoints and the full-folder-structure fetch.

### 1. Telemetry first (new signals)
- `[:engram, :crypto, :dek_cache]` — hit/miss counter on every DekCache lookup. A miss pairs with a provider unwrap (network RPC under AwsKms), so the ratio is the leading indicator of read-path crypto cost.
- `[:engram, :crypto, :decrypt_batch]` — `duration_us` + `count` per batch, tagged `kind` (`:notes` | `:manifest_notes` | `:manifest_attachments`). Both registered as PromEx metrics.

### 2. Parallel note batch decrypt
`Crypto.decrypt_notes_batch/2` fans note decryption out via chunked `Task.async_stream` (one chunk per scheduler, order preserved, ≤32 items stay inline). `notes.ex` list decrypt routes through it. Bench on 10 schedulers:

| shape | sequential | parallel |
|---|---|---|
| 1k notes × 50KB | 203ms | **57ms (3.6×)** |
| 1k notes × 5KB | 19ms | **10ms (1.9×)** |
| 10k × 120B paths | 43ms | 50ms — **kept sequential** |

Manifest path loops stay sequential: path-sized payloads decrypt in ~4µs and the parallel copy-back overhead measured *slower*. Telemetry will tell us if a real-world vault disagrees.

Safety notes: ciphertexts are refc binaries (no copy on fan-out); workers self-mark `:sensitive` via `get_dek/1` (T3.3/M9); worker exit re-raises in the caller matching sequential semantics; DEK pre-warmed once so workers are pure ETS hits.

### 3. `list_folder_markers` narrowed
Was `select: n` (full ~20-column rows) to consume only `id` + `folder`. Now projects just the decrypt inputs + `folder_hmac` (pinned by MaterializationTest).

### 4. Frontend staleTime
`useFolders` + path-keyed `useFolderNotes` had `staleTime: 0` → full folder-tree refetch (server-side decrypt-every-marker) on each remount/focus. Now 60s via `FOLDER_NOTES_STALE_MS`, matching `useFolderNotesById`. Mutations + `channel.ts` invalidation unchanged.

### Deliberately NOT done
- **No new index for the manifest query**: existing partial unique index `(user_id, vault_id, path_hmac) WHERE deleted_at IS NULL` already serves the access path, and `kind='note'` is non-selective (~all rows) — an extra index is write amplification with no read win.

## Testing
- 2524 backend tests green (7 new: DekCache telemetry ×2, decrypt_notes_batch ×4, manifest telemetry ×1)
- Frontend: 441 vitest green + tsc clean
- Pre-existing (not from this PR): 2 unhandled vitest rejections (`getToken is not a function`, `use-vault-ready-events.ts:41`) — local-only, CI doesn't run frontend vitest; will file follow-up issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)