### PR TITLE
fix(frontend): don't show free-tier caps/upgrade framing on self-host

### DIFF
--- a/frontend/src/billing/use-is-free-tier.test.ts
+++ b/frontend/src/billing/use-is-free-tier.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+let billingEnabled = true
+let tier: string | undefined = 'free'
+
+vi.mock('../config-context', async () => {
+  const actual = await vi.importActual<typeof import('../config-context')>('../config-context')
+  return { ...actual, useConfig: () => ({ billingEnabled }) as ReturnType<typeof actual.useConfig> }
+})
+
+vi.mock('../api/queries', async () => {
+  const actual = await vi.importActual<typeof import('../api/queries')>('../api/queries')
+  return { ...actual, useBillingStatus: () => ({ data: tier ? { tier } : undefined }) }
+})
+
+import { useIsFreeTier } from './use-is-free-tier'
+
+beforeEach(() => {
+  billingEnabled = true
+  tier = 'free'
+})
+
+describe('useIsFreeTier', () => {
+  it('true on SaaS free tier', () => {
+    billingEnabled = true
+    tier = 'free'
+    expect(renderHook(() => useIsFreeTier()).result.current).toBe(true)
+  })
+
+  it('treats "none" (no subscription) as free on SaaS', () => {
+    billingEnabled = true
+    tier = 'none'
+    expect(renderHook(() => useIsFreeTier()).result.current).toBe(true)
+  })
+
+  it('false on paid tiers', () => {
+    billingEnabled = true
+    tier = 'pro'
+    expect(renderHook(() => useIsFreeTier()).result.current).toBe(false)
+  })
+
+  it('false on self-host even though tier reports "free"', () => {
+    billingEnabled = false
+    tier = 'free'
+    expect(renderHook(() => useIsFreeTier()).result.current).toBe(false)
+  })
+
+  it('false while billing status is still loading', () => {
+    billingEnabled = true
+    tier = undefined
+    expect(renderHook(() => useIsFreeTier()).result.current).toBe(false)
+  })
+})

--- a/frontend/src/billing/use-is-free-tier.ts
+++ b/frontend/src/billing/use-is-free-tier.ts
@@ -1,0 +1,18 @@
+import { useBillingStatus } from '../api/queries'
+import { useConfig } from '../config-context'
+
+/**
+ * True only when paid tiers exist AND the user is on the free tier.
+ *
+ * Self-host (`billingEnabled=false`) has no billing and unlimited
+ * connections, yet the backend still reports tier `"free"` for any
+ * subscription-less user. A raw `tier === 'free'` check therefore wrongly
+ * renders free-tier caps / upgrade framing on self-host. Gate every
+ * free-tier UI affordance on this hook instead of comparing tier directly.
+ */
+export function useIsFreeTier(): boolean {
+  const { billingEnabled } = useConfig()
+  const { data } = useBillingStatus()
+  if (!billingEnabled) return false
+  return data?.tier === 'free' || data?.tier === 'none'
+}

--- a/frontend/src/layout/app-sidebar.test.tsx
+++ b/frontend/src/layout/app-sidebar.test.tsx
@@ -11,6 +11,8 @@ let billingStatusValue: { data: Partial<BillingStatus> | undefined; isLoading: b
   data: { tier: 'free', active: false } as Partial<BillingStatus>,
   isLoading: false,
 }
+// SaaS by default; self-host flips false (no billing → no free-tier footer).
+let billingEnabled = true
 
 vi.mock('../auth/use-auth-adapter', () => ({
   useAuthAdapter: () => ({ user: { email: 'test@example.com', imageUrl: null }, logout: vi.fn() }),
@@ -21,6 +23,13 @@ vi.mock('../api/queries', async () => {
     ...actual,
     useSearch: () => ({ data: [], isLoading: false, error: null }),
     useBillingStatus: () => billingStatusValue,
+  }
+})
+vi.mock('../config-context', async () => {
+  const actual = await vi.importActual<typeof import('../config-context')>('../config-context')
+  return {
+    ...actual,
+    useConfig: () => ({ billingEnabled }) as ReturnType<typeof actual.useConfig>,
   }
 })
 
@@ -64,7 +73,10 @@ describe('AppSidebar', () => {
 })
 
 describe('AppSidebar — Free-tier footer', () => {
-  beforeEach(() => window.localStorage.clear())
+  beforeEach(() => {
+    window.localStorage.clear()
+    billingEnabled = true
+  })
 
   it('renders the Free footer with an Upgrade link when tier=free', () => {
     billingStatusValue = {
@@ -91,6 +103,18 @@ describe('AppSidebar — Free-tier footer', () => {
 
   it('does not render the footer while billing status is loading', () => {
     billingStatusValue = { data: undefined, isLoading: true }
+    renderSidebar()
+
+    expect(screen.queryByText(/free tier.*1 connection/i)).toBeNull()
+    expect(screen.queryByRole('link', { name: /upgrade/i })).toBeNull()
+  })
+
+  it('does not render the footer on self-host (billing disabled) even when tier=free', () => {
+    billingEnabled = false
+    billingStatusValue = {
+      data: { tier: 'free', active: false } as Partial<BillingStatus>,
+      isLoading: false,
+    }
     renderSidebar()
 
     expect(screen.queryByText(/free tier.*1 connection/i)).toBeNull()

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router'
-import { useBillingStatus } from '../api/queries'
+import { useIsFreeTier } from '../billing/use-is-free-tier'
 import FilesPanel from './files-panel'
 import Rail from './rail'
 import SearchPanel from './search-panel'
@@ -7,8 +7,7 @@ import { useRailView } from './rail-view-context'
 
 export default function AppSidebarPanel() {
   const { view } = useRailView()
-  const billing = useBillingStatus()
-  const showFreeFooter = billing.data?.tier === 'free'
+  const showFreeFooter = useIsFreeTier()
 
   return (
     <div className="flex h-full flex-col">

--- a/frontend/src/onboarding/checklist-widget.test.tsx
+++ b/frontend/src/onboarding/checklist-widget.test.tsx
@@ -63,6 +63,15 @@ vi.mock('../api/queries', async () => {
   }
 })
 
+vi.mock('../config-context', async () => {
+  const actual = await vi.importActual<typeof import('../config-context')>('../config-context')
+  return {
+    ...actual,
+    // SaaS context — free-tier footer logic under test depends on this.
+    useConfig: () => ({ billingEnabled: true }) as ReturnType<typeof actual.useConfig>,
+  }
+})
+
 let activeQc: QueryClient | null = null
 
 function wrap(ui: ReactNode) {

--- a/frontend/src/onboarding/checklist-widget.tsx
+++ b/frontend/src/onboarding/checklist-widget.tsx
@@ -4,11 +4,11 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Waypoints } from 'lucide-react'
 import { useOnboardingActions } from './use-onboarding-actions'
 import {
-  useBillingStatus,
   useConnections,
   useOnboardingStatus,
   type OnboardingStatus,
 } from '../api/queries'
+import { useIsFreeTier } from '../billing/use-is-free-tier'
 import { Button } from '../components/ui/button'
 import { Shimmer } from '../components/ui/shimmer'
 
@@ -67,8 +67,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
   const status = useOnboardingStatus()
   const profile = status.data?.profile
   const connections = useConnections({ enabled: !!profile?.uses_obsidian })
-  const billing = useBillingStatus()
-  const tier = billing.data?.tier
+  const isFreeTier = useIsFreeTier()
   const qc = useQueryClient()
 
   if (ob.isLoading) return null
@@ -236,7 +235,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
           </li>
         ))}
       </ul>
-      {tier === 'free' && (
+      {isFreeTier && (
         <p className="border-t border-border px-4 py-3 text-xs text-muted-foreground">
           You're on Free — 1 connection.{' '}
           <Link

--- a/frontend/src/onboarding/onboard-tools-page.test.tsx
+++ b/frontend/src/onboarding/onboard-tools-page.test.tsx
@@ -24,6 +24,9 @@ let billingStatus: { data: Partial<BillingStatus> | undefined; isLoading: boolea
   isLoading: false,
 }
 
+// SaaS by default; self-host flips this false (no billing, unlimited connections).
+let billingEnabled = true
+
 vi.mock('../api/queries', async () => {
   const actual = await vi.importActual<typeof import('../api/queries')>('../api/queries')
   return {
@@ -35,6 +38,14 @@ vi.mock('../api/queries', async () => {
       isError: false,
     }),
     useBillingStatus: () => billingStatus,
+  }
+})
+
+vi.mock('../config-context', async () => {
+  const actual = await vi.importActual<typeof import('../config-context')>('../config-context')
+  return {
+    ...actual,
+    useConfig: () => ({ billingEnabled }) as ReturnType<typeof actual.useConfig>,
   }
 })
 
@@ -67,6 +78,7 @@ beforeEach(() => {
     data: { tier: 'free', active: false } as Partial<BillingStatus>,
     isLoading: false,
   }
+  billingEnabled = true
 })
 
 describe('OnboardToolsPage — Free tier', () => {
@@ -91,6 +103,35 @@ describe('OnboardToolsPage — Free tier', () => {
     fireEvent.click(cursor)
     expect(cursor).toHaveAttribute('data-state', 'checked')
     expect(claude).toHaveAttribute('data-state', 'unchecked')
+  })
+})
+
+describe('OnboardToolsPage — Self-host (billing disabled)', () => {
+  beforeEach(() => {
+    // Self-host: no billing. tier is still "free" (no subscription) but
+    // connections are unlimited, so the step must not gate to a single pick.
+    billingEnabled = false
+    billingStatus = {
+      data: { tier: 'free', active: false } as Partial<BillingStatus>,
+      isLoading: false,
+    }
+  })
+
+  it('does not render the Free-tier single-select banner', () => {
+    render(wrap(<OnboardToolsPage />))
+    expect(screen.queryByText(/free tier.*pick 1 to start/i)).toBeNull()
+  })
+
+  it('allows multi-select (no auto-deselect)', () => {
+    render(wrap(<OnboardToolsPage />))
+
+    const claude = screen.getByLabelText(/^Claude$/i)
+    fireEvent.click(claude)
+    const cursor = screen.getByLabelText(/^Cursor$/i)
+    fireEvent.click(cursor)
+
+    expect(claude).toHaveAttribute('data-state', 'checked')
+    expect(cursor).toHaveAttribute('data-state', 'checked')
   })
 })
 

--- a/frontend/src/onboarding/onboard-tools-page.tsx
+++ b/frontend/src/onboarding/onboard-tools-page.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react'
 import { Link, Navigate, useNavigate } from 'react-router'
-import {
-  useBillingStatus,
-  useOnboardingStatus,
-  useSetOnboardingProfile,
-} from '../api/queries'
+import { useOnboardingStatus, useSetOnboardingProfile } from '../api/queries'
+import { useIsFreeTier } from '../billing/use-is-free-tier'
 import { Checkbox } from '@/components/ui/checkbox'
 import AuthPanel from '@/layout/auth-panel'
 import LoadingScreen from '../layout/loading-screen'
@@ -21,8 +18,7 @@ export default function OnboardToolsPage() {
   const navigate = useNavigate()
   const { data: status, isLoading } = useOnboardingStatus()
   const setProfile = useSetOnboardingProfile()
-  const billing = useBillingStatus()
-  const isFree = billing.data?.tier === 'free'
+  const isFree = useIsFreeTier()
 
   if (isLoading || !status) {
     return <LoadingScreen />

--- a/frontend/src/settings/connections-page.test.tsx
+++ b/frontend/src/settings/connections-page.test.tsx
@@ -36,6 +36,15 @@ vi.mock('../api/queries', async () => {
   }
 })
 
+vi.mock('../config-context', async () => {
+  const actual = await vi.importActual<typeof import('../config-context')>('../config-context')
+  return {
+    ...actual,
+    // SaaS context — free-tier cap fallbacks under test depend on this.
+    useConfig: () => ({ billingEnabled: true }) as ReturnType<typeof actual.useConfig>,
+  }
+})
+
 // ── Fixture data ──────────────────────────────────────────────
 
 const baseObs: import('../api/queries').Connection = {

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -11,6 +11,7 @@ import {
   useRevokePat,
 } from '../api/queries'
 import { ApiError } from '../api/client'
+import { useIsFreeTier } from '../billing/use-is-free-tier'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -31,7 +32,7 @@ import { SettingsSectionCard } from '@/settings/account/section-card'
 function useTierCaps() {
   const { data } = useBillingStatus()
   const tier = data?.tier ?? 'free'
-  const isFree = tier === 'free' || tier === 'none'
+  const isFree = useIsFreeTier()
   const caps = data?.caps
   return {
     tier,

--- a/frontend/src/viewer/note-view.test.tsx
+++ b/frontend/src/viewer/note-view.test.tsx
@@ -1,9 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 import NoteView from './note-view'
 
 let mockTier: 'free' | 'starter' | 'pro' | 'trial' | 'none' = 'free'
+// SaaS by default; self-host flips false (no billing → attachments ungated).
+let billingEnabled = true
 const showUpgradeMock = vi.fn()
 
 vi.mock('../api/queries', async () => {
@@ -12,6 +14,18 @@ vi.mock('../api/queries', async () => {
     ...actual,
     useBillingStatus: () => ({ data: { tier: mockTier } }),
   }
+})
+
+vi.mock('../config-context', async () => {
+  const actual = await vi.importActual<typeof import('../config-context')>('../config-context')
+  return {
+    ...actual,
+    useConfig: () => ({ billingEnabled }) as ReturnType<typeof actual.useConfig>,
+  }
+})
+
+beforeEach(() => {
+  billingEnabled = true
 })
 
 vi.mock('@/billing/upgrade-dialog-provider', () => ({
@@ -51,6 +65,14 @@ describe('NoteView attachment gating', () => {
 
   it('renders AttachmentImg for paid tier on the same embed', () => {
     mockTier = 'pro'
+    renderNote('Here is an embed:\n\n![[image.png]]\n')
+    expect(screen.getByTestId('attachment-img')).toHaveTextContent('image.png')
+    expect(screen.queryByTestId('attachment-fallback-lock')).toBeNull()
+  })
+
+  it('renders AttachmentImg on self-host (billing disabled) even though tier is "free"', () => {
+    billingEnabled = false
+    mockTier = 'free'
     renderNote('Here is an embed:\n\n![[image.png]]\n')
     expect(screen.getByTestId('attachment-img')).toHaveTextContent('image.png')
     expect(screen.queryByTestId('attachment-fallback-lock')).toBeNull()

--- a/frontend/src/viewer/note-view.tsx
+++ b/frontend/src/viewer/note-view.tsx
@@ -9,7 +9,7 @@ import remarkCallouts from '@portaljs/remark-callouts'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import remarkWikiLink from 'remark-wiki-link'
-import { useBillingStatus } from '../api/queries'
+import { useIsFreeTier } from '../billing/use-is-free-tier'
 import { AttachmentFallback } from './attachment-fallback'
 import AttachmentImg from './attachment-img'
 import MermaidBlock from './mermaid-block'
@@ -57,8 +57,7 @@ const rehypePlugins = [
 const TEXT_EMBED = /\.(md|canvas)$/i
 
 export default function NoteView({ content, title, tags, updatedAt }: NoteViewProps) {
-  const { data: billing } = useBillingStatus()
-  const tier = billing?.tier
+  const isFreeTier = useIsFreeTier()
   const { frontmatter, body } = useMemo(() => {
     try {
       const parsed = matter(content)
@@ -129,7 +128,7 @@ export default function NoteView({ content, title, tags, updatedAt }: NoteViewPr
                 // Free tier: gate any non-text attachment (images, pdfs, etc).
                 // `.md` / `.canvas` embeds remain free-tier-allowed because
                 // they're first-class note types, not stored attachments.
-                if (tier === 'free' && !TEXT_EMBED.test(path)) {
+                if (isFreeTier && !TEXT_EMBED.test(path)) {
                   return <AttachmentFallback filename={path} />
                 }
                 return <AttachmentImg path={path} alt={alt} />


### PR DESCRIPTION
## Problem

Self-host runs with billing disabled (`billingEnabled=false`) and **unlimited** connections. But the backend's `/billing/status` still reports `tier: "free"` for any subscription-less user (`Billing.tier/1` only returns `:starter`/`:pro` for an active subscription; everything else is `:free`). Several frontend sites compared `tier === 'free'` directly — so self-host wrongly rendered free-tier gating:

- **Onboarding tools step** (`/onboard/tools`) — forced single-select with "Free tier — pick 1 to start. Upgrade…" (the Upgrade link points at `/onboard/billing`, a step that doesn't even exist on self-host)
- **App sidebar** (editor pane) — "Free tier — 1 connection. Upgrade" footer
- **Onboarding checklist widget** — "You're on Free — 1 connection. Upgrade" footer
- **Connections page** — fell back to a 1-connection cap
- **Note viewer** — gated image / PDF / other non-text attachment embeds behind a fallback lock

Backend was already correct: `limits_enforced=false` on self-host → `Billing.effective_limit/2` returns `:unlimited` → `/billing/status` caps are `null`. This was purely a frontend display/gate bug keyed off the raw tier.

## Fix

New single source of truth `useIsFreeTier()` that ANDs the tier check with `billingEnabled`:

```ts
export function useIsFreeTier(): boolean {
  const { billingEnabled } = useConfig()
  const { data } = useBillingStatus()
  if (!billingEnabled) return false
  return data?.tier === 'free' || data?.tier === 'none'
}
```

All five sites route through it instead of comparing `tier` directly. Notably, the note-viewer change **unblocks image/PDF embeds on self-host**.

## Tests

- New `useIsFreeTier` unit test: SaaS free/none → `true`, paid → `false`, **self-host → `false`**, loading → `false`
- Self-host cases added to the tools step, sidebar footer, and note-view attachment rendering tests
- Existing SaaS-tier tests updated with a `billingEnabled: true` config mock and still pass (57 tests green across the 6 files)

Verified live in the running self-host web app: the onboarding tools step now allows multi-select with no upgrade banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)