### PR TITLE
feat(obs): PromEx plugin for read-path crypto telemetry

### DIFF
--- a/lib/engram/prom_ex.ex
+++ b/lib/engram/prom_ex.ex
@@ -26,7 +26,8 @@ defmodule Engram.PromEx do
       Engram.PromEx.Qdrant,
       Engram.PromEx.Sync,
       Engram.PromEx.Search,
-      Engram.PromEx.Mcp
+      Engram.PromEx.Mcp,
+      Engram.PromEx.Crypto
     ]
   end
 

--- a/lib/engram/prom_ex/crypto.ex
+++ b/lib/engram/prom_ex/crypto.ex
@@ -1,0 +1,73 @@
+defmodule Engram.PromEx.Crypto do
+  @moduledoc """
+  PromEx plugin for read-path crypto cost (PR #530 telemetry).
+
+  Subscribes to:
+
+    * `[:engram, :crypto, :dek_cache]` — `%{count: 1}`, metadata
+      `%{outcome: :hit | :miss}`. A miss pairs with a provider unwrap
+      (network RPC under AwsKms), so the hit/miss ratio is the leading
+      indicator of unwrap cost on the read path.
+    * `[:engram, :crypto, :decrypt_batch]` — `%{count: rows,
+      duration_us: µs}`, metadata `%{kind: :notes | :manifest_notes |
+      :manifest_attachments}`. Sizes the per-request decrypt fan-out on
+      list endpoints + the sync manifest.
+
+  Metrics:
+
+    * `engram_prom_ex_crypto_dek_cache_total` — tags `[:outcome]`.
+    * `engram_prom_ex_crypto_decrypt_batch_duration_microseconds` —
+      tags `[:kind]`.
+    * `engram_prom_ex_crypto_decrypt_batch_rows` — tags `[:kind]`.
+
+  These events are also declared in `EngramWeb.Telemetry.metrics/0`,
+  but that list feeds LiveDashboard only — this plugin is what gets
+  them onto the scraped `/metrics` endpoint.
+
+  Cardinality contract: only the atoms above. NEVER add user_id,
+  vault_id, or note ids.
+  """
+
+  use PromEx.Plugin
+
+  @dek_cache_event [:engram, :crypto, :dek_cache]
+  @decrypt_batch_event [:engram, :crypto, :decrypt_batch]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :crypto)
+
+    Event.build(
+      :engram_crypto_event_metrics,
+      [
+        counter(
+          metric_prefix ++ [:dek_cache, :total],
+          event_name: @dek_cache_event,
+          description: "DekCache lookups by outcome (hit | miss).",
+          tags: [:outcome]
+        ),
+        distribution(
+          metric_prefix ++ [:decrypt_batch, :duration, :microseconds],
+          event_name: @decrypt_batch_event,
+          measurement: :duration_us,
+          description: "Batch decrypt wall-time per kind.",
+          reporter_options: [
+            buckets: [100, 500, 1_000, 5_000, 10_000, 50_000, 100_000, 500_000, 1_000_000]
+          ],
+          tags: [:kind]
+        ),
+        distribution(
+          metric_prefix ++ [:decrypt_batch, :rows],
+          event_name: @decrypt_batch_event,
+          measurement: :count,
+          description: "Rows decrypted per batch, per kind.",
+          reporter_options: [
+            buckets: [1, 10, 50, 100, 500, 1_000, 5_000, 10_000]
+          ],
+          tags: [:kind]
+        )
+      ]
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.395",
+      version: "0.5.396",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/prom_ex/crypto_test.exs
+++ b/test/engram/prom_ex/crypto_test.exs
@@ -1,0 +1,69 @@
+defmodule Engram.PromEx.CryptoTest do
+  @moduledoc """
+  Verifies the Crypto PromEx plugin metric shape.
+
+  Event emission is covered by `Engram.Crypto.DekCacheTest` (dek_cache
+  hit/miss) and `Engram.CryptoTest` (decrypt_notes_batch). The
+  plugin-shape test below is what guards Prometheus registration —
+  `EngramWeb.Telemetry.metrics/0` feeds LiveDashboard only, so without
+  this plugin the events never reach the scraped /metrics endpoint.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.PromEx.Crypto, as: CryptoPlugin
+  alias PromEx.MetricTypes.Event
+
+  describe "event_metrics/1" do
+    test "returns Event struct(s) prefixed [:engram, :prom_ex, :crypto]" do
+      events = CryptoPlugin.event_metrics(otp_app: :engram) |> List.wrap()
+      assert Enum.all?(events, &match?(%Event{}, &1))
+      metrics = Enum.flat_map(events, & &1.metrics)
+      assert Enum.any?(metrics, fn m -> Enum.at(m.name, 2) == :crypto end)
+    end
+
+    test "declares an outcome-tagged counter on [:engram, :crypto, :dek_cache]" do
+      metrics =
+        CryptoPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Counter{}, m) and
+                 m.event_name == [:engram, :crypto, :dek_cache] and
+                 :outcome in m.tags
+             end)
+    end
+
+    test "declares kind-tagged duration + batch-size distributions on decrypt_batch" do
+      metrics =
+        CryptoPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
+      target = [:engram, :crypto, :decrypt_batch]
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target and
+                 m.measurement == :duration_us and :kind in m.tags
+             end)
+
+      assert Enum.any?(metrics, fn m ->
+               match?(%Telemetry.Metrics.Distribution{}, m) and m.event_name == target and
+                 m.measurement == :count and :kind in m.tags
+             end)
+    end
+
+    test "no per-tenant tags" do
+      metrics =
+        CryptoPlugin.event_metrics(otp_app: :engram) |> List.wrap() |> Enum.flat_map(& &1.metrics)
+
+      banned = [:user_id, :vault_id, :note_id, :tenant_id]
+
+      for m <- metrics, tag <- m.tags do
+        refute tag in banned, "Crypto metric #{inspect(m.name)} has banned tag #{inspect(tag)}"
+      end
+    end
+  end
+
+  describe "registration" do
+    test "plugin is wired into Engram.PromEx" do
+      assert Engram.PromEx.Crypto in Engram.PromEx.plugins()
+    end
+  end
+end


### PR DESCRIPTION
## What

Follow-up to #530. While verifying the new telemetry on staging Grafana, found the events never reach Prometheus: `EngramWeb.Telemetry.metrics/0` feeds LiveDashboard only (its reporter is commented out in the supervisor) — the scraped `/metrics` endpoint exports the PromEx plugin registry, and PromEx only runs the bundled plugins + the five custom ones (Voyage/Qdrant/Sync/Search/Mcp).

Adds `Engram.PromEx.Crypto`, same pattern as `Engram.PromEx.Search`:

- `engram_prom_ex_crypto_dek_cache_total{outcome="hit|miss"}`
- `engram_prom_ex_crypto_decrypt_batch_duration_microseconds{kind}` (distribution, 100µs–1s buckets)
- `engram_prom_ex_crypto_decrypt_batch_rows{kind}` (distribution, 1–10k buckets)

Cardinality contract preserved: outcome/kind atoms only, no per-tenant tags (pinned by test).

## Known related gap (not fixed here)

All the older T3-audit crypto counters in `telemetry.ex` (rotate, aad_rebind, boot_canary, previous_fallback_hit, …) share this LiveDashboard-only fate — none are in Grafana today despite code comments claiming PromEx visibility. Filed as a separate issue.

## Testing
- 5 new plugin-shape tests (RED→GREEN), full prom_ex test dir green (27 tests)
- credo --strict clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)