### PR TITLE
fix(frontend): show file tree when a vault has root notes but no folders

### DIFF
--- a/frontend/src/viewer/folder-tree.test.tsx
+++ b/frontend/src/viewer/folder-tree.test.tsx
@@ -14,16 +14,35 @@ vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
 }))
 
+const DEFAULT_FOLDERS = [
+  { id: '1', parent_id: null, name: 'Projects', count: 1 },
+  { id: '2', parent_id: null, name: 'archive', count: 0 },
+]
+const DEFAULT_ROOT_NOTE = {
+  id: '42',
+  path: 'a.md',
+  title: 'a',
+  folder: '',
+  tags: [],
+  version: 1,
+  mtime: '',
+  created_at: '',
+  updated_at: '',
+}
+
 const {
   batchDeleteNotesMutate,
   batchMoveNotesMutate,
   batchDeleteFoldersMutate,
   batchMoveFoldersMutate,
+  mock,
 } = vi.hoisted(() => ({
   batchDeleteNotesMutate: vi.fn(),
   batchMoveNotesMutate: vi.fn(),
   batchDeleteFoldersMutate: vi.fn(),
   batchMoveFoldersMutate: vi.fn(),
+  // Mutable per-test fixtures (folders + root notes), set in beforeEach.
+  mock: { folders: [] as unknown[], rootNotes: [] as unknown[] },
 }))
 
 vi.mock('../api/queries', async () => {
@@ -31,32 +50,14 @@ vi.mock('../api/queries', async () => {
   return {
     ...actual,
     useFolders: () => ({
-      data: [
-        { id: '1', parent_id: null, name: 'Projects', count: 1 },
-        { id: '2', parent_id: null, name: 'archive', count: 0 },
-      ],
+      data: mock.folders,
       isLoading: false,
       isError: false,
     }),
     // Root notes for the by-id loader (legacy useFolderNotes('') compat)
     useFolderNotes: (folder: string) => {
       if (folder === '') {
-        return {
-          data: [
-            {
-              id: '42',
-              path: 'a.md',
-              title: 'a',
-              folder: '',
-              tags: [],
-              version: 1,
-              mtime: '',
-              created_at: '',
-              updated_at: '',
-            },
-          ],
-          isLoading: false,
-        }
+        return { data: mock.rootNotes, isLoading: false }
       }
       return { data: [], isLoading: false }
     },
@@ -109,6 +110,8 @@ beforeEach(() => {
   batchMoveNotesMutate.mockReset()
   batchDeleteFoldersMutate.mockReset()
   batchMoveFoldersMutate.mockReset()
+  mock.folders = DEFAULT_FOLDERS.map((f) => ({ ...f }))
+  mock.rootNotes = [{ ...DEFAULT_ROOT_NOTE }]
 })
 
 describe('FolderTree (HT)', () => {
@@ -131,6 +134,22 @@ describe('FolderTree (HT)', () => {
     renderTree()
     const link = await screen.findByRole('treeitem', { name: 'a' })
     expect(link).toHaveAttribute('href', '/note/42')
+  })
+
+  it('shows root notes even when there are zero folders (new doc at root)', async () => {
+    mock.folders = []
+    mock.rootNotes = [{ ...DEFAULT_ROOT_NOTE }]
+    renderTree()
+    // Must NOT short-circuit to the empty state — the root note is present.
+    expect(screen.queryByText('No notes yet.')).toBeNull()
+    expect(await screen.findByRole('treeitem', { name: 'a' })).toHaveAttribute('href', '/note/42')
+  })
+
+  it('shows the empty state only when there are no folders AND no root notes', async () => {
+    mock.folders = []
+    mock.rootNotes = []
+    renderTree()
+    expect(await screen.findByText('No notes yet.')).toBeInTheDocument()
   })
 
   it('right-click on a folder row opens the ContextMenu', async () => {

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -370,7 +370,10 @@ export default function FolderTree() {
       </p>
     )
   }
-  if (!folders || folders.length === 0) {
+  // Empty only when there are neither folders nor root-level notes. A vault
+  // with root notes but no folders (e.g. a freshly created "Untitled" at root)
+  // must still render the tree — the loader stitches rootNotes under ROOT.
+  if (!folders || (folders.length === 0 && rootNotes.length === 0)) {
     return (
       <p data-testid="folder-tree-root" className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
         No notes yet.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.395",
+      version: "0.5.396",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

Creating a new note at the vault **root** (no folders) left the file pane showing **"No notes yet."** — the just-created note was invisible in the tree.

`viewer/folder-tree.tsx` gated its empty state on folders alone:

```jsx
if (!folders || folders.length === 0) {
  return <p>No notes yet.</p>
}
```

Root-level notes come from a separate source (`useFolderNotes('')` → `rootNotes`) that the loader stitches under ROOT. With zero folders, the guard short-circuited before that rendered — so any vault containing only root notes looked empty.

## Fix

Render the empty state only when there are **neither** folders **nor** root notes:

```jsx
if (!folders || (folders.length === 0 && rootNotes.length === 0)) {
```

## Tests

- zero folders + one root note → the note renders as a `treeitem`, no empty state
- zero folders + zero root notes → "No notes yet." still shown
- existing folder/root-note render tests still pass (8 total)

Verified live in the self-host web app: a doc created at root now appears in the file pane immediately.

(Includes the mandatory `mix.exs` version bump 0.5.395 → 0.5.396.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)