### PR TITLE
feat(secrets): consolidated APP_SECRETS_JSON blob (KMS reduction phase 0)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,16 @@
 import Config
 
+# Prod delivers all app secrets as one SSM SecureString (1 KMS decrypt
+# instead of one per secret). Expand it into the process env BEFORE the
+# System.get_env/1 reads below so they resolve unchanged. Self-host/dev set
+# individual env vars and never set APP_SECRETS_JSON, so this is a no-op.
+# Malformed JSON raises here → boot fails loud rather than starting with
+# missing secrets.
+if blob = System.get_env("APP_SECRETS_JSON") do
+  Engram.Secrets.unpack(blob, &System.get_env/1)
+  |> Enum.each(fn {k, v} -> System.put_env(k, v) end)
+end
+
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the
 # system starts, so it is typically used to load production configuration

--- a/lib/engram/secrets.ex
+++ b/lib/engram/secrets.ex
@@ -24,7 +24,10 @@ defmodule Engram.Secrets do
       map when is_map(map) ->
         map
         |> Enum.reject(fn {k, _v} -> getenv.(k) != nil end)
-        |> Map.new(fn {k, v} -> {k, to_string(v)} end)
+        |> Map.new(fn
+          {k, v} when is_binary(v) or is_number(v) or is_boolean(v) -> {k, to_string(v)}
+          {k, _v} -> raise ArgumentError, "APP_SECRETS_JSON[#{k}] must be a scalar value"
+        end)
 
       other ->
         raise ArgumentError,

--- a/lib/engram/secrets.ex
+++ b/lib/engram/secrets.ex
@@ -1,0 +1,34 @@
+defmodule Engram.Secrets do
+  @moduledoc """
+  Prod delivers all app secrets as a single SSM SecureString JSON blob
+  (`APP_SECRETS_JSON`) so the task incurs one `kms:Decrypt` instead of one
+  per secret. `unpack/2` expands that blob into a map suitable for
+  `System.put_env/1`. Self-host/dev set individual env vars and never set
+  the blob, so this is a no-op there.
+
+  An individually-set env var always wins over the blob — this preserves
+  per-key emergency overrides and makes the migration window safe.
+  """
+
+  @doc """
+  Given the blob string (or nil) and an env-lookup function, returns the
+  `%{name => value}` pairs to inject. Keys already present (lookup returns a
+  non-nil value) are excluded. Raises on malformed or non-object JSON.
+  """
+  @spec unpack(String.t() | nil, (String.t() -> String.t() | nil)) ::
+          %{String.t() => String.t()}
+  def unpack(nil, _getenv), do: %{}
+
+  def unpack(blob, getenv) when is_binary(blob) and is_function(getenv, 1) do
+    case Jason.decode!(blob) do
+      map when is_map(map) ->
+        map
+        |> Enum.reject(fn {k, _v} -> getenv.(k) != nil end)
+        |> Map.new(fn {k, v} -> {k, to_string(v)} end)
+
+      other ->
+        raise ArgumentError,
+              "APP_SECRETS_JSON must be a JSON object, got: #{inspect(other)}"
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.396",
+      version: "0.5.397",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/secrets_test.exs
+++ b/test/engram/secrets_test.exs
@@ -33,4 +33,27 @@ defmodule Engram.SecretsTest do
   test "non-object JSON raises ArgumentError" do
     assert_raise ArgumentError, fn -> Secrets.unpack("[1,2,3]", fn _ -> nil end) end
   end
+
+  test "a nested-object value raises ArgumentError without leaking the value" do
+    blob = ~s({"GOOD":"x","NESTED":{"secret":"leak"}})
+    err = assert_raise ArgumentError, fn -> Secrets.unpack(blob, fn _ -> nil end) end
+    refute err.message =~ "leak"
+    assert err.message =~ "NESTED"
+  end
+
+  test "a null value raises ArgumentError" do
+    assert_raise ArgumentError, fn ->
+      Secrets.unpack(~s({"A":null}), fn _ -> nil end)
+    end
+  end
+
+  test "an individually-set empty-string env var still wins (excluded)" do
+    blob = ~s({"A":"1"})
+    getenv = fn
+      "A" -> ""
+      _ -> nil
+    end
+
+    assert Secrets.unpack(blob, getenv) == %{}
+  end
 end

--- a/test/engram/secrets_test.exs
+++ b/test/engram/secrets_test.exs
@@ -13,6 +13,7 @@ defmodule Engram.SecretsTest do
 
   test "an individually-set env var wins and is excluded" do
     blob = ~s({"A":"1","B":"2"})
+
     getenv = fn
       "A" -> "override"
       _ -> nil
@@ -49,6 +50,7 @@ defmodule Engram.SecretsTest do
 
   test "an individually-set empty-string env var still wins (excluded)" do
     blob = ~s({"A":"1"})
+
     getenv = fn
       "A" -> ""
       _ -> nil

--- a/test/engram/secrets_test.exs
+++ b/test/engram/secrets_test.exs
@@ -1,0 +1,36 @@
+defmodule Engram.SecretsTest do
+  use ExUnit.Case, async: true
+  alias Engram.Secrets
+
+  test "nil blob returns empty map" do
+    assert Secrets.unpack(nil, fn _ -> nil end) == %{}
+  end
+
+  test "expands all keys when env is empty" do
+    blob = ~s({"A":"1","B":"2"})
+    assert Secrets.unpack(blob, fn _ -> nil end) == %{"A" => "1", "B" => "2"}
+  end
+
+  test "an individually-set env var wins and is excluded" do
+    blob = ~s({"A":"1","B":"2"})
+    getenv = fn
+      "A" -> "override"
+      _ -> nil
+    end
+
+    assert Secrets.unpack(blob, getenv) == %{"B" => "2"}
+  end
+
+  test "coerces non-string JSON values to strings" do
+    blob = ~s({"N":42,"B":true})
+    assert Secrets.unpack(blob, fn _ -> nil end) == %{"N" => "42", "B" => "true"}
+  end
+
+  test "malformed JSON raises" do
+    assert_raise Jason.DecodeError, fn -> Secrets.unpack("{not json", fn _ -> nil end) end
+  end
+
+  test "non-object JSON raises ArgumentError" do
+    assert_raise ArgumentError, fn -> Secrets.unpack("[1,2,3]", fn _ -> nil end) end
+  end
+end


### PR DESCRIPTION
## Why

Phase 0 of the KMS free-tier reduction (spec: engram-workspace#74). Prod delivers secrets to ECS as 32 individual SSM SecureString params → 32 `kms:Decrypt` per read (CI plans + task starts), tripping the 20k/mo free tier. The fix delivers app secrets as **one** `APP_SECRETS_JSON` blob (1 decrypt). This PR is the backend half: teach the app to unpack it.

## What

- `Engram.Secrets.unpack/2` — pure, fully unit-tested: expands the JSON blob into `%{env => value}`, an individually-set env var wins (override + migration safety), fails loud on malformed / non-object / non-scalar JSON **without leaking the value** into logs.
- `config/runtime.exs` prelude (right after `import Config`): when `APP_SECRETS_JSON` is set, unpack it into the process env so the existing ~96 `System.get_env/1` reads resolve unchanged.

## Safety

- **Pure no-op until infra sets `APP_SECRETS_JSON`** (engram-infra Phase 1). Self-host / dev / staging-fastraid set individual env vars and never set the blob → unaffected.
- An individually-set var overrides the blob, so the migration window and emergency per-key overrides are safe.

## Tests

`Engram.Secrets` — 9 unit tests, 0 failures. Compile clean with `--warnings-as-errors`; credo + sobelow green.

> Note: local `mix test` against PG16 on `:5432` fails on `transaction_timeout` (ecto 3.14, PG17+ only) — a pre-existing env mismatch (real dev DB is PG18 on `:5433`), not this change. CI uses ephemeral postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)