### PR TITLE
perf: wave-1 hot-path quick wins (audit remediation)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -85,12 +85,13 @@ export const api = {
   async post<T>(
     path: string,
     body?: unknown,
-    opts?: { headers?: Record<string, string> },
+    opts?: { headers?: Record<string, string>; signal?: AbortSignal },
   ): Promise<T> {
     const res = await authFetch(path, {
       method: 'POST',
       body: body ? JSON.stringify(body) : undefined,
       headers: opts?.headers,
+      signal: opts?.signal,
     })
     return res.json()
   },

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -55,6 +55,7 @@ import {
   useRenameFolder,
   useRenameNote,
   useReverseCancel,
+  useSearch,
 } from './queries'
 
 let qc: QueryClient
@@ -1057,5 +1058,39 @@ describe('useBatchMoveFolders', () => {
     expect(folders?.folders.find((f) => f.id === '7')?.name).toBe('src')
     expect(folders?.folders.find((f) => f.id === '7')?.parent_id).toBeNull()
     expect(folders?.folders.find((f) => f.id === '8')?.name).toBe('src/sub')
+  })
+})
+
+describe('useSearch', () => {
+  it('forwards an abort signal so superseded searches are cancelled', async () => {
+    post.mockResolvedValue({ results: [] })
+
+    const { result } = renderHook(() => useSearch('alpha'), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(post).toHaveBeenCalledWith(
+      '/search',
+      { query: 'alpha', limit: 20 },
+      { signal: expect.any(AbortSignal) },
+    )
+  })
+
+  it('keeps previous results visible while the next query is in flight', async () => {
+    const firstResults = [{ id: '1', path: 'a.md', title: 'A' }]
+    post.mockResolvedValueOnce({ results: firstResults })
+
+    const { result, rerender } = renderHook(({ q }) => useSearch(q), {
+      wrapper,
+      initialProps: { q: 'alpha' },
+    })
+    await waitFor(() => expect(result.current.data).toEqual(firstResults))
+
+    // Second query never resolves during the assertion window — previous
+    // results must remain rendered instead of flickering to empty.
+    post.mockImplementationOnce(() => new Promise(() => {}))
+    rerender({ q: 'alpha beta' })
+
+    expect(result.current.data).toEqual(firstResults)
+    expect(result.current.isPlaceholderData).toBe(true)
   })
 })

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,4 +1,10 @@
-import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { api, ApiError } from './client'
@@ -314,9 +320,14 @@ export function useSearch(query: string) {
   const vaultId = useActiveVaultId()
   return useQuery({
     queryKey: ['search', vaultId, query],
-    queryFn: () => api.post<{ results: SearchResult[] }>('/search', { query, limit: 20 }),
+    // Each search costs a Voyage embedding + Qdrant round trip server-side:
+    // abort superseded requests, and keep the previous results rendered
+    // while the next key loads so the panel doesn't flicker empty.
+    queryFn: ({ signal }) =>
+      api.post<{ results: SearchResult[] }>('/search', { query, limit: 20 }, { signal }),
     select: (data) => data.results,
     enabled: query.length > 0,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/src/layout/search-panel.tsx
+++ b/frontend/src/layout/search-panel.tsx
@@ -1,8 +1,9 @@
 import { Search, X } from 'lucide-react'
-import { useDeferredValue, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { type SearchResult, useSearch } from '../api/queries'
 import { pushRecent, readRecent } from './recent-searches'
 import { useRailView } from './rail-view-context'
@@ -10,7 +11,10 @@ import { useRailView } from './rail-view-context'
 export default function SearchPanel() {
   const { setView } = useRailView()
   const [input, setInput] = useState('')
-  const deferred = useDeferredValue(input.trim())
+  // True debounce, not useDeferredValue: deferral only delays rendering —
+  // every settled keystroke still became a new query key, i.e. one vector
+  // search (Voyage embed + Qdrant) per character typed.
+  const deferred = useDebouncedValue(input.trim(), 300)
   const { data: results, isLoading, error } = useSearch(deferred)
   const [recent, setRecent] = useState<string[]>(() => readRecent())
   const inputRef = useRef<HTMLInputElement>(null)

--- a/frontend/src/lib/use-debounced-value.test.ts
+++ b/frontend/src/lib/use-debounced-value.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+import { useDebouncedValue } from './use-debounced-value'
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('a', 300))
+    expect(result.current).toBe('a')
+  })
+
+  it('adopts only the latest value, only after the delay elapses', () => {
+    const { result, rerender } = renderHook(({ v }) => useDebouncedValue(v, 300), {
+      initialProps: { v: 'a' },
+    })
+
+    rerender({ v: 'ab' })
+    rerender({ v: 'abc' })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe('abc')
+  })
+
+  it('restarts the timer on every change (trailing debounce)', () => {
+    const { result, rerender } = renderHook(({ v }) => useDebouncedValue(v, 300), {
+      initialProps: { v: 'a' },
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    rerender({ v: 'ab' })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    // 400ms since mount but only 200ms since last change — still 'a'
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current).toBe('ab')
+  })
+})

--- a/frontend/src/lib/use-debounced-value.ts
+++ b/frontend/src/lib/use-debounced-value.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Trailing debounce of a changing value. Unlike `useDeferredValue` — which
+ * only defers *rendering* and still yields one settled value per keystroke —
+ * this emits nothing until the input has been stable for `delayMs`, so
+ * consumers keyed on the result (e.g. query keys) fire once per pause
+ * instead of once per keystroke.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/frontend/src/viewer/note-editor.test.tsx
+++ b/frontend/src/viewer/note-editor.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+import NoteEditor from './note-editor'
+
+// Captures the extensions prop identity per render. @uiw/react-codemirror
+// watches this prop and dispatches a full reconfigure effect whenever its
+// identity changes — a fresh array per keystroke reconfigures the editor
+// continuously while typing.
+const capturedExtensions: unknown[] = []
+
+vi.mock('@uiw/react-codemirror', () => ({
+  default: (props: { extensions: unknown }) => {
+    capturedExtensions.push(props.extensions)
+    return <div data-testid="cm" />
+  },
+}))
+
+vi.mock('../theme/theme-provider', () => ({
+  useTheme: () => ({ resolved: 'light' }),
+}))
+
+describe('NoteEditor extensions stability', () => {
+  it('passes a referentially stable extensions array across re-renders', () => {
+    capturedExtensions.length = 0
+    const onChange = () => {}
+
+    const { rerender } = render(<NoteEditor value="a" onChange={onChange} />)
+    rerender(<NoteEditor value="ab" onChange={onChange} />)
+    rerender(<NoteEditor value="abc" onChange={onChange} />)
+
+    expect(capturedExtensions).toHaveLength(3)
+    expect(capturedExtensions[1]).toBe(capturedExtensions[0])
+    expect(capturedExtensions[2]).toBe(capturedExtensions[0])
+  })
+})

--- a/frontend/src/viewer/note-editor.tsx
+++ b/frontend/src/viewer/note-editor.tsx
@@ -15,6 +15,19 @@ const mobileSafeTheme = EditorView.theme({
   '.cm-scroller': { fontFamily: 'inherit' },
 })
 
+// Module scope: react-codemirror reconfigures the editor whenever the
+// extensions prop identity changes — an inline array re-instantiated the
+// markdown language package on every keystroke.
+const extensions = [markdown(), EditorView.lineWrapping, mobileSafeTheme]
+
+const basicSetup = {
+  lineNumbers: false,
+  foldGutter: false,
+  highlightActiveLine: false,
+  highlightActiveLineGutter: false,
+  autocompletion: false,
+}
+
 export default function NoteEditor({ value, onChange }: NoteEditorProps) {
   const { resolved } = useTheme()
 
@@ -23,14 +36,8 @@ export default function NoteEditor({ value, onChange }: NoteEditorProps) {
       value={value}
       onChange={onChange}
       theme={resolved}
-      extensions={[markdown(), EditorView.lineWrapping, mobileSafeTheme]}
-      basicSetup={{
-        lineNumbers: false,
-        foldGutter: false,
-        highlightActiveLine: false,
-        highlightActiveLineGutter: false,
-        autocompletion: false,
-      }}
+      extensions={extensions}
+      basicSetup={basicSetup}
       className="min-h-[70vh] rounded-md border border-border bg-muted/30"
     />
   )

--- a/frontend/src/viewer/note-view.memo.test.tsx
+++ b/frontend/src/viewer/note-view.memo.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+
+import NoteView from './note-view'
+
+// Counts actual ReactMarkdown renders — each one is a full remark/rehype
+// parse of the note in production, the dominant typing-latency cost.
+let markdownRenders = 0
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => {
+    markdownRenders++
+    return <div data-testid="md">{children}</div>
+  },
+  defaultUrlTransform: (url: string) => url,
+}))
+
+vi.mock('../api/queries', () => ({
+  useBillingStatus: () => ({ data: { tier: 'pro' } }),
+}))
+
+vi.mock('./attachment-img', () => ({ default: () => null }))
+vi.mock('./mermaid-block', () => ({ default: () => null }))
+
+const EMPTY_TAGS: string[] = []
+const UPDATED_AT = new Date('2026-06-07').toISOString()
+
+// Simulates NotePage while typing: parent state changes every keystroke,
+// but the preview's props stay referentially identical.
+function Harness() {
+  const [, setTick] = useState(0)
+  return (
+    <>
+      <button type="button" onClick={() => setTick((t) => t + 1)}>
+        tick
+      </button>
+      <NoteView content="# Hello" title="T" tags={EMPTY_TAGS} updatedAt={UPDATED_AT} />
+    </>
+  )
+}
+
+describe('NoteView memoization', () => {
+  it('does not re-run the markdown pipeline when parent re-renders with identical props', () => {
+    markdownRenders = 0
+    render(<Harness />)
+    expect(markdownRenders).toBe(1)
+
+    fireEvent.click(screen.getByText('tick'))
+    fireEvent.click(screen.getByText('tick'))
+
+    expect(markdownRenders).toBe(1)
+  })
+})

--- a/frontend/src/viewer/note-view.tsx
+++ b/frontend/src/viewer/note-view.tsx
@@ -1,5 +1,5 @@
 import matter from 'gray-matter'
-import { useMemo } from 'react'
+import { memo, useMemo } from 'react'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
 import rehypeHighlight from 'rehype-highlight'
@@ -56,7 +56,11 @@ const rehypePlugins = [
 // are first-class note types that should still link normally on Free.
 const TEXT_EMBED = /\.(md|canvas)$/i
 
-export default function NoteView({ content, title, tags, updatedAt }: NoteViewProps) {
+// memo: NotePage re-renders on every editor keystroke (draft state) while
+// the preview stays force-mounted with identical props; react-markdown has
+// no internal memoization, so an unmemoized NoteView re-ran the full
+// remark/rehype pipeline (gfm + KaTeX + highlight) per keystroke.
+function NoteView({ content, title, tags, updatedAt }: NoteViewProps) {
   const { data: billing } = useBillingStatus()
   const tier = billing?.tier
   const { frontmatter, body } = useMemo(() => {
@@ -144,3 +148,5 @@ export default function NoteView({ content, title, tags, updatedAt }: NoteViewPr
     </article>
   )
 }
+
+export default memo(NoteView)

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -317,23 +317,39 @@ defmodule Engram.Crypto do
     # representative per group: content (with title), path (with folder),
     # and tags (standalone). Any group present → load DEK + run decrypt.
     not is_nil(note.content_ciphertext) or
+      not is_nil(note.title_ciphertext) or
       not is_nil(note.path_ciphertext) or
       not is_nil(note.tags_ciphertext)
   end
 
-  defp decrypt_phase_4_note_fields(%Engram.Notes.Note{content_ciphertext: nil} = note, _dek),
+  # Content and title decrypt independently: metadata-only listings project
+  # out content_ciphertext (the big column) while still carrying title.
+  defp decrypt_phase_4_note_fields(%Engram.Notes.Note{} = note, dek) do
+    with {:ok, note} <- decrypt_note_content(note, dek) do
+      decrypt_note_title(note, dek)
+    end
+  end
+
+  defp decrypt_note_content(%Engram.Notes.Note{content_ciphertext: nil} = note, _dek),
     do: {:ok, note}
 
-  defp decrypt_phase_4_note_fields(%Engram.Notes.Note{} = note, dek) do
-    content_aad = decrypt_aad(note, :notes, :content)
-    title_aad = decrypt_aad(note, :notes, :title)
+  defp decrypt_note_content(%Engram.Notes.Note{} = note, dek) do
+    aad = decrypt_aad(note, :notes, :content)
 
-    with {:ok, content} <-
-           Envelope.decrypt(note.content_ciphertext, note.content_nonce, dek, content_aad),
-         {:ok, title} <-
-           Envelope.decrypt(note.title_ciphertext, note.title_nonce, dek, title_aad) do
-      {:ok, %{note | content: content, title: title}}
-    else
+    case Envelope.decrypt(note.content_ciphertext, note.content_nonce, dek, aad) do
+      {:ok, content} -> {:ok, %{note | content: content}}
+      :error -> {:error, :decrypt_failed}
+    end
+  end
+
+  defp decrypt_note_title(%Engram.Notes.Note{title_ciphertext: nil} = note, _dek),
+    do: {:ok, note}
+
+  defp decrypt_note_title(%Engram.Notes.Note{} = note, dek) do
+    aad = decrypt_aad(note, :notes, :title)
+
+    case Envelope.decrypt(note.title_ciphertext, note.title_nonce, dek, aad) do
+      {:ok, title} -> {:ok, %{note | title: title}}
       :error -> {:error, :decrypt_failed}
     end
   end

--- a/lib/engram/embedders/voyage.ex
+++ b/lib/engram/embedders/voyage.ex
@@ -79,6 +79,19 @@ defmodule Engram.Embedders.Voyage do
   defp status_label({:error, {status, _}}) when is_integer(status), do: :client_error
   defp status_label({:error, _}), do: :error
 
+  @doc """
+  Default Req options per embed purpose.
+
+  `:query` backs synchronous user search — the request process is pinned
+  for the whole call, so a Voyage brownout must fail fast (one attempt,
+  short timeout) instead of holding searches for up to ~2 minutes.
+  `:index` runs in Oban workers where patient retries are the right call.
+  Explicit caller opts always win over these defaults.
+  """
+  @spec request_defaults(atom()) :: keyword()
+  def request_defaults(:query), do: [receive_timeout: 5_000, retry: false]
+  def request_defaults(_purpose), do: [receive_timeout: 30_000, retry: :transient, max_retries: 3]
+
   defp do_embed_texts(texts, opts) do
     url = Application.get_env(:engram, :voyage_url, @default_url)
     model = Keyword.get(opts, :model, Application.get_env(:engram, :embed_model, @default_model))
@@ -88,17 +101,15 @@ defmodule Engram.Embedders.Voyage do
         raise "VOYAGE_API_KEY not configured (set VOYAGE_API_KEY env var)"
 
     {req_opts, _} = Keyword.split(opts, [:retry, :max_retries, :receive_timeout])
+    purpose = Keyword.get(opts, :purpose, :index)
 
     result =
       Req.post(
         "#{url}/v1/embeddings",
         [
           json: %{input: texts, model: model},
-          headers: [{"authorization", "Bearer #{api_key}"}],
-          receive_timeout: 30_000,
-          retry: :transient,
-          max_retries: 3
-        ] ++ req_opts
+          headers: [{"authorization", "Bearer #{api_key}"}]
+        ] ++ Keyword.merge(request_defaults(purpose), req_opts)
       )
 
     case result do

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1873,17 +1873,24 @@ defmodule Engram.Notes do
   # is one-shot anyway, but avoiding extra channel traffic keeps the
   # invariant readable from the server side too.
   defp maybe_broadcast_vault_populated(user, vault) do
-    {:ok, count} =
+    # "Exactly one row?" via LIMIT 2 instead of COUNT(*): the aggregate
+    # visits every matching row, so a bulk first-sync paid an O(vault)
+    # count on every insert. The probe touches at most two index entries
+    # regardless of vault size. Scope stays per-vault (NOT the per-user
+    # usage_meters counter — multi-vault users must still get the event
+    # for a new vault's first note).
+    {:ok, ids} =
       Repo.with_tenant(user.id, fn ->
-        Repo.one(
+        Repo.all(
           from n in Note,
             where: n.user_id == ^user.id and n.vault_id == ^vault.id,
-            select: count(n.id)
+            select: n.id,
+            limit: 2
         )
       end)
 
     _ =
-      if count == 1 do
+      if length(ids) == 1 do
         EngramWeb.Endpoint.broadcast(
           "user:#{user.id}",
           "vault_populated",

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -855,28 +855,69 @@ defmodule Engram.Notes do
     end
   end
 
+  # Every persisted Note column except content_ciphertext/content_nonce —
+  # the metadata projection for listings that never serialize content.
+  # Skipping the big column saves its I/O AND its AES-GCM decrypt (the
+  # phase-4 helpers short-circuit per-field on nil ciphertext).
+  @note_meta_fields [
+    :id,
+    :version,
+    :kind,
+    :dek_version,
+    :content_hash,
+    :embed_hash,
+    :mtime,
+    :deleted_at,
+    :title_ciphertext,
+    :title_nonce,
+    :tags_ciphertext,
+    :tags_nonce,
+    :path_ciphertext,
+    :path_nonce,
+    :path_hmac,
+    :folder_ciphertext,
+    :folder_nonce,
+    :folder_hmac,
+    :tags_hmac,
+    :user_id,
+    :vault_id,
+    :created_at,
+    :updated_at
+  ]
+
   @doc """
   Returns notes changed (upserted or deleted) since the given datetime.
   Deleted notes are included with deleted: true.
+
+  Options:
+
+    * `fields: :meta` — project out `content_ciphertext` and return
+      `content: nil`. Used by the sync channel's `pull_changes`, whose
+      reply never includes content; skips the dominant column read and
+      its decrypt.
   """
-  @spec list_changes(map(), map(), DateTime.t()) :: {:ok, [map()]}
-  def list_changes(user, vault, since) do
-    {:ok, notes} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.all(
-          from(n in Note,
-            where:
-              n.user_id == ^user.id and n.vault_id == ^vault.id and n.updated_at >= ^since and
-                n.kind == "note",
-            order_by: [asc: n.updated_at]
-          )
-        )
-      end)
+  @spec list_changes(map(), map(), DateTime.t(), keyword()) :: {:ok, [map()]}
+  def list_changes(user, vault, since, opts \\ []) do
+    base =
+      from(n in Note,
+        where:
+          n.user_id == ^user.id and n.vault_id == ^vault.id and n.updated_at >= ^since and
+            n.kind == "note",
+        order_by: [asc: n.updated_at]
+      )
+
+    query =
+      case Keyword.get(opts, :fields, :all) do
+        :meta -> from(n in base, select: struct(n, @note_meta_fields))
+        :all -> base
+      end
+
+    {:ok, notes} = Repo.with_tenant(user.id, fn -> Repo.all(query) end)
 
     changes =
-      Enum.map(notes, fn note ->
-        note = decrypt_or_raise!(note, user)
-
+      notes
+      |> decrypt_or_raise!(user)
+      |> Enum.map(fn note ->
         %{
           id: note.id,
           path: note.path,
@@ -1204,6 +1245,9 @@ defmodule Engram.Notes do
       {:ok, filter_key} ->
         target_hmac = Crypto.hmac_field(filter_key, folder)
 
+        # Metadata projection: every caller serializes summaries (path,
+        # title, tags, ...) — content is never returned, so don't fetch
+        # or decrypt it.
         {:ok, notes} =
           Repo.with_tenant(user.id, fn ->
             Repo.all(
@@ -1212,7 +1256,8 @@ defmodule Engram.Notes do
                   n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
                     n.kind == "note" and
                     n.folder_hmac == ^target_hmac,
-                order_by: [asc: n.id]
+                order_by: [asc: n.id],
+                select: struct(n, @note_meta_fields)
               )
             )
           end)

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -236,7 +236,9 @@ defmodule EngramWeb.SyncChannel do
 
         case DateTime.from_iso8601(since_str) do
           {:ok, since, _} ->
-            {:ok, changes} = Notes.list_changes(user, vault, since)
+            # :meta — this reply never includes content (clients pull
+            # bodies separately), so skip the content fetch + decrypt.
+            {:ok, changes} = Notes.list_changes(user, vault, since, fields: :meta)
 
             serialized =
               Enum.map(changes, fn c ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.397",
+      version: "0.5.398",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -223,6 +223,31 @@ defmodule Engram.CryptoTest do
       {:ok, out} = Crypto.maybe_decrypt_note_fields(note, user)
       assert out.tags == ["alpha", "beta"]
     end
+
+    test "decrypts title when content_ciphertext is absent (sparse projection)", %{user: user} do
+      # Metadata-only listings project out content_ciphertext to skip the
+      # big-column I/O + decrypt. Title must still decrypt — the phase-4
+      # gate may not couple title to content presence.
+      {:ok, user} = Crypto.ensure_user_dek(user)
+
+      note_id = Ecto.UUID.generate()
+
+      {:ok, enc} =
+        Crypto.encrypt_note_fields(%{content: "body", title: "My Title"}, user, note_id)
+
+      note = %Engram.Notes.Note{
+        id: note_id,
+        dek_version: Crypto.row_version_aad_bound(),
+        content_ciphertext: nil,
+        content_nonce: nil,
+        title_ciphertext: enc.title_ciphertext,
+        title_nonce: enc.title_nonce
+      }
+
+      {:ok, out} = Crypto.maybe_decrypt_note_fields(note, user)
+      assert out.title == "My Title"
+      assert out.content == nil
+    end
   end
 
   defp build_encrypted_note(user, content, title) do

--- a/test/engram/embedders/voyage_test.exs
+++ b/test/engram/embedders/voyage_test.exs
@@ -55,6 +55,40 @@ defmodule Engram.Embedders.VoyageTest do
       end)
     end
 
+    test "query purpose defaults to fast-fail request options" do
+      # Interactive search holds a request process for the full embed call.
+      # With the index defaults (30s timeout x 4 attempts) a Voyage brownout
+      # pins searches for up to ~2 minutes each. Queries fail fast instead;
+      # callers can still override per call.
+      defaults = Voyage.request_defaults(:query)
+      assert defaults[:receive_timeout] == 5_000
+      assert defaults[:retry] == false
+    end
+
+    test "index purpose keeps patient retry defaults" do
+      defaults = Voyage.request_defaults(:index)
+      assert defaults[:receive_timeout] == 30_000
+      assert defaults[:retry] == :transient
+      assert defaults[:max_retries] == 3
+    end
+
+    test "query purpose does not retry against a failing upstream", %{bypass: bypass} do
+      # Behavior pin: with purpose: :query and no caller overrides, a 500
+      # gets exactly ONE request (retry: false), not 4.
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Bypass.expect(bypass, "POST", "/v1/embeddings", fn conn ->
+        Agent.update(counter, &(&1 + 1))
+        Plug.Conn.send_resp(conn, 500, ~s({"error": "boom"}))
+      end)
+
+      capture_log(fn ->
+        assert {:error, {500, _}} = Voyage.embed_texts(["hello"], purpose: :query)
+      end)
+
+      assert Agent.get(counter, & &1) == 1
+    end
+
     test "sends correct model in request body", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/v1/embeddings", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -484,6 +484,29 @@ defmodule Engram.NotesTest do
       assert Enum.any?(changes, &(&1.path == "Test/SameSecond.md")),
              "Changes in the same second as truncated server_time must be included"
     end
+
+    test "fields: :meta returns full metadata with content omitted", %{user: user, vault: vault} do
+      # The sync channel's pull_changes drops content from its reply, so it
+      # asks for the metadata-only projection — content_ciphertext (the big
+      # column) is never fetched or decrypted.
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Meta/Sparse.md",
+          "content" => "# Big body that must not be decrypted",
+          "mtime" => 1_000.0
+        })
+
+      past = DateTime.add(note.updated_at, -60, :second)
+      {:ok, changes} = Notes.list_changes(user, vault, past, fields: :meta)
+
+      change = Enum.find(changes, &(&1.path == "Meta/Sparse.md"))
+      assert change != nil
+      assert change.title == "Big body that must not be decrypted"
+      assert change.folder == "Meta"
+      assert change.version == note.version
+      assert change.deleted == false
+      assert change.content == nil
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -907,6 +930,26 @@ defmodule Engram.NotesTest do
       paths = Enum.map(notes, & &1.path)
       assert "Health/Note1.md" in paths
       assert "Health/Note2.md" in paths
+    end
+
+    test "does not fetch or decrypt note content (metadata listing)", %{
+      user: user,
+      vault: vault
+    } do
+      # Every caller (folders controller note_summary, MCP list_folder, tree
+      # loaders) serializes metadata only — content stays projected out so
+      # folder browsing never pays content I/O + decrypt.
+      Notes.upsert_note(user, vault, %{
+        "path" => "Health/Sparse.md",
+        "content" => "# never needed here",
+        "mtime" => 1_000.0
+      })
+
+      {:ok, [note]} = Notes.list_notes_in_folder(user, vault, "Health")
+      assert note.title == "never needed here"
+      assert note.path == "Health/Sparse.md"
+      assert note.content == nil
+      assert note.content_ciphertext == nil
     end
 
     test "returns root-level notes with empty string", %{user: user, vault: vault} do

--- a/test/engram_web/channels/user_channel_test.exs
+++ b/test/engram_web/channels/user_channel_test.exs
@@ -89,5 +89,38 @@ defmodule EngramWeb.UserChannelTest do
 
       refute_broadcast "vault_populated", %{}, 200
     end
+
+    # Characterization guard: the populated check is VAULT-scoped, not
+    # user-scoped. A user with an existing populated vault must still get
+    # the broadcast for the first note of a NEW vault. (Protects against
+    # replacing the existence probe with the per-user notes_count meter.)
+    test "fires for the first note of a second vault even when another vault has notes",
+         %{user: user} do
+      # Free tier caps vaults at 1 — lift it so this user can hold two.
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+
+      {:ok, vault_a} = Vaults.create_vault(user, %{name: "A"})
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault_a, %{
+          "path" => "Existing.md",
+          "content" => "old",
+          "mtime" => 1_700_000_000.0
+        })
+
+      assert_broadcast "vault_populated", %{}
+
+      {:ok, vault_b} = Vaults.create_vault(user, %{name: "B"})
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault_b, %{
+          "path" => "Fresh.md",
+          "content" => "new",
+          "mtime" => 1_700_000_001.0
+        })
+
+      assert_broadcast "vault_populated", %{vault_id: vault_b_id}
+      assert vault_b_id == vault_b.id
+    end
   end
 end


### PR DESCRIPTION
## Summary

First wave of the 2026-06-12 performance/scalability audit — five S-effort, high-payoff fixes with no protocol changes.

**Backend**
- **`COUNT(*)` per insert → `LIMIT 2` probe** — `maybe_broadcast_vault_populated` ran a full vault count on every note insert (O(N²) row visits across a bulk first sync). Bounded existence probe touches ≤2 index entries. New characterization test pins the per-vault (not per-user) broadcast scope.
- **Metadata-only projection for `pull_changes` + folder listings** — both serialized summaries only but fetched + decrypted `content_ciphertext` (the dominant column) for every row. New `fields: :meta` projection on `list_changes`, applied to `list_notes_in_folder`; phase-4 title decrypt decoupled from content presence; `list_changes` decrypt now routes through the parallel batch path instead of per-note serial.
- **Search query embeds fail fast** — per-purpose Voyage request defaults: `:query` (synchronous user search) gets 5s timeout + no retry instead of inheriting 30s × 4 attempts (~2 min worst-case request hold during a Voyage brownout); `:index` keeps patient retries for Oban workers.

**Frontend**
- **Keystroke cost** — `memo(NoteView)` (react-markdown has no internal memoization; the force-mounted preview re-ran the full remark/rehype pipeline per keystroke) + module-scope CodeMirror `extensions`/`basicSetup` (inline array identity dispatched a reconfigure per keystroke).
- **Search spend** — 300ms trailing debounce replaces `useDeferredValue` (which defers rendering only — every keystroke still fired a Voyage embed + Qdrant search), `AbortSignal` threaded through `api.post` cancels superseded requests, `keepPreviousData` stops result flicker.

## Test plan
- [x] Full backend suite: 2545 tests, 0 failures (PG18)
- [x] `mix credo --strict` + `mix format --check-formatted` clean
- [x] Frontend: 449 tests across 96 files green (incl. 5 new TDD tests), `tsc` clean, prod build passes
- [x] New tests written RED-first for every change

## Notes
- Pre-existing (NOT this PR): frontend `bun run test` exits 1 on main from 2 unhandled `getToken` rejections in onboarding tests — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)