### PR TITLE
perf: cache onboarding gate verdict + limit override lookups

### DIFF
--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -36,8 +36,9 @@ defmodule Engram.Application do
         cache_store_child(),
         Engram.UsageMeters.ActivityCache,
         Engram.Onboarding.TermsCache,
-        # Subscribes to CacheSync in init → must start after PubSub.
+        # Subscribe to CacheSync in init → must start after PubSub.
         Engram.Onboarding.GateCache,
+        Engram.Billing.OverrideCache,
         Engram.Auth.SignupRejections,
         rate_limiter_child(),
         {Oban, Application.fetch_env!(:engram, Oban)},

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -36,6 +36,8 @@ defmodule Engram.Application do
         cache_store_child(),
         Engram.UsageMeters.ActivityCache,
         Engram.Onboarding.TermsCache,
+        # Subscribes to CacheSync in init → must start after PubSub.
+        Engram.Onboarding.GateCache,
         Engram.Auth.SignupRejections,
         rate_limiter_child(),
         {Oban, Application.fetch_env!(:engram, Oban)},

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -38,6 +38,10 @@ defmodule Engram.Application do
         Engram.Onboarding.TermsCache,
         # Subscribe to CacheSync in init → must start after PubSub.
         Engram.Onboarding.GateCache,
+        # Dedicated LISTEN/NOTIFY connection — OverrideCache LISTENs on it
+        # so raw-SQL override writes (trigger → pg_notify) evict caches on
+        # every node. Must start before OverrideCache.
+        pg_notifications_child(),
         Engram.Billing.OverrideCache,
         Engram.Auth.SignupRejections,
         rate_limiter_child(),
@@ -181,6 +185,30 @@ defmodule Engram.Application do
     if Engram.Cache.backend() == :redis do
       {Engram.Cache.Redix, Application.get_env(:engram, Engram.Cache, [])}
     end
+  end
+
+  # One LISTEN/NOTIFY connection per node, shared by caches that subscribe
+  # to Postgres triggers (OverrideCache today). auto_reconnect re-LISTENs
+  # after a connection blip — Postgrex re-establishes the subscriptions on
+  # reconnect for listeners registered via listen/3.
+  defp pg_notifications_child do
+    opts =
+      Engram.Repo.config()
+      |> Keyword.take([
+        :hostname,
+        :host,
+        :port,
+        :username,
+        :password,
+        :database,
+        :ssl,
+        :ssl_opts,
+        :socket_options,
+        :url
+      ])
+      |> Keyword.merge(name: Engram.PgNotifications, auto_reconnect: true, sync_connect: false)
+
+    {Postgrex.Notifications, opts}
   end
 
   # Start the concrete limiter matching the configured backend. ETS (default)

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -94,19 +94,24 @@ defmodule Engram.Billing do
   # ── Private Limit Helpers ─────────────────────────────────────────
 
   defp user_override_lookup(user_id, string_key) do
-    now = DateTime.utc_now()
+    # Read-through cache (60s TTL, hits AND misses): this lookup runs on
+    # every effective_limit resolution and hot paths resolve several
+    # limits per request, while override rows are rare admin grants.
+    Engram.Billing.OverrideCache.fetch(user_id, string_key, fn ->
+      now = DateTime.utc_now()
 
-    Repo.one(
-      from(o in UserLimitOverride,
-        where:
-          o.user_id == ^user_id and
-            o.key == ^string_key and
-            (is_nil(o.expires_at) or o.expires_at > ^now),
-        select: fragment("?->'v'", o.value)
-      ),
-      skip_tenant_check: true
-    )
-    |> wrap_lookup()
+      Repo.one(
+        from(o in UserLimitOverride,
+          where:
+            o.user_id == ^user_id and
+              o.key == ^string_key and
+              (is_nil(o.expires_at) or o.expires_at > ^now),
+          select: fragment("?->'v'", o.value)
+        ),
+        skip_tenant_check: true
+      )
+      |> wrap_lookup()
+    end)
   end
 
   defp env_override_lookup(tier, key) do

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -594,6 +594,11 @@ defmodule Engram.Billing do
   # vault_created broadcast in Engram.Vaults. Fire-and-forget: if nobody
   # is listening, Phoenix.PubSub drops it.
   defp broadcast_subscription_activated(user_id, %Subscription{} = sub) do
+    # Chokepoint for every subscription mutation (created/updated/canceled):
+    # tier/status flips can change the onboarding gate's subscription_ok,
+    # so the cached pass verdict must re-derive.
+    :ok = Engram.Onboarding.GateCache.evict(user_id)
+
     _ =
       EngramWeb.Endpoint.broadcast(
         "user:#{user_id}",

--- a/lib/engram/billing/override_cache.ex
+++ b/lib/engram/billing/override_cache.ex
@@ -112,7 +112,7 @@ defmodule Engram.Billing.OverrideCache do
       ])
 
     :ok = CacheSync.subscribe()
-    listen_pg()
+    :ok = listen_pg()
     {:ok, %{}}
   end
 
@@ -129,6 +129,7 @@ defmodule Engram.Billing.OverrideCache do
 
       _pid ->
         {:ok, _ref} = Postgrex.Notifications.listen(Engram.PgNotifications, @pg_channel)
+        :ok
     end
   catch
     kind, reason ->

--- a/lib/engram/billing/override_cache.ex
+++ b/lib/engram/billing/override_cache.ex
@@ -24,8 +24,11 @@ defmodule Engram.Billing.OverrideCache do
 
   alias Engram.Cluster.CacheSync
 
+  require Logger
+
   @table :engram_billing_override_cache
   @ttl_ms 60_000
+  @pg_channel "user_limit_overrides_changed"
 
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
@@ -109,10 +112,38 @@ defmodule Engram.Billing.OverrideCache do
       ])
 
     :ok = CacheSync.subscribe()
+    listen_pg()
     {:ok, %{}}
   end
 
+  # LISTEN on the channel fired by the user_limit_overrides AFTER-write
+  # trigger (migration 20260612100000). This is what makes raw-SQL writers
+  # (support-runbook grants, e2e helpers) coherent: every node hears the
+  # NOTIFY directly from Postgres and evicts within milliseconds, no app
+  # API involved. Failure to listen is non-fatal — the TTL still bounds
+  # staleness — so log and continue.
+  defp listen_pg do
+    case Process.whereis(Engram.PgNotifications) do
+      nil ->
+        Logger.warning("OverrideCache: PG notifications process not running; TTL-only eviction")
+
+      _pid ->
+        {:ok, _ref} = Postgrex.Notifications.listen(Engram.PgNotifications, @pg_channel)
+    end
+  catch
+    kind, reason ->
+      Logger.warning(
+        "OverrideCache: failed to LISTEN #{@pg_channel} (#{kind}: #{inspect(reason)}); " <>
+          "TTL-only eviction"
+      )
+  end
+
   @impl true
+  def handle_info({:notification, _pid, _ref, @pg_channel, user_id}, state) do
+    _ = delete_local(user_id)
+    {:noreply, state}
+  end
+
   def handle_info({:cache_sync, {:billing_override_evict, user_id}}, state) do
     _ = delete_local(user_id)
     {:noreply, state}

--- a/lib/engram/billing/override_cache.ex
+++ b/lib/engram/billing/override_cache.ex
@@ -1,0 +1,128 @@
+defmodule Engram.Billing.OverrideCache do
+  @moduledoc """
+  Node-local read-through cache for `user_limit_overrides` lookups, keyed by
+  `{user_id, limit_key}` with a #{div(60_000, 1000)}s TTL.
+
+  `Engram.Billing.effective_limit/2` consults the override table first on
+  every resolution, and hot paths resolve several limits per request (search
+  checks reranker + cross_vault, the RPS/write plugs each resolve a budget).
+  Overrides are rare — OG-waitlist / admin grants — so the dominant cached
+  value is the MISS; both hits and misses are stored.
+
+  Invalidation:
+
+    * grants/revocations happen out-of-band (iex / support runbook), so the
+      TTL is the primary bound — a new grant is visible within a minute;
+      `evict/1` exists for callers that want immediacy.
+    * `Engram.Billing.Workers.OverrideExpirySweep` calls `evict_all/0`
+      whenever it deletes expired rows.
+    * evictions ride `Engram.Cluster.CacheSync` so peer nodes drop their
+      copies too.
+  """
+
+  use GenServer
+
+  alias Engram.Cluster.CacheSync
+
+  @table :engram_billing_override_cache
+  @ttl_ms 60_000
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @doc """
+  Returns the cached lookup result (`{:hit, value}` | `:miss`) for the pair,
+  or runs `fun` and caches whatever it returns.
+  """
+  @spec fetch(Ecto.UUID.t(), String.t(), (-> {:hit, term()} | :miss)) ::
+          {:hit, term()} | :miss
+  def fetch(user_id, limit_key, fun) do
+    key = {user_id, limit_key}
+
+    case lookup(key) do
+      {:ok, result} ->
+        result
+
+      :stale ->
+        result = fun.()
+        put(key, result)
+        result
+    end
+  end
+
+  @spec evict(Ecto.UUID.t()) :: :ok
+  def evict(user_id) do
+    _ = delete_local(user_id)
+    CacheSync.broadcast({:billing_override_evict, user_id})
+  end
+
+  @spec evict_all() :: :ok
+  def evict_all do
+    _ = clear_local()
+    CacheSync.broadcast(:billing_override_evict_all)
+  end
+
+  defp lookup(key) do
+    case :ets.lookup(@table, key) do
+      [{^key, result, expires_at}] ->
+        if System.monotonic_time(:millisecond) < expires_at, do: {:ok, result}, else: :stale
+
+      _ ->
+        :stale
+    end
+  rescue
+    # Table absent (cache process down) → treat every read as stale; the
+    # caller falls through to the authoritative DB lookup.
+    ArgumentError -> :stale
+  end
+
+  defp put(key, result) do
+    expires_at = System.monotonic_time(:millisecond) + @ttl_ms
+    :ets.insert(@table, {key, result, expires_at})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp delete_local(user_id) do
+    :ets.match_delete(@table, {{user_id, :_}, :_, :_})
+  rescue
+    ArgumentError -> true
+  end
+
+  defp clear_local do
+    :ets.delete_all_objects(@table)
+  rescue
+    ArgumentError -> true
+  end
+
+  @impl true
+  def init(:ok) do
+    _ =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    :ok = CacheSync.subscribe()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info({:cache_sync, {:billing_override_evict, user_id}}, state) do
+    _ = delete_local(user_id)
+    {:noreply, state}
+  end
+
+  def handle_info({:cache_sync, :billing_override_evict_all}, state) do
+    _ = clear_local()
+    {:noreply, state}
+  end
+
+  # Ignore cache_sync messages addressed to other caches.
+  def handle_info({:cache_sync, _other}, state), do: {:noreply, state}
+end

--- a/lib/engram/billing/workers/override_expiry_sweep.ex
+++ b/lib/engram/billing/workers/override_expiry_sweep.ex
@@ -24,6 +24,10 @@ defmodule Engram.Billing.Workers.OverrideExpirySweep do
         skip_tenant_check: true
       )
 
+    # Cached lookups (hits and misses) may now be wrong — flush so
+    # expirations take effect without waiting out the cache TTL.
+    if count > 0, do: Engram.Billing.OverrideCache.evict_all()
+
     :telemetry.execute(
       [:engram, :billing, :overrides, :expired],
       %{count: count},

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -258,6 +258,12 @@ defmodule Engram.Onboarding do
         user
         |> Ecto.Changeset.change(onboarding_profile: merged)
         |> Repo.update(skip_tenant_check: true)
+        |> tap(fn
+          # uses_obsidian flips can re-arm the vault gate for a passed
+          # user — drop the cached verdict so the plug re-derives.
+          {:ok, _} -> Engram.Onboarding.GateCache.evict(user.id)
+          _ -> :ok
+        end)
     end
   end
 

--- a/lib/engram/onboarding/gate_cache.ex
+++ b/lib/engram/onboarding/gate_cache.ex
@@ -1,0 +1,116 @@
+defmodule Engram.Onboarding.GateCache do
+  @moduledoc """
+  Node-local cache of the RequireOnboarding PASS verdict, keyed by user id.
+
+  Deriving the verdict costs ~3 DB round-trips per request (profile re-read +
+  `has_vault?` inside its own RLS transaction) for an answer that is true for
+  essentially every post-onboarding request. Only PASS is cached — failing
+  users always hit the authoritative slow path, so a stale entry can never
+  withhold access, only briefly extend it.
+
+  Staleness is bounded two ways:
+
+    * every pass→fail transition has an eviction write-site — vault deletion
+      (`Engram.Vaults.delete_vault/2`), subscription mutation (every
+      `Engram.Billing.upsert_from_paddle_event/1` clause via
+      `broadcast_subscription_activated/2`), profile edits
+      (`Engram.Onboarding.set_profile/2`), and a terms-floor bump
+      (`Engram.Legal.VersionCache.invalidate_all/0`, whose
+      `:version_evict_all` broadcast this cache also consumes);
+    * a #{div(60_000, 1000)}s TTL backstops any write-site this list misses.
+
+  Cross-node: evictions ride `Engram.Cluster.CacheSync` exactly like
+  `Engram.Crypto.DekCache` — the mutating node clears its own table
+  synchronously, peers clear on the broadcast.
+  """
+
+  use GenServer
+
+  alias Engram.Cluster.CacheSync
+
+  @table :engram_onboarding_gate_cache
+  @ttl_ms 60_000
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec passed?(Ecto.UUID.t()) :: boolean()
+  def passed?(user_id) do
+    case :ets.lookup(@table, user_id) do
+      [{^user_id, expires_at}] ->
+        System.monotonic_time(:millisecond) < expires_at
+
+      _ ->
+        false
+    end
+  rescue
+    # Table absent (cache process down) → behave as a miss; the plug falls
+    # through to the authoritative status derivation.
+    ArgumentError -> false
+  end
+
+  @spec mark_passed(Ecto.UUID.t(), non_neg_integer()) :: :ok
+  def mark_passed(user_id, ttl_ms \\ @ttl_ms) do
+    expires_at = System.monotonic_time(:millisecond) + ttl_ms
+    :ets.insert(@table, {user_id, expires_at})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Clears the verdict locally and broadcasts the eviction to peer nodes.
+  Idempotent; receiving our own broadcast is a harmless double-delete.
+  """
+  @spec evict(Ecto.UUID.t()) :: :ok
+  def evict(user_id) do
+    _ = delete_local(user_id)
+    CacheSync.broadcast({:onboarding_gate_evict, user_id})
+  end
+
+  @spec evict_all() :: :ok
+  def evict_all do
+    _ = :ets.delete_all_objects(@table)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp delete_local(user_id) do
+    :ets.delete(@table, user_id)
+  rescue
+    ArgumentError -> true
+  end
+
+  @impl true
+  def init(:ok) do
+    _ =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    :ok = CacheSync.subscribe()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info({:cache_sync, {:onboarding_gate_evict, user_id}}, state) do
+    _ = delete_local(user_id)
+    {:noreply, state}
+  end
+
+  # A terms (re)seed or publish can raise the required floor, flipping any
+  # passed user back to failing — drop every verdict and re-derive.
+  def handle_info({:cache_sync, :version_evict_all}, state) do
+    _ = :ets.delete_all_objects(@table)
+    {:noreply, state}
+  end
+
+  # Ignore cache_sync messages addressed to other caches.
+  def handle_info({:cache_sync, _other}, state), do: {:noreply, state}
+end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -439,6 +439,12 @@ defmodule Engram.Vaults do
       end
     end)
     |> unwrap_transaction()
+    |> tap(fn
+      # Deleting the last vault can flip the onboarding gate back to
+      # failing — drop the cached pass verdict so it re-derives.
+      {:ok, _} -> Engram.Onboarding.GateCache.evict(user.id)
+      _ -> :ok
+    end)
   end
 
   # ── Restore (soft-delete reversal) ──────────────────────────────────────────

--- a/lib/engram_web/plugs/require_onboarding.ex
+++ b/lib/engram_web/plugs/require_onboarding.ex
@@ -16,6 +16,7 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
   import Plug.Conn
 
   alias Engram.Onboarding
+  alias Engram.Onboarding.GateCache
 
   def init(opts), do: opts
 
@@ -28,11 +29,23 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
         |> halt()
 
       user ->
-        gate(conn, Onboarding.status(user))
+        # Deriving status costs ~3 DB round-trips (profile re-read +
+        # has_vault? in its own RLS transaction) on EVERY vault-scoped
+        # request. The verdict is cached on pass; failing users always
+        # take the authoritative slow path. Eviction contract lives in
+        # the GateCache moduledoc.
+        if GateCache.passed?(user.id) do
+          conn
+        else
+          gate(conn, Onboarding.status(user), user)
+        end
     end
   end
 
-  defp gate(conn, %{next_step: :done}), do: conn
+  defp gate(conn, %{next_step: :done}, user) do
+    :ok = GateCache.mark_passed(user.id)
+    conn
+  end
 
   defp gate(
          conn,
@@ -41,7 +54,8 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
            subscription_ok: sub_ok,
            profile_complete: profile_ok,
            next_step: next_step
-         } = status
+         } = status,
+         user
        ) do
     has_vault = Map.get(status, :has_vault, true)
     # uses_obsidian users bypass the vault gate (plugin creates vault later).
@@ -61,6 +75,7 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
       # yet (e.g. obsidian user mid-flow whose plugin is about to first-sync).
       # Runtime traffic permission and wizard state are intentionally
       # decoupled — see `Engram.Onboarding.next_step/5`.
+      :ok = GateCache.mark_passed(user.id)
       conn
     else
       body = %{error: "onboarding_required", missing: missing, next_step: next_step}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.398",
+      version: "0.5.399",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260612100000_notify_on_user_limit_override_change.exs
+++ b/priv/repo/migrations/20260612100000_notify_on_user_limit_override_change.exs
@@ -1,0 +1,35 @@
+defmodule Engram.Repo.Migrations.NotifyOnUserLimitOverrideChange do
+  use Ecto.Migration
+
+  @moduledoc """
+  pg_notify on every user_limit_overrides write so the per-node
+  OverrideCache (60s TTL) evicts immediately — for EVERY writer,
+  including raw SQL (support-runbook grants, e2e helpers) that can't
+  call the app's eviction API. phase/expand: purely additive.
+  """
+
+  def up do
+    execute("""
+    CREATE OR REPLACE FUNCTION notify_user_limit_override_change() RETURNS trigger AS $$
+    BEGIN
+      PERFORM pg_notify(
+        'user_limit_overrides_changed',
+        (COALESCE(NEW.user_id, OLD.user_id))::text
+      );
+      RETURN COALESCE(NEW, OLD);
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    execute("""
+    CREATE TRIGGER user_limit_overrides_notify
+    AFTER INSERT OR UPDATE OR DELETE ON user_limit_overrides
+    FOR EACH ROW EXECUTE FUNCTION notify_user_limit_override_change();
+    """)
+  end
+
+  def down do
+    execute("DROP TRIGGER IF EXISTS user_limit_overrides_notify ON user_limit_overrides;")
+    execute("DROP FUNCTION IF EXISTS notify_user_limit_override_change();")
+  end
+end

--- a/priv/repo/migrations/20260612100000_notify_on_user_limit_override_change.exs
+++ b/priv/repo/migrations/20260612100000_notify_on_user_limit_override_change.exs
@@ -18,7 +18,10 @@ defmodule Engram.Repo.Migrations.NotifyOnUserLimitOverrideChange do
       );
       RETURN COALESCE(NEW, OLD);
     END;
-    $$ LANGUAGE plpgsql;
+    $$ LANGUAGE plpgsql
+    -- Pinned search_path (splinter: function_search_path_mutable). The body
+    -- only touches pg_catalog builtins, so empty is correct.
+    SET search_path = '';
     """)
 
     execute("""

--- a/test/engram/billing/override_cache_test.exs
+++ b/test/engram/billing/override_cache_test.exs
@@ -1,0 +1,42 @@
+defmodule Engram.Billing.OverrideCacheTest do
+  use ExUnit.Case, async: false
+
+  alias Engram.Billing.OverrideCache
+
+  setup do
+    on_exit(fn -> OverrideCache.evict_all() end)
+    :ok
+  end
+
+  test "fetch caches the function result within the TTL" do
+    user_id = Ecto.UUID.generate()
+
+    assert :miss = OverrideCache.fetch(user_id, "vaults_cap", fn -> :miss end)
+    # Second fetch must NOT invoke the fun.
+    assert :miss = OverrideCache.fetch(user_id, "vaults_cap", fn -> raise "should not run" end)
+  end
+
+  test "a Postgres notification for the user evicts their cached entries" do
+    # The user_limit_overrides table carries an AFTER-write trigger that
+    # pg_notifys the user_id — so raw-SQL writers (support runbook, e2e
+    # helpers) invalidate this cache without touching the app API. This
+    # pins the message handling; the trigger itself is exercised by the
+    # vault-limit e2e test (lift-by-SQL then immediate retry).
+    user_id = Ecto.UUID.generate()
+    other_id = Ecto.UUID.generate()
+
+    assert :miss = OverrideCache.fetch(user_id, "vaults_cap", fn -> :miss end)
+    assert :miss = OverrideCache.fetch(other_id, "vaults_cap", fn -> :miss end)
+
+    send(
+      Process.whereis(OverrideCache),
+      {:notification, self(), make_ref(), "user_limit_overrides_changed", user_id}
+    )
+
+    :sys.get_state(OverrideCache)
+
+    # Evicted user re-runs the fun; unrelated user stays cached.
+    assert {:hit, 42} = OverrideCache.fetch(user_id, "vaults_cap", fn -> {:hit, 42} end)
+    assert :miss = OverrideCache.fetch(other_id, "vaults_cap", fn -> raise "should not run" end)
+  end
+end

--- a/test/engram/billing/workers/override_expiry_sweep_test.exs
+++ b/test/engram/billing/workers/override_expiry_sweep_test.exs
@@ -96,6 +96,34 @@ defmodule Engram.Billing.Workers.OverrideExpirySweepTest do
       assert Repo.get(UserLimitOverride, survivor.id)
     end
 
+    test "flushes the override cache when it deletes rows" do
+      # Cache a miss for one user, then grant them an override. The sweep
+      # deleting any expired row (another user's here) must evict_all so
+      # grants/deletions become visible without waiting out the TTL.
+      user = insert(:user)
+      on_exit(fn -> Engram.Billing.OverrideCache.evict_all() end)
+
+      default = Engram.Billing.effective_limit(user, :notes_cap)
+
+      Repo.insert!(%UserLimitOverride{
+        user_id: user.id,
+        key: "notes_cap",
+        value: %{"v" => 123_456},
+        reason: "test",
+        set_by: "test"
+      })
+
+      # Miss is cached — still the default.
+      assert Engram.Billing.effective_limit(user, :notes_cap) == default
+
+      past = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+      insert_override(insert(:user), past)
+
+      assert :ok = perform_job(OverrideExpirySweep, %{})
+
+      assert Engram.Billing.effective_limit(user, :notes_cap) == 123_456
+    end
+
     test "handles mixed past + future + NULL in a single sweep" do
       now = DateTime.utc_now(:second)
       past = DateTime.add(now, -3600, :second)

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -927,6 +927,63 @@ defmodule Engram.BillingTest do
     end
   end
 
+  describe "user override caching" do
+    alias Engram.Billing.OverrideCache
+
+    setup do
+      on_exit(fn -> OverrideCache.evict_all() end)
+      %{user: insert(:user)}
+    end
+
+    test "caches an override hit after the first lookup", %{user: user} do
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 9})
+
+      {first, q1} =
+        with_query_count("user_limit_overrides", fn ->
+          Billing.effective_limit(user, :vaults_cap)
+        end)
+
+      assert first == 9
+      assert q1 == 1
+
+      {second, q2} =
+        with_query_count("user_limit_overrides", fn ->
+          Billing.effective_limit(user, :vaults_cap)
+        end)
+
+      assert second == 9
+      assert q2 == 0
+    end
+
+    test "caches the miss — the common case is no override row", %{user: user} do
+      {_, q1} =
+        with_query_count("user_limit_overrides", fn ->
+          Billing.effective_limit(user, :vaults_cap)
+        end)
+
+      assert q1 == 1
+
+      {_, q2} =
+        with_query_count("user_limit_overrides", fn ->
+          Billing.effective_limit(user, :vaults_cap)
+        end)
+
+      assert q2 == 0
+    end
+
+    test "evict/1 makes a newly granted override visible immediately", %{user: user} do
+      default = Billing.effective_limit(user, :vaults_cap)
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 33})
+
+      # The miss is cached — stale default until evicted (or TTL).
+      assert Billing.effective_limit(user, :vaults_cap) == default
+
+      :ok = OverrideCache.evict(user.id)
+      assert Billing.effective_limit(user, :vaults_cap) == 33
+    end
+
+  end
+
   defp with_subscription_query_count(fun), do: with_query_count("subscriptions", fun)
 
   # Counts Repo queries against `source` emitted while `fun` runs. Telemetry

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -981,7 +981,6 @@ defmodule Engram.BillingTest do
       :ok = OverrideCache.evict(user.id)
       assert Billing.effective_limit(user, :vaults_cap) == 33
     end
-
   end
 
   defp with_subscription_query_count(fun), do: with_query_count("subscriptions", fun)

--- a/test/engram/onboarding/gate_cache_test.exs
+++ b/test/engram/onboarding/gate_cache_test.exs
@@ -1,0 +1,106 @@
+defmodule Engram.Onboarding.GateCacheTest do
+  use Engram.DataCase, async: false
+
+  alias Engram.Cluster.CacheSync
+  alias Engram.Onboarding.GateCache
+
+  setup do
+    on_exit(fn -> GateCache.evict_all() end)
+    :ok
+  end
+
+  # Processing of PubSub messages is async; a synchronous call to the cache
+  # GenServer flushes everything ahead of it in the mailbox.
+  defp sync, do: :sys.get_state(GateCache)
+
+  describe "core verdict cache" do
+    test "passed?/1 is false for an unknown user" do
+      refute GateCache.passed?(Ecto.UUID.generate())
+    end
+
+    test "mark_passed/1 then passed?/1 is true" do
+      id = Ecto.UUID.generate()
+      :ok = GateCache.mark_passed(id)
+      assert GateCache.passed?(id)
+    end
+
+    test "evict/1 removes the verdict" do
+      id = Ecto.UUID.generate()
+      :ok = GateCache.mark_passed(id)
+      :ok = GateCache.evict(id)
+      refute GateCache.passed?(id)
+    end
+
+    test "entries expire after their ttl" do
+      id = Ecto.UUID.generate()
+      :ok = GateCache.mark_passed(id, 0)
+      refute GateCache.passed?(id)
+    end
+  end
+
+  describe "cluster invalidation" do
+    test "evict on one node clears peers via cache_sync broadcast" do
+      id = Ecto.UUID.generate()
+      :ok = GateCache.mark_passed(id)
+
+      # Simulate the message arriving from a peer node.
+      CacheSync.broadcast({:onboarding_gate_evict, id})
+      sync()
+
+      refute GateCache.passed?(id)
+    end
+
+    test "terms version invalidation clears ALL verdicts" do
+      # A new required terms floor can flip every passed user back to
+      # failing — the gate must re-derive for everyone.
+      id = Ecto.UUID.generate()
+      :ok = GateCache.mark_passed(id)
+
+      CacheSync.broadcast(:version_evict_all)
+      sync()
+
+      refute GateCache.passed?(id)
+    end
+  end
+
+  describe "eviction write-sites" do
+    test "set_profile evicts the user's verdict" do
+      user = insert(:user, onboarding_profile: %{})
+      :ok = GateCache.mark_passed(user.id)
+
+      {:ok, _} = Engram.Onboarding.set_profile(user, %{uses_obsidian: true, tools: ["claude"]})
+
+      refute GateCache.passed?(user.id)
+    end
+
+    test "delete_vault evicts the user's verdict" do
+      user = insert(:user)
+      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "V"})
+      :ok = GateCache.mark_passed(user.id)
+
+      {:ok, _} = Engram.Vaults.delete_vault(user, vault.id)
+
+      refute GateCache.passed?(user.id)
+    end
+
+    test "paddle subscription upsert evicts the user's verdict" do
+      user = insert(:user)
+      :ok = GateCache.mark_passed(user.id)
+
+      {:ok, _} =
+        Engram.Billing.upsert_from_paddle_event(%{
+          "event_type" => "subscription.created",
+          "data" => %{
+            "id" => "sub_gatecache_test",
+            "customer_id" => "ctm_gatecache_test",
+            "status" => "active",
+            "custom_data" => %{"user_id" => user.id},
+            "items" => [%{"price" => %{"id" => "pri_starter_monthly_test"}}],
+            "current_billing_period" => %{"ends_at" => "2026-07-01T00:00:00Z"}
+          }
+        })
+
+      refute GateCache.passed?(user.id)
+    end
+  end
+end

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -2,6 +2,7 @@ defmodule Engram.VaultsTest do
   use Engram.DataCase, async: true
   use Oban.Testing, repo: Engram.Repo
 
+  alias Engram.Billing.OverrideCache
   alias Engram.Vaults
 
   setup do
@@ -39,7 +40,7 @@ defmodule Engram.VaultsTest do
       # cached the override MISS — evict so the grant is visible (same idiom
       # as PlanCache.invalidate after mid-test plan edits).
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
-      :ok = Engram.Billing.OverrideCache.evict(user.id)
+      :ok = OverrideCache.evict(user.id)
 
       assert {:ok, vault2} = Vaults.create_vault(user, %{name: "Second"})
       assert vault2.is_default == false
@@ -79,7 +80,7 @@ defmodule Engram.VaultsTest do
       # Lift the limit via per-user override. Earlier creates cached the
       # override MISS — evict so the grant is visible immediately.
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
-      :ok = Engram.Billing.OverrideCache.evict(user.id)
+      :ok = OverrideCache.evict(user.id)
 
       {:ok, _} = Vaults.create_vault(user, %{name: "Second"})
       {:ok, _} = Vaults.create_vault(user, %{name: "Third"})
@@ -819,7 +820,7 @@ defmodule Engram.VaultsTest do
       {:ok, _} = Engram.Vaults.create_vault(user, %{name: "Main"})
       # First create cached the override MISS — evict so the grant lands.
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
-      :ok = Engram.Billing.OverrideCache.evict(user.id)
+      :ok = OverrideCache.evict(user.id)
       {:ok, _} = Engram.Vaults.create_vault(user, %{name: "Second"})
 
       assert ["first_vault_created"] = Engram.Onboarding.list_actions(user.id)

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -35,8 +35,11 @@ defmodule Engram.VaultsTest do
       {:ok, _} = Vaults.create_vault(user, %{name: "First"})
 
       # Give the second user unlimited vaults via user_overrides or just test default (1) blocks
-      # Override the limit so we can insert a second vault
+      # Override the limit so we can insert a second vault. The first create
+      # cached the override MISS — evict so the grant is visible (same idiom
+      # as PlanCache.invalidate after mid-test plan edits).
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
+      :ok = Engram.Billing.OverrideCache.evict(user.id)
 
       assert {:ok, vault2} = Vaults.create_vault(user, %{name: "Second"})
       assert vault2.is_default == false
@@ -73,8 +76,10 @@ defmodule Engram.VaultsTest do
       assert {:error, {:vault_limit_reached, 1, 1}} =
                Vaults.create_vault(user, %{name: "Second"})
 
-      # Lift the limit via per-user override
+      # Lift the limit via per-user override. Earlier creates cached the
+      # override MISS — evict so the grant is visible immediately.
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
+      :ok = Engram.Billing.OverrideCache.evict(user.id)
 
       {:ok, _} = Vaults.create_vault(user, %{name: "Second"})
       {:ok, _} = Vaults.create_vault(user, %{name: "Third"})
@@ -812,7 +817,9 @@ defmodule Engram.VaultsTest do
     test "second vault does not double-record" do
       user = insert(:user)
       {:ok, _} = Engram.Vaults.create_vault(user, %{name: "Main"})
+      # First create cached the override MISS — evict so the grant lands.
       insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 5})
+      :ok = Engram.Billing.OverrideCache.evict(user.id)
       {:ok, _} = Engram.Vaults.create_vault(user, %{name: "Second"})
 
       assert ["first_vault_created"] = Engram.Onboarding.list_actions(user.id)

--- a/test/engram_web/plugs/require_onboarding_test.exs
+++ b/test/engram_web/plugs/require_onboarding_test.exs
@@ -175,4 +175,61 @@ defmodule EngramWeb.Plugs.RequireOnboardingTest do
     conn = conn |> assign(:current_user, user) |> RequireOnboarding.call([])
     assert Plug.Conn.get_resp_header(conn, "content-type") |> List.first() =~ "application/json"
   end
+
+  describe "pass-verdict caching" do
+    alias Engram.Onboarding.GateCache
+
+    setup do
+      on_exit(fn -> GateCache.evict_all() end)
+      :ok
+    end
+
+    defp passed_user do
+      user = insert(:user, onboarding_profile: %{})
+      {:ok, _} = Onboarding.accept_terms(user, "2026-05-15", %{})
+      insert(:subscription, user: user, status: "active")
+      {:ok, _} = Onboarding.set_profile(user, %{uses_obsidian: false, tools: ["claude"]})
+      {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "My Vault"})
+      {user, vault}
+    end
+
+    test "a passing request populates the cache and short-circuits the next one",
+         %{conn: conn} do
+      {user, vault} = passed_user()
+
+      first = conn |> assign(:current_user, user) |> RequireOnboarding.call([])
+      refute first.halted
+      assert GateCache.passed?(user.id)
+
+      # Break the underlying state WITHOUT going through the context (no
+      # eviction fires): the cached verdict must short-circuit — proving the
+      # plug no longer re-derives status per request.
+      import Ecto.Query
+
+      Engram.Repo.update_all(
+        from(v in Engram.Vaults.Vault, where: v.id == ^vault.id),
+        [set: [deleted_at: DateTime.utc_now(:second)]],
+        skip_tenant_check: true
+      )
+
+      second = conn |> assign(:current_user, user) |> RequireOnboarding.call([])
+      refute second.halted
+    end
+
+    test "context vault deletion evicts the verdict and the gate re-derives",
+         %{conn: conn} do
+      {user, vault} = passed_user()
+
+      first = conn |> assign(:current_user, user) |> RequireOnboarding.call([])
+      refute first.halted
+
+      {:ok, _} = Engram.Vaults.delete_vault(user, vault.id)
+
+      second = conn |> assign(:current_user, user) |> RequireOnboarding.call([])
+      assert second.halted
+      assert second.status == 403
+      body = Phoenix.ConnTest.json_response(second, 403)
+      assert body["missing"] == ["vault"]
+    end
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -132,6 +132,12 @@ defmodule Engram.Factory do
     }
   end
 
+  # Override lookups are cached (Engram.Billing.OverrideCache, 60s TTL,
+  # misses included). Inserting an override AFTER the same user's limits
+  # have already been resolved in the test requires an explicit
+  # `OverrideCache.evict(user.id)` — same idiom as PlanCache.invalidate
+  # after mid-test plan edits. Inserts in setup (before any limit check)
+  # need nothing.
   def user_limit_override_factory do
     %Engram.Billing.UserLimitOverride{
       id: Ecto.UUID.generate(),


### PR DESCRIPTION
## Summary

Wave-2a of the 2026-06-12 performance audit: removes the two expensive per-request DB costs in the vault-scoped plug chain.

**GateCache — RequireOnboarding pass verdict** (`Engram.Onboarding.GateCache`)
Deriving onboarding status cost ~3 DB round-trips per request (profile re-read + `has_vault?` inside its own RLS transaction) for an answer that's true for essentially every post-onboarding user. Pass-only ETS cache, 60s TTL. Every pass→fail transition has an eviction write-site:
- vault deletion (`Vaults.delete_vault/2`)
- every subscription mutation (chokepoint in `broadcast_subscription_activated/2`)
- profile edits (`Onboarding.set_profile/2` — `uses_obsidian` flips re-arm the vault gate)
- terms-floor bumps (consumes the existing `:version_evict_all` CacheSync broadcast)

Failing users always take the authoritative slow path — staleness can only briefly extend access, never withhold it. Cross-node eviction rides `Cluster.CacheSync` (DekCache pattern).

**OverrideCache — user_limit_overrides lookups** (`Engram.Billing.OverrideCache`)
`effective_limit/2` consulted the override table on every resolution; hot paths resolve several limits per request (search: reranker + cross_vault; RPS/write plugs: one each) while override rows are rare admin grants. 60s-TTL read-through cache storing hits AND misses (the miss is the common case). `OverrideExpirySweep` flushes on delete; evictions broadcast cluster-wide.

**Consciously out of scope:** caching the api-key→user resolution. User structs carry DEK/rotation/billing fields where staleness is dangerous on the auth boundary, and the win is a single indexed lookup. The api-contract.md claim of an existing API-key cache is doc drift — separate workspace-repo fix.

## Test plan
- [x] Full suite: 2560 tests, 0 failures (PG18)
- [x] TDD red-first: GateCache unit + cluster-eviction tests, plug short-circuit proof (breaks DB state behind the cache, asserts no re-derive), eviction-site tests (vault delete, paddle webhook, set_profile, expiry sweep), override hit/miss/evict query-count tests
- [x] 3 vaults tests needed explicit `OverrideCache.evict` after mid-test grants — same idiom as `PlanCache.invalidate`, documented in the factory
- [x] `mix credo --strict`, `mix format --check-formatted`, `mix dialyzer` clean

## Ops note
Manual override grants via iex now take up to 60s to become visible, or run `Engram.Billing.OverrideCache.evict(user_id)` after the grant — support-runbook update queued in the workspace repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)