### PR TITLE
perf(web): route-level code splitting + lazy CodeMirror editor

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,33 +1,45 @@
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, type ReactNode } from 'react'
 import { Navigate, createBrowserRouter } from 'react-router'
 import AuthGuard from './auth/auth-guard'
 import SignInPage from './auth/sign-in'
 import SignUpPage from './auth/sign-up'
 import WaitlistPage from './auth/waitlist'
-import BillingPage from './billing/billing-page'
 import { UpgradeDialogProvider } from './billing/upgrade-dialog-provider'
 import type { EngramConfig } from './config'
-import AdminPanel from './features/admin/AdminPanel'
-import ResetPasswordPage from './features/auth/ResetPasswordPage'
-import DeviceLinkPage from './device/device-link-page'
 import AppLayout from './layout/app-layout'
 import NotFoundPage from './not-found'
-import ConnectionsPage from './settings/connections-page'
 import SettingsLayout from './settings/settings-layout'
-import VaultsPage from './settings/vaults-page'
-import OAuthAuthorizePage from './oauth/oauth-authorize-page'
 import { ROUTES } from './routes'
-import Dashboard from './viewer/dashboard'
-import NotePage from './viewer/note-page'
 import OnboardingGate from './onboarding/onboarding-gate'
 import OnboardLayout from './onboarding/onboard-layout'
 import OnboardRedirect from './onboarding/onboard-redirect'
-import AgreementPage from './onboarding/agreement-page'
-import OnboardBillingPage from './onboarding/onboard-billing-page'
-import OnboardToolsPage from './onboarding/onboard-tools-page'
-import OnboardVaultPage from './onboarding/onboard-vault-page'
 import { OnboardingShell } from './onboarding/onboarding-shell'
 import { Outlet } from 'react-router'
+
+// Route-level code splitting. The viewer stack alone (remark/rehype +
+// KaTeX wiring + CodeMirror behind NotePage) dominated a 1.78 MB main
+// chunk that even the sign-in page had to parse. Entry surfaces
+// (sign-in/up, layouts, guards) stay eager; everything behind navigation
+// loads on demand.
+const Dashboard = lazy(() => import('./viewer/dashboard'))
+const NotePage = lazy(() => import('./viewer/note-page'))
+const BillingPage = lazy(() => import('./billing/billing-page'))
+const AdminPanel = lazy(() => import('./features/admin/AdminPanel'))
+const ResetPasswordPage = lazy(() => import('./features/auth/ResetPasswordPage'))
+const DeviceLinkPage = lazy(() => import('./device/device-link-page'))
+const ConnectionsPage = lazy(() => import('./settings/connections-page'))
+const VaultsPage = lazy(() => import('./settings/vaults-page'))
+const OAuthAuthorizePage = lazy(() => import('./oauth/oauth-authorize-page'))
+const AgreementPage = lazy(() => import('./onboarding/agreement-page'))
+const OnboardBillingPage = lazy(() => import('./onboarding/onboard-billing-page'))
+const OnboardToolsPage = lazy(() => import('./onboarding/onboard-tools-page'))
+const OnboardVaultPage = lazy(() => import('./onboarding/onboard-vault-page'))
+
+const routeFallback = <p className="p-6 text-muted-foreground">Loading…</p>
+
+function suspended(el: ReactNode) {
+  return <Suspense fallback={routeFallback}>{el}</Suspense>
+}
 
 // Root layout — mounts the UpgradeDialogProvider INSIDE the router so the
 // dialog's `useNavigate` works, and so any nested API call that 402s opens
@@ -80,7 +92,7 @@ export function createAppRouter(config: EngramConfig): AppRouter {
     { path: ROUTES.SIGN_UP, element: <SignUpPage /> },
     { path: ROUTES.WAITLIST, element: <WaitlistPage /> },
     // Public reset — the one-time token IS the credential.
-    { path: '/reset-password', element: <ResetPasswordPage /> },
+    { path: '/reset-password', element: suspended(<ResetPasswordPage />) },
 
     // Authenticated routes
     {
@@ -93,22 +105,22 @@ export function createAppRouter(config: EngramConfig): AppRouter {
           element: <OnboardLayout />,
           children: [
             { index: true, element: <OnboardRedirect /> },
-            { path: 'agreement', element: <AgreementPage /> },
-            { path: 'billing', element: <OnboardBillingPage /> },
-            { path: 'tools', element: <OnboardToolsPage /> },
-            { path: 'vault', element: <OnboardVaultPage /> },
+            { path: 'agreement', element: suspended(<AgreementPage />) },
+            { path: 'billing', element: suspended(<OnboardBillingPage />) },
+            { path: 'tools', element: suspended(<OnboardToolsPage />) },
+            { path: 'vault', element: suspended(<OnboardVaultPage />) },
           ],
         },
 
         // /link is reachable mid-onboarding — the wizard's Obsidian branch
         // requires the user to complete device-flow here before progressing.
         // Sits OUTSIDE the OnboardingGate to dodge the redirect-to-/onboard.
-        { path: ROUTES.DEVICE_LINK, element: <DeviceLinkPage /> },
+        { path: ROUTES.DEVICE_LINK, element: suspended(<DeviceLinkPage />) },
 
         // OAuth consent — reachable mid-onboarding so an MCP client (e.g.
         // Claude Desktop) initiating a connection during signup can complete
         // the OAuth dance without being bounced to /onboard.
-        { path: ROUTES.OAUTH_CONSENT, element: <OAuthAuthorizePage /> },
+        { path: ROUTES.OAUTH_CONSENT, element: suspended(<OAuthAuthorizePage />) },
 
         // Dashboard tree — gated by OnboardingGate.
         {
@@ -127,8 +139,8 @@ export function createAppRouter(config: EngramConfig): AppRouter {
                 {
                   element: <AppLayout />,
                   children: [
-                    { path: ROUTES.HOME, element: <Dashboard /> },
-                    { path: '/note/:id', element: <NotePage /> },
+                    { path: ROUTES.HOME, element: suspended(<Dashboard />) },
+                    { path: '/note/:id', element: suspended(<NotePage />) },
                     {
                       path: 'settings',
                       element: <SettingsLayout />,
@@ -147,14 +159,14 @@ export function createAppRouter(config: EngramConfig): AppRouter {
                             </Suspense>
                           ),
                         },
-                        { path: 'vaults', element: <VaultsPage /> },
-                        { path: 'connections', element: <ConnectionsPage /> },
+                        { path: 'vaults', element: suspended(<VaultsPage />) },
+                        { path: 'connections', element: suspended(<ConnectionsPage />) },
                         { path: 'api-keys', element: <Navigate to="/settings/connections" replace /> },
                         ...(config.billingEnabled
-                          ? [{ path: 'billing', element: <BillingPage /> }]
+                          ? [{ path: 'billing', element: suspended(<BillingPage />) }]
                           : []),
                         ...(config.authProvider === 'local'
-                          ? [{ path: 'admin', element: <AdminPanel /> }]
+                          ? [{ path: 'admin', element: suspended(<AdminPanel />) }]
                           : []),
                       ],
                     },

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import { toast } from 'sonner'
 import { useNote, useUpdateNote } from '../api/queries'
@@ -6,10 +6,13 @@ import { useRightSidebar } from '../layout/right-sidebar-context'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import NoteEditor from './note-editor'
 import NoteToc from './note-toc'
 import NoteView from './note-view'
 import { useRemoteUpdateBanner } from './use-remote-update-banner'
+
+// CodeMirror (language pkg + view) only loads when the user first opens
+// the Edit tab — most note views never do.
+const NoteEditor = lazy(() => import('./note-editor'))
 
 type Mode = 'preview' | 'edit'
 
@@ -27,6 +30,14 @@ export default function NotePage() {
 
   const [mode, setMode] = useState<Mode>('preview')
   const [draft, setDraft] = useState('')
+  // Latch: the edit pane is forceMounted to preserve editor state across
+  // tab switches, but the (lazy) editor itself shouldn't mount — or its
+  // chunk download — until the user first enters edit mode.
+  const [editorTouched, setEditorTouched] = useState(false)
+
+  useEffect(() => {
+    if (mode === 'edit') setEditorTouched(true)
+  }, [mode])
 
   // Sync draft only when the user navigates to a different note. Re-syncing
   // on every `note.content` change would clobber in-progress edits whenever
@@ -164,7 +175,11 @@ export default function NotePage() {
         )}
         <ScrollArea className="h-full">
           <div className="px-6 py-6 lg:px-8 lg:py-8" data-tour="note-editor">
-            <NoteEditor value={draft} onChange={setDraft} />
+            {editorTouched && (
+              <Suspense fallback={<p className="text-muted-foreground">Loading editor…</p>}>
+                <NoteEditor value={draft} onChange={setDraft} />
+              </Suspense>
+            )}
           </div>
         </ScrollArea>
       </TabsContent>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.401",
+      version: "0.5.406",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.398",
+      version: "0.5.401",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Wave-2c of the 2026-06-12 performance audit.

The main chunk shipped **1.78 MB** of JS to every visitor — including the sign-in page — because every route (and through `NotePage`, the whole remark/rehype + KaTeX + highlight.js + CodeMirror stack) was statically imported in `createAppRouter`.

- All routes behind navigation are now `React.lazy` with a shared Suspense fallback (extends the pattern AccountPage already used). Entry surfaces (sign-in/up/waitlist, layouts, guards, gates) stay eager.
- `NoteEditor` (CodeMirror) loads only when the Edit tab is first opened. A `editorTouched` latch keeps it mounted afterward, preserving the existing `forceMount` state-retention contract.

**Result:** main chunk 1,782 kB → **969 kB** (303 kB gzip). `note-page` (814 kB) and `note-editor` (612 kB) are now on-demand chunks.

## Test plan
- [x] Frontend suite: 448 passed across 96 files
- [x] `tsc --noEmit` clean; production build green
- [x] Chunk sizes verified from build output (numbers above)
- [ ] Manual smoke: navigate sign-in → dashboard → note → edit tab (CI e2e-browser covers the route flows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)