### PR TITLE
perf(web): coalesce + target WS note_changed invalidations

### DIFF
--- a/frontend/src/api/channel.test.ts
+++ b/frontend/src/api/channel.test.ts
@@ -1,36 +1,139 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { QueryClient } from '@tanstack/react-query'
-import { handleNoteChanged } from './channel'
+import { __resetNoteChangeBatch, handleNoteChanged } from './channel'
 
-function mockQueryClient() {
-  return { invalidateQueries: vi.fn() } as unknown as QueryClient & {
+function mockQueryClient(foldersData?: unknown) {
+  return {
+    invalidateQueries: vi.fn(),
+    getQueryData: vi.fn(() => foldersData),
+  } as unknown as QueryClient & {
     invalidateQueries: ReturnType<typeof vi.fn>
+    getQueryData: ReturnType<typeof vi.fn>
   }
 }
 
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  __resetNoteChangeBatch()
+  vi.useRealTimers()
+})
+
 describe('handleNoteChanged', () => {
-  it('invalidates the per-note query for the upserted path', () => {
+  it('invalidates the per-note query for the upserted path immediately', () => {
     const qc = mockQueryClient()
     handleNoteChanged({ event_type: 'upsert', path: 'foo/bar.md', vault_id: '7' }, qc, '7')
     expect(qc.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['note', '7', 'foo/bar.md'] })
   })
 
-  it('invalidates folder/folderNotes/search lists for the vault', () => {
+  it('defers list invalidation to a coalescing window, then targets the changed folder', () => {
     const qc = mockQueryClient()
-    handleNoteChanged({ event_type: 'upsert', path: 'a.md', vault_id: '7' }, qc, '7')
-    const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey[0])
-    expect(keys).toEqual(expect.arrayContaining(['folders', 'folderNotes', 'search']))
+    handleNoteChanged(
+      { event_type: 'upsert', path: 'docs/a.md', folder: 'docs', vault_id: '7' },
+      qc,
+      '7',
+    )
+
+    // List-level keys must NOT fire synchronously.
+    const syncKeys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    expect(syncKeys).not.toContainEqual(['folders', '7'])
+    expect(syncKeys.some((k) => k[0] === 'search')).toBe(false)
+
+    vi.advanceTimersByTime(250)
+
+    const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    expect(keys).toContainEqual(['folders', '7'])
+    expect(keys).toContainEqual(['folderNotes', '7', 'docs'])
+    expect(keys).toContainEqual(['search', '7'])
+    // Untargeted folderNotes (whole-prefix) must not be used when the
+    // folder is known.
+    expect(keys).not.toContainEqual(['folderNotes', '7'])
   })
 
-  it('invalidates on delete event_type as well', () => {
+  it('coalesces a sync burst into one flush per distinct folder', () => {
     const qc = mockQueryClient()
-    handleNoteChanged({ event_type: 'delete', path: 'gone.md', vault_id: '7' }, qc, '7')
-    expect(qc.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['note', '7', 'gone.md'] })
+    for (let i = 0; i < 50; i++) {
+      handleNoteChanged(
+        { event_type: 'upsert', path: `a/n${i}.md`, folder: 'a', vault_id: '7' },
+        qc,
+        '7',
+      )
+      handleNoteChanged(
+        { event_type: 'upsert', path: `b/n${i}.md`, folder: 'b', vault_id: '7' },
+        qc,
+        '7',
+      )
+    }
+
+    vi.advanceTimersByTime(250)
+
+    const calls = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    const folderNotesCalls = calls.filter((k) => k[0] === 'folderNotes')
+    const foldersCalls = calls.filter((k) => k[0] === 'folders')
+    const searchCalls = calls.filter((k) => k[0] === 'search')
+
+    expect(folderNotesCalls).toEqual(
+      expect.arrayContaining([
+        ['folderNotes', '7', 'a'],
+        ['folderNotes', '7', 'b'],
+      ]),
+    )
+    expect(folderNotesCalls).toHaveLength(2)
+    expect(foldersCalls).toHaveLength(1)
+    expect(searchCalls).toHaveLength(1)
+  })
+
+  it('resolves folder-notes-by-id keys from the cached folder tree', () => {
+    const qc = mockQueryClient({
+      folders: [
+        { id: 'f1', parent_id: null, name: 'docs', count: 3 },
+        { id: 'f2', parent_id: null, name: 'other', count: 1 },
+      ],
+    })
+
+    handleNoteChanged(
+      { event_type: 'upsert', path: 'docs/a.md', folder: 'docs', vault_id: '7' },
+      qc,
+      '7',
+    )
+    vi.advanceTimersByTime(250)
+
+    const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    expect(keys).toContainEqual(['folder-notes-by-id', '7', 'f1'])
+    expect(keys).not.toContainEqual(['folder-notes-by-id', '7', 'f2'])
+  })
+
+  it('falls back to broad folder-notes-by-id invalidation when the folder is not in cache', () => {
+    const qc = mockQueryClient({ folders: [] })
+
+    handleNoteChanged(
+      { event_type: 'upsert', path: 'brand-new/a.md', folder: 'brand-new', vault_id: '7' },
+      qc,
+      '7',
+    )
+    vi.advanceTimersByTime(250)
+
+    const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    expect(keys).toContainEqual(['folder-notes-by-id', '7'])
+  })
+
+  it('derives the folder from the path when the payload omits it (delete events)', () => {
+    const qc = mockQueryClient()
+    handleNoteChanged({ event_type: 'delete', path: 'docs/gone.md', vault_id: '7' }, qc, '7')
+
+    expect(qc.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['note', '7', 'docs/gone.md'] })
+
+    vi.advanceTimersByTime(250)
+    const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    expect(keys).toContainEqual(['folderNotes', '7', 'docs'])
   })
 
   it('ignores payloads from a different vault (avoids cross-vault noise)', () => {
     const qc = mockQueryClient()
     handleNoteChanged({ event_type: 'upsert', path: 'a.md', vault_id: '99' }, qc, '7')
+    vi.advanceTimersByTime(250)
     expect(qc.invalidateQueries).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -38,6 +38,67 @@ export function subscribeToNoteChanges(listener: NoteChangedListener): () => voi
   }
 }
 
+// ── Coalesced list invalidation ───────────────────────────────────────────
+// A plugin sync burst delivers one note_changed per note (hundreds in a
+// row). Invalidating every folder/search list per event refetched
+// O(events × active queries) against a backend that decrypts rows
+// server-side — the per-note keys stay synchronous (cheap, exact), but
+// list-level keys batch into one targeted flush per window.
+
+const BATCH_WINDOW_MS = 250
+
+interface PendingBatch {
+  queryClient: QueryClient
+  vaultId: string
+  folders: Set<string>
+  timer: ReturnType<typeof setTimeout>
+}
+
+let pending: PendingBatch | null = null
+
+function folderFromPath(path: string): string {
+  const idx = path.lastIndexOf('/')
+  return idx === -1 ? '' : path.slice(0, idx)
+}
+
+interface CachedFolders {
+  folders?: Array<{ id: string; name: string }>
+}
+
+function flushBatch(batch: PendingBatch): void {
+  const { queryClient, vaultId, folders } = batch
+  queryClient.invalidateQueries({ queryKey: ['folders', vaultId] })
+  queryClient.invalidateQueries({ queryKey: ['search', vaultId] })
+
+  // The by-id keys are keyed on folder-marker ids; resolve names through
+  // the cached tree. Unknown folders (just created, tree not refetched
+  // yet) fall back to one broad invalidation.
+  const cached = queryClient.getQueryData<CachedFolders>(['folders', vaultId])
+  let broadById = false
+
+  for (const folder of folders) {
+    queryClient.invalidateQueries({ queryKey: ['folderNotes', vaultId, folder] })
+    const entry = cached?.folders?.find((f) => f.name === folder)
+    if (entry) {
+      queryClient.invalidateQueries({ queryKey: ['folder-notes-by-id', vaultId, entry.id] })
+    } else {
+      broadById = true
+    }
+  }
+
+  if (broadById) {
+    queryClient.invalidateQueries({ queryKey: ['folder-notes-by-id', vaultId] })
+  }
+}
+
+/** Test hook: drop any pending batch without flushing. */
+export function __resetNoteChangeBatch(): void {
+  if (pending) {
+    clearTimeout(pending.timer)
+    pending = null
+  }
+}
+
 export function handleNoteChanged(
   payload: NoteChangedPayload,
   queryClient: QueryClient,
@@ -53,10 +114,21 @@ export function handleNoteChanged(
   }
   // Legacy path-keyed key still in use by some hooks; keep invalidating it.
   queryClient.invalidateQueries({ queryKey: ['note', activeVaultId, payload.path] })
-  queryClient.invalidateQueries({ queryKey: ['folders', activeVaultId] })
-  queryClient.invalidateQueries({ queryKey: ['folderNotes', activeVaultId] })
-  queryClient.invalidateQueries({ queryKey: ['folder-notes-by-id', activeVaultId] })
-  queryClient.invalidateQueries({ queryKey: ['search', activeVaultId] })
+
+  if (!pending) {
+    const batch: PendingBatch = {
+      queryClient,
+      vaultId: activeVaultId,
+      folders: new Set(),
+      timer: setTimeout(() => {
+        pending = null
+        flushBatch(batch)
+      }, BATCH_WINDOW_MS),
+    }
+    pending = batch
+  }
+
+  pending.folders.add(payload.folder ?? folderFromPath(payload.path))
 
   for (const listener of listeners) listener(payload)
 }
@@ -86,6 +158,7 @@ export async function connectChannel({ userId, vaultId, getToken, queryClient }:
 }
 
 export function disconnectChannel() {
+  __resetNoteChangeBatch()
   if (channel) {
     channel.leave()
     channel = null

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.402",
+      version: "0.5.405",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.398",
+      version: "0.5.402",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Wave-2d of the 2026-06-12 performance audit — the frontend half of the sync-burst scaling cliff.

`handleNoteChanged` invalidated **all** `folders` / `folderNotes` / `folder-notes-by-id` / `search` queries on every single `note_changed` event. A plugin sync burst (hundreds of notes) amplified into O(events × active queries) refetches against a backend that pays decrypt cost per row.

Now:
- Per-note keys (`['note', vault, id|path]`) stay synchronous — cheap and exact.
- List-level keys coalesce into one flush per 250ms window, targeting only the folders named in the batch (`['folderNotes', vault, folder]`; by-id keys resolved through the cached folder tree, one broad fallback if a folder isn't cached yet).
- A 100-event burst across 2 folders now costs 2 targeted folderNotes + 1 folders + 1 search invalidation instead of 400.

## Test plan
- [x] RED-first: 8 tests incl. burst-coalescing (50×2 events → exactly 2+1+1 list invalidations), by-id resolution from cache, broad fallback, path-derived folder for deletes, cross-vault guard, #277 regression
- [x] Full frontend suite green; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)