### PR TITLE
perf: shared-scan folder cascades + parallel batch decrypt

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1394,36 +1394,36 @@ defmodule Engram.Notes do
     exists?
   end
 
-  defp do_rename_folder(user, vault, old_folder, old_prefix, new_folder) do
-    # Phase B.3: plaintext `folder` column is gone — can't `WHERE folder LIKE
-    # 'prefix/%'` in SQL. Load all non-deleted notes, decrypt path+folder,
-    # then filter by prefix in Elixir. Single decrypt per row, then bulk
-    # updates use the already-decrypted plaintext.
-    {:ok, all_notes} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.all(
-          from(n in Note,
-            where: n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at),
-            select: n
-          )
-        )
-      end)
+  # Fetch + decrypt every live row in the vault for a folder-cascade scan
+  # (Phase B.3: plaintext `folder` is gone, so prefix filtering happens in
+  # Elixir over decrypted rows). Markers hydrate their single folder
+  # envelope; real notes go through the parallel batch decryptor instead
+  # of one-at-a-time. `:meta` skips the content column entirely for flows
+  # that never rewrite content (delete cascades).
+  defp fetch_decrypted_live_rows(user, vault, fields) do
+    base =
+      from(n in Note,
+        where: n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at)
+      )
 
-    # Marker rows have nil path_ciphertext, so the standard decrypt path
-    # short-circuits before unwrapping the folder envelope (gated on
-    # path_ciphertext != nil). Branch on kind so markers go through the
-    # dedicated hydrate path Task 4 introduced — they still carry a
-    # folder, so the prefix-match filter below catches them alongside
-    # real notes.
+    query =
+      case fields do
+        :meta -> from(n in base, select: struct(n, @note_meta_fields))
+        :all -> base
+      end
+
+    {:ok, rows} = Repo.with_tenant(user.id, fn -> Repo.all(query) end)
     {:ok, dek} = Crypto.get_dek(user)
 
-    decrypted =
-      Enum.map(all_notes, fn note ->
-        case note.kind do
-          "folder" -> hydrate_folder_marker(note, dek)
-          _ -> decrypt_or_raise!(note, user)
-        end
-      end)
+    # Marker rows have nil path_ciphertext, so the standard decrypt path
+    # short-circuits before unwrapping the folder envelope — they go
+    # through the dedicated hydrate path instead.
+    {markers, real} = Enum.split_with(rows, &(&1.kind == "folder"))
+    Enum.map(markers, &hydrate_folder_marker(&1, dek)) ++ decrypt_or_raise!(real, user)
+  end
+
+  defp do_rename_folder(user, vault, old_folder, old_prefix, new_folder) do
+    decrypted = fetch_decrypted_live_rows(user, vault, :all)
 
     notes =
       Enum.filter(decrypted, fn n ->
@@ -1602,35 +1602,21 @@ defmodule Engram.Notes do
     end
   end
 
-  defp do_delete_folder(user, vault, folder) do
-    prefix = folder <> "/"
+  defp do_delete_folder(user, vault, folder), do: do_delete_folders(user, vault, [folder])
 
-    # Phase B.3 mirror of do_rename_folder/5: plaintext `folder` is gone,
-    # so we cannot prefix-filter in SQL. Load all live rows, decrypt the
-    # folder envelope, then filter in Elixir.
-    {:ok, all_rows} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.all(
-          from(n in Note,
-            where: n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at),
-            select: n
-          )
-        )
-      end)
-
-    {:ok, dek} = Crypto.get_dek(user)
-
-    decrypted =
-      Enum.map(all_rows, fn row ->
-        case row.kind do
-          "folder" -> hydrate_folder_marker(row, dek)
-          _ -> decrypt_or_raise!(row, user)
-        end
-      end)
+  # Shared-scan cascade delete for one or more folders: ONE vault fetch
+  # (metadata projection — deletes never touch content) + one parallel
+  # batch decrypt + one update_all, regardless of how many folders the
+  # batch names. Overlapping folders (parent + child in the same batch)
+  # naturally dedupe through the union filter.
+  defp do_delete_folders(user, vault, folders) do
+    prefixes = Enum.map(folders, &(&1 <> "/"))
+    decrypted = fetch_decrypted_live_rows(user, vault, :meta)
 
     matches =
       Enum.filter(decrypted, fn r ->
-        r.folder == folder or String.starts_with?(r.folder || "", prefix)
+        f = r.folder || ""
+        f in folders or Enum.any?(prefixes, &String.starts_with?(f, &1))
       end)
 
     if matches == [] do
@@ -1706,23 +1692,26 @@ defmodule Engram.Notes do
     Repo.transaction(fn ->
       with {:ok, user} <- Crypto.ensure_user_dek(user),
            {:ok, dek} <- Crypto.get_dek(user) do
+        # Resolve every marker first (cheap indexed lookups), then run ONE
+        # shared-scan cascade for all folders — the old per-id shape
+        # re-fetched and re-decrypted the entire vault once per marker.
         marker_ids
-        |> Enum.reduce_while(%{deleted: 0}, fn id, acc ->
+        |> Enum.reduce_while([], fn id, acc ->
           case get_folder_marker_by_id(user, vault, id) do
             {:ok, marker} ->
-              folder = hydrate_folder_marker(marker, dek).folder
-              # do_delete_folder/3 returns {:ok, %{deleted: n}} only — Crypto.ensure_user_dek
-              # already ran above so the error path is unreachable here.
-              {:ok, %{deleted: n}} = do_delete_folder(user, vault, folder)
-              {:cont, Map.update!(acc, :deleted, &(&1 + n))}
+              {:cont, [hydrate_folder_marker(marker, dek).folder | acc]}
 
             {:error, :not_found} ->
               {:halt, {:rollback, {:not_found, id}}}
           end
         end)
         |> case do
-          {:rollback, reason} -> Repo.rollback(reason)
-          acc -> acc
+          {:rollback, reason} ->
+            Repo.rollback(reason)
+
+          folders ->
+            {:ok, %{deleted: n}} = do_delete_folders(user, vault, folders)
+            %{deleted: n}
         end
       else
         {:error, reason} -> Repo.rollback(reason)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.399",
+      version: "0.5.403",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes_batch_test.exs
+++ b/test/engram/notes_batch_test.exs
@@ -175,6 +175,33 @@ defmodule Engram.NotesBatchTest do
     test "empty list → {:ok, %{deleted: 0}}", %{user: user, vault: vault} do
       assert {:ok, %{deleted: 0}} = Notes.batch_delete_folders(user, vault, [])
     end
+
+    test "scans the vault once for the whole batch, not once per marker", %{
+      user: user,
+      vault: vault
+    } do
+      # Each folder cascade used to re-fetch and re-decrypt EVERY live row
+      # in the vault per marker id — a 10-folder batch in a 10k-note vault
+      # meant 10 full-vault decrypt passes inside one transaction.
+      {:ok, m1} = Notes.create_folder_marker(user, vault, "F1")
+      {:ok, m2} = Notes.create_folder_marker(user, vault, "F2")
+      {:ok, m3} = Notes.create_folder_marker(user, vault, "F3")
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "F1/a.md"})
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "F2/b.md"})
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "F3/c.md"})
+
+      {result, queries} =
+        with_notes_query_count(fn ->
+          Notes.batch_delete_folders(user, vault, [m1.id, m2.id, m3.id])
+        end)
+
+      assert {:ok, %{deleted: 6}} = result
+
+      # 3 marker lookups + 1 vault scan + 1 update_all (+1 headroom).
+      # The per-marker shape costs >= 9 (3 lookups + 3 scans + 3 updates).
+      assert queries <= 6,
+             "expected a single shared vault scan, saw #{queries} notes-table queries"
+    end
   end
 
   describe "batch_move_folders/3" do
@@ -253,6 +280,31 @@ defmodule Engram.NotesBatchTest do
     test "empty list → {:ok, %{moved: 0}}", %{user: user, vault: vault} do
       {:ok, target_marker} = Notes.create_folder_marker(user, vault, "Parent")
       assert {:ok, %{moved: 0}} = Notes.batch_move_folders(user, vault, [], target_marker.id)
+    end
+  end
+
+  # Counts Repo queries against the notes table emitted while `fun` runs,
+  # scoped to this test's pid (same shape as billing_test's helper).
+  defp with_notes_query_count(fun) do
+    test_pid = self()
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    handler_id = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:engram, :repo, :query],
+      fn _event, _measurements, %{source: src}, _config ->
+        if src == "notes" and self() == test_pid, do: Agent.update(counter, &(&1 + 1))
+      end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, Agent.get(counter, & &1)}
+    after
+      :telemetry.detach(handler_id)
+      Agent.stop(counter)
     end
   end
 end


### PR DESCRIPTION
## Summary

Wave-2e of the 2026-06-12 performance audit — the tree-actions hot path.

Folder rename/delete loaded every live vault row (all columns, including `content_ciphertext`) and decrypted **serially, one row at a time**, bypassing the parallel batch decryptor from PR #530. Worse, `batch_delete_folders` repeated that full-vault fetch+decrypt once **per marker id** inside a single transaction — a 10-folder batch in a 10k-note vault meant 10 full-vault decrypt passes on one pinned connection.

Changes:
- New `fetch_decrypted_live_rows/3` helper: one fetch, markers hydrated via their single folder envelope, real notes through `Crypto.decrypt_notes_batch` (parallel, 3.6×).
- Delete cascades use the `:meta` projection — content is never rewritten on delete, so the dominant column is no longer fetched or decrypted at all.
- `batch_delete_folders` resolves all markers first (indexed lookups), then runs ONE shared-scan cascade; overlapping folders (parent+child in one batch) dedupe naturally through the union filter.
- Rename keeps the full fetch (content feeds title re-derivation + re-encryption) but now batch-decrypts in parallel.

**Deferred:** `batch_move_folders` still scans per marker — collapsing it needs rename-internals rework to share per-destination conflict checks across the batch.

## Test plan
- [x] RED-first query-count characterization: 3-folder batch delete = ≤6 notes-table queries (was exactly 9; per-marker scans)
- [x] Full suite: 2563 tests, 0 failures (PG18)
- [x] credo --strict / format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)