### PR TITLE
perf: periodic sweep for expired idempotency entries

### DIFF
--- a/lib/engram/idempotency.ex
+++ b/lib/engram/idempotency.ex
@@ -2,18 +2,37 @@ defmodule Engram.Idempotency do
   @moduledoc """
   ETS-backed idempotency-key cache for batch endpoints.
   TTL default 24h; entries beyond TTL return :miss.
+
+  A periodic sweep deletes expired rows — entries cache full response
+  bodies, and lazy expiry alone (lookup returning :miss) never reclaimed
+  the memory.
   """
   use GenServer
 
   @table :engram_idempotency
   @default_ttl_ms 24 * 60 * 60 * 1000
+  @sweep_interval_ms 10 * 60 * 1000
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
   @impl true
   def init(_opts) do
     _ = :ets.new(@table, [:set, :public, :named_table, read_concurrency: true])
+    _ = schedule_sweep()
     {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    now = System.monotonic_time(:millisecond)
+    # Matches {key, response, expires_at} where expires_at <= now.
+    _ = :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}])
+    _ = schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep do
+    Process.send_after(self(), :sweep, @sweep_interval_ms)
   end
 
   def remember(key, response, opts \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.399",
+      version: "0.5.404",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/idempotency_test.exs
+++ b/test/engram/idempotency_test.exs
@@ -33,4 +33,21 @@ defmodule Engram.IdempotencyTest do
     Process.sleep(5)
     assert :miss = Idempotency.lookup("key-2")
   end
+
+  test "periodic sweep deletes expired rows from the table" do
+    # Entries cache full response bodies for batch endpoints; expired rows
+    # previously returned :miss but were never deleted — a certain (if
+    # slow) memory leak. Live entries must survive the sweep.
+    Idempotency.remember("dead-1", %{status: 200, body: %{big: "payload"}}, ttl_ms: 0)
+    Idempotency.remember("dead-2", %{status: 200, body: %{}}, ttl_ms: 0)
+    Idempotency.remember("alive", %{status: 200, body: %{}}, ttl_ms: 60_000)
+    Process.sleep(5)
+
+    send(Process.whereis(Idempotency), :sweep)
+    :sys.get_state(Idempotency)
+
+    assert :ets.lookup(:engram_idempotency, "dead-1") == []
+    assert :ets.lookup(:engram_idempotency, "dead-2") == []
+    assert [{"alive", _, _}] = :ets.lookup(:engram_idempotency, "alive")
+  end
 end


### PR DESCRIPTION
## Summary

Wave-2f (small): `Engram.Idempotency` cached full response bodies with a 24h TTL but only expired entries lazily — `lookup/1` returned `:miss` while the row (and its cached body) stayed in ETS forever. Certain slow memory leak under any sustained batch-endpoint traffic.

10-minute `:ets.select_delete` sweep on the owning GenServer; live entries survive.

Known remaining gap (audit follow-up, not this PR): the cache is per-node, so a retried batch op can replay on a different ECS node — cluster-correct storage via the Redis cache backend is a separate decision.

## Test plan
- [x] RED-first: sweep deletes expired rows, preserves live ones
- [x] credo --strict / format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)