### PR TITLE
feat(sync): protocol rev — bulk push, paginated changes, hash-only broadcasts

### DIFF
--- a/docs/context/channel-event-contract.md
+++ b/docs/context/channel-event-contract.md
@@ -1,20 +1,20 @@
 # Context Doc: Phoenix Channel Event Contract
 
-_Last verified: 2026-04-03_
+_Last verified: 2026-06-12 (sync protocol rev — dual-field broadcasts, notes.batch digest)_
 
 ## Status
-Working — design finalized, implementation in progress.
+Working — shipped. Updated for the 2026-06-12 sync protocol rev.
 
 ## What This Is
-Complete specification for the Phoenix Channel-based real-time sync protocol between the Obsidian plugin and the Engram server.
+Complete specification for the Phoenix Channel-based real-time sync protocol between the Obsidian plugin / web SPA and the Engram server.
 
 ## Connection & Auth
 
 ```
-WebSocket connect: wss://engram.fly.dev/socket/websocket?token=<api_key>
+WebSocket connect: wss://api.engram.page/socket/websocket?token=<api_key|jwt>
   → Socket.connect/3 validates Bearer token, assigns user_id
-  → Client joins topic "sync:{user_id}"
-  → Channel.join/3 verifies user_id matches socket assignment
+  → Client joins topic "sync:{user_id}:{vault_id}"
+  → Channel.join/3 verifies user_id matches socket assignment + vault ownership
   → Presence tracks device (device_id from join params)
 ```
 
@@ -23,22 +23,45 @@ WebSocket connect: wss://engram.fly.dev/socket/websocket?token=<api_key>
 | Event | Payload | Server Response | Purpose |
 |-------|---------|-----------------|---------|
 | `push_note` | `{path, content, mtime, version?}` | `{note: {...}, indexing: "queued"}` or `{conflict: true, server_note: {...}}` | Push local change (same contract as POST /notes) |
-| `delete_note` | `{path}` | `{ok: true}` | Soft-delete (same as DELETE /notes/{path}) |
+| `delete_note` | `{path}` | `{deleted: true}` | Soft-delete (same as DELETE /notes/{path}) |
 | `rename_note` | `{old_path, new_path}` | `{note: {...}}` | Rename (same as POST /notes/rename) |
-| `pull_changes` | `{since: ISO8601}` | `{changes: [...], server_time: ISO8601}` | Pull changes since timestamp |
-| `push_attachment` | `{path, content_base64, mime_type, mtime}` | `{attachment: {...}}` | Push attachment |
+| `pull_changes` | `{since: ISO8601}` | `{changes: [...], server_time: ISO8601}` | Pull changes since timestamp (meta-only — no content; clients fetch bodies separately) |
 
 ## Server → Client Broadcasts
 
 | Event | Payload | When | Purpose |
 |-------|---------|------|---------|
-| `note_changed` | `{event_type: "upsert"\|"delete", path, timestamp, kind: "note"\|"attachment"}` | After any note/attachment mutation by ANY device | Real-time sync notification |
-| `presence_state` | `{devices: [{device_id, joined_at}]}` | On join | Current connected devices for this user |
-| `presence_diff` | `{joins: [...], leaves: [...]}` | On device connect/disconnect | Device change notification |
+| `note_changed` (upsert) | `{event_type: "upsert", id, path, vault_id, content, content_hash, title, folder, tags, mtime, updated_at, version}` | After a single-note upsert by ANY device | Real-time sync notification |
+| `note_changed` (delete) | `{event_type: "delete", path, vault_id}` | After a delete/rename-away | Tombstone notification |
+| `notes.batch` (upsert digest) | `{op: "upsert", vault_id, notes: [{event_type, id, path, title, folder, tags, mtime, version, updated_at, content_hash}]}` | ONE per `POST /api/notes/batch` call (replaces N `note_changed` events) | Bulk-push digest — metadata-only, never carries content |
+| `notes.batch` (delete/move) | `{op: "delete"\|"move", ids, target_folder_id?}` | After batch delete / batch move | Batch-op notification |
+| `vault_populated` | `{vault_id}` (topic `user:{user_id}`) | First note lands in an empty vault | FTUX listener |
+| `presence_state` / `presence_diff` | Phoenix Presence shapes | Join / device change | Connected-device tracking |
+
+## content_hash + the dual-field transition
+
+`content_hash` is the server-side HMAC of the note content (keyed per-user —
+**clients can never compute it locally**; they store the last seen value per
+path and compare opaquely).
+
+**Dual-field transition (one release):** `note_changed` upsert payloads carry
+BOTH `content` and `content_hash` as of the 2026-06-12 protocol rev. `content`
+is dropped the release after the plugin min-version floor covers the hash-only
+handler. Self-host backends and plugins update on independent cadences — do
+NOT drop `content` early. The `notes.batch` upsert digest is new in this rev
+and was hash-only from day one.
+
+Client behavior: compare the broadcast's `content_hash` to the stored
+per-path serverHash → equal means no-op; differing means apply inline
+`content` if present, else `GET /notes/{path}`.
 
 ## Echo Suppression
 
-The server does NOT broadcast `note_changed` back to the device that originated the change. Phoenix Channels supports this via `broadcast_from/3` (broadcasts to all *except* the sender). The plugin's existing 5-second echo cooldown remains as a safety net for edge cases.
+Channel-originated pushes (`push_note`) broadcast via `broadcast_from/4` — the
+pushing socket does NOT receive its own `note_changed`. HTTP-originated pushes
+(REST single + batch) cannot identify a socket and use plain `broadcast`; the
+plugin's pushing/recently-pushed sets plus the hash compare make the echo a
+no-op. The 5-second echo cooldown remains as a safety net.
 
 ## Conflict Flow (over WebSocket)
 
@@ -48,7 +71,7 @@ Server checks: notes.version for this path
 
 If version matches (3 == 3):
   → Upsert, increment to version 4
-  → Reply: {note: {..., version: 4}, indexing: "queued"}
+  → Reply: {note: {..., version: 4, content_hash}, indexing: "queued"}
   → broadcast_from: note_changed {path, event_type: "upsert", ...}
 
 If version mismatch (3 != 5):
@@ -58,11 +81,9 @@ If version mismatch (3 != 5):
   → If conflicts: client shows ConflictModal, user resolves, then push
 ```
 
-## Plugin Integration
-
-The plugin's `NoteStream` class (SSE) is replaced by a Phoenix Channel client. The `SyncEngine` calls change from `this.api.pushNote()` (HTTP) + `this.stream.onEvent` (SSE) to `this.channel.push("push_note", ...)` + `this.channel.on("note_changed", ...)`. The conflict resolution and 3-way merge logic is unchanged — only the transport layer changes.
-
 ## References
 - Sync Channel: `lib/engram_web/channels/sync_channel.ex`
-- Presence: `lib/engram_web/presence.ex`
-- Socket: `lib/engram_web/channels/user_socket.ex`
+- Broadcast construction: `lib/engram/notes.ex` (`broadcast_change/6`, `batch_upsert_side_effects/3`)
+- SPA handlers: `frontend/src/api/channel.ts` (`handleNoteChanged`, `handleNotesBatch`)
+- Plugin handlers: `Engram-obsidian/src/channel.ts` + `src/sync.ts` (`handleStreamEvent`)
+- REST counterpart: workspace `docs/api-contract.md`

--- a/e2e/tests/api_only/test_76_batch_pagination.py
+++ b/e2e/tests/api_only/test_76_batch_pagination.py
@@ -1,0 +1,179 @@
+"""Test 76: Sync protocol rev — POST /notes/batch + paginated /notes/changes.
+
+Contract tests for the bulk-push endpoint and keyset pagination:
+
+  * POST /notes/batch upserts up to 100 notes per request behind an
+    idempotency key, returning a per-note results array.
+  * GET /notes/changes caps every response at 500 rows and exposes
+    has_more/next_cursor; a cursor loop covers the full delta with no
+    loss and no duplicates.
+  * Legacy convergence: a pre-pagination client that only advances
+    ``since = server_time`` (no cursor) still collects EVERY change —
+    server_time is anchored at the truncation point when has_more.
+  * fields=meta swaps content for content_hash.
+
+Seeds 1100 notes (3 pages) into the shared vault and batch-deletes them
+afterwards so later suites see a clean slate.
+"""
+
+import os
+import time
+import uuid
+
+import pytest
+
+API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+
+SEED_COUNT = 1100  # > 2 full pages of 500
+EPOCH = "2020-01-01T00:00:00Z"
+PREFIX = "BatchPage"
+
+
+def _batch_push(api, notes: list[dict]) -> dict:
+    resp = api.session.post(
+        f"{API_URL}/notes/batch",
+        json={"notes": notes},
+        headers={"X-Idempotency-Key": str(uuid.uuid4())},
+        timeout=30,
+    )
+    assert resp.status_code == 200, f"batch push failed: {resp.status_code} {resp.text}"
+    return resp.json()
+
+
+def _get_changes(api, since: str, **params) -> dict:
+    resp = api.session.get(
+        f"{API_URL}/notes/changes",
+        params={"since": since, **params},
+        timeout=30,
+    )
+    assert resp.status_code == 200, f"changes failed: {resp.status_code} {resp.text}"
+    return resp.json()
+
+
+@pytest.fixture(scope="module")
+def seeded(api_sync):
+    """Seed SEED_COUNT notes via the batch endpoint; batch-delete on teardown."""
+    ids: list[str] = []
+    for start in range(0, SEED_COUNT, 100):
+        notes = [
+            {
+                "path": f"{PREFIX}/n{i:04d}.md",
+                "content": f"# Note {i}\n\nbatch-seeded",
+                "mtime": time.time(),
+            }
+            for i in range(start, min(start + 100, SEED_COUNT))
+        ]
+        body = _batch_push(api_sync, notes)
+        results = body["results"]
+        assert len(results) == len(notes)
+        for r in results:
+            assert r["status"] == "ok", f"unexpected result: {r}"
+            ids.append(r["id"])
+
+    yield ids
+
+    # Cleanup — one atomic batch delete (no documented cap on ids).
+    resp = api_sync.session.post(
+        f"{API_URL}/notes/batch-delete",
+        json={"ids": ids},
+        headers={"X-Idempotency-Key": str(uuid.uuid4())},
+        timeout=60,
+    )
+    assert resp.status_code == 200, f"cleanup failed: {resp.status_code} {resp.text}"
+
+
+class TestBatchUpsert:
+    def test_batch_results_carry_id_version_and_hash(self, api_sync, seeded):
+        """Spot-check the per-note result contract on a fresh small batch."""
+        body = _batch_push(
+            api_sync,
+            [{"path": f"{PREFIX}/contract-check.md", "content": "# C", "mtime": time.time()}],
+        )
+        (result,) = body["results"]
+        assert result["status"] == "ok"
+        assert result["version"] == 1
+        assert result["server_path"] == f"{PREFIX}/contract-check.md"
+        assert isinstance(result["content_hash"], str) and result["content_hash"]
+        # Idempotent re-push of identical content bumps the version (update
+        # semantics match the single-note endpoint).
+        body2 = _batch_push(
+            api_sync,
+            [{"path": f"{PREFIX}/contract-check.md", "content": "# C", "mtime": time.time()}],
+        )
+        assert body2["results"][0]["version"] == 2
+        api_sync.delete_note(f"{PREFIX}/contract-check.md")
+
+    def test_batch_conflict_carries_server_note(self, api_sync, seeded):
+        path = f"{PREFIX}/conflict-check.md"
+        _batch_push(api_sync, [{"path": path, "content": "v1", "mtime": time.time()}])
+        _batch_push(api_sync, [{"path": path, "content": "v2", "mtime": time.time()}])
+
+        body = _batch_push(
+            api_sync,
+            [{"path": path, "content": "stale", "mtime": time.time(), "version": 1}],
+        )
+        (result,) = body["results"]
+        assert result["status"] == "conflict"
+        assert result["server_note"]["content"] == "v2"
+        assert result["server_note"]["version"] == 2
+        api_sync.delete_note(path)
+
+
+class TestPaginationConvergence:
+    def test_cursor_loop_covers_full_delta(self, api_sync, seeded):
+        """New-plugin shape: limit+cursor loop — complete, no duplicates."""
+        seen: set[str] = set()
+        cursor = None
+        pages = 0
+        while True:
+            params = {"limit": 500, "fields": "meta"}
+            if cursor:
+                params["cursor"] = cursor
+            page = _get_changes(api_sync, EPOCH, **params)
+            pages += 1
+            assert len(page["changes"]) <= 500
+            for c in page["changes"]:
+                if c["path"].startswith(f"{PREFIX}/n"):
+                    assert c["path"] not in seen, f"duplicate across pages: {c['path']}"
+                    seen.add(c["path"])
+                # fields=meta: hash present, content absent
+                assert "content" not in c
+                assert c["content_hash"]
+            if not page["has_more"]:
+                assert page["next_cursor"] is None
+                break
+            cursor = page["next_cursor"]
+            assert cursor, "has_more without next_cursor"
+            assert pages < 50, "cursor loop did not converge"
+
+        assert len(seen) == SEED_COUNT
+
+    def test_legacy_since_polling_converges_without_loss(self, api_sync, seeded):
+        """OLD-plugin shape: no limit/cursor, since = server_time each poll.
+
+        The capped response anchors server_time at the truncation point, so
+        successive polls walk the full delta instead of skipping the tail.
+        This is the back-compat check the spec calls out — if it fails, the
+        cap must be gated on a plugin-version header instead.
+        """
+        seen: set[str] = set()
+        since = EPOCH
+        polls = 0
+        while polls < 50:
+            page = _get_changes(api_sync, since)
+            polls += 1
+            for c in page["changes"]:
+                if c["path"].startswith(f"{PREFIX}/n"):
+                    seen.add(c["path"])
+                    # Legacy (no fields param) pages still carry content.
+                    assert "content" in c
+            if len(seen) >= SEED_COUNT:
+                break
+            assert page["server_time"] > since or page["changes"], (
+                "legacy poll made no progress — livelock"
+            )
+            since = page["server_time"]
+
+        assert len(seen) == SEED_COUNT, (
+            f"legacy polling lost changes: {len(seen)}/{SEED_COUNT} after {polls} polls"
+        )

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -1,0 +1,58 @@
+"""Test 77: 1k-note bulk first sync lands via the batch endpoint in bounded time.
+
+Protocol rev: pushAll sends notes through POST /notes/batch in chunks of
+100 — a 1,000-note first sync is ~10 HTTP round-trips instead of 1,000.
+The duration bound is deliberately generous for CI noise but far below
+what the per-note path costs (1,000 paced requests), so a silent fallback
+to per-note pushes fails this test.
+"""
+
+import time
+
+import pytest
+
+from helpers.vault import write_note
+
+NOTE_COUNT = 1000
+PUSH_TIME_BOUND_S = 120
+
+
+@pytest.mark.asyncio
+async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
+    # Seed 1,000 files on disk, then wait for Obsidian's indexer to see them
+    # (raw filesystem writes only reach app.vault.getFiles() once the
+    # watcher fires).
+    for i in range(NOTE_COUNT):
+        write_note(
+            vault_a,
+            f"Bulk/n{i:04d}.md",
+            f"# Bulk note {i}\n\nfirst-sync payload {i}",
+        )
+
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        count = await cdp_a.evaluate(
+            "app.vault.getFiles().filter(f => f.path.startsWith('Bulk/')).length"
+        )
+        if isinstance(count, int) and count >= NOTE_COUNT:
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"Obsidian indexed only {count}/{NOTE_COUNT} bulk files")
+
+    started = time.monotonic()
+    result = await cdp_a.trigger_full_sync()
+    elapsed = time.monotonic() - started
+
+    assert result.get("pushed", 0) >= NOTE_COUNT, f"fullSync result: {result}"
+    assert elapsed < PUSH_TIME_BOUND_S, (
+        f"bulk first sync took {elapsed:.1f}s (bound {PUSH_TIME_BOUND_S}s) — "
+        "did the plugin fall back to per-note pushes?"
+    )
+
+    # Server-side proof: every note is in the manifest.
+    manifest = api_sync.get_manifest()
+    bulk_paths = [n["path"] for n in manifest["notes"] if n["path"].startswith("Bulk/")]
+    assert len(bulk_paths) >= NOTE_COUNT, (
+        f"manifest holds {len(bulk_paths)}/{NOTE_COUNT} bulk notes"
+    )

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -19,6 +19,15 @@ PUSH_TIME_BOUND_S = 120
 
 @pytest.mark.asyncio
 async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
+    # Close the sync gate FIRST: every raw write below fires the vault
+    # watcher, and an open gate turns that into 1,000 debounced single-note
+    # auto-pushes — a request storm that exhausts the rate budget and
+    # starves the batch sync this test measures. handleModify short-circuits
+    # while the gate is closed.
+    await cdp_a.evaluate(
+        "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked(true)"
+    )
+
     # Seed 1,000 files on disk, then wait for Obsidian's indexer to see them
     # (raw filesystem writes only reach app.vault.getFiles() once the
     # watcher fires).
@@ -40,9 +49,12 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
     else:
         raise TimeoutError(f"Obsidian indexed only {count}/{NOTE_COUNT} bulk files")
 
-    # The PreSync gate blocks engine work until accepted (1,000 new local
-    # files look destructive) — accept it explicitly like push_file_now does.
+    # Re-open the gate the same way a user accepting the PreSync modal does
+    # (persists the fingerprint + flips syncBlocked false).
     await cdp_a.accept_sync_gate()
+    await cdp_a.evaluate(
+        "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked(false)"
+    )
 
     started = time.monotonic()
     result = await cdp_a.trigger_full_sync()

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -40,6 +40,10 @@ async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
     else:
         raise TimeoutError(f"Obsidian indexed only {count}/{NOTE_COUNT} bulk files")
 
+    # The PreSync gate blocks engine work until accepted (1,000 new local
+    # files look destructive) — accept it explicitly like push_file_now does.
+    await cdp_a.accept_sync_gate()
+
     started = time.monotonic()
     result = await cdp_a.trigger_full_sync()
     elapsed = time.monotonic() - started

--- a/e2e/tests/test_78_hash_only_live_update.py
+++ b/e2e/tests/test_78_hash_only_live_update.py
@@ -1,0 +1,57 @@
+"""Test 78: hash-compare live sync — updates apply, identical re-pushes are inert.
+
+Protocol rev: note_changed broadcasts carry content_hash (dual-field for
+one release). The plugin compares the hash to its stored per-path
+serverHash before touching the vault:
+
+  * differing hash → the change applies (inline content or body fetch)
+  * identical hash (e.g. a same-content re-push bumping the version) →
+    no vault write, no conflict file
+
+Every wait is explicit with generous timeouts — this is the surface of
+flake issue #547 (note-live-update), re-covered here deterministically.
+"""
+
+import time
+
+import pytest
+
+from helpers.vault import wait_for_content, wait_for_file
+
+PATH = "E2E/HashOnlyLive.md"
+
+
+@pytest.mark.asyncio
+async def test_hash_only_live_update(vault_b, cdp_b, api_sync):
+    # Explicit precondition: B's channel must be up before we broadcast.
+    await cdp_b.wait_for_stream_connected(timeout=20)
+
+    # 1. Create via API → B receives the broadcast and materializes the file.
+    api_sync.create_note(PATH, "# HashLive v1\n\noriginal body")
+    content = wait_for_file(vault_b, PATH, timeout=30)
+    assert "HashLive v1" in content
+
+    # 2. Update via API → differing content_hash → B applies the new body.
+    api_sync.create_note(PATH, "# HashLive v2\n\nupdated body")
+    wait_for_content(vault_b, PATH, "HashLive v2", timeout=30)
+
+    # 3. Re-push the IDENTICAL content (server bumps version, hash unchanged).
+    #    B's hash compare must treat the broadcast as a no-op: same content,
+    #    no conflict copy spawned.
+    before_mtime = (vault_b / PATH).stat().st_mtime
+    api_sync.create_note(PATH, "# HashLive v2\n\nupdated body")
+    api_sync.wait_for_note_content(PATH, "updated body", timeout=15)
+
+    # Give the broadcast time to arrive and (correctly) be ignored.
+    time.sleep(5)
+
+    content = (vault_b / PATH).read_text(encoding="utf-8")
+    assert "HashLive v2" in content, "identical re-push corrupted the local file"
+
+    conflict_copies = list((vault_b / "E2E").glob("HashOnlyLive (conflict*"))
+    assert conflict_copies == [], f"identical re-push spawned conflicts: {conflict_copies}"
+
+    after_mtime = (vault_b / PATH).stat().st_mtime
+    assert after_mtime == before_mtime, (
+        "identical re-push rewrote the local file — hash compare didn't skip"
+    )

--- a/frontend/src/api/channel.test.ts
+++ b/frontend/src/api/channel.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { QueryClient } from '@tanstack/react-query'
-import { __resetNoteChangeBatch, handleNoteChanged } from './channel'
+import { __resetNoteChangeBatch, handleNoteChanged, handleNotesBatch } from './channel'
 
 function mockQueryClient(foldersData?: unknown) {
   return {
@@ -147,5 +147,51 @@ describe('handleNoteChanged', () => {
       '7',
     )
     expect(qc.invalidateQueries).toHaveBeenCalled()
+  })
+})
+
+describe('handleNotesBatch', () => {
+  it('applies per-note invalidations for an upsert digest (bulk push)', () => {
+    const qc = mockQueryClient()
+    handleNotesBatch(
+      {
+        op: 'upsert',
+        vault_id: '7',
+        notes: [
+          { id: 'id-1', path: 'docs/a.md', folder: 'docs', content_hash: 'h1' },
+          { id: 'id-2', path: 'notes/b.md', folder: 'notes', content_hash: 'h2' },
+        ],
+      },
+      qc,
+      '7',
+    )
+
+    const syncKeys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    expect(syncKeys).toContainEqual(['note', '7', 'id-1'])
+    expect(syncKeys).toContainEqual(['note', '7', 'docs/a.md'])
+    expect(syncKeys).toContainEqual(['note', '7', 'id-2'])
+
+    vi.advanceTimersByTime(250)
+
+    const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    expect(keys).toContainEqual(['folders', '7'])
+    expect(keys).toContainEqual(['folderNotes', '7', 'docs'])
+    expect(keys).toContainEqual(['folderNotes', '7', 'notes'])
+  })
+
+  it('ignores digests from a different vault', () => {
+    const qc = mockQueryClient()
+    handleNotesBatch(
+      { op: 'upsert', vault_id: 'other', notes: [{ id: 'x', path: 'a.md' }] },
+      qc,
+      '7',
+    )
+    expect(qc.invalidateQueries).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-upsert ops', () => {
+    const qc = mockQueryClient()
+    handleNotesBatch({ op: 'delete', vault_id: '7' }, qc, '7')
+    expect(qc.invalidateQueries).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -133,6 +133,43 @@ export function handleNoteChanged(
   for (const listener of listeners) listener(payload)
 }
 
+// Bulk pushes (POST /api/notes/batch) broadcast ONE notes.batch digest
+// (op "upsert", metadata-only entries) instead of N note_changed events.
+// Re-feed each entry through handleNoteChanged so per-note keys invalidate
+// synchronously and list keys ride the same coalescing window.
+export interface NotesBatchPayload {
+  op: string
+  vault_id?: string
+  notes?: Array<{
+    id: string
+    path: string
+    folder?: string
+    title?: string
+    tags?: string[]
+    mtime?: number
+    version?: number
+    updated_at?: string
+    content_hash?: string
+  }>
+}
+
+export function handleNotesBatch(
+  payload: NotesBatchPayload,
+  queryClient: QueryClient,
+  activeVaultId: string,
+): void {
+  if (payload.op !== 'upsert') return
+  if (payload.vault_id !== activeVaultId) return
+
+  for (const note of payload.notes ?? []) {
+    handleNoteChanged(
+      { event_type: 'upsert', vault_id: activeVaultId, ...note },
+      queryClient,
+      activeVaultId,
+    )
+  }
+}
+
 export async function connectChannel({ userId, vaultId, getToken, queryClient }: ConnectOptions) {
   disconnectChannel()
 
@@ -149,6 +186,10 @@ export async function connectChannel({ userId, vaultId, getToken, queryClient }:
 
   channel.on('note_changed', (payload: NoteChangedPayload) => {
     handleNoteChanged(payload, queryClient, vaultId)
+  })
+
+  channel.on('notes.batch', (payload: NotesBatchPayload) => {
+    handleNotesBatch(payload, queryClient, vaultId)
   })
 
   channel

--- a/frontend/src/layout/app-layout.test.tsx
+++ b/frontend/src/layout/app-layout.test.tsx
@@ -4,6 +4,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import AppLayout from './app-layout'
 import { ThemeProvider } from '../theme/theme-provider'
+import { ConfigProvider } from '../config-context'
+import type { EngramConfig } from '../config'
+
+// AppSidebarPanel reads the billing flag via useIsFreeTier() -> useConfig();
+// the layout tree won't mount without a ConfigProvider above it.
+const testConfig: EngramConfig = {
+  authProvider: 'clerk',
+  clerkPublishableKey: '',
+  billingEnabled: true,
+  clerkWaitlistMode: false,
+  apiBase: '',
+  wsBase: '',
+}
 
 vi.mock('../api/queries', async () => {
   const actual = await vi.importActual<typeof import('../api/queries')>('../api/queries')
@@ -22,6 +35,7 @@ vi.mock('../auth/use-auth-adapter', () => ({
 function renderLayout() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
+    <ConfigProvider config={testConfig}>
     <QueryClientProvider client={qc}>
       <ThemeProvider>
         <MemoryRouter initialEntries={['/']}>
@@ -32,7 +46,8 @@ function renderLayout() {
           </Routes>
         </MemoryRouter>
       </ThemeProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
+    </ConfigProvider>,
   )
 }
 

--- a/frontend/src/viewer/note-view.memo.test.tsx
+++ b/frontend/src/viewer/note-view.memo.test.tsx
@@ -3,6 +3,18 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { useState } from 'react'
 
 import NoteView from './note-view'
+import { ConfigProvider } from '../config-context'
+import type { EngramConfig } from '../config'
+
+// NoteView reads useIsFreeTier() -> useConfig(); mount a minimal config.
+const testConfig: EngramConfig = {
+  authProvider: 'clerk',
+  clerkPublishableKey: '',
+  billingEnabled: true,
+  clerkWaitlistMode: false,
+  apiBase: '',
+  wsBase: '',
+}
 
 // Counts actual ReactMarkdown renders — each one is a full remark/rehype
 // parse of the note in production, the dominant typing-latency cost.
@@ -43,7 +55,11 @@ function Harness() {
 describe('NoteView memoization', () => {
   it('does not re-run the markdown pipeline when parent re-renders with identical props', () => {
     markdownRenders = 0
-    render(<Harness />)
+    render(
+      <ConfigProvider config={testConfig}>
+        <Harness />
+      </ConfigProvider>,
+    )
     expect(markdownRenders).toBe(1)
 
     fireEvent.click(screen.getByText('tick'))

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -853,6 +853,368 @@ defmodule Engram.Notes do
     end)
   end
 
+  # ---------------------------------------------------------------------------
+  # Batch upsert (sync protocol rev — bulk push)
+  # ---------------------------------------------------------------------------
+
+  # Persisted columns written by the batch-insert path. Mirrors what the
+  # single-note changeset INSERT produces; timestamps are merged separately
+  # because `insert_all` does not autogenerate them.
+  @batch_insert_columns [
+    :id,
+    :kind,
+    :version,
+    :dek_version,
+    :content_hash,
+    :mtime,
+    :user_id,
+    :vault_id,
+    :content_ciphertext,
+    :content_nonce,
+    :title_ciphertext,
+    :title_nonce,
+    :tags_ciphertext,
+    :tags_nonce,
+    :path_ciphertext,
+    :path_nonce,
+    :path_hmac,
+    :folder_ciphertext,
+    :folder_nonce,
+    :folder_hmac,
+    :tags_hmac
+  ]
+
+  @doc """
+  Bulk create/update of notes in ONE tenant transaction.
+
+  Protocol-rev counterpart of `upsert_note/3` for the plugin's bulk/initial
+  sync: one `path_hmac IN (...)` lookup for the whole batch, per-note encrypt,
+  a single `insert_all` for new rows, one usage-meter increment, one
+  `Oban.insert_all` for embed jobs, and one `notes.batch` digest broadcast
+  (op `"upsert"`, metadata-only — no content) instead of N `note_changed`
+  events.
+
+  Returns `{:ok, %{results: [...]}}` with one entry per input note, in input
+  order:
+
+    * `%{path, status: :ok, id, version, content_hash}`
+    * `%{path, status: :conflict, server_note: %Note{}}` — stale client
+      version; the decrypted server note mirrors today's single-note 409 body
+      so 3-way merge keeps working. Does not block other entries.
+    * `%{path, status: :error, errors: term}` — per-note validation failure
+      (blank path, duplicate path within the batch, invalid changeset). Does
+      not block other entries.
+
+  Whole-batch failure: `{:error, {:notes_cap_reached, limit, current}}` when
+  the would-be inserts exceed the plan's notes cap (nothing is committed —
+  mirrors the single-note 402 so the client can fall back / surface upgrade).
+
+  Batch size is capped at the controller boundary (100), matching the other
+  batch endpoints.
+  """
+  @spec batch_upsert_notes(map(), map(), [map()]) ::
+          {:ok, %{results: [map()]}}
+          | {:error, {:notes_cap_reached, non_neg_integer(), non_neg_integer()}}
+          | {:error, term()}
+  def batch_upsert_notes(_user, _vault, []), do: {:ok, %{results: []}}
+
+  def batch_upsert_notes(user, vault, notes_params) when is_list(notes_params) do
+    with {:ok, user} <- Crypto.ensure_user_dek(user),
+         {:ok, filter_key} <- Crypto.dek_filter_key(user) do
+      entries = normalize_batch_entries(user, filter_key, notes_params)
+
+      case Repo.with_tenant(user.id, fn -> run_batch_upsert(user, vault, entries) end) do
+        {:ok, state} ->
+          batch_upsert_side_effects(user, vault, state)
+          {:ok, %{results: batch_upsert_results(user, state.entries)}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  # Parse + sanitize each entry outside the transaction (pure CPU). Marks
+  # blank paths and intra-batch duplicates (by sanitized-path HMAC) as
+  # per-note errors so they never reach the write path.
+  defp normalize_batch_entries(user, filter_key, notes_params) do
+    notes_params
+    |> Enum.map(fn attrs ->
+      path = attrs["path"] || attrs[:path]
+      content = attrs["content"] || attrs[:content] || ""
+
+      if path in [nil, ""] do
+        %{input_path: path || "", result: {:error, %{path: ["can't be blank"]}}}
+      else
+        sanitized = PathSanitizer.sanitize(path)
+        {:ok, hash} = content_hash(user, content)
+
+        %{
+          input_path: path,
+          path: sanitized,
+          path_hmac: Crypto.hmac_field(filter_key, sanitized),
+          content: content,
+          mtime: attrs["mtime"] || attrs[:mtime],
+          client_version: attrs["version"] || attrs[:version],
+          client_id: attrs["id"] || attrs[:id],
+          title: Helpers.extract_title(content, sanitized),
+          folder: Helpers.extract_folder(sanitized),
+          tags: Helpers.extract_tags(content),
+          hash: hash,
+          result: nil
+        }
+      end
+    end)
+    |> mark_duplicate_paths()
+  end
+
+  defp mark_duplicate_paths(entries) do
+    {marked, _seen} =
+      Enum.map_reduce(entries, MapSet.new(), fn entry, seen ->
+        case entry do
+          %{result: nil, path_hmac: hmac} ->
+            if MapSet.member?(seen, hmac) do
+              {%{entry | result: {:error, %{path: ["duplicate path in batch"]}}}, seen}
+            else
+              {entry, MapSet.put(seen, hmac)}
+            end
+
+          other ->
+            {other, seen}
+        end
+      end)
+
+    marked
+  end
+
+  defp run_batch_upsert(user, vault, entries) do
+    pending = Enum.filter(entries, &is_nil(&1.result))
+    hmacs = Enum.map(pending, & &1.path_hmac)
+
+    existing_by_hmac =
+      Repo.all(
+        from(n in Note,
+          where:
+            n.user_id == ^user.id and n.vault_id == ^vault.id and n.path_hmac in ^hmacs and
+              is_nil(n.deleted_at)
+        )
+      )
+      |> Map.new(&{&1.path_hmac, &1})
+
+    # vault_populated probe — must read BEFORE the insert_all below.
+    was_empty =
+      not Repo.exists?(from(n in Note, where: n.user_id == ^user.id and n.vault_id == ^vault.id))
+
+    to_insert =
+      Enum.count(pending, &(not Map.has_key?(existing_by_hmac, &1.path_hmac)))
+
+    check_batch_notes_cap!(user, to_insert)
+
+    now = DateTime.utc_now()
+
+    {entries, insert_rows} =
+      Enum.map_reduce(entries, [], fn entry, rows ->
+        process_batch_entry(entry, existing_by_hmac, user, vault, now, rows)
+      end)
+
+    inserted_count = length(insert_rows)
+
+    if inserted_count > 0 do
+      {^inserted_count, nil} = Repo.insert_all(Note, Enum.reverse(insert_rows))
+      :ok = UsageMeters.inc_notes_count(user.id, inserted_count)
+    end
+
+    %{entries: entries, inserted_count: inserted_count, was_empty: was_empty, now: now}
+  end
+
+  # Mirrors the single-note cap check, scaled to the batch's insert count.
+  # `check_limit/3` admits one insert when `current < limit`, so admitting N
+  # inserts requires `current + N - 1 < limit`.
+  defp check_batch_notes_cap!(_user, 0), do: :ok
+
+  defp check_batch_notes_cap!(user, to_insert) do
+    current_count = UsageMeters.notes_count(user.id)
+
+    case Billing.check_limit(user, :notes_cap, current_count + to_insert - 1) do
+      :ok ->
+        :ok
+
+      {:error, :limit_reached} ->
+        limit = Billing.effective_limit(user, :notes_cap)
+        Repo.rollback({:notes_cap_reached, limit, current_count})
+    end
+  end
+
+  defp process_batch_entry(%{result: nil} = entry, existing_by_hmac, user, vault, now, rows) do
+    case Map.get(existing_by_hmac, entry.path_hmac) do
+      nil ->
+        case build_batch_insert_row(entry, user, vault, now) do
+          {:ok, id, row} ->
+            info = %{id: id, version: 1, prev_hash: nil, updated_at: now}
+            {%{entry | result: {:ok, info}}, [row | rows]}
+
+          {:error, errors} ->
+            {%{entry | result: {:error, errors}}, rows}
+        end
+
+      existing ->
+        {%{entry | result: update_batch_entry(entry, existing, user)}, rows}
+    end
+  end
+
+  defp process_batch_entry(entry, _existing_by_hmac, _user, _vault, _now, rows),
+    do: {entry, rows}
+
+  defp update_batch_entry(entry, existing, user) do
+    if entry.client_version != nil and entry.client_version != existing.version do
+      {:conflict, existing}
+    else
+      base_attrs = batch_base_attrs(entry, user)
+
+      case do_update_note(existing, base_attrs, user, entry.path, entry.folder, entry.tags) do
+        {:ok, {prev_hash, updated}} ->
+          {:ok,
+           %{
+             id: updated.id,
+             version: updated.version,
+             prev_hash: prev_hash,
+             updated_at: updated.updated_at
+           }}
+
+        {:error, changeset} ->
+          {:error, changeset}
+      end
+    end
+  end
+
+  defp build_batch_insert_row(entry, user, vault, now) do
+    note_id =
+      case entry.client_id && Ecto.UUID.cast(entry.client_id) do
+        {:ok, valid_uuid} -> valid_uuid
+        _ -> mint_id()
+      end
+
+    base_attrs = batch_base_attrs(entry, user, vault)
+
+    with {:ok, encrypted} <- Crypto.encrypt_note_fields(base_attrs, user, note_id) do
+      phase_b =
+        inject_phase_b_fields(encrypted, user, note_id, entry.path, entry.folder, entry.tags)
+
+      changeset = Note.changeset(%Note{id: note_id}, phase_b)
+
+      if changeset.valid? do
+        row =
+          changeset
+          |> Ecto.Changeset.apply_changes()
+          |> Map.take(@batch_insert_columns)
+          |> Map.merge(%{id: note_id, version: 1, created_at: now, updated_at: now})
+
+        {:ok, note_id, row}
+      else
+        {:error, changeset}
+      end
+    end
+  end
+
+  defp batch_base_attrs(entry, user, vault \\ nil) do
+    attrs = %{
+      kind: "note",
+      content: entry.content,
+      title: entry.title,
+      tags: entry.tags,
+      content_hash: entry.hash,
+      mtime: entry.mtime,
+      user_id: user.id
+    }
+
+    if vault, do: Map.put(attrs, :vault_id, vault.id), else: attrs
+  end
+
+  # Post-commit side effects: embed jobs (one Oban.insert_all), the digest
+  # broadcast, FTUX vault_populated, and the per-creation funnel events.
+  # Mirrors the single-note path; the digest replaces N note_changed events.
+  defp batch_upsert_side_effects(user, vault, state) do
+    ok_entries =
+      Enum.filter(state.entries, fn
+        %{result: {:ok, _}} -> true
+        _ -> false
+      end)
+
+    embed_jobs =
+      ok_entries
+      |> Enum.filter(fn %{hash: hash, result: {:ok, info}} -> info.prev_hash != hash end)
+      |> Enum.map(fn %{result: {:ok, info}} -> EmbedNote.new_debounced(info.id) end)
+
+    _ = if embed_jobs != [], do: Oban.insert_all(embed_jobs)
+
+    if ok_entries != [] do
+      digest =
+        Enum.map(ok_entries, fn %{result: {:ok, info}} = entry ->
+          %{
+            "event_type" => "upsert",
+            "id" => info.id,
+            "path" => entry.path,
+            "title" => entry.title,
+            "folder" => entry.folder,
+            "tags" => entry.tags,
+            "mtime" => entry.mtime,
+            "version" => info.version,
+            "updated_at" => info.updated_at,
+            "content_hash" => entry.hash
+          }
+        end)
+
+      _ =
+        EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "notes.batch", %{
+          op: "upsert",
+          notes: digest
+        })
+    end
+
+    created = Enum.filter(ok_entries, fn %{result: {:ok, info}} -> is_nil(info.prev_hash) end)
+
+    if state.was_empty and created != [] do
+      _ =
+        EngramWeb.Endpoint.broadcast("user:#{user.id}", "vault_populated", %{
+          vault_id: vault.id
+        })
+    end
+
+    distinct_id = Engram.Observability.PostHog.distinct_id_for(user)
+
+    Enum.each(created, fn _ ->
+      :ok =
+        Engram.Observability.PostHog.capture(distinct_id, "note_created", %{vault_id: vault.id})
+    end)
+
+    :ok
+  end
+
+  defp batch_upsert_results(user, entries) do
+    Enum.map(entries, fn entry ->
+      case entry.result do
+        {:ok, info} ->
+          %{
+            path: entry.input_path,
+            status: :ok,
+            id: info.id,
+            version: info.version,
+            content_hash: entry.hash
+          }
+
+        {:conflict, existing} ->
+          %{
+            path: entry.input_path,
+            status: :conflict,
+            server_note: decrypt_or_raise!(existing, user)
+          }
+
+        {:error, errors} ->
+          %{path: entry.input_path, status: :error, errors: errors}
+      end
+    end)
+  end
+
   # Resolve the note by id (ownership + cross-vault check) and delegate to
   # rename_note/4 with the recomposed path. rename_note takes the OLD path
   # string, sanitizes the new path, and pre-checks the unique

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -211,14 +211,21 @@ defmodule Engram.Notes do
   @doc """
   Creates or updates a note. Sanitizes path, extracts metadata, computes content_hash.
   Returns {:ok, note} or {:error, changeset}.
+
+  Options:
+
+    * `broadcast_from: pid` — emit the `note_changed` broadcast via
+      `Endpoint.broadcast_from/4` so the given subscriber (the pushing
+      channel process) is excluded. Channel pushes pass `self()`; HTTP
+      pushes have no socket to exclude and use plain broadcast.
   """
-  @spec upsert_note(map(), map(), map()) ::
+  @spec upsert_note(map(), map(), map(), keyword()) ::
           {:ok, Note.t()}
           | {:error, Ecto.Changeset.t()}
           | {:error, :version_conflict, Note.t()}
           | {:error, {:notes_cap_reached, non_neg_integer(), non_neg_integer()}}
           | {:error, atom()}
-  def upsert_note(user, vault, attrs) do
+  def upsert_note(user, vault, attrs, opts \\ []) do
     path = attrs["path"] || attrs[:path]
     content = attrs["content"] || attrs[:content] || ""
     mtime = attrs["mtime"] || attrs[:mtime]
@@ -281,7 +288,7 @@ defmodule Engram.Notes do
             end
 
           note = decrypt_or_raise!(note, user)
-          :ok = broadcast_change(user.id, vault.id, "upsert", note.path, note)
+          :ok = broadcast_change(user.id, vault.id, "upsert", note.path, note, opts)
 
           if is_nil(prev_hash) do
             # FTUX vault page listens for this — fires when an empty vault
@@ -2413,7 +2420,15 @@ defmodule Engram.Notes do
     end
   end
 
-  @spec broadcast_change(Ecto.UUID.t(), Ecto.UUID.t(), String.t(), String.t(), Note.t()) :: :ok
+  @spec broadcast_change(
+          Ecto.UUID.t(),
+          Ecto.UUID.t(),
+          String.t(),
+          String.t(),
+          Note.t(),
+          keyword()
+        ) ::
+          :ok
   # Emits `vault_populated` only when this insert took the vault from 0
   # to 1 notes. Subsequent inserts skip the broadcast; the FTUX listener
   # is one-shot anyway, but avoiding extra channel traffic keeps the
@@ -2447,21 +2462,37 @@ defmodule Engram.Notes do
     :ok
   end
 
-  defp broadcast_change(user_id, vault_id, "upsert", path, %Note{} = note) do
+  defp broadcast_change(user_id, vault_id, "upsert", path, %Note{} = note, opts \\ []) do
+    # Protocol rev — dual-field transition: the payload carries BOTH
+    # `content` and `content_hash` for one release. `content` is dropped the
+    # release after the plugin min-version floor covers the hash-only
+    # handler (self-host backends and plugins update on independent
+    # cadences — do NOT remove early).
+    payload = %{
+      "event_type" => "upsert",
+      "id" => note.id,
+      "path" => path,
+      "vault_id" => vault_id,
+      "content" => note.content || "",
+      "content_hash" => note.content_hash,
+      "title" => note.title || "",
+      "folder" => note.folder || "",
+      "tags" => note.tags || [],
+      "mtime" => note.mtime,
+      "updated_at" => note.updated_at,
+      "version" => note.version
+    }
+
+    topic = "sync:#{user_id}:#{vault_id}"
+
     _ =
-      EngramWeb.Endpoint.broadcast("sync:#{user_id}:#{vault_id}", "note_changed", %{
-        "event_type" => "upsert",
-        "id" => note.id,
-        "path" => path,
-        "vault_id" => vault_id,
-        "content" => note.content || "",
-        "title" => note.title || "",
-        "folder" => note.folder || "",
-        "tags" => note.tags || [],
-        "mtime" => note.mtime,
-        "updated_at" => note.updated_at,
-        "version" => note.version
-      })
+      case Keyword.get(opts, :broadcast_from) do
+        pid when is_pid(pid) ->
+          EngramWeb.Endpoint.broadcast_from(pid, topic, "note_changed", payload)
+
+        nil ->
+          EngramWeb.Endpoint.broadcast(topic, "note_changed", payload)
+      end
 
     :ok
   end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1207,7 +1207,10 @@ defmodule Engram.Notes do
             status: :ok,
             id: info.id,
             version: info.version,
-            content_hash: entry.hash
+            content_hash: entry.hash,
+            # Canonical (sanitized) path — differs from `path` when the
+            # sanitizer rewrote the input; clients rename local files to it.
+            server_path: entry.path
           }
 
         {:conflict, existing} ->

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1302,23 +1302,126 @@ defmodule Engram.Notes do
     changes =
       notes
       |> decrypt_or_raise!(user)
-      |> Enum.map(fn note ->
-        %{
-          id: note.id,
-          path: note.path,
-          title: note.title,
-          folder: note.folder,
-          tags: note.tags,
-          version: note.version,
-          mtime: note.mtime,
-          content: note.content,
-          deleted: not is_nil(note.deleted_at),
-          updated_at: note.updated_at
-        }
-      end)
+      |> Enum.map(&change_map/1)
 
     {:ok, changes}
   end
+
+  @changes_page_max_limit 500
+
+  @doc """
+  Keyset-paginated variant of `list_changes/4` (sync protocol rev).
+
+  Options:
+
+    * `limit:` — page size, clamped to 1..#{@changes_page_max_limit}
+      (default #{@changes_page_max_limit}).
+    * `cursor:` — opaque cursor from a previous page's `next_cursor`.
+      Encodes `(updated_at, id)`; rows are ordered by that pair so pages
+      never lose or duplicate rows even when timestamps collide.
+    * `fields: :meta` — skip the content column + its decrypt; entries carry
+      `content_hash` instead (`content: nil`). Clients fetch bodies
+      selectively for hashes they don't already hold.
+
+  Returns `{:ok, %{changes: [...], has_more: bool, next_cursor: binary | nil}}`
+  or `{:error, :invalid_cursor}`.
+  """
+  @spec list_changes_page(map(), map(), DateTime.t(), keyword()) ::
+          {:ok, %{changes: [map()], has_more: boolean(), next_cursor: binary() | nil}}
+          | {:error, :invalid_cursor}
+  def list_changes_page(user, vault, since, opts \\ []) do
+    limit =
+      opts
+      |> Keyword.get(:limit, @changes_page_max_limit)
+      |> min(@changes_page_max_limit)
+      |> max(1)
+
+    fields = Keyword.get(opts, :fields, :all)
+
+    with {:ok, cursor} <- decode_changes_cursor(Keyword.get(opts, :cursor)) do
+      base =
+        from(n in Note,
+          where:
+            n.user_id == ^user.id and n.vault_id == ^vault.id and n.updated_at >= ^since and
+              n.kind == "note",
+          order_by: [asc: n.updated_at, asc: n.id],
+          limit: ^(limit + 1)
+        )
+
+      base =
+        case cursor do
+          nil ->
+            base
+
+          {ts, id} ->
+            from(n in base,
+              where: n.updated_at > ^ts or (n.updated_at == ^ts and n.id > ^id)
+            )
+        end
+
+      query =
+        case fields do
+          :meta -> from(n in base, select: struct(n, @note_meta_fields))
+          :all -> base
+        end
+
+      {:ok, notes} = Repo.with_tenant(user.id, fn -> Repo.all(query) end)
+
+      {page, has_more} =
+        if length(notes) > limit do
+          {Enum.take(notes, limit), true}
+        else
+          {notes, false}
+        end
+
+      changes =
+        page
+        |> decrypt_or_raise!(user)
+        |> Enum.map(&change_map/1)
+
+      next_cursor =
+        if has_more do
+          last = List.last(page)
+          encode_changes_cursor(last.updated_at, last.id)
+        end
+
+      {:ok, %{changes: changes, has_more: has_more, next_cursor: next_cursor}}
+    end
+  end
+
+  defp change_map(note) do
+    %{
+      id: note.id,
+      path: note.path,
+      title: note.title,
+      folder: note.folder,
+      tags: note.tags,
+      version: note.version,
+      mtime: note.mtime,
+      content: note.content,
+      content_hash: note.content_hash,
+      deleted: not is_nil(note.deleted_at),
+      updated_at: note.updated_at
+    }
+  end
+
+  defp encode_changes_cursor(updated_at, id),
+    do: Base.url_encode64("#{DateTime.to_iso8601(updated_at)}|#{id}", padding: false)
+
+  defp decode_changes_cursor(nil), do: {:ok, nil}
+
+  defp decode_changes_cursor(cursor) when is_binary(cursor) do
+    with {:ok, raw} <- Base.url_decode64(cursor, padding: false),
+         [ts_str, id_str] <- String.split(raw, "|", parts: 2),
+         {:ok, ts, _} <- DateTime.from_iso8601(ts_str),
+         {:ok, id} <- Ecto.UUID.cast(id_str) do
+      {:ok, {ts, id}}
+    else
+      _ -> {:error, :invalid_cursor}
+    end
+  end
+
+  defp decode_changes_cursor(_), do: {:error, :invalid_cursor}
 
   @doc """
   Returns unique tags across all non-deleted notes for a user.

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1198,39 +1198,40 @@ defmodule Engram.Notes do
 
     _ = if embed_jobs != [], do: Oban.insert_all(embed_jobs)
 
-    if ok_entries != [] do
-      digest =
-        Enum.map(ok_entries, fn %{result: {:ok, info}} = entry ->
-          %{
-            "event_type" => "upsert",
-            "id" => info.id,
-            "path" => entry.path,
-            "title" => entry.title,
-            "folder" => entry.folder,
-            "tags" => entry.tags,
-            "mtime" => entry.mtime,
-            "version" => info.version,
-            "updated_at" => info.updated_at,
-            "content_hash" => entry.hash
-          }
-        end)
+    _ =
+      if ok_entries != [] do
+        digest =
+          Enum.map(ok_entries, fn %{result: {:ok, info}} = entry ->
+            %{
+              "event_type" => "upsert",
+              "id" => info.id,
+              "path" => entry.path,
+              "title" => entry.title,
+              "folder" => entry.folder,
+              "tags" => entry.tags,
+              "mtime" => entry.mtime,
+              "version" => info.version,
+              "updated_at" => info.updated_at,
+              "content_hash" => entry.hash
+            }
+          end)
 
-      _ =
-        EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "notes.batch", %{
-          op: "upsert",
-          vault_id: vault.id,
-          notes: digest
-        })
-    end
+        _ =
+          EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "notes.batch", %{
+            op: "upsert",
+            vault_id: vault.id,
+            notes: digest
+          })
+      end
 
     created = Enum.filter(ok_entries, fn %{result: {:ok, info}} -> is_nil(info.prev_hash) end)
 
-    if state.was_empty and created != [] do
-      _ =
+    _ =
+      if state.was_empty and created != [] do
         EngramWeb.Endpoint.broadcast("user:#{user.id}", "vault_populated", %{
           vault_id: vault.id
         })
-    end
+      end
 
     distinct_id = PostHog.distinct_id_for(user)
 

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -976,19 +976,35 @@ defmodule Engram.Notes do
     |> mark_duplicate_paths()
   end
 
+  # Marks intra-batch duplicates as per-note errors: by sanitized-path HMAC
+  # (second write would be an update-of-uncommitted-row) and by client id
+  # (two rows with one PK in a single insert_all raises "cannot affect row
+  # a second time" even under ON CONFLICT, aborting the whole batch).
   defp mark_duplicate_paths(entries) do
     {marked, _seen} =
-      Enum.map_reduce(entries, MapSet.new(), fn entry, seen ->
+      Enum.map_reduce(entries, {MapSet.new(), MapSet.new()}, fn entry, {paths, ids} ->
         case entry do
           %{result: nil, path_hmac: hmac} ->
-            if MapSet.member?(seen, hmac) do
-              {%{entry | result: {:error, %{path: ["duplicate path in batch"]}}}, seen}
-            else
-              {entry, MapSet.put(seen, hmac)}
+            client_id =
+              case entry.client_id && Ecto.UUID.cast(entry.client_id) do
+                {:ok, valid} -> valid
+                _ -> nil
+              end
+
+            cond do
+              MapSet.member?(paths, hmac) ->
+                {%{entry | result: {:error, %{path: ["duplicate path in batch"]}}}, {paths, ids}}
+
+              client_id && MapSet.member?(ids, client_id) ->
+                {%{entry | result: {:error, %{id: ["duplicate id in batch"]}}}, {paths, ids}}
+
+              true ->
+                ids = if client_id, do: MapSet.put(ids, client_id), else: ids
+                {entry, {MapSet.put(paths, hmac), ids}}
             end
 
           other ->
-            {other, seen}
+            {other, {paths, ids}}
         end
       end)
 
@@ -1025,10 +1041,37 @@ defmodule Engram.Notes do
         process_batch_entry(entry, existing_by_hmac, user, vault, now, rows)
       end)
 
-    inserted_count = length(insert_rows)
+    # on_conflict: :nothing — a PK collision (client-supplied id already in
+    # the DB, possibly cross-tenant) or a path-unique race degrades to a
+    # per-note error below instead of aborting the whole batch with a raise.
+    {entries, inserted_count} =
+      case insert_rows do
+        [] ->
+          {entries, 0}
+
+        rows ->
+          {_count, returned} =
+            Repo.insert_all(Note, Enum.reverse(rows), on_conflict: :nothing, returning: [:id])
+
+          inserted_ids = MapSet.new(returned, & &1.id)
+
+          entries =
+            Enum.map(entries, fn
+              %{result: {:ok, %{prev_hash: nil, id: id}}} = entry ->
+                if MapSet.member?(inserted_ids, id) do
+                  entry
+                else
+                  %{entry | result: {:error, %{id: ["already exists"]}}}
+                end
+
+              entry ->
+                entry
+            end)
+
+          {entries, MapSet.size(inserted_ids)}
+      end
 
     if inserted_count > 0 do
-      {^inserted_count, nil} = Repo.insert_all(Note, Enum.reverse(insert_rows))
       :ok = UsageMeters.inc_notes_count(user.id, inserted_count)
     end
 

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1174,6 +1174,7 @@ defmodule Engram.Notes do
       _ =
         EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "notes.batch", %{
           op: "upsert",
+          vault_id: vault.id,
           notes: digest
         })
     end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -10,6 +10,7 @@ defmodule Engram.Notes do
   alias Engram.Crypto
   alias Engram.Crypto.Envelope
   alias Engram.Notes.{Enqueue, Helpers, Note, PathSanitizer}
+  alias Engram.Observability.PostHog
   alias Engram.Repo
   alias Engram.UsageMeters
   alias Engram.Workers.{DeleteNoteIndex, EmbedNote}
@@ -299,8 +300,8 @@ defmodule Engram.Notes do
             # Funnel telemetry — emit once per real creation so the funnel
             # doesn't double-count idempotent re-pushes of unchanged notes.
             :ok =
-              Engram.Observability.PostHog.capture(
-                Engram.Observability.PostHog.distinct_id_for(user),
+              PostHog.capture(
+                PostHog.distinct_id_for(user),
                 "note_created",
                 %{vault_id: vault.id}
               )
@@ -1188,11 +1189,11 @@ defmodule Engram.Notes do
         })
     end
 
-    distinct_id = Engram.Observability.PostHog.distinct_id_for(user)
+    distinct_id = PostHog.distinct_id_for(user)
 
     Enum.each(created, fn _ ->
       :ok =
-        Engram.Observability.PostHog.capture(distinct_id, "note_created", %{vault_id: vault.id})
+        PostHog.capture(distinct_id, "note_created", %{vault_id: vault.id})
     end)
 
     :ok

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -144,7 +144,9 @@ defmodule EngramWeb.SyncChannel do
         user = socket.assigns.current_user
         vault = socket.assigns.vault
 
-        case Notes.upsert_note(user, vault, params) do
+        # broadcast_from: the pushing socket already holds this content —
+        # excluding it halves the pusher's bandwidth on bulk syncs.
+        case Notes.upsert_note(user, vault, params, broadcast_from: self()) do
           {:ok, note} ->
             reply = %{
               "note" => serialize_note(note),

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -179,7 +179,7 @@ defmodule EngramWeb.NotesController do
         {:ok, %{changes: changes, has_more: has_more, next_cursor: next_cursor}} ->
           json(conn, %{
             changes: Enum.map(changes, &change_json(&1, fields)),
-            server_time: DateTime.utc_now() |> DateTime.to_iso8601(),
+            server_time: changes_server_time(changes, has_more),
             has_more: has_more,
             next_cursor: next_cursor
           })
@@ -201,6 +201,21 @@ defmodule EngramWeb.NotesController do
 
   def changes(conn, _params) do
     conn |> put_status(400) |> json(%{error: "missing required param: since"})
+  end
+
+  # Legacy-client convergence: pre-pagination plugins advance
+  # `since = server_time` after every poll. On a truncated page, "now" would
+  # skip the un-fetched tail forever (silent loss) — so server_time is the
+  # high-water mark this response is COMPLETE through: the last returned
+  # change's updated_at when has_more, "now" otherwise. The since filter is
+  # inclusive (>=), so the next poll resumes exactly at the boundary (the
+  # boundary row repeats once; applies are idempotent).
+  defp changes_server_time(changes, true) when changes != [] do
+    changes |> List.last() |> Map.fetch!(:updated_at) |> DateTime.to_iso8601()
+  end
+
+  defp changes_server_time(_changes, _has_more) do
+    DateTime.utc_now() |> DateTime.to_iso8601()
   end
 
   @changes_max_limit 500

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -161,27 +161,64 @@ defmodule EngramWeb.NotesController do
     end
   end
 
-  def changes(conn, %{"since" => since_str}) do
+  # Protocol rev — keyset pagination. Requests without `limit` are still
+  # capped at the server max (500) and gain `has_more`/`next_cursor`; old
+  # plugins see a truncated-but-valid page and converge over successive
+  # polls because they advance `since = server_time`.
+  def changes(conn, %{"since" => since_str} = params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    case DateTime.from_iso8601(since_str) do
-      {:ok, since, _} ->
-        {:ok, changes} = Notes.list_changes(user, vault, since)
+    with {:since, {:ok, since, _}} <- {:since, DateTime.from_iso8601(since_str)},
+         {:ok, limit} <- parse_changes_limit(params["limit"]),
+         {:ok, fields} <- parse_changes_fields(params["fields"]) do
+      opts = [limit: limit, fields: fields]
+      opts = if params["cursor"], do: Keyword.put(opts, :cursor, params["cursor"]), else: opts
 
-        json(conn, %{
-          changes: Enum.map(changes, &change_json/1),
-          server_time: DateTime.utc_now() |> DateTime.to_iso8601()
-        })
+      case Notes.list_changes_page(user, vault, since, opts) do
+        {:ok, %{changes: changes, has_more: has_more, next_cursor: next_cursor}} ->
+          json(conn, %{
+            changes: Enum.map(changes, &change_json(&1, fields)),
+            server_time: DateTime.utc_now() |> DateTime.to_iso8601(),
+            has_more: has_more,
+            next_cursor: next_cursor
+          })
 
-      {:error, _} ->
+        {:error, :invalid_cursor} ->
+          conn |> put_status(400) |> json(%{error: "invalid_cursor"})
+      end
+    else
+      {:since, _} ->
         conn |> put_status(400) |> json(%{error: "invalid since timestamp"})
+
+      {:error, :invalid_limit} ->
+        conn |> put_status(400) |> json(%{error: "invalid_limit"})
+
+      {:error, :invalid_fields} ->
+        conn |> put_status(400) |> json(%{error: "invalid_fields"})
     end
   end
 
   def changes(conn, _params) do
     conn |> put_status(400) |> json(%{error: "missing required param: since"})
   end
+
+  @changes_max_limit 500
+
+  defp parse_changes_limit(nil), do: {:ok, @changes_max_limit}
+
+  defp parse_changes_limit(limit) when is_binary(limit) do
+    case Integer.parse(limit) do
+      {n, ""} when n >= 1 -> {:ok, min(n, @changes_max_limit)}
+      _ -> {:error, :invalid_limit}
+    end
+  end
+
+  defp parse_changes_limit(_), do: {:error, :invalid_limit}
+
+  defp parse_changes_fields(nil), do: {:ok, :all}
+  defp parse_changes_fields("meta"), do: {:ok, :meta}
+  defp parse_changes_fields(_), do: {:error, :invalid_fields}
 
   # ---------------------------------------------------------------------------
   # Batch ops
@@ -380,7 +417,9 @@ defmodule EngramWeb.NotesController do
     }
   end
 
-  defp change_json(change) do
+  defp change_json(change, fields \\ :all)
+
+  defp change_json(change, :meta) do
     %{
       id: change.id,
       path: change.path,
@@ -389,10 +428,16 @@ defmodule EngramWeb.NotesController do
       tags: change.tags || [],
       version: change.version,
       mtime: change.mtime,
-      content: change.content || "",
+      content_hash: change.content_hash,
       deleted: change.deleted,
       updated_at: change.updated_at
     }
+  end
+
+  defp change_json(change, :all) do
+    change
+    |> change_json(:meta)
+    |> Map.put(:content, change.content || "")
   end
 
   defp format_errors(changeset), do: EngramWeb.format_errors(changeset)

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -309,7 +309,8 @@ defmodule EngramWeb.NotesController do
       status: "ok",
       id: result.id,
       version: result.version,
-      content_hash: result.content_hash
+      content_hash: result.content_hash,
+      server_path: result.server_path
     }
   end
 

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -198,6 +198,95 @@ defmodule EngramWeb.NotesController do
   # a retry returns the cached 200 but does NOT re-broadcast. Tracked as a
   # follow-up (after-commit hook).
 
+  @batch_upsert_max 100
+
+  def batch_upsert(conn, %{"notes" => notes}) when is_list(notes) do
+    cond do
+      length(notes) > @batch_upsert_max ->
+        conn |> put_status(400) |> json(%{error: "too_many_notes", max: @batch_upsert_max})
+
+      not Enum.all?(notes, &is_map/1) ->
+        conn |> put_status(400) |> json(%{error: "invalid_notes"})
+
+      true ->
+        do_batch_upsert(conn, notes)
+    end
+  end
+
+  def batch_upsert(conn, _params) do
+    conn |> put_status(400) |> json(%{error: "missing required param: notes"})
+  end
+
+  defp do_batch_upsert(conn, notes) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    # Per-note size gate (mirrors the single-note 413): oversized entries
+    # become per-note errors instead of failing the whole batch — the other
+    # 99 notes in a bulk sync shouldn't pay for one huge file.
+    {sized, oversized} =
+      notes
+      |> Enum.with_index()
+      |> Enum.split_with(fn {note, _idx} ->
+        byte_size(note["content"] || "") <= @max_note_bytes
+      end)
+
+    case Notes.batch_upsert_notes(user, vault, Enum.map(sized, &elem(&1, 0))) do
+      {:ok, %{results: results}} ->
+        by_index =
+          sized
+          |> Enum.map(&elem(&1, 1))
+          |> Enum.zip(Enum.map(results, &batch_result_json/1))
+          |> Map.new()
+
+        oversized_by_index =
+          Map.new(oversized, fn {note, idx} ->
+            {idx,
+             %{
+               path: note["path"] || "",
+               status: "error",
+               errors: %{content: ["exceeds maximum size of 10MB"]}
+             }}
+          end)
+
+        merged =
+          Enum.map(0..(length(notes) - 1), fn idx ->
+            by_index[idx] || oversized_by_index[idx]
+          end)
+
+        body = %{results: merged}
+        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+        json(conn, body)
+
+      {:error, {:notes_cap_reached, limit, current}} ->
+        EngramWeb.LimitResponse.halt(conn, "notes_cap_exceeded", :notes_cap, limit, current)
+
+      {:error, _reason} ->
+        conn |> put_status(500) |> json(%{error: "internal"})
+    end
+  end
+
+  defp batch_result_json(%{status: :ok} = result) do
+    %{
+      path: result.path,
+      status: "ok",
+      id: result.id,
+      version: result.version,
+      content_hash: result.content_hash
+    }
+  end
+
+  defp batch_result_json(%{status: :conflict} = result) do
+    %{path: result.path, status: "conflict", server_note: note_json(result.server_note)}
+  end
+
+  defp batch_result_json(%{status: :error} = result) do
+    %{path: result.path, status: "error", errors: batch_errors_json(result.errors)}
+  end
+
+  defp batch_errors_json(%Ecto.Changeset{} = changeset), do: format_errors(changeset)
+  defp batch_errors_json(other), do: other
+
   def batch_delete(conn, %{"ids" => ids}) when is_list(ids) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
@@ -282,6 +371,10 @@ defmodule EngramWeb.NotesController do
       tags: note.tags || [],
       version: note.version,
       content: note.content || "",
+      # Protocol rev — clients store the server hash per path so hash-only
+      # broadcasts / fields=meta pages can be compared without refetching.
+      # The hash is keyed server-side (HMAC); clients treat it as opaque.
+      content_hash: note.content_hash,
       mtime: note.mtime,
       updated_at: note.updated_at
     }

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -210,6 +210,13 @@ defmodule EngramWeb.NotesController do
   # change's updated_at when has_more, "now" otherwise. The since filter is
   # inclusive (>=), so the next poll resumes exactly at the boundary (the
   # boundary row repeats once; applies are idempotent).
+  #
+  # Bound: legacy convergence assumes fewer than `limit` rows share one
+  # updated_at microsecond — a longer same-usec run would re-serve the same
+  # page forever. Server-side bulk writes stamp at most 100 rows per `now`
+  # (batch upsert cap) and legacy clients can't lower the 500 default, so
+  # the run length stays well under the page size. Revisit if a bulk path
+  # ever writes >500 rows in one timestamp.
   defp changes_server_time(changes, true) when changes != [] do
     changes |> List.last() |> Map.fetch!(:updated_at) |> DateTime.to_iso8601()
   end

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -440,8 +440,6 @@ defmodule EngramWeb.NotesController do
     }
   end
 
-  defp change_json(change, fields \\ :all)
-
   defp change_json(change, :meta) do
     %{
       id: change.id,

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -169,7 +169,7 @@ defmodule EngramWeb.NotesController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    with {:since, {:ok, since, _}} <- {:since, DateTime.from_iso8601(since_str)},
+    with {:ok, since} <- parse_changes_since(since_str),
          {:ok, limit} <- parse_changes_limit(params["limit"]),
          {:ok, fields} <- parse_changes_fields(params["fields"]) do
       opts = [limit: limit, fields: fields]
@@ -188,7 +188,7 @@ defmodule EngramWeb.NotesController do
           conn |> put_status(400) |> json(%{error: "invalid_cursor"})
       end
     else
-      {:since, _} ->
+      {:error, :invalid_since} ->
         conn |> put_status(400) |> json(%{error: "invalid since timestamp"})
 
       {:error, :invalid_limit} ->
@@ -219,6 +219,13 @@ defmodule EngramWeb.NotesController do
   end
 
   @changes_max_limit 500
+
+  defp parse_changes_since(since_str) do
+    case DateTime.from_iso8601(since_str) do
+      {:ok, since, _offset} -> {:ok, since}
+      {:error, _} -> {:error, :invalid_since}
+    end
+  end
 
   defp parse_changes_limit(nil), do: {:ok, @changes_max_limit}
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -321,6 +321,7 @@ defmodule EngramWeb.Router do
     # The plug halts with the cached response BEFORE the action runs.
     scope "/" do
       pipe_through EngramWeb.Plugs.IdempotencyKey
+      post "/notes/batch", NotesController, :batch_upsert
       post "/notes/batch-delete", NotesController, :batch_delete
       post "/notes/batch-move", NotesController, :batch_move
       post "/folders/batch-delete", FoldersController, :batch_delete

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.414",
+      version: "0.5.415",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes_batch_upsert_test.exs
+++ b/test/engram/notes_batch_upsert_test.exs
@@ -185,6 +185,46 @@ defmodule Engram.NotesBatchUpsertTest do
       assert note.content == "first"
     end
 
+    test "duplicate client ids within a batch error after the first occurrence", %{
+      user: user,
+      vault: vault
+    } do
+      shared_id = Ecto.UUID.generate()
+
+      notes = [
+        %{"path" => "one.md", "content" => "x", "mtime" => 1.0, "id" => shared_id},
+        %{"path" => "two.md", "content" => "x", "mtime" => 1.0, "id" => shared_id}
+      ]
+
+      assert {:ok, %{results: [first, second]}} = Notes.batch_upsert_notes(user, vault, notes)
+      assert %{status: :ok} = first
+      assert %{status: :error} = second
+
+      assert {:ok, _} = Notes.get_note(user, vault, "one.md")
+      assert {:error, :not_found} = Notes.get_note(user, vault, "two.md")
+    end
+
+    test "client id colliding with an existing row degrades to a per-note error", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, existing} =
+        Notes.upsert_note(user, vault, %{"path" => "taken.md", "content" => "x", "mtime" => 1.0})
+
+      notes = [
+        %{"path" => "thief.md", "content" => "x", "mtime" => 1.0, "id" => existing.id},
+        %{"path" => "fine.md", "content" => "x", "mtime" => 1.0}
+      ]
+
+      assert {:ok, %{results: [collided, ok]}} = Notes.batch_upsert_notes(user, vault, notes)
+      assert %{path: "thief.md", status: :error} = collided
+      assert %{path: "fine.md", status: :ok} = ok
+
+      # The meter only counts rows that actually landed.
+      assert UsageMeters.notes_count(user.id) == 2
+      assert {:error, :not_found} = Notes.get_note(user, vault, "thief.md")
+    end
+
     test "whole batch is rejected when inserts would exceed the notes cap", %{
       user: user,
       vault: vault

--- a/test/engram/notes_batch_upsert_test.exs
+++ b/test/engram/notes_batch_upsert_test.exs
@@ -335,7 +335,11 @@ defmodule Engram.NotesBatchUpsertTest do
                ])
 
       assert r.status == :ok
-      # Sanitizer strips the traversal — note lands at a safe path.
+      # Sanitizer strips the traversal — note lands at a safe path. The
+      # result echoes the input path for correlation and exposes the
+      # canonical path separately so clients can rename local files.
+      assert r.path == "../escape.md"
+      assert r.server_path == "escape.md"
       assert {:ok, _} = Notes.get_note(user, vault, "escape.md")
     end
   end

--- a/test/engram/notes_batch_upsert_test.exs
+++ b/test/engram/notes_batch_upsert_test.exs
@@ -1,0 +1,342 @@
+defmodule Engram.NotesBatchUpsertTest do
+  use Engram.DataCase, async: true
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Notes
+  alias Engram.UsageMeters
+
+  setup do
+    user = insert(:user)
+
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+
+    %{user: user, vault: vault}
+  end
+
+  describe "batch_upsert_notes/3 — inserts" do
+    test "inserts new notes and returns per-note ok results in input order", %{
+      user: user,
+      vault: vault
+    } do
+      notes = [
+        %{"path" => "a.md", "content" => "# A", "mtime" => 1.0},
+        %{"path" => "sub/b.md", "content" => "# B", "mtime" => 2.0}
+      ]
+
+      assert {:ok, %{results: [r1, r2]}} = Notes.batch_upsert_notes(user, vault, notes)
+
+      assert %{path: "a.md", status: :ok, version: 1} = r1
+      assert %{path: "sub/b.md", status: :ok, version: 1} = r2
+      assert is_binary(r1.id) and is_binary(r2.id)
+      assert is_binary(r1.content_hash)
+
+      assert {:ok, note} = Notes.get_note(user, vault, "a.md")
+      assert note.content == "# A"
+      assert note.title == "A"
+
+      assert {:ok, nested} = Notes.get_note(user, vault, "sub/b.md")
+      assert nested.folder == "sub"
+    end
+
+    test "increments the notes meter once by the inserted count", %{user: user, vault: vault} do
+      notes = for i <- 1..3, do: %{"path" => "n#{i}.md", "content" => "x", "mtime" => 1.0}
+
+      assert {:ok, _} = Notes.batch_upsert_notes(user, vault, notes)
+      assert UsageMeters.notes_count(user.id) == 3
+    end
+
+    test "honors a client-supplied uuid on insert", %{user: user, vault: vault} do
+      client_id = Ecto.UUID.generate()
+
+      assert {:ok, %{results: [r]}} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "c.md", "content" => "x", "mtime" => 1.0, "id" => client_id}
+               ])
+
+      assert r.id == client_id
+    end
+
+    test "enqueues one embed job per changed note", %{user: user, vault: vault} do
+      notes = [
+        %{"path" => "a.md", "content" => "alpha", "mtime" => 1.0},
+        %{"path" => "b.md", "content" => "beta", "mtime" => 1.0}
+      ]
+
+      assert {:ok, %{results: results}} = Notes.batch_upsert_notes(user, vault, notes)
+      ids = Enum.map(results, & &1.id)
+
+      jobs = all_enqueued(worker: Engram.Workers.EmbedNote)
+      assert Enum.sort(Enum.map(jobs, & &1.args["note_id"])) == Enum.sort(ids)
+    end
+  end
+
+  describe "batch_upsert_notes/3 — updates" do
+    test "updates existing notes, bumping version", %{user: user, vault: vault} do
+      {:ok, existing} =
+        Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "v1", "mtime" => 1.0})
+
+      assert {:ok, %{results: [r]}} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "a.md", "content" => "v2", "mtime" => 2.0}
+               ])
+
+      assert %{path: "a.md", status: :ok, version: 2} = r
+      assert r.id == existing.id
+
+      assert {:ok, note} = Notes.get_note(user, vault, "a.md")
+      assert note.content == "v2"
+      assert UsageMeters.notes_count(user.id) == 1
+    end
+
+    test "skips the embed job when content is unchanged", %{user: user, vault: vault} do
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "same", "mtime" => 1.0})
+
+      # Drain jobs enqueued by the seed upsert.
+      seed_jobs = all_enqueued(worker: Engram.Workers.EmbedNote)
+
+      assert {:ok, %{results: [%{status: :ok}]}} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "a.md", "content" => "same", "mtime" => 2.0}
+               ])
+
+      assert all_enqueued(worker: Engram.Workers.EmbedNote) == seed_jobs
+    end
+
+    test "mixed insert + update in one batch", %{user: user, vault: vault} do
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "old.md", "content" => "v1", "mtime" => 1.0})
+
+      notes = [
+        %{"path" => "old.md", "content" => "v2", "mtime" => 2.0},
+        %{"path" => "new.md", "content" => "n", "mtime" => 2.0}
+      ]
+
+      assert {:ok, %{results: [r_old, r_new]}} = Notes.batch_upsert_notes(user, vault, notes)
+      assert %{status: :ok, version: 2} = r_old
+      assert %{status: :ok, version: 1} = r_new
+      assert UsageMeters.notes_count(user.id) == 2
+    end
+  end
+
+  describe "batch_upsert_notes/3 — conflicts and errors" do
+    test "stale client version yields a conflict entry carrying the server note", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "v1", "mtime" => 1.0})
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "v2", "mtime" => 2.0})
+
+      notes = [
+        %{"path" => "a.md", "content" => "mine", "mtime" => 3.0, "version" => 1},
+        %{"path" => "b.md", "content" => "ok", "mtime" => 3.0}
+      ]
+
+      assert {:ok, %{results: [conflict, ok]}} = Notes.batch_upsert_notes(user, vault, notes)
+
+      assert %{path: "a.md", status: :conflict, server_note: server_note} = conflict
+      assert server_note.content == "v2"
+      assert server_note.version == 2
+      assert server_note.path == "a.md"
+
+      # Conflict must not block the rest of the batch.
+      assert %{path: "b.md", status: :ok} = ok
+      assert {:ok, _} = Notes.get_note(user, vault, "b.md")
+
+      # Server content untouched by the stale push.
+      assert {:ok, note} = Notes.get_note(user, vault, "a.md")
+      assert note.content == "v2"
+    end
+
+    test "blank path yields a per-note error entry without failing the batch", %{
+      user: user,
+      vault: vault
+    } do
+      notes = [
+        %{"path" => "", "content" => "x", "mtime" => 1.0},
+        %{"path" => "ok.md", "content" => "x", "mtime" => 1.0}
+      ]
+
+      assert {:ok, %{results: [bad, good]}} = Notes.batch_upsert_notes(user, vault, notes)
+      assert %{path: "", status: :error} = bad
+      assert %{path: "ok.md", status: :ok} = good
+    end
+
+    test "duplicate paths within a batch error after the first occurrence", %{
+      user: user,
+      vault: vault
+    } do
+      notes = [
+        %{"path" => "dup.md", "content" => "first", "mtime" => 1.0},
+        %{"path" => "dup.md", "content" => "second", "mtime" => 2.0}
+      ]
+
+      assert {:ok, %{results: [first, second]}} = Notes.batch_upsert_notes(user, vault, notes)
+      assert %{status: :ok} = first
+      assert %{status: :error} = second
+
+      assert {:ok, note} = Notes.get_note(user, vault, "dup.md")
+      assert note.content == "first"
+    end
+
+    test "whole batch is rejected when inserts would exceed the notes cap", %{
+      user: user,
+      vault: vault
+    } do
+      insert(:user_limit_override, user: user, key: "notes_cap", value: %{"v" => 2})
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "x", "mtime" => 1.0})
+
+      notes = [
+        %{"path" => "b.md", "content" => "x", "mtime" => 1.0},
+        %{"path" => "c.md", "content" => "x", "mtime" => 1.0}
+      ]
+
+      assert {:error, {:notes_cap_reached, 2, 1}} = Notes.batch_upsert_notes(user, vault, notes)
+
+      # Nothing committed.
+      assert {:error, :not_found} = Notes.get_note(user, vault, "b.md")
+      assert UsageMeters.notes_count(user.id) == 1
+    end
+
+    test "updates are exempt from the notes cap", %{user: user, vault: vault} do
+      insert(:user_limit_override, user: user, key: "notes_cap", value: %{"v" => 1})
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "v1", "mtime" => 1.0})
+
+      assert {:ok, %{results: [%{status: :ok, version: 2}]}} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "a.md", "content" => "v2", "mtime" => 2.0}
+               ])
+    end
+  end
+
+  describe "batch_upsert_notes/3 — broadcast digest" do
+    test "emits one notes.batch digest instead of per-note note_changed", %{
+      user: user,
+      vault: vault
+    } do
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      notes = [
+        %{"path" => "a.md", "content" => "# A", "mtime" => 1.0},
+        %{"path" => "b.md", "content" => "# B", "mtime" => 2.0}
+      ]
+
+      assert {:ok, %{results: results}} = Notes.batch_upsert_notes(user, vault, notes)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "notes.batch",
+        payload: %{op: "upsert", notes: digest}
+      }
+
+      assert length(digest) == 2
+      [first | _] = Enum.sort_by(digest, & &1["path"])
+      assert first["path"] == "a.md"
+      assert first["id"] == Enum.find(results, &(&1.path == "a.md")).id
+      assert first["version"] == 1
+      assert is_binary(first["content_hash"])
+      assert first["title"] == "A"
+      refute Map.has_key?(first, "content")
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "note_changed"}, 100
+    end
+
+    test "conflict and error entries are excluded from the digest", %{user: user, vault: vault} do
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "v1", "mtime" => 1.0})
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      notes = [
+        %{"path" => "a.md", "content" => "stale", "mtime" => 2.0, "version" => 99},
+        %{"path" => "ok.md", "content" => "x", "mtime" => 2.0}
+      ]
+
+      assert {:ok, _} = Notes.batch_upsert_notes(user, vault, notes)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "notes.batch",
+        payload: %{op: "upsert", notes: [only]}
+      }
+
+      assert only["path"] == "ok.md"
+    end
+
+    test "an all-conflict batch emits no digest", %{user: user, vault: vault} do
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "v1", "mtime" => 1.0})
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      assert {:ok, %{results: [%{status: :conflict}]}} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "a.md", "content" => "stale", "mtime" => 2.0, "version" => 99}
+               ])
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "notes.batch"}, 100
+    end
+
+    test "broadcasts vault_populated when the batch populates an empty vault", %{
+      user: user,
+      vault: vault
+    } do
+      EngramWeb.Endpoint.subscribe("user:#{user.id}")
+
+      assert {:ok, _} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "first.md", "content" => "x", "mtime" => 1.0},
+                 %{"path" => "second.md", "content" => "x", "mtime" => 1.0}
+               ])
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "vault_populated",
+        payload: %{vault_id: vault_id}
+      }
+
+      assert vault_id == vault.id
+    end
+
+    test "does not broadcast vault_populated for an already-populated vault", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "seed.md", "content" => "x", "mtime" => 1.0})
+
+      EngramWeb.Endpoint.subscribe("user:#{user.id}")
+
+      assert {:ok, _} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "more.md", "content" => "x", "mtime" => 1.0}
+               ])
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "vault_populated"}, 100
+    end
+  end
+
+  describe "batch_upsert_notes/3 — edges" do
+    test "empty list returns empty results", %{user: user, vault: vault} do
+      assert {:ok, %{results: []}} = Notes.batch_upsert_notes(user, vault, [])
+    end
+
+    test "path traversal is sanitized like the single-note path", %{user: user, vault: vault} do
+      assert {:ok, %{results: [r]}} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "../escape.md", "content" => "x", "mtime" => 1.0}
+               ])
+
+      assert r.status == :ok
+      # Sanitizer strips the traversal — note lands at a safe path.
+      assert {:ok, _} = Notes.get_note(user, vault, "escape.md")
+    end
+  end
+end

--- a/test/engram/notes_broadcast_test.exs
+++ b/test/engram/notes_broadcast_test.exs
@@ -1,0 +1,53 @@
+defmodule Engram.NotesBroadcastTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Notes
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  describe "note_changed upsert broadcast (protocol rev dual-field)" do
+    test "carries BOTH content and content_hash for the transition release", %{
+      user: user,
+      vault: vault
+    } do
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "a.md",
+          "content" => "# A",
+          "mtime" => 1.0
+        })
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: payload
+      }
+
+      assert payload["event_type"] == "upsert"
+      assert payload["content"] == "# A"
+      assert payload["content_hash"] == note.content_hash
+      assert is_binary(payload["content_hash"])
+    end
+
+    test "broadcast_from: pid excludes that subscriber", %{user: user, vault: vault} do
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      {:ok, _} =
+        Notes.upsert_note(
+          user,
+          vault,
+          %{"path" => "b.md", "content" => "# B", "mtime" => 1.0},
+          broadcast_from: self()
+        )
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "note_changed"}, 100
+    end
+  end
+end

--- a/test/engram/notes_changes_page_test.exs
+++ b/test/engram/notes_changes_page_test.exs
@@ -1,0 +1,126 @@
+defmodule Engram.NotesChangesPageTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Notes
+  alias Engram.Notes.Note
+  alias Engram.Repo
+
+  @epoch ~U[2020-01-01 00:00:00.000000Z]
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  defp seed_notes(user, vault, n) do
+    for i <- 1..n do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "n#{String.pad_leading(to_string(i), 3, "0")}.md",
+          "content" => "note #{i}",
+          "mtime" => i * 1.0
+        })
+
+      note
+    end
+  end
+
+  describe "list_changes_page/4" do
+    test "pages through all changes without overlap or loss", %{user: user, vault: vault} do
+      seed_notes(user, vault, 5)
+
+      assert {:ok, %{changes: page1, has_more: true, next_cursor: cursor1}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 2)
+
+      assert length(page1) == 2
+      assert is_binary(cursor1)
+
+      assert {:ok, %{changes: page2, has_more: true, next_cursor: cursor2}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 2, cursor: cursor1)
+
+      assert {:ok, %{changes: page3, has_more: false, next_cursor: nil}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 2, cursor: cursor2)
+
+      all_ids = Enum.map(page1 ++ page2 ++ page3, & &1.id)
+      assert length(all_ids) == 5
+      assert length(Enum.uniq(all_ids)) == 5
+    end
+
+    test "a full final page reports has_more false on the follow-up call", %{
+      user: user,
+      vault: vault
+    } do
+      seed_notes(user, vault, 2)
+
+      assert {:ok, %{changes: changes, has_more: false, next_cursor: nil}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 2)
+
+      assert length(changes) == 2
+    end
+
+    test "identical updated_at timestamps don't lose or duplicate rows across pages", %{
+      user: user,
+      vault: vault
+    } do
+      notes = seed_notes(user, vault, 3)
+      shared_ts = DateTime.utc_now()
+      ids = Enum.map(notes, & &1.id)
+
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(from(n in Note, where: n.id in ^ids),
+            set: [updated_at: shared_ts]
+          )
+        end)
+
+      assert {:ok, %{changes: page1, has_more: true, next_cursor: cursor}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 2)
+
+      assert {:ok, %{changes: page2, has_more: false}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 2, cursor: cursor)
+
+      collected = Enum.map(page1 ++ page2, & &1.id)
+      assert Enum.sort(collected) == Enum.sort(ids)
+    end
+
+    test "every change carries content_hash", %{user: user, vault: vault} do
+      seed_notes(user, vault, 1)
+
+      assert {:ok, %{changes: [change]}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 10)
+
+      assert is_binary(change.content_hash)
+      assert change.content == "note 1"
+    end
+
+    test "fields: :meta returns content_hash but no content", %{user: user, vault: vault} do
+      seed_notes(user, vault, 1)
+
+      assert {:ok, %{changes: [change]}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 10, fields: :meta)
+
+      assert is_binary(change.content_hash)
+      assert change.content == nil
+      assert change.path == "n001.md"
+    end
+
+    test "includes deleted notes", %{user: user, vault: vault} do
+      seed_notes(user, vault, 2)
+      :ok = Notes.delete_note(user, vault, "n001.md")
+
+      assert {:ok, %{changes: changes}} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 10)
+
+      deleted = Enum.find(changes, & &1.deleted)
+      assert deleted.path == "n001.md"
+    end
+
+    test "invalid cursor returns an error", %{user: user, vault: vault} do
+      assert {:error, :invalid_cursor} =
+               Notes.list_changes_page(user, vault, @epoch, limit: 10, cursor: "garbage!!")
+    end
+  end
+end

--- a/test/engram_web/channels/sync_channel_test.exs
+++ b/test/engram_web/channels/sync_channel_test.exs
@@ -184,24 +184,31 @@ defmodule EngramWeb.SyncChannelTest do
         "event_type" => "upsert",
         "path" => "Test/Shared.md",
         "content" => "# Shared",
+        "content_hash" => content_hash,
         "title" => "Shared"
       }
+
+      # Protocol rev dual-field transition: hash rides along with content
+      # for one release so old and new plugins both work.
+      assert is_binary(content_hash)
     end
 
-    test "broadcasts note_changed to sender (Endpoint.broadcast semantics)", %{socket: socket} do
-      push(socket, "push_note", %{
-        "path" => "Test/Echo.md",
-        "content" => "# Echo",
-        "mtime" => 1_000.0
-      })
+    test "does NOT push note_changed back to the sender (broadcast_from semantics)", %{
+      socket: socket
+    } do
+      ref =
+        push(socket, "push_note", %{
+          "path" => "Test/Echo.md",
+          "content" => "# Echo",
+          "mtime" => 1_000.0
+        })
 
-      # Notes context uses Endpoint.broadcast (not broadcast_from!), so sender
-      # also receives the note_changed event. Clients should deduplicate by path/version.
-      assert_push "note_changed", %{
-        "event_type" => "upsert",
-        "path" => "Test/Echo.md",
-        "content" => "# Echo"
-      }
+      assert_reply ref, :ok, %{"note" => _}
+
+      # Protocol rev: channel pushes broadcast via broadcast_from, so the
+      # pushing socket no longer pays for its own echo. (HTTP pushes still
+      # use plain broadcast — no socket to exclude.)
+      refute_push "note_changed", %{"path" => "Test/Echo.md"}
     end
 
     test "sanitizes path in push_note", %{socket: socket} do

--- a/test/engram_web/controllers/notes_changes_pagination_test.exs
+++ b/test/engram_web/controllers/notes_changes_pagination_test.exs
@@ -1,0 +1,121 @@
+defmodule EngramWeb.NotesChangesPaginationTest do
+  use EngramWeb.ConnCase, async: false
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    vault = insert(:vault, user: user, is_default: true)
+    {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
+    authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
+    %{conn: authed, user: user, vault: vault}
+  end
+
+  defp seed(user, vault, n) do
+    for i <- 1..n do
+      {:ok, note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          path: "n#{i}.md",
+          content: "note #{i}",
+          mtime: i * 1.0
+        })
+
+      note
+    end
+  end
+
+  describe "GET /api/notes/changes pagination" do
+    test "limit + cursor loop converges and covers all changes", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      seed(user, vault, 3)
+
+      page1 =
+        conn
+        |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z&limit=2")
+        |> json_response(200)
+
+      assert length(page1["changes"]) == 2
+      assert page1["has_more"] == true
+      assert is_binary(page1["next_cursor"])
+      assert is_binary(page1["server_time"])
+
+      page2 =
+        conn
+        |> get(
+          ~p"/api/notes/changes?since=2020-01-01T00:00:00Z&limit=2&cursor=#{page1["next_cursor"]}"
+        )
+        |> json_response(200)
+
+      assert length(page2["changes"]) == 1
+      assert page2["has_more"] == false
+      assert page2["next_cursor"] == nil
+
+      paths = Enum.map(page1["changes"] ++ page2["changes"], & &1["path"])
+      assert Enum.sort(paths) == ["n1.md", "n2.md", "n3.md"]
+    end
+
+    test "responses without explicit limit keep the legacy shape plus pagination fields", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      seed(user, vault, 1)
+
+      body =
+        conn
+        |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z")
+        |> json_response(200)
+
+      assert [change] = body["changes"]
+      assert change["content"] == "note 1"
+      assert is_binary(change["content_hash"])
+      assert body["has_more"] == false
+      assert body["next_cursor"] == nil
+    end
+
+    test "fields=meta omits content and keeps content_hash", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      seed(user, vault, 1)
+
+      body =
+        conn
+        |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z&fields=meta")
+        |> json_response(200)
+
+      assert [change] = body["changes"]
+      refute Map.has_key?(change, "content")
+      assert is_binary(change["content_hash"])
+      assert change["path"] == "n1.md"
+    end
+
+    test "invalid cursor → 400", %{conn: conn} do
+      body =
+        conn
+        |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z&cursor=!!!notacursor")
+        |> json_response(400)
+
+      assert body["error"] == "invalid_cursor"
+    end
+
+    test "invalid limit → 400", %{conn: conn} do
+      assert conn
+             |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z&limit=abc")
+             |> json_response(400)
+
+      assert conn
+             |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z&limit=0")
+             |> json_response(400)
+    end
+
+    test "invalid fields value → 400", %{conn: conn} do
+      assert conn
+             |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z&fields=everything")
+             |> json_response(400)
+    end
+  end
+end

--- a/test/engram_web/controllers/notes_changes_pagination_test.exs
+++ b/test/engram_web/controllers/notes_changes_pagination_test.exs
@@ -93,6 +93,41 @@ defmodule EngramWeb.NotesChangesPaginationTest do
       assert change["path"] == "n1.md"
     end
 
+    test "has_more responses anchor server_time at the last returned change (legacy convergence)",
+         %{conn: conn, user: user, vault: vault} do
+      seed(user, vault, 3)
+
+      page1 =
+        conn
+        |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z&limit=2")
+        |> json_response(200)
+
+      assert page1["has_more"] == true
+      # A legacy client advances since = server_time after every poll. If
+      # server_time were "now", the un-fetched tail (updated_at < now) would
+      # be skipped forever — silent data loss. Anchoring server_time at the
+      # last returned row makes the next inclusive since-poll resume exactly
+      # at the truncation point.
+      last_updated_at = page1["changes"] |> List.last() |> Map.fetch!("updated_at")
+      assert page1["server_time"] == last_updated_at
+
+      # The legacy loop converges: poll again from server_time, no cursor.
+      page2 =
+        conn
+        |> get(~p"/api/notes/changes?since=#{page1["server_time"]}&limit=2")
+        |> json_response(200)
+
+      assert page2["has_more"] == false
+      # Full final page → server_time reverts to "now" semantics (parseable,
+      # >= the last change).
+      assert {:ok, _, _} = DateTime.from_iso8601(page2["server_time"])
+
+      all_paths =
+        Enum.map(page1["changes"] ++ page2["changes"], & &1["path"]) |> Enum.uniq()
+
+      assert Enum.sort(all_paths) == ["n1.md", "n2.md", "n3.md"]
+    end
+
     test "invalid cursor → 400", %{conn: conn} do
       body =
         conn

--- a/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
+++ b/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
@@ -29,6 +29,7 @@ defmodule EngramWeb.NotesControllerBatchUpsertTest do
       assert %{"path" => "a.md", "status" => "ok", "version" => 1} = r1
       assert is_binary(r1["id"])
       assert is_binary(r1["content_hash"])
+      assert r1["server_path"] == "a.md"
       assert %{"path" => "sub/b.md", "status" => "ok"} = r2
 
       replay =
@@ -139,3 +140,4 @@ defmodule EngramWeb.NotesControllerBatchUpsertTest do
     end
   end
 end
+

--- a/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
+++ b/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
@@ -1,0 +1,141 @@
+defmodule EngramWeb.NotesControllerBatchUpsertTest do
+  use EngramWeb.ConnCase, async: false
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    vault = insert(:vault, user: user, is_default: true)
+    {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
+    authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
+    %{conn: authed, user: user, vault: vault}
+  end
+
+  describe "POST /api/notes/batch" do
+    test "bulk insert returns per-note results + idempotency replay", %{conn: conn} do
+      key = Ecto.UUID.generate()
+
+      notes = [
+        %{path: "a.md", content: "# A", mtime: 1.0},
+        %{path: "sub/b.md", content: "# B", mtime: 2.0}
+      ]
+
+      body =
+        conn
+        |> put_req_header("x-idempotency-key", key)
+        |> post(~p"/api/notes/batch", %{notes: notes})
+        |> json_response(200)
+
+      assert [r1, r2] = body["results"]
+      assert %{"path" => "a.md", "status" => "ok", "version" => 1} = r1
+      assert is_binary(r1["id"])
+      assert is_binary(r1["content_hash"])
+      assert %{"path" => "sub/b.md", "status" => "ok"} = r2
+
+      replay =
+        conn
+        |> put_req_header("x-idempotency-key", key)
+        |> post(~p"/api/notes/batch", %{notes: notes})
+        |> json_response(200)
+
+      assert replay == body
+    end
+
+    test "missing idempotency key → 400", %{conn: conn} do
+      conn
+      |> post(~p"/api/notes/batch", %{notes: [%{path: "a.md", content: "x", mtime: 1.0}]})
+      |> json_response(400)
+    end
+
+    test "more than 100 notes → 400", %{conn: conn} do
+      notes = for i <- 1..101, do: %{path: "n#{i}.md", content: "x", mtime: 1.0}
+
+      body =
+        conn
+        |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+        |> post(~p"/api/notes/batch", %{notes: notes})
+        |> json_response(400)
+
+      assert body["error"] == "too_many_notes"
+      assert body["max"] == 100
+    end
+
+    test "missing notes param → 400", %{conn: conn} do
+      conn
+      |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+      |> post(~p"/api/notes/batch", %{})
+      |> json_response(400)
+    end
+
+    test "oversized note becomes a per-note error without failing the batch", %{conn: conn} do
+      big = String.duplicate("a", 10 * 1024 * 1024 + 1)
+
+      notes = [
+        %{path: "big.md", content: big, mtime: 1.0},
+        %{path: "ok.md", content: "fine", mtime: 1.0}
+      ]
+
+      body =
+        conn
+        |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+        |> post(~p"/api/notes/batch", %{notes: notes})
+        |> json_response(200)
+
+      assert [big_result, ok_result] = body["results"]
+      assert %{"path" => "big.md", "status" => "error"} = big_result
+      assert %{"path" => "ok.md", "status" => "ok"} = ok_result
+    end
+
+    test "stale version yields a conflict entry mirroring the single-note 409 body", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, _} =
+        Engram.Notes.upsert_note(user, vault, %{path: "a.md", content: "v1", mtime: 1.0})
+
+      {:ok, _} =
+        Engram.Notes.upsert_note(user, vault, %{path: "a.md", content: "v2", mtime: 2.0})
+
+      body =
+        conn
+        |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+        |> post(~p"/api/notes/batch", %{
+          notes: [%{path: "a.md", content: "mine", mtime: 3.0, version: 1}]
+        })
+        |> json_response(200)
+
+      assert [%{"path" => "a.md", "status" => "conflict", "server_note" => server_note}] =
+               body["results"]
+
+      assert server_note["content"] == "v2"
+      assert server_note["version"] == 2
+      assert server_note["path"] == "a.md"
+      assert is_binary(server_note["content_hash"])
+    end
+
+    test "cap exceeded → 402 with LimitResponse shape, nothing committed", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      insert(:user_limit_override, user: user, key: "notes_cap", value: %{"v" => 1})
+
+      body =
+        conn
+        |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+        |> post(~p"/api/notes/batch", %{
+          notes: [
+            %{path: "a.md", content: "x", mtime: 1.0},
+            %{path: "b.md", content: "x", mtime: 1.0}
+          ]
+        })
+        |> json_response(402)
+
+      assert body["error"] == "limit_exceeded"
+      assert body["reason"] == "notes_cap_exceeded"
+      assert body["limit"] == 1
+
+      assert {:error, :not_found} = Engram.Notes.get_note(user, vault, "a.md")
+    end
+  end
+end

--- a/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
+++ b/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
@@ -140,4 +140,3 @@ defmodule EngramWeb.NotesControllerBatchUpsertTest do
     end
   end
 end
-


### PR DESCRIPTION
Backend side of the sync protocol rev. Pairs with plugin PR engram-app/Engram-obsidian#98 (same-name branch `feat/sync-protocol-rev` auto-pairs in e2e). Spec: workspace `docs/superpowers/specs/2026-06-12-sync-protocol-rev-design.md` (approved 2026-06-12). Final item of the 2026-06-12 perf audit (#538–#551 shipped the rest).

## A. `POST /api/notes/batch` (new)

- Max 100 notes/request, behind the `IdempotencyKey` plug (replay-safe like batch-delete/move).
- `Notes.batch_upsert_notes/3`: ONE tenant txn — single `path_hmac IN (...)` lookup, per-note encrypt, one `insert_all` for new rows, one meter increment, one `Oban.insert_all` for embeds, one `notes.batch` digest broadcast (op `"upsert"`, metadata-only) instead of N `note_changed` events.
- Per-note results `{path, status: ok|conflict|error, id, version, content_hash, server_path}`; conflicts carry the decrypted server note (mirrors the single-note 409 body) and don't block the rest of the batch. Oversized notes (>10MB) degrade to per-note errors. Whole-batch 402 `LimitResponse` on notes_cap.
- `server_path` exposes the sanitized canonical path so clients can rename local files (mirrors `resp.note.path` on single push).

## B. Paginated `/api/notes/changes`

- `limit` (default+max 500), opaque keyset cursor `(updated_at, id)` — tie-safe ordering, `has_more` + `next_cursor` in the response. `fields=meta` returns `content_hash` instead of `content` and skips the content column read + decrypt.
- **Legacy convergence fix (beyond spec):** old plugins advance `since = server_time` unconditionally. A truncated page with `server_time = now` would silently skip the un-fetched tail forever (loss, not livelock — worse than the spec's flagged risk). When `has_more`, `server_time` is anchored at the last returned change's `updated_at`, so the legacy inclusive since-poll resumes exactly at the truncation point and converges with no loss. Covered by a controller test and the e2e legacy-polling test.

## C. Dual-field `note_changed` + echo suppression

- Upsert payloads now carry `content_hash` ALONGSIDE `content` for ONE release; drop `content` next release once the plugin min-version floor covers the hash-only handler (self-host cadence — per approved spec, lockstep rejected).
- Channel pushes broadcast via `broadcast_from(self())` — the pusher stops receiving its own full-body echo. HTTP pushes keep plain broadcast (no socket to exclude).
- `note_json`/`change_json` gain `content_hash` so clients can store the per-path server hash (opaque HMAC — never client-computable).

## SPA

- `channel.ts` handles the new `notes.batch` upsert digest: per-note invalidations through the existing coalesced flush. Also fixes two pre-existing provider-less test harnesses (`app-layout`, `note-view.memo`) that broke when `useIsFreeTier()` landed in those trees (vitest isn't a CI gate).

## e2e (new)

- `api_only/test_76`: batch contract + 1100-note pagination — cursor-loop completeness AND legacy `since=server_time` polling convergence.
- `test_77`: 1k-note bulk first sync, bounded duration + manifest completeness.
- `test_78`: hash-compare live updates with explicit waits (re-covers the #547 flake surface); identical re-pushes are inert.

## Notes

- **No migration** (no schema change).
- Channel `pull_changes` is untouched (already meta-only; plugin uses the HTTP path).
- Known cost: a 1k-note batch first sync emits one PostHog `note_created` per real insert (semantics parity with the single-path funnel counting); can move to PostHog's batch endpoint later if the task-spawn burst matters.
- `mix test` 2623/0 · credo --strict clean · frontend vitest 475/0 + build clean.

Docs: `docs/context/channel-event-contract.md` updated in-repo; workspace `docs/api-contract.md` follows in a workspace PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)