### PR TITLE
fix(ci): publish prebuilt engram-ci image to registry for cross-runner e2e

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -289,11 +289,18 @@ jobs:
             echo "Neither fingerprint cached — running full test suite"
           fi
 
-  # Build the CI engram image ONCE per CI run. All e2e-* jobs share the
-  # same docker daemon on this VM, so a single `docker tag` makes the
-  # image visible to every downstream runner without registry push.
-  # Image tag = content-stable hash of Dockerfile inputs; identical trees
-  # short-circuit via `docker image inspect`.
+  # Build the CI engram image ONCE per CI run and publish it to the FastRaid
+  # local registry (LOCAL_REGISTRY, :5001) so EVERY downstream runner can pull
+  # it. The isolated runner pool is multi-host (runner-1..runner-N), each with
+  # its OWN docker daemon — the old "single `docker tag` is visible to every
+  # downstream runner" assumption only held when prebuild and the e2e consumer
+  # happened to land on the same host. When they didn't, the consumer's
+  # `up --no-build` found no local image, fell back to pulling the bare
+  # `engram-ci:<hash>` tag from Docker Hub, and the backend never booted (every
+  # e2e test then erroring with "connection refused"). Publishing to :5001 —
+  # the same push-capable registry the ci-pass/ci-e2e-pass markers already use —
+  # makes the image host-independent. Image tag = content-stable hash of
+  # Dockerfile inputs; identical trees short-circuit via a registry HEAD probe.
   prebuild-ci-image:
     needs: fingerprint
     # Image consumed by e2e-clerk (any trigger, gated on e2e-cache-hit) and
@@ -316,12 +323,23 @@ jobs:
             mix.exs mix.lock \
             config lib priv frontend \
             | sha256sum | cut -c1-12)
-          IMAGE="engram-ci:${HASH}"
+          # Registry-qualified ref so any runner can pull it. LOCAL_REGISTRY is
+          # hard-set at the workflow level (:5001); guard anyway so a misconfig
+          # degrades to the legacy bare tag (same-host-only) instead of
+          # emitting a malformed `/engram-ci:...` ref.
+          if [ -n "${LOCAL_REGISTRY:-}" ]; then
+            IMAGE="${LOCAL_REGISTRY}/engram-ci:${HASH}"
+          else
+            echo "::warning::LOCAL_REGISTRY unset — falling back to local-only tag (cross-runner pulls will fail)"
+            IMAGE="engram-ci:${HASH}"
+          fi
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
-          echo "Image tag: $IMAGE"
+          echo "Image: $IMAGE"
 
-      - name: Build image (skip if already cached on this daemon)
+      - name: Build + push CI image (skip if already in registry)
         env:
+          HASH: ${{ steps.tag.outputs.hash }}
           IMAGE: ${{ steps.tag.outputs.image }}
           # Use buildx's plain progress writer instead of the fancy tty printer.
           # The latter races on `--load`/LoadImage: a progress goroutine writes
@@ -330,14 +348,35 @@ jobs:
           # such goroutine.
           BUILDKIT_PROGRESS: plain
         run: |
-          if docker image inspect "$IMAGE" >/dev/null 2>&1; then
-            echo "::notice::Image $IMAGE already cached locally — skipping build"
-            exit 0
+          # Already published for this exact tree? Reuse — the registry is the
+          # cross-host source of truth, so probe IT (not the local daemon, which
+          # only reflects what this one runner happens to have built before).
+          if [ -n "${LOCAL_REGISTRY:-}" ]; then
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -I \
+              "http://${LOCAL_REGISTRY}/v2/engram-ci/manifests/${HASH}" || true)
+            if [ "$CODE" = "200" ]; then
+              echo "::notice::Image $IMAGE already in registry — skipping build+push"
+              exit 0
+            fi
           fi
-          ENGRAM_CI_IMAGE="$IMAGE" \
-            docker compose -f docker-compose.ci.yml build engram
-          docker image inspect "$IMAGE" >/dev/null
-          echo "Built and tagged $IMAGE"
+
+          # Build locally only if this daemon doesn't already have the layers.
+          IMAGE_LOCAL="engram-ci:${HASH}"
+          if ! docker image inspect "$IMAGE_LOCAL" >/dev/null 2>&1; then
+            ENGRAM_CI_IMAGE="$IMAGE_LOCAL" \
+              docker compose -f docker-compose.ci.yml build engram
+            docker image inspect "$IMAGE_LOCAL" >/dev/null
+          fi
+
+          # Publish so every runner can pull it. When LOCAL_REGISTRY is unset
+          # (degraded mode), IMAGE == IMAGE_LOCAL and there is nothing to push.
+          if [ "$IMAGE" != "$IMAGE_LOCAL" ]; then
+            docker tag "$IMAGE_LOCAL" "$IMAGE"
+            docker push "$IMAGE"
+            echo "Pushed $IMAGE"
+          else
+            echo "::warning::No registry — $IMAGE stays local to this runner"
+          fi
 
   # Compile Elixir code ONCE in both :dev and :test envs, cache deps and
   # _build artifacts. Downstream jobs (unit-tests, lint, e2e-browser) all
@@ -644,10 +683,15 @@ jobs:
             # Clean up stale CI collection on SlowRaid Qdrant before starting
             curl -sf -X DELETE "http://10.0.20.201:6333/collections/${QDRANT_COLLECTION}" > /dev/null 2>&1 || true
 
-            # Image was already built by the `prebuild-ci-image` job.
+            # Pull the image `prebuild-ci-image` published to the FastRaid
+            # registry — this runner may be a different host than the one that
+            # built it. Explicit pull (vs relying on compose's pull-on-missing)
+            # keeps the failure legible: a registry miss fails here with the
+            # real ref instead of a confusing Docker Hub denial during `up`.
+            docker pull "$ENGRAM_CI_IMAGE"
             # ENGRAM_CI_IMAGE pins docker-compose.ci.yml's `image:` to that
-            # exact tag. `--no-build` makes startup fail loudly if the tag
-            # is missing (regression detector vs a silent rebuild).
+            # exact tag. `--no-build` keeps startup honest — never a silent
+            # rebuild; the image must already exist (now pulled above).
             docker compose -f docker-compose.ci.yml -p "$CI_PROJECT" up -d --no-build --wait
 
             # Quick verification — compose --wait already confirmed healthcheck,
@@ -936,8 +980,12 @@ jobs:
           # Prune dangling images + volumes to reclaim disk
           docker image prune -f 2>/dev/null || true
           docker volume prune -f 2>/dev/null || true
-          # Keep only the 3 most recent engram-ci cache tags
-          docker images --format '{{.Repository}}:{{.Tag}}' --filter "reference=engram-ci:*" \
+          # Keep only the 3 most recent engram-ci cache tags. Match BOTH the
+          # bare local build tag (engram-ci:<hash>) and the registry-qualified
+          # tag the e2e jobs now pull (${LOCAL_REGISTRY}/engram-ci:<hash>) —
+          # otherwise the pulled copies accumulate unbounded on each runner.
+          docker images --format '{{.Repository}}:{{.Tag}}' \
+            --filter "reference=engram-ci:*" --filter "reference=*/engram-ci:*" \
             | tail -n +4 | xargs -r docker rmi 2>/dev/null || true
           # Clean up ci-artifacts and stale Bun native cache files
           rm -rf ci-artifacts/
@@ -1160,6 +1208,9 @@ jobs:
           CI_PG_PORT: ${{ steps.ports.outputs.pg_port }}
         run: |
           docker compose -f docker-compose.ci-database.yml -p "$CI_PROJECT" down -v --remove-orphans 2>/dev/null || true
+          # Pull the prebuilt image from the FastRaid registry — this runner
+          # may differ from the host that built it (see prebuild-ci-image).
+          docker pull "$ENGRAM_CI_IMAGE"
           # --no-build: reuse the image the prebuild-ci-image job already built.
           docker compose -f docker-compose.ci-database.yml -p "$CI_PROJECT" up -d --no-build --wait
 
@@ -2084,9 +2135,12 @@ jobs:
           # Clean up stale Qdrant collection
           curl -sf -X DELETE "http://10.0.20.201:6333/collections/${QDRANT_COLLECTION}" > /dev/null 2>&1 || true
 
-          # Image was already built by `prebuild-ci-image`. ENGRAM_CI_IMAGE
-          # pins docker-compose.ci.yml's `image:` to that tag and --no-build
-          # fails loudly if missing instead of silently rebuilding.
+          # Pull the prebuilt image from the FastRaid registry — this runner
+          # may differ from the host that built it (see prebuild-ci-image).
+          docker pull "$ENGRAM_CI_IMAGE"
+          # ENGRAM_CI_IMAGE pins docker-compose.ci.yml's `image:` to that tag;
+          # --no-build keeps startup honest (no silent rebuild) now that the
+          # image is guaranteed present via the pull above.
           docker compose -f docker-compose.ci.yml -f docker-compose.ci-local.yml \
             -p "$CI_PROJECT" up -d --no-build --wait
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,9 +18,11 @@ name: engram-ci
 
 services:
   engram:
-    # Pre-built tag from the CI `prebuild-ci-image` job — all e2e-* jobs
-    # share this image via the runner VM's shared docker daemon. Local dev
-    # falls back to `engram-ci:local` (built by `docker compose build`).
+    # Registry-qualified tag published by the CI `prebuild-ci-image` job
+    # (`${LOCAL_REGISTRY}/engram-ci:<hash>` on FastRaid :5001). The e2e jobs
+    # `docker pull` it before `up --no-build`, so it works regardless of which
+    # runner host they land on — the pool is multi-daemon, not shared. Local
+    # dev falls back to `engram-ci:local` (built by `docker compose build`).
     image: ${ENGRAM_CI_IMAGE:-engram-ci:local}
     build:
       context: .

--- a/docs/context/docker-build-cache-pitfalls.md
+++ b/docs/context/docker-build-cache-pitfalls.md
@@ -63,6 +63,7 @@ The extra ~1 minute of compile time is worth the guarantee that the released ima
 - BuildKit cache mount IDs (`id=mix-build`) are shared across repositories on the same runner. A different project's build could theoretically pollute the mount — one more reason to avoid `_build` caching.
 - When debugging, `gh run view --log` truncates BuildKit output. Use `gh run download` and inspect `ci-*-stack.log` for the full build log.
 - The only safe cache for Elixir releases is `deps` (compiled dependencies). App beams must be rebuilt from source every time.
+- **Cross-runner image distribution (2026-06-13):** the `engram-ci:<hash>` image the `prebuild-ci-image` job builds is NOT visible to other runners just because they're "on the same VM" — the isolated pool is multi-host (runner-1..runner-N), each with its own docker daemon. The original design `docker tag`'d the image locally and the e2e jobs ran `up --no-build`; when prebuild and the e2e consumer landed on different hosts, compose found no local image, tried to pull bare `engram-ci:<hash>` from Docker Hub, got `pull access denied / No such image`, and the backend container never started — surfacing as EVERY e2e test erroring with `Connection refused` to the API. Fix: prebuild pushes `${LOCAL_REGISTRY}/engram-ci:<hash>` to the FastRaid registry (:5001, the same one the ci-pass markers use) and the e2e bring-up steps `docker pull` it first. Symptom to recognize in `docker-compose.log`: it's EMPTY (engram never ran) and `ci-*-stack.log` shows `No such image: engram-ci:<hash>`.
 
 ## References
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.413",
+      version: "0.5.414",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Root cause (concrete instance of the engram-infra#508 "runner instability")

The isolated runner pool is **multi-host** (runner-1…runner-N), each with its own docker daemon. But `prebuild-ci-image` built `engram-ci:<hash>` as a **bare local tag** and the e2e jobs ran `docker compose up --no-build` on the assumption — stated verbatim in the old comment — that "all e2e-* jobs share the same docker daemon on this VM."

When prebuild and an e2e consumer landed on **different** hosts (e.g. prebuild on runner-9, e2e-clerk on runner-1), the consumer's daemon had no such image, compose fell back to pulling the bare `engram-ci:<hash>` tag from Docker Hub → `pull access denied / No such image` → the **backend container never started**. Every e2e test then errored with `Connection refused` to the API. It passed only when the two jobs happened to share a host, which is why it read as intermittent "flake."

**Diagnosis trail:** `docker-compose.log` is empty (engram never ran); `ci-*-stack.log` shows `No such image: engram-ci:<hash>`; prebuild log shows `already cached locally — skipping build` on one runner while e2e fails on another.

## Fix

- `prebuild-ci-image` now tags + pushes `${LOCAL_REGISTRY}/engram-ci:<hash>` to the FastRaid registry (`:5001` — the same push-capable registry the `ci-pass` / `ci-e2e-pass` markers already use), and its skip-guard probes the **registry** (`HEAD /v2/engram-ci/manifests/<hash>`) instead of the local daemon. Job output `image` is the registry-qualified ref.
- The three e2e bring-ups (`e2e-clerk`, `storage-database`, `e2e-local`) `docker pull "$ENGRAM_CI_IMAGE"` before `up --no-build`, so they work on any runner host. `--no-build` stays (no silent rebuilds).
- Image cleanup extended to GC the registry-qualified copies too (`reference=*/engram-ci:*`).
- Degrades to the legacy local-only tag if `LOCAL_REGISTRY` is unset.

## Validation

This PR edits `.github/workflows/verify.yml` + `docker-compose.ci.yml`, both in the fingerprint hash → it busts the e2e cache, so `prebuild-ci-image` + `e2e-clerk` + `e2e-local` all **run and exercise the new pull-from-registry path** on this PR. A green e2e-clerk here IS the proof.

No migration. Root cause + recognition tips recorded in `docs/context/docker-build-cache-pitfalls.md`.

Refs engram-infra#508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)