### PR TITLE
fix(release): fail-loud schema-baseline guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,18 @@ multi-phase migrations are now safe in a single migrate:
 
 Phase labels still apply for any column-type change or destructive DDL.
 
+## Baseline / `structure.sql` regen requires a wipe at EVERY env
+
+A baseline regen (rewriting `priv/repo/structure.sql` + `baseline.exs`) only
+takes effect on an EMPTY schema — on an existing DB the baseline row in
+`schema_migrations` makes it a silent no-op. So such a change MUST be paired
+with an actual DB wipe/recreate at every env, and the infra step must be a
+**taint + recreate**, never an in-place engine upgrade that preserves data. An
+in-place PG17→PG18 bump is exactly what stranded prod on legacy integer PKs on
+2026-06-11 (see `docs/context/pg18-uuidv7-prod-crashloop-2026-06-11.md`).
+`Engram.Release.verify_schema_baseline/0` now fails the deploy loud if this is
+ever missed again.
+
 ## The `# safety_assured:` escape
 
 Top-of-file magic comment, justification required:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,4 +30,11 @@ fi
 /app/bin/engram eval "Engram.Release.prepare_database()"
 /app/bin/engram eval "Engram.Release.migrate()"
 
+# Fail-loud schema-baseline guard. If the DB silently kept its legacy
+# integer-PK shape (an in-place engine upgrade that skipped the baseline
+# replay — the 2026-06-11 incident), this exits non-zero with an actionable
+# message HERE, instead of the BEAM crash-looping on a cryptic Ecto.UUID
+# load error during boot. set -e turns the non-zero eval into a clean abort.
+/app/bin/engram eval "Engram.Release.verify_schema_baseline()"
+
 exec "$@"

--- a/lib/engram/release.ex
+++ b/lib/engram/release.ex
@@ -186,6 +186,53 @@ defmodule Engram.Release do
     end
   end
 
+  @doc """
+  Fail-loud schema-baseline guard. Invoked from `entrypoint.sh` AFTER
+  `migrate/0` and BEFORE the app server boots.
+
+  If a database silently kept its legacy integer-PK shape — an in-place engine
+  upgrade that preserved data and skipped the wreck-and-recreate baseline replay
+  (the 2026-06-11 PG18/uuidv7 incident) — this raises so the deploy fails at the
+  migrate step with a one-line diagnosis, instead of the app crash-looping on a
+  cryptic `cannot load 1 as type Ecto.UUID` error during `Legal.Seeder`.
+
+  No-op (`:ok`) on a healthy uuid schema (including right after a successful
+  `reset_baseline/0`, which heals the state first) or an absent sentinel table.
+  """
+  def verify_schema_baseline do
+    _ = load_app()
+
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &verify_schema_baseline!/1)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Raises when `table`'s `id` is a legacy integer PK (the drift `reset_baseline/0`
+  heals), otherwise returns `:ok`. `table` defaults to the `terms_versions`
+  sentinel. Public for testing.
+  """
+  def verify_schema_baseline!(repo, table \\ "terms_versions") do
+    if legacy_integer_pk?(repo, table) do
+      raise """
+      Schema baseline check FAILED: `#{table}.id` is a legacy integer column, but \
+      the code expects a uuid PK (PG18/uuidv7 baseline). This database predates the \
+      uuidv7 cutover and was never wiped/recreated — an in-place engine upgrade \
+      preserves data and silently skips the baseline replay (the 2026-06-11 incident).
+
+      Remedy: deploy once with ENGRAM_DB_RESET_BASELINE=true (DESTROYS ALL DATA, \
+      replays the uuid baseline), or write an ALTER ... TYPE uuid data migration if \
+      the data must be kept.
+
+      See docs/context/pg18-uuidv7-prod-crashloop-2026-06-11.md\
+      """
+    end
+
+    :ok
+  end
+
   defp do_prepare_database(repo) do
     repo.query!(@create_engram_app_role_sql, [])
     repo.query!(@grant_schema_usage_sql, [])

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.423",
+      version: "0.5.424",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/release_test.exs
+++ b/test/engram/release_test.exs
@@ -29,4 +29,34 @@ defmodule Engram.ReleaseTest do
       refute Release.legacy_integer_pk?(Repo, "table_that_does_not_exist")
     end
   end
+
+  describe "verify_schema_baseline!/2" do
+    test "returns :ok for the current uuid `terms_versions` schema" do
+      assert :ok == Release.verify_schema_baseline!(Repo, "terms_versions")
+    end
+
+    test "returns :ok when the sentinel table is absent (fresh DB)" do
+      assert :ok == Release.verify_schema_baseline!(Repo, "table_that_does_not_exist")
+    end
+
+    test "raises an actionable error on a legacy integer-PK table" do
+      Repo.query!("CREATE TABLE baseline_probe_legacy (id bigint NOT NULL)", [])
+
+      err =
+        assert_raise RuntimeError, fn ->
+          Release.verify_schema_baseline!(Repo, "baseline_probe_legacy")
+        end
+
+      # Names the offending column and the documented remedy so the operator
+      # gets a one-line diagnosis instead of a cryptic Ecto.UUID crash-loop.
+      assert err.message =~ "baseline_probe_legacy.id"
+      assert err.message =~ "ENGRAM_DB_RESET_BASELINE"
+    end
+  end
+
+  describe "verify_schema_baseline/0" do
+    test "returns :ok on a healthy uuid schema (all configured repos)" do
+      assert :ok == Release.verify_schema_baseline()
+    end
+  end
 end


### PR DESCRIPTION
## Why

Hardening follow-up to the **2026-06-11 PG18/uuidv7 prod crash-loop** (`docs/context/pg18-uuidv7-prod-crashloop-2026-06-11.md`).

That incident: PR #524's PG18/uuidv7 rework is a wreck-and-recreate baseline, not a data migration — the uuid schema only materializes by replaying `structure.sql` on an empty DB. engram-infra #476 did an **in-place** PG17→PG18 engine upgrade instead of the specced taint+recreate, so prod kept its legacy integer-PK tables while the baseline migration stayed marked-applied. The app then crash-looped on boot:

```
** (ArgumentError) cannot load `1` as type Ecto.UUID for field `id` in schema Engram.Legal.TermsVersion
```

Recovery already shipped (`reset_baseline/0`, #528). **The gap this closes:** when the reset flag is off (every normal deploy), nothing detects the drift — the operator just gets a cryptic `Ecto.UUID` crash-loop with no diagnosis.

## What

- **`Engram.Release.verify_schema_baseline/0`** — called from `entrypoint.sh` **after** `migrate`, **before** the app boots. If the DB silently kept its legacy integer-PK shape, it raises → `set -e` aborts the deploy at the migrate step with an actionable message (names the column + the `ENGRAM_DB_RESET_BASELINE` remedy + the context-doc), instead of a BEAM crash-loop.
- Reuses the existing `legacy_integer_pk?/2` sentinel. **Flag-agnostic** — asserts actual post-migrate state, so it no-ops right after a successful `reset_baseline/0` and on healthy uuid schemas / absent table.
- `AGENTS.md`: a baseline/`structure.sql` regen requires a wipe + **taint-recreate** at every env, never an in-place engine upgrade.

## Tests (TDD)

`test/engram/release_test.exs` — uuid `:ok`, absent-table `:ok`, integer-drift **raises** (asserts message names column + `ENGRAM_DB_RESET_BASELINE`), `/0` integration `:ok`. Watched RED→GREEN. Local verify on PG18: format, Credo, `--warnings-as-errors`, `sh -n entrypoint.sh`, 7/7 green. No migration files touched.

Design spec: `engram-workspace` PR (companion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)