### PR TITLE
fix(ci): reap orphan Clerk e2e users hourly, not daily

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -18,7 +18,7 @@ name: cron
 
 on:
   schedule:
-    - cron: '30 6 * * *'    # clerk-orphans            (daily 06:30 UTC)
+    - cron: '30 * * * *'    # clerk-orphans            (hourly, :30)
     - cron: '0 3 * * 0'     # runner-cleanup           (Sun 03:00 UTC)
     - cron: '0 4 * * 1'     # obsidian-update          (Mon 04:00 UTC)
     - cron: '17 13 * * 1'   # frontend-major-updates   (Mon 13:17 UTC)
@@ -52,11 +52,15 @@ jobs:
   # (issue #160), so users from a run cancelled / OOM-killed before its
   # session_cleanup fired would otherwise accumulate forever. This cron
   # mops them up — with a 1h age filter to avoid racing in-flight runs.
-  # Once-daily off-peak; per-run pytest fixture handles the fresh-user path
-  # so hourly was overkill.
+  # Hourly (:30): the Clerk dev instance caps at 100 users, and a heavy-CI
+  # burst (release day, an e2e-rerun storm) can mint 100+ e2e-* users within
+  # a few hours — faster than a once-daily sweep clears them, exhausting the
+  # quota and 403'ing every Clerk-auth e2e run (2026-06-13). Hourly bounds the
+  # standing orphan count to ~1-2h of churn; the 1h age filter still protects
+  # in-flight runs. (Was once-daily 2026-06-02..06-13 — too sparse for bursts.)
   clerk-orphans:
     if: |
-      github.event.schedule == '30 6 * * *'
+      github.event.schedule == '30 * * * *'
       || github.event.inputs.task == 'clerk-orphans'
     runs-on: [self-hosted, linux, x64, isolated]
     permissions:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.416",
+      version: "0.5.417",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What actually happened (corrects Engram#558)

The Clerk Orphan Reaper was **not** dead. It's a job in the consolidated `cron.yml` (which replaced the standalone `clerk-orphans.yml` around 2026-06-02 — that consolidation is the "last run 2026-06-02" I mis-read as a stoppage). The `cron` workflow fires daily and the reaper job has been **successfully deleting users** (e.g. the 06-12 run reaped dozens).

The real defect is **cadence**. The consolidation changed the reaper from hourly → **once-daily** with the note "hourly was overkill." But the Clerk dev instance caps at **100 users total**, and a heavy-CI burst — release day plus an e2e-rerun storm (exactly 2026-06-13 during the sync-protocol-rev landing) — mints 100+ `e2e-*` users within a few hours. That blows the quota *before* the next daily sweep, and every Clerk-auth e2e run starts failing with `403 api.clerk.dev/v1/users`. I had to manually reap 81 orphans to recover tonight.

## Fix

Restore the original **hourly** cadence (`30 * * * *`). The `--older-than 1h` age filter is unchanged, so in-flight runs are still protected (issue #160); hourly just bounds the standing orphan count to ~1–2h of churn instead of ~24h. Manual dispatch is unchanged: `gh workflow run cron.yml -f task=clerk-orphans`.

No code change; cron schedule + matching `if:` + the stale comment only. Version bump 0.5.416.

Closes #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)