### PR TITLE
fix(config): gate rate-limit override on CI + fail-closed saas CORS/WS origins

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -229,10 +229,24 @@ if config_env() != :test do
   end
 end
 
-# Rate limit override for CI E2E tests (only effective when CI=true).
-# Production deploys never set CI=true, so this is unreachable in prod.
-if override = System.get_env("RATE_LIMIT_AUTH_OVERRIDE") do
-  config :engram, :rate_limit_auth_override, String.to_integer(override)
+# Rate-limit override for CI/E2E stacks only, gated on CI=true so a stray
+# RATE_LIMIT_AUTH_OVERRIDE in a prod task def can never weaken the auth
+# limiter. CI stacks (docker-compose.ci*.yml, the Playwright runner) set
+# CI=true; production never does. See Engram.RuntimeConfig.
+case Engram.RuntimeConfig.rate_limit_auth_override(&System.get_env/1) do
+  {:ok, limit} ->
+    config :engram, :rate_limit_auth_override, limit
+
+  {:ignored, raw} ->
+    require Logger
+
+    Logger.warning(
+      "RATE_LIMIT_AUTH_OVERRIDE=#{raw} ignored: the auth rate-limit override " <>
+        "is only honored when CI=true."
+    )
+
+  :none ->
+    :ok
 end
 
 # Clerk auth (only required when AUTH_PROVIDER=clerk)
@@ -613,12 +627,22 @@ if config_env() == :prod do
     secret_key_base: secret_key_base
 
   # CORS and WebSocket origin — only lock down when PHX_HOST is explicitly set.
-  # Without it (CI, local dev), defaults apply: CORS allows "*", WS allows all.
+  # Without it, defaults apply: CORS allows "*", WS allows all. That permissive
+  # default is fine for self-host (single-tenant, same-origin), but a saas
+  # deploy (AUTH_PROVIDER=clerk) MUST have PHX_HOST or it would answer
+  # Access-Control-Allow-Origin: * and accept any WS Origin — so we fail closed
+  # there (see Engram.RuntimeConfig.validate_saas_origins!/2).
   # See Engram.HostOrigins for parsing rules (CSV, scheme expansion, dedup).
   #
   # ENGRAM_SAAS_FRONTEND_ORIGINS appends extra origins (comma-separated) for the
   # Cloudflare Pages saas frontend at app.engram.page + its preview deploys at
   # *.engram-frontend.pages.dev. Unset on selfhost (same-origin) → no-op.
+  Engram.RuntimeConfig.validate_saas_origins!(
+    auth_provider,
+    phx_hosts,
+    System.get_env("CI") == "true"
+  )
+
   if phx_hosts do
     extra_origins =
       case System.get_env("ENGRAM_SAAS_FRONTEND_ORIGINS") do

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -79,6 +79,12 @@ services:
       # well above the prod default 10 req/60s/IP from the test runner's
       # single source IP — collisions yield flaky 429 "rate_limited" failures.
       # Mirrors the override in docker-compose.ci-local.yml.
+      # CI=true gates the override on (runtime.exs / Engram.RuntimeConfig): the
+      # backend only honors RATE_LIMIT_AUTH_OVERRIDE when CI=true, so a stray
+      # copy of this var can never weaken the limiter in prod. Inherited by the
+      # ci-local overlay. (The Playwright e2e job runs in the GitHub runner,
+      # which sets CI=true automatically.)
+      CI: "true"
       RATE_LIMIT_AUTH_OVERRIDE: "1000"
       # Free-tier launch test_72_cancel_to_free_overlimit signs a synthetic
       # subscription.canceled webhook with this fixed secret so the e2e

--- a/lib/engram/runtime_config.ex
+++ b/lib/engram/runtime_config.ex
@@ -1,0 +1,65 @@
+defmodule Engram.RuntimeConfig do
+  @moduledoc """
+  Pure decision helpers for `config/runtime.exs`.
+
+  Boot-time config is awkward to test (it runs once, at release start, and
+  mutates global app env). Keeping the *decisions* here — as pure functions
+  over an injected `getenv` — lets the rules be unit-tested while `runtime.exs`
+  stays a thin wiring layer. Mirrors `Engram.HostOrigins`, which `runtime.exs`
+  already calls the same way.
+  """
+
+  @doc """
+  Decides whether the `RATE_LIMIT_AUTH_OVERRIDE` env var should loosen the auth
+  rate limit.
+
+  The override exists only to stop CI/E2E stacks from 429-ing themselves; it
+  must never weaken the limiter in production. Production task definitions
+  never set `CI=true`, so gating on it makes a stray `RATE_LIMIT_AUTH_OVERRIDE`
+  (e.g. copy-pasted from a CI compose file) a no-op in prod.
+
+    * `{:ok, integer}`  — present and `CI=true`: apply it.
+    * `{:ignored, raw}` — present but not in CI: do NOT apply; the caller logs.
+    * `:none`           — absent or blank.
+
+  `getenv` is a `(String.t() -> String.t() | nil)` (e.g. `&System.get_env/1`).
+  """
+  @spec rate_limit_auth_override((String.t() -> String.t() | nil)) ::
+          {:ok, integer()} | {:ignored, String.t()} | :none
+  def rate_limit_auth_override(getenv) when is_function(getenv, 1) do
+    case getenv.("RATE_LIMIT_AUTH_OVERRIDE") do
+      nil -> :none
+      "" -> :none
+      raw -> if getenv.("CI") == "true", do: {:ok, String.to_integer(raw)}, else: {:ignored, raw}
+    end
+  end
+
+  @doc """
+  Guards against a saas deploy booting with permissive CORS / WebSocket origin
+  checks.
+
+  CORS + `check_origin` are only locked down when `PHX_HOST` is set; without it
+  both fall back to allow-all. That permissive default is fine for self-host
+  (single-tenant, same-origin), but a saas deploy (`AUTH_PROVIDER=clerk`) MUST
+  have `PHX_HOST` — otherwise the multi-tenant API answers `Access-Control-
+  Allow-Origin: *` and the socket accepts any Origin. Fail closed (refuse to
+  boot) instead of silently open.
+
+  `ci?` is `true` in CI/E2E stacks: the `e2e-clerk` stack legitimately runs
+  Clerk auth on localhost without `PHX_HOST` (and needs the permissive WS
+  default so the Obsidian `app://` origin isn't rejected), so the guard is
+  skipped there. Production never sets `CI=true`, so prod protection is intact.
+
+  Returns `:ok`, or raises when `auth_provider` is `:clerk`, `phx_hosts` is
+  falsy, and `ci?` is `false`.
+  """
+  @spec validate_saas_origins!(atom(), term(), boolean()) :: :ok
+  def validate_saas_origins!(_auth_provider, _phx_hosts, true = _ci?), do: :ok
+
+  def validate_saas_origins!(:clerk, phx_hosts, _ci?) when phx_hosts in [nil, false] do
+    raise "PHX_HOST is required when AUTH_PROVIDER=clerk (saas): without it, CORS " <>
+            "and WebSocket origin checks fall back to permissive allow-all defaults."
+  end
+
+  def validate_saas_origins!(_auth_provider, _phx_hosts, _ci?), do: :ok
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.418",
+      version: "0.5.420",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/runtime_config_test.exs
+++ b/test/engram/runtime_config_test.exs
@@ -1,0 +1,57 @@
+defmodule Engram.RuntimeConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.RuntimeConfig
+
+  defp getenv(map), do: fn key -> Map.get(map, key) end
+
+  describe "rate_limit_auth_override/1" do
+    test "applies the override only when CI=true" do
+      env = getenv(%{"RATE_LIMIT_AUTH_OVERRIDE" => "1000", "CI" => "true"})
+      assert RuntimeConfig.rate_limit_auth_override(env) == {:ok, 1000}
+    end
+
+    test "ignores the override when CI is not true (e.g. a stray prod env var)" do
+      env = getenv(%{"RATE_LIMIT_AUTH_OVERRIDE" => "1000"})
+      assert RuntimeConfig.rate_limit_auth_override(env) == {:ignored, "1000"}
+    end
+
+    test "ignores the override when CI is set to something other than true" do
+      env = getenv(%{"RATE_LIMIT_AUTH_OVERRIDE" => "1000", "CI" => "false"})
+      assert RuntimeConfig.rate_limit_auth_override(env) == {:ignored, "1000"}
+    end
+
+    test "returns :none when the override is absent" do
+      assert RuntimeConfig.rate_limit_auth_override(getenv(%{"CI" => "true"})) == :none
+    end
+
+    test "returns :none when the override is blank" do
+      env = getenv(%{"RATE_LIMIT_AUTH_OVERRIDE" => "", "CI" => "true"})
+      assert RuntimeConfig.rate_limit_auth_override(env) == :none
+    end
+  end
+
+  describe "validate_saas_origins!/3" do
+    test "raises when a Clerk (saas) deploy has no PHX_HOST and is not CI" do
+      assert_raise RuntimeError, ~r/PHX_HOST/, fn ->
+        RuntimeConfig.validate_saas_origins!(:clerk, nil, false)
+      end
+    end
+
+    test "does NOT raise in CI (the e2e-clerk stack runs Clerk auth on localhost without PHX_HOST)" do
+      assert RuntimeConfig.validate_saas_origins!(:clerk, nil, true) == :ok
+    end
+
+    test "passes for a Clerk deploy with PHX_HOST set" do
+      assert RuntimeConfig.validate_saas_origins!(
+               :clerk,
+               %{origins: ["https://app.engram.page"]},
+               false
+             ) == :ok
+    end
+
+    test "passes for self-host (local auth) without PHX_HOST — same-origin is fine" do
+      assert RuntimeConfig.validate_saas_origins!(:local, nil, false) == :ok
+    end
+  end
+end


### PR DESCRIPTION
## Prod config hardening (audit findings #6 + #18)

Two low-severity but real prod-config fail-open issues from the security audit. Logic lives in a new testable `Engram.RuntimeConfig` helper (mirrors `HostOrigins`); `runtime.exs` stays thin wiring.

### #6 — `RATE_LIMIT_AUTH_OVERRIDE` honored in prod
The override was applied whenever the env var was present, despite the comment claiming "only effective when `CI=true` / unreachable in prod" — the code never checked `CI`. A stray copy (e.g. from a CI compose file) into a prod task def would silently weaken the auth limiter.

**Fix:** gated on `CI=true` via `RuntimeConfig.rate_limit_auth_override/1`; logs a warning if the var is set without `CI`. The two CI compose stacks now set `CI: "true"` so the override still applies in e2e (the Playwright job already runs in the GitHub runner where `CI=true` is automatic). **e2e CI itself validates this** — if propagation were wrong, `e2e-local`/`e2e-clerk` would 429 and fail before merge.

### #18 — CORS/WS fail *open* when `PHX_HOST` unset
CORS + `check_origin` only lock down when `PHX_HOST` is set; otherwise both fall back to allow-all (`ACAO: *`, socket accepts any Origin) with no boot failure. That's fine for **self-host** (single-tenant, same-origin — it legitimately runs the prod release without `PHX_HOST`), but a **saas** deploy (`AUTH_PROVIDER=clerk`) booting without `PHX_HOST` would be wide open.

**Fix:** `RuntimeConfig.validate_saas_origins!/2` raises for a Clerk deploy with no `PHX_HOST` (fail closed). Self-host (`auth_provider` defaults to `:local`) is unaffected — verified against the `AUTH_PROVIDER` default at `runtime.exs`.

### Tests
- `RuntimeConfigTest`: override applied only on `CI=true`; ignored otherwise; `:none` when absent/blank. Saas guard raises for `:clerk` + no host, passes for `:clerk` + host and for `:local` + no host.
- Full suite: **2650 tests, 0 failures**. Compose YAML validated.

Prod (`app.engram.page`) and staging both set `PHX_HOST`, so the guard only triggers on genuine misconfiguration; self-host is explicitly exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
