### PR TITLE
fix(obs): exempt /metrics from host-rewrite unknown-host 410

### DIFF
--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -90,9 +90,19 @@ defmodule EngramWeb.Plugs.HostRewrite do
   # them, tasks go unhealthy, and the deployment circuit breaker rolls back.
   @health_paths ~w(/api/health /api/health/deep)
 
+  # Same any-host requirement: the Grafana Agent sidecar scrapes the PromEx
+  # endpoint as `curl localhost:4000/metrics` (Host = localhost, an unknown
+  # host). Without this exemption reject_unknown_hosts=true 410s every scrape
+  # → up=0 → no app/BEAM metrics. The route stays bearer-guarded by
+  # EngramWeb.Plugs.MetricsAuth, so passing it through here is safe.
+  @metrics_path "/metrics"
+
   defp handle_unknown_host(conn, opts) do
     cond do
       conn.request_path in @health_paths ->
+        conn
+
+      conn.request_path == @metrics_path ->
         conn
 
       opts[:reject_unknown_hosts] && conn.host not in opts[:allowed_extra_hosts] ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.417",
+      version: "0.5.418",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -256,6 +256,25 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
       refute out.halted
     end
 
+    # The Grafana Agent sidecar scrapes the bearer-guarded PromEx endpoint as
+    # `curl localhost:4000/metrics` (Host = localhost), which is neither
+    # api_host nor mcp_host. Without an exemption, reject_unknown_hosts=true
+    # 410s the scrape → up=0 → no app/BEAM metrics. /metrics must pass through
+    # on ANY host (MetricsAuth still guards it).
+    test "with reject_unknown_hosts=true, /metrics passes through on localhost (agent scrape)" do
+      opts =
+        HostRewrite.init(
+          api_host: "api.engram.page",
+          mcp_host: "mcp.engram.page",
+          reject_unknown_hosts: true
+        )
+
+      conn = conn(:get, "/metrics") |> Map.put(:host, "localhost")
+      out = HostRewrite.call(conn, opts)
+
+      refute out.halted
+    end
+
     test "with reject_unknown_hosts=true, non-health /api path on unknown host still 410s" do
       opts =
         HostRewrite.init(


### PR DESCRIPTION
## Why

Prod app/BEAM metrics (`engram_prom_ex_*`) have not flowed since ~2026-06-11 — `up{job="prometheus.scrape.engram_app"}` = **0** on every task. Diagnosed against prod (read-only): the Grafana Agent (Alloy) sidecar scrapes the PromEx endpoint as `curl localhost:4000/metrics` (Host = `localhost`). In saas prod `reject_unknown_hosts=true`, and `HostRewrite.handle_unknown_host` only exempts `@health_paths` (`/api/health`, `/api/health/deep`) — so `/metrics` on the `localhost` Host returns **410 Gone**, Prometheus marks the target `up=0`, and no application/BEAM metrics are ingested. The ECS health check kept the task green only because `/api/health` *is* exempted, which masked the gap (metrics still showed task-count from CloudWatch).

This broke the moment the Alloy localhost scrape and saas-only host-rewrite started coexisting (~06-11). Separate from the Loki logging gap (engram-infra#518) and the schema guard (#561).

## Fix

Exempt `/metrics` on any host in `handle_unknown_host`, same category as the health probes (internal endpoints that must answer regardless of Host). The route stays bearer-guarded by `EngramWeb.Plugs.MetricsAuth`, so passing it through host-rewrite is safe — no new exposure.

## Test (TDD)

`host_rewrite_test.exs`: with `reject_unknown_hosts=true`, `/metrics` on `localhost` now passes through (was 410). Watched RED→GREEN. Mirrors the existing `/api/health` exemption tests. Full host_rewrite unit + integration suites green; format/Credo/`--warnings-as-errors` clean.

After deploy: `up{job="prometheus.scrape.engram_app"}` → 1 and `engram_prom_ex_*` ingestion resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)