### PR TITLE
fix(ci): CI override for the pre-auth rate limiter — kills the e2e 429 flake

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2351,7 +2351,7 @@ jobs:
           # Same for PreAuthRateLimit (vault pipeline, default 600 req/60s):
           # browser suites that create notes burst /api/notes past it → 429s.
           # CI=true is set automatically by the GitHub runner, so it's honored.
-          PRE_AUTH_RATE_LIMIT_OVERRIDE: "10000"
+          PRE_AUTH_RATE_LIMIT_OVERRIDE: "100000"
           # Production self-host default is invite_only; pin "open" so the
           # Playwright fixtures (which register multiple users) don't 403 with
           # invite_required. Matches docker-compose.ci-local.yml for e2e-local.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2348,6 +2348,10 @@ jobs:
           # past it on /api/auth/register → 429s. Matches the value already
           # set in docker-compose.ci-local.yml for the e2e-local job.
           RATE_LIMIT_AUTH_OVERRIDE: "1000"
+          # Same for PreAuthRateLimit (vault pipeline, default 600 req/60s):
+          # browser suites that create notes burst /api/notes past it → 429s.
+          # CI=true is set automatically by the GitHub runner, so it's honored.
+          PRE_AUTH_RATE_LIMIT_OVERRIDE: "10000"
           # Production self-host default is invite_only; pin "open" so the
           # Playwright fixtures (which register multiple users) don't 403 with
           # invite_required. Matches docker-compose.ci-local.yml for e2e-local.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -249,6 +249,27 @@ case Engram.RuntimeConfig.rate_limit_auth_override(&System.get_env/1) do
     :ok
 end
 
+# Pre-auth (vault-pipeline) rate-limit override for CI/E2E stacks only, gated on
+# CI=true. Mirrors RATE_LIMIT_AUTH_OVERRIDE: without it the release build runs
+# EngramWeb.Plugs.PreAuthRateLimit at its 600 req/60s default, which 429s bulk/
+# rapid E2E writes against /api/notes (test_77 bulk-sync, test_78 hash-update).
+# Gating on CI=true keeps the prod 401-loop defense intact.
+case Engram.RuntimeConfig.pre_auth_rate_limit_override(&System.get_env/1) do
+  {:ok, limit} ->
+    config :engram, :pre_auth_rate_limit_override, limit
+
+  {:ignored, raw} ->
+    require Logger
+
+    Logger.warning(
+      "PRE_AUTH_RATE_LIMIT_OVERRIDE=#{raw} ignored: the pre-auth rate-limit " <>
+        "override is only honored when CI=true."
+    )
+
+  :none ->
+    :ok
+end
+
 # Clerk auth (only required when AUTH_PROVIDER=clerk)
 # Note: use local variable, not Application.get_env — runtime.exs config
 # is accumulated and not yet applied, so get_env reads stale config.

--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -10,6 +10,9 @@ services:
       CLERK_ISSUER: ""
       # CI tests register many users rapidly from same IP
       RATE_LIMIT_AUTH_OVERRIDE: "1000"
+      # Bulk/rapid E2E writes burst past PreAuthRateLimit's 600 req/60s default
+      # on /api/notes (test_77 bulk-sync, test_78 hash-update). CI=true gated.
+      PRE_AUTH_RATE_LIMIT_OVERRIDE: "10000"
       # Self-host default in production is invite_only; pin "open" here so the
       # API-only e2e fixtures (which register many users) don't need to seed
       # an admin + flip the gate before every test.

--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -12,7 +12,7 @@ services:
       RATE_LIMIT_AUTH_OVERRIDE: "1000"
       # Bulk/rapid E2E writes burst past PreAuthRateLimit's 600 req/60s default
       # on /api/notes (test_77 bulk-sync, test_78 hash-update). CI=true gated.
-      PRE_AUTH_RATE_LIMIT_OVERRIDE: "10000"
+      PRE_AUTH_RATE_LIMIT_OVERRIDE: "100000"
       # Self-host default in production is invite_only; pin "open" here so the
       # API-only e2e fixtures (which register many users) don't need to seed
       # an admin + flip the gate before every test.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -90,7 +90,7 @@ services:
       # defaults to 600 req/60s per bucket — bulk/rapid E2E writes (test_77
       # bulk-sync ~1000 notes, test_78 hash-update) burst past it → flaky 429s.
       # Same CI=true gating as the auth override (runtime.exs).
-      PRE_AUTH_RATE_LIMIT_OVERRIDE: "10000"
+      PRE_AUTH_RATE_LIMIT_OVERRIDE: "100000"
       # Free-tier launch test_72_cancel_to_free_overlimit signs a synthetic
       # subscription.canceled webhook with this fixed secret so the e2e
       # exercises the real verify_signature → upsert_from_paddle_event path

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -86,6 +86,11 @@ services:
       # which sets CI=true automatically.)
       CI: "true"
       RATE_LIMIT_AUTH_OVERRIDE: "1000"
+      # PreAuthRateLimit (the 401-loop defense in front of /api/notes etc.)
+      # defaults to 600 req/60s per bucket — bulk/rapid E2E writes (test_77
+      # bulk-sync ~1000 notes, test_78 hash-update) burst past it → flaky 429s.
+      # Same CI=true gating as the auth override (runtime.exs).
+      PRE_AUTH_RATE_LIMIT_OVERRIDE: "10000"
       # Free-tier launch test_72_cancel_to_free_overlimit signs a synthetic
       # subscription.canceled webhook with this fixed secret so the e2e
       # exercises the real verify_signature → upsert_from_paddle_event path

--- a/lib/engram/runtime_config.ex
+++ b/lib/engram/runtime_config.ex
@@ -27,7 +27,35 @@ defmodule Engram.RuntimeConfig do
   @spec rate_limit_auth_override((String.t() -> String.t() | nil)) ::
           {:ok, integer()} | {:ignored, String.t()} | :none
   def rate_limit_auth_override(getenv) when is_function(getenv, 1) do
-    case getenv.("RATE_LIMIT_AUTH_OVERRIDE") do
+    ci_gated_int_override(getenv, "RATE_LIMIT_AUTH_OVERRIDE")
+  end
+
+  @doc """
+  Decides whether the `PRE_AUTH_RATE_LIMIT_OVERRIDE` env var should loosen the
+  pre-auth (vault-pipeline) rate limit — the 401-loop defense in front of
+  `/api/notes`, `/api/search`, etc. (`EngramWeb.Plugs.PreAuthRateLimit`).
+
+  Same contract and CI-gating as `rate_limit_auth_override/1`: the override only
+  exists so bulk/rapid E2E stacks don't 429 themselves (e.g. `test_77` bulk-sync
+  pushing ~1000 notes through the default 600 req/60s bucket). Gated on `CI=true`
+  so a stray `PRE_AUTH_RATE_LIMIT_OVERRIDE` in a prod task def can never weaken
+  the defense — production never sets `CI=true`.
+
+    * `{:ok, integer}`  — present and `CI=true`: apply it.
+    * `{:ignored, raw}` — present but not in CI: do NOT apply; the caller logs.
+    * `:none`           — absent or blank.
+  """
+  @spec pre_auth_rate_limit_override((String.t() -> String.t() | nil)) ::
+          {:ok, integer()} | {:ignored, String.t()} | :none
+  def pre_auth_rate_limit_override(getenv) when is_function(getenv, 1) do
+    ci_gated_int_override(getenv, "PRE_AUTH_RATE_LIMIT_OVERRIDE")
+  end
+
+  # Shared rule: an integer override env var is honored only when `CI=true`,
+  # so a stray copy into a prod task def is inert. Returns {:ok, int} in CI,
+  # {:ignored, raw} when present outside CI, or :none when absent/blank.
+  defp ci_gated_int_override(getenv, var) do
+    case getenv.(var) do
       nil -> :none
       "" -> :none
       raw -> if getenv.("CI") == "true", do: {:ok, String.to_integer(raw)}, else: {:ignored, raw}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.420",
+      version: "0.5.421",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/runtime_config_test.exs
+++ b/test/engram/runtime_config_test.exs
@@ -33,18 +33,18 @@ defmodule Engram.RuntimeConfigTest do
 
   describe "pre_auth_rate_limit_override/1" do
     test "applies the override only when CI=true" do
-      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "10000", "CI" => "true"})
-      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ok, 10_000}
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "100000", "CI" => "true"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ok, 100_000}
     end
 
     test "ignores the override when CI is not true (e.g. a stray prod env var)" do
-      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "10000"})
-      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ignored, "10000"}
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "100000"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ignored, "100000"}
     end
 
     test "ignores the override when CI is set to something other than true" do
-      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "10000", "CI" => "false"})
-      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ignored, "10000"}
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "100000", "CI" => "false"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ignored, "100000"}
     end
 
     test "returns :none when the override is absent" do
@@ -53,6 +53,11 @@ defmodule Engram.RuntimeConfigTest do
 
     test "returns :none when the override is blank" do
       env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "", "CI" => "true"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == :none
+    end
+
+    test "is independent of the auth override env var" do
+      env = getenv(%{"RATE_LIMIT_AUTH_OVERRIDE" => "1000", "CI" => "true"})
       assert RuntimeConfig.pre_auth_rate_limit_override(env) == :none
     end
   end

--- a/test/engram/runtime_config_test.exs
+++ b/test/engram/runtime_config_test.exs
@@ -31,6 +31,32 @@ defmodule Engram.RuntimeConfigTest do
     end
   end
 
+  describe "pre_auth_rate_limit_override/1" do
+    test "applies the override only when CI=true" do
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "10000", "CI" => "true"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ok, 10_000}
+    end
+
+    test "ignores the override when CI is not true (e.g. a stray prod env var)" do
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "10000"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ignored, "10000"}
+    end
+
+    test "ignores the override when CI is set to something other than true" do
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "10000", "CI" => "false"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ignored, "10000"}
+    end
+
+    test "returns :none when the override is absent" do
+      assert RuntimeConfig.pre_auth_rate_limit_override(getenv(%{"CI" => "true"})) == :none
+    end
+
+    test "returns :none when the override is blank" do
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "", "CI" => "true"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == :none
+    end
+  end
+
   describe "validate_saas_origins!/3" do
     test "raises when a Clerk (saas) deploy has no PHX_HOST and is not CI" do
       assert_raise RuntimeError, ~r/PHX_HOST/, fn ->


### PR DESCRIPTION
## Root cause of the recurring `e2e-clerk` flake

The `/api/notes` 429s that keep failing `e2e-clerk` come from **`EngramWeb.Plugs.PreAuthRateLimit`** (the #491 401-loop defense), default **600 req/60s per path-category bucket**:

```
test_77_bulk_first_sync: assert 199 >= 1000   (bulk push throttled at the 600 window)
test_78_hash_only_live_update: POST /api/notes → 429 {"error":"rate_limited"}
```

The **auth** limiter has a CI override (`RATE_LIMIT_AUTH_OVERRIDE`, gated on `CI=true` by #563). The **pre-auth** limiter's override knob (`:pre_auth_rate_limit_override`) was wired **only in `config/test.exs`** (for `mix test`) — never in `runtime.exs` — so the e2e **release build** ran at the 600 default and bulk/rapid note writes burst past it, flaking on runner timing. #563 didn't fix this because it gated a *different* limiter.

## Fix (mirrors #563 exactly, for the pre-auth limiter)

- `Engram.RuntimeConfig.pre_auth_rate_limit_override/1` — CI-gated decision helper (shared `ci_gated_int_override/2` with the auth path; the auth function now delegates to it too).
- `runtime.exs` consumes it → `:pre_auth_rate_limit_override`.
- `PRE_AUTH_RATE_LIMIT_OVERRIDE: "10000"` in `docker-compose.ci.yml`, `docker-compose.ci-local.yml`, and the Playwright job in `verify.yml` (next to the existing auth override).

**CI-gating keeps prod's 401-loop defense intact** — production never sets `CI=true`, so a stray copy of the var is inert (logs a warning).

## Tests (TDD)

`runtime_config_test.exs`: 5 cases for `pre_auth_rate_limit_override/1` (CI-applies, ignored-without-CI, ignored-non-true, absent, blank), mirroring the auth-override tests. Watched RED→GREEN; format/Credo/`--warnings-as-errors` clean; compose + verify.yml YAML validated. This PR's own `e2e-clerk` run exercises the fix.

Fixes the flake tracked in #565.