### PR TITLE
fix(ci): allow lifting pre-auth rate limit in e2e (PRE_AUTH_RATE_LIMIT_OVERRIDE)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -249,6 +249,21 @@ case Engram.RuntimeConfig.rate_limit_auth_override(&System.get_env/1) do
     :ok
 end
 
+# Pre-auth (vault-pipeline) limiter override, same CI=true gate. Lets bulk
+# e2e flows lift the default 600/min /api/notes cap; a no-op in prod.
+case Engram.RuntimeConfig.pre_auth_rate_limit_override(&System.get_env/1) do
+  {:ok, limit} ->
+    config :engram, :pre_auth_rate_limit_override, limit
+
+  {:ignored, raw} ->
+    require Logger
+
+    Logger.warning("PRE_AUTH_RATE_LIMIT_OVERRIDE=#{raw} ignored: only honored when CI=true.")
+
+  :none ->
+    :ok
+end
+
 # Clerk auth (only required when AUTH_PROVIDER=clerk)
 # Note: use local variable, not Application.get_env — runtime.exs config
 # is accumulated and not yet applied, so get_env reads stale config.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -86,6 +86,11 @@ services:
       # which sets CI=true automatically.)
       CI: "true"
       RATE_LIMIT_AUTH_OVERRIDE: "1000"
+      # Lift the pre-auth (vault-pipeline) 600/min /api/notes cap for e2e —
+      # bulk flows (e.g. test_78 hash-only / protocol-rev bulk push) burst past
+      # it from the runner's single source IP. Same CI=true gate, so it can
+      # never weaken the limiter in prod.
+      PRE_AUTH_RATE_LIMIT_OVERRIDE: "100000"
       # Free-tier launch test_72_cancel_to_free_overlimit signs a synthetic
       # subscription.canceled webhook with this fixed secret so the e2e
       # exercises the real verify_signature → upsert_from_paddle_event path

--- a/lib/engram/runtime_config.ex
+++ b/lib/engram/runtime_config.ex
@@ -27,7 +27,24 @@ defmodule Engram.RuntimeConfig do
   @spec rate_limit_auth_override((String.t() -> String.t() | nil)) ::
           {:ok, integer()} | {:ignored, String.t()} | :none
   def rate_limit_auth_override(getenv) when is_function(getenv, 1) do
-    case getenv.("RATE_LIMIT_AUTH_OVERRIDE") do
+    ci_gated_override(getenv, "RATE_LIMIT_AUTH_OVERRIDE")
+  end
+
+  @doc """
+  Same CI-gated contract as `rate_limit_auth_override/1`, for the pre-auth
+  (vault-pipeline) limiter via `PRE_AUTH_RATE_LIMIT_OVERRIDE`. Needed so bulk
+  e2e flows (e.g. the protocol-rev bulk-push test) can lift the default
+  600/min `/api/notes` cap without 429-ing themselves; production never sets
+  `CI=true`, so it can't weaken the limiter there.
+  """
+  @spec pre_auth_rate_limit_override((String.t() -> String.t() | nil)) ::
+          {:ok, integer()} | {:ignored, String.t()} | :none
+  def pre_auth_rate_limit_override(getenv) when is_function(getenv, 1) do
+    ci_gated_override(getenv, "PRE_AUTH_RATE_LIMIT_OVERRIDE")
+  end
+
+  defp ci_gated_override(getenv, var) do
+    case getenv.(var) do
       nil -> :none
       "" -> :none
       raw -> if getenv.("CI") == "true", do: {:ok, String.to_integer(raw)}, else: {:ignored, raw}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.420",
+      version: "0.5.421",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/runtime_config_test.exs
+++ b/test/engram/runtime_config_test.exs
@@ -31,6 +31,27 @@ defmodule Engram.RuntimeConfigTest do
     end
   end
 
+  describe "pre_auth_rate_limit_override/1" do
+    test "applies the override only when CI=true" do
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "100000", "CI" => "true"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ok, 100_000}
+    end
+
+    test "ignores the override when not CI (a stray prod env var)" do
+      env = getenv(%{"PRE_AUTH_RATE_LIMIT_OVERRIDE" => "100000"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == {:ignored, "100000"}
+    end
+
+    test "returns :none when absent" do
+      assert RuntimeConfig.pre_auth_rate_limit_override(getenv(%{"CI" => "true"})) == :none
+    end
+
+    test "is independent of the auth override env var" do
+      env = getenv(%{"RATE_LIMIT_AUTH_OVERRIDE" => "1000", "CI" => "true"})
+      assert RuntimeConfig.pre_auth_rate_limit_override(env) == :none
+    end
+  end
+
   describe "validate_saas_origins!/3" do
     test "raises when a Clerk (saas) deploy has no PHX_HOST and is not CI" do
       assert_raise RuntimeError, ~r/PHX_HOST/, fn ->


### PR DESCRIPTION
## Allow lifting the pre-auth rate limit in e2e

The pre-auth (vault-pipeline) limiter introduced in #560 has **no env-var override** — it's hardcoded at 600 req/min for `/api/notes` in the prod release, overridable only in `test.exs` (i.e. `mix test`). So in **e2e** the prod-release stack always runs at 600/min, and bulk flows (the protocol-rev bulk-push `test_78_hash_only_live_update`) burst past it from the runner's single source IP → `429 rate_limited`, intermittently reddening unrelated PRs (surfaced on #566).

This is a robustness gap in #560 — the auth limiter has `RATE_LIMIT_AUTH_OVERRIDE`, the pre-auth one had nothing.

### Change
- `Engram.RuntimeConfig.pre_auth_rate_limit_override/1` — same `CI=true`-gated contract as the auth override (refactored shared logic into `ci_gated_override/2`). A no-op in prod (prod never sets `CI=true`), so it can't weaken the limiter there.
- Wired in `runtime.exs`.
- `PRE_AUTH_RATE_LIMIT_OVERRIDE=100000` in the CI compose so bulk e2e flows have headroom.

### Tests
- `RuntimeConfigTest`: applied only on `CI=true`; ignored otherwise; `:none` when absent; independent of the auth override var. Compose YAML validated.

Unblocks e2e for the in-flight security PRs (#566 webhook idempotency, lifecycle gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
