### PR TITLE
feat(auth): gate suspended/deleted accounts off the management plane

### DIFF
--- a/lib/engram_web/plugs/account_lifecycle.ex
+++ b/lib/engram_web/plugs/account_lifecycle.ex
@@ -1,0 +1,73 @@
+defmodule EngramWeb.Plugs.AccountLifecycle do
+  @moduledoc """
+  Request-time lifecycle gate for authenticated users. Runs after
+  `EngramWeb.Plugs.Auth` (so `current_user` is set) on every authenticated
+  pipeline — user-scoped, onboarding, and vault-scoped.
+
+  Without this, a user soft-deleted by the inactivity sweep or suspended by an
+  admin still holds a valid JWT until it expires, and could keep using the
+  management plane (mint API keys, CRUD vaults, change billing). This closes
+  that window.
+
+  ## Deleted (`deleted_at`)
+
+  Terminal. Returns **410 Gone** on every endpoint, no exemptions — the vault
+  was auto-deleted after 90 days of inactivity; the path forward is re-signup
+  (the Clerk identity is untouched).
+
+  ## Suspended (`suspended_at`)
+
+  Admin action (abuse/fraud). Returns **403 Forbidden** EXCEPT on a small
+  allowlist so the SPA can explain the state and the user can still settle up:
+
+    * `GET /api/me` — read own status
+    * `GET /api/onboarding/status` — onboarding status read
+    * `/api/billing/*` (any method) — view + self-reactivate (pay)
+
+  Deleted takes precedence over suspended.
+  """
+
+  import Plug.Conn
+  alias Phoenix.Controller
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{assigns: %{current_user: %{deleted_at: %DateTime{}}}} = conn, _opts) do
+    deny(
+      conn,
+      410,
+      "account_deleted",
+      "Your vault was auto-deleted after 90 days of inactivity. You can re-signup."
+    )
+  end
+
+  def call(%Plug.Conn{assigns: %{current_user: %{suspended_at: %DateTime{}}}} = conn, _opts) do
+    if suspension_exempt?(conn) do
+      conn
+    else
+      deny(
+        conn,
+        403,
+        "account_suspended",
+        "Your account is suspended. Contact support to resolve it."
+      )
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  defp suspension_exempt?(%Plug.Conn{method: "GET", request_path: "/api/me"}), do: true
+
+  defp suspension_exempt?(%Plug.Conn{method: "GET", request_path: "/api/onboarding/status"}),
+    do: true
+
+  defp suspension_exempt?(%Plug.Conn{request_path: path}),
+    do: String.starts_with?(path, "/api/billing/")
+
+  defp deny(conn, status, error, message) do
+    conn
+    |> put_status(status)
+    |> Controller.json(%{error: error, message: message})
+    |> halt()
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -163,6 +163,11 @@ defmodule EngramWeb.Router do
     pipe_through [
       :api,
       EngramWeb.Plugs.Auth,
+      # Gate deleted (410) / suspended (403) accounts off the management plane.
+      # A user soft-deleted by the inactivity sweep or admin-suspended still
+      # holds a valid JWT; without this they could mint API keys, CRUD vaults,
+      # and change billing until token expiry.
+      EngramWeb.Plugs.AccountLifecycle,
       EngramWeb.Plugs.RotationLockCheck,
       EngramWeb.Plugs.RequireApiRpsBudget
     ]
@@ -235,6 +240,7 @@ defmodule EngramWeb.Router do
     pipe_through [
       :api,
       EngramWeb.Plugs.Auth,
+      EngramWeb.Plugs.AccountLifecycle,
       EngramWeb.Plugs.RotationLockCheck
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.422",
+      version: "0.5.423",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/account_lifecycle_wiring_test.exs
+++ b/test/engram_web/account_lifecycle_wiring_test.exs
@@ -1,0 +1,69 @@
+defmodule EngramWeb.AccountLifecycleWiringTest do
+  @moduledoc """
+  Integration smoke tests proving EngramWeb.Plugs.AccountLifecycle is wired on
+  the user-scoped (management-plane) pipeline — the gap the audit flagged: a
+  suspended/soft-deleted user could otherwise mint API keys, CRUD vaults, and
+  change billing until their JWT expired.
+
+  The vault-scoped pipeline keeps its existing AccountDeleted (410) +
+  RequireActiveSubscription (402 account_suspended) behavior — covered by
+  RouterPipelineTest and OnboardingGateIntegrationTest — so it is not re-tested
+  here.
+  """
+  use EngramWeb.ConnCase, async: false
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    _vault = insert(:vault, user: user, is_default: true)
+    {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    %{conn: put_req_header(conn, "authorization", "Bearer #{api_key}"), user: user}
+  end
+
+  defp suspend(user) do
+    user
+    |> Ecto.Changeset.change(%{suspended_at: DateTime.utc_now()})
+    |> Engram.Repo.update!(skip_tenant_check: true)
+  end
+
+  defp soft_delete(user) do
+    user
+    |> Ecto.Changeset.change(%{deleted_at: DateTime.utc_now()})
+    |> Engram.Repo.update!(skip_tenant_check: true)
+  end
+
+  test "suspended user gets 403 on a user-scoped management endpoint", %{conn: conn, user: user} do
+    suspend(user)
+
+    conn = get(conn, "/api/vaults")
+
+    assert conn.status == 403
+    assert %{"error" => "account_suspended"} = json_response(conn, 403)
+  end
+
+  test "soft-deleted user gets 410 on a user-scoped management endpoint", %{
+    conn: conn,
+    user: user
+  } do
+    soft_delete(user)
+
+    conn = get(conn, "/api/vaults")
+
+    assert conn.status == 410
+    assert %{"error" => "account_deleted"} = json_response(conn, 410)
+  end
+
+  test "suspended user can still reach billing (self-reactivate exemption)", %{
+    conn: conn,
+    user: user
+  } do
+    suspend(user)
+
+    # AccountLifecycle must NOT halt billing — exempt so a suspended user can
+    # pay to reactivate. (The controller then handles the request normally.)
+    assert get(conn, "/api/billing/status").status != 403
+  end
+
+  test "active user proceeds past the gate on the management plane", %{conn: conn} do
+    assert get(conn, "/api/vaults").status not in [403, 410]
+  end
+end

--- a/test/engram_web/plugs/account_lifecycle_test.exs
+++ b/test/engram_web/plugs/account_lifecycle_test.exs
@@ -1,0 +1,83 @@
+defmodule EngramWeb.Plugs.AccountLifecycleTest do
+  use EngramWeb.ConnCase, async: true
+
+  alias Engram.Accounts.User
+  alias EngramWeb.Plugs.AccountLifecycle
+
+  defp run(conn, user, method \\ "GET", path \\ "/api/notes/changes") do
+    %{conn | method: method, request_path: path}
+    |> Plug.Conn.assign(:current_user, user)
+    |> AccountLifecycle.call([])
+  end
+
+  describe "deleted accounts" do
+    test "410 Gone on any endpoint", %{conn: conn} do
+      user = %User{id: 1, deleted_at: DateTime.utc_now()}
+      conn = run(conn, user, "POST", "/api/api-keys")
+
+      assert conn.halted
+      assert json_response(conn, 410)["error"] == "account_deleted"
+    end
+
+    test "410 even on otherwise-exempt billing paths (deleted is terminal)", %{conn: conn} do
+      user = %User{id: 1, deleted_at: DateTime.utc_now()}
+      conn = run(conn, user, "GET", "/api/billing/status")
+
+      assert conn.halted
+      assert json_response(conn, 410)["error"] == "account_deleted"
+    end
+
+    test "deleted takes precedence over suspended", %{conn: conn} do
+      user = %User{id: 1, deleted_at: DateTime.utc_now(), suspended_at: DateTime.utc_now()}
+      assert json_response(run(conn, user), 410)["error"] == "account_deleted"
+    end
+  end
+
+  describe "suspended accounts" do
+    setup do
+      %{user: %User{id: 2, suspended_at: DateTime.utc_now()}}
+    end
+
+    test "403 on a management-plane write", %{conn: conn, user: user} do
+      conn = run(conn, user, "POST", "/api/api-keys")
+
+      assert conn.halted
+      assert json_response(conn, 403)["error"] == "account_suspended"
+    end
+
+    test "403 on vault data", %{conn: conn, user: user} do
+      assert json_response(run(conn, user, "GET", "/api/notes/changes"), 403)["error"] ==
+               "account_suspended"
+    end
+
+    test "GET /api/me is exempt (read own status)", %{conn: conn, user: user} do
+      refute run(conn, user, "GET", "/api/me").halted
+    end
+
+    test "GET /api/onboarding/status is exempt", %{conn: conn, user: user} do
+      refute run(conn, user, "GET", "/api/onboarding/status").halted
+    end
+
+    test "billing endpoints are exempt for self-reactivation (any method)", %{
+      conn: conn,
+      user: user
+    } do
+      refute run(conn, user, "GET", "/api/billing/status").halted
+      refute run(conn, user, "POST", "/api/billing/reverse-cancel").halted
+    end
+
+    test "DELETE /api/me is NOT exempt (only GET status read)", %{conn: conn, user: user} do
+      assert run(conn, user, "DELETE", "/api/me").halted
+    end
+  end
+
+  describe "active accounts and missing user" do
+    test "active user passes through", %{conn: conn} do
+      refute run(conn, %User{id: 3, deleted_at: nil, suspended_at: nil}).halted
+    end
+
+    test "no current_user assigned passes through", %{conn: conn} do
+      refute AccountLifecycle.call(conn, []).halted
+    end
+  end
+end


### PR DESCRIPTION
## Gate suspended/deleted accounts off the management plane (audit finding #4)

A user soft-deleted by the inactivity sweep (`deleted_at`) or admin-suspended (`suspended_at`) still held a valid JWT and could keep using the **user-scoped management plane** — mint API keys, CRUD vaults, change billing — until the token expired. The vault pipeline already gated them; the user-scoped + onboarding pipelines did not.

### Change
- **`EngramWeb.Plugs.AccountLifecycle`** (subsumes the deleted-only `AccountDeleted` for these pipelines):
  - **deleted → 410** (terminal, re-signup).
  - **suspended → 403**, with exemptions so the SPA can explain the state and the user can settle up:
    - `GET /api/me`, `GET /api/onboarding/status` (read status)
    - `/api/billing/*` (any method — view + self-reactivate / pay)
- Mounted on the **user-scoped + onboarding** pipelines (after `Auth`).

### Scope decision (important)
The **vault pipeline is intentionally left unchanged** — it keeps `AccountDeleted` (410) + `RequireActiveSubscription` (**402 `account_suspended`**). The frontend's `limit-copy.ts` already handles that 402 suspended shape, so changing it to 403 would break the existing suspended-user UX. This PR only adds gating where there was **none**, so no existing contract changes.

(Per the maintainer's product call: suspended users are blocked but may still read status + reach billing to self-reactivate.)

### Tests (TDD)
- `AccountLifecycleTest` — deleted 410 (incl. precedence over suspended, terminal over billing); suspended 403; exemptions for GET `/me`, `/onboarding/status`, billing (any method); `DELETE /me` not exempt; active + no-user pass-through.
- `AccountLifecycleWiringTest` — integration: suspended → 403 and deleted → 410 on `/api/vaults`; billing reachable while suspended; active passes.
- Existing `RouterPipelineTest` + `OnboardingGateIntegrationTest` (vault 402-suspended) still green. Full suite: **2654 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
