### PR TITLE
fix(frontend): SPA security headers + report-only CSP [HELD FOR REVIEW]

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,0 +1,22 @@
+# Cloudflare Workers Assets response headers for app.engram.page (saas).
+# Served by the Worker-assets pipeline (wrangler.jsonc assets.directory=./dist);
+# copied here from public/ at build time. Harmless in the self-host build
+# (priv/static/app) — Phoenix doesn't consume this file.
+#
+# The finding: the Cloudflare-served SPA origin had NO CSP / framing / sniff /
+# referrer protection (EngramWeb.CSP only covers Phoenix-served responses, not
+# the Worker-served app shell).
+#
+# Rollout note — CSP is shipped as **Report-Only** on purpose. A wrong/too-tight
+# CSP would silently break Clerk / Paddle / PostHog / Sentry. Report-Only never
+# blocks; it only surfaces violations (browser devtools, and a collector if
+# report-to is wired). Validate via a browser smoke of sign-in + checkout +
+# search, confirm zero violations, THEN rename the header to
+# `Content-Security-Policy` to enforce. The other four headers below are safe to
+# enforce immediately.
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(self "https://*.paddle.com")
+  Content-Security-Policy-Report-Only: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' https://clerk.engram.page https://*.clerk.accounts.dev https://cdn.paddle.com https://*.paddle.com https://us-assets.i.posthog.com https://static.cloudflareinsights.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; worker-src 'self' blob:; connect-src 'self' https://api.engram.page https://clerk.engram.page https://*.clerk.accounts.dev https://us.i.posthog.com https://us-assets.i.posthog.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.paddle.com https://cloudflareinsights.com; frame-src 'self' https://*.paddle.com https://clerk.engram.page https://challenges.cloudflare.com

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.424",
+      version: "0.5.426",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## SPA security headers + report-only CSP (audit finding #11) — HELD FOR REVIEW

`app.engram.page` is served by **Cloudflare Workers Assets**, so `EngramWeb.CSP` (Phoenix-only) never applied to the app shell — the primary app origin had no CSP, framing, MIME-sniff, or referrer protection.

### Change — `frontend/public/_headers`
Copied into the build output and served by the Worker-assets pipeline. Two tiers:

**Enforced immediately (zero breakage risk):**
- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- minimal `Permissions-Policy`

**Report-Only (cannot break the app):**
- `Content-Security-Policy-Report-Only` with a researched allowlist — Clerk (`clerk.engram.page`, `*.clerk.accounts.dev`), Paddle (`cdn.paddle.com`, `*.paddle.com`), PostHog (`us.i.posthog.com`, `us-assets.i.posthog.com`), Sentry (`*.ingest*.sentry.io`), Cloudflare Insights + Turnstile, and `api.engram.page`.

### Why report-only
A wrong/too-tight CSP silently breaks sign-in / checkout / search. Report-Only **never blocks** — it only reports violations. This ships the protection safely; the enforce flip is a deliberate follow-up.

### ⚠️ Before merge / to enforce (your call)
1. Browser smoke on a preview deploy: sign-in (Clerk), checkout (Paddle), search, note render, PostHog/Sentry load — confirm **zero CSP-Report-Only violations** in devtools.
2. Then rename `Content-Security-Policy-Report-Only` → `Content-Security-Policy` to enforce (and ideally wire a `report-to` collector for prod observability).

Verified: `_headers` ships in the build output (`vite build` copies `public/`). Self-host build is unaffected (Phoenix doesn't read the file). No app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
