### PR TITLE
fix(db): opt-in verify_peer TLS to Postgres [HELD FOR REVIEW]

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -563,25 +563,17 @@ if config_env() == :prod do
 
   maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
 
-  # DATABASE_SSL=true enables TLS to the Postgres server. Required by
-  # AWS RDS (pg_hba.conf rejects "no encryption" connections);
-  # self-host MinIO/local Postgres typically has no SSL configured so
-  # default is false. `verify: :verify_none` skips peer cert chain
-  # validation — the RDS root CA isn't bundled into the Alpine image
-  # and traffic is already inside the prod VPC, so peer auth adds no
-  # meaningful confidentiality beyond what TLS-on-the-wire provides.
+  # DATABASE_SSL=true enables TLS to the Postgres server (required by AWS RDS;
+  # self-host local pg usually has none, so default off). Verification mode is
+  # DATABASE_SSL_MODE: unset → `verify_none` (the long-standing default, kept so
+  # this can't break a running deploy); `verify-full` → `verify_peer` against
+  # the OS trust store with SNI + hostname check, closing the in-VPC MITM gap.
+  # verify-full is opt-in: flip it once the chain is confirmed on staging.
+  # See Engram.RuntimeConfig.database_ssl/2.
   #
-  # Postgrex 0.20+ accepts the SSL opt list directly under `:ssl` (a
-  # keyword list both enables TLS and supplies the opts); the older
-  # `:ssl_opts` companion key was deprecated and emits one
-  # `:ssl_opts is deprecated, pass opts to :ssl instead` warning per
-  # connection start.
+  # Postgrex 0.20+ accepts the SSL opt list directly under `:ssl`.
   database_ssl_opts =
-    if System.get_env("DATABASE_SSL") in ~w(true 1) do
-      [ssl: [verify: :verify_none]]
-    else
-      []
-    end
+    Engram.RuntimeConfig.database_ssl(&System.get_env/1, URI.parse(database_url).host)
 
   config :engram,
          Engram.Repo,

--- a/lib/engram/runtime_config.ex
+++ b/lib/engram/runtime_config.ex
@@ -90,4 +90,46 @@ defmodule Engram.RuntimeConfig do
   end
 
   def validate_saas_origins!(_auth_provider, _phx_hosts, _ci?), do: :ok
+
+  @doc """
+  Builds the `Engram.Repo` SSL options from env.
+
+    * `DATABASE_SSL` not in `~w(true 1)` → `[]` (no TLS; self-host/local pg).
+    * SSL on, `DATABASE_SSL_MODE` unset/other → `[ssl: [verify: :verify_none]]`
+      — the long-standing behavior, kept as the default so merging this can't
+      break a running deploy.
+    * SSL on, `DATABASE_SSL_MODE` in `verify-full`/`verify-peer` →
+      `verify: :verify_peer` against the OS trust store
+      (`:public_key.cacerts_get/0`; the runtime image ships `ca-certificates`,
+      which includes the Amazon Root CA that AWS RDS certs chain to), with SNI
+      and HTTPS-style hostname verification. This closes the MITM gap from
+      `verify_none`, but is **opt-in** — the operator flips
+      `DATABASE_SSL_MODE=verify-full` after confirming the chain validates on
+      staging, since a CA/SNI mismatch would otherwise block DB connections.
+
+  `db_host` is the Postgres host (from `DATABASE_URL`), used for SNI +
+  hostname-check.
+  """
+  @spec database_ssl((String.t() -> String.t() | nil), String.t() | nil) :: keyword()
+  def database_ssl(getenv, db_host) when is_function(getenv, 1) do
+    if getenv.("DATABASE_SSL") in ["true", "1"] do
+      [ssl: ssl_opts(getenv.("DATABASE_SSL_MODE"), db_host)]
+    else
+      []
+    end
+  end
+
+  defp ssl_opts(mode, db_host) when mode in ["verify-full", "verify-peer"] do
+    [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get(),
+      server_name_indication: to_charlist(db_host || ""),
+      customize_hostname_check: [
+        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+      ],
+      depth: 4
+    ]
+  end
+
+  defp ssl_opts(_mode, _db_host), do: [verify: :verify_none]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.426",
+      version: "0.5.427",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/runtime_config_test.exs
+++ b/test/engram/runtime_config_test.exs
@@ -85,4 +85,32 @@ defmodule Engram.RuntimeConfigTest do
       assert RuntimeConfig.validate_saas_origins!(:local, nil, false) == :ok
     end
   end
+
+  describe "database_ssl/2" do
+    test "returns [] when DATABASE_SSL is off (self-host / local pg)" do
+      assert RuntimeConfig.database_ssl(getenv(%{}), "db.local") == []
+      assert RuntimeConfig.database_ssl(getenv(%{"DATABASE_SSL" => "false"}), "db.local") == []
+    end
+
+    test "defaults to verify_none when SSL is on but no mode set (unchanged prod behavior)" do
+      env = getenv(%{"DATABASE_SSL" => "true"})
+      assert [ssl: opts] = RuntimeConfig.database_ssl(env, "db.rds.amazonaws.com")
+      assert opts[:verify] == :verify_none
+      refute Keyword.has_key?(opts, :cacerts)
+    end
+
+    test "verify-full enables peer verification with the OS trust store + SNI + hostname check" do
+      env = getenv(%{"DATABASE_SSL" => "true", "DATABASE_SSL_MODE" => "verify-full"})
+      assert [ssl: opts] = RuntimeConfig.database_ssl(env, "db.rds.amazonaws.com")
+      assert opts[:verify] == :verify_peer
+      assert opts[:server_name_indication] == ~c"db.rds.amazonaws.com"
+      assert Keyword.has_key?(opts, :cacerts)
+      assert Keyword.has_key?(opts, :customize_hostname_check)
+    end
+
+    test "verify-full is ignored when SSL itself is off (must opt into TLS first)" do
+      env = getenv(%{"DATABASE_SSL_MODE" => "verify-full"})
+      assert RuntimeConfig.database_ssl(env, "db.rds.amazonaws.com") == []
+    end
+  end
 end


### PR DESCRIPTION
## Postgres verify_peer TLS support (audit finding #13) — HELD FOR REVIEW

The prod RDS connection used `verify: :verify_none` — TLS encrypts the wire but **skips peer-cert chain validation**, so anyone able to position on the app↔RDS path inside the VPC (compromised sidecar, ARP/DNS spoof, rogue service impersonating the DB endpoint) could transparently MITM the Postgres session.

### Change — env-gated, default unchanged
`DATABASE_SSL_MODE`:
- **unset → `verify_none`** (exactly today's behavior — so merging is a **no-op** for the running deploy).
- **`verify-full` → `verify_peer`** against the OS trust store (`:public_key.cacerts_get/0`; the Debian runtime image ships `ca-certificates`, which includes the **Amazon Root CA** that RDS certs chain to), with SNI + HTTPS-style hostname verification.

Logic in `Engram.RuntimeConfig.database_ssl/2`, unit-tested (off / verify_none default / verify-full opts / verify-full-ignored-when-SSL-off). No Dockerfile change — `ca-certificates` is already installed.

### ⚠️ Your verification before flipping it on
This is **opt-in** because a CA/SNI mismatch would block DB connections. Recommended:
1. Merge this (no behavior change yet).
2. On **staging-fastraid** (or a throwaway), set `DATABASE_SSL_MODE=verify-full` and confirm the app boots + connects (the RDS cert chains to a CA in `ca-certificates`). If staging isn't RDS, validate against prod RDS in a controlled window.
3. If it connects clean, set `DATABASE_SSL_MODE=verify-full` in the prod ECS task def (engram-infra).

If the chain ever fails to validate (custom/region cert not in the OS store), the fallback is to bundle the RDS global CA bundle and point `cacertfile` at it — happy to follow up with that variant if step 2 fails.

Full suite: **2682 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
