### PR TITLE
fix(cors): allow X-Vault-ID header in preflight

### DIFF
--- a/lib/engram_web/plugs/cors.ex
+++ b/lib/engram_web/plugs/cors.ex
@@ -30,7 +30,7 @@ defmodule EngramWeb.Plugs.CORS do
     conn
     |> put_resp_header("access-control-allow-origin", resolve_origin(conn))
     |> put_resp_header("access-control-allow-methods", "GET, POST, PUT, DELETE, OPTIONS")
-    |> put_resp_header("access-control-allow-headers", "authorization, content-type")
+    |> put_resp_header("access-control-allow-headers", "authorization, content-type, x-vault-id")
     |> put_resp_header("access-control-max-age", "86400")
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.429",
+      version: "0.5.430",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/plugs/cors_test.exs
+++ b/test/engram_web/plugs/cors_test.exs
@@ -11,6 +11,19 @@ defmodule EngramWeb.Plugs.CORSTest do
     assert get_resp_header(conn, "access-control-allow-origin") != []
   end
 
+  test "preflight allows the X-Vault-ID header the SPA sends on every request" do
+    # The web SPA sets X-Vault-ID (api/client.ts) to scope requests to a vault.
+    # If it is not in access-control-allow-headers the browser blocks the
+    # preflight and every authenticated call fails with a CORS error.
+    conn =
+      build_conn()
+      |> put_req_header("origin", "https://app.engram.dev")
+      |> options("/api/health")
+
+    [allow_headers] = get_resp_header(conn, "access-control-allow-headers")
+    assert String.contains?(String.downcase(allow_headers), "x-vault-id")
+  end
+
   test "non-OPTIONS requests also receive the CORS origin header" do
     # The plug runs before the router on all requests, not just preflight.
     conn =


### PR DESCRIPTION
## Problem

Prod login is broken. Console on `app.engram.page`:

```
Access to fetch at 'https://api.engram.page/onboarding/status' from origin
'https://app.engram.page' has been blocked by CORS policy: Request header
field x-vault-id is not allowed by Access-Control-Allow-Headers in preflight response.
```

The web SPA sets `X-Vault-ID` on every authenticated request (`frontend/src/api/client.ts:51`) to scope calls to a vault. The CORS plug only advertised `authorization, content-type` in `access-control-allow-headers`, so the browser rejects the preflight and every vault-scoped call (`/onboarding/status`, `/api/notes`, …) fails — login never completes.

## Fix

Add `x-vault-id` to the allow-headers list in `EngramWeb.Plugs.CORS`. Verified the SPA sends no other custom headers (`Content-Type` + `Authorization` already allowed).

## Test

TDD — added a preflight test asserting `x-vault-id` is present in `access-control-allow-headers`. RED before the one-line fix, GREEN after. Full CORS suite: 11 tests, 0 failures.

## Deploy note

Prod is release-gated (`release-v*` tag → deploy-prod.yml), **not** merge-gated. Merging this auto-deploys staging-fastraid only; prod needs a release tag cut to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)