### PR TITLE
fix(ci): correct stale :5000 registry refs to :5001 (engram-infra#315)

### DIFF
--- a/.github/setup-runner.sh
+++ b/.github/setup-runner.sh
@@ -10,7 +10,12 @@ set -euo pipefail
 
 echo "=== Engram CI Runner Setup ==="
 
-DOCKER_REGISTRY="10.0.20.214:5000"
+# Push-capable OCI distribution registry (registry:2) on :5001 — the same
+# LOCAL_REGISTRY the CI workflow seeds/pulls from. NOT the rpardini
+# pull-through proxy on :5000: that's a read-only MITM cache, so a
+# `docker push` to it fails (and used to abort this whole bootstrap). See
+# engram-infra#315.
+DOCKER_REGISTRY="10.0.20.214:5001"
 NPM_REGISTRY="http://10.0.20.214:4873"
 
 # ── System dependencies for e2e tests ───────────────────────────────────

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2438,7 +2438,7 @@ jobs:
     needs: [fingerprint, ci]
     runs-on: [self-hosted, linux, x64, isolated]
     steps:
-      # Markers live in LOCAL_REGISTRY (FastRaid 10.0.20.214:5000) as tiny
+      # Markers live in LOCAL_REGISTRY (FastRaid 10.0.20.214:5001) as tiny
       # `FROM scratch` images, NOT actions/cache — see fingerprint job for
       # the ref-scoping bug that motivated the switch. A scratch image with
       # a single file is ~few KB; the registry GCs orphan blobs but keeps

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.431",
+      version: "0.5.432",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

Removes the two stale `10.0.20.214:5000` references that lingered after CI migrated to the real `:5001` registry — the refs that made engram-infra#315 *look* like an unfixed registry bug when the underlying problem was already routed around.

## Background (engram-infra#315)

`:5000` is the **rpardini pull-through proxy** — a read-only MITM cache. Probed live: it returns HTTP 200 for *any* manifest hash and serves `octet-stream`, and it rejects pushes. CI's fingerprint cache, `record-pass` markers, and the `engram-ci` image all moved to a real `registry:2` at **`:5001`** (`LOCAL_REGISTRY`), which correctly 404s unknown hashes. That migration resolved both #315 defects; only stale refs remained.

## Changes

- **`.github/setup-runner.sh`** — `DOCKER_REGISTRY` pointed at `:5001`. It seeds base images with `docker push`, which the `:5000` proxy *rejects* → under `set -euo pipefail` the whole runner bootstrap aborted. `:5001` is push-capable, so this both drops the stale ref and unbreaks the script. Added a comment explaining why not `:5000`.
- **`.github/workflows/verify.yml`** — `record-pass` comment claimed markers live at `:5000`; corrected to `:5001`.

The intentional *"NOT `:5000` — that's the proxy"* explanatory comments are kept (they're the guardrail).

## No CI behavior change

Live CI jobs already use `:5001` via the workflow-level `LOCAL_REGISTRY`. This only touches a one-time manual bootstrap script + a comment.

## Validation

- `bash -n setup-runner.sh` ✅ · `verify.yml` YAML parse ✅
- Repo-wide sweep: no remaining `:5000/<image>` pull paths; only the intentional explanatory comments reference `:5000`.

Closes engram-infra#315

🤖 Generated with [Claude Code](https://claude.com/claude-code)