### PR TITLE
refactor(frontend): unify tree note-list cache on by-id 'root'

### DIFF
--- a/frontend/src/api/channel.test.ts
+++ b/frontend/src/api/channel.test.ts
@@ -105,6 +105,20 @@ describe('handleNoteChanged', () => {
     expect(keys).not.toContainEqual(['folder-notes-by-id', '7', 'f2'])
   })
 
+  it('targets the by-id root sentinel for a root note (no folder marker)', () => {
+    const qc = mockQueryClient({ folders: [] })
+
+    // Root note: no folder in the payload, derived as '' from the path.
+    handleNoteChanged({ event_type: 'upsert', path: 'top.md', vault_id: '7' }, qc, '7')
+    vi.advanceTimersByTime(250)
+
+    const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey)
+    expect(keys).toContainEqual(['folderNotes', '7', ''])
+    expect(keys).toContainEqual(['folder-notes-by-id', '7', 'root'])
+    // Root must NOT fall back to the broad whole-prefix invalidation.
+    expect(keys).not.toContainEqual(['folder-notes-by-id', '7'])
+  })
+
   it('falls back to broad folder-notes-by-id invalidation when the folder is not in cache', () => {
     const qc = mockQueryClient({ folders: [] })
 

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -1,6 +1,7 @@
 import { Socket, Channel } from 'phoenix'
 import type { QueryClient } from '@tanstack/react-query'
 import { getWsBase, joinWsUrl } from './base'
+import { ROOT_FOLDER_ID } from './queries'
 
 let socket: Socket | null = null
 let channel: Channel | null = null
@@ -78,6 +79,11 @@ function flushBatch(batch: PendingBatch): void {
 
   for (const folder of folders) {
     queryClient.invalidateQueries({ queryKey: ['folderNotes', vaultId, folder] })
+    // Root has no folder marker; its id-keyed list keys under the sentinel.
+    if (folder === '') {
+      queryClient.invalidateQueries({ queryKey: ['folder-notes-by-id', vaultId, ROOT_FOLDER_ID] })
+      continue
+    }
     const entry = cached?.folders?.find((f) => f.name === folder)
     if (entry) {
       queryClient.invalidateQueries({ queryKey: ['folder-notes-by-id', vaultId, entry.id] })

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -897,13 +897,9 @@ describe('useBatchDeleteNotes', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['folder-notes-by-id', '42'] })
   })
 
-  it('optimistically strips deleted root notes from the folderNotes cache', async () => {
-    qc.setQueryData(['folderNotes', '42', ''], {
-      notes: [
-        { id: '1', path: 'a.md', title: 'a', folder: '', tags: [], version: 1, mtime: '', created_at: '', updated_at: '' },
-        { id: '2', path: 'b.md', title: 'b', folder: '', tags: [], version: 1, mtime: '', created_at: '', updated_at: '' },
-      ],
-    })
+  it('optimistically strips deleted root notes from the by-id root list', async () => {
+    // Root notes share the one id-keyed cache under the 'root' sentinel.
+    seedFolderNotesById('root', [{ id: '1', path: 'a.md', folder: '' }, { id: '2', path: 'b.md', folder: '' }])
 
     let resolvePost!: (v: unknown) => void
     post.mockReturnValue(new Promise((r) => (resolvePost = r)))
@@ -914,19 +910,15 @@ describe('useBatchDeleteNotes', () => {
     })
 
     await waitFor(() => {
-      const root = qc.getQueryData<{ notes: Array<{ id: string }> }>(['folderNotes', '42', ''])
-      expect(root?.notes.map((n) => n.id)).toEqual(['2'])
+      const root = qc.getQueryData<Array<{ id: string }>>(['folder-notes-by-id', '42', 'root'])
+      expect(root?.map((n) => n.id)).toEqual(['2'])
     })
 
     resolvePost({ deleted: 1 })
   })
 
-  it('rolls back the folderNotes cache when the server rejects', async () => {
-    qc.setQueryData(['folderNotes', '42', ''], {
-      notes: [
-        { id: '1', path: 'a.md', title: 'a', folder: '', tags: [], version: 1, mtime: '', created_at: '', updated_at: '' },
-      ],
-    })
+  it('rolls back the by-id root list when the server rejects', async () => {
+    seedFolderNotesById('root', [{ id: '1', path: 'a.md', folder: '' }])
     post.mockRejectedValue(new ApiError(500, 'boom'))
 
     const { result } = renderHook(() => useBatchDeleteNotes(), { wrapper })
@@ -938,14 +930,15 @@ describe('useBatchDeleteNotes', () => {
       }
     })
 
-    const root = qc.getQueryData<{ notes: Array<{ id: string }> }>(['folderNotes', '42', ''])
-    expect(root?.notes.map((n) => n.id)).toEqual(['1'])
+    const root = qc.getQueryData<Array<{ id: string }>>(['folder-notes-by-id', '42', 'root'])
+    expect(root?.map((n) => n.id)).toEqual(['1'])
   })
 })
 
 describe('useCreateNote — optimistic placeholder', () => {
-  it('inserts a placeholder at root then swaps it for the real note', async () => {
-    qc.setQueryData(['folderNotes', '42', ''], { notes: [] })
+  it('inserts a placeholder at root (by-id "root") then swaps it for the real note', async () => {
+    // Root notes share the one id-keyed cache under the 'root' sentinel.
+    qc.setQueryData(['folder-notes-by-id', '42', 'root'], [])
 
     let resolvePost!: (v: unknown) => void
     post.mockReturnValue(new Promise((r) => (resolvePost = r)))
@@ -956,21 +949,21 @@ describe('useCreateNote — optimistic placeholder', () => {
     })
 
     await waitFor(() => {
-      const root = qc.getQueryData<{ notes: Array<{ id: string; title: string }> }>([
-        'folderNotes',
+      const root = qc.getQueryData<Array<{ id: string; title: string }>>([
+        'folder-notes-by-id',
         '42',
-        '',
+        'root',
       ])
-      expect(root?.notes).toHaveLength(1)
-      expect(root?.notes[0]?.id).toMatch(/^optimistic-/)
-      expect(root?.notes[0]?.title).toBe('Untitled')
+      expect(root).toHaveLength(1)
+      expect(root?.[0]?.id).toMatch(/^optimistic-/)
+      expect(root?.[0]?.title).toBe('Untitled')
     })
 
     resolvePost({ note: { id: 'real-1' } })
 
     await waitFor(() => {
-      const root = qc.getQueryData<{ notes: Array<{ id: string }> }>(['folderNotes', '42', ''])
-      expect(root?.notes[0]?.id).toBe('real-1')
+      const root = qc.getQueryData<Array<{ id: string }>>(['folder-notes-by-id', '42', 'root'])
+      expect(root?.[0]?.id).toBe('real-1')
     })
   })
 
@@ -979,7 +972,6 @@ describe('useCreateNote — optimistic placeholder', () => {
       folders: [{ id: 'f9', parent_id: null, name: 'sub', count: 0 }],
     })
     qc.setQueryData(['folder-notes-by-id', '42', 'f9'], [])
-    qc.setQueryData(['folderNotes', '42', 'sub'], { notes: [] })
 
     let resolvePost!: (v: unknown) => void
     post.mockReturnValue(new Promise((r) => (resolvePost = r)))
@@ -1114,12 +1106,13 @@ describe('useBatchMoveNotes', () => {
     expect(byId['9']).toBe(1)
   })
 
-  it('moves notes to the vault root: appends to the root list, strips the source', async () => {
+  it('moves notes to the vault root: appends to the by-id root list, strips the source', async () => {
     qc.setQueryData(['folders', '42'], {
       folders: [{ id: '5', parent_id: null, name: 'src', count: 2 }],
     })
     seedFolderNotesById('5', [{ id: '1' }, { id: '2' }])
-    qc.setQueryData(['folderNotes', '42', ''], { notes: [] })
+    // Root shares the one id-keyed cache under the 'root' sentinel.
+    qc.setQueryData(['folder-notes-by-id', '42', 'root'], [])
 
     let resolvePost!: (v: unknown) => void
     post.mockReturnValue(new Promise((r) => (resolvePost = r)))
@@ -1130,13 +1123,13 @@ describe('useBatchMoveNotes', () => {
     })
 
     await waitFor(() => {
-      const root = qc.getQueryData<{ notes: Array<{ id: string; folder: string }> }>([
-        'folderNotes',
+      const root = qc.getQueryData<Array<{ id: string; folder: string }>>([
+        'folder-notes-by-id',
         '42',
-        '',
+        'root',
       ])
-      expect(root?.notes.map((n) => n.id)).toContain('1')
-      expect(root?.notes.find((n) => n.id === '1')?.folder).toBe('')
+      expect(root?.map((n) => n.id)).toContain('1')
+      expect(root?.find((n) => n.id === '1')?.folder).toBe('')
       const src = qc.getQueryData<Array<{ id: string }>>(['folder-notes-by-id', '42', '5'])
       expect(src?.map((n) => n.id)).toEqual(['2'])
     })
@@ -1144,16 +1137,12 @@ describe('useBatchMoveNotes', () => {
     resolvePost({ moved: 1 })
   })
 
-  it('moves a note FROM the root into a folder (strips the root list)', async () => {
+  it('moves a note FROM the root into a folder (strips the by-id root list)', async () => {
     qc.setQueryData(['folders', '42'], {
       folders: [{ id: '9', parent_id: null, name: 'dst', count: 0 }],
     })
     qc.setQueryData(['folder-notes-by-id', '42', '9'], [])
-    qc.setQueryData(['folderNotes', '42', ''], {
-      notes: [
-        { id: '1', path: 'a.md', title: 'a', folder: '', tags: [], version: 1, mtime: '', created_at: '', updated_at: '' },
-      ],
-    })
+    seedFolderNotesById('root', [{ id: '1', path: 'a.md', folder: '' }])
 
     let resolvePost!: (v: unknown) => void
     post.mockReturnValue(new Promise((r) => (resolvePost = r)))
@@ -1164,8 +1153,8 @@ describe('useBatchMoveNotes', () => {
     })
 
     await waitFor(() => {
-      const root = qc.getQueryData<{ notes: Array<{ id: string }> }>(['folderNotes', '42', ''])
-      expect(root?.notes.map((n) => n.id)).toEqual([])
+      const root = qc.getQueryData<Array<{ id: string }>>(['folder-notes-by-id', '42', 'root'])
+      expect(root?.map((n) => n.id)).toEqual([])
       const dst = qc.getQueryData<Array<{ id: string }>>(['folder-notes-by-id', '42', '9'])
       expect(dst?.map((n) => n.id)).toContain('1')
     })

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -159,11 +159,30 @@ export function useFolderNotes(folder: string, options?: { enabled?: boolean }) 
 
 // Headless-tree consumers key folder nodes by id and fetch their note
 // children via the by-id endpoint (Task 6). Path-keyed `useFolderNotes`
-// stays in place for legacy consumers; new tree code uses this hook so
-// rename / move events don't invalidate by stale path keys.
+// stays in place for the dashboard folder-browse view; the tree reads
+// everything (root + subfolders) through this one id-keyed cache so a
+// note mutation only has to patch a single place.
 // 60s of staleness keeps re-expansions instant while a `notes.batch` channel
 // event (or any single-note mutation) still invalidates the key and refetches.
 export const FOLDER_NOTES_STALE_MS = 60_000
+
+// The vault root has no folder-marker row (the by-id endpoint requires a
+// non-null id), so it keys its note list under this sentinel — the same value
+// the backend already uses as the batch-move root target. One id-space, one
+// shape (`NoteSummary[]`), for every folder including root.
+export const ROOT_FOLDER_ID = 'root'
+
+// Single fetcher behind every id-keyed note list. Root reads the path-keyed
+// list endpoint (the only one that accepts an empty folder); every other
+// folder reads its by-id endpoint. Both normalize to `NoteSummary[]`.
+export function fetchNotesForFolderId(folderId: string): Promise<NoteSummary[]> {
+  if (folderId === ROOT_FOLDER_ID) {
+    return api.get<{ notes: NoteSummary[] }>('/folders/list?folder=').then((r) => r.notes)
+  }
+  return api
+    .get<{ notes: NoteSummary[] }>(`/folders/by-id/${folderId}/notes`)
+    .then((r) => r.notes)
+}
 
 export function useFolderNotesById(
   folderId: string | null,
@@ -172,13 +191,28 @@ export function useFolderNotesById(
   const vaultId = useActiveVaultId()
   return useQuery({
     queryKey: ['folder-notes-by-id', vaultId, folderId],
-    queryFn: () =>
-      api
-        .get<{ notes: NoteSummary[] }>(`/folders/by-id/${folderId}/notes`)
-        .then((r) => r.notes),
+    queryFn: () => fetchNotesForFolderId(folderId as string),
     enabled: folderId != null && (opts.enabled ?? true),
     staleTime: FOLDER_NOTES_STALE_MS,
   })
+}
+
+// Resolve a folder PATH (a NoteSummary.folder, or '' for the vault root) to the
+// id its note list is cached under. Root maps to the sentinel without a lookup;
+// every other folder resolves through the folders cache marker. Returns null
+// when an unknown non-root folder isn't in the cache yet — callers skip the
+// optimistic patch and let the list surface on its next fetch.
+function folderIdForPath(
+  qc: QueryClient,
+  vaultId: string | null | undefined,
+  folder: string,
+): string | null {
+  if (folder === '') return ROOT_FOLDER_ID
+  return (
+    qc
+      .getQueryData<{ folders: Folder[] }>(['folders', vaultId])
+      ?.folders.find((f) => f.name === folder)?.id ?? null
+  )
 }
 
 export function useNote(id: string | null) {
@@ -259,41 +293,27 @@ export function useFetchNoteFresh() {
   return fetchNoteById
 }
 
-type NoteListShape = 'legacy' | 'byId'
-
 interface CreateNoteContext {
   key: readonly unknown[]
-  shape: NoteListShape
-  snapshot: unknown
+  snapshot: NoteSummary[]
   placeholderId: string
 }
 
-// Replace the row whose id === `id` in a note-list cache, handling both shapes
-// the tree reads: path-keyed `{ notes }` (root/legacy) and id-keyed
-// `NoteSummary[]` (subfolders). Used to swap an optimistic placeholder for the
-// server row. No-op when the list isn't cached.
+// Replace the row whose id === `id` in an id-keyed note-list cache. Used to
+// swap an optimistic placeholder for the server row. No-op when the list isn't
+// cached.
 function patchRowInList(
   qc: QueryClient,
   key: readonly unknown[],
-  shape: NoteListShape,
   id: string,
   patch: Partial<NoteSummary>,
 ): void {
-  if (shape === 'legacy') {
-    const cur = qc.getQueryData<{ notes: NoteSummary[] }>(key)
-    if (cur) {
-      qc.setQueryData<{ notes: NoteSummary[] }>(key, {
-        notes: cur.notes.map((n) => (n.id === id ? { ...n, ...patch } : n)),
-      })
-    }
-  } else {
-    const cur = qc.getQueryData<NoteSummary[]>(key)
-    if (cur) {
-      qc.setQueryData<NoteSummary[]>(
-        key,
-        cur.map((n) => (n.id === id ? { ...n, ...patch } : n)),
-      )
-    }
+  const cur = qc.getQueryData<NoteSummary[]>(key)
+  if (cur) {
+    qc.setQueryData<NoteSummary[]>(
+      key,
+      cur.map((n) => (n.id === id ? { ...n, ...patch } : n)),
+    )
   }
 }
 
@@ -319,8 +339,10 @@ export function useCreateNote() {
     CreateNoteContext | undefined
   >({
     mutationFn: async ({ folder }) => {
-      const existingNotes =
-        qc.getQueryData<{ notes: NoteSummary[] }>(['folderNotes', vaultId, folder])?.notes ?? []
+      const folderId = folderIdForPath(qc, vaultId, folder)
+      const existingNotes = folderId
+        ? qc.getQueryData<NoteSummary[]>(['folder-notes-by-id', vaultId, folderId]) ?? []
+        : []
       // Exclude optimistic placeholders so the server name matches the one we
       // showed optimistically (no needless "Untitled 1" bump from our own row).
       const existingNames = realFilenames(existingNotes)
@@ -346,32 +368,21 @@ export function useCreateNote() {
       }
       throw new ApiError(500, 'useCreateNote: exceeded race retries')
     },
-    // Drop a placeholder row into the cache the tree reads so a new note shows
-    // instantly (on-disk feel), then swap it for the server row on success.
+    // Drop a placeholder row into the id-keyed list the tree reads so a new
+    // note shows instantly (on-disk feel), then swap it for the server row on
+    // success. Root and subfolders share one cache keyed by folder id.
     onMutate: async ({ folder }) => {
-      // Root notes live in the path-keyed list; subfolders in the by-id list.
-      let key: readonly unknown[]
-      let shape: 'legacy' | 'byId'
-      if (folder === '') {
-        key = ['folderNotes', vaultId, '']
-        shape = 'legacy'
-      } else {
-        const f = qc
-          .getQueryData<{ folders: Folder[] }>(['folders', vaultId])
-          ?.folders.find((x) => x.name === folder)
-        if (!f) return undefined
-        key = ['folder-notes-by-id', vaultId, f.id]
-        shape = 'byId'
-      }
+      const folderId = folderIdForPath(qc, vaultId, folder)
+      // Unknown non-root folder not in the cache yet — skip; surfaces on expand.
+      if (folderId == null) return undefined
+      const key = ['folder-notes-by-id', vaultId, folderId] as const
       await qc.cancelQueries({ queryKey: key })
 
-      const snapshot = qc.getQueryData(key)
+      const snapshot = qc.getQueryData<NoteSummary[]>(key)
       // Not cached (e.g. an unexpanded subfolder) — skip; it surfaces on expand.
       if (snapshot === undefined) return undefined
 
-      const existing: NoteSummary[] =
-        shape === 'legacy' ? (snapshot as { notes: NoteSummary[] }).notes : (snapshot as NoteSummary[])
-      const name = collideBump(realFilenames(existing), 'Untitled.md', { cap: 1000 })
+      const name = collideBump(realFilenames(snapshot), 'Untitled.md', { cap: 1000 })
       const path = folder ? `${folder}/${name}` : name
       const now = new Date().toISOString()
       const placeholderId = `optimistic-${crypto.randomUUID()}`
@@ -387,30 +398,25 @@ export function useCreateNote() {
         updated_at: now,
       }
 
-      if (shape === 'legacy') {
-        qc.setQueryData<{ notes: NoteSummary[] }>(key, {
-          notes: [...(snapshot as { notes: NoteSummary[] }).notes, placeholder],
-        })
-      } else {
-        qc.setQueryData<NoteSummary[]>(key, [...(snapshot as NoteSummary[]), placeholder])
-      }
-      return { key, shape, snapshot, placeholderId }
+      qc.setQueryData<NoteSummary[]>(key, [...snapshot, placeholder])
+      return { key, snapshot, placeholderId }
     },
     onSuccess: ({ id, path }, vars, ctx) => {
       // Swap the placeholder for the server-assigned id/path.
       if (ctx) {
         const filename = path.split('/').pop() ?? path
-        patchRowInList(qc, ctx.key, ctx.shape, ctx.placeholderId, {
+        patchRowInList(qc, ctx.key, ctx.placeholderId, {
           id,
           path,
           title: filename.replace(/\.md$/, ''),
         })
+        // Only the target folder's list changed — no need to stale the whole
+        // prefix (which would force every folder to refetch on next expand).
+        qc.invalidateQueries({ queryKey: ctx.key })
       }
       qc.invalidateQueries({ queryKey: ['folders', vaultId] })
+      // Keep the path-keyed list fresh for the dashboard folder-browse view.
       qc.invalidateQueries({ queryKey: ['folderNotes', vaultId, vars.folder] })
-      // Only the target folder's by-id list changed — no need to stale the
-      // whole prefix (which would force every folder to refetch on next expand).
-      if (ctx?.shape === 'byId') qc.invalidateQueries({ queryKey: ctx.key })
       navigate(`/note/${id}`)
     },
     onError: (err, _vars, ctx) => {
@@ -1537,13 +1543,11 @@ export function useDeleteFolder() {
 // (via onSettled refetch); on error the placeholder is pulled.
 
 interface DuplicateNoteContext {
-  newFolder: string
-  newFolderNotes: { notes: NoteSummary[] } | undefined
   placeholderId: string
-  // The id-keyed list the tree reads (set only for a non-root target folder
-  // whose list is cached), plus its snapshot for rollback.
-  byIdKey?: readonly unknown[]
-  byIdNotes?: NoteSummary[]
+  // The id-keyed list the tree reads (set only when the target folder's list
+  // is cached), plus its snapshot for rollback.
+  key?: readonly unknown[]
+  snapshot?: NoteSummary[]
 }
 
 export function useDuplicateNote() {
@@ -1565,78 +1569,61 @@ export function useDuplicateNote() {
     },
     onMutate: async ({ src_path, new_path }) => {
       const newFolder = folderOf(new_path)
-      const listKey = ['folderNotes', vaultId, newFolder] as const
-      await qc.cancelQueries({ queryKey: listKey })
+      const targetId = folderIdForPath(qc, vaultId, newFolder)
 
       // Placeholder id — the real one arrives with the POST response.
       // `optimistic-` prefix avoids collisions with real backend uuids;
       // onSuccess swaps it for the server-assigned id in the cached list.
       const placeholderId = `optimistic-${crypto.randomUUID()}`
-      const ctx: DuplicateNoteContext = {
-        newFolder,
-        newFolderNotes: qc.getQueryData<{ notes: NoteSummary[] }>(listKey),
-        placeholderId,
-      }
+      const ctx: DuplicateNoteContext = { placeholderId }
 
       // Seed metadata from the source row if we have it cached — gives
       // the placeholder a usable title/tags so the row looks real.
-      const srcRowFromOldList = qc
-        .getQueryData<{ notes: NoteSummary[] }>(['folderNotes', vaultId, folderOf(src_path)])
-        ?.notes.find((n) => n.path === src_path)
+      const srcId = folderIdForPath(qc, vaultId, folderOf(src_path))
+      const srcRow = srcId
+        ? qc
+            .getQueryData<NoteSummary[]>(['folder-notes-by-id', vaultId, srcId])
+            ?.find((n) => n.path === src_path)
+        : undefined
       const now = new Date().toISOString()
       const placeholder: NoteSummary = {
         id: placeholderId,
         path: new_path,
-        title: srcRowFromOldList?.title ?? '',
+        title: srcRow?.title ?? '',
         folder: newFolder,
-        tags: srcRowFromOldList?.tags ?? [],
+        tags: srcRow?.tags ?? [],
         version: 1,
         mtime: now,
         created_at: now,
         updated_at: now,
       }
 
-      if (ctx.newFolderNotes) {
-        updateCachedList<NoteSummary>(qc, listKey, (prev) => ({
-          notes: [...prev.notes.filter((n) => n.path !== new_path), placeholder],
-        }))
-      }
-
-      // Mirror into the id-keyed list the tree actually reads (subfolders).
-      // Root targets (newFolder === '') have no folders-cache row and surface
-      // via the rootNotes path above. Only patch when the list is cached;
-      // otherwise the dupe lands on the next expand fetch.
-      if (newFolder) {
-        const targetFolder = qc
-          .getQueryData<{ folders: Folder[] }>(['folders', vaultId])
-          ?.folders.find((f) => f.name === newFolder)
-        if (targetFolder) {
-          const byIdKey = ['folder-notes-by-id', vaultId, targetFolder.id] as const
-          // Cancel before reading+writing so an in-flight refetch of this list
-          // can't resolve afterwards and clobber the optimistic placeholder.
-          await qc.cancelQueries({ queryKey: byIdKey })
-          const byIdNotes = qc.getQueryData<NoteSummary[]>(byIdKey)
-          if (byIdNotes) {
-            ctx.byIdKey = byIdKey
-            ctx.byIdNotes = byIdNotes
-            qc.setQueryData<NoteSummary[]>(byIdKey, [
-              ...byIdNotes.filter((n) => n.path !== new_path),
-              placeholder,
-            ])
-          }
+      // Drop the placeholder into the id-keyed list the tree reads (root or
+      // subfolder). Only patch when cached; otherwise it lands on the next
+      // expand fetch. Cancel first so an in-flight refetch can't clobber it.
+      if (targetId != null) {
+        const key = ['folder-notes-by-id', vaultId, targetId] as const
+        await qc.cancelQueries({ queryKey: key })
+        const snapshot = qc.getQueryData<NoteSummary[]>(key)
+        if (snapshot) {
+          ctx.key = key
+          ctx.snapshot = snapshot
+          qc.setQueryData<NoteSummary[]>(key, [
+            ...snapshot.filter((n) => n.path !== new_path),
+            placeholder,
+          ])
         }
       }
       return ctx
     },
     onSuccess: (data, _vars, ctx) => {
-      if (!ctx) return
+      if (!ctx?.key) return
       const real = data.note
       if (!real?.id) return
-      // Swap the placeholder for the real server row in BOTH lists the tree may
-      // read (path-keyed root/legacy + id-keyed subfolder), so a tree consumer
-      // keying on `n.id` transitions smoothly. onSettled also invalidates; the
-      // swap avoids a momentary "missing note" flash.
-      const patch: Partial<NoteSummary> = {
+      // Swap the placeholder for the real server row so a tree consumer keying
+      // on `n.id` transitions smoothly. onSettled also invalidates; the swap
+      // avoids a momentary "missing note" flash.
+      patchRowInList(qc, ctx.key, ctx.placeholderId, {
         id: real.id,
         path: real.path,
         title: real.title,
@@ -1646,16 +1633,11 @@ export function useDuplicateNote() {
         mtime: real.mtime,
         created_at: real.created_at,
         updated_at: real.updated_at,
-      }
-      patchRowInList(qc, ['folderNotes', vaultId, ctx.newFolder], 'legacy', ctx.placeholderId, patch)
-      if (ctx.byIdKey) patchRowInList(qc, ctx.byIdKey, 'byId', ctx.placeholderId, patch)
+      })
     },
     onError: (err, _vars, ctx) => {
-      if (ctx?.newFolderNotes !== undefined) {
-        qc.setQueryData(['folderNotes', vaultId, ctx.newFolder], ctx.newFolderNotes)
-      }
-      if (ctx?.byIdKey && ctx.byIdNotes !== undefined) {
-        qc.setQueryData(ctx.byIdKey, ctx.byIdNotes)
+      if (ctx?.key && ctx.snapshot !== undefined) {
+        qc.setQueryData(ctx.key, ctx.snapshot)
       }
       if (err.status === 409) {
         toast.error('A note with that name already exists.')
@@ -1698,15 +1680,13 @@ function idempotencyHeaders(): { headers: Record<string, string> } {
 }
 
 interface BatchNotesContext {
-  // Every by-id list we patched. We keep the snapshot map ordered by the
-  // QueryClient cache scan so rollback restores under the same key.
+  // Every by-id list we patched (root included — it keys under ROOT_FOLDER_ID).
+  // We keep the snapshot map ordered by the QueryClient cache scan so rollback
+  // restores under the same key.
   noteListSnapshots: Array<{ key: readonly unknown[]; data: NoteSummary[] | undefined }>
   // Folders cache snapshot — present only when a move patched folder counts
   // (so the tree's structure key changes and it rebuilds). Used for rollback.
   folders?: { folders: Folder[] }
-  // Path-keyed folderNotes snapshots (root notes live here, not in by-id
-  // lists). Patched by batch delete so a root note disappears optimistically.
-  legacyListSnapshots?: Array<{ key: readonly unknown[]; data: { notes: NoteSummary[] } | undefined }>
 }
 
 export function useBatchDeleteNotes() {
@@ -1726,9 +1706,10 @@ export function useBatchDeleteNotes() {
       ),
     onMutate: async ({ ids }) => {
       await qc.cancelQueries({ queryKey: ['folder-notes-by-id', vaultId] })
-      await qc.cancelQueries({ queryKey: ['folderNotes', vaultId] })
       const idSet = new Set(ids)
 
+      // One id-keyed cache holds every note list (root keys under
+      // ROOT_FOLDER_ID), so a single scan strips deleted rows everywhere.
       const snapshots: BatchNotesContext['noteListSnapshots'] = []
       const queries = qc
         .getQueryCache()
@@ -1743,33 +1724,17 @@ export function useBatchDeleteNotes() {
         )
       }
 
-      // Root notes (and any legacy path-keyed consumers) live in
-      // ['folderNotes', vaultId, folder] as { notes }, not the by-id lists —
-      // strip them here too so a deleted root note disappears optimistically.
-      const legacyListSnapshots: BatchNotesContext['legacyListSnapshots'] = []
-      for (const q of qc.getQueryCache().findAll({ queryKey: ['folderNotes', vaultId] })) {
-        const data = qc.getQueryData<{ notes: NoteSummary[] }>(q.queryKey)
-        if (!data) continue
-        legacyListSnapshots.push({ key: q.queryKey, data })
-        qc.setQueryData<{ notes: NoteSummary[] }>(q.queryKey, {
-          notes: data.notes.filter((n) => !idSet.has(n.id)),
-        })
-      }
-
       // Drop any cached note body for the deleted ids so a stale
       // useNote(id) subscriber 404s on remount instead of rendering.
       for (const id of ids) {
         qc.removeQueries({ queryKey: ['note', vaultId, id] })
       }
 
-      return { noteListSnapshots: snapshots, legacyListSnapshots }
+      return { noteListSnapshots: snapshots }
     },
     onError: (_err, _vars, ctx) => {
       if (!ctx) return
       for (const snap of ctx.noteListSnapshots) {
-        qc.setQueryData(snap.key, snap.data)
-      }
-      for (const snap of ctx.legacyListSnapshots ?? []) {
         qc.setQueryData(snap.key, snap.data)
       }
       toast.error('Batch delete failed.')
@@ -1799,28 +1764,26 @@ export function useBatchMoveNotes() {
       ),
     onMutate: async ({ ids, target_folder_id }) => {
       await qc.cancelQueries({ queryKey: ['folder-notes-by-id', vaultId] })
-      await qc.cancelQueries({ queryKey: ['folderNotes', vaultId] })
       await qc.cancelQueries({ queryKey: ['folders', vaultId] })
       const idSet = new Set(ids)
 
       // Destination path: a real folder's name, or '' for the vault root
-      // (target_folder_id === 'root', the backend sentinel — no folders row).
+      // (target_folder_id === ROOT_FOLDER_ID — no folders row).
       const foldersCache = qc.getQueryData<{ folders: Folder[] }>(['folders', vaultId])
-      const targetIsRoot = target_folder_id === 'root'
-      const targetFolderName = targetIsRoot
-        ? ''
-        : (foldersCache?.folders.find((f) => f.id === target_folder_id)?.name ?? null)
+      const targetFolderName =
+        target_folder_id === ROOT_FOLDER_ID
+          ? ''
+          : (foldersCache?.folders.find((f) => f.id === target_folder_id)?.name ?? null)
 
       const snapshots: BatchNotesContext['noteListSnapshots'] = []
-      const legacyListSnapshots: BatchNotesContext['legacyListSnapshots'] = []
       const moved: NoteSummary[] = []
       // How many notes left each source folder — used to decrement folder
       // counts below so the tree's structure key changes and it rebuilds.
       const removedPerFolder = new Map<string, number>()
 
       // First pass: strip moved notes from every source list (capture the rows
-      // so we can re-attach them to the target). Subfolders live in by-id lists;
-      // root notes live in the path-keyed folderNotes[''] list.
+      // so we can re-attach them to the target). Root and subfolders share one
+      // id-keyed cache, so a single scan covers them all.
       for (const q of qc.getQueryCache().findAll({ queryKey: ['folder-notes-by-id', vaultId] })) {
         const data = qc.getQueryData<NoteSummary[]>(q.queryKey)
         if (!data) continue
@@ -1839,23 +1802,10 @@ export function useBatchMoveNotes() {
         }
         qc.setQueryData<NoteSummary[]>(q.queryKey, keep)
       }
-      for (const q of qc.getQueryCache().findAll({ queryKey: ['folderNotes', vaultId] })) {
-        const data = qc.getQueryData<{ notes: NoteSummary[] }>(q.queryKey)
-        if (!data) continue
-        const sourcePath = q.queryKey[2] as string | undefined
-        // Skip the destination list itself (a same-list move is a no-op).
-        if (targetIsRoot && sourcePath === '') continue
-        legacyListSnapshots.push({ key: q.queryKey, data })
-        const keep: NoteSummary[] = []
-        for (const n of data.notes) {
-          if (idSet.has(n.id)) moved.push(n)
-          else keep.push(n)
-        }
-        qc.setQueryData<{ notes: NoteSummary[] }>(q.queryKey, { notes: keep })
-      }
 
       // Second pass: append the moved rows to the destination list (if cached),
-      // rewriting folder + path so each row looks at-home.
+      // rewriting folder + path so each row looks at-home. The target keys
+      // under its id — ROOT_FOLDER_ID for the vault root.
       if (moved.length > 0 && targetFolderName !== null) {
         const dest = targetFolderName
         const patched = moved.map<NoteSummary>((n) => {
@@ -1864,20 +1814,9 @@ export function useBatchMoveNotes() {
             : n.path
           return { ...n, folder: dest, path: dest ? `${dest}/${filename}` : filename }
         })
-        if (targetIsRoot) {
-          const rootKey = ['folderNotes', vaultId, ''] as const
-          const rootData = qc.getQueryData<{ notes: NoteSummary[] }>(rootKey)
-          if (rootData) {
-            legacyListSnapshots.push({ key: rootKey, data: rootData })
-            qc.setQueryData<{ notes: NoteSummary[] }>(rootKey, {
-              notes: [...rootData.notes, ...patched],
-            })
-          }
-        } else {
-          const targetKey = ['folder-notes-by-id', vaultId, target_folder_id] as const
-          const targetData = qc.getQueryData<NoteSummary[]>(targetKey)
-          if (targetData) qc.setQueryData<NoteSummary[]>(targetKey, [...targetData, ...patched])
-        }
+        const targetKey = ['folder-notes-by-id', vaultId, target_folder_id] as const
+        const targetData = qc.getQueryData<NoteSummary[]>(targetKey)
+        if (targetData) qc.setQueryData<NoteSummary[]>(targetKey, [...targetData, ...patched])
       }
 
       // Patch the individual `['note', vaultId, id]` caches so an open viewer
@@ -1924,14 +1863,11 @@ export function useBatchMoveNotes() {
         }
       }
 
-      return { noteListSnapshots: snapshots, legacyListSnapshots, folders: foldersSnapshot }
+      return { noteListSnapshots: snapshots, folders: foldersSnapshot }
     },
     onError: (_err, _vars, ctx) => {
       if (!ctx) return
       for (const snap of ctx.noteListSnapshots) {
-        qc.setQueryData(snap.key, snap.data)
-      }
-      for (const snap of ctx.legacyListSnapshots ?? []) {
         qc.setQueryData(snap.key, snap.data)
       }
       if (ctx.folders !== undefined) qc.setQueryData(['folders', vaultId], ctx.folders)

--- a/frontend/src/viewer/folder-tree.test.tsx
+++ b/frontend/src/viewer/folder-tree.test.tsx
@@ -54,14 +54,11 @@ vi.mock('../api/queries', async () => {
       isLoading: mock.loading,
       isError: false,
     }),
-    // Root notes for the by-id loader (legacy useFolderNotes('') compat)
-    useFolderNotes: (folder: string) => {
-      if (folder === '') {
+    useFolderNotesById: (folderId: string | null) => {
+      // Root notes share the one id-keyed cache under the 'root' sentinel.
+      if (folderId === 'root') {
         return { data: mock.rootNotes, isLoading: false }
       }
-      return { data: [], isLoading: false }
-    },
-    useFolderNotesById: (folderId: string | null) => {
       if (folderId === '1') {
         return {
           data: [
@@ -94,6 +91,10 @@ vi.mock('../api/queries', async () => {
 
 function renderTree() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  // The loader reads note lists straight from the query cache. Root notes key
+  // under the 'root' sentinel; useActiveVaultId is unset in tests, so the tree
+  // resolves vaultId to ''. Seed it so root notes render without a fetch.
+  qc.setQueryData(['folder-notes-by-id', '', 'root'], mock.rootNotes)
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -5,10 +5,11 @@ import { toast } from 'sonner'
 import {
   type Folder,
   FOLDER_NOTES_STALE_MS,
+  fetchNotesForFolderId,
   type Note,
-  type NoteSummary,
+  ROOT_FOLDER_ID,
   useFolders,
-  useFolderNotes,
+  useFolderNotesById,
   useBatchDeleteNotes,
   useBatchMoveNotes,
   useBatchDeleteFolders,
@@ -17,7 +18,6 @@ import {
   useRenameFolder,
   useDuplicateNote,
 } from '../api/queries'
-import { api } from '../api/client'
 import { useActiveVaultId } from '../api/active-vault'
 import { useFolderTreeState } from '../layout/folder-tree-context'
 import { useEngramTree } from './tree/use-engram-tree'
@@ -52,10 +52,11 @@ type DialogState =
 
 export default function FolderTree() {
   const { data: folders, isLoading, isError } = useFolders()
-  // Root notes still come via the legacy path-keyed endpoint — the by-id
-  // hook requires a non-null folderId. The loader stitches these into
-  // the tree under ROOT.
-  const { data: rootNotes = [] } = useFolderNotes('', { enabled: true })
+  // Root notes share the one id-keyed cache under the ROOT_FOLDER_ID sentinel
+  // (its fetcher hits the path-keyed list endpoint, since the by-id endpoint
+  // needs a real folder id). Subscribing here gives root an observer so
+  // invalidations refetch it; the loader stitches the rows under ROOT.
+  const { data: rootNotes = [] } = useFolderNotesById(ROOT_FOLDER_ID)
   const { sort } = useFolderTreeState()
   const vaultId = useActiveVaultId()
   const qc = useQueryClient()
@@ -115,14 +116,12 @@ export default function FolderTree() {
     if (folderIds.length) batchMoveFolders.mutate({ ids: folderIds, target_parent_id: dest })
   }
 
-  // The loader fires this on cache-miss when a folder is expanded. Mirrors
-  // the queryFn inside `useFolderNotesById` so react-query treats both as
-  // the same query (cache key + fetcher shape).
+  // The loader fires this on cache-miss when a folder is expanded. Shares the
+  // single fetcher with `useFolderNotesById` so react-query treats both as the
+  // same query (cache key + fetcher shape) — and so a 'root' id routes to the
+  // path-keyed list endpoint instead of the non-existent by-id/root route.
   const fetchFolderNotes = useCallback(
-    (folderId: string) =>
-      api
-        .get<{ notes: NoteSummary[] }>(`/folders/by-id/${folderId}/notes`)
-        .then((r) => r.notes),
+    (folderId: string) => fetchNotesForFolderId(folderId),
     [],
   )
 
@@ -154,7 +153,6 @@ export default function FolderTree() {
 
   const { tree, virtualizer, items } = useEngramTree({
     folders: folders ?? EMPTY_FOLDERS,
-    rootNotes,
     qc,
     vaultId: vaultId ?? '',
     sort,

--- a/frontend/src/viewer/tree/loader.test.ts
+++ b/frontend/src/viewer/tree/loader.test.ts
@@ -37,6 +37,18 @@ const notesByFolder: Record<string, NoteSummary[]> = {
   ],
 }
 
+const rootNote: NoteSummary = {
+  id: '300',
+  path: 'top.md',
+  title: 'top',
+  folder: '',
+  tags: [],
+  version: 1,
+  mtime: '2026-01-03T00:00:00Z',
+  created_at: '2026-01-03T00:00:00Z',
+  updated_at: '2026-01-03T00:00:00Z',
+}
+
 function makeQc(): QueryClient {
   const qc = new QueryClient()
   qc.setQueryData(['folder-notes-by-id', 'v', '1'], notesByFolder['1'])
@@ -45,14 +57,23 @@ function makeQc(): QueryClient {
 }
 
 describe('buildLoader', () => {
-  it('root returns top-level folders + any root notes, sorted', () => {
-    const loader = buildLoader({ folders, qc: makeQc(), vaultId: 'v', sort: 'name-asc' as SortKey, rootNotes: [] })
+  it('root returns top-level folders + root notes from the by-id root cache, sorted', () => {
+    const qc = makeQc()
+    // Root notes live in the one id-keyed cache under the 'root' sentinel.
+    qc.setQueryData(['folder-notes-by-id', 'v', 'root'], [rootNote])
+    const loader = buildLoader({ folders, qc, vaultId: 'v', sort: 'name-asc' as SortKey })
+    const children = loader.getChildren('root')
+    expect(children.map(c => c.itemId)).toEqual(['f:1', 'n:300'])
+  })
+
+  it('root with no cached root list returns folders only', () => {
+    const loader = buildLoader({ folders, qc: makeQc(), vaultId: 'v', sort: 'name-asc' as SortKey })
     const children = loader.getChildren('root')
     expect(children.map(c => c.itemId)).toEqual(['f:1'])
   })
 
   it('folder children return child folders first then notes', () => {
-    const loader = buildLoader({ folders, qc: makeQc(), vaultId: 'v', sort: 'name-asc' as SortKey, rootNotes: [] })
+    const loader = buildLoader({ folders, qc: makeQc(), vaultId: 'v', sort: 'name-asc' as SortKey })
     const children = loader.getChildren('f:1')
     expect(children.map(c => c.itemId)).toEqual(['f:2', 'n:100'])
   })
@@ -68,7 +89,6 @@ describe('buildLoader', () => {
       qc,
       vaultId: 'v',
       sort: 'name-asc' as SortKey,
-      rootNotes: [],
       fetchFolderNotes,
     })
     const children = loader.getChildren('f:2')
@@ -84,22 +104,36 @@ describe('buildLoader', () => {
     expect(fetchFolderNotes).toHaveBeenCalledWith('2')
   })
 
+  it('root cache miss triggers a fetch for the root sentinel', () => {
+    const qc = new QueryClient()
+    const fetchFolderNotes = vi.fn(() => Promise.resolve<NoteSummary[]>([]))
+    const fetchSpy = vi.spyOn(qc, 'fetchQuery')
+    const loader = buildLoader({ folders, qc, vaultId: 'v', sort: 'name-asc' as SortKey, fetchFolderNotes })
+    loader.getChildren('root')
+    expect(fetchSpy).toHaveBeenCalledWith(expect.objectContaining({
+      queryKey: ['folder-notes-by-id', 'v', 'root'],
+    }))
+    const call = fetchSpy.mock.calls[0]?.[0] as unknown as { queryFn: () => Promise<NoteSummary[]> }
+    void call.queryFn()
+    expect(fetchFolderNotes).toHaveBeenCalledWith('root')
+  })
+
   it('cache miss without fetcher returns [] and does not fetch', () => {
     const qc = new QueryClient()
     const fetchSpy = vi.spyOn(qc, 'fetchQuery')
-    const loader = buildLoader({ folders, qc, vaultId: 'v', sort: 'name-asc' as SortKey, rootNotes: [] })
+    const loader = buildLoader({ folders, qc, vaultId: 'v', sort: 'name-asc' as SortKey })
     const children = loader.getChildren('f:2')
     expect(children).toEqual([])
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('getItem returns shaped TreeItem for a folder id', () => {
-    const loader = buildLoader({ folders, qc: makeQc(), vaultId: 'v', sort: 'name-asc' as SortKey, rootNotes: [] })
+    const loader = buildLoader({ folders, qc: makeQc(), vaultId: 'v', sort: 'name-asc' as SortKey })
     expect(loader.getItem('f:1')?.item).toMatchObject({ kind: 'folder', id: '1', path: 'Projects', name: 'Projects' })
   })
 
   it('note sort by modified-desc', () => {
-    const loader = buildLoader({ folders, qc: makeQc(), vaultId: 'v', sort: 'modified-desc' as SortKey, rootNotes: [] })
+    const loader = buildLoader({ folders, qc: makeQc(), vaultId: 'v', sort: 'modified-desc' as SortKey })
     const children = loader.getChildren('f:1')
     // Notes only; folders sorted by name. Here just 1 note.
     expect(children.map(c => c.itemId)).toContain('n:100')

--- a/frontend/src/viewer/tree/loader.ts
+++ b/frontend/src/viewer/tree/loader.ts
@@ -1,5 +1,10 @@
 import { QueryClient } from '@tanstack/react-query'
-import { FOLDER_NOTES_STALE_MS, type Folder, type NoteSummary } from '../../api/queries'
+import {
+  FOLDER_NOTES_STALE_MS,
+  ROOT_FOLDER_ID,
+  type Folder,
+  type NoteSummary,
+} from '../../api/queries'
 import type { TreeItem } from './types'
 import { ROOT_ID, formatItemId, parseItemId } from './types'
 
@@ -13,7 +18,6 @@ interface LoaderDeps {
   qc: QueryClient
   vaultId: string
   sort: SortKey
-  rootNotes: NoteSummary[]
   fetchFolderNotes?: (folderId: string) => Promise<NoteSummary[]>
   onChildrenLoaded?: (folderId: string) => void
 }
@@ -60,11 +64,8 @@ function folderLoaderItem(deps: LoaderDeps, id: string): LoaderItem | undefined 
 }
 
 function noteLoaderItem(deps: LoaderDeps, id: string): LoaderItem | undefined {
-  // Root notes live in deps.rootNotes (the by-id endpoint requires a
-  // non-null folder id, so root uses the path-keyed hook upstream).
-  const rootHit = deps.rootNotes.find(n => n.id === id)
-  if (rootHit) return { itemId: formatItemId({ kind: 'note', id }), item: noteToTreeItem(rootHit), isFolder: false }
-  // Otherwise the note lives in some cached folder-notes-by-id list.
+  // Every note list — root (keyed under ROOT_FOLDER_ID) and subfolders — lives
+  // in the one id-keyed cache, so a single scan finds the note.
   for (const [, list] of deps.qc.getQueriesData<NoteSummary[]>({ queryKey: ['folder-notes-by-id'] })) {
     const hit = list?.find(n => n.id === id)
     if (hit) return { itemId: formatItemId({ kind: 'note', id }), item: noteToTreeItem(hit), isFolder: false }
@@ -72,35 +73,21 @@ function noteLoaderItem(deps: LoaderDeps, id: string): LoaderItem | undefined {
   return undefined
 }
 
-function rootChildren(deps: LoaderDeps): LoaderItem[] {
-  const tops = deps.folders
-    .filter(f => f.parent_id == null)
+function folderLoaderItems(deps: LoaderDeps, parentId: string | null): LoaderItem[] {
+  return deps.folders
+    .filter(f => f.parent_id === parentId)
     .sort((a, b) => folderCmp(a, b, deps.sort))
     .map(f => ({
       itemId: formatItemId({ kind: 'folder', id: f.id }),
       item: { kind: 'folder' as const, id: f.id, path: f.name, name: f.name.split('/').pop() ?? f.name, count: f.count },
       isFolder: true,
     }))
-
-  const noteItems = sortNotes(deps.rootNotes, deps.sort).map(n => ({
-    itemId: formatItemId({ kind: 'note', id: n.id }),
-    item: noteToTreeItem(n),
-    isFolder: false,
-  }))
-
-  return [...tops, ...noteItems]
 }
 
-function folderChildren(deps: LoaderDeps, folderId: string): LoaderItem[] {
-  const childFolders = deps.folders
-    .filter(f => f.parent_id === folderId)
-    .sort((a, b) => folderCmp(a, b, deps.sort))
-    .map(f => ({
-      itemId: formatItemId({ kind: 'folder', id: f.id }),
-      item: { kind: 'folder' as const, id: f.id, path: f.name, name: f.name.split('/').pop() ?? f.name, count: f.count },
-      isFolder: true,
-    }))
-
+// Note children for a folder id (ROOT_FOLDER_ID for the vault root). Reads the
+// id-keyed cache; on a miss, lazily fetches and asks HT to refetch the branch.
+// Returns null on a cache miss so callers can render folders-only meanwhile.
+function noteChildItems(deps: LoaderDeps, folderId: string): LoaderItem[] | null {
   const cached = deps.qc.getQueryData<NoteSummary[]>(['folder-notes-by-id', deps.vaultId, folderId])
   if (!cached) {
     if (deps.fetchFolderNotes) {
@@ -116,16 +103,25 @@ function folderChildren(deps: LoaderDeps, folderId: string): LoaderItem[] {
         .then(() => deps.onChildrenLoaded?.(folderId))
         .catch(() => {})
     }
-    return childFolders
+    return null
   }
-
-  const noteItems = sortNotes(cached, deps.sort).map(n => ({
+  return sortNotes(cached, deps.sort).map(n => ({
     itemId: formatItemId({ kind: 'note', id: n.id }),
     item: noteToTreeItem(n),
     isFolder: false,
   }))
+}
 
-  return [...childFolders, ...noteItems]
+function rootChildren(deps: LoaderDeps): LoaderItem[] {
+  const tops = folderLoaderItems(deps, null)
+  const noteItems = noteChildItems(deps, ROOT_FOLDER_ID) ?? []
+  return [...tops, ...noteItems]
+}
+
+function folderChildren(deps: LoaderDeps, folderId: string): LoaderItem[] {
+  const childFolders = folderLoaderItems(deps, folderId)
+  const noteItems = noteChildItems(deps, folderId)
+  return noteItems ? [...childFolders, ...noteItems] : childFolders
 }
 
 function folderCmp(a: Folder, b: Folder, sort: SortKey): number {

--- a/frontend/src/viewer/tree/use-engram-tree.test.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.test.ts
@@ -6,37 +6,33 @@ import type { Folder, NoteSummary } from '../../api/queries'
 
 describe('treeStructureKey', () => {
   it('changes when a folder count changes (so a move rebuilds the tree)', () => {
-    const before = treeStructureKey([{ id: 'f1', count: 0, parent_id: null }], [], 'name-asc')
-    const after = treeStructureKey([{ id: 'f1', count: 1, parent_id: null }], [], 'name-asc')
+    const before = treeStructureKey([{ id: 'f1', count: 0, parent_id: null }], 'name-asc')
+    const after = treeStructureKey([{ id: 'f1', count: 1, parent_id: null }], 'name-asc')
     expect(after).not.toBe(before)
   })
 
   it('changes when a folder is reparented (folder move rebuilds the tree)', () => {
-    const before = treeStructureKey([{ id: 'f1', count: 0, parent_id: null }], [], 'name-asc')
-    const after = treeStructureKey([{ id: 'f1', count: 0, parent_id: 'p2' }], [], 'name-asc')
+    const before = treeStructureKey([{ id: 'f1', count: 0, parent_id: null }], 'name-asc')
+    const after = treeStructureKey([{ id: 'f1', count: 0, parent_id: 'p2' }], 'name-asc')
     expect(after).not.toBe(before)
   })
 
-  it('changes when root notes change', () => {
-    const before = treeStructureKey([{ id: 'f1', count: 0, parent_id: null }], [], 'name-asc')
-    const after = treeStructureKey([{ id: 'f1', count: 0, parent_id: null }], ['n1'], 'name-asc')
-    expect(after).not.toBe(before)
-  })
+  // Root-note changes no longer flow through the structure key — they live in
+  // the id-keyed cache under 'root' and rebuild via the QueryCache subscription
+  // (see the 'rebuilds … by-id list changes' test below).
 
   it('is stable when nothing structural changes', () => {
     expect(
-      treeStructureKey([{ id: 'f1', count: 2, parent_id: null }], ['n1'], 'name-asc'),
-    ).toBe(treeStructureKey([{ id: 'f1', count: 2, parent_id: null }], ['n1'], 'name-asc'))
+      treeStructureKey([{ id: 'f1', count: 2, parent_id: null }], 'name-asc'),
+    ).toBe(treeStructureKey([{ id: 'f1', count: 2, parent_id: null }], 'name-asc'))
   })
 })
 
 describe('useEngramTree', () => {
   const folders: Folder[] = [{ id: '1', parent_id: null, name: 'Projects', count: 1 }]
-  const rootNotes: NoteSummary[] = []
   const scrollRef = { current: null as HTMLDivElement | null }
   const baseDeps = {
     folders,
-    rootNotes,
     qc: new QueryClient(),
     vaultId: 'v',
     sort: 'name-asc' as const,
@@ -73,6 +69,30 @@ describe('useEngramTree', () => {
           updated_at: '',
         },
       ])
+    })
+
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+  })
+
+  it('rebuilds the tree when the root note list (by-id "root") changes', async () => {
+    const qc = new QueryClient()
+    const { result } = renderHook(() => useEngramTree({ ...baseDeps, qc }))
+    const spy = vi.spyOn(result.current.tree, 'rebuildTree')
+
+    // Root notes now live in the same id-keyed cache under the 'root' sentinel.
+    const note: NoteSummary = {
+      id: 'r1',
+      path: 'r1.md',
+      title: 'r1',
+      folder: '',
+      tags: [],
+      version: 1,
+      mtime: '',
+      created_at: '',
+      updated_at: '',
+    }
+    act(() => {
+      qc.setQueryData(['folder-notes-by-id', 'v', 'root'], [note])
     })
 
     await waitFor(() => expect(spy).toHaveBeenCalled())

--- a/frontend/src/viewer/tree/use-engram-tree.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.ts
@@ -16,11 +16,10 @@ import type { QueryClient } from '@tanstack/react-query'
 import { buildLoader, type SortKey, type LoaderItem } from './loader'
 import { ROOT_ID } from './types'
 import { resolveDropMove } from './drop-redirect'
-import type { Folder, NoteSummary } from '../../api/queries'
+import { ROOT_FOLDER_ID, type Folder, type NoteSummary } from '../../api/queries'
 
 interface Deps {
   folders: Folder[]
-  rootNotes: NoteSummary[]
   qc: QueryClient
   vaultId: string
   sort: SortKey
@@ -41,14 +40,17 @@ type Data = LoaderItem
  *  - a folder move reparents it, changing `parent_id`.
  * Without these, headless-tree keeps a stale per-folder child list after a move
  * until the user manually collapses/expands the folder.
+ *
+ * Note-list changes (including root notes, now keyed under ROOT_FOLDER_ID) are
+ * covered separately by the QueryCache subscription below, so they don't need
+ * to be fingerprinted here.
  */
 export function treeStructureKey(
   folders: Pick<Folder, 'id' | 'count' | 'parent_id'>[],
-  rootNoteIds: string[],
   sort: SortKey,
 ): string {
   const folderKey = folders.map((f) => `${f.id}:${f.count}:${f.parent_id ?? ''}`).join('|')
-  return `${folderKey}::${rootNoteIds.join('|')}::${sort}`
+  return `${folderKey}::${sort}`
 }
 
 export function useEngramTree(deps: Deps) {
@@ -59,17 +61,18 @@ export function useEngramTree(deps: Deps) {
       qc: deps.qc,
       vaultId: deps.vaultId,
       sort: deps.sort,
-      rootNotes: deps.rootNotes,
       fetchFolderNotes: deps.fetchFolderNotes,
       onChildrenLoaded: (folderId) => {
         const t = treeRef.current
         if (!t) return
-        const inst = t.getItemInstance(`f:${folderId}`)
+        // Root notes hang off the ROOT_ID container, not an `f:<id>` marker.
+        const itemId = folderId === ROOT_FOLDER_ID ? ROOT_ID : `f:${folderId}`
+        const inst = t.getItemInstance(itemId)
         // invalidateChildrenIds returns a promise but we don't need to await
         inst?.invalidateChildrenIds()
       },
     }),
-    [deps.folders, deps.qc, deps.vaultId, deps.sort, deps.rootNotes, deps.fetchFolderNotes],
+    [deps.folders, deps.qc, deps.vaultId, deps.sort, deps.fetchFolderNotes],
   )
 
   // Bridge our LoaderItem-returning loader to HT's TreeDataLoader<T> shape
@@ -165,11 +168,7 @@ export function useEngramTree(deps: Deps) {
   // data shape changes — keyed on stable structural fingerprints so we never
   // re-trigger from spurious identity churn (rebuildTree → setState → render
   // would otherwise spin into a max-update-depth loop).
-  const structureKey = treeStructureKey(
-    deps.folders,
-    deps.rootNotes.map((n) => n.id),
-    deps.sort,
-  )
+  const structureKey = treeStructureKey(deps.folders, deps.sort)
   const lastKey = useRef('')
   useEffect(() => {
     if (lastKey.current === structureKey) return

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.430",
+      version: "0.5.431",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

The folder tree read **root** notes from a path-keyed `['folderNotes', '']` `{notes}` cache and **subfolder** notes from `['folder-notes-by-id', id]` `NoteSummary[]`. Two caches, two shapes — so every note mutation had to patch both with root-vs-subfolder forks (a recurring "did you touch both caches?" footgun, documented under "remaining gaps" in `docs/context/folder-tree-optimistic-rebuild.md`).

This collapses the tree onto **one id-keyed cache, one shape**. Root keys under the existing `'root'` sentinel (already the backend's batch-move root target); its fetcher hits the path-keyed list endpoint since the by-id route requires a real folder id.

This is **follow-up A** of the two deferred items from #575.

## Changes
- `queries.ts`: new `ROOT_FOLDER_ID` + shared `fetchNotesForFolderId` (branches `'root'` → `/folders/list?folder=`). `useFolderNotesById` accepts `'root'`. `patchRowInList` drops its shape param. `useCreateNote` / `useDuplicateNote` / `useBatchDeleteNotes` / `useBatchMoveNotes` now patch a single id-keyed cache; `legacyListSnapshots` removed.
- `loader.ts`: root is just another folder id; dropped `deps.rootNotes` + the root special-case in `noteLoaderItem`.
- `use-engram-tree.ts`: dropped `rootNotes` dep; `treeStructureKey(folders, sort)` drops `rootNoteIds` (root changes rebuild via the existing by-id QueryCache subscription).
- `folder-tree.tsx`: `useFolderNotesById('root')` replaces `useFolderNotes('')`; the loader's lazy fetcher routes through `fetchNotesForFolderId` (fixes a would-be `/folders/by-id/root/notes` 404).
- `channel.ts`: a root note's `''` folder targets the `'root'` by-id key instead of the broad invalidation.

## Not changed
The dashboard's path-keyed `useFolderNotes` (non-root folder browse) stays; mutations still invalidate it for freshness.

## Test
- `bunx tsc --noEmit` clean (the CI gate via `build:saas`).
- `bun run test` green: 505 passed. (Two pre-existing unhandled-rejection errors in `device-link-page.test.tsx` reproduce on clean `main` — unrelated; vitest isn't run in CI anyway.)
- Updated `queries.test.tsx`, `loader.test.ts`, `use-engram-tree.test.ts`, `folder-tree.test.tsx`, `channel.test.ts` to the unified shape; added root-sentinel coverage in loader/tree/channel tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)