### PR TITLE
feat(frontend): non-blocking conflict resolution in the note editor

### DIFF
--- a/frontend/e2e/note-live-update.spec.ts
+++ b/frontend/e2e/note-live-update.spec.ts
@@ -11,8 +11,10 @@ import { test, expect, type Page } from '@playwright/test'
  *
  * The note view defaults to the editor (plain markdown source). A remote
  * update is applied into the live CodeMirror doc via a 3-way merge, so an
- * in-progress local draft is preserved rather than clobbered (no banner —
- * the merge is silent).
+ * in-progress local draft is preserved rather than clobbered. A CLEAN merge is
+ * silent; a TRUE conflict (line-level overlap) does NOT write markers silently
+ * — it surfaces a non-blocking ConflictBar (Keep mine / Take theirs / View
+ * merge) and keeps the draft until the user chooses.
  */
 
 const PASS = 'E2eTestPass!99'
@@ -196,6 +198,48 @@ test.describe('SPA viewer live-update (#277)', () => {
 
     await expect(editor).toContainText('remote-added-line', { timeout: 5_000 })
     await expect(editor).toContainText('draft-edit')
+
+    await ctx.close()
+  })
+
+  test('a true conflict surfaces a non-blocking bar and keeps the draft until resolved', async ({
+    browser,
+    baseURL,
+  }) => {
+    const email = `e2e-live-conflict-${Date.now()}@test.com`
+    const token = await registerAndLogin(baseURL!, email)
+    const vault = await createVault(baseURL!, token, `liveconflict-${Date.now()}`)
+    const path = 'live-conflict.md'
+    // Single line so the local + remote edits provably land on the same line
+    // (a line-level overlap is what makes node-diff3 report a conflict).
+    const { id: noteId } = await upsertNote(baseURL!, token, vault.id, path, 'shared line')
+
+    const ctx = await browser.newContext()
+    const page = await ctx.newPage()
+    await signInForNote(page, email, vault.id, noteId)
+
+    const editor = page.locator('.cm-content')
+    await expect(editor).toContainText('shared line', { timeout: 10_000 })
+
+    // Local draft: append to the shared line (do NOT save).
+    await editor.click()
+    await page.keyboard.press('Control+End')
+    await page.keyboard.type(' MINE')
+
+    // Remote client changes the SAME line — a true conflict.
+    await upsertNote(baseURL!, token, vault.id, path, 'shared line REMOTE')
+
+    // The non-blocking bar appears; the draft is NOT silently overwritten.
+    const bar = page.getByTestId('conflict-bar')
+    await expect(bar).toBeVisible({ timeout: 5_000 })
+    await expect(editor).toContainText('MINE')
+    await expect(editor).not.toContainText('REMOTE')
+
+    // Resolve with "Take theirs": the editor adopts the remote and the bar closes.
+    await bar.getByRole('button', { name: 'Take theirs' }).click()
+    await expect(bar).toBeHidden()
+    await expect(editor).toContainText('shared line REMOTE')
+    await expect(editor).not.toContainText('MINE')
 
     await ctx.close()
   })

--- a/frontend/e2e/note-live-update.spec.ts
+++ b/frontend/e2e/note-live-update.spec.ts
@@ -159,7 +159,7 @@ test.describe('SPA viewer live-update (#277)', () => {
     await ctx.close()
   })
 
-  test('a remote update merges into the editor without losing the local draft', async ({
+  test('a non-overlapping remote update merges silently without losing the local draft', async ({
     browser,
     baseURL,
   }) => {
@@ -172,32 +172,34 @@ test.describe('SPA viewer live-update (#277)', () => {
       token,
       vault.id,
       path,
-      '# Initial\n\noriginal text.',
+      '# Initial\n\nintro.\n\noriginal text.',
     )
 
     const ctx = await browser.newContext()
     const page = await ctx.newPage()
     await signInForNote(page, email, vault.id, noteId)
 
-    // Editor is the default mode; type a local unsaved edit into CodeMirror.
+    // Editor is the default mode; type a local unsaved edit at the END.
     const editor = page.locator('.cm-content')
     await expect(editor).toContainText('original text.', { timeout: 10_000 })
     await editor.click()
     await page.keyboard.press('Control+End')
     await page.keyboard.type(' draft-edit')
 
-    // Remote client lands an update (on a separate line) while the editor is
-    // dirty — the 3-way merge keeps the local draft AND folds in the remote.
+    // Remote edits a DIFFERENT region (the heading, far from the local edit),
+    // so the 3-way merge is clean: it folds in silently — no conflict bar —
+    // and keeps the local draft.
     await upsertNote(
       baseURL!,
       token,
       vault.id,
       path,
-      '# Initial\n\noriginal text.\n\nremote-added-line',
+      '# Heading remote\n\nintro.\n\noriginal text.',
     )
 
-    await expect(editor).toContainText('remote-added-line', { timeout: 5_000 })
+    await expect(editor).toContainText('Heading remote', { timeout: 5_000 })
     await expect(editor).toContainText('draft-edit')
+    await expect(page.getByTestId('conflict-bar')).toBeHidden()
 
     await ctx.close()
   })

--- a/frontend/src/viewer/conflict-bar.test.tsx
+++ b/frontend/src/viewer/conflict-bar.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ConflictBar } from './conflict-bar'
+
+function setup() {
+  const onKeepMine = vi.fn()
+  const onTakeTheirs = vi.fn()
+  const onViewMerge = vi.fn()
+  const onDismiss = vi.fn()
+  render(
+    <ConflictBar
+      onKeepMine={onKeepMine}
+      onTakeTheirs={onTakeTheirs}
+      onViewMerge={onViewMerge}
+      onDismiss={onDismiss}
+    />,
+  )
+  return { onKeepMine, onTakeTheirs, onViewMerge, onDismiss }
+}
+
+describe('ConflictBar', () => {
+  it('renders a non-blocking status bar with the three resolution actions', () => {
+    setup()
+    const bar = screen.getByTestId('conflict-bar')
+    expect(bar).toHaveAttribute('role', 'status')
+    expect(screen.getByRole('button', { name: 'Keep mine' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Take theirs' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'View merge' })).toBeInTheDocument()
+  })
+
+  it('fires onKeepMine', () => {
+    const { onKeepMine } = setup()
+    fireEvent.click(screen.getByRole('button', { name: 'Keep mine' }))
+    expect(onKeepMine).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onTakeTheirs', () => {
+    const { onTakeTheirs } = setup()
+    fireEvent.click(screen.getByRole('button', { name: 'Take theirs' }))
+    expect(onTakeTheirs).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onViewMerge', () => {
+    const { onViewMerge } = setup()
+    fireEvent.click(screen.getByRole('button', { name: 'View merge' }))
+    expect(onViewMerge).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onDismiss from the ✕ button', () => {
+    const { onDismiss } = setup()
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/viewer/conflict-bar.tsx
+++ b/frontend/src/viewer/conflict-bar.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@/components/ui/button'
+
+interface ConflictBarProps {
+  // Keep the local draft (already in the editor) and persist it over the
+  // newly-adopted remote base.
+  onKeepMine: () => void
+  // Replace the draft with the incoming remote content.
+  onTakeTheirs: () => void
+  // Apply the 3-way merge WITH git-style conflict markers for manual resolution.
+  onViewMerge: () => void
+  // Dismiss without an explicit choice — keeps the draft (same as Keep mine).
+  onDismiss: () => void
+}
+
+// Non-blocking conflict affordance. The default behavior on a conflicting
+// remote change is to KEEP the local draft visible (never silently overwrite
+// it with conflict markers); this bar gives the user agency to pick a
+// resolution. It sits above the editor rather than overlaying it, so editing
+// stays possible while it's shown.
+export function ConflictBar({
+  onKeepMine,
+  onTakeTheirs,
+  onViewMerge,
+  onDismiss,
+}: ConflictBarProps) {
+  return (
+    <aside
+      role="status"
+      aria-label="Conflicting change from another device"
+      data-testid="conflict-bar"
+      className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border bg-muted px-4 py-2 text-xs text-muted-foreground"
+    >
+      <span className="min-w-0 flex-1">
+        Another device changed this note in a way that conflicts with your unsaved edits.
+      </span>
+      <Button variant="ghost" size="sm" onClick={onKeepMine}>
+        Keep mine
+      </Button>
+      <Button variant="ghost" size="sm" onClick={onTakeTheirs}>
+        Take theirs
+      </Button>
+      <Button variant="ghost" size="sm" onClick={onViewMerge}>
+        View merge
+      </Button>
+      <Button variant="ghost" size="sm" aria-label="Dismiss" onClick={onDismiss}>
+        ✕
+      </Button>
+    </aside>
+  )
+}

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { forwardRef, useImperativeHandle } from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { NoteChangedPayload } from '../api/channel'
 
 // --- module mocks: isolate the SURFACE (no Save/Revert, toggle, editor) ---
 vi.mock('react-router', () => ({
@@ -19,6 +21,7 @@ const note = {
   content: 'hello',
 }
 
+const onEditSpy = vi.fn()
 vi.mock('../api/queries', () => ({
   useNote: () => ({ data: note, isLoading: false, error: null }),
   useSaveNoteContent: () => vi.fn().mockResolvedValue(2),
@@ -27,22 +30,45 @@ vi.mock('../api/queries', () => ({
 
 vi.mock('../api/active-vault', () => ({ useActiveVaultId: () => 'v1' }))
 
-vi.mock('../api/channel', () => ({ subscribeToNoteChanges: () => () => {} }))
+// Capture the channel subscriber so a test can fire a remote change.
+let fireRemote: ((p: NoteChangedPayload) => void) | null = null
+vi.mock('../api/channel', () => ({
+  subscribeToNoteChanges: (cb: (p: NoteChangedPayload) => void) => {
+    fireRemote = cb
+    return () => {
+      fireRemote = null
+    }
+  },
+}))
 
 vi.mock('../layout/right-sidebar-context', () => ({
   useRightSidebar: () => ({ setContent: vi.fn() }),
 }))
 
-// Editor mock that surfaces its `value` prop and can fire an edit, so we can
-// assert what content the editor (re)mounts with across mode toggles.
+// Editor mock: forwards the imperative handle (getDoc/applyRemote) note-page
+// drives, surfaces its `value` prop, and can fire an edit. `editorDoc` is the
+// live CodeMirror doc; tests set it to stage a local draft.
+let editorDoc = 'hello'
+const appliedRemote: string[] = []
 vi.mock('./note-editor', () => ({
-  default: (props: { value: string; onChange: (v: string) => void }) => (
-    <div data-testid="cm-editor">
-      <span data-testid="cm-value">{props.value}</span>
-      <button type="button" onClick={() => props.onChange('PASTED')}>
-        sim-edit
-      </button>
-    </div>
+  default: forwardRef(
+    (props: { value: string; onChange: (v: string) => void }, ref) => {
+      useImperativeHandle(ref, () => ({
+        getDoc: () => editorDoc,
+        applyRemote: (t: string) => {
+          editorDoc = t
+          appliedRemote.push(t)
+        },
+      }))
+      return (
+        <div data-testid="cm-editor">
+          <span data-testid="cm-value">{props.value}</span>
+          <button type="button" onClick={() => props.onChange('PASTED')}>
+            sim-edit
+          </button>
+        </div>
+      )
+    },
   ),
 }))
 
@@ -50,6 +76,17 @@ vi.mock('./note-view', () => ({ default: () => <div data-testid="note-view" /> }
 vi.mock('./note-toc', () => ({ default: () => <div data-testid="note-toc" /> }))
 
 import NotePage from './note-page'
+
+beforeEach(() => {
+  fireRemote = null
+  editorDoc = 'hello'
+  appliedRemote.length = 0
+  onEditSpy.mockReset()
+})
+
+function remote(content: string, version = 2): NoteChangedPayload {
+  return { event_type: 'upsert', id: 'n1', path: 'a.md', vault_id: 'v1', content, version }
+}
 
 describe('NotePage surface', () => {
   it('renders the editor by default with no Save or Revert button', async () => {
@@ -79,5 +116,79 @@ describe('NotePage surface', () => {
     // stale per-note initial value.
     await screen.findByTestId('cm-editor')
     expect(screen.getByTestId('cm-value')).toHaveTextContent('PASTED')
+  })
+})
+
+describe('NotePage conflict resolution', () => {
+  it('a clean remote merge applies silently — no conflict bar', async () => {
+    render(<NotePage />)
+    await screen.findByTestId('cm-editor')
+    // No local divergence on the changed region → clean merge.
+    editorDoc = 'hello'
+
+    act(() => fireRemote?.(remote('hello\n\nremote line')))
+
+    expect(screen.queryByTestId('conflict-bar')).toBeNull()
+    // The remote text was applied to the editor.
+    expect(appliedRemote).toContain('hello\n\nremote line')
+  })
+
+  it('a conflicting remote change surfaces the bar WITHOUT clobbering the draft', async () => {
+    render(<NotePage />)
+    await screen.findByTestId('cm-editor')
+
+    // Local draft diverges on the same line the remote also changes.
+    editorDoc = 'hello mine'
+    act(() => fireRemote?.(remote('hello theirs')))
+
+    expect(await screen.findByTestId('conflict-bar')).toBeInTheDocument()
+    // The draft must NOT be silently overwritten with remote/marker text.
+    expect(appliedRemote).toEqual([])
+    expect(editorDoc).toBe('hello mine')
+  })
+
+  it('Take theirs adopts the remote content and dismisses the bar', async () => {
+    render(<NotePage />)
+    await screen.findByTestId('cm-editor')
+    editorDoc = 'hello mine'
+    act(() => fireRemote?.(remote('hello theirs')))
+    await screen.findByTestId('conflict-bar')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Take theirs' }))
+
+    expect(screen.queryByTestId('conflict-bar')).toBeNull()
+    expect(appliedRemote).toContain('hello theirs')
+    expect(editorDoc).toBe('hello theirs')
+  })
+
+  it('View merge writes the marker text for manual cleanup', async () => {
+    render(<NotePage />)
+    await screen.findByTestId('cm-editor')
+    editorDoc = 'hello mine'
+    act(() => fireRemote?.(remote('hello theirs')))
+    await screen.findByTestId('conflict-bar')
+
+    fireEvent.click(screen.getByRole('button', { name: 'View merge' }))
+
+    expect(screen.queryByTestId('conflict-bar')).toBeNull()
+    // node-diff3 marker fences land in the applied text.
+    const applied = appliedRemote[appliedRemote.length - 1] ?? ''
+    expect(applied).toContain('<<<<<<<')
+    expect(applied).toContain('>>>>>>>')
+  })
+
+  it('Keep mine dismisses the bar and leaves the draft in place', async () => {
+    render(<NotePage />)
+    await screen.findByTestId('cm-editor')
+    editorDoc = 'hello mine'
+    act(() => fireRemote?.(remote('hello theirs')))
+    await screen.findByTestId('conflict-bar')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep mine' }))
+
+    expect(screen.queryByTestId('conflict-bar')).toBeNull()
+    expect(editorDoc).toBe('hello mine')
+    // 'mine' is the resolution — remote was never applied over the draft.
+    expect(appliedRemote).toEqual([])
   })
 })

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -12,7 +12,17 @@ import NoteToc from './note-toc'
 import NoteView from './note-view'
 import { merge3 } from './merge'
 import { useAutosave } from './use-autosave'
+import { ConflictBar } from './conflict-bar'
 import type { NoteEditorHandle } from './note-editor'
+
+// A remote change that conflicts with the open draft (line-level overlap).
+// We hold the three candidate texts so the user can pick a resolution from
+// the non-blocking ConflictBar instead of having markers written silently.
+interface PendingConflict {
+  mine: string
+  theirs: string
+  merged: string
+}
 
 // CodeMirror (language pkg + view) only loads when the editor first mounts.
 const NoteEditor = lazy(() => import('./note-editor'))
@@ -33,6 +43,8 @@ export default function NotePage() {
   const { setContent: setRightContent } = useRightSidebar()
 
   const [mode, setMode] = useState<Mode>('live')
+  // Non-null while a conflicting remote change is awaiting the user's choice.
+  const [conflict, setConflict] = useState<PendingConflict | null>(null)
 
   // `base` = last server-synced content; the common ancestor for 3-way merges.
   const baseRef = useRef('')
@@ -107,20 +119,59 @@ export default function NotePage() {
   // no longer echoes through onChange (see note-editor), so persist any merged-
   // in local edits explicitly: adopt the remote version as the new base, then
   // schedule a save of the merged text only when it differs from the remote.
+  //
+  // On a CLEAN merge this stays silent (the draft + remote fold together). On a
+  // TRUE conflict (line-level overlap) we do NOT write git-style markers into
+  // the doc; instead we keep the local draft visible and surface the
+  // non-blocking ConflictBar so the user picks the resolution. base/version
+  // still advance to the remote so a subsequent save rebases onto it.
   useEffect(() => {
     if (!note) return
     return subscribeToNoteChanges((p) => {
       if (p.id !== note.id || p.vault_id !== vaultId || p.content == null) return
+      const remote = p.content
       const local = editorRef.current?.getDoc() ?? docRef.current
-      const { text, conflict } = merge3(baseRef.current, local, p.content)
-      baseRef.current = p.content
-      docRef.current = text
-      editorRef.current?.applyRemote(text)
+      const { text, conflict: hasConflict } = merge3(baseRef.current, local, remote)
+      baseRef.current = remote
       if (p.version != null) setVersion(p.version)
-      if (text !== p.content) onEdit(text)
-      if (conflict) toast.message('Merged a conflicting change from another device')
+      if (hasConflict) {
+        // Keep the draft in the editor untouched; offer the choice.
+        setConflict({ mine: local, theirs: remote, merged: text })
+      } else {
+        docRef.current = text
+        editorRef.current?.applyRemote(text)
+        if (text !== remote) onEdit(text)
+      }
     })
   }, [note?.id, vaultId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Resolve an open conflict with the user's explicit choice. The local draft
+  // is never silently discarded: 'mine' persists the live draft over the new
+  // remote base, 'theirs' adopts the remote, 'merge' writes the marker'd text
+  // for manual cleanup. base/version already advanced when the conflict was
+  // raised, so each path saves at the right version.
+  const resolveConflict = useCallback(
+    (choice: 'mine' | 'theirs' | 'merge') => {
+      if (!conflict) return
+      if (choice === 'theirs') {
+        docRef.current = conflict.theirs
+        editorRef.current?.applyRemote(conflict.theirs)
+        // Matches the remote base already saved elsewhere — no save needed.
+      } else if (choice === 'merge') {
+        docRef.current = conflict.merged
+        editorRef.current?.applyRemote(conflict.merged)
+        onEdit(conflict.merged)
+      } else {
+        // Keep mine: persist whatever is currently in the editor (the draft,
+        // plus any keystrokes since the conflict was raised).
+        const live = editorRef.current?.getDoc() ?? conflict.mine
+        docRef.current = live
+        onEdit(live)
+      }
+      setConflict(null)
+    },
+    [conflict, onEdit],
+  )
 
   // Signal the onboarding tour that the user opened a note (step 1 gate).
   useEffect(() => {
@@ -204,6 +255,15 @@ export default function NotePage() {
           </Button>
         </div>
       </div>
+
+      {conflict && (
+        <ConflictBar
+          onKeepMine={() => resolveConflict('mine')}
+          onTakeTheirs={() => resolveConflict('theirs')}
+          onViewMerge={() => resolveConflict('merge')}
+          onDismiss={() => resolveConflict('mine')}
+        />
+      )}
 
       {mode === 'reading' ? (
         <ScrollArea className="min-h-0 flex-1">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.432",
+      version: "0.5.433",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

When a remote `note_changed` lands while the editor is open with a **conflicting** draft, the 3-way merge used to silently inject git-style `<<<<<<< / ======= / >>>>>>>` markers into the live doc and autosave them — the user got only a toast, no say.

Now:
- **Clean merge** → silent (draft + remote fold together), unchanged.
- **True conflict** (line-level overlap) → keep the local draft in the editor untouched and surface a **non-blocking `ConflictBar`** with **Keep mine / Take theirs / View merge**. `base`/version still advance to the remote so the chosen resolution saves at the right version. The draft is never silently discarded; dismiss = Keep mine.

This is **follow-up B** of the two deferred items from #575. Per the brief, the silent merge stays the default — no blocking banner was reintroduced.

## Changes
- `conflict-bar.tsx` — new non-blocking bar (semantic `<aside role="status">`, design-token styling, no palette/`!important`).
- `note-page.tsx` — the channel handler branches on `merge3`'s `conflict` flag; `resolveConflict('mine'|'theirs'|'merge')` applies the choice via the existing annotation-guarded `applyRemote`/`getDoc`.
- `note-page.test.tsx` — conflict integration tests (clean stays silent; conflict shows the bar without clobbering the draft; Keep mine / Take theirs / View merge each apply correctly) with a ref-forwarding editor mock + capturable channel callback.
- `conflict-bar.test.tsx` — renders the three actions + fires each callback.
- `e2e/note-live-update.spec.ts` — same-line local+remote edit raises the bar, keeps the draft, and Take theirs adopts the remote.

## Test
- `bunx tsc --noEmit` clean (the CI gate via `build:saas`).
- `bun run test` green: 512 passed. (Two pre-existing unhandled-rejection errors in `device-link-page.test.tsx` reproduce on clean `main` — unrelated; vitest isn't run in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)