### PR TITLE
fix(cors): allow PATCH in preflight allow-methods

### DIFF
--- a/lib/engram_web/plugs/cors.ex
+++ b/lib/engram_web/plugs/cors.ex
@@ -29,7 +29,7 @@ defmodule EngramWeb.Plugs.CORS do
   defp put_cors_headers(conn) do
     conn
     |> put_resp_header("access-control-allow-origin", resolve_origin(conn))
-    |> put_resp_header("access-control-allow-methods", "GET, POST, PUT, DELETE, OPTIONS")
+    |> put_resp_header("access-control-allow-methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
     |> put_resp_header("access-control-allow-headers", "authorization, content-type, x-vault-id")
     |> put_resp_header("access-control-max-age", "86400")
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.434",
+      version: "0.5.435",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/plugs/cors_test.exs
+++ b/test/engram_web/plugs/cors_test.exs
@@ -24,6 +24,21 @@ defmodule EngramWeb.Plugs.CORSTest do
     assert String.contains?(String.downcase(allow_headers), "x-vault-id")
   end
 
+  test "preflight allows PATCH — the SPA verb for /onboarding/profile and friends" do
+    # The web SPA's api client (api/client.ts) exposes patch (no put), and
+    # several routes use PATCH: /onboarding/profile, /me, /vaults/:id,
+    # /registration, /users/:id. If PATCH is absent from
+    # access-control-allow-methods the browser blocks the preflight and
+    # onboarding (and every PATCH call) fails with a CORS error in prod.
+    conn =
+      build_conn()
+      |> put_req_header("origin", "https://app.engram.dev")
+      |> options("/api/health")
+
+    [allow_methods] = get_resp_header(conn, "access-control-allow-methods")
+    assert String.contains?(String.upcase(allow_methods), "PATCH")
+  end
+
   test "non-OPTIONS requests also receive the CORS origin header" do
     # The plug runs before the router on all requests, not just preflight.
     conn =


### PR DESCRIPTION
## Problem

Prod onboarding is broken. From `app.engram.page`, the PATCH to `/onboarding/profile` fails preflight:

```
Access to fetch at 'https://api.engram.page/onboarding/profile' from origin
'https://app.engram.page' has been blocked by CORS policy: Method PATCH is not
allowed by Access-Control-Allow-Methods in preflight response.
```

## Root cause

`EngramWeb.Plugs.CORS` set `access-control-allow-methods` to a static
`GET, POST, PUT, DELETE, OPTIONS` — **no PATCH**. The header is hardcoded and
does not reflect the matched route's verb, so any PATCH request is rejected at
preflight regardless of whether a PATCH route exists.

Six routes use PATCH, all reachable from the browser SPA (whose api client
exposes `patch`, not `put`):
- `PATCH /onboarding/profile`
- `PATCH /me`
- `PATCH /vaults/:id`
- `PATCH /registration`
- `PATCH /users/:id`

## Why it escaped tests

Non-browser clients (Obsidian Electron, curl) skip CORS preflight entirely, so
the API + Obsidian E2E suites never exercised it. Only the web SPA hits the wall.

## Fix

Add `PATCH` to the allow-methods list. One line.

## Test

Added a failing-first test in `cors_test.exs` asserting preflight advertises
PATCH. Full plug suite green (12 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)