### PR TITLE
fix(e2e): Sync Center/modal UI test updates + Clerk leak fixes

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -525,6 +525,12 @@ class CdpClient:
                 const p = {PLUGIN_PATH};
                 if (p.__origRunSyncFromChoice) return 'already-installed';
                 p.__origRunSyncFromChoice = p.runSyncFromChoice.bind(p);
+                // runSyncWithProgress wraps runSyncFromChoice with a live
+                // progress modal. Bypass it under the spy so the dispatch test
+                // doesn't leave a (never-completing, swallowed) progress modal
+                // mounted across parametrized runs.
+                p.__origRunSyncWithProgress = p.runSyncWithProgress.bind(p);
+                p.runSyncWithProgress = async (choice) => p.runSyncFromChoice(choice);
                 p.__lastSyncChoice = null;
                 const swallow = {swallow_js};
                 p.runSyncFromChoice = async (choice) => {{
@@ -552,6 +558,10 @@ class CdpClient:
                 const p = {PLUGIN_PATH};
                 if (!p.__origRunSyncFromChoice) return 'not-installed';
                 p.runSyncFromChoice = p.__origRunSyncFromChoice;
+                if (p.__origRunSyncWithProgress) {{
+                    p.runSyncWithProgress = p.__origRunSyncWithProgress;
+                    delete p.__origRunSyncWithProgress;
+                }}
                 delete p.__origRunSyncFromChoice;
                 delete p.__lastSyncChoice;
                 return 'removed';
@@ -1352,10 +1362,11 @@ class CdpClient:
     #     data-category, data-count, data-path, data-action, data-status,
     #     .engram-ignored-item, .engram-restore, .engram-activity-entry,
     #     .engram-clear-activity) that do not exist in source.
-    #   - Source uses: .engram-sync-center-group, .engram-sync-center-issue-row,
-    #     .engram-sync-center-activity-row, .engram-sync-center-group-head
-    #     (text contains category label + count), button text "Open"/"Ignore"
-    #     /"Restore", .engram-sync-center-activity-action, etc.
+    #   - Source uses: .engram-sync-center-card (needs-attention, title in
+    #     .engram-sync-center-card-title), .engram-sync-center-issue-row,
+    #     .engram-sync-center-activity-row (text contains category label +
+    #     count), button text "Open"/"Ignore"/"Restore",
+    #     .engram-sync-center-activity-action, etc.
     #   - Data attributes (data-category, data-count, data-path, data-action,
     #     data-status) are ABSENT from the plugin source — helpers below use
     #     structural/text queries instead. Tests that depend on .dataset will
@@ -1371,18 +1382,19 @@ class CdpClient:
     async def get_issue_groups(self) -> list[dict]:
         """Return [{category, count, items: [{path, actions:[...]}]}].
 
-        Falls back to structural parsing since source has no data-category /
-        data-count / data-path attributes. category is taken from the h4
-        heading text; count from issues in the list; path from the
-        .engram-sync-center-issue-path div text.
+        The Sync Center "Needs attention" area renders one card per failure
+        reason (.engram-sync-center-card): category from the card title, file
+        rows from .engram-sync-center-issue-row inside (in a collapsed "Show
+        files" expander — still in the DOM). Source has no data-* attributes,
+        so we parse structurally.
         """
         return await self.evaluate(
             "Array.from(document.querySelectorAll("
-            "'.engram-sync-center .engram-sync-center-group')).map(g => ({"
-            "category: g.querySelector('.engram-sync-center-group-head')?.firstChild"
+            "'.engram-sync-center .engram-sync-center-card')).map(c => ({"
+            "category: c.querySelector('.engram-sync-center-card-title')"
             "?.textContent?.trim() || '',"
-            "count: g.querySelectorAll('.engram-sync-center-issue-row').length,"
-            "items: Array.from(g.querySelectorAll('.engram-sync-center-issue-row')).map(i => ({"
+            "count: c.querySelectorAll('.engram-sync-center-issue-row').length,"
+            "items: Array.from(c.querySelectorAll('.engram-sync-center-issue-row')).map(i => ({"
             "path: i.querySelector('.engram-sync-center-issue-path')?.textContent?.trim() || '',"
             "actions: Array.from(i.querySelectorAll('.engram-sync-center-issue-actions button'))"
             ".map(b => b.textContent.trim())}))"

--- a/e2e/helpers/cleanup.py
+++ b/e2e/helpers/cleanup.py
@@ -9,6 +9,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from helpers.clerk_constants import is_e2e_clerk_email
+
 logger = logging.getLogger(__name__)
 
 VAULT_PATHS = [
@@ -92,9 +94,6 @@ def cleanup_clerk_users(clerk_client, clerk_user_ids: list[str]) -> None:
             logger.warning("Failed to delete Clerk user %s: %s", user_id, e)
 
 
-_E2E_EMAIL_PREFIXES = ("e2e-sync-", "e2e-iso-", "e2e-vault-iso-", "e2e-oauth-", "e2e-clerk-")
-
-
 def cleanup_all_e2e_clerk_users(clerk_client, run_id: str | None = None) -> int:
     """Find and delete e2e-* users in the Clerk instance.
 
@@ -125,8 +124,7 @@ def cleanup_all_e2e_clerk_users(clerk_client, run_id: str | None = None) -> int:
             break
         for user in batch:
             emails = [ea["email_address"] for ea in user.get("email_addresses", [])]
-            is_e2e = any(e.startswith(pfx) for e in emails for pfx in _E2E_EMAIL_PREFIXES)
-            if not is_e2e:
+            if not any(is_e2e_clerk_email(e) for e in emails):
                 continue
             if run_marker is not None and not any(run_marker in e for e in emails):
                 continue

--- a/e2e/helpers/clerk.py
+++ b/e2e/helpers/clerk.py
@@ -13,6 +13,8 @@ import random
 import time
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +55,23 @@ class ClerkClient:
         self.session.headers["Authorization"] = f"Bearer {secret_key}"
         self.session.headers["Content-Type"] = "application/json"
         self.base_url = "https://api.clerk.dev/v1"
+        # Clerk rate-limits the Backend API (429). Without backoff, a burst of
+        # e2e runs fails create/delete hard mid-suite — which then skips the
+        # per-test cleanup and leaks users (compounding the quota problem).
+        # Retry 429 + transient 5xx with exponential backoff, honoring the
+        # Retry-After header. POST/DELETE are included: a 429'd request was
+        # rejected (not processed), and create_user already handles the
+        # idempotent "identifier taken" case, so retrying is safe.
+        retry = Retry(
+            total=5,
+            backoff_factor=1.0,  # 1s, 2s, 4s, 8s, 16s
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=frozenset({"GET", "POST", "DELETE"}),
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("https://", adapter)
 
     def find_user_by_email(self, email: str) -> str | None:
         """Find a Clerk user ID by email address. Returns user_id or None."""
@@ -111,7 +130,22 @@ class ClerkClient:
         # Block until Clerk's session endpoint can see this user. Without
         # this, every downstream caller (create_session_token, JWT mint,
         # etc.) races Clerk's propagation lag — see #193.
-        self._wait_until_session_ready(user_id)
+        #
+        # If readiness fails (timeout, rate-limit), the user already exists in
+        # Clerk but the id never reaches the caller's try/finally — so it would
+        # orphan and leak. Delete it best-effort before propagating the error.
+        try:
+            self._wait_until_session_ready(user_id)
+        except Exception:
+            logger.warning(
+                "session-ready failed for %s (%s) — deleting to avoid orphan",
+                user_id, email,
+            )
+            try:
+                self.delete_user(user_id)
+            except Exception as del_err:
+                logger.error("orphan cleanup failed for %s: %s", user_id, del_err)
+            raise
         return user_id
 
     def _wait_until_session_ready(self, user_id: str) -> None:

--- a/e2e/helpers/clerk_constants.py
+++ b/e2e/helpers/clerk_constants.py
@@ -1,0 +1,20 @@
+"""Canonical identification of e2e-created Clerk users.
+
+Single source of truth shared by the in-run sweep (helpers/cleanup.py) and the
+hourly reaper (scripts/cleanup_clerk_users.py). Historically each used its own
+hard-coded list of email *prefixes*, and every new test suite added a prefix
+(e2e-conn-, e2e-free-signup-, e2e-cancel-free-, …) that one or both lists
+forgot — so those users leaked until the dev-tier 100-user cap was hit (#558).
+
+Every e2e Clerk user is minted with an ``e2e-`` local part AND the
+``+clerk_test`` plus-tag (the dev-instance "don't deliver email" convention,
+see helpers/clerk.py + conftest.py). Matching on that signature is robust to
+new suites and cannot match a real user.
+"""
+
+from __future__ import annotations
+
+
+def is_e2e_clerk_email(email: str) -> bool:
+    """True iff `email` belongs to an e2e-minted Clerk test user."""
+    return email.startswith("e2e-") and "+clerk_test@" in email

--- a/e2e/scripts/cleanup_clerk_users.py
+++ b/e2e/scripts/cleanup_clerk_users.py
@@ -27,30 +27,12 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 CLERK_API = "https://api.clerk.dev/v1"
-E2E_EMAIL_PREFIXES = (
-    "e2e-sync-",
-    "e2e-iso-",
-    "e2e-vault-iso-",
-    "e2e-oauth-",
-    "e2e-clerk-",
-    # Playwright frontend e2e (frontend/e2e/global-setup.ts) self-cleans
-    # its own prefix at setup, but only when the job runs successfully.
-    # When e2e-browser fails (Clerk quota, runner OOM, etc.) those users
-    # leak; this reaper is the safety net. The 1h --older-than filter
-    # protects in-flight Playwright runs from being culled.
-    "e2e-browser-",
-    # Onboarding wizard tests from the signup wizard work (PR #142 era).
-    # The test code is gone but Clerk users persist; 70+ accumulated
-    # since 2026-05-15 and ate most of the dev-tier 100-user cap.
-    "e2e-onboard-",
-    # Free-tier launch suite (PR #502): attachment quota, signup-on-free,
-    # cancel-into-free. Each test fixture creates its own Clerk user that
-    # leaks when the job fails post-create; ~100 accumulated by 2026-06-09
-    # and re-hit the dev-tier 100-user cap.
-    "e2e-free-att-",
-    "e2e-free-signup-",
-    "e2e-cancel-free-",
-)
+
+# Identify e2e users via the shared predicate (e2e- local part + +clerk_test
+# tag) rather than a per-suite prefix list — the old hard-coded lists kept
+# missing new suites (e2e-conn-, …), leaking users until the 100-user cap (#558).
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+from helpers.clerk_constants import is_e2e_clerk_email  # noqa: E402
 
 
 def get_all_users(session: requests.Session) -> list[dict]:
@@ -77,11 +59,10 @@ def get_all_users(session: requests.Session) -> list[dict]:
 
 def is_e2e_user(user: dict) -> bool:
     """Check if a Clerk user was created by E2E tests."""
-    for ea in user.get("email_addresses", []):
-        email = ea.get("email_address", "")
-        if any(email.startswith(prefix) for prefix in E2E_EMAIL_PREFIXES):
-            return True
-    return False
+    return any(
+        is_e2e_clerk_email(ea.get("email_address", ""))
+        for ea in user.get("email_addresses", [])
+    )
 
 
 _DURATION_RE = re.compile(r"^(\d+)([smhd])$")

--- a/e2e/tests/test_51_sync_preview_modal.py
+++ b/e2e/tests/test_51_sync_preview_modal.py
@@ -88,7 +88,7 @@ async def test_modal_appears_on_first_sync(vault_a, cdp_a):
 @pytest.mark.parametrize(
     "label, expected_choice, destructive",
     [
-        ("Merge", "smart-merge", False),
+        ("Sync", "smart-merge", False),
         ("Push all + keep remote", "push-all-keep-remote", False),
         ("Pull all + keep local", "pull-all-keep-local", False),
         ("Push all + delete remote", "push-all-delete-remote", True),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.437",
+      version: "0.5.438",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Two related e2e fixes (folded together per request). Version 0.5.437 → 0.5.438.

## 1. Plugin UI test updates (was the original scope)
The plugin PR (engram-app/Engram-obsidian#101) renames the sync-modal "Merge" → "Sync" and redesigns the Sync Center issues panel into per-reason cards. #101's `backend/e2e` check runs against backend **main**, so these must land here first.
- `test_51`: dispatch param `"Merge"` → `"Sync"`.
- `cdp.get_issue_groups()`: read `.engram-sync-center-card` / `-card-title` (cards) instead of the removed `.engram-sync-center-group`.
- choice spy: neutralize `runSyncWithProgress` so the new live progress modal doesn't linger across parametrized runs.

## 2. Clerk test-user leak + 429 resilience (root-caused this session)
Recurring Clerk `403` (quota) / `429` (rate-limit) e2e failures. #558 fixed only the dead reaper cron; these are the upstream leaks:
- **A — no backoff on Clerk Backend API.** A burst of runs gets 429'd on `POST /users`, fails the suite mid-run, which skips per-test cleanup → leaks. Added a urllib3 `Retry` adapter (429 + transient 5xx, exponential backoff, honors `Retry-After`).
- **B — orphan-on-partial-failure.** `create_user` created the user, then awaited `_wait_until_session_ready`; if that threw, the id never reached the caller's `try/finally` → orphan. Now best-effort deletes it before re-raising.
- **C — brittle prefix lists.** Both the in-run sweep and the reaper hard-coded email prefixes, and new suites kept being missed (`e2e-conn-` was absent from **both** → test_71's ~10 users/run never swept). Replaced with one shared predicate `helpers/clerk_constants.is_e2e_clerk_email` (`e2e-` local part + `+clerk_test` tag) — robust to new suites, can't match a real user.

Verified via mock (retry config, orphan-delete, predicate) + the reaper script still imports/runs. Does **not** retroactively delete existing orphans — clear those via `cleanup_clerk_users.py` or the hourly reaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)