### PR TITLE
feat: show image/PDF attachments in the web file tree (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-attachments-in-file-tree.md
+++ b/docs/superpowers/plans/2026-06-14-attachments-in-file-tree.md
@@ -29,7 +29,7 @@
 
 **Frontend**
 - Modify `frontend/src/viewer/tree/types.ts` — `attachment` TreeItem variant + id encode/decode.
-- Modify `frontend/src/api/queries.ts` — `AttachmentSummary` type + `useAttachments` + `fetchAttachments`.
+- Modify `frontend/src/api/queries.ts` — `AttachmentSummary` type + `useAttachments`. (No `fetchAttachments`: the full attachment list loads eagerly via the hook — there's no per-folder lazy fetch like notes have.)
 - Create `frontend/src/viewer/tree/synthesize-folders.ts` — pure helper.
 - Modify `frontend/src/viewer/tree/loader.ts` — bucket attachments into folder/root children.
 - Modify `frontend/src/viewer/tree/use-engram-tree.ts` — thread `attachments` into the loader + structure key.

--- a/docs/superpowers/plans/2026-06-14-attachments-in-file-tree.md
+++ b/docs/superpowers/plans/2026-06-14-attachments-in-file-tree.md
@@ -1,0 +1,1419 @@
+# Attachments in the Web File Tree — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show image/PDF (and other binary) attachments in the web SPA file tree and let users click to open a read-only preview.
+
+**Architecture:** A new `GET /api/attachments` lists vault attachment metadata; the existing `GET /api/attachments/*path` gains a `?raw=1` mode that streams real bytes (fixing the latent `AttachmentImg` bug). The frontend tree loader buckets attachments into their folders by path, synthesizing any folder that exists only because it holds attachments, and renders each as a `<Link>` to a new `/attachment/*` preview page.
+
+**Tech Stack:** Elixir/Phoenix + ExUnit (backend); React + react-router + @tanstack/react-query + @headless-tree + Vite + bun test (frontend).
+
+**Repo / worktree:** `engram/.worktrees/attachments-in-tree`, branch `feat/attachments-in-file-tree`. Single PR (backend + frontend).
+
+**Commands:**
+- Backend single test: `mix test path/to/test.exs:LINE`
+- Backend all: `mix test`
+- Frontend single: `bun test path/to/file.test.tsx`
+- Frontend all: `bun test`
+- Pre-push lints (frontend): `bun run lint:obsidian && bun run lint:css && bunx biome check .`
+
+---
+
+## File structure
+
+**Backend**
+- Modify `lib/engram/attachments.ex` — add `list_attachments/2`; extract a shared decrypt-map builder.
+- Modify `lib/engram_web/controllers/attachments_controller.ex` — add `index/2`; add `?raw=1` branch to `show/2`.
+- Modify `lib/engram_web/router.ex` — add `get "/attachments"` route (before the `*path` splat).
+- Test `test/engram/attachments_test.exs`, `test/engram_web/controllers/attachments_controller_test.exs`.
+
+**Frontend**
+- Modify `frontend/src/viewer/tree/types.ts` — `attachment` TreeItem variant + id encode/decode.
+- Modify `frontend/src/api/queries.ts` — `AttachmentSummary` type + `useAttachments` + `fetchAttachments`.
+- Create `frontend/src/viewer/tree/synthesize-folders.ts` — pure helper.
+- Modify `frontend/src/viewer/tree/loader.ts` — bucket attachments into folder/root children.
+- Modify `frontend/src/viewer/tree/use-engram-tree.ts` — thread `attachments` into the loader + structure key.
+- Modify `frontend/src/viewer/tree/tree-row.tsx` — attachment row (icon + link + badge).
+- Modify `frontend/src/api/client.ts` — `getBlob` accepts optional headers (unused now, but keeps the option open) — **skip**; instead append `?raw=1` at call sites.
+- Modify `frontend/src/viewer/attachment-img.tsx` — fetch with `?raw=1`.
+- Create `frontend/src/viewer/attachment-page.tsx` — preview page.
+- Modify `frontend/src/router.tsx` — lazy `AttachmentPage` + `/attachment/*` route.
+- Modify `frontend/src/viewer/folder-tree.tsx` — `useAttachments` + `synthesizeFolders` + pass through; `onMove` target guard.
+- Tests: `types.test.ts`, `synthesize-folders.test.ts`, `loader.test.ts`, `tree-row.test.tsx`, `attachment-img.test.tsx`, `attachment-page.test.tsx`.
+
+---
+
+## Task 1: Backend — `Attachments.list_attachments/2`
+
+**Files:**
+- Modify: `lib/engram/attachments.ex`
+- Test: `test/engram/attachments_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Find the existing `list_changes` test in `test/engram/attachments_test.exs` for the setup pattern (user, vault, `upsert_attachment`). Add:
+
+```elixir
+describe "list_attachments/2" do
+  test "returns non-deleted attachment metadata for the vault", %{user: user, vault: vault} do
+    {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+      "path" => "img/a.png",
+      "content_base64" => Base.encode64("PNGDATA"),
+      "mime_type" => "image/png"
+    })
+    {:ok, b} = Attachments.upsert_attachment(user, vault, %{
+      "path" => "b.pdf",
+      "content_base64" => Base.encode64("PDFDATA"),
+      "mime_type" => "application/pdf"
+    })
+    :ok = Attachments.delete_attachment(user, vault, "b.pdf")
+
+    {:ok, list} = Attachments.list_attachments(user, vault)
+
+    paths = Enum.map(list, & &1.path)
+    assert "img/a.png" in paths
+    refute "b.pdf" in paths
+
+    a = Enum.find(list, &(&1.path == "img/a.png"))
+    assert a.mime_type == "image/png"
+    assert a.size_bytes == byte_size("PNGDATA")
+    assert Map.has_key?(a, :updated_at)
+    refute Map.has_key?(a, :deleted_at)
+    # b is referenced only to assert deletion filtering
+    assert b.path == "b.pdf"
+  end
+
+  test "scopes to the given user+vault", %{user: user, vault: vault} do
+    other = user_fixture()
+    other_vault = vault_fixture(other)
+    {:ok, _} = Attachments.upsert_attachment(other, other_vault, %{
+      "path" => "secret.png",
+      "content_base64" => Base.encode64("X"),
+      "mime_type" => "image/png"
+    })
+
+    {:ok, list} = Attachments.list_attachments(user, vault)
+    refute Enum.any?(list, &(&1.path == "secret.png"))
+  end
+end
+```
+
+(Use the same fixture helpers the file already imports — match `user_fixture`/`vault_fixture` to the existing test's setup; if the existing test destructures `%{user: user, vault: vault}` from a `setup`, reuse it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram/attachments_test.exs -k "list_attachments"`
+Expected: FAIL — `function Engram.Attachments.list_attachments/2 is undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `lib/engram/attachments.ex`, refactor `list_changes/3` to share a private mapper and add `list_attachments/2`. Replace the existing `list_changes/3` body's `Enum.map` with a call to `decrypt_metadata/2`, and add:
+
+```elixir
+@doc """
+Lists non-deleted attachment metadata for a vault (no content).
+"""
+def list_attachments(user, vault) do
+  user = fresh_user(user)
+
+  Repo.with_tenant(user.id, fn ->
+    from(a in Attachment,
+      where: a.user_id == ^user.id and a.vault_id == ^vault.id and is_nil(a.deleted_at),
+      order_by: [asc: a.updated_at]
+    )
+    |> Repo.all()
+  end)
+  |> unwrap_tenant()
+  |> case do
+    {:ok, atts} ->
+      {:ok, Enum.map(atts, fn att -> Map.delete(decrypt_metadata(att, user), :deleted_at) end)}
+
+    err ->
+      err
+  end
+end
+
+defp decrypt_metadata(att, user) do
+  {:ok, decrypted} = Crypto.maybe_decrypt_attachment_fields(att, user)
+
+  %{
+    path: decrypted.path,
+    mime_type: decrypted.mime_type,
+    size_bytes: decrypted.size_bytes,
+    mtime: decrypted.mtime,
+    updated_at: decrypted.updated_at,
+    deleted_at: decrypted.deleted_at
+  }
+end
+```
+
+And change `list_changes/3`'s mapper to `Enum.map(atts, &decrypt_metadata(&1, user))`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `mix test test/engram/attachments_test.exs`
+Expected: PASS (both new tests + existing `list_changes` tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/attachments.ex test/engram/attachments_test.exs
+git commit -m "feat(attachments): add list_attachments/2 context fn"
+```
+
+---
+
+## Task 2: Backend — `GET /api/attachments` endpoint
+
+**Files:**
+- Modify: `lib/engram_web/controllers/attachments_controller.ex`
+- Modify: `lib/engram_web/router.ex`
+- Test: `test/engram_web/controllers/attachments_controller_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/engram_web/controllers/attachments_controller_test.exs` (reuse its existing authenticated-conn setup):
+
+```elixir
+describe "GET /api/attachments (index)" do
+  test "lists non-deleted attachments", %{conn: conn, user: user, vault: vault} do
+    {:ok, _} = Engram.Attachments.upsert_attachment(user, vault, %{
+      "path" => "diagrams/arch.png",
+      "content_base64" => Base.encode64("PNG"),
+      "mime_type" => "image/png"
+    })
+
+    resp = conn |> get(~p"/api/attachments") |> json_response(200)
+
+    assert [%{"path" => "diagrams/arch.png", "mime_type" => "image/png"} = a] = resp["attachments"]
+    assert a["size_bytes"] == 3
+    assert Map.has_key?(a, "updated_at")
+  end
+
+  test "returns empty list for a vault with no attachments", %{conn: conn} do
+    resp = conn |> get(~p"/api/attachments") |> json_response(200)
+    assert resp["attachments"] == []
+  end
+
+  test "401 without auth", %{vault: _vault} do
+    conn = build_conn() |> get(~p"/api/attachments")
+    assert conn.status in [401, 403]
+  end
+end
+```
+
+(Match the auth-bypass / vault-assign setup the rest of this file uses; if it uses a `register_and_log_in` style helper, reuse it for the authed cases and a bare `build_conn()` for the 401 case.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram_web/controllers/attachments_controller_test.exs -k "index"`
+Expected: FAIL — no route for `GET /api/attachments` (likely matches the `*path` splat → 404 "attachment not found", or a `Phoenix.Router.NoRouteError`).
+
+- [ ] **Step 3: Implement**
+
+In `lib/engram_web/router.ex`, add the index route **before** the splat (so `/attachments` isn't captured as a path):
+
+```elixir
+    # Attachments
+    post "/attachments", AttachmentsController, :upload
+    get "/attachments", AttachmentsController, :index
+    get "/attachments/changes", AttachmentsController, :changes
+    get "/attachments/*path", AttachmentsController, :show
+    delete "/attachments/*path", AttachmentsController, :delete
+```
+
+In `lib/engram_web/controllers/attachments_controller.ex`, add:
+
+```elixir
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    {:ok, atts} = Attachments.list_attachments(user, vault)
+
+    json(conn, %{
+      attachments:
+        Enum.map(atts, fn a ->
+          %{
+            path: a.path,
+            mime_type: a.mime_type,
+            size_bytes: a.size_bytes,
+            mtime: a.mtime,
+            updated_at: a.updated_at
+          }
+        end)
+    })
+  end
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `mix test test/engram_web/controllers/attachments_controller_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram_web/router.ex lib/engram_web/controllers/attachments_controller.ex test/engram_web/controllers/attachments_controller_test.exs
+git commit -m "feat(attachments): GET /api/attachments list endpoint"
+```
+
+---
+
+## Task 3: Backend — `?raw=1` raw-bytes mode on `show`
+
+**Files:**
+- Modify: `lib/engram_web/controllers/attachments_controller.ex`
+- Test: `test/engram_web/controllers/attachments_controller_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+describe "GET /api/attachments/*path?raw=1" do
+  test "streams raw bytes with the attachment Content-Type", %{conn: conn, user: user, vault: vault} do
+    {:ok, _} = Engram.Attachments.upsert_attachment(user, vault, %{
+      "path" => "p.png",
+      "content_base64" => Base.encode64("RAWBYTES"),
+      "mime_type" => "image/png"
+    })
+
+    conn = get(conn, ~p"/api/attachments/p.png?raw=1")
+
+    assert conn.status == 200
+    assert response_content_type(conn, :png) =~ "image/png"
+    assert conn.resp_body == "RAWBYTES"
+  end
+
+  test "without raw still returns JSON with content_base64", %{conn: conn, user: user, vault: vault} do
+    {:ok, _} = Engram.Attachments.upsert_attachment(user, vault, %{
+      "path" => "q.png",
+      "content_base64" => Base.encode64("BYTES"),
+      "mime_type" => "image/png"
+    })
+
+    resp = conn |> get(~p"/api/attachments/q.png") |> json_response(200)
+    assert resp["content_base64"] == Base.encode64("BYTES")
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram_web/controllers/attachments_controller_test.exs -k "raw"`
+Expected: FAIL — `?raw=1` request returns JSON (`conn.resp_body` is a JSON string, not `"RAWBYTES"`).
+
+- [ ] **Step 3: Implement**
+
+Replace the `show/2` head + its `{:ok, att}` branch in `lib/engram_web/controllers/attachments_controller.ex`:
+
+```elixir
+  def show(conn, %{"path" => path_parts} = params) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+    path = Path.join(path_parts)
+
+    case Attachments.get_attachment(user, vault, path) do
+      {:ok, nil} ->
+        conn |> put_status(404) |> json(%{error: "attachment not found"})
+
+      {:ok, att} ->
+        if params["raw"] == "1" do
+          conn
+          |> put_resp_content_type(att.mime_type || "application/octet-stream")
+          |> send_resp(200, att.content)
+        else
+          json(conn, %{
+            id: att.id,
+            path: att.path,
+            mime_type: att.mime_type,
+            size_bytes: att.size_bytes,
+            mtime: att.mtime,
+            content_base64: Base.encode64(att.content),
+            created_at: att.created_at,
+            updated_at: att.updated_at
+          })
+        end
+
+      {:error, {:storage, _reason}} ->
+        conn |> put_status(502) |> json(%{error: "failed to fetch attachment from storage"})
+
+      {:error, _reason} ->
+        conn |> put_status(500) |> json(%{error: "internal error fetching attachment"})
+    end
+  end
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `mix test test/engram_web/controllers/attachments_controller_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram_web/controllers/attachments_controller.ex test/engram_web/controllers/attachments_controller_test.exs
+git commit -m "feat(attachments): ?raw=1 streams attachment bytes"
+```
+
+---
+
+## Task 4: Frontend — `attachment` TreeItem variant + id codec
+
+**Files:**
+- Modify: `frontend/src/viewer/tree/types.ts`
+- Test: `frontend/src/viewer/tree/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/viewer/tree/types.test.ts`:
+
+```ts
+import { formatItemId, parseItemId } from './types'
+
+describe('attachment item ids', () => {
+  it('round-trips a simple attachment path', () => {
+    const id = formatItemId({ kind: 'attachment', path: 'img/a.png' })
+    expect(id).toBe('a:img/a.png')
+    expect(parseItemId(id)).toEqual({ kind: 'attachment', path: 'img/a.png' })
+  })
+
+  it('round-trips a path with spaces and unicode', () => {
+    const path = 'My Files/diagram (final).pdf'
+    const id = formatItemId({ kind: 'attachment', path })
+    expect(parseItemId(id)).toEqual({ kind: 'attachment', path })
+  })
+
+  it('keeps slashes as path separators, not encoded', () => {
+    const id = formatItemId({ kind: 'attachment', path: 'a/b/c.png' })
+    expect(id.startsWith('a:')).toBe(true)
+    expect(parseItemId(id)).toEqual({ kind: 'attachment', path: 'a/b/c.png' })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test frontend/src/viewer/tree/types.test.ts`
+Expected: FAIL — `formatItemId` rejects `kind: 'attachment'` / type error / wrong output.
+
+- [ ] **Step 3: Implement**
+
+In `frontend/src/viewer/tree/types.ts`:
+
+```ts
+export type TreeItem =
+  | { kind: 'folder'; id: string; path: string; name: string; count: number }
+  | { kind: 'note'; id: string; path: string; title: string; ext: string | null }
+  | { kind: 'attachment'; path: string; mime: string; size: number }
+
+// ...
+
+export function formatItemId(
+  input:
+    | { kind: 'folder' | 'note'; id: string }
+    | { kind: 'attachment'; path: string },
+): ItemId {
+  if (input.kind === 'attachment') {
+    const encoded = input.path.split('/').map(encodeURIComponent).join('/')
+    return `a:${encoded}`
+  }
+  return `${input.kind === 'folder' ? 'f' : 'n'}:${input.id}`
+}
+
+export type ParsedItemId =
+  | { kind: 'folder'; id: string }
+  | { kind: 'note'; id: string }
+  | { kind: 'attachment'; path: string }
+  | { kind: 'root' }
+
+export function parseItemId(id: ItemId): ParsedItemId {
+  if (id === ROOT_ID) return { kind: 'root' }
+  const colon = id.indexOf(':')
+  if (colon < 0) throw new Error(`Unknown tree item id: ${id}`)
+  const prefix = id.slice(0, colon)
+  const rest = id.slice(colon + 1)
+  if (rest.length === 0) throw new Error(`Unknown tree item id: ${id}`)
+  if (prefix === 'f') return { kind: 'folder', id: rest }
+  if (prefix === 'n') return { kind: 'note', id: rest }
+  if (prefix === 'a') {
+    const path = rest.split('/').map(decodeURIComponent).join('/')
+    return { kind: 'attachment', path }
+  }
+  throw new Error(`Unknown tree item id: ${id}`)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test frontend/src/viewer/tree/types.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/tree/types.ts frontend/src/viewer/tree/types.test.ts
+git commit -m "feat(tree): attachment TreeItem variant + a: id codec"
+```
+
+---
+
+## Task 5: Frontend — `useAttachments` query
+
+**Files:**
+- Modify: `frontend/src/api/queries.ts`
+- Test: `frontend/src/api/queries.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/api/queries.test.tsx` (reuse its existing QueryClient + `api` mock pattern — match how `useFolders`/`useFolderNotes` are tested in that file):
+
+```tsx
+import { useAttachments } from './queries'
+
+it('useAttachments fetches /attachments and returns the array', async () => {
+  vi.spyOn(api, 'get').mockResolvedValueOnce({
+    attachments: [
+      { path: 'a.png', mime_type: 'image/png', size_bytes: 10, mtime: 1, updated_at: '2026-06-10T00:00:00Z' },
+    ],
+  })
+  const { result } = renderHook(() => useAttachments(), { wrapper })
+  await waitFor(() => expect(result.current.data).toBeDefined())
+  expect(api.get).toHaveBeenCalledWith('/attachments')
+  expect(result.current.data?.[0].path).toBe('a.png')
+})
+```
+
+(If this file uses `jest` rather than `vitest` globals, swap `vi` → `jest`. Mirror the exact wrapper/`renderHook` import already in the file.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test frontend/src/api/queries.test.tsx -t useAttachments`
+Expected: FAIL — `useAttachments` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Add to `frontend/src/api/queries.ts` (near `useFolders`):
+
+```ts
+export interface AttachmentSummary {
+  path: string
+  mime_type: string
+  size_bytes: number
+  mtime: number
+  updated_at: string
+}
+
+const selectAttachments = (data: { attachments: AttachmentSummary[] }) => data.attachments
+
+export function useAttachments() {
+  const vaultId = useActiveVaultId()
+  const demo = useDemoVaultOptional()
+  const query = useQuery({
+    queryKey: ['attachments', vaultId],
+    queryFn: () => api.get<{ attachments: AttachmentSummary[] }>('/attachments'),
+    select: selectAttachments,
+    enabled: !demo?.active,
+    staleTime: FOLDER_NOTES_STALE_MS,
+  })
+  // Demo vaults carry no binary attachments.
+  if (demo?.active) {
+    return { ...query, data: [] as AttachmentSummary[], isLoading: false, isFetching: false, error: null }
+  }
+  return query
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test frontend/src/api/queries.test.tsx -t useAttachments`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/queries.ts frontend/src/api/queries.test.tsx
+git commit -m "feat(api): useAttachments query + AttachmentSummary"
+```
+
+---
+
+## Task 6: Frontend — `synthesizeFolders` helper
+
+**Files:**
+- Create: `frontend/src/viewer/tree/synthesize-folders.ts`
+- Test: `frontend/src/viewer/tree/synthesize-folders.test.ts`
+
+The helper returns the real folders plus a synthetic folder row for every
+attachment directory (and its ancestor chain) that isn't already a real folder.
+Real folders always keep their id. Synthetic ids are `syn:<path>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { synthesizeFolders } from './synthesize-folders'
+import type { Folder } from '../../api/queries'
+import type { AttachmentSummary } from '../../api/queries'
+
+const att = (path: string): AttachmentSummary => ({
+  path, mime_type: 'image/png', size_bytes: 1, mtime: 0, updated_at: '',
+})
+
+describe('synthesizeFolders', () => {
+  it('returns real folders unchanged when every attachment dir exists', () => {
+    const real: Folder[] = [{ id: 'r1', parent_id: null, name: 'img', count: 2 }]
+    const out = synthesizeFolders(real, [att('img/a.png')])
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ id: 'r1', name: 'img' })
+  })
+
+  it('synthesizes a folder that exists only via an attachment', () => {
+    const out = synthesizeFolders([], [att('pics/a.png')])
+    const pics = out.find((f) => f.name === 'pics')
+    expect(pics).toMatchObject({ id: 'syn:pics', parent_id: null, name: 'pics' })
+  })
+
+  it('synthesizes the full ancestor chain with correct parent ids', () => {
+    const out = synthesizeFolders([], [att('a/b/c.png')])
+    const a = out.find((f) => f.name === 'a')
+    const b = out.find((f) => f.name === 'a/b')
+    expect(a).toMatchObject({ id: 'syn:a', parent_id: null })
+    expect(b).toMatchObject({ id: 'syn:a/b', parent_id: 'syn:a' })
+  })
+
+  it('links a synthetic child under an existing real parent', () => {
+    const real: Folder[] = [{ id: 'r1', parent_id: null, name: 'docs', count: 0 }]
+    const out = synthesizeFolders(real, [att('docs/sub/x.pdf')])
+    const sub = out.find((f) => f.name === 'docs/sub')
+    expect(sub).toMatchObject({ id: 'syn:docs/sub', parent_id: 'r1' })
+  })
+
+  it('root-level attachments add no folders', () => {
+    const out = synthesizeFolders([], [att('cover.png')])
+    expect(out).toHaveLength(0)
+  })
+
+  it('does not duplicate a synthetic dir shared by two attachments', () => {
+    const out = synthesizeFolders([], [att('p/a.png'), att('p/b.png')])
+    expect(out.filter((f) => f.name === 'p')).toHaveLength(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test frontend/src/viewer/tree/synthesize-folders.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import type { Folder } from '../../api/queries'
+import type { AttachmentSummary } from '../../api/queries'
+
+// Folder dirs that exist only because they hold attachments aren't returned by
+// /api/folders (folders are derived from notes + markers). Synthesize them so
+// every attachment is reachable. Real folders win their id; synthetic rows use
+// `syn:<full-path>` ids and link to their parent (real or synthetic).
+export function synthesizeFolders(
+  real: Folder[],
+  attachments: AttachmentSummary[],
+): Folder[] {
+  const byName = new Map<string, Folder>()
+  for (const f of real) byName.set(f.name, f)
+
+  // Collect every directory prefix from attachment paths.
+  const dirs = new Set<string>()
+  for (const a of attachments) {
+    const slash = a.path.lastIndexOf('/')
+    if (slash < 0) continue // root attachment, no folder
+    const dir = a.path.slice(0, slash)
+    const segments = dir.split('/')
+    for (let i = 1; i <= segments.length; i++) dirs.add(segments.slice(0, i).join('/'))
+  }
+
+  // Synthesize missing dirs, shallow-first so parents exist before children.
+  const sorted = [...dirs].sort((x, y) => x.split('/').length - y.split('/').length)
+  for (const name of sorted) {
+    if (byName.has(name)) continue
+    const slash = name.lastIndexOf('/')
+    const parentName = slash < 0 ? null : name.slice(0, slash)
+    const parent = parentName == null ? null : byName.get(parentName) ?? null
+    byName.set(name, {
+      id: `syn:${name}`,
+      parent_id: parent ? parent.id : null,
+      name,
+      count: 0,
+    })
+  }
+
+  return [...byName.values()]
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test frontend/src/viewer/tree/synthesize-folders.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/tree/synthesize-folders.ts frontend/src/viewer/tree/synthesize-folders.test.ts
+git commit -m "feat(tree): synthesizeFolders for attachment-only dirs"
+```
+
+---
+
+## Task 7: Frontend — loader buckets attachments
+
+**Files:**
+- Modify: `frontend/src/viewer/tree/loader.ts`
+- Test: `frontend/src/viewer/tree/loader.test.ts`
+
+The loader gains an `attachments: AttachmentSummary[]` dep. `rootChildren`
+appends root attachments (no slash); `folderChildren` appends attachments whose
+dirname equals the folder's `name`. Each group is sorted by filename; attachments
+render after notes within a folder.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/viewer/tree/loader.test.ts` (reuse its existing `buildLoader` + QueryClient setup; match how it seeds folder-notes cache):
+
+```ts
+import type { AttachmentSummary } from '../../api/queries'
+
+const att = (path: string): AttachmentSummary => ({
+  path, mime_type: path.endsWith('.pdf') ? 'application/pdf' : 'image/png',
+  size_bytes: 1, mtime: 0, updated_at: '',
+})
+
+it('lists root attachments under ROOT', () => {
+  const loader = buildLoader({
+    folders: [], qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('cover.png')],
+  })
+  const kids = loader.getChildren(ROOT_ID)
+  const a = kids.find((k) => k.item.kind === 'attachment')
+  expect(a?.item).toMatchObject({ kind: 'attachment', path: 'cover.png', mime: 'image/png' })
+  expect(a?.itemId).toBe('a:cover.png')
+})
+
+it('buckets an attachment under its folder', () => {
+  const folders = [{ id: 'f1', parent_id: null, name: 'img', count: 0 }]
+  const loader = buildLoader({
+    folders, qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('img/a.png')],
+  })
+  // seed empty notes cache for the folder so notes resolve to []
+  qc.setQueryData(['folder-notes-by-id', 'v1', 'f1'], [])
+  const kids = loader.getChildren('f:f1')
+  expect(kids.map((k) => k.item.kind)).toContain('attachment')
+  const a = kids.find((k) => k.item.kind === 'attachment')
+  expect(a?.item).toMatchObject({ path: 'img/a.png' })
+})
+
+it('does not leak a subfolder attachment into its parent', () => {
+  const folders = [
+    { id: 'f1', parent_id: null, name: 'img', count: 0 },
+    { id: 'f2', parent_id: 'f1', name: 'img/sub', count: 0 },
+  ]
+  const loader = buildLoader({
+    folders, qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('img/sub/deep.png')],
+  })
+  qc.setQueryData(['folder-notes-by-id', 'v1', 'f1'], [])
+  const kids = loader.getChildren('f:f1')
+  expect(kids.find((k) => k.item.kind === 'attachment')).toBeUndefined()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test frontend/src/viewer/tree/loader.test.ts`
+Expected: FAIL — `buildLoader` doesn't accept/use `attachments`; no attachment items returned.
+
+- [ ] **Step 3: Implement**
+
+In `frontend/src/viewer/tree/loader.ts`:
+
+1. Import the type and extend `LoaderDeps`:
+
+```ts
+import {
+  FOLDER_NOTES_STALE_MS,
+  ROOT_FOLDER_ID,
+  type AttachmentSummary,
+  type Folder,
+  type NoteSummary,
+} from '../../api/queries'
+```
+
+```ts
+interface LoaderDeps {
+  folders: Folder[]
+  qc: QueryClient
+  vaultId: string
+  sort: SortKey
+  attachments?: AttachmentSummary[]
+  fetchFolderNotes?: (folderId: string) => Promise<NoteSummary[]>
+  onChildrenLoaded?: (folderId: string) => void
+}
+```
+
+2. Add helpers + bucket calls. Add near `noteToTreeItem`:
+
+```ts
+function attachmentDir(path: string): string {
+  const slash = path.lastIndexOf('/')
+  return slash < 0 ? '' : path.slice(0, slash)
+}
+
+function attachmentToTreeItem(a: AttachmentSummary): Extract<TreeItem, { kind: 'attachment' }> {
+  return { kind: 'attachment', path: a.path, mime: a.mime_type, size: a.size_bytes }
+}
+
+function attachmentItemsForDir(deps: LoaderDeps, dir: string): LoaderItem[] {
+  const list = (deps.attachments ?? []).filter((a) => attachmentDir(a.path) === dir)
+  const sign = deps.sort.endsWith('-desc') ? -1 : 1
+  const fname = (p: string) => p.split('/').pop() ?? p
+  return list
+    .sort((a, b) => sign * fname(a.path).localeCompare(fname(b.path)))
+    .map((a) => ({
+      itemId: formatItemId({ kind: 'attachment', path: a.path }),
+      item: attachmentToTreeItem(a),
+      isFolder: false,
+    }))
+}
+```
+
+3. Resolve a folder id → its path name, then append attachment items. Update
+`folderChildren` and `rootChildren`:
+
+```ts
+function rootChildren(deps: LoaderDeps): LoaderItem[] {
+  const tops = folderLoaderItems(deps, null)
+  const noteItems = noteChildItems(deps, ROOT_FOLDER_ID) ?? []
+  const attItems = attachmentItemsForDir(deps, '')
+  return [...tops, ...noteItems, ...attItems]
+}
+
+function folderChildren(deps: LoaderDeps, folderId: string): LoaderItem[] {
+  const childFolders = folderLoaderItems(deps, folderId)
+  const noteItems = noteChildItems(deps, folderId)
+  const folder = deps.folders.find((f) => f.id === folderId)
+  const attItems = folder ? attachmentItemsForDir(deps, folder.name) : []
+  const notes = noteItems ?? []
+  return [...childFolders, ...notes, ...attItems]
+}
+```
+
+(Note: `folderChildren` previously returned `childFolders` alone on a notes
+cache miss; now it always appends loaded attachments so they show immediately
+while notes lazy-load.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test frontend/src/viewer/tree/loader.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/tree/loader.ts frontend/src/viewer/tree/loader.test.ts
+git commit -m "feat(tree): loader buckets attachments into folders + root"
+```
+
+---
+
+## Task 8: Frontend — thread attachments through `useEngramTree`
+
+**Files:**
+- Modify: `frontend/src/viewer/tree/use-engram-tree.ts`
+
+No new test (covered by loader tests + the integration in Task 12); this wires
+the dep and makes the tree rebuild when attachments land.
+
+- [ ] **Step 1: Add `attachments` to `Deps` + pass to loader**
+
+In `frontend/src/viewer/tree/use-engram-tree.ts`:
+
+```ts
+import type { AttachmentSummary, Folder, NoteSummary } from '../../api/queries'
+```
+
+Add to the `Deps` interface (next to `folders`):
+
+```ts
+  attachments?: AttachmentSummary[]
+```
+
+Pass it into `buildLoader`:
+
+```ts
+    () => buildLoader({
+      folders: deps.folders,
+      qc: deps.qc,
+      vaultId: deps.vaultId,
+      sort: deps.sort,
+      attachments: deps.attachments,
+      fetchFolderNotes: deps.fetchFolderNotes,
+      onChildrenLoaded: (folderId) => {
+        // ...unchanged...
+      },
+    }),
+    [deps.folders, deps.qc, deps.vaultId, deps.sort, deps.attachments, deps.fetchFolderNotes],
+```
+
+- [ ] **Step 2: Fold an attachments fingerprint into the structure key**
+
+Find `const structureKey = treeStructureKey(deps.folders, deps.sort)` and the
+`treeStructureKey` helper. Add an attachments fingerprint so HT rebuilds when the
+attachment set changes within already-known folders:
+
+```ts
+function attachmentsFingerprint(attachments?: AttachmentSummary[]): string {
+  if (!attachments || attachments.length === 0) return '0'
+  // length + max(updated_at) is enough: the list is static per fetch, and any
+  // add/remove changes one of the two.
+  let max = ''
+  for (const a of attachments) if (a.updated_at > max) max = a.updated_at
+  return `${attachments.length}:${max}`
+}
+```
+
+Then:
+
+```ts
+  const structureKey =
+    treeStructureKey(deps.folders, deps.sort) + '#' + attachmentsFingerprint(deps.attachments)
+```
+
+- [ ] **Step 3: Verify the tree still builds**
+
+Run: `bun test frontend/src/viewer/folder-tree.test.tsx`
+Expected: PASS (existing tests unaffected — `attachments` is optional).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/viewer/tree/use-engram-tree.ts
+git commit -m "feat(tree): thread attachments into loader + structure key"
+```
+
+---
+
+## Task 9: Frontend — attachment row in `tree-row.tsx`
+
+**Files:**
+- Modify: `frontend/src/viewer/tree/tree-row.tsx`
+- Test: `frontend/src/viewer/tree/tree-row.test.tsx`
+
+Attachment rows are pure navigation `<Link>`s — no context menu, no long-press,
+no drag (those belong to Phase 2). They get a mime-based leading icon + an
+uppercase extension badge.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/viewer/tree/tree-row.test.tsx` (reuse its existing render
+harness that builds an `ItemInstance` mock; match how note rows are tested there):
+
+```tsx
+it('renders an attachment row as a link to /attachment/<path> with an ext badge', () => {
+  const instance = makeInstance({
+    item: { kind: 'attachment', path: 'img/a.png', mime: 'image/png', size: 10 },
+  })
+  render(<MemoryRouter><TreeRow instance={instance} /></MemoryRouter>)
+  const link = screen.getByRole('link')
+  expect(link).toHaveAttribute('href', '/attachment/img/a.png')
+  expect(screen.getByText('a.png')).toBeInTheDocument()
+  expect(screen.getByText('PNG')).toBeInTheDocument()
+})
+```
+
+(Use the file's existing `makeInstance`/render helpers verbatim — only the
+`item` payload is new. If the helper is named differently, match it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test frontend/src/viewer/tree/tree-row.test.tsx -t attachment`
+Expected: FAIL — attachment item renders as a note (wrong href `/note/undefined`) or throws.
+
+- [ ] **Step 3: Implement**
+
+In `frontend/src/viewer/tree/tree-row.tsx`:
+
+1. Extend the lucide import:
+
+```tsx
+import { ChevronRight, File, FileText, Image } from 'lucide-react'
+```
+
+2. Add an attachment branch **after** the folder branch and **before** the note
+return. Build the link target from the path:
+
+```tsx
+  if (item.kind === 'attachment') {
+    const filename = item.path.split('/').pop() ?? item.path
+    const dot = filename.lastIndexOf('.')
+    const ext = dot > 0 ? filename.slice(dot + 1).toLowerCase() : null
+    const encoded = item.path.split('/').map(encodeURIComponent).join('/')
+    const Icon = item.mime.startsWith('image/')
+      ? Image
+      : item.mime === 'application/pdf'
+        ? FileText
+        : File
+    return (
+      <Link
+        to={`/attachment/${encoded}`}
+        {...instance.getProps()}
+        onContextMenu={contextMenuHandler}
+        aria-selected={instance.isSelected()}
+        className={rowClass(instance)}
+        style={{ paddingLeft: `${notePad}px` }}
+      >
+        <IndentGuides depth={depth} />
+        <Icon aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
+        <span className="min-w-0 flex-1 truncate">{filename}</span>
+        {ext && (
+          <span className="shrink-0 text-xs uppercase text-gray-400 dark:text-gray-500">{ext}</span>
+        )}
+      </Link>
+    )
+  }
+```
+
+3. The rename branch at the top references `item.kind === 'folder' ? ... : ...`
+for padding and `leafName`. `leafName` already handles non-folder items via
+`item.path.split('/').pop()`, which covers attachments — no change needed (and
+attachments never enter renaming in Phase 1).
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test frontend/src/viewer/tree/tree-row.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/tree/tree-row.tsx frontend/src/viewer/tree/tree-row.test.tsx
+git commit -m "feat(tree): render attachment rows with icon + link"
+```
+
+---
+
+## Task 10: Frontend — fix `AttachmentImg` to fetch raw bytes
+
+**Files:**
+- Modify: `frontend/src/viewer/attachment-img.tsx`
+- Create: `frontend/src/viewer/attachment-img.test.tsx`
+
+`AttachmentImg` currently fetches the JSON endpoint via `getBlob`, so the image
+never renders. Append `?raw=1` so it streams real bytes (Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import AttachmentImg from './attachment-img'
+import { api } from '../api/client'
+
+beforeAll(() => {
+  // jsdom lacks createObjectURL
+  // @ts-expect-error test shim
+  URL.createObjectURL = vi.fn(() => 'blob:fake')
+  // @ts-expect-error test shim
+  URL.revokeObjectURL = vi.fn()
+})
+
+it('fetches the attachment with ?raw=1 and renders an img', async () => {
+  const spy = vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'image/png' }))
+  render(<AttachmentImg path="img/a.png" alt="A" />)
+  await waitFor(() => expect(screen.getByRole('img')).toBeInTheDocument())
+  expect(spy).toHaveBeenCalledWith('/attachments/img/a.png?raw=1')
+})
+```
+
+(Swap `vitest` → `jest` globals if the project uses jest; match a sibling test's import header.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test frontend/src/viewer/attachment-img.test.tsx`
+Expected: FAIL — `getBlob` called with `/attachments/img/a.png` (no `?raw=1`).
+
+- [ ] **Step 3: Implement**
+
+In `frontend/src/viewer/attachment-img.tsx`, change the fetch line:
+
+```tsx
+    const encoded = path.split('/').map(encodeURIComponent).join('/')
+    api
+      .getBlob(`/attachments/${encoded}?raw=1`)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test frontend/src/viewer/attachment-img.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/attachment-img.tsx frontend/src/viewer/attachment-img.test.tsx
+git commit -m "fix(viewer): AttachmentImg fetches raw bytes via ?raw=1"
+```
+
+---
+
+## Task 11: Frontend — `AttachmentPage` preview + route
+
+**Files:**
+- Create: `frontend/src/viewer/attachment-page.tsx`
+- Modify: `frontend/src/router.tsx`
+- Test: `frontend/src/viewer/attachment-page.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router'
+import { vi } from 'vitest'
+import AttachmentPage from './attachment-page'
+import { api } from '../api/client'
+
+beforeAll(() => {
+  // @ts-expect-error shim
+  URL.createObjectURL = vi.fn(() => 'blob:fake')
+  // @ts-expect-error shim
+  URL.revokeObjectURL = vi.fn()
+})
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/attachment/${path}`]}>
+      <Routes>
+        <Route path="/attachment/*" element={<AttachmentPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+it('renders an <img> for an image attachment', async () => {
+  vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'image/png' }))
+  renderAt('img/a.png')
+  await waitFor(() => expect(screen.getByRole('img')).toBeInTheDocument())
+  expect(api.getBlob).toHaveBeenCalledWith('/attachments/img/a.png?raw=1')
+})
+
+it('renders an iframe for a pdf attachment', async () => {
+  vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'application/pdf' }))
+  renderAt('doc.pdf')
+  await waitFor(() => expect(screen.getByTitle('doc.pdf')).toBeInTheDocument())
+})
+
+it('renders a download fallback for unsupported types', async () => {
+  vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'application/zip' }))
+  renderAt('a.zip')
+  await waitFor(() => expect(screen.getByRole('link', { name: /download/i })).toBeInTheDocument())
+})
+
+it('shows an error state when the fetch fails', async () => {
+  vi.spyOn(api, 'getBlob').mockRejectedValueOnce(new Error('boom'))
+  renderAt('missing.png')
+  await waitFor(() => expect(screen.getByText(/couldn.t load/i)).toBeInTheDocument())
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test frontend/src/viewer/attachment-page.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `frontend/src/viewer/attachment-page.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router'
+import { api } from '../api/client'
+
+// Read-only preview for a single attachment. The path is the route splat
+// (`/attachment/*`). Fetches raw bytes (?raw=1) as a typed Blob so the browser
+// renders images / PDFs natively; unsupported types fall back to a download link.
+export default function AttachmentPage() {
+  const params = useParams()
+  const path = params['*'] ?? ''
+  const filename = path.split('/').pop() ?? path
+
+  const [url, setUrl] = useState<string | null>(null)
+  const [mime, setMime] = useState<string>('')
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let revoke: string | null = null
+    let cancelled = false
+    setUrl(null)
+    setError(false)
+    const encoded = path.split('/').map(encodeURIComponent).join('/')
+    api
+      .getBlob(`/attachments/${encoded}?raw=1`)
+      .then((blob) => {
+        if (cancelled) return
+        const objectUrl = URL.createObjectURL(blob)
+        revoke = objectUrl
+        setMime(blob.type)
+        setUrl(objectUrl)
+      })
+      .catch(() => !cancelled && setError(true))
+    return () => {
+      cancelled = true
+      if (revoke) URL.revokeObjectURL(revoke)
+    }
+  }, [path])
+
+  if (error) {
+    return (
+      <section className="p-6">
+        <p className="text-sm text-destructive">Couldn't load {filename}.</p>
+      </section>
+    )
+  }
+  if (!url) {
+    return (
+      <section className="p-6">
+        <p className="text-sm text-muted-foreground">Loading {filename}…</p>
+      </section>
+    )
+  }
+  if (mime.startsWith('image/')) {
+    return (
+      <section className="flex h-full items-center justify-center overflow-auto p-6">
+        <img src={url} alt={filename} className="max-h-full max-w-full rounded" />
+      </section>
+    )
+  }
+  if (mime === 'application/pdf') {
+    return <iframe title={filename} src={url} className="h-full w-full border-0" />
+  }
+  return (
+    <section className="p-6">
+      <p className="mb-3 text-sm text-muted-foreground">Preview not supported for {filename}.</p>
+      <a
+        href={url}
+        download={filename}
+        className="inline-flex items-center rounded bg-primary px-3 py-2 text-sm text-primary-foreground"
+      >
+        Download {filename}
+      </a>
+    </section>
+  )
+}
+```
+
+In `frontend/src/router.tsx`:
+
+1. Add the lazy import near the other viewer lazies:
+
+```tsx
+const AttachmentPage = lazy(() => import('./viewer/attachment-page'))
+```
+
+2. Add the route next to `/note/:id` inside the `AppLayout` children:
+
+```tsx
+                    { path: '/note/:id', element: suspended(<NotePage />) },
+                    { path: '/attachment/*', element: suspended(<AttachmentPage />) },
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test frontend/src/viewer/attachment-page.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/attachment-page.tsx frontend/src/router.tsx frontend/src/viewer/attachment-page.test.tsx
+git commit -m "feat(viewer): AttachmentPage preview + /attachment/* route"
+```
+
+---
+
+## Task 12: Frontend — wire attachments into `FolderTree`
+
+**Files:**
+- Modify: `frontend/src/viewer/folder-tree.tsx`
+- Test: `frontend/src/viewer/folder-tree.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/viewer/folder-tree.test.tsx` (match its existing mock setup
+for `useFolders`/`useFolderNotesById`; add a `useAttachments` mock):
+
+```tsx
+it('renders an attachment row from useAttachments', async () => {
+  mockUseFolders([])              // however the file stubs folders
+  mockUseAttachments([
+    { path: 'cover.png', mime_type: 'image/png', size_bytes: 1, mtime: 0, updated_at: '2026-06-10T00:00:00Z' },
+  ])
+  render(<FolderTree />, { wrapper })
+  expect(await screen.findByText('cover.png')).toBeInTheDocument()
+})
+```
+
+(Implement `mockUseAttachments` the same way the file already mocks `useFolders`
+— a `vi.mock('../api/queries', ...)` factory returning the stubbed hook. If the
+file mocks the whole module, add `useAttachments` to that factory.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test frontend/src/viewer/folder-tree.test.tsx -t attachment`
+Expected: FAIL — no attachment row (FolderTree doesn't read attachments yet).
+
+- [ ] **Step 3: Implement**
+
+In `frontend/src/viewer/folder-tree.tsx`:
+
+1. Import the hook + helper + `useMemo`:
+
+```tsx
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+```
+
+```tsx
+import {
+  // ...existing imports...
+  useAttachments,
+  type AttachmentSummary,
+} from '../api/queries'
+import { synthesizeFolders } from './tree/synthesize-folders'
+```
+
+2. Read attachments + build the synthesized folder list. After the
+`useFolders()` line:
+
+```tsx
+  const { data: attachments = [] as AttachmentSummary[] } = useAttachments()
+```
+
+3. Add a stable empty array sentinel near `EMPTY_FOLDERS`:
+
+```tsx
+const EMPTY_ATTACHMENTS: AttachmentSummary[] = []
+```
+
+4. Compute the augmented folders (memoized so identity is stable):
+
+```tsx
+  const allFolders = useMemo(
+    () => synthesizeFolders(folders ?? EMPTY_FOLDERS, attachments ?? EMPTY_ATTACHMENTS),
+    [folders, attachments],
+  )
+```
+
+5. Pass `allFolders` + `attachments` to `useEngramTree`:
+
+```tsx
+  const { tree, virtualizer, items } = useEngramTree({
+    folders: allFolders,
+    attachments: attachments ?? EMPTY_ATTACHMENTS,
+    qc,
+    vaultId: vaultId ?? '',
+    sort,
+    scrollParentRef: scrollRef,
+    onRenameCommit,
+    onMove,
+    fetchFolderNotes,
+  })
+```
+
+6. Guard `onMove` so an attachment row (or any non-folder/root target) is never a
+drop destination. Change the early guard:
+
+```tsx
+  const onMove = (sourceIds: string[], targetItemId: string) => {
+    const target = parseItemId(targetItemId)
+    if (target.kind !== 'folder' && target.kind !== 'root') return
+    // ...rest unchanged...
+```
+
+7. Update the empty-state guard so a vault with only attachments still renders.
+Change:
+
+```tsx
+  if (!folders || (folders.length === 0 && rootNotes.length === 0)) {
+```
+
+to:
+
+```tsx
+  if (!folders || (allFolders.length === 0 && rootNotes.length === 0 && attachments.length === 0)) {
+```
+
+(`allFolders` already includes synthesized dirs, so an images-only subtree
+renders; a vault with only root-level attachments also passes via the
+`attachments.length` clause.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test frontend/src/viewer/folder-tree.test.tsx`
+Expected: PASS (new test + existing tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/folder-tree.tsx frontend/src/viewer/folder-tree.test.tsx
+git commit -m "feat(tree): wire attachments + synthesized folders into FolderTree"
+```
+
+---
+
+## Task 13: Full verification + lints
+
+- [ ] **Step 1: Backend suite**
+
+Run: `mix test`
+Expected: PASS.
+
+- [ ] **Step 2: Frontend suite**
+
+Run: `cd frontend && bun test`
+Expected: PASS.
+
+- [ ] **Step 3: Frontend build + lints (per project rules)**
+
+Run: `cd frontend && bun run build && bun run lint:obsidian && bun run lint:css && bunx biome check .`
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke (optional, via local browser CDP tunnel)**
+
+Bring up `make saas-dev`, open the app, confirm: image + PDF + a non-previewable
+file appear in the tree under the right folders (incl. an images-only folder),
+clicking each opens the expected preview, and the sidebar stays mounted.
+
+- [ ] **Step 5: Commit any lint fixups, then open the PR** (after user review per workflow rules).
+
+---
+
+## Spec coverage check
+
+- Backend `GET /api/attachments` → Task 1 (context) + Task 2 (endpoint/route).
+- Raw bytes / fix broken `AttachmentImg` → Task 3 (backend `?raw=1`) + Task 10 (frontend).
+- `attachment` TreeItem + `a:` id → Task 4.
+- `useAttachments` query → Task 5.
+- Synthesize attachment-only folders → Task 6 + wired in Task 12.
+- Loader bucketing → Task 7 + Task 8 (rebuild trigger).
+- Tree row icon/badge/link → Task 9.
+- `/attachment/*` preview (image/pdf/unsupported/loading/error) → Task 11.
+- FolderTree integration + empty-state + drop-target guard → Task 12.
+- Verification + lints → Task 13.
+
+## Deferred (Phase 2/3, out of scope)
+
+- Delete / rename / move / drag for attachments (the row deliberately wires no
+  context menu, long-press, or drag in Phase 1).
+- Upload + paid-tier upload gating in the web UI.
+- True interleave-sort of notes + attachments (Phase 1 lists attachments after
+  notes within a folder, each group sorted by name).
+- Thumbnails in tree rows; attachment-list pagination for very large vaults.

--- a/docs/superpowers/specs/2026-06-14-attachments-in-file-tree-design.md
+++ b/docs/superpowers/specs/2026-06-14-attachments-in-file-tree-design.md
@@ -1,0 +1,163 @@
+# Attachments in the Web File Tree — Phase 1 (display + preview)
+
+**Date:** 2026-06-14
+**Status:** Design — approved for planning
+**Repo:** `engram` (backend + `frontend/`), single PR
+**Branch:** `feat/attachments-in-file-tree`
+
+## Problem
+
+The web SPA file tree (`frontend/src/viewer/tree/`) is built from **folders +
+notes only**. Engram stores vault files as two distinct backend concepts:
+
+- **Notes** — markdown + canvas, full rows in the `notes` table.
+- **Attachments** — binaries (images, PDFs, …), encrypted blobs in S3 with
+  metadata in the `attachments` table.
+
+Attachments are never surfaced in the tree. Users with images/PDFs in their
+vault cannot see or open them on the web. This is Phase 1 of a larger
+"full attachment management on web" goal — it ships **display + preview**.
+Later phases add delete/rename (Phase 2) and upload (Phase 3).
+
+## Scope
+
+**In:** list attachments per vault; show them in the tree with type-aware
+icons; click to open a read-only preview (image inline, PDF embedded, other
+types → download link).
+
+**Out (later phases):** upload, delete, rename, move, drag-drop, paid-tier
+upload gating. No changes to the sync protocol or the plugin.
+
+## Constraints / facts
+
+- Attachment `path` is HMAC-encrypted at rest — you cannot glob or `LIKE` it.
+  Listing requires decrypting each row's path (the existing `list_changes`
+  read path already does this).
+- The `attachments` metadata serializer exposes **no client-facing uuid**;
+  `path` is the unique key within a vault. The tree will key attachment rows
+  by encoded path, and preview fetches by path via the existing
+  `GET /api/attachments/*path` blob endpoint.
+- Folders are derived backend-side from notes + explicit folder markers
+  (`Notes.list_folders_with_counts` + `list_folder_markers`). Attachments are
+  **not** a folder source — so a folder containing only attachments is absent
+  from the `/api/folders` response. The frontend must synthesize those folders
+  (decision below).
+- Binary attachments are a paid-tier feature (free is text-only). So these
+  files exist only for paid / self-host users. The list endpoint is **not**
+  feature-gated — free-tier simply returns `[]`.
+
+## Backend
+
+### New endpoint: `GET /api/attachments`
+
+Returns non-deleted attachment metadata for the active vault:
+
+```json
+{ "attachments": [
+  { "path": "diagrams/arch.png", "mime_type": "image/png",
+    "size_bytes": 20481, "mtime": 1718300000.0, "updated_at": "2026-06-10T…Z" }
+] }
+```
+
+- New context fn `Engram.Attachments.list_attachments/2` — same query/decrypt
+  shape as `list_changes/3` but `where deleted_at IS NULL`, and omits the
+  `deleted_at` field from output. (Refactor: `list_changes` can call a shared
+  private builder so the decrypt logic lives in one place.)
+- New `AttachmentsController.index/2`, serialized like `serialize_metadata/1`.
+- Route on the vault-scoped pipeline (alongside `attachments/changes`):
+  `get "/attachments", AttachmentsController, :index`. Must be declared
+  **before** `get "/attachments/*path"` so it isn't swallowed by the splat.
+- No `Billing.check_feature` gate — returns whatever rows exist.
+
+### Tests
+- `Engram.AttachmentsTest`: `list_attachments/2` returns non-deleted only,
+  decrypts paths, scopes by user+vault (tenant isolation), excludes
+  soft-deleted rows.
+- `AttachmentsControllerTest`: `GET /api/attachments` shape + auth boundary
+  (401 unauthenticated) + empty list for a vault with no attachments.
+
+## Frontend
+
+### 1. Tree item type (`viewer/tree/types.ts`)
+Add a third variant:
+```ts
+| { kind: 'attachment'; path: string; mime: string; size: number }
+```
+itemId encoding gains an `a:` prefix carrying the **encoded path** (no uuid):
+`formatItemId`/`parseItemId`/`ParsedItemId` extended; round-trip preserved
+(path may contain `/`, so encode each segment, join with `/`, and split only
+on the first `:` as today). Tests in `types.test.ts`.
+
+### 2. Query (`api/queries.ts`)
+`useAttachments(vaultId)` → `GET /attachments`, cached like folder-notes
+(`staleTime` reuse). Type `AttachmentSummary { path; mime_type; size_bytes;
+mtime; updated_at }`.
+
+### 3. Loader (`viewer/tree/loader.ts`)
+- Bucket attachments by `dirname(path)`:
+  - `""` (no slash) → vault root children.
+  - otherwise → the folder row whose `name` equals that dirname.
+- **Synthesize missing folders.** Build the set of dirnames from attachment
+  paths; for any not present in `folders`, synthesize folder rows (with synthetic
+  ids + parent linkage up the chain to root) so every attachment is reachable.
+  Synthetic folders get `count` = contained attachment count and merge with real
+  folders by path (a real folder always wins its id). Keep this in a small,
+  separately-tested helper (`synthesizeFolders(folders, attachments)`).
+- Attachments sort alongside notes by filename under the active sort key.
+
+### 4. Tree row (`viewer/tree/tree-row.tsx`)
+Render `kind: 'attachment'` as `<Link to={/attachment/<encoded>}>` with:
+- a mime-based icon (image / pdf / generic-file),
+- an uppercase extension badge (reuse the note-row badge pattern).
+
+### 5. Preview page + route
+- New lazy `viewer/attachment-page.tsx`, route `{ path: '/attachment/*',
+  element: suspended(<AttachmentPage/>) }` inside `AppLayout` (same shell as
+  `/note/:id`), so the tree sidebar stays mounted.
+- Reads the splat path, fetches via `api.getBlob('/attachments/' + encoded)`
+  (reuse `AttachmentImg`'s blob-URL + revoke lifecycle):
+  - `image/*` → `<img>`,
+  - `application/pdf` → `<iframe>` (or `<object>`),
+  - else → filename + size + a download link + "Preview not supported".
+- Loading + error (404 / fetch fail) states mirror `AttachmentImg`.
+
+### Tests
+- `loader.test.ts`: attachments bucket to root vs folder; sort interleave with
+  notes; **synthesize** path (attachment-only folder appears, nested chain,
+  real-folder id preserved on collision).
+- `types.test.ts`: `a:` round-trip incl. paths with `/` and spaces.
+- `tree-row.test.tsx`: attachment row renders a `/attachment/...` link + icon + badge.
+- `attachment-page.test.tsx`: image branch, pdf branch, unsupported branch,
+  loading + error states.
+
+## Data flow
+
+```
+GET /api/attachments ──▶ useAttachments() ──▶ loader buckets by dirname
+                                              + synthesizeFolders()
+                                                     │
+   folders + notes (existing) ────────────────────────┤
+                                                     ▼
+                                          Headless-Tree rows
+                                                     │ click attachment
+                                                     ▼
+                              /attachment/*path ──▶ AttachmentPage
+                                                     │ getBlob(/attachments/*path)
+                                                     ▼
+                                        <img> | <iframe> | download
+```
+
+## Out of scope / deferred
+
+- Phase 2: delete + rename + move (reuse tree-actions + wire backend delete).
+- Phase 3: drag-drop upload + paid-tier upload gating in the web UI.
+- Thumbnails / image previews in the tree row itself (open-only for now).
+- Pagination of the attachment list (vaults with thousands of attachments) —
+  Phase 1 returns the full list; revisit if it becomes a payload concern.
+
+## Testing strategy
+
+TDD per unit: write the failing backend context/controller test and the
+frontend loader/types/row/page tests first, then implement. Backend via
+`mix test`; frontend via `bun test` (run `lint:obsidian`/`lint:css`/biome
+locally before pushing per project rules).

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -41,6 +41,7 @@
         "react-dom": "^19.2.6",
         "react-joyride": "^3.1.0",
         "react-markdown": "^10.1.0",
+        "react-pdf": "^10.4.1",
         "react-resizable-panels": "^4.11.2",
         "react-router": "^7.16.0",
         "rehype-autolink-headings": "^7.1.0",
@@ -383,6 +384,30 @@
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "http://10.0.20.214:4873/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.9", "http://10.0.20.214:4873/@mswjs/interceptors/-/interceptors-0.41.9.tgz", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas/-/canvas-0.1.100.tgz", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.100", "@napi-rs/canvas-darwin-arm64": "0.1.100", "@napi-rs/canvas-darwin-x64": "0.1.100", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100", "@napi-rs/canvas-linux-arm64-gnu": "0.1.100", "@napi-rs/canvas-linux-arm64-musl": "0.1.100", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-musl": "0.1.100", "@napi-rs/canvas-win32-arm64-msvc": "0.1.100", "@napi-rs/canvas-win32-x64-msvc": "0.1.100" } }, "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz", { "os": "android", "cpu": "arm64" }, "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz", { "os": "linux", "cpu": "arm" }, "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz", { "os": "linux", "cpu": "none" }, "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz", { "os": "linux", "cpu": "x64" }, "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz", { "os": "linux", "cpu": "x64" }, "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA=="],
+
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "http://10.0.20.214:4873/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "http://10.0.20.214:4873/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1560,6 +1585,8 @@
 
     "longest-streak": ["longest-streak@3.1.0", "http://10.0.20.214:4873/longest-streak/-/longest-streak-3.1.0.tgz", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
+    "loose-envify": ["loose-envify@1.4.0", "http://10.0.20.214:4873/loose-envify/-/loose-envify-1.4.0.tgz", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
     "lowercase-keys": ["lowercase-keys@1.0.1", "http://10.0.20.214:4873/lowercase-keys/-/lowercase-keys-1.0.1.tgz", {}, "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="],
 
     "lowlight": ["lowlight@3.3.0", "http://10.0.20.214:4873/lowlight/-/lowlight-3.3.0.tgz", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.0.0", "highlight.js": "~11.11.0" } }, "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ=="],
@@ -1572,7 +1599,11 @@
 
     "magic-string": ["magic-string@0.30.21", "http://10.0.20.214:4873/magic-string/-/magic-string-0.30.21.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "make-cancellable-promise": ["make-cancellable-promise@2.0.0", "http://10.0.20.214:4873/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz", {}, "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw=="],
+
     "make-dir": ["make-dir@1.3.0", "http://10.0.20.214:4873/make-dir/-/make-dir-1.3.0.tgz", { "dependencies": { "pify": "^3.0.0" } }, "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ=="],
+
+    "make-event-props": ["make-event-props@2.0.0", "http://10.0.20.214:4873/make-event-props/-/make-event-props-2.0.0.tgz", {}, "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw=="],
 
     "markdown-table": ["markdown-table@3.0.4", "http://10.0.20.214:4873/markdown-table/-/markdown-table-3.0.4.tgz", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
@@ -1617,6 +1648,8 @@
     "media-typer": ["media-typer@1.1.0", "http://10.0.20.214:4873/media-typer/-/media-typer-1.1.0.tgz", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "http://10.0.20.214:4873/merge-descriptors/-/merge-descriptors-2.0.0.tgz", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "merge-refs": ["merge-refs@2.0.0", "http://10.0.20.214:4873/merge-refs/-/merge-refs-2.0.0.tgz", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
     "merge-stream": ["merge-stream@2.0.0", "http://10.0.20.214:4873/merge-stream/-/merge-stream-2.0.0.tgz", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -1806,6 +1839,8 @@
 
     "pathe": ["pathe@2.0.3", "http://10.0.20.214:4873/pathe/-/pathe-2.0.3.tgz", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pdfjs-dist": ["pdfjs-dist@5.4.296", "http://10.0.20.214:4873/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.80" } }, "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q=="],
+
     "pend": ["pend@1.2.0", "http://10.0.20.214:4873/pend/-/pend-1.2.0.tgz", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "pg": ["pg@8.21.0", "http://10.0.20.214:4873/pg/-/pg-8.21.0.tgz", { "dependencies": { "pg-connection-string": "^2.13.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.14.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA=="],
@@ -1919,6 +1954,8 @@
     "react-joyride": ["react-joyride@3.1.0", "http://10.0.20.214:4873/react-joyride/-/react-joyride-3.1.0.tgz", { "dependencies": { "@fastify/deepmerge": "^3.2.1", "@floating-ui/react-dom": "^2.1.8", "@gilbarbara/deep-equal": "^0.4.1", "@gilbarbara/hooks": "^0.11.0", "@gilbarbara/types": "^0.2.2", "is-lite": "^2.0.0", "react-innertext": "^1.1.5", "scroll": "^3.0.1", "scrollparent": "^2.1.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "16.8 - 19", "react-dom": "16.8 - 19" } }, "sha512-+UEDpNsYSHhhSW/OQcNl6+oODYx20EP6TykSD45if0MqAAZMYD+3DU64w9wP3fBjQswvq5BgK99w3rw6ing69g=="],
 
     "react-markdown": ["react-markdown@10.1.0", "http://10.0.20.214:4873/react-markdown/-/react-markdown-10.1.0.tgz", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
+    "react-pdf": ["react-pdf@10.4.1", "http://10.0.20.214:4873/react-pdf/-/react-pdf-10.4.1.tgz", { "dependencies": { "clsx": "^2.0.0", "dequal": "^2.0.3", "make-cancellable-promise": "^2.0.0", "make-event-props": "^2.0.0", "merge-refs": "^2.0.0", "pdfjs-dist": "5.4.296", "tiny-invariant": "^1.0.0", "warning": "^4.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "http://10.0.20.214:4873/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
@@ -2245,6 +2282,8 @@
     "vitest": ["vitest@4.1.7", "http://10.0.20.214:4873/vitest/-/vitest-4.1.7.tgz", { "dependencies": { "@vitest/expect": "4.1.7", "@vitest/mocker": "4.1.7", "@vitest/pretty-format": "4.1.7", "@vitest/runner": "4.1.7", "@vitest/snapshot": "4.1.7", "@vitest/spy": "4.1.7", "@vitest/utils": "4.1.7", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.7", "@vitest/browser-preview": "4.1.7", "@vitest/browser-webdriverio": "4.1.7", "@vitest/coverage-istanbul": "4.1.7", "@vitest/coverage-v8": "4.1.7", "@vitest/ui": "4.1.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "http://10.0.20.214:4873/w3c-keyname/-/w3c-keyname-2.2.8.tgz", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
+    "warning": ["warning@4.0.3", "http://10.0.20.214:4873/warning/-/warning-4.0.3.tgz", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "http://10.0.20.214:4873/web-namespaces/-/web-namespaces-2.0.1.tgz", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "react-dom": "^19.2.6",
     "react-joyride": "^3.1.0",
     "react-markdown": "^10.1.0",
+    "react-pdf": "^10.4.1",
     "react-resizable-panels": "^4.11.2",
     "react-router": "^7.16.0",
     "rehype-autolink-headings": "^7.1.0",

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1358,7 +1358,7 @@ describe('useAttachments', () => {
   it('fetches /attachments and returns the attachments array', async () => {
     get.mockResolvedValue({
       attachments: [
-        { path: 'a.png', mime_type: 'image/png', size_bytes: 10, mtime: 1, updated_at: '2026-06-10T00:00:00Z' },
+        { id: 'a-1', path: 'a.png', mime_type: 'image/png', size_bytes: 10, mtime: 1, updated_at: '2026-06-10T00:00:00Z' },
       ],
     })
 

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -43,6 +43,7 @@ import {
   type Folder,
   type Note,
   useAcceptTerms,
+  useAttachments,
   useBatchDeleteFolders,
   useBatchDeleteNotes,
   useBatchMoveFolders,
@@ -1350,5 +1351,21 @@ describe('useSearch', () => {
 
     expect(result.current.data).toEqual(firstResults)
     expect(result.current.isPlaceholderData).toBe(true)
+  })
+})
+
+describe('useAttachments', () => {
+  it('fetches /attachments and returns the attachments array', async () => {
+    get.mockResolvedValue({
+      attachments: [
+        { path: 'a.png', mime_type: 'image/png', size_bytes: 10, mtime: 1, updated_at: '2026-06-10T00:00:00Z' },
+      ],
+    })
+
+    const { result } = renderHook(() => useAttachments(), { wrapper })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+
+    expect(get).toHaveBeenCalledWith('/attachments')
+    expect(result.current.data?.[0].path).toBe('a.png')
   })
 })

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1366,6 +1366,6 @@ describe('useAttachments', () => {
     await waitFor(() => expect(result.current.data).toBeDefined())
 
     expect(get).toHaveBeenCalledWith('/attachments')
-    expect(result.current.data?.[0].path).toBe('a.png')
+    expect(result.current.data?.[0]?.path).toBe('a.png')
   })
 })

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -167,6 +167,7 @@ export function useFolderNotes(folder: string, options?: { enabled?: boolean }) 
 export const FOLDER_NOTES_STALE_MS = 60_000
 
 export interface AttachmentSummary {
+  id: string
   path: string
   mime_type: string
   size_bytes: number

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -166,6 +166,33 @@ export function useFolderNotes(folder: string, options?: { enabled?: boolean }) 
 // event (or any single-note mutation) still invalidates the key and refetches.
 export const FOLDER_NOTES_STALE_MS = 60_000
 
+export interface AttachmentSummary {
+  path: string
+  mime_type: string
+  size_bytes: number
+  mtime: number
+  updated_at: string
+}
+
+const selectAttachments = (data: { attachments: AttachmentSummary[] }) => data.attachments
+
+export function useAttachments() {
+  const vaultId = useActiveVaultId()
+  const demo = useDemoVaultOptional()
+  const query = useQuery({
+    queryKey: ['attachments', vaultId],
+    queryFn: () => api.get<{ attachments: AttachmentSummary[] }>('/attachments'),
+    select: selectAttachments,
+    enabled: !demo?.active,
+    staleTime: FOLDER_NOTES_STALE_MS,
+  })
+  // Demo vaults carry no binary attachments.
+  if (demo?.active) {
+    return { ...query, data: [] as AttachmentSummary[], isLoading: false, isFetching: false, error: null }
+  }
+  return query
+}
+
 // The vault root has no folder-marker row (the by-id endpoint requires a
 // non-null id), so it keys its note list under this sentinel — the same value
 // the backend already uses as the batch-move root target. One id-space, one

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -22,8 +22,9 @@ import { Outlet } from 'react-router'
 // (sign-in/up, layouts, guards) stay eager; everything behind navigation
 // loads on demand.
 const Dashboard = lazy(() => import('./viewer/dashboard'))
-const NotePage = lazy(() => import('./viewer/note-page'))
-const AttachmentPage = lazy(() => import('./viewer/attachment-page'))
+// /note/:id resolves to the note OR attachment viewer (VaultItemPage owns the
+// lazy NotePage/AttachmentPage chunks).
+const VaultItemPage = lazy(() => import('./viewer/vault-item-page'))
 const BillingPage = lazy(() => import('./billing/billing-page'))
 const AdminPanel = lazy(() => import('./features/admin/AdminPanel'))
 const ResetPasswordPage = lazy(() => import('./features/auth/ResetPasswordPage'))
@@ -141,8 +142,7 @@ export function createAppRouter(config: EngramConfig): AppRouter {
                   element: <AppLayout />,
                   children: [
                     { path: ROUTES.HOME, element: suspended(<Dashboard />) },
-                    { path: '/note/:id', element: suspended(<NotePage />) },
-                    { path: '/attachment/*', element: suspended(<AttachmentPage />) },
+                    { path: '/note/:id', element: suspended(<VaultItemPage />) },
                     {
                       path: 'settings',
                       element: <SettingsLayout />,

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,6 +7,7 @@ import WaitlistPage from './auth/waitlist'
 import { UpgradeDialogProvider } from './billing/upgrade-dialog-provider'
 import type { EngramConfig } from './config'
 import AppLayout from './layout/app-layout'
+import LoadingPane from './viewer/loading-pane'
 import NotFoundPage from './not-found'
 import SettingsLayout from './settings/settings-layout'
 import { ROUTES } from './routes'
@@ -37,7 +38,7 @@ const OnboardBillingPage = lazy(() => import('./onboarding/onboard-billing-page'
 const OnboardToolsPage = lazy(() => import('./onboarding/onboard-tools-page'))
 const OnboardVaultPage = lazy(() => import('./onboarding/onboard-vault-page'))
 
-const routeFallback = <p className="p-6 text-muted-foreground">Loading…</p>
+const routeFallback = <LoadingPane />
 
 function suspended(el: ReactNode) {
   return <Suspense fallback={routeFallback}>{el}</Suspense>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -23,6 +23,7 @@ import { Outlet } from 'react-router'
 // loads on demand.
 const Dashboard = lazy(() => import('./viewer/dashboard'))
 const NotePage = lazy(() => import('./viewer/note-page'))
+const AttachmentPage = lazy(() => import('./viewer/attachment-page'))
 const BillingPage = lazy(() => import('./billing/billing-page'))
 const AdminPanel = lazy(() => import('./features/admin/AdminPanel'))
 const ResetPasswordPage = lazy(() => import('./features/auth/ResetPasswordPage'))
@@ -141,6 +142,7 @@ export function createAppRouter(config: EngramConfig): AppRouter {
                   children: [
                     { path: ROUTES.HOME, element: suspended(<Dashboard />) },
                     { path: '/note/:id', element: suspended(<NotePage />) },
+                    { path: '/attachment/*', element: suspended(<AttachmentPage />) },
                     {
                       path: 'settings',
                       element: <SettingsLayout />,

--- a/frontend/src/viewer/attachment-img.test.tsx
+++ b/frontend/src/viewer/attachment-img.test.tsx
@@ -1,0 +1,19 @@
+import { beforeAll, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import AttachmentImg from './attachment-img'
+import { api } from '../api/client'
+
+beforeAll(() => {
+  // jsdom lacks createObjectURL/revokeObjectURL
+  // @ts-expect-error test shim
+  URL.createObjectURL = vi.fn(() => 'blob:fake')
+  // @ts-expect-error test shim
+  URL.revokeObjectURL = vi.fn()
+})
+
+it('fetches the attachment with ?raw=1 and renders an img', async () => {
+  const spy = vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'image/png' }))
+  render(<AttachmentImg path="img/a.png" alt="A" />)
+  await waitFor(() => expect(screen.getByRole('img')).toBeInTheDocument())
+  expect(spy).toHaveBeenCalledWith('/attachments/img/a.png?raw=1')
+})

--- a/frontend/src/viewer/attachment-img.test.tsx
+++ b/frontend/src/viewer/attachment-img.test.tsx
@@ -1,7 +1,7 @@
 import { beforeAll, expect, it, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import AttachmentImg from './attachment-img'
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 
 beforeAll(() => {
   // jsdom lacks createObjectURL/revokeObjectURL
@@ -14,4 +14,17 @@ it('fetches the attachment with ?raw=1 and renders an img', async () => {
   render(<AttachmentImg path="img/a.png" alt="A" />)
   await waitFor(() => expect(screen.getByRole('img')).toBeInTheDocument())
   expect(spy).toHaveBeenCalledWith('/attachments/img/a.png?raw=1')
+})
+
+it('says "Missing attachment" only on a real 404', async () => {
+  vi.spyOn(api, 'getBlob').mockRejectedValueOnce(new ApiError(404, 'not found'))
+  render(<AttachmentImg path="img/a.png" />)
+  await waitFor(() => expect(screen.getByText(/missing attachment/i)).toBeInTheDocument())
+})
+
+it('does NOT claim "missing" on a transient 5xx — says temporarily unavailable', async () => {
+  vi.spyOn(api, 'getBlob').mockRejectedValueOnce(new ApiError(502, 'storage down'))
+  render(<AttachmentImg path="img/a.png" />)
+  await waitFor(() => expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument())
+  expect(screen.queryByText(/missing attachment/i)).not.toBeInTheDocument()
 })

--- a/frontend/src/viewer/attachment-img.test.tsx
+++ b/frontend/src/viewer/attachment-img.test.tsx
@@ -5,9 +5,7 @@ import { api } from '../api/client'
 
 beforeAll(() => {
   // jsdom lacks createObjectURL/revokeObjectURL
-  // @ts-expect-error test shim
   URL.createObjectURL = vi.fn(() => 'blob:fake')
-  // @ts-expect-error test shim
   URL.revokeObjectURL = vi.fn()
 })
 

--- a/frontend/src/viewer/attachment-img.tsx
+++ b/frontend/src/viewer/attachment-img.tsx
@@ -10,7 +10,7 @@ export default function AttachmentImg({ path, alt }: { path: string; alt?: strin
     let cancelled = false
     const encoded = path.split('/').map(encodeURIComponent).join('/')
     api
-      .getBlob(`/attachments/${encoded}`)
+      .getBlob(`/attachments/${encoded}?raw=1`)
       .then((blob) => {
         if (cancelled) return
         const url = URL.createObjectURL(blob)

--- a/frontend/src/viewer/attachment-img.tsx
+++ b/frontend/src/viewer/attachment-img.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react'
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
+
+// 'missing' only for a real 404; a transient 5xx/network failure must NOT claim
+// the file is missing (the file exists, storage is just unreachable).
+type LoadError = 'missing' | 'failed'
 
 export default function AttachmentImg({ path, alt }: { path: string; alt?: string }) {
   const [src, setSrc] = useState<string | null>(null)
-  const [error, setError] = useState(false)
+  const [error, setError] = useState<LoadError | null>(null)
 
   useEffect(() => {
     let revoke: string | null = null
@@ -17,7 +21,12 @@ export default function AttachmentImg({ path, alt }: { path: string; alt?: strin
         revoke = url
         setSrc(url)
       })
-      .catch(() => !cancelled && setError(true))
+      .catch((err) => {
+        if (cancelled) return
+        // A non-ApiError is a bug (e.g. createObjectURL), not a load failure.
+        if (!(err instanceof ApiError)) console.error('attachment image load failed', path, err)
+        setError(err instanceof ApiError && err.status === 404 ? 'missing' : 'failed')
+      })
     return () => {
       cancelled = true
       if (revoke) URL.revokeObjectURL(revoke)
@@ -27,7 +36,9 @@ export default function AttachmentImg({ path, alt }: { path: string; alt?: strin
   if (error) {
     return (
       <span className="inline-flex items-center gap-1 rounded bg-destructive/10 px-1.5 py-0.5 text-xs text-destructive">
-        Missing attachment: {path}
+        {error === 'missing'
+          ? `Missing attachment: ${path}`
+          : `Couldn't load ${path} (temporarily unavailable)`}
       </span>
     )
   }

--- a/frontend/src/viewer/attachment-page.test.tsx
+++ b/frontend/src/viewer/attachment-page.test.tsx
@@ -79,11 +79,11 @@ it('shows an error state when the byte fetch fails', async () => {
   await waitFor(() => expect(screen.getByText(/couldn.t load/i)).toBeInTheDocument())
 })
 
-it('shows a loading state before the bytes resolve', () => {
+it('shows a centered loading spinner before the bytes resolve', () => {
   mockAttachments = [att({ id: 'img-1', path: 'slow.png', mime_type: 'image/png' })]
   vi.spyOn(api, 'getBlob').mockReturnValueOnce(new Promise<Blob>(() => {}))
   renderAt('img-1')
-  expect(screen.getByText(/loading slow\.png/i)).toBeInTheDocument()
+  expect(screen.getByRole('status')).toBeInTheDocument()
 })
 
 it('shows "not found" when no attachment matches the id', () => {

--- a/frontend/src/viewer/attachment-page.test.tsx
+++ b/frontend/src/viewer/attachment-page.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeAll, expect, it, vi } from 'vitest'
+import AttachmentPage from './attachment-page'
+import { api } from '../api/client'
+
+beforeAll(() => {
+  URL.createObjectURL = vi.fn(() => 'blob:fake')
+  URL.revokeObjectURL = vi.fn()
+})
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/attachment/${path}`]}>
+      <Routes>
+        <Route path="/attachment/*" element={<AttachmentPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+it('renders an <img> for an image attachment', async () => {
+  vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'image/png' }))
+  renderAt('img/a.png')
+  await waitFor(() => expect(screen.getByRole('img')).toBeInTheDocument())
+  expect(api.getBlob).toHaveBeenCalledWith('/attachments/img/a.png?raw=1')
+})
+
+it('renders an iframe for a pdf attachment', async () => {
+  vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'application/pdf' }))
+  renderAt('doc.pdf')
+  await waitFor(() => expect(screen.getByTitle('doc.pdf')).toBeInTheDocument())
+})
+
+it('renders a download fallback for unsupported types', async () => {
+  vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'application/zip' }))
+  renderAt('a.zip')
+  await waitFor(() => expect(screen.getByRole('link', { name: /download/i })).toBeInTheDocument())
+})
+
+it('shows an error state when the fetch fails', async () => {
+  vi.spyOn(api, 'getBlob').mockRejectedValueOnce(new Error('boom'))
+  renderAt('missing.png')
+  await waitFor(() => expect(screen.getByText(/couldn.t load/i)).toBeInTheDocument())
+})

--- a/frontend/src/viewer/attachment-page.test.tsx
+++ b/frontend/src/viewer/attachment-page.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
-import { beforeAll, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, expect, it, vi } from 'vitest'
 import AttachmentPage from './attachment-page'
 import { api } from '../api/client'
+import type { AttachmentSummary } from '../api/queries'
 
 // Stub the heavy pdf.js viewer — this suite only verifies routing-by-mime, not
 // pdf.js rendering (covered in pdf-view.test.tsx).
@@ -10,50 +11,83 @@ vi.mock('./pdf-view', () => ({
   default: ({ filename }: { filename: string }) => <div data-testid="pdf-view">pdf {filename}</div>,
 }))
 
+// AttachmentPage resolves the route :id against the attachments list. Drive that
+// list from the test (must be `mock*`-prefixed for vitest's vi.mock hoist guard).
+let mockAttachments: AttachmentSummary[] = []
+let mockLoading = false
+vi.mock('../api/queries', () => ({
+  useAttachments: () => ({ data: mockAttachments, isLoading: mockLoading }),
+}))
+
+const att = (over: Partial<AttachmentSummary> & { id: string }): AttachmentSummary => ({
+  path: 'doc.pdf',
+  mime_type: 'application/pdf',
+  size_bytes: 1,
+  mtime: 0,
+  updated_at: '',
+  ...over,
+})
+
 beforeAll(() => {
   URL.createObjectURL = vi.fn(() => 'blob:fake')
   URL.revokeObjectURL = vi.fn()
 })
 
-function renderAt(path: string) {
+beforeEach(() => {
+  mockAttachments = []
+  mockLoading = false
+  vi.restoreAllMocks()
+})
+
+function renderAt(id: string) {
   return render(
-    <MemoryRouter initialEntries={[`/attachment/${path}`]}>
+    <MemoryRouter initialEntries={[`/note/${id}`]}>
       <Routes>
-        <Route path="/attachment/*" element={<AttachmentPage />} />
+        <Route path="/note/:id" element={<AttachmentPage />} />
       </Routes>
     </MemoryRouter>,
   )
 }
 
-it('renders an <img> for an image attachment', async () => {
+it('renders an <img> for an image attachment, fetching bytes by path', async () => {
+  mockAttachments = [att({ id: 'img-1', path: 'img/a.png', mime_type: 'image/png' })]
   vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'image/png' }))
-  renderAt('img/a.png')
+  renderAt('img-1')
   await waitFor(() => expect(screen.getByRole('img')).toBeInTheDocument())
   expect(api.getBlob).toHaveBeenCalledWith('/attachments/img/a.png?raw=1')
 })
 
 it('renders the pdf.js viewer for a pdf attachment', async () => {
+  mockAttachments = [att({ id: 'pdf-1', path: 'reports/q3.pdf' })]
   vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'application/pdf' }))
-  renderAt('doc.pdf')
+  renderAt('pdf-1')
   await waitFor(() => expect(screen.getByTestId('pdf-view')).toBeInTheDocument())
-  expect(screen.getByTestId('pdf-view')).toHaveTextContent('doc.pdf')
+  expect(screen.getByTestId('pdf-view')).toHaveTextContent('q3.pdf')
 })
 
 it('renders a download fallback for unsupported types', async () => {
+  mockAttachments = [att({ id: 'zip-1', path: 'a.zip', mime_type: 'application/zip' })]
   vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'application/zip' }))
-  renderAt('a.zip')
+  renderAt('zip-1')
   await waitFor(() => expect(screen.getByRole('link', { name: /download/i })).toBeInTheDocument())
 })
 
-it('shows an error state when the fetch fails', async () => {
+it('shows an error state when the byte fetch fails', async () => {
+  mockAttachments = [att({ id: 'img-1', path: 'missing.png', mime_type: 'image/png' })]
   vi.spyOn(api, 'getBlob').mockRejectedValueOnce(new Error('boom'))
-  renderAt('missing.png')
+  renderAt('img-1')
   await waitFor(() => expect(screen.getByText(/couldn.t load/i)).toBeInTheDocument())
 })
 
-it('shows a loading state before the fetch resolves', () => {
-  // A promise that never resolves keeps the component in its loading branch.
+it('shows a loading state before the bytes resolve', () => {
+  mockAttachments = [att({ id: 'img-1', path: 'slow.png', mime_type: 'image/png' })]
   vi.spyOn(api, 'getBlob').mockReturnValueOnce(new Promise<Blob>(() => {}))
-  renderAt('slow.png')
+  renderAt('img-1')
   expect(screen.getByText(/loading slow\.png/i)).toBeInTheDocument()
+})
+
+it('shows "not found" when no attachment matches the id', () => {
+  mockAttachments = [att({ id: 'other' })]
+  renderAt('missing-id')
+  expect(screen.getByText(/not found/i)).toBeInTheDocument()
 })

--- a/frontend/src/viewer/attachment-page.test.tsx
+++ b/frontend/src/viewer/attachment-page.test.tsx
@@ -43,3 +43,10 @@ it('shows an error state when the fetch fails', async () => {
   renderAt('missing.png')
   await waitFor(() => expect(screen.getByText(/couldn.t load/i)).toBeInTheDocument())
 })
+
+it('shows a loading state before the fetch resolves', () => {
+  // A promise that never resolves keeps the component in its loading branch.
+  vi.spyOn(api, 'getBlob').mockReturnValueOnce(new Promise<Blob>(() => {}))
+  renderAt('slow.png')
+  expect(screen.getByText(/loading slow\.png/i)).toBeInTheDocument()
+})

--- a/frontend/src/viewer/attachment-page.test.tsx
+++ b/frontend/src/viewer/attachment-page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeAll, beforeEach, expect, it, vi } from 'vitest'
 import AttachmentPage from './attachment-page'
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 import type { AttachmentSummary } from '../api/queries'
 
 // Stub the heavy pdf.js viewer — this suite only verifies routing-by-mime, not
@@ -72,11 +72,19 @@ it('renders a download fallback for unsupported types', async () => {
   await waitFor(() => expect(screen.getByRole('link', { name: /download/i })).toBeInTheDocument())
 })
 
-it('shows an error state when the byte fetch fails', async () => {
-  mockAttachments = [att({ id: 'img-1', path: 'missing.png', mime_type: 'image/png' })]
-  vi.spyOn(api, 'getBlob').mockRejectedValueOnce(new Error('boom'))
+it('shows a transient error (not "missing") when the byte fetch fails with a 5xx', async () => {
+  mockAttachments = [att({ id: 'img-1', path: 'x.png', mime_type: 'image/png' })]
+  vi.spyOn(api, 'getBlob').mockRejectedValueOnce(new ApiError(502, 'storage down'))
   renderAt('img-1')
-  await waitFor(() => expect(screen.getByText(/couldn.t load/i)).toBeInTheDocument())
+  await waitFor(() => expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument())
+  expect(screen.queryByText(/no longer exists/i)).not.toBeInTheDocument()
+})
+
+it('shows "no longer exists" when the byte fetch 404s', async () => {
+  mockAttachments = [att({ id: 'img-1', path: 'gone.png', mime_type: 'image/png' })]
+  vi.spyOn(api, 'getBlob').mockRejectedValueOnce(new ApiError(404, 'not found'))
+  renderAt('img-1')
+  await waitFor(() => expect(screen.getByText(/no longer exists/i)).toBeInTheDocument())
 })
 
 it('shows a centered loading spinner before the bytes resolve', () => {

--- a/frontend/src/viewer/attachment-page.test.tsx
+++ b/frontend/src/viewer/attachment-page.test.tsx
@@ -4,6 +4,12 @@ import { beforeAll, expect, it, vi } from 'vitest'
 import AttachmentPage from './attachment-page'
 import { api } from '../api/client'
 
+// Stub the heavy pdf.js viewer — this suite only verifies routing-by-mime, not
+// pdf.js rendering (covered in pdf-view.test.tsx).
+vi.mock('./pdf-view', () => ({
+  default: ({ filename }: { filename: string }) => <div data-testid="pdf-view">pdf {filename}</div>,
+}))
+
 beforeAll(() => {
   URL.createObjectURL = vi.fn(() => 'blob:fake')
   URL.revokeObjectURL = vi.fn()
@@ -26,10 +32,11 @@ it('renders an <img> for an image attachment', async () => {
   expect(api.getBlob).toHaveBeenCalledWith('/attachments/img/a.png?raw=1')
 })
 
-it('renders an iframe for a pdf attachment', async () => {
+it('renders the pdf.js viewer for a pdf attachment', async () => {
   vi.spyOn(api, 'getBlob').mockResolvedValueOnce(new Blob(['x'], { type: 'application/pdf' }))
   renderAt('doc.pdf')
-  await waitFor(() => expect(screen.getByTitle('doc.pdf')).toBeInTheDocument())
+  await waitFor(() => expect(screen.getByTestId('pdf-view')).toBeInTheDocument())
+  expect(screen.getByTestId('pdf-view')).toHaveTextContent('doc.pdf')
 })
 
 it('renders a download fallback for unsupported types', async () => {

--- a/frontend/src/viewer/attachment-page.tsx
+++ b/frontend/src/viewer/attachment-page.tsx
@@ -1,24 +1,30 @@
 import { lazy, Suspense, useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import { api } from '../api/client'
+import { useAttachments } from '../api/queries'
 
 // pdf.js is heavy — only pull its chunk when a PDF is actually opened, never
 // for image/other previews.
 const PdfView = lazy(() => import('./pdf-view'))
 
-// Read-only preview for a single attachment. The path is the route splat
-// (`/attachment/*`). Fetches raw bytes (?raw=1) as a typed Blob so the browser
-// renders images / PDFs natively; unsupported types fall back to a download link.
+// Read-only preview for a single attachment, routed by uuid (/attachment/:id) —
+// like notes, so the URL survives a rename/move. Resolves the id to its path +
+// mime from the already-loaded attachments list (the tree sidebar keeps it
+// warm), then streams raw bytes (?raw=1) as a typed Blob so the browser renders
+// images / PDFs natively; unsupported types fall back to a download link.
 export default function AttachmentPage() {
-  const params = useParams()
-  const path = params['*'] ?? ''
+  const { id } = useParams()
+  const { data: attachments, isLoading } = useAttachments()
+  const att = attachments?.find((a) => a.id === id)
+  const path = att?.path ?? ''
   const filename = path.split('/').pop() ?? path
+  const mime = att?.mime_type ?? ''
 
   const [url, setUrl] = useState<string | null>(null)
-  const [mime, setMime] = useState<string>('')
   const [error, setError] = useState(false)
 
   useEffect(() => {
+    if (!path) return
     let revoke: string | null = null
     let cancelled = false
     setUrl(null)
@@ -30,7 +36,6 @@ export default function AttachmentPage() {
         if (cancelled) return
         const objectUrl = URL.createObjectURL(blob)
         revoke = objectUrl
-        setMime(blob.type)
         setUrl(objectUrl)
       })
       .catch(() => !cancelled && setError(true))
@@ -40,6 +45,22 @@ export default function AttachmentPage() {
     }
   }, [path])
 
+  // Attachment list still loading and the id isn't resolved yet.
+  if (!att && isLoading) {
+    return (
+      <section className="p-6">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </section>
+    )
+  }
+  // List loaded but no attachment with this id (deleted, or a stale link).
+  if (!att) {
+    return (
+      <section className="p-6">
+        <p className="text-sm text-destructive">Attachment not found.</p>
+      </section>
+    )
+  }
   if (error) {
     return (
       <section className="p-6">

--- a/frontend/src/viewer/attachment-page.tsx
+++ b/frontend/src/viewer/attachment-page.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router'
+import { api } from '../api/client'
+
+// Read-only preview for a single attachment. The path is the route splat
+// (`/attachment/*`). Fetches raw bytes (?raw=1) as a typed Blob so the browser
+// renders images / PDFs natively; unsupported types fall back to a download link.
+export default function AttachmentPage() {
+  const params = useParams()
+  const path = params['*'] ?? ''
+  const filename = path.split('/').pop() ?? path
+
+  const [url, setUrl] = useState<string | null>(null)
+  const [mime, setMime] = useState<string>('')
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let revoke: string | null = null
+    let cancelled = false
+    setUrl(null)
+    setError(false)
+    const encoded = path.split('/').map(encodeURIComponent).join('/')
+    api
+      .getBlob(`/attachments/${encoded}?raw=1`)
+      .then((blob) => {
+        if (cancelled) return
+        const objectUrl = URL.createObjectURL(blob)
+        revoke = objectUrl
+        setMime(blob.type)
+        setUrl(objectUrl)
+      })
+      .catch(() => !cancelled && setError(true))
+    return () => {
+      cancelled = true
+      if (revoke) URL.revokeObjectURL(revoke)
+    }
+  }, [path])
+
+  if (error) {
+    return (
+      <section className="p-6">
+        <p className="text-sm text-destructive">Couldn&apos;t load {filename}.</p>
+      </section>
+    )
+  }
+  if (!url) {
+    return (
+      <section className="p-6">
+        <p className="text-sm text-muted-foreground">Loading {filename}…</p>
+      </section>
+    )
+  }
+  if (mime.startsWith('image/')) {
+    return (
+      <section className="flex h-full items-center justify-center overflow-auto p-6">
+        <img src={url} alt={filename} className="max-h-full max-w-full rounded" />
+      </section>
+    )
+  }
+  if (mime === 'application/pdf') {
+    return <iframe title={filename} src={url} className="h-full w-full border-0" />
+  }
+  return (
+    <section className="p-6">
+      <p className="mb-3 text-sm text-muted-foreground">Preview not supported for {filename}.</p>
+      <a
+        href={url}
+        download={filename}
+        className="inline-flex items-center rounded bg-primary px-3 py-2 text-sm text-primary-foreground"
+      >
+        Download {filename}
+      </a>
+    </section>
+  )
+}

--- a/frontend/src/viewer/attachment-page.tsx
+++ b/frontend/src/viewer/attachment-page.tsx
@@ -2,6 +2,8 @@ import { lazy, Suspense, useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import { api } from '../api/client'
 import { useAttachments } from '../api/queries'
+import LoadingPane from './loading-pane'
+import PreviewColumn from './preview-column'
 
 // pdf.js is heavy — only pull its chunk when a PDF is actually opened, never
 // for image/other previews.
@@ -47,11 +49,7 @@ export default function AttachmentPage() {
 
   // Attachment list still loading and the id isn't resolved yet.
   if (!att && isLoading) {
-    return (
-      <section className="p-6">
-        <p className="text-sm text-muted-foreground">Loading…</p>
-      </section>
-    )
+    return <LoadingPane />
   }
   // List loaded but no attachment with this id (deleted, or a stale link).
   if (!att) {
@@ -69,28 +67,25 @@ export default function AttachmentPage() {
     )
   }
   if (!url) {
-    return (
-      <section className="p-6">
-        <p className="text-sm text-muted-foreground">Loading {filename}…</p>
-      </section>
-    )
+    return <LoadingPane />
   }
   if (mime.startsWith('image/')) {
     return (
-      <section className="flex h-full items-center justify-center overflow-auto p-6">
-        <img src={url} alt={filename} className="max-h-full max-w-full rounded" />
-      </section>
+      <PreviewColumn>
+        <div className="flex w-full justify-center p-4">
+          <img
+            src={url}
+            alt={filename}
+            className="max-w-full rounded shadow-md"
+            style={{ maxWidth: 800 }}
+          />
+        </div>
+      </PreviewColumn>
     )
   }
   if (mime === 'application/pdf') {
     return (
-      <Suspense
-        fallback={
-          <section className="p-6">
-            <p className="text-sm text-muted-foreground">Loading viewer…</p>
-          </section>
-        }
-      >
+      <Suspense fallback={<LoadingPane />}>
         <PdfView url={url} filename={filename} />
       </Suspense>
     )

--- a/frontend/src/viewer/attachment-page.tsx
+++ b/frontend/src/viewer/attachment-page.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import { api } from '../api/client'
+
+// pdf.js is heavy — only pull its chunk when a PDF is actually opened, never
+// for image/other previews.
+const PdfView = lazy(() => import('./pdf-view'))
 
 // Read-only preview for a single attachment. The path is the route splat
 // (`/attachment/*`). Fetches raw bytes (?raw=1) as a typed Blob so the browser
@@ -58,7 +62,17 @@ export default function AttachmentPage() {
     )
   }
   if (mime === 'application/pdf') {
-    return <iframe title={filename} src={url} className="h-full w-full border-0" />
+    return (
+      <Suspense
+        fallback={
+          <section className="p-6">
+            <p className="text-sm text-muted-foreground">Loading viewer…</p>
+          </section>
+        }
+      >
+        <PdfView url={url} filename={filename} />
+      </Suspense>
+    )
   }
   return (
     <section className="p-6">

--- a/frontend/src/viewer/attachment-page.tsx
+++ b/frontend/src/viewer/attachment-page.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react'
 import { useParams } from 'react-router'
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 import { useAttachments } from '../api/queries'
 import LoadingPane from './loading-pane'
 import PreviewColumn from './preview-column'
@@ -23,14 +23,15 @@ export default function AttachmentPage() {
   const mime = att?.mime_type ?? ''
 
   const [url, setUrl] = useState<string | null>(null)
-  const [error, setError] = useState(false)
+  // 'missing' = real 404; 'failed' = transient (5xx/network) — don't conflate.
+  const [error, setError] = useState<'missing' | 'failed' | null>(null)
 
   useEffect(() => {
     if (!path) return
     let revoke: string | null = null
     let cancelled = false
     setUrl(null)
-    setError(false)
+    setError(null)
     const encoded = path.split('/').map(encodeURIComponent).join('/')
     api
       .getBlob(`/attachments/${encoded}?raw=1`)
@@ -40,7 +41,11 @@ export default function AttachmentPage() {
         revoke = objectUrl
         setUrl(objectUrl)
       })
-      .catch(() => !cancelled && setError(true))
+      .catch((err) => {
+        if (cancelled) return
+        if (!(err instanceof ApiError)) console.error('attachment load failed', path, err)
+        setError(err instanceof ApiError && err.status === 404 ? 'missing' : 'failed')
+      })
     return () => {
       cancelled = true
       if (revoke) URL.revokeObjectURL(revoke)
@@ -62,7 +67,11 @@ export default function AttachmentPage() {
   if (error) {
     return (
       <section className="p-6">
-        <p className="text-sm text-destructive">Couldn&apos;t load {filename}.</p>
+        <p className="text-sm text-destructive">
+          {error === 'missing'
+            ? `${filename} no longer exists.`
+            : `Couldn't load ${filename} — it may be temporarily unavailable.`}
+        </p>
       </section>
     )
   }

--- a/frontend/src/viewer/folder-tree.test.tsx
+++ b/frontend/src/viewer/folder-tree.test.tsx
@@ -220,6 +220,7 @@ describe('FolderTree (HT)', () => {
     mock.rootNotes = []
     mock.attachments = [
       {
+        id: 'cover-1',
         path: 'cover.png',
         mime_type: 'image/png',
         size_bytes: 1,

--- a/frontend/src/viewer/folder-tree.test.tsx
+++ b/frontend/src/viewer/folder-tree.test.tsx
@@ -41,8 +41,8 @@ const {
   batchMoveNotesMutate: vi.fn(),
   batchDeleteFoldersMutate: vi.fn(),
   batchMoveFoldersMutate: vi.fn(),
-  // Mutable per-test fixtures (folders + root notes + loading flag), set in beforeEach.
-  mock: { folders: [] as unknown[], rootNotes: [] as unknown[], loading: false },
+  // Mutable per-test fixtures (folders + root notes + loading flag + attachments), set in beforeEach.
+  mock: { folders: [] as unknown[], rootNotes: [] as unknown[], loading: false, attachments: [] as unknown[] },
 }))
 
 vi.mock('../api/queries', async () => {
@@ -54,6 +54,7 @@ vi.mock('../api/queries', async () => {
       isLoading: mock.loading,
       isError: false,
     }),
+    useAttachments: () => ({ data: mock.attachments, isLoading: false }),
     useFolderNotesById: (folderId: string | null) => {
       // Root notes share the one id-keyed cache under the 'root' sentinel.
       if (folderId === 'root') {
@@ -114,6 +115,7 @@ beforeEach(() => {
   mock.folders = DEFAULT_FOLDERS.map((f) => ({ ...f }))
   mock.rootNotes = [{ ...DEFAULT_ROOT_NOTE }]
   mock.loading = false
+  mock.attachments = []
 })
 
 describe('FolderTree (HT)', () => {
@@ -211,5 +213,21 @@ describe('FolderTree (HT)', () => {
       expect(screen.getByTestId('folder-tree-root')).toBeInTheDocument()
     })
     expect(screen.queryByText('Loading…')).not.toBeInTheDocument()
+  })
+
+  it('renders an attachment row from useAttachments', async () => {
+    mock.folders = []
+    mock.rootNotes = []
+    mock.attachments = [
+      {
+        path: 'cover.png',
+        mime_type: 'image/png',
+        size_bytes: 1,
+        mtime: 0,
+        updated_at: '2026-06-10T00:00:00Z',
+      },
+    ]
+    renderTree()
+    expect(await screen.findByText('cover.png')).toBeInTheDocument()
   })
 })

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -88,6 +88,8 @@ export default function FolderTree() {
   // existing item path's folder + new leaf name.
   const onRenameCommit = (itemId: string, newName: string) => {
     const p = parseItemId(itemId)
+    // Synthetic folders have no backend record — nothing to rename.
+    if (p.kind === 'folder' && p.id.startsWith('syn:')) return
     if (p.kind === 'note') {
       const item = qc.getQueryCache().findAll({ queryKey: ['folder-notes-by-id', vaultId] })
         .flatMap((q) => (q.state.data as Array<{ id: string; path: string }> | undefined) ?? [])
@@ -112,9 +114,15 @@ export default function FolderTree() {
   const onMove = (sourceIds: string[], targetItemId: string) => {
     const target = parseItemId(targetItemId)
     if (target.kind !== 'folder' && target.kind !== 'root') return
+    // Synthetic folders (id prefix 'syn:') are UI-only scaffolding for
+    // attachment-only dirs — they have no backend record, so they can be
+    // neither a move destination nor a moved source.
+    if (target.kind === 'folder' && target.id.startsWith('syn:')) return
     const parsed = sourceIds.map(parseItemId)
     const noteIds = parsed.filter((p) => p.kind === 'note').map((p) => (p as { id: string }).id)
-    const folderIds = parsed.filter((p) => p.kind === 'folder').map((p) => (p as { id: string }).id)
+    const folderIds = parsed
+      .filter((p) => p.kind === 'folder' && !(p as { id: string }).id.startsWith('syn:'))
+      .map((p) => (p as { id: string }).id)
     // 'root' is the backend sentinel for the vault root; a folder target uses
     // its marker id. Note→root has no optimistic patch (root notes live under a
     // different cache key than the by-id folder lists), so a moved note briefly

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -20,7 +20,7 @@ import {
   useRenameFolder,
   useDuplicateNote,
 } from '../api/queries'
-import { synthesizeFolders } from './tree/synthesize-folders'
+import { isSyntheticFolderId, synthesizeFolders } from './tree/synthesize-folders'
 import { useActiveVaultId } from '../api/active-vault'
 import { useFolderTreeState } from '../layout/folder-tree-context'
 import { useEngramTree } from './tree/use-engram-tree'
@@ -89,7 +89,7 @@ export default function FolderTree() {
   const onRenameCommit = (itemId: string, newName: string) => {
     const p = parseItemId(itemId)
     // Synthetic folders have no backend record — nothing to rename.
-    if (p.kind === 'folder' && p.id.startsWith('syn:')) return
+    if (p.kind === 'folder' && isSyntheticFolderId(p.id)) return
     if (p.kind === 'note') {
       const item = qc.getQueryCache().findAll({ queryKey: ['folder-notes-by-id', vaultId] })
         .flatMap((q) => (q.state.data as Array<{ id: string; path: string }> | undefined) ?? [])
@@ -117,11 +117,11 @@ export default function FolderTree() {
     // Synthetic folders (id prefix 'syn:') are UI-only scaffolding for
     // attachment-only dirs — they have no backend record, so they can be
     // neither a move destination nor a moved source.
-    if (target.kind === 'folder' && target.id.startsWith('syn:')) return
+    if (target.kind === 'folder' && isSyntheticFolderId(target.id)) return
     const parsed = sourceIds.map(parseItemId)
     const noteIds = parsed.filter((p) => p.kind === 'note').map((p) => (p as { id: string }).id)
     const folderIds = parsed
-      .filter((p) => p.kind === 'folder' && !(p as { id: string }).id.startsWith('syn:'))
+      .filter((p) => p.kind === 'folder' && !isSyntheticFolderId((p as { id: string }).id))
       .map((p) => (p as { id: string }).id)
     // 'root' is the backend sentinel for the vault root; a folder target uses
     // its marker id. Note→root has no optimistic patch (root notes live under a
@@ -342,7 +342,7 @@ export default function FolderTree() {
       // Synthetic folders (syn:) have no backend record — never send their id
       // to a batch mutation. Unreachable today (their rows expose no menu), but
       // a guard here keeps any future bulk-select path from 404ing.
-      else if (p.kind === 'folder' && !p.id.startsWith('syn:')) folderIds.push(p.id)
+      else if (p.kind === 'folder' && !isSyntheticFolderId(p.id)) folderIds.push(p.id)
     }
     return { noteIds, folderIds }
   }

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -339,7 +339,10 @@ export default function FolderTree() {
     for (const id of itemIds) {
       const p = parseItemId(id)
       if (p.kind === 'note') noteIds.push(p.id)
-      else if (p.kind === 'folder') folderIds.push(p.id)
+      // Synthetic folders (syn:) have no backend record — never send their id
+      // to a batch mutation. Unreachable today (their rows expose no menu), but
+      // a guard here keeps any future bulk-select path from 404ing.
+      else if (p.kind === 'folder' && !p.id.startsWith('syn:')) folderIds.push(p.id)
     }
     return { noteIds, folderIds }
   }

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -1,13 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import {
+  type AttachmentSummary,
   type Folder,
   FOLDER_NOTES_STALE_MS,
   fetchNotesForFolderId,
   type Note,
   ROOT_FOLDER_ID,
+  useAttachments,
   useFolders,
   useFolderNotesById,
   useBatchDeleteNotes,
@@ -18,6 +20,7 @@ import {
   useRenameFolder,
   useDuplicateNote,
 } from '../api/queries'
+import { synthesizeFolders } from './tree/synthesize-folders'
 import { useActiveVaultId } from '../api/active-vault'
 import { useFolderTreeState } from '../layout/folder-tree-context'
 import { useEngramTree } from './tree/use-engram-tree'
@@ -38,10 +41,11 @@ type MoveRow =
   | { kind: 'file'; path: string }
   | { kind: 'folder'; path: string }
 
-// Module-level stable empty array — passing `folders ?? []` creates a new
-// reference each render while the query is loading, which spins up an
-// infinite re-render loop in useEngramTree's rebuildTree effect.
+// Module-level stable empty arrays — passing `folders ?? []` / `attachments ?? []`
+// creates a new reference each render while the query is loading, which spins
+// up an infinite re-render loop in useEngramTree's rebuildTree effect.
 const EMPTY_FOLDERS: Folder[] = []
+const EMPTY_ATTACHMENTS: AttachmentSummary[] = []
 
 type DialogState =
   | { kind: 'none' }
@@ -57,6 +61,11 @@ export default function FolderTree() {
   // needs a real folder id). Subscribing here gives root an observer so
   // invalidations refetch it; the loader stitches the rows under ROOT.
   const { data: rootNotes = [] } = useFolderNotesById(ROOT_FOLDER_ID)
+  const { data: attachments = EMPTY_ATTACHMENTS } = useAttachments()
+  const allFolders = useMemo(
+    () => synthesizeFolders(folders ?? EMPTY_FOLDERS, attachments),
+    [folders, attachments],
+  )
   const { sort } = useFolderTreeState()
   const vaultId = useActiveVaultId()
   const qc = useQueryClient()
@@ -102,7 +111,7 @@ export default function FolderTree() {
   // matching batch hook. Drop target must be a folder or the vault root.
   const onMove = (sourceIds: string[], targetItemId: string) => {
     const target = parseItemId(targetItemId)
-    if (target.kind === 'note') return
+    if (target.kind !== 'folder' && target.kind !== 'root') return
     const parsed = sourceIds.map(parseItemId)
     const noteIds = parsed.filter((p) => p.kind === 'note').map((p) => (p as { id: string }).id)
     const folderIds = parsed.filter((p) => p.kind === 'folder').map((p) => (p as { id: string }).id)
@@ -152,7 +161,8 @@ export default function FolderTree() {
   }, [folders, prefetchFolderNotes])
 
   const { tree, virtualizer, items } = useEngramTree({
-    folders: folders ?? EMPTY_FOLDERS,
+    folders: allFolders,
+    attachments,
     qc,
     vaultId: vaultId ?? '',
     sort,
@@ -366,7 +376,7 @@ export default function FolderTree() {
   // Empty only when there are neither folders nor root-level notes. A vault
   // with root notes but no folders (e.g. a freshly created "Untitled" at root)
   // must still render the tree — the loader stitches rootNotes under ROOT.
-  if (!folders || (folders.length === 0 && rootNotes.length === 0)) {
+  if (!folders || (allFolders.length === 0 && rootNotes.length === 0 && attachments.length === 0)) {
     return (
       <p data-testid="folder-tree-root" className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
         No notes yet.

--- a/frontend/src/viewer/loading-pane.tsx
+++ b/frontend/src/viewer/loading-pane.tsx
@@ -1,0 +1,18 @@
+import { Loader2 } from 'lucide-react'
+
+// Centered loading state for full-pane content — route/lazy fallbacks, notes,
+// and attachment previews. Fills the pane when it has a height and falls back to
+// a sensible minimum otherwise, so the spinner lands in the middle instead of a
+// bare "Loading…" in the top-left corner.
+export default function LoadingPane({ label }: { label?: string }) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex h-full min-h-[60vh] w-full flex-col items-center justify-center gap-3 text-muted-foreground"
+    >
+      <Loader2 aria-hidden className="size-8 animate-spin" />
+      {label ? <p className="text-sm">{label}</p> : <span className="sr-only">Loading</span>}
+    </div>
+  )
+}

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -8,6 +8,7 @@ import { ApiError } from '../api/client'
 import { useRightSidebar } from '../layout/right-sidebar-context'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import LoadingPane from './loading-pane'
 import NoteToc from './note-toc'
 import NoteView from './note-view'
 import { merge3 } from './merge'
@@ -207,7 +208,7 @@ export default function NotePage() {
   )
 
   if (validId === null) return <p className="p-6 text-destructive">Invalid note id.</p>
-  if (isLoading) return <p className="p-6 text-muted-foreground">Loading note…</p>
+  if (isLoading) return <LoadingPane />
   if (error) return <p className="p-6 text-destructive">Failed to load note: {error.message}</p>
   if (!note) return <p className="p-6 text-muted-foreground">Note not found</p>
 

--- a/frontend/src/viewer/pdf-view.test.tsx
+++ b/frontend/src/viewer/pdf-view.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import { expect, it, vi } from 'vitest'
+
+// pdf.js can't render in jsdom (canvas + worker), so stub react-pdf: Document
+// reports a fixed page count, Page renders a marker. This verifies PdfView's
+// own logic — the page loop driven by onLoadSuccess.
+vi.mock('react-pdf', () => ({
+  pdfjs: { GlobalWorkerOptions: {} },
+  Document: ({
+    onLoadSuccess,
+    children,
+  }: {
+    onLoadSuccess?: (d: { numPages: number }) => void
+    children: React.ReactNode
+  }) => {
+    useEffect(() => onLoadSuccess?.({ numPages: 3 }), [onLoadSuccess])
+    return <div data-testid="pdf-document">{children}</div>
+  },
+  Page: ({ pageNumber }: { pageNumber: number }) => (
+    <div data-testid="pdf-page">page {pageNumber}</div>
+  ),
+}))
+
+import PdfView from './pdf-view'
+
+it('renders one Page per page reported by the document', async () => {
+  render(<PdfView url="blob:fake" filename="doc.pdf" />)
+  await waitFor(() => expect(screen.getAllByTestId('pdf-page')).toHaveLength(3))
+  expect(screen.getByText('page 1')).toBeInTheDocument()
+  expect(screen.getByText('page 3')).toBeInTheDocument()
+})

--- a/frontend/src/viewer/pdf-view.tsx
+++ b/frontend/src/viewer/pdf-view.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 import 'react-pdf/dist/Page/TextLayer.css'
+import { ScrollArea } from '@/components/ui/scroll-area'
 
 // Self-host the pdf.js worker from the bundled pdfjs-dist (Vite resolves the
 // `new URL(..., import.meta.url)` asset reference at build time). Keeps PDF
@@ -11,11 +12,15 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   import.meta.url,
 ).toString()
 
-// Continuous, fit-to-width PDF viewer. Renders every page stacked in one
-// scroll column (our chrome, not the browser's iframe toolbar). The page
-// width tracks the container so pages fill the pane and reflow on resize.
+// Cap page render width to roughly a natural Letter/A4 page (~800px) so pages
+// read as a centered document column instead of stretching across wide panes.
+const MAX_PAGE_WIDTH = 800
+
+// Continuous, fit-to-width PDF viewer. Mirrors the note view's surface — a
+// centered max-w-[840px] card column with a ScrollArea — and stacks every page
+// in one scroll column over a muted gutter so the white pages stay distinct.
 export default function PdfView({ url, filename }: { url: string; filename: string }) {
-  const containerRef = useRef<HTMLElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
   const [numPages, setNumPages] = useState(0)
   const [width, setWidth] = useState(0)
 
@@ -26,28 +31,33 @@ export default function PdfView({ url, filename }: { url: string; filename: stri
     return () => window.removeEventListener('resize', measure)
   }, [])
 
-  // px-4 padding (16 each side) — render slightly narrower than the container,
-  // capped so pages don't blow up on ultra-wide panes.
-  const pageWidth = width ? Math.min(width - 32, 1000) : undefined
+  // p-4 gutter (16 each side) — render slightly narrower than the column, capped
+  // so pages never blow past a natural page width.
+  const pageWidth = width ? Math.min(width - 32, MAX_PAGE_WIDTH) : undefined
 
   return (
-    <section ref={containerRef} className="h-full overflow-auto bg-muted/30 px-4 py-4">
-      <Document
-        file={url}
-        onLoadSuccess={({ numPages }) => setNumPages(numPages)}
-        loading={<p className="text-sm text-muted-foreground">Loading {filename}…</p>}
-        error={<p className="text-sm text-destructive">Couldn&apos;t render {filename}.</p>}
-      >
-        {Array.from({ length: numPages }, (_, i) => (
-          <Page
-            key={i + 1}
-            pageNumber={i + 1}
-            width={pageWidth}
-            className="mx-auto mb-4 shadow-sm"
-            renderAnnotationLayer={false}
-          />
-        ))}
-      </Document>
+    <section className="mx-auto -my-6 flex h-[calc(100%+3rem)] min-h-0 w-full min-w-0 max-w-[840px] flex-col overflow-hidden">
+      <ScrollArea className="min-h-0 flex-1">
+        <div ref={containerRef} className="w-full p-4">
+          <Document
+            file={url}
+            onLoadSuccess={({ numPages }) => setNumPages(numPages)}
+            className="flex flex-col items-center gap-4"
+            loading={<p className="p-2 text-sm text-muted-foreground">Loading {filename}…</p>}
+            error={<p className="p-2 text-sm text-destructive">Couldn&apos;t render {filename}.</p>}
+          >
+            {Array.from({ length: numPages }, (_, i) => (
+              <Page
+                key={i + 1}
+                pageNumber={i + 1}
+                width={pageWidth}
+                className="shadow-md"
+                renderAnnotationLayer={false}
+              />
+            ))}
+          </Document>
+        </div>
+      </ScrollArea>
     </section>
   )
 }

--- a/frontend/src/viewer/pdf-view.tsx
+++ b/frontend/src/viewer/pdf-view.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 import 'react-pdf/dist/Page/TextLayer.css'
-import { ScrollArea } from '@/components/ui/scroll-area'
+import LoadingPane from './loading-pane'
+import PreviewColumn from './preview-column'
 
 // Self-host the pdf.js worker from the bundled pdfjs-dist (Vite resolves the
 // `new URL(..., import.meta.url)` asset reference at build time). Keeps PDF
@@ -36,28 +37,26 @@ export default function PdfView({ url, filename }: { url: string; filename: stri
   const pageWidth = width ? Math.min(width - 32, MAX_PAGE_WIDTH) : undefined
 
   return (
-    <section className="mx-auto -my-6 flex h-[calc(100%+3rem)] min-h-0 w-full min-w-0 max-w-[840px] flex-col overflow-hidden">
-      <ScrollArea className="min-h-0 flex-1">
-        <div ref={containerRef} className="w-full p-4">
-          <Document
-            file={url}
-            onLoadSuccess={({ numPages }) => setNumPages(numPages)}
-            className="flex flex-col items-center gap-4"
-            loading={<p className="p-2 text-sm text-muted-foreground">Loading {filename}…</p>}
-            error={<p className="p-2 text-sm text-destructive">Couldn&apos;t render {filename}.</p>}
-          >
-            {Array.from({ length: numPages }, (_, i) => (
-              <Page
-                key={i + 1}
-                pageNumber={i + 1}
-                width={pageWidth}
-                className="shadow-md"
-                renderAnnotationLayer={false}
-              />
-            ))}
-          </Document>
-        </div>
-      </ScrollArea>
-    </section>
+    <PreviewColumn>
+      <div ref={containerRef} className="w-full p-4">
+        <Document
+          file={url}
+          onLoadSuccess={({ numPages }) => setNumPages(numPages)}
+          className="flex flex-col items-center gap-4"
+          loading={<LoadingPane />}
+          error={<p className="p-2 text-sm text-destructive">Couldn&apos;t render {filename}.</p>}
+        >
+          {Array.from({ length: numPages }, (_, i) => (
+            <Page
+              key={i + 1}
+              pageNumber={i + 1}
+              width={pageWidth}
+              className="shadow-md"
+              renderAnnotationLayer={false}
+            />
+          ))}
+        </Document>
+      </div>
+    </PreviewColumn>
   )
 }

--- a/frontend/src/viewer/pdf-view.tsx
+++ b/frontend/src/viewer/pdf-view.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react'
+import { Document, Page, pdfjs } from 'react-pdf'
+import 'react-pdf/dist/Page/AnnotationLayer.css'
+import 'react-pdf/dist/Page/TextLayer.css'
+
+// Self-host the pdf.js worker from the bundled pdfjs-dist (Vite resolves the
+// `new URL(..., import.meta.url)` asset reference at build time). Keeps PDF
+// rendering offline / same-origin — no CDN fetch.
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString()
+
+// Continuous, fit-to-width PDF viewer. Renders every page stacked in one
+// scroll column (our chrome, not the browser's iframe toolbar). The page
+// width tracks the container so pages fill the pane and reflow on resize.
+export default function PdfView({ url, filename }: { url: string; filename: string }) {
+  const containerRef = useRef<HTMLElement>(null)
+  const [numPages, setNumPages] = useState(0)
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const measure = () => setWidth(containerRef.current?.clientWidth ?? 0)
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [])
+
+  // px-4 padding (16 each side) — render slightly narrower than the container,
+  // capped so pages don't blow up on ultra-wide panes.
+  const pageWidth = width ? Math.min(width - 32, 1000) : undefined
+
+  return (
+    <section ref={containerRef} className="h-full overflow-auto bg-muted/30 px-4 py-4">
+      <Document
+        file={url}
+        onLoadSuccess={({ numPages }) => setNumPages(numPages)}
+        loading={<p className="text-sm text-muted-foreground">Loading {filename}…</p>}
+        error={<p className="text-sm text-destructive">Couldn&apos;t render {filename}.</p>}
+      >
+        {Array.from({ length: numPages }, (_, i) => (
+          <Page
+            key={i + 1}
+            pageNumber={i + 1}
+            width={pageWidth}
+            className="mx-auto mb-4 shadow-sm"
+            renderAnnotationLayer={false}
+          />
+        ))}
+      </Document>
+    </section>
+  )
+}

--- a/frontend/src/viewer/preview-column.tsx
+++ b/frontend/src/viewer/preview-column.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+// Shared surface for full-pane attachment previews (image, PDF). Mirrors the
+// note view's reading column — a centered max-w-[840px] track with a ScrollArea
+// — so files and notes share one visual frame. Callers render their own content
+// (image / pdf pages) inside, centered with a shadow.
+export default function PreviewColumn({ children }: { children: ReactNode }) {
+  return (
+    <section className="mx-auto -my-6 flex h-[calc(100%+3rem)] min-h-0 w-full min-w-0 max-w-[840px] flex-col overflow-hidden">
+      <ScrollArea className="min-h-0 flex-1">{children}</ScrollArea>
+    </section>
+  )
+}

--- a/frontend/src/viewer/tree/loader.test.ts
+++ b/frontend/src/viewer/tree/loader.test.ts
@@ -128,6 +128,29 @@ it('shows attachments even while folder notes are still loading (cache miss)', (
   expect(kids.find((k) => k.item.kind === 'attachment')).toBeDefined()
 })
 
+it('buckets an attachment under a synthetic (syn:) folder', () => {
+  // The whole point of synthesizeFolders: an attachment-only dir gets a synthetic
+  // folder row, and its attachment must appear as that folder's child.
+  const folders = [{ id: 'syn:pics', parent_id: null, name: 'pics', count: 0 }]
+  const loader = buildLoader({
+    folders, qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('pics/a.png')],
+  })
+  qc.setQueryData(['folder-notes-by-id', 'v1', 'syn:pics'], [])
+  const kids = loader.getChildren('f:syn:pics')
+  const a = kids.find((k) => k.item.kind === 'attachment')
+  expect(a?.item).toMatchObject({ path: 'pics/a.png' })
+})
+
+it('getItem resolves an attachment id to its row, and undefined when absent', () => {
+  const loader = buildLoader({
+    folders: [], qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('cover.png')],
+  })
+  expect(loader.getItem('a:cover.png')?.item).toMatchObject({ kind: 'attachment', path: 'cover.png' })
+  expect(loader.getItem('a:nope.png')).toBeUndefined()
+})
+
 describe('buildLoader', () => {
   it('root returns top-level folders + root notes from the by-id root cache, sorted', () => {
     const qc = makeQc()

--- a/frontend/src/viewer/tree/loader.test.ts
+++ b/frontend/src/viewer/tree/loader.test.ts
@@ -118,11 +118,7 @@ it('does not leak a subfolder attachment into its parent', () => {
 
 it('shows attachments even while folder notes are still loading (cache miss)', () => {
   const folders = [{ id: 'f1', parent_id: null, name: 'img', count: 0 }]
-  const loader = buildLoader({
-    folders, qc, vaultId: 'v1', sort: 'name-asc',
-    attachments: [att('img/a.png')],
-    // no fetchFolderNotes, no seeded cache -> noteChildItems returns null
-  })
+  // A fresh client with no seeded notes cache -> noteChildItems returns null.
   const freshQc = new QueryClient()
   const loaderFresh = buildLoader({
     folders, qc: freshQc, vaultId: 'v1', sort: 'name-asc',

--- a/frontend/src/viewer/tree/loader.test.ts
+++ b/frontend/src/viewer/tree/loader.test.ts
@@ -75,6 +75,20 @@ it('lists root attachments under ROOT', () => {
   expect(a?.itemId).toBe('a:cover.png')
 })
 
+it('orders root attachments by mtime under modified-desc', () => {
+  const older: AttachmentSummary = { ...att('old.png'), mtime: 100 }
+  const newer: AttachmentSummary = { ...att('new.png'), mtime: 200 }
+  const loader = buildLoader({
+    folders: [], qc, vaultId: 'v1', sort: 'modified-desc',
+    attachments: [older, newer],
+  })
+  const paths = loader
+    .getChildren('root')
+    .filter((k) => k.item.kind === 'attachment')
+    .map((k) => (k.item as { path: string }).path)
+  expect(paths).toEqual(['new.png', 'old.png'])
+})
+
 it('buckets an attachment under its folder', () => {
   const folders = [{ id: 'f1', parent_id: null, name: 'img', count: 0 }]
   const loader = buildLoader({

--- a/frontend/src/viewer/tree/loader.test.ts
+++ b/frontend/src/viewer/tree/loader.test.ts
@@ -60,7 +60,7 @@ function makeQc(): QueryClient {
 const qc = new QueryClient()
 
 const att = (path: string): AttachmentSummary => ({
-  path, mime_type: path.endsWith('.pdf') ? 'application/pdf' : 'image/png',
+  id: `att:${path}`, path, mime_type: path.endsWith('.pdf') ? 'application/pdf' : 'image/png',
   size_bytes: 1, mtime: 0, updated_at: '',
 })
 

--- a/frontend/src/viewer/tree/loader.test.ts
+++ b/frontend/src/viewer/tree/loader.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { QueryClient } from '@tanstack/react-query'
 import { buildLoader, type SortKey } from './loader'
-import type { Folder, NoteSummary } from '../../api/queries'
+import type { AttachmentSummary, Folder, NoteSummary } from '../../api/queries'
 
 const folders: Folder[] = [
   { id: '1', parent_id: null, name: 'Projects', count: 2 },
@@ -55,6 +55,68 @@ function makeQc(): QueryClient {
   qc.setQueryData(['folder-notes-by-id', 'v', '2'], notesByFolder['2'])
   return qc
 }
+
+// Standalone qc for attachment tests (no pre-seeded folder notes)
+const qc = new QueryClient()
+
+const att = (path: string): AttachmentSummary => ({
+  path, mime_type: path.endsWith('.pdf') ? 'application/pdf' : 'image/png',
+  size_bytes: 1, mtime: 0, updated_at: '',
+})
+
+it('lists root attachments under ROOT', () => {
+  const loader = buildLoader({
+    folders: [], qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('cover.png')],
+  })
+  const kids = loader.getChildren('root')
+  const a = kids.find((k) => k.item.kind === 'attachment')
+  expect(a?.item).toMatchObject({ kind: 'attachment', path: 'cover.png', mime: 'image/png' })
+  expect(a?.itemId).toBe('a:cover.png')
+})
+
+it('buckets an attachment under its folder', () => {
+  const folders = [{ id: 'f1', parent_id: null, name: 'img', count: 0 }]
+  const loader = buildLoader({
+    folders, qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('img/a.png')],
+  })
+  qc.setQueryData(['folder-notes-by-id', 'v1', 'f1'], [])
+  const kids = loader.getChildren('f:f1')
+  expect(kids.map((k) => k.item.kind)).toContain('attachment')
+  const a = kids.find((k) => k.item.kind === 'attachment')
+  expect(a?.item).toMatchObject({ path: 'img/a.png' })
+})
+
+it('does not leak a subfolder attachment into its parent', () => {
+  const folders = [
+    { id: 'f1', parent_id: null, name: 'img', count: 0 },
+    { id: 'f2', parent_id: 'f1', name: 'img/sub', count: 0 },
+  ]
+  const loader = buildLoader({
+    folders, qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('img/sub/deep.png')],
+  })
+  qc.setQueryData(['folder-notes-by-id', 'v1', 'f1'], [])
+  const kids = loader.getChildren('f:f1')
+  expect(kids.find((k) => k.item.kind === 'attachment')).toBeUndefined()
+})
+
+it('shows attachments even while folder notes are still loading (cache miss)', () => {
+  const folders = [{ id: 'f1', parent_id: null, name: 'img', count: 0 }]
+  const loader = buildLoader({
+    folders, qc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('img/a.png')],
+    // no fetchFolderNotes, no seeded cache -> noteChildItems returns null
+  })
+  const freshQc = new QueryClient()
+  const loaderFresh = buildLoader({
+    folders, qc: freshQc, vaultId: 'v1', sort: 'name-asc',
+    attachments: [att('img/a.png')],
+  })
+  const kids = loaderFresh.getChildren('f:f1')
+  expect(kids.find((k) => k.item.kind === 'attachment')).toBeDefined()
+})
 
 describe('buildLoader', () => {
   it('root returns top-level folders + root notes from the by-id root cache, sorted', () => {

--- a/frontend/src/viewer/tree/loader.ts
+++ b/frontend/src/viewer/tree/loader.ts
@@ -2,6 +2,7 @@ import { QueryClient } from '@tanstack/react-query'
 import {
   FOLDER_NOTES_STALE_MS,
   ROOT_FOLDER_ID,
+  type AttachmentSummary,
   type Folder,
   type NoteSummary,
 } from '../../api/queries'
@@ -18,6 +19,7 @@ interface LoaderDeps {
   qc: QueryClient
   vaultId: string
   sort: SortKey
+  attachments?: AttachmentSummary[]
   fetchFolderNotes?: (folderId: string) => Promise<NoteSummary[]>
   onChildrenLoaded?: (folderId: string) => void
 }
@@ -112,16 +114,42 @@ function noteChildItems(deps: LoaderDeps, folderId: string): LoaderItem[] | null
   }))
 }
 
+function attachmentDir(path: string): string {
+  const slash = path.lastIndexOf('/')
+  return slash < 0 ? '' : path.slice(0, slash)
+}
+
+function attachmentToTreeItem(a: AttachmentSummary): Extract<TreeItem, { kind: 'attachment' }> {
+  return { kind: 'attachment', path: a.path, mime: a.mime_type, size: a.size_bytes }
+}
+
+function attachmentItemsForDir(deps: LoaderDeps, dir: string): LoaderItem[] {
+  const list = (deps.attachments ?? []).filter((a) => attachmentDir(a.path) === dir)
+  const sign = deps.sort.endsWith('-desc') ? -1 : 1
+  const fname = (p: string) => p.split('/').pop() ?? p
+  return list
+    .sort((a, b) => sign * fname(a.path).localeCompare(fname(b.path)))
+    .map((a) => ({
+      itemId: formatItemId({ kind: 'attachment', path: a.path }),
+      item: attachmentToTreeItem(a),
+      isFolder: false,
+    }))
+}
+
 function rootChildren(deps: LoaderDeps): LoaderItem[] {
   const tops = folderLoaderItems(deps, null)
   const noteItems = noteChildItems(deps, ROOT_FOLDER_ID) ?? []
-  return [...tops, ...noteItems]
+  const attItems = attachmentItemsForDir(deps, '')
+  return [...tops, ...noteItems, ...attItems]
 }
 
 function folderChildren(deps: LoaderDeps, folderId: string): LoaderItem[] {
   const childFolders = folderLoaderItems(deps, folderId)
   const noteItems = noteChildItems(deps, folderId)
-  return noteItems ? [...childFolders, ...noteItems] : childFolders
+  const folder = deps.folders.find((f) => f.id === folderId)
+  const attItems = folder ? attachmentItemsForDir(deps, folder.name) : []
+  const notes = noteItems ?? []
+  return [...childFolders, ...notes, ...attItems]
 }
 
 function folderCmp(a: Folder, b: Folder, sort: SortKey): number {

--- a/frontend/src/viewer/tree/loader.ts
+++ b/frontend/src/viewer/tree/loader.ts
@@ -122,7 +122,7 @@ function attachmentDir(path: string): string {
 }
 
 function attachmentToTreeItem(a: AttachmentSummary): Extract<TreeItem, { kind: 'attachment' }> {
-  return { kind: 'attachment', path: a.path, mime: a.mime_type, size: a.size_bytes }
+  return { kind: 'attachment', id: a.id, path: a.path, mime: a.mime_type, size: a.size_bytes }
 }
 
 // Resolve an attachment item id back to its row. The HT bridge caches rows from

--- a/frontend/src/viewer/tree/loader.ts
+++ b/frontend/src/viewer/tree/loader.ts
@@ -88,7 +88,8 @@ function folderLoaderItems(deps: LoaderDeps, parentId: string | null): LoaderIte
 
 // Note children for a folder id (ROOT_FOLDER_ID for the vault root). Reads the
 // id-keyed cache; on a miss, lazily fetches and asks HT to refetch the branch.
-// Returns null on a cache miss so callers can render folders-only meanwhile.
+// Returns null on a cache miss so callers can render folders + attachments
+// (but not notes) while the fetch is in flight.
 function noteChildItems(deps: LoaderDeps, folderId: string): LoaderItem[] | null {
   const cached = deps.qc.getQueryData<NoteSummary[]>(['folder-notes-by-id', deps.vaultId, folderId])
   if (!cached) {
@@ -127,8 +128,15 @@ function attachmentItemsForDir(deps: LoaderDeps, dir: string): LoaderItem[] {
   const list = (deps.attachments ?? []).filter((a) => attachmentDir(a.path) === dir)
   const sign = deps.sort.endsWith('-desc') ? -1 : 1
   const fname = (p: string) => p.split('/').pop() ?? p
+  // Honor the temporal sort key via `mtime` so attachments order consistently
+  // with notes under modified-*. Attachments carry no created_at, so created-*
+  // (and name-*) fall back to filename.
+  const cmp =
+    deps.sort.startsWith('modified')
+      ? (a: AttachmentSummary, b: AttachmentSummary) => sign * (a.mtime - b.mtime)
+      : (a: AttachmentSummary, b: AttachmentSummary) => sign * fname(a.path).localeCompare(fname(b.path))
   return list
-    .sort((a, b) => sign * fname(a.path).localeCompare(fname(b.path)))
+    .sort(cmp)
     .map((a) => ({
       itemId: formatItemId({ kind: 'attachment', path: a.path }),
       item: attachmentToTreeItem(a),

--- a/frontend/src/viewer/tree/loader.ts
+++ b/frontend/src/viewer/tree/loader.ts
@@ -37,7 +37,8 @@ export function buildLoader(deps: LoaderDeps) {
       const p = parseItemId(itemId)
       if (p.kind === 'root') return undefined
       if (p.kind === 'folder') return folderLoaderItem(deps, p.id)
-      return noteLoaderItem(deps, p.id)
+      if (p.kind === 'note') return noteLoaderItem(deps, p.id)
+      return attachmentLoaderItem(deps, p.path)
     },
 
     getChildren(itemId: string): LoaderItem[] {
@@ -122,6 +123,19 @@ function attachmentDir(path: string): string {
 
 function attachmentToTreeItem(a: AttachmentSummary): Extract<TreeItem, { kind: 'attachment' }> {
   return { kind: 'attachment', path: a.path, mime: a.mime_type, size: a.size_bytes }
+}
+
+// Resolve an attachment item id back to its row. The HT bridge caches rows from
+// getChildren, so this is only hit for ids HT knows before enumerating (rare),
+// but it keeps getItem total over the whole TreeItem union.
+function attachmentLoaderItem(deps: LoaderDeps, path: string): LoaderItem | undefined {
+  const a = (deps.attachments ?? []).find((x) => x.path === path)
+  if (!a) return undefined
+  return {
+    itemId: formatItemId({ kind: 'attachment', path }),
+    item: attachmentToTreeItem(a),
+    isFolder: false,
+  }
 }
 
 function attachmentItemsForDir(deps: LoaderDeps, dir: string): LoaderItem[] {

--- a/frontend/src/viewer/tree/synthesize-folders.test.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.test.ts
@@ -3,7 +3,7 @@ import { synthesizeFolders } from './synthesize-folders'
 import type { AttachmentSummary, Folder } from '../../api/queries'
 
 const att = (path: string): AttachmentSummary => ({
-  path, mime_type: 'image/png', size_bytes: 1, mtime: 0, updated_at: '',
+  id: `att:${path}`, path, mime_type: 'image/png', size_bytes: 1, mtime: 0, updated_at: '',
 })
 
 describe('synthesizeFolders', () => {

--- a/frontend/src/viewer/tree/synthesize-folders.test.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import { synthesizeFolders } from './synthesize-folders'
 import type { AttachmentSummary, Folder } from '../../api/queries'
 

--- a/frontend/src/viewer/tree/synthesize-folders.test.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { synthesizeFolders } from './synthesize-folders'
+import { isSyntheticFolderId, synthesizeFolders } from './synthesize-folders'
 import type { AttachmentSummary, Folder } from '../../api/queries'
 
 const att = (path: string): AttachmentSummary => ({
@@ -43,5 +43,11 @@ describe('synthesizeFolders', () => {
   it('does not duplicate a synthetic dir shared by two attachments', () => {
     const out = synthesizeFolders([], [att('p/a.png'), att('p/b.png')])
     expect(out.filter((f) => f.name === 'p')).toHaveLength(1)
+  })
+
+  it('isSyntheticFolderId distinguishes synthesized rows from real uuids', () => {
+    const syn = synthesizeFolders([], [att('pics/a.png')]).find((f) => f.name === 'pics')
+    expect(isSyntheticFolderId(syn!.id)).toBe(true)
+    expect(isSyntheticFolderId('a1b2c3d4-0000-0000-0000-000000000000')).toBe(false)
   })
 })

--- a/frontend/src/viewer/tree/synthesize-folders.test.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.test.ts
@@ -1,0 +1,46 @@
+import { synthesizeFolders } from './synthesize-folders'
+import type { AttachmentSummary, Folder } from '../../api/queries'
+
+const att = (path: string): AttachmentSummary => ({
+  path, mime_type: 'image/png', size_bytes: 1, mtime: 0, updated_at: '',
+})
+
+describe('synthesizeFolders', () => {
+  it('returns real folders unchanged when every attachment dir exists', () => {
+    const real: Folder[] = [{ id: 'r1', parent_id: null, name: 'img', count: 2 }]
+    const out = synthesizeFolders(real, [att('img/a.png')])
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ id: 'r1', name: 'img' })
+  })
+
+  it('synthesizes a folder that exists only via an attachment', () => {
+    const out = synthesizeFolders([], [att('pics/a.png')])
+    const pics = out.find((f) => f.name === 'pics')
+    expect(pics).toMatchObject({ id: 'syn:pics', parent_id: null, name: 'pics' })
+  })
+
+  it('synthesizes the full ancestor chain with correct parent ids', () => {
+    const out = synthesizeFolders([], [att('a/b/c.png')])
+    const a = out.find((f) => f.name === 'a')
+    const b = out.find((f) => f.name === 'a/b')
+    expect(a).toMatchObject({ id: 'syn:a', parent_id: null })
+    expect(b).toMatchObject({ id: 'syn:a/b', parent_id: 'syn:a' })
+  })
+
+  it('links a synthetic child under an existing real parent', () => {
+    const real: Folder[] = [{ id: 'r1', parent_id: null, name: 'docs', count: 0 }]
+    const out = synthesizeFolders(real, [att('docs/sub/x.pdf')])
+    const sub = out.find((f) => f.name === 'docs/sub')
+    expect(sub).toMatchObject({ id: 'syn:docs/sub', parent_id: 'r1' })
+  })
+
+  it('root-level attachments add no folders', () => {
+    const out = synthesizeFolders([], [att('cover.png')])
+    expect(out).toHaveLength(0)
+  })
+
+  it('does not duplicate a synthetic dir shared by two attachments', () => {
+    const out = synthesizeFolders([], [att('p/a.png'), att('p/b.png')])
+    expect(out.filter((f) => f.name === 'p')).toHaveLength(1)
+  })
+})

--- a/frontend/src/viewer/tree/synthesize-folders.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.ts
@@ -1,0 +1,41 @@
+import type { AttachmentSummary, Folder } from '../../api/queries'
+
+// Folder dirs that exist only because they hold attachments aren't returned by
+// /api/folders (folders are derived from notes + markers, not attachments).
+// Synthesize them so every attachment is reachable in the tree. Real folders
+// win their id; synthetic rows use `syn:<full-path>` ids and link to their
+// parent (real or synthetic).
+export function synthesizeFolders(
+  real: Folder[],
+  attachments: AttachmentSummary[],
+): Folder[] {
+  const byName = new Map<string, Folder>()
+  for (const f of real) byName.set(f.name, f)
+
+  // Collect every directory prefix from attachment paths.
+  const dirs = new Set<string>()
+  for (const a of attachments) {
+    const slash = a.path.lastIndexOf('/')
+    if (slash < 0) continue // root attachment — no folder needed
+    const dir = a.path.slice(0, slash)
+    const segments = dir.split('/')
+    for (let i = 1; i <= segments.length; i++) dirs.add(segments.slice(0, i).join('/'))
+  }
+
+  // Synthesize missing dirs, shallow-first so parents exist before children.
+  const sorted = [...dirs].sort((x, y) => x.split('/').length - y.split('/').length)
+  for (const name of sorted) {
+    if (byName.has(name)) continue
+    const slash = name.lastIndexOf('/')
+    const parentName = slash < 0 ? null : name.slice(0, slash)
+    const parent = parentName == null ? null : (byName.get(parentName) ?? null)
+    byName.set(name, {
+      id: `syn:${name}`,
+      parent_id: parent ? parent.id : null,
+      name,
+      count: 0,
+    })
+  }
+
+  return [...byName.values()]
+}

--- a/frontend/src/viewer/tree/synthesize-folders.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.ts
@@ -1,5 +1,15 @@
 import type { AttachmentSummary, Folder } from '../../api/queries'
 
+// Synthetic folders (attachment-only dirs not in /api/folders) carry this id
+// prefix. They have no backend record, so id-keyed backend calls (rename, move,
+// delete, note-prefetch) must skip them — `isSyntheticFolderId` is the single
+// home for that check.
+const SYNTHETIC_ID_PREFIX = 'syn:'
+
+export function isSyntheticFolderId(id: string): boolean {
+  return id.startsWith(SYNTHETIC_ID_PREFIX)
+}
+
 // Folder dirs that exist only because they hold attachments aren't returned by
 // /api/folders (folders are derived from notes + markers, not attachments).
 // Synthesize them so every attachment is reachable in the tree. Real folders
@@ -30,7 +40,7 @@ export function synthesizeFolders(
     const parentName = slash < 0 ? null : name.slice(0, slash)
     const parent = parentName == null ? null : (byName.get(parentName) ?? null)
     byName.set(name, {
-      id: `syn:${name}`,
+      id: `${SYNTHETIC_ID_PREFIX}${name}`,
       parent_id: parent ? parent.id : null,
       name,
       count: 0,

--- a/frontend/src/viewer/tree/tree-row.test.tsx
+++ b/frontend/src/viewer/tree/tree-row.test.tsx
@@ -165,6 +165,19 @@ describe('TreeRow', () => {
     expect(onContextMenu).toHaveBeenCalledWith('f:1', 42, 99)
   })
 
+  it('does not invoke onContextMenu on a synthetic (syn:) folder row', () => {
+    const onContextMenu = vi.fn()
+    const synthetic: TreeItem = { kind: 'folder', id: 'syn:pics', path: 'pics', name: 'pics', count: 0 }
+    const instance = mockInstance({ data: synthetic })
+    render(
+      <MemoryRouter>
+        <TreeRow instance={instance} onContextMenu={onContextMenu} />
+      </MemoryRouter>,
+    )
+    fireEvent.contextMenu(screen.getByRole('button'), { clientX: 42, clientY: 99 })
+    expect(onContextMenu).not.toHaveBeenCalled()
+  })
+
   it('invokes onContextMenu with item id + clientX/Y on right-click of a note row', () => {
     const onContextMenu = vi.fn()
     const instance = mockInstance({ data: noteItem })

--- a/frontend/src/viewer/tree/tree-row.test.tsx
+++ b/frontend/src/viewer/tree/tree-row.test.tsx
@@ -9,7 +9,7 @@ import type { LoaderItem } from './loader'
 const folderItem: TreeItem = { kind: 'folder', id: '1', path: 'Projects', name: 'Projects', count: 3 }
 const noteItem: TreeItem = { kind: 'note', id: '100', path: 'Projects/a.md', title: 'a', ext: 'md' }
 const orgNote: TreeItem = { kind: 'note', id: '101', path: 'Projects/b.org', title: 'b', ext: 'org' }
-const attachmentItem: TreeItem = { kind: 'attachment', path: 'img/a.png', mime: 'image/png', size: 10 }
+const attachmentItem: TreeItem = { kind: 'attachment', id: 'att-1', path: 'img/a.png', mime: 'image/png', size: 10 }
 
 interface InstanceOverrides {
   data?: TreeItem
@@ -277,7 +277,7 @@ describe('TreeRow', () => {
     expect(clearData).toHaveBeenCalledWith('text/plain')
   })
 
-  it('renders attachment as link to /attachment/:encoded-path', () => {
+  it('renders attachment as a link to /note/:id (uuid, not path)', () => {
     const instance = mockInstance({ data: attachmentItem })
     render(
       <MemoryRouter>
@@ -285,7 +285,7 @@ describe('TreeRow', () => {
       </MemoryRouter>,
     )
     const link = screen.getByRole('link') as HTMLAnchorElement
-    expect(link.getAttribute('href')).toBe('/attachment/img/a.png')
+    expect(link.getAttribute('href')).toBe('/note/att-1')
     expect(screen.getByText('a.png')).toBeInTheDocument()
   })
 

--- a/frontend/src/viewer/tree/tree-row.test.tsx
+++ b/frontend/src/viewer/tree/tree-row.test.tsx
@@ -271,8 +271,7 @@ describe('TreeRow', () => {
         <TreeRow instance={instance} />
       </MemoryRouter>,
     )
-    const badge = screen.getByText('png')
+    const badge = screen.getByText('PNG')
     expect(badge).toBeInTheDocument()
-    expect(badge.className).toMatch(/uppercase/)
   })
 })

--- a/frontend/src/viewer/tree/tree-row.test.tsx
+++ b/frontend/src/viewer/tree/tree-row.test.tsx
@@ -178,6 +178,18 @@ describe('TreeRow', () => {
     expect(onContextMenu).not.toHaveBeenCalled()
   })
 
+  it('does not invoke onContextMenu on an attachment row (display-only in Phase 1)', () => {
+    const onContextMenu = vi.fn()
+    const instance = mockInstance({ data: attachmentItem })
+    render(
+      <MemoryRouter>
+        <TreeRow instance={instance} onContextMenu={onContextMenu} />
+      </MemoryRouter>,
+    )
+    fireEvent.contextMenu(screen.getByRole('link'), { clientX: 42, clientY: 99 })
+    expect(onContextMenu).not.toHaveBeenCalled()
+  })
+
   it('invokes onContextMenu with item id + clientX/Y on right-click of a note row', () => {
     const onContextMenu = vi.fn()
     const instance = mockInstance({ data: noteItem })

--- a/frontend/src/viewer/tree/tree-row.test.tsx
+++ b/frontend/src/viewer/tree/tree-row.test.tsx
@@ -9,6 +9,7 @@ import type { LoaderItem } from './loader'
 const folderItem: TreeItem = { kind: 'folder', id: '1', path: 'Projects', name: 'Projects', count: 3 }
 const noteItem: TreeItem = { kind: 'note', id: '100', path: 'Projects/a.md', title: 'a', ext: 'md' }
 const orgNote: TreeItem = { kind: 'note', id: '101', path: 'Projects/b.org', title: 'b', ext: 'org' }
+const attachmentItem: TreeItem = { kind: 'attachment', path: 'img/a.png', mime: 'image/png', size: 10 }
 
 interface InstanceOverrides {
   data?: TreeItem
@@ -25,8 +26,14 @@ interface InstanceOverrides {
 
 function mockInstance(overrides: InstanceOverrides = {}) {
   const data = overrides.data ?? folderItem
+  const itemIdStr =
+    data.kind === 'folder'
+      ? `f:${data.id}`
+      : data.kind === 'note'
+        ? `n:${data.id}`
+        : `a:${data.path.split('/').map(encodeURIComponent).join('/')}`
   const loaderItem: LoaderItem = {
-    itemId: `${data.kind === 'folder' ? 'f' : 'n'}:${data.id}`,
+    itemId: itemIdStr,
     item: data,
     isFolder: data.kind === 'folder',
   }
@@ -243,5 +250,29 @@ describe('TreeRow', () => {
     // The <a href> link payload Chrome uses for split-view must be cleared.
     expect(clearData).toHaveBeenCalledWith('text/uri-list')
     expect(clearData).toHaveBeenCalledWith('text/plain')
+  })
+
+  it('renders attachment as link to /attachment/:encoded-path', () => {
+    const instance = mockInstance({ data: attachmentItem })
+    render(
+      <MemoryRouter>
+        <TreeRow instance={instance} />
+      </MemoryRouter>,
+    )
+    const link = screen.getByRole('link') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('/attachment/img/a.png')
+    expect(screen.getByText('a.png')).toBeInTheDocument()
+  })
+
+  it('shows uppercase ext badge for attachment', () => {
+    const instance = mockInstance({ data: attachmentItem })
+    render(
+      <MemoryRouter>
+        <TreeRow instance={instance} />
+      </MemoryRouter>,
+    )
+    const badge = screen.getByText('png')
+    expect(badge).toBeInTheDocument()
+    expect(badge.className).toMatch(/uppercase/)
   })
 })

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -62,15 +62,19 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
   }
 
   if (item.kind === 'folder') {
-    const hoverPrefetch = onFolderHover
-      ? () => onFolderHover(item.id)
-      : undefined
+    // Synthetic folders (id prefix 'syn:') are UI-only scaffolding for
+    // attachment-only dirs — they have no backend record, so rename/delete/move
+    // and note-prefetch don't apply. Drop their action affordances; expansion
+    // (to reveal the attachments inside) still works.
+    const isSynthetic = item.id.startsWith('syn:')
+    const hoverPrefetch =
+      onFolderHover && !isSynthetic ? () => onFolderHover(item.id) : undefined
     return (
       <button
         type="button"
         {...instance.getProps()}
-        {...longPressProps}
-        onContextMenu={contextMenuHandler}
+        {...(isSynthetic ? {} : longPressProps)}
+        onContextMenu={isSynthetic ? undefined : contextMenuHandler}
         onPointerEnter={hoverPrefetch}
         onFocus={hoverPrefetch}
         aria-expanded={instance.isExpanded()}

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -6,6 +6,7 @@ import type { LoaderItem } from './loader'
 import type { TreeItem } from './types'
 import { RenameInput } from '../tree-actions/rename-input'
 import { useLongPress } from '../tree-actions/use-long-press'
+import { isSyntheticFolderId } from './synthesize-folders'
 
 interface Props {
   instance: ItemInstance<LoaderItem>
@@ -62,11 +63,11 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
   }
 
   if (item.kind === 'folder') {
-    // Synthetic folders (id prefix 'syn:') are UI-only scaffolding for
-    // attachment-only dirs — they have no backend record, so rename/delete/move
-    // and note-prefetch don't apply. Drop their action affordances; expansion
-    // (to reveal the attachments inside) still works.
-    const isSynthetic = item.id.startsWith('syn:')
+    // Synthetic folders are UI-only scaffolding for attachment-only dirs — they
+    // have no backend record, so rename/delete/move and note-prefetch don't
+    // apply. Drop their action affordances; expansion (to reveal the
+    // attachments inside) still works.
+    const isSynthetic = isSyntheticFolderId(item.id)
     const hoverPrefetch =
       onFolderHover && !isSynthetic ? () => onFolderHover(item.id) : undefined
     return (

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -108,7 +108,7 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
         <Icon aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
         <span className="min-w-0 flex-1 truncate">{filename}</span>
         {ext && (
-          <span className="shrink-0 text-xs uppercase text-gray-400 dark:text-gray-500">{ext}</span>
+          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">{ext.toUpperCase()}</span>
         )}
       </Link>
     )

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -93,7 +93,6 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
     const filename = item.path.split('/').pop() ?? item.path
     const dot = filename.lastIndexOf('.')
     const ext = dot > 0 ? filename.slice(dot + 1).toLowerCase() : null
-    const encoded = item.path.split('/').map(encodeURIComponent).join('/')
     const Icon = item.mime.startsWith('image/')
       ? Image
       : item.mime === 'application/pdf'
@@ -102,9 +101,12 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
     // Phase 1 is display + preview only: attachments wire no context menu /
     // long-press, so the file action menu (rename/move/delete) — all no-ops for
     // an attachment — never surfaces. Pure navigation.
+    // Routed by uuid under the unified /note/:id (VaultItemPage resolves
+    // note-vs-file) so the URL survives a rename/move. The HT itemId stays
+    // path-keyed (internal tree machinery).
     return (
       <Link
-        to={`/attachment/${encoded}`}
+        to={`/note/${item.id}`}
         {...instance.getProps()}
         aria-selected={instance.isSelected()}
         className={rowClass(instance)}

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, File, FileText, Image } from 'lucide-react'
 import { Link } from 'react-router'
 import type { ItemInstance } from '@headless-tree/core'
 import type { LoaderItem } from './loader'
@@ -82,6 +82,35 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
         <Chevron open={instance.isExpanded()} />
         <span className="min-w-0 flex-1 truncate">{item.name}</span>
       </button>
+    )
+  }
+
+  if (item.kind === 'attachment') {
+    const filename = item.path.split('/').pop() ?? item.path
+    const dot = filename.lastIndexOf('.')
+    const ext = dot > 0 ? filename.slice(dot + 1).toLowerCase() : null
+    const encoded = item.path.split('/').map(encodeURIComponent).join('/')
+    const Icon = item.mime.startsWith('image/')
+      ? Image
+      : item.mime === 'application/pdf'
+        ? FileText
+        : File
+    return (
+      <Link
+        to={`/attachment/${encoded}`}
+        {...instance.getProps()}
+        onContextMenu={contextMenuHandler}
+        aria-selected={instance.isSelected()}
+        className={rowClass(instance)}
+        style={{ paddingLeft: `${notePad}px` }}
+      >
+        <IndentGuides depth={depth} />
+        <Icon aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
+        <span className="min-w-0 flex-1 truncate">{filename}</span>
+        {ext && (
+          <span className="shrink-0 text-xs uppercase text-gray-400 dark:text-gray-500">{ext}</span>
+        )}
+      </Link>
     )
   }
 

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -99,11 +99,13 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
       : item.mime === 'application/pdf'
         ? FileText
         : File
+    // Phase 1 is display + preview only: attachments wire no context menu /
+    // long-press, so the file action menu (rename/move/delete) — all no-ops for
+    // an attachment — never surfaces. Pure navigation.
     return (
       <Link
         to={`/attachment/${encoded}`}
         {...instance.getProps()}
-        onContextMenu={contextMenuHandler}
         aria-selected={instance.isSelected()}
         className={rowClass(instance)}
         style={{ paddingLeft: `${notePad}px` }}

--- a/frontend/src/viewer/tree/types.test.ts
+++ b/frontend/src/viewer/tree/types.test.ts
@@ -18,3 +18,23 @@ describe('item id helpers', () => {
     expect(parseItemId(ROOT_ID)).toEqual({ kind: 'root' })
   })
 })
+
+describe('attachment item ids', () => {
+  it('round-trips a simple attachment path', () => {
+    const id = formatItemId({ kind: 'attachment', path: 'img/a.png' })
+    expect(id).toBe('a:img/a.png')
+    expect(parseItemId(id)).toEqual({ kind: 'attachment', path: 'img/a.png' })
+  })
+
+  it('round-trips a path with spaces and unicode', () => {
+    const path = 'My Files/diagram (final).pdf'
+    const id = formatItemId({ kind: 'attachment', path })
+    expect(parseItemId(id)).toEqual({ kind: 'attachment', path })
+  })
+
+  it('keeps slashes as path separators, not encoded', () => {
+    const id = formatItemId({ kind: 'attachment', path: 'a/b/c.png' })
+    expect(id.startsWith('a:')).toBe(true)
+    expect(parseItemId(id)).toEqual({ kind: 'attachment', path: 'a/b/c.png' })
+  })
+})

--- a/frontend/src/viewer/tree/types.ts
+++ b/frontend/src/viewer/tree/types.ts
@@ -1,18 +1,28 @@
 export type TreeItem =
   | { kind: 'folder'; id: string; path: string; name: string; count: number }
   | { kind: 'note'; id: string; path: string; title: string; ext: string | null }
+  | { kind: 'attachment'; id: string; path: string; mime: string; size: number }
 
 export type ItemId = string
 
 export const ROOT_ID: ItemId = 'root'
 
-export function formatItemId(input: { kind: 'folder' | 'note'; id: string }): ItemId {
+export function formatItemId(
+  input:
+    | { kind: 'folder' | 'note'; id: string }
+    | { kind: 'attachment'; path: string },
+): ItemId {
+  if (input.kind === 'attachment') {
+    const encoded = input.path.split('/').map(encodeURIComponent).join('/')
+    return `a:${encoded}`
+  }
   return `${input.kind === 'folder' ? 'f' : 'n'}:${input.id}`
 }
 
 export type ParsedItemId =
   | { kind: 'folder'; id: string }
   | { kind: 'note'; id: string }
+  | { kind: 'attachment'; path: string }
   | { kind: 'root' }
 
 export function parseItemId(id: ItemId): ParsedItemId {
@@ -26,5 +36,9 @@ export function parseItemId(id: ItemId): ParsedItemId {
   if (rest.length === 0) throw new Error(`Unknown tree item id: ${id}`)
   if (prefix === 'f') return { kind: 'folder', id: rest }
   if (prefix === 'n') return { kind: 'note', id: rest }
+  if (prefix === 'a') {
+    const path = rest.split('/').map(decodeURIComponent).join('/')
+    return { kind: 'attachment', path }
+  }
   throw new Error(`Unknown tree item id: ${id}`)
 }

--- a/frontend/src/viewer/tree/types.ts
+++ b/frontend/src/viewer/tree/types.ts
@@ -1,7 +1,7 @@
 export type TreeItem =
   | { kind: 'folder'; id: string; path: string; name: string; count: number }
   | { kind: 'note'; id: string; path: string; title: string; ext: string | null }
-  | { kind: 'attachment'; id: string; path: string; mime: string; size: number }
+  | { kind: 'attachment'; path: string; mime: string; size: number }
 
 export type ItemId = string
 

--- a/frontend/src/viewer/tree/types.ts
+++ b/frontend/src/viewer/tree/types.ts
@@ -1,7 +1,7 @@
 export type TreeItem =
   | { kind: 'folder'; id: string; path: string; name: string; count: number }
   | { kind: 'note'; id: string; path: string; title: string; ext: string | null }
-  | { kind: 'attachment'; path: string; mime: string; size: number }
+  | { kind: 'attachment'; id: string; path: string; mime: string; size: number }
 
 export type ItemId = string
 

--- a/frontend/src/viewer/tree/use-engram-tree.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.ts
@@ -134,7 +134,9 @@ export function useEngramTree(deps: Deps) {
       const d = item.getItemData()
       if (!d) return ''
       const t = d.item
-      return t.kind === 'folder' ? t.name : t.title
+      if (t.kind === 'folder') return t.name
+      if (t.kind === 'attachment') return t.path.split('/').pop() ?? t.path
+      return t.title
     },
     isItemFolder: (item: ItemInstance<Data>) => {
       const d = item.getItemData()

--- a/frontend/src/viewer/tree/use-engram-tree.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.ts
@@ -16,10 +16,11 @@ import type { QueryClient } from '@tanstack/react-query'
 import { buildLoader, type SortKey, type LoaderItem } from './loader'
 import { ROOT_ID } from './types'
 import { resolveDropMove } from './drop-redirect'
-import { ROOT_FOLDER_ID, type Folder, type NoteSummary } from '../../api/queries'
+import { ROOT_FOLDER_ID, type Folder, type NoteSummary, type AttachmentSummary } from '../../api/queries'
 
 interface Deps {
   folders: Folder[]
+  attachments?: AttachmentSummary[]
   qc: QueryClient
   vaultId: string
   sort: SortKey
@@ -53,6 +54,15 @@ export function treeStructureKey(
   return `${folderKey}::${sort}`
 }
 
+function attachmentsFingerprint(attachments?: AttachmentSummary[]): string {
+  if (!attachments || attachments.length === 0) return '0'
+  // length + max(updated_at) is enough: the list is static per fetch, and any
+  // add/remove changes one of the two.
+  let max = ''
+  for (const a of attachments) if (a.updated_at > max) max = a.updated_at
+  return `${attachments.length}:${max}`
+}
+
 export function useEngramTree(deps: Deps) {
   const treeRef = useRef<ReturnType<typeof useTree<Data>> | null>(null)
   const inner = useMemo(
@@ -61,6 +71,7 @@ export function useEngramTree(deps: Deps) {
       qc: deps.qc,
       vaultId: deps.vaultId,
       sort: deps.sort,
+      attachments: deps.attachments,
       fetchFolderNotes: deps.fetchFolderNotes,
       onChildrenLoaded: (folderId) => {
         const t = treeRef.current
@@ -72,7 +83,7 @@ export function useEngramTree(deps: Deps) {
         inst?.invalidateChildrenIds()
       },
     }),
-    [deps.folders, deps.qc, deps.vaultId, deps.sort, deps.fetchFolderNotes],
+    [deps.folders, deps.qc, deps.vaultId, deps.sort, deps.attachments, deps.fetchFolderNotes],
   )
 
   // Bridge our LoaderItem-returning loader to HT's TreeDataLoader<T> shape
@@ -168,7 +179,8 @@ export function useEngramTree(deps: Deps) {
   // data shape changes — keyed on stable structural fingerprints so we never
   // re-trigger from spurious identity churn (rebuildTree → setState → render
   // would otherwise spin into a max-update-depth loop).
-  const structureKey = treeStructureKey(deps.folders, deps.sort)
+  const structureKey =
+    treeStructureKey(deps.folders, deps.sort) + '#' + attachmentsFingerprint(deps.attachments)
   const lastKey = useRef('')
   useEffect(() => {
     if (lastKey.current === structureKey) return

--- a/frontend/src/viewer/vault-item-page.test.tsx
+++ b/frontend/src/viewer/vault-item-page.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { expect, it, vi } from 'vitest'
+import type { AttachmentSummary } from '../api/queries'
+
+// Stub both heavy viewers — this suite only verifies the note-vs-attachment
+// routing decision, not their rendering.
+vi.mock('./note-page', () => ({ default: () => <div data-testid="note-page" /> }))
+vi.mock('./attachment-page', () => ({ default: () => <div data-testid="attachment-page" /> }))
+
+let mockAttachments: AttachmentSummary[] = []
+vi.mock('../api/queries', () => ({
+  useAttachments: () => ({ data: mockAttachments, isLoading: false }),
+}))
+
+import VaultItemPage from './vault-item-page'
+
+const att = (id: string): AttachmentSummary => ({
+  id,
+  path: `${id}.png`,
+  mime_type: 'image/png',
+  size_bytes: 1,
+  mtime: 0,
+  updated_at: '',
+})
+
+async function renderAt(id: string) {
+  render(
+    <MemoryRouter initialEntries={[`/note/${id}`]}>
+      <Routes>
+        <Route path="/note/:id" element={<VaultItemPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+  // Let the lazy child resolve.
+  await screen.findByTestId(/page$/)
+}
+
+it('renders the attachment viewer when the id is in the attachments list', async () => {
+  mockAttachments = [att('file-1')]
+  await renderAt('file-1')
+  expect(screen.getByTestId('attachment-page')).toBeInTheDocument()
+  expect(screen.queryByTestId('note-page')).not.toBeInTheDocument()
+})
+
+it('renders the note viewer when the id is not an attachment', async () => {
+  mockAttachments = [att('file-1')]
+  await renderAt('note-99')
+  expect(screen.getByTestId('note-page')).toBeInTheDocument()
+  expect(screen.queryByTestId('attachment-page')).not.toBeInTheDocument()
+})

--- a/frontend/src/viewer/vault-item-page.test.tsx
+++ b/frontend/src/viewer/vault-item-page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
-import { expect, it, vi } from 'vitest'
+import { beforeEach, expect, it, vi } from 'vitest'
 import type { AttachmentSummary } from '../api/queries'
 
 // Stub both heavy viewers — this suite only verifies the note-vs-attachment
@@ -8,9 +8,10 @@ import type { AttachmentSummary } from '../api/queries'
 vi.mock('./note-page', () => ({ default: () => <div data-testid="note-page" /> }))
 vi.mock('./attachment-page', () => ({ default: () => <div data-testid="attachment-page" /> }))
 
-let mockAttachments: AttachmentSummary[] = []
+let mockAttachments: AttachmentSummary[] | undefined = []
+let mockLoading = false
 vi.mock('../api/queries', () => ({
-  useAttachments: () => ({ data: mockAttachments, isLoading: false }),
+  useAttachments: () => ({ data: mockAttachments, isLoading: mockLoading }),
 }))
 
 import VaultItemPage from './vault-item-page'
@@ -24,28 +25,48 @@ const att = (id: string): AttachmentSummary => ({
   updated_at: '',
 })
 
-async function renderAt(id: string) {
-  render(
+beforeEach(() => {
+  mockAttachments = []
+  mockLoading = false
+})
+
+function renderAt(id: string) {
+  return render(
     <MemoryRouter initialEntries={[`/note/${id}`]}>
       <Routes>
         <Route path="/note/:id" element={<VaultItemPage />} />
       </Routes>
     </MemoryRouter>,
   )
+}
+
+async function renderAndAwaitChild(id: string) {
+  renderAt(id)
   // Let the lazy child resolve.
   await screen.findByTestId(/page$/)
 }
 
 it('renders the attachment viewer when the id is in the attachments list', async () => {
   mockAttachments = [att('file-1')]
-  await renderAt('file-1')
+  await renderAndAwaitChild('file-1')
   expect(screen.getByTestId('attachment-page')).toBeInTheDocument()
   expect(screen.queryByTestId('note-page')).not.toBeInTheDocument()
 })
 
 it('renders the note viewer when the id is not an attachment', async () => {
   mockAttachments = [att('file-1')]
-  await renderAt('note-99')
+  await renderAndAwaitChild('note-99')
   expect(screen.getByTestId('note-page')).toBeInTheDocument()
+  expect(screen.queryByTestId('attachment-page')).not.toBeInTheDocument()
+})
+
+it('waits (no NotePage) while the attachments list is still loading on a cold deep-link', () => {
+  // The race the resolver exists to handle: list not yet loaded. Must NOT mount
+  // NotePage (which would fire a doomed note fetch for an attachment id).
+  mockAttachments = undefined
+  mockLoading = true
+  renderAt('unknown-id')
+  expect(screen.getByRole('status')).toBeInTheDocument()
+  expect(screen.queryByTestId('note-page')).not.toBeInTheDocument()
   expect(screen.queryByTestId('attachment-page')).not.toBeInTheDocument()
 })

--- a/frontend/src/viewer/vault-item-page.tsx
+++ b/frontend/src/viewer/vault-item-page.tsx
@@ -16,7 +16,19 @@ const AttachmentPage = lazy(() => import('./attachment-page'))
 // then re-resolves (the common case — a note — is never delayed).
 export default function VaultItemPage() {
   const { id } = useParams()
-  const { data: attachments } = useAttachments()
+  const { data: attachments, isLoading } = useAttachments()
+
+  // Until the attachments list has loaded we can't tell a note id from an
+  // attachment id, so wait — don't guess "note" and mount NotePage, which would
+  // fire a doomed GET /notes/:id for an attachment id and flash a 404 error on a
+  // valid attachment deep-link. The list is warm from the sidebar on in-app nav,
+  // so this only briefly gates a cold deep-link / hard refresh. (If the list
+  // outright failed, `attachments` is undefined → we fall through to NotePage,
+  // the common case — an accepted degradation since a failed list already breaks
+  // the sidebar.)
+  if (isLoading && !attachments) {
+    return <LoadingPane />
+  }
   const isAttachment = attachments?.some((a) => a.id === id) ?? false
 
   return (

--- a/frontend/src/viewer/vault-item-page.tsx
+++ b/frontend/src/viewer/vault-item-page.tsx
@@ -1,0 +1,26 @@
+import { lazy, Suspense } from 'react'
+import { useParams } from 'react-router'
+import { useAttachments } from '../api/queries'
+
+// Both viewers are heavy (NotePage pulls remark/CodeMirror; AttachmentPage pulls
+// pdf.js on demand) — load whichever the route resolves to.
+const NotePage = lazy(() => import('./note-page'))
+const AttachmentPage = lazy(() => import('./attachment-page'))
+
+// Resolver behind the unified /note/:id route. Notes and attachments share one
+// URL shape (like Obsidian, where everything is a vault item) — decide which
+// viewer to mount by checking the loaded attachments list. The tree sidebar
+// keeps that list warm, so in-app navigation resolves instantly; a cold
+// deep-link to an attachment briefly renders NotePage until the list lands,
+// then re-resolves (the common case — a note — is never delayed).
+export default function VaultItemPage() {
+  const { id } = useParams()
+  const { data: attachments } = useAttachments()
+  const isAttachment = attachments?.some((a) => a.id === id) ?? false
+
+  return (
+    <Suspense fallback={<p className="p-6 text-sm text-muted-foreground">Loading…</p>}>
+      {isAttachment ? <AttachmentPage /> : <NotePage />}
+    </Suspense>
+  )
+}

--- a/frontend/src/viewer/vault-item-page.tsx
+++ b/frontend/src/viewer/vault-item-page.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react'
 import { useParams } from 'react-router'
 import { useAttachments } from '../api/queries'
+import LoadingPane from './loading-pane'
 
 // Both viewers are heavy (NotePage pulls remark/CodeMirror; AttachmentPage pulls
 // pdf.js on demand) — load whichever the route resolves to.
@@ -19,7 +20,7 @@ export default function VaultItemPage() {
   const isAttachment = attachments?.some((a) => a.id === id) ?? false
 
   return (
-    <Suspense fallback={<p className="p-6 text-sm text-muted-foreground">Loading…</p>}>
+    <Suspense fallback={<LoadingPane />}>
       {isAttachment ? <AttachmentPage /> : <NotePage />}
     </Suspense>
   )

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -298,11 +298,8 @@ defmodule Engram.Attachments do
     |> case do
       {:ok, atts} ->
         {:ok,
-         Enum.map(atts, fn att ->
-           att
-           |> decrypt_metadata(user)
-           |> Map.delete(:deleted_at)
-           |> Map.put(:id, att.id)
+         decrypt_each(atts, user, fn att, meta ->
+           meta |> Map.delete(:deleted_at) |> Map.put(:id, att.id)
          end)}
 
       err ->
@@ -328,7 +325,7 @@ defmodule Engram.Attachments do
     |> unwrap_tenant()
     |> case do
       {:ok, atts} ->
-        {:ok, Enum.map(atts, &decrypt_metadata(&1, user))}
+        {:ok, decrypt_each(atts, user, fn _att, meta -> meta end)}
 
       err ->
         err
@@ -485,17 +482,47 @@ defmodule Engram.Attachments do
     end
   end
 
+  # Returns {:ok, metadata} or {:error, reason}. Callers SKIP + log on error so a
+  # single undecryptable ("poison") row — e.g. AAD mismatch after a botched DEK
+  # rotation — doesn't crash the whole list and blank every attachment in the
+  # vault.
   defp decrypt_metadata(att, user) do
-    {:ok, decrypted} = Crypto.maybe_decrypt_attachment_fields(att, user)
+    case Crypto.maybe_decrypt_attachment_fields(att, user) do
+      {:ok, decrypted} ->
+        {:ok,
+         %{
+           path: decrypted.path,
+           mime_type: decrypted.mime_type,
+           size_bytes: decrypted.size_bytes,
+           mtime: decrypted.mtime,
+           updated_at: decrypted.updated_at,
+           deleted_at: decrypted.deleted_at
+         }}
 
-    %{
-      path: decrypted.path,
-      mime_type: decrypted.mime_type,
-      size_bytes: decrypted.size_bytes,
-      mtime: decrypted.mtime,
-      updated_at: decrypted.updated_at,
-      deleted_at: decrypted.deleted_at
-    }
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Decrypts each row, skipping (and logging) any that fail. `extra.(att, meta)`
+  # post-processes a successful metadata map (e.g. drop :deleted_at, add :id).
+  defp decrypt_each(atts, user, extra) do
+    Enum.flat_map(atts, fn att ->
+      case decrypt_metadata(att, user) do
+        {:ok, meta} ->
+          [extra.(att, meta)]
+
+        {:error, reason} ->
+          require Logger
+
+          Logger.error("Skipping undecryptable attachment",
+            attachment_id: att.id,
+            reason: inspect(reason)
+          )
+
+          []
+      end
+    end)
   end
 
   defp unwrap_tenant({:ok, {:ok, result}}), do: {:ok, result}

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -282,6 +282,29 @@ defmodule Engram.Attachments do
   end
 
   @doc """
+  Lists non-deleted attachment metadata for a vault (no content).
+  """
+  def list_attachments(user, vault) do
+    user = fresh_user(user)
+
+    Repo.with_tenant(user.id, fn ->
+      from(a in Attachment,
+        where: a.user_id == ^user.id and a.vault_id == ^vault.id and is_nil(a.deleted_at),
+        order_by: [asc: a.updated_at]
+      )
+      |> Repo.all()
+    end)
+    |> unwrap_tenant()
+    |> case do
+      {:ok, atts} ->
+        {:ok, Enum.map(atts, fn att -> Map.delete(decrypt_metadata(att, user), :deleted_at) end)}
+
+      err ->
+        err
+    end
+  end
+
+  @doc """
   Lists attachment changes since a given timestamp. Returns metadata only (no content).
   """
   def list_changes(user, vault, since) do
@@ -299,21 +322,7 @@ defmodule Engram.Attachments do
     |> unwrap_tenant()
     |> case do
       {:ok, atts} ->
-        changes =
-          Enum.map(atts, fn att ->
-            {:ok, decrypted} = Crypto.maybe_decrypt_attachment_fields(att, user)
-
-            %{
-              path: decrypted.path,
-              mime_type: decrypted.mime_type,
-              size_bytes: decrypted.size_bytes,
-              mtime: decrypted.mtime,
-              updated_at: decrypted.updated_at,
-              deleted_at: decrypted.deleted_at
-            }
-          end)
-
-        {:ok, changes}
+        {:ok, Enum.map(atts, &decrypt_metadata(&1, user))}
 
       err ->
         err
@@ -468,6 +477,19 @@ defmodule Engram.Attachments do
       {:ok, binary} -> {:ok, binary}
       :error -> {:error, :invalid_base64}
     end
+  end
+
+  defp decrypt_metadata(att, user) do
+    {:ok, decrypted} = Crypto.maybe_decrypt_attachment_fields(att, user)
+
+    %{
+      path: decrypted.path,
+      mime_type: decrypted.mime_type,
+      size_bytes: decrypted.size_bytes,
+      mtime: decrypted.mtime,
+      updated_at: decrypted.updated_at,
+      deleted_at: decrypted.deleted_at
+    }
   end
 
   defp unwrap_tenant({:ok, {:ok, result}}), do: {:ok, result}

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -297,7 +297,13 @@ defmodule Engram.Attachments do
     |> unwrap_tenant()
     |> case do
       {:ok, atts} ->
-        {:ok, Enum.map(atts, fn att -> Map.delete(decrypt_metadata(att, user), :deleted_at) end)}
+        {:ok,
+         Enum.map(atts, fn att ->
+           att
+           |> decrypt_metadata(user)
+           |> Map.delete(:deleted_at)
+           |> Map.put(:id, att.id)
+         end)}
 
       err ->
         err

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -113,21 +113,29 @@ defmodule EngramWeb.AttachmentsController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    {:ok, atts} = Attachments.list_attachments(user, vault)
+    # The whole tree sidebar depends on this; handle a list failure explicitly
+    # (logged 500 body) instead of a bare-match MatchError stacktrace.
+    case Attachments.list_attachments(user, vault) do
+      {:ok, atts} ->
+        json(conn, %{
+          attachments:
+            Enum.map(atts, fn a ->
+              %{
+                id: a.id,
+                path: a.path,
+                mime_type: a.mime_type,
+                size_bytes: a.size_bytes,
+                mtime: a.mtime,
+                updated_at: a.updated_at
+              }
+            end)
+        })
 
-    json(conn, %{
-      attachments:
-        Enum.map(atts, fn a ->
-          %{
-            id: a.id,
-            path: a.path,
-            mime_type: a.mime_type,
-            size_bytes: a.size_bytes,
-            mtime: a.mtime,
-            updated_at: a.updated_at
-          }
-        end)
-    })
+      {:error, reason} ->
+        require Logger
+        Logger.error("Failed to list attachments", vault_id: vault.id, reason: inspect(reason))
+        conn |> put_status(500) |> json(%{error: "failed to list attachments"})
+    end
   end
 
   def show(conn, %{"path" => path_parts} = params) do
@@ -142,19 +150,19 @@ defmodule EngramWeb.AttachmentsController do
       {:ok, att} ->
         if params["raw"] == "1" do
           # Raw bytes are served from the API origin. nosniff (set on the :api
-          # pipeline) stops content-type confusion, but a declared text/html or
-          # image/svg+xml still renders inline — and SVG can carry script — if a
-          # user navigates straight to the raw URL. Force those to download;
-          # everything else (images, PDF) may render inline for preview.
-          disposition =
-            if att.mime_type in ["text/html", "image/svg+xml"], do: "attachment", else: "inline"
+          # pipeline) stops content-type confusion, but a declared inline type
+          # still renders in the browser — and HTML/SVG/XML can execute script
+          # (SVG <script>, XML via xml-stylesheet/XSLT). The MIME whitelist admits
+          # the whole `text/` prefix, so an allowlist of types known-safe to
+          # render inline is the correct gate; everything else force-downloads.
+          disposition = if inline_safe?(att.mime_type), do: "inline", else: "attachment"
+          # Strip control chars/quotes so a crafted filename can't break the
+          # header (Plug rejects control chars → 500 otherwise).
+          filename = String.replace(Path.basename(att.path), ~r/[[:cntrl:]"]/u, "")
 
           conn
           |> put_resp_content_type(att.mime_type || "application/octet-stream")
-          |> put_resp_header(
-            "content-disposition",
-            ~s(#{disposition}; filename="#{Path.basename(att.path)}")
-          )
+          |> put_resp_header("content-disposition", ~s(#{disposition}; filename="#{filename}"))
           |> send_resp(200, att.content)
         else
           json(conn, %{
@@ -219,6 +227,17 @@ defmodule EngramWeb.AttachmentsController do
   end
 
   defp format_errors(changeset), do: EngramWeb.format_errors(changeset)
+
+  # Types safe to render inline in the browser on the API origin. Raster images
+  # and PDFs are inert; SVG (script via <script>) and HTML/XML (script via
+  # markup or XSLT) are NOT — they force-download. Everything not on this list
+  # downloads by default.
+  defp inline_safe?(nil), do: false
+  defp inline_safe?("image/svg+xml"), do: false
+
+  defp inline_safe?(mime) when is_binary(mime) do
+    String.starts_with?(mime, "image/") or mime == "application/pdf" or mime == "text/plain"
+  end
 
   defp serialize_metadata(att) do
     %{

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -129,7 +129,7 @@ defmodule EngramWeb.AttachmentsController do
     })
   end
 
-  def show(conn, %{"path" => path_parts}) do
+  def show(conn, %{"path" => path_parts} = params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
     path = Path.join(path_parts)
@@ -139,16 +139,22 @@ defmodule EngramWeb.AttachmentsController do
         conn |> put_status(404) |> json(%{error: "attachment not found"})
 
       {:ok, att} ->
-        json(conn, %{
-          id: att.id,
-          path: att.path,
-          mime_type: att.mime_type,
-          size_bytes: att.size_bytes,
-          mtime: att.mtime,
-          content_base64: Base.encode64(att.content),
-          created_at: att.created_at,
-          updated_at: att.updated_at
-        })
+        if params["raw"] == "1" do
+          conn
+          |> put_resp_content_type(att.mime_type || "application/octet-stream")
+          |> send_resp(200, att.content)
+        else
+          json(conn, %{
+            id: att.id,
+            path: att.path,
+            mime_type: att.mime_type,
+            size_bytes: att.size_bytes,
+            mtime: att.mtime,
+            content_base64: Base.encode64(att.content),
+            created_at: att.created_at,
+            updated_at: att.updated_at
+          })
+        end
 
       {:error, {:storage, _reason}} ->
         conn |> put_status(502) |> json(%{error: "failed to fetch attachment from storage"})

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -109,6 +109,26 @@ defmodule EngramWeb.AttachmentsController do
     end
   end
 
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    {:ok, atts} = Attachments.list_attachments(user, vault)
+
+    json(conn, %{
+      attachments:
+        Enum.map(atts, fn a ->
+          %{
+            path: a.path,
+            mime_type: a.mime_type,
+            size_bytes: a.size_bytes,
+            mtime: a.mtime,
+            updated_at: a.updated_at
+          }
+        end)
+    })
+  end
+
   def show(conn, %{"path" => path_parts}) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -119,6 +119,7 @@ defmodule EngramWeb.AttachmentsController do
       attachments:
         Enum.map(atts, fn a ->
           %{
+            id: a.id,
             path: a.path,
             mime_type: a.mime_type,
             size_bytes: a.size_bytes,

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -140,8 +140,20 @@ defmodule EngramWeb.AttachmentsController do
 
       {:ok, att} ->
         if params["raw"] == "1" do
+          # Raw bytes are served from the API origin. nosniff (set on the :api
+          # pipeline) stops content-type confusion, but a declared text/html or
+          # image/svg+xml still renders inline — and SVG can carry script — if a
+          # user navigates straight to the raw URL. Force those to download;
+          # everything else (images, PDF) may render inline for preview.
+          disposition =
+            if att.mime_type in ["text/html", "image/svg+xml"], do: "attachment", else: "inline"
+
           conn
           |> put_resp_content_type(att.mime_type || "application/octet-stream")
+          |> put_resp_header(
+            "content-disposition",
+            ~s(#{disposition}; filename="#{Path.basename(att.path)}")
+          )
           |> send_resp(200, att.content)
         else
           json(conn, %{

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -353,6 +353,7 @@ defmodule EngramWeb.Router do
 
     # Attachments
     post "/attachments", AttachmentsController, :upload
+    get "/attachments", AttachmentsController, :index
     get "/attachments/changes", AttachmentsController, :changes
     get "/attachments/*path", AttachmentsController, :show
     delete "/attachments/*path", AttachmentsController, :delete

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.444",
+      version: "0.5.445",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -331,6 +331,41 @@ defmodule Engram.AttachmentsTest do
       {:ok, list} = Attachments.list_attachments(user, vault)
       refute Enum.any?(list, &(&1.path == "secret.png"))
     end
+
+    test "skips an undecryptable row instead of crashing the whole list",
+         %{user: user, vault: vault} do
+      {:ok, _good} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "good.png",
+          "content_base64" => Base.encode64("X"),
+          "mime_type" => "image/png"
+        })
+
+      {:ok, bad} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "bad.png",
+          "content_base64" => Base.encode64("Y"),
+          "mime_type" => "image/png"
+        })
+
+      # Corrupt the bad row's path ciphertext → decrypt_metadata returns
+      # {:error, :decrypt_failed} for it (AEAD verification fails).
+      Engram.Repo.with_tenant(user.id, fn ->
+        from(a in Attachment, where: a.id == ^bad.id)
+        |> Engram.Repo.update_all(set: [path_ciphertext: :crypto.strong_rand_bytes(48)])
+      end)
+
+      log =
+        capture_log(fn ->
+          {:ok, list} = Attachments.list_attachments(user, vault)
+          paths = Enum.map(list, & &1.path)
+          assert "good.png" in paths
+          refute "bad.png" in paths
+          assert length(list) == 1
+        end)
+
+      assert log =~ "Skipping undecryptable attachment"
+    end
   end
 
   describe "encrypted S3 storage path" do

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -287,16 +287,20 @@ defmodule Engram.AttachmentsTest do
     end
 
     test "returns non-deleted attachment metadata for the vault", %{user: user, vault: vault} do
-      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "img/a.png",
-        "content_base64" => Base.encode64("PNGDATA"),
-        "mime_type" => "image/png"
-      })
-      {:ok, _b} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "b.pdf",
-        "content_base64" => Base.encode64("PDFDATA"),
-        "mime_type" => "application/pdf"
-      })
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "img/a.png",
+          "content_base64" => Base.encode64("PNGDATA"),
+          "mime_type" => "image/png"
+        })
+
+      {:ok, _b} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "b.pdf",
+          "content_base64" => Base.encode64("PDFDATA"),
+          "mime_type" => "application/pdf"
+        })
+
       :ok = Attachments.delete_attachment(user, vault, "b.pdf")
 
       {:ok, list} = Attachments.list_attachments(user, vault)
@@ -315,11 +319,13 @@ defmodule Engram.AttachmentsTest do
     test "scopes to the given user+vault", %{user: user, vault: vault} do
       other = insert(:user)
       other_vault = insert(:vault, user: other)
-      {:ok, _} = Attachments.upsert_attachment(other, other_vault, %{
-        "path" => "secret.png",
-        "content_base64" => Base.encode64("X"),
-        "mime_type" => "image/png"
-      })
+
+      {:ok, _} =
+        Attachments.upsert_attachment(other, other_vault, %{
+          "path" => "secret.png",
+          "content_base64" => Base.encode64("X"),
+          "mime_type" => "image/png"
+        })
 
       {:ok, list} = Attachments.list_attachments(user, vault)
       refute Enum.any?(list, &(&1.path == "secret.png"))

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -280,6 +280,53 @@ defmodule Engram.AttachmentsTest do
     end
   end
 
+  describe "list_attachments/2" do
+    setup do
+      Mox.stub_with(Engram.MockStorage, Engram.Storage.InMemory)
+      :ok
+    end
+
+    test "returns non-deleted attachment metadata for the vault", %{user: user, vault: vault} do
+      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "img/a.png",
+        "content_base64" => Base.encode64("PNGDATA"),
+        "mime_type" => "image/png"
+      })
+      {:ok, b} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "b.pdf",
+        "content_base64" => Base.encode64("PDFDATA"),
+        "mime_type" => "application/pdf"
+      })
+      :ok = Attachments.delete_attachment(user, vault, "b.pdf")
+
+      {:ok, list} = Attachments.list_attachments(user, vault)
+
+      paths = Enum.map(list, & &1.path)
+      assert "img/a.png" in paths
+      refute "b.pdf" in paths
+
+      a = Enum.find(list, &(&1.path == "img/a.png"))
+      assert a.mime_type == "image/png"
+      assert a.size_bytes == byte_size("PNGDATA")
+      assert Map.has_key?(a, :updated_at)
+      refute Map.has_key?(a, :deleted_at)
+      assert b.path == "b.pdf"
+    end
+
+    test "scopes to the given user+vault", %{user: user, vault: vault} do
+      other = insert(:user)
+      other_vault = insert(:vault, user: other)
+      {:ok, _} = Attachments.upsert_attachment(other, other_vault, %{
+        "path" => "secret.png",
+        "content_base64" => Base.encode64("X"),
+        "mime_type" => "image/png"
+      })
+
+      {:ok, list} = Attachments.list_attachments(user, vault)
+      refute Enum.any?(list, &(&1.path == "secret.png"))
+    end
+  end
+
   describe "encrypted S3 storage path" do
     setup do
       Mox.stub_with(Engram.MockStorage, Engram.Storage.InMemory)

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -313,6 +313,7 @@ defmodule Engram.AttachmentsTest do
       assert a.mime_type == "image/png"
       assert a.size_bytes == byte_size("PNGDATA")
       assert Map.has_key?(a, :updated_at)
+      assert a.id != nil
       refute Map.has_key?(a, :deleted_at)
     end
 

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -292,7 +292,7 @@ defmodule Engram.AttachmentsTest do
         "content_base64" => Base.encode64("PNGDATA"),
         "mime_type" => "image/png"
       })
-      {:ok, b} = Attachments.upsert_attachment(user, vault, %{
+      {:ok, _b} = Attachments.upsert_attachment(user, vault, %{
         "path" => "b.pdf",
         "content_base64" => Base.encode64("PDFDATA"),
         "mime_type" => "application/pdf"
@@ -310,7 +310,6 @@ defmodule Engram.AttachmentsTest do
       assert a.size_bytes == byte_size("PNGDATA")
       assert Map.has_key?(a, :updated_at)
       refute Map.has_key?(a, :deleted_at)
-      assert b.path == "b.pdf"
     end
 
     test "scopes to the given user+vault", %{user: user, vault: vault} do

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -483,6 +483,7 @@ defmodule EngramWeb.AttachmentsControllerTest do
 
       assert a["size_bytes"] == 3
       assert Map.has_key?(a, "updated_at")
+      assert is_binary(a["id"])
     end
 
     test "returns empty list for a vault with no attachments", %{conn: conn} do

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -463,6 +463,42 @@ defmodule EngramWeb.AttachmentsControllerTest do
   end
 
   # ---------------------------------------------------------------------------
+  # GET /attachments — List (index)
+  # ---------------------------------------------------------------------------
+
+  describe "GET /attachments (index)" do
+    test "lists non-deleted attachments", %{conn: conn} do
+      post(conn, "/api/attachments", %{
+        path: "diagrams/arch.png",
+        content_base64: Base.encode64("PNG"),
+        mtime: 1_000.0
+      })
+
+      resp = conn |> get("/api/attachments") |> json_response(200)
+
+      assert [%{"path" => "diagrams/arch.png", "mime_type" => "image/png"} = a] =
+               resp["attachments"]
+
+      assert a["size_bytes"] == 3
+      assert Map.has_key?(a, "updated_at")
+    end
+
+    test "returns empty list for a vault with no attachments", %{conn: conn} do
+      resp = conn |> get("/api/attachments") |> json_response(200)
+      assert resp["attachments"] == []
+    end
+
+    test "returns 401 without auth", %{conn: conn} do
+      conn =
+        conn
+        |> delete_req_header("authorization")
+        |> get("/api/attachments")
+
+      assert conn.status in [401, 403]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Multi-tenant isolation
   # ---------------------------------------------------------------------------
 

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -544,6 +544,25 @@ defmodule EngramWeb.AttachmentsControllerTest do
              ]
     end
 
+    test "forces download for text/* markup types (allowlist, not just svg/html)", %{conn: conn} do
+      # text/xml is admitted by the MIME whitelist's `text/` prefix and can run
+      # script via XSLT — it must NOT render inline.
+      _ =
+        conn
+        |> post("/api/attachments", %{
+          path: "data.xml",
+          content_base64: Base.encode64("<?xml version=\"1.0\"?><root/>"),
+          mime_type: "text/xml",
+          mtime: 1.0
+        })
+        |> json_response(200)
+
+      resp = get(conn, "/api/attachments/data.xml?raw=1")
+
+      assert resp.status == 200
+      assert get_resp_header(resp, "content-disposition") == [~s(attachment; filename="data.xml")]
+    end
+
     test "without raw still returns JSON with content_base64", %{conn: conn} do
       _ =
         conn

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -468,11 +468,13 @@ defmodule EngramWeb.AttachmentsControllerTest do
 
   describe "GET /attachments (index)" do
     test "lists non-deleted attachments", %{conn: conn} do
-      post(conn, "/api/attachments", %{
+      conn
+      |> post("/api/attachments", %{
         path: "diagrams/arch.png",
         content_base64: Base.encode64("PNG"),
         mtime: 1_000.0
       })
+      |> json_response(200)
 
       resp = conn |> get("/api/attachments") |> json_response(200)
 

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -508,7 +508,11 @@ defmodule EngramWeb.AttachmentsControllerTest do
     test "streams raw bytes with the attachment Content-Type", %{conn: conn} do
       _ =
         conn
-        |> post("/api/attachments", %{path: "p.png", content_base64: Base.encode64("RAWBYTES"), mtime: 1.0})
+        |> post("/api/attachments", %{
+          path: "p.png",
+          content_base64: Base.encode64("RAWBYTES"),
+          mtime: 1.0
+        })
         |> json_response(200)
 
       resp = get(conn, "/api/attachments/p.png?raw=1")
@@ -533,13 +537,20 @@ defmodule EngramWeb.AttachmentsControllerTest do
       resp = get(conn, "/api/attachments/diagram.svg?raw=1")
 
       assert resp.status == 200
-      assert get_resp_header(resp, "content-disposition") == [~s(attachment; filename="diagram.svg")]
+
+      assert get_resp_header(resp, "content-disposition") == [
+               ~s(attachment; filename="diagram.svg")
+             ]
     end
 
     test "without raw still returns JSON with content_base64", %{conn: conn} do
       _ =
         conn
-        |> post("/api/attachments", %{path: "q.png", content_base64: Base.encode64("BYTES"), mtime: 1.0})
+        |> post("/api/attachments", %{
+          path: "q.png",
+          content_base64: Base.encode64("BYTES"),
+          mtime: 1.0
+        })
         |> json_response(200)
 
       resp = conn |> get("/api/attachments/q.png") |> json_response(200)

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -501,6 +501,33 @@ defmodule EngramWeb.AttachmentsControllerTest do
   end
 
   # ---------------------------------------------------------------------------
+  # GET /attachments/*path?raw=1 — Raw byte streaming
+  # ---------------------------------------------------------------------------
+
+  describe "GET /attachments/*path?raw=1" do
+    test "streams raw bytes with the attachment Content-Type", %{conn: conn} do
+      conn
+      |> post("/api/attachments", %{path: "p.png", content_base64: Base.encode64("RAWBYTES"), mtime: 1.0})
+      |> json_response(200)
+
+      conn = get(conn, "/api/attachments/p.png?raw=1")
+
+      assert conn.status == 200
+      assert response_content_type(conn, :png) =~ "image/png"
+      assert conn.resp_body == "RAWBYTES"
+    end
+
+    test "without raw still returns JSON with content_base64", %{conn: conn} do
+      conn
+      |> post("/api/attachments", %{path: "q.png", content_base64: Base.encode64("BYTES"), mtime: 1.0})
+      |> json_response(200)
+
+      resp = conn |> get("/api/attachments/q.png") |> json_response(200)
+      assert resp["content_base64"] == Base.encode64("BYTES")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Multi-tenant isolation
   # ---------------------------------------------------------------------------
 

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -506,21 +506,41 @@ defmodule EngramWeb.AttachmentsControllerTest do
 
   describe "GET /attachments/*path?raw=1" do
     test "streams raw bytes with the attachment Content-Type", %{conn: conn} do
-      conn
-      |> post("/api/attachments", %{path: "p.png", content_base64: Base.encode64("RAWBYTES"), mtime: 1.0})
-      |> json_response(200)
+      _ =
+        conn
+        |> post("/api/attachments", %{path: "p.png", content_base64: Base.encode64("RAWBYTES"), mtime: 1.0})
+        |> json_response(200)
 
-      conn = get(conn, "/api/attachments/p.png?raw=1")
+      resp = get(conn, "/api/attachments/p.png?raw=1")
 
-      assert conn.status == 200
-      assert response_content_type(conn, :png) =~ "image/png"
-      assert conn.resp_body == "RAWBYTES"
+      assert resp.status == 200
+      assert response_content_type(resp, :png) =~ "image/png"
+      assert resp.resp_body == "RAWBYTES"
+      assert get_resp_header(resp, "content-disposition") == [~s(inline; filename="p.png")]
+    end
+
+    test "forces download for inline-script types (svg)", %{conn: conn} do
+      _ =
+        conn
+        |> post("/api/attachments", %{
+          path: "diagram.svg",
+          content_base64: Base.encode64("<svg/>"),
+          mime_type: "image/svg+xml",
+          mtime: 1.0
+        })
+        |> json_response(200)
+
+      resp = get(conn, "/api/attachments/diagram.svg?raw=1")
+
+      assert resp.status == 200
+      assert get_resp_header(resp, "content-disposition") == [~s(attachment; filename="diagram.svg")]
     end
 
     test "without raw still returns JSON with content_base64", %{conn: conn} do
-      conn
-      |> post("/api/attachments", %{path: "q.png", content_base64: Base.encode64("BYTES"), mtime: 1.0})
-      |> json_response(200)
+      _ =
+        conn
+        |> post("/api/attachments", %{path: "q.png", content_base64: Base.encode64("BYTES"), mtime: 1.0})
+        |> json_response(200)
 
       resp = conn |> get("/api/attachments/q.png") |> json_response(200)
       assert resp["content_base64"] == Base.encode64("BYTES")


### PR DESCRIPTION
## Summary

Phase 1 of surfacing vault **attachments** (images, PDFs, other binaries) in the web SPA. Previously the file tree showed markdown/canvas notes only — attachments (a separate backend concept, encrypted blobs in S3) were invisible on the web. This adds:

- **Backend** — `GET /api/attachments` lists a vault's non-deleted attachment metadata; the existing `GET /api/attachments/*path` gains a `?raw=1` mode that streams real bytes with the right `Content-Type` (the JSON-only endpoint is unchanged, so plugin sync is unaffected).
- **Frontend** — attachments appear in the file tree (type icon + ext badge), bucketed into their folder by path; clicking opens a read-only preview (`/attachment/*`): image inline, PDF embedded, other types → download. Folders that exist *only* because they hold attachments are synthesized client-side so nothing is hidden.

Scope is **display + preview only**. Delete/rename/move (Phase 2) and upload (Phase 3) are deferred and have their own follow-up specs.

### Notable
- **Fixes a latent bug:** `AttachmentImg` (the markdown inline-embed component) fetched the JSON endpoint via `getBlob`, so `![[image.png]]` embeds never rendered. Now uses `?raw=1` → real bytes.
- **Security at the boundary:** raw bytes are served only on the authenticated vault-scoped pipeline (`nosniff` already set); `?raw=1` forces `content-disposition: attachment` for `text/html` + `image/svg+xml` (SVG can carry script) and `inline` otherwise. List endpoint is intentionally not feature-gated — free tier simply has none.
- **Synthetic folders are non-actionable:** `syn:` rows have no backend record, so context-menu/long-press/prefetch and move/rename are suppressed (with `partition()` defense-in-depth). Attachment rows are likewise display-only (no dead action menu).

Spec: `docs/superpowers/specs/2026-06-14-attachments-in-file-tree-design.md`
Plan: `docs/superpowers/plans/2026-06-14-attachments-in-file-tree.md`

## Test Plan
- [x] Backend: full ExUnit suite — **2696 tests, 0 failures**. New coverage: `list_attachments/2` (non-deleted filter, tenant isolation), `GET /api/attachments` (shape, empty, 401), `?raw=1` (raw bytes + Content-Type + the three content-disposition branches).
- [x] Frontend: full vitest suite — **544 passed**. New coverage: id codec round-trips, `synthesizeFolders`, loader bucketing (root/folder/no-leak/mtime-sort/cache-miss), tree-row attachment + synthetic/attachment context-menu suppression, `AttachmentImg` raw fetch, `AttachmentPage` (image/pdf/unsupported/error/loading), `FolderTree` integration.
- [x] `tsc --noEmit` clean; `vite build` succeeds.
- [ ] Manual smoke: confirm image + PDF + a non-previewable file render in the tree (incl. an images-only folder) and open correctly; sidebar stays mounted across navigation.

> **Note:** rebased onto `main` and bumped to `0.5.439`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)