### PR TITLE
fix(ci): check out e2e/helpers for clerk-orphans reaper

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -72,8 +72,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # The script imports `helpers.clerk_constants` (the shared e2e-email
+          # predicate, added for #558), so the helpers package must be checked
+          # out too — sparse-checkout omitting it crashed the reaper with
+          # ModuleNotFoundError, leaving the quota to fill (#558).
           sparse-checkout: |
             e2e/scripts/cleanup_clerk_users.py
+            e2e/helpers/__init__.py
+            e2e/helpers/clerk_constants.py
 
       - name: Ensure requests is available
         # --break-system-packages: isolated runner VM runs Python 3.12

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.440",
+      version: "0.5.441",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

The hourly `clerk-orphans` reaper (in `cron.yml`) has been crashing on **every** run since 2026-06-02, so stale `e2e-*` Clerk users were never deleted. The dev instance filled to its 100-user cap and every Clerk-auth e2e job started 403'ing with `user_quota_exceeded`.

Root cause:

```
File ".../e2e/scripts/cleanup_clerk_users.py", line 35
    from helpers.clerk_constants import is_e2e_clerk_email
ModuleNotFoundError: No module named 'helpers'
```

The #558 change centralized the e2e-email predicate into `helpers.clerk_constants` and imported it from the cleanup script — but the reaper job's `sparse-checkout` pulls **only** `e2e/scripts/cleanup_clerk_users.py`, so the `helpers` package isn't on disk. The script dies before deleting anyone.

## Fix

Add `e2e/helpers/__init__.py` + `e2e/helpers/clerk_constants.py` to the reaper's sparse-checkout.

## Verified

Dispatched `cron.yml -f task=clerk-orphans` from this branch (run 27538122333): **success — "Deleted 81 e2e users."** Quota recovered from ~100 → ~19.

Fixes #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)