### PR TITLE
fix(ci): sparse-checkout e2e/helpers so clerk-orphans reaper runs (#558)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           sparse-checkout: |
             e2e/scripts/cleanup_clerk_users.py
+            e2e/helpers
 
       - name: Ensure requests is available
         # --break-system-packages: isolated runner VM runs Python 3.12

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.439",
+      version: "0.5.441",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem (#558)

The hourly `clerk-orphans` cron reaps stale e2e Clerk test users to keep the dev instance under its **100-user cap**. It has been a silent no-op since the script gained a `helpers.clerk_constants` import: the job's `actions/checkout` sparse-fetched only `e2e/scripts/cleanup_clerk_users.py`, so `e2e/helpers/` was never on disk and every run died with:

```
ModuleNotFoundError: No module named 'helpers'
```

With the reaper dead, e2e users piled up to the cap, and every e2e job that creates a Clerk user started failing with `403 user_quota_exceeded` ("reached your limit of 100 users").

## Fix

Add `e2e/helpers` to the job's `sparse-checkout`. `clerk_constants.py` imports nothing beyond the stdlib, so no new runtime deps.

## Verification

Dispatched the workflow from this branch (`workflow_dispatch -f task=clerk-orphans`): checkout now includes `e2e/helpers`, the import resolves, and the reaper ran clean —

```
INFO: Total users in instance: 33
INFO: E2E test users: 33 | Real users: 0
INFO: Age filter --older-than 1:00:00: kept 3 / 33 e2e users
INFO: Done. Deleted 3 e2e users.
```

The hourly cron will now keep the instance under the cap going forward.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)