### PR TITLE
feat(search): hybrid keyword + vector search (tsvector + RRF) (#595)

### DIFF
--- a/lib/engram/keyword_index.ex
+++ b/lib/engram/keyword_index.ex
@@ -1,0 +1,39 @@
+defmodule Engram.KeywordIndex do
+  @moduledoc """
+  Behaviour for the keyword (full-text) leg of hybrid search (#595).
+
+  This is the swap seam. Today the only impl is `Engram.KeywordIndex.Postgres`
+  (native `tsvector` + `ts_rank_cd` on the primary RDS). When keyword relevance
+  becomes a measured bottleneck at scale, a `KeywordIndex.TigerCloud`
+  (`pg_textsearch` BM25) adapter drops in behind the same callbacks — call
+  sites in `Engram.Search` and `Engram.Workers.EmbedNote` never change. See the
+  decision log on issue #595.
+
+  Resolve the configured impl with `module/0`.
+  """
+
+  @typedoc "Plaintext-populated note (persisted row + decrypted `content`/`title`)."
+  @type note :: Engram.Notes.Note.t()
+
+  @typedoc "Tenant + vault scope for a search. `vault_id: nil` searches all of the user's vaults."
+  @type scope :: %{required(:user_id) => String.t(), optional(:vault_id) => String.t() | nil}
+
+  @typedoc "A ranked hit: the note id and its keyword relevance score (higher = better)."
+  @type hit :: {note_id :: String.t(), rank :: float()}
+
+  @doc "Index (insert-or-replace) a note's plaintext into the keyword store."
+  @callback upsert(note()) :: :ok | {:error, term()}
+
+  @doc "Remove a note from the keyword store."
+  @callback delete(note_id :: String.t()) :: :ok
+
+  @doc """
+  Return up to `:limit` keyword hits for `query` within `scope`, best-ranked
+  first. Must isolate by tenant.
+  """
+  @callback search(query :: String.t(), scope(), opts :: keyword()) :: {:ok, [hit()]}
+
+  @doc "The configured keyword-index adapter (defaults to the native Postgres leg)."
+  @spec module() :: module()
+  def module, do: Application.get_env(:engram, :keyword_index, Engram.KeywordIndex.Postgres)
+end

--- a/lib/engram/keyword_index/postgres.ex
+++ b/lib/engram/keyword_index/postgres.ex
@@ -1,0 +1,102 @@
+defmodule Engram.KeywordIndex.Postgres do
+  @moduledoc """
+  Native-Postgres keyword leg (#595): `tsvector` + `ts_rank_cd` on the primary
+  RDS. Zero extra infra. Honest about what it is — this is TF/proximity ranking,
+  NOT BM25 (no IDF, no term saturation). At per-user-vault scale that gap is
+  small and RRF fusion with the vector leg absorbs the score-scale mismatch.
+
+  Write/read split mirrors the codebase's RLS model:
+
+    * `upsert/1`/`delete/1` run on the default connection role (RLS-bypassing,
+      like the chunk inserts in `Engram.Indexing`) — called only from the
+      trusted `EmbedNote` worker. Tenant safety comes from the explicit
+      `user_id`/`vault_id` written into the row.
+    * `search/3` runs inside `Repo.with_tenant/2`, dropping to the `engram_app`
+      role so Postgres RLS enforces tenant isolation at the row level, on top of
+      the explicit `vault_id` filter.
+
+  Title is weighted `A` and body `B`, so a title hit out-ranks a body-only hit.
+  Queries use `websearch_to_tsquery` (handles quotes, `OR`, `-term`) so literal
+  user queries like `PADDLE_API_KEY` Just Work.
+  """
+  @behaviour Engram.KeywordIndex
+
+  import Ecto.Query
+
+  alias Engram.Notes.NoteFts
+  alias Engram.Repo
+
+  # `english` is the v1 text-search config (per-language stemming for mixed
+  # vaults is deferred, #595). Inlined as a SQL literal, not a bind param —
+  # `to_tsvector`/`websearch_to_tsquery` take a `regconfig` (oid), which
+  # Postgrex can't encode from a string.
+
+  @impl Engram.KeywordIndex
+  def upsert(%{id: note_id, user_id: user_id, vault_id: vault_id} = note) do
+    title = note.title || ""
+    content = note.content || ""
+
+    sql = """
+    INSERT INTO notes_fts (note_id, user_id, vault_id, search_vector, created_at, updated_at)
+    VALUES ($1, $2, $3,
+      setweight(to_tsvector('english', $4), 'A') || setweight(to_tsvector('english', $5), 'B'),
+      now(), now())
+    ON CONFLICT (note_id) DO UPDATE
+      SET search_vector = EXCLUDED.search_vector,
+          vault_id = EXCLUDED.vault_id,
+          updated_at = now()
+    """
+
+    case Repo.query(sql, [
+           dump_uuid(note_id),
+           dump_uuid(user_id),
+           dump_uuid(vault_id),
+           title,
+           content
+         ]) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl Engram.KeywordIndex
+  def delete(note_id) do
+    Repo.query!("DELETE FROM notes_fts WHERE note_id = $1", [dump_uuid(note_id)])
+    :ok
+  end
+
+  # Postgrex binds a uuid column param as the 16-byte binary, not the text form.
+  defp dump_uuid(id), do: id |> to_string() |> Ecto.UUID.dump!()
+
+  @impl Engram.KeywordIndex
+  def search(query, %{user_id: user_id} = scope, opts) do
+    limit = Keyword.get(opts, :limit, 5)
+    vault_id = Map.get(scope, :vault_id)
+
+    {:ok, rows} =
+      Repo.with_tenant(to_string(user_id), fn ->
+        NoteFts
+        |> where(
+          [f],
+          fragment("search_vector @@ websearch_to_tsquery('english', ?)", ^query)
+        )
+        |> maybe_vault(vault_id)
+        |> order_by(
+          [f],
+          desc: fragment("ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))", ^query)
+        )
+        |> limit(^limit)
+        |> select(
+          [f],
+          {f.note_id,
+           fragment("ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))", ^query)}
+        )
+        |> Repo.all()
+      end)
+
+    {:ok, rows}
+  end
+
+  defp maybe_vault(query, nil), do: query
+  defp maybe_vault(query, vault_id), do: where(query, [f], f.vault_id == ^vault_id)
+end

--- a/lib/engram/notes/note_fts.ex
+++ b/lib/engram/notes/note_fts.ex
@@ -1,0 +1,21 @@
+defmodule Engram.Notes.NoteFts do
+  @moduledoc """
+  Side-table row holding the per-note full-text `search_vector` (#595).
+
+  PK is `note_id` (1:1 with `notes`), so this does not use `Engram.Schema`
+  (which forces an `:id` PK). The `search_vector` (`tsvector`) is written via a
+  raw `setweight(...)` fragment in `Engram.KeywordIndex.Postgres` and never
+  loaded into the struct, so it is intentionally not declared as a field.
+  """
+  use Ecto.Schema
+
+  @primary_key {:note_id, Ecto.UUID, autogenerate: false}
+  @foreign_key_type Ecto.UUID
+
+  schema "notes_fts" do
+    field :user_id, Ecto.UUID
+    field :vault_id, Ecto.UUID
+
+    timestamps(type: :utc_datetime_usec, inserted_at: :created_at)
+  end
+end

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -8,9 +8,14 @@ defmodule Engram.Search do
   - `:reranker`  — Engram.Rerankers.Jina | .None | any Engram.Reranker impl
   """
 
+  alias Engram.KeywordIndex
+  alias Engram.Notes
+  alias Engram.Repo
+  alias Engram.Search.Rrf
   alias Engram.Vector.Qdrant
 
   @min_candidates 20
+  @leg_timeout 5_000
 
   defp collection, do: Application.get_env(:engram, :qdrant_collection, "obsidian_notes")
 
@@ -131,38 +136,13 @@ defmodule Engram.Search do
   defp emit_search_performed(_user, _other, _started_at, _cross_vault), do: :ok
 
   defp do_search(user, vault, query, opts) do
-    limit = Keyword.get(opts, :limit, 5)
-    tags = Keyword.get(opts, :tags)
+    mode = Keyword.get(opts, :mode, :vector)
     folder = Keyword.get(opts, :folder)
-
-    # Fetch more candidates when reranking is active for THIS user (per-plan).
-    rerank_for_user? = reranker_active_for?(user)
-    fetch_limit = if rerank_for_user?, do: max(limit * 4, @min_candidates), else: limit
+    tags = Keyword.get(opts, :tags)
 
     case translate_phase_b_filters(user, folder, tags) do
       {:ok, phase_b_kw} ->
-        with {:ok, [vector]} <- embed_for_search(query) do
-          search_opts =
-            [user_id: to_string(user.id), limit: fetch_limit]
-            |> then(&if(vault, do: Keyword.put(&1, :vault_id, to_string(vault.id)), else: &1))
-            |> Keyword.merge(phase_b_kw)
-
-          with {:ok, candidates} <- Qdrant.search(collection(), vector, search_opts),
-               vaults_by_id = load_candidate_vaults(user, vault, candidates),
-               {:ok, decrypted} <-
-                 Engram.Crypto.decrypt_qdrant_candidates(
-                   candidates,
-                   user,
-                   vaults_by_id,
-                   collection()
-                 ) do
-            rerank_module = if rerank_for_user?, do: reranker(), else: Engram.Rerankers.None
-
-            with {:ok, ranked} <- rerank_module.rerank(query, decrypted, limit) do
-              {:ok, rehydrate_display_fields(ranked, user)}
-            end
-          end
-        end
+        run_mode(mode, user, vault, query, opts, phase_b_kw)
 
       :no_dek_with_filter ->
         # Caller asked to filter by folder/tags but has no DEK provisioned —
@@ -170,6 +150,180 @@ defmodule Engram.Search do
         # match anyway. Mirrors list_folders (B.2.2) defensive empty.
         {:ok, []}
     end
+  end
+
+  # --- mode dispatch (#595) -------------------------------------------------
+  #
+  # Internal default is `:vector` (backward-compatible for the MCP path and the
+  # existing test suite, which assert raw cosine scores). The web controller
+  # opts into `:hybrid` as the user-facing default; `?mode=` overrides.
+
+  defp run_mode(:vector, user, vault, query, opts, phase_b_kw),
+    do: vector_leg(user, vault, query, opts, phase_b_kw)
+
+  defp run_mode(:keyword, user, vault, query, opts, _phase_b_kw),
+    do: keyword_leg(user, vault, query, opts)
+
+  # Both legs run concurrently; the slower (usually Qdrant) bounds latency, not
+  # the sum. Either leg failing degrades to the other rather than failing the
+  # whole search — hybrid is the resilient default at the API.
+  defp run_mode(:hybrid, user, vault, query, opts, phase_b_kw) do
+    limit = Keyword.get(opts, :limit, 5)
+
+    vtask = Task.async(fn -> vector_leg(user, vault, query, opts, phase_b_kw) end)
+    ktask = Task.async(fn -> keyword_leg(user, vault, query, opts) end)
+
+    with {:ok, vres} <- Task.await(vtask, @leg_timeout) do
+      # Keyword is the additive leg: a keyword-leg failure degrades to
+      # vector-only rather than failing the search. A vector-leg failure
+      # propagates (preserves the error→500 contract; no error swallowing).
+      kres = leg_results(Task.await(ktask, @leg_timeout))
+      {:ok, fuse_legs(vres, kres, limit)}
+    end
+  end
+
+  defp leg_results({:ok, results}) when is_list(results), do: results
+  defp leg_results(_), do: []
+
+  # --- vector leg (Qdrant KNN → decrypt → rerank → rehydrate) ---------------
+
+  defp vector_leg(user, vault, query, opts, phase_b_kw) do
+    limit = Keyword.get(opts, :limit, 5)
+
+    # Fetch more candidates when reranking is active for THIS user (per-plan).
+    rerank_for_user? = reranker_active_for?(user)
+    fetch_limit = if rerank_for_user?, do: max(limit * 4, @min_candidates), else: limit
+
+    with {:ok, [vector]} <- embed_for_search(query) do
+      search_opts =
+        [user_id: to_string(user.id), limit: fetch_limit]
+        |> then(&if(vault, do: Keyword.put(&1, :vault_id, to_string(vault.id)), else: &1))
+        |> Keyword.merge(phase_b_kw)
+
+      with {:ok, candidates} <- Qdrant.search(collection(), vector, search_opts),
+           vaults_by_id = load_candidate_vaults(user, vault, candidates),
+           {:ok, decrypted} <-
+             Engram.Crypto.decrypt_qdrant_candidates(
+               candidates,
+               user,
+               vaults_by_id,
+               collection()
+             ) do
+        rerank_module = if rerank_for_user?, do: reranker(), else: Engram.Rerankers.None
+
+        with {:ok, ranked} <- rerank_module.rerank(query, decrypted, limit) do
+          {:ok, rehydrate_display_fields(ranked, user)}
+        end
+      end
+    end
+  end
+
+  # --- keyword leg (tsvector → ts_rank_cd → ts_headline snippet) ------------
+
+  # Cross-vault keyword search is deferred for v1 (the leg scopes by a single
+  # vault). Cross-vault hybrid therefore runs vector-only.
+  defp keyword_leg(_user, nil, _query, _opts), do: {:ok, []}
+
+  defp keyword_leg(user, vault, query, opts) do
+    limit = Keyword.get(opts, :limit, 5)
+    scope = %{user_id: to_string(user.id), vault_id: to_string(vault.id)}
+
+    with {:ok, hits} <- KeywordIndex.module().search(query, scope, limit: limit) do
+      results =
+        hits
+        |> Enum.map(fn {note_id, rank} ->
+          build_keyword_result(user, vault, note_id, rank, query)
+        end)
+        |> Enum.reject(&is_nil/1)
+
+      {:ok, results}
+    end
+  end
+
+  defp build_keyword_result(user, vault, note_id, rank, query) do
+    case Notes.get_note_by_id(user, vault, note_id) do
+      {:ok, note} ->
+        %{
+          source_path: note.path,
+          title: note.title,
+          heading_path: nil,
+          text: keyword_snippet(query, note.content),
+          score: rank,
+          tags: note.tags || [],
+          qdrant_id: nil
+        }
+
+      {:error, :not_found} ->
+        # Race: indexed in notes_fts but the note row is gone/soft-deleted.
+        nil
+    end
+  end
+
+  # Postgres ts_headline highlights the matched terms (markdown bold, fitting
+  # an MD app). Falls back to a leading excerpt if highlighting errors.
+  defp keyword_snippet(query, content) do
+    text = content || ""
+
+    case Repo.query(
+           "SELECT ts_headline('english', $1, websearch_to_tsquery('english', $2), " <>
+             "'StartSel=**, StopSel=**, MaxFragments=1, MaxWords=30, MinWords=10')",
+           [text, query]
+         ) do
+      {:ok, %{rows: [[snippet]]}} when is_binary(snippet) -> snippet
+      _ -> String.slice(text, 0, 200)
+    end
+  end
+
+  # --- RRF fusion of the two legs (#595) ------------------------------------
+
+  # Fuse on `source_path` (the common key — the vector leg is chunk-level, the
+  # keyword leg is note-level). RRF ranks the *notes*; we then return the
+  # original vector chunks for the surviving notes (re-scored to the note's
+  # fused score) so the controller's chunk grouping + match_count still work,
+  # plus one synthetic result per keyword-only note (no vector chunk to reuse).
+  defp fuse_legs(vres, kres, limit) do
+    v_by_path = best_by_path(vres)
+
+    v_ranked =
+      v_by_path
+      |> Map.values()
+      |> Enum.sort_by(& &1.score, :desc)
+      |> Enum.map(& &1.source_path)
+
+    k_ranked = kres |> Enum.map(& &1.source_path) |> Enum.uniq()
+
+    scored = [v_ranked, k_ranked] |> Rrf.fuse() |> Map.new()
+
+    top_paths =
+      scored
+      |> Enum.sort_by(fn {_path, score} -> score end, :desc)
+      |> Enum.take(limit)
+      |> Enum.map(&elem(&1, 0))
+      |> MapSet.new()
+
+    vector_paths = MapSet.new(Map.keys(v_by_path))
+
+    v_kept =
+      vres
+      |> Enum.filter(&MapSet.member?(top_paths, &1.source_path))
+      |> Enum.map(&%{&1 | score: Map.fetch!(scored, &1.source_path)})
+
+    k_only =
+      kres
+      |> Enum.filter(fn r ->
+        MapSet.member?(top_paths, r.source_path) and
+          not MapSet.member?(vector_paths, r.source_path)
+      end)
+      |> Enum.map(&%{&1 | score: Map.fetch!(scored, &1.source_path)})
+
+    v_kept ++ k_only
+  end
+
+  defp best_by_path(results) do
+    results
+    |> Enum.reject(&is_nil(Map.get(&1, :source_path)))
+    |> Enum.group_by(& &1.source_path)
+    |> Map.new(fn {path, group} -> {path, Enum.max_by(group, & &1.score)} end)
   end
 
   # Returns either {:ok, kw} where kw is the [folder_hmac: ..., tags_hmac: ...]

--- a/lib/engram/search/rrf.ex
+++ b/lib/engram/search/rrf.ex
@@ -1,0 +1,47 @@
+defmodule Engram.Search.Rrf do
+  @moduledoc """
+  Reciprocal Rank Fusion for hybrid search (#595).
+
+  Merges N ranked id-lists (the keyword leg and the vector leg) into one ranked
+  list using `score(id) = Σ_legs weight_leg / (k + rank)`. Because it depends
+  only on each id's *rank position* within a leg — never the raw score — the
+  legs' incompatible score scales (`ts_rank_cd` vs cosine similarity) never have
+  to be reconciled. The `weights` knob is the tunable blend #595 calls for.
+
+  Note: RRF absorbs score-*scale* mismatch between legs; it does NOT fix a leg's
+  internal ordering. The keyword leg is a candidate generator here, not the
+  final ranker.
+  """
+
+  @default_k 60
+
+  @type ranked :: [id :: term()]
+
+  @doc """
+  Fuse ranked id-lists. Each input list is ordered best-first (head = rank 1).
+  Returns `[{id, fused_score}]` sorted by score descending, ids de-duplicated.
+
+  Options:
+    * `:k` — RRF constant (default #{@default_k}); larger `k` flattens the
+      contribution of top ranks.
+    * `:weights` — per-leg weights aligned with the input lists (default 1.0
+      each).
+  """
+  @spec fuse([ranked()], keyword()) :: [{term(), float()}]
+  def fuse(ranked_lists, opts \\ []) do
+    k = Keyword.get(opts, :k, @default_k)
+    weights = Keyword.get(opts, :weights, List.duplicate(1.0, length(ranked_lists)))
+
+    ranked_lists
+    |> Enum.zip(weights)
+    |> Enum.reduce(%{}, fn {ids, weight}, acc ->
+      ids
+      |> Enum.with_index(1)
+      |> Enum.reduce(acc, fn {id, rank}, acc ->
+        contribution = weight / (k + rank)
+        Map.update(acc, id, contribution, &(&1 + contribution))
+      end)
+    end)
+    |> Enum.sort_by(fn {_id, score} -> score end, :desc)
+  end
+end

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -29,6 +29,7 @@ defmodule Engram.Workers.EmbedNote do
   alias Engram.Crypto
   alias Engram.Crypto.RotationGate
   alias Engram.Indexing
+  alias Engram.KeywordIndex
   alias Engram.Logger.DecryptFailure
   alias Engram.Notes.Note
   alias Engram.Repo
@@ -201,6 +202,7 @@ defmodule Engram.Workers.EmbedNote do
 
             case Indexing.index_note(decrypted_note, vault) do
               {:ok, _count} ->
+                index_keywords(decrypted_note)
                 stamp_embed_hash(note)
                 :ok
 
@@ -250,6 +252,35 @@ defmodule Engram.Workers.EmbedNote do
 
             {:error, reason}
         end
+    end
+  end
+
+  # #595 — keyword (tsvector) leg, written in the same decrypted pass that
+  # embedded the note. Best-effort by design: a keyword-index failure must NOT
+  # fail an otherwise-successful embed (which would trigger a wasteful Voyage
+  # re-embed on the next Oban attempt). The failure is surfaced via telemetry +
+  # log so a stuck leg is visible; a missing notes_fts row is repaired by the
+  # backfill/reconcile path, not by re-running the expensive embed.
+  defp index_keywords(decrypted_note) do
+    case KeywordIndex.module().upsert(decrypted_note) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        :telemetry.execute(
+          [:engram, :keyword_index, :upsert_failed],
+          %{count: 1},
+          %{user_id: decrypted_note.user_id, note_id: decrypted_note.id}
+        )
+
+        Logger.warning("keyword_index_upsert_failed",
+          category: :embed,
+          user_id: decrypted_note.user_id,
+          note_id: decrypted_note.id,
+          error_kind: Engram.Telemetry.error_kind(reason)
+        )
+
+        :ok
     end
   end
 

--- a/lib/engram_web/controllers/search_controller.ex
+++ b/lib/engram_web/controllers/search_controller.ex
@@ -20,11 +20,14 @@ defmodule EngramWeb.SearchController do
     tags = params["tags"]
     folder = params["folder"]
     cross_vault = Map.get(params, "cross_vault", false)
+    # #595 — the web endpoint defaults to hybrid (keyword + vector). `?mode=`
+    # lets a client isolate a single leg (keyword|vector) for debugging/tests.
+    mode = parse_mode(params["mode"])
 
     chunk_limit = max(note_limit * @overfetch_factor, @min_overfetch)
 
     opts =
-      [limit: chunk_limit, cross_vault: cross_vault]
+      [limit: chunk_limit, cross_vault: cross_vault, mode: mode]
       |> then(&if(tags, do: Keyword.put(&1, :tags, tags), else: &1))
       |> then(&if(folder, do: Keyword.put(&1, :folder, folder), else: &1))
 
@@ -63,6 +66,12 @@ defmodule EngramWeb.SearchController do
     |> put_status(422)
     |> json(%{error: "query is required"})
   end
+
+  # Unknown/missing mode falls back to the hybrid default rather than erroring —
+  # a stray ?mode=foo degrades to the best behavior, not a 4xx.
+  defp parse_mode("keyword"), do: :keyword
+  defp parse_mode("vector"), do: :vector
+  defp parse_mode(_), do: :hybrid
 
   defp clamp_limit(nil), do: 5
   defp clamp_limit(n) when is_integer(n), do: n |> max(1) |> min(@max_search_limit)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.443",
+      version: "0.5.444",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260615000000_create_notes_fts.exs
+++ b/priv/repo/migrations/20260615000000_create_notes_fts.exs
@@ -1,0 +1,56 @@
+defmodule Engram.Repo.Migrations.CreateNotesFts do
+  @moduledoc """
+  #595 — keyword/full-text search leg. Side table holding a per-note tsvector
+  (computed in-app after decrypt, NOT a GENERATED column — a generated column
+  can't read `content_ciphertext`). Kept off the hot `notes` row to keep that
+  row narrow. Plaintext-derived → same trust class as embeddings; encrypted at
+  rest at the storage layer (RDS KMS), RLS-isolated per tenant.
+  """
+  use Ecto.Migration
+
+  def change do
+    create table(:notes_fts, primary_key: false) do
+      add :note_id, references(:notes, type: :uuid, on_delete: :delete_all),
+        primary_key: true
+
+      add :user_id, references(:users, type: :uuid, on_delete: :delete_all), null: false
+      add :vault_id, references(:vaults, type: :uuid, on_delete: :delete_all), null: false
+      add :search_vector, :tsvector, null: false
+
+      timestamps(type: :utc_datetime_usec, inserted_at: :created_at)
+    end
+
+    # Plain (non-CONCURRENT) GIN is safe here: the table is created in THIS
+    # migration so it holds zero rows — nothing to lock. Squawk exempts indexes
+    # on same-migration tables. (Steady-state writes ride GIN fastupdate; the
+    # bulk backfill worker is where the drop→bulk-load→rebuild dance lives.)
+    create index(:notes_fts, [:search_vector], using: :gin)
+    create index(:notes_fts, [:vault_id])
+
+    # RLS — identical tenant_isolation shape to notes/chunks. The adapter also
+    # scopes by user_id/vault_id explicitly; this is the row-level backstop.
+    execute(
+      "ALTER TABLE notes_fts ENABLE ROW LEVEL SECURITY",
+      "ALTER TABLE notes_fts DISABLE ROW LEVEL SECURITY"
+    )
+
+    execute(
+      "ALTER TABLE notes_fts FORCE ROW LEVEL SECURITY",
+      "ALTER TABLE notes_fts NO FORCE ROW LEVEL SECURITY"
+    )
+
+    execute(
+      """
+      CREATE POLICY tenant_isolation_notes_fts ON notes_fts
+        USING ((user_id)::text = (SELECT current_setting('app.current_tenant', true)))
+        WITH CHECK ((user_id)::text = (SELECT current_setting('app.current_tenant', true)))
+      """,
+      "DROP POLICY tenant_isolation_notes_fts ON notes_fts"
+    )
+
+    execute(
+      "GRANT SELECT, INSERT, UPDATE, DELETE ON notes_fts TO engram_app",
+      "REVOKE ALL ON notes_fts FROM engram_app"
+    )
+  end
+end

--- a/priv/repo/migrations/20260615000000_create_notes_fts.exs
+++ b/priv/repo/migrations/20260615000000_create_notes_fts.exs
@@ -10,8 +10,7 @@ defmodule Engram.Repo.Migrations.CreateNotesFts do
 
   def change do
     create table(:notes_fts, primary_key: false) do
-      add :note_id, references(:notes, type: :uuid, on_delete: :delete_all),
-        primary_key: true
+      add :note_id, references(:notes, type: :uuid, on_delete: :delete_all), primary_key: true
 
       add :user_id, references(:users, type: :uuid, on_delete: :delete_all), null: false
       add :vault_id, references(:vaults, type: :uuid, on_delete: :delete_all), null: false

--- a/test/engram/keyword_index/postgres_test.exs
+++ b/test/engram/keyword_index/postgres_test.exs
@@ -1,0 +1,80 @@
+defmodule Engram.KeywordIndex.PostgresTest do
+  @moduledoc """
+  Unit tests for the native-Postgres keyword-search adapter (tsvector +
+  ts_rank_cd). Proves the leg #595 wants: exact-term recall that dense vector
+  search misses (identifiers, code, exact strings), plus per-tenant isolation.
+  """
+  use Engram.DataCase, async: true
+
+  alias Engram.Fixtures
+  alias Engram.KeywordIndex.Postgres
+
+  setup do
+    {:ok, user} = Fixtures.user_with_dek_fixture()
+    vault = Fixtures.insert_vault!(user, "Test Vault")
+    %{user: user, vault: vault}
+  end
+
+  # The decrypted-note shape EmbedNote hands to the keyword index: the persisted
+  # row plus the plaintext `content`/`title` virtual fields populated.
+  defp decrypted(user, vault, content, title) do
+    note = Fixtures.insert_note!(user, vault, %{content: content, title: title})
+    %{note | content: content, title: title}
+  end
+
+  describe "upsert/1 then search/3" do
+    test "recalls a note by an exact identifier in its body", %{user: user, vault: vault} do
+      note = decrypted(user, vault, "The deploy secret is PADDLE_API_KEY=sk_live_abc123", "Secrets")
+
+      assert :ok = Postgres.upsert(note)
+
+      assert {:ok, results} =
+               Postgres.search("PADDLE_API_KEY", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+
+      assert note.id in Enum.map(results, fn {note_id, _rank} -> note_id end)
+    end
+
+    test "does not recall notes for an unrelated query", %{user: user, vault: vault} do
+      note = decrypted(user, vault, "Notes about gardening and tomatoes", "Garden")
+      assert :ok = Postgres.upsert(note)
+
+      assert {:ok, results} =
+               Postgres.search("PADDLE_API_KEY", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+
+      refute note.id in Enum.map(results, fn {note_id, _rank} -> note_id end)
+    end
+
+    test "re-upsert replaces the prior vector (no duplicate, reflects new text)",
+         %{user: user, vault: vault} do
+      note = decrypted(user, vault, "first body mentions alpha", "T")
+      assert :ok = Postgres.upsert(note)
+      # Same note id, new content — must overwrite, not insert a second row.
+      assert :ok = Postgres.upsert(%{note | content: "second body mentions bravo"})
+
+      assert {:ok, gone} = Postgres.search("alpha", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+      refute note.id in Enum.map(gone, fn {id, _} -> id end)
+
+      assert {:ok, hit} = Postgres.search("bravo", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+      assert note.id in Enum.map(hit, fn {id, _} -> id end)
+    end
+  end
+
+  describe "tenant isolation" do
+    test "never returns another user's note for the same keyword", %{user: user, vault: vault} do
+      {:ok, other} = Fixtures.user_with_dek_fixture()
+      other_vault = Fixtures.insert_vault!(other, "Other Vault")
+
+      mine = decrypted(user, vault, "shared keyword WIDGET here", "Mine")
+      theirs = decrypted(other, other_vault, "shared keyword WIDGET here", "Theirs")
+      assert :ok = Postgres.upsert(mine)
+      assert :ok = Postgres.upsert(theirs)
+
+      assert {:ok, results} =
+               Postgres.search("WIDGET", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+
+      ids = Enum.map(results, fn {id, _} -> id end)
+      assert mine.id in ids
+      refute theirs.id in ids
+    end
+  end
+end

--- a/test/engram/keyword_index/postgres_test.exs
+++ b/test/engram/keyword_index/postgres_test.exs
@@ -24,12 +24,15 @@ defmodule Engram.KeywordIndex.PostgresTest do
 
   describe "upsert/1 then search/3" do
     test "recalls a note by an exact identifier in its body", %{user: user, vault: vault} do
-      note = decrypted(user, vault, "The deploy secret is PADDLE_API_KEY=sk_live_abc123", "Secrets")
+      note =
+        decrypted(user, vault, "The deploy secret is PADDLE_API_KEY=sk_live_abc123", "Secrets")
 
       assert :ok = Postgres.upsert(note)
 
       assert {:ok, results} =
-               Postgres.search("PADDLE_API_KEY", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+               Postgres.search("PADDLE_API_KEY", %{user_id: user.id, vault_id: vault.id},
+                 limit: 5
+               )
 
       assert note.id in Enum.map(results, fn {note_id, _rank} -> note_id end)
     end
@@ -39,7 +42,9 @@ defmodule Engram.KeywordIndex.PostgresTest do
       assert :ok = Postgres.upsert(note)
 
       assert {:ok, results} =
-               Postgres.search("PADDLE_API_KEY", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+               Postgres.search("PADDLE_API_KEY", %{user_id: user.id, vault_id: vault.id},
+                 limit: 5
+               )
 
       refute note.id in Enum.map(results, fn {note_id, _rank} -> note_id end)
     end
@@ -51,10 +56,14 @@ defmodule Engram.KeywordIndex.PostgresTest do
       # Same note id, new content — must overwrite, not insert a second row.
       assert :ok = Postgres.upsert(%{note | content: "second body mentions bravo"})
 
-      assert {:ok, gone} = Postgres.search("alpha", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+      assert {:ok, gone} =
+               Postgres.search("alpha", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+
       refute note.id in Enum.map(gone, fn {id, _} -> id end)
 
-      assert {:ok, hit} = Postgres.search("bravo", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+      assert {:ok, hit} =
+               Postgres.search("bravo", %{user_id: user.id, vault_id: vault.id}, limit: 5)
+
       assert note.id in Enum.map(hit, fn {id, _} -> id end)
     end
   end

--- a/test/engram/search/rrf_test.exs
+++ b/test/engram/search/rrf_test.exs
@@ -1,0 +1,42 @@
+defmodule Engram.Search.RrfTest do
+  @moduledoc """
+  Reciprocal Rank Fusion (#595). Pure ranking math — merges the keyword and
+  vector legs by rank position, so the two legs' incompatible score scales
+  (ts_rank_cd vs cosine) never need to be reconciled.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.Search.Rrf
+
+  test "an id ranked by both legs beats an id ranked by only one" do
+    vector = ["a", "b", "c"]
+    keyword = ["b", "d"]
+
+    fused = Rrf.fuse([vector, keyword])
+    order = Enum.map(fused, fn {id, _score} -> id end)
+
+    # `b` is #2 in vector and #1 in keyword → highest combined.
+    assert hd(order) == "b"
+    # every id from both legs survives the fusion, de-duplicated.
+    assert Enum.sort(order) == ["a", "b", "c", "d"]
+  end
+
+  test "uses 1/(k+rank) with k defaulting to 60" do
+    # Single leg, single id at rank 1 → 1/(60+1).
+    assert [{"x", score}] = Rrf.fuse([["x"]])
+    assert_in_delta score, 1.0 / 61.0, 1.0e-9
+  end
+
+  test "per-leg weights bias the fusion" do
+    vector = ["v"]
+    keyword = ["k"]
+
+    # Equal weights: both at rank 1 → tie; weighting keyword higher floats k up.
+    weighted = Rrf.fuse([vector, keyword], weights: [1.0, 5.0])
+    assert hd(Enum.map(weighted, fn {id, _} -> id end)) == "k"
+  end
+
+  test "empty legs fuse to an empty list" do
+    assert Rrf.fuse([[], []]) == []
+  end
+end

--- a/test/engram/search_test.exs
+++ b/test/engram/search_test.exs
@@ -575,6 +575,94 @@ defmodule Engram.SearchTest do
     end
   end
 
+  describe "search/4 keyword + hybrid modes (#595)" do
+    # The keyword leg reads notes_fts directly — no embedder, no Qdrant. Index
+    # the note straight through the adapter (the EmbedNote path is covered
+    # elsewhere) so this test isolates the read path.
+    defp index_keyword(user, vault, content, title) do
+      note = Engram.Fixtures.insert_note!(user, vault, %{content: content, title: title})
+      decrypted = %{note | content: content, title: title}
+      :ok = Engram.KeywordIndex.Postgres.upsert(decrypted)
+      decrypted
+    end
+
+    test "mode: :keyword recalls an exact identifier the vector leg would miss",
+         %{user: user, vault: vault} do
+      note = index_keyword(user, vault, "deploy uses PADDLE_API_KEY=sk_live here", "Ops")
+
+      assert {:ok, results} = Search.search(user, vault, "PADDLE_API_KEY", mode: :keyword)
+
+      assert Enum.any?(results, &(&1.source_path == note.path))
+      # ts_headline returns a highlighted excerpt. The `english` config
+      # tokenizes the identifier on underscores, so each component is bolded
+      # (**PADDLE**_**API**_**KEY**) — assert the highlight, not a raw substring.
+      hit = Enum.find(results, &(&1.source_path == note.path))
+      assert hit.text =~ "PADDLE"
+      assert hit.text =~ "**"
+    end
+
+    test "mode: :keyword returns [] when nothing matches", %{user: user, vault: vault} do
+      _ = index_keyword(user, vault, "notes about gardening", "Garden")
+      assert {:ok, []} = Search.search(user, vault, "PADDLE_API_KEY", mode: :keyword)
+    end
+
+    test "mode: :hybrid fuses the keyword hit with vector results", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
+      # A note only the keyword leg can find (exact identifier).
+      kw_note = index_keyword(user, vault, "the value is XYZZY_TOKEN=42", "Secrets")
+
+      # A different note the vector leg returns.
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts, _opts -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      {:ok, enc} =
+        Engram.Crypto.encrypt_qdrant_payload(
+          %{text: "semantic body", title: "Vector Note", heading_path: "root"},
+          user,
+          "engram_notes",
+          "qid-v"
+        )
+
+      qdrant_result = %{
+        "result" => [
+          %{
+            "id" => "qid-v",
+            "score" => 0.9,
+            "payload" => %{
+              "text" => enc.text,
+              "title" => enc.title,
+              "heading_path" => enc.heading_path,
+              "text_nonce" => enc.text_nonce,
+              "title_nonce" => enc.title_nonce,
+              "heading_path_nonce" => enc.heading_path_nonce,
+              "aad_version" => enc.aad_version,
+              "source_path" => "vector/note.md",
+              "tags" => [],
+              "user_id" => to_string(user.id),
+              "vault_id" => to_string(vault.id)
+            }
+          }
+        ]
+      }
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(qdrant_result))
+      end)
+
+      assert {:ok, results} = Search.search(user, vault, "XYZZY_TOKEN", mode: :hybrid)
+
+      paths = Enum.map(results, & &1.source_path)
+      # Both legs contribute: the keyword-only note AND the vector note.
+      assert kw_note.path in paths
+      assert "vector/note.md" in paths
+    end
+  end
+
   describe "search/4 with encrypted vaults" do
     setup do
       Engram.Crypto.DekCache.invalidate_all()

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -55,6 +55,33 @@ defmodule Engram.Workers.EmbedNoteTest do
       assert :ok = perform_job(EmbedNote, %{note_id: note.id})
     end
 
+    test "populates the keyword index (notes_fts) after embedding", %{
+      bypass: bypass,
+      user: user,
+      vault: vault,
+      note: note
+    } do
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+      end)
+
+      stub_qdrant(bypass)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      # The note body is "# Hello\n\nWorld." — a keyword the dense vector leg
+      # might miss must now be findable via the tsvector leg.
+      assert {:ok, hits} =
+               Engram.KeywordIndex.Postgres.search(
+                 "World",
+                 %{user_id: user.id, vault_id: vault.id},
+                 limit: 5
+               )
+
+      assert note.id in Enum.map(hits, fn {id, _rank} -> id end)
+    end
+
     test "stamps embed_hash on success", %{bypass: bypass, note: note} do
       Engram.MockEmbedder
       |> expect(:embed_texts, fn texts ->

--- a/test/engram_web/controllers/search_controller_test.exs
+++ b/test/engram_web/controllers/search_controller_test.exs
@@ -71,7 +71,9 @@ defmodule EngramWeb.SearchControllerTest do
       assert %{"results" => results} = json_response(conn, 200)
       assert length(results) == 1
       [hit] = results
-      assert hit["score"] == 0.95
+      # #595: the endpoint now defaults to hybrid, so `score` is the RRF fused
+      # score (rank-based, ordering-meaningful), not the raw cosine value.
+      assert hit["score"] > 0
       assert hit["path"] == "Health/Iron Panel.md"
       assert hit["title"] == "Iron Panel"
       assert hit["folder"] == "Health"
@@ -269,7 +271,8 @@ defmodule EngramWeb.SearchControllerTest do
       assert iron["path"] == "Health/Iron Panel.md"
       assert iron["match_count"] == 3
       assert iron["snippet"] == "Ferritin section."
-      assert iron["score"] == 0.95
+      # Hybrid (RRF) re-scores by rank; assert the ordering, not the raw cosine.
+      assert iron["score"] > vitd["score"]
 
       assert vitd["path"] == "Health/Vitamin D.md"
       assert vitd["match_count"] == 1


### PR DESCRIPTION
Implements the keyword/full-text leg of search and fuses it with the existing vector (Qdrant) leg. Closes the core of #595; full decision + rationale live in the [#595 decision comment](https://github.com/engram-app/Engram/issues/595#issuecomment-4706713327).

## Approach (the short version)

Native Postgres `tsvector` + `ts_rank_cd` on the existing RDS, behind a swappable `Engram.KeywordIndex` behaviour. True BM25 is **not installable on managed RDS** (needs `shared_preload_libraries`) and the cheap "ParadeDB replica" path is broken by our ciphertext-at-rest, so BM25 is deferred to managed Tiger Cloud `pg_textsearch` at scale — the `KeywordIndex` seam means that's a one-adapter swap, not a rewrite. Vector store stays on Qdrant.

## What's in here

- **`notes_fts` side table** (`phase/expand` migration): note-level `tsvector`, GIN index, RLS `tenant_isolation_notes_fts`. Computed in-app after decrypt (a `GENERATED` column can't read `content_ciphertext`); plaintext-derived, encrypted at rest at the storage layer.
- **`Engram.KeywordIndex` behaviour + `.Postgres` adapter**: title weighted `A` / body `B`, `websearch_to_tsquery('english', …)`. Writes via the trusted worker role (like chunk inserts); **searches inside `Repo.with_tenant` so Postgres RLS enforces tenant isolation** row-level.
- **`EmbedNote` hook**: indexes the keyword leg in the same already-decrypted pass (best-effort — a keyword failure logs + emits telemetry but doesn't fail the embed / trigger a wasteful re-embed).
- **`Engram.Search.Rrf`**: reciprocal rank fusion (k=60, tunable weights), fuses on rank so `ts_rank_cd` vs cosine scales never reconcile.
- **Hybrid `Search`**: `?mode=keyword|vector|hybrid`. Web endpoint defaults to **hybrid**; legs run concurrently (`Task.async`); keyword-only hits get a `ts_headline`-highlighted snippet. Internal `Search.search` default stays `:vector` so the **MCP path and other callers are unchanged**.

## ⚠️ Client-facing note (plugin / web)

On the **hybrid** path the result `score` is now the **RRF fused value** (rank-meaningful, e.g. ~0.016), not raw cosine (~0.95). Ordering is preserved and correct; clients that sort by score are fine, clients that threshold on an absolute cosine value are not. The MCP and `?mode=vector` paths still return cosine.

## Deferred

- **Backfill worker → #605.** Existing un-indexed notes aren't backfilled; new/edited notes self-index, and a wipe+re-sync repopulates (pre-launch, "no data is sacred"). #605 is also the future Tiger Cloud migration tool.
- **Cross-vault keyword** leg (single-vault for v1) → cross-vault hybrid runs vector-only.
- Honest labeling: it's `ts_rank_cd` (TF/proximity), **not** BM25.

## Tests

TDD throughout. Full suite green locally: **2771 tests, 0 failures**. New: `keyword_index` (4), `rrf` (4), keyword/hybrid `search` modes (3), `embed_note` keyword hook (1); existing `search_controller` updated for the hybrid score contract.

Refs #595