### PR TITLE
test: table-drive path_sanitizer + CI --slowest visibility

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1114,7 +1114,9 @@ jobs:
           # (unused aliases, unused vars, etc.) as fatal. Lib warnings are
           # already gated by `mix compile --warnings-as-errors` in the lint
           # job; this extends the same bar to test/**.
-          mix test --warnings-as-errors
+          # --slowest 20 surfaces the slowest tests each run so async/serial
+          # tuning stays data-driven (the suite is sync-pool-bound, not CPU-bound).
+          mix test --warnings-as-errors --slowest 20
 
       - name: Lint DB schema (splinter)
         run: |

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.446",
+      version: "0.5.447",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/path_sanitizer_test.exs
+++ b/test/engram/notes/path_sanitizer_test.exs
@@ -8,62 +8,32 @@ defmodule Engram.Notes.PathSanitizerTest do
   # ---------------------------------------------------------------------------
 
   describe "illegal char stripping" do
-    test "strips question mark" do
-      assert PathSanitizer.sanitize("Notes/Why?.md") == "Notes/Why.md"
-    end
+    # Uniform input -> output cases. Table-driven to keep each case visible
+    # with a descriptive failure message, without 14 near-identical test bodies.
+    @illegal_char_cases [
+      {"strips question mark", "Notes/Why?.md", "Notes/Why.md"},
+      {"strips asterisk", "Notes/Important*.md", "Notes/Important.md"},
+      {"strips colon", "Notes/HH:MM.md", "Notes/HHMM.md"},
+      {"strips angle brackets", "Notes/<tag>.md", "Notes/tag.md"},
+      {"strips double quotes", ~s(Notes/"quoted".md), "Notes/quoted.md"},
+      {"strips pipe", "Notes/A|B.md", "Notes/AB.md"},
+      {"strips backslash", "Notes/A\\B.md", "Notes/AB.md"},
+      {"strips multiple illegal chars", ~s(Notes/What: A "Great" Day*.md),
+       "Notes/What A Great Day.md"},
+      {"preserves forward slash", "A/B/C.md", "A/B/C.md"},
+      {"collapses multiple spaces", "Notes/Too   Many  Spaces.md", "Notes/Too Many Spaces.md"},
+      {"strips leading space per segment", "Notes/ Padded.md", "Notes/Padded.md"},
+      {"strips trailing slash", "Notes/Subfolder/", "Notes/Subfolder"},
+      {"no change for clean path", "Notes/Clean File.md", "Notes/Clean File.md"},
+      {"single segment no folder", "Inbox.md", "Inbox.md"}
+    ]
 
-    test "strips asterisk" do
-      assert PathSanitizer.sanitize("Notes/Important*.md") == "Notes/Important.md"
-    end
-
-    test "strips colon" do
-      assert PathSanitizer.sanitize("Notes/HH:MM.md") == "Notes/HHMM.md"
-    end
-
-    test "strips angle brackets" do
-      assert PathSanitizer.sanitize("Notes/<tag>.md") == "Notes/tag.md"
-    end
-
-    test "strips double quotes" do
-      assert PathSanitizer.sanitize(~s(Notes/"quoted".md)) == "Notes/quoted.md"
-    end
-
-    test "strips pipe" do
-      assert PathSanitizer.sanitize("Notes/A|B.md") == "Notes/AB.md"
-    end
-
-    test "strips backslash" do
-      assert PathSanitizer.sanitize("Notes/A\\B.md") == "Notes/AB.md"
-    end
-
-    test "strips multiple illegal chars" do
-      assert PathSanitizer.sanitize(~s(Notes/What: A "Great" Day*.md)) ==
-               "Notes/What A Great Day.md"
-    end
-
-    test "preserves forward slash" do
-      assert PathSanitizer.sanitize("A/B/C.md") == "A/B/C.md"
-    end
-
-    test "collapses multiple spaces" do
-      assert PathSanitizer.sanitize("Notes/Too   Many  Spaces.md") ==
-               "Notes/Too Many Spaces.md"
-    end
-
-    test "strips leading space per segment" do
-      assert PathSanitizer.sanitize("Notes/ Padded.md") == "Notes/Padded.md"
-    end
-
-    test "strips trailing slash" do
-      assert PathSanitizer.sanitize("Notes/Subfolder/") == "Notes/Subfolder"
-    end
-
-    test "no change for clean path" do
-      assert PathSanitizer.sanitize("Notes/Clean File.md") == "Notes/Clean File.md"
-    end
-
-    test "single segment no folder" do
-      assert PathSanitizer.sanitize("Inbox.md") == "Inbox.md"
+    test "sanitizes each illegal-char case to its expected output" do
+      for {desc, input, expected} <- @illegal_char_cases do
+        assert PathSanitizer.sanitize(input) == expected,
+               "#{desc}: sanitize(#{inspect(input)}) expected #{inspect(expected)}, " <>
+                 "got #{inspect(PathSanitizer.sanitize(input))}"
+      end
     end
   end
 


### PR DESCRIPTION
## What

Two low-risk test-suite hygiene changes, split out of a broader test-suite audit:

1. **path_sanitizer_test** — collapse 14 near-identical `sanitize(input) == output` tests into one table-driven test iterating a `{desc, input, expected}` list with a per-case failure message. Coverage unchanged (all 14 pairs still asserted); file drops **36 → 23 tests**, ~30 fewer lines. Traversal / edge-case / combined-attack blocks left as-is (non-uniform assertions).
2. **CI `--slowest 20`** — added to the `mix test` invocation so async/serial tuning stays data-driven.

## Why this is small (the interesting part)

The audit's headline finding: the suite is **sync-pool-bound** — a full run is ~104s async + **~141s serial** (148/260 files are `async: false`). The serial pool is the real speedup target.

A planned third change here — flipping ~19 isolated files to `async: true` — was **dropped** because it deterministically **deadlocks at seed 0**:

- `create_user_with_password` (`lib/engram/accounts.ex:113`) takes a global `pg_advisory_xact_lock` to serialize the first-user-becomes-admin claim (correct for prod).
- Under the Ecto SQL sandbox each test runs inside **one long wrapping transaction**, so that `*_xact_lock` is held for the **entire test**, not just the user-create.
- Raising async concurrency makes user-creating tests pile onto that one global lock; combined with the shared-mode serial connection they form a lock cycle → `40P01 deadlock_detected`.
- Reproduced: flips @ seed 0 = 2 deadlock failures; clean origin/main @ seed 0 = green.

This latent deadlock gates **both** async levers (the file flips *and* the `Application.put_env` Voyage/Qdrant base-URL refactor). Tracked in a follow-up issue; the fix (gate the bootstrap advisory lock off in test config, mirroring the existing `:boot_canary_enabled` pattern) is the actual unlock for the ~20–35% wall-clock win.

## Test
- `mix test test/engram/notes/path_sanitizer_test.exs` → 23 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)