### PR TITLE
feat(sync): cursor-pull backend — device cursors + keyset /sync/changes + bootstrap (PR B1)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-sync-cursor-pull-b1-backend.md
+++ b/docs/superpowers/plans/2026-06-16-sync-cursor-pull-b1-backend.md
@@ -1,0 +1,693 @@
+# Sync Cursor Pull — PR B1 (backend) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Backend for the ordered cursor pull: a `vault_device_cursors` watermark table, an opaque `(seq,id)` keyset pull merging notes+attachments (`GET /sync/changes?cursor=`), `change_seq` exposed for bootstrap, dormant `HISTORY_EXPIRED`, and an `attachments.version` column for resurrection-parity. API-tested only — plugin/web migration are PR B2/B3.
+
+**Architecture:** Mirror the existing timestamp keyset pagination (`Notes.list_changes_page/4` + `encode/decode_changes_cursor`, `notes.ex:1496-1591`) but key on `(seq, id)` instead of `(updated_at, id)` and include tombstones. A new `Engram.Sync` context owns the cursor codec + the watermark upsert. A new `SyncController.changes` action merges the two per-table seq feeds by `(seq,id)` (seqs are globally unique per vault — each `next_seq!` bump is distinct across tables — so the keyset is well-ordered across the union). The pull records the device's watermark from the *incoming* cursor (pull-carries-ack).
+
+**Tech Stack:** Elixir 1.17+/Phoenix 1.8+, Ecto, Postgres+RLS (`Repo.with_tenant`), ExUnit + ConnCase. Migration-safety `phase/*` labels; `structure.sql` is a baseline snapshot (NOT regenerated — commit only the migration). One `phase/expand` label, one `mix.exs` bump for this PR.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-sync-cursor-pull-design.md` (PR B1 = the "backend" rollout step).
+
+---
+
+## File structure
+
+**Create:**
+- `priv/repo/migrations/<ts>_cursor_pull_expand.exs` — `vault_device_cursors` table + `attachments.version` column (phase/expand).
+- `lib/engram/sync.ex` — `Engram.Sync`: cursor codec (`encode_cursor/2`, `decode_cursor/1`) + `record_cursor/3` (watermark upsert) + `retention_floor/1` (returns 0; PR D replaces).
+- `lib/engram/sync/device_cursor.ex` — Ecto schema for `vault_device_cursors`.
+- `lib/engram_web/controllers/sync_controller.ex` — already exists (`manifest`); ADD `changes/2`.
+- `test/engram/sync_test.exs` — codec + watermark tests.
+- `test/engram/notes_seq_feed_test.exs`, `test/engram/attachments_seq_feed_test.exs` — context seq-feed tests.
+- `test/engram_web/controllers/sync_changes_test.exs` — endpoint tests.
+
+**Modify:**
+- `lib/engram/attachments/attachment.ex` — add `field :version, :integer, default: 1` + cast.
+- `lib/engram/attachments.ex` — bump `version` in `write_row` (~133) and `delete_attachment` (~250); add `list_changes_by_seq/3`.
+- `lib/engram/notes.ex` — add `list_changes_by_seq/3` (mirror `list_changes_page`, keyed on seq, all kinds, tombstones included).
+- `lib/engram_web/router.ex` — add `get "/sync/changes", SyncController, :changes` on the vault-scoped pipeline (~line 352, next to `/sync/manifest`).
+- `lib/engram_web/controllers/sync_controller.ex` — `manifest/2` response gains `change_seq`.
+- `lib/engram/vaults.ex` — add `current_seq/1` (read `change_seq` for a vault).
+
+**Do NOT** touch `structure.sql`.
+
+---
+
+### Task 1: Migration — `vault_device_cursors` + `attachments.version` (phase/expand)
+
+**Files:** Create `priv/repo/migrations/<ts>_cursor_pull_expand.exs` (use a timestamp strictly greater than the newest existing migration; check `ls priv/repo/migrations/`).
+
+- [ ] **Step 1: Write the migration**
+
+```elixir
+defmodule Engram.Repo.Migrations.CursorPullExpand do
+  use Ecto.Migration
+
+  @moduledoc """
+  Sync cursor pull, step B1. phase/expand: purely additive.
+  - vault_device_cursors: per-(vault,device) sync watermark (GC + eviction).
+  - attachments.version: optimistic-concurrency / resurrection-safety parity
+    with notes.version (nullable->default 1; bumped on write).
+  """
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    create table(:vault_device_cursors, primary_key: false) do
+      add :vault_id, references(:vaults, type: :uuid, on_delete: :delete_all), null: false
+      add :device_id, :text, null: false
+      add :last_seq, :bigint, null: false, default: 0
+      add :last_seen_at, :utc_datetime, null: false
+    end
+
+    create unique_index(:vault_device_cursors, [:vault_id, :device_id], concurrently: true)
+
+    alter table(:attachments) do
+      add :version, :integer, null: false, default: 1
+    end
+  end
+
+  def down do
+    alter table(:attachments) do
+      remove :version
+    end
+
+    drop index(:vault_device_cursors, [:vault_id, :device_id])
+    drop table(:vault_device_cursors)
+  end
+end
+```
+
+> Note: `create table` inside `@disable_ddl_transaction` is fine; the `unique_index(..., concurrently: true)` is the part that needs the disabled transaction. If the runner objects to a CONCURRENTLY index on a brand-new (empty) table, drop `concurrently: true` from this one index — a new empty table has nothing to lock. Report which you used.
+
+- [ ] **Step 2: Apply (do NOT regenerate structure.sql)**
+
+Run: `mix ecto.migrate`. Expected: clean. Verify via DB inspection: `vault_device_cursors` exists with the PK+unique index; `attachments.version` is `integer NOT NULL DEFAULT 1`. Optionally `mix ecto.rollback --step 1` then re-migrate.
+
+- [ ] **Step 3: Lint**
+
+Run: `bash priv/repo/lint_migrations.sh` (Squawk). Expected: pass (additive; new table; constant default). Note result.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add priv/repo/migrations/<ts>_cursor_pull_expand.exs
+git commit -m "feat(sync): vault_device_cursors + attachments.version (phase/expand)"
+```
+
+---
+
+### Task 2: Attachment `version` — schema + bump on write
+
+**Files:** Modify `lib/engram/attachments/attachment.ex`, `lib/engram/attachments.ex`. Test: `test/engram/attachments_seq_feed_test.exs` (version part).
+
+> Scope: column + monotonic bump on every write + surface in the feed. The 409-reject-on-stale-version enforcement is a **push-path** concern and rides with the client migration (B2/B3) — NOT in B1.
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule Engram.AttachmentsSeqFeedTest do
+  use Engram.DataCase, async: true
+  alias Engram.{Attachments, Vaults, Repo}
+
+  setup do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  defp b64(b), do: Base.encode64(b)
+  defp put(user, vault, path), do: Attachments.upsert_attachment(user, vault, %{"path" => path, "content_base64" => b64(path), "mime_type" => "image/png"})
+
+  test "version starts at 1 and bumps on update", %{user: user, vault: vault} do
+    {:ok, a} = put(user, vault, "a.png")
+    r1 = Repo.with_tenant(user.id, fn -> Repo.get(Attachments.Attachment, a.id) end)
+    {:ok, {:ok, r1}} = {:ok, r1} |> then(&{:ok, &1})
+    assert r1.version == 1
+    {:ok, _} = put(user, vault, "a.png")
+    r2 = Repo.with_tenant(user.id, fn -> Repo.get(Attachments.Attachment, a.id) end)
+    {:ok, r2} = {:ok, r2}
+    assert r2.version == 2
+  end
+end
+```
+> (`Repo.with_tenant` returns `{:ok, value}` — unwrap. Adjust the helper shape to whatever's cleanest; the assertion contract is version=1 on insert, +1 on update.)
+
+- [ ] **Step 2: Run — FAIL** (`version` field unknown / nil). `mix test test/engram/attachments_seq_feed_test.exs`
+
+- [ ] **Step 3: Add the schema field**
+
+In `lib/engram/attachments/attachment.ex` add after `field :seq, :integer`:
+```elixir
+    field :version, :integer, default: 1
+```
+and add `:version` to the `cast/3` list in `changeset/2`.
+
+- [ ] **Step 4: Bump version on write**
+
+In `lib/engram/attachments.ex` `write_row/4` (~133), alongside the existing `seq` stamp, set version. For an update, increment the existing row's version; for insert it defaults to 1:
+```elixir
+    changeset_attrs =
+      changeset_attrs
+      |> Map.put(:seq, Engram.Vaults.next_seq!(changeset_attrs.vault_id))
+      |> then(fn attrs ->
+        case existing do
+          %Attachment{version: v} -> Map.put(attrs, :version, (v || 1) + 1)
+          _ -> attrs
+        end
+      end)
+```
+In `delete_attachment/3` (~250), add `version` to the `update_all` set by reading the row's current version first, OR (simpler) increment via SQL is overkill — instead include `version` bump only where a struct is available. For the bulk soft-delete, fetch the row's version is unnecessary for B1's feed (a delete already carries `deleted: true`); leave `delete_attachment` version untouched and note it. (Resurrection-safety on delete is push-path; deletes are conveyed by the tombstone flag, not version.)
+
+- [ ] **Step 5: Run — PASS.** Then regression `mix test test/engram/attachments_test.exs test/engram/attachments_seq_test.exs`.
+
+- [ ] **Step 6: Commit**
+```bash
+git add lib/engram/attachments/attachment.ex lib/engram/attachments.ex test/engram/attachments_seq_feed_test.exs
+git commit -m "feat(sync): add attachments.version, bump on write"
+```
+
+---
+
+### Task 3: `Engram.Sync` context — cursor codec + watermark
+
+**Files:** Create `lib/engram/sync.ex`, `lib/engram/sync/device_cursor.ex`. Test: `test/engram/sync_test.exs`.
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule Engram.SyncTest do
+  use Engram.DataCase, async: true
+  alias Engram.{Sync, Vaults, Repo}
+
+  test "cursor round-trips (seq,id) and rejects garbage" do
+    id = Ecto.UUID.generate()
+    tok = Sync.encode_cursor(42, id)
+    assert {:ok, {42, ^id}} = Sync.decode_cursor(tok)
+    assert {:ok, nil} = Sync.decode_cursor(nil)
+    assert {:error, :invalid_cursor} = Sync.decode_cursor("not-base64!!")
+  end
+
+  test "record_cursor upserts a monotonic watermark per (vault, device)" do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+
+    :ok = Sync.record_cursor(user, vault, "dev-1", 10)
+    :ok = Sync.record_cursor(user, vault, "dev-1", 25)
+    :ok = Sync.record_cursor(user, vault, "dev-1", 20)  # lagging pull must NOT regress
+
+    {:ok, row} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.get_by(Sync.DeviceCursor, vault_id: vault.id, device_id: "dev-1")
+      end)
+    assert row.last_seq == 25
+  end
+
+  test "record_cursor with nil device_id is a no-op" do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+    assert :ok = Sync.record_cursor(user, vault, nil, 5)
+  end
+end
+```
+
+- [ ] **Step 2: Run — FAIL** (`Engram.Sync` undefined). `mix test test/engram/sync_test.exs`
+
+- [ ] **Step 3: Schema** — `lib/engram/sync/device_cursor.ex`:
+```elixir
+defmodule Engram.Sync.DeviceCursor do
+  @moduledoc false
+  use Engram.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "vault_device_cursors" do
+    field :vault_id, :binary_id, primary_key: true
+    field :device_id, :string, primary_key: true
+    field :last_seq, :integer, default: 0
+    field :last_seen_at, :utc_datetime
+  end
+
+  def changeset(c, attrs) do
+    c
+    |> cast(attrs, [:vault_id, :device_id, :last_seq, :last_seen_at])
+    |> validate_required([:vault_id, :device_id, :last_seq, :last_seen_at])
+  end
+end
+```
+
+- [ ] **Step 4: Context** — `lib/engram/sync.ex`:
+```elixir
+defmodule Engram.Sync do
+  @moduledoc """
+  Ordered change-log sync: opaque (seq,id) cursor codec + per-device
+  watermark recording (the GC/eviction record; NOT the pagination source
+  of truth — clients hold their own position).
+  """
+  import Ecto.Query
+  alias Engram.Repo
+  alias Engram.Sync.DeviceCursor
+
+  @doc "Opaque cursor token = url-safe base64 of `<seq>:<id>`."
+  def encode_cursor(seq, id) when is_integer(seq) and is_binary(id),
+    do: Base.url_encode64("#{seq}:#{id}", padding: false)
+
+  def decode_cursor(nil), do: {:ok, nil}
+
+  def decode_cursor(tok) when is_binary(tok) do
+    with {:ok, raw} <- Base.url_decode64(tok, padding: false),
+         [seq_str, id_str] <- String.split(raw, ":", parts: 2),
+         {seq, ""} <- Integer.parse(seq_str),
+         {:ok, id} <- Ecto.UUID.cast(id_str) do
+      {:ok, {seq, id}}
+    else
+      _ -> {:error, :invalid_cursor}
+    end
+  end
+
+  def decode_cursor(_), do: {:error, :invalid_cursor}
+
+  @doc "Retention floor for HISTORY_EXPIRED. 0 until PR D (compaction) lands."
+  def retention_floor(_vault), do: 0
+
+  @doc """
+  Records a device's confirmed-applied watermark (pull-carries-ack).
+  Monotonic via GREATEST so a lagging/out-of-order pull never regresses it.
+  No-op when device_id is nil/blank.
+  """
+  def record_cursor(_user, _vault, device_id, _seq) when device_id in [nil, ""], do: :ok
+
+  def record_cursor(user, vault, device_id, seq) when is_integer(seq) do
+    now = DateTime.utc_now(:second)
+
+    Repo.with_tenant(user.id, fn ->
+      Repo.insert_all(
+        DeviceCursor,
+        [%{vault_id: vault.id, device_id: device_id, last_seq: seq, last_seen_at: now}],
+        on_conflict: [set: [last_seen_at: now], inc: []],
+        conflict_target: [:vault_id, :device_id]
+      )
+
+      # GREATEST bump in one statement so concurrent pulls can't regress it.
+      Repo.query!(
+        "UPDATE vault_device_cursors SET last_seq = GREATEST(last_seq, $3), last_seen_at = $4 WHERE vault_id = $1 AND device_id = $2",
+        [Ecto.UUID.dump!(vault.id), device_id, seq, now]
+      )
+    end)
+
+    :ok
+  end
+
+  defdelegate child_spec(opts), to: Engram.Sync.DeviceCursor, as: :__struct__
+end
+```
+> Drop the bogus `defdelegate` line — included only to flag: do NOT add one. The real module ends after `record_cursor`. Expose `Engram.Sync.DeviceCursor` via `alias` in tests as `Sync.DeviceCursor` (add `alias Engram.Sync.DeviceCursor` re-export or reference the full module in tests).
+
+> Implementation note: the insert_all-then-update is a clean upsert-with-GREATEST. If simpler, do a single `INSERT ... ON CONFLICT DO UPDATE SET last_seq = GREATEST(...), last_seen_at = ...` via `Repo.query!`. Pick the clearer one; the contract is the 3 tests.
+
+- [ ] **Step 5: Run — PASS.** `mix test test/engram/sync_test.exs`
+
+- [ ] **Step 6: Commit**
+```bash
+git add lib/engram/sync.ex lib/engram/sync/device_cursor.ex test/engram/sync_test.exs
+git commit -m "feat(sync): Engram.Sync cursor codec + device watermark"
+```
+
+---
+
+### Task 4: `Notes.list_changes_by_seq/3` — keyset seq feed
+
+**Files:** Modify `lib/engram/notes.ex`. Test: `test/engram/notes_seq_feed_test.exs`.
+
+> Mirror `list_changes_page/4` (notes.ex:1496-1557) but: filter `seq > cursor` keyed on `(seq, id)`; include ALL kinds (notes + folders) and tombstones (NO `deleted_at` filter, NO `kind == "note"` filter) — the feed must carry deletes/renames/folder ops. Reuse `change_map/1` + `@note_meta_fields`.
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule Engram.NotesSeqFeedTest do
+  use Engram.DataCase, async: true
+  alias Engram.{Notes, Vaults}
+
+  setup do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+    %{user: user, vault: vault}
+  end
+
+  test "returns rows with seq > cursor in (seq,id) order, includes tombstones", %{user: user, vault: vault} do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "A"})
+    {:ok, b} = Notes.upsert_note(user, vault, %{"path" => "b.md", "content" => "B"})
+    :ok = Notes.delete_note(user, vault, "a.md")  # tombstone, new seq
+
+    {:ok, %{changes: all}} = Notes.list_changes_by_seq(user, vault, 0)
+    # a (deleted) + b both present; the delete carries deleted: true
+    assert Enum.any?(all, &(&1.path == "a.md" and &1.deleted))
+    assert Enum.any?(all, &(&1.path == "b.md" and not &1.deleted))
+    # seq strictly increasing
+    seqs = Enum.map(all, & &1.seq)
+    assert seqs == Enum.sort(seqs)
+
+    # cursor past b's seq returns nothing newer (no later writes)
+    last_seq = List.last(all).seq
+    {:ok, %{changes: []}} = Notes.list_changes_by_seq(user, vault, last_seq, after_id: List.last(all).id)
+  end
+
+  test "paginates with limit + has_more", %{user: user, vault: vault} do
+    for i <- 1..3, do: Notes.upsert_note(user, vault, %{"path" => "n#{i}.md", "content" => "x"})
+    {:ok, p1} = Notes.list_changes_by_seq(user, vault, 0, limit: 2)
+    assert length(p1.changes) == 2 and p1.has_more
+    {c, i} = p1.next
+    {:ok, p2} = Notes.list_changes_by_seq(user, vault, c, after_id: i, limit: 2)
+    assert length(p2.changes) == 1 and not p2.has_more
+  end
+end
+```
+> The fn signature: `list_changes_by_seq(user, vault, after_seq, opts \\ [])` where opts may carry `after_id` (the keyset tiebreak), `limit`, `fields`. Returns `{:ok, %{changes: [change_map ++ %{seq:}], has_more: bool, next: {seq,id} | nil}}`. Each change_map must include `:seq`.
+
+- [ ] **Step 2: Run — FAIL.** `mix test test/engram/notes_seq_feed_test.exs`
+
+- [ ] **Step 3: Implement** in `lib/engram/notes.ex` (mirror `list_changes_page`, key on seq):
+```elixir
+@doc """
+Seq-cursor change feed: rows with `(seq, id) > (after_seq, after_id)`,
+ALL kinds + tombstones, ordered by (seq, id), paginated. Each change_map
+carries :seq. Used by the unified /sync/changes pull.
+"""
+def list_changes_by_seq(user, vault, after_seq, opts \\ []) when is_integer(after_seq) do
+  limit = opts |> Keyword.get(:limit, @changes_page_max_limit) |> min(@changes_page_max_limit) |> max(1)
+  fields = Keyword.get(opts, :fields, :all)
+  after_id = Keyword.get(opts, :after_id)
+
+  base =
+    from(n in Note,
+      where: n.user_id == ^user.id and n.vault_id == ^vault.id and not is_nil(n.seq),
+      order_by: [asc: n.seq, asc: n.id],
+      limit: ^(limit + 1)
+    )
+
+  base =
+    if after_id do
+      from n in base, where: n.seq > ^after_seq or (n.seq == ^after_seq and n.id > ^after_id)
+    else
+      from n in base, where: n.seq > ^after_seq
+    end
+
+  query =
+    case fields do
+      :meta -> from(n in base, select: struct(n, @note_meta_fields ++ [:seq]))
+      :all -> base
+    end
+
+  {:ok, rows} = Repo.with_tenant(user.id, fn -> Repo.all(query) end)
+  {page, has_more} = if length(rows) > limit, do: {Enum.take(rows, limit), true}, else: {rows, false}
+
+  changes =
+    page
+    |> decrypt_or_raise!(user)
+    |> Enum.map(fn n -> n |> change_map() |> Map.put(:seq, n.seq) end)
+
+  next = if has_more, do: (last = List.last(page); {last.seq, last.id}), else: nil
+  {:ok, %{changes: changes, has_more: has_more, next: next}}
+end
+```
+> Confirm `@note_meta_fields` includes `:id` + `:seq` (add `:seq` to it if `select: struct` needs it; the `:all` path loads the full row so seq is present). Confirm `decrypt_or_raise!` tolerates tombstones (deleted rows) — it does in `list_changes`.
+
+- [ ] **Step 4: Run — PASS.** Then `mix test test/engram/notes_test.exs test/engram/notes_changes_page_test.exs` (no regression).
+
+- [ ] **Step 5: Commit**
+```bash
+git add lib/engram/notes.ex test/engram/notes_seq_feed_test.exs
+git commit -m "feat(sync): Notes.list_changes_by_seq keyset feed"
+```
+
+---
+
+### Task 5: `Attachments.list_changes_by_seq/3` — keyset seq feed
+
+**Files:** Modify `lib/engram/attachments.ex`. Test: `test/engram/attachments_seq_feed_test.exs` (append).
+
+> Mirror Task 4 over `Attachment`. Include tombstones (no `deleted_at` filter). Reuse `decrypt_each`. Each entry carries `:seq`, `:version`, `:deleted` (`deleted_at != nil`), `:id`, `:path`, `:mime_type`, `:size_bytes`, `:mtime`, `:updated_at`.
+
+- [ ] **Step 1: Append failing test**
+```elixir
+  test "attachment seq feed returns seq>cursor incl tombstones", %{user: user, vault: vault} do
+    {:ok, a} = put(user, vault, "a.png")
+    :ok = Attachments.delete_attachment(user, vault, "a.png")
+    {:ok, %{changes: ch}} = Attachments.list_changes_by_seq(user, vault, 0)
+    assert Enum.any?(ch, &(&1.path == "a.png" and &1.deleted))
+    assert Enum.all?(ch, &is_integer(&1.seq))
+  end
+```
+
+- [ ] **Step 2: Run — FAIL.**
+
+- [ ] **Step 3: Implement** in `lib/engram/attachments.ex`:
+```elixir
+def list_changes_by_seq(user, vault, after_seq, opts \\ []) when is_integer(after_seq) do
+  user = fresh_user(user)
+  limit = opts |> Keyword.get(:limit, 500) |> min(500) |> max(1)
+  after_id = Keyword.get(opts, :after_id)
+
+  base =
+    from(a in Attachment,
+      where: a.user_id == ^user.id and a.vault_id == ^vault.id and not is_nil(a.seq),
+      order_by: [asc: a.seq, asc: a.id],
+      limit: ^(limit + 1)
+    )
+
+  base =
+    if after_id do
+      from a in base, where: a.seq > ^after_seq or (a.seq == ^after_seq and a.id > ^after_id)
+    else
+      from a in base, where: a.seq > ^after_seq
+    end
+
+  Repo.with_tenant(user.id, fn -> Repo.all(base) end)
+  |> unwrap_tenant()
+  |> case do
+    {:ok, atts} ->
+      {page, has_more} = if length(atts) > limit, do: {Enum.take(atts, limit), true}, else: {atts, false}
+
+      changes =
+        decrypt_each(page, user, fn att, meta ->
+          meta
+          |> Map.put(:id, att.id)
+          |> Map.put(:seq, att.seq)
+          |> Map.put(:version, att.version)
+          |> Map.put(:deleted, not is_nil(att.deleted_at))
+          |> Map.delete(:deleted_at)
+        end)
+
+      next = if has_more, do: (l = List.last(page); {l.seq, l.id}), else: nil
+      {:ok, %{changes: changes, has_more: has_more, next: next}}
+
+    err ->
+      err
+  end
+end
+```
+
+- [ ] **Step 4: Run — PASS.** Then `mix test test/engram/attachments_test.exs`.
+
+- [ ] **Step 5: Commit**
+```bash
+git add lib/engram/attachments.ex test/engram/attachments_seq_feed_test.exs
+git commit -m "feat(sync): Attachments.list_changes_by_seq keyset feed"
+```
+
+---
+
+### Task 6: Unified pull endpoint `GET /sync/changes`
+
+**Files:** Modify `lib/engram_web/controllers/sync_controller.ex`, `lib/engram_web/router.ex`. Test: `test/engram_web/controllers/sync_changes_test.exs`.
+
+> Merge the two per-table seq feeds by `(seq, id)` (seqs are globally unique per vault, so the union is well-ordered), page to `limit`, tag each entry `type: "note"|"attachment"`, return `next_cursor` (opaque) + `has_more`, and record the device watermark from the *incoming* cursor (pull-carries-ack). HISTORY_EXPIRED check uses `Sync.retention_floor` (0 → never fires).
+
+- [ ] **Step 1: Write the failing test**
+```elixir
+defmodule EngramWeb.SyncChangesTest do
+  use EngramWeb.ConnCase, async: true
+  alias Engram.{Notes, Attachments}
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    vault = insert(:vault, user: user, is_default: true)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "k")
+    grant_api_write!(user)
+    authed = conn |> put_req_header("authorization", "Bearer #{api_key}") |> put_req_header("x-device-id", "dev-1")
+    %{conn: authed, user: user, vault: vault}
+  end
+
+  test "pulls notes+attachments merged by seq, paginates, records watermark", %{conn: conn, user: user, vault: vault} do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n1.md", "content" => "x"})
+    {:ok, _} = Attachments.upsert_attachment(user, vault, %{"path" => "a.png", "content_base64" => Base.encode64("p"), "mime_type" => "image/png"})
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n2.md", "content" => "y"})
+
+    p1 = conn |> get(~p"/api/sync/changes?limit=2") |> json_response(200)
+    assert length(p1["changes"]) == 2
+    assert p1["has_more"] == true
+    assert Enum.all?(p1["changes"], &(&1["type"] in ["note", "attachment"]))
+    # strictly increasing seq across the merged page
+    seqs = Enum.map(p1["changes"], & &1["seq"])
+    assert seqs == Enum.sort(seqs)
+
+    p2 = conn |> get(~p"/api/sync/changes?cursor=#{p1["next_cursor"]}&limit=2") |> json_response(200)
+    assert length(p2["changes"]) == 1 and p2["has_more"] == false
+
+    # watermark recorded for dev-1
+    {:ok, row} = Engram.Repo.with_tenant(user.id, fn -> Engram.Repo.get_by(Engram.Sync.DeviceCursor, vault_id: vault.id, device_id: "dev-1") end)
+    assert row.last_seq >= 1
+  end
+
+  test "malformed cursor -> 400", %{conn: conn} do
+    assert conn |> get(~p"/api/sync/changes?cursor=%%%bad") |> json_response(400)
+  end
+end
+```
+
+- [ ] **Step 2: Run — FAIL** (route missing). `mix test test/engram_web/controllers/sync_changes_test.exs`
+
+- [ ] **Step 3: Route** — `lib/engram_web/router.ex`, next to `get "/sync/manifest"`:
+```elixir
+    get "/sync/changes", SyncController, :changes
+```
+
+- [ ] **Step 4: Read `X-Device-Id`** — simplest is in the controller (no new plug). In `SyncController.changes`, `device_id = conn |> get_req_header("x-device-id") |> List.first()`.
+
+- [ ] **Step 5: Implement `changes/2`** in `lib/engram_web/controllers/sync_controller.ex`:
+```elixir
+def changes(conn, params) do
+  user = conn.assigns.current_user
+  vault = conn.assigns.current_vault
+  device_id = conn |> get_req_header("x-device-id") |> List.first()
+  limit = parse_limit(params["limit"])
+
+  with {:ok, cursor} <- Engram.Sync.decode_cursor(params["cursor"]) do
+    {after_seq, after_id} = cursor || {0, nil}
+
+    if after_seq < Engram.Sync.retention_floor(vault) do
+      conn |> put_status(410) |> json(%{error: "history_expired"})
+    else
+      {:ok, %{changes: notes, has_more: nm}} =
+        Engram.Notes.list_changes_by_seq(user, vault, after_seq, after_id: after_id, limit: limit + 1)
+
+      {:ok, %{changes: atts, has_more: am}} =
+        Engram.Attachments.list_changes_by_seq(user, vault, after_seq, after_id: after_id, limit: limit + 1)
+
+      merged =
+        ((notes |> Enum.map(&Map.put(&1, :type, "note"))) ++
+           (atts |> Enum.map(&Map.put(&1, :type, "attachment"))))
+        |> Enum.sort_by(&{&1.seq, &1.id})
+
+      {page, has_more} =
+        if length(merged) > limit, do: {Enum.take(merged, limit), true}, else: {merged, nm or am}
+
+      next_cursor =
+        if has_more do
+          last = List.last(page)
+          Engram.Sync.encode_cursor(last.seq, last.id)
+        end
+
+      # pull-carries-ack: the cursor the client sent = what it durably applied.
+      :ok = Engram.Sync.record_cursor(user, vault, device_id, after_seq)
+
+      json(conn, %{changes: Enum.map(page, &change_json/1), next_cursor: next_cursor, has_more: has_more})
+    end
+  else
+    {:error, :invalid_cursor} -> conn |> put_status(400) |> json(%{error: "invalid_cursor"})
+  end
+end
+
+defp parse_limit(nil), do: 500
+defp parse_limit(s) when is_binary(s) do
+  case Integer.parse(s) do
+    {n, ""} when n > 0 -> min(n, 1000)
+    _ -> 500
+  end
+end
+
+defp change_json(c), do: Map.update(c, :id, nil, & &1)  # already a plain map; serialize keys as-is
+```
+> `change_json/1`: the merged entries are plain maps (note change_map + :seq + :type; attachment meta + :seq + :version + :type). Phoenix JSON-encodes maps directly, so `Enum.map(page, & &1)` suffices — drop the `change_json` indirection if not needed. Ensure note vs attachment maps both carry the keys the client needs (notes: path/title/folder/tags/version/content_hash/content/deleted/seq/type; attachments: path/mime_type/size_bytes/mtime/version/deleted/seq/type). Content for notes follows the existing dual-field; for B1 default to `:all` or honor a `fields` param — keep parity with the timestamp feed (default `:all`).
+>
+> **Merge-pagination correctness:** fetching `limit+1` from EACH table then merging + taking `limit` is correct for `has_more` (if either had more, or the merged total exceeds limit). Verify the `has_more` logic against the test (3 items, limit 2 → page 2 then 1).
+
+- [ ] **Step 6: Run — PASS.** `mix test test/engram_web/controllers/sync_changes_test.exs`
+
+- [ ] **Step 7: Commit**
+```bash
+git add lib/engram_web/controllers/sync_controller.ex lib/engram_web/router.ex test/engram_web/controllers/sync_changes_test.exs
+git commit -m "feat(sync): GET /sync/changes unified keyset cursor pull"
+```
+
+---
+
+### Task 7: Expose `change_seq` for bootstrap (manifest)
+
+**Files:** Modify `lib/engram/vaults.ex`, `lib/engram_web/controllers/sync_controller.ex`. Test: `test/engram_web/controllers/sync_changes_test.exs` (append) or a manifest test.
+
+> A bootstrapping client needs the vault's current `change_seq` so it can set its cursor to "everything ≤ S" after applying the manifest. Add it to the existing `/sync/manifest` response.
+
+- [ ] **Step 1: Append failing test**
+```elixir
+  test "manifest includes current change_seq", %{conn: conn, user: user, vault: vault} do
+    {:ok, _} = Engram.Notes.upsert_note(user, vault, %{"path" => "n.md", "content" => "x"})
+    body = conn |> get(~p"/api/sync/manifest") |> json_response(200)
+    assert is_integer(body["change_seq"])
+    assert body["change_seq"] >= 1
+  end
+```
+
+- [ ] **Step 2: Run — FAIL.**
+
+- [ ] **Step 3: `Vaults.current_seq/1`** in `lib/engram/vaults.ex`:
+```elixir
+@doc "Reads the vault's current change_seq watermark (read-only)."
+def current_seq(vault_id) do
+  %{rows: [[seq]]} = Repo.query!("SELECT change_seq FROM vaults WHERE id = $1", [Ecto.UUID.dump!(vault_id)])
+  seq
+end
+```
+
+- [ ] **Step 4:** In `SyncController.render_manifest` (and `render_empty_manifest`), add `change_seq: Engram.Vaults.current_seq(vault.id)` to the JSON (empty manifest → `change_seq: 0` or the real value; the real value is fine).
+
+- [ ] **Step 5: Run — PASS.**
+
+- [ ] **Step 6: Commit**
+```bash
+git add lib/engram/vaults.ex lib/engram_web/controllers/sync_controller.ex test/engram_web/controllers/sync_changes_test.exs
+git commit -m "feat(sync): expose change_seq in manifest for bootstrap"
+```
+
+---
+
+### Task 8: Full suite green + version bump
+
+- [ ] **Step 1:** `mix test` — all green. Root-cause any failure (don't skip). A likely one: `@note_meta_fields` missing `:seq` for the `:meta` select — fix by adding `:seq` to that module attr.
+- [ ] **Step 2:** Bump `mix.exs` version once (patch +1 over current main — **check `git show origin/main:mix.exs | grep version` at the time and pick strictly greater**, since main moves).
+- [ ] **Step 3:** Commit `chore: bump version for cursor-pull backend (PR B1)`.
+
+---
+
+## Self-review
+
+**Spec coverage (B1 = backend rollout step):** `device_id` header read (Task 6) ✅ · `vault_device_cursors` (Tasks 1,3) ✅ · keyset pull (Tasks 4,5,6) ✅ · pull-carries-ack watermark (Tasks 3,6) ✅ · bootstrap `change_seq` (Task 7) ✅ · `HISTORY_EXPIRED` dormant (Task 6, floor=0) ✅ · attachment `version` (Tasks 1,2) ✅ · perf #5 partial index / #4 batch-coalesce — **NOT in this plan; fold into a follow-up task or B-D** (flagged, not silently dropped). Manifest-authoritative reconcile + plugin/web = B2/B3.
+
+**Placeholder scan:** Two intentional "do NOT add this" markers (the bogus `defdelegate` in Task 3, the `change_json` indirection in Task 6) are called out explicitly with the correct alternative — not placeholders. No TBD/TODO.
+
+**Type consistency:** `list_changes_by_seq(user, vault, after_seq, opts)` returns `%{changes, has_more, next}` in both Notes + Attachments. `Engram.Sync.{encode_cursor/2, decode_cursor/1, record_cursor/4, retention_floor/1}` + `Engram.Sync.DeviceCursor` referenced consistently. Cursor token is `<seq>:<id>` base64 everywhere.
+
+**Deferred (flagged):** perf #4/#5; attachment 409-on-stale-version (push-path, B2/B3); the merge-pagination `has_more` edge — verify against Task 6's test before trusting.

--- a/docs/superpowers/specs/2026-06-16-sync-cursor-pull-design.md
+++ b/docs/superpowers/specs/2026-06-16-sync-cursor-pull-design.md
@@ -1,0 +1,186 @@
+# Ordered Cursor Sync — device cursors + keyset pull + snapshot bootstrap + client migration
+
+**Date:** 2026-06-16
+**Status:** Design — approved for planning
+**Repos:** `engram` (backend + `frontend/`) and `engram-obsidian-sync` (plugin)
+**Branch:** `feat/sync-cursor-pull` (engram) + paired plugin branch
+**Builds on:** PR A (merged, #622, `2b770e80`) — the `seq` substrate.
+**Implements:** the spec's rollout steps **B + C + client migration**, framed as one
+feature (the backbone is useless until something reads `seq`). See the parent
+design `docs/superpowers/specs/2026-06-16-sync-change-log-backbone-design.md` for
+the full model + the consistency-model decision — not repeated here.
+
+## Problem
+
+PR A stamps a per-vault monotonic `seq` on every write, but **nothing reads it** —
+the timestamp `/changes?since` feed is still primary, with all its holes (no total
+order, rename resurrection, no month-stale convergence). This feature makes the
+ordered log *readable and authoritative*: a per-device cursor pull (`seq > cursor`)
+plus a snapshot bootstrap, and migrates the plugin + web to use them. That delivers
+ordered, convergent multi-device sync — the original goal.
+
+## Decisions (locked during brainstorming)
+
+1. **`device_id` = a random per-install UUID**, minted + persisted by each client
+   (plugin data / web localStorage), sent via an `X-Device-Id` header. **NOT** the
+   plugin's existing `clientId` — that is a SHA-256 of the vault *path* (`plugin/
+   src/main.ts:46`), so two devices sharing a path collide; it's a vault-location
+   key, not a device key. A reset/reinstall → new `device_id` → one clean
+   re-bootstrap (safe).
+2. **Stateless cursor, opaque token, pull-carries-ack.** The client owns its
+   position (it alone knows what it durably applied) and sends an opaque cursor
+   token (base64 of `seq:id`) each pull; the server is a pure function
+   `(cursor) → page`. The token a client sends *is* its ack ("applied up to here"),
+   so the server updates the device's watermark from it. No separate ack endpoint.
+3. **Wipe + re-sync pre-launch** — no backfill. Dropping/recreating DBs re-stamps
+   `seq` on every row via the normal write path, so legacy `seq IS NULL` rows never
+   reach the cursor pull. (#623 backfill is therefore unneeded for launch.)
+4. **One feature, sequenced PRs** — backend (cursor + bootstrap) → plugin → web.
+   The timestamp feed stays primary until a later PR retires it (rollout step E).
+5. **Manifest-authoritative bootstrap with a three-way reconcile** (closes the
+   "local-only → re-push/resurrect" weakness — see §F).
+6. **Attachment `version` column** added for resurrection-parity with notes.
+
+## Non-goals
+
+- **Compaction / GC** (rollout step D) — `vault_device_cursors` records the
+  watermark this feature needs, but the low-water-mark Oban job is a later PR.
+  `HISTORY_EXPIRED` ships wired but **dormant** (no compaction yet → never fires).
+- **Retiring the timestamp feed** (step E) — coexists here.
+- Version vectors / CRDT / P2P (settled in the parent spec).
+
+## Architecture
+
+### A. `device_id`
+- Plugin: mint `crypto.randomUUID()` once, persist in plugin data (new field,
+  *separate* from `clientId`), send `X-Device-Id` on cursor pull. Mobile + desktop
+  each get their own.
+- Web: mint + persist a UUID in `localStorage`, send the same header.
+- Backend: read the header in the vault-scoped pipeline; absent/blank → the pull
+  still works (stateless) but no watermark row is written (a watermark needs a
+  device to attribute to). Treat a missing `device_id` as a soft degrade, logged.
+
+### B. `vault_device_cursors` (Postgres, RLS-scoped)
+```sql
+CREATE TABLE vault_device_cursors (
+  vault_id     uuid        NOT NULL REFERENCES vaults(id),
+  device_id    text        NOT NULL,
+  last_seq     bigint      NOT NULL DEFAULT 0,
+  last_seen_at timestamptz NOT NULL,
+  PRIMARY KEY (vault_id, device_id)
+);
+```
+Updated as a **side effect** of a pull (upsert `last_seq` from the incoming
+cursor's seq, `last_seen_at = now()`). It is the GC-watermark + eviction record —
+**never** the pagination source of truth (that's the client's token). `phase/expand`.
+
+### C. Keyset pull
+`GET /changes?cursor=<token>` (or no token → bootstrap, §E):
+```sql
+-- token decodes to (cursor_seq, cursor_id)
+SELECT ... FROM notes
+WHERE vault_id = $1 AND (seq, id) > ($cursor_seq, $cursor_id)
+ORDER BY seq, id LIMIT $page
+-- UNION the same over attachments; merge + sort by (seq,id); page across both
+```
+- Uses the existing `(vault_id, seq, id)` index (PR A) — index-ordered, no sort.
+- **Tombstones included** (`deleted_at IS NOT NULL`) so deletes/renames propagate.
+- Response: the page of rows (same dual-field metadata/content shape as today's
+  feed) + a `next_cursor` token (the `(seq,id)` of the last row) + `has_more`.
+- The dual-field payload (metadata-only vs +content) from `/changes` is preserved.
+
+### D. Pull-carries-ack (watermark)
+The incoming `cursor` token = "I have durably applied up to `(seq,id)`." On each
+pull the server upserts `vault_device_cursors(last_seq = cursor_seq,
+last_seen_at = now())`. The watermark therefore reflects **confirmed-applied**
+state — compaction (PR D) can safely GC `seq <= min(last_seq)`. No ack endpoint.
+
+### E. Snapshot bootstrap + `HISTORY_EXPIRED`
+- **No cursor token** (new/reset device) → the client fetches the existing
+  **manifest** (full path inventory, computed on-demand) + the vault's current
+  `change_seq`, runs the three-way reconcile (§F), then sets its cursor to
+  `(change_seq, MAX_UUID)` so the first incremental pull returns only `seq >
+  change_seq`.
+- **`HISTORY_EXPIRED`** — if an incoming `cursor_seq` is below the retention floor
+  (oldest retained tombstone's seq; **0 until PR D compacts** → never fires yet),
+  the pull returns `410 HISTORY_EXPIRED` → the client re-bootstraps. Shipping the
+  response + handling now lets PR D turn on compaction without a client change.
+
+### F. Manifest-authoritative three-way reconcile (the convergence fix)
+On bootstrap the manifest is server truth, but a client may hold local files +
+offline edits. Using the persisted **syncState baseline** (plugin already keeps
+last-synced hashes per path) disambiguates the four cases:
+- in manifest, not local → **pull**
+- in local + manifest → content-compare → pull / 3-way-merge conflict (existing)
+- in local, not manifest, **in baseline** → server-deleted → **delete local**
+- in local, not manifest, **not in baseline** → created locally offline → **push**
+
+This is the canonical fix for today's "local-only → always push" (which resurrects
+server-deleted files). The web has no offline-edit story, so its bootstrap is the
+simpler "manifest is truth, render it" case.
+
+### G. Attachment `version` column
+Add `version integer NOT NULL DEFAULT 1` to `attachments` (`phase/expand`) +
+bump it on write, mirroring notes' optimistic-concurrency/resurrection-safety.
+Wire the 409-on-stale-version path for attachment writes.
+
+### H. Coexistence
+The cursor pull is **additive** beside `/changes?since`. A client migrates by
+switching its sync loop to the cursor pull + bootstrap; an un-migrated client keeps
+using the timestamp feed. Both read the same rows. The real-time socket
+(`sync:<user>:<vault>`) stays a latency accelerator; the durable cursor feed is
+truth, so a reconnecting client always converges via pull.
+
+## Data flow (incremental pull)
+```
+client (has cursor token T = (seq,id) it last applied)
+  GET /changes?cursor=T   + X-Device-Id: <uuid>
+        ▼
+server: rows WHERE (seq,id) > T ORDER BY seq,id LIMIT p   (notes ∪ attachments, incl. tombstones)
+        upsert vault_device_cursors(last_seq=T.seq, last_seen_at=now)   ← watermark/ack
+        ▼
+  → { rows, next_cursor, has_more }
+client: apply rows in (seq,id) order (tombstone→trash, else write); persist next_cursor; repeat until !has_more
+```
+
+## Error handling / edge cases
+- **Opaque token tampering / malformed** → 400; client falls back to bootstrap.
+- **`device_id` rotation** (reinstall/reset) → new id → no cursor row → bootstrap.
+- **Concurrent pulls from one device** → stateless + idempotent; both return pages
+  for their sent cursor; watermark upsert is last-writer (monotonic via `GREATEST`
+  to avoid a lagging pull regressing the watermark).
+- **Shared-seq page boundary** → `(seq,id)` keyset handles ties (no drop/dup).
+- **`HISTORY_EXPIRED`** dormant until PR D; handler exists so D is a no-client-change flip.
+- **Manifest + offline local edits** → the §F baseline disambiguation prevents
+  deleting offline-created files.
+
+## Rollout / PR structure (sequenced; one spec)
+- **PR B1 — backend**: `attachment.version` + `vault_device_cursors` + keyset pull
+  + bootstrap/`HISTORY_EXPIRED` + watermark-on-pull. API-tested. Folds perf
+  deferrals **#5** (partial index `(vault_id, seq) WHERE deleted_at IS NOT NULL`)
+  and **#4** (coalesce batch-update `vaults` writes via one `+N RETURNING`).
+- **PR B2 — plugin**: mint `device_id`; switch the sync loop to cursor pull;
+  manifest-authoritative three-way bootstrap; `HISTORY_EXPIRED` handling.
+- **PR B3 — web**: mint `device_id`; cursor pull; manifest bootstrap.
+Each engram PR: one `phase/*` label, one `mix.exs` bump. Plugin PR: one manifest bump.
+
+## Testing
+**Backend (`mix test`):** keyset pull correctness (ties across page boundary;
+notes∪attachments interleave by `(seq,id)`; tombstones surfaced); opaque token
+round-trip + tamper→400; watermark upsert monotonic (`GREATEST`); bootstrap returns
+manifest + current change_seq; `HISTORY_EXPIRED` boundary (floor=0 → never fires);
+attachment `version` bump + 409-on-stale; tenant isolation on `vault_device_cursors`.
+**Plugin (`bun test`):** device_id mint/persist; cursor advance + resume; the §F
+three-way reconcile (the four cases — esp. server-deleted→delete-local and
+offline-created→push); `HISTORY_EXPIRED`→re-bootstrap.
+**E2E (`make e2e`, paired plugin branch):** two devices converge over the cursor
+pull; a device offline across rename+delete+create reconnects and converges with
+**no duplicate / no resurrection / no lost delete** (the headline win); a
+server-side folder rename propagates both renamed rows + tombstones in one ordered
+pull.
+
+## Prerequisites / follow-ups
+- **Pre-launch DB wipe** before this ships (re-stamps `seq`); #623 backfill then unneeded.
+- **PR D (compaction)** turns on `HISTORY_EXPIRED` + bounds tombstones — next after this.
+- **PR E** retires the timestamp feed once all clients are migrated.
+- **#608** attachment actions resumes on top of this (move/delete become ordered feed entries).

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -349,6 +349,79 @@ defmodule Engram.Attachments do
   end
 
   @doc """
+  Seq-cursor change feed over attachments: rows with `(seq, id) > (after_seq,
+  after_id)`, ordered by `(seq, id)`, paginated. Mirrors
+  `Engram.Notes.list_changes_by_seq/4`.
+
+  Carries the FULL change set — tombstones included (no `deleted_at` filter) so
+  deletes flow through the unified `/sync/changes` pull. Per-vault `seq` is
+  monotonic and unique, so `(seq, id)` is a stable keyset that never loses or
+  duplicates rows across pages.
+
+  Options:
+
+    * `after_id:` — the keyset tiebreak id from the previous page's `next`
+      (the `id` component); required to resume mid-`seq`, harmless otherwise.
+    * `limit:` — page size, clamped to 1..500 (default 500).
+
+  Each change entry carries `:id`, `:seq`, `:version`, `:deleted`
+  (`deleted_at != nil`), plus `:path`, `:mime_type`, `:size_bytes`, `:mtime`,
+  `:updated_at`. Returns
+  `{:ok, %{changes: [...], has_more: bool, next: {seq, id} | nil}}`.
+  """
+  @spec list_changes_by_seq(map(), map(), integer(), keyword()) ::
+          {:ok, %{changes: [map()], has_more: boolean(), next: {integer(), binary()} | nil}}
+          | {:error, term()}
+  def list_changes_by_seq(user, vault, after_seq, opts \\ []) when is_integer(after_seq) do
+    user = fresh_user(user)
+    limit = opts |> Keyword.get(:limit, 500) |> min(500) |> max(1)
+    after_id = Keyword.get(opts, :after_id)
+
+    base =
+      from(a in Attachment,
+        where: a.user_id == ^user.id and a.vault_id == ^vault.id and not is_nil(a.seq),
+        order_by: [asc: a.seq, asc: a.id],
+        limit: ^(limit + 1)
+      )
+
+    base =
+      if after_id do
+        from(a in base, where: a.seq > ^after_seq or (a.seq == ^after_seq and a.id > ^after_id))
+      else
+        from(a in base, where: a.seq > ^after_seq)
+      end
+
+    Repo.with_tenant(user.id, fn -> Repo.all(base) end)
+    |> unwrap_tenant()
+    |> case do
+      {:ok, atts} ->
+        {page, has_more} =
+          if length(atts) > limit, do: {Enum.take(atts, limit), true}, else: {atts, false}
+
+        changes =
+          decrypt_each(page, user, fn att, meta ->
+            meta
+            |> Map.put(:id, att.id)
+            |> Map.put(:seq, att.seq)
+            |> Map.put(:version, att.version)
+            |> Map.put(:deleted, not is_nil(att.deleted_at))
+            |> Map.delete(:deleted_at)
+          end)
+
+        next =
+          if has_more do
+            last = List.last(page)
+            {last.seq, last.id}
+          end
+
+        {:ok, %{changes: changes, has_more: has_more, next: next}}
+
+      err ->
+        err
+    end
+  end
+
+  @doc """
   Returns storage usage for a vault: total bytes and file count.
   """
   def storage_usage(user, vault) do

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -134,8 +134,17 @@ defmodule Engram.Attachments do
     Repo.with_tenant(user.id, fn ->
       # Sync backbone: stamp a monotonic seq inside the same tenant txn so the
       # bump and the row write commit atomically. Applies to insert + update.
+      # version mirrors notes.version for resurrection parity: an update sets
+      # existing.version + 1; an insert leaves the schema default (1) untouched.
       changeset_attrs =
-        Map.put(changeset_attrs, :seq, Engram.Vaults.next_seq!(changeset_attrs.vault_id))
+        changeset_attrs
+        |> Map.put(:seq, Engram.Vaults.next_seq!(changeset_attrs.vault_id))
+        |> then(fn attrs ->
+          case existing do
+            %Attachment{version: v} -> Map.put(attrs, :version, v + 1)
+            _ -> attrs
+          end
+        end)
 
       case existing do
         nil ->

--- a/lib/engram/attachments/attachment.ex
+++ b/lib/engram/attachments/attachment.ex
@@ -24,6 +24,10 @@ defmodule Engram.Attachments.Attachment do
     field :deleted_at, :utc_datetime
     # Sync change-log seq (monotonic per vault). Stamped on every write.
     field :seq, :integer
+    # Sync resurrection-parity counter (mirrors notes.version). Starts at 1 on
+    # insert, +1 on every content update. NOT bumped on soft-delete — deletes
+    # are conveyed by the `deleted_at` tombstone, not version.
+    field :version, :integer, default: 1
     field :encryption_version, :integer, default: 1
     # T3.4 / H5 — DEK version this row's ciphertext was wrapped under.
     field :dek_version, :integer, default: 1
@@ -52,6 +56,7 @@ defmodule Engram.Attachments.Attachment do
       :storage_key,
       :deleted_at,
       :seq,
+      :version,
       :encryption_version,
       :dek_version,
       :dek_version_pending,

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1413,6 +1413,7 @@ defmodule Engram.Notes do
   # phase-4 helpers short-circuit per-field on nil ciphertext).
   @note_meta_fields [
     :id,
+    :seq,
     :version,
     :kind,
     :dek_version,
@@ -1554,6 +1555,84 @@ defmodule Engram.Notes do
 
       {:ok, %{changes: changes, has_more: has_more, next_cursor: next_cursor}}
     end
+  end
+
+  @doc """
+  Seq-cursor change feed: rows with `(seq, id) > (after_seq, after_id)`,
+  ordered by `(seq, id)`, paginated.
+
+  Unlike `list_changes_page/4` (the timestamp feed) this carries the FULL
+  change set: ALL kinds (notes + folder markers) and tombstones (no
+  `deleted_at` filter, no `kind == "note"` filter) so deletes / renames /
+  folder ops all flow through the unified `/sync/changes` pull. Per-vault
+  `seq` is monotonic and unique, so `(seq, id)` is a stable keyset that never
+  loses or duplicates rows across pages.
+
+  Options:
+
+    * `after_id:` — the keyset tiebreak id from the previous page's `next`
+      (the `id` component); required to resume mid-`seq`, harmless otherwise.
+    * `limit:` — page size, clamped to 1..#{@changes_page_max_limit}
+      (default #{@changes_page_max_limit}).
+    * `fields: :meta` — skip the content column + its decrypt; entries carry
+      `content_hash` and `content: nil`.
+
+  Each change_map carries an extra `:seq` key. Returns
+  `{:ok, %{changes: [...], has_more: bool, next: {seq, id} | nil}}`.
+  """
+  @spec list_changes_by_seq(map(), map(), integer(), keyword()) ::
+          {:ok, %{changes: [map()], has_more: boolean(), next: {integer(), binary()} | nil}}
+  def list_changes_by_seq(user, vault, after_seq, opts \\ []) when is_integer(after_seq) do
+    limit =
+      opts
+      |> Keyword.get(:limit, @changes_page_max_limit)
+      |> min(@changes_page_max_limit)
+      |> max(1)
+
+    fields = Keyword.get(opts, :fields, :all)
+    after_id = Keyword.get(opts, :after_id)
+
+    base =
+      from(n in Note,
+        where: n.user_id == ^user.id and n.vault_id == ^vault.id and not is_nil(n.seq),
+        order_by: [asc: n.seq, asc: n.id],
+        limit: ^(limit + 1)
+      )
+
+    base =
+      if after_id do
+        from(n in base, where: n.seq > ^after_seq or (n.seq == ^after_seq and n.id > ^after_id))
+      else
+        from(n in base, where: n.seq > ^after_seq)
+      end
+
+    query =
+      case fields do
+        :meta -> from(n in base, select: struct(n, @note_meta_fields))
+        :all -> base
+      end
+
+    {:ok, notes} = Repo.with_tenant(user.id, fn -> Repo.all(query) end)
+
+    {page, has_more} =
+      if length(notes) > limit do
+        {Enum.take(notes, limit), true}
+      else
+        {notes, false}
+      end
+
+    changes =
+      page
+      |> decrypt_or_raise!(user)
+      |> Enum.map(fn note -> note |> change_map() |> Map.put(:seq, note.seq) end)
+
+    next =
+      if has_more do
+        last = List.last(page)
+        {last.seq, last.id}
+      end
+
+    {:ok, %{changes: changes, has_more: has_more, next: next}}
   end
 
   defp change_map(note) do

--- a/lib/engram/sync.ex
+++ b/lib/engram/sync.ex
@@ -1,0 +1,71 @@
+defmodule Engram.Sync do
+  @moduledoc """
+  Ordered change-log sync: opaque (seq,id) cursor codec + per-device
+  watermark recording (the GC/eviction record; NOT the pagination source
+  of truth — clients hold their own position).
+  """
+  alias Engram.Repo
+
+  @doc "Opaque cursor token = url-safe base64 of `<seq>:<id>`."
+  def encode_cursor(seq, id) when is_integer(seq) and is_binary(id),
+    do: Base.url_encode64("#{seq}:#{id}", padding: false)
+
+  @doc """
+  Decodes an opaque cursor back to `{seq, id}`. `nil` decodes to `{:ok, nil}`
+  (a first-pull / no-cursor request); anything malformed is
+  `{:error, :invalid_cursor}` so callers can 400 rather than crash.
+  """
+  def decode_cursor(nil), do: {:ok, nil}
+
+  def decode_cursor(tok) when is_binary(tok) do
+    with {:ok, raw} <- Base.url_decode64(tok, padding: false),
+         [seq_str, id_str] <- String.split(raw, ":", parts: 2),
+         {seq, ""} <- Integer.parse(seq_str),
+         {:ok, id} <- Ecto.UUID.cast(id_str) do
+      {:ok, {seq, id}}
+    else
+      _ -> {:error, :invalid_cursor}
+    end
+  end
+
+  def decode_cursor(_), do: {:error, :invalid_cursor}
+
+  @doc "Retention floor for HISTORY_EXPIRED. 0 until PR D (compaction) lands."
+  def retention_floor(_vault), do: 0
+
+  @doc """
+  Records a device's confirmed-applied watermark (pull-carries-ack).
+
+  Monotonic via `GREATEST` so a lagging/out-of-order pull never regresses
+  the stored `last_seq`. No-op when `device_id` is nil/blank (e.g. a
+  legacy client that doesn't send one).
+
+  Single `INSERT ... ON CONFLICT DO UPDATE` so concurrent pulls for the
+  same (vault, device) can't interleave an insert + a stale update.
+  Runs inside `Repo.with_tenant/2` so the write executes as `engram_app`
+  with the tenant context set. The table is not under RLS (it's a
+  GC/eviction record, not tenant-row-policy data), but `with_tenant`
+  keeps the role/connection discipline consistent with every other write.
+  """
+  def record_cursor(_user, _vault, device_id, _seq) when device_id in [nil, ""], do: :ok
+
+  def record_cursor(user, vault, device_id, seq) when is_integer(seq) do
+    now = DateTime.utc_now(:second)
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.query!(
+          """
+          INSERT INTO vault_device_cursors (vault_id, device_id, last_seq, last_seen_at)
+          VALUES ($1, $2, $3, $4)
+          ON CONFLICT (vault_id, device_id) DO UPDATE
+            SET last_seq = GREATEST(vault_device_cursors.last_seq, EXCLUDED.last_seq),
+                last_seen_at = EXCLUDED.last_seen_at
+          """,
+          [Ecto.UUID.dump!(vault.id), device_id, seq, now]
+        )
+      end)
+
+    :ok
+  end
+end

--- a/lib/engram/sync/device_cursor.ex
+++ b/lib/engram/sync/device_cursor.ex
@@ -1,0 +1,24 @@
+defmodule Engram.Sync.DeviceCursor do
+  @moduledoc """
+  Per-(vault, device) sync watermark — the GC/eviction record for the
+  ordered change-log. NOT the pagination source of truth; clients hold
+  their own cursor position. `last_seq` is the highest seq the device has
+  confirmed-applied (recorded via pull-carries-ack, monotonic).
+
+  The table has no surrogate `id` — its natural key is the composite
+  (vault_id, device_id), so this schema does NOT use `Engram.Schema`
+  (which would inject a UUID `id` primary key the column doesn't have).
+  """
+  use Ecto.Schema
+
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  @foreign_key_type Ecto.UUID
+  schema "vault_device_cursors" do
+    field :vault_id, Ecto.UUID, primary_key: true
+    field :device_id, :string, primary_key: true
+    field :last_seq, :integer, default: 0
+    field :last_seen_at, :utc_datetime
+  end
+end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -120,6 +120,31 @@ defmodule Engram.Vaults do
     seq
   end
 
+  @doc """
+  Reads the vault's current `change_seq` watermark (read-only).
+
+  Unlike `next_seq!/1` — which the docstring requires callers run inside
+  their own `Repo.with_tenant/2` write transaction — this is a standalone
+  read, so it sets the tenant itself. The `vaults` table is under FORCE ROW
+  LEVEL SECURITY (policy `tenant_isolation_vaults`), so a raw query without
+  `app.current_tenant` set would match zero rows. Mirrors `next_seq!/1`'s
+  raw-SQL + `Ecto.UUID.dump!/1` access idiom otherwise.
+  """
+  def current_seq(user_id, vault_id) do
+    {:ok, seq} =
+      Repo.with_tenant(user_id, fn ->
+        %{rows: [[seq]]} =
+          Repo.query!(
+            "SELECT change_seq FROM vaults WHERE id = $1",
+            [Ecto.UUID.dump!(vault_id)]
+          )
+
+        seq
+      end)
+
+    seq
+  end
+
   # ── Register (idempotent) ───────────────────────────────────────────────────
 
   @doc """

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -28,6 +28,95 @@ defmodule EngramWeb.SyncController do
     end
   end
 
+  @doc """
+  Unified ordered change-log pull. Merges the per-table seq feeds (notes +
+  attachments) into one `(seq, id)`-ordered page, tags each entry with its
+  `type`, and returns an opaque `next_cursor` + `has_more`.
+
+  Per-vault `seq` is globally unique across notes AND attachments (both draw
+  from `Vaults.next_seq!/1`), so sorting the union by `{seq, id}` is a total
+  order — no note/attachment seq collisions.
+
+  Pull-carries-ack: records the device watermark from the *incoming* cursor
+  (what the client has durably applied), NOT the new page's max seq.
+  """
+  def changes(conn, params) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+    device_id = conn |> get_req_header("x-device-id") |> List.first()
+    limit = parse_limit(params["limit"])
+
+    case Engram.Sync.decode_cursor(params["cursor"]) do
+      {:ok, cursor} ->
+        render_changes(conn, user, vault, device_id, cursor || {0, nil}, limit)
+
+      {:error, :invalid_cursor} ->
+        conn |> put_status(400) |> json(%{error: "invalid_cursor"})
+    end
+  end
+
+  defp render_changes(conn, user, vault, device_id, {after_seq, after_id}, limit) do
+    if after_seq < Engram.Sync.retention_floor(vault) do
+      conn |> put_status(410) |> json(%{error: "history_expired"})
+    else
+      # Fetch limit+1 from EACH table so the merged page can still fill
+      # `limit` even if one feed is entirely consumed within the window.
+      {:ok, %{changes: notes, has_more: notes_more}} =
+        Engram.Notes.list_changes_by_seq(user, vault, after_seq,
+          after_id: after_id,
+          limit: limit + 1
+        )
+
+      {:ok, %{changes: atts, has_more: atts_more}} =
+        Engram.Attachments.list_changes_by_seq(user, vault, after_seq,
+          after_id: after_id,
+          limit: limit + 1
+        )
+
+      merged =
+        (Enum.map(notes, &Map.put(&1, :type, "note")) ++
+           Enum.map(atts, &Map.put(&1, :type, "attachment")))
+        |> Enum.sort_by(&{&1.seq, &1.id})
+
+      {page, has_more} =
+        if length(merged) > limit do
+          {Enum.take(merged, limit), true}
+        else
+          {merged, notes_more or atts_more}
+        end
+
+      next_cursor =
+        if has_more do
+          last = List.last(page)
+          Engram.Sync.encode_cursor(last.seq, last.id)
+        end
+
+      # The cursor the client *sent* is what it has durably applied; record
+      # that as the watermark (no-op when device_id is nil/blank).
+      :ok = Engram.Sync.record_cursor(user, vault, device_id, after_seq)
+
+      json(conn, %{changes: page, next_cursor: next_cursor, has_more: has_more})
+    end
+  end
+
+  # Both seq feeds hard-cap their own page at 500 rows. The controller MUST
+  # clamp to the same ceiling: each feed is fetched with `limit + 1`, and that
+  # +1 probe is what lets the merge detect "more rows exist" and trim safely.
+  # If the controller allowed a larger limit, a feed could return its capped
+  # 500 (< limit) while more in-range rows remain, the merge would skip the
+  # trim branch, and `next_cursor` would jump past those rows — silently
+  # dropping them from the pull. Keep this in lockstep with the feed caps.
+  @max_page_limit 500
+
+  defp parse_limit(nil), do: @max_page_limit
+
+  defp parse_limit(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, ""} when n > 0 -> min(n, @max_page_limit)
+      _ -> @max_page_limit
+    end
+  end
+
   defp render_empty_manifest(conn) do
     json(conn, %{notes: [], attachments: [], total_notes: 0, total_attachments: 0})
   end

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -24,7 +24,7 @@ defmodule EngramWeb.SyncController do
     # to an empty manifest instead of crashing on `{:ok, dek}` match.
     case Crypto.get_dek(user) do
       {:ok, dek} -> render_manifest(conn, user, vault, dek)
-      {:error, :no_dek} -> render_empty_manifest(conn)
+      {:error, :no_dek} -> render_empty_manifest(conn, user, vault)
     end
   end
 
@@ -117,8 +117,14 @@ defmodule EngramWeb.SyncController do
     end
   end
 
-  defp render_empty_manifest(conn) do
-    json(conn, %{notes: [], attachments: [], total_notes: 0, total_attachments: 0})
+  defp render_empty_manifest(conn, user, vault) do
+    json(conn, %{
+      notes: [],
+      attachments: [],
+      total_notes: 0,
+      total_attachments: 0,
+      change_seq: Engram.Vaults.current_seq(user.id, vault.id)
+    })
   end
 
   defp render_manifest(conn, user, vault, dek) do
@@ -175,7 +181,8 @@ defmodule EngramWeb.SyncController do
       notes: notes,
       attachments: attachments,
       total_notes: length(notes),
-      total_attachments: length(attachments)
+      total_attachments: length(attachments),
+      change_seq: Engram.Vaults.current_seq(user.id, vault.id)
     })
   end
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -350,6 +350,7 @@ defmodule EngramWeb.Router do
 
     # Sync
     get "/sync/manifest", SyncController, :manifest
+    get "/sync/changes", SyncController, :changes
 
     # Attachments
     post "/attachments", AttachmentsController, :upload

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.451",
+      version: "0.5.452",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260616130000_cursor_pull_expand.exs
+++ b/priv/repo/migrations/20260616130000_cursor_pull_expand.exs
@@ -1,0 +1,37 @@
+defmodule Engram.Repo.Migrations.CursorPullExpand do
+  use Ecto.Migration
+
+  @moduledoc """
+  Sync cursor pull, step B1. phase/expand: purely additive.
+  - vault_device_cursors: per-(vault,device) sync watermark (GC + eviction).
+  - attachments.version: optimistic-concurrency / resurrection-safety parity
+    with notes.version (nullable->default 1; bumped on write).
+  """
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    create table(:vault_device_cursors, primary_key: false) do
+      add :vault_id, references(:vaults, type: :uuid, on_delete: :delete_all), null: false
+      add :device_id, :text, null: false
+      add :last_seq, :bigint, null: false, default: 0
+      add :last_seen_at, :utc_datetime, null: false
+    end
+
+    create unique_index(:vault_device_cursors, [:vault_id, :device_id], concurrently: true)
+
+    alter table(:attachments) do
+      add :version, :integer, null: false, default: 1
+    end
+  end
+
+  def down do
+    alter table(:attachments) do
+      remove :version
+    end
+
+    drop index(:vault_device_cursors, [:vault_id, :device_id])
+    drop table(:vault_device_cursors)
+  end
+end

--- a/priv/repo/migrations/20260616130000_cursor_pull_expand.exs
+++ b/priv/repo/migrations/20260616130000_cursor_pull_expand.exs
@@ -9,8 +9,10 @@ defmodule Engram.Repo.Migrations.CursorPullExpand do
     supplies the uniqueness + index the ON CONFLICT upsert targets, and its
     leading vault_id column covers the FK, so no separate index is needed.
   - attachments.version: optimistic-concurrency / resurrection-safety parity
-    with notes.version (nullable->default 1; bumped on write).
+    with notes.version (default 1; bumped on write). bigint to match the seq
+    counters + satisfy squawk's prefer-bigint rule.
 
+  `last_seen_at` is timestamptz (absolute instant; squawk prefer-timestamp-tz).
   Fully transactional: a new (empty) table + a metadata-only NOT NULL column
   add with a constant default (PG11+) need no CONCURRENTLY, so no
   @disable_ddl_transaction.
@@ -24,11 +26,11 @@ defmodule Engram.Repo.Migrations.CursorPullExpand do
 
       add :device_id, :text, null: false, primary_key: true
       add :last_seq, :bigint, null: false, default: 0
-      add :last_seen_at, :utc_datetime, null: false
+      add :last_seen_at, :timestamptz, null: false
     end
 
     alter table(:attachments) do
-      add :version, :integer, null: false, default: 1
+      add :version, :bigint, null: false, default: 1
     end
   end
 

--- a/priv/repo/migrations/20260616130000_cursor_pull_expand.exs
+++ b/priv/repo/migrations/20260616130000_cursor_pull_expand.exs
@@ -4,22 +4,28 @@ defmodule Engram.Repo.Migrations.CursorPullExpand do
   @moduledoc """
   Sync cursor pull, step B1. phase/expand: purely additive.
   - vault_device_cursors: per-(vault,device) sync watermark (GC + eviction).
+    Composite PRIMARY KEY (vault_id, device_id) — the table's natural key,
+    matching `Engram.Sync.DeviceCursor`'s composite primary_key. The PK
+    supplies the uniqueness + index the ON CONFLICT upsert targets, and its
+    leading vault_id column covers the FK, so no separate index is needed.
   - attachments.version: optimistic-concurrency / resurrection-safety parity
     with notes.version (nullable->default 1; bumped on write).
-  """
 
-  @disable_ddl_transaction true
-  @disable_migration_lock true
+  Fully transactional: a new (empty) table + a metadata-only NOT NULL column
+  add with a constant default (PG11+) need no CONCURRENTLY, so no
+  @disable_ddl_transaction.
+  """
 
   def up do
     create table(:vault_device_cursors, primary_key: false) do
-      add :vault_id, references(:vaults, type: :uuid, on_delete: :delete_all), null: false
-      add :device_id, :text, null: false
+      add :vault_id, references(:vaults, type: :uuid, on_delete: :delete_all),
+        null: false,
+        primary_key: true
+
+      add :device_id, :text, null: false, primary_key: true
       add :last_seq, :bigint, null: false, default: 0
       add :last_seen_at, :utc_datetime, null: false
     end
-
-    create unique_index(:vault_device_cursors, [:vault_id, :device_id], concurrently: true)
 
     alter table(:attachments) do
       add :version, :integer, null: false, default: 1
@@ -31,7 +37,6 @@ defmodule Engram.Repo.Migrations.CursorPullExpand do
       remove :version
     end
 
-    drop index(:vault_device_cursors, [:vault_id, :device_id])
     drop table(:vault_device_cursors)
   end
 end

--- a/test/engram/attachments_seq_feed_test.exs
+++ b/test/engram/attachments_seq_feed_test.exs
@@ -33,4 +33,55 @@ defmodule Engram.AttachmentsSeqFeedTest do
     {:ok, _} = put(user, vault, "a.png")
     assert att_row(user, a.id).version == 2
   end
+
+  test "attachment seq feed returns seq>cursor incl tombstones", %{user: user, vault: vault} do
+    {:ok, _a} = put(user, vault, "a.png")
+    :ok = Attachments.delete_attachment(user, vault, "a.png")
+    {:ok, %{changes: ch}} = Attachments.list_changes_by_seq(user, vault, 0)
+    assert Enum.any?(ch, &(&1.path == "a.png" and &1.deleted))
+    assert Enum.all?(ch, &is_integer(&1.seq))
+  end
+
+  test "attachment seq feed: keyset ordering, version, and pagination", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} = put(user, vault, "x.png")
+    {:ok, _} = put(user, vault, "y.png")
+    {:ok, _} = put(user, vault, "z.png")
+
+    {:ok, %{changes: ch, has_more: more, next: next}} =
+      Attachments.list_changes_by_seq(user, vault, 0, limit: 2)
+
+    assert length(ch) == 2
+    assert more
+    assert {seq, id} = next
+    assert is_integer(seq) and is_binary(id)
+
+    # seq strictly ascending across the page
+    seqs = Enum.map(ch, & &1.seq)
+    assert seqs == Enum.sort(seqs)
+
+    # every entry carries the full metadata contract
+    for c <- ch do
+      assert is_integer(c.seq)
+      assert is_integer(c.version)
+      assert is_boolean(c.deleted)
+      assert is_binary(c.id)
+      assert is_binary(c.path)
+      assert is_binary(c.mime_type)
+      assert Map.has_key?(c, :size_bytes)
+      assert Map.has_key?(c, :mtime)
+      assert Map.has_key?(c, :updated_at)
+      refute Map.has_key?(c, :deleted_at)
+    end
+
+    # resume from the cursor returns the remainder, exhausting the feed
+    {:ok, %{changes: ch2, has_more: more2, next: next2}} =
+      Attachments.list_changes_by_seq(user, vault, seq, limit: 2, after_id: id)
+
+    assert length(ch2) == 1
+    refute more2
+    assert is_nil(next2)
+  end
 end

--- a/test/engram/attachments_seq_feed_test.exs
+++ b/test/engram/attachments_seq_feed_test.exs
@@ -1,0 +1,36 @@
+defmodule Engram.AttachmentsSeqFeedTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.{Attachments, Repo, Vaults}
+
+  setup do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  defp b64(bin), do: Base.encode64(bin)
+
+  defp att_row(user, id) do
+    {:ok, row} = Repo.with_tenant(user.id, fn -> Repo.get(Attachments.Attachment, id) end)
+    row
+  end
+
+  defp put(user, vault, path) do
+    Attachments.upsert_attachment(user, vault, %{
+      "path" => path,
+      "content_base64" => b64(path),
+      "mime_type" => "image/png"
+    })
+  end
+
+  test "version starts at 1 and bumps on update", %{user: user, vault: vault} do
+    {:ok, a} = put(user, vault, "a.png")
+    assert att_row(user, a.id).version == 1
+
+    {:ok, _} = put(user, vault, "a.png")
+    assert att_row(user, a.id).version == 2
+  end
+end

--- a/test/engram/notes_seq_feed_test.exs
+++ b/test/engram/notes_seq_feed_test.exs
@@ -1,0 +1,47 @@
+defmodule Engram.NotesSeqFeedTest do
+  use Engram.DataCase, async: true
+  alias Engram.{Notes, Vaults}
+
+  setup do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+    %{user: user, vault: vault}
+  end
+
+  test "returns rows with seq > cursor in (seq,id) order, includes tombstones", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "A"})
+    {:ok, _b} = Notes.upsert_note(user, vault, %{"path" => "b.md", "content" => "B"})
+    # tombstone, new seq
+    :ok = Notes.delete_note(user, vault, "a.md")
+
+    {:ok, %{changes: all}} = Notes.list_changes_by_seq(user, vault, 0)
+    # a (deleted) + b both present; the delete carries deleted: true
+    assert Enum.any?(all, &(&1.path == "a.md" and &1.deleted))
+    assert Enum.any?(all, &(&1.path == "b.md" and not &1.deleted))
+    # seq strictly increasing
+    seqs = Enum.map(all, & &1.seq)
+    assert seqs == Enum.sort(seqs)
+
+    # cursor past last seq returns nothing newer (no later writes)
+    last = List.last(all)
+    {:ok, %{changes: []}} = Notes.list_changes_by_seq(user, vault, last.seq, after_id: last.id)
+  end
+
+  test "paginates with limit + has_more", %{user: user, vault: vault} do
+    for i <- 1..3, do: Notes.upsert_note(user, vault, %{"path" => "n#{i}.md", "content" => "x"})
+    {:ok, p1} = Notes.list_changes_by_seq(user, vault, 0, limit: 2)
+    assert length(p1.changes) == 2 and p1.has_more
+    {c, i} = p1.next
+    {:ok, p2} = Notes.list_changes_by_seq(user, vault, c, after_id: i, limit: 2)
+    assert length(p2.changes) == 1 and not p2.has_more
+
+    # page boundary: union of both pages covers every row exactly once (no gap, no dup)
+    paths = Enum.map(p1.changes ++ p2.changes, & &1.path)
+    assert Enum.sort(paths) == ["n1.md", "n2.md", "n3.md"]
+  end
+end

--- a/test/engram/sync_test.exs
+++ b/test/engram/sync_test.exs
@@ -1,0 +1,56 @@
+defmodule Engram.SyncTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Sync
+  alias Engram.Sync.DeviceCursor
+  alias Engram.Vaults
+
+  test "cursor round-trips (seq,id) and rejects garbage" do
+    id = Ecto.UUID.generate()
+    tok = Sync.encode_cursor(42, id)
+    assert {:ok, {42, ^id}} = Sync.decode_cursor(tok)
+    assert {:ok, nil} = Sync.decode_cursor(nil)
+    assert {:error, :invalid_cursor} = Sync.decode_cursor("not-base64!!")
+  end
+
+  test "decode_cursor rejects well-formed base64 with malformed payloads" do
+    # valid base64, but no ":" separator
+    assert {:error, :invalid_cursor} = Sync.decode_cursor(Base.url_encode64("42", padding: false))
+    # non-integer seq
+    bad_seq = Base.url_encode64("x:#{Ecto.UUID.generate()}", padding: false)
+    assert {:error, :invalid_cursor} = Sync.decode_cursor(bad_seq)
+    # non-UUID id
+    assert {:error, :invalid_cursor} =
+             Sync.decode_cursor(Base.url_encode64("42:not-a-uuid", padding: false))
+
+    # non-binary, non-nil arg hits the catch-all clause
+    assert {:error, :invalid_cursor} = Sync.decode_cursor(42)
+  end
+
+  test "record_cursor upserts a monotonic watermark per (vault, device)" do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+
+    :ok = Sync.record_cursor(user, vault, "dev-1", 10)
+    :ok = Sync.record_cursor(user, vault, "dev-1", 25)
+    # lagging pull must NOT regress the watermark
+    :ok = Sync.record_cursor(user, vault, "dev-1", 20)
+
+    {:ok, row} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.get_by(DeviceCursor, vault_id: vault.id, device_id: "dev-1")
+      end)
+
+    assert row.last_seq == 25
+  end
+
+  test "record_cursor with nil device_id is a no-op" do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+    assert :ok = Sync.record_cursor(user, vault, nil, 5)
+  end
+end

--- a/test/engram_web/controllers/sync_changes_test.exs
+++ b/test/engram_web/controllers/sync_changes_test.exs
@@ -65,4 +65,12 @@ defmodule EngramWeb.SyncChangesTest do
     # has no "<seq>:<id>" shape) — exercises decode_cursor's {:error, :invalid_cursor}.
     assert conn |> get(~p"/api/sync/changes?cursor=not-a-real-cursor") |> json_response(400)
   end
+
+  test "manifest includes current change_seq", %{conn: conn, user: user, vault: vault} do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n.md", "content" => "x"})
+    body = conn |> get(~p"/api/sync/manifest") |> json_response(200)
+    assert is_integer(body["change_seq"])
+    # exactly one write bumped the per-vault counter from 0 → 1
+    assert body["change_seq"] == 1
+  end
 end

--- a/test/engram_web/controllers/sync_changes_test.exs
+++ b/test/engram_web/controllers/sync_changes_test.exs
@@ -1,0 +1,68 @@
+defmodule EngramWeb.SyncChangesTest do
+  use EngramWeb.ConnCase, async: true
+  alias Engram.{Attachments, Notes}
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    vault = insert(:vault, user: user, is_default: true)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "k")
+    grant_api_write!(user)
+
+    authed =
+      conn
+      |> put_req_header("authorization", "Bearer #{api_key}")
+      |> put_req_header("x-device-id", "dev-1")
+
+    %{conn: authed, user: user, vault: vault}
+  end
+
+  test "pulls notes+attachments merged by seq, paginates, records watermark", %{
+    conn: conn,
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n1.md", "content" => "x"})
+
+    {:ok, _} =
+      Attachments.upsert_attachment(user, vault, %{
+        "path" => "a.png",
+        "content_base64" => Base.encode64("p"),
+        "mime_type" => "image/png"
+      })
+
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n2.md", "content" => "y"})
+
+    p1 = conn |> get(~p"/api/sync/changes?limit=2") |> json_response(200)
+    assert length(p1["changes"]) == 2
+    assert p1["has_more"] == true
+    assert Enum.all?(p1["changes"], &(&1["type"] in ["note", "attachment"]))
+    # strictly increasing seq across the merged page
+    seqs = Enum.map(p1["changes"], & &1["seq"])
+    assert seqs == Enum.sort(seqs)
+
+    p2 =
+      conn |> get(~p"/api/sync/changes?cursor=#{p1["next_cursor"]}&limit=2") |> json_response(200)
+
+    assert length(p2["changes"]) == 1 and p2["has_more"] == false
+
+    # pull-carries-ack: the watermark is the seq the SECOND pull's cursor
+    # carried in (= what the client had applied = page 1's last seq), NOT the
+    # new page's max seq. With seqs 1,2,3 and page size 2, page 2's incoming
+    # cursor seq is 2, so the recorded watermark is exactly 2. Asserting the
+    # exact value guards against a regression to recording the page max (3).
+    {:ok, row} =
+      Engram.Repo.with_tenant(user.id, fn ->
+        Engram.Repo.get_by(Engram.Sync.DeviceCursor, vault_id: vault.id, device_id: "dev-1")
+      end)
+
+    assert row.last_seq == 2
+  end
+
+  test "malformed cursor -> 400", %{conn: conn} do
+    # A valid query param that is NOT a valid opaque cursor token (decodes but
+    # has no "<seq>:<id>" shape) — exercises decode_cursor's {:error, :invalid_cursor}.
+    assert conn |> get(~p"/api/sync/changes?cursor=not-a-real-cursor") |> json_response(400)
+  end
+end

--- a/test/engram_web/controllers/sync_controller_test.exs
+++ b/test/engram_web/controllers/sync_controller_test.exs
@@ -23,6 +23,8 @@ defmodule EngramWeb.SyncControllerTest do
       assert body["attachments"] == []
       assert body["total_notes"] == 0
       assert body["total_attachments"] == 0
+      # zero-write vault → change_seq bootstrap floor is 0
+      assert body["change_seq"] == 0
     end
 
     test "includes notes with path and content_hash", %{conn: conn} do


### PR DESCRIPTION
## Summary

Backend half of the sync change-log backbone (PR B1). Makes the ordered `seq` log (shipped in PR A, #622) **readable** via a device-cursor keyset pull.

- **Migration (phase/expand, additive):** `vault_device_cursors` watermark table (composite `(vault_id, device_id)` key) + `attachments.version` column.
- **`attachments.version`** — schema field + monotonic bump on write (resurrection-parity with `notes.version`; delete path untouched — tombstones carry `deleted_at`).
- **`Engram.Sync`** — opaque `(seq,id)` base64 cursor codec + `record_cursor/4` monotonic watermark upsert (single `INSERT … ON CONFLICT … GREATEST`) + `retention_floor/1` stub (returns 0; PR D replaces).
- **Keyset feeds** — `Notes.list_changes_by_seq/4` + `Attachments.list_changes_by_seq/4`: `(seq,id)`-ordered, all kinds + tombstones.
- **`GET /sync/changes`** — merges both feeds by `(seq,id)` (seq is globally unique per vault → total order), opaque `next_cursor`, `X-Device-Id` header, **pull-carries-ack** watermark from the *incoming* cursor, dormant `HISTORY_EXPIRED` 410. Page limit clamped to the per-feed cap (500) to prevent a row-skip at large page sizes.
- **Bootstrap** — `change_seq` exposed in `/sync/manifest` (via `Vaults.current_seq/2`, RLS-scoped) so a client can set its cursor to "everything ≤ S" after applying the snapshot.

Plugin (B2) + web (B3) migrate to this next; the legacy timestamp `/changes?since` feed coexists until a later rollout PR retires it.

## Test plan

- [x] `mix test` — full suite green (2832 tests, 0 failures, 7 skipped) on `--seed 0`; new B1 tests cover cursor round-trip + garbage rejection, monotonic watermark, both keyset feeds (tombstones, ordering, page-boundary union, pagination), the merged endpoint (merge order, pagination, exact pull-carries-ack watermark `== 2`, 400 on bad cursor), and manifest `change_seq` (`== 1` populated / `== 0` empty).
- [x] `mix format` / `compile --warnings-as-errors` / `credo --strict` / `sobelow` all clean.
- [x] Migration is additive, reversible, `structure.sql` untouched.

## Notes / dependencies

- **Pre-launch DB wipe required** before B1 ships end-to-end — re-stamps `seq` on any legacy rows (no backfill; #623 obsolete if wiped).
- **Flaky-suite watch:** one unreproducible full-suite failure observed in 1 of 7 runs (passes on `--seed 0`); appears to originate in the just-landed #624 async-parallelization wave (advisory-lock `40P01` class), not the sync code (B1 tests are sandbox-isolated/deterministic). Worth a follow-up against #615/#616/#619.
- Deferred (flagged, not lost): perf #4 (coalesce batch-update vault writes) / #5 (partial tombstone index); attachment 409-reject-on-stale-version (push-path → B2/B3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)