### PR TITLE
test(e2e): port sync tests to B2 cursor contract (pairs with plugin #109)

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -683,6 +683,10 @@ class CdpClient:
         """Read the lastSync timestamp string."""
         return await self.evaluate(f"{ENGINE_PATH}.lastSync")
 
+    async def get_sync_cursor(self) -> str | None:
+        """Read the opaque sync cursor (B2 ordered-pull watermark)."""
+        return await self.evaluate(f"{ENGINE_PATH}.getSyncCursor()")
+
     async def accelerate_echo_expiry(self, path: str, ms: int = 200) -> None:
         """Replace the pending recentlyPushed timer for ``path`` with a short one.
 

--- a/e2e/tests/test_44_oauth_device_flow.py
+++ b/e2e/tests/test_44_oauth_device_flow.py
@@ -130,7 +130,10 @@ async def test_full_device_flow(
             # Trigger sync
             result = await cdp_a.trigger_full_sync()
             logger.info("Sync result: %s", result)
-            assert result.get("pushed", 0) >= 1, f"Expected push, got: {result}"
+            # Post-B2, offline-created files are pushed inside bootstrap(), so
+            # fullSync()'s `pushed` counter can read 0 even though the file
+            # reached the server. Assert server-side arrival instead of the
+            # (now-unreliable) push counter.
 
             # Verify note reached server using OAuth access token
             resp = requests.get(

--- a/e2e/tests/test_58_commands_palette.py
+++ b/e2e/tests/test_58_commands_palette.py
@@ -1,7 +1,7 @@
 """Test 58: Plugin command palette entries each fire their handler.
 
 Covers the four commands not already tested elsewhere:
-  sync-now        — lastSync timestamp advances after fullSync completes
+  sync-now        — pulls a pending server change down into the vault
   push-all        — pushAll() is invoked on SyncEngine (spy counter)
   pull-all        — pullAll() is invoked on SyncEngine (spy counter)
   show-sync-log   — .engram-sync-log-modal mounts in the DOM
@@ -31,28 +31,41 @@ Notice observation rationale:
 
 from __future__ import annotations
 import asyncio
+import uuid
+
 import pytest
+from helpers.vault import wait_for_content
 
 
 # ---------------------------------------------------------------------------
-# test_sync_now_advances_last_sync
+# test_sync_now_pulls_pending_change
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_sync_now_advances_last_sync(cdp_a):
-    """sync-now: lastSync timestamp changes after the command completes."""
-    before = await cdp_a.get_last_sync()
+async def test_sync_now_pulls_pending_change(vault_a, cdp_a, api_sync):
+    """sync-now: the command runs a sync that pulls a pending server change.
+
+    Post-B2, lastSync is frozen (the opaque syncCursor is the watermark), so
+    "lastSync advances" is no longer a valid signal. Instead we create a note
+    on the server out-of-band, fire sync-now, and assert the pull lands the
+    note in the local vault — a behavior assertion that holds regardless of
+    cursor internals.
+    """
+    unique = uuid.uuid4().hex[:12]
+    path = f"E2E/SyncNowCmd-{unique}.md"
+    marker = f"sync-now pull marker {unique}"
+    content = f"# Sync Now Command\n{marker}"
+
+    # Create the note server-side (out-of-band — not via the local vault).
+    api_sync.create_note(path, content)
+
+    # Fire the command under test.
     await cdp_a.run_command("sync-now")
-    # fullSync is async — give it up to 10 s to finish
-    deadline = asyncio.get_event_loop().time() + 10
-    after = before
-    while asyncio.get_event_loop().time() < deadline:
-        after = await cdp_a.get_last_sync()
-        if after != before:
-            break
-        await asyncio.sleep(0.25)
-    assert after != before, (
-        f"lastSync did not advance after sync-now (before={before!r}, after={after!r})"
+
+    # The note must arrive locally as a result of the sync the command ran.
+    local = wait_for_content(vault_a, path, marker, timeout=15)
+    assert marker in local, (
+        f"sync-now did not pull pending server change into {path!r}"
     )
 
 

--- a/e2e/tests/test_59_status_bar_click.py
+++ b/e2e/tests/test_59_status_bar_click.py
@@ -3,8 +3,8 @@
 User paths covered:
   1. Gate blocked  → clicking the status bar opens SyncPreviewModal so the
                      user can pick a sync direction.
-  2. Gate unblocked → clicking the status bar fires fullSync() and the
-                     lastSync timestamp advances.
+  2. Gate unblocked → clicking the status bar runs a sync that pulls a
+                     pending server change down into the vault.
 
 Seed/restore rationale:
   test_click_blocked_opens_modal:
@@ -16,18 +16,20 @@ Seed/restore rationale:
       seed file, restores the sync handlers, and re-accepts the gate so
       subsequent tests are not left in a blocked state.
 
-  test_click_unblocked_triggers_sync:
+  test_click_triggers_sync_pull:
     - Relies on the gate being open (normal post-conftest state).
-    - Does not mutate vault files — only measures lastSync advancement.
-    - Does not need a restore block because no persistent state is changed.
+    - Creates a note server-side, clicks the status bar, asserts the pull
+      lands it locally. lastSync is frozen post-B2 (opaque syncCursor is the
+      watermark), so behavior — not timestamp advancement — is asserted.
+    - Does not need a restore block because no local vault state is mutated.
 """
 
 from __future__ import annotations
 
-import asyncio
+import uuid
 
 import pytest
-from helpers.vault import write_note
+from helpers.vault import wait_for_content, write_note
 
 
 # ---------------------------------------------------------------------------
@@ -75,27 +77,32 @@ async def test_click_blocked_opens_modal(vault_a, cdp_a):
 
 
 # ---------------------------------------------------------------------------
-# test_click_unblocked_triggers_sync
+# test_click_triggers_sync_pull
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_click_unblocked_triggers_sync(cdp_a):
-    """Gate open: status bar click fires fullSync and lastSync advances."""
-    before = await cdp_a.get_last_sync()
+async def test_click_triggers_sync_pull(vault_a, cdp_a, api_sync):
+    """Gate open: status bar click runs a sync that pulls a pending change.
 
+    Post-B2, lastSync is frozen (the opaque syncCursor is the watermark), so
+    "lastSync advances" is no longer a valid signal. We create a note on the
+    server out-of-band, click the status bar, and assert the resulting sync
+    lands the note locally — a behavior assertion independent of cursor state.
+    """
+    unique = uuid.uuid4().hex[:12]
+    path = f"E2E/StatusBarClick-{unique}.md"
+    marker = f"status-bar pull marker {unique}"
+    content = f"# Status Bar Click\n{marker}"
+
+    # Create the note server-side (out-of-band — not via the local vault).
+    api_sync.create_note(path, content)
+
+    # The gate is open in normal post-conftest state; a click runs fullSync.
     await cdp_a.click_status_bar()
 
-    # fullSync is async; poll up to 10 s for lastSync to change.
-    deadline = asyncio.get_event_loop().time() + 10
-    after = before
-    while asyncio.get_event_loop().time() < deadline:
-        after = await cdp_a.get_last_sync()
-        if after != before:
-            break
-        await asyncio.sleep(0.25)
-
-    assert after != before, (
-        f"lastSync did not advance after status bar click "
-        f"(before={before!r}, after={after!r})"
+    # The note must arrive locally as a result of the sync the click ran.
+    local = wait_for_content(vault_a, path, marker, timeout=15)
+    assert marker in local, (
+        f"status bar click did not pull pending server change into {path!r}"
     )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.452",
+      version: "0.5.453",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Adapts the Obsidian E2E suite to the **B2 cursor-pull sync contract** (plugin PR `engram-app/Engram-obsidian#109`). B2 replaced the legacy timestamp feed with an ordered cursor pull, which changes two behaviors these tests asserted:

1. **`lastSync` is frozen** — the opaque `syncCursor` is the watermark now, so "lastSync advances after a sync" is obsolete.
2. **Bootstrap pushes offline-created files inside `bootstrap()`** — a `fullSync` push *counter* can read 0 even though the file reaches the server.

Changes:
- `e2e/helpers/cdp.py` — add `get_sync_cursor()` (reads `syncEngine.getSyncCursor()`).
- `test_58_commands_palette` / `test_59_status_bar_click` — assert the command/click actually **pulls a pending server change** (create a server note → run sync-now / click → assert it arrives locally), instead of asserting `lastSync` changed.
- `test_44_oauth_device_flow` — assert the created note **arrives on the server** (the in-file `GET /notes/{path}`), instead of asserting the `fullSync` push count ≥ 1.

## Verification

The paired e2e (this branch + plugin `feat/sync-cursor-pull-b2`) is **green** — run [27667988219](https://github.com/engram-app/Engram/actions/runs/27667988219): **109 passed**. That run also validated the plugin-side B2 fixes (reconnect catch-up after a vault swap; offline-queue recovery).

## Merge note

This pairs with plugin #109 (chicken-and-egg): these ported tests assert B2 behavior, so they fail against plugin `main` (pre-B2). **Merge order: plugin #109 first** (B2 → plugin main), then this PR — at which point its auto-triggered e2e runs against a B2 plugin main and passes. Detail in workspace `docs/context/b2-cursor-pull-e2e-triage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)