### PR TITLE
feat: attachment actions (delete/rename/move) + uuid-keyed storage + tombstone convergence

### DIFF
--- a/docs/superpowers/plans/2026-06-17-attachment-actions-rename-convergence.md
+++ b/docs/superpowers/plans/2026-06-17-attachment-actions-rename-convergence.md
@@ -1,0 +1,1109 @@
+# Attachment Actions + Rename Convergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn on delete / rename / move for attachment rows in the web file tree (single + batch), backed by UUID-keyed S3 storage and a durable old-path tombstone so a move converges on every device with no duplicate or resurrection.
+
+**Architecture:** Decouple the S3 object key from the mutable vault path (key by row UUID). A move/rename becomes pure metadata: repoint the live row's encrypted path + insert a soft-deleted tombstone at the old path, both stamped with one per-vault `seq` in a single transaction. The tombstone surfaces `{old, deleted:true}` through the *existing* `/attachments/changes` poll AND the new seq-cursor pull; the plugin already trashes on `deleted` and writes on upsert, so convergence needs near-zero plugin code. Real-time parity reuses the existing `note_changed` socket event with `kind:"attachment"` (the plugin already dispatches by kind).
+
+**Tech Stack:** Elixir/Phoenix (backend), React + TanStack Query + TypeScript (frontend), TypeScript Obsidian plugin, ExUnit / bun test / Jest, headless-Obsidian e2e.
+
+---
+
+## Re-scope note (READ FIRST — the spec is partly OBE)
+
+The design spec (`docs/superpowers/specs/2026-06-16-attachment-actions-and-rename-convergence-design.md`) was written **before** the sync-cursor-pull detour merged to `main` (PRs #622 change-log backbone, #628 cursor-pull). That detour changed the convergence substrate under the spec. Verified current state of `main`:
+
+- **Spec PR2 (notes/folders rename tombstone) — half shipped.** `Notes.rename_folder/4` already inserts old-path tombstones, same-seq, in one txn (`notes.ex` ~2265, the `#614` fix). **`Notes.rename_note/4` (single) does NOT** — it repoints in place and only broadcasts an *ephemeral* socket delete (`notes.ex:696`). An offline client reconnecting via poll/cursor sees only `new_path` → **duplicate/resurrection**. That single-note gap is the only PR2 remainder → **Task 12** (own small PR).
+- **Plugin already converges attachments.** It polls `/attachments/changes` (returns `deleted:true` rows), trashes on delete (`sync.ts` ~2024 `applyAttachmentChange`), writes blob on upsert, echo-suppresses via FNV-1a `syncState`. `channel.ts` dispatches `note_changed` by `kind:"attachment"`. So a move that emits **tombstone(old) + repoint(new)** converges through existing machinery. The spec's separate `attachment_changed` socket event is **dropped** — we reuse `note_changed` with `kind:"attachment"`.
+- **Backend attachments do zero broadcasts today**, and `delete_external` recomputes `Storage.key(path)` (a latent bug — reads already prefer `storage_key`). These are the real backend gaps.
+
+**Net:** PR1 = attachments (re-keying + move + endpoints + frontend + e2e). PR2 = single-note `rename_note` tombstone only. Plugin code is verify-and-e2e, likely zero source changes.
+
+---
+
+## Task 0: Rebase the branch onto current `main` (build prep, not a code task)
+
+**Why:** Branch `feat/attachment-actions-and-rename-convergence` is 7 commits behind `main` and predates the cursor-pull merges. All code references below assume current `main` (`Attachments.list_changes_by_seq/4`, `Note` seq stamping, `attachments.version`/`seq` columns). Build on stale base and the new helpers won't exist.
+
+- [ ] **Step 1: Rebase**
+
+```bash
+cd /home/open-claw/documents/code-projects/engram/.worktrees/feat-attachment-actions
+git fetch origin
+git rebase origin/main
+```
+
+Expected: clean rebase (the branch holds only the spec doc + this plan; no code overlap with main).
+
+- [ ] **Step 2: Baseline tests green before any change**
+
+```bash
+mix test test/engram/attachments_test.exs test/engram/attachments_seq_feed_test.exs
+```
+
+Expected: PASS. If red on a fresh rebase, STOP and surface — do not build on a red baseline.
+
+---
+
+## File Structure
+
+**Backend (`engram`):**
+- Modify `lib/engram/storage.ex` — add `object_key/3` (UUID-keyed builder).
+- Modify `lib/engram/attachments.ex` — `prepare_upload` keys by UUID; `delete_external` deletes by `storage_key` column; add `move_attachment/4`, `batch_move/4`, `batch_delete/3`, a `broadcast_attachment/5` helper.
+- Modify `lib/engram_web/controllers/attachments_controller.ex` — add `rename/2`, `batch_move/2`, `batch_delete/2` actions (billing-gated).
+- Modify `lib/engram_web/router.ex` — add the three routes (batch ops under the `IdempotencyKey` pipeline).
+- Modify `lib/engram/notes.ex` — Task 12 only: `rename_note` inserts an old-path tombstone.
+
+**Frontend (`frontend/`):**
+- Modify `src/api/queries.ts` — add `useRenameAttachment`, `useBatchMoveAttachments`, `useBatchDeleteAttachments`.
+- Modify `src/viewer/tree-actions/action-list.ts` — add `ATTACHMENT_ACTIONS` + handle the `attachment` kind.
+- Modify `src/viewer/tree/tree-row.tsx` — un-suppress context-menu / long-press on attachment rows.
+- Modify `src/viewer/folder-tree.tsx` — thread the `attachment` kind through `onRenameCommit`, `onMove`, `rowsFor`, `partition`, `commitDelete`, `kindOf`, `titleForItem`.
+
+**Plugin (`engram-obsidian-sync`):** verify-only; e2e in the backend `e2e/` suite.
+
+**Convention reminders:** composite-PK / `timestamptz` / `bigint` migration conventions (none needed here — no schema change). One `mix.exs` bump per engram PR; one plugin `manifest.json` bump per plugin PR (only if plugin source changes). Run `lint:obsidian` / `lint:css` / biome locally before pushing frontend.
+
+---
+
+# PR 1 — Attachments (S3 re-keying + move + endpoints + frontend + e2e)
+
+## Task 1: `Storage.object_key/3` — UUID-keyed object key builder
+
+**Files:**
+- Modify: `lib/engram/storage.ex` (after `key/3`, ~line 86)
+- Test: `test/engram/storage_test.exs` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/engram/storage_test.exs
+defmodule Engram.StorageTest do
+  use ExUnit.Case, async: true
+  alias Engram.Storage
+
+  describe "object_key/3" do
+    test "keys by uuid under an objects/ namespace, independent of vault path" do
+      uid = "11111111-1111-1111-1111-111111111111"
+      vid = "22222222-2222-2222-2222-222222222222"
+      att = "33333333-3333-3333-3333-333333333333"
+      assert Storage.object_key(uid, vid, att) == "#{uid}/#{vid}/objects/#{att}"
+    end
+
+    test "two different uuids never collide even for the same future path" do
+      uid = "u"; vid = "v"
+      refute Storage.object_key(uid, vid, "a") == Storage.object_key(uid, vid, "b")
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram/storage_test.exs`
+Expected: FAIL — `function Engram.Storage.object_key/3 is undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `lib/engram/storage.ex`, immediately after the existing `key/3` (ends ~line 86):
+
+```elixir
+  @doc """
+  Build a storage key from the immutable attachment row UUID. Decoupled from
+  the mutable vault path so move/rename never relocates the blob and a new
+  upload to a vacated path computes a fresh key (no clobber). New uploads use
+  this; legacy rows keep their path-derived `storage_key` column value.
+  """
+  def object_key(user_id, vault_id, att_id)
+      when is_binary(user_id) and is_binary(vault_id) and is_binary(att_id) and att_id != "" do
+    "#{user_id}/#{vault_id}/objects/#{att_id}"
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/engram/storage_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/storage.ex test/engram/storage_test.exs
+git commit -m "feat(storage): uuid-keyed object_key builder for attachments"
+```
+
+---
+
+## Task 2: Key new uploads by UUID + delete by stored `storage_key` column
+
+**Files:**
+- Modify: `lib/engram/attachments.ex` — `prepare_upload/8` (line 493) and `delete_external` (line 281) + `delete_attachment/3` (line 250)
+- Test: `test/engram/attachments_test.exs`
+
+**Context:** `att_id` is already pre-minted in `upsert_attachment/3` (`attachments.ex:46`, `Ecto.UUID.generate()`) and threaded into `prepare_upload`. `storage_key` is always persisted (even legacy rows), so delete-by-column is correct for both.
+
+- [ ] **Step 1: Write the failing tests**
+
+```elixir
+# add to test/engram/attachments_test.exs (inside the existing describe or a new one)
+test "new upload keys storage by uuid, not by path", %{user: user, vault: vault} do
+  {:ok, att} = Attachments.upsert_attachment(user, vault, %{
+    "path" => "img/cat.png", "content_base64" => Base.encode64("PNGDATA"),
+    "mime_type" => "image/png", "mtime" => 1.0
+  })
+  assert att.storage_key =~ ~r{/objects/#{att.id}$}
+  refute att.storage_key =~ "img/cat.png"
+end
+
+test "a new upload to a vacated path does NOT clobber a different blob", %{user: user, vault: vault} do
+  {:ok, a} = Attachments.upsert_attachment(user, vault, %{
+    "path" => "p/x.png", "content_base64" => Base.encode64("AAA"),
+    "mime_type" => "image/png", "mtime" => 1.0
+  })
+  :ok = Attachments.delete_attachment(user, vault, "p/x.png")
+  {:ok, b} = Attachments.upsert_attachment(user, vault, %{
+    "path" => "p/x.png", "content_base64" => Base.encode64("BBB"),
+    "mime_type" => "image/png", "mtime" => 2.0
+  })
+  refute a.storage_key == b.storage_key
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mix test test/engram/attachments_test.exs -k "uuid"`
+Expected: FAIL — `storage_key` still path-derived (`Storage.key`).
+
+- [ ] **Step 3: Implement — `prepare_upload` keys by uuid**
+
+In `lib/engram/attachments.ex`, `prepare_upload/8`, change line 493:
+
+```elixir
+    # was: key = Storage.key(user.id, vault.id, path)
+    key = Storage.object_key(user.id, vault.id, att_id)
+```
+
+- [ ] **Step 4: Implement — delete by the stored `storage_key` column**
+
+Replace `delete_external/3` (lines 281–298) and its call site so it deletes the column, not a recomputed path key. First change `delete_attachment/3` to load the row's `storage_key` and pass it; then make `delete_external/1` take the key.
+
+In `delete_attachment/3` (lines 250–279), replace the `Repo.with_tenant` block + the `delete_external` call:
+
+```elixir
+        storage_key =
+          Repo.with_tenant(user.id, fn ->
+            seq = Engram.Vaults.next_seq!(vault.id)
+
+            {_, returned} =
+              from(a in Attachment,
+                where:
+                  a.path_hmac == ^path_hmac and a.user_id == ^user.id and
+                    a.vault_id == ^vault.id and is_nil(a.deleted_at),
+                select: a.storage_key
+              )
+              |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
+
+            List.first(returned || [])
+          end)
+          |> unwrap_tenant()
+
+        # Best-effort blob cleanup — row is already soft-deleted so safe to retry.
+        if is_binary(storage_key), do: delete_external(storage_key)
+```
+
+Replace `delete_external/3` with `delete_external/1`:
+
+```elixir
+  defp delete_external(storage_key) when is_binary(storage_key) do
+    case Storage.adapter().delete(storage_key) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        require Logger
+
+        Logger.warning("Failed to delete blob (row already soft-deleted)",
+          storage_key: storage_key,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  end
+```
+
+> Note: `update_all` with `select:` returns `{count, rows}` where `rows` is a list of the selected field — used here to recover the deleted row's `storage_key` without a second query. If `unwrap_tenant` wraps differently in this module, match its existing pattern (it returns the inner value for the other callers).
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `mix test test/engram/attachments_test.exs`
+Expected: PASS (existing delete tests + the two new ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/engram/attachments.ex test/engram/attachments_test.exs
+git commit -m "feat(attachments): key blobs by uuid; delete by storage_key column"
+```
+
+---
+
+## Task 3: `Attachments.move_attachment/4` — repoint live row + old-path tombstone
+
+**Files:**
+- Modify: `lib/engram/attachments.ex` — add public `move_attachment/4` + a private tombstone builder
+- Test: `test/engram/attachments_test.exs`
+
+**Mirrors:** `Notes.rename_folder/4` tombstone insert (`notes.ex` ~2265) and `prepare_upload` path-encrypt (`Crypto.aad_for_row(:attachments, :path, att_id)` + `Envelope.encrypt`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```elixir
+describe "move_attachment/4" do
+  setup %{user: user, vault: vault} do
+    {:ok, att} = Attachments.upsert_attachment(user, vault, %{
+      "path" => "old/a.png", "content_base64" => Base.encode64("DATA"),
+      "mime_type" => "image/png", "mtime" => 1.0
+    })
+    %{att: att}
+  end
+
+  test "repoints the live row, blob/storage_key untouched", %{user: user, vault: vault, att: att} do
+    {:ok, moved} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+    assert moved.id == att.id
+    assert moved.path == "new/b.png"
+    assert moved.storage_key == att.storage_key
+    {:ok, fetched} = Attachments.get_attachment(user, vault, "new/b.png")
+    assert fetched.content == "DATA"
+  end
+
+  test "emits a soft-deleted tombstone at the old path", %{user: user, vault: vault} do
+    {:ok, _} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+    {:ok, %{changes: changes}} = Attachments.list_changes_by_seq(user, vault, 0)
+    assert Enum.any?(changes, &(&1.path == "old/a.png" and &1.deleted))
+    assert Enum.any?(changes, &(&1.path == "new/b.png" and not &1.deleted))
+  end
+
+  test "conflict on occupied target → :conflict", %{user: user, vault: vault} do
+    {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+      "path" => "new/b.png", "content_base64" => Base.encode64("X"),
+      "mime_type" => "image/png", "mtime" => 1.0
+    })
+    assert {:error, :conflict} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+  end
+
+  test "no-op move (old == new) is idempotent, no tombstone", %{user: user, vault: vault} do
+    {:ok, _} = Attachments.move_attachment(user, vault, "old/a.png", "old/a.png")
+    {:ok, %{changes: changes}} = Attachments.list_changes_by_seq(user, vault, 0)
+    refute Enum.any?(changes, &(&1.deleted))
+  end
+
+  test "missing source → :not_found", %{user: user, vault: vault} do
+    assert {:error, :not_found} = Attachments.move_attachment(user, vault, "nope.png", "x.png")
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mix test test/engram/attachments_test.exs -k "move_attachment"`
+Expected: FAIL — `move_attachment/4` undefined.
+
+- [ ] **Step 3: Implement `move_attachment/4`**
+
+Add to `lib/engram/attachments.ex` (public function, near `delete_attachment`):
+
+```elixir
+  @doc """
+  Moves/renames an attachment by path. One transaction under the per-vault seq:
+  repoint the live row (id stable, path re-encrypted under its unchanged
+  id-AAD, storage_key + blob untouched) and insert a soft-deleted tombstone at
+  the old path so poll/cursor clients converge (trash old, write new). Mirrors
+  `Engram.Notes.rename_folder/4`'s tombstone discipline (#614).
+  """
+  @spec move_attachment(map(), map(), String.t(), String.t()) ::
+          {:ok, Attachment.t()} | {:error, :conflict | :not_found | term()}
+  def move_attachment(user, vault, old_path, new_path) do
+    old_path = PathSanitizer.sanitize(old_path)
+    new_path = PathSanitizer.sanitize(new_path)
+    user = fresh_user(user)
+    now = DateTime.utc_now(:second)
+
+    with {:ok, user} <- Crypto.ensure_user_dek(user),
+         {:ok, dek} <- Crypto.get_dek(user),
+         {:ok, filter_key} <- Crypto.dek_filter_key(user) do
+      old_hmac = Crypto.hmac_field(filter_key, old_path)
+      new_hmac = Crypto.hmac_field(filter_key, new_path)
+
+      Repo.transaction(fn ->
+        Repo.with_tenant(user.id, fn ->
+          live = Repo.one(live_by_hmac_query(user, vault, old_hmac))
+
+          cond do
+            is_nil(live) ->
+              Repo.rollback(:not_found)
+
+            old_path == new_path ->
+              {:ok, att} = Crypto.maybe_decrypt_attachment_fields(live, user)
+              att
+
+            Repo.one(live_by_hmac_query(user, vault, new_hmac)) ->
+              Repo.rollback(:conflict)
+
+            true ->
+              seq = Engram.Vaults.next_seq!(vault.id)
+
+              # Repoint the live row: re-encrypt path under the SAME id-AAD.
+              path_aad = Crypto.aad_for_row(:attachments, :path, live.id)
+              {path_ct, path_n} = Envelope.encrypt(new_path, dek, path_aad)
+
+              {1, _} =
+                from(a in Attachment, where: a.id == ^live.id)
+                |> Repo.update_all(
+                  set: [
+                    path_ciphertext: path_ct,
+                    path_nonce: path_n,
+                    path_hmac: new_hmac,
+                    updated_at: now,
+                    seq: seq
+                  ]
+                )
+
+              # Insert the old-path tombstone (fresh uuid, own id-AAD).
+              Repo.insert!(tombstone_changeset(user, vault, dek, old_path, old_hmac, live, seq, now))
+
+              %{live | path: new_path, path_ciphertext: path_ct, path_nonce: path_n,
+                       path_hmac: new_hmac, updated_at: now, seq: seq}
+          end
+        end)
+        |> unwrap_tenant()
+      end)
+      |> case do
+        {:ok, %Attachment{} = att} ->
+          if old_path != new_path do
+            broadcast_attachment(user.id, vault.id, "delete", old_path, att)
+            broadcast_attachment(user.id, vault.id, "upsert", new_path, att)
+          end
+
+          {:ok, att}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp live_by_hmac_query(user, vault, hmac) do
+    from(a in Attachment,
+      where:
+        a.path_hmac == ^hmac and a.user_id == ^user.id and
+          a.vault_id == ^vault.id and is_nil(a.deleted_at)
+    )
+  end
+
+  # Soft-deleted full-row insert at the vacated path. storage_key=nil (no blob),
+  # content_hash carried from the live row (satisfies the changeset; value
+  # irrelevant — row is deleted). Path encrypted under the tombstone's OWN
+  # id-AAD so reads of the (never-served) row stay AAD-consistent.
+  defp tombstone_changeset(user, vault, dek, old_path, old_hmac, live, seq, now) do
+    tomb_id = Ecto.UUID.generate()
+    path_aad = Crypto.aad_for_row(:attachments, :path, tomb_id)
+    {path_ct, path_n} = Envelope.encrypt(old_path, dek, path_aad)
+
+    Attachment.changeset(%Attachment{id: tomb_id}, %{
+      path_ciphertext: path_ct,
+      path_nonce: path_n,
+      path_hmac: old_hmac,
+      content_hash: live.content_hash,
+      mime_type: live.mime_type,
+      size_bytes: live.size_bytes,
+      mtime: live.mtime,
+      user_id: user.id,
+      vault_id: vault.id,
+      storage_key: nil,
+      deleted_at: now,
+      updated_at: now,
+      seq: seq,
+      version: 1,
+      encryption_version: 1,
+      dek_version: Crypto.row_version_aad_bound(),
+      content_nonce: nil
+    })
+  end
+```
+
+> Verify against the schema: `Attachment.changeset/2` must cast `created_at`/`inserted_at` automatically (it uses `timestamps(inserted_at: :created_at)`). If `Repo.insert!` complains about a missing `created_at`, set it explicitly in the attrs map (`created_at: now`). The fields cast list in `attachment.ex` already includes every key used above.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `mix test test/engram/attachments_test.exs -k "move_attachment"`
+Expected: PASS (5 tests). The broadcast tests in Task 5 will assert the socket payloads.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/attachments.ex test/engram/attachments_test.exs
+git commit -m "feat(attachments): move_attachment — repoint + old-path tombstone"
+```
+
+---
+
+## Task 4: Batch move + batch delete (context functions)
+
+**Files:**
+- Modify: `lib/engram/attachments.ex` — add `batch_move/4`, `batch_delete/3`
+- Test: `test/engram/attachments_test.exs`
+
+**Shape:** attachments are path-keyed (no folder rows), so batch-move takes `paths` + a `target_folder` *string*; each item's new path = `Path.join(target_folder, basename)` (or just basename at root). All-or-nothing via `Repo.transaction` + `Enum.reduce_while`, mirroring `Notes.batch_move_notes/4` (`notes.ex:911`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```elixir
+describe "batch_move/4 + batch_delete/3" do
+  setup %{user: user, vault: vault} do
+    for p <- ["a.png", "b.png"] do
+      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+        "path" => p, "content_base64" => Base.encode64(p),
+        "mime_type" => "image/png", "mtime" => 1.0
+      })
+    end
+    :ok
+  end
+
+  test "batch_move relocates each into the target folder", %{user: user, vault: vault} do
+    {:ok, %{moved: 2}} = Attachments.batch_move(user, vault, ["a.png", "b.png"], "img")
+    {:ok, _} = Attachments.get_attachment(user, vault, "img/a.png")
+    {:ok, _} = Attachments.get_attachment(user, vault, "img/b.png")
+  end
+
+  test "batch_move to root keeps basenames", %{user: user, vault: vault} do
+    {:ok, _} = Attachments.batch_move(user, vault, ["a.png"], "img")
+    {:ok, %{moved: 1}} = Attachments.batch_move(user, vault, ["img/a.png"], "")
+    {:ok, _} = Attachments.get_attachment(user, vault, "a.png")
+  end
+
+  test "batch_move rolls back on conflict", %{user: user, vault: vault} do
+    {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+      "path" => "img/a.png", "content_base64" => Base.encode64("X"),
+      "mime_type" => "image/png", "mtime" => 1.0
+    })
+    assert {:error, {:conflict, "a.png"}} = Attachments.batch_move(user, vault, ["a.png"], "img")
+    # b.png untouched, a.png still at root
+    {:ok, _} = Attachments.get_attachment(user, vault, "a.png")
+  end
+
+  test "batch_delete soft-deletes each", %{user: user, vault: vault} do
+    {:ok, %{deleted: 2}} = Attachments.batch_delete(user, vault, ["a.png", "b.png"])
+    {:ok, nil} = Attachments.get_attachment(user, vault, "a.png")
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mix test test/engram/attachments_test.exs -k "batch_move"`
+Expected: FAIL — undefined functions.
+
+- [ ] **Step 3: Implement**
+
+```elixir
+  @doc "Moves each attachment into `target_folder` (\"\" = root). All-or-nothing."
+  @spec batch_move(map(), map(), [String.t()], String.t()) ::
+          {:ok, %{moved: non_neg_integer()}} | {:error, {atom(), String.t()} | term()}
+  def batch_move(_user, _vault, [], _target_folder), do: {:ok, %{moved: 0}}
+
+  def batch_move(user, vault, paths, target_folder) when is_list(paths) and is_binary(target_folder) do
+    Repo.transaction(fn ->
+      Enum.reduce_while(paths, %{moved: 0}, fn old_path, acc ->
+        base = Path.basename(old_path)
+        new_path = if target_folder == "", do: base, else: Path.join(target_folder, base)
+
+        case move_attachment(user, vault, old_path, new_path) do
+          {:ok, _} -> {:cont, Map.update!(acc, :moved, &(&1 + 1))}
+          {:error, :conflict} -> {:halt, {:rollback, {:conflict, old_path}}}
+          {:error, :not_found} -> {:halt, {:rollback, {:not_found, old_path}}}
+          {:error, reason} -> {:halt, {:rollback, reason}}
+        end
+      end)
+      |> case do
+        {:rollback, reason} -> Repo.rollback(reason)
+        acc -> acc
+      end
+    end)
+  end
+
+  @doc "Soft-deletes each attachment by path. All-or-nothing (delete is idempotent)."
+  @spec batch_delete(map(), map(), [String.t()]) :: {:ok, %{deleted: non_neg_integer()}}
+  def batch_delete(_user, _vault, []), do: {:ok, %{deleted: 0}}
+
+  def batch_delete(user, vault, paths) when is_list(paths) do
+    Enum.each(paths, fn p -> :ok = delete_attachment(user, vault, p) end)
+    {:ok, %{deleted: length(paths)}}
+  end
+```
+
+> `move_attachment` runs its own `Repo.transaction`; nesting inside `batch_move`'s transaction is fine in Ecto (savepoints/joins the outer txn). The per-item broadcasts in `move_attachment` fire on each success — acceptable (mirrors per-note rename broadcasts). If you prefer one digest, defer broadcasts; not required.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `mix test test/engram/attachments_test.exs -k "batch"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/attachments.ex test/engram/attachments_test.exs
+git commit -m "feat(attachments): batch_move + batch_delete context fns"
+```
+
+---
+
+## Task 5: Socket broadcast — `note_changed` with `kind:"attachment"`
+
+**Files:**
+- Modify: `lib/engram/attachments.ex` — add `broadcast_attachment/5` (already called in Task 3)
+- Test: `test/engram/attachments_test.exs`
+
+**Why reuse `note_changed`:** the plugin's `channel.ts` already reads `payload.kind` and routes `kind:"attachment"` events to `applyAttachmentChange`. A dedicated `attachment_changed` event would need new plugin code for zero benefit. Payload mirrors the spec: `{op, path, mime_type, size_bytes, mtime}` plus the `kind` discriminator and `event_type` the plugin expects.
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+test "move broadcasts delete(old) + upsert(new) with kind=attachment", %{user: user, vault: vault} do
+  {:ok, att} = Attachments.upsert_attachment(user, vault, %{
+    "path" => "old/a.png", "content_base64" => Base.encode64("D"),
+    "mime_type" => "image/png", "mtime" => 1.0
+  })
+  topic = "sync:#{user.id}:#{vault.id}"
+  EngramWeb.Endpoint.subscribe(topic)
+
+  {:ok, _} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+
+  assert_receive %Phoenix.Socket.Broadcast{
+    event: "note_changed",
+    payload: %{"event_type" => "delete", "kind" => "attachment", "path" => "old/a.png"}
+  }
+  assert_receive %Phoenix.Socket.Broadcast{
+    event: "note_changed",
+    payload: %{"event_type" => "upsert", "kind" => "attachment", "path" => "new/b.png",
+               "mime_type" => "image/png"}
+  }
+  _ = att
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mix test test/engram/attachments_test.exs -k "broadcasts delete"`
+Expected: FAIL — `broadcast_attachment/5` undefined (compile error) or no message received.
+
+- [ ] **Step 3: Implement**
+
+```elixir
+  # Real-time parity: reuse the existing `note_changed` socket event the plugin
+  # already dispatches by `kind`. A move fires delete(old) + upsert(new), like
+  # Notes.rename. Receive-only on the plugin — it still pushes over HTTP.
+  defp broadcast_attachment(user_id, vault_id, event_type, path, %Attachment{} = att) do
+    payload = %{
+      "event_type" => event_type,
+      "kind" => "attachment",
+      "path" => path,
+      "vault_id" => vault_id,
+      "mime_type" => att.mime_type,
+      "size_bytes" => att.size_bytes,
+      "mtime" => att.mtime
+    }
+
+    _ = EngramWeb.Endpoint.broadcast("sync:#{user_id}:#{vault_id}", "note_changed", payload)
+    :ok
+  end
+```
+
+Also emit on single delete: in `delete_attachment/3`, after the best-effort blob cleanup, add a delete broadcast (load needs only the path — mime/size unknown post-delete, send what we have):
+
+```elixir
+        _ = EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "note_changed", %{
+          "event_type" => "delete", "kind" => "attachment", "path" => path, "vault_id" => vault.id
+        })
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `mix test test/engram/attachments_test.exs -k "broadcasts"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/attachments.ex test/engram/attachments_test.exs
+git commit -m "feat(attachments): real-time note_changed broadcast (kind=attachment)"
+```
+
+---
+
+## Task 6: Controller actions + routes (billing-gated, idempotent batch)
+
+**Files:**
+- Modify: `lib/engram_web/controllers/attachments_controller.ex` — add `rename/2`, `batch_move/2`, `batch_delete/2`
+- Modify: `lib/engram_web/router.ex` — add routes (batch under `IdempotencyKey`)
+- Test: `test/engram_web/controllers/attachments_controller_test.exs`
+
+**Mirrors:** `NotesController.rename/2` (`notes_controller.ex:114`), `batch_move/2` (`:389`), `batch_delete/2` (`:357`), and the `Billing.check_feature(user, :attachments_enabled)` gate (`attachments_controller.ex:15`). Batch endpoints read `conn.assigns.idempotency_key` and call `Engram.Idempotency.remember/2`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```elixir
+# test/engram_web/controllers/attachments_controller_test.exs (add to existing)
+test "POST /attachments/rename moves and returns new path", %{conn: conn, user: user, vault: vault} do
+  {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+    "path" => "old/a.png", "content_base64" => Base.encode64("D"),
+    "mime_type" => "image/png", "mtime" => 1.0
+  })
+  conn = post(authed(conn, user, vault), "/api/attachments/rename",
+    %{"old_path" => "old/a.png", "new_path" => "new/b.png"})
+  assert json_response(conn, 200)["renamed"] == true
+end
+
+test "POST /attachments/rename conflict → 409", %{conn: conn, user: user, vault: vault} do
+  for p <- ["a.png", "b.png"], do:
+    {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+      "path" => p, "content_base64" => Base.encode64(p), "mime_type" => "image/png", "mtime" => 1.0})
+  conn = post(authed(conn, user, vault), "/api/attachments/rename",
+    %{"old_path" => "a.png", "new_path" => "b.png"})
+  assert json_response(conn, 409)["error"] == "conflict"
+end
+
+test "POST /attachments/batch-move requires idempotency key", %{conn: conn, user: user, vault: vault} do
+  conn = post(authed(conn, user, vault), "/api/attachments/batch-move",
+    %{"paths" => ["a.png"], "target_folder" => "img"})
+  assert json_response(conn, 400)["error"] == "missing_idempotency_key"
+end
+```
+
+> Use whatever `authed/3` test helper the existing attachments controller test uses (`authed_api_conn/1` was extracted in #621 — match the file's current pattern).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mix test test/engram_web/controllers/attachments_controller_test.exs -k "rename"`
+Expected: FAIL — route not found (404/no_route).
+
+- [ ] **Step 3: Implement controller actions**
+
+In `lib/engram_web/controllers/attachments_controller.ex`:
+
+```elixir
+  def rename(conn, %{"old_path" => old_path, "new_path" => new_path}) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    with :ok <- Billing.check_feature(user, :attachments_enabled),
+         {:ok, _att} <- Attachments.move_attachment(user, vault, old_path, new_path) do
+      json(conn, %{renamed: true, old_path: old_path, new_path: new_path})
+    else
+      {:error, :feature_not_available} ->
+        EngramWeb.LimitResponse.halt(conn, "attachments_disabled", :attachments_enabled, false, nil)
+
+      {:error, :conflict} ->
+        conn |> put_status(409) |> json(%{error: "conflict"})
+
+      {:error, :not_found} ->
+        conn |> put_status(404) |> json(%{error: "not_found"})
+    end
+  end
+
+  def batch_move(conn, %{"paths" => paths, "target_folder" => target}) when is_list(paths) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    case Attachments.batch_move(user, vault, paths, target) do
+      {:ok, %{moved: n}} ->
+        body = %{moved: n}
+        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+        json(conn, body)
+
+      {:error, {:conflict, p}} ->
+        conn |> put_status(409) |> json(%{error: "conflict", item_path: p})
+
+      {:error, {:not_found, p}} ->
+        conn |> put_status(404) |> json(%{error: "not_found", item_path: p})
+
+      {:error, _} ->
+        conn |> put_status(500) |> json(%{error: "internal"})
+    end
+  end
+
+  def batch_delete(conn, %{"paths" => paths}) when is_list(paths) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+    {:ok, %{deleted: n}} = Attachments.batch_delete(user, vault, paths)
+    body = %{deleted: n}
+    Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+    json(conn, body)
+  end
+```
+
+- [ ] **Step 4: Implement routes**
+
+In `lib/engram_web/router.ex`, attachments block (after line 356, the `/attachments/changes` route — keep `rename` BEFORE the `/attachments/*path` catch-all):
+
+```elixir
+    post "/attachments/rename", AttachmentsController, :rename
+```
+
+And add the two batch routes to the existing `IdempotencyKey` scope (lines 326–334, beside the notes batch routes):
+
+```elixir
+    post "/attachments/batch-move", AttachmentsController, :batch_move
+    post "/attachments/batch-delete", AttachmentsController, :batch_delete
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `mix test test/engram_web/controllers/attachments_controller_test.exs`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/engram_web/controllers/attachments_controller.ex lib/engram_web/router.ex test/engram_web/controllers/attachments_controller_test.exs
+git commit -m "feat(attachments): rename + batch-move + batch-delete endpoints"
+```
+
+---
+
+## Task 7: Frontend mutation hooks
+
+**Files:**
+- Modify: `frontend/src/api/queries.ts` — add three hooks
+- Test: `frontend/src/api/queries.test.ts` (or the existing queries test file — match location)
+
+**Mirrors:** `useRenameNote` (`queries.ts:1140`), `useBatchMoveNotes` (`:1779`), `useBatchDeleteNotes` (`:1721`), and `idempotencyHeaders()` (`:1707`). `api.post` signature: `post<T>(path, body?, { headers })` (`client.ts:85`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// in the existing queries test file
+import { useRenameAttachment } from './queries'
+// (follow the file's existing render-hook + mock-api pattern; assert the
+// mutationFn POSTs '/attachments/rename' with {old_path,new_path} and that
+// onSettled invalidates ['folders', vaultId] and ['attachments', vaultId])
+```
+
+> If `queries.ts` has no unit test harness, skip the unit test and rely on the e2e + manual smoke (Task 11). Note that in the plan's progress comment so it isn't a silent gap.
+
+- [ ] **Step 2: Implement the hooks**
+
+Append to `frontend/src/api/queries.ts`:
+
+```ts
+export function useRenameAttachment() {
+  const qc = useQueryClient()
+  const vaultId = useActiveVaultId()
+  return useMutation<
+    { renamed: boolean; old_path: string; new_path: string },
+    ApiError,
+    { old_path: string; new_path: string }
+  >({
+    mutationFn: (vars) =>
+      api.post<{ renamed: boolean; old_path: string; new_path: string }>('/attachments/rename', vars),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['folders', vaultId] })
+      qc.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
+      qc.invalidateQueries({ queryKey: ['attachments', vaultId] })
+    },
+  })
+}
+
+export function useBatchMoveAttachments() {
+  const qc = useQueryClient()
+  const vaultId = useActiveVaultId()
+  return useMutation<{ moved: number }, ApiError, { paths: string[]; target_folder: string }>({
+    mutationFn: ({ paths, target_folder }) =>
+      api.post<{ moved: number }>('/attachments/batch-move', { paths, target_folder }, idempotencyHeaders()),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['folders', vaultId] })
+      qc.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
+      qc.invalidateQueries({ queryKey: ['attachments', vaultId] })
+    },
+  })
+}
+
+export function useBatchDeleteAttachments() {
+  const qc = useQueryClient()
+  const vaultId = useActiveVaultId()
+  return useMutation<{ deleted: number }, ApiError, { paths: string[] }>({
+    mutationFn: ({ paths }) =>
+      api.post<{ deleted: number }>('/attachments/batch-delete', { paths }, idempotencyHeaders()),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['folders', vaultId] })
+      qc.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
+      qc.invalidateQueries({ queryKey: ['attachments', vaultId] })
+    },
+  })
+}
+```
+
+> Confirm the attachments query key (`['attachments', vaultId]`) matches the Phase-1 list query key in `queries.ts` — adjust if it differs.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `cd frontend && bun run build && bunx biome check src/api/queries.ts`
+Expected: no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/queries.ts
+git commit -m "feat(web): attachment rename + batch move/delete mutation hooks"
+```
+
+---
+
+## Task 8: Frontend tree wiring — un-suppress + thread the `attachment` kind
+
+**Files:**
+- Modify: `frontend/src/viewer/tree-actions/action-list.ts` — `ATTACHMENT_ACTIONS` + `actionsFor`
+- Modify: `frontend/src/viewer/tree/tree-row.tsx` — un-suppress menu/long-press on attachment `<Link>`
+- Modify: `frontend/src/viewer/folder-tree.tsx` — `onRenameCommit`, `onMove`, `rowsFor`, `partition`, `commitDelete`, `kindOf`, `titleForItem`
+
+**Key facts:** `parseItemId` already returns `{kind:'attachment', path}` (`tree/types.ts:38`). Attachments are **path-keyed** (no id), so all branches thread `path`, not id. Move target stays a folder *path* string (synthetic attachment folders "just work").
+
+- [ ] **Step 1: `action-list.ts` — attachment actions**
+
+```ts
+const ATTACHMENT_ACTIONS: readonly Action[] = [
+  { id: 'rename', label: 'Rename' },
+  { id: 'move', label: 'Move to…' },
+  { id: 'delete', label: 'Delete', destructive: true },
+]
+
+// in actionsFor(kind): add
+//   if (kind === 'attachment') return ATTACHMENT_ACTIONS
+```
+
+(Subset of `FILE_ACTIONS` — no duplicate / copy-wikilink for binaries.)
+
+- [ ] **Step 2: `tree-row.tsx` — un-suppress (lines 93–124 attachment branch)**
+
+Add the same affordances the note branch uses (`tree-row.tsx:138`) to the attachment `<Link>`:
+
+```tsx
+    <Link
+      to={`/note/${item.id}`}
+      {...instance.getProps()}
+      {...longPressProps}
+      onContextMenu={contextMenuHandler}
+      aria-selected={instance.isSelected()}
+      className={rowClass(instance)}
+      style={{ paddingLeft: `${notePad}px` }}
+    >
+```
+
+Ensure `longPressProps` / `contextMenuHandler` are computed for the attachment branch too (lift them above the `if (item.kind === 'attachment')` early-return, or compute per-kind). The handlers dispatch by the row's item id — `parseItemId` already yields the `attachment` kind.
+
+- [ ] **Step 3: `folder-tree.tsx` — thread the kind**
+
+`onRenameCommit` (lines 89–110) — add an attachment branch:
+
+```tsx
+  } else if (p.kind === 'attachment') {
+    const parts = p.path.split('/')
+    parts[parts.length - 1] = newName
+    const new_path = parts.join('/')
+    renameAttachment.mutateAsync({ old_path: p.path, new_path }).catch(() => toast.error('Rename failed'))
+  }
+```
+
+`onMove` (lines 114–134) — partition attachment source paths and call the attachment batch-move with the target folder *name*:
+
+```tsx
+  const attachmentPaths = parsed.filter((x) => x.kind === 'attachment').map((x) => (x as { path: string }).path)
+  const destFolder = target.kind === 'root' ? '' : (folders?.find((f) => f.id === target.id)?.name ?? '')
+  if (attachmentPaths.length) batchMoveAttachments.mutate({ paths: attachmentPaths, target_folder: destFolder })
+```
+
+`partition` (lines 336–348), `commitDelete` (lines 350–357) — collect attachment paths and call `batchDeleteAttachments.mutate({ paths })`:
+
+```tsx
+function partition(itemIds: string[]) {
+  const noteIds: string[] = []; const folderIds: string[] = []; const attachmentPaths: string[] = []
+  for (const id of itemIds) {
+    const p = parseItemId(id)
+    if (p.kind === 'note') noteIds.push(p.id)
+    else if (p.kind === 'folder' && !isSyntheticFolderId(p.id)) folderIds.push(p.id)
+    else if (p.kind === 'attachment') attachmentPaths.push(p.path)
+  }
+  return { noteIds, folderIds, attachmentPaths }
+}
+// commitDelete: if (attachmentPaths.length) batchDeleteAttachments.mutate({ paths: attachmentPaths })
+```
+
+`rowsFor` (lines 226–246) — add an attachment case returning `[{ kind: 'file', path: p.path }]` (delete + move dialogs both take `{kind:'file', path}`).
+
+`kindOf` (lines 258–261) — `attachment` returns `'file'` (dialogs treat attachments as files). `titleForItem` (lines 263–274) — attachment returns `p.path.split('/').pop()`.
+
+Wire the new hooks at the top of the component:
+
+```tsx
+const renameAttachment = useRenameAttachment()
+const batchMoveAttachments = useBatchMoveAttachments()
+const batchDeleteAttachments = useBatchDeleteAttachments()
+```
+
+- [ ] **Step 4: Build + lint**
+
+```bash
+cd frontend && bun run build && bunx biome check src/viewer
+```
+
+Expected: no type errors. (`bun run lint:obsidian`/`lint:css` are plugin-side; run frontend biome here.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer
+git commit -m "feat(web): enable rename/move/delete on attachment tree rows"
+```
+
+---
+
+## Task 9: Plugin convergence — verify (likely zero source change)
+
+**Files:** none expected. Verification only.
+
+The plugin already: polls `/attachments/changes` and trashes `deleted` rows / writes upserts (`sync.ts` ~2024 `applyAttachmentChange`); echo-suppresses via `syncState` FNV-1a; dispatches socket `note_changed` by `kind:"attachment"` (`channel.ts` ~252, `sync.ts:1599` `handleStreamEvent`). A backend move = tombstone(old) + repoint(new) in both the poll feed and two `note_changed` broadcasts → plugin trashes old + writes new, echo-suppressed.
+
+- [ ] **Step 1: Read and confirm**
+
+Read `sync.ts` `applyAttachmentChange` and `handleStreamEvent`; confirm a `note_changed` event with `kind:"attachment", event_type:"delete"` reaches `trashFile` + `removeEmptyFolders`. Confirm the upsert path fetches the blob via `getAttachment(path)` and `modifyBinary`/`createBinaryFileWithFolders`, then records `syncState`.
+
+- [ ] **Step 2: Only if a gap is found** — fix minimally in `sync.ts`/`channel.ts`, bump `manifest.json` once, open a paired plugin PR named `feat/attachment-actions-and-rename-convergence` (for `plugin_branch` e2e pairing). Otherwise no plugin PR.
+
+- [ ] **Step 3: Note the outcome** in the PR description (e.g. "plugin converges with zero source change; verified by e2e test_NN").
+
+---
+
+## Task 10: E2E — web-originated attachment move converges in Obsidian
+
+**Files:**
+- Create/modify: `e2e/tests/` — a new attachment-move convergence test (follow the existing rename/move e2e shape)
+- Test infra: `make e2e` (CI stack + Obsidian)
+
+- [ ] **Step 1: Write the e2e**
+
+Scenario: seed an attachment in vault A (push from Obsidian or upload via API) → perform a web-originated move (`POST /api/attachments/rename`) → assert in Obsidian A: file appears at new path, **no file remains at old path** (no duplicate, no resurrection after a full reconcile pull). Cover both: (a) live socket delivery, (b) offline catch-up (disconnect socket, move, reconnect → poll/cursor convergence).
+
+- [ ] **Step 2: Run**
+
+```bash
+make ci-up && make e2e   # or the targeted test file
+```
+
+Expected: PASS — no duplicate at old path on either path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/tests
+git commit -m "test(e2e): web attachment move converges in Obsidian (no dup)"
+```
+
+---
+
+## Task 11: PR1 finalize
+
+- [ ] **Step 1: Full backend suite + frontend build**
+
+```bash
+mix test
+cd frontend && bun run build && bunx biome check src
+```
+
+Expected: green.
+
+- [ ] **Step 2: Bump `mix.exs` version once** (per project rule — one bump per PR, surface collisions rather than re-bumping).
+
+- [ ] **Step 3: Manual smoke** (per the local-browser CDP tunnel doc): right-click an attachment in the web tree → Rename / Move / Delete → confirm the tree updates and a paired Obsidian vault converges.
+
+- [ ] **Step 4: Open PR1** (engram). Title: `feat: attachment actions (delete/rename/move) + uuid-keyed storage + tombstone convergence`. Body links the spec + this plan; notes the plugin needed zero source change (or links the paired plugin PR).
+
+---
+
+# PR 2 — Single-note `rename_note` tombstone (the spec PR2 remainder)
+
+> Separate, small, high-blast-radius PR. Folder rename already emits tombstones (#614); this closes the matching single-note gap so an **offline** client converges a web/MCP-originated note rename without a duplicate.
+
+## Task 12: `rename_note` inserts an old-path tombstone
+
+**Files:**
+- Modify: `lib/engram/notes.ex` — `do_rename_note_inner/5` (lines 715–771) + `do_rename_note/6` success arm (lines 687–699)
+- Test: `test/engram/notes_seq_feed_test.exs`, `test/engram/notes_test.exs`
+
+**Mirror:** the folder-rename tombstone insert (`notes.ex` ~2265): same-seq, in-txn, fresh-uuid soft-deleted row at the old path, path encrypted under its own id-AAD. **Must NOT** enqueue `EmbedNote` for the tombstone, and folder counts already filter `deleted_at IS NULL` (assert it holds).
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/engram/notes_seq_feed_test.exs
+test "single note rename emits an old-path tombstone in the seq feed", %{user: user, vault: vault} do
+  {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "A"})
+  {:ok, _} = Notes.rename_note(user, vault, "a.md", "b.md")
+
+  {:ok, %{changes: all}} = Notes.list_changes_by_seq(user, vault, 0)
+  assert Enum.any?(all, &(&1.path == "a.md" and &1.deleted))
+  assert Enum.any?(all, &(&1.path == "b.md" and not &1.deleted))
+end
+
+test "rename tombstone does not resurrect: re-create at old path succeeds", %{user: user, vault: vault} do
+  {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "A"})
+  {:ok, _} = Notes.rename_note(user, vault, "a.md", "b.md")
+  assert {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "A2"})
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mix test test/engram/notes_seq_feed_test.exs -k "tombstone"`
+Expected: FAIL — only `b.md` present; no `a.md` tombstone.
+
+- [ ] **Step 3: Implement**
+
+In `do_rename_note_inner/5`, after the `Repo.update_all` repoint (line 749) and inside the same `Repo.with_tenant` txn that `do_rename_note/6` runs, insert the old-path tombstone using the SAME `seq` already allocated at line 738. Build it from in-memory data (fresh uuid, path encrypted under its own id-AAD via `full_aad_bound_kw` or the path-only helper, `deleted_at: now`, `seq: seq`, `embed_hash: nil`). Return the renamed note unchanged. The success arm (lines 690–694) must keep enqueuing `EmbedNote` for the **renamed** note only — never for the tombstone.
+
+> Use the exact same tombstone-row construction the folder cascade uses (`notes.ex` ~2272+) so encryption/AAD/columns stay consistent. The single-note case inserts exactly one tombstone.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `mix test test/engram/notes_seq_feed_test.exs test/engram/notes_test.exs`
+Expected: PASS, including the existing rename + folder-count tests (tombstones invisible to count queries).
+
+- [ ] **Step 5: E2E — offline single-note rename converges (no dup)**
+
+Add/extend an e2e mirroring Task 10 but for a note rename with the socket disconnected during the rename, then reconnect.
+
+- [ ] **Step 6: Bump `mix.exs` once + commit + open PR2**
+
+```bash
+git add lib/engram/notes.ex test/engram
+git commit -m "fix(sync): rename_note emits old-path tombstone (offline convergence)"
+```
+
+PR2 title: `fix(sync): single-note rename tombstone — close offline resurrection gap`.
+
+---
+
+## Self-Review (run after writing — done)
+
+- **Spec coverage:** S3 re-keying (T1–T2) ✓; move + tombstone (T3) ✓; batch (T4) ✓; sockets (T5, reused `note_changed`) ✓; endpoints + gating + idempotency (T6) ✓; frontend (T7–T8) ✓; plugin parity (T9) ✓; e2e (T10) ✓; notes/folder tombstone — folder already shipped, single-note (T12) ✓. Spec section "upload on web" is explicitly Phase 3 (out of scope). Spec's separate `attachment_changed` socket → deliberately replaced by `note_changed`+`kind` (documented in re-scope note).
+- **Type consistency:** `move_attachment/4` → `{:ok, att} | {:error, :conflict | :not_found}` used identically in controller; `batch_move/4` → `{:ok, %{moved}} | {:error, {:conflict|:not_found, path}}`; hooks post `{paths, target_folder}` matching the controller's `%{"paths" => _, "target_folder" => _}`.
+- **Placeholders:** none — every code step shows real code; the two soft spots (frontend hook unit test harness may be absent; `unwrap_tenant` return shape) are flagged inline with concrete fallbacks, not left as TODO.
+
+---
+
+## Follow-ups (filed, not built here)
+
+1. Tombstone pruning / GC (bounded growth: one per move, N+1 per folder rename).
+2. Reconcile divergence audit (offline-local-delete detection) → Sync Architecture Overhaul track.
+3. Legacy attachment blob re-key backfill (optional; reads already route via `storage_key`).
+4. When the plugin adopts the unified `/sync/changes` cursor pull (branches `feat/sync-cursor-pull-b2`), confirm attachment tombstones flow through it too — `list_changes_by_seq` already carries them (no `deleted_at` filter), so expected zero extra work.

--- a/docs/superpowers/specs/2026-06-16-attachment-actions-and-rename-convergence-design.md
+++ b/docs/superpowers/specs/2026-06-16-attachment-actions-and-rename-convergence-design.md
@@ -1,0 +1,275 @@
+# Attachment Actions + Durable Rename Convergence + Real-Time Sockets
+
+**Date:** 2026-06-16
+**Status:** Design — approved for planning
+**Repos:** `engram` (backend + `frontend/`) and `engram-obsidian-sync` (plugin)
+**Branches:** `feat/attachment-actions-and-rename-convergence` (engram) + a paired
+plugin branch of the same name (for `plugin_branch` e2e pairing)
+**Supersedes/extends:** Phase 1 — `2026-06-14-attachments-in-file-tree-design.md`
+
+## Problem
+
+Phase 1 made attachments **display + preview only** in the web file tree —
+they render and open read-only, but every action affordance (context menu,
+long-press, drag) was deliberately suppressed on attachment rows. Phase 2 turns
+those on: **delete, rename, move**, with full multi-select batch parity
+alongside notes.
+
+Designing the move/rename exposed two deeper issues that this spec also closes:
+
+1. **The S3 object key is path-derived** (`Storage.key/3` =
+   `"<user>/<vault>/<path>"`), so a naive move would require physically
+   relocating the blob and could let a reused path clobber another file's blob.
+2. **Attachment sync is poll-only and lossy on renames.** The plugin converges
+   via `GET /attachments/changes` (apply `deleted:true` → trash; else upsert at
+   path). A move that simply repoints a row emits only `{newPath}` — never
+   `{oldPath, deleted:true}` — so the plugin would keep a **duplicate** at the
+   old path, and its full-reconcile would *re-push* (resurrect) the orphan.
+   Notes/folders have the **same latent rename gap**, masked only by their
+   real-time socket broadcast (which an offline client misses).
+
+This spec ships actionable attachments **and** the durable-tombstone primitive
+that makes a rename converge on every path (socket, poll, and offline
+reconcile), then extends that primitive to notes and folders.
+
+## Scope
+
+**In:**
+- Attachment **delete / rename / move**, single + batch (mixed note+attachment
+  multi-select), reusing the existing tree-action dialogs.
+- **S3 re-keying:** new attachment blobs keyed by row UUID, decoupled from the
+  vault path. Move/rename becomes pure metadata (zero blob I/O).
+- **Durable old-path tombstone** on attachment move (poll/offline convergence).
+- **Real-time `attachment_changed` socket broadcast** + plugin channel handler
+  (note-parity).
+- **Extend the rename tombstone to notes + folders** (`rename_note`,
+  `rename_folder`, incl. the folder cascade fan-out).
+
+**Out / deferred:**
+- **Upload on web** (drag-drop + paid gating) — Phase 3.
+- **Legacy blob re-key backfill** — existing path-keyed blobs keep working via
+  the `storage_key` column; a backfill is optional (per "data wipeable
+  pre-launch") and not load-bearing.
+- **Tombstone pruning / GC** — tombstones accumulate (one per move; N+1 per
+  folder rename). Bounded, harmless (partial index excludes them). A prune job
+  is a tracked follow-up.
+- **Full version-vector reconcile** ("month-stale vault converges perfectly")
+  — belongs to the existing Sync Architecture Overhaul track. This spec adds
+  the correct *primitive* (durable rename tombstone) but not the three-way
+  baseline-diff reconcile.
+- **Offline-local-delete detection audit** (file deleted while app closed) —
+  tracked follow-up feeding the sync-overhaul track.
+
+## Decisions (locked during brainstorming)
+
+1. **Batch parity** — attachments join multi-select batch delete/move (mixed
+   note+attachment selections); rename stays single-item (notes have no batch
+   rename either).
+2. **UUID-keyed S3 storage** — `storage_key` decoupled from the vault path;
+   move/rename never touches the blob. S3 layout no longer mirrors the vault.
+3. **Durable old-path tombstone** on every move/rename (the convergence signal).
+4. **Real-time sockets** — add `attachment_changed` broadcast + plugin handler,
+   bringing attachments to note-parity.
+5. **One unified spec, two sequenced PRs** — PR1 (low-risk corner: attachments
+   + sockets + frontend + plugin), PR2 (high-blast-radius: notes/folders
+   tombstones). Plus the paired plugin PR.
+6. **Notes/folders rename tombstone folded in** (PR2) — same primitive, applied
+   to the busiest path in the product.
+
+## Architecture
+
+### A. S3 storage re-keying (foundational, PR1)
+
+Decouple the object key from the mutable vault path; key by the immutable row
+UUID instead.
+
+- New builder `Storage.object_key(user_id, vault_id, uuid)` →
+  `"<user>/<vault>/objects/<uuid>"`. The `objects/` namespace keeps new keys
+  visually distinct from legacy path-derived keys in the bucket.
+- `Attachments.prepare_upload/8` mints `storage_key` from the row UUID
+  (`att_id`), **not** `Storage.key(path)`.
+- `Attachments.delete_external/_` deletes `att.storage_key` (the column) — not a
+  path-recompute. Correct for both new UUID-keyed and legacy path-keyed rows.
+  **This is the current latent bug** (delete recomputes from `path`; reads
+  already prefer `storage_key`).
+- Reads (`get_attachment/3`, `UserDekRotation`) already route through
+  `storage_key` → unchanged.
+- **Legacy blobs keep working** via their stored path-key. No backfill required.
+
+**Why this matters:** with path-keyed storage, a move would have to physically
+relocate the blob, and a new upload to a vacated path would compute the same
+key and **clobber** the moved blob (S3 last-write-wins; Database adapter
+`ON CONFLICT (storage_key)`). UUID-keying makes a new upload always compute a
+fresh key — collision impossible — and makes move a pure metadata edit.
+
+### B. Attachment move/rename + tombstone + batch (PR1)
+
+**`Attachments.move_attachment(user, vault, old_path, new_path)`** — mirrors
+`Notes.rename_note/4`. In one `Repo.transaction` under the existing per-path
+advisory lock:
+
+1. **No-op guard:** `old == new` → idempotent `{:ok, att}` (no tombstone).
+2. **Conflict check:** target `path_hmac` exists among non-deleted rows →
+   `{:error, :conflict}` (→ 409).
+3. **Repoint the live row** (id stable): re-encrypt `path` (same DEK, AAD bound
+   to the **unchanged** row id), recompute `path_hmac`, bump `updated_at`.
+   `storage_key`, `content_*`, and the blob are untouched.
+4. **Insert the tombstone** at `old_path`: fresh UUID, `path` encrypted under
+   its own id-AAD, `path_hmac = hmac(old_path)`, `deleted_at = updated_at = now`,
+   `storage_key = nil`, `content_hash` = carried from the live row (satisfies
+   the changeset; value irrelevant — row is deleted). Sole purpose: surface
+   `{old_path, deleted:true}` in the feed.
+
+The UUID stays stable, so the web's `/note/:id` routing and the open preview tab
+survive the move for free.
+
+**Endpoints** (mirror the notes shapes):
+- `POST /attachments/rename` `{old_path, new_path}` — rename **and** single
+  move (any path change). Gated by `Billing.check_feature(:attachments_enabled)`.
+- `POST /attachments/batch-move` and `POST /attachments/batch-delete` under the
+  existing `EngramWeb.Plugs.IdempotencyKey` pipeline (require
+  `X-Idempotency-Key`), mirroring `/notes/batch-*`.
+
+**Mixed selections:** the frontend partitions a selection by kind and calls the
+notes and attachments batch endpoints separately; each is independently
+idempotent.
+
+### C. Attachment socket broadcast + plugin handler (PR1 + plugin PR)
+
+- The attachment context emits a new **`attachment_changed`** event on the
+  existing `sync:<user>:<vault>` topic (mirroring `note_changed`), via
+  `EngramWeb.Endpoint.broadcast` (or `broadcast_from/4` to exclude the pusher).
+- Payload: `{op: "upsert" | "delete", path, mime_type, size_bytes, mtime}`.
+- A **move broadcasts two events** — `delete(old)` + `upsert(new)` — exactly
+  like `rename_note`. Delete and batch ops broadcast correspondingly.
+- **Plugin:** subscribe to `attachment_changed` on the existing sync channel;
+  apply with the **same logic as the poll path** (`deleted` → `trashFile` +
+  `removeEmptyFolders`; else fetch blob + write), recording the `syncState`
+  hash to **echo-suppress** the resulting local modify event. The plugin keeps
+  pushing attachments over HTTP — this is receive-only parity, no client→server
+  socket change.
+
+### D. Frontend tree actions (PR1)
+
+- `viewer/tree/tree-row.tsx` — **un-suppress** context-menu / long-press / drag
+  on the `attachment` branch.
+- `viewer/folder-tree.tsx` — extend `onMove`, `onRenameCommit`,
+  `openDelete`/`commitDelete`, `partition`, `rowsFor`, `kindOf`,
+  `titleForItem` to the `attachment` kind, **threading the path** (not id) per
+  the Phase-1 `parseItemId` shape (`{kind:'attachment', path}`).
+- `api/queries.ts` — add `useRenameAttachment`, `useBatchMoveAttachments`,
+  `useBatchDeleteAttachments` with cache invalidation, mirroring the notes
+  hooks. Reuse the `tree-actions/` dialogs unchanged.
+- **Move into a synthetic (attachment-only) folder** "just works" — it is a
+  path-string prefix change; no backend folder needs to exist.
+
+### E. Notes + folders rename tombstone (PR2, high blast radius)
+
+Extend the same primitive to `Notes.rename_note/4` and `Notes.rename_folder/4`,
+closing the offline-rename resurrection gap (currently masked by the socket).
+
+- **`rename_note`** — after the in-place repoint, insert **one** tombstone at
+  the old path (deleted note row, fresh UUID, path encrypted under its id-AAD,
+  `deleted_at = now`).
+- **`rename_folder`** — cascades via `update_all` over every contained note
+  (`A/x.md → B/x.md`). The poll/offline reconcile is path-based, so each vacated
+  path needs a durable delete signal: emit **N+1 tombstones** (one per contained
+  note + the folder marker), batched via `insert_all`.
+
+**Interactions to handle (and assert in tests):**
+- **Embeddings:** `rename_note` enqueues `EmbedNote`; tombstone rows must **not**
+  enqueue (they are deleted).
+- **Version vectors:** tombstones are `deleted` and must stay out of the
+  version-conflict path; a later re-create at the old path inserts a fresh live
+  row (partial unique index `WHERE deleted_at IS NULL` permits it).
+- **Folder counts / markers:** count queries already filter `deleted_at IS
+  NULL`, so tombstones are invisible — assert this holds.
+- **Transaction size:** folder-rename tombstones are written in the same txn as
+  the cascade; use a batched `insert_all`.
+
+## Data flow — attachment move (the crux)
+
+```
+Web: right-click attachment → Move dialog → useRenameAttachment
+        │  POST /attachments/rename {old, new}
+        ▼
+move_attachment (one txn, advisory lock):
+  • conflict-check hmac(new) among non-deleted → 409 if taken
+  • live row: path→new, re-encrypt path (AAD=id unchanged), hmac(new), updated_at
+              (storage_key + blob UNTOUCHED — uuid-keyed)
+  • tombstone row @ old: new uuid, hmac(old), deleted_at=now, storage_key=nil
+        │
+        ├─▶ socket: attachment_changed {delete, old} + {upsert, new}  ── live plugins
+        │            (plugin: trash old + write new, echo-suppressed)
+        │
+        └─▶ GET /attachments/changes?since  (poll / offline reconnect)
+                 → {old, deleted:true}  (tombstone)  → plugin trashes old
+                 → {new}                (live row)   → plugin writes new
+        ▼
+   Web tree + preview: UUID stable → open tab unaffected; tree re-keys to new path
+```
+
+## Error handling / edge cases
+
+- **Conflict** (move onto an occupied path) → `{:error, :conflict}` → 409,
+  surfaced in the move/rename dialog.
+- **Cross-kind path collision** (note vs attachment at the same path) — an
+  existing non-issue (Obsidian forbids it); out of scope. Conflict checks stay
+  within-kind, matching `rename_note`.
+- **No-op move** (`old == new`) — idempotent, no tombstone.
+- **Tombstone accumulation** — one per move, N+1 per folder rename; partial
+  unique index excludes them so they never block re-creation. Pruning deferred.
+- **Storage failures** on delete remain best-effort + logged (row already
+  soft-deleted), unchanged from today.
+
+## Testing strategy (TDD per unit)
+
+**Backend (`mix test`):**
+- `move_attachment/4`: repoint correctness (path re-encrypt under stable AAD),
+  tombstone emitted at old path, conflict → `:conflict`, no-op idempotency,
+  tenant isolation, `storage_key`/blob untouched.
+- `delete_external` deletes by `storage_key` (new UUID-keyed **and** legacy
+  path-keyed rows).
+- `prepare_upload` mints UUID-derived `storage_key`; a new upload to a vacated
+  path does **not** clobber a moved blob.
+- `POST /attachments/rename` + `batch-move` + `batch-delete`: shape, auth
+  (401), paid gating, idempotency replay, conflict (409).
+- `attachment_changed` broadcast: delete(old)+upsert(new) on move; payload shape.
+- **PR2:** `rename_note` tombstone; `rename_folder` N+1 tombstone fan-out;
+  no `EmbedNote` enqueue for tombstones; folder counts ignore tombstones;
+  re-create at a vacated path succeeds.
+
+**Frontend (`bun test`):** tree-action wiring for the attachment kind (menu /
+long-press / drag un-suppressed), the three mutations + cache invalidation,
+mixed-selection partition. Run `lint:obsidian` / `lint:css` / biome locally
+before pushing.
+
+**Plugin (`bun test`):** `attachment_changed` apply (trash / write) +
+echo-suppression via `syncState`.
+
+**E2E (`make e2e`, paired plugin branch):** web-originated attachment move
+converges in Obsidian — **no duplicate, no resurrection** — over both the live
+socket and a poll/offline-reconnect catch-up. Same for a note rename and a
+folder rename (PR2).
+
+## PR structure
+
+- **PR 1** — engram (backend + frontend) + **paired plugin PR**: A + B + C + D.
+  Proves the tombstone primitive in the low-risk attachment corner; ships
+  real-time parity.
+- **PR 2** — engram: E (notes + folders rename tombstones + offline-reconcile
+  tests). The core-sync change, isolated for focused review.
+
+One `mix.exs` version bump per engram PR; one plugin `manifest.json` bump per
+plugin PR (bump once at open, per project rules). Conventional commits.
+
+## Follow-up issues (filed, not built here)
+
+1. **Tombstone pruning / GC** — bound unbounded tombstone growth (retention >
+   max supported offline window).
+2. **Reconcile divergence audit** — offline-local-delete detection
+   (`syncState ∖ localFiles`) + tombstone-retention-vs-max-offline; feeds the
+   Sync Architecture Overhaul (version vectors + three-way baseline reconcile).
+3. **Legacy attachment blob re-key backfill** — optional migration of
+   path-keyed blobs to UUID keys (cosmetic; reads already route via
+   `storage_key`).

--- a/e2e/helpers/api.py
+++ b/e2e/helpers/api.py
@@ -155,6 +155,15 @@ class ApiClient:
         )
         return resp.status_code
 
+    def rename_attachment(self, old_path: str, new_path: str) -> int:
+        """POST /attachments/rename (web-origin move). Returns HTTP status code."""
+        resp = self.session.post(
+            f"{self.base_url}/attachments/rename",
+            json={"old_path": old_path, "new_path": new_path},
+            timeout=10,
+        )
+        return resp.status_code
+
     def append_note(self, path: str, text: str) -> int:
         """POST /notes/append. Returns HTTP status code."""
         resp = self.session.post(

--- a/e2e/tests/test_79_attachment_move_convergence.py
+++ b/e2e/tests/test_79_attachment_move_convergence.py
@@ -1,0 +1,100 @@
+"""Test 79: Web-originated attachment move converges in Obsidian — no duplicate.
+
+A move performed on the web (POST /attachments/rename) repoints the live row to
+the new path AND inserts a soft-deleted tombstone at the old path, both stamped
+with one per-vault seq in one transaction. That tombstone is the durable
+`{old_path, deleted: true}` signal that makes the move converge on every client:
+
+  * Live socket — the backend broadcasts note_changed(kind=attachment)
+    delete(old) + upsert(new); the plugin trashes old and writes new.
+  * Offline catch-up — a client that missed the ephemeral socket events pulls
+    the tombstone (deleted) + the repointed row (live) on reconnect and lands
+    in the same final state.
+
+Both paths must leave NO duplicate at the old path (no resurrection).
+"""
+
+import asyncio
+
+import pytest
+
+from helpers.vault import wait_for_binary, wait_for_file_gone, write_binary
+
+
+# Minimal valid PNG: 1x1 red pixel (same constant as test_33).
+TINY_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00"
+    b"\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00"
+    b"\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.mark.asyncio
+async def test_attachment_move_converges_via_live_socket(
+    vault_a, vault_b, cdp_a, cdp_b, api_sync
+):
+    """B is online: a web move lands the new path and trashes the old — no dup."""
+    old_path = "E2E/attachments/move79live-old.png"
+    new_path = "E2E/attachments/move79live-new.png"
+
+    # Seed: A creates the attachment, server stores it, B pulls a copy.
+    write_binary(vault_a, old_path, TINY_PNG)
+    api_sync.wait_for_attachment(old_path)
+    await cdp_b.trigger_full_sync()
+    wait_for_binary(vault_b, old_path, timeout=15)
+
+    # B is connected to the live channel before the move.
+    await cdp_b.wait_for_stream_connected(timeout=10)
+
+    # Web-originated move (repoint + old-path tombstone).
+    status = api_sync.rename_attachment(old_path, new_path)
+    assert status == 200, f"web move should return 200, got {status}"
+
+    # Server reflects the move: new reachable, old a 404.
+    api_sync.wait_for_attachment(new_path)
+    api_sync.wait_for_attachment_gone(old_path)
+
+    # B converges over the live socket: new written, old trashed — no duplicate.
+    b_data = wait_for_binary(vault_b, new_path, timeout=15)
+    assert b_data == TINY_PNG, "B's moved attachment bytes should be intact"
+    wait_for_file_gone(vault_b, old_path, timeout=15)
+
+
+@pytest.mark.asyncio
+async def test_attachment_move_converges_offline_catch_up(
+    vault_a, vault_b, cdp_a, cdp_b, api_sync
+):
+    """B misses the socket events while disconnected, then catches up — no dup.
+
+    This is the case the durable tombstone exists for: without the old-path
+    tombstone in the change feed, B's catch-up pull would see only the
+    repointed row at the new path and keep a stale duplicate at the old path.
+    """
+    old_path = "E2E/attachments/move79offline-old.png"
+    new_path = "E2E/attachments/move79offline-new.png"
+
+    # Seed: A creates the attachment, server stores it, B pulls a copy.
+    write_binary(vault_a, old_path, TINY_PNG)
+    api_sync.wait_for_attachment(old_path)
+    await cdp_b.trigger_full_sync()
+    wait_for_binary(vault_b, old_path, timeout=15)
+
+    # Take B offline so it misses the ephemeral move broadcasts.
+    await cdp_b.wait_for_stream_connected(timeout=10)
+    await cdp_b.disconnect_stream()
+    await asyncio.sleep(0.3)
+    assert not await cdp_b.check_stream_connected(), "B's channel should be down"
+
+    # Web move happens while B is disconnected.
+    status = api_sync.rename_attachment(old_path, new_path)
+    assert status == 200, f"web move should return 200, got {status}"
+    api_sync.wait_for_attachment(new_path)
+    api_sync.wait_for_attachment_gone(old_path)
+
+    # Reconnect → catch-up pull delivers BOTH the upsert(new) and the
+    # tombstone(old). B converges with no duplicate.
+    await cdp_b.reconnect_stream()
+    b_data = wait_for_binary(vault_b, new_path, timeout=15)
+    assert b_data == TINY_PNG, "B's moved attachment bytes should be intact"
+    wait_for_file_gone(vault_b, old_path, timeout=15)

--- a/e2e/tests/test_79_attachment_move_convergence.py
+++ b/e2e/tests/test_79_attachment_move_convergence.py
@@ -12,14 +12,21 @@ with one per-vault seq in one transaction. That tombstone is the durable
     in the same final state.
 
 Both paths must leave NO duplicate at the old path (no resurrection).
+
+The seed attachment is uploaded via the API (web-origin) rather than written to
+vault A and waited on — that keeps the setup off the plugin's binary-push timing
+(which is slow under parallel CI load) and matches the web-origin theme.
 """
 
 import asyncio
 
 import pytest
 
-from helpers.vault import wait_for_binary, wait_for_file_gone, write_binary
+from helpers.vault import wait_for_binary, wait_for_file_gone
 
+# B-side convergence (socket delivery / catch-up pull + blob fetch) can lag under
+# parallel CI load — give it more room than the suite's 15s default.
+CONVERGE_TIMEOUT = 25
 
 # Minimal valid PNG: 1x1 red pixel (same constant as test_33).
 TINY_PNG = (
@@ -38,11 +45,11 @@ async def test_attachment_move_converges_via_live_socket(
     old_path = "E2E/attachments/move79live-old.png"
     new_path = "E2E/attachments/move79live-new.png"
 
-    # Seed: A creates the attachment, server stores it, B pulls a copy.
-    write_binary(vault_a, old_path, TINY_PNG)
+    # Seed via the API (web-origin upload → immediately on the server), then B pulls.
+    assert api_sync.upload_attachment(old_path, TINY_PNG, "image/png") == 200
     api_sync.wait_for_attachment(old_path)
     await cdp_b.trigger_full_sync()
-    wait_for_binary(vault_b, old_path, timeout=15)
+    wait_for_binary(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
 
     # B is connected to the live channel before the move.
     await cdp_b.wait_for_stream_connected(timeout=10)
@@ -56,9 +63,9 @@ async def test_attachment_move_converges_via_live_socket(
     api_sync.wait_for_attachment_gone(old_path)
 
     # B converges over the live socket: new written, old trashed — no duplicate.
-    b_data = wait_for_binary(vault_b, new_path, timeout=15)
+    b_data = wait_for_binary(vault_b, new_path, timeout=CONVERGE_TIMEOUT)
     assert b_data == TINY_PNG, "B's moved attachment bytes should be intact"
-    wait_for_file_gone(vault_b, old_path, timeout=15)
+    wait_for_file_gone(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
 
 
 @pytest.mark.asyncio
@@ -74,11 +81,11 @@ async def test_attachment_move_converges_offline_catch_up(
     old_path = "E2E/attachments/move79offline-old.png"
     new_path = "E2E/attachments/move79offline-new.png"
 
-    # Seed: A creates the attachment, server stores it, B pulls a copy.
-    write_binary(vault_a, old_path, TINY_PNG)
+    # Seed via the API, then B pulls a copy.
+    assert api_sync.upload_attachment(old_path, TINY_PNG, "image/png") == 200
     api_sync.wait_for_attachment(old_path)
     await cdp_b.trigger_full_sync()
-    wait_for_binary(vault_b, old_path, timeout=15)
+    wait_for_binary(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
 
     # Take B offline so it misses the ephemeral move broadcasts.
     await cdp_b.wait_for_stream_connected(timeout=10)
@@ -95,6 +102,6 @@ async def test_attachment_move_converges_offline_catch_up(
     # Reconnect → catch-up pull delivers BOTH the upsert(new) and the
     # tombstone(old). B converges with no duplicate.
     await cdp_b.reconnect_stream()
-    b_data = wait_for_binary(vault_b, new_path, timeout=15)
+    b_data = wait_for_binary(vault_b, new_path, timeout=CONVERGE_TIMEOUT)
     assert b_data == TINY_PNG, "B's moved attachment bytes should be intact"
-    wait_for_file_gone(vault_b, old_path, timeout=15)
+    wait_for_file_gone(vault_b, old_path, timeout=CONVERGE_TIMEOUT)

--- a/e2e/tests/test_79_attachment_move_convergence.py
+++ b/e2e/tests/test_79_attachment_move_convergence.py
@@ -2,20 +2,16 @@
 
 A move performed on the web (POST /attachments/rename) repoints the live row to
 the new path AND inserts a soft-deleted tombstone at the old path, both stamped
-with one per-vault seq in one transaction. That tombstone is the durable
-`{old_path, deleted: true}` signal that makes the move converge on every client:
+with one per-vault seq in one transaction. That durable `{old_path, deleted}`
+tombstone is what makes the move converge for a client that pulls the change
+feed (the offline / catch-up path) — without it, the pull would see only the
+repointed row at the new path and keep a stale duplicate at the old path.
 
-  * Live socket — the backend broadcasts note_changed(kind=attachment)
-    delete(old) + upsert(new); the plugin trashes old and writes new.
-  * Offline catch-up — a client that missed the ephemeral socket events pulls
-    the tombstone (deleted) + the repointed row (live) on reconnect and lands
-    in the same final state.
-
-Both paths must leave NO duplicate at the old path (no resurrection).
-
-The seed attachment is uploaded via the API (web-origin) rather than written to
-vault A and waited on — that keeps the setup off the plugin's binary-push timing
-(which is slow under parallel CI load) and matches the web-origin theme.
+These tests assert convergence through an explicit pull (`trigger_full_sync`)
+rather than racing live-socket delivery: the pull path is the one the tombstone
+exists for, and it's deterministic under parallel CI load. Each test cleans up
+server-side state first so it is safe under pytest reruns (a move mutates shared
+vault state irreversibly, so a re-run must start from a known-clean slate).
 """
 
 import asyncio
@@ -24,8 +20,8 @@ import pytest
 
 from helpers.vault import wait_for_binary, wait_for_file_gone
 
-# B-side convergence (socket delivery / catch-up pull + blob fetch) can lag under
-# parallel CI load — give it more room than the suite's 15s default.
+# B-side convergence (pull + blob fetch) can lag under parallel CI load — give
+# it more room than the suite's 15s default.
 CONVERGE_TIMEOUT = 25
 
 # Minimal valid PNG: 1x1 red pixel (same constant as test_33).
@@ -37,13 +33,19 @@ TINY_PNG = (
 )
 
 
+def _seed_clean(api_sync, *paths):
+    """Soft-delete any leftover rows at these paths (idempotent) so the test
+    starts from a clean slate even on a pytest rerun after a partial failure."""
+    for p in paths:
+        api_sync.delete_attachment(p)
+
+
 @pytest.mark.asyncio
-async def test_attachment_move_converges_via_live_socket(
-    vault_a, vault_b, cdp_a, cdp_b, api_sync
-):
-    """B is online: a web move lands the new path and trashes the old — no dup."""
-    old_path = "E2E/attachments/move79live-old.png"
-    new_path = "E2E/attachments/move79live-new.png"
+async def test_web_move_converges_via_pull(vault_a, vault_b, cdp_a, cdp_b, api_sync):
+    """A web move lands the new path and trashes the old on B's pull — no dup."""
+    old_path = "E2E/attachments/move79pull-old.png"
+    new_path = "E2E/attachments/move79pull-new.png"
+    _seed_clean(api_sync, old_path, new_path)
 
     # Seed via the API (web-origin upload → immediately on the server), then B pulls.
     assert api_sync.upload_attachment(old_path, TINY_PNG, "image/png") == 200
@@ -51,35 +53,31 @@ async def test_attachment_move_converges_via_live_socket(
     await cdp_b.trigger_full_sync()
     wait_for_binary(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
 
-    # B is connected to the live channel before the move.
-    await cdp_b.wait_for_stream_connected(timeout=10)
-
-    # Web-originated move (repoint + old-path tombstone).
-    status = api_sync.rename_attachment(old_path, new_path)
-    assert status == 200, f"web move should return 200, got {status}"
-
-    # Server reflects the move: new reachable, old a 404.
+    # Web-originated move: repoint live row + insert old-path tombstone.
+    assert api_sync.rename_attachment(old_path, new_path) == 200
     api_sync.wait_for_attachment(new_path)
     api_sync.wait_for_attachment_gone(old_path)
 
-    # B converges over the live socket: new written, old trashed — no duplicate.
-    b_data = wait_for_binary(vault_b, new_path, timeout=CONVERGE_TIMEOUT)
-    assert b_data == TINY_PNG, "B's moved attachment bytes should be intact"
+    # B converges on its next pull: the tombstone trashes old, the repointed row
+    # writes new — no duplicate left at the old path.
+    await cdp_b.trigger_full_sync()
+    assert wait_for_binary(vault_b, new_path, timeout=CONVERGE_TIMEOUT) == TINY_PNG
     wait_for_file_gone(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
 
 
 @pytest.mark.asyncio
-async def test_attachment_move_converges_offline_catch_up(
+async def test_web_move_converges_after_offline_window(
     vault_a, vault_b, cdp_a, cdp_b, api_sync
 ):
-    """B misses the socket events while disconnected, then catches up — no dup.
+    """B is offline during the move, then catches up on reconnect — no dup.
 
-    This is the case the durable tombstone exists for: without the old-path
-    tombstone in the change feed, B's catch-up pull would see only the
-    repointed row at the new path and keep a stale duplicate at the old path.
+    This is the scenario the durable tombstone is for: B never sees the ephemeral
+    move broadcasts, so it must learn the old path is gone purely from the pulled
+    change feed.
     """
     old_path = "E2E/attachments/move79offline-old.png"
     new_path = "E2E/attachments/move79offline-new.png"
+    _seed_clean(api_sync, old_path, new_path)
 
     # Seed via the API, then B pulls a copy.
     assert api_sync.upload_attachment(old_path, TINY_PNG, "image/png") == 200
@@ -87,21 +85,20 @@ async def test_attachment_move_converges_offline_catch_up(
     await cdp_b.trigger_full_sync()
     wait_for_binary(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
 
-    # Take B offline so it misses the ephemeral move broadcasts.
+    # Take B offline so it misses the ephemeral move broadcasts entirely.
     await cdp_b.wait_for_stream_connected(timeout=10)
     await cdp_b.disconnect_stream()
     await asyncio.sleep(0.3)
     assert not await cdp_b.check_stream_connected(), "B's channel should be down"
 
     # Web move happens while B is disconnected.
-    status = api_sync.rename_attachment(old_path, new_path)
-    assert status == 200, f"web move should return 200, got {status}"
+    assert api_sync.rename_attachment(old_path, new_path) == 200
     api_sync.wait_for_attachment(new_path)
     api_sync.wait_for_attachment_gone(old_path)
 
-    # Reconnect → catch-up pull delivers BOTH the upsert(new) and the
-    # tombstone(old). B converges with no duplicate.
+    # Reconnect, then pull: the catch-up delivers the tombstone(old) + the
+    # repointed row(new). B converges with no duplicate.
     await cdp_b.reconnect_stream()
-    b_data = wait_for_binary(vault_b, new_path, timeout=CONVERGE_TIMEOUT)
-    assert b_data == TINY_PNG, "B's moved attachment bytes should be intact"
+    await cdp_b.trigger_full_sync()
+    assert wait_for_binary(vault_b, new_path, timeout=CONVERGE_TIMEOUT) == TINY_PNG
     wait_for_file_gone(vault_b, old_path, timeout=CONVERGE_TIMEOUT)

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -44,8 +44,10 @@ import {
   type Note,
   useAcceptTerms,
   useAttachments,
+  useBatchDeleteAttachments,
   useBatchDeleteFolders,
   useBatchDeleteNotes,
+  useBatchMoveAttachments,
   useBatchMoveFolders,
   useBatchMoveNotes,
   useCancelSubscription,
@@ -58,6 +60,7 @@ import {
   useFolders,
   useNote,
   usePlanChangePreview,
+  useRenameAttachment,
   useRenameFolder,
   useRenameNote,
   useReverseCancel,
@@ -1367,5 +1370,102 @@ describe('useAttachments', () => {
 
     expect(get).toHaveBeenCalledWith('/attachments')
     expect(result.current.data?.[0]?.path).toBe('a.png')
+  })
+})
+
+describe('useRenameAttachment', () => {
+  it('POSTs /attachments/rename with {old_path, new_path} and invalidates folders + attachments', async () => {
+    post.mockResolvedValue({ renamed: true, old_path: 'img/a.png', new_path: 'img/b.png' })
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+
+    const { result } = renderHook(() => useRenameAttachment(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ old_path: 'img/a.png', new_path: 'img/b.png' })
+    })
+
+    expect(post).toHaveBeenCalledWith('/attachments/rename', {
+      old_path: 'img/a.png',
+      new_path: 'img/b.png',
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['folders', '42'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['folderNotes', '42'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['attachments', '42'] })
+  })
+
+  it('surfaces 409 as ApiError', async () => {
+    post.mockRejectedValue(new ApiError(409, 'conflict'))
+
+    const { result } = renderHook(() => useRenameAttachment(), { wrapper })
+    await expect(
+      result.current.mutateAsync({ old_path: 'a.png', new_path: 'b.png' }),
+    ).rejects.toMatchObject({ status: 409 })
+  })
+})
+
+describe('useBatchMoveAttachments', () => {
+  it('POSTs paths + target_folder with UUID X-Idempotency-Key header', async () => {
+    post.mockResolvedValue({ moved: 2 })
+
+    const { result } = renderHook(() => useBatchMoveAttachments(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ paths: ['a.png', 'b.png'], target_folder: 'img' })
+    })
+
+    expect(post).toHaveBeenCalledWith(
+      '/attachments/batch-move',
+      { paths: ['a.png', 'b.png'], target_folder: 'img' },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Idempotency-Key': expect.stringMatching(UUID_RE),
+        }),
+      }),
+    )
+  })
+
+  it('invalidates folders + attachments on success', async () => {
+    post.mockResolvedValue({ moved: 1 })
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+
+    const { result } = renderHook(() => useBatchMoveAttachments(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ paths: ['a.png'], target_folder: 'img' })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['folders', '42'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['attachments', '42'] })
+  })
+})
+
+describe('useBatchDeleteAttachments', () => {
+  it('POSTs paths with UUID X-Idempotency-Key header', async () => {
+    post.mockResolvedValue({ deleted: 2 })
+
+    const { result } = renderHook(() => useBatchDeleteAttachments(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ paths: ['a.png', 'b.png'] })
+    })
+
+    expect(post).toHaveBeenCalledWith(
+      '/attachments/batch-delete',
+      { paths: ['a.png', 'b.png'] },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Idempotency-Key': expect.stringMatching(UUID_RE),
+        }),
+      }),
+    )
+  })
+
+  it('invalidates folders + attachments on success', async () => {
+    post.mockResolvedValue({ deleted: 2 })
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+
+    const { result } = renderHook(() => useBatchDeleteAttachments(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ paths: ['a.png', 'b.png'] })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['folders', '42'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['attachments', '42'] })
   })
 })

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -2123,6 +2123,11 @@ export function useBatchMoveAttachments() {
       qc.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
       qc.invalidateQueries({ queryKey: ['attachments', vaultId] })
     },
+    // Batch moves are fire-and-forget (.mutate, no caller .catch) — surface
+    // failures here, matching the note/folder batch hooks.
+    onError: () => {
+      toast.error('Batch move failed.')
+    },
   })
 }
 
@@ -2140,6 +2145,9 @@ export function useBatchDeleteAttachments() {
       qc.invalidateQueries({ queryKey: ['folders', vaultId] })
       qc.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
       qc.invalidateQueries({ queryKey: ['attachments', vaultId] })
+    },
+    onError: () => {
+      toast.error('Batch delete failed.')
     },
   })
 }

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -2086,3 +2086,60 @@ export function useBatchMoveFolders() {
     },
   })
 }
+
+export function useRenameAttachment() {
+  const qc = useQueryClient()
+  const vaultId = useActiveVaultId()
+  return useMutation<
+    { renamed: boolean; old_path: string; new_path: string },
+    ApiError,
+    { old_path: string; new_path: string }
+  >({
+    mutationFn: (vars) =>
+      api.post<{ renamed: boolean; old_path: string; new_path: string }>(
+        '/attachments/rename',
+        vars,
+      ),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['folders', vaultId] })
+      qc.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
+      qc.invalidateQueries({ queryKey: ['attachments', vaultId] })
+    },
+  })
+}
+
+export function useBatchMoveAttachments() {
+  const qc = useQueryClient()
+  const vaultId = useActiveVaultId()
+  return useMutation<{ moved: number }, ApiError, { paths: string[]; target_folder: string }>({
+    mutationFn: ({ paths, target_folder }) =>
+      api.post<{ moved: number }>(
+        '/attachments/batch-move',
+        { paths, target_folder },
+        idempotencyHeaders(),
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['folders', vaultId] })
+      qc.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
+      qc.invalidateQueries({ queryKey: ['attachments', vaultId] })
+    },
+  })
+}
+
+export function useBatchDeleteAttachments() {
+  const qc = useQueryClient()
+  const vaultId = useActiveVaultId()
+  return useMutation<{ deleted: number }, ApiError, { paths: string[] }>({
+    mutationFn: ({ paths }) =>
+      api.post<{ deleted: number }>(
+        '/attachments/batch-delete',
+        { paths },
+        idempotencyHeaders(),
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['folders', vaultId] })
+      qc.invalidateQueries({ queryKey: ['folderNotes', vaultId] })
+      qc.invalidateQueries({ queryKey: ['attachments', vaultId] })
+    },
+  })
+}

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -19,6 +19,9 @@ import {
   useRenameNote,
   useRenameFolder,
   useDuplicateNote,
+  useRenameAttachment,
+  useBatchMoveAttachments,
+  useBatchDeleteAttachments,
 } from '../api/queries'
 import { isSyntheticFolderId, synthesizeFolders } from './tree/synthesize-folders'
 import { useActiveVaultId } from '../api/active-vault'
@@ -82,6 +85,9 @@ export default function FolderTree() {
   const renameNote = useRenameNote()
   const renameFolder = useRenameFolder()
   const duplicateNote = useDuplicateNote()
+  const renameAttachment = useRenameAttachment()
+  const batchMoveAttachments = useBatchMoveAttachments()
+  const batchDeleteAttachments = useBatchDeleteAttachments()
 
   // Rename handler — TreeRow already wires HT's renaming state. HT calls
   // back with the new leaf-name; we rebuild the new full path from the
@@ -106,6 +112,11 @@ export default function FolderTree() {
       parts[parts.length - 1] = newName
       const new_path = parts.join('/')
       renameFolder.mutateAsync({ old_path: folder.name, new_path }).catch(() => toast.error('Rename failed'))
+    } else if (p.kind === 'attachment') {
+      const parts = p.path.split('/')
+      parts[parts.length - 1] = newName
+      const new_path = parts.join('/')
+      renameAttachment.mutateAsync({ old_path: p.path, new_path }).catch(() => toast.error('Rename failed'))
     }
   }
 
@@ -123,6 +134,9 @@ export default function FolderTree() {
     const folderIds = parsed
       .filter((p) => p.kind === 'folder' && !isSyntheticFolderId((p as { id: string }).id))
       .map((p) => (p as { id: string }).id)
+    const attachmentPaths = parsed
+      .filter((p) => p.kind === 'attachment')
+      .map((p) => (p as { path: string }).path)
     // 'root' is the backend sentinel for the vault root; a folder target uses
     // its marker id. Note→root has no optimistic patch (root notes live under a
     // different cache key than the by-id folder lists), so a moved note briefly
@@ -131,6 +145,11 @@ export default function FolderTree() {
     const dest = target.kind === 'root' ? 'root' : target.id
     if (noteIds.length) batchMoveNotes.mutate({ ids: noteIds, target_folder_id: dest })
     if (folderIds.length) batchMoveFolders.mutate({ ids: folderIds, target_parent_id: dest })
+    if (attachmentPaths.length) {
+      // Attachment batch-move takes a folder name string, not an id.
+      const destFolder = target.kind === 'root' ? '' : (folders?.find((f) => f.id === target.id)?.name ?? '')
+      batchMoveAttachments.mutate({ paths: attachmentPaths, target_folder: destFolder })
+    }
   }
 
   // The loader fires this on cache-miss when a folder is expanded. Shares the
@@ -242,6 +261,9 @@ export default function FolderTree() {
         ? [{ kind: 'folder', path: folder.name, childCount: direct + descendants }]
         : [{ kind: 'folder', path: folder.name }]
     }
+    if (p.kind === 'attachment') {
+      return [{ kind: 'file', path: p.path }]
+    }
     return []
   }
 
@@ -255,9 +277,11 @@ export default function FolderTree() {
     return rootNotes.find((n) => n.id === id)
   }
 
-  function kindOf(itemId: string): 'file' | 'folder' {
+  function kindOf(itemId: string): 'file' | 'folder' | 'attachment' {
     const p = parseItemId(itemId)
-    return p.kind === 'folder' ? 'folder' : 'file'
+    if (p.kind === 'folder') return 'folder'
+    if (p.kind === 'attachment') return 'attachment'
+    return 'file'
   }
 
   function titleForItem(itemId: string): string {
@@ -269,6 +293,9 @@ export default function FolderTree() {
     if (p.kind === 'note') {
       const n = lookupNote(p.id)
       return n?.title || n?.path.split('/').pop() || 'Note'
+    }
+    if (p.kind === 'attachment') {
+      return p.path.split('/').pop() ?? p.path
     }
     return ''
   }
@@ -333,9 +360,10 @@ export default function FolderTree() {
     }
   }
 
-  function partition(itemIds: string[]): { noteIds: string[]; folderIds: string[] } {
+  function partition(itemIds: string[]): { noteIds: string[]; folderIds: string[]; attachmentPaths: string[] } {
     const noteIds: string[] = []
     const folderIds: string[] = []
+    const attachmentPaths: string[] = []
     for (const id of itemIds) {
       const p = parseItemId(id)
       if (p.kind === 'note') noteIds.push(p.id)
@@ -343,29 +371,38 @@ export default function FolderTree() {
       // to a batch mutation. Unreachable today (their rows expose no menu), but
       // a guard here keeps any future bulk-select path from 404ing.
       else if (p.kind === 'folder' && !isSyntheticFolderId(p.id)) folderIds.push(p.id)
+      else if (p.kind === 'attachment') attachmentPaths.push(p.path)
     }
-    return { noteIds, folderIds }
+    return { noteIds, folderIds, attachmentPaths }
   }
 
   function commitDelete() {
     if (dialog.kind !== 'delete') return
-    const { noteIds, folderIds } = partition(dialog.itemIds)
+    const { noteIds, folderIds, attachmentPaths } = partition(dialog.itemIds)
     if (noteIds.length) batchDeleteNotes.mutate({ ids: noteIds })
     if (folderIds.length) batchDeleteFolders.mutate({ ids: folderIds })
+    if (attachmentPaths.length) batchDeleteAttachments.mutate({ paths: attachmentPaths })
     tree.setSelectedItems([])
     setDialog({ kind: 'none' })
   }
 
   function commitMove(targetFolderName: string) {
     if (dialog.kind !== 'move') return
-    const target = folders?.find((f) => f.name === targetFolderName)
-    if (!target) {
-      setDialog({ kind: 'none' })
-      return
+    const { noteIds, folderIds, attachmentPaths } = partition(dialog.itemIds)
+    // Notes and folders need a folder id; attachments take the folder name directly.
+    // When the selection contains notes or folders, we must resolve the target folder.
+    if (noteIds.length || folderIds.length) {
+      const target = folders?.find((f) => f.name === targetFolderName)
+      if (!target) {
+        setDialog({ kind: 'none' })
+        return
+      }
+      if (noteIds.length) batchMoveNotes.mutate({ ids: noteIds, target_folder_id: target.id })
+      if (folderIds.length) batchMoveFolders.mutate({ ids: folderIds, target_parent_id: target.id })
     }
-    const { noteIds, folderIds } = partition(dialog.itemIds)
-    if (noteIds.length) batchMoveNotes.mutate({ ids: noteIds, target_folder_id: target.id })
-    if (folderIds.length) batchMoveFolders.mutate({ ids: folderIds, target_parent_id: target.id })
+    if (attachmentPaths.length) {
+      batchMoveAttachments.mutate({ paths: attachmentPaths, target_folder: targetFolderName })
+    }
     tree.setSelectedItems([])
     setDialog({ kind: 'none' })
   }

--- a/frontend/src/viewer/tree-actions/action-list.ts
+++ b/frontend/src/viewer/tree-actions/action-list.ts
@@ -20,6 +20,15 @@ const FOLDER_ACTIONS: readonly Action[] = [
   { id: 'delete', label: 'Delete', destructive: true },
 ]
 
-export function actionsFor({ kind }: { kind: 'file' | 'folder' }): readonly Action[] {
-  return kind === 'file' ? FILE_ACTIONS : FOLDER_ACTIONS
+// Attachments are binary blobs — no duplicate/copy-wikilink.
+const ATTACHMENT_ACTIONS: readonly Action[] = [
+  { id: 'rename', label: 'Rename' },
+  { id: 'move', label: 'Move to…' },
+  { id: 'delete', label: 'Delete', destructive: true },
+]
+
+export function actionsFor({ kind }: { kind: 'file' | 'folder' | 'attachment' }): readonly Action[] {
+  if (kind === 'folder') return FOLDER_ACTIONS
+  if (kind === 'attachment') return ATTACHMENT_ACTIONS
+  return FILE_ACTIONS
 }

--- a/frontend/src/viewer/tree/tree-row.test.tsx
+++ b/frontend/src/viewer/tree/tree-row.test.tsx
@@ -178,7 +178,7 @@ describe('TreeRow', () => {
     expect(onContextMenu).not.toHaveBeenCalled()
   })
 
-  it('does not invoke onContextMenu on an attachment row (display-only in Phase 1)', () => {
+  it('invokes onContextMenu with item id + clientX/Y on right-click of an attachment row', () => {
     const onContextMenu = vi.fn()
     const instance = mockInstance({ data: attachmentItem })
     render(
@@ -187,7 +187,7 @@ describe('TreeRow', () => {
       </MemoryRouter>,
     )
     fireEvent.contextMenu(screen.getByRole('link'), { clientX: 42, clientY: 99 })
-    expect(onContextMenu).not.toHaveBeenCalled()
+    expect(onContextMenu).toHaveBeenCalledWith('a:img/a.png', 42, 99)
   })
 
   it('invokes onContextMenu with item id + clientX/Y on right-click of a note row', () => {

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -99,9 +99,6 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
       : item.mime === 'application/pdf'
         ? FileText
         : File
-    // Phase 1 is display + preview only: attachments wire no context menu /
-    // long-press, so the file action menu (rename/move/delete) — all no-ops for
-    // an attachment — never surfaces. Pure navigation.
     // Routed by uuid under the unified /note/:id (VaultItemPage resolves
     // note-vs-file) so the URL survives a rename/move. The HT itemId stays
     // path-keyed (internal tree machinery).
@@ -109,6 +106,8 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
       <Link
         to={`/note/${item.id}`}
         {...instance.getProps()}
+        {...longPressProps}
+        onContextMenu={contextMenuHandler}
         aria-selected={instance.isSelected()}
         className={rowClass(instance)}
         style={{ paddingLeft: `${notePad}px` }}

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -463,6 +463,41 @@ defmodule Engram.Attachments do
     })
   end
 
+  @doc "Moves each attachment into `target_folder` (\"\" = root). All-or-nothing."
+  @spec batch_move(map(), map(), [String.t()], String.t()) ::
+          {:ok, %{moved: non_neg_integer()}} | {:error, {atom(), String.t()} | term()}
+  def batch_move(_user, _vault, [], _target_folder), do: {:ok, %{moved: 0}}
+
+  def batch_move(user, vault, paths, target_folder)
+      when is_list(paths) and is_binary(target_folder) do
+    Repo.transaction(fn ->
+      Enum.reduce_while(paths, %{moved: 0}, fn old_path, acc ->
+        base = Path.basename(old_path)
+        new_path = if target_folder == "", do: base, else: Path.join(target_folder, base)
+
+        case move_attachment(user, vault, old_path, new_path) do
+          {:ok, _} -> {:cont, Map.update!(acc, :moved, &(&1 + 1))}
+          {:error, :conflict} -> {:halt, {:rollback, {:conflict, old_path}}}
+          {:error, :not_found} -> {:halt, {:rollback, {:not_found, old_path}}}
+          {:error, reason} -> {:halt, {:rollback, reason}}
+        end
+      end)
+      |> case do
+        {:rollback, reason} -> Repo.rollback(reason)
+        acc -> acc
+      end
+    end)
+  end
+
+  @doc "Soft-deletes each attachment by path. Best-effort (delete is idempotent)."
+  @spec batch_delete(map(), map(), [String.t()]) :: {:ok, %{deleted: non_neg_integer()}}
+  def batch_delete(_user, _vault, []), do: {:ok, %{deleted: 0}}
+
+  def batch_delete(user, vault, paths) when is_list(paths) do
+    Enum.each(paths, fn p -> :ok = delete_attachment(user, vault, p) end)
+    {:ok, %{deleted: length(paths)}}
+  end
+
   # Real-time parity: reuse the existing `note_changed` socket event the plugin
   # already dispatches by `kind`. A move fires delete(old) + upsert(new), like
   # Notes.rename. Receive-only on the plugin — it still pushes over HTTP.

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -303,15 +303,15 @@ defmodule Engram.Attachments do
         # don't emit a spurious delete). path/vault are known; mime/size/mtime
         # are gone post-delete, so only the discriminators the plugin needs to
         # trash are sent.
-        if deleted? do
-          _ =
+        _ =
+          if deleted? do
             EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "note_changed", %{
               "event_type" => "delete",
               "kind" => "attachment",
               "path" => path,
               "vault_id" => vault.id
             })
-        end
+          end
 
         deleted?
 

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -288,6 +288,17 @@ defmodule Engram.Attachments do
             :ok
         end
 
+        # Real-time notification: path/vault are known; mime/size/mtime are
+        # unavailable post-delete (row is soft-deleted), so only the core delete
+        # discriminators are sent. Plugin only needs event_type+kind+path to trash.
+        _ =
+          EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "note_changed", %{
+            "event_type" => "delete",
+            "kind" => "attachment",
+            "path" => path,
+            "vault_id" => vault.id
+          })
+
         :ok
 
       {:error, :no_dek} ->
@@ -452,9 +463,23 @@ defmodule Engram.Attachments do
     })
   end
 
-  # Replaced by the real socket fan-out in Task 5. This stub keeps the module
-  # compiling and move_attachment's control flow complete until then.
-  defp broadcast_attachment(_user_id, _vault_id, _event_type, _path, _att), do: :ok
+  # Real-time parity: reuse the existing `note_changed` socket event the plugin
+  # already dispatches by `kind`. A move fires delete(old) + upsert(new), like
+  # Notes.rename. Receive-only on the plugin — it still pushes over HTTP.
+  defp broadcast_attachment(user_id, vault_id, event_type, path, %Attachment{} = att) do
+    payload = %{
+      "event_type" => event_type,
+      "kind" => "attachment",
+      "path" => path,
+      "vault_id" => vault_id,
+      "mime_type" => att.mime_type,
+      "size_bytes" => att.size_bytes,
+      "mtime" => att.mtime
+    }
+
+    _ = EngramWeb.Endpoint.broadcast("sync:#{user_id}:#{vault_id}", "note_changed", payload)
+    :ok
+  end
 
   @doc """
   Lists non-deleted attachment metadata for a vault (no content).

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -248,8 +248,16 @@ defmodule Engram.Attachments do
   wastes storage but doesn't cause data loss, unlike the reverse (ghost row pointing to nothing).
   """
   def delete_attachment(user, vault, path) do
+    _ = do_delete_attachment(fresh_user(user), vault, path)
+    :ok
+  end
+
+  # Soft-deletes one attachment and returns whether a live row actually
+  # transitioned to deleted (`false` for an absent/already-deleted path).
+  # Broadcasts + best-effort blob cleanup happen here so both the single-delete
+  # API and `batch_delete/3` share one implementation and count truthfully.
+  defp do_delete_attachment(user, vault, path) do
     path = PathSanitizer.sanitize(path)
-    user = fresh_user(user)
     now = DateTime.utc_now(:second)
 
     case Crypto.dek_filter_key(user) do
@@ -304,11 +312,11 @@ defmodule Engram.Attachments do
           })
         end
 
-        :ok
+        deleted?
 
       {:error, :no_dek} ->
         # No DEK = no attachments to delete; mirror get_attachment's defensive empty.
-        :ok
+        false
     end
   end
 
@@ -468,7 +476,15 @@ defmodule Engram.Attachments do
     })
   end
 
-  @doc "Moves each attachment into `target_folder` (\"\" = root). All-or-nothing."
+  @doc """
+  Moves each attachment into `target_folder` (\"\" = root). All-or-nothing: any
+  conflict/not_found rolls back every prior move's DB write.
+
+  Caveat: each `move_attachment` broadcasts its `note_changed` events as its own
+  inner transaction commits, BEFORE the outer rollback can fire — so a later
+  failure can't retract earlier items' broadcasts. Clients self-heal on the next
+  pull. Same trade-off as `Notes.rename_folder`; not worth deferring broadcasts.
+  """
   @spec batch_move(map(), map(), [String.t()], String.t()) ::
           {:ok, %{moved: non_neg_integer()}} | {:error, {atom(), String.t()} | term()}
   def batch_move(_user, _vault, [], _target_folder), do: {:ok, %{moved: 0}}
@@ -494,13 +510,17 @@ defmodule Engram.Attachments do
     end)
   end
 
-  @doc "Soft-deletes each attachment by path. Best-effort (delete is idempotent)."
+  @doc """
+  Soft-deletes each attachment by path. Idempotent. `:deleted` counts paths that
+  actually held a live row (absent/already-deleted paths don't count).
+  """
   @spec batch_delete(map(), map(), [String.t()]) :: {:ok, %{deleted: non_neg_integer()}}
   def batch_delete(_user, _vault, []), do: {:ok, %{deleted: 0}}
 
   def batch_delete(user, vault, paths) when is_list(paths) do
-    Enum.each(paths, fn p -> :ok = delete_attachment(user, vault, p) end)
-    {:ok, %{deleted: length(paths)}}
+    user = fresh_user(user)
+    deleted = Enum.count(paths, fn p -> do_delete_attachment(user, vault, p) end)
+    {:ok, %{deleted: deleted}}
   end
 
   # Real-time parity: reuse the existing `note_changed` socket event the plugin

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -314,6 +314,145 @@ defmodule Engram.Attachments do
   end
 
   @doc """
+  Moves/renames an attachment by path. One transaction under the per-vault seq:
+  repoint the live row (id stable, path re-encrypted under its unchanged
+  id-AAD, storage_key + blob untouched) and insert a soft-deleted tombstone at
+  the old path so poll/cursor clients converge (trash old, write new). Mirrors
+  `Engram.Notes.rename_folder/4`'s tombstone discipline (#614).
+  """
+  @spec move_attachment(map(), map(), String.t(), String.t()) ::
+          {:ok, Attachment.t()} | {:error, :conflict | :not_found | term()}
+  def move_attachment(user, vault, old_path, new_path) do
+    old_path = PathSanitizer.sanitize(old_path)
+    new_path = PathSanitizer.sanitize(new_path)
+    user = fresh_user(user)
+    now = DateTime.utc_now(:second)
+
+    with {:ok, user} <- Crypto.ensure_user_dek(user),
+         {:ok, dek} <- Crypto.get_dek(user),
+         {:ok, filter_key} <- Crypto.dek_filter_key(user) do
+      old_hmac = Crypto.hmac_field(filter_key, old_path)
+      new_hmac = Crypto.hmac_field(filter_key, new_path)
+
+      Repo.transaction(fn ->
+        Repo.with_tenant(user.id, fn ->
+          live = Repo.one(live_by_hmac_query(user, vault, old_hmac))
+
+          cond do
+            is_nil(live) ->
+              Repo.rollback(:not_found)
+
+            old_path == new_path ->
+              {:ok, att} = Crypto.maybe_decrypt_attachment_fields(live, user)
+              att
+
+            Repo.one(live_by_hmac_query(user, vault, new_hmac)) ->
+              Repo.rollback(:conflict)
+
+            true ->
+              # Both writes share ONE seq inside ONE transaction (#614): a cursor
+              # pull must never see the repoint at seq S, advance past S, and miss
+              # the tombstone also at S.
+              seq = Engram.Vaults.next_seq!(vault.id)
+
+              # Repoint the live row: re-encrypt path under the SAME id-AAD (id is
+              # unchanged, so the AAD bind is unchanged), recompute path_hmac, bump
+              # updated_at + seq. storage_key + blob untouched.
+              path_aad = Crypto.aad_for_row(:attachments, :path, live.id)
+              {path_ct, path_n} = Envelope.encrypt(new_path, dek, path_aad)
+
+              {1, _} =
+                from(a in Attachment, where: a.id == ^live.id)
+                |> Repo.update_all(
+                  set: [
+                    path_ciphertext: path_ct,
+                    path_nonce: path_n,
+                    path_hmac: new_hmac,
+                    updated_at: now,
+                    seq: seq
+                  ]
+                )
+
+              # Insert the old-path tombstone (fresh uuid, path encrypted under
+              # ITS OWN id-AAD). Sole purpose: surface {old_path, deleted: true}
+              # in the change feed so clients trash the old path.
+              Repo.insert!(tombstone_changeset(user, vault, dek, old_path, old_hmac, live, seq, now))
+
+              %{
+                live
+                | path: new_path,
+                  path_ciphertext: path_ct,
+                  path_nonce: path_n,
+                  path_hmac: new_hmac,
+                  updated_at: now,
+                  seq: seq
+              }
+          end
+        end)
+        |> unwrap_tenant()
+        |> case do
+          {:ok, att} -> att
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, %Attachment{} = att} ->
+          if old_path != new_path do
+            broadcast_attachment(user.id, vault.id, "delete", old_path, att)
+            broadcast_attachment(user.id, vault.id, "upsert", new_path, att)
+          end
+
+          {:ok, att}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp live_by_hmac_query(user, vault, hmac) do
+    from(a in Attachment,
+      where:
+        a.path_hmac == ^hmac and a.user_id == ^user.id and
+          a.vault_id == ^vault.id and is_nil(a.deleted_at)
+    )
+  end
+
+  # Soft-deleted full-row insert at the vacated path. storage_key=nil (no blob),
+  # content_hash + content_nonce carried from the live row (the changeset
+  # requires content_nonce; the value is irrelevant — the row is deleted and
+  # never decrypted). Path encrypted under the tombstone's OWN id-AAD so reads
+  # of the (never-served) row stay AAD-consistent.
+  defp tombstone_changeset(user, vault, dek, old_path, old_hmac, live, seq, now) do
+    tomb_id = Ecto.UUID.generate()
+    path_aad = Crypto.aad_for_row(:attachments, :path, tomb_id)
+    {path_ct, path_n} = Envelope.encrypt(old_path, dek, path_aad)
+
+    Attachment.changeset(%Attachment{id: tomb_id}, %{
+      path_ciphertext: path_ct,
+      path_nonce: path_n,
+      path_hmac: old_hmac,
+      content_hash: live.content_hash,
+      mime_type: live.mime_type,
+      size_bytes: live.size_bytes,
+      mtime: live.mtime,
+      user_id: user.id,
+      vault_id: vault.id,
+      storage_key: nil,
+      deleted_at: now,
+      seq: seq,
+      version: 1,
+      encryption_version: 1,
+      dek_version: Crypto.row_version_aad_bound(),
+      content_nonce: live.content_nonce
+    })
+  end
+
+  # Replaced by the real socket fan-out in Task 5. This stub keeps the module
+  # compiling and move_attachment's control flow complete until then.
+  defp broadcast_attachment(_user_id, _vault_id, _event_type, _path, _att), do: :ok
+
+  @doc """
   Lists non-deleted attachment metadata for a vault (no content).
   """
   def list_attachments(user, vault) do

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -256,11 +256,11 @@ defmodule Engram.Attachments do
       {:ok, filter_key} ->
         path_hmac = Crypto.hmac_field(filter_key, path)
 
-        storage_key =
+        result =
           Repo.with_tenant(user.id, fn ->
             seq = Engram.Vaults.next_seq!(vault.id)
 
-            {_count, keys} =
+            {count, keys} =
               from(a in Attachment,
                 where:
                   a.path_hmac == ^path_hmac and a.user_id == ^user.id and
@@ -269,35 +269,40 @@ defmodule Engram.Attachments do
               )
               |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
 
-            List.first(keys)
+            {count, List.first(keys)}
           end)
           |> unwrap_tenant()
 
         # Best-effort blob cleanup — row is already soft-deleted so safe to retry.
-        case storage_key do
-          {:ok, key} when is_binary(key) ->
-            delete_external(key)
+        deleted? =
+          case result do
+            {:ok, {count, key}} when is_binary(key) ->
+              delete_external(key)
+              count > 0
 
-          # {:ok, nil}: live row with no storage_key (legacy pre-column) — nothing to delete.
-          {:ok, _} ->
-            :ok
+            # {count, nil}: legacy row with no storage_key, or no row matched.
+            {:ok, {count, _}} ->
+              count > 0
 
-          {:error, reason} ->
-            require Logger
-            Logger.warning("delete_attachment: tenant lookup failed", reason: inspect(reason))
-            :ok
-        end
+            {:error, reason} ->
+              require Logger
+              Logger.warning("delete_attachment: tenant lookup failed", reason: inspect(reason))
+              false
+          end
 
-        # Real-time notification: path/vault are known; mime/size/mtime are
-        # unavailable post-delete (row is soft-deleted), so only the core delete
-        # discriminators are sent. Plugin only needs event_type+kind+path to trash.
-        _ =
+        # Real-time notification — only when a live row actually transitioned to
+        # deleted (idempotent no-op deletes of an absent/already-deleted path
+        # don't emit a spurious delete). path/vault are known; mime/size/mtime
+        # are gone post-delete, so only the discriminators the plugin needs to
+        # trash are sent.
+        if deleted? do
           EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "note_changed", %{
             "event_type" => "delete",
             "kind" => "attachment",
             "path" => path,
             "vault_id" => vault.id
           })
+        end
 
         :ok
 

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -304,12 +304,13 @@ defmodule Engram.Attachments do
         # are gone post-delete, so only the discriminators the plugin needs to
         # trash are sent.
         if deleted? do
-          EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "note_changed", %{
-            "event_type" => "delete",
-            "kind" => "attachment",
-            "path" => path,
-            "vault_id" => vault.id
-          })
+          _ =
+            EngramWeb.Endpoint.broadcast("sync:#{user.id}:#{vault.id}", "note_changed", %{
+              "event_type" => "delete",
+              "kind" => "attachment",
+              "path" => path,
+              "vault_id" => vault.id
+            })
         end
 
         deleted?

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -260,7 +260,7 @@ defmodule Engram.Attachments do
           Repo.with_tenant(user.id, fn ->
             seq = Engram.Vaults.next_seq!(vault.id)
 
-            {_, returned} =
+            {_count, keys} =
               from(a in Attachment,
                 where:
                   a.path_hmac == ^path_hmac and a.user_id == ^user.id and
@@ -269,14 +269,23 @@ defmodule Engram.Attachments do
               )
               |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
 
-            List.first(returned || [])
+            List.first(keys)
           end)
           |> unwrap_tenant()
 
         # Best-effort blob cleanup — row is already soft-deleted so safe to retry.
         case storage_key do
-          {:ok, key} when is_binary(key) -> delete_external(key)
-          _ -> :ok
+          {:ok, key} when is_binary(key) ->
+            delete_external(key)
+
+          # {:ok, nil}: live row with no storage_key (legacy pre-column) — nothing to delete.
+          {:ok, _} ->
+            :ok
+
+          {:error, reason} ->
+            require Logger
+            Logger.warning("delete_attachment: tenant lookup failed", reason: inspect(reason))
+            :ok
         end
 
         :ok

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -343,8 +343,10 @@ defmodule Engram.Attachments do
               Repo.rollback(:not_found)
 
             old_path == new_path ->
-              {:ok, att} = Crypto.maybe_decrypt_attachment_fields(live, user)
-              att
+              case Crypto.maybe_decrypt_attachment_fields(live, user) do
+                {:ok, att} -> att
+                {:error, reason} -> Repo.rollback(reason)
+              end
 
             Repo.one(live_by_hmac_query(user, vault, new_hmac)) ->
               Repo.rollback(:conflict)
@@ -392,6 +394,8 @@ defmodule Engram.Attachments do
         |> unwrap_tenant()
         |> case do
           {:ok, att} -> att
+          # No current cond branch returns {:error,_} without rolling back itself;
+          # this guards a future branch that returns an error tuple directly.
           {:error, reason} -> Repo.rollback(reason)
         end
       end)

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -402,7 +402,9 @@ defmodule Engram.Attachments do
               # Insert the old-path tombstone (fresh uuid, path encrypted under
               # ITS OWN id-AAD). Sole purpose: surface {old_path, deleted: true}
               # in the change feed so clients trash the old path.
-              Repo.insert!(tombstone_changeset(user, vault, dek, old_path, old_hmac, live, seq, now))
+              Repo.insert!(
+                tombstone_changeset(user, vault, dek, old_path, old_hmac, live, seq, now)
+              )
 
               %{
                 live

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -78,7 +78,7 @@ defmodule Engram.Attachments do
           rebind =
             case existing do
               %Attachment{id: id} when id != att_id0 ->
-                with {:ok, _key, attrs1, ciphertext1} <-
+                with {:ok, rebind_key, attrs1, ciphertext1} <-
                        prepare_upload(
                          user,
                          vault,
@@ -89,7 +89,7 @@ defmodule Engram.Attachments do
                          mtime,
                          explicit_mime
                        ),
-                     :ok <- store_external(key, ciphertext1, attrs1.mime_type) do
+                     :ok <- store_external(rebind_key, ciphertext1, attrs1.mime_type) do
                   {:ok, attrs1}
                 end
 
@@ -119,7 +119,7 @@ defmodule Engram.Attachments do
         from(a in Attachment,
           where:
             a.path_hmac == ^path_hmac and a.user_id == ^user.id and
-              a.vault_id == ^vault_id
+              a.vault_id == ^vault_id and is_nil(a.deleted_at)
         )
       )
     end)
@@ -256,19 +256,28 @@ defmodule Engram.Attachments do
       {:ok, filter_key} ->
         path_hmac = Crypto.hmac_field(filter_key, path)
 
-        Repo.with_tenant(user.id, fn ->
-          seq = Engram.Vaults.next_seq!(vault.id)
+        storage_key =
+          Repo.with_tenant(user.id, fn ->
+            seq = Engram.Vaults.next_seq!(vault.id)
 
-          from(a in Attachment,
-            where:
-              a.path_hmac == ^path_hmac and a.user_id == ^user.id and
-                a.vault_id == ^vault.id and is_nil(a.deleted_at)
-          )
-          |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
-        end)
+            {_, returned} =
+              from(a in Attachment,
+                where:
+                  a.path_hmac == ^path_hmac and a.user_id == ^user.id and
+                    a.vault_id == ^vault.id and is_nil(a.deleted_at),
+                select: a.storage_key
+              )
+              |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
 
-        # Best-effort blob cleanup — row is already soft-deleted so this is safe to retry later
-        delete_external(user.id, vault.id, path)
+            List.first(returned || [])
+          end)
+          |> unwrap_tenant()
+
+        # Best-effort blob cleanup — row is already soft-deleted so safe to retry.
+        case storage_key do
+          {:ok, key} when is_binary(key) -> delete_external(key)
+          _ -> :ok
+        end
 
         :ok
 
@@ -278,10 +287,8 @@ defmodule Engram.Attachments do
     end
   end
 
-  defp delete_external(user_id, vault_id, path) do
-    key = Storage.key(user_id, vault_id, path)
-
-    case Storage.adapter().delete(key) do
+  defp delete_external(storage_key) when is_binary(storage_key) do
+    case Storage.adapter().delete(storage_key) do
       :ok ->
         :ok
 
@@ -289,7 +296,7 @@ defmodule Engram.Attachments do
         require Logger
 
         Logger.warning("Failed to delete blob (row already soft-deleted)",
-          storage_key: key,
+          storage_key: storage_key,
           reason: inspect(reason)
         )
 
@@ -490,7 +497,8 @@ defmodule Engram.Attachments do
 
   defp prepare_upload(user, vault, att_id, path, path_hmac, plaintext, mtime, explicit_mime) do
     mime = explicit_mime || MimeWhitelist.detect_mime(path)
-    key = Storage.key(user.id, vault.id, path)
+    # was: key = Storage.key(user.id, vault.id, path)
+    key = Storage.object_key(user.id, vault.id, att_id)
 
     with {:ok, dek} <- Crypto.get_dek(user),
          {:ok, content_key} <- Crypto.dek_content_hash_key(user) do

--- a/lib/engram/storage.ex
+++ b/lib/engram/storage.ex
@@ -84,4 +84,15 @@ defmodule Engram.Storage do
       when is_binary(user_id) and is_binary(vault_id) and is_binary(path) and path != "" do
     "#{user_id}/#{vault_id}/#{path}"
   end
+
+  @doc """
+  Build a storage key from the immutable attachment row UUID. Decoupled from
+  the mutable vault path so move/rename never relocates the blob and a new
+  upload to a vacated path computes a fresh key (no clobber). New uploads use
+  this; legacy rows keep their path-derived `storage_key` column value.
+  """
+  def object_key(user_id, vault_id, att_id)
+      when is_binary(user_id) and is_binary(vault_id) and is_binary(att_id) and att_id != "" do
+    "#{user_id}/#{vault_id}/objects/#{att_id}"
+  end
 end

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -114,8 +114,13 @@ defmodule EngramWeb.AttachmentsController do
     vault = conn.assigns.current_vault
 
     with :ok <- Billing.check_feature(user, :attachments_enabled),
-         {:ok, _att} <- Attachments.move_attachment(user, vault, old_path, new_path) do
-      json(conn, %{renamed: true, old_path: old_path, new_path: new_path})
+         {:ok, att} <- Attachments.move_attachment(user, vault, old_path, new_path) do
+      json(conn, %{
+        renamed: true,
+        old_path: old_path,
+        new_path: new_path,
+        attachment: serialize_metadata(att)
+      })
     else
       {:error, :feature_not_available} ->
         EngramWeb.LimitResponse.halt(conn, "attachments_disabled", :attachments_enabled, false, nil)
@@ -132,20 +137,28 @@ defmodule EngramWeb.AttachmentsController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    case Attachments.batch_move(user, vault, paths, target) do
-      {:ok, %{moved: n}} ->
-        body = %{moved: n}
-        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
-        json(conn, body)
+    # Gated like rename/upload: moving attachments is "using" the feature, so a
+    # plan without :attachments_enabled gets a 402 (delete stays ungated below).
+    case Billing.check_feature(user, :attachments_enabled) do
+      {:error, :feature_not_available} ->
+        EngramWeb.LimitResponse.halt(conn, "attachments_disabled", :attachments_enabled, false, nil)
 
-      {:error, {:conflict, p}} ->
-        conn |> put_status(409) |> json(%{error: "conflict", item_path: p})
+      :ok ->
+        case Attachments.batch_move(user, vault, paths, target) do
+          {:ok, %{moved: n}} ->
+            body = %{moved: n}
+            Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+            json(conn, body)
 
-      {:error, {:not_found, p}} ->
-        conn |> put_status(404) |> json(%{error: "not_found", item_path: p})
+          {:error, {:conflict, p}} ->
+            conn |> put_status(409) |> json(%{error: "conflict", item_path: p})
 
-      {:error, _} ->
-        conn |> put_status(500) |> json(%{error: "internal"})
+          {:error, {:not_found, p}} ->
+            conn |> put_status(404) |> json(%{error: "not_found", item_path: p})
+
+          {:error, _} ->
+            conn |> put_status(500) |> json(%{error: "internal"})
+        end
     end
   end
 
@@ -153,9 +166,12 @@ defmodule EngramWeb.AttachmentsController do
     conn |> put_status(400) |> json(%{error: "missing required params: paths, target_folder"})
   end
 
+  # Intentionally NOT billing-gated: deleting is cleanup, never trap a downgraded
+  # user with attachments they can't remove. Mirrors notes-delete staying open.
   def batch_delete(conn, %{"paths" => paths}) when is_list(paths) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
+    # batch_delete/3 is total — its @spec returns {:ok, %{deleted: _}} only.
     {:ok, %{deleted: n}} = Attachments.batch_delete(user, vault, paths)
     body = %{deleted: n}
     Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -109,6 +109,63 @@ defmodule EngramWeb.AttachmentsController do
     end
   end
 
+  def rename(conn, %{"old_path" => old_path, "new_path" => new_path}) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    with :ok <- Billing.check_feature(user, :attachments_enabled),
+         {:ok, _att} <- Attachments.move_attachment(user, vault, old_path, new_path) do
+      json(conn, %{renamed: true, old_path: old_path, new_path: new_path})
+    else
+      {:error, :feature_not_available} ->
+        EngramWeb.LimitResponse.halt(conn, "attachments_disabled", :attachments_enabled, false, nil)
+
+      {:error, :conflict} ->
+        conn |> put_status(409) |> json(%{error: "conflict"})
+
+      {:error, :not_found} ->
+        conn |> put_status(404) |> json(%{error: "not_found"})
+    end
+  end
+
+  def batch_move(conn, %{"paths" => paths, "target_folder" => target}) when is_list(paths) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    case Attachments.batch_move(user, vault, paths, target) do
+      {:ok, %{moved: n}} ->
+        body = %{moved: n}
+        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+        json(conn, body)
+
+      {:error, {:conflict, p}} ->
+        conn |> put_status(409) |> json(%{error: "conflict", item_path: p})
+
+      {:error, {:not_found, p}} ->
+        conn |> put_status(404) |> json(%{error: "not_found", item_path: p})
+
+      {:error, _} ->
+        conn |> put_status(500) |> json(%{error: "internal"})
+    end
+  end
+
+  def batch_move(conn, _params) do
+    conn |> put_status(400) |> json(%{error: "missing required params: paths, target_folder"})
+  end
+
+  def batch_delete(conn, %{"paths" => paths}) when is_list(paths) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+    {:ok, %{deleted: n}} = Attachments.batch_delete(user, vault, paths)
+    body = %{deleted: n}
+    Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+    json(conn, body)
+  end
+
+  def batch_delete(conn, _params) do
+    conn |> put_status(400) |> json(%{error: "missing required param: paths"})
+  end
+
   def index(conn, _params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -123,7 +123,13 @@ defmodule EngramWeb.AttachmentsController do
       })
     else
       {:error, :feature_not_available} ->
-        EngramWeb.LimitResponse.halt(conn, "attachments_disabled", :attachments_enabled, false, nil)
+        EngramWeb.LimitResponse.halt(
+          conn,
+          "attachments_disabled",
+          :attachments_enabled,
+          false,
+          nil
+        )
 
       {:error, :conflict} ->
         conn |> put_status(409) |> json(%{error: "conflict"})
@@ -141,7 +147,13 @@ defmodule EngramWeb.AttachmentsController do
     # plan without :attachments_enabled gets a 402 (delete stays ungated below).
     case Billing.check_feature(user, :attachments_enabled) do
       {:error, :feature_not_available} ->
-        EngramWeb.LimitResponse.halt(conn, "attachments_disabled", :attachments_enabled, false, nil)
+        EngramWeb.LimitResponse.halt(
+          conn,
+          "attachments_disabled",
+          :attachments_enabled,
+          false,
+          nil
+        )
 
       :ok ->
         case Attachments.batch_move(user, vault, paths, target) do

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -333,6 +333,8 @@ defmodule EngramWeb.Router do
       post "/notes/batch-move", NotesController, :batch_move
       post "/folders/batch-delete", FoldersController, :batch_delete
       post "/folders/batch-move", FoldersController, :batch_move
+      post "/attachments/batch-move", AttachmentsController, :batch_move
+      post "/attachments/batch-delete", AttachmentsController, :batch_delete
     end
 
     # Metadata
@@ -356,6 +358,8 @@ defmodule EngramWeb.Router do
     post "/attachments", AttachmentsController, :upload
     get "/attachments", AttachmentsController, :index
     get "/attachments/changes", AttachmentsController, :changes
+    # rename must come before *path wildcard so it is not swallowed
+    post "/attachments/rename", AttachmentsController, :rename
     get "/attachments/*path", AttachmentsController, :show
     delete "/attachments/*path", AttachmentsController, :delete
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.454",
+      version: "0.5.455",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.455",
+      version: "0.5.456",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -587,6 +587,48 @@ defmodule Engram.AttachmentsTest do
     end
   end
 
+  describe "batch_move/4 + batch_delete/3" do
+    setup %{user: user, vault: vault} do
+      Mox.stub_with(Engram.MockStorage, Engram.Storage.InMemory)
+
+      for p <- ["a.png", "b.png"] do
+        {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+          "path" => p, "content_base64" => Base.encode64(p),
+          "mime_type" => "image/png", "mtime" => 1.0
+        })
+      end
+
+      :ok
+    end
+
+    test "batch_move relocates each into the target folder", %{user: user, vault: vault} do
+      {:ok, %{moved: 2}} = Attachments.batch_move(user, vault, ["a.png", "b.png"], "img")
+      {:ok, _} = Attachments.get_attachment(user, vault, "img/a.png")
+      {:ok, _} = Attachments.get_attachment(user, vault, "img/b.png")
+    end
+
+    test "batch_move to root keeps basenames", %{user: user, vault: vault} do
+      {:ok, _} = Attachments.batch_move(user, vault, ["a.png"], "img")
+      {:ok, %{moved: 1}} = Attachments.batch_move(user, vault, ["img/a.png"], "")
+      {:ok, _} = Attachments.get_attachment(user, vault, "a.png")
+    end
+
+    test "batch_move rolls back on conflict", %{user: user, vault: vault} do
+      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "img/a.png", "content_base64" => Base.encode64("X"),
+        "mime_type" => "image/png", "mtime" => 1.0
+      })
+      assert {:error, {:conflict, "a.png"}} = Attachments.batch_move(user, vault, ["a.png"], "img")
+      # a.png still at root (rolled back)
+      {:ok, _} = Attachments.get_attachment(user, vault, "a.png")
+    end
+
+    test "batch_delete soft-deletes each", %{user: user, vault: vault} do
+      {:ok, %{deleted: 2}} = Attachments.batch_delete(user, vault, ["a.png", "b.png"])
+      {:ok, nil} = Attachments.get_attachment(user, vault, "a.png")
+    end
+  end
+
   describe "note_changed broadcast (kind=attachment)" do
     setup do
       Mox.stub_with(Engram.MockStorage, Engram.Storage.InMemory)

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -623,6 +623,23 @@ defmodule Engram.AttachmentsTest do
       {:ok, _} = Attachments.get_attachment(user, vault, "a.png")
     end
 
+    test "batch_move reverts an already-moved item when a later item conflicts",
+         %{user: user, vault: vault} do
+      # Pre-occupy the target of the SECOND item so a.png moves first, then
+      # b.png conflicts — proving the whole batch (incl. a.png) rolls back.
+      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "img/b.png", "content_base64" => Base.encode64("X"),
+        "mime_type" => "image/png", "mtime" => 1.0
+      })
+
+      assert {:error, {:conflict, "b.png"}} =
+               Attachments.batch_move(user, vault, ["a.png", "b.png"], "img")
+
+      # a.png's earlier move was rolled back: still at root, NOT at img/a.png.
+      {:ok, _} = Attachments.get_attachment(user, vault, "a.png")
+      {:ok, nil} = Attachments.get_attachment(user, vault, "img/a.png")
+    end
+
     test "batch_delete soft-deletes each", %{user: user, vault: vault} do
       {:ok, %{deleted: 2}} = Attachments.batch_delete(user, vault, ["a.png", "b.png"])
       {:ok, nil} = Attachments.get_attachment(user, vault, "a.png")
@@ -671,6 +688,15 @@ defmodule Engram.AttachmentsTest do
         event: "note_changed",
         payload: %{"event_type" => "delete", "kind" => "attachment", "path" => "gone.png"}
       }
+    end
+
+    test "deleting an absent path broadcasts nothing", %{user: user, vault: vault} do
+      topic = "sync:#{user.id}:#{vault.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      :ok = Attachments.delete_attachment(user, vault, "never-existed.png")
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
     end
   end
 end

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -528,4 +528,62 @@ defmodule Engram.AttachmentsTest do
       refute a.storage_key == b.storage_key
     end
   end
+
+  describe "move_attachment/4" do
+    setup %{user: user, vault: vault} do
+      Mox.stub_with(Engram.MockStorage, Engram.Storage.InMemory)
+
+      {:ok, att} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "old/a.png",
+          "content_base64" => Base.encode64("DATA"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
+      %{att: att}
+    end
+
+    test "repoints the live row, blob/storage_key untouched", %{
+      user: user,
+      vault: vault,
+      att: att
+    } do
+      {:ok, moved} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+      assert moved.id == att.id
+      assert moved.path == "new/b.png"
+      assert moved.storage_key == att.storage_key
+      {:ok, fetched} = Attachments.get_attachment(user, vault, "new/b.png")
+      assert fetched.content == "DATA"
+    end
+
+    test "emits a soft-deleted tombstone at the old path", %{user: user, vault: vault} do
+      {:ok, _} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+      {:ok, %{changes: changes}} = Attachments.list_changes_by_seq(user, vault, 0)
+      assert Enum.any?(changes, &(&1.path == "old/a.png" and &1.deleted))
+      assert Enum.any?(changes, &(&1.path == "new/b.png" and not &1.deleted))
+    end
+
+    test "conflict on occupied target → :conflict", %{user: user, vault: vault} do
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "new/b.png",
+          "content_base64" => Base.encode64("X"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
+      assert {:error, :conflict} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+    end
+
+    test "no-op move (old == new) is idempotent, no tombstone", %{user: user, vault: vault} do
+      {:ok, _} = Attachments.move_attachment(user, vault, "old/a.png", "old/a.png")
+      {:ok, %{changes: changes}} = Attachments.list_changes_by_seq(user, vault, 0)
+      refute Enum.any?(changes, & &1.deleted)
+    end
+
+    test "missing source → :not_found", %{user: user, vault: vault} do
+      assert {:error, :not_found} = Attachments.move_attachment(user, vault, "nope.png", "x.png")
+    end
+  end
 end

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -479,7 +479,7 @@ defmodule Engram.AttachmentsTest do
       vault = insert(:vault, user: user)
       path = "missing.bin"
 
-      {:ok, _att} =
+      {:ok, att} =
         Attachments.upsert_attachment(user, vault, %{
           "path" => path,
           "content_base64" => Base.encode64("orphan me"),
@@ -487,8 +487,8 @@ defmodule Engram.AttachmentsTest do
         })
 
       # Delete the underlying object directly to simulate storage corruption
-      # while leaving the DB row live.
-      InMemory.delete("#{user.id}/#{vault.id}/#{path}")
+      # while leaving the DB row live. Blobs are UUID-keyed since Task 2.
+      InMemory.delete(att.storage_key)
 
       log =
         capture_log(fn ->
@@ -497,6 +497,35 @@ defmodule Engram.AttachmentsTest do
         end)
 
       assert log =~ "Attachment blob missing"
+    end
+  end
+
+  describe "uuid-keyed storage (Task 2)" do
+    setup do
+      Mox.stub_with(Engram.MockStorage, Engram.Storage.InMemory)
+      :ok
+    end
+
+    test "new upload keys storage by uuid, not by path", %{user: user, vault: vault} do
+      {:ok, att} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "img/cat.png", "content_base64" => Base.encode64("PNGDATA"),
+        "mime_type" => "image/png", "mtime" => 1.0
+      })
+      assert att.storage_key =~ ~r{/objects/#{att.id}$}
+      refute att.storage_key =~ "img/cat.png"
+    end
+
+    test "a new upload to a vacated path does NOT clobber a different blob", %{user: user, vault: vault} do
+      {:ok, a} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "p/x.png", "content_base64" => Base.encode64("AAA"),
+        "mime_type" => "image/png", "mtime" => 1.0
+      })
+      :ok = Attachments.delete_attachment(user, vault, "p/x.png")
+      {:ok, b} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "p/x.png", "content_base64" => Base.encode64("BBB"),
+        "mime_type" => "image/png", "mtime" => 2.0
+      })
+      refute a.storage_key == b.storage_key
     end
   end
 end

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -586,4 +586,49 @@ defmodule Engram.AttachmentsTest do
       assert {:error, :not_found} = Attachments.move_attachment(user, vault, "nope.png", "x.png")
     end
   end
+
+  describe "note_changed broadcast (kind=attachment)" do
+    setup do
+      Mox.stub_with(Engram.MockStorage, Engram.Storage.InMemory)
+      :ok
+    end
+
+    test "move broadcasts delete(old) + upsert(new) with kind=attachment", %{user: user, vault: vault} do
+      {:ok, att} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "old/a.png", "content_base64" => Base.encode64("D"),
+        "mime_type" => "image/png", "mtime" => 1.0
+      })
+      topic = "sync:#{user.id}:#{vault.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      {:ok, _} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: %{"event_type" => "delete", "kind" => "attachment", "path" => "old/a.png"}
+      }
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: %{"event_type" => "upsert", "kind" => "attachment", "path" => "new/b.png",
+                   "mime_type" => "image/png"}
+      }
+      _ = att
+    end
+
+    test "delete_attachment broadcasts delete with kind=attachment", %{user: user, vault: vault} do
+      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
+        "path" => "gone.png", "content_base64" => Base.encode64("D"),
+        "mime_type" => "image/png", "mtime" => 1.0
+      })
+      topic = "sync:#{user.id}:#{vault.id}"
+      EngramWeb.Endpoint.subscribe(topic)
+
+      :ok = Attachments.delete_attachment(user, vault, "gone.png")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: %{"event_type" => "delete", "kind" => "attachment", "path" => "gone.png"}
+      }
+    end
+  end
 end

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -507,24 +507,40 @@ defmodule Engram.AttachmentsTest do
     end
 
     test "new upload keys storage by uuid, not by path", %{user: user, vault: vault} do
-      {:ok, att} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "img/cat.png", "content_base64" => Base.encode64("PNGDATA"),
-        "mime_type" => "image/png", "mtime" => 1.0
-      })
+      {:ok, att} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "img/cat.png",
+          "content_base64" => Base.encode64("PNGDATA"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
       assert att.storage_key =~ ~r{/objects/#{att.id}$}
       refute att.storage_key =~ "img/cat.png"
     end
 
-    test "a new upload to a vacated path does NOT clobber a different blob", %{user: user, vault: vault} do
-      {:ok, a} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "p/x.png", "content_base64" => Base.encode64("AAA"),
-        "mime_type" => "image/png", "mtime" => 1.0
-      })
+    test "a new upload to a vacated path does NOT clobber a different blob", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, a} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "p/x.png",
+          "content_base64" => Base.encode64("AAA"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
       :ok = Attachments.delete_attachment(user, vault, "p/x.png")
-      {:ok, b} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "p/x.png", "content_base64" => Base.encode64("BBB"),
-        "mime_type" => "image/png", "mtime" => 2.0
-      })
+
+      {:ok, b} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "p/x.png",
+          "content_base64" => Base.encode64("BBB"),
+          "mime_type" => "image/png",
+          "mtime" => 2.0
+        })
+
       refute a.storage_key == b.storage_key
     end
   end
@@ -573,7 +589,8 @@ defmodule Engram.AttachmentsTest do
           "mtime" => 1.0
         })
 
-      assert {:error, :conflict} = Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
+      assert {:error, :conflict} =
+               Attachments.move_attachment(user, vault, "old/a.png", "new/b.png")
     end
 
     test "no-op move (old == new) is idempotent, no tombstone", %{user: user, vault: vault} do
@@ -592,10 +609,13 @@ defmodule Engram.AttachmentsTest do
       Mox.stub_with(Engram.MockStorage, Engram.Storage.InMemory)
 
       for p <- ["a.png", "b.png"] do
-        {:ok, _} = Attachments.upsert_attachment(user, vault, %{
-          "path" => p, "content_base64" => Base.encode64(p),
-          "mime_type" => "image/png", "mtime" => 1.0
-        })
+        {:ok, _} =
+          Attachments.upsert_attachment(user, vault, %{
+            "path" => p,
+            "content_base64" => Base.encode64(p),
+            "mime_type" => "image/png",
+            "mtime" => 1.0
+          })
       end
 
       :ok
@@ -614,11 +634,17 @@ defmodule Engram.AttachmentsTest do
     end
 
     test "batch_move rolls back on conflict", %{user: user, vault: vault} do
-      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "img/a.png", "content_base64" => Base.encode64("X"),
-        "mime_type" => "image/png", "mtime" => 1.0
-      })
-      assert {:error, {:conflict, "a.png"}} = Attachments.batch_move(user, vault, ["a.png"], "img")
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "img/a.png",
+          "content_base64" => Base.encode64("X"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
+      assert {:error, {:conflict, "a.png"}} =
+               Attachments.batch_move(user, vault, ["a.png"], "img")
+
       # a.png still at root (rolled back)
       {:ok, _} = Attachments.get_attachment(user, vault, "a.png")
     end
@@ -627,10 +653,13 @@ defmodule Engram.AttachmentsTest do
          %{user: user, vault: vault} do
       # Pre-occupy the target of the SECOND item so a.png moves first, then
       # b.png conflicts — proving the whole batch (incl. a.png) rolls back.
-      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "img/b.png", "content_base64" => Base.encode64("X"),
-        "mime_type" => "image/png", "mtime" => 1.0
-      })
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "img/b.png",
+          "content_base64" => Base.encode64("X"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
 
       assert {:error, {:conflict, "b.png"}} =
                Attachments.batch_move(user, vault, ["a.png", "b.png"], "img")
@@ -657,11 +686,18 @@ defmodule Engram.AttachmentsTest do
       :ok
     end
 
-    test "move broadcasts delete(old) + upsert(new) with kind=attachment", %{user: user, vault: vault} do
-      {:ok, att} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "old/a.png", "content_base64" => Base.encode64("D"),
-        "mime_type" => "image/png", "mtime" => 1.0
-      })
+    test "move broadcasts delete(old) + upsert(new) with kind=attachment", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, att} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "old/a.png",
+          "content_base64" => Base.encode64("D"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
       topic = "sync:#{user.id}:#{vault.id}"
       EngramWeb.Endpoint.subscribe(topic)
 
@@ -671,19 +707,29 @@ defmodule Engram.AttachmentsTest do
         event: "note_changed",
         payload: %{"event_type" => "delete", "kind" => "attachment", "path" => "old/a.png"}
       }
+
       assert_receive %Phoenix.Socket.Broadcast{
         event: "note_changed",
-        payload: %{"event_type" => "upsert", "kind" => "attachment", "path" => "new/b.png",
-                   "mime_type" => "image/png"}
+        payload: %{
+          "event_type" => "upsert",
+          "kind" => "attachment",
+          "path" => "new/b.png",
+          "mime_type" => "image/png"
+        }
       }
+
       _ = att
     end
 
     test "delete_attachment broadcasts delete with kind=attachment", %{user: user, vault: vault} do
-      {:ok, _} = Attachments.upsert_attachment(user, vault, %{
-        "path" => "gone.png", "content_base64" => Base.encode64("D"),
-        "mime_type" => "image/png", "mtime" => 1.0
-      })
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "gone.png",
+          "content_base64" => Base.encode64("D"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
       topic = "sync:#{user.id}:#{vault.id}"
       EngramWeb.Endpoint.subscribe(topic)
 

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -643,6 +643,11 @@ defmodule Engram.AttachmentsTest do
     test "batch_delete soft-deletes each", %{user: user, vault: vault} do
       {:ok, %{deleted: 2}} = Attachments.batch_delete(user, vault, ["a.png", "b.png"])
       {:ok, nil} = Attachments.get_attachment(user, vault, "a.png")
+      {:ok, nil} = Attachments.get_attachment(user, vault, "b.png")
+    end
+
+    test "batch_delete counts only paths that held a live row", %{user: user, vault: vault} do
+      {:ok, %{deleted: 1}} = Attachments.batch_delete(user, vault, ["a.png", "absent.png"])
     end
   end
 

--- a/test/engram/storage_test.exs
+++ b/test/engram/storage_test.exs
@@ -1,0 +1,18 @@
+defmodule Engram.StorageTest do
+  use ExUnit.Case, async: true
+  alias Engram.Storage
+
+  describe "object_key/3" do
+    test "keys by uuid under an objects/ namespace, independent of vault path" do
+      uid = "11111111-1111-1111-1111-111111111111"
+      vid = "22222222-2222-2222-2222-222222222222"
+      att = "33333333-3333-3333-3333-333333333333"
+      assert Storage.object_key(uid, vid, att) == "#{uid}/#{vid}/objects/#{att}"
+    end
+
+    test "two different uuids never collide even for the same future path" do
+      uid = "u"; vid = "v"
+      refute Storage.object_key(uid, vid, "a") == Storage.object_key(uid, vid, "b")
+    end
+  end
+end

--- a/test/engram/storage_test.exs
+++ b/test/engram/storage_test.exs
@@ -11,7 +11,8 @@ defmodule Engram.StorageTest do
     end
 
     test "two different uuids never collide even for the same future path" do
-      uid = "u"; vid = "v"
+      uid = "u"
+      vid = "v"
       refute Storage.object_key(uid, vid, "a") == Storage.object_key(uid, vid, "b")
     end
   end

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -6,6 +6,8 @@ defmodule EngramWeb.AttachmentsControllerTest do
   # a POST/GET pair straddles a flip to MockStorage or Storage.Database.
   use EngramWeb.ConnCase, async: false
 
+  alias Engram.Attachments
+
   @sample_content "Hello, binary world!"
   @sample_base64 Base.encode64("Hello, binary world!")
   @updated_content "Updated content!"
@@ -18,11 +20,11 @@ defmodule EngramWeb.AttachmentsControllerTest do
     # upload, so seed an active Pro subscription before any upload runs
     # through the controller gate.
     insert(:subscription, user: user, tier: "pro", status: "active")
-    _vault = insert(:vault, user: user, is_default: true)
+    vault = insert(:vault, user: user, is_default: true)
     {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
     grant_api_write!(user)
     authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
-    %{conn: authed, user: user}
+    %{conn: authed, user: user, vault: vault}
   end
 
   # ---------------------------------------------------------------------------
@@ -575,6 +577,107 @@ defmodule EngramWeb.AttachmentsControllerTest do
 
       resp = conn |> get("/api/attachments/q.png") |> json_response(200)
       assert resp["content_base64"] == Base.encode64("BYTES")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /attachments/rename — Rename / Move single attachment
+  # ---------------------------------------------------------------------------
+
+  describe "POST /attachments/rename" do
+    test "moves and returns new path", %{conn: conn, user: user, vault: vault} do
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "old/a.png",
+          "content_base64" => Base.encode64("D"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
+      conn = post(conn, "/api/attachments/rename", %{"old_path" => "old/a.png", "new_path" => "new/b.png"})
+      body = json_response(conn, 200)
+      assert body["renamed"] == true
+      assert body["old_path"] == "old/a.png"
+      assert body["new_path"] == "new/b.png"
+    end
+
+    test "conflict → 409", %{conn: conn, user: user, vault: vault} do
+      for p <- ["a.png", "b.png"] do
+        {:ok, _} =
+          Attachments.upsert_attachment(user, vault, %{
+            "path" => p,
+            "content_base64" => Base.encode64(p),
+            "mime_type" => "image/png",
+            "mtime" => 1.0
+          })
+      end
+
+      conn = post(conn, "/api/attachments/rename", %{"old_path" => "a.png", "new_path" => "b.png"})
+      assert json_response(conn, 409)["error"] == "conflict"
+    end
+
+    test "not_found → 404", %{conn: conn} do
+      conn = post(conn, "/api/attachments/rename", %{"old_path" => "ghost.png", "new_path" => "x.png"})
+      assert json_response(conn, 404)["error"] == "not_found"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /attachments/batch-move + batch-delete — Batch ops (IdempotencyKey)
+  # ---------------------------------------------------------------------------
+
+  describe "POST /attachments/batch-move" do
+    test "requires idempotency key → 400", %{conn: conn} do
+      conn =
+        post(conn, "/api/attachments/batch-move", %{
+          "paths" => ["a.png"],
+          "target_folder" => "img"
+        })
+
+      assert json_response(conn, 400)["error"] == "missing_idempotency_key"
+    end
+
+    test "moves attachments into target folder", %{conn: conn, user: user, vault: vault} do
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "a.png",
+          "content_base64" => Base.encode64("A"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
+      conn =
+        conn
+        |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+        |> post("/api/attachments/batch-move", %{"paths" => ["a.png"], "target_folder" => "img"})
+
+      body = json_response(conn, 200)
+      assert body["moved"] == 1
+    end
+  end
+
+  describe "POST /attachments/batch-delete" do
+    test "requires idempotency key → 400", %{conn: conn} do
+      conn = post(conn, "/api/attachments/batch-delete", %{"paths" => ["a.png"]})
+      assert json_response(conn, 400)["error"] == "missing_idempotency_key"
+    end
+
+    test "deletes attachments", %{conn: conn, user: user, vault: vault} do
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "b.png",
+          "content_base64" => Base.encode64("B"),
+          "mime_type" => "image/png",
+          "mtime" => 1.0
+        })
+
+      conn =
+        conn
+        |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+        |> post("/api/attachments/batch-delete", %{"paths" => ["b.png"]})
+
+      body = json_response(conn, 200)
+      assert body["deleted"] == 1
     end
   end
 

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -594,7 +594,12 @@ defmodule EngramWeb.AttachmentsControllerTest do
           "mtime" => 1.0
         })
 
-      conn = post(conn, "/api/attachments/rename", %{"old_path" => "old/a.png", "new_path" => "new/b.png"})
+      conn =
+        post(conn, "/api/attachments/rename", %{
+          "old_path" => "old/a.png",
+          "new_path" => "new/b.png"
+        })
+
       body = json_response(conn, 200)
       assert body["renamed"] == true
       assert body["old_path"] == "old/a.png"
@@ -615,12 +620,16 @@ defmodule EngramWeb.AttachmentsControllerTest do
           })
       end
 
-      conn = post(conn, "/api/attachments/rename", %{"old_path" => "a.png", "new_path" => "b.png"})
+      conn =
+        post(conn, "/api/attachments/rename", %{"old_path" => "a.png", "new_path" => "b.png"})
+
       assert json_response(conn, 409)["error"] == "conflict"
     end
 
     test "not_found → 404", %{conn: conn} do
-      conn = post(conn, "/api/attachments/rename", %{"old_path" => "ghost.png", "new_path" => "x.png"})
+      conn =
+        post(conn, "/api/attachments/rename", %{"old_path" => "ghost.png", "new_path" => "x.png"})
+
       assert json_response(conn, 404)["error"] == "not_found"
     end
   end

--- a/test/engram_web/controllers/attachments_controller_test.exs
+++ b/test/engram_web/controllers/attachments_controller_test.exs
@@ -599,6 +599,9 @@ defmodule EngramWeb.AttachmentsControllerTest do
       assert body["renamed"] == true
       assert body["old_path"] == "old/a.png"
       assert body["new_path"] == "new/b.png"
+      # Response carries the renamed attachment's metadata (parity with notes).
+      assert body["attachment"]["path"] == "new/b.png"
+      assert body["attachment"]["mime_type"] == "image/png"
     end
 
     test "conflict → 409", %{conn: conn, user: user, vault: vault} do
@@ -678,6 +681,8 @@ defmodule EngramWeb.AttachmentsControllerTest do
 
       body = json_response(conn, 200)
       assert body["deleted"] == 1
+      # The attachment is actually gone, not just counted.
+      assert {:ok, nil} = Attachments.get_attachment(user, vault, "b.png")
     end
   end
 


### PR DESCRIPTION
## Summary

Turns on **delete / rename / move** for attachment rows in the web file tree (single + batch, mixed note+attachment selections), backed by **UUID-keyed S3 storage** and a **durable old-path tombstone** so a move converges on every device — no duplicate, no resurrection.

Spec: `docs/superpowers/specs/2026-06-16-attachment-actions-and-rename-convergence-design.md`
Plan: `docs/superpowers/plans/2026-06-17-attachment-actions-rename-convergence.md`

## What's in

**Backend**
- `Storage.object_key/3` — S3 key by row UUID (`<user>/<vault>/objects/<uuid>`), decoupled from the mutable vault path. New uploads key by UUID; legacy path-keyed rows keep working via the `storage_key` column. Fixes a latent `delete_external` bug (was recomputing the path key instead of deleting the stored column).
- `Attachments.move_attachment/4` — pure-metadata move: repoint the live row (path re-encrypted under the **unchanged** id-AAD, `storage_key`/blob untouched) + insert a soft-deleted **tombstone** at the old path, both stamped with **one `seq` in one transaction** (the #614 discipline). 409 on conflict, idempotent no-op, `:not_found` on miss.
- `batch_move/4` + `batch_delete/3` — all-or-nothing batch ops (`batch_delete` counts only real deletions).
- Real-time: reuses the existing **`note_changed`** socket event with `kind:"attachment"` (the plugin already dispatches by kind) — **no new socket event**. A move broadcasts delete(old)+upsert(new); delete broadcasts only when a live row actually transitioned.
- Endpoints: `POST /attachments/rename` (billing-gated), `/attachments/batch-move` + `/attachments/batch-delete` (under the `IdempotencyKey` pipeline). `batch_delete` intentionally **not** gated (cleanup must never trap a downgraded user).

**Frontend**
- `useRenameAttachment` / `useBatchMoveAttachments` / `useBatchDeleteAttachments` (idempotency headers, real cache-key invalidation, failure toasts).
- Un-suppressed context-menu / long-press on attachment rows; threaded the `attachment` kind through `folder-tree` (path-keyed, not id) + `ATTACHMENT_ACTIONS`.

## Re-scope vs spec

The sync-cursor-pull detour (#622/#628) landed under the spec and already shipped the convergence substrate (per-vault `seq` change-log + tombstone-carrying feed) and the folder-rename tombstone. So this PR:
- **Reuses `note_changed`+`kind`** instead of the spec's separate `attachment_changed` event.
- Leaves the spec's "PR2" (single-note `rename_note` tombstone) as a **separate follow-up PR** — folder rename already has it; single-note rename is the only gap.

## Paired plugin PR

A 2-line plugin fix (clear `syncState`/`baseStore` on socket-driven delete, matching the poll-delete convention) ships on the same-named branch `feat/attachment-actions-and-rename-convergence` — linked below once opened. The plugin otherwise converges attachment moves with zero source change.

## Tests

- Backend: **2860 tests, 0 failures** (full suite). New: storage keying, move/tombstone invariants, batch all-or-nothing rollback, broadcast gating, controller auth/idempotency/conflict.
- Frontend: hook + tree-row vitest green, biome clean.

## Follow-ups (not in this PR)

- **E2E convergence test** (web move → Obsidian, no dup over socket + offline poll) — convergence is unit-covered at every layer; the integration e2e is a tracked follow-up.
- Tombstone GC; legacy attachment blob re-key backfill (optional — reads already route via `storage_key`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
