### PR TITLE
fix(sync): single-note rename tombstone — close offline resurrection gap

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -749,6 +749,52 @@ defmodule Engram.Notes do
       )
 
     if count == 1 do
+      # Insert a soft-deleted tombstone for the OLD path so the seq-cursor
+      # change feed carries a durable `{old_path, deleted: true}` delete
+      # signal. Without it, an offline client that reconnects and pulls by
+      # cursor sees only the repointed live row at `new_path` and keeps a
+      # duplicate at `old_path` (#614, single-note analogue). Mirrors the
+      # `do_rename_folder/5` cascade: a fresh row-id-bound full-row insert,
+      # stamped with the SAME `seq` as the repoint above so a cursor pull
+      # (`WHERE seq > cursor`) can't observe the repoint at seq S, advance
+      # past S, and miss the tombstone (also S). Built from in-memory data so
+      # it folds into this same `Repo.with_tenant` transaction. The tombstone
+      # never enqueues EmbedNote — only the renamed live note does.
+      old_path = decrypted_note.path
+      tomb_id = mint_id()
+      mtime_float = DateTime.to_unix(now) + 0.0
+
+      tomb_kw =
+        full_aad_bound_kw(user, tomb_id, "", "", old_path, Helpers.extract_folder(old_path), [])
+
+      tombstone =
+        Map.merge(
+          %{
+            id: tomb_id,
+            content_hash: "",
+            mtime: mtime_float,
+            user_id: user.id,
+            vault_id: note.vault_id,
+            created_at: now,
+            updated_at: now,
+            deleted_at: now,
+            seq: seq
+          },
+          Map.new(tomb_kw)
+        )
+
+      # `on_conflict: :nothing` is belt-and-suspenders — the tombstone has a
+      # fresh UUIDv7 PK and `deleted_at != nil` excludes it from the partial
+      # unique path index, so a conflict is structurally impossible today. Log
+      # if that ever stops holding (e.g. an index-semantics change), since a
+      # dropped tombstone silently reopens the offline-resurrection gap.
+      {inserted, _} = Repo.insert_all(Note, [tombstone], on_conflict: :nothing)
+
+      if inserted == 0 do
+        require Logger
+        Logger.warning("rename_note tombstone dropped on conflict", vault_id: note.vault_id)
+      end
+
       # Splice the freshly-encrypted ciphertext + dek_version=2
       # into the in-memory struct so callers (broadcast, MCP,
       # controllers) read the new plaintext without re-decrypting

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.454",
+      version: "0.5.456",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.456",
+      version: "0.5.457",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes_seq_feed_test.exs
+++ b/test/engram/notes_seq_feed_test.exs
@@ -32,6 +32,24 @@ defmodule Engram.NotesSeqFeedTest do
     {:ok, %{changes: []}} = Notes.list_changes_by_seq(user, vault, last.seq, after_id: last.id)
   end
 
+  test "single note rename emits an old-path tombstone in the seq feed", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "A"})
+    {:ok, _} = Notes.rename_note(user, vault, "a.md", "b.md")
+
+    {:ok, %{changes: all}} = Notes.list_changes_by_seq(user, vault, 0)
+    assert Enum.any?(all, &(&1.path == "a.md" and &1.deleted))
+    assert Enum.any?(all, &(&1.path == "b.md" and not &1.deleted))
+  end
+
+  test "rename tombstone does not block re-create at the old path", %{user: user, vault: vault} do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "A"})
+    {:ok, _} = Notes.rename_note(user, vault, "a.md", "b.md")
+    assert {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "A2"})
+  end
+
   test "paginates with limit + has_more", %{user: user, vault: vault} do
     for i <- 1..3, do: Notes.upsert_note(user, vault, %{"path" => "n#{i}.md", "content" => "x"})
     {:ok, p1} = Notes.list_changes_by_seq(user, vault, 0, limit: 2)


### PR DESCRIPTION
## Summary

Closes the single-note analogue of the folder-rename resurrection gap (#614). `Notes.rename_note/4` now inserts a durable old-path **tombstone**, so an **offline** client that converges a web/MCP-originated note rename via the seq-cursor pull doesn't keep a **duplicate** at the old path.

## Background

`rename_folder/4` already emits old-path tombstones (same `seq`, one transaction) so the change feed (`list_changes_by_seq` / `GET /sync/changes`) carries a durable `{old_path, deleted:true}` signal. **`rename_note/4` did not** — it repointed the row in place and only broadcast an *ephemeral* socket delete. An online client gets the socket delete; an **offline** client reconnecting via cursor sees only the repointed live row at `new_path` and never learns `old_path` is gone → duplicate.

## Fix

Insert exactly one soft-deleted tombstone at the old path inside the **same transaction** and with the **same `seq`** as the in-place repoint, mirroring the `rename_folder/4` cascade construction field-for-field:
- fresh UUIDv7 id, all ciphertext columns bound to the **tombstone's own** id-AAD (not the live note's),
- `path_hmac = hmac(old_path)`, `deleted_at = now`, `seq` = the repoint's seq.

Same-seq/same-txn is the #614 invariant: a cursor pull (`WHERE seq > cursor`) can never observe the repoint at seq S, advance past S, and miss the tombstone (also S).

Invariants held: the tombstone never enqueues `EmbedNote` (only the renamed live note does); `deleted_at != nil` excludes it from the partial unique path index so re-creating a note at the old path still works; folder counts (which filter `deleted_at IS NULL`) are unaffected; the existing socket broadcast is untouched. Added an observability log on the structurally-impossible `on_conflict` drop so a future index-semantics change can't silently reopen the gap.

## Tests

TDD — two new seq-feed tests (old-path tombstone present; re-create at old path succeeds), red-first. **103 tests, 0 failures** across `notes_seq_feed` + `notes`; broader regression (notes + notes_seq + sync_channel) green; `mix format` + `mix credo --strict` clean.

## Relation to #631

Separate, isolated PR for the high-blast-radius core-sync change. #631 (attachment actions) shipped the same tombstone primitive in the low-risk attachment corner; this applies it to the busiest path. Independent — no ordering dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
