### PR TITLE
docs(audit): refresh backend context docs to as-built reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ takes effect on an EMPTY schema — on an existing DB the baseline row in
 `schema_migrations` makes it a silent no-op. So such a change MUST be paired
 with an actual DB wipe/recreate at every env, and the infra step must be a
 **taint + recreate**, never an in-place engine upgrade that preserves data. An
-in-place PG17→PG18 bump is exactly what stranded prod on legacy integer PKs on
+in-place PG16→PG18 bump is exactly what stranded prod on legacy integer PKs on
 2026-06-11 (see `docs/context/pg18-uuidv7-prod-crashloop-2026-06-11.md`).
 `Engram.Release.verify_schema_baseline/0` now fails the deploy loud if this is
 ever missed again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,15 +35,15 @@ Engram is a single Elixir/Phoenix OTP application — search, MCP server, note s
 | Qdrant Client | `lib/engram/vector/qdrant.ex` | Thin HTTP wrapper (~150 LOC, Req) |
 | Embedders | `lib/engram/embedders/` | Voyage AI (SaaS) + Ollama (self-hosted) |
 | Search | `lib/engram/search.ex` | Vector search, optional reranking |
-| MCP Server | `lib/engram/mcp/` | MCP tool definitions via Hermes MCP |
+| MCP Server | `lib/engram/mcp/` | Hand-rolled MCP server + tool definitions (no external MCP dep) |
 | Attachments | `lib/engram/attachments.ex` | AWS S3 (ExAws) or local |
 | Auth | `lib/engram/auth.ex` | API keys, internal JWT (Joken), RLS context |
 | Clerk Auth | `lib/engram/auth/clerk*.ex` | Clerk JWT verification (SPA + WebSocket primary path) |
-| Onboarding | `lib/engram_web/plugs/require_onboarding.ex` | TOS + active-sub gate on vault pipeline (`router.ex:189`) |
+| Onboarding | `lib/engram_web/plugs/require_onboarding.ex` | TOS + active-sub gate on vault pipeline (`router.ex:307`) |
 | Billing | `lib/engram/billing/`, `lib/engram/paddle/` | Paddle webhook receiver, billing config endpoint, subscriptions |
 | Crypto | `lib/engram/crypto/`, `lib/engram/encryption/` | Per-user DEKs, AAD bind, master-key rotation, boot canary |
 | MCP OAuth | `lib/engram_web/oauth/` | OAuth 2.1 + Dynamic Client Registration for Claude Desktop Connectors |
-| Oban Workers | `lib/engram/workers/` | EmbedNote, ReindexAll, PurgeSoftDeletes, RetryDiscarded, OrphanChunkScan, RotateUserDek, MasterRotation, AadRebind, BackfillContentHashHmac, ReconcileEmbeddings |
+| Oban Workers | `lib/engram/workers/`, `lib/engram/billing/workers/` | EmbedNote, ReconcileEmbeddings, ReindexKeyword, DeleteNoteIndex, RotateUserDek, RotateUserMasterKey, BackfillContentHashHmac, AccountExport, InactivityCleanup, MigrateUserProvider, OrphanSweep, CleanupVault, VaultDeletedEmail, CleanupDeviceAuthWorker, OriginAbuseSweep, PaddleReconcile, OverrideExpirySweep |
 
 ### Key Patterns
 
@@ -71,10 +71,11 @@ SEARCH:            MCP/REST → Voyage embed query → Qdrant similarity → top
 **Worktrees**: `git worktree add` fires `.githooks/post-checkout`, which hardlinks `deps/`, `_build/`, and `frontend/node_modules/` from the canonical checkout into the new tree. First-compile time drops from ~3min to ~10sec because mix's incremental compiler skips unchanged files. No setup needed — just `git worktree add <path> -b <branch> origin/main` and start working.
 
 ```bash
-# Docker Compose (Elixir + PostgreSQL + Qdrant)
-docker compose -f docker-compose.elixir.yml up --build
+# Docker Compose (Elixir + PostgreSQL + Qdrant + Ollama + MinIO)
+docker compose up --build
+# docker-compose.elixir.yml is a lighter variant (Elixir + PostgreSQL + MinIO, no Qdrant/Ollama)
 
-# Outside Docker (requires Elixir 1.17+, PostgreSQL, Qdrant)
+# Outside Docker (requires Elixir 1.15+, PostgreSQL, Qdrant)
 mix deps.get
 mix ecto.setup          # Create DB + run migrations + seeds
 mix phx.server          # http://localhost:4000
@@ -83,7 +84,7 @@ mix phx.server          # http://localhost:4000
 iex -S mix phx.server
 
 # Push a test note
-curl -X POST http://localhost:4000/notes \
+curl -X POST http://localhost:4000/api/notes \
   -H "Authorization: Bearer engram_..." \
   -H "Content-Type: application/json" \
   -d '{"path": "Test/Hello.md", "content": "# Hello\nTest note", "mtime": 1709234567.0}'
@@ -118,7 +119,7 @@ mix dialyzer                              # slow first run (~5-10 min PLT build)
 
 **Pre-push hook** (`.githooks/pre-push`, activated via `git config core.hooksPath .githooks`): runs all four informationally in Phase 1. Promoted to fatal phase by phase. Bypass with `git push --no-verify` for WIP / emergency. Dialyzer skipped from pre-push (too slow); CI handles it.
 
-**CI:** `lint` job in `.github/workflows/ci.yml`. PLT cached via `actions/cache@v4` keyed on `mix.lock` hash. Required check on `main` once Phase 2 lands.
+**CI:** `lint` job in `.github/workflows/verify.yml`. PLT cached via `actions/cache@v4` keyed on `mix.lock` hash. Required check on `main` once Phase 2 lands.
 
 **Ratchet semantics** (Phase 3 onward): each phase fixes findings to zero, then promotes the CI step to fatal. Numbers strictly decrease — new PRs that introduce findings fail.
 
@@ -132,7 +133,7 @@ mix dialyzer                              # slow first run (~5-10 min PLT build)
 | 4: Search | Vector search, folder/tag filter | shipped |
 | 5: Real-time | Phoenix Channel sync, Presence | shipped |
 | 6: Attachments | AWS S3 via ExAws | shipped |
-| 7: MCP | Hermes MCP server + OAuth 2.1 + DCR | shipped |
+| 7: MCP | Hand-rolled MCP server + OAuth 2.1 + DCR | shipped |
 | 8: Web UI | React SPA (Vite + shadcn/ui), Obsidian-style viewer + CodeMirror 6 editor | shipped |
 | 9: Deploy | AWS ECS Fargate for SaaS, OIDC pull-based deploy to self-host, isolated runner VM pool | shipped |
 | 10: Billing | Paddle (Merchant-of-Record), subscriptions, RequireOnboarding gate | shipped |
@@ -171,7 +172,6 @@ Self-host (no `PADDLE_API_KEY`): free, no billing wiring. See `docs/context/padd
 | `docs/context/billing-tier-frontend-contract.md` | `tier` values (default `free`, not `none`); consumers must handle every tier + gate on `!active` |
 | `docs/context/oidc-deploy-cutover.md` | OIDC pull-based deploy daemon, legacy SSH-as-root retirement |
 | `docs/context/aws-kms-provider-integration.md` | Tier-4 / Phase F roadmap for KMS provider routing |
-| `docs/context/followup-show-attachments-in-tree.md` | One-feature follow-up tracker |
 | `docs/context/local-supabase-audit.md` | Throwaway local Supabase stack to run Studio Security/Performance Advisors against the Engram schema (AVX2 CLI build, encrypted-seed, RLS role grant, boot-canary gotchas) |
 | `docs/context/spa-state-injection.md` | How Phoenix ships server-known state into `window.__ENGRAM_CONFIG__` so the React SPA can render first-paint-correct UI without a fetch round-trip — the recipe for adding new injected fields, dev vs prod behavior, gotchas (NOT real SSR; see #353) |
 | `docs/context/folder-tree-optimistic-rebuild.md` | How the SPA folder-tree (headless-tree) reads notes from `folder-notes-by-id` + `folderNotes` caches and what triggers `rebuildTree()` — `treeStructureKey` (id:count:parent_id) + a QueryCache subscription; the 2026-06-13 optimistic move/delete/duplicate fixes + remaining gaps |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,8 @@ without Docker — i.e. you're hacking on the app itself.
 
 ### Prerequisites
 
-- Elixir 1.17+ and Erlang/OTP 27+
-- PostgreSQL 16+
+- Elixir 1.15+ and Erlang/OTP 27+
+- PostgreSQL 18+ (the schema baseline uses `uuidv7`; older majors won't boot)
 - [Qdrant](https://qdrant.tech) running locally or Qdrant Cloud
 - [Ollama](https://ollama.com) (optional — only if running embeddings locally;
   the alternative is `EMBED_BACKEND=voyage` with a Voyage API key)
@@ -114,7 +114,7 @@ curl -X POST http://localhost:4000/api/auth/register \
 TOKEN=$(curl -s -X POST http://localhost:4000/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email": "you@example.com", "password": "your-password"}' \
-  | jq -r '.token')
+  | jq -r '.access_token')
 
 # Create API key
 curl -X POST http://localhost:4000/api/api-keys \

--- a/docs/context/async-indexing-pipeline.md
+++ b/docs/context/async-indexing-pipeline.md
@@ -1,9 +1,9 @@
 # Context Doc: Async Indexing Pipeline (Oban)
 
-_Last verified: 2026-04-03_
+_Last verified: 2026-06-18 (against `config/config.exs` + `lib/engram/workers/`)_
 
 ## Status
-Working — design finalized, implementation in progress.
+Live. Core EmbedNote mechanics (debounce, dedup, content-hash skip, DB-is-source-of-truth) are current. Queue list + crontab below regenerated from `config/config.exs:55-74`.
 
 ## What This Is
 Complete specification for the Oban-based async embedding pipeline. All RAG work (parse → embed → Qdrant upsert) runs asynchronously. Note sync remains synchronous and immediate.
@@ -34,11 +34,15 @@ POST /notes (or Channel push_note)
 
 ## Oban Queues
 
-| Queue | Concurrency | Rate Limit | Purpose |
-|-------|------------|------------|---------|
-| `embed` | 5 | 100/min (Voyage API ceiling) | Per-note embedding after upsert |
-| `reindex` | 1 | 10/min | Bulk re-embedding (model migration, context format change) |
-| `maintenance` | 2 | — | Soft-delete purge, stale job cleanup, orphan chunk detection |
+From `config/config.exs:58` — `queues: [embed: 5, reindex: 1, maintenance: 2, crypto_backfill: 1, export: 1]`. There is no Oban Pro and no `rate_limit` queue option (`engine: Oban.Engines.Basic`, plugins are only Pruner/Lifeline/Cron). Voyage backpressure is enforced by the worker snoozing on 429s, not by an Oban rate limiter (see Backpressure below).
+
+| Queue | Concurrency | Purpose |
+|-------|------------|---------|
+| `embed` | 5 | Per-note embedding after upsert (`EmbedNote`) |
+| `reindex` | 1 | Bulk re-embedding — model/context migration (`reindex_keyword.ex`, reindex workers) |
+| `maintenance` | 2 | General background maintenance |
+| `crypto_backfill` | 1 | DEK/master-key rotation + content-hash HMAC backfill (`rotate_user_dek.ex`, `rotate_user_master_key.ex`, `backfill_content_hash_hmac.ex`, `migrate_user_provider.ex`) |
+| `export` | 1 | Account data export (`account_export.ex`) |
 
 ## Deduplication & Debouncing
 
@@ -54,7 +58,7 @@ defmodule Engram.Workers.EmbedNote do
     unique: [
       period: 60,                          # dedup window
       keys: [:note_id],                    # one job per note
-      states: [:available, :scheduled]     # don't dedup if already executing
+      states: :incomplete                  # dedup across all not-yet-completed states
     ]
 
   @impl true
@@ -93,32 +97,43 @@ Oban.insert(EmbedNote.new(
 | 5 | 1 hour | Last attempt |
 | Exhausted | Move to `discarded` | Note is stored but not searchable |
 
-**Discarded job recovery:** A daily Oban cron job (`maintenance` queue) scans for `discarded` embed jobs and re-enqueues them.
+**Embed-backlog recovery:** The `ReconcileEmbeddings` cron (every 15 min) re-enqueues notes whose embedding is missing/stale — it scans the `idx_notes_embed_pending` partial index (`embed_hash IS NULL OR embed_hash <> content_hash`) rather than scanning Oban's `discarded` table. This covers both exhausted jobs and notes that never got a job.
 
-**Crash safety:** Oban's `rescue_orphaned_jobs` plugin detects jobs stuck in `executing` state (no heartbeat for 60s) and moves them back to `available` for retry.
+**Crash safety:** Oban's `Lifeline` plugin (config.exs:61) detects jobs stuck in `executing` after a node crash and moves them back to `available` for retry.
 
 ## Backpressure
 
-- **Oban concurrency limit** — `embed` queue runs max 5 concurrent workers. If 500 notes are pushed at once, they queue up and process 5 at a time.
-- **Voyage AI rate limiting** — Oban's `rate_limit` option caps at 100 jobs/min per queue, matching Voyage API ceilings.
+- **Oban concurrency limit** — `embed` queue runs max 5 concurrent workers. If 500 notes are pushed at once, they queue and process 5 at a time.
+- **Voyage AI rate limiting** — handled in the worker, NOT by an Oban rate limiter. On a Voyage `429` the worker returns `{:snooze, n}` (default 60s, env `EMBED_429_SNOOZE_SECONDS`) which reschedules without burning an attempt (`embed_note.ex:179-210`). Optionally, a client-side cap (`VOYAGE_RPM` / `VOYAGE_QUERY_RPM`) fails fast with a synthetic 429 before the real API call (`runtime.exs:131-137`).
 - **Qdrant writes** — each embed job does one batch upsert per note (not per chunk), so write pressure scales with notes, not chunks.
 - **Memory** — workers fetch one note at a time from DB; no risk of loading 500 notes into memory simultaneously.
 
 ## Scheduled Jobs (Cron)
 
+Verbatim from `config/config.exs:55-74`:
+
 ```elixir
 config :engram, Oban,
-  queues: [embed: 5, reindex: 1, maintenance: 2],
+  engine: Oban.Engines.Basic,
+  repo: Engram.Repo,
+  queues: [embed: 5, reindex: 1, maintenance: 2, crypto_backfill: 1, export: 1],
   plugins: [
-    {Oban.Plugins.Pruner, max_age: 7 * 24 * 3600},  # prune completed jobs after 7 days
-    Oban.Plugins.Lifeline,                             # rescue orphaned jobs
-    {Oban.Plugins.Cron, crontab: [
-      {"0 3 * * *", Engram.Workers.PurgeSoftDeletes},  # daily at 3am: hard-delete notes with deleted_at > 30 days
-      {"0 4 * * *", Engram.Workers.RetryDiscarded},     # daily at 4am: re-enqueue discarded embed jobs
-      {"0 5 * * 0", Engram.Workers.OrphanChunkScan},    # weekly: find Qdrant points with no matching chunks row
-    ]}
+    {Oban.Plugins.Pruner, max_age: 7 * 24 * 3600},   # prune completed jobs after 7 days
+    Oban.Plugins.Lifeline,                            # rescue orphaned (post-crash) jobs
+    {Oban.Plugins.Cron,
+     crontab: [
+       {"*/15 * * * *", Engram.Workers.ReconcileEmbeddings},     # re-enqueue missing/stale embeds
+       {"0 * * * *",    Engram.Workers.CleanupDeviceAuthWorker}, # hourly: expire device-auth codes
+       {"0 2 * * *",    Engram.Billing.Workers.PaddleReconcile}, # daily: reconcile subscription state
+       {"0 3 * * *",    Engram.Billing.Workers.OverrideExpirySweep}, # daily: expire limit overrides
+       {"30 3 * * *",   Engram.Workers.InactivityCleanup},       # daily: inactivity warnings + cleanup
+       {"0 4 * * *",    Engram.Workers.OriginAbuseSweep},        # daily: client-origin abuse sweep
+       {"0 5 * * 0",    Engram.Workers.OrphanSweep}              # weekly Sun: cross-store orphan cleanup (Qdrant/S3)
+     ]}
   ]
 ```
+
+> `PurgeSoftDeletes` / `RetryDiscarded` / `OrphanChunkScan` do **not** exist. Soft-delete + cross-store orphan cleanup is `OrphanSweep` (weekly); embed re-enqueue is `ReconcileEmbeddings` (every 15 min); test env disables Oban entirely (`config/test.exs:79`, `testing: :manual`).
 
 ## Re-indexing & Embedding Migration
 
@@ -130,8 +145,8 @@ Re-indexing is needed when **any** of these change: embedding model, context for
 - Chunk size change (e.g., 512 → 1024 tokens) — different chunk boundaries
 - Multimodal upgrade (voyage-multimodal-3.5) — different vector space
 
-**Blue-green strategy:**
-1. Create second Qdrant collection (`obsidian_notes_v2`)
+**Blue-green strategy:** (the live collection is `engram_notes` — see `docs/context/environment-variables.md` for the `QDRANT_COLLECTION` default nuance)
+1. Create second Qdrant collection (e.g. `engram_notes_v2`)
 2. Oban `reindex` queue processes all notes (low priority, max concurrency 1)
 3. Each note: re-parse → re-contextualize → re-embed → upsert to v2 collection + update Postgres `chunks`
 4. When complete: swap `QDRANT_COLLECTION` pointer to v2, delete v1
@@ -144,6 +159,8 @@ Re-indexing is needed when **any** of these change: embedding model, context for
 **Metadata:** Store `{model, context_format_version, chunk_config}` with each Qdrant collection for tracking.
 
 ## References
-- Oban workers: `lib/engram/workers/`
+- Oban config (queues + crontab): `config/config.exs:55-74`
+- EmbedNote worker: `lib/engram/workers/embed_note.ex`
+- Oban workers (full set): `lib/engram/workers/`, `lib/engram/billing/workers/`
 - Indexing orchestrator: `lib/engram/indexing.ex`
 - Chunking strategy: `docs/context/chunking-retrieval-strategy.md`

--- a/docs/context/attachment-mime-whitelist.md
+++ b/docs/context/attachment-mime-whitelist.md
@@ -70,7 +70,7 @@ catches it. Phase 2 PhotoDNA addresses the residual image-payload case.
 ## Operator launch checklist
 
 1. Decide policy for SaaS: gate ON by default. No env vars needed on
-   Fly — module defaults match the SaaS posture.
+   AWS — module defaults match the SaaS posture.
 2. For self-host docs, add a note to `engram.ax` quick-start docs that
    `ATTACHMENT_MIME_BYPASS=true` is available for operators who need to
    distribute executables from their personal vault.

--- a/docs/context/aws-kms-provider-integration.md
+++ b/docs/context/aws-kms-provider-integration.md
@@ -2,7 +2,7 @@
 
 > Non-obvious discoveries from Phase 1 (PR #110). Prevents rediscovery in Phase 2 (BootCanary polymorphism) and Phase 3 (ProviderMigration).
 >
-> **Status update 2026-05-20:** Phase 2 quietly shipped — `Engram.Crypto.BootCanary.verify!/0` calls `Resolver.provider()` + `provider.boot_check/0` + `provider.unwrap_dek_no_fallback/2`. `MasterRotation` uses `Resolver.provider_for/1`. Only Phase 3 (cross-provider migration state machine) remains pending. Staging cutover docs in workspace plan `ok-i-think-we-shimmying-duckling.md`.
+> **Status update 2026-06-18:** All three phases shipped. Phase 2 — `Engram.Crypto.BootCanary.verify!/0` calls `Resolver.provider()` + `provider.boot_check/0` + `provider.unwrap_dek_no_fallback/2`; `MasterRotation` uses `Resolver.provider_for/1`. **Phase 3 — the cross-provider migration state machine is live:** `Engram.Crypto.ProviderMigration` (`lib/engram/crypto/provider_migration.ex`) + the `Engram.Workers.MigrateUserProvider` Oban worker + the `mix engram.migrate_provider` task (`lib/mix/tasks/engram.migrate_provider.ex`). Per-user Local→KMS migration no longer requires a DB wipe — see the corrected "Phase 3" note at the bottom.
 
 ## Architecture — Three Layers
 
@@ -93,7 +93,7 @@ config :ex_aws, :kms,
 
 ### The Trap
 
-The S3 storage backend (Fly Tigris) sets **global** `:ex_aws` creds:
+The S3 storage backend (AWS S3 in prod / MinIO in self-host) sets **global** `:ex_aws` creds:
 
 ```elixir
 # runtime.exs — storage config
@@ -106,7 +106,7 @@ config :ex_aws,
 If KMS wiring puts credentials at the same global level:
 
 ```elixir
-# WRONG: overwrites Tigris creds
+# WRONG: overwrites the storage backend's creds
 config :ex_aws,
   access_key_id: AWS_ACCESS_KEY_ID,  # Silently replaces STORAGE_ACCESS_KEY_ID
   secret_access_key: AWS_SECRET_ACCESS_KEY,
@@ -120,14 +120,21 @@ Result: S3 attachment storage breaks at runtime. No error — just silent auth f
 Always scope KMS credentials to the service-specific namespace:
 
 ```elixir
-# Scoped to :ex_aws, :kms — preserves Tigris creds
-config :ex_aws, :kms,
-  access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
-  secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
-  region: System.fetch_env!("AWS_REGION")
+# Scoped to :ex_aws, :kms — preserves the global storage creds.
+# On AWS ECS Fargate the static keys are left UNSET so ex_aws falls
+# back to the task role; only region is set. Static keys are an
+# opt-in (local dev / non-task-role) path:
+if System.get_env("AWS_ACCESS_KEY_ID") do
+  config :ex_aws, :kms,
+    access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
+    secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
+    region: System.fetch_env!("AWS_REGION")
+else
+  config :ex_aws, :kms, region: System.fetch_env!("AWS_REGION")
+end
 ```
 
-ExAws merges service-scoped config into the global namespace at request time, so both credential sets coexist.
+ExAws merges service-scoped config into the global namespace at request time, so both credential sets coexist. (See `config/runtime.exs` ~L482-500.)
 
 ## Provider Tag Byte `0xAA` Rationale
 
@@ -142,7 +149,7 @@ def identify_from_blob(<<0x01, 0x01, _::binary-size(60)>>), do: :local  # v1 = k
 def identify_from_blob(<<0x02, 0x01, _::binary-size(60)>>), do: :local  # v2 = key rotation
 ```
 
-**Phase 1 ships this helper but does NOT wire it into read paths.** Phase 3 (ProviderMigration) will use it to route decryption during the Local→KMS migration window.
+Phase 1 shipped this helper unwired; **Phase 3 (ProviderMigration, now shipped) wires it into the read path** to route decryption during the Local→KMS migration window.
 
 ## EncryptionContext for AAD Binding
 
@@ -178,10 +185,9 @@ From `KeyProvider.AwsKms.unwrap_dek/2`:
 ### Ships
 - Provider + behaviour + Mox seam + conformance suite + `Config.validate!/0` extension + `runtime.exs` opt-in arm + `identify_from_blob/1` primitive.
 
-### Does NOT Ship (at PR #110 — see status update at top)
+### Did NOT ship at PR #110 — now resolved
 - ~~BootCanary polymorphism (Phase 2)~~ — shipped post PR #110; see status update.
-- ProviderMigration state machine (Phase 3).
-- Fly secrets / IAM policy creation (Phase 4 cutover for prod). Staging cutover lives in the workspace plan, not here.
-- Changes to `Engram.Crypto.get_dek/1` read paths — still read-only from configured provider; no cross-provider blob routing.
+- ~~ProviderMigration state machine (Phase 3)~~ — **SHIPPED**: `Engram.Crypto.ProviderMigration` + `Engram.Workers.MigrateUserProvider` + `mix engram.migrate_provider`. `identify_from_blob/1` is now wired into the read path so Local and KMS blobs are routed during the migration window.
+- IAM / CMK provisioning for prod — handled in **engram-infra Terraform**, not Fly. Prod runs on AWS ECS Fargate: KMS access is granted via the **task role** (no static keys in env), and the master/app secrets live in **AWS SSM Parameter Store** (SOPS-managed), NOT Fly secrets.
 
-Key impl detail: All DEK operations (get/wrap/unwrap) use the configured provider, but the migration machinery to change provider per-user doesn't exist yet — staging cutover therefore wipes the DB rather than migrating.
+Key impl detail (corrected): The per-user provider-migration machinery now exists, so cutover **migrates** users (re-wraps each DEK Local→KMS via `ProviderMigration`) rather than wiping the DB. The old "staging cutover wipes the DB" note applied only before Phase 3 landed.

--- a/docs/context/b2-cursor-pull-e2e-triage.md
+++ b/docs/context/b2-cursor-pull-e2e-triage.md
@@ -1,0 +1,80 @@
+# PR B2 (cursor-pull) — paired e2e failure triage
+
+**Date:** 2026-06-17
+**Context:** Plugin PR `engram-app/Engram-obsidian#109` (cursor-pull migration) paired with merged backend B1 (#628). First paired e2e run (backend run 27665339557, `e2e-clerk`) had **5 failures**. This doc captures the root-cause so it isn't rediscovered.
+
+## TL;DR
+Core convergence WORKS (test_49 cross-auth push↔receive, test_50 live SSE, conflict/preview/special-chars all green). The 5 failures are: 3 obsolete-contract/accounting test-ports + 1 real B2 reconnect-catch-up bug (test_48 ×2).
+
+## The 5 failures
+
+| Test | Symptom | Verdict |
+|---|---|---|
+| `test_58_commands_palette::test_sync_now_advances_last_sync` | `lastSync` didn't change | **Obsolete** — B2 freezes `lastSync` (cursor is the watermark). Port: assert the cursor advances. |
+| `test_59_status_bar_click::test_click_unblocked_triggers_sync` | `lastSync` didn't change | **Obsolete** — same. Port to cursor. |
+| `test_44_oauth_device_flow::test_full_device_flow` | `Expected push, got {pulled:0,pushed:0}` | **Accounting** — B2 bootstrap pushes offline-created files INSIDE `bootstrap()`, so `fullSync`'s push counter reads 0 though the file reaches the server. Port: assert server-side arrival, not push count. |
+| `test_48_oauth_reconnect_catchup::test_oauth_reconnect_catches_up` | `OAuthReconnect.md` never appeared after reconnect | **REAL BUG** (see below). |
+| `test_48_oauth_reconnect_catchup::test_oauth_reconnect_receives_update` | V2 update never applied after reconnect | **REAL BUG** (same). |
+
+## Evidence (from run-27665339557 vault tarballs)
+- `e2e/helpers/obsidian.py:139` seeds `lastSync: "2020-01-01T00:00:00Z"` but **no `syncCursor`** → every e2e plugin starts in B2's bootstrap path.
+- The `catches_up` worker vault: `OAuthReconnect.md` genuinely **absent**.
+- The `receives_update` worker vault: file present (V1 via SSE) but V2 missing; `data.json` `syncCursor` = seq **83** (unchanged from before the disconnect), `lastSync` frozen `2020...`.
+- Non-OAuth reconnect tests (`ChannelReconnect`, `TopicReconnectCheck`) PASSED — so the bug is specific to the **OAuth-swap path**.
+
+## Root cause of test_48 (real bug)
+`swap_to_oauth` (e2e/helpers/oauth.py) changes `vaultId` → B2's `SyncEngine.invalidateIfVaultChanged()` clears the cursor → the reconnect-time `pull()` (wired at plugin `main.ts:843` `channel.onStatusChange(connected) → syncEngine.pull()`) must **bootstrap** (manifest + full genesis pull), which is slow.
+
+The cursor stayed at 83 and V2 (a later seq) was never pulled → most consistent with **the reconnect catch-up `pull()` being dropped by the `pulling` re-entry guard** (`if (this.pulling) return 0`) while the slow post-swap bootstrap is still in flight. A dropped catch-up = the missed change is never fetched (the cursor never advances, V2 never applied).
+
+Secondary contributing issue: an **empty-vault genesis pull leaves the cursor null** (`pullViaCursor` only advances on `next_cursor`/`changes.length>0`), so a freshly-swapped empty vault never establishes a cursor → repeated full bootstraps. Spec §E actually said to set the cursor to `(change_seq, MAX_UUID)` after bootstrap (the `ManifestResponse.change_seq` field is typed in B2 but unused) — that's the intended fix for the empty case.
+
+## Fix plan
+**Plugin (PR #109 branch):**
+1. **Coalesce a dropped pull** — if `pull()` is called while one is in flight, set a `pullRequested` flag and re-run once when the current pull finishes (so a reconnect catch-up is never silently lost to the re-entry guard). This is the primary test_48 fix.
+2. **§E cursor-after-bootstrap** — after the genesis pull in `bootstrap()`, set the cursor from `manifest.change_seq` (`encodeCursor(change_seq, MAX_UUID)`) when the genesis pull left it null/behind, so the cursor always reflects the true head (fixes empty-vault + makes reconnect resume incremental instead of re-bootstrapping).
+
+**Backend e2e (engram repo, pairs with #109):**
+3. Port `test_58`/`test_59` → assert the cursor advances (add a `get_sync_cursor` CDP helper reading `plugin.syncEngine.getSyncCursor()`), not `lastSync`.
+4. Port `test_44` → assert the created file arrives on the server (GET /notes or manifest), not `fullSync` push count.
+
+**Verify:** re-dispatch the paired e2e via the plugin PR (`trigger-e2e` / `plugin_branch=feat/sync-cursor-pull-b2`), iterate to green.
+
+## UPDATE 2026-06-17 — round 2 (run 27666381848, backend `fix/b2-cursor-e2e-ports` + plugin `feat/sync-cursor-pull-b2`)
+**5 → 2 failures.** The 3 contract/accounting ports (test_44/58/59) now PASS. The 2 reconnect tests (test_48 ×2) STILL fail — the coalesce-pull + §E-cursor fixes did NOT resolve them.
+
+Evidence (run-27666381848 w1-a vault `data.json`): `syncCursor` = seq **37** (`019ed3e9-c906-788a-8d66-4b521f2b7007`), note has V1 (via SSE), V2 (created-while-disconnected, a later seq) absent. So **no pull fetched seq>37 after V2 was created**, despite `main.ts:843` firing `pull()` on reconnect and `pullViaCursor(37)` *should* return seq>37.
+
+Narrowed scope: live sync (test_49/50) AND non-swap reconnect-catch-up (ChannelReconnect/TopicReconnect) PASS. ONLY the **auth/vault-swap + reconnect-catch-up** path fails (`swap_to_oauth` changes vaultId → `invalidateIfVaultChanged` clears the cursor).
+
+**Blocker:** the plugin runtime rlog (which shows what `pull()` actually did on reconnect — ran? errored? returned empty?) goes to the ephemeral CI backend and is gone. Can't pin from artifacts. Blind-fix wasted one e2e cycle.
+
+## UPDATE 2026-06-17 — rounds 3-5: test_48 FIXED, test_24 regressed
+
+**test_48 ROOT CAUSE + FIX (verified green round 4/5):** `invalidateIfVaultChanged()` (clears the per-vault cursor on a vault swap) was wired into `fullSync`/`pullAll` but NOT `pull()`. The reconnect catch-up calls `pull()` directly, so after `swap_to_oauth` the reconnect pull used the prior vault's cursor against the new vault — `getSyncChanges(seq > <foreign seq>)` returns nothing → disconnected-change never arrives, cursor frozen at the foreign seq. **Fix (plugin commit 9cfac7f):** call `invalidateIfVaultChanged()` at the top of `pull()`. test_48 ×2 now PASS.
+
+**NEW regression: test_24_offline_queue_replay** ("Queue not drained after 10s, size=2"). Deterministic (failed initial + rerun in rounds 3 AND 4 = 4 consecutive; reruns=1). Passed rounds 1-2.
+- test_24 does NOT swap vaults (`simulate_offline` only overrides `api.pushNote/health` to throw; `vaultId` unchanged), so `invalidateIfVaultChanged` is a state-level NO-OP there (no wipe, no saveData). The ONLY effect of the round-3 change is the extra `await invalidateIfVaultChanged()` tick at `pull()` start.
+- Recovery path: `restore_online()` calls `flushQueue()` directly (await); separately, health-recovery → goOnline → `pull()`. The extra await shifted this race → queue (2 entries) not draining.
+- In test_24 the cursor is SET (initial sync), so the recovery `pull()` is `pullViaCursor` (NOT bootstrap/§F) — so the "bootstrap §F double-pushes queued files" theory is NOT it.
+- OPEN: exact race mechanism unconfirmed (needs runtime rlog / local repro). Candidates: (a) `pullViaCursor` applying a remote change to the offline-edited file mid-flush; (b) coalesce re-run interacting with the direct flushQueue; (c) a pre-existing flushQueue/goOnline double-invocation race that the await timing now loses.
+
+**Status:** 4/5 original failures fixed (44/48×2/58/59 green). test_24 is a recovery-path timing regression exposed by the test_48 fix. Branches: plugin `feat/sync-cursor-pull-b2` (9cfac7f), backend e2e `fix/b2-cursor-e2e-ports`.
+
+**Next options:** (A) instrument test_24/pull with CDP state capture + re-run; (B) local e2e repro (`make e2e` + Obsidian); (C) make the test_48 fix surgical (only null the stale cursor when `syncStateVaultId != vaultId` AND a cursor exists — skipped entirely when vault matches, so zero perturbation to test_24's timing) and re-run.
+
+## RESOLVED 2026-06-17 — all e2e green (paired run 27667988219: 109 passed)
+- **test_48** fixed by the **gated** vault-swap cursor invalidation in `pull()` (plugin: only call `invalidateIfVaultChanged()` when `getSyncCursor() != null && syncStateVaultId != null && syncStateVaultId != settings.vaultId`). Skipped entirely when the vault is unchanged → no hot-path perturbation.
+- **test_24** root cause = the **coalesce-pull** change (a wrong-guess attempt at test_48: re-run a dropped pull via `pullRequested` + `setTimeout`). It added an extra recovery-time `pull()` that raced `flushQueue()` (offline-queue replay) → intermittent "Queue not drained". **Reverted** (it fixed no test). With coalesce gone + gated invalidate (no-op for test_24), test_24's path ≡ the passing round-1 code → green.
+- Final plugin fix commits on `feat/sync-cursor-pull-b2`: `8abab94` (§E cursor seed — kept), `9cfac7f`→`c437ff4` (gated invalidate), `00bcddd` (revert coalesce). Backend e2e ports on `fix/b2-cursor-e2e-ports`.
+- **Lesson:** verify a fix actually fixes the target before stacking more; the coalesce guess wasn't validated in isolation and introduced a race. Also: paired e2e MUST be run on a `workflow_dispatch` of the backend ports-branch with `plugin_branch=<fix branch>` — PR #109's auto `trigger-e2e` runs against backend `main` (no ports) and is red as a sequencing artifact.
+
+**Merge sequencing (chicken-and-egg):** the backend e2e ports assert B2 behavior (fail vs plugin `main`); plugin #109's e2e needs the ports (fail vs backend `main`). Land plugin #109 first (accept the artifact-red `backend/e2e`; the paired run proves green), THEN open/merge the backend ports PR (its e2e then runs against plugin `main` with B2 → green).
+
+## Key anchors
+- Reconnect→pull wiring: plugin `src/main.ts:843`.
+- Re-entry guard: plugin `src/sync.ts` `pull()` `if (this.pulling) return 0`.
+- Cursor advance: plugin `src/sync.ts` `pullViaCursor` (final-page `encodeCursor`).
+- Cursor clear on vault change: plugin `src/sync.ts` `invalidateIfVaultChanged` / `resetForVaultChange`.
+- Bootstrap: plugin `src/sync.ts` `bootstrap()`.
+- e2e seed: `engram/e2e/helpers/obsidian.py:139`; OAuth swap: `engram/e2e/helpers/oauth.py` `swap_to_oauth`.

--- a/docs/context/billing-tier-frontend-contract.md
+++ b/docs/context/billing-tier-frontend-contract.md
@@ -1,6 +1,6 @@
 # Context Doc: Billing tier contract (backend → frontend)
 
-_Last verified: 2026-05-26_
+_Last verified: 2026-06-18_
 
 ## Status
 Working — fixed in PR #309 (`fix/onboarding-flow`).
@@ -14,18 +14,29 @@ made the onboarding billing step render blank.
 `GET /api/billing/status` returns `tier` from `Engram.Billing.tier/1`
 (`lib/engram/billing.ex`). Possible values:
 
-`free | trial | starter | pro`  (plus `none` historically — see gotcha)
+`free | starter | pro`  (plus `none` historically — see gotcha)
 
 **A user with no/canceled/expired subscription is `:free`, NOT `:none`.** Pricing
-v2 changed the default. `active?/1` is true only for `active | past_due |
-trialing` subscriptions.
+v2 changed the default. There is **no `:trial` tier** — trial-status
+subscriptions surface as their paid tier (`:starter`/`:pro`), because the
+`@entitled_statuses` set is `active | trialing | past_due` (`billing.ex:148`).
+
+**Two distinct "active" notions — do not conflate them:**
+- The `active` field in the `/api/billing/status` JSON body is computed as
+  **`Billing.tier(user) in [:starter, :pro]`** (`billing_controller.ex:16`). It
+  means "on a paid tier". A `:free` user is `active: false` here.
+- `Engram.Billing.active?/1` (`billing.ex:200`) is a **separate, suspension-only**
+  predicate: `is_nil(user.suspended_at)`. It is NOT the source of the response
+  field, and it is true for healthy Free users. Don't assume the JSON `active`
+  flag mirrors `active?/1`; they answer different questions.
 
 ## Rule for consumers
 - Handle **every** tier value, including `free`. A label/lookup keyed only on a
   subset silently renders empty for the missing key.
-- Derive "this user needs to pick a paid plan" from **`!billing.active`**, not
-  from `tier === 'none'` (or any single tier string). `active` is the
-  authoritative flag and self-heals as tiers are added/renamed.
+- Derive "this user is on a paid plan" from the response **`active`** field
+  (= paid tier). To branch on "needs to pick a plan", treat `tier === 'free'`
+  (or `active === false`) as the signal — but note `free` is a legitimate
+  finished state outside onboarding (see gotcha), not inherently "broken".
 
 ## Gotchas
 - **`tier === 'none'` is stale.** Before pricing v2 a subscriptionless user was
@@ -34,10 +45,15 @@ trialing` subscriptions.
   - an **empty plan badge** (`TIER_LABELS["free"]` was `undefined`), and
   - **hidden plan cards** (`needsSubscription = tier === 'none'` was false for
     `free`), so the onboarding billing step looked blank/broken.
-- **Onboarding still gates on a paid plan.** `Engram.Onboarding.status/1` sets
-  `subscription_ok = Billing.active?(user)`, and `free` is NOT active — so a
-  brand-new user sits on the billing step until they start a trial. `free` is the
-  "not chosen yet" state during onboarding, not a finish state.
+- **Onboarding gates on tier OR an explicit Free choice.**
+  `Engram.Onboarding.status/1` (`onboarding.ex:166`) computes
+  `subscription_ok` as: self-host (`billing_enabled=false`) **or**
+  `Billing.tier(user) in [:starter, :pro]` **or**
+  `user.free_tier_accepted_at` is set. It does **not** call `active?/1`.
+  A brand-new hosted user sits on the billing step until they either start a
+  paid plan or click **"Continue with Free"** (which sets `free_tier_accepted_at`
+  and lets the wizard advance). So `free` IS a valid finish state for onboarding —
+  it just requires the explicit Free acceptance, not merely "tier == free".
 - **No SPA error boundary.** An uncaught render error in a route element blanks
   the subtree (react-router default) with no console-visible app error. A blank
   step ≠ a crash here — it was a data/contract issue, confirmed by mounting the

--- a/docs/context/channel-event-contract.md
+++ b/docs/context/channel-event-contract.md
@@ -35,6 +35,7 @@ WebSocket connect: wss://api.engram.page/socket/websocket?token=<api_key|jwt>
 | `note_changed` (delete) | `{event_type: "delete", path, vault_id}` | After a delete/rename-away | Tombstone notification |
 | `notes.batch` (upsert digest) | `{op: "upsert", vault_id, notes: [{event_type, id, path, title, folder, tags, mtime, version, updated_at, content_hash}]}` | ONE per `POST /api/notes/batch` call (replaces N `note_changed` events) | Bulk-push digest — metadata-only, never carries content |
 | `notes.batch` (delete/move) | `{op: "delete"\|"move", ids, target_folder_id?}` | After batch delete / batch move | Batch-op notification |
+| `vault_created` | `{vault_id, ...}` (topic `user:{user_id}`) | A vault is created (`Engram.Vaults.broadcast_vault_created/2`) | FTUX listener — onboarding waits for this alongside `vault_populated` |
 | `vault_populated` | `{vault_id}` (topic `user:{user_id}`) | First note lands in an empty vault | FTUX listener |
 | `presence_state` / `presence_diff` | Phoenix Presence shapes | Join / device change | Connected-device tracking |
 

--- a/docs/context/chunking-retrieval-strategy.md
+++ b/docs/context/chunking-retrieval-strategy.md
@@ -1,16 +1,24 @@
 # Context Doc: Chunking & Retrieval Strategy
 
-_Last verified: 2026-04-03_
+_Last verified: 2026-06-18_
 
 ## Status
-Working — priorities 1-2 in implementation, 3-5 planned.
+Working — priorities 1-3 shipped (BM25 hybrid landed in #610), 4-5 planned.
 
 ## What This Is
 Layered strategy for chunking notes and retrieving relevant content. Each priority is independent.
 
 ## Current State
 
-Heading-aware chunking at ~512 tokens / 50 overlap (approximate, word-based ~4 chars/token — Voyage API handles actual tokenization). Folder-aware context prepended before embedding. Vector-only search.
+Heading-aware chunking at ~512 tokens / 50 overlap (approximate, word-based ~4 chars/token — Voyage API handles actual tokenization). Folder-aware context prepended before embedding. **Hybrid search (dense + BM25 keyword) shipped in #610** — see below.
+
+### Hybrid keyword search (shipped #610)
+Per-chunk sparse vectors live alongside the dense vector in the same Qdrant point. Tokens are NOT stored as plaintext: each token is `HMAC(user_DEK, token) → u32` (no plaintext keywords at rest). Real BM25 scoring uses Qdrant's server-side IDF with client-side TF / length-norm; an NFKC + CJK-bigram tokenizer feeds both index and query. The two legs are fused server-side via Reciprocal Rank Fusion (RRF), so the hybrid `score` is an RRF rank score, NOT a cosine similarity. Callers pick a leg via `?mode=` on `GET /api/search`:
+- HTTP default (param absent or unrecognized) → `:hybrid` (`search_controller.ex:81`)
+- `?mode=vector` → dense only; `?mode=keyword` → BM25 only
+- Note the `Engram.Search.search/4` library default is `:vector` (`search.ex:135`) — the HTTP layer overrides it to `:hybrid`.
+
+Modules: `lib/engram/keyword_index/{bm25,qdrant_sparse,tokenizer,stats}.ex`, reindex via `lib/engram/workers/reindex_keyword.ex`, leg dispatch in `lib/engram/search.ex` (`run_legs/4`).
 
 ## Decided Approach (Layered, Each Independent)
 
@@ -18,7 +26,7 @@ Heading-aware chunking at ~512 tokens / 50 overlap (approximate, word-based ~4 c
 |----------|---------|-------------|---------------|
 | **1** | **Folder-aware context prepending** | Prepend `folder_path > title > heading` to chunk text before embedding. ~35% retrieval failure reduction (Anthropic benchmark). | `Engram.Indexing` |
 | **2** | **Structure preservation** | Keep code blocks, bullet lists, and markdown tables as atomic units — never split mid-block. | `Engram.Parsers.Markdown` |
-| **3** | **BM25 hybrid search** | Add sparse vectors (Qdrant native) alongside dense vectors. Reciprocal rank fusion. | `Engram.Search`, `Engram.Vector.Qdrant` |
+| **3** | **BM25 hybrid search** ✅ SHIPPED (#610) | Per-chunk HMAC sparse vectors (Qdrant native) alongside dense vectors. Server-side RRF. `?mode=` dispatch. | `Engram.Search`, `Engram.KeywordIndex.*` |
 | **4** | **Chunk size benchmarking** | Test 256 vs 512 vs 1024 on real data. | `Engram.Parsers.Markdown` |
 | **5** | **Parent-child retrieval** | Small chunks for precision, return parent section for context. | `Engram.Search`, `Engram.Vector.Qdrant` |
 

--- a/docs/context/connections-client-identity.md
+++ b/docs/context/connections-client-identity.md
@@ -20,7 +20,7 @@ Identity now resolves via `LogoAllowlist.resolve(software_id, redirect_uris)` in
 1. Try the `software_id` allowlist first (preserves our own `engram-vault-sync` plugin).
 2. Fall back to matching the **redirect_uri host** against a vendor-host allowlist (`claude.ai` → Claude).
 
-A `slug` field now flows: `Connections.oauth_rows/1` → `ConnectionsController.serialize/1` → `/api/connections` JSON → React checklist (`connectedSlugs.has(slug)` auto-checks the row).
+A `slug` field now flows: `Connections.list_for_user/1` → `ConnectionsController.serialize/1` → `/api/connections` JSON → React checklist (`connectedSlugs.has(slug)` auto-checks the row).
 
 ## Trust model (security-relevant — do not weaken)
 

--- a/docs/context/database-schema-rls.md
+++ b/docs/context/database-schema-rls.md
@@ -1,99 +1,167 @@
 # Context Doc: Database Schema & RLS
 
-_Last verified: 2026-04-03_
+_Last verified: 2026-06-18 (against `priv/repo/structure.sql`)_
 
 ## Status
-Working — design finalized, implementation in progress.
+Live. Schema below is regenerated from `priv/repo/structure.sql`. The RLS / Ecto enforcement model is current.
 
 ## What This Is
-Complete PostgreSQL schema with Row-Level Security policies and the Ecto integration strategy for tenant isolation.
+The PostgreSQL schema (encrypted-at-rest, multi-vault, uuidv7 PKs) with Row-Level Security policies and the Ecto integration strategy for tenant isolation.
 
-## Schema
+## Schema — Key Facts (these differ from older drafts)
+
+- **PKs are `uuid DEFAULT uuidv7()`** — NOT BIGSERIAL/BIGINT. All FKs are `uuid`. (Prod was migrated off integer PKs; see `docs/context/pg18-uuidv7-prod-crashloop-2026-06-11.md`.)
+- **Timestamp column is `created_at`** on most tables (a few OAuth/device tables still use `inserted_at` — noted inline).
+- **Plaintext columns are GONE.** `notes`/`attachments`/`vaults` store `*_ciphertext` + `*_nonce` (AES-GCM) for the value, plus `*_hmac` for the columns that must be searchable/uniquely-indexed (path, folder, tags). There is no `path`/`title`/`content`/`folder`/`tags` plaintext column anywhere. See `docs/context/encryption-operations.md`.
+- **`vaults` table + `vault_id` FK** — a user can have multiple vaults; `notes`/`chunks`/`attachments` are scoped by both `user_id` and `vault_id`.
+- **~28 tables total** (full list below). The four-table sketch in older drafts was fiction.
+
+### Full table list (`priv/repo/structure.sql`)
+
+`api_key_vaults`, `api_keys`, `attachments`, `chunks`, `client_logs`, `client_origin_stats`, `device_authorizations`, `device_refresh_tokens`, `email_suppressions`, `instance_settings`, `invites`, `notes`, `oauth_authorization_codes`, `oauth_clients`, `oauth_refresh_tokens`, `oban_jobs`, `password_reset_tokens`, `plans`, `refresh_tokens`, `storage_objects`, `subscriptions`, `system_canaries`, `terms_versions`, `usage_meters`, `user_agreements`, `user_limit_overrides`, `users`, `vaults`.
+
+### Core tables (verbatim shape from structure.sql)
 
 ```sql
-CREATE TABLE users (
-  id BIGSERIAL PRIMARY KEY,
-  email TEXT UNIQUE NOT NULL,
-  display_name TEXT,
-  inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+-- structure.sql:556
+CREATE TABLE public.users (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    email text NOT NULL,
+    display_name text,
+    created_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL,
+    external_id text,                 -- Clerk user id (SaaS)
+    plan_id uuid,
+    password_hash character varying(255),
+    role character varying(255) DEFAULT 'member' NOT NULL,
+    encrypted_dek bytea,              -- per-user DEK, wrapped by master key / KMS CMK
+    dek_version integer DEFAULT 1 NOT NULL,
+    key_provider character varying(255) DEFAULT 'local' NOT NULL,
+    dek_rotation_locked_at timestamp without time zone,
+    normalized_email text,
+    phone_verified_at timestamp without time zone,
+    deleted_at timestamp without time zone,
+    inactivity_warning_60_at timestamp without time zone,
+    inactivity_warning_80_at timestamp without time zone,
+    suspended_at timestamp with time zone
 );
 
-CREATE TABLE notes (
-  id BIGSERIAL PRIMARY KEY,
-  user_id BIGINT NOT NULL REFERENCES users(id),
-  path TEXT NOT NULL,
-  title TEXT,
-  content TEXT,
-  folder TEXT,
-  tags TEXT[],
-  version INTEGER NOT NULL DEFAULT 1,       -- monotonic, incremented on every upsert (optimistic concurrency)
-  content_hash TEXT,                         -- SHA256 of content, enables skip-if-unchanged during sync
-  mtime DOUBLE PRECISION,
-  deleted_at TIMESTAMPTZ,
-  inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE(user_id, path)
+-- structure.sql:583  (multi-vault — name is encrypted, hmac for lookup)
+CREATE TABLE public.vaults (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    user_id uuid NOT NULL,
+    description text,
+    slug text NOT NULL,
+    client_id text,
+    is_default boolean DEFAULT false NOT NULL,
+    deleted_at timestamp(0) without time zone,
+    created_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL,
+    name_ciphertext bytea NOT NULL,
+    name_nonce bytea NOT NULL,
+    name_hmac bytea NOT NULL,
+    dek_version integer DEFAULT 1 NOT NULL
 );
 
--- Chunk metadata (source of truth for what chunks exist; vectors + raw text live in Qdrant)
-CREATE TABLE chunks (
-  id BIGSERIAL PRIMARY KEY,
-  note_id BIGINT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
-  user_id BIGINT NOT NULL REFERENCES users(id),
-  position SMALLINT NOT NULL,               -- chunk order within note (0-indexed)
-  heading_path TEXT,                         -- e.g., "## Benefits > ### Omega-3"
-  char_start INTEGER NOT NULL,              -- start offset in note content
-  char_end INTEGER NOT NULL,                -- end offset in note content
-  qdrant_point_id UUID NOT NULL,            -- reference to Qdrant vector point
-  inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE(note_id, position)
+-- structure.sql:229  (encrypted at rest; path/folder/tags also HMAC'd for indexing)
+CREATE TABLE public.notes (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    user_id uuid NOT NULL,
+    vault_id uuid NOT NULL,
+    version integer DEFAULT 1 NOT NULL,       -- server-controlled, optimistic concurrency
+    content_hash text,                         -- hash of plaintext, skip-if-unchanged on sync
+    embed_hash text,                           -- content_hash at last successful embed (idempotency)
+    mtime double precision,
+    deleted_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    content_ciphertext bytea NOT NULL, content_nonce bytea NOT NULL,
+    title_ciphertext bytea NOT NULL,   title_nonce bytea NOT NULL,
+    tags_ciphertext bytea NOT NULL,    tags_nonce bytea NOT NULL,
+    path_ciphertext bytea NOT NULL,    path_nonce bytea NOT NULL,    path_hmac bytea NOT NULL,
+    folder_ciphertext bytea NOT NULL,  folder_nonce bytea NOT NULL,  folder_hmac bytea NOT NULL,
+    tags_hmac bytea[] DEFAULT ARRAY[]::bytea[],  -- one HMAC per tag, GIN-indexed
+    dek_version integer DEFAULT 1 NOT NULL
 );
 
-CREATE TABLE attachments (
-  id BIGSERIAL PRIMARY KEY,
-  user_id BIGINT NOT NULL REFERENCES users(id),
-  path TEXT NOT NULL,
-  mime_type TEXT,
-  size_bytes BIGINT,
-  mtime DOUBLE PRECISION,
-  deleted_at TIMESTAMPTZ,
-  inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE(user_id, path)
-  -- content stored in AWS S3 (SaaS) or local filesystem (self-hosted), NOT in DB
+-- structure.sql:99  (chunk metadata; vectors + contextualized text live in Qdrant)
+CREATE TABLE public.chunks (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    note_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    vault_id uuid NOT NULL,
+    "position" smallint NOT NULL,
+    heading_path text,
+    char_start integer NOT NULL,
+    char_end integer NOT NULL,
+    qdrant_point_id uuid NOT NULL,
+    created_at timestamp(0) without time zone NOT NULL
 );
 
-CREATE TABLE api_keys (
-  id BIGSERIAL PRIMARY KEY,
-  user_id BIGINT NOT NULL REFERENCES users(id),
-  key_hash TEXT NOT NULL,  -- SHA256 of raw key, raw never stored
-  name TEXT,
-  last_used TIMESTAMPTZ,
-  inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+-- structure.sql:71  (bytes live in S3/MinIO or storage_objects; path encrypted)
+CREATE TABLE public.attachments (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    user_id uuid NOT NULL,
+    vault_id uuid NOT NULL,
+    mime_type text,
+    size_bytes bigint,
+    mtime double precision,
+    deleted_at timestamp(0) without time zone,
+    created_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL,
+    content_hash text,
+    content_nonce bytea,
+    storage_key character varying(255),         -- S3 object key (or storage_objects.storage_key)
+    path_ciphertext bytea NOT NULL, path_nonce bytea NOT NULL, path_hmac bytea NOT NULL,
+    encryption_version integer DEFAULT 0 NOT NULL,
+    dek_version integer DEFAULT 1 NOT NULL,
+    dek_version_pending integer
 );
+
+-- structure.sql:55
+CREATE TABLE public.api_keys (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    user_id uuid NOT NULL,
+    key_hash text NOT NULL,                     -- hash of raw key, raw never stored
+    name text,
+    last_used timestamp(0) without time zone,
+    created_at timestamp(0) without time zone NOT NULL
+);
+-- api_keys are scoped to vaults via the join table api_key_vaults(api_key_id, vault_id).
 ```
 
-## Indexes
+> The remaining tables (auth/OAuth/device flow, billing — `plans`/`subscriptions`/`usage_meters`/`user_limit_overrides`, legal — `terms_versions`/`user_agreements`, crypto canary — `system_canaries`, ops — `client_logs`/`client_origin_stats`/`email_suppressions`/`instance_settings`/`invites`, `oban_jobs`, `storage_objects`) are defined in `priv/repo/structure.sql`. When in doubt, read structure.sql — it is the generated source of truth.
+
+## Indexes (selected, from structure.sql)
 
 ```sql
-CREATE INDEX idx_notes_user_updated ON notes(user_id, updated_at);    -- changes-since query
-CREATE INDEX idx_notes_user_folder ON notes(user_id, folder);          -- folder listing
-CREATE INDEX idx_notes_user_deleted ON notes(user_id, deleted_at)
-  WHERE deleted_at IS NOT NULL;                                        -- soft-delete cleanup
-CREATE INDEX idx_chunks_note ON chunks(note_id);                       -- chunk lookup by note
-CREATE INDEX idx_api_keys_hash ON api_keys(key_hash);                  -- auth lookup
+-- notes: lookups are HMAC-based (no plaintext path/folder to index)
+CREATE UNIQUE INDEX notes_user_id_vault_id_path_hmac_index               -- structure.sql:1070
+  ON public.notes (user_id, vault_id, path_hmac) WHERE (deleted_at IS NULL);
+CREATE INDEX notes_user_id_vault_id_folder_hmac_index                    -- :1063
+  ON public.notes (user_id, vault_id, folder_hmac);
+CREATE INDEX notes_tags_hmac_index ON public.notes USING gin (tags_hmac); -- :1056
+CREATE INDEX idx_notes_user_updated ON public.notes (user_id, updated_at); -- :1028  changes-since
+CREATE INDEX idx_notes_user_deleted ON public.notes (user_id, deleted_at)  -- :1021
+  WHERE (deleted_at IS NOT NULL);
+CREATE INDEX idx_notes_embed_pending ON public.notes (embed_hash)          -- :1014  embed backlog
+  WHERE ((deleted_at IS NULL) AND ((embed_hash IS NULL) OR (embed_hash <> content_hash)));
+CREATE UNIQUE INDEX chunks_note_id_position_index ON public.chunks (note_id, "position"); -- :881
+CREATE UNIQUE INDEX idx_api_keys_hash ON public.api_keys (key_hash);       -- :972  auth lookup
 ```
 
 ## RLS Policies
 
+Six tables carry `FORCE ROW LEVEL SECURITY` + a `tenant_isolation_*` policy (structure.sql:1618-1690): **`notes`, `chunks`, `attachments`, `api_keys`, `vaults`, `user_agreements`**.
+
 ```sql
 ALTER TABLE notes ENABLE ROW LEVEL SECURITY;
-ALTER TABLE notes FORCE ROW LEVEL SECURITY;
+ALTER TABLE ONLY notes FORCE ROW LEVEL SECURITY;
 CREATE POLICY tenant_isolation_notes ON notes
-  USING (user_id::text = current_setting('app.current_tenant', true))
-  WITH CHECK (user_id::text = current_setting('app.current_tenant', true));
+  USING      ((user_id)::text = (SELECT current_setting('app.current_tenant', true)))
+  WITH CHECK ((user_id)::text = (SELECT current_setting('app.current_tenant', true)));
 
--- Repeat for attachments, api_keys, chunks
+-- Identical tenant_isolation_* policy on chunks, attachments, api_keys, vaults, user_agreements.
 ```
 
 ## DB Roles
@@ -113,21 +181,17 @@ The RLS system has a subtle failure mode: if any code path queries a tenant-scop
 defmodule Engram.Repo do
   use Ecto.Repo, otp_app: :engram
 
-  # Layer 1: Tenant-scoped transaction wrapper
-  def with_tenant(tenant_id, fun) do
-    Process.put(:engram_tenant, tenant_id)
-    try do
-      transaction(fn ->
-        query!("SET LOCAL app.current_tenant = $1", [to_string(tenant_id)])
-        fun.()
-      end)
-    after
-      Process.delete(:engram_tenant)
-    end
-  end
+  # Layer 1: Tenant-scoped transaction wrapper.
+  # tenant_id is a UUID *string* (uuidv7 PKs). Sets both the process-dict guard
+  # (for prepare_query) and the transaction-local app.current_tenant via
+  # set_config(..., true) — the `true` (is_local) scopes it to the txn so it
+  # disappears on commit/rollback (PgBouncer-safe). Nested calls for the same
+  # tenant run fun directly; a nested call for a *different* tenant raises.
+  def with_tenant(tenant_id, fun) when is_binary(tenant_id), do: ...
 
-  # Layer 2: Safety net — raises if tenant-scoped table queried without context
-  @tenant_tables ~w(notes chunks attachments api_keys)a
+  # Layer 2: Safety net — raises if a tenant-scoped table is queried without context.
+  # MUST match the six FORCE-RLS tables above (lib/engram/repo.ex:8).
+  @tenant_tables ~w(notes chunks attachments api_keys vaults user_agreements)a
 
   @impl true
   def prepare_query(_operation, query, opts) do
@@ -140,11 +204,13 @@ defmodule Engram.Repo do
   end
 
   defp tenant_required?(query) do
-    # Check if query targets a tenant-scoped table
-    # Implementation: inspect the Ecto.Query source and match against @tenant_tables
+    # Inspect the Ecto.Query source and match against @tenant_tables
+    # (compares against @tenant_table_strings — repo.ex:135).
   end
 end
 ```
+
+> Implementation note: the real `with_tenant/2` uses PostgreSQL `set_config('app.current_tenant', $1, true)` (transaction-local), not `SET LOCAL` as a separate statement, and the policy reads it back with `(SELECT current_setting(...))`. The conceptual model — process-dict guard + txn-local setting + RLS policy comparison — is exactly as described here.
 
 ## Enforcement Layers
 
@@ -170,30 +236,30 @@ Ecto.Sandbox wraps each test in a transaction that rolls back. `SET LOCAL` insid
 
 ```elixir
 test "tenant isolation via RLS" do
-  user_a = insert(:user)
+  user_a = insert(:user)   # uuidv7 id
   user_b = insert(:user)
 
   {:ok, _} = Repo.with_tenant(user_a.id, fn ->
-    Repo.insert!(%Note{user_id: user_a.id, path: "secret.md", content: "private"})
+    insert(:note, user_id: user_a.id)   # note content is encrypted; build via factory
   end)
 
-  {:ok, notes} = Repo.with_tenant(user_b.id, fn ->
-    Repo.all(Note)
-  end)
+  {:ok, notes} = Repo.with_tenant(user_b.id, fn -> Repo.all(Note) end)
   assert notes == []
 
-  assert_raise Engram.TenantError, fn ->
-    Repo.all(Note)
-  end
+  # No tenant context → prepare_query raises before the query runs.
+  assert_raise Engram.TenantError, fn -> Repo.all(Note) end
 end
 ```
 
 ## Key Design Notes
 
-- **Sync versioning:** `version` is a server-controlled monotonic counter. Plugin sends known version on push; mismatch returns 409 with current state. `content_hash` (SHA256) enables skip-if-unchanged.
+- **Sync versioning:** `version` is a server-controlled monotonic counter. Plugin sends known version on push; mismatch returns 409 with current state. `content_hash` enables skip-if-unchanged; `embed_hash` (= content_hash at last successful embed) gates re-embedding.
 - **Chunk storage (hybrid):** Postgres `chunks` = source of truth for boundaries/positions. Qdrant = vectors + contextualized text. Enables parent-child retrieval.
-- **IDs:** BIGSERIAL for internal FKs only. API uses `path` as identifier. Add `public_id UUID` column if share links needed later.
+- **IDs:** `uuid DEFAULT uuidv7()` everywhere (time-ordered UUIDs — index-friendly, no sequence hotspot). Used both internally and in the API; no separate `public_id` needed.
+- **Encryption at rest:** values are AES-GCM (`*_ciphertext` + `*_nonce`), AAD-bound, under a per-user DEK (`users.encrypted_dek`). Searchable/uniquely-indexed columns (path, folder, tags) carry an additional keyed `*_hmac`. See `docs/context/encryption-operations.md`.
 
 ## References
-- Ecto schemas: `lib/engram/` (notes.ex, chunks.ex, etc.)
+- Generated schema (source of truth): `priv/repo/structure.sql`
+- Repo RLS enforcement: `lib/engram/repo.ex`
+- Ecto schemas: `lib/engram/` (e.g. `notes/note.ex`, `vaults/vault.ex`)
 - Migrations: `priv/repo/migrations/`

--- a/docs/context/deploy-prod.md
+++ b/docs/context/deploy-prod.md
@@ -6,7 +6,7 @@ When to read this: shipping code to `app.engram.page`, rolling back a bad deploy
 
 Two-stage pipeline. Image build lives in this repo; image-tag selection lives in [engram-infra](https://github.com/engram-app/engram-infra). **The live image tag is reconcilable from git** — `var.engram_image_tag` in `engram-infra/main/envs/prod/variables.tf` is the source of truth.
 
-1. **`build-ecr.yml`** (this repo) — runs on every push to `main`. Builds the Docker image and pushes to ECR tagged `sha-<7>`. The image sits in ECR; **nothing rolls.**
+1. **`build-and-publish-image` job in `verify.yml`** (this repo) — runs on every push to `main` (the former standalone `build-ecr.yml`, since folded into `verify.yml`). Builds the Docker image and pushes to ECR tagged `sha-<7>`. The image sits in ECR; **nothing rolls.**
 
 2. **`deploy-prod.yml`** (this repo) — runs only when a `release-v*` git tag is pushed. Opens a PR in engram-infra rewriting `engram_image_tag` default to the `sha-<7>` of the tagged commit, enables auto-merge.
 
@@ -82,7 +82,7 @@ Operator AWS profile is `engram-infra-operator` (read-only — `operator-cheatsh
 
 - **`deploy-prod.yml` step "Rewrite engram_image_tag default" fails** — regex regression. Check `main/envs/prod/variables.tf` shape in engram-infra; the workflow expects exactly one `variable "engram_image_tag"` block with a `default = "..."` line.
 - **Bot PR opens but doesn't auto-merge** — engram-infra CI failing (typically tflint or terraform plan). Open the PR, read the failing check, fix root cause in engram-infra. The bot will reuse the `bot/bump-engram-prod` branch on the next release tag.
-- **`terraform apply` on engram-infra fails on `ResourceNotFoundException`** — `sha-<7>` image isn't in ECR. `build-ecr.yml` for that commit hasn't finished (or never ran). Confirm with `aws ecr describe-images`; rerun build-ecr if needed.
+- **`terraform apply` on engram-infra fails on `ResourceNotFoundException`** — `sha-<7>` image isn't in ECR. The `build-and-publish-image` job in `verify.yml` for that commit hasn't finished (or never ran). Confirm with `aws ecr describe-images`; rerun the `verify.yml` run (or its `build-and-publish-image` job) if needed.
 - **Service crash-loops after deploy** — task running but health checks fail. Check CloudWatch Logs `/ecs/engram-saas-prod`, then forward-roll to the last-known-good `sha-<7>` via a new release tag.
 - **App token mint step 403s** — `engram-infra-tf` App permissions changed. Required: `contents: read & write` + `pull-requests: read & write` on engram-infra. Adjust at https://github.com/organizations/engram-app/settings/apps/engram-infra-tf.
 

--- a/docs/context/dev-iteration-loop.md
+++ b/docs/context/dev-iteration-loop.md
@@ -4,17 +4,18 @@ How to make changes show up in a browser when iterating locally on this VM. Patt
 
 ## TL;DR
 
-- **Phoenix** (`make dev`): serves API + the **prod-built** SPA bundle from `priv/static/app/`. Listens on `:4000`.
+- **Phoenix** (`make dev`): serves API + the **prod-built** SPA bundle from `priv/static/app/`. Listens on `:4000` (localhost only).
 - **Vite** (`make frontend-dev` / `bun run dev` in `backend/frontend`): hot-reload dev server on `:5173`. Proxies `/api` and `/socket` back to Phoenix on `:4000`.
-- The user-facing host **`app.engram.page`** routes to this VM's Phoenix `:4000` via **Cloudflare → FastRaid nginx → Phoenix**. DNS for `app.engram.page` is proxied through Cloudflare; Cloudflare forwards to the FastRaid (10.0.20.214) nginx reverse proxy, which terminates TLS and upstreams to this dev VM on `:4000`. Vite (:5173) is reachable only as `localhost:5173`.
+- This loop is **local-only**. Nothing here ships to a public host. `app.engram.page` is **AWS ECS Fargate PROD** and is reached only by pushing a `release-v*` tag (GitOps); `staging.engram.page` is **FastRaid staging**. A local `bun run build` updates only this machine's `localhost:4000` — it does NOT reach prod or staging. (See `docs/context/deploy-prod.md`.)
 
 | Want                                | Hit                                  | Requires                                    |
 | ----------------------------------- | ------------------------------------ | ------------------------------------------- |
 | Frontend hot-reload while editing   | `http://localhost:5173/`         | `make frontend-dev` running                 |
 | Test prod bundle locally            | `http://localhost:4000/`         | `make dev` running + `bun run build`        |
-| Share with friends / external test  | `https://app.engram.page/`       | `make dev` running + `bun run build`        |
+| Ship to staging                     | `staging.engram.page`            | merge to `main` (auto-deploys FastRaid)     |
+| Ship to prod                        | `app.engram.page`                | push a `release-v*` tag (GitOps → AWS ECS)  |
 
-> **Important:** `app.engram.page` only sees what Phoenix serves. To make changes visible there during dev, you must run `bun run build` inside `backend/frontend/` so Phoenix has the new static bundle to ship.
+> **Important:** the `:4000` page on this machine only sees what Phoenix serves locally. To make a UI change visible at `localhost:4000`, run `bun run build` inside `backend/frontend/` so Phoenix has the new static bundle to ship. This has no effect on staging/prod.
 
 ## The white-page gotcha (and the fix)
 
@@ -32,7 +33,7 @@ How to make changes show up in a browser when iterating locally on this VM. Patt
 
 **Fix:** `config/dev.exs` sets `:spa_cache_enabled?` to `false`. SpaController checks this flag and skips the persistent_term in dev/test, rebuilding the split on every request. `index.html` is ~1KB so the cost is negligible. Prod keeps the cache (one read per BEAM lifetime).
 
-If you ever see a white page on `:4000` or `app.engram.page` after a rebuild and the controller cache is somehow re-enabled, the recovery is `make dev-stop && make dev`.
+If you ever see a white page on `localhost:4000` after a rebuild and the controller cache is somehow re-enabled, the recovery is `make dev-stop && make dev`. (The same caching mechanism exists in prod, but prod gets a fresh BEAM per deploy, so a stale-cache white page can't survive a deploy.)
 
 ## When to rebuild / restart
 
@@ -41,7 +42,7 @@ If you ever see a white page on `:4000` or `app.engram.page` after a rebuild and
 | Edit `.ex` file                                 | Phoenix code-reloads automatically (Bandit + `Code.reload!`)  |
 | Edit `config/dev.exs`                           | Restart Phoenix (`make dev-stop && make dev`)                 |
 | Edit `.tsx`/`.ts`/`.css` and viewing on `:5173` | Vite hot-reloads automatically                                |
-| Edit `.tsx`/`.ts`/`.css` and viewing on `:4000` or `app.engram.page` | `bun run build` in `backend/frontend/`. No Phoenix restart needed (cache disabled in dev). |
+| Edit `.tsx`/`.ts`/`.css` and viewing on `localhost:4000` | `bun run build` in `backend/frontend/`. No Phoenix restart needed (cache disabled in dev). |
 
 ## Background-process recipe
 
@@ -61,17 +62,16 @@ make frontend-dev                                         # Vite :5173 (separate
 > `make dev-stop` also kills any stray listeners on :5173–:5199 as a
 > safety net.
 
-Steer the user to `:5173` for fast feedback. If they're on `app.engram.page`, every UI change requires `bun run build` first. If the page goes white after a rebuild, suspect SPA cache (verify with the curl/grep above) before suspecting JS errors.
+Steer the user to `:5173` for fast feedback. If they're on `localhost:4000`, every UI change requires `bun run build` first. If the page goes white after a rebuild, suspect SPA cache (verify with the curl/grep above) before suspecting JS errors.
 
-## Hosting path
+## Hosting path (where each host actually lives)
 
-`app.engram.page` is the alpha-test public host. Request flow:
+This local dev loop does **not** front any public host. The public hosts are deployed infrastructure, not this VM:
 
-1. Browser → `https://app.engram.page` (Cloudflare DNS, proxied/orange-cloud).
-2. Cloudflare → FastRaid (`10.0.20.214`) over Cloudflare tunnel.
-3. FastRaid nginx terminates TLS and reverse-proxies to this dev VM (Claw) on `:4000`.
-4. Phoenix serves the API + prod-built SPA from `priv/static/app/`.
+- **`app.engram.page`** → **AWS ECS Fargate PROD** (RDS + S3). Updated only by GitOps: push a `release-v*` tag → engram-infra Terraform reconciles the ECS image tag → service rolls. See `docs/context/deploy-prod.md`.
+- **`staging.engram.page`** → **FastRaid staging** (`10.0.20.214`). Auto-deployed on merge to `main`.
+- **`engram.page`** (apex) → the marketing site, unrelated to the app.
 
-Because step 4 is **this** machine running `make dev`, every UI change still needs `bun run build` to be visible to external testers — same as hitting `localhost:4000` here. Pure-backend changes don't need a rebuild (Phoenix code-reloads on file save).
+A local `bun run build` only updates this machine's `localhost:4000`; it never reaches prod or staging. To get a change in front of external testers, ship it to staging (merge) or prod (release tag). Pure-backend changes still code-reload locally on file save (Bandit + `Code.reload!`).
 
-The marketing site at `engram.page` (apex) is unrelated and points elsewhere — only the `app.` subdomain proxies to this dev VM.
+> **Historical note:** an earlier alpha setup did proxy `app.engram.page` → Cloudflare → FastRaid → this dev VM:4000. That topology is dead — `app.engram.page` is AWS prod now. Do not assume a `bun run build` here is visible at any public host.

--- a/docs/context/e2e-vault-registration-diagnostics.md
+++ b/docs/context/e2e-vault-registration-diagnostics.md
@@ -18,7 +18,7 @@ TimeoutError: Vault not registered after 15s on CDP port <N>
 | `api.registerVault` status | Meaning | Where to look |
 |---|---|---|
 | **401 Unauthorized** | API key was invalidated mid-suite. Backend `api_keys` table cascades from `users`, so a deleted Clerk user kills its API key. | `e2e/conftest.py:auth_provider`. The nuclear `cleanup_all_e2e_clerk_users()` deletes *every* user with email prefix `e2e-*` without run-id namespacing → two races: worker-vs-worker within one run, AND run-vs-run across concurrent CI. Tracking: [issue #160]. **Do not "fix" this by moving the sweep into a CI pre-step** — that just trades one race for a wider one; see issue for real fix options (per-run namespace, scheduled orphan reaper). |
-| **402 Payment Required** | User hit `max_vaults` (default 1, see `lib/engram/billing.ex:16`). Something created a second vault for this user. | Check `api.listVaults` output — if `length > 1`, find the test that called `api.create_vault` or `api.register_vault` with a *different* `client_id`. Same `client_id` is idempotent and won't trip the limit. |
+| **402 Payment Required** | User hit `vaults_cap` (default 1, see `lib/engram/billing/limit_keys.ex:17`). Something created a second vault for this user. | Check `api.listVaults` output — if `length > 1`, find the test that called `api.create_vault` or `api.register_vault` with a *different* `client_id`. Same `client_id` is idempotent and won't trip the limit. |
 | **5xx Server Error** | Backend hiccup. Read the response body in pytest log; check `docker logs engram --tail 100` on the CI runner. | Usually transient; reruns mask it. If consistent, it's a real backend bug. |
 | Network error (no status) | Backend unreachable. | Compose stack didn't fully boot — see the `wait_for_engram_ready` step in `docker-compose.ci.yml`. |
 | `find_by_client_id` returns nil + `register_vault` returns OK | Plugin's `clientId` doesn't match what conftest's `api_sync.register_vault` used. | `e2e/helpers/obsidian.py:135-136` writes `clientId` into `data.json`; verify it matches `sync_client_id` from `conftest.py`. |
@@ -43,7 +43,7 @@ Only one production code path nulls it: `channel.onVaultDeleted` at `src/main.ts
 - `src/main.ts:677-685` — `onVaultDeleted` handler (only place that nulls `vaultId`).
 - `src/api.ts:132-138` — raw `EngramApi.registerVault` that throws with `.status`.
 - `lib/engram/vaults.ex:70-113` — backend `register_vault` (idempotent by `client_id`).
-- `lib/engram/billing.ex:16` — `max_vaults` default.
+- `lib/engram/billing/limit_keys.ex:17` — `vaults_cap` default.
 
 ## Test harness references
 

--- a/docs/context/elixir-architecture-decisions.md
+++ b/docs/context/elixir-architecture-decisions.md
@@ -1,12 +1,24 @@
 # Context Doc: Elixir Architecture Decisions
 
-_Last verified: 2026-04-03_
+_Original audit: 2026-04-02. Reconciled with shipped reality: 2026-06-18._
 
-## Status
-Working — these decisions are finalized and guide all implementation.
+> **PARTIALLY SUPERSEDED — read the inline corrections.**
+> This is the original (2026-04-02) decision-log. Several early-launch choices
+> changed once the product shipped. The **language/OTP/RLS/PubSub/Oban/Qdrant**
+> core decisions still hold. The **deployment, hosting, ID, MCP, Redis, email,
+> and billing** rows below were since reversed — each carries an inline
+> **UPDATE** note, and the Fly-based "Infrastructure Setup" runbook at the
+> bottom is dead (see `docs/context/deploy-prod.md` for the live AWS GitOps
+> deploy). Do NOT run any `fly` command against prod.
+>
+> **Shipped reality (2026-06-18):** PROD = AWS ECS Fargate + RDS + S3,
+> deployed via `release-v*` tag → engram-infra Terraform reconcile (GitOps).
+> FastRaid = staging. PKs are `uuid` (uuidv7). MCP is hand-rolled (no external
+> MCP dep). Redix is not a dependency. Email = Resend (shipped). Billing =
+> Paddle (shipped).
 
 ## What This Is
-Complete decision audit for the Engram Elixir/Phoenix architecture. Captures what was chosen, what was rejected, and why.
+Complete decision audit for the Engram Elixir/Phoenix architecture. Captures what was chosen, what was rejected, and why — with inline UPDATE notes where the shipped product diverged from the original call.
 
 ## Decision Audit (2026-04-02)
 
@@ -16,31 +28,31 @@ Complete decision audit for the Engram Elixir/Phoenix architecture. Captures wha
 | **Real-time** | **Phoenix Channels (WebSocket)** | Bidirectional, built-in presence tracking, cluster-native PubSub, no reconnect hacks |
 | **Multi-tenancy** | **PostgreSQL RLS + tenant_id** | DB-enforced isolation via `SET LOCAL` per transaction, fail-closed (no tenant = no rows), defense-in-depth |
 | **DB roles** | **Two roles** | `engram_owner` (migrations, bypasses RLS) + `engram_app` (runtime, subject to RLS) |
-| **Clustering** | **dns_cluster** | Auto node discovery via Fly's `.internal` DNS, enables distributed PubSub |
+| **Clustering** | **dns_cluster** | Auto node discovery via DNS, enables distributed PubSub. _UPDATE: prod runs on AWS ECS Fargate, not Fly — discovery is via the platform's service DNS, not Fly `.internal`._ |
 | **PubSub** | **Phoenix.PubSub.PG2** | Native Erlang distribution, cross-region broadcast, no Redis needed |
 | **Caching** | **ETS** (Erlang Term Storage) | In-process, clustered via PubSub if needed, eliminates Redis dependency |
 | **Rate limiting** | **Hammer** | Token bucket, ETS or Redis backend, Plug integration |
 | **Auth: JWT** | **Joken** | Lightweight, Plug-native |
 | **Auth: API keys** | **SHA256 hash + ETS cache** | Same security model, fast in-process caching |
-| **S3 client** | **ExAws + ExAws.S3** | Battle-tested, Tigris-compatible, official Fly docs |
+| **S3 client** | **ExAws + ExAws.S3** | Battle-tested, S3-compatible. _UPDATE: attachments live in AWS S3 (not Fly Tigris)._ |
 | **Qdrant client** | **Custom Req HTTP wrapper** (~150 LOC) | No official Elixir SDK; REST API is simple, thin wrapper sufficient |
 | **Embeddings** | **Req HTTP wrapper** (~30 LOC) | Same Voyage AI REST API, just different HTTP client |
 | **Markdown parsing** | **Earmark AST + custom walker** | Earmark provides full AST, chunking logic reimplemented (~150 LOC) |
-| **MCP server** | **Hermes MCP** (Elixir) | Young but functional, working production examples exist |
+| **MCP server** | **Hand-rolled** (Elixir) | _UPDATE: Hermes MCP was NOT adopted — the MCP server is hand-rolled (`lib/engram/mcp/`), no external MCP dependency in mix.exs. The "MCP fallback" row below (raw JSON-RPC) is effectively what shipped._ |
 | **Job queue** | **Oban** (PostgreSQL-backed) | Durable jobs survive crashes/deploys, built-in retry/backoff/dedup/rate-limiting, no new infra (uses existing Postgres) |
 | **Testing** | **ExUnit + ExMachina + Mox + Bypass** | `async: true` parallel tests, Ecto.Sandbox per-test transactions |
-| **Deployment** | **`fly launch`** (auto-detects Phoenix) | Generates Dockerfile, fly.toml, clustering config automatically |
+| **Deployment** | ~~`fly launch`~~ → **AWS ECS Fargate (GitOps)** | _UPDATE: Fly was dropped. Prod deploys by pushing a `release-v*` git tag, which opens a PR in engram-infra rewriting the ECS image tag; engram-infra's Terraform applies it and rolls the service. No fly.toml, no `fly` commands. See `docs/context/deploy-prod.md`._ |
 | **Observability** | **PromEx + Sentry** | PromEx auto-instruments Phoenix/Ecto/Oban/BEAM metrics; Sentry captures errors with stack traces. Both free tier. |
-| **Backups** | **Fly volume snapshots** (daily, free) | Sufficient for launch. WAL-based PITR when revenue justifies. Qdrant data is reconstructable from Postgres. |
+| **Backups** | **RDS snapshots** (daily) + S3 versioning | _UPDATE: prod runs on AWS RDS, so backups are RDS automated snapshots (7d) + S3 versioning, not Fly volume snapshots. Qdrant data is reconstructable from Postgres. See `docs/context/disaster-recovery.md`._ |
 | **RLS enforcement** | **Layered defense** | Process-dict guard in `Repo.prepare_query` raises on unscoped tenant queries. Safe with PgBouncer transaction mode + Ecto.Sandbox. |
-| **IDs** | **BIGSERIAL internal only** | API uses `path` as identifier. Numeric IDs never in responses. Add `public_id UUID` column if share links needed later. |
+| **IDs** | **`uuid` (uuidv7) PKs** | _UPDATE: BIGSERIAL was reversed — primary keys are `uuid` generated by `uuidv7()` (time-ordered). Note URLs are now id-addressable. The earlier "BIGSERIAL internal only / path as identifier" plan is dead._ |
 | **App structure** | **Single OTP app** | No umbrella. Single app is simpler at this scale. Split indexing into separate app only if deployment topology requires it. |
 | **Supervision** | **one_for_one** | Independent worker processes. Channel crashes don't affect Oban, Oban crashes don't affect Channels. |
 | **Self-hosted embedding** | **Ollama only** | voyage-4-nano requires Voyage API key, contradicts "free, user's own infra." Ollama is truly local. |
-| **MCP fallback** | Hermes MCP (primary) | If Hermes abandoned: raw JSON-RPC stdio server (~200 LOC). MCP protocol is simple. Monitor Hermes activity quarterly. |
+| **MCP fallback** | _N/A — fallback became the implementation_ | The "raw JSON-RPC server" fallback is what shipped; Hermes MCP was never adopted. |
 | **Tokenizer for chunking** | Approximate word-based (~4 chars/token) | Voyage handles actual tokenization. 512 "tokens" is a soft target. |
-| **Email** | None for launch | API key auth doesn't need email verification. Add Swoosh for password reset when there are paying users. |
-| **Billing** | None for launch (future Phase 10) | Paddle (Merchant-of-Record) integration after core product works — Paddle handles VAT/sales tax globally, simplifying international SaaS pricing. Quota enforcement designed separately. |
+| **Email** | **Resend** (shipped) | _UPDATE: "none for launch" reversed — transactional email ships via Resend, gated on `RESEND_API_KEY` (see `config/runtime.exs`). Inbound bounce/complaint webhook at `POST /webhooks/resend`._ |
+| **Billing** | **Paddle (shipped, Phase 10)** | Paddle (Merchant-of-Record) handles VAT/sales tax globally. _UPDATE: shipped — webhook receiver, billing config endpoint, subscriptions, RequireOnboarding gate all live._ |
 | **Load testing** | Deferred to Phase 9 (Deploy) | Key questions: WebSocket connections/machine, embedding throughput, Voyage rate ceiling impact on bulk operations. |
 
 ## Unchanged Decisions
@@ -49,9 +61,9 @@ Complete decision audit for the Engram Elixir/Phoenix architecture. Captures wha
 |------|----------|---------|
 | **Embedding provider** | Voyage AI `voyage-4-large` (1024d, $0.06/M tokens) | Top MTEB, shared space with nano, matryoshka support |
 | **Vector DB** | Qdrant Cloud (free tier 1GB) | Same provider, REST API access |
-| **Compute** | Fly.io | First-class Phoenix support |
-| **Database** | Fly Postgres | With RLS policies |
-| **Attachments** | Fly Tigris (S3) | ExAws client |
+| **Compute** | ~~Fly.io~~ → **AWS ECS Fargate** | _UPDATE: prod runs on AWS ECS Fargate (FastRaid = staging)._ |
+| **Database** | ~~Fly Postgres~~ → **AWS RDS** | With RLS policies. Postgres pinned `18.4`. |
+| **Attachments** | ~~Fly Tigris~~ → **AWS S3** | ExAws client |
 | **No reranker** | Vector-only search to start | Will benchmark Voyage Rerank 2.5 vs Jina later |
 | **Dimensions** | 1024d (Voyage default) | Benchmark 512d later via matryoshka |
 
@@ -59,49 +71,39 @@ Complete decision audit for the Engram Elixir/Phoenix architecture. Captures wha
 
 | Library | Version | Purpose | Maturity |
 |---------|---------|---------|----------|
-| **Phoenix** | 1.8+ | Web framework, Channels, PubSub | Production |
-| **Ecto** | 3.12+ | Database layer, migrations, schemas | Production |
-| **Oban** | 2.18+ | PostgreSQL-backed job queue | Production |
-| **Joken** | 2.6+ | JWT sign/verify | Production |
-| **ExAws** + **ExAws.S3** | 2.6+ | S3 client for Tigris | Production |
-| **Hammer** | 6.1+ | Rate limiting (token bucket) | Production |
-| **Redix** | 1.2+ | Redis client (optional) | Production |
-| **Earmark** | 1.4+ | Markdown → AST parsing | Production |
-| **Req** | 0.5+ | HTTP client (Qdrant, Voyage AI) | Production |
-| **Hermes MCP** | latest | MCP server protocol | Early |
-| **PromEx** | 1.9+ | Prometheus metrics (Phoenix, Ecto, Oban, BEAM) | Production |
-| **Sentry** | 10.0+ | Error tracking | Production |
-| **dns_cluster** | 0.1+ | Fly.io node discovery | Production |
-| **ExMachina** | dev | Test factories | Production |
-| **Mox** | dev | Behaviour-based mocks | Production |
-| **Bypass** | dev | HTTP mock server | Production |
+| **Phoenix** | ~> 1.8.5 | Web framework, Channels, PubSub | Production |
+| **ecto_sql** | ~> 3.13 | Database layer, migrations, schemas | Production |
+| **Oban** | ~> 2.18 | PostgreSQL-backed job queue | Production |
+| **Joken** (+ joken_jwks) | ~> 2.6 | JWT sign/verify (Clerk JWKS) | Production |
+| **ExAws** + **ExAws.S3** + **ExAws.KMS** | ~> 2.5 / 2.4 | S3 client (AWS S3) + KMS | Production |
+| **Hammer** (+ hammer_backend_redis) | ~> 7.3 / 7.0 | Rate limiting (ETS default; Redis backend for clustered prod) | Production |
+| **Earmark** | ~> 1.4 | Markdown → AST parsing | Production |
+| **Req** | ~> 0.5 | HTTP client (Qdrant, Voyage AI) | Production |
+| _MCP server_ | (hand-rolled) | No external MCP dep — `lib/engram/mcp/` | — |
+| **PromEx** | ~> 1.11 | Prometheus metrics (Phoenix, Ecto, Oban, BEAM) | Production |
+| **Sentry** | ~> 10.0 | Error tracking | Production |
+| **dns_cluster** | ~> 0.2.0 | Node discovery via DNS | Production |
+| **ExMachina** | ~> 2.8 (test) | Test factories | Production |
+| **Mox** | ~> 1.1 (test) | Behaviour-based mocks | Production |
+| **Bypass** | ~> 2.1 (test) | HTTP mock server | Production |
+
+_Note: **Redix** is NOT a direct dependency. The only Redis touchpoint is `hammer_backend_redis`, used solely as the shared rate-limit store in clustered SaaS prod; self-host stays Redis-free (ETS backend)._
 
 ## Development Environment
 
-**Local dev on FastRaid (Docker):**
-- Elixir app runs in Docker container on FastRaid
-- Connects to **real** Voyage AI API (not mocked)
-- Connects to **real** Qdrant Cloud (not local)
-- Connects to **real** Tigris (not local S3)
-- PostgreSQL in Docker (local, with RLS policies)
-- This ensures adapters are validated against real services from day 1
-
-**Why Docker on FastRaid:** FastRaid is the dev VM with GPU (for Ollama self-hosted testing). Docker provides consistent Elixir environment without installing Elixir system-wide.
+Local dev uses Docker Compose (`docker compose up --build` from the repo root: Elixir + PostgreSQL + Qdrant + Ollama + MinIO). See `docs/context/dev-iteration-loop.md` for the day-to-day loop. The original FastRaid-Docker-against-real-cloud-adapters model is no longer the dev default; FastRaid now runs the **staging** environment, not local dev.
 
 ## Infrastructure Setup
 
-| # | Action | Command / Steps | Status |
-|---|--------|-----------------|--------|
-| 1 | Create Fly app | `fly launch --name engram` (auto-detects Phoenix) | Done |
-| 2 | Create Fly Postgres | `fly postgres create --name engram-db` | TODO |
-| 3 | Attach Postgres | `fly postgres attach --app engram engram-db` | TODO |
-| 4 | Create Tigris bucket | `fly storage create --name engram-attachments` | TODO |
-| 5 | Qdrant Cloud cluster | Create at qdrant.tech (free tier, 1GB RAM) | TODO |
-| 6 | Voyage AI API key | Get at voyageai.com | TODO |
-| 7 | Set secrets | `fly secrets set VOYAGE_API_KEY=... QDRANT_URL=... QDRANT_API_KEY=... JWT_SECRET=... RELEASE_COOKIE=...` | TODO |
-| 8 | Deploy | `fly deploy` | TODO |
-| 9 | Verify | `curl https://engram.fly.dev/health/deep` | TODO |
+> **DEAD — historical only.** This Fly.io bring-up runbook never went to prod.
+> Prod runs on **AWS ECS Fargate + RDS + S3**, deployed via GitOps (push a
+> `release-v*` tag → engram-infra Terraform reconciles the ECS image tag).
+> Secrets are SOPS-encrypted → SSM → ECS task env (`APP_SECRETS_JSON` blob),
+> NOT `fly secrets set`. For the live deploy procedure see
+> `docs/context/deploy-prod.md`. Do NOT run any `fly` command — there is no
+> Fly app and no `engram.fly.dev`.
 
 ## References
 - Build phases: see CLAUDE.md
-- Pricing: see `docs/context/pricing-strategy.md`
+- Live prod deploy: `docs/context/deploy-prod.md`
+- Pricing: see `../engram-workspace/docs/context/pricing-strategy.md` (workspace repo, relative to the engram repo root)

--- a/docs/context/encryption-operations.md
+++ b/docs/context/encryption-operations.md
@@ -1,17 +1,14 @@
 # Context Doc: Encryption-at-Rest Operations
 
-_Last verified: 2026-05-05 (post-B.3)_
+_Last verified: 2026-06-18 (post-B.4)_
 
-> **⚠ Most of this runbook is historical.** Phase B.3 (PR #71, 0.5.28) retired the vault decrypt path entirely — the `POST/DELETE /api/vaults/:id/decrypt` endpoints, `Engram.Workers.DecryptVault`, and the `Engram.Crypto.request_decrypt_vault/2` / `cancel_decrypt_vault/2` API are all deleted. Encryption is one-way; per-note read decryption happens transparently. The toggle/cooldown sections below describe the pre-B.3 world and are kept for historical context only.
+> **⚠ The toggle/cooldown half of this runbook is historical — the feature is GONE.** Phase B.3 (PR #71, 0.5.28) retired the vault decrypt path, and B.4 (PR #72, 0.5.29) retired the encrypt toggle entirely. **As of today (verified against `lib/`):** there are NO `/api/vaults/:id/encrypt`, `/decrypt`, or `/encryption_progress` routes; no `EncryptVault`/`DecryptVault` workers; no `users.encryption_toggle_cooldown_days` column; no `mix engram.set_cooldown` task; and no `encryption_status` / `last_toggle_at` vault fields. Encryption is unconditional and one-way; per-note read decryption happens transparently. The "Per-User Toggle Cooldown", "Toggle Flow & State Machine", and the related triage recipes below describe the **pre-B.4 world** and are kept only for archaeological context — do not act on them.
 >
-> **Current operator surface (post-B.3):**
-> - Every saas vault is encrypted at rest. Path/folder/tags/name plaintext columns dropped on saas in B.3.
-> - `POST /api/vaults/:id/encrypt` still exists — it converts a non-encrypted vault to encrypted (one-way). New vaults default to non-encrypted; this is closing in B.4.
-> - `GET /api/vaults/:id/encryption_progress` still works for monitoring an in-flight encrypt job.
-> - Decrypt routes return 404 (route removed in B.3, no replacement).
+> **Current operator surface (post-B.4):**
+> - Every vault is encrypted at rest by default at create time. There is no per-vault toggle, no cooldown, no in-flight encrypt job to monitor.
+> - Path/folder/tags/name + `notes.content`/`title` plaintext columns were dropped (B.3/B.4).
 > - To check vault state, query Postgres directly or use the engram MCP `list_vaults`.
->
-> **Forward plan shipped:** B.4 (PR #72, 2026-05-06) retired the `vault.encrypted` flag, dropped `notes.content`/`title` plaintext columns, and removed the encrypt toggle entirely. Every vault encrypted by default at create time.
+> - The live operator runbooks that still apply are the **Tier-3 sections** further down: master-key rotation (T3.5), master-key backup, and per-user DEK rotation (T3.7).
 
 ## Status (historical — pre-B.3)
 
@@ -53,9 +50,11 @@ The toggle described in this runbook governs **notes only**. Attachments encrypt
 ## What This Is
 Operator runbook for encryption toggling, per-user cooldown, and incident triage. Companion to the architecture spec at `docs/superpowers/specs/2026-04-07-encryption-at-rest-design.md`.
 
-## Per-User Toggle Cooldown
+## Per-User Toggle Cooldown (HISTORICAL — removed in B.4; does not exist today)
 
-Users can encrypt/decrypt their vaults via the plugin (`POST /api/vaults/:id/encrypt`, `POST /api/vaults/:id/decrypt`). To prevent abusive flapping, each user has an independent `users.encryption_toggle_cooldown_days INTEGER NULL` column.
+> This entire section describes a feature that no longer exists. The endpoints, the `users.encryption_toggle_cooldown_days` column, and the `mix engram.set_cooldown` task were all removed when the encrypt/decrypt toggle was retired (B.3/B.4). Retained for context only.
+
+Users could encrypt/decrypt their vaults via the plugin (`POST /api/vaults/:id/encrypt`, `POST /api/vaults/:id/decrypt`). To prevent abusive flapping, each user had an independent `users.encryption_toggle_cooldown_days INTEGER NULL` column.
 
 | Value | Behavior |
 |-------|----------|
@@ -68,12 +67,10 @@ The plugin reads the effective `cooldown_days` from the vault JSON (`/api/vaults
 ### Setting the cooldown
 
 ```bash
-# In a release shell on the FastRaid container
-docker exec -it engram bin/engram remote
-iex> Engram.Accounts.set_encryption_toggle_cooldown_days(Engram.Accounts.get_user!(<id>), 7)
-
-# OR from a dev shell with .env.elixir loaded
-mix engram.set_cooldown <user_id> <days|null>
+# HISTORICAL — neither of these works today. The function and the Mix
+# task were removed with the toggle feature (B.4).
+# iex> Engram.Accounts.set_encryption_toggle_cooldown_days(user, 7)
+# mix engram.set_cooldown <user_id> <days|null>
 ```
 
 The Mix task accepts `null`, `none`, or `NULL` to clear the column. Negative values are rejected at the function-clause level — there is no `0`-vs-`NULL` distinction at the Crypto layer (both bypass the cooldown predicate).
@@ -253,7 +250,7 @@ If you discover post-step-5 that the new key is wrong (lost, corrupted, mistyped
 
 _Added 2026-05-08 with PR #78 (T3.5)._
 
-> **Selfhost reality check:** today, we have one paying environment (selfhost on FastRaid) and zero managed-key-by-customer instances. The "named owners" convention below applies primarily to the saas instance; selfhost users carry their own backup obligation, which is captured in product-level UX (out of scope here).
+> **Environment reality check (updated 2026-06-18):** prod is **AWS ECS Fargate** (`app.engram.page`); FastRaid runs **staging** (`staging.engram.page`), NOT prod. The master key on prod lives in **AWS SSM Parameter Store (SecureString, SOPS-managed via engram-infra TF)** — not a FastRaid container env. The "named owners" convention below applies to the saas instance; selfhost users carry their own backup obligation, captured in product-level UX (out of scope here).
 
 ### What to back up
 
@@ -268,7 +265,7 @@ Sources of truth:
 
 **Tier-3 launch baseline (today):**
 
-1. **Primary:** the value lives in the FastRaid Unraid template's runtime ENV. SSH access required. Owner: open-claw.
+1. **Primary:** prod's authoritative copy lives in **AWS SSM Parameter Store** (SecureString), sourced from the SOPS-encrypted secrets file in engram-infra TF. (Staging on FastRaid keeps its own separate key in its Unraid template ENV.) Owner: open-claw.
 2. **Secondary:** sealed printout in a physical safe at owner's residence. Owner: open-claw.
 3. **Off-site copy:** encrypted, stored in 1Password personal vault. Owner: open-claw.
 
@@ -337,10 +334,13 @@ Local / staging (Mix task — operator gets exit code, blocks until done):
 
     mix engram.rotate_user_dek --user-id <ID>
 
-Production (release rpc — synchronous, fits short rotations < 1 min):
+Production (release rpc — synchronous, fits short rotations < 1 min). Prod is AWS ECS Fargate, so shell in via ECS Exec rather than `docker exec`:
 
-    docker exec engram-saas /app/bin/engram rpc \
-      "Engram.Crypto.UserDekRotation.rotate_user(<ID>)"
+    aws ecs execute-command --cluster <cluster> --task <task-id> \
+      --container engram --interactive \
+      --command "/app/bin/engram rpc 'Engram.Crypto.UserDekRotation.rotate_user(<ID>)'"
+
+    # (Staging on FastRaid: docker exec engram /app/bin/engram rpc "...")
 
 Production (Oban worker — preferred for long rotations that must survive node restarts):
 

--- a/docs/context/environment-variables.md
+++ b/docs/context/environment-variables.md
@@ -1,92 +1,200 @@
 # Context Doc: Environment Variables
 
-_Last verified: 2026-04-03_
+_Last verified: 2026-06-18 (regenerated from `config/runtime.exs`)_
 
 ## Status
-Working — all variables defined, some only used once infrastructure is set up.
+Live. This is regenerated from `config/runtime.exs` (the ~90 vars it reads), with compile-time defaults pulled from `config/config.exs`, `config/dev.exs`, `config/test.exs`. Line numbers cite `config/runtime.exs` unless noted.
 
-## What This Is
-Complete list of environment variables for the Engram Elixir/Phoenix application.
+## How runtime.exs is shaped (read this first)
 
-## Core
+- **`APP_SECRETS_JSON`** (runtime.exs:9-12) — prod ships ALL app secrets as one SSM SecureString blob (one KMS decrypt). `Engram.Secrets.unpack/2` expands it into the process env *before* every `System.get_env` below, so the individual var names still resolve. Self-host/dev leave it unset (no-op). Malformed JSON fails boot loudly. See `docs/context/kms-secret-consolidation` work.
+- **Auth shape switch:** `AUTH_PROVIDER` (default `local`, runtime.exs:174) selects self-host (built-in email/password) vs SaaS (`clerk`). Many vars below are required *only* when `clerk`.
+- **Billing gate:** `billing_enabled` is derived — `auth_provider == :clerk and PADDLE_API_KEY != nil` (runtime.exs:403-405). Self-host (or SaaS without a Paddle key) short-circuits the onboarding wizard.
+- **Test guard:** blocks gated on `config_env() != :test` (storage, embedder, email, Paddle, key provider) so a developer's exported shell vars can't flip `mix test` onto real adapters.
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `DATABASE_URL` | — | PostgreSQL connection string (injected from platform secrets; AWS RDS in prod) |
-| `SECRET_KEY_BASE` | — | Phoenix secret (generate with `mix phx.gen.secret`; injected from secrets in prod) |
-| `PHX_HOST` | `localhost` | Phoenix host for URL generation |
-| `PORT` | `4000` | HTTP listen port (container port; the load balancer terminates TLS in front) |
-| `DNS_CLUSTER_QUERY` | — | libcluster DNS query for BEAM node discovery |
-| `RELEASE_COOKIE` | — | Erlang distribution cookie (pin as a secret) |
-| `QDRANT_URL` | `http://localhost:6333` | Vector database (Qdrant Cloud URL for SaaS) |
-| `QDRANT_API_KEY` | — | Qdrant Cloud API key (not needed for local) |
-| `QDRANT_COLLECTION` | `obsidian_notes` | Qdrant collection name |
+---
 
-## Embedding
+## Core / Endpoint
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `EMBED_BACKEND` | `ollama` | `voyage` (SaaS) or `ollama` (self-hosted) |
-| `EMBED_MODEL` | `nomic-embed-text` | Embedding model name (`voyage-4-large` for SaaS) |
-| `EMBED_DIMS` | `768` | Vector dimensions (1024 for Voyage, 768 for nomic) |
-| `VOYAGE_API_KEY` | — | Voyage AI API key (required when `EMBED_BACKEND=voyage`) |
-| `OLLAMA_URL` | `http://localhost:11434` | Ollama server (self-hosted only) |
+| `APP_SECRETS_JSON` | unset | Prod-only bundled-secrets blob, unpacked into env at boot (runtime.exs:9). |
+| `PHX_SERVER` | unset | Start the Phoenix server in a release (`bin/engram start`) (:30). |
+| `PORT` | `4000` | HTTP listen port (:35). |
+| `PHX_HOST` | unset (`localhost` for URLs in dev) | Canonical host(s) for URL gen + CORS/WS origin. **Comma-separated; first entry is canonical** (:508). When unset, CORS allows `*` and WS allows all (fine for self-host; a SaaS deploy fails closed if `PHX_HOST` is missing — :653). |
+| `PHX_SCHEME` | `https` prod / `http` dev | URL scheme (:511). |
+| `PHX_PORT` | `443` prod / `80` dev | URL port for generated links (:515). |
+| `DATABASE_URL` | — (required in prod, :558) | `ecto://USER:PASS@HOST/DATABASE`. |
+| `POOL_SIZE` | `10` | Ecto pool size (:582). |
+| `ECTO_IPV6` | unset | `true`/`1` → connect to Postgres over IPv6 (:564). |
+| `DATABASE_SSL` | off | `true` enables TLS to Postgres (required by AWS RDS) (:575, via `RuntimeConfig.database_ssl/2`). |
+| `DATABASE_SSL_MODE` | `verify_none` | `verify-full` → `verify_peer` w/ OS trust store + SNI + hostname check (:570). |
+| `SECRET_KEY_BASE` | — (required in prod, :597) | Phoenix cookie/secret signing. |
+| `JWT_SECRET` | — (required in prod, :604) | Joken default signer for internal JWTs (:610). |
+| `DNS_CLUSTER_QUERY` | unset | libcluster DNS query for BEAM node discovery (:612). |
+| `REDIS_URL` | unset | Opt-in shared rate-limiter + per-user cache backend (ElastiCache). Unset → per-node ETS. Fails open + alerts if unreachable (:618-632). |
 
-## Search
+> `RELEASE_COOKIE` is consumed by the Elixir release runtime (`rel/`/`mix release`), not read in `runtime.exs`.
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `JINA_URL` | — | Reranker URL (empty = vector-only search) |
-
-## Attachments
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `STORAGE_BACKEND` | `s3` | `s3` (AWS S3 prod + MinIO self-host), `local` (filesystem), or `database` (Postgres bytea) |
-| `STORAGE_BUCKET` | `engram-attachments` | S3 bucket name |
-| `STORAGE_ACCESS_KEY_ID` | — | S3 access key. Leave unset on AWS ECS to use the task role (instance metadata) |
-| `STORAGE_SECRET_ACCESS_KEY` | — | S3 secret key (set alongside `STORAGE_ACCESS_KEY_ID`) |
-| `STORAGE_REGION` | `auto` | S3 region (falls back to `AWS_REGION`, then `us-east-1`) |
-| `STORAGE_HOST` | — | Endpoint host override for MinIO / non-AWS S3; unset for AWS-native S3 |
-| `STORAGE_SCHEME` / `STORAGE_PORT` | `https://` / `443` | Endpoint scheme + port, used only when `STORAGE_HOST` is set |
-
-## Auth
+## Frontend / Hosts / CORS
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `JWT_SECRET` | — | JWT signing key (Joken signer) |
-| `REGISTRATION_ENABLED` | `true` | Allow new user registration |
+| `ENGRAM_SAAS_FRONTEND_ORIGINS` | unset | Extra CORS/WS origins (comma-sep) for the Cloudflare Pages SPA + preview deploys (:661). |
+| `ENGRAM_HOST_REWRITE_ENABLED` | unset (`false`) | `true` enables `HostRewrite` plug for the dedicated `api.`/`mcp.engram.page` hosts. Self-host + current `app.` leave unset → strict no-op (:684). |
+| `ENGRAM_SAAS_ONLY` | unset | `true` → `reject_unknown_hosts` in HostRewrite (:685). |
+| `ENGRAM_HOST_REWRITE_API_HOST` | `api.engram.page` | API host for path rewrite (:695). |
+| `ENGRAM_HOST_REWRITE_MCP_HOST` | `mcp.engram.page` | MCP host for path rewrite (:696). |
+| `ENGRAM_ALLOWED_EXTRA_HOSTS` | unset | Comma-sep extra allowed hosts (:688). |
+| `ENGRAM_FRONTEND_URL` | unset | Absolute SPA base URL for cross-origin OAuth `/authorize` 302 (post-eject) (:706). |
+| `ENGRAM_UPGRADE_URL` | `https://app.engram.page/settings/billing` | Upgrade URL surfaced in 402 limit-exceeded responses (:198-200). |
+| `TRUST_CF_CONNECTING_IP` | `false` | Prod-only: trust `CF-Connecting-IP` for rate-limit client IP. Safe only under Cloudflare AOP `verify` (:534). |
 
-## Limits & Features
+## Storage / Attachments
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `POOL_SIZE` | `10` | Ecto PostgreSQL pool size |
-| `MAX_ATTACHMENT_SIZE` | `5242880` | Per-file attachment size limit (bytes) |
-| `MAX_STORAGE_PER_USER` | `1073741824` | Total user storage quota (bytes) |
-| `MAX_NOTE_SIZE` | `10485760` | Max single note size (bytes) |
-| `RATE_LIMIT_RPM` | `0` (unlimited) | Requests per minute per user (Hammer) |
-| `REDIS_URL` | — | Optional Redis (only needed if not using ETS for rate limiting) |
-
-## Observability
+> **`STORAGE_BACKEND` code default is `s3`** (runtime.exs:44 — `System.get_env("STORAGE_BACKEND", "s3")`). `s3` is the SaaS/prod (AWS S3) and standard self-host (MinIO) path. `database` (#297) is a self-host-only convenience that stores opaque ciphertext in the generic `storage_objects` table (NOT the removed `attachments.content` column). Unknown values raise at boot (:77).
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `SENTRY_DSN` | — | Sentry error tracking DSN (empty = disabled) |
+| `STORAGE_BACKEND` | `s3` | `s3` or `database` (:44). |
+| `STORAGE_BUCKET` | `engram-attachments` | S3 bucket (:47). |
+| `STORAGE_ACCESS_KEY_ID` | unset | Static S3 key (MinIO/non-AWS). Leave unset on ECS to use the task role (:53). |
+| `STORAGE_SECRET_ACCESS_KEY` | — | Paired secret (required if access key set, :55). |
+| `STORAGE_REGION` | `auto` (falls back to `AWS_REGION`, then `us-east-1`) | S3 region (:57, :60). |
+| `STORAGE_HOST` | unset | Endpoint host override for MinIO / non-AWS S3 (:66). |
+| `STORAGE_SCHEME` | `https://` | Used only when `STORAGE_HOST` set (:68). |
+| `STORAGE_PORT` | `443` | Used only when `STORAGE_HOST` set (:70). |
 
-## Billing (Paddle)
+## Embedding (Voyage / Ollama)
 
-Paddle is the Merchant-of-Record. Server-side keys gate API calls (portal sessions, etc.); the client token is sent to the frontend so it can open the Paddle.js overlay; price IDs map tiers to Paddle prices. See `docs/context/paddle-integration.md`.
+> Embedder default is `voyage` (runtime.exs:85 — `EMBED_BACKEND` defaults to `voyage`). `ollama` selects the self-host adapter.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `PADDLE_ENV` | `sandbox` | `sandbox` or `production` — selects api.paddle.com base URL |
-| `PADDLE_API_KEY` | — | Server-side Paddle API key (Bearer auth for portal sessions, etc.) |
-| `PADDLE_NOTIFICATION_SECRET` | — | Webhook signing secret — HMAC-SHA256 of `ts:body` |
-| `PADDLE_CLIENT_TOKEN` | — | Public token returned by `GET /api/billing/config` for the Paddle.js overlay |
-| `PADDLE_STARTER_PRICE_ID` | — | Paddle price ID for the Starter tier (`pri_…`) |
-| `PADDLE_PRO_PRICE_ID` | — | Paddle price ID for the Pro tier (`pri_…`) |
+| `EMBED_BACKEND` | `voyage` | `voyage` or `ollama` (:85). |
+| `VOYAGE_API_KEY` | unset | Voyage AI key (used when backend = voyage) (:92). |
+| `EMBED_MODEL` | (compile-time) | Override symmetric embed model (:97). |
+| `EMBED_DIMS` | (compile-time) | Override vector dimensions (:101). |
+| `DOC_EMBED_MODEL` | falls back to `EMBED_MODEL` | Asymmetric: doc-indexing model (:107). |
+| `QUERY_EMBED_MODEL` | falls back to `EMBED_MODEL` | Asymmetric: query model (:111). |
+| `EMBED_429_SNOOZE_SECONDS` | `60` | Voyage-429 snooze (worker reschedules without burning an attempt) (:118). |
+| `VOYAGE_RPM` | unset (no throttle) | Client-side cap — synthetic 429 before real call (:131). |
+| `VOYAGE_QUERY_RPM` | falls back to `VOYAGE_RPM` | Separate bucket for synchronous search (:135). |
+| `OLLAMA_URL` | (adapter default `http://localhost:11434`) | Ollama server (self-host). |
+
+## Vector DB (Qdrant)
+
+> **`QDRANT_COLLECTION` — nuance.** `runtime.exs` only sets the config when the env var is present (:143-145). The *fallback if unset* differs by source: dev/test config pin `engram_notes` (`config/dev.exs:78`, `config/test.exs:71`), but the module-level `Application.get_env(:engram, :qdrant_collection, "obsidian_notes")` fallback is **`obsidian_notes`** (`lib/engram/indexing.ex:20`, `lib/engram/search.ex:16`). In prod the collection comes from the `QDRANT_COLLECTION` env var; the live prod collection is **`engram_notes`** (set explicitly). Net: never rely on the implicit fallback in prod — set `QDRANT_COLLECTION` explicitly.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `QDRANT_URL` | (compile-time) | Qdrant base URL (:139). |
+| `QDRANT_COLLECTION` | env-driven; fallback `obsidian_notes` (module) / `engram_notes` (dev+test+prod) | Collection name (:143). See nuance above. |
+| `QDRANT_API_KEY` | unset | Qdrant Cloud key (:147). |
+| `QDRANT_BINARY_QUANTIZATION` | on | Set `false` to disable BQ on non-AVX2 hardware (:152). |
+
+## Search / Reranker
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `RERANKER_BACKEND` | `none` | `jina` or `none` (:157). |
+| `JINA_URL` | — (required when `RERANKER_BACKEND=jina`) | Reranker URL (:163). |
+
+## Auth (local / Clerk)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `AUTH_PROVIDER` | `local` | `local` (built-in email/password) or `clerk` (SaaS JWKS) (:174). |
+| `ENGRAM_DEFAULT_REGISTRATION_MODE` | `invite_only` | Self-host registration default: `closed` / `invite_only` / `open` (:186). |
+| `CLERK_JWKS_URL` | — (required if clerk, :277) | Clerk JWKS endpoint. |
+| `CLERK_ISSUER` | — (required if clerk, :284) | Clerk issuer. |
+| `CLERK_PUBLISHABLE_KEY` | — (required if clerk, :290) | Clerk publishable key. |
+| `CLERK_SECRET_KEY` | unset | Backend API key (`sk_*`) — revoke duplicate signups (pricing v2 §A) (:300). |
+| `CLERK_WEBHOOK_SECRET` | unset | Verifies inbound svix signatures (`whsec_*`) (:304). |
+| `CLERK_AUTHORIZED_PARTIES` | unset (passthrough) | Comma-sep `azp` allowlist (:313). |
+| `CLERK_WAITLIST_MODE` | unset | `1`/`true` → SPA waitlist UI (mirror the Clerk dashboard) (:333). |
+
+## Encryption / Key Provider
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `KEY_PROVIDER` | `local` | `local` or `aws_kms` (:454). |
+| `ENCRYPTION_MASTER_KEY` | unset | Master key for wrapping per-user DEKs (local provider) (:462). |
+| `ENCRYPTION_MASTER_KEY_PREVIOUS` | unset | Old master key during rotation (:463). |
+| `ENCRYPTION_MASTER_KEY_VERSION` | `1` | Master key version (:465). |
+| `DEK_CACHE_TTL_MS` | `3600000` (1h) | DEK cache TTL (:466). |
+| `BOOT_CANARY_ENABLED` | on | `false` disables the boot canary during master-key rotation window (:476). See `encryption-operations.md`. |
+| `AWS_KMS_KEY_ID` | — (required if `KEY_PROVIDER=aws_kms`, :483) | KMS CMK id. |
+| `AWS_REGION` | — (required for KMS; also S3 region fallback) | AWS region (:484). |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | unset | Static KMS creds; unset on ECS → task role (:494). |
+
+## Email (Resend)
+
+> Default provider is NoOp; Resend activates when `RESEND_API_KEY` is set (non-test only) (:214).
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `RESEND_API_KEY` | unset | Activates `Engram.Email.Resend` (:215). |
+| `EMAIL_FROM` | unset | From-address override (:220). |
+| `RESEND_WEBHOOK_SECRET` | unset | `whsec_*` for `POST /webhooks/resend` (bounce/complaint). Unset → endpoint rejects all events (:227). |
+
+## Billing (Paddle — MoR)
+
+Paddle is the Merchant-of-Record. Server keys gate API calls; the client token feeds the Paddle.js overlay; price IDs are **split monthly/annual per tier** (not a single `PADDLE_<TIER>_PRICE_ID`). See `docs/context/paddle-integration.md`. All Paddle config is non-test-only (:368).
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `PADDLE_ENV` | `sandbox` | `sandbox` or `production` (:397). |
+| `PADDLE_API_KEY` | unset | Server-side key; also gates `billing_enabled` (:369). |
+| `PADDLE_NOTIFICATION_SECRET` | unset | Webhook signing secret (:373). |
+| `PADDLE_CLIENT_TOKEN` | unset | Public token for the overlay (:377). |
+| `PADDLE_STARTER_MONTHLY_PRICE_ID` | unset | Starter monthly `pri_*` (:382). |
+| `PADDLE_STARTER_ANNUAL_PRICE_ID` | unset | Starter annual `pri_*` (:386). |
+| `PADDLE_PRO_MONTHLY_PRICE_ID` | unset | Pro monthly `pri_*` (:390). |
+| `PADDLE_PRO_ANNUAL_PRICE_ID` | unset | Pro annual `pri_*` (:393). |
+
+## Limits & Plan Enforcement
+
+> Per-tier numeric limits are NOT individual env vars anymore. They are defined by `Engram.Billing.LimitKeys` and overridden via generated `ENGRAM_<TIER>_<KEY>` env vars parsed at boot (:436-445). Bad values fail boot. Old knobs `REGISTRATION_ENABLED`, `MAX_ATTACHMENT_SIZE`, `MAX_STORAGE_PER_USER`, `MAX_NOTE_SIZE`, `RATE_LIMIT_RPM` are **gone** — migrated to LimitKeys.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ENGRAM_LIMITS_ENFORCED` | derived (`clerk` + Paddle key) | `true`/`false` override of plan-limit enforcement (:414). |
+| `ENGRAM_<TIER>_<KEY>` | unset | Per-tier limit overrides (e.g. `ENGRAM_FREE_MAX_NOTES`); names come from `LimitKeys.env_var_names/0` (:437). |
+| `REQUIRE_PHONE_FOR_EMBED` | off | Pricing v2 §A phone-verification gate on EmbedNote (:341). |
+| `ATTACHMENT_MIME_BYPASS` | off (gate ON) | `true` disables the MIME/extension whitelist (:351). |
+| `ATTACHMENT_MIME_ALLOWLIST_EXTRA` | unset | Comma-sep extra allowed MIMEs without disabling the gate (:355). |
+| `RATE_LIMIT_AUTH_OVERRIDE` | ignored unless `CI=true` | Auth-limiter override for CI/E2E only (:236). |
+| `PRE_AUTH_RATE_LIMIT_OVERRIDE` | ignored unless `CI=true` | Pre-auth (vault-pipeline) limiter override for CI/E2E only (:257). |
+| `CI` | unset | `true` unlocks the two rate-limit overrides above (:236). |
+
+## Observability (Sentry / PostHog / Pyroscope / Metrics)
+
+Each block is opt-in: unset → no-op (dev/test/self-host emit nothing).
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `METRICS_AUTH_TOKEN` | unset | Bearer guarding the PromEx `/metrics` scrape. Unset → `MetricsAuth` plug fails closed (endpoint disabled) (:748). |
+| `SENTRY_DSN` | unset | Sentry error tracking (:757). |
+| `RELEASE_SHA` | unset | Sentry release tag — must match `getsentry/action-release` (:770). |
+| `POSTHOG_API_KEY` | unset | Server-side PostHog capture (:794). |
+| `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog ingest host (:797). |
+| `GRAFANA_PYROSCOPE_URL` | unset | Enables continuous CPU profiling (:812). |
+| `GRAFANA_PYROSCOPE_USERNAME` | — (required if Pyroscope URL set, :817) | Pyroscope username. |
+| `GRAFANA_AGENT_TOKEN` | — (required if Pyroscope URL set, :819) | Shared Grafana Cloud token (metrics/logs/traces/profiles write). |
+| `PYROSCOPE_APP_NAME` | `engram-saas-prod` | Pyroscope app label (:821). |
+| `HOSTNAME` / `ECS_TASK_ID` | `unknown` | Pyroscope instance label (:823). |
+
+## Notes on removed / migrated vars
+
+- `REGISTRATION_ENABLED` → replaced by `ENGRAM_DEFAULT_REGISTRATION_MODE` + `Engram.Instance.registration_mode/0`.
+- `MAX_ATTACHMENT_SIZE`, `MAX_STORAGE_PER_USER`, `MAX_NOTE_SIZE`, `RATE_LIMIT_RPM` → moved into `Engram.Billing.LimitKeys` (per-tier; override via `ENGRAM_<TIER>_<KEY>`).
+- Legal version/hash env vars → dropped; legal docs now live in the `terms_versions` table seeded from `priv/legal/legal-manifest.json` (:448).
 
 ## References
-- Runtime config: `config/runtime.exs`
-- Dev config: `config/dev.exs`
+- Runtime config (source of truth): `config/runtime.exs`
+- Compile-time defaults: `config/config.exs`, `config/dev.exs`, `config/test.exs`
+- Module-level Qdrant collection fallback: `lib/engram/indexing.ex:20`, `lib/engram/search.ex:16`
+- Limit keys: `Engram.Billing.LimitKeys`
+- Paddle: `docs/context/paddle-integration.md`
+- Encryption: `docs/context/encryption-operations.md`

--- a/docs/context/folder-tree-optimistic-rebuild.md
+++ b/docs/context/folder-tree-optimistic-rebuild.md
@@ -41,9 +41,10 @@ explicit **`rebuildTree()` / `invalidateChildrenIds()`**. It does NOT react to
 cache writes. So we trigger rebuilds ourselves via two mechanisms in
 `use-engram-tree.ts`:
 
-1. **`treeStructureKey(folders, rootNoteIds, sort)`** → a `useEffect` that calls
+1. **`treeStructureKey(folders, sort)`** → a `useEffect` that calls
    `rebuildTree()` when the key changes. Fingerprints each folder as
-   `id:count:parent_id`, plus root note ids, plus sort. Keyed (not identity) so
+   `id:count:parent_id`, plus sort (the call site also concatenates an
+   `attachmentsFingerprint(...)` onto the result). Keyed (not identity) so
    spurious churn doesn't spin a max-update-depth loop.
    **Blind spot**: it does NOT see `folder-notes-by-id` list *contents*. A note
    op that changes a by-id list without changing any folder count/parent_id will

--- a/docs/context/local-supabase-audit.md
+++ b/docs/context/local-supabase-audit.md
@@ -89,13 +89,13 @@ supabase start --workdir ~/supabase-engram-audit
 1. **No AVX2 on this CPU** — see Failed Approaches. Build CLI with `GOAMD64=v1`.
 2. **Encryption at rest** — notes/vaults are per-user-DEK, AAD-bound AES-GCM with HMAC lookup columns; plaintext columns are gone. Seed only through the app contexts.
 3. **Boot canary** — the app boots `BootCanaryGuard`, which wraps/unwraps a canary row in `system_canaries` using `ENCRYPTION_MASTER_KEY`. Seed once with key A then re-run with key B → boot fails: `boot canary unwrap failed: :invalid_wrapping`. Fix: pin ONE stable master key (`~/supabase-engram-audit/.master_key`). If the canary is already wrapped under a lost key on this throwaway DB (no real encrypted data to protect): `DELETE FROM system_canaries;` then re-run.
-4. **RLS role grant** — `Repo.with_tenant/2` does `SET LOCAL ROLE engram_app` + `SET LOCAL app.current_tenant`. Supabase's `postgres` user is not a true superuser and isn't a member of `engram_app`, so writes fail with `42501 permission denied to set role "engram_app"`. The `engram_app` role itself already exists (created by migration `20260403000846_add_rls_policies`). Fix: `GRANT engram_app TO postgres;` (run as postgres via the `docker exec ... psql` above).
+4. **RLS role grant** — `Repo.with_tenant/2` does `SET LOCAL ROLE engram_app` + `SET LOCAL app.current_tenant`. Supabase's `postgres` user is not a true superuser and isn't a member of `engram_app`, so writes fail with `42501 permission denied to set role "engram_app"`. The `engram_app` role itself already exists (created by the schema baseline `20260602000000_baseline.exs`; the original `20260403000846_add_rls_policies` migration was collapsed into the baseline in #401). Fix: `GRANT engram_app TO postgres;` (run as postgres via the `docker exec ... psql` above).
 5. **Embeddings / Oban** — `upsert_note` enqueues Oban `:embed` jobs that would call Voyage AI + Qdrant (external/cloud). `dev_seeds.exs` pauses the `:embed` and `:reindex` queues before inserting, so nothing fires; jobs stay queued in `oban_jobs` (harmless, and realistic queue data for the audit).
 6. **Studio is loopback-only** — reach via SSH tunnel or the LAN IP (Docker publishes on `0.0.0.0`); firewalld may need port 54323 opened.
 
 ## References
 - Seed script: `backend/priv/repo/dev_seeds.exs`
 - Dev config honoring `DATABASE_URL`: `backend/config/dev.exs`
-- RLS migration creating `engram_app`: `backend/priv/repo/migrations/20260403000846_add_rls_policies.exs`
+- RLS/role setup creating `engram_app`: `backend/priv/repo/migrations/20260602000000_baseline.exs` (the per-migration `20260403000846_add_rls_policies.exs` was collapsed into this baseline in #401)
 - Schema/RLS background: `backend/docs/context/database-schema-rls.md`
 - Supabase CLI monorepo: https://github.com/supabase/cli (`apps/cli-go/`)

--- a/docs/context/mcp-oauth.md
+++ b/docs/context/mcp-oauth.md
@@ -1,8 +1,10 @@
 # MCP OAuth 2.1 + DCR — How It Works
 
-End-to-end OAuth 2.1 + Dynamic Client Registration on Engram's MCP endpoint, so Claude Connectors / Cursor / ChatGPT custom GPTs / any other standards-compliant client can auto-auth against `app.engram.page/api/mcp` (saas) or `engram.ax/api/mcp` (selfhost) without per-client integration code.
+End-to-end OAuth 2.1 + Dynamic Client Registration on Engram's MCP endpoint, so Claude Connectors / Cursor / ChatGPT custom GPTs / any other standards-compliant client can auto-auth against `mcp.engram.page/api/mcp` (saas) or `engram.ax/api/mcp` (selfhost) without per-client integration code.
 
-Plan: `docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md`. Shipped in PRs #91-#97 across 6 backend phases (Phase 0-6) plus the docs PR.
+> **Host note:** the saas MCP endpoint is `mcp.engram.page`, NOT `app.engram.page`. The `host_rewrite.ex` plug rejects `/api/mcp` and `/oauth/*` on `app.engram.page` (old path now 405s). All curl examples below use `mcp.engram.page`.
+
+Plan: `docs/superpowers/plans/2026-05-09-mcp-oauth-dcr.md`. Shipped in PRs #91-#97 across 6 backend phases (Phase 0-6) plus the docs PR. Phases 7.A/7.B/7.C and the SPA consent page are also shipped.
 
 ## Wire flow (what Claude Connectors actually does)
 
@@ -50,7 +52,7 @@ Scope is propagated through code → refresh token → access JWT. Today the JWT
 
 ```bash
 # Register via DCR — no admin involvement
-curl -X POST https://app.engram.page/oauth/register \
+curl -X POST https://mcp.engram.page/oauth/register \
   -H "Content-Type: application/json" \
   -d '{"redirect_uris":["http://localhost:9999/cb"],"client_name":"my-cli"}'
 
@@ -62,7 +64,7 @@ Use the returned `client_id` in a normal authorize → token flow. PKCE is manda
 ## How to revoke a refresh token
 
 ```bash
-curl -X POST https://app.engram.page/oauth/revoke \
+curl -X POST https://mcp.engram.page/oauth/revoke \
   -H "Content-Type: application/json" \
   -d '{"token":"engram_oauth_rt_...","client_id":"<uuid>"}'
 ```
@@ -79,17 +81,13 @@ Always returns 200 per RFC 7009 §2.2. If `client_id` doesn't own the token, it'
 
 All three skip RLS — they're keyed by client_id or token-hash and looked up before user identity is established. Cleanup runs hourly via `Engram.Workers.CleanupDeviceAuthWorker`.
 
-## Phase 7+ — what's left
+## Phase 7 — SPA consent mediation (all shipped)
 
-Phases 7-9 of the plan are smoke/conformance tests against:
-- Real Claude desktop Connectors UI (`app.engram.page` + `engram.ax`)
-- Cursor / Continue / ChatGPT custom GPT (cross-client conformance)
+Phases 7.A/7.B/7.C are all shipped; the live Connectors flow has been verified against Claude Desktop Connectors.
 
-These need a live deployment after the PRs land.
+**Phase 7.A — SPA mediation:** `GET /oauth/authorize` is public. It validates client_id + redirect_uri + PKCE then 302s the browser to `/oauth/consent?<all-params-preserved>`. The React SPA reads the URL params, fetches `/api/oauth/clients/:client_id` to display the client name, renders a consent UI under the user's existing Clerk JWT session, and POSTs `/api/oauth/authorize/consent` with `vault_choice` + the full param set. The backend mints the code and returns JSON `{redirect_uri: "..."}` so the SPA does `window.location.assign(json.redirect_uri)`.
 
-**Phase 7.A (shipped) — SPA mediation:** `GET /oauth/authorize` is now public. It validates client_id + redirect_uri + PKCE then 302s the browser to `/oauth/consent?<all-params-preserved>`. The React SPA reads the URL params, fetches `/api/oauth/clients/:client_id` to display the client name, renders a consent UI under the user's existing Clerk JWT session, and POSTs `/api/oauth/authorize/consent` with `vault_choice` + the full param set. The backend mints the code and returns JSON `{redirect_uri: "..."}` so the SPA does `window.location.assign(json.redirect_uri)`.
-
-**Phase 7.B (in flight)** ships the actual React consent page. **7.C** is the live Connectors walk-through.
+**Phase 7.B** ships the actual React consent page. **Phase 7.C** is the live Connectors walk-through against `mcp.engram.page` + `engram.ax`, plus cross-client conformance (Cursor / Continue / ChatGPT custom GPT). All complete.
 
 ## Failed approaches (none yet)
 

--- a/docs/context/oidc-deploy-cutover.md
+++ b/docs/context/oidc-deploy-cutover.md
@@ -1,5 +1,18 @@
 # OIDC deploy cutover
 
+> **STAGING-ONLY / LARGELY SUPERSEDED — historical record.**
+> This cutover applied to the **FastRaid (now staging)** deploy path, and
+> only to the daemon's `/deploy` (image-roll) endpoint. That endpoint is now
+> a **legacy fallback**. The live staging deploy path is the daemon's
+> **`/tf-apply`** endpoint driven by a Terraform-tfvars var-bump PR
+> (`bump-infra-tfvars` in `verify.yml`) — the same GitOps "image tag in git →
+> engram-infra reconciles" model as prod. **PROD does not use this daemon at
+> all**: prod ships via a `release-v*` tag → engram-infra Terraform apply on
+> AWS ECS (see `docs/context/deploy-prod.md`). The OIDC token model, JWKS
+> validation, cert/firewall setup, and SSH-key decommission below are still
+> accurate for the staging daemon; treat the `/deploy`-rolls-the-image flow as
+> the fallback, not the primary path.
+
 Replaced the SSH-as-root deploy with a pull-based daemon
 (`engram-deployer`) running on FastRaid. Runner mints a per-job OIDC
 token, daemon validates against GitHub's JWKS and pins

--- a/docs/context/paddle-integration.md
+++ b/docs/context/paddle-integration.md
@@ -55,7 +55,7 @@ When the frontend opens `Paddle.Checkout.open()`, it MUST include at least `user
 
 ```js
 Paddle.Checkout.open({
-  items: [{ priceId: cfg.price_ids.starter, quantity: 1 }],
+  items: [{ priceId: cfg.price_ids.starter.monthly, quantity: 1 }],
   customer: { email: cfg.customer_email },
   customData: {
     ...cfg.custom_data,          // { user_id: 42 }
@@ -78,11 +78,11 @@ Whatever the overlay sends becomes `data.custom_data` on every subscription webh
 | `subscription.created` | Insert row (or upsert on `user_id` conflict). Populates `paddle_customer_id`, `paddle_subscription_id`, `tier`, `status`, `current_period_end`, `custom_data`. | First touch — bind the Paddle entities to the user. |
 | `subscription.activated` | Update `status`, `tier`, `current_period_end` by `paddle_subscription_id`. | Fires when trial converts to paid. |
 | `subscription.updated` | Same as activated. | Plan change, billing cycle roll, dunning recovery. |
-| `subscription.past_due` | Same as activated; status becomes `"past_due"`. | Card declined, retry in progress. We still gate access in `active?/1` since past-due remains within the grace window. |
-| `subscription.canceled` | Status becomes `"canceled"`. | End of life. `active?/1` returns false. |
+| `subscription.past_due` | Same as activated; status becomes `"past_due"`. | Card declined, retry in progress. `past_due` is in `@entitled_statuses`, so `tier/1` still reports the paid tier during the grace window. |
+| `subscription.canceled` | Status becomes `"canceled"`. | End of life. `canceled` is NOT entitled, so `tier/1` drops back to `:free`. (`active?/1` is suspension-only — `is_nil(suspended_at)` — and is unaffected by subscription status.) |
 | anything else | `{:ok, :ignored}` | Transactions, invoices, payment methods, etc. — out of scope for the subscription row. |
 
-`tier` is derived from `data.items[0].price.id` matched against `:paddle_starter_price_id` / `:paddle_pro_price_id` config; anything unrecognized falls back to `"starter"`.
+`tier` is derived from `data.items[0].price.id` matched against the four price-ID config keys (`:paddle_starter_monthly_price_id`, `:paddle_starter_annual_price_id`, `:paddle_pro_monthly_price_id`, `:paddle_pro_annual_price_id`) via `Engram.Billing.tier_from_subscription/1`. Anything unrecognized returns `{:error, :unknown_price_id}` — the upserter then leaves the existing tier UNCHANGED and captures a Sentry message (`billing.ex:446/512/589`). It does NOT fall back to `"starter"`.
 
 ## Trial
 
@@ -95,8 +95,10 @@ export PADDLE_ENV=sandbox
 export PADDLE_API_KEY=pdl_sdbx_apns_...
 export PADDLE_NOTIFICATION_SECRET=pdl_ntfn_...
 export PADDLE_CLIENT_TOKEN=test_...
-export PADDLE_STARTER_PRICE_ID=pri_01...
-export PADDLE_PRO_PRICE_ID=pri_01...
+export PADDLE_STARTER_MONTHLY_PRICE_ID=pri_01...
+export PADDLE_STARTER_ANNUAL_PRICE_ID=pri_01...
+export PADDLE_PRO_MONTHLY_PRICE_ID=pri_01...
+export PADDLE_PRO_ANNUAL_PRICE_ID=pri_01...
 ```
 
 Use the **Paddle CLI** to forward sandbox webhooks at localhost:
@@ -172,4 +174,4 @@ PromEx + Prometheus + alert rules are tracked separately on the engram-infra rep
 
 - Frontend wiring of Paddle.js (marketing site + app). Owned by the frontend rewrite.
 - Affiliate-platform-specific integration (Rewardful etc.). Configured in their dashboards, not in our code.
-- Annual prices ($50/yr, $100/yr). Same wiring; just add the price IDs when they exist in Paddle.
+- Annual prices ($70/yr Starter, $140/yr Pro). Wired via the `*_annual_price_id` config keys; surfaced under `price_ids.{starter,pro}.annual` in `GET /api/billing/config`.

--- a/docs/context/pricing-v2-server-side-enforcement-audit.md
+++ b/docs/context/pricing-v2-server-side-enforcement-audit.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-05-21 (shipped with PR #198).
 
+> **Snapshot — catalog has drifted.** This is a point-in-time audit of the `LimitKeys` catalog as of the date above. Since then the catalog moved (now at `lib/engram/billing/limit_keys.ex`): `realtime_sync_enabled` and `inactivity_warn_60_days` listed below are dead, and roughly eight newer keys are not represented here. Treat the table as historical; re-run `mix engram.lint.no_client_only_rate_limits` for the live picture.
+
 Closes pricing-v2 §G's audit criterion: walk every `LimitKeys` catalog key and confirm each Free-restrictive limit has a server-side enforcement site. The `mix engram.lint.no_client_only_rate_limits` task encodes this audit and runs in CI on every push.
 
 ## Audit results

--- a/docs/context/refresh-token-reuse-detection.md
+++ b/docs/context/refresh-token-reuse-detection.md
@@ -1,7 +1,9 @@
-# Refresh token rotation — reuse detection + leeway (build plan)
+# Refresh token rotation — reuse detection + leeway (as-built)
 
-_Status: built 2026-05-28 on `fix/refresh-token-grace-window` (Engram PR #341),
-v0.5.245. Backend repo (`engram`)._
+_Status: SHIPPED 2026-05-28 (Engram PR #341), v0.5.245. Backend repo (`engram`).
+Both halves landed: the leeway/overlap window AND token-family reuse-detection
+revocation. This doc describes the as-built behavior; the old "build plan"
+sections were folded into "As built" below._
 
 ## Why
 
@@ -28,55 +30,42 @@ token rotation + reuse detection with token-family revocation**, layered with a
   new one, skip breach detection. (Auth0 `leeway` / "Rotation Overlap Period";
   default 0, "shortest amount of time" recommended.)
 
-PR #341 added the leeway half (`@refresh_grace_seconds 60`) but **not** the
-family-revocation half — that is the gap to close. Keep the leeway; add families.
+PR #341 shipped **both** halves: the leeway/overlap window and family-wide
+reuse-detection revocation.
 
 Sources: RFC 9700 §4.14.2 (ietf.org/rfc/rfc9700.html); Auth0 "Refresh Token
 Rotation" + "Configure Refresh Token Rotation" (`leeway` attr); WorkOS "We read
 RFC 9700".
 
-## Current state
+## As built
 
-- `lib/engram/auth/device_flow.ex` — `refresh_access_token/1` accepts a token
-  revoked within `@refresh_grace_seconds` (60s); stamps `revoked_at` only on
-  first use. **No family tracking, no reuse-detection revocation.**
-- `Engram.Auth.DeviceRefreshToken` schema — no `family_id` column.
-- PR #341 (`fix/refresh-token-grace-window`) open with the leeway-only change +
-  tests; CI green. Decide: extend this PR with families, or supersede it.
-
-## Build plan (TDD, one step per commit)
-
-1. **Migration** — add `family_id :uuid` to `device_refresh_tokens` (+ index).
-   Backfill: give every existing row its own fresh `family_id` (each existing
-   token = its own family). Add to the schema + changeset.
-2. **`create_refresh_token/3`** — accept an optional `family_id`; generate a new
-   uuid when nil (new login), inherit it on rotation. Device authorize/exchange
-   path mints a new family; `refresh_access_token` passes the old token's family.
-3. **`refresh_access_token/1` reuse detection** — look up by hash where
-   `expires_at > now` (regardless of `revoked_at`). Then:
-   - not found → `{:error, :invalid_refresh_token}`
-   - active (`revoked_at` nil) → rotate: revoke it, issue child in same family.
-   - revoked **within** leeway → benign retry: issue child in same family, no
-     revocation (this is the existing grace path).
-   - revoked **outside** leeway (or an older token) → **reuse detected**:
-     **hard-`delete_all` the entire family** (`where family_id == ^fid`), return
-     `{:error, :invalid_refresh_token}`. **Delete, not `update_all` set
-     `revoked_at`** — a freshly-revoked current token would land *inside* the
-     leeway window and be misclassified as a benign retry on its next
-     presentation, defeating the revocation. Deleting removes that ambiguity;
-     `Logger.warning` the breach (family_id + user_id) so the audit trail
-     survives the row deletion.
-   - Renamed `@refresh_grace_seconds` → `@refresh_leeway_seconds`; trimmed 60s →
-     30s (Auth0 recommends shortest; plugin reload races resolve in <1s).
-4. **Tests** (`test/engram/auth/device_flow_test.exs` +
-   `test/engram_web/controllers/device_auth_controller_test.exs`):
-   - normal rotation chain still works;
-   - reuse within leeway → ok (exists);
-   - **reuse outside leeway → family revoked**: after reuse, the *valid current*
-     token in that family is also rejected (the security-defining test);
-   - boundary at exactly the leeway cutoff; expired-AND-revoked still rejected;
-   - unknown token → invalid (exists).
-5. Version bump `mix.exs` (pre-push hook enforces it). Format + credo. CI green.
+- **Schema** — `Engram.Auth.DeviceRefreshToken` has a `family_id :uuid` column
+  (`device_refresh_token.ex:8`), required in the changeset. Each existing row was
+  backfilled with its own fresh family.
+- **`create_refresh_token/3`** (`device_flow.ex:257`) takes an optional
+  `family_id`; `nil` mints a fresh uuid (new login), rotation inherits the old
+  token's `family_id` to keep the lineage together.
+- **`refresh_access_token/1`** (`device_flow.ex:144`) looks up by hash where
+  `expires_at > now` (regardless of `revoked_at`), then:
+  - not found → `{:error, :invalid_refresh_token}`
+  - active (`revoked_at` nil) → rotate: stamp `revoked_at`, issue child in same
+    family.
+  - revoked **within** leeway → benign retry: `issue_child` in same family, no
+    re-revocation.
+  - revoked **outside** leeway (or older token) → **reuse breach**:
+    `invalidate_family/1` runs `delete_all where family_id == ^fid`
+    (`device_flow.ex:251`) and returns `{:error, :invalid_refresh_token}`. It
+    **deletes** rather than `update_all` set `revoked_at` — a freshly-revoked
+    current token would otherwise land *inside* the leeway and be misclassified
+    as benign on next presentation. A `Logger.warning` records the breach
+    (`family_id` + `user_id`) so the audit trail survives row deletion.
+- **Leeway policy** — extracted into `Engram.Auth.RefreshLeeway` (`@seconds 30`,
+  boundary-inclusive `benign?/2`). The old `@refresh_grace_seconds 60` is gone.
+- **Tests** — `test/engram/auth/device_flow_test.exs` +
+  `test/engram_web/controllers/device_auth_controller_test.exs` cover: normal
+  rotation chain, reuse within leeway → ok, **reuse outside leeway → whole family
+  revoked (the current valid token also rejected)**, the leeway boundary,
+  expired-AND-revoked rejected, unknown token → invalid.
 
 ## Notes / gotchas
 

--- a/docs/context/spa-state-injection.md
+++ b/docs/context/spa-state-injection.md
@@ -48,12 +48,13 @@ both modes:
 
 **Frontend (`frontend/src/config.ts`):**
 
-1. `loadConfig()` reads `window.__ENGRAM_CONFIG__` at module init time.
+1. `loadConfig()` (async) reads `window.__ENGRAM_CONFIG__` at module init time.
 2. Validates `authProvider`. Returns a typed `EngramConfig`.
-3. If the injected config is missing (Vite dev), falls back to
-   `import.meta.env.VITE_*` variables.
-4. Exports `export const config = loadConfig()` — a single eager value,
-   not a hook. Other modules import and use synchronously.
+3. If the injected config is missing (Vite dev), falls back to fetching
+   `/config.json`, then to defaults.
+4. Exports `export const configPromise = loadConfig()` — a single eager
+   `Promise<EngramConfig>` resolved once at module init. Consumers await it
+   (e.g. before bootstrapping the React root), not a hook.
 
 **Per-consumer pattern (e.g., `frontend/src/auth/use-bootstrap.ts`):**
 

--- a/docs/context/testing-strategy.md
+++ b/docs/context/testing-strategy.md
@@ -36,7 +36,7 @@ Key advantage: `async: true` runs tests in parallel with per-test DB transaction
 
 If you spin up a fresh Postgres just to run `mix test` (e.g. an isolated audit/CI-repro container), two things bite in order:
 
-1. **Postgres must be 18+.** The baseline `structure.sql` uses `uuidv7()` (PK default) and `SET transaction_timeout` — both PG17-and-earlier fail (`function uuidv7() does not exist` / `unrecognized configuration parameter`). Use `postgres:18-alpine`. This is the test-side mirror of the prod cutover in [[pg18-uuidv7-prod-crashloop-2026-06-11]].
+1. **Postgres must be 18+.** The baseline `structure.sql` uses `uuidv7()` (PK default) and `SET transaction_timeout` — both PG17-and-earlier fail (`function uuidv7() does not exist` / `unrecognized configuration parameter`). Use `postgres:18.4` (the version CI and the compose files pin). This is the test-side mirror of the prod cutover in [[pg18-uuidv7-prod-crashloop-2026-06-11]].
 2. **The `engram_app` role must exist before migrate.** The baseline dump ends with `GRANT ... TO engram_app`; with no role you get `role "engram_app" does not exist`. `mix engram.prepare_database` creates it (+ default privileges).
 
 The `test` mix alias already chains this correctly:
@@ -53,14 +53,14 @@ See `docs/context/database-schema-rls.md` for the RLS spike test example.
 
 ## CI Pipeline
 
-All tests run in GitHub Actions (`.github/workflows/ci.yml`):
+All tests run in GitHub Actions (`.github/workflows/verify.yml`):
 
 1. **Unit tests** — `mix test` + `python3 -m pytest e2e/unit_tests/ -v` (E2E helpers)
 2. **E2E tests** — starts CI stack + headless Obsidian, runs full sync scenarios
 
-**Code quality checks:** `mix format --check-formatted` and `mix credo`. Dialyzer optional (slow, add later).
+**Code quality checks:** `mix format --check-formatted` and `mix credo --strict` (both fatal in the `lint` job). Dialyzer also runs in CI. See CLAUDE.md "Quality Tooling" for the full fatal-lint set.
 
 ## References
 - ExUnit tests: `test/`
 - E2E tests: `e2e/tests/`
-- CI config: `.github/workflows/ci.yml`
+- CI config: `.github/workflows/verify.yml`

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.454",
+      version: "0.5.455",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Backend half of a 5-repo doc-accuracy audit (workspace PR engram-app/engram-workspace#83). 26 docs re-verified against current code; rewrites only where wrong.

**HIGH (8):** CLAUDE.md (ci.yml→verify.yml, router.ex:307, real Oban workers, /api/notes, Hermes→hand-rolled), database-schema-rls (uuidv7 + encryption-stripped columns + 28 tables + real 6 tenant tables), environment-variables (regen from runtime.exs ~90 vars; `STORAGE_BACKEND` default **s3**), async-indexing-pipeline (real queues/crons), billing-tier-frontend-contract (`active?/1` suspension-only), mcp-oauth (mcp.engram.page host), elixir-architecture-decisions (Fly→AWS, uuidv7, superseded banner), dev-iteration-loop (app.engram.page = prod).

**MED/LOW:** chunking/aws-kms/refresh-token shipped-not-planned; deploy-prod/oidc-cutover/testing-strategy (verify.yml, pg 18.4); paddle $70/$140; CONTRIBUTING access_token+PG18; assorted code-anchor fixes.

**New doc:** `b2-cursor-pull-e2e-triage.md` — resolved B2 cursor-pull e2e triage (no committed equivalent).

Doc-only; `mix.exs` bumped 0.5.454→0.5.455 only to satisfy the one-bump-per-PR / version-check policy.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>