### PR TITLE
fix(e2e): deterministically drain offline queue on restore_online

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -996,12 +996,14 @@ class CdpClient:
         """
         result = await self.evaluate(js)
         logger.info("Online restored on CDP port %d: %s", self.port, result)
-        # Trigger recovery if engine is offline
-        is_offline = await self.get_offline_status()
-        if is_offline:
-            await self.evaluate(
-                f"{ENGINE_PATH}.flushQueue()", await_promise=True
-            )
+        # Always drain the queue explicitly, awaited. Previously this was gated
+        # on `get_offline_status()` being true — but the engine's health check
+        # can auto-recover (flip online) before this check, which skipped the
+        # explicit flush and left the queue to drain via the slow auto-retry
+        # loop, intermittently blowing the drain timeout (#635). flushQueue is a
+        # no-op on an empty queue and idempotent on the server, so calling it
+        # unconditionally is safe and makes the drain deterministic.
+        await self.evaluate(f"{ENGINE_PATH}.flushQueue()", await_promise=True)
 
     async def get_queue_size(self) -> int:
         """Read the offline queue size."""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.457",
+      version: "0.5.458",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Fixes the intermittent `test_24_offline_queue_replay` flake: `TimeoutError: Queue not drained after 10s, size=2` (#635).

## Root cause (not a timeout problem)

`CdpClient.restore_online()` restored the API methods and then called `flushQueue()` **only when `get_offline_status()` was still true**:

```python
is_offline = await self.get_offline_status()
if is_offline:
    await self.evaluate(f"{ENGINE_PATH}.flushQueue()", await_promise=True)
```

The engine's health-check can **auto-recover** (flip `online`) between restoring the API methods and that status read. When it does, `is_offline` is `false`, the explicit awaited flush is **skipped**, and the queue drains only via the engine's slow auto-retry loop — which intermittently exceeds the test's 10s drain budget under parallel CI load. The queue always *eventually* drains (it's a timing race, not a stuck queue), which is exactly the flake signature.

## Fix

Always call `flushQueue()` (awaited), unconditionally:

```python
await self.evaluate(f"{ENGINE_PATH}.flushQueue()", await_promise=True)
```

`flushQueue()` is a no-op on an empty queue (`if entries.length === 0 return 0`) and idempotent on the server (upserts are idempotent; deletes swallow 404), so calling it unconditionally is safe. Because it's awaited, the queue is drained by the time `restore_online()` returns — `wait_for_queue_drain` then sees an empty queue on its first poll. Deterministic, no timeout bump needed (a bigger timeout would only paper over the race).

Verified locally: `py_compile` clean. The behavioral validation is the e2e suite itself (`test_24` should now pass deterministically across reruns).

Closes #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
