### PR TITLE
fix(e2e/ci): stabilize e2e-clerk flake storm (#643, #635, #428, #576)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -146,11 +146,15 @@ jobs:
             AUTH=(-H "Accept: application/vnd.github+json")
           fi
 
+          # --retry-all-errors so a transient connection reset (curl 35/52/56)
+          # — not just HTTP 5xx — is retried. A single blip here is fatal:
+          # the whole pipeline gates on fingerprint's output, so one reset
+          # cascades to unit-tests/e2e-*/prebuild-* (#576).
           resolve_sha() {
-            curl -fsS "${AUTH[@]}" "${API}/commits/$1" | jq -r '.sha'
+            curl -fsS --retry 3 --retry-all-errors --retry-delay 2 "${AUTH[@]}" "${API}/commits/$1" | jq -r '.sha'
           }
           branch_exists() {
-            curl -fsS -o /dev/null "${AUTH[@]}" "${API}/branches/$1"
+            curl -fsS -o /dev/null --retry 3 --retry-all-errors --retry-delay 2 "${AUTH[@]}" "${API}/branches/$1"
           }
 
           if [ -n "$DISPATCH_REF" ]; then
@@ -916,7 +920,7 @@ jobs:
           API="https://api.github.com/repos/engram-app/Engram-obsidian"
           AUTH=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
           # Resolve to full 40-char SHA (short SHAs from manual dispatches won't work)
-          PLUGIN_SHA=$(curl -fsS "${AUTH[@]}" "${API}/commits/${SHORT_SHA}" | jq -r '.sha')
+          PLUGIN_SHA=$(curl -fsS --retry 3 --retry-all-errors --retry-delay 2 "${AUTH[@]}" "${API}/commits/${SHORT_SHA}" | jq -r '.sha')
           # Determine overall E2E result from prior steps
           if [ "${{ job.status }}" = "success" ]; then
             STATE="success"
@@ -925,7 +929,7 @@ jobs:
             STATE="failure"
             DESC="E2E tests failed"
           fi
-          curl -fsS -X POST "${AUTH[@]}" "${API}/statuses/${PLUGIN_SHA}" \
+          curl -fsS -X POST --retry 3 --retry-all-errors --retry-delay 2 "${AUTH[@]}" "${API}/statuses/${PLUGIN_SHA}" \
             -d "$(jq -nc --arg state "$STATE" --arg context "backend/e2e" --arg description "$DESC" --arg target_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
                   '{state:$state, context:$context, description:$description, target_url:$target_url}')"
 

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -956,12 +956,18 @@ class CdpClient:
         (function() {{
             const se = {ENGINE_PATH};
             se._origPushNote = se.api.pushNote.bind(se.api);
+            se._origPushNotesBatch = se.api.pushNotesBatch.bind(se.api);
             se._origDeleteNote = se.api.deleteNote.bind(se.api);
             se._origPushAttachment = se.api.pushAttachment.bind(se.api);
             se._origDeleteAttachment = se.api.deleteAttachment.bind(se.api);
             se._origHealth = se.api.health.bind(se.api);
             const fail = async () => {{ throw new Error('simulated offline'); }};
             se.api.pushNote = fail;
+            // pushNotesBatch (POST /notes/batch, protocol rev #557) is a SEPARATE
+            // method — without overriding it too, multi-file pushes that coalesce
+            // into a batch bypass the simulation, the real call succeeds, and the
+            // engine flips back online (goOnline) so it never goes offline (#635).
+            se.api.pushNotesBatch = fail;
             se.api.deleteNote = fail;
             se.api.pushAttachment = fail;
             se.api.deleteAttachment = fail;
@@ -982,11 +988,13 @@ class CdpClient:
         (function() {{
             const se = {ENGINE_PATH};
             if (se._origPushNote) se.api.pushNote = se._origPushNote;
+            if (se._origPushNotesBatch) se.api.pushNotesBatch = se._origPushNotesBatch;
             if (se._origDeleteNote) se.api.deleteNote = se._origDeleteNote;
             if (se._origPushAttachment) se.api.pushAttachment = se._origPushAttachment;
             if (se._origDeleteAttachment) se.api.deleteAttachment = se._origDeleteAttachment;
             if (se._origHealth) se.api.health = se._origHealth;
             delete se._origPushNote;
+            delete se._origPushNotesBatch;
             delete se._origDeleteNote;
             delete se._origPushAttachment;
             delete se._origDeleteAttachment;

--- a/e2e/tests/api_only/test_50_qdrant_binary_quantization.py
+++ b/e2e/tests/api_only/test_50_qdrant_binary_quantization.py
@@ -109,8 +109,12 @@ class TestSearchRoundTrip:
 
         # Step 1: Wait for THIS note to be indexed in Qdrant (not just any points).
         # #590: source_path is no longer in the payload — match by path_hmac.
+        # 120s (was 60s, #428): the worst-case async path is Voyage 429 backoff
+        # + Qdrant Cloud cold-start + Oban contention, which exceeded 60s under
+        # CI load. This doesn't mask perf regressions — the RDS/ECS health
+        # alarms (#259) still fire on real slowdowns.
         wait_for_qdrant_indexed(
-            seeded_note["vault_id"], path_hmac, note_path, timeout=60
+            seeded_note["vault_id"], path_hmac, note_path, timeout=120
         )
 
         # Step 2: Embed query directly via Ollama

--- a/e2e/tests/test_24_offline_queue_replay.py
+++ b/e2e/tests/test_24_offline_queue_replay.py
@@ -29,16 +29,25 @@ async def test_offline_queue_replay(vault_a, cdp_a, api_sync):
         time.sleep(0.3)  # Space apart to ensure separate push attempts
         write_note(vault_a, path2, "# Offline Note 2\nAlso queued while offline")
 
-        # Wait for push attempts to fail and queue
-        deadline = time.monotonic() + 10
+        # Both the offline flag and the queue fill are REACTIONS to the
+        # simulated push failures — and the engine flips `offline` on its own
+        # health/error path, which can lag the queue fill under e2e-clerk load.
+        # The old code broke out as soon as queue >= 2, then snapshotted
+        # `offline` immediately — a point-in-time assert on eventually-
+        # consistent state that flaked (#635). Poll for BOTH conditions before
+        # asserting.
+        deadline = time.monotonic() + 15
+        offline = False
+        queue_size = 0
         while time.monotonic() < deadline:
-            if await cdp_a.get_queue_size() >= 2:
+            offline = await cdp_a.get_offline_status()
+            queue_size = await cdp_a.get_queue_size()
+            if offline and queue_size >= 2:
                 break
             await asyncio.sleep(0.5)
 
         # Verify offline state
-        assert await cdp_a.get_offline_status(), "Engine should be offline"
-        queue_size = await cdp_a.get_queue_size()
+        assert offline, "Engine should be offline"
         assert queue_size >= 2, f"Expected at least 2 queued entries, got {queue_size}"
     finally:
         # MUST restore even if assertions fail — prevents cascade

--- a/e2e/tests/test_47_oauth_websocket_live_sync.py
+++ b/e2e/tests/test_47_oauth_websocket_live_sync.py
@@ -33,7 +33,11 @@ pytestmark = pytest.mark.skipif(
     reason="E2E_CLERK_SECRET_KEY not set — skipping OAuth WebSocket tests",
 )
 
-RT_TIMEOUT = 10  # slightly more generous than test_45 for OAuth overhead
+# WS round-trip budget under e2e-clerk load (2-worker xdist + Clerk-auth
+# latency). 10s flaked repeatedly (#643); matches test_78's proven 30s
+# budget (#565). These tests only run under e2e-clerk (skipif below), so a
+# single generous constant is correct — no variant branching needed.
+RT_TIMEOUT = 30
 
 
 def _log_latency(label: str, t0: float) -> float:

--- a/e2e/tests/test_48_oauth_reconnect_catchup.py
+++ b/e2e/tests/test_48_oauth_reconnect_catchup.py
@@ -32,7 +32,10 @@ pytestmark = pytest.mark.skipif(
     reason="E2E_CLERK_SECRET_KEY not set — skipping OAuth reconnect tests",
 )
 
-RT_TIMEOUT = 15  # generous for reconnect + catch-up overhead
+# Reconnect + catch-up round-trip budget under e2e-clerk load. 15s flaked
+# (#643); aligned with test_47 + test_78's 30s budget (#565). Clerk-only
+# (skipif below), so one generous constant suffices.
+RT_TIMEOUT = 30
 
 
 def _log_latency(label: str, t0: float) -> float:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.463",
+      version: "0.5.464",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
e2e-clerk has been ~50% red on `main` this morning, blocking merges across the repo (3 consecutive failures on PR #642's runs, all in unrelated tests). This bundles the root-caused stabilizations. Each is a real fix, not a blind rerun.

## #643 — OAuth-WS round-trip budget (primary blocker, 3/3 attempts)
`test_47` (`RT_TIMEOUT=10`) and `test_48` (`15`) timed out on the API→broadcast→channel→plugin-write round-trip under e2e-clerk (2-worker xdist + Clerk-auth latency). Both pass on *some* runs → the broadcast arrives, just sometimes >budget = **latency, not a dropped event**. Raised both to **30s**, matching `test_78`'s proven budget from #565. Both are clerk-only (`skipif E2E_CLERK_SECRET_KEY`), so a single constant is correct.

## #635 — test_24 offline precondition race (reopened; 2/3 attempts)
The test broke out of its wait loop as soon as `queue >= 2`, then **immediately** asserted `get_offline_status()`. But the engine flips `offline` reactively on its health/error path, which lags the queue fill under load — a point-in-time assert on eventually-consistent state. #636 fixed `restore_online`/drain determinism but never touched this precondition. Now **polls for both `offline` AND `queue>=2`** before asserting.

## #428 — qdrant index wait
Worst-case async path (Voyage 429 backoff + Qdrant cold-start + Oban contention) exceeded 60s. Raised to **120s**. Already poll-until-deadline; doesn't mask perf regressions (#259 alarms still fire). Closes #428.

## #576 — fingerprint plugin-SHA curl retries
The resolve curls had no retry; one connection reset cascades the whole pipeline (everything gates on `fingerprint`). Added `--retry 3 --retry-all-errors --retry-delay 2` to all plugin-API GETs + the status POST. Closes #576.

## Verification
This PR's own `e2e-clerk` run is the test — it exercises test_24/47/48 under real load. Python syntax + YAML validated locally.

Closes #428, #576. Refs #643, #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)