### PR TITLE
ci(e2e): reap stale Clerk orphans on every e2e-clerk run (if: always())

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -936,6 +936,26 @@ jobs:
       # ------------------------------------------------------------------
       # Cleanup — MUST kill everything, even on cancel/failure
       # ------------------------------------------------------------------
+      # Reap stale e2e Clerk orphans on EVERY run (not just the throttled
+      # hourly cron, which GitHub fires only ~every 3-5h and a CI burst
+      # outpaces). Runs `if: always()` so it fires even when pytest is
+      # hard-killed before its session_cleanup fixture (helpers/clerk.py
+      # ClerkClient.cleanup_tracked) could delete this run's users. The
+      # `--older-than 1h` age filter protects any concurrent run's in-flight
+      # users — same safety belt the cron uses — so this never races a
+      # sibling. Together: per-run fixture cleanup handles this run's users
+      # immediately; this step + cron mop up crashed-run orphans frequently.
+      - name: Reap stale Clerk orphans (>1h)
+        if: always()
+        env:
+          E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
+        run: |
+          if [ -z "${E2E_CLERK_SECRET_KEY}" ]; then
+            echo "E2E_CLERK_SECRET_KEY not set — skipping orphan reap." >&2
+            exit 0
+          fi
+          python3 e2e/scripts/cleanup_clerk_users.py --older-than 1h || true
+
       - name: Collect failure logs
         if: failure()
         run: |

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.467",
+      version: "0.5.468",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Why

The hourly `clerk-orphans` cron **works** (verified: reaped 63 users at 07:36 today), but GitHub fires the `30 * * * *` schedule only **~every 3-5h** — a CI burst piles e2e orphans past the 100-user cap *between* runs, exhausting the Clerk dev quota and 403'ing every Clerk-auth e2e (today's storm). Per the directive: **don't rely on the cron** — the job should clean up after itself.

## What

Add an `if: always()` teardown step to the **e2e-clerk** job running `cleanup_clerk_users.py --older-than 1h` after the tests.

- **`if: always()`** — fires even when pytest is hard-killed (job timeout / runner eviction) before its `session_cleanup` fixture (the #650 per-run `ClerkClient.cleanup_tracked`) could delete this run's users.
- **`--older-than 1h`** — age filter protects any concurrent run's in-flight users (e2e-clerk has no cross-run concurrency lock); same safety belt the cron uses, so it never races a sibling.

## Layered model (after this + #650)
1. **#650 fixture cleanup** — deletes THIS run's users immediately at session teardown, race-safe via tracked IDs (handles the normal path).
2. **This step** — every e2e-clerk run also reaps orphans >1h old → reaping frequency now tracks CI activity (which is exactly when orphans appear), instead of the throttled hourly cron.
3. **Cron** — final backstop.

Refs #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)