### PR TITLE
fix(test): add getToken to device-link useAuthAdapter mock

### DIFF
--- a/frontend/src/device/device-link-page.test.tsx
+++ b/frontend/src/device/device-link-page.test.tsx
@@ -11,7 +11,15 @@ const { setActiveVaultId } = vi.hoisted(() => ({ setActiveVaultId: vi.fn() }))
 vi.mock('../api/active-vault', () => ({ setActiveVaultId }))
 
 const authState = vi.hoisted(() => ({ current: { isSignedIn: true } as { isSignedIn: boolean } }))
-vi.mock('../auth/use-auth-adapter', () => ({ useAuthAdapter: () => authState.current }))
+// useAuthAdapter must expose getToken: DeviceLinkPage mounts useVaultReadyEvents,
+// whose effect calls `await getToken()`. Without it the fire-and-forget connect()
+// rejects with "getToken is not a function" (an unhandled rejection that fails the
+// run even though assertions pass). Returning null makes connect() early-return —
+// no socket opened in the unit test. Spread authState last so per-test isSignedIn
+// still applies.
+vi.mock('../auth/use-auth-adapter', () => ({
+  useAuthAdapter: () => ({ getToken: () => Promise.resolve(null), ...authState.current }),
+}))
 
 vi.mock('../theme/theme-toggle', () => ({
   default: () => <button type="button">theme</button>,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.468",
+      version: "0.5.469",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

`device-link-page.test.tsx` mocks `useAuthAdapter` with only `{ isSignedIn }`. But `DeviceLinkPage` mounts `useVaultReadyEvents`, whose effect runs a fire-and-forget `async connect()` that calls `await getToken()` (`use-vault-ready-events.ts:41`). With `getToken` absent from the mock, `connect()` rejects with `TypeError: getToken is not a function` — an **unhandled rejection** that makes `vitest run` exit 1 even though every assertion passes.

The mock went stale: `useVaultReadyEvents` was added to `DeviceLinkPage` after the test's mock was written, and the mock was never updated.

This is latent (no blocking CI check runs the frontend unit suite in fail-on-unhandled mode), but it surfaces as 2 unhandled errors / exit 1 on any local full `vitest run`.

## Fix

Inject `getToken` in the mock factory, returning `null`:

```ts
useAuthAdapter: () => ({ getToken: () => Promise.resolve(null), ...authState.current })
```

`null` makes `connect()` hit its `if (!token) return` guard and exit cleanly — no socket opened in the unit test. Spreading `authState.current` last keeps per-test `isSignedIn` working.

## Verification

`vitest run src/device/device-link-page.test.tsx` → 6 passed, **exit 0, no unhandled errors** (was exit 1 with 2 unhandled rejections). `tsc --noEmit` clean.

Found while shipping #647; fixed separately to keep that PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)