### PR TITLE
feat(api-docs): annotate Vaults + Account endpoints

### DIFF
--- a/lib/engram_web/api_spec.ex
+++ b/lib/engram_web/api_spec.ex
@@ -38,7 +38,15 @@ defmodule EngramWeb.ApiSpec do
         %Tag{name: "Notes", description: "Create, read, update, delete, and sync notes."},
         %Tag{name: "Folders", description: "Browse and manage folders."},
         %Tag{name: "Search", description: "Vector, keyword, and hybrid search."},
-        %Tag{name: "Tags", description: "List vault tags."}
+        %Tag{name: "Tags", description: "List vault tags."},
+        %Tag{
+          name: "Vaults",
+          description: "Create, manage, soft-delete, restore, and purge vaults."
+        },
+        %Tag{
+          name: "Account",
+          description: "Current user profile, storage usage, and account deletion."
+        }
       ],
       components: %Components{
         # Engram accepts all credentials on the same `Authorization: Bearer`

--- a/lib/engram_web/controllers/storage_controller.ex
+++ b/lib/engram_web/controllers/storage_controller.ex
@@ -1,5 +1,7 @@
 defmodule EngramWeb.StorageController do
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias EngramWeb.Schemas
 
   alias Engram.Attachments
   alias Engram.Billing
@@ -9,6 +11,12 @@ defmodule EngramWeb.StorageController do
   # unbounded (Billing.effective_limit returns :unlimited).
   @selfhost_max_file_bytes 524_288_000
   @max_storage_bytes 1_073_741_824
+
+  operation(:index,
+    summary: "Get storage usage and caps",
+    tags: ["Account"],
+    responses: [ok: {"Storage usage", "application/json", Schemas.StorageUsage}]
+  )
 
   def index(conn, _params) do
     user = conn.assigns.current_user

--- a/lib/engram_web/controllers/users_controller.ex
+++ b/lib/engram_web/controllers/users_controller.ex
@@ -1,7 +1,15 @@
 defmodule EngramWeb.UsersController do
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias EngramWeb.Schemas
 
   alias Engram.Accounts
+
+  operation(:me,
+    summary: "Get the current user",
+    tags: ["Account"],
+    responses: [ok: {"Current user", "application/json", Schemas.UserResponse}]
+  )
 
   def me(conn, _params) do
     user = conn.assigns.current_user
@@ -15,6 +23,17 @@ defmodule EngramWeb.UsersController do
       }
     })
   end
+
+  operation(:update,
+    summary: "Update the current user's profile",
+    tags: ["Account"],
+    request_body:
+      {"Profile fields", "application/json", Schemas.UpdateProfileRequest, required: true},
+    responses: [
+      ok: {"Updated user", "application/json", Schemas.UserResponse},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.ValidationError}
+    ]
+  )
 
   def update(conn, params) do
     user = conn.assigns.current_user
@@ -44,6 +63,22 @@ defmodule EngramWeb.UsersController do
         |> json(%{error: "validation_failed", details: details})
     end
   end
+
+  operation(:delete,
+    summary: "Delete the current user's account",
+    tags: ["Account"],
+    description: "Irreversible. Requires the account password for confirmation.",
+    request_body:
+      {"Password confirmation", "application/json", Schemas.DeleteAccountRequest, required: true},
+    responses: [
+      ok: {"Account deleted", "application/json", Schemas.OkFlag},
+      bad_request: {"password_required", "application/json", Schemas.MessageError},
+      forbidden: {"invalid_password", "application/json", Schemas.MessageError},
+      conflict:
+        {"last_admin — cannot delete the only admin", "application/json", Schemas.MessageError},
+      unprocessable_entity: {"delete_failed", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def delete(conn, %{"password" => password}) when is_binary(password) do
     user = conn.assigns.current_user

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -1,5 +1,7 @@
 defmodule EngramWeb.VaultsController do
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias EngramWeb.Schemas
 
   alias Engram.Auth.DeviceFlow
   alias Engram.Vaults
@@ -7,6 +9,26 @@ defmodule EngramWeb.VaultsController do
   @zero_counts %{notes: 0, attachments: 0}
 
   # ── index ──────────────────────────────────────────────────────────────────
+
+  operation(:index,
+    summary: "List vaults",
+    tags: ["Vaults"],
+    parameters: [
+      deleted: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Pass \"true\" to list soft-deleted vaults instead of active ones."
+      ],
+      user_code: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Device-link user code; echoes a `suggested_vault_name`."
+      ]
+    ],
+    responses: [ok: {"Vaults", "application/json", Schemas.VaultsResponse}]
+  )
 
   def index(conn, %{"deleted" => "true"}) do
     user = conn.assigns.current_user
@@ -45,6 +67,18 @@ defmodule EngramWeb.VaultsController do
 
   # ── create ─────────────────────────────────────────────────────────────────
 
+  operation(:create,
+    summary: "Create a vault",
+    tags: ["Vaults"],
+    request_body:
+      {"Vault attributes", "application/json", Schemas.CreateVaultRequest, required: true},
+    responses: [
+      created: {"Created", "application/json", Schemas.VaultResponse},
+      payment_required: {"Vault cap reached", "application/json", Schemas.LimitError},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
+    ]
+  )
+
   def create(conn, params) do
     user = conn.assigns.current_user
 
@@ -72,6 +106,16 @@ defmodule EngramWeb.VaultsController do
   end
 
   # ── show ───────────────────────────────────────────────────────────────────
+
+  operation(:show,
+    summary: "Get a vault by id",
+    tags: ["Vaults"],
+    parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
+    responses: [
+      ok: {"Vault", "application/json", Schemas.VaultResponse},
+      not_found: {"No such vault", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def show(conn, %{"id" => id}) do
     user = conn.assigns.current_user
@@ -103,6 +147,19 @@ defmodule EngramWeb.VaultsController do
 
   # ── update ─────────────────────────────────────────────────────────────────
 
+  operation(:update,
+    summary: "Update a vault",
+    tags: ["Vaults"],
+    parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
+    request_body:
+      {"Fields to change", "application/json", Schemas.UpdateVaultRequest, required: true},
+    responses: [
+      ok: {"Updated", "application/json", Schemas.VaultResponse},
+      not_found: {"No such vault", "application/json", Schemas.MessageError},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
+    ]
+  )
+
   def update(conn, %{"id" => id} = params) do
     user = conn.assigns.current_user
     attrs = Map.take(params, ["name", "description", "is_default"])
@@ -129,6 +186,16 @@ defmodule EngramWeb.VaultsController do
 
   # ── delete ─────────────────────────────────────────────────────────────────
 
+  operation(:delete,
+    summary: "Soft-delete a vault",
+    tags: ["Vaults"],
+    parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
+    responses: [
+      ok: {"Soft-deleted (restorable for 30 days)", "application/json", Schemas.VaultDeleted},
+      not_found: {"No such vault", "application/json", Schemas.MessageError}
+    ]
+  )
+
   def delete(conn, %{"id" => id}) do
     user = conn.assigns.current_user
 
@@ -145,6 +212,17 @@ defmodule EngramWeb.VaultsController do
   end
 
   # ── restore ──────────────────────────────────────────────────────────────────
+
+  operation(:restore,
+    summary: "Restore a soft-deleted vault",
+    tags: ["Vaults"],
+    parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
+    responses: [
+      ok: {"Restored", "application/json", Schemas.VaultResponse},
+      payment_required: {"Vault cap reached", "application/json", Schemas.LimitError},
+      not_found: {"No such vault", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def restore(conn, %{"id" => id}) do
     user = conn.assigns.current_user
@@ -176,6 +254,17 @@ defmodule EngramWeb.VaultsController do
 
   # ── purge (immediate hard delete) ──────────────────────────────────────────────
 
+  operation(:purge,
+    summary: "Permanently purge a vault",
+    tags: ["Vaults"],
+    description: "Immediate, irreversible hard delete — skips the 30-day soft-delete window.",
+    parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
+    responses: [
+      ok: {"Purged", "application/json", Schemas.VaultPurged},
+      not_found: {"No such vault", "application/json", Schemas.MessageError}
+    ]
+  )
+
   def purge(conn, %{"id" => id}) do
     user = conn.assigns.current_user
 
@@ -195,6 +284,22 @@ defmodule EngramWeb.VaultsController do
   # encrypted at rest by definition; per-note reads decrypt on demand.
 
   # ── register ───────────────────────────────────────────────────────────────
+
+  operation(:register,
+    summary: "Register or fetch a vault by client_id (idempotent)",
+    tags: ["Vaults"],
+    description:
+      "Used by the plugin on first sync. Returns 201 with `status: created` for a new " <>
+        "vault, or 200 with `status: existing` when the client_id already maps to one.",
+    request_body:
+      {"Name + client_id", "application/json", Schemas.RegisterVaultRequest, required: true},
+    responses: [
+      ok: {"Existing vault", "application/json", Schemas.RegisterVaultResponse},
+      created: {"Newly created vault", "application/json", Schemas.RegisterVaultResponse},
+      bad_request: {"name and client_id are required", "application/json", Schemas.MessageError},
+      payment_required: {"Vault cap reached", "application/json", Schemas.LimitError}
+    ]
+  )
 
   def register(conn, params) do
     user = conn.assigns.current_user

--- a/lib/engram_web/schemas/account.ex
+++ b/lib/engram_web/schemas/account.ex
@@ -1,0 +1,104 @@
+defmodule EngramWeb.Schemas.User do
+  @moduledoc "The authenticated user's profile."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "User",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      email: %Schema{type: :string, format: :email},
+      role: %Schema{type: :string, example: "user"},
+      display_name: %Schema{type: :string, nullable: true}
+    },
+    required: [:id, :email]
+  })
+end
+
+defmodule EngramWeb.Schemas.UserResponse do
+  @moduledoc false
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "UserResponse",
+    type: :object,
+    properties: %{user: EngramWeb.Schemas.User},
+    required: [:user]
+  })
+end
+
+defmodule EngramWeb.Schemas.UpdateProfileRequest do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "UpdateProfileRequest",
+    type: :object,
+    properties: %{display_name: %Schema{type: :string, nullable: true}}
+  })
+end
+
+defmodule EngramWeb.Schemas.DeleteAccountRequest do
+  @moduledoc "Self-serve account deletion requires the account password."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "DeleteAccountRequest",
+    type: :object,
+    properties: %{password: %Schema{type: :string, format: :password}},
+    required: [:password]
+  })
+end
+
+defmodule EngramWeb.Schemas.OkFlag do
+  @moduledoc "Generic success acknowledgement."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "OkFlag",
+    type: :object,
+    properties: %{ok: %Schema{type: :boolean, example: true}},
+    required: [:ok]
+  })
+end
+
+defmodule EngramWeb.Schemas.ValidationError do
+  @moduledoc "422 body carrying a top-level message and a field→messages detail map."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ValidationError",
+    type: :object,
+    properties: %{
+      error: %Schema{type: :string, example: "validation_failed"},
+      details: %Schema{type: :object, description: "field → [messages]"}
+    },
+    required: [:error]
+  })
+end
+
+defmodule EngramWeb.Schemas.StorageUsage do
+  @moduledoc "Per-user attachment storage usage and caps (bytes)."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "StorageUsage",
+    type: :object,
+    properties: %{
+      used_bytes: %Schema{type: :integer},
+      file_count: %Schema{type: :integer},
+      max_bytes: %Schema{type: :integer},
+      max_attachment_bytes: %Schema{
+        type: :integer,
+        description: "Per-file cap for the user's plan."
+      }
+    },
+    required: [:used_bytes, :file_count, :max_bytes, :max_attachment_bytes]
+  })
+end

--- a/lib/engram_web/schemas/common.ex
+++ b/lib/engram_web/schemas/common.ex
@@ -115,3 +115,41 @@ defmodule EngramWeb.Schemas.MovedCount do
     required: [:moved]
   })
 end
+
+defmodule EngramWeb.Schemas.MessageError do
+  @moduledoc "Error body carrying a single machine-readable message under `error`."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "MessageError",
+    type: :object,
+    properties: %{error: %Schema{type: :string, example: "not found"}},
+    required: [:error]
+  })
+end
+
+defmodule EngramWeb.Schemas.LimitError do
+  @moduledoc "402 plan-limit body emitted by EngramWeb.LimitResponse."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "LimitError",
+    type: :object,
+    properties: %{
+      error: %Schema{type: :string, example: "limit_exceeded"},
+      reason: %Schema{type: :string, example: "vaults_cap_exceeded"},
+      tier: %Schema{type: :string, nullable: true, example: "free"},
+      limit_key: %Schema{type: :string, nullable: true, example: "vaults_cap"},
+      limit: %Schema{
+        nullable: true,
+        description: "Integer or boolean cap.",
+        oneOf: [%Schema{type: :integer}, %Schema{type: :boolean}]
+      },
+      current: %Schema{type: :integer, nullable: true},
+      upgrade_url: %Schema{type: :string, nullable: true}
+    },
+    required: [:error, :reason]
+  })
+end

--- a/lib/engram_web/schemas/vaults.ex
+++ b/lib/engram_web/schemas/vaults.ex
@@ -1,0 +1,163 @@
+defmodule EngramWeb.Schemas.Vault do
+  @moduledoc "A vault. `deleted_at`/`purge_at` are non-null only for soft-deleted vaults."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "Vault",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      name: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
+      slug: %Schema{type: :string, nullable: true},
+      is_default: %Schema{type: :boolean},
+      created_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      encrypted: %Schema{
+        type: :boolean,
+        description: "Always true — vaults are encrypted at rest."
+      },
+      note_count: %Schema{type: :integer},
+      attachment_count: %Schema{type: :integer},
+      deleted_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      purge_at: %Schema{
+        type: :string,
+        format: :"date-time",
+        nullable: true,
+        description: "When a soft-deleted vault is hard-purged (deleted_at + 30d)."
+      }
+    },
+    required: [:id, :name]
+  })
+end
+
+defmodule EngramWeb.Schemas.VaultResponse do
+  @moduledoc false
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "VaultResponse",
+    type: :object,
+    properties: %{vault: EngramWeb.Schemas.Vault},
+    required: [:vault]
+  })
+end
+
+defmodule EngramWeb.Schemas.VaultsResponse do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "VaultsResponse",
+    type: :object,
+    properties: %{
+      vaults: %Schema{type: :array, items: EngramWeb.Schemas.Vault},
+      suggested_vault_name: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Present only when a `user_code` query param is supplied (device-link flow)."
+      }
+    },
+    required: [:vaults]
+  })
+end
+
+defmodule EngramWeb.Schemas.CreateVaultRequest do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "CreateVaultRequest",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
+      is_default: %Schema{type: :boolean}
+    },
+    required: [:name]
+  })
+end
+
+defmodule EngramWeb.Schemas.UpdateVaultRequest do
+  @moduledoc "Partial update — only supplied fields change."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "UpdateVaultRequest",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string},
+      description: %Schema{type: :string, nullable: true},
+      is_default: %Schema{type: :boolean}
+    }
+  })
+end
+
+defmodule EngramWeb.Schemas.RegisterVaultRequest do
+  @moduledoc "Idempotent register-or-fetch by client_id (plugin first-sync)."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "RegisterVaultRequest",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string},
+      client_id: %Schema{type: :string, description: "Client-generated stable vault id."}
+    },
+    required: [:name, :client_id]
+  })
+end
+
+defmodule EngramWeb.Schemas.RegisterVaultResponse do
+  @moduledoc "A Vault plus a `status` discriminating a fresh create (201) from an existing match (200)."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "RegisterVaultResponse",
+    type: :object,
+    allOf: [
+      EngramWeb.Schemas.Vault,
+      %Schema{
+        type: :object,
+        properties: %{status: %Schema{type: :string, enum: ["created", "existing"]}}
+      }
+    ]
+  })
+end
+
+defmodule EngramWeb.Schemas.VaultDeleted do
+  @moduledoc "Soft-delete acknowledgement."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "VaultDeleted",
+    type: :object,
+    properties: %{
+      deleted: %Schema{type: :boolean, example: true},
+      id: %Schema{type: :string, format: :uuid}
+    },
+    required: [:deleted, :id]
+  })
+end
+
+defmodule EngramWeb.Schemas.VaultPurged do
+  @moduledoc "Hard-purge acknowledgement."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "VaultPurged",
+    type: :object,
+    properties: %{
+      purged: %Schema{type: :boolean, example: true},
+      id: %Schema{type: :string, format: :uuid}
+    },
+    required: [:purged, :id]
+  })
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.474",
+      version: "0.5.475",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -354,6 +354,37 @@
         "x-struct": "Elixir.EngramWeb.Schemas.ChangesResponse",
         "x-validate": null
       },
+      "UpdateProfileRequest": {
+        "properties": {
+          "display_name": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "UpdateProfileRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.UpdateProfileRequest",
+        "x-validate": null
+      },
+      "MessageError": {
+        "properties": {
+          "error": {
+            "example": "not found",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "title": "MessageError",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.MessageError",
+        "x-validate": null
+      },
       "SearchRequest": {
         "properties": {
           "cross_vault": {
@@ -405,6 +436,29 @@
         "title": "SearchRequest",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.SearchRequest",
+        "x-validate": null
+      },
+      "RegisterVaultRequest": {
+        "properties": {
+          "client_id": {
+            "description": "Client-generated stable vault id.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "name",
+          "client_id"
+        ],
+        "title": "RegisterVaultRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.RegisterVaultRequest",
         "x-validate": null
       },
       "AppendRequest": {
@@ -498,6 +552,98 @@
         "x-struct": "Elixir.EngramWeb.Schemas.FolderNamesResponse",
         "x-validate": null
       },
+      "UpdateVaultRequest": {
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "is_default": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "UpdateVaultRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.UpdateVaultRequest",
+        "x-validate": null
+      },
+      "LimitError": {
+        "properties": {
+          "current": {
+            "nullable": true,
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "error": {
+            "example": "limit_exceeded",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "limit": {
+            "description": "Integer or boolean cap.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "type": "integer",
+                "x-struct": null,
+                "x-validate": null
+              },
+              {
+                "type": "boolean",
+                "x-struct": null,
+                "x-validate": null
+              }
+            ],
+            "x-struct": null,
+            "x-validate": null
+          },
+          "limit_key": {
+            "example": "vaults_cap",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "reason": {
+            "example": "vaults_cap_exceeded",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "tier": {
+            "example": "free",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "upgrade_url": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "error",
+          "reason"
+        ],
+        "title": "LimitError",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.LimitError",
+        "x-validate": null
+      },
       "SearchResponse": {
         "properties": {
           "results": {
@@ -531,6 +677,109 @@
         "x-struct": "Elixir.EngramWeb.Schemas.FolderResponse",
         "x-validate": null
       },
+      "VaultsResponse": {
+        "properties": {
+          "suggested_vault_name": {
+            "description": "Present only when a `user_code` query param is supplied (device-link flow).",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "vaults": {
+            "items": {
+              "$ref": "#/components/schemas/Vault"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "vaults"
+        ],
+        "title": "VaultsResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.VaultsResponse",
+        "x-validate": null
+      },
+      "VaultResponse": {
+        "properties": {
+          "vault": {
+            "$ref": "#/components/schemas/Vault"
+          }
+        },
+        "required": [
+          "vault"
+        ],
+        "title": "VaultResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.VaultResponse",
+        "x-validate": null
+      },
+      "User": {
+        "properties": {
+          "display_name": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "email": {
+            "format": "email",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "role": {
+            "example": "user",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "email"
+        ],
+        "title": "User",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.User",
+        "x-validate": null
+      },
+      "RegisterVaultResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Vault"
+          },
+          {
+            "properties": {
+              "status": {
+                "enum": [
+                  "created",
+                  "existing"
+                ],
+                "type": "string",
+                "x-struct": null,
+                "x-validate": null
+              }
+            },
+            "type": "object",
+            "x-struct": null,
+            "x-validate": null
+          }
+        ],
+        "title": "RegisterVaultResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.RegisterVaultResponse",
+        "x-validate": null
+      },
       "BatchIdsRequest": {
         "properties": {
           "ids": {
@@ -553,6 +802,118 @@
         "x-struct": "Elixir.EngramWeb.Schemas.BatchIdsRequest",
         "x-validate": null
       },
+      "OkFlag": {
+        "properties": {
+          "ok": {
+            "example": true,
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "OkFlag",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.OkFlag",
+        "x-validate": null
+      },
+      "DeleteAccountRequest": {
+        "properties": {
+          "password": {
+            "format": "password",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "password"
+        ],
+        "title": "DeleteAccountRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.DeleteAccountRequest",
+        "x-validate": null
+      },
+      "Vault": {
+        "properties": {
+          "attachment_count": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "created_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "deleted_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "description": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "encrypted": {
+            "description": "Always true — vaults are encrypted at rest.",
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "is_default": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "note_count": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "purge_at": {
+            "description": "When a soft-deleted vault is hard-purged (deleted_at + 30d).",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "slug": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "Vault",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.Vault",
+        "x-validate": null
+      },
       "CreateFolderRequest": {
         "properties": {
           "folder": {
@@ -567,6 +928,29 @@
         "title": "CreateFolderRequest",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.CreateFolderRequest",
+        "x-validate": null
+      },
+      "ValidationError": {
+        "properties": {
+          "details": {
+            "description": "field → [messages]",
+            "type": "object",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "error": {
+            "example": "validation_failed",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "title": "ValidationError",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.ValidationError",
         "x-validate": null
       },
       "DeletedCount": {
@@ -718,6 +1102,33 @@
         "x-struct": "Elixir.EngramWeb.Schemas.Conflict",
         "x-validate": null
       },
+      "CreateVaultRequest": {
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "is_default": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "CreateVaultRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.CreateVaultRequest",
+        "x-validate": null
+      },
       "DeletedFlag": {
         "properties": {
           "deleted": {
@@ -817,6 +1228,41 @@
         "x-struct": "Elixir.EngramWeb.Schemas.RenameNoteResponse",
         "x-validate": null
       },
+      "StorageUsage": {
+        "properties": {
+          "file_count": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "max_attachment_bytes": {
+            "description": "Per-file cap for the user's plan.",
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "max_bytes": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "used_bytes": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "used_bytes",
+          "file_count",
+          "max_bytes",
+          "max_attachment_bytes"
+        ],
+        "title": "StorageUsage",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.StorageUsage",
+        "x-validate": null
+      },
       "FolderNotesResponse": {
         "properties": {
           "notes": {
@@ -857,6 +1303,20 @@
         "x-struct": "Elixir.EngramWeb.Schemas.AppendResponse",
         "x-validate": null
       },
+      "UserResponse": {
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "title": "UserResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.UserResponse",
+        "x-validate": null
+      },
       "FolderRenameResponse": {
         "properties": {
           "count": {
@@ -883,6 +1343,30 @@
         "title": "FolderRenameResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.FolderRenameResponse",
+        "x-validate": null
+      },
+      "VaultPurged": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "purged": {
+            "example": true,
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "purged",
+          "id"
+        ],
+        "title": "VaultPurged",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.VaultPurged",
         "x-validate": null
       },
       "Error": {
@@ -968,6 +1452,30 @@
         "title": "BatchUpsertResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.BatchUpsertResponse",
+        "x-validate": null
+      },
+      "VaultDeleted": {
+        "properties": {
+          "deleted": {
+            "example": true,
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "deleted",
+          "id"
+        ],
+        "title": "VaultDeleted",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.VaultDeleted",
         "x-validate": null
       },
       "BatchMoveNotesRequest": {
@@ -1468,6 +1976,144 @@
         "security": [],
         "summary": "Readiness probe",
         "tags": []
+      }
+    },
+    "/api/me": {
+      "delete": {
+        "callbacks": {},
+        "description": "Irreversible. Requires the account password for confirmation.",
+        "operationId": "EngramWeb.UsersController.delete",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAccountRequest"
+              }
+            }
+          },
+          "description": "Password confirmation",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkFlag"
+                }
+              }
+            },
+            "description": "Account deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "password_required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "invalid_password"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "last_admin — cannot delete the only admin"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "delete_failed"
+          }
+        },
+        "summary": "Delete the current user's account",
+        "tags": [
+          "Account"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "operationId": "EngramWeb.UsersController.me",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            },
+            "description": "Current user"
+          }
+        },
+        "summary": "Get the current user",
+        "tags": [
+          "Account"
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "operationId": "EngramWeb.UsersController.update",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProfileRequest"
+              }
+            }
+          },
+          "description": "Profile fields",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            },
+            "description": "Updated user"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            },
+            "description": "Validation error"
+          }
+        },
+        "summary": "Update the current user's profile",
+        "tags": [
+          "Account"
+        ]
       }
     },
     "/api/notes": {
@@ -2144,6 +2790,445 @@
           "Tags"
         ]
       }
+    },
+    "/api/user/storage": {
+      "get": {
+        "callbacks": {},
+        "operationId": "EngramWeb.StorageController.index",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StorageUsage"
+                }
+              }
+            },
+            "description": "Storage usage"
+          }
+        },
+        "summary": "Get storage usage and caps",
+        "tags": [
+          "Account"
+        ]
+      }
+    },
+    "/api/vaults": {
+      "get": {
+        "callbacks": {},
+        "operationId": "EngramWeb.VaultsController.index",
+        "parameters": [
+          {
+            "description": "Pass \"true\" to list soft-deleted vaults instead of active ones.",
+            "in": "query",
+            "name": "deleted",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Device-link user code; echoes a `suggested_vault_name`.",
+            "in": "query",
+            "name": "user_code",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultsResponse"
+                }
+              }
+            },
+            "description": "Vaults"
+          }
+        },
+        "summary": "List vaults",
+        "tags": [
+          "Vaults"
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "operationId": "EngramWeb.VaultsController.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVaultRequest"
+              }
+            }
+          },
+          "description": "Vault attributes",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LimitError"
+                }
+              }
+            },
+            "description": "Vault cap reached"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Validation error"
+          }
+        },
+        "summary": "Create a vault",
+        "tags": [
+          "Vaults"
+        ]
+      }
+    },
+    "/api/vaults/register": {
+      "post": {
+        "callbacks": {},
+        "description": "Used by the plugin on first sync. Returns 201 with `status: created` for a new vault, or 200 with `status: existing` when the client_id already maps to one.",
+        "operationId": "EngramWeb.VaultsController.register",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterVaultRequest"
+              }
+            }
+          },
+          "description": "Name + client_id",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterVaultResponse"
+                }
+              }
+            },
+            "description": "Existing vault"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterVaultResponse"
+                }
+              }
+            },
+            "description": "Newly created vault"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "name and client_id are required"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LimitError"
+                }
+              }
+            },
+            "description": "Vault cap reached"
+          }
+        },
+        "summary": "Register or fetch a vault by client_id (idempotent)",
+        "tags": [
+          "Vaults"
+        ]
+      }
+    },
+    "/api/vaults/{id}": {
+      "delete": {
+        "callbacks": {},
+        "operationId": "EngramWeb.VaultsController.delete",
+        "parameters": [
+          {
+            "description": "Vault UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultDeleted"
+                }
+              }
+            },
+            "description": "Soft-deleted (restorable for 30 days)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such vault"
+          }
+        },
+        "summary": "Soft-delete a vault",
+        "tags": [
+          "Vaults"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "operationId": "EngramWeb.VaultsController.show",
+        "parameters": [
+          {
+            "description": "Vault UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultResponse"
+                }
+              }
+            },
+            "description": "Vault"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such vault"
+          }
+        },
+        "summary": "Get a vault by id",
+        "tags": [
+          "Vaults"
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "operationId": "EngramWeb.VaultsController.update",
+        "parameters": [
+          {
+            "description": "Vault UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateVaultRequest"
+              }
+            }
+          },
+          "description": "Fields to change",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultResponse"
+                }
+              }
+            },
+            "description": "Updated"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such vault"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Validation error"
+          }
+        },
+        "summary": "Update a vault",
+        "tags": [
+          "Vaults"
+        ]
+      }
+    },
+    "/api/vaults/{id}/purge": {
+      "post": {
+        "callbacks": {},
+        "description": "Immediate, irreversible hard delete — skips the 30-day soft-delete window.",
+        "operationId": "EngramWeb.VaultsController.purge",
+        "parameters": [
+          {
+            "description": "Vault UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultPurged"
+                }
+              }
+            },
+            "description": "Purged"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such vault"
+          }
+        },
+        "summary": "Permanently purge a vault",
+        "tags": [
+          "Vaults"
+        ]
+      }
+    },
+    "/api/vaults/{id}/restore": {
+      "post": {
+        "callbacks": {},
+        "operationId": "EngramWeb.VaultsController.restore",
+        "parameters": [
+          {
+            "description": "Vault UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultResponse"
+                }
+              }
+            },
+            "description": "Restored"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LimitError"
+                }
+              }
+            },
+            "description": "Vault cap reached"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such vault"
+          }
+        },
+        "summary": "Restore a soft-deleted vault",
+        "tags": [
+          "Vaults"
+        ]
+      }
     }
   },
   "security": [
@@ -2174,6 +3259,14 @@
     {
       "description": "List vault tags.",
       "name": "Tags"
+    },
+    {
+      "description": "Create, manage, soft-delete, restore, and purge vaults.",
+      "name": "Vaults"
+    },
+    {
+      "description": "Current user profile, storage usage, and account deletion.",
+      "name": "Account"
     }
   ]
 }

--- a/test/engram_web/api_spec_test.exs
+++ b/test/engram_web/api_spec_test.exs
@@ -138,4 +138,83 @@ defmodule EngramWeb.ApiSpecTest do
       assert Map.has_key?(op.responses, 200)
     end
   end
+
+  describe "Vaults paths" do
+    setup do: %{spec: EngramWeb.ApiSpec.spec()}
+
+    test "declares Vaults + Account tags", %{spec: spec} do
+      names = Enum.map(spec.tags, & &1.name)
+      assert "Vaults" in names and "Account" in names
+    end
+
+    test "GET /api/vaults documents deleted + user_code query params", %{spec: spec} do
+      op = spec.paths["/api/vaults"].get
+      assert op.tags == ["Vaults"]
+      names = Enum.map(op.parameters, & &1.name)
+      assert :deleted in names and :user_code in names
+      assert Map.has_key?(op.responses, 200)
+    end
+
+    test "POST /api/vaults documents request + 201/402/422", %{spec: spec} do
+      op = spec.paths["/api/vaults"].post
+      assert op.tags == ["Vaults"]
+      assert op.requestBody
+      assert Enum.sort(Map.keys(op.responses)) == [201, 402, 422]
+    end
+
+    test "POST /api/vaults/register documents request + 200/201/400/402", %{spec: spec} do
+      op = spec.paths["/api/vaults/register"].post
+      assert op.requestBody
+      assert Enum.sort(Map.keys(op.responses)) == [200, 201, 400, 402]
+    end
+
+    test "GET /api/vaults/{id} documents id path param + 404", %{spec: spec} do
+      op = spec.paths["/api/vaults/{id}"].get
+      assert Enum.any?(op.parameters, &(&1.name == :id and &1.in == :path and &1.required))
+      assert Map.has_key?(op.responses, 200) and Map.has_key?(op.responses, 404)
+    end
+
+    test "DELETE /api/vaults/{id} documents 200/404", %{spec: spec} do
+      op = spec.paths["/api/vaults/{id}"].delete
+      assert Map.has_key?(op.responses, 200) and Map.has_key?(op.responses, 404)
+    end
+
+    test "POST /api/vaults/{id}/restore documents 200/402/404", %{spec: spec} do
+      op = spec.paths["/api/vaults/{id}/restore"].post
+      assert Enum.sort(Map.keys(op.responses)) == [200, 402, 404]
+    end
+
+    test "POST /api/vaults/{id}/purge documents 200/404", %{spec: spec} do
+      op = spec.paths["/api/vaults/{id}/purge"].post
+      assert Enum.sort(Map.keys(op.responses)) == [200, 404]
+    end
+  end
+
+  describe "Account paths" do
+    setup do: %{spec: EngramWeb.ApiSpec.spec()}
+
+    test "GET /api/me returns the current user", %{spec: spec} do
+      op = spec.paths["/api/me"].get
+      assert op.tags == ["Account"]
+      assert Map.has_key?(op.responses, 200)
+    end
+
+    test "PATCH /api/me documents request + 200/422", %{spec: spec} do
+      op = spec.paths["/api/me"].patch
+      assert op.requestBody
+      assert Enum.sort(Map.keys(op.responses)) == [200, 422]
+    end
+
+    test "DELETE /api/me documents request + 200/400/403/409/422", %{spec: spec} do
+      op = spec.paths["/api/me"].delete
+      assert op.requestBody
+      assert Enum.sort(Map.keys(op.responses)) == [200, 400, 403, 409, 422]
+    end
+
+    test "GET /api/user/storage documents 200", %{spec: spec} do
+      op = spec.paths["/api/user/storage"].get
+      assert op.tags == ["Account"]
+      assert Map.has_key?(op.responses, 200)
+    end
+  end
 end


### PR DESCRIPTION
Second annotation batch on top of the now-merged OpenAPI pipeline (#657). Annotates **12 endpoints** with full OpenApiSpex specs — request bodies, path/query params, response schemas, and the real per-endpoint error codes — plus two new sidebar tags.

### Endpoints
- **Vaults** (`VaultsController`): `index`, `register`, `create`, `show`, `update`, `delete`, `restore`, `purge`
- **Account** (`UsersController` + `StorageController`): `GET/PATCH/DELETE /api/me`, `GET /api/user/storage`

### Schemas
- New `lib/engram_web/schemas/vaults.ex` and `schemas/account.ex`
- Shared additions to `schemas/common.ex`: `MessageError` (`{error}` bodies) and `LimitError` (the 402 `EngramWeb.LimitResponse` shape — reusable by the Billing batch next)

### Notes
- `RegisterVaultResponse` uses `allOf: [Vault, {status}]` to model the flat `vault_json + status` body (200 existing / 201 created).
- `Vault.deleted_at`/`purge_at` are nullable — non-null only on the `?deleted=true` listing.
- Regenerated `openapi.json` is in sync (CI drift gate normalizes sorted-key JSON). Verified locally: 28 paths, 51 schemas.
- One version bump (0.5.474 → 0.5.475).

On merge, the #653 sync workflow auto-opens the marketing PR. Operation-slug cleanup (`operation_id:` for prettier `/operations/...` URLs across all controllers) is tracked as a separate follow-up sweep.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>