### PR TITLE
chore(api-docs): slug-clean operationIds for readable doc URLs

### DIFF
--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -6,6 +6,7 @@ defmodule EngramWeb.FoldersController do
   alias EngramWeb.Schemas
 
   operation(:index,
+    operation_id: "folders-index",
     summary: "List folders",
     tags: ["Folders"],
     responses: [ok: {"Folders", "application/json", Schemas.FoldersResponse}]
@@ -51,6 +52,7 @@ defmodule EngramWeb.FoldersController do
   end
 
   operation(:explicit,
+    operation_id: "folders-explicit",
     summary: "List explicitly-created (empty-capable) folders",
     tags: ["Folders"],
     responses: [ok: {"Folder names", "application/json", Schemas.FolderNamesResponse}]
@@ -64,6 +66,7 @@ defmodule EngramWeb.FoldersController do
   end
 
   operation(:list,
+    operation_id: "folders-list",
     summary: "List notes in a folder (metadata only)",
     tags: ["Folders"],
     parameters: [folder: [in: :query, type: :string, required: true, description: "Folder path"]],
@@ -89,6 +92,7 @@ defmodule EngramWeb.FoldersController do
   end
 
   operation(:list_notes,
+    operation_id: "folders-list-notes",
     summary: "List notes in a folder by id (metadata only)",
     tags: ["Folders"],
     parameters: [id: [in: :path, type: :string, required: true, description: "Folder UUID"]],
@@ -115,6 +119,7 @@ defmodule EngramWeb.FoldersController do
   end
 
   operation(:create,
+    operation_id: "folders-create",
     summary: "Create a folder",
     tags: ["Folders"],
     request_body:
@@ -152,6 +157,7 @@ defmodule EngramWeb.FoldersController do
   end
 
   operation(:delete,
+    operation_id: "folders-delete",
     summary: "Delete a folder by path",
     tags: ["Folders"],
     parameters: [path: [in: :path, type: :string, required: true, description: "Folder path"]],
@@ -179,6 +185,7 @@ defmodule EngramWeb.FoldersController do
   end
 
   operation(:rename,
+    operation_id: "folders-rename",
     summary: "Rename / move a folder",
     tags: ["Folders"],
     request_body: {"Old + new path", "application/json", Schemas.RenameRequest, required: true},
@@ -221,6 +228,7 @@ defmodule EngramWeb.FoldersController do
   # follow-up (after-commit hook).
 
   operation(:batch_delete,
+    operation_id: "folders-batch-delete",
     summary: "Delete folders by id (idempotent)",
     tags: ["Folders"],
     request_body: {"Folder ids", "application/json", Schemas.BatchIdsRequest, required: true},
@@ -265,6 +273,7 @@ defmodule EngramWeb.FoldersController do
   end
 
   operation(:batch_move,
+    operation_id: "folders-batch-move",
     summary: "Move folders under a new parent (idempotent)",
     tags: ["Folders"],
     request_body:

--- a/lib/engram_web/controllers/health_controller.ex
+++ b/lib/engram_web/controllers/health_controller.ex
@@ -5,6 +5,7 @@ defmodule EngramWeb.HealthController do
   alias EngramWeb.Schemas.HealthStatus
 
   operation(:index,
+    operation_id: "health",
     summary: "Liveness probe",
     security: [],
     description: "Cheap liveness check. Always 200 if the app is up.",
@@ -18,6 +19,7 @@ defmodule EngramWeb.HealthController do
   end
 
   operation(:deep,
+    operation_id: "health-deep",
     summary: "Readiness probe",
     security: [],
     description:

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -8,6 +8,7 @@ defmodule EngramWeb.NotesController do
   @max_note_bytes 10 * 1024 * 1024
 
   operation(:upsert,
+    operation_id: "notes-upsert",
     summary: "Create or update a note",
     tags: ["Notes"],
     request_body:
@@ -76,6 +77,7 @@ defmodule EngramWeb.NotesController do
   end
 
   operation(:append,
+    operation_id: "notes-append",
     summary: "Append text to a note (creating it if absent)",
     tags: ["Notes"],
     request_body: {"Path + text", "application/json", Schemas.AppendRequest, required: true},
@@ -126,6 +128,7 @@ defmodule EngramWeb.NotesController do
   end
 
   operation(:show,
+    operation_id: "notes-show",
     summary: "Get a note by path",
     tags: ["Notes"],
     parameters: [
@@ -149,6 +152,7 @@ defmodule EngramWeb.NotesController do
   end
 
   operation(:rename,
+    operation_id: "notes-rename",
     summary: "Rename / move a note",
     tags: ["Notes"],
     request_body: {"Old + new path", "application/json", Schemas.RenameRequest, required: true},
@@ -176,6 +180,7 @@ defmodule EngramWeb.NotesController do
   end
 
   operation(:delete,
+    operation_id: "notes-delete",
     summary: "Delete a note by path",
     tags: ["Notes"],
     parameters: [path: [in: :path, type: :string, required: true, description: "Note path"]],
@@ -191,6 +196,7 @@ defmodule EngramWeb.NotesController do
   end
 
   operation(:show_by_id,
+    operation_id: "notes-show-by-id",
     summary: "Get a note by id",
     tags: ["Notes"],
     parameters: [id: [in: :path, type: :string, required: true, description: "Note UUID"]],
@@ -215,6 +221,7 @@ defmodule EngramWeb.NotesController do
   end
 
   operation(:delete_by_id,
+    operation_id: "notes-delete-by-id",
     summary: "Delete a note by id",
     tags: ["Notes"],
     parameters: [id: [in: :path, type: :string, required: true, description: "Note UUID"]],
@@ -239,6 +246,7 @@ defmodule EngramWeb.NotesController do
   end
 
   operation(:changes,
+    operation_id: "notes-changes",
     summary: "List note changes since a cursor (keyset pagination)",
     tags: ["Notes"],
     parameters: [
@@ -364,6 +372,7 @@ defmodule EngramWeb.NotesController do
   @batch_upsert_max 100
 
   operation(:batch_upsert,
+    operation_id: "notes-batch-upsert",
     summary: "Upsert up to 100 notes (idempotent via X-Idempotency-Key)",
     tags: ["Notes"],
     request_body: {"Notes array", "application/json", Schemas.BatchUpsertRequest, required: true},
@@ -462,6 +471,7 @@ defmodule EngramWeb.NotesController do
   defp batch_errors_json(other), do: other
 
   operation(:batch_delete,
+    operation_id: "notes-batch-delete",
     summary: "Delete notes by id (idempotent)",
     tags: ["Notes"],
     request_body: {"Note ids", "application/json", Schemas.BatchIdsRequest, required: true},
@@ -506,6 +516,7 @@ defmodule EngramWeb.NotesController do
   end
 
   operation(:batch_move,
+    operation_id: "notes-batch-move",
     summary: "Move notes to a folder (idempotent)",
     tags: ["Notes"],
     request_body:

--- a/lib/engram_web/controllers/search_controller.ex
+++ b/lib/engram_web/controllers/search_controller.ex
@@ -16,6 +16,7 @@ defmodule EngramWeb.SearchController do
   @min_overfetch 20
 
   operation(:search,
+    operation_id: "search",
     summary: "Search notes (vector / keyword / hybrid)",
     tags: ["Search"],
     request_body: {"Search query", "application/json", Schemas.SearchRequest, required: true},

--- a/lib/engram_web/controllers/storage_controller.ex
+++ b/lib/engram_web/controllers/storage_controller.ex
@@ -13,6 +13,7 @@ defmodule EngramWeb.StorageController do
   @max_storage_bytes 1_073_741_824
 
   operation(:index,
+    operation_id: "account-storage",
     summary: "Get storage usage and caps",
     tags: ["Account"],
     responses: [ok: {"Storage usage", "application/json", Schemas.StorageUsage}]

--- a/lib/engram_web/controllers/tags_controller.ex
+++ b/lib/engram_web/controllers/tags_controller.ex
@@ -6,6 +6,7 @@ defmodule EngramWeb.TagsController do
   alias Engram.Notes
 
   operation(:index,
+    operation_id: "tags",
     summary: "List all tags in the vault",
     tags: ["Tags"],
     responses: [ok: {"Tags", "application/json", Schemas.TagsResponse}]

--- a/lib/engram_web/controllers/users_controller.ex
+++ b/lib/engram_web/controllers/users_controller.ex
@@ -6,6 +6,7 @@ defmodule EngramWeb.UsersController do
   alias Engram.Accounts
 
   operation(:me,
+    operation_id: "account-me",
     summary: "Get the current user",
     tags: ["Account"],
     responses: [ok: {"Current user", "application/json", Schemas.UserResponse}]
@@ -25,6 +26,7 @@ defmodule EngramWeb.UsersController do
   end
 
   operation(:update,
+    operation_id: "account-update",
     summary: "Update the current user's profile",
     tags: ["Account"],
     request_body:
@@ -65,6 +67,7 @@ defmodule EngramWeb.UsersController do
   end
 
   operation(:delete,
+    operation_id: "account-delete",
     summary: "Delete the current user's account",
     tags: ["Account"],
     description: "Irreversible. Requires the account password for confirmation.",

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -11,6 +11,7 @@ defmodule EngramWeb.VaultsController do
   # ── index ──────────────────────────────────────────────────────────────────
 
   operation(:index,
+    operation_id: "vaults-index",
     summary: "List vaults",
     tags: ["Vaults"],
     parameters: [
@@ -68,6 +69,7 @@ defmodule EngramWeb.VaultsController do
   # ── create ─────────────────────────────────────────────────────────────────
 
   operation(:create,
+    operation_id: "vaults-create",
     summary: "Create a vault",
     tags: ["Vaults"],
     request_body:
@@ -108,6 +110,7 @@ defmodule EngramWeb.VaultsController do
   # ── show ───────────────────────────────────────────────────────────────────
 
   operation(:show,
+    operation_id: "vaults-show",
     summary: "Get a vault by id",
     tags: ["Vaults"],
     parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
@@ -148,6 +151,7 @@ defmodule EngramWeb.VaultsController do
   # ── update ─────────────────────────────────────────────────────────────────
 
   operation(:update,
+    operation_id: "vaults-update",
     summary: "Update a vault",
     tags: ["Vaults"],
     parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
@@ -187,6 +191,7 @@ defmodule EngramWeb.VaultsController do
   # ── delete ─────────────────────────────────────────────────────────────────
 
   operation(:delete,
+    operation_id: "vaults-delete",
     summary: "Soft-delete a vault",
     tags: ["Vaults"],
     parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
@@ -214,6 +219,7 @@ defmodule EngramWeb.VaultsController do
   # ── restore ──────────────────────────────────────────────────────────────────
 
   operation(:restore,
+    operation_id: "vaults-restore",
     summary: "Restore a soft-deleted vault",
     tags: ["Vaults"],
     parameters: [id: [in: :path, type: :string, required: true, description: "Vault UUID"]],
@@ -255,6 +261,7 @@ defmodule EngramWeb.VaultsController do
   # ── purge (immediate hard delete) ──────────────────────────────────────────────
 
   operation(:purge,
+    operation_id: "vaults-purge",
     summary: "Permanently purge a vault",
     tags: ["Vaults"],
     description: "Immediate, irreversible hard delete — skips the 30-day soft-delete window.",
@@ -286,6 +293,7 @@ defmodule EngramWeb.VaultsController do
   # ── register ───────────────────────────────────────────────────────────────
 
   operation(:register,
+    operation_id: "vaults-register",
     summary: "Register or fetch a vault by client_id (idempotent)",
     tags: ["Vaults"],
     description:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.475",
+      version: "0.5.476",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -1527,7 +1527,7 @@
     "/api/folders": {
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.index",
+        "operationId": "folders-index",
         "parameters": [],
         "responses": {
           "200": {
@@ -1548,7 +1548,7 @@
       },
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.create",
+        "operationId": "folders-create",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -1592,7 +1592,7 @@
     "/api/folders/*path": {
       "delete": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.delete",
+        "operationId": "folders-delete",
         "parameters": [
           {
             "description": "Folder path",
@@ -1620,7 +1620,7 @@
     "/api/folders/batch-delete": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.batch_delete",
+        "operationId": "folders-batch-delete",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -1684,7 +1684,7 @@
     "/api/folders/batch-move": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.batch_move",
+        "operationId": "folders-batch-move",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -1748,7 +1748,7 @@
     "/api/folders/by-id/{id}/notes": {
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.list_notes",
+        "operationId": "folders-list-notes",
         "parameters": [
           {
             "description": "Folder UUID",
@@ -1803,7 +1803,7 @@
     "/api/folders/explicit": {
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.explicit",
+        "operationId": "folders-explicit",
         "parameters": [],
         "responses": {
           "200": {
@@ -1826,7 +1826,7 @@
     "/api/folders/list": {
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.list",
+        "operationId": "folders-list",
         "parameters": [
           {
             "description": "Folder path",
@@ -1871,7 +1871,7 @@
     "/api/folders/rename": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.FoldersController.rename",
+        "operationId": "folders-rename",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -1926,7 +1926,7 @@
       "get": {
         "callbacks": {},
         "description": "Cheap liveness check. Always 200 if the app is up.",
-        "operationId": "EngramWeb.HealthController.index",
+        "operationId": "health",
         "parameters": [],
         "responses": {
           "200": {
@@ -1949,7 +1949,7 @@
       "get": {
         "callbacks": {},
         "description": "Checks dependencies whose absence fails every request (Postgres). 503 when degraded.",
-        "operationId": "EngramWeb.HealthController.deep",
+        "operationId": "health-deep",
         "parameters": [],
         "responses": {
           "200": {
@@ -1982,7 +1982,7 @@
       "delete": {
         "callbacks": {},
         "description": "Irreversible. Requires the account password for confirmation.",
-        "operationId": "EngramWeb.UsersController.delete",
+        "operationId": "account-delete",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2054,7 +2054,7 @@
       },
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.UsersController.me",
+        "operationId": "account-me",
         "parameters": [],
         "responses": {
           "200": {
@@ -2075,7 +2075,7 @@
       },
       "patch": {
         "callbacks": {},
-        "operationId": "EngramWeb.UsersController.update",
+        "operationId": "account-update",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2119,7 +2119,7 @@
     "/api/notes": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.upsert",
+        "operationId": "notes-upsert",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2183,7 +2183,7 @@
     "/api/notes/*path": {
       "delete": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.delete",
+        "operationId": "notes-delete",
         "parameters": [
           {
             "description": "Note path",
@@ -2216,7 +2216,7 @@
       },
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.show",
+        "operationId": "notes-show",
         "parameters": [
           {
             "description": "Note path (slash-separated)",
@@ -2261,7 +2261,7 @@
     "/api/notes/append": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.append",
+        "operationId": "notes-append",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2305,7 +2305,7 @@
     "/api/notes/batch": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.batch_upsert",
+        "operationId": "notes-batch-upsert",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2349,7 +2349,7 @@
     "/api/notes/batch-delete": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.batch_delete",
+        "operationId": "notes-batch-delete",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2413,7 +2413,7 @@
     "/api/notes/batch-move": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.batch_move",
+        "operationId": "notes-batch-move",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2477,7 +2477,7 @@
     "/api/notes/by-id/{id}": {
       "delete": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.delete_by_id",
+        "operationId": "notes-delete-by-id",
         "parameters": [
           {
             "description": "Note UUID",
@@ -2530,7 +2530,7 @@
       },
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.show_by_id",
+        "operationId": "notes-show-by-id",
         "parameters": [
           {
             "description": "Note UUID",
@@ -2585,7 +2585,7 @@
     "/api/notes/changes": {
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.changes",
+        "operationId": "notes-changes",
         "parameters": [
           {
             "description": "ISO8601 timestamp cursor",
@@ -2663,7 +2663,7 @@
     "/api/notes/rename": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.NotesController.rename",
+        "operationId": "notes-rename",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2717,7 +2717,7 @@
     "/api/search": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.SearchController.search",
+        "operationId": "search",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2771,7 +2771,7 @@
     "/api/tags": {
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.TagsController.index",
+        "operationId": "tags",
         "parameters": [],
         "responses": {
           "200": {
@@ -2794,7 +2794,7 @@
     "/api/user/storage": {
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.StorageController.index",
+        "operationId": "account-storage",
         "parameters": [],
         "responses": {
           "200": {
@@ -2817,7 +2817,7 @@
     "/api/vaults": {
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.VaultsController.index",
+        "operationId": "vaults-index",
         "parameters": [
           {
             "description": "Pass \"true\" to list soft-deleted vaults instead of active ones.",
@@ -2861,7 +2861,7 @@
       },
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.VaultsController.create",
+        "operationId": "vaults-create",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2916,7 +2916,7 @@
       "post": {
         "callbacks": {},
         "description": "Used by the plugin on first sync. Returns 201 with `status: created` for a new vault, or 200 with `status: existing` when the client_id already maps to one.",
-        "operationId": "EngramWeb.VaultsController.register",
+        "operationId": "vaults-register",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -2980,7 +2980,7 @@
     "/api/vaults/{id}": {
       "delete": {
         "callbacks": {},
-        "operationId": "EngramWeb.VaultsController.delete",
+        "operationId": "vaults-delete",
         "parameters": [
           {
             "description": "Vault UUID",
@@ -3023,7 +3023,7 @@
       },
       "get": {
         "callbacks": {},
-        "operationId": "EngramWeb.VaultsController.show",
+        "operationId": "vaults-show",
         "parameters": [
           {
             "description": "Vault UUID",
@@ -3066,7 +3066,7 @@
       },
       "patch": {
         "callbacks": {},
-        "operationId": "EngramWeb.VaultsController.update",
+        "operationId": "vaults-update",
         "parameters": [
           {
             "description": "Vault UUID",
@@ -3133,7 +3133,7 @@
       "post": {
         "callbacks": {},
         "description": "Immediate, irreversible hard delete — skips the 30-day soft-delete window.",
-        "operationId": "EngramWeb.VaultsController.purge",
+        "operationId": "vaults-purge",
         "parameters": [
           {
             "description": "Vault UUID",
@@ -3178,7 +3178,7 @@
     "/api/vaults/{id}/restore": {
       "post": {
         "callbacks": {},
-        "operationId": "EngramWeb.VaultsController.restore",
+        "operationId": "vaults-restore",
         "parameters": [
           {
             "description": "Vault UUID",

--- a/test/engram_web/api_spec_test.exs
+++ b/test/engram_web/api_spec_test.exs
@@ -139,6 +139,39 @@ defmodule EngramWeb.ApiSpecTest do
     end
   end
 
+  describe "operationId slugs" do
+    setup do: %{spec: EngramWeb.ApiSpec.spec()}
+
+    test "every operation sets an explicit, slug-clean operationId", %{spec: spec} do
+      ids =
+        for {_path, item} <- spec.paths,
+            verb <- [:get, :post, :patch, :put, :delete],
+            op = Map.get(item, verb),
+            not is_nil(op),
+            do: op.operationId
+
+      assert ids != []
+
+      for id <- ids do
+        # No default `EngramWeb.SomeController.action` ids leak through — those
+        # slugify to unreadable mush (engramweb...controlleraction).
+        refute id =~ "Controller", "operationId still defaulted: #{id}"
+        refute id =~ ".", "operationId should be hyphenated, not dotted: #{id}"
+        assert id =~ ~r/^[a-z0-9-]+$/, "operationId not slug-clean: #{id}"
+      end
+
+      # Unique across the whole spec (slugs must not collide).
+      assert length(ids) == length(Enum.uniq(ids))
+    end
+
+    test "known endpoints carry their expected operationId", %{spec: spec} do
+      assert spec.paths["/api/notes"].post.operationId == "notes-upsert"
+      assert spec.paths["/api/vaults/{id}/restore"].post.operationId == "vaults-restore"
+      assert spec.paths["/api/me"].get.operationId == "account-me"
+      assert spec.paths["/api/search"].post.operationId == "search"
+    end
+  end
+
   describe "Vaults paths" do
     setup do: %{spec: EngramWeb.ApiSpec.spec()}
 


### PR DESCRIPTION
Sets an explicit `operation_id` on all **36** annotated operations across the 8 controllers (Notes/Folders/Search/Tags/Health/Vaults/Account) so the rendered API docs get readable URLs.

### Why
starlight-openapi slugs each `operationId` through **github-slugger**, which lowercases and **strips dots**. The open_api_spex default id `EngramWeb.VaultsController.create` therefore collapses to `/operations/engramwebvaultscontrollercreate/`. github-slugger *keeps* hyphens, so a hyphenated id survives intact.

### Scheme
`<tag>-<action>`, hyphenated — `vaults-create`, `account-me`, `notes-batch-upsert`, `folders-list-notes` (single-word `search` / `tags` / `health` kept bare; `health-deep` for the readiness probe).

**Before:** `/operations/engramwebvaultscontrollercreate/`
**After:**  `/operations/vaults-create/`

### Safety
- Pure-docs: only `operationId` strings change; no routes, params, or response shapes touched.
- New guard test asserts every operationId is explicit, slug-clean (`^[a-z0-9-]+$`, no `Controller`, no `.`) and unique across the spec.
- 31 tests / 0 failures; `openapi.json` regenerated and drift-gate IN SYNC; one version bump (0.5.475 → 0.5.476).

On merge, the sync workflow opens the marketing PR automatically.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>