### PR TITLE
feat(api-docs): annotate Attachments / Sync / Embedding / Logs endpoints

### DIFF
--- a/lib/engram_web/api_spec.ex
+++ b/lib/engram_web/api_spec.ex
@@ -46,7 +46,14 @@ defmodule EngramWeb.ApiSpec do
         %Tag{
           name: "Account",
           description: "Current user profile, storage usage, and account deletion."
-        }
+        },
+        %Tag{
+          name: "Attachments",
+          description: "Upload, fetch, move, and delete binary attachments."
+        },
+        %Tag{name: "Sync", description: "Vault manifest and the unified change feed."},
+        %Tag{name: "Embedding", description: "Embedding/index progress."},
+        %Tag{name: "Logs", description: "Client remote-log ingestion and retrieval."}
       ],
       components: %Components{
         # Engram accepts all credentials on the same `Authorization: Bearer`

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -1,9 +1,29 @@
 defmodule EngramWeb.AttachmentsController do
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias EngramWeb.Schemas
 
   alias Engram.Attachments
   alias Engram.Billing
   alias Engram.Storage.MimeWhitelist
+
+  operation(:upload,
+    operation_id: "attachments-upload",
+    summary: "Upload an attachment (base64 JSON)",
+    tags: ["Attachments"],
+    request_body:
+      {"Attachment bytes", "application/json", Schemas.UploadAttachmentRequest, required: true},
+    responses: [
+      ok: {"Uploaded", "application/json", Schemas.AttachmentResponse},
+      bad_request: {"Invalid base64", "application/json", Schemas.MessageError},
+      payment_required:
+        {"Attachments require a paid plan / quota", "application/json", Schemas.LimitError},
+      unsupported_media_type:
+        {"MIME or extension not allowed", "application/json", Schemas.MimeRejected},
+      unprocessable_entity: {"Missing/invalid content", "application/json", Schemas.MessageError},
+      bad_gateway: {"Storage backend failure", "application/json", Schemas.MessageError}
+    ]
+  )
 
   # Free-tier launch §4.5 — attachments are a paid-tier feature. Gate at the
   # top of the upload action so Free users 402 BEFORE any S3 work, file
@@ -109,6 +129,20 @@ defmodule EngramWeb.AttachmentsController do
     end
   end
 
+  operation(:rename,
+    operation_id: "attachments-rename",
+    summary: "Rename / move an attachment",
+    tags: ["Attachments"],
+    request_body: {"Old + new path", "application/json", Schemas.RenameRequest, required: true},
+    responses: [
+      ok: {"Renamed", "application/json", Schemas.AttachmentRenameResponse},
+      payment_required:
+        {"Attachments require a paid plan", "application/json", Schemas.LimitError},
+      not_found: {"No such attachment", "application/json", Schemas.MessageError},
+      conflict: {"Target exists", "application/json", Schemas.MessageError}
+    ]
+  )
+
   def rename(conn, %{"old_path" => old_path, "new_path" => new_path}) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
@@ -138,6 +172,23 @@ defmodule EngramWeb.AttachmentsController do
         conn |> put_status(404) |> json(%{error: "not_found"})
     end
   end
+
+  operation(:batch_move,
+    operation_id: "attachments-batch-move",
+    summary: "Move attachments to a folder (idempotent)",
+    tags: ["Attachments"],
+    request_body:
+      {"Paths + target folder", "application/json", Schemas.AttachmentBatchMoveRequest,
+       required: true},
+    responses: [
+      ok: {"Moved count", "application/json", Schemas.MovedCount},
+      bad_request: {"Missing params", "application/json", Schemas.MessageError},
+      payment_required:
+        {"Attachments require a paid plan", "application/json", Schemas.LimitError},
+      not_found: {"An item was not found", "application/json", Schemas.BatchItemError},
+      conflict: {"An item conflicts at target", "application/json", Schemas.BatchItemError}
+    ]
+  )
 
   def batch_move(conn, %{"paths" => paths, "target_folder" => target}) when is_list(paths) do
     user = conn.assigns.current_user
@@ -180,6 +231,18 @@ defmodule EngramWeb.AttachmentsController do
 
   # Intentionally NOT billing-gated: deleting is cleanup, never trap a downgraded
   # user with attachments they can't remove. Mirrors notes-delete staying open.
+  operation(:batch_delete,
+    operation_id: "attachments-batch-delete",
+    summary: "Delete attachments by path (idempotent)",
+    tags: ["Attachments"],
+    request_body:
+      {"Paths", "application/json", Schemas.AttachmentBatchDeleteRequest, required: true},
+    responses: [
+      ok: {"Deleted count", "application/json", Schemas.DeletedCount},
+      bad_request: {"Missing paths", "application/json", Schemas.MessageError}
+    ]
+  )
+
   def batch_delete(conn, %{"paths" => paths}) when is_list(paths) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
@@ -193,6 +256,16 @@ defmodule EngramWeb.AttachmentsController do
   def batch_delete(conn, _params) do
     conn |> put_status(400) |> json(%{error: "missing required param: paths"})
   end
+
+  operation(:index,
+    operation_id: "attachments-index",
+    summary: "List attachments (metadata only)",
+    tags: ["Attachments"],
+    responses: [
+      ok: {"Attachments", "application/json", Schemas.AttachmentsResponse},
+      internal_server_error: {"Listing failed", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def index(conn, _params) do
     user = conn.assigns.current_user
@@ -222,6 +295,29 @@ defmodule EngramWeb.AttachmentsController do
         conn |> put_status(500) |> json(%{error: "failed to list attachments"})
     end
   end
+
+  operation(:show,
+    operation_id: "attachments-show",
+    summary: "Get an attachment",
+    tags: ["Attachments"],
+    description:
+      "Returns metadata + base64 content by default. Pass `?raw=1` to stream the raw bytes instead.",
+    parameters: [
+      path: [in: :path, type: :string, required: true, description: "Attachment path"],
+      raw: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "\"1\" streams raw bytes instead of JSON."
+      ]
+    ],
+    responses: [
+      ok: {"Attachment", "application/json", Schemas.AttachmentWithContent},
+      not_found: {"No such attachment", "application/json", Schemas.MessageError},
+      bad_gateway: {"Storage fetch failed", "application/json", Schemas.MessageError},
+      internal_server_error: {"Fetch error", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def show(conn, %{"path" => path_parts} = params) do
     user = conn.assigns.current_user
@@ -270,6 +366,14 @@ defmodule EngramWeb.AttachmentsController do
     end
   end
 
+  operation(:delete,
+    operation_id: "attachments-delete",
+    summary: "Delete an attachment",
+    tags: ["Attachments"],
+    parameters: [path: [in: :path, type: :string, required: true, description: "Attachment path"]],
+    responses: [ok: {"Deleted", "application/json", Schemas.AttachmentDeleted}]
+  )
+
   def delete(conn, %{"path" => path_parts}) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
@@ -278,6 +382,19 @@ defmodule EngramWeb.AttachmentsController do
     Attachments.delete_attachment(user, vault, path)
     json(conn, %{deleted: true, path: path})
   end
+
+  operation(:changes,
+    operation_id: "attachments-changes",
+    summary: "List attachment changes since a timestamp",
+    tags: ["Attachments"],
+    parameters: [
+      since: [in: :query, type: :string, required: true, description: "ISO 8601 timestamp cursor"]
+    ],
+    responses: [
+      ok: {"Changes", "application/json", Schemas.AttachmentChangesResponse},
+      bad_request: {"Missing/invalid since", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def changes(conn, %{"since" => since_str}) do
     user = conn.assigns.current_user

--- a/lib/engram_web/controllers/embed_status_controller.ex
+++ b/lib/engram_web/controllers/embed_status_controller.ex
@@ -1,10 +1,19 @@
 defmodule EngramWeb.EmbedStatusController do
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   import Ecto.Query
 
   alias Engram.Notes.Note
   alias Engram.Repo
+  alias EngramWeb.Schemas
+
+  operation(:index,
+    operation_id: "embed-status",
+    summary: "Get embedding/index progress",
+    tags: ["Embedding"],
+    responses: [ok: {"Index status", "application/json", Schemas.EmbedStatusResponse}]
+  )
 
   def index(conn, _params) do
     user = conn.assigns.current_user

--- a/lib/engram_web/controllers/logs_controller.ex
+++ b/lib/engram_web/controllers/logs_controller.ex
@@ -1,7 +1,17 @@
 defmodule EngramWeb.LogsController do
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias EngramWeb.Schemas
 
   alias Engram.Logs
+
+  operation(:ingest,
+    operation_id: "logs-ingest",
+    summary: "Ingest client logs",
+    tags: ["Logs"],
+    request_body: {"Log lines", "application/json", Schemas.LogIngestRequest, required: true},
+    responses: [ok: {"Persisted count", "application/json", Schemas.LogIngestResponse}]
+  )
 
   def ingest(conn, %{"logs" => logs}) when is_list(logs) do
     user = conn.assigns.current_user
@@ -10,6 +20,19 @@ defmodule EngramWeb.LogsController do
   end
 
   def ingest(conn, _params), do: json(conn, %{ok: true, count: 0})
+
+  operation(:index,
+    operation_id: "logs-list",
+    summary: "List ingested logs",
+    tags: ["Logs"],
+    parameters: [
+      level: [in: :query, type: :string, required: false, description: "Filter by level"],
+      category: [in: :query, type: :string, required: false, description: "Filter by category"],
+      since: [in: :query, type: :string, required: false, description: "ISO 8601 lower bound"],
+      limit: [in: :query, type: :integer, required: false, description: "Max rows"]
+    ],
+    responses: [ok: {"Logs", "application/json", Schemas.LogsResponse}]
+  )
 
   def index(conn, params) do
     user = conn.assigns.current_user

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -1,5 +1,6 @@
 defmodule EngramWeb.SyncController do
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   import Ecto.Query
 
@@ -8,6 +9,15 @@ defmodule EngramWeb.SyncController do
   alias Engram.Crypto.Envelope
   alias Engram.Notes.Note
   alias Engram.Repo
+  alias EngramWeb.Schemas
+
+  operation(:manifest,
+    operation_id: "sync-manifest",
+    summary: "Get the full vault manifest",
+    tags: ["Sync"],
+    description: "Every live note + attachment path and content hash, for sync reconciliation.",
+    responses: [ok: {"Manifest", "application/json", Schemas.ManifestResponse}]
+  )
 
   def manifest(conn, _params) do
     user = conn.assigns.current_user
@@ -40,6 +50,22 @@ defmodule EngramWeb.SyncController do
   Pull-carries-ack: records the device watermark from the *incoming* cursor
   (what the client has durably applied), NOT the new page's max seq.
   """
+  operation(:changes,
+    operation_id: "sync-changes",
+    summary: "Pull the unified note + attachment change feed",
+    tags: ["Sync"],
+    parameters: [
+      limit: [in: :query, type: :integer, required: false, description: "Max rows (≤500)"],
+      fields: [in: :query, type: :string, required: false, description: "\"meta\" or \"all\""],
+      cursor: [in: :query, type: :string, required: false, description: "Opaque keyset cursor"]
+    ],
+    responses: [
+      ok: {"Changes page", "application/json", Schemas.SyncChangesResponse},
+      bad_request: {"Invalid cursor", "application/json", Schemas.MessageError},
+      gone: {"Cursor older than retention window", "application/json", Schemas.MessageError}
+    ]
+  )
+
   def changes(conn, params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault

--- a/lib/engram_web/schemas/attachments.ex
+++ b/lib/engram_web/schemas/attachments.ex
@@ -1,0 +1,219 @@
+defmodule EngramWeb.Schemas.AttachmentMeta do
+  @moduledoc "Attachment metadata (no bytes). `created_at` is absent in list responses."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentMeta",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid, nullable: true},
+      path: %Schema{type: :string, example: "assets/diagram.png"},
+      mime_type: %Schema{type: :string, nullable: true},
+      size_bytes: %Schema{type: :integer},
+      mtime: %Schema{type: :number, format: :float, description: "Client mtime (epoch seconds)"},
+      created_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      updated_at: %Schema{type: :string, format: :"date-time", nullable: true}
+    },
+    required: [:path]
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentWithContent do
+  @moduledoc "Attachment metadata plus its base64 bytes (default `show` response)."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentWithContent",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid, nullable: true},
+      path: %Schema{type: :string},
+      mime_type: %Schema{type: :string, nullable: true},
+      size_bytes: %Schema{type: :integer},
+      mtime: %Schema{type: :number, format: :float},
+      content_base64: %Schema{type: :string, description: "Base64-encoded file bytes."},
+      created_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      updated_at: %Schema{type: :string, format: :"date-time", nullable: true}
+    },
+    required: [:path, :content_base64]
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentResponse do
+  @moduledoc false
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentResponse",
+    type: :object,
+    properties: %{attachment: EngramWeb.Schemas.AttachmentMeta},
+    required: [:attachment]
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentsResponse do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentsResponse",
+    type: :object,
+    properties: %{attachments: %Schema{type: :array, items: EngramWeb.Schemas.AttachmentMeta}},
+    required: [:attachments]
+  })
+end
+
+defmodule EngramWeb.Schemas.UploadAttachmentRequest do
+  @moduledoc "Attachments are uploaded as base64 JSON (not multipart)."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "UploadAttachmentRequest",
+    type: :object,
+    properties: %{
+      path: %Schema{type: :string},
+      content_base64: %Schema{type: :string, description: "Base64-encoded file bytes."},
+      mime_type: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Detected from path if omitted."
+      }
+    },
+    required: [:path, :content_base64]
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentRenameResponse do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentRenameResponse",
+    type: :object,
+    properties: %{
+      renamed: %Schema{type: :boolean},
+      old_path: %Schema{type: :string},
+      new_path: %Schema{type: :string},
+      attachment: EngramWeb.Schemas.AttachmentMeta
+    }
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentDeleted do
+  @moduledoc "Single attachment delete acknowledgement."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentDeleted",
+    type: :object,
+    properties: %{
+      deleted: %Schema{type: :boolean, example: true},
+      path: %Schema{type: :string}
+    },
+    required: [:deleted, :path]
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentChange do
+  @moduledoc "One attachment delta from the changes feed."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentChange",
+    type: :object,
+    properties: %{
+      path: %Schema{type: :string},
+      mime_type: %Schema{type: :string, nullable: true},
+      size_bytes: %Schema{type: :integer},
+      mtime: %Schema{type: :number, format: :float},
+      updated_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      deleted: %Schema{type: :boolean}
+    },
+    required: [:path]
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentChangesResponse do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentChangesResponse",
+    type: :object,
+    properties: %{
+      changes: %Schema{type: :array, items: EngramWeb.Schemas.AttachmentChange},
+      server_time: %Schema{type: :string, format: :"date-time"}
+    },
+    required: [:changes]
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentBatchMoveRequest do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentBatchMoveRequest",
+    type: :object,
+    properties: %{
+      paths: %Schema{type: :array, items: %Schema{type: :string}},
+      target_folder: %Schema{type: :string}
+    },
+    required: [:paths, :target_folder]
+  })
+end
+
+defmodule EngramWeb.Schemas.AttachmentBatchDeleteRequest do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AttachmentBatchDeleteRequest",
+    type: :object,
+    properties: %{paths: %Schema{type: :array, items: %Schema{type: :string}}},
+    required: [:paths]
+  })
+end
+
+defmodule EngramWeb.Schemas.MimeRejected do
+  @moduledoc "415 body — file type/extension not allowed by the MIME whitelist."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "MimeRejected",
+    type: :object,
+    properties: %{
+      error: %Schema{type: :string, example: "mime_not_allowed"},
+      mime_type: %Schema{type: :string, nullable: true},
+      extension: %Schema{type: :string, nullable: true}
+    },
+    required: [:error]
+  })
+end
+
+defmodule EngramWeb.Schemas.BatchItemError do
+  @moduledoc "Batch op error pinpointing the offending item path."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "BatchItemError",
+    type: :object,
+    properties: %{
+      error: %Schema{type: :string, example: "conflict"},
+      item_path: %Schema{type: :string}
+    },
+    required: [:error]
+  })
+end

--- a/lib/engram_web/schemas/logs.ex
+++ b/lib/engram_web/schemas/logs.ex
@@ -1,0 +1,83 @@
+defmodule EngramWeb.Schemas.LogInput do
+  @moduledoc "A single client log line submitted for remote ingestion."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "LogInput",
+    type: :object,
+    properties: %{
+      level: %Schema{type: :string, example: "error"},
+      category: %Schema{type: :string, nullable: true},
+      message: %Schema{type: :string},
+      stack: %Schema{type: :string, nullable: true},
+      ts: %Schema{type: :string, format: :"date-time", nullable: true},
+      plugin_version: %Schema{type: :string, nullable: true},
+      platform: %Schema{type: :string, nullable: true}
+    }
+  })
+end
+
+defmodule EngramWeb.Schemas.LogIngestRequest do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "LogIngestRequest",
+    type: :object,
+    properties: %{logs: %Schema{type: :array, items: EngramWeb.Schemas.LogInput}},
+    required: [:logs]
+  })
+end
+
+defmodule EngramWeb.Schemas.LogIngestResponse do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "LogIngestResponse",
+    type: :object,
+    properties: %{
+      ok: %Schema{type: :boolean, example: true},
+      count: %Schema{type: :integer, description: "Number of log lines persisted."}
+    },
+    required: [:ok, :count]
+  })
+end
+
+defmodule EngramWeb.Schemas.LogRecord do
+  @moduledoc "A persisted remote log line."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "LogRecord",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      ts: %Schema{type: :string, format: :"date-time", nullable: true},
+      level: %Schema{type: :string, nullable: true},
+      category: %Schema{type: :string, nullable: true},
+      message: %Schema{type: :string, nullable: true},
+      stack: %Schema{type: :string, nullable: true},
+      plugin_version: %Schema{type: :string, nullable: true},
+      platform: %Schema{type: :string, nullable: true},
+      created_at: %Schema{type: :string, format: :"date-time", nullable: true}
+    }
+  })
+end
+
+defmodule EngramWeb.Schemas.LogsResponse do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "LogsResponse",
+    type: :object,
+    properties: %{logs: %Schema{type: :array, items: EngramWeb.Schemas.LogRecord}},
+    required: [:logs]
+  })
+end

--- a/lib/engram_web/schemas/sync.ex
+++ b/lib/engram_web/schemas/sync.ex
@@ -1,0 +1,100 @@
+defmodule EngramWeb.Schemas.ManifestEntry do
+  @moduledoc "A single manifest row: decrypted path + content hash."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ManifestEntry",
+    type: :object,
+    properties: %{
+      path: %Schema{type: :string},
+      content_hash: %Schema{type: :string, nullable: true}
+    },
+    required: [:path]
+  })
+end
+
+defmodule EngramWeb.Schemas.ManifestResponse do
+  @moduledoc "Full vault manifest — every live note and attachment path + hash."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ManifestResponse",
+    type: :object,
+    properties: %{
+      notes: %Schema{type: :array, items: EngramWeb.Schemas.ManifestEntry},
+      attachments: %Schema{type: :array, items: EngramWeb.Schemas.ManifestEntry},
+      total_notes: %Schema{type: :integer},
+      total_attachments: %Schema{type: :integer},
+      change_seq: %Schema{type: :integer, description: "Current per-vault sequence watermark."}
+    },
+    required: [:notes, :attachments, :total_notes, :total_attachments, :change_seq]
+  })
+end
+
+defmodule EngramWeb.Schemas.SyncChange do
+  @moduledoc "One entry in the unified note+attachment change feed."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "SyncChange",
+    type: :object,
+    properties: %{
+      type: %Schema{type: :string, enum: ["note", "attachment"]},
+      path: %Schema{type: :string},
+      seq: %Schema{type: :integer, description: "Per-vault ordering key."},
+      id: %Schema{type: :string, format: :uuid, nullable: true},
+      content_hash: %Schema{type: :string, nullable: true},
+      content: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Note body — present only when fields=all."
+      },
+      deleted: %Schema{type: :boolean, nullable: true}
+    },
+    required: [:type, :seq]
+  })
+end
+
+defmodule EngramWeb.Schemas.SyncChangesResponse do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "SyncChangesResponse",
+    type: :object,
+    properties: %{
+      changes: %Schema{type: :array, items: EngramWeb.Schemas.SyncChange},
+      next_cursor: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Opaque keyset cursor; null on the last page."
+      },
+      has_more: %Schema{type: :boolean}
+    },
+    required: [:changes, :has_more]
+  })
+end
+
+defmodule EngramWeb.Schemas.EmbedStatusResponse do
+  @moduledoc "Embedding/index progress counts for the user's notes."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "EmbedStatusResponse",
+    type: :object,
+    properties: %{
+      total: %Schema{type: :integer},
+      indexed: %Schema{
+        type: :integer,
+        description: "Notes whose embedding matches current content."
+      },
+      pending: %Schema{type: :integer, description: "Notes awaiting (re)embedding."}
+    },
+    required: [:total, :indexed, :pending]
+  })
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.476",
+      version: "0.5.477",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -368,6 +368,20 @@
         "x-struct": "Elixir.EngramWeb.Schemas.UpdateProfileRequest",
         "x-validate": null
       },
+      "AttachmentResponse": {
+        "properties": {
+          "attachment": {
+            "$ref": "#/components/schemas/AttachmentMeta"
+          }
+        },
+        "required": [
+          "attachment"
+        ],
+        "title": "AttachmentResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentResponse",
+        "x-validate": null
+      },
       "MessageError": {
         "properties": {
           "error": {
@@ -438,6 +452,38 @@
         "x-struct": "Elixir.EngramWeb.Schemas.SearchRequest",
         "x-validate": null
       },
+      "SyncChangesResponse": {
+        "properties": {
+          "changes": {
+            "items": {
+              "$ref": "#/components/schemas/SyncChange"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "has_more": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "next_cursor": {
+            "description": "Opaque keyset cursor; null on the last page.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "changes",
+          "has_more"
+        ],
+        "title": "SyncChangesResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.SyncChangesResponse",
+        "x-validate": null
+      },
       "RegisterVaultRequest": {
         "properties": {
           "client_id": {
@@ -461,6 +507,78 @@
         "x-struct": "Elixir.EngramWeb.Schemas.RegisterVaultRequest",
         "x-validate": null
       },
+      "ManifestEntry": {
+        "properties": {
+          "content_hash": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "ManifestEntry",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.ManifestEntry",
+        "x-validate": null
+      },
+      "AttachmentBatchMoveRequest": {
+        "properties": {
+          "paths": {
+            "items": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "target_folder": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "paths",
+          "target_folder"
+        ],
+        "title": "AttachmentBatchMoveRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentBatchMoveRequest",
+        "x-validate": null
+      },
+      "AttachmentDeleted": {
+        "properties": {
+          "deleted": {
+            "example": true,
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "deleted",
+          "path"
+        ],
+        "title": "AttachmentDeleted",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentDeleted",
+        "x-validate": null
+      },
       "AppendRequest": {
         "properties": {
           "path": {
@@ -481,6 +599,79 @@
         "title": "AppendRequest",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.AppendRequest",
+        "x-validate": null
+      },
+      "LogIngestResponse": {
+        "properties": {
+          "count": {
+            "description": "Number of log lines persisted.",
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "ok": {
+            "example": true,
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "ok",
+          "count"
+        ],
+        "title": "LogIngestResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.LogIngestResponse",
+        "x-validate": null
+      },
+      "LogsResponse": {
+        "properties": {
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/LogRecord"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "logs"
+        ],
+        "title": "LogsResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.LogsResponse",
+        "x-validate": null
+      },
+      "UploadAttachmentRequest": {
+        "properties": {
+          "content_base64": {
+            "description": "Base64-encoded file bytes.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mime_type": {
+            "description": "Detected from path if omitted.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "path",
+          "content_base64"
+        ],
+        "title": "UploadAttachmentRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.UploadAttachmentRequest",
         "x-validate": null
       },
       "RenameRequest": {
@@ -550,6 +741,128 @@
         "title": "FolderNamesResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.FolderNamesResponse",
+        "x-validate": null
+      },
+      "LogIngestRequest": {
+        "properties": {
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/LogInput"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "logs"
+        ],
+        "title": "LogIngestRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.LogIngestRequest",
+        "x-validate": null
+      },
+      "AttachmentChange": {
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mime_type": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mtime": {
+            "format": "float",
+            "type": "number",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "size_bytes": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "updated_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "AttachmentChange",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentChange",
+        "x-validate": null
+      },
+      "SyncChange": {
+        "properties": {
+          "content": {
+            "description": "Note body — present only when fields=all.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "content_hash": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "deleted": {
+            "nullable": true,
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "seq": {
+            "description": "Per-vault ordering key.",
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "type": {
+            "enum": [
+              "note",
+              "attachment"
+            ],
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "type",
+          "seq"
+        ],
+        "title": "SyncChange",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.SyncChange",
         "x-validate": null
       },
       "UpdateVaultRequest": {
@@ -644,6 +957,91 @@
         "x-struct": "Elixir.EngramWeb.Schemas.LimitError",
         "x-validate": null
       },
+      "MimeRejected": {
+        "properties": {
+          "error": {
+            "example": "mime_not_allowed",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "extension": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mime_type": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "title": "MimeRejected",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.MimeRejected",
+        "x-validate": null
+      },
+      "AttachmentMeta": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mime_type": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mtime": {
+            "description": "Client mtime (epoch seconds)",
+            "format": "float",
+            "type": "number",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "example": "assets/diagram.png",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "size_bytes": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "updated_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "AttachmentMeta",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentMeta",
+        "x-validate": null
+      },
       "SearchResponse": {
         "properties": {
           "results": {
@@ -661,6 +1059,32 @@
         "title": "SearchResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.SearchResponse",
+        "x-validate": null
+      },
+      "AttachmentRenameResponse": {
+        "properties": {
+          "attachment": {
+            "$ref": "#/components/schemas/AttachmentMeta"
+          },
+          "new_path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "old_path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "renamed": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "AttachmentRenameResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentRenameResponse",
         "x-validate": null
       },
       "FolderResponse": {
@@ -703,6 +1127,70 @@
         "x-struct": "Elixir.EngramWeb.Schemas.VaultsResponse",
         "x-validate": null
       },
+      "LogRecord": {
+        "properties": {
+          "category": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "created_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "level": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "message": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "platform": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "plugin_version": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "stack": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "ts": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "LogRecord",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.LogRecord",
+        "x-validate": null
+      },
       "VaultResponse": {
         "properties": {
           "vault": {
@@ -715,6 +1203,57 @@
         "title": "VaultResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.VaultResponse",
+        "x-validate": null
+      },
+      "EmbedStatusResponse": {
+        "properties": {
+          "indexed": {
+            "description": "Notes whose embedding matches current content.",
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "pending": {
+            "description": "Notes awaiting (re)embedding.",
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "total": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "total",
+          "indexed",
+          "pending"
+        ],
+        "title": "EmbedStatusResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.EmbedStatusResponse",
+        "x-validate": null
+      },
+      "AttachmentBatchDeleteRequest": {
+        "properties": {
+          "paths": {
+            "items": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "paths"
+        ],
+        "title": "AttachmentBatchDeleteRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentBatchDeleteRequest",
         "x-validate": null
       },
       "User": {
@@ -995,6 +1534,56 @@
         "x-struct": "Elixir.EngramWeb.Schemas.FolderListResponse",
         "x-validate": null
       },
+      "LogInput": {
+        "properties": {
+          "category": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "level": {
+            "example": "error",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "message": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "platform": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "plugin_version": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "stack": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "ts": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "LogInput",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.LogInput",
+        "x-validate": null
+      },
       "BatchUpsertRequest": {
         "properties": {
           "notes": {
@@ -1102,6 +1691,25 @@
         "x-struct": "Elixir.EngramWeb.Schemas.Conflict",
         "x-validate": null
       },
+      "AttachmentsResponse": {
+        "properties": {
+          "attachments": {
+            "items": {
+              "$ref": "#/components/schemas/AttachmentMeta"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "attachments"
+        ],
+        "title": "AttachmentsResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentsResponse",
+        "x-validate": null
+      },
       "CreateVaultRequest": {
         "properties": {
           "description": {
@@ -1127,6 +1735,67 @@
         "title": "CreateVaultRequest",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.CreateVaultRequest",
+        "x-validate": null
+      },
+      "AttachmentWithContent": {
+        "properties": {
+          "content_base64": {
+            "description": "Base64-encoded file bytes.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "created_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mime_type": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mtime": {
+            "format": "float",
+            "type": "number",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "size_bytes": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "updated_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "path",
+          "content_base64"
+        ],
+        "title": "AttachmentWithContent",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentWithContent",
         "x-validate": null
       },
       "DeletedFlag": {
@@ -1200,6 +1869,53 @@
         "title": "UpsertNoteRequest",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.UpsertNoteRequest",
+        "x-validate": null
+      },
+      "ManifestResponse": {
+        "properties": {
+          "attachments": {
+            "items": {
+              "$ref": "#/components/schemas/ManifestEntry"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "change_seq": {
+            "description": "Current per-vault sequence watermark.",
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/components/schemas/ManifestEntry"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "total_attachments": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "total_notes": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "notes",
+          "attachments",
+          "total_notes",
+          "total_attachments",
+          "change_seq"
+        ],
+        "title": "ManifestResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.ManifestResponse",
         "x-validate": null
       },
       "RenameNoteResponse": {
@@ -1315,6 +2031,53 @@
         "title": "UserResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.UserResponse",
+        "x-validate": null
+      },
+      "AttachmentChangesResponse": {
+        "properties": {
+          "changes": {
+            "items": {
+              "$ref": "#/components/schemas/AttachmentChange"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "server_time": {
+            "format": "date-time",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "changes"
+        ],
+        "title": "AttachmentChangesResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.AttachmentChangesResponse",
+        "x-validate": null
+      },
+      "BatchItemError": {
+        "properties": {
+          "error": {
+            "example": "conflict",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "item_path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "title": "BatchItemError",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.BatchItemError",
         "x-validate": null
       },
       "FolderRenameResponse": {
@@ -1524,41 +2287,20 @@
   },
   "openapi": "3.0.0",
   "paths": {
-    "/api/folders": {
-      "get": {
-        "callbacks": {},
-        "operationId": "folders-index",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoldersResponse"
-                }
-              }
-            },
-            "description": "Folders"
-          }
-        },
-        "summary": "List folders",
-        "tags": [
-          "Folders"
-        ]
-      },
+    "/api/notes": {
       "post": {
         "callbacks": {},
-        "operationId": "folders-create",
+        "operationId": "notes-upsert",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateFolderRequest"
+                "$ref": "#/components/schemas/UpsertNoteRequest"
               }
             }
           },
-          "description": "Folder path",
+          "description": "Note to upsert",
           "required": true
         },
         "responses": {
@@ -1566,11 +2308,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FolderResponse"
+                  "$ref": "#/components/schemas/NoteResponse"
                 }
               }
             },
-            "description": "Created"
+            "description": "Created/updated"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Conflict"
+                }
+              }
+            },
+            "description": "Version conflict"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Note exceeds 10MB"
           },
           "422": {
             "content": {
@@ -1580,24 +2342,24 @@
                 }
               }
             },
-            "description": "Empty/root folder rejected"
+            "description": "Validation error"
           }
         },
-        "summary": "Create a folder",
+        "summary": "Create or update a note",
         "tags": [
-          "Folders"
+          "Notes"
         ]
       }
     },
-    "/api/folders/*path": {
-      "delete": {
+    "/api/vaults/{id}/restore": {
+      "post": {
         "callbacks": {},
-        "operationId": "folders-delete",
+        "operationId": "vaults-restore",
         "parameters": [
           {
-            "description": "Folder path",
+            "description": "Vault UUID",
             "in": "path",
-            "name": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string",
@@ -1607,30 +2369,104 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Deleted (empty body)"
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultResponse"
+                }
+              }
+            },
+            "description": "Restored"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LimitError"
+                }
+              }
+            },
+            "description": "Vault cap reached"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such vault"
           }
         },
-        "summary": "Delete a folder by path",
+        "summary": "Restore a soft-deleted vault",
+        "tags": [
+          "Vaults"
+        ]
+      }
+    },
+    "/api/folders/explicit": {
+      "get": {
+        "callbacks": {},
+        "operationId": "folders-explicit",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderNamesResponse"
+                }
+              }
+            },
+            "description": "Folder names"
+          }
+        },
+        "summary": "List explicitly-created (empty-capable) folders",
         "tags": [
           "Folders"
         ]
       }
     },
-    "/api/folders/batch-delete": {
+    "/api/sync/manifest": {
+      "get": {
+        "callbacks": {},
+        "description": "Every live note + attachment path and content hash, for sync reconciliation.",
+        "operationId": "sync-manifest",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManifestResponse"
+                }
+              }
+            },
+            "description": "Manifest"
+          }
+        },
+        "summary": "Get the full vault manifest",
+        "tags": [
+          "Sync"
+        ]
+      }
+    },
+    "/api/notes/batch": {
       "post": {
         "callbacks": {},
-        "operationId": "folders-batch-delete",
+        "operationId": "notes-batch-upsert",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/BatchIdsRequest"
+                "$ref": "#/components/schemas/BatchUpsertRequest"
               }
             }
           },
-          "description": "Folder ids",
+          "description": "Notes array",
           "required": true
         },
         "responses": {
@@ -1638,11 +2474,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeletedCount"
+                  "$ref": "#/components/schemas/BatchUpsertResponse"
                 }
               }
             },
-            "description": "Deleted count"
+            "description": "Per-note results"
           },
           "400": {
             "content": {
@@ -1652,32 +2488,56 @@
                 }
               }
             },
-            "description": "Invalid ids"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Some ids not found"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Conflict"
+            "description": "Invalid array / >100 items"
           }
         },
-        "summary": "Delete folders by id (idempotent)",
+        "summary": "Upsert up to 100 notes (idempotent via X-Idempotency-Key)",
         "tags": [
-          "Folders"
+          "Notes"
+        ]
+      }
+    },
+    "/api/notes/append": {
+      "post": {
+        "callbacks": {},
+        "operationId": "notes-append",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppendRequest"
+              }
+            }
+          },
+          "description": "Path + text",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppendResponse"
+                }
+              }
+            },
+            "description": "Appended"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Validation error"
+          }
+        },
+        "summary": "Append text to a note (creating it if absent)",
+        "tags": [
+          "Notes"
         ]
       }
     },
@@ -1745,94 +2605,49 @@
         ]
       }
     },
-    "/api/folders/by-id/{id}/notes": {
+    "/api/notes/changes": {
       "get": {
         "callbacks": {},
-        "operationId": "folders-list-notes",
+        "operationId": "notes-changes",
         "parameters": [
           {
-            "description": "Folder UUID",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FolderNotesResponse"
-                }
-              }
-            },
-            "description": "Folder notes"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Invalid UUID"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "No such folder"
-          }
-        },
-        "summary": "List notes in a folder by id (metadata only)",
-        "tags": [
-          "Folders"
-        ]
-      }
-    },
-    "/api/folders/explicit": {
-      "get": {
-        "callbacks": {},
-        "operationId": "folders-explicit",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FolderNamesResponse"
-                }
-              }
-            },
-            "description": "Folder names"
-          }
-        },
-        "summary": "List explicitly-created (empty-capable) folders",
-        "tags": [
-          "Folders"
-        ]
-      }
-    },
-    "/api/folders/list": {
-      "get": {
-        "callbacks": {},
-        "operationId": "folders-list",
-        "parameters": [
-          {
-            "description": "Folder path",
+            "description": "ISO8601 timestamp cursor",
             "in": "query",
-            "name": "folder",
+            "name": "since",
             "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Max rows (<=500)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "\"meta\" or \"all\"",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Opaque pagination cursor",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
             "schema": {
               "type": "string",
               "x-struct": null,
@@ -1845,11 +2660,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FolderListResponse"
+                  "$ref": "#/components/schemas/ChangesResponse"
                 }
               }
             },
-            "description": "Folder notes"
+            "description": "Changes page"
           },
           "400": {
             "content": {
@@ -1859,29 +2674,29 @@
                 }
               }
             },
-            "description": "Missing folder param"
+            "description": "Invalid since/limit/fields/cursor"
           }
         },
-        "summary": "List notes in a folder (metadata only)",
+        "summary": "List note changes since a cursor (keyset pagination)",
         "tags": [
-          "Folders"
+          "Notes"
         ]
       }
     },
-    "/api/folders/rename": {
+    "/api/folders/batch-delete": {
       "post": {
         "callbacks": {},
-        "operationId": "folders-rename",
+        "operationId": "folders-batch-delete",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RenameRequest"
+                "$ref": "#/components/schemas/BatchIdsRequest"
               }
             }
           },
-          "description": "Old + new path",
+          "description": "Folder ids",
           "required": true
         },
         "responses": {
@@ -1889,11 +2704,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FolderRenameResponse"
+                  "$ref": "#/components/schemas/DeletedCount"
                 }
               }
             },
-            "description": "Renamed"
+            "description": "Deleted count"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Invalid ids"
           },
           "404": {
             "content": {
@@ -1903,7 +2728,7 @@
                 }
               }
             },
-            "description": "No such folder"
+            "description": "Some ids not found"
           },
           "409": {
             "content": {
@@ -1913,69 +2738,223 @@
                 }
               }
             },
-            "description": "Target exists"
+            "description": "Conflict"
           }
         },
-        "summary": "Rename / move a folder",
+        "summary": "Delete folders by id (idempotent)",
         "tags": [
           "Folders"
         ]
       }
     },
-    "/api/health": {
-      "get": {
+    "/api/attachments/*path": {
+      "delete": {
         "callbacks": {},
-        "description": "Cheap liveness check. Always 200 if the app is up.",
-        "operationId": "health",
-        "parameters": [],
+        "operationId": "attachments-delete",
+        "parameters": [
+          {
+            "description": "Attachment path",
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthStatus"
+                  "$ref": "#/components/schemas/AttachmentDeleted"
                 }
               }
             },
-            "description": "Service is up"
+            "description": "Deleted"
           }
         },
-        "security": [],
-        "summary": "Liveness probe",
-        "tags": []
+        "summary": "Delete an attachment",
+        "tags": [
+          "Attachments"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "description": "Returns metadata + base64 content by default. Pass `?raw=1` to stream the raw bytes instead.",
+        "operationId": "attachments-show",
+        "parameters": [
+          {
+            "description": "Attachment path",
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "\"1\" streams raw bytes instead of JSON.",
+            "in": "query",
+            "name": "raw",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentWithContent"
+                }
+              }
+            },
+            "description": "Attachment"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such attachment"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Fetch error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Storage fetch failed"
+          }
+        },
+        "summary": "Get an attachment",
+        "tags": [
+          "Attachments"
+        ]
       }
     },
-    "/api/health/deep": {
+    "/api/logs": {
       "get": {
         "callbacks": {},
-        "description": "Checks dependencies whose absence fails every request (Postgres). 503 when degraded.",
-        "operationId": "health-deep",
-        "parameters": [],
+        "operationId": "logs-list",
+        "parameters": [
+          {
+            "description": "Filter by level",
+            "in": "query",
+            "name": "level",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Filter by category",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "ISO 8601 lower bound",
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Max rows",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthStatus"
+                  "$ref": "#/components/schemas/LogsResponse"
                 }
               }
             },
-            "description": "All critical deps ok"
+            "description": "Logs"
+          }
+        },
+        "summary": "List ingested logs",
+        "tags": [
+          "Logs"
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "operationId": "logs-ingest",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogIngestRequest"
+              }
+            }
           },
-          "503": {
+          "description": "Log lines",
+          "required": true
+        },
+        "responses": {
+          "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthStatus"
+                  "$ref": "#/components/schemas/LogIngestResponse"
                 }
               }
             },
-            "description": "Degraded"
+            "description": "Persisted count"
           }
         },
-        "security": [],
-        "summary": "Readiness probe",
-        "tags": []
+        "summary": "Ingest client logs",
+        "tags": [
+          "Logs"
+        ]
       }
     },
     "/api/me": {
@@ -2116,20 +3095,163 @@
         ]
       }
     },
-    "/api/notes": {
+    "/api/sync/changes": {
+      "get": {
+        "callbacks": {},
+        "operationId": "sync-changes",
+        "parameters": [
+          {
+            "description": "Max rows (≤500)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "\"meta\" or \"all\"",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Opaque keyset cursor",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncChangesResponse"
+                }
+              }
+            },
+            "description": "Changes page"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Invalid cursor"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Cursor older than retention window"
+          }
+        },
+        "summary": "Pull the unified note + attachment change feed",
+        "tags": [
+          "Sync"
+        ]
+      }
+    },
+    "/api/attachments/changes": {
+      "get": {
+        "callbacks": {},
+        "operationId": "attachments-changes",
+        "parameters": [
+          {
+            "description": "ISO 8601 timestamp cursor",
+            "in": "query",
+            "name": "since",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentChangesResponse"
+                }
+              }
+            },
+            "description": "Changes"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Missing/invalid since"
+          }
+        },
+        "summary": "List attachment changes since a timestamp",
+        "tags": [
+          "Attachments"
+        ]
+      }
+    },
+    "/api/folders": {
+      "get": {
+        "callbacks": {},
+        "operationId": "folders-index",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoldersResponse"
+                }
+              }
+            },
+            "description": "Folders"
+          }
+        },
+        "summary": "List folders",
+        "tags": [
+          "Folders"
+        ]
+      },
       "post": {
         "callbacks": {},
-        "operationId": "notes-upsert",
+        "operationId": "folders-create",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpsertNoteRequest"
+                "$ref": "#/components/schemas/CreateFolderRequest"
               }
             }
           },
-          "description": "Note to upsert",
+          "description": "Folder path",
           "required": true
         },
         "responses": {
@@ -2137,31 +3259,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NoteResponse"
+                  "$ref": "#/components/schemas/FolderResponse"
                 }
               }
             },
-            "description": "Created/updated"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Conflict"
-                }
-              }
-            },
-            "description": "Version conflict"
-          },
-          "413": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Note exceeds 10MB"
+            "description": "Created"
           },
           "422": {
             "content": {
@@ -2171,12 +3273,186 @@
                 }
               }
             },
-            "description": "Validation error"
+            "description": "Empty/root folder rejected"
           }
         },
-        "summary": "Create or update a note",
+        "summary": "Create a folder",
+        "tags": [
+          "Folders"
+        ]
+      }
+    },
+    "/api/vaults/{id}/purge": {
+      "post": {
+        "callbacks": {},
+        "description": "Immediate, irreversible hard delete — skips the 30-day soft-delete window.",
+        "operationId": "vaults-purge",
+        "parameters": [
+          {
+            "description": "Vault UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultPurged"
+                }
+              }
+            },
+            "description": "Purged"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such vault"
+          }
+        },
+        "summary": "Permanently purge a vault",
+        "tags": [
+          "Vaults"
+        ]
+      }
+    },
+    "/api/notes/rename": {
+      "post": {
+        "callbacks": {},
+        "operationId": "notes-rename",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameRequest"
+              }
+            }
+          },
+          "description": "Old + new path",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RenameNoteResponse"
+                }
+              }
+            },
+            "description": "Renamed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "No such note"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Target exists / version conflict"
+          }
+        },
+        "summary": "Rename / move a note",
         "tags": [
           "Notes"
+        ]
+      }
+    },
+    "/api/attachments/batch-move": {
+      "post": {
+        "callbacks": {},
+        "operationId": "attachments-batch-move",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachmentBatchMoveRequest"
+              }
+            }
+          },
+          "description": "Paths + target folder",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MovedCount"
+                }
+              }
+            },
+            "description": "Moved count"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Missing params"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LimitError"
+                }
+              }
+            },
+            "description": "Attachments require a paid plan"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchItemError"
+                }
+              }
+            },
+            "description": "An item was not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchItemError"
+                }
+              }
+            },
+            "description": "An item conflicts at target"
+          }
+        },
+        "summary": "Move attachments to a folder (idempotent)",
+        "tags": [
+          "Attachments"
         ]
       }
     },
@@ -2258,108 +3534,20 @@
         ]
       }
     },
-    "/api/notes/append": {
+    "/api/attachments/batch-delete": {
       "post": {
         "callbacks": {},
-        "operationId": "notes-append",
+        "operationId": "attachments-batch-delete",
         "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AppendRequest"
+                "$ref": "#/components/schemas/AttachmentBatchDeleteRequest"
               }
             }
           },
-          "description": "Path + text",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppendResponse"
-                }
-              }
-            },
-            "description": "Appended"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Validation error"
-          }
-        },
-        "summary": "Append text to a note (creating it if absent)",
-        "tags": [
-          "Notes"
-        ]
-      }
-    },
-    "/api/notes/batch": {
-      "post": {
-        "callbacks": {},
-        "operationId": "notes-batch-upsert",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BatchUpsertRequest"
-              }
-            }
-          },
-          "description": "Notes array",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BatchUpsertResponse"
-                }
-              }
-            },
-            "description": "Per-note results"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Invalid array / >100 items"
-          }
-        },
-        "summary": "Upsert up to 100 notes (idempotent via X-Idempotency-Key)",
-        "tags": [
-          "Notes"
-        ]
-      }
-    },
-    "/api/notes/batch-delete": {
-      "post": {
-        "callbacks": {},
-        "operationId": "notes-batch-delete",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BatchIdsRequest"
-              }
-            }
-          },
-          "description": "Note ids",
+          "description": "Paths",
           "required": true
         },
         "responses": {
@@ -2377,440 +3565,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/MessageError"
                 }
               }
             },
-            "description": "Invalid ids"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Some ids not found"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Conflict"
+            "description": "Missing paths"
           }
         },
-        "summary": "Delete notes by id (idempotent)",
+        "summary": "Delete attachments by path (idempotent)",
         "tags": [
-          "Notes"
-        ]
-      }
-    },
-    "/api/notes/batch-move": {
-      "post": {
-        "callbacks": {},
-        "operationId": "notes-batch-move",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BatchMoveNotesRequest"
-              }
-            }
-          },
-          "description": "Ids + target folder",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MovedCount"
-                }
-              }
-            },
-            "description": "Moved count"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Invalid input"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Some ids not found"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Conflict"
-          }
-        },
-        "summary": "Move notes to a folder (idempotent)",
-        "tags": [
-          "Notes"
-        ]
-      }
-    },
-    "/api/notes/by-id/{id}": {
-      "delete": {
-        "callbacks": {},
-        "operationId": "notes-delete-by-id",
-        "parameters": [
-          {
-            "description": "Note UUID",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeletedFlag"
-                }
-              }
-            },
-            "description": "Deleted"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Invalid UUID"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "No such note"
-          }
-        },
-        "summary": "Delete a note by id",
-        "tags": [
-          "Notes"
-        ]
-      },
-      "get": {
-        "callbacks": {},
-        "operationId": "notes-show-by-id",
-        "parameters": [
-          {
-            "description": "Note UUID",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Note"
-                }
-              }
-            },
-            "description": "Note"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Invalid UUID"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "No such note"
-          }
-        },
-        "summary": "Get a note by id",
-        "tags": [
-          "Notes"
-        ]
-      }
-    },
-    "/api/notes/changes": {
-      "get": {
-        "callbacks": {},
-        "operationId": "notes-changes",
-        "parameters": [
-          {
-            "description": "ISO8601 timestamp cursor",
-            "in": "query",
-            "name": "since",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "Max rows (<=500)",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "\"meta\" or \"all\"",
-            "in": "query",
-            "name": "fields",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "Opaque pagination cursor",
-            "in": "query",
-            "name": "cursor",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChangesResponse"
-                }
-              }
-            },
-            "description": "Changes page"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Invalid since/limit/fields/cursor"
-          }
-        },
-        "summary": "List note changes since a cursor (keyset pagination)",
-        "tags": [
-          "Notes"
-        ]
-      }
-    },
-    "/api/notes/rename": {
-      "post": {
-        "callbacks": {},
-        "operationId": "notes-rename",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RenameRequest"
-              }
-            }
-          },
-          "description": "Old + new path",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RenameNoteResponse"
-                }
-              }
-            },
-            "description": "Renamed"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "No such note"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Target exists / version conflict"
-          }
-        },
-        "summary": "Rename / move a note",
-        "tags": [
-          "Notes"
-        ]
-      }
-    },
-    "/api/search": {
-      "post": {
-        "callbacks": {},
-        "operationId": "search",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SearchRequest"
-              }
-            }
-          },
-          "description": "Search query",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SearchResponse"
-                }
-              }
-            },
-            "description": "Results"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "cross_vault requires Pro"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Missing query"
-          }
-        },
-        "summary": "Search notes (vector / keyword / hybrid)",
-        "tags": [
-          "Search"
-        ]
-      }
-    },
-    "/api/tags": {
-      "get": {
-        "callbacks": {},
-        "operationId": "tags",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TagsResponse"
-                }
-              }
-            },
-            "description": "Tags"
-          }
-        },
-        "summary": "List all tags in the vault",
-        "tags": [
-          "Tags"
-        ]
-      }
-    },
-    "/api/user/storage": {
-      "get": {
-        "callbacks": {},
-        "operationId": "account-storage",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StorageUsage"
-                }
-              }
-            },
-            "description": "Storage usage"
-          }
-        },
-        "summary": "Get storage usage and caps",
-        "tags": [
-          "Account"
+          "Attachments"
         ]
       }
     },
@@ -2912,6 +3676,253 @@
         ]
       }
     },
+    "/api/user/storage": {
+      "get": {
+        "callbacks": {},
+        "operationId": "account-storage",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StorageUsage"
+                }
+              }
+            },
+            "description": "Storage usage"
+          }
+        },
+        "summary": "Get storage usage and caps",
+        "tags": [
+          "Account"
+        ]
+      }
+    },
+    "/api/folders/*path": {
+      "delete": {
+        "callbacks": {},
+        "operationId": "folders-delete",
+        "parameters": [
+          {
+            "description": "Folder path",
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted (empty body)"
+          }
+        },
+        "summary": "Delete a folder by path",
+        "tags": [
+          "Folders"
+        ]
+      }
+    },
+    "/api/tags": {
+      "get": {
+        "callbacks": {},
+        "operationId": "tags",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsResponse"
+                }
+              }
+            },
+            "description": "Tags"
+          }
+        },
+        "summary": "List all tags in the vault",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/search": {
+      "post": {
+        "callbacks": {},
+        "operationId": "search",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "description": "Search query",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Results"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "cross_vault requires Pro"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Missing query"
+          }
+        },
+        "summary": "Search notes (vector / keyword / hybrid)",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
+    "/api/notes/batch-delete": {
+      "post": {
+        "callbacks": {},
+        "operationId": "notes-batch-delete",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchIdsRequest"
+              }
+            }
+          },
+          "description": "Note ids",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletedCount"
+                }
+              }
+            },
+            "description": "Deleted count"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Invalid ids"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Some ids not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "summary": "Delete notes by id (idempotent)",
+        "tags": [
+          "Notes"
+        ]
+      }
+    },
+    "/api/folders/by-id/{id}/notes": {
+      "get": {
+        "callbacks": {},
+        "operationId": "folders-list-notes",
+        "parameters": [
+          {
+            "description": "Folder UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderNotesResponse"
+                }
+              }
+            },
+            "description": "Folder notes"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Invalid UUID"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "No such folder"
+          }
+        },
+        "summary": "List notes in a folder by id (metadata only)",
+        "tags": [
+          "Folders"
+        ]
+      }
+    },
     "/api/vaults/register": {
       "post": {
         "callbacks": {},
@@ -2974,6 +3985,171 @@
         "summary": "Register or fetch a vault by client_id (idempotent)",
         "tags": [
           "Vaults"
+        ]
+      }
+    },
+    "/api/folders/list": {
+      "get": {
+        "callbacks": {},
+        "operationId": "folders-list",
+        "parameters": [
+          {
+            "description": "Folder path",
+            "in": "query",
+            "name": "folder",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderListResponse"
+                }
+              }
+            },
+            "description": "Folder notes"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Missing folder param"
+          }
+        },
+        "summary": "List notes in a folder (metadata only)",
+        "tags": [
+          "Folders"
+        ]
+      }
+    },
+    "/api/health/deep": {
+      "get": {
+        "callbacks": {},
+        "description": "Checks dependencies whose absence fails every request (Postgres). 503 when degraded.",
+        "operationId": "health-deep",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            },
+            "description": "All critical deps ok"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            },
+            "description": "Degraded"
+          }
+        },
+        "security": [],
+        "summary": "Readiness probe",
+        "tags": []
+      }
+    },
+    "/api/attachments/rename": {
+      "post": {
+        "callbacks": {},
+        "operationId": "attachments-rename",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameRequest"
+              }
+            }
+          },
+          "description": "Old + new path",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentRenameResponse"
+                }
+              }
+            },
+            "description": "Renamed"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LimitError"
+                }
+              }
+            },
+            "description": "Attachments require a paid plan"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such attachment"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Target exists"
+          }
+        },
+        "summary": "Rename / move an attachment",
+        "tags": [
+          "Attachments"
+        ]
+      }
+    },
+    "/api/embed-status": {
+      "get": {
+        "callbacks": {},
+        "operationId": "embed-status",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmbedStatusResponse"
+                }
+              }
+            },
+            "description": "Index status"
+          }
+        },
+        "summary": "Get embedding/index progress",
+        "tags": [
+          "Embedding"
         ]
       }
     },
@@ -3129,14 +4305,13 @@
         ]
       }
     },
-    "/api/vaults/{id}/purge": {
-      "post": {
+    "/api/notes/by-id/{id}": {
+      "delete": {
         "callbacks": {},
-        "description": "Immediate, irreversible hard delete — skips the 30-day soft-delete window.",
-        "operationId": "vaults-purge",
+        "operationId": "notes-delete-by-id",
         "parameters": [
           {
-            "description": "Vault UUID",
+            "description": "Note UUID",
             "in": "path",
             "name": "id",
             "required": true,
@@ -3152,13 +4327,227 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VaultPurged"
+                  "$ref": "#/components/schemas/DeletedFlag"
                 }
               }
             },
-            "description": "Purged"
+            "description": "Deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Invalid UUID"
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "No such note"
+          }
+        },
+        "summary": "Delete a note by id",
+        "tags": [
+          "Notes"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "operationId": "notes-show-by-id",
+        "parameters": [
+          {
+            "description": "Note UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              }
+            },
+            "description": "Note"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Invalid UUID"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "No such note"
+          }
+        },
+        "summary": "Get a note by id",
+        "tags": [
+          "Notes"
+        ]
+      }
+    },
+    "/api/folders/rename": {
+      "post": {
+        "callbacks": {},
+        "operationId": "folders-rename",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameRequest"
+              }
+            }
+          },
+          "description": "Old + new path",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderRenameResponse"
+                }
+              }
+            },
+            "description": "Renamed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "No such folder"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Target exists"
+          }
+        },
+        "summary": "Rename / move a folder",
+        "tags": [
+          "Folders"
+        ]
+      }
+    },
+    "/api/notes/batch-move": {
+      "post": {
+        "callbacks": {},
+        "operationId": "notes-batch-move",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchMoveNotesRequest"
+              }
+            }
+          },
+          "description": "Ids + target folder",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MovedCount"
+                }
+              }
+            },
+            "description": "Moved count"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Invalid input"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Some ids not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "summary": "Move notes to a folder (idempotent)",
+        "tags": [
+          "Notes"
+        ]
+      }
+    },
+    "/api/attachments": {
+      "get": {
+        "callbacks": {},
+        "operationId": "attachments-index",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentsResponse"
+                }
+              }
+            },
+            "description": "Attachments"
+          },
+          "500": {
             "content": {
               "application/json": {
                 "schema": {
@@ -3166,42 +4555,49 @@
                 }
               }
             },
-            "description": "No such vault"
+            "description": "Listing failed"
           }
         },
-        "summary": "Permanently purge a vault",
+        "summary": "List attachments (metadata only)",
         "tags": [
-          "Vaults"
+          "Attachments"
         ]
-      }
-    },
-    "/api/vaults/{id}/restore": {
+      },
       "post": {
         "callbacks": {},
-        "operationId": "vaults-restore",
-        "parameters": [
-          {
-            "description": "Vault UUID",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
+        "operationId": "attachments-upload",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadAttachmentRequest"
+              }
             }
-          }
-        ],
+          },
+          "description": "Attachment bytes",
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VaultResponse"
+                  "$ref": "#/components/schemas/AttachmentResponse"
                 }
               }
             },
-            "description": "Restored"
+            "description": "Uploaded"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Invalid base64"
           },
           "402": {
             "content": {
@@ -3211,9 +4607,19 @@
                 }
               }
             },
-            "description": "Vault cap reached"
+            "description": "Attachments require a paid plan / quota"
           },
-          "404": {
+          "415": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MimeRejected"
+                }
+              }
+            },
+            "description": "MIME or extension not allowed"
+          },
+          "422": {
             "content": {
               "application/json": {
                 "schema": {
@@ -3221,13 +4627,46 @@
                 }
               }
             },
-            "description": "No such vault"
+            "description": "Missing/invalid content"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Storage backend failure"
           }
         },
-        "summary": "Restore a soft-deleted vault",
+        "summary": "Upload an attachment (base64 JSON)",
         "tags": [
-          "Vaults"
+          "Attachments"
         ]
+      }
+    },
+    "/api/health": {
+      "get": {
+        "callbacks": {},
+        "description": "Cheap liveness check. Always 200 if the app is up.",
+        "operationId": "health",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            },
+            "description": "Service is up"
+          }
+        },
+        "security": [],
+        "summary": "Liveness probe",
+        "tags": []
       }
     }
   },
@@ -3267,6 +4706,22 @@
     {
       "description": "Current user profile, storage usage, and account deletion.",
       "name": "Account"
+    },
+    {
+      "description": "Upload, fetch, move, and delete binary attachments.",
+      "name": "Attachments"
+    },
+    {
+      "description": "Vault manifest and the unified change feed.",
+      "name": "Sync"
+    },
+    {
+      "description": "Embedding/index progress.",
+      "name": "Embedding"
+    },
+    {
+      "description": "Client remote-log ingestion and retrieval.",
+      "name": "Logs"
     }
   ]
 }

--- a/test/engram_web/api_spec_test.exs
+++ b/test/engram_web/api_spec_test.exs
@@ -250,4 +250,64 @@ defmodule EngramWeb.ApiSpecTest do
       assert Map.has_key?(op.responses, 200)
     end
   end
+
+  describe "Attachments / Sync / Embedding / Logs paths" do
+    setup do: %{spec: EngramWeb.ApiSpec.spec()}
+
+    test "declares Attachments/Sync/Embedding/Logs tags", %{spec: spec} do
+      names = Enum.map(spec.tags, & &1.name)
+      assert "Attachments" in names and "Sync" in names
+      assert "Embedding" in names and "Logs" in names
+    end
+
+    test "POST /api/attachments documents request + 200/400/402/415/422/502", %{spec: spec} do
+      op = spec.paths["/api/attachments"].post
+      assert op.tags == ["Attachments"]
+      assert op.requestBody
+      assert Enum.sort(Map.keys(op.responses)) == [200, 400, 402, 415, 422, 502]
+    end
+
+    test "GET /api/attachments/*path documents raw query param + 404", %{spec: spec} do
+      op = spec.paths["/api/attachments/*path"].get
+      names = Enum.map(op.parameters, & &1.name)
+      assert :path in names and :raw in names
+      assert Map.has_key?(op.responses, 404)
+    end
+
+    test "GET /api/attachments/changes documents since + 400", %{spec: spec} do
+      op = spec.paths["/api/attachments/changes"].get
+      assert Enum.any?(op.parameters, &(&1.name == :since and &1.required))
+      assert Map.has_key?(op.responses, 400)
+    end
+
+    test "GET /api/sync/manifest documents 200", %{spec: spec} do
+      op = spec.paths["/api/sync/manifest"].get
+      assert op.tags == ["Sync"]
+      assert Map.has_key?(op.responses, 200)
+    end
+
+    test "GET /api/sync/changes documents 200/400/410", %{spec: spec} do
+      op = spec.paths["/api/sync/changes"].get
+      assert Enum.sort(Map.keys(op.responses)) == [200, 400, 410]
+    end
+
+    test "GET /api/embed-status documents 200", %{spec: spec} do
+      op = spec.paths["/api/embed-status"].get
+      assert op.tags == ["Embedding"]
+      assert Map.has_key?(op.responses, 200)
+    end
+
+    test "POST /api/logs documents request + 200", %{spec: spec} do
+      op = spec.paths["/api/logs"].post
+      assert op.tags == ["Logs"]
+      assert op.requestBody
+      assert Map.has_key?(op.responses, 200)
+    end
+
+    test "GET /api/logs documents level/category/since/limit query params", %{spec: spec} do
+      op = spec.paths["/api/logs"].get
+      names = Enum.map(op.parameters, & &1.name)
+      assert :level in names and :category in names and :since in names and :limit in names
+    end
+  end
 end


### PR DESCRIPTION
Third annotation batch — the **integration surface** the Obsidian plugin and external clients actually call. 13 endpoints, full OpenApiSpex specs (request bodies, params, response schemas, real error codes), 4 new sidebar tags, slug-clean operationIds.

### Endpoints
- **Attachments** (8): `upload`, `index`, `changes`, `rename`, `show`, `delete`, `batch-move`, `batch-delete`
- **Sync** (2): `manifest`, unified note+attachment change feed
- **Embedding** (1): embed/index progress counts
- **Logs** (2): client log ingest + list

### Notes
- **Attachments upload is base64 JSON, not multipart** (`UploadAttachmentRequest`) — documented as such.
- `show` returns metadata+base64 by default; `?raw=1` streams bytes (noted in the param + description).
- Reuses shared `LimitError` (402), `MessageError`, `MovedCount`/`DeletedCount`, `RenameRequest`.
- New schema modules: `schemas/{attachments,sync,logs}.ex`. Each op sets an explicit `operation_id` (`attachments-upload`, `sync-manifest`, `embed-status`, `logs-list`, …) so doc URLs are clean from the start.

### Deliberately excluded
**Billing + Onboarding** — first-party SPA internals (Paddle overlay, signup wizard), 404 on self-host, not a third-party integration surface. Documenting them would add noise + leak internal billing semantics.

### Verify
40 tests / 0 failures; compile w-as-e clean; `openapi.json` regenerated + drift-gate IN SYNC (38 paths, 74 schemas, 49 clean operationIds); format + credo + sobelow green; one version bump (0.5.476 → 0.5.477).

On merge, the sync workflow opens the marketing PR automatically.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>