### PR TITLE
feat(api-docs): annotate API Keys + Connections endpoints

### DIFF
--- a/lib/engram_web/api_spec.ex
+++ b/lib/engram_web/api_spec.ex
@@ -53,7 +53,12 @@ defmodule EngramWeb.ApiSpec do
         },
         %Tag{name: "Sync", description: "Vault manifest and the unified change feed."},
         %Tag{name: "Embedding", description: "Embedding/index progress."},
-        %Tag{name: "Logs", description: "Client remote-log ingestion and retrieval."}
+        %Tag{name: "Logs", description: "Client remote-log ingestion and retrieval."},
+        %Tag{name: "API Keys", description: "Create, list, and revoke personal API keys."},
+        %Tag{
+          name: "Connections",
+          description: "List and revoke OAuth clients, devices, and PATs."
+        }
       ],
       components: %Components{
         # Engram accepts all credentials on the same `Authorization: Bearer`

--- a/lib/engram_web/controllers/auth_controller.ex
+++ b/lib/engram_web/controllers/auth_controller.ex
@@ -1,7 +1,16 @@
 defmodule EngramWeb.AuthController do
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Engram.Accounts
+  alias EngramWeb.Schemas
+
+  operation(:list_api_keys,
+    operation_id: "apikeys-list",
+    summary: "List API keys",
+    tags: ["API Keys"],
+    responses: [ok: {"API keys", "application/json", Schemas.ApiKeysResponse}]
+  )
 
   def list_api_keys(conn, _params) do
     user = conn.assigns.current_user
@@ -20,6 +29,18 @@ defmodule EngramWeb.AuthController do
     })
   end
 
+  operation(:create_api_key,
+    operation_id: "apikeys-create",
+    summary: "Create an API key",
+    tags: ["API Keys"],
+    description: "The raw `key` is returned once in this response and never again.",
+    request_body: {"Key name", "application/json", Schemas.CreateApiKeyRequest, required: true},
+    responses: [
+      ok: {"Created (raw key)", "application/json", Schemas.ApiKeyCreated},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
+    ]
+  )
+
   def create_api_key(conn, %{"name" => name}) do
     user = conn.assigns.current_user
 
@@ -33,6 +54,18 @@ defmodule EngramWeb.AuthController do
         |> json(%{errors: format_errors(changeset)})
     end
   end
+
+  operation(:revoke_api_key,
+    operation_id: "apikeys-revoke",
+    summary: "Revoke an API key",
+    tags: ["API Keys"],
+    parameters: [id: [in: :path, type: :string, required: true, description: "API key UUID"]],
+    responses: [
+      ok: {"Revoked", "application/json", Schemas.DeletedFlag},
+      bad_request: {"Invalid id", "application/json", Schemas.MessageError},
+      not_found: {"No such key", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def revoke_api_key(conn, %{"id" => id}) do
     user = conn.assigns.current_user

--- a/lib/engram_web/controllers/connections_controller.ex
+++ b/lib/engram_web/controllers/connections_controller.ex
@@ -8,14 +8,44 @@ defmodule EngramWeb.ConnectionsController do
   enumerate or alter its sibling credentials.
   """
   use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
   alias Engram.Connections
+  alias EngramWeb.Schemas
 
   plug EngramWeb.Plugs.EnforcePatCreation when action in [:create_pat]
+
+  operation(:index,
+    operation_id: "connections-list",
+    summary: "List active connections",
+    tags: ["Connections"],
+    description: "OAuth client families, device families, and PATs. Session-auth only.",
+    responses: [ok: {"Connections", "application/json", Schemas.ConnectionsList}]
+  )
 
   def index(conn, _params) do
     user = conn.assigns.current_user
     json(conn, Enum.map(Connections.list_for_user(user), &serialize/1))
   end
+
+  operation(:delete_oauth,
+    operation_id: "connections-delete-oauth",
+    summary: "Revoke an OAuth client connection",
+    tags: ["Connections"],
+    parameters: [
+      client_id: [in: :path, type: :string, required: true, description: "OAuth client id"],
+      vault_id: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Scope revoke to one vault"
+      ]
+    ],
+    responses: [
+      no_content: "Revoked (empty body)",
+      not_found: {"No such connection", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def delete_oauth(conn, %{"client_id" => client_id} = params) do
     user = conn.assigns.current_user
@@ -31,6 +61,18 @@ defmodule EngramWeb.ConnectionsController do
         |> json(%{error: "not_found"})
     end
   end
+
+  operation(:create_pat,
+    operation_id: "connections-create-pat",
+    summary: "Create a personal access token",
+    tags: ["Connections"],
+    description: "The raw `key` is returned once. Subject to the per-plan PAT creation limit.",
+    request_body: {"PAT name", "application/json", Schemas.CreatePatRequest, required: true},
+    responses: [
+      created: {"Created (raw key)", "application/json", Schemas.ApiKeyCreated},
+      unprocessable_entity: {"Blank/invalid name", "application/json", Schemas.Error}
+    ]
+  )
 
   def create_pat(conn, params) do
     user = conn.assigns.current_user
@@ -55,6 +97,19 @@ defmodule EngramWeb.ConnectionsController do
     end
   end
 
+  operation(:delete_device,
+    operation_id: "connections-delete-device",
+    summary: "Revoke a device connection",
+    tags: ["Connections"],
+    parameters: [
+      family_id: [in: :path, type: :string, required: true, description: "Device family id"]
+    ],
+    responses: [
+      no_content: "Revoked (empty body)",
+      not_found: {"No such connection", "application/json", Schemas.MessageError}
+    ]
+  )
+
   def delete_device(conn, %{"family_id" => family_id}) do
     user = conn.assigns.current_user
 
@@ -68,6 +123,19 @@ defmodule EngramWeb.ConnectionsController do
         |> json(%{error: "not_found"})
     end
   end
+
+  operation(:delete_pat,
+    operation_id: "connections-delete-pat",
+    summary: "Revoke a personal access token",
+    tags: ["Connections"],
+    parameters: [
+      id: [in: :path, type: :string, required: true, description: "PAT (API key) UUID"]
+    ],
+    responses: [
+      no_content: "Revoked (empty body)",
+      not_found: {"No such PAT", "application/json", Schemas.MessageError}
+    ]
+  )
 
   def delete_pat(conn, %{"id" => id_str}) do
     user = conn.assigns.current_user

--- a/lib/engram_web/schemas/connections.ex
+++ b/lib/engram_web/schemas/connections.ex
@@ -1,0 +1,115 @@
+defmodule EngramWeb.Schemas.ApiKeyMeta do
+  @moduledoc "An API key / PAT (metadata only — the secret is shown once at creation)."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ApiKeyMeta",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      name: %Schema{type: :string},
+      created_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      last_used: %Schema{type: :string, format: :"date-time", nullable: true}
+    },
+    required: [:id, :name]
+  })
+end
+
+defmodule EngramWeb.Schemas.ApiKeysResponse do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ApiKeysResponse",
+    type: :object,
+    properties: %{keys: %Schema{type: :array, items: EngramWeb.Schemas.ApiKeyMeta}},
+    required: [:keys]
+  })
+end
+
+defmodule EngramWeb.Schemas.CreateApiKeyRequest do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "CreateApiKeyRequest",
+    type: :object,
+    properties: %{name: %Schema{type: :string}},
+    required: [:name]
+  })
+end
+
+defmodule EngramWeb.Schemas.ApiKeyCreated do
+  @moduledoc "Creation response — `key` is the raw secret, returned only once."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ApiKeyCreated",
+    type: :object,
+    properties: %{
+      key: %Schema{type: :string, description: "Raw secret — store it now; never shown again."},
+      id: %Schema{type: :string, format: :uuid},
+      name: %Schema{type: :string}
+    },
+    required: [:key, :id, :name]
+  })
+end
+
+defmodule EngramWeb.Schemas.Connection do
+  @moduledoc "An active credential — an OAuth client family or a device family."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "Connection",
+    type: :object,
+    properties: %{
+      kind: %Schema{type: :string, example: "oauth"},
+      client_id: %Schema{type: :string, nullable: true},
+      key_id: %Schema{type: :string, nullable: true},
+      name: %Schema{type: :string, nullable: true},
+      software_id: %Schema{type: :string, nullable: true},
+      software_version: %Schema{type: :string, nullable: true},
+      verified: %Schema{type: :boolean, nullable: true},
+      logo: %Schema{type: :string, nullable: true},
+      slug: %Schema{type: :string, nullable: true},
+      vault_id: %Schema{type: :string, format: :uuid, nullable: true},
+      vault_name: %Schema{type: :string, nullable: true},
+      scope: %Schema{type: :string, nullable: true},
+      last_used_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      connected_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      first_user_agent: %Schema{type: :string, nullable: true},
+      first_ip: %Schema{type: :string, nullable: true},
+      redirect_uris: %Schema{type: :array, nullable: true, items: %Schema{type: :string}}
+    },
+    required: [:kind]
+  })
+end
+
+defmodule EngramWeb.Schemas.ConnectionsList do
+  @moduledoc "A flat array of the user's active connections."
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ConnectionsList",
+    type: :array,
+    items: EngramWeb.Schemas.Connection
+  })
+end
+
+defmodule EngramWeb.Schemas.CreatePatRequest do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "CreatePatRequest",
+    type: :object,
+    properties: %{name: %Schema{type: :string}},
+    required: [:name]
+  })
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.477",
+      version: "0.5.478",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -320,6 +320,36 @@
         "x-struct": "Elixir.EngramWeb.Schemas.MovedCount",
         "x-validate": null
       },
+      "ApiKeyCreated": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "key": {
+            "description": "Raw secret — store it now; never shown again.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "key",
+          "id",
+          "name"
+        ],
+        "title": "ApiKeyCreated",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.ApiKeyCreated",
+        "x-validate": null
+      },
       "ChangesResponse": {
         "properties": {
           "changes": {
@@ -380,6 +410,22 @@
         "title": "AttachmentResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.AttachmentResponse",
+        "x-validate": null
+      },
+      "CreateApiKeyRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "CreateApiKeyRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.CreateApiKeyRequest",
         "x-validate": null
       },
       "MessageError": {
@@ -762,6 +808,43 @@
         "x-struct": "Elixir.EngramWeb.Schemas.LogIngestRequest",
         "x-validate": null
       },
+      "ApiKeyMeta": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "last_used": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "ApiKeyMeta",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.ApiKeyMeta",
+        "x-validate": null
+      },
       "AttachmentChange": {
         "properties": {
           "deleted": {
@@ -1101,6 +1184,15 @@
         "x-struct": "Elixir.EngramWeb.Schemas.FolderResponse",
         "x-validate": null
       },
+      "ConnectionsList": {
+        "items": {
+          "$ref": "#/components/schemas/Connection"
+        },
+        "title": "ConnectionsList",
+        "type": "array",
+        "x-struct": "Elixir.EngramWeb.Schemas.ConnectionsList",
+        "x-validate": null
+      },
       "VaultsResponse": {
         "properties": {
           "suggested_vault_name": {
@@ -1292,6 +1384,127 @@
         "x-struct": "Elixir.EngramWeb.Schemas.User",
         "x-validate": null
       },
+      "Connection": {
+        "properties": {
+          "client_id": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "connected_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "first_ip": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "first_user_agent": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "key_id": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "kind": {
+            "example": "oauth",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "last_used_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "logo": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "redirect_uris": {
+            "items": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            },
+            "nullable": true,
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "scope": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "slug": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "software_id": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "software_version": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "vault_id": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "vault_name": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "verified": {
+            "nullable": true,
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "title": "Connection",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.Connection",
+        "x-validate": null
+      },
       "RegisterVaultResponse": {
         "allOf": [
           {
@@ -1469,6 +1682,25 @@
         "x-struct": "Elixir.EngramWeb.Schemas.CreateFolderRequest",
         "x-validate": null
       },
+      "ApiKeysResponse": {
+        "properties": {
+          "keys": {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyMeta"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "title": "ApiKeysResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.ApiKeysResponse",
+        "x-validate": null
+      },
       "ValidationError": {
         "properties": {
           "details": {
@@ -1602,6 +1834,22 @@
         "title": "BatchUpsertRequest",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.BatchUpsertRequest",
+        "x-validate": null
+      },
+      "CreatePatRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "CreatePatRequest",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.CreatePatRequest",
         "x-validate": null
       },
       "NoteMeta": {
@@ -2429,6 +2677,44 @@
         ]
       }
     },
+    "/api/connections/pat/{id}": {
+      "delete": {
+        "callbacks": {},
+        "operationId": "connections-delete-pat",
+        "parameters": [
+          {
+            "description": "PAT (API key) UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Revoked (empty body)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such PAT"
+          }
+        },
+        "summary": "Revoke a personal access token",
+        "tags": [
+          "Connections"
+        ]
+      }
+    },
     "/api/sync/manifest": {
       "get": {
         "callbacks": {},
@@ -2854,6 +3140,44 @@
         "summary": "Get an attachment",
         "tags": [
           "Attachments"
+        ]
+      }
+    },
+    "/api/connections/device/{family_id}": {
+      "delete": {
+        "callbacks": {},
+        "operationId": "connections-delete-device",
+        "parameters": [
+          {
+            "description": "Device family id",
+            "in": "path",
+            "name": "family_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Revoked (empty body)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such connection"
+          }
+        },
+        "summary": "Revoke a device connection",
+        "tags": [
+          "Connections"
         ]
       }
     },
@@ -3750,6 +4074,51 @@
         ]
       }
     },
+    "/api/connections/pat": {
+      "post": {
+        "callbacks": {},
+        "description": "The raw `key` is returned once. Subject to the per-plan PAT creation limit.",
+        "operationId": "connections-create-pat",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePatRequest"
+              }
+            }
+          },
+          "description": "PAT name",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreated"
+                }
+              }
+            },
+            "description": "Created (raw key)"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Blank/invalid name"
+          }
+        },
+        "summary": "Create a personal access token",
+        "tags": [
+          "Connections"
+        ]
+      }
+    },
     "/api/search": {
       "post": {
         "callbacks": {},
@@ -4030,6 +4399,96 @@
         "summary": "List notes in a folder (metadata only)",
         "tags": [
           "Folders"
+        ]
+      }
+    },
+    "/api/api-keys": {
+      "get": {
+        "callbacks": {},
+        "operationId": "apikeys-list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeysResponse"
+                }
+              }
+            },
+            "description": "API keys"
+          }
+        },
+        "summary": "List API keys",
+        "tags": [
+          "API Keys"
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "The raw `key` is returned once in this response and never again.",
+        "operationId": "apikeys-create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApiKeyRequest"
+              }
+            }
+          },
+          "description": "Key name",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreated"
+                }
+              }
+            },
+            "description": "Created (raw key)"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Validation error"
+          }
+        },
+        "summary": "Create an API key",
+        "tags": [
+          "API Keys"
+        ]
+      }
+    },
+    "/api/connections": {
+      "get": {
+        "callbacks": {},
+        "description": "OAuth client families, device families, and PATs. Session-auth only.",
+        "operationId": "connections-list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionsList"
+                }
+              }
+            },
+            "description": "Connections"
+          }
+        },
+        "summary": "List active connections",
+        "tags": [
+          "Connections"
         ]
       }
     },
@@ -4413,6 +4872,61 @@
         ]
       }
     },
+    "/api/api-keys/{id}": {
+      "delete": {
+        "callbacks": {},
+        "operationId": "apikeys-revoke",
+        "parameters": [
+          {
+            "description": "API key UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletedFlag"
+                }
+              }
+            },
+            "description": "Revoked"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "Invalid id"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such key"
+          }
+        },
+        "summary": "Revoke an API key",
+        "tags": [
+          "API Keys"
+        ]
+      }
+    },
     "/api/folders/rename": {
       "post": {
         "callbacks": {},
@@ -4528,6 +5042,55 @@
         "summary": "Move notes to a folder (idempotent)",
         "tags": [
           "Notes"
+        ]
+      }
+    },
+    "/api/connections/oauth/{client_id}": {
+      "delete": {
+        "callbacks": {},
+        "operationId": "connections-delete-oauth",
+        "parameters": [
+          {
+            "description": "OAuth client id",
+            "in": "path",
+            "name": "client_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Scope revoke to one vault",
+            "in": "query",
+            "name": "vault_id",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Revoked (empty body)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageError"
+                }
+              }
+            },
+            "description": "No such connection"
+          }
+        },
+        "summary": "Revoke an OAuth client connection",
+        "tags": [
+          "Connections"
         ]
       }
     },
@@ -4722,6 +5285,14 @@
     {
       "description": "Client remote-log ingestion and retrieval.",
       "name": "Logs"
+    },
+    {
+      "description": "Create, list, and revoke personal API keys.",
+      "name": "API Keys"
+    },
+    {
+      "description": "List and revoke OAuth clients, devices, and PATs.",
+      "name": "Connections"
     }
   ]
 }

--- a/test/engram_web/api_spec_test.exs
+++ b/test/engram_web/api_spec_test.exs
@@ -310,4 +310,59 @@ defmodule EngramWeb.ApiSpecTest do
       assert :level in names and :category in names and :since in names and :limit in names
     end
   end
+
+  describe "API Keys / Connections paths" do
+    setup do: %{spec: EngramWeb.ApiSpec.spec()}
+
+    test "declares API Keys + Connections tags", %{spec: spec} do
+      names = Enum.map(spec.tags, & &1.name)
+      assert "API Keys" in names and "Connections" in names
+    end
+
+    test "GET /api/api-keys documents 200", %{spec: spec} do
+      op = spec.paths["/api/api-keys"].get
+      assert op.tags == ["API Keys"]
+      assert Map.has_key?(op.responses, 200)
+    end
+
+    test "POST /api/api-keys documents request + 200/422", %{spec: spec} do
+      op = spec.paths["/api/api-keys"].post
+      assert op.requestBody
+      assert Enum.sort(Map.keys(op.responses)) == [200, 422]
+    end
+
+    test "DELETE /api/api-keys/{id} documents id param + 200/400/404", %{spec: spec} do
+      op = spec.paths["/api/api-keys/{id}"].delete
+      assert Enum.any?(op.parameters, &(&1.name == :id and &1.in == :path))
+      assert Enum.sort(Map.keys(op.responses)) == [200, 400, 404]
+    end
+
+    test "GET /api/connections documents 200", %{spec: spec} do
+      op = spec.paths["/api/connections"].get
+      assert op.tags == ["Connections"]
+      assert Map.has_key?(op.responses, 200)
+    end
+
+    test "DELETE /api/connections/oauth/{client_id} documents client_id + vault_id + 204/404", %{
+      spec: spec
+    } do
+      op = spec.paths["/api/connections/oauth/{client_id}"].delete
+      names = Enum.map(op.parameters, & &1.name)
+      assert :client_id in names and :vault_id in names
+      assert Enum.sort(Map.keys(op.responses)) == [204, 404]
+    end
+
+    test "POST /api/connections/pat documents request + 201/422", %{spec: spec} do
+      op = spec.paths["/api/connections/pat"].post
+      assert op.requestBody
+      assert Enum.sort(Map.keys(op.responses)) == [201, 422]
+    end
+
+    test "DELETE /api/connections/pat/{id} + device/{family_id} are 204/404", %{spec: spec} do
+      pat = spec.paths["/api/connections/pat/{id}"].delete
+      dev = spec.paths["/api/connections/device/{family_id}"].delete
+      assert Enum.sort(Map.keys(pat.responses)) == [204, 404]
+      assert Enum.sort(Map.keys(dev.responses)) == [204, 404]
+    end
+  end
 end


### PR DESCRIPTION
Final integration-surface batch — the 8 self-service credential-management endpoints, with full OpenApiSpex specs, slug-clean operationIds, and two sidebar tags.

### Endpoints
- **API Keys** (3, `AuthController`): list / create / revoke
- **Connections** (5, `ConnectionsController`): list; revoke OAuth client / device / PAT; create PAT

### Notes
- `create` / `create_pat` return the raw `key` once (`ApiKeyCreated` — documented as one-time).
- `GET /connections` returns a bare JSON array → modeled as a top-level `type: :array` schema (`ConnectionsList`).
- The four revokes are 204 no-body (`no_content: "..."` description form, matching the shipped folders-delete idiom).
- New `schemas/connections.ex`; reuses `DeletedFlag`/`MessageError`/`Error`.

### Verify
48 tests / 0 failures; compile w-as-e clean; `openapi.json` regenerated + drift-gate IN SYNC (45 paths); format + credo + sobelow green; one version bump (0.5.477 → 0.5.478).

This completes the public REST integration surface. **Billing + Onboarding stay excluded** (first-party SPA internals, 404 on self-host).

On merge, the sync workflow opens the marketing PR automatically.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>