### PR TITLE
test(web): make config fallback test env-independent

### DIFF
--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -1,10 +1,22 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { loadConfig } from './config'
 
 describe('loadConfig', () => {
   beforeEach(() => {
     delete (window as { __ENGRAM_CONFIG__?: unknown }).__ENGRAM_CONFIG__
     vi.restoreAllMocks()
+    // Null out the VITE_* vars defaultConfig() reads so the no-config fallback
+    // is deterministic regardless of the dev's local .env. A saas-shape .env
+    // sets VITE_AUTH_PROVIDER=clerk, which otherwise makes the "falls back to
+    // local defaults" case read clerk and fail only on that machine (green in
+    // CI, where no such env exists).
+    vi.stubEnv('VITE_AUTH_PROVIDER', undefined)
+    vi.stubEnv('VITE_API_BASE', undefined)
+    vi.stubEnv('VITE_WS_BASE', undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('reads apiBase + wsBase from window injection when present', async () => {

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.480",
+      version: "0.5.481",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem
`config.test.ts` → "falls back to local defaults when both window + /config.json fail" reaches `defaultConfig()`, which reads `VITE_AUTH_PROVIDER` / `VITE_API_BASE` / `VITE_WS_BASE` from `import.meta.env`. On a dev machine with a **saas-shape `.env`** (`VITE_AUTH_PROVIDER=clerk`), vitest picks those up, so the test reads `clerk` and fails — **only on that machine**. It's green in CI (no such env) and on `origin/main`, which is why it slipped through.

This trains devs to ignore a red test, which can mask a real regression.

## Fix
Stub the `VITE_*` vars `defaultConfig()` reads to `undefined` in `beforeEach` (unstub in `afterEach`), so the no-config fallback asserts the true defaults regardless of the dev's local `.env`. Test-only; no app code changes.

## Verification
- Before: `6 passed | 1 failed` in a saas-`.env` shell.
- After: `7 passed` in the same shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)