### PR TITLE
perf(telemetry): drop high-cardinality user_id/vault_id metric tags

### DIFF
--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -147,7 +147,8 @@ defmodule EngramWeb.Telemetry do
       counter("engram.crypto.rotate.dek.snoozed.count",
         event_name: [:engram, :crypto, :rotate, :dek, :snoozed],
         measurement: :count,
-        tags: [:user_id],
+        # No :user_id tag — one Prometheus series per user is unbounded
+        # cardinality (#517). user_id stays in event metadata for logs.
         description: "T3.7 per-user DEK rotation snoozed because lock held by another rotation"
       ),
       counter("engram.crypto.aad_rebind.attachment_skipped.count",
@@ -211,7 +212,8 @@ defmodule EngramWeb.Telemetry do
       # / StatsD / OTel) picks them up without a second PR. Pinned by
       # `test/engram_web/telemetry_test.exs`.
       counter("engram.embed.rate_limited.count",
-        tags: [:vault_id],
+        # No :vault_id tag — one Prometheus series per vault is unbounded
+        # cardinality (#517). vault_id stays in event metadata for logs.
         description:
           "Real Voyage 429 (post-network) — each event = one snoozed EmbedNote job. Layer 1 surface. Non-zero = either real Voyage rate-limit hits OR Layer 2 leaking; use `engram.embed.client_rate_limited.count` to distinguish."
       ),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.481",
+      version: "0.5.484",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/telemetry_test.exs
+++ b/test/engram_web/telemetry_test.exs
@@ -239,5 +239,31 @@ defmodule EngramWeb.TelemetryTest do
       assert EngramWeb.Telemetry.websocket_poll_period() == :timer.seconds(30),
              "WS gauge cadence is a contract — 30s balances spike-visibility against per-tick cost"
     end
+
+    test "engram.crypto.rotate.dek.snoozed.count carries no per-user label (cardinality guard)" do
+      metric =
+        Enum.find(
+          EngramWeb.Telemetry.metrics(),
+          &(&1.name == [:engram, :crypto, :rotate, :dek, :snoozed, :count])
+        )
+
+      assert metric, "expected an engram.crypto.rotate.dek.snoozed.count metric"
+
+      refute :user_id in metric.tags,
+             "snoozed counter must NOT tag :user_id — one Prometheus series per user is unbounded cardinality (#517)"
+    end
+
+    test "engram.embed.rate_limited.count carries no per-vault label (cardinality guard)" do
+      metric =
+        Enum.find(
+          EngramWeb.Telemetry.metrics(),
+          &(&1.name == [:engram, :embed, :rate_limited, :count])
+        )
+
+      assert metric, "expected an engram.embed.rate_limited.count metric"
+
+      refute :vault_id in metric.tags,
+             "rate_limited counter must NOT tag :vault_id — one Prometheus series per vault is unbounded cardinality (#517)"
+    end
   end
 end


### PR DESCRIPTION
`engram.crypto.rotate.dek.snoozed.count` tagged `:user_id` and `engram.embed.rate_limited.count` tagged `:vault_id`. Each unique label value mints a Prometheus time series, so per-user/per-vault tags are unbounded cardinality — a Grafana free-tier ingest risk once real users hit prod.

Drops both tags from the counter declarations; the ids remain in event metadata (still available to log/other handlers). Adds two cardinality-guard tests mirroring the existing websocket-gauge guards.

Closes #517 (v1-launch / p0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)