### PR TITLE
test(api-spec): add doc-coverage gate + seed core request examples

### DIFF
--- a/lib/engram_web/controllers/embed_status_controller.ex
+++ b/lib/engram_web/controllers/embed_status_controller.ex
@@ -11,6 +11,7 @@ defmodule EngramWeb.EmbedStatusController do
   operation(:index,
     operation_id: "embed-status",
     summary: "Get embedding/index progress",
+    "x-internal": true,
     tags: ["Embedding"],
     responses: [ok: {"Index status", "application/json", Schemas.EmbedStatusResponse}]
   )

--- a/lib/engram_web/controllers/logs_controller.ex
+++ b/lib/engram_web/controllers/logs_controller.ex
@@ -8,6 +8,7 @@ defmodule EngramWeb.LogsController do
   operation(:ingest,
     operation_id: "logs-ingest",
     summary: "Ingest client logs",
+    "x-internal": true,
     tags: ["Logs"],
     request_body: {"Log lines", "application/json", Schemas.LogIngestRequest, required: true},
     responses: [ok: {"Persisted count", "application/json", Schemas.LogIngestResponse}]
@@ -24,6 +25,7 @@ defmodule EngramWeb.LogsController do
   operation(:index,
     operation_id: "logs-list",
     summary: "List ingested logs",
+    "x-internal": true,
     tags: ["Logs"],
     parameters: [
       level: [in: :query, type: :string, required: false, description: "Filter by level"],

--- a/lib/engram_web/schemas/folders.ex
+++ b/lib/engram_web/schemas/folders.ex
@@ -85,7 +85,8 @@ defmodule EngramWeb.Schemas.CreateFolderRequest do
     title: "CreateFolderRequest",
     type: :object,
     properties: %{folder: %Schema{type: :string}},
-    required: [:folder]
+    required: [:folder],
+    example: %{"folder" => "Projects/Engram"}
   })
 end
 

--- a/lib/engram_web/schemas/notes.ex
+++ b/lib/engram_web/schemas/notes.ex
@@ -27,7 +27,13 @@ defmodule EngramWeb.Schemas.UpsertNoteRequest do
       folder: %Schema{type: :string, nullable: true},
       tags: %Schema{type: :array, items: %Schema{type: :string}}
     },
-    required: [:path, :mtime]
+    required: [:path, :mtime],
+    example: %{
+      "path" => "Projects/Engram.md",
+      "content" => "# Engram\n\nAn AI-powered personal knowledge base.\n",
+      "mtime" => 1_718_900_000.0,
+      "tags" => ["project", "ai"]
+    }
   })
 end
 
@@ -70,7 +76,11 @@ defmodule EngramWeb.Schemas.AppendRequest do
     title: "AppendRequest",
     type: :object,
     properties: %{path: %Schema{type: :string}, text: %Schema{type: :string}},
-    required: [:path, :text]
+    required: [:path, :text],
+    example: %{
+      "path" => "Daily/2026-06-20.md",
+      "text" => "\n- [ ] Ship the API docs coverage gate\n"
+    }
   })
 end
 

--- a/lib/engram_web/schemas/search.ex
+++ b/lib/engram_web/schemas/search.ex
@@ -14,7 +14,12 @@ defmodule EngramWeb.Schemas.SearchRequest do
       mode: %Schema{type: :string, enum: ["keyword", "vector", "hybrid"]},
       cross_vault: %Schema{type: :boolean, description: "Pro plan only."}
     },
-    required: [:query]
+    required: [:query],
+    example: %{
+      "query" => "omega-3 dosage",
+      "limit" => 5,
+      "mode" => "hybrid"
+    }
   })
 end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.484",
+      version: "0.5.485",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -446,6 +446,11 @@
         "x-validate": null
       },
       "SearchRequest": {
+        "example": {
+          "limit": 5,
+          "mode": "hybrid",
+          "query": "omega-3 dosage"
+        },
         "properties": {
           "cross_vault": {
             "description": "Pro plan only.",
@@ -626,6 +631,10 @@
         "x-validate": null
       },
       "AppendRequest": {
+        "example": {
+          "path": "Daily/2026-06-20.md",
+          "text": "\n- [ ] Ship the API docs coverage gate\n"
+        },
         "properties": {
           "path": {
             "type": "string",
@@ -1667,6 +1676,9 @@
         "x-validate": null
       },
       "CreateFolderRequest": {
+        "example": {
+          "folder": "Projects/Engram"
+        },
         "properties": {
           "folder": {
             "type": "string",
@@ -2064,6 +2076,15 @@
         "x-validate": null
       },
       "UpsertNoteRequest": {
+        "example": {
+          "content": "# Engram\n\nAn AI-powered personal knowledge base.\n",
+          "mtime": 1.7189e9,
+          "path": "Projects/Engram.md",
+          "tags": [
+            "project",
+            "ai"
+          ]
+        },
         "properties": {
           "content": {
             "type": "string",
@@ -3246,7 +3267,8 @@
         "summary": "List ingested logs",
         "tags": [
           "Logs"
-        ]
+        ],
+        "x-internal": true
       },
       "post": {
         "callbacks": {},
@@ -3278,7 +3300,8 @@
         "summary": "Ingest client logs",
         "tags": [
           "Logs"
-        ]
+        ],
+        "x-internal": true
       }
     },
     "/api/me": {
@@ -4609,7 +4632,8 @@
         "summary": "Get embedding/index progress",
         "tags": [
           "Embedding"
-        ]
+        ],
+        "x-internal": true
       }
     },
     "/api/vaults/{id}": {

--- a/test/engram_web/api_spec_coverage_test.exs
+++ b/test/engram_web/api_spec_coverage_test.exs
@@ -1,0 +1,146 @@
+defmodule EngramWeb.ApiSpecCoverageTest do
+  @moduledoc """
+  Universal documentation-coverage gate over the generated OpenAPI spec.
+
+  Unlike `api_spec_test.exs` (which asserts specific endpoints exist with
+  specific params/responses), this walks EVERY operation and enforces
+  doc-quality invariants, so a newly-annotated endpoint cannot ship
+  under-documented without an explicit, visible exemption.
+
+  Two escape hatches, both deliberate:
+
+    * `"x-internal": true` on the operation — the endpoint is internal and
+      intentionally kept out of the public docs (it is also filtered out of
+      the published docs site). Permanent.
+    * the `@pending_*` allowlists below — known documentation debt awaiting
+      backfill. These lists must only SHRINK. Adding a new endpoint does NOT
+      entitle you to grow them; document the endpoint instead.
+  """
+  use ExUnit.Case, async: true
+
+  alias OpenApiSpex.{MediaType, Reference, RequestBody}
+
+  @verbs [:get, :post, :put, :patch, :delete]
+
+  # Operations still missing a prose `description` (backfill: PR #2).
+  # MUST ONLY SHRINK — a new endpoint earns its way off this list by being
+  # documented, never onto it.
+  @pending_description ~w(
+    account-me account-storage account-update apikeys-list apikeys-revoke
+    attachments-batch-delete attachments-batch-move attachments-changes
+    attachments-delete attachments-index attachments-rename attachments-upload
+    connections-delete-device connections-delete-oauth connections-delete-pat
+    folders-batch-delete folders-batch-move folders-create folders-delete
+    folders-explicit folders-index folders-list folders-list-notes folders-rename
+    notes-append notes-batch-delete notes-batch-move notes-batch-upsert
+    notes-changes notes-delete notes-delete-by-id notes-rename notes-show
+    notes-show-by-id notes-upsert search sync-changes tags
+    vaults-create vaults-delete vaults-index vaults-restore vaults-show vaults-update
+  )
+
+  # Operations whose JSON request body still lacks a top-level `example`
+  # (backfill follow-up). MUST ONLY SHRINK.
+  @pending_request_example ~w(
+    account-delete account-update apikeys-create
+    attachments-batch-delete attachments-batch-move attachments-rename
+    attachments-upload connections-create-pat
+    folders-batch-delete folders-batch-move folders-rename
+    notes-batch-delete notes-batch-move notes-batch-upsert notes-rename
+    vaults-create vaults-register vaults-update
+  )
+
+  setup_all do
+    %{spec: EngramWeb.ApiSpec.spec()}
+  end
+
+  defp operations(spec) do
+    for {path, item} <- spec.paths,
+        verb <- @verbs,
+        op = Map.get(item, verb),
+        not is_nil(op),
+        do: {path, verb, op}
+  end
+
+  defp internal?(op), do: (op.extensions || %{})["x-internal"] == true
+
+  defp id(op, path, verb), do: op.operationId || "#{verb} #{path}"
+
+  # True when the operation carries a JSON request body.
+  defp json_request_body?(%{requestBody: %RequestBody{content: content}})
+       when is_map(content),
+       do: Map.has_key?(content, "application/json")
+
+  defp json_request_body?(_), do: false
+
+  defp request_example?(%{requestBody: %RequestBody{content: content}}, spec) do
+    case content["application/json"] do
+      %MediaType{} = media -> media_example?(media, spec)
+      _ -> false
+    end
+  end
+
+  defp request_example?(_, _), do: false
+
+  # A request example can sit on the media object directly, or (the common
+  # case here) on the referenced request schema.
+  defp media_example?(%MediaType{example: nil, schema: schema}, spec),
+    do: schema_example?(schema, spec)
+
+  defp media_example?(%MediaType{example: _present}, _spec), do: true
+
+  defp schema_example?(%Reference{"$ref": ref}, spec) do
+    title = ref |> String.split("/") |> List.last()
+    schema_example?(spec.components.schemas[title], spec)
+  end
+
+  defp schema_example?(%{example: nil}, _spec), do: false
+  defp schema_example?(%{example: _present}, _spec), do: true
+  defp schema_example?(_, _spec), do: false
+
+  test "every broadcast operation has a prose description", %{spec: spec} do
+    missing =
+      for {path, verb, op} <- operations(spec),
+          not internal?(op),
+          id(op, path, verb) not in @pending_description,
+          not (is_binary(op.description) and op.description != "") do
+        id(op, path, verb)
+      end
+
+    assert missing == [],
+           "Operations missing a `description` — add one, or (only if truly " <>
+             "internal) mark the operation `\"x-internal\": true`:\n" <>
+             Enum.map_join(Enum.sort(missing), "\n", &"  - #{&1}")
+  end
+
+  test "every broadcast operation with a request body has a top-level example",
+       %{spec: spec} do
+    missing =
+      for {path, verb, op} <- operations(spec),
+          not internal?(op),
+          json_request_body?(op),
+          id(op, path, verb) not in @pending_request_example,
+          not request_example?(op, spec) do
+        id(op, path, verb)
+      end
+
+    assert missing == [],
+           "Operations whose request body has no top-level `example` " <>
+             "(add `example:` to the request schema):\n" <>
+             Enum.map_join(Enum.sort(missing), "\n", &"  - #{&1}")
+  end
+
+  test "every schema-level example validates against its own schema", %{spec: spec} do
+    invalid =
+      for {title, schema} <- spec.components.schemas,
+          ex = Map.get(schema, :example),
+          not is_nil(ex),
+          match?({:error, _}, OpenApiSpex.cast_value(ex, schema)) do
+        title
+      end
+
+    assert invalid == [],
+           "Schema examples that do not validate against their schema " <>
+             "(the example rotted — fix it or the schema):\n" <>
+             Enum.map_join(Enum.sort(invalid), "\n", &"  - #{&1}")
+  end
+end


### PR DESCRIPTION
## What

Adds a **universal documentation-coverage gate** over the generated OpenAPI spec (`test/engram_web/api_spec_coverage_test.exs`). It walks *every* operation and fails CI when one lacks:
- a prose `description`, or
- (for ops with a JSON request body) a top-level `example`.

Plus an **example-rot check**: every schema-level `example` is cast against its own schema, so a field change that breaks an example turns CI red instead of shipping a lying example.

## Why

Today only hand-picked endpoints are asserted; a new endpoint can ship under-documented silently. This makes under-documentation a **build failure**, and it rides the existing spec drift-gate + `sync-openapi-to-marketing` pipeline — so a fix in a schema module propagates to the live docs untouched. No second source to drift.

## Escape hatches (both deliberate)

- `"x-internal": true` on an operation → permanently exempt + kept out of the public docs. Applied here to **Logs** + **Embedding** (internal, not part of the broadcast API surface).
- Shrink-only `@pending_description` / `@pending_request_example` allowlists → known debt awaiting backfill. **These must only shrink** — a new endpoint earns its way off by being documented, never onto them.

## This PR (scope: gate + flags + 4 examples)

- Mark `embed-status`, `logs-ingest`, `logs-list` `x-internal`.
- Add request examples to `notes-upsert`, `notes-append`, `search`, `folders-create`.
- Allowlist the remaining ~45 description gaps + ~18 request-example gaps.
- Regenerate `openapi.json`.

**Follow-ups:** PR #2 backfills the remaining descriptions (drains `@pending_description`); a small engram-marketing PR filters `x-internal` ops out of the published docs site.

## Verification

- Gate test: RED first (harvested the gap lists), then GREEN.
- `mix test api_spec_coverage_test.exs api_spec_test.exs` → 51 tests, 0 failures.
- `mix format` + `mix credo` clean on touched files.
- OpenAPI drift gate: committed `openapi.json` matches a fresh regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)