### PR TITLE
fix(cors): allow X-Device-Id header in preflight allowlist

### DIFF
--- a/lib/engram_web/plugs/cors.ex
+++ b/lib/engram_web/plugs/cors.ex
@@ -30,7 +30,10 @@ defmodule EngramWeb.Plugs.CORS do
     conn
     |> put_resp_header("access-control-allow-origin", resolve_origin(conn))
     |> put_resp_header("access-control-allow-methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-    |> put_resp_header("access-control-allow-headers", "authorization, content-type, x-vault-id")
+    |> put_resp_header(
+      "access-control-allow-headers",
+      "authorization, content-type, x-vault-id, x-device-id"
+    )
     |> put_resp_header("access-control-max-age", "86400")
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.488",
+      version: "0.5.489",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/plugs/cors_test.exs
+++ b/test/engram_web/plugs/cors_test.exs
@@ -24,6 +24,21 @@ defmodule EngramWeb.Plugs.CORSTest do
     assert String.contains?(String.downcase(allow_headers), "x-vault-id")
   end
 
+  test "preflight allows the X-Device-Id header the SPA sends on every request" do
+    # The web SPA sets X-Device-Id (api/client.ts, added in #630 for the
+    # cursor-pull gap-filler) on every request so the backend can attribute a
+    # sync cursor per device. If it is not in access-control-allow-headers the
+    # browser blocks the preflight and every authenticated call fails with a
+    # CORS error in prod (app.engram.page -> api.engram.page).
+    conn =
+      build_conn()
+      |> put_req_header("origin", "https://app.engram.dev")
+      |> options("/api/health")
+
+    [allow_headers] = get_resp_header(conn, "access-control-allow-headers")
+    assert String.contains?(String.downcase(allow_headers), "x-device-id")
+  end
+
   test "preflight allows PATCH — the SPA verb for /onboarding/profile and friends" do
     # The web SPA's api client (api/client.ts) exposes patch (no put), and
     # several routes use PATCH: /onboarding/profile, /me, /vaults/:id,


### PR DESCRIPTION
## Prod incident — app.engram.page broken

The SPA at app.engram.page could not reach the API. Browser console:
```
Access to fetch at 'https://api.engram.page/onboarding/status' ... blocked by CORS policy:
Request header field x-device-id is not allowed by Access-Control-Allow-Headers in preflight response.
```

## Root cause
- The web SPA sends `X-Device-Id` on **every** request (`frontend/src/api/client.ts:54`, added in #630 for the cursor-pull gap-filler), and the backend reads it (`sync_controller.ex:78`).
- But `EngramWeb.Plugs.CORS` never added `x-device-id` to `access-control-allow-headers` (it had `authorization, content-type, x-vault-id`).
- Every cross-origin preflight from `app.engram.page` → `api.engram.page` was rejected.

This was a **latent gap since #630**: the `X-Device-Id`-sending frontend only reached prod when PR #673 (a frontend-only change) triggered the first `frontend/` Cloudflare-Worker deploy since #630. The prod backend (release-gated, 0.5.447) still has the old allowlist.

## Fix
One line — add `x-device-id` to the allow-headers (same shape as the prior `x-vault-id` addition). Regression test added (mirrors the `x-vault-id` test). All 13 CORS tests green.

## Deploy note
Prod is **release-gated** — this must reach prod via a `release-v*` tag, not just merge. Plan: merge → tag `release-v0.5.488` → deploy-prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)