### PR TITLE
refactor(api): rename misnamed parse_int* helpers to parse_uuid*

### DIFF
--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -271,7 +271,7 @@ defmodule EngramWeb.FoldersController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    case parse_int_list(ids) do
+    case parse_uuid_list(ids) do
       :error ->
         conn |> put_status(400) |> json(%{error: "invalid_ids"})
 
@@ -321,7 +321,7 @@ defmodule EngramWeb.FoldersController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    with {:ok, ids} <- parse_int_list(ids),
+    with {:ok, ids} <- parse_uuid_list(ids),
          {:ok, tgt} <- parse_move_target(tgt) do
       case Notes.batch_move_folders(user, vault, ids, tgt) do
         {:ok, %{moved: n}} ->
@@ -365,9 +365,9 @@ defmodule EngramWeb.FoldersController do
   defp format_error(binary) when is_binary(binary), do: binary
   defp format_error(_), do: "internal_error"
 
-  defp parse_int_list(list) when is_list(list) do
+  defp parse_uuid_list(list) when is_list(list) do
     Enum.reduce_while(list, {:ok, []}, fn item, {:ok, acc} ->
-      case parse_int(item) do
+      case parse_uuid(item) do
         {:ok, n} -> {:cont, {:ok, [n | acc]}}
         :error -> {:halt, :error}
       end
@@ -378,13 +378,13 @@ defmodule EngramWeb.FoldersController do
     end
   end
 
-  defp parse_int(s) when is_binary(s), do: Ecto.UUID.cast(s)
-  defp parse_int(_), do: :error
+  defp parse_uuid(s) when is_binary(s), do: Ecto.UUID.cast(s)
+  defp parse_uuid(_), do: :error
 
   # Move target is either a folder-marker UUID or the literal "root" sentinel
   # (top level — no parent marker). "root" must bypass the UUID cast.
   defp parse_move_target("root"), do: {:ok, "root"}
-  defp parse_move_target(s) when is_binary(s), do: parse_int(s)
+  defp parse_move_target(s) when is_binary(s), do: parse_uuid(s)
   defp parse_move_target(_), do: :error
 
   defp broadcast_batch(user, vault, payload) do

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -525,7 +525,7 @@ defmodule EngramWeb.NotesController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    case parse_int_list(ids) do
+    case parse_uuid_list(ids) do
       :error ->
         conn |> put_status(400) |> json(%{error: "invalid_ids"})
 
@@ -575,7 +575,7 @@ defmodule EngramWeb.NotesController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    with {:ok, ids} <- parse_int_list(ids),
+    with {:ok, ids} <- parse_uuid_list(ids),
          {:ok, tgt} <- parse_move_target(tgt) do
       case Notes.batch_move_notes(user, vault, ids, tgt) do
         {:ok, %{moved: n}} ->
@@ -662,9 +662,9 @@ defmodule EngramWeb.NotesController do
   # bounded atom escapes; a %Note{} buried in a reason tuple never does).
   defp classify_reason(reason), do: Engram.Telemetry.error_kind(reason)
 
-  defp parse_int_list(list) when is_list(list) do
+  defp parse_uuid_list(list) when is_list(list) do
     Enum.reduce_while(list, {:ok, []}, fn item, {:ok, acc} ->
-      case parse_int(item) do
+      case parse_uuid(item) do
         {:ok, n} -> {:cont, {:ok, [n | acc]}}
         :error -> {:halt, :error}
       end
@@ -675,13 +675,13 @@ defmodule EngramWeb.NotesController do
     end
   end
 
-  defp parse_int(s) when is_binary(s), do: Ecto.UUID.cast(s)
-  defp parse_int(_), do: :error
+  defp parse_uuid(s) when is_binary(s), do: Ecto.UUID.cast(s)
+  defp parse_uuid(_), do: :error
 
   # Move target is either a folder-marker UUID or the literal "root" sentinel
   # (vault root — no marker). "root" must bypass the UUID cast.
   defp parse_move_target("root"), do: {:ok, "root"}
-  defp parse_move_target(s) when is_binary(s), do: parse_int(s)
+  defp parse_move_target(s) when is_binary(s), do: parse_uuid(s)
   defp parse_move_target(_), do: :error
 
   defp broadcast_batch(user, vault, payload) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.490",
+      version: "0.5.491",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

`parse_int` / `parse_int_list` in `notes_controller.ex` and `folders_controller.ex` actually `Ecto.UUID.cast/1` the batch `ids` — note and folder PKs are UUIDs (`Engram.Schema` sets `@primary_key {:id, Ecto.UUID}`). The `_int` name is a leftover from the integer-PK era and already misled a reader into believing the batch endpoints accept integers. Renamed to `parse_uuid` / `parse_uuid_list`.

## Scope

- `notes_controller.ex`, `folders_controller.ex` — renamed (UUID-casting variants).
- `admin/invite_controller.ex` — **untouched**: its `parse_int/2` is a real `Integer.parse` for `max_uses` / `expires_in_days`, correctly named.

Pure rename, no behavior change.

## Verification

- `mix compile --warnings-as-errors` clean.
- `mix test notes_controller_test + folders_controller_batch_test + api_spec_coverage_test` → 50 tests, 0 failures.
- `mix format` + `mix credo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)