### PR TITLE
feat: consolidated /api/bootstrap + ETS-cached entitlement matrix

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -619,6 +619,10 @@ export function useBillingStatus() {
   return useQuery({
     queryKey: ['billing', 'status'],
     queryFn: () => api.get<BillingStatus>('/billing/status'),
+    // Seeded fresh by useAppBootstrap on first load; mutations that change
+    // billing invalidate this key explicitly, so a short staleTime just
+    // suppresses a redundant refetch-on-mount of the seeded payload.
+    staleTime: 60_000,
   })
 }
 
@@ -765,6 +769,64 @@ export function useRecordOnboardingAction() {
       api.post<{ status: string }>('/onboarding/actions', { action }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['onboarding', 'status'] }),
     retry: 3,
+  })
+}
+
+// ── Bootstrap ──────────────────────────────────────────────────────────────
+//
+// One round-trip on first load that returns onboarding + capabilities + vaults
+// (+ billing when enabled), replacing the serial onboarding/billing/vaults
+// fan-out the app used to make before becoming usable. See
+// docs/context/spa-state-injection.md for why this is a fetch (the SaaS HTML is
+// served by Cloudflare and can't inject per-user post-auth state at first paint).
+
+// Resolved entitlement matrix. Every LimitKeys key: an integer cap, a boolean
+// feature flag, or null (no cap / unlimited). Advisory for UX gating — the
+// server still enforces every limit authoritatively.
+export interface Capabilities {
+  tier: 'free' | 'starter' | 'pro'
+  limits: Record<string, number | boolean | null>
+}
+
+export interface BootstrapPayload {
+  onboarding: OnboardingStatus
+  capabilities: Capabilities
+  vaults: { vaults: Vault[] }
+  // Present only when billing is enabled (SaaS); absent on self-host.
+  billing?: BillingStatus
+}
+
+export function useCapabilities() {
+  return useQuery({
+    queryKey: ['capabilities'],
+    // Normally read straight from the cache seeded by useAppBootstrap (staleTime
+    // Infinity → no fetch). The queryFn is a fallback for any consumer that
+    // mounts before the gate's bootstrap seed lands.
+    queryFn: () => api.get<BootstrapPayload>('/bootstrap').then((b) => b.capabilities),
+    staleTime: Infinity,
+  })
+}
+
+/**
+ * Fetches the consolidated first-load payload and seeds the granular query
+ * caches (onboarding, billing, vaults, capabilities) so the hooks that read
+ * those keys resolve from cache instead of issuing their own requests. Mount
+ * this at the top of the authenticated tree (the onboarding gate) so the seed
+ * lands before any vault-scoped view mounts.
+ */
+export function useAppBootstrap() {
+  const qc = useQueryClient()
+  return useQuery({
+    queryKey: ['bootstrap'],
+    queryFn: async () => {
+      const data = await api.get<BootstrapPayload>('/bootstrap')
+      qc.setQueryData(['onboarding', 'status'], data.onboarding)
+      qc.setQueryData(['capabilities'], data.capabilities)
+      qc.setQueryData(['vaults'], data.vaults)
+      if (data.billing) qc.setQueryData(['billing', 'status'], data.billing)
+      return data
+    },
+    staleTime: Infinity,
   })
 }
 
@@ -938,6 +1000,10 @@ export function useVaults() {
     queryFn: () => api.get<{ vaults: Vault[] }>('/vaults'),
     select: (data) => data.vaults,
     enabled: !demo?.active,
+    // Seeded fresh by useAppBootstrap on first load; vault mutations invalidate
+    // this key explicitly, so a short staleTime just suppresses the redundant
+    // refetch-on-mount of the seeded list.
+    staleTime: 60_000,
   })
   if (demo?.active && demo.vault) {
     const base = {

--- a/frontend/src/onboarding/onboarding-gate.test.tsx
+++ b/frontend/src/onboarding/onboarding-gate.test.tsx
@@ -5,13 +5,20 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import OnboardingGate from './onboarding-gate'
 
 vi.mock('../api/queries', () => ({
-  useOnboardingStatus: vi.fn(),
+  useAppBootstrap: vi.fn(),
 }))
 
-import { useOnboardingStatus } from '../api/queries'
+import { useAppBootstrap } from '../api/queries'
 
-function renderWith(status: ReturnType<typeof useOnboardingStatus>) {
-  vi.mocked(useOnboardingStatus).mockReturnValue(status as never)
+// The gate reads onboarding state out of the consolidated bootstrap payload, so
+// wrap each onboarding status under `data.onboarding`.
+function renderWith(onboarding: unknown, rest: Record<string, unknown> = {}) {
+  vi.mocked(useAppBootstrap).mockReturnValue({
+    data: onboarding == null ? undefined : { onboarding },
+    isLoading: false,
+    isError: false,
+    ...rest,
+  } as never)
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
@@ -31,84 +38,60 @@ function renderWith(status: ReturnType<typeof useOnboardingStatus>) {
 }
 
 describe('OnboardingGate', () => {
-  it('renders loading state while status query is pending', () => {
-    renderWith({ data: undefined, isLoading: true, isError: false } as never)
+  it('renders loading state while bootstrap query is pending', () => {
+    renderWith(null, { isLoading: true })
     expect(screen.getByText(/loading/i)).toBeInTheDocument()
   })
 
   it('renders children when next_step is done', () => {
-    renderWith({
-      data: { enabled: true, next_step: 'done', terms_ok: true, subscription_ok: true },
-      isLoading: false,
-      isError: false,
-    } as never)
+    renderWith({ enabled: true, next_step: 'done', terms_ok: true, subscription_ok: true })
     expect(screen.getByText('dashboard')).toBeInTheDocument()
   })
 
   it('renders children when wizard is disabled (self-host)', () => {
-    renderWith({
-      data: { enabled: false, next_step: 'done' },
-      isLoading: false,
-      isError: false,
-    } as never)
+    renderWith({ enabled: false, next_step: 'done' })
     expect(screen.getByText('dashboard')).toBeInTheDocument()
   })
 
   it('redirects to /onboard/agreement when next_step=agreement', () => {
     renderWith({
-      data: {
-        enabled: true,
-        next_step: 'agreement',
-        terms_ok: false,
-        subscription_ok: false,
-      },
-      isLoading: false,
-      isError: false,
-    } as never)
+      enabled: true,
+      next_step: 'agreement',
+      terms_ok: false,
+      subscription_ok: false,
+    })
     expect(screen.getByText('agreement-step')).toBeInTheDocument()
   })
 
   it('redirects to /onboard/billing when next_step=billing', () => {
     renderWith({
-      data: {
-        enabled: true,
-        next_step: 'billing',
-        terms_ok: true,
-        subscription_ok: false,
-      },
-      isLoading: false,
-      isError: false,
-    } as never)
+      enabled: true,
+      next_step: 'billing',
+      terms_ok: true,
+      subscription_ok: false,
+    })
     expect(screen.getByText('billing-step')).toBeInTheDocument()
   })
 
   it('redirects to /onboard/tools when next_step=tools', () => {
     renderWith({
-      data: {
-        enabled: true,
-        next_step: 'tools',
-        terms_ok: true,
-        subscription_ok: true,
-        profile_complete: false,
-      },
-      isLoading: false,
-      isError: false,
-    } as never)
+      enabled: true,
+      next_step: 'tools',
+      terms_ok: true,
+      subscription_ok: true,
+      profile_complete: false,
+    })
     expect(screen.getByText('tools-step')).toBeInTheDocument()
   })
 
   it('redirects to /onboard/vault when next_step=vault', () => {
     renderWith({
-      data: {
-        enabled: true,
-        next_step: 'vault',
-        terms_ok: true,
-        subscription_ok: true,
-        profile_complete: false,
-      },
-      isLoading: false,
-      isError: false,
-    } as never)
+      enabled: true,
+      next_step: 'vault',
+      terms_ok: true,
+      subscription_ok: true,
+      profile_complete: false,
+    })
     expect(screen.getByText('vault-step')).toBeInTheDocument()
   })
 })

--- a/frontend/src/onboarding/onboarding-gate.tsx
+++ b/frontend/src/onboarding/onboarding-gate.tsx
@@ -1,17 +1,22 @@
 import { Navigate, Outlet } from 'react-router'
-import { useOnboardingStatus } from '../api/queries'
+import { useAppBootstrap } from '../api/queries'
 import LoadingScreen from '../layout/loading-screen'
 
 export default function OnboardingGate() {
-  const { data, isLoading } = useOnboardingStatus()
+  // Single first-load fetch: resolves onboarding state AND seeds the billing /
+  // vaults / capabilities caches, so the views mounted past this gate read from
+  // cache instead of each issuing their own request.
+  const { data, isLoading } = useAppBootstrap()
 
   if (isLoading || !data) {
     return <LoadingScreen />
   }
 
-  if (!data.enabled || data.next_step === 'done') {
+  const onboarding = data.onboarding
+
+  if (!onboarding.enabled || onboarding.next_step === 'done') {
     return <Outlet />
   }
 
-  return <Navigate to={`/onboard/${data.next_step}`} replace />
+  return <Navigate to={`/onboard/${onboarding.next_step}`} replace />
 }

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -43,6 +43,10 @@ defmodule Engram.Application do
         # every node. Must start before OverrideCache.
         pg_notifications_child(),
         Engram.Billing.OverrideCache,
+        # Resolved-entitlement cache (tier + full LimitKeys matrix), keyed by
+        # user. Also LISTENs on user_limit_overrides_changed, so it must start
+        # after pg_notifications_child like OverrideCache.
+        Engram.Billing.EntitlementCache,
         Engram.Auth.SignupRejections,
         rate_limiter_child(),
         {Oban, Application.fetch_env!(:engram, Oban)},

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -7,6 +7,7 @@ defmodule Engram.Billing do
   """
 
   import Ecto.Query
+  alias Engram.Billing.EntitlementCache
   alias Engram.Billing.LimitKeys
   alias Engram.Billing.PlanCache
   alias Engram.Billing.Subscription
@@ -189,6 +190,50 @@ defmodule Engram.Billing do
       _ -> nil
     end
   end
+
+  @doc """
+  Returns the user's full, JSON-ready entitlement snapshot:
+
+      %{tier: "free", limits: %{"notes_cap" => 10_000, "api_write_enabled" => false, ...}}
+
+  Every `LimitKeys` key is resolved through `effective_limit/2` and normalized:
+  integer caps stay integers (`:unlimited`/`nil`/`-1` → `null`), boolean
+  features stay booleans (`:unlimited` → `true`, the "limits disabled" sense).
+
+  Backed by `Engram.Billing.EntitlementCache` (24h TTL + explicit invalidation
+  on subscription/override changes) so the bootstrap path serves the whole
+  matrix from one ETS read. This is advisory UX state — server-side
+  `check_limit/3` / `check_feature/2` remain the authoritative gates.
+  """
+  @spec capabilities(Engram.Accounts.User.t()) :: %{tier: String.t(), limits: map()}
+  def capabilities(%Engram.Accounts.User{id: nil} = user), do: compute_capabilities(user)
+
+  def capabilities(%Engram.Accounts.User{} = user) do
+    EntitlementCache.fetch(user.id, fn -> compute_capabilities(user) end)
+  end
+
+  defp compute_capabilities(user) do
+    limits =
+      Map.new(LimitKeys.all(), fn key ->
+        value = normalize_capability(LimitKeys.type(key), effective_limit(user, key))
+        {Atom.to_string(key), value}
+      end)
+
+    %{tier: Atom.to_string(tier(user)), limits: limits}
+  end
+
+  # Boolean feature: :unlimited (enforcement off) opens the gate; explicit
+  # true/false flows through; anything else fails closed.
+  defp normalize_capability(:boolean, :unlimited), do: true
+  defp normalize_capability(:boolean, true), do: true
+  defp normalize_capability(:boolean, false), do: false
+  defp normalize_capability(:boolean, _), do: false
+  # Integer cap: "no cap" sentinels collapse to null for the wire.
+  defp normalize_capability(:integer, :unlimited), do: nil
+  defp normalize_capability(:integer, nil), do: nil
+  defp normalize_capability(:integer, -1), do: nil
+  defp normalize_capability(:integer, n) when is_integer(n), do: n
+  defp normalize_capability(:integer, _), do: nil
 
   @doc """
   Returns true when the user is not suspended. Tier defaults to `:free`
@@ -639,6 +684,10 @@ defmodule Engram.Billing do
     # tier/status flips can change the onboarding gate's subscription_ok,
     # so the cached pass verdict must re-derive.
     :ok = Engram.Onboarding.GateCache.evict(user_id)
+
+    # Same flip changes the user's tier and therefore their entire resolved
+    # limit matrix — drop the cached entitlement snapshot so it re-derives.
+    :ok = EntitlementCache.evict(user_id)
 
     # Carry the full plan snapshot so the plugin can re-gate attachments the
     # instant the subscription flips, without a follow-up fetch. `tier` stays

--- a/lib/engram/billing/entitlement_cache.ex
+++ b/lib/engram/billing/entitlement_cache.ex
@@ -1,0 +1,177 @@
+defmodule Engram.Billing.EntitlementCache do
+  @moduledoc """
+  Node-local read-through cache of a user's resolved *entitlements* — their
+  tier plus the full `Engram.Billing.LimitKeys` matrix — keyed by user id.
+
+  `Engram.Billing.capabilities/1` resolves every `LimitKeys` key for a user
+  (each a `effective_limit/2` walk over override → env → plan → default). That
+  answer is stable for the life of a subscription, so the bootstrap path
+  (`GET /api/bootstrap`) and any future hot caller can serve it from a single
+  ETS read instead of re-resolving the whole matrix per request.
+
+  Unlike `OverrideCache` (which caches the raw override row lookup, hits AND
+  misses, on a 60s TTL), this caches the *fully resolved* capability map on a
+  long #{div(86_400_000, 3_600_000)}h TTL — because freshness here is carried by
+  explicit invalidation, not by the TTL:
+
+    * subscription mutations (created/updated/canceled) evict via
+      `Engram.Billing.broadcast_subscription_activated/2` — tier flips change
+      every limit, so the cached map must re-derive;
+    * override expiry (`Engram.Billing.Workers.OverrideExpirySweep`) calls
+      `evict_all/0` whenever it deletes rows;
+    * out-of-band override writes (support runbook / e2e SQL) fire the
+      `user_limit_overrides_changed` Postgres NOTIFY — this cache LISTENs on it
+      exactly like `OverrideCache`, so a grant/revoke evicts the affected user
+      on every node within milliseconds.
+
+  The long TTL is purely a backstop for an invalidation site this list misses;
+  it is NOT the freshness mechanism. A stale entry can only ever extend an
+  entitlement for at most the TTL — server-side enforcement
+  (`check_limit/3` / `check_feature/2`) remains the authoritative gate, so this
+  cache is advisory for UX, never a security boundary.
+
+  Cross-node evictions ride `Engram.Cluster.CacheSync` like every other
+  node-local cache here.
+  """
+
+  use GenServer
+
+  alias Engram.Cluster.CacheSync
+
+  require Logger
+
+  @table :engram_billing_entitlement_cache
+  @ttl_ms 86_400_000
+  @pg_channel "user_limit_overrides_changed"
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @doc """
+  Returns the cached entitlement map for `user_id`, or runs `fun`, caches its
+  result, and returns it.
+  """
+  @spec fetch(Ecto.UUID.t(), (-> map())) :: map()
+  def fetch(user_id, fun) do
+    case lookup(user_id) do
+      {:ok, value} ->
+        value
+
+      :stale ->
+        value = fun.()
+        put(user_id, value)
+        value
+    end
+  end
+
+  @doc """
+  Clears the entitlement entry for one user locally and on peer nodes. Call on
+  every entitlement-changing event (subscription mutation, override write).
+  """
+  @spec evict(Ecto.UUID.t()) :: :ok
+  def evict(user_id) do
+    _ = delete_local(user_id)
+    CacheSync.broadcast({:billing_entitlement_evict, user_id})
+  end
+
+  @doc "Flushes every entry locally and on peer nodes (bulk override expiry)."
+  @spec evict_all() :: :ok
+  def evict_all do
+    _ = clear_local()
+    CacheSync.broadcast(:billing_entitlement_evict_all)
+  end
+
+  defp lookup(user_id) do
+    case :ets.lookup(@table, user_id) do
+      [{^user_id, value, expires_at}] ->
+        if System.monotonic_time(:millisecond) < expires_at, do: {:ok, value}, else: :stale
+
+      _ ->
+        :stale
+    end
+  rescue
+    # Table absent (cache process down) → treat every read as stale; the
+    # caller falls through to the authoritative resolution.
+    ArgumentError -> :stale
+  end
+
+  defp put(user_id, value) do
+    expires_at = System.monotonic_time(:millisecond) + @ttl_ms
+    :ets.insert(@table, {user_id, value, expires_at})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp delete_local(user_id) do
+    :ets.delete(@table, user_id)
+  rescue
+    ArgumentError -> true
+  end
+
+  defp clear_local do
+    :ets.delete_all_objects(@table)
+  rescue
+    ArgumentError -> true
+  end
+
+  @impl true
+  def init(:ok) do
+    _ =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    :ok = CacheSync.subscribe()
+    :ok = listen_pg()
+    {:ok, %{}}
+  end
+
+  # LISTEN on the channel fired by the user_limit_overrides AFTER-write trigger
+  # (migration 20260612100000), shared with OverrideCache. This is what makes
+  # raw-SQL override writers coherent: every node hears the NOTIFY directly from
+  # Postgres and evicts within milliseconds. Failure to listen is non-fatal —
+  # the TTL still bounds staleness — so log and continue.
+  defp listen_pg do
+    case Process.whereis(Engram.PgNotifications) do
+      nil ->
+        Logger.warning(
+          "EntitlementCache: PG notifications process not running; TTL-only eviction"
+        )
+
+      _pid ->
+        {:ok, _ref} = Postgrex.Notifications.listen(Engram.PgNotifications, @pg_channel)
+        :ok
+    end
+  catch
+    kind, reason ->
+      Logger.warning(
+        "EntitlementCache: failed to LISTEN #{@pg_channel} (#{kind}: #{inspect(reason)}); " <>
+          "TTL-only eviction"
+      )
+  end
+
+  @impl true
+  def handle_info({:notification, _pid, _ref, @pg_channel, user_id}, state) do
+    _ = delete_local(user_id)
+    {:noreply, state}
+  end
+
+  def handle_info({:cache_sync, {:billing_entitlement_evict, user_id}}, state) do
+    _ = delete_local(user_id)
+    {:noreply, state}
+  end
+
+  def handle_info({:cache_sync, :billing_entitlement_evict_all}, state) do
+    _ = clear_local()
+    {:noreply, state}
+  end
+
+  # Ignore cache_sync messages addressed to other caches.
+  def handle_info({:cache_sync, _other}, state), do: {:noreply, state}
+end

--- a/lib/engram/billing/workers/override_expiry_sweep.ex
+++ b/lib/engram/billing/workers/override_expiry_sweep.ex
@@ -25,8 +25,13 @@ defmodule Engram.Billing.Workers.OverrideExpirySweep do
       )
 
     # Cached lookups (hits and misses) may now be wrong — flush so
-    # expirations take effect without waiting out the cache TTL.
-    if count > 0, do: Engram.Billing.OverrideCache.evict_all()
+    # expirations take effect without waiting out the cache TTL. Both the raw
+    # override lookup cache and the resolved-entitlement cache derive from
+    # these rows.
+    if count > 0 do
+      Engram.Billing.OverrideCache.evict_all()
+      Engram.Billing.EntitlementCache.evict_all()
+    end
 
     :telemetry.execute(
       [:engram, :billing, :overrides, :expired],

--- a/lib/engram/connections.ex
+++ b/lib/engram/connections.ex
@@ -39,7 +39,7 @@ defmodule Engram.Connections do
   "Active" means: not revoked, not consumed (OAuth), not expired.
   Multiple tokens in the same rotation family collapse to 1 (DISTINCT).
   """
-  @spec count_active(integer(), kind()) :: non_neg_integer()
+  @spec count_active(Ecto.UUID.t(), kind()) :: non_neg_integer()
   def count_active(user_id, :obsidian) do
     oauth_active_count(user_id, "obsidian") + device_active_count(user_id)
   end
@@ -79,7 +79,7 @@ defmodule Engram.Connections do
   is inside the `device_swap_cooldown_hours` window after revoking a
   device. Family-grain (not row-grain): one revoke per swap.
   """
-  @spec most_recent_device_revoke(integer()) :: DateTime.t() | nil
+  @spec most_recent_device_revoke(Ecto.UUID.t()) :: DateTime.t() | nil
   def most_recent_device_revoke(user_id) do
     from(rt in DeviceRefreshToken,
       where: rt.user_id == ^user_id,

--- a/lib/engram_web/controllers/billing_controller.ex
+++ b/lib/engram_web/controllers/billing_controller.ex
@@ -8,10 +8,19 @@ defmodule EngramWeb.BillingController do
   require Logger
 
   def status(conn, _params) do
-    user = conn.assigns.current_user
+    json(conn, status_payload(conn.assigns.current_user))
+  end
+
+  @doc """
+  Builds the `GET /api/billing/status` JSON map for a user. Public so the
+  consolidated `GET /api/bootstrap` endpoint serves the identical shape. Holds
+  the *volatile* slice (live trial countdown, connection counts, swap cooldown)
+  — the stable capability matrix is served separately via `Billing.capabilities/1`.
+  """
+  def status_payload(user) do
     sub = Billing.get_subscription(user)
 
-    json(conn, %{
+    %{
       tier: to_string(Billing.tier(user)),
       active: Billing.tier(user) in [:starter, :pro],
       trial_days_remaining: Billing.trial_days_remaining(user),
@@ -42,7 +51,7 @@ defmodule EngramWeb.BillingController do
       # window already elapsed). Lets /link render a cooldown-specific
       # banner + disable Authorize BEFORE the user trips the 402.
       device_swap_cooldown_remaining_hours: swap_cooldown_remaining(user)
-    })
+    }
   end
 
   # Mirrors `EnforceDeviceCap.remaining_cooldown_hours/2`: computed from

--- a/lib/engram_web/controllers/bootstrap_controller.ex
+++ b/lib/engram_web/controllers/bootstrap_controller.ex
@@ -1,0 +1,51 @@
+defmodule EngramWeb.BootstrapController do
+  @moduledoc """
+  One authenticated round-trip that returns everything the SPA needs to decide
+  what to render and what the user is allowed to do — replacing the serial
+  `GET /api/onboarding/status` + `GET /api/billing/status` + `GET /api/vaults`
+  fan-out the app used to make before becoming usable.
+
+  Lives on the onboarding pipeline (Auth, but NOT RequireOnboarding /
+  RequireApiRpsBudget) so the client can call it on first load, *before*
+  onboarding is complete, to learn `next_step`.
+
+  Payload:
+
+      {
+        "onboarding":   { ...identical to GET /api/onboarding/status... },
+        "capabilities": { "tier": "...", "limits": { "<key>": <int|bool|null> } },
+        "vaults":       { "vaults": [...] },
+        "billing":      { ...identical to GET /api/billing/status... }   // only when billing enabled
+      }
+
+  `capabilities` is the stable, ETS-cached entitlement matrix (24h TTL +
+  invalidation on subscription/override change). `onboarding`, `vaults`, and the
+  volatile `billing` slice are computed fresh — they track ordinary user actions
+  (accepting terms, creating a vault, connecting a device) that must not lag.
+  """
+  use EngramWeb, :controller
+
+  alias Engram.Billing
+  alias EngramWeb.BillingController
+  alias EngramWeb.OnboardingController
+  alias EngramWeb.VaultsController
+
+  def show(conn, _params) do
+    user = conn.assigns.current_user
+
+    payload = %{
+      onboarding: OnboardingController.status_payload(user),
+      capabilities: Billing.capabilities(user),
+      vaults: VaultsController.index_payload(user)
+    }
+
+    payload =
+      if Application.get_env(:engram, :billing_enabled, false) do
+        Map.put(payload, :billing, BillingController.status_payload(user))
+      else
+        payload
+      end
+
+    json(conn, payload)
+  end
+end

--- a/lib/engram_web/controllers/onboarding_controller.ex
+++ b/lib/engram_web/controllers/onboarding_controller.ex
@@ -6,18 +6,22 @@ defmodule EngramWeb.OnboardingController do
   alias EngramWeb.RequestMeta
 
   def status(conn, _params) do
-    user = conn.assigns.current_user
+    json(conn, status_payload(conn.assigns.current_user))
+  end
 
-    payload =
-      Onboarding.status(user)
-      |> Map.update!(:next_step, &Atom.to_string/1)
-      |> Map.update!(:steps, fn steps -> Enum.map(steps, &Atom.to_string/1) end)
-      |> reject_nil_notice()
-      |> reject_empty_profile()
-      |> Map.put(:actions, Onboarding.list_actions(user.id))
-      |> Map.put(:vault_count, Engram.Vaults.count_for(user))
-
-    json(conn, payload)
+  @doc """
+  Builds the `GET /api/onboarding/status` JSON map for a user. Public so the
+  consolidated `GET /api/bootstrap` endpoint serves the identical shape without
+  re-deriving the transforms.
+  """
+  def status_payload(user) do
+    Onboarding.status(user)
+    |> Map.update!(:next_step, &Atom.to_string/1)
+    |> Map.update!(:steps, fn steps -> Enum.map(steps, &Atom.to_string/1) end)
+    |> reject_nil_notice()
+    |> reject_empty_profile()
+    |> Map.put(:actions, Onboarding.list_actions(user.id))
+    |> Map.put(:vault_count, Engram.Vaults.count_for(user))
   end
 
   def record(conn, %{"action" => action}) when is_binary(action) do

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -47,12 +47,7 @@ defmodule EngramWeb.VaultsController do
 
   def index(conn, params) do
     user = conn.assigns.current_user
-    vaults = Vaults.list_vaults(user)
-    counts = Vaults.content_counts_for(user, vaults)
-
-    payload = %{
-      vaults: Enum.map(vaults, &vault_json(&1, Map.get(counts, &1.id, @zero_counts)))
-    }
+    payload = index_payload(user)
 
     payload =
       case Map.get(params, "user_code") do
@@ -68,6 +63,18 @@ defmodule EngramWeb.VaultsController do
       end
 
     json(conn, payload)
+  end
+
+  @doc """
+  Builds the base `GET /api/vaults` JSON map (`%{vaults: [...]}`) for a user.
+  Public so the consolidated `GET /api/bootstrap` endpoint serves the identical
+  list shape without the device-link `user_code` extension.
+  """
+  def index_payload(user) do
+    vaults = Vaults.list_vaults(user)
+    counts = Vaults.content_counts_for(user, vaults)
+
+    %{vaults: Enum.map(vaults, &vault_json(&1, Map.get(counts, &1.id, @zero_counts)))}
   end
 
   # ── create ─────────────────────────────────────────────────────────────────

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -31,8 +31,8 @@ defmodule EngramWeb.Plugs.HostRewrite do
   # Missing entries silently 404 in prod — guarded by a regression test.
   @api_top_segments ~w(
     notes folders search vaults attachments oauth mcp auth admin billing
-    tasks health user me onboarding api-keys connections tags sync logs
-    embed-status openapi
+    tasks health user me onboarding bootstrap api-keys connections tags sync
+    logs embed-status openapi
   )
 
   # Test-only accessor exposing the @api_top_segments allowlist so the

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -258,6 +258,12 @@ defmodule EngramWeb.Router do
       EngramWeb.Plugs.RotationLockCheck
     ]
 
+    # Consolidated first-load payload: onboarding + capabilities + vaults
+    # (+ billing when enabled) in one round-trip. Sits here (not the
+    # vault-scoped pipeline) so the SPA can fetch it before onboarding is
+    # complete to learn `next_step`.
+    get "/bootstrap", BootstrapController, :show
+
     # Onboarding wizard — status + TOS acceptance. Exempt from
     # RequireOnboarding (the plug is only on the vault-scoped pipeline)
     # so the wizard can actually function before completion.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.495",
+      version: "0.5.496",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/billing/capabilities_test.exs
+++ b/test/engram/billing/capabilities_test.exs
@@ -1,0 +1,70 @@
+defmodule Engram.Billing.CapabilitiesTest do
+  # async: false — Billing.capabilities/1 reads through the process-global
+  # EntitlementCache (named ETS, not sandboxed), so concurrent users of the
+  # same cache could observe each other's entries. evict_all between tests
+  # keeps them isolated.
+  use Engram.DataCase, async: false
+
+  alias Engram.Billing
+  alias Engram.Billing.EntitlementCache
+
+  setup do
+    on_exit(fn -> EntitlementCache.evict_all() end)
+    :ok
+  end
+
+  test "resolves the free-tier matrix for a user with no subscription" do
+    user = insert(:user)
+    caps = Billing.capabilities(user)
+
+    assert caps.tier == "free"
+    assert caps.limits["notes_cap"] == 10_000
+    assert caps.limits["vaults_cap"] == 1
+    # Boolean feature stays a boolean; integer "unlimited" caps serialize to nil.
+    assert caps.limits["api_write_enabled"] == false
+    assert caps.limits["ai_queries_per_day"] == nil
+  end
+
+  test "resolves paid-tier limits when the user has an entitling subscription" do
+    user = insert(:user)
+    insert(:subscription, user: user, tier: "starter", status: "active")
+
+    caps = Billing.capabilities(user)
+
+    assert caps.tier == "starter"
+    assert caps.limits["notes_cap"] == 50_000
+    assert caps.limits["vaults_cap"] == 5
+    assert caps.limits["api_write_enabled"] == true
+  end
+
+  test "exposes every defined limit key as a JSON-safe value" do
+    user = insert(:user)
+    caps = Billing.capabilities(user)
+
+    expected_keys = Enum.map(Engram.Billing.LimitKeys.all(), &Atom.to_string/1)
+    assert Enum.sort(Map.keys(caps.limits)) == Enum.sort(expected_keys)
+
+    Enum.each(caps.limits, fn {_key, v} ->
+      assert is_integer(v) or is_boolean(v) or is_nil(v)
+    end)
+  end
+
+  test "serves a cached snapshot until the entitlement cache is evicted" do
+    user = insert(:user)
+
+    # Warm the cache while the user is on Free.
+    assert %{tier: "free"} = Billing.capabilities(user)
+
+    # A raw subscription insert does NOT route through the eviction chokepoint
+    # (broadcast_subscription_activated/2), so the cached Free snapshot stands.
+    insert(:subscription, user: user, tier: "pro", status: "active")
+    assert %{tier: "free"} = Billing.capabilities(user)
+
+    # Explicit eviction (what the chokepoint and override sweep call) forces a
+    # re-derivation that now sees the paid tier.
+    :ok = EntitlementCache.evict(user.id)
+    caps = Billing.capabilities(user)
+    assert caps.tier == "pro"
+    assert caps.limits["notes_cap"] == nil
+  end
+end

--- a/test/engram/billing/entitlement_cache_test.exs
+++ b/test/engram/billing/entitlement_cache_test.exs
@@ -1,0 +1,69 @@
+defmodule Engram.Billing.EntitlementCacheTest do
+  use ExUnit.Case, async: false
+
+  alias Engram.Billing.EntitlementCache
+
+  setup do
+    on_exit(fn -> EntitlementCache.evict_all() end)
+    :ok
+  end
+
+  test "fetch caches the function result and serves it without re-running fun" do
+    user_id = Ecto.UUID.generate()
+    value = %{tier: "free", limits: %{"notes_cap" => 10_000}}
+
+    assert ^value = EntitlementCache.fetch(user_id, fn -> value end)
+    # Second fetch must NOT invoke the fun.
+    assert ^value = EntitlementCache.fetch(user_id, fn -> raise "should not run" end)
+  end
+
+  test "evict drops one user, leaving others cached" do
+    user_id = Ecto.UUID.generate()
+    other_id = Ecto.UUID.generate()
+
+    assert :a = EntitlementCache.fetch(user_id, fn -> :a end)
+    assert :b = EntitlementCache.fetch(other_id, fn -> :b end)
+
+    :ok = EntitlementCache.evict(user_id)
+
+    # Evicted user re-runs the fun; unrelated user stays cached.
+    assert :a2 = EntitlementCache.fetch(user_id, fn -> :a2 end)
+    assert :b = EntitlementCache.fetch(other_id, fn -> raise "should not run" end)
+  end
+
+  test "evict_all flushes every entry" do
+    a = Ecto.UUID.generate()
+    b = Ecto.UUID.generate()
+
+    assert :a = EntitlementCache.fetch(a, fn -> :a end)
+    assert :b = EntitlementCache.fetch(b, fn -> :b end)
+
+    :ok = EntitlementCache.evict_all()
+
+    assert :a2 = EntitlementCache.fetch(a, fn -> :a2 end)
+    assert :b2 = EntitlementCache.fetch(b, fn -> :b2 end)
+  end
+
+  test "a Postgres notification for the user evicts their cached entry" do
+    # Shared with OverrideCache: the user_limit_overrides AFTER-write trigger
+    # pg_notifys the user_id, so raw-SQL override writes (support runbook,
+    # e2e helpers) invalidate the resolved-entitlement cache too. This pins
+    # the message handling.
+    user_id = Ecto.UUID.generate()
+    other_id = Ecto.UUID.generate()
+
+    assert :cached = EntitlementCache.fetch(user_id, fn -> :cached end)
+    assert :other = EntitlementCache.fetch(other_id, fn -> :other end)
+
+    send(
+      Process.whereis(EntitlementCache),
+      {:notification, self(), make_ref(), "user_limit_overrides_changed", user_id}
+    )
+
+    # Force the GenServer to process the message before asserting.
+    :sys.get_state(EntitlementCache)
+
+    assert :rederived = EntitlementCache.fetch(user_id, fn -> :rederived end)
+    assert :other = EntitlementCache.fetch(other_id, fn -> raise "should not run" end)
+  end
+end

--- a/test/engram_web/controllers/bootstrap_controller_test.exs
+++ b/test/engram_web/controllers/bootstrap_controller_test.exs
@@ -1,0 +1,107 @@
+defmodule EngramWeb.BootstrapControllerTest do
+  # async: false — flips the global :billing_enabled app env (toggles whether
+  # the billing slice is present) and reads through the process-global
+  # EntitlementCache. Matches the other billing_enabled-flipping suites.
+  use EngramWeb.ConnCase, async: false
+
+  alias Engram.Accounts
+  alias Engram.Billing.EntitlementCache
+  alias Engram.Legal.VersionCache
+  alias Engram.LegalFixtures
+
+  setup do
+    on_exit(fn -> EntitlementCache.evict_all() end)
+    :ok
+  end
+
+  defp authed_conn(conn) do
+    user = insert(:user, onboarding_profile: %{})
+    {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
+    grant_api_write!(user)
+    {put_req_header(conn, "authorization", "Bearer #{raw_key}"), user}
+  end
+
+  describe "GET /api/bootstrap (billing enabled)" do
+    setup %{conn: conn} do
+      prev = Application.get_env(:engram, :billing_enabled)
+      Application.put_env(:engram, :billing_enabled, true)
+
+      LegalFixtures.insert_version(
+        document: "terms_of_service",
+        version: "2026-05-15",
+        content_hash: "canonical",
+        material: true,
+        effective_date: nil
+      )
+
+      LegalFixtures.insert_version(
+        document: "privacy_policy",
+        version: "2026-05-15",
+        content_hash: "p",
+        material: true,
+        effective_date: nil
+      )
+
+      VersionCache.invalidate_all()
+      on_exit(&VersionCache.invalidate_all/0)
+      on_exit(fn -> Application.put_env(:engram, :billing_enabled, prev) end)
+
+      {conn, user} = authed_conn(conn)
+      {:ok, conn: conn, user: user}
+    end
+
+    test "returns onboarding, capabilities, vaults, and billing in one payload", %{conn: conn} do
+      body = conn |> get("/api/bootstrap") |> json_response(200)
+
+      # Onboarding slice mirrors GET /api/onboarding/status for a fresh user.
+      assert body["onboarding"]["enabled"] == true
+      assert body["onboarding"]["next_step"] == "agreement"
+
+      # Capabilities slice — free-tier matrix.
+      assert body["capabilities"]["tier"] == "free"
+      assert body["capabilities"]["limits"]["notes_cap"] == 10_000
+      assert body["capabilities"]["limits"]["api_write_enabled"] == false
+
+      # Vaults slice — empty for a brand-new user.
+      assert body["vaults"]["vaults"] == []
+
+      # Billing slice present because billing is enabled.
+      assert body["billing"]["tier"] == "free"
+      assert body["billing"]["active"] == false
+    end
+
+    test "capabilities reflect a paid subscription", %{conn: conn, user: user} do
+      insert(:subscription, user: user, tier: "pro", status: "active")
+
+      body = conn |> get("/api/bootstrap") |> json_response(200)
+
+      assert body["capabilities"]["tier"] == "pro"
+      assert body["capabilities"]["limits"]["notes_cap"] == nil
+      assert body["billing"]["tier"] == "pro"
+    end
+
+    test "returns 401 without auth" do
+      assert build_conn() |> get("/api/bootstrap") |> json_response(401)
+    end
+  end
+
+  describe "GET /api/bootstrap (billing disabled / self-host)" do
+    setup %{conn: conn} do
+      prev = Application.get_env(:engram, :billing_enabled)
+      Application.put_env(:engram, :billing_enabled, false)
+      on_exit(fn -> Application.put_env(:engram, :billing_enabled, prev) end)
+
+      {conn, user} = authed_conn(conn)
+      {:ok, conn: conn, user: user}
+    end
+
+    test "omits the billing slice but still returns capabilities", %{conn: conn} do
+      body = conn |> get("/api/bootstrap") |> json_response(200)
+
+      refute Map.has_key?(body, "billing")
+      assert body["capabilities"]["tier"] == "free"
+      assert is_map(body["capabilities"]["limits"])
+      assert body["onboarding"]["enabled"] == true
+    end
+  end
+end

--- a/test/engram_web/controllers/bootstrap_controller_test.exs
+++ b/test/engram_web/controllers/bootstrap_controller_test.exs
@@ -17,7 +17,9 @@ defmodule EngramWeb.BootstrapControllerTest do
   defp authed_conn(conn) do
     user = insert(:user, onboarding_profile: %{})
     {:ok, raw_key, _api_key} = Accounts.create_api_key(user, "test")
-    grant_api_write!(user)
+    # No grant_api_write! — /api/bootstrap is GET-only and RequireApiWriteEnabled
+    # never gates GET/HEAD, so granting the paid feature here would wrongly flip
+    # the asserted free-tier api_write_enabled default (false) to true.
     {put_req_header(conn, "authorization", "Bearer #{raw_key}"), user}
   end
 


### PR DESCRIPTION
Supersedes #681 (same work, moved off the `claude/*` branch — CI's `on: push` allowlist only matches conventional prefixes, so #681 never ran any checks).

## What

Collapse the 3–4 serial first-load round-trips (onboarding status, billing status, vaults) into one `GET /api/bootstrap`, and back the user's resolved capability matrix with a long-lived, explicitly-invalidated ETS cache so repeated resolution is a single ETS read.

**Backend**
- `Engram.Billing.EntitlementCache`: node-local ETS cache of `{tier, limits}` keyed by user id, 24h TTL (backstop; freshness comes from explicit invalidation). Mirrors `OverrideCache` (CacheSync cross-node evictions + LISTEN on `user_limit_overrides_changed`).
- `Engram.Billing.capabilities/1`: resolves every `LimitKeys` key via `effective_limit/2` into a JSON-ready `%{tier, limits}` map, served through `EntitlementCache`.
- Invalidation wired into the two entitlement-changing sites: subscription-mutation chokepoint (`broadcast_subscription_activated/2`) + override-expiry sweep, plus the shared PG NOTIFY for out-of-band override writes.
- `EngramWeb.BootstrapController` + `GET /api/bootstrap` on the onboarding pipeline (Auth but not RequireOnboarding) so the SPA can fetch before onboarding completes. Reuses extracted `*_payload/1` builders so each slice is byte-identical to its standalone endpoint.

Capabilities are advisory UX state; server-side `check_limit/3` + `check_feature/2` remain authoritative. Onboarding progress and usage counts stay computed-fresh — only the stable tier+limits slice is cached.

**Frontend**
- `useAppBootstrap()`: one `/bootstrap` fetch that seeds the onboarding/billing/vaults/capabilities query caches, mounted in `OnboardingGate`.
- Short `staleTime` on `useVaults`/`useBillingStatus` so the seed isn't immediately refetched; mutations still invalidate explicitly.

## Pickup changes (this branch, on top of the original)
- Rebased onto `main`.
- **Fixed the one failing test**: `bootstrap_controller_test` `authed_conn` granted `api_write_enabled`, but `/api/bootstrap` is GET-only and `RequireApiWriteEnabled` never gates GET/HEAD — the grant was spurious and wrongly flipped the asserted free-tier default (`false`) to `true`. Removed it.
- Version `0.5.495 → 0.5.496` (`.495` landed on `main` via a parallel merge).

## Verification (local)
- Backend: entitlement_cache + capabilities + bootstrap suites 12/0; touched controller suites 230/0; `mix format` clean; `mix credo` clean.
- Frontend: `onboarding-gate.test.tsx` 7/7; `tsc --noEmit` clean.

Original authorship preserved in the branch history (Opus 4.8 cloud session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)