### PR TITLE
fix(billing): refresh tier UI after upgrade (#603)

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1107,16 +1107,30 @@ export function useCreateVault() {
 // /billing/status + /billing/subscription so the StatusCard reflects the
 // new scheduled change immediately, before webhook sync catches up.
 
-function invalidateBilling(qc: QueryClient) {
-  qc.invalidateQueries({ queryKey: ['billing', 'status'] })
-  qc.invalidateQueries({ queryKey: ['billing', 'subscription'] })
+/**
+ * Invalidate every cache derived from the user's subscription state — the
+ * volatile billing slices AND the cached capability matrix (`['capabilities']`,
+ * the tier+limits map seeded by bootstrap). Call after ANY subscription change
+ * (checkout completed, activation push, plan change, cancel, reverse-cancel) so
+ * the tier badge, caps, plan-change "current" highlight, and free-tier gates
+ * all refresh together. Missing one key here is how an upgrade leaves the UI
+ * stuck on the old tier until a manual refresh (#603). Returns a promise so
+ * callers that need fresh data before navigating can await it.
+ */
+export function invalidateBillingState(qc: QueryClient) {
+  return Promise.all([
+    qc.invalidateQueries({ queryKey: ['billing', 'status'] }),
+    qc.invalidateQueries({ queryKey: ['billing', 'subscription'] }),
+    qc.invalidateQueries({ queryKey: ['billing', 'transactions'] }),
+    qc.invalidateQueries({ queryKey: ['capabilities'] }),
+  ])
 }
 
 export function useCancelSubscription() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: () => api.post<Record<string, unknown>>('/billing/cancel-subscription'),
-    onSuccess: () => invalidateBilling(qc),
+    onSuccess: () => invalidateBillingState(qc),
   })
 }
 
@@ -1124,7 +1138,7 @@ export function useReverseCancel() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: () => api.post<Record<string, unknown>>('/billing/reverse-cancel'),
-    onSuccess: () => invalidateBilling(qc),
+    onSuccess: () => invalidateBillingState(qc),
   })
 }
 
@@ -1160,7 +1174,7 @@ export function useConfirmPlanChange() {
       api.post<Record<string, unknown>>('/billing/plan-change/confirm', {
         target_price_id: targetPriceId,
       }),
-    onSuccess: () => invalidateBilling(qc),
+    onSuccess: () => invalidateBillingState(qc),
   })
 }
 

--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -411,6 +411,76 @@ describe('BillingPage — Paddle effect cleanup', () => {
     })
   })
 
+  it('upgrade: CHECKOUT_COMPLETED invalidates billing/status and capabilities (#603)', async () => {
+    // The bug: an upgrade's CHECKOUT_COMPLETED invalidated only subscription +
+    // transactions, never ['billing','status'] or ['capabilities']. The
+    // activation push + onboarding poll didn't cover it (next_step is already
+    // 'done' on upgrade), so every useBillingStatus() consumer stayed on the
+    // old tier until a manual refresh.
+    get.mockImplementation(async (url: string) => {
+      if (url === '/billing/status')
+        return { tier: 'free', active: false, trial_days_remaining: 0, subscription: null, caps: {} }
+      if (url === '/billing/config')
+        return {
+          client_token: 'tok',
+          environment: 'sandbox',
+          price_ids: {
+            starter: { monthly: 'p1', annual: 'p2' },
+            pro: { monthly: 'p3', annual: 'p4' },
+          },
+          customer_email: 'u@example.com',
+          custom_data: { user_id: '1' },
+          vaults_cap: null,
+        }
+      if (url === '/me') return { user: ME }
+      if (url === '/onboarding/status') return { next_step: 'done', enabled: true }
+      throw new Error(`unexpected GET ${url}`)
+    })
+
+    let captured: ((event: { name: string; data?: unknown }) => void) | undefined
+    initializePaddleMock.mockImplementation(async (opts: { eventCallback?: typeof captured }) => {
+      captured = opts.eventCallback
+      return { Checkout: { open: vi.fn(), close: vi.fn() } }
+    })
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+    render(
+      <QueryClientProvider client={qc}>
+        <AuthContext.Provider value={authAdapter}>
+          <ThemeProvider>
+            <MemoryRouter>
+              {/* Settings flow (no onActivated) — the upgrade path. */}
+              <BillingPage />
+            </MemoryRouter>
+          </ThemeProvider>
+        </AuthContext.Provider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => expect(captured).toBeDefined())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      captured!({ name: 'checkout.completed', data: { transaction_id: 'txn_up_1' } })
+      await Promise.resolve()
+    })
+
+    const keyFired = (k0: string, k1?: string) =>
+      invalidateSpy.mock.calls.some(([arg]) => {
+        const key = (arg as { queryKey?: unknown[] })?.queryKey
+        return Array.isArray(key) && key[0] === k0 && (k1 === undefined || key[1] === k1)
+      })
+
+    await waitFor(() => {
+      expect(keyFired('billing', 'status')).toBe(true)
+      expect(keyFired('capabilities')).toBe(true)
+    })
+  })
+
   it('subscribed flow: Cancel button opens CancelPanel inline (no portal redirect)', async () => {
     initializePaddleMock.mockResolvedValue({ Checkout: { open: vi.fn(), close: vi.fn() } })
 

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -8,6 +8,7 @@ import {
   useBillingSubscriptionDetail,
   useBillingHistory,
   useMe,
+  invalidateBillingState,
   type BillingCadence,
   type OnboardingStatus,
 } from '../api/queries'
@@ -157,9 +158,7 @@ export default function BillingPage({
     setCheckingOut(false)
     setCompletedAt(null)
     setSlow(false)
-    await qc.invalidateQueries({ queryKey: ['billing', 'status'] })
-    await qc.invalidateQueries({ queryKey: ['billing', 'subscription'] })
-    await qc.invalidateQueries({ queryKey: ['billing', 'transactions'] })
+    await invalidateBillingState(qc)
     await qc.invalidateQueries({ queryKey: ['onboarding', 'status'] })
 
     if (onActivatedRef.current && !onActivatedFiredRef.current) {
@@ -225,8 +224,7 @@ export default function BillingPage({
             const txn = (event.data as { transaction_id?: string } | undefined)?.transaction_id ?? null
             setTransactionId(txn)
             setCompletedAt((prev) => prev ?? Date.now())
-            qc.invalidateQueries({ queryKey: ['billing', 'subscription'] })
-            qc.invalidateQueries({ queryKey: ['billing', 'transactions'] })
+            invalidateBillingState(qc)
             break
           }
           case CheckoutEventNames.CHECKOUT_COMPLETED: {
@@ -236,8 +234,7 @@ export default function BillingPage({
             // timer is the fallback if the push never arrives (and is also
             // armed here in case PAYMENT_INITIATED dropped).
             setCompletedAt((prev) => prev ?? Date.now())
-            qc.invalidateQueries({ queryKey: ['billing', 'subscription'] })
-            qc.invalidateQueries({ queryKey: ['billing', 'transactions'] })
+            invalidateBillingState(qc)
             break
           }
           case CheckoutEventNames.CHECKOUT_PAYMENT_FAILED:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.499",
+      version: "0.5.500",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Symptom

User on **Free** upgrades to Starter/Pro — Paddle checkout completes (DB updated, email sent), but the UI everywhere still treats them as Free: free-tier banners, vault/connection caps, plan-change "current" badge. Manual refresh fixes it.

## Root cause

`billing-page.tsx` `CHECKOUT_COMPLETED` / `PAYMENT_INITIATED` handlers invalidated only `['billing','subscription']` + `['billing','transactions']` — **never `['billing','status']`**, which every `useBillingStatus()` consumer reads (header badge, caps, plan-change panel, free-tier gates). The activation push + onboarding poll don't cover the upgrade path: `pollUntilActive` exits on `next_step === 'done'`, already true for an existing user, so it short-circuits before refreshing status.

Compounding it: the new bootstrap **`['capabilities']`** cache (tier+limits matrix, added in #690) was invalidated on *no* subscription-change path — a latent repeat of the same bug once the UI starts reading it.

## Fix

Centralize into one exported **`invalidateBillingState(qc)`** that invalidates every subscription-derived cache — `status`, `subscription`, `transactions`, `capabilities` — and call it at *every* change site:
- `CHECKOUT_COMPLETED` + `CHECKOUT_PAYMENT_INITIATED` (billing-page)
- `handleSubscriptionActivated` (WS push)
- `useCancelSubscription` / `useReverseCancel` / `useConfirmPlanChange` mutations

One helper so a future key can't be silently missed the way `['billing','status']` was.

## Test
New: `CHECKOUT_COMPLETED invalidates billing/status and capabilities (#603)`. Existing invalidation tests still pass (helper is a superset).

Verification: billing-page + queries suites 72/72, `tsc --noEmit` clean, biome clean.

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)