### PR TITLE
chore/purge redis docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Engram is a single Elixir/Phoenix OTP application — search, MCP server, note s
 ### Key Patterns
 
 - **OTP supervision** — `one_for_one`: Channel crashes don't affect Oban, and vice versa
-- **Phoenix Channels + PubSub** — bidirectional real-time sync, cluster-wide broadcast via Erlang distribution (no Redis for PubSub/caches — BEAM clustering handles those natively; SaaS prod uses Redis/ElastiCache **only** as the shared rate-limit store so per-plan/§G and Voyage-quota counters are exact across clustered nodes; self-host stays Redis-free, rate limiter defaults to ETS)
+- **Phoenix Channels + PubSub** — bidirectional real-time sync, cluster-wide broadcast via Erlang distribution (**no Redis/Valkey anywhere** — BEAM handles PubSub/caches natively; clustered SaaS prod runs a distributed ETS + Phoenix.PubSub rate limiter, self-host plain ETS, and the durable daily search cap is a Postgres token bucket — ElastiCache removed 2026-06-21)
 - **PostgreSQL RLS** — DB-enforced tenant isolation via `SET LOCAL app.current_tenant`. `Repo.prepare_query` raises on unscoped queries. See `docs/context/database-schema-rls.md`
 - **Two DB roles** — `engram_owner` (migrations) and `engram_app` (runtime, subject to RLS)
 - **Behaviour-based adapters** — `Engram.Embedder` behaviour for Voyage/Ollama

--- a/docs/context/elixir-architecture-decisions.md
+++ b/docs/context/elixir-architecture-decisions.md
@@ -31,7 +31,7 @@ Complete decision audit for the Engram Elixir/Phoenix architecture. Captures wha
 | **Clustering** | **dns_cluster** | Auto node discovery via DNS, enables distributed PubSub. _UPDATE: prod runs on AWS ECS Fargate, not Fly — discovery is via the platform's service DNS, not Fly `.internal`._ |
 | **PubSub** | **Phoenix.PubSub.PG2** | Native Erlang distribution, cross-region broadcast, no Redis needed |
 | **Caching** | **ETS** (Erlang Term Storage) | In-process, clustered via PubSub if needed, eliminates Redis dependency |
-| **Rate limiting** | **Hammer** | Token bucket, ETS or Redis backend, Plug integration |
+| **Rate limiting** | **Hammer** | Token bucket, ETS backend, Plug integration. _UPDATE (2026-06-21): the Redis backend was removed — clustered prod uses a distributed ETS + Phoenix.PubSub limiter, self-host plain ETS; the durable daily search cap moved to a Postgres token bucket (`usage_buckets`)._ |
 | **Auth: JWT** | **Joken** | Lightweight, Plug-native |
 | **Auth: API keys** | **SHA256 hash + ETS cache** | Same security model, fast in-process caching |
 | **S3 client** | **ExAws + ExAws.S3** | Battle-tested, S3-compatible. _UPDATE: attachments live in AWS S3 (not Fly Tigris)._ |
@@ -76,7 +76,7 @@ Complete decision audit for the Engram Elixir/Phoenix architecture. Captures wha
 | **Oban** | ~> 2.18 | PostgreSQL-backed job queue | Production |
 | **Joken** (+ joken_jwks) | ~> 2.6 | JWT sign/verify (Clerk JWKS) | Production |
 | **ExAws** + **ExAws.S3** + **ExAws.KMS** | ~> 2.5 / 2.4 | S3 client (AWS S3) + KMS | Production |
-| **Hammer** (+ hammer_backend_redis) | ~> 7.3 / 7.0 | Rate limiting (ETS default; Redis backend for clustered prod) | Production |
+| **Hammer** | ~> 7.3 | Rate limiting (ETS default; distributed ETS + Phoenix.PubSub for clustered prod — `hammer_backend_redis` removed 2026-06-21) | Production |
 | **Earmark** | ~> 1.4 | Markdown → AST parsing | Production |
 | **Req** | ~> 0.5 | HTTP client (Qdrant, Voyage AI) | Production |
 | _MCP server_ | (hand-rolled) | No external MCP dep — `lib/engram/mcp/` | — |
@@ -87,7 +87,7 @@ Complete decision audit for the Engram Elixir/Phoenix architecture. Captures wha
 | **Mox** | ~> 1.1 (test) | Behaviour-based mocks | Production |
 | **Bypass** | ~> 2.1 (test) | HTTP mock server | Production |
 
-_Note: **Redix** is NOT a direct dependency. The only Redis touchpoint is `hammer_backend_redis`, used solely as the shared rate-limit store in clustered SaaS prod; self-host stays Redis-free (ETS backend)._
+_Note: there is **no Redis/Redix dependency**. The `hammer_backend_redis` + ElastiCache path was removed 2026-06-21 — clustered SaaS prod uses a distributed ETS + Phoenix.PubSub rate limiter, self-host uses plain ETS, and the durable daily search cap is a Postgres token bucket._
 
 ## Development Environment
 

--- a/docs/context/environment-variables.md
+++ b/docs/context/environment-variables.md
@@ -31,8 +31,7 @@ Live. This is regenerated from `config/runtime.exs` (the ~90 vars it reads), wit
 | `DATABASE_SSL_MODE` | `verify_none` | `verify-full` → `verify_peer` w/ OS trust store + SNI + hostname check (:570). |
 | `SECRET_KEY_BASE` | — (required in prod, :597) | Phoenix cookie/secret signing. |
 | `JWT_SECRET` | — (required in prod, :604) | Joken default signer for internal JWTs (:610). |
-| `DNS_CLUSTER_QUERY` | unset | libcluster DNS query for BEAM node discovery (:612). |
-| `REDIS_URL` | unset | Opt-in shared rate-limiter + per-user cache backend (ElastiCache). Unset → per-node ETS. Fails open + alerts if unreachable (:618-632). |
+| `DNS_CLUSTER_QUERY` | unset | libcluster DNS query for BEAM node discovery (:612). When set, the rate limiter auto-selects the distributed ETS + Phoenix.PubSub backend; unset → plain ETS. |
 
 > `RELEASE_COOKIE` is consumed by the Elixir release runtime (`rel/`/`mix release`), not read in `runtime.exs`.
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.500",
+      version: "0.5.501",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- **docs: purge stale Redis refs from backend context docs**
- **chore: bump version to 0.5.501**
