### PR TITLE
Knock out three contained issues: #604, #689, #688

### DIFF
--- a/frontend/src/onboarding/checklist-widget.test.tsx
+++ b/frontend/src/onboarding/checklist-widget.test.tsx
@@ -127,7 +127,7 @@ describe('ChecklistWidget — per-tool rows', () => {
     expect(screen.getByText(/connect cursor/i)).toBeInTheDocument()
   })
 
-  it('auto-clears a tool row when a matching MCP connection exists', () => {
+  it('keeps a tool row visible (struck through) when a matching MCP connection exists', () => {
     onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ['claude', 'cursor'] }
     connectionsValue = {
       data: [
@@ -155,7 +155,13 @@ describe('ChecklistWidget — per-tool rows', () => {
     }
     render(wrap(<ChecklistWidget onStartTour={() => {}} />))
 
-    expect(screen.queryByText(/connect claude/i)).not.toBeInTheDocument()
+    // Completed row stays — checked off, struck through, no actions — rather
+    // than vanishing (#604).
+    const claude = screen.getByText(/connect claude/i)
+    expect(claude).toBeInTheDocument()
+    expect(claude).toHaveClass('line-through')
+    expect(claude).toHaveTextContent('☑')
+    expect(screen.queryByLabelText(/dismiss connect claude/i)).toBeNull()
     expect(screen.getByText(/connect cursor/i)).toBeInTheDocument()
   })
 
@@ -221,7 +227,7 @@ describe('ChecklistWidget — Obsidian plugin row', () => {
     expect(screen.queryByText(/install.*obsidian/i)).toBeNull()
   })
 
-  it('hides the Obsidian row when an obsidian connection exists', () => {
+  it('keeps the Obsidian row visible (struck through) when an obsidian connection exists', () => {
     onboardingStatusValue.data!.profile = { uses_obsidian: true, tools: [] }
     connectionsValue = {
       data: [
@@ -240,7 +246,10 @@ describe('ChecklistWidget — Obsidian plugin row', () => {
     }
     render(wrap(<ChecklistWidget onStartTour={() => {}} />))
 
-    expect(screen.queryByText(/install.*obsidian/i)).toBeNull()
+    // Completed install row stays, struck through (#604).
+    const row = screen.getByText(/install.*obsidian/i)
+    expect(row).toBeInTheDocument()
+    expect(row).toHaveClass('line-through')
   })
 })
 
@@ -338,6 +347,58 @@ describe('ChecklistWidget — hide when empty', () => {
 
     const { container } = render(wrap(<ChecklistWidget onStartTour={() => {}} />))
     expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('ChecklistWidget — completed rows stay visible (#604)', () => {
+  it('renders a completed row checked off, struck through, with no action buttons', () => {
+    onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ['claude', 'cursor'] }
+    connectionsValue = {
+      data: [
+        {
+          kind: 'mcp', slug: 'claude', client_id: 'c1', key_id: null,
+          name: 'Claude', software_id: null, software_version: null,
+          verified: true, logo: null, vault_id: null, vault_name: null,
+          scope: 'mcp', last_used_at: null, connected_at: null,
+          first_user_agent: null, first_ip: null,
+          redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+        },
+      ],
+      isLoading: false,
+    }
+    render(wrap(<ChecklistWidget onStartTour={() => {}} />))
+
+    const claude = screen.getByText(/connect claude/i)
+    expect(claude).toHaveClass('line-through')
+    expect(claude).toHaveClass('text-muted-foreground')
+    expect(claude).toHaveTextContent('☑')
+
+    // Action affordances are suppressed on the completed row: only the
+    // still-active cursor row keeps its Setup guide link + dismiss button.
+    expect(screen.queryByLabelText(/dismiss connect claude/i)).toBeNull()
+    expect(screen.getAllByRole('link', { name: /setup guide/i })).toHaveLength(1)
+  })
+
+  it('counts a completed row in the progress readout while keeping it visible', () => {
+    onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ['claude', 'cursor'] }
+    connectionsValue = {
+      data: [
+        {
+          kind: 'mcp', slug: 'claude', client_id: 'c1', key_id: null,
+          name: 'Claude', software_id: null, software_version: null,
+          verified: true, logo: null, vault_id: null, vault_name: null,
+          scope: 'mcp', last_used_at: null, connected_at: null,
+          first_user_agent: null, first_ip: null,
+          redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+        },
+      ],
+      isLoading: false,
+    }
+    render(wrap(<ChecklistWidget onStartTour={() => {}} />))
+
+    // vault + tour + claude + cursor = 4 items, claude done = 1.
+    expect(screen.getByText(/1 of 4 done/i)).toBeInTheDocument()
+    expect(screen.getByText(/connect claude/i)).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/onboarding/checklist-widget.tsx
+++ b/frontend/src/onboarding/checklist-widget.tsx
@@ -19,7 +19,11 @@ interface Props {
 interface Item {
   key: string
   label: string
+  // `done` = genuinely completed (vault created, MCP/obsidian connection
+  // resolved). Completed rows stay visible, struck through. Dismissal is a
+  // separate user action (`dismissed`) that removes the row entirely.
   done: boolean
+  dismissed?: boolean
   docUrl?: string
   startTour?: () => void
   dismissible?: boolean
@@ -123,7 +127,8 @@ export function ChecklistWidget({ onStartTour }: Props) {
           {
             key: 'install_obsidian_plugin',
             label: 'Install the Obsidian plugin',
-            done: hasObsidianConnection || isDismissed('install_obsidian_plugin'),
+            done: hasObsidianConnection,
+            dismissed: isDismissed('install_obsidian_plugin'),
             docUrl: DOC_URLS.install_obsidian_plugin,
             dismissible: true,
           } as Item,
@@ -134,7 +139,10 @@ export function ChecklistWidget({ onStartTour }: Props) {
           {
             key: 'tour',
             label: 'Take the tour',
-            done: isDismissed('tour'),
+            // No in-row completion signal — `tour_completed` removes the row
+            // structurally (guard above). Only dismissal hides it here.
+            done: false,
+            dismissed: isDismissed('tour'),
             startTour: onStartTour,
             dismissible: true,
           } as Item,
@@ -144,16 +152,21 @@ export function ChecklistWidget({ onStartTour }: Props) {
       (slug): Item => ({
         key: slug,
         label: TOOL_LABELS[slug] ?? `Connect ${slug}`,
-        done: isDismissed(slug) || connectedSlugs.has(slug),
+        done: connectedSlugs.has(slug),
+        dismissed: isDismissed(slug),
         docUrl: DOC_URLS[slug] ?? DOC_FALLBACK,
         dismissible: true,
       }),
     ),
   ]
 
-  const visible = items.filter((i) => !i.done)
+  // Dismissed rows are removed entirely (the × is "hide this"). Completed rows
+  // stay visible — struck through — so progress is felt, not silently erased.
+  // The whole widget retires only once nothing is left to act on.
+  const visible = items.filter((i) => !i.dismissed)
+  const hasActionable = items.some((i) => !i.done && !i.dismissed)
 
-  if (visible.length === 0) return null
+  if (!hasActionable) return null
 
   if (collapsed) {
     return (
@@ -172,7 +185,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
   }
 
   const total = items.length
-  const completed = items.filter((i) => i.done).length
+  const completed = items.filter((i) => i.done || i.dismissed).length
   const pct = total === 0 ? 0 : Math.round((completed / total) * 100)
 
   return (
@@ -213,33 +226,42 @@ export function ChecklistWidget({ onStartTour }: Props) {
             key={i.key}
             className="flex items-center justify-between gap-2 text-sm"
           >
-            <span className="flex items-center gap-2">
-              <span aria-hidden>☐</span>
+            <span
+              className={
+                i.done
+                  ? 'flex items-center gap-2 text-muted-foreground line-through'
+                  : 'flex items-center gap-2'
+              }
+            >
+              <span aria-hidden>{i.done ? '☑' : '☐'}</span>
               {i.label}
             </span>
-            <span className="flex items-center gap-1">
-              {i.startTour ? (
-                <Button size="sm" variant="outline" onClick={i.startTour}>
-                  Start
-                </Button>
-              ) : i.docUrl ? (
-                <Button asChild size="sm" variant="outline">
-                  <a href={i.docUrl} target="_blank" rel="noreferrer">
-                    Setup guide ↗
-                  </a>
-                </Button>
-              ) : null}
-              {i.dismissible && (
-                <button
-                  type="button"
-                  aria-label={`Dismiss ${i.label}`}
-                  className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                  onClick={() => dismiss(i.key)}
-                >
-                  ×
-                </button>
-              )}
-            </span>
+            {/* Completed rows carry no actions — just the checked-off label. */}
+            {!i.done && (
+              <span className="flex items-center gap-1">
+                {i.startTour ? (
+                  <Button size="sm" variant="outline" onClick={i.startTour}>
+                    Start
+                  </Button>
+                ) : i.docUrl ? (
+                  <Button asChild size="sm" variant="outline">
+                    <a href={i.docUrl} target="_blank" rel="noreferrer">
+                      Setup guide ↗
+                    </a>
+                  </Button>
+                ) : null}
+                {i.dismissible && (
+                  <button
+                    type="button"
+                    aria-label={`Dismiss ${i.label}`}
+                    className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    onClick={() => dismiss(i.key)}
+                  >
+                    ×
+                  </button>
+                )}
+              </span>
+            )}
           </li>
         ))}
       </ul>

--- a/lib/engram/accounts/lifecycle.ex
+++ b/lib/engram/accounts/lifecycle.ex
@@ -167,6 +167,14 @@ defmodule Engram.Accounts.Lifecycle do
                skip_tenant_check: true
              )
 
+             # `usage_buckets` is a system table (no FK to users, so the cascade
+             # above does not reach it) — purge the user's rate-limit rows
+             # explicitly so they don't orphan on account deletion. Raw DELETE:
+             # the table has no Ecto schema and is written outside tenant scope.
+             Repo.query!("DELETE FROM usage_buckets WHERE user_id = $1::uuid", [
+               Ecto.UUID.dump!(user.id)
+             ])
+
              Repo.delete!(user, skip_tenant_check: true)
            end,
            skip_tenant_check: true

--- a/lib/engram/prom_ex.ex
+++ b/lib/engram/prom_ex.ex
@@ -28,7 +28,8 @@ defmodule Engram.PromEx do
       Engram.PromEx.Search,
       Engram.PromEx.Mcp,
       Engram.PromEx.Crypto,
-      Engram.PromEx.Reliability
+      Engram.PromEx.Reliability,
+      Engram.PromEx.Usage
     ]
   end
 

--- a/lib/engram/prom_ex/usage.ex
+++ b/lib/engram/prom_ex/usage.ex
@@ -1,0 +1,39 @@
+defmodule Engram.PromEx.Usage do
+  @moduledoc """
+  PromEx plugin for usage-cap enforcement counters. Makes the daily
+  token-bucket cap (`Engram.Usage.DailyCap`) observable on the scraped
+  `/metrics` endpoint.
+
+  Events + metrics:
+
+    * `[:engram, :usage, :daily_cap]` → `..._daily_cap_total`, tags
+      `[:kind, :decision]` — every cap check, split by bucket `kind`
+      (e.g. `inapp_search`) and `decision` (`allow` | `deny` |
+      `fail_open`). `fail_open` is the outage signal: the DB errored and
+      the call allowed through, so a non-trivial rate there means the cap
+      is not actually enforcing.
+
+  Cardinality contract: `kind` is a fixed bucket label and `decision` is
+  one of three atoms — both bounded. NEVER add user_id.
+  """
+
+  use PromEx.Plugin
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :usage)
+
+    Event.build(
+      :engram_usage_event_metrics,
+      [
+        counter(
+          metric_prefix ++ [:daily_cap, :total],
+          event_name: [:engram, :usage, :daily_cap],
+          description: "Daily token-bucket cap checks by bucket kind + decision.",
+          tags: [:kind, :decision]
+        )
+      ]
+    )
+  end
+end

--- a/lib/engram/usage/daily_cap.ex
+++ b/lib/engram/usage/daily_cap.ex
@@ -22,6 +22,8 @@ defmodule Engram.Usage.DailyCap do
   def spend(user_id, kind, capacity, refill_per_sec) do
     case Cache.empty_until(user_id, kind) do
       {:empty, retry_after_sec} ->
+        # Short-circuit deny: a known-empty bucket never touched the DB.
+        emit(kind, :deny)
         {:deny, retry_after_sec}
 
       :unknown ->
@@ -50,6 +52,7 @@ defmodule Engram.Usage.DailyCap do
 
     case Repo.query(@sql, [user_id_bin, kind, capacity * 1.0, refill_per_sec]) do
       {:ok, %{rows: [[tokens]]}} ->
+        emit(kind, :allow)
         {:allow, tokens}
 
       {:ok, %{rows: []}} ->
@@ -57,11 +60,25 @@ defmodule Engram.Usage.DailyCap do
         # regenerates, so subsequent requests skip the DB.
         retry = if refill_per_sec > 0, do: ceil(1 / refill_per_sec), else: 3600
         Cache.mark_empty(user_id, kind, retry)
+        emit(kind, :deny)
         {:deny, retry}
 
       {:error, reason} ->
         Logger.warning("daily_cap fail-open", kind: kind, reason: inspect(reason))
+        emit(kind, :fail_open)
         {:allow, 0.0}
     end
+  end
+
+  # Allow/deny/fail-open visibility for the daily cap. `kind` is a fixed
+  # bucket label (e.g. "inapp_search") — safe to tag (low cardinality);
+  # never user_id. Picked up by `Engram.PromEx.Usage`.
+  @spec emit(String.t(), :allow | :deny | :fail_open) :: :ok
+  defp emit(kind, decision) do
+    :telemetry.execute(
+      [:engram, :usage, :daily_cap],
+      %{count: 1},
+      %{kind: kind, decision: decision}
+    )
   end
 end

--- a/test/engram/accounts/lifecycle_test.exs
+++ b/test/engram/accounts/lifecycle_test.exs
@@ -176,6 +176,27 @@ defmodule Engram.Accounts.LifecycleTest do
       assert String.length(hmac) == 64
     end
 
+    test "purges the user's usage_buckets rows (no FK, so cascade misses them)" do
+      user = insert(:user, external_id: nil)
+      uid = Ecto.UUID.dump!(user.id)
+
+      # Seed two operational rate-limit rows the cascade would otherwise orphan.
+      Repo.query!(
+        "INSERT INTO usage_buckets (user_id, kind, tokens, last_refill_at) VALUES ($1::uuid, $2, 9.0, now())",
+        [uid, "inapp_search"]
+      )
+
+      Repo.query!(
+        "INSERT INTO usage_buckets (user_id, kind, tokens, last_refill_at) VALUES ($1::uuid, $2, 5.0, now())",
+        [uid, "external_ai_search"]
+      )
+
+      assert :ok = Lifecycle.hard_delete(user, :user)
+
+      assert %{rows: [[0]]} =
+               Repo.query!("SELECT count(*) FROM usage_buckets WHERE user_id = $1::uuid", [uid])
+    end
+
     test "with paddle sub + external_id: cancels Paddle + deletes Clerk + emits had_sub:true" do
       user = insert(:user, external_id: "user_clerk_xyz")
       sub = insert(:subscription, user: user, paddle_subscription_id: "sub_test_abc")

--- a/test/engram/usage/daily_cap_test.exs
+++ b/test/engram/usage/daily_cap_test.exs
@@ -32,4 +32,36 @@ defmodule Engram.Usage.DailyCapTest do
 
     assert {:allow, _} = DailyCap.spend(u, "inapp_search", 10, 1.0)
   end
+
+  describe "telemetry" do
+    setup do
+      ref = make_ref()
+      parent = self()
+
+      :telemetry.attach(
+        "daily-cap-test-#{inspect(ref)}",
+        [:engram, :usage, :daily_cap],
+        fn _event, measurements, metadata, _ ->
+          send(parent, {:cap_event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach("daily-cap-test-#{inspect(ref)}") end)
+      :ok
+    end
+
+    test "emits an allow decision when a token is spent" do
+      assert {:allow, _} = DailyCap.spend(uid(), "inapp_search", 10, 10 / 86_400)
+      assert_receive {:cap_event, %{count: 1}, %{kind: "inapp_search", decision: :allow}}
+    end
+
+    test "emits a deny decision when the bucket is empty" do
+      u = uid()
+      for _ <- 1..10, do: DailyCap.spend(u, "inapp_search", 10, 0.0)
+      # Drain the allow events from filling the bucket.
+      assert {:deny, _} = DailyCap.spend(u, "inapp_search", 10, 0.0)
+      assert_receive {:cap_event, %{count: 1}, %{kind: "inapp_search", decision: :deny}}
+    end
+  end
 end


### PR DESCRIPTION
Batches three small, well-scoped issues. Each change ships with the test that pins its behavior. Three commits, one per issue, for clean review/cherry-pick.

## #604 — Setup checklist: completed items check off + strike through, not disappear
`fix(onboarding)` · `frontend/src/onboarding/checklist-widget.tsx` (+ test)

The checklist removed each item the moment it completed, so the list silently shrank and users lost any sense of progress. Completed rows now stay in place — checked off (☑), struck through, muted, with action buttons suppressed — and the widget retires only once nothing is left to act on.

**Note on the issue's "just drop the filter" instruction:** doing that literally would have broken the × button, because `done` conflated genuine *completion* with user *dismissal*. I split them: dismissal still removes a row outright (that's what dismiss means), while a vault created or an MCP/Obsidian connection resolving now leaves the row visible and checked. Tests updated accordingly (the two old "auto-clears / hides on connection" tests now assert the struck-through render), plus new coverage for the checked glyph, `line-through`/`text-muted-foreground` classes, suppressed actions, and an unchanged progress count.

## #689 — DailyCap: allow/deny/fail-open telemetry
`feat(usage)` · `lib/engram/usage/daily_cap.ex`, `lib/engram/prom_ex/usage.ex`, `lib/engram/prom_ex.ex` (+ test)

`DailyCap.spend/4` enforced the daily token-bucket cap but emitted no telemetry. Now emits `[:engram, :usage, :daily_cap]` on every check, tagged by bucket `kind` + `decision`, registered as a counter in a new `Engram.PromEx.Usage` plugin so it lands on the scraped `/metrics` endpoint. `fail_open` is the key signal: a non-trivial rate there means the cap is allowing traffic through during a DB outage and isn't actually enforcing. Cardinality contract honored — `kind` is a fixed label, `decision` is one of three atoms, never user_id.

## #688 — usage_buckets: clean up rows on account deletion
`fix(accounts)` · `lib/engram/accounts/lifecycle.ex` (+ test)

`usage_buckets` is a system table with no FK to users, so the hard-delete Postgres cascade never reached it and a deleted user's rate-limit rows orphaned. They're now deleted explicitly inside the hard-delete transaction (raw `DELETE` — the table has no Ecto schema and is written outside tenant scope), committing atomically with the user-row removal.

## Testing
No Elixir toolchain in the authoring environment, so backend tests run in CI. Tests were written alongside each change (TDD): `daily_cap_test.exs` telemetry cases, `lifecycle_test.exs` usage_buckets purge case, and the `checklist-widget.test.tsx` updates above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRtZakuEpzeG6JoPeXeSFS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRtZakuEpzeG6JoPeXeSFS)_