### PR TITLE
fix(onboarding): stop fire-and-forget socket connect from leaking unhandled rejections (#531)

### DIFF
--- a/frontend/src/billing/use-subscription-activated-events.ts
+++ b/frontend/src/billing/use-subscription-activated-events.ts
@@ -55,7 +55,12 @@ export function useSubscriptionActivatedEvents({
       })
     }
 
-    connect()
+    // Never let the fire-and-forget promise dangle: a rejecting getToken()
+    // would otherwise escape as an unhandled rejection. Swallow + log,
+    // mirroring the channel-join error path.
+    connect().catch((err) => {
+      console.error('user channel connect failed (subscription activation listener)', err)
+    })
 
     return () => {
       cancelled = true

--- a/frontend/src/onboarding/use-vault-ready-events.test.tsx
+++ b/frontend/src/onboarding/use-vault-ready-events.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { AuthContext, type AuthAdapter } from '../auth/auth-context'
+
+const {
+  channelHandlers,
+  channelOn,
+  socketChannelMock,
+  socketConnectMock,
+  socketDisconnectMock,
+  socketCtor,
+} = vi.hoisted(() => {
+  const channelHandlers: Record<string, (payload: unknown) => void> = {}
+  const channelOn = vi.fn((event: string, cb: (payload: unknown) => void) => {
+    channelHandlers[event] = cb
+  })
+  const channelMock = {
+    on: channelOn,
+    join: () => ({ receive: () => ({}) }),
+  }
+  const socketChannelMock = vi.fn(() => channelMock)
+  const socketConnectMock = vi.fn()
+  const socketDisconnectMock = vi.fn()
+  // Phoenix's Socket is invoked with `new` — use a constructor function (not a
+  // vi.fn() arrow returning an object, which Mock's `new` semantics reject).
+  const socketCtor = vi.fn(function MockSocket(this: object, ..._args: unknown[]) {
+    Object.assign(this, {
+      connect: socketConnectMock,
+      channel: socketChannelMock,
+      disconnect: socketDisconnectMock,
+    })
+  })
+  return {
+    channelHandlers,
+    channelOn,
+    socketChannelMock,
+    socketConnectMock,
+    socketDisconnectMock,
+    socketCtor,
+  }
+})
+
+vi.mock('phoenix', () => ({ Socket: socketCtor }))
+
+import { useVaultReadyEvents } from './use-vault-ready-events'
+
+// getToken is the lynchpin: the hook's fire-and-forget connect() awaits it.
+// A getToken that rejects (or isn't a function) used to crash the vitest run
+// with an unhandled rejection — see #531 / #652. `tokenImpl` is swappable per
+// test, but the adapter object itself is STABLE so the hook's effect (keyed on
+// getToken) doesn't spuriously re-run on every re-render.
+let tokenImpl: () => Promise<string | null> = async () => 'tok-test'
+
+const authAdapter: AuthAdapter = {
+  isLoaded: true,
+  isSignedIn: true,
+  user: { email: 'u@example.com' },
+  getToken: () => tokenImpl(),
+  logout: async () => {},
+  hasBuiltInUI: false,
+}
+
+function wrap({ children }: { children: React.ReactNode }) {
+  return React.createElement(AuthContext.Provider, { value: authAdapter }, children)
+}
+
+describe('useVaultReadyEvents', () => {
+  beforeEach(() => {
+    tokenImpl = async () => 'tok-test'
+    socketCtor.mockClear()
+    socketChannelMock.mockClear()
+    socketConnectMock.mockClear()
+    socketDisconnectMock.mockClear()
+    channelOn.mockClear()
+    for (const k of Object.keys(channelHandlers)) delete channelHandlers[k]
+  })
+
+  it('connects to user:{userId} and subscribes to vault_created + vault_populated', async () => {
+    renderHook(() => useVaultReadyEvents({ userId: '42', enabled: true }), { wrapper: wrap })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(socketCtor).toHaveBeenCalledWith('/socket', { params: { token: 'tok-test' } })
+    expect(socketChannelMock).toHaveBeenCalledWith('user:42')
+    expect(channelHandlers['vault_created']).toBeDefined()
+    expect(channelHandlers['vault_populated']).toBeDefined()
+  })
+
+  it('flips vaultCreated + records vaultId when vault_created fires', async () => {
+    const { result } = renderHook(() => useVaultReadyEvents({ userId: '42', enabled: true }), {
+      wrapper: wrap,
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      channelHandlers['vault_created']!({ vault_id: 'v_1' })
+    })
+
+    expect(result.current.vaultCreated).toBe(true)
+    expect(result.current.vaultPopulated).toBe(false)
+    expect(result.current.vaultId).toBe('v_1')
+  })
+
+  it('flips vaultPopulated (and vaultCreated) when vault_populated fires', async () => {
+    const { result } = renderHook(() => useVaultReadyEvents({ userId: '42', enabled: true }), {
+      wrapper: wrap,
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      channelHandlers['vault_populated']!({ vault_id: 'v_2' })
+    })
+
+    expect(result.current.vaultCreated).toBe(true)
+    expect(result.current.vaultPopulated).toBe(true)
+    expect(result.current.vaultId).toBe('v_2')
+  })
+
+  it('does not connect when enabled is false', async () => {
+    renderHook(() => useVaultReadyEvents({ userId: '42', enabled: false }), { wrapper: wrap })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(socketCtor).not.toHaveBeenCalled()
+  })
+
+  it('does not connect when userId is null', async () => {
+    renderHook(() => useVaultReadyEvents({ userId: null, enabled: true }), { wrapper: wrap })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(socketCtor).not.toHaveBeenCalled()
+  })
+
+  it('disconnects the socket on unmount', async () => {
+    const { unmount } = renderHook(() => useVaultReadyEvents({ userId: '42', enabled: true }), {
+      wrapper: wrap,
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    unmount()
+    expect(socketDisconnectMock).toHaveBeenCalledOnce()
+  })
+
+  // Regression for #531: a rejecting getToken must NOT leak an unhandled
+  // rejection out of the fire-and-forget connect(). The hook catches + logs
+  // it instead, and never reaches socket construction.
+  it('swallows a rejecting getToken without an unhandled rejection', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    tokenImpl = () => Promise.reject(new Error('auth not ready'))
+
+    renderHook(() => useVaultReadyEvents({ userId: '42', enabled: true }), { wrapper: wrap })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(socketCtor).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith('user channel connect failed', expect.any(Error))
+    consoleError.mockRestore()
+  })
+})

--- a/frontend/src/onboarding/use-vault-ready-events.ts
+++ b/frontend/src/onboarding/use-vault-ready-events.ts
@@ -68,7 +68,13 @@ export function useVaultReadyEvents({ userId, enabled }: Options): State {
       })
     }
 
-    connect()
+    // Fire-and-forget, but never let the promise dangle: a rejecting
+    // getToken() (auth not ready, network error) would otherwise surface
+    // as an unhandled rejection — which crashes the test runner and is
+    // noise in prod. Swallow + log, mirroring the channel-join error path.
+    connect().catch((err) => {
+      console.error('user channel connect failed', err)
+    })
 
     return () => {
       cancelled = true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.506",
+      version: "0.5.507",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Closes #531.

## Root cause
`useVaultReadyEvents` (and its twin `useSubscriptionActivatedEvents`) start an async `connect()` inside `useEffect` and never handle its rejection:

```ts
connect()            // ← dangling promise
return () => { ... } // cleanup
```

When `getToken()` rejects (auth not ready, network error, or a test that didn't mock it) the promise rejects with nothing catching it → unhandled rejection → `bun run test` exits 1 even though all assertions pass. In prod it's unhandled-rejection noise.

PR #652 had already patched the *device-link test's* mock (one of the two rejections in the report), but the fire-and-forget pattern itself was still fragile.

## Fix
Catch the promise at the call site and log it, mirroring the existing channel-join error path. Applied to both sibling hooks so the symmetric defect can't reappear via the billing path.

```ts
connect().catch((err) => {
  console.error('user channel connect failed', err)
})
```

## Tests
Adds the previously-missing `use-vault-ready-events.test.tsx`, mirroring the established `use-subscription-activated-events.test.tsx` harness (hoisted phoenix-Socket mock + stable `AuthContext` adapter). Covers connect/subscribe, both `vault_created` / `vault_populated` state transitions, the disabled / null-user no-connect guards, unmount disconnect, and a **#531 regression case**: a rejecting `getToken` is swallowed (logged, no socket constructed) rather than escaping as an unhandled rejection.

## Verification note
This repo runs no frontend-vitest job in CI (called out in #531 itself), and the authoring environment couldn't install frontend deps (network), so these tests weren't executed here — they're written to mirror the already-passing sibling suite exactly. Standing up a frontend-vitest CI job is the separate decision #531 also raises; happy to do that in a follow-up if you want CI to actually guard this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRtZakuEpzeG6JoPeXeSFS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRtZakuEpzeG6JoPeXeSFS)_