### PR TITLE
feat(notes): extract inline #tags from note body (#594)

### DIFF
--- a/lib/engram/notes/helpers.ex
+++ b/lib/engram/notes/helpers.ex
@@ -17,17 +17,26 @@ defmodule Engram.Notes.Helpers do
       filename_without_extension(path)
   end
 
+  # Inline Obsidian tag: `#tag` or nested `#area/sub`. Must be preceded by
+  # start-of-string or whitespace (so `word#x` and `https://h/#frag` are NOT
+  # tags) and must start with a word char (so `# heading` — a space after the
+  # hash — is NOT a tag). `{}` delimiter avoids escaping the `/`.
+  @inline_tag_re ~r{(?:^|\s)#([\w][\w/-]*)}
+
   @doc """
-  Extracts tags from YAML frontmatter. Returns [] if none found.
+  Extracts tags from a note: YAML frontmatter tags merged with inline
+  `#tags` (incl. nested `#area/sub`) found in the body.
+
+  Inline scanning skips fenced + inline code, URL fragments, and heading
+  markers, and drops purely-numeric matches (`#42`) — none of which are
+  tags in Obsidian. Frontmatter tags come first; duplicates are removed.
+  Returns [] if none found.
   """
   @spec extract_tags(String.t()) :: [String.t()]
   def extract_tags(content) do
-    with fm when fm != nil <- extract_frontmatter(content),
-         {:ok, tags} <- parse_frontmatter_tags(fm) do
-      tags
-    else
-      _ -> []
-    end
+    frontmatter_tags = extract_frontmatter_tags(content)
+    inline_tags = extract_inline_tags(content)
+    Enum.uniq(frontmatter_tags ++ inline_tags)
   end
 
   @doc """
@@ -77,6 +86,41 @@ defmodule Engram.Notes.Helpers do
       nil -> ""
       filename when is_binary(filename) -> Path.rootname(filename)
     end
+  end
+
+  defp extract_frontmatter_tags(content) do
+    with fm when fm != nil <- extract_frontmatter(content),
+         {:ok, tags} <- parse_frontmatter_tags(fm) do
+      tags
+    else
+      _ -> []
+    end
+  end
+
+  defp extract_inline_tags(content) do
+    content
+    |> strip_frontmatter()
+    |> strip_code()
+    |> then(&Regex.scan(@inline_tag_re, &1, capture: :all_but_first))
+    |> List.flatten()
+    # Trim trailing separators left by e.g. `#foo/` at a word boundary.
+    |> Enum.map(&Regex.replace(~r{[/-]+$}, &1, ""))
+    |> Enum.reject(&(&1 == "" or numeric_tag?(&1)))
+  end
+
+  # Obsidian rejects purely-numeric tags (so `#42`, `#1/2` are not tags).
+  defp numeric_tag?(tag), do: Regex.match?(~r{^[\d/_-]+$}, tag)
+
+  defp strip_frontmatter(content), do: Regex.replace(@frontmatter_re, content, "")
+
+  # Fenced (``` / ~~~) and inline (`…`) code spans, stripped before scanning
+  # so a `#tag` written as a code example isn't indexed.
+  @code_span_res [~r/```.*?```/s, ~r/~~~.*?~~~/s, ~r/`[^`\n]*`/]
+
+  # Replace code spans with a space (not "") so a preceding word can't fuse
+  # onto a following `#tag` across the removed span.
+  defp strip_code(text) do
+    Enum.reduce(@code_span_res, text, &Regex.replace(&1, &2, " "))
   end
 
   defp parse_frontmatter_tags(fm) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.504",
+      version: "0.5.506",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/helpers_test.exs
+++ b/test/engram/notes/helpers_test.exs
@@ -84,6 +84,51 @@ defmodule Engram.Notes.HelpersTest do
       content = "---\ntitle: Just a title\n---\nBody"
       assert Helpers.extract_tags(content) == []
     end
+
+    test "extracts an inline #tag from the body" do
+      assert Helpers.extract_tags("Some body with a #fitness tag") == ["fitness"]
+    end
+
+    test "extracts a nested inline #area/sub tag" do
+      assert Helpers.extract_tags("Work note #area/subarea here") == ["area/subarea"]
+    end
+
+    test "merges frontmatter tags with inline tags, frontmatter first, deduped" do
+      content = "---\ntags: [health]\n---\nBody #fitness and again #health"
+      assert Helpers.extract_tags(content) == ["health", "fitness"]
+    end
+
+    test "skips #tags inside a fenced code block" do
+      content = "Intro #real\n\n```\nnot a #tag here\n```\n\nOutro"
+      assert Helpers.extract_tags(content) == ["real"]
+    end
+
+    test "skips #tags inside an inline code span" do
+      content = "Use `#notatag` in code but #realtag in prose"
+      assert Helpers.extract_tags(content) == ["realtag"]
+    end
+
+    test "skips the # fragment in a URL" do
+      content = "See https://example.com/docs#section for details"
+      assert Helpers.extract_tags(content) == []
+    end
+
+    test "does not treat a word-attached hash as a tag" do
+      assert Helpers.extract_tags("issue C#sharp note") == []
+    end
+
+    test "skips heading markers" do
+      content = "# Heading One\n## Heading Two\nBody #onlytag"
+      assert Helpers.extract_tags(content) == ["onlytag"]
+    end
+
+    test "rejects purely-numeric matches like #42" do
+      assert Helpers.extract_tags("Closes #42 and tags #bug") == ["bug"]
+    end
+
+    test "deduplicates repeated inline tags" do
+      assert Helpers.extract_tags("#dup once #dup twice") == ["dup"]
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #594.

## Problem
`Engram.Notes.Helpers.extract_tags/1` parsed **only** YAML frontmatter, so the inline `#tags` (incl. nested `#area/sub`) that Obsidian users lean on were never indexed.

## Change
`extract_tags/1` now scans the body for inline tags and merges them with frontmatter tags — frontmatter first, deduped via `Enum.uniq/1`. It flows through the existing `tags_ciphertext` + `tags_hmac` storage and HMAC search path, so **no schema change** and both upsert sites (`Notes.upsert_note` + the bulk path) get it for free.

False-positive guards, matching Obsidian's own tag rules:
- **Fenced + inline code** (` ``` `, `~~~`, `` `…` ``) stripped before scanning, so a `#tag` written as a code example isn't indexed.
- A tag must be preceded by **start-of-line or whitespace**, so `word#x` and URL fragments like `https://h/docs#section` are skipped.
- A **space after the hash** (`# Heading`) is a heading marker, not a tag.
- **Purely-numeric** matches (`#42`, e.g. issue refs) are dropped.

## Tests
`helpers_test.exs` gains cases for: inline extraction, nested `#area/sub`, frontmatter+inline merge/dedup, and each exclusion (code fence, inline code, URL, word-attached `C#`, heading, numeric `#42`). These run in the Elixir `unit-tests` CI job.

I also audited every existing test that asserts `.tags` / `tags_hmac`: they all use frontmatter or heading-only (`# Title`) bodies, both safe under the new rules — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRtZakuEpzeG6JoPeXeSFS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRtZakuEpzeG6JoPeXeSFS)_