### PR TITLE
fix: stop logging successful health-check probes

### DIFF
--- a/lib/engram_web/request_logger.ex
+++ b/lib/engram_web/request_logger.ex
@@ -45,19 +45,11 @@ defmodule EngramWeb.RequestLogger do
 
   @doc false
   def handle_event(@stop_event, %{duration: duration}, %{conn: conn}, _config) do
-    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
-
-    Logger.log(
-      level_for_status(conn.status),
-      "#{conn.method} #{conn.status} in #{duration_ms}ms",
-      method: conn.method,
-      status: conn.status,
-      route: route(conn),
-      request_path: conn.request_path,
-      request_query: conn.query_string,
-      user_id: current_user_id(conn),
-      mtls_clientcert_subject: mtls_clientcert_subject(conn)
-    )
+    if suppress_request_log?(conn) do
+      :ok
+    else
+      emit_request_log(conn, duration)
+    end
   end
 
   def handle_event(@exception_event, _measurements, %{conn: conn} = metadata, _config) do
@@ -76,6 +68,35 @@ defmodule EngramWeb.RequestLogger do
   end
 
   def handle_event(_, _, _, _), do: :ok
+
+  defp emit_request_log(conn, duration) do
+    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+
+    Logger.log(
+      level_for_status(conn.status),
+      "#{conn.method} #{conn.status} in #{duration_ms}ms",
+      method: conn.method,
+      status: conn.status,
+      route: route(conn),
+      request_path: conn.request_path,
+      request_query: conn.query_string,
+      user_id: current_user_id(conn),
+      mtls_clientcert_subject: mtls_clientcert_subject(conn)
+    )
+  end
+
+  # ALB liveness (/health) and readiness (/health/deep) probes hit every task
+  # every 1-2s. Logging each successful one is pure noise — and at sustained
+  # volume it is the bulk of the log shipper's traffic, which can tip the Loki
+  # pipeline into a retry-amplification storm. Drop only the *successful*
+  # probes (status < 400); a degraded health check still logs at :error/:warning
+  # so a failing target stays visible. Keyed on the matched controller, never
+  # the path, so it can't be spoofed by an arbitrary /health-prefixed request.
+  defp suppress_request_log?(%Plug.Conn{status: status, private: private})
+       when is_integer(status) and status < 400,
+       do: private[:phoenix_controller] == EngramWeb.HealthController
+
+  defp suppress_request_log?(_), do: false
 
   # A 5xx flood must elevate above :info so level-keyed alerting sees it; a 4xx
   # is a client error worth a :warning; everything else stays :info.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.501",
+      version: "0.5.502",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/request_logger_test.exs
+++ b/test/engram_web/request_logger_test.exs
@@ -255,6 +255,45 @@ defmodule EngramWeb.RequestLoggerTest do
     assert event.level == :info
   end
 
+  test "suppresses successful health-check probes (ALB hits these every 1-2s — pure noise)" do
+    for action <- [:index, :deep] do
+      conn = %Plug.Conn{
+        method: "GET",
+        request_path: "/health",
+        query_string: "",
+        status: 200,
+        private: %{phoenix_controller: EngramWeb.HealthController, phoenix_action: action}
+      }
+
+      {_, events} =
+        LogCapture.with_events(fn ->
+          :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 1_000_000}, %{conn: conn})
+        end)
+
+      refute find_request_event(events),
+             "expected no log for successful HealthController##{action}, got: #{inspect(events)}"
+    end
+  end
+
+  test "still logs a degraded (non-2xx) health check so a failing readiness probe stays visible" do
+    conn = %Plug.Conn{
+      method: "GET",
+      request_path: "/health/deep",
+      query_string: "",
+      status: 503,
+      private: %{phoenix_controller: EngramWeb.HealthController, phoenix_action: :deep}
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 1_000_000}, %{conn: conn})
+      end)
+
+    event = find_request_event(events)
+    assert event, "a degraded (503) health check must still log"
+    assert event.level == :error
+  end
+
   test "logs a router_dispatch exception with route + bounded error_kind (no secret leak)" do
     conn = %Plug.Conn{
       method: "GET",


### PR DESCRIPTION
## Why

Grafana Cloud billed **>1 TB** of Loki ingest this month with no customers, while only **~367 MB** was actually stored. Root cause is retry amplification (Fluent Bit resends chunks on Grafana 504s, each resend re-metered) — but the *fuel* is volume: the bulk of legit log lines are successful ALB health-check probes (`/health`, `/health/deep`) hitting every task every 1–2s, each logged at `:info`.

This is the **source-side** half of the fix. Shipper-side cap (gzip + `Retry_Limit`) ships in engram-infra#616.

## What

`RequestLogger` now drops successful (`status < 400`) `HealthController` probes, keyed on the **matched controller** (not the path — can't be spoofed by an arbitrary `/health`-prefixed request). Degraded health checks (503/5xx) still log at `:warning`/`:error` so a failing target stays visible.

Matches the infra runbook's stated guardrail: *rate-limit at the app side, not via Fluent Bit drops.*

## Tests

TDD — watched the suppression test fail first, then pass. `13 tests, 0 failures`. `mix format` + credo clean, compiles under `--warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)