### PR TITLE
fix(webapp): show derived folders missing from the file tree

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -8,6 +8,7 @@ import {
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { api, ApiError } from './client'
+import { isSyntheticFolderId, syntheticFolderId, syntheticFolderPath } from '../viewer/tree/synthesize-folders'
 import { useActiveVaultId } from './active-vault'
 import { useDemoVaultOptional } from '../onboarding/tour/demo-vault-provider'
 import { collideBump } from '@/lib/collide-bump'
@@ -73,8 +74,15 @@ export interface User {
 // Hoisted so React Query treats the select identity as stable; otherwise an
 // inline arrow re-runs every render and returns a fresh array, breaking
 // memoized consumers (e.g. useEngramTree's rebuild useEffect).
-const selectFolders = (data: { folders: Array<Folder & { id: string | null }> }) =>
-  data.folders.filter((f): f is Folder => f.id != null && f.name !== '')
+// The backend returns a null id for the synthetic root row (name === '') AND for
+// every *derived* folder (one that exists only because notes live in it — no
+// explicit marker row). Drop only the root row; give derived folders a stable
+// synthetic id keyed on their path so the `Folder.id: string` contract holds and
+// they aren't erased from the tree. synthesizeFolders then links parents/ancestors.
+const selectFolders = (data: { folders: Array<Folder & { id: string | null }> }): Folder[] =>
+  data.folders
+    .filter((f) => f.name !== '')
+    .map((f) => (f.id != null ? (f as Folder) : { ...f, id: syntheticFolderId(f.name) }))
 
 export function useFolders() {
   const vaultId = useActiveVaultId()
@@ -229,6 +237,15 @@ export const ROOT_FOLDER_ID = 'root'
 export function fetchNotesForFolderId(folderId: string): Promise<NoteSummary[]> {
   if (folderId === ROOT_FOLDER_ID) {
     return api.get<{ notes: NoteSummary[] }>('/folders/list?folder=').then((r) => r.notes)
+  }
+  // Derived/synthesized folders have no backend marker row, so the by-id endpoint
+  // can't resolve them. They carry a `syn:<path>` id — list their notes by path
+  // through the same endpoint root uses.
+  if (isSyntheticFolderId(folderId)) {
+    const path = syntheticFolderPath(folderId)
+    return api
+      .get<{ notes: NoteSummary[] }>(`/folders/list?folder=${encodeURIComponent(path)}`)
+      .then((r) => r.notes)
   }
   return api
     .get<{ notes: NoteSummary[] }>(`/folders/by-id/${folderId}/notes`)

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -393,7 +393,12 @@ export default function FolderTree() {
     // When the selection contains notes or folders, we must resolve the target folder.
     if (noteIds.length || folderIds.length) {
       const target = folders?.find((f) => f.name === targetFolderName)
-      if (!target) {
+      // A derived folder has a `syn:` id, not a real marker the backend can move
+      // into; sending it would fail server-side and optimistically strand items
+      // at root. Such folders are filtered out of the dialog's targets below, so
+      // this is a defensive guard.
+      if (!target || isSyntheticFolderId(target.id)) {
+        if (target) toast.error('That folder has no saved marker yet — open it once to create one.')
         setDialog({ kind: 'none' })
         return
       }
@@ -472,7 +477,9 @@ export default function FolderTree() {
       {dialog.kind === 'move' && (
         <MoveDialog
           nodes={dialog.nodes}
-          folders={folders.map((f) => ({ name: f.name }))}
+          // Only real-marker folders are valid move targets; derived folders
+          // (syn: ids) have no id the backend move endpoints can resolve.
+          folders={folders.filter((f) => !isSyntheticFolderId(f.id)).map((f) => ({ name: f.name }))}
           onPick={commitMove}
           onCancel={() => setDialog({ kind: 'none' })}
         />

--- a/frontend/src/viewer/tree/synthesize-folders.test.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.test.ts
@@ -45,6 +45,30 @@ describe('synthesizeFolders', () => {
     expect(out.filter((f) => f.name === 'p')).toHaveLength(1)
   })
 
+  it('synthesizes missing ancestors from a note-folder path (no attachments)', () => {
+    // Backend returns only the leaf folder that holds notes; ancestors are absent.
+    const real: Folder[] = [{ id: 'syn:a/b/c', parent_id: null, name: 'a/b/c', count: 3 }]
+    const out = synthesizeFolders(real, [])
+    const a = out.find((f) => f.name === 'a')
+    const ab = out.find((f) => f.name === 'a/b')
+    const abc = out.find((f) => f.name === 'a/b/c')
+    expect(a).toMatchObject({ parent_id: null })
+    expect(ab).toMatchObject({ parent_id: a!.id })
+    expect(abc).toMatchObject({ id: 'syn:a/b/c', parent_id: ab!.id })
+  })
+
+  it('derives parent_id by path for flat note-folders the backend returned unparented', () => {
+    // Both come back parent_id:null (derived folders); x/y must nest under x.
+    const real: Folder[] = [
+      { id: 'syn:x', parent_id: null, name: 'x', count: 1 },
+      { id: 'syn:x/y', parent_id: null, name: 'x/y', count: 2 },
+    ]
+    const out = synthesizeFolders(real, [])
+    const x = out.find((f) => f.name === 'x')
+    const xy = out.find((f) => f.name === 'x/y')
+    expect(xy).toMatchObject({ parent_id: x!.id })
+  })
+
   it('isSyntheticFolderId distinguishes synthesized rows from real uuids', () => {
     const syn = synthesizeFolders([], [att('pics/a.png')]).find((f) => f.name === 'pics')
     expect(isSyntheticFolderId(syn!.id)).toBe(true)

--- a/frontend/src/viewer/tree/synthesize-folders.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.ts
@@ -10,42 +10,67 @@ export function isSyntheticFolderId(id: string): boolean {
   return id.startsWith(SYNTHETIC_ID_PREFIX)
 }
 
-// Folder dirs that exist only because they hold attachments aren't returned by
-// /api/folders (folders are derived from notes + markers, not attachments).
-// Synthesize them so every attachment is reachable in the tree. Real folders
-// win their id; synthetic rows use `syn:<full-path>` ids and link to their
-// parent (real or synthetic).
+// Stable id for a folder the backend returned with a null id (a derived folder)
+// or one we synthesize as a missing ancestor. Keyed on the full path so the same
+// folder always resolves to the same id across renders and across the two call
+// sites (selectFolders seeding it, synthesizeFolders linking parents to it).
+export function syntheticFolderId(name: string): string {
+  return `${SYNTHETIC_ID_PREFIX}${name}`
+}
+
+// Recover the folder path encoded in a synthetic id (inverse of syntheticFolderId).
+export function syntheticFolderPath(id: string): string {
+  return id.slice(SYNTHETIC_ID_PREFIX.length)
+}
+
+// Reconstruct the full folder tree the UI needs from the backend's flat,
+// incomplete list. `/api/folders` returns only leaf folders that directly hold
+// a note (derived folders, with a null id the caller has already replaced with
+// a stable `syn:<path>` id) — plus explicit markers. It omits two things we
+// must rebuild here:
+//   1. Ancestor folders that hold only sub-folders (no note directly inside).
+//   2. Folder dirs that exist only because they hold an attachment.
+// And it returns every derived folder unparented (`parent_id: null`), so the
+// tree would flatten them all to the root. We therefore re-derive every
+// folder's `parent_id` from its path and synthesize any missing ancestor.
+// Real folders keep their id; missing nodes get `syn:<full-path>` ids.
 export function synthesizeFolders(
   real: Folder[],
   attachments: AttachmentSummary[],
 ): Folder[] {
-  const byName = new Map<string, Folder>()
-  for (const f of real) byName.set(f.name, f)
+  const realByName = new Map<string, Folder>()
+  for (const f of real) realByName.set(f.name, f)
 
-  // Collect every directory prefix from attachment paths.
-  const dirs = new Set<string>()
+  // Every folder path we must represent, plus all of its ancestor prefixes —
+  // sourced from both the real folder names and the attachment directories.
+  const paths = new Set<string>()
+  const addPrefixes = (full: string) => {
+    if (!full) return
+    const segments = full.split('/')
+    for (let i = 1; i <= segments.length; i++) paths.add(segments.slice(0, i).join('/'))
+  }
+  for (const f of real) addPrefixes(f.name)
   for (const a of attachments) {
     const slash = a.path.lastIndexOf('/')
-    if (slash < 0) continue // root attachment — no folder needed
-    const dir = a.path.slice(0, slash)
-    const segments = dir.split('/')
-    for (let i = 1; i <= segments.length; i++) dirs.add(segments.slice(0, i).join('/'))
+    if (slash >= 0) addPrefixes(a.path.slice(0, slash))
   }
 
-  // Synthesize missing dirs, shallow-first so parents exist before children.
-  const sorted = [...dirs].sort((x, y) => x.split('/').length - y.split('/').length)
-  for (const name of sorted) {
-    if (byName.has(name)) continue
-    const slash = name.lastIndexOf('/')
-    const parentName = slash < 0 ? null : name.slice(0, slash)
-    const parent = parentName == null ? null : (byName.get(parentName) ?? null)
-    byName.set(name, {
-      id: `${SYNTHETIC_ID_PREFIX}${name}`,
-      parent_id: parent ? parent.id : null,
-      name,
-      count: 0,
+  // A path's id: the real folder's id when present, else a stable synthetic id.
+  // Used for both the node itself and parent links, so they always agree.
+  const idFor = (name: string): string => realByName.get(name)?.id ?? syntheticFolderId(name)
+
+  // Emit shallow-first so parents precede children in the output.
+  return [...paths]
+    .sort((x, y) => x.split('/').length - y.split('/').length)
+    .map((name) => {
+      const real = realByName.get(name)
+      const slash = name.lastIndexOf('/')
+      const parentName = slash < 0 ? null : name.slice(0, slash)
+      return {
+        id: idFor(name),
+        parent_id: parentName == null ? null : idFor(parentName),
+        name,
+        count: real ? real.count : 0,
+      }
     })
-  }
-
-  return [...byName.values()]
 }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.502",
+      version: "0.5.503",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

In the web app's file tree, folders that contain notes were **missing** — only folders that happened to hold an attachment showed up. Reported against a real vault where `Roadmap`, `Strategy`, `Technical`, and a nested work-log path were all invisible despite holding many notes.

## Root cause

`GET /api/folders` returns `id: null` and `parent_id: null` for every **derived** folder (one that exists only because notes live in it — only explicit empty-folder markers get real ids). Two things then dropped them:

1. **`selectFolders`** filtered out every `id == null` row to drop the synthetic root row (`name === ''`) — erasing all derived folders with it.
2. **`synthesizeFolders`** reconstructed missing ancestors only from **attachment** paths, so note-only folders never got a parent and flattened to the root — where they also collided on the same `f:null` tree-item id, so only one rendered.

## Fix (webapp only)

- `selectFolders` drops only the root row and assigns each derived folder a stable `syn:<path>` id, preserving the `Folder.id: string` contract.
- `synthesizeFolders` re-derives every folder's `parent_id` from its path and synthesizes missing ancestors from **folder names** too (not just attachments).
- `fetchNotesForFolderId` lists derived-folder notes **by path** (`/folders/list?folder=<path>`, the endpoint root already uses), since synthetic folders have no by-id marker.

## Verification

- TDD: 2 new `synthesize-folders` cases (ancestor synthesis + path-derived parents); full frontend suite **612 passed**, `tsc --noEmit` clean.
- Live against a real vault: all folders render, deep nesting reconstructs (`1. Alignment → 4. Work Log → 2026-05`), derived-folder notes load, notes open.

## Not covered

Genuinely-empty folders (zero notes anywhere inside) still don't appear — the backend returns nothing for them, so the client can't synthesize them. Handled separately by a plugin-side first-sync seeding change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)