### PR TITLE
feat(webapp): move notes/folders into derived folders by path

### DIFF
--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1002,17 +1002,17 @@ describe('useCreateNote — optimistic placeholder', () => {
 })
 
 describe('useBatchMoveNotes', () => {
-  it('POSTs ids + target_folder_id with UUID idempotency header', async () => {
+  it('POSTs ids + target_folder path with UUID idempotency header', async () => {
     post.mockResolvedValue({ moved: 2 })
 
     const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
     await act(async () => {
-      await result.current.mutateAsync({ ids: ['1', '2'], target_folder_id: '9' })
+      await result.current.mutateAsync({ ids: ['1', '2'], target_folder: 'dst' })
     })
 
     expect(post).toHaveBeenCalledWith(
       '/notes/batch-move',
-      { ids: ['1', '2'], target_folder_id: '9' },
+      { ids: ['1', '2'], target_folder: 'dst' },
       expect.objectContaining({
         headers: expect.objectContaining({
           'X-Idempotency-Key': expect.stringMatching(UUID_RE),
@@ -1030,7 +1030,7 @@ describe('useBatchMoveNotes', () => {
 
     const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
     act(() => {
-      result.current.mutate({ ids: ['1', '2'], target_folder_id: '9' })
+      result.current.mutate({ ids: ['1', '2'], target_folder: 'dst' })
     })
 
     await waitFor(() => {
@@ -1048,7 +1048,7 @@ describe('useBatchMoveNotes', () => {
     const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
     await act(async () => {
       try {
-        await result.current.mutateAsync({ ids: ['1', '2'], target_folder_id: '9' })
+        await result.current.mutateAsync({ ids: ['1', '2'], target_folder: 'dst' })
       } catch {
         // expected
       }
@@ -1073,7 +1073,7 @@ describe('useBatchMoveNotes', () => {
 
     const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
     act(() => {
-      result.current.mutate({ ids: ['1', '2'], target_folder_id: '9' })
+      result.current.mutate({ ids: ['1', '2'], target_folder: 'dst' })
     })
 
     await waitFor(() => {
@@ -1099,7 +1099,7 @@ describe('useBatchMoveNotes', () => {
     const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
     await act(async () => {
       try {
-        await result.current.mutateAsync({ ids: ['1', '2'], target_folder_id: '9' })
+        await result.current.mutateAsync({ ids: ['1', '2'], target_folder: 'dst' })
       } catch {
         // expected
       }
@@ -1124,7 +1124,7 @@ describe('useBatchMoveNotes', () => {
 
     const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
     act(() => {
-      result.current.mutate({ ids: ['1'], target_folder_id: 'root' })
+      result.current.mutate({ ids: ['1'], target_folder: '' })
     })
 
     await waitFor(() => {
@@ -1154,7 +1154,7 @@ describe('useBatchMoveNotes', () => {
 
     const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
     act(() => {
-      result.current.mutate({ ids: ['1'], target_folder_id: '9' })
+      result.current.mutate({ ids: ['1'], target_folder: 'dst' })
     })
 
     await waitFor(() => {
@@ -1163,6 +1163,50 @@ describe('useBatchMoveNotes', () => {
       const dst = qc.getQueryData<Array<{ id: string }>>(['folder-notes-by-id', '42', '9'])
       expect(dst?.map((n) => n.id)).toContain('1')
     })
+
+    resolvePost({ moved: 1 })
+  })
+
+  it('moves notes into a DERIVED folder (no marker) keyed under its syn: id', async () => {
+    qc.setQueryData(['folders', '42'], {
+      // A derived folder comes back from the backend with a null id; the
+      // optimistic patch must key its note list under syn:<path>, the same id
+      // the loader uses, and bump its count by name (id is null in this cache).
+      folders: [
+        { id: '5', parent_id: null, name: 'src', count: 2 },
+        { id: null, parent_id: null, name: 'Derived', count: 0 },
+      ] as unknown as Folder[],
+    })
+    seedFolderNotesById('5', [{ id: '1' }, { id: '2' }])
+    qc.setQueryData(['folder-notes-by-id', '42', 'syn:Derived'], [])
+
+    let resolvePost!: (v: unknown) => void
+    post.mockReturnValue(new Promise((r) => (resolvePost = r)))
+
+    const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
+    act(() => {
+      result.current.mutate({ ids: ['1'], target_folder: 'Derived' })
+    })
+
+    await waitFor(() => {
+      const dst = qc.getQueryData<Array<{ id: string; folder: string }>>([
+        'folder-notes-by-id',
+        '42',
+        'syn:Derived',
+      ])
+      expect(dst?.map((n) => n.id)).toContain('1')
+      expect(dst?.find((n) => n.id === '1')?.folder).toBe('Derived')
+      const src = qc.getQueryData<Array<{ id: string }>>(['folder-notes-by-id', '42', '5'])
+      expect(src?.map((n) => n.id)).toEqual(['2'])
+      const folders = qc.getQueryData<{ folders: Folder[] }>(['folders', '42'])
+      expect(folders?.folders.find((f) => f.name === 'Derived')?.count).toBe(1)
+    })
+
+    expect(post).toHaveBeenCalledWith(
+      '/notes/batch-move',
+      { ids: ['1'], target_folder: 'Derived' },
+      expect.anything(),
+    )
 
     resolvePost({ moved: 1 })
   })
@@ -1243,19 +1287,19 @@ describe('useBatchDeleteFolders', () => {
 })
 
 describe('useBatchMoveFolders', () => {
-  it('POSTs target_parent_id (NOT target_folder_id) with UUID idempotency header', async () => {
+  it('POSTs target_parent (NOT target_folder) with UUID idempotency header', async () => {
     post.mockResolvedValue({ moved: 1 })
 
     const { result } = renderHook(() => useBatchMoveFolders(), { wrapper })
     await act(async () => {
-      await result.current.mutateAsync({ ids: ['7'], target_parent_id: '9' })
+      await result.current.mutateAsync({ ids: ['7'], target_parent: 'dst' })
     })
 
     expect(post).toHaveBeenCalledWith(
       '/folders/batch-move',
-      // Regression: the folders endpoint uses `target_parent_id`, NOT
-      // `target_folder_id` (notes endpoint). Don't conflate them.
-      { ids: ['7'], target_parent_id: '9' },
+      // Regression: the folders endpoint uses `target_parent`, NOT
+      // `target_folder` (notes endpoint). Don't conflate them.
+      { ids: ['7'], target_parent: 'dst' },
       expect.objectContaining({
         headers: expect.objectContaining({
           'X-Idempotency-Key': expect.stringMatching(UUID_RE),
@@ -1278,7 +1322,7 @@ describe('useBatchMoveFolders', () => {
 
     const { result } = renderHook(() => useBatchMoveFolders(), { wrapper })
     act(() => {
-      result.current.mutate({ ids: ['7'], target_parent_id: '9' })
+      result.current.mutate({ ids: ['7'], target_parent: 'dst' })
     })
 
     await waitFor(() => {
@@ -1299,6 +1343,40 @@ describe('useBatchMoveFolders', () => {
     resolvePost({ moved: 2 })
   })
 
+  it('re-parents a folder under a DERIVED parent (syn: id)', async () => {
+    qc.setQueryData(['folders', '42'], {
+      // Derived parent: backend id is null. The moved folder's parent_id must
+      // flip to syn:<path> (the loader id), and its name prefix to the path.
+      folders: [
+        { id: '7', parent_id: null, name: 'src', count: 0 },
+        { id: null, parent_id: null, name: 'Derived', count: 0 },
+      ] as unknown as Folder[],
+    })
+
+    let resolvePost!: (v: unknown) => void
+    post.mockReturnValue(new Promise((r) => (resolvePost = r)))
+
+    const { result } = renderHook(() => useBatchMoveFolders(), { wrapper })
+    act(() => {
+      result.current.mutate({ ids: ['7'], target_parent: 'Derived' })
+    })
+
+    await waitFor(() => {
+      const folders = qc.getQueryData<{ folders: Folder[] }>(['folders', '42'])
+      const moved = folders?.folders.find((f) => f.id === '7')
+      expect(moved?.name).toBe('Derived/src')
+      expect(moved?.parent_id).toBe('syn:Derived')
+    })
+
+    expect(post).toHaveBeenCalledWith(
+      '/folders/batch-move',
+      { ids: ['7'], target_parent: 'Derived' },
+      expect.anything(),
+    )
+
+    resolvePost({ moved: 1 })
+  })
+
   it('rolls back on error', async () => {
     qc.setQueryData(['folders', '42'], {
       folders: [
@@ -1311,7 +1389,7 @@ describe('useBatchMoveFolders', () => {
     const { result } = renderHook(() => useBatchMoveFolders(), { wrapper })
     await act(async () => {
       try {
-        await result.current.mutateAsync({ ids: ['7'], target_parent_id: '9' })
+        await result.current.mutateAsync({ ids: ['7'], target_parent: 'dst' })
       } catch {
         // expected
       }

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1210,6 +1210,40 @@ describe('useBatchMoveNotes', () => {
 
     resolvePost({ moved: 1 })
   })
+
+  it('decrements a DERIVED source folder count when moving notes OUT of it', async () => {
+    // Source is a derived folder (null id in the raw cache, note list keyed
+    // under its syn:<path> loader id). The decrement must match it by name.
+    qc.setQueryData(['folders', '42'], {
+      folders: [
+        { id: null, parent_id: null, name: 'Derived', count: 2 },
+        { id: '9', parent_id: null, name: 'dst', count: 0 },
+      ] as unknown as Folder[],
+    })
+    seedFolderNotesById('syn:Derived', [{ id: '1' }, { id: '2' }])
+    qc.setQueryData(['folder-notes-by-id', '42', '9'], [])
+
+    let resolvePost!: (v: unknown) => void
+    post.mockReturnValue(new Promise((r) => (resolvePost = r)))
+
+    const { result } = renderHook(() => useBatchMoveNotes(), { wrapper })
+    act(() => {
+      result.current.mutate({ ids: ['1'], target_folder: 'dst' })
+    })
+
+    await waitFor(() => {
+      const folders = qc.getQueryData<{ folders: Folder[] }>(['folders', '42'])
+      expect(folders?.folders.find((f) => f.name === 'Derived')?.count).toBe(1)
+      const src = qc.getQueryData<Array<{ id: string }>>([
+        'folder-notes-by-id',
+        '42',
+        'syn:Derived',
+      ])
+      expect(src?.map((n) => n.id)).toEqual(['2'])
+    })
+
+    resolvePost({ moved: 1 })
+  })
 })
 
 describe('useBatchDeleteFolders', () => {

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1930,9 +1930,11 @@ export function useBatchMoveNotes() {
 
       const snapshots: BatchNotesContext['noteListSnapshots'] = []
       const moved: NoteSummary[] = []
-      // How many notes left each source folder — used to decrement folder
-      // counts below so the tree's structure key changes and it rebuilds.
-      const removedPerFolder = new Map<string, number>()
+      // How many notes left each source folder, keyed by folder NAME — used to
+      // decrement folder counts below. Keyed by name (not id) because a derived
+      // folder's raw `['folders']` row has a null id, so id matching would miss
+      // it; the note lists, however, are keyed by the loader id (real or syn:).
+      const removedPerName = new Map<string, number>()
 
       // First pass: strip moved notes from every source list (capture the rows
       // so we can re-attach them to the target). Root and subfolders share one
@@ -1942,12 +1944,23 @@ export function useBatchMoveNotes() {
         if (!data) continue
         snapshots.push({ key: q.queryKey, data })
         const folderId = q.queryKey[2] as string | null | undefined
+        // Resolve this source list's folder PATH so the count decrement matches
+        // the raw folders cache by name (root sentinel → '', syn:<path> → path,
+        // real id → its cached name).
+        const srcName =
+          typeof folderId !== 'string'
+            ? null
+            : folderId === ROOT_FOLDER_ID
+              ? ''
+              : isSyntheticFolderId(folderId)
+                ? syntheticFolderPath(folderId)
+                : (foldersCache?.folders.find((ff) => ff.id === folderId)?.name ?? null)
         const keep: NoteSummary[] = []
         for (const n of data) {
           if (idSet.has(n.id) && folderId !== targetCacheId) {
             moved.push(n)
-            if (typeof folderId === 'string') {
-              removedPerFolder.set(folderId, (removedPerFolder.get(folderId) ?? 0) + 1)
+            if (srcName !== null) {
+              removedPerName.set(srcName, (removedPerName.get(srcName) ?? 0) + 1)
             }
           } else {
             keep.push(n)
@@ -2001,16 +2014,17 @@ export function useBatchMoveNotes() {
       // Snapshot for rollback. Skipped when nothing moved; for a root target
       // ('root' has no folder row) sources still decrement.
       let foldersSnapshot: { folders: Folder[] } | undefined
-      if (moved.length > 0 || removedPerFolder.size > 0) {
+      if (moved.length > 0 || removedPerName.size > 0) {
         const cache = qc.getQueryData<{ folders: Folder[] }>(['folders', vaultId])
         if (cache) {
           foldersSnapshot = cache
           const patched = cache.folders.map((f) => {
             let count = f.count
-            const removed = removedPerFolder.get(f.id)
+            // Both source decrement and destination bump match by NAME: a
+            // derived folder has a null id in the raw cache, so id matching
+            // would miss it.
+            const removed = removedPerName.get(f.name)
             if (removed) count -= removed
-            // Match the destination by NAME: a derived target has a null id in
-            // the raw cache, so id comparison would miss it.
             if (target_folder !== '' && f.name === target_folder) count += moved.length
             return count === f.count ? f : { ...f, count }
           })

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1902,27 +1902,31 @@ export function useBatchMoveNotes() {
   return useMutation<
     { moved: number },
     ApiError,
-    { ids: string[]; target_folder_id: string },
+    { ids: string[]; target_folder: string },
     BatchNotesContext
   >({
-    mutationFn: ({ ids, target_folder_id }) =>
+    mutationFn: ({ ids, target_folder }) =>
       api.post<{ moved: number }>(
         '/notes/batch-move',
-        { ids, target_folder_id },
+        { ids, target_folder },
         idempotencyHeaders(),
       ),
-    onMutate: async ({ ids, target_folder_id }) => {
+    onMutate: async ({ ids, target_folder }) => {
       await qc.cancelQueries({ queryKey: ['folder-notes-by-id', vaultId] })
       await qc.cancelQueries({ queryKey: ['folders', vaultId] })
       const idSet = new Set(ids)
 
-      // Destination path: a real folder's name, or '' for the vault root
-      // (target_folder_id === ROOT_FOLDER_ID — no folders row).
+      // Destination is the folder PATH ('' = vault root). The by-id note cache
+      // keys under the folder's loader id — a real marker id, else the stable
+      // `syn:<path>` id a derived folder carries — so the optimistic add lands
+      // in the same list the tree reads.
       const foldersCache = qc.getQueryData<{ folders: Folder[] }>(['folders', vaultId])
-      const targetFolderName =
-        target_folder_id === ROOT_FOLDER_ID
-          ? ''
-          : (foldersCache?.folders.find((f) => f.id === target_folder_id)?.name ?? null)
+      const targetFolderName = target_folder
+      const targetCacheId =
+        target_folder === ''
+          ? ROOT_FOLDER_ID
+          : (foldersCache?.folders.find((f) => f.name === target_folder)?.id ??
+            syntheticFolderId(target_folder))
 
       const snapshots: BatchNotesContext['noteListSnapshots'] = []
       const moved: NoteSummary[] = []
@@ -1940,7 +1944,7 @@ export function useBatchMoveNotes() {
         const folderId = q.queryKey[2] as string | null | undefined
         const keep: NoteSummary[] = []
         for (const n of data) {
-          if (idSet.has(n.id) && folderId !== target_folder_id) {
+          if (idSet.has(n.id) && folderId !== targetCacheId) {
             moved.push(n)
             if (typeof folderId === 'string') {
               removedPerFolder.set(folderId, (removedPerFolder.get(folderId) ?? 0) + 1)
@@ -1955,7 +1959,7 @@ export function useBatchMoveNotes() {
       // Second pass: append the moved rows to the destination list (if cached),
       // rewriting folder + path so each row looks at-home. The target keys
       // under its id — ROOT_FOLDER_ID for the vault root.
-      if (moved.length > 0 && targetFolderName !== null) {
+      if (moved.length > 0) {
         const dest = targetFolderName
         const patched = moved.map<NoteSummary>((n) => {
           const filename = n.path.includes('/')
@@ -1963,7 +1967,7 @@ export function useBatchMoveNotes() {
             : n.path
           return { ...n, folder: dest, path: dest ? `${dest}/${filename}` : filename }
         })
-        const targetKey = ['folder-notes-by-id', vaultId, target_folder_id] as const
+        const targetKey = ['folder-notes-by-id', vaultId, targetCacheId] as const
         const targetData = qc.getQueryData<NoteSummary[]>(targetKey)
         if (targetData) qc.setQueryData<NoteSummary[]>(targetKey, [...targetData, ...patched])
       }
@@ -1971,7 +1975,7 @@ export function useBatchMoveNotes() {
       // Patch the individual `['note', vaultId, id]` caches so an open viewer
       // reflects the new folder. Path/folder shift; id stable. Applies to root
       // targets too (dest === '').
-      if (targetFolderName !== null) {
+      {
         const dest = targetFolderName
         for (const id of ids) {
           const note = qc.getQueryData<Note>(['note', vaultId, id])
@@ -2005,7 +2009,9 @@ export function useBatchMoveNotes() {
             let count = f.count
             const removed = removedPerFolder.get(f.id)
             if (removed) count -= removed
-            if (f.id === target_folder_id) count += moved.length
+            // Match the destination by NAME: a derived target has a null id in
+            // the raw cache, so id comparison would miss it.
+            if (target_folder !== '' && f.name === target_folder) count += moved.length
             return count === f.count ? f : { ...f, count }
           })
           qc.setQueryData<{ folders: Folder[] }>(['folders', vaultId], { folders: patched })
@@ -2126,18 +2132,17 @@ export function useBatchMoveFolders() {
   return useMutation<
     { moved: number },
     ApiError,
-    { ids: string[]; target_parent_id: string },
+    { ids: string[]; target_parent: string },
     BatchFoldersContext
   >({
-    mutationFn: ({ ids, target_parent_id }) =>
+    mutationFn: ({ ids, target_parent }) =>
       api.post<{ moved: number }>(
         '/folders/batch-move',
-        // The folders endpoint uses `target_parent_id` — the notes
-        // endpoint uses `target_folder_id`. Don't conflate.
-        { ids, target_parent_id },
+        // Move by PATH (target_parent) so a derived parent with no marker works.
+        { ids, target_parent },
         idempotencyHeaders(),
       ),
-    onMutate: async ({ ids, target_parent_id }) => {
+    onMutate: async ({ ids, target_parent }) => {
       const foldersKey = ['folders', vaultId] as const
       await qc.cancelQueries({ queryKey: foldersKey })
 
@@ -2145,14 +2150,23 @@ export function useBatchMoveFolders() {
       const ctx: BatchFoldersContext = { folders, noteListSnapshots: [] }
       if (!folders) return ctx
 
-      // Resolve the target's name once. Cycle defense: if the target
-      // sits under one of the moved roots, we skip the patch and let
-      // the server reject (the backend has the authoritative cycle
-      // check). Frontend silence beats lying optimistically.
-      const targetFolder = folders.folders.find((f) => f.id === target_parent_id)
-      const targetName = targetFolder?.name ?? ''
+      // Destination is the parent PATH ('' = top level). Children link to the
+      // target's loader id — a real marker id, else the stable `syn:<path>` id a
+      // derived parent carries (its raw-cache id is null).
+      const targetName = target_parent
+      const targetCacheId =
+        target_parent === ''
+          ? null
+          : (folders.folders.find((f) => f.name === target_parent)?.id ??
+            syntheticFolderId(target_parent))
       const descendants = collectFolderDescendants(folders.folders, ids)
-      if (descendants.has(target_parent_id)) return ctx
+      // Cycle defense by path: the target is one of the moved folders or sits
+      // under one. Skip the optimistic patch and let the server reject (it has
+      // the authoritative cycle check). Frontend silence beats lying.
+      const movedNames = folders.folders.filter((f) => ids.includes(f.id)).map((f) => f.name)
+      if (movedNames.some((n) => target_parent === n || target_parent.startsWith(`${n}/`))) {
+        return ctx
+      }
 
       // Rewrite each moved root: parent_id flips to the target,
       // name path prefix is rebuilt as `${targetName}/${basename}`.
@@ -2166,7 +2180,7 @@ export function useBatchMoveFolders() {
           const basename = slash < 0 ? f.name : f.name.slice(slash + 1)
           return {
             ...f,
-            parent_id: target_parent_id,
+            parent_id: targetCacheId,
             name: targetName ? `${targetName}/${basename}` : basename,
           }
         }

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -125,29 +125,24 @@ export default function FolderTree() {
   const onMove = (sourceIds: string[], targetItemId: string) => {
     const target = parseItemId(targetItemId)
     if (target.kind !== 'folder' && target.kind !== 'root') return
-    // Synthetic folders (id prefix 'syn:') are UI-only scaffolding for
-    // attachment-only dirs — they have no backend record, so they can be
-    // neither a move destination nor a moved source.
-    if (target.kind === 'folder' && isSyntheticFolderId(target.id)) return
     const parsed = sourceIds.map(parseItemId)
     const noteIds = parsed.filter((p) => p.kind === 'note').map((p) => (p as { id: string }).id)
+    // A derived folder has no marker id, so it can't be a move SOURCE — only
+    // real-marker folders can be dragged. (It can still be a destination, below,
+    // since everything now moves by PATH.)
     const folderIds = parsed
       .filter((p) => p.kind === 'folder' && !isSyntheticFolderId((p as { id: string }).id))
       .map((p) => (p as { id: string }).id)
     const attachmentPaths = parsed
       .filter((p) => p.kind === 'attachment')
       .map((p) => (p as { path: string }).path)
-    // 'root' is the backend sentinel for the vault root; a folder target uses
-    // its marker id. Note→root has no optimistic patch (root notes live under a
-    // different cache key than the by-id folder lists), so a moved note briefly
-    // disappears until useBatchMoveNotes' onSuccess invalidation + the
-    // count-keyed rebuildTree reconcile it at root — an accepted trade-off.
-    const dest = target.kind === 'root' ? 'root' : target.id
-    if (noteIds.length) batchMoveNotes.mutate({ ids: noteIds, target_folder_id: dest })
-    if (folderIds.length) batchMoveFolders.mutate({ ids: folderIds, target_parent_id: dest })
+    // Destination PATH ('' = vault root). Resolved from the synthesized tree so
+    // a derived folder (syn: id) yields its path — moves into it work by path.
+    const destFolder =
+      target.kind === 'root' ? '' : (allFolders.find((f) => f.id === target.id)?.name ?? '')
+    if (noteIds.length) batchMoveNotes.mutate({ ids: noteIds, target_folder: destFolder })
+    if (folderIds.length) batchMoveFolders.mutate({ ids: folderIds, target_parent: destFolder })
     if (attachmentPaths.length) {
-      // Attachment batch-move takes a folder name string, not an id.
-      const destFolder = target.kind === 'root' ? '' : (folders?.find((f) => f.id === target.id)?.name ?? '')
       batchMoveAttachments.mutate({ paths: attachmentPaths, target_folder: destFolder })
     }
   }
@@ -389,22 +384,10 @@ export default function FolderTree() {
   function commitMove(targetFolderName: string) {
     if (dialog.kind !== 'move') return
     const { noteIds, folderIds, attachmentPaths } = partition(dialog.itemIds)
-    // Notes and folders need a folder id; attachments take the folder name directly.
-    // When the selection contains notes or folders, we must resolve the target folder.
-    if (noteIds.length || folderIds.length) {
-      const target = folders?.find((f) => f.name === targetFolderName)
-      // A derived folder has a `syn:` id, not a real marker the backend can move
-      // into; sending it would fail server-side and optimistically strand items
-      // at root. Such folders are filtered out of the dialog's targets below, so
-      // this is a defensive guard.
-      if (!target || isSyntheticFolderId(target.id)) {
-        if (target) toast.error('That folder has no saved marker yet — open it once to create one.')
-        setDialog({ kind: 'none' })
-        return
-      }
-      if (noteIds.length) batchMoveNotes.mutate({ ids: noteIds, target_folder_id: target.id })
-      if (folderIds.length) batchMoveFolders.mutate({ ids: folderIds, target_parent_id: target.id })
-    }
+    // Everything moves by PATH (targetFolderName is the folder path, '' = root),
+    // so a derived folder with no marker is a valid destination.
+    if (noteIds.length) batchMoveNotes.mutate({ ids: noteIds, target_folder: targetFolderName })
+    if (folderIds.length) batchMoveFolders.mutate({ ids: folderIds, target_parent: targetFolderName })
     if (attachmentPaths.length) {
       batchMoveAttachments.mutate({ paths: attachmentPaths, target_folder: targetFolderName })
     }
@@ -477,9 +460,9 @@ export default function FolderTree() {
       {dialog.kind === 'move' && (
         <MoveDialog
           nodes={dialog.nodes}
-          // Only real-marker folders are valid move targets; derived folders
-          // (syn: ids) have no id the backend move endpoints can resolve.
-          folders={folders.filter((f) => !isSyntheticFolderId(f.id)).map((f) => ({ name: f.name }))}
+          // Every folder is a valid target now that moves go by path — including
+          // derived folders (notes inside, no marker).
+          folders={allFolders.map((f) => ({ name: f.name }))}
           onPick={commitMove}
           onCancel={() => setDialog({ kind: 'none' })}
         />

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -994,32 +994,25 @@ defmodule Engram.Notes do
   (after-commit hooks so broadcasts only fire post-commit) is tracked as a
   follow-up and will land before more batch ops are added.
   """
-  @spec batch_move_notes(map(), map(), [String.t()], String.t()) ::
+  @spec batch_move_notes(map(), map(), [String.t()], String.t() | {:path, String.t()}) ::
           {:ok, %{moved: non_neg_integer()}}
           | {:error, {:not_found | :conflict, String.t()} | term()}
   def batch_move_notes(_user, _vault, [], _target_folder_id), do: {:ok, %{moved: 0}}
 
-  def batch_move_notes(user, vault, ids, "root") when is_list(ids) do
+  # Move into a folder given by PATH. No marker is required — a "derived" folder
+  # exists purely as a path on its notes. `folder == ""` means the vault root.
+  def batch_move_notes(user, vault, ids, {:path, folder})
+      when is_list(ids) and is_binary(folder) do
     Repo.transaction(fn ->
       case Crypto.ensure_user_dek(user) do
-        {:ok, user} ->
-          ids
-          |> Enum.reduce_while(%{moved: 0}, fn id, acc ->
-            case move_note_into_folder(user, vault, id, "") do
-              {:ok, _} -> {:cont, Map.update!(acc, :moved, &(&1 + 1))}
-              {:error, {kind, id_err}} -> {:halt, {:rollback, {kind, id_err}}}
-              {:error, :not_found} -> {:halt, {:rollback, {:not_found, id}}}
-            end
-          end)
-          |> case do
-            {:rollback, reason} -> Repo.rollback(reason)
-            acc -> acc
-          end
-
-        {:error, reason} ->
-          Repo.rollback(reason)
+        {:ok, user} -> reduce_move_notes(user, vault, ids, folder)
+        {:error, reason} -> Repo.rollback(reason)
       end
     end)
+  end
+
+  def batch_move_notes(user, vault, ids, "root") when is_list(ids) do
+    batch_move_notes(user, vault, ids, {:path, ""})
   end
 
   def batch_move_notes(user, vault, ids, target_folder_id)
@@ -1029,27 +1022,31 @@ defmodule Engram.Notes do
            {:ok, marker} <- get_folder_marker_by_id(user, vault, target_folder_id),
            {:ok, dek} <- Crypto.get_dek(user) do
         target_folder = hydrate_folder_marker(marker, dek).folder
-
-        ids
-        |> Enum.reduce_while(%{moved: 0}, fn id, acc ->
-          case move_note_into_folder(user, vault, id, target_folder) do
-            {:ok, _} -> {:cont, Map.update!(acc, :moved, &(&1 + 1))}
-            # move_note_into_folder wraps the conflict error as
-            # {:error, {:conflict, id}}; the bare :not_found from the inner
-            # get_note_by_id propagates through `with`.
-            {:error, {kind, id_err}} -> {:halt, {:rollback, {kind, id_err}}}
-            {:error, :not_found} -> {:halt, {:rollback, {:not_found, id}}}
-          end
-        end)
-        |> case do
-          {:rollback, reason} -> Repo.rollback(reason)
-          acc -> acc
-        end
+        reduce_move_notes(user, vault, ids, target_folder)
       else
         {:error, :not_found} -> Repo.rollback({:not_found, target_folder_id})
         {:error, reason} -> Repo.rollback(reason)
       end
     end)
+  end
+
+  # Shared move loop (runs inside a transaction): move each id into
+  # `target_folder` (a path), rolling the whole batch back on the first failure.
+  # move_note_into_folder wraps a path collision as {:error, {:conflict, id}};
+  # the bare :not_found from the inner get_note_by_id is tagged with its id here.
+  defp reduce_move_notes(user, vault, ids, target_folder) do
+    ids
+    |> Enum.reduce_while(%{moved: 0}, fn id, acc ->
+      case move_note_into_folder(user, vault, id, target_folder) do
+        {:ok, _} -> {:cont, Map.update!(acc, :moved, &(&1 + 1))}
+        {:error, {kind, id_err}} -> {:halt, {:rollback, {kind, id_err}}}
+        {:error, :not_found} -> {:halt, {:rollback, {:not_found, id}}}
+      end
+    end)
+    |> case do
+      {:rollback, reason} -> Repo.rollback(reason)
+      acc -> acc
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -2583,33 +2580,27 @@ defmodule Engram.Notes do
   fires per-note broadcasts inside the transaction; rolled-back batches may
   leak events.
   """
-  @spec batch_move_folders(map(), map(), [String.t()], String.t()) ::
+  @spec batch_move_folders(map(), map(), [String.t()], String.t() | {:path, String.t()}) ::
           {:ok, %{moved: non_neg_integer()}}
           | {:error, {:not_found | :conflict | :cycle, String.t()} | term()}
   def batch_move_folders(_user, _vault, [], _target_folder_id), do: {:ok, %{moved: 0}}
 
-  def batch_move_folders(user, vault, marker_ids, "root") when is_list(marker_ids) do
+  # Move folders under a parent given by PATH. No marker is required at the
+  # target — a "derived" parent exists purely as a path. `folder == ""` is root.
+  def batch_move_folders(user, vault, marker_ids, {:path, folder})
+      when is_list(marker_ids) and is_binary(folder) do
     Repo.transaction(fn ->
       with {:ok, user} <- Crypto.ensure_user_dek(user),
            {:ok, dek} <- Crypto.get_dek(user) do
-        marker_ids
-        |> Enum.reduce_while(%{moved: 0}, fn id, acc ->
-          case move_folder_into(user, vault, id, "", dek) do
-            {:ok, _} -> {:cont, Map.update!(acc, :moved, &(&1 + 1))}
-            {:error, :not_found} -> {:halt, {:rollback, {:not_found, id}}}
-            {:error, :conflict} -> {:halt, {:rollback, {:conflict, id}}}
-            {:error, :cycle} -> {:halt, {:rollback, {:cycle, id}}}
-            {:error, reason} -> {:halt, {:rollback, reason}}
-          end
-        end)
-        |> case do
-          {:rollback, reason} -> Repo.rollback(reason)
-          acc -> acc
-        end
+        reduce_move_folders(user, vault, marker_ids, folder, dek)
       else
         {:error, reason} -> Repo.rollback(reason)
       end
     end)
+  end
+
+  def batch_move_folders(user, vault, marker_ids, "root") when is_list(marker_ids) do
+    batch_move_folders(user, vault, marker_ids, {:path, ""})
   end
 
   def batch_move_folders(user, vault, marker_ids, target_folder_id)
@@ -2619,26 +2610,31 @@ defmodule Engram.Notes do
            {:ok, target_marker} <- get_folder_marker_by_id(user, vault, target_folder_id),
            {:ok, dek} <- Crypto.get_dek(user) do
         target_folder = hydrate_folder_marker(target_marker, dek).folder
-
-        marker_ids
-        |> Enum.reduce_while(%{moved: 0}, fn id, acc ->
-          case move_folder_into(user, vault, id, target_folder, dek) do
-            {:ok, _} -> {:cont, Map.update!(acc, :moved, &(&1 + 1))}
-            {:error, :not_found} -> {:halt, {:rollback, {:not_found, id}}}
-            {:error, :conflict} -> {:halt, {:rollback, {:conflict, id}}}
-            {:error, :cycle} -> {:halt, {:rollback, {:cycle, id}}}
-            {:error, reason} -> {:halt, {:rollback, reason}}
-          end
-        end)
-        |> case do
-          {:rollback, reason} -> Repo.rollback(reason)
-          acc -> acc
-        end
+        reduce_move_folders(user, vault, marker_ids, target_folder, dek)
       else
         {:error, :not_found} -> Repo.rollback({:not_found, target_folder_id})
         {:error, reason} -> Repo.rollback(reason)
       end
     end)
+  end
+
+  # Shared move loop (runs inside a transaction): move each marker under
+  # `target_folder` (a path), rolling the whole batch back on the first failure.
+  defp reduce_move_folders(user, vault, marker_ids, target_folder, dek) do
+    marker_ids
+    |> Enum.reduce_while(%{moved: 0}, fn id, acc ->
+      case move_folder_into(user, vault, id, target_folder, dek) do
+        {:ok, _} -> {:cont, Map.update!(acc, :moved, &(&1 + 1))}
+        {:error, :not_found} -> {:halt, {:rollback, {:not_found, id}}}
+        {:error, :conflict} -> {:halt, {:rollback, {:conflict, id}}}
+        {:error, :cycle} -> {:halt, {:rollback, {:cycle, id}}}
+        {:error, reason} -> {:halt, {:rollback, reason}}
+      end
+    end)
+    |> case do
+      {:rollback, reason} -> Repo.rollback(reason)
+      acc -> acc
+    end
   end
 
   # Resolve source marker → compute new folder under target → delegate to

--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -317,37 +317,31 @@ defmodule EngramWeb.FoldersController do
     ]
   )
 
+  # Re-parent under a folder PATH — works for a derived parent (no marker). The
+  # target path is sanitized downstream by rename_folder, so traversal is safe.
+  def batch_move(conn, %{"ids" => ids, "target_parent" => folder})
+      when is_list(ids) and is_binary(folder) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    case parse_uuid_list(ids) do
+      {:ok, ids} ->
+        result = Notes.batch_move_folders(user, vault, ids, {:path, folder})
+        send_move_result(conn, user, vault, ids, result, %{target_parent: folder})
+
+      :error ->
+        conn |> put_status(400) |> json(%{error: "invalid_ids"})
+    end
+  end
+
   def batch_move(conn, %{"ids" => ids, "target_parent_id" => tgt}) when is_list(ids) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
     with {:ok, ids} <- parse_uuid_list(ids),
          {:ok, tgt} <- parse_move_target(tgt) do
-      case Notes.batch_move_folders(user, vault, ids, tgt) do
-        {:ok, %{moved: n}} ->
-          body = %{moved: n}
-          Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
-
-          broadcast_batch(user, vault, %{
-            op: "move",
-            ids: ids,
-            target_parent_id: tgt
-          })
-
-          json(conn, body)
-
-        {:error, {:not_found, id}} ->
-          conn |> put_status(404) |> json(%{error: "not_found", item_id: id})
-
-        {:error, {:conflict, id}} ->
-          conn |> put_status(409) |> json(%{error: "conflict", item_id: id})
-
-        {:error, {:cycle, id}} ->
-          conn |> put_status(409) |> json(%{error: "cycle", item_id: id})
-
-        {:error, _reason} ->
-          conn |> put_status(500) |> json(%{error: "internal"})
-      end
+      result = Notes.batch_move_folders(user, vault, ids, tgt)
+      send_move_result(conn, user, vault, ids, result, %{target_parent_id: tgt})
     else
       :error -> conn |> put_status(400) |> json(%{error: "invalid_ids"})
     end
@@ -356,7 +350,31 @@ defmodule EngramWeb.FoldersController do
   def batch_move(conn, _params) do
     conn
     |> put_status(400)
-    |> json(%{error: "missing required params: ids, target_parent_id"})
+    |> json(%{error: "missing required params: ids, and target_parent or target_parent_id"})
+  end
+
+  # Shared response for both move variants. `broadcast_extra` carries the new
+  # parent (target_parent path or target_parent_id) to peer sessions.
+  defp send_move_result(conn, user, vault, ids, result, broadcast_extra) do
+    case result do
+      {:ok, %{moved: n}} ->
+        body = %{moved: n}
+        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+        broadcast_batch(user, vault, Map.merge(%{op: "move", ids: ids}, broadcast_extra))
+        json(conn, body)
+
+      {:error, {:not_found, id}} ->
+        conn |> put_status(404) |> json(%{error: "not_found", item_id: id})
+
+      {:error, {:conflict, id}} ->
+        conn |> put_status(409) |> json(%{error: "conflict", item_id: id})
+
+      {:error, {:cycle, id}} ->
+        conn |> put_status(409) |> json(%{error: "cycle", item_id: id})
+
+      {:error, _reason} ->
+        conn |> put_status(500) |> json(%{error: "internal"})
+    end
   end
 
   # Low-cardinality error formatter for JSON responses; avoids inspect/1 leaking term shape.

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -571,34 +571,31 @@ defmodule EngramWeb.NotesController do
     ]
   )
 
+  # Move by folder PATH — works for derived folders (no marker). The target
+  # path is sanitized downstream by rename_note, so traversal is not a concern.
+  def batch_move(conn, %{"ids" => ids, "target_folder" => folder})
+      when is_list(ids) and is_binary(folder) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+
+    case parse_uuid_list(ids) do
+      {:ok, ids} ->
+        result = Notes.batch_move_notes(user, vault, ids, {:path, folder})
+        send_move_result(conn, user, vault, ids, result, %{target_folder: folder})
+
+      :error ->
+        conn |> put_status(400) |> json(%{error: "invalid_ids"})
+    end
+  end
+
   def batch_move(conn, %{"ids" => ids, "target_folder_id" => tgt}) when is_list(ids) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
     with {:ok, ids} <- parse_uuid_list(ids),
          {:ok, tgt} <- parse_move_target(tgt) do
-      case Notes.batch_move_notes(user, vault, ids, tgt) do
-        {:ok, %{moved: n}} ->
-          body = %{moved: n}
-          Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
-
-          broadcast_batch(user, vault, %{
-            op: "move",
-            ids: ids,
-            target_folder_id: tgt
-          })
-
-          json(conn, body)
-
-        {:error, {:not_found, id}} ->
-          conn |> put_status(404) |> json(%{error: "not_found", item_id: id})
-
-        {:error, {:conflict, id}} ->
-          conn |> put_status(409) |> json(%{error: "conflict", item_id: id})
-
-        {:error, _reason} ->
-          conn |> put_status(500) |> json(%{error: "internal"})
-      end
+      result = Notes.batch_move_notes(user, vault, ids, tgt)
+      send_move_result(conn, user, vault, ids, result, %{target_folder_id: tgt})
     else
       :error -> conn |> put_status(400) |> json(%{error: "invalid_ids"})
     end
@@ -607,7 +604,28 @@ defmodule EngramWeb.NotesController do
   def batch_move(conn, _params) do
     conn
     |> put_status(400)
-    |> json(%{error: "missing required params: ids, target_folder_id"})
+    |> json(%{error: "missing required params: ids, and target_folder or target_folder_id"})
+  end
+
+  # Shared response for both move variants. `broadcast_extra` carries the
+  # destination (target_folder path or target_folder_id) to peer sessions.
+  defp send_move_result(conn, user, vault, ids, result, broadcast_extra) do
+    case result do
+      {:ok, %{moved: n}} ->
+        body = %{moved: n}
+        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+        broadcast_batch(user, vault, Map.merge(%{op: "move", ids: ids}, broadcast_extra))
+        json(conn, body)
+
+      {:error, {:not_found, id}} ->
+        conn |> put_status(404) |> json(%{error: "not_found", item_id: id})
+
+      {:error, {:conflict, id}} ->
+        conn |> put_status(409) |> json(%{error: "conflict", item_id: id})
+
+      {:error, _reason} ->
+        conn |> put_status(500) |> json(%{error: "internal"})
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/engram_web/schemas/folders.ex
+++ b/lib/engram_web/schemas/folders.ex
@@ -129,9 +129,15 @@ defmodule EngramWeb.Schemas.BatchMoveFoldersRequest do
     type: :object,
     properties: %{
       ids: %Schema{type: :array, items: %Schema{type: :string, format: :uuid}},
-      target_parent_id: %Schema{type: :string, description: "Parent folder UUID or \"root\"."}
+      target_parent_id: %Schema{type: :string, description: "Parent folder UUID or \"root\"."},
+      target_parent: %Schema{
+        type: :string,
+        description:
+          "Destination parent folder path (alternative to target_parent_id; \"\" = top level). " <>
+            "Use this to re-parent under a derived folder that has no marker."
+      }
     },
-    required: [:ids, :target_parent_id],
+    required: [:ids],
     example: %{
       "ids" => [
         "3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f",

--- a/lib/engram_web/schemas/notes.ex
+++ b/lib/engram_web/schemas/notes.ex
@@ -218,9 +218,15 @@ defmodule EngramWeb.Schemas.BatchMoveNotesRequest do
     type: :object,
     properties: %{
       ids: %Schema{type: :array, items: %Schema{type: :string, format: :uuid}},
-      target_folder_id: %Schema{type: :string, description: "Folder UUID or \"root\"."}
+      target_folder_id: %Schema{type: :string, description: "Folder UUID or \"root\"."},
+      target_folder: %Schema{
+        type: :string,
+        description:
+          "Destination folder path (alternative to target_folder_id; \"\" = vault root). " <>
+            "Use this to move into a derived folder that has no marker."
+      }
     },
-    required: [:ids, :target_folder_id],
+    required: [:ids],
     example: %{
       "ids" => [
         "9f1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.503",
+      version: "0.5.504",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -22,6 +22,12 @@
             "x-struct": null,
             "x-validate": null
           },
+          "target_parent": {
+            "description": "Destination parent folder path (alternative to target_parent_id; \"\" = top level). Use this to re-parent under a derived folder that has no marker.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "target_parent_id": {
             "description": "Parent folder UUID or \"root\".",
             "type": "string",
@@ -30,8 +36,7 @@
           }
         },
         "required": [
-          "ids",
-          "target_parent_id"
+          "ids"
         ],
         "title": "BatchMoveFoldersRequest",
         "type": "object",
@@ -2617,6 +2622,12 @@
             "x-struct": null,
             "x-validate": null
           },
+          "target_folder": {
+            "description": "Destination folder path (alternative to target_folder_id; \"\" = vault root). Use this to move into a derived folder that has no marker.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "target_folder_id": {
             "description": "Folder UUID or \"root\".",
             "type": "string",
@@ -2625,8 +2636,7 @@
           }
         },
         "required": [
-          "ids",
-          "target_folder_id"
+          "ids"
         ],
         "title": "BatchMoveNotesRequest",
         "type": "object",

--- a/test/engram/notes_batch_test.exs
+++ b/test/engram/notes_batch_test.exs
@@ -149,6 +149,51 @@ defmodule Engram.NotesBatchTest do
       {:ok, moved} = Notes.get_note_by_id(user, vault, n1.id)
       assert moved.path == "a.md"
     end
+
+    test "moves notes into a folder by PATH with no marker (derived target)", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, n1} = Notes.upsert_note(user, vault, %{path: "a.md"})
+      {:ok, n2} = Notes.upsert_note(user, vault, %{path: "b.md"})
+
+      # No create_folder_marker — "Derived/Sub" exists only as a path. Notes
+      # should still move into it (derived folders need no marker).
+      assert {:ok, %{moved: 2}} =
+               Notes.batch_move_notes(user, vault, [n1.id, n2.id], {:path, "Derived/Sub"})
+
+      {:ok, n1_after} = Notes.get_note_by_id(user, vault, n1.id)
+      assert n1_after.path == "Derived/Sub/a.md"
+      assert n1_after.folder == "Derived/Sub"
+    end
+
+    test "path target \"\" moves a note to the vault root", %{user: user, vault: vault} do
+      {:ok, _m} = Notes.create_folder_marker(user, vault, "Archive")
+      {:ok, n1} = Notes.upsert_note(user, vault, %{path: "Archive/a.md"})
+
+      assert {:ok, %{moved: 1}} = Notes.batch_move_notes(user, vault, [n1.id], {:path, ""})
+
+      {:ok, moved} = Notes.get_note_by_id(user, vault, n1.id)
+      assert moved.path == "a.md"
+    end
+
+    test "path move rolls back on a cross-vault id", %{
+      user: user,
+      vault: vault,
+      other_user: other_user,
+      other_vault: other_vault
+    } do
+      {:ok, n1} = Notes.upsert_note(user, vault, %{path: "a.md"})
+      {:ok, foreign} = Notes.upsert_note(other_user, other_vault, %{path: "f.md"})
+
+      assert {:error, {:not_found, id}} =
+               Notes.batch_move_notes(user, vault, [n1.id, foreign.id], {:path, "Derived"})
+
+      assert id == foreign.id
+      # Atomic: n1 stayed put.
+      {:ok, n1_after} = Notes.get_note_by_id(user, vault, n1.id)
+      assert n1_after.path == "a.md"
+    end
   end
 
   describe "batch_delete_folders/2" do
@@ -246,6 +291,20 @@ defmodule Engram.NotesBatchTest do
       assert "Parent/B" in names
       refute "A" in names
       refute "B" in names
+    end
+
+    test "moves a folder into a derived target by PATH (no marker)", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, m1} = Notes.create_folder_marker(user, vault, "A")
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "A/a.md"})
+
+      # "Derived" has no marker — the folder still moves into it by path.
+      assert {:ok, %{moved: 1}} =
+               Notes.batch_move_folders(user, vault, [m1.id], {:path, "Derived"})
+
+      assert {:ok, %{path: "Derived/A/a.md"}} = Notes.get_note(user, vault, "Derived/A/a.md")
     end
 
     test "rolls back on conflict (target already has a same-named child)",

--- a/test/engram_web/controllers/notes_controller_batch_test.exs
+++ b/test/engram_web/controllers/notes_controller_batch_test.exs
@@ -95,5 +95,23 @@ defmodule EngramWeb.NotesControllerBatchTest do
       {:ok, moved} = Engram.Notes.get_note_by_id(user, vault, n1.id)
       assert moved.path == "a.md"
     end
+
+    test "moves notes into a derived folder via target_folder path (no marker)", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, n1} = Engram.Notes.upsert_note(user, vault, %{path: "a.md"})
+
+      body =
+        conn
+        |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+        |> post(~p"/api/notes/batch-move", %{ids: [n1.id], target_folder: "Derived/Sub"})
+        |> json_response(200)
+
+      assert body == %{"moved" => 1}
+      {:ok, moved} = Engram.Notes.get_note_by_id(user, vault, n1.id)
+      assert moved.path == "Derived/Sub/a.md"
+    end
   end
 end


### PR DESCRIPTION
**Stacked on #700** (base is `fix/folder-tree-derived-folder-ids`). Review/merge #700 first.

## Why

#700 made derived folders (notes inside, no marker row) *visible* in the tree, but it had to **block them as move destinations**: the by-id move endpoints can't resolve a folder with no marker id (derived folders come back from `/api/folders` with `id: null`). This makes moving notes/folders **into** a derived folder actually work — by **path**, the way attachment moves already do.

## Backend

- `Notes.batch_move_notes` / `batch_move_folders` accept a `{:path, folder}` target (no marker required); the shared reduce loop is extracted to `reduce_move_notes` / `reduce_move_folders`; `"root"` now routes through `{:path, ""}`.
- `POST /notes/batch-move` accepts **`target_folder`** (path); `POST /folders/batch-move` accepts **`target_parent`** (path) — alongside the existing `*_id` params. The path is sanitized downstream by `rename_note` / `rename_folder` (`PathSanitizer.sanitize`), so traversal is safe.
- Request schemas gain the optional path field; `required` relaxed to `[:ids]` (the controller catch-all still 400s when neither target is present).

## Frontend

- `commitMove` and drag `onMove` send the folder **path**; the synthetic-folder guard/filter from #700 is removed, and the MoveDialog offers **all** folders again.
- `useBatchMoveNotes` / `useBatchMoveFolders` post the path and key optimistic updates by the destination's **loader id** (real marker id, else `syn:<path>`, else `ROOT_FOLDER_ID`), bumping/decrementing folder counts **by name** (a derived folder's raw-cache id is null). Folder-move cycle check is now path-based.

## Tests

- Backend: context + controller path-move cases, incl. moving into a **marker-less** target and cross-vault rollback. (760 backend tests pass; credo + sobelow + format clean.)
- Frontend: optimistic cases for moving notes **and** folders **into** a derived folder, and decrementing the count when moving notes **out of** one. (615 frontend tests pass; tsc + biome clean.)

## Review notes

Reviewed by an automated pass; the one finding (optimistic count decrement for a derived *source* folder keyed by null id) is fixed in the second commit + covered by a new test. Backend reduce-helper extraction is byte-faithful (same transaction/rollback/dek semantics). The `notes.batch` broadcast field rename is inert — the only consumer (`channel.ts`) early-returns unless `op === "upsert"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)