### PR TITLE
fix(e2e): isolate offline queue per test (#635)

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -406,6 +406,42 @@ async def _track_apikey_wipe(request):
         )
 
 
+@pytest.fixture(autouse=True)
+async def _isolate_offline_queue(request):
+    """Reset each used instance's offline queue + issues BEFORE every test.
+
+    Obsidian instances are session-scoped (one process per worker for the
+    whole suite), but every test re-registers its vault, so settings.vaultId
+    churns across tests. The offline queue keys entries by `{vaultId}:{path}`
+    and flushQueue dequeues by the CURRENT settings.vaultId — so an entry
+    enqueued under a prior test's vaultId can never be dequeued and lingers
+    in the queue forever (`queue.size` counts entries across ALL vaultIds).
+
+    Any offline test that doesn't fully drain leaks those orphaned entries
+    into every later test; drain-to-zero tests (test_24/test_29) then fail
+    with "Queue not drained" against foreign-vaultId entries they never
+    created. engram#635 misdiagnosed this as an offline-flag load race and
+    only stabilized the flag timing, so the failure kept recurring.
+
+    Clearing per-test guarantees each test starts from an empty queue. Skips
+    tests that don't use a CDP instance (api_only, etc.). Best-effort: an
+    instance not yet booted on this worker must not fail the test, so a reset
+    error is logged at debug and swallowed (no real state to corrupt).
+    """
+    for name in ("cdp_a", "cdp_b", "cdp_c"):
+        if name not in request.fixturenames:
+            continue
+        try:
+            cdp = request.getfixturevalue(name)
+            await cdp.reset_sync_state()
+        except Exception as e:  # noqa: BLE001 — best-effort pre-test isolation
+            logging.getLogger(__name__).debug(
+                "offline-queue reset skipped for %s/%s: %s",
+                name, request.node.nodeid, e,
+            )
+    yield
+
+
 @pytest.fixture(scope="session", autouse=True)
 async def _assert_plugin_surfaces(cdp_a):
     """Hard-fail once if the plugin under test lacks required surfaces.

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -1065,6 +1065,31 @@ class CdpClient:
         await self.evaluate(f"{ENGINE_PATH}.queue.entries.clear()")
         logger.info("Queue cleared on CDP port %d", self.port)
 
+    async def reset_sync_state(self) -> None:
+        """Clear the offline queue AND sync issues for per-test isolation.
+
+        Quiet, best-effort sibling of clear_queue() used by the per-test
+        autouse fixture. The Obsidian instances are session-scoped but
+        settings.vaultId churns per test (each test re-registers its vault).
+        The offline queue keys entries by `{vaultId}:{path}` and flushQueue
+        dequeues by the CURRENT settings.vaultId, so an entry enqueued under
+        an earlier test's vaultId can never be dequeued and lingers forever
+        (`queue.size` counts entries across ALL vaultIds). Clearing both
+        stores between tests stops that cross-test leakage. See engram#635.
+        """
+        await self.evaluate(
+            f"""
+            (function() {{
+                const se = {ENGINE_PATH};
+                if (se && se.queue && se.queue.entries) se.queue.entries.clear();
+                if (se && se.issues && typeof se.issues.clearAll === 'function') {{
+                    se.issues.clearAll();
+                }}
+                return 'reset';
+            }})()
+            """
+        )
+
     async def persist_plugin_data(self) -> None:
         """Synchronously flush settings + queue + sync state to data.json.
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.508",
+      version: "0.5.509",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Root cause

`test_24_offline_queue_replay` has been failing **deterministically** under `e2e-clerk` (not a load flake), timing out at `wait_for_queue_drain` with size growing 2→6 across reruns. #635/#658 chased an offline-*flag* load race and only stabilized the flag timing, so it kept recurring.

The real cause is **cross-test offline-queue contamination**:

- Obsidian instances are **session-scoped** (one process per worker for the whole suite), but each test re-registers its vault, so `settings.vaultId` churns across tests.
- The offline queue keys entries by `{vaultId}:{path}` and `flushQueue` dequeues by the **current** `settings.vaultId`. An entry enqueued under a *prior* test's vaultId can therefore **never be dequeued** — it lingers forever. `queue.size` counts entries across **all** vaultIds.
- `data.json` from the failed run is the smoking gun: test_24's queue held three *other* tests' notes — `What: A "Great" Day*.md`, `Why do I resist feeling good?.md`, `LargeNote.md` — duplicated across **four different vaultIds**.

test_24 is just the canary: it's the only test that waits for `size == 0`, which is impossible once foreign-vaultId orphans accumulate.

## Fix

- New function-scoped **autouse** fixture `_isolate_offline_queue` clears each used instance's offline queue + sync issues **before every test**.
- New quiet helper `CdpClient.reset_sync_state()`.

Each test now starts from an empty queue, so drain-to-zero assertions only ever see their own entries.

## Verification

The `e2e-clerk` job on this PR is the verification — it ran red 3/3 on the unrelated docs PR #127 (plugin) before this. Watching it here.

## Follow-up (separate, plugin repo)

`flushQueue` should dequeue by `entry.vaultId`, not `settings.vaultId`, so vaultId drift can't orphan entries even outside the test harness. Latent (vaultId is stable in production); filing separately.

Refs #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)