### PR TITLE
feat(frontend): on-brand app crash page

### DIFF
--- a/frontend/src/error-fallback.test.tsx
+++ b/frontend/src/error-fallback.test.tsx
@@ -23,6 +23,11 @@ describe('ErrorFallback', () => {
     )
   })
 
+  it('renders the branded backdrop', () => {
+    const { container } = render(<ErrorFallback error={new Error('boom')} />)
+    expect(container.querySelector('.grid-overlay')).toBeInTheDocument()
+  })
+
   it('shows the Sentry reference id when one is provided', () => {
     render(<ErrorFallback error={new Error('boom')} eventId="abc123" />)
     expect(screen.getByText(/abc123/)).toBeInTheDocument()

--- a/frontend/src/error-fallback.test.tsx
+++ b/frontend/src/error-fallback.test.tsx
@@ -28,14 +28,23 @@ describe('ErrorFallback', () => {
     expect(container.querySelector('.grid-overlay')).toBeInTheDocument()
   })
 
-  it('shows the Sentry reference id when one is provided', () => {
-    render(<ErrorFallback error={new Error('boom')} eventId="abc123" />)
+  it('shows the Sentry reference id only when reporting is active', () => {
+    render(<ErrorFallback error={new Error('boom')} eventId="abc123" reported />)
     expect(screen.getByText(/abc123/)).toBeInTheDocument()
   })
 
-  it('omits the reference line when no eventId is present', () => {
-    render(<ErrorFallback error={new Error('boom')} />)
+  it('omits the reference line when reporting is off, even with an event id', () => {
+    render(<ErrorFallback error={new Error('boom')} eventId="abc123" reported={false} />)
     expect(screen.queryByText(/reference/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/abc123/)).not.toBeInTheDocument()
+  })
+
+  it('claims the error was reported only when reporting is active', () => {
+    const { rerender } = render(<ErrorFallback error={new Error('boom')} reported />)
+    expect(screen.getByText(/has been reported/i)).toBeInTheDocument()
+
+    rerender(<ErrorFallback error={new Error('boom')} reported={false} />)
+    expect(screen.queryByText(/has been reported/i)).not.toBeInTheDocument()
   })
 
   it('reveals the error message in dev builds', () => {

--- a/frontend/src/error-fallback.test.tsx
+++ b/frontend/src/error-fallback.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import ErrorFallback from './error-fallback'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('ErrorFallback', () => {
+  it('renders the branded heading, reload action, and a plain home link', () => {
+    render(<ErrorFallback error={new Error('boom')} />)
+
+    expect(
+      screen.getByRole('heading', { name: /something went wrong/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument()
+    // Plain anchor (not a router <Link>) — the fallback renders outside
+    // RouterProvider, so it must navigate via href, not router context.
+    expect(screen.getByRole('link', { name: /back to home/i })).toHaveAttribute(
+      'href',
+      '/',
+    )
+  })
+
+  it('shows the Sentry reference id when one is provided', () => {
+    render(<ErrorFallback error={new Error('boom')} eventId="abc123" />)
+    expect(screen.getByText(/abc123/)).toBeInTheDocument()
+  })
+
+  it('omits the reference line when no eventId is present', () => {
+    render(<ErrorFallback error={new Error('boom')} />)
+    expect(screen.queryByText(/reference/i)).not.toBeInTheDocument()
+  })
+
+  it('reveals the error message in dev builds', () => {
+    vi.stubEnv('DEV', true)
+    render(<ErrorFallback error={new Error('kaboom-detail')} />)
+    expect(screen.getByText(/kaboom-detail/)).toBeInTheDocument()
+  })
+
+  it('hides the error message in production builds', () => {
+    vi.stubEnv('DEV', false)
+    render(<ErrorFallback error={new Error('kaboom-detail')} />)
+    expect(screen.queryByText(/kaboom-detail/)).not.toBeInTheDocument()
+  })
+
+  it('reloads the page when reload is clicked', () => {
+    const reload = vi.fn()
+    vi.spyOn(window.location, 'reload').mockImplementation(reload)
+
+    render(<ErrorFallback error={new Error('boom')} />)
+    fireEvent.click(screen.getByRole('button', { name: /reload/i }))
+
+    expect(reload).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/error-fallback.tsx
+++ b/frontend/src/error-fallback.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react'
 import AuthBackdrop from './layout/auth-backdrop'
 import AuthPanel from './layout/auth-panel'
 import { Button } from '@/components/ui/button'
@@ -14,12 +15,23 @@ import { heading } from '@/lib/ui-classes'
 //
 // Sentry passes `{ error, componentStack, eventId, resetError }` to the
 // fallback; we surface `eventId` as a support reference and `error` (dev only).
+//
+// `reported` gates the "has been reported" claim + the reference id. Sentry
+// hands us an eventId even when no client is initialized (dev / self-host with
+// no VITE_SENTRY_DSN), but that id has no transport behind it — claiming the
+// crash was reported would be a lie. `getClient()` is truthy only when
+// Sentry.init actually ran, so we default to it and let tests inject the flag.
 type ErrorFallbackProps = {
   error: unknown
   eventId?: string
+  reported?: boolean
 }
 
-export default function ErrorFallback({ error, eventId }: ErrorFallbackProps) {
+export default function ErrorFallback({
+  error,
+  eventId,
+  reported = !!Sentry.getClient(),
+}: ErrorFallbackProps) {
   const message = error instanceof Error ? error.message : String(error)
 
   return (
@@ -39,7 +51,7 @@ export default function ErrorFallback({ error, eventId }: ErrorFallbackProps) {
           </p>
           <h1 className={heading}>Something went wrong</h1>
           <p className="max-w-md text-sm text-muted-foreground">
-            An unexpected error broke this page. It has been reported. Try
+            An unexpected error broke this page.{reported ? ' It has been reported.' : ''} Try
             reloading — if it keeps happening, contact{' '}
             <a className="underline" href="mailto:support@engram.page">
               support@engram.page
@@ -47,7 +59,7 @@ export default function ErrorFallback({ error, eventId }: ErrorFallbackProps) {
             .
           </p>
 
-          {eventId ? (
+          {reported && eventId ? (
             <p className="text-xs text-muted-foreground">
               Reference:{' '}
               <code className="rounded bg-muted px-1.5 py-0.5 font-mono">{eventId}</code>

--- a/frontend/src/error-fallback.tsx
+++ b/frontend/src/error-fallback.tsx
@@ -1,3 +1,4 @@
+import AuthBackdrop from './layout/auth-backdrop'
 import AuthPanel from './layout/auth-panel'
 import { Button } from '@/components/ui/button'
 import { heading } from '@/lib/ui-classes'
@@ -29,8 +30,10 @@ export default function ErrorFallback({ error, eventId }: ErrorFallbackProps) {
           Engram
         </span>
       </header>
-      <section className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-        <AuthPanel className="flex flex-col items-center gap-4 text-center">
+      <section className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <AuthBackdrop />
+        <div className="relative z-10 flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <AuthPanel className="flex flex-col items-center gap-4 text-center">
           <p className="bg-gradient-to-r from-brand-purple to-primary bg-clip-text text-7xl font-extrabold leading-none tracking-tight text-transparent sm:text-8xl">
             Oops
           </p>
@@ -71,7 +74,8 @@ export default function ErrorFallback({ error, eventId }: ErrorFallbackProps) {
               </pre>
             </details>
           ) : null}
-        </AuthPanel>
+          </AuthPanel>
+        </div>
       </section>
     </main>
   )

--- a/frontend/src/error-fallback.tsx
+++ b/frontend/src/error-fallback.tsx
@@ -1,0 +1,78 @@
+import AuthPanel from './layout/auth-panel'
+import { Button } from '@/components/ui/button'
+import { heading } from '@/lib/ui-classes'
+
+// Top-level crash page rendered by `<Sentry.ErrorBoundary>` in main.tsx.
+//
+// CRITICAL: this renders OUTSIDE every provider (it replaces the whole app
+// subtree), so it must not touch RouterProvider, ThemeProvider, or config
+// context. That means a plain <a href> instead of react-router <Link>, a hard
+// `window.location.reload()` to re-run the bootstrap chain, and the AuthShell
+// header inlined here WITHOUT the ThemeToggle (which needs theme context).
+// Brand color tokens are global CSS, so they resolve fine without a provider.
+//
+// Sentry passes `{ error, componentStack, eventId, resetError }` to the
+// fallback; we surface `eventId` as a support reference and `error` (dev only).
+type ErrorFallbackProps = {
+  error: unknown
+  eventId?: string
+}
+
+export default function ErrorFallback({ error, eventId }: ErrorFallbackProps) {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return (
+    <main className="flex h-dvh flex-col bg-background text-foreground">
+      <header className="flex items-center justify-between border-b border-border bg-card px-4 py-2">
+        <span className="flex items-center gap-2 text-lg font-semibold text-foreground">
+          <img src="/engram-mark.svg" alt="" className="size-6" />
+          Engram
+        </span>
+      </header>
+      <section className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <AuthPanel className="flex flex-col items-center gap-4 text-center">
+          <p className="bg-gradient-to-r from-brand-purple to-primary bg-clip-text text-7xl font-extrabold leading-none tracking-tight text-transparent sm:text-8xl">
+            Oops
+          </p>
+          <h1 className={heading}>Something went wrong</h1>
+          <p className="max-w-md text-sm text-muted-foreground">
+            An unexpected error broke this page. It has been reported. Try
+            reloading — if it keeps happening, contact{' '}
+            <a className="underline" href="mailto:support@engram.page">
+              support@engram.page
+            </a>
+            .
+          </p>
+
+          {eventId ? (
+            <p className="text-xs text-muted-foreground">
+              Reference:{' '}
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono">{eventId}</code>
+            </p>
+          ) : null}
+
+          <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+            <Button type="button" onClick={() => window.location.reload()}>
+              Reload
+            </Button>
+            <Button asChild variant="outline">
+              <a href="/">Back to home</a>
+            </Button>
+          </div>
+
+          {import.meta.env.DEV ? (
+            <details className="mt-4 w-full max-w-md rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-left text-sm">
+              <summary className="cursor-pointer font-medium">
+                Error detail (dev only)
+              </summary>
+              <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words text-xs">
+                {message}
+                {error instanceof Error && error.stack ? `\n\n${error.stack}` : ''}
+              </pre>
+            </details>
+          ) : null}
+        </AuthPanel>
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/error-fallback.tsx
+++ b/frontend/src/error-fallback.tsx
@@ -52,7 +52,7 @@ export default function ErrorFallback({
           <h1 className={heading}>Something went wrong</h1>
           <p className="max-w-md text-sm text-muted-foreground">
             An unexpected error broke this page.{reported ? ' It has been reported.' : ''} Try
-            reloading — if it keeps happening, contact{' '}
+            reloading. If it keeps happening, contact{' '}
             <a className="underline" href="mailto:support@engram.page">
               support@engram.page
             </a>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,6 +11,7 @@ import { configPromise, type EngramConfig } from './config'
 import { ConfigProvider } from './config-context'
 import { ThemeProvider } from './theme/theme-provider'
 import LoadingScreen from './layout/loading-screen'
+import ErrorFallback from './error-fallback'
 import './main.css'
 
 // Sentry — opt-in via VITE_SENTRY_DSN at build time. No-op (zero
@@ -80,33 +81,21 @@ if (posthogKey) {
 const ClerkAuthProvider = lazy(() => import('./auth/clerk-auth-provider'))
 const LocalAuthProvider = lazy(() => import('./auth/local-auth-provider'))
 
-function ErrorFallback() {
-  return (
-    <main className="grid min-h-screen place-items-center p-6 text-center">
-      <section>
-        <h1 className="text-xl font-semibold">Something went wrong.</h1>
-        <p className="mt-2 text-sm opacity-70">
-          The error has been reported. Try reloading; if it keeps happening,
-          contact support@engram.page.
-        </p>
-        <button
-          type="button"
-          className="mt-4 rounded border px-3 py-1 text-sm"
-          onClick={() => window.location.reload()}
-        >
-          Reload
-        </button>
-      </section>
-    </main>
-  )
-}
-
 // Bootstrap chain: `use(configPromise)` suspends until config resolves
 // (window injection → /config.json → defaults). Once resolved, build the
 // runtime router (route shape depends on auth provider + billingEnabled)
 // and install it so module-level consumers like clerk-auth-provider can
 // imperatively navigate via `getAppRouter()`.
 function AppShell({ config }: { config: EngramConfig }) {
+  // Dev-only crash trigger for eyeballing ErrorFallback. Throws HERE, above
+  // RouterProvider, on purpose: a throwing *route* would be caught by React
+  // Router's own error boundary, not the outer Sentry.ErrorBoundary we're
+  // styling. Visit `?boom` to see the real crash page. Stripped from prod
+  // builds by the import.meta.env.DEV gate.
+  if (import.meta.env.DEV && new URLSearchParams(window.location.search).has('boom')) {
+    throw new Error('Intentional crash (?boom) — testing ErrorFallback')
+  }
+
   const AuthProvider = config.authProvider === 'clerk' ? ClerkAuthProvider : LocalAuthProvider
   // Memoize so StrictMode's double-render + any future ConfigProvider
   // updates don't blow away the router instance + its history stack.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.509",
+      version: "0.5.510",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

Replaces the bare-bones `Sentry.ErrorBoundary` fallback with an on-brand crash page, matching the 404 page's visual language.

Before: unstyled `border` + `opacity-70` block. After: gradient "Oops" flair, Engram header, `AuthBackdrop` (grid + neural glows), `AuthPanel` card, reload + back-to-home, support reference.

## Key design constraints

- **Renders outside all providers.** The fallback replaces the entire app subtree, so it has no `RouterProvider`/`ThemeProvider`/config context. It's fully self-contained: plain `<a href="/">` (not router `<Link>` — would re-crash), `window.location.reload()`, and the header omits `ThemeToggle` (needs theme ctx). `AuthBackdrop`/`AuthPanel` are pure CSS → safe to reuse. Brand color tokens are global CSS, not context.
- **Honest reporting copy.** Sentry hands the boundary an `eventId` even when no client is initialized (dev / self-host with no `VITE_SENTRY_DSN`), but that id has no transport. So "It has been reported" + the `Reference:` line are gated on `reported` (defaults to `!!Sentry.getClient()`). They show only where Sentry actually ships — SaaS prod.
- **Dev-only `?boom` trigger** in `AppShell`, above `RouterProvider` — a throwing *route* would be caught by React Router's own error boundary, never reaching the Sentry root boundary. Stripped from prod by `import.meta.env.DEV`.

## Test

`?boom` in dev — verified live (saas-dev pointed at the worktree) the page renders branded, and in dev correctly drops the "reported" claim + reference.

8 unit tests in `error-fallback.test.tsx` (branding, backdrop, reload, home link, dev error detail gating, reporting-claim gating). All green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)