### PR TITLE
fix(oban): register orphaned cleanup/indexing/default queues

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,16 @@ config :engram, :storage, Engram.Storage.S3
 config :engram, Oban,
   engine: Oban.Engines.Basic,
   repo: Engram.Repo,
-  queues: [embed: 5, reindex: 1, maintenance: 2, crypto_backfill: 1, export: 1],
+  queues: [
+    embed: 5,
+    reindex: 1,
+    maintenance: 2,
+    crypto_backfill: 1,
+    export: 1,
+    cleanup: 1,
+    indexing: 2,
+    default: 1
+  ],
   plugins: [
     {Oban.Plugins.Pruner, max_age: 7 * 24 * 3600},
     Oban.Plugins.Lifeline,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.510",
+      version: "0.5.511",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/oban_queue_config_test.exs
+++ b/test/engram/oban_queue_config_test.exs
@@ -3,17 +3,12 @@ defmodule Engram.ObanQueueConfigTest do
   # registered in `config :engram, Oban, queues: [...]`. A worker pointed
   # at an unregistered queue has no producer on any node, so its jobs sit
   # `available` forever and never execute (the orphaned-queue failure mode
-  # that stranded :indexing + :default in prod). Catches it at compile/CI
-  # time instead of via a Grafana backlog days later.
+  # that stranded :cleanup + :indexing + :default in prod). Catches it at
+  # compile/CI time instead of via a Grafana backlog days later.
   use ExUnit.Case, async: true
 
   test "every Oban worker's queue is registered in the Oban queues config" do
-    configured =
-      :engram
-      |> Application.fetch_env!(Oban)
-      |> Keyword.fetch!(:queues)
-      |> Keyword.keys()
-      |> MapSet.new()
+    configured = MapSet.new(configured_queues())
 
     {:ok, modules} = :application.get_key(:engram, :modules)
 
@@ -30,8 +25,26 @@ defmodule Engram.ObanQueueConfigTest do
              "Jobs in an unregistered queue have no producer and never execute.\n" <>
              "Add the queue to config/config.exs (or fix the worker's queue:).\n\n" <>
              Enum.map_join(offenders, "\n", fn {mod, q} ->
-               "  #{inspect(mod)} -> :#{q}"
+               "  #{inspect(mod)} -> #{inspect(q)}"
              end)
+  end
+
+  # The configured queue list. `testing: :manual` (config/test.exs) deep-merges
+  # into the base `config/config.exs` Oban config, so `:queues` is the real
+  # base list here. Guard against an env that stubs it to `false`/`nil` — that
+  # would mean NO worker can run, which is itself a misconfiguration, not a
+  # silently-empty allowlist that passes the test vacuously.
+  defp configured_queues do
+    case Application.fetch_env!(:engram, Oban)[:queues] do
+      queues when is_list(queues) and queues != [] ->
+        Keyword.keys(queues)
+
+      other ->
+        flunk(
+          "config :engram, Oban, queues: must be a non-empty keyword list, got: " <>
+            inspect(other)
+        )
+    end
   end
 
   defp oban_worker?(mod) do
@@ -40,9 +53,13 @@ defmodule Engram.ObanQueueConfigTest do
 
   # Pull the worker's actual queue from a built changeset so it reflects the
   # real `use Oban.Worker, queue:` value (no reliance on private internals).
+  # If a worker overrides `new/1` to require args and raises on `%{}`, surface
+  # that as its own offender instead of crashing the whole guard.
   defp worker_queue(mod) do
     mod.new(%{})
     |> Ecto.Changeset.get_field(:queue)
     |> String.to_existing_atom()
+  rescue
+    error -> {:could_not_build, Exception.message(error)}
   end
 end

--- a/test/engram/oban_queue_config_test.exs
+++ b/test/engram/oban_queue_config_test.exs
@@ -1,0 +1,48 @@
+defmodule Engram.ObanQueueConfigTest do
+  # Guard: every Oban worker must enqueue to a queue that is actually
+  # registered in `config :engram, Oban, queues: [...]`. A worker pointed
+  # at an unregistered queue has no producer on any node, so its jobs sit
+  # `available` forever and never execute (the orphaned-queue failure mode
+  # that stranded :indexing + :default in prod). Catches it at compile/CI
+  # time instead of via a Grafana backlog days later.
+  use ExUnit.Case, async: true
+
+  test "every Oban worker's queue is registered in the Oban queues config" do
+    configured =
+      :engram
+      |> Application.fetch_env!(Oban)
+      |> Keyword.fetch!(:queues)
+      |> Keyword.keys()
+      |> MapSet.new()
+
+    {:ok, modules} = :application.get_key(:engram, :modules)
+
+    offenders =
+      for mod <- modules,
+          Code.ensure_loaded?(mod),
+          oban_worker?(mod),
+          queue = worker_queue(mod),
+          queue not in configured,
+          do: {mod, queue}
+
+    assert offenders == [],
+           "Oban workers target queues missing from `config :engram, Oban, queues:`.\n" <>
+             "Jobs in an unregistered queue have no producer and never execute.\n" <>
+             "Add the queue to config/config.exs (or fix the worker's queue:).\n\n" <>
+             Enum.map_join(offenders, "\n", fn {mod, q} ->
+               "  #{inspect(mod)} -> :#{q}"
+             end)
+  end
+
+  defp oban_worker?(mod) do
+    Oban.Worker in (mod.module_info(:attributes)[:behaviour] || [])
+  end
+
+  # Pull the worker's actual queue from a built changeset so it reflects the
+  # real `use Oban.Worker, queue:` value (no reliance on private internals).
+  defp worker_queue(mod) do
+    mod.new(%{})
+    |> Ecto.Changeset.get_field(:queue)
+    |> String.to_existing_atom()
+  end
+end


### PR DESCRIPTION
## Problem

Three Oban workers enqueue to queues **not registered** in `config :engram, Oban, queues:`. With no producer for those queues on any node, their jobs sit `available`/`scheduled` forever and never execute.

Confirmed in **prod** via PromEx (`engram_prom_ex_oban_queue_length_count` + `oban_init_status_info`): both ECS nodes ran only `embed, reindex, maintenance, crypto_backfill, export`. Backlog was non-draining (flat `executing`=0).

| Worker | Queue | Impact |
|--------|-------|--------|
| `CleanupVault` | `:cleanup` | vault + **account hard-delete** after 30d retention — orphaned = deleted-account data never purged (data-retention exposure) |
| `DeleteNoteIndex` | `:indexing` | Qdrant vector cleanup on note delete — leaves ghost chunks |
| `OriginAbuseSweep` | `:default` | daily Pro fair-use telemetry sweep (Pricing v2 §E) |

(A Grafana chart showed "8 indexing + 24 default" — that's 2× double-counting: two ECS nodes each report the same global Oban DB gauge. Real backlog ≈ half.)

## Fix

Register the three queues. On deploy Oban auto-drains the existing backlog — no manual intervention.

## Prevention

Adds `test/engram/oban_queue_config_test.exs` — asserts every `Oban.Worker`'s queue is registered. This class of bug now fails in CI instead of via a production backlog days later. (The guard caught `:cleanup`, which the original report had missed.)

## Verification
- compile (warnings-as-errors) ✅
- format ✅ / credo --strict ✅ / sobelow ✅
- guard test red → green ✅; `oban_test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)