### PR TITLE
chore(ci): drop premature release-initiated Grafana annotation

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -232,39 +232,15 @@ jobs:
             --data "$(jq -nc --arg c "$CONTENT" '{content:$c}')" \
             "$WEBHOOK"
 
-      # Mark "release initiated" in Grafana so the operator sees a vertical
-      # line on every Engram-folder dashboard. The matching "applied"
-      # annotation lands ~3-5 min later when engram-infra's
-      # `terraform (prod)` apply rolls the ECS service onto the new task
-      # def. SAT is mirrored from SOPS to a repo secret here (see comment
-      # in engram-infra `main/envs/prod/grafana.tf`); rotation requires
-      # updating both. Best-effort: a failed annotation doesn't fail the
-      # deploy. Skipped silently if the secret isn't set (e.g. on a fork).
-      - name: Annotate release-initiated in Grafana
-        if: success() && steps.open-pr.outputs.pull-request-number != '' && env.GRAFANA_SAT != ''
-        env:
-          GRAFANA_SAT: ${{ secrets.GRAFANA_SAT_CLAUDE_CODE }}
-          RELEASE: ${{ steps.tags.outputs.release }}
-          IMAGE: ${{ steps.tags.outputs.image_tag }}
-          PR_URL: ${{ steps.open-pr.outputs.pull-request-url }}
-          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          NOW_MS=$(( $(date +%s%N) / 1000000 ))
-          TEXT=$(printf 'release initiated: `%s` → `%s`\nengram-infra PR: %s\n[run](%s)' \
-            "$RELEASE" "$IMAGE" "$PR_URL" "$GH_RUN_URL")
-          BODY=$(jq -nc \
-            --arg time "$NOW_MS" \
-            --arg text "$TEXT" \
-            '{time:($time|tonumber), text:$text, tags:["deploy","initiated","engram","prod"]}')
-          curl -sS --fail-with-body --max-time 10 \
-            -X POST \
-            -H "Authorization: Bearer $GRAFANA_SAT" \
-            -H "Content-Type: application/json" \
-            -d "$BODY" \
-            https://calmeucalyptus520.grafana.net/api/annotations \
-            | jq -r '"annotation id: \(.id)"' \
-            || echo "::warning::Grafana annotation failed — deploy unaffected"
+      # No Grafana annotation here. This step only opens the image-bump PR
+      # in engram-infra — prod hasn't moved yet (the ECS rollout happens
+      # ~3-5 min later when that PR merges and engram-infra's
+      # `terraform (prod)` apply rolls the service). A marker stamped now
+      # would sit minutes before the actual change. The authoritative prod
+      # deploy annotation is emitted by engram-infra CI as a REGION spanning
+      # the real ECS rollout window (see `terraform (prod)` job +
+      # `.github/actions/grafana-annotate`). Deploy progress/failure still
+      # surfaces via the Discord notifications above/below.
 
       # Failure path — same webhook, different framing. `failure()`
       # fires when an earlier step exited non-zero.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.511",
+      version: "0.5.512",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

`deploy-prod.yml` fired a "release initiated" Grafana annotation stamped at **tag-push time**. But this job only opens the image-bump PR in engram-infra — prod doesn't move until ~3-5 min later when that PR merges and engram-infra's `terraform (prod)` apply rolls the ECS service onto the new task def. The marker sat minutes before the real change, misleading when reading a metric blip against "when did we deploy?".

## Change

Remove the `Annotate release-initiated in Grafana` step. The authoritative prod deploy annotation is now emitted by **engram-infra CI as a region** spanning the actual ECS rollout window (paired PR engram-infra#637). Deploy progress + failure still surface via the Discord notifications in this job (unchanged).

`mix.exs` version bumped 0.5.511 → 0.5.512 per the repo's one-bump-per-PR policy (CI-only change, but the pre-push hook + version-check require it).

## Note
`GRAFANA_SAT_CLAUDE_CODE` repo secret is now unused here — left in place (harmless; SOPS-mirrored, rotation touches both repos).

## Verification
`python3 yaml.safe_load` on `deploy-prod.yml` → OK; pre-push fast-path `mix format --check-formatted` → passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)