### PR TITLE
chore(oban): raise stage_interval 1s → 5s to cut staging-poll churn

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,6 +55,13 @@ config :engram, :storage, Engram.Storage.S3
 config :engram, Oban,
   engine: Oban.Engines.Basic,
   repo: Engram.Repo,
+  # Staging poll cadence (default 1s). Fresh inserts dispatch instantly via the
+  # Postgres notifier (pg_notify), which also fans out across our unclustered
+  # prod nodes through the shared DB — so this poll only paces promotion of
+  # scheduled/retry jobs and acts as a missed-notify safety net. 5s trims ~80%
+  # of the source-less BEGIN/COMMIT/SELECT staging churn with no fresh-insert
+  # latency cost.
+  stage_interval: :timer.seconds(5),
   queues: [
     embed: 5,
     reindex: 1,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.515",
+      version: "0.5.516",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

Set Oban `stage_interval: :timer.seconds(5)` (was the implicit 1s default).

## Why

The Stager polls every 1s to promote scheduled/retry jobs and emit a missed-notify safety signal. Each tick is a `BEGIN` / `COMMIT` + source-less `SELECT` — the bulk of the `source_unavailable` traffic on the Grafana Ecto chart. 5s trims ~80% of that churn.

**No fresh-insert latency cost:** new jobs dispatch instantly via the Postgres notifier (pg_notify), which also crosses our two prod nodes through the shared DB (they're unclustered — see #710). The poll only paces scheduled/retry promotion, which nothing here needs sub-5s.

## Verification

- `mix format` clean; `stage_interval` is a validated top-level Oban config key (`oban/config.ex`).
- Topology-independent: safe whether or not clustering is later enabled.

Refs #710 (clustering audit that surfaced this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)