### PR TITLE
feat(rate-limiter): cluster-status gauge (works clustered + standalone)

### DIFF
--- a/lib/engram/prom_ex/rate_limiter.ex
+++ b/lib/engram/prom_ex/rate_limiter.ex
@@ -47,4 +47,54 @@ defmodule Engram.PromEx.RateLimiter do
       ]
     )
   end
+
+  @impl true
+  def polling_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :rate_limiter)
+    poll_rate = Keyword.get(opts, :rate_limiter_poll_rate, 5_000)
+
+    Polling.build(
+      :engram_rate_limiter_polling_metrics,
+      poll_rate,
+      {__MODULE__, :execute_cluster_metrics, []},
+      [
+        last_value(
+          metric_prefix ++ [:cluster, :peers],
+          event_name: [:engram, :rate_limiter, :cluster],
+          measurement: :peers,
+          description:
+            "Connected BEAM peer nodes. 0 = standalone/unclustered → rate-limit counts are per-node only."
+        ),
+        last_value(
+          metric_prefix ++ [:cluster, :distributed],
+          event_name: [:engram, :rate_limiter, :cluster],
+          measurement: :distributed,
+          description:
+            "1 when the cluster-shared :distributed_ets backend is active, else 0 (per-node :ets)."
+        )
+      ]
+    )
+  end
+
+  @doc """
+  Polled emitter for cluster status. Reports the BEAM peer count and whether the
+  cluster-shared backend is active, so the limiter telemetry is interpretable in
+  BOTH clustered and standalone deploys (self-host or unclustered prod):
+
+    * standalone → `peers: 0, distributed: 0`
+    * clustered  → `peers: >=1, distributed: 1`
+  """
+  @spec execute_cluster_metrics() :: :ok
+  def execute_cluster_metrics do
+    :telemetry.execute(
+      [:engram, :rate_limiter, :cluster],
+      %{peers: length(Node.list()), distributed: distributed_flag()},
+      %{}
+    )
+  end
+
+  defp distributed_flag do
+    if EngramWeb.RateLimiter.backend() == :distributed_ets, do: 1, else: 0
+  end
 end

--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -240,6 +240,13 @@ defmodule EngramWeb.Telemetry do
         description:
           "DistributedETS cross-node PubSub increments, `:result` :applied | :dropped. The warm-window signal: `:applied` ramping from a new node's boot = warming from peers; `:dropped` > 0 = lost increments."
       ),
+      last_value("engram.rate_limiter.cluster.peers",
+        description:
+          "Connected BEAM peer nodes (0 = standalone/unclustered → limiter counts per-node only)."
+      ),
+      last_value("engram.rate_limiter.cluster.distributed",
+        description: "1 if the cluster-shared :distributed_ets backend is active, else 0."
+      ),
 
       # PR #244 — Paddle webhook reliability surfaces.
       #

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.514",
+      version: "0.5.515",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/prom_ex/rate_limiter_test.exs
+++ b/test/engram/prom_ex/rate_limiter_test.exs
@@ -50,4 +50,44 @@ defmodule Engram.PromEx.RateLimiterTest do
       refute tag in banned, "metric #{inspect(m.name)} has banned tag #{inspect(tag)}"
     end
   end
+
+  describe "polling_metrics/1 — cluster status (works clustered + standalone)" do
+    alias PromEx.MetricTypes.Polling
+
+    defp polling do
+      Plugin.polling_metrics(otp_app: :engram) |> List.wrap()
+    end
+
+    test "returns a Polling group with peers + distributed last_value gauges" do
+      groups = polling()
+      assert groups != []
+      assert Enum.all?(groups, &match?(%Polling{}, &1))
+
+      metrics = Enum.flat_map(groups, & &1.metrics)
+      names = Enum.map(metrics, & &1.name)
+
+      assert [:engram, :prom_ex, :rate_limiter, :cluster, :peers] in names
+      assert [:engram, :prom_ex, :rate_limiter, :cluster, :distributed] in names
+      assert Enum.all?(metrics, &match?(%Telemetry.Metrics.LastValue{}, &1))
+    end
+
+    test "execute_cluster_metrics/0 emits peers + distributed (0/0 when standalone :ets)" do
+      ref = make_ref()
+      test_pid = self()
+
+      :telemetry.attach(
+        {__MODULE__, ref},
+        [:engram, :rate_limiter, :cluster],
+        fn _name, meas, _meta, _ -> send(test_pid, {:cluster, ref, meas}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+      # In the test VM there are no connected peers and the backend is :ets,
+      # so this is the standalone/non-clustered reading: peers 0, distributed 0.
+      Plugin.execute_cluster_metrics()
+      assert_receive {:cluster, ^ref, %{peers: 0, distributed: 0}}, 1000
+    end
+  end
 end


### PR DESCRIPTION
## Why

Follow-on to #708 (merged). #708's `hit` + `remote_inc` telemetry alone can't tell you **which deploy config a node is in**: on a standalone/unclustered node the `:distributed_ets` backend isn't running, so `remote_inc` is simply *absent* — a dashboard can't distinguish "clustered + idle" from "not clustered at all". This matters because prod is currently unclustered (p0 #710) and self-host is single-node by design.

(Would have ridden in #708, but it auto-merged before this could be appended.)

## What

A polled **cluster-status gauge** so the limiter telemetry is interpretable in **both** configs:

- `engram_prom_ex_rate_limiter_cluster_peers` = `length(Node.list())`
- `engram_prom_ex_rate_limiter_cluster_distributed` = `1` if the `:distributed_ets` backend is active, else `0`

| Deploy | peers | distributed |
|---|---|---|
| self-host / unclustered prod | `0` | `0` |
| clustered prod | `>=1` | `1` |

Polled every 5s via a PromEx `Polling` group; also declared in `EngramWeb.Telemetry` for LiveDashboard. No tags (bounded by construction).

This is the signal that makes "is the shared rate-limit store actually shared?" answerable at a glance, and doubles as a lightweight **#710 clustering-health monitor** (`peers`/`distributed` flip 0→1 the day clustering comes up).

## Tests (TDD)

`Engram.PromEx.RateLimiterTest`:
- `polling_metrics/1` declares both `last_value` gauges on `[:engram, :rate_limiter, :cluster]`.
- `execute_cluster_metrics/0` emits `%{peers: 0, distributed: 0}` in the standalone test VM (no peers, `:ets` backend).

Watched RED → GREEN; 7/7 plugin tests pass, `--warnings-as-errors` + credo clean, formatted. Version `0.5.514 → 0.5.515`.

Refs #708, #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)