### PR TITLE
docs(rel): fix false RELEASE_COOKIE comment in env.sh.eex (#710)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.516",
+      version: "0.5.517",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,8 +1,13 @@
 #!/bin/sh
 # Cluster ECS tasks with long node names bound to the task ENI IP so DNSCluster
 # (DNS_CLUSTER_QUERY -> Cloud Map service DNS) can discover peers by resolving
-# the service name to all task IPs and connecting to engram@<ip>. RELEASE_COOKIE
-# is supplied via env (SOPS) so only trusted nodes cluster.
+# the service name to all task IPs and connecting to engram@<ip>. The cluster
+# cookie is the per-build value baked into the release image by `mix release`
+# (releases/COOKIE) — there is NO RELEASE_COOKIE env/SOPS secret. Same-image
+# tasks share the baked cookie and cluster; a rolling deploy's old/new tasks
+# have different cookies and intentionally do NOT cluster, so distribution
+# never mixes code versions. (Trust boundary is the self-scoped task SG inside
+# the private VPC, not the cookie.)
 #
 # Gated on ECS_ENABLE_CLUSTER: when unset (self-host, local, single-node), the
 # default mix-release env (short names, no clustering) applies and DNS_CLUSTER_QUERY


### PR DESCRIPTION
Surfaced by the engram-infra#642 review (cross-repo consistency).

## Problem
`rel/env.sh.eex:4-5` claims *"RELEASE_COOKIE is supplied via env (SOPS) so only trusted nodes cluster."* — but **nothing sets RELEASE_COOKIE**: no env var, no SOPS key, and infra#642 deliberately relies on the per-build cookie baked into the release by `mix release` (`releases/COOKIE`).

## Why it matters
The stale comment would mislead an operator into wiring a static cookie via SOPS — which would **break the property that a rolling deploy's old/new (different-image) tasks do NOT cluster** (different baked cookies), the safety that keeps distribution from mixing code versions mid-deploy.

## Fix
Comment-only. Describes the baked-cookie reality and the real trust boundary (the `self`-scoped task SG inside the private VPC, not the cookie). No behavior change.

Pairs with engram-app/engram-infra#642. Refs #710.

> **Merge order:** after #711 (which takes 0.5.516); this takes 0.5.517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)