### PR TITLE
fix(release): COPY rel/ into builder so clustering env.sh ships (#710)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,13 @@ RUN --mount=type=cache,target=/app/deps,id=mix-deps,sharing=locked \
 COPY lib lib
 COPY priv priv
 COPY --from=frontend /priv/static/app priv/static/app
+# rel/ holds env.sh.eex, whose ECS_ENABLE_CLUSTER gate exports
+# RELEASE_DISTRIBUTION=name + RELEASE_NODE=engram@<ip> for BEAM clustering
+# (engram-app/Engram#710). Without this COPY, `mix release` below never sees
+# the template and emits the DEFAULT env.sh (short-name `sname` mode) — so the
+# clustering env var lands on a release that can't read it and nodes never
+# connect (peers=0). Must be COPY'd before `mix release`.
+COPY rel rel
 # Compile and release in one RUN, no _build cache mount. Splitting the
 # two steps with a shared _build cache produced stale beams in CI —
 # `mix compile --force` ran but `mix release` in the next RUN still

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.517",
+      version: "0.5.518",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -14,5 +14,11 @@
 # stays unset -> DNSCluster runs in :ignore mode. Self-host behavior is unchanged.
 if [ -n "$ECS_ENABLE_CLUSTER" ]; then
   export RELEASE_DISTRIBUTION=name
-  export RELEASE_NODE="engram@$(hostname -i | awk '{print $1}')"
+  # Node name must be engram@<ENI-IPv4> to match the Cloud Map A record
+  # DNSCluster connects to. `hostname -i` can return an IPv6 (link-local)
+  # first on a dual-stack host, and `hostname -I` also lists the 169.254.x
+  # ECS task-metadata address — both would break node-name matching. Take the
+  # first non-link-local IPv4 from the full address list instead.
+  _eni_ipv4="$(hostname -I | awk '{for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ && $i !~ /^169\.254\./) { print $i; exit }}')"
+  export RELEASE_NODE="engram@${_eni_ipv4}"
 fi


### PR DESCRIPTION
## The bug
Clustering has **never worked** in prod, and this is why: the Dockerfile copies `mix.exs`, `config/`, `lib`, `priv` — but **never `COPY rel rel`**. So `mix release` runs without `rel/env.sh.eex` in context and emits the **default** `env.sh`. The `ECS_ENABLE_CLUSTER` gate (which exports `RELEASE_DISTRIBUTION=name` + `RELEASE_NODE=engram@<ip>`, in `rel/env.sh.eex` since #327 / 2026-05-28) has therefore shipped in **zero** images.

## Live evidence (break-glass exec on prod)
- `ECS_ENABLE_CLUSTER=true` **is** set in the container (infra#642 applied) ✅
- but `grep -c ECS_ENABLE_CLUSTER /app/releases/0.5.516/env.sh` → **0** ❌
- node runs `dist: "sname"`, `RELEASE_NODE: "engram"` → short-name mode, no long-name peers
- metric: `distributed=1` (runtime.exs reads `DNS_CLUSTER_QUERY`) but `peers=0` on both nodes
- Cloud Map resolves both IPs, SG allows EPMD+dist — everything else is correct

## Fix
`COPY rel rel` before `mix release`. `rel/` contains only `env.sh.eex`.

## Deploy
After merge, cut a prod release (`release-v*` tag) built from this commit. Then verify on a node: `distributed=1` **and** `peers>=1` (the [#708] cluster metric), or `Node.list()` shows the peer.

Closes the root cause behind #710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)