### PR TITLE
build: fail the image build if the clustering gate is missing (#710)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,7 @@ RUN --mount=type=cache,target=/app/deps,id=mix-deps,sharing=locked \
     mix deps.get --only $MIX_ENV && \
     mix compile --force && \
     mix release && \
+    sh -c 'grep -q ECS_ENABLE_CLUSTER /app/_build/prod/rel/engram/releases/*/env.sh || { echo "FATAL: clustering gate (ECS_ENABLE_CLUSTER) missing from release env.sh — was rel/ copied before mix release? See engram-app/Engram#710" >&2; exit 1; }' && \
     cp -r /app/_build/prod/rel/engram /app/_release
 
 # ─── Runner ───────────────────────────────────────────────────────────────

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.518",
+      version: "0.5.519",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Why
The #710 root cause was that `mix release` **silently** emitted a default `env.sh` (no `ECS_ENABLE_CLUSTER` gate) when `rel/` wasn't in the Docker build context. That shipped a broken, unclustered image for **a month** with no signal. #717 fixed the `COPY rel`; this makes the failure mode **impossible to ship silently again**.

## What
A guard right after `mix release` in the Dockerfile:
```sh
grep -q ECS_ENABLE_CLUSTER /app/_build/prod/rel/engram/releases/*/env.sh \
  || { echo 'FATAL: clustering gate missing ...'; exit 1; }
```
If the gate isn't compiled into the release env.sh, the **image build fails** (exit 1, loud message) — in CI and local builds alike, before anything ships.

## Validated
- Gate present → exit 0 (passes)
- Gate absent (simulating the #710 bug) → `FATAL` + exit 1 (build fails)

Note: a `#` comment can't live inside the `RUN`'s `\`-continued chain (it'd comment out the joined line), so the guard self-documents via the FATAL message + this PR.

Cheap insurance. Refs #710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)