### PR TITLE
fix(ci): phase-label-required false-positives on non-migration PRs (#718)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1676,9 +1676,20 @@ jobs:
       - name: Detect migration touches
         id: detect
         run: |
-          git fetch -q --depth=1 origin main || true
+          # Fetch main FULLY (checkout is fetch-depth:0). The previous
+          # `--depth=1` left main shallow, so `origin/main...HEAD` couldn't
+          # resolve a merge-base and `git diff` fell back to the empty tree —
+          # making EVERY file (incl. all existing migrations) look added, so
+          # the label was demanded on non-migration PRs. Compute the base
+          # explicitly and fail loud if it can't, rather than guessing. (#718)
+          git fetch -q origin main
+          base=$(git merge-base FETCH_HEAD HEAD)
+          if [ -z "$base" ]; then
+            echo "::error::Could not compute merge-base with origin/main — cannot determine migration touches."
+            exit 1
+          fi
           changed=$(git diff --name-only --diff-filter=ACMR \
-            origin/main...HEAD -- 'priv/repo/migrations/*.exs' || true)
+            "$base" HEAD -- 'priv/repo/migrations/*.exs')
           if [ -z "$changed" ]; then
             echo "touches=false" >> "$GITHUB_OUTPUT"
             echo "No migration changes on this branch — phase label not required."

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.519",
+      version: "0.5.520",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Bug
`phase-label-required` intermittently demanded a `phase/*` label on PRs with **no** migration (hit #717 during the clustering work; a bare re-run cleared it).

## Root cause
```sh
git fetch -q --depth=1 origin main || true
git diff ... origin/main...HEAD -- 'priv/repo/migrations/*.exs'
```
The `--depth=1` fetch leaves main shallow, so the three-dot `origin/main...HEAD` can't resolve a merge-base and `git diff` falls back to the **empty tree** → every file (incl. all existing migrations) reads as added → `touches=true` → label demanded. Intermittent, depending on what's reachable in the local object store.

## Fix
- Full `git fetch origin main` (checkout is already `fetch-depth: 0`)
- `base=$(git merge-base FETCH_HEAD HEAD)`, **fail loudly** if empty (don't silently treat all files as changed)
- diff `$base HEAD` (explicit base) instead of the merge-base-dependent three-dot

## Self-test
This PR has no migration, so its own `phase-label-required` run (using the branch's fixed workflow) should pass without a label — a live confirmation of the fix.

Closes #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)