### PR TITLE
fix(mcp): advertise bare host as canonical RFC 9728 resource on saas mcp_host

### DIFF
--- a/lib/engram_web/controllers/well_known_controller.ex
+++ b/lib/engram_web/controllers/well_known_controller.ex
@@ -19,11 +19,36 @@ defmodule EngramWeb.WellKnownController do
     base = base_url(conn)
 
     json(conn, %{
-      resource: base <> "/api/mcp",
+      # The advertised `resource` must be the URL at which THIS host actually
+      # serves MCP — RFC 9728 lets us advertise only one, and strict clients
+      # bind the token audience to it (and self-check it == the dialed URL).
+      #
+      #   * saas dedicated MCP host (`mcp.engram.page`): HostRewrite maps the
+      #     bare root `/` → `/api/mcp`, so the canonical resource is the BARE
+      #     host. Users paste `https://mcp.engram.page` (no path); advertising
+      #     the path here made strict clients (Claude Code CLI) abort on the
+      #     mismatch. See Engram#634.
+      #   * everything else (selfhost `engram.ax`, `app`/`api` hosts): no MCP
+      #     rewrite — bare `/` is the SPA and MCP lives only at `/api/mcp`, so
+      #     the resource MUST keep the path or self-host clients would mismatch.
+      #
+      # Token `aud` is the fixed string "engram" (see Engram.Token), independent
+      # of this URL, so either form breaks no server-side audience check.
+      resource: if(mcp_rewrite_host?(conn), do: base, else: base <> "/api/mcp"),
       authorization_servers: [base],
       bearer_methods_supported: ["header"],
       resource_documentation: base <> "/docs"
     })
+  end
+
+  # True only when the dialed host is the saas dedicated MCP host that
+  # HostRewrite serves at the bare root (`:host_rewrite` config sets `mcp_host`).
+  # Selfhost leaves `:host_rewrite` unset → always false → path form.
+  defp mcp_rewrite_host?(conn) do
+    case Application.get_env(:engram, :host_rewrite, []) do
+      opts when is_list(opts) -> opts[:mcp_host] != nil and conn.host == opts[:mcp_host]
+      _ -> false
+    end
   end
 
   def authorization_server(conn, _params) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.520",
+      version: "0.5.521",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/well_known_controller_test.exs
+++ b/test/engram_web/controllers/well_known_controller_test.exs
@@ -7,6 +7,9 @@ defmodule EngramWeb.WellKnownControllerTest do
       body = json_response(conn, 200)
 
       assert is_binary(body["resource"])
+      # No host_rewrite config in plain test conn (selfhost shape) → MCP is only
+      # at the /api/mcp path, so that's the advertised resource. The bare-host
+      # form is mcp_host-only; see WellKnownHostTest.
       assert String.ends_with?(body["resource"], "/api/mcp")
       assert is_list(body["authorization_servers"])
       assert body["authorization_servers"] != []

--- a/test/engram_web/controllers/well_known_host_test.exs
+++ b/test/engram_web/controllers/well_known_host_test.exs
@@ -4,11 +4,16 @@ defmodule EngramWeb.WellKnownHostTest do
 
   setup do
     prev = Application.get_env(:engram, :cors_origin)
+    prev_rewrite = Application.get_env(:engram, :host_rewrite)
 
     on_exit(fn ->
       if prev,
         do: Application.put_env(:engram, :cors_origin, prev),
         else: Application.delete_env(:engram, :cors_origin)
+
+      if prev_rewrite,
+        do: Application.put_env(:engram, :host_rewrite, prev_rewrite),
+        else: Application.delete_env(:engram, :host_rewrite)
     end)
 
     :ok
@@ -26,6 +31,7 @@ defmodule EngramWeb.WellKnownHostTest do
         |> get("/.well-known/oauth-protected-resource")
         |> json_response(200)
 
+      # app.engram.page is allowlisted but NOT the mcp_host → path form.
       assert body["resource"] == "http://app.engram.page/api/mcp"
       assert body["authorization_servers"] == ["http://app.engram.page"]
     end
@@ -52,6 +58,25 @@ defmodule EngramWeb.WellKnownHostTest do
 
       refute body["resource"] =~ "evil.example.com"
       assert String.ends_with?(body["resource"], "/api/mcp")
+    end
+
+    test "advertises the BARE host as the resource on the saas mcp_host (Engram#634)", %{
+      conn: conn
+    } do
+      # On the dedicated saas MCP host, HostRewrite serves MCP at the bare root,
+      # so the canonical resource is the bare host (no /api/mcp path). Strict
+      # clients (Claude Code CLI) paste the bare host and self-check it.
+      Application.put_env(:engram, :cors_origin, ["http://mcp.engram.page"])
+      Application.put_env(:engram, :host_rewrite, mcp_host: "mcp.engram.page")
+
+      body =
+        %{conn | host: "mcp.engram.page"}
+        |> get("/.well-known/oauth-protected-resource")
+        |> json_response(200)
+
+      assert body["resource"] == "http://mcp.engram.page"
+      refute String.ends_with?(body["resource"], "/api/mcp")
+      assert body["authorization_servers"] == ["http://mcp.engram.page"]
     end
   end
 end


### PR DESCRIPTION
## Problem
`GET /.well-known/oauth-protected-resource` advertised `resource = <host>/api/mcp` for **every** host. On the dedicated saas MCP host `mcp.engram.page`, `HostRewrite` serves MCP at the **bare root** (`/` → `/api/mcp`), and users paste the bare host. Strict RFC 9728 clients (the **Claude Code CLI** MCP SDK) enforce `resource == configured server URL`, so a bare-host config aborted on the path mismatch. Lenient clients (Claude desktop Connectors) ignore the field, which is why "other apps connect but the CLI doesn't."

## Fix
Advertise the **bare host** as the canonical `resource` **only** when the dialed host is the configured `:host_rewrite` `mcp_host`. Every other host keeps the `/api/mcp` path form:

- **saas `mcp.engram.page`** → `resource = https://mcp.engram.page` (bare) ✅ CLI connects
- **selfhost `engram.ax`** → `:host_rewrite` unset, MCP only at `/api/mcp` → `resource = …/api/mcp` (unchanged, **no regression**)
- **`app` / `api` hosts** → path form (MCP not served at their bare root)

## Safety
- Server still answers at **both** bare + `/api/mcp` on saas (`HostRewrite` routes both) — back-compat preserved.
- Token `aud` is the fixed string `"engram"` (`Engram.Token`), independent of the resource URL → **no server-side audience check changes**.
- RFC 8707 `resource` request param is forward-only (consent route); nothing validates it against a fixed value.

## Tests
- TDD red→green. `well_known_controller_test` (selfhost shape → path), `well_known_host_test` (app host → path; **new** mcp_host test → bare; evil host → canonical path).
- `well_known` + `oauth_authorize` + `mcp_transport` suites green; `mix format` + credo + sobelow clean.

## Tradeoff (the #634 decision)
RFC 9728 allows only one canonical `resource`. Strict clients still pinned to the saas `…/api/mcp` path will now mismatch and should use the bare host. Pre-launch; marketing integration guides still say `/api/mcp` and need the same bare alignment (follow-up).

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Self-host: not hardcoded, configured via `PHX_HOST`
Every URL in both `.well-known` docs is derived from `base_url(conn)` → `EngramWeb.Endpoint.url()` / dialed host, both sourced from **`PHX_HOST`** (`runtime.exs:508,519,663`). No `engram.page` is pinned. A self-hoster sets `PHX_HOST=notes.acme.com` and `.well-known` advertises `https://notes.acme.com/api/mcp` automatically — zero code changes. The `mcp.engram.page` literal exists only as a default for `ENGRAM_HOST_REWRITE_MCP_HOST`, gated behind `ENGRAM_HOST_REWRITE_ENABLED=true` (saas-only; `runtime.exs:672,684`). Because the bare-vs-path choice keys off `:host_rewrite`'s `mcp_host` (not a literal), a self-hoster who wants a bare MCP subdomain can opt in via the same env vars.
