### PR TITLE
feat(web): redirect signed-out users from unknown paths to sign-in

### DIFF
--- a/frontend/src/auth/auth-guard.tsx
+++ b/frontend/src/auth/auth-guard.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Outlet, useLocation } from 'react-router'
-import { ROUTES } from '../routes'
 import LoadingScreen from '../layout/loading-screen'
+import { signInRedirectTarget } from './sign-in-redirect'
 import { useAuthAdapter } from './use-auth-adapter'
 
 export default function AuthGuard() {
@@ -12,12 +12,7 @@ export default function AuthGuard() {
   }
 
   if (!isSignedIn) {
-    const returnTo = location.pathname + location.search + location.hash
-    const target =
-      returnTo && returnTo !== ROUTES.HOME
-        ? `${ROUTES.SIGN_IN}?return_to=${encodeURIComponent(returnTo)}`
-        : ROUTES.SIGN_IN
-    return <Navigate to={target} replace />
+    return <Navigate to={signInRedirectTarget(location)} replace />
   }
 
   return <Outlet />

--- a/frontend/src/auth/catch-all-route.test.tsx
+++ b/frontend/src/auth/catch-all-route.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import CatchAllRoute from './catch-all-route'
+
+// Mutable auth state so each test can pick signed-in / signed-out / loading.
+const authState = { current: { isLoaded: true, isSignedIn: false } }
+vi.mock('./use-auth-adapter', () => ({
+  useAuthAdapter: () => authState.current,
+}))
+
+vi.mock('../theme/theme-toggle', () => ({
+  default: () => <button type="button">theme</button>,
+}))
+
+function SignInStub() {
+  const { search } = useLocation()
+  return <p>sign-in {search}</p>
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/sign-in" element={<SignInStub />} />
+        <Route path="*" element={<CatchAllRoute />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('CatchAllRoute', () => {
+  it('redirects a signed-out user to sign-in with the attempted path as return_to', () => {
+    authState.current = { isLoaded: true, isSignedIn: false }
+    renderAt('/some/typo')
+    expect(screen.getByText(/sign-in/)).toHaveTextContent('return_to=%2Fsome%2Ftypo')
+    expect(screen.queryByText('404')).not.toBeInTheDocument()
+  })
+
+  it('shows the 404 page to a signed-in user', () => {
+    authState.current = { isLoaded: true, isSignedIn: true }
+    renderAt('/some/typo')
+    expect(screen.getByText('404')).toBeInTheDocument()
+    expect(screen.queryByText(/sign-in/)).not.toBeInTheDocument()
+  })
+
+  it('does not redirect or 404 while auth state is still loading', () => {
+    authState.current = { isLoaded: false, isSignedIn: false }
+    renderAt('/some/typo')
+    expect(screen.queryByText('404')).not.toBeInTheDocument()
+    expect(screen.queryByText(/sign-in/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/auth/catch-all-route.test.tsx
+++ b/frontend/src/auth/catch-all-route.test.tsx
@@ -44,9 +44,10 @@ describe('CatchAllRoute', () => {
     expect(screen.queryByText(/sign-in/)).not.toBeInTheDocument()
   })
 
-  it('does not redirect or 404 while auth state is still loading', () => {
+  it('shows the loading screen (not a 404 flash or premature redirect) while auth state resolves', () => {
     authState.current = { isLoaded: false, isSignedIn: false }
     renderAt('/some/typo')
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
     expect(screen.queryByText('404')).not.toBeInTheDocument()
     expect(screen.queryByText(/sign-in/)).not.toBeInTheDocument()
   })

--- a/frontend/src/auth/catch-all-route.tsx
+++ b/frontend/src/auth/catch-all-route.tsx
@@ -1,0 +1,27 @@
+import { Navigate, useLocation } from 'react-router'
+import LoadingScreen from '../layout/loading-screen'
+import NotFoundPage from '../not-found'
+import { signInRedirectTarget } from './sign-in-redirect'
+import { useAuthAdapter } from './use-auth-adapter'
+
+// Auth-aware catch-all for unmatched paths.
+//
+// A signed-out visitor hitting any unknown URL is bounced to sign-in
+// (with the attempted path as return_to) rather than shown a dead-end 404 —
+// there is nothing for them to do on a 404 until they authenticate anyway.
+// Signed-in users still get the real 404; a typo for them is just a typo,
+// not a reason to round-trip through auth.
+export default function CatchAllRoute() {
+  const { isLoaded, isSignedIn } = useAuthAdapter()
+  const location = useLocation()
+
+  if (!isLoaded) {
+    return <LoadingScreen />
+  }
+
+  if (!isSignedIn) {
+    return <Navigate to={signInRedirectTarget(location)} replace />
+  }
+
+  return <NotFoundPage />
+}

--- a/frontend/src/auth/sign-in-redirect.test.ts
+++ b/frontend/src/auth/sign-in-redirect.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { signInRedirectTarget } from './sign-in-redirect'
+
+describe('signInRedirectTarget', () => {
+  it('redirects to bare sign-in from the home path (no return_to round-trip)', () => {
+    expect(signInRedirectTarget({ pathname: '/', search: '', hash: '' })).toBe('/sign-in')
+  })
+
+  it('preserves the original path as an encoded return_to', () => {
+    expect(signInRedirectTarget({ pathname: '/note/abc', search: '', hash: '' })).toBe(
+      '/sign-in?return_to=%2Fnote%2Fabc',
+    )
+  })
+
+  it('includes search and hash in the return_to', () => {
+    expect(
+      signInRedirectTarget({ pathname: '/settings', search: '?tab=billing', hash: '#plan' }),
+    ).toBe('/sign-in?return_to=%2Fsettings%3Ftab%3Dbilling%23plan')
+  })
+})

--- a/frontend/src/auth/sign-in-redirect.ts
+++ b/frontend/src/auth/sign-in-redirect.ts
@@ -1,0 +1,18 @@
+import { ROUTES } from '../routes'
+
+// Build the sign-in URL for a signed-out user, preserving where they were
+// headed as an encoded `return_to` so the post-login redirect lands them
+// back. Home gets no round-trip — that's already the default landing.
+//
+// Shared by AuthGuard (protected routes) and CatchAllRoute (unknown paths)
+// so the two redirect surfaces can't drift apart.
+export function signInRedirectTarget(location: {
+  pathname: string
+  search: string
+  hash: string
+}): string {
+  const returnTo = location.pathname + location.search + location.hash
+  return returnTo && returnTo !== ROUTES.HOME
+    ? `${ROUTES.SIGN_IN}?return_to=${encodeURIComponent(returnTo)}`
+    : ROUTES.SIGN_IN
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, type ReactNode } from 'react'
 import { Navigate, createBrowserRouter } from 'react-router'
 import AuthGuard from './auth/auth-guard'
+import CatchAllRoute from './auth/catch-all-route'
 import SignInPage from './auth/sign-in'
 import SignUpPage from './auth/sign-up'
 import WaitlistPage from './auth/waitlist'
@@ -8,7 +9,6 @@ import { UpgradeDialogProvider } from './billing/upgrade-dialog-provider'
 import type { EngramConfig } from './config'
 import AppLayout from './layout/app-layout'
 import LoadingPane from './viewer/loading-pane'
-import NotFoundPage from './not-found'
 import SettingsLayout from './settings/settings-layout'
 import { ROUTES } from './routes'
 import OnboardingGate from './onboarding/onboarding-gate'
@@ -182,8 +182,11 @@ export function createAppRouter(config: EngramConfig): AppRouter {
       ],
     },
 
-    // Catch-all (public — typos shouldn't trigger Clerk redirect)
-    { path: '*', element: <NotFoundPage /> },
+    // Catch-all — auth-aware: signed-out visitors are bounced to sign-in
+    // (with return_to), signed-in users see the real 404. A typo for a
+    // logged-in user is just a typo; for a logged-out one there's nothing
+    // to do on a 404 but authenticate.
+    { path: '*', element: <CatchAllRoute /> },
       ],
     },
   ],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.521",
+      version: "0.5.522",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

The SPA catch-all route showed a dead-end 404 to **everyone** — including logged-out visitors, who have nothing to do on a 404 but authenticate. This makes the catch-all auth-aware:

- **Signed-out** → redirect to `/sign-in?return_to=<attempted path>` (client-side `<Navigate replace>`; an SPA can't emit a true HTTP 301)
- **Signed-in** → the real 404 page (a typo is just a typo)
- **Loading** → spinner, no premature bounce

Public routes (`/sign-in`, `/sign-up`, `/waitlist`, `/reset-password`) are untouched.

## Why

The `*` fallback was the only route sitting *outside* `AuthGuard`, so unknown paths leaked a 404 to unauthenticated users instead of funneling them into the login/signup flow.

## How

- `auth/sign-in-redirect.ts` — extracted shared `signInRedirectTarget()` building the `return_to` URL, so `AuthGuard` and the new catch-all share one format and can't drift
- `auth/catch-all-route.tsx` — auth-aware catch-all
- `router.tsx` — `*` now renders `CatchAllRoute`
- `auth/auth-guard.tsx` — deduped onto the shared helper

## Verification

- New tests: `sign-in-redirect.test.ts` + `catch-all-route.test.tsx` (signed-out redirect w/ return_to, signed-in 404, loading) — written test-first
- Full frontend suite: 638/638 pass
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)