### PR TITLE
fix(billing): paginate Paddle list on has_more, not next presence

### DIFF
--- a/docs/context/paddle-list-pagination-has-more.md
+++ b/docs/context/paddle-list-pagination-has-more.md
@@ -1,0 +1,39 @@
+# Paddle list pagination: stop on `has_more`, never `next`
+
+How to paginate Paddle list endpoints without an infinite loop. Owner: billing. Status: fixed in PR #723.
+
+## The gotcha
+
+Paddle list endpoints (`/subscriptions`, `/transactions`, etc.) return a pagination block:
+
+```json
+"meta": { "pagination": { "per_page": 200, "next": "https://api.paddle.com/subscriptions?after=sub_xyz...", "has_more": false, "estimated_total": 45 } }
+```
+
+`meta.pagination.next` is **always present, even on the last page** — it is a resume *bookmark* (`after=<last_id>`), NOT a "there's more data" flag. The authoritative terminator is the boolean `meta.pagination.has_more`.
+
+Paddle's docs say this outright (https://developer.paddle.com/api-reference/about/pagination):
+- `next` — "Always returned, even if `has_more` is `false`."
+- "Check `has_more` rather than inferring whether there are more pages from the presence of `next`."
+
+**Rule: drive pagination off `has_more`. Never treat the presence/absence of `next` as the terminator.**
+
+## How it bit us
+
+`lib/engram/paddle/client/http.ex` `list_pages/6` (the `list_subscriptions/1` walker, used by the daily `PaddleReconcile` Oban worker) originally stopped only when `next == nil`/`""`. In prod that never happens, so it kept paging past the final page. Following `next` from the last page (`after=<last_id>`) returns a `next` URL that's already been fetched → the `seen`-MapSet infinite-loop guard tripped → `{:partial, ..., :pagination_loop}`.
+
+Symptom: the daily page-severity alert `engram-prod-loki-billing-error` with `reason_label=pagination_loop`, firing ~02:00 UTC (the reconcile worker's schedule).
+
+- Introduced #379 (2026-06-04).
+- Only became *visible* after billing logs reached Loki via #707 (2026-06-23) — the loop had been silently degrading reconcile reads before then.
+- Fixed in PR #723: stop when `has_more != true`; the `next` nil/"" check and the `seen` loop-guard + `@max_pages` cap are kept as defense-in-depth (they should now be unreachable in normal operation).
+
+## The test trap
+
+The original fixtures mocked `next: nil` to terminate the walk — a response **real Paddle never sends**. The bug shipped green because the test world didn't match prod.
+
+**Any Paddle list mock MUST include `has_more`** (and should keep a non-nil `next` on the final page, matching real Paddle, so a test can't accidentally rely on `next` to stop).
+
+## See also
+
+- `docs/context/paddle-integration.md` — full Paddle wiring, the `PaddleReconcile` worker, and the drift-response runbook.

--- a/lib/engram/paddle/client/http.ex
+++ b/lib/engram/paddle/client/http.ex
@@ -150,14 +150,23 @@ defmodule Engram.Paddle.Client.HTTP do
   defp list_pages(url, params, headers, acc, seen, page) do
     case Req.get(url, params: params, headers: headers, receive_timeout: 15_000) do
       {:ok, %Req.Response{status: 200, body: %{"data" => data} = body}} when is_list(data) ->
-        case get_in(body, ["meta", "pagination", "next"]) do
-          nil ->
+        # `has_more` is Paddle's authoritative terminator: per the docs, the
+        # `next` URL is ALWAYS returned (even on the last page), so stopping
+        # on `next == nil` never triggers in production and walks the worker
+        # past the final page until the loop/cap guard trips. Stop here unless
+        # Paddle says there's another page. `next` nil/"" is kept as a belt-
+        # and-suspenders terminator for older/edge responses.
+        next_url = get_in(body, ["meta", "pagination", "next"])
+        has_more = get_in(body, ["meta", "pagination", "has_more"])
+
+        cond do
+          has_more != true ->
             {:ok, Enum.reverse([data | acc]) |> List.flatten()}
 
-          "" ->
+          not is_binary(next_url) or next_url == "" ->
             {:ok, Enum.reverse([data | acc]) |> List.flatten()}
 
-          next_url when is_binary(next_url) ->
+          true ->
             if MapSet.member?(seen, next_url) do
               # Paddle returned a `next` URL we've already fetched — would
               # be an infinite loop. Stop and surface what we have, tagged

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.522",
+      version: "0.5.523",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/paddle/client/http_test.exs
+++ b/test/engram/paddle/client/http_test.exs
@@ -36,6 +36,73 @@ defmodule Engram.Paddle.Client.HTTPTest do
       assert {:ok, [%{"id" => "sub_1"}]} = HTTP.list_subscriptions(@since)
     end
 
+    test "stops on has_more=false even when next URL is present", %{bypass: bypass} do
+      # Real Paddle ALWAYS returns a `next` URL, even on the last page —
+      # `has_more` is the authoritative terminator (per Paddle docs). The
+      # client must stop on has_more=false and NOT follow `next`, otherwise
+      # it walks past the last page until the loop/cap guard trips.
+      next_url = "http://localhost:#{bypass.port}/subscriptions?after=sub_1"
+      counter = :counters.new(1, [])
+
+      Bypass.expect(bypass, "GET", "/subscriptions", fn conn ->
+        :counters.add(counter, 1, 1)
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{
+            "data" => [%{"id" => "sub_1"}],
+            "meta" => %{"pagination" => %{"next" => next_url, "has_more" => false}}
+          })
+        )
+      end)
+
+      assert {:ok, [%{"id" => "sub_1"}]} = HTTP.list_subscriptions(@since)
+      # Exactly one request — the next URL must not be followed.
+      assert :counters.get(counter, 1) == 1
+    end
+
+    test "follows next when has_more=true, stops on the has_more=false page",
+         %{bypass: bypass} do
+      # Multi-page walk driven by has_more, with `next` populated on every
+      # page (including the last) the way real Paddle behaves.
+      base = "http://localhost:#{bypass.port}"
+
+      Bypass.expect(bypass, "GET", "/subscriptions", fn conn ->
+        body =
+          case conn.query_string do
+            "after=sub_1" ->
+              %{
+                "data" => [%{"id" => "sub_2"}],
+                "meta" => %{
+                  "pagination" => %{
+                    "next" => "#{base}/subscriptions?after=sub_2",
+                    "has_more" => false
+                  }
+                }
+              }
+
+            _ ->
+              %{
+                "data" => [%{"id" => "sub_1"}],
+                "meta" => %{
+                  "pagination" => %{
+                    "next" => "#{base}/subscriptions?after=sub_1",
+                    "has_more" => true
+                  }
+                }
+              }
+          end
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end)
+
+      assert {:ok, [%{"id" => "sub_1"}, %{"id" => "sub_2"}]} = HTTP.list_subscriptions(@since)
+    end
+
     test "follows meta.pagination.next URL with empty params on follow-up", %{bypass: bypass} do
       next_url = "http://localhost:#{bypass.port}/subscriptions?after=sub_1"
 
@@ -48,7 +115,7 @@ defmodule Engram.Paddle.Client.HTTPTest do
             _ ->
               %{
                 "data" => [%{"id" => "sub_1"}],
-                "meta" => %{"pagination" => %{"next" => next_url}}
+                "meta" => %{"pagination" => %{"next" => next_url, "has_more" => true}}
               }
           end
 
@@ -86,7 +153,7 @@ defmodule Engram.Paddle.Client.HTTPTest do
       Bypass.expect(bypass, "GET", "/subscriptions", fn conn ->
         body = %{
           "data" => [%{"id" => "sub_loop_" <> (conn.query_string || "first")}],
-          "meta" => %{"pagination" => %{"next" => loop_url}}
+          "meta" => %{"pagination" => %{"next" => loop_url, "has_more" => true}}
         }
 
         conn
@@ -113,7 +180,9 @@ defmodule Engram.Paddle.Client.HTTPTest do
 
         body = %{
           "data" => [%{"id" => "sub_p#{n}"}],
-          "meta" => %{"pagination" => %{"next" => "#{base}/subscriptions?cursor=p#{n}"}}
+          "meta" => %{
+            "pagination" => %{"next" => "#{base}/subscriptions?cursor=p#{n}", "has_more" => true}
+          }
         }
 
         conn


### PR DESCRIPTION
## What

The Paddle subscriptions-list pager terminated on `meta.pagination.next == nil`. Per Paddle docs, **`next` is always returned, even on the last page** — `has_more` is the authoritative terminator. So the stop branch is dead code in prod: the worker walked past the final page, the `after=<last_id>` cursor returned an already-seen `next` URL, and the infinite-loop guard tripped.

## Symptom

Daily page-severity alert `engram-prod-loki-billing-error` firing ~02:00 UTC, `reason_label=pagination_loop`, from:
- `lib/engram/paddle/client/http.ex` — "Paddle subscriptions-list pagination loop detected"
- `lib/engram/billing/reconciliation.ex` — `paddle_reconcile_partial_list`

Bug dates to #379 (2026-06-04); only became visible when `category=billing` logs started shipping to Loki via #707 (2026-06-23), exposing it on the first daily reconcile after.

## Impact

Low data-risk today — single page (<200 subs) already holds every subscription, so drift detection still saw everyone. But: (a) daily false page alert, (b) **every reconcile run falsely tagged `:partial`**, masking the real truncation signal that flag exists to raise, (c) at >200 subs it would trip on the genuine final page every run.

## Fix

`list_pages/6` now stops when `has_more != true`. The `seen`-URL loop guard and `@max_pages` cap are retained as defense-in-depth for genuine Paddle misbehavior (`has_more: true` that never ends). `next` nil/"" kept as a belt-and-suspenders terminator.

## Tests

The old fixtures mocked `next: nil` to terminate — a response real Paddle never sends — which is why the bug shipped green; `has_more` appeared in zero Paddle tests. Fixtures now carry `has_more`, plus two new tests:
- `stops on has_more=false even when next URL is present` (asserts exactly one request — no follow)
- `follows next when has_more=true, stops on the has_more=false page`

Verified locally: http_test 11/11, reconciliation + worker suites 20/20, `mix format`/credo/sobelow clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)