### PR TITLE
fix(mcp): vault dogfooding bugs — set_vault UUID, get_note dedup, block-list tags

### DIFF
--- a/lib/engram/mcp/handlers.ex
+++ b/lib/engram/mcp/handlers.ex
@@ -203,17 +203,7 @@ defmodule Engram.MCP.Handlers do
 
     case Notes.get_note(user, vault, source_path) do
       {:ok, note} ->
-        lines = ["# #{note.title}"]
-
-        lines =
-          if note.tags && note.tags != [],
-            do: lines ++ ["**Tags:** #{Enum.join(note.tags, ", ")}"],
-            else: lines
-
-        lines = lines ++ ["**Path:** #{note.path}"]
-        lines = lines ++ ["**Folder:** #{note.folder || ""}\n"]
-        lines = lines ++ [note.content]
-        {:ok, Enum.join(lines, "\n")}
+        {:ok, format_get_note(note)}
 
       {:error, :not_found} ->
         {:ok, "Note not found: #{source_path}"}
@@ -534,4 +524,55 @@ defmodule Engram.MCP.Handlers do
   end
 
   defp now, do: :os.system_time(:second) |> Kernel./(1) |> Float.round(1)
+
+  @doc """
+  Render a note for the `get_note` MCP response.
+
+  The note body is returned verbatim (read-modify-write callers depend on it).
+  Title/Tags are only injected as a convenience header when the body does not
+  already carry them — a note's own frontmatter or leading `# H1` is the
+  canonical source, so we don't repeat it (#731). Path/Folder are filesystem
+  metadata that never live in the body, so they are always included.
+  """
+  def format_get_note(note) do
+    content = note.content || ""
+    fm = frontmatter_block(content)
+
+    # Suppress an injected field only when the body actually carries it: a
+    # frontmatter `title:`/`tags:` key, or (for the title) a body `# H1`.
+    body_has_title = fm_has_key?(fm, "title") or body_has_h1?(content)
+    inject_tags? = note.tags && note.tags != [] && not fm_has_key?(fm, "tags")
+
+    title_lines = if body_has_title, do: [], else: ["# #{note.title}"]
+    tag_lines = if inject_tags?, do: ["**Tags:** #{Enum.join(note.tags, ", ")}"], else: []
+
+    (title_lines ++
+       tag_lines ++
+       ["**Path:** #{note.path}", "**Folder:** #{note.folder || ""}", "", content])
+    |> Enum.join("\n")
+  end
+
+  # The YAML frontmatter block (content between the leading `---` fences), or nil.
+  # Tolerates a leading BOM and CRLF line endings.
+  defp frontmatter_block(content) do
+    case Regex.run(~r/\A\x{FEFF}?---\r?\n(.*?)\r?\n---/su, content, capture: :all_but_first) do
+      [fm] -> fm
+      _ -> nil
+    end
+  end
+
+  defp fm_has_key?(nil, _key), do: false
+  defp fm_has_key?(fm, key), do: Regex.match?(~r/^\s*#{key}\s*:/mi, fm)
+
+  # A level-1 ATX heading at the top of the body (after any frontmatter). `##`+
+  # are subheadings, not the title.
+  defp body_has_h1?(content) do
+    content
+    |> strip_frontmatter()
+    |> String.trim_leading()
+    |> then(&Regex.match?(~r/\A#(?!#)\s+/, &1))
+  end
+
+  defp strip_frontmatter(content),
+    do: Regex.replace(~r/\A\x{FEFF}?---\r?\n.*?\r?\n---/su, content, "")
 end

--- a/lib/engram/mcp/tools.ex
+++ b/lib/engram/mcp/tools.ex
@@ -65,7 +65,11 @@ defmodule Engram.MCP.Tools do
       inputSchema: %{
         "type" => "object",
         "properties" => %{
-          "vault_id" => %{"type" => "integer", "description" => "Vault ID to set as active"}
+          "vault_id" => %{
+            "type" => "string",
+            "format" => "uuid",
+            "description" => "Vault ID (UUID) to set as active"
+          }
         }
       },
       handler: &Handlers.handle("set_vault", &1, &2, &3)

--- a/lib/engram/notes/helpers.ex
+++ b/lib/engram/notes/helpers.ex
@@ -4,7 +4,7 @@ defmodule Engram.Notes.Helpers do
   No DB access — safe to call anywhere.
   """
 
-  @frontmatter_re ~r/\A---\n(.*?)\n---/s
+  @frontmatter_re ~r/\A---\r?\n(.*?)\r?\n---/s
   @heading_re ~r/^#\s+(.+)$/m
 
   @doc """
@@ -124,9 +124,55 @@ defmodule Engram.Notes.Helpers do
   end
 
   defp parse_frontmatter_tags(fm) do
-    case Regex.run(~r/^tags:\s*(.+)$/m, fm, capture: :all_but_first) do
-      [raw] -> {:ok, parse_tag_value(String.trim(raw))}
-      _ -> :error
+    cond do
+      # Block-style list: `tags:` alone on its line, items as `  - item` below.
+      block = parse_block_list_tags(fm) ->
+        {:ok, block}
+
+      # Inline value on the same line: `tags: [a, b]` or `tags: a, b`.
+      # `[ \t]*` (no newline) + `\S` keeps the match on the `tags:` line so it
+      # never spills onto a following `- item` line.
+      match = Regex.run(~r/^tags:[ \t]*(\S.*)$/m, fm, capture: :all_but_first) ->
+        [raw] = match
+        {:ok, parse_tag_value(String.trim(raw))}
+
+      true ->
+        :error
+    end
+  end
+
+  # YAML block list under a bare `tags:` line. Returns nil when not block-style
+  # so the caller falls through to inline parsing.
+  defp parse_block_list_tags(fm) do
+    case Regex.run(~r/^tags:[ \t]*\r?\n(.*)/ms, fm, capture: :all_but_first) do
+      [rest] ->
+        items =
+          rest
+          |> String.split("\n")
+          |> Enum.take_while(&Regex.match?(~r/^\s*-\s+/, &1))
+          |> Enum.map(&(&1 |> String.replace(~r/^\s*-\s+/, "") |> unquote_tag()))
+          |> Enum.reject(&(&1 == ""))
+
+        if items == [], do: nil, else: items
+
+      _ ->
+        nil
+    end
+  end
+
+  # Strip surrounding matching quotes from a YAML scalar (and trim whitespace).
+  defp unquote_tag(raw) do
+    s = String.trim(raw)
+
+    cond do
+      String.length(s) >= 2 and String.starts_with?(s, "\"") and String.ends_with?(s, "\"") ->
+        String.slice(s, 1, String.length(s) - 2)
+
+      String.length(s) >= 2 and String.starts_with?(s, "'") and String.ends_with?(s, "'") ->
+        String.slice(s, 1, String.length(s) - 2)
+
+      true ->
+        s
     end
   end
 
@@ -137,7 +183,7 @@ defmodule Engram.Notes.Helpers do
     rest
     |> String.trim_trailing("]")
     |> String.split(",")
-    |> Enum.map(&String.trim/1)
+    |> Enum.map(&unquote_tag/1)
     |> Enum.reject(&(&1 == ""))
   end
 
@@ -145,7 +191,7 @@ defmodule Engram.Notes.Helpers do
     # Comma-separated string: tag1, tag2
     raw
     |> String.split(",")
-    |> Enum.map(&String.trim/1)
+    |> Enum.map(&unquote_tag/1)
     |> Enum.reject(&(&1 == ""))
   end
 end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -358,6 +358,15 @@ defmodule Engram.Vaults do
   or {:error, :not_found}.
   """
   def get_vault(user, vault_id) do
+    # A lookup must never raise on bad input: a malformed UUID would otherwise
+    # trigger an Ecto cast error at query time (callers pass raw client values).
+    case Ecto.UUID.cast(vault_id) do
+      {:ok, vault_id} -> fetch_vault(user, vault_id)
+      :error -> {:error, :not_found}
+    end
+  end
+
+  defp fetch_vault(user, vault_id) do
     user = fresh_user(user)
 
     result =

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.524",
+      version: "0.5.525",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/mcp/handlers_get_note_test.exs
+++ b/test/engram/mcp/handlers_get_note_test.exs
@@ -1,0 +1,69 @@
+defmodule Engram.MCP.HandlersGetNoteTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.MCP.Handlers
+
+  defp note(attrs) do
+    Enum.into(attrs, %{title: "Untitled", tags: [], path: "n.md", folder: "", content: ""})
+  end
+
+  describe "format_get_note/1 — metadata de-duplication (#731)" do
+    test "a note with frontmatter does not re-inject Title or Tags" do
+      content = "---\ntitle: My Note\ntags:\n  - project\n---\n# My Note\n\nBody text."
+      out = Handlers.format_get_note(note(title: "My Note", tags: ["project"], content: content))
+
+      assert String.starts_with?(out, "**Path:** n.md"),
+             "no injected title/tags before Path block"
+
+      refute String.contains?(out, "**Tags:**"), "Tags should come from frontmatter, not injected"
+      assert String.contains?(out, content), "note body must be returned verbatim"
+    end
+
+    test "a note opening with an H2 still gets an injected title (## is not an H1)" do
+      content = "## Subheading\n\nBody."
+      out = Handlers.format_get_note(note(title: "Real Title", tags: [], content: content))
+
+      assert String.starts_with?(out, "# Real Title")
+    end
+
+    test "frontmatter without a tags: key still injects inline-derived tags" do
+      content = "---\ntitle: T\n---\nBody with #inline"
+      out = Handlers.format_get_note(note(title: "T", tags: ["inline"], content: content))
+
+      assert String.contains?(out, "**Tags:** inline")
+    end
+
+    test "frontmatter without a title: key still injects the title" do
+      content = "---\ntags:\n  - x\n---\nBody."
+      out = Handlers.format_get_note(note(title: "Derived", tags: ["x"], content: content))
+
+      assert String.starts_with?(out, "# Derived")
+      refute String.contains?(out, "**Tags:**"), "tags live in frontmatter, not injected"
+    end
+
+    test "nil tags and nil folder render without crashing" do
+      out = Handlers.format_get_note(note(title: "N", tags: nil, folder: nil, content: "plain"))
+
+      assert String.contains?(out, "# N")
+      assert String.contains?(out, "**Folder:** \n")
+      refute String.contains?(out, "**Tags:**")
+    end
+
+    test "a frontmatter-less note keeps the injected Title and Tags" do
+      content = "Just a plain body, no frontmatter."
+      out = Handlers.format_get_note(note(title: "Plain", tags: ["x"], content: content))
+
+      assert String.contains?(out, "# Plain")
+      assert String.contains?(out, "**Tags:** x")
+      assert String.contains?(out, content)
+    end
+
+    test "a frontmatter-less note that opens with an H1 does not get a duplicate injected title" do
+      content = "# Heading\n\nBody."
+      out = Handlers.format_get_note(note(title: "Heading", tags: [], content: content))
+
+      # Only the body's own H1 should remain — no injected `# Heading` on top of it.
+      assert Enum.count(String.split(out, "\n"), &(&1 == "# Heading")) == 1
+    end
+  end
+end

--- a/test/engram/mcp/tools_set_vault_schema_test.exs
+++ b/test/engram/mcp/tools_set_vault_schema_test.exs
@@ -1,0 +1,11 @@
+defmodule Engram.MCP.ToolsSetVaultSchemaTest do
+  use ExUnit.Case, async: true
+
+  test "set_vault advertises vault_id as a UUID string, not an integer (#724)" do
+    tool = Enum.find(Engram.MCP.Tools.list(), &(&1.name == "set_vault"))
+    schema = tool.inputSchema["properties"]["vault_id"]
+
+    assert schema["type"] == "string"
+    assert schema["format"] == "uuid"
+  end
+end

--- a/test/engram/notes/helpers_test.exs
+++ b/test/engram/notes/helpers_test.exs
@@ -67,6 +67,46 @@ defmodule Engram.Notes.HelpersTest do
       assert Helpers.extract_tags(content) == ["health", "fitness"]
     end
 
+    test "block-style (multi-line) list tags" do
+      content = "---\ntags:\n  - project\n  - work\n---\nBody"
+      assert Helpers.extract_tags(content) == ["project", "work"]
+    end
+
+    test "block-style list tags with a leading blank line and inline tag" do
+      content = "---\ntags:\n  - alpha\n  - beta\n---\nBody with #gamma"
+      assert Helpers.extract_tags(content) == ["alpha", "beta", "gamma"]
+    end
+
+    test "single-item block list" do
+      content = "---\ntags:\n  - solo\n---\nBody"
+      assert Helpers.extract_tags(content) == ["solo"]
+    end
+
+    test "block list stops at the next frontmatter key" do
+      content = "---\ntags:\n  - alpha\n  - beta\nauthor: me\n---\nBody"
+      assert Helpers.extract_tags(content) == ["alpha", "beta"]
+    end
+
+    test "block list preceded by other frontmatter keys" do
+      content = "---\ntitle: T\ntags:\n  - alpha\n  - beta\naliases:\n  - x\n---\nBody"
+      assert Helpers.extract_tags(content) == ["alpha", "beta"]
+    end
+
+    test "quoted block-list items are unquoted" do
+      content = "---\ntags:\n  - \"alpha\"\n  - 'beta'\n---\nBody"
+      assert Helpers.extract_tags(content) == ["alpha", "beta"]
+    end
+
+    test "quoted inline-list items are unquoted" do
+      content = "---\ntags: [\"alpha\", 'beta']\n---\nBody"
+      assert Helpers.extract_tags(content) == ["alpha", "beta"]
+    end
+
+    test "CRLF frontmatter with a block list" do
+      content = "---\r\ntags:\r\n  - alpha\r\n  - beta\r\n---\r\nBody"
+      assert Helpers.extract_tags(content) == ["alpha", "beta"]
+    end
+
     test "no frontmatter returns empty list" do
       assert Helpers.extract_tags("# No Tags\nBody") == []
     end

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -429,6 +429,12 @@ defmodule Engram.VaultsTest do
       assert {:error, :not_found} = Vaults.get_vault(user, Ecto.UUID.generate())
     end
 
+    test "returns {:error, :not_found} for a malformed (non-UUID) id without raising", %{
+      user: user
+    } do
+      assert {:error, :not_found} = Vaults.get_vault(user, "not-a-uuid")
+    end
+
     test "returns {:error, :not_found} for another user's vault", %{
       user: user,
       other_user: other_user

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -280,6 +280,15 @@ defmodule EngramWeb.McpControllerTest do
 
       assert text == "Note not found: Missing/Note.md"
     end
+
+    test "does not re-inject title/tags already in the decrypted body (#731)", %{conn: conn} do
+      # Seeded note has frontmatter `tags: [...]` + a `# Supplements` H1.
+      conn = call_tool(conn, "get_note", %{"source_path" => "Health/Supplements.md"})
+      text = tool_text(conn)
+
+      refute text =~ "**Tags:**", "tags live in frontmatter; must not be re-injected"
+      assert Enum.count(String.split(text, "\n"), &(&1 == "# Supplements")) == 1
+    end
   end
 
   # =========================================================================

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -182,6 +182,14 @@ defmodule EngramWeb.McpControllerTest do
 
       assert text =~ "Error:"
     end
+
+    test "with a malformed (non-UUID) vault_id returns a clean error, not a cast crash",
+         %{conn: conn} do
+      conn = call_tool(conn, "set_vault", %{"vault_id" => "not-a-uuid"})
+      text = tool_text(conn)
+
+      assert text =~ "Vault not found"
+    end
   end
 
   # =========================================================================


### PR DESCRIPTION
Fixes three MCP bugs found in the 2026-06-23 vault dogfooding session. One commit per issue.

## #724 — `set_vault` unusable for vault switching
The tool schema typed `vault_id` as an **integer**, but vault IDs are UUIDs. MCP clients validate against the schema and serialize the UUID unquoted → invalid JSON that never reaches the server. Schema now `string`/`format: uuid` (matches the REST schema). Also hardened `Vaults.get_vault/2` to tolerate a malformed UUID instead of raising an Ecto cast error (500 + leaky log) — fixes every caller, including the MCP controller's `resolve_mcp_vault`.

## #731 — `get_note` repeats title/tags
`get_note` injected a `# Title` + `**Tags:**` header and then appended the note body verbatim — duplicating metadata the body already carries (frontmatter + `# H1`). Now Title/Tags are injected **only** when the body doesn't already carry them (a frontmatter `title:`/`tags:` key, or a body `# H1` after any frontmatter). `##`+ are subheadings, BOM/CRLF tolerated. Body still returned verbatim (read-modify-write integrity).

## #732 — YAML block-style frontmatter tags mangled
`parse_frontmatter_tags` let `\s*` eat the newline after a bare `tags:` line and captured the first `- item` as a literal tag (`"- project"`). Block lists were never parsed — wrong tags in indexing and `list_folder`. Now parses block lists, strips surrounding quotes from scalars, and tolerates CRLF.

## Tests
TDD throughout (failing test first). 216 affected tests green locally; `mix format` + `credo --strict` clean. Coverage includes a DB+decrypt integration test through `handle("get_note", …)` that caught a real duplicate-title edge (frontmatter w/o title key + body H1), plus end-to-end `set_vault` valid/nonexistent/malformed UUID.

Closes #724
Closes #731
Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)