### PR TITLE
fix(embed): cap re-billing on permanently-failing notes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -119,6 +119,13 @@ if config_env() != :test do
     config :engram, :embed_429_snooze_seconds, String.to_integer(secs)
   end
 
+  # Cooldown (seconds) parked on a note that exhausts its embed attempts, before
+  # ReconcileEmbeddings retries it. Caps re-billing on permanently-failing notes.
+  # Default 6h (21_600). Lower it to retry broken notes sooner at higher cost.
+  if secs = System.get_env("EMBED_POISON_COOLDOWN_SECONDS") do
+    config :engram, :embed_poison_cooldown_seconds, String.to_integer(secs)
+  end
+
   # Client-side Voyage rate limit. Unset = no throttle (self-host default).
   # Set to your Voyage paid-tier RPM (e.g. 2000) to fail fast with a synthetic
   # 429 before burning real API calls. EmbedNote snoozes on the synthetic 429

--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -29,6 +29,13 @@ defmodule Engram.Notes.Note do
     field :dek_version, :integer, default: 1
     field :content_hash, :string
     field :embed_hash, :string
+    # Poison-loop guard: when a note exhausts its EmbedNote attempts, the worker
+    # stamps a cooldown timestamp here. ReconcileEmbeddings skips notes whose
+    # cooldown hasn't elapsed, so a permanently-failing note re-bills Voyage at
+    # most once per cooldown window instead of every 15-minute cron tick. Cleared
+    # on the next successful embed. Only gates the cron — direct user-action
+    # enqueues (upsert/rename) always run.
+    field :embed_retry_after, :utc_datetime_usec
     field :mtime, :float
     field :deleted_at, :utc_datetime_usec
     field :content_ciphertext, :binary

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -39,7 +39,7 @@ defmodule Engram.Workers.EmbedNote do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
+  def perform(%Oban.Job{args: args} = job) do
     note_id = args["note_id"]
     # T3.2 — `old_path_hmac` is a base64-encoded HMAC, never plaintext path.
     old_path_hmac_b64 = args["old_path_hmac"]
@@ -84,6 +84,7 @@ defmodule Engram.Workers.EmbedNote do
                         :ok
 
                       other ->
+                        _ = maybe_mark_poison(note, other, job)
                         other
                     end
 
@@ -184,6 +185,63 @@ defmodule Engram.Workers.EmbedNote do
     Application.get_env(:engram, :embed_429_snooze_seconds, 60)
   end
 
+  # Cooldown parked on a note that has exhausted its embed attempts. Env-driven
+  # via `EMBED_POISON_COOLDOWN_SECONDS` (wired in runtime.exs). Default 6h: a
+  # genuinely-broken note re-bills Voyage ~4×/day instead of ~96×/day, while a
+  # transient provider outage self-heals within hours (vs a hard give-up that
+  # would strand the whole vault until manual reset).
+  defp poison_cooldown_seconds do
+    Application.get_env(:engram, :embed_poison_cooldown_seconds, 21_600)
+  end
+
+  # Final-attempt failure: park the note for a cooldown so ReconcileEmbeddings
+  # stops re-enqueuing (and re-billing) it every 15 minutes. Only fires on the
+  # terminal Oban attempt and only for {:error, _} — snooze/cancel/discard are
+  # not embed failures. The content_hash guard mirrors stamp_embed_hash: if the
+  # note was edited mid-flight, don't park the now-different content. Emits a
+  # distinct [:engram, :embed, :poison] event so the give-up is alertable
+  # separately from per-attempt [:engram, :embed, :failed] noise.
+  defp maybe_mark_poison(note, {:error, reason}, %Oban.Job{attempt: attempt, max_attempts: max})
+       when attempt >= max do
+    cooldown = poison_cooldown_seconds()
+    retry_after = DateTime.add(DateTime.utc_now(), cooldown, :second)
+
+    {count, _} =
+      from(n in Note, where: n.id == ^note.id and n.content_hash == ^note.content_hash)
+      |> Repo.update_all([set: [embed_retry_after: retry_after]], skip_tenant_check: true)
+
+    error_kind = Engram.Telemetry.error_kind(reason)
+    status = embed_error_status(reason)
+
+    :telemetry.execute(
+      [:engram, :embed, :poison],
+      %{count: 1, cooldown_seconds: cooldown},
+      %{
+        error_kind: error_kind,
+        status: status,
+        note_id: note.id,
+        user_id: note.user_id,
+        parked: count > 0
+      }
+    )
+
+    Logger.error(
+      "embed_poisoned",
+      Metadata.with_category(:error, :search,
+        user_id: note.user_id,
+        vault_id: note.vault_id,
+        note_id: note.id,
+        error_kind: error_kind,
+        status: status,
+        cooldown_seconds: cooldown
+      )
+    )
+
+    :ok
+  end
+
+  defp maybe_mark_poison(_note, _result, _job), do: :ok
+
   defp run_embed(note, old_path_hmac_b64) do
     user = Accounts.get_user!(note.user_id)
 
@@ -262,6 +320,8 @@ defmodule Engram.Workers.EmbedNote do
   # Optimistic lock: only set embed_hash if content_hash hasn't changed since
   # we started embedding. If it changed (concurrent edit), this is a no-op —
   # the reconciliation cron or the next debounced job will pick up the new version.
+  # Also clears any embed_retry_after poison cooldown — a successful embed means
+  # the note is no longer broken.
   defp stamp_embed_hash(%Note{content_hash: nil}), do: :ok
 
   defp stamp_embed_hash(note) do
@@ -269,7 +329,9 @@ defmodule Engram.Workers.EmbedNote do
       from(n in Note,
         where: n.id == ^note.id and n.content_hash == ^note.content_hash
       )
-      |> Repo.update_all([set: [embed_hash: note.content_hash]], skip_tenant_check: true)
+      |> Repo.update_all([set: [embed_hash: note.content_hash, embed_retry_after: nil]],
+        skip_tenant_check: true
+      )
 
     if count == 0 do
       Logger.debug(

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -197,18 +197,26 @@ defmodule Engram.Workers.EmbedNote do
   # Final-attempt failure: park the note for a cooldown so ReconcileEmbeddings
   # stops re-enqueuing (and re-billing) it every 15 minutes. Only fires on the
   # terminal Oban attempt and only for {:error, _} — snooze/cancel/discard are
-  # not embed failures. The content_hash guard mirrors stamp_embed_hash: if the
-  # note was edited mid-flight, don't park the now-different content. Emits a
-  # distinct [:engram, :embed, :poison] event so the give-up is alertable
-  # separately from per-attempt [:engram, :embed, :failed] noise.
+  # not embed failures. Like stamp_embed_hash, an optimistic content_hash guard
+  # avoids parking content that was edited mid-flight — but a nil content_hash
+  # must still park (WHERE content_hash = NULL never matches, which would leave
+  # the exact loop this guards against running), so fall back to an id-only match.
   defp maybe_mark_poison(note, {:error, reason}, %Oban.Job{attempt: attempt, max_attempts: max})
        when attempt >= max do
     cooldown = poison_cooldown_seconds()
     retry_after = DateTime.add(DateTime.utc_now(), cooldown, :second)
 
+    park_query =
+      if is_nil(note.content_hash) do
+        from(n in Note, where: n.id == ^note.id)
+      else
+        from(n in Note, where: n.id == ^note.id and n.content_hash == ^note.content_hash)
+      end
+
     {count, _} =
-      from(n in Note, where: n.id == ^note.id and n.content_hash == ^note.content_hash)
-      |> Repo.update_all([set: [embed_retry_after: retry_after]], skip_tenant_check: true)
+      Repo.update_all(park_query, [set: [embed_retry_after: retry_after]],
+        skip_tenant_check: true
+      )
 
     error_kind = Engram.Telemetry.error_kind(reason)
     status = embed_error_status(reason)

--- a/lib/engram/workers/reconcile_embeddings.ex
+++ b/lib/engram/workers/reconcile_embeddings.ex
@@ -9,6 +9,9 @@ defmodule Engram.Workers.ReconcileEmbeddings do
   - embed_hash IS NULL (never embedded)
   - embed_hash != content_hash (content changed since last embed)
   - not soft-deleted
+  - embed_retry_after IS NULL or elapsed (not inside a poison cooldown — see
+    EmbedNote: a note that exhausts its attempts is parked for a cooldown window
+    so it can't re-bill Voyage every tick)
 
   Uses the partial index idx_notes_embed_pending for fast lookups.
   Batches to avoid flooding the embed queue.
@@ -40,12 +43,19 @@ defmodule Engram.Workers.ReconcileEmbeddings do
     # O(total vaults) queries at scale for a worker that only needs ids.
     # Per-vault fairness isn't needed: EmbedNote is uniq-deduped, and the
     # oldest-first order drains any backlog across ticks.
+    now = DateTime.utc_now()
+
     note_ids =
       Note
       |> join(:inner, [n], v in Vault, on: v.id == n.vault_id and is_nil(v.deleted_at))
       |> where([n], n.kind == "note")
       |> where([n], is_nil(n.deleted_at))
       |> where([n], is_nil(n.embed_hash) or n.embed_hash != n.content_hash)
+      # Poison-loop guard: a note that exhausts its EmbedNote attempts gets an
+      # embed_retry_after cooldown stamp. Skip it until the cooldown elapses so a
+      # permanently-failing note re-bills Voyage at most once per window, not
+      # every tick. NULL = no cooldown = eligible now.
+      |> where([n], is_nil(n.embed_retry_after) or n.embed_retry_after <= ^now)
       |> order_by([n], asc: n.updated_at)
       |> limit(@batch_size)
       |> select([n], n.id)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.524",
+      version: "0.5.525",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.525",
+      version: "0.5.526",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260624000000_add_embed_retry_after_to_notes_expand.exs
+++ b/priv/repo/migrations/20260624000000_add_embed_retry_after_to_notes_expand.exs
@@ -6,7 +6,10 @@ defmodule Engram.Repo.Migrations.AddEmbedRetryAfterToNotesExpand do
   # hasn't elapsed, capping re-bill on permanently-failing notes.
   def change do
     alter table(:notes) do
-      add :embed_retry_after, :utc_datetime_usec
+      # :timestamptz (not :utc_datetime_usec, which renders bare `timestamp`)
+      # to satisfy Squawk's prefer-timestamp-tz rule. The schema field stays
+      # :utc_datetime_usec — Ecto reads timestamptz as a UTC DateTime.
+      add :embed_retry_after, :timestamptz
     end
   end
 end

--- a/priv/repo/migrations/20260624000000_add_embed_retry_after_to_notes_expand.exs
+++ b/priv/repo/migrations/20260624000000_add_embed_retry_after_to_notes_expand.exs
@@ -1,0 +1,12 @@
+defmodule Engram.Repo.Migrations.AddEmbedRetryAfterToNotesExpand do
+  use Ecto.Migration
+
+  # phase/expand — additive nullable column; no backfill (NULL = eligible now).
+  # Poison-loop guard: ReconcileEmbeddings skips notes whose embed cooldown
+  # hasn't elapsed, capping re-bill on permanently-failing notes.
+  def change do
+    alter table(:notes) do
+      add :embed_retry_after, :utc_datetime_usec
+    end
+  end
+end

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -295,6 +295,86 @@ defmodule Engram.Workers.EmbedNoteTest do
     end
   end
 
+  describe "perform/1 — poison-loop guard" do
+    test "stamps embed_retry_after on the final failed attempt", %{bypass: bypass, note: note} do
+      stub_qdrant(bypass)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts -> {:error, {500, %{"detail" => "boom"}}} end)
+
+      assert {:error, {500, _}} =
+               perform_job(EmbedNote, %{note_id: note.id}, attempt: 5, max_attempts: 5)
+
+      updated = Repo.get!(Note, note.id, skip_tenant_check: true)
+      assert updated.embed_retry_after != nil
+      assert DateTime.compare(updated.embed_retry_after, DateTime.utc_now()) == :gt
+    end
+
+    test "does NOT stamp embed_retry_after on a non-final attempt", %{bypass: bypass, note: note} do
+      stub_qdrant(bypass)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts -> {:error, {500, %{"detail" => "boom"}}} end)
+
+      assert {:error, {500, _}} =
+               perform_job(EmbedNote, %{note_id: note.id}, attempt: 1, max_attempts: 5)
+
+      updated = Repo.get!(Note, note.id, skip_tenant_check: true)
+      assert is_nil(updated.embed_retry_after)
+    end
+
+    test "emits [:engram, :embed, :poison] telemetry on the final failed attempt",
+         %{bypass: bypass, note: note} do
+      stub_qdrant(bypass)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts -> {:error, {503, %{"detail" => "boom"}}} end)
+
+      test_pid = self()
+      handler_id = {__MODULE__, make_ref()}
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :embed, :poison],
+        fn _e, measurements, metadata, _ ->
+          send(test_pid, {:poison, measurements, metadata})
+        end,
+        nil
+      )
+
+      try do
+        assert {:error, {503, _}} =
+                 perform_job(EmbedNote, %{note_id: note.id}, attempt: 5, max_attempts: 5)
+      after
+        :telemetry.detach(handler_id)
+      end
+
+      assert_received {:poison, %{count: 1}, %{status: 503, note_id: note_id}}
+      assert note_id == note.id
+    end
+
+    test "clears embed_retry_after on a successful embed", %{bypass: bypass, note: note} do
+      # Simulate a previously-poisoned note still carrying a cooldown stamp.
+      from(n in Note, where: n.id == ^note.id)
+      |> Repo.update_all(
+        [set: [embed_retry_after: DateTime.add(DateTime.utc_now(), 3600, :second)]],
+        skip_tenant_check: true
+      )
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn texts ->
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 3) end)}
+      end)
+
+      stub_qdrant(bypass)
+
+      assert :ok = perform_job(EmbedNote, %{note_id: note.id})
+
+      updated = Repo.get!(Note, note.id, skip_tenant_check: true)
+      assert is_nil(updated.embed_retry_after)
+    end
+  end
+
   describe "job scheduling" do
     test "Notes.upsert_note enqueues EmbedNote job", %{user: user, vault: vault} do
       {:ok, note} =

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -310,6 +310,25 @@ defmodule Engram.Workers.EmbedNoteTest do
       assert DateTime.compare(updated.embed_retry_after, DateTime.utc_now()) == :gt
     end
 
+    test "parks a nil-content_hash note on the final attempt (id-only match)",
+         %{bypass: bypass, note: note} do
+      # A nil content_hash must still park — otherwise the optimistic
+      # `content_hash = NULL` guard never matches and the loop persists.
+      from(n in Note, where: n.id == ^note.id)
+      |> Repo.update_all([set: [content_hash: nil]], skip_tenant_check: true)
+
+      stub_qdrant(bypass)
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _texts -> {:error, {500, %{"detail" => "boom"}}} end)
+
+      assert {:error, {500, _}} =
+               perform_job(EmbedNote, %{note_id: note.id}, attempt: 5, max_attempts: 5)
+
+      updated = Repo.get!(Note, note.id, skip_tenant_check: true)
+      assert updated.embed_retry_after != nil
+    end
+
     test "does NOT stamp embed_retry_after on a non-final attempt", %{bypass: bypass, note: note} do
       stub_qdrant(bypass)
 

--- a/test/engram/workers/reconcile_embeddings_test.exs
+++ b/test/engram/workers/reconcile_embeddings_test.exs
@@ -131,6 +131,34 @@ defmodule Engram.Workers.ReconcileEmbeddingsTest do
       assert :ok = perform_job(ReconcileEmbeddings, %{})
       refute_enqueued(worker: EmbedNote, args: %{"note_id" => note.id})
     end
+
+    test "skips poisoned notes still inside their embed cooldown" do
+      user = insert(:user)
+
+      note =
+        insert(:note,
+          user: user,
+          embed_hash: nil,
+          embed_retry_after: DateTime.add(DateTime.utc_now(), 3600, :second)
+        )
+
+      assert :ok = perform_job(ReconcileEmbeddings, %{})
+      refute_enqueued(worker: EmbedNote, args: %{"note_id" => note.id})
+    end
+
+    test "queues poisoned notes whose embed cooldown has elapsed" do
+      user = insert(:user)
+
+      note =
+        insert(:note,
+          user: user,
+          embed_hash: nil,
+          embed_retry_after: DateTime.add(DateTime.utc_now(), -3600, :second)
+        )
+
+      assert :ok = perform_job(ReconcileEmbeddings, %{})
+      assert_enqueued(worker: EmbedNote, args: %{"note_id" => note.id})
+    end
   end
 
   defp collect_queries(acc \\ []) do


### PR DESCRIPTION
## Problem

A note whose `EmbedNote` job exhausts its 5 attempts never stamps `embed_hash`. `ReconcileEmbeddings` (15-min cron) re-finds it via `embed_hash IS NULL OR embed_hash <> content_hash` and re-enqueues it **every tick, forever**. Worst case — the Voyage call *succeeds* (tokens billed) but a downstream step keeps failing (e.g. Qdrant upsert reject, decrypt) — this re-bills Voyage ~96×/day on a single broken note, unbounded, with no dead-letter.

## Fix

A flat **cooldown** parked on the note's terminal failed attempt:

- New nullable column `notes.embed_retry_after` (phase/expand migration).
- `EmbedNote` — on the terminal Oban attempt (`attempt >= max_attempts`) for an `{:error, _}` result, `maybe_mark_poison` stamps `embed_retry_after = now + cooldown` (default **6h**, `EMBED_POISON_COOLDOWN_SECONDS`) and emits a distinct `[:engram, :embed, :poison]` telemetry event + `embed_poisoned` error log (carries `error_kind`/`status` — the *why-it-failed* signal).
- `ReconcileEmbeddings` — skips notes inside their cooldown (`embed_retry_after IS NULL OR <= now`). Broken note now re-bills ~4×/day instead of ~96×/day.
- A successful embed clears the stamp (in `stamp_embed_hash`, same optimistic content_hash lock).

## Why flat cooldown (not hard give-up)

A hard "give up after K failures" would let a **Voyage-wide outage poison the entire vault** until manual reset. A flat cooldown self-heals within hours and retries immediately on a content edit. It gates **only the cron** — direct user-action enqueues (upsert/rename) always run immediately, so search freshness is unaffected.

## Tests (TDD)

- Reconcile: skips notes in cooldown / queues them once elapsed.
- EmbedNote: stamps `embed_retry_after` on final attempt only (not earlier attempts); emits `:poison` telemetry; clears stamp on success.
- 208 worker + notes tests green; format + credo + sobelow clean.

## Follow-up

Alarm on `embed_poisoned` (Loki alert on the error log, or a PromEx counter) — separate infra PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)