### PR TITLE
feat(embed): settle-debounce notes before embedding

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -119,6 +119,20 @@ if config_env() != :test do
     config :engram, :embed_429_snooze_seconds, String.to_integer(secs)
   end
 
+  # Settle debounce: a note must sit unedited this many seconds before it embeds,
+  # so a burst of rapid saves collapses into one Voyage call. Higher = cheaper but
+  # staler search index after an edit. Default 30s.
+  if secs = System.get_env("EMBED_SETTLE_SECONDS") do
+    config :engram, :embed_settle_seconds, String.to_integer(secs)
+  end
+
+  # Max-wait ceiling: a continuously-edited note embeds at most this many seconds
+  # after its first pending edit, even if never quiet (prevents starvation).
+  # Default 300s (5m). Keep > EMBED_SETTLE_SECONDS.
+  if secs = System.get_env("EMBED_SETTLE_MAX_WAIT_SECONDS") do
+    config :engram, :embed_settle_max_wait_seconds, String.to_integer(secs)
+  end
+
   # Client-side Voyage rate limit. Unset = no throttle (self-host default).
   # Set to your Voyage paid-tier RPM (e.g. 2000) to fail fast with a synthetic
   # 429 before burning real API calls. EmbedNote snoozes on the synthetic 429

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1399,7 +1399,11 @@ defmodule Engram.Notes do
     embed_jobs =
       ok_entries
       |> Enum.filter(fn %{hash: hash, result: {:ok, info}} -> info.prev_hash != hash end)
-      |> Enum.map(fn %{result: {:ok, info}} -> EmbedNote.new_debounced(info.id) end)
+      # clamp: false — Oban.insert_all ignores unique/replace, so the settle
+      # ceiling is moot here; skip the per-note burst-start SELECT.
+      |> Enum.map(fn %{result: {:ok, info}} ->
+        EmbedNote.new_debounced(info.id, clamp: false)
+      end)
 
     _ = if embed_jobs != [], do: Oban.insert_all(embed_jobs)
 

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -298,10 +298,20 @@ defmodule Engram.Workers.EmbedNote do
   Pass `old_path_hmac:` (base64) when the note was renamed — the worker will
   delete old-path Qdrant points before re-indexing under the new path. T3.2:
   HMAC bytes (not plaintext path) are what survives in `oban_jobs.args` JSONB.
+
+  Pass `clamp: false` from bulk callers that enqueue via `Oban.insert_all`
+  (batch upsert, reconcile sweep). `insert_all` ignores `unique`/`replace`, so
+  the ceiling is meaningless there — `clamp: false` skips the per-note
+  `existing_burst_start` SELECT that would otherwise run once per note for
+  nothing (a 500-note reconcile tick = 500 wasted queries).
   """
   def new_debounced(note_id, opts \\ []) do
     quiet_at = DateTime.add(DateTime.utc_now(), settle_seconds(), :second)
-    scheduled_at = clamp_to_ceiling(note_id, quiet_at)
+
+    scheduled_at =
+      if Keyword.get(opts, :clamp, true),
+        do: clamp_to_ceiling(note_id, quiet_at),
+        else: quiet_at
 
     args = %{note_id: note_id}
 
@@ -333,6 +343,13 @@ defmodule Engram.Workers.EmbedNote do
   # Clamp the trailing-debounce target to burst_start + max_wait so a
   # continuously-edited note still embeds. nil burst_start = no pending job =
   # fresh burst, use the full settle window.
+  #
+  # Race note: existing_burst_start reads outside the advisory lock that Oban's
+  # insert_unique takes. A concurrent enqueue for the same note can make us miss
+  # an in-flight job and replace scheduled_at with an un-clamped quiet_at — but
+  # that only pushes the embed at most one settle interval past the ceiling
+  # (never earlier, never duplicate), and the next edit self-corrects. Bounded
+  # extra staleness, not a correctness bug — not worth locking the read path.
   defp clamp_to_ceiling(note_id, quiet_at) do
     case existing_burst_start(note_id) do
       nil ->
@@ -345,8 +362,8 @@ defmodule Engram.Workers.EmbedNote do
   end
 
   # inserted_at of the in-flight EmbedNote job for this note — the burst start,
-  # preserved across `replace: [:scheduled_at]` re-inserts. skip_tenant_check:
-  # Oban.Job is not a tenant-scoped schema.
+  # preserved across `replace: [:scheduled_at]` re-inserts. oban_jobs is not a
+  # tenant-scoped table, so no skip_tenant_check needed.
   defp existing_burst_start(note_id) do
     from(j in Oban.Job,
       where: j.worker == "Engram.Workers.EmbedNote",
@@ -356,6 +373,6 @@ defmodule Engram.Workers.EmbedNote do
       limit: 1,
       select: j.inserted_at
     )
-    |> Repo.one(skip_tenant_check: true)
+    |> Repo.one()
   end
 end

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -282,15 +282,27 @@ defmodule Engram.Workers.EmbedNote do
   end
 
   @doc """
-  Build an Oban job with 5-second debounce.
-  `replace: [:scheduled_at]` resets the timer on rapid edits (dedup by note_id).
+  Build a debounced EmbedNote job — embed only once the note has been quiet.
+
+  Trailing debounce: each edit re-inserts with `replace: [:scheduled_at]`, which
+  pushes the run time to `now + settle` (default 30s, `EMBED_SETTLE_SECONDS`), so
+  a burst of rapid saves collapses into a single Voyage call after the editing
+  settles.
+
+  Max-wait ceiling: a note edited continuously would otherwise never embed (the
+  timer keeps resetting). We clamp `scheduled_at` to `burst_start + max_wait`
+  (default 5m, `EMBED_SETTLE_MAX_WAIT_SECONDS`), where `burst_start` is the
+  surviving job's `inserted_at` (unchanged by `replace`). The unique `period` is
+  widened to span the whole window so dedup holds until the ceiling fires.
 
   Pass `old_path_hmac:` (base64) when the note was renamed — the worker will
   delete old-path Qdrant points before re-indexing under the new path. T3.2:
   HMAC bytes (not plaintext path) are what survives in `oban_jobs.args` JSONB.
   """
   def new_debounced(note_id, opts \\ []) do
-    scheduled_at = DateTime.add(DateTime.utc_now(), 5, :second)
+    quiet_at = DateTime.add(DateTime.utc_now(), settle_seconds(), :second)
+    scheduled_at = clamp_to_ceiling(note_id, quiet_at)
+
     args = %{note_id: note_id}
 
     args =
@@ -301,7 +313,49 @@ defmodule Engram.Workers.EmbedNote do
     new(
       args,
       scheduled_at: scheduled_at,
-      replace: [:scheduled_at]
+      replace: [:scheduled_at],
+      # Override the worker default (60s) so dedup spans the full settle+ceiling
+      # window — otherwise a burst longer than the period spawns a second job and
+      # resets the ceiling.
+      unique: [
+        period: settle_max_wait_seconds() + settle_seconds(),
+        keys: [:note_id],
+        states: :incomplete
+      ]
     )
+  end
+
+  defp settle_seconds, do: Application.get_env(:engram, :embed_settle_seconds, 30)
+
+  defp settle_max_wait_seconds,
+    do: Application.get_env(:engram, :embed_settle_max_wait_seconds, 300)
+
+  # Clamp the trailing-debounce target to burst_start + max_wait so a
+  # continuously-edited note still embeds. nil burst_start = no pending job =
+  # fresh burst, use the full settle window.
+  defp clamp_to_ceiling(note_id, quiet_at) do
+    case existing_burst_start(note_id) do
+      nil ->
+        quiet_at
+
+      burst_start ->
+        ceiling = DateTime.add(burst_start, settle_max_wait_seconds(), :second)
+        if DateTime.compare(quiet_at, ceiling) == :gt, do: ceiling, else: quiet_at
+    end
+  end
+
+  # inserted_at of the in-flight EmbedNote job for this note — the burst start,
+  # preserved across `replace: [:scheduled_at]` re-inserts. skip_tenant_check:
+  # Oban.Job is not a tenant-scoped schema.
+  defp existing_burst_start(note_id) do
+    from(j in Oban.Job,
+      where: j.worker == "Engram.Workers.EmbedNote",
+      where: fragment("? ->> 'note_id' = ?", j.args, ^to_string(note_id)),
+      where: j.state in ["scheduled", "available", "executing", "retryable"],
+      order_by: [asc: j.inserted_at],
+      limit: 1,
+      select: j.inserted_at
+    )
+    |> Repo.one(skip_tenant_check: true)
   end
 end

--- a/lib/engram/workers/reconcile_embeddings.ex
+++ b/lib/engram/workers/reconcile_embeddings.ex
@@ -58,7 +58,10 @@ defmodule Engram.Workers.ReconcileEmbeddings do
           Engram.Logger.Metadata.with_category(:debug, :search, total_count: length(note_ids))
         )
 
-        Oban.insert_all(Enum.map(note_ids, &EmbedNote.new_debounced/1))
+        # clamp: false — insert_all ignores unique/replace, so the settle
+        # ceiling is moot; skip the per-note burst-start SELECT (one per stale
+        # note, up to @batch_size, every tick).
+        Oban.insert_all(Enum.map(note_ids, &EmbedNote.new_debounced(&1, clamp: false)))
       end
 
     :ok

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.525",
+      version: "0.5.527",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/workers/embed_note_test.exs
+++ b/test/engram/workers/embed_note_test.exs
@@ -295,6 +295,72 @@ defmodule Engram.Workers.EmbedNoteTest do
     end
   end
 
+  describe "new_debounced — settle debounce" do
+    setup do
+      prev_settle = Application.get_env(:engram, :embed_settle_seconds)
+      prev_max = Application.get_env(:engram, :embed_settle_max_wait_seconds)
+      Application.put_env(:engram, :embed_settle_seconds, 30)
+      Application.put_env(:engram, :embed_settle_max_wait_seconds, 300)
+
+      on_exit(fn ->
+        restore = fn key, val ->
+          if is_nil(val),
+            do: Application.delete_env(:engram, key),
+            else: Application.put_env(:engram, key, val)
+        end
+
+        restore.(:embed_settle_seconds, prev_settle)
+        restore.(:embed_settle_max_wait_seconds, prev_max)
+      end)
+
+      :ok
+    end
+
+    defp embed_job(note_id) do
+      from(j in Oban.Job, where: fragment("? ->> 'note_id' = ?", j.args, ^to_string(note_id)))
+      |> Repo.one!()
+    end
+
+    test "schedules ~settle seconds out by default", %{note: note} do
+      {:ok, _} = Oban.insert(EmbedNote.new_debounced(note.id))
+
+      job = embed_job(note.id)
+      diff = DateTime.diff(job.scheduled_at, DateTime.utc_now(), :second)
+      assert diff in 25..35
+    end
+
+    test "a rapid re-insert keeps a single job and pushes the timer out", %{note: note} do
+      {:ok, _} = Oban.insert(EmbedNote.new_debounced(note.id))
+      {:ok, _} = Oban.insert(EmbedNote.new_debounced(note.id))
+
+      jobs =
+        from(j in Oban.Job, where: fragment("? ->> 'note_id' = ?", j.args, ^to_string(note.id)))
+        |> Repo.all()
+
+      assert length(jobs) == 1
+      diff = DateTime.diff(hd(jobs).scheduled_at, DateTime.utc_now(), :second)
+      assert diff in 25..35
+    end
+
+    test "clamps scheduled_at to the max-wait ceiling for a continuously-edited note",
+         %{note: note} do
+      {:ok, _} = Oban.insert(EmbedNote.new_debounced(note.id))
+
+      # Backdate the burst start to 290s ago — 10s short of the 300s ceiling.
+      # The next edit must clamp to the ceiling (~now+10s), NOT the full 30s settle.
+      burst_start = DateTime.add(DateTime.utc_now(), -290, :second)
+
+      from(j in Oban.Job, where: fragment("? ->> 'note_id' = ?", j.args, ^to_string(note.id)))
+      |> Repo.update_all(set: [inserted_at: burst_start])
+
+      {:ok, _} = Oban.insert(EmbedNote.new_debounced(note.id))
+
+      job = embed_job(note.id)
+      diff = DateTime.diff(job.scheduled_at, DateTime.utc_now(), :second)
+      assert diff <= 15
+    end
+  end
+
   describe "job scheduling" do
     test "Notes.upsert_note enqueues EmbedNote job", %{user: user, vault: vault} do
       {:ok, note} =


### PR DESCRIPTION
## What

Embed a note only after it has been **quiet for a settle window**, so a burst of rapid saves (autosave, fast typing) collapses into a single Voyage call instead of re-embedding the whole note on every save.

## How

`EmbedNote.new_debounced/2`:

- Schedules `now + EMBED_SETTLE_SECONDS` (default **30s**); each edit resets the timer via `replace: [:scheduled_at]` (trailing debounce — already the mechanism, just widened from the old fixed 5s).
- **Max-wait ceiling:** clamps `scheduled_at` to `burst_start + EMBED_SETTLE_MAX_WAIT_SECONDS` (default **5m**) so a continuously-edited note still embeds instead of starving. `burst_start` = the surviving job's `inserted_at`, which `replace` preserves across re-inserts.
- Widens the unique `period` to `settle + max_wait` so dedup holds across the whole burst. (A burst longer than the old 60s `period` would spawn a second job and reset the ceiling — caught by a test.)

Only enqueue *timing* changes. The worker still embeds the **latest** content at fire time. Content sync and realtime fan-out are unaffected — only the **search index** lags by the settle window.

## Tradeoff

Search-index freshness: a note isn't searchable via semantic search until ~30s after the last edit. The note content itself appears in the vault instantly. 30s chosen to collapse autosave bursts while keeping search feeling fresh; both knobs are env-configurable.

## Tests (TDD)

- Schedules ~settle seconds out by default.
- Rapid re-insert keeps a single job, pushes the timer out.
- Clamps to the max-wait ceiling for a continuously-edited note (this test also pins the period-widening — without it the re-insert spawns a 2nd job).
- 205 worker + notes tests green; format + credo clean.

## Merge coupling

⚠️ Version-coupled with #736 (poison-loop fix). Main is `0.5.525`; #736 is `0.5.526`, this is `0.5.527`. **Merge #736 first, then this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)