### PR TITLE
docs(worklog): route engram work logs to Engram vault

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,3 +365,5 @@ every destructive change. Adding more tools is Tier 2 work; do not preempt.
 project: engram
 goal: income
 value: financial-freedom
+worklog_vault: Engram
+worklog_path: 90 Work Log/todd

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.529",
+      version: "0.5.530",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Adds `worklog_vault: Engram` + `worklog_path: 90 Work Log/todd` to the `## Life OS` block in AGENTS.md (+ the mandatory one-per-PR version bump 0.5.529→0.5.530).

**Why:** the work-log skill routes entries to the vault/folder named in the nearest CLAUDE.md/AGENTS.md Life OS block. Only the workspace repo had these fields, so work-log entries written during backend sessions fell back to the default vault instead of landing in Engram → `90 Work Log/todd`. This wires backend to match the workspace (and the parallel plugin PR).

One shared folder across all three repos; per-project `#project/` tags differentiate entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)