### PR TITLE
fix(notes): extract_tags byte-sliced multibyte chars → invalid-UTF-8 tags at rest (#741 root cause)

### DIFF
--- a/docs/context/invalid-utf8-at-rest-json-500.md
+++ b/docs/context/invalid-utf8-at-rest-json-500.md
@@ -18,6 +18,11 @@ Note content is encrypted (AES-GCM) and stored as Postgres `bytea` ciphertext. `
 1. JSON-decoded **input** is always valid UTF-8, so corruption enters via a client write where the raw bytes are already invalid.
 2. The bytes survive encryption **byte-for-byte** (AES-GCM is byte-transparent), and `bytea` storage does no validation — so they persist at rest.
 3. On read, decryption yields the same invalid bytes, which crash `Jason.encode` at **four** JSON boundaries:
+
+### Second source: `extract_tags` byte-sliced multibyte chars (PR #745, found via the prod backfill)
+There is a SECOND way invalid UTF-8 reached `bytea` — **from perfectly valid content**, not a corrupt client write. The inline-tag regex `@inline_tag_re ~r{(?:^|\s)#([\w][\w/-]*)}` was compiled **without the `u` flag**, so Erlang's `re` ran in byte mode where its char tables treat a multibyte char's lead byte (e.g. `0xE2` of an en-dash `–`) as `\w` but the continuation bytes as not. Content like `#628–` therefore captured `628`+`0xE2` — an invalid-UTF-8 **tag** — which then got encrypted into `tags_ciphertext` and persisted. Because the *content* was valid, the write-time content scrub never caught it, and the #739 backfill (which repairs by re-saving content through `upsert`, re-deriving tags) **reproduced the same byte-slice** and could never reach `corrupt: 0`. Fix = add `u` to the regex (codepoint-aware scan). Once fixed, re-deriving yields clean tags, so the **existing** backfill cleans the legacy rows. Found by running `utf8_audit --fix` on prod: `corrupt: 5` persisted across runs; all 5 were `#NNN–`-style tags.
+
+The four `Jason.encode` crash boundaries (the original #727/#740 symptom):
    - MCP search response
    - Web `/api/search`
    - REST `GET /api/notes/:path` and `/changes`

--- a/lib/engram/notes/helpers.ex
+++ b/lib/engram/notes/helpers.ex
@@ -93,7 +93,15 @@ defmodule Engram.Notes.Helpers do
   # start-of-string or whitespace (so `word#x` and `https://h/#frag` are NOT
   # tags) and must start with a word char (so `# heading` — a space after the
   # hash — is NOT a tag). `{}` delimiter avoids escaping the `/`.
-  @inline_tag_re ~r{(?:^|\s)#([\w][\w/-]*)}
+  #
+  # The `u` (unicode) flag is load-bearing: without it Erlang's `re` runs in
+  # byte mode, where its char tables treat a multibyte char's lead byte (e.g.
+  # `0xE2` of an en-dash `–`) as a word char but the continuation bytes as not —
+  # so `#628–` captured `628` + a lone `0xE2`, an INVALID-UTF-8 tag emitted from
+  # perfectly valid content. That's the root cause of the corrupt tags found at
+  # rest in prod (#741). `u` makes the scan codepoint-aware, so `–` is one
+  # non-word codepoint and the capture stops cleanly at `628`.
+  @inline_tag_re ~r{(?:^|\s)#([\w][\w/-]*)}u
 
   @doc """
   Extracts tags from a note: YAML frontmatter tags merged with inline

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.532",
+      version: "0.5.533",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/helpers_test.exs
+++ b/test/engram/notes/helpers_test.exs
@@ -240,6 +240,24 @@ defmodule Engram.Notes.HelpersTest do
     test "deduplicates repeated inline tags" do
       assert Helpers.extract_tags("#dup once #dup twice") == ["dup"]
     end
+
+    test "never byte-slices a multibyte char after a #tag (#741 root cause)" do
+      # `–` (en-dash U+2013 = <<0xE2,0x80,0x93>>) immediately after `#628`. The
+      # byte-mode regex used to capture `628` + the en-dash's lead byte (0xE2),
+      # emitting an invalid-UTF-8 tag from VALID content — the exact source of
+      # the corrupt tags found at rest in prod.
+      content = "note x #628" <> <<0xE2, 0x80, 0x93>> <> " y"
+      assert String.valid?(content)
+
+      tags = Helpers.extract_tags(content)
+      assert Enum.all?(tags, &String.valid?/1)
+      # 628 is purely numeric and the en-dash is not a tag char → no tag at all.
+      assert tags == []
+    end
+
+    test "keeps a real multibyte inline tag intact" do
+      assert Helpers.extract_tags("a #café and #über b") == ["café", "über"]
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/notes/utf8_backfill_test.exs
+++ b/test/engram/notes/utf8_backfill_test.exs
@@ -95,6 +95,39 @@ defmodule Engram.Notes.Utf8BackfillTest do
     refute_received {:scrub, %{boundary: :write}}
   end
 
+  test "fix cleans corrupt tags now that extract_tags no longer byte-slices (#741 prod scenario)",
+       %{user: user, vault: vault} do
+    # Content whose (now-fixed) extract_tags re-derives to clean tags; we inject
+    # the legacy byte-sliced tag (`628`+0xE2) directly into the tags column to
+    # mimic the 5 prod rows. Before the regex fix, re-deriving reproduced the
+    # corruption and the backfill could never reach corrupt:0.
+    {:ok, note} =
+      Notes.upsert_note(user, vault, %{
+        "path" => "Test/EnDash.md",
+        "content" => "x #628" <> <<0xE2, 0x80, 0x93>> <> " y",
+        "mtime" => 1.0
+      })
+
+    {:ok, dek} = Crypto.get_dek(user)
+
+    {tags_ct, tags_nonce} =
+      Crypto.Envelope.encrypt(
+        :erlang.term_to_binary([<<54, 50, 56, 226>>]),
+        dek,
+        Crypto.aad_for_row(:notes, :tags, note.id)
+      )
+
+    {:ok, {1, _}} =
+      Repo.with_tenant(user.id, fn ->
+        from(n in Note, where: n.id == ^note.id)
+        |> Repo.update_all(set: [tags_ciphertext: tags_ct, tags_nonce: tags_nonce])
+      end)
+
+    assert %{corrupt: 1} = Utf8Backfill.scan()
+    assert %{fixed: 1} = Utf8Backfill.scan(fix: true)
+    assert %{corrupt: 0} = Utf8Backfill.scan()
+  end
+
   test "leaves valid rows untouched (no false positives)", %{user: user, vault: vault} do
     {:ok, _} =
       Notes.upsert_note(user, vault, %{

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -186,6 +186,26 @@ defmodule Engram.NotesTest do
       assert_receive {:scrub, %{count: 1}, %{boundary: :write}}
     end
 
+    test "#741: a multibyte char after a numeric #tag never stores invalid-UTF-8 tags at rest",
+         %{user: user, vault: vault} do
+      # Valid content `x #628– y` (en-dash) used to make extract_tags emit a
+      # byte-sliced `628`+0xE2 tag that persisted as invalid UTF-8 — the prod
+      # source of corrupt tags. Assert the STORED tags are valid at rest.
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Test/EnDashTag.md",
+          "content" => "x #628" <> <<0xE2, 0x80, 0x93>> <> " y",
+          "mtime" => 1.0
+        })
+
+      {:ok, raw} =
+        Engram.Repo.with_tenant(user.id, fn -> Engram.Repo.get!(Engram.Notes.Note, note.id) end)
+
+      {:ok, dec} = Engram.Crypto.decrypt_note_fields_unscrubbed(raw, user)
+
+      assert Enum.all?(dec.tags, &String.valid?/1)
+    end
+
     test "#738: note_changed broadcast payload is JSON-safe when content holds invalid UTF-8",
          %{user: user, vault: vault} do
       EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")


### PR DESCRIPTION
## What this fixes
Running the #741 backfill on prod surfaced a deeper bug: `mix engram.utf8_audit --fix` reported `fixed: 5` but a re-scan kept finding `corrupt: 5` — all 5 were `#NNN–`-style tags.

**Root cause:** the inline-tag regex was compiled **without the `u` flag**:
```elixir
@inline_tag_re ~r{(?:^|\s)#([\w][\w/-]*)}
```
In byte mode, Erlang's `re` char tables count a multibyte char's **lead byte** (`0xE2` of an en-dash `–`) as `\w` but its continuation bytes as not. So valid content like `#628–` captured `628`+`0xE2` — an **invalid-UTF-8 tag emitted from perfectly valid content** — which got encrypted into `tags_ciphertext` and persisted at rest.

That explains both mysteries:
- The write-time **content** scrub (#740) never caught it — the *content* is valid; only the derived tag was mangled.
- The #741 backfill couldn't fix it — it repairs by re-saving content through `upsert`, which **re-derives tags via the same byte-slicing `extract_tags`**, reproducing the corruption every run.

## The fix
Add the `u` (unicode) flag so the scan is codepoint-aware: `–` is one non-word codepoint, the capture stops cleanly at `628` (then rejected as numeric → no tag). Real multibyte tags (`#café`, `#über`, `#area/sub`) are unaffected.

**No backfill code change needed:** once `extract_tags` is correct, re-deriving yields clean tags, so the existing `utf8_audit --fix` cleans the legacy prod rows on a re-run (verified by test).

## Tests
- `extract_tags` byte-slice regression (valid `#628–` content → no invalid tag) + real-multibyte-tag intact
- write path stores **valid tags at rest** for `#628–` content
- backfill drives the injected prod-shape tag corruption to `corrupt: 0`
- Full: `mix format` · `compile --warnings-as-errors` · `credo --strict` · Dialyzer (clean) · 157 affected tests, 0 failures

## Deploy plan
Ship via `release-v0.5.533`, then re-run `Engram.Notes.Utf8Backfill.scan(fix: true)` on prod — the 5 legacy rows clean to 0.

Follow-up to #740/#741; closes the root cause behind the prod `corrupt: 5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)