### PR TITLE
test(mcp): regression for #726 get_note utf8 truncation

### DIFF
--- a/docs/context/invalid-utf8-at-rest-json-500.md
+++ b/docs/context/invalid-utf8-at-rest-json-500.md
@@ -11,6 +11,7 @@ Note content is encrypted (AES-GCM) and stored as Postgres `bytea` ciphertext. `
 ## Symptom
 - `search_notes` (MCP) returned HTTP **500** — looked like a "concurrency" issue but is actually **content-dependent**, not concurrency.
 - Crashed `Phoenix.PubSub.Adapter` on `note_changed` Channel broadcasts.
+- `get_note` (MCP) appeared to **silently truncate** a note to "header + intro" (#726) — same root cause: the bad byte broke the JSON egress, so only bytes *before* it reached the client. Not a separate bug; fixed by the same read-boundary scrub. Regression test: `test/engram/mcp/handlers_get_note_utf8_test.exs`.
 - Prod Loki signature: `** (Jason.EncodeError) invalid byte 0xE2 in <<...>>` where the bytes decode to the search response markdown / note content.
 - Example corruption: a multibyte char like `–` (U+2013 = `E2 80 93`) truncated to a lone `0xE2` lead byte.
 
@@ -67,5 +68,6 @@ The original #740 fix was **silent** — `scrub_utf8` replaced bad bytes with no
 ## References
 - PR #740 (fix)
 - Issue #727 (fixed) — search 500
+- Issue #726 (same root cause) — `get_note` "header + intro" truncation; locked by `handlers_get_note_utf8_test.exs`
 - Issue #738 (channel `note_changed`, fixed; now has a direct broadcast-payload regression test)
 - Issue #739 (backfill — shipped as `mix engram.utf8_audit --fix`)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.533",
+      version: "0.5.534",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/mcp/handlers_get_note_utf8_test.exs
+++ b/test/engram/mcp/handlers_get_note_utf8_test.exs
@@ -1,0 +1,72 @@
+defmodule Engram.MCP.HandlersGetNoteUtf8Test do
+  # Regression for #726: `get_note` silently truncated a note body, returning
+  # only the "header + intro" and dropping the rest. Root cause was an invalid
+  # UTF-8 byte at rest (same source as the #727 search 500 / #745 tag byte-slice):
+  # the bad byte broke the JSON egress, so only the bytes *before* it reached the
+  # client. The #740 read-boundary scrub (Crypto.maybe_decrypt_note_fields, which
+  # get_note flows through) now replaces the bad byte with U+FFFD and preserves
+  # the full body. This test drives the real handler path to lock that the tail
+  # after the bad byte is never dropped again.
+  use Engram.DataCase, async: true
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Crypto
+  alias Engram.MCP.Handlers
+  alias Engram.Notes
+  alias Engram.Notes.Note
+  alias Engram.Repo
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  # Persist a row whose content decrypts to invalid UTF-8 — a legacy row written
+  # before the #727/#740 write-time scrub. Write a clean note, then overwrite its
+  # content ciphertext in place with bytes that are invalid UTF-8 at rest.
+  defp corrupt_note!(user, vault, path, bad) do
+    {:ok, note} =
+      Notes.upsert_note(user, vault, %{
+        "path" => path,
+        "content" => "# Title\n\nclean placeholder",
+        "mtime" => 1.0
+      })
+
+    {:ok, enc} = Crypto.encrypt_note_fields(%{content: bad, title: "Title"}, user, note.id)
+
+    {:ok, {1, _}} =
+      Repo.with_tenant(user.id, fn ->
+        from(n in Note, where: n.id == ^note.id)
+        |> Repo.update_all(
+          set: [content_ciphertext: enc.content_ciphertext, content_nonce: enc.content_nonce]
+        )
+      end)
+
+    note
+  end
+
+  test "get_note returns the full body when content has an invalid UTF-8 byte at rest",
+       %{user: user, vault: vault} do
+    head = "# Title\n\nIntro before the bad byte."
+    tail = "Tail after the bad byte — this is what #726 silently dropped."
+    # A lone 0xE2 — the lead byte of a multibyte char (e.g. en-dash) with its
+    # continuation bytes missing. Invalid UTF-8, sitting between head and tail.
+    corrupt_note!(user, vault, "Test/Corrupt.md", head <> <<0xE2>> <> tail)
+
+    assert {:ok, out} =
+             Handlers.handle("get_note", user, vault, %{"source_path" => "Test/Corrupt.md"})
+
+    # The output is clean UTF-8 — no raw bad byte leaks to the JSON boundary.
+    assert String.valid?(out)
+    # Intro survives (it always did — this is the "header + intro" the bug returned)…
+    assert out =~ "Intro before the bad byte."
+    # …and so does the tail. Pre-#740 this was truncated away.
+    assert out =~ "Tail after the bad byte"
+    # The bad byte was replaced, not dropped — body length is preserved, not cut.
+    assert out =~ "�"
+  end
+end


### PR DESCRIPTION
## What

Locks the fix for **#726** (`get_note` silently returned "header + intro", dropping the rest of the body) with a DB-backed regression test driving the real MCP `get_note` handler.

## Root cause (already fixed in prod)

#726 was **not** a separate bug — it shares the **#727/#745** root cause: an invalid UTF-8 byte at rest in the note body breaks the JSON egress, so only the bytes *before* it reach the client. Fixed in prod (v0.5.533) by:
- #740 — read-boundary scrub (`Crypto.maybe_decrypt_note_fields`, which `get_note` flows through) → bad byte → `U+FFFD`, full length preserved
- #745 — `u`-flag tag regex (stops *creating* invalid UTF-8)
- #739 — backfill for legacy rows

The two originally-affected notes were deleted on 2026-06-23, so this is verified by **mechanism + test**, not by re-reading them.

## The test

`test/engram/mcp/handlers_get_note_utf8_test.exs` — inserts a corrupt-at-rest note (lone `0xE2` between an intro and a tail), calls `Handlers.handle("get_note", ...)`, asserts the **tail survives** + output is valid UTF-8 + bad byte replaced.

**Proven to catch the regression:** with the read scrub bypassed, the handler raises in `format_get_note`'s regex (→ 500) and the test fails.

## Also

- `docs/context/invalid-utf8-at-rest-json-500.md` — documents #726 as a symptom of the same root cause.
- Format + credo clean; 18 related MCP/utf8 tests green.

Refs #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)