### PR TITLE
perf(search): repath Qdrant points on rename instead of re-embedding (#746)

### DIFF
--- a/e2e/tests/api_only/test_77_rename_repath_search.py
+++ b/e2e/tests/api_only/test_77_rename_repath_search.py
@@ -1,0 +1,136 @@
+"""Test 77: folder rename repaths Qdrant points — search finds the note under
+its NEW folder and no longer under the OLD one (#746, end-to-end).
+
+Renaming a folder updates each note's path_hmac/folder_hmac on the row inside
+the rename transaction, then the `RepathNoteIndex` Oban worker PATCHes the
+existing Qdrant points' path_hmac/folder_hmac in place — no re-embed. The unit
+tests prove the wire contract and that the embedder is never called; this test
+proves the repath actually lands in a real Qdrant by exercising the user-facing
+seam:
+
+  1. A folder-scoped `/api/search` (folder -> folder_hmac -> Qdrant filter)
+     finds the note under its NEW folder after the rename.
+  2. The same search under the OLD folder returns nothing — the points no
+     longer carry the old folder_hmac.
+
+The "zero Voyage calls" half is covered by `RepathNoteIndexTest`
+(no-Mox-expectation); e2e has no way to count embedder calls.
+
+API-only (no Obsidian, no Clerk gate). Mirrors test_67's index-then-search
+shape; the repath runs asynchronously (Oban, ~3s debounce), so step 1 polls.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+from helpers.crypto_probe import latest_note_path_hmac, wait_for_qdrant_indexed
+
+API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
+
+logger = logging.getLogger(__name__)
+
+
+class TestRenameRepathSearch:
+    """A folder rename must move the note's Qdrant points to the new
+    folder_hmac without re-embedding, so folder-filtered search follows it."""
+
+    def test_folder_rename_repaths_points_in_qdrant(self, api_sync):
+        vaults = api_sync.list_vaults()
+        assert vaults, "api_sync should have a registered vault"
+        vault_id = vaults[0]["id"]
+        client = api_sync.with_vault(vault_id)
+
+        ts = int(time.time())
+        src_folder = f"repath-src-{ts}"
+        dst_folder = f"repath-dst-{ts}"
+        filename = f"note-{ts}.md"
+        old_path = f"{src_folder}/{filename}"
+        new_path = f"{dst_folder}/{filename}"
+        # Distinctive token so the query matches exactly this note.
+        query = f"zzrepathfingerprint{ts}"
+
+        # 1. Seed one note in the source folder and let the embed worker land
+        #    it in Qdrant under the old path_hmac.
+        resp = client.session.post(
+            f"{API_URL}/notes",
+            json={
+                "path": old_path,
+                "content": f"# Repath note\n\n{query} body content here.\n",
+                "mtime": time.time(),
+            },
+            timeout=10,
+        )
+        assert resp.ok, f"upsert {old_path} failed: {resp.status_code} {resp.text[:300]}"
+
+        old_path_hmac = latest_note_path_hmac(vault_id)
+        wait_for_qdrant_indexed(vault_id, old_path_hmac, old_path, timeout=90)
+
+        # 1a. Baseline: folder-scoped search finds it under the OLD folder.
+        before = self._search(client, query, folder=src_folder, limit=10)
+        assert {r.get("path") for r in before} == {old_path}, (
+            f"baseline: search in {src_folder!r} should find {old_path!r}, "
+            f"got {[r.get('path') for r in before]}"
+        )
+
+        # 2. Rename the folder. This repoints the note row (new path_hmac /
+        #    folder_hmac) and enqueues RepathNoteIndex — NOT a re-embed.
+        status = client.rename_folder(src_folder, dst_folder)
+        assert status == 200, f"rename_folder returned {status}"
+
+        # 3. Poll until the repath lands: folder-scoped search under the NEW
+        #    folder returns the note at its new path. This only succeeds if the
+        #    Qdrant points now carry the new folder_hmac AND path_hmac — i.e.
+        #    the points were PATCHed in place, not deleted.
+        found = self._poll_search(client, query, folder=dst_folder, want=new_path, timeout=90)
+        assert found, (
+            f"after rename, search in {dst_folder!r} never returned {new_path!r} "
+            f"within 90s — repath did not land in Qdrant"
+        )
+
+        # 4. The OLD folder filter must now return nothing — the points no
+        #    longer carry the old folder_hmac. (Guards a repath that ADDED the
+        #    new hmac without overwriting the old, leaving ghost matches.)
+        after_old = self._search(client, query, folder=src_folder, limit=10)
+        assert after_old == [], (
+            f"after rename, search in old folder {src_folder!r} should be empty, "
+            f"got {[r.get('path') for r in after_old]}"
+        )
+
+    @staticmethod
+    def _search(
+        client,
+        query: str,
+        *,
+        folder: str | None = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        body: dict = {"query": query, "limit": limit}
+        if folder is not None:
+            body["folder"] = folder
+
+        resp = client.session.post(f"{API_URL}/search", json=body, timeout=30)
+        assert resp.status_code == 200, (
+            f"/api/search failed: {resp.status_code} {resp.text[:300]}"
+        )
+        return resp.json().get("results", [])
+
+    def _poll_search(
+        self,
+        client,
+        query: str,
+        *,
+        folder: str,
+        want: str,
+        timeout: float = 90.0,
+    ) -> bool:
+        """Poll folder-scoped search until `want` appears (repath is async)."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            results = self._search(client, query, folder=folder, limit=10)
+            if want in {r.get("path") for r in results}:
+                return True
+            time.sleep(2)
+        return False

--- a/lib/engram/indexing.ex
+++ b/lib/engram/indexing.ex
@@ -147,6 +147,39 @@ defmodule Engram.Indexing do
   end
 
   @doc """
+  Re-path a note's Qdrant points after a rename (#746): overwrite the
+  `path_hmac`/`folder_hmac` payload keys on the points still filed under
+  `old_path_hmac` with the note row's CURRENT (post-rename) hmacs. Vectors,
+  sparse vectors, and encrypted payload fields are untouched — no Voyage call.
+  """
+  def repath_points(note, old_path_hmac) do
+    Qdrant.set_payload_by_filter(
+      collection(),
+      to_string(note.user_id),
+      to_string(note.vault_id),
+      old_path_hmac,
+      %{
+        "path_hmac" => encode_hmac(note.path_hmac),
+        "folder_hmac" => encode_hmac(note.folder_hmac)
+      }
+    )
+  end
+
+  @doc """
+  Exact count of a note's Qdrant points under `path_hmac` (#746). Used by the
+  repath worker to branch between PATCH, re-embed self-heal, and the
+  embedded-but-missing inconsistency warning.
+  """
+  def count_points_by_path_hmac(note, path_hmac) do
+    Qdrant.count_by_note(
+      collection(),
+      to_string(note.user_id),
+      to_string(note.vault_id),
+      path_hmac
+    )
+  end
+
+  @doc """
   Remove all indexed data for a note (Qdrant points first, then Postgres
   chunks). T3.2 — Qdrant filter keys off `path_hmac` (base64), not plaintext
   `source_path`. The note row's `path_hmac` is the source of truth.

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -737,11 +737,14 @@ defmodule Engram.Notes do
 
     case result do
       {:ok, {:ok, note}} ->
-        # T3.2 — pass old_path_hmac (base64) to the worker, never plaintext.
+        # #746 — rename only changes the path; repath the existing Qdrant
+        # points instead of re-embedding through Voyage. T3.2: base64 hmac, never plaintext.
         _ =
           Enqueue.enqueue(
-            EmbedNote.new_debounced(note.id, old_path_hmac: old_path_hmac_b64!(user, old_path)),
-            "embed_note"
+            Engram.Workers.RepathNoteIndex.new_debounced(note.id,
+              old_path_hmac: old_path_hmac_b64!(user, old_path)
+            ),
+            "repath_note_index"
           )
 
         :ok = broadcast_change(user.id, vault.id, "delete", old_path)
@@ -793,7 +796,6 @@ defmodule Engram.Notes do
       |> Repo.update_all(
         set:
           [
-            embed_hash: nil,
             updated_at: now,
             seq: seq
           ] ++ full_kw
@@ -2359,7 +2361,6 @@ defmodule Engram.Notes do
                 |> Repo.update_all(
                   set:
                     [
-                      embed_hash: nil,
                       updated_at: now,
                       seq: seq
                     ] ++ full_kw
@@ -2416,10 +2417,10 @@ defmodule Engram.Notes do
       Enum.each(real_note_updates, fn {note, old_note_path, new_path, _folder, _title} ->
         _ =
           Enqueue.enqueue(
-            Engram.Workers.EmbedNote.new_debounced(note.id,
+            Engram.Workers.RepathNoteIndex.new_debounced(note.id,
               old_path_hmac: old_path_hmac_b64!(user, old_note_path)
             ),
-            "embed_note"
+            "repath_note_index"
           )
 
         :ok = broadcast_change(user.id, vault.id, "delete", old_note_path)

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -343,6 +343,33 @@ defmodule Engram.Vector.Qdrant do
   end
 
   @doc """
+  Exact count of points matching `{user_id, vault_id, path_hmac}`. Used by the
+  repath worker (#746) to confirm points exist before/after a payload PATCH and
+  to detect an embedded note whose points went missing.
+  """
+  def count_by_note(col \\ nil, user_id, vault_id, path_hmac) do
+    col = col || collection()
+
+    filter = %{
+      must: [
+        %{key: "user_id", match: %{value: user_id}},
+        %{key: "vault_id", match: %{value: vault_id}},
+        %{key: "path_hmac", match: %{value: path_hmac}}
+      ]
+    }
+
+    opts = [json: %{filter: filter, exact: true}] ++ req_opts()
+
+    instrument(:count, fn ->
+      case Req.post("#{base_url()}/collections/#{col}/points/count", opts) do
+        {:ok, %{status: 200, body: %{"result" => %{"count" => count}}}} -> {:ok, count}
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
+  end
+
+  @doc """
   Delete every point owned by `user_id` across all of their vaults. Used by
   the §C inactivity soft-delete path — single Qdrant call regardless of
   vault count.

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -243,6 +243,36 @@ defmodule Engram.Vector.Qdrant do
     end)
   end
 
+  @doc """
+  Patch (overwrite-or-add) payload keys on EVERY point matching the
+  `{user_id, vault_id, path_hmac}` filter — vectors untouched. The cost-free
+  way to re-path a note's points after a rename without re-running the
+  embedder (#746). Triple-scope is mandatory: filtering on `path_hmac` alone
+  could cross tenants if two users' folded HMACs collide.
+  """
+  def set_payload_by_filter(col \\ nil, user_id, vault_id, path_hmac, payload)
+      when is_map(payload) do
+    col = col || collection()
+
+    filter = %{
+      must: [
+        %{key: "user_id", match: %{value: user_id}},
+        %{key: "vault_id", match: %{value: vault_id}},
+        %{key: "path_hmac", match: %{value: path_hmac}}
+      ]
+    }
+
+    opts = [json: %{filter: filter, payload: payload}] ++ req_opts()
+
+    instrument(:set_payload, fn ->
+      case Req.post("#{base_url()}/collections/#{col}/points/payload", opts) do
+        {:ok, %{status: 200}} -> :ok
+        {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
+  end
+
   # #590: note-metadata fields that leaked as plaintext into payloads written
   # before the fix. Canonical list — the mix task and prod rpc both go through
   # delete_leaked_plaintext_keys/1 so this never drifts.

--- a/lib/engram/workers/repath_note_index.ex
+++ b/lib/engram/workers/repath_note_index.ex
@@ -1,0 +1,105 @@
+defmodule Engram.Workers.RepathNoteIndex do
+  @moduledoc """
+  Oban worker: re-paths a note's Qdrant points after a rename WITHOUT
+  re-embedding (#746). Point IDs are random UUIDs preserved across rename and
+  the payload AAD binds to point-UUID, so dense/sparse vectors and ciphertext
+  survive — only the plaintext `path_hmac`/`folder_hmac` filter-keys change.
+
+  Branches on the point count under the OLD path_hmac:
+
+    * count > 0                                -> PATCH new hmacs onto the points
+    * count == 0 and content_hash != embed_hash -> enqueue EmbedNote (embed fresh)
+    * count == 0 and content_hash == embed_hash -> warn: embedded note lost its
+      points (real inconsistency; reconciler #264 owns repair)
+
+  Shares the `:embed` queue with EmbedNote; repath jobs are cheap (no Voyage)
+  so they don't meaningfully starve embeds.
+  """
+
+  use Oban.Worker,
+    queue: :embed,
+    max_attempts: 5,
+    unique: [period: 120, keys: [:note_id, :old_path_hmac], states: :incomplete]
+
+  alias Engram.Indexing
+  alias Engram.Logger.Metadata
+  alias Engram.Notes.Enqueue
+  alias Engram.Notes.Note
+  alias Engram.Repo
+  alias Engram.Workers.EmbedNote
+
+  require Logger
+
+  @doc """
+  Build a deduped job. `old_path_hmac` is the base64 HMAC of the pre-rename
+  path (T3.2 — never plaintext). Scheduled a few seconds out so the rename
+  txn's broadcasts settle first; replaced on re-insert within the window.
+  """
+  def new_debounced(note_id, opts \\ []) do
+    args = %{note_id: note_id, old_path_hmac: Keyword.fetch!(opts, :old_path_hmac)}
+    new(args, schedule_in: 3, replace: [:scheduled_at])
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    note_id = args["note_id"]
+    old_path_hmac = args["old_path_hmac"]
+
+    # skip_tenant_check: trusted internal worker, scoped by note_id.
+    case Repo.get(Note, note_id, skip_tenant_check: true) do
+      nil ->
+        {:discard, "note #{note_id} not found"}
+
+      %Note{deleted_at: deleted_at} when deleted_at != nil ->
+        {:discard, "note #{note_id} is soft-deleted"}
+
+      note ->
+        case Indexing.count_points_by_path_hmac(note, old_path_hmac) do
+          {:ok, count} when count > 0 ->
+            case Indexing.repath_points(note, old_path_hmac) do
+              :ok ->
+                # #746 — Grafana proof that rename took the cheap path (0 Voyage).
+                :telemetry.execute(
+                  [:engram, :indexing, :repath, :ok],
+                  %{count: count},
+                  %{note_id: note.id}
+                )
+
+                :ok
+
+              other ->
+                other
+            end
+
+          {:ok, 0} ->
+            handle_no_points(note)
+
+          {:error, _} = err ->
+            err
+        end
+    end
+  end
+
+  # Zero points under the old path. Either the note still needs embedding
+  # (embed it fresh under the new path), or it claims to be embedded but its
+  # points vanished (a real inconsistency we surface, not silently swallow).
+  defp handle_no_points(%Note{content_hash: ch, embed_hash: eh} = note) when ch != eh do
+    _ = Enqueue.enqueue(EmbedNote.new_debounced(note.id), "embed_note")
+    :ok
+  end
+
+  defp handle_no_points(%Note{} = note) do
+    Logger.warning(
+      "repath found zero Qdrant points for embedded note #{note.id}",
+      Metadata.with_category(:warning, :search, note_id: note.id)
+    )
+
+    :telemetry.execute(
+      [:engram, :indexing, :repath, :missing_points],
+      %{count: 1},
+      %{note_id: note.id}
+    )
+
+    :ok
+  end
+end

--- a/lib/engram/workers/repath_note_index.ex
+++ b/lib/engram/workers/repath_note_index.ex
@@ -9,8 +9,14 @@ defmodule Engram.Workers.RepathNoteIndex do
 
     * count > 0                                -> PATCH new hmacs onto the points
     * count == 0 and content_hash != embed_hash -> enqueue EmbedNote (embed fresh)
-    * count == 0 and content_hash == embed_hash -> warn: embedded note lost its
-      points (real inconsistency; reconciler #264 owns repair)
+    * count == 0 and content_hash == embed_hash -> warn: benign on rapid multi-rename
+      (A→B→C) or when a content-edit EmbedNote wins the race; not an error
+
+  On repeated Qdrant failure (count or PATCH), Oban retries up to max_attempts.
+  On the final attempt, instead of discarding with stranded points, the worker
+  falls back to `EmbedNote` with `old_path_hmac` — which deletes old-path points
+  and re-embeds under the new path — so no points ever strand permanently. The
+  fallback emits `[:engram, :indexing, :repath, :fallback]` telemetry.
 
   Shares the `:embed` queue with EmbedNote; repath jobs are cheap (no Voyage)
   so they don't meaningfully starve embeds.
@@ -41,7 +47,7 @@ defmodule Engram.Workers.RepathNoteIndex do
   end
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
+  def perform(%Oban.Job{args: args} = job) do
     note_id = args["note_id"]
     old_path_hmac = args["old_path_hmac"]
 
@@ -67,15 +73,15 @@ defmodule Engram.Workers.RepathNoteIndex do
 
                 :ok
 
-              other ->
-                other
+              {:error, _} = err ->
+                maybe_fallback(job, note, old_path_hmac, err)
             end
 
           {:ok, 0} ->
             handle_no_points(note)
 
           {:error, _} = err ->
-            err
+            maybe_fallback(job, note, old_path_hmac, err)
         end
     end
   end
@@ -102,4 +108,31 @@ defmodule Engram.Workers.RepathNoteIndex do
 
     :ok
   end
+
+  # On the final attempt, fall back to EmbedNote (with old_path_hmac so it
+  # deletes old-path points AND re-embeds under the new path). This ensures no
+  # points ever strand under a stale path_hmac after all retries are exhausted.
+  defp maybe_fallback(%Oban.Job{attempt: a, max_attempts: m} = _job, note, old_path_hmac, _err)
+       when a >= m do
+    _ =
+      Enqueue.enqueue(
+        EmbedNote.new_debounced(note.id, old_path_hmac: old_path_hmac),
+        "embed_note"
+      )
+
+    Logger.warning(
+      "repath exhausted #{m} attempts for note #{note.id}; falling back to EmbedNote",
+      Metadata.with_category(:warning, :search, note_id: note.id)
+    )
+
+    :telemetry.execute(
+      [:engram, :indexing, :repath, :fallback],
+      %{count: 1},
+      %{note_id: note.id}
+    )
+
+    :ok
+  end
+
+  defp maybe_fallback(_job, _note, _old_path_hmac, err), do: err
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.536",
+      version: "0.5.537",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -580,6 +580,62 @@ defmodule Engram.IndexingTest do
     end
   end
 
+  # ---------------------------------------------------------------------------
+  # repath_points/2 + count_points_by_path_hmac/2 (#746)
+  # ---------------------------------------------------------------------------
+
+  describe "repath_points/2 + count_points_by_path_hmac/2 (#746)" do
+    setup do
+      bypass = Bypass.open()
+      Engram.ServiceConfig.put_override(:qdrant_url, "http://localhost:#{bypass.port}")
+      %{bypass: bypass}
+    end
+
+    test "repath_points PATCHes current path/folder hmac onto old-path points", %{bypass: bypass} do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+
+      note = %Engram.Notes.Note{
+        id: Ecto.UUID.generate(),
+        user_id: user.id,
+        vault_id: vault.id,
+        path_hmac: <<1, 2, 3>>,
+        folder_hmac: <<4, 5, 6>>
+      }
+
+      old_b64 = Base.encode64(<<9, 9, 9>>)
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+
+        assert decoded["payload"]["path_hmac"] == Base.encode64(<<1, 2, 3>>)
+        assert decoded["payload"]["folder_hmac"] == Base.encode64(<<4, 5, 6>>)
+
+        assert %{"key" => "path_hmac", "match" => %{"value" => ^old_b64}} =
+                 Enum.find(decoded["filter"]["must"], &(&1["key"] == "path_hmac"))
+
+        Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+      end)
+
+      assert :ok = Engram.Indexing.repath_points(note, old_b64)
+    end
+
+    test "count_points_by_path_hmac returns the count", %{bypass: bypass} do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      note = %Engram.Notes.Note{id: Ecto.UUID.generate(), user_id: user.id, vault_id: vault.id}
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": {"count": 2}}))
+      end)
+
+      assert {:ok, 2} = Engram.Indexing.count_points_by_path_hmac(note, Base.encode64(<<9>>))
+    end
+  end
+
   # Markdown with `n` distinct heading sections — each becomes at least one
   # chunk under the heading-aware chunker.
   defp big_sectioned_content(n) do

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -1,5 +1,6 @@
 defmodule Engram.NotesTest do
   use Engram.DataCase, async: true
+  use Oban.Testing, repo: Engram.Repo
 
   alias Engram.Notes
 
@@ -1761,6 +1762,50 @@ defmodule Engram.NotesTest do
         event: "note_changed",
         payload: %{"event_type" => "delete", "path" => "Watched/a.md"}
       }
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #746 — rename must repath Qdrant points, not re-embed through Voyage
+  # ---------------------------------------------------------------------------
+
+  describe "rename does not re-embed (#746)" do
+    test "single-note rename enqueues RepathNoteIndex, not EmbedNote, and keeps embed_hash",
+         %{user: user, vault: vault} do
+      note =
+        Engram.Fixtures.insert_note!(user, vault, %{path: "A/Note.md", content: "# x\n\nbody"})
+
+      import Ecto.Query
+
+      from(n in Engram.Notes.Note, where: n.id == ^note.id)
+      |> Engram.Repo.update_all([set: [embed_hash: note.content_hash]], skip_tenant_check: true)
+
+      assert {:ok, _} = Engram.Notes.rename_note(user, vault, "A/Note.md", "B/Note.md")
+
+      assert_enqueued(worker: Engram.Workers.RepathNoteIndex, args: %{note_id: note.id})
+      refute_enqueued(worker: Engram.Workers.EmbedNote)
+
+      reloaded = Engram.Repo.get!(Engram.Notes.Note, note.id, skip_tenant_check: true)
+      assert reloaded.embed_hash == note.content_hash
+    end
+
+    test "folder rename enqueues RepathNoteIndex for each note, not EmbedNote",
+         %{user: user, vault: vault} do
+      note =
+        Engram.Fixtures.insert_note!(user, vault, %{path: "Old/Note.md", content: "# x\n\nbody"})
+
+      import Ecto.Query
+
+      from(n in Engram.Notes.Note, where: n.id == ^note.id)
+      |> Engram.Repo.update_all([set: [embed_hash: note.content_hash]], skip_tenant_check: true)
+
+      assert {:ok, _} = Engram.Notes.rename_folder(user, vault, "Old", "New")
+
+      assert_enqueued(worker: Engram.Workers.RepathNoteIndex, args: %{note_id: note.id})
+      refute_enqueued(worker: Engram.Workers.EmbedNote)
+
+      reloaded = Engram.Repo.get!(Engram.Notes.Note, note.id, skip_tenant_check: true)
+      assert reloaded.embed_hash == note.content_hash
     end
   end
 end

--- a/test/engram/vector/qdrant_test.exs
+++ b/test/engram/vector/qdrant_test.exs
@@ -283,6 +283,33 @@ defmodule Engram.Vector.QdrantTest do
     end
   end
 
+  describe "count_by_note/4" do
+    test "returns the exact point count for the filter", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+
+        assert decoded["exact"] == true
+        must = decoded["filter"]["must"]
+        assert %{"key" => "path_hmac", "match" => %{"value" => "oldp=="}} in must
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": {"count": 3}}))
+      end)
+
+      assert {:ok, 3} = Qdrant.count_by_note("engram_notes", "7", "9", "oldp==")
+    end
+
+    test "returns {:error, _} on non-200", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
+        Plug.Conn.send_resp(conn, 503, ~s({"status":"error"}))
+      end)
+
+      assert {:error, {503, _}} = Qdrant.count_by_note("engram_notes", "7", "9", "oldp==")
+    end
+  end
+
   describe "search/3" do
     test "returns search results", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/collections/test_col/points/query", fn conn ->

--- a/test/engram/vector/qdrant_test.exs
+++ b/test/engram/vector/qdrant_test.exs
@@ -768,6 +768,71 @@ defmodule Engram.Vector.QdrantTest do
     end
   end
 
+  describe "set_payload_by_filter/5" do
+    test "PATCHes payload on points matching the user/vault/path_hmac filter", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+
+        assert decoded["payload"] == %{"path_hmac" => "newp==", "folder_hmac" => "newf=="}
+
+        must = decoded["filter"]["must"]
+        assert %{"key" => "user_id", "match" => %{"value" => "7"}} in must
+        assert %{"key" => "vault_id", "match" => %{"value" => "9"}} in must
+        assert %{"key" => "path_hmac", "match" => %{"value" => "oldp=="}} in must
+        # No explicit point-id list — this is a filter-scoped patch.
+        refute Map.has_key?(decoded, "points")
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": true}))
+      end)
+
+      assert :ok =
+               Qdrant.set_payload_by_filter("engram_notes", "7", "9", "oldp==", %{
+                 "path_hmac" => "newp==",
+                 "folder_hmac" => "newf=="
+               })
+    end
+
+    test "returns {:error, {status, body}} on non-200", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(500, ~s({"status":"error"}))
+      end)
+
+      assert {:error, {500, _}} =
+               Qdrant.set_payload_by_filter("engram_notes", "7", "9", "oldp==", %{
+                 "path_hmac" => "x"
+               })
+    end
+
+    # Tenant-isolation guard (#746): even if two users' folded path_hmacs
+    # collide, the filter is scoped by the caller's user_id + vault_id, so a
+    # PATCH for user 7 can never touch user 8's points. The typed required
+    # args make a path_hmac-only filter impossible to express.
+    test "scopes the PATCH to the caller's user_id/vault_id (no cross-tenant)", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        must = Jason.decode!(body)["filter"]["must"]
+
+        assert %{"key" => "user_id", "match" => %{"value" => "7"}} in must
+        assert %{"key" => "vault_id", "match" => %{"value" => "9"}} in must
+        # Crucially NOT user 8 — the colliding tenant.
+        refute %{"key" => "user_id", "match" => %{"value" => "8"}} in must
+
+        Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+      end)
+
+      # Same colliding path_hmac "collide==" as a hypothetical user 8 — still scoped to 7/9.
+      assert :ok =
+               Qdrant.set_payload_by_filter("engram_notes", "7", "9", "collide==", %{
+                 "path_hmac" => "x"
+               })
+    end
+  end
+
   describe "authentication" do
     test "sends api-key header when qdrant_api_key is configured", %{bypass: bypass} do
       ServiceConfig.put_override(:qdrant_api_key, "test-qdrant-key")

--- a/test/engram/workers/repath_note_index_test.exs
+++ b/test/engram/workers/repath_note_index_test.exs
@@ -110,6 +110,17 @@ defmodule Engram.Workers.RepathNoteIndexTest do
              })
   end
 
+  test "discards when note is soft-deleted", %{note: note} do
+    from(n in Note, where: n.id == ^note.id)
+    |> Repo.update_all([set: [deleted_at: DateTime.utc_now()]], skip_tenant_check: true)
+
+    assert {:discard, _} =
+             perform_job(RepathNoteIndex, %{
+               note_id: note.id,
+               old_path_hmac: Base.encode64(<<7>>)
+             })
+  end
+
   test "returns error so Oban retries when Qdrant count fails", %{bypass: bypass, note: note} do
     Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
       Plug.Conn.send_resp(conn, 503, ~s({"status":"error"}))
@@ -117,5 +128,45 @@ defmodule Engram.Workers.RepathNoteIndexTest do
 
     assert {:error, _} =
              perform_job(RepathNoteIndex, %{note_id: note.id, old_path_hmac: Base.encode64(<<7>>)})
+  end
+
+  test "non-final attempt with Qdrant 503 returns error (Oban retries, no EmbedNote)", %{
+    bypass: bypass,
+    note: note
+  } do
+    Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
+      Plug.Conn.send_resp(conn, 503, ~s({"status":"error"}))
+    end)
+
+    assert {:error, _} =
+             perform_job(
+               RepathNoteIndex,
+               %{note_id: note.id, old_path_hmac: Base.encode64(<<7>>)},
+               attempt: 1,
+               max_attempts: 5
+             )
+
+    refute_enqueued(worker: EmbedNote)
+  end
+
+  test "final attempt with Qdrant 503 falls back to EmbedNote and returns :ok", %{
+    bypass: bypass,
+    note: note
+  } do
+    old_path_hmac = Base.encode64(<<7>>)
+
+    Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
+      Plug.Conn.send_resp(conn, 503, ~s({"status":"error"}))
+    end)
+
+    assert :ok =
+             perform_job(
+               RepathNoteIndex,
+               %{note_id: note.id, old_path_hmac: old_path_hmac},
+               attempt: 5,
+               max_attempts: 5
+             )
+
+    assert_enqueued(worker: EmbedNote, args: %{note_id: note.id, old_path_hmac: old_path_hmac})
   end
 end

--- a/test/engram/workers/repath_note_index_test.exs
+++ b/test/engram/workers/repath_note_index_test.exs
@@ -1,0 +1,121 @@
+defmodule Engram.Workers.RepathNoteIndexTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  import Ecto.Query, only: [from: 2]
+  import Mox
+
+  alias Engram.Crypto
+  alias Engram.Notes.Note
+  alias Engram.Repo
+  alias Engram.Workers.{EmbedNote, RepathNoteIndex}
+
+  setup :verify_on_exit!
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:engram, :qdrant_url, "http://localhost:#{bypass.port}")
+    on_exit(fn -> Application.delete_env(:engram, :qdrant_url) end)
+
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    vault = insert(:vault, user: user)
+
+    note =
+      Engram.Fixtures.insert_note!(user, vault, %{
+        path: "New/Hello.md",
+        content: "# Hello\n\nWorld."
+      })
+
+    # Simulate an already-embedded note: embed_hash == content_hash.
+    from(n in Note, where: n.id == ^note.id)
+    |> Repo.update_all([set: [embed_hash: note.content_hash]], skip_tenant_check: true)
+
+    %{bypass: bypass, note: %{note | embed_hash: note.content_hash}}
+  end
+
+  defp stub_count(bypass, count) do
+    Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, ~s({"result": {"count": #{count}}}))
+    end)
+  end
+
+  test "PATCHes payload, emits repath:ok telemetry, makes no embedder call", %{
+    bypass: bypass,
+    note: note
+  } do
+    stub_count(bypass, 2)
+
+    Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      decoded = Jason.decode!(body)
+      assert decoded["payload"]["path_hmac"] == Base.encode64(note.path_hmac)
+      Plug.Conn.send_resp(conn, 200, ~s({"result": true}))
+    end)
+
+    ref = make_ref()
+    test_pid = self()
+
+    :telemetry.attach(
+      "repath-ok-#{inspect(ref)}",
+      [:engram, :indexing, :repath, :ok],
+      fn _event, measurements, _meta, _ -> send(test_pid, {ref, measurements}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach("repath-ok-#{inspect(ref)}") end)
+
+    # No Mox expectation on Engram.MockEmbedder — if it embeds, the test fails.
+    assert :ok =
+             perform_job(RepathNoteIndex, %{note_id: note.id, old_path_hmac: Base.encode64(<<7>>)})
+
+    assert_received {^ref, %{count: 2}}
+  end
+
+  test "enqueues EmbedNote when zero points and content not yet embedded", %{
+    bypass: bypass,
+    note: note
+  } do
+    # Make the note look unembedded: clear embed_hash.
+    from(n in Note, where: n.id == ^note.id)
+    |> Repo.update_all([set: [embed_hash: nil]], skip_tenant_check: true)
+
+    stub_count(bypass, 0)
+
+    assert :ok =
+             perform_job(RepathNoteIndex, %{note_id: note.id, old_path_hmac: Base.encode64(<<7>>)})
+
+    assert_enqueued(worker: EmbedNote, args: %{note_id: note.id})
+  end
+
+  test "warns (no enqueue) when zero points but note is marked embedded", %{
+    bypass: bypass,
+    note: note
+  } do
+    stub_count(bypass, 0)
+
+    assert :ok =
+             perform_job(RepathNoteIndex, %{note_id: note.id, old_path_hmac: Base.encode64(<<7>>)})
+
+    refute_enqueued(worker: EmbedNote)
+  end
+
+  test "discards when note is missing" do
+    assert {:discard, _} =
+             perform_job(RepathNoteIndex, %{
+               note_id: "00000000-0000-0000-0000-000000999999",
+               old_path_hmac: Base.encode64(<<7>>)
+             })
+  end
+
+  test "returns error so Oban retries when Qdrant count fails", %{bypass: bypass, note: note} do
+    Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
+      Plug.Conn.send_resp(conn, 503, ~s({"status":"error"}))
+    end)
+
+    assert {:error, _} =
+             perform_job(RepathNoteIndex, %{note_id: note.id, old_path_hmac: Base.encode64(<<7>>)})
+  end
+end


### PR DESCRIPTION
Closes #746.

## Problem

Renaming a folder (or moving/renaming a single note) re-embedded **every** affected note through Voyage AI, even though note **content is unchanged** — only the path changed. Two coupled bugs forced it: the rename cleared `embed_hash: nil`, and the `EmbedNote` enqueue passed `old_path_hmac`, which bypassed the content-hash idempotency guard → delete old Qdrant points + recompute dense vectors via Voyage + re-insert.

## Why re-embedding was unnecessary

Nothing path-derived lives in the vectors or ciphertext: point IDs are random UUIDs (preserved across rename), the payload AAD binds to the point UUID (not the path), and sparse keyword vectors are content-only. The **only** things that change on rename are two plaintext payload filter-keys: `path_hmac` and `folder_hmac`.

## What this does

Re-paths the existing Qdrant points in place via a payload PATCH instead of re-embedding:

- `Qdrant.set_payload_by_filter/5` — filter-scoped payload PATCH (tenant triple required as discrete args)
- `Qdrant.count_by_note/4` — exact point count by filter
- `Indexing.repath_points/2` + `count_points_by_path_hmac/2` — wrappers
- `Engram.Workers.RepathNoteIndex` — Oban worker; branches on point count:
  - count > 0 → PATCH `path_hmac`/`folder_hmac` to the row's current values, emit `[:engram,:indexing,:repath,:ok]` telemetry, **0 Voyage calls**
  - count == 0 & content changed → enqueue `EmbedNote` (self-heal, embed fresh under new path)
  - count == 0 & embedded → warn telemetry (inconsistency surfaced, not swallowed)
  - **exhaustion backstop:** if the PATCH/count fails all 5 Oban attempts, fall back to `EmbedNote` **with `old_path_hmac`** (delete-old + re-embed = today's behavior) so points never strand
- `Engram.Notes` — both rename sites (single-note + folder) stop clearing `embed_hash` and enqueue `RepathNoteIndex` instead of `EmbedNote`; `seq`/`updated_at` bump + broadcasts preserved

**Net:** folder rename of N notes = N cheap Qdrant PATCHes, **0 Voyage calls**.

## Scope

- **In:** folder rename + single-note move/rename (both shared the wasteful pattern).
- **Out:** attachments — not in Qdrant, nothing to repath.

## Tests

TDD throughout: 8 worker tests (incl. zero-Voyage assertion via no-Mox-expectation, tenant isolation, backstop on final attempt), Qdrant client + Indexing tests, and rename-site context tests asserting `RepathNoteIndex` enqueued / `EmbedNote` not / `embed_hash` preserved for both rename types. Full suite green except one **pre-existing, unrelated flake**: `test/engram/notes/helpers_test.exs:63` (`refute_receive` UTF-8 scrub telemetry) — a global `:telemetry` handler in an `async: true` module races with concurrent scrubs; file + test are byte-identical to `main`, passes in isolation (48/48). Filed as a follow-up.

## Follow-ups (filed separately)

- PromEx plugin to register the `[:engram,:indexing,:repath,*]` telemetry so the zero-Voyage proof reaches Grafana
- `helpers_test.exs` scrub-telemetry test isolation (pre-existing flake)
- Minor test-coverage: tenant-filter assertions in count tests; PATCH-exhaustion path test

Design spec: Engram vault `50 Engineering/_Superpowers Specs/2026-06-25-rename-repath-no-reembed-design.md`. Reviewed via subagent-driven development (per-task + whole-branch opus review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
