### PR TITLE
feat(obs): PromEx plugin for rename-repath telemetry (#753)

### DIFF
--- a/lib/engram/prom_ex.ex
+++ b/lib/engram/prom_ex.ex
@@ -28,6 +28,7 @@ defmodule Engram.PromEx do
       Engram.PromEx.Search,
       Engram.PromEx.Mcp,
       Engram.PromEx.Crypto,
+      Engram.PromEx.Indexing,
       Engram.PromEx.Notes,
       Engram.PromEx.Reliability,
       Engram.PromEx.Usage,

--- a/lib/engram/prom_ex/indexing.ex
+++ b/lib/engram/prom_ex/indexing.ex
@@ -1,0 +1,59 @@
+defmodule Engram.PromEx.Indexing do
+  @moduledoc """
+  PromEx plugin for index-maintenance telemetry — currently the rename repath
+  worker (`Engram.Workers.RepathNoteIndex`, #746/#753).
+
+  Subscribes to:
+
+    * `[:engram, :indexing, :repath, :stop]` — `%{count}`, metadata
+      `%{outcome: :ok | :missing_points | :fallback}`:
+        - `:ok`             — points PATCHed in place (the cheap, 0-Voyage path);
+          `count` is the number of points repathed.
+        - `:missing_points` — embedded note had zero points under the old path
+          (benign on rapid multi-rename; a real inconsistency otherwise).
+        - `:fallback`       — repath exhausted retries and fell back to a full
+          re-embed; `count` is 1 (an event tick).
+
+  Metrics:
+
+    * `engram_prom_ex_indexing_repath_total` — counter of repath events by
+      `:outcome`. Alert on `:fallback` / `:missing_points` rate; the `:ok` rate
+      is the "renames took the cheap path" signal.
+    * `engram_prom_ex_indexing_repath_points_total` — sum of `count` by
+      `:outcome`. For `:ok` this is total points repathed = the zero-Voyage
+      volume saved.
+
+  Cardinality contract: only `:outcome` (closed enum). NEVER add note_id,
+  user_id, or vault_id.
+  """
+
+  use PromEx.Plugin
+
+  @repath_stop_event [:engram, :indexing, :repath, :stop]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :indexing)
+
+    Event.build(
+      :engram_indexing_event_metrics,
+      [
+        counter(
+          metric_prefix ++ [:repath, :total],
+          event_name: @repath_stop_event,
+          description: "Rename repath outcomes from the RepathNoteIndex worker.",
+          tags: [:outcome]
+        ),
+        sum(
+          metric_prefix ++ [:repath, :points, :total],
+          event_name: @repath_stop_event,
+          measurement: :count,
+          description:
+            "Qdrant points repathed in place by outcome (0-Voyage volume saved on :ok).",
+          tags: [:outcome]
+        )
+      ]
+    )
+  end
+end

--- a/lib/engram/workers/repath_note_index.ex
+++ b/lib/engram/workers/repath_note_index.ex
@@ -15,8 +15,11 @@ defmodule Engram.Workers.RepathNoteIndex do
   On repeated Qdrant failure (count or PATCH), Oban retries up to max_attempts.
   On the final attempt, instead of discarding with stranded points, the worker
   falls back to `EmbedNote` with `old_path_hmac` — which deletes old-path points
-  and re-embeds under the new path — so no points ever strand permanently. The
-  fallback emits `[:engram, :indexing, :repath, :fallback]` telemetry.
+  and re-embeds under the new path — so no points ever strand permanently.
+
+  Every branch emits one `[:engram, :indexing, :repath, :stop]` telemetry event
+  with `%{count}` and a bounded `%{outcome: :ok | :missing_points | :fallback}`
+  tag, mapped to Prometheus by `Engram.PromEx.Indexing` (#753).
 
   Shares the `:embed` queue with EmbedNote; repath jobs are cheap (no Voyage)
   so they don't meaningfully starve embeds.
@@ -65,12 +68,8 @@ defmodule Engram.Workers.RepathNoteIndex do
             case Indexing.repath_points(note, old_path_hmac) do
               :ok ->
                 # #746 — Grafana proof that rename took the cheap path (0 Voyage).
-                :telemetry.execute(
-                  [:engram, :indexing, :repath, :ok],
-                  %{count: count},
-                  %{note_id: note.id}
-                )
-
+                # `count` is the number of points patched.
+                emit_repath(:ok, count)
                 :ok
 
               {:error, _} = err ->
@@ -100,12 +99,7 @@ defmodule Engram.Workers.RepathNoteIndex do
       Metadata.with_category(:warning, :search, note_id: note.id)
     )
 
-    :telemetry.execute(
-      [:engram, :indexing, :repath, :missing_points],
-      %{count: 1},
-      %{note_id: note.id}
-    )
-
+    emit_repath(:missing_points, 1)
     :ok
   end
 
@@ -125,14 +119,21 @@ defmodule Engram.Workers.RepathNoteIndex do
       Metadata.with_category(:warning, :search, note_id: note.id)
     )
 
-    :telemetry.execute(
-      [:engram, :indexing, :repath, :fallback],
-      %{count: 1},
-      %{note_id: note.id}
-    )
-
+    emit_repath(:fallback, 1)
     :ok
   end
 
   defp maybe_fallback(_job, _note, _old_path_hmac, err), do: err
+
+  # Single repath telemetry event tagged by a bounded `:outcome` so PromEx maps
+  # one counter + one points-sum (see `Engram.PromEx.Indexing`). Cardinality
+  # contract: `:outcome` only — never note_id/user_id/vault_id. `count` is the
+  # number of points patched on `:ok`, and 1 (an event tick) otherwise.
+  defp emit_repath(outcome, count) do
+    :telemetry.execute(
+      [:engram, :indexing, :repath, :stop],
+      %{count: count},
+      %{outcome: outcome}
+    )
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.537",
+      version: "0.5.538",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/prom_ex/indexing_test.exs
+++ b/test/engram/prom_ex/indexing_test.exs
@@ -1,0 +1,45 @@
+defmodule Engram.PromEx.IndexingTest do
+  @moduledoc """
+  Unit-tests the metric DEFINITIONS the plugin registers — that the repath
+  `:stop` event maps to an outcome-tagged counter + points-sum with the
+  expected names. This guards the producer/consumer contract (event name,
+  measurement key, cardinality) without standing up a full PromEx supervision
+  tree.
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.PromEx.Indexing
+
+  @repath_stop_event [:engram, :indexing, :repath, :stop]
+
+  test "event_metrics/1 maps the repath :stop event to outcome-tagged metrics" do
+    built = Indexing.event_metrics(otp_app: :engram)
+    metrics = built.metrics
+
+    assert metrics != [], "plugin should register at least one metric"
+
+    # Every metric subscribes to the single repath :stop event...
+    assert Enum.all?(metrics, &(&1.event_name == @repath_stop_event)),
+           "all repath metrics must subscribe to #{inspect(@repath_stop_event)}"
+
+    # ...and is tagged ONLY by the bounded :outcome (cardinality contract —
+    # never note_id/user_id/vault_id).
+    assert Enum.all?(metrics, &(&1.tags == [:outcome])),
+           "repath metrics must be tagged by [:outcome] only, got: " <>
+             inspect(Enum.map(metrics, & &1.tags))
+
+    names = Enum.map(metrics, & &1.name)
+
+    assert [:engram, :prom_ex, :indexing, :repath, :total] in names
+    assert [:engram, :prom_ex, :indexing, :repath, :points, :total] in names
+
+    counter = Enum.find(metrics, &match?(%Telemetry.Metrics.Counter{}, &1))
+    sum = Enum.find(metrics, &match?(%Telemetry.Metrics.Sum{}, &1))
+
+    assert counter, "expected a Counter for repath event total (events/sec by outcome)"
+    assert sum, "expected a Sum for repath points total"
+
+    # The points-sum reads the `count` measurement (points patched on :ok).
+    assert sum.measurement == :count
+  end
+end

--- a/test/engram/workers/repath_note_index_test.exs
+++ b/test/engram/workers/repath_note_index_test.exs
@@ -59,19 +59,20 @@ defmodule Engram.Workers.RepathNoteIndexTest do
     test_pid = self()
 
     :telemetry.attach(
-      "repath-ok-#{inspect(ref)}",
-      [:engram, :indexing, :repath, :ok],
-      fn _event, measurements, _meta, _ -> send(test_pid, {ref, measurements}) end,
+      "repath-stop-#{inspect(ref)}",
+      [:engram, :indexing, :repath, :stop],
+      fn _event, measurements, meta, _ -> send(test_pid, {ref, measurements, meta}) end,
       nil
     )
 
-    on_exit(fn -> :telemetry.detach("repath-ok-#{inspect(ref)}") end)
+    on_exit(fn -> :telemetry.detach("repath-stop-#{inspect(ref)}") end)
 
     # No Mox expectation on Engram.MockEmbedder — if it embeds, the test fails.
     assert :ok =
              perform_job(RepathNoteIndex, %{note_id: note.id, old_path_hmac: Base.encode64(<<7>>)})
 
-    assert_received {^ref, %{count: 2}}
+    # Single event tagged by outcome; measurement carries the patched point count.
+    assert_received {^ref, %{count: 2}, %{outcome: :ok}}
   end
 
   test "enqueues EmbedNote when zero points and content not yet embedded", %{


### PR DESCRIPTION
Closes #753.

Follow-up to #746 (rename repath). The repath worker emitted telemetry but no PromEx plugin mapped it, so the "rename took the cheap path (0 Voyage)" signal and the fallback/missing-points alarms never reached Grafana.

## Changes

**1. Single tagged event (worker refactor).** Collapsed the 3 separate repath events (`:ok` / `:missing_points` / `:fallback`) into one `[:engram,:indexing,:repath,:stop]` carrying `%{count}` + a bounded `%{outcome: :ok | :missing_points | :fallback}` tag — matching the `qdrant`/`crypto` plugin convention (one metric, filterable by outcome). No external consumers existed yet, so the event-shape change is safe.

**2. `Engram.PromEx.Indexing` plugin.** Maps the `:stop` event to:
- `engram_prom_ex_indexing_repath_total` — counter of repath events by `:outcome` (alert on `:fallback`/`:missing_points` rate; `:ok` rate = cheap-path signal)
- `engram_prom_ex_indexing_repath_points_total` — sum of `count` by `:outcome` (for `:ok`, total points repathed = zero-Voyage volume saved)

Registered in `Engram.PromEx.plugins/0`. **Cardinality contract: `:outcome` only** — never note_id/user_id/vault_id (matches the other plugins' contracts).

## Tests

- New `Engram.PromEx.IndexingTest` asserts `event_metrics/1` registers the counter + sum, both subscribed to the `:stop` event, tagged `[:outcome]` only, with the expected metric names and `:count` measurement. (Establishes the first PromEx-plugin unit test — none existed.)
- Updated the worker's `:ok` telemetry test to the new event + `%{outcome: :ok}`.
- Full suite green (3137 tests).

Grafana dashboard/alert wiring lives in engram-infra and is out of scope here — this PR makes the metrics exist on `/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
