### PR TITLE
fix(test): scope utf8_scrub telemetry handlers to own process (#754)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.539",
+      version: "0.5.540",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/helpers_test.exs
+++ b/test/engram/notes/helpers_test.exs
@@ -39,7 +39,12 @@ defmodule Engram.Notes.HelpersTest do
         handler,
         [:engram, :notes, :utf8_scrub],
         fn _event, measurements, metadata, pid ->
-          send(pid, {:scrub_telemetry, measurements, metadata})
+          # Handlers run synchronously in the process that called
+          # `:telemetry.execute`, so `self()` here is the emitter. Forward only
+          # events emitted by THIS test's own process — otherwise a concurrent
+          # async test that scrubs invalid UTF-8 trips this global handler and
+          # leaks into our mailbox, flaking `refute_receive` (#754).
+          if self() == pid, do: send(pid, {:scrub_telemetry, measurements, metadata})
         end,
         self()
       )
@@ -61,6 +66,22 @@ defmodule Engram.Notes.HelpersTest do
     test "does not emit telemetry for valid input (fast path)" do
       assert Helpers.scrub_utf8("clean", :write) == "clean"
       refute_receive {:scrub_telemetry, _, _}
+    end
+
+    test "ignores scrub events emitted by other processes (no cross-test leak, #754)" do
+      # Reproduces the flake deterministically: a DIFFERENT process scrubs
+      # invalid input while our handler is attached. :telemetry handlers run
+      # synchronously in the caller of `:telemetry.execute`, so before the fix
+      # this test's *global* handler fired in the foreign process and leaked a
+      # `{:scrub_telemetry, ...}` into our mailbox — exactly how a concurrent
+      # async test tripped the `refute_receive` above under load. The handler
+      # must only forward events from its own test's process.
+      task = Task.async(fn -> Helpers.scrub_utf8("x" <> <<0xE2>>, :read) end)
+      assert Task.await(task) == "x�"
+
+      # The scrub above (in the task process) already ran; if the handler had
+      # leaked it, the message would be in our mailbox now.
+      refute_received {:scrub_telemetry, _, _}
     end
 
     test "logs a warning on the write boundary (new corruption is actionable)" do

--- a/test/engram/notes/utf8_backfill_test.exs
+++ b/test/engram/notes/utf8_backfill_test.exs
@@ -81,7 +81,10 @@ defmodule Engram.Notes.Utf8BackfillTest do
     :telemetry.attach(
       handler,
       [:engram, :notes, :utf8_scrub],
-      fn _e, _meas, meta, pid -> send(pid, {:scrub, meta}) end,
+      # Forward only events from this test's own process — a concurrent async
+      # test scrubbing on the :write boundary would otherwise leak into the
+      # `refute_received` below (#754; handlers run in the emitter's process).
+      fn _e, _meas, meta, pid -> if self() == pid, do: send(pid, {:scrub, meta}) end,
       self()
     )
 


### PR DESCRIPTION
Closes #754.

## Root cause

`helpers_test.exs` and `utf8_backfill_test.exs` (both `async: true`) attach a **global** `:telemetry` handler on `[:engram, :notes, :utf8_scrub]` and forward events to the test pid. `:telemetry` handlers run synchronously **in the process that calls `:telemetry.execute`** — so when a *different* async test scrubs invalid UTF-8 (e.g. helpers_test's own write-boundary case), it trips these handlers and leaks a `{:scrub*, ...}` message into the wrong test's mailbox. That intermittently fails the `refute_receive`/`refute_received` assertions ("does not emit telemetry for valid input"). It surfaced under the higher async load added by #746/#753; the files are otherwise byte-identical to `main` and pass in isolation.

## Fix

Guard each handler with `if self() == pid` so it only forwards events emitted **by its own test's process**. Airtight regardless of ExUnit scheduling, and keeps both modules `async: true`.

Adds a **deterministic regression test**: a separate process scrubs invalid input while the handler is attached; the handler must ignore it. This fails without the guard (reproduces the leak on demand) and passes with it — so the fix is proven, not rerun-until-green.

## Scope

Fixes the two `utf8_scrub` `refute` sites (same event, same bug). Left as a lower-risk follow-up: `enqueue_test.exs` uses the same handler shape on `[:engram,:notes,:enqueue,:failed]`, but that event only fires on enqueue *failure* — unlikely to be emitted by concurrent tests, so low flake risk.

Full suite green (3138 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
