### PR TITLE
fix(worktree): stop seeding _build into new worktrees (cross-worktree contamination)

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
 # Post-checkout hook: when a fresh worktree is created via `git worktree add`,
-# hardlink `deps/`, `_build/`, and `frontend/node_modules/` from the canonical
-# checkout so the first `mix compile` / lint / pre-push doesn't take ~5 minutes
-# rebuilding everything from scratch.
+# hardlink `deps/` and `frontend/node_modules/` from the canonical checkout so
+# the first lint / pre-push / bun step doesn't re-fetch everything (node_modules
+# alone is ~1GB).
 #
-# Hardlinks are inode-shared — instant copy, zero disk overhead. Mix's
-# incremental compiler sees identical mtimes and skips work for unchanged
-# files; only files the new branch actually edited recompile. When a build
-# tool writes (mix, bun), it creates a NEW file rather than mutating in-place,
-# so the hardlink chain detaches naturally — no cross-worktree corruption risk.
+# Hardlinks are inode-shared — instant, zero disk overhead. This is safe ONLY
+# for fetched *sources* (deps, node_modules): build tools don't rewrite those in
+# place, so no worktree can corrupt another's copy.
+#
+# `_build/` is deliberately NOT seeded. It holds compiled, env- and
+# dependency-specific artifacts, and mix rewrites some of them (notably
+# `lib/<app>/ebin/<app>.app`) IN PLACE. Hardlinking shared that inode, so a
+# sibling worktree with different deps (e.g. one carrying `y_ex`) silently
+# poisoned every other worktree's `<app>.app`, and a half-built canonical
+# propagated missing yecc `.beam`s (expo/jose) — recurring, hard-to-diagnose
+# "module not available" boot failures. Copying instead of hardlinking is no
+# safer here: a sibling created with the old hook keeps rewriting the canonical
+# through its existing hardlinks, so any seed from the canonical can be
+# re-poisoned. The robust fix is to build `_build` fresh per worktree — `deps/`
+# is hardlinked, so the first `mix compile` compiles from local source (~3-4 min
+# once) and never inherits another worktree's state.
 #
 # Why a hook (and not a wrapper script): `git worktree add` fires post-checkout
 # directly. The hook runs BEFORE any human or AI agent touches the new tree,
@@ -49,5 +60,4 @@ link_if_missing() {
 }
 
 link_if_missing deps
-link_if_missing _build
 link_if_missing frontend/node_modules

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.540",
+      version: "0.5.541",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

The `.githooks/post-checkout` hook hardlinks `deps/`, `_build/`, and `frontend/node_modules/` from the canonical checkout into each new worktree to skip a cold rebuild. The hook's premise — "build tools only ever write *new* files, so hardlinks detach naturally" — is **false for `_build/`**:

- mix rewrites some compiled artifacts (notably `lib/<app>/ebin/<app>.app`) **in place**, so the shared inode lets a sibling worktree with different deps (e.g. one carrying `y_ex`) silently poison **every other worktree's** `engram.app`.
- A partially-built canonical propagates **missing yecc `.beam`s** (`:expo_po_parser`, `:jose_jwk`).

Net effect: recurring, hard-to-diagnose `** (Mix) Could not start application X` / `function :Y.f/1 is undefined (module not available)` boot failures on **every** newly-created worktree (hit 4× in one session; each needs a manual `mix deps.compile --force` to clear).

## Fix

Stop seeding `_build/`. Keep hardlinking `deps/` and `frontend/node_modules/` — those are fetched *sources*, never rewritten in place, so sharing inodes is safe and keeps disk near-zero (node_modules is ~1GB).

Each worktree now builds `_build` fresh from the hardlinked `deps` source. First `mix compile` costs ~3-4 min once, then incremental as usual — in exchange for builds that **never inherit another worktree's state**.

**Why not copy `_build` instead of hardlink** (which would keep the cold-build optimization): a sibling created with the *old* hook keeps rewriting the canonical through its existing hardlinks, so any seed from the canonical can be re-poisoned. Building fresh is the only approach immune to that.

## Verification

`_build` is only ~69M and the hook change is shell-only (no app-code impact), so validated by behavior: created a throwaway worktree under the patched hook and confirmed —
- `_build` is **not** seeded; `deps` + `node_modules` **are** hardlinked.
- A from-scratch `mix compile` exits 0, the built `engram.app` has **0 `y_ex` refs**, and `expo_po_parser.beam` + `jose_jwk.beam` are **present**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
