### PR TITLE
test(repath): close tenant-scoping + PATCH-exhaustion coverage gaps (#755)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.542",
+      version: "0.5.543",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/indexing_test.exs
+++ b/test/engram/indexing_test.exs
@@ -626,13 +626,25 @@ defmodule Engram.IndexingTest do
       vault = insert(:vault, user: user)
       note = %Engram.Notes.Note{id: Ecto.UUID.generate(), user_id: user.id, vault_id: vault.id}
 
+      old_b64 = Base.encode64(<<9>>)
+
       Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/count", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        must = Jason.decode!(body)["filter"]["must"]
+
+        # The wrapper must forward the full tenant triple to Qdrant (#755).
+        assert %{"key" => "user_id", "match" => %{"value" => to_string(user.id)}} in must
+        assert %{"key" => "vault_id", "match" => %{"value" => to_string(vault.id)}} in must
+
+        assert %{"key" => "path_hmac", "match" => %{"value" => ^old_b64}} =
+                 Enum.find(must, &(&1["key"] == "path_hmac"))
+
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.send_resp(200, ~s({"result": {"count": 2}}))
       end)
 
-      assert {:ok, 2} = Engram.Indexing.count_points_by_path_hmac(note, Base.encode64(<<9>>))
+      assert {:ok, 2} = Engram.Indexing.count_points_by_path_hmac(note, old_b64)
     end
   end
 

--- a/test/engram/vector/qdrant_test.exs
+++ b/test/engram/vector/qdrant_test.exs
@@ -290,7 +290,11 @@ defmodule Engram.Vector.QdrantTest do
         decoded = Jason.decode!(body)
 
         assert decoded["exact"] == true
+        # Tenant triple is mandatory (#755) — a regression dropping user_id or
+        # vault_id would silently count across tenants.
         must = decoded["filter"]["must"]
+        assert %{"key" => "user_id", "match" => %{"value" => "7"}} in must
+        assert %{"key" => "vault_id", "match" => %{"value" => "9"}} in must
         assert %{"key" => "path_hmac", "match" => %{"value" => "oldp=="}} in must
 
         conn

--- a/test/engram/workers/repath_note_index_test.exs
+++ b/test/engram/workers/repath_note_index_test.exs
@@ -170,4 +170,30 @@ defmodule Engram.Workers.RepathNoteIndexTest do
 
     assert_enqueued(worker: EmbedNote, args: %{note_id: note.id, old_path_hmac: old_path_hmac})
   end
+
+  test "final attempt with repath PATCH 503 falls back to EmbedNote and returns :ok", %{
+    bypass: bypass,
+    note: note
+  } do
+    old_path_hmac = Base.encode64(<<7>>)
+
+    # Points exist (count > 0) but the payload PATCH itself keeps failing. The
+    # other exhaustion test fails the COUNT call; this one exercises the
+    # repath_points/2 error arm of maybe_fallback/4 (#755).
+    stub_count(bypass, 2)
+
+    Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/payload", fn conn ->
+      Plug.Conn.send_resp(conn, 503, ~s({"status":"error"}))
+    end)
+
+    assert :ok =
+             perform_job(
+               RepathNoteIndex,
+               %{note_id: note.id, old_path_hmac: old_path_hmac},
+               attempt: 5,
+               max_attempts: 5
+             )
+
+    assert_enqueued(worker: EmbedNote, args: %{note_id: note.id, old_path_hmac: old_path_hmac})
+  end
 end


### PR DESCRIPTION
Closes #755.

Test-only follow-up to the rename-repath work (#746). Closes the three minor coverage gaps the per-task + whole-branch reviews flagged. The code under test is already correct — these are regression guards.

## Changes

1. **`count_by_note` success test** (`qdrant_test.exs`) now asserts the full `{user_id, vault_id, path_hmac}` tenant triple in the Qdrant filter, not just `path_hmac`. A regression dropping user_id/vault_id would otherwise count across tenants and stay green.
2. **`count_points_by_path_hmac` test** (`indexing_test.exs`) asserts the wrapper forwards the full triple to Qdrant (previously only checked the return value).
3. **`RepathNoteIndex`** (`repath_note_index_test.exs`) gets a dedicated test for the **PATCH-exhaustion** path: count > 0, then `repath_points/2` (the payload PATCH) fails on the final attempt → falls back to `EmbedNote` with `old_path_hmac`. The existing exhaustion test only failed the *count* call; this exercises the other `maybe_fallback/4` arm.

82 tests green across the three files. First build in a worktree under the new #759 hook — compiled clean from scratch (0 contamination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
