### PR TITLE
docs(readme): swap CI shield for MCP-native badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 MCP-native · semantic + keyword search · real-time sync · self-hostable · source-available · Elixir/Phoenix
 
-[![Verify](https://github.com/engram-app/Engram/actions/workflows/verify.yml/badge.svg)](https://github.com/engram-app/Engram/actions/workflows/verify.yml)
+[![MCP](https://img.shields.io/badge/MCP-native-8A2BE2)](https://modelcontextprotocol.io)
 [![Last commit](https://img.shields.io/github/last-commit/engram-app/Engram)](https://github.com/engram-app/Engram/commits/main)
 [![Stars](https://img.shields.io/github/stars/engram-app/Engram?style=flat)](https://github.com/engram-app/Engram/stargazers)
 [![License](https://img.shields.io/badge/license-PolyForm_SB_1.0-blue)](LICENSE)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.544",
+      version: "0.5.545",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Replaces the `Verify` (CI) shield with an MCP-native badge.

CI-passing tells a reader nothing actionable; `MCP | native` (linking to modelcontextprotocol.io) leads with what makes Engram distinct. Other badges unchanged. Version bump 0.5.545 (per-PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)