### PR TITLE
fix(crdt): announce crdt_doc_ready so device B discovers new notes

### DIFF
--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -17,7 +17,7 @@ defmodule Engram.Notes.CrdtPersistence do
   import Ecto.Query
   alias Engram.{Accounts, Crypto, Repo}
   alias Engram.Logger.Metadata
-  alias Engram.Notes.{CrdtCheckpointTimer, CrdtUpdateLog, Note}
+  alias Engram.Notes.{CrdtBridge, CrdtCheckpointTimer, CrdtUpdateLog, Note}
 
   require Logger
 
@@ -33,12 +33,28 @@ defmodule Engram.Notes.CrdtPersistence do
       Repo.with_tenant(user_id, fn ->
         case Repo.get(Note, note_id) do
           %Note{} = note ->
-            case Crypto.decrypt_crdt_state(note, user) do
-              {:ok, snapshot} when is_binary(snapshot) -> :ok = Yex.apply_update(doc, snapshot)
-              _ -> :ok
-            end
+            from_snapshot? =
+              case Crypto.decrypt_crdt_state(note, user) do
+                {:ok, snapshot} when is_binary(snapshot) ->
+                  :ok = Yex.apply_update(doc, snapshot)
+                  true
 
-            replay_tail(doc, user, note_id)
+                _ ->
+                  false
+              end
+
+            tail_count = replay_tail(doc, user, note_id)
+
+            # Fresh room: no snapshot AND no tail-log updates means this note has
+            # never been CRDT-edited, so the only source of truth is the plaintext
+            # `notes.content`. Seed the doc from it so a device that has never
+            # opened the note (discovery via the crdt_doc_ready announce or a
+            # /changes pull) still receives the body over the y-protocols
+            # handshake. The client's `seedOnce` guard (skips when an LCA exists)
+            # prevents a double-seed once the server is authoritative.
+            if not from_snapshot? and tail_count == 0 do
+              seed_from_content(doc, note, user)
+            end
 
           nil ->
             :ok
@@ -133,12 +149,17 @@ defmodule Engram.Notes.CrdtPersistence do
     :ok
   end
 
+  # Replays the encrypted tail-log onto `doc` and returns the number of rows
+  # found (whether or not each decrypted) so bind/3 can tell a fresh room (0
+  # rows) from one that already carries CRDT history.
   defp replay_tail(doc, user, note_id) do
-    CrdtUpdateLog
-    |> where([l], l.note_id == ^note_id)
-    |> order_by([l], asc: l.inserted_at)
-    |> Repo.all()
-    |> Enum.each(fn row ->
+    rows =
+      CrdtUpdateLog
+      |> where([l], l.note_id == ^note_id)
+      |> order_by([l], asc: l.inserted_at)
+      |> Repo.all()
+
+    Enum.each(rows, fn row ->
       shaped = %Note{
         id: note_id,
         dek_version: Crypto.row_version_aad_bound(),
@@ -166,5 +187,25 @@ defmodule Engram.Notes.CrdtPersistence do
           )
       end
     end)
+
+    length(rows)
+  end
+
+  # Seeds a fresh doc's text from the note's plaintext content. Used only when
+  # the note has no CRDT state yet (see bind/3) so discovery delivers the body.
+  # maybe_decrypt_note_fields/2 also UTF-8-scrubs the content, keeping the Yjs
+  # text JSON-safe. A nil/empty body seeds nothing (a blank note stays blank).
+  defp seed_from_content(doc, %Note{} = note, user) do
+    case Crypto.maybe_decrypt_note_fields(note, user) do
+      {:ok, %Note{content: content}} when is_binary(content) and content != "" ->
+        doc
+        |> Yex.Doc.get_text(CrdtBridge.text_name())
+        |> Yex.Text.insert(0, content)
+
+        :ok
+
+      _ ->
+        :ok
+    end
   end
 end

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -108,6 +108,12 @@ defmodule EngramWeb.CrdtChannel do
             |> assign(:rooms, Map.put(socket.assigns.rooms, doc_id, entry))
             |> assign(:room_doc, Map.put(socket.assigns.room_doc, room, doc_id))
 
+          # Announce to all OTHER clients on this vault's crdt: channel that a
+          # room is now active for doc_id. Recipients send a sync-step-1 (state
+          # vector) which the server answers with step-2 (the diff they're
+          # missing), so any device that doesn't yet have this note gets it.
+          broadcast_from!(socket, "crdt_doc_ready", %{"doc_id" => doc_id})
+
           {:ok, socket, entry}
         end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.547",
+      version: "0.5.548",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -81,12 +81,14 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert cached_user.id == user.id
   end
 
-  test "bind/3 with no snapshot (nil crdt_state) starts empty doc", ctx do
+  test "bind/3 seeds the doc from notes.content when fresh (no snapshot, no tail-log)", ctx do
     %{user: user, vault: vault} = ctx
-    # Write a note without crdt_state (via insert bypassing Notes.upsert_note
-    # side-effects). Since Notes.upsert_note always seeds crdt_state, we use
-    # a second fresh note and zero out its crdt_state columns manually.
-    {:ok, note2} = Notes.upsert_note(user, vault, %{"path" => "empty.md", "content" => "hi"})
+    # A note whose CRDT state has never been written (no snapshot, no tail-log)
+    # but which carries plaintext content. A device that has never CRDT-edited
+    # this note (e.g. device B discovering it) must still receive that content
+    # over the y-protocols handshake — so bind seeds the doc from notes.content.
+    {:ok, note2} =
+      Notes.upsert_note(user, vault, %{"path" => "seed.md", "content" => "hello world"})
 
     {:ok, _} =
       Repo.with_tenant(user.id, fn ->
@@ -100,8 +102,58 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     doc = CrdtBridge.new_doc()
     _returned = CrdtPersistence.bind(st, note2.id, doc)
 
-    # An empty doc has an empty string — bind should not crash
-    assert is_binary(CrdtBridge.text_of(doc))
+    assert CrdtBridge.text_of(doc) == "hello world"
+  end
+
+  test "bind/3 does NOT seed from content when a tail-log exists (no double-seed)", ctx do
+    %{user: user, vault: vault} = ctx
+    # crdt_state snapshot is absent, but a tail-log update already represents the
+    # note's CRDT history. Seeding from notes.content here would duplicate text
+    # (content + tail). The tail-log is authoritative — content must NOT be added.
+    {:ok, note2} =
+      Notes.upsert_note(user, vault, %{"path" => "tail.md", "content" => "PLAINTEXT"})
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note2.id),
+          set: [crdt_state_ciphertext: nil, crdt_state_nonce: nil]
+        )
+      end)
+
+    st = %{user_id: user.id, vault_id: note2.vault_id, note_id: note2.id}
+
+    # Append a tail-log update that sets the CRDT text to a distinct value.
+    {:ok, %{state: upd}} = CrdtBridge.merge_plaintext(nil, "TAIL")
+    seed_doc = CrdtBridge.new_doc()
+    _ = CrdtPersistence.update_v1(st, upd, note2.id, seed_doc)
+
+    doc = CrdtBridge.new_doc()
+    _returned = CrdtPersistence.bind(st, note2.id, doc)
+
+    # Only the tail-log content — notes.content ("PLAINTEXT") was not seeded on top.
+    text = CrdtBridge.text_of(doc)
+    assert text == "TAIL"
+    refute text =~ "PLAINTEXT"
+  end
+
+  test "bind/3 does not seed when content is empty (fresh, blank note)", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note2} = Notes.upsert_note(user, vault, %{"path" => "blank.md", "content" => ""})
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note2.id),
+          set: [crdt_state_ciphertext: nil, crdt_state_nonce: nil]
+        )
+      end)
+
+    st = %{user_id: user.id, vault_id: note2.vault_id, note_id: note2.id}
+    doc = CrdtBridge.new_doc()
+    _returned = CrdtPersistence.bind(st, note2.id, doc)
+
+    assert CrdtBridge.text_of(doc) == ""
   end
 
   # ── update_v1/4 writes encrypted log row ──────────────────────────────────

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -196,4 +196,21 @@ defmodule EngramWeb.CrdtChannelTest do
       assert Process.alive?(room_pid)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # crdt_doc_ready — device-B discovery announce
+  # ---------------------------------------------------------------------------
+  #
+  # When a client first opens a room, ensure_room/2 fires
+  # `broadcast_from!(socket, "crdt_doc_ready", %{"doc_id" => doc_id})` so OTHER
+  # devices on the vault topic learn the note exists and pull it (they would
+  # otherwise never observe the room, since the channel only observes rooms it
+  # has itself sent a crdt_msg for). Asserting this in a unit test requires a
+  # live :global room, and a room's terminate-time snapshot flush
+  # (CrdtPersistence.unbind) runs AFTER the test's sandbox owner exits — it
+  # crashes and cascades the Repo down for the next test (same hazard called
+  # out for the self-bootstrap case above). The full announce → step-1 → pull
+  # path is therefore covered by the CRDT-on e2e suite (device-B receive),
+  # not here. The plugin-side receive/dispatch is unit-tested in
+  # channel-crdt.test.ts (`NoteChannel inbound crdt_doc_ready`).
 end


### PR DESCRIPTION
## Problem

CRDT bug #3 (device-B discovery). A note created on **device A** was never received on **device B**. Root cause: `CrdtChannel` uses a per-room observer pattern — device B only observes a room after **it itself** sends a `crdt_msg` for that doc, and the plugin's C1 guard suppresses the legacy `note_changed` / `/changes` discovery path while CRDT owns content. So a brand-new note had no path to reach B.

## Fix (durable, two layers + a seed)

1. **Edge-triggered announce** (`crdt_channel.ex`): when a client first opens a room, `broadcast_from!` a `crdt_doc_ready {doc_id}` to all **other** subscribers on the vault topic. Each recipient sends a sync-step-1; the server replies step-2 and the note is delivered. Fast path for the both-devices-online case.

2. **Fresh-room seed** (`crdt_persistence.ex`): `bind/3` previously started a room's Yjs doc **empty** when the note had no `crdt_state` snapshot and no tail-log. A device discovering such a note would then receive an empty step-2 and write a **blank file** (data loss for legacy notes / notes never CRDT-edited). Now `bind/3` seeds the doc's text from the decrypted `notes.content` — but **only when fresh** (no snapshot AND no tail-log rows), since any CRDT history is authoritative and seeding on top would duplicate text. The client's `seedOnce` guard (skips once an LCA exists) + the singleton room make the server the single source of truth.

The plugin-side level-triggered backstop (enroll discovered notes from `/changes`) ships in the companion plugin PR.

## Companion PR

Plugin: `engram-app/Engram-obsidian` #144 (`fix/crdt-doc-ready-receive`) — handles `crdt_doc_ready` and enrolls discovered notes from pull. **Merge this backend PR first.**

## Code review

Independently reviewed (code-reviewer agent). The review caught the edge-triggered lost-wakeup gap (a device not subscribed at announce time misses the note) — addressed by the seed + the plugin's level-triggered pull-enroll, which together make discovery durable.

## Tests

- The announce requires a live `:global` room; verifying it in a unit test crashes the ExUnit sandbox (room terminate flushes to Repo after the owner exits), so it's covered by the CRDT-on e2e suite. A note in `crdt_channel_test.exs` records this.
- `bind/3` seeding is unit-tested in `crdt_persistence_test.exs` (seeds when fresh; does NOT seed when a tail-log exists; does not seed an empty note) — TDD.

Gauntlet green: format, compile --warnings-as-errors, credo --strict, sobelow, dialyzer, full `mix test` (3201, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)