### PR TITLE
fix(crdt): recover from the SharedDoc observe/auto-exit race

### DIFF
--- a/lib/engram/notes/crdt_registry.ex
+++ b/lib/engram/notes/crdt_registry.ex
@@ -12,7 +12,17 @@ defmodule Engram.Notes.CrdtRegistry do
   `DynamicSupervisor` wired in `Engram.Application`).
   """
 
+  alias Yex.Sync.SharedDoc
+
   @sup Engram.Notes.CrdtDocSupervisor
+
+  # The singleton room has `auto_exit: true`, so it stops when its last observer
+  # leaves. `:global.whereis_name` can hand back a room that is mid-termination,
+  # so a plain `observe/1` GenServer.call would exit and crash the caller. Retry
+  # a bounded number of times, yielding so `:global` drops the dead registration
+  # and a fresh room is started on the next attempt.
+  @observe_attempts 5
+  @observe_retry_delay_ms 5
 
   @doc "The `:global` registration name for a note's doc room."
   @spec global_name(String.t()) :: {:global, {:crdt_doc, String.t()}}
@@ -40,6 +50,51 @@ defmodule Engram.Notes.CrdtRegistry do
           {:error, {:already_started, pid}} -> {:ok, pid}
           {:error, _} = err -> err
         end
+    end
+  end
+
+  @doc """
+  Ensure the singleton room for `note_id` is started AND observed by the
+  CALLING process, recovering from the auto-exit race.
+
+  Must be called from the process that should receive `{:yjs, frame, room}`
+  broadcasts (the channel), since `SharedDoc.observe/1` registers `self()`.
+  Returns `{:error, :room_unavailable}` if the room keeps auto-exiting across
+  every attempt.
+  """
+  @spec ensure_observed(String.t(), String.t(), String.t()) :: {:ok, pid()} | {:error, term()}
+  def ensure_observed(user_id, vault_id, note_id) do
+    observe_with_retry(
+      fn -> ensure_started(user_id, vault_id, note_id) end,
+      fn room -> SharedDoc.observe(room) end
+    )
+  end
+
+  @doc """
+  Retry helper backing `ensure_observed/3`. Calls `start_fun` to obtain a room,
+  then `observe_fun` on it; if `observe_fun` exits (the room auto-exited mid
+  race), yields and retries with a freshly obtained room. Extracted so the
+  retry logic is testable with injected functions.
+  """
+  @spec observe_with_retry((-> {:ok, room} | {:error, term()}), (room -> :ok), pos_integer()) ::
+          {:ok, room} | {:error, term()}
+        when room: term()
+  def observe_with_retry(start_fun, observe_fun, attempts \\ @observe_attempts)
+
+  def observe_with_retry(_start_fun, _observe_fun, attempts) when attempts <= 0 do
+    {:error, :room_unavailable}
+  end
+
+  def observe_with_retry(start_fun, observe_fun, attempts) do
+    with {:ok, room} <- start_fun.() do
+      try do
+        :ok = observe_fun.(room)
+        {:ok, room}
+      catch
+        :exit, _reason ->
+          Process.sleep(@observe_retry_delay_ms)
+          observe_with_retry(start_fun, observe_fun, attempts - 1)
+      end
     end
   end
 end

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -99,8 +99,7 @@ defmodule EngramWeb.CrdtChannel do
         user = socket.assigns.current_user
 
         with {:ok, note_id} <- resolve_note_id(user, vault, doc_id),
-             {:ok, room} <- CrdtRegistry.ensure_started(user.id, vault.id, note_id) do
-          :ok = SharedDoc.observe(room)
+             {:ok, room} <- CrdtRegistry.ensure_observed(user.id, vault.id, note_id) do
           entry = %{room: room, note_id: note_id}
 
           socket =

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.548",
+      version: "0.5.549",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_registry_test.exs
+++ b/test/engram/notes/crdt_registry_test.exs
@@ -34,6 +34,59 @@ defmodule Engram.Notes.CrdtRegistryTest do
     refute p1 == p2
   end
 
+  describe "observe_with_retry/3 — auto-exit race recovery" do
+    test "observes once and returns the room when observe succeeds" do
+      test_pid = self()
+      start_fun = fn -> {:ok, :room1} end
+      observe_fun = fn room -> send(test_pid, {:observed, room}) && :ok end
+
+      assert {:ok, :room1} = CrdtRegistry.observe_with_retry(start_fun, observe_fun, 3)
+      assert_received {:observed, :room1}
+    end
+
+    test "retries with a fresh room when observe exits mid-race, then succeeds" do
+      # The singleton room auto-exits (last observer left) between whereis and
+      # observe, so the first observe exits. The retry must re-start a fresh room
+      # and observe THAT, not crash the caller.
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      start_fun = fn ->
+        {:ok, Agent.get_and_update(counter, fn n -> {{:room, n}, n + 1} end)}
+      end
+
+      observe_fun = fn
+        {:room, 0} -> exit(:normal)
+        _ -> :ok
+      end
+
+      assert {:ok, {:room, 1}} = CrdtRegistry.observe_with_retry(start_fun, observe_fun, 3)
+    end
+
+    test "gives up with {:error, :room_unavailable} after exhausting attempts" do
+      start_fun = fn -> {:ok, :room} end
+      observe_fun = fn _ -> exit(:normal) end
+
+      assert {:error, :room_unavailable} =
+               CrdtRegistry.observe_with_retry(start_fun, observe_fun, 3)
+    end
+
+    test "propagates a start_fun error without retrying observe" do
+      start_fun = fn -> {:error, :nope} end
+      observe_fun = fn _ -> flunk("observe must not run when start fails") end
+
+      assert {:error, :nope} = CrdtRegistry.observe_with_retry(start_fun, observe_fun, 3)
+    end
+  end
+
+  # NOTE: `ensure_observed/3` against a real room is integration-tested via the
+  # CrdtChannel (ensure_room → ensure_observed), where the channel process owns
+  # the observer registration and ExUnit tears it down before the sandbox
+  # closes. Observing a :global room directly from the TEST process would leave
+  # it to auto-exit after the sandbox owner exits, and its terminate-time
+  # CrdtPersistence.unbind Repo write would crash and cascade the suite (the
+  # same hazard documented in crdt_channel_test.exs). The retry logic itself is
+  # covered deterministically by the observe_with_retry/3 tests above.
+
   test "room doc uses UTF-16 offset kind", ctx do
     %{user: u, vault: v} = ctx
     # Use a note with empty content so the doc starts blank — this isolates the


### PR DESCRIPTION
## Problem

Surfaced by the CRDT-on diagnostic e2e: `CrdtChannel` crashes were preventing CRDT sync from working. The backend log showed:

```
GenServer terminating ** (stop) exited in: GenServer.call(<room>, {:observe, …})
  ** (EXIT) normal
  crdt_channel.ex:103: ensure_room/2
```

The singleton `SharedDoc` room has `auto_exit: true`, so it stops when its last observer's process DOWNs / unobserves. There's a race: `:global.whereis_name` can hand back a room that is **mid-termination** (its last observer just left), and the subsequent `SharedDoc.observe/1` GenServer.call to that terminating room **exits, crashing the whole channel**. Under the e2e's connect/disconnect churn this fired repeatedly (the socket showed 59 crdt joins but only 1 `crdt_msg` and 0 announces — rooms never stayed established).

## Fix

`CrdtRegistry.ensure_observed/3` starts **and** observes the room with a bounded retry: if `observe` exits, it yields (so `:global` drops the dead registration) and retries with a freshly started room, giving up with `{:error, :room_unavailable}` after N attempts. `ensure_room/2` now calls it instead of `ensure_started` + a bare `observe`, so an unrecoverable room degrades to a logged dropped `crdt_msg` rather than a channel crash.

The retry logic is extracted as `observe_with_retry/3` and unit-tested deterministically with injected start/observe functions (success, retry-then-succeed, exhaustion, start-error). The real-room path is covered via the existing `CrdtChannel` tests.

## Scope note

This fixes one of two transport defects the diag e2e surfaced. The other — a `"Received oversize fragmented message"` that crashes the **whole socket** (seen on Sync/User/Crdt channels alike, not CRDT-specific; Bandit's 8 MB `max_fragmented_message_size`) — is tracked separately. Re-running the CRDT-on diag e2e after this merges will measure the impact on device-B sync.

## Tests

Gauntlet green: format, credo --strict, sobelow, dialyzer, full `mix test` (3205, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)