### PR TITLE
feat(crdt): deliver external writes to live CRDT clients (gap 3)

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -2985,6 +2985,16 @@ defmodule Engram.Notes do
           Engram.Sync.Broadcast.emit(topic, "note_changed", payload)
       end
 
+    # Deliver-out to CRDT clients (gap ③): push the merged plaintext to a live
+    # room's observers and announce the doc so clients lacking it pull. Runs
+    # post-commit, best-effort, only when CRDT is enabled. CRDT-origin writes
+    # never reach here (the checkpoint writes the DB directly), so this fires
+    # solely for REST/MCP/web/cascade writes — no double-delivery.
+    _ =
+      if crdt_enabled?() do
+        Engram.Notes.CrdtDeliver.deliver_out(user_id, vault_id, path, note.id, note.content || "")
+      end
+
     :ok
   end
 

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -1,0 +1,81 @@
+defmodule Engram.Notes.CrdtDeliver do
+  @moduledoc """
+  Deliver-out bridge: propagate non-CRDT-origin content writes (REST / MCP /
+  web SPA / folder cascade) to connected CRDT clients.
+
+  The write path (`Notes.upsert_note/4`) merges incoming plaintext into the
+  note's persisted Yjs state, but a write that does NOT arrive over the `crdt:`
+  channel never reaches the live in-memory room nor any client observing it.
+  This module closes that gap (spec §4.3 deliver-out / handoff gap ③) with two
+  complementary, best-effort, post-commit steps:
+
+    1. If a room is already live for the note (an Obsidian client has it open),
+       apply the merged plaintext onto the room's owned `Y.Text` via
+       `SharedDoc.update_doc/2`. The room's `handle_update_v1` then broadcasts
+       the resulting v1 frame to every observer (and appends it to the durable
+       update-log). Routing through the owner process keeps the single-owner
+       invariant — the doc is never mutated from two processes.
+
+    2. ALWAYS announce `crdt_doc_ready` on the vault topic so any client that
+       does not yet hold a room for this note (including a brand-new note just
+       created via REST/MCP) opens one and pulls via sync step-1. Step 1 alone
+       is insufficient: the plugin's enrollment is once-per-session, so an
+       already-enrolled client only converges from a pushed frame, while a
+       not-yet-enrolled client only converges from the announce.
+
+  The caller gates this on `crdt_enabled?/0`; this module always delivers when
+  invoked. It never raises — a delivery failure must not fail the write.
+  """
+
+  alias Engram.Notes.{CrdtBridge, CrdtRegistry}
+  alias Yex.Sync.SharedDoc
+
+  @doc """
+  Propagate a committed plaintext write for `note_id` to CRDT clients on
+  `vault_id`. `content` is the post-merge plaintext (the note's materialized
+  body); `path` is the note's vault-relative path. Returns `:ok` regardless of
+  per-step outcome.
+  """
+  @spec deliver_out(String.t(), String.t(), String.t(), String.t(), String.t()) :: :ok
+  def deliver_out(user_id, vault_id, path, note_id, content)
+      when is_binary(content) do
+    push_to_live_room(note_id, content)
+    announce(user_id, vault_id, path)
+    :ok
+  end
+
+  # Step 1 — push the diff frame to a live room's observers, if one exists.
+  # Non-creating lookup so an external write never spins a room for a note
+  # nobody is observing. `:global.whereis_name` can hand back a room that is
+  # mid auto-exit, so guard the GenServer.call against an :exit — the announce
+  # (step 2) still lets clients re-pull when the push could not land.
+  defp push_to_live_room(note_id, content) do
+    case CrdtRegistry.lookup(note_id) do
+      nil ->
+        :ok
+
+      room ->
+        try do
+          SharedDoc.update_doc(room, fn doc ->
+            doc
+            |> Yex.Doc.get_text(CrdtBridge.text_name())
+            |> CrdtBridge.diff_into_text(content)
+          end)
+        catch
+          :exit, _reason -> :ok
+        end
+    end
+  end
+
+  # Step 2 — discovery announce. Mirrors the channel's own `crdt_doc_ready`
+  # event (CrdtChannel.ensure_room/2); the plugin handles both identically.
+  defp announce(user_id, vault_id, path) do
+    EngramWeb.Endpoint.broadcast(
+      "crdt:#{user_id}:#{vault_id}",
+      "crdt_doc_ready",
+      %{"doc_id" => "#{vault_id}/#{path}"}
+    )
+
+    :ok
+  end
+end

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -70,11 +70,12 @@ defmodule Engram.Notes.CrdtDeliver do
   # Step 2 — discovery announce. Mirrors the channel's own `crdt_doc_ready`
   # event (CrdtChannel.ensure_room/2); the plugin handles both identically.
   defp announce(user_id, vault_id, path) do
-    EngramWeb.Endpoint.broadcast(
-      "crdt:#{user_id}:#{vault_id}",
-      "crdt_doc_ready",
-      %{"doc_id" => "#{vault_id}/#{path}"}
-    )
+    _ =
+      EngramWeb.Endpoint.broadcast(
+        "crdt:#{user_id}:#{vault_id}",
+        "crdt_doc_ready",
+        %{"doc_id" => "#{vault_id}/#{path}"}
+      )
 
     :ok
   end

--- a/lib/engram/notes/crdt_registry.ex
+++ b/lib/engram/notes/crdt_registry.ex
@@ -29,6 +29,19 @@ defmodule Engram.Notes.CrdtRegistry do
   def global_name(note_id) when is_binary(note_id), do: {:global, {:crdt_doc, note_id}}
 
   @doc """
+  Find the live room for `note_id` WITHOUT starting one, returning `nil` when
+  no room is running anywhere in the cluster. Used by the deliver-out path,
+  which must never spin a room for a note nobody is observing.
+  """
+  @spec lookup(String.t()) :: pid() | nil
+  def lookup(note_id) when is_binary(note_id) do
+    case :global.whereis_name({:crdt_doc, note_id}) do
+      pid when is_pid(pid) -> pid
+      :undefined -> nil
+    end
+  end
+
+  @doc """
   Idempotently start (or find) the singleton room for `note_id`.
 
   Returns `{:ok, pid}` whether the room was just started or was already

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.550",
+      version: "0.5.551",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -1,0 +1,156 @@
+defmodule Engram.Notes.CrdtDeliverTest do
+  # async: false — registers rooms under :global (cluster-wide names) and
+  # subscribes to Endpoint topics. Uses a BARE SharedDoc with no persistence
+  # module, so there is no terminate-time DB flush (the :global-room sandbox
+  # hazard documented in crdt_channel_test.exs is specifically CrdtPersistence's
+  # unbind; a no-op room avoids it).
+  use Engram.DataCase, async: false
+
+  alias Engram.Notes.{CrdtDeliver, CrdtRegistry}
+  alias Yex.Sync.SharedDoc
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "DeliverTest"})
+    %{user: user, vault: vault}
+  end
+
+  describe "deliver_out/5 — announce" do
+    test "broadcasts crdt_doc_ready to the vault crdt topic", %{user: user, vault: vault} do
+      EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
+      note_id = Ecto.UUID.generate()
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "a.md", note_id, "# A")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "crdt_doc_ready",
+        payload: %{"doc_id" => doc_id}
+      }
+
+      assert doc_id == "#{vault.id}/a.md"
+    end
+
+    test "announces even when no room is live (no crash, vault-prefixed nested path)",
+         %{user: user, vault: vault} do
+      EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
+      note_id = Ecto.UUID.generate()
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "deep/nest/b.md", note_id, "x")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "crdt_doc_ready",
+        payload: %{"doc_id" => doc_id}
+      }
+
+      assert doc_id == "#{vault.id}/deep/nest/b.md"
+    end
+  end
+
+  describe "deliver_out/5 — live-room frame push" do
+    test "pushes a yjs frame to a live room's observers", %{user: user, vault: vault} do
+      note_id = Ecto.UUID.generate()
+      room = start_bare_room(note_id, "base")
+      SharedDoc.observe(room)
+
+      EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "n.md", note_id, "base updated")
+
+      # The observing test process receives the diff frame produced by applying
+      # the incoming plaintext onto the room's owned doc (deliver-out, gap 3).
+      assert_receive {:yjs, frame, ^room}, 1000
+      assert is_binary(frame)
+
+      # And the discovery announce still fires for vault clients lacking the room.
+      assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
+
+      # The room's owned text converged to the incoming plaintext.
+      doc = SharedDoc.get_doc(room)
+      assert Engram.Notes.CrdtBridge.text_of(doc) == "base updated"
+    end
+
+    test "no-op when incoming equals the room's current text (still announces)",
+         %{user: user, vault: vault} do
+      note_id = Ecto.UUID.generate()
+      room = start_bare_room(note_id, "same")
+      SharedDoc.observe(room)
+      EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "n.md", note_id, "same")
+
+      # diff_into_text is a no-op on equality → no frame broadcast...
+      refute_receive {:yjs, _frame, ^room}, 200
+      # ...but the announce always fires.
+      assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
+    end
+  end
+
+  describe "upsert_note wiring — crdt_enabled gate" do
+    setup do
+      prev = Application.get_env(:engram, :crdt_enabled, false)
+      Application.put_env(:engram, :crdt_enabled, true)
+      on_exit(fn -> Application.put_env(:engram, :crdt_enabled, prev) end)
+      :ok
+    end
+
+    test "an upsert announces crdt_doc_ready when crdt is enabled",
+         %{user: user, vault: vault} do
+      EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
+
+      {:ok, _note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "w.md",
+          "content" => "hi",
+          "mtime" => 1.0
+        })
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "crdt_doc_ready",
+        payload: %{"doc_id" => doc_id}
+      }
+
+      assert doc_id == "#{vault.id}/w.md"
+    end
+  end
+
+  test "an upsert does NOT announce crdt_doc_ready when crdt is disabled (default)",
+       %{user: user, vault: vault} do
+    EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
+
+    {:ok, _note} =
+      Engram.Notes.upsert_note(user, vault, %{
+        "path" => "w2.md",
+        "content" => "hi",
+        "mtime" => 1.0
+      })
+
+    refute_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 200
+  end
+
+  # A SharedDoc with NO persistence module (no bind/unbind), registered under the
+  # same :global name CrdtRegistry uses, so CrdtRegistry.lookup/1 finds it.
+  # auto_exit: false keeps it alive across observer churn within the test.
+  defp start_bare_room(note_id, seed_text) do
+    {:ok, room} =
+      SharedDoc.start_link(
+        [
+          doc_name: note_id,
+          doc_option: %Yex.Doc.Options{offset_kind: :utf16},
+          auto_exit: false
+        ],
+        name: CrdtRegistry.global_name(note_id)
+      )
+
+    on_exit(fn -> if Process.alive?(room), do: GenServer.stop(room) end)
+
+    if seed_text do
+      SharedDoc.update_doc(room, fn doc ->
+        Yex.Text.insert(Yex.Doc.get_text(doc, Engram.Notes.CrdtBridge.text_name()), 0, seed_text)
+      end)
+    end
+
+    room
+  end
+end


### PR DESCRIPTION
## What

Closes the CRDT **deliver-out** gap (handoff gap ③ / spec §4.3): non-CRDT-origin content writes (REST / MCP / web SPA / folder cascade) now propagate to connected `crdt:` clients in realtime.

Before this, an external write merged into the note's Yjs state and broadcast to `sync:`, but **nothing pushed a frame to a live CRDT room nor announced the doc to clients lacking it**. Under CRDT-default that regresses realtime sync for every web/MCP/AI edit — it's the foundational piece the CRDT-default migration depends on.

## How

New `Engram.Notes.CrdtDeliver.deliver_out/5`, called post-commit from `broadcast_change/6` when `crdt_enabled?`:

1. **Live room → push frame.** If a room is open for the note, apply the merged plaintext onto its owned `Y.Text` via `SharedDoc.update_doc`. The room's `handle_update_v1` broadcasts the v1 frame to all observers and appends to the durable update-log. Routing through the owner process preserves the single-owner invariant (never mutate the doc from two processes).
2. **Always announce `crdt_doc_ready`** on the vault topic so clients without the room (incl. brand-new API-created notes) open one and pull via sync step-1.

Both are required: the plugin's enrollment is once-per-session, so already-enrolled clients converge only from a pushed frame, not-yet-enrolled clients only from the announce. CRDT-origin writes never reach `broadcast_change` (the checkpoint writes the DB directly), so there's **no double-delivery**. Best-effort, never raises — delivery must not fail the write.

Adds `CrdtRegistry.lookup/1` (non-creating room lookup) so an external write never spins a room for a note nobody is observing.

## Tests

`test/engram/notes/crdt_deliver_test.exs` (6 tests, TDD):
- announce fires on the vault topic (incl. nested paths);
- live-room frame push converges the room's text + observers receive the frame (uses a bare no-persistence `SharedDoc` to avoid the documented `:global` room-terminate sandbox cascade);
- no-op on equal content (still announces);
- `upsert_note` wiring gated on `crdt_enabled?` (announces when on, silent when off).

Backend-only; CRDT stays off by default. End-to-end delivery is validated by the CRDT e2e suite (test_45/46) once the `e2e-crdt` job is wired (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)