### PR TITLE
test(e2e): path-sanitization-under-CRDT coverage

### DIFF
--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -163,7 +163,10 @@ async def test_illegal_path_chars_sanitized_under_crdt(vault_a, cdp_a, api_sync)
     write_note(vault_a, dirty_path, "# What\nIllegal chars stripped under CRDT.")
 
     # The sanitized clean path receives the body (eventually, post-checkpoint).
-    api_sync.wait_for_note_content(clean_path, "Illegal chars stripped", timeout=CRDT_TIMEOUT)
+    # Heavier than a direct-path CRDT flow: the note bootstraps at a DIFFERENT
+    # (sanitized) path than the wire doc_id, so allow extra slack on slower CI
+    # runners on top of the checkpoint debounce.
+    api_sync.wait_for_note_content(clean_path, "Illegal chars stripped", timeout=60)
 
     # The dirty path is never a real note — sanitization is not bypassed.
     assert api_sync.get_note(dirty_path) is None

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -147,3 +147,23 @@ async def test_edit_after_discovery_round_trips(vault_a, vault_b, cdp_a, cdp_b, 
 
     a_content = wait_for_content(vault_a, path, "appended on B", timeout=CRDT_TIMEOUT)
     assert "origin A" in a_content and "appended on B" in a_content
+
+
+@pytest.mark.asyncio
+async def test_illegal_path_chars_sanitized_under_crdt(vault_a, cdp_a, api_sync):
+    """A note authored with illegal filename chars is sanitized server-side on
+    the CRDT bootstrap path (get_or_bootstrap_note -> upsert_note ->
+    PathSanitizer), and its body still materializes to the CLEAN path after the
+    checkpoint. Proves the CRDT write path does NOT bypass path sanitization —
+    the dirty path never becomes a real note (path-traversal / illegal-char
+    defense holds under CRDT, not just on the REST upsert)."""
+    dirty_path = 'E2E/Crdt/What: A "Great" Day*.md'
+    clean_path = "E2E/Crdt/What A Great Day.md"
+
+    write_note(vault_a, dirty_path, "# What\nIllegal chars stripped under CRDT.")
+
+    # The sanitized clean path receives the body (eventually, post-checkpoint).
+    api_sync.wait_for_note_content(clean_path, "Illegal chars stripped", timeout=CRDT_TIMEOUT)
+
+    # The dirty path is never a real note — sanitization is not bypassed.
+    assert api_sync.get_note(dirty_path) is None

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.551",
+      version: "0.5.552",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

Adds a `tests/crdt/` case proving the **path-sanitization defense holds on the CRDT write path**, not just on REST upserts.

The CRDT path bootstraps unknown notes via `get_or_bootstrap_note → upsert_note → PathSanitizer.sanitize`, so a note authored with illegal filename chars (`: " *`) is sanitized to a clean path. The test asserts the body materializes to the **clean** path (post-checkpoint, CRDT-aware wait) and the **dirty path never becomes a real note**.

## Why

Part of the CRDT-default readiness gate — confirms a security-relevant invariant (illegal-char / path-traversal defense) survives under CRDT. The legacy `test_18` covers this on the REST/`trigger_full_sync` path and stays in the CRDT-off lane until Phase 3 removes it; this adds the CRDT-lane equivalent.

Validated on the local harness (1 passed, ~19s). Runs in the `e2e-crdt` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)