### PR TITLE
feat(crdt): flip CRDT sync on by default (Phase 2)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,9 +55,11 @@ config :engram, :storage, Engram.Storage.S3
 # replacement for legacy push/pull (basic A→B delivery is not functional and it
 # changes offline-queue / versioning / conflict-file semantics). When false the
 # server keeps legacy 409-on-stale-version conflict resolution, and the plugin's
-# matching `enableCrdt` setting keeps it off the `crdt:` topic. Flip to true only
-# once the end-to-end CRDT path is verified.
-config :engram, :crdt_enabled, false
+# matching `enableCrdt` setting keeps it off the `crdt:` topic. CRDT is now the
+# DEFAULT content-sync path (verified e2e via the crdt: suite + gap-3 external
+# delivery); opt OUT explicitly with CRDT_ENABLED=false (falls back to legacy
+# 409-on-stale-version conflict resolution — the e2e-clerk lane + kill switch).
+config :engram, :crdt_enabled, true
 
 # Oban job queue (per-env overrides in dev/test/prod configs)
 config :engram, Oban,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -425,11 +425,15 @@ config :engram,
        :billing_enabled,
        auth_provider == :clerk and System.get_env("PADDLE_API_KEY") != nil
 
-# CRDT (Yjs) sync opt-in. Ships dormant (config.exs default false); flipped on
-# for staging/prod rollout via CRDT_ENABLED=true. Test env sets no env var, so
-# unit tests keep the default-off legacy conflict semantics.
-if System.get_env("CRDT_ENABLED") == "true" do
-  config :engram, :crdt_enabled, true
+# CRDT (Yjs) sync is the DEFAULT (config.exs sets true). A deploy opts OUT
+# explicitly with CRDT_ENABLED=false (kill switch + the e2e-clerk legacy lane);
+# CRDT_ENABLED=true is a harmless explicit-on. Unset → keep the default. Test
+# env pins false in config/test.exs to keep legacy-conflict unit tests
+# deterministic regardless of this env var.
+case System.get_env("CRDT_ENABLED") do
+  "false" -> config :engram, :crdt_enabled, false
+  "true" -> config :engram, :crdt_enabled, true
+  _ -> :ok
 end
 
 # Plan limits enforcement toggle.

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,6 +17,12 @@ config :engram, :pre_auth_rate_limit_override, 10_000
 # cover BootCanary directly via Engram.Crypto.BootCanaryTest.
 config :engram, :boot_canary_enabled, false
 
+# CRDT is the default content-sync path in config.exs, but unit tests assert
+# the legacy 409-on-stale-version conflict path and the deliver-out gate's
+# default-off behavior. Pin false here; tests that exercise CRDT opt in
+# per-test via Application.put_env(:engram, :crdt_enabled, true).
+config :engram, :crdt_enabled, false
+
 # #619 — bootstrap admin advisory lock disabled in tests. It's a global
 # pg_advisory_xact_lock; under the SQL sandbox (one transaction per test) it's
 # held for the whole test and deadlocks once enough user-creating tests run

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.551",
+      version: "0.5.553",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

**Phase 2 of the CRDT-default migration** — CRDT (Yjs) content sync becomes the default path.

- `config.exs`: `crdt_enabled false → true`
- `runtime.exs`: invert the env gate to explicit **opt-out** — `CRDT_ENABLED=false` disables (kill switch + the e2e-clerk legacy lane), `=true` is a harmless explicit-on, unset keeps the default-on
- `test.exs`: pin `crdt_enabled: false` so legacy 409-conflict unit tests + the deliver-out default-off gate stay deterministic (CRDT tests opt in via `Application.put_env`)

## Readiness (why now)

- `tests/crdt/` suite green in CI (the `e2e-crdt` job)
- gap ③ external delivery validated 6/6 on the harness (API/MCP create/update/delete reach CRDT vaults)
- Path sanitization confirmed to hold on the CRDT bootstrap path (#773)

## Blast radius

Merging lands CRDT-on on **staging.engram.page** (the canary). **Prod is unaffected** until a `release-v*` tag. CI stays clean both ways: `e2e-clerk` pins `CRDT_ENABLED=false` (legacy lane), `e2e-crdt` runs CRDT-on.

Paired with plugin PR `feat/crdt-default-flip` (Engram-obsidian) which flips `enableCrdt` default on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)