### PR TITLE
fix(crdt): only announce CRDT for markdown — non-md modify regression

### DIFF
--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -39,8 +39,18 @@ defmodule Engram.Notes.CrdtDeliver do
   @spec deliver_out(String.t(), String.t(), String.t(), String.t(), String.t()) :: :ok
   def deliver_out(user_id, vault_id, path, note_id, content)
       when is_binary(content) do
-    push_to_live_room(note_id, content)
-    announce(user_id, vault_id, path)
+    # CRDT manages MARKDOWN content only — the plugin's routeModify enrolls only
+    # `.md` into Yjs (mirroring Relay's SyncType.Document = "markdown"; canvas and
+    # other types are separate, non-markdown-Yjs sync paths). Announcing CRDT for
+    # a non-markdown note (e.g. `.canvas`) makes the client enroll it into a Yjs
+    # doc, flush it to disk (marking the path recently-flushed), and then SUPPRESS
+    # the user's next real edit as an echo — silently dropping the write. Those
+    # files sync via the legacy push path, so only deliver/announce for `.md`.
+    if String.ends_with?(path, ".md") do
+      push_to_live_room(note_id, content)
+      announce(user_id, vault_id, path)
+    end
+
     :ok
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.553",
+      version: "0.5.555",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## The bug (live on staging since the Phase 2 flip)

Under CRDT-default, **modifications to non-markdown notes (`.canvas`) are silently dropped** — they never reach the server. Creates work; modifies are swallowed.

### Root cause

gap③'s `deliver_out` announced `crdt_doc_ready` for **every** note upsert, including non-markdown. For a `.canvas` note the client then:
1. enrolls it into a Yjs doc (it shouldn't — the plugin only routes `.md` to CRDT),
2. `flushFromCrdt`'s it to disk, which marks the path `recentlyFlushed`,
3. so `handleModify` drops the user's **next real edit** as an echo.

### Fix

CRDT manages **markdown only** — gate `deliver_out` on `.md`. This mirrors the plugin's `routeModify` (`.md`-only) and **Relay's `SyncType.Document = "markdown"`** (canvas is a separate, non-markdown-Yjs sync type with its own provider — it's never pulled into the markdown Yjs path). Non-markdown notes stay on the legacy push path.

Pinned via CDP instrumentation (the `recentlyFlushed` guard was swallowing the modify) and **verified on the harness** — the canvas modify now reaches the server (test_41 green).

A paired plugin change adds a matching `.md` guard to `enroll()` (defense-in-depth, mirroring Relay's layered `isDocument` gate).

> Independent of the Phase 3 PR (#775): this fixes a live gap③ regression directly on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)