### PR TITLE
ci: always run unit-tests + lint (drop fingerprint skip)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -391,8 +391,10 @@ jobs:
   prebuild-mix:
     needs: fingerprint
     # Consumed by unit-tests, lint, e2e-browser — all backend-only and skipped
-    # on plugin dispatch.
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true'
+    # on plugin dispatch. NOT fingerprint-gated: unit-tests/lint always run
+    # (they're fast + cheap to recompile), and they hard-`needs` this job, so
+    # a skipped prebuild would drag them into skip. e2e-browser stays gated.
+    if: github.event_name != 'repository_dispatch'
     runs-on: [self-hosted, linux, x64, isolated]
     outputs:
       beam-tag: ${{ steps.beam.outputs.tag }}
@@ -1472,8 +1474,10 @@ jobs:
   unit-tests:
     needs: [fingerprint, prebuild-mix]
     # Skip on cross-repo plugin dispatch — plugin can't regress backend ExUnit.
-    # Also skip when fingerprint already proved green for this content.
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true'
+    # NOT fingerprint-gated: the suite is fast (~4min) and skipping it on a
+    # cache hit created a blind spot — it stopped executing on main for a
+    # stretch and let a Repo-crashing test land. Always run on backend pushes.
+    if: github.event_name != 'repository_dispatch'
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -1752,8 +1756,10 @@ jobs:
   lint:
     needs: [fingerprint, prebuild-mix]
     # Skip on cross-repo plugin dispatch — plugin can't regress backend lints.
-    # Also skip when fingerprint already proved green.
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true'
+    # NOT fingerprint-gated: lint is fast and shares prebuild-mix with
+    # unit-tests; skipping it on a cache hit silently let credo/sobelow
+    # regressions merge. Always run on backend pushes.
+    if: github.event_name != 'repository_dispatch'
     runs-on: [self-hosted, linux, x64, isolated]
 
     steps:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.558",
+      version: "0.5.559",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

`unit-tests` and `lint` were gated on the backend-content fingerprint:
```yaml
if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true'
```
On the squash-merge-to-main push the content hash matches the just-tested PR, so the cache hits and **both jobs skip on essentially every main push**. They stopped actually executing on main for a stretch — long enough for a Repo-crashing CRDT test (`Engram.Notes.CrdtE2ETest` orphaning `:crdt_doc` rooms that crash-loop on DB checkout after the sandbox owner exits, taking `Engram.Repo` down → 898/3213 cascade) to land unseen. It only surfaced on dependabot PR #762, which touches `.github/` and busts the fingerprint.

## Change

Drop the `backend-cache-hit` clause from `unit-tests`, `lint`, and `prebuild-mix`. They always run on backend pushes/PRs now; still skipped on cross-repo `repository_dispatch` (plugin e2e). `prebuild-mix` un-gated because the other two hard-`needs` it. Heavy jobs (e2e, image build) + marker-save/`ci` aggregate stay fingerprint-gated. Both are already required checks, so always-running closes the blind spot. ~4min added per main push.

(Re-homed from `ci/` → `chore/`: `verify.yml` push trigger only fires on allowlisted branch prefixes, and `ci/**` isn't one — superseded #778.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)