### PR TITLE
test: fix #777 :global CrdtDoc room sandbox poisoning + local-test tooling

### DIFF
--- a/docs/context/local-backend-testing.md
+++ b/docs/context/local-backend-testing.md
@@ -1,0 +1,62 @@
+# Running the backend ExUnit suite locally
+
+Fast local `mix test` against a docker Postgres — no CI round-trip. The
+`scripts/test-local.sh` wrapper encodes everything below; reach for the doc only
+when the script misbehaves or you want to understand the moving parts.
+
+## TL;DR
+
+```bash
+scripts/test-local.sh                         # whole suite (~190s, 3200+ tests)
+scripts/test-local.sh test/engram/foo_test.exs[:42]   # one file / line
+scripts/test-local.sh --teardown              # drop the test DB after
+scripts/test-local.sh --reset -- test/...     # drop+recreate test DB first
+```
+
+Runs from the main checkout OR any worktree (it resolves its own repo dir).
+
+## What it needs
+
+- **Elixir/OTP locally** — `elixir --version` (1.19 / OTP 26 works; project targets 1.17+).
+- **Postgres on `localhost:5432`, creds `engram/engram`** — these are the
+  defaults baked into `config/test.exs` (used only when `DATABASE_URL` is
+  unset). The `backend-postgres-1` docker container already serves this; start
+  it with `docker start backend-postgres-1` if it's down. Container is shared
+  with dev — the script never stops it, only drops the `engram_test` DB.
+- **Nothing else.** The `test` mix alias self-bootstraps the schema:
+  `ecto.create --quiet` → `engram.prepare_database` → `ecto.migrate --quiet` →
+  `test`. `engram.prepare_database` is the cluster bootstrap (creates the
+  `engram_app` role + DEFAULT PRIVILEGES) that the baseline dump's GRANTs need —
+  skip it and migrations fail. It's idempotent.
+
+## The three gotchas the wrapper handles
+
+1. **Worktree dep-lock mismatch.** New worktrees hardlink `deps/` from the
+   parent checkout (see the `post-checkout` hook), so they carry the *parent
+   branch's* `mix.lock`. `MIX_ENV=test mix compile` then dies with
+   `lock mismatch ... run "mix deps.get"`. A `mix deps.get` reconciles to the
+   current tree's lock (no-op when already in sync). The script always runs it.
+2. **Stray `DATABASE_URL`.** `config/test.exs` reads `DATABASE_URL` first; if
+   your shell exports one (e.g. from a dev `.env`), the suite silently runs
+   against the wrong DB. The script `unset`s it.
+3. **Postgres not up.** mix's connect error is noisy; the script pre-checks the
+   TCP port and prints the `docker start` hint instead.
+
+## Teardown
+
+Per-test data is reverted by the Ecto SQL sandbox automatically — no teardown
+needed between runs. `--teardown` only drops the `engram_test` *database* so you
+leave zero schema behind; the next run recreates it. `--reset` does the same up
+front when you suspect a stale/partial schema.
+
+## Notes
+
+- Excluded tags (need external infra): `:qdrant_integration`, `:cluster`,
+  `:integration` — the local run skips them, matching CI's unit-tests job.
+- CI uses an ephemeral postgres + a shared `_build` cache; locally you reuse the
+  same `backend-postgres-1` and your worktree's `_build`. Same `mix test`,
+  same alias, so green locally == green in the `unit-tests` job.
+- Sandbox + `:global` CrdtDoc rooms: tests that exercise the CRDT path spin
+  global rooms that outlive the test; `test/support/data_case.ex` stops them in
+  `on_exit` before the sandbox owner is torn down (see #777). If you add CRDT
+  tests, keep them `async: false`.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.553",
+      version: "0.5.556",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# test-local.sh — run the backend ExUnit suite locally, fast.
+#
+# Runs `mix test` against a local Postgres (the `backend-postgres-1` docker
+# container on :5432, creds engram/engram — the defaults baked into
+# config/test.exs). The `test` mix alias self-bootstraps the DB
+# (ecto.create -> engram.prepare_database -> ecto.migrate -> test), so this
+# wrapper only handles the things that bite you otherwise:
+#
+#   * worktrees hardlink deps/ from the parent checkout, which carries the
+#     PARENT branch's mix.lock — a `deps.get` reconciles it to THIS tree's lock
+#     (skipped when already in sync, so it's cheap).
+#   * a stray DATABASE_URL in the shell overrides the localhost:5432 test
+#     defaults and silently points the suite at the wrong DB — we unset it.
+#   * Postgres must actually be reachable before mix tries to connect.
+#
+# Usage:
+#   scripts/test-local.sh                       # whole suite
+#   scripts/test-local.sh test/engram/foo_test.exs[:42]   # a file / line
+#   scripts/test-local.sh --teardown            # drop the test DB after the run
+#   scripts/test-local.sh --reset -- test/...   # drop+recreate test DB first
+#
+# Flags (must come before a literal `--`, or are sniffed from anywhere):
+#   --teardown   drop engram_test after the run (leaves the container alone)
+#   --reset      drop the test DB before running (forces a clean schema)
+# Everything else is passed straight through to `mix test`.
+#
+set -euo pipefail
+
+# Resolve the backend checkout this script lives in (works from any worktree).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_DIR"
+
+PG_HOST="${PGHOST:-localhost}"
+PG_PORT="${PGPORT:-5432}"
+
+teardown=0
+reset=0
+mix_args=()
+for arg in "$@"; do
+  case "$arg" in
+    --teardown) teardown=1 ;;
+    --reset)    reset=1 ;;
+    --)         ;; # separator, ignore
+    *)          mix_args+=("$arg") ;;
+  esac
+done
+
+# config/test.exs reads DATABASE_URL first; a stray one silently wins.
+unset DATABASE_URL
+
+echo "==> repo: $REPO_DIR"
+
+# 1. Postgres reachable? (bash /dev/tcp avoids a hard dep on pg_isready/nc.)
+if ! timeout 3 bash -c "exec 3<>/dev/tcp/$PG_HOST/$PG_PORT" 2>/dev/null; then
+  echo "ERROR: Postgres not reachable at $PG_HOST:$PG_PORT." >&2
+  echo "       Start the dev DB, e.g.:  docker start backend-postgres-1" >&2
+  exit 1
+fi
+echo "==> postgres ok at $PG_HOST:$PG_PORT"
+
+# 2. Reconcile deps to THIS tree's lock (no-op when already satisfied).
+mix deps.get >/dev/null
+
+# 3. Optional pre-run reset for a guaranteed-clean schema.
+if [ "$reset" = 1 ]; then
+  echo "==> dropping test DB (reset)"
+  MIX_ENV=test mix ecto.drop --quiet || true
+fi
+
+# 4. Run. The `test` alias creates+prepares+migrates idempotently first.
+echo "==> mix test ${mix_args[*]:-(full suite)}"
+status=0
+MIX_ENV=test mix test "${mix_args[@]}" || status=$?
+
+# 5. Optional teardown — drop the test DB only (never touches the container,
+#    which is shared with dev). The sandbox already reverts per-test data, so
+#    this is just for leaving zero schema behind.
+if [ "$teardown" = 1 ]; then
+  echo "==> dropping test DB (teardown)"
+  MIX_ENV=test mix ecto.drop --quiet || true
+fi
+
+exit "$status"

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -39,6 +39,41 @@ defmodule Engram.DataCase do
   def setup_sandbox(tags) do
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Engram.Repo, shared: not tags[:async])
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+
+    # A test may spin up `:global` CrdtDoc rooms (any test exercising the CRDT
+    # sync path). A room is a sandbox-using process that is NOT linked to the
+    # test, so it outlives the test and its `terminate` -> `CrdtPersistence.unbind/3`
+    # (a DB write) runs AFTER `stop_owner/1` above has torn down the connection's
+    # owner — checking out a dead-owner connection and poisoning the shared
+    # sandbox for every later test (see #777).
+    #
+    # Fix: synchronously stop any live rooms before the owner is stopped. on_exit
+    # is LIFO, so registering this AFTER the stop_owner callback runs it FIRST —
+    # the room's unbind executes while the shared connection is still checked in.
+    #
+    # Gated on shared (non-async) mode only: there, this test runs alone, so
+    # stopping every room is safe. In async mode rooms belong to concurrently
+    # running tests and must not be touched (and an async test cannot lend its
+    # connection to an unrelated room anyway).
+    unless tags[:async] do
+      on_exit(&stop_crdt_rooms/0)
+    end
+  end
+
+  # Stop every live CrdtDoc room synchronously so its terminate/unbind runs
+  # against the still-checked-in shared sandbox connection. Best-effort: a room
+  # already mid-exit just resolves to an :exit we swallow.
+  defp stop_crdt_rooms do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(Engram.Notes.CrdtDocSupervisor),
+        is_pid(pid) do
+      try do
+        GenServer.stop(pid, :normal, 5_000)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+
+    :ok
   end
 
   @doc """


### PR DESCRIPTION
## What

Fixes the order-dependent `unit-tests` flake (#777): `CrdtChannelTest` poisoning
the shared Ecto sandbox, cascading `DBConnection`/`owner exited` failures into
unrelated tests (`CacheSyncTest`, `DailyCapTest`).

## Root cause

Tests on the CRDT path spin up `:global` `CrdtDoc` rooms. A room is a
sandbox-using process **not linked to the test**, so it outlives the test; its
`terminate` -> `CrdtPersistence.unbind/3` (a DB write) runs *after*
`DataCase.setup_sandbox`'s `stop_owner/1` on_exit has torn down the connection's
owner. The room then checks out a dead-owner connection and poisons the shared
sandbox for every later test.

## Fix

`DataCase.setup_sandbox` now registers a second `on_exit` (after `stop_owner`, so
LIFO runs it **first**; gated on shared/non-async mode where the test runs alone)
that synchronously stops every live `CrdtDocSupervisor` room. The room's
unbind then executes while the shared sandbox connection is still checked in.

This self-heals the whole CRDT test class, including future CRDT tests.

## Validation

- Reproduced the poisoning trio (`crdt_channel_test` -> `cache_sync_test` ->
  `daily_cap_test`) failing pre-fix; green 3x post-fix.
- Full suite: **3211 tests, 0 failures**.

## Also

Adds `scripts/test-local.sh` + `docs/context/local-backend-testing.md` for fast
local `mix test` against the docker Postgres (per-worktree `deps.get`,
`DATABASE_URL` unset, optional `--teardown`/`--reset`).

Refs #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)