### PR TITLE
fix(email): point logo at engram.page + drop em dashes from copy

### DIFF
--- a/lib/engram/email/template.ex
+++ b/lib/engram/email/template.ex
@@ -32,8 +32,14 @@ defmodule Engram.Email.Template do
     |> Phoenix.HTML.safe_to_string()
   end
 
+  # Marketing-hosted absolute URL. The backend's own /email/engram-mark.png is
+  # unreachable in prod: app.engram.page is Cloudflare Pages (serves the SPA
+  # index.html for unknown paths) and api.engram.page rewrites /email ->
+  # /api/email -> 404. engram.page serves the asset reliably from public/.
+  @mark_url "https://engram.page/engram-mark.png"
+
   defp layout(body) do
-    mark_url = EngramWeb.Endpoint.url() <> "/email/engram-mark.png"
+    mark_url = @mark_url
 
     """
     <mjml>

--- a/lib/engram/mailer.ex
+++ b/lib/engram/mailer.ex
@@ -28,12 +28,12 @@ defmodule Engram.Mailer do
     body = """
     <mj-text font-size="18px" font-weight="600">Welcome to Engram, #{name}.</mj-text>
     <mj-text>Your account is ready. Engram keeps your Obsidian vault synced
-    across every device — and turns those notes into searchable, structured
+    across every device, and turns those notes into searchable, structured
     memory you can hand to any AI tool you use.</mj-text>
     <mj-text>To get started, install the Engram plugin in Obsidian and connect
     it to your account. Your notes start syncing immediately.</mj-text>
     <mj-button href="#{@install_url}" background-color="#{Tokens.brand_purple()}" color="#{Tokens.brand_purple_fg()}">Install the Engram plugin</mj-button>
-    <mj-text>— The Engram team</mj-text>
+    <mj-text>The Engram team</mj-text>
     """
 
     render_and_deliver(email, "Welcome to Engram", body)
@@ -54,7 +54,7 @@ defmodule Engram.Mailer do
       anything is removed.</p>
       <p>Just open Obsidian with the Engram plugin enabled and we'll
       reset the clock.</p>
-      <p>— Engram</p>
+      <p>Engram</p>
       """,
       []
     )
@@ -63,15 +63,15 @@ defmodule Engram.Mailer do
   def send_inactivity_warning_80(%User{email: email}) do
     deliver(
       email,
-      "Engram: final notice — 10 days until auto-delete",
+      "Engram: final notice, 10 days until auto-delete",
       """
       <p>Hi,</p>
       <p>This is your final notice. Your Engram vault will be auto-deleted
       in ~10 days unless you sync at least once before then.</p>
       <p>Open Obsidian with the Engram plugin enabled to keep your vault.
-      Already moved on? No action needed — your data will be removed
+      Already moved on? No action needed, your data will be removed
       automatically.</p>
-      <p>— Engram</p>
+      <p>Engram</p>
       """,
       []
     )
@@ -97,9 +97,9 @@ defmodule Engram.Mailer do
       """
       <p>Hi,</p>
       <p>Your Engram vault has been auto-deleted after 90 days of inactivity.
-      Your Clerk login is still active — you can sign back in and start
+      Your Clerk login is still active, you can sign back in and start
       fresh whenever you want.</p>
-      <p>— Engram</p>
+      <p>Engram</p>
       """
     }
   end
@@ -110,7 +110,7 @@ defmodule Engram.Mailer do
       """
       <p>Hi,</p>
       <p>You requested account deletion. Your data is being removed.</p>
-      <p>— Engram</p>
+      <p>Engram</p>
       """
     }
   end
@@ -122,7 +122,7 @@ defmodule Engram.Mailer do
       <p>Hi,</p>
       <p>Your account was deleted via your authentication provider.
       Your data is being removed.</p>
-      <p>— Engram</p>
+      <p>Engram</p>
       """
     }
   end
@@ -139,7 +139,7 @@ defmodule Engram.Mailer do
     body = """
     <mj-text>Your Engram vault "#{vault_name}" has been deleted.</mj-text>
     <mj-text>It will be permanently removed on #{purge_date}. Until then you can
-    restore it — or, if you meant to delete it, remove it permanently now — from
+    restore it, or if you meant to delete it, remove it permanently now, from
     your vault settings.</mj-text>
     <mj-button href="#{manage_url}" background-color="#{Tokens.brand_purple()}" color="#{Tokens.brand_purple_fg()}">Manage vault</mj-button>
     <mj-text>No action is needed if you want it gone; it will be cleaned up

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.559",
+      version: "0.5.560",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/email/template_test.exs
+++ b/test/engram/email/template_test.exs
@@ -20,9 +20,18 @@ defmodule Engram.Email.TemplateTest do
       refute html =~ "#5b5bd6"
     end
 
-    test "includes the mark image from the configured endpoint", %{html: html} do
-      assert html =~ "/email/engram-mark.png",
-             "expected the mark URL to appear in the rendered HTML"
+    test "includes the marketing-hosted mark image", %{html: html} do
+      assert html =~ "https://engram.page/engram-mark.png",
+             "expected the marketing-hosted mark URL in the rendered HTML"
+    end
+
+    test "does not reference the unreachable backend /email/ asset path", %{html: html} do
+      # app.engram.page is Cloudflare Pages (returns the SPA index.html) and
+      # api.engram.page rewrites /email -> /api/email -> 404, so the backend's
+      # own /email/engram-mark.png is unreachable. The logo must be the
+      # marketing-hosted absolute URL instead.
+      refute html =~ "/email/engram-mark.png",
+             "the backend /email/ asset path is unreachable in prod"
     end
 
     test "footer copy matches the memory-layer positioning", %{html: html} do

--- a/test/engram/mailer_test.exs
+++ b/test/engram/mailer_test.exs
@@ -114,6 +114,18 @@ defmodule Engram.MailerTest do
 
       assert :ok = Mailer.send_welcome(user)
     end
+
+    test "copy contains no em dashes" do
+      user = insert(:user, email: "user@example.com", display_name: "Sam")
+
+      expect(Engram.Email.ProviderMock, :send, fn _to, subject, html, _opts ->
+        refute subject =~ "—", "house style: no em dashes in copy"
+        refute html =~ "—", "house style: no em dashes in copy"
+        :ok
+      end)
+
+      assert :ok = Mailer.send_welcome(user)
+    end
   end
 
   describe "send_account_deleted_notice/2" do
@@ -124,6 +136,7 @@ defmodule Engram.MailerTest do
         assert to == "u@example.com"
         assert subject == "Engram: your vault was auto-deleted"
         assert html =~ "90 days of inactivity"
+        refute html =~ "—", "house style: no em dashes in copy"
         :ok
       end)
 
@@ -157,6 +170,32 @@ defmodule Engram.MailerTest do
     end
   end
 
+  describe "inactivity warnings" do
+    test "60-day warning copy contains no em dashes" do
+      user = insert(:user, email: "u@example.com")
+
+      expect(Engram.Email.ProviderMock, :send, fn _to, subject, html, _opts ->
+        refute subject =~ "—", "house style: no em dashes in copy"
+        refute html =~ "—", "house style: no em dashes in copy"
+        :ok
+      end)
+
+      assert :ok = Mailer.send_inactivity_warning_60(user)
+    end
+
+    test "80-day warning copy contains no em dashes" do
+      user = insert(:user, email: "u@example.com")
+
+      expect(Engram.Email.ProviderMock, :send, fn _to, subject, html, _opts ->
+        refute subject =~ "—", "house style: no em dashes in copy"
+        refute html =~ "—", "house style: no em dashes in copy"
+        :ok
+      end)
+
+      assert :ok = Mailer.send_inactivity_warning_80(user)
+    end
+  end
+
   describe "send_vault_deletion_notice/4" do
     test "returns :ok and includes the manage link, vault name, and purge date" do
       user = insert(:user, email: "u@example.com")
@@ -167,6 +206,8 @@ defmodule Engram.MailerTest do
         assert html =~ "My Vault"
         assert html =~ "June 27, 2026"
         assert html =~ "https://app.engram.page/settings/vaults?highlight=1"
+        refute subject =~ "—", "house style: no em dashes in copy"
+        refute html =~ "—", "house style: no em dashes in copy"
         :ok
       end)
 


### PR DESCRIPTION
## Why

Two transactional-email bugs.

### 1. Broken logo image
The email layout (`Engram.Email.Template`) referenced the logo via `EngramWeb.Endpoint.url() <> "/email/engram-mark.png"` → `https://app.engram.page/email/engram-mark.png` in prod (`PHX_HOST=app.engram.page`). That host is **Cloudflare Pages (the SPA)**, so the path returns `index.html` (text/html) → broken `<img>`. `api.engram.page` can't serve it either: `HostRewrite` rewrites `/email`→`/api/email`→404. The asset was unreachable on every host (never worked in prod).

Fix: point the layout at the marketing-hosted PNG, `https://engram.page/engram-mark.png` (added in **engram-marketing#141**). PNG, not the existing SVG, because Outlook/Gmail render SVG `<img>` poorly.

Affects the two layout-rendered emails: **welcome** and **vault-deletion notice**.

### 2. Em dashes in copy
House style: no em dashes in copy. Stripped them from all user-visible email strings (sign-offs `— Engram`/`— The Engram team`, prose, the `final notice — 10 days` subject). Module/function docstrings left as-is (dev-facing).

## Changes
- `email/template.ex`: logo `@mark_url` → `https://engram.page/engram-mark.png`
- `mailer.ex`: em dashes → period/comma; sign-offs → `Engram` / `The Engram team`

## Tests (TDD — red→green)
- `template_test.exs`: asserts the marketing-hosted URL + refutes the unreachable `/email/` path
- `mailer_test.exs`: `refute html/subject =~ "—"` across welcome, vault-deletion, inactivity 60/80, account-deleted
- `mix test test/engram/email/template_test.exs test/engram/mailer_test.exs` → **24 tests, 0 failures**; `mix format` + `mix credo` clean

## Sequencing
Depends on **engram-marketing#141** deploying first (so `https://engram.page/engram-mark.png` resolves). Merge/deploy that before tagging a backend release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)