### PR TITLE
ci: skip legal-cross-repo check on Dependabot PRs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2917,7 +2917,13 @@ jobs:
   # the mirror check so a marketing-only bump is caught there too.
   legal-cross-repo:
     name: legal cross-repo hash check
-    if: github.event_name != 'repository_dispatch'
+    # Skipped on Dependabot PRs: this job mints a GH App token to read the
+    # marketing repo, but Dependabot runs with the Dependabot secret scope
+    # so create-github-app-token fails ("private-key must be non-empty") and
+    # the job errors rather than skips — which the `ci` aggregate treats as
+    # fatal, permanently blocking dep bumps. Dependabot never touches legal
+    # docs, so skip it (mirrors how e2e-clerk is skipped for Dependabot).
+    if: github.event_name != 'repository_dispatch' && github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, linux, x64, isolated]
     steps:
       - name: Reset sparse-checkout leaked from cross-repo jobs

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.560",
+      version: "0.5.561",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

`legal-cross-repo` mints a GH App token (`create-github-app-token`) to read the marketing repo for the cross-repo legal-doc hash check. **Dependabot PRs run with the Dependabot secret scope**, so the private key is empty and the step errors:
```
The 'private-key' input must be set to a non-empty string.
```
The job **fails** (not skips). The `ci` aggregate's success-or-skipped loop includes `legal-cross-repo`, so a failure there makes `ci` exit 1 → `ci` is a required check → **every backend Dependabot PR is permanently blocked**. This is why #762 (a trivial GHA-version bump) couldn't merge even with unit-tests green.

## Fix

Skip `legal-cross-repo` for `dependabot[bot]` (it can't access the secret, and a dep bump never touches legal docs) — the same way `e2e-clerk` is already skipped for Dependabot. The `ci` loop then sees it as `skipped` and passes.

## Follow-up

Once this merges, `@dependabot recreate` on #762 picks it up and it auto-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)