### PR TITLE
fix(sync): scrub note_changed payload at sync-Channel egress (#738)

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -2919,24 +2919,27 @@ defmodule Engram.Notes do
     # release after the plugin min-version floor covers the hash-only
     # handler (self-host backends and plugins update on independent
     # cadences — do NOT remove early).
-    # `note` here is always either freshly written (upsert/batch scrub its
+    # `note` here is normally either freshly written (upsert/batch scrub its
     # content) or loaded through Crypto.maybe_decrypt_note_fields (read-boundary
-    # scrub), so its text fields are already valid UTF-8 — no per-field scrub
-    # needed at this broadcast site (#738).
-    payload = %{
-      "event_type" => "upsert",
-      "id" => note.id,
-      "path" => path,
-      "vault_id" => vault_id,
-      "content" => note.content || "",
-      "content_hash" => note.content_hash,
-      "title" => note.title || "",
-      "folder" => note.folder || "",
-      "tags" => note.tags || [],
-      "mtime" => note.mtime,
-      "updated_at" => note.updated_at,
-      "version" => note.version
-    }
+    # scrub), so its text fields are usually already valid UTF-8. The egress
+    # scrub below is the last line of defense (#738): a caller that reaches this
+    # site with unscrubbed content (a direct DB or CRDT write) would otherwise
+    # ship invalid bytes that crash the V2 JSON serializer and take down PubSub.
+    payload =
+      Helpers.scrub_broadcast_payload(%{
+        "event_type" => "upsert",
+        "id" => note.id,
+        "path" => path,
+        "vault_id" => vault_id,
+        "content" => note.content || "",
+        "content_hash" => note.content_hash,
+        "title" => note.title || "",
+        "folder" => note.folder || "",
+        "tags" => note.tags || [],
+        "mtime" => note.mtime,
+        "updated_at" => note.updated_at,
+        "version" => note.version
+      })
 
     topic = "sync:#{user_id}:#{vault_id}"
 

--- a/lib/engram/notes/helpers.ex
+++ b/lib/engram/notes/helpers.ex
@@ -27,7 +27,7 @@ defmodule Engram.Notes.Helpers do
     if String.valid?(str), do: str, else: do_scrub_utf8(str, <<>>)
   end
 
-  @scrub_boundaries [:write, :read, :search, :backfill]
+  @scrub_boundaries [:write, :read, :search, :backfill, :broadcast]
 
   @doc """
   Boundary-instrumented `scrub_utf8/1`. On the scrub slow path (invalid bytes
@@ -46,10 +46,15 @@ defmodule Engram.Notes.Helpers do
       spike `:write` and page on-call with a false "buggy client" signal — the
       repair pre-scrubs here, then the write path sees already-valid content
       and fast-paths (no `:write` tick).
+    * **`:broadcast`** — the sync-Channel egress (#738). Defense-in-depth: the
+      `note_changed` payload is scrubbed just before `Jason` encodes it, so even
+      a caller that hands the broadcast site content bypassing the write/read
+      scrubs (a direct DB or CRDT write) never crashes the serializer. Like
+      `:read`, counter-only — never pages.
 
   Valid input takes the fast path with no telemetry and no allocation.
   """
-  @spec scrub_utf8(String.t(), :write | :read | :search | :backfill) :: String.t()
+  @spec scrub_utf8(String.t(), :write | :read | :search | :backfill | :broadcast) :: String.t()
   def scrub_utf8(str, boundary) when is_binary(str) and boundary in @scrub_boundaries do
     if String.valid?(str) do
       str
@@ -78,6 +83,52 @@ defmodule Engram.Notes.Helpers do
 
   defp do_scrub_utf8(<<_bad, rest::binary>>, acc),
     do: do_scrub_utf8(rest, <<acc::binary, "�">>)
+
+  # Text fields of a `note_changed` upsert payload that originate from decrypted
+  # note content and so could carry invalid UTF-8 at rest. `path` is structural
+  # (sanitized + HMAC-validated at write) and always valid, so it is left alone.
+  @broadcast_text_fields ~w(content title folder)
+
+  @doc """
+  Scrubs the string fields of a `note_changed` broadcast payload to valid UTF-8
+  at the sync-Channel egress (#738 defense-in-depth).
+
+  Content/title/folder/tags decrypt from `bytea` ciphertext that bypasses
+  Postgres's UTF-8 guard; the write and read boundaries already scrub, but this
+  final pass keeps the channel self-defending against any caller (a direct DB or
+  CRDT write) that reaches the broadcast site with unscrubbed bytes — invalid
+  UTF-8 would otherwise crash the V2 JSON serializer and take down PubSub.
+
+  Only keys that are present and binary are touched, so the metadata-only
+  `delete` payload passes through untouched. Valid payloads return unchanged.
+  """
+  @spec scrub_broadcast_payload(map()) :: map()
+  def scrub_broadcast_payload(payload) when is_map(payload) do
+    payload
+    |> scrub_broadcast_text_fields()
+    |> scrub_broadcast_tags()
+  end
+
+  defp scrub_broadcast_text_fields(payload) do
+    Enum.reduce(@broadcast_text_fields, payload, fn key, acc ->
+      case acc do
+        %{^key => value} when is_binary(value) ->
+          %{acc | key => scrub_utf8(value, :broadcast)}
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp scrub_broadcast_tags(%{"tags" => tags} = payload) when is_list(tags) do
+    %{payload | "tags" => Enum.map(tags, &scrub_broadcast_tag/1)}
+  end
+
+  defp scrub_broadcast_tags(payload), do: payload
+
+  defp scrub_broadcast_tag(tag) when is_binary(tag), do: scrub_utf8(tag, :broadcast)
+  defp scrub_broadcast_tag(tag), do: tag
 
   @doc """
   Extracts the note title from content (frontmatter > h1 heading > filename).

--- a/lib/engram/prom_ex/notes.ex
+++ b/lib/engram/prom_ex/notes.ex
@@ -5,7 +5,7 @@ defmodule Engram.PromEx.Notes do
   Subscribes to:
 
     * `[:engram, :notes, :utf8_scrub]` — `%{count: 1}`, metadata
-      `%{boundary: :write | :read | :search | :backfill}`. Emitted on the scrub
+      `%{boundary: :write | :read | :search | :backfill | :broadcast}`. Emitted on the scrub
       slow path (invalid UTF-8 found at a JSON-materializing boundary, see
       `Engram.Notes.Helpers.scrub_utf8/2`). A rising `boundary="write"` rate
       means new corruption is entering at rest — a buggy client — and is the
@@ -45,7 +45,8 @@ defmodule Engram.PromEx.Notes do
         counter(
           metric_prefix ++ [:utf8_scrub, :total],
           event_name: @utf8_scrub_event,
-          description: "Invalid-UTF-8 scrubs by boundary (write | read | search).",
+          description:
+            "Invalid-UTF-8 scrubs by boundary (write | read | search | backfill | broadcast).",
           tags: [:boundary]
         )
       ]

--- a/lib/engram_web/telemetry.ex
+++ b/lib/engram_web/telemetry.ex
@@ -191,7 +191,8 @@ defmodule EngramWeb.Telemetry do
       # once the #739 backfill runs. Scraped to Grafana via Engram.PromEx.Notes.
       counter("engram.notes.utf8_scrub.count",
         tags: [:boundary],
-        description: "Invalid-UTF-8 scrubs by boundary (:write | :read | :search)"
+        description:
+          "Invalid-UTF-8 scrubs by boundary (:write | :read | :search | :backfill | :broadcast)"
       ),
       counter("engram.search.payload_shape_mismatch.count",
         description: "Qdrant payload shape mismatches — drift between writer and reader"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.561",
+      version: "0.5.562",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/helpers_test.exs
+++ b/test/engram/notes/helpers_test.exs
@@ -29,6 +29,47 @@ defmodule Engram.Notes.HelpersTest do
     end
   end
 
+  describe "scrub_broadcast_payload/1" do
+    test "scrubs every text field of a note_changed payload to valid UTF-8" do
+      bad = "body" <> <<0xE2>> <> "tail"
+
+      payload = %{
+        "event_type" => "upsert",
+        "path" => "Test/Note.md",
+        "content" => bad,
+        "title" => "Title" <> <<0xE2>>,
+        "folder" => "Folder" <> <<0xE2>>,
+        "tags" => ["clean", "dirty" <> <<0xE2>>],
+        "version" => 3
+      }
+
+      out = Helpers.scrub_broadcast_payload(payload)
+
+      # The whole payload is what crashed Phoenix.PubSub/Jason on #738.
+      assert {:ok, _} = Jason.encode(out)
+      assert String.valid?(out["content"])
+      assert String.valid?(out["title"])
+      assert String.valid?(out["folder"])
+      assert Enum.all?(out["tags"], &String.valid?/1)
+      # Bad bytes are replaced, not dropped — the rest of the text survives.
+      assert out["content"] =~ "body"
+      assert out["content"] =~ "tail"
+      # Non-text fields pass through untouched.
+      assert out["version"] == 3
+      assert out["event_type"] == "upsert"
+    end
+
+    test "leaves an already-valid payload byte-identical" do
+      payload = %{"content" => "clean", "title" => "T", "folder" => "F", "tags" => ["a", "b"]}
+      assert Helpers.scrub_broadcast_payload(payload) == payload
+    end
+
+    test "tolerates a payload missing the optional text fields (delete shape)" do
+      payload = %{"event_type" => "delete", "path" => "Test/Gone.md", "vault_id" => "v"}
+      assert Helpers.scrub_broadcast_payload(payload) == payload
+    end
+  end
+
   describe "scrub_utf8/2 instrumentation" do
     import ExUnit.CaptureLog
 

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -206,6 +206,52 @@ defmodule Engram.NotesTest do
       assert payload["content"] =~ "broadcast"
     end
 
+    test "#738: note_changed broadcast from rename is JSON-safe for a note corrupt at rest",
+         %{user: user, vault: vault} do
+      import Ecto.Query, only: [from: 2]
+
+      # Legacy row: written before the #740 write-time scrub, so its content
+      # decrypts to invalid UTF-8. Rename only changes the path, then re-broadcasts
+      # the note's content over the sync Channel — exercising the read-boundary
+      # scrub, NOT the upsert write scrub the other #738 test covers. Build a clean
+      # note, then overwrite its content ciphertext in place with invalid bytes.
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Test/Rename Me.md",
+          "content" => "# Title\n\nclean placeholder",
+          "mtime" => 1.0
+        })
+
+      bad = "# Title\n\nrenamed" <> <<0xE2>> <> "payload"
+
+      {:ok, enc} =
+        Engram.Crypto.encrypt_note_fields(%{content: bad, title: "Title"}, user, note.id)
+
+      {:ok, {1, _}} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          from(n in Engram.Notes.Note, where: n.id == ^note.id)
+          |> Engram.Repo.update_all(
+            set: [content_ciphertext: enc.content_ciphertext, content_nonce: enc.content_nonce]
+          )
+        end)
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      {:ok, _} = Notes.rename_note(user, vault, "Test/Rename Me.md", "Test/Renamed.md")
+
+      # rename emits a metadata-only "delete" for the old path, then an "upsert"
+      # carrying the note body — that upsert is the payload that crashed #738.
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: %{"event_type" => "upsert"} = payload
+      }
+
+      assert {:ok, _} = Jason.encode(payload)
+      assert String.valid?(payload["content"])
+      assert String.valid?(payload["title"])
+      assert payload["content"] =~ "renamed"
+    end
+
     test "content_hash is HMAC-SHA256 (64-char hex), not legacy MD5",
          %{user: user, vault: vault} do
       content = "# Hash Format Probe\nbody"


### PR DESCRIPTION
## What

Adds a defense-in-depth UTF-8 scrub at the sync-Channel egress so an invalid-UTF-8 `note_changed` payload can never crash the Phoenix V2 JSON serializer (which terminated `Engram.PubSub.Adapter` in the #738 prod incident).

## Why

Investigation found the root cause was **already fixed by #740** (the #727 fix): `content`/`title`/`folder`/`tags` are virtual fields sourced only from `Crypto.maybe_decrypt_note_fields` (read-boundary scrub), and `upsert_note`/batch scrub on write. So every *current* broadcast path is UTF-8-safe.

#738 stayed open as (a) a coverage gap — the existing test only exercised the **write** path — and (b) the channel egress relying on an upstream invariant rather than self-defending. This PR closes both.

## Changes

- `Helpers.scrub_broadcast_payload/1` — scrubs `content`/`title`/`folder`/`tags` (only when present + binary; `path` left as-is: structural, HMAC-validated, always valid). On a new `:broadcast` telemetry boundary (counter-only, never pages — like `:read`).
- Wired into `broadcast_change`'s upsert payload in `notes.ex`; updated the stale "no scrub needed here" comment.
- Boundary enumeration doc-strings in `prom_ex/notes.ex` + `telemetry.ex` updated to include `:backfill | :broadcast`.
- Version bump 0.5.561 → 0.5.562.

## Tests (TDD red→green)

- `helpers_test.exs` — unit tests: all text fields → valid UTF-8, valid payloads byte-identical, delete-shape payload passes through.
- `notes_test.exs` — regression: a note **corrupt at rest** (invalid ciphertext), renamed, broadcasts a JSON-safe payload — exercises the read-boundary/rename egress path the original #738 test missed.

Verify: `mix format` + `mix credo` clean; full notes/helpers/crypto/telemetry suites green (209 + 29 tests, 0 failures). Independent code review: no correctness/security/convention issues.

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)