### PR TITLE
test(notes): guard list_folders count == list_folder contract (#728)

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -2105,6 +2105,11 @@ defmodule Engram.Notes do
         # Per folder_hmac, pick any one row (for envelope decryption) and
         # count only kind='note' rows. Marker-only folders yield count 0;
         # mixed folders yield the note count (markers excluded).
+        #
+        # The count MUST equal what `list_notes_in_folder/3` returns for the
+        # same folder (both read kind='note' rows grouped by folder_hmac) — the
+        # MCP `list_folders` vs `list_folder` contract (#728). Guarded by the
+        # "invariant vs list_notes_in_folder/3 (#728)" tests in notes_test.exs.
         {:ok, rows} =
           Repo.with_tenant(user.id, fn ->
             Repo.all(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.562",
+      version: "0.5.563",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -1101,6 +1101,70 @@ defmodule Engram.NotesTest do
     end
   end
 
+  describe "list_folders_with_counts/2 invariant vs list_notes_in_folder/3 (#728)" do
+    # The MCP `list_folders` count MUST equal what `list_folder` actually
+    # returns for the same folder. #728: list_folders reported 1 for a folder
+    # that held 3 notes. Assert the invariant across folder shapes.
+    #
+    # Two directions, so neither a count mismatch NOR a dropped folder can
+    # slip past: (1) every `expected` folder is present in the result, and
+    # (2) every returned folder's count equals its `list_notes_in_folder` length.
+    defp assert_counts_match(user, vault, expected) do
+      {:ok, folders} = Notes.list_folders_with_counts(user, vault)
+      returned = MapSet.new(folders, & &1.folder)
+
+      for folder <- expected do
+        assert MapSet.member?(returned, folder),
+               "expected folder #{inspect(folder)} in list_folders_with_counts, " <>
+                 "got #{inspect(Enum.sort(returned))}"
+      end
+
+      for %{folder: folder, count: count} <- folders do
+        {:ok, notes} = Notes.list_notes_in_folder(user, vault, folder)
+
+        assert count == length(notes),
+               "folder #{inspect(folder)}: list_folders count=#{count} but " <>
+                 "list_notes_in_folder returned #{length(notes)}"
+      end
+    end
+
+    test "flat folder with 3 notes", %{user: user, vault: vault} do
+      for i <- 1..3 do
+        Notes.upsert_note(user, vault, %{
+          "path" => "Todos/Task#{i}.md",
+          "content" => "t#{i}",
+          "mtime" => 1.0
+        })
+      end
+
+      assert_counts_match(user, vault, ["Todos"])
+    end
+
+    test "nested folders: parent with direct notes + subfolder with notes",
+         %{user: user, vault: vault} do
+      Notes.upsert_note(user, vault, %{"path" => "Todos/A.md", "content" => "a", "mtime" => 1.0})
+      Notes.upsert_note(user, vault, %{"path" => "Todos/B.md", "content" => "b", "mtime" => 1.0})
+
+      Notes.upsert_note(user, vault, %{
+        "path" => "Todos/Sub/C.md",
+        "content" => "c",
+        "mtime" => 1.0
+      })
+
+      assert_counts_match(user, vault, ["Todos", "Todos/Sub"])
+    end
+
+    test "mixed: root notes + marker folder + populated folder",
+         %{user: user, vault: vault} do
+      Notes.upsert_note(user, vault, %{"path" => "Root.md", "content" => "r", "mtime" => 1.0})
+      {:ok, _} = Notes.create_folder_marker(user, vault, "Empty")
+      Notes.upsert_note(user, vault, %{"path" => "Work/X.md", "content" => "x", "mtime" => 1.0})
+      Notes.upsert_note(user, vault, %{"path" => "Work/Y.md", "content" => "y", "mtime" => 1.0})
+
+      assert_counts_match(user, vault, ["", "Empty", "Work"])
+    end
+  end
+
   describe "list_folders_with_counts/2 with markers" do
     test "marker for an otherwise-empty folder appears with count 0",
          %{user: user, vault: vault} do


### PR DESCRIPTION
## TL;DR

#728 reported `list_folders` showing **1** note for a folder that held **3**, then self-correcting. **The count query is correct** — investigation found no query-level bug. This PR locks the contract the issue asked for with an invariant guard test and closes the ticket.

## Investigation

`list_folders_with_counts/2` (the MCP `list_folders` source) and `list_notes_in_folder/3` (the `list_folder` source) both read `kind='note'` rows grouped by `folder_hmac` under the same `user`/`vault`/`deleted_at` filters. They cannot diverge for consistent data. Reproduced the invariant across **flat, nested, marker+notes, and root** shapes — all hold.

The observed "1 vs 3" was **transient**:
- a read concurrent with async ingest (notes still committing), or
- a `folder_hmac` skew window during `UserDekRotation` (re-HMACs `folder_hmac` with the new key). Note: in that state **both** queries undercount in lockstep, so they still agree — there's no clean query fix, and the invariant alone can't detect it.

So there is no one-line code bug. The defect, if any, is `folder_hmac` canonicality during rotation — a separate data-consistency concern, intentionally out of scope here.

## Change

- **Guard test** — `list_folders` count `== length(list_notes_in_folder(folder))` across folder shapes (exactly the assertion #728 requested), so a future query change can't silently make the two sources of truth diverge.
- **Doc comment** at `list_folders_with_counts/2` pointing to the guard + the `list_folder` contract.
- Version bump 0.5.562 → 0.5.563.

No production behavior change. `mix format` clean; all 10 `list_folders_with_counts` tests pass.

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)