### PR TITLE
fix(vaults): revoke vault-scoped tokens on soft-delete (#764)

### DIFF
--- a/lib/engram/connections.ex
+++ b/lib/engram/connections.ex
@@ -126,6 +126,38 @@ defmodule Engram.Connections do
   end
 
   @doc """
+  Revokes all active OAuth refresh tokens and device refresh tokens scoped to
+  `vault_id` for `user_id`.
+
+  Called at vault soft-delete time so the connections page clears immediately.
+  Idempotent — safe to call twice.
+  """
+  @spec revoke_by_vault(Ecto.UUID.t(), Ecto.UUID.t()) :: :ok
+  def revoke_by_vault(user_id, vault_id) do
+    now = DateTime.utc_now(:second)
+
+    Repo.update_all(
+      from(t in RefreshToken,
+        where: t.user_id == ^user_id,
+        where: t.vault_id == ^vault_id,
+        where: is_nil(t.revoked_at)
+      ),
+      set: [revoked_at: now]
+    )
+
+    Repo.update_all(
+      from(rt in DeviceRefreshToken,
+        where: rt.user_id == ^user_id,
+        where: rt.vault_id == ^vault_id,
+        where: is_nil(rt.revoked_at)
+      ),
+      set: [revoked_at: now]
+    )
+
+    :ok
+  end
+
+  @doc """
   Revokes (sets `revoked_at = now`) all active device refresh tokens for
   `(user_id, family_id)`.
 

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -482,6 +482,7 @@ defmodule Engram.Vaults do
 
           case result do
             {:ok, deleted} ->
+              _ = Engram.Connections.revoke_by_vault(deleted.user_id, deleted.id)
               _ = Engram.Workers.CleanupVault.enqueue(deleted.id, deleted.user_id)
               _ = Engram.Workers.VaultDeletedEmail.enqueue(deleted.user_id, deleted.id)
               emit_vault_count(deleted.user_id, :deleted)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.563",
+      version: "0.5.564",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/connections_test.exs
+++ b/test/engram/connections_test.exs
@@ -487,5 +487,33 @@ defmodule Engram.ConnectionsTest do
       assert :ok = Connections.revoke_by_vault(user.id, vault.id)
       assert :ok = Connections.revoke_by_vault(user.id, vault.id)
     end
+
+    test "returns :ok and revokes nothing for a vault with no tokens" do
+      user = insert_user()
+      vault = insert(:vault, user: user)
+
+      assert :ok = Connections.revoke_by_vault(user.id, vault.id)
+    end
+
+    test "leaves OAuth grants with no vault binding (vault_id: nil) untouched" do
+      # vault_id is cast-only on OAuth refresh tokens (not required), so a grant
+      # can have nil binding. Such a grant is NOT scoped to any vault — it shows
+      # on the connections page with vault_id: nil, independent of any vault.
+      # Deleting a vault must not collaterally revoke it.
+      user = insert_user()
+      vault = insert(:vault, user: user)
+      client = insert(:oauth_client, kind: "mcp")
+
+      insert(:oauth_refresh_token,
+        user_id: user.id,
+        client_id: client.client_id,
+        vault_id: nil
+      )
+
+      assert :ok = Connections.revoke_by_vault(user.id, vault.id)
+
+      # The unbound grant survives — it was never the deleted vault's connection
+      assert Connections.count_active(user.id, :mcp) == 1
+    end
   end
 end

--- a/test/engram/connections_test.exs
+++ b/test/engram/connections_test.exs
@@ -410,4 +410,82 @@ defmodule Engram.ConnectionsTest do
       assert Connections.count_active(other.id, :obsidian) == 1
     end
   end
+
+  describe "revoke_by_vault/2" do
+    test "revokes all active OAuth tokens scoped to the vault" do
+      user = insert_user()
+      vault = insert(:vault, user: user)
+      other_vault = insert(:vault, user: user)
+      client = insert(:oauth_client, kind: "mcp")
+
+      insert(:oauth_refresh_token,
+        user_id: user.id,
+        client_id: client.client_id,
+        vault_id: vault.id
+      )
+
+      insert(:oauth_refresh_token,
+        user_id: user.id,
+        client_id: client.client_id,
+        vault_id: other_vault.id
+      )
+
+      assert :ok = Connections.revoke_by_vault(user.id, vault.id)
+
+      # The other-vault token must survive
+      assert Connections.count_active(user.id, :mcp) == 1
+    end
+
+    test "revokes all active device tokens scoped to the vault" do
+      user = insert_user()
+      vault = insert(:vault, user: user)
+      other_vault = insert(:vault, user: user)
+
+      family1 = Ecto.UUID.generate()
+      family2 = Ecto.UUID.generate()
+      insert(:device_refresh_token, user: user, vault: vault, family_id: family1)
+      insert(:device_refresh_token, user: user, vault: other_vault, family_id: family2)
+
+      assert :ok = Connections.revoke_by_vault(user.id, vault.id)
+
+      # The other-vault device token must survive
+      assert Connections.count_active(user.id, :obsidian) == 1
+    end
+
+    test "does not touch tokens belonging to a different user" do
+      user = insert_user()
+      other = insert_user()
+      vault = insert(:vault, user: other)
+      client = insert(:oauth_client, kind: "mcp")
+
+      insert(:oauth_refresh_token,
+        user_id: other.id,
+        client_id: client.client_id,
+        vault_id: vault.id
+      )
+
+      insert(:device_refresh_token, user: other, vault: vault)
+
+      assert :ok = Connections.revoke_by_vault(user.id, vault.id)
+
+      # other user's connections must be untouched
+      assert Connections.count_active(other.id, :mcp) == 1
+      assert Connections.count_active(other.id, :obsidian) == 1
+    end
+
+    test "is idempotent — second call on already-revoked vault returns :ok" do
+      user = insert_user()
+      vault = insert(:vault, user: user)
+      client = insert(:oauth_client, kind: "mcp")
+
+      insert(:oauth_refresh_token,
+        user_id: user.id,
+        client_id: client.client_id,
+        vault_id: vault.id
+      )
+
+      assert :ok = Connections.revoke_by_vault(user.id, vault.id)
+      assert :ok = Connections.revoke_by_vault(user.id, vault.id)
+    end
+  end
 end

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -3,6 +3,7 @@ defmodule Engram.VaultsTest do
   use Oban.Testing, repo: Engram.Repo
 
   alias Engram.Billing.OverrideCache
+  alias Engram.Connections
   alias Engram.Vaults
 
   setup do
@@ -563,6 +564,26 @@ defmodule Engram.VaultsTest do
         worker: Engram.Workers.VaultDeletedEmail,
         args: %{vault_id: v.id, user_id: user.id}
       )
+    end
+
+    test "revokes vault-scoped OAuth and device tokens on soft-delete", %{user: user} do
+      {:ok, vault} = Vaults.create_vault(user, %{name: "Gone"})
+      client = insert(:oauth_client, kind: "mcp")
+      family_id = Ecto.UUID.generate()
+
+      insert(:oauth_refresh_token,
+        user_id: user.id,
+        client_id: client.client_id,
+        vault_id: vault.id
+      )
+
+      insert(:device_refresh_token, user: user, vault: vault, family_id: family_id)
+
+      assert {:ok, _} = Vaults.delete_vault(user, vault.id)
+
+      # Both token kinds revoked immediately — no 30-day wait
+      assert Connections.count_active(user.id, :mcp) == 0
+      assert Connections.count_active(user.id, :obsidian) == 0
     end
   end
 

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -567,23 +567,40 @@ defmodule Engram.VaultsTest do
     end
 
     test "revokes vault-scoped OAuth and device tokens on soft-delete", %{user: user} do
-      {:ok, vault} = Vaults.create_vault(user, %{name: "Gone"})
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, gone} = Vaults.create_vault(user, %{name: "Gone"})
+      {:ok, kept} = Vaults.create_vault(user, %{name: "Kept"})
       client = insert(:oauth_client, kind: "mcp")
-      family_id = Ecto.UUID.generate()
 
+      # Connections on the doomed vault…
       insert(:oauth_refresh_token,
         user_id: user.id,
         client_id: client.client_id,
-        vault_id: vault.id
+        vault_id: gone.id
       )
 
-      insert(:device_refresh_token, user: user, vault: vault, family_id: family_id)
+      insert(:device_refresh_token, user: user, vault: gone, family_id: Ecto.UUID.generate())
 
-      assert {:ok, _} = Vaults.delete_vault(user, vault.id)
+      # …and connections on a vault that survives.
+      insert(:oauth_refresh_token,
+        user_id: user.id,
+        client_id: client.client_id,
+        vault_id: kept.id
+      )
 
-      # Both token kinds revoked immediately — no 30-day wait
-      assert Connections.count_active(user.id, :mcp) == 0
-      assert Connections.count_active(user.id, :obsidian) == 0
+      insert(:device_refresh_token, user: user, vault: kept, family_id: Ecto.UUID.generate())
+
+      assert {:ok, _} = Vaults.delete_vault(user, gone.id)
+
+      # The deleted vault's connections vanish from the page immediately (the
+      # #764 symptom is the connections list, not just the active count).
+      vault_ids = user |> Connections.list_for_user() |> Enum.map(& &1.vault_id)
+      refute gone.id in vault_ids
+      assert kept.id in vault_ids
+
+      # Both kept-vault token kinds remain active — no collateral revocation.
+      assert Connections.count_active(user.id, :mcp) == 1
+      assert Connections.count_active(user.id, :obsidian) == 1
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds `Connections.revoke_by_vault/2` — sets `revoked_at = now` on all active OAuth refresh tokens and device refresh tokens for a given `(user_id, vault_id)` pair
- Calls it from `delete_vault/2` immediately after soft-delete so the connections page clears right away
- 5 new tests: 4 in `ConnectionsTest` covering the function contract, 1 in `VaultsTest` asserting the integration

## Root cause

`delete_vault/2` sets `deleted_at` but never touched any tokens. OAuth tokens (`refresh_tokens.vault_id`) have no FK constraint and orphaned permanently. Device tokens (`device_refresh_tokens.vault_id`) have `ON DELETE CASCADE` but that only fires at hard-delete (30 days later via `CleanupVault`). Both types stayed active, so the connections page kept showing a phantom entry with `vault_name: nil` (rendered as `#<uuid>` in the frontend) with no way to surface that the vault was gone.

## Test plan

- `mix test test/engram/connections_test.exs test/engram/vaults_test.exs` — 103 tests, 0 failures
- Pre-push: format ✓ compile ✓ credo ✓ sobelow ✓

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)