### PR TITLE
fix(db): UTC-pin three naive-timestamp now() defaults

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.566",
+      version: "0.5.567",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260629240000_utc_naive_defaults_expand.exs
+++ b/priv/repo/migrations/20260629240000_utc_naive_defaults_expand.exs
@@ -1,0 +1,32 @@
+defmodule Engram.Repo.Migrations.UtcNaiveDefaultsExpand do
+  use Ecto.Migration
+
+  @moduledoc """
+  phase/expand — metadata-only `ALTER COLUMN SET DEFAULT` (no table rewrite,
+  no lock, forward-compatible).
+
+  Three columns are `timestamp` (naive) but carry a DB-side `now()` default.
+  `now()` returns `timestamptz`; coercing it into a naive column uses the
+  server's TimeZone GUC, so the stored value is only UTC while the GUC is UTC.
+  Pin them to `timezone('UTC', now())`, which produces a UTC-naive value
+  regardless of the session timezone — the same form Oban already uses.
+
+  Audit finding Engram#792. `user_agreements.accepted_at` is the
+  compliance-relevant one (recorded ToS acceptance time). The columns stay
+  naive `timestamp` (consistent with the rest); only the default changes.
+  """
+
+  def up do
+    execute "ALTER TABLE usage_meters ALTER COLUMN updated_at SET DEFAULT timezone('UTC', now())"
+
+    execute "ALTER TABLE user_agreements ALTER COLUMN accepted_at SET DEFAULT timezone('UTC', now())"
+
+    execute "ALTER TABLE user_limit_overrides ALTER COLUMN set_at SET DEFAULT timezone('UTC', now())"
+  end
+
+  def down do
+    execute "ALTER TABLE usage_meters ALTER COLUMN updated_at SET DEFAULT now()"
+    execute "ALTER TABLE user_agreements ALTER COLUMN accepted_at SET DEFAULT now()"
+    execute "ALTER TABLE user_limit_overrides ALTER COLUMN set_at SET DEFAULT now()"
+  end
+end


### PR DESCRIPTION
Audit follow-up (#792). **`phase/expand`** — metadata-only `ALTER COLUMN SET DEFAULT` (no table rewrite, no lock).

`usage_meters.updated_at`, `user_agreements.accepted_at` (compliance — ToS acceptance time), and `user_limit_overrides.set_at` are naive `timestamp` columns with a `now()` default. `now()` returns `timestamptz`; coercing it into a naive column uses the server `TimeZone` GUC, so the stored value is only UTC while the GUC is UTC. Pin them to `timezone('UTC', now())` — UTC-naive regardless of session tz (the form Oban already uses).

The 69 other naive columns are left as-is (UTC convention holds; squawk's `prefer-timestamptz` already guards new ones).

**Scope note:** the RLS-coverage item from #792 turned out to be **already guarded** — `test/engram/rls_coverage_test.exs` (added in #476) already asserts every user_id table is RLS or allowlisted, and already lists `subscriptions` + `account_exports` as deliberately app-scoped (webhook/worker access). So no RLS change here.

## Test plan
Migration up/down/up verified; default confirmed = `timezone('UTC', now())`. Pre-push: format ✓ compile ✓ credo ✓ sobelow ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)