### PR TITLE
feat(crdt): frontmatter as Y.Map — backend (1/3)

### DIFF
--- a/.superpowers/sdd/credo-alias-fix-report.md
+++ b/.superpowers/sdd/credo-alias-fix-report.md
@@ -1,0 +1,32 @@
+# Credo AliasUsage Fix Report
+
+## Summary
+
+Fixed 28 `AliasUsage` findings (all `Engram.Notes.*` nested modules used
+fully-qualified inside modules that never declared an alias) so that
+`mix credo --strict` exits 0 under Elixir 1.17.3 (mise-pinned).
+
+## Files Changed
+
+### `lib/engram/notes/crdt_bridge.ex`
+
+- Added `alias Engram.Notes.Frontmatter` after `import Bitwise` (3 sites fixed).
+- Replaced 3 fully-qualified `Engram.Notes.Frontmatter.*` calls:
+  - `project_doc/1`: `Engram.Notes.Frontmatter.project(...)` -> `Frontmatter.project(...)`
+  - `ingest_plaintext/2`: `Engram.Notes.Frontmatter.split(...)` -> `Frontmatter.split(...)`
+  - `ingest_plaintext/2`: `Engram.Notes.Frontmatter.parse(...)` -> `Frontmatter.parse(...)`
+
+### `test/engram/notes/crdt_bridge_test.exs`
+
+- The module already had `alias Engram.Notes.CrdtBridge` at the top.
+- Replaced all 24 fully-qualified `Engram.Notes.CrdtBridge.*` calls with the
+  short `CrdtBridge.*` form across 5 describe blocks + top-level tests using
+  `replace_all` (pure mechanical rename, zero logic changes).
+
+## Verification
+
+- `mix credo --strict` (mise exec, Elixir 1.17.3): **exit 0, "found no issues"**
+  (3537 mods/funs, 663 source files, 12.0 s analysis)
+- `mix compile` (mise exec): clean, 2 files compiled, 0 warnings on our files
+- `mix test test/engram/notes/crdt_bridge_test.exs` (mise exec): all green
+- `mix format` applied to both changed files before commit

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,0 +1,101 @@
+# Task 3: Frontmatter `parse/1` Review Fixes
+
+## Summary
+Fixed two review findings in `Engram.Notes.Frontmatter.parse/1`:
+1. Replaced raising `Jason.encode!/1` with non-raising `Jason.encode/1`
+2. Added three new test cases covering nested maps, inline colons, and bare lists
+
+## Changes
+
+### Implementation (`lib/engram/notes/frontmatter.ex`)
+- Changed parse/1 from direct `Jason.encode!(v)` to call new helper `encode_values/1`
+- Added `encode_values/1` helper function (lines 74-89) that:
+  - Uses `Enum.reduce_while` to encode all map values
+  - Returns `{:ok, values_map}` on success
+  - Returns `:error` if ANY value fails to encode (exotic types like tuples)
+  - Folds encode failures into the same `:error` path as malformed YAML
+- Updated docstring to reflect non-raising behavior
+
+### Tests (`test/engram/notes/frontmatter_test.exs`)
+Added three new test cases:
+1. **nested map value**: verifies JSON encoding of nested maps and order exclusion of nested keys
+2. **inline colon in value**: verifies regex correctly extracts key despite colon in value
+3. **bare list**: verifies rejection of non-map YAML (YamlElixir returns list, triggers `is_map/1` guard)
+
+## Test Results
+```
+Running ExUnit with seed: 262008, max_cases: 20
+Excluding tags: [:qdrant_integration, :cluster, :integration]
+
+.............
+Finished in 0.3 seconds (0.3s async, 0.00s sync)
+13 tests, 0 failures
+```
+
+All existing tests continue to pass. No changes to existing test behavior.
+
+## Command
+```bash
+cd /home/open-claw/documents/code-projects/engram/.worktrees/feat-crdt-fm-backend && \
+mix format lib/engram/notes/frontmatter.ex test/engram/notes/frontmatter_test.exs && \
+mix test test/engram/notes/frontmatter_test.exs
+```
+
+---
+
+## Critical Review Fix: encode_values/1 error match arm
+
+### Bug
+The `reduce_while` halt arm was `:error -> {:halt, :error}`. `Jason.encode/1` never returns
+the bare atom `:error` -- it returns `{:ok, binary}` or `{:error, %Jason.EncodeError{}}`.
+The Elixir compiler confirmed this with a "clause will never match" typing violation warning.
+The original crash risk (unencodable value raises `CaseClauseError`) remained live.
+
+### Fix
+Changed the halt arm from `:error -> {:halt, :error}` to `{:error, _} -> {:halt, :error}` to
+match Jason's actual return shape. Also changed `encode_values/1` from `defp` to a public
+`@doc false` function so the encode-failure branch can be directly unit-tested.
+
+### Experiment: .nan / .inf investigation
+Ran `YamlElixir.read_from_string("x: .nan\n")` and `.inf` / `-.inf` in `mix run --no-start`:
+
+```
+nan:     {:ok, %{"x" => :nan}}
+inf:     {:ok, %{"x" => :"+inf"}}
+neg-inf: {:ok, %{"x" => :"-inf"}}
+```
+
+`Jason.encode(:nan)` returns `{:ok, "\"nan\""}` -- atoms encode as strings. So YAML special
+floats do NOT yield an unencodable term in this YamlElixir version.
+
+### Test approach: direct encode_values/1 unit test via tuple
+Since no real YAML value triggers a Jason encode error (atoms, lists, maps, numbers all
+encode fine), added a direct `encode_values/1` test with a tuple value:
+
+```elixir
+assert Frontmatter.encode_values(%{"key" => {:not, :encodable}}) == :error
+```
+
+`Jason.encode({:not, :encodable})` returns `{:error, %Protocol.UndefinedError{}}`, which
+now hits the corrected `{:error, _}` arm and halts with `:error` -- previously the bare
+`:error` arm was a dead clause and the `case` on `Jason.encode/1` would have crashed with
+`CaseClauseError`.
+
+### RED evidence
+The new test `encode_values/1 returns :error when a value is unencodable` FAILS without the
+match-arm fix because the old `:error ->` arm is unreachable -- the `case` on
+`Jason.encode({:not, :encodable})` gets `{:error, %Protocol.UndefinedError{}}` and raises
+`CaseClauseError` instead of halting with `:error`, causing the test to crash rather than
+assert `:error`.
+
+### Final test run
+```
+Running ExUnit with seed: 224820, max_cases: 20
+Excluding tags: [:qdrant_integration, :cluster, :integration]
+
+...............
+Finished in 0.2 seconds (0.2s async, 0.00s sync)
+15 tests, 0 failures
+```
+
+15 tests (was 13), 0 failures. `mix compile` clean with no warnings.

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -16,12 +16,32 @@ defmodule Engram.Notes.CrdtBridge do
   import Bitwise
 
   @text_name "content"
+  @frontmatter_name "frontmatter"
+  @order_name "frontmatter_order"
+  @doc_schema_version 2
   @flatten_bytes 500_000
   @flatten_clients 1_000
 
   @doc "The shared Y.Text key holding note body content."
   @spec text_name() :: String.t()
   def text_name, do: @text_name
+
+  @doc "The CRDT doc schema version. Bump on any incompatible doc-shape change."
+  @spec doc_schema_version() :: pos_integer()
+  def doc_schema_version, do: @doc_schema_version
+
+  @doc """
+  Current frontmatter order list and JSON-encoded values map of a doc.
+
+  Returns `{[], %{}}` for a fresh doc where neither the `@order_name` Y.Array
+  nor the `@frontmatter_name` Y.Map have ever been written to.
+  """
+  @spec frontmatter_of(Yex.Doc.t()) :: {[String.t()], %{String.t() => String.t()}}
+  def frontmatter_of(%Yex.Doc{} = doc) do
+    order = doc |> Yex.Doc.get_array(@order_name) |> Yex.Array.to_list()
+    values = doc |> Yex.Doc.get_map(@frontmatter_name) |> Yex.Map.to_map()
+    {order, values}
+  end
 
   @doc """
   A fresh Y.Doc with the UTF-16 offset kind. The SINGLE source of truth for

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -79,6 +79,14 @@ defmodule Engram.Notes.CrdtBridge do
     end
   end
 
+  @doc "Rebuild full note plaintext from the doc's frontmatter + body."
+  @spec project_doc(Yex.Doc.t()) :: String.t()
+  def project_doc(%Yex.Doc{} = doc) do
+    {order, values} = frontmatter_of(doc)
+    body = doc |> Yex.Doc.get_text(@text_name) |> Yex.Text.to_string()
+    Engram.Notes.Frontmatter.project(order, values, body)
+  end
+
   @doc "Current plaintext of the doc's content Y.Text."
   @spec text_of(Yex.Doc.t()) :: String.t()
   def text_of(%Yex.Doc{} = doc) do

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -83,13 +83,16 @@ defmodule Engram.Notes.CrdtBridge do
   @spec project_doc(Yex.Doc.t()) :: String.t()
   def project_doc(%Yex.Doc{} = doc) do
     {order, values} = frontmatter_of(doc)
-    body = doc |> Yex.Doc.get_text(@text_name) |> Yex.Text.to_string()
-    Engram.Notes.Frontmatter.project(order, values, body)
+    Engram.Notes.Frontmatter.project(order, values, body_of(doc))
   end
 
-  @doc "Current plaintext of the doc's content Y.Text."
+  @doc "Full projected note plaintext (frontmatter + body)."
   @spec text_of(Yex.Doc.t()) :: String.t()
-  def text_of(%Yex.Doc{} = doc) do
+  def text_of(%Yex.Doc{} = doc), do: project_doc(doc)
+
+  @doc "Body-only plaintext (the content Y.Text, no frontmatter)."
+  @spec body_of(Yex.Doc.t()) :: String.t()
+  def body_of(%Yex.Doc{} = doc) do
     doc |> Yex.Doc.get_text(@text_name) |> Yex.Text.to_string()
   end
 
@@ -228,9 +231,8 @@ defmodule Engram.Notes.CrdtBridge do
   """
   @spec flatten(Yex.Doc.t()) :: {:ok, %{doc: Yex.Doc.t(), state: binary()}} | {:error, term()}
   def flatten(%Yex.Doc{} = doc) do
-    text = text_of(doc)
     fresh = new_doc()
-    Yex.Text.insert(Yex.Doc.get_text(fresh, @text_name), 0, text)
+    :ok = ingest_plaintext(fresh, project_doc(doc))
 
     case Yex.encode_state_as_update(fresh) do
       {:ok, state} -> {:ok, %{doc: fresh, state: state}}

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -29,7 +29,10 @@ defmodule Engram.Notes.CrdtBridge do
   def text_name, do: @text_name
 
   @doc "The CRDT doc schema version. Bump on any incompatible doc-shape change."
-  @spec doc_schema_version() :: pos_integer()
+  # Spec is the exact literal, not pos_integer(): the project's dialyzer flags
+  # overspecs (contract_supertype) and this returns the compile-time constant.
+  # Bump both @doc_schema_version and this spec together on a doc-shape change.
+  @spec doc_schema_version() :: 2
   def doc_schema_version, do: @doc_schema_version
 
   @doc """

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -148,6 +148,50 @@ defmodule Engram.Notes.CrdtBridge do
   end
 
   @doc """
+  Ingest full note plaintext into the doc's frontmatter Y.Map + order Y.Array and
+  body Y.Text. Only changed map keys are written. Malformed frontmatter falls
+  back to treating the entire text as body.
+  """
+  @spec ingest_plaintext(Yex.Doc.t(), String.t()) :: :ok
+  def ingest_plaintext(%Yex.Doc{} = doc, plaintext) when is_binary(plaintext) do
+    {fm_block, body} = Engram.Notes.Frontmatter.split(plaintext)
+
+    {order, values, body} =
+      case fm_block && Engram.Notes.Frontmatter.parse(fm_block) do
+        {:ok, order, values} -> {order, values, body}
+        # nil (no frontmatter) or :error (malformed) -> whole text is body
+        _ -> {[], %{}, plaintext}
+      end
+
+    apply_frontmatter(doc, order, values)
+    text = Yex.Doc.get_text(doc, @text_name)
+    :ok = diff_into_text(text, body)
+    :ok
+  end
+
+  defp apply_frontmatter(doc, order, values) do
+    map = Yex.Doc.get_map(doc, @frontmatter_name)
+    current = Yex.Map.to_map(map)
+
+    # Upsert changed keys.
+    Enum.each(values, fn {k, v} ->
+      if Map.get(current, k) != v, do: Yex.Map.set(map, k, v)
+    end)
+
+    # Delete keys no longer present.
+    Enum.each(Map.keys(current), fn k ->
+      unless Map.has_key?(values, k), do: Yex.Map.delete(map, k)
+    end)
+
+    # Replace the order array wholesale (small list; simplest correct form).
+    arr = Yex.Doc.get_array(doc, @order_name)
+    len = arr |> Yex.Array.to_list() |> length()
+    if len > 0, do: Yex.Array.delete_range(arr, 0, len)
+    if order != [], do: Yex.Array.insert_list(arr, 0, order)
+    :ok
+  end
+
+  @doc """
   Distinct client IDs present in the doc's state vector.
 
   The y-js v1 state vector is LEB128-encoded: a leading varint gives the

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -15,6 +15,8 @@ defmodule Engram.Notes.CrdtBridge do
 
   import Bitwise
 
+  alias Engram.Notes.Frontmatter
+
   @text_name "content"
   @frontmatter_name "frontmatter"
   @order_name "frontmatter_order"
@@ -83,7 +85,7 @@ defmodule Engram.Notes.CrdtBridge do
   @spec project_doc(Yex.Doc.t()) :: String.t()
   def project_doc(%Yex.Doc{} = doc) do
     {order, values} = frontmatter_of(doc)
-    Engram.Notes.Frontmatter.project(order, values, body_of(doc))
+    Frontmatter.project(order, values, body_of(doc))
   end
 
   @doc "Full projected note plaintext (frontmatter + body)."
@@ -163,10 +165,10 @@ defmodule Engram.Notes.CrdtBridge do
   """
   @spec ingest_plaintext(Yex.Doc.t(), String.t()) :: :ok
   def ingest_plaintext(%Yex.Doc{} = doc, plaintext) when is_binary(plaintext) do
-    {fm_block, body} = Engram.Notes.Frontmatter.split(plaintext)
+    {fm_block, body} = Frontmatter.split(plaintext)
 
     {order, values, body} =
-      case fm_block && Engram.Notes.Frontmatter.parse(fm_block) do
+      case fm_block && Frontmatter.parse(fm_block) do
         {:ok, order, values} -> {order, values, body}
         # nil (no frontmatter) or :error (malformed) -> whole text is body
         _ -> {[], %{}, plaintext}

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -236,7 +236,7 @@ defmodule Engram.Notes.CrdtBridge do
 
     case Yex.encode_state_as_update(fresh) do
       {:ok, state} -> {:ok, %{doc: fresh, state: state}}
-      {:error, reason} -> {:error, {:encode_failed, reason}}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -100,14 +100,12 @@ defmodule Engram.Notes.CrdtBridge do
   @spec merge_plaintext(binary() | nil, String.t()) ::
           {:ok, %{state: binary(), text: String.t()}} | {:error, term()}
   def merge_plaintext(state, incoming) when is_binary(incoming) do
-    with {:ok, doc} <- doc_from_state(state) do
-      text = Yex.Doc.get_text(doc, @text_name)
-      :ok = diff_into_text(text, incoming)
-
-      case Yex.encode_state_as_update(doc) do
-        {:ok, encoded} -> {:ok, %{state: encoded, text: Yex.Text.to_string(text)}}
-        {:error, reason} -> {:error, {:encode_failed, reason}}
-      end
+    with {:ok, doc} <- doc_from_state(state),
+         :ok <- ingest_plaintext(doc, incoming),
+         {:ok, encoded} <- Yex.encode_state_as_update(doc) do
+      {:ok, %{state: encoded, text: project_doc(doc)}}
+    else
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -191,18 +191,17 @@ defmodule Engram.Notes.CrdtPersistence do
     length(rows)
   end
 
-  # Seeds a fresh doc's text from the note's plaintext content. Used only when
-  # the note has no CRDT state yet (see bind/3) so discovery delivers the body.
+  # Seeds a fresh doc from the note's plaintext content via the frontmatter
+  # codec. Used only when the note has no CRDT state yet (see bind/3) so
+  # discovery delivers the body. Frontmatter is split into Y.Map("frontmatter")
+  # + Y.Array("frontmatter_order") and only the body lands in the body Y.Text,
+  # ensuring concurrent frontmatter edits engage the LWW per-key path.
   # maybe_decrypt_note_fields/2 also UTF-8-scrubs the content, keeping the Yjs
   # text JSON-safe. A nil/empty body seeds nothing (a blank note stays blank).
   defp seed_from_content(doc, %Note{} = note, user) do
     case Crypto.maybe_decrypt_note_fields(note, user) do
       {:ok, %Note{content: content}} when is_binary(content) and content != "" ->
-        doc
-        |> Yex.Doc.get_text(CrdtBridge.text_name())
-        |> Yex.Text.insert(0, content)
-
-        :ok
+        :ok = CrdtBridge.ingest_plaintext(doc, content)
 
       _ ->
         :ok

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -73,11 +73,13 @@ defmodule Engram.Notes.Frontmatter do
 
   # Encode all map values to JSON strings. Returns {:ok, values_map} on success,
   # :error if any value cannot be encoded (unencodable exotic types like tuples).
+  # Values are deep-sorted before encoding so nested-map keys are canonical
+  # (lexicographic, matching JS JSON.stringify with sorted keys in the plugin).
   @doc false
   def encode_values(map) do
     result =
       Enum.reduce_while(map, %{}, fn {k, v}, acc ->
-        case Jason.encode(v) do
+        case Jason.encode(deep_sort(v)) do
           {:ok, json_str} -> {:cont, Map.put(acc, k, json_str)}
           {:error, _} -> {:halt, :error}
         end
@@ -88,6 +90,22 @@ defmodule Engram.Notes.Frontmatter do
       values_map -> {:ok, values_map}
     end
   end
+
+  # Recursively sort map keys for canonical JSON encoding. Arrays keep their
+  # order. Scalars (string, number, bool, nil) are returned as-is. Unencodable
+  # values (e.g. tuples) pass through unchanged so Jason.encode still returns
+  # {:error, _} on them, preserving the :halt/:error path in encode_values/1.
+  defp deep_sort(value) when is_map(value) do
+    Jason.OrderedObject.new(
+      value
+      |> Enum.sort_by(fn {k, _} -> k end)
+      |> Enum.map(fn {k, v} -> {k, deep_sort(v)} end)
+    )
+  end
+
+  defp deep_sort(value) when is_list(value), do: Enum.map(value, &deep_sort/1)
+
+  defp deep_sort(value), do: value
 
   @doc """
   Render ordered keys and JSON-encoded values into a YAML block (no fences).

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -49,8 +49,9 @@ defmodule Engram.Notes.Frontmatter do
 
   @doc """
   Parse a frontmatter YAML block into `{:ok, order, values}` where `values` maps
-  each top-level key to the `Jason.encode!` of its parsed value, and `order` is
-  the source key order. Returns `:error` on malformed YAML.
+  each top-level key to the JSON-encoded string of its parsed value, and `order` is
+  the source key order. Returns `:error` on malformed YAML or if any value cannot
+  be JSON-encoded.
   """
   @spec parse(String.t()) :: {:ok, [String.t()], %{String.t() => String.t()}} | :error
   def parse(""), do: {:ok, [], %{}}
@@ -59,11 +60,31 @@ defmodule Engram.Notes.Frontmatter do
     case YamlElixir.read_from_string(block) do
       {:ok, map} when is_map(map) ->
         order = top_level_key_order(block, map)
-        values = Map.new(map, fn {k, v} -> {k, Jason.encode!(v)} end)
-        {:ok, order, values}
+
+        case encode_values(map) do
+          {:ok, values} -> {:ok, order, values}
+          :error -> :error
+        end
 
       _ ->
         :error
+    end
+  end
+
+  # Encode all map values to JSON strings. Returns {:ok, values_map} on success,
+  # :error if any value cannot be encoded (unencodable exotic types like tuples).
+  defp encode_values(map) do
+    result =
+      Enum.reduce_while(map, %{}, fn {k, v}, acc ->
+        case Jason.encode(v) do
+          {:ok, json_str} -> {:cont, Map.put(acc, k, json_str)}
+          :error -> {:halt, :error}
+        end
+      end)
+
+    case result do
+      :error -> :error
+      values_map -> {:ok, values_map}
     end
   end
 

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -89,6 +89,34 @@ defmodule Engram.Notes.Frontmatter do
     end
   end
 
+  @doc """
+  Render ordered keys and JSON-encoded values into a YAML block (no fences).
+  Empty inputs yield "". Output parses back to the same values (self-idempotent).
+
+  Each value in `values` is a JSON string (as produced by `parse/1`); it is
+  decoded before handing to the YAML emitter so the output is canonical YAML,
+  not a string-of-JSON-literal.
+  """
+  @spec emit([String.t()], %{String.t() => String.t()}) :: String.t()
+  def emit([], _values), do: ""
+
+  def emit(order, values) when is_list(order) and is_map(values) do
+    order
+    |> Enum.filter(&Map.has_key?(values, &1))
+    |> Enum.map(fn key ->
+      decoded = Jason.decode!(values[key])
+      Ymlr.document!(%{key => decoded}, sort_maps: false) |> String.replace_prefix("---\n", "")
+    end)
+    |> Enum.join("")
+    |> ensure_trailing_newline()
+  end
+
+  defp ensure_trailing_newline(""), do: ""
+
+  defp ensure_trailing_newline(s) do
+    if String.ends_with?(s, "\n"), do: s, else: s <> "\n"
+  end
+
   # Recover source order: top-level keys appear as `key:` at column 0.
   defp top_level_key_order(block, map) do
     block

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -1,0 +1,47 @@
+defmodule Engram.Notes.Frontmatter do
+  @moduledoc """
+  Pure codec between a note's YAML frontmatter and the structured form stored in
+  the CRDT `Y.Map`. No Yex here: split/parse/emit/project are total functions on
+  strings and maps so they are trivially testable and reusable.
+  """
+
+  @fence "---"
+
+  @doc """
+  Split a note into its frontmatter YAML block (text between the fences, without
+  the `---` lines) and its body. Returns `{nil, full_text}` when there is no
+  well-formed leading frontmatter (must start at byte 0 and have a closing fence).
+  """
+  @spec split(String.t()) :: {String.t() | nil, String.t()}
+  def split(plaintext) when is_binary(plaintext) do
+    case plaintext do
+      @fence <> <<?\n, rest::binary>> ->
+        case rest do
+          @fence <> <<?\n, body::binary>> ->
+            # Empty frontmatter: --- immediately followed by ---
+            {"", body}
+
+          _ ->
+            # Look for closing fence preceded by newline
+            case String.split(rest, "\n#{@fence}\n", parts: 2) do
+              [block, body] ->
+                {block <> "\n", body}
+
+              # No closing fence with trailing newline; try fence at EOF
+              [_only] ->
+                split_trailing(rest, plaintext)
+            end
+        end
+
+      _ ->
+        {nil, plaintext}
+    end
+  end
+
+  defp split_trailing(rest, original) do
+    case String.split(rest, "\n#{@fence}", parts: 2) do
+      [block, ""] -> {block <> "\n", ""}
+      _ -> {nil, original}
+    end
+  end
+end

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -46,4 +46,37 @@ defmodule Engram.Notes.Frontmatter do
       _ -> {nil, original}
     end
   end
+
+  @doc """
+  Parse a frontmatter YAML block into `{:ok, order, values}` where `values` maps
+  each top-level key to the `Jason.encode!` of its parsed value, and `order` is
+  the source key order. Returns `:error` on malformed YAML.
+  """
+  @spec parse(String.t()) :: {:ok, [String.t()], %{String.t() => String.t()}} | :error
+  def parse(""), do: {:ok, [], %{}}
+
+  def parse(block) when is_binary(block) do
+    case YamlElixir.read_from_string(block) do
+      {:ok, map} when is_map(map) ->
+        order = top_level_key_order(block, map)
+        values = Map.new(map, fn {k, v} -> {k, Jason.encode!(v)} end)
+        {:ok, order, values}
+
+      _ ->
+        :error
+    end
+  end
+
+  # Recover source order: top-level keys appear as `key:` at column 0.
+  defp top_level_key_order(block, map) do
+    block
+    |> String.split("\n")
+    |> Enum.reduce([], fn line, acc ->
+      case Regex.run(~r/^([^\s:][^:]*):/, line) do
+        [_, key] -> if Map.has_key?(map, key) and key not in acc, do: [key | acc], else: acc
+        _ -> acc
+      end
+    end)
+    |> Enum.reverse()
+  end
 end

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -73,12 +73,13 @@ defmodule Engram.Notes.Frontmatter do
 
   # Encode all map values to JSON strings. Returns {:ok, values_map} on success,
   # :error if any value cannot be encoded (unencodable exotic types like tuples).
-  defp encode_values(map) do
+  @doc false
+  def encode_values(map) do
     result =
       Enum.reduce_while(map, %{}, fn {k, v}, acc ->
         case Jason.encode(v) do
           {:ok, json_str} -> {:cont, Map.put(acc, k, json_str)}
-          :error -> {:halt, :error}
+          {:error, _} -> {:halt, :error}
         end
       end)
 

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -6,6 +6,8 @@ defmodule Engram.Notes.Frontmatter do
   """
 
   @fence "---"
+  @fence_line_pattern ~r/\n---[ \t]*\r?\n/
+  @fence_eof_pattern ~r/\n---[ \t]*\r?$/
 
   @doc """
   Split a note into its frontmatter YAML block (text between the fences, without
@@ -22,8 +24,8 @@ defmodule Engram.Notes.Frontmatter do
             {"", body}
 
           _ ->
-            # Look for closing fence preceded by newline
-            case String.split(rest, "\n#{@fence}\n", parts: 2) do
+            # Look for closing fence preceded by newline (with optional trailing whitespace/CR)
+            case Regex.split(@fence_line_pattern, rest, parts: 2) do
               [block, body] ->
                 {block <> "\n", body}
 
@@ -39,7 +41,7 @@ defmodule Engram.Notes.Frontmatter do
   end
 
   defp split_trailing(rest, original) do
-    case String.split(rest, "\n#{@fence}", parts: 2) do
+    case Regex.split(@fence_eof_pattern, rest, parts: 2) do
       [block, ""] -> {block <> "\n", ""}
       _ -> {nil, original}
     end

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -103,11 +103,10 @@ defmodule Engram.Notes.Frontmatter do
   def emit(order, values) when is_list(order) and is_map(values) do
     order
     |> Enum.filter(&Map.has_key?(values, &1))
-    |> Enum.map(fn key ->
+    |> Enum.map_join("", fn key ->
       decoded = Jason.decode!(values[key])
       Ymlr.document!(%{key => decoded}, sort_maps: false) |> String.replace_prefix("---\n", "")
     end)
-    |> Enum.join("")
     |> ensure_trailing_newline()
   end
 

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -117,6 +117,17 @@ defmodule Engram.Notes.Frontmatter do
     if String.ends_with?(s, "\n"), do: s, else: s <> "\n"
   end
 
+  @doc "Assemble full note plaintext from frontmatter parts and body."
+  @spec project([String.t()], %{String.t() => String.t()}, String.t()) :: String.t()
+  def project([], _values, body), do: body
+
+  def project(order, values, body) when is_binary(body) do
+    case emit(order, values) do
+      "" -> body
+      block -> "---\n" <> block <> "---\n" <> body
+    end
+  end
+
   # Recover source order: top-level keys appear as `key:` at column 0.
   defp top_level_key_order(block, map) do
     block

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -25,7 +25,17 @@ defmodule EngramWeb.CrdtChannel do
   #   room_doc :: %{room_pid => doc_id}  (reverse map for broadcast routing)
 
   @impl true
-  def join("crdt:" <> ids, _params, socket) do
+  def join("crdt:" <> ids, params, socket) do
+    proto = Map.get(params, "crdt_proto", 1)
+
+    if proto < Engram.Notes.CrdtBridge.doc_schema_version() do
+      {:error, %{reason: "crdt_proto_too_old", min: Engram.Notes.CrdtBridge.doc_schema_version()}}
+    else
+      join_authenticated("crdt:" <> ids, socket)
+    end
+  end
+
+  defp join_authenticated("crdt:" <> ids, socket) do
     user = socket.assigns.current_user
 
     user_id_str = to_string(user.id)

--- a/mix.exs
+++ b/mix.exs
@@ -86,6 +86,10 @@ defmodule Engram.MixProject do
       # Markdown parsing
       {:earmark, "~> 1.4"},
 
+      # YAML parsing and generation for frontmatter codec
+      {:yaml_elixir, "~> 2.11"},
+      {:ymlr, "~> 5.1"},
+
       # Yjs CRDT engine (Rust `yrs` via Rustler NIF). Stock Hex release with
       # precompiled binaries — NO fork, NO DirtyCpu (Gate 0 spike proved
       # bounded docs stay under the 1ms NIF budget). v1 wire format only.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.574",
+      version: "0.5.575",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -89,5 +89,6 @@
   "y_ex": {:hex, :y_ex, "0.10.5", "046a9c611850a4c1bb7eab741559c0ebf5f30fef87fc770542225b11167925f0", [:mix], [{:rustler, ">= 0.0.0", [hex: :rustler, repo: "hexpm", optional: true]}, {:rustler_precompiled, ">= 0.6.0", [hex: :rustler_precompiled, repo: "hexpm", optional: false]}], "hexpm", "bb24a00829824d9601cfb5acd3c9de55dbd20fae5a9590e2d804a1b080fe4dcc"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.12.1", "d74f2d82294651b58dac849c45a82aaea639766797359baff834b64439f6b3f4", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "d9ac16563c737d55f9bfeed7627489156b91268a3a21cd55c54eb2e335207fed"},
+  "ymlr": {:hex, :ymlr, "5.1.5", "0b9207c7940be3f2bc29b77cd55109d5aa2f4dcde6575942017335769e6f5628", [:mix], [], "hexpm", "7030cb240c46850caeb3b01be745307632be319b15f03083136f6251f49b516d"},
   "zstream": {:hex, :zstream, "0.6.7", "ae74c7544f4e0563ffbe71324bf1c9bbc0ab33bb580a0ae718da511fb8a5c9d6", [:mix], [], "hexpm", "48c43ae0f00cfcda1ccb69c1d044755663d43b2ee8a0a65763648bf2078d634d"},
 }

--- a/priv/repo/migrations/20260629250000_clear_v1_crdt_state_migrate.exs
+++ b/priv/repo/migrations/20260629250000_clear_v1_crdt_state_migrate.exs
@@ -1,0 +1,31 @@
+# rollback-irreversible — purged v1 CRDT snapshots cannot be reconstructed;
+# `down` raises by design. Pre-launch data is wipeable: the next bind re-seeds
+# every note from `notes.content` via the v2 codec (frontmatter Y.Map +
+# body-only Y.Text). Take a DB backup before deploying if you need a fallback.
+defmodule Engram.Repo.Migrations.ClearV1CrdtStateMigrate do
+  use Ecto.Migration
+
+  # phase/migrate-data — data-only reset; no schema DDL.
+  #
+  # The v2 CRDT doc shape (frontmatter in a Y.Map, body-only Y.Text) is
+  # incompatible with persisted v1 snapshots (whole file in a single Y.Text
+  # content node). Loading v1 state against the v2 codec keeps frontmatter
+  # in the body and leaves the per-key Y.Map empty — the new frontmatter
+  # CRDT never engages.
+  #
+  # Fix: clear both the snapshot columns on `notes` AND the `crdt_update_log`
+  # tail-log (a surviving tail would replay v1 updates onto a re-seeded v2
+  # doc). On next bind, `seed_from_content` routes through the v2 codec and
+  # re-seeds from `notes.content` cleanly.
+  #
+  # DELETE is used (not TRUNCATE) so the operation runs inside the migration
+  # transaction and respects RLS row-level policies on `crdt_update_log`.
+  def up do
+    execute("UPDATE notes SET crdt_state_ciphertext = NULL, crdt_state_nonce = NULL")
+    execute("DELETE FROM crdt_update_log")
+  end
+
+  def down do
+    raise "ClearV1CrdtStateMigrate is irreversible — purged snapshots cannot be restored"
+  end
+end

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -62,12 +62,21 @@ defmodule Engram.Notes.CrdtBridgeTest do
     end
   end
 
+  describe "text_of vs body_of" do
+    test "text_of returns the full projected note; body_of returns body only" do
+      doc = Engram.Notes.CrdtBridge.new_doc()
+      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
+      assert Engram.Notes.CrdtBridge.text_of(doc) == "---\ntitle: Hi\n---\nbody\n"
+      assert Engram.Notes.CrdtBridge.body_of(doc) == "body\n"
+    end
+  end
+
   describe "ingest_plaintext/2" do
     test "splits frontmatter into the map/order and body into the text" do
       doc = Engram.Notes.CrdtBridge.new_doc()
       :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
       assert Engram.Notes.CrdtBridge.frontmatter_of(doc) == {["title"], %{"title" => "\"Hi\""}}
-      assert Engram.Notes.CrdtBridge.text_of(doc) == "body\n"
+      assert Engram.Notes.CrdtBridge.body_of(doc) == "body\n"
     end
 
     test "malformed frontmatter keeps the whole text as body" do

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -114,6 +114,15 @@ defmodule Engram.Notes.CrdtBridgeTest do
     end
   end
 
+  describe "flatten/1 preserves frontmatter" do
+    test "flattened doc keeps frontmatter and body" do
+      doc = Engram.Notes.CrdtBridge.new_doc()
+      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
+      {:ok, %{doc: flat}} = Engram.Notes.CrdtBridge.flatten(doc)
+      assert Engram.Notes.CrdtBridge.text_of(flat) == "---\ntitle: Hi\n---\nbody\n"
+    end
+  end
+
   test "multibyte + astral-plane (emoji) edits round-trip without corruption" do
     # Astral emoji 🎉 / 😀 are 2 UTF-16 code units each; multibyte BMP chars
     # (é, 漢) are 1 unit but >1 byte — a :bytes offset would mis-slice both.

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -64,62 +64,62 @@ defmodule Engram.Notes.CrdtBridgeTest do
 
   describe "text_of vs body_of" do
     test "text_of returns the full projected note; body_of returns body only" do
-      doc = Engram.Notes.CrdtBridge.new_doc()
-      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
-      assert Engram.Notes.CrdtBridge.text_of(doc) == "---\ntitle: Hi\n---\nbody\n"
-      assert Engram.Notes.CrdtBridge.body_of(doc) == "body\n"
+      doc = CrdtBridge.new_doc()
+      :ok = CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
+      assert CrdtBridge.text_of(doc) == "---\ntitle: Hi\n---\nbody\n"
+      assert CrdtBridge.body_of(doc) == "body\n"
     end
   end
 
   describe "ingest_plaintext/2" do
     test "splits frontmatter into the map/order and body into the text" do
-      doc = Engram.Notes.CrdtBridge.new_doc()
-      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
-      assert Engram.Notes.CrdtBridge.frontmatter_of(doc) == {["title"], %{"title" => "\"Hi\""}}
-      assert Engram.Notes.CrdtBridge.body_of(doc) == "body\n"
+      doc = CrdtBridge.new_doc()
+      :ok = CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
+      assert CrdtBridge.frontmatter_of(doc) == {["title"], %{"title" => "\"Hi\""}}
+      assert CrdtBridge.body_of(doc) == "body\n"
     end
 
     test "malformed frontmatter keeps the whole text as body" do
-      doc = Engram.Notes.CrdtBridge.new_doc()
-      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\nbroken: : :\n---\nbody\n")
-      assert Engram.Notes.CrdtBridge.frontmatter_of(doc) == {[], %{}}
-      assert Engram.Notes.CrdtBridge.text_of(doc) == "---\nbroken: : :\n---\nbody\n"
+      doc = CrdtBridge.new_doc()
+      :ok = CrdtBridge.ingest_plaintext(doc, "---\nbroken: : :\n---\nbody\n")
+      assert CrdtBridge.frontmatter_of(doc) == {[], %{}}
+      assert CrdtBridge.text_of(doc) == "---\nbroken: : :\n---\nbody\n"
     end
   end
 
   describe "project_doc/1" do
     test "round-trips ingest then project back to equivalent plaintext" do
-      doc = Engram.Notes.CrdtBridge.new_doc()
-      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
-      assert Engram.Notes.CrdtBridge.project_doc(doc) == "---\ntitle: Hi\n---\nbody\n"
+      doc = CrdtBridge.new_doc()
+      :ok = CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
+      assert CrdtBridge.project_doc(doc) == "---\ntitle: Hi\n---\nbody\n"
     end
 
     test "body-only doc projects to body only" do
-      doc = Engram.Notes.CrdtBridge.new_doc()
-      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "no frontmatter\n")
-      assert Engram.Notes.CrdtBridge.project_doc(doc) == "no frontmatter\n"
+      doc = CrdtBridge.new_doc()
+      :ok = CrdtBridge.ingest_plaintext(doc, "no frontmatter\n")
+      assert CrdtBridge.project_doc(doc) == "no frontmatter\n"
     end
   end
 
   describe "merge_plaintext/2 with frontmatter" do
     test "ingests frontmatter and returns projected text + re-encodable state" do
       {:ok, %{state: state, text: text}} =
-        Engram.Notes.CrdtBridge.merge_plaintext(nil, "---\ntitle: Hi\n---\nbody\n")
+        CrdtBridge.merge_plaintext(nil, "---\ntitle: Hi\n---\nbody\n")
 
       assert text == "---\ntitle: Hi\n---\nbody\n"
       assert is_binary(state)
 
-      {:ok, doc2} = Engram.Notes.CrdtBridge.doc_from_state(state)
-      assert Engram.Notes.CrdtBridge.frontmatter_of(doc2) == {["title"], %{"title" => "\"Hi\""}}
+      {:ok, doc2} = CrdtBridge.doc_from_state(state)
+      assert CrdtBridge.frontmatter_of(doc2) == {["title"], %{"title" => "\"Hi\""}}
     end
   end
 
   describe "flatten/1 preserves frontmatter" do
     test "flattened doc keeps frontmatter and body" do
-      doc = Engram.Notes.CrdtBridge.new_doc()
-      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
-      {:ok, %{doc: flat}} = Engram.Notes.CrdtBridge.flatten(doc)
-      assert Engram.Notes.CrdtBridge.text_of(flat) == "---\ntitle: Hi\n---\nbody\n"
+      doc = CrdtBridge.new_doc()
+      :ok = CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
+      {:ok, %{doc: flat}} = CrdtBridge.flatten(doc)
+      assert CrdtBridge.text_of(flat) == "---\ntitle: Hi\n---\nbody\n"
     end
   end
 

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -78,6 +78,20 @@ defmodule Engram.Notes.CrdtBridgeTest do
     end
   end
 
+  describe "project_doc/1" do
+    test "round-trips ingest then project back to equivalent plaintext" do
+      doc = Engram.Notes.CrdtBridge.new_doc()
+      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
+      assert Engram.Notes.CrdtBridge.project_doc(doc) == "---\ntitle: Hi\n---\nbody\n"
+    end
+
+    test "body-only doc projects to body only" do
+      doc = Engram.Notes.CrdtBridge.new_doc()
+      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "no frontmatter\n")
+      assert Engram.Notes.CrdtBridge.project_doc(doc) == "no frontmatter\n"
+    end
+  end
+
   test "multibyte + astral-plane (emoji) edits round-trip without corruption" do
     # Astral emoji 🎉 / 😀 are 2 UTF-16 code units each; multibyte BMP chars
     # (é, 漢) are 1 unit but >1 byte — a :bytes offset would mis-slice both.

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -62,6 +62,22 @@ defmodule Engram.Notes.CrdtBridgeTest do
     end
   end
 
+  describe "ingest_plaintext/2" do
+    test "splits frontmatter into the map/order and body into the text" do
+      doc = Engram.Notes.CrdtBridge.new_doc()
+      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\ntitle: Hi\n---\nbody\n")
+      assert Engram.Notes.CrdtBridge.frontmatter_of(doc) == {["title"], %{"title" => "\"Hi\""}}
+      assert Engram.Notes.CrdtBridge.text_of(doc) == "body\n"
+    end
+
+    test "malformed frontmatter keeps the whole text as body" do
+      doc = Engram.Notes.CrdtBridge.new_doc()
+      :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, "---\nbroken: : :\n---\nbody\n")
+      assert Engram.Notes.CrdtBridge.frontmatter_of(doc) == {[], %{}}
+      assert Engram.Notes.CrdtBridge.text_of(doc) == "---\nbroken: : :\n---\nbody\n"
+    end
+  end
+
   test "multibyte + astral-plane (emoji) edits round-trip without corruption" do
     # Astral emoji 🎉 / 😀 are 2 UTF-16 code units each; multibyte BMP chars
     # (é, 漢) are 1 unit but >1 byte — a :bytes offset would mis-slice both.

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -51,6 +51,17 @@ defmodule Engram.Notes.CrdtBridgeTest do
   # code units. The Gate 0 spike only exercised ASCII; an astral-plane edit
   # (emoji are surrogate pairs = 2 UTF-16 units) is where a bytes/graphemes
   # offset corrupts the doc. These round-trips prove the unit is correct.
+  describe "frontmatter accessors" do
+    test "frontmatter_of returns empty order and values for a fresh doc" do
+      doc = CrdtBridge.new_doc()
+      assert CrdtBridge.frontmatter_of(doc) == {[], %{}}
+    end
+
+    test "doc_schema_version is 2" do
+      assert CrdtBridge.doc_schema_version() == 2
+    end
+  end
+
   test "multibyte + astral-plane (emoji) edits round-trip without corruption" do
     # Astral emoji 🎉 / 😀 are 2 UTF-16 code units each; multibyte BMP chars
     # (é, 漢) are 1 unit but >1 byte — a :bytes offset would mis-slice both.

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -92,6 +92,19 @@ defmodule Engram.Notes.CrdtBridgeTest do
     end
   end
 
+  describe "merge_plaintext/2 with frontmatter" do
+    test "ingests frontmatter and returns projected text + re-encodable state" do
+      {:ok, %{state: state, text: text}} =
+        Engram.Notes.CrdtBridge.merge_plaintext(nil, "---\ntitle: Hi\n---\nbody\n")
+
+      assert text == "---\ntitle: Hi\n---\nbody\n"
+      assert is_binary(state)
+
+      {:ok, doc2} = Engram.Notes.CrdtBridge.doc_from_state(state)
+      assert Engram.Notes.CrdtBridge.frontmatter_of(doc2) == {["title"], %{"title" => "\"Hi\""}}
+    end
+  end
+
   test "multibyte + astral-plane (emoji) edits round-trip without corruption" do
     # Astral emoji 🎉 / 😀 are 2 UTF-16 code units each; multibyte BMP chars
     # (é, 漢) are 1 unit but >1 byte — a :bytes offset would mis-slice both.

--- a/test/engram/notes/crdt_e2e_test.exs
+++ b/test/engram/notes/crdt_e2e_test.exs
@@ -41,7 +41,7 @@ defmodule Engram.Notes.CrdtE2ETest do
     socket_a_raw = user_socket(user)
 
     {:ok, _, joined_a} =
-      subscribe_and_join(socket_a_raw, EngramWeb.CrdtChannel, topic, %{})
+      subscribe_and_join(socket_a_raw, EngramWeb.CrdtChannel, topic, %{"crdt_proto" => 2})
 
     Ecto.Adapters.SQL.Sandbox.allow(Engram.Repo, self(), joined_a.channel_pid)
 
@@ -132,7 +132,7 @@ defmodule Engram.Notes.CrdtE2ETest do
     socket_b_raw = user_socket(user)
 
     {:ok, _, joined_b} =
-      subscribe_and_join(socket_b_raw, EngramWeb.CrdtChannel, topic, %{})
+      subscribe_and_join(socket_b_raw, EngramWeb.CrdtChannel, topic, %{"crdt_proto" => 2})
 
     Ecto.Adapters.SQL.Sandbox.allow(Engram.Repo, self(), joined_b.channel_pid)
 

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -337,6 +337,42 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert is_binary(CrdtBridge.text_of(doc))
   end
 
+  # ── seed_from_content routes frontmatter through the codec ────────────────
+
+  test "bind/3 seed routes frontmatter into Y.Map, not body Y.Text", ctx do
+    %{user: user, vault: vault} = ctx
+
+    # Note whose plaintext content includes a frontmatter block.
+    content = "---\ntitle: Hi\n---\nbody\n"
+
+    {:ok, note2} =
+      Notes.upsert_note(user, vault, %{"path" => "fm_seed.md", "content" => content})
+
+    # Clear CRDT state so bind/3 takes the fresh-room / seed path.
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note2.id),
+          set: [crdt_state_ciphertext: nil, crdt_state_nonce: nil]
+        )
+      end)
+
+    st = %{user_id: user.id, vault_id: note2.vault_id, note_id: note2.id}
+    doc = CrdtBridge.new_doc()
+    _returned = CrdtPersistence.bind(st, note2.id, doc)
+
+    {fm_order, fm_values} = CrdtBridge.frontmatter_of(doc)
+
+    # Frontmatter must be populated in the Y.Map — not silently dropped.
+    assert fm_order != [], "frontmatter_order should be non-empty after seed"
+    assert Map.has_key?(fm_values, "title"), "Y.Map must contain the 'title' key"
+
+    # Body Y.Text must NOT contain the raw frontmatter block.
+    body = CrdtBridge.body_of(doc)
+    refute String.contains?(body, "---"), "raw frontmatter delimiters must not appear in body"
+    assert String.contains?(body, "body"), "body content must be preserved"
+  end
+
   # ── bind/3 replays tail-log after snapshot ────────────────────────────────
 
   test "bind/3 replays tail-log rows on top of the snapshot", ctx do

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -66,6 +66,33 @@ defmodule Engram.Notes.FrontmatterTest do
     end
   end
 
+  describe "emit/2 and self-idempotency" do
+    test "emits keys in order and round-trips through parse" do
+      order = ["title", "tags"]
+      values = %{"title" => "\"Hi\"", "tags" => "[\"a\",\"b\"]"}
+      block = Frontmatter.emit(order, values)
+      assert {:ok, ^order, ^values} = Frontmatter.parse(block)
+    end
+
+    test "empty inputs emit an empty string" do
+      assert Frontmatter.emit([], %{}) == ""
+    end
+
+    test "keys missing from values are silently skipped" do
+      order = ["title", "missing_key"]
+      values = %{"title" => "\"Hello\""}
+      block = Frontmatter.emit(order, values)
+      assert {:ok, ["title"], %{"title" => "\"Hello\""}} = Frontmatter.parse(block)
+    end
+
+    test "nested map value round-trips" do
+      order = ["meta"]
+      values = %{"meta" => "{\"author\":\"Todd\"}"}
+      block = Frontmatter.emit(order, values)
+      assert {:ok, ^order, ^values} = Frontmatter.parse(block)
+    end
+  end
+
   describe "encode_values/1" do
     # Route: YamlElixir special floats (.nan/.inf) are parsed to atoms, which
     # Jason encodes as strings, so they do NOT trigger an encode error. The

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -65,4 +65,19 @@ defmodule Engram.Notes.FrontmatterTest do
       assert Frontmatter.parse("- a\n- b\n") == :error
     end
   end
+
+  describe "encode_values/1" do
+    # Route: YamlElixir special floats (.nan/.inf) are parsed to atoms, which
+    # Jason encodes as strings, so they do NOT trigger an encode error. The
+    # encode-failure branch is tested directly via a map containing a tuple
+    # value, which is unencodable by the Jason.Encoder protocol.
+    test "returns :error when a value is unencodable (e.g. a tuple)" do
+      assert Frontmatter.encode_values(%{"key" => {:not, :encodable}}) == :error
+    end
+
+    test "returns {:ok, values_map} when all values are encodable" do
+      assert Frontmatter.encode_values(%{"a" => 1, "b" => "hello"}) ==
+               {:ok, %{"a" => "1", "b" => "\"hello\""}}
+    end
+  end
 end

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -107,4 +107,15 @@ defmodule Engram.Notes.FrontmatterTest do
                {:ok, %{"a" => "1", "b" => "\"hello\""}}
     end
   end
+
+  describe "project/3" do
+    test "wraps frontmatter in fences and prepends to body" do
+      assert Frontmatter.project(["title"], %{"title" => "\"Hi\""}, "body\n") ==
+               "---\ntitle: Hi\n---\nbody\n"
+    end
+
+    test "empty frontmatter produces body only (no fence)" do
+      assert Frontmatter.project([], %{}, "body only\n") == "body only\n"
+    end
+  end
 end

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -56,6 +56,16 @@ defmodule Engram.Notes.FrontmatterTest do
       assert result == {:ok, ["meta"], %{"meta" => "{\"author\":\"Todd\"}"}}
     end
 
+    test "nested map value uses recursively sorted keys (canonical JSON, matches plugin)" do
+      result = Frontmatter.parse("meta:\n  b: 2\n  a: 1\n")
+      assert result == {:ok, ["meta"], %{"meta" => "{\"a\":1,\"b\":2}"}}
+    end
+
+    test "deeply nested map value uses recursively sorted keys at all levels" do
+      result = Frontmatter.parse("outer:\n  z:\n    y: 1\n    x: 2\n")
+      assert result == {:ok, ["outer"], %{"outer" => "{\"z\":{\"x\":2,\"y\":1}}"}}
+    end
+
     test "inline colon in value extracts key correctly" do
       result = Frontmatter.parse("url: https://example.com\n")
       assert result == {:ok, ["url"], %{"url" => "\"https://example.com\""}}

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -50,5 +50,19 @@ defmodule Engram.Notes.FrontmatterTest do
     test "malformed yaml returns :error" do
       assert Frontmatter.parse("title: : : broken\n  - bad indent\n") == :error
     end
+
+    test "nested map value encodes to JSON, nested keys do not appear in order" do
+      result = Frontmatter.parse("meta:\n  author: Todd\n")
+      assert result == {:ok, ["meta"], %{"meta" => "{\"author\":\"Todd\"}"}}
+    end
+
+    test "inline colon in value extracts key correctly" do
+      result = Frontmatter.parse("url: https://example.com\n")
+      assert result == {:ok, ["url"], %{"url" => "\"https://example.com\""}}
+    end
+
+    test "bare list (not a map) returns :error" do
+      assert Frontmatter.parse("- a\n- b\n") == :error
+    end
   end
 end

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -25,5 +25,15 @@ defmodule Engram.Notes.FrontmatterTest do
       assert Frontmatter.split("\n---\ntitle: Hi\n---\nbody\n") ==
                {nil, "\n---\ntitle: Hi\n---\nbody\n"}
     end
+
+    test "closing fence at EOF with no trailing newline" do
+      assert Frontmatter.split("---\ntitle: Hi\n---") ==
+               {"title: Hi\n", ""}
+    end
+
+    test "closing fence with trailing space" do
+      assert Frontmatter.split("---\ntitle: Hi\n--- \nbody\n") ==
+               {"title: Hi\n", "body\n"}
+    end
   end
 end

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -1,0 +1,29 @@
+defmodule Engram.Notes.FrontmatterTest do
+  use ExUnit.Case, async: true
+  alias Engram.Notes.Frontmatter
+
+  describe "split/1" do
+    test "extracts the yaml block and body when a well-formed fence is present" do
+      assert Frontmatter.split("---\ntitle: Hi\n---\nbody text\n") ==
+               {"title: Hi\n", "body text\n"}
+    end
+
+    test "returns nil block and full text as body when there is no frontmatter" do
+      assert Frontmatter.split("just body\nno fence\n") == {nil, "just body\nno fence\n"}
+    end
+
+    test "returns nil block when the closing fence is missing (unrecognized)" do
+      assert Frontmatter.split("---\ntitle: Hi\nno close\n") ==
+               {nil, "---\ntitle: Hi\nno close\n"}
+    end
+
+    test "empty frontmatter yields an empty block, not nil" do
+      assert Frontmatter.split("---\n---\nbody\n") == {"", "body\n"}
+    end
+
+    test "frontmatter must start at byte 0 (leading blank line means no frontmatter)" do
+      assert Frontmatter.split("\n---\ntitle: Hi\n---\nbody\n") ==
+               {nil, "\n---\ntitle: Hi\n---\nbody\n"}
+    end
+  end
+end

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -36,4 +36,19 @@ defmodule Engram.Notes.FrontmatterTest do
                {"title: Hi\n", "body\n"}
     end
   end
+
+  describe "parse/1" do
+    test "returns ordered keys and JSON-encoded values" do
+      assert Frontmatter.parse("title: Hi\ntags:\n  - a\n  - b\n") ==
+               {:ok, ["title", "tags"], %{"title" => "\"Hi\"", "tags" => "[\"a\",\"b\"]"}}
+    end
+
+    test "empty block yields empty order and values" do
+      assert Frontmatter.parse("") == {:ok, [], %{}}
+    end
+
+    test "malformed yaml returns :error" do
+      assert Frontmatter.parse("title: : : broken\n  - bad indent\n") == :error
+    end
+  end
 end

--- a/test/engram/notes/yaml_deps_smoke_test.exs
+++ b/test/engram/notes/yaml_deps_smoke_test.exs
@@ -1,0 +1,12 @@
+defmodule Engram.Notes.YamlDepsSmokeTest do
+  use ExUnit.Case, async: true
+
+  test "yaml_elixir parses and ymlr emits a round-trippable map" do
+    {:ok, parsed} = YamlElixir.read_from_string("title: Hello\ntags:\n  - a\n  - b\n")
+    assert parsed == %{"title" => "Hello", "tags" => ["a", "b"]}
+
+    emitted = Ymlr.document!(parsed)
+    {:ok, reparsed} = YamlElixir.read_from_string(emitted)
+    assert reparsed == parsed
+  end
+end

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -20,7 +20,7 @@ defmodule EngramWeb.CrdtChannelTest do
         socket,
         EngramWeb.CrdtChannel,
         "crdt:#{user.id}:#{vault.id}",
-        %{}
+        %{"crdt_proto" => 2}
       )
 
     {:ok, _, joined} = result
@@ -49,6 +49,36 @@ defmodule EngramWeb.CrdtChannelTest do
                  socket,
                  EngramWeb.CrdtChannel,
                  "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+    end
+
+    test "rejects join when crdt_proto is below server schema version", %{
+      user: user,
+      vault: vault
+    } do
+      socket = user_socket(user)
+
+      assert {:error, %{reason: "crdt_proto_too_old", min: 2}} =
+               subscribe_and_join(
+                 socket,
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 1}
+               )
+    end
+
+    test "rejects join when crdt_proto is absent (defaults to 1)", %{
+      user: user,
+      vault: vault
+    } do
+      socket = user_socket(user)
+
+      assert {:error, %{reason: "crdt_proto_too_old", min: 2}} =
+               subscribe_and_join(
+                 socket,
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
                  %{}
                )
     end
@@ -65,7 +95,7 @@ defmodule EngramWeb.CrdtChannelTest do
                  socket,
                  EngramWeb.CrdtChannel,
                  "crdt:#{user.id}:#{vault.id}",
-                 %{}
+                 %{"crdt_proto" => 2}
                )
     end
 
@@ -79,7 +109,7 @@ defmodule EngramWeb.CrdtChannelTest do
                  socket,
                  EngramWeb.CrdtChannel,
                  "crdt:#{user.id}:#{other_vault.id}",
-                 %{}
+                 %{"crdt_proto" => 2}
                )
     end
 
@@ -91,7 +121,7 @@ defmodule EngramWeb.CrdtChannelTest do
                  socket,
                  EngramWeb.CrdtChannel,
                  "crdt:#{user.id}:not-a-uuid",
-                 %{}
+                 %{"crdt_proto" => 2}
                )
     end
   end


### PR DESCRIPTION
## CRDT frontmatter as Y.Map — backend (sub-plan 1 of 3)

Moves note frontmatter out of the single `Y.Text("content")` into a dedicated `Y.Map("frontmatter")` (per-key LWW, JSON-encoded values) + `Y.Array("frontmatter_order")`, with the content `Y.Text` holding **body only**. This stops the concurrent-edit interleave corruption where Obsidian's block-level Properties rewrites and the web's char-level edits fought over the same YAML region of one `Y.Text`.

**Design spec:** Engram vault → `50 Engineering/_Superpowers Specs/2026-06-29-crdt-frontmatter-ymap-design.md`
**Plan:** `engram-workspace/docs/superpowers/plans/2026-06-29-crdt-frontmatter-ymap-backend.md`

### What's here
- **`Engram.Notes.Frontmatter`** — pure codec: `split` / `parse` / `emit` / `project`. Parses via `yaml_elixir`, emits via `ymlr` (per-key emit + join, since Ymlr alphabetizes maps). JSON-encoded values; non-raising; self-idempotent round-trip.
- **`crdt_bridge.ex`** — `frontmatter_of/1`, `ingest_plaintext/2` (split → Y.Map/order + body Y.Text, upsert-only-changed keys), `project_doc/1` (self-sufficient projection), `text_of/1` now returns the full projected note, `body_of/1` added; `merge_plaintext`/`flatten` reworked; `@doc_schema_version 2`.
- **`crdt_persistence.ex`** — `seed_from_content` routed through the codec (was inserting raw content incl. frontmatter into the body Y.Text).
- **CRDT channel** — join gated on `crdt_proto >= 2`; pre-v2 clients are refused and degrade to REST (which now also splits frontmatter server-side), so a mixed fleet never corrupts the new shape or loses data.
- **Cutover migration** (`phase/migrate-data`) — clears persisted v1 CRDT state (`crdt_state_*` + `crdt_update_log`) so every note re-seeds into the v2 shape from `notes.content` on next bind. Pre-launch, data is wipeable.

### Safe to merge before clients
No v2 clients exist yet; the proto gate keeps live CRDT off until the plugin + web sub-plans (2/3, 3/3) ship. REST sync keeps working throughout.

### Verification
Full suite **3286 / 0**; `mix format` / `credo` (clean on changed files; only non-blocking `[D]` alias hints) / `sobelow` clean. Built TDD task-by-task with per-task + whole-branch review; the whole-branch review caught the two persistence-layer shape-divergence paths (seed + v1 discard) now fixed here.

### Deferred (non-blocking) follow-ups
A handful of test-coverage + cosmetic Minors (double-ingest idempotency test, a few codec edge tests, `crdt_checkpoint.ex` `{:encode_failed}` consistency, an orphaned test comment). None affect correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
