### PR TITLE
fix(crypto): scrub UTF-8 in decrypted note path at read boundary

### DIFF
--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -382,6 +382,7 @@ defmodule Engram.Crypto do
       note
       | content: scrub_field(note.content),
         title: scrub_field(note.title),
+        path: scrub_field(note.path),
         folder: scrub_field(note.folder),
         tags: scrub_tags(note.tags)
     }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.568",
+      version: "0.5.569",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -222,6 +222,27 @@ defmodule Engram.CryptoTest do
       assert out.content =~ "PRs #71"
     end
 
+    test "scrubs invalid UTF-8 in a decrypted path so the changes feed is JSON-safe (#798)",
+         %{user: user} do
+      {:ok, user} = Crypto.ensure_user_dek(user)
+
+      # `change_map/1` emits :path on the REST /api/changes feed, but the
+      # read-boundary scrub skipped path — the one egress text field left
+      # unscrubbed. A legacy path holding a truncated multibyte char (`–`
+      # cut to its 0xE2 lead byte) would crash Jason on that feed.
+      note = %Engram.Notes.Note{
+        id: Ecto.UUID.generate(),
+        path: "Notes/PRs #71" <> <<0xE2>> <> ".md",
+        folder: "Notes"
+      }
+
+      {:ok, out} = Crypto.maybe_decrypt_note_fields(note, user)
+
+      assert String.valid?(out.path)
+      assert {:ok, _} = Jason.encode(%{path: out.path})
+      assert out.path =~ "PRs #71"
+    end
+
     test "newly-inserted note rows carry dek_version=1 (T3.4 / H5)", %{user: user} do
       # T3.4 / H5 — the per-row column was added with default 1. New rows
       # inserted via the factory satisfy that default. This test locks the


### PR DESCRIPTION
## What

Closes the residual gap from #798. The read-boundary UTF-8 scrub (`scrub_note_text_fields/1`, added in #727/#740) covered `content`/`title`/`folder`/`tags` but **not `path`**. `change_map/1` emits `:path` on the REST `/api/changes` feed, so a legacy note whose decrypted path holds invalid UTF-8 (a multibyte char byte-truncated at rest) would still crash `Jason` and 500 the whole changes page.

## Investigation

The `Jason.EncodeError: invalid byte 0xE2` issues (Sentry, n=126, SyncController) were **already fixed** for content/title/folder/tags by #740 (shipped v0.5.528; prod on 0.5.535) — zero occurrences since 2026-06-24. `path` was the one egress text field still unscrubbed. Theoretical (path is sanitized on write) but it completes the egress coverage in the spirit of #785's "self-defend at egress."

## Fix

Add `path: scrub_field(note.path)` to `scrub_note_text_fields/1`, so every reader of `maybe_decrypt_note_fields/2` (get_note, REST changes, Channel broadcast) is fully JSON-safe.

## Tests

New TDD test (RED→GREEN): a note with a 0xE2-truncated path → `maybe_decrypt_note_fields/2` returns a valid, JSON-encodable path. `mix test` 109/0 across crypto + notes/helpers + sync_controller + mcp-utf8 suites; format + credo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)