### PR TITLE
feat(ci): fine-grained CI skips — per-job gating, --stale unit, targeted e2e (Phases 1-4)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -109,6 +109,17 @@ jobs:
       backend-cache-hit: ${{ steps.backend-lookup.outputs.cache-hit }}
       e2e-cache-hit: ${{ steps.e2e-lookup.outputs.cache-hit }}
       plugin-sha: ${{ steps.plugin-sha.outputs.sha }}
+      is-full: ${{ steps.skips.outputs.is-full }}
+      skip-lint: ${{ steps.skips.outputs.skip-lint }}
+      skip-unit-tests: ${{ steps.skips.outputs.skip-unit-tests }}
+      skip-storage-database: ${{ steps.skips.outputs.skip-storage-database }}
+      skip-e2e-clerk: ${{ steps.skips.outputs.skip-e2e-clerk }}
+      skip-e2e-crdt: ${{ steps.skips.outputs.skip-e2e-crdt }}
+      skip-e2e-local: ${{ steps.skips.outputs.skip-e2e-local }}
+      skip-e2e-browser: ${{ steps.skips.outputs.skip-e2e-browser }}
+      skip-n1-compat: ${{ steps.skips.outputs.skip-n1-compat }}
+      skip-build-and-publish-image: ${{ steps.skips.outputs.skip-build-and-publish-image }}
+      hash-build-and-publish-image: ${{ steps.skips.outputs.hash-build-and-publish-image }}
     steps:
       - name: Generate App token
         id: app-token
@@ -303,6 +314,28 @@ jobs:
           else
             echo "cache-hit=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Fine-grained skip flags (SHADOW, log-only)
+        id: skips
+        env:
+          PLUGIN_SHA: ${{ steps.plugin-sha.outputs.sha }}
+        run: |
+          # Resolve the BEAM tag (mirrors prebuild-mix) so OTP/Elixir changes bust hashes.
+          OTP=$(erl -eval 'io:format("~s",[erlang:system_info(otp_release)]),halt()' -noshell)
+          ERTS=$(erl -eval 'io:format("~s",[erlang:system_info(version)]),halt()' -noshell)
+          ELX=$(elixir --short-version)
+          export BEAM_TAG="otp${OTP}-erts${ERTS}-elx${ELX}"
+          # is-full: main pushes and [ci-full]/force_full runs validate everything (no skips).
+          if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.event.inputs.force_full }}" = "true" ] || git log -1 --pretty=%B | grep -qiF '[ci-full]'; then
+            echo "is-full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-full=false" >> "$GITHUB_OUTPUT"
+          fi
+          # compute.sh emit writes skip-<job>/hash-<job> lines to $GITHUB_OUTPUT.
+          bash ci/fingerprint/compute.sh emit
+          echo "::group::SHADOW fine-grained skip predictions (log-only, not enforced)"
+          grep -E '^skip-' "$GITHUB_OUTPUT" | sed 's/^/  /' || true
+          echo "::endgroup::"
 
       - name: Report decision
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1720,7 +1720,20 @@ jobs:
           # job; this extends the same bar to test/**.
           # --slowest 20 surfaces the slowest tests each run so async/serial
           # tuning stays data-driven (the suite is sync-pool-bound, not CPU-bound).
-          mix test --warnings-as-errors --slowest 20
+          #
+          # Phase 3: PRs run `mix test --stale` (only tests whose modules changed
+          # vs the restored _build/test manifest, plus their compile-dependents)
+          # for fast iteration; full runs (main / [ci-full] / force_full, via
+          # is-full) run the WHOLE suite as the safety net. ExUnit compile-tracking
+          # drives --stale; because main always re-validates everything, a
+          # mis-narrowed --stale set on a PR is caught at merge, never shipped.
+          if [ "${{ needs.fingerprint.outputs.is-full }}" = "true" ]; then
+            echo "::notice::Full run (is-full) — entire ExUnit suite"
+            mix test --warnings-as-errors --slowest 20
+          else
+            echo "::notice::PR run — mix test --stale (full suite runs on main)"
+            mix test --stale --warnings-as-errors --slowest 20
+          fi
 
       - name: OpenAPI spec drift gate
         env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -328,7 +328,14 @@ jobs:
             echo "cache-hit=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Fine-grained skip flags (SHADOW, log-only)
+      - name: Self-test fingerprint scripts
+        # Fails the fingerprint job (and thus the whole run) if a groups.sh /
+        # compute.sh edit breaks group hashing or maps a job to an unknown group
+        # — the skip logic gates real coverage, so a silent break here would
+        # mis-skip jobs. Runs in ~1s.
+        run: bash ci/fingerprint/test/groups_test.sh
+
+      - name: Fine-grained per-job skip flags (enforced)
         id: skips
         env:
           PLUGIN_SHA: ${{ steps.plugin-sha.outputs.sha }}
@@ -350,26 +357,35 @@ jobs:
           # commit message runs ONLY that suite's e2e job, with `pytest -k <pattern>`,
           # and marks the run NON-mergeable (the ci aggregate fails on a target).
           # suite is one of clerk|crdt|local|browser; pattern is a pytest -k expr.
-          # Lets you iterate on a single e2e test without the full suite; the real
-          # coverage runs unconditionally on merge to main.
-          # Match ONLY the four known suite names so prose / placeholder text like
-          # a literal e2e-colon-suite-slash-pattern example in a commit body does
-          # not accidentally trigger a (non-mergeable) targeted run.
-          E2E_LINE=$(git log -1 --pretty=%B | grep -oiE '\[e2e:[[:space:]]*(clerk|crdt|local|browser)/[^]]+\]' | head -1 || true)
-          if [ -n "$E2E_LINE" ]; then
-            E2E_SUITE=$(printf '%s' "$E2E_LINE" | sed -E 's/.*\[e2e:[[:space:]]*(clerk|crdt|local|browser)\/.*/\1/I' | tr 'A-Z' 'a-z')
-            E2E_PATTERN=$(printf '%s' "$E2E_LINE" | sed -E 's/.*\[e2e:[[:space:]]*(clerk|crdt|local|browser)\/([^]]+)\]/\2/I')
-            echo "e2e-target-suite=$E2E_SUITE"     >> "$GITHUB_OUTPUT"
-            echo "e2e-target-pattern=$E2E_PATTERN" >> "$GITHUB_OUTPUT"
-            echo "::notice::Targeted e2e: suite=$E2E_SUITE pattern='$E2E_PATTERN' — run is NON-mergeable (ci will fail)."
-          else
-            echo "e2e-target-suite="   >> "$GITHUB_OUTPUT"
-            echo "e2e-target-pattern=" >> "$GITHUB_OUTPUT"
+          #
+          # IGNORED on full runs (main / [ci-full] / force_full): main must always
+          # run the full e2e matrix, and ignoring the tag here also stops
+          # record-job-markers from seeding a full-hash e2e marker off a single
+          # -k subset (a squash-merge whose body still carries the tag).
+          #
+          # SECURITY: the pattern is restricted to a pytest -k -safe charset
+          # ([A-Za-z0-9_ .:/()-]) — anything with shell metacharacters (quotes,
+          # $(), backticks, ;, |) fails to match and is treated as no target. The
+          # value is ALSO consumed by the pytest steps via env: (NOT ${{ }}
+          # interpolation into the run script), so it can never be expanded as
+          # shell. Two layers against commit-message command injection on the
+          # self-hosted runner. Only the four known suite names match, so prose /
+          # placeholder text never accidentally triggers a (non-mergeable) run.
+          E2E_SUITE=""; E2E_PATTERN=""
+          if [ "$IS_FULL_RUN" != true ]; then
+            E2E_LINE=$(git log -1 --pretty=%B | grep -oiE '\[e2e:[[:space:]]*(clerk|crdt|local|browser)/[A-Za-z0-9_ .:/()-]+\]' | head -1 || true)
+            if [ -n "$E2E_LINE" ]; then
+              E2E_SUITE=$(printf '%s' "$E2E_LINE" | sed -E 's#.*\[e2e:[[:space:]]*(clerk|crdt|local|browser)/.*#\1#I' | tr 'A-Z' 'a-z')
+              E2E_PATTERN=$(printf '%s' "$E2E_LINE" | sed -E 's#.*\[e2e:[[:space:]]*(clerk|crdt|local|browser)/([A-Za-z0-9_ .:/()-]+)\]#\2#I')
+              echo "::notice::Targeted e2e: suite=$E2E_SUITE pattern='$E2E_PATTERN' — run is NON-mergeable (ci will fail)."
+            fi
           fi
+          echo "e2e-target-suite=$E2E_SUITE"     >> "$GITHUB_OUTPUT"
+          echo "e2e-target-pattern=$E2E_PATTERN" >> "$GITHUB_OUTPUT"
           # compute.sh emit writes skip-<job>/hash-<job> lines to $GITHUB_OUTPUT.
           # IS_FULL_RUN is read by emit to force every skip-* false on full runs.
           bash ci/fingerprint/compute.sh emit
-          echo "::group::SHADOW fine-grained skip predictions (log-only, not enforced)"
+          echo "::group::Fine-grained per-job skip decisions (ENFORCED — gates the jobs below)"
           grep -E '^skip-' "$GITHUB_OUTPUT" | sed 's/^/  /' || true
           echo "::endgroup::"
 
@@ -620,8 +636,12 @@ jobs:
           # frontend/Dockerfile/mix.* change still demands a bump (and build-and-publish
           # still errors on a version-exists collision), so this only relaxes the gate
           # for non-deployable (CI/docs/test/lint-config) branches.
+          # rel/ is baked into the release image (Dockerfile `COPY rel rel`:
+          # env.sh.eex cluster gate + RELEASE_NODE), so a rel change IS deployable
+          # and must require a bump. (Keep this list in sync with groups.sh's
+          # deployable groups — elixir-src+priv+frontend+docker-image.)
           DEPLOYABLE=$(git diff --name-only origin/main...HEAD -- \
-            lib priv config frontend Dockerfile entrypoint.sh .dockerignore mix.exs mix.lock)
+            lib priv config frontend Dockerfile entrypoint.sh .dockerignore rel mix.exs mix.lock)
           if [ -z "$DEPLOYABLE" ]; then
             echo "No deployable paths changed vs main (CI/docs/test/lint-config only) — version bump not required."
             exit 0
@@ -1026,13 +1046,16 @@ jobs:
           # run on this REST-path job — it has its own (CRDT_ENABLED) job. Ignore
           # it here so it isn't even collected as skips.
           # Phase 4: inject `-k <pattern>` when [e2e: clerk/<pattern>] targeted; empty => full.
-          E2E_K="${{ needs.fingerprint.outputs.e2e-target-pattern }}"
+          # E2E_PATTERN arrives via env: (charset-restricted at source), never
+          # ${{ }}-interpolated into this script — no command-injection surface.
+          E2E_K="${E2E_PATTERN:-}"
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/ --ignore=tests/api_only/ --ignore=tests/crdt/ \
             "${K_ARGS[@]}" \
             -n "${E2E_WORKERS:-2}" --dist=loadfile \
             -v --timeout=300 -p no:cacheprovider --no-header
         env:
+          E2E_PATTERN: ${{ needs.fingerprint.outputs.e2e-target-pattern }}
           ENGRAM_API_URL: http://localhost:${{ steps.ports.outputs.engram_port }}/api
           ENGRAM_PLUGIN_SRC: ${{ github.workspace }}/plugin-src
           CI_POSTGRES_CONTAINER: ${{ env.CI_PROJECT }}-postgres-1
@@ -1537,10 +1560,13 @@ jobs:
           # into CRDT (E2E_ENABLE_CRDT=true) against a CRDT_ENABLED backend and
           # uses eventually-consistent assertions.
           # Phase 4: inject `-k <pattern>` when [e2e: crdt/<pattern>] targeted; empty => full.
-          E2E_K="${{ needs.fingerprint.outputs.e2e-target-pattern }}"
+          # E2E_PATTERN arrives via env: (charset-restricted at source), never
+          # ${{ }}-interpolated into this script — no command-injection surface.
+          E2E_K="${E2E_PATTERN:-}"
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/crdt/ "${K_ARGS[@]}" -v --timeout=180 -p no:cacheprovider --no-header
         env:
+          E2E_PATTERN: ${{ needs.fingerprint.outputs.e2e-target-pattern }}
           ENGRAM_API_URL: http://localhost:${{ steps.ports.outputs.engram_port }}/api
           ENGRAM_PLUGIN_SRC: ${{ github.workspace }}/plugin-src
           CI_POSTGRES_CONTAINER: ${{ env.CI_PROJECT }}-postgres-1
@@ -2864,9 +2890,12 @@ jobs:
           QDRANT_URL: http://10.0.20.201:6333
           QDRANT_COLLECTION: ${{ env.QDRANT_COLLECTION }}
           OLLAMA_URL: http://10.0.20.214:11434
+          E2E_PATTERN: ${{ needs.fingerprint.outputs.e2e-target-pattern }}
         run: |
           # Phase 4: inject `-k <pattern>` when [e2e: local/<pattern>] targeted; empty => full.
-          E2E_K="${{ needs.fingerprint.outputs.e2e-target-pattern }}"
+          # E2E_PATTERN arrives via env: (charset-restricted at source), never
+          # ${{ }}-interpolated into this script — no command-injection surface.
+          E2E_K="${E2E_PATTERN:-}"
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/api_only/ "${K_ARGS[@]}" -v --timeout=180 -p no:cacheprovider --no-header
 
@@ -3266,7 +3295,12 @@ jobs:
   # hash a later run looks up — no recompute, no BEAM-on-recorder-host dependency.
   record-job-markers:
     if: always() && needs.fingerprint.outputs.is-full == 'true'
-    needs: [fingerprint, lint, unit-tests, storage-database, e2e-clerk, e2e-crdt, e2e-local, e2e-browser, n1-compat]
+    # n1-compat is intentionally EXCLUDED: it has several early `exit 0` success
+    # paths (no open PR, no phase/expand label, no new migrations) that return
+    # green WITHOUT running the migration rollforward. Recording a marker off
+    # those would let a later identical-content PR skip the real check. It is a
+    # cheap branch-only job, so it simply always runs (never marker-skipped).
+    needs: [fingerprint, lint, unit-tests, storage-database, e2e-clerk, e2e-crdt, e2e-local, e2e-browser]
     runs-on: [self-hosted, linux, x64, isolated]
     env:
       LINT_RESULT: ${{ needs.lint.result }}
@@ -3276,7 +3310,6 @@ jobs:
       E2E_CRDT_RESULT: ${{ needs.e2e-crdt.result }}
       E2E_LOCAL_RESULT: ${{ needs.e2e-local.result }}
       E2E_BROWSER_RESULT: ${{ needs.e2e-browser.result }}
-      N1_COMPAT_RESULT: ${{ needs.n1-compat.result }}
       HASH_LINT: ${{ needs.fingerprint.outputs.hash-lint }}
       HASH_UNIT_TESTS: ${{ needs.fingerprint.outputs.hash-unit-tests }}
       HASH_STORAGE_DATABASE: ${{ needs.fingerprint.outputs.hash-storage-database }}
@@ -3284,7 +3317,6 @@ jobs:
       HASH_E2E_CRDT: ${{ needs.fingerprint.outputs.hash-e2e-crdt }}
       HASH_E2E_LOCAL: ${{ needs.fingerprint.outputs.hash-e2e-local }}
       HASH_E2E_BROWSER: ${{ needs.fingerprint.outputs.hash-e2e-browser }}
-      HASH_N1_COMPAT: ${{ needs.fingerprint.outputs.hash-n1-compat }}
     steps:
       - uses: actions/checkout@v7
       - name: Record per-job markers for jobs that passed this full run
@@ -3311,7 +3343,6 @@ jobs:
           record e2e-crdt         "$E2E_CRDT_RESULT"         "$HASH_E2E_CRDT"
           record e2e-local        "$E2E_LOCAL_RESULT"        "$HASH_E2E_LOCAL"
           record e2e-browser      "$E2E_BROWSER_RESULT"      "$HASH_E2E_BROWSER"
-          record n1-compat        "$N1_COMPAT_RESULT"        "$HASH_N1_COMPAT"
 
   # When plugin dispatch arrives and the (backend, plugin) pair is already
   # cached green, e2e-clerk is skipped — its in-job "Report E2E status to

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -352,10 +352,13 @@ jobs:
           # suite is one of clerk|crdt|local|browser; pattern is a pytest -k expr.
           # Lets you iterate on a single e2e test without the full suite; the real
           # coverage runs unconditionally on merge to main.
-          E2E_LINE=$(git log -1 --pretty=%B | grep -oiE '\[e2e:[[:space:]]*[a-z]+/[^]]+\]' | head -1 || true)
+          # Match ONLY the four known suite names so prose / placeholder text like
+          # a literal e2e-colon-suite-slash-pattern example in a commit body does
+          # not accidentally trigger a (non-mergeable) targeted run.
+          E2E_LINE=$(git log -1 --pretty=%B | grep -oiE '\[e2e:[[:space:]]*(clerk|crdt|local|browser)/[^]]+\]' | head -1 || true)
           if [ -n "$E2E_LINE" ]; then
-            E2E_SUITE=$(printf '%s' "$E2E_LINE" | sed -E 's/.*\[e2e:[[:space:]]*([a-z]+)\/.*/\1/I' | tr 'A-Z' 'a-z')
-            E2E_PATTERN=$(printf '%s' "$E2E_LINE" | sed -E 's/.*\[e2e:[[:space:]]*[a-z]+\/([^]]+)\]/\1/I')
+            E2E_SUITE=$(printf '%s' "$E2E_LINE" | sed -E 's/.*\[e2e:[[:space:]]*(clerk|crdt|local|browser)\/.*/\1/I' | tr 'A-Z' 'a-z')
+            E2E_PATTERN=$(printf '%s' "$E2E_LINE" | sed -E 's/.*\[e2e:[[:space:]]*(clerk|crdt|local|browser)\/([^]]+)\]/\2/I')
             echo "e2e-target-suite=$E2E_SUITE"     >> "$GITHUB_OUTPUT"
             echo "e2e-target-pattern=$E2E_PATTERN" >> "$GITHUB_OUTPUT"
             echo "::notice::Targeted e2e: suite=$E2E_SUITE pattern='$E2E_PATTERN' — run is NON-mergeable (ci will fail)."

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -119,6 +119,16 @@ jobs:
       skip-e2e-browser: ${{ steps.skips.outputs.skip-e2e-browser }}
       skip-n1-compat: ${{ steps.skips.outputs.skip-n1-compat }}
       skip-build-and-publish-image: ${{ steps.skips.outputs.skip-build-and-publish-image }}
+      # Per-job hashes — consumed by record-job-markers so a recorded marker
+      # matches the exact hash a later run looks up (no recompute on the recorder).
+      hash-lint: ${{ steps.skips.outputs.hash-lint }}
+      hash-unit-tests: ${{ steps.skips.outputs.hash-unit-tests }}
+      hash-storage-database: ${{ steps.skips.outputs.hash-storage-database }}
+      hash-e2e-clerk: ${{ steps.skips.outputs.hash-e2e-clerk }}
+      hash-e2e-crdt: ${{ steps.skips.outputs.hash-e2e-crdt }}
+      hash-e2e-local: ${{ steps.skips.outputs.hash-e2e-local }}
+      hash-e2e-browser: ${{ steps.skips.outputs.hash-e2e-browser }}
+      hash-n1-compat: ${{ steps.skips.outputs.hash-n1-compat }}
       hash-build-and-publish-image: ${{ steps.skips.outputs.hash-build-and-publish-image }}
     steps:
       - name: Generate App token
@@ -328,10 +338,13 @@ jobs:
           # is-full: main pushes and [ci-full]/force_full runs validate everything (no skips).
           if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.event.inputs.force_full }}" = "true" ] || git log -1 --pretty=%B | grep -qiF '[ci-full]'; then
             echo "is-full=true" >> "$GITHUB_OUTPUT"
+            export IS_FULL_RUN=true
           else
             echo "is-full=false" >> "$GITHUB_OUTPUT"
+            export IS_FULL_RUN=false
           fi
           # compute.sh emit writes skip-<job>/hash-<job> lines to $GITHUB_OUTPUT.
+          # IS_FULL_RUN is read by emit to force every skip-* false on full runs.
           bash ci/fingerprint/compute.sh emit
           echo "::group::SHADOW fine-grained skip predictions (log-only, not enforced)"
           grep -E '^skip-' "$GITHUB_OUTPUT" | sed 's/^/  /' || true
@@ -592,7 +605,10 @@ jobs:
     #     bumps and the same coverage runs when we merge into main).
     # `ci` aggregate updated below to allow this job's `skipped` result on
     # Dependabot PRs.
-    if: needs.fingerprint.outputs.e2e-cache-hit != 'true' && github.actor != 'dependabot[bot]'
+    # Per-job fingerprint skip (skip-e2e-clerk) replaces the coarse e2e-cache-hit:
+    # skips only when this exact (docker-image+elixir-src+e2e-harness+plugin)
+    # content already passed full on main; forced false on full runs.
+    if: needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -1115,7 +1131,8 @@ jobs:
     # separate display band below (+150 vs e2e-clerk's +50): clerk spans
     # displays ~45-134, crdt ~145-234.
     needs: [fingerprint, prebuild-ci-image]
-    if: needs.fingerprint.outputs.e2e-cache-hit != 'true' && github.actor != 'dependabot[bot]'
+    # Per-job skip (skip-e2e-crdt): same group as e2e-clerk; forced false on full runs.
+    if: needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -1559,10 +1576,14 @@ jobs:
   unit-tests:
     needs: [fingerprint, prebuild-mix]
     # Skip on cross-repo plugin dispatch — plugin can't regress backend ExUnit.
-    # NOT fingerprint-gated: the suite is fast (~4min) and skipping it on a
-    # cache hit created a blind spot — it stopped executing on main for a
-    # stretch and let a Repo-crashing test land. Always run on backend pushes.
-    if: github.event_name != 'repository_dispatch'
+    # Per-job fingerprint skip (skip-unit-tests) is safe here even though a coarse
+    # cache-hit was historically NOT trusted (it once let a Repo-crashing test
+    # ride a green on main): markers seed ONLY on full runs and `is-full` forces
+    # skip=false on main, so unit-tests ALWAYS executes on main and can never
+    # silently stop. On a PR it skips only when this exact
+    # elixir-src+test+migrations content already passed full on main.
+    # (Phase 3 will further narrow PR runs to `mix test --stale`.)
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-unit-tests != 'true'
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -1764,9 +1785,10 @@ jobs:
     # (Postgres bytea, no MinIO) and round-trip attachment bytes through the
     # storage adapter via `bin/engram rpc`. This is the only job that exercises
     # the no-MinIO boot path — the rest of CI runs STORAGE_BACKEND=s3. Skipped on
-    # cross-repo plugin dispatch (can't regress backend) and when the backend
-    # fingerprint already proved green.
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true'
+    # cross-repo plugin dispatch (can't regress backend) and via the per-job
+    # fingerprint skip (skip-storage-database = elixir-src+migrations+docker-image;
+    # forced false on full runs).
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-storage-database != 'true'
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -1841,10 +1863,13 @@ jobs:
   lint:
     needs: [fingerprint, prebuild-mix]
     # Skip on cross-repo plugin dispatch — plugin can't regress backend lints.
-    # NOT fingerprint-gated: lint is fast and shares prebuild-mix with
-    # unit-tests; skipping it on a cache hit silently let credo/sobelow
-    # regressions merge. Always run on backend pushes.
-    if: github.event_name != 'repository_dispatch'
+    # Per-job fingerprint skip (skip-lint) is safe even though a coarse cache-hit
+    # was historically NOT trusted (it once let credo/sobelow regressions merge):
+    # markers seed ONLY on full runs and `is-full` forces skip=false on main, so
+    # lint ALWAYS executes on main. On a PR it skips only when this exact
+    # elixir-src+test+lint-config content (incl. .credo.exs/.sobelow-conf/.formatter.exs)
+    # already passed full on main.
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-lint != 'true'
     runs-on: [self-hosted, linux, x64, isolated]
 
     steps:
@@ -2441,10 +2466,14 @@ jobs:
     # Simpler than the original plan: applies migrations, doesn't run
     # the prev release's full mix test (brittle across versions). The
     # "migrate applies cleanly" check is the load-bearing invariant.
+    # Per-job skip (skip-n1-compat = elixir-src+migrations; forced false on full
+    # runs). n1-compat is branch-only (never runs on main), so its marker only
+    # seeds via a [ci-full]/force_full branch run — in practice it nearly always
+    # runs, which is fine (it's a cheap expand-phase migration apply check).
     if: |
       github.event_name == 'push' &&
       github.ref != 'refs/heads/main' &&
-      needs.fingerprint.outputs.backend-cache-hit != 'true'
+      needs.fingerprint.outputs.skip-n1-compat != 'true'
     runs-on: [self-hosted, linux, x64, isolated]
     needs: [fingerprint, prebuild-mix]
     permissions:
@@ -2686,10 +2715,11 @@ jobs:
     needs: [fingerprint, prebuild-ci-image]
     # Skip on cross-repo plugin dispatch — plugin uses Clerk JWTs in production,
     # so the local-auth API path is backend-internal.
-    # Also skip when fingerprint already proved green, or when running on a
-    # Dependabot PR (Phoenix webServer boot needs secrets Dependabot can't
+    # Also skip via the per-job fingerprint (skip-e2e-local =
+    # docker-image+elixir-src+e2e-harness+frontend; forced false on full runs), or
+    # on a Dependabot PR (Phoenix webServer boot needs secrets Dependabot can't
     # access; unit-tests + lint cover the meaningful surface).
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true' && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-local != 'true' && github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -2806,9 +2836,10 @@ jobs:
     needs: [fingerprint, prebuild-mix]
     # Skip on cross-repo plugin dispatch — Playwright targets backend's React
     # frontend, which the plugin (separate repo) cannot affect.
-    # Also skip when fingerprint already proved green, or on Dependabot PRs
-    # (Phoenix webServer needs Clerk secrets Dependabot can't access).
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true' && github.actor != 'dependabot[bot]'
+    # Also skip via the per-job fingerprint (skip-e2e-browser =
+    # docker-image+elixir-src+e2e-harness+frontend; forced false on full runs), or
+    # on Dependabot PRs (Phoenix webServer needs Clerk secrets Dependabot can't access).
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-browser != 'true' && github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -3151,6 +3182,65 @@ jobs:
           docker push "$TAG"
           rm -rf "$WORKDIR"
           echo "::notice::Saved e2e marker $TAG"
+
+  # Fine-grained per-job markers (ci-<job>:<hash-job>) in LOCAL_REGISTRY — the
+  # forward-looking replacement for the coarse ci-pass/ci-e2e-pass markers above
+  # (legacy record-pass retired in Phase 5). Recorded ONLY on full runs (main /
+  # [ci-full] / force_full): the whole job is gated on `is-full`, so a reduced-mode
+  # PR pass (future Phase 3 `--stale` unit, Phase 4 targeted e2e) can NEVER seed a
+  # marker. PRs consume these via the fingerprint job's skip-<job> lookup; they
+  # never produce. Each job seeds its own marker independently iff it ran to
+  # success this run; skipped/failed jobs are left unmarked. Hashes come straight
+  # from the fingerprint job (MARKER_HASH) so a recorded tag always matches the
+  # hash a later run looks up — no recompute, no BEAM-on-recorder-host dependency.
+  record-job-markers:
+    if: always() && needs.fingerprint.outputs.is-full == 'true'
+    needs: [fingerprint, lint, unit-tests, storage-database, e2e-clerk, e2e-crdt, e2e-local, e2e-browser, n1-compat]
+    runs-on: [self-hosted, linux, x64, isolated]
+    env:
+      LINT_RESULT: ${{ needs.lint.result }}
+      UNIT_TESTS_RESULT: ${{ needs.unit-tests.result }}
+      STORAGE_DATABASE_RESULT: ${{ needs.storage-database.result }}
+      E2E_CLERK_RESULT: ${{ needs.e2e-clerk.result }}
+      E2E_CRDT_RESULT: ${{ needs.e2e-crdt.result }}
+      E2E_LOCAL_RESULT: ${{ needs.e2e-local.result }}
+      E2E_BROWSER_RESULT: ${{ needs.e2e-browser.result }}
+      N1_COMPAT_RESULT: ${{ needs.n1-compat.result }}
+      HASH_LINT: ${{ needs.fingerprint.outputs.hash-lint }}
+      HASH_UNIT_TESTS: ${{ needs.fingerprint.outputs.hash-unit-tests }}
+      HASH_STORAGE_DATABASE: ${{ needs.fingerprint.outputs.hash-storage-database }}
+      HASH_E2E_CLERK: ${{ needs.fingerprint.outputs.hash-e2e-clerk }}
+      HASH_E2E_CRDT: ${{ needs.fingerprint.outputs.hash-e2e-crdt }}
+      HASH_E2E_LOCAL: ${{ needs.fingerprint.outputs.hash-e2e-local }}
+      HASH_E2E_BROWSER: ${{ needs.fingerprint.outputs.hash-e2e-browser }}
+      HASH_N1_COMPAT: ${{ needs.fingerprint.outputs.hash-n1-compat }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Record per-job markers for jobs that passed this full run
+        run: |
+          set -uo pipefail
+          # record <job> <result> <hash>: seed ci-<job>:<hash> iff the job
+          # succeeded. record.sh self-guards on IS_FULL_RUN and uses MARKER_HASH
+          # verbatim (no recompute) so the tag matches the fingerprint lookup.
+          record() {
+            if [ "$2" != "success" ]; then
+              echo "::notice::skip marker $1 (result=$2)"
+              return 0
+            fi
+            if [ -z "$3" ]; then
+              echo "::warning::no hash for $1 — marker not recorded"
+              return 0
+            fi
+            IS_FULL_RUN=true MARKER_HASH="$3" bash ci/fingerprint/record.sh record "$1"
+          }
+          record lint             "$LINT_RESULT"             "$HASH_LINT"
+          record unit-tests       "$UNIT_TESTS_RESULT"       "$HASH_UNIT_TESTS"
+          record storage-database "$STORAGE_DATABASE_RESULT" "$HASH_STORAGE_DATABASE"
+          record e2e-clerk        "$E2E_CLERK_RESULT"        "$HASH_E2E_CLERK"
+          record e2e-crdt         "$E2E_CRDT_RESULT"         "$HASH_E2E_CRDT"
+          record e2e-local        "$E2E_LOCAL_RESULT"        "$HASH_E2E_LOCAL"
+          record e2e-browser      "$E2E_BROWSER_RESULT"      "$HASH_E2E_BROWSER"
+          record n1-compat        "$N1_COMPAT_RESULT"        "$HASH_N1_COMPAT"
 
   # When plugin dispatch arrives and the (backend, plugin) pair is already
   # cached green, e2e-clerk is skipped — its in-job "Report E2E status to

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -130,6 +130,9 @@ jobs:
       hash-e2e-browser: ${{ steps.skips.outputs.hash-e2e-browser }}
       hash-n1-compat: ${{ steps.skips.outputs.hash-n1-compat }}
       hash-build-and-publish-image: ${{ steps.skips.outputs.hash-build-and-publish-image }}
+      # Phase 4 targeted e2e ([e2e: suite/pattern] in HEAD commit). Empty = full e2e.
+      e2e-target-suite: ${{ steps.skips.outputs.e2e-target-suite }}
+      e2e-target-pattern: ${{ steps.skips.outputs.e2e-target-pattern }}
     steps:
       - name: Generate App token
         id: app-token
@@ -342,6 +345,23 @@ jobs:
           else
             echo "is-full=false" >> "$GITHUB_OUTPUT"
             export IS_FULL_RUN=false
+          fi
+          # Phase 4: opt-in targeted e2e. `[e2e: <suite>/<pattern>]` in the HEAD
+          # commit message runs ONLY that suite's e2e job, with `pytest -k <pattern>`,
+          # and marks the run NON-mergeable (the ci aggregate fails on a target).
+          # suite is one of clerk|crdt|local|browser; pattern is a pytest -k expr.
+          # Lets you iterate on a single e2e test without the full suite; the real
+          # coverage runs unconditionally on merge to main.
+          E2E_LINE=$(git log -1 --pretty=%B | grep -oiE '\[e2e:[[:space:]]*[a-z]+/[^]]+\]' | head -1 || true)
+          if [ -n "$E2E_LINE" ]; then
+            E2E_SUITE=$(printf '%s' "$E2E_LINE" | sed -E 's/.*\[e2e:[[:space:]]*([a-z]+)\/.*/\1/I' | tr 'A-Z' 'a-z')
+            E2E_PATTERN=$(printf '%s' "$E2E_LINE" | sed -E 's/.*\[e2e:[[:space:]]*[a-z]+\/([^]]+)\]/\1/I')
+            echo "e2e-target-suite=$E2E_SUITE"     >> "$GITHUB_OUTPUT"
+            echo "e2e-target-pattern=$E2E_PATTERN" >> "$GITHUB_OUTPUT"
+            echo "::notice::Targeted e2e: suite=$E2E_SUITE pattern='$E2E_PATTERN' — run is NON-mergeable (ci will fail)."
+          else
+            echo "e2e-target-suite="   >> "$GITHUB_OUTPUT"
+            echo "e2e-target-pattern=" >> "$GITHUB_OUTPUT"
           fi
           # compute.sh emit writes skip-<job>/hash-<job> lines to $GITHUB_OUTPUT.
           # IS_FULL_RUN is read by emit to force every skip-* false on full runs.
@@ -624,7 +644,7 @@ jobs:
     # Per-job fingerprint skip (skip-e2e-clerk) replaces the coarse e2e-cache-hit:
     # skips only when this exact (docker-image+elixir-src+e2e-harness+plugin)
     # content already passed full on main; forced false on full runs.
-    if: needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]'
+    if: needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'clerk')
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -1002,7 +1022,11 @@ jobs:
           # into CRDT and uses eventually-consistent assertions, so it must NOT
           # run on this REST-path job — it has its own (CRDT_ENABLED) job. Ignore
           # it here so it isn't even collected as skips.
+          # Phase 4: inject `-k <pattern>` when [e2e: clerk/<pattern>] targeted; empty => full.
+          E2E_K="${{ needs.fingerprint.outputs.e2e-target-pattern }}"
+          K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/ --ignore=tests/api_only/ --ignore=tests/crdt/ \
+            "${K_ARGS[@]}" \
             -n "${E2E_WORKERS:-2}" --dist=loadfile \
             -v --timeout=300 -p no:cacheprovider --no-header
         env:
@@ -1148,7 +1172,7 @@ jobs:
     # displays ~45-134, crdt ~145-234.
     needs: [fingerprint, prebuild-ci-image]
     # Per-job skip (skip-e2e-crdt): same group as e2e-clerk; forced false on full runs.
-    if: needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]'
+    if: needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt')
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -1509,7 +1533,10 @@ jobs:
           # tests/crdt/ is the CRDT-only suite (spec §12a). It opts the plugin
           # into CRDT (E2E_ENABLE_CRDT=true) against a CRDT_ENABLED backend and
           # uses eventually-consistent assertions.
-          python3 -m pytest tests/crdt/ -v --timeout=180 -p no:cacheprovider --no-header
+          # Phase 4: inject `-k <pattern>` when [e2e: crdt/<pattern>] targeted; empty => full.
+          E2E_K="${{ needs.fingerprint.outputs.e2e-target-pattern }}"
+          K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
+          python3 -m pytest tests/crdt/ "${K_ARGS[@]}" -v --timeout=180 -p no:cacheprovider --no-header
         env:
           ENGRAM_API_URL: http://localhost:${{ steps.ports.outputs.engram_port }}/api
           ENGRAM_PLUGIN_SRC: ${{ github.workspace }}/plugin-src
@@ -2748,7 +2775,7 @@ jobs:
     # docker-image+elixir-src+e2e-harness+frontend; forced false on full runs), or
     # on a Dependabot PR (Phoenix webServer boot needs secrets Dependabot can't
     # access; unit-tests + lint cover the meaningful surface).
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-local != 'true' && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-local != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'local')
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -2834,7 +2861,11 @@ jobs:
           QDRANT_URL: http://10.0.20.201:6333
           QDRANT_COLLECTION: ${{ env.QDRANT_COLLECTION }}
           OLLAMA_URL: http://10.0.20.214:11434
-        run: python3 -m pytest tests/api_only/ -v --timeout=180 -p no:cacheprovider --no-header
+        run: |
+          # Phase 4: inject `-k <pattern>` when [e2e: local/<pattern>] targeted; empty => full.
+          E2E_K="${{ needs.fingerprint.outputs.e2e-target-pattern }}"
+          K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
+          python3 -m pytest tests/api_only/ "${K_ARGS[@]}" -v --timeout=180 -p no:cacheprovider --no-header
 
       - name: Collect failure logs
         if: failure()
@@ -2868,7 +2899,7 @@ jobs:
     # Also skip via the per-job fingerprint (skip-e2e-browser =
     # docker-image+elixir-src+e2e-harness+frontend; forced false on full runs), or
     # on Dependabot PRs (Phoenix webServer needs Clerk secrets Dependabot can't access).
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-browser != 'true' && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-browser != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'browser')
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -3125,6 +3156,14 @@ jobs:
           EL="${{ needs.e2e-local.result }}"
           EB="${{ needs.e2e-browser.result }}"
           LG="${{ needs.legal-cross-repo.result }}"
+
+          # Phase 4: a targeted e2e run ([e2e: suite/pattern]) is NEVER mergeable —
+          # only one suite ran (with -k), so the full integration matrix is unproven.
+          # Drop the tag and push to run the full suite before merging.
+          if [ -n "${{ needs.fingerprint.outputs.e2e-target-suite }}" ]; then
+            echo "::error::Targeted e2e run ([e2e: ${{ needs.fingerprint.outputs.e2e-target-suite }}/...]) is not mergeable — remove the [e2e: ...] tag and push to run the full e2e suite."
+            exit 1
+          fi
 
           # version-check is skipped on main (only runs on branches) — that's expected.
           if [ "$VC" != "success" ] && [ "$VC" != "skipped" ]; then

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -588,6 +588,22 @@ jobs:
             echo "Backend + e2e content already shipped (fingerprint cache-hit): no new image will build, version bump not required."
             exit 0
           fi
+          # Path-aware bump gate. The CACHE_HIT_BOTH signal above is NOT a reliable
+          # "is this deployable?" test: verify.yml is deliberately inside BACKEND_HASH
+          # (so a CI-logic change forces a full re-run), which means a CI-only branch
+          # MISSES the fingerprint cache yet builds NO new image. Decouple the deploy
+          # question from the CI-fingerprint by diffing the actual runtime paths against
+          # main; require a bump only when one of them moved. A real lib/priv/config/
+          # frontend/Dockerfile/mix.* change still demands a bump (and build-and-publish
+          # still errors on a version-exists collision), so this only relaxes the gate
+          # for non-deployable (CI/docs/test/lint-config) branches.
+          DEPLOYABLE=$(git diff --name-only origin/main...HEAD -- \
+            lib priv config frontend Dockerfile entrypoint.sh .dockerignore mix.exs mix.lock)
+          if [ -z "$DEPLOYABLE" ]; then
+            echo "No deployable paths changed vs main (CI/docs/test/lint-config only) — version bump not required."
+            exit 0
+          fi
+          echo "::group::Deployable paths changed vs main"; echo "$DEPLOYABLE"; echo "::endgroup::"
           BRANCH_VERSION=$(grep 'version:' mix.exs | head -1 | sed 's/.*"\(.*\)".*/\1/')
           MAIN_VERSION=$(git show origin/main:mix.exs | grep 'version:' | head -1 | sed 's/.*"\(.*\)".*/\1/')
           if [ "$BRANCH_VERSION" = "$MAIN_VERSION" ]; then

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -366,7 +366,7 @@ jobs:
           # SECURITY: the pattern is restricted to a pytest -k -safe charset
           # ([A-Za-z0-9_ .:/()-]) — anything with shell metacharacters (quotes,
           # $(), backticks, ;, |) fails to match and is treated as no target. The
-          # value is ALSO consumed by the pytest steps via env: (NOT ${{ }}
+          # value is ALSO consumed by the pytest steps via env: (NOT template
           # interpolation into the run script), so it can never be expanded as
           # shell. Two layers against commit-message command injection on the
           # self-hosted runner. Only the four known suite names match, so prose /
@@ -1047,7 +1047,7 @@ jobs:
           # it here so it isn't even collected as skips.
           # Phase 4: inject `-k <pattern>` when [e2e: clerk/<pattern>] targeted; empty => full.
           # E2E_PATTERN arrives via env: (charset-restricted at source), never
-          # ${{ }}-interpolated into this script — no command-injection surface.
+          # template-interpolated into this script — no command-injection surface.
           E2E_K="${E2E_PATTERN:-}"
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/ --ignore=tests/api_only/ --ignore=tests/crdt/ \
@@ -1561,7 +1561,7 @@ jobs:
           # uses eventually-consistent assertions.
           # Phase 4: inject `-k <pattern>` when [e2e: crdt/<pattern>] targeted; empty => full.
           # E2E_PATTERN arrives via env: (charset-restricted at source), never
-          # ${{ }}-interpolated into this script — no command-injection surface.
+          # template-interpolated into this script — no command-injection surface.
           E2E_K="${E2E_PATTERN:-}"
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/crdt/ "${K_ARGS[@]}" -v --timeout=180 -p no:cacheprovider --no-header
@@ -2894,7 +2894,7 @@ jobs:
         run: |
           # Phase 4: inject `-k <pattern>` when [e2e: local/<pattern>] targeted; empty => full.
           # E2E_PATTERN arrives via env: (charset-restricted at source), never
-          # ${{ }}-interpolated into this script — no command-injection surface.
+          # template-interpolated into this script — no command-injection surface.
           E2E_K="${E2E_PATTERN:-}"
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/api_only/ "${K_ARGS[@]}" -v --timeout=180 -p no:cacheprovider --no-header

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3502,14 +3502,26 @@ jobs:
           # github.run_attempt is 1 on the first push-triggered run, 2+ on
           # any `gh run rerun` invocation. Cleanly distinguishes "operator
           # didn't bump" from "operator is retrying a known-good build".
+          # Path-aware collision guard. The "version exists but not cache-hit"
+          # ERROR is meant to catch a developer who changed deployable code but
+          # forgot to bump. But verify.yml / ci/ live INSIDE BACKEND_HASH, so a
+          # CI-only merge misses the coarse cache (cache_hit_both=false) while
+          # leaving the image byte-identical — the existing tag IS correct and a
+          # bump would be a no-op. So only ERROR when a DEPLOYABLE path actually
+          # changed in this merge (same path set version-check uses). HEAD~1..HEAD
+          # = the squash-merge just landed on main (checkout is fetch-depth: 0).
+          DEPLOYABLE=$(git diff --name-only HEAD~1 HEAD -- \
+            lib priv config frontend Dockerfile entrypoint.sh .dockerignore rel mix.exs mix.lock)
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin > /dev/null
           IMAGE_EXISTS=false
           if docker manifest inspect "${GHCR_IMAGE}:${VERSION}" > /dev/null 2>&1; then
-            if [ "${{ github.run_attempt }}" = "1" ] && [ "$CACHE_HIT_BOTH" != "true" ]; then
-              echo "ERROR: Version ${VERSION} already exists in GHCR. Bump the version in mix.exs before merging." >&2
+            if [ "${{ github.run_attempt }}" = "1" ] && [ "$CACHE_HIT_BOTH" != "true" ] && [ -n "$DEPLOYABLE" ]; then
+              echo "ERROR: Version ${VERSION} already exists in GHCR and deployable paths changed in this merge. Bump the version in mix.exs before merging." >&2
+              echo "::group::Deployable paths changed (HEAD~1..HEAD)"; echo "$DEPLOYABLE"; echo "::endgroup::"
               exit 1
             fi
-            echo "::notice::Image ${GHCR_IMAGE}:${VERSION} already in GHCR (run_attempt=${{ github.run_attempt }}, cache_hit_both=${CACHE_HIT_BOTH}); skipping build, jumping to deploy."
+            DEP_NOTE=$([ -n "$DEPLOYABLE" ] && echo "deployable changed" || echo "CI/docs-only, image unchanged")
+            echo "::notice::Image ${GHCR_IMAGE}:${VERSION} already in GHCR (run_attempt=${{ github.run_attempt }}, cache_hit_both=${CACHE_HIT_BOTH}, ${DEP_NOTE}); skipping build, jumping to deploy."
             IMAGE_EXISTS=true
           fi
 

--- a/ci/fingerprint/compute.sh
+++ b/ci/fingerprint/compute.sh
@@ -1,0 +1,39 @@
+# ci/fingerprint/compute.sh
+. "$(dirname "${BASH_SOURCE[0]}")/groups.sh"
+# job -> groups (SUPERSETS; see spec). plugin handled via PLUGIN_SHA.
+job_names() { echo "lint unit-tests storage-database e2e-clerk e2e-crdt e2e-local e2e-browser n1-compat build-and-publish-image"; }
+job_groups() {
+  case "$1" in
+    lint)              echo "elixir-src unit-tests lint-config" ;;
+    unit-tests)        echo "elixir-src unit-tests migrations" ;;
+    storage-database)  echo "elixir-src migrations docker-image" ;;
+    e2e-clerk|e2e-crdt) echo "docker-image elixir-src e2e-harness +plugin" ;;
+    e2e-local|e2e-browser) echo "docker-image elixir-src e2e-harness frontend" ;;
+    n1-compat)         echo "elixir-src migrations" ;;
+    build-and-publish-image) echo "docker-image elixir-src frontend migrations" ;;
+    *) echo "unknown job: $1" >&2; return 2 ;;
+  esac
+}
+job_hash() {
+  local job="$1" acc="" g
+  for g in $(job_groups "$job"); do
+    if [ "$g" = "+plugin" ]; then acc="$acc plugin:${PLUGIN_SHA:-}"; else acc="$acc $(group_hash "$g" "$BEAM_TAG")"; fi
+  done
+  printf '%s' "$acc" | sha256sum | cut -d' ' -f1
+}
+marker_exists() { # ci-<job>:<hash>
+  [ -n "${LOCAL_REGISTRY:-}" ] || return 1
+  local body; body=$(curl -s --max-time 5 -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+    "http://${LOCAL_REGISTRY}/v2/ci-$1/manifests/$2" || true)
+  printf '%s' "$body" | jq -e 'type=="object" and has("schemaVersion")' >/dev/null 2>&1
+}
+emit_skips() { # writes skip-<job>/hash-<job> to GITHUB_OUTPUT
+  local job h skip
+  for job in $(job_names); do
+    h=$(job_hash "$job")
+    if marker_exists "$job" "$h"; then skip=true; else skip=false; fi
+    echo "skip-$job=$skip" >> "$GITHUB_OUTPUT"
+    echo "hash-$job=$h"    >> "$GITHUB_OUTPUT"
+  done
+}
+[ "${1:-}" = emit ] && emit_skips || true

--- a/ci/fingerprint/compute.sh
+++ b/ci/fingerprint/compute.sh
@@ -3,14 +3,17 @@
 # job -> groups (SUPERSETS; see spec). plugin handled via PLUGIN_SHA.
 job_names() { echo "lint unit-tests storage-database e2e-clerk e2e-crdt e2e-local e2e-browser n1-compat build-and-publish-image"; }
 job_groups() {
+  # ci-meta on EVERY job so a workflow/fingerprint-script change re-runs all jobs.
+  # e2e jobs include `priv` because the e2e stack boots the real release, which
+  # runs Engram.Release.migrate() at startup — a migration-only change must bust them.
   case "$1" in
-    lint)              echo "elixir-src unit-tests lint-config" ;;
-    unit-tests)        echo "elixir-src unit-tests migrations" ;;
-    storage-database)  echo "elixir-src migrations docker-image" ;;
-    e2e-clerk|e2e-crdt) echo "docker-image elixir-src e2e-harness +plugin" ;;
-    e2e-local|e2e-browser) echo "docker-image elixir-src e2e-harness frontend" ;;
-    n1-compat)         echo "elixir-src migrations" ;;
-    build-and-publish-image) echo "docker-image elixir-src frontend migrations" ;;
+    lint)              echo "elixir-src unit-tests lint-config ci-meta" ;;
+    unit-tests)        echo "elixir-src unit-tests priv ci-meta" ;;
+    storage-database)  echo "elixir-src priv docker-image ci-meta" ;;
+    e2e-clerk|e2e-crdt) echo "docker-image elixir-src e2e-harness priv +plugin ci-meta" ;;
+    e2e-local|e2e-browser) echo "docker-image elixir-src e2e-harness frontend priv ci-meta" ;;
+    n1-compat)         echo "elixir-src priv ci-meta" ;;
+    build-and-publish-image) echo "docker-image elixir-src frontend priv ci-meta" ;;
     *) echo "unknown job: $1" >&2; return 2 ;;
   esac
 }

--- a/ci/fingerprint/compute.sh
+++ b/ci/fingerprint/compute.sh
@@ -31,9 +31,20 @@ emit_skips() { # writes skip-<job>/hash-<job> to GITHUB_OUTPUT
   local job h skip
   for job in $(job_names); do
     h=$(job_hash "$job")
-    if marker_exists "$job" "$h"; then skip=true; else skip=false; fi
+    # Full runs (main / [ci-full] / force_full) NEVER skip: main is the safety
+    # net that re-runs everything and re-seeds markers, so force skip=false there
+    # regardless of marker presence. PRs skip only when a marker already exists.
+    if [ "${IS_FULL_RUN:-false}" = true ]; then
+      skip=false
+    elif marker_exists "$job" "$h"; then
+      skip=true
+    else
+      skip=false
+    fi
     echo "skip-$job=$skip" >> "$GITHUB_OUTPUT"
     echo "hash-$job=$h"    >> "$GITHUB_OUTPUT"
   done
 }
-[ "${1:-}" = emit ] && emit_skips || true
+# `if` (not `&& ... || true`) so a real emit failure propagates while sourcing
+# this file with no args stays exit-0 (source-safe for compute_test / record.sh).
+if [ "${1:-}" = emit ]; then emit_skips; fi

--- a/ci/fingerprint/groups.sh
+++ b/ci/fingerprint/groups.sh
@@ -5,11 +5,23 @@ group_paths() {
   case "$1" in
     elixir-src)  echo "lib config mix.lock" ;;        # mix.exs handled separately (version-stripped)
     unit-tests)  echo "test" ;;
-    migrations)  echo "priv/repo/migrations priv/repo/seeds.exs" ;;
+    # Whole priv/, not just migrations: priv/legal (ToS manifests the legal
+    # seeder loads at boot), priv/static (SPA assets), priv/gettext, seeds, and
+    # structure.sql all affect unit-tests / the booted release. Legacy
+    # BACKEND_HASH hashed all of priv; under-including here silently skips jobs.
+    priv)        echo "priv" ;;
     e2e-harness) echo "e2e" ;;
     frontend)    echo "frontend" ;;
-    docker-image) echo "Dockerfile entrypoint.sh .dockerignore" ;;
-    lint-config) echo ".credo.exs .sobelow-conf .formatter.exs" ;;
+    # rel/ is COPY'd into the release image (Dockerfile `COPY rel rel`: env.sh.eex
+    # cluster gate + RELEASE_NODE). ci/compose*.yml drive every e2e/storage stack.
+    # Both were in BACKEND_HASH; dropping them lets a stack/release-env change skip.
+    docker-image) echo "Dockerfile entrypoint.sh .dockerignore rel ci/compose.yml ci/compose.local.yml ci/compose.database.yml" ;;
+    # .dialyzer_ignore.exs gates the lint job's dialyzer step (a fatal check).
+    lint-config) echo ".credo.exs .sobelow-conf .formatter.exs .dialyzer_ignore.exs" ;;
+    # The CI logic itself: a change to the workflow or the fingerprint scripts
+    # must bust EVERY job's hash (mirrors BACKEND_HASH including verify.yml), so
+    # a CI-config change is never skipped by a stale per-job marker.
+    ci-meta)     echo ".github/workflows/verify.yml ci/fingerprint" ;;
     *) echo "unknown group: $1" >&2; return 2 ;;
   esac
 }

--- a/ci/fingerprint/groups.sh
+++ b/ci/fingerprint/groups.sh
@@ -1,0 +1,25 @@
+# ci/fingerprint/groups.sh: single source of truth for CI input groups.
+# group_paths <group>  -> echoes the pathspecs for git ls-tree
+# group_hash  <group> <beam_tag> -> sha256 of tracked content under those paths (+ beam tag)
+group_paths() {
+  case "$1" in
+    elixir-src)  echo "lib config mix.lock" ;;        # mix.exs handled separately (version-stripped)
+    unit-tests)  echo "test" ;;
+    migrations)  echo "priv/repo/migrations priv/repo/seeds.exs" ;;
+    e2e-harness) echo "e2e" ;;
+    frontend)    echo "frontend" ;;
+    docker-image) echo "Dockerfile entrypoint.sh .dockerignore" ;;
+    lint-config) echo ".credo.exs .sobelow-conf .formatter.exs" ;;
+    *) echo "unknown group: $1" >&2; return 2 ;;
+  esac
+}
+group_hash() {
+  local group="$1" beam="${2:-}" paths
+  paths=$(group_paths "$group") || return 2
+  { git ls-tree -r HEAD -- $paths 2>/dev/null
+    if [ "$group" = elixir-src ]; then
+      grep -vE '^[[:space:]]*version: "[0-9]+\.[0-9]+\.[0-9]+"' mix.exs | sha256sum
+    fi
+    echo "beam:$beam"
+  } | sha256sum | cut -d' ' -f1
+}

--- a/ci/fingerprint/record.sh
+++ b/ci/fingerprint/record.sh
@@ -1,0 +1,12 @@
+# ci/fingerprint/record.sh
+. "$(dirname "${BASH_SOURCE[0]}")/compute.sh"
+record_marker() {
+  [ "${IS_FULL_RUN:-false}" = true ] || { echo "not a full run; skip marker for $1"; return 0; }
+  [ -n "${LOCAL_REGISTRY:-}" ] || { echo "::warning::LOCAL_REGISTRY unset; marker $1 not recorded"; return 0; }
+  local job="$1" h; h=$(job_hash "$job")
+  local d; d=$(mktemp -d); ( cd "$d" && echo FROM scratch > Dockerfile && echo "$h" > marker \
+    && docker build -q -t "${LOCAL_REGISTRY}/ci-$job:$h" -f Dockerfile . >/dev/null \
+    && docker push -q "${LOCAL_REGISTRY}/ci-$job:$h" >/dev/null )
+  rm -rf "$d"; echo "recorded ci-$job:$h"
+}
+[ "${1:-}" = record ] && record_marker "${2:?job}" || true

--- a/ci/fingerprint/record.sh
+++ b/ci/fingerprint/record.sh
@@ -3,10 +3,20 @@
 record_marker() {
   [ "${IS_FULL_RUN:-false}" = true ] || { echo "not a full run; skip marker for $1"; return 0; }
   [ -n "${LOCAL_REGISTRY:-}" ] || { echo "::warning::LOCAL_REGISTRY unset; marker $1 not recorded"; return 0; }
-  local job="$1" h; h=$(job_hash "$job")
-  local d; d=$(mktemp -d); ( cd "$d" && echo FROM scratch > Dockerfile && echo "$h" > marker \
-    && docker build -q -t "${LOCAL_REGISTRY}/ci-$job:$h" -f Dockerfile . >/dev/null \
-    && docker push -q "${LOCAL_REGISTRY}/ci-$job:$h" >/dev/null )
-  rm -rf "$d"; echo "recorded ci-$job:$h"
+  # Prefer the hash the fingerprint job already emitted + looked up (MARKER_HASH)
+  # so the recorded tag matches a later run's lookup EXACTLY — recomputing here
+  # would depend on BEAM being on the recording runner's host (it isn't, for the
+  # docker-bound e2e/storage jobs), silently producing a mismatched tag.
+  local job="$1" h; h="${MARKER_HASH:-$(job_hash "$job")}"
+  local d; d=$(mktemp -d)
+  if ( cd "$d" && echo FROM scratch > Dockerfile && echo "$h" > marker \
+        && docker build -q -t "${LOCAL_REGISTRY}/ci-$job:$h" -f Dockerfile . >/dev/null \
+        && docker push -q "${LOCAL_REGISTRY}/ci-$job:$h" >/dev/null ); then
+    rm -rf "$d"; echo "recorded ci-$job:$h"
+  else
+    # Non-fatal: a registry blip must not fail an otherwise-green full run, but
+    # surface it (the old code echoed "recorded" even when the push failed).
+    rm -rf "$d"; echo "::warning::marker push failed for ci-$job:$h"; return 0
+  fi
 }
-[ "${1:-}" = record ] && record_marker "${2:?job}" || true
+if [ "${1:-}" = record ]; then record_marker "${2:?job}"; fi

--- a/ci/fingerprint/test/groups_test.sh
+++ b/ci/fingerprint/test/groups_test.sh
@@ -1,0 +1,19 @@
+# ci/fingerprint/test/groups_test.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+. ci/fingerprint/groups.sh
+. ci/fingerprint/compute.sh
+fail=0
+h=$(group_hash elixir-src otp27); [ -n "$h" ] || { echo "FAIL elixir-src empty"; fail=1; }
+[ "$(group_hash elixir-src otp27)" = "$h" ] || { echo "FAIL non-deterministic"; fail=1; }
+if group_hash bogus otp27 2>/dev/null; then echo "FAIL bogus accepted"; fail=1; fi
+[ "$(group_hash elixir-src otp27)" != "$(group_hash elixir-src otp99)" ] || { echo "FAIL beam not mixed"; fail=1; }
+# every job maps only to known groups (+plugin is a sentinel, allowed)
+for j in $(job_names); do
+  for g in $(job_groups "$j"); do
+    [ "$g" = "+plugin" ] && continue
+    group_paths "$g" >/dev/null || { echo "FAIL job $j -> unknown group $g"; fail=1; }
+  done
+done
+[ "$fail" = 0 ] && echo "groups_test OK"
+exit $fail


### PR DESCRIPTION
## What

Replaces the coarse single-`BACKEND_HASH`/`E2E_HASH` CI fingerprint with **per-concern, per-job content skips**, **`mix test --stale`** on PR unit runs, and **opt-in targeted e2e**. A change re-runs only what it affects; `main` always runs everything full as the safety net and is the sole producer of skip markers.

**Scope: Phases 0-4.** Phase 5 (retire the legacy coarse fingerprint) is a deliberate **fast-follow** PR — it rewires live deploy gates and is gated on observing the new system green across a real merge (markers seed on the first main run).

## Phases in this PR

- **Phase 0** — `ci/fingerprint/{groups,compute,record}.sh` (+ tests): testable per-concern input groups; `job_hash` = sha256 over a job's groups' tracked content + BEAM tag (+ plugin SHA for e2e).
- **Phase 1** — `fingerprint` emits `skip-<job>`/`hash-<job>`/`is-full`; the 8 backend test jobs gate on `skip-<job>`; a consolidated `record-job-markers` job seeds `ci-<job>:<hash>` in the LAN registry **only on full runs**, per job iff it succeeded, keyed by the fingerprint's emitted hash.
- **version-check** — made genuinely path-aware (deployable-path diff vs main) so CI-only branches no longer demand a version bump. (`verify.yml` lives inside the fingerprint, so the old cache-hit gate wrongly flagged every CI change as deployable.)
- **Phase 3** — `unit-tests` runs `mix test --stale` on PRs, the full suite on `main`/`[ci-full]`/`force_full`.
- **Phase 4** — `[e2e: <suite>/<pattern>]` in the HEAD commit runs only that suite's e2e job with `pytest -k <pattern>` (suites: clerk|crdt|local|browser); the others skip and the `ci` aggregate fails (non-mergeable). Parser matches only the four real suite names.

## Safety

- **Safe-by-design:** the `ci-<job>` marker namespace is empty until a `main` full run seeds it, so until then every `skip-*` is false and **every job runs** (today's behavior). Validated live: a full push run is green with the whole suite executing.
- **`main` is the net:** `IS_FULL_RUN` forces `skip=false` on `main`/`[ci-full]`/`force_full`; `--stale` falls back to the full suite; markers re-seed. A PR job skips/narrows only against content already proven full-green on `main`.
- **Markers recorded only on full runs** — PRs consume, never produce, so a reduced-mode (`--stale` / targeted) pass can't seed a bad marker.
- **Deploy path untouched.** `build-and-publish-image` keeps its real GHCR image-existence gate; `deploy-frontend`/`submit-dep-graph` keep the coarse gate (retired in the Phase 5 follow-up). Markers are LAN-registry scratch images, never deployed.

## Validation

`bash -n` scripts, `groups_test` green, YAML parses (26 jobs), `emit` dry-runs (PR=all-false / full=all-forced-false), targeted-parser unit checks (placeholder ignored, spaced patterns + case ok), and a full live CI run green on the empty-target path with all jobs executing.

Spec: vault `50 Engineering/_Superpowers Specs/2026-06-30-fine-grained-ci-skip-design.md`. Builds on #801.