### PR TITLE
fix(ci): cold-compile on lockfile change + surface hidden compile errors

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -555,16 +555,22 @@ jobs:
         uses: actions/cache@v6
         with:
           path: _build/dev
+          # No restore-keys: the key is mix.lock-scoped, so a restore-key prefix
+          # hit would reuse a _build compiled against a DIFFERENT dependency set
+          # after a lockfile change. Incremental compile on such a stale _build
+          # crashes protocol consolidation (FunctionClauseError in
+          # :elixir_erl.dynamic_form/1). A lockfile change should cold-compile.
           key: ${{ steps.keys.outputs.build-dev }}
-          restore-keys: mix-build-dev-v2-${{ steps.beam.outputs.tag }}-
 
       - name: Cache _build/test
         id: cache-build-test
         uses: actions/cache@v6
         with:
           path: _build/test
+          # No restore-keys: see the _build/dev cache above. A restore-key hit
+          # across a mix.lock change reuses a _build built against different deps
+          # and crashes protocol consolidation on the incremental compile.
           key: ${{ steps.keys.outputs.build-test }}
-          restore-keys: mix-build-test-v2-${{ steps.beam.outputs.tag }}-
 
       - name: Fetch deps (if missing or lockfile changed)
         # Don't gate on `[ -d deps ]` — the cache's `restore-keys`
@@ -591,8 +597,14 @@ jobs:
           pid_dev=$!
           MIX_ENV=test mix compile --warnings-as-errors --no-deps-check >/tmp/compile-test.log 2>&1 &
           pid_test=$!
-          wait "$pid_dev";  rc_dev=$?
-          wait "$pid_test"; rc_test=$?
+          # Capture exit codes WITHOUT aborting under `set -e`. A bare
+          # `wait "$pid"; rc=$?` lets a failing wait trip `set -e` and kill the
+          # script before the logs below print, hiding the compile error
+          # entirely (every failed compile showed up as an empty log). `|| rc=$?`
+          # tolerates the failure so the cat + final gate still run.
+          rc_dev=0; rc_test=0
+          wait "$pid_dev"  || rc_dev=$?
+          wait "$pid_test" || rc_test=$?
           echo "::group::Compile :dev output";  cat /tmp/compile-dev.log;  echo "::endgroup::"
           echo "::group::Compile :test output"; cat /tmp/compile-test.log; echo "::endgroup::"
           [ "$rc_dev" -eq 0 ] && [ "$rc_test" -eq 0 ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.570",
+      version: "0.5.572",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Fix `prebuild-mix` failing on dependency-adding PRs (+ make compile errors visible)

Two CI bugs, found while diagnosing why PR #800 (adds `ymlr` + `yaml_elixir`) failed `prebuild-mix` in ~8s with **no visible error**.

### Bug 1 — stale `_build` restore crashes protocol consolidation
The `_build/dev` and `_build/test` caches used `restore-keys: mix-build-{dev,test}-v2-<beam>-`, a prefix that **strips the `mix.lock` hash**. On a lockfile change the exact key misses and the restore-key fallback restores a `_build` compiled against a **different dependency set**. The subsequent incremental `mix compile --no-deps-check` then crashes during protocol consolidation:
```
** (FunctionClauseError) no function clause matching in :elixir_erl.dynamic_form/1
   ... OpenApiSpex.Extendable ...
```
Reproduced locally (stale `_build` + incremental → same crash; `--force` → clean). This hits **any** PR that changes `mix.lock`.

**Fix:** drop the `_build` `restore-keys`. The exact key is `mix.lock`-scoped (per #801), so it still hits when the lockfile is unchanged (the common, fast path); a lockfile change now **cold-compiles cleanly** instead of reusing a mismatched `_build`. (The `deps/` cache keeps its restore-key — `mix deps.get` reconciles a partial deps restore correctly; only compiled artifacts can't be reconciled.)

### Bug 2 — compile errors were swallowed
The parallel-compile step runs under `bash -e` with:
```bash
wait "$pid_dev"; rc_dev=$?
```
Under `set -e`, a failing `wait` **aborts the script before** the `cat /tmp/compile-*.log`, so the actual compiler output never printed — every compile failure surfaced as an empty 386-line log. **Fix:** `wait "$pid" || rc=$?` so the logs and the final gate still run.

### Impact
- Unblocks PR #800 and any future dependency-adding PR.
- Makes all future `prebuild-mix` compile failures actually readable.
- No change to the happy path (unchanged `mix.lock` → exact cache hit, same speed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
