### PR TITLE
fix(githooks): make pre-push version-bump gate path-aware

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -54,18 +54,31 @@ if [ -z "$branch_version" ] || [ -z "$main_version" ]; then
 fi
 
 if [ "$branch_version" = "$main_version" ]; then
-  cat >&2 <<EOF
-✖ pre-push: mix.exs version ($branch_version) has not been bumped from main.
+  # Path-aware bump gate (mirrors CI's version-check + build-and-publish guards):
+  # only require a bump when a DEPLOYABLE path actually changed. verify.yml / ci/
+  # / docs ship no new release image, so a CI/docs-only branch needs no bump —
+  # CI's version-check now agrees (it diffs the same path set), so blocking here
+  # only forced a needless `--no-verify`. A real lib/priv/config/frontend/
+  # Dockerfile/rel/mix.* change with an unbumped version is still rejected.
+  deployable="$(git diff --name-only origin/main...HEAD -- \
+    lib priv config frontend Dockerfile entrypoint.sh .dockerignore rel mix.exs mix.lock 2>/dev/null || true)"
+  if [ -n "$deployable" ]; then
+    cat >&2 <<EOF
+✖ pre-push: mix.exs version ($branch_version) has not been bumped from main,
+  but deployable paths changed:
+$(echo "$deployable" | sed 's/^/    /')
 
   Bump the version in mix.exs before pushing:
     sed -i 's/version: "$main_version"/version: "<new>"/' mix.exs
 
   To push WIP without bumping, use: git push --no-verify
 EOF
-  exit 1
+    exit 1
+  fi
+  echo "✓ pre-push: version unchanged but only non-deployable paths changed (CI/docs) — bump not required"
+else
+  echo "✓ pre-push: mix.exs version differs from main (main=$main_version, branch=$branch_version)"
 fi
-
-echo "✓ pre-push: mix.exs version differs from main (main=$main_version, branch=$branch_version)"
 
 # ── Quality gates ────────────────────────────────────────────────────────
 # Two stages, each parallelized. Cuts wall time roughly in half:


### PR DESCRIPTION
## What

The `.githooks/pre-push` hook refused to push any branch whose `mix.exs` version still matched `main`, forcing `git push --no-verify` on every **CI-only / docs-only** branch (verify.yml, `ci/`, `*.md`) — which ship no new release image and need no version bump.

## Why now

After #803, CI's `version-check` **and** `build-and-publish-image` are both path-aware (they require a bump only when a deployable path changed). The pre-push hook was the last holdout still demanding a bump for every branch, so it kept forcing `--no-verify` — which also skips the hook's quality gates (format/compile/credo/sobelow), defeating their purpose.

## How

Require a bump only when a **deployable** path actually changed vs `origin/main` — the same set CI uses: `lib priv config frontend Dockerfile entrypoint.sh .dockerignore rel mix.exs mix.lock`. A CI/docs-only branch with an unchanged version now passes the gate (and still runs the quality gates). A real content change with an unbumped version is still rejected.

## Validation

This branch (hook-only change, no version bump) was pushed **without** `--no-verify` — the new hook took the path-aware route ("no Elixir-affecting files… running format only ✓") and allowed it. The old hook would have blocked it.