### PR TITLE
fix(ci): make prebuild-ci-image + ci is-full-aware (main runs full)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -420,8 +420,18 @@ jobs:
     # Image consumed by e2e-clerk (any trigger, gated on e2e-cache-hit) and
     # e2e-local (push/workflow_dispatch only, gated on backend-cache-hit).
     # Build whenever at least one consumer will run.
+    #
+    # is-full forces a build on full runs (main / [ci-full] / force_full). The
+    # e2e + storage-database jobs `needs:` this image and, on full runs, their
+    # per-job skip flags are forced false — but a job whose dependency was
+    # SKIPPED is itself skipped regardless of its own if:. Without this clause a
+    # main merge that hit the coarse cache (e.g. a change outside BACKEND_HASH)
+    # skipped this prebuild, cascade-skipping every e2e/storage job, so "main
+    # runs everything full" silently did not hold. This makes the coarse gate
+    # is-full-aware to match the per-job layer.
     if: |
-      needs.fingerprint.outputs.e2e-cache-hit != 'true'
+      needs.fingerprint.outputs.is-full == 'true'
+      || needs.fingerprint.outputs.e2e-cache-hit != 'true'
       || (github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.backend-cache-hit != 'true')
     runs-on: [self-hosted, linux, x64, isolated]
     outputs:
@@ -3173,7 +3183,11 @@ jobs:
             marketing-md=_marketing/src/legal
 
   ci:
-    if: always() && (needs.fingerprint.outputs.backend-cache-hit != 'true' || needs.fingerprint.outputs.e2e-cache-hit != 'true')
+    # is-full keeps the aggregate gate alive on full runs (main / [ci-full] /
+    # force_full) even when the coarse cache hit — otherwise ci skips on main
+    # and a real e2e/unit failure there is never gated. Mirrors the per-job +
+    # prebuild is-full forcing so main is genuinely the full safety net.
+    if: always() && (needs.fingerprint.outputs.is-full == 'true' || needs.fingerprint.outputs.backend-cache-hit != 'true' || needs.fingerprint.outputs.e2e-cache-hit != 'true')
     needs: [fingerprint, version-check, unit-tests, lint, storage-database, e2e-clerk, e2e-crdt, e2e-local, e2e-browser, n1-compat, legal-cross-repo]
     runs-on: [self-hosted, linux, x64, isolated]
     steps:


### PR DESCRIPTION
## The bug

"main runs everything full as the safety net" — the core promise of the fine-grained skip system (#803) — did **not** actually hold for the e2e + storage suite.

Observed on the #805 merge to main (`c8f0c253`): `e2e-clerk`, `e2e-crdt`, `e2e-local`, and `storage-database` all **skipped**.

## Root cause

The per-job skip layer is `is-full`-aware (on main, `IS_FULL_RUN=true` forces every `skip-<job>` false). But `prebuild-ci-image` and the `ci` aggregate still gate on the **legacy coarse fingerprint** (`backend-cache-hit`/`e2e-cache-hit`), which is **not** `is-full`-aware (deliberately left for the Phase 5 retirement).

On a main merge that hits the coarse cache — any change outside `BACKEND_HASH`, e.g. #805's `.githooks/`-only change — `prebuild-ci-image` skipped. Every job that `needs:` it (the four e2e jobs + `storage-database`) then cascade-skipped: **a job whose dependency was skipped is itself skipped, regardless of its own (is-full-forced) `if:`**.

## Fix

Add `needs.fingerprint.outputs.is-full == 'true'` to the `prebuild-ci-image` and `ci` gates, so full runs (main / `[ci-full]` / `force_full`) always build the CI image and run the aggregate. The e2e/storage jobs then run (their per-job skip is already forced false on main).

**Strictly additive / deploy-safe:** PRs are unchanged (`is-full` false → the coarse fast path is intact). Main only ever runs **more**. The deploy jobs (build-and-publish / deploy-frontend) are untouched — they correctly skip rebuilding identical content.

Pending the Phase 5 coarse-fingerprint retirement, which removes this per-job-vs-coarse split entirely.