### PR TITLE
fix(ci): compile deps before app on cold _build (prebuild-mix follow-up to #804)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -603,6 +603,26 @@ jobs:
           # --warnings-as-errors keeps the downstream lint compile a fast no-op
           # on cache restore. --no-deps-check: deps were just reconciled by the
           # `mix deps.get` step above, so skip the redundant lockfile recheck.
+          #
+          # Compile dependencies FIRST. On a cold _build (a lockfile change busts
+          # the mix.lock-scoped build cache, so no _build is restored), the app
+          # compile below uses --no-deps-check and will NOT build deps itself —
+          # it fails fast with "module Ecto.* is not loaded". deps.compile builds
+          # them; it is a near no-op when _build was restored warm (lockfile
+          # unchanged). Parallel per env to mirror the app-compile parallelism.
+          MIX_ENV=dev  mix deps.compile >/tmp/deps-dev.log 2>&1 &
+          dpid_dev=$!
+          MIX_ENV=test mix deps.compile >/tmp/deps-test.log 2>&1 &
+          dpid_test=$!
+          drc_dev=0; drc_test=0
+          wait "$dpid_dev"  || drc_dev=$?
+          wait "$dpid_test" || drc_test=$?
+          if [ "$drc_dev" -ne 0 ] || [ "$drc_test" -ne 0 ]; then
+            echo "::group::deps.compile :dev output";  cat /tmp/deps-dev.log;  echo "::endgroup::"
+            echo "::group::deps.compile :test output"; cat /tmp/deps-test.log; echo "::endgroup::"
+            echo "deps.compile failed (dev=$drc_dev test=$drc_test)" >&2
+            exit 1
+          fi
           MIX_ENV=dev  mix compile --warnings-as-errors --no-deps-check >/tmp/compile-dev.log 2>&1 &
           pid_dev=$!
           MIX_ENV=test mix compile --warnings-as-errors --no-deps-check >/tmp/compile-test.log 2>&1 &

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.572",
+      version: "0.5.574",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Follow-up to #804: compile deps on a cold `_build`

#804 dropped the `_build` `restore-keys` so a lockfile change cold-compiles (avoiding the stale-`_build` protocol-consolidation crash). But the prebuild app-compile uses `mix compile --no-deps-check`, which does **not** build dependencies on a cold `_build`. So a dependency-adding PR now fails fast with:

```
error: module Ecto.Schema is not loaded and could not be found
   use Engram.Schema  (lib/engram/accounts/api_key.ex:3)
error: module Ecto.Query is not loaded ...
```

(Surfaced thanks to #804's log-swallow fix — previously this was an empty 386-line log.)

**Fix:** run `mix deps.compile` (per env, in parallel) before the app compile. On a cold `_build` it builds the deps so the app compile finds them; when `_build` is restored warm (lockfile unchanged) it's a near no-op, so the common fast path is unaffected.

### Validation
This PR doesn't change `mix.lock`, so its own CI runs the warm path and can't exercise the cold path — same as #804. The real confirmation is **#800** (which adds `ymlr` + `yaml_elixir`) going green after it rebases onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
