### PR TITLE
chore(frontend): ratchet a11y useButtonType, noRedundantRoles, noSvgWithoutTitle

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -10,6 +10,7 @@
 			"**",
 			"!**/dist",
 			"!**/node_modules",
+			"!public",
 			"!**/playwright-report",
 			"!**/test-results",
 			"!bun.lock"
@@ -68,12 +69,9 @@
 						"noLabelWithoutControl": "off",
 						"noNoninteractiveElementInteractions": "off",
 						"noNoninteractiveElementToInteractiveRole": "off",
-						"noRedundantRoles": "off",
 						"noStaticElementInteractions": "off",
-						"noSvgWithoutTitle": "off",
 						"useAriaPropsForRole": "off",
 						"useAriaPropsSupportedByRole": "off",
-						"useButtonType": "off",
 						"useFocusableInteractive": "off",
 						"useKeyWithClickEvents": "off",
 						"useSemanticElements": "off"

--- a/frontend/src/billing/cancel-panel.tsx
+++ b/frontend/src/billing/cancel-panel.tsx
@@ -42,7 +42,7 @@ export default function CancelPanel({ detail, tier, onClose }: CancelPanelProps)
 	}
 
 	return (
-		<section role="region" aria-label="Cancel subscription" className="space-y-4 pt-2">
+		<section aria-label="Cancel subscription" className="space-y-4 pt-2">
 			<header>
 				<h2 className="font-semibold text-base text-foreground">Cancel subscription</h2>
 				<p className="mt-2 text-muted-foreground text-sm">

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -85,6 +85,7 @@ export function CadenceToggle({
 		<div role="radiogroup" aria-label="Billing cadence" className="flex justify-center">
 			<div className="inline-flex rounded-full border border-border bg-muted p-1 text-sm">
 				<button
+					type="button"
 					role="radio"
 					aria-checked={cadence === "monthly"}
 					onClick={() => onChange("monthly")}
@@ -98,6 +99,7 @@ export function CadenceToggle({
 					Monthly
 				</button>
 				<button
+					type="button"
 					role="radio"
 					aria-checked={cadence === "annual"}
 					onClick={() => onChange("annual")}
@@ -216,6 +218,7 @@ export function PlanCard({
 				) : (
 					<>
 						<button
+							type="button"
 							onClick={() => onAction(tier)}
 							disabled={disabled}
 							className={cn(

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -96,7 +96,7 @@ function PlanChangePicker({ billing, onClose }: { billing: BillingStatus; onClos
 
 	if (!config) {
 		return (
-			<section role="region" aria-label="Change plan" className="py-2">
+			<section aria-label="Change plan" className="py-2">
 				<p className="text-muted-foreground text-sm">Loading plan options…</p>
 			</section>
 		);
@@ -116,7 +116,7 @@ function PlanChangePicker({ billing, onClose }: { billing: BillingStatus; onClos
 	}
 
 	return (
-		<section role="region" aria-label="Change plan" className="space-y-5 pt-2">
+		<section aria-label="Change plan" className="space-y-5 pt-2">
 			<header>
 				<h2 className="font-semibold text-base text-foreground">Change your plan</h2>
 				<p className="mt-2 text-muted-foreground text-sm">
@@ -218,7 +218,7 @@ function TrialNotice({
 
 	if (alreadyCanceled) {
 		return (
-			<section role="region" aria-label="Change plan" className="space-y-4 pt-2">
+			<section aria-label="Change plan" className="space-y-4 pt-2">
 				<header>
 					<h2 className="font-semibold text-base text-foreground">Change your plan</h2>
 					<p className="mt-2 text-muted-foreground text-sm">
@@ -247,7 +247,7 @@ function TrialNotice({
 	}
 
 	return (
-		<section role="region" aria-label="Change plan" className="space-y-4 pt-2">
+		<section aria-label="Change plan" className="space-y-4 pt-2">
 			<header>
 				<h2 className="font-semibold text-base text-foreground">Change your plan</h2>
 				<p className="mt-2 text-muted-foreground text-sm">

--- a/frontend/src/billing/upgrade-dialog-provider.test.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.test.tsx
@@ -6,7 +6,11 @@ import { UpgradeDialogProvider, useUpgradeDialog } from "./upgrade-dialog-provid
 
 function Trigger() {
 	const { showUpgrade } = useUpgradeDialog();
-	return <button onClick={() => showUpgrade("notes_cap_exceeded")}>show</button>;
+	return (
+		<button type="button" onClick={() => showUpgrade("notes_cap_exceeded")}>
+			show
+		</button>
+	);
 }
 
 function renderWithRouter(ui: React.ReactNode) {

--- a/frontend/src/components/subscription-alert.tsx
+++ b/frontend/src/components/subscription-alert.tsx
@@ -60,6 +60,7 @@ export function SubscriptionAlert({ subscription, onDismiss, className }: Subscr
 				</span>
 				{onDismiss && (
 					<button
+						type="button"
 						onClick={onDismiss}
 						aria-label="Dismiss alert"
 						className="shrink-0 rounded-sm opacity-60 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"

--- a/frontend/src/layout/rail-view-context.test.tsx
+++ b/frontend/src/layout/rail-view-context.test.tsx
@@ -7,8 +7,12 @@ function Probe() {
 	return (
 		<>
 			<span data-testid="view">{view}</span>
-			<button onClick={() => setView("search")}>to-search</button>
-			<button onClick={() => setView("files")}>to-files</button>
+			<button type="button" onClick={() => setView("search")}>
+				to-search
+			</button>
+			<button type="button" onClick={() => setView("files")}>
+				to-files
+			</button>
 		</>
 	);
 }

--- a/frontend/src/onboarding/create-first-vault-modal.test.tsx
+++ b/frontend/src/onboarding/create-first-vault-modal.test.tsx
@@ -6,7 +6,9 @@ const DEMO_VAULT_ID = "01923a4b-cdef-7000-89ab-cdef01234567";
 
 vi.mock("../components/vault-create-form", () => ({
 	VaultCreateForm: ({ onCreated }: { onCreated: (id: string) => void }) => (
-		<button onClick={() => onCreated(DEMO_VAULT_ID)}>fake-create</button>
+		<button type="button" onClick={() => onCreated(DEMO_VAULT_ID)}>
+			fake-create
+		</button>
 	),
 }));
 

--- a/frontend/src/viewer/attachment-upload/provider.test.tsx
+++ b/frontend/src/viewer/attachment-upload/provider.test.tsx
@@ -19,7 +19,11 @@ vi.mock("../../onboarding/tour/demo-vault-provider", () => ({
 
 function TriggerButton() {
 	const { openUpload } = useAttachmentUpload();
-	return <button onClick={() => openUpload([new File(["x"], "fromButton.txt")])}>open</button>;
+	return (
+		<button type="button" onClick={() => openUpload([new File(["x"], "fromButton.txt")])}>
+			open
+		</button>
+	);
 }
 
 function fileDragEvent(type: string, withFiles: boolean) {

--- a/frontend/src/viewer/dashboard.tsx
+++ b/frontend/src/viewer/dashboard.tsx
@@ -58,7 +58,7 @@ function FolderNotes({ folder }: { folder: string }) {
 
 	return (
 		<section aria-label={`Notes in ${folder}`}>
-			<ul role="list">
+			<ul>
 				{notes.map((note) => (
 					<li key={note.path}>
 						<NoteRow note={note} />

--- a/frontend/src/viewer/note-toc.tsx
+++ b/frontend/src/viewer/note-toc.tsx
@@ -39,7 +39,7 @@ export default function NoteToc({ content }: { content: string }) {
 					On this page
 				</p>
 			</header>
-			<ul role="list" className="space-y-px py-2">
+			<ul className="space-y-px py-2">
 				{headings.map((h, i) => (
 					<li key={`${h.id}-${i}`}>
 						<a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.577",
+      version: "0.5.578",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
First ratchet PR from #812 (re-enabling deferred Biome rules one cohesive group per PR).

## What

Re-enables three **mechanical** a11y rules that were deferred in the initial Biome adoption (#815):

| Rule | Sites | Fix |
|------|-------|-----|
| `useButtonType` | 9 | explicit `type="button"` |
| `noRedundantRoles` | 7 | drop redundant `role` (safe autofix) |
| `noSvgWithoutTitle` | 0 | free lock-in (see below) |

Also excludes `public/` from linting: it holds static SVG assets and OAuth manual-test HTML fixtures, not authored components, and was the sole source of `noSvgWithoutTitle`/`useButtonType` noise. After that exclusion `noSvgWithoutTitle` has zero source violations, so enabling it just locks the rule in for free.

## Deferred to follow-ups

The a11y group is larger than these three. The remaining 10 rules need real work and stay off (tracked in #812):

- **Interactive-onClick cluster** (`noNoninteractiveElementInteractions`, `noNoninteractiveElementToInteractiveRole`, `noStaticElementInteractions`, `useKeyWithClickEvents`, `useFocusableInteractive`) — clickable `div`/`li` needing button-conversion or keyboard handlers; behavior-affecting refactors.
- **`useSemanticElements`** — flags the styled `role="radio"` segmented toggle; proper fix is real `<input type=radio>`, a design change.
- **`noLabelWithoutControl`, `useAriaPropsForRole`, `useAriaPropsSupportedByRole`** — a few thorny sites (library-spread props, `combobox` role needing paired aria).
- **`noAutofocus`** — autofocus in modal first-fields is intentional UX.

## Verification

- `bun run ci` (biome ci) clean
- `tsc --noEmit` clean
- touched test files green (13/13)

Refs #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)