### PR TITLE
chore(frontend): ratchet a11y interactive-element rules

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -67,13 +67,9 @@
 					"a11y": {
 						"noAutofocus": "off",
 						"noLabelWithoutControl": "off",
-						"noNoninteractiveElementInteractions": "off",
 						"noNoninteractiveElementToInteractiveRole": "off",
-						"noStaticElementInteractions": "off",
 						"useAriaPropsForRole": "off",
 						"useAriaPropsSupportedByRole": "off",
-						"useFocusableInteractive": "off",
-						"useKeyWithClickEvents": "off",
 						"useSemanticElements": "off"
 					},
 					"complexity": {

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -690,16 +690,18 @@ function ModalShell({
 	children: React.ReactNode;
 }) {
 	return (
-		<section
-			role="dialog"
-			aria-modal="true"
-			aria-labelledby="modal-title"
-			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-			onClick={onClose}
-		>
-			<article
-				className="w-full max-w-md rounded-lg bg-card p-6 shadow-xl"
-				onClick={(e) => e.stopPropagation()}
+		<div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+			<button
+				type="button"
+				aria-label="Close dialog"
+				onClick={onClose}
+				className="fixed inset-0 bg-black/50"
+			/>
+			<section
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="modal-title"
+				className="relative w-full max-w-md rounded-lg bg-card p-6 shadow-xl"
 			>
 				<header className="mb-4">
 					<h2 id="modal-title" className="font-semibold text-foreground text-lg">
@@ -707,8 +709,8 @@ function ModalShell({
 					</h2>
 				</header>
 				{children}
-			</article>
-		</section>
+			</section>
+		</div>
 	);
 }
 

--- a/frontend/src/viewer/attachment-upload/upload-dialog.tsx
+++ b/frontend/src/viewer/attachment-upload/upload-dialog.tsx
@@ -164,6 +164,7 @@ export function AttachmentUploadDialog({ initialFiles, folders, defaultFolder, o
 						className="max-h-24 overflow-y-auto rounded border border-border focus:outline-none focus:ring-2 focus:ring-blue-400"
 					>
 						{candidates.map((name, i) => (
+							// biome-ignore lint/a11y/useFocusableInteractive lint/a11y/useKeyWithClickEvents: option in an aria-activedescendant listbox; options are intentionally not individually focusable and keyboard activation is handled on the listbox container above
 							<li
 								key={name || "__root__"}
 								id={optionId(i)}

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -508,6 +508,7 @@ export default function FolderTree() {
 
 	return (
 		<>
+			{/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: drag-and-drop drop zone; native HTML5 DnD has no keyboard equivalent, keyboard users move folders via the action menu */}
 			<nav
 				{...containerProps}
 				ref={setContainerEl}

--- a/frontend/src/viewer/tree-actions/action-drawer.tsx
+++ b/frontend/src/viewer/tree-actions/action-drawer.tsx
@@ -11,7 +11,9 @@ interface Props {
 export function ActionDrawer({ title, actions, onPick, onClose, onSelectMore }: Props) {
 	return (
 		<>
-			<div
+			<button
+				type="button"
+				aria-label="Close menu"
 				data-testid="action-drawer-backdrop"
 				onClick={onClose}
 				className="fixed inset-0 z-40 bg-black/40"

--- a/frontend/src/viewer/tree-actions/move-dialog.tsx
+++ b/frontend/src/viewer/tree-actions/move-dialog.tsx
@@ -69,6 +69,7 @@ export function MoveDialog({ folders, nodes, onPick, onCancel }: Props) {
 			/>
 			<ul role="listbox" className="max-h-72 overflow-y-auto py-1">
 				{candidates.map((name, i) => (
+					// biome-ignore lint/a11y/useFocusableInteractive lint/a11y/useKeyWithClickEvents: option in a combobox-controlled listbox; options are intentionally not individually focusable and keyboard activation is handled on the input above
 					<li
 						key={name || "__root__"}
 						role="option"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.578",
+      version: "0.5.579",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Second ratchet PR from #812. Enables four interactive-element a11y rules:
`noNoninteractiveElementInteractions`, `noStaticElementInteractions`, `useFocusableInteractive`, `useKeyWithClickEvents`.

## Real accessibility fixes

Backdrop-dismiss handlers on non-interactive elements (keyboard users couldn't activate them):

- **connections-page Modal** — the backdrop is now a real `<button aria-label="Close dialog">` rendered as a sibling of the dialog panel, instead of an `onClick` on the `<section>` wrapper plus a `stopPropagation` child. `role="dialog"` moves onto the actual panel (more correct). Behavior preserved: click backdrop closes, click panel does not.
- **action-drawer** — backdrop `<div onClick>` becomes a `<button aria-label="Close menu">` (`data-testid` preserved so tests keep working).

## Documented suppressions (correct ARIA patterns Biome can't model)

- **folder-tree drop zone** — native HTML5 drag-and-drop has no keyboard equivalent; keyboard users move folders via the action menu.
- **upload-dialog / move-dialog listbox options** — `aria-activedescendant` listboxes: options are intentionally *not* individually focusable, and keyboard activation lives on the listbox container / combobox input. Each `biome-ignore` names only the two rules it actually covers.

## Deferred

`noNoninteractiveElementToInteractiveRole` stays off (still tracked in #812). Clearing it means converting the `<ul>`/`<li>` listbox markup to `<div role=...>` to drop the implicit-list-vs-ARIA-role conflict, which is a separate semantic change and gets its own PR.

## Verification

- `bun run ci` (biome ci) clean
- `tsc --noEmit` clean
- 44 tests across the touched components green (action-drawer, move-dialog, folder-tree, upload-dialog, attachment provider, connections-page)

Refs #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)