### PR TITLE
fix(crdt): normalize stray in-body frontmatter into the Y.Map (backend 2/3)

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1435,7 +1435,8 @@ defmodule Engram.Notes do
 
     base_attrs = batch_base_attrs(entry, user, vault)
 
-    with {:ok, encrypted} <- Crypto.encrypt_note_fields(base_attrs, user, note_id) do
+    with {:ok, encrypted} <- Crypto.encrypt_note_fields(base_attrs, user, note_id),
+         {:ok, crdt} <- build_crdt_state(entry, user, note_id) do
       phase_b =
         inject_phase_b_fields(encrypted, user, note_id, entry.path, entry.folder, entry.tags)
 
@@ -1447,11 +1448,21 @@ defmodule Engram.Notes do
           |> Ecto.Changeset.apply_changes()
           |> Map.take(@batch_insert_columns)
           |> Map.merge(%{id: note_id, version: 1, created_at: now, updated_at: now})
+          |> Map.merge(crdt)
 
         {:ok, note_id, row}
       else
         {:error, changeset}
       end
+    end
+  end
+
+  defp build_crdt_state(entry, user, note_id) do
+    content = entry.content || ""
+
+    with {:ok, %{state: state}} <- Engram.Notes.CrdtBridge.merge_plaintext(nil, content),
+         {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(state, user, note_id) do
+      {:ok, %{crdt_state_ciphertext: ct, crdt_state_nonce: nonce}}
     end
   end
 

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1460,6 +1460,10 @@ defmodule Engram.Notes do
   defp build_crdt_state(entry, user, note_id) do
     content = entry.content || ""
 
+    # merge_plaintext ingests via CrdtBridge.ingest_plaintext, which splits any
+    # frontmatter fence out of the body into the Y.Map at insert time, so the
+    # seeded state already satisfies the invariant. No normalize_doc is needed
+    # on this path (unlike bind/3, which heals legacy at-rest state).
     with {:ok, %{state: state}} <- Engram.Notes.CrdtBridge.merge_plaintext(nil, content),
          {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(state, user, note_id) do
       {:ok, %{crdt_state_ciphertext: ct, crdt_state_nonce: nonce}}

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -183,6 +183,55 @@ defmodule Engram.Notes.CrdtBridge do
     :ok
   end
 
+  @doc """
+  Heal a doc that violates the frontmatter invariant. If the body `Y.Text`
+  starts with a frontmatter fence, lift its keys into `Y.Map` (Y.Map wins on
+  a key collision; fence-only keys are appended to the order array) and strip
+  the fence from the body. Loops so stacked fences fully heal in one call.
+
+  Idempotent: a doc whose body has no leading fence, or whose top block is not
+  valid map YAML, is left unchanged.
+  """
+  @spec normalize_doc(Yex.Doc.t()) :: :ok
+  def normalize_doc(%Yex.Doc{} = doc) do
+    body = body_of(doc)
+
+    case Frontmatter.split(body) do
+      {nil, _} ->
+        :ok
+
+      {fm_block, rest} ->
+        case Frontmatter.parse(fm_block) do
+          {:ok, order, values} ->
+            map = Yex.Doc.get_map(doc, @frontmatter_name)
+            arr = Yex.Doc.get_array(doc, @order_name)
+            existing = Yex.Map.to_map(map)
+            existing_order = Yex.Array.to_list(arr)
+
+            # Y.Map wins: only lift keys not already present.
+            new_keys = Enum.filter(order, fn k -> not Map.has_key?(existing, k) end)
+            Enum.each(new_keys, fn k -> Yex.Map.set(map, k, Map.fetch!(values, k)) end)
+
+            to_append = Enum.reject(new_keys, fn k -> k in existing_order end)
+
+            if to_append != [] do
+              Yex.Array.insert_list(arr, length(existing_order), to_append)
+            end
+
+            text = Yex.Doc.get_text(doc, @text_name)
+            :ok = diff_into_text(text, rest)
+
+            # The body may now begin with another fence (stacked); heal again.
+            # Terminates: each pass strips one fence so the body strictly shrinks.
+            normalize_doc(doc)
+
+          :error ->
+            # Malformed or non-map YAML at the top: not real frontmatter. Leave as-is.
+            :ok
+        end
+    end
+  end
+
   defp apply_frontmatter(doc, order, values) do
     map = Yex.Doc.get_map(doc, @frontmatter_name)
     current = Yex.Map.to_map(map)

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -68,9 +68,7 @@ defmodule Engram.Notes.CrdtDeliver do
       room ->
         try do
           SharedDoc.update_doc(room, fn doc ->
-            doc
-            |> Yex.Doc.get_text(CrdtBridge.text_name())
-            |> CrdtBridge.diff_into_text(content)
+            CrdtBridge.ingest_plaintext(doc, content)
           end)
         catch
           :exit, _reason -> :ok

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -56,6 +56,8 @@ defmodule Engram.Notes.CrdtPersistence do
               seed_from_content(doc, note, user)
             end
 
+            :ok = CrdtBridge.normalize_doc(doc)
+
           nil ->
             :ok
         end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.587",
+      version: "0.5.588",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -191,6 +191,13 @@ defmodule Engram.Notes.CrdtBridgeTest do
       assert :ok = CrdtBridge.normalize_doc(doc)
       assert {CrdtBridge.frontmatter_of(doc), CrdtBridge.body_of(doc)} == first
     end
+
+    test "strips an empty frontmatter fence and terminates" do
+      doc = CrdtBridge.new_doc() |> seed_body("---\n---\nbody\n")
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert CrdtBridge.frontmatter_of(doc) == {[], %{}}
+      assert CrdtBridge.body_of(doc) == "body\n"
+    end
   end
 
   test "multibyte + astral-plane (emoji) edits round-trip without corruption" do

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -123,6 +123,76 @@ defmodule Engram.Notes.CrdtBridgeTest do
     end
   end
 
+  describe "normalize_doc/1" do
+    defp seed_body(doc, str) do
+      text = Yex.Doc.get_text(doc, CrdtBridge.text_name())
+      Yex.Text.insert(text, 0, str)
+      doc
+    end
+
+    test "lifts a single leading fence into the Y.Map and strips it from the body" do
+      doc = CrdtBridge.new_doc() |> seed_body("---\ntitle: Hi\n---\nbody\n")
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert CrdtBridge.frontmatter_of(doc) == {["title"], %{"title" => "\"Hi\""}}
+      assert CrdtBridge.body_of(doc) == "body\n"
+    end
+
+    test "heals stacked fences in one call, appending fence-only keys in order" do
+      doc =
+        CrdtBridge.new_doc()
+        |> seed_body("---\nasdf: asdf\n---\n---\ntitle: Hi\ntags:\n  - a\n---\nbody\n")
+
+      assert :ok = CrdtBridge.normalize_doc(doc)
+
+      assert CrdtBridge.frontmatter_of(doc) ==
+               {["asdf", "title", "tags"],
+                %{"asdf" => "\"asdf\"", "title" => "\"Hi\"", "tags" => "[\"a\"]"}}
+
+      assert CrdtBridge.body_of(doc) == "body\n"
+    end
+
+    test "Y.Map wins on a key collision; fence value is discarded" do
+      doc = CrdtBridge.new_doc()
+      map = Yex.Doc.get_map(doc, "frontmatter")
+      Yex.Map.set(map, "title", "\"New\"")
+      arr = Yex.Doc.get_array(doc, "frontmatter_order")
+      Yex.Array.insert_list(arr, 0, ["title"])
+      seed_body(doc, "---\ntitle: Old\n---\nbody\n")
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert CrdtBridge.frontmatter_of(doc) == {["title"], %{"title" => "\"New\""}}
+      assert CrdtBridge.body_of(doc) == "body\n"
+    end
+
+    test "no-op when the body has no leading fence" do
+      doc = CrdtBridge.new_doc() |> seed_body("just body\nmore\n")
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert CrdtBridge.frontmatter_of(doc) == {[], %{}}
+      assert CrdtBridge.body_of(doc) == "just body\nmore\n"
+    end
+
+    test "no-op on a mid-body horizontal rule (fence not at the very top)" do
+      doc = CrdtBridge.new_doc() |> seed_body("text\n---\nmore\n")
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert CrdtBridge.frontmatter_of(doc) == {[], %{}}
+      assert CrdtBridge.body_of(doc) == "text\n---\nmore\n"
+    end
+
+    test "leaves a non-map YAML top block untouched (not real frontmatter)" do
+      doc = CrdtBridge.new_doc() |> seed_body("---\njust a scalar line\n---\nx\n")
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert CrdtBridge.frontmatter_of(doc) == {[], %{}}
+      assert CrdtBridge.body_of(doc) == "---\njust a scalar line\n---\nx\n"
+    end
+
+    test "is idempotent" do
+      doc = CrdtBridge.new_doc() |> seed_body("---\ntitle: Hi\n---\nbody\n")
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      first = {CrdtBridge.frontmatter_of(doc), CrdtBridge.body_of(doc)}
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert {CrdtBridge.frontmatter_of(doc), CrdtBridge.body_of(doc)} == first
+    end
+  end
+
   test "multibyte + astral-plane (emoji) edits round-trip without corruption" do
     # Astral emoji 🎉 / 😀 are 2 UTF-16 code units each; multibyte BMP chars
     # (é, 漢) are 1 unit but >1 byte — a :bytes offset would mis-slice both.

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -6,7 +6,7 @@ defmodule Engram.Notes.CrdtDeliverTest do
   # unbind; a no-op room avoids it).
   use Engram.DataCase, async: false
 
-  alias Engram.Notes.{CrdtDeliver, CrdtRegistry}
+  alias Engram.Notes.{CrdtBridge, CrdtDeliver, CrdtRegistry}
   alias Yex.Sync.SharedDoc
 
   setup do
@@ -69,6 +69,25 @@ defmodule Engram.Notes.CrdtDeliverTest do
       # The room's owned text converged to the incoming plaintext.
       doc = SharedDoc.get_doc(room)
       assert Engram.Notes.CrdtBridge.text_of(doc) == "base updated"
+    end
+
+    test "delivering a frontmatter change updates the live room's Y.Map, not just the body",
+         %{user: user, vault: vault} do
+      note_id = Ecto.UUID.generate()
+      room = start_bare_room(note_id, "old body\n")
+
+      :ok =
+        CrdtDeliver.deliver_out(
+          user.id,
+          vault.id,
+          "n.md",
+          note_id,
+          "---\ntitle: Hi\n---\nnew body\n"
+        )
+
+      doc = SharedDoc.get_doc(room)
+      assert CrdtBridge.frontmatter_of(doc) == {["title"], %{"title" => "\"Hi\""}}
+      assert CrdtBridge.body_of(doc) == "new body\n"
     end
 
     test "no-op when incoming equals the room's current text (still announces)",

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -373,6 +373,30 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert String.contains?(body, "body"), "body content must be preserved"
   end
 
+  # ── bind/3 self-heals legacy docs with fence inline in Y.Text ───────────
+
+  test "bind heals a persisted doc whose body Y.Text still holds a frontmatter fence",
+       %{user: user, note: note} do
+    # Craft an illegal at-rest state: fence inline in the body Y.Text, empty Y.Map.
+    doc = CrdtBridge.new_doc()
+    text = Yex.Doc.get_text(doc, CrdtBridge.text_name())
+    Yex.Text.insert(text, 0, "---\ntitle: Hi\n---\nbody\n")
+    {:ok, state} = Yex.encode_state_as_update(doc)
+    {:ok, {ct, nonce}} = Crypto.encrypt_crdt_state(state, user, note.id)
+
+    Repo.with_tenant(user.id, fn ->
+      from(n in Note, where: n.id == ^note.id)
+      |> Repo.update_all(set: [crdt_state_ciphertext: ct, crdt_state_nonce: nonce])
+    end)
+
+    st = %{user_id: user.id, vault_id: note.vault_id, note_id: note.id}
+    bound = CrdtBridge.new_doc()
+    CrdtPersistence.bind(st, note.id, bound)
+
+    assert CrdtBridge.frontmatter_of(bound) == {["title"], %{"title" => "\"Hi\""}}
+    assert CrdtBridge.body_of(bound) == "body\n"
+  end
+
   # ── bind/3 replays tail-log after snapshot ────────────────────────────────
 
   test "bind/3 replays tail-log rows on top of the snapshot", ctx do

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -1881,6 +1881,39 @@ defmodule Engram.NotesTest do
   # #746 — rename must repath Qdrant points, not re-embed through Voyage
   # ---------------------------------------------------------------------------
 
+  # ---------------------------------------------------------------------------
+  # batch_upsert_notes — crdt_state seeded at insert time
+  # ---------------------------------------------------------------------------
+
+  describe "batch_upsert_notes/3 — crdt_state seeding" do
+    test "batch-inserted note carries crdt_state decoding to the frontmatter Y.Map",
+         %{user: user, vault: vault} do
+      import Ecto.Query, only: [from: 2]
+
+      {:ok, %{results: _}} =
+        Notes.batch_upsert_notes(user, vault, [
+          %{"path" => "Batch/JoinRefBatch.md", "content" => "---\ntitle: Batched\n---\nbody\n"}
+        ])
+
+      # The vault is freshly created in setup, so it holds exactly this one note.
+      {:ok, note} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          Engram.Repo.one(from(n in Engram.Notes.Note, where: n.vault_id == ^vault.id))
+        end)
+
+      refute is_nil(note.crdt_state_ciphertext)
+
+      {:ok, state} = Engram.Crypto.decrypt_crdt_state(note, user)
+      doc = Engram.Notes.CrdtBridge.new_doc()
+      :ok = Yex.apply_update(doc, state)
+
+      assert Engram.Notes.CrdtBridge.frontmatter_of(doc) ==
+               {["title"], %{"title" => "\"Batched\""}}
+
+      assert Engram.Notes.CrdtBridge.body_of(doc) == "body\n"
+    end
+  end
+
   describe "rename does not re-embed (#746)" do
     test "single-note rename enqueues RepathNoteIndex, not EmbedNote, and keeps embed_hash",
          %{user: user, vault: vault} do

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -3,6 +3,7 @@ defmodule Engram.NotesTest do
   use Oban.Testing, repo: Engram.Repo
 
   alias Engram.Notes
+  alias Engram.Notes.CrdtBridge
 
   setup do
     user = insert(:user)
@@ -1904,13 +1905,13 @@ defmodule Engram.NotesTest do
       refute is_nil(note.crdt_state_ciphertext)
 
       {:ok, state} = Engram.Crypto.decrypt_crdt_state(note, user)
-      doc = Engram.Notes.CrdtBridge.new_doc()
+      doc = CrdtBridge.new_doc()
       :ok = Yex.apply_update(doc, state)
 
-      assert Engram.Notes.CrdtBridge.frontmatter_of(doc) ==
+      assert CrdtBridge.frontmatter_of(doc) ==
                {["title"], %{"title" => "\"Batched\""}}
 
-      assert Engram.Notes.CrdtBridge.body_of(doc) == "body\n"
+      assert CrdtBridge.body_of(doc) == "body\n"
     end
   end
 


### PR DESCRIPTION
## Why

Frontmatter now lives in `Y.Map("frontmatter")` + `Y.Array("frontmatter_order")`, not as a `---` fence inside `Y.Text("content")`. Nothing enforced that invariant, so a stray in-body fence (legacy notes, or an Obsidian edit that reintroduces one) double-projects against the Y.Map. Result: two stacked frontmatter blocks and no unity between the Obsidian and web views of the same note (proven live on `JoinRefTest`).

This makes the server the single point that heals the invariant on every ingest path, so Obsidian ↔ web frontmatter stays coherent regardless of which client wrote the fence.

## What

- **`CrdtBridge.normalize_doc/1`** — loop-heals a doc: splits any in-body frontmatter fence out of `Y.Text`, folds new keys into the Y.Map (Y.Map wins on conflict — never clobbers existing keys), appends new keys to the order array, strips the fence from the body. Idempotent; empty-fence and termination locked by test.
- **`CrdtPersistence.bind/3`** — calls `normalize_doc` after seed, covering the snapshot / tail / seed paths so legacy at-rest state self-heals on open.
- **`push_to_live_room/2`** — routes plaintext through `ingest_plaintext` so the live room's Y.Map receives frontmatter (was diffing raw content straight into `Y.Text`).
- **`Notes.build_batch_insert_row/4`** — seeds `crdt_state` at batch-insert time via `merge_plaintext`, so bulk-inserted notes satisfy the invariant from row zero.

## Testing

Full suite green: **3313 tests, 0 failures**. Each task shipped TDD-first (failing test → impl). SDD two-stage review per task + opus whole-branch review: READY TO MERGE.

Backend 2/3 of the CRDT-frontmatter-as-Y.Map wave (backend 1/3 = #800). Web widget PR #810 is drafted until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)