### PR TITLE
chore(frontend): ratchet a11y noLabelWithoutControl

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -66,7 +66,10 @@
 				"rules": {
 					"a11y": {
 						"noAutofocus": "off",
-						"noLabelWithoutControl": "off",
+						"noLabelWithoutControl": {
+							"level": "error",
+							"options": { "inputComponents": ["Checkbox"] }
+						},
 						"noNoninteractiveElementToInteractiveRole": "off",
 						"useAriaPropsForRole": "off",
 						"useAriaPropsSupportedByRole": "off",

--- a/frontend/src/viewer/attachment-upload/upload-dialog.tsx
+++ b/frontend/src/viewer/attachment-upload/upload-dialog.tsx
@@ -152,9 +152,9 @@ export function AttachmentUploadDialog({ initialFiles, folders, defaultFolder, o
 
 			{candidates.length > 1 && (
 				<section className="px-4 py-3">
-					<label className="mb-1 block font-medium text-muted-foreground text-xs">
+					<span className="mb-1 block font-medium text-muted-foreground text-xs">
 						Destination folder
-					</label>
+					</span>
 					<ul
 						role="listbox"
 						aria-label="Destination folder"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.579",
+      version: "0.5.580",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Third ratchet PR from #812. Enables `noLabelWithoutControl`.

## What

Four sites flagged. Three wrap the design-system `<Checkbox>` (a Radix control, not a native `<input>`), which Biome doesn't recognize as a form control:

- `onboarding/agreement-page.tsx`
- `onboarding/onboard-tools-page.tsx`
- `settings/account/danger-zone-section-local.tsx`

Rather than churn that (correct) markup, the rule is configured to know about our input component:

```json
"noLabelWithoutControl": { "level": "error", "options": { "inputComponents": ["Checkbox"] } }
```

The fourth site (`viewer/attachment-upload/upload-dialog.tsx`, "Destination folder") was a `<label>` used as a plain heading for a listbox that already carries its own `aria-label`. Changed to a `<span>` so it isn't a control-less label.

## Verification

- `bun run ci` (biome ci) clean
- `tsc --noEmit` clean
- 19 tests across the touched components green

Refs #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)