### PR TITLE
chore(frontend): ratchet a11y noNoninteractiveElementToInteractiveRole

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -70,7 +70,6 @@
 							"level": "error",
 							"options": { "inputComponents": ["Checkbox"] }
 						},
-						"noNoninteractiveElementToInteractiveRole": "off",
 						"useAriaPropsForRole": "off",
 						"useAriaPropsSupportedByRole": "off",
 						"useSemanticElements": "off"

--- a/frontend/src/viewer/attachment-upload/upload-dialog.tsx
+++ b/frontend/src/viewer/attachment-upload/upload-dialog.tsx
@@ -155,7 +155,7 @@ export function AttachmentUploadDialog({ initialFiles, folders, defaultFolder, o
 					<span className="mb-1 block font-medium text-muted-foreground text-xs">
 						Destination folder
 					</span>
-					<ul
+					<div
 						role="listbox"
 						aria-label="Destination folder"
 						tabIndex={0}
@@ -165,7 +165,7 @@ export function AttachmentUploadDialog({ initialFiles, folders, defaultFolder, o
 					>
 						{candidates.map((name, i) => (
 							// biome-ignore lint/a11y/useFocusableInteractive lint/a11y/useKeyWithClickEvents: option in an aria-activedescendant listbox; options are intentionally not individually focusable and keyboard activation is handled on the listbox container above
-							<li
+							<div
 								key={name || "__root__"}
 								id={optionId(i)}
 								role="option"
@@ -174,9 +174,9 @@ export function AttachmentUploadDialog({ initialFiles, folders, defaultFolder, o
 								className={`cursor-pointer px-3 py-1 text-sm ${name === folder ? "bg-blue-50 dark:bg-blue-950" : ""}`}
 							>
 								{name === "" ? "/ (root)" : name}
-							</li>
+							</div>
 						))}
-					</ul>
+					</div>
 				</section>
 			)}
 

--- a/frontend/src/viewer/tree-actions/move-dialog.tsx
+++ b/frontend/src/viewer/tree-actions/move-dialog.tsx
@@ -67,10 +67,10 @@ export function MoveDialog({ folders, nodes, onPick, onCancel }: Props) {
 				placeholder={placeholder}
 				className="w-full border-gray-200 border-b bg-transparent p-3 text-sm outline-none dark:border-gray-700"
 			/>
-			<ul role="listbox" className="max-h-72 overflow-y-auto py-1">
+			<div role="listbox" className="max-h-72 overflow-y-auto py-1">
 				{candidates.map((name, i) => (
 					// biome-ignore lint/a11y/useFocusableInteractive lint/a11y/useKeyWithClickEvents: option in a combobox-controlled listbox; options are intentionally not individually focusable and keyboard activation is handled on the input above
-					<li
+					<div
 						key={name || "__root__"}
 						role="option"
 						aria-selected={i === active}
@@ -80,9 +80,9 @@ export function MoveDialog({ folders, nodes, onPick, onCancel }: Props) {
 						}`}
 					>
 						{name === "" ? "/ (root)" : name}
-					</li>
+					</div>
 				))}
-			</ul>
+			</div>
 		</dialog>
 	);
 }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.580",
+      version: "0.5.581",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fourth ratchet PR from #812. Enables `noNoninteractiveElementToInteractiveRole`, finishing the listbox story from the interactive-element PR (#817).

## What

Converts the two ARIA listboxes from `<ul>`/`<li>` to `<div role="listbox">` / `<div role="option">`:

- `viewer/attachment-upload/upload-dialog.tsx` (destination-folder picker)
- `viewer/tree-actions/move-dialog.tsx` (move-target picker)

Using `<ul>`/`<li>` *with* `role="listbox"`/`"option"` pits each element's implicit list semantics against its ARIA role — exactly what this rule flags. Plain `<div>`s carry the role cleanly. `role="option"`, `aria-selected`, `aria-activedescendant`, and the `onClick`/`onKeyDown` wiring are unchanged, so behavior and the `getByRole("option")` test queries are unaffected.

The `useFocusableInteractive`/`useKeyWithClickEvents` suppressions on the option elements stay — still the correct `aria-activedescendant` pattern.

## Verification

- `bun run ci` (biome ci) clean
- `tsc --noEmit` clean
- 13 tests across move-dialog + upload-dialog green

Refs #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)