### PR TITLE
chore(frontend): ratchet a11y useAriaPropsForRole + useAriaPropsSupportedByRole

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -70,8 +70,6 @@
 							"level": "error",
 							"options": { "inputComponents": ["Checkbox"] }
 						},
-						"useAriaPropsForRole": "off",
-						"useAriaPropsSupportedByRole": "off",
 						"useSemanticElements": "off"
 					},
 					"complexity": {

--- a/frontend/src/auth/local-sign-up.tsx
+++ b/frontend/src/auth/local-sign-up.tsx
@@ -76,6 +76,7 @@ export default function LocalSignUp() {
 		return (
 			<AuthLayout>
 				<div
+					role="status"
 					aria-busy
 					aria-label="Loading"
 					className="h-[420px] w-full max-w-sm rounded-2xl border border-border bg-card shadow-sm sm:p-8"

--- a/frontend/src/viewer/tree-actions/move-dialog.tsx
+++ b/frontend/src/viewer/tree-actions/move-dialog.tsx
@@ -44,6 +44,8 @@ export function MoveDialog({ folders, nodes, onPick, onCancel }: Props) {
 			)}
 			<input
 				role="combobox"
+				aria-expanded={candidates.length > 0}
+				aria-controls="move-dialog-listbox"
 				autoFocus
 				value={query}
 				onChange={(e) => {
@@ -67,7 +69,7 @@ export function MoveDialog({ folders, nodes, onPick, onCancel }: Props) {
 				placeholder={placeholder}
 				className="w-full border-gray-200 border-b bg-transparent p-3 text-sm outline-none dark:border-gray-700"
 			/>
-			<div role="listbox" className="max-h-72 overflow-y-auto py-1">
+			<div id="move-dialog-listbox" role="listbox" className="max-h-72 overflow-y-auto py-1">
 				{candidates.map((name, i) => (
 					// biome-ignore lint/a11y/useFocusableInteractive lint/a11y/useKeyWithClickEvents: option in a combobox-controlled listbox; options are intentionally not individually focusable and keyboard activation is handled on the input above
 					<div

--- a/frontend/src/viewer/tree/tree-row.test.tsx
+++ b/frontend/src/viewer/tree/tree-row.test.tsx
@@ -99,7 +99,7 @@ describe("TreeRow", () => {
 				<TreeRow instance={instance} />
 			</MemoryRouter>,
 		);
-		expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+		expect(screen.getByRole("treeitem")).toHaveAttribute("aria-expanded", "true");
 	});
 
 	it("renders note as link to /note/:id", () => {
@@ -163,7 +163,7 @@ describe("TreeRow", () => {
 				<TreeRow instance={instance} />
 			</MemoryRouter>,
 		);
-		expect(screen.getByRole("button")).toHaveAttribute("aria-selected", "true");
+		expect(screen.getByRole("treeitem")).toHaveAttribute("aria-selected", "true");
 	});
 
 	it("indents by depth × 12px via getItemMeta().level", () => {
@@ -173,7 +173,7 @@ describe("TreeRow", () => {
 				<TreeRow instance={instance} />
 			</MemoryRouter>,
 		);
-		const btn = screen.getByRole("button");
+		const btn = screen.getByRole("treeitem");
 		expect(btn.style.paddingLeft).toBe("28px"); // 2 * 12 + 4
 	});
 
@@ -185,7 +185,7 @@ describe("TreeRow", () => {
 				<TreeRow instance={instance} onContextMenu={onContextMenu} />
 			</MemoryRouter>,
 		);
-		fireEvent.contextMenu(screen.getByRole("button"), { clientX: 42, clientY: 99 });
+		fireEvent.contextMenu(screen.getByRole("treeitem"), { clientX: 42, clientY: 99 });
 		expect(onContextMenu).toHaveBeenCalledWith("f:1", 42, 99);
 	});
 
@@ -204,7 +204,7 @@ describe("TreeRow", () => {
 				<TreeRow instance={instance} onContextMenu={onContextMenu} />
 			</MemoryRouter>,
 		);
-		fireEvent.contextMenu(screen.getByRole("button"), { clientX: 42, clientY: 99 });
+		fireEvent.contextMenu(screen.getByRole("treeitem"), { clientX: 42, clientY: 99 });
 		expect(onContextMenu).not.toHaveBeenCalled();
 	});
 
@@ -282,7 +282,7 @@ describe("TreeRow", () => {
 				<TreeRow instance={instance} />
 			</MemoryRouter>,
 		);
-		const btn = screen.getByRole("button");
+		const btn = screen.getByRole("treeitem");
 		expect(btn).toHaveAttribute("data-ht", "yes");
 		expect(btn).toHaveAttribute("tabindex", "-1");
 	});

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -76,6 +76,9 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
 				type="button"
 				{...instance.getProps()}
 				{...(isSynthetic ? {} : longPressProps)}
+				// getProps() spreads role="treeitem" from @headless-tree; declare it
+				// explicitly so the linter sees the role that supports aria-expanded/selected
+				role="treeitem"
 				onContextMenu={isSynthetic ? undefined : contextMenuHandler}
 				onPointerEnter={hoverPrefetch}
 				onFocus={hoverPrefetch}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.581",
+      version: "0.5.582",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fifth ratchet PR from #812. Enables the aria-props pair: `useAriaPropsForRole` and `useAriaPropsSupportedByRole`.

## Fixes

- **move-dialog combobox** — `role="combobox"` requires `aria-expanded`. Added it plus `aria-controls` wiring to the listbox (which now carries an `id`). Proper combobox contract.
- **local-sign-up loading skeleton** — a bare `<div aria-busy aria-label>` gave a generic element aria props it doesn't support. Added `role="status"` (a loading live region), which supports both.
- **tree-row folder button** — `aria-selected`/`aria-expanded` were flagged because `role="treeitem"` arrives via the `@headless-tree` `getProps()` spread, invisible to the linter. Declared `role="treeitem"` explicitly so the linter sees the role that supports those props. No runtime change (`getProps()` already sets it — confirmed in `@headless-tree/core`).

## Test correction

The `tree-row` test mock returns `{}` for `getProps()`, so 6 folder-row tests were asserting a `button` role that production never renders (the real element is a `treeitem`). Updated those queries to `getByRole("treeitem")` to match what the app actually renders. Assertions unchanged.

## Verification

- `bun run ci` (biome ci) clean
- `tsc --noEmit` clean
- 100 tests green across the touched files + the full tree/folder suites

Refs #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)