### PR TITLE
chore(frontend): ratchet a11y useSemanticElements

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -68,8 +68,7 @@
 						"noLabelWithoutControl": {
 							"level": "error",
 							"options": { "inputComponents": ["Checkbox"] }
-						},
-						"useSemanticElements": "off"
+						}
 					},
 					"complexity": {
 						"noExcessiveLinesPerFunction": "off",

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -84,32 +84,40 @@ export function CadenceToggle({
 	return (
 		<div role="radiogroup" aria-label="Billing cadence" className="flex justify-center">
 			<div className="inline-flex rounded-full border border-border bg-muted p-1 text-sm">
-				<button
-					type="button"
-					role="radio"
-					aria-checked={cadence === "monthly"}
-					onClick={() => onChange("monthly")}
+				<label
 					className={cn(
-						"inline-flex items-center justify-center rounded-full px-4 py-1.5 font-medium leading-none transition",
+						"inline-flex cursor-pointer items-center justify-center rounded-full px-4 py-1.5 font-medium leading-none transition focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1",
 						cadence === "monthly"
 							? "bg-primary text-primary-foreground"
 							: "text-muted-foreground hover:text-foreground",
 					)}
 				>
+					<input
+						type="radio"
+						name="billing-cadence"
+						value="monthly"
+						checked={cadence === "monthly"}
+						onChange={() => onChange("monthly")}
+						className="sr-only"
+					/>
 					Monthly
-				</button>
-				<button
-					type="button"
-					role="radio"
-					aria-checked={cadence === "annual"}
-					onClick={() => onChange("annual")}
+				</label>
+				<label
 					className={cn(
-						"inline-flex items-center justify-center rounded-full px-4 py-1.5 font-medium leading-none transition",
+						"inline-flex cursor-pointer items-center justify-center rounded-full px-4 py-1.5 font-medium leading-none transition focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1",
 						cadence === "annual"
 							? "bg-primary text-primary-foreground"
 							: "text-muted-foreground hover:text-foreground",
 					)}
 				>
+					<input
+						type="radio"
+						name="billing-cadence"
+						value="annual"
+						checked={cadence === "annual"}
+						onChange={() => onChange("annual")}
+						className="sr-only"
+					/>
 					Annual{" "}
 					<span
 						className={cn(
@@ -119,7 +127,7 @@ export function CadenceToggle({
 					>
 						save 17%
 					</span>
-				</button>
+				</label>
 			</div>
 		</div>
 	);

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.583",
+      version: "0.5.584",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Seventh and **final** a11y ratchet PR from #812. Enables `useSemanticElements`.

## What

The billing cadence toggle rendered its Monthly/Annual options as `<button role="radio">` inside a `role="radiogroup"`. Rebuilt them as native `<input type="radio">` controls wrapped in styled `<label>`s:

- Inputs are visually hidden (`sr-only`); the label carries the pill styling driven by the `checked`/`cadence` state.
- `focus-within:ring-*` on each label restores a visible keyboard focus indicator.
- Native radios bring real arrow-key group navigation and checked semantics for free.

The `role="radiogroup"` container is unchanged (the rule only flagged the `role="radio"` buttons, not the group).

## Ratchet complete

With this, **every a11y rule deferred in #812 is enabled** — no a11y rules remain in the override. Summary of the 7 PRs: #816, #817, #819, #820, #821, #822, and this one.

## Verification

- `bun run ci` (biome ci) clean
- `tsc --noEmit` clean
- 64 billing tests green

Refs #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)