### PR TITLE
chore(frontend): ratchet suspicious noLeakedRender

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -143,7 +143,6 @@
 					},
 					"suspicious": {
 						"noReactSpecificProps": "off",
-						"noLeakedRender": "off",
 						"noAlert": "off",
 						"noConsole": { "level": "error", "options": { "allow": ["error", "warn"] } },
 						"noEmptyBlockStatements": "off",

--- a/frontend/src/auth/local-sign-in.tsx
+++ b/frontend/src/auth/local-sign-in.tsx
@@ -75,7 +75,7 @@ export default function LocalSignIn() {
 					<h1 className={heading}>Sign in to Engram</h1>
 				</div>
 
-				{error && (
+				{Boolean(error) && (
 					<p role="alert" className={cn(destructiveAlert, "p-3 text-foreground")}>
 						{error}
 					</p>

--- a/frontend/src/auth/local-sign-up.tsx
+++ b/frontend/src/auth/local-sign-up.tsx
@@ -138,7 +138,7 @@ export default function LocalSignUp() {
 					</h1>
 				</div>
 
-				{bootstrap?.bootstrap_pending && (
+				{Boolean(bootstrap?.bootstrap_pending) && (
 					<>
 						<aside
 							className="rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-foreground text-sm"
@@ -178,9 +178,8 @@ export default function LocalSignUp() {
 					</>
 				)}
 
-				{invite &&
-					invitePreview &&
-					(invitePreview.valid ? (
+				{invite && invitePreview ? (
+					invitePreview.valid ? (
 						<p className="rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-foreground text-sm">
 							You've been invited{invitePreview.label ? ` (${invitePreview.label})` : ""} — finish
 							below to join.
@@ -192,9 +191,10 @@ export default function LocalSignUp() {
 						>
 							This invite link is invalid, expired, or already used.
 						</p>
-					))}
+					)
+				) : null}
 
-				{error && (
+				{Boolean(error) && (
 					<p role="alert" className={cn(destructiveAlert, "p-3 text-foreground")}>
 						{error}
 					</p>

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -578,7 +578,7 @@ export default function BillingPage({
 									open={openTier === "starter"}
 									onOpen={() => setOpenTier("starter")}
 								/>
-								{freeOption && (
+								{freeOption ? (
 									<PlanAccordionRow
 										name={FREE_TIER.name}
 										price={FREE_TIER.price}
@@ -591,7 +591,7 @@ export default function BillingPage({
 										open={openTier === "free"}
 										onOpen={() => setOpenTier("free")}
 									/>
-								)}
+								) : null}
 							</ul>
 						</>
 					)}
@@ -622,7 +622,7 @@ export default function BillingPage({
 							onClick={() => openPortal()}
 							disabled={portalLoading}
 						>
-							{portalLoading && <Loader2 aria-hidden className="size-4 animate-spin" />}
+							{Boolean(portalLoading) && <Loader2 aria-hidden className="size-4 animate-spin" />}
 							{portalLoading ? "Opening Paddle…" : "Open Paddle billing portal"}
 						</Button>
 						<p className="text-muted-foreground text-xs">

--- a/frontend/src/billing/cancel-panel.tsx
+++ b/frontend/src/billing/cancel-panel.tsx
@@ -63,7 +63,7 @@ export default function CancelPanel({ detail, tier, onClose }: CancelPanelProps)
 			</ul>
 			<div className="flex gap-2">
 				<Button variant="destructive" onClick={confirm} disabled={cancel.isPending}>
-					{cancel.isPending && <Loader2 aria-hidden className="size-4 animate-spin" />}
+					{Boolean(cancel.isPending) && <Loader2 aria-hidden className="size-4 animate-spin" />}
 					{cancel.isPending ? "Canceling…" : "Cancel at period end"}
 				</Button>
 				<Button variant="ghost" onClick={onClose} disabled={cancel.isPending}>

--- a/frontend/src/billing/current-plan-card.tsx
+++ b/frontend/src/billing/current-plan-card.tsx
@@ -55,20 +55,20 @@ export default function CurrentPlanCard({
 				</p>
 			)}
 
-			{sub && (
+			{sub ? (
 				<dl className="grid grid-cols-2 gap-4 text-sm">
 					<dt className="text-muted-foreground">Status</dt>
 					<dd className="font-medium capitalize">{sub.status.replace("_", " ")}</dd>
-					{periodEnd && (
+					{Boolean(periodEnd) && (
 						<>
 							<dt className="text-muted-foreground">{periodLabel}</dt>
 							<dd className="font-medium">{periodEnd}</dd>
 						</>
 					)}
 				</dl>
-			)}
+			) : null}
 
-			{children && <div className="border-border border-t pt-4">{children}</div>}
+			{Boolean(children) && <div className="border-border border-t pt-4">{children}</div>}
 		</section>
 	);
 }

--- a/frontend/src/billing/payment-method-card.tsx
+++ b/frontend/src/billing/payment-method-card.tsx
@@ -25,7 +25,7 @@ export default function PaymentMethodCard({
 			<header className="flex items-center justify-between">
 				<h2 className="font-semibold text-foreground text-lg">Payment method</h2>
 				<Button variant="outline" size="sm" onClick={onUpdate} disabled={updating}>
-					{updating && <Loader2 aria-hidden className="size-3 animate-spin" />}
+					{Boolean(updating) && <Loader2 aria-hidden className="size-3 animate-spin" />}
 					{updating ? "Opening…" : "Update"}
 				</Button>
 			</header>

--- a/frontend/src/billing/pending-change-banner.tsx
+++ b/frontend/src/billing/pending-change-banner.tsx
@@ -52,7 +52,9 @@ function ReverseCancelButton() {
 
 	return (
 		<Button size="sm" onClick={onReverse} disabled={reverseCancel.isPending}>
-			{reverseCancel.isPending && <Loader2 aria-hidden className="size-3.5 animate-spin" />}
+			{Boolean(reverseCancel.isPending) && (
+				<Loader2 aria-hidden className="size-3.5 animate-spin" />
+			)}
 			{reverseCancel.isPending ? "Reversing…" : "Keep my subscription"}
 		</Button>
 	);

--- a/frontend/src/billing/plan-cards.tsx
+++ b/frontend/src/billing/plan-cards.tsx
@@ -201,7 +201,7 @@ export function PlanCard({
 				state === "current" && "border-primary/60 shadow-sm ring-1 ring-primary/30",
 			)}
 		>
-			{badgeText && (
+			{Boolean(badgeText) && (
 				<span className="absolute -top-3 left-6 rounded-full bg-primary px-2.5 py-0.5 font-semibold text-primary-foreground text-xs uppercase tracking-wide">
 					{badgeText}
 				</span>
@@ -239,7 +239,7 @@ export function PlanCard({
 						>
 							{ctaLabel}
 						</button>
-						{selected && ctaSubLabel && (
+						{Boolean(selected && ctaSubLabel) && (
 							<p className="text-center text-muted-foreground text-xs">{ctaSubLabel}</p>
 						)}
 					</>
@@ -300,7 +300,7 @@ export function PlanAccordionRow({
 				<span className="flex min-w-0 flex-col gap-1">
 					<span className="flex flex-wrap items-center gap-x-2 font-semibold text-foreground text-sm">
 						<span>{name}</span>
-						{recommended && (
+						{Boolean(recommended) && (
 							<span className="inline-flex items-center rounded-full bg-primary px-2 pt-[4px] pb-[2px] font-semibold text-[10px] text-primary-foreground uppercase leading-none tracking-wide">
 								Popular
 							</span>
@@ -344,7 +344,7 @@ export function PlanAccordionRow({
 						>
 							{ctaLabel}
 						</button>
-						{ctaNote && (
+						{Boolean(ctaNote) && (
 							<p className="mt-1.5 text-center text-muted-foreground text-xs">{ctaNote}</p>
 						)}
 					</div>

--- a/frontend/src/billing/plan-change-panel.tsx
+++ b/frontend/src/billing/plan-change-panel.tsx
@@ -174,7 +174,7 @@ function PlanChangePicker({ billing, onClose }: { billing: BillingStatus; onClos
 					onClick={onConfirm}
 					disabled={!(selectedTier && targetPriceId) || preview.isFetching || confirm.isPending}
 				>
-					{confirm.isPending && <Loader2 aria-hidden className="size-4 animate-spin" />}
+					{Boolean(confirm.isPending) && <Loader2 aria-hidden className="size-4 animate-spin" />}
 					{confirm.isPending ? "Applying…" : "Confirm change"}
 				</Button>
 				<Button variant="ghost" onClick={onClose} disabled={confirm.isPending}>

--- a/frontend/src/billing/upgrade-dialog-provider.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.tsx
@@ -26,7 +26,7 @@ export function UpgradeDialogProvider({ children }: { children: ReactNode }) {
 	return (
 		<UpgradeCtx.Provider value={{ showUpgrade }}>
 			{children}
-			{reason && (
+			{reason ? (
 				<UpgradeRequiredDialog
 					reason={reason}
 					open={true}
@@ -36,7 +36,7 @@ export function UpgradeDialogProvider({ children }: { children: ReactNode }) {
 						}
 					}}
 				/>
-			)}
+			) : null}
 		</UpgradeCtx.Provider>
 	);
 }

--- a/frontend/src/components/checkout-summary.tsx
+++ b/frontend/src/components/checkout-summary.tsx
@@ -65,7 +65,7 @@ export function CheckoutSummary({
 						>
 							<div className="min-w-0 flex-1">
 								<span className="font-medium">{item.name}</span>
-								{item.priceName && (
+								{Boolean(item.priceName) && (
 									<span className="text-muted-foreground"> — {item.priceName}</span>
 								)}
 								{item.quantity > 1 && (
@@ -105,14 +105,14 @@ export function CheckoutSummary({
 					</div>
 				</dl>
 
-				{(recurringInfo || trialPeriod) && (
+				{Boolean(recurringInfo || trialPeriod) && (
 					<p className="text-muted-foreground text-xs">
-						{trialPeriod && <span>{trialPeriod} free trial. </span>}
-						{recurringInfo && <span>Then {recurringInfo}.</span>}
+						{Boolean(trialPeriod) && <span>{trialPeriod} free trial. </span>}
+						{Boolean(recurringInfo) && <span>Then {recurringInfo}.</span>}
 					</p>
 				)}
 
-				{policyUrl && (
+				{Boolean(policyUrl) && (
 					<a
 						href={policyUrl}
 						target="_blank"

--- a/frontend/src/components/inline-checkout.tsx
+++ b/frontend/src/components/inline-checkout.tsx
@@ -227,7 +227,7 @@ export function InlineCheckout({
 				className,
 			)}
 		>
-			{summaryFirst && (
+			{Boolean(summaryFirst) && (
 				<div className={cn("w-full", isHorizontal && "lg:w-72 lg:shrink-0")}>
 					<CheckoutSummary summary={summaryData} policyUrl={policyUrl} policyLabel={policyLabel} />
 				</div>

--- a/frontend/src/components/plan-change-breakdown.tsx
+++ b/frontend/src/components/plan-change-breakdown.tsx
@@ -57,7 +57,7 @@ function TransactionSection({
 		<div className="flex flex-col gap-3">
 			<div>
 				<h4 className="font-medium text-sm">{title}</h4>
-				{description && <p className="text-muted-foreground text-xs">{description}</p>}
+				{Boolean(description) && <p className="text-muted-foreground text-xs">{description}</p>}
 			</div>
 
 			<div className="flex flex-col gap-2">
@@ -71,13 +71,13 @@ function TransactionSection({
 							<span className="text-muted-foreground text-xs">
 								{item.quantity > 1 && `${item.quantity} \u00d7 `}
 								{formatMoney(item.unitPrice, currency)}
-								{item.isProrated && (
+								{Boolean(item.isProrated) && (
 									<Badge variant="secondary" className="ml-1 px-1 py-0 text-[10px]">
 										Prorated
 									</Badge>
 								)}
 							</span>
-							{item.prorationPeriod && (
+							{Boolean(item.prorationPeriod) && (
 								<span className="text-muted-foreground text-xs">{item.prorationPeriod}</span>
 							)}
 						</div>
@@ -213,7 +213,7 @@ export function PlanChangeBreakdown({
 						</div>
 					)}
 
-				{immediateTransaction && (
+				{immediateTransaction ? (
 					<>
 						<Separator />
 						<TransactionSection
@@ -223,9 +223,9 @@ export function PlanChangeBreakdown({
 							currency={currency}
 						/>
 					</>
-				)}
+				) : null}
 
-				{nextTransaction && (
+				{nextTransaction ? (
 					<>
 						<Separator />
 						<TransactionSection
@@ -235,9 +235,9 @@ export function PlanChangeBreakdown({
 							currency={currency}
 						/>
 					</>
-				)}
+				) : null}
 
-				{recurringTransaction && (
+				{recurringTransaction ? (
 					<>
 						<Separator />
 						<TransactionSection
@@ -247,7 +247,7 @@ export function PlanChangeBreakdown({
 							currency={currency}
 						/>
 					</>
-				)}
+				) : null}
 			</CardContent>
 		</Card>
 	);

--- a/frontend/src/components/plan-change-preview.tsx
+++ b/frontend/src/components/plan-change-preview.tsx
@@ -176,7 +176,7 @@ export function PlanChangePreview({
 						</Badge>
 					</div>
 
-					{prorationLabel && (
+					{Boolean(prorationLabel) && (
 						<div className="flex items-center justify-between text-sm">
 							<span className="text-muted-foreground">Billing</span>
 							<span className="text-right">{prorationLabel}</span>
@@ -190,19 +190,19 @@ export function PlanChangePreview({
 						</div>
 					)}
 
-					{discount && (
+					{discount ? (
 						<div className="flex items-center justify-between text-sm">
 							<span className="text-muted-foreground">Discount</span>
 							<span className="text-right">
 								<span className="text-success-foreground">{discount.description}</span>
-								{discount.endsAt && (
+								{discount.endsAt ? (
 									<span className="block text-muted-foreground text-xs">
 										until {formatDate(discount.endsAt)}
 									</span>
-								)}
+								) : null}
 							</span>
 						</div>
-					)}
+					) : null}
 				</div>
 
 				<Separator />
@@ -258,12 +258,12 @@ export function PlanChangePreview({
 				)}
 
 				{/* Contextual notes derived from subscription state */}
-				{isTrialing && isNeutral && (
+				{Boolean(isTrialing && isNeutral) && (
 					<p className="text-muted-foreground text-xs">
 						No charges during your trial. Billing begins when your trial ends.
 					</p>
 				)}
-				{isManual && isCharge && (
+				{Boolean(isManual && isCharge) && (
 					<p className="text-muted-foreground text-xs">
 						An invoice will be created for this amount.
 					</p>

--- a/frontend/src/components/pricing-select-card-grid.tsx
+++ b/frontend/src/components/pricing-select-card-grid.tsx
@@ -57,7 +57,7 @@ export function PricingSelectCardGrid({
 					className,
 				)}
 			>
-				{showBadges && (
+				{Boolean(showBadges) && (
 					<div
 						className={cn(
 							"absolute -top-3 z-10 flex gap-1.5",
@@ -66,22 +66,26 @@ export function PricingSelectCardGrid({
 							badgePosition === "right" && "right-4",
 						)}
 					>
-						{badge && <Badge className="bg-primary text-primary-foreground">{badge}</Badge>}
-						{isCurrent && <Badge variant="secondary">{currentPlanLabel}</Badge>}
+						{Boolean(badge) && (
+							<Badge className="bg-primary text-primary-foreground">{badge}</Badge>
+						)}
+						{Boolean(isCurrent) && <Badge variant="secondary">{currentPlanLabel}</Badge>}
 					</div>
 				)}
 
 				<CardHeader className="flex flex-1 flex-col items-center justify-center p-0 text-center">
 					<CardTitle className="font-medium text-base">{name}</CardTitle>
-					{description && <div className="mt-0.5 text-muted-foreground text-xs">{description}</div>}
-					{originalTotal && (
+					{Boolean(description) && (
+						<div className="mt-0.5 text-muted-foreground text-xs">{description}</div>
+					)}
+					{Boolean(originalTotal) && (
 						<div className="mt-2 text-muted-foreground text-sm line-through">{originalTotal}</div>
 					)}
 					<div className="mt-2 font-bold text-2xl">{total}</div>
-					{showInterval && interval && (
+					{Boolean(showInterval && interval) && (
 						<div className="text-muted-foreground text-xs">per {interval}</div>
 					)}
-					{trialPeriod && (
+					{Boolean(trialPeriod) && (
 						<div className="mt-1 text-muted-foreground text-xs">{trialPeriod} free trial</div>
 					)}
 				</CardHeader>

--- a/frontend/src/components/pricing-select-card-stacked.tsx
+++ b/frontend/src/components/pricing-select-card-stacked.tsx
@@ -47,7 +47,7 @@ export function PricingSelectCardStacked({
 				<Skeleton className="mb-2 h-4 w-24" />
 				<Skeleton className="mb-1 h-8 w-32" />
 				<Skeleton className="h-3 w-16" />
-				{icon && <Skeleton className="absolute top-6 right-6 h-12 w-12 rounded-lg" />}
+				{Boolean(icon) && <Skeleton className="absolute top-6 right-6 h-12 w-12 rounded-lg" />}
 			</Card>
 		);
 	}
@@ -62,7 +62,7 @@ export function PricingSelectCardStacked({
 					className,
 				)}
 			>
-				{showBadges && (
+				{Boolean(showBadges) && (
 					<div
 						className={cn(
 							"absolute -top-3 z-10 flex gap-1.5",
@@ -71,27 +71,29 @@ export function PricingSelectCardStacked({
 							badgePosition === "right" && "right-4",
 						)}
 					>
-						{badge && <Badge className="bg-primary text-primary-foreground">{badge}</Badge>}
-						{isCurrent && <Badge variant="secondary">{currentPlanLabel}</Badge>}
+						{Boolean(badge) && (
+							<Badge className="bg-primary text-primary-foreground">{badge}</Badge>
+						)}
+						{Boolean(isCurrent) && <Badge variant="secondary">{currentPlanLabel}</Badge>}
 					</div>
 				)}
 
 				<div className="flex items-start justify-between">
 					<CardHeader className="p-0">
 						<div className="mb-1 text-muted-foreground text-sm">{description || name}</div>
-						{originalTotal && (
+						{Boolean(originalTotal) && (
 							<div className="text-muted-foreground text-sm line-through">{originalTotal}</div>
 						)}
 						<CardTitle className="font-bold text-3xl">{total}</CardTitle>
-						{showInterval && interval && (
+						{Boolean(showInterval && interval) && (
 							<div className="text-muted-foreground text-sm">per {interval}</div>
 						)}
-						{trialPeriod && (
+						{Boolean(trialPeriod) && (
 							<div className="mt-1 text-muted-foreground text-xs">{trialPeriod} free trial</div>
 						)}
 					</CardHeader>
 
-					{icon && <div className="h-12 w-12 shrink-0 rounded-lg">{icon}</div>}
+					{Boolean(icon) && <div className="h-12 w-12 shrink-0 rounded-lg">{icon}</div>}
 				</div>
 			</Card>
 		</RadioGroupPrimitive.Item>

--- a/frontend/src/components/subscription-alert.tsx
+++ b/frontend/src/components/subscription-alert.tsx
@@ -44,7 +44,7 @@ export function SubscriptionAlert({ subscription, onDismiss, className }: Subscr
 			<AlertDescription className="flex items-center justify-between gap-4 text-inherit">
 				<span>
 					{alert.message}
-					{alert.actionUrl && alert.actionLabel && (
+					{Boolean(alert.actionUrl && alert.actionLabel) && (
 						<>
 							{" "}
 							<a
@@ -58,7 +58,7 @@ export function SubscriptionAlert({ subscription, onDismiss, className }: Subscr
 						</>
 					)}
 				</span>
-				{onDismiss && (
+				{Boolean(onDismiss) && (
 					<button
 						type="button"
 						onClick={onDismiss}

--- a/frontend/src/components/subscription-payment-card.tsx
+++ b/frontend/src/components/subscription-payment-card.tsx
@@ -79,16 +79,18 @@ export function SubscriptionPaymentCard({
 					)}
 				</PaymentInfoRow>
 
-				{displayLabel && (
+				{Boolean(displayLabel) && (
 					<>
 						<Separator />
 						<div className="flex items-center justify-between gap-4">
 							<PaymentInfoRow icon={PaymentMethodIcon} label="Payment method">
 								<div className="truncate font-medium text-sm">{displayLabel}</div>
-								{expiryLabel && <div className="text-muted-foreground text-xs">{expiryLabel}</div>}
+								{Boolean(expiryLabel) && (
+									<div className="text-muted-foreground text-xs">{expiryLabel}</div>
+								)}
 							</PaymentInfoRow>
 
-							{updatePaymentMethodUrl && (
+							{Boolean(updatePaymentMethodUrl) && (
 								<a
 									href={updatePaymentMethodUrl}
 									target="_blank"

--- a/frontend/src/components/subscription-status-card.tsx
+++ b/frontend/src/components/subscription-status-card.tsx
@@ -244,19 +244,19 @@ export function SubscriptionStatusCard({
 							<CardTitle className="truncate">{cardTitle}</CardTitle>
 							{statusBadgePosition === "inline" && <StatusBadge status={status} />}
 						</div>
-						{isSingleItem && primaryItem?.priceName && (
+						{isSingleItem && primaryItem?.priceName ? (
 							<CardDescription>{primaryItem.priceName}</CardDescription>
-						)}
+						) : null}
 					</div>
 					<div className="flex shrink-0 items-center gap-2">
 						{statusBadgePosition === "end" && <StatusBadge status={status} />}
-						{isSingleItem && primaryItem?.productImageUrl && (
+						{isSingleItem && primaryItem?.productImageUrl ? (
 							<img
 								src={primaryItem.productImageUrl}
 								alt={primaryItem.productName}
 								className="size-12 rounded-md object-cover"
 							/>
-						)}
+						) : null}
 					</div>
 				</div>
 			</CardHeader>
@@ -276,7 +276,7 @@ export function SubscriptionStatusCard({
 					</Alert>
 				)}
 
-				{scheduledChangeNote && (
+				{Boolean(scheduledChangeNote) && (
 					<Alert>
 						<Clock className="size-4" />
 						<AlertTitle>Scheduled change</AlertTitle>
@@ -320,26 +320,26 @@ export function SubscriptionStatusCard({
 				<Separator />
 
 				<div className="space-y-1.5">
-					{discount && (
+					{discount ? (
 						<div className="flex items-center justify-between text-success-foreground">
 							<span className="flex items-center gap-1.5 text-sm">
 								Discount
-								{discount.code && (
+								{Boolean(discount.code) && (
 									<span className="rounded bg-success/10 px-1.5 py-0.5 text-xs">
 										{discount.code}
 									</span>
 								)}
-								{discount.endsAt && (
+								{discount.endsAt ? (
 									<span className="text-muted-foreground text-xs">
 										until {formatDate(discount.endsAt)}
 									</span>
-								)}
+								) : null}
 							</span>
 							<span className="text-sm tabular-nums">
 								{discount.description ?? `\u2212${formatMoney(discount.savingsAmount, currency)}`}
 							</span>
 						</div>
-					)}
+					) : null}
 
 					<div className="flex items-center justify-between font-medium">
 						<span className="text-sm">Total</span>
@@ -353,14 +353,14 @@ export function SubscriptionStatusCard({
 				<Separator />
 
 				<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-muted-foreground text-sm">
-					{nextBilledAt && nextBillingLabel && (
+					{nextBilledAt && nextBillingLabel ? (
 						<div className="flex items-center gap-1.5">
 							<CalendarIcon className="size-3.5" />
 							<span>
 								{nextBillingLabel} {formatDate(nextBilledAt)}
 							</span>
 						</div>
-					)}
+					) : null}
 					{collectionMode && !effectiveScheduledChange && status !== "past_due" && (
 						<div className="flex items-center gap-1.5">
 							{collectionMode === "automatic" ? (
@@ -376,21 +376,21 @@ export function SubscriptionStatusCard({
 							)}
 						</div>
 					)}
-					{canceledAt && (
+					{canceledAt ? (
 						<div className="flex items-center gap-1.5">
 							<span>Canceled {formatDate(canceledAt)}</span>
 						</div>
-					)}
+					) : null}
 				</div>
 
-				{hasActions && (
+				{Boolean(hasActions) && (
 					<div className="flex flex-wrap gap-2 pt-1">
-						{showChangePlan && (
+						{Boolean(showChangePlan) && (
 							<Button onClick={onChangePlan} size="sm">
 								Change plan
 							</Button>
 						)}
-						{showUpdatePayment && (
+						{Boolean(showUpdatePayment) && (
 							<Button
 								variant={isPastDue ? "default" : "outline"}
 								size="sm"

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -54,7 +54,7 @@ function DialogContent({
 				{...props}
 			>
 				{children}
-				{showCloseButton && (
+				{Boolean(showCloseButton) && (
 					<DialogPrimitive.Close data-slot="dialog-close" asChild>
 						<Button variant="ghost" className="absolute top-3 right-3" size="icon-sm">
 							<XIcon />

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -59,7 +59,7 @@ function SheetContent({
 				{...props}
 			>
 				{children}
-				{showCloseButton && (
+				{Boolean(showCloseButton) && (
 					<SheetPrimitive.Close data-slot="sheet-close" asChild>
 						<Button variant="ghost" className="absolute top-3 right-3" size="icon-sm">
 							<XIcon />

--- a/frontend/src/components/vault-create-form.tsx
+++ b/frontend/src/components/vault-create-form.tsx
@@ -68,9 +68,9 @@ export function VaultCreateForm({
 			</label>
 			<div className="mt-3 flex gap-2">
 				<Button type="submit" size="sm" disabled={create.isPending || !name.trim()}>
-					{create.isPending ? "Creating…" : submitLabel}
+					{create.isPending ? "Creating…" : `${submitLabel}`}
 				</Button>
-				{showCancel && (
+				{Boolean(showCancel) && (
 					<Button type="button" variant="ghost" size="sm" onClick={onCancel}>
 						Cancel
 					</Button>

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -296,7 +296,7 @@ export default function DeviceLinkPage() {
 							onCustomChange={setCustomName}
 							atVaultCap={atVaultCap}
 						/>
-						{atVaultCap && (
+						{Boolean(atVaultCap) && (
 							<p className="text-muted-foreground text-xs">
 								Your Free plan includes 1 vault — link into the existing one above, or{" "}
 								<a
@@ -328,7 +328,7 @@ export default function DeviceLinkPage() {
 					<SuccessStep linkedVaultId={linkedVaultId} onForward={() => navigate("/")} />
 				)}
 
-				{error && (
+				{Boolean(error) && (
 					<p role="alert" className={cn(destructiveAlert, "p-3 text-foreground")}>
 						{error}
 					</p>

--- a/frontend/src/features/admin/AdminPanel.tsx
+++ b/frontend/src/features/admin/AdminPanel.tsx
@@ -58,7 +58,7 @@ export default function AdminPanel() {
 					Members
 				</h2>
 
-				{resetUrl && (
+				{Boolean(resetUrl) && (
 					<aside
 						className="rounded-lg border border-primary/40 bg-primary/5 p-4 text-sm"
 						role="status"

--- a/frontend/src/features/admin/InvitesTab.tsx
+++ b/frontend/src/features/admin/InvitesTab.tsx
@@ -112,7 +112,7 @@ export default function InvitesTab() {
 				</button>
 			</form>
 
-			{lastUrl && (
+			{lastUrl ? (
 				<aside
 					className="rounded-md border border-primary/40 bg-primary/5 p-3 text-sm"
 					role="status"
@@ -140,7 +140,7 @@ export default function InvitesTab() {
 						</button>
 					</div>
 				</aside>
-			)}
+			) : null}
 
 			{loading ? (
 				<p className="text-muted-foreground text-sm">Loading invites…</p>

--- a/frontend/src/features/admin/MembersTab.tsx
+++ b/frontend/src/features/admin/MembersTab.tsx
@@ -39,7 +39,7 @@ function ActionButton({
 					: "border-border bg-background hover:bg-accent disabled:hover:bg-background",
 			)}
 		>
-			{busy && <Loader2 aria-hidden className="size-3 animate-spin" />}
+			{Boolean(busy) && <Loader2 aria-hidden className="size-3 animate-spin" />}
 			{children}
 		</button>
 	);

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -82,7 +82,7 @@ export default function ResetPasswordPage() {
 							</p>
 						</div>
 
-						{error && (
+						{Boolean(error) && (
 							<p role="alert" className={cn(destructiveAlert, "p-3 text-foreground")}>
 								{error}
 							</p>

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -82,7 +82,7 @@ function DesktopLayout() {
 							className="grid-overlay pointer-events-none absolute inset-0 z-0 opacity-30"
 						/>
 						<TrialBanner />
-						{hasRight && rightCollapsed && (
+						{Boolean(hasRight && rightCollapsed) && (
 							<Button
 								variant="ghost"
 								size="icon-sm"

--- a/frontend/src/layout/mobile-layout.tsx
+++ b/frontend/src/layout/mobile-layout.tsx
@@ -84,7 +84,7 @@ export default function MobileLayout() {
 				</section>
 				<nav className="flex items-center gap-1" aria-label="Main navigation">
 					<UserMenu />
-					{rightContent && (
+					{Boolean(rightContent) && (
 						<Sheet open={rightOpen} onOpenChange={setRightOpen}>
 							<SheetTrigger asChild>
 								<Button variant="ghost" size="icon" aria-label="Open outline" className="h-11 w-11">

--- a/frontend/src/layout/search-panel.tsx
+++ b/frontend/src/layout/search-panel.tsx
@@ -72,12 +72,12 @@ export default function SearchPanel() {
 				{!deferred && recent.length > 0 && (
 					<RecentList recent={recent} onPick={(q) => setInput(q)} />
 				)}
-				{deferred && isLoading && (
+				{Boolean(deferred && isLoading) && (
 					<p className="px-3 py-2 text-muted-foreground text-xs">Searching…</p>
 				)}
-				{error && (
+				{error ? (
 					<p className="px-3 py-2 text-destructive text-xs">Search failed: {error.message}</p>
-				)}
+				) : null}
 				{deferred && results && results.length === 0 && !isLoading && (
 					<p className="px-3 py-2 text-muted-foreground text-xs">No results for "{deferred}"</p>
 				)}
@@ -133,7 +133,7 @@ function ResultRow({ result }: { result: SearchResult }) {
 			{result.heading_path && result.heading_path !== result.title && (
 				<p className="text-muted-foreground text-xs">↳ {result.heading_path}</p>
 			)}
-			{result.snippet && (
+			{Boolean(result.snippet) && (
 				<p className="mt-1 line-clamp-2 text-muted-foreground text-xs">{result.snippet}</p>
 			)}
 		</Link>

--- a/frontend/src/layout/vault-switcher.tsx
+++ b/frontend/src/layout/vault-switcher.tsx
@@ -52,7 +52,9 @@ export default function VaultSwitcher() {
 							Vault
 						</span>
 						<span className="flex items-center gap-1.5 truncate font-medium text-foreground text-sm">
-							{active.encrypted && <Lock className="size-3 shrink-0 text-muted-foreground" />}
+							{Boolean(active.encrypted) && (
+								<Lock className="size-3 shrink-0 text-muted-foreground" />
+							)}
 							{active.name}
 						</span>
 					</span>
@@ -82,7 +84,7 @@ export default function VaultSwitcher() {
 					>
 						{vaults.map((v) => (
 							<DropdownMenuRadioItem key={v.id} value={v.id}>
-								{v.encrypted && <Lock className="mr-1 size-3 text-muted-foreground" />}
+								{Boolean(v.encrypted) && <Lock className="mr-1 size-3 text-muted-foreground" />}
 								<span className="truncate">{v.name}</span>
 							</DropdownMenuRadioItem>
 						))}
@@ -98,7 +100,7 @@ function VaultLabel({ vault }: { vault: Vault }) {
 		<section className="border-border border-t px-3 py-2">
 			<p className="font-medium text-[10px] text-muted-foreground uppercase tracking-wide">Vault</p>
 			<p className="flex items-center gap-1.5 truncate font-medium text-foreground text-sm">
-				{vault.encrypted && <Lock className="size-3 shrink-0 text-muted-foreground" />}
+				{Boolean(vault.encrypted) && <Lock className="size-3 shrink-0 text-muted-foreground" />}
 				{vault.name}
 			</p>
 		</section>

--- a/frontend/src/oauth/oauth-authorize-page.tsx
+++ b/frontend/src/oauth/oauth-authorize-page.tsx
@@ -240,7 +240,7 @@ export default function OAuthAuthorizePage() {
 					<p className="text-muted-foreground text-sm">Loading…</p>
 				) : (
 					<>
-						{capCheck.atCap && existingPeer && (
+						{capCheck.atCap && existingPeer ? (
 							<div
 								role="status"
 								className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-foreground text-sm"
@@ -261,7 +261,7 @@ export default function OAuthAuthorizePage() {
 								</a>{" "}
 								to keep both connected.
 							</div>
-						)}
+						) : null}
 						<fieldset className="flex flex-col gap-2">
 							<legend className="mb-1 font-medium text-foreground text-sm">Which vault?</legend>
 							{vaultsQuery.data?.map((v) => {
@@ -294,7 +294,7 @@ export default function OAuthAuthorizePage() {
 							</label>
 						</fieldset>
 
-						{submitError && (
+						{Boolean(submitError) && (
 							<p role="alert" className={cn(destructiveAlert, "p-3 text-foreground")}>
 								{submitError}
 							</p>

--- a/frontend/src/onboarding/checklist-widget.tsx
+++ b/frontend/src/onboarding/checklist-widget.tsx
@@ -249,7 +249,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
 										</a>
 									</Button>
 								) : null}
-								{i.dismissible && (
+								{Boolean(i.dismissible) && (
 									<button
 										type="button"
 										aria-label={`Dismiss ${i.label}`}

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -204,7 +204,7 @@ function SourceScreen({
 				/>
 			</div>
 
-			{pickError && (
+			{Boolean(pickError) && (
 				<p role="alert" className="text-destructive text-sm">
 					{pickError}
 				</p>

--- a/frontend/src/onboarding/onboarding-shell.tsx
+++ b/frontend/src/onboarding/onboarding-shell.tsx
@@ -50,7 +50,7 @@ function ShellInner({ children }: { children: ReactNode }) {
 	return (
 		<>
 			{children}
-			{tourActive && (
+			{Boolean(tourActive) && (
 				<TourController
 					active={tourActive}
 					reachedEnd={tourReachedEnd}
@@ -58,7 +58,9 @@ function ShellInner({ children }: { children: ReactNode }) {
 					onExit={onTourExit}
 				/>
 			)}
-			{showVaultModal && <CreateFirstVaultModal onCreated={() => setVaultModalHandled(true)} />}
+			{Boolean(showVaultModal) && (
+				<CreateFirstVaultModal onCreated={() => setVaultModalHandled(true)} />
+			)}
 			{!tourActive && <ChecklistWidget onStartTour={startTour} />}
 		</>
 	);

--- a/frontend/src/settings/account/danger-zone-section-local.tsx
+++ b/frontend/src/settings/account/danger-zone-section-local.tsx
@@ -103,7 +103,7 @@ export function DangerZoneSectionLocal() {
 							/>
 							I understand this is irreversible
 						</label>
-						{error && <p className="text-destructive text-sm">{error}</p>}
+						{Boolean(error) && <p className="text-destructive text-sm">{error}</p>}
 					</fieldset>
 					<DialogFooter>
 						<DialogClose asChild>

--- a/frontend/src/settings/account/password-section-local.tsx
+++ b/frontend/src/settings/account/password-section-local.tsx
@@ -85,7 +85,7 @@ export function PasswordSectionLocal() {
 						required
 					/>
 				</label>
-				{error && <p className="text-destructive text-sm">{error}</p>}
+				{Boolean(error) && <p className="text-destructive text-sm">{error}</p>}
 				<Button type="submit" size="sm" disabled={submitting}>
 					{submitting ? "Changing…" : "Change password"}
 				</Button>

--- a/frontend/src/settings/account/password-section.tsx
+++ b/frontend/src/settings/account/password-section.tsx
@@ -48,7 +48,7 @@ export function PasswordSection() {
 					submit();
 				}}
 			>
-				{hasPassword && (
+				{Boolean(hasPassword) && (
 					<label className="block font-medium text-foreground text-sm">
 						Current password
 						<input

--- a/frontend/src/settings/account/section-card.tsx
+++ b/frontend/src/settings/account/section-card.tsx
@@ -13,9 +13,11 @@ export function SettingsSectionCard({ title, description, headerAction, children
 			<header className="mb-4 flex items-start justify-between gap-3">
 				<div>
 					<h2 className="font-semibold text-base text-foreground">{title}</h2>
-					{description && <p className="mt-1 text-muted-foreground text-sm">{description}</p>}
+					{Boolean(description) && (
+						<p className="mt-1 text-muted-foreground text-sm">{description}</p>
+					)}
 				</div>
-				{headerAction && <div className="shrink-0">{headerAction}</div>}
+				{Boolean(headerAction) && <div className="shrink-0">{headerAction}</div>}
 			</header>
 			{children}
 		</section>

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -180,14 +180,14 @@ export default function ConnectionsPage() {
 				}
 			/>
 
-			{pendingRevoke && (
+			{pendingRevoke ? (
 				<ConfirmRevokeModal
 					name={pendingRevoke.name}
 					description={pendingRevoke.description}
 					onConfirm={pendingRevoke.onConfirm}
 					onClose={() => setPendingRevoke(null)}
 				/>
-			)}
+			) : null}
 		</article>
 	);
 }
@@ -242,25 +242,25 @@ function ConnectionCard({
 					</div>
 				</summary>
 				<dl className="mt-1 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 px-3 text-muted-foreground text-xs [&_dt]:font-semibold">
-					{connection.software_version && (
+					{Boolean(connection.software_version) && (
 						<>
 							<dt>Version:</dt>
 							<dd>{connection.software_version}</dd>
 						</>
 					)}
-					{connection.connected_at && (
+					{connection.connected_at ? (
 						<>
 							<dt>Connected:</dt>
 							<dd>{new Date(connection.connected_at).toLocaleString()}</dd>
 						</>
-					)}
-					{connection.last_used_at && (
+					) : null}
+					{connection.last_used_at ? (
 						<>
 							<dt>Last active:</dt>
 							<dd>{new Date(connection.last_used_at).toLocaleString()}</dd>
 						</>
-					)}
-					{connection.scope && (
+					) : null}
+					{Boolean(connection.scope) && (
 						<>
 							<dt>Scopes:</dt>
 							<dd>{connection.scope}</dd>
@@ -268,13 +268,13 @@ function ConnectionCard({
 					)}
 					<dt>Identifier:</dt>
 					<dd className="break-all font-mono">{connection.client_id ?? connection.key_id}</dd>
-					{connection.first_ip && (
+					{Boolean(connection.first_ip) && (
 						<>
 							<dt>First IP:</dt>
 							<dd>{connection.first_ip}</dd>
 						</>
 					)}
-					{connection.first_user_agent && (
+					{Boolean(connection.first_user_agent) && (
 						<>
 							<dt>User agent:</dt>
 							<dd className="break-all">{connection.first_user_agent}</dd>
@@ -391,7 +391,7 @@ function PatSection({
 				</section>
 			)}
 
-			{showCreate && (
+			{Boolean(showCreate) && (
 				<CreatePatModal
 					onClose={() => setShowCreate(false)}
 					onCreated={(k) => {
@@ -401,7 +401,7 @@ function PatSection({
 				/>
 			)}
 
-			{newKey && <RevealKeyModal createdKey={newKey} onClose={() => setNewKey(null)} />}
+			{newKey ? <RevealKeyModal createdKey={newKey} onClose={() => setNewKey(null)} /> : null}
 		</SettingsSectionCard>
 	);
 }
@@ -450,7 +450,7 @@ function CreatePatModal({
 					</span>
 				</label>
 
-				{create.error && (
+				{Boolean(create.error) && (
 					<p className="text-destructive text-sm" role="alert">
 						{create.error instanceof ApiError
 							? create.error.message
@@ -661,7 +661,7 @@ function ConfirmRevokeModal({
 					<DialogTitle>Revoke "{name}"?</DialogTitle>
 					<DialogDescription>{description}</DialogDescription>
 				</DialogHeader>
-				{error && (
+				{Boolean(error) && (
 					<p
 						className="rounded-md bg-destructive/10 px-3 py-2 text-destructive text-sm"
 						role="alert"

--- a/frontend/src/settings/vaults/active-vaults-section.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.tsx
@@ -34,7 +34,7 @@ export function ActiveVaultsSection() {
 				)
 			}
 		>
-			{atCap && (
+			{Boolean(atCap) && (
 				<aside className="mb-4 flex items-center justify-between gap-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
 					<p className="text-foreground text-sm">
 						Your Free plan allows {vaultsCap} vault. Upgrade to Starter for more vaults.
@@ -57,7 +57,7 @@ export function ActiveVaultsSection() {
 					/>
 				</section>
 			)}
-			{isLoading && <p className="text-muted-foreground text-sm">Loading…</p>}
+			{Boolean(isLoading) && <p className="text-muted-foreground text-sm">Loading…</p>}
 			<table className="w-full text-sm">
 				<thead>
 					<tr className="border-border border-b text-left text-muted-foreground text-xs">
@@ -81,13 +81,13 @@ export function ActiveVaultsSection() {
 				</tbody>
 			</table>
 
-			{deleteTarget && (
+			{deleteTarget ? (
 				<DeleteVaultDialog
 					vault={deleteTarget}
 					open={deleteTarget !== null}
 					onOpenChange={(open) => !open && setDeleteTarget(null)}
 				/>
-			)}
+			) : null}
 		</SettingsSectionCard>
 	);
 }
@@ -122,7 +122,7 @@ function VaultRow({ vault, onDelete }: { vault: Vault; onDelete: () => void }) {
 				) : (
 					<span className="flex items-center gap-2">
 						<span className="font-medium text-foreground">{vault.name}</span>
-						{vault.is_default && (
+						{Boolean(vault.is_default) && (
 							<span className="rounded bg-muted px-2 py-0.5 text-muted-foreground text-xs">
 								Default
 							</span>

--- a/frontend/src/viewer/attachment-upload/provider.tsx
+++ b/frontend/src/viewer/attachment-upload/provider.tsx
@@ -125,7 +125,7 @@ export function AttachmentUploadProvider({ children }: { children: React.ReactNo
 					}
 				}}
 			/>
-			{dragging && (
+			{Boolean(dragging) && (
 				<div
 					aria-hidden
 					className="fixed inset-0 z-50 flex items-center justify-center bg-blue-500/10 ring-2 ring-blue-400 ring-inset backdrop-blur-sm"

--- a/frontend/src/viewer/attachment-upload/upload-dialog.tsx
+++ b/frontend/src/viewer/attachment-upload/upload-dialog.tsx
@@ -173,7 +173,7 @@ export function AttachmentUploadDialog({ initialFiles, folders, defaultFolder, o
 								onClick={() => setFolder(name)}
 								className={`cursor-pointer px-3 py-1 text-sm ${name === folder ? "bg-blue-50 dark:bg-blue-950" : ""}`}
 							>
-								{name === "" ? "/ (root)" : name}
+								{name === "" ? "/ (root)" : `${name}`}
 							</div>
 						))}
 					</div>

--- a/frontend/src/viewer/dashboard.tsx
+++ b/frontend/src/viewer/dashboard.tsx
@@ -24,7 +24,7 @@ function NoteRow({ note }: NoteRowProps) {
 				</h3>
 			</Link>
 			<footer className="mt-1 flex flex-wrap items-center gap-3 text-gray-500 text-xs dark:text-gray-400">
-				{note.folder && <span>{note.folder}</span>}
+				{Boolean(note.folder) && <span>{note.folder}</span>}
 				{note.tags.length > 0 && (
 					<ul className="flex gap-1" aria-label="Tags">
 						{note.tags.map((tag) => (

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -107,7 +107,7 @@ export default function NotePage() {
 			)}
 			<div className="flex shrink-0 items-center gap-2 border-border border-b px-4 py-2">
 				<h2 className="flex min-w-0 flex-1 items-baseline gap-1 text-sm" title={titlePath}>
-					{note.folder && (
+					{Boolean(note.folder) && (
 						<span className="min-w-0 shrink truncate text-muted-foreground">{note.folder}/</span>
 					)}
 					<span className="min-w-0 truncate font-medium">{note.title}</span>

--- a/frontend/src/viewer/tree-actions/action-drawer.tsx
+++ b/frontend/src/viewer/tree-actions/action-drawer.tsx
@@ -42,7 +42,7 @@ export function ActionDrawer({ title, actions, onPick, onClose, onSelectMore }: 
 						{a.label}
 					</button>
 				))}
-				{onSelectMore && (
+				{onSelectMore ? (
 					<button
 						type="button"
 						onClick={() => {
@@ -53,7 +53,7 @@ export function ActionDrawer({ title, actions, onPick, onClose, onSelectMore }: 
 					>
 						Select more
 					</button>
-				)}
+				) : null}
 			</div>
 		</>
 	);

--- a/frontend/src/viewer/tree-actions/move-dialog.tsx
+++ b/frontend/src/viewer/tree-actions/move-dialog.tsx
@@ -81,7 +81,7 @@ export function MoveDialog({ folders, nodes, onPick, onCancel }: Props) {
 							i === active ? "bg-blue-50 dark:bg-blue-950" : ""
 						}`}
 					>
-						{name === "" ? "/ (root)" : name}
+						{name === "" ? "/ (root)" : `${name}`}
 					</div>
 				))}
 			</div>

--- a/frontend/src/viewer/tree-actions/rename-input.tsx
+++ b/frontend/src/viewer/tree-actions/rename-input.tsx
@@ -49,7 +49,7 @@ export function RenameInput({ initial, kind, error, onCommit, onCancel }: Props)
 				onBlur={() => onCancel()}
 				className="w-full rounded border border-blue-400 bg-white px-1 py-0.5 text-gray-900 text-sm dark:bg-gray-900 dark:text-gray-100"
 			/>
-			{error && (
+			{Boolean(error) && (
 				<span className="text-red-600 text-xs dark:text-red-400" role="alert">
 					{error}
 				</span>

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -122,11 +122,11 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
 					className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500"
 				/>
 				<span className="min-w-0 flex-1 truncate">{filename}</span>
-				{ext && (
+				{ext ? (
 					<span className="shrink-0 text-gray-400 text-xs dark:text-gray-500">
 						{ext.toUpperCase()}
 					</span>
-				)}
+				) : null}
 			</Link>
 		);
 	}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.586",
+      version: "0.5.587",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Non-a11y ratchet PR from #812 (real-bug tier). Enables `noLeakedRender` across **all 118 sites in ~50 files**.

The rule catches JSX guards like `{count && <X>}` that render a literal `0`/`NaN`/`""` when the left operand is a falsy non-boolean (e.g. `{items.length && <List/>}` renders `0` for an empty array).

## No autofix — each site fixed by hand, behavior preserved, zero suppressions

- **Simple guards** → `Boolean(cond) && <JSX>`. (Plain `!!` is rejected here by the already-enabled `noImplicitCoercions` rule, which mandates `Boolean()`.)
- **Guards that narrow the condition inside the JSX** → ternary `{cond ? <JSX> : null}`, because `Boolean(x)` defeats TypeScript's control-flow narrowing (TS narrows on the truthy operand of `&&`/`?:` but not through `Boolean()`). Using `Boolean()` there produced 34 tsc errors; the ternary preserves narrowing and is leak-safe (`null` alternate).
- **Three pre-existing ternaries** with a string alternate that Biome also flagged → template-literal alternate (`` `${x}` ``), provably a string and behavior-identical.

Verified with no `biome-ignore` and no `!!` in the diff.

## Verification

- `bun run ci` (biome ci) clean
- `tsc --noEmit` clean
- Full suite: **645/645 tests pass** (121 files)

Refs #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)