### PR TITLE
chore(frontend): ratchet nursery useNamedCaptureGroup

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -97,7 +97,6 @@
 						"useDomQuerySelector": "off",
 						"useExpect": "off",
 						"useImportsFirst": "off",
-						"useNamedCaptureGroup": "off",
 						"useReactFunctionComponentDefinition": "off",
 						"useRegexpTest": "off",
 						"useTestHooksOnTop": "off",

--- a/frontend/e2e/onboarding-ftux.spec.ts
+++ b/frontend/e2e/onboarding-ftux.spec.ts
@@ -62,7 +62,7 @@ test.describe("FTUX happy path", () => {
 		// a prior run (or backend seed). If we land outside `/`, skip with a clear
 		// signal so the rest of the suite still runs.
 		await page.waitForURL((url) => !url.pathname.startsWith("/sign-in"), { timeout: 15_000 });
-		if (!new URL(page.url()).pathname.match(/^\/(note|search)?\/?$/u)) {
+		if (!new URL(page.url()).pathname.match(/^\/(?:note|search)?\/?$/u)) {
 			test.skip(
 				true,
 				`Onboarding wizard not pre-completed for test user (landed on ${new URL(page.url()).pathname}). ` +
@@ -110,7 +110,7 @@ test.describe("FTUX happy path", () => {
 	test("checklist widget mounts on the dashboard after vault creation", async ({ page }) => {
 		await clerkSignIn(page, state.email);
 		await page.waitForURL((url) => !url.pathname.startsWith("/sign-in"), { timeout: 15_000 });
-		if (!new URL(page.url()).pathname.match(/^\/(note|search)?\/?$/u)) {
+		if (!new URL(page.url()).pathname.match(/^\/(?:note|search)?\/?$/u)) {
 			test.skip(true, "Onboarding wizard not pre-completed for test user.");
 			return;
 		}
@@ -134,7 +134,7 @@ test.describe("FTUX happy path", () => {
 	}) => {
 		await clerkSignIn(page, state.email);
 		await page.waitForURL((url) => !url.pathname.startsWith("/sign-in"), { timeout: 15_000 });
-		if (!new URL(page.url()).pathname.match(/^\/(note|search)?\/?$/u)) {
+		if (!new URL(page.url()).pathname.match(/^\/(?:note|search)?\/?$/u)) {
 			test.skip(true, "Onboarding wizard not pre-completed for test user.");
 			return;
 		}
@@ -160,7 +160,7 @@ test.describe("FTUX happy path", () => {
 	test("completed flow does not re-fire modals after reload", async ({ page }) => {
 		await clerkSignIn(page, state.email);
 		await page.waitForURL((url) => !url.pathname.startsWith("/sign-in"), { timeout: 15_000 });
-		if (!new URL(page.url()).pathname.match(/^\/(note|search)?\/?$/u)) {
+		if (!new URL(page.url()).pathname.match(/^\/(?:note|search)?\/?$/u)) {
 			test.skip(true, "Onboarding wizard not pre-completed for test user.");
 			return;
 		}
@@ -201,7 +201,7 @@ test.describe("FTUX happy path", () => {
 	test("user with existing vault sees no vault modal", async ({ page }) => {
 		await clerkSignIn(page, state.email);
 		await page.waitForURL((url) => !url.pathname.startsWith("/sign-in"), { timeout: 15_000 });
-		if (!new URL(page.url()).pathname.match(/^\/(note|search)?\/?$/u)) {
+		if (!new URL(page.url()).pathname.match(/^\/(?:note|search)?\/?$/u)) {
 			test.skip(true, "Onboarding wizard not pre-completed for test user.");
 			return;
 		}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -31,14 +31,14 @@ export default defineConfig({
 	projects: [
 		{
 			name: "local",
-			testMatch: /\/(local-auth|dark-mode|mobile|note-live-update)\.spec\.ts$/u,
+			testMatch: /\/(?:local-auth|dark-mode|mobile|note-live-update)\.spec\.ts$/u,
 			use: {
 				baseURL: `http://localhost:${LOCAL_VITE_PORT}`,
 			},
 		},
 		{
 			name: "clerk",
-			testMatch: /\/(clerk-auth|onboarding-ftux)\.spec\.ts$/u,
+			testMatch: /\/(?:clerk-auth|onboarding-ftux)\.spec\.ts$/u,
 			use: {
 				baseURL: `http://localhost:${CLERK_VITE_PORT}`,
 			},

--- a/frontend/scripts/sync-theme.ts
+++ b/frontend/scripts/sync-theme.ts
@@ -99,8 +99,11 @@ function blockBody(css: string, selector: string, mustContain: string): string {
 
 function parseVars(body: string): Map<string, string> {
 	const out = new Map<string, string>();
-	for (const m of body.matchAll(/--([\w-]+):\s*([^;]+);/gu)) {
-		out.set(m[1], m[2].trim());
+	for (const m of body.matchAll(/--(?<name>[\w-]+):\s*(?<value>[^;]+);/gu)) {
+		const { name, value } = m.groups ?? {};
+		if (name && value !== undefined) {
+			out.set(name, value.trim());
+		}
 	}
 	return out;
 }

--- a/frontend/src/viewer/note-toc.tsx
+++ b/frontend/src/viewer/note-toc.tsx
@@ -12,7 +12,7 @@ function extractHeadings(markdown: string): Heading[] {
 	const headings: Heading[] = [];
 	// Strip fenced code blocks so `# foo` inside them isn't picked up.
 	const stripped = markdown.replace(/```[\s\S]*?```/gu, "");
-	const re = /^(#{1,6})\s+(.+?)\s*#*\s*$/gmu;
+	const re = /^(?<hashes>#{1,6})\s+(?<text>.+?)\s*#*\s*$/gmu;
 	let match = re.exec(stripped);
 	while (match !== null) {
 		const hashes = match[1] ?? "";

--- a/frontend/src/viewer/note-view.tsx
+++ b/frontend/src/viewer/note-view.tsx
@@ -24,7 +24,7 @@ interface NoteViewProps {
 const ATTACHMENT_SCHEME = "engram-attachment:";
 
 function rewriteEmbeds(raw: string): string {
-	return raw.replace(/!\[\[([^\]]+)\]\]/gu, (_match, inner: string) => {
+	return raw.replace(/!\[\[(?<inner>[^\]]+)\]\]/gu, (_match, inner: string) => {
 		const [path, alias] = inner.split("|").map((s) => s.trim());
 		return `![${alias ?? path}](${ATTACHMENT_SCHEME}${path})`;
 	});
@@ -55,7 +55,7 @@ const rehypePlugins = [
 
 // Attachment file extensions are anything OTHER than markdown / canvas — those
 // are first-class note types that should still link normally on Free.
-const TEXT_EMBED = /\.(md|canvas)$/iu;
+const TEXT_EMBED = /\.(?:md|canvas)$/iu;
 
 // memo: NotePage re-renders on every editor keystroke (draft state) while
 // the preview stays force-mounted with identical props; react-markdown has
@@ -117,7 +117,7 @@ function NoteView({ content, tags }: NoteViewProps) {
 					}
 					components={{
 						code({ className, children, ...rest }) {
-							const lang = /language-(\w+)/u.exec(className ?? "")?.[1];
+							const lang = /language-(?<lang>\w+)/u.exec(className ?? "")?.[1];
 							const code = String(children).replace(/\n$/u, "");
 							if (lang === "mermaid") {
 								return <MermaidBlock code={code} />;

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.588",
+      version: "0.5.589",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Part of the Biome lint ratchet (tracking #812): re-enable one deferred rule per PR.

## This PR: \`nursery/useNamedCaptureGroup\` (14 sites)

Requires every regex capturing group to be named or non-capturing. Fixes:
- **Unused captures** (match-only) become non-capturing \`(?:...)\` — the 5 identical URL-path checks in \`onboarding-ftux.spec.ts\`, both \`testMatch\` regexes in \`playwright.config.ts\`, and \`TEXT_EMBED\` in \`note-view.tsx\`.
- **Accessed captures** get names — \`sync-theme.ts\` parseVars (now reads \`m.groups\`), \`note-toc.tsx\` heading regex, and the \`![[...]]\` embed / \`language-*\` code-fence regexes in \`note-view.tsx\`. Named groups stay index-accessible in JS, so \`match[1]\`/\`?.[1]\` and the \`replace\` positional callback are unchanged in behavior.

No autofix exists for this rule in Biome 2.5.1 — all sites hand-fixed.

## Verification (local)
- \`biome ci .\` clean
- \`tsc --noEmit\` exit 0
- \`vitest run\` 645/645 pass (121 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)