### PR TITLE
chore(frontend): ratchet style useDestructuring

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -137,7 +137,6 @@
 						"useComponentExportOnlyModules": "off",
 						"useConsistentMemberAccessibility": "off",
 						"useConsistentMethodSignatures": "off",
-						"useDestructuring": "off",
 						"useExportsLast": "off"
 					},
 					"suspicious": {

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -2061,7 +2061,7 @@ export function useBatchMoveNotes() {
 				if (cache) {
 					foldersSnapshot = cache;
 					const patched = cache.folders.map((f) => {
-						let count = f.count;
+						let { count } = f;
 						// Both source decrement and destination bump match by NAME: a
 						// derived folder has a null id in the raw cache, so id matching
 						// would miss it.

--- a/frontend/src/auth/clerk-auth-provider.test.ts
+++ b/frontend/src/auth/clerk-auth-provider.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { toRelativeUrl } from "./clerk-auth-provider";
 
 describe("toRelativeUrl", () => {
-	const origin = window.location.origin;
+	const { origin } = window.location;
 
 	it("strips same-origin absolute URLs to path", () => {
 		expect(toRelativeUrl(`${origin}/`)).toBe("/");

--- a/frontend/src/auth/local-auth-provider.tsx
+++ b/frontend/src/auth/local-auth-provider.tsx
@@ -7,7 +7,7 @@ import { useClearQueryCacheOnUserChange } from "./use-clear-query-cache-on-user-
 
 function parseJwtPayload(token: string): Record<string, unknown> | null {
 	try {
-		const base64 = token.split(".")[1];
+		const [, base64] = token.split(".");
 		if (!base64) {
 			return null;
 		}

--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -196,7 +196,7 @@ describe("BillingPage — Paddle effect cleanup", () => {
 		renderBilling({ inline: true });
 
 		await waitFor(() => expect(initializePaddleMock).toHaveBeenCalled());
-		const settings = initializePaddleMock.mock.calls[0]![0].checkout.settings;
+		const { settings } = initializePaddleMock.mock.calls[0]![0].checkout;
 		expect(settings.displayMode).toBe("inline");
 		expect(settings.frameTarget).toBe("paddle-checkout");
 	});
@@ -210,7 +210,7 @@ describe("BillingPage — Paddle effect cleanup", () => {
 		renderBilling({ inline: false });
 
 		await waitFor(() => expect(initializePaddleMock).toHaveBeenCalled());
-		const settings = initializePaddleMock.mock.calls[0]![0].checkout.settings;
+		const { settings } = initializePaddleMock.mock.calls[0]![0].checkout;
 		expect(settings.displayMode).toBe("overlay");
 	});
 

--- a/frontend/src/components/subscription-status-card.tsx
+++ b/frontend/src/components/subscription-status-card.tsx
@@ -202,7 +202,7 @@ export function SubscriptionStatusCard({
 	} = subscription;
 
 	const isSingleItem = items.length === 1;
-	const primaryItem = items[0];
+	const [primaryItem] = items;
 	const isPastDue = status === "past_due";
 
 	const effectiveScheduledChange = getValidScheduledChange(status, scheduledChange);

--- a/frontend/src/crdt/channel.test.ts
+++ b/frontend/src/crdt/channel.test.ts
@@ -40,7 +40,7 @@ describe("CrdtChannel", () => {
 		// session forwards via sendUpdateRaw; emulate it:
 		const update = await aMgr.encodeStateAsUpdate("n.md");
 		aCh.sendUpdateRaw(aMgr.docId("n.md"), update);
-		const frame = aSends[aSends.length - 1]![1];
+		const [, frame] = aSends[aSends.length - 1]!;
 
 		const bMgr = mkManager();
 		const bCh = new CrdtChannel({ manager: bMgr, send: () => {} });

--- a/frontend/src/lib/checkout-summary-utils.ts
+++ b/frontend/src/lib/checkout-summary-utils.ts
@@ -61,7 +61,7 @@ export function mapCheckoutEventsToSummary(data: CheckoutEventsInput): CheckoutS
 		lineTotal: item.totals?.subtotal ?? 0,
 	}));
 
-	const totals = data.totals;
+	const { totals } = data;
 	const recurringTotals = data.recurring_totals;
 
 	const discount = totals?.discount && totals.discount > 0 ? totals.discount : undefined;

--- a/frontend/src/lib/plan-change-preview-utils.ts
+++ b/frontend/src/lib/plan-change-preview-utils.ts
@@ -108,9 +108,13 @@ export function mapPreviewToPlanChangeData(
 	preview: SubscriptionPreviewResponse,
 	discount?: PaddleDiscount | null,
 ): PlanChangePreviewData {
-	const currencyCode = preview.currencyCode;
-	const { updateSummary, immediateTransaction, nextTransaction, recurringTransactionDetails } =
-		preview;
+	const {
+		currencyCode,
+		updateSummary,
+		immediateTransaction,
+		nextTransaction,
+		recurringTransactionDetails,
+	} = preview;
 
 	const resultAmount = parseAmount(updateSummary.result.amount, currencyCode);
 	const creditAmount = parseAmount(updateSummary.credit.amount, currencyCode);

--- a/frontend/src/oauth/oauth-authorize-page.test.tsx
+++ b/frontend/src/oauth/oauth-authorize-page.test.tsx
@@ -197,8 +197,8 @@ describe("OAuthAuthorizePage", () => {
 		await waitFor(() =>
 			expect(postOAuthConsent).toHaveBeenCalledWith(expect.objectContaining({ client_id: "cli" })),
 		);
-		const delOrder = apiDel.mock.invocationCallOrder[0];
-		const consentOrder = postOAuthConsent.mock.invocationCallOrder[0];
+		const [delOrder] = apiDel.mock.invocationCallOrder;
+		const [consentOrder] = postOAuthConsent.mock.invocationCallOrder;
 		expect(delOrder).toBeDefined();
 		expect(consentOrder).toBeDefined();
 		expect(delOrder!).toBeLessThan(consentOrder!);

--- a/frontend/src/onboarding/onboarding-gate.tsx
+++ b/frontend/src/onboarding/onboarding-gate.tsx
@@ -12,7 +12,7 @@ export default function OnboardingGate() {
 		return <LoadingScreen />;
 	}
 
-	const onboarding = data.onboarding;
+	const { onboarding } = data;
 
 	if (!onboarding.enabled || onboarding.next_step === "done") {
 		return <Outlet />;

--- a/frontend/src/onboarding/tour/demo-vault-provider.test.tsx
+++ b/frontend/src/onboarding/tour/demo-vault-provider.test.tsx
@@ -25,8 +25,7 @@ describe("DemoVaultProvider", () => {
 	it("inactive by default, active after activate()", async () => {
 		let activate!: () => Promise<void>;
 		function Capture() {
-			const ctx = useDemoVault();
-			activate = ctx.activate;
+			({ activate } = useDemoVault());
 			return null;
 		}
 		render(

--- a/frontend/src/settings/account/clerk-errors.ts
+++ b/frontend/src/settings/account/clerk-errors.ts
@@ -5,7 +5,7 @@ import { isClerkAPIResponseError } from "@clerk/react/errors";
 // which field the instance rejected); without this they get swallowed.
 export function clerkErrorMessage(e: unknown, fallback: string): string {
 	if (isClerkAPIResponseError(e)) {
-		const first = e.errors[0];
+		const [first] = e.errors;
 		return first?.longMessage ?? first?.message ?? fallback;
 	}
 	return fallback;

--- a/frontend/src/viewer/attachment-upload/file-to-base64.ts
+++ b/frontend/src/viewer/attachment-upload/file-to-base64.ts
@@ -5,7 +5,7 @@ export function fileToBase64(file: File): Promise<string> {
 		const reader = new FileReader();
 		reader.onerror = () => reject(reader.error ?? new Error("file read failed"));
 		reader.onload = () => {
-			const result = reader.result;
+			const { result } = reader;
 			if (typeof result !== "string") {
 				reject(new Error("unexpected FileReader result"));
 				return;

--- a/frontend/src/viewer/tree-actions/delete-confirm.tsx
+++ b/frontend/src/viewer/tree-actions/delete-confirm.tsx
@@ -10,7 +10,7 @@ function buildMessage(nodes: Node[]): string {
 	if (nodes.length > 1) {
 		return `Delete ${nodes.length} items?`;
 	}
-	const node = nodes[0];
+	const [node] = nodes;
 	if (!node) {
 		return "Delete?";
 	}

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -29,7 +29,7 @@ export function TreeRow({ instance, onContextMenu, onLongPress, onFolderHover }:
 		: undefined;
 
 	const data = instance.getItemData();
-	const item = data.item;
+	const { item } = data;
 	const depth = instance.getItemMeta()?.level ?? 0;
 	const folderPad = depth * 12 + 4;
 	const notePad = folderPad + 20; // align note label under folder name (chevron 16px + gap 4px)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.589",
+      version: "0.5.590",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Part of the Biome lint ratchet (tracking #812): re-enable one deferred rule per PR.

## This PR: \`style/useDestructuring\` (17 sites)

Prefer destructuring over repeated member/index reads:
- **Object member reads** (\`const x = obj.x\`) become \`const { x } = obj\` — \`queries.ts\`, \`clerk-auth-provider.test\`, \`subscription-status-card\`, \`checkout-summary-utils\`, \`plan-change-preview-utils\`, \`onboarding-gate\`, \`file-to-base64\`, \`tree-row\`, \`billing-page.test\`, \`demo-vault-provider.test\`.
- **Single-index reads** (\`const x = arr[0]\`, \`token.split(".")[1]\`) become array destructuring (\`const [x] = arr\`, \`const [, base64] = ...\`) — \`local-auth-provider\`, \`channel.test\`, \`oauth-authorize-page.test\`, \`clerk-errors\`, \`delete-confirm\`.

All behavior-preserving. No autofix exists for this rule in Biome 2.5.1 (hand-fixed).

## Verification (local)
- \`biome ci .\` clean
- \`tsc --noEmit\` exit 0
- \`vitest run\` 645/645 pass (121 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)