### PR TITLE
test(crdt): fix TOCTOU teardown race in crdt_deliver_test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.591",
+      version: "0.5.592",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -141,7 +141,17 @@ defmodule Engram.Notes.CrdtDeliverTest do
         name: CrdtRegistry.global_name(note_id)
       )
 
-    on_exit(fn -> if Process.alive?(room), do: GenServer.stop(room) end)
+    on_exit(fn ->
+      # The room can terminate on its own between the alive? check and the
+      # stop (SharedDoc auto-exits when its last observer leaves), so a bare
+      # GenServer.stop races and exits with :noproc. Tolerate an already-dead
+      # process rather than crash the on_exit callback.
+      try do
+        if Process.alive?(room), do: GenServer.stop(room)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
 
     if seed_text do
       SharedDoc.update_doc(room, fn doc ->


### PR DESCRIPTION
## Problem

`crdt_deliver_test.exs` setup registered:

```elixir
on_exit(fn -> if Process.alive?(room), do: GenServer.stop(room) end)
```

`SharedDoc` auto-exits when its last observer leaves, so the room process can terminate on its own in the window **between** the `Process.alive?/1` check and the `GenServer.stop/1` call. When that happens the stop exits with `:noproc`, which crashes the `on_exit` callback and fails an otherwise-passing test:

```
** (exit) exited in: GenServer.stop(#PID<...>, :normal, :infinity)
    ** (EXIT) no process: the process is not alive...
```

Classic TOCTOU. It stays hidden on `mix test --stale` PR runs (this file's tests only run when their modules change) and surfaced during a full `--stale` recompile on an unrelated web PR.

## Fix

Wrap the guarded stop in `try/catch :exit` so an already-dead process is tolerated instead of crashing the teardown:

```elixir
on_exit(fn ->
  try do
    if Process.alive?(room), do: GenServer.stop(room)
  catch
    :exit, _ -> :ok
  end
end)
```

## Testing

`mix test test/engram/notes/crdt_deliver_test.exs` → 6 tests, 0 failures. This is a test-only teardown fix; no lib code changes.

Follow-up from #818 (which added this test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)