### PR TITLE
chore(frontend): ratchet nursery useImportsFirst

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -96,7 +96,6 @@
 						"useBaseline": "off",
 						"useDomQuerySelector": "off",
 						"useExpect": "off",
-						"useImportsFirst": "off",
 						"useReactFunctionComponentDefinition": "off",
 						"useRegexpTest": "off",
 						"useTestHooksOnTop": "off",

--- a/frontend/src/api/channel-crdt.test.ts
+++ b/frontend/src/api/channel-crdt.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { connectChannel, disconnectChannel } from "./channel";
 
 // Mock the phoenix Socket/Channel so we can assert the crdt: topic join +
 // inbound event routing without a real WS.
@@ -41,8 +42,6 @@ const sessionMock = vi.hoisted(() => ({
 	resyncOpenDocs: vi.fn(),
 }));
 vi.mock("../crdt/session", () => sessionMock);
-
-import { connectChannel, disconnectChannel } from "./channel";
 
 describe("crdt channel wiring", () => {
 	beforeEach(() => {

--- a/frontend/src/api/channel-onopen.test.ts
+++ b/frontend/src/api/channel-onopen.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { connectChannel, disconnectChannel } from "./channel";
 
 // Minimal phoenix mock: capture the onOpen callback and the channel handlers.
 // Uses vi.hoisted + a constructor function (not arrow) so `new Socket(...)` works.
@@ -26,8 +27,6 @@ vi.mock("phoenix", () => ({
 	Socket: socketCtor,
 	Channel: vi.fn(),
 }));
-
-import { connectChannel, disconnectChannel } from "./channel";
 
 afterEach(() => {
 	disconnectChannel();

--- a/frontend/src/api/cursor-sync.test.ts
+++ b/frontend/src/api/cursor-sync.test.ts
@@ -1,5 +1,9 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetNoteChangeBatch } from "./channel";
+import { ApiError, api } from "./client";
+import { encodeCursor, getCursor, MAX_UUID, setCursor } from "./cursor";
+import { __resetCursorSyncInflight, installCursorSyncTriggers, runCursorSync } from "./cursor-sync";
 
 vi.mock("./client", () => ({
 	api: { get: vi.fn() },
@@ -20,11 +24,6 @@ const activeVaultRef = vi.hoisted(() => ({ current: "v1" }));
 vi.mock("./active-vault", () => ({
 	getActiveVaultId: () => activeVaultRef.current,
 }));
-
-import { __resetNoteChangeBatch } from "./channel";
-import { ApiError, api } from "./client";
-import { encodeCursor, getCursor, MAX_UUID, setCursor } from "./cursor";
-import { __resetCursorSyncInflight, installCursorSyncTriggers, runCursorSync } from "./cursor-sync";
 
 const get = api.get as unknown as ReturnType<typeof vi.fn>;
 

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -2,6 +2,35 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { ApiError } from "./client";
+import {
+	type Folder,
+	type Note,
+	useAcceptTerms,
+	useAttachments,
+	useBatchDeleteAttachments,
+	useBatchDeleteFolders,
+	useBatchDeleteNotes,
+	useBatchMoveAttachments,
+	useBatchMoveFolders,
+	useBatchMoveNotes,
+	useCancelSubscription,
+	useConfirmPlanChange,
+	useCreateNote,
+	useDeleteFolder,
+	useDeleteNote,
+	useDuplicateNote,
+	useFolderNotesById,
+	useFolders,
+	useNote,
+	usePlanChangePreview,
+	useRenameAttachment,
+	useRenameFolder,
+	useRenameNote,
+	useReverseCancel,
+	useSearch,
+	useUploadAttachment,
+} from "./queries";
 
 vi.mock("sonner", () => ({
 	toast: {
@@ -37,36 +66,6 @@ vi.mock("./client", async () => {
 		setTokenGetter: vi.fn(),
 	};
 });
-
-import { ApiError } from "./client";
-import {
-	type Folder,
-	type Note,
-	useAcceptTerms,
-	useAttachments,
-	useBatchDeleteAttachments,
-	useBatchDeleteFolders,
-	useBatchDeleteNotes,
-	useBatchMoveAttachments,
-	useBatchMoveFolders,
-	useBatchMoveNotes,
-	useCancelSubscription,
-	useConfirmPlanChange,
-	useCreateNote,
-	useDeleteFolder,
-	useDeleteNote,
-	useDuplicateNote,
-	useFolderNotesById,
-	useFolders,
-	useNote,
-	usePlanChangePreview,
-	useRenameAttachment,
-	useRenameFolder,
-	useRenameNote,
-	useReverseCancel,
-	useSearch,
-	useUploadAttachment,
-} from "./queries";
 
 let qc: QueryClient;
 

--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type AuthAdapter, AuthContext } from "../auth/auth-context";
 import { ThemeProvider } from "../theme/theme-provider";
+import BillingPage from "./billing-page";
 
 const initializePaddleMock = vi.fn();
 vi.mock("@paddle/paddle-js", () => ({
@@ -46,8 +47,6 @@ const { channelHandlers, socketCtor } = vi.hoisted(() => {
 	return { channelHandlers, socketCtor };
 });
 vi.mock("phoenix", () => ({ Socket: socketCtor }));
-
-import BillingPage from "./billing-page";
 
 const authAdapter: AuthAdapter = {
 	isLoaded: true,

--- a/frontend/src/billing/cancel-panel.test.tsx
+++ b/frontend/src/billing/cancel-panel.test.tsx
@@ -2,15 +2,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubscriptionDetail } from "../api/queries";
+import CancelPanel from "./cancel-panel";
 
 const { post } = vi.hoisted(() => ({ post: vi.fn() }));
 vi.mock("../api/client", () => ({
 	api: { get: vi.fn(), post, patch: vi.fn(), del: vi.fn() },
 	setTokenGetter: vi.fn(),
 }));
-
-import type { SubscriptionDetail } from "../api/queries";
-import CancelPanel from "./cancel-panel";
 
 let qc: QueryClient;
 

--- a/frontend/src/billing/pending-change-banner.test.tsx
+++ b/frontend/src/billing/pending-change-banner.test.tsx
@@ -2,14 +2,13 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PendingChangeBanner from "./pending-change-banner";
 
 const { post } = vi.hoisted(() => ({ post: vi.fn() }));
 vi.mock("../api/client", () => ({
 	api: { get: vi.fn(), post, patch: vi.fn(), del: vi.fn() },
 	setTokenGetter: vi.fn(),
 }));
-
-import PendingChangeBanner from "./pending-change-banner";
 
 let qc: QueryClient;
 

--- a/frontend/src/billing/plan-change-panel.test.tsx
+++ b/frontend/src/billing/plan-change-panel.test.tsx
@@ -2,15 +2,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BillingStatus } from "../api/queries";
+import PlanChangePanel from "./plan-change-panel";
 
 const { get, post } = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }));
 vi.mock("../api/client", () => ({
 	api: { get, post, patch: vi.fn(), del: vi.fn() },
 	setTokenGetter: vi.fn(),
 }));
-
-import type { BillingStatus } from "../api/queries";
-import PlanChangePanel from "./plan-change-panel";
 
 let qc: QueryClient;
 

--- a/frontend/src/billing/use-is-free-tier.test.ts
+++ b/frontend/src/billing/use-is-free-tier.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useIsFreeTier } from "./use-is-free-tier";
 
 let billingEnabled = true;
 let tier: string | undefined = "free";
@@ -16,8 +17,6 @@ vi.mock("../api/queries", async () => {
 	const actual = await vi.importActual<typeof import("../api/queries")>("../api/queries");
 	return { ...actual, useBillingStatus: () => ({ data: tier ? { tier } : undefined }) };
 });
-
-import { useIsFreeTier } from "./use-is-free-tier";
 
 beforeEach(() => {
 	billingEnabled = true;

--- a/frontend/src/billing/use-subscription-activated-events.test.tsx
+++ b/frontend/src/billing/use-subscription-activated-events.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type AuthAdapter, AuthContext } from "../auth/auth-context";
+import { useSubscriptionActivatedEvents } from "./use-subscription-activated-events";
 
 const {
 	channelHandlers,
@@ -42,8 +43,6 @@ const {
 });
 
 vi.mock("phoenix", () => ({ Socket: socketCtor }));
-
-import { useSubscriptionActivatedEvents } from "./use-subscription-activated-events";
 
 const authAdapter: AuthAdapter = {
 	isLoaded: true,

--- a/frontend/src/components/vault-create-form.test.tsx
+++ b/frontend/src/components/vault-create-form.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VaultCreateForm } from "./vault-create-form";
 
 // vi.mock factories run at the top of the file — declare their fakes
 // via vi.hoisted so the references resolve when the mock executes.
@@ -14,8 +15,6 @@ vi.mock("@/api/queries", () => ({
 }));
 
 vi.mock("sonner", () => ({ toast: { error: toastError, success: toastSuccess } }));
-
-import { VaultCreateForm } from "./vault-create-form";
 
 describe("VaultCreateForm onError", () => {
 	beforeEach(() => vi.clearAllMocks());

--- a/frontend/src/layout/folder-actions.test.tsx
+++ b/frontend/src/layout/folder-actions.test.tsx
@@ -2,6 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import FolderActions from "./folder-actions";
+import { FolderTreeProvider } from "./folder-tree-context";
 
 const { navigate, post, toastError, openUpload } = vi.hoisted(() => ({
 	navigate: vi.fn(),
@@ -51,9 +53,6 @@ vi.mock("../api/active-vault", () => ({
 	getActiveVaultId: () => "1",
 	setActiveVaultId: vi.fn(),
 }));
-
-import FolderActions from "./folder-actions";
-import { FolderTreeProvider } from "./folder-tree-context";
 
 function renderWithProviders() {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/lib/paddle-sdk-types.ts
+++ b/frontend/src/lib/paddle-sdk-types.ts
@@ -1,3 +1,8 @@
+// CheckoutSettings from the SDK, widened to include "express" in the variant
+// union. The express variant is a valid Paddle.js variant not yet reflected in
+// the SDK's Variant type ('multi-page' | 'one-page').
+import type { CheckoutCustomer, CheckoutSettings as SDKCheckoutSettings } from "@paddle/paddle-js";
+
 export type {
 	CheckoutCustomer,
 	CheckoutEventsData,
@@ -12,10 +17,6 @@ export type {
 
 export { CheckoutEventNames } from "@paddle/paddle-js";
 
-// CheckoutSettings from the SDK, widened to include "express" in the variant
-// union. The express variant is a valid Paddle.js variant not yet reflected in
-// the SDK's Variant type ('multi-page' | 'one-page').
-import type { CheckoutCustomer, CheckoutSettings as SDKCheckoutSettings } from "@paddle/paddle-js";
 export type CheckoutSettings = Omit<SDKCheckoutSettings, "variant"> & {
 	variant?: SDKCheckoutSettings["variant"] | "express";
 };

--- a/frontend/src/onboarding/agreement-page.flow.test.tsx
+++ b/frontend/src/onboarding/agreement-page.flow.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { MemoryRouter, Navigate, Route, Routes, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOnboardingStatus } from "../api/queries";
+import AgreementPage from "./agreement-page";
 
 const { get, post } = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }));
 vi.mock("../api/client", () => ({
@@ -16,9 +18,6 @@ vi.mock("../legal/load", () => ({
 	loadVersion: () => "# Terms\n\nMock terms content.",
 	sha256Hex: async () => "a".repeat(64),
 }));
-
-import { useOnboardingStatus } from "../api/queries";
-import AgreementPage from "./agreement-page";
 
 function LocationProbe() {
 	const loc = useLocation();

--- a/frontend/src/onboarding/onboard-billing-page.test.tsx
+++ b/frontend/src/onboarding/onboard-billing-page.test.tsx
@@ -5,6 +5,8 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type AuthAdapter, AuthContext } from "../auth/auth-context";
 import { ThemeProvider } from "../theme/theme-provider";
+// Import AFTER mocks so the hooks resolve against the mocked client.
+import OnboardBillingPage from "./onboard-billing-page";
 
 // Capture the Paddle eventCallback so the test can drive it (or refuse to).
 let capturedEventCallback: ((event: { name: string; data?: unknown }) => void) | undefined;
@@ -74,9 +76,6 @@ vi.mock("../api/client", () => ({
 	api: { get, post, patch, del },
 	setTokenGetter: vi.fn(),
 }));
-
-// Import AFTER mocks so the hooks resolve against the mocked client.
-import OnboardBillingPage from "./onboard-billing-page";
 
 const authAdapter: AuthAdapter = {
 	isLoaded: true,

--- a/frontend/src/onboarding/onboard-layout.test.tsx
+++ b/frontend/src/onboarding/onboard-layout.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { describe, expect, it, vi } from "vitest";
+import { useOnboardingStatus } from "../api/queries";
 import OnboardLayout from "./onboard-layout";
 
 const logout = vi.fn();
@@ -16,8 +17,6 @@ vi.mock("../theme/theme-toggle", () => ({
 vi.mock("../api/queries", () => ({
 	useOnboardingStatus: vi.fn(),
 }));
-
-import { useOnboardingStatus } from "../api/queries";
 
 type Steps = ("agreement" | "billing" | "tools" | "vault")[];
 

--- a/frontend/src/onboarding/onboard-tools-page.test.tsx
+++ b/frontend/src/onboarding/onboard-tools-page.test.tsx
@@ -4,6 +4,8 @@ import type React from "react";
 import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BillingStatus, OnboardingStatus } from "../api/queries";
+// Import after mocks
+import OnboardToolsPage from "./onboard-tools-page";
 
 const mutateAsync = vi.fn().mockResolvedValue({});
 
@@ -48,9 +50,6 @@ vi.mock("../config-context", async () => {
 		useConfig: () => ({ billingEnabled }) as ReturnType<typeof actual.useConfig>,
 	};
 });
-
-// Import after mocks
-import OnboardToolsPage from "./onboard-tools-page";
 
 function wrap(ui: React.ReactNode) {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/onboarding/onboarding-gate.test.tsx
+++ b/frontend/src/onboarding/onboarding-gate.test.tsx
@@ -2,13 +2,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { describe, expect, it, vi } from "vitest";
+import { useAppBootstrap } from "../api/queries";
 import OnboardingGate from "./onboarding-gate";
 
 vi.mock("../api/queries", () => ({
 	useAppBootstrap: vi.fn(),
 }));
-
-import { useAppBootstrap } from "../api/queries";
 
 // The gate reads onboarding state out of the consolidated bootstrap payload, so
 // wrap each onboarding status under `data.onboarding`.

--- a/frontend/src/onboarding/use-vault-ready-events.test.tsx
+++ b/frontend/src/onboarding/use-vault-ready-events.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type AuthAdapter, AuthContext } from "../auth/auth-context";
+import { useVaultReadyEvents } from "./use-vault-ready-events";
 
 const {
 	channelHandlers,
@@ -42,8 +43,6 @@ const {
 });
 
 vi.mock("phoenix", () => ({ Socket: socketCtor }));
-
-import { useVaultReadyEvents } from "./use-vault-ready-events";
 
 // getToken is the lynchpin: the hook's fire-and-forget connect() awaits it.
 // A getToken that rejects (or isn't a function) used to crash the vitest run

--- a/frontend/src/settings/account-page-local.test.tsx
+++ b/frontend/src/settings/account-page-local.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import AccountPageLocal from "./account-page-local";
 
 vi.mock("./account/profile-section-local", () => ({
 	ProfileSectionLocal: () => <div data-testid="profile" />,
@@ -16,8 +17,6 @@ vi.mock("./account/password-section-local", () => ({
 vi.mock("./account/danger-zone-section-local", () => ({
 	DangerZoneSectionLocal: () => <div data-testid="danger" />,
 }));
-
-import AccountPageLocal from "./account-page-local";
 
 describe("AccountPageLocal", () => {
 	it("renders every section in order", () => {

--- a/frontend/src/settings/account-page.test.tsx
+++ b/frontend/src/settings/account-page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { makeUser } from "./account/section-test-helpers";
+import AccountPage from "./account-page";
 
 vi.mock("@clerk/react", () => ({
 	useUser: () => ({ user: makeUser(), isLoaded: true }),
@@ -17,8 +18,6 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/theme/theme-provider", () => ({
 	useTheme: () => ({ theme: "system", resolved: "dark", setTheme: vi.fn() }),
 }));
-
-import AccountPage from "./account-page";
 
 describe("AccountPage", () => {
 	it("renders the section stack with no embedded Clerk UserProfile", () => {

--- a/frontend/src/settings/account/appearance-section.test.tsx
+++ b/frontend/src/settings/account/appearance-section.test.tsx
@@ -1,13 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppearanceSection } from "./appearance-section";
 
 const setTheme = vi.fn();
 let theme = "system";
 vi.mock("@/theme/theme-provider", () => ({
 	useTheme: () => ({ theme, resolved: "dark", setTheme }),
 }));
-
-import { AppearanceSection } from "./appearance-section";
 
 describe("AppearanceSection", () => {
 	beforeEach(() => {

--- a/frontend/src/settings/account/connected-accounts-section.test.tsx
+++ b/frontend/src/settings/account/connected-accounts-section.test.tsx
@@ -1,6 +1,7 @@
 import { isReverificationCancelledError } from "@clerk/react/errors";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectedAccountsSection } from "./connected-accounts-section";
 import { makeUser } from "./section-test-helpers";
 
 const googleAcct = {
@@ -20,8 +21,6 @@ vi.mock("@clerk/react/errors", () => ({
 	isReverificationCancelledError: vi.fn(() => false),
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { ConnectedAccountsSection } from "./connected-accounts-section";
 
 describe("ConnectedAccountsSection", () => {
 	beforeEach(() => {

--- a/frontend/src/settings/account/danger-zone-section-local.test.tsx
+++ b/frontend/src/settings/account/danger-zone-section-local.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DangerZoneSectionLocal } from "./danger-zone-section-local";
 
 const { logout, deleteMutate, navigate } = vi.hoisted(() => ({
 	logout: vi.fn(),
@@ -14,8 +15,6 @@ vi.mock("react-router", () => ({ useNavigate: () => navigate }));
 vi.mock("../../api/queries", () => ({
 	useDeleteSelf: () => ({ mutateAsync: deleteMutate, isPending: false }),
 }));
-
-import { DangerZoneSectionLocal } from "./danger-zone-section-local";
 
 beforeEach(() => {
 	logout.mockReset().mockResolvedValue(undefined);

--- a/frontend/src/settings/account/danger-zone-section.test.tsx
+++ b/frontend/src/settings/account/danger-zone-section.test.tsx
@@ -2,6 +2,7 @@ import { isReverificationCancelledError } from "@clerk/react/errors";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DangerZoneSection } from "./danger-zone-section";
 import { makeUser } from "./section-test-helpers";
 
 const signOut = vi.fn().mockResolvedValue({});
@@ -16,8 +17,6 @@ vi.mock("@clerk/react/errors", () => ({
 	isReverificationCancelledError: vi.fn(() => false),
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { DangerZoneSection } from "./danger-zone-section";
 
 describe("DangerZoneSection", () => {
 	beforeEach(() => {

--- a/frontend/src/settings/account/email-readonly-section.test.tsx
+++ b/frontend/src/settings/account/email-readonly-section.test.tsx
@@ -1,10 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { EmailReadonlySection } from "./email-readonly-section";
 
 const meData = { id: 1, email: "me@example.com", role: "member", display_name: null };
 vi.mock("../../api/queries", () => ({ useMe: () => ({ data: meData }) }));
-
-import { EmailReadonlySection } from "./email-readonly-section";
 
 describe("EmailReadonlySection", () => {
 	it("renders the user email", () => {

--- a/frontend/src/settings/account/email-section.test.tsx
+++ b/frontend/src/settings/account/email-section.test.tsx
@@ -1,6 +1,7 @@
 import { isReverificationCancelledError } from "@clerk/react/errors";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EmailSection } from "./email-section";
 import { makeUser } from "./section-test-helpers";
 
 const newEmail = {
@@ -41,8 +42,6 @@ vi.mock("@clerk/react/errors", () => ({
 	isReverificationCancelledError: vi.fn(() => false),
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { EmailSection } from "./email-section";
 
 describe("EmailSection", () => {
 	beforeEach(() => {

--- a/frontend/src/settings/account/password-section-local.test.tsx
+++ b/frontend/src/settings/account/password-section-local.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PasswordSectionLocal } from "./password-section-local";
 
 const { logout, apiPost, navigate } = vi.hoisted(() => ({
 	logout: vi.fn().mockResolvedValue(undefined),
@@ -16,8 +17,6 @@ vi.mock("../../api/client", () => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => navigate }));
-
-import { PasswordSectionLocal } from "./password-section-local";
 
 beforeEach(() => {
 	logout.mockReset().mockResolvedValue(undefined);

--- a/frontend/src/settings/account/password-section.test.tsx
+++ b/frontend/src/settings/account/password-section.test.tsx
@@ -2,6 +2,7 @@ import { isReverificationCancelledError } from "@clerk/react/errors";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PasswordSection } from "./password-section";
 import { makeUser } from "./section-test-helpers";
 
 let user = makeUser();
@@ -14,8 +15,6 @@ vi.mock("@clerk/react/errors", () => ({
 	isReverificationCancelledError: vi.fn(() => false),
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { PasswordSection } from "./password-section";
 
 describe("PasswordSection", () => {
 	beforeEach(() => {

--- a/frontend/src/settings/account/profile-section-local.test.tsx
+++ b/frontend/src/settings/account/profile-section-local.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProfileSectionLocal } from "./profile-section-local";
 
 const { updateMutate } = vi.hoisted(() => ({
 	updateMutate: vi.fn(),
@@ -17,8 +18,6 @@ vi.mock("../../api/queries", () => ({
 vi.mock("sonner", () => ({
 	toast: { success: vi.fn(), error: vi.fn() },
 }));
-
-import { ProfileSectionLocal } from "./profile-section-local";
 
 function wrap(ui: React.ReactNode) {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/settings/account/profile-section.test.tsx
+++ b/frontend/src/settings/account/profile-section.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProfileSection } from "./profile-section";
 import { makeUser } from "./section-test-helpers";
 
 const user = makeUser();
@@ -12,8 +13,6 @@ vi.mock("@clerk/react/errors", () => ({
 	isReverificationCancelledError: () => false,
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { ProfileSection } from "./profile-section";
 
 describe("ProfileSection", () => {
 	beforeEach(() => vi.clearAllMocks());

--- a/frontend/src/settings/account/sessions-section.test.tsx
+++ b/frontend/src/settings/account/sessions-section.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionsSection } from "./sessions-section";
 
 const current = {
 	id: "sess_current",
@@ -17,8 +18,6 @@ vi.mock("@clerk/react", () => ({
 	useSession: () => ({ session: { id: "sess_current" } }),
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { SessionsSection } from "./sessions-section";
 
 describe("SessionsSection", () => {
 	beforeEach(() => vi.clearAllMocks());

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -4,12 +4,6 @@ import { useEffect, useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogOverlay } from "@/components/ui/dialog";
-
-// Keep this in sync with the duration-200 class on DialogPrimitive.Content
-// below — we hold the dialog mounted for one animation cycle after
-// onOpenChange(false) so Radix's exit transition plays before we navigate.
-const CLOSE_ANIMATION_MS = 200;
-
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	Sheet,
@@ -21,6 +15,11 @@ import {
 import { useMe } from "../api/queries";
 import { useConfig } from "../config-context";
 import { buildSettingsSections, type SettingsSection } from "./sections";
+
+// Keep this in sync with the duration-200 class on DialogPrimitive.Content
+// below — we hold the dialog mounted for one animation cycle after
+// onOpenChange(false) so Radix's exit transition plays before we navigate.
+const CLOSE_ANIMATION_MS = 200;
 
 function SettingsNavList({
 	sections,

--- a/frontend/src/settings/vaults-page.test.tsx
+++ b/frontend/src/settings/vaults-page.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import VaultsPage from "./vaults-page";
 
 vi.mock("./vaults/active-vaults-section", () => ({
 	ActiveVaultsSection: () => <div>active-section</div>,
@@ -7,8 +8,6 @@ vi.mock("./vaults/active-vaults-section", () => ({
 vi.mock("./vaults/deleted-vaults-section", () => ({
 	DeletedVaultsSection: () => <div>deleted-section</div>,
 }));
-
-import VaultsPage from "./vaults-page";
 
 describe("VaultsPage", () => {
 	it("renders header + both sections (create flow lives inside ActiveVaultsSection)", () => {

--- a/frontend/src/settings/vaults/active-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActiveVaultsSection } from "./active-vaults-section";
 
 const deleteMutate = vi.fn();
 const updateMutate = vi.fn();
@@ -47,8 +48,6 @@ vi.mock("@/api/queries", () => ({
 	useBillingStatus: () => ({ data: billingState.current }),
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { ActiveVaultsSection } from "./active-vaults-section";
 
 describe("ActiveVaultsSection", () => {
 	beforeEach(() => {

--- a/frontend/src/settings/vaults/delete-vault-dialog.test.tsx
+++ b/frontend/src/settings/vaults/delete-vault-dialog.test.tsx
@@ -1,13 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DeleteVaultDialog } from "./delete-vault-dialog";
 
 const deleteMutate = vi.fn();
 vi.mock("@/api/queries", () => ({
 	useDeleteVault: () => ({ mutate: deleteMutate, isPending: false }),
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { DeleteVaultDialog } from "./delete-vault-dialog";
 
 const vault = {
 	id: "7",

--- a/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/deleted-vaults-section.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import type { ReactElement } from "react";
 import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DeletedVaultsSection } from "./deleted-vaults-section";
 
 const restoreMutate = vi.fn();
 const purgeMutate = vi.fn();
@@ -31,8 +32,6 @@ vi.mock("@/api/queries", () => ({
 	useBillingConfig: () => ({ data: { vaults_cap: cap } }),
 }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { DeletedVaultsSection } from "./deleted-vaults-section";
 
 function renderWithRouter(ui: ReactElement, { route = "/settings/vaults" } = {}) {
 	return render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>);

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
+import NotePage from "./note-page";
 
 const { openDoc, closeDoc, enroll } = vi.hoisted(() => ({
 	openDoc: vi.fn(),
@@ -24,8 +25,6 @@ vi.mock("react-router", () => ({ useParams: () => ({ id: "note-1" }) }));
 vi.mock("../layout/right-sidebar-context", () => ({
 	useRightSidebar: () => ({ setContent: () => {} }),
 }));
-
-import NotePage from "./note-page";
 
 const NOTE = {
 	id: "note-1",

--- a/frontend/src/viewer/pdf-view.test.tsx
+++ b/frontend/src/viewer/pdf-view.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { expect, it, vi } from "vitest";
+import PdfView from "./pdf-view";
 
 // pdf.js can't render in jsdom (canvas + worker), so stub react-pdf: Document
 // reports a fixed page count, Page renders a marker. This verifies PdfView's
@@ -21,8 +22,6 @@ vi.mock("react-pdf", () => ({
 		<div data-testid="pdf-page">page {pageNumber}</div>
 	),
 }));
-
-import PdfView from "./pdf-view";
 
 it("renders one Page per page reported by the document", async () => {
 	render(<PdfView url="blob:fake" filename="doc.pdf" />);

--- a/frontend/src/viewer/vault-item-page.test.tsx
+++ b/frontend/src/viewer/vault-item-page.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, expect, it, vi } from "vitest";
 import type { AttachmentSummary } from "../api/queries";
+import VaultItemPage from "./vault-item-page";
 
 // Stub both heavy viewers — this suite only verifies the note-vs-attachment
 // routing decision, not their rendering.
@@ -13,8 +14,6 @@ let mockLoading = false;
 vi.mock("../api/queries", () => ({
 	useAttachments: () => ({ data: mockAttachments, isLoading: mockLoading }),
 }));
-
-import VaultItemPage from "./vault-item-page";
 
 const att = (id: string): AttachmentSummary => ({
 	id,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.592",
+      version: "0.5.593",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Part of the Biome lint ratchet (tracking #812): re-enable one deferred rule per PR.

## This PR: \`nursery/useImportsFirst\` (52 sites, 40 files)

Requires all \`import\`/\`import type\` statements to precede any other statement. Fix: hoist the trailing imports into the top import block, preserving relative order; interspersed statements keep their order below.

- **Test files (38):** imports that sat after \`vi.mock(...)\` / \`vi.hoisted(...)\` / mock-helper blocks. vitest hoists \`vi.mock\` calls regardless of source position, so moving imports above them is behavior-preserving. No mock factory bodies or their ordering vs module-scope bindings were changed.
- **\`src/lib/paddle-sdk-types.ts\`:** the lone \`import type\` (with its comment) moved above the \`export ... from\` re-exports.
- **\`src/settings/settings-layout.tsx\`:** the interspersed \`const CLOSE_ANIMATION_MS\` (with comment) moved below the imports.

The \`organizeImports\` assist re-sorted the moved blocks. No autofix exists for the rule itself in Biome 2.5.1.

## Verification (local, post-rebase onto latest main)
- \`biome ci .\` clean (382 files)
- \`tsc --noEmit\` exit 0
- \`vitest run\` 672/672 pass (126 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)