### PR TITLE
docs(frontend): capture Biome mechanical-ratchet gotchas

### DIFF
--- a/frontend/docs/context/biome-linting.md
+++ b/frontend/docs/context/biome-linting.md
@@ -64,11 +64,66 @@ Intent lives in #812 and commit messages.
 5. Biome 2.5.1 uses `"preset": "recommended"` if you regenerate config; `migrate`
    renames the older `recommended: true` form.
 
+6. **`bun run ci` can't find `biome` locally** — the `ci` script calls bare `biome`,
+   which resolves via `node_modules/.bin` only in CI. To run the same gate locally
+   use `npx @biomejs/biome ci .` (or `bunx`). Same for one-off rule checks:
+   `npx @biomejs/biome lint --only=<group>/<rule> --max-diagnostics=none .`.
+
+7. **Most ratchet rules have NO autofix in 2.5.1 — plan for hand-fixing.** Verified
+   with `--write` and `--write --unsafe`: `useExportsLast`, `useImportsFirst`,
+   `useDestructuring`, `useNamedCaptureGroup`, and `noVoid` all report *"No fixes
+   applied."* — every site is hand-fixed. `lint:fix` does nothing for them. (The
+   `organizeImports` **assist** does re-sort, which matters for §8.) Measure a rule's
+   scope up front: `npx @biomejs/biome lint --only=<group>/<rule> --max-diagnostics=none . | grep -E "^Found"`.
+
+## Per-rule notes (learned while ratcheting — see #812)
+
+- **`useNamedCaptureGroup`** — a captured group must be named or made non-capturing.
+  Unused (match-only) groups → `(?:...)`. Groups read by index (`m[1]`, `?.[1]`) or
+  by a `replace` positional callback → add a name (`(?<x>...)`); named groups stay
+  **index-accessible** in JS, so `m[1]` keeps working — no call-site change needed.
+- **`useDestructuring`** — `const x = obj.x` → `const { x } = obj`; a single index read
+  (`arr[0]`, `token.split(".")[1]`) → array destructure (`const [x] = arr`,
+  `const [, base64] = ...`). Assignment to an outer `let` → `({ x } = obj)` (needs
+  parens).
+- **`useImportsFirst`** — imports must precede any other statement. Almost all
+  violations are vitest tests where imports sit after `vi.mock`/`vi.hoisted`. vitest
+  **hoists `vi.mock` to the top regardless of source order**, so moving the trailing
+  imports above the mocks is behavior-preserving. Do NOT reorder the mock factories or
+  their module-scope bindings. Verify with the **full** `vitest run` (mock ordering).
+- **`useExportsLast`** — all exported declarations must sit at the end. Reorder so
+  non-exports come first, exports last. TDZ risk: moving a `const`/`let`/`class` above
+  a binding it references throws at runtime. `function` decls hoist (safe);
+  `interface`/`type` are compile-erased (safe). Guard: after reordering run
+  `tsc --noEmit` and grep for `error TS2448|2454|2449` (use-before-declaration) — must
+  be zero — plus a full `vitest run`.
+- **`noVoid` is behavioral here, not mechanical** — every site is the deliberate
+  floating-promise idiom (`void promise().catch(...)`, `void logout()`,
+  `void import(...)`). Removing `void` either leaves an unhandled floating promise or
+  forces `await` (changes the caller). Handle it in the behavioral tier, not as a
+  mechanical sweep.
+
 ## Re-enabling a ratchet rule (the workflow)
 
 1. Pick a rule (or one cohesive group) from **issue #812**.
-2. Delete it from `overrides[0]` in `biome.json`.
-3. `bun run lint:fix`, then hand-fix residual violations (apply the unsafe-fix
-   caveats in §3/§4 as needed).
-4. Confirm `bun run ci` **and** `bunx tsc --noEmit` are both green.
-5. One rule / cohesive group **per PR** — don't batch unrelated rules.
+2. Measure scope (§7) and delete the rule from `overrides[0]` in `biome.json`.
+3. Try `npx @biomejs/biome lint --write [--unsafe] --only=<group>/<rule> .`; expect
+   NO autofix for the rules in §7 — hand-fix the sites (apply the §3/§4 caveats and
+   the per-rule notes above).
+4. If you moved imports, run `npx @biomejs/biome check --write .` once to let the
+   `organizeImports` assist re-sort the moved blocks (§8 territory).
+5. Confirm `npx @biomejs/biome ci .` **and** `npx tsc --noEmit` **and** the affected
+   (or full) `npx vitest run` are all green.
+6. One `mix.exs` version bump **per PR** (frontend is a deployable path → the
+   `version-check` gate). One rule / cohesive group per PR — don't batch unrelated
+   rules.
+
+## Progress (as of 2026-07-01)
+
+Mechanical tier **complete**: `noLeakedRender` (#826), `useNamedCaptureGroup` (#827),
+`useDestructuring` (#828), `useImportsFirst` (#830), `useExportsLast` (#831), on top of
+the earlier a11y tier. Remaining in #812: the **behavioral tier** (`noVoid`,
+`useExhaustiveDependencies`, `noEqualsToNull`, `noUnnecessaryConditions`, `useAwait`,
+`noShadow`, `noEmptyBlockStatements`, `noReturnAssign` — autofixes change semantics,
+hand-review each) and config-gated `useAtIndex` (its `.at(-1)` autofix needs a tsconfig
+`lib` → es2022 bump in the same PR).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.594",
+      version: "0.5.595",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Owed follow-up for the Biome ratchet (tracking #812). Documents what the mechanical tier taught us so the next session doesn't rediscover it.

Adds to \`frontend/docs/context/biome-linting.md\`:
- The mechanical rules have **no autofix** in Biome 2.5.1 (verified with \`--write --unsafe\`) — every site is hand-fixed.
- Per-rule notes: \`useNamedCaptureGroup\` (named groups stay index-accessible), \`useDestructuring\`, \`useImportsFirst\` (vitest hoists \`vi.mock\`, so import moves are safe; verify with full \`vitest run\`), \`useExportsLast\` (TDZ guard via \`tsc\` TS2448/2454/2449 + full vitest), and \`noVoid\` is **behavioral** (floating-promise idiom), not mechanical.
- Local invocation gotcha (\`bun run ci\` can't find \`biome\`; use \`npx @biomejs/biome ci .\`).
- A progress marker: mechanical tier complete (#826/#827/#828/#830/#831); behavioral tier + config-gated \`useAtIndex\` remain.

Docs-only; the \`mix.exs\` bump is just to satisfy the deployable-path version gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)