### PR TITLE
chore(frontend): ratchet suspicious noEqualsToNull

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -142,7 +142,6 @@
 						"noAlert": "off",
 						"noConsole": { "level": "error", "options": { "allow": ["error", "warn"] } },
 						"noEmptyBlockStatements": "off",
-						"noEqualsToNull": "off",
 						"noReturnAssign": "off",
 						"noShadow": "off",
 						"noSkippedTests": "off",

--- a/frontend/src/api/active-vault.ts
+++ b/frontend/src/api/active-vault.ts
@@ -19,7 +19,7 @@ function readStored(): string | null {
 
 function writeStored(id: string | null) {
 	try {
-		if (id == null) {
+		if (id === null) {
 			localStorage.removeItem(STORAGE_KEY);
 		} else {
 			localStorage.setItem(STORAGE_KEY, id);

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -170,7 +170,7 @@ export function handleNoteChanged(
 		return;
 	}
 
-	if (payload.id != null) {
+	if (payload.id !== undefined) {
 		queryClient.invalidateQueries({ queryKey: ["note", activeVaultId, payload.id] });
 	}
 	// Legacy path-keyed key still in use by some hooks; keep invalidating it.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,7 +20,7 @@ async function authFetch(path: string, options: RequestInit = {}): Promise<Respo
 		headers.set("Authorization", `Bearer ${token}`);
 	}
 	const vaultId = getActiveVaultId();
-	if (vaultId != null) {
+	if (vaultId !== null) {
 		headers.set("X-Vault-ID", String(vaultId));
 	}
 	headers.set("X-Device-Id", getDeviceId());

--- a/frontend/src/api/cursor-sync.ts
+++ b/frontend/src/api/cursor-sync.ts
@@ -40,7 +40,7 @@ function stillActive(vaultId: string): boolean {
 
 async function doCursorSync(vaultId: string, queryClient: QueryClient): Promise<void> {
 	const cursor = getCursor(vaultId);
-	if (cursor == null) {
+	if (cursor === null) {
 		const seeded = await bootstrap();
 		if (stillActive(vaultId)) {
 			setCursor(vaultId, seeded);

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -35,7 +35,7 @@ function encodePathSegments(path: string): string {
 const selectFolders = (data: { folders: Array<Folder & { id: string | null }> }): Folder[] =>
 	data.folders
 		.filter((f) => f.name !== "")
-		.map((f) => (f.id == null ? { ...f, id: syntheticFolderId(f.name) } : (f as Folder)));
+		.map((f) => (f.id === null ? { ...f, id: syntheticFolderId(f.name) } : (f as Folder)));
 
 const selectNotes = (data: { notes: NoteSummary[] }) => data.notes;
 
@@ -215,7 +215,7 @@ function collectFolderDescendants(folders: Folder[], rootIds: string[]): Set<str
 	while (changed) {
 		changed = false;
 		for (const f of folders) {
-			if (f.parent_id != null && result.has(f.parent_id) && !result.has(f.id)) {
+			if (f.parent_id !== null && result.has(f.parent_id) && !result.has(f.id)) {
 				result.add(f.id);
 				changed = true;
 			}
@@ -454,7 +454,7 @@ export function useFolderNotesById(folderId: string | null, opts: { enabled?: bo
 	return useQuery({
 		queryKey: ["folder-notes-by-id", vaultId, folderId],
 		queryFn: () => fetchNotesForFolderId(folderId as string),
-		enabled: folderId != null && (opts.enabled ?? true),
+		enabled: folderId !== null && (opts.enabled ?? true),
 		staleTime: FOLDER_NOTES_STALE_MS,
 	});
 }
@@ -464,7 +464,7 @@ export function useNote(id: string | null) {
 	return useQuery({
 		queryKey: ["note", vaultId, id],
 		queryFn: () => fetchNoteById(id as string),
-		enabled: id != null,
+		enabled: id !== null,
 	});
 }
 
@@ -484,7 +484,7 @@ export function useUpdateNote() {
 			// path. Invalidate the specific id when the server returns it,
 			// and refresh folder listings so the title/mtime stay current.
 			const id = data?.note?.id;
-			if (id != null) {
+			if (id !== undefined) {
 				qc.invalidateQueries({ queryKey: ["note", vaultId, id] });
 			}
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
@@ -539,7 +539,7 @@ export function useCreateNote() {
 		onMutate: async ({ folder }) => {
 			const folderId = folderIdForPath(qc, vaultId, folder);
 			// Unknown non-root folder not in the cache yet — skip; surfaces on expand.
-			if (folderId == null) {
+			if (folderId === null) {
 				return;
 			}
 			const key = ["folder-notes-by-id", vaultId, folderId] as const;
@@ -1368,7 +1368,7 @@ export function useRenameNote() {
 			const fromList = oldFolderNotes?.notes.find((n) => n.path === old_path);
 			let noteId: string | null = fromList?.id ?? null;
 			let prevNote: Note | undefined;
-			if (noteId == null) {
+			if (noteId === null) {
 				const cached = qc
 					.getQueryCache()
 					.findAll({ queryKey: ["note", vaultId] })
@@ -1414,7 +1414,9 @@ export function useRenameNote() {
 			// Remove from old list (by id when we have it, by path otherwise).
 			if (oldFolderNotes) {
 				updateCachedList<NoteSummary>(qc, oldListKey, (prev) => ({
-					notes: prev.notes.filter((n) => (noteId == null ? n.path !== old_path : n.id !== noteId)),
+					notes: prev.notes.filter((n) =>
+						noteId === null ? n.path !== old_path : n.id !== noteId,
+					),
 				}));
 			}
 
@@ -1422,7 +1424,7 @@ export function useRenameNote() {
 			if (renamedSummary && newFolderNotes) {
 				updateCachedList<NoteSummary>(qc, newListKey, (prev) => ({
 					notes: [
-						...prev.notes.filter((n) => (noteId == null ? n.path !== new_path : n.id !== noteId)),
+						...prev.notes.filter((n) => (noteId === null ? n.path !== new_path : n.id !== noteId)),
 						renamedSummary,
 					],
 				}));
@@ -1467,7 +1469,7 @@ export function useRenameNote() {
 			// change. Update those fields in place under the SAME cache key
 			// (`['note', vaultId, id]`). No key shuffle: any subscriber to
 			// useNote(id) sees the new fields without remounting.
-			if (noteId != null && prevNote) {
+			if (noteId !== null && prevNote) {
 				qc.setQueryData<Note>(["note", vaultId, noteId], {
 					...prevNote,
 					path: new_path,
@@ -1493,7 +1495,7 @@ export function useRenameNote() {
 			if (ctx.folders !== undefined) {
 				qc.setQueryData(foldersKey, ctx.folders);
 			}
-			if (ctx.noteId != null && ctx.prevNote !== undefined) {
+			if (ctx.noteId !== null && ctx.prevNote !== undefined) {
 				qc.setQueryData(["note", vaultId, ctx.noteId], ctx.prevNote);
 			}
 			renameErrorToast(err, "file");
@@ -1829,7 +1831,7 @@ export function useDuplicateNote() {
 			// Drop the placeholder into the id-keyed list the tree reads (root or
 			// subfolder). Only patch when cached; otherwise it lands on the next
 			// expand fetch. Cancel first so an in-flight refetch can't clobber it.
-			if (targetId != null) {
+			if (targetId !== null) {
 				const key = ["folder-notes-by-id", vaultId, targetId] as const;
 				await qc.cancelQueries({ queryKey: key });
 				const snapshot = qc.getQueryData<NoteSummary[]>(key);

--- a/frontend/src/api/use-channel.ts
+++ b/frontend/src/api/use-channel.ts
@@ -24,7 +24,7 @@ export function useChannel() {
 	}, [getToken]);
 
 	useEffect(() => {
-		if (!user || vaultId == null) {
+		if (!user || vaultId === null) {
 			return;
 		}
 

--- a/frontend/src/billing/format.ts
+++ b/frontend/src/billing/format.ts
@@ -7,7 +7,12 @@ export function formatMoney(
 	currency: string | null | undefined,
 	locale?: string,
 ): string | null {
-	if (minorUnits == null || currency == null) {
+	if (
+		minorUnits === null ||
+		minorUnits === undefined ||
+		currency === null ||
+		currency === undefined
+	) {
 		return null;
 	}
 

--- a/frontend/src/billing/use-subscription-activated-events.ts
+++ b/frontend/src/billing/use-subscription-activated-events.ts
@@ -28,7 +28,7 @@ export function useSubscriptionActivatedEvents({ userId, enabled, onActivated }:
 	const { getToken } = useAuthAdapter();
 
 	useEffect(() => {
-		if (!enabled || userId == null) {
+		if (!enabled || userId === null || userId === undefined) {
 			return;
 		}
 

--- a/frontend/src/components/checkout-summary.tsx
+++ b/frontend/src/components/checkout-summary.tsx
@@ -124,7 +124,7 @@ export function CheckoutSummary({
 						<dd className="tabular-nums">{formatMoney(subtotal, currency)}</dd>
 					</div>
 
-					{discount != null && discount > 0 && (
+					{discount !== null && discount !== undefined && discount > 0 && (
 						<div className="flex justify-between text-success-foreground">
 							<dt>Discount</dt>
 							<dd className="tabular-nums">−{formatMoney(discount, currency)}</dd>

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -216,7 +216,7 @@ function DeviceLinkPage() {
 					{step === "pick-vault" ? "Choose a vault to sync" : "Link Obsidian Vault"}
 				</h1>
 
-				{capCheck.swapCooldownHours != null && step !== "success" ? (
+				{capCheck.swapCooldownHours !== null && step !== "success" ? (
 					// Cooldown gates the Sync button (line 319) regardless of whether
 					// an active device still exists — the backend rejects a new family
 					// inside the swap window. Render the banner on cooldown alone, not
@@ -316,7 +316,7 @@ function DeviceLinkPage() {
 						<Button
 							type="button"
 							onClick={handleAuthorize}
-							disabled={loading || !canAuthorize || capCheck.swapCooldownHours != null}
+							disabled={loading || !canAuthorize || capCheck.swapCooldownHours !== null}
 							className="w-full"
 						>
 							{loading ? "Syncing…" : "Sync"}
@@ -354,7 +354,7 @@ function SuccessStep({ linkedVaultId, onForward }: SuccessStepProps) {
 	// on `linkedVaultId` so we only forward for THIS link session — broadcasts
 	// from an unrelated vault won't shove us anywhere.
 	useEffect(() => {
-		if (vaultPopulated && vaultId != null && vaultId === linkedVaultId) {
+		if (vaultPopulated && vaultId !== null && vaultId === linkedVaultId) {
 			onForward();
 		}
 	}, [vaultPopulated, vaultId, linkedVaultId, onForward]);

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -42,14 +42,14 @@ function DesktopLayout() {
 	};
 
 	useEffect(() => {
-		if (rightContent == null) {
+		if (rightContent === null || rightContent === undefined) {
 			rightRef.current?.collapse();
 		} else if (rightRef.current?.isCollapsed()) {
 			rightRef.current?.expand();
 		}
 	}, [rightContent]);
 
-	const hasRight = rightContent != null;
+	const hasRight = rightContent !== null && rightContent !== undefined;
 
 	return (
 		<section className="flex h-screen bg-background text-foreground">

--- a/frontend/src/layout/search-panel.tsx
+++ b/frontend/src/layout/search-panel.tsx
@@ -120,7 +120,7 @@ function RecentList({ recent, onPick }: { recent: string[]; onPick: (q: string) 
 
 function ResultRow({ result }: { result: SearchResult }) {
 	// Orphan hits (no id) are unreachable — render nothing.
-	if (result.id == null) {
+	if (result.id === null) {
 		return null;
 	}
 	const href = `/note/${result.id}`;

--- a/frontend/src/layout/vault-switcher.tsx
+++ b/frontend/src/layout/vault-switcher.tsx
@@ -20,7 +20,7 @@ function VaultSwitcher() {
 		if (!vaults || vaults.length === 0) {
 			return;
 		}
-		const stillValid = activeId != null && vaults.some((v) => v.id === activeId);
+		const stillValid = activeId !== null && vaults.some((v) => v.id === activeId);
 		if (stillValid) {
 			return;
 		}

--- a/frontend/src/lib/active-folder.ts
+++ b/frontend/src/lib/active-folder.ts
@@ -8,7 +8,7 @@ export function useActiveFolder(): string {
 	const id = params.id ?? null;
 	const vaultId = useActiveVaultId();
 	const qc = useQueryClient();
-	if (id == null || id === "") {
+	if (id === null || id === "") {
 		return "";
 	}
 	const note = qc.getQueryData<Note>(["note", vaultId, id]);

--- a/frontend/src/lib/checkout-summary-utils.ts
+++ b/frontend/src/lib/checkout-summary-utils.ts
@@ -72,9 +72,11 @@ export function mapCheckoutEventsToSummary(data: CheckoutEventsInput): CheckoutS
 	let recurringTotal: number | undefined;
 	let recurringInterval: string | undefined;
 	let recurringFrequency: number | undefined;
-	const firstRecurringItem = data.items?.find((item) => item.billing_cycle != null);
+	const firstRecurringItem = data.items?.find(
+		(item) => item.billing_cycle !== null && item.billing_cycle !== undefined,
+	);
 	const billingCycle = firstRecurringItem?.billing_cycle;
-	if (billingCycle && recurringTotals?.total != null) {
+	if (billingCycle && recurringTotals?.total !== null && recurringTotals?.total !== undefined) {
 		recurringTotal = recurringTotals.total;
 		recurringInterval = billingCycle.interval;
 		recurringFrequency = billingCycle.frequency;
@@ -82,7 +84,9 @@ export function mapCheckoutEventsToSummary(data: CheckoutEventsInput): CheckoutS
 
 	// Build trial period label from the first item that has a trial period.
 	let trialPeriod: string | undefined;
-	const firstTrialItem = data.items?.find((item) => item.trial_period != null);
+	const firstTrialItem = data.items?.find(
+		(item) => item.trial_period !== null && item.trial_period !== undefined,
+	);
 	if (firstTrialItem?.trial_period) {
 		trialPeriod = formatTrialPeriod(firstTrialItem.trial_period);
 	}

--- a/frontend/src/lib/plan-change-breakdown-utils.ts
+++ b/frontend/src/lib/plan-change-breakdown-utils.ts
@@ -85,7 +85,7 @@ interface BreakdownPreviewResponse {
 
 function mapLineItems(items: LineItem[], currencyCode: string): PlanChangeLineItemData[] {
 	return items.map((item) => {
-		const hasProration = item.proration != null;
+		const hasProration = item.proration !== undefined;
 		let prorationPeriod: string | undefined;
 
 		if (hasProration && item.proration) {

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -237,7 +237,7 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
 	// Auto-commit + activate once the plugin has actually written notes, so
 	// the user is hands-off the moment their first sync lands.
 	useEffect(() => {
-		if (vaultPopulated && vaultId != null && !isCommitting) {
+		if (vaultPopulated && vaultId !== null && !isCommitting) {
 			setActiveVaultId(vaultId);
 			void onCommit();
 		}

--- a/frontend/src/onboarding/onboarding-gate.test.tsx
+++ b/frontend/src/onboarding/onboarding-gate.test.tsx
@@ -13,7 +13,7 @@ vi.mock("../api/queries", () => ({
 // wrap each onboarding status under `data.onboarding`.
 function renderWith(onboarding: unknown, rest: Record<string, unknown> = {}) {
 	vi.mocked(useAppBootstrap).mockReturnValue({
-		data: onboarding == null ? undefined : { onboarding },
+		data: onboarding === null || onboarding === undefined ? undefined : { onboarding },
 		isLoading: false,
 		isError: false,
 		...rest,

--- a/frontend/src/onboarding/use-vault-ready-events.ts
+++ b/frontend/src/onboarding/use-vault-ready-events.ts
@@ -32,7 +32,7 @@ export function useVaultReadyEvents({ userId, enabled }: Options): State {
 	const [state, setState] = useState<State>(INITIAL);
 
 	useEffect(() => {
-		if (!enabled || userId == null) {
+		if (!enabled || userId === null || userId === undefined) {
 			return;
 		}
 

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -62,7 +62,7 @@ function ConnectionCard({
 	onRevoke: () => void;
 }) {
 	const vaultLabel =
-		connection.vault_id == null
+		connection.vault_id === null
 			? "All vaults"
 			: (connection.vault_name ?? `#${connection.vault_id}`);
 
@@ -609,8 +609,8 @@ export default function ConnectionsPage() {
 	const pats = list.filter((c) => c.kind === "pat");
 
 	const obsCount =
-		caps.obsidianCap == null ? `${obs.length}` : `${obs.length} / ${caps.obsidianCap}`;
-	const mcpCount = caps.mcpCap == null ? `${mcp.length}` : `${mcp.length} / ${caps.mcpCap}`;
+		caps.obsidianCap === null ? `${obs.length}` : `${obs.length} / ${caps.obsidianCap}`;
+	const mcpCount = caps.mcpCap === null ? `${mcp.length}` : `${mcp.length} / ${caps.mcpCap}`;
 
 	return (
 		<article className="space-y-8">

--- a/frontend/src/settings/vaults/active-vaults-section.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.tsx
@@ -106,7 +106,7 @@ export function ActiveVaultsSection() {
 	const vaultsCap = billing?.caps.vaults ?? null;
 	const vaultCount = vaults?.length ?? 0;
 	const atCap = typeof vaultsCap === "number" && vaultsCap > 0 && vaultCount >= vaultsCap;
-	const titleSuffix = vaultsCap == null ? "" : ` (${vaultCount} / ${vaultsCap})`;
+	const titleSuffix = vaultsCap === null ? "" : ` (${vaultCount} / ${vaultsCap})`;
 
 	return (
 		<SettingsSectionCard

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -243,7 +243,7 @@ export default function FolderTree() {
 	// where they are after navigation. Mirrors the old recursive
 	// `containsSelected` behaviour but driven by HT's expand API.
 	useEffect(() => {
-		if (selectedNoteId == null || !folders) {
+		if (selectedNoteId === null || !folders) {
 			return;
 		}
 		const note = qc.getQueryData<Note>(["note", vaultId, selectedNoteId]);

--- a/frontend/src/viewer/property-fields.tsx
+++ b/frontend/src/viewer/property-fields.tsx
@@ -14,7 +14,7 @@ const inputCls =
 	"w-full rounded border border-border bg-transparent px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring";
 
 function ScalarField({ type, value, onCommit, onFocusChange }: FieldProps) {
-	const initial = value == null ? "" : String(value);
+	const initial = value === null || value === undefined ? "" : String(value);
 	const [draft, setDraft] = useState(initial);
 	const inputRef = useRef<HTMLInputElement>(null);
 	useEffect(() => {

--- a/frontend/src/viewer/property-types.ts
+++ b/frontend/src/viewer/property-types.ts
@@ -8,7 +8,7 @@ const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 const DATE_TIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/;
 
 function scalarToString(v: unknown): string {
-	if (v == null) {
+	if (v === null || v === undefined) {
 		return "";
 	}
 	if (typeof v === "string") {
@@ -55,7 +55,7 @@ export function coerceValue(value: unknown, to: PropertyType): unknown {
 			if (Array.isArray(value)) {
 				return value;
 			}
-			if (value === "" || value == null) {
+			if (value === "" || value === null || value === undefined) {
 				return [];
 			}
 			return [scalarToString(value)];
@@ -63,7 +63,7 @@ export function coerceValue(value: unknown, to: PropertyType): unknown {
 			if (Array.isArray(value)) {
 				return value.map(scalarToString).join(", ");
 			}
-			if (value == null) {
+			if (value === null || value === undefined) {
 				return "";
 			}
 			return scalarToString(value);
@@ -78,7 +78,7 @@ export function coerceValue(value: unknown, to: PropertyType): unknown {
 			return Boolean(value) && scalarToString(value) !== "false" && scalarToString(value) !== "";
 		case "date":
 		case "datetime":
-			return value == null ? "" : scalarToString(value);
+			return value === null || value === undefined ? "" : scalarToString(value);
 		default:
 			return value;
 	}

--- a/frontend/src/viewer/tree/drop-redirect.ts
+++ b/frontend/src/viewer/tree/drop-redirect.ts
@@ -18,7 +18,7 @@ export function resolveDropMove(
 ): { dest: string; ids: string[] } | null {
 	// A root destination is allowed (move to vault root). Only a missing target
 	// is a no-op. Sources already at root are filtered below.
-	if (destId == null) {
+	if (destId === undefined) {
 		return null;
 	}
 	const ids = sources.filter((s) => s.parentId !== destId).map((s) => s.id);

--- a/frontend/src/viewer/tree/synthesize-folders.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.ts
@@ -75,7 +75,7 @@ export function synthesizeFolders(real: Folder[], attachments: AttachmentSummary
 			const parentName = slash < 0 ? null : name.slice(0, slash);
 			return {
 				id: idFor(name),
-				parent_id: parentName == null ? null : idFor(parentName),
+				parent_id: parentName === null ? null : idFor(parentName),
 				name,
 				count: real ? real.count : 0,
 			};

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.595",
+      version: "0.5.596",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
First rule of the **behavioral tier** of the Biome ratchet (tracking #812). Unlike the mechanical tier, this rule's autofix changes semantics, so every site was hand-fixed by operand type.

## This PR: \`suspicious/noEqualsToNull\` (48 sites)

Biome's only fix is the **unsafe** `== null` → `=== null`, which is a bug wherever the operand can be `undefined` (the loose `== null` idiom matches null **and** undefined). Fixed precisely per operand type:

- **`=== null` / `!== null`** where the operand is `X | null` (28 sites) — vault ids, folder/note ids, `?? null` results, `Connection.vault_id`, caps, etc.
- **`=== undefined` / `!== undefined`** where the operand is `X | undefined` (4 sites) — optional props (`payload.id?`, `item.proration?`), optional-chained reads (`data?.note?.id`), `destId: string | undefined`.
- **explicit `x === null || x === undefined`** where the operand is `X | null | undefined`, `unknown`, or `ReactNode` (16 sites) — `formatMoney` args, `userId`, `discount`, `AppLayout` content, property-editor `value`/`unknown`, checkout-summary totals.

Operand types were read from declarations (params, interfaces, hook return types); `tsc` guards against a wrong choice compiling.

## Verification (local)
- `biome ci .` clean (382 files, rule enabled)
- `tsc --noEmit` exit 0
- `vitest run` 672/672 pass (126 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)