### PR TITLE
chore(frontend): ratchet complexity noVoid

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -74,8 +74,7 @@
 						"noExcessiveLinesPerFunction": "off",
 						"useMaxParams": "off",
 						"noExcessiveCognitiveComplexity": "off",
-						"noForEach": "off",
-						"noVoid": "off"
+						"noForEach": "off"
 					},
 					"correctness": {
 						"useQwikValidLexicalScope": "off",

--- a/frontend/docs/context/biome-linting.md
+++ b/frontend/docs/context/biome-linting.md
@@ -97,11 +97,32 @@ Intent lives in #812 and commit messages.
   `interface`/`type` are compile-erased (safe). Guard: after reordering run
   `tsc --noEmit` and grep for `error TS2448|2454|2449` (use-before-declaration) — must
   be zero — plus a full `vitest run`.
-- **`noVoid` is behavioral here, not mechanical** — every site is the deliberate
-  floating-promise idiom (`void promise().catch(...)`, `void logout()`,
-  `void import(...)`). Removing `void` either leaves an unhandled floating promise or
-  forces `await` (changes the caller). Handle it in the behavioral tier, not as a
-  mechanical sweep.
+- **`noVoid`** — every site was the fire-and-forget idiom (`void promise().catch(...)`,
+  `void logout()`, `void import(...)`). Biome has **no** type-aware floating-promise
+  rule, so simply dropping `void` is behavior-identical (`void expr` and `expr` both
+  evaluate + discard the promise) and trips nothing. For `() => void logout()` in a
+  `() => void`-typed handler, use a block body (`() => { logout(); }`) to keep the
+  undefined return. One `void page;` unused-param marker in a skipped e2e test was fixed
+  by dropping the unused `{ page }` param instead.
+- **`noEqualsToNull` needs per-operand types, NOT the `=== null` autofix** — the loose
+  `x == null` idiom matches null AND undefined; Biome's unsafe fix rewrites to `=== null`
+  (null only), a silent bug wherever the operand can be `undefined`. Fix by type:
+  `=== null` for `X | null`, `=== undefined` for `X | undefined` (optional props,
+  `?.` reads), explicit `x === null || x === undefined` for `X | null | undefined` /
+  `unknown` / `ReactNode`. `tsc` won't catch a wrong choice. Done (#833).
+- **`suspicious/noUnnecessaryConditions` is PERMANENTLY OFF — do not ratchet it.** Biome's
+  flow/type analysis is weaker than `tsc`'s and produces ~15/17 false positives here:
+  loop-mutated counters (`if (deleted)` where `deleted++`) flagged "always falsy";
+  `RegExp.exec()` null guards flagged constant; closure-captured mutable flags flagged
+  "always falsy"; a reachable `switch (x: string)` flagged "unreachable case" (Biome type
+  bug); and necessary `?.` on `| null`/`| undefined` operands flagged "unnecessary".
+  Enabling it would need ~15 `biome-ignore` on correct code. Treat like the framework-wrong
+  rules in `overrides[0]`, not a deferred target.
+
+**Measure with the rule's REAL group.** `--only=<group>/<rule>` silently reports zero for a
+wrong group (e.g. `--only=style/noShadow` → 0, but the rule is `suspicious/noShadow` → 41).
+The group in `biome.json`'s override is authoritative; confirm the count is non-zero before
+concluding a rule is already satisfied.
 
 ## Re-enabling a ratchet rule (the workflow)
 
@@ -122,8 +143,11 @@ Intent lives in #812 and commit messages.
 
 Mechanical tier **complete**: `noLeakedRender` (#826), `useNamedCaptureGroup` (#827),
 `useDestructuring` (#828), `useImportsFirst` (#830), `useExportsLast` (#831), on top of
-the earlier a11y tier. Remaining in #812: the **behavioral tier** (`noVoid`,
-`useExhaustiveDependencies`, `noEqualsToNull`, `noUnnecessaryConditions`, `useAwait`,
-`noShadow`, `noEmptyBlockStatements`, `noReturnAssign` — autofixes change semantics,
-hand-review each) and config-gated `useAtIndex` (its `.at(-1)` autofix needs a tsconfig
+the earlier a11y tier.
+
+Behavioral tier in progress: `noEqualsToNull` (#833), `noReturnAssign` (#834) merged,
+`noVoid` this PR. `noUnnecessaryConditions` dropped as permanently-off (see per-rule
+note above). Remaining in #812: `useExhaustiveDependencies` (~29, highest bug-value,
+riskiest autofix), `useAwait` (~31), `noShadow` (~41), `noEmptyBlockStatements` (~116) —
+all hand-review; plus config-gated `useAtIndex` (its `.at(-1)` autofix needs a tsconfig
 `lib` → es2022 bump in the same PR).

--- a/frontend/e2e/onboarding-ftux.spec.ts
+++ b/frontend/e2e/onboarding-ftux.spec.ts
@@ -182,12 +182,11 @@ test.describe("FTUX happy path", () => {
 		await expect(page.getByRole("heading", { name: /first vault/iu })).toHaveCount(0);
 	});
 
-	test("completing device-link flow ticks the plugin checklist item", async ({ page }) => {
+	test("completing device-link flow ticks the plugin checklist item", async () => {
 		// This test requires triggering the backend device-flow exchange end-to-end.
 		// No harness helper exists yet — skipping with a clear signal so the rest of
 		// the suite still runs. File a follow-up issue to add a device-flow helper
 		// and unskip this test.
-		void page;
 		test.skip(true, "requires device-flow helper — see follow-up issue");
 
 		// Sketch:

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -293,7 +293,7 @@ export async function connectChannel({
 	const crdtTopic = `crdt:${userId}:${vaultId}`;
 	crdtChannel = socket.channel(crdtTopic, { crdt_proto: 2 });
 	crdtChannel.on("crdt_msg", (p: { doc_id: string; b64: string }) => {
-		void crdtHandleFrame(docPathFromDocId(p.doc_id), p.b64).catch((err) =>
+		crdtHandleFrame(docPathFromDocId(p.doc_id), p.b64).catch((err) =>
 			console.warn("CRDT frame handling error (dropped)", err),
 		);
 	});

--- a/frontend/src/crdt/enrollment.ts
+++ b/frontend/src/crdt/enrollment.ts
@@ -23,7 +23,7 @@ export class CrdtEnrollment {
 			return;
 		}
 		this.enrolled.add(path);
-		void this.startSync(path).then(() => this.onAfterEnroll?.(path));
+		this.startSync(path).then(() => this.onAfterEnroll?.(path));
 	}
 
 	reset(path: string): void {

--- a/frontend/src/crdt/manager.ts
+++ b/frontend/src/crdt/manager.ts
@@ -77,7 +77,7 @@ export class CrdtManager {
 			return;
 		}
 		e.doc.destroy();
-		void e.persistence.destroy();
+		e.persistence.destroy();
 		this.docs.delete(id);
 	}
 

--- a/frontend/src/crdt/session.ts
+++ b/frontend/src/crdt/session.ts
@@ -91,7 +91,7 @@ export function stopCrdtSession(): void {
 	for (const a of session.awareness.values()) {
 		a.destroy();
 	}
-	void session.manager.destroy().catch((e) => console.warn("CRDT session teardown error", e));
+	session.manager.destroy().catch((e) => console.warn("CRDT session teardown error", e));
 	session = null;
 }
 

--- a/frontend/src/layout/user-menu.tsx
+++ b/frontend/src/layout/user-menu.tsx
@@ -70,7 +70,12 @@ export default function UserMenu() {
 					))}
 				</DropdownMenuRadioGroup>
 				<DropdownMenuSeparator />
-				<DropdownMenuItem className="gap-2.5 px-3 py-2.5 text-sm" onSelect={() => void logout()}>
+				<DropdownMenuItem
+					className="gap-2.5 px-3 py-2.5 text-sm"
+					onSelect={() => {
+						logout();
+					}}
+				>
 					<LogOut className="h-4 w-4" />
 					Sign out
 				</DropdownMenuItem>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -62,7 +62,7 @@ if (cfBeaconToken) {
 const posthogKey = import.meta.env.VITE_POSTHOG_KEY;
 const posthogHost = import.meta.env.VITE_POSTHOG_HOST ?? "https://us.i.posthog.com";
 if (posthogKey) {
-	void import("posthog-js").then(({ default: posthog }) => {
+	import("posthog-js").then(({ default: posthog }) => {
 		posthog.init(posthogKey, {
 			api_host: posthogHost,
 			persistence: "memory",

--- a/frontend/src/onboarding/checklist-widget.tsx
+++ b/frontend/src/onboarding/checklist-widget.tsx
@@ -98,7 +98,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
 			return { ...prev, actions: [...prev.actions, action] };
 		});
 
-		void ob.recordAsync(action).catch(() => {
+		ob.recordAsync(action).catch(() => {
 			// The mutation hook already retries 3× — reaching here means the
 			// server rejected. Roll back by invalidating so the next refetch
 			// restores the real cache state.

--- a/frontend/src/onboarding/onboard-vault-page.tsx
+++ b/frontend/src/onboarding/onboard-vault-page.tsx
@@ -239,7 +239,7 @@ function ObsidianInlinePanel({ userId, isCommitting, onCommit }: ObsidianInlineP
 	useEffect(() => {
 		if (vaultPopulated && vaultId !== null && !isCommitting) {
 			setActiveVaultId(vaultId);
-			void onCommit();
+			onCommit();
 		}
 	}, [vaultPopulated, vaultId, isCommitting, onCommit]);
 

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -176,7 +176,7 @@ export default function FolderTree() {
 	// so we don't fetch twice if the user clicks before the hover resolves.
 	const prefetchFolderNotes = useCallback(
 		(folderId: string) => {
-			void qc.prefetchQuery({
+			qc.prefetchQuery({
 				queryKey: ["folder-notes-by-id", vaultId, folderId],
 				queryFn: () => fetchFolderNotes(folderId),
 				staleTime: FOLDER_NOTES_STALE_MS,

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -50,7 +50,7 @@ export default function NotePage() {
 			return;
 		}
 		let cancelled = false;
-		void openDoc(path).then((h) => {
+		openDoc(path).then((h) => {
 			if (cancelled || !h) {
 				return;
 			}

--- a/frontend/src/viewer/tree/loader.test.ts
+++ b/frontend/src/viewer/tree/loader.test.ts
@@ -237,7 +237,7 @@ describe("buildLoader", () => {
 		const call = fetchSpy.mock.calls[0]?.[0] as unknown as {
 			queryFn: (ctx?: unknown) => Promise<NoteSummary[]>;
 		};
-		void call.queryFn();
+		call.queryFn();
 		expect(fetchFolderNotes).toHaveBeenCalledWith("2");
 	});
 
@@ -261,7 +261,7 @@ describe("buildLoader", () => {
 		const call = fetchSpy.mock.calls[0]?.[0] as unknown as {
 			queryFn: () => Promise<NoteSummary[]>;
 		};
-		void call.queryFn();
+		call.queryFn();
 		expect(fetchFolderNotes).toHaveBeenCalledWith("root");
 	});
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.597",
+      version: "0.5.598",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Behavioral tier of the Biome ratchet (tracking #812).

## This PR: \`complexity/noVoid\` (13 sites)

All 13 were the fire-and-forget idiom: \`void promise().catch(...)\`, \`void logout()\`, \`void import(...)\`. Biome has **no** type-aware floating-promise rule, so dropping \`void\` is behavior-identical (\`void expr\` and \`expr\` both evaluate and discard). Two special cases:
- \`onSelect={() => void logout()}\` → block body \`() => { logout(); }\` to keep the \`() => void\` return.
- \`void page;\` (an unused-param marker in a skipped e2e test) → dropped the unused \`{ page }\` param instead.

## Also: shelve \`suspicious/noUnnecessaryConditions\` as permanently-off
Documented in \`biome-linting.md\` + issue #812. Investigation found ~15/17 sites are Biome flow-analysis **false positives** (loop-mutated counters, \`RegExp.exec()\` null guards, closure-captured mutable flags, a reachable \`string\` switch flagged "unreachable", and necessary \`?.\` on nullable operands). Enabling it would require ~15 \`biome-ignore\` on correct code, so it moves to the permanently-off set rather than the ratchet queue.

## Verification (local)
- \`biome ci .\` clean (382 files, rule enabled; no other rule triggered by dropping \`void\`)
- \`tsc --noEmit\` exit 0
- \`vitest run\` 672/672 pass (126 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)