### PR TITLE
chore(frontend): ratchet suspicious useAwait

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -143,8 +143,7 @@
 						"noEmptyBlockStatements": "off",
 						"noShadow": "off",
 						"noSkippedTests": "off",
-						"noUnnecessaryConditions": "off",
-						"useAwait": "off"
+						"noUnnecessaryConditions": "off"
 					}
 				}
 			}
@@ -179,7 +178,7 @@
 						"noGlobalDirnameFilename": "off"
 					},
 					"style": { "noProcessEnv": "off" },
-					"suspicious": { "noConsole": "off", "noExplicitAny": "off" },
+					"suspicious": { "noConsole": "off", "noExplicitAny": "off", "useAwait": "off" },
 					"performance": { "noDelete": "off" },
 					"nursery": {
 						"noPlaywrightWaitForTimeout": "off",

--- a/frontend/src/api/oauth.ts
+++ b/frontend/src/api/oauth.ts
@@ -26,9 +26,9 @@ export interface OAuthConsentResponse {
 	redirect_uri: string;
 }
 
-export async function fetchOAuthClient(clientId: string): Promise<OAuthClientMetadata> {
+export function fetchOAuthClient(clientId: string): Promise<OAuthClientMetadata> {
 	const url = joinApiUrl(getApiBase(), `/api/oauth/clients/${encodeURIComponent(clientId)}`);
-	return fetch(url).then(async (res) => {
+	return fetch(url).then((res) => {
 		if (!res.ok) {
 			throw new Error(`oauth client lookup failed: ${res.status}`);
 		}
@@ -36,6 +36,6 @@ export async function fetchOAuthClient(clientId: string): Promise<OAuthClientMet
 	});
 }
 
-export async function postOAuthConsent(params: OAuthConsentParams): Promise<OAuthConsentResponse> {
+export function postOAuthConsent(params: OAuthConsentParams): Promise<OAuthConsentResponse> {
 	return api.post<OAuthConsentResponse>("/oauth/authorize/consent", params);
 }

--- a/frontend/src/auth/local-auth-provider.tsx
+++ b/frontend/src/auth/local-auth-provider.tsx
@@ -83,7 +83,7 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
 			return accessToken;
 		}
 
-		return doRefresh();
+		return await doRefresh();
 	}, [accessToken, doRefresh]);
 
 	useEffect(() => {

--- a/frontend/worker/index.ts
+++ b/frontend/worker/index.ts
@@ -36,6 +36,6 @@ export default {
 		// Defensive fallthrough: anything else that reaches the Worker is served
 		// from static assets. With the scoped `run_worker_first` this is only hit
 		// if the route list ever widens.
-		return env.ASSETS.fetch(request);
+		return await env.ASSETS.fetch(request);
 	},
 };

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.598",
+      version: "0.5.599",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Behavioral tier of the Biome ratchet (tracking #812).

## This PR: \`suspicious/useAwait\` — 5 source fixes + test-scope exemption

31 flagged sites. **26 are async test mocks/callbacks** (e.g. \`get.mockImplementation(async (url) => …)\`, \`vi.fn(async …)\`, \`it("…", async () => …)\`) that must return a Promise to match the real signature they mock. Removing \`async\` there breaks the contract; async-without-await is idiomatic in mocks. So \`useAwait\` is scoped **off in the test-files override**, next to the existing \`noConsole\`/\`noExplicitAny\` exemptions.

The **5 source sites** are fixed:
- \`oauth.ts\` — \`fetchOAuthClient\` / \`postOAuthConsent\` and the inner \`.then\` callback had redundant \`async\` (bodies already return promises via \`fetch().then()\` / \`api.post()\`) → dropped \`async\`, return types unchanged.
- \`local-auth-provider\` \`getToken\` and \`worker/index.ts\` \`fetch\` — \`async\` is meaningful (normalizes mixed returns / matches the Worker signature), so added a behavior-neutral \`await\` to the promise-returning \`return\`.

## Verification (local)
- \`biome ci .\` clean (382 files, rule enabled + test exemption)
- \`tsc --noEmit\` exit 0
- \`vitest run\` 672/672 pass (126 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)