### PR TITLE
chore(frontend): ratchet suspicious noShadow

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -141,7 +141,6 @@
 						"noAlert": "off",
 						"noConsole": { "level": "error", "options": { "allow": ["error", "warn"] } },
 						"noEmptyBlockStatements": "off",
-						"noShadow": "off",
 						"noSkippedTests": "off",
 						"noUnnecessaryConditions": "off"
 					}
@@ -178,7 +177,12 @@
 						"noGlobalDirnameFilename": "off"
 					},
 					"style": { "noProcessEnv": "off" },
-					"suspicious": { "noConsole": "off", "noExplicitAny": "off", "useAwait": "off" },
+					"suspicious": {
+						"noConsole": "off",
+						"noExplicitAny": "off",
+						"useAwait": "off",
+						"noShadow": "off"
+					},
 					"performance": { "noDelete": "off" },
 					"nursery": {
 						"noPlaywrightWaitForTimeout": "off",

--- a/frontend/src/auth/local-auth-provider.tsx
+++ b/frontend/src/auth/local-auth-provider.tsx
@@ -123,8 +123,8 @@ export default function LocalAuthProvider({ children }: { children: React.ReactN
 		});
 
 		if (!res.ok) {
-			const body = await res.json().catch(() => ({}));
-			throw new Error(body.error ?? "Registration failed");
+			const errorBody = await res.json().catch(() => ({}));
+			throw new Error(errorBody.error ?? "Registration failed");
 		}
 
 		const data = await res.json();

--- a/frontend/src/components/vault-create-form.tsx
+++ b/frontend/src/components/vault-create-form.tsx
@@ -40,11 +40,11 @@ export function VaultCreateForm({
 					setName("");
 					onCreated?.(res.vault.id);
 				},
-				onError: (e) => {
+				onError: (err) => {
 					// 402 cap errors are already surfaced by UpgradeDialogProvider via
 					// the central LimitExceededError handler — don't double-render as a
 					// toast.
-					if (e instanceof Error && e.name === "LimitExceededError") {
+					if (err instanceof Error && err.name === "LimitExceededError") {
 						return;
 					}
 					toast.error("Could not create vault");

--- a/frontend/src/viewer/pdf-view.tsx
+++ b/frontend/src/viewer/pdf-view.tsx
@@ -41,7 +41,7 @@ export default function PdfView({ url, filename }: { url: string; filename: stri
 			<div ref={containerRef} className="w-full p-4">
 				<Document
 					file={url}
-					onLoadSuccess={({ numPages }) => setNumPages(numPages)}
+					onLoadSuccess={({ numPages: loadedPages }) => setNumPages(loadedPages)}
 					className="flex flex-col items-center gap-4"
 					loading={<LoadingPane />}
 					error={<p className="p-2 text-destructive text-sm">Couldn&apos;t render {filename}.</p>}

--- a/frontend/src/viewer/tree-actions/duplicate.ts
+++ b/frontend/src/viewer/tree-actions/duplicate.ts
@@ -6,7 +6,8 @@ export function nextCopyName(path: string, existing: Set<string>): string {
 	const stem = dot > 0 ? name.slice(0, dot) : name;
 	const ext = dot > 0 ? name.slice(dot) : "";
 
-	const candidate = (n: number) => `${folder}${stem} (${n === 1 ? "copy" : `copy ${n}`})${ext}`;
+	const candidate = (attempt: number) =>
+		`${folder}${stem} (${attempt === 1 ? "copy" : `copy ${attempt}`})${ext}`;
 
 	let n = 1;
 	while (existing.has(candidate(n))) {

--- a/frontend/src/viewer/tree/synthesize-folders.ts
+++ b/frontend/src/viewer/tree/synthesize-folders.ts
@@ -70,14 +70,14 @@ export function synthesizeFolders(real: Folder[], attachments: AttachmentSummary
 	return [...paths]
 		.sort((x, y) => x.split("/").length - y.split("/").length)
 		.map((name) => {
-			const real = realByName.get(name);
+			const realFolder = realByName.get(name);
 			const slash = name.lastIndexOf("/");
 			const parentName = slash < 0 ? null : name.slice(0, slash);
 			return {
 				id: idFor(name),
 				parent_id: parentName === null ? null : idFor(parentName),
 				name,
-				count: real ? real.count : 0,
+				count: realFolder ? realFolder.count : 0,
 			};
 		});
 }

--- a/frontend/src/viewer/tree/use-engram-tree.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.ts
@@ -173,12 +173,12 @@ export function useEngramTree(deps: Deps) {
 		// highlight (isDragTarget) is the right affordance, not a reorder line.
 		canReorder: false,
 		onRename: (item: ItemInstance<Data>, value: string) => deps.onRenameCommit(item.getId(), value),
-		onDrop: (items: ItemInstance<Data>[], target: DragTarget<Data>) => {
+		onDrop: (dragged: ItemInstance<Data>[], target: DragTarget<Data>) => {
 			// HT normalizes `target.item` to the destination container (the parent
 			// folder for between-siblings, or the folder dropped onto). We ignore the
 			// insertion index and reparent into it. See drop-redirect.ts.
 			const destId = (target as { item?: ItemInstance<Data> }).item?.getId();
-			const sources = items.map((i) => ({
+			const sources = dragged.map((i) => ({
 				id: i.getId(),
 				parentId: i.getParent()?.getId(),
 			}));

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.599",
+      version: "0.5.600",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Behavioral tier of the Biome ratchet (tracking #812).

## This PR: \`suspicious/noShadow\` — 6 source renames + test-scope exemption

41 flagged sites. **35 are the \`vi.hoisted\` mock-factory idiom** — the inner \`const onOpen\`/\`socketCtor\`/\`channelHandlers\` intentionally shares the name it's destructured out as, plus per-test \`const qc\`/\`const folders\` reuse. Renaming there is pure churn, so \`noShadow\` is scoped **off in the test-files override** next to the existing \`noConsole\`/\`noExplicitAny\`/\`useAwait\` exemptions.

The **6 source sites** renamed the inner shadowing binding:
- \`local-auth-provider\`: error body \`body\` → \`errorBody\`
- \`vault-create-form\`: \`onError\` param \`e\` (shadowed the \`submit\` FormEvent) → \`err\`
- \`pdf-view\`: \`onLoadSuccess\` destructure \`numPages\` (shadowed the state) → \`loadedPages\`
- \`use-engram-tree\`: \`onDrop\` param \`items\` (shadowed \`tree.getItems()\`) → \`dragged\`
- \`synthesize-folders\`: inner \`real\` (shadowed the \`real\` param) → \`realFolder\`
- \`duplicate.ts\`: \`candidate\` param \`n\` (shadowed \`let n\`) → \`attempt\`

## Verification (local)
- \`biome ci .\` clean (382 files, rule enabled + test exemption)
- \`tsc --noEmit\` exit 0
- \`vitest run\` 672/672 pass (126 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)