### PR TITLE
chore(frontend): ratchet suspicious/noEmptyBlockStatements

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -140,7 +140,6 @@
 						"noReactSpecificProps": "off",
 						"noAlert": "off",
 						"noConsole": { "level": "error", "options": { "allow": ["error", "warn"] } },
-						"noEmptyBlockStatements": "off",
 						"noSkippedTests": "off",
 						"noUnnecessaryConditions": "off"
 					}
@@ -181,7 +180,8 @@
 						"noConsole": "off",
 						"noExplicitAny": "off",
 						"useAwait": "off",
-						"noShadow": "off"
+						"noShadow": "off",
+						"noEmptyBlockStatements": "off"
 					},
 					"performance": { "noDelete": "off" },
 					"nursery": {

--- a/frontend/src/viewer/tree/loader.ts
+++ b/frontend/src/viewer/tree/loader.ts
@@ -93,7 +93,10 @@ function noteChildItems(deps: LoaderDeps, folderId: string): LoaderItem[] | null
 				// The notes are now in the cache, but HT cached the empty children
 				// list when it first asked. Tell it to refetch this branch.
 				.then(() => deps.onChildrenLoaded?.(folderId))
-				.catch(() => {});
+				.catch(() => {
+					// Best-effort background prefetch: a failed refetch just leaves the
+					// branch to load lazily on next expand, so swallow the error.
+				});
 		}
 		return null;
 	}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.600",
+      version: "0.5.601",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Enables `suspicious/noEmptyBlockStatements` in the frontend Biome config (Biome ratchet, refs #812).

## What
- One source site fixed: `src/viewer/tree/loader.ts` best-effort background prefetch `.catch(() => {})` now carries an in-block comment documenting why the refetch error is swallowed (a failed prefetch just falls back to lazy load on next expand).
- 115 of 116 sites are in test/e2e files — empty no-op mock callbacks, empty mock method bodies, one intentional cleanup catch. Empty no-op callbacks are idiomatic in tests, so the rule is scoped **off** in the test-files override alongside the existing `noConsole`/`noExplicitAny`/`useAwait`/`noShadow` exemptions.

## Verify
- `biome ci` clean (382 files)
- `tsc --noEmit` exit 0
- `vitest run` 672/672

Refs #812