### PR TITLE
fix(web): paddle onboarding + settings account UX

### DIFF
--- a/frontend/src/billing/billing-page.test.tsx
+++ b/frontend/src/billing/billing-page.test.tsx
@@ -242,7 +242,12 @@ describe("BillingPage — Paddle effect cleanup", () => {
 		expect(openMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("onboarding (inline): CHECKOUT_PAYMENT_FAILED restores the plan picker", async () => {
+	it("onboarding (inline): CHECKOUT_PAYMENT_FAILED keeps Paddle's frame open so the decline reason + retry stay visible", async () => {
+		// A declined card is a normal, retryable state: Paddle keeps its inline
+		// frame open and shows the reason ("card declined" etc.) with a retry.
+		// We must NOT tear the frame down — doing so bounced the user back to the
+		// plan picker with no explanation. (Genuine checkout.error / payment.error
+		// events still close; see the next test.)
 		mockBillingApi();
 		let captured: ((event: { name: string; data?: unknown }) => void) | undefined;
 		initializePaddleMock.mockImplementation(async (opts: { eventCallback?: typeof captured }) => {
@@ -269,7 +274,37 @@ describe("BillingPage — Paddle effect cleanup", () => {
 			await Promise.resolve();
 		});
 
-		// Mount target gone, plan cards back
+		// Frame stays mounted; user is NOT bounced to the plan picker.
+		expect(container.querySelector(".paddle-checkout")).not.toBeNull();
+		expect(queryAllByText("Starter").length).toBe(0);
+	});
+
+	it("onboarding (inline): a genuine CHECKOUT_ERROR closes the frame and surfaces a message", async () => {
+		mockBillingApi();
+		let captured: ((event: { name: string; data?: unknown }) => void) | undefined;
+		initializePaddleMock.mockImplementation(async (opts: { eventCallback?: typeof captured }) => {
+			captured = opts.eventCallback;
+			return { Checkout: { open: vi.fn(), close: vi.fn() } };
+		});
+
+		const { container, queryAllByText } = renderBilling({ inline: true });
+
+		await waitFor(() => expect(queryAllByText("Starter").length).toBeGreaterThan(0));
+		const startBtn = Array.from(container.querySelectorAll("button")).find(
+			(b) => b.textContent === "Start free trial",
+		)!;
+		await act(async () => {
+			startBtn.click();
+			await Promise.resolve();
+		});
+		expect(container.querySelector(".paddle-checkout")).not.toBeNull();
+
+		await act(async () => {
+			captured!({ name: "checkout.error", data: {} });
+			await Promise.resolve();
+		});
+
+		// Fatal checkout error: frame gone, plan picker restored.
 		expect(container.querySelector(".paddle-checkout")).toBeNull();
 		expect(queryAllByText("Starter").length).toBeGreaterThan(0);
 	});
@@ -355,6 +390,84 @@ describe("BillingPage — Paddle effect cleanup", () => {
 
 		await waitFor(() => expect(onActivated).toHaveBeenCalled());
 		expect(closeMock).toHaveBeenCalled();
+	});
+
+	it("onboarding (inline): the activation bridge survives billing.active flipping true (no blank flash)", async () => {
+		// The activation push both (a) raises the "Setting up your account…" bridge
+		// and (b) flips billing.active true server-side. If the bridge lives behind
+		// the `needsSubscription = !billing.active` gate, (b) unmounts it before the
+		// wizard navigates → a blank panel flashes. The bridge must persist.
+		let billingActive = false;
+		get.mockImplementation(async (url: string) => {
+			if (url === "/billing/status") {
+				return billingActive
+					? { tier: "starter", active: true, trial_days_remaining: 0, subscription: null, caps: {} }
+					: { tier: "free", active: false, trial_days_remaining: 0, subscription: null, caps: {} };
+			}
+			if (url === "/billing/config") {
+				return {
+					client_token: "tok",
+					environment: "sandbox",
+					price_ids: {
+						starter: { monthly: "p1", annual: "p2" },
+						pro: { monthly: "p3", annual: "p4" },
+					},
+					customer_email: "u@example.com",
+					custom_data: { user_id: "1" },
+					vaults_cap: null,
+				};
+			}
+			if (url === "/me") {
+				return { user: ME };
+			}
+			if (url === "/onboarding/status") {
+				return { next_step: "tools", enabled: true };
+			}
+			throw new Error(`unexpected GET ${url}`);
+		});
+
+		initializePaddleMock.mockImplementation(async () => ({
+			Checkout: { open: vi.fn(), close: vi.fn() },
+		}));
+
+		// no-op onActivated: mirrors the wizard NOT yet navigating, so the steady
+		// bridge must hold on its own instead of relying on an unmount.
+		const onActivated = vi.fn();
+		const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(
+			<QueryClientProvider client={qc}>
+				<AuthContext.Provider value={authAdapter}>
+					<ThemeProvider>
+						<MemoryRouter>
+							<BillingPage hideHeading onActivated={onActivated} />
+						</MemoryRouter>
+					</ThemeProvider>
+				</AuthContext.Provider>
+			</QueryClientProvider>,
+		);
+
+		await waitFor(() => expect(channelHandlers.subscription_activated).toBeDefined());
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		// Server flips the subscription active; mirror it so the handler's refetch
+		// returns active and needsSubscription goes false mid-activation.
+		billingActive = true;
+		await act(async () => {
+			channelHandlers.subscription_activated!({
+				tier: "starter",
+				status: "trialing",
+				subscription_id: "sub_1",
+			});
+			await Promise.resolve();
+		});
+
+		await waitFor(() => expect(onActivated).toHaveBeenCalled());
+		// Until the wizard navigates, the steady bridge must still be on screen —
+		// not a blank panel.
+		expect(screen.getByText(/Setting up your account/iu)).toBeInTheDocument();
 	});
 
 	it("invalidates billing/status on subscription_activated channel event (settings flow)", async () => {

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -328,13 +328,26 @@ export default function BillingPage({
 						invalidateBillingState(qc);
 						break;
 					}
-					case CheckoutEventNames.CHECKOUT_PAYMENT_FAILED:
+					case CheckoutEventNames.CHECKOUT_PAYMENT_FAILED: {
+						// A declined card is a normal, retryable state: Paddle keeps its
+						// inline frame open and shows the reason ("card declined",
+						// "insufficient funds", …) with a retry. Leave the frame mounted
+						// (do NOT setCheckingOut(false)) so the user sees WHY and can try
+						// another card, instead of being bounced back to the plan picker
+						// with no explanation. Only clear the completion cooldown/recovery
+						// state so a stale COMPLETED/INITIATED timer can't fire.
+						setCompletedAt(null);
+						setSlow(false);
+						break;
+					}
 					case CheckoutEventNames.CHECKOUT_PAYMENT_ERROR:
 					case CheckoutEventNames.CHECKOUT_ERROR: {
+						// Genuine checkout-level error (not a routine decline) — the frame
+						// may be in a broken state, so close it and surface a message.
 						setCheckingOut(false);
 						setCompletedAt(null);
 						setSlow(false);
-						toast.error("Payment did not go through. Please try again.");
+						toast.error("Something went wrong with checkout. Please try again.");
 						break;
 					}
 					default:
@@ -347,7 +360,12 @@ export default function BillingPage({
 							displayMode: "inline",
 							frameTarget: INLINE_FRAME_TARGET,
 							frameInitialHeight: 450,
-							frameStyle: "width:100%; min-height:450px; background:transparent; border:none;",
+							// No fixed min-height: Paddle auto-resizes the iframe to fit its
+							// content, and a hard floor overrode the downward resize — so the
+							// short post-payment success screen was stranded in a tall 450px
+							// box. frameInitialHeight covers the initial paint before Paddle
+							// reports the real height. (min-width matches Paddle's own sample.)
+							frameStyle: "width:100%; min-width:312px; background:transparent; border:none;",
 							theme: resolved === "dark" ? "dark" : "light",
 							locale: "en",
 						}
@@ -439,6 +457,9 @@ export default function BillingPage({
 	}
 
 	const needsSubscription = !billing.active;
+	// Keep the panel mounted across the activation flip: the push that raises the
+	// `finalizing` bridge also flips billing.active → needsSubscription false.
+	const showPlanSection = needsSubscription || finalizing;
 	const checkoutReady = Boolean(paddle && config);
 
 	async function openPortal(action?: string) {
@@ -525,7 +546,10 @@ export default function BillingPage({
 				</CurrentPlanCard>
 			)}
 
-			{needsSubscription && (
+			{/* showPlanSection = needsSubscription || finalizing — keeps the bridge
+			    mounted across the activation flip so it doesn't flash blank before
+			    the wizard navigates to the next step. */}
+			{showPlanSection ? (
 				<section className="space-y-4">
 					{finalizing ? (
 						<section
@@ -672,7 +696,7 @@ export default function BillingPage({
 						</>
 					)}
 				</section>
-			)}
+			) : null}
 
 			{!hideHeading && billing.subscription && (
 				<>

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -435,3 +435,12 @@ html {
 		animation: none;
 	}
 }
+
+/* Paddle's overlay checkout iframe is appended to <body>. When it opens from
+   inside a Radix dialog (e.g. the Settings modal's change-plan / update-payment
+   flows), Radix sets `body { pointer-events: none }`, which the overlay inherits
+   — so its inputs can't be clicked despite its max z-index. Re-enable hit-testing
+   on Paddle's own overlay so it stays interactive above any dialog. */
+.paddle-frame-overlay {
+	pointer-events: auto;
+}

--- a/frontend/src/onboarding/onboard-billing-page.test.tsx
+++ b/frontend/src/onboarding/onboard-billing-page.test.tsx
@@ -356,7 +356,7 @@ describe("OnboardBillingPage — push activation", () => {
 		expect(toolsPageMounts).toBe(1);
 	});
 
-	it("returns from inline Paddle frame back to plan picker on CHECKOUT_PAYMENT_FAILED", async () => {
+	it("keeps the inline Paddle frame open on CHECKOUT_PAYMENT_FAILED so the decline reason + retry stay visible", async () => {
 		get.mockImplementation(async (url: string) => {
 			if (url === "/billing/status") {
 				return BILLING_INACTIVE;
@@ -389,13 +389,17 @@ describe("OnboardBillingPage — push activation", () => {
 		});
 		expect(container.querySelector(".paddle-checkout")).not.toBeNull();
 
-		// Payment fails — plan picker comes back.
+		// Payment fails (declined card): Paddle keeps its frame open and shows the
+		// reason with a retry. We must NOT bounce back to the plan picker.
 		await act(async () => {
 			capturedEventCallback!({ name: "checkout.payment.failed" });
+			await Promise.resolve();
 		});
 
-		await waitFor(() => expect(container.querySelector(".paddle-checkout")).toBeNull());
-		expect(screen.getAllByRole("button", { name: /start free trial/iu }).length).toBeGreaterThan(0);
+		expect(container.querySelector(".paddle-checkout")).not.toBeNull();
+		expect(screen.queryAllByRole("button", { name: /start free trial/iu }).length).toBe(0);
+		// The user can still back out manually.
+		expect(screen.getByRole("button", { name: /choose a different plan/iu })).toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/settings/account-page.tsx
+++ b/frontend/src/settings/account-page.tsx
@@ -8,7 +8,7 @@ import { SessionsSection } from "./account/sessions-section";
 
 // OAuth providers enabled on this Clerk instance. Confirm against the instance
 // before adjusting (see note below).
-const OAUTH_PROVIDERS = ["oauth_apple", "oauth_google", "oauth_github"] as const;
+const OAUTH_PROVIDERS = ["oauth_google", "oauth_github", "oauth_discord"] as const;
 
 export default function AccountPage() {
 	return (

--- a/frontend/src/settings/account/connected-accounts-section.test.tsx
+++ b/frontend/src/settings/account/connected-accounts-section.test.tsx
@@ -8,6 +8,7 @@ const googleAcct = {
 	id: "ext_1",
 	provider: "google",
 	emailAddress: "ada@gmail.com",
+	verification: { status: "verified" },
 	destroy: vi.fn().mockResolvedValue({}),
 };
 let user = makeUser({ externalAccounts: [googleAcct] });
@@ -43,6 +44,7 @@ describe("ConnectedAccountsSection", () => {
 			provider: "github",
 			emailAddress: "",
 			username: null,
+			verification: { status: "verified" },
 			destroy: vi.fn(),
 		};
 		user = makeUser({ externalAccounts: [bare] });
@@ -60,5 +62,27 @@ describe("ConnectedAccountsSection", () => {
 				expect.objectContaining({ strategy: "oauth_github" }),
 			),
 		);
+	});
+
+	it("does not treat an unverified/incomplete link as connected, and keeps the provider available", () => {
+		// createExternalAccount leaves an unverified record if the user abandons or
+		// the OAuth handshake fails. That must NOT show as connected.
+		const incomplete = {
+			id: "ext_x",
+			provider: "discord",
+			emailAddress: "",
+			verification: { status: "unverified" },
+			destroy: vi.fn(),
+		};
+		user = makeUser({ externalAccounts: [incomplete] });
+		render(<ConnectedAccountsSection providers={["oauth_discord"]} />);
+		expect(screen.queryByRole("button", { name: /disconnect discord/iu })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /connect discord/iu })).toBeInTheDocument();
+	});
+
+	it("offers Discord as a connectable provider", () => {
+		user = makeUser({ externalAccounts: [] });
+		render(<ConnectedAccountsSection providers={["oauth_discord"]} />);
+		expect(screen.getByRole("button", { name: /connect discord/iu })).toBeInTheDocument();
 	});
 });

--- a/frontend/src/settings/account/connected-accounts-section.tsx
+++ b/frontend/src/settings/account/connected-accounts-section.tsx
@@ -33,16 +33,16 @@ const GoogleIcon = () => (
 	</svg>
 );
 
-const AppleIcon = () => (
+const DiscordIcon = () => (
 	<svg viewBox="0 0 16 16" aria-hidden="true" className="size-4 fill-current">
-		<path d="M11.18 8.46c-.02-1.62 1.32-2.4 1.38-2.44-.75-1.1-1.92-1.25-2.34-1.27-1-.1-1.95.59-2.45.59-.5 0-1.29-.57-2.12-.56-1.09.02-2.1.63-2.66 1.61-1.13 1.97-.29 4.88.81 6.48.54.78 1.18 1.66 2.02 1.63.81-.03 1.12-.52 2.1-.52.98 0 1.26.52 2.12.51.88-.02 1.43-.8 1.97-1.58.62-.91.88-1.79.89-1.83-.02-.01-1.71-.66-1.72-2.61ZM9.6 3.69c.44-.54.74-1.28.66-2.02-.64.03-1.41.43-1.87.96-.41.47-.77 1.23-.67 1.95.71.06 1.43-.36 1.88-.89Z" />
+		<path d="M13.545 2.907a13.2 13.2 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0 8 8 0 0 0-.412-.833.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.036a13.3 13.3 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a9 9 0 0 1-1.248-.595.05.05 0 0 1-.02-.066l.015-.019q.126-.093.246-.192a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.099.245.192a.05.05 0 0 1-.004.085 8 8 0 0 1-1.249.594.05.05 0 0 0-.03.03.05.05 0 0 0 .003.041q.36.697.817 1.329a.05.05 0 0 0 .056.019 13.2 13.2 0 0 0 4.001-2.02.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.03.03 0 0 0-.02-.019m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612" />
 	</svg>
 );
 
 const PROVIDERS: Record<string, { name: string; icon: ReactNode }> = {
 	github: { name: "GitHub", icon: <GitHubIcon /> },
 	google: { name: "Google", icon: <GoogleIcon /> },
-	apple: { name: "Apple", icon: <AppleIcon /> },
+	discord: { name: "Discord", icon: <DiscordIcon /> },
 };
 
 function meta(raw: string) {
@@ -64,7 +64,15 @@ export function ConnectedAccountsSection({ providers }: { providers: OAuthStrate
 	if (!(isLoaded && user)) {
 		return null;
 	}
-	const connected = new Set(user.externalAccounts.map((a) => `oauth_${a.provider}`));
+	// Only accounts Clerk has actually verified count as connected. An abandoned
+	// or failed OAuth link leaves an `unverified` externalAccount record behind;
+	// treating those as connected made the button flip to "connected" even when
+	// the handshake never completed. Filter them out so the provider stays
+	// offered and the user can retry.
+	const verifiedAccounts = user.externalAccounts.filter(
+		(a) => a.verification?.status === "verified",
+	);
+	const connected = new Set(verifiedAccounts.map((a) => `oauth_${a.provider}`));
 
 	async function onDisconnect(destroy: () => Promise<unknown>) {
 		try {
@@ -104,9 +112,9 @@ export function ConnectedAccountsSection({ providers }: { providers: OAuthStrate
 			title="Connected accounts"
 			description="Link third-party sign-in providers."
 		>
-			{user.externalAccounts.length > 0 && (
+			{verifiedAccounts.length > 0 && (
 				<ul className="divide-y divide-border">
-					{user.externalAccounts.map((a) => {
+					{verifiedAccounts.map((a) => {
 						const { name, icon } = meta(a.provider);
 						const secondary = a.emailAddress || a.username || "Connected";
 						return (

--- a/frontend/src/settings/account/email-section.test.tsx
+++ b/frontend/src/settings/account/email-section.test.tsx
@@ -1,37 +1,20 @@
 import { isReverificationCancelledError } from "@clerk/react/errors";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EmailSection } from "./email-section";
 import { makeUser } from "./section-test-helpers";
 
-const newEmail = {
-	id: "eml_2",
-	emailAddress: "new@example.com",
-	prepareVerification: vi.fn().mockResolvedValue({}),
-	attemptVerification: vi.fn().mockResolvedValue({}),
-};
-
-function twoEmailUser() {
-	return makeUser({
-		createEmailAddress: vi.fn().mockResolvedValue(newEmail),
-		emailAddresses: [
-			{
-				id: "eml_1",
-				emailAddress: "ada@example.com",
-				verification: { status: "verified" },
-				destroy: vi.fn().mockResolvedValue({}),
-			},
-			{
-				id: "eml_2b",
-				emailAddress: "second@example.com",
-				verification: { status: "verified" },
-				destroy: vi.fn().mockResolvedValue({}),
-			},
-		],
-	});
+function makeVerifiableEmail(id: string, address: string) {
+	return {
+		id,
+		emailAddress: address,
+		prepareVerification: vi.fn().mockResolvedValue({}),
+		attemptVerification: vi.fn().mockResolvedValue({}),
+	};
 }
 
-let user = twoEmailUser();
+let user = makeUser();
 
 vi.mock("@clerk/react", () => ({
 	useUser: () => ({ user, isLoaded: true }),
@@ -47,61 +30,213 @@ describe("EmailSection", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.mocked(isReverificationCancelledError).mockReturnValue(false);
-		user = twoEmailUser();
+		user = makeUser();
 	});
 
-	it("lists existing emails", () => {
+	it("shows the current primary email and no multi-email management", () => {
 		render(<EmailSection />);
 		expect(screen.getByText("ada@example.com")).toBeInTheDocument();
+		expect(screen.queryByLabelText(/add email/iu)).not.toBeInTheDocument();
+		expect(screen.getByLabelText(/new email/iu)).toBeInTheDocument();
 	});
 
-	it("adds an email and prepares verification", async () => {
+	it("changes to a brand-new email: create → verify → set primary → remove old", async () => {
+		const created = makeVerifiableEmail("eml_2", "new@example.com");
+		user = makeUser({ createEmailAddress: vi.fn().mockResolvedValue(created) });
 		render(<EmailSection />);
-		fireEvent.change(screen.getByLabelText(/add email/iu), {
+
+		fireEvent.change(screen.getByLabelText(/new email/iu), {
 			target: { value: "new@example.com" },
 		});
-		fireEvent.click(screen.getByRole("button", { name: /^add$/iu }));
+		fireEvent.click(screen.getByRole("button", { name: /update email/iu }));
+
 		await waitFor(() =>
 			expect(user.createEmailAddress).toHaveBeenCalledWith({ email: "new@example.com" }),
 		);
 		await waitFor(() =>
-			expect(newEmail.prepareVerification).toHaveBeenCalledWith({ strategy: "email_code" }),
+			expect(created.prepareVerification).toHaveBeenCalledWith({ strategy: "email_code" }),
 		);
-	});
 
-	it("verifies the new email with a code", async () => {
-		render(<EmailSection />);
-		fireEvent.change(screen.getByLabelText(/add email/iu), {
-			target: { value: "new@example.com" },
+		fireEvent.change(await screen.findByLabelText(/verification code/iu), {
+			target: { value: "123456" },
 		});
-		fireEvent.click(screen.getByRole("button", { name: /^add$/iu }));
-		await screen.findByLabelText(/verification code/iu);
-		fireEvent.change(screen.getByLabelText(/verification code/iu), { target: { value: "123456" } });
 		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
-		await waitFor(() =>
-			expect(newEmail.attemptVerification).toHaveBeenCalledWith({ code: "123456" }),
-		);
-	});
 
-	it("removes an email via destroy and reloads the user", async () => {
-		render(<EmailSection />);
-		fireEvent.click(screen.getByRole("button", { name: /remove ada@example.com/iu }));
+		await waitFor(() =>
+			expect(created.attemptVerification).toHaveBeenCalledWith({ code: "123456" }),
+		);
+		await waitFor(() =>
+			expect(user.update).toHaveBeenCalledWith({ primaryEmailAddressId: "eml_2" }),
+		);
+		// old primary is removed so the account ends with a single email
 		await waitFor(() => expect(user.emailAddresses[0]!.destroy).toHaveBeenCalled());
 		await waitFor(() => expect(user.reload).toHaveBeenCalled());
+		expect(toast.success).toHaveBeenCalledWith("Email updated");
 	});
 
-	it("disables Remove when only one email address remains", () => {
+	it("reuses an already-verified address on the account without a code step", async () => {
+		const secondary = {
+			id: "eml_2b",
+			emailAddress: "second@example.com",
+			verification: { status: "verified" },
+			destroy: vi.fn().mockResolvedValue({}),
+			prepareVerification: vi.fn(),
+			attemptVerification: vi.fn(),
+		};
 		user = makeUser({
 			emailAddresses: [
 				{
 					id: "eml_1",
 					emailAddress: "ada@example.com",
 					verification: { status: "verified" },
-					destroy: vi.fn(),
+					destroy: vi.fn().mockResolvedValue({}),
 				},
+				secondary,
 			],
 		});
 		render(<EmailSection />);
-		expect(screen.getByRole("button", { name: /remove ada@example.com/iu })).toBeDisabled();
+
+		fireEvent.change(screen.getByLabelText(/new email/iu), {
+			target: { value: "second@example.com" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /update email/iu }));
+
+		await waitFor(() =>
+			expect(user.update).toHaveBeenCalledWith({ primaryEmailAddressId: "eml_2b" }),
+		);
+		expect(screen.queryByLabelText(/verification code/iu)).not.toBeInTheDocument();
+		await waitFor(() => expect(user.emailAddresses[0]!.destroy).toHaveBeenCalled());
+		expect(user.createEmailAddress).not.toHaveBeenCalled();
+	});
+
+	it("re-sends a code for an existing but unverified address (skips create)", async () => {
+		const secondary = {
+			id: "eml_2b",
+			emailAddress: "second@example.com",
+			verification: { status: "unverified" },
+			destroy: vi.fn().mockResolvedValue({}),
+			prepareVerification: vi.fn().mockResolvedValue({}),
+			attemptVerification: vi.fn().mockResolvedValue({}),
+		};
+		user = makeUser({
+			emailAddresses: [
+				{
+					id: "eml_1",
+					emailAddress: "ada@example.com",
+					verification: { status: "verified" },
+					destroy: vi.fn().mockResolvedValue({}),
+				},
+				secondary,
+			],
+		});
+		render(<EmailSection />);
+
+		fireEvent.change(screen.getByLabelText(/new email/iu), {
+			target: { value: "second@example.com" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /update email/iu }));
+
+		await waitFor(() =>
+			expect(secondary.prepareVerification).toHaveBeenCalledWith({ strategy: "email_code" }),
+		);
+		expect(user.createEmailAddress).not.toHaveBeenCalled();
+		await screen.findByLabelText(/verification code/iu);
+	});
+
+	it("rejects changing to the address that is already primary", async () => {
+		render(<EmailSection />);
+		fireEvent.change(screen.getByLabelText(/new email/iu), {
+			target: { value: "ada@example.com" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /update email/iu }));
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalledWith("That's already your email"));
+		expect(user.createEmailAddress).not.toHaveBeenCalled();
+	});
+
+	it("shows 'Invalid code' only when the code itself is rejected", async () => {
+		const created = {
+			id: "eml_2",
+			emailAddress: "new@example.com",
+			prepareVerification: vi.fn().mockResolvedValue({}),
+			attemptVerification: vi.fn().mockRejectedValue(new Error("bad code")),
+		};
+		user = makeUser({ createEmailAddress: vi.fn().mockResolvedValue(created) });
+		render(<EmailSection />);
+		fireEvent.change(screen.getByLabelText(/new email/iu), {
+			target: { value: "new@example.com" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /update email/iu }));
+		fireEvent.change(await screen.findByLabelText(/verification code/iu), {
+			target: { value: "000000" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Invalid code"));
+		// The code failed, so the primary must NOT have changed.
+		expect(user.update).not.toHaveBeenCalled();
+	});
+
+	it("reports a promotion failure (not 'Invalid code') when set-primary fails after the code verifies", async () => {
+		const created = {
+			id: "eml_2",
+			emailAddress: "new@example.com",
+			prepareVerification: vi.fn().mockResolvedValue({}),
+			attemptVerification: vi.fn().mockResolvedValue({}),
+		};
+		user = makeUser({
+			createEmailAddress: vi.fn().mockResolvedValue(created),
+			update: vi.fn().mockRejectedValue(new Error("set-primary failed")),
+		});
+		render(<EmailSection />);
+		fireEvent.change(screen.getByLabelText(/new email/iu), {
+			target: { value: "new@example.com" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /update email/iu }));
+		fireEvent.change(await screen.findByLabelText(/verification code/iu), {
+			target: { value: "123456" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+
+		await waitFor(() => expect(created.attemptVerification).toHaveBeenCalled());
+		await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Could not update email"));
+		expect(toast.error).not.toHaveBeenCalledWith("Invalid code");
+	});
+
+	it("still reports success when removing the old address fails after the primary changed", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const created = {
+			id: "eml_2",
+			emailAddress: "new@example.com",
+			prepareVerification: vi.fn().mockResolvedValue({}),
+			attemptVerification: vi.fn().mockResolvedValue({}),
+		};
+		const oldPrimary = {
+			id: "eml_1",
+			emailAddress: "ada@example.com",
+			verification: { status: "verified" },
+			destroy: vi.fn().mockRejectedValue(new Error("cleanup failed")),
+		};
+		user = makeUser({
+			emailAddresses: [oldPrimary],
+			createEmailAddress: vi.fn().mockResolvedValue(created),
+		});
+		render(<EmailSection />);
+		fireEvent.change(screen.getByLabelText(/new email/iu), {
+			target: { value: "new@example.com" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /update email/iu }));
+		fireEvent.change(await screen.findByLabelText(/verification code/iu), {
+			target: { value: "123456" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /verify/iu }));
+
+		// Primary switched, so the change succeeded despite the cleanup failure.
+		await waitFor(() =>
+			expect(user.update).toHaveBeenCalledWith({ primaryEmailAddressId: "eml_2" }),
+		);
+		await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Email updated"));
+		expect(toast.error).not.toHaveBeenCalled();
+		consoleError.mockRestore();
 	});
 });

--- a/frontend/src/settings/account/email-section.tsx
+++ b/frontend/src/settings/account/email-section.tsx
@@ -9,129 +9,138 @@ import { SettingsSectionCard } from "./section-card";
 const inputClass =
 	"mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring";
 
+// Clerk can't rename an email address, so "change my primary email" is really:
+// add (or reuse) the new address → verify it → set it primary → delete the old
+// primary. We present that as a single "update email" flow that ends with one
+// address on the account.
 export function EmailSection() {
 	const { user, isLoaded } = useUser();
-	const [email, setEmail] = useState("");
+	const [newEmail, setNewEmail] = useState("");
+	const [code, setCode] = useState("");
+	// The address awaiting an email code, held between "send code" and "verify".
 	const [pending, setPending] = useState<{
+		id: string;
 		attemptVerification: (p: { code: string }) => Promise<unknown>;
 	} | null>(null);
-	const [code, setCode] = useState("");
-	const removeEmail = useReverification((destroy: () => Promise<unknown>) => destroy());
-	const setPrimary = useReverification((id: string) => user!.update({ primaryEmailAddressId: id }));
-	// Adding an email is reverification-protected — raw calls return 403.
+
+	// All three calls are reverification-protected — raw calls return 403.
 	const createEmailAddress = useReverification((address: string) =>
 		user!.createEmailAddress({ email: address }),
 	);
+	const setPrimary = useReverification((id: string) => user!.update({ primaryEmailAddressId: id }));
+	const removeEmail = useReverification((destroy: () => Promise<unknown>) => destroy());
 
 	if (!(isLoaded && user)) {
 		return null;
 	}
 
-	async function add() {
+	const primaryId = user.primaryEmailAddressId;
+	const currentEmail = user.emailAddresses.find((e) => e.id === primaryId)?.emailAddress ?? "";
+
+	// Promote `newId` to primary and delete the previous primary so exactly one
+	// address remains. `previousPrimaryId` is captured by the caller before the
+	// promotion so the cleanup targets the right address.
+	async function promoteAndCleanUp(newId: string, previousPrimaryId: string | null) {
+		await setPrimary(newId);
+		const old =
+			previousPrimaryId && previousPrimaryId !== newId
+				? user!.emailAddresses.find((e) => e.id === previousPrimaryId)
+				: undefined;
+		// Best-effort: the primary has already changed, so removing the old
+		// address is secondary. A failure here must NOT be reported as if the
+		// whole email change failed (that left a leftover address + a misleading
+		// error). Worst case the old address lingers, harmlessly.
+		if (old) {
+			try {
+				await removeEmail(() => old.destroy());
+			} catch (e) {
+				if (!isReverificationCancelledError(e)) {
+					console.error("primary email changed but old address cleanup failed", e);
+				}
+			}
+		}
+		await user!.reload();
+		setPending(null);
+		setNewEmail("");
+		setCode("");
+		toast.success("Email updated");
+	}
+
+	async function startChange() {
+		const target = newEmail.trim();
+		if (!target) {
+			return;
+		}
+		if (target.toLowerCase() === currentEmail.toLowerCase()) {
+			toast.error("That's already your email");
+			return;
+		}
 		try {
-			const created = await createEmailAddress(email);
+			// Reuse an address already on the account (e.g. a leftover secondary)
+			// instead of re-adding it, which Clerk would reject as a duplicate.
+			const existing = user!.emailAddresses.find(
+				(e) => e.emailAddress.toLowerCase() === target.toLowerCase(),
+			);
+			if (existing) {
+				if (existing.verification?.status === "verified") {
+					await promoteAndCleanUp(existing.id, primaryId);
+					return;
+				}
+				await existing.prepareVerification({ strategy: "email_code" });
+				setPending({
+					id: existing.id,
+					attemptVerification: (p) => existing.attemptVerification(p),
+				});
+				toast.success("Verification code sent");
+				return;
+			}
+
+			const created = await createEmailAddress(target);
 			await created.prepareVerification({ strategy: "email_code" });
-			setPending(created);
+			setPending({
+				id: created.id,
+				attemptVerification: (p) => created.attemptVerification(p),
+			});
 			toast.success("Verification code sent");
 		} catch (e) {
 			if (isReverificationCancelledError(e)) {
 				return;
 			}
-			toast.error(clerkErrorMessage(e, "Could not add email"));
+			toast.error(clerkErrorMessage(e, "Could not update email"));
 		}
 	}
 
 	async function verify() {
+		if (!pending) {
+			return;
+		}
+		// Verify the code first — only a failure HERE means a bad code.
 		try {
-			await pending!.attemptVerification({ code });
-			setPending(null);
-			setEmail("");
-			setCode("");
-			toast.success("Email verified");
+			await pending.attemptVerification({ code });
 		} catch {
 			toast.error("Invalid code");
+			return;
 		}
-	}
-
-	async function makePrimary(id: string) {
+		// Code accepted; promotion is a separate step so its errors aren't
+		// misreported as "Invalid code".
 		try {
-			await setPrimary(id);
-			await user!.reload();
-			toast.success("Primary email updated");
+			await promoteAndCleanUp(pending.id, primaryId);
 		} catch (e) {
 			if (isReverificationCancelledError(e)) {
 				return;
 			}
-			toast.error("Could not set primary email");
+			toast.error(clerkErrorMessage(e, "Could not update email"));
 		}
 	}
-
-	async function remove(destroy: () => Promise<unknown>) {
-		try {
-			await removeEmail(destroy);
-			await user!.reload();
-			toast.success("Email removed");
-		} catch (e) {
-			if (isReverificationCancelledError(e)) {
-				return;
-			}
-			toast.error("Could not remove email");
-		}
-	}
-
-	const sortedEmails = [...user.emailAddresses].sort((a, b) => {
-		if (a.id === user!.primaryEmailAddressId) {
-			return -1;
-		}
-		if (b.id === user!.primaryEmailAddressId) {
-			return 1;
-		}
-		return 0;
-	});
 
 	return (
-		<SettingsSectionCard
-			title="Email addresses"
-			description="Add, verify, or remove email addresses."
-		>
-			<ul className="divide-y divide-border">
-				{sortedEmails.map((e) => (
-					<li
-						key={e.id}
-						className="flex flex-col gap-2 py-3 text-sm first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between"
-					>
-						<span className="flex min-w-0 items-center gap-2 text-foreground">
-							<span className="truncate">{e.emailAddress}</span>
-							{e.id === user.primaryEmailAddressId && (
-								<span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
-									Primary
-								</span>
-							)}
-						</span>
-						<span className="flex shrink-0 gap-2">
-							{e.id !== user.primaryEmailAddressId && (
-								<Button variant="outline" size="sm" onClick={() => makePrimary(e.id)}>
-									Make primary
-								</Button>
-							)}
-							<Button
-								variant="destructive"
-								size="sm"
-								disabled={user.emailAddresses.length <= 1}
-								title={
-									user.emailAddresses.length <= 1
-										? "You must keep at least one email address"
-										: undefined
-								}
-								aria-label={`Remove ${e.emailAddress}`}
-								onClick={() => remove(() => e.destroy())}
-							>
-								Remove
-							</Button>
-						</span>
-					</li>
-				))}
-			</ul>
+		<SettingsSectionCard title="Email" description="Change the email you use to sign in.">
+			<div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/40 px-3 py-2">
+				<span className="min-w-0 truncate font-mono text-foreground text-sm">{currentEmail}</span>
+				<span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
+					Primary
+				</span>
+			</div>
 
 			{pending ? (
 				<form
@@ -149,6 +158,9 @@ export function EmailSection() {
 							onChange={(ev) => setCode(ev.target.value)}
 						/>
 					</label>
+					<p className="mt-1 text-muted-foreground text-xs">
+						Enter the code we sent to confirm your new email.
+					</p>
 					<Button className="mt-2" type="submit">
 						Verify
 					</Button>
@@ -158,19 +170,19 @@ export function EmailSection() {
 					className="mt-4 flex items-end gap-2"
 					onSubmit={(ev) => {
 						ev.preventDefault();
-						add();
+						startChange();
 					}}
 				>
 					<label className="block flex-1 font-medium text-foreground text-sm">
-						Add email
+						New email
 						<input
 							className={inputClass}
 							type="email"
-							value={email}
-							onChange={(ev) => setEmail(ev.target.value)}
+							value={newEmail}
+							onChange={(ev) => setNewEmail(ev.target.value)}
 						/>
 					</label>
-					<Button type="submit">Add</Button>
+					<Button type="submit">Update email</Button>
 				</form>
 			)}
 		</SettingsSectionCard>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.601",
+      version: "0.5.602",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Five frontend UI/UX fixes around the Paddle onboarding flow and the Settings › Account page. All TDD'd; full frontend suite green (679 tests), biome + tsc clean. Verified live in a real browser (saas dev over a cloudflare tunnel) via CDP.

## Onboarding checkout (`billing-page.tsx`, `main.css`)
- **Declined card no longer bounces silently.** `CHECKOUT_PAYMENT_FAILED` now keeps Paddle's inline frame open so its decline reason + retry stay visible, instead of tearing the frame down and dumping the user back on the plan picker with only a transient toast. Genuine `CHECKOUT_ERROR` / `PAYMENT_ERROR` still close + surface a message.
- **Success transition no longer flashes blank.** The "Setting up your account…" bridge was gated on `needsSubscription`, which the activation push itself flips false → the panel unmounted mid-transition. Hoisted it above that gate so it holds until the wizard navigates.
- **Success screen fits its box.** Dropped the fixed `min-height:450px` on the Paddle inline frame so it auto-resizes down to the short success screen (`frameInitialHeight` still covers first paint).
- **Paddle overlay clickable from inside the Settings dialog.** Radix Dialog sets `body { pointer-events: none }`; Paddle's body-level overlay inherited it and couldn't be clicked. `.paddle-frame-overlay { pointer-events: auto }` re-enables it (no `!important`).

## Settings › Account (`email-section.tsx`, `connected-accounts-section.tsx`, `account-page.tsx`)
- **Email: single "update primary email" flow.** Replaces the multi-email manager. Add (or reuse an existing address) → verify code → set primary → best-effort remove the old address. Verification and promotion are separate so a post-verify failure isn't misreported as "Invalid code", and a cleanup failure doesn't present the (already-succeeded) change as a failure.
- **Connected accounts: Apple → Discord**, and only `verification.status === "verified"` accounts count as connected — an abandoned/failed OAuth link no longer shows as connected.

## Review
Ran through pr-review-toolkit code review: no critical/high issues; two Important findings in the email rewrite (partial-state failure + misattributed error message) fixed, with 3 added edge-case tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)