### PR TITLE
chore(frontend): ratchet correctness/useExhaustiveDependencies

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -80,7 +80,6 @@
 						"useQwikValidLexicalScope": "off",
 						"noInvalidPositionAtImportRule": "off",
 						"noUndeclaredDependencies": "off",
-						"useExhaustiveDependencies": "off",
 						"useImageSize": "off",
 						"useUniqueElementIds": "off"
 					},

--- a/frontend/docs/context/biome-linting.md
+++ b/frontend/docs/context/biome-linting.md
@@ -118,6 +118,26 @@ Intent lives in #812 and commit messages.
   bug); and necessary `?.` on `| null`/`| undefined` operands flagged "unnecessary".
   Enabling it would need ~15 `biome-ignore` on correct code. Treat like the framework-wrong
   rules in `overrides[0]`, not a deferred target.
+- **`useExhaustiveDependencies` — enabled with 5 real fixes + 7 justified `biome-ignore`
+  (#840).** This is the only React-hook dep checker (there is **no eslint** here; `lint` is
+  Biome-only, so the pre-existing `// eslint-disable-next-line react-hooks/exhaustive-deps`
+  comments were **dead** and were replaced). Four site shapes:
+  1. **Narrowed dep** ("more specific than its captures"): effect uses `user.id` but lists
+     `user?.id`. Fix honestly by **hoisting the primitive** (`const userId = user?.id;` then
+     dep `[userId]`) so capture == dep, preserving the narrow-refire intent (`use-channel`,
+     `note-page`). Watch `noEqualsToNull`: a hoisted `X | undefined` guard is `=== undefined`,
+     not `== null`.
+  2. **Mount-only fetch** (`refresh()` in `[]`): wrap `refresh` in `useCallback` with its
+     real deps, then dep `[refresh]` (`InvitesTab`; `MembersTab` needed a `useCallback`
+     cascade because its `sortUsers` captured `currentUserId`).
+  3. **Proxy key** Biome can't see (`discountIdKey = discountId ?? ""` used as the dep while
+     `discountId` is read inside): just add the real dep — behavior-neutral.
+  4. **Genuine intentional / false positive** → `biome-ignore` with a reason: stabilization
+     memos keyed on sub-fields or `JSON.stringify`, open-once effects guarded by a ref
+     (`inline-checkout` — live Paddle money-path, do NOT add deps), mount-only cache reads via
+     ref (`billing-page`), imperative `ref.current` handles (`app-layout`), and **trigger
+     deps** like `pathname` where the body only calls setters (`mobile-layout` — Biome calls
+     it "extra" but removing it breaks the feature).
 
 **Measure with the rule's REAL group.** `--only=<group>/<rule>` silently reports zero for a
 wrong group (e.g. `--only=style/noShadow` → 0, but the rule is `suspicious/noShadow` → 41).
@@ -145,9 +165,10 @@ Mechanical tier **complete**: `noLeakedRender` (#826), `useNamedCaptureGroup` (#
 `useDestructuring` (#828), `useImportsFirst` (#830), `useExportsLast` (#831), on top of
 the earlier a11y tier.
 
-Behavioral tier in progress: `noEqualsToNull` (#833), `noReturnAssign` (#834) merged,
-`noVoid` this PR. `noUnnecessaryConditions` dropped as permanently-off (see per-rule
-note above). Remaining in #812: `useExhaustiveDependencies` (~29, highest bug-value,
-riskiest autofix), `useAwait` (~31), `noShadow` (~41), `noEmptyBlockStatements` (~116) —
-all hand-review; plus config-gated `useAtIndex` (its `.at(-1)` autofix needs a tsconfig
-`lib` → es2022 bump in the same PR).
+Behavioral tier: `noEqualsToNull` (#833), `noReturnAssign` (#834), `noVoid` (#835),
+`useAwait` (#836), `noShadow` (#837), `noEmptyBlockStatements` (#838), and
+`useExhaustiveDependencies` (#840) merged. `noUnnecessaryConditions` dropped as
+permanently-off (see per-rule note above).
+
+Remaining in #812: config-gated `useAtIndex` (its `.at(-1)` autofix needs a tsconfig
+`lib` → es2022 bump in the same PR). With that, the behavioral tier is otherwise done.

--- a/frontend/src/api/use-channel.ts
+++ b/frontend/src/api/use-channel.ts
@@ -23,13 +23,18 @@ export function useChannel() {
 		getTokenRef.current = getToken;
 	}, [getToken]);
 
+	// Key the socket effect on the primitive id, not the whole `user` object: a
+	// new `user` identity on every `useMe` refetch would needlessly tear the
+	// socket down and back up. Hoisting `user?.id` makes the captured value and
+	// the dependency the same narrow primitive.
+	const userId = user?.id;
 	useEffect(() => {
-		if (!user || vaultId === null) {
+		if (userId === undefined || vaultId === null) {
 			return;
 		}
 
 		connectChannel({
-			userId: user.id,
+			userId,
 			vaultId,
 			getToken: () => getTokenRef.current(),
 			queryClient,
@@ -51,5 +56,5 @@ export function useChannel() {
 			removeTriggers();
 			removeCrdtResync();
 		};
-	}, [user?.id, vaultId]);
+	}, [userId, vaultId]);
 }

--- a/frontend/src/billing/billing-page.tsx
+++ b/frontend/src/billing/billing-page.tsx
@@ -274,6 +274,7 @@ export default function BillingPage({
 	// onboarding mode. Skipped for Free users who deliberately re-visit
 	// /onboard/billing to upgrade — bouncing them back to the next step
 	// defeats the upgrade affordance.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: mount-only synchronous cache check; qc identity is stable and onActivated is read via ref, and billing?.active is intentionally sampled on first paint only (the page renders Loading first anyway).
 	useEffect(() => {
 		if (!onActivatedRef.current) {
 			return;
@@ -286,10 +287,6 @@ export default function BillingPage({
 			onActivatedFiredRef.current = true;
 			onActivatedRef.current(cached);
 		}
-		// mount-only — qc identity is stable, onActivated read via ref.
-		// billing?.active read on first paint; the page renders Loading first
-		// anyway and we only want the synchronous case (cache hit).
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {

--- a/frontend/src/components/inline-checkout.tsx
+++ b/frontend/src/components/inline-checkout.tsx
@@ -109,10 +109,10 @@ export function InlineCheckout({
 		},
 	});
 
-	// Stable ref — effects re-run only when actual values change
+	// Stable ref so effects re-run only when an actual value changes.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally keyed on individual customer sub-fields so the memo recomputes only when a real value changes, not on every new `customer` object identity from props.
 	const stableCustomer = React.useMemo(
 		() => customer,
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[
 			customer?.id,
 			customer?.email,
@@ -128,11 +128,8 @@ export function InlineCheckout({
 		],
 	);
 
-	const stableCustomData = React.useMemo(
-		() => customData,
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[JSON.stringify(customData)],
-	);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keyed on JSON.stringify(customData) to stabilize by value; the raw `customData` object identity changes every render.
+	const stableCustomData = React.useMemo(() => customData, [JSON.stringify(customData)]);
 
 	const itemsKey = React.useMemo(
 		() => items.map((i) => `${i.priceId}:${i.quantity ?? 1}`).join(","),
@@ -145,7 +142,8 @@ export function InlineCheckout({
 	// cycle as openCheckout when isReady first becomes true.
 	const prevItemsKeyRef = React.useRef<string | null>(null);
 
-	// Open checkout once Paddle is ready
+	// Open checkout once Paddle is ready.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: opens the Paddle checkout exactly once (guarded by isOpenRef); intentionally keyed on isReady only so later prop churn cannot re-open or re-initialize the live checkout.
 	React.useEffect(() => {
 		if (!isReady || items.length === 0) {
 			return;
@@ -163,10 +161,10 @@ export function InlineCheckout({
 				...(successUrl && { successUrl }),
 			});
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isReady]);
 
-	// Update items reactively after mount
+	// Update items reactively after mount.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the memoized itemsKey, not the `items` array (new identity each render); items/updateItems are read fresh inside the effect.
 	React.useEffect(() => {
 		if (!(isReady && isOpenRef.current)) {
 			return;
@@ -185,7 +183,6 @@ export function InlineCheckout({
 		}
 		prevItemsKeyRef.current = itemsKey;
 		updateItems(items.map((i) => ({ priceId: i.priceId, quantity: i.quantity ?? 1 })));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [itemsKey, isReady]);
 
 	// Subscribe to all Paddle events: update summary + forward to onEvent

--- a/frontend/src/features/admin/InvitesTab.tsx
+++ b/frontend/src/features/admin/InvitesTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
 import { adminApi, type Invite } from "./api";
@@ -13,7 +13,7 @@ export default function InvitesTab() {
 	// The raw URL is shown ONCE — backend never returns it again. Don't persist.
 	const [lastUrl, setLastUrl] = useState<string | null>(null);
 
-	async function refresh() {
+	const refresh = useCallback(async () => {
 		try {
 			const res = await adminApi.listInvites();
 			setInvites(res.invites);
@@ -23,11 +23,11 @@ export default function InvitesTab() {
 		} finally {
 			setLoading(false);
 		}
-	}
+	}, []);
 
 	useEffect(() => {
 		refresh();
-	}, []);
+	}, [refresh]);
 
 	async function create(e: React.FormEvent) {
 		e.preventDefault();

--- a/frontend/src/features/admin/MembersTab.tsx
+++ b/frontend/src/features/admin/MembersTab.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight, Loader2 } from "lucide-react";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
 import { cn } from "@/lib/utils";
@@ -66,19 +66,21 @@ export default function MembersTab({
 		{},
 	);
 
-	function sortUsers(list: AdminUser[]): AdminUser[] {
-		return [...list].sort((a, b) => {
-			if (a.id === currentUserId) {
-				return -1;
-			}
-			if (b.id === currentUserId) {
-				return 1;
-			}
-			return 0;
-		});
-	}
+	const sortUsers = useCallback(
+		(list: AdminUser[]): AdminUser[] =>
+			[...list].sort((a, b) => {
+				if (a.id === currentUserId) {
+					return -1;
+				}
+				if (b.id === currentUserId) {
+					return 1;
+				}
+				return 0;
+			}),
+		[currentUserId],
+	);
 
-	async function refresh() {
+	const refresh = useCallback(async () => {
 		try {
 			const res = await adminApi.listUsers();
 			setUsers(sortUsers(res.users));
@@ -87,11 +89,11 @@ export default function MembersTab({
 		} finally {
 			setLoading(false);
 		}
-	}
+	}, [sortUsers]);
 
 	useEffect(() => {
 		refresh();
-	}, []);
+	}, [refresh]);
 
 	// Optimistic mutation: patch the local row immediately so the UI
 	// reflects the intent on the next paint. On success we refresh from

--- a/frontend/src/hooks/use-paddle-prices.tsx
+++ b/frontend/src/hooks/use-paddle-prices.tsx
@@ -105,7 +105,7 @@ export function usePaddlePrices(args: UsePaddlePricesArgs): {
 		} finally {
 			setLoading(false);
 		}
-	}, [paddle, priceIdsKey, countryCode, discountIdKey]);
+	}, [paddle, priceIdsKey, countryCode, discountId, discountIdKey]);
 
 	useEffect(() => {
 		fetchPrices();

--- a/frontend/src/layout/app-layout.tsx
+++ b/frontend/src/layout/app-layout.tsx
@@ -41,6 +41,7 @@ function DesktopLayout() {
 		}
 	};
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: rightRef.current exposes imperative panel handles, not reactive values; the effect intentionally keys on rightContent alone.
 	useEffect(() => {
 		if (rightContent === null || rightContent === undefined) {
 			rightRef.current?.collapse();

--- a/frontend/src/layout/mobile-layout.tsx
+++ b/frontend/src/layout/mobile-layout.tsx
@@ -37,6 +37,7 @@ export default function MobileLayout() {
 	// Programmatic navigations (e.g. clicking "New note" in FolderActions) don't
 	// trigger closeOnLinkClick. Close both drawers on any route change so the
 	// editor isn't hidden behind a still-open sheet on small screens.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname is a change trigger, not a captured value (the effect only calls setters); keying on it is required to close both drawers on navigation.
 	useEffect(() => {
 		setLeftOpen(false);
 		setRightOpen(false);

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -76,14 +76,19 @@ export default function NotePage() {
 	}, [note?.path]);
 
 	// ToC reads the materialized REST content (refreshed by note_changed).
+	// Hoist the two primitives the effect actually depends on so the captured
+	// values match the dependency list (a new `note` object identity each
+	// render would otherwise rebuild the ToC needlessly).
+	const notePath = note?.path;
+	const noteContent = note?.content;
 	useEffect(() => {
-		if (!note) {
+		if (notePath === undefined) {
 			setRightContent(null);
 			return;
 		}
-		setRightContent(<NoteToc content={note.content} />);
+		setRightContent(<NoteToc content={noteContent ?? ""} />);
 		return () => setRightContent(null);
-	}, [note?.path, note?.content, setRightContent]);
+	}, [notePath, noteContent, setRightContent]);
 
 	if (validId === null) {
 		return <p className="p-6 text-destructive">Invalid note id.</p>;

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.601",
+      version: "0.5.602",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Enables `correctness/useExhaustiveDependencies` in the frontend Biome config (Biome ratchet, refs #812). This is the **only** React-hook dependency checker in the repo — `lint` is Biome-only, so the pre-existing `// eslint-disable-next-line react-hooks/exhaustive-deps` comments were dead and are replaced here.

## 5 sites fixed honestly (no suppression)
- **use-channel, note-page** — hoist the narrowed primitive (`const userId = user?.id`) so the captured value and the dependency match, preserving the deliberate refire-scoping (socket survives token rotation; ToC doesn't rebuild on new `note` identity).
- **InvitesTab, MembersTab** — wrap the mount-fetch fn in `useCallback`, dep `[fn]`. MembersTab needed a cascade because `sortUsers` captures `currentUserId`.
- **use-paddle-prices** — add `discountId` (read inside the callback; `discountIdKey` was a value-proxy Biome can't follow) to the deps.

## 7 genuinely-intentional sites → `biome-ignore` with reason
Each replaces a dead eslint-disable or documents a Biome false positive:
- **inline-checkout ×4** — stabilization memos (keyed on sub-fields / `JSON.stringify`) + the open-once effect guarded by `isOpenRef`. This is the **live Paddle money-path**; adding deps would re-init the checkout overlay.
- **billing-page** — mount-only synchronous cache read (qc stable, `onActivated` via ref).
- **app-layout** — `rightRef.current` exposes imperative panel handles, not reactive values.
- **mobile-layout** — `pathname` is a change *trigger* (body only calls setters); Biome flags it "extra" but removing it breaks close-drawers-on-navigation.

Per the anti-suppression rule, the 7 ignores were surfaced and approved before adding; they document already-correct code rather than hiding a real omission.

## Verify
- `biome ci` clean (382 files)
- `tsc --noEmit` exit 0
- `vitest run` 672/672

Doc `frontend/docs/context/biome-linting.md` updated (per-rule note + progress). Refs #812