### PR TITLE
chore(frontend): ratchet style/useAtIndex + tsconfig lib ES2022

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -130,7 +130,6 @@
 						"noNestedTernary": "off",
 						"noNonNullAssertion": "off",
 						"noParameterProperties": "off",
-						"useAtIndex": "off",
 						"useComponentExportOnlyModules": "off",
 						"useConsistentMemberAccessibility": "off",
 						"useConsistentMethodSignatures": "off"

--- a/frontend/docs/context/biome-linting.md
+++ b/frontend/docs/context/biome-linting.md
@@ -26,8 +26,10 @@ then turns two sets back off:
   nursery pulls in; and React/TS-hostile rules (`noTernary`, `noJsxLiterals`,
   `useExplicitType`/`useExplicitReturnType`, `noMagicNumbers`, `noNonNullAssertion`,
   `useNamingConvention` — the API is **snake_case**, so this would fight every DTO).
-- **(b) Ratchet-deferred** — real rules the current code violates, to be re-enabled
-  one-per-PR. Tracked in **engram-app/Engram issue #812**.
+- **(b) Ratchet-deferred** — real rules the current code violated, re-enabled one-per-PR
+  under **engram-app/Engram issue #812** (now **COMPLETE** — see Progress below). The only
+  rule left permanently off from this bucket is `noUnnecessaryConditions` (Biome false
+  positives), which has effectively graduated to bucket (a).
 
 There is no per-rule comment distinguishing (a) from (b) in the file — see gotcha §1.
 Intent lives in #812 and commit messages.
@@ -166,9 +168,13 @@ Mechanical tier **complete**: `noLeakedRender` (#826), `useNamedCaptureGroup` (#
 the earlier a11y tier.
 
 Behavioral tier: `noEqualsToNull` (#833), `noReturnAssign` (#834), `noVoid` (#835),
-`useAwait` (#836), `noShadow` (#837), `noEmptyBlockStatements` (#838), and
-`useExhaustiveDependencies` (#840) merged. `noUnnecessaryConditions` dropped as
-permanently-off (see per-rule note above).
+`useAwait` (#836), `noShadow` (#837), `noEmptyBlockStatements` (#838),
+`useExhaustiveDependencies` (#840), and `useAtIndex` (#841) merged. `useAtIndex` also
+bumped `tsconfig` `lib` `ES2020` → `ES2022` so `.at()` types resolve (the 5 sites were
+all `[x.length - 1]` with an existing `?`/`!` guard, so `.at(-1)`'s `T | undefined`
+return was safe). `noUnnecessaryConditions` dropped as permanently-off (see per-rule note
+above).
 
-Remaining in #812: config-gated `useAtIndex` (its `.at(-1)` autofix needs a tsconfig
-`lib` → es2022 bump in the same PR). With that, the behavioral tier is otherwise done.
+**#812 CLOSED — ratchet complete.** Every deferred rule is either enabled or intentionally
+off with documented rationale (`noUnnecessaryConditions` in `overrides[0]`). No rules
+remain to ratchet.

--- a/frontend/src/api/cursor-sync.ts
+++ b/frontend/src/api/cursor-sync.ts
@@ -118,7 +118,7 @@ function nextCursor(page: ChangesPage, prev: string): string {
 	if (page.next_cursor) {
 		return page.next_cursor;
 	}
-	const last = page.changes[page.changes.length - 1];
+	const last = page.changes.at(-1);
 	return last ? encodeCursor(last.seq, last.id) : prev;
 }
 

--- a/frontend/src/crdt/channel.test.ts
+++ b/frontend/src/crdt/channel.test.ts
@@ -40,7 +40,7 @@ describe("CrdtChannel", () => {
 		// session forwards via sendUpdateRaw; emulate it:
 		const update = await aMgr.encodeStateAsUpdate("n.md");
 		aCh.sendUpdateRaw(aMgr.docId("n.md"), update);
-		const [, frame] = aSends[aSends.length - 1]!;
+		const [, frame] = aSends.at(-1)!;
 
 		const bMgr = mkManager();
 		const bCh = new CrdtChannel({ manager: bMgr, send: () => {} });

--- a/frontend/src/crdt/session.test.ts
+++ b/frontend/src/crdt/session.test.ts
@@ -48,7 +48,7 @@ describe("crdt session", () => {
 		const handle = await openDoc("note.md");
 		handle!.ytext.insert(0, "abc");
 		await vi.waitFor(() => expect(push).toHaveBeenCalled());
-		expect(push.mock.calls[push.mock.calls.length - 1]![0]).toBe(`${VAULT}/note.md`);
+		expect(push.mock.calls.at(-1)![0]).toBe(`${VAULT}/note.md`);
 	});
 
 	it("docPathFromDocId strips the vault prefix", () => {
@@ -75,7 +75,7 @@ describe("crdt session", () => {
 		const a = await openDoc("note.md");
 		a!.ytext.insert(0, "ghost-content");
 		await vi.waitFor(() => expect(frames.length).toBeGreaterThan(0));
-		const [, b64] = frames[frames.length - 1]!;
+		const [, b64] = frames.at(-1)!;
 		stopCrdtSession();
 
 		// New session — do NOT open ghost.md
@@ -94,7 +94,7 @@ describe("crdt session", () => {
 		const a = await openDoc("note.md");
 		a!.ytext.insert(0, "payload");
 		await vi.waitFor(() => expect(frames.length).toBeGreaterThan(0));
-		const [, b64] = frames[frames.length - 1]!;
+		const [, b64] = frames.at(-1)!;
 		stopCrdtSession();
 		startCrdtSession({ vaultId: VAULT, push: () => {} });
 		await openDoc("note.md");

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"useDefineForClassFields": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.602",
+      version: "0.5.603",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Enables `style/useAtIndex` — the **final rule** in the #812 Biome ratchet.

## Config
- `tsconfig.json` `lib` `ES2020` → `ES2022` so `Array.prototype.at()` types resolve. `target` stays `ES2020` (tsc is `noEmit` here; Vite/esbuild does the build and already targets modern browsers, all of which support `.at()`).

## Sites (5, hand-fixed — Biome classifies the fix unsafe)
All were `arr[arr.length - 1]` with an existing guard, so `.at(-1)`'s `T | undefined` return is safe:
- `api/cursor-sync.ts` `nextCursor` — guarded by `last ?`
- `crdt/channel.test.ts` + `crdt/session.test.ts` ×4 — all `!`-asserted

## Verify
- `biome ci` clean (382 files)
- `tsc --noEmit` exit 0 (lib bump clean)
- `vitest run` 679/679

Closes the ratchet: every #812 rule is now enabled or intentionally off with documented rationale (`noUnnecessaryConditions`). Doc `frontend/docs/context/biome-linting.md` updated. Closes #812