### PR TITLE
perf(frontend): cut sign-in critical path (dormant inline-bootstrap flag, app-shell code split, splash, lazy Sentry)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4375,6 +4375,11 @@ jobs:
           VITE_CLERK_WAITLIST_MODE: 'false'
           VITE_API_BASE: https://api.engram.page
           VITE_WS_BASE: wss://api.engram.page
+          # Activates the inlineBootstrap vite plugin: inline
+          # window.__ENGRAM_CONFIG__ (no /config.json round trip), preconnect
+          # to clerk.engram.page, and modulepreload of the Clerk chunks. The
+          # plugin hard-fails the build if the VITE_* config above is missing.
+          VITE_INLINE_BOOTSTRAP_CONFIG: '1'
           # PROD publishable key (pk_live_…). Distinct from the repo SECRET
           # `VITE_CLERK_PUBLISHABLE_KEY`, which is the pk_test the e2e CI uses
           # — baking that here would point the live app at the dev Clerk

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4375,11 +4375,10 @@ jobs:
           VITE_CLERK_WAITLIST_MODE: 'false'
           VITE_API_BASE: https://api.engram.page
           VITE_WS_BASE: wss://api.engram.page
-          # Activates the inlineBootstrap vite plugin: inline
-          # window.__ENGRAM_CONFIG__ (no /config.json round trip), preconnect
-          # to clerk.engram.page, and modulepreload of the Clerk chunks. The
-          # plugin hard-fails the build if the VITE_* config above is missing.
-          VITE_INLINE_BOOTSTRAP_CONFIG: '1'
+          # VITE_INLINE_BOOTSTRAP_CONFIG=1 (inline config + Clerk preconnect +
+          # modulepreload) is set by the build:saas script itself so local saas
+          # builds produce the same artifact as CI. The plugin hard-fails the
+          # build if the VITE_* config above is missing.
           # PROD publishable key (pk_live_…). Distinct from the repo SECRET
           # `VITE_CLERK_PUBLISHABLE_KEY`, which is the pk_test the e2e CI uses
           # — baking that here would point the live app at the dev Clerk

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,7 +25,24 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!-- Static splash: paints as soon as the (render-blocking) stylesheet
+           lands, long before the JS bundle parses and React mounts. React's
+           createRoot().render() replaces it with the app. Markup + classes
+           mirror src/layout/loading-screen.tsx so the splash → LoadingScreen
+           handoff is pixel-identical (keep the two in sync). -->
+      <main
+        role="status"
+        aria-label="Loading"
+        class="flex h-screen flex-col items-center justify-center gap-3 bg-background text-foreground"
+      >
+        <span
+          aria-hidden="true"
+          class="size-6 animate-spin rounded-full border-2 border-border border-t-primary"
+        ></span>
+        <p class="text-muted-foreground text-sm">Loading…</p>
+      </main>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
 		"dev": "vite",
 		"build": "bun run build:selfhost",
 		"build:selfhost": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build",
-		"build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build --outDir dist --emptyOutDir && bun scripts/write-config-json.ts dist/config.json",
+		"build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && VITE_INLINE_BOOTSTRAP_CONFIG=1 vite build --outDir dist --emptyOutDir && bun scripts/write-config-json.ts dist/config.json",
 		"preview": "vite preview",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/frontend/src/billing/upgrade-dialog-provider.test.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.test.tsx
@@ -36,7 +36,11 @@ describe("UpgradeDialogProvider", () => {
 			</UpgradeDialogProvider>,
 		);
 		fireEvent.click(screen.getByText("show"));
-		await waitFor(() => expect(screen.getByText(/note limit/iu)).toBeInTheDocument());
+		// Generous timeout: the dialog is lazy() now, and the FIRST test to touch
+		// it pays vitest's cold on-demand transform of the chunk (>1s).
+		expect(
+			await screen.findByText(/note limit/iu, undefined, { timeout: 5000 }),
+		).toBeInTheDocument();
 	});
 
 	it("dialog closes when onOpenChange(false) fires", async () => {

--- a/frontend/src/billing/upgrade-dialog-provider.test.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.test.tsx
@@ -50,8 +50,10 @@ describe("UpgradeDialogProvider", () => {
 			</UpgradeDialogProvider>,
 		);
 		fireEvent.click(screen.getByText("show"));
-		// Radix Dialog provides only an X (sr-only "Close") to dismiss.
-		const dismiss = await screen.findByRole("button", { name: /close/iu });
+		// Radix Dialog provides only an X (sr-only "Close") to dismiss. Same 5s
+		// timeout as above: whichever test runs FIRST pays the cold transform of
+		// the lazy dialog chunk, so neither may assume a warm module cache.
+		const dismiss = await screen.findByRole("button", { name: /close/iu }, { timeout: 5000 });
 		fireEvent.click(dismiss);
 		await waitFor(() => expect(screen.queryByText(/note limit/iu)).not.toBeInTheDocument());
 	});

--- a/frontend/src/billing/upgrade-dialog-provider.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.tsx
@@ -31,7 +31,9 @@ export function UpgradeDialogProvider({ children }: { children: ReactNode }) {
 		// Warm-up failure is non-fatal (the lazy() render path + the
 		// vite:preloadError reload handle a real one); catch only prevents an
 		// unhandled rejection.
-		import("./upgrade-required-dialog").catch(() => {});
+		import("./upgrade-required-dialog").catch((err) => {
+			console.warn("[upgrade-dialog] chunk warm-up failed (non-fatal):", err);
+		});
 		return () => setUpgradeHandler(null);
 	}, [showUpgrade]);
 

--- a/frontend/src/billing/upgrade-dialog-provider.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.tsx
@@ -25,6 +25,10 @@ export function UpgradeDialogProvider({ children }: { children: ReactNode }) {
 	// leak between provider remounts (StrictMode, HMR, tests).
 	useEffect(() => {
 		setUpgradeHandler(showUpgrade);
+		// Warm the lazy dialog chunk off the critical path (module cache dedupes
+		// with the lazy() import) — a 402 on a slow connection should open the
+		// dialog immediately, not after a cold chunk round trip of dead air.
+		void import("./upgrade-required-dialog");
 		return () => setUpgradeHandler(null);
 	}, [showUpgrade]);
 

--- a/frontend/src/billing/upgrade-dialog-provider.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.tsx
@@ -1,9 +1,14 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useState } from "react";
 
 import { setUpgradeHandler } from "@/api/client";
 
-import { UpgradeRequiredDialog } from "./upgrade-required-dialog";
+// Lazy: the provider mounts at the router root (so it wraps the sign-in page
+// too), but the dialog itself only renders after a 402 — no reason for its
+// radix-dialog + billing-copy weight to sit in the eager entry bundle.
+const UpgradeRequiredDialog = lazy(() =>
+	import("./upgrade-required-dialog").then((m) => ({ default: m.UpgradeRequiredDialog })),
+);
 
 interface Ctx {
 	showUpgrade: (reason: string) => void;
@@ -27,15 +32,17 @@ export function UpgradeDialogProvider({ children }: { children: ReactNode }) {
 		<UpgradeCtx.Provider value={{ showUpgrade }}>
 			{children}
 			{reason ? (
-				<UpgradeRequiredDialog
-					reason={reason}
-					open={true}
-					onOpenChange={(open) => {
-						if (!open) {
-							setReason(null);
-						}
-					}}
-				/>
+				<Suspense fallback={null}>
+					<UpgradeRequiredDialog
+						reason={reason}
+						open={true}
+						onOpenChange={(open) => {
+							if (!open) {
+								setReason(null);
+							}
+						}}
+					/>
+				</Suspense>
 			) : null}
 		</UpgradeCtx.Provider>
 	);

--- a/frontend/src/billing/upgrade-dialog-provider.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.tsx
@@ -28,7 +28,10 @@ export function UpgradeDialogProvider({ children }: { children: ReactNode }) {
 		// Warm the lazy dialog chunk off the critical path (module cache dedupes
 		// with the lazy() import) — a 402 on a slow connection should open the
 		// dialog immediately, not after a cold chunk round trip of dead air.
-		void import("./upgrade-required-dialog");
+		// Warm-up failure is non-fatal (the lazy() render path + the
+		// vite:preloadError reload handle a real one); catch only prevents an
+		// unhandled rejection.
+		import("./upgrade-required-dialog").catch(() => {});
 		return () => setUpgradeHandler(null);
 	}, [showUpgrade]);
 

--- a/frontend/src/error-fallback.tsx
+++ b/frontend/src/error-fallback.tsx
@@ -1,10 +1,9 @@
-import * as Sentry from "@sentry/react";
 import { Button } from "@/components/ui/button";
 import { heading } from "@/lib/ui-classes";
 import AuthBackdrop from "./layout/auth-backdrop";
 import AuthPanel from "./layout/auth-panel";
 
-// Top-level crash page rendered by `<Sentry.ErrorBoundary>` in main.tsx.
+// Top-level crash page rendered by `RootErrorBoundary` in main.tsx.
 //
 // CRITICAL: this renders OUTSIDE every provider (it replaces the whole app
 // subtree), so it must not touch RouterProvider, ThemeProvider, or config
@@ -13,25 +12,19 @@ import AuthPanel from "./layout/auth-panel";
 // header inlined here WITHOUT the ThemeToggle (which needs theme context).
 // Brand color tokens are global CSS, so they resolve fine without a provider.
 //
-// Sentry passes `{ error, componentStack, eventId, resetError }` to the
-// fallback; we surface `eventId` as a support reference and `error` (dev only).
-//
-// `reported` gates the "has been reported" claim + the reference id. Sentry
-// hands us an eventId even when no client is initialized (dev / self-host with
-// no VITE_SENTRY_DSN), but that id has no transport behind it — claiming the
-// crash was reported would be a lie. `getClient()` is truthy only when
-// Sentry.init actually ran, so we default to it and let tests inject the flag.
+// `reported` gates the "has been reported" claim + the reference id — claiming
+// a crash was reported when no Sentry client has transport behind it would be
+// a lie. The boundary sets it (with the eventId) only after captureException
+// actually dispatched; the SDK is lazy-loaded, so no sync default is possible
+// here and it defaults to false. Must NOT import @sentry/react — this file is
+// in the eager entry bundle.
 interface ErrorFallbackProps {
 	error: unknown;
 	eventId?: string;
 	reported?: boolean;
 }
 
-export default function ErrorFallback({
-	error,
-	eventId,
-	reported = Boolean(Sentry.getClient()),
-}: ErrorFallbackProps) {
+export default function ErrorFallback({ error, eventId, reported = false }: ErrorFallbackProps) {
 	const message = error instanceof Error ? error.message : String(error);
 
 	return (

--- a/frontend/src/layout/app-shell.ts
+++ b/frontend/src/layout/app-shell.ts
@@ -1,0 +1,12 @@
+// Barrel for the authenticated app shell. The router lazy()-imports every
+// layout through THIS module so they land in ONE async chunk — four separate
+// lazy(() => import("./x")) calls would nest three Suspense boundaries into a
+// sequential chunk-fetch waterfall (gate → shell → app-layout) on every
+// signed-in load. Keeping the shell out of the eager entry is what keeps
+// yjs/phoenix/react-joyride/react-resizable-panels off the sign-in page's
+// critical path.
+
+export { default as OnboardingGate } from "../onboarding/onboarding-gate";
+export { OnboardingShell } from "../onboarding/onboarding-shell";
+export { default as SettingsLayout } from "../settings/settings-layout";
+export { default as AppLayout } from "./app-layout";

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -3,11 +3,9 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Light highlight.js theme — applies by default. */
-@import "highlight.js/styles/github.css" layer(base);
-
-/* KaTeX math styles. */
-@import "katex/dist/katex.min.css" layer(base);
+/* highlight.js + KaTeX styles moved to viewer/markdown.css (imported by
+ * note-view.tsx) so they ride the lazy viewer chunk, not the render-blocking
+ * stylesheet that gates the sign-in page. */
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/inter";
@@ -152,82 +150,7 @@
 	}
 }
 
-/* Dark highlight.js theme — wrapped so it only applies under `.dark`. */
 @layer base {
-	html.dark .hljs {
-		color: #c9d1d9;
-		background: #0d1117;
-	}
-	html.dark .hljs-doctag,
-	html.dark .hljs-keyword,
-	html.dark .hljs-meta .hljs-keyword,
-	html.dark .hljs-template-tag,
-	html.dark .hljs-template-variable,
-	html.dark .hljs-type,
-	html.dark .hljs-variable.language_ {
-		color: #ff7b72;
-	}
-	html.dark .hljs-title,
-	html.dark .hljs-title.class_,
-	html.dark .hljs-title.class_.inherited__,
-	html.dark .hljs-title.function_ {
-		color: #d2a8ff;
-	}
-	html.dark .hljs-attr,
-	html.dark .hljs-attribute,
-	html.dark .hljs-literal,
-	html.dark .hljs-meta,
-	html.dark .hljs-number,
-	html.dark .hljs-operator,
-	html.dark .hljs-variable,
-	html.dark .hljs-selector-attr,
-	html.dark .hljs-selector-class,
-	html.dark .hljs-selector-id {
-		color: #79c0ff;
-	}
-	html.dark .hljs-regexp,
-	html.dark .hljs-string,
-	html.dark .hljs-meta .hljs-string {
-		color: #a5d6ff;
-	}
-	html.dark .hljs-built_in,
-	html.dark .hljs-symbol {
-		color: #ffa657;
-	}
-	html.dark .hljs-comment,
-	html.dark .hljs-code,
-	html.dark .hljs-formula {
-		color: #8b949e;
-	}
-	html.dark .hljs-name,
-	html.dark .hljs-quote,
-	html.dark .hljs-selector-tag,
-	html.dark .hljs-selector-pseudo {
-		color: #7ee787;
-	}
-	html.dark .hljs-section {
-		color: #1f6feb;
-		font-weight: bold;
-	}
-	html.dark .hljs-bullet {
-		color: #f2cc60;
-	}
-	html.dark .hljs-emphasis {
-		color: #c9d1d9;
-		font-style: italic;
-	}
-	html.dark .hljs-strong {
-		color: #c9d1d9;
-		font-weight: bold;
-	}
-	html.dark .hljs-addition {
-		color: #aff5b4;
-		background: #033a16;
-	}
-	html.dark .hljs-deletion {
-		color: #ffdcd7;
-		background: #67060c;
-	}
 	* {
 		@apply border-border outline-ring/50;
 	}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,6 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { lazy, StrictMode, Suspense, use, useMemo } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
-import { Toaster } from "@/components/ui/sonner";
 import { setApiBase, setWsBase } from "./api/base";
 import { queryClient } from "./api/query-client";
 import { configPromise, type EngramConfig } from "./config";
@@ -81,6 +80,12 @@ if (posthogKey) {
 const ClerkAuthProvider = lazy(() => import("./auth/clerk-auth-provider"));
 const LocalAuthProvider = lazy(() => import("./auth/local-auth-provider"));
 
+// sonner (~32 KB) is toast plumbing, not first-paint UI — lazy so it loads in
+// parallel after mount instead of inside the eager bundle that gates the
+// sign-in page. Worst case a toast fired before the chunk lands is dropped;
+// toasts are interaction-driven, so that window is effectively unreachable.
+const Toaster = lazy(() => import("@/components/ui/sonner").then((m) => ({ default: m.Toaster })));
+
 // Bootstrap chain: `use(configPromise)` suspends until config resolves
 // (window injection → /config.json → defaults). Once resolved, build the
 // runtime router (route shape depends on auth provider + billingEnabled)
@@ -112,7 +117,11 @@ function AppShell({ config }: { config: EngramConfig }) {
 					<AuthProvider>
 						<QueryClientProvider client={queryClient}>
 							<RouterProvider router={router} />
-							<Toaster richColors closeButton />
+							{/* Own boundary — a suspending Toaster must not trip the outer
+							    fallback and blank the app to LoadingScreen. */}
+							<Suspense fallback={null}>
+								<Toaster richColors closeButton />
+							</Suspense>
 						</QueryClientProvider>
 					</AuthProvider>
 				</Suspense>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,5 @@
-import * as Sentry from "@sentry/react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { lazy, StrictMode, Suspense, use, useMemo } from "react";
+import { Component, lazy, type ReactNode, StrictMode, Suspense, use, useMemo } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
 import { setApiBase, setWsBase } from "./api/base";
@@ -17,19 +16,28 @@ import "./main.css";
 // network calls) when the env var is unset, so dev / self-host
 // builds are unaffected. Tracing + replay stay off in Tier 1;
 // OpenTelemetry → Tempo lands in Tier 2 with explicit sampling.
+//
+// Dynamically imported (like posthog below) so the SDK stays out of the eager
+// bundle that gates the sign-in page. Tradeoff, named: a non-render error in
+// the few-hundred-ms window before the chunk lands goes unreported (the SDK's
+// global handlers install at init). Render crashes are NOT lost —
+// RootErrorBoundary awaits `sentryReady` before capturing.
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
-if (sentryDsn) {
-	Sentry.init({
-		dsn: sentryDsn,
-		environment: import.meta.env.MODE,
-		release: import.meta.env.VITE_GIT_SHA,
-		integrations: [],
-		// sendDefaultPii=false (SDK default) keeps cookies + the
-		// Authorization header out of breadcrumbs even if the SDK's
-		// own scrubbing misses something. Restated for documentation.
-		sendDefaultPii: false,
-	});
-}
+const sentryReady = sentryDsn
+	? import("@sentry/react").then((Sentry) => {
+			Sentry.init({
+				dsn: sentryDsn,
+				environment: import.meta.env.MODE,
+				release: import.meta.env.VITE_GIT_SHA,
+				integrations: [],
+				// sendDefaultPii=false (SDK default) keeps cookies + the
+				// Authorization header out of breadcrumbs even if the SDK's
+				// own scrubbing misses something. Restated for documentation.
+				sendDefaultPii: false,
+			});
+			return Sentry;
+		})
+	: null;
 
 // Cloudflare Web Analytics — cookieless RUM beacon. Opt-in via
 // VITE_CF_BEACON_TOKEN at build time; no-op when unset so dev /
@@ -94,7 +102,7 @@ const Toaster = lazy(() => import("@/components/ui/sonner").then((m) => ({ defau
 function AppShell({ config }: { config: EngramConfig }) {
 	// Dev-only crash trigger for eyeballing ErrorFallback. Throws HERE, above
 	// RouterProvider, on purpose: a throwing *route* would be caught by React
-	// Router's own error boundary, not the outer Sentry.ErrorBoundary we're
+	// Router's own error boundary, not the outer RootErrorBoundary we're
 	// styling. Visit `?boom` to see the real crash page. Stripped from prod
 	// builds by the import.meta.env.DEV gate.
 	if (import.meta.env.DEV && new URLSearchParams(window.location.search).has("boom")) {
@@ -141,12 +149,50 @@ function BootstrapGate() {
 	return <AppShell config={config} />;
 }
 
+// Replaces Sentry.ErrorBoundary so the SDK can load lazily. Capture waits on
+// `sentryReady`, then surfaces the eventId + an honest `reported` flag to
+// ErrorFallback (only claimed once captureException actually dispatched).
+interface RootErrorBoundaryState {
+	hasError: boolean;
+	error: unknown;
+	eventId?: string;
+	reported: boolean;
+}
+
+class RootErrorBoundary extends Component<{ children: ReactNode }, RootErrorBoundaryState> {
+	state: RootErrorBoundaryState = { hasError: false, error: null, reported: false };
+
+	static getDerivedStateFromError(error: unknown): Partial<RootErrorBoundaryState> {
+		return { hasError: true, error };
+	}
+
+	componentDidCatch(error: unknown) {
+		sentryReady?.then((Sentry) => {
+			const eventId = Sentry.captureException(error);
+			this.setState({ eventId, reported: true });
+		});
+	}
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<ErrorFallback
+					error={this.state.error}
+					eventId={this.state.eventId}
+					reported={this.state.reported}
+				/>
+			);
+		}
+		return this.props.children;
+	}
+}
+
 createRoot(document.getElementById("root")!).render(
-	<Sentry.ErrorBoundary fallback={ErrorFallback}>
+	<RootErrorBoundary>
 		<StrictMode>
 			<Suspense fallback={<LoadingScreen />}>
 				<BootstrapGate />
 			</Suspense>
 		</StrictMode>
-	</Sentry.ErrorBoundary>,
+	</RootErrorBoundary>,
 );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,31 +12,79 @@ import { createAppRouter, installAppRouter } from "./router";
 import { ThemeProvider } from "./theme/theme-provider";
 import "./main.css";
 
+// Stale-deploy self-heal. Every lazy() below (app shell, Clerk provider,
+// Toaster, upgrade dialog, …) is a hashed chunk that a deploy can rotate out
+// from under an open tab; without this, the next lazy render 404s and the
+// throw lands on React Router's default error page (no route defines
+// errorElement). Vite fires `vite:preloadError` for failed dynamic-import
+// loads — reload once to pick up the fresh index.html + hashes.
+// preventDefault() suppresses the rethrow for the reload we handle; the
+// 30s guard means a genuinely broken asset host degrades back to the error
+// page instead of a reload loop.
+window.addEventListener("vite:preloadError", (event) => {
+	const KEY = "engram:chunk-reload-at";
+	const last = Number(sessionStorage.getItem(KEY) ?? 0);
+	if (Date.now() - last < 30_000) {
+		return;
+	}
+	sessionStorage.setItem(KEY, String(Date.now()));
+	event.preventDefault();
+	window.location.reload();
+});
+
 // Sentry — opt-in via VITE_SENTRY_DSN at build time. No-op (zero
 // network calls) when the env var is unset, so dev / self-host
 // builds are unaffected. Tracing + replay stay off in Tier 1;
 // OpenTelemetry → Tempo lands in Tier 2 with explicit sampling.
 //
 // Dynamically imported (like posthog below) so the SDK stays out of the eager
-// bundle that gates the sign-in page. Tradeoff, named: a non-render error in
-// the few-hundred-ms window before the chunk lands goes unreported (the SDK's
-// global handlers install at init). Render crashes are NOT lost —
-// RootErrorBoundary awaits `sentryReady` before capturing.
+// bundle that gates the sign-in page. The pre-init gap is bridged by the
+// early-error queue below: window error/unhandledrejection events that fire
+// before the chunk lands are buffered and flushed into captureException once
+// init runs, so bootstrap-window crashes still report. Resolves to null when
+// the chunk itself fails to load (ad-blockers match "sentry" in asset URLs;
+// stale-tab 404s) — callers must tolerate that, and it must NOT surface as an
+// unhandled rejection.
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
-const sentryReady = sentryDsn
-	? import("@sentry/react").then((Sentry) => {
-			Sentry.init({
-				dsn: sentryDsn,
-				environment: import.meta.env.MODE,
-				release: import.meta.env.VITE_GIT_SHA,
-				integrations: [],
-				// sendDefaultPii=false (SDK default) keeps cookies + the
-				// Authorization header out of breadcrumbs even if the SDK's
-				// own scrubbing misses something. Restated for documentation.
-				sendDefaultPii: false,
-			});
-			return Sentry;
-		})
+
+type SentrySdk = typeof import("@sentry/react");
+
+const earlyErrors: unknown[] = [];
+const onEarlyError = (e: ErrorEvent) => earlyErrors.push(e.error ?? e.message);
+const onEarlyRejection = (e: PromiseRejectionEvent) => earlyErrors.push(e.reason);
+if (sentryDsn) {
+	window.addEventListener("error", onEarlyError);
+	window.addEventListener("unhandledrejection", onEarlyRejection);
+}
+
+const sentryReady: Promise<SentrySdk | null> | null = sentryDsn
+	? import("@sentry/react")
+			.then((Sentry) => {
+				Sentry.init({
+					dsn: sentryDsn,
+					environment: import.meta.env.MODE,
+					release: import.meta.env.VITE_GIT_SHA,
+					integrations: [],
+					// sendDefaultPii=false (SDK default) keeps cookies + the
+					// Authorization header out of breadcrumbs even if the SDK's
+					// own scrubbing misses something. Restated for documentation.
+					sendDefaultPii: false,
+				});
+				// The SDK's own global handlers are live from here; hand it the
+				// backlog and retire the temporary listeners.
+				window.removeEventListener("error", onEarlyError);
+				window.removeEventListener("unhandledrejection", onEarlyRejection);
+				for (const err of earlyErrors.splice(0)) {
+					Sentry.captureException(err);
+				}
+				return Sentry as SentrySdk;
+			})
+			.catch((err) => {
+				window.removeEventListener("error", onEarlyError);
+				window.removeEventListener("unhandledrejection", onEarlyRejection);
+				console.warn("[sentry] SDK failed to load — crash reporting disabled:", err);
+				return null;
+			})
 	: null;
 
 // Cloudflare Web Analytics — cookieless RUM beacon. Opt-in via
@@ -94,6 +142,25 @@ const LocalAuthProvider = lazy(() => import("./auth/local-auth-provider"));
 // toasts are interaction-driven, so that window is effectively unreachable.
 const Toaster = lazy(() => import("@/components/ui/sonner").then((m) => ({ default: m.Toaster })));
 
+// Toasts are cosmetic: if the sonner chunk is truly unloadable (network flake
+// that survives the vite:preloadError reload), losing toasts must not take
+// down an otherwise working app via RootErrorBoundary.
+class OptionalBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+	state = { failed: false };
+
+	static getDerivedStateFromError() {
+		return { failed: true };
+	}
+
+	componentDidCatch(error: unknown) {
+		console.warn("[toaster] disabled — chunk failed to load:", error);
+	}
+
+	render() {
+		return this.state.failed ? null : this.props.children;
+	}
+}
+
 // Bootstrap chain: `use(configPromise)` suspends until config resolves
 // (window injection → /config.json → defaults). Once resolved, build the
 // runtime router (route shape depends on auth provider + billingEnabled)
@@ -127,9 +194,11 @@ function AppShell({ config }: { config: EngramConfig }) {
 							<RouterProvider router={router} />
 							{/* Own boundary — a suspending Toaster must not trip the outer
 							    fallback and blank the app to LoadingScreen. */}
-							<Suspense fallback={null}>
-								<Toaster richColors closeButton />
-							</Suspense>
+							<OptionalBoundary>
+								<Suspense fallback={null}>
+									<Toaster richColors closeButton />
+								</Suspense>
+							</OptionalBoundary>
 						</QueryClientProvider>
 					</AuthProvider>
 				</Suspense>
@@ -166,9 +235,14 @@ class RootErrorBoundary extends Component<{ children: ReactNode }, RootErrorBoun
 		return { hasError: true, error };
 	}
 
-	componentDidCatch(error: unknown) {
+	componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
+		// captureReactException is what Sentry.ErrorBoundary itself uses — it
+		// attaches the React componentStack, which plain captureException drops.
 		sentryReady?.then((Sentry) => {
-			const eventId = Sentry.captureException(error);
+			if (!Sentry) {
+				return;
+			}
+			const eventId = Sentry.captureReactException(error, errorInfo);
 			this.setState({ eventId, reported: true });
 		});
 	}

--- a/frontend/src/onboarding/onboard-entry.ts
+++ b/frontend/src/onboarding/onboard-entry.ts
@@ -1,0 +1,6 @@
+// Barrel for the onboarding entry surface (layout + index redirect), lazy()-
+// imported by the router through this single module so both land in one async
+// chunk instead of a nested lazy waterfall. Individual wizard steps stay as
+// their own lazy chunks. See layout/app-shell.ts for the same pattern.
+export { default as OnboardLayout } from "./onboard-layout";
+export { default as OnboardRedirect } from "./onboard-redirect";

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,20 +7,37 @@ import SignUpPage from "./auth/sign-up";
 import WaitlistPage from "./auth/waitlist";
 import { UpgradeDialogProvider } from "./billing/upgrade-dialog-provider";
 import type { EngramConfig } from "./config";
-import AppLayout from "./layout/app-layout";
-import OnboardLayout from "./onboarding/onboard-layout";
-import OnboardRedirect from "./onboarding/onboard-redirect";
-import OnboardingGate from "./onboarding/onboarding-gate";
-import { OnboardingShell } from "./onboarding/onboarding-shell";
+import LoadingScreen from "./layout/loading-screen";
 import { ROUTES } from "./routes";
-import SettingsLayout from "./settings/settings-layout";
 import LoadingPane from "./viewer/loading-pane";
 
 // Route-level code splitting. The viewer stack alone (remark/rehype +
 // KaTeX wiring + CodeMirror behind NotePage) dominated a 1.78 MB main
 // chunk that even the sign-in page had to parse. Entry surfaces
-// (sign-in/up, layouts, guards) stay eager; everything behind navigation
-// loads on demand.
+// (sign-in/up, guards) stay eager; everything behind navigation —
+// including the authenticated app shell — loads on demand.
+
+// The app-shell layouts all resolve through ONE barrel module so they share a
+// single async chunk (no gate → shell → layout chunk waterfall). This is what
+// keeps yjs / phoenix / react-joyride / react-resizable-panels / the folder
+// tree out of the eager bundle that gates the sign-in page.
+const AppLayout = lazy(() => import("./layout/app-shell").then((m) => ({ default: m.AppLayout })));
+const OnboardingGate = lazy(() =>
+	import("./layout/app-shell").then((m) => ({ default: m.OnboardingGate })),
+);
+const OnboardingShell = lazy(() =>
+	import("./layout/app-shell").then((m) => ({ default: m.OnboardingShell })),
+);
+const SettingsLayout = lazy(() =>
+	import("./layout/app-shell").then((m) => ({ default: m.SettingsLayout })),
+);
+// Onboarding entry surface — same one-chunk barrel pattern.
+const OnboardLayout = lazy(() =>
+	import("./onboarding/onboard-entry").then((m) => ({ default: m.OnboardLayout })),
+);
+const OnboardRedirect = lazy(() =>
+	import("./onboarding/onboard-entry").then((m) => ({ default: m.OnboardRedirect })),
+);
 const Dashboard = lazy(() => import("./viewer/dashboard"));
 // /note/:id resolves to the note OR attachment viewer (VaultItemPage owns the
 // lazy NotePage/AttachmentPage chunks).
@@ -41,6 +58,13 @@ const routeFallback = <LoadingPane />;
 
 function suspended(el: ReactNode) {
 	return <Suspense fallback={routeFallback}>{el}</Suspense>;
+}
+
+// Layout-level boundary: full-screen fallback matching AuthGuard's own
+// loading state, so the auth-resolve → shell-chunk-fetch handoff doesn't
+// flash between two different spinners.
+function suspendedScreen(el: ReactNode) {
+	return <Suspense fallback={<LoadingScreen />}>{el}</Suspense>;
 }
 
 // Root layout — mounts the UpgradeDialogProvider INSIDE the router so the
@@ -105,9 +129,9 @@ export function createAppRouter(config: EngramConfig): AppRouter {
 						// OnboardingGate (would redirect-loop).
 						{
 							path: "/onboard",
-							element: <OnboardLayout />,
+							element: suspendedScreen(<OnboardLayout />),
 							children: [
-								{ index: true, element: <OnboardRedirect /> },
+								{ index: true, element: suspended(<OnboardRedirect />) },
 								{ path: "agreement", element: suspended(<AgreementPage />) },
 								{ path: "billing", element: suspended(<OnboardBillingPage />) },
 								{ path: "tools", element: suspended(<OnboardToolsPage />) },
@@ -127,26 +151,26 @@ export function createAppRouter(config: EngramConfig): AppRouter {
 
 						// Dashboard tree — gated by OnboardingGate.
 						{
-							element: <OnboardingGate />,
+							element: suspendedScreen(<OnboardingGate />),
 							children: [
 								{
 									// OnboardingShell wraps the dashboard tree so the tour offer,
 									// first-vault modal, and checklist only mount on the main app
 									// surface — NOT on /settings/*, /device-link, or /oauth.
-									element: (
+									element: suspendedScreen(
 										<OnboardingShell>
 											<Outlet />
-										</OnboardingShell>
+										</OnboardingShell>,
 									),
 									children: [
 										{
-											element: <AppLayout />,
+											element: suspendedScreen(<AppLayout />),
 											children: [
 												{ path: ROUTES.HOME, element: suspended(<Dashboard />) },
 												{ path: "/note/:id", element: suspended(<VaultItemPage />) },
 												{
 													path: "settings",
-													element: <SettingsLayout />,
+													element: suspended(<SettingsLayout />),
 													children: [
 														{
 															index: true,

--- a/frontend/src/viewer/markdown.css
+++ b/frontend/src/viewer/markdown.css
@@ -1,0 +1,92 @@
+/* Rendered-markdown styles (highlight.js + KaTeX), imported by note-view.tsx
+ * so they ship with the lazy viewer chunk instead of the eager main
+ * stylesheet that gates the sign-in page's first paint.
+ *
+ * `layer(base)` matters: it keeps these rules in the same cascade layer they
+ * occupied when main.css imported them, so Tailwind utilities/components keep
+ * winning the same specificity fights. The `base` layer order is established
+ * by main.css (loaded first, render-blocking); rules here join it. */
+
+/* Light highlight.js theme — applies by default. */
+@import "highlight.js/styles/github.css" layer(base);
+
+/* KaTeX math styles. */
+@import "katex/dist/katex.min.css" layer(base);
+
+/* Dark highlight.js theme — wrapped so it only applies under `.dark`. */
+@layer base {
+	html.dark .hljs {
+		color: #c9d1d9;
+		background: #0d1117;
+	}
+	html.dark .hljs-doctag,
+	html.dark .hljs-keyword,
+	html.dark .hljs-meta .hljs-keyword,
+	html.dark .hljs-template-tag,
+	html.dark .hljs-template-variable,
+	html.dark .hljs-type,
+	html.dark .hljs-variable.language_ {
+		color: #ff7b72;
+	}
+	html.dark .hljs-title,
+	html.dark .hljs-title.class_,
+	html.dark .hljs-title.class_.inherited__,
+	html.dark .hljs-title.function_ {
+		color: #d2a8ff;
+	}
+	html.dark .hljs-attr,
+	html.dark .hljs-attribute,
+	html.dark .hljs-literal,
+	html.dark .hljs-meta,
+	html.dark .hljs-number,
+	html.dark .hljs-operator,
+	html.dark .hljs-variable,
+	html.dark .hljs-selector-attr,
+	html.dark .hljs-selector-class,
+	html.dark .hljs-selector-id {
+		color: #79c0ff;
+	}
+	html.dark .hljs-regexp,
+	html.dark .hljs-string,
+	html.dark .hljs-meta .hljs-string {
+		color: #a5d6ff;
+	}
+	html.dark .hljs-built_in,
+	html.dark .hljs-symbol {
+		color: #ffa657;
+	}
+	html.dark .hljs-comment,
+	html.dark .hljs-code,
+	html.dark .hljs-formula {
+		color: #8b949e;
+	}
+	html.dark .hljs-name,
+	html.dark .hljs-quote,
+	html.dark .hljs-selector-tag,
+	html.dark .hljs-selector-pseudo {
+		color: #7ee787;
+	}
+	html.dark .hljs-section {
+		color: #1f6feb;
+		font-weight: bold;
+	}
+	html.dark .hljs-bullet {
+		color: #f2cc60;
+	}
+	html.dark .hljs-emphasis {
+		color: #c9d1d9;
+		font-style: italic;
+	}
+	html.dark .hljs-strong {
+		color: #c9d1d9;
+		font-weight: bold;
+	}
+	html.dark .hljs-addition {
+		color: #aff5b4;
+		background: #033a16;
+	}
+	html.dark .hljs-deletion {
+		color: #ffdcd7;
+		background: #67060c;
+	}
+}

--- a/frontend/src/viewer/note-view.tsx
+++ b/frontend/src/viewer/note-view.tsx
@@ -9,6 +9,8 @@ import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkWikiLink from "remark-wiki-link";
+// hljs + KaTeX styles ride this lazy chunk, not the eager main stylesheet.
+import "./markdown.css";
 import { useIsFreeTier } from "../billing/use-is-free-tier";
 import { AttachmentFallback } from "./attachment-fallback";
 import AttachmentImg from "./attachment-img";

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.603",
+      version: "0.5.604",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Why

Time-to-login-screen on app.engram.page was gated by a serial waterfall: 274 KB gz eager bundle → /config.json fetch → lazy clerk-auth-provider chunk → lazy clerk-sign-in chunk → remote clerk.browser.js TLS handshake → FAPI.

## What

1. **Deploy workflow: set `VITE_INLINE_BOOTSTRAP_CONFIG=1`** — the inlineBootstrap vite plugin (inline `window.__ENGRAM_CONFIG__`, clerk.engram.page preconnect, Clerk chunk modulepreload) shipped gated on this flag but nothing ever set it, so it was a no-op in prod. Verified live: prod index.html has none of the three optimizations. All env the plugin needs is already in the build step; it hard-fails the build if config is missing.
2. **App-shell code split** — layouts (`AppLayout`, `OnboardingGate`, `OnboardingShell`, `SettingsLayout`) were eager while their pages were lazy, dragging yjs+lib0, react-joyride, react-resizable-panels, phoenix, headless-tree, virtual-core and sonner into the bundle that gates sign-in. All now `lazy()` through a single `app-shell` barrel (one async chunk — no nested gate→shell→layout fetch waterfall for signed-in users). `OnboardLayout`/`OnboardRedirect` same pattern via `onboard-entry`. `Toaster` + `UpgradeRequiredDialog` lazy behind `fallback={null}` boundaries.
3. **Static splash in index.html** — `#root` was empty (blank white) until React mounted. Splash mirrors `LoadingScreen` markup/classes (stylesheet is render-blocking, so tokens are live at first paint); `createRoot().render()` swaps it out.
4. **Lazy Sentry + viewer CSS split** — `@sentry/react` dynamic-imports behind the DSN gate (posthog pattern); `Sentry.ErrorBoundary` → small `RootErrorBoundary` that awaits the SDK before `captureException` (render crashes still report with eventId; named tradeoff: non-render errors in the pre-chunk-load window go unreported). highlight.js + KaTeX CSS move to `viewer/markdown.css` on the lazy note-page chunk, `layer(base)` preserved.

## Numbers (raw / gzip)

| Asset | Before | After |
|---|---|---|
| Eager entry JS | 894 KB / 274 KB | **447 KB / 142 KB** |
| Render-blocking CSS | 174 KB / 31 KB | **143 KB / 22 KB** |

Plus: no /config.json round trip, Clerk chunks download in parallel with the main bundle, Clerk TLS pre-warmed, first paint at CSS-load instead of React-mount.

## Verification

- `tsc --noEmit` clean, biome clean, vitest 679/679 green
- saas-shaped build inspected: inline config + preconnect + both modulepreloads + splash all present in emitted index.html
- sourcemap-verified yjs/joyride/phoenix/resizable-panels/headless-tree/virtual-core/sonner/@sentry all out of the eager chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)