### PR TITLE
fix: FORCE-RLS migration no-op + idempotent-upsert short-circuit (audit wave)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,16 @@ dropped identifiers from your migration and greps `lib/` for them. If any
 reference survives, the gate fails. Fix it by going back and shipping the
 code removal in an earlier release first.
 
+## Data DML in migrations — FORCE RLS trap
+
+Raw `UPDATE`/`DELETE`/`INSERT` against a tenant table in a migration silently
+touches **zero rows on prod**: the migrator (`engram_admin`) owns the tables
+but has no BYPASSRLS, migrations set no `app.current_tenant`, and FORCE RLS
+binds owners too — dev/CI superusers mask it. Wrap the DML in
+`ALTER TABLE ... NO FORCE ROW LEVEL SECURITY` / re-`FORCE` and add a
+fail-loud rowcount assertion. `migration_rls_lint_test.exs` enforces this;
+full pattern + rationale in `docs/context/migrations-force-rls-data-dml.md`.
+
 ## Forbidden in expand-phase migrations
 
 Squawk (run via `priv/repo/lint_migrations.sh`) already hard-fails on:

--- a/docs/context/migrations-force-rls-data-dml.md
+++ b/docs/context/migrations-force-rls-data-dml.md
@@ -1,0 +1,59 @@
+# Data migrations vs FORCE ROW LEVEL SECURITY — silent 0-row no-op
+
+## The trap
+
+Raw DML (`execute("UPDATE/DELETE/INSERT ...")`) in a migration against a
+tenant-scoped table (`Engram.Repo.tenant_tables/0`) **silently touches zero
+rows on prod** and succeeds anyway:
+
+- Tenant tables carry `FORCE ROW LEVEL SECURITY`, so even the table owner is
+  policy-bound.
+- The prod migrator role (`engram_admin`, the RDS master) owns the tables but
+  has neither SUPERUSER nor BYPASSRLS.
+- Migrations set no `app.current_tenant`, so the tenant policy's
+  `current_setting(..., true)` is NULL → every row filtered → DML "succeeds"
+  on 0 rows, no error, migration marked applied.
+
+**Dev/CI mask the bug completely**: their Docker `POSTGRES_USER` is a
+superuser, which bypasses RLS regardless of FORCE, so the migration works
+there and CI stays green. First hit: `20260629250000_clear_v1_crdt_state_migrate.exs`
+(v1 CRDT purge), caught in the 2026-07-02 audit before it reached a
+`release-v*` tag.
+
+## The pattern
+
+Drop the owner-applies flag for the migration transaction, verify, restore:
+
+```elixir
+execute("ALTER TABLE notes NO FORCE ROW LEVEL SECURITY")
+execute("UPDATE notes SET ...")
+# rowcount / invariant assertion via DO $$ ... RAISE EXCEPTION ... $$
+execute("ALTER TABLE notes FORCE ROW LEVEL SECURITY")
+```
+
+Why this is safe:
+
+- Owners bypass RLS *unless* FORCE — `NO FORCE` restores the owner bypass.
+- `ALTER TABLE` takes ACCESS EXCLUSIVE, so app queries can't run during the
+  unforced window; migrations run in a transaction, so rollback restores
+  FORCE on any failure.
+- Always add a fail-loud verification (DO-block count + `RAISE EXCEPTION`)
+  **while still unforced**, so a partial purge can't slip through silently.
+- Requires the migrator to be the table owner (it is — it ran the CREATEs).
+  `SET row_security = off` is NOT equivalent: for a non-BYPASSRLS role it
+  errors instead of bypassing (loud, but the migration then can't run).
+
+## The guard
+
+`test/lint/migration_rls_lint_test.exs` fails any migration with tenant-table
+DML that lacks the NO FORCE/FORCE pair (allowlist with justification for
+legitimate exceptions). Sibling of `raw_sql_tenant_table_lint_test.exs`,
+which covers `lib/` but not `priv/repo/migrations/` — that gap is how the
+first instance slipped through.
+
+## Dead ends
+
+- "DELETE respects RLS" as a *feature* in a migration comment — that framing
+  was the bug: respecting RLS in a tenant-less session means seeing nothing.
+- Testing the fix on dev/CI proves nothing about prod (superuser bypass).
+  Trust the pattern + the loud assertion, not a green local run.

--- a/e2e/tests/api_only/test_76_batch_pagination.py
+++ b/e2e/tests/api_only/test_76_batch_pagination.py
@@ -94,13 +94,20 @@ class TestBatchUpsert:
         assert result["version"] == 1
         assert result["server_path"] == f"{PREFIX}/contract-check.md"
         assert isinstance(result["content_hash"], str) and result["content_hash"]
-        # Idempotent re-push of identical content bumps the version (update
-        # semantics match the single-note endpoint).
+        # Idempotent re-push of identical content short-circuits: no version
+        # bump, same hash (matches the single-note endpoint). A changed body
+        # is what bumps the version.
         body2 = _batch_push(
             api_sync,
             [{"path": f"{PREFIX}/contract-check.md", "content": "# C", "mtime": time.time()}],
         )
-        assert body2["results"][0]["version"] == 2
+        assert body2["results"][0]["version"] == 1
+        assert body2["results"][0]["content_hash"] == result["content_hash"]
+        body3 = _batch_push(
+            api_sync,
+            [{"path": f"{PREFIX}/contract-check.md", "content": "# C changed", "mtime": time.time()}],
+        )
+        assert body3["results"][0]["version"] == 2
         api_sync.delete_note(f"{PREFIX}/contract-check.md")
 
 

--- a/e2e/tests/test_30_sse_catch_up_multi.py
+++ b/e2e/tests/test_30_sse_catch_up_multi.py
@@ -7,6 +7,7 @@ the channel is down and verifies all are delivered on reconnect.
 """
 
 import asyncio
+import time
 
 import pytest
 
@@ -33,9 +34,14 @@ async def test_channel_catch_up_multi(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     assert not await cdp_b.check_stream_connected(), "B's channel should be disconnected"
 
     try:
-        # A creates 3 notes while B's channel is down
+        # A creates 3 notes while B's channel is down. The nonce keeps the
+        # content unique per attempt: on a flake RERUN the notes already exist
+        # server-side from attempt 1, and a byte-identical re-push
+        # short-circuits (no new seq, no broadcast) — so B's catch-up would
+        # legitimately have nothing new to deliver and the rerun always fails.
+        nonce = time.time()
         for i, path in enumerate(paths, 1):
-            write_note(vault_a, path, f"# Channel Catch Up {i}\nMissed while disconnected")
+            write_note(vault_a, path, f"# Channel Catch Up {i} ({nonce})\nMissed while disconnected")
 
         # Wait for all to reach server
         for path in paths:

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -336,7 +336,7 @@ defmodule Engram.Notes do
               )
 
             existing ->
-              do_update_note(existing, base_attrs, user, sanitized_path, folder, tags)
+              do_update_note(existing, base_attrs, user, sanitized_path, folder, tags, opts)
           end
         end)
 
@@ -349,7 +349,16 @@ defmodule Engram.Notes do
 
           note = decrypt_or_raise!(note, user)
           maybe_log_path_rewrite(user, vault, path, sanitized_path, note.id)
-          :ok = broadcast_change(user.id, vault.id, "upsert", note.path, note, opts)
+
+          # Hash equality means do_update_note short-circuited (no version/seq
+          # change persisted) — broadcasting would fan a phantom change out to
+          # every connected device. Inserts (prev_hash nil) and real updates
+          # always differ, so they broadcast as before; forced rewrites may
+          # keep the same hash (e.g. a tags repair) but did persist a change.
+          _ =
+            if prev_hash != note.content_hash or Keyword.get(opts, :force, false) do
+              :ok = broadcast_change(user.id, vault.id, "upsert", note.path, note, opts)
+            end
 
           if is_nil(prev_hash) do
             # FTUX vault page listens for this — fires when an empty vault
@@ -535,7 +544,30 @@ defmodule Engram.Notes do
   # CRDT (Yjs) is the only content-sync path: merge_plaintext in do_update_note
   # IS the conflict resolution. A stale client_version never 409s — the diverging
   # write is merged convergently into crdt_state (no legacy conflict-copy flow).
-  defp do_update_note(existing, base_attrs, user, sanitized_path, folder, _tags) do
+  defp do_update_note(existing, base_attrs, user, sanitized_path, folder, _tags, opts \\ []) do
+    if is_binary(existing.content_hash) and
+         existing.content_hash == base_attrs.content_hash and
+         not Keyword.get(opts, :force, false) do
+      # Idempotent re-push (plugin retry, offline-queue replay, MCP re-write):
+      # the incoming content hashes identically to the stored merged content,
+      # so the CRDT diff is a provable no-op. Skip the whole pipeline — CRDT
+      # decrypt/merge/re-encrypt, field re-encryption, the row rewrite (TOAST
+      # + WAL churn on the content blob), the version bump, and the seq
+      # allocation — and return the row unchanged. The caller skips the
+      # note_changed broadcast on hash equality, so other devices don't
+      # reconcile a phantom change. Tradeoff: a same-content push with a newer
+      # mtime keeps the stored mtime; sync state is hash/seq-based, so nothing
+      # keys off it. Tombstones never reach here (note_by_path_query filters
+      # deleted_at), so delete → re-push still resurrects via the insert path.
+      # Repair paths that re-derive persisted fields from unchanged content
+      # (e.g. Utf8Backfill fixing corrupt tags) pass `force: true` to opt out.
+      {:ok, {existing.content_hash, existing}}
+    else
+      do_rewrite_note(existing, base_attrs, user, sanitized_path, folder)
+    end
+  end
+
+  defp do_rewrite_note(existing, base_attrs, user, sanitized_path, folder) do
     with {:ok, crdt} <- maybe_merge_crdt(existing, base_attrs.content, user, existing.id) do
       merged_title = Helpers.extract_title(crdt.merged_text, sanitized_path)
 
@@ -1505,10 +1537,18 @@ defmodule Engram.Notes do
 
     _ = if embed_jobs != [], do: Oban.insert_all(embed_jobs)
 
+    # Same hash gate as the embed jobs: entries whose update short-circuited
+    # (idempotent re-push, no version/seq persisted) must not appear in the
+    # digest, or every batch re-sync fans a phantom change to all devices.
+    changed_entries =
+      Enum.filter(ok_entries, fn %{hash: hash, result: {:ok, info}} ->
+        info.prev_hash != hash
+      end)
+
     _ =
-      if ok_entries != [] do
+      if changed_entries != [] do
         digest =
-          Enum.map(ok_entries, fn %{result: {:ok, info}} = entry ->
+          Enum.map(changed_entries, fn %{result: {:ok, info}} = entry ->
             %{
               "event_type" => "upsert",
               "id" => info.id,

--- a/lib/engram/notes/utf8_backfill.ex
+++ b/lib/engram/notes/utf8_backfill.ex
@@ -148,12 +148,20 @@ defmodule Engram.Notes.Utf8Backfill do
   #     the scrubbed content by upsert.
   defp fix_note(user, %Note{} = decrypted, acc) do
     with {:ok, vault} <- Vaults.get_vault(user, decrypted.vault_id),
+         # force: the #741 scenario is corrupt TAGS under byte-identical
+         # content — without it the idempotent-upsert short-circuit would
+         # skip the rewrite and never re-derive the tags.
          {:ok, _note} <-
-           Notes.upsert_note(user, vault, %{
-             "path" => decrypted.path,
-             "content" => Helpers.scrub_utf8(decrypted.content || "", :backfill),
-             "mtime" => decrypted.mtime
-           }) do
+           Notes.upsert_note(
+             user,
+             vault,
+             %{
+               "path" => decrypted.path,
+               "content" => Helpers.scrub_utf8(decrypted.content || "", :backfill),
+               "mtime" => decrypted.mtime
+             },
+             force: true
+           ) do
       bump(acc, :fixed)
     else
       other ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.604",
+      version: "0.5.605",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260629250000_clear_v1_crdt_state_migrate.exs
+++ b/priv/repo/migrations/20260629250000_clear_v1_crdt_state_migrate.exs
@@ -17,12 +17,44 @@ defmodule Engram.Repo.Migrations.ClearV1CrdtStateMigrate do
   # tail-log (a surviving tail would replay v1 updates onto a re-seeded v2
   # doc). On next bind, `seed_from_content` routes through the v2 codec and
   # re-seeds from `notes.content` cleanly.
-  #
-  # DELETE is used (not TRUNCATE) so the operation runs inside the migration
-  # transaction and respects RLS row-level policies on `crdt_update_log`.
   def up do
+    # Both tables carry FORCE ROW LEVEL SECURITY, and the migrator role
+    # (`engram_admin` on prod RDS) is the table owner but has neither
+    # SUPERUSER nor BYPASSRLS. Migrations set no `app.current_tenant`, so the
+    # tenant policy would filter EVERY row and the DML below would silently
+    # touch 0 rows on prod — dev/CI masked this because their Docker
+    # superuser bypasses RLS regardless of FORCE. Owners bypass RLS unless
+    # FORCE, so drop the flag for this transaction: the ACCESS EXCLUSIVE lock
+    # keeps app queries out of the unforced window, and FORCE is restored
+    # before commit (or by rollback on failure).
+    execute("ALTER TABLE notes NO FORCE ROW LEVEL SECURITY")
+    execute("ALTER TABLE crdt_update_log NO FORCE ROW LEVEL SECURITY")
+
     execute("UPDATE notes SET crdt_state_ciphertext = NULL, crdt_state_nonce = NULL")
     execute("DELETE FROM crdt_update_log")
+
+    # Fail loud if the purge didn't stick (e.g. a role/ownership change makes
+    # the owner bypass ineffective again). A silent partial purge replays v1
+    # state onto the v2 codec — the exact bug this migration exists to
+    # prevent. Runs while NO FORCE is still in effect so the counts see all
+    # rows.
+    execute("""
+    DO $$
+    DECLARE remaining bigint;
+    BEGIN
+      SELECT COUNT(*) INTO remaining FROM notes WHERE crdt_state_ciphertext IS NOT NULL;
+      IF remaining > 0 THEN
+        RAISE EXCEPTION 'v1 CRDT purge incomplete: % notes still carry crdt_state', remaining;
+      END IF;
+      SELECT COUNT(*) INTO remaining FROM crdt_update_log;
+      IF remaining > 0 THEN
+        RAISE EXCEPTION 'v1 CRDT purge incomplete: % crdt_update_log rows remain', remaining;
+      END IF;
+    END $$;
+    """)
+
+    execute("ALTER TABLE notes FORCE ROW LEVEL SECURITY")
+    execute("ALTER TABLE crdt_update_log FORCE ROW LEVEL SECURITY")
   end
 
   def down do

--- a/test/engram/notes_idempotent_upsert_test.exs
+++ b/test/engram/notes_idempotent_upsert_test.exs
@@ -1,0 +1,88 @@
+defmodule Engram.NotesIdempotentUpsertTest do
+  @moduledoc """
+  A re-push of byte-identical content (plugin retry, offline-queue replay,
+  MCP re-write) must be a no-op: no version bump, no seq allocation, no
+  note_changed broadcast. Without the short-circuit every idempotent re-push
+  pays full CRDT merge + re-encrypt + row rewrite and fans a phantom change
+  out to every connected device.
+  """
+  use Engram.DataCase, async: true
+
+  alias Engram.Notes
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  test "re-push of identical content does not bump version or seq", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, n1} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# Same"})
+    {:ok, n2} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# Same"})
+
+    assert n2.id == n1.id
+    assert n2.version == n1.version
+    assert n2.seq == n1.seq
+    assert n2.content_hash == n1.content_hash
+  end
+
+  test "re-push of identical content does not broadcast note_changed", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# Same"})
+
+    EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# Same"})
+
+    refute_receive %Phoenix.Socket.Broadcast{event: "note_changed"}, 100
+  end
+
+  test "changed content still bumps version, advances seq, and broadcasts", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, n1} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# One"})
+
+    EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+    {:ok, n2} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# Two"})
+
+    assert n2.version == n1.version + 1
+    assert n2.seq > n1.seq
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
+  end
+
+  test "batch re-push of identical content is a no-op: no version bump, no digest broadcast",
+       %{user: user, vault: vault} do
+    entries = [%{"path" => "a.md", "content" => "# Same"}]
+    {:ok, %{results: [r1]}} = Notes.batch_upsert_notes(user, vault, entries)
+
+    EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+    {:ok, %{results: [r2]}} = Notes.batch_upsert_notes(user, vault, entries)
+
+    assert %{status: :ok, version: v1} = r1
+    assert %{status: :ok, version: ^v1} = r2
+    refute_receive %Phoenix.Socket.Broadcast{event: "notes.batch"}, 100
+  end
+
+  test "re-push after a delete resurrects instead of short-circuiting", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, n1} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# Same"})
+    :ok = Notes.delete_note(user, vault, "a.md")
+
+    {:ok, n2} = Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# Same"})
+
+    assert is_nil(n2.deleted_at)
+    refute n2.id == n1.id
+  end
+end

--- a/test/lint/migration_rls_lint_test.exs
+++ b/test/lint/migration_rls_lint_test.exs
@@ -1,0 +1,80 @@
+defmodule Engram.MigrationRlsLintTest do
+  @moduledoc """
+  Grep-style lint: raw DML in a migration must NOT target a tenant-scoped
+  table without explicitly handling FORCE ROW LEVEL SECURITY.
+
+  Migrations run as the migrator role — `engram_admin` (RDS master) on prod,
+  which is the table owner but has neither SUPERUSER nor BYPASSRLS. Tenant
+  tables carry FORCE ROW LEVEL SECURITY, and a migration sets no
+  `app.current_tenant`, so the tenant policy sees NULL and filters every row:
+  the DML "succeeds" touching 0 rows — a silent no-op. Dev/CI mask the bug
+  because their Docker `POSTGRES_USER` is a superuser, which bypasses RLS
+  regardless of FORCE, so the migration works there and CI stays green.
+
+  The accepted pattern is to drop the owner-applies flag for the migration
+  transaction and restore it before commit:
+
+      execute("ALTER TABLE notes NO FORCE ROW LEVEL SECURITY")
+      execute("UPDATE notes SET ...")
+      execute("ALTER TABLE notes FORCE ROW LEVEL SECURITY")
+
+  (Owner bypasses RLS unless FORCE, so NO FORCE restores the bypass; the
+  ACCESS EXCLUSIVE lock keeps app queries out of the unforced window, and a
+  rollback restores FORCE.) A migration that does this — or is allowlisted
+  with a justification — passes the lint.
+
+  Tenant tables are sourced from `Engram.Repo.tenant_tables/0` so the lint
+  can't drift from the guarded set. Sibling of
+  `Engram.RawSqlTenantTableLintTest`, which covers `lib/` but not
+  `priv/repo/migrations/`.
+  """
+  use ExUnit.Case, async: true
+
+  @migrations_dir Path.expand("../../priv/repo/migrations", __DIR__)
+
+  @tenant_tables Enum.map(Engram.Repo.tenant_tables(), &Atom.to_string/1)
+
+  # Migrations allowed to run tenant-table DML without the NO FORCE dance.
+  # Each entry needs a comment explaining why (e.g. predates FORCE RLS and is
+  # already applied in every environment).
+  @allowlist []
+
+  test "tenant-table DML in migrations handles FORCE ROW LEVEL SECURITY" do
+    offenders =
+      @migrations_dir
+      |> Path.join("*.exs")
+      |> Path.wildcard()
+      |> Enum.reject(fn path ->
+        Enum.any?(@allowlist, &String.ends_with?(path, &1))
+      end)
+      |> Enum.flat_map(&scan_file/1)
+
+    assert offenders == [],
+           "Tenant-table DML in a migration runs RLS-filtered to ZERO rows on " <>
+             "prod (FORCE RLS + no tenant context = silent no-op; dev/CI " <>
+             "superuser masks it). Wrap the DML in " <>
+             "ALTER TABLE <t> NO FORCE ROW LEVEL SECURITY / FORCE ROW LEVEL " <>
+             "SECURITY, or allowlist the file with a justification.\n\n" <>
+             Enum.map_join(offenders, "\n", fn {file, table} ->
+               "#{file} → table `#{table}`"
+             end)
+  end
+
+  defp scan_file(path) do
+    content = File.read!(path)
+    rel = Path.relative_to(path, @migrations_dir)
+
+    Enum.flat_map(@tenant_tables, fn table ->
+      dml = ~r/\b(?:UPDATE|DELETE\s+FROM|INSERT\s+INTO)\s+#{table}\b/i
+      unforce = ~r/ALTER\s+TABLE\s+#{table}\s+NO\s+FORCE\s+ROW\s+LEVEL\s+SECURITY/i
+      reforce = ~r/ALTER\s+TABLE\s+#{table}\s+FORCE\s+ROW\s+LEVEL\s+SECURITY/i
+
+      if Regex.match?(dml, content) and
+           not (Regex.match?(unforce, content) and Regex.match?(reforce, content)) do
+        [{rel, table}]
+      else
+        []
+      end
+    end)
+  end
+end


### PR DESCRIPTION
Two highest-priority fixes from the 2026-07-02 backend audit, bundled as one wave.

## 1. `ClearV1CrdtStateMigrate` silently no-ops on prod (FORCE RLS)

The migrator role (`engram_admin` on prod RDS) is the table owner but has neither SUPERUSER nor BYPASSRLS, and migrations set no `app.current_tenant`. Under FORCE ROW LEVEL SECURITY the tenant policy filters every row, so `UPDATE notes SET crdt_state_ciphertext = NULL` and `DELETE FROM crdt_update_log` would touch **0 rows with no error** on prod. Dev/CI masked it: Docker `POSTGRES_USER` is a superuser, which bypasses RLS regardless of FORCE. If shipped as-is, v1 CRDT snapshots survive and the v2 codec replays incompatible state — the exact bug the migration exists to prevent.

Fix:
- Wrap the DML in `ALTER TABLE ... NO FORCE ROW LEVEL SECURITY` / re-`FORCE` (owner bypass restored for the migration transaction; ACCESS EXCLUSIVE lock keeps app queries out of the unforced window; rollback restores FORCE).
- DO-block rowcount assertion fails loud on a partial purge.
- New `migration_rls_lint_test`: tenant-table DML in a migration must handle FORCE RLS or be allowlisted with a justification — the existing raw-SQL tenant lint covers `lib/` but not `priv/repo/migrations/`, which is how this slipped through.

**`allow-migration-edit`:** the migration is in no `release-v*` tag (verified via `git tag --contains`), so prod has never run it; the in-place edit is safe.

Note: the prod migrator must be the table owner for the NO FORCE toggle (it is — it ran the CREATEs). The lint's error message documents the pattern for future data migrations.

## 2. Idempotent note re-pushes short-circuit on `content_hash` match

A re-push of byte-identical content (plugin retry, offline-queue replay, MCP re-write) ran the full update pipeline: CRDT decrypt + merge (provable no-op) + re-encode + re-encrypt of every field, full row rewrite (TOAST/WAL churn on the content blob), version bump, vault seq allocation, and a full-content `note_changed` broadcast that every device reconciled as a phantom change. Only the embed enqueue was hash-gated.

Now:
- `do_update_note` returns the row unchanged when the incoming hash equals the stored `content_hash`.
- Single-note broadcast and the batch `notes.batch` digest are gated on hash change (same gate the embed jobs already used).
- `force: true` opts out for repair paths that re-derive persisted fields from unchanged content — `Utf8Backfill` needs it (#741 scenario: corrupt tags under byte-identical content; caught by the existing regression test during this work).
- Tombstones never reach the short-circuit (path lookup filters `deleted_at`), so delete → re-push still resurrects (covered by test).

Tradeoff: a same-content push with a newer mtime keeps the stored mtime. Sync state is hash/seq-based, so nothing keys off it; documented in code.

## Testing

- TDD: all new tests watched red first (lint flagged the migration; no-op re-push bumped version 1→2 and broadcast; batch digest fanned out).
- New: `notes_idempotent_upsert_test.exs` (5 tests: no version/seq bump, no broadcast, changed-content still bumps+broadcasts, batch no-op digest gate, delete-resurrect guard), `migration_rls_lint_test.exs`.
- Full re-migrate from scratch proves the edited migration executes (`MIX_ENV=test mix ecto.reset` path).
- Full suite: 3311 tests, 0 failures. credo --strict clean, sobelow clean, mix format applied.

Refs the 2026-07-02 audit follow-ups (#855–#859 track the feature gaps separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)