### PR TITLE
perf: hot-path quick wins — burst index, search fail-fast, avgdl cache, meta rehydration

### DIFF
--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -35,6 +35,7 @@ defmodule Engram.Application do
         Engram.Crypto.DekCache,
         Engram.UsageMeters.ActivityCache,
         Engram.Usage.DailyCap.Cache,
+        Engram.KeywordIndex.Stats.Cache,
         Engram.Onboarding.TermsCache,
         # Subscribe to CacheSync in init → must start after PubSub.
         Engram.Onboarding.GateCache,

--- a/lib/engram/keyword_index/stats.ex
+++ b/lib/engram/keyword_index/stats.ex
@@ -14,13 +14,36 @@ defmodule Engram.KeywordIndex.Stats do
 
   import Ecto.Query
 
+  alias Engram.KeywordIndex.Stats.Cache
   alias Engram.Notes.Chunk
   alias Engram.Repo
 
   @default_avgdl 100.0
 
+  @doc """
+  Per-vault avgdl, cached per node (#861): every EmbedNote job reads this,
+  and the uncached AVG over the vault's whole chunk set made initial
+  indexing O(N^2) in DB row visits. Staleness inside the cache TTL is
+  harmless — see `Engram.KeywordIndex.Stats.Cache`.
+  """
   @spec avgdl(Ecto.UUID.t()) :: float()
   def avgdl(vault_id) do
+    case Cache.get(vault_id) do
+      {:ok, value} ->
+        value
+
+      :miss ->
+        value = compute_avgdl(vault_id)
+        :ok = Cache.put(vault_id, value)
+        value
+    end
+  end
+
+  @doc "Drops the cached avgdl for a vault (e.g. before a bulk re-normalize)."
+  @spec evict(Ecto.UUID.t()) :: :ok
+  defdelegate evict(vault_id), to: Cache
+
+  defp compute_avgdl(vault_id) do
     Chunk
     |> where([c], c.vault_id == ^vault_id and not is_nil(c.token_count))
     |> select([c], avg(c.token_count))

--- a/lib/engram/keyword_index/stats_cache.ex
+++ b/lib/engram/keyword_index/stats_cache.ex
@@ -1,0 +1,61 @@
+defmodule Engram.KeywordIndex.Stats.Cache do
+  @moduledoc """
+  Per-node ETS cache for per-vault avgdl (#861). Every EmbedNote job needs
+  the vault's average chunk token length for BM25 length normalization;
+  recomputing `SELECT avg(token_count)` per job makes initial indexing of a
+  large vault O(N^2) in DB row visits. avgdl is a soft normalizer (the #605
+  re-normalize worker recomputes weights when a vault drifts), so a value up
+  to @ttl_ms stale is harmless — and per-node staleness is safe for the same
+  reason.
+  """
+  use GenServer
+
+  @table :engram_avgdl_cache
+  @ttl_ms :timer.minutes(10)
+
+  def start_link(_), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @spec get(binary()) :: {:ok, float()} | :miss
+  def get(vault_id) do
+    case :ets.lookup(@table, vault_id) do
+      [{^vault_id, value, expires}] ->
+        if System.monotonic_time(:millisecond) < expires, do: {:ok, value}, else: :miss
+
+      _ ->
+        :miss
+    end
+  rescue
+    ArgumentError -> :miss
+  end
+
+  @spec put(binary(), float()) :: :ok
+  def put(vault_id, value) do
+    expires = System.monotonic_time(:millisecond) + @ttl_ms
+    :ets.insert(@table, {vault_id, value, expires})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @spec evict(binary()) :: :ok
+  def evict(vault_id) do
+    :ets.delete(@table, vault_id)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @impl true
+  def init(:ok) do
+    _ =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    {:ok, %{}}
+  end
+end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -20,6 +20,38 @@ defmodule Engram.Notes do
 
   require Logger
 
+  # Every persisted Note column except content_ciphertext/content_nonce —
+  # the metadata projection for reads that never serialize content (changes
+  # feeds `fields=meta`, search rehydration). Skipping the big column saves
+  # its I/O AND its AES-GCM decrypt (the phase-4 helpers short-circuit
+  # per-field on nil ciphertext).
+  @note_meta_fields [
+    :id,
+    :seq,
+    :version,
+    :kind,
+    :dek_version,
+    :content_hash,
+    :embed_hash,
+    :mtime,
+    :deleted_at,
+    :title_ciphertext,
+    :title_nonce,
+    :tags_ciphertext,
+    :tags_nonce,
+    :path_ciphertext,
+    :path_nonce,
+    :path_hmac,
+    :folder_ciphertext,
+    :folder_nonce,
+    :folder_hmac,
+    :tags_hmac,
+    :user_id,
+    :vault_id,
+    :created_at,
+    :updated_at
+  ]
+
   @doc """
   Composable query scope that restricts a `Note` query to kind='note' rows.
   Every site that wants real notes (excluding folder markers) should
@@ -59,7 +91,7 @@ defmodule Engram.Notes do
             join: n in ^notes_only(),
             on: n.id == c.note_id,
             where: c.qdrant_point_id in ^uuids,
-            select: {c.qdrant_point_id, n}
+            select: {c.qdrant_point_id, struct(n, @note_meta_fields)}
           )
         )
       end)
@@ -1642,37 +1674,6 @@ defmodule Engram.Notes do
         {:error, {:not_found, id}}
     end
   end
-
-  # Every persisted Note column except content_ciphertext/content_nonce —
-  # the metadata projection for listings that never serialize content.
-  # Skipping the big column saves its I/O AND its AES-GCM decrypt (the
-  # phase-4 helpers short-circuit per-field on nil ciphertext).
-  @note_meta_fields [
-    :id,
-    :seq,
-    :version,
-    :kind,
-    :dek_version,
-    :content_hash,
-    :embed_hash,
-    :mtime,
-    :deleted_at,
-    :title_ciphertext,
-    :title_nonce,
-    :tags_ciphertext,
-    :tags_nonce,
-    :path_ciphertext,
-    :path_nonce,
-    :path_hmac,
-    :folder_ciphertext,
-    :folder_nonce,
-    :folder_hmac,
-    :tags_hmac,
-    :user_id,
-    :vault_id,
-    :created_at,
-    :updated_at
-  ]
 
   @doc """
   Returns notes changed (upserted or deleted) since the given datetime.

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -45,21 +45,42 @@ defmodule Engram.Vector.Qdrant do
   defp qdrant_status({:ok, _}), do: :ok
   defp qdrant_status({:error, _}), do: :error
 
-  defp req_opts do
+  # Per-purpose Req options. `:indexing` (default) is patient — 30s timeout +
+  # transient retries; callers are Oban workers where an in-call retry is
+  # cheaper than burning a job attempt. `:search` backs the synchronous
+  # `/api/search` request path and must fail fast: with the indexing opts a
+  # Qdrant brownout pins each request up to ~2min (30s x 4 attempts), holding
+  # Bandit processes and cascading into pool pressure. Same split the Voyage
+  # embedder already has (`request_defaults(:query)` = 5s, no retry).
+  @doc false
+  def req_opts(purpose \\ :indexing)
+
+  def req_opts(:search) do
+    put_api_key(
+      receive_timeout: 5_000,
+      retry: false,
+      max_retries: 0,
+      connect_options: [protocols: [:http1]]
+    )
+  end
+
+  def req_opts(:indexing) do
     {retry, max_retries} =
       case ServiceConfig.get(:qdrant_retry, :transient) do
         false -> {false, 0}
         mode -> {mode, 3}
       end
 
-    base = [
+    put_api_key(
       receive_timeout: 30_000,
       retry: retry,
       max_retries: max_retries,
       retry_log_level: :warning,
       connect_options: [protocols: [:http1]]
-    ]
+    )
+  end
 
+  defp put_api_key(base) do
     case ServiceConfig.get(:qdrant_api_key) do
       nil -> base
       key -> Keyword.put(base, :headers, [{"api-key", key}])
@@ -478,7 +499,7 @@ defmodule Engram.Vector.Qdrant do
     col = col || collection()
 
     instrument(:search, fn ->
-      do_search(col, [json: search_body(vector, search_opts)] ++ req_opts())
+      do_search(col, [json: search_body(vector, search_opts)] ++ req_opts(:search))
     end)
   end
 
@@ -548,7 +569,7 @@ defmodule Engram.Vector.Qdrant do
     col = col || collection()
 
     instrument(:sparse_search, fn ->
-      do_search(col, [json: sparse_search_body(sparse, search_opts)] ++ req_opts())
+      do_search(col, [json: sparse_search_body(sparse, search_opts)] ++ req_opts(:search))
     end)
   end
 
@@ -573,7 +594,7 @@ defmodule Engram.Vector.Qdrant do
     col = col || collection()
 
     instrument(:hybrid_search, fn ->
-      do_search(col, [json: hybrid_search_body(dense, sparse, search_opts)] ++ req_opts())
+      do_search(col, [json: hybrid_search_body(dense, sparse, search_opts)] ++ req_opts(:search))
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.605",
+      version: "0.5.606",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260702110000_oban_embed_note_id_index_expand.exs
+++ b/priv/repo/migrations/20260702110000_oban_embed_note_id_index_expand.exs
@@ -1,0 +1,28 @@
+defmodule Engram.Repo.Migrations.ObanEmbedNoteIdIndexExpand do
+  use Ecto.Migration
+
+  # phase/expand — new index only, no schema change.
+  #
+  # EmbedNote.existing_burst_start/1 runs on every content-changing upsert
+  # (debounce clamp) and filters oban_jobs by worker + args->>'note_id' +
+  # state. Without this index the lookup scans the embed backlog, so write
+  # latency degrades exactly when the queue is already stressed (Voyage
+  # outage, onboarding wave). Partial + expression: only in-flight EmbedNote
+  # rows are indexed, so steady-state maintenance cost is near zero.
+  #
+  # Keep the state list in sync with existing_burst_start/1 — the query's
+  # `state IN (...)` must be a subset of the predicate or the planner
+  # rejects the index (guarded by embed_note_burst_index_test.exs).
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index("oban_jobs", ["(args->>'note_id')"],
+             name: :oban_jobs_embed_note_note_id_index,
+             where:
+               "worker = 'Engram.Workers.EmbedNote' AND state IN ('scheduled','available','executing','retryable')",
+             concurrently: true
+           )
+  end
+end

--- a/test/engram/keyword_index/stats_cache_test.exs
+++ b/test/engram/keyword_index/stats_cache_test.exs
@@ -1,0 +1,69 @@
+defmodule Engram.KeywordIndex.StatsCacheTest do
+  @moduledoc """
+  avgdl is cached per vault: every EmbedNote job previously ran
+  `SELECT avg(token_count)` over the vault's whole chunk set, making initial
+  indexing of a large vault O(N^2) in DB row visits. BM25 length-norm is a
+  soft signal (the #605 re-normalize worker handles drift), so a stale value
+  inside the TTL is harmless.
+  """
+  use Engram.DataCase, async: true
+
+  alias Engram.KeywordIndex.Stats
+  alias Engram.Notes.Chunk
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  defp insert_chunk!(user, vault, note, position, token_count) do
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        %Chunk{}
+        |> Chunk.changeset(%{
+          note_id: note.id,
+          user_id: user.id,
+          vault_id: vault.id,
+          position: position,
+          char_start: 0,
+          char_end: 10,
+          token_count: token_count,
+          qdrant_point_id: Ecto.UUID.generate()
+        })
+        |> Repo.insert!()
+      end)
+  end
+
+  test "second read is served from cache, not recomputed", %{user: user, vault: vault} do
+    {:ok, note} =
+      Engram.Notes.upsert_note(user, vault, %{"path" => "a.md", "content" => "# A"})
+
+    insert_chunk!(user, vault, note, 0, 100)
+    insert_chunk!(user, vault, note, 1, 200)
+
+    assert Stats.avgdl(vault.id) == 150.0
+
+    # Change the underlying data; a cached read must NOT see it yet.
+    insert_chunk!(user, vault, note, 2, 700)
+    assert Stats.avgdl(vault.id) == 150.0
+  end
+
+  test "evict/1 forces a recompute", %{user: user, vault: vault} do
+    {:ok, note} =
+      Engram.Notes.upsert_note(user, vault, %{"path" => "b.md", "content" => "# B"})
+
+    insert_chunk!(user, vault, note, 0, 100)
+    assert Stats.avgdl(vault.id) == 100.0
+
+    insert_chunk!(user, vault, note, 1, 300)
+    :ok = Stats.evict(vault.id)
+    assert Stats.avgdl(vault.id) == 200.0
+  end
+
+  test "empty vault default is returned and cached", %{vault: vault} do
+    assert Stats.avgdl(vault.id) == 100.0
+  end
+end

--- a/test/engram/notes_display_fields_meta_test.exs
+++ b/test/engram/notes_display_fields_meta_test.exs
@@ -1,0 +1,64 @@
+defmodule Engram.NotesDisplayFieldsMetaTest do
+  @moduledoc """
+  `display_fields_by_qdrant_points/2` only needs path + tags, so it must not
+  load or decrypt note CONTENT (up to candidate-pool notes per `/api/search`
+  request — the content decrypt was the dominant cost of every search).
+
+  Proof: a row whose content ciphertext is corrupted must still rehydrate —
+  the old full-struct path decrypts content, fails, and silently drops the
+  point from the result map.
+  """
+  use Engram.DataCase, async: true
+
+  alias Engram.Notes
+  alias Engram.Notes.Chunk
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  test "rehydrates path/tags without touching content ciphertext", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, note} =
+      Notes.upsert_note(user, vault, %{
+        "path" => "Health/iron.md",
+        "content" => "---\ntags: [labs]\n---\n# Iron\n\nFerritin levels.",
+        "mtime" => 1_000.0
+      })
+
+    point_id = Ecto.UUID.generate()
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        %Chunk{}
+        |> Chunk.changeset(%{
+          note_id: note.id,
+          user_id: user.id,
+          vault_id: vault.id,
+          position: 0,
+          char_start: 0,
+          char_end: 10,
+          qdrant_point_id: point_id
+        })
+        |> Repo.insert!()
+      end)
+
+    # Corrupt the content ciphertext at rest. Any code path that decrypts
+    # content now fails; the meta projection never reads the column.
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        from(n in Notes.Note, where: n.id == ^note.id)
+        |> Repo.update_all(set: [content_ciphertext: <<0, 1, 2, 3>>])
+      end)
+
+    result = Notes.display_fields_by_qdrant_points(user, [point_id])
+
+    assert %{source_path: "Health/iron.md", tags: ["labs"]} = result[point_id]
+  end
+end

--- a/test/engram/vector/qdrant_req_opts_test.exs
+++ b/test/engram/vector/qdrant_req_opts_test.exs
@@ -1,0 +1,57 @@
+defmodule Engram.Vector.QdrantReqOptsTest do
+  @moduledoc """
+  Per-purpose Req options: user-facing search must fail fast (short
+  receive_timeout, NO retries — a Qdrant brownout must not pin `/api/search`
+  requests for 30s x 4 attempts), while indexing keeps the patient defaults
+  (Oban retries the whole job anyway, but transient in-call retries save
+  attempts).
+  """
+  use ExUnit.Case, async: true
+
+  alias Engram.ServiceConfig
+  alias Engram.Vector.Qdrant
+
+  describe "req_opts/1" do
+    test "search purpose: short timeout, retries disabled" do
+      opts = Qdrant.req_opts(:search)
+
+      assert opts[:retry] == false
+      assert opts[:max_retries] == 0
+      assert opts[:receive_timeout] <= 5_000
+    end
+
+    test "indexing purpose: patient timeout, retry follows :qdrant_retry config" do
+      ServiceConfig.put_override(:qdrant_retry, :transient)
+      opts = Qdrant.req_opts(:indexing)
+
+      assert opts[:retry] == :transient
+      assert opts[:max_retries] == 3
+      assert opts[:receive_timeout] == 30_000
+    end
+  end
+
+  describe "search path behavior" do
+    setup do
+      bypass = Bypass.open()
+      ServiceConfig.put_override(:qdrant_url, "http://localhost:#{bypass.port}")
+      # Force retries ON so a regression (search using the indexing opts)
+      # shows up as extra attempts.
+      ServiceConfig.put_override(:qdrant_retry, :transient)
+      %{bypass: bypass}
+    end
+
+    test "search makes exactly one attempt on a 503", %{bypass: bypass} do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Bypass.stub(bypass, "POST", "/collections/c/points/query", fn conn ->
+        Agent.update(counter, &(&1 + 1))
+        Plug.Conn.send_resp(conn, 503, ~s({"status":"overloaded"}))
+      end)
+
+      assert {:error, _} =
+               Qdrant.search("c", [0.1, 0.2], user_id: Ecto.UUID.generate(), limit: 1)
+
+      assert Agent.get(counter, & &1) == 1
+    end
+  end
+end

--- a/test/engram/workers/embed_note_burst_index_test.exs
+++ b/test/engram/workers/embed_note_burst_index_test.exs
@@ -1,0 +1,38 @@
+defmodule Engram.Workers.EmbedNoteBurstIndexTest do
+  @moduledoc """
+  `EmbedNote.existing_burst_start/1` runs on every content-changing upsert
+  (`clamp: true` default) and filters `oban_jobs` by worker + `args->>'note_id'`
+  + state. Without a supporting index that's a scan of the embed backlog —
+  write latency degrades exactly when the queue is already stressed (positive
+  feedback under a Voyage outage or an onboarding wave).
+
+  Asserts the partial expression index exists and its predicate covers the
+  same worker + state set the query uses (drift here silently reverts to
+  scans — keep in sync with `existing_burst_start/1`).
+  """
+  use Engram.DataCase, async: true
+
+  # Mirror of the state list in EmbedNote.existing_burst_start/1.
+  @query_states ~w(scheduled available executing retryable)
+
+  test "partial expression index backs the burst-start lookup" do
+    %{rows: rows} =
+      Repo.query!(
+        "SELECT indexdef FROM pg_indexes WHERE tablename = 'oban_jobs' AND indexname = $1",
+        ["oban_jobs_embed_note_note_id_index"]
+      )
+
+    assert [[indexdef]] = rows,
+           "missing index oban_jobs_embed_note_note_id_index on oban_jobs"
+
+    assert indexdef =~ "note_id",
+           "index must be an expression index on (args ->> 'note_id')"
+
+    assert indexdef =~ "Engram.Workers.EmbedNote"
+
+    for state <- @query_states do
+      assert indexdef =~ state,
+             "index predicate must cover state '#{state}' (used by existing_burst_start/1)"
+    end
+  end
+end


### PR DESCRIPTION
Closes #861 — audit wave 1 (follow-up to #860). Four small hot-path fixes, TDD'd (all tests watched red first).

## Changes

1. **Partial expression index for the burst-start lookup** (`20260702110000`, `phase/expand`, CONCURRENTLY). `EmbedNote.existing_burst_start/1` runs on every content-changing upsert and filtered `oban_jobs` by `args->>'note_id'` with no index — the lookup scanned the embed backlog, so write latency degraded exactly when the queue was already stressed. Partial (worker + 4 in-flight states) so steady-state maintenance is near zero; a test asserts the predicate stays in sync with the query's state list.

2. **Qdrant per-purpose req opts.** `search`/`sparse_search`/`hybrid_search` now use `receive_timeout: 5s, retry: false`; a Qdrant brownout previously pinned each `/api/search` request up to ~2 min (30s x 4 attempts), holding Bandit processes. Indexing keeps the patient defaults (Oban callers). Mirrors the Voyage embedder's existing query/document split. Bypass test proves search makes exactly one attempt on 503 even with `:qdrant_retry` forced to `:transient`.

3. **Per-vault avgdl ETS cache** (10 min TTL + `evict/1`). Every embed job ran `SELECT avg(token_count)` over the vault's entire chunk set — O(N²) DB row visits for initial indexing of a large vault. BM25 length-norm is a soft signal (per the module's own doc), so TTL staleness is harmless; the future #605 re-normalize worker can `evict/1` first.

4. **Search rehydration uses the meta projection.** `display_fields_by_qdrant_points/2` selected and decrypted the full note row (content included) to return path+tags for up to candidate-pool notes per search. Now projects `@note_meta_fields` (attribute hoisted to module top; single definition). Test proves content is untouched: a row with corrupted content ciphertext still rehydrates.

## Testing

- 8 new tests across 4 files, all watched red first.
- Full suite 3319 tests, 0 failures × 3 consecutive runs (one earlier run showed 2 transient failures that did not recur and left no captured names; flagging for visibility).
- credo --strict clean, sobelow clean. v0.5.606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)