### PR TITLE
fix: sync correctness under clustering — PG idempotency, seq NOT NULL, pull_changes removal (audit wave 2)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -86,6 +86,9 @@ config :engram, Oban,
        # Daily client_logs retention sweep (Engram#792 — the log sink was
        # unbounded at ~98% of the DB).
        {"15 4 * * *", Engram.Workers.ClientLogsPruner},
+       # Daily expired idempotency_keys sweep (#862) — expired rows read as
+       # :miss already; this reclaims the encrypted response-body storage.
+       {"45 4 * * *", Engram.Workers.IdempotencyPrune},
        # Cross-store orphan sweep — weekly safety net for failed
        # event-driven Qdrant/S3 deletes. Sun 05:00 UTC, off-peak.
        {"0 5 * * 0", Engram.Workers.OrphanSweep}

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -52,7 +52,6 @@ defmodule Engram.Application do
         rate_limiter_child(),
         {Oban, Application.fetch_env!(:engram, Oban)},
         clerk_strategy_child(),
-        {Engram.Idempotency, []},
         # One DynamicSupervisor owns all live CRDT doc rooms. Rooms are
         # cluster-wide singletons via :global; this supervisor is the local
         # owner when a room is started on this node (see CrdtRegistry).

--- a/lib/engram/idempotency.ex
+++ b/lib/engram/idempotency.ex
@@ -36,33 +36,39 @@ defmodule Engram.Idempotency do
     ttl_ms = Keyword.get(opts, :ttl_ms, @default_ttl_ms)
     expires_at = DateTime.add(DateTime.utc_now(), ttl_ms, :millisecond)
 
-    with {:ok, dek} <- Crypto.get_dek(user) do
-      {ciphertext, nonce} = Envelope.encrypt(Jason.encode!(body), dek, aad(user.id, key))
+    case Crypto.get_dek(user) do
+      {:ok, dek} ->
+        {ciphertext, nonce} = Envelope.encrypt(Jason.encode!(body), dek, aad(user.id, key))
 
-      {:ok, _} =
-        Repo.with_tenant(user.id, fn ->
-          Repo.insert_all(
-            Key,
-            [
-              %{
-                id: Ecto.UUID.generate(),
-                user_id: user.id,
-                key: key,
-                status: status,
-                response_ciphertext: ciphertext,
-                response_nonce: nonce,
-                expires_at: expires_at,
-                inserted_at: DateTime.utc_now()
-              }
-            ],
-            # First response wins — a concurrent duplicate remember no-ops.
-            on_conflict: :nothing,
-            conflict_target: [:user_id, :key]
-          )
-        end)
+        {:ok, _} =
+          Repo.with_tenant(user.id, fn ->
+            Repo.insert_all(
+              Key,
+              [
+                %{
+                  id: Ecto.UUID.generate(),
+                  user_id: user.id,
+                  key: key,
+                  status: status,
+                  response_ciphertext: ciphertext,
+                  response_nonce: nonce,
+                  expires_at: expires_at,
+                  inserted_at: DateTime.utc_now()
+                }
+              ],
+              # First response wins — a concurrent duplicate remember no-ops.
+              on_conflict: :nothing,
+              conflict_target: [:user_id, :key]
+            )
+          end)
+
+        :ok
+
+      {:error, _} ->
+        # No DEK → nothing to cache. A future replay degrades to
+        # re-execution, which is safe (idempotent upserts short-circuit).
+        :ok
     end
-
-    :ok
   end
 
   @spec lookup(map(), Ecto.UUID.t()) :: {:ok, %{status: integer(), body: term()}} | :miss

--- a/lib/engram/idempotency.ex
+++ b/lib/engram/idempotency.ex
@@ -1,56 +1,125 @@
 defmodule Engram.Idempotency do
   @moduledoc """
-  ETS-backed idempotency-key cache for batch endpoints.
-  TTL default 24h; entries beyond TTL return :miss.
+  Postgres-backed idempotency-key store for batch endpoints (#862).
 
-  A periodic sweep deletes expired rows — entries cache full response
-  bodies, and lazy expiry alone (lookup returning :miss) never reclaimed
-  the memory.
+  The previous ETS cache was node-local: under clustering, a client retry
+  routed to the other node missed the cache and re-executed the batch — the
+  idempotency key was defeated by the load balancer. It was also keyed
+  globally rather than per user. Rows here are user-scoped (lookup requires
+  the authenticated user) and the cached response body is encrypted under
+  the user's DEK with the AAD bound to `(user_id, key)` — batch responses
+  carry plaintext note paths, which never sit plaintext at rest anywhere
+  else.
+
+  Decrypt failure degrades to `:miss` by design: after a per-user DEK
+  rotation (T3.7) old rows are unreadable, and re-executing the batch is
+  safe — identical-content upserts short-circuit (#860), so a replayed
+  batch converges on the same result.
+
+  Expiry: rows past `expires_at` (default TTL 24h) read as `:miss`
+  immediately and are deleted by the daily `IdempotencyPrune` worker.
   """
-  use GenServer
 
-  @table :engram_idempotency
+  import Ecto.Query
+
+  alias Engram.Crypto
+  alias Engram.Crypto.Envelope
+  alias Engram.Idempotency.Key
+  alias Engram.Repo
+
+  require Logger
+
   @default_ttl_ms 24 * 60 * 60 * 1000
-  @sweep_interval_ms 10 * 60 * 1000
 
-  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  @spec remember(map(), Ecto.UUID.t(), %{status: integer(), body: term()}, keyword()) :: :ok
+  def remember(user, key, %{status: status, body: body}, opts \\ []) do
+    ttl_ms = Keyword.get(opts, :ttl_ms, @default_ttl_ms)
+    expires_at = DateTime.add(DateTime.utc_now(), ttl_ms, :millisecond)
 
-  @impl true
-  def init(_opts) do
-    _ = :ets.new(@table, [:set, :public, :named_table, read_concurrency: true])
-    _ = schedule_sweep()
-    {:ok, %{}}
-  end
+    with {:ok, dek} <- Crypto.get_dek(user) do
+      {ciphertext, nonce} = Envelope.encrypt(Jason.encode!(body), dek, aad(user.id, key))
 
-  @impl true
-  def handle_info(:sweep, state) do
-    now = System.monotonic_time(:millisecond)
-    # Matches {key, response, expires_at} where expires_at <= now.
-    _ = :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}])
-    _ = schedule_sweep()
-    {:noreply, state}
-  end
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.insert_all(
+            Key,
+            [
+              %{
+                id: Ecto.UUID.generate(),
+                user_id: user.id,
+                key: key,
+                status: status,
+                response_ciphertext: ciphertext,
+                response_nonce: nonce,
+                expires_at: expires_at,
+                inserted_at: DateTime.utc_now()
+              }
+            ],
+            # First response wins — a concurrent duplicate remember no-ops.
+            on_conflict: :nothing,
+            conflict_target: [:user_id, :key]
+          )
+        end)
+    end
 
-  defp schedule_sweep do
-    Process.send_after(self(), :sweep, @sweep_interval_ms)
-  end
-
-  def remember(key, response, opts \\ []) do
-    ttl = Keyword.get(opts, :ttl_ms, @default_ttl_ms)
-    expires_at = System.monotonic_time(:millisecond) + ttl
-    :ets.insert(@table, {key, response, expires_at})
     :ok
   end
 
-  def lookup(key) do
-    case :ets.lookup(@table, key) do
-      [{^key, response, expires_at}] ->
-        if expires_at > System.monotonic_time(:millisecond),
-          do: {:ok, response},
-          else: :miss
+  @spec lookup(map(), Ecto.UUID.t()) :: {:ok, %{status: integer(), body: term()}} | :miss
+  def lookup(user, key) do
+    now = DateTime.utc_now()
 
-      [] ->
+    {:ok, row} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.one(
+          from(k in Key,
+            where: k.user_id == ^user.id and k.key == ^key and k.expires_at > ^now
+          )
+        )
+      end)
+
+    with %Key{} <- row,
+         {:ok, dek} <- Crypto.get_dek(user),
+         {:ok, json} <-
+           decrypt_response(row.response_ciphertext, row.response_nonce, dek, user.id, key) do
+      {:ok, %{status: row.status, body: Jason.decode!(json)}}
+    else
+      _ -> :miss
+    end
+  end
+
+  @doc """
+  Deletes expired rows across all users. Cross-tenant by design (the table
+  relies on app-layer scoping — see the rls_coverage allowlist); called by
+  the daily `Engram.Workers.IdempotencyPrune` cron.
+  """
+  @spec prune_expired() :: {:ok, non_neg_integer()}
+  def prune_expired do
+    {count, _} =
+      Repo.delete_all(
+        from(k in Key, where: k.expires_at <= ^DateTime.utc_now()),
+        skip_tenant_check: true
+      )
+
+    {:ok, count}
+  end
+
+  defp decrypt_response(ciphertext, nonce, dek, user_id, key) do
+    case Envelope.decrypt(ciphertext, nonce, dek, aad(user_id, key)) do
+      {:ok, json} ->
+        {:ok, json}
+
+      :error ->
+        # Expected after a per-user DEK rotation — replay-by-re-execution is
+        # safe (idempotent upserts short-circuit), so degrade to :miss.
+        Logger.warning(
+          "idempotency_response_undecryptable",
+          Engram.Logger.Metadata.with_category(:warning, :crypto, user_id: user_id)
+        )
+
         :miss
     end
   end
+
+  defp aad(user_id, key), do: "idempotency_keys:response:#{user_id}:#{key}"
 end

--- a/lib/engram/idempotency/key.ex
+++ b/lib/engram/idempotency/key.ex
@@ -1,0 +1,16 @@
+defmodule Engram.Idempotency.Key do
+  @moduledoc false
+  use Engram.Schema
+
+  schema "idempotency_keys" do
+    field :key, Ecto.UUID
+    field :status, :integer
+    field :response_ciphertext, :binary
+    field :response_nonce, :binary
+    field :expires_at, :utc_datetime_usec
+
+    belongs_to :user, Engram.Accounts.User
+
+    timestamps(type: :utc_datetime_usec, inserted_at: :inserted_at, updated_at: false)
+  end
+end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1675,43 +1675,6 @@ defmodule Engram.Notes do
     end
   end
 
-  @doc """
-  Returns notes changed (upserted or deleted) since the given datetime.
-  Deleted notes are included with deleted: true.
-
-  Options:
-
-    * `fields: :meta` — project out `content_ciphertext` and return
-      `content: nil`. Used by the sync channel's `pull_changes`, whose
-      reply never includes content; skips the dominant column read and
-      its decrypt.
-  """
-  @spec list_changes(map(), map(), DateTime.t(), keyword()) :: {:ok, [map()]}
-  def list_changes(user, vault, since, opts \\ []) do
-    base =
-      from(n in Note,
-        where:
-          n.user_id == ^user.id and n.vault_id == ^vault.id and n.updated_at >= ^since and
-            n.kind == "note",
-        order_by: [asc: n.updated_at]
-      )
-
-    query =
-      case Keyword.get(opts, :fields, :all) do
-        :meta -> from(n in base, select: struct(n, @note_meta_fields))
-        :all -> base
-      end
-
-    {:ok, notes} = Repo.with_tenant(user.id, fn -> Repo.all(query) end)
-
-    changes =
-      notes
-      |> decrypt_or_raise!(user)
-      |> Enum.map(&change_map/1)
-
-    {:ok, changes}
-  end
-
   @changes_page_max_limit 500
 
   @doc """

--- a/lib/engram/webhooks/idempotency.ex
+++ b/lib/engram/webhooks/idempotency.ex
@@ -11,22 +11,33 @@ defmodule Engram.Webhooks.Idempotency do
   no-ops instead of re-running side effects (re-issuing PostHog events,
   re-touching subscription state, etc.).
 
-  Backed by `Engram.Idempotency` (process-wide ETS, 24h TTL) — long enough to
-  cover provider retry windows. A blank/missing id can't be deduped, so it
-  always proceeds (signature + timestamp remain the floor).
+  Backed by the `processed_webhook_events` table (#862) so dedup is
+  cross-node and restart-proof — the previous ETS backing was node-local,
+  and a provider retry routed to the other node re-ran side effects. Rows
+  older than 7 days (well past provider retry windows) are pruned by
+  `Engram.Workers.IdempotencyPrune`. A blank/missing id can't be deduped,
+  so it always proceeds (signature + timestamp remain the floor).
   """
 
-  alias Engram.Idempotency
+  import Ecto.Query
+
+  alias Engram.Repo
 
   @type source :: :paddle | :clerk
+
+  @retention_days 7
 
   @doc "Returns `:proceed` if this event hasn't been processed, else `:duplicate`."
   @spec check(source(), String.t() | nil) :: :proceed | :duplicate
   def check(source, id) when is_binary(id) and id != "" do
-    case Idempotency.lookup(key(source, id)) do
-      {:ok, _} -> :duplicate
-      :miss -> :proceed
-    end
+    exists =
+      Repo.exists?(
+        from(e in "processed_webhook_events",
+          where: e.provider == ^to_string(source) and e.event_id == ^id
+        )
+      )
+
+    if exists, do: :duplicate, else: :proceed
   end
 
   def check(_source, _id), do: :proceed
@@ -37,11 +48,26 @@ defmodule Engram.Webhooks.Idempotency do
   """
   @spec mark_processed(source(), String.t() | nil) :: :ok
   def mark_processed(source, id) when is_binary(id) and id != "" do
-    Idempotency.remember(key(source, id), :processed)
+    _ =
+      Repo.insert_all(
+        "processed_webhook_events",
+        [%{provider: to_string(source), event_id: id}],
+        on_conflict: :nothing
+      )
+
     :ok
   end
 
   def mark_processed(_source, _id), do: :ok
 
-  defp key(source, id), do: "webhook:#{source}:#{id}"
+  @doc "Deletes rows past the retention window. Called by IdempotencyPrune."
+  @spec prune() :: {:ok, non_neg_integer()}
+  def prune do
+    cutoff = DateTime.add(DateTime.utc_now(), -@retention_days, :day)
+
+    {count, _} =
+      Repo.delete_all(from(e in "processed_webhook_events", where: e.inserted_at < ^cutoff))
+
+    {:ok, count}
+  end
 end

--- a/lib/engram/workers/idempotency_prune.ex
+++ b/lib/engram/workers/idempotency_prune.ex
@@ -1,0 +1,21 @@
+defmodule Engram.Workers.IdempotencyPrune do
+  @moduledoc """
+  Daily sweep of expired idempotency_keys rows (#862). Expired rows already
+  read as :miss; this reclaims the storage (each row caches a full encrypted
+  batch response body).
+  """
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  @impl Oban.Worker
+  def perform(_job) do
+    {:ok, keys} = Engram.Idempotency.prune_expired()
+    {:ok, webhooks} = Engram.Webhooks.Idempotency.prune()
+
+    if keys + webhooks > 0 do
+      require Logger
+      Logger.info("idempotency_prune keys=#{keys} webhook_events=#{webhooks}")
+    end
+
+    :ok
+  end
+end

--- a/lib/engram_web/channels/sync_channel.ex
+++ b/lib/engram_web/channels/sync_channel.ex
@@ -113,15 +113,14 @@ defmodule EngramWeb.SyncChannel do
   # pull_changes
   # ---------------------------------------------------------------------------
 
+  # Removed op (#862): the handler was unbounded — it loaded + decrypted the
+  # entire vault change set (Pro = uncapped) into ONE channel frame. No client
+  # ever shipped calling it (plugin + SPA use the keyset-paginated HTTP feed
+  # at GET /api/sync/changes), so it goes away rather than growing pagination.
+  # The stub keeps a stray legacy caller from crashing the channel.
   @impl true
-  def handle_in("pull_changes", %{"since" => since_str}, socket) do
-    span_sync(:pull_changes, fn -> do_pull_changes(since_str, socket) end)
-  end
-
   def handle_in("pull_changes", _params, socket) do
-    # T3.7 — missing `since` key; no need to gate (no DEK access before param parse).
-    # The since-required check is purely structural validation — not a DEK write path.
-    {:reply, {:error, %{"reason" => "since is required"}}, socket}
+    {:reply, {:error, %{"reason" => "gone", "use" => "GET /api/sync/changes"}}, socket}
   end
 
   # ---------------------------------------------------------------------------
@@ -227,63 +226,7 @@ defmodule EngramWeb.SyncChannel do
     end
   end
 
-  defp do_pull_changes(since_str, socket) do
-    # T3.7 — re-read the lock state; stale snapshot from connect/3. Reads are
-    # also blocked: between a sweep batch writing dek_version=new and final_flip
-    # invalidating the DekCache, the old DEK in cache cannot decrypt the new
-    # ciphertext — reads during this window fail with :decrypt_failed.
-    case RotationGate.check(socket.assigns.current_user.id) do
-      {:error, :rotation_in_progress} ->
-        :telemetry.execute(
-          [:engram, :crypto, :rotate, :dek, :gate_blocked],
-          %{count: 1},
-          %{gate_path: :channel, op: :pull_changes}
-        )
-
-        {:reply, {:error, %{reason: "rotation_in_progress", retry_after_seconds: 60}}, socket}
-
-      {:error, :user_not_found} ->
-        {:reply, {:error, %{reason: "user_not_found"}}, socket}
-
-      :ok ->
-        user = socket.assigns.current_user
-        vault = socket.assigns.vault
-
-        case DateTime.from_iso8601(since_str) do
-          {:ok, since, _} ->
-            # :meta — this reply never includes content (clients pull
-            # bodies separately), so skip the content fetch + decrypt.
-            {:ok, changes} = Notes.list_changes(user, vault, since, fields: :meta)
-
-            serialized =
-              Enum.map(changes, fn c ->
-                %{
-                  "id" => c.id,
-                  "path" => c.path,
-                  "title" => c.title,
-                  "folder" => c.folder,
-                  "tags" => c.tags,
-                  "version" => c.version,
-                  "mtime" => c.mtime,
-                  "deleted" => c.deleted,
-                  "updated_at" => DateTime.to_iso8601(c.updated_at)
-                }
-              end)
-
-            reply = %{
-              "changes" => serialized,
-              "server_time" => DateTime.utc_now() |> DateTime.to_iso8601()
-            }
-
-            {:reply, {:ok, reply}, socket}
-
-          {:error, _} ->
-            {:reply, {:error, %{"reason" => "invalid since timestamp"}}, socket}
-        end
-    end
-  end
-
-  # ---------------------------------------------------------------------------
+  # -----------------------------------------------------------------------------
   # Telemetry helpers — engram-app/engram-infra#340
   # ---------------------------------------------------------------------------
 

--- a/lib/engram_web/controllers/attachments_controller.ex
+++ b/lib/engram_web/controllers/attachments_controller.ex
@@ -223,7 +223,13 @@ defmodule EngramWeb.AttachmentsController do
         case Attachments.batch_move(user, vault, paths, target) do
           {:ok, %{moved: n}} ->
             body = %{moved: n}
-            Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+
+            Engram.Idempotency.remember(
+              conn.assigns.current_user,
+              conn.assigns.idempotency_key,
+              %{status: 200, body: body}
+            )
+
             json(conn, body)
 
           {:error, {:conflict, p}} ->
@@ -266,7 +272,12 @@ defmodule EngramWeb.AttachmentsController do
     # batch_delete/3 is total — its @spec returns {:ok, %{deleted: _}} only.
     {:ok, %{deleted: n}} = Attachments.batch_delete(user, vault, paths)
     body = %{deleted: n}
-    Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+
+    Engram.Idempotency.remember(conn.assigns.current_user, conn.assigns.idempotency_key, %{
+      status: 200,
+      body: body
+    })
+
     json(conn, body)
   end
 

--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -289,7 +289,13 @@ defmodule EngramWeb.FoldersController do
         case Folders.batch_delete(user, vault, ids) do
           {:ok, %{notes: n, attachments: a}} ->
             body = %{deleted: n, deleted_attachments: a}
-            Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+
+            Engram.Idempotency.remember(
+              conn.assigns.current_user,
+              conn.assigns.idempotency_key,
+              %{status: 200, body: body}
+            )
+
             broadcast_batch(user, vault, %{op: "delete", ids: ids})
             json(conn, body)
 
@@ -377,7 +383,12 @@ defmodule EngramWeb.FoldersController do
     case result do
       {:ok, %{notes: n, attachments: a}} ->
         body = %{moved: n, moved_attachments: a}
-        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+
+        Engram.Idempotency.remember(conn.assigns.current_user, conn.assigns.idempotency_key, %{
+          status: 200,
+          body: body
+        })
+
         broadcast_batch(user, vault, Map.merge(%{op: "move", ids: ids}, broadcast_extra))
         json(conn, body)
 

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -474,7 +474,12 @@ defmodule EngramWeb.NotesController do
           end)
 
         body = %{results: merged}
-        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+
+        Engram.Idempotency.remember(conn.assigns.current_user, conn.assigns.idempotency_key, %{
+          status: 200,
+          body: body
+        })
+
         json(conn, body)
 
       {:error, {:notes_cap_reached, limit, current}} ->
@@ -536,7 +541,13 @@ defmodule EngramWeb.NotesController do
         case Notes.batch_delete_notes(user, vault, ids) do
           {:ok, %{deleted: n}} ->
             body = %{deleted: n}
-            Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+
+            Engram.Idempotency.remember(
+              conn.assigns.current_user,
+              conn.assigns.idempotency_key,
+              %{status: 200, body: body}
+            )
+
             broadcast_batch(user, vault, %{op: "delete", ids: ids})
             json(conn, body)
 
@@ -616,7 +627,12 @@ defmodule EngramWeb.NotesController do
     case result do
       {:ok, %{moved: n}} ->
         body = %{moved: n}
-        Engram.Idempotency.remember(conn.assigns.idempotency_key, %{status: 200, body: body})
+
+        Engram.Idempotency.remember(conn.assigns.current_user, conn.assigns.idempotency_key, %{
+          status: 200,
+          body: body
+        })
+
         broadcast_batch(user, vault, Map.merge(%{op: "move", ids: ids}, broadcast_extra))
         json(conn, body)
 

--- a/lib/engram_web/plugs/idempotency_key.ex
+++ b/lib/engram_web/plugs/idempotency_key.ex
@@ -24,7 +24,9 @@ defmodule EngramWeb.Plugs.IdempotencyKey do
   end
 
   defp maybe_replay(conn, key) do
-    case Idempotency.lookup(key) do
+    # User-scoped: the key namespace is per authenticated user (Auth runs
+    # before this plug), so one tenant can never replay another's response.
+    case Idempotency.lookup(conn.assigns.current_user, key) do
       {:ok, %{status: status, body: body}} ->
         conn
         |> put_resp_content_type("application/json")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.606",
+      version: "0.5.607",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260702120000_backfill_seq_not_null_migrate.exs
+++ b/priv/repo/migrations/20260702120000_backfill_seq_not_null_migrate.exs
@@ -1,0 +1,87 @@
+defmodule Engram.Repo.Migrations.BackfillSeqNotNullMigrate do
+  use Ecto.Migration
+
+  # phase/migrate-data — backfill NULL seq rows, then harden with NOT NULL.
+  #
+  # The seq change feed filters `seq IS NOT NULL`, so a NULL-seq row silently
+  # never syncs. Every current write path stamps seq app-side, but nothing at
+  # the DB level enforced it, and the backfill the 20260616120000 moduledoc
+  # promised (20260616120100) never shipped. Backfill any stragglers per
+  # vault (ordered by updated_at so backfilled history replays in edit
+  # order), advance the vault counter past them, then add validated NOT NULL
+  # constraints (PG18 named-constraint pattern — no ACCESS EXCLUSIVE scan;
+  # see AGENTS.md "PG18-era cheap patterns").
+  #
+  # notes/attachments/vaults carry FORCE ROW LEVEL SECURITY and the migrator
+  # has no tenant context — without the NO FORCE dance this DML silently
+  # touches 0 rows on prod (see docs/context/migrations-force-rls-data-dml.md).
+  def up do
+    execute("ALTER TABLE notes NO FORCE ROW LEVEL SECURITY")
+    execute("ALTER TABLE attachments NO FORCE ROW LEVEL SECURITY")
+    execute("ALTER TABLE vaults NO FORCE ROW LEVEL SECURITY")
+
+    execute(backfill_sql("notes"))
+    execute(backfill_sql("attachments"))
+
+    execute("""
+    DO $$
+    DECLARE remaining bigint;
+    BEGIN
+      SELECT COUNT(*) INTO remaining FROM notes WHERE seq IS NULL;
+      IF remaining > 0 THEN
+        RAISE EXCEPTION 'seq backfill incomplete: % notes rows still NULL', remaining;
+      END IF;
+      SELECT COUNT(*) INTO remaining FROM attachments WHERE seq IS NULL;
+      IF remaining > 0 THEN
+        RAISE EXCEPTION 'seq backfill incomplete: % attachments rows still NULL', remaining;
+      END IF;
+    END $$;
+    """)
+
+    execute("ALTER TABLE notes FORCE ROW LEVEL SECURITY")
+    execute("ALTER TABLE attachments FORCE ROW LEVEL SECURITY")
+    execute("ALTER TABLE vaults FORCE ROW LEVEL SECURITY")
+
+    execute("ALTER TABLE notes ADD CONSTRAINT notes_seq_not_null NOT NULL seq NOT VALID")
+    execute("ALTER TABLE notes VALIDATE CONSTRAINT notes_seq_not_null")
+
+    execute(
+      "ALTER TABLE attachments ADD CONSTRAINT attachments_seq_not_null NOT NULL seq NOT VALID"
+    )
+
+    execute("ALTER TABLE attachments VALIDATE CONSTRAINT attachments_seq_not_null")
+  end
+
+  def down do
+    execute("ALTER TABLE notes DROP CONSTRAINT notes_seq_not_null")
+    execute("ALTER TABLE attachments DROP CONSTRAINT attachments_seq_not_null")
+    # Backfilled seq values stay — they are valid feed entries, not damage.
+  end
+
+  # Assign each NULL-seq row the next seqs after the vault's current counter
+  # (ordered by updated_at, id within the vault), then advance the counter
+  # past them so live writes can't collide. Both UPDATEs share the `nulls`
+  # CTE snapshot, so the counts match by construction.
+  defp backfill_sql(table) do
+    """
+    WITH nulls AS (
+      SELECT id, vault_id,
+             row_number() OVER (PARTITION BY vault_id ORDER BY updated_at, id) AS rn
+      FROM #{table}
+      WHERE seq IS NULL
+    ),
+    bumped AS (
+      UPDATE #{table} t
+      SET seq = v.change_seq + nulls.rn
+      FROM nulls
+      JOIN vaults v ON v.id = nulls.vault_id
+      WHERE t.id = nulls.id
+      RETURNING t.id
+    )
+    UPDATE vaults v
+    SET change_seq = v.change_seq + c.cnt
+    FROM (SELECT vault_id, count(*) AS cnt FROM nulls GROUP BY vault_id) c
+    WHERE v.id = c.vault_id
+    """
+  end
+end

--- a/priv/repo/migrations/20260702130000_create_idempotency_keys_expand.exs
+++ b/priv/repo/migrations/20260702130000_create_idempotency_keys_expand.exs
@@ -1,6 +1,11 @@
 defmodule Engram.Repo.Migrations.CreateIdempotencyKeysExpand do
   use Ecto.Migration
 
+  # squawk-ignore-file
+  #
+  # squawk false positives here: indexes on a freshly-created (empty) table cannot block
+  # anything, and `status` holds an HTTP status code (bounded < 600).
+
   # phase/expand — new table; no backfill.
   #
   # Replaces the node-local ETS idempotency cache for batch endpoints (#862):

--- a/priv/repo/migrations/20260702130000_create_idempotency_keys_expand.exs
+++ b/priv/repo/migrations/20260702130000_create_idempotency_keys_expand.exs
@@ -1,0 +1,39 @@
+defmodule Engram.Repo.Migrations.CreateIdempotencyKeysExpand do
+  use Ecto.Migration
+
+  # phase/expand — new table; no backfill.
+  #
+  # Replaces the node-local ETS idempotency cache for batch endpoints (#862):
+  # under clustering, a client retry routed to the other node missed the ETS
+  # entry and re-executed the batch — the idempotency key was defeated by the
+  # LB. Rows are also user-scoped (the ETS cache was keyed globally) and the
+  # cached response body is DEK-encrypted + AAD-bound to (user, key), because
+  # batch responses carry plaintext note paths.
+  #
+  # No RLS (rls_coverage allowlist): every read/write filters user_id
+  # app-side, the payload is ciphertext under the tenant's own DEK, and the
+  # expiry pruner needs cheap cross-tenant deletes.
+  def change do
+    create table(:idempotency_keys, primary_key: false) do
+      add :id, :uuid, primary_key: true, default: fragment("uuidv7()")
+      add :user_id, references(:users, type: :uuid, on_delete: :delete_all), null: false
+      add :key, :uuid, null: false
+      add :status, :integer, null: false
+      add :response_ciphertext, :binary, null: false
+      add :response_nonce, :binary, null: false
+      add :expires_at, :timestamptz, null: false
+      add :inserted_at, :timestamptz, null: false, default: fragment("now()")
+    end
+
+    # Replay lookup key; unique so concurrent duplicate remembers race to one
+    # row (ON CONFLICT DO NOTHING — first response wins).
+    create unique_index(:idempotency_keys, [:user_id, :key])
+    # Expiry pruner scan.
+    create index(:idempotency_keys, [:expires_at])
+
+    execute(
+      "GRANT SELECT, INSERT, UPDATE, DELETE ON idempotency_keys TO engram_app",
+      "REVOKE ALL ON idempotency_keys FROM engram_app"
+    )
+  end
+end

--- a/priv/repo/migrations/20260702140000_create_processed_webhook_events_expand.exs
+++ b/priv/repo/migrations/20260702140000_create_processed_webhook_events_expand.exs
@@ -1,6 +1,10 @@
 defmodule Engram.Repo.Migrations.CreateProcessedWebhookEventsExpand do
   use Ecto.Migration
 
+  # squawk-ignore-file
+  #
+  # squawk false positives here: index on a freshly-created (empty) table cannot block anything.
+
   # phase/expand — new table; no backfill.
   #
   # Cross-node webhook replay dedup (#862): the ETS-backed guard was

--- a/priv/repo/migrations/20260702140000_create_processed_webhook_events_expand.exs
+++ b/priv/repo/migrations/20260702140000_create_processed_webhook_events_expand.exs
@@ -1,0 +1,27 @@
+defmodule Engram.Repo.Migrations.CreateProcessedWebhookEventsExpand do
+  use Ecto.Migration
+
+  # phase/expand — new table; no backfill.
+  #
+  # Cross-node webhook replay dedup (#862): the ETS-backed guard was
+  # node-local, so a Paddle/Clerk retry routed to the other node re-ran side
+  # effects (duplicate PostHog events, subscription re-touch). Handlers are
+  # state-convergent so impact was low — a unique PG row makes the dedup
+  # cross-node and restart-proof. Rows are (provider, event_id) only; pruned
+  # after 7 days (well past provider retry windows) by IdempotencyPrune.
+  def change do
+    create table(:processed_webhook_events, primary_key: false) do
+      add :provider, :text, null: false, primary_key: true
+      add :event_id, :text, null: false, primary_key: true
+      add :inserted_at, :timestamptz, null: false, default: fragment("now()")
+    end
+
+    # Prune scan (delete where inserted_at < now() - interval '7 days').
+    create index(:processed_webhook_events, [:inserted_at])
+
+    execute(
+      "GRANT SELECT, INSERT, UPDATE, DELETE ON processed_webhook_events TO engram_app",
+      "REVOKE ALL ON processed_webhook_events FROM engram_app"
+    )
+  end
+end

--- a/test/engram/crypto/aad_rebind_test.exs
+++ b/test/engram/crypto/aad_rebind_test.exs
@@ -37,6 +37,7 @@ defmodule Engram.Crypto.AadRebindTest do
         |> Ecto.Changeset.cast(
           %{
             content_hash: "h",
+            seq: 1,
             mtime: 0.0,
             user_id: user.id,
             vault_id: vault.id,
@@ -57,6 +58,7 @@ defmodule Engram.Crypto.AadRebindTest do
           },
           [
             :content_hash,
+            :seq,
             :mtime,
             :user_id,
             :vault_id,

--- a/test/engram/idempotency_test.exs
+++ b/test/engram/idempotency_test.exs
@@ -1,53 +1,89 @@
 defmodule Engram.IdempotencyTest do
-  use ExUnit.Case, async: false
+  @moduledoc """
+  PG-backed idempotency store (#862). The previous ETS cache was node-local
+  (a retry routed to the other Fargate task re-executed the batch — the key
+  was defeated by the LB) and globally keyed (not user-scoped). Rows are
+  user-scoped, DEK-encrypted at rest (batch responses carry plaintext note
+  paths), and expire via the daily prune worker.
+  """
+  use Engram.DataCase, async: true
+
   alias Engram.Idempotency
 
   setup do
-    # Use a fresh table per test so we don't fight start_link/already_started across tests.
-    # The Idempotency GenServer is started in the supervision tree at app start
-    # for normal runs; in tests we want to verify the basic put/get behavior.
-    on_exit(fn ->
-      if :ets.whereis(:engram_idempotency) != :undefined,
-        do: :ets.delete_all_objects(:engram_idempotency)
-    end)
-
-    case Idempotency.start_link([]) do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
-
-    :ok
+    user = insert(:user)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    other = insert(:user)
+    {:ok, other} = Engram.Crypto.ensure_user_dek(other)
+    %{user: user, other: other}
   end
 
-  test "remember/2 stores; lookup/1 returns it" do
-    Idempotency.remember("key-1", %{status: 200, body: %{ok: true}})
-    assert {:ok, %{status: 200}} = Idempotency.lookup("key-1")
+  defp key, do: Ecto.UUID.generate()
+
+  test "remember/lookup round-trips through Postgres", %{user: user} do
+    k = key()
+    :ok = Idempotency.remember(user, k, %{status: 200, body: %{"results" => [%{"ok" => true}]}})
+
+    assert {:ok, %{status: 200, body: %{"results" => [%{"ok" => true}]}}} =
+             Idempotency.lookup(user, k)
   end
 
-  test "lookup/1 returns :miss for unknown keys" do
-    assert :miss = Idempotency.lookup("unknown")
+  test "lookup is user-scoped — another user cannot replay the key", %{
+    user: user,
+    other: other
+  } do
+    k = key()
+    :ok = Idempotency.remember(user, k, %{status: 200, body: %{"secret" => true}})
+
+    assert :miss = Idempotency.lookup(other, k)
   end
 
-  test "expired entries return :miss" do
-    Idempotency.remember("key-2", %{status: 200, body: %{}}, ttl_ms: 0)
-    Process.sleep(5)
-    assert :miss = Idempotency.lookup("key-2")
+  test "unknown key misses", %{user: user} do
+    assert :miss = Idempotency.lookup(user, key())
   end
 
-  test "periodic sweep deletes expired rows from the table" do
-    # Entries cache full response bodies for batch endpoints; expired rows
-    # previously returned :miss but were never deleted — a certain (if
-    # slow) memory leak. Live entries must survive the sweep.
-    Idempotency.remember("dead-1", %{status: 200, body: %{big: "payload"}}, ttl_ms: 0)
-    Idempotency.remember("dead-2", %{status: 200, body: %{}}, ttl_ms: 0)
-    Idempotency.remember("alive", %{status: 200, body: %{}}, ttl_ms: 60_000)
-    Process.sleep(5)
+  test "expired entries miss", %{user: user} do
+    k = key()
+    :ok = Idempotency.remember(user, k, %{status: 200, body: %{}}, ttl_ms: -1_000)
+    assert :miss = Idempotency.lookup(user, k)
+  end
 
-    send(Process.whereis(Idempotency), :sweep)
-    :sys.get_state(Idempotency)
+  test "response body is ciphertext at rest", %{user: user} do
+    k = key()
+    :ok = Idempotency.remember(user, k, %{status: 200, body: %{"path" => "Secret/plans.md"}})
 
-    assert :ets.lookup(:engram_idempotency, "dead-1") == []
-    assert :ets.lookup(:engram_idempotency, "dead-2") == []
-    assert [{"alive", _, _}] = :ets.lookup(:engram_idempotency, "alive")
+    {:ok, key_bin} = Ecto.UUID.dump(k)
+
+    %{rows: [[ciphertext]]} =
+      Repo.query!(
+        "SELECT response_ciphertext FROM idempotency_keys WHERE key = $1",
+        [key_bin]
+      )
+
+    refute ciphertext =~ "Secret/plans.md"
+    assert {:ok, %{body: %{"path" => "Secret/plans.md"}}} = Idempotency.lookup(user, k)
+  end
+
+  test "duplicate remember keeps the first response", %{user: user} do
+    k = key()
+    :ok = Idempotency.remember(user, k, %{status: 200, body: %{"attempt" => 1}})
+    :ok = Idempotency.remember(user, k, %{status: 200, body: %{"attempt" => 2}})
+
+    assert {:ok, %{body: %{"attempt" => 1}}} = Idempotency.lookup(user, k)
+  end
+
+  test "prune_expired/0 deletes expired rows across users, keeps live ones", %{
+    user: user,
+    other: other
+  } do
+    dead_a = key()
+    dead_b = key()
+    alive = key()
+    :ok = Idempotency.remember(user, dead_a, %{status: 200, body: %{}}, ttl_ms: -1_000)
+    :ok = Idempotency.remember(other, dead_b, %{status: 200, body: %{}}, ttl_ms: -1_000)
+    :ok = Idempotency.remember(user, alive, %{status: 200, body: %{}})
+
+    assert {:ok, 2} = Idempotency.prune_expired()
+    assert {:ok, _} = Idempotency.lookup(user, alive)
   end
 end

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -639,7 +639,7 @@ defmodule Engram.NotesTest do
         })
 
       past = DateTime.add(note.updated_at, -60, :second)
-      {:ok, changes} = Notes.list_changes(user, vault, past)
+      {:ok, %{changes: changes}} = Notes.list_changes_page(user, vault, past)
 
       assert Enum.any?(changes, &(&1.path == "Test/Recent.md"))
     end
@@ -654,7 +654,7 @@ defmodule Engram.NotesTest do
       Notes.delete_note(user, vault, "Test/Deleted.md")
 
       past = ~U[2020-01-01 00:00:00Z]
-      {:ok, changes} = Notes.list_changes(user, vault, past)
+      {:ok, %{changes: changes}} = Notes.list_changes_page(user, vault, past)
 
       deleted = Enum.find(changes, &(&1.path == "Test/Deleted.md"))
       assert deleted != nil
@@ -674,13 +674,13 @@ defmodule Engram.NotesTest do
       })
 
       past = ~U[2020-01-01 00:00:00Z]
-      {:ok, changes} = Notes.list_changes(user, vault, past)
+      {:ok, %{changes: changes}} = Notes.list_changes_page(user, vault, past)
 
       refute Enum.any?(changes, &(&1.path == "Test/Other.md"))
     end
 
     test "returns empty list when no changes since timestamp", %{user: user, vault: vault} do
-      {:ok, changes} = Notes.list_changes(user, vault, ~U[2099-01-01 00:00:00Z])
+      {:ok, %{changes: changes}} = Notes.list_changes_page(user, vault, ~U[2099-01-01 00:00:00Z])
       assert changes == []
     end
 
@@ -698,7 +698,7 @@ defmodule Engram.NotesTest do
         })
 
       past = DateTime.add(note.updated_at, -60, :second)
-      {:ok, changes} = Notes.list_changes(user, vault, past)
+      {:ok, %{changes: changes}} = Notes.list_changes_page(user, vault, past)
 
       paths = Enum.map(changes, & &1.path)
       assert paths == ["Real.md"]
@@ -716,7 +716,7 @@ defmodule Engram.NotesTest do
       # Changes must still appear when queried with that truncated value.
       # This guards against > vs >= regressions in the list_changes query.
       since_truncated = DateTime.truncate(note.updated_at, :second)
-      {:ok, changes} = Notes.list_changes(user, vault, since_truncated)
+      {:ok, %{changes: changes}} = Notes.list_changes_page(user, vault, since_truncated)
 
       assert Enum.any?(changes, &(&1.path == "Test/SameSecond.md")),
              "Changes in the same second as truncated server_time must be included"
@@ -734,7 +734,7 @@ defmodule Engram.NotesTest do
         })
 
       past = DateTime.add(note.updated_at, -60, :second)
-      {:ok, changes} = Notes.list_changes(user, vault, past, fields: :meta)
+      {:ok, %{changes: changes}} = Notes.list_changes_page(user, vault, past, fields: :meta)
 
       change = Enum.find(changes, &(&1.path == "Meta/Sparse.md"))
       assert change != nil

--- a/test/engram/repo/migrations/seq_not_null_test.exs
+++ b/test/engram/repo/migrations/seq_not_null_test.exs
@@ -1,0 +1,31 @@
+defmodule Engram.Repo.Migrations.SeqNotNullTest do
+  @moduledoc """
+  The seq change feed silently EXCLUDES rows with NULL seq (`list_changes_seq`
+  filters `not is_nil(n.seq)`), so a forgotten `put_change(:seq, ...)` in a
+  future write path would mean notes that never sync, with no error anywhere.
+  The DB must enforce the invariant: validated NOT NULL constraints on
+  notes.seq and attachments.seq (PG18 named-constraint pattern, see AGENTS.md
+  "PG18-era cheap patterns").
+  """
+  use Engram.DataCase, async: true
+
+  for {table, conname} <- [
+        {"notes", "notes_seq_not_null"},
+        {"attachments", "attachments_seq_not_null"}
+      ] do
+    test "#{table}.seq carries a validated NOT NULL constraint" do
+      %{rows: rows} =
+        Repo.query!(
+          """
+          SELECT convalidated FROM pg_constraint
+          WHERE conrelid = to_regclass($1) AND conname = $2
+          """,
+          [unquote(table), unquote(conname)]
+        )
+
+      assert [[true]] = rows,
+             "#{unquote(table)}.seq must have validated NOT NULL constraint " <>
+               "#{unquote(conname)} — NULL-seq rows silently vanish from the sync feed"
+    end
+  end
+end

--- a/test/engram/rls_coverage_test.exs
+++ b/test/engram/rls_coverage_test.exs
@@ -11,9 +11,14 @@ defmodule Engram.RlsCoverageTest do
   # User-scoped tables that deliberately rely on application-layer `user_id`
   # filtering rather than a database RLS policy. Adding an entry here is a
   # conscious decision — prefer enabling RLS for anything holding tenant data.
+  # idempotency_keys: reads/writes always filter user_id app-side, the payload
+  # is DEK-encrypted + AAD-bound to (user_id, key) — cryptographic tenant
+  # isolation even on a scoping bug — and the daily prune worker needs cheap
+  # cross-tenant deletes (FORCE RLS would block the app-role sweep).
   @no_rls_allowlist ~w(
     account_exports
     client_logs
+    idempotency_keys
     client_origin_stats
     device_authorizations
     device_refresh_tokens

--- a/test/engram/vault_isolation_test.exs
+++ b/test/engram/vault_isolation_test.exs
@@ -115,7 +115,7 @@ defmodule Engram.VaultIsolationTest do
           "mtime" => 1_000.0
         })
 
-      {:ok, changes_a} = Notes.list_changes(user, vault_a, past)
+      {:ok, %{changes: changes_a}} = Notes.list_changes_page(user, vault_a, past)
       paths_a = Enum.map(changes_a, & &1.path)
 
       assert "vault-a-note.md" in paths_a
@@ -143,7 +143,7 @@ defmodule Engram.VaultIsolationTest do
           "mtime" => 1_000.0
         })
 
-      {:ok, changes_b} = Notes.list_changes(user, vault_b, past)
+      {:ok, %{changes: changes_b}} = Notes.list_changes_page(user, vault_b, past)
       paths_b = Enum.map(changes_b, & &1.path)
 
       assert "vault-b-note.md" in paths_b

--- a/test/engram/webhooks/idempotency_test.exs
+++ b/test/engram/webhooks/idempotency_test.exs
@@ -1,7 +1,7 @@
 defmodule Engram.Webhooks.IdempotencyTest do
-  # async: false — the underlying Engram.Idempotency is a process-wide ETS
-  # table, not sandboxed per test. Unique ids keep tests independent.
-  use ExUnit.Case, async: false
+  # PG-backed (#862): processed_webhook_events rows make dedup cross-node —
+  # a provider retry routed to the other node previously re-ran side effects.
+  use Engram.DataCase, async: true
 
   alias Engram.Webhooks.Idempotency
 

--- a/test/engram_web/channels/sync_channel_test.exs
+++ b/test/engram_web/channels/sync_channel_test.exs
@@ -338,48 +338,15 @@ defmodule EngramWeb.SyncChannelTest do
   # pull_changes
   # ---------------------------------------------------------------------------
 
-  describe "pull_changes" do
-    test "returns changes since timestamp", %{socket: socket, user: user, vault: vault} do
-      Notes.upsert_note(user, vault, %{
-        "path" => "Test/Recent.md",
-        "content" => "# Recent",
-        "mtime" => 1_000.0
-      })
-
+  describe "pull_changes (removed op)" do
+    # The op never shipped in any plugin release or the SPA (HTTP cursor sync
+    # at GET /api/sync/changes is the catch-up path). The handler was
+    # unbounded: it loaded + decrypted the entire vault change set into one
+    # channel frame. A stub reply keeps a stray legacy caller from crashing
+    # the channel.
+    test "replies gone with the HTTP replacement", %{socket: socket} do
       ref = push(socket, "pull_changes", %{"since" => "2020-01-01T00:00:00Z"})
-
-      assert_reply ref, :ok, %{"changes" => changes, "server_time" => _}
-      assert Enum.any?(changes, &(&1["path"] == "Test/Recent.md"))
-    end
-
-    test "returns empty changes for future timestamp", %{socket: socket} do
-      ref = push(socket, "pull_changes", %{"since" => "2099-01-01T00:00:00Z"})
-      assert_reply ref, :ok, %{"changes" => []}
-    end
-
-    test "returns error for invalid timestamp", %{socket: socket} do
-      ref = push(socket, "pull_changes", %{"since" => "not-a-date"})
-      assert_reply ref, :error, %{"reason" => _}
-    end
-
-    test "returns error when since is missing", %{socket: socket} do
-      ref = push(socket, "pull_changes", %{})
-      assert_reply ref, :error, %{"reason" => _}
-    end
-
-    test "carries note id in each change", %{socket: socket, user: user, vault: vault} do
-      {:ok, note} =
-        Notes.upsert_note(user, vault, %{
-          "path" => "Test/WithId.md",
-          "content" => "# WithId",
-          "mtime" => 1_000.0
-        })
-
-      ref = push(socket, "pull_changes", %{"since" => "2020-01-01T00:00:00Z"})
-      assert_reply ref, :ok, %{"changes" => changes}
-
-      change = Enum.find(changes, &(&1["path"] == "Test/WithId.md"))
-      assert change["id"] == note.id
+      assert_reply ref, :error, %{"reason" => "gone", "use" => "GET /api/sync/changes"}
     end
   end
 
@@ -449,11 +416,6 @@ defmodule EngramWeb.SyncChannelTest do
           "new_path" => "Lock/New.md"
         })
 
-      assert_reply ref, :error, %{reason: "rotation_in_progress", retry_after_seconds: 60}
-    end
-
-    test "pull_changes replies rotation_in_progress when user is locked", %{socket: socket} do
-      ref = push(socket, "pull_changes", %{"since" => "2020-01-01T00:00:00Z"})
       assert_reply ref, :error, %{reason: "rotation_in_progress", retry_after_seconds: 60}
     end
   end

--- a/test/engram_web/plugs/idempotency_key_test.exs
+++ b/test/engram_web/plugs/idempotency_key_test.exs
@@ -1,36 +1,38 @@
 defmodule EngramWeb.Plugs.IdempotencyKeyTest do
-  use EngramWeb.ConnCase, async: false
+  use EngramWeb.ConnCase, async: true
+
+  import Engram.Factory
+
   alias EngramWeb.Plugs.IdempotencyKey
 
   setup do
-    case Engram.Idempotency.start_link([]) do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
-
-    :ok
+    user = insert(:user)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    %{user: user}
   end
 
-  test "missing header → 400" do
-    conn = build_conn() |> IdempotencyKey.call(IdempotencyKey.init([]))
+  defp conn_for(user), do: build_conn() |> Plug.Conn.assign(:current_user, user)
+
+  test "missing header → 400", %{user: user} do
+    conn = conn_for(user) |> IdempotencyKey.call(IdempotencyKey.init([]))
     assert conn.status == 400
     assert json_body(conn)["error"] == "missing_idempotency_key"
   end
 
-  test "non-uuid header → 400" do
+  test "non-uuid header → 400", %{user: user} do
     conn =
-      build_conn()
+      conn_for(user)
       |> put_req_header("x-idempotency-key", "not-a-uuid")
       |> IdempotencyKey.call(IdempotencyKey.init([]))
 
     assert conn.status == 400
   end
 
-  test "valid uuid passes through, assigns the key" do
+  test "valid uuid passes through, assigns the key", %{user: user} do
     key = Ecto.UUID.generate()
 
     conn =
-      build_conn()
+      conn_for(user)
       |> put_req_header("x-idempotency-key", key)
       |> IdempotencyKey.call(IdempotencyKey.init([]))
 
@@ -38,17 +40,33 @@ defmodule EngramWeb.Plugs.IdempotencyKeyTest do
     assert conn.assigns.idempotency_key == key
   end
 
-  test "replay returns cached response and halts" do
+  test "replay returns cached response and halts", %{user: user} do
     key = Ecto.UUID.generate()
-    Engram.Idempotency.remember(key, %{status: 200, body: %{cached: true}})
+    Engram.Idempotency.remember(user, key, %{status: 200, body: %{cached: true}})
 
     conn =
-      build_conn()
+      conn_for(user)
       |> put_req_header("x-idempotency-key", key)
       |> IdempotencyKey.call(IdempotencyKey.init([]))
 
     assert conn.halted
     assert json_body(conn) == %{"cached" => true}
+  end
+
+  test "another user's key does not replay — batch would re-execute", %{user: user} do
+    key = Ecto.UUID.generate()
+    Engram.Idempotency.remember(user, key, %{status: 200, body: %{cached: true}})
+
+    other = insert(:user)
+    {:ok, other} = Engram.Crypto.ensure_user_dek(other)
+
+    conn =
+      conn_for(other)
+      |> put_req_header("x-idempotency-key", key)
+      |> IdempotencyKey.call(IdempotencyKey.init([]))
+
+    refute conn.halted
+    assert conn.assigns.idempotency_key == key
   end
 
   defp json_body(conn), do: conn.resp_body |> Jason.decode!()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -59,6 +59,9 @@ defmodule Engram.Factory do
     %Engram.Notes.Note{
       id: Ecto.UUID.generate(),
       version: 1,
+      # DB-enforced NOT NULL (NULL-seq rows vanish from the sync feed); a
+      # monotone placeholder is fine — seq-semantics tests use app paths.
+      seq: sequence(:note_seq, & &1),
       content_hash: :crypto.hash(:sha256, "# Test note content") |> Base.encode16(case: :lower),
       embed_hash: nil,
       user: user,
@@ -84,6 +87,7 @@ defmodule Engram.Factory do
 
     %Engram.Attachments.Attachment{
       id: Ecto.UUID.generate(),
+      seq: sequence(:attachment_seq, & &1),
       content: <<0, 1, 2, 3>>,
       content_hash: :crypto.hash(:sha256, <<0, 1, 2, 3>>) |> Base.encode16(case: :lower),
       mime_type: "image/png",

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -121,6 +121,11 @@ defmodule Engram.Fixtures do
 
     {:ok, inserted} =
       Repo.with_tenant(user.id, fn ->
+        # DB-enforced NOT NULL (NULL-seq rows vanish from the sync feed) —
+        # stamp a real per-vault seq inside the tenant txn (next_seq!'s
+        # row-lock contract) unless the caller overrode it.
+        note_attrs = Map.put_new(note_attrs, :seq, Engram.Vaults.next_seq!(vault.id))
+
         %Note{}
         |> Note.changeset(note_attrs)
         |> Repo.insert!()
@@ -253,6 +258,9 @@ defmodule Engram.Fixtures do
     att_id = Ecto.UUID.generate()
     storage_key = Engram.Storage.key(user.id, vault.id, path)
 
+    # DB-enforced NOT NULL on seq (NULL rows vanish from the sync feed).
+    {:ok, seq} = Repo.with_tenant(user.id, fn -> Engram.Vaults.next_seq!(vault.id) end)
+
     # Legacy v1 encrypt: empty AAD
     {content_ct, content_nonce} = Envelope.encrypt(content, dek, <<>>)
     {path_ct, path_nonce} = Envelope.encrypt(path, dek, <<>>)
@@ -273,6 +281,7 @@ defmodule Engram.Fixtures do
       mime_type: mime_type,
       size_bytes: byte_size(content),
       mtime: mtime,
+      seq: seq,
       encryption_version: 1,
       dek_version: 1
     }


### PR DESCRIPTION
Closes #862 — audit wave 2. Three sync-correctness fixes, TDD'd throughout.

## 1. Idempotency → Postgres (cross-node + user-scoped + encrypted)

The ETS batch-idempotency cache was node-local: under clustering, a client retry routed to the other Fargate task missed the cache and **re-executed the batch** — the key was defeated by the LB. It was also keyed globally rather than per user (a guessed UUID could theoretically replay another tenant's response). Now:

- `idempotency_keys` rows per (user, key), unique index = first-response-wins under concurrent duplicates.
- Response bodies are **DEK-encrypted, AAD-bound to (user_id, key)** — batch responses carry plaintext note paths, which never sit plaintext at rest anywhere else. Test proves ciphertext at rest.
- Decrypt failure (e.g. after per-user DEK rotation, whose sweep doesn't cover this table) degrades to `:miss` — safe, because identical-content upserts short-circuit (#860), so re-execution converges.
- Webhook replay dedup (Paddle/Clerk) gets the same treatment via a `processed_webhook_events` (provider, event_id) table — previously node-local ETS.
- Daily `IdempotencyPrune` cron sweeps both (expired keys; webhook rows past 7d).
- `rls_coverage` allowlist entry with justification (app-layer scoping + ciphertext payload + cross-tenant prune).

## 2. `seq` backfill + NOT NULL

The seq change feed filters `seq IS NOT NULL`, so a NULL-seq row **silently never syncs** — one forgotten `put_change(:seq, ...)` in a future write path would be invisible data loss. The backfill the `20260616120000` moduledoc promised (`20260616120100`) never shipped. Migration backfills stragglers per vault (NO FORCE RLS dance per the migration lint from #860, fail-loud verification) and hardens both columns with validated NOT NULL constraints (PG18 named-constraint pattern per AGENTS.md — no ACCESS EXCLUSIVE scan). The constraint immediately caught every raw-insert test fixture missing seq — exactly the class of bug it exists to catch.

## 3. WS `pull_changes` removed

The handler loaded + decrypted the **entire vault change set** (Pro = uncapped) into one channel frame. No client ever shipped calling it — the plugin's history never contained it and the SPA doesn't use it; catch-up is the keyset-paginated HTTP feed. Removed rather than paginated; a stub replies `gone`/use-HTTP so a stray caller can't crash the channel. `Notes.list_changes/4` (sole caller) removed; its tests port to `list_changes_page/4`.

## Label note

Mixed-phase PR (two `phase/expand` table creates + one `phase/migrate-data` backfill); the check takes exactly one label, so it carries the stricter `phase/migrate-data`.

## Testing

- All new/changed behavior TDD'd (idempotency PG contract 7 tests, user-scoping plug test, seq constraint test, gone-stub test — all watched red first).
- Full suite 3320 tests, 0 failures; credo --strict clean; sobelow clean. v0.5.607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)