### PR TITLE
fix(crdt): loud deliver-out degradation + projection-hash digest gate (post-merge review of #846)

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1772,9 +1772,15 @@ defmodule Engram.Notes do
     # Same hash gate as the embed jobs: entries whose update short-circuited
     # (idempotent re-push, no version/seq persisted) must not appear in the
     # digest, or every batch re-sync fans a phantom change to all devices.
+    # Compare projection-vs-projection (info.content_hash, the stored CRDT
+    # projection) — NOT the raw entry hash. For frontmatter notes the
+    # projection re-serializes YAML, so raw != projection on every push; a
+    # raw-hash gate broadcasts a phantom digest for each idempotent re-push
+    # of such notes (the exact syncedHashes re-pull loop Finding 2 fixed in
+    # the digest body below).
     changed_entries =
-      Enum.filter(ok_entries, fn %{hash: hash, result: {:ok, info}} ->
-        info.prev_hash != hash
+      Enum.filter(ok_entries, fn %{result: {:ok, info}} ->
+        info.prev_hash != info.content_hash
       end)
 
     _ =

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -70,85 +70,143 @@ defmodule Engram.Notes.CrdtDeliver do
 
   # Step 1 — converge a live room onto the just-committed state, if one exists.
   # Non-creating lookup so an external write never spins a room for a note
-  # nobody is observing. `:global.whereis_name` can hand back a room that is
-  # mid auto-exit, so guard the GenServer.call against an :exit — the announce
-  # (step 2) still lets clients re-pull when the push could not land.
+  # nobody is observing.
   #
-  # Applies the stored merged state (shared lineage — see moduledoc). Falls
-  # back to the legacy plaintext re-diff only when the state cannot be loaded
-  # (no note row / decrypt failure) so delivery still happens; that path
-  # re-encodes the change on the room's lineage and is NOT double-safe, but a
-  # rare degraded delivery beats none.
+  # Applies the stored merged state (shared lineage — see moduledoc). The
+  # plaintext re-diff runs ONLY for rows that have no CRDT state at all
+  # (legacy/lazy rows) — there is no competing lineage to double. A note whose
+  # state exists but fails to load (decrypt error, KMS outage, missing row)
+  # SKIPS the push instead: re-encoding its content on the room's lineage is
+  # the doubling corruption this module exists to prevent, and the announce
+  # (step 2) still fires so enrolled clients re-pull. Every skip is logged at
+  # :error (Sentry-visible) — a sustained fallback rate must be loud.
   defp push_to_live_room(user_id, note_id, content) do
     case CrdtRegistry.lookup(note_id) do
       nil ->
         :ok
 
       room ->
-        state = load_merged_state(user_id, note_id)
+        case load_merged_state(user_id, note_id) do
+          {:ok, state} when is_binary(state) ->
+            room_apply(room, note_id, fn doc -> apply_state(doc, state, note_id) end)
 
-        try do
-          SharedDoc.update_doc(room, fn doc ->
-            apply_or_ingest(doc, state, content, note_id)
-          end)
-        catch
-          :exit, _reason -> :ok
+          {:ok, nil} ->
+            room_apply(room, note_id, fn doc -> CrdtBridge.ingest_plaintext(doc, content) end)
+
+          {:error, _reason} ->
+            # Already logged in load_merged_state. Deliberately no ingest.
+            :ok
         end
     end
   end
 
-  defp apply_or_ingest(doc, state, content, note_id) when is_binary(state) do
+  # `:global.whereis_name` can hand back a room that is mid auto-exit, so the
+  # GenServer.call is guarded against benign exits (the announce still lets
+  # clients re-pull when the push could not land). Every OTHER exit reason —
+  # call timeout, a crash of the room while running our fun — is a real bug
+  # signal and is logged at :error rather than swallowed: with
+  # `restart: :temporary` a crashed room drops all observers, and a repeating
+  # crash loop would otherwise produce zero log lines from this module.
+  defp room_apply(room, note_id, fun) do
+    SharedDoc.update_doc(room, fun)
+  catch
+    :exit, {:noproc, _} ->
+      :ok
+
+    :exit, {:normal, _} ->
+      :ok
+
+    :exit, {:shutdown, _} ->
+      :ok
+
+    :exit, reason ->
+      Logger.error(
+        "crdt deliver room push exited",
+        Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
+      )
+
+      :ok
+  end
+
+  defp apply_state(doc, state, note_id) do
     case Yex.apply_update(doc, state) do
       :ok ->
         :ok
 
       {:error, reason} ->
-        Logger.warning(
-          "crdt deliver apply_update failed, falling back to plaintext ingest",
-          Metadata.with_category(:warning, :sync, note_id: note_id, reason: inspect(reason))
+        # The just-committed state failed to apply — the doc or the state is
+        # already suspect, so plaintext-diffing into that same doc would be
+        # the worst possible response (foreign-lineage re-encode on top of a
+        # broken doc). Skip; observers converge via the announce → step-1
+        # re-pull against a fresh room.
+        Logger.error(
+          "crdt deliver apply_update failed — skipping push",
+          Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
         )
 
-        CrdtBridge.ingest_plaintext(doc, content)
+        :ok
     end
-  end
-
-  defp apply_or_ingest(doc, nil, content, _note_id) do
-    CrdtBridge.ingest_plaintext(doc, content)
   end
 
   # Loads + decrypts the note's committed CRDT snapshot. Runs post-commit in
   # the writer process, so the row read here is the state the write just
-  # persisted. Returns nil on any failure — the caller degrades to the
-  # plaintext-ingest fallback. Never raises.
+  # persisted. Returns:
+  #   {:ok, binary} — the merged state to apply (shared lineage)
+  #   {:ok, nil}    — the row has NO CRDT state (legacy/lazy row); plaintext
+  #                   ingest is the only delivery available and is safe
+  #   {:error, r}   — the state exists but could not be read (decrypt/KMS/
+  #                   missing row/raise) — logged here at :error; the caller
+  #                   must NOT fall back to a plaintext re-encode
+  # Never raises/exits/throws (delivery must not fail the write).
   defp load_merged_state(user_id, note_id) do
     user = Accounts.get_user!(user_id)
 
     result =
       Repo.with_tenant(user_id, fn ->
-        with %Note{} = note <- Repo.get(Note, note_id),
-             {:ok, state} when is_binary(state) <- Crypto.decrypt_crdt_state(note, user) do
-          state
-        else
-          _ -> nil
+        case Repo.get(Note, note_id) do
+          nil ->
+            {:error, :missing_row}
+
+          %Note{crdt_state_ciphertext: nil} ->
+            {:ok, nil}
+
+          %Note{} = note ->
+            case Crypto.decrypt_crdt_state(note, user) do
+              {:ok, state} when is_binary(state) -> {:ok, state}
+              {:ok, nil} -> {:ok, nil}
+              {:error, reason} -> {:error, reason}
+            end
         end
       end)
 
     # with_tenant wraps the fun's return in {:ok, _} (Ecto transaction).
     case result do
-      {:ok, state} when is_binary(state) -> state
-      _ -> nil
+      {:ok, {:ok, state_or_nil}} ->
+        {:ok, state_or_nil}
+
+      {:ok, {:error, reason}} ->
+        log_state_load_failure(note_id, reason)
+        {:error, reason}
+
+      {:error, reason} ->
+        log_state_load_failure(note_id, {:tenant_txn, reason})
+        {:error, reason}
     end
   rescue
     err ->
-      Logger.warning(
-        "crdt deliver state load failed",
-        Metadata.with_category(:warning, :sync,
-          note_id: note_id,
-          reason: Exception.format(:error, err, __STACKTRACE__)
-        )
-      )
+      log_state_load_failure(note_id, Exception.format(:error, err, __STACKTRACE__))
+      {:error, :raised}
+  catch
+    kind, reason ->
+      log_state_load_failure(note_id, {kind, reason})
+      {:error, :caught}
+  end
 
-      nil
+  defp log_state_load_failure(note_id, reason) do
+    Logger.error(
+      "crdt deliver state load failed — skipping room push (announce still fires)",
+      Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
+    )
   end
 
   # Step 2 — discovery announce. Mirrors the channel's own `crdt_doc_ready`

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.609",
+      version: "0.5.610",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -6,7 +6,11 @@ defmodule Engram.Notes.CrdtDeliverTest do
   # unbind; a no-op room avoids it).
   use Engram.DataCase, async: false
 
-  alias Engram.Notes.{CrdtBridge, CrdtDeliver, CrdtRegistry}
+  import Ecto.Query
+  import ExUnit.CaptureLog
+
+  alias Engram.{Notes, Repo}
+  alias Engram.Notes.{CrdtBridge, CrdtDeliver, CrdtRegistry, Note}
   alias Yex.Sync.SharedDoc
 
   setup do
@@ -49,39 +53,48 @@ defmodule Engram.Notes.CrdtDeliverTest do
   end
 
   describe "deliver_out/5 — live-room frame push" do
+    # These are PRIMARY-path tests: a real note row exists and deliver-out
+    # applies its stored merge-lineage state. Rooms start EMPTY (production
+    # rooms bind FROM the snapshot, so a plaintext-seeded bare room would put
+    # the same text on a second lineage and double on the state apply).
     test "pushes a yjs frame to a live room's observers", %{user: user, vault: vault} do
-      note_id = Ecto.UUID.generate()
-      room = start_bare_room(note_id, "base")
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "n.md", "content" => "base"})
+      room = start_bare_room(note.id, "")
       SharedDoc.observe(room)
 
       EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
 
-      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "n.md", note_id, "base updated")
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "n.md", note.id, "base")
 
-      # The observing test process receives the diff frame produced by applying
-      # the incoming plaintext onto the room's owned doc (deliver-out, gap 3).
+      # The observing test process receives the frame produced by applying the
+      # stored merge state onto the room's owned doc (deliver-out, gap 3).
       assert_receive {:yjs, frame, ^room}, 1000
       assert is_binary(frame)
 
       # And the discovery announce still fires for vault clients lacking the room.
       assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
 
-      # The room's owned text converged to the incoming plaintext.
+      # The room's owned text converged to the stored content.
       doc = SharedDoc.get_doc(room)
-      assert Engram.Notes.CrdtBridge.text_of(doc) == "base updated"
+      assert CrdtBridge.text_of(doc) == "base"
     end
 
     test "delivering a frontmatter change updates the live room's Y.Map, not just the body",
          %{user: user, vault: vault} do
-      note_id = Ecto.UUID.generate()
-      room = start_bare_room(note_id, "old body\n")
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "n.md",
+          "content" => "---\ntitle: Hi\n---\nnew body\n"
+        })
+
+      room = start_bare_room(note.id, "")
 
       :ok =
         CrdtDeliver.deliver_out(
           user.id,
           vault.id,
           "n.md",
-          note_id,
+          note.id,
           "---\ntitle: Hi\n---\nnew body\n"
         )
 
@@ -90,18 +103,23 @@ defmodule Engram.Notes.CrdtDeliverTest do
       assert CrdtBridge.body_of(doc) == "new body\n"
     end
 
-    test "no-op when incoming equals the room's current text (still announces)",
+    test "re-delivery of already-applied state is a no-op (still announces)",
          %{user: user, vault: vault} do
-      note_id = Ecto.UUID.generate()
-      room = start_bare_room(note_id, "same")
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "n.md", "content" => "same"})
+      room = start_bare_room(note.id, "")
       SharedDoc.observe(room)
       EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
 
-      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "n.md", note_id, "same")
+      # First delivery converges the empty room onto the stored state.
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "n.md", note.id, "same")
+      assert_receive {:yjs, _frame, ^room}, 1000
 
-      # diff_into_text is a no-op on equality → no frame broadcast...
+      # Second delivery of the SAME state: apply_update is idempotent on
+      # already-present ops → no new frame broadcast...
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "n.md", note.id, "same")
       refute_receive {:yjs, _frame, ^room}, 200
-      # ...but the announce always fires.
+      # ...but the announce always fires (twice total).
+      assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
       assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
     end
   end
@@ -130,6 +148,68 @@ defmodule Engram.Notes.CrdtDeliverTest do
   # A SharedDoc with NO persistence module (no bind/unbind), registered under the
   # same :global name CrdtRegistry uses, so CrdtRegistry.lookup/1 finds it.
   # auto_exit: false keeps it alive across observer churn within the test.
+  # ---------------------------------------------------------------------------
+  # State-load failure handling (post-merge review findings)
+  #
+  # A note that HAS CRDT state which fails to load (decrypt error, KMS outage)
+  # must NOT degrade to the plaintext re-diff: re-encoding server-known content
+  # on the room's lineage is the doubling corruption this module exists to
+  # prevent. The push is skipped (loudly) and the announce still fires so
+  # enrolled clients re-pull. Only a row with NO state at all (legacy/lazy
+  # rows) may plaintext-ingest — there is no competing lineage to double.
+  # ---------------------------------------------------------------------------
+
+  describe "deliver_out/5 — state-load failure handling" do
+    test "decrypt failure skips the room push (no plaintext re-encode) but still announces",
+         %{user: user, vault: vault} do
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s.md", "content" => "orig"})
+
+      # Corrupt the stored CRDT state so decrypt fails (ciphertext mismatch).
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(from(n in Note, where: n.id == ^note.id),
+            set: [crdt_state_ciphertext: <<0, 1, 2, 3>>]
+          )
+        end)
+
+      room = start_bare_room(note.id, "orig")
+      EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
+
+      log =
+        capture_log(fn ->
+          assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "s.md", note.id, "orig updated")
+          assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
+        end)
+
+      # The room was NOT mutated — a plaintext ingest would have re-encoded
+      # "orig updated" on the room's lineage.
+      doc = SharedDoc.get_doc(room)
+      assert CrdtBridge.text_of(doc) == "orig"
+
+      # The degradation is loud (Sentry captures Logger.error).
+      assert log =~ "crdt deliver state load failed"
+    end
+
+    test "a row without CRDT state falls back to plaintext ingest (legacy row)",
+         %{user: user, vault: vault} do
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "l.md", "content" => "orig"})
+
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(from(n in Note, where: n.id == ^note.id),
+            set: [crdt_state_ciphertext: nil, crdt_state_nonce: nil]
+          )
+        end)
+
+      room = start_bare_room(note.id, "orig")
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "l.md", note.id, "orig updated")
+
+      doc = SharedDoc.get_doc(room)
+      assert CrdtBridge.text_of(doc) == "orig updated"
+    end
+  end
+
   defp start_bare_room(note_id, seed_text) do
     {:ok, room} =
       SharedDoc.start_link(

--- a/test/engram/notes_idempotent_upsert_test.exs
+++ b/test/engram/notes_idempotent_upsert_test.exs
@@ -73,6 +73,31 @@ defmodule Engram.NotesIdempotentUpsertTest do
     refute_receive %Phoenix.Socket.Broadcast{event: "notes.batch"}, 100
   end
 
+  test "batch re-push of a frontmatter note (raw != stored projection) does not broadcast a phantom digest",
+       %{user: user, vault: vault} do
+    # The CRDT projection re-serializes YAML frontmatter, so the stored content
+    # can differ from the raw push bytes. A re-push of the SAME raw bytes then
+    # misses the identical-content short-circuit (projection vs raw hash) and
+    # runs the full rewrite — but the rewrite converges to the SAME projection
+    # (prev_hash == content_hash), so no digest entry may be broadcast. Gating
+    # the digest on the raw entry hash instead fans a phantom change to every
+    # device on each idempotent re-push of such a note.
+    raw = "---\ntitle:    Spaced   Out\n---\nbody\n"
+    entries = [%{"path" => "fm.md", "content" => raw}]
+    {:ok, _} = Notes.batch_upsert_notes(user, vault, entries)
+
+    {:ok, stored} = Notes.get_note(user, vault, "fm.md")
+    # Precondition: projection and raw genuinely diverge — otherwise this test
+    # is vacuous (the identical-content test above already covers that case).
+    assert stored.content != raw
+
+    EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+    {:ok, _} = Notes.batch_upsert_notes(user, vault, entries)
+
+    refute_receive %Phoenix.Socket.Broadcast{event: "notes.batch"}, 100
+  end
+
   test "re-push after a delete resurrects instead of short-circuiting", %{
     user: user,
     vault: vault


### PR DESCRIPTION
## What

Post-merge code review of #846 (three independent review passes: correctness, silent-failure hunt, plugin gate review) surfaced one Important consistency bug and a cluster of observability hazards in the deliver-out path. This PR fixes all confirmed backend findings.

## 1. Deliver-out: silent degradation into the corruption-prone fallback (the big one)

`load_merged_state` swallowed every tuple-shaped failure — `{:error, :decrypt_failed}`, KMS `{:error, _}` from `unwrap_dek`, missing row — and returned bare `nil` with **zero logging** (the `rescue` only covered raises). `apply_or_ingest(doc, nil, ...)` then fell back to the plaintext re-diff, which re-encodes server-known content on the room's lineage — the exact doubling corruption #846 shipped to fix. A KMS outage or key-rotation half-state would have silently re-enabled fleet-wide corruption with no log, metric, or Sentry event.

Now:
- `load_merged_state` returns `{:ok, state} | {:ok, nil} | {:error, reason}` and logs every failure at `:error` (Sentry's LoggerHandler captures `:error`, not `:warning`).
- A note whose state exists but cannot be read **skips the room push** — no plaintext re-encode. The announce (step 2) still fires, so enrolled clients re-pull. Temporary staleness beats durable corruption.
- Plaintext ingest survives ONLY for rows with no CRDT state at all (legacy/lazy rows) — no competing lineage to double.
- `Yex.apply_update` `{:error, _}` no longer plaintext-diffs into the same suspect doc; logs at `:error` and skips.
- The blanket `catch :exit -> :ok` now distinguishes benign exits (`:noproc`/`:normal`/`:shutdown`) from call timeouts and room crashes, which are logged — with `restart: :temporary`, a room crash-loop was previously invisible from this module.
- The whole loader is exception-, throw-, and exit-safe (the never-fails-the-write contract previously covered raises only).

## 2. Batch digest gate: phantom broadcasts for frontmatter notes

`changed_entries` gated the digest on `info.prev_hash != entry.hash` (raw push bytes) while the embed gate three lines up correctly uses `info.content_hash` (stored CRDT projection). For frontmatter notes the projection re-serializes YAML, so raw != projection on every push: each idempotent batch re-push fanned a phantom digest to all devices — the syncedHashes re-pull loop #846's Finding 2 fixed in the digest body but not in the gate. Now projection-vs-projection, consistent with the embed gate and the single-note path.

## 3. Test coverage for the fallback seam

- Decrypt-failure: room untouched (no re-encode), `:error` logged, announce still fires.
- Legacy nil-state row: plaintext ingest still delivers.
- Phantom digest regression (verified red against the raw-hash gate).
- The three pre-existing live-room deliver tests used random UUIDs with no note row — they were unknowingly exercising the fallback. Rewritten as intentional primary-path tests (real rows, empty rooms matching production bind semantics).

## Verification

Full suite 3355/0 (a Qdrant/Voyage Req-timeout triple flaked under parallel load once, green in isolation and on full rerun). format/credo/sobelow via pre-push. Version 0.5.610.

Remaining review findings tracked separately: plugin enroll-on-gate-skip (cold-start drifted notes sit out live sync until opened) lands as a plugin PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
