### PR TITLE
fix(e2e): wall-clock budget for Clerk session-create retry

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1056,6 +1056,13 @@ jobs:
           # Add bun to PATH for E2E tests (already installed by plugin build)
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
+      # Harness unit tests (stack-free): e2e/unit has its own pytest rootdir
+      # so e2e/conftest.py (Obsidian/auth session fixtures) never loads.
+      # Guards helper logic like the Clerk session-create retry budget (#869).
+      - name: "Harness unit tests"
+        working-directory: e2e/unit
+        run: python3 -m pytest . -v --no-header -p no:cacheprovider
+
       # ------------------------------------------------------------------
       # Obsidian E2E tests
       # ------------------------------------------------------------------

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -101,6 +101,13 @@ if _WORKER > 0:
 # run instead of nuking sibling runs' users mid-flight (issue #160).
 _RUN_ID = os.environ.get("GITHUB_RUN_ID", "local")
 
+# Per-JOB namespace. GITHUB_RUN_ID alone is NOT enough: all parallel jobs of
+# one workflow run share it, and the worker-0 setup sweep scoped to run-only
+# deleted sibling jobs' live Clerk users mid-suite (issue #869 — e2e-api's
+# sweep killed e2e-clerk's users; only test_49 noticed because it is the one
+# mid-suite Clerk session minter). "localjob" outside CI.
+_JOB_ID = os.environ.get("GITHUB_JOB", "localjob")
+
 
 # ---------------------------------------------------------------------------
 # Unique timestamp for this test run
@@ -110,10 +117,12 @@ _RUN_ID = os.environ.get("GITHUB_RUN_ID", "local")
 def ts():
     """Per-worker, per-run unique suffix for e2e-* emails.
 
-    Format: ``{YYYYMMDDHHMMSSffffff}r{RUN_ID}w{WORKER}`` — the ``r{RUN_ID}``
-    segment scopes cleanup to this CI run (see issue #160).
+    Format: ``{YYYYMMDDHHMMSSffffff}r{RUN_ID}j{JOB_ID}w{WORKER}`` — the
+    ``r{RUN_ID}j{JOB_ID}`` segment scopes cleanup to this CI run AND job
+    (issues #160 + #869: parallel jobs share GITHUB_RUN_ID, so run-only
+    scoping let one job's sweep delete a sibling job's live users).
     """
-    return f"{datetime.now().strftime('%Y%m%d%H%M%S%f')}r{_RUN_ID}w{_WORKER}"
+    return f"{datetime.now().strftime('%Y%m%d%H%M%S%f')}r{_RUN_ID}j{_JOB_ID}w{_WORKER}"
 
 
 # ---------------------------------------------------------------------------
@@ -132,10 +141,10 @@ def auth_provider():
     """
     provider = get_auth_provider(API_URL)
     if _WORKER == 0:
-        # Scope sweep to THIS run's namespace — never touch sibling runs'
-        # users. Orphans from crashed runs are reaped out-of-band by
-        # .github/workflows/clerk-orphans.yml (issue #160).
-        provider.cleanup_all_e2e_users(run_id=_RUN_ID)
+        # Scope sweep to THIS run+job namespace — never touch sibling runs'
+        # OR sibling jobs' users (issues #160, #869). Orphans from crashed
+        # runs are reaped out-of-band by .github/workflows/clerk-orphans.yml.
+        provider.cleanup_all_e2e_users(run_id=_RUN_ID, job_id=_JOB_ID)
     return provider
 
 

--- a/e2e/helpers/auth_provider.py
+++ b/e2e/helpers/auth_provider.py
@@ -44,7 +44,7 @@ class AuthProvider(ABC):
         """Best-effort cleanup of a provisioned user."""
 
     @abstractmethod
-    def cleanup_all_e2e_users(self, run_id: str | None = None) -> int:
+    def cleanup_all_e2e_users(self, run_id: str | None = None, job_id: str | None = None) -> int:
         """Sweep e2e-* users for ``run_id`` (defaults to None = all runs).
 
         Callers in the pytest session pass the current run id so they only
@@ -108,9 +108,9 @@ class ClerkAuthProvider(AuthProvider):
         except Exception as e:
             logger.warning("Failed to delete Clerk user %s: %s", provider_user_id, e)
 
-    def cleanup_all_e2e_users(self, run_id: str | None = None) -> int:
+    def cleanup_all_e2e_users(self, run_id: str | None = None, job_id: str | None = None) -> int:
         from helpers.cleanup import cleanup_all_e2e_clerk_users
-        return cleanup_all_e2e_clerk_users(self.clerk_client, run_id=run_id)
+        return cleanup_all_e2e_clerk_users(self.clerk_client, run_id=run_id, job_id=job_id)
 
     def get_clerk_auth(self, clerk_user_id: str):
         """Return a ClerkAuth adapter for direct JWT auth (OAuth tests)."""
@@ -170,7 +170,7 @@ class LocalAuthProvider(AuthProvider):
         # Local users are cleaned up via DB cleanup in session teardown
         pass
 
-    def cleanup_all_e2e_users(self, run_id: str | None = None) -> int:  # noqa: ARG002
+    def cleanup_all_e2e_users(self, run_id: str | None = None, job_id: str | None = None) -> int:  # noqa: ARG002
         # No external service to clean — DB cleanup handles it
         return 0
 

--- a/e2e/helpers/cleanup.py
+++ b/e2e/helpers/cleanup.py
@@ -94,14 +94,24 @@ def cleanup_clerk_users(clerk_client, clerk_user_ids: list[str]) -> None:
             logger.warning("Failed to delete Clerk user %s: %s", user_id, e)
 
 
-def cleanup_all_e2e_clerk_users(clerk_client, run_id: str | None = None) -> int:
+def cleanup_all_e2e_clerk_users(
+    clerk_client, run_id: str | None = None, job_id: str | None = None
+) -> int:
     """Find and delete e2e-* users in the Clerk instance.
 
-    By default scopes the sweep to ``run_id`` — only emails containing
-    ``r{run_id}`` are deleted. This prevents the cross-run cascade
-    documented in issue #160: a CI run's worker-0 fixture used to nuke
-    every e2e-* user, including ones being actively used by sibling CI
-    runs, causing HTTP 401 storms in those runs.
+    By default scopes the sweep to ``run_id`` + ``job_id`` — only emails
+    containing ``r{run_id}j{job_id}w`` are deleted. Weaker scoping caused
+    two cascades:
+
+    - issue #160: no scoping — a run's worker-0 fixture nuked every e2e-*
+      user, including sibling RUNS' active users (401 storms).
+    - issue #869 (2026-07-02): run-only scoping — GITHUB_RUN_ID is shared
+      by all parallel JOBS of one workflow run, so the e2e-api job's setup
+      sweep deleted the e2e-clerk job's live users mid-suite (POST
+      /sessions 404 in test_49; every e2e-clerk teardown delete already 404).
+
+    ``job_id`` distinguishes sibling jobs; a job re-run (same run id, same
+    job id) still reaps its own previous attempt's leftovers.
 
     Passing ``run_id=None`` restores the legacy nuclear behavior — useful
     only from the standalone reaper script (``scripts/cleanup_clerk_users.py``)
@@ -113,7 +123,12 @@ def cleanup_all_e2e_clerk_users(clerk_client, run_id: str | None = None) -> int:
     offset = 0
     # Anchor on the trailing ``w`` so that run id "123" never substring-matches
     # into another run's "r12345w0" segment. Worker suffix is always present.
-    run_marker = f"r{run_id}w" if run_id else None
+    if run_id and job_id:
+        run_marker = f"r{run_id}j{job_id}w"
+    elif run_id:
+        run_marker = f"r{run_id}w"
+    else:
+        run_marker = None
     while True:
         try:
             batch = clerk_client.list_users(limit=100, offset=offset)
@@ -137,7 +152,12 @@ def cleanup_all_e2e_clerk_users(clerk_client, run_id: str | None = None) -> int:
             break
         offset += 100
     if deleted:
-        scope = f"run {run_id}" if run_id else "ALL runs"
+        if run_id and job_id:
+            scope = f"run {run_id} job {job_id}"
+        elif run_id:
+            scope = f"run {run_id}"
+        else:
+            scope = "ALL runs"
         logger.info("Cleaned up %d orphaned e2e Clerk users (%s)", deleted, scope)
     return deleted
 

--- a/e2e/helpers/clerk.py
+++ b/e2e/helpers/clerk.py
@@ -23,19 +23,22 @@ logger = logging.getLogger(__name__)
 # Observed window today (issue #193) is up to ~6s in degraded periods;
 # in normal operation it's sub-second.
 #
-# Strategy (revised after #193 reopened):
+# Strategy (revised again for #869):
 #   - create_user() blocks until POST /sessions stops 404'ing (readiness
 #     probe). Concentrates the wait at one site instead of every caller
 #     racing the propagation.
-#   - _create_session_with_retry stays as a defensive backstop for the
-#     unlikely case where someone reuses an old user_id mid-flight, but
-#     its budget is tight — readiness was already proven upstream.
+#   - _create_session_with_retry is the backstop — and it must be wall-clock
+#     budgeted, not attempt-capped: propagation is NON-monotonic. One probe
+#     success does not pin the user to every replica, so a later POST
+#     /sessions can 404 again for seconds (#869 hit this 4x in one day with
+#     the old ~3s / 5-attempt cap while the same commit passed on rerun).
 _SESSION_READY_MAX_WAIT_SECONDS = 60.0
 _SESSION_READY_INITIAL_BACKOFF = 0.5
 _SESSION_READY_MAX_BACKOFF = 8.0
 
-_SESSION_CREATE_MAX_ATTEMPTS = 5
+_SESSION_CREATE_MAX_WAIT_SECONDS = 30.0
 _SESSION_CREATE_INITIAL_BACKOFF = 0.2
+_SESSION_CREATE_MAX_BACKOFF = 4.0
 
 
 class ClerkPropagationTimeout(RuntimeError):
@@ -249,42 +252,43 @@ class ClerkClient:
         return token
 
     def _create_session_with_retry(self, user_id: str) -> str:
-        """POST /sessions with exponential-backoff retry on 404 resource_not_found.
+        """POST /sessions with capped-backoff retry on 404 resource_not_found.
 
-        Returns the session_id. Raises on non-404 errors immediately, or after
-        exhausting retries on persistent 404.
+        Wall-clock budgeted (_SESSION_CREATE_MAX_WAIT_SECONDS): Clerk's
+        propagation is non-monotonic, so the readiness probe in create_user
+        does not guarantee this call's replica has the user yet (#869).
+        Returns the session_id. Raises on non-404 errors immediately, or
+        once the budget is exhausted on persistent 404.
         """
+        deadline = time.monotonic() + _SESSION_CREATE_MAX_WAIT_SECONDS
         backoff = _SESSION_CREATE_INITIAL_BACKOFF
-        last_resp: requests.Response | None = None
-        for attempt in range(1, _SESSION_CREATE_MAX_ATTEMPTS + 1):
+        attempt = 0
+        while True:
+            attempt += 1
             resp = self.session.post(
                 f"{self.base_url}/sessions",
                 json={"user_id": user_id},
                 timeout=10,
             )
-            last_resp = resp
             if resp.ok:
                 return resp.json()["id"]
             if resp.status_code == 404 and self._is_resource_not_found(resp):
-                if attempt < _SESSION_CREATE_MAX_ATTEMPTS:
+                if time.monotonic() + backoff <= deadline:
                     logger.warning(
-                        "Clerk create_session 404 for user %s (attempt %d/%d, sleeping %.2fs)",
-                        user_id, attempt, _SESSION_CREATE_MAX_ATTEMPTS, backoff,
+                        "Clerk create_session 404 for user %s (attempt %d, sleeping %.2fs, budget %.0fs)",
+                        user_id, attempt, backoff, _SESSION_CREATE_MAX_WAIT_SECONDS,
                     )
                     time.sleep(backoff)
-                    backoff *= 2
+                    backoff = min(backoff * 2, _SESSION_CREATE_MAX_BACKOFF)
                     continue
                 logger.error(
-                    "Clerk create_session 404 for user %s exhausted %d retries: %s",
-                    user_id, _SESSION_CREATE_MAX_ATTEMPTS, resp.text,
+                    "Clerk create_session 404 for user %s exhausted %.0fs budget (%d attempts): %s",
+                    user_id, _SESSION_CREATE_MAX_WAIT_SECONDS, attempt, resp.text,
                 )
             else:
                 logger.error("Clerk create_session failed: %s %s", resp.status_code, resp.text)
             resp.raise_for_status()
-        # Defensive — raise_for_status above should always raise on the final attempt.
-        assert last_resp is not None
-        last_resp.raise_for_status()
-        raise RuntimeError("unreachable")  # pragma: no cover
+            raise RuntimeError("unreachable")  # pragma: no cover
 
     @staticmethod
     def _is_resource_not_found(resp: requests.Response) -> bool:

--- a/e2e/unit/conftest.py
+++ b/e2e/unit/conftest.py
@@ -1,0 +1,6 @@
+"""Make e2e/helpers importable when pytest runs with rootdir e2e/unit."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/e2e/unit/pytest.ini
+++ b/e2e/unit/pytest.ini
@@ -1,0 +1,5 @@
+; Standalone rootdir for stack-free helper unit tests. Running `pytest` from
+; this directory keeps confcutdir here, so e2e/conftest.py (session-scoped
+; autouse fixtures that boot Obsidian + auth against the CI stack) never loads.
+[pytest]
+addopts = -ra

--- a/e2e/unit/test_cleanup_scope.py
+++ b/e2e/unit/test_cleanup_scope.py
@@ -1,0 +1,81 @@
+"""Unit tests for the run/job-scoped Clerk sweep — no CI stack needed.
+
+Regression lock for the second (and dominant) #869 failure mode: the
+worker-0 `auth_provider` setup sweep was scoped by GITHUB_RUN_ID only, but
+all parallel jobs of one workflow run SHARE that run id — so the e2e-api
+job's setup sweep deleted the e2e-clerk job's live users mid-suite
+(observed 2026-07-02: every e2e-clerk user 404'd at teardown; only test_49
+noticed because it is the only mid-suite Clerk session minter). The sweep
+must be scoped to run AND job.
+"""
+
+from __future__ import annotations
+
+from helpers.cleanup import cleanup_all_e2e_clerk_users
+
+
+class _FakeClerkClient:
+    def __init__(self, users: list[dict]) -> None:
+        self._users = users
+        self.deleted: list[str] = []
+
+    def list_users(self, limit: int = 100, offset: int = 0) -> list[dict]:
+        return self._users[offset : offset + limit]
+
+    def delete_user(self, user_id: str) -> None:
+        self.deleted.append(user_id)
+
+
+def _user(uid: str, email: str) -> dict:
+    return {"id": uid, "email_addresses": [{"email_address": email}]}
+
+
+def test_sweep_scoped_to_run_and_job() -> None:
+    client = _FakeClerkClient(
+        [
+            # Same run, SAME job (a previous attempt's leftover) — delete.
+            _user("u_own", "e2e-sync-123r777je2e-clerkw0+clerk_test@example.com"),
+            # Same run, DIFFERENT job (live sibling job's user) — keep!
+            _user("u_sibling", "e2e-sync-124r777je2e-apiw0+clerk_test@example.com"),
+            # Different run — keep.
+            _user("u_other_run", "e2e-sync-125r888je2e-clerkw0+clerk_test@example.com"),
+            # Not an e2e user — keep.
+            _user("u_real", "todd@example.com"),
+        ]
+    )
+
+    deleted = cleanup_all_e2e_clerk_users(client, run_id="777", job_id="e2e-clerk")
+
+    assert client.deleted == ["u_own"]
+    assert deleted == 1
+
+
+def test_sweep_without_job_scope_keeps_legacy_run_marker() -> None:
+    """run_id without job_id keeps the old r{run}w anchor (legacy emails)."""
+    client = _FakeClerkClient(
+        [
+            _user("u_legacy", "e2e-sync-123r777w0+clerk_test@example.com"),
+            _user("u_other", "e2e-sync-124r888w0+clerk_test@example.com"),
+        ]
+    )
+
+    deleted = cleanup_all_e2e_clerk_users(client, run_id="777")
+
+    assert client.deleted == ["u_legacy"]
+    assert deleted == 1
+
+
+def test_nuclear_sweep_still_deletes_all_e2e_users() -> None:
+    """run_id=None (standalone reaper path) deletes every e2e user."""
+    client = _FakeClerkClient(
+        [
+            _user("u_a", "e2e-sync-123r777je2e-clerkw0+clerk_test@example.com"),
+            _user("u_b", "e2e-iso-124r888je2e-apiw1+clerk_test@example.com"),
+            _user("u_real", "todd@example.com"),
+        ]
+    )
+
+    deleted = cleanup_all_e2e_clerk_users(client, run_id=None)
+
+    assert client.deleted == ["u_a", "u_b"]
+    assert deleted == 2

--- a/e2e/unit/test_clerk_retry.py
+++ b/e2e/unit/test_clerk_retry.py
@@ -1,0 +1,111 @@
+"""Unit tests for helpers.clerk session-create retry — no CI stack needed.
+
+Regression lock for issue #869: Clerk's POST /sessions is eventually
+consistent and NON-monotonic vs POST /users — the create_user readiness
+probe can succeed and a later create_session still 404 for several seconds
+(observed ~6s in degraded periods). The backstop retry must be wall-clock
+budgeted, not a handful of tight attempts.
+
+These tests fake the HTTP layer and the clock; they run without any stack.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+
+import helpers.clerk as clerk_mod
+from helpers.clerk import ClerkClient
+
+
+def _resp(status_code: int, body: dict) -> requests.Response:
+    r = requests.Response()
+    r.status_code = status_code
+    r._content = json.dumps(body).encode()
+    return r
+
+
+def _not_found() -> requests.Response:
+    return _resp(404, {"errors": [{"code": "resource_not_found"}]})
+
+
+class _FakeClock:
+    """Deterministic time.monotonic/time.sleep pair: sleeping advances the clock."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+@pytest.fixture()
+def clock(monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
+    c = _FakeClock()
+    monkeypatch.setattr(clerk_mod.time, "monotonic", c.monotonic)
+    monkeypatch.setattr(clerk_mod.time, "sleep", c.sleep)
+    return c
+
+
+def _client_with_responses(
+    monkeypatch: pytest.MonkeyPatch, responses: list[requests.Response]
+) -> tuple[ClerkClient, list[int]]:
+    client = ClerkClient("sk_test_fake")
+    calls: list[int] = []
+
+    def fake_post(url: str, **_kwargs: object) -> requests.Response:
+        assert url.endswith("/sessions")
+        calls.append(1)
+        return responses.pop(0) if len(responses) > 1 else responses[0]
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    return client, calls
+
+
+def test_session_create_survives_slow_propagation(
+    monkeypatch: pytest.MonkeyPatch, clock: _FakeClock
+) -> None:
+    """Six consecutive 404s (beyond the old 5-attempt cap) then success."""
+    responses = [_not_found() for _ in range(6)] + [_resp(200, {"id": "sess_ok"})]
+    client, calls = _client_with_responses(monkeypatch, responses)
+
+    session_id = client._create_session_with_retry("user_fresh")
+
+    assert session_id == "sess_ok"
+    assert len(calls) == 7
+    # All waiting stayed within the wall-clock budget.
+    assert sum(clock.slept) <= clerk_mod._SESSION_CREATE_MAX_WAIT_SECONDS
+
+
+def test_session_create_gives_up_after_wall_clock_budget(
+    monkeypatch: pytest.MonkeyPatch, clock: _FakeClock
+) -> None:
+    """Persistent 404 raises HTTPError once the budget is exhausted, not before."""
+    client, calls = _client_with_responses(monkeypatch, [_not_found()])
+
+    with pytest.raises(requests.HTTPError):
+        client._create_session_with_retry("user_never")
+
+    assert sum(clock.slept) >= clerk_mod._SESSION_CREATE_MAX_WAIT_SECONDS * 0.8
+    assert len(calls) >= 6  # kept trying throughout the window
+
+
+def test_session_create_raises_immediately_on_non_404(
+    monkeypatch: pytest.MonkeyPatch, clock: _FakeClock
+) -> None:
+    client, calls = _client_with_responses(
+        monkeypatch, [_resp(500, {"errors": [{"code": "internal"}]})]
+    )
+
+    with pytest.raises(requests.HTTPError):
+        client._create_session_with_retry("user_500")
+
+    assert len(calls) == 1
+    assert clock.slept == []


### PR DESCRIPTION
Closes #869 — root-caused to TWO stacked causes; this PR fixes both.

## Root cause (the dominant one): sibling-job Clerk sweep

The worker-0 `auth_provider` fixture sweeps leftover e2e Clerk users at setup, scoped by `GITHUB_RUN_ID` only. But every parallel job of one workflow run shares that run id, so the e2e-api job's setup sweep deleted the e2e-clerk job's LIVE users mid-suite. Evidence from run 28621934881/28622800713 artifacts: all three e2e-clerk users (both xdist workers) were created and usable at 21:32:53-21:33:00, then permanently 404'd from `POST /v1/sessions` starting ~21:33 (exactly when e2e-api's fixture initialized), and every e2e-clerk teardown `DELETE /v1/users/:id` already returned 404. Only test_49 fails because it is the only test that mints fresh Clerk session tokens mid-suite (API-key auth is unaffected; backend rows are untouched). Job-level reruns always passed because the sibling job never re-runs alongside.

Fix: emails now embed `r{RUN_ID}j{GITHUB_JOB}w{WORKER}` and the sweep anchors on the full run+job marker. A job re-run (same run id + job id) still reaps its own previous attempt's leftovers; the standalone nuclear reaper path (`run_id=None` + `--older-than`) is unchanged.

## Secondary: retry budget for genuine propagation lag

Clerk's `POST /sessions` propagation is also non-monotonic (#193 class): the readiness probe can succeed and a later create still 404 briefly. The backstop retry tolerated only ~3.2s (5 attempts); it is now wall-clock budgeted at 30s with capped backoff. (This alone did NOT cure #869 — a deleted user 404s forever — which is how the sweep cascade surfaced.)

## Tests + CI

- New stack-free harness unit tests in `e2e/unit/` (own pytest rootdir, so `e2e/conftest.py`'s session fixtures never load): retry budget behavior (3 tests) + sweep scoping (3 tests: sibling-job immunity, legacy run-only marker, nuclear path). All TDD'd red-first.
- New `Harness unit tests` fail-fast step in the e2e-clerk job.

No version bump: e2e/ and workflow files are not deployable paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)