### PR TITLE
chore: remove dead /share/*path SPA route

### DIFF
--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -431,6 +431,8 @@ defmodule EngramWeb.Router do
     get "/settings/*path", SpaController, :index
     get "/note/*path", SpaController, :index
     get "/oauth/consent", SpaController, :index
-    get "/share/*path", SpaController, :index
+    # NOTE: no /share/* route: sharing doesn't exist yet (no /api/share*,
+    # no schema, no SPA page). Removed 2026-07-02 (#858) after shipping as a
+    # vestigial whitelist entry; re-add alongside the actual feature.
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.610",
+      version: "0.5.612",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -22,16 +22,14 @@ defmodule EngramWeb.SpaControllerTest do
     assert response(conn, 200) =~ "<!DOCTYPE html>"
   end
 
-  test "GET /share/abc123 returns index.html (SPA fallback)", %{conn: conn} do
-    conn = get(conn, "/share/abc123")
-    assert conn.status == 200
-    assert response(conn, 200) =~ "<!DOCTYPE html>"
-  end
-
-  test "GET /share/abc123/folder/note returns index.html (SPA fallback)", %{conn: conn} do
-    conn = get(conn, "/share/abc123/folder/note")
-    assert conn.status == 200
-    assert response(conn, 200) =~ "<!DOCTYPE html>"
+  test "GET /share/* is gone: no share feature exists behind it (#858)", %{conn: conn} do
+    # The whitelist entry was vestigial: no /api/share* endpoints, no share
+    # schema, no SPA route. Advertising the path without the feature ships
+    # ambiguous intent; re-add the route when sharing is actually designed.
+    # Nested path asserted too so a future narrower route (e.g. /share/:id)
+    # can't silently change deep-link behavior without touching this test.
+    assert conn |> get("/share/abc123") |> response(404)
+    assert conn |> get("/share/abc123/folder/note") |> response(404)
   end
 
   test "GET / injects runtime config script", %{conn: conn} do


### PR DESCRIPTION
Refs #858 (2026-07-02 audit, quick win 2 of 2 — option B: defer). The `get "/share/*path"` whitelist entry was vestigial: no `/api/share*` endpoints, no share schema, no SPA page. The router should not advertise a surface that doesn't exist — especially one that, when real, needs a deliberate crypto design (public decrypt-and-serve path). #858 stays open for option A (design + ship sharing); a router comment marks where the route returns.

Test asserts `/share/*` now 404s. Full suite green, credo clean. v0.5.611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)