### PR TITLE
fix(crdt): bootstrap keeps raced STEP1s, refuses deleted-path resurrect

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -792,8 +792,61 @@ defmodule Engram.Notes do
     sanitized = PathSanitizer.sanitize(path)
 
     case get_note(user, vault, sanitized) do
-      {:ok, note} -> {:ok, note}
-      {:error, :not_found} -> upsert_note(user, vault, %{"path" => sanitized, "content" => ""})
+      {:ok, note} ->
+        {:ok, note}
+
+      {:error, :not_found} ->
+        # A soft-deleted row at this path means the STEP1 is STALE (the note was
+        # deleted or renamed away) — refuse rather than bootstrap. The unique
+        # index is partial (deleted_at IS NULL), so the empty insert would slip
+        # through and silently resurrect the note server-side: the e2e
+        # "RenameOld.md still on server" / delete-ghost failures.
+        if deleted_note_exists?(user, vault, sanitized) do
+          {:error, :not_found}
+        else
+          case upsert_note(user, vault, %{"path" => sanitized, "content" => ""}) do
+            {:ok, note} ->
+              {:ok, note}
+
+            {:error, :version_conflict, _existing} ->
+              # Lost the insert race to a concurrent creator — usually the same
+              # device's REST push for the note this STEP1 announces. The row
+              # exists now, so resolve to it instead of dropping the frame: a
+              # dropped STEP1 is never retried (plugin enrollment is
+              # once-per-session) and pins the receiver's file empty forever.
+              # Re-fetch via get_note so a row deleted in the interim still
+              # resolves to :not_found rather than resurrecting.
+              get_note(user, vault, sanitized)
+
+            other ->
+              other
+          end
+        end
+    end
+  end
+
+  # True when a soft-deleted row exists at `path` (live rows excluded by the
+  # caller's get_note miss). Multiple deleted rows can share a path_hmac —
+  # existence is all the bootstrap guard needs.
+  defp deleted_note_exists?(user, vault, path) do
+    case Crypto.dek_filter_key(user) do
+      {:ok, filter_key} ->
+        hmac = Crypto.hmac_field(filter_key, path)
+
+        query =
+          from(n in Note,
+            where:
+              n.user_id == ^user.id and n.vault_id == ^vault.id and n.path_hmac == ^hmac and
+                not is_nil(n.deleted_at)
+          )
+
+        case Repo.with_tenant(user.id, fn -> Repo.exists?(query) end) do
+          {:ok, exists?} -> exists?
+          _ -> false
+        end
+
+      _ ->
+        false
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.612",
+      version: "0.5.613",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -505,6 +505,67 @@ defmodule Engram.NotesTest do
       assert note.id == existing.id
       assert note.content == "# hi"
     end
+
+    test "does not resurrect a soft-deleted path", %{user: user, vault: vault} do
+      # A stale CRDT STEP1 for a deleted (or renamed-away) path must be refused,
+      # not re-bootstrapped: the partial unique index (deleted_at IS NULL) lets
+      # the empty-content insert through, silently recreating the note server-side
+      # — the e2e "RenameOld.md still on server" / empty-ghost-file failures.
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "Bootstrap/Gone.md", "content" => "# bye"})
+
+      Notes.delete_note(user, vault, "Bootstrap/Gone.md")
+
+      assert {:error, :not_found} = Notes.get_or_bootstrap_note(user, vault, "Bootstrap/Gone.md")
+
+      # No live row was created at the deleted path.
+      assert {:error, :not_found} = Notes.get_note(user, vault, "Bootstrap/Gone.md")
+    end
+
+    test "recovers the concurrent creator's note instead of dropping the frame", %{
+      user: user,
+      vault: vault
+    } do
+      # Race: STEP1 bootstrap loses the insert to the same device's REST push
+      # (get_note misses, then the insert hits the winner's row). The loser must
+      # return the winner's live note — an error here drops the crdt frame and,
+      # because plugin enrollment is once-per-session, pins the receiver's file
+      # empty forever (the e2e "assert 'X' in ''" cluster).
+      for i <- 1..40 do
+        path = "Bootstrap/Race#{i}.md"
+        parent = self()
+
+        racer =
+          spawn_link(fn ->
+            receive do
+              :go ->
+                # The REST push may itself lose the insert race to the bootstrap
+                # and get the 409-conflict it reconciles from — both are fine here.
+                case Notes.upsert_note(user, vault, %{"path" => path, "content" => "# body"}) do
+                  {:ok, _} -> :ok
+                  {:error, :version_conflict, _} -> :ok
+                end
+
+                send(parent, :raced)
+            end
+          end)
+
+        Ecto.Adapters.SQL.Sandbox.allow(Engram.Repo, self(), racer)
+        send(racer, :go)
+
+        result = Notes.get_or_bootstrap_note(user, vault, path)
+        assert_receive :raced, 5_000
+
+        # Whatever the interleave, the frame must resolve to a live note —
+        # never a leaked conflict tuple, never a changeset error.
+        assert {:ok, %Notes.Note{}} = result
+
+        # And the bootstrap's empty write must never clobber the real body.
+        assert {:ok, final} = Notes.get_note(user, vault, path)
+        assert final.content in ["# body", ""]
+        refute final.deleted_at
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause of the e2e-clerk failure cluster (empty bodies + rename/delete ghosts)

Traced from run 28626826880 artifacts (vault-B had `HashOnlyLive.md`, `RenameOld.md`, `RenameNew.md`, `OAuthWSDelete.md` all present-but-EMPTY) + backend log (3× `could not resolve/bootstrap note → :version_conflict` with dropped `crdt_msg`, 97× `note_concurrent_insert_race` in the 2-min window).

Two defects in `Notes.get_or_bootstrap_note/3`:

**1. Raced STEP1 dropped → note pinned empty forever.** When a note's first STEP1 races the same device's REST push, the bootstrap's empty insert loses (`{:error, :version_conflict, existing}`) and `resolve_note_id` logged + dropped the frame. Plugin enrollment is once-per-session — the receiver never retries, so its file stays `''` (the `assert 'X' in ''` class: test_02/03/04/38/43/49/50/78). Fix: resolve to the winner's live row (re-fetch via `get_note` so a row deleted in the interim still refuses).

**2. Stale STEP1 resurrects deleted/renamed paths.** The path unique index is partial (`WHERE deleted_at IS NULL`), so a bootstrap for a soft-deleted path inserts a fresh EMPTY live row — recreating the note server-side (test_10 "RenameOld.md still on server after 10s", delete ghosts). Fix: refuse bootstrap when a soft-deleted row exists at the path.

## Notes for review

- The deleted-path guard means a **CRDT-first re-creation at a previously-deleted path** is refused until the REST push creates the live row (content then flows via `CrdtDeliver.deliver_out`). If plugin PR 155's offline-capture wave later makes CRDT the only creation path for md bodies, this guard needs a partner change (tombstone-aware bootstrap) — flagging explicitly.
- Concurrency test asserts the invariants (never a leaked conflict tuple, bootstrap never clobbers a real body) across 40 raced iterations; the deleted-path test is deterministic RED-before/GREEN-after.
- Related: plugin #163 (bisect), #870/#875 (empty-body flakes), #879 (rename cleanup timeout). Refs all; closing should wait for e2e confirmation.

Refs #870, Refs #875, Refs #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)