### PR TITLE
test(e2e): exact-content asserts, Clerk-secret guard, tighten RT budget

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -38,6 +38,23 @@ API_URL = os.environ.get("ENGRAM_API_URL") or "http://localhost:8100/api"
 PLUGIN_SRC = Path(os.environ.get("ENGRAM_PLUGIN_SRC", Path(__file__).parent.parent / "plugin"))
 OBSIDIAN_BIN = Path.home() / "Applications" / "Obsidian.AppImage"
 
+
+def pytest_configure(config):
+    """Fail fast when a Clerk-shaped run is missing its secret.
+
+    The Clerk-gated test files skip themselves when E2E_CLERK_SECRET_KEY is
+    empty, so a misconfigured secret would otherwise turn ~9 files into green
+    skips instead of a loud failure.
+    """
+    if os.environ.get("AUTH_PROVIDER") == "clerk" and not os.environ.get(
+        "E2E_CLERK_SECRET_KEY"
+    ):
+        pytest.exit(
+            "AUTH_PROVIDER=clerk but E2E_CLERK_SECRET_KEY is empty — "
+            "Clerk-gated tests would silently skip. Fix the secret wiring.",
+            returncode=1,
+        )
+
 def _worker_index() -> int:
     """xdist worker number (0 for master / serial runs)."""
     worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")

--- a/e2e/helpers/obsidian.py
+++ b/e2e/helpers/obsidian.py
@@ -132,10 +132,11 @@ class ObsidianInstance:
             "liveSyncEnabled": True,
             "maxFileSizeMB": 5,
         }
-        # Opt the plugin into the file-level CRDT sync path (spec §12a). Gated by
-        # the E2E_ENABLE_CRDT env so the legacy e2e jobs stay on the REST push/
-        # pull path while a dedicated CRDT job runs the same harness with CRDT on.
-        # Requires the backend to advertise the `crdt:` topic (CRDT_ENABLED=true).
+        # Explicitly pin the file-level CRDT sync path (spec §12a) for the
+        # dedicated CRDT job. NOTE: since plugin #148 enableCrdt DEFAULTS to
+        # true, so even without this key the general suite runs CRDT whenever
+        # the backend advertises the `crdt:` topic (CRDT_ENABLED=true) —
+        # omitting it does NOT pin the legacy REST path.
         if os.environ.get("E2E_ENABLE_CRDT") == "true":
             settings["enableCrdt"] = True
         if self.client_id:

--- a/e2e/helpers/vault.py
+++ b/e2e/helpers/vault.py
@@ -91,6 +91,34 @@ def wait_for_content(
     )
 
 
+def wait_for_exact_content(
+    vault_path: Path,
+    rel_path: str,
+    expected: str,
+    timeout: float = 15,
+    poll: float = 0.3,
+) -> str:
+    """Poll until file content equals expected exactly, return it.
+
+    Substring checks pass even when sync truncates, duplicates, or reorders
+    body lines; exact equality is the only assertion that proves the full
+    payload survived the round trip.
+    """
+    full = vault_path / rel_path
+    last: str | None = None
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if full.exists():
+            last = full.read_text(encoding="utf-8")
+            if last == expected:
+                return last
+        time.sleep(poll)
+    raise TimeoutError(
+        f"File {rel_path} never exactly matched expected content within {timeout}s\n"
+        f"--- expected ---\n{expected!r}\n--- last seen ---\n{last!r}"
+    )
+
+
 def list_notes(vault_path: Path, folder: str = "") -> list[str]:
     """List .md files in folder (relative paths)."""
     search = vault_path / folder if folder else vault_path

--- a/e2e/tests/test_02_sse_live_a_to_b.py
+++ b/e2e/tests/test_02_sse_live_a_to_b.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from helpers.vault import wait_for_file, write_note
+from helpers.vault import wait_for_exact_content, write_note
 
 
 @pytest.mark.asyncio
@@ -21,6 +21,5 @@ async def test_live_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     # Wait for A's push to land on server
     api_sync.wait_for_note(path, timeout=10)
 
-    # B should receive via channel — poll for file (no manual pull!)
-    b_content = wait_for_file(vault_b, path, timeout=15)
-    assert "Live Sync Test" in b_content, "B did not receive A's note via channel"
+    # B should receive via channel — poll until the FULL body arrives (no manual pull!)
+    wait_for_exact_content(vault_b, path, content, timeout=15)

--- a/e2e/tests/test_03_reverse_sync_b_to_a.py
+++ b/e2e/tests/test_03_reverse_sync_b_to_a.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from helpers.vault import read_note, write_note
+from helpers.vault import wait_for_exact_content, write_note
 
 
 @pytest.mark.asyncio
@@ -21,6 +21,5 @@ async def test_b_creates_a_receives(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     # A pulls
     await cdp_a.trigger_full_sync()
 
-    # Verify file in A's vault
-    a_content = read_note(vault_a, path)
-    assert "Reverse Sync" in a_content, "A did not receive B's note"
+    # Verify the FULL body landed in A's vault (poll — pull write is async)
+    wait_for_exact_content(vault_a, path, content, timeout=15)

--- a/e2e/tests/test_04_modify_propagation.py
+++ b/e2e/tests/test_04_modify_propagation.py
@@ -2,30 +2,30 @@
 
 import pytest
 
-from helpers.vault import read_note, write_note
+from helpers.vault import wait_for_exact_content, write_note
 
 
 @pytest.mark.asyncio
 async def test_modify_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     """A edits an existing synced note, B receives the update."""
     path = "E2E/ModifyTest.md"
+    v1 = "# Modify Test\nVersion 1"
+    v2 = "# Modify Test\nVersion 2 — updated by A"
 
     # A creates initial version
-    write_note(vault_a, path, "# Modify Test\nVersion 1")
+    write_note(vault_a, path, v1)
     api_sync.wait_for_note(path, timeout=10)
 
     # Sync to B
     await cdp_b.trigger_full_sync()
-    assert "Version 1" in read_note(vault_b, path)
+    wait_for_exact_content(vault_b, path, v1, timeout=15)
 
     # A modifies the note
-    write_note(vault_a, path, "# Modify Test\nVersion 2 — updated by A")
+    write_note(vault_a, path, v2)
 
     # Poll server until update lands
     api_sync.wait_for_note_content(path, "Version 2", timeout=10)
 
-    # B pulls the update
+    # B pulls the update — exact match proves v1 fully replaced, not merged/duplicated
     await cdp_b.trigger_full_sync()
-
-    b_content = read_note(vault_b, path)
-    assert "Version 2" in b_content, "B did not receive A's modification"
+    wait_for_exact_content(vault_b, path, v2, timeout=15)

--- a/e2e/tests/test_38_special_char_paths.py
+++ b/e2e/tests/test_38_special_char_paths.py
@@ -6,56 +6,56 @@ patterns in real Obsidian vaults.
 
 import pytest
 
-from helpers.vault import wait_for_file, write_note
+from helpers.vault import wait_for_exact_content, write_note
 
 
 @pytest.mark.asyncio
 async def test_spaces_in_path(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     """File with spaces in name syncs A→B."""
     path = "E2E/My Notes (2026).md"
+    content = "# Spaced Path\nContent with spaces in filename."
 
-    write_note(vault_a, path, "# Spaced Path\nContent with spaces in filename.")
+    write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
     await cdp_b.trigger_full_sync()
-    b_content = wait_for_file(vault_b, path, timeout=15)
-    assert "Spaced Path" in b_content
+    wait_for_exact_content(vault_b, path, content, timeout=15)
 
 
 @pytest.mark.asyncio
 async def test_unicode_in_path(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     """File with unicode characters syncs A→B."""
     path = "E2E/Café Résumé.md"
+    content = "# Café Notes\nAccented characters in filename."
 
-    write_note(vault_a, path, "# Café Notes\nAccented characters in filename.")
+    write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
     await cdp_b.trigger_full_sync()
-    b_content = wait_for_file(vault_b, path, timeout=15)
-    assert "Café Notes" in b_content
+    wait_for_exact_content(vault_b, path, content, timeout=15)
 
 
 @pytest.mark.asyncio
 async def test_emoji_in_path(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     """File with emoji in name syncs A→B (common Obsidian pattern)."""
     path = "E2E/📝 Daily Log.md"
+    content = "# Daily Log\nEmoji filename test."
 
-    write_note(vault_a, path, "# Daily Log\nEmoji filename test.")
+    write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
     await cdp_b.trigger_full_sync()
-    b_content = wait_for_file(vault_b, path, timeout=15)
-    assert "Daily Log" in b_content
+    wait_for_exact_content(vault_b, path, content, timeout=15)
 
 
 @pytest.mark.asyncio
 async def test_special_chars_combined(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     """File with mixed special characters syncs A→B."""
     path = "E2E/Project [v2.0] — Final (Draft).md"
+    content = "# Mixed Special Chars\nBrackets, em-dash, parens."
 
-    write_note(vault_a, path, "# Mixed Special Chars\nBrackets, em-dash, parens.")
+    write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
     await cdp_b.trigger_full_sync()
-    b_content = wait_for_file(vault_b, path, timeout=15)
-    assert "Mixed Special Chars" in b_content
+    wait_for_exact_content(vault_b, path, content, timeout=15)

--- a/e2e/tests/test_47_oauth_websocket_live_sync.py
+++ b/e2e/tests/test_47_oauth_websocket_live_sync.py
@@ -34,10 +34,10 @@ pytestmark = pytest.mark.skipif(
 )
 
 # WS round-trip budget under e2e-clerk load (2-worker xdist + Clerk-auth
-# latency). 10s flaked repeatedly (#643); matches test_78's proven 30s
-# budget (#565). These tests only run under e2e-clerk (skipif below), so a
-# single generous constant is correct — no variant branching needed.
-RT_TIMEOUT = 30
+# latency). 10s flaked repeatedly (#643). Tightened 30s → 15s: this is a
+# live-sync latency property — a 30s budget would mask a real broadcast
+# regression. If 15s flakes, profile the xdist contention; do not re-widen.
+RT_TIMEOUT = 15
 
 
 def _log_latency(label: str, t0: float) -> float:

--- a/e2e/tests/test_48_oauth_reconnect_catchup.py
+++ b/e2e/tests/test_48_oauth_reconnect_catchup.py
@@ -33,9 +33,9 @@ pytestmark = pytest.mark.skipif(
 )
 
 # Reconnect + catch-up round-trip budget under e2e-clerk load. 15s flaked
-# (#643); aligned with test_47 + test_78's 30s budget (#565). Clerk-only
-# (skipif below), so one generous constant suffices.
-RT_TIMEOUT = 30
+# once (#643) but 30s masks real catch-up latency regressions. Tightened
+# back to 15s; if it flakes, profile the xdist contention — do not re-widen.
+RT_TIMEOUT = 15
 
 
 def _log_latency(label: str, t0: float) -> float:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.613",
+      version: "0.5.614",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
From the e2e coverage audit: harden the suite so green proves more, without touching reruns (kept per Todd).

## Changes

- **`wait_for_exact_content` helper** (`helpers/vault.py`) — polls until the synced file equals the expected body **exactly**. The prevailing substring asserts pass even if sync truncates, duplicates, or reorders body lines; exact equality is the only assertion that catches silent corruption (the PR 155 append-doubling class).
- **test_02 / test_03 / test_04 / test_38** — swapped substring asserts for exact-content polls. test_04 now also proves v1 was fully replaced (not merged/duplicated). test_03 gains polling (was a point-in-time `read_note` race).
- **Clerk-secret fail-fast** (`conftest.py pytest_configure`) — `AUTH_PROVIDER=clerk` + empty `E2E_CLERK_SECRET_KEY` now aborts the run loudly. Previously ~9 Clerk-gated files would skip green on a misconfigured secret while the job could still pass.
- **RT_TIMEOUT 30s → 15s** (test_47/48) — the WS live-sync round trip is a latency property; 30s masks a real broadcast regression. Comment says: if 15s flakes, profile the xdist contention, do not re-widen.
- **Stale CRDT comment fixed** (`helpers/obsidian.py`) — it claimed omitting `E2E_ENABLE_CRDT` keeps jobs on legacy REST; false since plugin #148 made `enableCrdt` default true.

## Verification

Ran the four hardened test files locally against the CRDT stack (`engram-crdt`, v0.5.558) with `--reruns 0`: **7 passed in 33s**. Exact-content asserts hold — the pipeline preserves bodies byte-for-byte, no trailing-newline normalization.

Guard verified: `AUTH_PROVIDER=clerk E2E_CLERK_SECRET_KEY= pytest --collect-only` exits 1 with the wiring message.

## Follow-up (separate PR)

CRDT property-test expansion (offline+concurrent merge, CRDT rename, frontmatter YMap convergence) — bigger scope, needs its own plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)