### PR TITLE
fix(indexing): bound Lingua model memory via low_accuracy_mode (OOM crash-loop fix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,7 @@ every destructive change. Adding more tools is Tier 2 work; do not preempt.
 | `docs/context/channel-event-contract.md` | Phoenix Channel events, conflict flow, plugin integration |
 | `docs/context/database-schema-rls.md` | Full SQL schema, RLS policies, Ecto enforcement |
 | `docs/context/chunking-retrieval-strategy.md` | Chunking priorities, rejected strategies |
+| `docs/context/lingua-language-detection-memory.md` | **Lingua NIF memory** — the `low_accuracy_mode` dial (~945 MB full vs ~135 MB trigram-only, off-heap, one-time global load); caused the #891 OOM crash-loop |
 | `docs/context/environment-variables.md` | All env vars by category |
 | `docs/context/testing-strategy.md` | Test layers, ExUnit tooling, CI pipeline |
 | `docs/context/deploy-prod.md` | AWS ECS deploy, backups, observability, security checklist |

--- a/config/config.exs
+++ b/config/config.exs
@@ -63,14 +63,13 @@ config :engram, Oban,
   # latency cost.
   stage_interval: :timer.seconds(5),
   queues: [
-    # Bounded low on purpose. Each *concurrent* Voyage embed HTTP request
-    # (Req → Finch → TLS) holds ~100 MB of off-heap memory (invisible to
-    # `:erlang.memory`, released after the request). At `embed: 5`, five
-    # simultaneous embeds + a ReconcileEmbeddings backlog blew the 1024 MB
-    # Fargate task ceiling → OOM crash-loop (2026-07-03). Guarded by
-    # ObanQueueConfigTest; do not raise without bounding the Finch pool +
-    # raising task memory. See the incident plan doc.
-    embed: 2,
+    # The 2026-07-03 OOM crash-loop was NOT caused by embed concurrency — it was
+    # the Lingua language-detector loading ~945 MB of full-accuracy n-gram models
+    # off-heap during indexing (fixed via `low_accuracy_mode: true` → ~135 MB; see
+    # lib/engram/keyword_index/lang_detect.ex + docs/context/lingua-language-detection-memory.md).
+    # With that bounded, embed concurrency is back to 5 (peak ≈ 560 MB, safe under
+    # the 1024 MB task). ObanQueueConfigTest keeps a sane ceiling as a tripwire.
+    embed: 5,
     reindex: 1,
     maintenance: 2,
     crypto_backfill: 1,

--- a/config/config.exs
+++ b/config/config.exs
@@ -63,7 +63,14 @@ config :engram, Oban,
   # latency cost.
   stage_interval: :timer.seconds(5),
   queues: [
-    embed: 5,
+    # Bounded low on purpose. Each *concurrent* Voyage embed HTTP request
+    # (Req → Finch → TLS) holds ~100 MB of off-heap memory (invisible to
+    # `:erlang.memory`, released after the request). At `embed: 5`, five
+    # simultaneous embeds + a ReconcileEmbeddings backlog blew the 1024 MB
+    # Fargate task ceiling → OOM crash-loop (2026-07-03). Guarded by
+    # ObanQueueConfigTest; do not raise without bounding the Finch pool +
+    # raising task memory. See the incident plan doc.
+    embed: 2,
     reindex: 1,
     maintenance: 2,
     crypto_backfill: 1,

--- a/docs/context/lingua-language-detection-memory.md
+++ b/docs/context/lingua-language-detection-memory.md
@@ -1,0 +1,43 @@
+# Context Doc: Lingua language-detection memory (the `low_accuracy_mode` dial)
+
+_Last verified: 2026-07-03_
+
+## Status
+Working — `low_accuracy_mode: true` set in `lib/engram/keyword_index/lang_detect.ex` (PR fixing #891/#892).
+
+## What This Is
+`Engram.KeywordIndex.LangDetect` does per-chunk Latin-script language detection (to route the keyword-index stemmer) via the **`Lingua` NIF** (precompiled Rust wrapper around lingua-rs). Its language models are large and live off-heap in the Rust NIF — this doc records how big, how they load, and the dial that controls it.
+
+## The key facts (measured on prod, 2026-07-03)
+- lingua-rs caches n-gram models in a **process-global static** inside the NIF. Models load **lazily on first use** and stay resident for the node's lifetime.
+- It is a **single shared load per BEAM node** — NOT per detection call, per Elixir process, or per note. (Proof: under 8-concurrent load the footprint grew to a ceiling and then stayed flat across further rounds; per-instance would have multiplied it.) Each node in a cluster loads its own copy.
+- Footprint by mode, for `builder_option: :all_languages_with_latin_script`:
+  - **full accuracy (default):** uni/bi/tri/quad/five-gram models → **~945 MB** resident.
+  - **`low_accuracy_mode: true`:** **trigram-only** → **~135 MB** resident (~7× smaller). Plateaus; does not grow with more text.
+- The memory is **off-heap** — invisible to `:erlang.memory` / PromEx BEAM metrics. Only container RSS / `smaps` `Anonymous` / ECS `MemoryUtilized` see it.
+
+## Why it mattered (incident #891/#892)
+On the 1024 MB Fargate task (512 CPU / 1024 MB, 3 containers, no per-container limits), full-accuracy model loading during an indexing burst pushed the engram container to the task ceiling → `OutOfMemoryError` → OOM crash-loop, connection-independent. Because the load is one-time-global and reaches ~945 MB **regardless of embed concurrency**, lowering `embed` concurrency alone does NOT bound it — `low_accuracy_mode` is the actual fix.
+
+## The dial
+`lib/engram/keyword_index/lang_detect.ex`, in the `Lingua.detect/2` call:
+```elixir
+low_accuracy_mode: true,   # trigram-only ~135 MB; false = full ~945 MB/node
+```
+Trade memory back for accuracy by flipping to `false` — but budget ~945 MB resident NIF memory **per node** and raise the ECS task memory accordingly. For our use (coarse language ID to pick a stemmer, gated at `@floor 0.40` confidence with a raw-index fallback), low accuracy is sufficient.
+
+## How to measure it
+The FireLens `null` output blacks out app logs (see #894), so measure via a one-off ECS task that `eval`s a script writing to S3:
+- Start the app (Oban neutralized), warm `Lingua.detect(..., low_accuracy_mode: <mode>)` over real note chunks, 8-concurrent, 2+ rounds.
+- Sample `/proc/self/smaps_rollup` `Anonymous:` (the off-heap number) — `:erlang.memory` will NOT show it.
+- Run each mode in a **separate task** — the global model cache persists for the process life, so you can't compare modes in one process.
+
+## Gotchas
+- `:erlang.memory` and PromEx BEAM memory panels will look fine (~150 MB) while RSS is ~1 GB — always cross-check container `MemoryUtilized` / `smaps` for NIF-heavy paths.
+- `Lingua.detect/2` rebuilds a `LanguageDetector` object per call (`native/.../lib.rs:83 builder.build()`), but that's cheap — the models are the global cache, not the detector object. Caching the detector object would NOT save memory; changing which models load (this dial / language restriction) is what matters.
+- `compute_language_confidence_values: true` scores against all candidate languages.
+
+## References
+- `lib/engram/keyword_index/lang_detect.ex` (the dial + moduledoc table)
+- Incident + fix plan: `docs/superpowers/plans/2026-07-02-crdt-oom-compaction-fixes.md`
+- Issues: #891 (p0 incident), #892 (this root cause)

--- a/docs/superpowers/plans/2026-07-02-crdt-oom-compaction-fixes.md
+++ b/docs/superpowers/plans/2026-07-02-crdt-oom-compaction-fixes.md
@@ -2,13 +2,17 @@
 
 _Created 2026-07-02. Branch: `fix/crdt-oom-compaction`. Root cause PROVEN by live measurement 2026-07-03._
 
-> **NOTE:** An earlier version of this doc blamed unbounded CRDT/Yjs history. **That was wrong** — disproven by measurement (max `crdt_state` is 18 KB, max tail-log is 2 rows). The real cause is below. History kept for the lesson: measure before theorizing.
+> **NOTE — two wrong theories, corrected by measurement (the lesson: measure before theorizing):**
+> 1. First blamed unbounded CRDT/Yjs history → disproven (max `crdt_state` 18 KB).
+> 2. Then blamed "~100 MB off-heap per concurrent Voyage HTTP request" → **also disproven**: 8 concurrent `Voyage.embed_texts` = flat 154 MB. The balloon was `prepare_index`'s *language-detection* step, not the HTTP call.
 
 ## TL;DR (proven)
 
 `release-v0.5.613` (CRDT-default) put prod into an **OOM crash-loop** (ECS: `"OutOfMemoryError: container killed due to memory usage"`, exit 137, every ~2-3 min), **connection-independent** (zero clients — socket/channel joins flat at 0).
 
-Root cause: **concurrent Voyage embedding HTTP requests balloon off-heap memory ~100 MB per *simultaneous* request**, and the `embed` Oban queue runs at **concurrency 5** with `ReconcileEmbeddings` re-enqueuing the whole backlog every 15 min. 5 concurrent embeds × ~100 MB off-heap blows the **1024 MB task ceiling** → OOM-kills the engram container → embed jobs orphan as `executing` → next boot repeats. Self-sustaining.
+Root cause: the **Lingua language-detector NIF** (`LangDetect`, called per chunk during indexing) loads **~945 MB of full-accuracy Latin-script n-gram models off-heap** (a one-time, process-global load — invisible to `:erlang.memory`). On the **1024 MB** Fargate task that OOM-kills the engram container whenever indexing runs. A **~341-note vault sync** created an `EmbedNote` backlog; `ReconcileEmbeddings` re-enqueues it every 15 min → each boot re-triggers model loading → OOM → jobs orphan as `executing` → self-sustaining. (Embed concurrency only sets *how fast* the models load; it does not bound the ~945 MB, so an embed-concurrency cap alone does NOT fix it.)
+
+Fix: `low_accuracy_mode: true` in `LangDetect` → trigram-only models → **~135 MB** (measured, ~7×). With that, embed concurrency stays at 5 (full throughput; peak ≈ 560 MB). See `docs/context/lingua-language-detection-memory.md`.
 
 Trigger: a **~341-note vault sync** (`019ef66f-*` UUIDv7 batch) created a large `EmbedNote` backlog.
 

--- a/docs/superpowers/plans/2026-07-02-crdt-oom-compaction-fixes.md
+++ b/docs/superpowers/plans/2026-07-02-crdt-oom-compaction-fixes.md
@@ -1,0 +1,65 @@
+# Prod OOM crash-loop (release-v0.5.613) — incident handoff + fix plan
+
+_Created 2026-07-02. Branch: `fix/crdt-oom-compaction`. Root cause PROVEN by live measurement 2026-07-03._
+
+> **NOTE:** An earlier version of this doc blamed unbounded CRDT/Yjs history. **That was wrong** — disproven by measurement (max `crdt_state` is 18 KB, max tail-log is 2 rows). The real cause is below. History kept for the lesson: measure before theorizing.
+
+## TL;DR (proven)
+
+`release-v0.5.613` (CRDT-default) put prod into an **OOM crash-loop** (ECS: `"OutOfMemoryError: container killed due to memory usage"`, exit 137, every ~2-3 min), **connection-independent** (zero clients — socket/channel joins flat at 0).
+
+Root cause: **concurrent Voyage embedding HTTP requests balloon off-heap memory ~100 MB per *simultaneous* request**, and the `embed` Oban queue runs at **concurrency 5** with `ReconcileEmbeddings` re-enqueuing the whole backlog every 15 min. 5 concurrent embeds × ~100 MB off-heap blows the **1024 MB task ceiling** → OOM-kills the engram container → embed jobs orphan as `executing` → next boot repeats. Self-sustaining.
+
+Trigger: a **~341-note vault sync** (`019ef66f-*` UUIDv7 batch) created a large `EmbedNote` backlog.
+
+## Measured evidence (one-off eval tasks → S3, bypassing the broken log pipeline)
+
+| Test | Setup | Peak RSS |
+|---|---|---|
+| parse + tokenize + sparse-encode, all 341 notes, sequential | pure Elixir | 130 MB |
+| same, 3× concurrent | pure Elixir | 151 MB |
+| Voyage embed, 15 requests **sequential** | real HTTPS | **flat 136 MB** (no growth → not a leak) |
+| `Indexing.prepare_index` incl. Voyage embed, **8 notes concurrent** | concurrent HTTPS | **1045 MB** |
+
+- At the 1045 MB peak, `erlang:memory total = 91 MB` — so **~950 MB is off-heap**, invisible to Erlang's accounting = the TLS/OpenSSL layer under `Req`→`Finch`.
+- Memory scales with **HTTP concurrency**, not data volume or request count. ~100 MB per simultaneous connection (abnormally high — see fix #3).
+- Data is tiny: 341 notes, biggest content 38 KB, all content 2.4 MB. `crdt_state` max 18 KB.
+- ECS confirms container-level OOM (task = 512 CPU / **1024 MB**, 3 containers, no per-container limits; sidecars ~110 MB combined).
+
+## What it is NOT (ruled out by measurement)
+- ❌ CRDT/Yjs history bloat — 18 KB max.
+- ❌ Parser / tokenizer / sparse encoder — flat 130-151 MB even concurrent.
+- ❌ A giant note — biggest 38 KB.
+- ❌ A leak — sequential embeds flat, GC releases.
+- ❌ Sidecars / cluster / `:global` — happens single-node, zero clients.
+
+## Root cause anchors (`backend/`)
+- `lib/engram/embedders/voyage.ex:109` — `Req.post` per embed request.
+- `mix.exs:102` — `{:req, "~> 0.5"}` with **no named Finch pool anywhere** (grep: no `Finch.start_link`, no `finch:` config) → Req uses its default Finch (up to 50 conns/host).
+- `config/config.exs:65` — `queues: [embed: 5, ...]` — embed concurrency 5.
+- `lib/engram/workers/reconcile_embeddings.ex` — cron every 15 min, re-enqueues up to 500 stale notes (`@batch_size 500`).
+- `lib/engram/indexing.ex:36/56/68` — `index_note → prepare_index → embed_for_indexing`.
+
+## Fix (proven-directed, TDD)
+1. **Cap embed queue concurrency** `config/config.exs` embed `5 → 1` (or 2). Directly kills the mechanism: at 1-2 concurrent, RSS stays ~140-280 MB, far under 1024. **Highest-confidence, cheapest fix.**
+2. **Bounded shared Finch pool for Req.** Start a named `Finch` (small `size`, e.g. 5-10) in the supervision tree; pass `finch: Engram.Finch` to `Req.post` in the Voyage (and Qdrant/Ollama) adapters. Caps concurrent connections regardless of caller fan-out.
+3. **Investigate the ~100 MB/connection** — abnormal for TLS. Candidates: `Req`/`Finch`/`Mint` TLS buffer sizes, `:ssl` socket `recbuf`, cert-chain decode per handshake, response decompression. Own follow-up; #1 makes it non-urgent.
+4. **Observability:** engram FireLens output is the `null` plugin → app logs barely reach Loki and the crash-moment scrape is always missed. Fix so a fatal event ships at least one line (before-OOM memory high-watermark telemetry, shorter flush interval).
+5. **(Infra, separate)** give the task headroom (memory ↑ and/or per-container limits); make `desired_count` and any interim memory bump permanent in TF or they revert on next apply.
+
+## Prod state during incident (for the record)
+- Version 0.5.613, task-def rev :93 (sha-2d923ab). **NOT rolled back** — fix forward.
+- `desired_count` set to 1 via break-glass (TF still says 2 — reverts on next apply; the cluster `:global` cascade only mattered at 2 nodes and is a separate concern, not the OOM cause).
+- **Stabilized 2026-07-03** by parking the embed backlog: `notes.embed_retry_after = now()+30d` for all pending-embed notes (the app's own poison-cooldown → `ReconcileEmbeddings` skips them) + cancelling queued `embed` jobs. No embeds run → no OOM → prod boots clean. **Search on the synced notes is stale until un-parked** (step below).
+
+## Rollout sequence
+1. ✅ Park embeds (done — stabilizes prod, no release).
+2. Ship fix #1 + #2 (TDD) → `release-v*` tag on the version-bump commit (image build is skipped if `mix.exs` version unchanged — tag the bump commit, not a trailing test-only commit).
+3. **Un-park:** clear `embed_retry_after` (`SET embed_retry_after = NULL WHERE embed_retry_after > now()+29d`) → backlog drains under the capped concurrency → search current.
+4. Fix #4 (observability) and #5 (infra headroom / TF) independently.
+
+## Guardrails carried in
+- Backend pre-push gates on format + credo + sobelow (not just compile).
+- Migration linters run in CI, not pre-push. `fix/` branch prefix is CI-eligible.
+- Bump `mix.exs` version ONCE when opening the PR, never on follow-ups.
+- Worktree deps auto-hardlinked by post-checkout hook — don't re-run `deps.get`.

--- a/lib/engram/keyword_index/lang_detect.ex
+++ b/lib/engram/keyword_index/lang_detect.ex
@@ -10,6 +10,27 @@ defmodule Engram.KeywordIndex.LangDetect do
   Uses the `Lingua` NIF (precompiled Rust, no build-time Rust required).
   The rustler_precompiled version is overridden to 0.9.x in mix.exs so it
   coexists with the mjml NIF under the same resolved version.
+
+  ## Memory dial: `low_accuracy_mode`
+
+  lingua-rs loads its n-gram language models into a **process-global** cache
+  inside the Rust NIF (loaded lazily on first use, then resident for the node's
+  lifetime — a single shared load, NOT per call / per process / per note).
+
+  The footprint depends on which models load:
+
+  | mode | models loaded | resident (all Latin-script langs) |
+  |------|---------------|-----------------------------------|
+  | full accuracy (default) | uni/bi/tri/quad/five-gram | **~945 MB** |
+  | `low_accuracy_mode: true` | **trigram only** | **~135 MB** |
+
+  Measured on prod (2026-07-03): full accuracy loaded ~945 MB off-heap (invisible
+  to `:erlang.memory`), which — on the 1024 MB Fargate task — OOM-crash-looped the
+  node whenever indexing ran (see #891/#892). We run **`low_accuracy_mode: true`**:
+  ~7x smaller, and coarse language ID is all we need here (we only route to a
+  *stemmer*, gated at `@floor` confidence with a raw-index fallback). To trade
+  memory back for accuracy, flip the dial below to `false` — but budget ~945 MB
+  of resident NIF memory per node and size the task accordingly.
   """
 
   # Confidence floor — below this we trust raw-only indexing more.
@@ -55,6 +76,11 @@ defmodule Engram.KeywordIndex.LangDetect do
     result =
       Lingua.detect(text,
         builder_option: :all_languages_with_latin_script,
+        # THE memory dial. true => trigram-only models (~135 MB resident) instead
+        # of the full uni..five-gram set (~945 MB). See the moduledoc table — this
+        # is what keeps the node under its memory limit while indexing. Flip to
+        # false only if you also raise the task memory by ~945 MB/node.
+        low_accuracy_mode: true,
         compute_language_confidence_values: true,
         preload_language_models: false
       )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.614",
+      version: "0.5.615",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/oban_queue_config_test.exs
+++ b/test/engram/oban_queue_config_test.exs
@@ -29,21 +29,21 @@ defmodule Engram.ObanQueueConfigTest do
              end)
   end
 
-  # Regression guard for the 2026-07-03 prod OOM crash-loop. Each *concurrent*
-  # Voyage embedding HTTP request (Req → Finch → TLS) holds ~100 MB of off-heap
-  # memory (invisible to `:erlang.memory`, released after the request). At
-  # `embed: 5`, five simultaneous embeds + a ReconcileEmbeddings backlog blew
-  # the 1024 MB Fargate task ceiling → OOM-killed the node every ~2 min. Keeping
-  # the embed producer small bounds peak concurrent HTTP fan-out to the embedder.
-  # See docs/superpowers/plans/2026-07-02-crdt-oom-compaction-fixes.md.
-  test "embed queue concurrency is capped low to bound embedder HTTP off-heap memory" do
+  # Tripwire against unbounded embed concurrency. The 2026-07-03 OOM crash-loop
+  # was NOT caused by embed concurrency itself — it was the Lingua language
+  # detector loading ~945 MB of full-accuracy models off-heap during indexing
+  # (fixed via `low_accuracy_mode: true`; see LangDetect +
+  # docs/context/lingua-language-detection-memory.md). With that bounded, embed: 5
+  # is safe (peak ≈ 560 MB under the 1024 MB task). This ceiling just stops the
+  # value being cranked into a new memory problem without a fresh measurement.
+  test "embed queue concurrency stays within a memory-safe ceiling" do
     embed_limit = configured_queue_limit(:embed)
 
-    assert is_integer(embed_limit) and embed_limit <= 2,
-           "embed queue concurrency must stay <= 2 (got #{inspect(embed_limit)}).\n" <>
-             "Each concurrent Voyage embed HTTP request holds ~100 MB off-heap (TLS);\n" <>
-             "embed: 5 OOM-killed the 1024 MB prod task on 2026-07-03. Do not raise this\n" <>
-             "without also bounding the shared Finch pool + raising the task memory."
+    assert is_integer(embed_limit) and embed_limit >= 1 and embed_limit <= 8,
+           "embed queue concurrency should be 1..8 (got #{inspect(embed_limit)}).\n" <>
+             "Above ~8, re-measure the per-node indexing footprint (Lingua models +\n" <>
+             "embed working set) against the ECS task memory before raising further —\n" <>
+             "see docs/context/lingua-language-detection-memory.md."
   end
 
   defp configured_queue_limit(queue) do

--- a/test/engram/oban_queue_config_test.exs
+++ b/test/engram/oban_queue_config_test.exs
@@ -29,6 +29,27 @@ defmodule Engram.ObanQueueConfigTest do
              end)
   end
 
+  # Regression guard for the 2026-07-03 prod OOM crash-loop. Each *concurrent*
+  # Voyage embedding HTTP request (Req → Finch → TLS) holds ~100 MB of off-heap
+  # memory (invisible to `:erlang.memory`, released after the request). At
+  # `embed: 5`, five simultaneous embeds + a ReconcileEmbeddings backlog blew
+  # the 1024 MB Fargate task ceiling → OOM-killed the node every ~2 min. Keeping
+  # the embed producer small bounds peak concurrent HTTP fan-out to the embedder.
+  # See docs/superpowers/plans/2026-07-02-crdt-oom-compaction-fixes.md.
+  test "embed queue concurrency is capped low to bound embedder HTTP off-heap memory" do
+    embed_limit = configured_queue_limit(:embed)
+
+    assert is_integer(embed_limit) and embed_limit <= 2,
+           "embed queue concurrency must stay <= 2 (got #{inspect(embed_limit)}).\n" <>
+             "Each concurrent Voyage embed HTTP request holds ~100 MB off-heap (TLS);\n" <>
+             "embed: 5 OOM-killed the 1024 MB prod task on 2026-07-03. Do not raise this\n" <>
+             "without also bounding the shared Finch pool + raising the task memory."
+  end
+
+  defp configured_queue_limit(queue) do
+    Application.fetch_env!(:engram, Oban)[:queues] |> Keyword.get(queue)
+  end
+
   # The configured queue list. `testing: :manual` (config/test.exs) deep-merges
   # into the base `config/config.exs` Oban config, so `:queues` is the real
   # base list here. Guard against an env that stubs it to `false`/`nil` — that


### PR DESCRIPTION
## Prod OOM crash-loop fix (release-v0.5.613, CRDT-default)

**Root cause (PROVEN by live measurement 2026-07-03):** the `Lingua` language-detector NIF (`Engram.KeywordIndex.LangDetect`, called per chunk during indexing) loads **~945 MB of full-accuracy Latin-script n-gram models off-heap** — a one-time, process-global load invisible to `:erlang.memory`. On the 1024 MB Fargate task that OOM-kills the engram container whenever indexing runs (`OutOfMemoryError`, exit 137, connection-independent). A ~341-note vault sync created an `EmbedNote` backlog; `ReconcileEmbeddings` re-enqueues every 15 min → each boot re-triggers model loading → OOM → self-sustaining.

**Fix:** `low_accuracy_mode: true` in `LangDetect` → trigram-only models → **~135 MB** (measured, ~7×). Coarse language ID is all we need (routes a stemmer, gated at `@floor 0.40` with a raw-index fallback).

Because the load is one-time-global and reaches ~945 MB **regardless of embed concurrency**, an embed-concurrency cap alone does NOT fix it. So embed concurrency is **restored to 5** (full indexing throughput; peak ≈ 560 MB, safe under 1024 MB). `ObanQueueConfigTest` keeps a 1..8 tripwire so the value can't be cranked into a new memory problem without a fresh measurement.

### Changes
- `lib/engram/keyword_index/lang_detect.ex` — `low_accuracy_mode: true` + moduledoc memory-dial table.
- `config/config.exs` — `embed: 5` restored, comment corrected to the Lingua root cause.
- `test/engram/oban_queue_config_test.exs` — reframed guard to a 1..8 memory-safe ceiling.
- `docs/context/lingua-language-detection-memory.md` — new context doc (the dial, measured numbers, how to measure).
- `docs/superpowers/plans/2026-07-02-crdt-oom-compaction-fixes.md` — incident handoff + fix plan (documents both disproven theories: CRDT bloat, then Voyage HTTP).

### Two wrong theories, corrected by measurement
1. Blamed unbounded CRDT/Yjs history → disproven (max `crdt_state` 18 KB).
2. Blamed ~100 MB/conn Voyage HTTP → disproven (8 concurrent embeds flat at 154 MB). The balloon was language detection, not the HTTP call.

### Rollout
Park (done, no release) → merge → tag `release-v0.5.615` on the version-bump commit → deploy → un-park (`UPDATE notes SET embed_retry_after = NULL WHERE embed_retry_after > now()+interval '29 days'`).

Refs #891 #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)
