### PR TITLE
fix(embed): crash-independent ReconcileEmbeddings backoff (#897)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -140,6 +140,14 @@ if config_env() != :test do
     config :engram, :embed_poison_cooldown_seconds, String.to_integer(secs)
   end
 
+  # Preemptive cooldown (seconds) ReconcileEmbeddings stamps on every note it
+  # enqueues (#897). Makes the backoff crash-independent: an OOM/node kill that
+  # bypasses the graceful poison stamp still can't cause immediate re-enqueue.
+  # MUST exceed the 15-min reconcile cron interval. Default 30m (1_800).
+  if secs = System.get_env("EMBED_RECONCILE_BACKOFF_SECONDS") do
+    config :engram, :embed_reconcile_backoff_seconds, String.to_integer(secs)
+  end
+
   # Client-side Voyage rate limit. Unset = no throttle (self-host default).
   # Set to your Voyage paid-tier RPM (e.g. 2000) to fail fast with a synthetic
   # 429 before burning real API calls. EmbedNote snoozes on the synthetic 429

--- a/lib/engram/workers/reconcile_embeddings.ex
+++ b/lib/engram/workers/reconcile_embeddings.ex
@@ -44,8 +44,11 @@ defmodule Engram.Workers.ReconcileEmbeddings do
     # Per-vault fairness isn't needed: EmbedNote is uniq-deduped, and the
     # oldest-first order drains any backlog across ticks.
     now = DateTime.utc_now()
+    backoff_until = DateTime.add(now, reconcile_backoff_seconds(), :second)
 
-    note_ids =
+    # Eligible stale notes, oldest-first, capped — kept as a subquery so the
+    # whole select-and-stamp is ONE statement (see the UPDATE below).
+    eligible =
       Note
       |> join(:inner, [n], v in Vault, on: v.id == n.vault_id and is_nil(v.deleted_at))
       |> where([n], n.kind == "note")
@@ -54,12 +57,33 @@ defmodule Engram.Workers.ReconcileEmbeddings do
       # Poison-loop guard: a note that exhausts its EmbedNote attempts gets an
       # embed_retry_after cooldown stamp. Skip it until the cooldown elapses so a
       # permanently-failing note re-bills Voyage at most once per window, not
-      # every tick. NULL = no cooldown = eligible now.
+      # every tick. NULL = no cooldown = eligible now. This same filter is what
+      # preserves a longer (poison) cooldown from the UPDATE below — a note
+      # inside any cooldown isn't selected, so it isn't re-stamped.
       |> where([n], is_nil(n.embed_retry_after) or n.embed_retry_after <= ^now)
       |> order_by([n], asc: n.updated_at)
       |> limit(@batch_size)
       |> select([n], n.id)
-      |> Repo.all(skip_tenant_check: true)
+
+    # #897 — crash-independent backoff, done ATOMICALLY. EmbedNote's poison
+    # cooldown only fires on a GRACEFUL terminal `{:error, _}` (maybe_mark_poison);
+    # an OOM/node kill kills the BEAM mid-embed, so the cooldown is never stamped
+    # and this worker would re-enqueue the same poison note every 15 min →
+    # self-sustaining crash loop (the 2026-07-03 incident). So instead of a
+    # read-only SELECT we UPDATE the eligible notes' embed_retry_after to a short
+    # future cooldown and RETURN their ids in one statement — no select→stamp
+    # race, and still a single `notes` query regardless of vault count. A
+    # successful EmbedNote clears the stamp back to NULL; a graceful terminal
+    # failure extends it to the full poison cooldown. The window MUST outlast the
+    # 15-min cron interval so a crash-poison note skips at least one tick.
+    # `kind == "note"` is redundant with the subquery (which already filters it)
+    # but kept explicit so this bulk UPDATE is self-evidently note-scoped — a
+    # folder marker can never get an embed cooldown stamped even if the subquery
+    # changed. Also satisfies NotesScopeLintTest (kind filter on the from/Note).
+    {_count, note_ids} =
+      from(n in Note, where: n.kind == "note" and n.id in subquery(eligible))
+      |> select([n], n.id)
+      |> Repo.update_all([set: [embed_retry_after: backoff_until]], skip_tenant_check: true)
 
     _ =
       if note_ids != [] do
@@ -75,5 +99,15 @@ defmodule Engram.Workers.ReconcileEmbeddings do
       end
 
     :ok
+  end
+
+  # #897 — preemptive cooldown window stamped on every enqueued note (see
+  # perform/1). MUST exceed the 15-minute cron interval so a crash-poison note
+  # skips at least one tick rather than re-enqueuing immediately. A healthy note
+  # is unaffected: its EmbedNote clears the stamp on success, typically within
+  # seconds. Env-driven via `EMBED_RECONCILE_BACKOFF_SECONDS` (runtime.exs);
+  # default 30 min.
+  defp reconcile_backoff_seconds do
+    Application.get_env(:engram, :embed_reconcile_backoff_seconds, 1_800)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.615",
+      version: "0.5.616",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/workers/reconcile_embeddings_test.exs
+++ b/test/engram/workers/reconcile_embeddings_test.exs
@@ -2,6 +2,7 @@ defmodule Engram.Workers.ReconcileEmbeddingsTest do
   use Engram.DataCase, async: false
   use Oban.Testing, repo: Engram.Repo
 
+  alias Engram.Notes.Note
   alias Engram.Workers.{EmbedNote, ReconcileEmbeddings}
 
   describe "perform/1" do
@@ -158,6 +159,57 @@ defmodule Engram.Workers.ReconcileEmbeddingsTest do
 
       assert :ok = perform_job(ReconcileEmbeddings, %{})
       assert_enqueued(worker: EmbedNote, args: %{"note_id" => note.id})
+    end
+
+    # #897 — crash-independent backoff. EmbedNote's poison cooldown only fires
+    # on a GRACEFUL terminal {:error, _}; an OOM/node kill bypasses it entirely,
+    # leaving embed_retry_after NULL, so reconcile re-enqueues the same poison
+    # note every 15 min → self-sustaining crash loop (the 2026-07-03 incident).
+    # Reconcile therefore preemptively stamps a short future cooldown on every
+    # note it enqueues; a crash can no longer cause immediate re-enqueue, and a
+    # successful EmbedNote clears the stamp back to NULL.
+    test "stamps a future embed_retry_after on every note it enqueues" do
+      user = insert(:user)
+      note = insert(:note, user: user, embed_hash: nil, embed_retry_after: nil)
+
+      assert :ok = perform_job(ReconcileEmbeddings, %{})
+      assert_enqueued(worker: EmbedNote, args: %{"note_id" => note.id})
+
+      reloaded = Repo.get!(Note, note.id, skip_tenant_check: true)
+
+      refute is_nil(reloaded.embed_retry_after),
+             "reconcile must stamp embed_retry_after so an OOM'd embed can't re-enqueue next tick"
+
+      assert DateTime.compare(reloaded.embed_retry_after, DateTime.utc_now()) == :gt,
+             "the preemptive cooldown must be in the future"
+    end
+
+    test "does not stamp notes it did not enqueue" do
+      user = insert(:user)
+      # up-to-date note — not enqueued, so it must not be collaterally cooled.
+      fresh = insert(:note, user: user, content_hash: "abc123", embed_hash: "abc123")
+
+      assert :ok = perform_job(ReconcileEmbeddings, %{})
+      refute_enqueued(worker: EmbedNote, args: %{"note_id" => fresh.id})
+
+      assert is_nil(Repo.get!(Note, fresh.id, skip_tenant_check: true).embed_retry_after)
+    end
+
+    test "the stamped cooldown makes a poison note skip the next reconcile tick" do
+      # End-to-end crash simulation: enqueue, DON'T run the embed job (mimics an
+      # OOM kill — no success clear, no graceful poison stamp), then tick again.
+      # The preemptive stamp alone must keep it out of the second batch.
+      user = insert(:user)
+      note = insert(:note, user: user, embed_hash: nil, embed_retry_after: nil)
+
+      assert :ok = perform_job(ReconcileEmbeddings, %{})
+      stamped = Repo.get!(Note, note.id, skip_tenant_check: true).embed_retry_after
+      refute is_nil(stamped)
+
+      # Second tick, no embed ran. Note is inside its fresh cooldown → not
+      # selected. (Its stamp is unchanged — we didn't re-stamp a skipped note.)
+      assert :ok = perform_job(ReconcileEmbeddings, %{})
+      assert Repo.get!(Note, note.id, skip_tenant_check: true).embed_retry_after == stamped
     end
   end
 


### PR DESCRIPTION
## Crash-independent ReconcileEmbeddings backoff (#897)

**The gap:** the embed poison-cooldown (`EmbedNote.maybe_mark_poison`) only fires on a **graceful terminal `{:error, _}`**. An OOM / node kill kills the BEAM mid-embed — the job never returns an error, so `embed_retry_after` is never stamped. On restart the note still "needs embed" with no cooldown, so `ReconcileEmbeddings` re-enqueues it every 15 min → re-crash. This is the self-sustaining loop behind the 2026-07-03 crash-loop (Engram #891): each boot re-triggered the Lingua OOM via reconcile.

**The fix:** reconcile now **preemptively stamps** a short future `embed_retry_after` on every note it enqueues, so the backoff no longer depends on the worker gracefully stamping it. Done **atomically** — a single `UPDATE notes SET embed_retry_after = now()+backoff WHERE id IN (<eligible subquery>) RETURNING id` replaces the old read-only SELECT:
- **No select→stamp race** — one statement selects, stamps, and returns the ids to enqueue.
- **Still one `notes` query regardless of vault count** — the existing O(1) invariant test passes unchanged.
- **Self-clearing** — a successful `EmbedNote` clears the stamp to `NULL` (existing behavior), so healthy notes are unaffected (typically cleared within seconds).
- **Graceful failures still escalate** — a terminal `{:error, _}` still extends to the full 6h poison cooldown.
- The eligibility filter (`embed_retry_after IS NULL OR <= now`) is what preserves any longer cooldown — a note inside a cooldown isn't selected, so it isn't re-stamped/shortened.

Window is env-tunable via `EMBED_RECONCILE_BACKOFF_SECONDS` (default 30m — must exceed the 15-min cron interval so a crash-poison note skips at least one tick).

### Tests (TDD)
- stamps a future `embed_retry_after` on every enqueued note
- does **not** stamp notes it didn't enqueue (up-to-date notes stay `NULL`)
- end-to-end: a stamped note (simulated crash — embed never ran) is skipped on the next tick
- existing suite green, incl. the single-`notes`-query invariant

Refs #897. Related: #891 (incident, fixed by #898), #895 (per-container mem limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
