### PR TITLE
feat(pyroscope): activate BEAM CPU profiling (env knob + self-telemetry)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -851,5 +851,15 @@ if pyroscope_url = System.get_env("GRAFANA_PYROSCOPE_URL") do
         raise("GRAFANA_AGENT_TOKEN required when GRAFANA_PYROSCOPE_URL is set"),
     app_name: System.get_env("PYROSCOPE_APP_NAME", "engram-saas-prod"),
     env: to_string(config_env()),
-    instance: System.get_env("HOSTNAME", System.get_env("ECS_TASK_ID", "unknown"))
+    instance: System.get_env("HOSTNAME", System.get_env("ECS_TASK_ID", "unknown")),
+    sample_interval_ms:
+      Engram.Observability.Pyroscope.parse_interval_ms(
+        System.get_env("PYROSCOPE_SAMPLE_INTERVAL_MS"),
+        10
+      ),
+    push_interval_ms:
+      Engram.Observability.Pyroscope.parse_interval_ms(
+        System.get_env("PYROSCOPE_PUSH_INTERVAL_MS"),
+        10_000
+      )
 end

--- a/lib/engram/observability/pyroscope.ex
+++ b/lib/engram/observability/pyroscope.ex
@@ -144,6 +144,21 @@ defmodule Engram.Observability.Pyroscope do
     end
   end
 
+  @doc """
+  Parse a millisecond interval from an env var string. Returns the
+  default for nil, blank, non-integer, or non-positive input so a
+  fat-fingered env value can never disable or invert the timer.
+  """
+  @spec parse_interval_ms(String.t() | nil, pos_integer()) :: pos_integer()
+  def parse_interval_ms(nil, default) when is_integer(default) and default > 0, do: default
+
+  def parse_interval_ms(value, default) when is_binary(value) do
+    case Integer.parse(String.trim(value)) do
+      {n, ""} when n > 0 -> n
+      _ -> default
+    end
+  end
+
   # ── GenServer callbacks ───────────────────────────────────────────
 
   @impl true

--- a/lib/engram/observability/pyroscope.ex
+++ b/lib/engram/observability/pyroscope.ex
@@ -188,7 +188,11 @@ defmodule Engram.Observability.Pyroscope do
       sample_interval_ms: sample_interval,
       push_interval_ms: push_interval,
       spy_name: Keyword.get(cfg, :spy_name, @default_spy_name),
-      sample_rate: div(1_000, sample_interval),
+      # Clamp to at least 1: an operator-supplied interval above 1000ms
+      # would otherwise floor to 0 and report a bogus sampleRate=0 to
+      # Pyroscope. Intended range is 10-50ms, so this only guards a
+      # fat-fingered env value.
+      sample_rate: max(1, div(1_000, sample_interval)),
       window_started_at_ms: now_ms(),
       sample_timer_ref: nil,
       push_timer_ref: nil,

--- a/lib/engram/observability/pyroscope.ex
+++ b/lib/engram/observability/pyroscope.ex
@@ -205,7 +205,15 @@ defmodule Engram.Observability.Pyroscope do
 
   @impl true
   def handle_info(:sample, state) do
-    counters = take_sample(state.counters)
+    process_count = length(Process.list())
+    {duration_us, counters} = :timer.tc(fn -> take_sample(state.counters) end)
+
+    :telemetry.execute(
+      [:engram, :pyroscope, :sample],
+      %{duration_ms: duration_us / 1_000, process_count: process_count},
+      %{}
+    )
+
     {:noreply, %{state | counters: counters, sample_timer_ref: schedule_sample(state)}}
   end
 

--- a/lib/engram/prom_ex.ex
+++ b/lib/engram/prom_ex.ex
@@ -32,7 +32,8 @@ defmodule Engram.PromEx do
       Engram.PromEx.Notes,
       Engram.PromEx.Reliability,
       Engram.PromEx.Usage,
-      Engram.PromEx.RateLimiter
+      Engram.PromEx.RateLimiter,
+      Engram.PromEx.Profiling
     ]
   end
 

--- a/lib/engram/prom_ex/profiling.ex
+++ b/lib/engram/prom_ex/profiling.ex
@@ -1,0 +1,45 @@
+defmodule Engram.PromEx.Profiling do
+  @moduledoc """
+  PromEx plugin exposing the Pyroscope sampler's own cost on `/metrics`,
+  so a profiling rollout can be proven cheap before it is trusted.
+
+  Event + metrics:
+
+    * `[:engram, :pyroscope, :sample]` →
+      `..._sample_duration_milliseconds` (distribution): wall time of one
+      `Process.list/0` sweep. If this approaches the sample interval the
+      sampler is throttling and the reported `sampleRate` is inaccurate.
+    * `..._sample_process_count` (last value): processes on the node at
+      the last pass, the multiplier on sampler cost.
+
+  Cardinality contract: measurements only, no tags. Never user/vault/note ids.
+  """
+
+  use PromEx.Plugin
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    metric_prefix = PromEx.metric_prefix(otp_app, :profiling)
+
+    Event.build(
+      :engram_profiling_event_metrics,
+      [
+        distribution(
+          metric_prefix ++ [:sample, :duration, :milliseconds],
+          event_name: [:engram, :pyroscope, :sample],
+          measurement: :duration_ms,
+          description: "Wall time of one Pyroscope sampler pass (Process.list sweep).",
+          unit: :millisecond,
+          reporter_options: [buckets: [0.5, 1, 2, 5, 10, 20, 50, 100]]
+        ),
+        last_value(
+          metric_prefix ++ [:sample, :process_count],
+          event_name: [:engram, :pyroscope, :sample],
+          measurement: :process_count,
+          description: "Processes on the node at the last Pyroscope sampler pass."
+        )
+      ]
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.616",
+      version: "0.5.618",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/observability/pyroscope_test.exs
+++ b/test/engram/observability/pyroscope_test.exs
@@ -229,4 +229,27 @@ defmodule Engram.Observability.PyroscopeTest do
       end
     end
   end
+
+  describe "sampler self-telemetry" do
+    test "each sample pass emits [:engram, :pyroscope, :sample] with duration_ms + process_count" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:engram, :pyroscope, :sample]])
+      on_exit(fn -> :telemetry.detach(ref) end)
+
+      Application.put_env(:engram, :pyroscope,
+        url: "http://localhost:1",
+        username: "u",
+        token: "t",
+        # Fast sampling, push far in the future so no /ingest during the test.
+        sample_interval_ms: 5,
+        push_interval_ms: 60_000
+      )
+
+      {:ok, pid} = Pyroscope.start_link([])
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid, :normal, 1_000) end)
+
+      assert_receive {[:engram, :pyroscope, :sample], ^ref, measurements, _meta}, 1_000
+      assert is_float(measurements.duration_ms) and measurements.duration_ms >= 0.0
+      assert is_integer(measurements.process_count) and measurements.process_count > 0
+    end
+  end
 end

--- a/test/engram/observability/pyroscope_test.exs
+++ b/test/engram/observability/pyroscope_test.exs
@@ -154,6 +154,28 @@ defmodule Engram.Observability.PyroscopeTest do
     end
   end
 
+  describe "parse_interval_ms/2" do
+    test "nil falls back to the default" do
+      assert Pyroscope.parse_interval_ms(nil, 10) == 10
+    end
+
+    test "a positive integer string parses" do
+      assert Pyroscope.parse_interval_ms("50", 10) == 50
+    end
+
+    test "surrounding whitespace is tolerated" do
+      assert Pyroscope.parse_interval_ms("  25 ", 10) == 25
+    end
+
+    test "zero, negative, and non-integer input fall back to the default" do
+      assert Pyroscope.parse_interval_ms("0", 10) == 10
+      assert Pyroscope.parse_interval_ms("-5", 10) == 10
+      assert Pyroscope.parse_interval_ms("abc", 10) == 10
+      assert Pyroscope.parse_interval_ms("", 10) == 10
+      assert Pyroscope.parse_interval_ms("12x", 10) == 10
+    end
+  end
+
   describe "push lifecycle (integration)" do
     test "after push_interval, POSTs to /ingest with the right params and resets counters" do
       bypass = Bypass.open()


### PR DESCRIPTION
## What

Activates the already-built but dormant BEAM CPU profiler (`Engram.Observability.Pyroscope`) safely, with an ops rate knob and self-telemetry. The profiler samples every process's stacktrace and pushes folded-stack CPU profiles to Grafana Cloud Pyroscope. It has shipped for a while but has never run in prod because the ECS task strips its `GRAFANA_*` vars from the app container (fixed by the companion infra PR).

This PR is the backend half. It ships **dark**: `child_spec/1` still returns `:ignore` until the Grafana vars are present, so nothing starts until the infra flip.

## Changes

- **Env-tunable intervals** (`runtime.exs` + new `parse_interval_ms/2`): `PYROSCOPE_SAMPLE_INTERVAL_MS` / `PYROSCOPE_PUSH_INTERVAL_MS` let prod dial the sample rate without a code deploy. The parser falls back to the default for nil/blank/non-positive/non-integer input, so a fat-fingered value can never disable or invert the timer.
- **Sampler self-telemetry** (`handle_info(:sample)` + new `Engram.PromEx.Profiling`): emits `[:engram, :pyroscope, :sample]` with `duration_ms` + `process_count`, surfaced on `/metrics` as a distribution + last_value (measurements only, no tags). This is the point of the effort: an operator can watch the sampler's own cost and detect throttling (a per-pass duration approaching the interval means the reported `sampleRate` is no longer accurate).
- **`sample_rate` floor clamp**: `max(1, div(1_000, interval))` guards against a bogus `sampleRate=0` if the interval knob is ever set above 1000ms.

## Testing

- `parse_interval_ms/2`: nil/blank/positive/whitespace/non-positive/non-integer cases.
- Self-telemetry: asserts the event fires with both measurements from a running sampler.
- Full gate green: `mix format`, `mix credo --strict` (0 issues), `mix sobelow` (exit 0), `mix test` (3371 tests, 0 failures).

## Deploy sequence (load-bearing)

This backend release **must reach prod before** the companion infra PR is merged/applied. The infra flip enables the profiler; if it lands first, an old image (without this PR's knob) ignores `PYROSCOPE_SAMPLE_INTERVAL_MS` and wakes the sampler at its 100Hz code default instead of the intended 20Hz. Order: merge this PR, cut the `release-v0.5.618` tag (deploys, profiler still dormant), then merge the infra PR (flips the vars, profiler wakes at 20Hz), then watch the canary gate.

Companion infra PR: **engram-app/engram-infra#775** — allow-lists the three Grafana vars into the app container and sets `PYROSCOPE_SAMPLE_INTERVAL_MS=50`.

Design spec: Engram vault `50 Engineering/_Superpowers Specs/2026-07-03-pyroscope-cpu-profiling-activation-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
