### PR TITLE
fix(crdt): checkpoint staleness guard — stop reverting REST writes in the deliver_out gap

### DIFF
--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -62,6 +62,26 @@ defmodule Engram.Notes.CrdtCheckpoint do
           end
       end
 
+    # Deliver_out gap guard: a REST/MCP write may have committed a newer
+    # crdt_state that this live room never ingested (CrdtDeliver.deliver_out is
+    # best-effort and runs post-commit, so a checkpoint firing in that window
+    # would otherwise encode the stale in-memory doc and REVERT the committed
+    # write — see Engram#902). Fold the DB's current crdt_state into the doc
+    # before encoding. apply_update is convergent + idempotent (a no-op when the
+    # room already has it), the same native-CRDT merge CrdtDeliver.push_to_live_room
+    # uses — so a stale room can never clobber a committed write.
+    _ =
+      case Repo.with_tenant(user_id, fn -> Repo.get(Note, note_id) end) do
+        {:ok, %Note{} = db_note} ->
+          case Crypto.decrypt_crdt_state(db_note, user) do
+            {:ok, db_state} when is_binary(db_state) -> Yex.apply_update(doc, db_state)
+            _ -> :ok
+          end
+
+        _ ->
+          :ok
+      end
+
     text = CrdtBridge.text_of(doc)
 
     with {:ok, raw_state} <- encode(doc),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.618",
+      version: "0.5.619",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -94,6 +94,60 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     assert tail_count_after == 0
   end
 
+  # ── Staleness guard: checkpoint must not revert a newer REST write ─────────
+
+  test "checkpoint does NOT revert a REST write that landed while the room was stale", ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    # A live room's in-memory doc, built from the note's current CRDT state
+    # ("before"). The room makes no local edit — it is simply about to go stale.
+    {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, raw_state} = Crypto.decrypt_crdt_state(raw_note, user)
+    {:ok, room_doc} = CrdtBridge.doc_from_state(raw_state)
+
+    # A REST/MCP write lands AFTER the room doc was built and BEFORE deliver_out
+    # ingests it into the live room: notes.content + crdt_state now say
+    # "before REST-EDIT". This is the deliver_out post-commit gap.
+    {:ok, _} =
+      Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before REST-EDIT"})
+
+    # The debounced checkpoint (or an unbind on last-observer disconnect) fires
+    # on the STALE room doc, whose projection is still "before".
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, room_doc)
+
+    # The committed REST write must survive: the checkpoint must not overwrite
+    # newer DB content with the room's stale projection. The room made no edit,
+    # so the convergent merge result is exactly the REST content.
+    {:ok, fresh} = Notes.get_note(user, vault, "p.md")
+    assert fresh.content == "before REST-EDIT"
+  end
+
+  test "checkpoint converges a stale room's own edit with a concurrent REST write", ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, raw_state} = Crypto.decrypt_crdt_state(raw_note, user)
+    {:ok, room_doc} = CrdtBridge.doc_from_state(raw_state)
+
+    # The live room makes its OWN edit: base "before" -> prepend a line.
+    :ok =
+      CrdtBridge.diff_into_text(
+        Yex.Doc.get_text(room_doc, CrdtBridge.text_name()),
+        "TOP\nbefore"
+      )
+
+    # Concurrently a REST write appends a line (base "before" -> "before\nBOT"),
+    # committing a new crdt_state the stale room never ingested.
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before\nBOT"})
+
+    # Checkpointing the stale room must converge BOTH edits, not drop either.
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, room_doc)
+
+    {:ok, fresh} = Notes.get_note(user, vault, "p.md")
+    assert fresh.content =~ "TOP"
+    assert fresh.content =~ "BOT"
+  end
+
   # ── Virtual field integrity: title/path not corrupted ─────────────────────
 
   test "checkpoint does not corrupt title or path_hmac on a note with a non-trivial path", ctx do


### PR DESCRIPTION
Tier 1 of #902. Fixes the primary REST↔CRDT divergence: a checkpoint firing in the `deliver_out` post-commit window could **revert a just-committed REST/MCP write**.

## Root cause

`Notes.upsert_note` commits `notes.content` + `crdt_state`, then `CrdtDeliver.deliver_out` pushes the snapshot into any live in-memory room — **post-commit and best-effort**. If a debounced checkpoint (5s idle / 60s ceiling) or an `unbind` on last-observer-disconnect fired in that gap, `CrdtCheckpoint.checkpoint` encoded the room's **stale** doc and `Repo.update!`'d `content` — overwriting the committed write with old text. The code already flagged the hazard (`notes.ex:1887`).

Affects API/MCP writes too — any REST-path write racing a live-room checkpoint.

## Fix

Before encoding, fold the DB's current `crdt_state` into the room doc via `Yex.apply_update` — a **native CRDT merge**: convergent, artifact-free, and idempotent (a no-op when the room already ingested it via `deliver_out`). This is the same mechanism `CrdtDeliver.push_to_live_room` uses, so it's proven, not novel merge logic. A stale room can no longer clobber a commit; a concurrent room edit + REST write **converge** instead of one dropping the other.

Cost: one extra `Repo.get` + decrypt per checkpoint. Checkpoints are debounced (~1 per dirty streak, not per-keystroke), so this is negligible; Tier 2 removes it by routing REST writes through the live room (single writer).

## Tests

- `checkpoint does NOT revert a REST write that landed while the room was stale` — reproduces the revert (RED without the fix: `left: "before"`).
- `checkpoint converges a stale room's own edit with a concurrent REST write` — both edits survive.
- Full `test/engram/notes/` scope green (221 → 223 tests), credo clean, format clean.

## Deferred

The bind/3 staleness re-seed (audit Q6) — latent defense-in-depth for a divergence that current atomic-write invariants prevent. Noted on #902, not included here to keep this scoped to the active bug.

Context: client-side guards in Engram-obsidian #169/#173/#174 kept e2e green by bypassing the fragile handshake; this closes the server gap they were working around.