### PR TITLE
feat(sync): CRDT delivery observability + rerun-safety fixes (test_78, test_49)

### DIFF
--- a/e2e/tests/test_49_cross_auth_sync.py
+++ b/e2e/tests/test_49_cross_auth_sync.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import os
 import time
+import uuid
 
 import pytest
 
@@ -67,8 +68,13 @@ async def test_apikey_push_oauth_receives(
         original_settings = await swap_to_oauth(cdp_a, tokens)
         await wait_for_stream(cdp_a)
 
-        # B (API key) creates a note
-        path = "E2E/CrossAuthApikeyToOauth.md"
+        # B (API key) creates a note. Unique path per run: these tests share the
+        # session-scoped sync_user, so a fixed path left over from a failed
+        # attempt would make the rerun's identical re-push hit the server's
+        # hash-equal broadcast-skip (idempotent no-op) and never deliver — a
+        # deterministic rerun failure. Unique paths keep every attempt a fresh,
+        # broadcasting insert (same rerun-safety approach as test_58/test_59).
+        path = f"E2E/CrossAuthApikeyToOauth-{uuid.uuid4().hex[:12]}.md"
         content = "# API Key → OAuth\nPushed by API key client, received by OAuth"
         write_note(vault_b, path, content)
 
@@ -109,8 +115,9 @@ async def test_oauth_push_apikey_receives(
         assert await cdp_a.check_stream_connected(), "A (OAuth) not connected"
         assert await cdp_b.check_stream_connected(), "B (API key) not connected"
 
-        # A (OAuth) creates a note and syncs
-        path = "E2E/CrossAuthOauthToApikey.md"
+        # A (OAuth) creates a note and syncs. Unique path per run for rerun-safety
+        # (see test_apikey_push_oauth_receives).
+        path = f"E2E/CrossAuthOauthToApikey-{uuid.uuid4().hex[:12]}.md"
         content = "# OAuth → API Key\nPushed by OAuth client, received by API key"
         write_note(vault_a, path, content)
 
@@ -144,7 +151,10 @@ async def test_rapid_api_edits_final_content_arrives(vault_b, cdp_b, api_sync):
     connected = await cdp_b.check_stream_connected()
     assert connected, "B's WebSocket channel is not connected"
 
-    path = "E2E/RapidEdits.md"
+    # Unique path per run for rerun-safety (shared sync_user; see
+    # test_apikey_push_oauth_receives). The final "Version 5 of 5" would hash-equal
+    # a leftover from a prior attempt and never re-broadcast.
+    path = f"E2E/RapidEdits-{uuid.uuid4().hex[:12]}.md"
 
     # Fire 5 rapid edits (no sleep between them)
     for i in range(1, 6):
@@ -170,7 +180,9 @@ async def test_rapid_api_edits_content_not_stale(vault_b, cdp_b, api_sync):
     connected = await cdp_b.check_stream_connected()
     assert connected, "B's WebSocket channel is not connected"
 
-    path = "E2E/RapidEditsStale.md"
+    # Unique path per run for rerun-safety (shared sync_user; see
+    # test_apikey_push_oauth_receives).
+    path = f"E2E/RapidEditsStale-{uuid.uuid4().hex[:12]}.md"
 
     # Rapid-fire edits
     for i in range(1, 8):

--- a/e2e/tests/test_78_hash_only_live_update.py
+++ b/e2e/tests/test_78_hash_only_live_update.py
@@ -23,6 +23,16 @@ PATH = "E2E/HashOnlyLive.md"
 
 @pytest.mark.asyncio
 async def test_hash_only_live_update(vault_b, cdp_b, api_sync):
+    # Rerun-safety: pytest-rerunfailures (reruns=1) retries on failure against a
+    # SHARED server DB with no reset between attempts. A note left over from a
+    # failed attempt 1 makes attempt 2's identical create hit the server's
+    # deliberate hash-equal broadcast-skip (an idempotent re-push is a no-op —
+    # no version bump, no note_changed), so B never gets the live event and
+    # wait_for_file times out. That makes the rerun DETERMINISTICALLY fail
+    # rather than retry. Soft-delete first so every attempt's create is a fresh,
+    # broadcasting insert. (Same rerun-safety pattern as test_79/test_80.)
+    api_sync.delete_note(PATH)
+
     # Explicit precondition: B's channel must be up before we broadcast.
     await cdp_b.wait_for_stream_connected(timeout=20)
 

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -25,6 +25,7 @@ defmodule Engram.Notes do
 
   alias Engram.Observability.PostHog
   alias Engram.Repo
+  alias Engram.Sync.Broadcast
   alias Engram.Telemetry
   alias Engram.UsageMeters
   alias Engram.Workers.{DeleteNoteIndex, EmbedNote}
@@ -2030,6 +2031,8 @@ defmodule Engram.Notes do
         |> decrypt_or_raise!(user)
         |> Enum.map(&change_map/1)
 
+      _ = log_changes_page(since, changes)
+
       next_cursor =
         if has_more do
           last = List.last(page)
@@ -2116,6 +2119,33 @@ defmodule Engram.Notes do
       end
 
     {:ok, %{changes: changes, has_more: has_more, next: next}}
+  end
+
+  # Catch-up-pull breadcrumb: a reconnecting client pulls `/api/notes/changes`
+  # to recover notes missed while disconnected (e2e `test_23`). The flake is a
+  # note returning EMPTY (or absent) from the pull, so we log what the page
+  # actually delivered — count + per-note `id:content_len` — to prove
+  # present/empty/absent server-side. Only NON-empty pages log, so an idle poll
+  # (the common case) stays silent and prod is not spammed on every poll.
+  # Privacy: UUID + content BYTE-LENGTH only. Never the path or content.
+  @changes_trace_sample 20
+  defp log_changes_page(_since, []), do: :ok
+
+  defp log_changes_page(since, changes) do
+    sample =
+      changes
+      |> Enum.take(@changes_trace_sample)
+      |> Enum.map_join(",", fn c -> "#{c.id}:#{byte_size(c.content || "")}" end)
+
+    more =
+      if length(changes) > @changes_trace_sample,
+        do: "+#{length(changes) - @changes_trace_sample}",
+        else: ""
+
+    Logger.info(
+      "changes page since=#{DateTime.to_iso8601(since)} count=#{length(changes)} notes=#{sample}#{more}",
+      Metadata.with_category(:info, :sync)
+    )
   end
 
   defp change_map(note) do
@@ -3293,12 +3323,13 @@ defmodule Engram.Notes do
       case Keyword.get(opts, :broadcast_from) do
         pid when is_pid(pid) ->
           # `broadcast_from` excludes the pushing socket; it is never used from
-          # the folder cascade (which has no socket to exclude), so it stays a
-          # direct Endpoint call and is not subject to deferral.
-          EngramWeb.Endpoint.broadcast_from(pid, topic, "note_changed", payload)
+          # the folder cascade (which has no socket to exclude), so it goes
+          # straight through (not subject to deferral). Routed through Broadcast
+          # so this socket-origin leg logs the same delivery breadcrumb.
+          Broadcast.emit_from(pid, topic, "note_changed", payload)
 
         nil ->
-          Engram.Sync.Broadcast.emit(topic, "note_changed", payload)
+          Broadcast.emit(topic, "note_changed", payload)
       end
 
     # Deliver-out to CRDT clients (gap ③): push the merged plaintext to a live
@@ -3314,7 +3345,7 @@ defmodule Engram.Notes do
   @spec broadcast_change(Ecto.UUID.t(), Ecto.UUID.t(), String.t(), String.t()) :: :ok
   defp broadcast_change(user_id, vault_id, event_type, path) do
     _ =
-      Engram.Sync.Broadcast.emit("sync:#{user_id}:#{vault_id}", "note_changed", %{
+      Broadcast.emit("sync:#{user_id}:#{vault_id}", "note_changed", %{
         "event_type" => event_type,
         "path" => path,
         "vault_id" => vault_id

--- a/lib/engram/sync/broadcast.ex
+++ b/lib/engram/sync/broadcast.ex
@@ -27,6 +27,10 @@ defmodule Engram.Sync.Broadcast do
   holds for every caller that does not opt in via `deferred/1`.
   """
 
+  alias Engram.Logger.Metadata
+
+  require Logger
+
   @buffer_key :__engram_sync_broadcast_buffer__
 
   @doc """
@@ -37,7 +41,7 @@ defmodule Engram.Sync.Broadcast do
   def emit(topic, event, payload) do
     case Process.get(@buffer_key) do
       nil ->
-        _ = EngramWeb.Endpoint.broadcast(topic, event, payload)
+        broadcast_now(topic, event, payload)
         :ok
 
       buffered when is_list(buffered) ->
@@ -85,11 +89,29 @@ defmodule Engram.Sync.Broadcast do
         |> Process.get([])
         |> Enum.reverse()
         |> Enum.each(fn {topic, event, payload} ->
-          EngramWeb.Endpoint.broadcast(topic, event, payload)
+          broadcast_now(topic, event, payload)
         end)
 
       _ ->
         :ok
     end
+  end
+
+  # Single point where a sync event actually hits PubSub. Emits a breadcrumb
+  # FIRST so the log lines up with the receiver's traced `sync join`/`sync leave`
+  # — the broadcast is fastlaned PubSub → socket (the sync channel has no
+  # `handle_out`), so this log is the only server-side proof a broadcast fired.
+  # Privacy: log ONLY UUIDs (topic + note_id). Never the note path or content.
+  defp broadcast_now(topic, event, payload) do
+    note_id = Map.get(payload, "id") || Map.get(payload, "note_id")
+    op = Map.get(payload, "event_type")
+
+    Logger.info(
+      "sync broadcast emit topic=#{topic} event=#{event} note_id=#{note_id} op=#{op}",
+      Metadata.with_category(:info, :sync, note_id: note_id)
+    )
+
+    _ = EngramWeb.Endpoint.broadcast(topic, event, payload)
+    :ok
   end
 end

--- a/lib/engram/sync/broadcast.ex
+++ b/lib/engram/sync/broadcast.ex
@@ -97,21 +97,44 @@ defmodule Engram.Sync.Broadcast do
     end
   end
 
-  # Single point where a sync event actually hits PubSub. Emits a breadcrumb
-  # FIRST so the log lines up with the receiver's traced `sync join`/`sync leave`
-  # — the broadcast is fastlaned PubSub → socket (the sync channel has no
-  # `handle_out`), so this log is the only server-side proof a broadcast fired.
-  # Privacy: log ONLY UUIDs (topic + note_id). Never the note path or content.
+  @doc """
+  Broadcasts `event` on `topic` to every subscriber EXCEPT `pid` (the pushing
+  socket), via `Endpoint.broadcast_from/4`.
+
+  This is the socket-origin delivery leg (a REST/CRDT push echoing to a note's
+  other live peers). It is never subject to the deferral buffer — `broadcast_from`
+  is only ever called with a live socket pid, outside the folder cascade — so it
+  logs and broadcasts directly, mirroring `broadcast_now/3`'s breadcrumb with
+  `mode=from`.
+  """
+  @spec emit_from(pid(), String.t(), String.t(), map()) :: :ok
+  def emit_from(pid, topic, event, payload) when is_pid(pid) do
+    log_emit(topic, event, payload, "from")
+    _ = EngramWeb.Endpoint.broadcast_from(pid, topic, event, payload)
+    :ok
+  end
+
+  # Single point where a fanout sync event actually hits PubSub. Emits a
+  # breadcrumb FIRST so the log lines up with the receiver's traced
+  # `sync join`/`sync leave` — the broadcast is fastlaned PubSub → socket (the
+  # sync channel has no `handle_out`), so this log is the only server-side proof
+  # a broadcast fired.
   defp broadcast_now(topic, event, payload) do
+    log_emit(topic, event, payload, "fanout")
+    _ = EngramWeb.Endpoint.broadcast(topic, event, payload)
+    :ok
+  end
+
+  # Shared delivery breadcrumb for both legs (`fanout` = broadcast to all,
+  # `from` = broadcast_from excluding the pusher).
+  # Privacy: log ONLY UUIDs (topic + note_id). Never the note path or content.
+  defp log_emit(topic, event, payload, mode) do
     note_id = Map.get(payload, "id") || Map.get(payload, "note_id")
     op = Map.get(payload, "event_type")
 
     Logger.info(
-      "sync broadcast emit topic=#{topic} event=#{event} note_id=#{note_id} op=#{op}",
+      "sync broadcast emit topic=#{topic} event=#{event} note_id=#{note_id} op=#{op} mode=#{mode}",
       Metadata.with_category(:info, :sync, note_id: note_id)
     )
-
-    _ = EngramWeb.Endpoint.broadcast(topic, event, payload)
-    :ok
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.622",
+      version: "0.5.623",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes_changes_page_trace_test.exs
+++ b/test/engram/notes_changes_page_trace_test.exs
@@ -1,0 +1,79 @@
+defmodule Engram.NotesChangesPageTraceTest do
+  @moduledoc """
+  Catch-up-pull breadcrumb for the `/api/notes/changes` timestamp feed
+  (`list_changes_page/4`).
+
+  A reconnecting client pulls this feed to catch up on notes it missed while
+  disconnected (e2e-clerk `test_23` reconnect catch-up). The failure mode is a
+  note that comes back EMPTY (or missing) from the pull, so the breadcrumb logs
+  what the page actually delivered — per-note `id:content_len` + count — so a CI
+  flake capture can prove whether the note was returned, returned empty, or
+  absent. Only NON-empty pages log (an idle poll returning nothing stays silent,
+  so prod is not spammed on every poll).
+
+  Privacy: only the note UUID + content BYTE-LENGTH are logged. Never the path
+  or content.
+  """
+  use Engram.DataCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Engram.Notes
+
+  @epoch ~U[2020-01-01 00:00:00.000000Z]
+
+  setup do
+    previous_level = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: previous_level) end)
+
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    %{user: user, vault: vault}
+  end
+
+  defp seed_notes(user, vault, n) do
+    for i <- 1..n do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "n#{String.pad_leading(to_string(i), 3, "0")}.md",
+          "content" => "note #{i}",
+          "mtime" => i * 1.0
+        })
+
+      note
+    end
+  end
+
+  test "a non-empty page logs a breadcrumb with count + per-note id:len", %{
+    user: user,
+    vault: vault
+  } do
+    [n1 | _] = seed_notes(user, vault, 2)
+
+    log =
+      capture_log(fn ->
+        {:ok, %{changes: changes}} = Notes.list_changes_page(user, vault, @epoch, limit: 10)
+        assert length(changes) == 2
+      end)
+
+    assert log =~ "changes page"
+    assert log =~ "count=2"
+    # per-note id:content_len — "note 1" is 6 bytes
+    assert log =~ "#{n1.id}:6"
+  end
+
+  test "an empty page logs NO breadcrumb", %{user: user, vault: vault} do
+    seed_notes(user, vault, 1)
+    future = ~U[2999-01-01 00:00:00.000000Z]
+
+    log =
+      capture_log(fn ->
+        {:ok, %{changes: []}} = Notes.list_changes_page(user, vault, future, limit: 10)
+      end)
+
+    refute log =~ "changes page"
+  end
+end

--- a/test/engram/sync/broadcast_trace_test.exs
+++ b/test/engram/sync/broadcast_trace_test.exs
@@ -1,0 +1,66 @@
+defmodule Engram.Sync.BroadcastTraceTest do
+  @moduledoc """
+  Emit-side breadcrumb for the `note_changed` broadcast path.
+
+  The broadcast is fastlaned PubSub → socket (the sync channel has no
+  `handle_out`), so the ONLY server-side observable that a broadcast fired is
+  this emit log. It lets a CI flake capture line the emit (topic = sync:user:vault
+  + note_id) up against the receiver's already-traced `sync join`/`sync leave` to
+  bisect a server-emit gap from a client-side drop (e2e-clerk test_78 stall).
+
+  Privacy: only UUIDs are logged (topic + note_id). Never the note path or content.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Engram.Sync.Broadcast
+
+  setup do
+    previous_level = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: previous_level) end)
+    :ok
+  end
+
+  test "emit logs a breadcrumb with topic, event, and note_id for note_changed" do
+    log =
+      capture_log(fn ->
+        Broadcast.emit("sync:user-1:vault-1", "note_changed", %{
+          "event_type" => "upsert",
+          "id" => "note-abc"
+        })
+      end)
+
+    assert log =~ "sync broadcast emit"
+    assert log =~ "sync:user-1:vault-1"
+    assert log =~ "note_changed"
+    assert log =~ "note-abc"
+  end
+
+  test "a deferred flush also logs the breadcrumb at actual emission (on commit)" do
+    log =
+      capture_log(fn ->
+        Broadcast.deferred(fn ->
+          Broadcast.emit("sync:u:v", "note_changed", %{"id" => "deferred-note"})
+          # Still buffered — nothing emitted (or logged) yet inside the fun.
+          {:ok, :done}
+        end)
+      end)
+
+    assert log =~ "sync broadcast emit"
+    assert log =~ "deferred-note"
+  end
+
+  test "a discarded (rolled-back) deferral logs NO emit breadcrumb" do
+    log =
+      capture_log(fn ->
+        Broadcast.deferred(fn ->
+          Broadcast.emit("sync:u:v", "note_changed", %{"id" => "rolled-back"})
+          {:error, :conflict}
+        end)
+      end)
+
+    refute log =~ "rolled-back"
+  end
+end

--- a/test/engram/sync/broadcast_trace_test.exs
+++ b/test/engram/sync/broadcast_trace_test.exs
@@ -63,4 +63,22 @@ defmodule Engram.Sync.BroadcastTraceTest do
 
     refute log =~ "rolled-back"
   end
+
+  test "emit_from/4 logs the breadcrumb (mode=from) and excludes the given pid" do
+    EngramWeb.Endpoint.subscribe("sync:from-test")
+
+    log =
+      capture_log(fn ->
+        Broadcast.emit_from(self(), "sync:from-test", "note_changed", %{"id" => "from-note"})
+      end)
+
+    assert log =~ "sync broadcast emit"
+    assert log =~ "sync:from-test"
+    assert log =~ "note_changed"
+    assert log =~ "from-note"
+    # Distinguishes the socket-origin (CRDT/REST push) leg from the fanout leg.
+    assert log =~ "mode=from"
+    # broadcast_from excludes the given pid — self() here — so no delivery back.
+    refute_receive %Phoenix.Socket.Broadcast{topic: "sync:from-test"}, 50
+  end
 end


### PR DESCRIPTION
Makes note-delivery server-side observable, then uses that to root-cause and fix a long-standing e2e-clerk flake class.

## Part 1 — Delivery observability (3 legs)
Each logs `category: :sync`, **UUIDs + content byte-length only** (never path/content); `loki_ship=false` so nothing ships to prod Loki.
- **fanout emit** (`Broadcast.emit/3` → `broadcast_now/3`): REST/MCP create → all subscribers. `mode=fanout`.
- **socket-origin push** (`Broadcast.emit_from/4`): the `broadcast_from/4` leg. `mode=from`.
- **catch-up pull** (`list_changes_page/4`): non-empty pages log `count` + per-note `id:content_len`. Empty pages stay silent.

## Part 2 — Root cause + rerun-safety fixes (found via Part 1)
The breadcrumbs showed test_78's create returned **200 but emitted no `note_changed`**. The `RERUN` marker explained it: under `reruns=1` (shared session user/vault, no DB reset), attempt 1 leaves the note behind, so attempt 2's byte-identical re-push hits the server's **deliberate hash-equal broadcast-skip** (an idempotent no-op — see `notes_idempotent_upsert_test`). B (connected, no catch-up) never gets the live event → 30s timeout. The rerun thus **deterministically fails instead of retrying** — why reruns never cured this flake family.

**The server optimization is correct** (a real reconnecting peer recovers via catch-up). The tests simply weren't rerun-safe:
- **test_78** — soft-delete the note before create (test_79/test_80 pattern).
- **test_49** (4 tests) — unique per-run paths (`uuid`). These `write_note` **locally** into the session-scoped vault, so a server-only delete wouldn't force a fresh push; unique paths keep every attempt fresh on both server and local sides (test_58/test_59 pattern).
- **test_47** — considered and **left unchanged**: it provisions a fresh OAuth user+vault per test, so its reruns never collide.

## Validation
- Unit: `broadcast_trace_test.exs`, `notes_changes_page_trace_test.exs`; 151-test regression green on the rerouted broadcast path.
- e2e-clerk went **GREEN** on the run that added the test_78 fix; the test_49 fix follows the same proven approach.

v0.5.623. Refs `ws-zombie-channel-diagnosis.md` (workspace #112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)