### PR TITLE
feat(e2e): remote-logging delivery oracle + suite-wide client capture

### DIFF
--- a/e2e/helpers/log_oracle.py
+++ b/e2e/helpers/log_oracle.py
@@ -1,0 +1,96 @@
+"""Delivery oracle: wait for a synced file AND, on timeout, mine the client
+log stream (GET /logs) to report WHERE the sync causal chain broke.
+
+Drop-in superset of ``wait_for_file`` for cross-instance delivery asserts.
+On success it behaves identically (polls the receiver's vault, returns file
+content, never touches the network). On timeout it queries
+``api_sync.get_logs()`` and classifies the receiver's client logs for the
+path so the failure names the gap instead of stalling blindly:
+
+    received     -> a "channel"/"ws" log line: "Event: ... <path>"
+    materialized -> a "pull" log line: "Created: <path>" / "Applied: <path>"
+
+A blank "file did not appear in 30s" becomes, e.g.,
+"received=yes materialized=no" (server delivered, client never wrote) or
+"received=no materialized=no" (never reached the client at all).
+
+Attribution note: e2e ``vault_a`` and ``vault_b`` share one user AND one
+client_id, so client_logs carry no per-instance field. We disambiguate the
+RECEIVER by category (the origin instance logs under "push"; the receiver
+logs under "pull"/"ws"/"channel") plus the path in the message. That holds
+for "A creates / B receives" delivery tests where B is the sole
+materializer. Once client_logs gains a device_id (tracked separately) the
+oracle can key on the instance directly.
+
+Log-line signatures verified against plugin src on 2026-07-04:
+  channel.ts:456  rlog().info("channel", f"Event: {type} {path}")
+  sync.ts:1992    rlog().info("ws", f"Event: {type} note: {path}")
+  sync.ts:2582    rlog().info("pull", f"Applied: {path} | ...")
+  sync.ts:2608    rlog().info("pull", f"Created: {path} | len=...")
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+_RECEIVE_CATEGORIES = ("channel", "ws")
+_MATERIALIZE_CATEGORY = "pull"
+_MATERIALIZE_PREFIXES = ("Created:", "Applied:")
+
+
+def _yn(flag: bool) -> str:
+    return "yes" if flag else "no"
+
+
+def _classify(logs: list[dict], rel_path: str) -> tuple[bool, bool, list[str]]:
+    """Scan client logs for the path. Return (received, materialized, hits)."""
+    received = False
+    materialized = False
+    hits: list[str] = []
+    for log in logs:
+        message = log.get("message", "")
+        if rel_path not in message:
+            continue
+        category = log.get("category", "")
+        hits.append(f"{category}: {message}")
+        if category in _RECEIVE_CATEGORIES and "Event:" in message:
+            received = True
+        if category == _MATERIALIZE_CATEGORY and message.startswith(_MATERIALIZE_PREFIXES):
+            materialized = True
+    return received, materialized, hits
+
+
+def wait_for_delivery(
+    vault_path, rel_path: str, api_sync, timeout: float = 30, poll: float = 0.3
+) -> str:
+    """Poll until ``rel_path`` materializes in ``vault_path``, return its content.
+
+    On timeout, raise TimeoutError whose message names the causal-chain gap,
+    mined from ``api_sync.get_logs()``.
+    """
+    full = Path(vault_path) / rel_path
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if full.exists():
+            return full.read_text(encoding="utf-8")
+        time.sleep(poll)
+
+    # Timed out. Enrich with the client-log causal chain. This is best-effort
+    # diagnostics on an ALREADY-failed wait: a log-query error must not mask
+    # the real TimeoutError, so we swallow it into the message rather than let
+    # it propagate and hide what actually failed.
+    received = materialized = False
+    hits: list[str] = []
+    try:
+        logs = api_sync.get_logs(limit=200).get("logs", [])
+        received, materialized, hits = _classify(logs, rel_path)
+    except Exception as exc:  # noqa: BLE001 - diagnostic enrichment, see comment above
+        hits = [f"(log query failed: {exc})"]
+
+    detail = "\n  ".join(hits) if hits else "(no client log line mentioned the path)"
+    raise TimeoutError(
+        f"{rel_path} not delivered within {timeout}s. "
+        f"Client-log evidence: received={_yn(received)} "
+        f"materialized={_yn(materialized)}.\n  {detail}"
+    )

--- a/e2e/helpers/log_oracle.py
+++ b/e2e/helpers/log_oracle.py
@@ -36,14 +36,18 @@ from pathlib import Path
 
 _RECEIVE_CATEGORIES = ("channel", "ws")
 _MATERIALIZE_CATEGORY = "pull"
-_MATERIALIZE_PREFIXES = ("Created:", "Applied:")
+# Receiver-side "wrote it to disk" signatures, per plugin src (2026-07-04):
+_NOTE_MATERIALIZE = ("Created:", "Applied:")
+_ATTACHMENT_MATERIALIZE = ("Attachment applied:", "Attachment created:")
 
 
 def _yn(flag: bool) -> str:
     return "yes" if flag else "no"
 
 
-def _classify(logs: list[dict], rel_path: str) -> tuple[bool, bool, list[str]]:
+def _classify(
+    logs: list[dict], rel_path: str, materialize_prefixes: tuple[str, ...]
+) -> tuple[bool, bool, list[str]]:
     """Scan client logs for the path. Return (received, materialized, hits)."""
     received = False
     materialized = False
@@ -56,15 +60,40 @@ def _classify(logs: list[dict], rel_path: str) -> tuple[bool, bool, list[str]]:
         hits.append(f"{category}: {message}")
         if category in _RECEIVE_CATEGORIES and "Event:" in message:
             received = True
-        if category == _MATERIALIZE_CATEGORY and message.startswith(_MATERIALIZE_PREFIXES):
+        if category == _MATERIALIZE_CATEGORY and message.startswith(materialize_prefixes):
             materialized = True
     return received, materialized, hits
+
+
+def _timeout_error(
+    rel_path: str, api_sync, timeout: float, materialize_prefixes: tuple[str, ...]
+) -> TimeoutError:
+    """Build a causal-chain TimeoutError from the client log stream.
+
+    Best-effort diagnostics on an ALREADY-failed wait: a log-query error must
+    not mask the real timeout, so we fold it into the message rather than let
+    it propagate and hide what actually failed.
+    """
+    received = materialized = False
+    hits: list[str] = []
+    try:
+        logs = api_sync.get_logs(limit=200).get("logs", [])
+        received, materialized, hits = _classify(logs, rel_path, materialize_prefixes)
+    except Exception as exc:  # noqa: BLE001 - diagnostic enrichment, see docstring
+        hits = [f"(log query failed: {exc})"]
+
+    detail = "\n  ".join(hits) if hits else "(no client log line mentioned the path)"
+    return TimeoutError(
+        f"{rel_path} not delivered within {timeout}s. "
+        f"Client-log evidence: received={_yn(received)} "
+        f"materialized={_yn(materialized)}.\n  {detail}"
+    )
 
 
 def wait_for_delivery(
     vault_path, rel_path: str, api_sync, timeout: float = 30, poll: float = 0.3
 ) -> str:
-    """Poll until ``rel_path`` materializes in ``vault_path``, return its content.
+    """Poll until ``rel_path`` materializes in ``vault_path``, return its text.
 
     On timeout, raise TimeoutError whose message names the causal-chain gap,
     mined from ``api_sync.get_logs()``.
@@ -75,22 +104,22 @@ def wait_for_delivery(
         if full.exists():
             return full.read_text(encoding="utf-8")
         time.sleep(poll)
+    raise _timeout_error(rel_path, api_sync, timeout, _NOTE_MATERIALIZE)
 
-    # Timed out. Enrich with the client-log causal chain. This is best-effort
-    # diagnostics on an ALREADY-failed wait: a log-query error must not mask
-    # the real TimeoutError, so we swallow it into the message rather than let
-    # it propagate and hide what actually failed.
-    received = materialized = False
-    hits: list[str] = []
-    try:
-        logs = api_sync.get_logs(limit=200).get("logs", [])
-        received, materialized, hits = _classify(logs, rel_path)
-    except Exception as exc:  # noqa: BLE001 - diagnostic enrichment, see comment above
-        hits = [f"(log query failed: {exc})"]
 
-    detail = "\n  ".join(hits) if hits else "(no client log line mentioned the path)"
-    raise TimeoutError(
-        f"{rel_path} not delivered within {timeout}s. "
-        f"Client-log evidence: received={_yn(received)} "
-        f"materialized={_yn(materialized)}.\n  {detail}"
-    )
+def wait_for_binary_delivery(
+    vault_path, rel_path: str, api_sync, timeout: float = 30, poll: float = 0.3
+) -> bytes:
+    """Attachment variant of ``wait_for_delivery``.
+
+    Waits for a non-empty binary file (a 0-byte placeholder is not delivered),
+    returns its bytes, and on timeout mines the log stream using the
+    attachment materialize signatures ("Attachment applied/created:").
+    """
+    full = Path(vault_path) / rel_path
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if full.exists() and full.stat().st_size > 0:
+            return full.read_bytes()
+        time.sleep(poll)
+    raise _timeout_error(rel_path, api_sync, timeout, _ATTACHMENT_MATERIALIZE)

--- a/e2e/helpers/log_oracle.py
+++ b/e2e/helpers/log_oracle.py
@@ -36,7 +36,11 @@ from pathlib import Path
 
 _RECEIVE_CATEGORIES = ("channel", "ws")
 _MATERIALIZE_CATEGORY = "pull"
-# Receiver-side "wrote it to disk" signatures, per plugin src (2026-07-04):
+# Receiver-side "wrote it to disk" signatures, per plugin src (2026-07-04).
+# These key on the classic REST pull path; a materialize via a CRDT binding
+# would not match, so the timeout diagnostic could under-report
+# materialized=no. Diagnostic-only: it never affects a test's pass/fail (the
+# assertion is the file on disk), only the failure message's precision.
 _NOTE_MATERIALIZE = ("Created:", "Applied:")
 _ATTACHMENT_MATERIALIZE = ("Attachment applied:", "Attachment created:")
 

--- a/e2e/helpers/log_oracle_test.py
+++ b/e2e/helpers/log_oracle_test.py
@@ -1,0 +1,104 @@
+"""Unit tests for the delivery log-oracle (helpers/log_oracle.py).
+
+Pure logic — no stack, no fixtures. The e2e root conftest boots the full
+Obsidian stack via a session-autouse fixture, so run these with confcutdir
+to skip it:
+
+    cd e2e && python3 -m pytest helpers/log_oracle_test.py \
+        --confcutdir helpers -o addopts='' --reruns 0 -p no:cacheprovider -q
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from helpers.log_oracle import wait_for_delivery
+
+
+class _FakeApi:
+    """Stand-in for the ApiClient — serves canned GET /logs rows."""
+
+    def __init__(self, logs=None, raise_on_get=False):
+        self._logs = logs or []
+        self._raise = raise_on_get
+        self.get_calls = 0
+
+    def get_logs(self, limit=200):
+        self.get_calls += 1
+        if self._raise:
+            raise RuntimeError("boom")
+        return {"logs": self._logs}
+
+
+def _pull_created(path):
+    return {"category": "pull", "level": "info", "message": f"Created: {path} | len=5"}
+
+
+def _channel_event(path):
+    return {"category": "channel", "level": "info", "message": f"Event: upsert {path}"}
+
+
+def test_returns_content_when_file_appears(tmp_path):
+    """On success it behaves like wait_for_file: returns content, never queries logs."""
+    rel = "E2E/Ok.md"
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_text("hello body", encoding="utf-8")
+    api = _FakeApi(raise_on_get=True)  # would blow up if the oracle queried logs
+
+    content = wait_for_delivery(tmp_path, rel, api, timeout=1, poll=0.02)
+
+    assert content == "hello body"
+    assert api.get_calls == 0
+
+
+def test_timeout_reports_received_but_not_materialized(tmp_path):
+    """Server delivered (channel Event) but client never wrote → pointed diagnosis."""
+    rel = "E2E/Stuck.md"
+    api = _FakeApi(logs=[_channel_event(rel)])
+
+    with pytest.raises(TimeoutError) as exc:
+        wait_for_delivery(tmp_path, rel, api, timeout=0.1, poll=0.02)
+
+    msg = str(exc.value)
+    assert "received=yes" in msg
+    assert "materialized=no" in msg
+    assert rel in msg
+    assert api.get_calls == 1
+
+
+def test_timeout_reports_never_received(tmp_path):
+    """No client log mentions the path → received=no materialized=no."""
+    rel = "E2E/Ghost.md"
+    api = _FakeApi(logs=[_channel_event("E2E/Unrelated.md")])
+
+    with pytest.raises(TimeoutError) as exc:
+        wait_for_delivery(tmp_path, rel, api, timeout=0.1, poll=0.02)
+
+    msg = str(exc.value)
+    assert "received=no" in msg
+    assert "materialized=no" in msg
+
+
+def test_timeout_reports_materialized(tmp_path):
+    """A pull 'Created:' line for the path counts as materialized."""
+    rel = "E2E/Written.md"
+    api = _FakeApi(logs=[_channel_event(rel), _pull_created(rel)])
+
+    with pytest.raises(TimeoutError) as exc:
+        wait_for_delivery(tmp_path, rel, api, timeout=0.1, poll=0.02)
+
+    msg = str(exc.value)
+    assert "received=yes" in msg
+    assert "materialized=yes" in msg
+
+
+def test_timeout_survives_log_query_failure(tmp_path):
+    """A failed log query must not mask the real TimeoutError."""
+    rel = "E2E/NoLogs.md"
+    api = _FakeApi(raise_on_get=True)
+
+    with pytest.raises(TimeoutError) as exc:
+        wait_for_delivery(tmp_path, rel, api, timeout=0.1, poll=0.02)
+
+    assert rel in str(exc.value)

--- a/e2e/helpers/log_oracle_test.py
+++ b/e2e/helpers/log_oracle_test.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import pytest
 
-from helpers.log_oracle import wait_for_delivery
+from helpers.log_oracle import wait_for_binary_delivery, wait_for_delivery
 
 
 class _FakeApi:
@@ -102,3 +102,50 @@ def test_timeout_survives_log_query_failure(tmp_path):
         wait_for_delivery(tmp_path, rel, api, timeout=0.1, poll=0.02)
 
     assert rel in str(exc.value)
+
+
+def _pull_attachment(path):
+    return {
+        "category": "pull",
+        "level": "info",
+        "message": f"Attachment created: {path} | bytes=3",
+    }
+
+
+def test_binary_returns_bytes_when_file_appears(tmp_path):
+    """Attachment variant: returns bytes on success, never queries logs."""
+    rel = "E2E/img.png"
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_bytes(b"PNG")
+    api = _FakeApi(raise_on_get=True)
+
+    data = wait_for_binary_delivery(tmp_path, rel, api, timeout=1, poll=0.02)
+
+    assert data == b"PNG"
+    assert api.get_calls == 0
+
+
+def test_binary_zero_byte_is_not_ready(tmp_path):
+    """A 0-byte placeholder is not a delivered attachment → still times out."""
+    rel = "E2E/empty.png"
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_bytes(b"")
+    api = _FakeApi(logs=[])
+
+    with pytest.raises(TimeoutError):
+        wait_for_binary_delivery(tmp_path, rel, api, timeout=0.1, poll=0.02)
+
+
+def test_binary_timeout_reports_attachment_materialized(tmp_path):
+    """A pull 'Attachment created:' line counts as materialized for attachments."""
+    rel = "E2E/late.png"
+    api = _FakeApi(logs=[_pull_attachment(rel)])
+
+    with pytest.raises(TimeoutError) as exc:
+        wait_for_binary_delivery(tmp_path, rel, api, timeout=0.1, poll=0.02)
+
+    msg = str(exc.value)
+    assert "materialized=yes" in msg
+    assert rel in msg

--- a/e2e/helpers/obsidian.py
+++ b/e2e/helpers/obsidian.py
@@ -131,6 +131,13 @@ class ObsidianInstance:
             "debounceMs": 500,
             "liveSyncEnabled": True,
             "maxFileSizeMB": 5,
+            # Ship client logs suite-wide (default is off). Every device's
+            # receive/materialize lines (categories channel/ws/pull) then land
+            # in client_logs, correlated to the #908 server breadcrumbs, so a
+            # delivery flake's FIRST failing run carries client-side evidence
+            # (non-deterministic flakes can't be reproduced on demand). Read by
+            # helpers/log_oracle.py::wait_for_delivery.
+            "remoteLoggingEnabled": True,
         }
         # Explicitly pin the file-level CRDT sync path (spec §12a) for the
         # dedicated CRDT job. NOTE: since plugin #148 enableCrdt DEFAULTS to

--- a/e2e/tests/test_10_rename_propagation.py
+++ b/e2e/tests/test_10_rename_propagation.py
@@ -6,7 +6,8 @@ mv would not trigger the plugin's rename handler).
 
 import pytest
 
-from helpers.vault import read_note, wait_for_file, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import read_note, write_note
 
 
 @pytest.mark.asyncio
@@ -34,6 +35,6 @@ async def test_rename_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     await cdp_b.trigger_full_sync()
 
     # Verify: B has new path, does NOT have old path
-    b_content = wait_for_file(vault_b, new_path, timeout=10)
+    b_content = wait_for_delivery(vault_b, new_path, api_sync, timeout=10)
     assert "Rename Test" in b_content, "B should have the renamed file"
     assert not (vault_b / old_path).exists(), "B should not have the old path"

--- a/e2e/tests/test_50_channel_topic_enforcement.py
+++ b/e2e/tests/test_50_channel_topic_enforcement.py
@@ -16,7 +16,8 @@ import time
 
 import pytest
 
-from helpers.vault import wait_for_file, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import write_note
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +100,7 @@ async def test_reconnect_rejoins_correct_topic(vault_a, vault_b, cdp_a, cdp_b, a
 
     # B should receive via the reconnected channel
     t0 = time.monotonic()
-    b_content = wait_for_file(vault_b, path, timeout=RT_TIMEOUT)
+    b_content = wait_for_delivery(vault_b, path, api_sync, timeout=RT_TIMEOUT)
     elapsed = time.monotonic() - t0
     logger.info("LATENCY [topic_reconnect]: %.3fs", elapsed)
 
@@ -133,5 +134,5 @@ async def test_live_sync_still_works_after_all_tests(
     write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
-    b_content = wait_for_file(vault_b, path, timeout=RT_TIMEOUT)
+    b_content = wait_for_delivery(vault_b, path, api_sync, timeout=RT_TIMEOUT)
     assert "Live sync still works" in b_content

--- a/e2e/tests/test_78_hash_only_live_update.py
+++ b/e2e/tests/test_78_hash_only_live_update.py
@@ -16,7 +16,8 @@ import time
 
 import pytest
 
-from helpers.vault import wait_for_content, wait_for_file
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import wait_for_content
 
 PATH = "E2E/HashOnlyLive.md"
 
@@ -28,7 +29,7 @@ async def test_hash_only_live_update(vault_b, cdp_b, api_sync):
     # failed attempt 1 makes attempt 2's identical create hit the server's
     # deliberate hash-equal broadcast-skip (an idempotent re-push is a no-op —
     # no version bump, no note_changed), so B never gets the live event and
-    # wait_for_file times out. That makes the rerun DETERMINISTICALLY fail
+    # wait_for_delivery times out. That makes the rerun DETERMINISTICALLY fail
     # rather than retry. Soft-delete first so every attempt's create is a fresh,
     # broadcasting insert. (Same rerun-safety pattern as test_79/test_80.)
     api_sync.delete_note(PATH)
@@ -38,7 +39,7 @@ async def test_hash_only_live_update(vault_b, cdp_b, api_sync):
 
     # 1. Create via API → B receives the broadcast and materializes the file.
     api_sync.create_note(PATH, "# HashLive v1\n\noriginal body")
-    content = wait_for_file(vault_b, PATH, timeout=30)
+    content = wait_for_delivery(vault_b, PATH, api_sync, timeout=30)
     assert "HashLive v1" in content
 
     # 2. Update via API → differing content_hash → B applies the new body.

--- a/e2e/tests/test_79_attachment_move_convergence.py
+++ b/e2e/tests/test_79_attachment_move_convergence.py
@@ -18,7 +18,8 @@ import asyncio
 
 import pytest
 
-from helpers.vault import wait_for_binary, wait_for_file_gone
+from helpers.log_oracle import wait_for_binary_delivery
+from helpers.vault import wait_for_file_gone
 
 # B-side convergence (pull + blob fetch) can lag under parallel CI load — give
 # it more room than the suite's 15s default.
@@ -51,7 +52,7 @@ async def test_web_move_converges_via_pull(vault_a, vault_b, cdp_a, cdp_b, api_s
     assert api_sync.upload_attachment(old_path, TINY_PNG, "image/png") == 200
     api_sync.wait_for_attachment(old_path)
     await cdp_b.trigger_full_sync()
-    wait_for_binary(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
+    wait_for_binary_delivery(vault_b, old_path, api_sync, timeout=CONVERGE_TIMEOUT)
 
     # Web-originated move: repoint live row + insert old-path tombstone.
     assert api_sync.rename_attachment(old_path, new_path) == 200
@@ -61,7 +62,7 @@ async def test_web_move_converges_via_pull(vault_a, vault_b, cdp_a, cdp_b, api_s
     # B converges on its next pull: the tombstone trashes old, the repointed row
     # writes new — no duplicate left at the old path.
     await cdp_b.trigger_full_sync()
-    assert wait_for_binary(vault_b, new_path, timeout=CONVERGE_TIMEOUT) == TINY_PNG
+    assert wait_for_binary_delivery(vault_b, new_path, api_sync, timeout=CONVERGE_TIMEOUT) == TINY_PNG
     wait_for_file_gone(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
 
 
@@ -83,7 +84,7 @@ async def test_web_move_converges_after_offline_window(
     assert api_sync.upload_attachment(old_path, TINY_PNG, "image/png") == 200
     api_sync.wait_for_attachment(old_path)
     await cdp_b.trigger_full_sync()
-    wait_for_binary(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
+    wait_for_binary_delivery(vault_b, old_path, api_sync, timeout=CONVERGE_TIMEOUT)
 
     # Take B offline so it misses the ephemeral move broadcasts entirely.
     await cdp_b.wait_for_stream_connected(timeout=10)
@@ -100,5 +101,5 @@ async def test_web_move_converges_after_offline_window(
     # repointed row(new). B converges with no duplicate.
     await cdp_b.reconnect_stream()
     await cdp_b.trigger_full_sync()
-    assert wait_for_binary(vault_b, new_path, timeout=CONVERGE_TIMEOUT) == TINY_PNG
+    assert wait_for_binary_delivery(vault_b, new_path, api_sync, timeout=CONVERGE_TIMEOUT) == TINY_PNG
     wait_for_file_gone(vault_b, old_path, timeout=CONVERGE_TIMEOUT)

--- a/e2e/tests/test_80_web_attachment_upload.py
+++ b/e2e/tests/test_80_web_attachment_upload.py
@@ -15,7 +15,7 @@ covers the web-origin contract end to end.
 
 import pytest
 
-from helpers.vault import wait_for_binary
+from helpers.log_oracle import wait_for_binary_delivery
 
 # B-side convergence (pull + blob fetch) can lag under parallel CI load — give
 # it more room than the suite's 15s default. Matches test_79.
@@ -44,4 +44,4 @@ async def test_web_upload_converges_via_pull(vault_a, vault_b, cdp_a, cdp_b, api
 
     # B converges on its next explicit pull — the deterministic convergence path.
     await cdp_b.trigger_full_sync()
-    assert wait_for_binary(vault_b, path, timeout=CONVERGE_TIMEOUT) == TINY_PNG
+    assert wait_for_binary_delivery(vault_b, path, api_sync, timeout=CONVERGE_TIMEOUT) == TINY_PNG

--- a/e2e/tests/test_81_suitewide_remote_logging.py
+++ b/e2e/tests/test_81_suitewide_remote_logging.py
@@ -1,0 +1,47 @@
+"""Test 81: suite-wide remote logging is on by default.
+
+Regression guard for the harness seed in helpers/obsidian.py
+(``remoteLoggingEnabled: True``). Unlike test_16, this test NEVER calls
+``enable_remote_logging`` — the whole point is that every device already
+ships client logs without a per-test opt-in, so a delivery flake's first
+failing run carries client-side evidence (consumed by
+helpers/log_oracle.py). If someone drops the seed, this fails loudly.
+"""
+
+import time
+
+import pytest
+
+from helpers.vault import write_note
+
+
+@pytest.mark.asyncio
+async def test_client_logs_ship_without_opt_in(vault_a, cdp_a, api_sync):
+    # NOTE: no cdp_a.enable_remote_logging() — capture must be on from the seed.
+
+    # Generate plugin activity so there is something to ship.
+    write_note(vault_a, "E2E/Rlog81/trigger.md", "# Rlog81\nForce rlog entries")
+    api_sync.wait_for_note("E2E/Rlog81/trigger.md", timeout=15)
+    await cdp_a.trigger_full_sync()
+    await cdp_a.flush_remote_logs()
+
+    plugin_categories = {"push", "pull", "lifecycle", "pacer", "channel", "ws"}
+    plugin_logs = []
+    logs = []
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        logs = api_sync.get_logs(limit=100).get("logs", [])
+        plugin_logs = [
+            l for l in logs
+            if l.get("category") in plugin_categories and l.get("plugin_version")
+        ]
+        if plugin_logs:
+            break
+        await cdp_a.flush_remote_logs()
+
+    assert len(plugin_logs) >= 1, (
+        "Suite-wide remote logging appears OFF: no plugin-generated log shipped "
+        "without an explicit enable_remote_logging() call. Check the "
+        "remoteLoggingEnabled seed in helpers/obsidian.py. "
+        f"Categories seen: {[l.get('category') for l in logs]}"
+    )

--- a/e2e/unit/test_log_oracle.py
+++ b/e2e/unit/test_log_oracle.py
@@ -1,11 +1,11 @@
 """Unit tests for the delivery log-oracle (helpers/log_oracle.py).
 
-Pure logic — no stack, no fixtures. The e2e root conftest boots the full
-Obsidian stack via a session-autouse fixture, so run these with confcutdir
-to skip it:
+Pure logic — no stack, no fixtures. Lives under e2e/unit/ (standalone
+pytest rootdir + a conftest that puts e2e/ on sys.path) so e2e/conftest.py
+(the Obsidian/auth session-autouse fixtures) never loads. Runs in CI via
+the "Harness unit tests" step; locally:
 
-    cd e2e && python3 -m pytest helpers/log_oracle_test.py \
-        --confcutdir helpers -o addopts='' --reruns 0 -p no:cacheprovider -q
+    cd e2e/unit && python3 -m pytest test_log_oracle.py -q
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why

Every e2e-clerk delivery-flake diagnosis is currently server-side inference only. The plugin ships no logs by default (`remoteLoggingEnabled: false`), the harness never enabled them, and only test_16/66 opted in per-test. So a flake's actual failure window runs dark client-side: we can see the server broadcast (or its absence, via the #908 breadcrumbs) but not whether instance B received or materialized the note.

This closes that blind spot and turns the log stream into a test oracle.

## What

- **Suite-wide capture (Part 1):** seed `remoteLoggingEnabled: True` in `helpers/obsidian.py`. Every device now ships its receive/materialize lines (categories `channel`/`ws`/`pull`) into `client_logs`, so the FIRST failing run carries client-side evidence (non-deterministic flakes cannot be reproduced on demand).
- **Delivery oracle (Part 3):** `helpers/log_oracle.py::wait_for_delivery` is a drop-in superset of `wait_for_file`. On success it is identical (polls the vault, returns content, no network). On timeout it queries `GET /logs` and reports the causal-chain gap, e.g. `received=yes materialized=no` (server delivered, client never wrote) instead of a blank 30s stall. `wait_for_binary_delivery` is the attachment counterpart (waits for a non-empty binary, mines the `Attachment applied/created:` signatures).
- **Retrofit (Part 4):** the delivery family now uses the oracle: notes test_78/10/50 (`wait_for_delivery`), attachments test_79/80 (`wait_for_binary_delivery`; `wait_for_file_gone` deletion checks unchanged). New **test_81** is a regression guard: client logs must ship without an explicit `enable_remote_logging()` opt-in.

## Attribution note (ground truth)

e2e `vault_a` and `vault_b` share one user AND one `client_id`, and `client_logs` has no per-instance column, so a log row cannot be attributed to instance B by any field. The oracle disambiguates the receiver by **category** (origin logs under `push`; receiver under `pull`/`ws`/`channel`) plus the path in the message. That holds for the "A creates / B receives" delivery tests where B is the sole materializer. A per-instance `device_id` is tracked separately (plugin + backend); once it lands the oracle can key on the instance directly.

## Testing

- Oracle logic is unit-tested in `e2e/unit/test_log_oracle.py` (8 tests, note + attachment variants). These run in CI via the existing **Harness unit tests** step (`cd e2e/unit && pytest .`, stack-free), now 14 harness unit tests total. Locally: `cd e2e/unit && python3 -m pytest test_log_oracle.py -q`.
- Stack-level behavior (the seed shipping logs, retrofits under real sync) is validated by the **e2e-clerk / e2e-crdt** CI jobs. Confirmed green: e2e-clerk ran the full suite (85 passed, 0 failed, 0 skipped) with all six touched tests collected.

## Follow-ups (out of scope here)

- Consume `device_id` in the oracle once the plugin/backend attribution change merges (then it keys on the instance directly instead of category + path).

Design spec: Engram vault `50 Engineering/_Superpowers Specs/2026-07-04-remote-logging-e2e-oracle-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)