### PR TITLE
fix(e2e): guard note-content wait helpers against 0-byte read race

### DIFF
--- a/e2e/helpers/log_oracle.py
+++ b/e2e/helpers/log_oracle.py
@@ -105,7 +105,13 @@ def wait_for_delivery(
     full = Path(vault_path) / rel_path
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if full.exists():
+        # Non-empty guard matches wait_for_binary_delivery: sync creates the
+        # file then writes the body, so a bare exists() check can return "" in
+        # the 0-byte window (the read-before-flush race). Returning "" makes the
+        # caller's substring assert fail WITHOUT this oracle's causal-chain
+        # diagnostic ever firing — so wait past the empty window like the
+        # binary variant does.
+        if full.exists() and full.stat().st_size > 0:
             return full.read_text(encoding="utf-8")
         time.sleep(poll)
     raise _timeout_error(rel_path, api_sync, timeout, _NOTE_MATERIALIZE)

--- a/e2e/helpers/vault.py
+++ b/e2e/helpers/vault.py
@@ -34,11 +34,18 @@ def delete_note(vault_path: Path, rel_path: str) -> None:
 def wait_for_file(
     vault_path: Path, rel_path: str, timeout: float = 15, poll: float = 0.3
 ) -> str:
-    """Poll until file exists, return content. Raise TimeoutError."""
+    """Poll until file exists and is non-empty, return content. Raise TimeoutError.
+
+    The non-empty guard mirrors wait_for_binary: sync materializes a note by
+    creating the file, then writing its body, so a bare exists() check can
+    catch the 0-byte window and return "" — the read-before-flush race behind
+    intermittent `assert "x" in ""` failures. No delivery test waits for a
+    genuinely-empty note (test_27 uses read_note), so requiring content is safe.
+    """
     full = vault_path / rel_path
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if full.exists():
+        if full.exists() and full.stat().st_size > 0:
             return full.read_text(encoding="utf-8")
         time.sleep(poll)
     raise TimeoutError(f"File {rel_path} did not appear within {timeout}s")

--- a/e2e/tests/test_50_channel_topic_enforcement.py
+++ b/e2e/tests/test_50_channel_topic_enforcement.py
@@ -111,13 +111,13 @@ async def test_reconnect_rejoins_correct_topic(vault_a, vault_b, cdp_a, cdp_b, a
 async def test_live_sync_still_works_after_all_tests(
     vault_a, vault_b, cdp_a, cdp_b, api_sync
 ):
-    """Smoke test: basic live sync still works at the end of the test suite.
+    """Smoke test: basic live sync still works.
 
     Guards against test pollution — if earlier tests leaked state or broke
-    auth, this catches it. Under xdist --dist=loadfile this runs last
-    within the worker that owns this file (all four tests stay co-located),
-    so "after all tests" still means after every test that mutated this
-    worker's Obsidian instances.
+    auth, this catches it. NOTE: under xdist --dist=loadfile the four tests in
+    this file stay co-located on one worker but run in collection order, so
+    this fires mid-suite (not literally last) — it is a live-sync smoke check,
+    not a guaranteed after-everything canary.
     """
     for _ in range(20):
         a_ok = await cdp_a.check_stream_connected()

--- a/e2e/unit/test_log_oracle.py
+++ b/e2e/unit/test_log_oracle.py
@@ -52,6 +52,40 @@ def test_returns_content_when_file_appears(tmp_path):
     assert api.get_calls == 0
 
 
+def test_zero_byte_note_is_not_ready(tmp_path):
+    """A 0-byte note is the read-before-flush window, not a delivery → keep waiting.
+
+    Regression for the bug where wait_for_delivery returned "" the instant the
+    file existed, so a caller's `assert "x" in ""` failed WITHOUT this oracle's
+    causal-chain diagnostic ever firing (test_50 line 138).
+    """
+    rel = "E2E/Empty.md"
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_text("", encoding="utf-8")
+    api = _FakeApi(logs=[])
+
+    with pytest.raises(TimeoutError):
+        wait_for_delivery(tmp_path, rel, api, timeout=0.1, poll=0.02)
+
+
+def test_waits_past_empty_window_then_returns_content(tmp_path):
+    """File appears empty first, gets its body a beat later → returns the body."""
+    import threading
+
+    rel = "E2E/Late.md"
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_text("", encoding="utf-8")  # 0-byte window, as sync creates it
+    threading.Timer(0.1, full.write_text, args=("flushed body",)).start()
+    api = _FakeApi(raise_on_get=True)  # must succeed without touching logs
+
+    content = wait_for_delivery(tmp_path, rel, api, timeout=2, poll=0.02)
+
+    assert content == "flushed body"
+    assert api.get_calls == 0
+
+
 def test_timeout_reports_received_but_not_materialized(tmp_path):
     """Server delivered (channel Event) but client never wrote → pointed diagnosis."""
     rel = "E2E/Stuck.md"

--- a/e2e/unit/test_vault.py
+++ b/e2e/unit/test_vault.py
@@ -1,0 +1,52 @@
+"""Unit tests for the vault wait helpers (helpers/vault.py).
+
+Pure filesystem logic — no stack, no fixtures. Runs in CI via the "Harness
+unit tests" step; locally:
+
+    cd e2e/unit && python3 -m pytest test_vault.py -q
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from helpers.vault import wait_for_file
+
+
+def test_wait_for_file_returns_content(tmp_path):
+    """Returns content once the file exists with a non-empty body."""
+    rel = "E2E/Note.md"
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_text("body", encoding="utf-8")
+
+    assert wait_for_file(tmp_path, rel, timeout=1, poll=0.02) == "body"
+
+
+def test_wait_for_file_skips_zero_byte_window(tmp_path):
+    """A 0-byte file is the read-before-flush window — keep waiting, don't return "".
+
+    Regression for the race behind intermittent `assert "x" in ""` failures:
+    sync creates the file, then writes the body, and a bare exists() check
+    returned "" in between.
+    """
+    rel = "E2E/Empty.md"
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_text("", encoding="utf-8")
+
+    with pytest.raises(TimeoutError):
+        wait_for_file(tmp_path, rel, timeout=0.1, poll=0.02)
+
+
+def test_wait_for_file_waits_past_empty_then_returns(tmp_path):
+    """Empty first, body flushed a beat later → returns the body, not ""."""
+    rel = "E2E/Late.md"
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_text("", encoding="utf-8")
+    threading.Timer(0.1, full.write_text, args=("flushed",)).start()
+
+    assert wait_for_file(tmp_path, rel, timeout=2, poll=0.02) == "flushed"


### PR DESCRIPTION
## Root cause

Recurring `e2e-clerk` flakes in the live-sync family (e.g. `test_50` → `assert 'Live sync still works' in ''`) were **not** a Clerk user-cleanup issue — the hourly reaper is healthy. The real bug is a **0-byte read-before-flush race** in the note-content wait helpers.

Sync materializes a note on the receiver by **creating the file, then writing its body**. Both `wait_for_file` and `wait_for_delivery` returned content the instant `full.exists()` was true — catching the empty window and returning `""`, which then fails the caller's `assert "x" in b_content`.

Their binary siblings (`wait_for_binary`, `wait_for_binary_delivery`) already guard `st_size > 0`. The note variants were simply inconsistent.

## Fix

Add the same `st_size > 0` guard to both helpers (two lines). This is at the source, so it covers every racy caller — `test_50/10/78` (via the oracle) and `test_23/30/41/43/47/48/49` (via `wait_for_file`) — with no per-test churn.

For `wait_for_delivery` this also **restores the #909 oracle's diagnostic**: a genuine delivery miss now reaches the causal-chain `TimeoutError` (`received=/materialized=`) instead of returning `""` and failing the assert blindly. So if `test_50` still fails after this, it fails *loudly* pointing at the real gap.

Also corrected `test_50`'s docstring: under `--dist=loadfile` it runs mid-suite in collection order, not "last" (the log showed it at 23%) — this false invariant misdirected earlier debugging.

## Tests

Stack-free regression tests in `e2e/unit/` (zero-byte-not-ready + waits-past-empty-window for both helpers). `19 passed` locally. Full Obsidian e2e verification runs in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)