### PR TITLE
test(e2e): tree-ops edge coverage (offline catch-up + delete-open-note) + 3 fixes

### DIFF
--- a/frontend/e2e/tree-ops-sync.spec.ts
+++ b/frontend/e2e/tree-ops-sync.spec.ts
@@ -135,6 +135,98 @@ test.describe("web tree ops sync (web to web)", () => {
 		await ctxB.close();
 	});
 
+	// The two tests above always anchor both tabs on a SURVIVING note, so
+	// neither tab ever ends up viewing the note that gets deleted. This is the
+	// gap: what happens when the note you are looking at gets deleted, both
+	// when you (the acting tab) delete it and when another tab (the observer)
+	// deletes it out from under you.
+	test("deleting the open note converges gracefully for both the acting and observer tab", async ({
+		browser,
+		baseURL,
+	}) => {
+		const email = `e2e-tree-delopen-${Date.now()}@test.com`;
+		const token = await registerAndLogin(baseURL!, email);
+		const vault = await createVault(baseURL!, token, `treedelopen-${Date.now()}`);
+		const { id: doomedId } = await upsertNote(
+			baseURL!,
+			token,
+			vault.id,
+			"doomed.md",
+			"doomed body\n",
+		);
+		// A surviving note. Not navigated to, just proof the vault isn't empty.
+		await upsertNote(baseURL!, token, vault.id, "survivor.md", "survivor body\n");
+
+		const ctxA = await browser.newContext();
+		const pageA = await ctxA.newPage();
+		const ctxB = await browser.newContext();
+		const pageB = await ctxB.newPage();
+
+		const pageErrorsA: Error[] = [];
+		const pageErrorsB: Error[] = [];
+		pageA.on("pageerror", (err) => pageErrorsA.push(err));
+		pageB.on("pageerror", (err) => pageErrorsB.push(err));
+
+		// Both tabs are anchored ON the note that is about to be deleted.
+		await signInForNote(pageA, email, vault.id, doomedId);
+		await signInForNote(pageB, email, vault.id, doomedId);
+
+		await expect(row(pageA, "doomed")).toBeVisible({ timeout: 10_000 });
+		await expect(row(pageB, "doomed")).toBeVisible({ timeout: 10_000 });
+
+		// Tab A deletes the note it is currently viewing (the real UI path).
+		await openContextMenu(pageA, "doomed");
+		await pickAction(pageA, "Delete");
+		await confirmDelete(pageA);
+
+		// Tree convergence in both tabs.
+		await expect(row(pageA, "doomed")).toHaveCount(0, { timeout: 10_000 });
+		await expect(row(pageB, "doomed")).toHaveCount(0, { timeout: 10_000 });
+
+		// OBSERVED behavior (found by running this test against main, not
+		// assumed): before the two root-cause fixes bundled with this test,
+		// BOTH tabs got stuck forever showing the already-deleted note's stale
+		// content, with no error, no redirect, no signal it was gone. Two
+		// distinct bugs converged on that one symptom:
+		//   1. The acting tab's `useBatchDeleteNotes`/`useDeleteNote` onMutate
+		//      called `qc.removeQueries(["note", vaultId, id])`, which destroys
+		//      the cached Query object outright. That orphans the CURRENTLY
+		//      MOUNTED useNote(id) observer (NotePage on the very note you just
+		//      deleted): nothing forces it to reconnect to a freshly-built
+		//      query, so it renders the last-known content forever. Fixed by
+		//      swapping to `invalidateQueries`, which refetches the SAME Query
+		//      object in place so every existing observer sees the result.
+		//   2. The backend's delete broadcast (`Notes.broadcast_change/4`, used
+		//      by delete_note/3, batch_delete_notes/3, and the folder-delete
+		//      cascade) never included the note's `id` in the `note_changed`
+		//      payload, only `path`. The web client's per-id invalidation
+		//      (`channel.ts` `handleNoteChanged`) is gated on `payload.id !==
+		//      undefined`, so the observer tab's id-keyed cache entry was NEVER
+		//      invalidated, only a defunct path-keyed one. Fixed by threading
+		//      the note id through to the broadcast for every "the note is
+		//      really gone" call site.
+		// With both fixed, useNote(id) refetches by id in both tabs, the
+		// backend 404s ("not found"), and NotePage's `error` branch renders
+		// "Failed to load note: not found" in place of the editor. The
+		// route/URL is left untouched (no redirect). That is the graceful
+		// state this test locks in: no dead editor showing stale content, no
+		// crash, no infinite spinner, just an explicit not-found message.
+		await expect(pageA).toHaveURL(new RegExp(`/note/${doomedId}`));
+		await expect(pageA.getByText(/Failed to load note/u)).toBeVisible({ timeout: 10_000 });
+
+		await expect(pageB).toHaveURL(new RegExp(`/note/${doomedId}`));
+		await expect(pageB.getByText(/Failed to load note/u)).toBeVisible({ timeout: 10_000 });
+
+		// No crash in either tab: the CRDT doc teardown (closeDoc fires from the
+		// effect cleanup once `note` flips to the error state and its derived
+		// `path` goes to null) must not throw an uncaught error.
+		expect(pageErrorsA).toEqual([]);
+		expect(pageErrorsB).toEqual([]);
+
+		await ctxA.close();
+		await ctxB.close();
+	});
+
 	test("move note propagates to a second tab", async ({ browser, baseURL }) => {
 		const email = `e2e-tree-mv-${Date.now()}@test.com`;
 		const token = await registerAndLogin(baseURL!, email);

--- a/frontend/e2e/tree-ops-sync.spec.ts
+++ b/frontend/e2e/tree-ops-sync.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import {
 	createFolder,
 	createVault,
@@ -15,6 +15,43 @@ import {
 	pickMoveTarget,
 	row,
 } from "./support/tree";
+
+type WSRoute = Parameters<Parameters<Page["routeWebSocket"]>[1]>[0];
+
+// Gates the app's own Phoenix socket (proxied through Vite dev at /socket)
+// so a test can simulate "this tab's realtime connection is down" without
+// touching HTTP. Deliberately narrower than `context.setOffline`: a full
+// network cutoff also kills Vite's OWN unrelated HMR websocket, and the dev
+// client's reconnect-recovery for THAT socket forces a full `location.reload()`
+// (see node_modules/vite/dist/client/client.mjs, "vite:ws:disconnect" handler),
+// which races the network as it comes back and can crash the tab with an
+// unrecoverable "Failed to fetch dynamically imported module" error. That is
+// a Vite-dev-only artifact, not a defect in the app's reconnect/cursor-sync
+// path, so this gate targets only the `/socket` pathname the Phoenix channel
+// uses, leaving Vite's HMR socket untouched.
+async function installSocketGate(
+	page: Page,
+): Promise<{ cut: () => Promise<void>; restore: () => void }> {
+	let blocked = false;
+	let current: WSRoute | null = null;
+	await page.routeWebSocket(/\/socket/u, (ws) => {
+		current = ws;
+		if (blocked) {
+			ws.close();
+			return;
+		}
+		ws.connectToServer();
+	});
+	return {
+		cut: async () => {
+			blocked = true;
+			await current?.close();
+		},
+		restore: () => {
+			blocked = false;
+		},
+	};
+}
 
 test.describe("web tree ops sync (web to web)", () => {
 	test("rename note propagates to a second tab", async ({ browser, baseURL }) => {
@@ -332,6 +369,126 @@ test.describe("web tree ops sync (web to web)", () => {
 		// Predicted red: with no descendant notes, the backend may emit no
 		// broadcast, so tab B never invalidates and the folder lingers.
 		await expect(row(pageB, "Empty")).toHaveCount(0, { timeout: 10_000 });
+
+		await ctxA.close();
+		await ctxB.close();
+	});
+
+	// Reconnect catch-up: tab B's socket is cut while the op happens in tab A,
+	// so B never sees the live broadcast. On reconnect the socket's onOpen
+	// fires runCursorSync, which pulls /sync/changes and feeds rows through
+	// the same invalidation pipeline as a live event. This is a distinct code
+	// path from the live-broadcast tests above and was, until this test,
+	// untested.
+	//
+	// KNOWN BUG (not a frontend defect): `/sync/changes` 500s on every call
+	// that reaches `Engram.Sync.record_cursor/4`, i.e. every call from a real
+	// client, because `client.ts` always sends `X-Device-Id` and the
+	// `vault_device_cursors` table (added in
+	// priv/repo/migrations/20260616130000_cursor_pull_expand.exs) was never
+	// granted to the `engram_app` role the write runs as (every sibling
+	// no-RLS table, e.g. idempotency_keys/processed_webhook_events, has an
+	// explicit `GRANT ... TO engram_app` in its migration; this one doesn't).
+	// `information_schema.role_table_grants` confirms `engram_app` has zero
+	// privileges on `vault_device_cursors`. The 500 happens after the
+	// changes page is already computed, so the client gets nothing and
+	// `runCursorSync`'s promise rejects (unhandled), silently killing catch-up
+	// for every focus/reconnect trigger, not just this offline scenario.
+	// Fix: a new migration granting SELECT/INSERT/UPDATE on
+	// vault_device_cursors to engram_app. Out of scope for this frontend e2e
+	// change; tracked here via test.fail() until fixed.
+	test("offline empty-folder delete catches up on reconnect", async ({ browser, baseURL }) => {
+		test.setTimeout(60_000);
+		test.fail(true, "vault_device_cursors missing GRANT to engram_app; see comment above");
+		const email = `e2e-tree-offdel-${Date.now()}@test.com`;
+		const token = await registerAndLogin(baseURL!, email);
+		const vault = await createVault(baseURL!, token, `treeoffdel-${Date.now()}`);
+		await createFolder(baseURL!, token, vault.id, "OfflineEmpty");
+		const { id: anchorId } = await upsertNote(baseURL!, token, vault.id, "anchor.md", "anchor\n");
+
+		const ctxA = await browser.newContext();
+		const pageA = await ctxA.newPage();
+		const ctxB = await browser.newContext();
+		const pageB = await ctxB.newPage();
+		const gate = await installSocketGate(pageB);
+		await signInForNote(pageA, email, vault.id, anchorId);
+		await signInForNote(pageB, email, vault.id, anchorId);
+
+		await expect(row(pageA, "OfflineEmpty")).toBeVisible({ timeout: 10_000 });
+		await expect(row(pageB, "OfflineEmpty")).toBeVisible({ timeout: 10_000 });
+
+		// Tab B's realtime connection goes dark, so it misses the live
+		// broadcast entirely (and every reconnect attempt is cut too).
+		await gate.cut();
+
+		await openContextMenu(pageA, "OfflineEmpty");
+		await pickAction(pageA, "Delete");
+		await confirmDelete(pageA);
+		await expect(row(pageA, "OfflineEmpty")).toHaveCount(0, { timeout: 10_000 });
+
+		// Let B's socket reconnect for real, and nudge the focus-based
+		// cursor-sync trigger too, since the socket's own reconnect jitter
+		// can be slow and unreliable in a headless run.
+		gate.restore();
+		await pageB.bringToFront();
+		await pageB.evaluate(() => window.dispatchEvent(new Event("focus")));
+
+		// Convergence via catch-up, not live broadcast: the marker-only delete
+		// (no descendant notes) is the sharpest case for a feed that skips
+		// folder markers.
+		await expect(row(pageB, "OfflineEmpty")).toHaveCount(0, { timeout: 20_000 });
+
+		await ctxA.close();
+		await ctxB.close();
+	});
+
+	// See the KNOWN BUG note above the previous test: the same
+	// vault_device_cursors GRANT gap makes /sync/changes 500 here too.
+	test("offline folder rename catches up on reconnect", async ({ browser, baseURL }) => {
+		test.setTimeout(60_000);
+		test.fail(true, "vault_device_cursors missing GRANT to engram_app; see comment above");
+		const email = `e2e-tree-offrnf-${Date.now()}@test.com`;
+		const token = await registerAndLogin(baseURL!, email);
+		const vault = await createVault(baseURL!, token, `treeoffrnf-${Date.now()}`);
+		await createFolder(baseURL!, token, vault.id, "OfflineOldName");
+		const { id: childId } = await upsertNote(
+			baseURL!,
+			token,
+			vault.id,
+			"OfflineOldName/child.md",
+			"child body\n",
+		);
+
+		const ctxA = await browser.newContext();
+		const pageA = await ctxA.newPage();
+		const ctxB = await browser.newContext();
+		const pageB = await ctxB.newPage();
+		const gate = await installSocketGate(pageB);
+		await signInForNote(pageA, email, vault.id, childId);
+		await signInForNote(pageB, email, vault.id, childId);
+
+		await expect(row(pageA, "OfflineOldName")).toBeVisible({ timeout: 10_000 });
+		await expect(row(pageB, "OfflineOldName")).toBeVisible({ timeout: 10_000 });
+
+		await gate.cut();
+
+		await openContextMenu(pageA, "OfflineOldName");
+		await pickAction(pageA, "Rename");
+		await commitRename(pageA, "OfflineNewName");
+		await expect(row(pageA, "OfflineNewName")).toBeVisible({ timeout: 10_000 });
+		await expect(row(pageA, "OfflineOldName")).toHaveCount(0);
+
+		gate.restore();
+		await pageB.bringToFront();
+		await pageB.evaluate(() => window.dispatchEvent(new Event("focus")));
+
+		// Convergence via catch-up: renamed folder appears, old name gone, and
+		// the child is reachable under the new name (cascade re-path survived
+		// the reconnect pull, not just the folder marker's own row).
+		await expect(row(pageB, "OfflineNewName")).toBeVisible({ timeout: 20_000 });
+		await expect(row(pageB, "OfflineOldName")).toHaveCount(0, { timeout: 20_000 });
+		await expandFolder(pageB, "OfflineNewName");
+		await expect(row(pageB, "child")).toBeVisible({ timeout: 20_000 });
 
 		await ctxA.close();
 		await ctxB.close();

--- a/frontend/e2e/tree-ops-sync.spec.ts
+++ b/frontend/e2e/tree-ops-sync.spec.ts
@@ -381,25 +381,19 @@ test.describe("web tree ops sync (web to web)", () => {
 	// path from the live-broadcast tests above and was, until this test,
 	// untested.
 	//
-	// KNOWN BUG (not a frontend defect): `/sync/changes` 500s on every call
-	// that reaches `Engram.Sync.record_cursor/4`, i.e. every call from a real
-	// client, because `client.ts` always sends `X-Device-Id` and the
-	// `vault_device_cursors` table (added in
+	// Previously a KNOWN BUG (not a frontend defect): `/sync/changes` 500'd on
+	// every call that reached `Engram.Sync.record_cursor/4`, i.e. every call
+	// from a real client, because `client.ts` always sends `X-Device-Id` and
+	// the `vault_device_cursors` table (added in
 	// priv/repo/migrations/20260616130000_cursor_pull_expand.exs) was never
 	// granted to the `engram_app` role the write runs as (every sibling
 	// no-RLS table, e.g. idempotency_keys/processed_webhook_events, has an
-	// explicit `GRANT ... TO engram_app` in its migration; this one doesn't).
-	// `information_schema.role_table_grants` confirms `engram_app` has zero
-	// privileges on `vault_device_cursors`. The 500 happens after the
-	// changes page is already computed, so the client gets nothing and
-	// `runCursorSync`'s promise rejects (unhandled), silently killing catch-up
-	// for every focus/reconnect trigger, not just this offline scenario.
-	// Fix: a new migration granting SELECT/INSERT/UPDATE on
-	// vault_device_cursors to engram_app. Out of scope for this frontend e2e
-	// change; tracked here via test.fail() until fixed.
+	// explicit `GRANT ... TO engram_app` in its migration; this one didn't).
+	// Fixed by priv/repo/migrations/20260705120000_grant_vault_device_cursors_
+	// expand.exs. This test now asserts real convergence through the fixed
+	// catch-up path.
 	test("offline empty-folder delete catches up on reconnect", async ({ browser, baseURL }) => {
 		test.setTimeout(60_000);
-		test.fail(true, "vault_device_cursors missing GRANT to engram_app; see comment above");
 		const email = `e2e-tree-offdel-${Date.now()}@test.com`;
 		const token = await registerAndLogin(baseURL!, email);
 		const vault = await createVault(baseURL!, token, `treeoffdel-${Date.now()}`);
@@ -442,11 +436,10 @@ test.describe("web tree ops sync (web to web)", () => {
 		await ctxB.close();
 	});
 
-	// See the KNOWN BUG note above the previous test: the same
-	// vault_device_cursors GRANT gap makes /sync/changes 500 here too.
+	// See the fixed-bug note above the previous test: same catch-up path,
+	// same grant fix.
 	test("offline folder rename catches up on reconnect", async ({ browser, baseURL }) => {
 		test.setTimeout(60_000);
-		test.fail(true, "vault_device_cursors missing GRANT to engram_app; see comment above");
 		const email = `e2e-tree-offrnf-${Date.now()}@test.com`;
 		const token = await registerAndLogin(baseURL!, email);
 		const vault = await createVault(baseURL!, token, `treeoffrnf-${Date.now()}`);

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1674,7 +1674,16 @@ export function useDeleteNote() {
 						: prev,
 				);
 			}
-			qc.removeQueries({ queryKey: noteKey });
+			// invalidateQueries, not removeQueries: removeQueries destroys the
+			// cached Query object outright, which orphans any CURRENTLY MOUNTED
+			// useNote(id) observer (e.g. NotePage on the note you just deleted),
+			// it keeps rendering the last-known content forever, because nothing
+			// forces that specific observer to reconnect to a freshly-built query.
+			// invalidateQueries marks the SAME Query object stale and refetches it
+			// in place (default refetchType "active"), so every existing observer
+			// gets the 404 and NotePage's `error` branch renders correctly instead
+			// of a frozen, already-deleted note. See e2e "deleting the open note".
+			qc.invalidateQueries({ queryKey: noteKey });
 			return ctx;
 		},
 		onError: (err, _vars, ctx) => {
@@ -1926,10 +1935,17 @@ export function useBatchDeleteNotes() {
 				);
 			}
 
-			// Drop any cached note body for the deleted ids so a stale
-			// useNote(id) subscriber 404s on remount instead of rendering.
+			// invalidateQueries, not removeQueries: removeQueries destroys the
+			// cached Query object outright, which orphans any CURRENTLY MOUNTED
+			// useNote(id) observer (e.g. NotePage on the note you just deleted),
+			// it keeps rendering the last-known content forever, because nothing
+			// forces that specific observer to reconnect to a freshly-built query.
+			// invalidateQueries marks the SAME Query object stale and refetches it
+			// in place (default refetchType "active"), so every existing observer
+			// (including a stale remount later) gets the 404 and NotePage's
+			// `error` branch renders correctly. See e2e "deleting the open note".
 			for (const id of ids) {
-				qc.removeQueries({ queryKey: ["note", vaultId, id] });
+				qc.invalidateQueries({ queryKey: ["note", vaultId, id] });
 			}
 
 			return { noteListSnapshots: snapshots };

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1045,9 +1045,9 @@ defmodule Engram.Notes do
             "repath_note_index"
           )
 
-        :ok = broadcast_change(user.id, vault.id, "delete", old_path)
+        :ok = broadcast_change(user.id, vault.id, "delete", old_path, nil)
         decrypted = decrypt_or_raise!(note, user)
-        :ok = broadcast_change(user.id, vault.id, "upsert", note.path, decrypted)
+        :ok = broadcast_change(user.id, vault.id, "upsert", note.path, decrypted, [])
         {:ok, decrypted}
 
       {:ok, {:no_change, note}} ->
@@ -1203,7 +1203,7 @@ defmodule Engram.Notes do
         Enqueue.enqueue(delete_note_index_job(note), "delete_note_index")
       end
 
-    broadcast_change(user.id, vault.id, "delete", path)
+    broadcast_change(user.id, vault.id, "delete", path, note && note.id)
   end
 
   @doc """
@@ -1312,8 +1312,8 @@ defmodule Engram.Notes do
           |> Crypto.decrypt_notes_batch(user)
           |> Enum.zip(notes)
           |> Enum.each(fn
-            {{:ok, note}, _raw} ->
-              broadcast_change(user.id, vault.id, "delete", note.path)
+            {{:ok, note}, raw} ->
+              broadcast_change(user.id, vault.id, "delete", note.path, raw.id)
 
             {{:error, reason}, raw} ->
               # The tombstone committed; only the broadcast is lost. Fail
@@ -2898,7 +2898,7 @@ defmodule Engram.Notes do
             "repath_note_index"
           )
 
-        :ok = broadcast_change(user.id, vault.id, "delete", old_note_path)
+        :ok = broadcast_change(user.id, vault.id, "delete", old_note_path, nil)
 
         # Root cause of a dropped CRDT rebind on cross-tab folder rename: the
         # 4-arity clause below carries no `id`, so a client's id-keyed
@@ -2911,7 +2911,8 @@ defmodule Engram.Notes do
             vault.id,
             "upsert",
             new_path,
-            %{note | path: new_path, folder: new_note_folder}
+            %{note | path: new_path, folder: new_note_folder},
+            []
           )
       end)
 
@@ -3005,7 +3006,7 @@ defmodule Engram.Notes do
       Enum.each(real_notes, fn note ->
         _ = Enqueue.enqueue(delete_note_index_job(note), "delete_note_index")
 
-        :ok = broadcast_change(user.id, vault.id, "delete", note.path)
+        :ok = broadcast_change(user.id, vault.id, "delete", note.path, note.id)
       end)
 
       # Root cause of the empty-folder-lingers-in-tab-B bug: an empty folder's
@@ -3017,7 +3018,7 @@ defmodule Engram.Notes do
       # emission style and position as the real-note loop above: after the
       # Repo.with_tenant transaction returns, so it never fires on rollback.
       Enum.each(markers, fn marker ->
-        :ok = broadcast_change(user.id, vault.id, "delete", marker.folder)
+        :ok = broadcast_change(user.id, vault.id, "delete", marker.folder, nil)
       end)
 
       {:ok, %{deleted: length(matches)}}
@@ -3338,7 +3339,7 @@ defmodule Engram.Notes do
     :ok
   end
 
-  defp broadcast_change(user_id, vault_id, "upsert", path, %Note{} = note, opts \\ []) do
+  defp broadcast_change(user_id, vault_id, "upsert", path, %Note{} = note, opts) do
     # Protocol rev — dual-field transition: the payload carries BOTH
     # `content` and `content_hash` for one release. `content` is dropped the
     # release after the plugin min-version floor covers the hash-only
@@ -3391,14 +3392,33 @@ defmodule Engram.Notes do
     :ok
   end
 
-  @spec broadcast_change(Ecto.UUID.t(), Ecto.UUID.t(), String.t(), String.t()) :: :ok
-  defp broadcast_change(user_id, vault_id, event_type, path) do
-    _ =
-      Broadcast.emit("sync:#{user_id}:#{vault_id}", "note_changed", %{
-        "event_type" => event_type,
-        "path" => path,
-        "vault_id" => vault_id
-      })
+  # `id` may be nil: rename's old-path "delete" signal and the id-less
+  # folder-marker delete legitimately have no note id to carry (the note
+  # either still exists under a new path, or it's a folder, not a note).
+  # When a note is genuinely gone (delete_note/3, batch_delete_notes/3, the
+  # folder-delete cascade's real-note loop), callers MUST pass the id: the web
+  # client's useNote(id) cache is keyed by id, not path, since the URL-by-id
+  # refactor, and only invalidates it `if payload.id !== undefined`. Omitting
+  # id here left a currently-open deleted note's editor stuck showing stale
+  # content forever in any OTHER tab watching the same note, never re-fetched,
+  # never errored. See e2e "deleting the open note" test.
+  @spec broadcast_change(
+          Ecto.UUID.t(),
+          Ecto.UUID.t(),
+          String.t(),
+          String.t(),
+          Ecto.UUID.t() | nil
+        ) :: :ok
+  defp broadcast_change(user_id, vault_id, event_type, path, id) do
+    payload = %{
+      "event_type" => event_type,
+      "path" => path,
+      "vault_id" => vault_id
+    }
+
+    payload = if id, do: Map.put(payload, "id", id), else: payload
+
+    _ = Broadcast.emit("sync:#{user_id}:#{vault_id}", "note_changed", payload)
 
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.627",
+      version: "0.5.628",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260705120000_grant_vault_device_cursors_expand.exs
+++ b/priv/repo/migrations/20260705120000_grant_vault_device_cursors_expand.exs
@@ -1,0 +1,20 @@
+defmodule Engram.Repo.Migrations.GrantVaultDeviceCursorsExpand do
+  use Ecto.Migration
+
+  # phase/expand: pure GRANT, no schema change.
+  #
+  # vault_device_cursors (priv/repo/migrations/20260616130000_cursor_pull_expand.exs)
+  # was created without the sibling GRANT every other no-default-privileges
+  # table carries (see idempotency_keys/processed_webhook_events expand
+  # migrations). Every write to it runs as `engram_app` via `Repo.with_tenant`
+  # (Engram.Sync.record_cursor/4), so the missing grant makes that write fail
+  # with permission denied, which 500s `GET /sync/changes` for any client that
+  # sends `X-Device-Id`, i.e. every real client on reconnect/focus catch-up.
+  def up do
+    execute "GRANT SELECT, INSERT, UPDATE, DELETE ON vault_device_cursors TO engram_app"
+  end
+
+  def down do
+    execute "REVOKE ALL ON vault_device_cursors FROM engram_app"
+  end
+end

--- a/test/engram_web/controllers/sync_changes_test.exs
+++ b/test/engram_web/controllers/sync_changes_test.exs
@@ -60,6 +60,31 @@ defmodule EngramWeb.SyncChangesTest do
     assert row.last_seq == 2
   end
 
+  # Regression: vault_device_cursors (priv/repo/migrations/20260616130000_
+  # cursor_pull_expand.exs) was created without a GRANT to engram_app, unlike
+  # every sibling no-RLS table. Engram.Sync.record_cursor/4 writes to it via
+  # Repo.with_tenant (which drops to the engram_app role), so every real
+  # request carrying X-Device-Id (every real client) hit `permission denied`
+  # and 500'd. Fixed by priv/repo/migrations/20260705120000_grant_vault_device_
+  # cursors_expand.exs. Without that grant this test 500s with a Postgrex
+  # 42501 insufficient_privilege error instead of asserting 200.
+  test "GET /sync/changes with X-Device-Id records the watermark instead of 500ing", %{
+    conn: conn,
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n.md", "content" => "x"})
+
+    assert conn |> get(~p"/api/sync/changes") |> json_response(200)
+
+    {:ok, row} =
+      Engram.Repo.with_tenant(user.id, fn ->
+        Engram.Repo.get_by(Engram.Sync.DeviceCursor, vault_id: vault.id, device_id: "dev-1")
+      end)
+
+    assert row.last_seq == 0
+  end
+
   test "malformed cursor -> 400", %{conn: conn} do
     # A valid query param that is NOT a valid opaque cursor token (decodes but
     # has no "<seq>:<id>" shape) — exercises decode_cursor's {:error, :invalid_cursor}.


### PR DESCRIPTION
## What

Edge-case follow-up to #913 (which covered the happy-path live-convergence tree ops). Adds the two highest-value gaps the review + investigations flagged — **offline reconnect catch-up** and **deleting the currently-open note** — and each test surfaced a real bug, fixed at root cause.

## Tests added (`frontend/e2e/tree-ops-sync.spec.ts`)

1. **Offline reconnect catch-up** (2 tests) — take a tab offline (gate its `/socket` only), perform a tree op in another tab (empty-folder delete, folder rename), reconnect, assert the offline tab converges via `runCursorSync` catch-up. Covers the catch-up path (distinct from live broadcast) that was untested.
2. **Delete the currently-open note** (1 test) — both tabs open on a note, one deletes it; asserts tree convergence + a graceful "not found" terminal state (no stuck editor, no `pageerror`) in **both** the acting and observer tabs.

## Bugs found + fixed

**1. `vault_device_cursors` never granted to `engram_app`** (`priv/repo/migrations/20260705120000_grant_vault_device_cursors_expand.exs`)
The table (added June 16) lacked the explicit `GRANT` every other app table carries. `record_cursor/4` runs as `engram_app` via `Repo.with_tenant`, and `sync_controller.ex:131` hard-matches `:ok`, so a permission-denied 500s **every** `GET /sync/changes` (clients always send `X-Device-Id`), silently breaking reconnect/focus catch-up. Fix: expand-phase `GRANT SELECT, INSERT, UPDATE, DELETE`. Backend regression test (`test/engram_web/controllers/sync_changes_test.exs`) exercises the real `engram_app` role (200-not-500 + persisted watermark), red-without/green-with.
**Prod impact:** very likely none — the deploy runs `Engram.Release.prepare_database` (`ALTER DEFAULT PRIVILEGES`), which auto-grants new tables at migrate time. The bug is *drift* affecting environments that run plain `mix ecto.migrate` without that bootstrap (local dev + CI `e2e-browser`). The explicit grant makes it deterministic everywhere and is defense-in-depth for prod. (Note: the CLAUDE.md claim that the default-privileges catch-all was "removed" is inaccurate — it lives in `prepare_database`, just non-retroactive; doc correction to follow.)

**2. Deleting the open note left both tabs stuck on stale content** (`frontend/src/api/queries.ts`, `lib/engram/notes.ex`)
Two compounding root causes: (a) `useDeleteNote`/`useBatchDeleteNotes` used `removeQueries`, which destroys the query object and orphans the mounted `useNote(id)` observer, so it never re-renders to not-found → `invalidateQueries`; (b) the delete broadcast carried no `id`, so an observer tab's id-keyed cache never invalidated → `broadcast_change/4`→`/5`, threading the note id through the *real* note-delete sites only (rename/move delete-of-old-path and folder-marker deletes correctly pass `nil`, since a renamed note still exists at its new path — this keeps #913's rename fix intact).

## Notes
- Filed #914 for the related dormant backend landmine (`get_or_bootstrap_note` bootstrap-on-enroll + `list_changes_page` marker exclusion).
- Deferred to a later pass: conflict tests (colliding rename / same-named move) and dotted-title-through-real-UI.
- Backend suite green (3467 tests); `tsc`/biome/format/credo/sobelow clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
