### PR TITLE
fix(test): kill two full-suite-load flakes at their roots (#886, #867)

### DIFF
--- a/frontend/src/billing/upgrade-dialog-provider.test.tsx
+++ b/frontend/src/billing/upgrade-dialog-provider.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { setUpgradeHandler } from "@/api/client";
 import { UpgradeDialogProvider, useUpgradeDialog } from "./upgrade-dialog-provider";
 
@@ -25,6 +25,14 @@ function renderWithRouter(ui: React.ReactNode) {
 }
 
 describe("UpgradeDialogProvider", () => {
+	// Pre-pay vitest's cold on-demand transform of the lazy dialog chunk HERE,
+	// outside any findByText timeout window. Under full-suite CPU starvation that
+	// transform (>1s) can blow the render assertion's 5s budget (#867); warming
+	// the module cache first makes every lazy() render resolve fast.
+	beforeAll(async () => {
+		await import("./upgrade-required-dialog");
+	}, 30_000);
+
 	beforeEach(() => {
 		setUpgradeHandler(null);
 	});

--- a/lib/engram/vector/qdrant.ex
+++ b/lib/engram/vector/qdrant.ex
@@ -63,7 +63,9 @@ defmodule Engram.Vector.Qdrant do
 
   def req_opts(:search) do
     put_api_key(
-      receive_timeout: 5_000,
+      # Default 5s fail-fast; overridable per-process so a Bypass test can pin a
+      # generous budget and not misread scheduler starvation as a real timeout.
+      receive_timeout: ServiceConfig.get(:qdrant_search_timeout, 5_000),
       retry: false,
       max_retries: 0,
       connect_options: [protocols: [:http1]]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.628",
+      version: "0.5.629",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/vector/qdrant_req_opts_test.exs
+++ b/test/engram/vector/qdrant_req_opts_test.exs
@@ -37,6 +37,11 @@ defmodule Engram.Vector.QdrantReqOptsTest do
       # Force retries ON so a regression (search using the indexing opts)
       # shows up as extra attempts.
       ServiceConfig.put_override(:qdrant_retry, :transient)
+      # Pin a generous receive_timeout: under full-suite load the BEAM scheduler
+      # can starve the Bypass handler past search's 5s fail-fast, so Req times
+      # out before the 503 lands and the attempt counter reads 0 (#886). We're
+      # asserting attempt COUNT, not fail-fast latency, so a wide budget is safe.
+      ServiceConfig.put_override(:qdrant_search_timeout, 30_000)
       %{bypass: bypass}
     end
 


### PR DESCRIPTION
Two independent unit/component-test flakes, same root shape: **a fixed timeout budget that includes work whose cost spikes under full-suite load**, so scheduler/CPU starvation gets misread as the failure the test asserts on. Bundled per the #916 flake-hardening precedent.

## #886 — `qdrant_req_opts_test` "search makes exactly one attempt on a 503"
Search's `receive_timeout` is a hardcoded 5s fail-fast. Under BEAM scheduler starvation the Bypass handler isn't scheduled in time, so Req returns `{:error, :timeout}` **before** the 503 lands and the attempt counter reads `0` → `assert 0 == 1`.

**Fix:** `req_opts(:search)` now reads `ServiceConfig.get(:qdrant_search_timeout, 5_000)`. In prod builds `ServiceConfig.get/2` is byte-identical to `Application.get_env/3` (the key is unset → 5_000), so **zero prod behavior change**. The Bypass test pins it to 30s. The test asserts attempt *count* (no-retry), not fail-fast *latency*, so a wide budget cannot mask a retry regression — a real regression still shows counter > 1.

## #867 — `upgrade-dialog-provider` "renders dialog when showUpgrade is called"
The dialog is `lazy()`, so the first `findByText` pays vitest's cold on-demand chunk transform (>1s) **inside** the 5s assertion window; under parallel-worker CPU starvation it blows the budget (~5.1s).

**Fix:** pre-pay the transform in `beforeAll` (outside any timed window) so every `lazy()` render hits a warm module cache. Test-only.

## Verification
- `mix test test/engram/vector/qdrant_req_opts_test.exs` → 3/3
- `bunx vitest run src/billing/upgrade-dialog-provider.test.tsx` → 4/4
- `mix format` clean · `mix credo` no issues · biome clean

Neither fix loosens an assertion, so neither can hide a real regression. These are 1/3391 load-induced flakes — CI can't prove the fix, but the mechanism is removed at the root.

Closes #886
Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)