### PR TITLE
fix(e2e): harden two frontend e2e flakes at their roots (#843, #455)

### DIFF
--- a/frontend/e2e/note-live-update.spec.ts
+++ b/frontend/e2e/note-live-update.spec.ts
@@ -80,17 +80,21 @@ test.describe("SPA viewer live-update (#277)", () => {
 		await expect(edA).toContainText("base line.", { timeout: 10_000 });
 		await expect(edB).toContainText("base line.", { timeout: 10_000 });
 
-		// Distinct concurrent edits, one per tab (appending at end-of-doc means
-		// the two inserts land at the same anchor as concurrent CRDT ops; the
-		// CRDT orders them deterministically by client id so both substrings are
-		// always present regardless of order).
+		// Distinct concurrent edits, one per tab, both appended at end-of-doc so
+		// they land at the same anchor as concurrent CRDT ops. Use insertText
+		// (single `insertText` input event → one CM6 transaction → one atomic
+		// CRDT insert) rather than `type` (one op PER CHARACTER): with per-char
+		// ops the two tabs' characters interleave at the shared anchor — still
+		// correct convergence, but each block stops being a contiguous substring
+		// so the toContainText asserts below flake (#843). One atomic op per
+		// block keeps each string contiguous while still racing concurrently.
 		await edA.click();
 		await pageA.keyboard.press("Control+End");
-		await pageA.keyboard.type(" AAA-from-tab-a");
+		await pageA.keyboard.insertText(" AAA-from-tab-a");
 
 		await edB.click();
 		await pageB.keyboard.press("Control+End");
-		await pageB.keyboard.type(" BBB-from-tab-b");
+		await pageB.keyboard.insertText(" BBB-from-tab-b");
 
 		// Both edits must converge in BOTH editors via the CRDT channel.
 		// If either assertion times out here, that is a real CRDT convergence bug

--- a/frontend/e2e/onboarding-ftux.spec.ts
+++ b/frontend/e2e/onboarding-ftux.spec.ts
@@ -24,8 +24,16 @@ function loadAuthState(): {
 
 async function clerkSignIn(page: Page, email: string) {
 	await page.goto("/sign-in/");
+	// global-setup's waitUntilEmailResolvable confirms the email resolves on ONE
+	// Clerk replica, but a later clerk.signIn can hit a lagging replica and still
+	// 'No user found' (#455) — cross-replica eventual consistency, not a logic
+	// bug, so riding it out is the correct handling. The old flat 5×1s=5s budget
+	// was too tight under CI load; back off to a ~20s budget. Any error that is
+	// NOT 'No user found' is a real failure and rethrows immediately.
+	const deadline = Date.now() + 20_000;
+	let backoff = 500;
 	let lastErr: unknown;
-	for (let attempt = 0; attempt < 5; attempt++) {
+	while (Date.now() < deadline) {
 		try {
 			await clerk.signIn({ page, emailAddress: email });
 			lastErr = undefined;
@@ -35,7 +43,8 @@ async function clerkSignIn(page: Page, email: string) {
 				throw err;
 			}
 			lastErr = err;
-			await page.waitForTimeout(1000);
+			await page.waitForTimeout(Math.min(backoff, Math.max(0, deadline - Date.now())));
+			backoff = Math.min(backoff * 2, 4000);
 		}
 	}
 	if (lastErr) {

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.629",
+      version: "0.5.630",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Two frontend e2e flakes, root-caused and fixed without loosening any assertion. Bundled per the #916/#919 flake-hardening pattern.

## #843 — note-live-update CRDT two-tab convergence (contiguity flake)
`page.keyboard.type(" AAA-from-tab-a")` commits **one CRDT op per character**. With two tabs typing at the same end-of-doc anchor, their per-char ops interleave (`… AA` + `BBB-from-tab-b` + `A-from-tab-a`). Convergence is correct and lossless (both editors end identical, all chars present), but each block is no longer a **contiguous substring**, so `toContainText("AAA-from-tab-a")` flakes.

**Fix:** `keyboard.insertText(...)` — a single `insertText` input event → one CM6 transaction → **one atomic CRDT insert** per block. Each block stays contiguous while still racing as a concurrent op at the shared anchor. This matches what the test's own comment already assumed ("the two inserts land at the same anchor as concurrent CRDT ops"). No assertion or timeout weakened.

## #455 — onboarding-ftux Clerk 'No user found' provision race
`global-setup`'s `waitUntilEmailResolvable` confirms the email resolves on **one** Clerk replica, but a later `clerk.signIn` can hit a **lagging replica** and still `No user found` — cross-replica eventual consistency, not a logic bug. The per-test retry was a flat 5×1s=5s, too tight under CI load.

**Fix:** back off to a ~20s budget (0.5s→4s exponential). Any error that is **not** `No user found` still rethrows immediately, so this widens tolerance for the external replica lag without masking a real auth failure. This is the correct handling for an external eventually-consistent dependency (retry/condition-wait), not a bandaid.

## Verification
Static only — these run behind the browser/Clerk e2e stack + secrets, so **CI e2e is the behavioral proof** (same as #919): biome clean on both specs, no TS errors, `mix.exs` bumped 0.5.629→630. `keyboard.insertText` is standard Playwright API.

Closes #843
Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)