### PR TITLE
feat(obs): attribute socket auth rejections + per-user trace attributes

### DIFF
--- a/lib/engram/auth/token_debug.ex
+++ b/lib/engram/auth/token_debug.ex
@@ -2,15 +2,13 @@ defmodule Engram.Auth.TokenDebug do
   @moduledoc """
   Best-effort, NON-verifying peek at a token's header + claims, for attributing
   auth rejections in logs. Never raises, never verifies a signature, never logs
-  raw sub (hashed with sha256-hex).
+  raw sub.
 
-  The sha256 hash here is intentionally NOT the keyed `Engram.Crypto.HMAC.hash_user_id/1`
-  used elsewhere for our internal `users.id`: this module hashes the JWT `sub`
-  claim from an as-yet-unverified, possibly-rejected token, which may be an
-  external issuer's subject id (Clerk, device flow, etc), not our own user id.
-  Reusing the keyed helper would conflate two different id spaces under one
-  key. Plain sha256-hex still gives stable, joinable, non-reversible labels
-  for correlating repeated rejections from the same presented token.
+  `sub_hash` uses the same keyed `Engram.Crypto.HMAC.hash_user_id/1` helper as
+  the `user_id` log metadata in `Engram.Logs`, `UserSocket`, `SyncChannel`, and
+  `CRDTChannel`. For internal JWTs, `sub` is our own `users.id`, so hashing it
+  with the same key produces the same hash used everywhere else, letting a
+  rejected internal-JWT `sub` correlate to that user's other log lines.
   """
 
   @spec metadata(String.t()) :: keyword()
@@ -38,5 +36,5 @@ defmodule Engram.Auth.TokenDebug do
   end
 
   defp hash_sub(nil), do: nil
-  defp hash_sub(sub), do: :crypto.hash(:sha256, sub) |> Base.encode16(case: :lower)
+  defp hash_sub(sub), do: Engram.Crypto.HMAC.hash_user_id(sub)
 end

--- a/lib/engram/auth/token_debug.ex
+++ b/lib/engram/auth/token_debug.ex
@@ -28,13 +28,13 @@ defmodule Engram.Auth.TokenDebug do
 
   defp safe_peek(fun, token) do
     case fun.(token) do
-      {:ok, map} -> map
+      {:ok, map} when is_map(map) -> map
       _ -> %{}
     end
   rescue
     _ -> %{}
   end
 
-  defp hash_sub(nil), do: nil
-  defp hash_sub(sub), do: Engram.Crypto.HMAC.hash_user_id(sub)
+  defp hash_sub(sub) when is_binary(sub), do: Engram.Crypto.HMAC.hash_user_id(sub)
+  defp hash_sub(_), do: nil
 end

--- a/lib/engram/auth/token_debug.ex
+++ b/lib/engram/auth/token_debug.ex
@@ -1,0 +1,42 @@
+defmodule Engram.Auth.TokenDebug do
+  @moduledoc """
+  Best-effort, NON-verifying peek at a token's header + claims, for attributing
+  auth rejections in logs. Never raises, never verifies a signature, never logs
+  raw sub (hashed with sha256-hex).
+
+  The sha256 hash here is intentionally NOT the keyed `Engram.Crypto.HMAC.hash_user_id/1`
+  used elsewhere for our internal `users.id`: this module hashes the JWT `sub`
+  claim from an as-yet-unverified, possibly-rejected token, which may be an
+  external issuer's subject id (Clerk, device flow, etc), not our own user id.
+  Reusing the keyed helper would conflate two different id spaces under one
+  key. Plain sha256-hex still gives stable, joinable, non-reversible labels
+  for correlating repeated rejections from the same presented token.
+  """
+
+  @spec metadata(String.t()) :: keyword()
+  def metadata(token) when is_binary(token) do
+    header = safe_peek(&Joken.peek_header/1, token)
+    claims = safe_peek(&Joken.peek_claims/1, token)
+
+    [
+      alg: header["alg"],
+      kid: header["kid"],
+      iss: claims["iss"],
+      sub_hash: hash_sub(claims["sub"])
+    ]
+  end
+
+  def metadata(_), do: [alg: nil, kid: nil, iss: nil, sub_hash: nil]
+
+  defp safe_peek(fun, token) do
+    case fun.(token) do
+      {:ok, map} -> map
+      _ -> %{}
+    end
+  rescue
+    _ -> %{}
+  end
+
+  defp hash_sub(nil), do: nil
+  defp hash_sub(sub), do: :crypto.hash(:sha256, sub) |> Base.encode16(case: :lower)
+end

--- a/lib/engram_web/plugs/trace_user_attrs.ex
+++ b/lib/engram_web/plugs/trace_user_attrs.ex
@@ -1,0 +1,44 @@
+defmodule EngramWeb.Plugs.TraceUserAttrs do
+  @moduledoc """
+  Stamps the current OTel request span with hashed `app.user_id` and `app.vault_id`
+  so traces are filterable per user/vault. Must run AFTER Auth (and VaultPlug for
+  vault_id). No-op when the assigns are absent.
+  """
+  @behaviour Plug
+  alias Engram.Crypto.HMAC
+  require OpenTelemetry.Tracer
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    case attrs_for(conn) do
+      [] -> :ok
+      attrs -> OpenTelemetry.Tracer.set_attributes(attrs)
+    end
+
+    conn
+  end
+
+  @spec attrs_for(Plug.Conn.t()) :: [{String.t(), String.t()}]
+  def attrs_for(conn) do
+    []
+    |> maybe_user(conn.assigns[:current_user])
+    |> maybe_vault(conn.assigns[:current_vault])
+  end
+
+  # Keyed HMAC, NOT plain sha256: matches the user_id hash in log metadata
+  # (Engram.Crypto.HMAC.hash_user_id/1) so trace and log user_id values correlate.
+  defp maybe_user(attrs, %{id: id}) when is_binary(id),
+    do: [{"app.user_id", HMAC.hash_user_id(id)} | attrs]
+
+  defp maybe_user(attrs, _), do: attrs
+
+  # `current_vault` (set by VaultPlug) is a `%Engram.Vaults.Vault{}` struct;
+  # only its id is relevant to the span attribute.
+  defp maybe_vault(attrs, %{id: id}) when is_binary(id),
+    do: [{"app.vault_id", id} | attrs]
+
+  defp maybe_vault(attrs, _), do: attrs
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -177,6 +177,10 @@ defmodule EngramWeb.Router do
     pipe_through [
       :api,
       EngramWeb.Plugs.Auth,
+      # Stamps app.user_id on the request span right after Auth resolves
+      # current_user. No current_vault at this scope, so app.vault_id is
+      # simply absent from these spans.
+      EngramWeb.Plugs.TraceUserAttrs,
       # Gate deleted (410) / suspended (403) accounts off the management plane.
       # A user soft-deleted by the inactivity sweep or admin-suspended still
       # holds a valid JWT; without this they could mint API keys, CRUD vaults,
@@ -254,6 +258,9 @@ defmodule EngramWeb.Router do
     pipe_through [
       :api,
       EngramWeb.Plugs.Auth,
+      # Stamps app.user_id on the request span (no current_vault at this
+      # onboarding scope, so app.vault_id stays absent here too).
+      EngramWeb.Plugs.TraceUserAttrs,
       EngramWeb.Plugs.AccountLifecycle,
       EngramWeb.Plugs.RotationLockCheck
     ]
@@ -335,7 +342,10 @@ defmodule EngramWeb.Router do
       EngramWeb.Plugs.RequireApiRpsBudget,
       EngramWeb.Plugs.EnforceSearchCap,
       EngramWeb.Plugs.RequireApiWriteEnabled,
-      EngramWeb.Plugs.VaultPlug
+      EngramWeb.Plugs.VaultPlug,
+      # Runs last so both current_user and current_vault are resolved:
+      # stamps app.user_id AND app.vault_id on the request span.
+      EngramWeb.Plugs.TraceUserAttrs
     ]
 
     # Notes CRUD

--- a/lib/engram_web/user_socket.ex
+++ b/lib/engram_web/user_socket.ex
@@ -34,7 +34,11 @@ defmodule EngramWeb.UserSocket do
 
         Logger.warning(
           "auth rejected",
-          Metadata.with_category(:warning, :auth, reason: label)
+          Metadata.with_category(
+            :warning,
+            :auth,
+            [reason: label] ++ Engram.Auth.TokenDebug.metadata(token)
+          )
         )
 
         :error

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.632",
+      version: "0.5.633",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/auth/token_debug_test.exs
+++ b/test/engram/auth/token_debug_test.exs
@@ -1,0 +1,36 @@
+defmodule Engram.Auth.TokenDebugTest.Fixtures do
+  @moduledoc false
+
+  # Bare-secret HS256 signer, same idiom as test/engram/token_test.exs. This
+  # is a throwaway signer used only to produce a well-formed JWT string for
+  # TokenDebug to peek at; TokenDebug never verifies, so the secret never
+  # matters to the assertions below.
+  def hs256(claims) do
+    signer = Joken.Signer.create("HS256", "throwaway-test-secret")
+    {:ok, token} = Joken.Signer.sign(claims, signer)
+    token
+  end
+end
+
+defmodule Engram.Auth.TokenDebugTest do
+  use ExUnit.Case, async: true
+
+  test "peeks header + claims of an unverified HS256 JWT" do
+    # token below is signed with a throwaway secret; TokenDebug must NOT verify it.
+    token = Engram.Auth.TokenDebugTest.Fixtures.hs256(%{"iss" => "engram", "sub" => "user_123"})
+    md = Engram.Auth.TokenDebug.metadata(token)
+    assert md[:alg] == "HS256"
+    assert md[:iss] == "engram"
+    assert md[:sub_hash] == :crypto.hash(:sha256, "user_123") |> Base.encode16(case: :lower)
+    refute md[:sub_hash] == "user_123"
+  end
+
+  test "returns all-nil metadata for a non-JWT string without raising" do
+    assert Engram.Auth.TokenDebug.metadata("not-a-jwt") == [
+             alg: nil,
+             kid: nil,
+             iss: nil,
+             sub_hash: nil
+           ]
+  end
+end

--- a/test/engram/auth/token_debug_test.exs
+++ b/test/engram/auth/token_debug_test.exs
@@ -21,7 +21,7 @@ defmodule Engram.Auth.TokenDebugTest do
     md = Engram.Auth.TokenDebug.metadata(token)
     assert md[:alg] == "HS256"
     assert md[:iss] == "engram"
-    assert md[:sub_hash] == :crypto.hash(:sha256, "user_123") |> Base.encode16(case: :lower)
+    assert md[:sub_hash] == Engram.Crypto.HMAC.hash_user_id("user_123")
     refute md[:sub_hash] == "user_123"
   end
 

--- a/test/engram/auth/token_debug_test.exs
+++ b/test/engram/auth/token_debug_test.exs
@@ -15,10 +15,12 @@ end
 defmodule Engram.Auth.TokenDebugTest do
   use ExUnit.Case, async: true
 
+  alias Engram.Auth.TokenDebug
+
   test "peeks header + claims of an unverified HS256 JWT" do
     # token below is signed with a throwaway secret; TokenDebug must NOT verify it.
     token = Engram.Auth.TokenDebugTest.Fixtures.hs256(%{"iss" => "engram", "sub" => "user_123"})
-    md = Engram.Auth.TokenDebug.metadata(token)
+    md = TokenDebug.metadata(token)
     assert md[:alg] == "HS256"
     assert md[:iss] == "engram"
     assert md[:sub_hash] == Engram.Crypto.HMAC.hash_user_id("user_123")
@@ -26,7 +28,7 @@ defmodule Engram.Auth.TokenDebugTest do
   end
 
   test "returns all-nil metadata for a non-JWT string without raising" do
-    assert Engram.Auth.TokenDebug.metadata("not-a-jwt") == [
+    assert TokenDebug.metadata("not-a-jwt") == [
              alg: nil,
              kid: nil,
              iss: nil,
@@ -37,7 +39,7 @@ defmodule Engram.Auth.TokenDebugTest do
   test "does not raise when sub claim is a number, and sub_hash is nil" do
     token = Engram.Auth.TokenDebugTest.Fixtures.hs256(%{"iss" => "engram", "sub" => 12_345})
 
-    md = Engram.Auth.TokenDebug.metadata(token)
+    md = TokenDebug.metadata(token)
 
     assert md[:alg] == "HS256"
     assert md[:iss] == "engram"

--- a/test/engram/auth/token_debug_test.exs
+++ b/test/engram/auth/token_debug_test.exs
@@ -33,4 +33,14 @@ defmodule Engram.Auth.TokenDebugTest do
              sub_hash: nil
            ]
   end
+
+  test "does not raise when sub claim is a number, and sub_hash is nil" do
+    token = Engram.Auth.TokenDebugTest.Fixtures.hs256(%{"iss" => "engram", "sub" => 12_345})
+
+    md = Engram.Auth.TokenDebug.metadata(token)
+
+    assert md[:alg] == "HS256"
+    assert md[:iss] == "engram"
+    assert md[:sub_hash] == nil
+  end
 end

--- a/test/engram_web/plugs/trace_user_attrs_test.exs
+++ b/test/engram_web/plugs/trace_user_attrs_test.exs
@@ -1,0 +1,21 @@
+defmodule EngramWeb.Plugs.TraceUserAttrsTest do
+  use EngramWeb.ConnCase, async: true
+  alias EngramWeb.Plugs.TraceUserAttrs
+
+  test "builds hashed user_id + vault_id attrs from assigns" do
+    conn =
+      build_conn()
+      |> Plug.Conn.assign(:current_user, %{id: "user_123"})
+      |> Plug.Conn.assign(:current_vault, %{id: "vault_abc"})
+
+    attrs = TraceUserAttrs.attrs_for(conn)
+    # user_id MUST use the SAME keyed HMAC as log metadata (Engram.Crypto.HMAC.hash_user_id/1)
+    # so traces filter/correlate against the same user_id value that appears in Loki logs.
+    assert {"app.user_id", Engram.Crypto.HMAC.hash_user_id("user_123")} in attrs
+    assert {"app.vault_id", "vault_abc"} in attrs
+  end
+
+  test "omits pairs when assigns are absent" do
+    assert TraceUserAttrs.attrs_for(build_conn()) == []
+  end
+end


### PR DESCRIPTION
## Why

The plugin bugfix (companion PR below) stops the chronic WebSocket `signature_error` bursts at their source. This PR is the observability half: make any **residual** `signature_error` attributable, and make prod traces filterable per user (the original support ask "follow traces for my account" was impossible because spans carried only HTTP-route attributes).

## Changes

**1. Attribute socket auth rejections** (`lib/engram_web/user_socket.ex` + new `Engram.Auth.TokenDebug`)

The `{:error, reason}` branch logged `auth rejected` with no attribution (rejection happens before the user is identified). It now also logs the presented token's `kid`, `iss`, `alg`, and `sub_hash`. `TokenDebug.metadata/1` is a pure, **non-verifying** peek (`Joken.peek_header/1` / `peek_claims/1`), **never raises** (guards + `is_map` + rescue cover crafted/non-JWT/non-string-`sub` input), and **never logs the raw sub**. `sub_hash` uses the keyed `Engram.Crypto.HMAC.hash_user_id/1` — the same helper used for the `user_id` in existing log metadata — so a rejected internal-JWT `sub` (which equals `users.id`) correlates to that user's other log lines.

**2. Per-user trace attributes** (new `EngramWeb.Plugs.TraceUserAttrs`)

Stamps `app.user_id` (same keyed HMAC, so trace and log `user_id` correlate) and `app.vault_id` onto the request span, added after `Auth`/`VaultPlug` in the authenticated pipelines. No-op when assigns are absent.

## Still open (flagged, not built)

Why a freshly minted internal HS256 token can fail signature verify at all (secret drift across nodes/deploys). Deferred until this attribution data exists to chase it.

## Companion

Plugin bugfix: engram-app/Engram-obsidian — branch `fix/ws-close-token-invalidation`.

## Testing

TDD. `TokenDebug`: HMAC correlation, all-nil non-JWT, no-raise on numeric `sub`. `TraceUserAttrs.attrs_for/1`: HMAC user_id + struct-extracted vault_id, empty when absent. Full `mix test` 3472 / 0 (one confirmed pre-existing `SyncChannel` flake). `mix format`, `credo --strict`, and `sobelow --exit low` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
