### PR TITLE
fix(ci/e2e): retry reclaimed image build + de-poison test_56 (#567, #915)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -487,8 +487,23 @@ jobs:
           # Build locally only if this daemon doesn't already have the layers.
           IMAGE_LOCAL="engram-ci:${HASH}"
           if ! docker image inspect "$IMAGE_LOCAL" >/dev/null 2>&1; then
-            ENGRAM_CI_IMAGE="$IMAGE_LOCAL" \
-              docker compose -f ci/compose.yml build engram
+            # The buildkit/docker daemon on the isolated pool can be reclaimed
+            # mid-`mix release`, dropping the gRPC transport with `graceful_stop`
+            # (#567) — a host/daemon event, not a build error. The build is
+            # idempotent (cache-reused), so retry a few times before failing the
+            # whole job; the daemon typically comes back within seconds.
+            for attempt in 1 2 3; do
+              if ENGRAM_CI_IMAGE="$IMAGE_LOCAL" \
+                   docker compose -f ci/compose.yml build engram; then
+                break
+              fi
+              if [ "$attempt" = 3 ]; then
+                echo "::error::CI image build failed after 3 attempts"
+                exit 1
+              fi
+              echo "::warning::build attempt $attempt failed (daemon reclaimed?) — retrying in 15s"
+              sleep 15
+            done
             docker image inspect "$IMAGE_LOCAL" >/dev/null
           fi
 

--- a/e2e/tests/test_56_sync_center_issues.py
+++ b/e2e/tests/test_56_sync_center_issues.py
@@ -34,7 +34,7 @@ NOTE_PATH = f"{SEED_DIR}/TooLarge.md"
 _11MB_CONTENT = "# Too-Large Note\n" + ("x" * (11 * 1024 * 1024))
 
 
-async def _wait_for_issue(cdp, path: str, timeout: float = 20) -> list[dict]:
+async def _wait_for_issue(cdp, path: str, timeout: float = 30) -> list[dict]:
     """Poll get_issue_groups() until an issue for `path` appears.
 
     Returns the full groups list once the issue is found.
@@ -63,6 +63,12 @@ async def test_too_large_issue_ignore(vault_a, cdp_a):
         wrote = True
 
         # ── 2. Full sync so the engine pushes and records the 413 rejection ──
+        # Accept the sync gate first: an upstream auth-swap test (test_47/48/49)
+        # sharing this session-scoped instance can leave the gate closed
+        # (syncBlocked), which makes fullSync short-circuit {pulled:0,pushed:0}
+        # — the 413 never fires and no too_large issue is recorded (#915). Assert
+        # the precondition here rather than trusting a neighbor's cleanup.
+        await cdp_a.accept_sync_gate()
         await cdp_a.trigger_full_sync()
 
         # ── 3. Open Sync Center ───────────────────────────────────────────────

--- a/e2e/tests/test_57_sync_center_log.py
+++ b/e2e/tests/test_57_sync_center_log.py
@@ -61,15 +61,25 @@ async def test_activity_log_records_push_then_clears(vault_a, cdp_a, api_sync):
     wrote = False
     try:
         # ── 1. Deterministically push the note via the engine ────────────────
+        # Ensure the CRDT channel is live first. push_file_now routes a small
+        # note via the CRDT path, which returns "CRDT push ok" WITHOUT verifying
+        # the channel is joined — so if an upstream auth-swap test (test_47/48/49)
+        # on this shared session-scoped instance left the channel dead-but-set,
+        # the Y.Doc update is silently dropped and the note never reaches the
+        # server (#915). Force a live channel so the push actually lands.
+        if not await cdp_a.check_stream_connected():
+            await cdp_a.reconnect_stream()
+        await cdp_a.wait_for_stream_connected()
+
         # push_file_now() creates via app.vault.create() and awaits pushFile()
         # directly, bypassing the handleModify debounce. It also appends a
         # 'push' entry to syncLog so the activity log assertion has a target.
         await cdp_a.push_file_now(path, "# activity log test")
         wrote = True
 
-        # Confirm the push reached the server (the helper awaits pushFile, so
-        # this should be immediate — the wait_for_note is belt-and-braces).
-        api_sync.wait_for_note(path, timeout=5)
+        # Confirm the push reached the server. Load-tolerant budget: under runner
+        # contention CRDT propagation can lag past a tight window (#915).
+        api_sync.wait_for_note(path, timeout=15)
 
         # ── 3. Open Sync Center and assert push entry present ────────────────
         await cdp_a.open_sync_center()

--- a/e2e/tests/test_57_sync_center_log.py
+++ b/e2e/tests/test_57_sync_center_log.py
@@ -61,25 +61,15 @@ async def test_activity_log_records_push_then_clears(vault_a, cdp_a, api_sync):
     wrote = False
     try:
         # ── 1. Deterministically push the note via the engine ────────────────
-        # Ensure the CRDT channel is live first. push_file_now routes a small
-        # note via the CRDT path, which returns "CRDT push ok" WITHOUT verifying
-        # the channel is joined — so if an upstream auth-swap test (test_47/48/49)
-        # on this shared session-scoped instance left the channel dead-but-set,
-        # the Y.Doc update is silently dropped and the note never reaches the
-        # server (#915). Force a live channel so the push actually lands.
-        if not await cdp_a.check_stream_connected():
-            await cdp_a.reconnect_stream()
-        await cdp_a.wait_for_stream_connected()
-
         # push_file_now() creates via app.vault.create() and awaits pushFile()
         # directly, bypassing the handleModify debounce. It also appends a
         # 'push' entry to syncLog so the activity log assertion has a target.
         await cdp_a.push_file_now(path, "# activity log test")
         wrote = True
 
-        # Confirm the push reached the server. Load-tolerant budget: under runner
-        # contention CRDT propagation can lag past a tight window (#915).
-        api_sync.wait_for_note(path, timeout=15)
+        # Confirm the push reached the server (the helper awaits pushFile, so
+        # this should be immediate — the wait_for_note is belt-and-braces).
+        api_sync.wait_for_note(path, timeout=5)
 
         # ── 3. Open Sync Center and assert push entry present ────────────────
         await cdp_a.open_sync_center()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.630",
+      version: "0.5.631",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Bundled per the #916/#919/#920 hardening pattern. **CI-validated, then re-scoped** after run 28761031045 disproved one of the fixes (see below).

## #567 — `prebuild-ci-image` dies with buildkit `graceful_stop` ✅
The buildkit/docker daemon on the isolated runner pool can be **reclaimed mid-`mix release`**, dropping the gRPC transport with `graceful_stop` — a host event, not a build error. Runner survives; build is idempotent.

**Fix:** wrap `docker compose build` in a **3-attempt retry (15s backoff)**. **Verified:** `prebuild-ci-image` passed (6m38s) on this branch.

Closes #567

## #915 — Sync Center poisoning — test_56 fixed, test_57 deferred
`test_56`/`test_57` share a session-scoped Obsidian instance with the auth-swap family (`test_47/48/49`), which can hand off a degraded baseline (closed gate / dead CRDT channel).

- **test_56** ✅ **`accept_sync_gate()` before `trigger_full_sync()`** — a closed gate makes fullSync short-circuit `{0,0}` (→ no 413 → no `too_large` issue). Issue poll 20s→30s. **Verified:** test_56 passed in run 28761031045.
- **test_57** ⏳ **deferred.** I first tried a test-level heal (`reconnect_stream` + `wait_for_stream_connected` before the push). CI disproved it: the channel **still hit "Stream not connected after 10s"** — the auth-swap poisoning breaks the channel/auth binding, not just a socket, so a `connect()` can't revive it within budget. Reverted. The real fix is the **product smell** the issue already flags: `pushFile` returns `"CRDT push ok"` on an *unjoined* CRDT channel (`sync.ts:1079`), silently dropping the update. That needs a plugin-side **REST fallback when the channel isn't joined** — a separate change in the plugin repo, not a test tweak.

Refs #915 (test_56 done; test_57 + the pushFile REST-fallback remain)

## Not in scope (independent flakes surfaced by the same contended run)
- `test_34_folder_rename` — its own tight 10s budget ("keep until swept separately"); ran before the auth-swap tests, not poisoned.
- e2e-browser `tree-ops-sync` two-tab `toContainText` — a file this PR doesn't touch; independent CRDT-timing flake.

## Verification
`prebuild-ci-image` + `test_56` verified green in run 28761031045; py_compile/YAML/shell all clean; `mix.exs` 0.5.630→631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)