### PR TITLE
chore(e2e): verify id-keyed CRDT main↔main consistency

### DIFF
--- a/e2e/tests/test_10_rename_propagation.py
+++ b/e2e/tests/test_10_rename_propagation.py
@@ -2,6 +2,11 @@
 
 Uses CDP vault.rename() to trigger Obsidian's handleRename (filesystem
 mv would not trigger the plugin's rename handler).
+
+Post id-keying (#925/#180): the renamed note keeps its stable note_id and
+its live CRDT room; the server moves/resurrects the row by id rather than
+delete+recreate. This suite pairs backend main against plugin main to verify
+the two note_id-keyed sides agree.
 """
 
 import pytest


### PR DESCRIPTION
**Verification PR (do not merge — proves the coordinated CRDT id-keying change is consistent on main).**

Backend #925 + plugin #180 (note_id-keyed CRDT) are both merged. This trivial docstring-only change forces a fresh e2e run whose plugin side auto-pairs against **plugin main** — now also note_id-keyed. Expectation:

- `e2e-crdt` + `e2e-clerk` **GREEN** (before the merges, a backend PR touching CRDT mismatched plugin main's path-keyed protocol → red).

If green, it proves merging both PRs resolved the per-PR coordinated-CI mismatch and the two sides agree on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)