### PR TITLE
test(e2e): rerun-safe unique paths for test_10

### DIFF
--- a/e2e/tests/test_10_rename_propagation.py
+++ b/e2e/tests/test_10_rename_propagation.py
@@ -4,6 +4,8 @@ Uses CDP vault.rename() to trigger Obsidian's handleRename (filesystem
 mv would not trigger the plugin's rename handler).
 """
 
+import uuid
+
 import pytest
 
 from helpers.log_oracle import wait_for_delivery
@@ -13,8 +15,16 @@ from helpers.vault import read_note, write_note
 @pytest.mark.asyncio
 async def test_rename_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     """A renames a synced file, B should see the new path (not delete+create)."""
-    old_path = "E2E/RenameOld.md"
-    new_path = "E2E/RenameNew.md"
+    # Unique per-run paths (rerun-safety, same pattern as test_49). The A/B
+    # Obsidian instances are session-scoped and NOT reset between pytest reruns,
+    # so fixed paths let a prior attempt's per-path state (sync-state, note_id
+    # map, a peer's leftover copy) contaminate the next attempt: the create
+    # echo-suppresses, or the old path is re-pushed and never goes away. A fresh
+    # suffix each invocation makes every attempt collision-free. Old/new share
+    # one suffix so the rename maps them as a pair.
+    suffix = uuid.uuid4().hex[:12]
+    old_path = f"E2E/RenameOld-{suffix}.md"
+    new_path = f"E2E/RenameNew-{suffix}.md"
 
     # A creates the note
     write_note(vault_a, old_path, "# Rename Test\nThis file will be renamed.")


### PR DESCRIPTION
Makes test_10 deterministic. The A/B Obsidian instances are session-scoped and not reset between pytest reruns, so fixed paths (RenameOld/RenameNew) let a prior attempt's per-path state contaminate the next. Fresh uuid suffix per invocation (test_49 pattern) eliminates the whole contamination surface. Underlying product bugs it exposed are fixed in #925/#180/#181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)