### PR TITLE
fix(sync): reject live note_id collisions + un-redact drop logs (corruption incident 2026-07-06)

### DIFF
--- a/docs/context/crdt-id-collision-corruption-2026-07-06.md
+++ b/docs/context/crdt-id-collision-corruption-2026-07-06.md
@@ -58,9 +58,13 @@ collision was **ruled out** (74 bits of `crypto.getRandomValues`).
 
 **Recommended plugin fix (needs runtime confirmation via the new logs first):** on the
 id-keying upgrade, do a **full id reconciliation** — learn the server's id for *every*
-existing note (via the full manifest/reconcile, which carries ids) into `NoteIdMap`
-**before** minting or pushing anything. Only genuinely new notes should mint.
-Do NOT blind-fix without confirming the exact learn-gap from prod logs / a repro.
+existing note into `NoteIdMap` **before** minting or pushing anything. Only genuinely new
+notes should mint. **Backend hook shipped in this PR:** `GET /sync/manifest` now returns
+`id` on every note/attachment entry (`ManifestEntry.id`), so the plugin can populate the
+whole path↔id map in one call on upgrade instead of guessing. The plugin also must not
+send CRDT frames under an unconfirmed id, and must re-key the CRDT room if the backend
+returns a different id than it guessed. Do NOT blind-fix without confirming the exact
+learn-gap from prod logs / a repro.
 
 ## Why the tests missed it — and the fix
 

--- a/docs/context/crdt-id-collision-corruption-2026-07-06.md
+++ b/docs/context/crdt-id-collision-corruption-2026-07-06.md
@@ -1,0 +1,112 @@
+# CRDT note_id-collision corruption (2026-07-06)
+
+Prod data-corruption incident on the day the CRDT **id-keying cutover** shipped
+(`#925` id-keyed doc_id + `#934` CRDT-state wipe, `release-v0.5.634/636`).
+Symptom chain reported by the (single, pre-launch) user:
+
+1. Edits made in the **web app never reached Obsidian** — not even via manual Sync.
+2. Content **transferred between notes**; one note's content **overwrote others**.
+3. In Obsidian, opening a note showed content for a few seconds then **blanked**.
+
+Direction asymmetry: Obsidian→web worked; web→Obsidian was dead. That, plus
+"reload survives" in the web (offline-first `y-indexeddb`) and the blanking
+reaching Obsidian, meant the damage was **persisted server-side**, in `notes.content`.
+
+## Root cause — two layers
+
+### Amplifier (server, `lib/engram/notes.ex` `upsert_note`) — FIXED
+
+`upsert_note` looks a note up by **path**; on a miss it looks up by **client_id**
+and, if found, `move_note`s that row onto the new path (clearing the tombstone,
+**crdt-merging** content, broadcasting `:moved` fleet-wide). `existing_by_client_id`
+returned **any** note with that id — **live or tombstoned, at any path** — with no guard.
+
+On the wire, "rename A→B (same id)" and "a *different* note that reuses A's id" are
+**identical**: one `upsert` to path B carrying a note_id already live at path A.
+So a client that emitted a duplicate note_id caused the server to **relocate +
+merge** the live A row onto B — destroying A and bleeding its content across notes,
+then fanning the collapse out to every device via the `:moved` broadcast.
+
+**Fix (`efcb89dc`):** `move_note` may only relocate a **tombstoned** prior. A live
+prior found by client_id (necessarily at a different path — the path lookup already
+missed) is an id-collision → returned as `{:id_collision, live}` → `{:error,
+:version_conflict}` with a distinct greppable log `note_id_collision_rejected`.
+Real renames delete-first (tombstone) → hit the safe resurrect branch, unaffected.
+A rename-race degrades to a transient conflict the client retries — safe, self-healing.
+
+### Trigger (client, plugin `src/sync.ts` `pushFile`) — CHARACTERIZED, NOT yet fixed
+
+`pushFile` mints a **fresh `uuid7()`** for any path not yet in its `NoteIdMap`
+(`src/crdt/note-id-map.ts`) and sends it as the POST body `id`. On a **fresh vault**
+this is fine — the plugin mints, the server adopts on insert, both agree. On an
+**EXISTING vault upgraded to id-keying**, the server already holds ids for
+pre-existing notes but the plugin's `NoteIdMap` starts empty, so the plugin mints
+its **own** divergent ids until it *learns* the server's from a pull.
+
+Divergence window symptoms (all observed): CRDT frames keyed by the plugin's minted
+id → server `resolve_note_id` → `note_in_vault?` false → **`crdt_msg` dropped
+`:not_found`** (this is what broke web→Obsidian live and produced the Loki drops);
+and, pre-fix, a rename/move in that window could push a new path with a diverged id
+that was live elsewhere → the server collapse above.
+
+**Leading hypothesis for the *systematic* (many-note) collapse:** the plugin's first
+upgraded sync learns ids only for notes in the **incremental `/sync/changes` feed**
+(`sync.ts` ~L2559 `noteIdMap.set(c.path, c.id)`); pre-existing **unchanged** notes
+are not in that feed, so their ids are never learned, the plugin mints divergent ids
+for them on the next push/edit, and rename/move churn collapses them. `uuid7()`
+collision was **ruled out** (74 bits of `crypto.getRandomValues`).
+
+**Recommended plugin fix (needs runtime confirmation via the new logs first):** on the
+id-keying upgrade, do a **full id reconciliation** — learn the server's id for *every*
+existing note (via the full manifest/reconcile, which carries ids) into `NoteIdMap`
+**before** minting or pushing anything. Only genuinely new notes should mint.
+Do NOT blind-fix without confirming the exact learn-gap from prod logs / a repro.
+
+## Why the tests missed it — and the fix
+
+- **The suite codified the corruption as correct.** `notes_client_mint_test.exs` had
+  `"moves a live id to a new path without double-counting"` asserting that pushing a
+  **live** note's id at a new path MOVES it and `A.md` → `:not_found`. Removed.
+- **`crdt_channel_test.exs:183`** asserts an unknown note_id **must** be dropped —
+  correct server defense, but it *masks* that the client should never send one.
+- **Every CRDT/sync test uses a FRESH vault** (in-session, unique ids). None seed a
+  pre-existing vault and run the **upgrade/backfill** path — the entire failure class.
+
+**Reusable pattern for upgrade/migration tests** (added in
+`notes_client_mint_test.exs` describe `"existing-vault upgrade safety"`): seed
+pre-existing **server** state, then drive the **upgraded client's divergent** behavior
+and assert no corruption. Extend this for future cutovers.
+
+## Observability fix (`a4b75cd7`)
+
+The dropped-frame warning logged `doc_id` under the **`:path`** metadata key, which
+`RedactFilter` scrubs to `[REDACTED]` — so during triage the note_ids of dropped
+edits were unreadable, and drops carried **no user_id/vault_id** (unattributable).
+Now: a well-formed doc_id logs under the un-redacted **`:note_id`** key + `user_id`/
+`vault_id` attribution; a non-UUID doc_id (stale path-keyed client, maybe a real path)
+stays under redacted `:path`. Loki gets it via the full-metadata FireLens JSON handler.
+
+**Loki queries for this incident:**
+```
+{service_name="engram"} |= "dropped crdt_msg"                     # drops (now carry note_id + user_id)
+{service_name="engram"} |= "note_id_collision_rejected"          # the guard firing (post-deploy)
+```
+
+## Recovery (NOT executed — needs approval; see recovery-plan section below)
+
+Server `notes.content` is corrupted; the user's **local Obsidian vault (backed up
+pre-blanking) is the clean source of truth**. Recovery is **Obsidian→server**, never
+the reverse. Outline:
+1. Keep the plugin disabled; confirm the vault backup is intact.
+2. Deploy the server guard (this branch) so the rebuild can't re-collapse.
+3. Wipe the corrupted CRDT state + rebuild `notes.content` from the clean local vault
+   (fresh push), ensuring the plugin adopts server ids (clear `NoteIdMap` so it
+   re-bootstraps cleanly, or land the plugin id-reconcile fix first).
+4. Verify note count + spot-check content before re-enabling live sync.
+
+## Files
+- `lib/engram/notes.ex` — `upsert_note` id-collision guard (`{:id_collision, live}`)
+- `lib/engram_web/channels/crdt_channel.ex` — `log_dropped/3` un-redacted note_id + attribution
+- `test/engram/notes_client_mint_test.exs` — collision guard + upgrade-safety tests
+- `test/engram_web/channels/crdt_channel_test.exs` — log-visibility + path-redaction tests
+- Plugin (follow-up): `src/sync.ts` `pushFile` id-selection, `src/crdt/note-id-map.ts`

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -370,6 +370,19 @@ defmodule Engram.Notes do
           case Repo.one(lookup_query) do
             nil ->
               case existing_by_client_id(client_id, vault) do
+                %Note{deleted_at: nil} = live ->
+                  # Live id-collision: this note_id already names a LIVE note at
+                  # a DIFFERENT path (there is no live note at THIS path — the
+                  # lookup above was nil). "rename A->B" and "a different note
+                  # that reuses A's id" are indistinguishable on the wire, and
+                  # move_note would relocate + crdt-merge A onto B, silently
+                  # destroying A and bleeding its content across notes (prod
+                  # incident 2026-07-06). A real rename tombstones the old path
+                  # first (delete_note) and takes the resurrect branch below;
+                  # a live match here is a duplicate-id bug, so reject it as a
+                  # conflict rather than collapsing two distinct notes.
+                  {:id_collision, live}
+
                 %Note{} = prior ->
                   move_note(prior, base_attrs, user, sanitized_path, folder)
 
@@ -465,6 +478,24 @@ defmodule Engram.Notes do
           # Phase B.3: virtual path/folder/tags need to be populated from
           # ciphertext before the controller serializes the conflict response.
           {:error, :version_conflict, decrypt_or_raise!(existing, user)}
+
+        {:ok, {:id_collision, live}} ->
+          # A push carried a note_id that already names a LIVE note at another
+          # path. Refused to move/merge (that destroys the live note). Log with
+          # a distinct, greppable key so this class — invisible until the
+          # 2026-07-06 corruption incident — is monitorable in Loki, then hand
+          # back a conflict so the client reconciles (re-mints its id / pulls).
+          Logger.warning(
+            "note_id_collision_rejected",
+            Metadata.with_category(:warning, :sync,
+              user_id: user.id,
+              vault_id: vault.id,
+              note_id: live.id,
+              server_version: live.version
+            )
+          )
+
+          {:error, :version_conflict, decrypt_or_raise!(live, user)}
 
         {:ok, {:error, changeset}} ->
           {:error, changeset}

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -369,34 +369,16 @@ defmodule Engram.Notes do
         Repo.with_tenant(user.id, fn ->
           case Repo.one(lookup_query) do
             nil ->
-              case existing_by_client_id(client_id, vault) do
-                %Note{deleted_at: nil} = live ->
-                  # Live id-collision: this note_id already names a LIVE note at
-                  # a DIFFERENT path (there is no live note at THIS path — the
-                  # lookup above was nil). "rename A->B" and "a different note
-                  # that reuses A's id" are indistinguishable on the wire, and
-                  # move_note would relocate + crdt-merge A onto B, silently
-                  # destroying A and bleeding its content across notes (prod
-                  # incident 2026-07-06). A real rename tombstones the old path
-                  # first (delete_note) and takes the resurrect branch below;
-                  # a live match here is a duplicate-id bug, so reject it as a
-                  # conflict rather than collapsing two distinct notes.
-                  {:id_collision, live}
-
-                %Note{} = prior ->
-                  move_note(prior, base_attrs, user, sanitized_path, folder)
-
-                nil ->
-                  insert_new_note(
-                    base_attrs,
-                    user,
-                    sanitized_path,
-                    folder,
-                    tags,
-                    client_id,
-                    lookup_query
-                  )
-              end
+              upsert_pathless(
+                client_id,
+                vault,
+                base_attrs,
+                user,
+                sanitized_path,
+                folder,
+                tags,
+                lookup_query
+              )
 
             existing ->
               do_update_note(existing, base_attrs, user, sanitized_path, folder, tags, opts)
@@ -617,6 +599,40 @@ defmodule Engram.Notes do
   # marker sharing the id space. `Repo.get` has no soft-delete default scope
   # (Note carries no query default, only `note_by_path_query` filters
   # `deleted_at` explicitly), so this returns tombstones as well as live rows.
+  # No live note exists at this path. Route by the client-supplied note_id.
+  # Must run inside the caller's `Repo.with_tenant` block (does tenant-scoped
+  # reads/writes).
+  defp upsert_pathless(
+         client_id,
+         vault,
+         base_attrs,
+         user,
+         sanitized_path,
+         folder,
+         tags,
+         lookup_query
+       ) do
+    case existing_by_client_id(client_id, vault) do
+      %Note{deleted_at: nil} = live ->
+        # Live id-collision: this note_id already names a LIVE note at a
+        # DIFFERENT path (there is no live note at THIS path — the lookup
+        # missed). "rename A->B" and "a different note that reuses A's id" are
+        # indistinguishable on the wire, and move_note would relocate +
+        # crdt-merge A onto B, silently destroying A and bleeding its content
+        # across notes (prod incident 2026-07-06). A real rename tombstones the
+        # old path first (delete_note) and takes the resurrect branch below; a
+        # live match here is a duplicate-id bug, so reject it as a conflict
+        # rather than collapsing two distinct notes.
+        {:id_collision, live}
+
+      %Note{} = prior ->
+        move_note(prior, base_attrs, user, sanitized_path, folder)
+
+      nil ->
+        insert_new_note(base_attrs, user, sanitized_path, folder, tags, client_id, lookup_query)
+    end
+  end
+
   defp existing_by_client_id(nil, _vault), do: nil
 
   defp existing_by_client_id(client_id, vault) do

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -107,13 +107,13 @@ defmodule EngramWeb.CrdtChannel do
         {:reply, {:error, %{reason: "rate_limited"}}, socket}
 
       {:error, :frame_too_large} ->
-        log_dropped(doc_id, :frame_too_large)
+        log_dropped(socket, doc_id, :frame_too_large)
         {:reply, {:error, %{reason: "frame_too_large"}}, socket}
 
       err ->
         # Surface drops rather than swallowing them silently — a dropped frame
         # (bad base64 or unresolvable doc_id) means a lost edit.
-        log_dropped(doc_id, err)
+        log_dropped(socket, doc_id, err)
         {:noreply, socket}
     end
   end
@@ -161,13 +161,30 @@ defmodule EngramWeb.CrdtChannel do
     end
   end
 
-  # doc_id is now the note_id (a UUID, no longer a cleartext path). Keep it out
-  # of the message body regardless, and keep the `path:` metadata key so it
-  # still routes through RedactFilter's existing scrub list unchanged.
-  defp log_dropped(doc_id, reason) do
+  # A note_id is a non-sensitive UUID and is REQUIRED to diagnose which note
+  # lost a dropped edit (redacting it under :path blocked the 2026-07-06
+  # incident triage), so log a well-formed doc_id under the un-redacted
+  # :note_id key. A doc_id that is NOT a UUID came from a stale path-keyed
+  # client and may be a real cleartext path — keep those under the redacted
+  # :path key so nothing sensitive ever leaks. The message body never carries
+  # the id either way.
+  defp log_dropped(socket, doc_id, reason) do
+    id_meta =
+      case Ecto.UUID.cast(doc_id) do
+        {:ok, note_id} -> [note_id: note_id]
+        :error -> [path: doc_id]
+      end
+
+    # Attribute the drop to a user + vault so a lost edit can be traced to who
+    # hit it (the 2026-07-06 drops carried neither, so they were unattributable).
+    attribution = [
+      user_id: socket.assigns.current_user.id,
+      vault_id: socket.assigns.vault.id
+    ]
+
     Logger.warning(
       "crdt_channel: dropped crdt_msg → #{inspect(reason)}",
-      Metadata.with_category(:warning, :sync, path: doc_id)
+      Metadata.with_category(:warning, :sync, attribution ++ id_meta)
     )
   end
 

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -204,7 +204,7 @@ defmodule EngramWeb.SyncController do
         Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, hash} ->
           aad = path_aad(:notes, id, dek_version)
           path = decrypt_path!(path_ct, path_nonce, dek, aad)
-          %{path: path, content_hash: hash}
+          %{id: id, path: path, content_hash: hash}
         end)
       end)
       |> Enum.sort_by(& &1.path)
@@ -214,7 +214,7 @@ defmodule EngramWeb.SyncController do
         Enum.map(attachment_rows, fn {id, dek_version, path_ct, path_nonce, hash} ->
           aad = path_aad(:attachments, id, dek_version)
           path = decrypt_path!(path_ct, path_nonce, dek, aad)
-          %{path: path, content_hash: hash}
+          %{id: id, path: path, content_hash: hash}
         end)
       end)
       |> Enum.sort_by(& &1.path)

--- a/lib/engram_web/schemas/sync.ex
+++ b/lib/engram_web/schemas/sync.ex
@@ -7,10 +7,15 @@ defmodule EngramWeb.Schemas.ManifestEntry do
     title: "ManifestEntry",
     type: :object,
     properties: %{
+      id: %Schema{
+        type: :string,
+        format: :uuid,
+        description: "Stable note/attachment id — lets a client reconcile its path↔id map."
+      },
       path: %Schema{type: :string},
       content_hash: %Schema{type: :string, nullable: true}
     },
-    required: [:path]
+    required: [:id, :path]
   })
 end
 

--- a/openapi.json
+++ b/openapi.json
@@ -669,6 +669,13 @@
             "x-struct": null,
             "x-validate": null
           },
+          "id": {
+            "description": "Stable note/attachment id — lets a client reconcile its path↔id map.",
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "path": {
             "type": "string",
             "x-struct": null,
@@ -676,6 +683,7 @@
           }
         },
         "required": [
+          "id",
           "path"
         ],
         "title": "ManifestEntry",

--- a/test/engram/notes_client_mint_test.exs
+++ b/test/engram/notes_client_mint_test.exs
@@ -5,6 +5,7 @@ defmodule Engram.NotesClientMintTest do
   use Engram.DataCase, async: true
 
   import Engram.Factory
+  import ExUnit.CaptureLog
 
   test "upsert_note honors client-supplied uuidv7 id" do
     user = insert(:user)
@@ -126,12 +127,17 @@ defmodule Engram.NotesClientMintTest do
         })
 
       # A different note at a different path reuses A's live note_id.
-      result =
-        Engram.Notes.upsert_note(user, vault, %{
-          "id" => id,
-          "path" => "B.md",
-          "content" => "BBB different body"
-        })
+      {result, log} =
+        with_log(fn ->
+          Engram.Notes.upsert_note(user, vault, %{
+            "id" => id,
+            "path" => "B.md",
+            "content" => "BBB different body"
+          })
+        end)
+
+      # The rejection is logged loudly under a greppable key (Loki monitoring).
+      assert log =~ "note_id_collision_rejected"
 
       # A survives intact at its original path — NOT moved, NOT merged.
       assert {:ok, a_still} = Engram.Notes.get_note(user, vault, "A.md")

--- a/test/engram/notes_client_mint_test.exs
+++ b/test/engram/notes_client_mint_test.exs
@@ -97,34 +97,53 @@ defmodule Engram.NotesClientMintTest do
       assert Engram.UsageMeters.notes_count(user.id) == 1
     end
 
-    test "moves a live id to a new path without double-counting" do
+    # NOTE (2026-07-06): a prior test here asserted that upserting a LIVE note's
+    # id at a new path MOVES it (destroying the original at the old path). That
+    # was the id-collision data-loss vector — removed. Moving a live note by id
+    # is now rejected (see "rejects a live id-collision ..." below). A real
+    # rename tombstones the old path first and is covered by
+    # "resurrects a tombstoned id at a new path (rename)" above, which also
+    # asserts the usage counter is not double-counted.
+
+    # DATA-LOSS GUARD (prod incident 2026-07-06): on the wire, "rename A->B"
+    # and "a DIFFERENT note that reuses A's note_id" are indistinguishable — a
+    # single upsert to path B carrying a note_id already live at path A. The
+    # old behavior MOVED + crdt-merged the live A row onto B, silently
+    # destroying A and bleeding its content across notes. A live id-collision
+    # must be REJECTED (conflict), never moved. Legit renames delete-first
+    # (tombstone) and take the resurrect path above, so they are unaffected.
+    test "rejects a live id-collision instead of collapsing two distinct notes" do
       user = insert(:user)
       {:ok, user} = Engram.Crypto.ensure_user_dek(user)
       vault = insert(:vault, user: user)
       id = UUIDv7.generate()
 
-      {:ok, _note} =
+      {:ok, _a} =
         Engram.Notes.upsert_note(user, vault, %{
           "id" => id,
           "path" => "A.md",
-          "content" => "# Hi\nbody"
+          "content" => "AAA original body"
         })
 
-      assert Engram.UsageMeters.notes_count(user.id) == 1
-
-      {:ok, moved} =
+      # A different note at a different path reuses A's live note_id.
+      result =
         Engram.Notes.upsert_note(user, vault, %{
           "id" => id,
           "path" => "B.md",
-          "content" => "# Hi\nbody"
+          "content" => "BBB different body"
         })
 
-      assert moved.id == id
-      assert moved.path == "B.md"
-      assert Engram.UsageMeters.notes_count(user.id) == 1
+      # A survives intact at its original path — NOT moved, NOT merged.
+      assert {:ok, a_still} = Engram.Notes.get_note(user, vault, "A.md")
+      assert a_still.id == id
+      assert a_still.content =~ "AAA original body"
+      refute a_still.content =~ "BBB"
 
-      assert {:ok, _} = Engram.Notes.get_note(user, vault, "B.md")
-      assert {:error, :not_found} = Engram.Notes.get_note(user, vault, "A.md")
+      # The colliding push is surfaced as a conflict, not silently applied.
+      assert {:error, :version_conflict, _} = result
+
+      # Exactly one note exists — the collision did not create/duplicate rows.
+      assert Engram.UsageMeters.notes_count(user.id) == 1
     end
 
     test "a fresh id at a new path still inserts normally" do

--- a/test/engram/notes_client_mint_test.exs
+++ b/test/engram/notes_client_mint_test.exs
@@ -162,4 +162,48 @@ defmodule Engram.NotesClientMintTest do
       assert Engram.UsageMeters.notes_count(user.id) == 1
     end
   end
+
+  # EXISTING-VAULT UPGRADE SAFETY (2026-07-06).
+  #
+  # Every other test here (and the whole e2e suite) exercises a FRESH vault:
+  # each note is created in-session with a uniquely minted id, so client and
+  # server ids always agree. An EXISTING vault upgraded to id-keying is
+  # different — the server already holds ids for pre-existing notes, but the
+  # plugin's note_id sidecar starts empty and mints its OWN ids until it learns
+  # the server's. That divergence is the shape that produced the corruption
+  # incident. These tests reproduce the upgraded-client behavior (a client
+  # supplying an id that disagrees with the server's) and pin that it can never
+  # corrupt. This is the reusable pattern for testing upgrade/migration issues:
+  # seed pre-existing SERVER state, then drive the UPGRADED client's divergent
+  # behavior and assert no data loss.
+  describe "existing-vault upgrade safety (divergent client ids)" do
+    test "a pre-existing note re-pushed with a DIFFERENT client id updates in place, no duplicate" do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault = insert(:vault, user: user)
+
+      # Pre-existing note: created before id-keying, so the SERVER minted its id.
+      {:ok, server_note} =
+        Engram.Notes.upsert_note(user, vault, %{"path" => "note.md", "content" => "v1"})
+
+      server_id = server_note.id
+
+      # Upgraded client doesn't know the server id yet and mints its own, then
+      # pushes the SAME path. Path-match must win: the row keeps its server id
+      # (client id ignored), content updates, and NO second note is created.
+      client_id = UUIDv7.generate()
+
+      {:ok, updated} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "id" => client_id,
+          "path" => "note.md",
+          "content" => "v2"
+        })
+
+      assert updated.id == server_id
+      refute updated.id == client_id
+      assert updated.content =~ "v2"
+      assert Engram.UsageMeters.notes_count(user.id) == 1
+    end
+  end
 end

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -226,8 +226,9 @@ defmodule EngramWeb.CrdtChannelTest do
     # Log hygiene: doc_id (note_id) must appear in metadata, not the message body
     # -------------------------------------------------------------------------
 
-    test "dropped-frame warning carries doc_id in metadata, not the message body",
+    test "dropped-frame warning exposes the note_id unredacted for diagnosis",
          %{socket: socket, doc_id: doc_id} do
+      # doc_id here is a valid note_id UUID (setup fixture).
       log =
         capture_log(fn ->
           push(socket, "crdt_msg", %{"doc_id" => doc_id, "b64" => "!!!not_valid_base64!!!"})
@@ -236,13 +237,38 @@ defmodule EngramWeb.CrdtChannelTest do
           refute_push "crdt_msg", _, 300
         end)
 
-      # The warning must have fired (non-vacuous check).
       assert log =~ "dropped crdt_msg",
              "Expected 'dropped crdt_msg' warning in log, got: #{inspect(log)}"
 
-      # The raw doc_id (note_id) must NOT appear in the log message body.
-      refute String.contains?(log, doc_id),
-             "Expected doc_id #{inspect(doc_id)} to be in metadata only, but it appeared in: #{inspect(log)}"
+      # A note_id is a non-sensitive UUID and is REQUIRED to diagnose which note
+      # lost the dropped edit — it must be visible (was redacted under :path,
+      # which blocked the 2026-07-06 incident triage).
+      assert String.contains?(log, doc_id),
+             "Expected note_id #{inspect(doc_id)} to be visible in the log, got: #{inspect(log)}"
+
+      # ...but only via metadata, never interpolated into the message body.
+      [_meta_and_level, msg] = String.split(log, "[warning]", parts: 2)
+
+      refute String.contains?(msg, doc_id),
+             "note_id must live in metadata, not the message body: #{inspect(msg)}"
+    end
+
+    test "a non-UUID doc_id stays redacted — never leaks a cleartext path",
+         %{socket: socket} do
+      # A stale path-keyed client sends a path as the doc_id. It is NOT a UUID,
+      # so it must fall back to the redacted :path metadata key and never appear.
+      secret_path = "PrivateFolder/Secret Note.md"
+
+      log =
+        capture_log(fn ->
+          push(socket, "crdt_msg", %{"doc_id" => secret_path, "b64" => Base.encode64(<<0>>)})
+          refute_push "crdt_msg", _, 300
+        end)
+
+      assert log =~ "dropped crdt_msg"
+
+      refute String.contains?(log, secret_path),
+             "A cleartext path in doc_id must never appear in logs: #{inspect(log)}"
     end
 
     test "second crdt_msg for the same doc reuses the cached room", %{

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -251,6 +251,12 @@ defmodule EngramWeb.CrdtChannelTest do
 
       refute String.contains?(msg, doc_id),
              "note_id must live in metadata, not the message body: #{inspect(msg)}"
+
+      # The drop must be attributable — user_id + vault_id (both non-sensitive
+      # UUIDs) let a lost edit be traced to who hit it (the 2026-07-06 drops
+      # carried neither).
+      assert log =~ "user_id=", "drop log must carry user_id for attribution: #{inspect(log)}"
+      assert log =~ "vault_id=", "drop log must carry vault_id for attribution: #{inspect(log)}"
     end
 
     test "a non-UUID doc_id stays redacted — never leaks a cleartext path",

--- a/test/engram_web/controllers/notes_controller_test.exs
+++ b/test/engram_web/controllers/notes_controller_test.exs
@@ -118,6 +118,40 @@ defmodule EngramWeb.NotesControllerTest do
       assert unchanged.content == "# Other user's note"
       assert unchanged.version == 1
     end
+
+    test "rejects a client id colliding with the user's OWN live note (409), leaving it intact",
+         %{conn: conn} do
+      # End-to-end wire contract for the 2026-07-06 corruption guard: a push to
+      # a NEW path that reuses a note_id already LIVE at another path in the same
+      # vault must 409 — never move/merge the live note onto the new path (which
+      # destroyed the original and bled its content across notes pre-fix).
+      id = UUIDv7.generate()
+
+      post(conn, "/api/notes", %{
+        id: id,
+        path: "Test/A.md",
+        content: "# A original",
+        mtime: 1_000.0
+      })
+
+      conn2 =
+        post(conn, "/api/notes", %{
+          id: id,
+          path: "Test/B.md",
+          content: "# B different",
+          mtime: 2_000.0
+        })
+
+      assert json_response(conn2, 409)
+
+      # A survives intact at its original path — not moved, not merged.
+      a = conn |> get("/api/notes/Test/A.md") |> json_response(200)
+      assert a["content"] =~ "A original"
+      refute a["content"] =~ "B different"
+
+      # B was never created — the live note was not relocated there.
+      assert conn |> get("/api/notes/Test/B.md") |> json_response(404)
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram_web/controllers/sync_controller_test.exs
+++ b/test/engram_web/controllers/sync_controller_test.exs
@@ -41,19 +41,36 @@ defmodule EngramWeb.SyncControllerTest do
       assert is_binary(note["content_hash"])
     end
 
-    test "includes each note's stable id (client id reconciliation hook)", %{conn: conn} do
+    test "includes each note's CORRECT stable id (client id reconciliation hook)",
+         %{conn: conn, user: user, vault: vault} do
       # The plugin uses this to learn the authoritative note_id for every
       # existing note on an id-keying upgrade, instead of minting divergent
-      # ids (the 2026-07-06 corruption trigger).
+      # ids (the 2026-07-06 corruption trigger). The id must be the note's
+      # ACTUAL id — a wrong-but-valid UUID would re-create the divergence.
       post(conn, "/api/notes", %{path: "Test/A.md", content: "# Alpha", mtime: 1_000.0})
+      # The POST provisioned the DEK in the DB, but the in-struct context user
+      # is stale — load it so get_note's path_hmac derivation resolves.
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      {:ok, real} = Engram.Notes.get_note(user, vault, "Test/A.md")
 
       body = conn |> get("/api/sync/manifest") |> json_response(200)
       note = Enum.find(body["notes"], &(&1["path"] == "Test/A.md"))
 
-      assert note != nil, "expected the note in the manifest, got: #{inspect(body["notes"])}"
+      assert note["id"] == real.id
+    end
 
-      assert {:ok, _} = Ecto.UUID.cast(note["id"]),
-             "manifest note must carry a valid UUID id, got: #{inspect(note["id"])}"
+    test "includes each attachment's stable id", %{conn: conn} do
+      post(conn, "/api/attachments", %{
+        path: "photos/img.png",
+        content_base64: Base.encode64("binary data"),
+        mtime: 1_000.0
+      })
+
+      body = conn |> get("/api/sync/manifest") |> json_response(200)
+      att = hd(body["attachments"])
+
+      assert {:ok, _} = Ecto.UUID.cast(att["id"]),
+             "manifest attachment must carry a valid UUID id, got: #{inspect(att["id"])}"
     end
 
     test "includes attachments with path and content_hash", %{conn: conn} do

--- a/test/engram_web/controllers/sync_controller_test.exs
+++ b/test/engram_web/controllers/sync_controller_test.exs
@@ -41,6 +41,21 @@ defmodule EngramWeb.SyncControllerTest do
       assert is_binary(note["content_hash"])
     end
 
+    test "includes each note's stable id (client id reconciliation hook)", %{conn: conn} do
+      # The plugin uses this to learn the authoritative note_id for every
+      # existing note on an id-keying upgrade, instead of minting divergent
+      # ids (the 2026-07-06 corruption trigger).
+      post(conn, "/api/notes", %{path: "Test/A.md", content: "# Alpha", mtime: 1_000.0})
+
+      body = conn |> get("/api/sync/manifest") |> json_response(200)
+      note = Enum.find(body["notes"], &(&1["path"] == "Test/A.md"))
+
+      assert note != nil, "expected the note in the manifest, got: #{inspect(body["notes"])}"
+
+      assert {:ok, _} = Ecto.UUID.cast(note["id"]),
+             "manifest note must carry a valid UUID id, got: #{inspect(note["id"])}"
+    end
+
     test "includes attachments with path and content_hash", %{conn: conn} do
       post(conn, "/api/attachments", %{
         path: "photos/img.png",


### PR DESCRIPTION
## Incident: CRDT note_id-collision corruption (2026-07-06)

On the id-keying cutover day (#925 + #934), a prod vault corrupted: web edits never
reached Obsidian, content **bled between notes** (one note overwrote others), and notes
**blanked** on open in Obsidian. Damage was persisted server-side in `notes.content`.

### Root cause (two layers)

**Amplifier — server (this PR):** `upsert_note`'s move-by-`client_id` branch relocated +
crdt-merged **any** note sharing the pushed note_id, including a **live** note at a
different path. On the wire, "rename A→B (same id)" and "a different note reusing A's id"
are identical, so a client that emitted a duplicate note_id silently destroyed one note
and bled its content across others, fanned out via the `:moved` broadcast.

**Trigger — client (follow-up, NOT in this PR):** on an **existing-vault upgrade**, the
plugin (`pushFile`) mints its own note_ids for pre-existing notes instead of adopting the
server's, until it learns them from a pull. That divergence produces the `crdt_msg`
`:not_found` drops and, pre-fix, the rename/move that hit the server collapse. Needs
runtime confirmation (via the new logs) before fixing — see the context doc.

### What's in this PR (containment + observability)

- **Guard (`notes.ex`):** `move_note` only resurrects a **tombstoned** prior. A live
  prior found by client_id is an id-collision → `{:error, :version_conflict}` +
  `note_id_collision_rejected` log. Real renames (delete-first → tombstone) unaffected.
- **Observability (`crdt_channel.ex`):** dropped-frame log now emits the **note_id
  un-redacted** (was under the scrubbed `:path` key — it blocked triage) + `user_id`/
  `vault_id` attribution. Non-UUID doc_ids stay redacted (never leak a real path).
- **Tests:** collision guard, log visibility/redaction, and an **existing-vault upgrade
  safety** suite — the migration-test pattern the suite lacked (every prior test used a
  fresh vault, which is why this class was invisible).
- **Context doc:** `docs/context/crdt-id-collision-corruption-2026-07-06.md`.

### Why testing missed it
The suite **codified the corruption as correct** (a test asserted the destructive
live-move; removed here), and every CRDT/sync test uses a fresh vault — never the
upgrade/backfill path where the bug lives.

### Deliberately NOT here (tracked)
1. **Plugin id-reconcile fix** (the functional trigger) — deferred pending log-confirmed repro.
2. **Data recovery** — rebuild `notes.content` from the clean local Obsidian vault; needs owner sign-off (separate runbook).

Full suite: **3484 tests, 0 failures.** Draft until the plugin follow-up + recovery are decided (per the one-PR preference, but shipping the safety guard fast as incident containment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
