### PR TITLE
chore(release): bump to 0.5.638 (deploy #937)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.637",
+      version: "0.5.638",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Version-only bump so the #937 corruption fix builds + ships. main was 0.5.637 (published by #935); #937 changed deployable code without a bump. See #937. 🤖 Generated with [Claude Code](https://claude.com/claude-code)