### PR TITLE
test(e2e): follow diagnostics-toggle rename in remote-logging harness

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -1142,11 +1142,16 @@ class CdpClient:
         return result if isinstance(result, str) else ""
 
     async def enable_remote_logging(self) -> None:
-        """Enable remote logging via plugin settings and trigger save."""
+        """Enable remote logging via plugin settings and trigger save.
+
+        Remote logging is one facet of the single ``diagnosticsEnabled`` toggle
+        (plugin collapsed remoteLoggingEnabled/diagnosticMode/tracingEnabled into
+        it); saveSettings() gates rlog().setEnabled on it.
+        """
         js = f"""
         (async function() {{
             const plugin = {PLUGIN_PATH};
-            plugin.settings.remoteLoggingEnabled = true;
+            plugin.settings.diagnosticsEnabled = true;
             await plugin.saveSettings();
             return 'enabled';
         }})()

--- a/e2e/helpers/obsidian.py
+++ b/e2e/helpers/obsidian.py
@@ -136,8 +136,10 @@ class ObsidianInstance:
             # in client_logs, correlated to the #908 server breadcrumbs, so a
             # delivery flake's FIRST failing run carries client-side evidence
             # (non-deterministic flakes can't be reproduced on demand). Read by
-            # helpers/log_oracle.py::wait_for_delivery.
-            "remoteLoggingEnabled": True,
+            # helpers/log_oracle.py::wait_for_delivery. Remote logging is a facet
+            # of the single diagnosticsEnabled toggle (plugin collapsed the three
+            # legacy diagnostics flags into it).
+            "diagnosticsEnabled": True,
         }
         # Explicitly pin the file-level CRDT sync path (spec §12a) for the
         # dedicated CRDT job. NOTE: since plugin #148 enableCrdt DEFAULTS to

--- a/e2e/tests/test_16_remote_logging_pipeline.py
+++ b/e2e/tests/test_16_remote_logging_pipeline.py
@@ -39,7 +39,7 @@ async def test_remote_logging_plugin_pipeline(vault_a, cdp_a, api_sync):
     await cdp_a.flush_remote_logs()
 
     # Poll GET /logs for plugin-generated entries (retry for timing)
-    plugin_categories = {"push", "pull", "lifecycle", "pacer"}
+    plugin_categories = {"push", "pull", "lifecycle", "channel"}
     plugin_logs = []
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline:

--- a/e2e/tests/test_66_remote_logging_toggle.py
+++ b/e2e/tests/test_66_remote_logging_toggle.py
@@ -1,17 +1,18 @@
 """Test 66: Remote logging toggle stops server flush when disabled.
 
 User path covered:
-  1. Enable remote logging via settings.remoteLoggingEnabled = true.
+  1. Enable remote logging via settings.diagnosticsEnabled = true.
   2. Log 25 entries via rlog() singleton (above the flush threshold of 20).
   3. Wait for auto-flush to deliver them to the server.
-  4. Disable remote logging via settings.remoteLoggingEnabled = false.
+  4. Disable remote logging via settings.diagnosticsEnabled = false.
   5. Log 25 more entries tagged "after-disable".
   6. Wait the same interval — assert the after-disable entries do NOT appear
      on the server (logging is suppressed).
 
 Implementation notes vs plan draft:
-  - Plan used settings.remoteLogging; real field is settings.remoteLoggingEnabled
-    (src/types.ts line 14).
+  - Remote logging is one facet of the single settings.diagnosticsEnabled toggle
+    (plugin collapsed remoteLoggingEnabled/diagnosticMode/tracingEnabled into it,
+    src/types.ts); saveSettings() gates rlog().setEnabled on it.
   - Plan used plugin.remoteLog?.info() — the rlog singleton is module-level
     (src/remote-log.ts), not a property on the plugin instance.  We access it
     via app.plugins.plugins['engram-vault-sync'].syncEngine (which indirectly
@@ -44,11 +45,16 @@ AFTER_MARKER = "test66-after-disable"
 
 
 async def _set_remote_logging(cdp, enabled: bool) -> None:
-    """Toggle remoteLoggingEnabled on one instance via saveSettings."""
+    """Toggle remote logging on one instance via saveSettings.
+
+    Remote logging is a facet of the single ``diagnosticsEnabled`` toggle (the
+    plugin collapsed remoteLoggingEnabled/diagnosticMode/tracingEnabled into it);
+    saveSettings() gates rlog().setEnabled on ``diagnosticsEnabled``.
+    """
     await cdp.evaluate(
         f"(async () => {{"
         f"  const p = app.plugins.plugins['{PLUGIN_ID}'];"
-        f"  p.settings.remoteLoggingEnabled = {str(enabled).lower()};"
+        f"  p.settings.diagnosticsEnabled = {str(enabled).lower()};"
         f"  await p.saveSettings();"
         f"}})()",
         await_promise=True,
@@ -57,7 +63,7 @@ async def _set_remote_logging(cdp, enabled: bool) -> None:
 
 @pytest.mark.asyncio
 async def test_disable_stops_flush(vault_a, cdp_a, cdp_b, api_sync):
-    """Logs generated after remoteLoggingEnabled=false do not reach the server.
+    """Logs generated after diagnosticsEnabled=false do not reach the server.
 
     Both sync-pair instances are toggled. test_16/66 aside, remote logging is
     seeded ON suite-wide (helpers/obsidian.py, backend #909), so instance B
@@ -71,10 +77,10 @@ async def test_disable_stops_flush(vault_a, cdp_a, cdp_b, api_sync):
     # Setup: capture original setting on both instances.
     # ------------------------------------------------------------------ #
     original_enabled_a = await cdp_a.evaluate(
-        f"app.plugins.plugins['{PLUGIN_ID}'].settings.remoteLoggingEnabled"
+        f"app.plugins.plugins['{PLUGIN_ID}'].settings.diagnosticsEnabled"
     )
     original_enabled_b = await cdp_b.evaluate(
-        f"app.plugins.plugins['{PLUGIN_ID}'].settings.remoteLoggingEnabled"
+        f"app.plugins.plugins['{PLUGIN_ID}'].settings.diagnosticsEnabled"
     )
 
     try:
@@ -153,7 +159,7 @@ async def test_disable_stops_flush(vault_a, cdp_a, cdp_b, api_sync):
 
     finally:
         # ------------------------------------------------------------------ #
-        # Restore: reset remoteLoggingEnabled on both instances, clean up
+        # Restore: reset diagnosticsEnabled on both instances, clean up
         # seeded notes.
         # ------------------------------------------------------------------ #
         await _set_remote_logging(cdp_a, bool(original_enabled_a))

--- a/e2e/tests/test_81_suitewide_remote_logging.py
+++ b/e2e/tests/test_81_suitewide_remote_logging.py
@@ -1,7 +1,7 @@
 """Test 81: suite-wide remote logging is on by default.
 
 Regression guard for the harness seed in helpers/obsidian.py
-(``remoteLoggingEnabled: True``). Unlike test_16, this test NEVER calls
+(``diagnosticsEnabled: True``). Unlike test_16, this test NEVER calls
 ``enable_remote_logging`` — the whole point is that every device already
 ships client logs without a per-test opt-in, so a delivery flake's first
 failing run carries client-side evidence (consumed by
@@ -25,7 +25,7 @@ async def test_client_logs_ship_without_opt_in(vault_a, cdp_a, api_sync):
     await cdp_a.trigger_full_sync()
     await cdp_a.flush_remote_logs()
 
-    plugin_categories = {"push", "pull", "lifecycle", "pacer", "channel", "ws"}
+    plugin_categories = {"push", "pull", "lifecycle", "channel", "ws"}
     plugin_logs = []
     logs = []
     deadline = time.monotonic() + 10
@@ -42,6 +42,6 @@ async def test_client_logs_ship_without_opt_in(vault_a, cdp_a, api_sync):
     assert len(plugin_logs) >= 1, (
         "Suite-wide remote logging appears OFF: no plugin-generated log shipped "
         "without an explicit enable_remote_logging() call. Check the "
-        "remoteLoggingEnabled seed in helpers/obsidian.py. "
+        "diagnosticsEnabled seed in helpers/obsidian.py. "
         f"Categories seen: {[l.get('category') for l in logs]}"
     )


### PR DESCRIPTION
## Why
Plugin PR [engram-app/Engram-obsidian#187](https://github.com/engram-app/Engram-obsidian/pull/187) collapses the three diagnostics toggles (`remoteLoggingEnabled` / `diagnosticMode` / `tracingEnabled`) into a single `diagnosticsEnabled`, which is what the plugin's `saveSettings()` now gates `rlog().setEnabled()` on.

The e2e harness still toggled the **old** `remoteLoggingEnabled` key at **runtime**. The load-time seed migrates fine (the plugin's upgrade migration maps legacy keys), but a runtime `settings.x = false` does not go through migration, so `test_66` "disabled" logging via a dead key and 29 log lines still shipped:

```
tests/test_66_remote_logging_toggle.py:149: assert 29 == 0
```

This is the failure the plugin-#187 e2e run surfaced.

## What
Point the **runtime** toggles + reads at `diagnosticsEnabled`:
- `helpers/cdp.py` `enable_remote_logging()`
- `test_66` `_set_remote_logging()` + original-state reads + docstrings
- `helpers/obsidian.py` suite-wide seed (was relying on migration; now explicit)
- `test_81` docstring + assertion message

Also drop the now-dead `pacer` log category from the `test_16` / `test_81` category sets: #187 removed the vestigial client rate-limit pacer, so no `pacer` rlog lines are emitted anymore. Both are OR-match sets, so `push`/`pull`/`lifecycle`/`channel` still satisfy them.

## Coupling / pairing
This change is **coupled** with plugin #187: the old test needs the old plugin, the new test needs the new plugin. This backend branch shares the plugin branch name (`fix/crdt-pull-materialize`) so `verify.yml` auto-links them — this PR's e2e runs the new harness against the #187 plugin, and #187's e2e picks this up once merged to `main`.

Python-only (e2e harness); no Elixir, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)