### PR TITLE
test: confidence wave — live-window discipline, resumed-device, cross-interface, MCP/CRDT parity, no reruns, web leg

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -328,6 +328,66 @@ def cdp_c(obsidian_c):
 
 
 # ---------------------------------------------------------------------------
+# Resumed-device fixture (dedicated instance pair, function-scoped)
+#
+# A stop/mutate-data.json/restart cycle must never touch the session-scoped
+# A/B/C fixtures the rest of the suite depends on, so this is its own pair on
+# its own ports/displays. It shares sync_user/sync_client_id with session A/B
+# so it lands on the SAME server vault api_sync polls (client_id upsert is
+# idempotent — four "devices" on one vault is exactly the multi-device shape
+# under test).
+# ---------------------------------------------------------------------------
+
+RESUMED_CDP_PORT_A = _worker_port("E2E_CDP_PORT_RESUMED_A", "9350")
+RESUMED_CDP_PORT_B = _worker_port("E2E_CDP_PORT_RESUMED_B", "9351")
+RESUMED_DISPLAY_BASE = int(os.environ.get("E2E_DISPLAY_BASE_RESUMED") or "150") - _WORKER * 2
+assert RESUMED_DISPLAY_BASE - 1 >= 1, (
+    f"RESUMED_DISPLAY_BASE={RESUMED_DISPLAY_BASE} too low for worker {_WORKER}"
+)
+
+
+@pytest.fixture
+def fresh_instance_pair(sync_user, sync_client_id):
+    """Dedicated A/B-shaped instance pair for tests that stop/restart a device.
+
+    Function-scoped so a mid-test restart can't poison the session fixtures.
+    """
+    inst_a = ObsidianInstance(
+        name="ResumedA",
+        vault_path=Path(f"{VAULT_PREFIX}-resumed-a"),
+        cdp_port=RESUMED_CDP_PORT_A,
+        display=f":{RESUMED_DISPLAY_BASE}",
+        api_url=API_URL,
+        api_key=sync_user[2],
+        plugin_src=PLUGIN_SRC,
+        obsidian_bin=OBSIDIAN_BIN,
+        client_id=sync_client_id,
+        config_dir=Path(f"{CONFIG_PREFIX}-resumed-a"),
+    )
+    inst_b = ObsidianInstance(
+        name="ResumedB",
+        vault_path=Path(f"{VAULT_PREFIX}-resumed-b"),
+        cdp_port=RESUMED_CDP_PORT_B,
+        display=f":{RESUMED_DISPLAY_BASE - 1}",
+        api_url=API_URL,
+        api_key=sync_user[2],
+        plugin_src=PLUGIN_SRC,
+        obsidian_bin=OBSIDIAN_BIN,
+        client_id=sync_client_id,
+        config_dir=Path(f"{CONFIG_PREFIX}-resumed-b"),
+    )
+    inst_a.start()
+    inst_b.start()
+    cdp_a = CdpClient(port=inst_a.cdp_port)
+    cdp_b = CdpClient(port=inst_b.cdp_port)
+    try:
+        yield inst_a, inst_b, cdp_a, cdp_b
+    finally:
+        inst_a.stop()
+        inst_b.stop()
+
+
+# ---------------------------------------------------------------------------
 # API clients (always use API key — works with any auth provider)
 # ---------------------------------------------------------------------------
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -351,6 +351,11 @@ def _oauth_ws_warm(cdp_a, clerk_client):
         clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="warm")
         try:
             original = await swap_to_oauth(cdp_a, tokens)
+            # From here on cdp_a wears the throwaway OAuth identity, whose
+            # Clerk user the outer finally deletes. restore_auth must run on
+            # EVERY exit path, or the session-scoped cdp_a serves the rest of
+            # the suite as a deleted user and one diagnosable warm-up failure
+            # cascades into dozens of misleading auth errors downstream.
             try:
                 await wait_for_stream(cdp_a, timeout=120)
             except TimeoutError as e:
@@ -360,11 +365,23 @@ def _oauth_ws_warm(cdp_a, clerk_client):
                     "first-connect cost, not the behavior under test -- check "
                     "backend/Clerk health before assuming a real regression."
                 ) from e
-            await restore_auth(cdp_a, original)
+            finally:
+                try:
+                    await restore_auth(cdp_a, original)
+                except Exception as restore_exc:  # noqa: BLE001 - must not mask the warm-up error
+                    # Best-effort on the failure path: swallowing here keeps the
+                    # original timeout as the reported cause; the cascade risk it
+                    # leaves behind is exactly what this restore tried to avoid,
+                    # so make the attempt loudly visible.
+                    print(f"_oauth_ws_warm: restore_auth failed after warm-up error: {restore_exc}")
             await wait_for_stream(cdp_a, timeout=120)
         finally:
             clerk_client.delete_user(clerk_user_id)
 
+    # NOTE: a temporary event loop on purpose (session fixture, sync context).
+    # It leaves CdpClient._ws bound to the closed loop; the first real test's
+    # _ensure_connected ping fails and reconnects -- relied-upon self-healing,
+    # not an accident. Don't "fix" the first-ping failure you see in logs.
     asyncio.run(_warm())
 
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -16,6 +16,7 @@ files triggers the plugin's file watcher, causing unexpected sync events.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import secrets
@@ -30,6 +31,7 @@ from helpers.billing import grant_test_plan
 from helpers.cdp import CdpClient
 from helpers.cleanup import cleanup_minio_bucket, cleanup_test_data, cleanup_vaults
 from helpers.obsidian import ObsidianInstance
+from helpers.oauth import provision_oauth_tokens, swap_to_oauth, restore_auth, wait_for_stream
 
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
@@ -325,6 +327,45 @@ def cdp_b(obsidian_b):
 @pytest.fixture(scope="session")
 def cdp_c(obsidian_c):
     return CdpClient(port=obsidian_c.cdp_port)
+
+
+@pytest.fixture(scope="session")
+def _oauth_ws_warm(cdp_a, clerk_client):
+    """Absorb the OAuth WebSocket cold-boot cost once, out of any test's
+    timed connect gate.
+
+    Evidence (CI, e2e-clerk, full suite): test_47's first OAuth test alone
+    ate the whole >60s cold-boot (token refresh + getMe backoff + WS
+    phx_join, under 2-worker xdist load + a second Obsidian instance
+    booting) inside its own RT_TIMEOUT-bounded assertion; the very next
+    OAuth test then passed in ~2s once the path was warm. Doing one
+    throwaway swap/wait/restore cycle here, in fixture setup with a
+    generous 120s boot budget, moves that cost out of the timed window.
+    Session-scoped: runs once total, whichever of test_47/48/49 executes
+    first (all three swap cdp_a to OAuth and gate on wait_for_stream).
+    """
+    if clerk_client is None:
+        return  # local-auth run: no OAuth test will request this fixture either
+
+    async def _warm():
+        clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="warm")
+        try:
+            original = await swap_to_oauth(cdp_a, tokens)
+            try:
+                await wait_for_stream(cdp_a, timeout=120)
+            except TimeoutError as e:
+                raise TimeoutError(
+                    "OAuth WS cold-boot warm-up (fixture _oauth_ws_warm) timed "
+                    f"out: {e}. This is one-time suite setup absorbing the "
+                    "first-connect cost, not the behavior under test -- check "
+                    "backend/Clerk health before assuming a real regression."
+                ) from e
+            await restore_auth(cdp_a, original)
+            await wait_for_stream(cdp_a, timeout=120)
+        finally:
+            clerk_client.delete_user(clerk_user_id)
+
+    asyncio.run(_warm())
 
 
 # ---------------------------------------------------------------------------

--- a/e2e/helpers/oauth.py
+++ b/e2e/helpers/oauth.py
@@ -25,6 +25,36 @@ logger = logging.getLogger(__name__)
 _P = "app.plugins.plugins['engram-vault-sync']"
 
 
+def _assert_owns_vault(api_url: str, access_token: str, vault_id: str, *, label: str) -> None:
+    """Fail fast if a freshly-minted OAuth vault_id isn't actually owned by
+    this token's identity.
+
+    Cheap GET /vaults check, done once at provisioning time. Without this,
+    a cross-account vaultId (this identity's token, someone else's vault)
+    joins `user:` fine but the `sync:` channel refuses it server-side with
+    no client-visible error — nothing retries, and the caller just hangs
+    on wait_for_stream's 120s timeout instead of failing loudly at the
+    point the bad state was created. See
+    docs/context/oauth-e2e-pairing-and-token-binding.md.
+    """
+    resp = requests.get(
+        f"{api_url}/vaults",
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, (
+        f"[{label}] vault-ownership check: GET /vaults failed: "
+        f"{resp.status_code} {resp.text[:300]}"
+    )
+    owned_ids = {str(v["id"]) for v in resp.json().get("vaults", [])}
+    assert str(vault_id) in owned_ids, (
+        f"[{label}] resolved vault_id={vault_id} is NOT owned by this identity's "
+        f"token (owned vaults: {owned_ids or 'none'}) — cross-account vaultId "
+        "would silently fail the sync: channel join and hang wait_for_stream "
+        "for up to 120s instead of failing here"
+    )
+
+
 async def provision_oauth_tokens(
     clerk_client, api_url: str, *, label: str = "test"
 ) -> tuple[str, dict]:
@@ -72,6 +102,7 @@ async def provision_oauth_tokens(
 
     tokens = poll_for_tokens(api_url, flow["device_code"], timeout=30)
     assert "access_token" in tokens
+    _assert_owns_vault(api_url, tokens["access_token"], tokens["vault_id"], label=label)
     return clerk_user_id, tokens
 
 
@@ -119,6 +150,7 @@ async def provision_oauth_for_existing_user(
 
     tokens = poll_for_tokens(api_url, flow["device_code"], timeout=30)
     assert "access_token" in tokens
+    _assert_owns_vault(api_url, tokens["access_token"], vault_id, label=label)
     return tokens
 
 
@@ -155,6 +187,18 @@ async def swap_to_oauth(cdp, tokens: dict) -> str:
     js = f"""
     (async function() {{
         const plugin = {_P};
+        // Clear vault-scoped state from whatever identity is currently
+        // loaded BEFORE adopting the new one. A stale settings.vaultId (or
+        // an accessToken cached+bound to a prior account's vault via
+        // accessTokenVaultId) surviving into this swap can silently join
+        // the wrong sync: topic — the backend refuses that join
+        // server-side with no client-visible error, and nothing retries
+        // (docs/context/oauth-e2e-pairing-and-token-binding.md).
+        plugin.settings.vaultId = null;
+        plugin.settings.accessToken = undefined;
+        plugin.settings.accessTokenExpiresAt = undefined;
+        plugin.settings.accessTokenVaultId = undefined;
+        // Re-resolve for the new identity from freshly-minted, server-verified tokens.
         plugin.settings.refreshToken = {refresh_token};
         plugin.settings.vaultId = {vault_id};
         plugin.settings.userEmail = {user_email};
@@ -195,6 +239,12 @@ async def restore_auth(cdp, original_settings_json: str) -> None:
     js = f"""
     (async function() {{
         const plugin = {_P};
+        // Same staleness concern as swap_to_oauth: drop any accessToken
+        // cached+bound (via accessTokenVaultId) to the OAuth vault we're
+        // walking away from before restoring the original identity.
+        plugin.settings.accessToken = undefined;
+        plugin.settings.accessTokenExpiresAt = undefined;
+        plugin.settings.accessTokenVaultId = undefined;
         plugin.settings.apiKey = {api_key};
         plugin.settings.refreshToken = {refresh_token};
         plugin.settings.vaultId = {vault_id};

--- a/e2e/helpers/oauth.py
+++ b/e2e/helpers/oauth.py
@@ -219,14 +219,18 @@ async def restore_auth(cdp, original_settings_json: str) -> None:
     logger.info("Plugin auth restored: %s", result)
 
 
-async def wait_for_stream(cdp, timeout: float = 30) -> None:
+async def wait_for_stream(cdp, timeout: float = 60) -> None:
     """Poll until WebSocket channel is connected after auth change.
 
-    30s (was 15s) matches the sibling RT_TIMEOUT that #643 bumped 10s->30s for
-    the same reason: under e2e-clerk load (2-worker xdist + Clerk latency) the
-    OAuth connect chain — token refresh + getMe (with 2s/4s retry backoff) + WS
-    phx_join — legitimately exceeds 15s. #643 raised the propagation wait but
-    missed this connect gate (different file).
+    60s (was 30s, which was 15s before #643): under full-suite e2e-clerk load
+    (2-worker xdist + Clerk latency + a SECOND Obsidian instance booting) the
+    OAuth connect chain — token refresh + getMe (2s/4s retry backoff) + WS
+    phx_join — intermittently exceeded 30s (test_47/test_48). reruns=0
+    (test-confidence-wave) exposed this: reruns had been silently doubling
+    the effective wait. This is a budget bump only — plugin-obsidian#186
+    diagnoses a SEPARATE post-connect delivery race (never-seen CRDT note
+    lost between `crdt:` join and the `crdt_doc_ready` announce) that this
+    gate does not touch; that fix is tracked there, not here.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/e2e/helpers/obsidian.py
+++ b/e2e/helpers/obsidian.py
@@ -106,6 +106,18 @@ class ObsidianInstance:
         if self.config_dir.exists():
             shutil.rmtree(self.config_dir, ignore_errors=True)
 
+    def mutate_data_json(self, mutator) -> None:
+        """Stop-state helper: rewrite the plugin's persisted data.json.
+
+        Call only while the instance is stopped. `mutator` receives the parsed
+        dict and mutates in place (e.g. wipe noteIds, keep syncCursor) so tests
+        can construct RESUMED-device states no fresh boot produces.
+        """
+        p = self.vault_path / ".obsidian" / "plugins" / "engram-vault-sync" / "data.json"
+        data = json.loads(p.read_text(encoding="utf-8"))
+        mutator(data)
+        p.write_text(json.dumps(data), encoding="utf-8")
+
     def _prepare_vault(self) -> None:
         """Create vault directory with plugin files and pre-configured settings."""
         if self.vault_path.exists():

--- a/e2e/helpers/obsidian.py
+++ b/e2e/helpers/obsidian.py
@@ -106,6 +106,16 @@ class ObsidianInstance:
         if self.config_dir.exists():
             shutil.rmtree(self.config_dir, ignore_errors=True)
 
+    def read_data_json(self) -> dict:
+        """Read the plugin's persisted data.json without mutating it.
+
+        Companion to mutate_data_json — used by tests that need to poll
+        persisted state (e.g. waiting for syncCursor to appear) rather than
+        rewrite it.
+        """
+        p = self.vault_path / ".obsidian" / "plugins" / "engram-vault-sync" / "data.json"
+        return json.loads(p.read_text(encoding="utf-8"))
+
     def mutate_data_json(self, mutator) -> None:
         """Stop-state helper: rewrite the plugin's persisted data.json.
 

--- a/e2e/helpers/web_spa.py
+++ b/e2e/helpers/web_spa.py
@@ -74,6 +74,10 @@ class WebSpaPeer:
     def _editor(self):
         return self._page.locator(".cm-content")
 
+    def editor_locator(self):
+        """Public CM6 content locator, for auto-retrying `expect(...)` asserts."""
+        return self._editor()
+
     async def append(self, text: str) -> None:
         """Append `text` at end-of-doc as one atomic CM6 transaction (one CRDT op)."""
         ed = self._editor()

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -2,18 +2,11 @@
 asyncio_mode = auto
 timeout = 180
 testpaths = tests
-# TODO: drop reruns once main is green on 2-3 consecutive runs with
-# the issue #160 fix in place (per-run Clerk namespace + cron reaper).
-#
-# Deterministic flakes are fixed (PR #159 — vault-registration self-heal,
-# echo-cooldown acceleration, modal-dismiss retry, test_60 uuid emails,
-# test_71 repr(None) JS bug). The remaining cross-run Clerk race is
-# scoped out via ``r{GITHUB_RUN_ID}`` in conftest.py:ts and the hourly
-# reaper at .github/workflows/clerk-orphans.yml. Removing reruns is a
-# one-line follow-up PR once we've banked enough green runs to trust it.
-reruns = 1
-reruns_delay = 2
-# -ra = show short summary for (a)ll non-passing outcomes, including reruns.
+# reruns are OFF: pytest-rerunfailures masked real defects for weeks
+# (rerun-safety class, e2e-delivery-flake-playbook.md §5 — session fixtures
+# + hash-equal broadcast-skip make attempt 2 deterministically different).
+# A flaky test is a finding, never a retry. See testing-surface-audit doc.
+reruns = 0
 addopts = -ra
 
 # ── Logging ──────────────────────────────────────────────────────────────

--- a/e2e/tests/api_only/test_50_qdrant_binary_quantization.py
+++ b/e2e/tests/api_only/test_50_qdrant_binary_quantization.py
@@ -30,15 +30,26 @@ def _collection_info():
     return resp.json()["result"]
 
 
-def _wait_for_collection(timeout=30):
-    """Poll until the Qdrant collection exists (created on first indexing)."""
+def _wait_for_collection(timeout=120):
+    """Poll until the Qdrant collection exists (created on first indexing).
+
+    120s (was 30s): collection creation depends on the embed queue's first
+    Oban job reaching ensure_collection — Ollama cold model load on LAN plus
+    CI queue contention pushed this past 30s. reruns=0 (test-confidence-wave)
+    exposed this: main run 28907196463 RERUN-rescued this exact fixture,
+    which silently doubled the effective wait to 60s.
+    """
     deadline = time.monotonic() + timeout
+    start = time.monotonic()
     while time.monotonic() < deadline:
         try:
             return _collection_info()
         except (requests.HTTPError, requests.ConnectionError, KeyError):
             time.sleep(2)
-    raise TimeoutError(f"Collection {QDRANT_COLLECTION} not created within {timeout}s")
+    elapsed = time.monotonic() - start
+    raise TimeoutError(
+        f"Collection {QDRANT_COLLECTION} not created within {timeout}s (waited {elapsed:.1f}s)"
+    )
 
 
 @pytest.fixture(scope="module")

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -15,12 +15,12 @@ immediate read-after-write.
 
 from __future__ import annotations
 
-import asyncio
 import os
 
 import pytest
 
-from helpers.vault import delete_note, read_note, wait_for_content, wait_for_file_gone, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import delete_note, wait_for_content, wait_for_file_gone, write_note
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("E2E_ENABLE_CRDT") != "true",
@@ -32,11 +32,15 @@ CRDT_TIMEOUT = 30
 
 
 async def _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, body, marker):
-    """Create `path` on A and wait until B has it on disk — a shared CRDT base."""
+    """Create `path` on A and wait until B has it on disk live — a shared CRDT base.
+
+    No pull backstop: this is the first time `path` exists on B, so the
+    delivery oracle's non-empty guard correctly signals arrival.
+    """
     write_note(vault_a, path, body)
     api_sync.wait_for_note_content(path, marker, timeout=CRDT_TIMEOUT)
-    await cdp_b.trigger_full_sync()
-    wait_for_content(vault_b, path, marker, timeout=CRDT_TIMEOUT)
+    content = wait_for_delivery(vault_b, path, api_sync, timeout=CRDT_TIMEOUT)
+    assert marker in content, f"B never received the shared base for {path}"
 
 
 @pytest.mark.asyncio
@@ -51,8 +55,7 @@ async def test_discovery_creates_file_on_b(vault_a, vault_b, cdp_a, cdp_b, api_s
     write_note(vault_a, path, "# Discovery\nbody authored on device A")
     api_sync.wait_for_note_content(path, "device A", timeout=CRDT_TIMEOUT)
 
-    await cdp_b.trigger_full_sync()
-    content = wait_for_content(vault_b, path, "device A", timeout=CRDT_TIMEOUT)
+    content = wait_for_delivery(vault_b, path, api_sync, timeout=CRDT_TIMEOUT)
     assert "body authored on device A" in content
 
 
@@ -70,12 +73,10 @@ async def test_concurrent_edits_both_survive(vault_a, vault_b, cdp_a, cdp_b, api
     write_note(vault_a, path, "shared base\nFROM_A\n")
     write_note(vault_b, path, "shared base\nFROM_B\n")
 
-    # Drive convergence in both directions.
-    for _ in range(3):
-        await asyncio.sleep(3)
-        await cdp_a.trigger_full_sync()
-        await cdp_b.trigger_full_sync()
-
+    # Both sides converge live over the y-protocols handshake — no pull
+    # backstop. Both files already exist (from the shared base above), so
+    # the content-aware poll (not the oracle's non-empty guard) proves the
+    # other side's edit actually arrived.
     a_final = wait_for_content(vault_a, path, "FROM_B", timeout=CRDT_TIMEOUT)
     b_final = wait_for_content(vault_b, path, "FROM_A", timeout=CRDT_TIMEOUT)
     assert "FROM_A" in a_final and "FROM_B" in a_final, f"A lost an edit: {a_final!r}"
@@ -91,10 +92,11 @@ async def test_no_conflict_modal_on_divergence(vault_a, vault_b, cdp_a, cdp_b, a
 
     write_note(vault_a, path, "base line\nA change\n")
     write_note(vault_b, path, "base line\nB change\n")
-    for _ in range(3):
-        await asyncio.sleep(3)
-        await cdp_a.trigger_full_sync()
-        await cdp_b.trigger_full_sync()
+
+    # Wait for the merge to actually converge live before checking for a
+    # modal — otherwise "no modal yet" would be a race, not a guarantee.
+    wait_for_content(vault_a, path, "B change", timeout=CRDT_TIMEOUT)
+    wait_for_content(vault_b, path, "A change", timeout=CRDT_TIMEOUT)
 
     # No conflict modal open in either app.
     for cdp in (cdp_a, cdp_b):
@@ -124,11 +126,6 @@ async def test_delete_propagates(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "delete me\n", "delete me")
 
     delete_note(vault_a, path)
-    for _ in range(3):
-        await asyncio.sleep(2)
-        await cdp_a.trigger_full_sync()
-        await cdp_b.trigger_full_sync()
-
     wait_for_file_gone(vault_b, path, timeout=CRDT_TIMEOUT)
 
 
@@ -140,10 +137,6 @@ async def test_edit_after_discovery_round_trips(vault_a, vault_b, cdp_a, cdp_b, 
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "origin A\n", "origin A")
 
     write_note(vault_b, path, "origin A\nappended on B\n")
-    for _ in range(3):
-        await asyncio.sleep(3)
-        await cdp_b.trigger_full_sync()
-        await cdp_a.trigger_full_sync()
 
     a_content = wait_for_content(vault_a, path, "appended on B", timeout=CRDT_TIMEOUT)
     assert "origin A" in a_content and "appended on B" in a_content

--- a/e2e/tests/crdt/test_obsidian_to_web_live.py
+++ b/e2e/tests/crdt/test_obsidian_to_web_live.py
@@ -1,0 +1,51 @@
+"""Cross-device coverage: an OBSIDIAN edit renders LIVE in the web SPA (audit #7).
+
+Counterpart to test_web_to_obsidian_live.py — same `web` fixture, same
+CRDT-only placement (the only CI job with local auth `WebSpaPeer` can sign
+into; e2e-clerk runs the rest of tests/ under Clerk auth, which this SPA
+sign-in helper does not speak).
+
+The SPA's note editor subscribes to the Phoenix CRDT channel and re-seeds its
+Y.Doc on any `note_changed` broadcast (frontend/e2e/note-live-update.spec.ts
+#277) — an Obsidian plugin push is exactly the "remote client upserts the
+open note" case that spec already covers for a REST-originated write. This
+proves the same live path for an Obsidian-originated write, with a second
+edit landing in the SAME open tab (no `page.goto`/reload) as the assertion
+that live delivery, not just initial load, is working.
+
+v1 scope is the read direction only (Obsidian -> web); the write direction
+(SPA CodeMirror edit -> Obsidian) is already covered by
+test_web_to_obsidian_live.py.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from playwright.async_api import expect
+
+from helpers.vault import write_note
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("E2E_ENABLE_CRDT") != "true",
+    reason="CRDT-only suite — set E2E_ENABLE_CRDT=true with a CRDT_ENABLED backend",
+)
+
+RT_TIMEOUT = 30  # generous: Obsidian push -> server -> WS -> SPA re-render
+
+
+@pytest.mark.asyncio
+async def test_obsidian_edit_renders_live_in_spa(vault_a, api_sync, web, sync_vault_id):
+    path = "E2E/Crdt/ObsidianToWeb.md"
+    write_note(vault_a, path, "# Web Live\nv1 from Obsidian")
+    note = api_sync.wait_for_note(path, timeout=15)
+
+    await web.open_note(note["id"], sync_vault_id)
+    editor = web.editor_locator()
+    await expect(editor).to_contain_text("v1 from Obsidian", timeout=15_000)
+
+    # THE assertion: a fresh Obsidian edit appears in the already-open tab
+    # WITHOUT any reload/navigation.
+    write_note(vault_a, path, "# Web Live\nv2 live update")
+    await expect(editor).to_contain_text("v2 live update", timeout=RT_TIMEOUT * 1_000)

--- a/e2e/tests/test_03_reverse_sync_b_to_a.py
+++ b/e2e/tests/test_03_reverse_sync_b_to_a.py
@@ -1,25 +1,21 @@
-"""Test 03: B creates note → A receives it. Proves bidirectional sync."""
+"""Test 03: B creates note → A receives it LIVE. Proves bidirectional live sync."""
 
 import pytest
 
-from helpers.vault import wait_for_exact_content, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import write_note
 
 
 @pytest.mark.asyncio
 async def test_b_creates_a_receives(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Reverse direction: B writes, A pulls."""
+    """Reverse direction: B writes, A receives via WS — no manual pull."""
     path = "E2E/ReverseSync.md"
     content = "# Reverse Sync\nCreated in vault B, should appear in vault A."
 
-    # B creates the note
     write_note(vault_b, path, content)
 
-    # Poll server until B's plugin pushes it
     note = api_sync.wait_for_note(path, timeout=10)
     assert note is not None, "Note not on server after B's push"
 
-    # A pulls
-    await cdp_a.trigger_full_sync()
-
-    # Verify the FULL body landed in A's vault (poll — pull write is async)
-    wait_for_exact_content(vault_a, path, content, timeout=15)
+    received = wait_for_delivery(vault_a, path, api_sync, timeout=30)
+    assert content in received

--- a/e2e/tests/test_04_modify_propagation.py
+++ b/e2e/tests/test_04_modify_propagation.py
@@ -2,12 +2,13 @@
 
 import pytest
 
-from helpers.vault import wait_for_exact_content, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import wait_for_content, write_note
 
 
 @pytest.mark.asyncio
 async def test_modify_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """A edits an existing synced note, B receives the update."""
+    """A edits an existing synced note, B receives the update — no manual pull."""
     path = "E2E/ModifyTest.md"
     v1 = "# Modify Test\nVersion 1"
     v2 = "# Modify Test\nVersion 2 — updated by A"
@@ -16,9 +17,9 @@ async def test_modify_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     write_note(vault_a, path, v1)
     api_sync.wait_for_note(path, timeout=10)
 
-    # Sync to B
-    await cdp_b.trigger_full_sync()
-    wait_for_exact_content(vault_b, path, v1, timeout=15)
+    # B receives it live (first delivery — file doesn't exist on B yet)
+    received = wait_for_delivery(vault_b, path, api_sync, timeout=30)
+    assert v1 in received
 
     # A modifies the note
     write_note(vault_a, path, v2)
@@ -26,6 +27,9 @@ async def test_modify_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     # Poll server until update lands
     api_sync.wait_for_note_content(path, "Version 2", timeout=10)
 
-    # B pulls the update — exact match proves v1 fully replaced, not merged/duplicated
-    await cdp_b.trigger_full_sync()
-    wait_for_exact_content(vault_b, path, v2, timeout=15)
+    # B receives the update live — no manual pull. B's file already exists
+    # (from v1 above) so the delivery oracle's non-empty guard can't detect
+    # this specific update; wait_for_content polls for the new marker text
+    # instead, which is still a pure vault-disk poll with no pull involved.
+    received = wait_for_content(vault_b, path, "Version 2", timeout=30)
+    assert v2 in received, "Full v2 body should replace v1, not merge/duplicate"

--- a/e2e/tests/test_05_delete_propagation.py
+++ b/e2e/tests/test_05_delete_propagation.py
@@ -2,21 +2,21 @@
 
 import pytest
 
+from helpers.log_oracle import wait_for_delivery
 from helpers.vault import delete_note, wait_for_file_gone, write_note
 
 
 @pytest.mark.asyncio
 async def test_delete_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """A deletes a synced file, B's copy should be removed on next pull."""
+    """A deletes a synced file, B's copy should be removed live — no manual pull."""
     path = "E2E/DeleteTest.md"
 
     # A creates the note
     write_note(vault_a, path, "# Delete Test\nThis file will be deleted.")
     api_sync.wait_for_note(path, timeout=10)
 
-    # Sync to B
-    await cdp_b.trigger_full_sync()
-    assert (vault_b / path).exists(), "B should have the note before deletion"
+    # B receives it live before deletion
+    wait_for_delivery(vault_b, path, api_sync, timeout=30)
 
     # A deletes the note
     delete_note(vault_a, path)
@@ -24,8 +24,5 @@ async def test_delete_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     # Poll server until delete propagates (soft-delete → 404)
     api_sync.wait_for_note_gone(path, timeout=10)
 
-    # B pulls — file should be trashed/removed
-    await cdp_b.trigger_full_sync()
-
-    # Wait for file to disappear (plugin moves to .trash)
-    wait_for_file_gone(vault_b, path, timeout=10)
+    # B removes it live (plugin moves to .trash) — no manual pull backstop
+    wait_for_file_gone(vault_b, path, timeout=30)

--- a/e2e/tests/test_09_bidirectional_multi.py
+++ b/e2e/tests/test_09_bidirectional_multi.py
@@ -2,12 +2,13 @@
 
 import pytest
 
+from helpers.log_oracle import wait_for_delivery
 from helpers.vault import list_notes, read_note, write_note
 
 
 @pytest.mark.asyncio
 async def test_bidirectional_multi_file(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Both sides create multiple files; after sync, both vaults have all of them."""
+    """Both sides create multiple files; after live sync, both vaults have all of them."""
     a_files = {
         "E2E/Multi/FromA-1.md": "# From A 1\nFirst file from A",
         "E2E/Multi/FromA-2.md": "# From A 2\nSecond file from A",
@@ -31,9 +32,11 @@ async def test_bidirectional_multi_file(vault_a, vault_b, cdp_a, cdp_b, api_sync
     for path in list(a_files) + list(b_files):
         api_sync.wait_for_note(path, timeout=15)
 
-    # Both sides pull to receive the other's files
-    await cdp_a.trigger_full_sync()
-    await cdp_b.trigger_full_sync()
+    # A receives B's files live, B receives A's files live — no manual pull.
+    for path in b_files:
+        wait_for_delivery(vault_a, path, api_sync, timeout=30)
+    for path in a_files:
+        wait_for_delivery(vault_b, path, api_sync, timeout=30)
 
     # Verify A has all 6 files
     for path in list(a_files) + list(b_files):

--- a/e2e/tests/test_10_rename_propagation.py
+++ b/e2e/tests/test_10_rename_propagation.py
@@ -9,7 +9,7 @@ import uuid
 import pytest
 
 from helpers.log_oracle import wait_for_delivery
-from helpers.vault import read_note, wait_for_file, wait_for_file_gone, write_note
+from helpers.vault import wait_for_file_gone, write_note
 
 
 @pytest.mark.asyncio
@@ -30,9 +30,8 @@ async def test_rename_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     write_note(vault_a, old_path, "# Rename Test\nThis file will be renamed.")
     api_sync.wait_for_note(old_path, timeout=10)
 
-    # Sync to B
-    await cdp_b.trigger_full_sync()
-    wait_for_file(vault_b, old_path, timeout=10)  # B has the note before rename
+    # B receives it live before rename — no manual pull
+    wait_for_delivery(vault_b, old_path, api_sync, timeout=30)
 
     # A renames via Obsidian's vault API (triggers handleRename → POST /notes/rename)
     await cdp_a.rename_file(old_path, new_path)
@@ -41,12 +40,10 @@ async def test_rename_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     api_sync.wait_for_note(new_path, timeout=10)
     api_sync.wait_for_note_gone(old_path, timeout=10)
 
-    # B pulls
-    await cdp_b.trigger_full_sync()
-
-    # Verify: B has new path, does NOT have old path. The rename reaches B as two
-    # separate events (delete old-path + upsert new-path), so the old-path removal
-    # can lag the new-path arrival — poll for it rather than asserting a snapshot.
-    b_content = wait_for_delivery(vault_b, new_path, api_sync, timeout=10)
+    # Verify: B has new path, does NOT have old path — both live, no manual pull.
+    # The rename reaches B as two separate events (delete old-path + upsert
+    # new-path), so the old-path removal can lag the new-path arrival — poll
+    # for it rather than asserting a snapshot.
+    b_content = wait_for_delivery(vault_b, new_path, api_sync, timeout=30)
     assert "Rename Test" in b_content, "B should have the renamed file"
-    wait_for_file_gone(vault_b, old_path, timeout=10)  # B no longer has the old path
+    wait_for_file_gone(vault_b, old_path, timeout=30)  # B no longer has the old path

--- a/e2e/tests/test_10_rename_propagation.py
+++ b/e2e/tests/test_10_rename_propagation.py
@@ -28,7 +28,10 @@ async def test_rename_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
 
     # A creates the note
     write_note(vault_a, old_path, "# Rename Test\nThis file will be renamed.")
-    api_sync.wait_for_note(old_path, timeout=10)
+    # 30s server-side budgets: the sender's first push / rename of a session
+    # can lag under CI load (cold-start reconcile sequencing, plugin#189's
+    # push face) — these are setup waits, not the live-delivery asserts.
+    api_sync.wait_for_note(old_path, timeout=30)
 
     # B receives it live before rename — no manual pull
     wait_for_delivery(vault_b, old_path, api_sync, timeout=30)
@@ -37,8 +40,8 @@ async def test_rename_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     await cdp_a.rename_file(old_path, new_path)
 
     # Wait for server to reflect the rename
-    api_sync.wait_for_note(new_path, timeout=10)
-    api_sync.wait_for_note_gone(old_path, timeout=10)
+    api_sync.wait_for_note(new_path, timeout=30)
+    api_sync.wait_for_note_gone(old_path, timeout=30)
 
     # Verify: B has new path, does NOT have old path — both live, no manual pull.
     # The rename reaches B as two separate events (delete old-path + upsert

--- a/e2e/tests/test_27_empty_note_sync.py
+++ b/e2e/tests/test_27_empty_note_sync.py
@@ -4,14 +4,33 @@ Edge case: a zero-content .md file should push, pull, and then accept
 edits that propagate normally.
 """
 
+import time
+
 import pytest
 
-from helpers.vault import read_note, wait_for_file, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import read_note, write_note
+
+
+def _wait_for_file_exists(vault_path, rel_path: str, timeout: float = 30, poll: float = 0.3) -> None:
+    """Poll for existence, allowing a genuinely empty (0-byte) file.
+
+    wait_for_delivery/wait_for_file guard on non-empty content to dodge the
+    0-byte read-before-flush race, but this test's whole point is a note
+    that legitimately stays empty — that guard would hang forever here.
+    """
+    full = vault_path / rel_path
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if full.exists():
+            return
+        time.sleep(poll)
+    raise TimeoutError(f"File {rel_path} did not appear within {timeout}s")
 
 
 @pytest.mark.asyncio
 async def test_empty_note_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Empty note pushes to server and pulls to B, then edits propagate."""
+    """Empty note pushes to server and reaches B live, then edits propagate."""
     path = "E2E/EmptyNote.md"
 
     # A creates an empty markdown file
@@ -22,9 +41,8 @@ async def test_empty_note_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     note = api_sync.get_note(path)
     assert note is not None, "Empty note should exist on server"
 
-    # B pulls — should get the empty file
-    await cdp_b.trigger_full_sync()
-    assert (vault_b / path).exists(), "B should have the empty file"
+    # B receives it live — no manual pull
+    _wait_for_file_exists(vault_b, path, timeout=30)
     b_content = read_note(vault_b, path)
     assert b_content.strip() == "" or len(b_content.strip()) == 0, (
         f"B's file should be empty, got: {b_content[:100]}"
@@ -34,9 +52,8 @@ async def test_empty_note_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     write_note(vault_a, path, "# No Longer Empty\nThis note has content now.")
     api_sync.wait_for_note_content(path, "No Longer Empty", timeout=10)
 
-    # B pulls the update
-    await cdp_b.trigger_full_sync()
-    b_content = read_note(vault_b, path)
+    # B receives the update live — no manual pull
+    b_content = wait_for_delivery(vault_b, path, api_sync, timeout=30)
     assert "No Longer Empty" in b_content, (
         f"B should have updated content, got: {b_content[:200]}"
     )

--- a/e2e/tests/test_33_attachment_sync.py
+++ b/e2e/tests/test_33_attachment_sync.py
@@ -1,13 +1,14 @@
 """Test 33: Binary attachment syncs from vault A to vault B.
 
 A creates a small PNG in the vault. The plugin detects it as a binary
-extension, pushes via pushAttachment. B syncs and receives the file
-with identical bytes. Deletion on A propagates to server and then to B.
+extension, pushes via pushAttachment. B receives it live with identical
+bytes. Deletion on A propagates to server and then to B live.
 """
 
 import pytest
 
-from helpers.vault import wait_for_binary, wait_for_file_gone, write_binary
+from helpers.log_oracle import wait_for_binary_delivery
+from helpers.vault import wait_for_file_gone, write_binary
 
 
 # Minimal valid PNG: 1x1 red pixel
@@ -21,14 +22,13 @@ TINY_PNG = (
 
 @pytest.mark.asyncio
 async def test_attachment_push_and_pull(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """A writes a PNG → server stores it → B pulls identical bytes."""
+    """A writes a PNG → server stores it → B receives identical bytes live."""
     att_path = "E2E/attachments/test33.png"
 
     write_binary(vault_a, att_path, TINY_PNG)
     api_sync.wait_for_attachment(att_path)
 
-    await cdp_b.trigger_full_sync()
-    b_data = wait_for_binary(vault_b, att_path, timeout=15)
+    b_data = wait_for_binary_delivery(vault_b, att_path, api_sync, timeout=30)
     assert b_data == TINY_PNG, (
         f"B's attachment bytes should match. Got {len(b_data)} bytes, expected {len(TINY_PNG)}"
     )
@@ -36,22 +36,18 @@ async def test_attachment_push_and_pull(vault_a, vault_b, cdp_a, cdp_b, api_sync
 
 @pytest.mark.asyncio
 async def test_attachment_delete_propagation(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Deleting an attachment on A removes it from server and B."""
+    """Deleting an attachment on A removes it from server and B live."""
     att_path = "E2E/attachments/test33del.png"
 
-    # Setup: A creates, server receives, B pulls a copy.
+    # Setup: A creates, server receives, B receives a copy live.
     write_binary(vault_a, att_path, TINY_PNG)
     api_sync.wait_for_attachment(att_path)
-    await cdp_b.trigger_full_sync()
-    wait_for_binary(vault_b, att_path, timeout=15)
+    wait_for_binary_delivery(vault_b, att_path, api_sync, timeout=30)
 
     # A deletes — vault.delete fires handleDelete on A, which calls
     # /attachments DELETE. Server reflects the soft-delete as 404.
     (vault_a / att_path).unlink()
     api_sync.wait_for_attachment_gone(att_path)
 
-    # B pulls — deletion propagates. Live-sync channel may already have
-    # delivered the delete by the time fullSync runs; either path lands
-    # B in the same final state.
-    await cdp_b.trigger_full_sync()
-    wait_for_file_gone(vault_b, att_path, timeout=15)
+    # B removes it live — no manual pull backstop
+    wait_for_file_gone(vault_b, att_path, timeout=30)

--- a/e2e/tests/test_34_folder_rename_propagation.py
+++ b/e2e/tests/test_34_folder_rename_propagation.py
@@ -1,21 +1,20 @@
 """Test 34: Folder rename propagates — notes appear at new paths on B.
 
 A creates notes in a folder. Server-side folder rename moves all notes
-(in-place path update + soft-deleted tombstone for old path). B syncs
-and sees notes under the new folder path. Old paths are cleaned up via
-the tombstone delete signals in the changes feed.
+(in-place path update + soft-deleted tombstone for old path). B receives
+the new paths live and sees old paths cleaned up via the tombstone delete
+signals — no manual pull backstop.
 """
-
-import time
 
 import pytest
 
-from helpers.vault import wait_for_file, wait_for_file_gone, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import wait_for_file_gone, write_note
 
 
 @pytest.mark.asyncio
 async def test_folder_rename_new_paths(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Renaming a folder makes notes appear at new paths for B."""
+    """Renaming a folder makes notes appear at new paths for B, live."""
     old_folder = "E2E/RenameFolder34"
     new_folder = "E2E/RenamedFolder34"
     note1 = f"{old_folder}/Note1.md"
@@ -27,10 +26,9 @@ async def test_folder_rename_new_paths(vault_a, vault_b, cdp_a, cdp_b, api_sync)
     api_sync.wait_for_note(note1, timeout=10)
     api_sync.wait_for_note(note2, timeout=10)
 
-    # B syncs to establish state
-    await cdp_b.trigger_full_sync()
-    assert (vault_b / note1).exists(), "B should have Note1 before rename"
-    assert (vault_b / note2).exists(), "B should have Note2 before rename"
+    # B receives both live to establish state before rename
+    wait_for_delivery(vault_b, note1, api_sync, timeout=30)
+    wait_for_delivery(vault_b, note2, api_sync, timeout=30)
 
     # Rename folder via API
     status = api_sync.rename_folder(old_folder, new_folder)
@@ -42,28 +40,25 @@ async def test_folder_rename_new_paths(vault_a, vault_b, cdp_a, cdp_b, api_sync)
     api_sync.wait_for_note(new_note1, timeout=10)
     api_sync.wait_for_note(new_note2, timeout=10)
 
-    # B syncs — should see new paths
-    await cdp_b.trigger_full_sync()
-    wait_for_file(vault_b, new_note1, timeout=15)
-    wait_for_file(vault_b, new_note2, timeout=15)
+    # B receives the new paths live — no manual pull
+    wait_for_delivery(vault_b, new_note1, api_sync, timeout=30)
+    wait_for_delivery(vault_b, new_note2, api_sync, timeout=30)
 
 
 @pytest.mark.asyncio
 async def test_folder_rename_old_paths_cleaned(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """After folder rename, old paths should be removed from B's vault."""
+    """After folder rename, old paths should be removed from B's vault live."""
     old_folder = "E2E/RenameCleanup34"
     new_folder = "E2E/RenamedCleanup34"
     note = f"{old_folder}/Cleanup.md"
 
     write_note(vault_a, note, "# Cleanup Test\nShould be removed at old path")
     api_sync.wait_for_note(note, timeout=10)
-    await cdp_b.trigger_full_sync()
-    assert (vault_b / note).exists(), "B should have note before rename"
+    wait_for_delivery(vault_b, note, api_sync, timeout=30)
 
     # Rename folder
     api_sync.rename_folder(old_folder, new_folder)
     api_sync.wait_for_note(f"{new_folder}/Cleanup.md", timeout=10)
 
-    # B syncs — tombstone delete signal should remove old path
-    await cdp_b.trigger_full_sync()
-    wait_for_file_gone(vault_b, note, timeout=15)
+    # B removes the old path live — tombstone delete signal, no manual pull
+    wait_for_file_gone(vault_b, note, timeout=30)

--- a/e2e/tests/test_37_append_sync.py
+++ b/e2e/tests/test_37_append_sync.py
@@ -1,26 +1,26 @@
-"""Test 37: Append-only sync — POST /notes/append adds content, B receives it.
+"""Test 37: Append-only sync — POST /notes/append adds content, B receives it live.
 
 Verifies that server-side append modifies the note and the appended
-content propagates to B on next sync.
+content propagates to B over live sync, with no manual pull.
 """
 
 import pytest
 
-from helpers.vault import read_note, wait_for_content, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import wait_for_content, write_note
 
 
 @pytest.mark.asyncio
 async def test_append_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Append via API grows the note, B receives cumulative content."""
+    """Append via API grows the note, B receives cumulative content live."""
     path = "E2E/AppendSync37.md"
 
     # A creates the base note
     write_note(vault_a, path, "# Append Test\nOriginal content.")
     api_sync.wait_for_note(path, timeout=10)
 
-    # B syncs to get base
-    await cdp_b.trigger_full_sync()
-    assert (vault_b / path).exists(), "B should have base note"
+    # B receives the base note live (first delivery — file doesn't exist yet)
+    wait_for_delivery(vault_b, path, api_sync, timeout=30)
 
     # Append via API
     status = api_sync.append_note(path, "\nAppended line 1.")
@@ -29,9 +29,11 @@ async def test_append_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     # Verify server has appended content
     api_sync.wait_for_note_content(path, "Appended line 1", timeout=10)
 
-    # B syncs — should see appended content
-    await cdp_b.trigger_full_sync()
-    b_content = wait_for_content(vault_b, path, "Appended line 1", timeout=15)
+    # B receives the appended content live. B's file already exists (from the
+    # base note above) so the delivery oracle's non-empty guard can't detect
+    # this specific update; wait_for_content polls for the new marker instead
+    # — still a pure vault-disk poll, no pull involved.
+    b_content = wait_for_content(vault_b, path, "Appended line 1", timeout=30)
     assert "Original content" in b_content, "Original content should be preserved"
 
     # Append again
@@ -39,8 +41,7 @@ async def test_append_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     assert status == 200, f"Second append should succeed, got {status}"
     api_sync.wait_for_note_content(path, "Appended line 2", timeout=10)
 
-    # B syncs again — cumulative
-    await cdp_b.trigger_full_sync()
-    b_content = wait_for_content(vault_b, path, "Appended line 2", timeout=15)
+    # B receives the second append live — cumulative
+    b_content = wait_for_content(vault_b, path, "Appended line 2", timeout=30)
     assert "Appended line 1" in b_content, "First append should still be present"
     assert "Appended line 2" in b_content, "Second append should be present"

--- a/e2e/tests/test_38_special_char_paths.py
+++ b/e2e/tests/test_38_special_char_paths.py
@@ -1,61 +1,62 @@
 """Test 38: Notes with special characters in filenames sync correctly.
 
 Tests unicode, spaces, parentheses, and emoji in file paths — all common
-patterns in real Obsidian vaults.
+patterns in real Obsidian vaults. B receives each live, no manual pull.
 """
 
 import pytest
 
-from helpers.vault import wait_for_exact_content, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import write_note
 
 
 @pytest.mark.asyncio
 async def test_spaces_in_path(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """File with spaces in name syncs A→B."""
+    """File with spaces in name syncs A→B live."""
     path = "E2E/My Notes (2026).md"
     content = "# Spaced Path\nContent with spaces in filename."
 
     write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
-    await cdp_b.trigger_full_sync()
-    wait_for_exact_content(vault_b, path, content, timeout=15)
+    received = wait_for_delivery(vault_b, path, api_sync, timeout=30)
+    assert content in received
 
 
 @pytest.mark.asyncio
 async def test_unicode_in_path(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """File with unicode characters syncs A→B."""
+    """File with unicode characters syncs A→B live."""
     path = "E2E/Café Résumé.md"
     content = "# Café Notes\nAccented characters in filename."
 
     write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
-    await cdp_b.trigger_full_sync()
-    wait_for_exact_content(vault_b, path, content, timeout=15)
+    received = wait_for_delivery(vault_b, path, api_sync, timeout=30)
+    assert content in received
 
 
 @pytest.mark.asyncio
 async def test_emoji_in_path(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """File with emoji in name syncs A→B (common Obsidian pattern)."""
+    """File with emoji in name syncs A→B live (common Obsidian pattern)."""
     path = "E2E/📝 Daily Log.md"
     content = "# Daily Log\nEmoji filename test."
 
     write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
-    await cdp_b.trigger_full_sync()
-    wait_for_exact_content(vault_b, path, content, timeout=15)
+    received = wait_for_delivery(vault_b, path, api_sync, timeout=30)
+    assert content in received
 
 
 @pytest.mark.asyncio
 async def test_special_chars_combined(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """File with mixed special characters syncs A→B."""
+    """File with mixed special characters syncs A→B live."""
     path = "E2E/Project [v2.0] — Final (Draft).md"
     content = "# Mixed Special Chars\nBrackets, em-dash, parens."
 
     write_note(vault_a, path, content)
     api_sync.wait_for_note(path, timeout=10)
 
-    await cdp_b.trigger_full_sync()
-    wait_for_exact_content(vault_b, path, content, timeout=15)
+    received = wait_for_delivery(vault_b, path, api_sync, timeout=30)
+    assert content in received

--- a/e2e/tests/test_41_canvas_sync.py
+++ b/e2e/tests/test_41_canvas_sync.py
@@ -2,14 +2,16 @@
 
 Canvas files are JSON text treated as TEXT_EXTENSIONS in the plugin.
 They sync through the same pushNote path as markdown but with a
-different extension. Verifies the full round-trip preserves JSON structure.
+different extension. Verifies the full round-trip preserves JSON structure,
+received live on B with no manual pull.
 """
 
 import json
 
 import pytest
 
-from helpers.vault import wait_for_file, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import wait_for_content, write_note
 
 
 CANVAS_CONTENT = json.dumps({
@@ -25,7 +27,7 @@ CANVAS_CONTENT = json.dumps({
 
 @pytest.mark.asyncio
 async def test_canvas_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Canvas JSON file syncs A→B with structure preserved."""
+    """Canvas JSON file syncs A→B live with structure preserved."""
     path = "E2E/TestCanvas41.canvas"
 
     # A creates a canvas file
@@ -38,9 +40,8 @@ async def test_canvas_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     note = api_sync.wait_for_note(path, timeout=10)
     assert note is not None, "Canvas should be on server"
 
-    # B syncs
-    await cdp_b.trigger_full_sync()
-    b_raw = wait_for_file(vault_b, path, timeout=15)
+    # B receives it live — no manual pull
+    b_raw = wait_for_delivery(vault_b, path, api_sync, timeout=30)
 
     # Verify JSON structure is preserved
     b_data = json.loads(b_raw)
@@ -51,13 +52,13 @@ async def test_canvas_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
 
 @pytest.mark.asyncio
 async def test_canvas_modify_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Modifying a canvas on A propagates changes to B."""
+    """Modifying a canvas on A propagates changes to B live."""
     path = "E2E/TestCanvasMod41.canvas"
 
-    # Create base canvas
+    # Create base canvas, B receives it live
     write_note(vault_a, path, CANVAS_CONTENT)
     api_sync.wait_for_note(path, timeout=10)
-    await cdp_b.trigger_full_sync()
+    wait_for_delivery(vault_b, path, api_sync, timeout=30)
 
     # Modify canvas — add a node
     modified = json.loads(CANVAS_CONTENT)
@@ -69,8 +70,10 @@ async def test_canvas_modify_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
 
     api_sync.wait_for_note_content(path, "New node", timeout=10)
 
-    # B syncs
-    await cdp_b.trigger_full_sync()
-    b_raw = wait_for_file(vault_b, path, timeout=15)
+    # B receives the modification live. B's file already exists (from the
+    # base canvas above) so the delivery oracle's non-empty guard can't
+    # detect this specific update; wait_for_content polls for the new node's
+    # text instead — still a pure vault-disk poll, no pull involved.
+    b_raw = wait_for_content(vault_b, path, "New node", timeout=30)
     b_data = json.loads(b_raw)
     assert len(b_data["nodes"]) == 3, "Modified canvas should have 3 nodes"

--- a/e2e/tests/test_43_deeply_nested_folders.py
+++ b/e2e/tests/test_43_deeply_nested_folders.py
@@ -1,17 +1,18 @@
 """Test 43: Deeply nested folder paths (4+ levels) sync correctly.
 
 Obsidian allows arbitrary nesting. Verifies that deep paths like
-E2E/A/B/C/D/Note.md push, pull, and propagate without path truncation.
+E2E/A/B/C/D/Note.md push and reach B live, without path truncation.
 """
 
 import pytest
 
-from helpers.vault import wait_for_file, write_note
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import write_note
 
 
 @pytest.mark.asyncio
 async def test_deep_folder_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """4-level deep note syncs A→B with full path preserved."""
+    """4-level deep note syncs A→B live with full path preserved."""
     path = "E2E/Level1/Level2/Level3/Level4/DeepNote43.md"
 
     write_note(vault_a, path, "# Deep Note\nFour levels of nesting.")
@@ -23,15 +24,14 @@ async def test_deep_folder_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     assert server_note.get("folder") == "E2E/Level1/Level2/Level3/Level4", \
         f"Folder should be the parent, got: {server_note.get('folder')}"
 
-    # B syncs
-    await cdp_b.trigger_full_sync()
-    b_content = wait_for_file(vault_b, path, timeout=15)
+    # B receives it live — no manual pull
+    b_content = wait_for_delivery(vault_b, path, api_sync, timeout=30)
     assert "Deep Note" in b_content
 
 
 @pytest.mark.asyncio
 async def test_deep_folder_multiple_notes(vault_a, vault_b, cdp_a, cdp_b, api_sync):
-    """Multiple notes at different depths all sync correctly."""
+    """Multiple notes at different depths all sync correctly, live."""
     paths = {
         "E2E/Depth43/A.md": "# Level 1",
         "E2E/Depth43/Sub/B.md": "# Level 2",
@@ -46,12 +46,9 @@ async def test_deep_folder_multiple_notes(vault_a, vault_b, cdp_a, cdp_b, api_sy
     for path in paths:
         api_sync.wait_for_note(path, timeout=10)
 
-    # B syncs
-    await cdp_b.trigger_full_sync()
-
-    # All should be in B's vault
+    # All should reach B's vault live — no manual pull
     for path, content_prefix in paths.items():
-        b_content = wait_for_file(vault_b, path, timeout=15)
+        b_content = wait_for_delivery(vault_b, path, api_sync, timeout=30)
         assert content_prefix.lstrip("# ").split()[0] in b_content, \
             f"B should have {path} with correct content"
 

--- a/e2e/tests/test_43_deeply_nested_folders.py
+++ b/e2e/tests/test_43_deeply_nested_folders.py
@@ -46,9 +46,14 @@ async def test_deep_folder_multiple_notes(vault_a, vault_b, cdp_a, cdp_b, api_sy
     for path in paths:
         api_sync.wait_for_note(path, timeout=10)
 
-    # All should reach B's vault live — no manual pull
+    # All should reach B's vault live — no manual pull.
+    # 60s budget (not the standard 30s): a 4-note burst shares one delivery
+    # window, and this test intermittently hits the received=yes
+    # materialized=no stall tracked in Engram-obsidian#189 (test_10 is the
+    # deterministic member and keeps the 30s window). Re-tighten when #189
+    # is fixed.
     for path, content_prefix in paths.items():
-        b_content = wait_for_delivery(vault_b, path, api_sync, timeout=30)
+        b_content = wait_for_delivery(vault_b, path, api_sync, timeout=60)
         assert content_prefix.lstrip("# ").split()[0] in b_content, \
             f"B should have {path} with correct content"
 

--- a/e2e/tests/test_47_oauth_websocket_live_sync.py
+++ b/e2e/tests/test_47_oauth_websocket_live_sync.py
@@ -47,7 +47,7 @@ def _log_latency(label: str, t0: float) -> float:
 
 
 @pytest.mark.asyncio
-async def test_oauth_client_receives_api_create(vault_a, cdp_a, clerk_client):
+async def test_oauth_client_receives_api_create(vault_a, cdp_a, clerk_client, _oauth_ws_warm):
     """OAuth-authenticated plugin receives real-time broadcast when API creates a note.
 
     This is the core regression test: before the fix, OAuth clients never joined
@@ -91,7 +91,7 @@ async def test_oauth_client_receives_api_create(vault_a, cdp_a, clerk_client):
 
 
 @pytest.mark.asyncio
-async def test_oauth_client_receives_api_update(vault_a, cdp_a, clerk_client):
+async def test_oauth_client_receives_api_update(vault_a, cdp_a, clerk_client, _oauth_ws_warm):
     """OAuth client receives updated content via WebSocket when API upserts a note."""
     clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="ws")
     original_settings = None
@@ -138,7 +138,7 @@ async def test_oauth_client_receives_api_update(vault_a, cdp_a, clerk_client):
 
 
 @pytest.mark.asyncio
-async def test_oauth_client_receives_api_delete(vault_a, cdp_a, clerk_client):
+async def test_oauth_client_receives_api_delete(vault_a, cdp_a, clerk_client, _oauth_ws_warm):
     """OAuth client removes file from vault when API deletes a note via WebSocket."""
     clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="ws")
     original_settings = None

--- a/e2e/tests/test_48_oauth_reconnect_catchup.py
+++ b/e2e/tests/test_48_oauth_reconnect_catchup.py
@@ -45,7 +45,7 @@ def _log_latency(label: str, t0: float) -> float:
 
 
 @pytest.mark.asyncio
-async def test_oauth_reconnect_catches_up(vault_a, cdp_a, clerk_client):
+async def test_oauth_reconnect_catches_up(vault_a, cdp_a, clerk_client, _oauth_ws_warm):
     """OAuth channel drops, API creates note, channel reconnects, client gets note.
 
     Proves that OAuth token re-auth + channel re-join works after disconnect,
@@ -97,7 +97,7 @@ async def test_oauth_reconnect_catches_up(vault_a, cdp_a, clerk_client):
 
 
 @pytest.mark.asyncio
-async def test_oauth_reconnect_receives_update(vault_a, cdp_a, clerk_client):
+async def test_oauth_reconnect_receives_update(vault_a, cdp_a, clerk_client, _oauth_ws_warm):
     """OAuth channel drops, API updates existing note, reconnect delivers update.
 
     Edge case: file already exists locally, content changes while disconnected.

--- a/e2e/tests/test_49_cross_auth_sync.py
+++ b/e2e/tests/test_49_cross_auth_sync.py
@@ -35,7 +35,9 @@ pytestmark = pytest.mark.skipif(
     reason="E2E_CLERK_SECRET_KEY not set — skipping cross-auth sync tests",
 )
 
-RT_TIMEOUT = 10
+# ponytail: 30s is a load-tuned CI budget, not a latency proof — 5 rapid
+# edits must settle end-to-end on a shared loaded runner (was 10, flaked).
+RT_TIMEOUT = 30
 
 
 def _log_latency(label: str, t0: float) -> float:

--- a/e2e/tests/test_49_cross_auth_sync.py
+++ b/e2e/tests/test_49_cross_auth_sync.py
@@ -51,7 +51,7 @@ def _log_latency(label: str, t0: float) -> float:
 
 @pytest.mark.asyncio
 async def test_apikey_push_oauth_receives(
-    vault_a, vault_b, cdp_a, cdp_b, api_sync, sync_user, clerk_client
+    vault_a, vault_b, cdp_a, cdp_b, api_sync, sync_user, clerk_client, _oauth_ws_warm
 ):
     """API key client (B) pushes a note → OAuth client (A) receives via WebSocket.
 
@@ -96,7 +96,7 @@ async def test_apikey_push_oauth_receives(
 
 @pytest.mark.asyncio
 async def test_oauth_push_apikey_receives(
-    vault_a, vault_b, cdp_a, cdp_b, api_sync, sync_user, clerk_client
+    vault_a, vault_b, cdp_a, cdp_b, api_sync, sync_user, clerk_client, _oauth_ws_warm
 ):
     """OAuth client (A) pushes a note → API key client (B) receives via WebSocket.
 

--- a/e2e/tests/test_65_problem_dir_scanner.py
+++ b/e2e/tests/test_65_problem_dir_scanner.py
@@ -74,6 +74,33 @@ async def test_node_modules_detected_and_addable(vault_a, cdp_a):
             await_promise=True,
         )
 
+    # Wait for Obsidian's vault index to pick up the externally-seeded
+    # node_modules/ folder BEFORE opening the Advanced tab. The scanner runs
+    # exactly ONCE, synchronously, at tab render (renderIgnoreWarnings calls
+    # app.vault.getFolderByPath) and never re-scans — so if the folder is not
+    # in the vault cache at render time, the warning row can NEVER appear no
+    # matter how long the DOM is polled afterwards. That is why bumping the
+    # DOM wait 5s -> 20s did not help (run 28919928915 failed the 20s window
+    # too): the failure is state-at-render-time, not render latency. Under
+    # full-suite CI load the inotify -> vault-index tick for an external
+    # mkdir can lag well past the moment we open the tab.
+    indexed = False
+    deadline = asyncio.get_event_loop().time() + 30
+    while asyncio.get_event_loop().time() < deadline:
+        indexed = await cdp_a.evaluate(
+            "Boolean(app.vault.getFolderByPath('node_modules'))"
+        )
+        if indexed:
+            break
+        await asyncio.sleep(0.2)
+    assert indexed, (
+        "Obsidian's vault index never picked up the externally-seeded "
+        "node_modules/ folder within 30 s — the scanner's precondition "
+        "failed, not the warning-row render. Check the vault file watcher "
+        "(inotify) in this environment before suspecting "
+        "renderIgnoreWarnings()."
+    )
+
     try:
         # Open the Obsidian settings modal and navigate to the plugin + Advanced tab.
         await cdp_a.evaluate(

--- a/e2e/tests/test_65_problem_dir_scanner.py
+++ b/e2e/tests/test_65_problem_dir_scanner.py
@@ -123,11 +123,13 @@ async def test_node_modules_detected_and_addable(vault_a, cdp_a):
 
         # Wait for the .engram-status-warning row to appear
         # (renderIgnoreWarnings detects the vault folder and renders the
-        # warning on tab render). The scanner is synchronous render — if
-        # it didn't fire within 5 s it's broken. No redisplay retries:
-        # those masked real regressions previously.
+        # warning on tab render). The scanner is synchronous render, but
+        # under full-suite CI load the render tick itself can be delayed —
+        # 5 s flaked intermittently (passed in the previous run). Widened
+        # to 20 s; this is still a poll, not a retry-with-redisplay (those
+        # masked real regressions previously).
         warning_visible = False
-        deadline = asyncio.get_event_loop().time() + 5
+        deadline = asyncio.get_event_loop().time() + 20
         while asyncio.get_event_loop().time() < deadline:
             warning_visible = await cdp_a.evaluate(
                 "Boolean(document.querySelector('.engram-status-warning'))"
@@ -137,7 +139,7 @@ async def test_node_modules_detected_and_addable(vault_a, cdp_a):
             await asyncio.sleep(0.2)
         assert warning_visible, (
             "node_modules/ warning row (.engram-status-warning) did not "
-            "appear within 5 s of opening the Advanced tab. Either the "
+            "appear within 20 s of opening the Advanced tab. Either the "
             "problem-dir scanner stopped detecting node_modules/, or "
             "renderIgnoreWarnings no longer emits .engram-status-warning. "
             "Inspect settings.ts renderIgnoreWarnings() against current source."

--- a/e2e/tests/test_79_attachment_move_convergence.py
+++ b/e2e/tests/test_79_attachment_move_convergence.py
@@ -7,11 +7,12 @@ tombstone is what makes the move converge for a client that pulls the change
 feed (the offline / catch-up path) — without it, the pull would see only the
 repointed row at the new path and keep a stale duplicate at the old path.
 
-These tests assert convergence through an explicit pull (`trigger_full_sync`)
-rather than racing live-socket delivery: the pull path is the one the tombstone
-exists for, and it's deterministic under parallel CI load. Each test cleans up
-server-side state first so it is safe under pytest reruns (a move mutates shared
-vault state irreversibly, so a re-run must start from a known-clean slate).
+These tests assert live delivery first, then convergence through an explicit
+pull (`trigger_full_sync`): the pull path is the one the tombstone exists for
+(catch-up after an offline window), and it's deterministic under parallel CI
+load. Each test cleans up server-side state first so it is safe under pytest
+reruns (a move mutates shared vault state irreversibly, so a re-run must start
+from a known-clean slate).
 """
 
 import asyncio
@@ -48,10 +49,10 @@ async def test_web_move_converges_via_pull(vault_a, vault_b, cdp_a, cdp_b, api_s
     new_path = "E2E/attachments/move79pull-new.png"
     _seed_clean(api_sync, old_path, new_path)
 
-    # Seed via the API (web-origin upload → immediately on the server), then B pulls.
+    # Seed via the API (web-origin upload → immediately on the server); B
+    # receives it live — no manual pull.
     assert api_sync.upload_attachment(old_path, TINY_PNG, "image/png") == 200
     api_sync.wait_for_attachment(old_path)
-    await cdp_b.trigger_full_sync()
     wait_for_binary_delivery(vault_b, old_path, api_sync, timeout=CONVERGE_TIMEOUT)
 
     # Web-originated move: repoint live row + insert old-path tombstone.
@@ -59,8 +60,13 @@ async def test_web_move_converges_via_pull(vault_a, vault_b, cdp_a, cdp_b, api_s
     api_sync.wait_for_attachment(new_path)
     api_sync.wait_for_attachment_gone(old_path)
 
-    # B converges on its next pull: the tombstone trashes old, the repointed row
-    # writes new — no duplicate left at the old path.
+    # B receives the move live first — proves live delivery isn't dead.
+    assert wait_for_binary_delivery(vault_b, new_path, api_sync, timeout=CONVERGE_TIMEOUT) == TINY_PNG
+
+    # B also converges on its next explicit pull: the tombstone trashes old,
+    # the repointed row writes new — no duplicate left at the old path. This
+    # pull-convergence path (not the live broadcast) is what the durable
+    # tombstone exists for — see module docstring.
     await cdp_b.trigger_full_sync()
     assert wait_for_binary_delivery(vault_b, new_path, api_sync, timeout=CONVERGE_TIMEOUT) == TINY_PNG
     wait_for_file_gone(vault_b, old_path, timeout=CONVERGE_TIMEOUT)
@@ -80,10 +86,9 @@ async def test_web_move_converges_after_offline_window(
     new_path = "E2E/attachments/move79offline-new.png"
     _seed_clean(api_sync, old_path, new_path)
 
-    # Seed via the API, then B pulls a copy.
+    # Seed via the API; B receives a copy live before going offline.
     assert api_sync.upload_attachment(old_path, TINY_PNG, "image/png") == 200
     api_sync.wait_for_attachment(old_path)
-    await cdp_b.trigger_full_sync()
     wait_for_binary_delivery(vault_b, old_path, api_sync, timeout=CONVERGE_TIMEOUT)
 
     # Take B offline so it misses the ephemeral move broadcasts entirely.

--- a/e2e/tests/test_80_web_attachment_upload.py
+++ b/e2e/tests/test_80_web_attachment_upload.py
@@ -42,6 +42,10 @@ async def test_web_upload_converges_via_pull(vault_a, vault_b, cdp_a, cdp_b, api
     assert api_sync.upload_attachment(path, TINY_PNG, "image/png") == 200
     api_sync.wait_for_attachment(path)
 
-    # B converges on its next explicit pull — the deterministic convergence path.
+    # B receives the upload live first — proves live delivery isn't dead.
+    assert wait_for_binary_delivery(vault_b, path, api_sync, timeout=CONVERGE_TIMEOUT) == TINY_PNG
+
+    # B also converges on its next explicit pull — the deterministic
+    # convergence path this test is actually about (see module docstring).
     await cdp_b.trigger_full_sync()
     assert wait_for_binary_delivery(vault_b, path, api_sync, timeout=CONVERGE_TIMEOUT) == TINY_PNG

--- a/e2e/tests/test_82_resumed_device_stale_idmap.py
+++ b/e2e/tests/test_82_resumed_device_stale_idmap.py
@@ -29,11 +29,39 @@ regression guard for that behavior; see task-A2-report.md for the full
 investigation (churn-note variant, in-memory map dumps, routing-log traces).
 """
 
+import asyncio
+import time
+
 import pytest
 
 from helpers.vault import wait_for_content, write_note
 
 pytestmark = pytest.mark.asyncio
+
+
+async def _wait_for_persisted_cursor(cdp, inst, timeout: float = 60, interval: float = 1.0) -> dict:
+    """Poll persist+read until data.json has earned a non-empty syncCursor.
+
+    The plugin only earns syncCursor from its first /sync/changes cycle.
+    Phase 1's wait_for_content proves the CONTENT arrived, but under CI load
+    that cycle's cursor write can still be in flight a moment later — a
+    single persist_plugin_data() call can race it and snapshot a cursor-less
+    data.json (CI-only failure: setup precondition, not the mutate-under-
+    test behavior). Poll instead of asserting on one persist.
+    """
+    deadline = time.monotonic() + timeout
+    last: dict = {}
+    while time.monotonic() < deadline:
+        await cdp.persist_plugin_data()
+        last = inst.read_data_json()
+        if last.get("syncCursor"):
+            return last
+        await asyncio.sleep(interval)
+    raise TimeoutError(
+        f"data.json never earned a syncCursor within {timeout}s "
+        f"(test_82 setup precondition, not the behavior under test); "
+        f"last snapshot had keys={sorted(last)}"
+    )
 
 
 async def test_resumed_device_with_stale_idmap_syncs_both_ways(
@@ -49,7 +77,7 @@ async def test_resumed_device_with_stale_idmap_syncs_both_ways(
     wait_for_content(inst_b.vault_path, "E2E/Resumed-push-seed.md", "original", timeout=30)
 
     # Phase 2: flush B's state, stop it, wipe the id map but KEEP the cursor.
-    await cdp_b.persist_plugin_data()
+    await _wait_for_persisted_cursor(cdp_b, inst_b)
     inst_b.stop()
 
     def wipe_map(data):

--- a/e2e/tests/test_82_resumed_device_stale_idmap.py
+++ b/e2e/tests/test_82_resumed_device_stale_idmap.py
@@ -1,0 +1,80 @@
+"""Test 82: RESUMED device (cursor set, stale/empty noteIdMap) still syncs live.
+
+Regression for plugin #180→#187 (stale noteIdMap broke BOTH directions while
+status showed "live"). Every other e2e device boots fresh (genesis pull →
+fully populated map); this is the one test that constructs the resumed state:
+stop a device, wipe its persisted noteIds while keeping its syncCursor, then
+restart and prove both pull and push still work.
+
+Both phases below edit a note that already exists (seeded in Phase 1, known
+to the server, then FORGOTTEN by the wipe) rather than create a brand-new
+note. A brand-new note's id<->path pairing is conveyed directly by the CRDT
+enrollment/join handshake regardless of noteIdMap state, so it does not
+exercise the bug (verified: both a pre-#187 and a #187+ plugin pass a
+new-note pull). The actual crux — per docs/context/noteidmap-stale-breaks-sync.md
+— is resolving the id of a note the device already knew and then forgot.
+
+KNOWN LIMITATION (bite-check): running this exact scenario against a plugin
+build predating #187 (dfc40db~1, commit 7e73d95) still PASSES in this local
+harness — traced noteIdMap.toJSON() against GET /sync/manifest at each
+checkpoint and confirmed B's in-memory map is already fully and CORRECTLY
+repopulated (matching the server's real ids) within a few seconds of
+restart, even without reconcileNoteIdMapFromManifest existing in that build.
+Some other mechanism in this harness (client catch-up pull on reconnect,
+and/or backend /sync/changes semantics) re-teaches ids faster/more broadly
+here than the original prod incident implies, so this test currently proves
+the BEHAVIOR (resumed device with a wiped map + preserved cursor still syncs
+both directions) rather than discriminating pre/post #187. Left as a
+regression guard for that behavior; see task-A2-report.md for the full
+investigation (churn-note variant, in-memory map dumps, routing-log traces).
+"""
+
+import pytest
+
+from helpers.vault import wait_for_content, write_note
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_resumed_device_with_stale_idmap_syncs_both_ways(
+    fresh_instance_pair, api_sync
+):
+    inst_a, inst_b, cdp_a, cdp_b = fresh_instance_pair
+
+    # Phase 1: normal sync so B earns a cursor + populated map, and learns the
+    # ids of two pre-existing notes (one per direction we'll test post-resume).
+    write_note(inst_a.vault_path, "E2E/Resumed-pull-seed.md", "# PullSeed\noriginal")
+    write_note(inst_a.vault_path, "E2E/Resumed-push-seed.md", "# PushSeed\noriginal")
+    wait_for_content(inst_b.vault_path, "E2E/Resumed-pull-seed.md", "original", timeout=30)
+    wait_for_content(inst_b.vault_path, "E2E/Resumed-push-seed.md", "original", timeout=30)
+
+    # Phase 2: flush B's state, stop it, wipe the id map but KEEP the cursor.
+    await cdp_b.persist_plugin_data()
+    inst_b.stop()
+
+    def wipe_map(data):
+        assert data.get("syncCursor"), "precondition: cursor must be set"
+        data["noteIds"] = {}
+
+    inst_b.mutate_data_json(wipe_map)
+    await inst_b.async_start(restart=True)
+
+    # Phase 3a: PULL direction — A edits the PRE-EXISTING pull-seed note (its
+    # id is exactly what the wiped map no longer knows); resumed B must
+    # live-materialize the edit. Uses wait_for_content (not the delivery
+    # oracle) because the path already exists non-empty on B, so the oracle's
+    # non-empty guard would return the stale content on the first poll.
+    write_note(inst_a.vault_path, "E2E/Resumed-pull-seed.md", "# PullSeed\nedited after B resumed")
+    got = wait_for_content(
+        inst_b.vault_path, "E2E/Resumed-pull-seed.md", "edited after B resumed", timeout=30
+    )
+    assert "edited after B resumed" in got
+
+    # Phase 3b: PUSH direction — resumed B edits the PRE-EXISTING push-seed
+    # note (its id is exactly what the wiped map no longer knows) and the
+    # server must get it.
+    write_note(inst_b.vault_path, "E2E/Resumed-push-seed.md", "# PushSeed\nedited on resumed B")
+    note = api_sync.wait_for_note_content(
+        "E2E/Resumed-push-seed.md", "edited on resumed B", timeout=30
+    )
+    assert note is not None, "resumed B's push never reached the server"

--- a/e2e/tests/test_83_cross_interface_orchestration.py
+++ b/e2e/tests/test_83_cross_interface_orchestration.py
@@ -1,0 +1,54 @@
+"""Test 83: one logical note traverses MCP → Obsidian → REST → Obsidian → MCP.
+
+The orchestration test the suite never had: every hop is LIVE (no manual
+pull), and the final read-back asserts all interfaces agree on the content.
+"""
+
+import pytest
+
+from helpers.log_oracle import wait_for_delivery
+from helpers.vault import read_note, wait_for_content, write_note
+
+pytestmark = pytest.mark.asyncio
+
+PATH = "E2E/Orchestra.md"
+RT_TIMEOUT = 30  # generous: this hop crosses MCP + WebSocket delivery
+
+
+def _mcp_text(response: dict) -> str:
+    """Extract the text string from an MCP JSON-RPC result (mirrors test_46)."""
+    return response["result"]["content"][0]["text"]
+
+
+async def test_mcp_rest_obsidian_agree(vault_b, cdp_b, api_sync):
+    # Hop 1 is MCP, so poll for the join ack like test_46 does (issue #161:
+    # a one-shot check races the publish below while the channel is still
+    # (re)joining after fixture/prior-test setup).
+    await cdp_b.wait_for_stream_connected(timeout=RT_TIMEOUT)
+
+    # Hop 1: MCP write_note → Obsidian receives live.
+    # (create_note has no `path` arg — it derives the filename from `title`
+    # via server-side auto-placement. write_note is the MCP tool that takes
+    # an exact path, matching test_46's write_note case.)
+    resp, status = api_sync.mcp_call(
+        "write_note", {"path": PATH, "content": "# Orchestra\nv1 via MCP"}
+    )
+    assert status == 200 and "Note saved" in _mcp_text(resp), f"MCP write failed: {resp}"
+    assert "v1 via MCP" in wait_for_delivery(vault_b, PATH, api_sync, timeout=RT_TIMEOUT)
+
+    # Hop 2: REST edit → Obsidian receives live.
+    api_sync.create_note(PATH, "# Orchestra\nv2 via REST")
+    wait_for_content(vault_b, PATH, "v2 via REST", timeout=RT_TIMEOUT)
+
+    # Hop 3: Obsidian edit → server, read back via REST and MCP.
+    write_note(vault_b, PATH, "# Orchestra\nv3 via Obsidian")
+    note = api_sync.wait_for_note_content(PATH, "v3 via Obsidian", timeout=RT_TIMEOUT)
+    assert note is not None, "Obsidian push never reached the server"
+
+    mcp_resp, status = api_sync.mcp_call("get_note", {"source_path": PATH})
+    assert status == 200
+    assert "v3 via Obsidian" in _mcp_text(mcp_resp), (
+        "MCP read-back disagrees with what Obsidian pushed"
+    )
+    # And the vault still holds the final truth (no echo rewrote it).
+    assert "v3 via Obsidian" in read_note(vault_b, PATH)

--- a/e2e/tests/test_83_cross_interface_orchestration.py
+++ b/e2e/tests/test_83_cross_interface_orchestration.py
@@ -4,6 +4,8 @@ The orchestration test the suite never had: every hop is LIVE (no manual
 pull), and the final read-back asserts all interfaces agree on the content.
 """
 
+import uuid
+
 import pytest
 
 from helpers.log_oracle import wait_for_delivery
@@ -11,7 +13,7 @@ from helpers.vault import read_note, wait_for_content, write_note
 
 pytestmark = pytest.mark.asyncio
 
-PATH = "E2E/Orchestra.md"
+PATH = f"E2E/Orchestra-{uuid.uuid4().hex[:12]}.md"
 RT_TIMEOUT = 30  # generous: this hop crosses MCP + WebSocket delivery
 
 

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -71,45 +71,59 @@ defmodule Engram.Attachments do
         # advisory lock; if the locked re-read reveals a different winning
         # id, we re-encrypt + re-PUT under the lock (rare race path only).
         # The lock auto-releases on commit/rollback.
-        Repo.transaction(fn ->
-          :ok = acquire_path_lock(user.id, path_hmac)
+        result =
+          Repo.transaction(fn ->
+            :ok = acquire_path_lock(user.id, path_hmac)
 
-          existing = fetch_existing(user, vault.id, path_hmac)
+            existing = fetch_existing(user, vault.id, path_hmac)
 
-          rebind =
-            case existing do
-              %Attachment{id: id} when id != att_id0 ->
-                with {:ok, rebind_key, attrs1, ciphertext1} <-
-                       prepare_upload(
-                         user,
-                         vault,
-                         id,
-                         path,
-                         path_hmac,
-                         plaintext,
-                         mtime,
-                         explicit_mime
-                       ),
-                     :ok <- store_external(rebind_key, ciphertext1, attrs1.mime_type) do
-                  {:ok, attrs1}
-                end
+            rebind =
+              case existing do
+                %Attachment{id: id} when id != att_id0 ->
+                  with {:ok, rebind_key, attrs1, ciphertext1} <-
+                         prepare_upload(
+                           user,
+                           vault,
+                           id,
+                           path,
+                           path_hmac,
+                           plaintext,
+                           mtime,
+                           explicit_mime
+                         ),
+                       :ok <- store_external(rebind_key, ciphertext1, attrs1.mime_type) do
+                    {:ok, attrs1}
+                  end
 
-              _ ->
-                {:ok, attrs0}
+                _ ->
+                  {:ok, attrs0}
+              end
+
+            with {:ok, changeset_attrs} <- rebind,
+                 {:ok, att} <- write_row(user, existing, att_id0, changeset_attrs) do
+              # Phase B.3: path is virtual — splice the plaintext we already
+              # have onto the returned struct so callers can read att.path
+              # without a second decrypt round-trip.
+              {:ok, %{att | path: path}}
             end
+            |> case do
+              {:ok, att} -> att
+              {:error, reason} -> Repo.rollback(reason)
+            end
+          end)
 
-          with {:ok, changeset_attrs} <- rebind,
-               {:ok, att} <- write_row(user, existing, att_id0, changeset_attrs) do
-            # Phase B.3: path is virtual — splice the plaintext we already
-            # have onto the returned struct so callers can read att.path
-            # without a second decrypt round-trip.
-            {:ok, %{att | path: path}}
-          end
-          |> case do
-            {:ok, att} -> att
-            {:error, reason} -> Repo.rollback(reason)
-          end
-        end)
+        # Real-time notification (Engram#942) — create/upload previously had NO
+        # live signal at all (only delete and move broadcast), so peers only
+        # ever saw a new/changed attachment via the next manual pull. Mirrors
+        # the "upsert" leg of move_attachment/4's broadcast_attachment/5 below
+        # — the plugin's WebSocket handler already fetches + materializes any
+        # attachment "upsert" event (it's the same code path move's new-path
+        # leg drives), so no plugin change is needed.
+        with {:ok, %Attachment{} = att} <- result do
+          broadcast_attachment(user.id, vault.id, "upsert", path, att)
+        end
+
+        result
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.643",
+      version: "0.5.644",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.640",
+      version: "0.5.641",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.641",
+      version: "0.5.642",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.642",
+      version: "0.5.643",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/attachments_broadcast_test.exs
+++ b/test/engram/attachments_broadcast_test.exs
@@ -1,0 +1,46 @@
+defmodule Engram.AttachmentsBroadcastTest do
+  use Engram.DataCase, async: false
+
+  import Mox
+
+  alias Engram.Attachments
+
+  setup :verify_on_exit!
+
+  setup do
+    prev = Application.get_env(:engram, :storage)
+    Application.put_env(:engram, :storage, Engram.MockStorage)
+    on_exit(fn -> Application.put_env(:engram, :storage, prev) end)
+
+    user = insert(:user)
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    vault = insert(:vault, user: user)
+    %{user: user, vault: vault}
+  end
+
+  describe "note_changed upsert broadcast on attachment create/upload (Engram#942)" do
+    test "upsert_attachment/3 broadcasts a note_changed upsert event", %{
+      user: user,
+      vault: vault
+    } do
+      Mox.stub(Engram.MockStorage, :put, fn _key, _bin, _opts -> :ok end)
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      assert {:ok, _att} =
+               Attachments.upsert_attachment(user, vault, %{
+                 "path" => "photos/live.png",
+                 "content_base64" => Base.encode64("live delivery content")
+               })
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: %{
+          "event_type" => "upsert",
+          "kind" => "attachment",
+          "path" => "photos/live.png"
+        }
+      }
+    end
+  end
+end

--- a/test/engram/crdt_sync_handoff_test.exs
+++ b/test/engram/crdt_sync_handoff_test.exs
@@ -1,0 +1,126 @@
+defmodule Engram.CrdtSyncHandoffTest do
+  @moduledoc """
+  A CRDT (web-editor) edit emits NO note_changed on the sync: topic — by
+  design, the only delivery guarantee for a sync-topic-only device (the
+  plugin) is the /api/sync/changes cursor feed. That handoff was never
+  tested: a regression that kept CRDT persistence out of the seq feed made
+  web edits silently invisible to Obsidian. This test pins both halves:
+  the (documented) silence AND the feed delivery.
+
+  Silence premise checked against #940 (fix/crdt-web-edit-delivery, already
+  merged on this branch): the checkpoint's new discovery announce
+  (`CrdtDeliver.announce_ready/4`) broadcasts `crdt_doc_ready` on the
+  `crdt:<user_id>:<vault_id>` topic only
+  (lib/engram/notes/crdt_deliver.ex:242-251 `defp announce/3`) — the
+  `sync:` topic still emits no `note_changed` for a CRDT-origin write. #940
+  does not change this test's silence premise.
+  """
+  use EngramWeb.ChannelCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Engram.{Crypto, Notes, Repo, Vaults}
+  alias Engram.Notes.{CrdtBridge, CrdtCheckpoint, CrdtRegistry}
+  alias Yex.Sync.SharedDoc
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "CrdtSyncHandoffTest"})
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "base"})
+
+    socket = user_socket(user)
+
+    {:ok, _, joined} =
+      subscribe_and_join(
+        socket,
+        EngramWeb.CrdtChannel,
+        "crdt:#{user.id}:#{vault.id}",
+        %{"crdt_proto" => 2}
+      )
+
+    Sandbox.allow(Repo, self(), joined.channel_pid)
+
+    %{socket: joined, user: user, vault: vault, note: note}
+  end
+
+  test "CRDT edit is silent on sync: topic but lands in the changes feed", %{
+    socket: socket,
+    user: user,
+    vault: vault,
+    note: note
+  } do
+    # 1. capture the current max cursor for the vault (changes-feed function)
+    seq0 = Vaults.current_seq(user.id, vault.id)
+
+    # 2. subscribe to "sync:#{user.id}:#{vault.id}"
+    EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+    # 3. drive a real Yjs update through the crdt channel (the update-crdt_msg
+    #    pattern from crdt_channel_test.exs :301-344 — step1 handshake, apply
+    #    the server's step2 state, mutate the client doc, ship the delta).
+    client = CrdtBridge.new_doc()
+    {:ok, {:sync_step1, sv}} = Yex.Sync.get_sync_step1(client)
+    {:ok, step1_frame} = Yex.Sync.message_encode({:sync, {:sync_step1, sv}})
+    push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => Base.encode64(step1_frame)})
+    assert_push "crdt_msg", %{"b64" => b64_step2}, 3000
+    {:ok, {:sync, {:sync_step2, upd}}} = Yex.Sync.message_decode(Base.decode64!(b64_step2))
+
+    {:ok, server_sv_before} = Yex.encode_state_vector(client)
+    :ok = Yex.apply_update(client, upd)
+    assert CrdtBridge.text_of(client) == "base"
+
+    text = Yex.Doc.get_text(client, CrdtBridge.text_name())
+    Yex.Text.insert(text, 4, " EDITED VIA WEB")
+    assert CrdtBridge.text_of(client) == "base EDITED VIA WEB"
+
+    {:ok, delta} = Yex.encode_state_as_update(client, server_sv_before)
+    {:ok, update_frame} = Yex.Sync.message_encode({:sync, {:sync_update, delta}})
+    push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => Base.encode64(update_frame)})
+
+    {:ok, room_pid} = CrdtRegistry.ensure_started(user.id, vault.id, note.id)
+
+    wait_until(fn ->
+      CrdtBridge.text_of(SharedDoc.get_doc(room_pid)) == "base EDITED VIA WEB"
+    end)
+
+    # 4. force the checkpoint to persist NOW — bypass the debounce timer
+    #    entirely by calling CrdtCheckpoint.checkpoint/4 directly with the
+    #    room's live doc, exactly as crdt_checkpoint_test.exs does.
+    room_doc = SharedDoc.get_doc(room_pid)
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, room_doc)
+
+    # 5. the CRDT write must NOT emit note_changed on the sync: topic — the
+    #    documented design (only the seq changes feed carries this edit to a
+    #    sync-topic-only device). If this ever starts receiving, the design
+    #    changed (see #940 note above) and this test must be updated
+    #    deliberately, not loosened.
+    refute_receive %Phoenix.Socket.Broadcast{event: "note_changed"}, 200
+
+    # 6. pull the changes feed from the step-1 cursor: the note must appear
+    #    with the CRDT-updated (decrypted) content and a bumped seq.
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, seq0)
+    change = Enum.find(changes, &(&1.id == note.id))
+
+    assert change, "checkpointed note missing from the seq changes feed"
+    assert change.content == "base EDITED VIA WEB"
+    assert change.seq > seq0
+  end
+
+  defp wait_until(condition, deadline \\ nil) do
+    deadline = deadline || System.monotonic_time(:millisecond) + 500
+
+    if condition.() do
+      :ok
+    else
+      now = System.monotonic_time(:millisecond)
+
+      if now >= deadline do
+        flunk("wait_until: condition never became true within 500ms")
+      else
+        Process.sleep(10)
+        wait_until(condition, deadline)
+      end
+    end
+  end
+end

--- a/test/engram/mcp/handlers_broadcast_test.exs
+++ b/test/engram/mcp/handlers_broadcast_test.exs
@@ -1,0 +1,183 @@
+defmodule Engram.MCP.HandlersBroadcastTest do
+  @moduledoc """
+  MCP write tools route through Notes.upsert_note — but until now nothing
+  asserted they produce the same note_changed fan-out as a plugin REST push.
+  A silent divergence on the MCP path (no broadcast) was green. These tests
+  make every MCP write tool prove its delivery side effect.
+  """
+  use Engram.DataCase, async: true
+
+  alias Engram.MCP.Handlers
+  alias Engram.Notes
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Test"})
+    EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+    %{user: user, vault: vault}
+  end
+
+  test "create_note broadcasts note_changed with content", %{user: user, vault: vault} do
+    # create_note derives its own path from title + suggested_folder (no "path"
+    # arg exists on this tool) — pass suggested_folder to skip the
+    # auto_place_folder Search call and keep the path deterministic.
+    assert {:ok, _} =
+             Handlers.handle("create_note", user, vault, %{
+               "title" => "A via MCP",
+               "content" => "body text",
+               "suggested_folder" => "mcp"
+             })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed", payload: p}
+    assert p["event_type"] == "upsert"
+    assert p["path"] == "mcp/A via MCP.md"
+    assert p["content"] =~ "body text"
+  end
+
+  test "write_note broadcasts note_changed", %{user: user, vault: vault} do
+    assert {:ok, _} =
+             Handlers.handle("write_note", user, vault, %{
+               "path" => "mcp/b.md",
+               "content" => "# B"
+             })
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      event: "note_changed",
+      payload: %{"path" => "mcp/b.md", "event_type" => "upsert"}
+    }
+  end
+
+  test "append_to_note broadcasts the appended content", %{user: user, vault: vault} do
+    {:ok, _} =
+      Handlers.handle("create_note", user, vault, %{
+        "title" => "C",
+        "content" => "body",
+        "suggested_folder" => "mcp"
+      })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
+
+    assert {:ok, _} =
+             Handlers.handle("append_to_note", user, vault, %{
+               "path" => "mcp/C.md",
+               "text" => "tail"
+             })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed", payload: p}
+    assert p["content"] =~ "tail"
+  end
+
+  test "patch_note broadcasts the replaced content", %{user: user, vault: vault} do
+    {:ok, _} =
+      Handlers.handle("write_note", user, vault, %{
+        "path" => "mcp/patch.md",
+        "content" => "# Patch\n\nfind me here"
+      })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
+
+    assert {:ok, _} =
+             Handlers.handle("patch_note", user, vault, %{
+               "path" => "mcp/patch.md",
+               "find" => "find me",
+               "replace" => "replaced"
+             })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed", payload: p}
+    assert p["content"] =~ "replaced here"
+  end
+
+  test "update_section broadcasts the new section content", %{user: user, vault: vault} do
+    {:ok, _} =
+      Handlers.handle("write_note", user, vault, %{
+        "path" => "mcp/section.md",
+        "content" => "# Doc\n\n## Notes\n\nold body\n"
+      })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
+
+    assert {:ok, _} =
+             Handlers.handle("update_section", user, vault, %{
+               "path" => "mcp/section.md",
+               "heading" => "Notes",
+               "content" => "new body"
+             })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed", payload: p}
+    assert p["content"] =~ "new body"
+    refute p["content"] =~ "old body"
+  end
+
+  test "rename_note broadcasts a delete for the old path and an upsert for the new path", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} =
+      Handlers.handle("create_note", user, vault, %{
+        "title" => "Old",
+        "content" => "body",
+        "suggested_folder" => "mcp"
+      })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
+
+    assert {:ok, _} =
+             Handlers.handle("rename_note", user, vault, %{
+               "old_path" => "mcp/Old.md",
+               "new_path" => "mcp/New.md"
+             })
+
+    # rename_note/4 is not a single event: it broadcasts a "delete" for the
+    # old path THEN an "upsert" for the new path (Notes.rename_note, notes.ex
+    # ~1160-1162) — there is no distinct "note_renamed" event.
+    assert_receive %Phoenix.Socket.Broadcast{
+      event: "note_changed",
+      payload: %{"event_type" => "delete", "path" => "mcp/Old.md"}
+    }
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      event: "note_changed",
+      payload: %{"event_type" => "upsert", "path" => "mcp/New.md"}
+    }
+  end
+
+  test "delete_note broadcasts the delete event with the note id", %{user: user, vault: vault} do
+    {:ok, _} =
+      Handlers.handle("create_note", user, vault, %{
+        "title" => "Gone",
+        "content" => "body",
+        "suggested_folder" => "mcp"
+      })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
+    {:ok, note} = Notes.get_note(user, vault, "mcp/Gone.md")
+
+    assert {:ok, _} = Handlers.handle("delete_note", user, vault, %{"path" => "mcp/Gone.md"})
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      event: "note_changed",
+      payload: %{"event_type" => "delete", "path" => "mcp/Gone.md", "id" => id}
+    }
+
+    assert id == note.id
+  end
+
+  test "MCP write advances the sync changes feed", %{user: user, vault: vault} do
+    since = ~U[2020-01-01 00:00:00Z]
+    {:ok, %{changes: before_changes}} = Notes.list_changes_page(user, vault, since)
+    refute Enum.any?(before_changes, &(&1.path == "mcp/feed.md"))
+
+    assert {:ok, _} =
+             Handlers.handle("write_note", user, vault, %{
+               "path" => "mcp/feed.md",
+               "content" => "# Feed"
+             })
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
+
+    {:ok, %{changes: after_changes}} = Notes.list_changes_page(user, vault, since)
+    assert Enum.any?(after_changes, &(&1.path == "mcp/feed.md"))
+  end
+end

--- a/test/engram/notes_broadcast_test.exs
+++ b/test/engram/notes_broadcast_test.exs
@@ -82,6 +82,36 @@ defmodule Engram.NotesBroadcastTest do
     end
   end
 
+  describe "rapid successive upserts broadcast (Engram#944)" do
+    test "two upserts to the same path with different content each broadcast a note_changed upsert",
+         %{user: user, vault: vault} do
+      {:ok, _base} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "canvas.canvas",
+          "content" => "base",
+          "mtime" => 1.0
+        })
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      # Fire the second upsert immediately after the first — no artificial
+      # delay — to mirror the e2e repro's back-to-back rapid writes.
+      {:ok, modified} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "canvas.canvas",
+          "content" => "modified",
+          "mtime" => 1.001
+        })
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: %{"event_type" => "upsert", "content_hash" => hash}
+      }
+
+      assert hash == modified.content_hash
+    end
+  end
+
   describe "rename_folder/4 cascade broadcast" do
     test "upsert broadcast for a renamed child carries the note id and new path", %{
       user: user,


### PR DESCRIPTION
## WARNING: 7 e2e tests on this branch are DELIBERATELY red

These tests surface real product gaps that pull-masking previously hid. Merging this PR **accepts these as known-red pending the linked issues** — re-adding pull-masking or reruns to make them green again is NOT the fix:

- `test_33_attachment_sync.py` (2 tests), `test_79_attachment_move_convergence.py` (2 tests), `test_80_web_attachment_upload.py` — attachment live delivery never actually happens. See #942 (evidence commented there).
- `test_41_canvas_sync.py` (canvas modify) — a rapid double-write loses the second update. See #944.
- `test_10_rename_propagation.py` — first-push-of-session cold-start delay. See Engram-obsidian#189 (evidence commented there).

## Context

- Workspace audit: `docs/context/testing-surface-audit-2026-07-07.md` (engram-workspace#116) — six failure-to-catch patterns across the stack, this PR + the companion plugin PR close items 1-4, 6, 7.
- Companion plugin PR: Engram-obsidian#190 (Phase B, done).

## Per-task summary

- **A1** (audit item 1 — pull-masking) — `4473d544` — assert live delivery lands within the live-sync window *before* any test falls back to a pull, so a broken live path can no longer hide behind pull-masking.
- **A2** (audit item 2 — fresh-device-only fixtures) — `b7b2c10c` — resumed-device regression test: a device that reconnects with a stale `noteIdMap` must still sync correctly, not just a freshly-provisioned one.
- **A3** (audit item 3 — cross-interface gaps) — `2bbf23d7` — orchestration test driving MCP + REST + Obsidian against the same vault in one flow, so a change from one interface is asserted visible from the others.
- **A4 + A5** (audit item 4 — untested `note_changed` fan-out) — `165875c7` (MCP write tools must emit `note_changed`) + `5e72cafa` (a CRDT-checkpointed edit must reach the `/changes` feed) — closes the gap where CRDT/MCP writes could silently skip the broadcast path.
- **(audit item 5 — plugin mock-shape asserts)** — handled by the companion plugin PR, Engram-obsidian#190. Not in this PR.
- **A6** (audit item 6 — rerun anti-diagnosis) — `fcc82a4c` — `reruns=0`. A flake is a finding, not noise to retry away.
- **A7** (audit item 7 — no browser-rendered coverage) — `acd0c26c` — new web SPA live-render leg, Obsidian edit → browser (`e2e/tests/crdt/test_obsidian_to_web_live.py`).

## Honest limitations

- **test_82's bite-check is inconclusive.** A pre-#187 plugin also passes this test, because the current backend re-teaches ids via an unpinned mechanism. #945 tracks pinning that mechanism down so the test can actually discriminate pre/post-#187 behavior. The fixture state itself (what's on disk after the flow) is verified independently and is not in question.
- **The web SPA browser leg only runs in the `e2e-crdt` job.** The browser sign-in helper is local-auth only, so it can't run in the main `e2e-clerk` suite yet. Follow-up: #949.

## Deliberately out of scope (per the plan)

- Mass rewrite of the plugin's 141 mock-shape assertions.
- 2-node topology coverage (PubSub fan-out, node-local idempotency caches, cross-node cache eviction) — tracked in #948.
- SPA write-direction leg (CodeMirror edit → Obsidian) + Clerk-capable browser sign-in — tracked in #949.

Refs #942, Refs #944, Refs #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## CI status after the de-flake waves (final)

Four fix waves ran after opening (commits `ca33a2a9`, `45f2c2c3`, `95495be0`, `600a547b`). Result:

- **Fixed (harness/infra, verified green):** test_50 collection-wait budget (was being RERUN-rescued in **4/4 recent green main runs** — proof the rerun net was propping up main), test_47/48 OAuth cold-boot moved into a session warm fixture, test_65 render window, test_82 cursor-persist race.
- **Remaining red = product findings only:**
  - Deterministic (7): test_33 ×2 / test_79 ×2 / test_80 (#942 attachment live delivery), test_41 modify (#944 double-write), test_10 (Engram-obsidian#189 materialize stall).
  - Intermittent (1): test_43 multi-note burst — same `received=yes materialized=no` signature as #189 (evidence commented there). Given a 60s window; it can still exceed it because the stall is unbounded (test_78 forensics showed materialization at teardown-reconnect). It flickers until #189 is fixed.
- Main-branch note: recent green main runs also rerun-rescued test_10 and test_78 — the rescue population this PR's `reruns = 0` makes visible is not specific to this branch.
