### PR TITLE
fix(oauth): scope is optional in authorization requests (RFC 6749)

### DIFF
--- a/frontend/src/oauth/oauth-authorize-page.test.tsx
+++ b/frontend/src/oauth/oauth-authorize-page.test.tsx
@@ -129,6 +129,26 @@ describe("OAuthAuthorizePage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders consent when scope is ABSENT — scope is optional per RFC 6749 §4.1.1", async () => {
+		// Claude Code's MCP re-auth flow omits scope (legal); the backend already
+		// defaults it (oauth.ex: params["scope"] || "mcp"). Requiring it here
+		// bricked every scope-less connect with 'Invalid authorization request'
+		// (found 2026-07-08 during the #951 vault-deletion recovery).
+		fetchOAuthClient.mockResolvedValue({
+			client_id: "cli",
+			client_name: "Claude Code",
+			kind: "mcp",
+		});
+		const NO_SCOPE_QS =
+			"?client_id=cli&redirect_uri=https://app/cb&response_type=code" +
+			"&code_challenge=abc&code_challenge_method=S256&state=xyz";
+		renderAt(NO_SCOPE_QS);
+		expect(await screen.findByText(/Claude Code/u)).toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", { name: /invalid authorization request/iu }),
+		).not.toBeInTheDocument();
+	});
+
 	it("shows the unknown-client alert when the client lookup fails", async () => {
 		fetchOAuthClient.mockRejectedValue(new Error("oauth client lookup failed: 404"));
 		renderAt(VALID_QS);

--- a/frontend/src/oauth/oauth-authorize-page.tsx
+++ b/frontend/src/oauth/oauth-authorize-page.tsx
@@ -27,17 +27,23 @@ const REQUIRED_PARAMS = [
 	"code_challenge",
 	"code_challenge_method",
 	"state",
-	"scope",
 ] as const;
+
+// `scope` is OPTIONAL in an authorization request (RFC 6749 §4.1.1) and the
+// backend already defaults an absent scope to "mcp" (Engram.OAuth.
+// validate_authorization_request). Requiring it here rejected legal
+// scope-less requests — Claude Code's MCP (re)connect flow omits it — with a
+// dead-end "Invalid authorization request" page. Mirror the backend default.
+const DEFAULT_SCOPE = "mcp";
 
 type RequiredParam = (typeof REQUIRED_PARAMS)[number];
 
 function readParams(search: URLSearchParams): {
-	values: Record<RequiredParam, string>;
+	values: Record<RequiredParam, string> & { scope: string };
 	resource: string | null;
 	missing: RequiredParam[];
 } {
-	const values = {} as Record<RequiredParam, string>;
+	const values = {} as Record<RequiredParam, string> & { scope: string };
 	const missing: RequiredParam[] = [];
 
 	for (const key of REQUIRED_PARAMS) {
@@ -48,6 +54,7 @@ function readParams(search: URLSearchParams): {
 			missing.push(key);
 		}
 	}
+	values.scope = search.get("scope") || DEFAULT_SCOPE;
 
 	return { values, resource: search.get("resource"), missing };
 }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.640",
+      version: "0.5.641",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
The SPA consent page hard-required `scope` in the authorization request, but scope is **optional** per RFC 6749 §4.1.1, and the backend already defaults an absent scope to `"mcp"` (`Engram.OAuth.validate_authorization_request`). Result: any legal scope-less authorization request — **Claude Code's MCP (re)connect flow omits scope** — dead-ended on "Invalid authorization request / This page should be opened via an OAuth client redirect" with no recovery path.

Found live tonight while recovering from #951 (vault-bound OAuth token stranded by vault deletion): re-authenticating the Claude Code MCP connection was impossible. Workaround that confirmed the diagnosis: manually appending `&scope=mcp` to the authorize URL renders consent fine.

**Fix (frontend-only):** drop `scope` from `REQUIRED_PARAMS`, mirror the backend's `"mcp"` default. Regression test: scope-less request renders consent, no invalid-request alert.

- Page tests 7/7, full frontend suite **761 green**, vite build clean
- v0.5.641
- Refs #951 (separate backend work: default-vault repointing, revoke-with-reason, contextless list_vaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)