### PR TITLE
fix(crdt): Phase 0 — no content write bypasses the CRDT

### DIFF
--- a/lib/engram/mcp/handlers.ex
+++ b/lib/engram/mcp/handlers.ex
@@ -260,15 +260,15 @@ defmodule Engram.MCP.Handlers do
     text = args["text"] || ""
 
     case Notes.get_note(user, vault, path) do
-      {:ok, note} ->
-        content = String.trim_trailing(note.content, "\n") <> "\n" <> text
-
-        case Notes.upsert_note(user, vault, %{
-               "path" => path,
-               "content" => content,
-               "mtime" => now()
-             }) do
+      {:ok, _note} ->
+        # Read-modify-write via the CAS helper: a write landing between the
+        # read and the upsert must trigger a re-read + rebuild, not be deleted
+        # by the full-content merge (2026-07-07: MCP appends erased).
+        case rmw_upsert(user, vault, path, fn content ->
+               String.trim_trailing(content, "\n") <> "\n" <> text
+             end) do
           {:ok, _} -> {:ok, "Note appended to: #{path}"}
+          {:error, :version_conflict, _} -> {:ok, "Note changed concurrently; retry: #{path}"}
           {:error, _} -> {:ok, "Failed to append to note: #{path}"}
         end
 
@@ -306,9 +306,11 @@ defmodule Engram.MCP.Handlers do
           case Notes.upsert_note(user, vault, %{
                  "path" => path,
                  "content" => new_content,
-                 "mtime" => now()
+                 "mtime" => now(),
+                 "base_hash" => note.content_hash
                }) do
             {:ok, _} -> {:ok, "Replaced #{count} occurrence(s) in #{path}"}
+            {:error, :version_conflict, _} -> {:ok, "Note changed concurrently; retry: #{path}"}
             {:error, _} -> {:ok, "Failed to patch note: #{path}"}
           end
         else
@@ -373,9 +375,11 @@ defmodule Engram.MCP.Handlers do
           case Notes.upsert_note(user, vault, %{
                  "path" => path,
                  "content" => final_content,
-                 "mtime" => now()
+                 "mtime" => now(),
+                 "base_hash" => note.content_hash
                }) do
             {:ok, _} -> {:ok, "Section '#{heading}' updated in #{path}"}
+            {:error, :version_conflict, _} -> {:ok, "Note changed concurrently; retry: #{path}"}
             {:error, _} -> {:ok, "Failed to update section in #{path}"}
           end
         end
@@ -498,6 +502,30 @@ defmodule Engram.MCP.Handlers do
   end
 
   # -- Private helpers --
+
+  @doc false
+  # Read-modify-write with compare-and-swap (Phase 0, identity-as-CRDT).
+  # Declares the read row's content_hash as `base_hash` so a write landing
+  # between the read and the upsert 409s instead of being deleted by the
+  # full-content merge, then retries ONCE on a fresh read. `rebuild` receives
+  # the current content and returns the new content. Public (doc: false) so
+  # the CAS interleaving is unit-testable with a racing rebuild fun.
+  def rmw_upsert(user, vault, path, rebuild, attempt \\ 0) do
+    with {:ok, note} <- Notes.get_note(user, vault, path) do
+      case Notes.upsert_note(user, vault, %{
+             "path" => path,
+             "content" => rebuild.(note.content),
+             "mtime" => now(),
+             "base_hash" => note.content_hash
+           }) do
+        {:error, :version_conflict, _} when attempt == 0 ->
+          rmw_upsert(user, vault, path, rebuild, 1)
+
+        other ->
+          other
+      end
+    end
+  end
 
   defp do_replace(content, find, replace, -1) do
     count = content |> String.split(find) |> length() |> Kernel.-(1)

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -336,6 +336,8 @@ defmodule Engram.Notes do
     mtime = attrs["mtime"] || attrs[:mtime]
     client_id = attrs["id"] || attrs[:id]
 
+    opts = put_base_hash_opt(opts, attrs)
+
     with {:ok, user} <- Crypto.ensure_user_dek(user),
          {:ok, path} <- validate_path(path),
          {:ok, hash} <- content_hash(user, content) do
@@ -461,6 +463,23 @@ defmodule Engram.Notes do
           # ciphertext before the controller serializes the conflict response.
           {:error, :version_conflict, decrypt_or_raise!(existing, user)}
 
+        {:ok, {:stale_base, existing}} ->
+          # Phase 0 stale-base gate: the writer declared a base_hash the row no
+          # longer holds. Refused to merge (a stale full-content push deletes
+          # newer content convergently — 2026-07-07 reconnect clobber). Distinct
+          # greppable key so the rate is monitorable in Loki.
+          Logger.warning(
+            "note_stale_base_rejected",
+            Metadata.with_category(:warning, :sync,
+              user_id: user.id,
+              vault_id: vault.id,
+              note_id: existing.id,
+              server_version: existing.version
+            )
+          )
+
+          {:error, :version_conflict, decrypt_or_raise!(existing, user)}
+
         {:ok, {:id_collision, live}} ->
           # A push carried a note_id that already names a LIVE note at another
           # path. Refused to move/merge (that destroys the live note). Log with
@@ -583,6 +602,19 @@ defmodule Engram.Notes do
               {:error, changeset}
           end
         end
+    end
+  end
+
+  # Phase 0 stale-base gate: a writer that declares the content_hash it READ
+  # (`base_hash`) gets compare-and-swap semantics — if the row moved, the
+  # write 409s instead of CRDT-merging. The merge diffs incoming FULL content
+  # against the stored snapshot, so a stale full-content push deletes newer
+  # content "convergently" (prod incident 2026-07-07). Absent base_hash keeps
+  # the merge behavior for legacy clients.
+  defp put_base_hash_opt(opts, attrs) do
+    case attrs["base_hash"] || attrs[:base_hash] do
+      base when is_binary(base) -> Keyword.put(opts, :base_hash, base)
+      _ -> opts
     end
   end
 
@@ -761,29 +793,47 @@ defmodule Engram.Notes do
   # IS the conflict resolution. A stale client_version never 409s — the diverging
   # write is merged convergently into crdt_state (no legacy conflict-copy flow).
   defp do_update_note(existing, base_attrs, user, sanitized_path, folder, _tags, opts \\ []) do
-    if is_binary(existing.content_hash) and
-         existing.content_hash == base_attrs.content_hash and
-         not Keyword.get(opts, :force, false) do
-      # Idempotent re-push (plugin retry, offline-queue replay, MCP re-write):
-      # the incoming content hashes identically to the stored merged content,
-      # so the CRDT diff is a provable no-op. Skip the whole pipeline — CRDT
-      # decrypt/merge/re-encrypt, field re-encryption, the row rewrite (TOAST
-      # + WAL churn on the content blob), the version bump, and the seq
-      # allocation — and return the row unchanged. The caller skips the
-      # note_changed broadcast on hash equality, so other devices don't
-      # reconcile a phantom change. Tradeoff: a same-content push with a newer
-      # mtime keeps the stored mtime; sync state is hash/seq-based, so nothing
-      # keys off it. Tombstones never reach here (note_by_path_query filters
-      # deleted_at), so delete → re-push still resurrects via the insert path.
-      # Repair paths that re-derive persisted fields from unchanged content
-      # (e.g. Utf8Backfill fixing corrupt tags) pass `force: true` to opt out.
-      # Return shape matches do_rewrite_note's 4-tuple: merged_text is the
-      # incoming content (hash-equal to the stored merged content by the guard
-      # above), so callers thread the same digest fields either way.
-      {:ok, {existing.content_hash, existing, base_attrs.content, existing.content_hash}}
-    else
-      do_rewrite_note(existing, base_attrs, user, sanitized_path, folder)
+    base_hash = Keyword.get(opts, :base_hash)
+
+    cond do
+      is_binary(existing.content_hash) and
+        existing.content_hash == base_attrs.content_hash and
+          not Keyword.get(opts, :force, false) ->
+        idempotent_repush(existing, base_attrs)
+
+      is_binary(base_hash) and is_binary(existing.content_hash) and
+          existing.content_hash != base_hash ->
+        # Stale base declared: the row moved since this writer read it. Refuse
+        # to merge (see upsert_note — a stale full-content push deletes newer
+        # content convergently); the writer re-reads and retries or surfaces a
+        # conflict. Matches the long-documented-but-missing 409 contract.
+        {:stale_base, existing}
+
+      true ->
+        do_rewrite_note(existing, base_attrs, user, sanitized_path, folder)
     end
+  end
+
+  # Idempotent re-push (plugin retry, offline-queue replay, MCP re-write):
+  # the incoming content hashes identically to the stored merged content,
+  # so the CRDT diff is a provable no-op. Skip the whole pipeline — CRDT
+  # decrypt/merge/re-encrypt, field re-encryption, the row rewrite (TOAST
+  # + WAL churn on the content blob), the version bump, and the seq
+  # allocation — and return the row unchanged. The caller skips the
+  # note_changed broadcast on hash equality, so other devices don't
+  # reconcile a phantom change. Tradeoff: a same-content push with a newer
+  # mtime keeps the stored mtime; sync state is hash/seq-based, so nothing
+  # keys off it. Tombstones never reach here (note_by_path_query filters
+  # deleted_at), so delete → re-push still resurrects via the insert path.
+  # Repair paths that re-derive persisted fields from unchanged content
+  # (e.g. Utf8Backfill fixing corrupt tags) pass `force: true` to opt out.
+  # Return shape matches do_rewrite_note's 4-tuple: merged_text is the
+  # incoming content (hash-equal to the stored merged content by the guard
+  # in do_update_note), so callers thread the same digest fields either way.
+  # Checked BEFORE the stale-base gate: a hash-equal push is a no-op whatever
+  # base the writer declared.
+  defp idempotent_repush(existing, base_attrs) do
+    {:ok, {existing.content_hash, existing, base_attrs.content, existing.content_hash}}
   end
 
   defp do_rewrite_note(existing, base_attrs, user, sanitized_path, folder) do

--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -62,134 +62,89 @@ defmodule Engram.Notes.CrdtCheckpoint do
           end
       end
 
-    text = CrdtBridge.text_of(doc)
+    # Phase 0 monotonicity (identity-as-CRDT): never materialize the live doc's
+    # state directly. Encode it ONCE (read-only — the room's doc is never
+    # mutated from here), then fold the row's STORED state into a scratch doc
+    # and materialize the union. The stored state is the same lineage
+    # deliver_out pushes, so the fold is idempotent; a room that missed a
+    # deliver_out (decrypt blip, KMS outage) is BEHIND writes that committed
+    # before any fence capture, and without the union its checkpoint would
+    # overwrite content AND crdt_state with the stale doc — destroying the
+    # REST/MCP write entirely (prod incident 2026-07-07: MCP appends erased).
+    # With the union the persisted state only ever grows; deletions still win
+    # (causally newer ops), and the version CAS below still guards the
+    # mid-checkpoint race window.
+    case encode(doc) do
+      {:ok, live_state} ->
+        # with_tenant wraps the fun's return in {:ok, _} (Ecto transaction). The
+        # fun returns {prev_hash, path} on a write (prev_hash drives the
+        # embed/deliver guard, path feeds the post-commit announce) or
+        # {:abort, reason} when the stored state is unreadable — overwriting a
+        # state we cannot prove we contain could destroy data, so we write
+        # nothing (unreadable ≠ absent).
+        {:ok, outcome} =
+          Repo.with_tenant(user_id, fn ->
+            # `note.path` / `note.folder` / `note.title` are VIRTUAL — a bare
+            # Repo.get! leaves them nil. Materialize through the decrypt path so
+            # they are populated BEFORE we re-derive title + re-HMAC path/folder.
+            # Without this, extract_title falls back to the UUID and
+            # inject_phase_b_fields_pub gets nil path/folder → corrupts
+            # path_hmac/folder_hmac so the row stops resolving by path.
+            {:ok, note} = Crypto.maybe_decrypt_note_fields(Repo.get!(Note, note_id), user)
 
-    with {:ok, raw_state} <- encode(doc),
-         {_flat_doc, state} <- maybe_flatten(doc, raw_state, note_id),
-         {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(state, user, note_id),
-         {:ok, key} <- Crypto.dek_content_hash_key(user) do
-      content_hash = Crypto.hmac_content_hash(key, text)
-      tags = Helpers.extract_tags(text)
+            with {:ok, union_doc} <- union_with_row_state(note, live_state, user),
+                 text = CrdtBridge.text_of(union_doc),
+                 {:ok, raw_state} <- encode(union_doc),
+                 {_flat_doc, state} <- maybe_flatten(union_doc, raw_state, note_id),
+                 {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(state, user, note_id),
+                 {:ok, key} <- Crypto.dek_content_hash_key(user) do
+              content_hash = Crypto.hmac_content_hash(key, text)
+              tags = Helpers.extract_tags(text)
 
-      # with_tenant wraps the fun's return in {:ok, _} (Ecto transaction). The
-      # fun returns {prev_hash, path}: prev_hash drives the embed/deliver guard,
-      # path feeds the post-commit deliver-out announce (needs the decrypted
-      # virtual path, only available inside the tenant txn).
-      {:ok, {prev_hash, path}} =
-        Repo.with_tenant(user_id, fn ->
-          # `note.path` / `note.folder` / `note.title` are VIRTUAL — a bare
-          # Repo.get! leaves them nil. Materialize through the decrypt path so
-          # they are populated BEFORE we re-derive title + re-HMAC path/folder.
-          # Without this, extract_title falls back to the UUID and
-          # inject_phase_b_fields_pub gets nil path/folder → corrupts
-          # path_hmac/folder_hmac so the row stops resolving by path.
-          {:ok, note} = Crypto.maybe_decrypt_note_fields(Repo.get!(Note, note_id), user)
-          prev = note.content_hash
-
-          if prev == content_hash do
-            # Text unchanged: compact the snapshot + prune, but do NOT touch
-            # version/seq/content — legacy /changes pullers must not see phantom edits.
-            {1, _} =
-              Repo.update_all(
-                from(n in Note, where: n.id == ^note_id and n.kind == "note"),
-                set: [
-                  crdt_state_ciphertext: ct,
-                  crdt_state_nonce: nonce,
-                  dek_version: Crypto.row_version_aad_bound()
-                ]
-              )
-
-            prune_tail(note_id, watermark)
-            {prev, note.path}
-          else
-            # Re-derive title from the note's decrypted (sanitized-at-write) path.
-            title = Helpers.extract_title(text, note.path)
-
-            merged = %{content: text, title: title, tags: tags, content_hash: content_hash}
-            {:ok, encrypted} = Crypto.encrypt_note_fields(merged, user, note_id)
-
-            phase_b =
-              Notes.inject_phase_b_fields_pub(
-                encrypted,
-                user,
-                note_id,
-                note.path,
-                note.folder,
-                tags
-              )
-              |> Notes.inject_okf_fields_pub(user, note_id, text)
-              |> Map.put(:crdt_state_ciphertext, ct)
-              |> Map.put(:crdt_state_nonce, nonce)
-              |> Map.put(:content_hash, content_hash)
-
-            # #902 fence. When the caller captured the doc at a known row version,
-            # persist only if the row is STILL at that version. A REST/MCP write
-            # that committed after the snapshot bumped `version`, so the CAS matches
-            # zero rows and we ABORT — never overwriting the newer committed content
-            # with our stale encoding. `captured_version` nil (e.g. the unbind path)
-            # keeps the prior unfenced behaviour. The field set is derived through
-            # Note.changeset (identical casting to the previous Repo.update!) and
-            # applied via a version-fenced update_all, mirroring the compaction branch.
-            captured = Keyword.get(opts, :captured_version)
-            fence_version = captured || note.version
-
-            changeset =
-              note
-              |> Note.changeset(Map.put(phase_b, :version, fence_version + 1))
-              |> Ecto.Changeset.put_change(:seq, Vaults.next_seq!(vault_id))
-
-            base_query = from(n in Note, where: n.id == ^note_id and n.kind == "note")
-
-            fenced_query =
-              if captured, do: where(base_query, [n], n.version == ^captured), else: base_query
-
-            # update_all does NOT auto-manage timestamps (Repo.update! does), and
-            # `updated_at` is never cast into changeset.changes. Set it explicitly —
-            # matching every sibling notes update_all — or the /api/notes/changes
-            # timestamp feed (filters + orders on updated_at) silently drops the edit.
-            set = changeset.changes |> Map.put(:updated_at, DateTime.utc_now()) |> Map.to_list()
-
-            case Repo.update_all(fenced_query, set: set) do
-              {1, _} ->
-                prune_tail(note_id, watermark)
-                {prev, note.path}
-
-              {0, _} ->
-                # The row advanced since our snapshot — a newer write is already
-                # committed. Do NOT prune (its tail rows may be unmerged) and do NOT
-                # revert. Return `content_hash` so the caller enqueues no embed for a
-                # write that did not happen; the next debounce tick re-captures the
-                # now-merged doc and checkpoints that.
-                Logger.info(
-                  "crdt checkpoint skipped stale write note_id=#{note_id} captured_version=#{fence_version}",
-                  Metadata.with_category(:info, :sync, note_id: note_id)
-                )
-
-                {content_hash, note.path}
+              checkpoint_write(note, vault_id, note_id, watermark, opts, %{
+                text: text,
+                tags: tags,
+                content_hash: content_hash,
+                ct: ct,
+                nonce: nonce,
+                user: user
+              })
+            else
+              err -> {:abort, err}
             end
-          end
-        end)
+          end)
 
-      _ =
-        if prev_hash != content_hash do
-          _ = Enqueue.enqueue(EmbedNote.new_debounced(note_id), "embed_note")
+        case outcome do
+          {prev_hash, new_hash, path} ->
+            _ =
+              if prev_hash != new_hash do
+                _ = Enqueue.enqueue(EmbedNote.new_debounced(note_id), "embed_note")
 
-          # Deliver-out gap: a web-editor edit lands ONLY via this checkpoint,
-          # which (unlike REST/MCP writes) never announced. A client not
-          # actively enrolled in the room — e.g. Obsidian — thus never
-          # discovered the edit, live or on next pull. Announce so it opens a
-          # room and pulls the just-persisted state. Announce-ONLY (not full
-          # deliver_out): live observers already converged via real-time frame
-          # relay, and the room-state push would `GenServer.call` self on the
-          # unbind path (checkpoint runs inside the room process there).
-          # `prev_hash != content_hash` fires only on a committed content change
-          # (compaction returns prev==hash; the #902 stale-abort returns hash),
-          # so idle compactions and aborted writes raise no spurious re-pull.
-          CrdtDeliver.announce_ready(user_id, vault_id, path, note_id)
+                # Deliver-out gap: a web-editor edit lands ONLY via this checkpoint,
+                # which (unlike REST/MCP writes) never announced. A client not
+                # actively enrolled in the room — e.g. Obsidian — thus never
+                # discovered the edit, live or on next pull. Announce so it opens a
+                # room and pulls the just-persisted state. Announce-ONLY (not full
+                # deliver_out): live observers already converged via real-time frame
+                # relay, and the room-state push would `GenServer.call` self on the
+                # unbind path (checkpoint runs inside the room process there).
+                # `prev_hash != new_hash` fires only on a committed content change
+                # (compaction and the #902 stale-abort both return equal hashes),
+                # so idle compactions and aborted writes raise no spurious re-pull.
+                CrdtDeliver.announce_ready(user_id, vault_id, path, note_id)
+              end
+
+            :ok
+
+          {:abort, err} ->
+            Logger.error(
+              "crdt checkpoint aborted note_id=#{note_id} reason=#{inspect(err)}",
+              Metadata.with_category(:error, :sync, note_id: note_id)
+            )
+
+            :ok
         end
 
-      :ok
-    else
       err ->
         Logger.error(
           "crdt checkpoint failed note_id=#{note_id} reason=#{inspect(err)}",
@@ -206,6 +161,122 @@ defmodule Engram.Notes.CrdtCheckpoint do
       )
 
       :ok
+  end
+
+  # Folds the row's stored CRDT state with the live doc's encoded state into a
+  # fresh scratch doc (Yjs union — idempotent, shared lineage). Absent stored
+  # state (legacy/lazy row) degrades to the live state alone; an UNREADABLE
+  # stored state is an error, never a degrade.
+  defp union_with_row_state(%Note{crdt_state_ciphertext: nil}, live_state, _user),
+    do: CrdtBridge.doc_from_state(live_state)
+
+  defp union_with_row_state(%Note{} = note, live_state, user) do
+    case Crypto.decrypt_crdt_state(note, user) do
+      {:ok, row_state} when is_binary(row_state) ->
+        with {:ok, union_doc} <- CrdtBridge.doc_from_state(row_state),
+             :ok <- Yex.apply_update(union_doc, live_state) do
+          {:ok, union_doc}
+        end
+
+      {:ok, nil} ->
+        CrdtBridge.doc_from_state(live_state)
+
+      {:error, reason} ->
+        {:error, {:row_state_unreadable, reason}}
+    end
+  end
+
+  # The two persistence branches (compaction vs. materialize), unchanged in
+  # behavior except that they now persist the UNION doc's text/state. Runs
+  # inside the caller's tenant txn; returns {prev_hash, new_hash, path} —
+  # equal hashes mean "no content change committed" (compaction / stale abort),
+  # which suppresses the caller's embed + announce.
+  defp checkpoint_write(note, vault_id, note_id, watermark, opts, m) do
+    %{text: text, tags: tags, content_hash: content_hash, ct: ct, nonce: nonce, user: user} = m
+    prev = note.content_hash
+
+    if prev == content_hash do
+      # Text unchanged: compact the snapshot + prune, but do NOT touch
+      # version/seq/content — legacy /changes pullers must not see phantom edits.
+      {1, _} =
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note_id and n.kind == "note"),
+          set: [
+            crdt_state_ciphertext: ct,
+            crdt_state_nonce: nonce,
+            dek_version: Crypto.row_version_aad_bound()
+          ]
+        )
+
+      prune_tail(note_id, watermark)
+      {prev, content_hash, note.path}
+    else
+      # Re-derive title from the note's decrypted (sanitized-at-write) path.
+      title = Helpers.extract_title(text, note.path)
+
+      merged = %{content: text, title: title, tags: tags, content_hash: content_hash}
+      {:ok, encrypted} = Crypto.encrypt_note_fields(merged, user, note_id)
+
+      phase_b =
+        Notes.inject_phase_b_fields_pub(
+          encrypted,
+          user,
+          note_id,
+          note.path,
+          note.folder,
+          tags
+        )
+        |> Notes.inject_okf_fields_pub(user, note_id, text)
+        |> Map.put(:crdt_state_ciphertext, ct)
+        |> Map.put(:crdt_state_nonce, nonce)
+        |> Map.put(:content_hash, content_hash)
+
+      # #902 fence. When the caller captured the doc at a known row version,
+      # persist only if the row is STILL at that version. A REST/MCP write
+      # that committed after the snapshot bumped `version`, so the CAS matches
+      # zero rows and we ABORT — never overwriting the newer committed content
+      # with our stale encoding. `captured_version` nil (e.g. the unbind path)
+      # keeps the prior unfenced behaviour. The field set is derived through
+      # Note.changeset (identical casting to the previous Repo.update!) and
+      # applied via a version-fenced update_all, mirroring the compaction branch.
+      captured = Keyword.get(opts, :captured_version)
+      fence_version = captured || note.version
+
+      changeset =
+        note
+        |> Note.changeset(Map.put(phase_b, :version, fence_version + 1))
+        |> Ecto.Changeset.put_change(:seq, Vaults.next_seq!(vault_id))
+
+      base_query = from(n in Note, where: n.id == ^note_id and n.kind == "note")
+
+      fenced_query =
+        if captured, do: where(base_query, [n], n.version == ^captured), else: base_query
+
+      # update_all does NOT auto-manage timestamps (Repo.update! does), and
+      # `updated_at` is never cast into changeset.changes. Set it explicitly —
+      # matching every sibling notes update_all — or the /api/notes/changes
+      # timestamp feed (filters + orders on updated_at) silently drops the edit.
+      set = changeset.changes |> Map.put(:updated_at, DateTime.utc_now()) |> Map.to_list()
+
+      case Repo.update_all(fenced_query, set: set) do
+        {1, _} ->
+          prune_tail(note_id, watermark)
+          {prev, content_hash, note.path}
+
+        {0, _} ->
+          # The row advanced since our snapshot — a newer write is already
+          # committed. Do NOT prune (its tail rows may be unmerged) and do NOT
+          # revert. Return equal hashes so the caller enqueues no embed for a
+          # write that did not happen; the next debounce tick re-captures the
+          # now-merged doc and checkpoints that.
+          Logger.info(
+            "crdt checkpoint skipped stale write note_id=#{note_id} captured_version=#{fence_version}",
+            Metadata.with_category(:info, :sync, note_id: note_id)
+          )
+
+          {content_hash, content_hash, note.path}
+      end
+    end
   end
 
   defp encode(doc) do

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -103,7 +103,26 @@ defmodule Engram.Notes.CrdtDeliver do
       room ->
         case load_merged_state(user_id, note_id) do
           {:ok, state} when is_binary(state) ->
-            room_apply(room, note_id, fn doc -> apply_state(doc, state, note_id) end)
+            # The apply runs inside the room process (update_doc discards the
+            # fun's return), so failure is signalled back by message — safe
+            # ordering: update_doc is a synchronous call, the send happens
+            # before the reply.
+            parent = self()
+
+            room_apply(room, note_id, fn doc ->
+              if apply_state(doc, state, note_id) == :apply_failed do
+                send(parent, {:crdt_deliver_apply_failed, note_id})
+              end
+
+              :ok
+            end)
+
+            receive do
+              {:crdt_deliver_apply_failed, ^note_id} ->
+                quarantine_room(room, note_id, :apply_update_failed)
+            after
+              0 -> :ok
+            end
 
           {:ok, nil} when content == "" ->
             # Empty content on a room with NO persisted CRDT state is ambiguous:
@@ -120,11 +139,33 @@ defmodule Engram.Notes.CrdtDeliver do
           {:ok, nil} ->
             room_apply(room, note_id, fn doc -> CrdtBridge.ingest_plaintext(doc, content) end)
 
-          {:error, _reason} ->
-            # Already logged in load_merged_state. Deliberately no ingest.
-            :ok
+          {:error, reason} ->
+            # Already logged in load_merged_state. Deliberately no ingest —
+            # and the room must not survive: see quarantine_room/3.
+            quarantine_room(room, note_id, reason)
         end
     end
+  end
+
+  # Phase 0 (identity-as-CRDT): a live room we could not converge onto the
+  # committed state is a poisoned cache. Left alive, it (a) serves its stale
+  # doc to every client the announce triggers to re-pull — blocking delivery
+  # of the committed write indefinitely — and (b) would checkpoint that stale
+  # doc on exit. Unregister the name first (so lookups stop resolving to the
+  # dying pid), then kill BRUTALLY: `:kill` is untrappable and skips
+  # terminate/2 → unbind → checkpoint, which must not run for a doc we could
+  # not converge. Nothing is lost: every room update was already appended to
+  # the durable tail-log by update_v1, and the next join re-binds a fresh room
+  # hydrated from the row's merged state + tail replay.
+  defp quarantine_room(room, note_id, reason) do
+    Logger.error(
+      "crdt deliver quarantined stale room — killed for rebind from row",
+      Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
+    )
+
+    _ = :global.unregister_name(CrdtRegistry.global_name(note_id))
+    Process.exit(room, :kill)
+    :ok
   end
 
   # `:global.whereis_name` can hand back a room that is mid auto-exit, so the
@@ -164,14 +205,14 @@ defmodule Engram.Notes.CrdtDeliver do
         # The just-committed state failed to apply — the doc or the state is
         # already suspect, so plaintext-diffing into that same doc would be
         # the worst possible response (foreign-lineage re-encode on top of a
-        # broken doc). Skip; observers converge via the announce → step-1
-        # re-pull against a fresh room.
+        # broken doc). Report failure; the caller quarantines the room so the
+        # announce → re-pull lands on a FRESH room hydrated from the row.
         Logger.error(
           "crdt deliver apply_update failed — skipping push",
           Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
         )
 
-        :ok
+        :apply_failed
     end
   end
 

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -11,9 +11,12 @@ defmodule EngramWeb.NotesController do
     operation_id: "notes-upsert",
     summary: "Create or update a note",
     description:
-      "Creates a note or updates the existing one at the same path. Concurrent edits are guarded " <>
-        "by mtime — a stale write returns 409 with the current server note. Notes over 10MB are " <>
-        "rejected with 413, and exceeding the plan's note cap returns 402.",
+      "Creates a note or updates the existing one at the same path. Updates are merged " <>
+        "convergently (CRDT) with the stored content. Optionally pass `base_hash` — the " <>
+        "`content_hash` you last read — for compare-and-swap semantics: if the note changed " <>
+        "since that read, the write returns 409 with the current server note instead of " <>
+        "merging. Notes over 10MB are rejected with 413, and exceeding the plan's note cap " <>
+        "returns 402.",
     tags: ["Notes"],
     request_body:
       {"Note to upsert", "application/json", Schemas.UpsertNoteRequest, required: true},

--- a/lib/engram_web/schemas/notes.ex
+++ b/lib/engram_web/schemas/notes.ex
@@ -23,6 +23,13 @@ defmodule EngramWeb.Schemas.UpsertNoteRequest do
       content: %Schema{type: :string},
       mtime: %Schema{type: :number, format: :float},
       version: %Schema{type: :integer, nullable: true},
+      base_hash: %Schema{
+        type: :string,
+        nullable: true,
+        description:
+          "Compare-and-swap guard: the content_hash you last read for this note. " <>
+            "If the note changed since, the write returns 409 instead of merging."
+      },
       title: %Schema{type: :string, nullable: true},
       folder: %Schema{type: :string, nullable: true},
       tags: %Schema{type: :array, items: %Schema{type: :string}}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.641",
+      version: "0.5.642",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -2258,6 +2258,13 @@
           ]
         },
         "properties": {
+          "base_hash": {
+            "description": "Compare-and-swap guard: the content_hash you last read for this note. If the note changed since, the write returns 409 instead of merging.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "content": {
             "type": "string",
             "x-struct": null,
@@ -2743,7 +2750,7 @@
     "/api/notes": {
       "post": {
         "callbacks": {},
-        "description": "Creates a note or updates the existing one at the same path. Concurrent edits are guarded by mtime — a stale write returns 409 with the current server note. Notes over 10MB are rejected with 413, and exceeding the plan's note cap returns 402.",
+        "description": "Creates a note or updates the existing one at the same path. Updates are merged convergently (CRDT) with the stored content. Optionally pass `base_hash` — the `content_hash` you last read — for compare-and-swap semantics: if the note changed since that read, the write returns 409 with the current server note instead of merging. Notes over 10MB are rejected with 413, and exceeding the plan's note cap returns 402.",
         "operationId": "notes-upsert",
         "parameters": [],
         "requestBody": {

--- a/test/engram/mcp/handlers_test.exs
+++ b/test/engram/mcp/handlers_test.exs
@@ -16,6 +16,74 @@ defmodule Engram.MCP.HandlersTest do
     %{user: user, vault: vault}
   end
 
+  describe "rmw_upsert/4 — read-modify-write CAS (Phase 0)" do
+    # MCP write tools are read-modify-write: get_note → rebuild → upsert. A
+    # write landing between the read and the upsert used to be silently
+    # deleted by the full-content merge (the rebuilt content is diffed against
+    # the moved row — 2026-07-07: MCP appends erased). rmw_upsert declares the
+    # read hash as base_hash and retries once on the resulting conflict.
+    test "retries once when the row moves between read and write", ctx do
+      %{user: user, vault: vault} = ctx
+      alias Engram.Notes
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "r.md", "content" => "base", "mtime" => 1.0})
+
+      raced = :counters.new(1, [])
+
+      {:ok, note} =
+        Handlers.rmw_upsert(user, vault, "r.md", fn content ->
+          # First rebuild simulates the race: a concurrent writer moves the row
+          # AFTER our read, BEFORE our upsert.
+          if :counters.get(raced, 1) == 0 do
+            :counters.add(raced, 1, 1)
+
+            {:ok, _} =
+              Notes.upsert_note(user, vault, %{
+                "path" => "r.md",
+                "content" => "base\nconcurrent",
+                "mtime" => 2.0
+              })
+          end
+
+          content <> "\nappended"
+        end)
+
+      # Neither write lost: the retry re-read the moved row and rebuilt on it.
+      assert note.content =~ "concurrent"
+      assert note.content =~ "appended"
+    end
+
+    test "gives up with an error after the retry also conflicts", ctx do
+      %{user: user, vault: vault} = ctx
+      alias Engram.Notes
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "g.md", "content" => "base", "mtime" => 1.0})
+
+      tick = :counters.new(1, [])
+
+      assert {:error, :version_conflict, _} =
+               Handlers.rmw_upsert(user, vault, "g.md", fn content ->
+                 # EVERY rebuild races — the row moves each time, so the retry
+                 # conflicts too and the helper must stop rather than loop.
+                 n = :counters.get(tick, 1)
+                 :counters.add(tick, 1, 1)
+
+                 {:ok, _} =
+                   Notes.upsert_note(user, vault, %{
+                     "path" => "g.md",
+                     "content" => "base\nconcurrent#{n}",
+                     "mtime" => 2.0 + n
+                   })
+
+                 content <> "\nappended"
+               end)
+    end
+  end
+
   describe "rename_folder handler" do
     test "cascades attachments and reports both counts", %{user: user, vault: vault} do
       {:ok, _} =

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -169,6 +169,82 @@ defmodule Engram.Notes.CrdtCheckpointTest do
            "checkpoint reverted a committed REST write (the #902 gap)"
   end
 
+  # ── Phase 0 (identity-as-CRDT): checkpoint must be MONOTONE ─────────────────
+  # The version fence only aborts when the row moved AFTER capture. A room whose
+  # doc missed a deliver_out (decrypt blip, KMS outage) is behind writes that
+  # committed BEFORE capture: the fence passes and the stale doc used to
+  # overwrite both notes.content AND crdt_state, destroying the REST/MCP write
+  # entirely (prod incident 2026-07-07: MCP work-log appends erased on plugin
+  # reconnect). Fix: checkpoint folds the row's stored state into the doc state
+  # (Yjs union, same lineage as deliver_out) before materializing — the output
+  # can only grow, never regress, regardless of what the room missed.
+
+  test "checkpoint UNIONS the row's stored state — a stale room doc cannot erase a REST write",
+       ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    # The room doc is built from the ORIGINAL state and diverges with a live
+    # edit — but it never receives the REST write below (a missed deliver_out).
+    {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, raw_state} = Crypto.decrypt_crdt_state(raw_note, user)
+    {:ok, doc} = CrdtBridge.doc_from_state(raw_state)
+    :ok = CrdtBridge.diff_into_text(Yex.Doc.get_text(doc, CrdtBridge.text_name()), "before EDIT")
+
+    # REST/MCP write commits new merged content + state, bumping the version —
+    # BEFORE the checkpoint captures anything, so no fence can catch this.
+    {:ok, _} =
+      Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before APPEND"})
+
+    # Room exits (unbind path: no captured_version). Today this blindly writes
+    # "before EDIT" over "before APPEND" — content AND crdt_state regress.
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+
+    {:ok, fresh} = Notes.get_note(user, vault, "p.md")
+
+    assert fresh.content =~ "APPEND",
+           "checkpoint erased a committed REST write the room doc never saw"
+
+    assert fresh.content =~ "EDIT",
+           "checkpoint lost the room's own live edit"
+
+    # The persisted CRDT state must also carry the union: rebuilding a doc from
+    # it must project the merged text (the row state is the durable truth the
+    # next bind hydrates from — content alone converging is not enough).
+    {:ok, after_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, after_state} = Crypto.decrypt_crdt_state(after_note, user)
+    {:ok, rebuilt} = CrdtBridge.doc_from_state(after_state)
+    rebuilt_text = CrdtBridge.text_of(rebuilt)
+    assert rebuilt_text =~ "APPEND"
+    assert rebuilt_text =~ "EDIT"
+  end
+
+  test "checkpoint ABORTS (row untouched) when the row's stored state cannot be read", ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    # Divergent room doc, as above.
+    {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, raw_state} = Crypto.decrypt_crdt_state(raw_note, user)
+    {:ok, doc} = CrdtBridge.doc_from_state(raw_state)
+    :ok = CrdtBridge.diff_into_text(Yex.Doc.get_text(doc, CrdtBridge.text_name()), "before EDIT")
+
+    # Corrupt the stored state so it cannot be decrypted: the checkpoint can no
+    # longer prove its write is a superset of the durable truth, so it must not
+    # write at all (unreadable ≠ absent — overwriting could destroy data).
+    Repo.with_tenant(user.id, fn ->
+      Repo.update_all(from(n in Note, where: n.id == ^note.id),
+        set: [crdt_state_ciphertext: <<0, 1, 2, 3>>, crdt_state_nonce: <<0::96>>]
+      )
+    end)
+
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+
+    {:ok, after_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    assert after_note.version == note.version, "checkpoint wrote despite unreadable stored state"
+
+    assert after_note.crdt_state_ciphertext == <<0, 1, 2, 3>>,
+           "checkpoint replaced a stored state it could not read"
+  end
+
   # ── /changes feed integrity: checkpoint must advance updated_at ────────────
 
   test "checkpoint advances updated_at so the /changes timestamp feed sees the edit", ctx do

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -184,8 +184,18 @@ defmodule Engram.Notes.CrdtDeliverTest do
   # ---------------------------------------------------------------------------
 
   describe "deliver_out/5 — state-load failure handling" do
-    test "decrypt failure skips the room push (no plaintext re-encode) but still announces",
+    test "decrypt failure QUARANTINES the room (killed, no unbind) and still announces",
          %{user: user, vault: vault} do
+      # Semantic flip from "skip the push, leave the room alive": a room we
+      # could not converge is a poisoned cache — it serves its stale doc to
+      # every client the announce triggers to re-pull, blocking delivery of
+      # the committed write, and (pre Phase-0 union) its next checkpoint
+      # reverted the row. Kill it brutally (no unbind checkpoint — never
+      # persist a doc we could not converge); the next join re-binds a fresh
+      # room hydrated from the row, which holds the merged truth.
+      # The bare room is start_link'ed to this test process; the quarantine
+      # kill would propagate over the link, so trap exits.
+      Process.flag(:trap_exit, true)
       {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s.md", "content" => "orig"})
 
       # Corrupt the stored CRDT state so decrypt fails (ciphertext mismatch).
@@ -197,6 +207,7 @@ defmodule Engram.Notes.CrdtDeliverTest do
         end)
 
       room = start_bare_room(note.id, "orig")
+      ref = Process.monitor(room)
       EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
 
       log =
@@ -205,13 +216,39 @@ defmodule Engram.Notes.CrdtDeliverTest do
           assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
         end)
 
-      # The room was NOT mutated — a plaintext ingest would have re-encoded
-      # "orig updated" on the room's lineage.
-      doc = SharedDoc.get_doc(room)
-      assert CrdtBridge.text_of(doc) == "orig"
+      # The poisoned room must be gone — killed, not gracefully stopped
+      # (a graceful stop would run unbind → checkpoint of the stale doc).
+      assert_receive {:DOWN, ^ref, :process, ^room, :killed}, 1000
+      assert CrdtRegistry.lookup(note.id) == nil
 
       # The degradation is loud (Sentry captures Logger.error).
       assert log =~ "crdt deliver state load failed"
+    end
+
+    test "apply_update failure QUARANTINES the room (killed) — no stale cache survives",
+         %{user: user, vault: vault} do
+      Process.flag(:trap_exit, true)
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s2.md", "content" => "orig"})
+
+      # Store VALIDLY-ENCRYPTED garbage: decrypt succeeds, Yex.apply_update fails.
+      {:ok, {ct, nonce}} = Engram.Crypto.encrypt_crdt_state("not a yjs update", user, note.id)
+
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(from(n in Note, where: n.id == ^note.id),
+            set: [crdt_state_ciphertext: ct, crdt_state_nonce: nonce]
+          )
+        end)
+
+      room = start_bare_room(note.id, "orig")
+      ref = Process.monitor(room)
+
+      capture_log(fn ->
+        assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "s2.md", note.id, "orig updated")
+      end)
+
+      assert_receive {:DOWN, ^ref, :process, ^room, :killed}, 1000
+      assert CrdtRegistry.lookup(note.id) == nil
     end
 
     test "a row without CRDT state falls back to plaintext ingest (legacy row)",

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -107,6 +107,81 @@ defmodule Engram.NotesTest do
   # ---------------------------------------------------------------------------
 
   describe "upsert_note/3" do
+    # Phase 0 (identity-as-CRDT): the documented-but-missing stale-base gate.
+    # The three-way CRDT merge diffs incoming FULL content against the stored
+    # snapshot — a stale client's push whose diff says "these paragraphs don't
+    # exist" thereby deletes newer content "convergently" (prod incident
+    # 2026-07-07, plugin reconnect clobber). A writer that declares the base it
+    # read (`base_hash` = the row's content_hash at read time) must 409 when
+    # the row has moved, so the client re-reads/merges instead of clobbering.
+    test "base_hash mismatch returns version_conflict instead of merging a stale write",
+         %{user: user, vault: vault} do
+      {:ok, v1} =
+        Notes.upsert_note(user, vault, %{"path" => "cas.md", "content" => "one", "mtime" => 1.0})
+
+      stale_base = v1.content_hash
+
+      # The row moves (someone else's write).
+      {:ok, v2} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "cas.md",
+          "content" => "one\ntwo",
+          "mtime" => 2.0
+        })
+
+      # A write declaring the OLD base must be refused with the server note.
+      assert {:error, :version_conflict, server_note} =
+               Notes.upsert_note(user, vault, %{
+                 "path" => "cas.md",
+                 "content" => "one\nstale rewrite",
+                 "mtime" => 3.0,
+                 "base_hash" => stale_base
+               })
+
+      assert server_note.id == v2.id
+
+      # Nothing was merged — the newer content is intact.
+      {:ok, fresh} = Notes.get_note(user, vault, "cas.md")
+      assert fresh.content == "one\ntwo"
+    end
+
+    test "base_hash matching the current row proceeds normally", %{user: user, vault: vault} do
+      {:ok, v1} =
+        Notes.upsert_note(user, vault, %{"path" => "cas2.md", "content" => "one", "mtime" => 1.0})
+
+      assert {:ok, updated} =
+               Notes.upsert_note(user, vault, %{
+                 "path" => "cas2.md",
+                 "content" => "one\ntwo",
+                 "mtime" => 2.0,
+                 "base_hash" => v1.content_hash
+               })
+
+      assert updated.content == "one\ntwo"
+    end
+
+    test "absent base_hash keeps the merge behavior (legacy clients)", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "cas3.md", "content" => "one", "mtime" => 1.0})
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "cas3.md",
+          "content" => "one\ntwo",
+          "mtime" => 2.0
+        })
+
+      assert {:ok, _} =
+               Notes.upsert_note(user, vault, %{
+                 "path" => "cas3.md",
+                 "content" => "one\nthree",
+                 "mtime" => 3.0
+               })
+    end
+
     test "creates a new note", %{user: user, vault: vault} do
       assert {:ok, note} =
                Notes.upsert_note(user, vault, %{


### PR DESCRIPTION
Phase 0 of the identity-as-CRDT decision (engram-workspace#118): the stored Y-doc state becomes the authority no write path may regress. Root-causes the 2026-07-07 prod incident where MCP work-log appends were erased on plugin reconnect.

## The three holes (all TDD'd RED first)

1. **Checkpoint could regress the row.** The version fence (#907) only catches writes landing AFTER capture; a room whose doc missed a `deliver_out` (decrypt blip, KMS outage) is behind writes committed BEFORE capture — its checkpoint overwrote `notes.content` AND `crdt_state`, destroying the REST/MCP write entirely (the unbind path wasn't even fenced). **Fix: the checkpoint is monotone** — it folds the row's stored state into the doc state (Yjs union, same lineage as `deliver_out`, idempotent) before materializing. Output state ⊇ row state ⊇ live doc state; deletions still win (causally newer ops). Unreadable stored state aborts the write (unreadable ≠ absent).
2. **A poisoned room survived deliver failure.** When `deliver_out` couldn't converge a live room, the room lived on as a stale cache: every client the announce triggered to re-pull got the stale doc, and the room's next checkpoint reverted the row. **Fix: quarantine** — unregister the global name and kill the room brutally (`:kill` skips terminate→unbind→checkpoint, which must not run for a doc we couldn't converge). Nothing is lost: all room updates are already in the durable tail-log; the next join re-binds fresh from the row.
3. **The documented 409 guard didn't exist.** The OpenAPI text advertised an mtime conflict gate; the code had none — any stale full-content push was diffed against the stored snapshot and "convergently" deleted newer content. **Fix: `base_hash` CAS** — a writer declaring the `content_hash` it read gets 409 `version_conflict` (greppable `note_stale_base_rejected`) when the row moved. MCP `append_to_note` routes through `rmw_upsert` (read-CAS-retry-once, race-interleaved unit test); `patch_note`/`update_section` declare their base and surface the conflict. Absent `base_hash` keeps merge behavior for existing clients.

## Deliberate semantic flips

- `getYText`-era invariant "deliver failure leaves the room untouched" → room is killed (the old invariant was the poison-cache).
- Checkpoint "always persists on room exit" → aborts when the stored state is unreadable.

## Testing

3504 backend tests green (2 consecutive full runs; one unidentified failure in an earlier run did not reproduce — its detail was lost to output truncation, flagged honestly). format + credo --strict (0 issues) + sobelow clean. v0.5.642.

## Follow-ups (not this PR)

- Plugin sends `base_hash` from its last-synced state (closes the reconnect-clobber class end-to-end) — plugin PR next.
- Phase 1: `notes.content` written only by checkpoint; feed sequencing from doc updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)