### PR TITLE
fix(crdt): reply note_not_found on dropped crdt_msg

### DIFF
--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -129,9 +129,19 @@ defmodule EngramWeb.CrdtChannel do
         log_dropped(socket, doc_id, :frame_too_large)
         {:reply, {:error, %{reason: "frame_too_large"}}, socket}
 
+      {:error, :not_found} = err ->
+        # Unknown note_id: the frame is undeliverable, and the SENDER is the
+        # one who must act — this is the create-race cross-wire signature
+        # (client keyed to an id the server never adopted, 2026-07-07). Reply
+        # so the plugin can trigger its live id-map reconcile immediately
+        # (ensureNoteIdMapped, plugin v1.11.22) instead of talking into the
+        # void until a cold-start reconcile (#955).
+        log_dropped(socket, doc_id, err)
+        {:reply, {:error, %{reason: "note_not_found", doc_id: doc_id}}, socket}
+
       err ->
         # Surface drops rather than swallowing them silently — a dropped frame
-        # (bad base64 or unresolvable doc_id) means a lost edit.
+        # (bad base64) means a lost edit.
         log_dropped(socket, doc_id, err)
         {:noreply, socket}
     end

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -141,7 +141,10 @@ defmodule EngramWeb.CrdtChannel do
 
       err ->
         # Surface drops rather than swallowing them silently — a dropped frame
-        # (bad base64) means a lost edit.
+        # (bad base64, non-UUID doc_id from a stale path-keyed client, or
+        # room_unavailable) means a lost edit. These stay reply-less: a
+        # non-UUID doc_id may be a cleartext path (never echo it back), and
+        # the sender has no actionable heal for the others.
         log_dropped(socket, doc_id, err)
         {:noreply, socket}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.642",
+      version: "0.5.643",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -200,6 +200,21 @@ defmodule EngramWeb.CrdtChannelTest do
              "Expected 'dropped crdt_msg' warning in log, got: #{inspect(log)}"
     end
 
+    test "crdt_msg for an unknown note_id REPLIES note_not_found so the client can heal (#955)",
+         %{socket: socket} do
+      # The silent drop left the sending client talking into the void — the
+      # 2026-07-07 create-race cross-wire stayed invisible client-side until a
+      # cold-start reconcile. The error reply lets the plugin trigger its live
+      # id-map reconcile (ensureNoteIdMapped, v1.11.22) immediately.
+      random_note_id = Ecto.UUID.generate()
+      tiny_b64 = Base.encode64(<<0>>)
+
+      capture_log(fn ->
+        ref = push(socket, "crdt_msg", %{"doc_id" => random_note_id, "b64" => tiny_b64})
+        assert_reply ref, :error, %{reason: "note_not_found", doc_id: ^random_note_id}, 500
+      end)
+    end
+
     test "malformed base64 is silently ignored — no crash",
          %{socket: socket, doc_id: doc_id} do
       push(socket, "crdt_msg", %{"doc_id" => doc_id, "b64" => "!!!not_valid_base64!!!"})


### PR DESCRIPTION
Handoff item A1 (identity-as-CRDT plan). The channel silently dropped `crdt_msg` frames for unknown note_ids — server-side Loki warn only, sender learned nothing. That silence is why the 2026-07-07 create-race cross-wire stayed invisible client-side until an Obsidian reload.

Now the channel replies `{error, %{reason: "note_not_found", doc_id}}` on exactly this drop class, so the plugin can fire its live id-map reconcile (`ensureNoteIdMapped`, shipped v1.11.22) the moment it happens. Bad-base64 drops stay reply-less (nothing actionable for the sender).

TDD: RED test asserting the reply, existing silent-drop + unredacted-note-id log tests unchanged. Channel suite 24/24; full suite 3505/0. Plugin-side handler is a follow-up PR (plugin repo).

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)