### PR TITLE
fix(crdt): rooms must not outlive their vault + review hardenings

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -635,6 +635,22 @@ defmodule Engram.Notes do
 
     Enum.each(ids, &Engram.Notes.CrdtRegistry.terminate_room/1)
     :ok
+  rescue
+    # Runs in delete_vault's post-commit tap: a raise here would surface as a
+    # failure of an already-COMMITTED delete and skip the GateCache eviction
+    # that follows. Cleanup never fails the write; orphaned rooms are killed
+    # by deliver-time quarantine anyway.
+    e ->
+      Logger.warning(
+        "crdt vault room teardown failed",
+        Metadata.with_category(:warning, :sync,
+          user_id: user_id,
+          vault_id: vault_id,
+          error: Exception.message(e)
+        )
+      )
+
+      :ok
   end
 
   # Id-keyed rename support (Phase I): the plugin renames a note by keeping

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -618,6 +618,25 @@ defmodule Engram.Notes do
     end
   end
 
+  @doc """
+  Kill every live CRDT room belonging to `vault_id`'s notes (#954). A room
+  must not outlive its vault: orphaned rooms kept ticking checkpoints against
+  rows being purged (the 2026-07-07 error storms). Brutal-kill via
+  CrdtRegistry.terminate_room — no unbind checkpoint runs, and nothing is
+  lost (tail-log holds every update; the vault is deleted anyway). Runs its
+  own tenant scope; lookups for room-less notes are cheap (:global whereis).
+  """
+  @spec kill_live_rooms_for_vault(String.t(), String.t()) :: :ok
+  def kill_live_rooms_for_vault(user_id, vault_id) do
+    {:ok, ids} =
+      Repo.with_tenant(user_id, fn ->
+        Repo.all(from(n in Note, where: n.vault_id == ^vault_id, select: n.id))
+      end)
+
+    Enum.each(ids, &Engram.Notes.CrdtRegistry.terminate_room/1)
+    :ok
+  end
+
   # Id-keyed rename support (Phase I): the plugin renames a note by keeping
   # the same client-minted id across `DELETE old` -> `POST new {id: same}`.
   # `delete_note/3` is a soft delete, so the tombstone row still holds PK=id

--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -43,8 +43,25 @@ defmodule Engram.Notes.CrdtCheckpoint do
   """
   @spec checkpoint(String.t(), String.t(), String.t(), Yex.Doc.t(), keyword()) :: :ok
   def checkpoint(user_id, vault_id, note_id, %Yex.Doc{} = doc, opts \\ []) do
-    user = Accounts.get_user!(user_id)
+    # Deleted user/note are EXPECTED lifecycle states here (vault force-purge
+    # deletes rows while rooms are still exiting) — skip quietly at :warning,
+    # never raise. Raising turned every room tick during a purge into a
+    # caught-but-logged error storm (Sentry + Loki, 2026-07-07 19:03, #954).
+    case Accounts.get_user(user_id) do
+      nil ->
+        Logger.warning(
+          "crdt checkpoint skipped — user deleted note_id=#{note_id}",
+          Metadata.with_category(:warning, :sync, note_id: note_id)
+        )
 
+        :ok
+
+      user ->
+        do_checkpoint(user, user_id, vault_id, note_id, doc, opts)
+    end
+  end
+
+  defp do_checkpoint(user, user_id, vault_id, note_id, doc, opts) do
     # Capture the prune watermark BEFORE reading/encoding the doc. Any tail row
     # inserted while we encode is NOT necessarily in the snapshot, so it must
     # survive the prune (it replays on next bind — apply_update is idempotent).
@@ -90,27 +107,34 @@ defmodule Engram.Notes.CrdtCheckpoint do
             # Without this, extract_title falls back to the UUID and
             # inject_phase_b_fields_pub gets nil path/folder → corrupts
             # path_hmac/folder_hmac so the row stops resolving by path.
-            {:ok, note} = Crypto.maybe_decrypt_note_fields(Repo.get!(Note, note_id), user)
+            case Repo.get(Note, note_id) do
+              # Deleted note (vault force-purge race): quiet skip, see checkpoint/5.
+              nil ->
+                {:skip, :note_deleted}
 
-            with {:ok, union_doc} <- union_with_row_state(note, live_state, user),
-                 text = CrdtBridge.text_of(union_doc),
-                 {:ok, raw_state} <- encode(union_doc),
-                 {_flat_doc, state} <- maybe_flatten(union_doc, raw_state, note_id),
-                 {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(state, user, note_id),
-                 {:ok, key} <- Crypto.dek_content_hash_key(user) do
-              content_hash = Crypto.hmac_content_hash(key, text)
-              tags = Helpers.extract_tags(text)
+              raw_note ->
+                {:ok, note} = Crypto.maybe_decrypt_note_fields(raw_note, user)
 
-              checkpoint_write(note, vault_id, note_id, watermark, opts, %{
-                text: text,
-                tags: tags,
-                content_hash: content_hash,
-                ct: ct,
-                nonce: nonce,
-                user: user
-              })
-            else
-              err -> {:abort, err}
+                with {:ok, union_doc} <- union_with_row_state(note, live_state, user),
+                     text = CrdtBridge.text_of(union_doc),
+                     {:ok, raw_state} <- encode(union_doc),
+                     {_flat_doc, state} <- maybe_flatten(union_doc, raw_state, note_id),
+                     {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(state, user, note_id),
+                     {:ok, key} <- Crypto.dek_content_hash_key(user) do
+                  content_hash = Crypto.hmac_content_hash(key, text)
+                  tags = Helpers.extract_tags(text)
+
+                  checkpoint_write(note, vault_id, note_id, watermark, opts, %{
+                    text: text,
+                    tags: tags,
+                    content_hash: content_hash,
+                    ct: ct,
+                    nonce: nonce,
+                    user: user
+                  })
+                else
+                  err -> {:abort, err}
+                end
             end
           end)
 
@@ -133,6 +157,14 @@ defmodule Engram.Notes.CrdtCheckpoint do
                 # so idle compactions and aborted writes raise no spurious re-pull.
                 CrdtDeliver.announce_ready(user_id, vault_id, path, note_id)
               end
+
+            :ok
+
+          {:skip, reason} ->
+            Logger.warning(
+              "crdt checkpoint skipped — #{inspect(reason)} note_id=#{note_id}",
+              Metadata.with_category(:warning, :sync, note_id: note_id)
+            )
 
             :ok
 

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -104,21 +104,26 @@ defmodule Engram.Notes.CrdtDeliver do
         case load_merged_state(user_id, note_id) do
           {:ok, state} when is_binary(state) ->
             # The apply runs inside the room process (update_doc discards the
-            # fun's return), so failure is signalled back by message — safe
-            # ordering: update_doc is a synchronous call, the send happens
-            # before the reply.
+            # fun's return), so failure is signalled back by message. The
+            # message is tagged with a per-call ref: if update_doc TIMES OUT,
+            # the room may run the fun later and send the signal after our
+            # receive already returned — an untagged message would then linger
+            # in this (possibly long-lived channel) process's mailbox and be
+            # consumed by the NEXT deliver for the same note, false-quarantining
+            # a healthy room (#953 retro-review F4). A stale ref never matches.
             parent = self()
+            ref = make_ref()
 
             room_apply(room, note_id, fn doc ->
               if apply_state(doc, state, note_id) == :apply_failed do
-                send(parent, {:crdt_deliver_apply_failed, note_id})
+                send(parent, {ref, :crdt_deliver_apply_failed})
               end
 
               :ok
             end)
 
             receive do
-              {:crdt_deliver_apply_failed, ^note_id} ->
+              {^ref, :crdt_deliver_apply_failed} ->
                 quarantine_room(room, note_id, :apply_update_failed)
             after
               0 -> :ok
@@ -157,15 +162,16 @@ defmodule Engram.Notes.CrdtDeliver do
   # not converge. Nothing is lost: every room update was already appended to
   # the durable tail-log by update_v1, and the next join re-binds a fresh room
   # hydrated from the row's merged state + tail replay.
-  defp quarantine_room(room, note_id, reason) do
+  defp quarantine_room(_room, note_id, reason) do
     Logger.error(
       "crdt deliver quarantined stale room — killed for rebind from row",
       Metadata.with_category(:error, :sync, note_id: note_id, reason: inspect(reason))
     )
 
-    _ = :global.unregister_name(CrdtRegistry.global_name(note_id))
-    Process.exit(room, :kill)
-    :ok
+    # terminate_room unregisters the INNER :global term before the kill —
+    # the previous inline version passed global_name/1's {:global, …} wrapper
+    # to unregister_name, a silent no-op (#953 retro-review F2).
+    CrdtRegistry.terminate_room(note_id)
   end
 
   # `:global.whereis_name` can hand back a room that is mid auto-exit, so the

--- a/lib/engram/notes/crdt_registry.ex
+++ b/lib/engram/notes/crdt_registry.ex
@@ -42,6 +42,30 @@ defmodule Engram.Notes.CrdtRegistry do
   end
 
   @doc """
+  Terminate a note's live room WITHOUT running its unbind checkpoint:
+  unregister the :global name first (so lookups stop resolving to the dying
+  pid — NOTE: :global registration uses the INNER term `{:crdt_doc, id}`, not
+  the `{:global, …}` wrapper `global_name/1` returns for GenServer `name:`),
+  then a brutal `:kill` (untrappable, skips terminate → unbind → checkpoint).
+  Safe on dead/absent rooms (both steps are idempotent no-ops). Used by the
+  deliver-out quarantine (a room that failed to converge must not persist)
+  and vault deletion (a room must not outlive its vault, #954). Nothing is
+  lost: every room update is already in the durable tail-log.
+  """
+  @spec terminate_room(String.t()) :: :ok
+  def terminate_room(note_id) when is_binary(note_id) do
+    case :global.whereis_name({:crdt_doc, note_id}) do
+      :undefined ->
+        :ok
+
+      pid when is_pid(pid) ->
+        _ = :global.unregister_name({:crdt_doc, note_id})
+        Process.exit(pid, :kill)
+        :ok
+    end
+  end
+
+  @doc """
   Idempotently start (or find) the singleton room for `note_id`.
 
   Returns `{:ok, pid}` whether the room was just started or was already

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -506,10 +506,17 @@ defmodule Engram.Vaults do
     end)
     |> unwrap_transaction()
     |> tap(fn
-      # Deleting the last vault can flip the onboarding gate back to
-      # failing — drop the cached pass verdict so it re-derives.
-      {:ok, _} -> Engram.Onboarding.GateCache.evict(user.id)
-      _ -> :ok
+      {:ok, deleted} ->
+        # Rooms must not outlive the vault (#954): orphaned rooms kept ticking
+        # checkpoints against rows being purged (2026-07-07 error storms).
+        # Post-commit on purpose — a rolled-back delete must not kill rooms.
+        _ = Engram.Notes.kill_live_rooms_for_vault(deleted.user_id, deleted.id)
+        # Deleting the last vault can flip the onboarding gate back to
+        # failing — drop the cached pass verdict so it re-derives.
+        Engram.Onboarding.GateCache.evict(user.id)
+
+      _ ->
+        :ok
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.644",
+      version: "0.5.645",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.642",
+      version: "0.5.644",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -615,6 +615,54 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     assert fresh.type_hmac == Crypto.hmac_field(filter_key, "reference")
   end
 
+  # ── #954: deleted note/user must be a QUIET skip, not a raise-noise storm ──
+  # Vault deletion (force-purge) hard-deletes rows while rooms live on; each
+  # room tick/exit then raised Ecto.NoResultsError — caught, but logged at
+  # error (Sentry + Loki storms, 2026-07-07 19:03). A missing row is an
+  # EXPECTED lifecycle state, not an error.
+
+  test "checkpoint on a DELETED note skips quietly — no raise, no error log", ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, raw_state} = Crypto.decrypt_crdt_state(raw_note, user)
+    {:ok, doc} = CrdtBridge.doc_from_state(raw_state)
+
+    # Hard-delete the row out from under the live room (the force-purge shape).
+    Repo.with_tenant(user.id, fn ->
+      Repo.delete_all(from(l in CrdtUpdateLog, where: l.note_id == ^note.id))
+      Repo.delete_all(from(n in Note, where: n.id == ^note.id))
+    end)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+      end)
+
+    refute log =~ "checkpoint raised", "deleted note must not raise: #{log}"
+    refute log =~ "[error]", "deleted note is expected lifecycle, not an error: #{log}"
+  end
+
+  test "checkpoint on a DELETED user skips quietly — no raise, no error log", ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, raw_state} = Crypto.decrypt_crdt_state(raw_note, user)
+    {:ok, doc} = CrdtBridge.doc_from_state(raw_state)
+
+    # A user id that never existed models the deleted-user shape without
+    # fighting FK cascades (matches the existing user-row-gone test).
+    gone_user_id = Ecto.UUID.generate()
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert :ok = CrdtCheckpoint.checkpoint(gone_user_id, vault.id, note.id, doc)
+      end)
+
+    refute log =~ "checkpoint raised", "deleted user must not raise: #{log}"
+    refute log =~ "[error]", "deleted user is expected lifecycle, not an error: #{log}"
+  end
+
   test "checkpoint nulls OKF fields when a live edit removes frontmatter", ctx do
     %{user: user, vault: vault} = ctx
 

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -225,6 +225,28 @@ defmodule Engram.Notes.CrdtDeliverTest do
       assert log =~ "crdt deliver state load failed"
     end
 
+    test "a STALE apply-failed message in the caller's mailbox does not quarantine a healthy room (#953-review F4)",
+         %{user: user, vault: vault} do
+      # A timed-out update_doc call can deliver its failure signal AFTER the
+      # receive returned, leaving it in this (long-lived, e.g. channel)
+      # process's mailbox. The signal is now ref-tagged per call, so a stale
+      # message from an earlier call can never match — the next deliver for
+      # the same note must NOT consume it and kill a healthy room.
+      Process.flag(:trap_exit, true)
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "h.md", "content" => "orig"})
+      room = start_bare_room(note.id, "")
+      ref = Process.monitor(room)
+
+      # Plant the legacy-shaped stray signal (what a timed-out earlier call
+      # would have left behind pre-fix).
+      send(self(), {:crdt_deliver_apply_failed, note.id})
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "h.md", note.id, "orig")
+
+      refute_receive {:DOWN, ^ref, :process, ^room, :killed}, 300
+      assert CrdtRegistry.lookup(note.id) == room
+    end
+
     test "apply_update failure QUARANTINES the room (killed) — no stale cache survives",
          %{user: user, vault: vault} do
       Process.flag(:trap_exit, true)

--- a/test/engram/notes/crdt_registry_test.exs
+++ b/test/engram/notes/crdt_registry_test.exs
@@ -102,4 +102,25 @@ defmodule Engram.Notes.CrdtRegistryTest do
     assert :ok = Yex.Text.insert(text, 0, "café")
     assert Yex.Text.to_string(text) == "café"
   end
+
+  describe "terminate_room/1 (#954 + #953-review F2)" do
+    test "unregisters the INNER :global term synchronously, then kills" do
+      note_id = Ecto.UUID.generate()
+      pid = spawn(fn -> Process.sleep(:infinity) end)
+      :yes = :global.register_name({:crdt_doc, note_id}, pid)
+      ref = Process.monitor(pid)
+
+      assert :ok = CrdtRegistry.terminate_room(note_id)
+
+      # The name is gone IMMEDIATELY (before :global's async DOWN cleanup) —
+      # this is exactly what the old wrapped-name unregister failed to do.
+      assert :global.whereis_name({:crdt_doc, note_id}) == :undefined
+      assert CrdtRegistry.lookup(note_id) == nil
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 1000
+    end
+
+    test "is a no-op for a room that is not running" do
+      assert :ok = CrdtRegistry.terminate_room(Ecto.UUID.generate())
+    end
+  end
 end

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -553,6 +553,14 @@ defmodule Engram.VaultsTest do
       assert Engram.Notes.CrdtRegistry.lookup(note.id) == nil
     end
 
+    test "kill_live_rooms_for_vault never raises (post-commit cleanup)", %{user: user} do
+      # Runs inside delete_vault's post-commit tap: a raise there would 500 a
+      # COMMITTED delete and skip the GateCache eviction. Cleanup must not
+      # fail the write (same convention as CrdtDeliver). A non-UUID vault_id
+      # makes Repo.all raise Ecto.Query.CastError — stand-in for any DB error.
+      assert :ok = Engram.Notes.kill_live_rooms_for_vault(user.id, "not-a-uuid")
+    end
+
     test "soft-deletes vault by setting deleted_at", %{user: user} do
       {:ok, vault} = Vaults.create_vault(user, %{name: "Temp"})
       assert {:ok, deleted} = Vaults.delete_vault(user, vault.id)

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -519,6 +519,40 @@ defmodule Engram.VaultsTest do
   # ---------------------------------------------------------------------------
 
   describe "delete_vault/2" do
+    test "kills live CRDT rooms for the vault's notes (#954)", %{user: user} do
+      # Rooms outliving their vault caused the 2026-07-07 checkpoint storms:
+      # the orphaned room kept ticking against rows being deleted. Soft-delete
+      # is the choke point — clients get vault_deleted and disconnect anyway.
+      Process.flag(:trap_exit, true)
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      {:ok, vault} = Vaults.create_vault(user, %{name: "Rooms"})
+
+      {:ok, note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "r.md",
+          "content" => "x",
+          "mtime" => 1.0
+        })
+
+      {:ok, room} =
+        Yex.Sync.SharedDoc.start_link(
+          [
+            doc_name: note.id,
+            doc_option: %Yex.Doc.Options{offset_kind: :utf16},
+            auto_exit: false
+          ],
+          name: Engram.Notes.CrdtRegistry.global_name(note.id)
+        )
+
+      ref = Process.monitor(room)
+
+      assert {:ok, _} = Vaults.delete_vault(user, vault.id)
+
+      assert_receive {:DOWN, ^ref, :process, ^room, :killed}, 1000
+      assert Engram.Notes.CrdtRegistry.lookup(note.id) == nil
+    end
+
     test "soft-deletes vault by setting deleted_at", %{user: user} do
       {:ok, vault} = Vaults.create_vault(user, %{name: "Temp"})
       assert {:ok, deleted} = Vaults.delete_vault(user, vault.id)


### PR DESCRIPTION
Handoff item A2 (closes #954) bundled with the two mechanical fixes from the #953 retro-review (same initiative: room lifecycle correctness).

1. **Vault deletion tears down rooms** — post-commit (a rolled-back delete must not kill rooms), via new `CrdtRegistry.terminate_room/1`. Orphaned rooms ticking against purged rows caused the 2026-07-07 checkpoint error storms.
2. **Checkpoint: deleted user/note = quiet skip** — `get_user`/`Repo.get` with :warning-level skips replace the caught-raise error storms (Sentry/Loki noise class).
3. **Review F2**: the deliver quarantine's `:global.unregister_name` received the `{:global, …}`-wrapped name — silently a no-op, defeating the lookup-race hardening. `terminate_room` unregisters the INNER `{:crdt_doc, id}` term; test pins that the name is gone synchronously, before :global's async DOWN cleanup.
4. **Review F4**: the apply-failure signal is ref-tagged per deliver call — a stale signal left by a timed-out `update_doc` can no longer be consumed by a later deliver and false-quarantine a healthy room (regression test plants the legacy-shaped stray message).

Remaining #953-review findings filed as design issues: #958 (flatten-lineage union doubling), #959 (tail-log leak on permanently-unreadable state).

TDD throughout (5 new tests, RED first where the behavior existed to flip). Full suite 3510/0, credo --strict clean. v0.5.644 (skips 643 held by open #957).

🤖 Generated with [Claude Code](https://claude.com/claude-code)