### PR TITLE
test(e2e): force-connect precondition for test_84/85

### DIFF
--- a/e2e/tests/test_84_create_race.py
+++ b/e2e/tests/test_84_create_race.py
@@ -39,8 +39,14 @@ async def test_create_race_adopts_winner_and_receives(vault_a, vault_b, cdp_a, c
     unique = uuid.uuid4().hex[:12]
     path = f"E2E/CreateRace-{unique}/Raced.md"
 
-    await cdp_a.wait_for_stream_connected(timeout=20)
-    await cdp_b.wait_for_stream_connected(timeout=20)
+    # These tests run LAST (highest numbers) and inherit the whole suite's
+    # socket churn — the stream can sit mid-backoff at test start (CI run
+    # 28936382212: "Stream not connected after 20s"). Force a known-good
+    # connection instead of waiting out the backoff timer.
+    for cdp in (cdp_a, cdp_b):
+        if not await cdp.check_stream_connected():
+            await cdp.reconnect_stream()
+        await cdp.wait_for_stream_connected(timeout=20)
 
     # The race: an API writer (the MCP/web stand-in) and plugin A create the
     # same path concurrently. push_file_now drives the real pushFile path —

--- a/e2e/tests/test_85_missed_delivery_no_deletion.py
+++ b/e2e/tests/test_85_missed_delivery_no_deletion.py
@@ -48,8 +48,14 @@ async def test_missed_delivery_then_local_push_no_deletion(
     server_marker = f"server-edit-{unique}"
     local_marker = f"local-edit-{unique}"
 
-    await cdp_a.wait_for_stream_connected(timeout=20)
-    await cdp_b.wait_for_stream_connected(timeout=20)
+    # These tests run LAST (highest numbers) and inherit the whole suite's
+    # socket churn — the stream can sit mid-backoff at test start (CI run
+    # 28936382212: "Stream not connected after 20s"). Force a known-good
+    # connection instead of waiting out the backoff timer.
+    for cdp in (cdp_a, cdp_b):
+        if not await cdp.check_stream_connected():
+            await cdp.reconnect_stream()
+        await cdp.wait_for_stream_connected(timeout=20)
 
     # Seed: A creates, B receives — both devices synced on a base version.
     base = f"# Missed Delivery\n\nbase-{unique}\n"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.646",
+      version: "0.5.647",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Follow-up to #962. test_84's first CI outing (run 28936382212) failed its `wait_for_stream_connected(timeout=20)` precondition — these tests run last (highest numbers) and inherit the whole suite's socket churn, so the stream can sit mid-backoff at test start. Force a known-good connection (reconnect if down, then wait) instead of waiting out the backoff timer; same primitive test_23/test_48 use.

Test-only; the assertion surfaces are unchanged. Both tests green locally against the CRDT stack. v0.5.647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)