### PR TITLE
fix(logs): cap client-reemit severity for alert-noise root causes

### DIFF
--- a/lib/engram/logs.ex
+++ b/lib/engram/logs.ex
@@ -88,12 +88,19 @@ defmodule Engram.Logs do
   # and Loki (warn+ always; info only when the client marks it diagnostic).
   # This makes both sides of a WS connection greppable by conn_id in ONE Loki
   # query, without the read-only DB bastion.
+  #
+  # Re-emit severity is capped at :warning (see normalize_level/1 below): a
+  # client-side "error" is a bug in ONE user's plugin, not a backend failure,
+  # and must never inflate engram-prod-loki-error-rate (severity="error").
+  # The original client severity survives in `client_severity` metadata so
+  # it's still queryable/greppable in Loki.
   defp reemit_to_logger(user, entries) do
     hashed_user = HMAC.hash_user_id(to_string(user.id))
 
     Enum.each(entries, fn entry ->
       try do
-        level = normalize_level(entry["level"] || entry[:level])
+        raw_level = entry["level"] || entry[:level]
+        level = normalize_level(raw_level)
         client_cat = entry["category"] || entry[:category] || ""
         msg = "[client:#{client_cat}] #{entry["message"] || entry[:message] || ""}"
 
@@ -101,7 +108,8 @@ defmodule Engram.Logs do
           Metadata.with_category(level, :client,
             conn_id: entry["conn_id"] || entry[:conn_id],
             device_id: entry["device_id"] || entry[:device_id],
-            user_id: hashed_user
+            user_id: hashed_user,
+            client_severity: raw_level || "info"
           )
 
         # Verbose diagnostic-mode entries opt into Loki per-entry even at :info.
@@ -123,7 +131,9 @@ defmodule Engram.Logs do
     end)
   end
 
+  # Client severity is capped at :warning on re-emit — never :error — so a
+  # broken plugin loop cannot masquerade as a backend error.
   defp normalize_level("warn"), do: :warning
-  defp normalize_level("error"), do: :error
+  defp normalize_level("error"), do: :warning
   defp normalize_level(_), do: :info
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.647",
+      version: "0.5.648",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/logs_reemit_test.exs
+++ b/test/engram/logs_reemit_test.exs
@@ -50,15 +50,42 @@ defmodule Engram.LogsReemitTest do
         }
       ])
 
-    assert_receive {^ref, meta}, 1000
+    assert_receive {^ref, _level, meta}, 1000
     assert meta[:loki_ship] == true
     assert meta[:category] == :client
   end
 
+  test "client-originated 'error' severity is capped at :warning so it never inflates the backend error-rate alert, but the original severity survives in metadata" do
+    user = insert(:user)
+    parent = self()
+    ref = make_ref()
+    handler_id = :logs_reemit_severity_test_handler
+
+    :logger.add_handler(handler_id, __MODULE__, %{config: %{parent: parent, ref: ref}})
+    on_exit(fn -> :logger.remove_handler(handler_id) end)
+
+    {:ok, 1} =
+      Logs.insert_logs(user, [
+        %{
+          "ts" => DateTime.utc_now() |> DateTime.to_iso8601(),
+          "level" => "error",
+          "category" => "channel",
+          "message" => "rate_limited",
+          "conn_id" => "c2",
+          "device_id" => "d1"
+        }
+      ])
+
+    assert_receive {^ref, level, meta}, 1000
+    assert level == :warning
+    assert meta[:category] == :client
+    assert meta[:client_severity] == "error"
+  end
+
   # :logger handler callback
-  def log(%{meta: meta}, %{config: %{parent: parent, ref: ref}}) do
-    if meta[:category] == :client and meta[:conn_id] == "c1" do
-      send(parent, {ref, meta})
+  def log(%{level: level, meta: meta}, %{config: %{parent: parent, ref: ref}}) do
+    if meta[:category] == :client and meta[:conn_id] in ["c1", "c2"] do
+      send(parent, {ref, level, meta})
     end
 
     :ok


### PR DESCRIPTION
## Summary
Two backend root-cause fixes from the 2026-07-07/08 alert-noise investigation (`engram-prod-loki-error-rate`):

- **Fix 1 (this PR)** — `Engram.Logs.reemit_to_logger/2` (`lib/engram/logs.ex`) re-emitted client plugin log lines at backend severity `:error`, so one user's broken plugin (e.g. a CRDT channel-join retry loop) could single-handedly trip the >20-error/5m alert and page on-call. Client severity is now capped at `:warning` on re-emit — `metadata_category="client"` was already stamped, but the alert filters on severity so the log level itself had to change. Original severity is preserved in a new `client_severity` metadata field for Loki queryability.
- **Fix 2 (checkpoint NoResultsError storm)** — investigated and found **already fixed on main** by commit `6e081bce` (PR #960/#954, merged the morning of Jul 8, before this branch's fork point). `lib/engram/notes/crdt_checkpoint.ex` already does nil-safe `Repo.get`/`Accounts.get_user` with quiet `:warning` skip-and-no-op for deleted notes/users, with regression tests (`test/engram/notes/crdt_checkpoint_test.exs`, the `#954` block). No code change needed; verified the 22 existing tests there still pass.

## Test plan
- [x] New test: client `"error"` re-emits at `:warning` with `client_severity: "error"` preserved (`test/engram/logs_reemit_test.exs`)
- [x] `mix test` — 3524 tests, 0 failures
- [x] `mix format --check-formatted`, `mix credo --strict`, `mix sobelow --exit low` — all clean
- [x] Confirmed `crdt_checkpoint_test.exs` (22 tests incl. #954 deleted-note/deleted-user cases) already green on main

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>