### PR TITLE
feat(cluster): cluster-clean deploys — /health/deep join gate + drain-side disconnect after socket drain

### DIFF
--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -230,12 +230,26 @@ defmodule Engram.Application do
 
   @impl true
   def prep_stop(state) do
-    # Only drain the cluster when actually clustered (SaaS prod).
+    # Only drain when actually clustered (SaaS prod). Peer disconnect happens
+    # in stop/1 — AFTER the endpoint's socket/HTTP drain — so WS clients on
+    # the dying node keep cross-node fan-out until they've reconnected away.
     if Application.get_env(:engram, :dns_cluster_query) do
       Engram.Drainer.drain()
     end
 
     state
+  end
+
+  @impl true
+  def stop(_state) do
+    # Runs after the supervision tree (endpoint included) has stopped: safe
+    # to leave the cluster now, and survivors observe a clean nodedown
+    # before the VM exits.
+    if Application.get_env(:engram, :dns_cluster_query) do
+      Engram.Drainer.disconnect_peers()
+    end
+
+    :ok
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/engram/cluster/readiness.ex
+++ b/lib/engram/cluster/readiness.ex
@@ -1,0 +1,97 @@
+defmodule Engram.Cluster.Readiness do
+  @moduledoc """
+  Cluster-join readiness for the ALB readiness probe (`/api/health/deep`).
+
+  During a rolling deploy a freshly-booted task must not take traffic while
+  its `Phoenix.PubSub` is still per-node — WS clients routed to it would
+  silently miss cross-node `note_changed` fan-out until DNSCluster connects
+  peers. This module answers "is this node safe to serve?":
+
+    * `:ready` — at least one BEAM peer is connected.
+    * `{:ready, :alone}` — no peers, but Cloud Map discovery shows no OTHER
+      node either (first-ever task, scale-to-1, disaster recovery — or a
+      discovery outage, which deliberately fails open: an unreachable
+      resolver must not block boot).
+    * `:waiting` — other nodes are discoverable but none is connected yet
+      (the deploy boot window). The probe returns 503 so ECS keeps the old
+      tasks serving until the new node has joined.
+    * `{:ready, :grace_expired}` — still unjoined after the boot grace
+      (#{div(:timer.seconds(60), 1000)}s). Passes WITH a warning so a broken
+      clustering layer (Cloud Map outage, SG regression, cookie mismatch,
+      undistributed node) can never wedge a deploy — the untouched
+      `engram-prod-cluster-degraded` alert remains the authority for
+      sustained splits. Grace is measured from VM start, so this is strictly
+      a *boot-join* gate: a later real split never yanks tasks from the ALB
+      (that would turn "degraded fan-out" into an outage).
+    * `:not_clustered` — no `DNS_CLUSTER_QUERY` (self-host, dev, test);
+      callers skip the check entirely.
+
+  Timing envelope: worst-case gate hold is the 60s grace, well inside ECS
+  `health_check_grace_period_seconds` (120s) and the CI ECS-health budget
+  (300s, ~160-200s baseline).
+  """
+
+  @default_grace_ms :timer.seconds(60)
+
+  @type status ::
+          :not_clustered | :ready | {:ready, :alone} | {:ready, :grace_expired} | :waiting
+
+  @doc """
+  Evaluate readiness against the live node. All collaborators are injectable
+  via `opts` for tests (same pattern as `Engram.Drainer`): `:query`, `:peers`,
+  `:resolver`, `:self_ip`, `:uptime_ms`, `:grace_ms`.
+  """
+  @spec check(keyword()) :: status()
+  def check(opts \\ []) do
+    query = Keyword.get(opts, :query, Application.get_env(:engram, :dns_cluster_query))
+
+    if is_binary(query) do
+      peers = Keyword.get(opts, :peers, &Node.list/0)
+      resolver = Keyword.get(opts, :resolver, &resolve_a/1)
+      self_ip = Keyword.get_lazy(opts, :self_ip, &self_ip/0)
+
+      decide(%{
+        peers: peers.(),
+        other_ips: resolver.(query) -- List.wrap(self_ip),
+        uptime_ms:
+          Keyword.get_lazy(opts, :uptime_ms, fn -> elem(:erlang.statistics(:wall_clock), 0) end),
+        grace_ms: Keyword.get(opts, :grace_ms, @default_grace_ms)
+      })
+    else
+      :not_clustered
+    end
+  end
+
+  @doc "Pure gate decision — see the moduledoc for the state semantics."
+  @spec decide(%{
+          peers: [node()],
+          other_ips: [String.t()],
+          uptime_ms: non_neg_integer(),
+          grace_ms: pos_integer()
+        }) :: status()
+  def decide(%{peers: [_ | _]}), do: :ready
+  def decide(%{other_ips: []}), do: {:ready, :alone}
+  def decide(%{uptime_ms: up, grace_ms: grace}) when up >= grace, do: {:ready, :grace_expired}
+  def decide(_state), do: :waiting
+
+  # Cloud Map serves A records only (awsvpc ENI IPv4s; RELEASE_NODE is
+  # engram@<ipv4>), so AAAA is intentionally not queried. :inet_res.lookup/3
+  # returns [] on any resolution error → fails open to :alone above.
+  defp resolve_a(query) do
+    query
+    |> String.to_charlist()
+    |> :inet_res.lookup(:in, :a)
+    |> Enum.map(&to_string(:inet.ntoa(&1)))
+  end
+
+  # "engram@10.30.1.50" → "10.30.1.50". An undistributed node
+  # (:nonode@nohost — the env.sh RELEASE_NODE gate failed) yields "nohost",
+  # which never matches a resolved IP, so all discovered nodes count as
+  # others and the node correctly rides :waiting → :grace_expired.
+  defp self_ip do
+    case node() |> to_string() |> String.split("@") do
+      [_name, host] -> host
+      _ -> nil
+    end
+  end
+end

--- a/lib/engram/cluster/readiness.ex
+++ b/lib/engram/cluster/readiness.ex
@@ -33,8 +33,8 @@ defmodule Engram.Cluster.Readiness do
 
   @default_grace_ms :timer.seconds(60)
 
-  @type status ::
-          :not_clustered | :ready | {:ready, :alone} | {:ready, :grace_expired} | :waiting
+  @type decision :: :ready | {:ready, :alone} | {:ready, :grace_expired} | :waiting
+  @type status :: :not_clustered | decision
 
   @doc """
   Evaluate readiness against the live node. All collaborators are injectable
@@ -78,7 +78,7 @@ defmodule Engram.Cluster.Readiness do
           other_ips: [String.t()],
           uptime_ms: non_neg_integer(),
           grace_ms: pos_integer()
-        }) :: status()
+        }) :: decision()
   def decide(%{peers: [_ | _]}), do: :ready
   def decide(%{other_ips: []}), do: {:ready, :alone}
   def decide(%{uptime_ms: up, grace_ms: grace}) when up >= grace, do: {:ready, :grace_expired}

--- a/lib/engram/cluster/readiness.ex
+++ b/lib/engram/cluster/readiness.ex
@@ -46,13 +46,23 @@ defmodule Engram.Cluster.Readiness do
     query = Keyword.get(opts, :query, Application.get_env(:engram, :dns_cluster_query))
 
     if is_binary(query) do
-      peers = Keyword.get(opts, :peers, &Node.list/0)
-      resolver = Keyword.get(opts, :resolver, &resolve_a/1)
-      self_ip = Keyword.get_lazy(opts, :self_ip, &self_ip/0)
+      peers = Keyword.get(opts, :peers, &Node.list/0).()
+
+      # Steady state (already joined) must never touch DNS: this runs on
+      # every /api/health/deep probe, and a hung VPC resolver must not cost
+      # the hot path anything once peers are connected.
+      other_ips =
+        if peers == [] do
+          resolver = Keyword.get(opts, :resolver, &resolve_a/1)
+          self_ip = Keyword.get_lazy(opts, :self_ip, &self_ip/0)
+          resolver.(query) -- List.wrap(self_ip)
+        else
+          []
+        end
 
       decide(%{
-        peers: peers.(),
-        other_ips: resolver.(query) -- List.wrap(self_ip),
+        peers: peers,
+        other_ips: other_ips,
         uptime_ms:
           Keyword.get_lazy(opts, :uptime_ms, fn -> elem(:erlang.statistics(:wall_clock), 0) end),
         grace_ms: Keyword.get(opts, :grace_ms, @default_grace_ms)
@@ -75,12 +85,22 @@ defmodule Engram.Cluster.Readiness do
   def decide(_state), do: :waiting
 
   # Cloud Map serves A records only (awsvpc ENI IPv4s; RELEASE_NODE is
-  # engram@<ipv4>), so AAAA is intentionally not queried. :inet_res.lookup/3
+  # engram@<ipv4>), so AAAA is intentionally not queried. :inet_res.lookup/4
   # returns [] on any resolution error → fails open to :alone above.
-  defp resolve_a(query) do
+  #
+  # Bounded to well under the ALB's 5s health-check timeout: the default
+  # retry/timeout (~6s+ worst case) means a hanging VPC resolver would pull
+  # every task from rotation instead of failing open. `opts` lets tests
+  # point at an unresponsive nameserver to prove the bound holds.
+  @doc false
+  @resolve_timeout_ms 1_500
+  @resolve_retry 1
+  def resolve_a(query, opts \\ []) do
+    resolve_opts = Keyword.merge([timeout: @resolve_timeout_ms, retry: @resolve_retry], opts)
+
     query
-    |> String.to_charlist()
-    |> :inet_res.lookup(:in, :a)
+    |> to_charlist()
+    |> :inet_res.lookup(:in, :a, resolve_opts)
     |> Enum.map(&to_string(:inet.ntoa(&1)))
   end
 

--- a/lib/engram/drainer.ex
+++ b/lib/engram/drainer.ex
@@ -1,13 +1,23 @@
 defmodule Engram.Drainer do
   @moduledoc """
-  Graceful drain run from `Engram.Application.prep_stop/1` on SIGTERM.
+  Graceful drain, split across the two OTP shutdown hooks:
 
-  Order matters: stop pulling NEW work (Oban), let the ALB stop routing new
-  requests (it already deregistered us), give in-flight work a short grace,
-  then disconnect from peers so survivors observe a clean `nodedown` instead
-  of a later `noproc`/`noconnection`. The Phoenix endpoint drains in-flight
-  HTTP/WebSocket connections separately during supervisor teardown (Thousand
-  Island shutdown_timeout + socket_drano).
+    * `drain/1` — from `Engram.Application.prep_stop/1` on SIGTERM, BEFORE the
+      supervision tree stops: stop pulling NEW work (Oban, local-only) and
+      give in-flight work a short grace.
+    * `disconnect_peers/1` — from `Engram.Application.stop/1`, AFTER the
+      supervision tree (endpoint + socket drain included) has stopped:
+      disconnect cluster peers so survivors observe a clean `nodedown`
+      instead of a later `noproc`/`noconnection`.
+
+  Peer disconnect deliberately happens LAST. Disconnecting during prep_stop
+  (as originally shipped in #742) severed PubSub while the endpoint was still
+  draining WS clients for up to ~25s — clients on the dying node silently
+  missed cross-node note_changed fan-out for that window, and the node kept
+  emitting cluster_peers=0 samples that lingered via metric staleness (the
+  post-deploy cluster-degraded blips). The Phoenix endpoint drains in-flight
+  HTTP/WebSocket connections during supervisor teardown (Thousand Island
+  shutdown_timeout + the UserSocket drainer), all with the cluster intact.
   """
 
   alias Engram.Logger.Metadata
@@ -19,8 +29,6 @@ defmodule Engram.Drainer do
   @spec drain(keyword()) :: :ok
   def drain(opts \\ []) do
     pause_oban = Keyword.get(opts, :pause_oban, &default_pause_oban/0)
-    peers = Keyword.get(opts, :peers, &Node.list/0)
-    disconnect = Keyword.get(opts, :disconnect, &Node.disconnect/1)
     grace_ms = Keyword.get(opts, :grace_ms, @default_grace_ms)
 
     Logger.info(
@@ -30,6 +38,14 @@ defmodule Engram.Drainer do
 
     pause_oban.()
     if grace_ms > 0, do: Process.sleep(grace_ms)
+
+    :ok
+  end
+
+  @spec disconnect_peers(keyword()) :: :ok
+  def disconnect_peers(opts \\ []) do
+    peers = Keyword.get(opts, :peers, &Node.list/0)
+    disconnect = Keyword.get(opts, :disconnect, &Node.disconnect/1)
 
     Enum.each(peers.(), fn node ->
       Logger.info(

--- a/lib/engram_web/controllers/health_controller.ex
+++ b/lib/engram_web/controllers/health_controller.ex
@@ -4,6 +4,8 @@ defmodule EngramWeb.HealthController do
 
   alias EngramWeb.Schemas.HealthStatus
 
+  require Logger
+
   operation(:index,
     operation_id: "health",
     summary: "Liveness probe",
@@ -23,7 +25,7 @@ defmodule EngramWeb.HealthController do
     summary: "Readiness probe",
     security: [],
     description:
-      "Checks dependencies whose absence fails every request (Postgres). 503 when degraded.",
+      "Checks dependencies whose absence fails every request (Postgres), plus BEAM cluster join on clustered deploys. 503 when degraded.",
     responses: [
       ok: {"All critical deps ok", "application/json", HealthStatus},
       service_unavailable: {"Degraded", "application/json", HealthStatus}
@@ -35,9 +37,18 @@ defmodule EngramWeb.HealthController do
   # S3 etc. stay OUT so a single dep outage cannot pull all tasks
   # from rotation. Surface those via /api/health/diagnostics (auth-gated)
   # and per-dep CloudWatch/Grafana alarms.
+  #
+  # Clustered deploys (DNS_CLUSTER_QUERY set) additionally gate on
+  # cluster join, so a rolling deploy's new task doesn't take traffic
+  # while its PubSub is still per-node (WS clients on it would silently
+  # miss cross-node note_changed fan-out). Bounded by a boot grace so
+  # broken clustering can never wedge a deploy — Engram.Cluster.Readiness.
   def deep(conn, _params) do
-    checks = %{"postgres" => check_postgres()}
-    all_ok = Enum.all?(checks, fn {_k, v} -> v == "ok" end)
+    checks =
+      %{"postgres" => check_postgres()}
+      |> put_cluster_check(Engram.Cluster.Readiness.check(cluster_readiness_opts()))
+
+    all_ok = Enum.all?(checks, fn {_k, v} -> String.starts_with?(v, "ok") end)
     status = if all_ok, do: "ok", else: "degraded"
     http_status = if all_ok, do: 200, else: 503
 
@@ -45,6 +56,29 @@ defmodule EngramWeb.HealthController do
     |> put_status(http_status)
     |> json(%{status: status, checks: checks})
   end
+
+  # Test seam only — lets ExUnit inject peers/resolver/uptime without real
+  # distribution. Unset everywhere else (empty opts = live node defaults).
+  defp cluster_readiness_opts do
+    Application.get_env(:engram, :cluster_readiness_opts, [])
+  end
+
+  defp put_cluster_check(checks, :not_clustered), do: checks
+  defp put_cluster_check(checks, :ready), do: Map.put(checks, "cluster", "ok")
+  defp put_cluster_check(checks, {:ready, :alone}), do: Map.put(checks, "cluster", "ok: alone")
+
+  defp put_cluster_check(checks, {:ready, :grace_expired}) do
+    Logger.warning(
+      "cluster readiness: unjoined past boot grace — passing to avoid wedging the deploy; " <>
+        "check Cloud Map A-records, ecs_task SG (EPMD 4369 + dist ports), RELEASE_COOKIE",
+      Engram.Logger.Metadata.with_category(:warning, :lifecycle, [])
+    )
+
+    Map.put(checks, "cluster", "ok: unjoined_grace_expired")
+  end
+
+  defp put_cluster_check(checks, :waiting),
+    do: Map.put(checks, "cluster", "waiting: cluster_unjoined")
 
   # diagnostics/2 is admin-gated in the router and intentionally excluded
   # from the public OpenAPI spec.

--- a/lib/engram_web/controllers/health_controller.ex
+++ b/lib/engram_web/controllers/health_controller.ex
@@ -48,7 +48,7 @@ defmodule EngramWeb.HealthController do
       %{"postgres" => check_postgres()}
       |> put_cluster_check(Engram.Cluster.Readiness.check(cluster_readiness_opts()))
 
-    all_ok = Enum.all?(checks, fn {_k, v} -> String.starts_with?(v, "ok") end)
+    all_ok = Enum.all?(checks, fn {_k, v} -> ok_status?(v) end)
     status = if all_ok, do: "ok", else: "degraded"
     http_status = if all_ok, do: 200, else: 503
 
@@ -56,6 +56,13 @@ defmodule EngramWeb.HealthController do
     |> put_status(http_status)
     |> json(%{status: status, checks: checks})
   end
+
+  # Values this controller itself produces are always exactly "ok" or
+  # "ok: <detail>" — never a bare prefix match. Keeps a future check value
+  # that merely starts with "ok" (e.g. an error message) from false-passing.
+  defp ok_status?("ok"), do: true
+  defp ok_status?("ok: " <> _), do: true
+  defp ok_status?(_), do: false
 
   # Test seam only — lets ExUnit inject peers/resolver/uptime without real
   # distribution. Unset everywhere else (empty opts = live node defaults).
@@ -67,12 +74,26 @@ defmodule EngramWeb.HealthController do
   defp put_cluster_check(checks, :ready), do: Map.put(checks, "cluster", "ok")
   defp put_cluster_check(checks, {:ready, :alone}), do: Map.put(checks, "cluster", "ok: alone")
 
+  @grace_expired_logged_key {__MODULE__, :cluster_grace_expired_logged}
+
   defp put_cluster_check(checks, {:ready, :grace_expired}) do
-    Logger.warning(
+    message =
       "cluster readiness: unjoined past boot grace — passing to avoid wedging the deploy; " <>
-        "check Cloud Map A-records, ecs_task SG (EPMD 4369 + dist ports), RELEASE_COOKIE",
-      Engram.Logger.Metadata.with_category(:warning, :lifecycle, [])
-    )
+        "check Cloud Map A-records, ecs_task SG (EPMD 4369 + dist ports), RELEASE_COOKIE"
+
+    # First observation of a sustained split logs at warning (drives the
+    # alert); every probe after that (~8/min) would otherwise duplicate it,
+    # so subsequent probes log at debug instead. A VM restart clears this
+    # naturally (persistent_term is process-free but node-scoped).
+    level =
+      if :persistent_term.get(@grace_expired_logged_key, false) do
+        :debug
+      else
+        :persistent_term.put(@grace_expired_logged_key, true)
+        :warning
+      end
+
+    Logger.log(level, message, Engram.Logger.Metadata.with_category(level, :lifecycle, []))
 
     Map.put(checks, "cluster", "ok: unjoined_grace_expired")
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.647",
+      version: "0.5.648",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.648",
+      version: "0.5.649",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -4741,7 +4741,7 @@
     "/api/health/deep": {
       "get": {
         "callbacks": {},
-        "description": "Checks dependencies whose absence fails every request (Postgres). 503 when degraded.",
+        "description": "Checks dependencies whose absence fails every request (Postgres), plus BEAM cluster join on clustered deploys. 503 when degraded.",
         "operationId": "health-deep",
         "parameters": [],
         "responses": {

--- a/test/engram/cluster/readiness_test.exs
+++ b/test/engram/cluster/readiness_test.exs
@@ -1,0 +1,102 @@
+defmodule Engram.Cluster.ReadinessTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Cluster.Readiness
+
+  describe "decide/1 (pure gate decision)" do
+    test "ready when any peer is connected" do
+      assert :ready =
+               Readiness.decide(%{
+                 peers: [:"engram@10.0.0.2"],
+                 other_ips: ["10.0.0.2"],
+                 uptime_ms: 0,
+                 grace_ms: 60_000
+               })
+    end
+
+    test "legitimately alone when discovery shows no other node (first task, scale-to-1, DR)" do
+      assert {:ready, :alone} =
+               Readiness.decide(%{peers: [], other_ips: [], uptime_ms: 0, grace_ms: 60_000})
+    end
+
+    test "waiting when peers exist in DNS but none are connected and grace has not elapsed" do
+      assert :waiting =
+               Readiness.decide(%{
+                 peers: [],
+                 other_ips: ["10.0.0.9"],
+                 uptime_ms: 10_000,
+                 grace_ms: 60_000
+               })
+    end
+
+    test "passes with grace_expired once the boot grace elapses, so a broken discovery layer cannot wedge a deploy" do
+      assert {:ready, :grace_expired} =
+               Readiness.decide(%{
+                 peers: [],
+                 other_ips: ["10.0.0.9"],
+                 uptime_ms: 60_000,
+                 grace_ms: 60_000
+               })
+    end
+  end
+
+  describe "check/1" do
+    test "not_clustered when no DNS cluster query is configured (self-host, dev, test)" do
+      assert :not_clustered = Readiness.check(query: nil)
+    end
+
+    test "ready when clustered and peers are connected" do
+      assert :ready =
+               Readiness.check(
+                 query: "app.engram.internal",
+                 peers: fn -> [:"engram@10.0.0.2"] end,
+                 resolver: fn _ -> ["10.0.0.2", "10.0.0.3"] end
+               )
+    end
+
+    test "excludes own IP from discovered peers (a node that only sees itself is alone)" do
+      # node() is :nonode@nohost in tests; inject self_ip to simulate a
+      # distributed node whose Cloud Map record is the only one.
+      assert {:ready, :alone} =
+               Readiness.check(
+                 query: "app.engram.internal",
+                 peers: fn -> [] end,
+                 resolver: fn _ -> ["10.0.0.7"] end,
+                 self_ip: "10.0.0.7"
+               )
+    end
+
+    test "waiting while other nodes are discoverable but unjoined, within grace" do
+      assert :waiting =
+               Readiness.check(
+                 query: "app.engram.internal",
+                 peers: fn -> [] end,
+                 resolver: fn _ -> ["10.0.0.9"] end,
+                 self_ip: "10.0.0.7",
+                 uptime_ms: 1_000,
+                 grace_ms: 60_000
+               )
+    end
+
+    test "grace_expired for a node that never joined (incl. undistributed node — the Jul 3 class)" do
+      assert {:ready, :grace_expired} =
+               Readiness.check(
+                 query: "app.engram.internal",
+                 peers: fn -> [] end,
+                 resolver: fn _ -> ["10.0.0.9"] end,
+                 self_ip: "10.0.0.7",
+                 uptime_ms: 120_000,
+                 grace_ms: 60_000
+               )
+    end
+
+    test "fails open to alone when DNS resolution errors (empty lookup) — a Cloud Map outage cannot block boot" do
+      assert {:ready, :alone} =
+               Readiness.check(
+                 query: "app.engram.internal",
+                 peers: fn -> [] end,
+                 resolver: fn _ -> [] end
+               )
+    end
+  end
+end

--- a/test/engram/cluster/readiness_test.exs
+++ b/test/engram/cluster/readiness_test.exs
@@ -98,5 +98,33 @@ defmodule Engram.Cluster.ReadinessTest do
                  resolver: fn _ -> [] end
                )
     end
+
+    test "steady state (peer already joined) never calls the resolver — must stay out of the hot path" do
+      assert :ready =
+               Readiness.check(
+                 query: "app.engram.internal",
+                 peers: fn -> [:"engram@10.0.0.2"] end,
+                 resolver: fn _ ->
+                   raise "resolver must not be invoked when peers are already connected"
+                 end
+               )
+    end
+  end
+
+  describe "resolve_a/2 (real :inet_res call, bounded timeout)" do
+    test "fails open (returns []) within a bounded budget against an unresponsive resolver" do
+      # 192.0.2.0/24 is TEST-NET-1 (RFC 5737): reserved, guaranteed non-routable,
+      # so this never gets a real answer — it exercises the same
+      # unresponsive-resolver path a hung VPC/Cloud Map resolver would.
+      {elapsed_us, result} =
+        :timer.tc(fn ->
+          Readiness.resolve_a(~c"example.invalid", nameservers: [{{192, 0, 2, 1}, 53}])
+        end)
+
+      assert result == []
+      # Well under the 5s ALB health-check timeout (with headroom for CI jitter);
+      # the unbounded default (~6s+) would blow this.
+      assert elapsed_us < 4_000_000
+    end
   end
 end

--- a/test/engram/drainer_test.exs
+++ b/test/engram/drainer_test.exs
@@ -5,12 +5,11 @@ defmodule Engram.DrainerTest do
 
   setup :verify_on_exit!
 
-  test "drain/1 pauses oban, then disconnects each peer node, in order" do
+  test "drain/1 pauses oban and does NOT disconnect peers (fan-out must survive the socket drain)" do
     test_pid = self()
 
     opts = [
       pause_oban: fn -> send(test_pid, :oban_paused) end,
-      peers: fn -> [:"a@1.1.1.1", :"b@2.2.2.2"] end,
       disconnect: fn node -> send(test_pid, {:disconnected, node}) end,
       grace_ms: 0
     ]
@@ -18,19 +17,25 @@ defmodule Engram.DrainerTest do
     assert :ok = Engram.Drainer.drain(opts)
 
     assert_receive :oban_paused
+    refute_receive {:disconnected, _}
+  end
+
+  test "disconnect_peers/1 disconnects each peer node, in order" do
+    test_pid = self()
+
+    opts = [
+      peers: fn -> [:"a@1.1.1.1", :"b@2.2.2.2"] end,
+      disconnect: fn node -> send(test_pid, {:disconnected, node}) end
+    ]
+
+    assert :ok = Engram.Drainer.disconnect_peers(opts)
+
     assert_receive {:disconnected, :"a@1.1.1.1"}
     assert_receive {:disconnected, :"b@2.2.2.2"}
   end
 
-  test "drain/1 is no-op-safe when there are no peers" do
-    opts = [
-      pause_oban: fn -> :ok end,
-      peers: fn -> [] end,
-      disconnect: fn _ -> :ok end,
-      grace_ms: 0
-    ]
-
-    assert :ok = Engram.Drainer.drain(opts)
+  test "disconnect_peers/1 is no-op-safe when there are no peers" do
+    assert :ok = Engram.Drainer.disconnect_peers(peers: fn -> [] end, disconnect: fn _ -> :ok end)
   end
 
   test "default pause path pauses only the local node (local_only: true)" do
@@ -50,12 +55,7 @@ defmodule Engram.DrainerTest do
     end)
 
     # No :pause_oban override → exercises the production default_pause_oban/0.
-    assert :ok =
-             Engram.Drainer.drain(
-               peers: fn -> [] end,
-               disconnect: fn _ -> :ok end,
-               grace_ms: 0
-             )
+    assert :ok = Engram.Drainer.drain(grace_ms: 0)
 
     assert_receive {:paused, call_opts}
     assert Keyword.get(call_opts, :local_only) == true

--- a/test/engram_web/controllers/health_controller_test.exs
+++ b/test/engram_web/controllers/health_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule EngramWeb.HealthControllerTest do
   use EngramWeb.ConnCase, async: false
 
+  import ExUnit.CaptureLog
+
   setup tags do
     if tags[:auth] do
       Application.put_env(:engram, :auth_provider, :local)
@@ -108,6 +110,33 @@ defmodule EngramWeb.HealthControllerTest do
 
       conn = get(conn, "/api/health/deep")
       assert json_response(conn, 200)["checks"]["cluster"] == "ok: unjoined_grace_expired"
+    end
+
+    test "logs the grace-expired warning only once, then debug — a sustained split must not spam the alert",
+         %{conn: conn} do
+      Application.put_env(:engram, :dns_cluster_query, "app.engram.internal")
+
+      Application.put_env(:engram, :cluster_readiness_opts,
+        peers: fn -> [] end,
+        resolver: fn _ -> ["10.0.0.9"] end,
+        self_ip: "10.0.0.7",
+        uptime_ms: 120_000,
+        grace_ms: 60_000
+      )
+
+      on_exit(fn ->
+        key = {EngramWeb.HealthController, :cluster_grace_expired_logged}
+        if :persistent_term.get(key, false), do: :persistent_term.erase(key)
+      end)
+
+      first_log = capture_log(fn -> get(conn, "/api/health/deep") end)
+      assert first_log =~ "cluster readiness: unjoined past boot grace"
+
+      # Second probe of the same sustained split must not repeat the
+      # warning — test.exs pins `logger level: :warning`, so a debug-level
+      # re-log is silently dropped rather than needing string matching here.
+      second_log = capture_log(fn -> get(conn, "/api/health/deep") end)
+      refute second_log =~ "cluster readiness: unjoined past boot grace"
     end
   end
 

--- a/test/engram_web/controllers/health_controller_test.exs
+++ b/test/engram_web/controllers/health_controller_test.exs
@@ -38,6 +38,79 @@ defmodule EngramWeb.HealthControllerTest do
     end
   end
 
+  describe "GET /health/deep cluster readiness gate (clustered deploys only)" do
+    setup do
+      on_exit(fn ->
+        Application.delete_env(:engram, :dns_cluster_query)
+        Application.delete_env(:engram, :cluster_readiness_opts)
+      end)
+    end
+
+    test "omits the cluster check entirely when not clustered (self-host shape unchanged)", %{
+      conn: conn
+    } do
+      conn = get(conn, "/api/health/deep")
+      refute Map.has_key?(json_response(conn, 200)["checks"], "cluster")
+    end
+
+    test "503 while other nodes are discoverable but unjoined (boot window)", %{conn: conn} do
+      Application.put_env(:engram, :dns_cluster_query, "app.engram.internal")
+
+      Application.put_env(:engram, :cluster_readiness_opts,
+        peers: fn -> [] end,
+        resolver: fn _ -> ["10.0.0.9"] end,
+        self_ip: "10.0.0.7",
+        uptime_ms: 1_000,
+        grace_ms: 60_000
+      )
+
+      conn = get(conn, "/api/health/deep")
+      body = json_response(conn, 503)
+      assert body["status"] == "degraded"
+      assert body["checks"]["cluster"] == "waiting: cluster_unjoined"
+    end
+
+    test "200 once a peer is joined", %{conn: conn} do
+      Application.put_env(:engram, :dns_cluster_query, "app.engram.internal")
+
+      Application.put_env(:engram, :cluster_readiness_opts,
+        peers: fn -> [:"engram@10.0.0.9"] end,
+        resolver: fn _ -> ["10.0.0.9"] end
+      )
+
+      conn = get(conn, "/api/health/deep")
+      assert json_response(conn, 200)["checks"]["cluster"] == "ok"
+    end
+
+    test "200 when legitimately alone (first task / scale-to-1)", %{conn: conn} do
+      Application.put_env(:engram, :dns_cluster_query, "app.engram.internal")
+
+      Application.put_env(:engram, :cluster_readiness_opts,
+        peers: fn -> [] end,
+        resolver: fn _ -> [] end
+      )
+
+      conn = get(conn, "/api/health/deep")
+      assert json_response(conn, 200)["checks"]["cluster"] == "ok: alone"
+    end
+
+    test "200 with warning once the boot grace expires — a discovery outage cannot wedge a deploy",
+         %{conn: conn} do
+      Application.put_env(:engram, :dns_cluster_query, "app.engram.internal")
+
+      Application.put_env(:engram, :cluster_readiness_opts,
+        peers: fn -> [] end,
+        resolver: fn _ -> ["10.0.0.9"] end,
+        self_ip: "10.0.0.7",
+        uptime_ms: 120_000,
+        grace_ms: 60_000
+      )
+
+      conn = get(conn, "/api/health/deep")
+      assert json_response(conn, 200)["checks"]["cluster"] == "ok: unjoined_grace_expired"
+    end
+  end
+
   describe "GET /health/diagnostics (admin-only full dep matrix)" do
     @tag :auth
     test "rejects unauthenticated requests with 401", %{conn: conn} do

--- a/test/engram_web/controllers/health_controller_test.exs
+++ b/test/engram_web/controllers/health_controller_test.exs
@@ -42,7 +42,13 @@ defmodule EngramWeb.HealthControllerTest do
 
   describe "GET /health/deep cluster readiness gate (clustered deploys only)" do
     setup do
+      # The log-once flag is node-global; reset around every test in this
+      # block so grace-expired test ordering can't leak between tests.
+      log_once_key = {EngramWeb.HealthController, :cluster_grace_expired_logged}
+      :persistent_term.erase(log_once_key)
+
       on_exit(fn ->
+        :persistent_term.erase(log_once_key)
         Application.delete_env(:engram, :dns_cluster_query)
         Application.delete_env(:engram, :cluster_readiness_opts)
       end)
@@ -123,11 +129,6 @@ defmodule EngramWeb.HealthControllerTest do
         uptime_ms: 120_000,
         grace_ms: 60_000
       )
-
-      on_exit(fn ->
-        key = {EngramWeb.HealthController, :cluster_grace_expired_logged}
-        if :persistent_term.get(key, false), do: :persistent_term.erase(key)
-      end)
 
       first_log = capture_log(fn -> get(conn, "/api/health/deep") end)
       assert first_log =~ "cluster readiness: unjoined past boot grace"


### PR DESCRIPTION
## Problem

Rolling deploys still produce windows where a node serves traffic with `cluster_peers=0` — its `Phoenix.PubSub` is per-node, so WS clients on that node silently miss cross-node `note_changed` fan-out. This is what the `engram-prod-cluster-degraded` deploy blips (Jul 3/5/7) trace back to. The alert is deliberately untouched; this fixes the cause.

Evidence + design space: `engram-workspace/.superpowers/sdd/alert-noise-investigation.md`. The Jul 3 02:00-08:00 UTC sustained episode is a **separate defect** (OTP `ssl` `tls_client_ticket_store` crash on KMS TLS 1.3 session tickets → VM exits → 2h ECS task churn) — root-caused and filed as #966, not stretched into this PR.

## What was already true (and therefore NOT re-done)

#742/#673 (stable `RELEASE_COOKIE`, socket drainer, 30s HTTP drain) shipped Jun 24, so old+new tasks can cluster mid-roll, and DNSCluster does its first resolve+connect in `init` (`handle_continue`) — before PubSub/Endpoint even start. Cloud Map TTL (10s), DNSCluster interval (5s), ALB HC (15s/2), and deployment percentages are already tight — **no infra changes needed**.

Two gaps remained, both app-side:

## 1. Boot side: cluster-join readiness gate on `/api/health/deep`

New `Engram.Cluster.Readiness`, consulted by the ALB readiness probe when `DNS_CLUSTER_QUERY` is set (self-host/dev/test: check omitted, response shape unchanged):

| state | probe | when |
|---|---|---|
| `ready` | 200 | ≥1 BEAM peer connected |
| `alone` | 200 | Cloud Map resolves no OTHER node (first task, scale-to-1, DR) — or resolution fails (fail-open: a Cloud Map outage must not block boot) |
| `waiting` | **503** | other nodes discoverable but unjoined, within the 60s boot grace — ECS keeps old tasks serving until the new node joins |
| `grace_expired` | 200 + warn log | still unjoined after 60s of VM uptime |

**Wedge-proofing:** the gate can only hold a deploy for 60s of boot. A permanently-alone node (SG regression, cookie mismatch, the undistributed-boot class from #966) passes after grace with a `lifecycle` warning, and the untouched cluster-degraded alert remains the authority. Grace is measured from VM start, so a *later* real split never yanks tasks from the ALB (that would upgrade "degraded fan-out" to an outage). Timing envelope: 60s grace < ECS `health_check_grace_period_seconds` (120s), and worst case stays well inside the CI `Verify ECS deployment health` 300s budget (~160-200s baseline).

## 2. Drain side: disconnect peers AFTER the socket drain, not before

`prep_stop` used to `Node.disconnect` peers 5s into SIGTERM while the endpoint kept draining WS clients for up to ~25s — clients on the dying node missed cross-node fan-out for that window, and the node kept emitting `cluster_peers=0` samples whose staleness lingers ~5m (the post-deploy alert-blip signature). Peer disconnect now moves to `Application.stop/1`, which runs after the supervision tree (endpoint + UserSocket drainer + PromEx) has stopped: full fan-out until the node stops serving, zero dying-node 0-peer samples, and survivors still get a clean `nodedown` before the VM exits.

## Tests (TDD)

`Engram.Cluster.Readiness.decide/1` is a pure decision function — unit-tested across ready/alone/waiting/grace-expired, plus `check/1` seams (self-IP exclusion, undistributed node, DNS fail-open). Controller tests cover the 503 boot window, all 200 paths, and that the unclustered response shape is unchanged. Drainer tests updated for the split (drain no longer disconnects; `disconnect_peers/1` ordered + no-op-safe).

Gauntlet: `mix format` clean, `credo --strict` 0 issues, `sobelow --exit` clean, full `mix test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
