### PR TITLE
test(e2e): adapt CRDT sync tests to truly-lazy room enrollment

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -684,6 +684,44 @@ class CdpClient:
         )
         return bool(result)
 
+    async def open_note_in_editor(self, path: str, timeout: float = 10) -> None:
+        """Open ``path`` in an Obsidian markdown editor and wait until it is
+        live-bound to its CRDT room.
+
+        Under lazy enrollment a note holds a live CRDT room ONLY while it is open
+        in the editor; a note nobody opened routes through convergent REST, not
+        the shared Y.Doc. So a test that needs true character-level CRDT merge
+        (both edits survive) must live-bind the note on each device first — this
+        helper is that step.
+
+        Opening the file fires the plugin's ``file-open`` handler → ``crdtLiveViews
+        .refresh()`` → ``EditorController.bindTo()``. ``bindTo`` is async (it awaits
+        the Y.Text from the CRDT manager), so we poll ``isBound(path)`` rather than
+        assuming the bind completes synchronously with the open.
+        """
+        escaped_path = json.dumps(path)
+        deadline = f"Date.now() + {int(timeout * 1000)}"
+        result = await self.evaluate(
+            f"""
+            (async () => {{
+                const p = {PLUGIN_PATH};
+                const file = app.vault.getFileByPath({escaped_path});
+                if (!file) return "no-file";
+                await app.workspace.getLeaf(false).openFile(file);
+                p.crdtLiveViews?.refresh();
+                const end = {deadline};
+                while (Date.now() < end) {{
+                    if (p.crdtLiveViews?.isBound(file.path)) return "bound";
+                    await new Promise((r) => setTimeout(r, 50));
+                }}
+                return "timeout";
+            }})()
+            """,
+            await_promise=True,
+        )
+        if result != "bound":
+            raise CdpError(f"open_note_in_editor({path!r}) did not live-bind: {result}")
+
     async def trigger_pull(self) -> int:
         """Call syncEngine.pull() and return count of pulled notes."""
         result = await self.evaluate(

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -68,6 +68,13 @@ async def test_concurrent_edits_both_survive(vault_a, vault_b, cdp_a, cdp_b, api
     path = "E2E/Crdt/Merge.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "shared base\n", "shared base")
 
+    # Lazy enrollment: a note holds a live CRDT room ONLY while open in the editor.
+    # Character-level merge needs both devices sharing one Y.Doc, so live-bind the
+    # note on each before diverging — otherwise the writes route through convergent
+    # REST (last-write-wins) and one edit is lost.
+    await cdp_a.open_note_in_editor(path)
+    await cdp_b.open_note_in_editor(path)
+
     # Independent edits at different positions, applied close together so neither
     # device has seen the other's change yet (true concurrency).
     write_note(vault_a, path, "shared base\nFROM_A\n")
@@ -89,6 +96,11 @@ async def test_no_conflict_modal_on_divergence(vault_a, vault_b, cdp_a, cdp_b, a
     under CRDT — no modal is shown (the C1 guard's whole purpose)."""
     path = "E2E/Crdt/NoModal.md"
     await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "base line\n", "base line")
+
+    # Live-bind both sides: under lazy enrollment only an editor-open note holds a
+    # live CRDT room, and silent merge (no conflict modal) is a CRDT-room property.
+    await cdp_a.open_note_in_editor(path)
+    await cdp_b.open_note_in_editor(path)
 
     write_note(vault_a, path, "base line\nA change\n")
     write_note(vault_b, path, "base line\nB change\n")

--- a/e2e/tests/test_85_missed_delivery_no_deletion.py
+++ b/e2e/tests/test_85_missed_delivery_no_deletion.py
@@ -108,24 +108,35 @@ async def test_missed_delivery_then_local_push_no_deletion(
         # Reconnect unconditionally — the session's later tests need B live.
         await cdp_b.reconnect_stream()
 
-    # After reconnect: B and the server converge on the same main-file
-    # content within one catch-up cycle, no restart.
-
-    async def _converged() -> bool:
-        server = (api_sync.get_note(path) or {}).get("content", "")
-        b_file = vault_b / path
-        if not (server.strip() and b_file.exists() and b_file.stat().st_size > 0):
-            return False
-        return server.strip() in b_file.read_text(encoding="utf-8")
-
+    # Durable end state — the incident invariant this test guards is
+    # "no silent deletion + no data loss on EITHER side". Under lazy enrollment a
+    # cold (never editor-opened) note holds no live CRDT room, so a genuine
+    # conflict cannot character-merge into one main file: it resolves keep-both.
+    # B surfaces the server edit it missed (delivered by its own ignorant push's
+    # 409, which carries the server body over REST — channel-independent, not the
+    # reconnect above; the reconnect just restores live sync for later tests) as a
+    # conflict-copy file, its local edit stays as the main file, and the server
+    # retains its edit. We do NOT assert single-main convergence (a live-room
+    # property, not a cold note's) — that would only pass vacuously here.
+    #
+    # Three legs, each failing a distinct real regression: the server edit deleted
+    # (the ignorant-push clobber), B's local edit lost (a keep-remote overwrite),
+    # or B never surfacing the server edit at all (the permanent-miss black hole).
+    # Poll: the 409 conflict-copy write can lag the push under CI load.
     deadline = 30
     while deadline > 0:
-        if await _converged():
+        b_union = _vault_texts(vault_b, folder)
+        server_body = (api_sync.get_note(path) or {}).get("content", "")
+        if server_marker in server_body and local_marker in b_union and server_marker in b_union:
             break
         await asyncio.sleep(1)
         deadline -= 1
-    assert deadline > 0, (
-        "B never converged to the server content after reconnect "
-        f"(server={(api_sync.get_note(path) or {}).get('content', '')[:200]!r}, "
-        f"b={(vault_b / path).read_text(encoding='utf-8')[:200] if (vault_b / path).exists() else None!r})"
+    assert server_marker in server_body, (
+        f"the ignorant push deleted the server edit (server={server_body[:200]!r})"
+    )
+    assert local_marker in b_union, (
+        f"B's local edit was lost to the server edit (b={b_union[:300]!r})"
+    )
+    assert server_marker in b_union, (
+        f"B never surfaced the missed server edit — permanent miss (b={b_union[:300]!r})"
     )


### PR DESCRIPTION
Paired with plugin PR engram-app/Engram-obsidian#223 (makes lazy CRDT room enrollment truly lazy — a room opens only for an editor-open note; cold notes sync room-free via convergent REST). These e2e tests assumed eager enrollment and are updated to match.

## Changes
- **`e2e/helpers/cdp.py`** — new `open_note_in_editor(path)` helper: opens a note in an Obsidian markdown leaf and polls `crdtLiveViews.isBound` until live-bound, so a test can exercise the true CRDT character-merge path a cold note no longer takes implicitly.
- **`test_crdt_sync.py`** — `test_concurrent_edits_both_survive` and `test_no_conflict_modal_on_divergence` now live-bind both devices before diverging (character-merge needs both peers sharing one Y.Doc room).
- **`test_85_missed_delivery_no_deletion.py`** — re-scoped the post-reconnect assertion. Single-main convergence is a live-room property; a cold-note conflict resolves keep-both. Now asserts the real no-loss invariant (three legs: server edit not deleted, local edit not lost, B surfaces the missed server edit) and drops the misleading "reconnect delivers it" framing (the 409 conflict copy, channel-independent, surfaces the server edit). The no-silent-deletion incident defense is unchanged.

## Verification
Local, against the truly-lazy plugin build: test_83, test_85, both concurrent-merge tests, renames (test_10/test_34), and discovery all pass; plugin unit suite 1803/0.

Refs engram-app/Engram-obsidian#221

🤖 Generated with [Claude Code](https://claude.com/claude-code)