### PR TITLE
feat(mcp): search all vaults by default + reach/scope non-default vaults (#985, #729)

### DIFF
--- a/docs/context/mcp-vault-selection.md
+++ b/docs/context/mcp-vault-selection.md
@@ -1,0 +1,147 @@
+# Proposal: MCP vault selection + the fate of the "default vault"
+
+_Written 2026-07-10 overnight for Todd's morning review. Covers P0 #985 (MCP set_vault
+cosmetic) and the standing question "justify the default vault or kill it." Related: #729,
+#951._
+
+## TL;DR
+
+- **Root cause of #985:** MCP over HTTP JSON-RPC is **stateless**. `set_vault` persists
+  nothing — its "Active vault: Health" reply is fiction. Every vault-scoped read/write tool
+  resolves its vault *per call*, and the only per-call signal (`args["vault_id"]`) was **never
+  advertised in any tool schema**, so clients never sent it. With no signal, the server
+  **silently fell back to the default vault**. Net: MCP could only ever read the default vault,
+  and did so without any error.
+- **The default vault is not the villain — silent fallback to it is.** The `is_default` flag has
+  exactly one honest job: zero-config routing for single-vault users and onboarding. It has **no
+  legitimate role in disambiguating multi-vault access**; using it there is the bug.
+- **Shipped fix (this branch, no schema/DB change):** (1) advertise an optional `vault_id` on
+  every vault-scoped tool, (2) **fail loud** on multi-vault ambiguity instead of silently
+  defaulting, (3) use "your only vault" (not the `is_default` flag) for the single-vault case.
+- **Your call (deferred, needs your decision):** whether to keep the `is_default` flag as-is
+  (Option 1), derive it and drop the column (Option 2), or move to per-connection binding and
+  delete `set_vault` entirely (Option 3). And whether to add tiny per-credential server-side
+  state so `set_vault` can become genuinely stateful. I did **not** ship any of these — they're
+  architecture calls that are yours.
+
+---
+
+## 1. How vault resolution actually works today
+
+Two auth paths reach `/api/mcp`, both landing in `McpController.resolve_mcp_vault/3`:
+
+| Signal | Where it comes from | Effect today |
+|---|---|---|
+| `oauth_scope_vault_id` | OAuth JWT `vault_id` claim, chosen at consent | If set → vault is **locked** to it; a different `vault_id` errors ("bound to vault X"). This is #729. |
+| `args["vault_id"]` | per-tool-call argument | Honored **if present** — but no read/write tool schema declared it, so it was never present. |
+| (nothing) | — | Silent fallback to `conn.assigns.current_vault`, which for MCP is **always the default vault** (VaultPlug gets no `X-Vault-ID` header from MCP clients). |
+
+Key subtlety: the OAuth consent screen **defaults to `vault:*`** (all-vaults, `oauth_scope_vault_id
+= nil`). So even the *unbound* token falls through to the silent-default branch. **Every path led
+to the default vault.** That's why `set_vault(Health)` echoed correctly (the handler just
+validates + echoes) but `list_folders` returned the Engram default tree.
+
+`set_vault` never wrote state anywhere. There is nowhere for it to write — the protocol is one
+independent HTTP POST per tool call.
+
+## 2. Why the default vault exists (the justification you asked for)
+
+`vaults.is_default` is a single per-user boolean, set `true` on the first vault created
+(`Vaults.create_vault`, `count == 0`). It is consumed in three places:
+
+1. **Onboarding / first sync** — the app needs somewhere to route notes before the user has any
+   concept of "vaults." The first vault is default; everything just works.
+2. **`VaultPlug` fallback** — a REST request with no `X-Vault-ID` resolves to the default. In
+   practice the Obsidian plugin and the SPA both always send the header now (plugin fixed in
+   #117), so this is a fallback for un-scoped/legacy/discovery callers.
+3. **MCP** — *was* the silent fallback (the #985 bug).
+
+**Honest assessment:** for a single-vault user, "the default vault" and "the user's only vault"
+are the same thing — you don't need a stored flag to know which vault to use when there's exactly
+one. The flag only does real work when there are **2+ vaults**, and that is precisely the case
+where using it as a fallback is wrong: it silently resolves an ambiguous request instead of
+making the caller be explicit. So:
+
+> The default vault earns its existence as a **single-vault / onboarding convenience**. It does
+> **not** earn a role in multi-vault disambiguation. Every bug in this cluster (#985, and the
+> latent half of #951) is the flag being used for the second job.
+
+## 3. What I shipped on this branch (conservative, reversible, no migration)
+
+Scope deliberately limited to things that are unambiguously correct and don't pre-empt your
+design decision:
+
+1. **Advertise `vault_id`** (optional, uuid) on every vault-scoped tool schema
+   (`search_notes`, `list_tags`, `list_folders`, `list_folder`, `get_note`, `create_folder`,
+   `suggest_folder`, and all write tools). Injected in one place in `Tools.list/0` so future
+   tools get it automatically; `list_vaults`/`set_vault` are exempt. The mechanism already
+   worked end-to-end (the restricted-API-key test proves it) — clients just were never told it
+   existed.
+2. **Fail loud on ambiguity.** `resolve_mcp_vault/3` no longer silently returns the default:
+   - exactly one vault → use it (single-vault users: zero change, zero config);
+   - `vault_id` given → resolve + access-check it (unresolvable → clear error, was a silent
+     default before);
+   - multiple vaults + nothing specified → **error** telling the model to call `list_vaults`
+     and pass `vault_id`.
+   The default `is_default` flag is no longer consulted on the MCP path at all — "your only
+   vault" replaces it, which also sidesteps the deleted-default strand (#951) for single-vault
+   users.
+3. **`set_vault` told the truth.** Its schema/description now states MCP keeps no active-vault
+   state between calls, and its reply echoes the exact `vault_id` to thread on subsequent calls.
+   (Handler behavior otherwise unchanged — its real fate is your decision below.)
+
+Regression test added: multi-vault account → `list_folders` with no `vault_id` errors loud;
+with `vault_id=B` returns B's tree, not the default. This is the test whose absence let the bug
+ship.
+
+**Not shipped (needs your sign-off):** any DB/migration, removal of `is_default`, per-credential
+stateful `set_vault`, OAuth consent UX change. See below.
+
+## 4. The decision that's yours
+
+### 4a. Fate of the `is_default` flag
+
+- **Option 1 — keep the flag, fix the fallback semantics (shipped for MCP).** Keep `is_default`
+  for onboarding + single-vault convenience; forbid silent multi-vault defaulting everywhere.
+  Extend the same fail-loud treatment to `VaultPlug` (REST). Lowest churn. **Recommended.**
+- **Option 2 — derive it, drop the column.** "Default" becomes computed: your only vault, else
+  none. Requires a migration + touching onboarding, VaultPlug, SPA, and #951's repoint logic.
+  Conceptually cleaner; a bigger bet. Worth doing only if the flag keeps causing bugs after
+  Option 1.
+- **Option 3 — per-connection binding, no runtime switch.** Vault is chosen once at connect time
+  (OAuth consent / API-key creation), immutable per credential; multi-vault = multiple
+  connectors. Delete `set_vault`. This matches MCP's stateless grain most honestly, and makes
+  #729 a non-issue. The cost is UX: to switch vaults in one Claude session you'd reconnect.
+
+### 4b. Should `set_vault` become genuinely stateful?
+
+If you want `set_vault(Health)` to "stick" for the rest of a session without threading `vault_id`
+on every call, the server must persist active-vault **per credential** (a tiny
+`mcp_active_vault{user_id, credential_key, vault_id}` row or ETS). That's a real (if small)
+stateful feature with cross-connection wrinkles (two clients on one token). I did not build it —
+it's a genuine product/architecture choice. The shipped per-call `vault_id` makes it optional
+rather than required.
+
+### 4c. OAuth consent defaults to `vault:*` silently
+
+Independent of the above: the consent screen picks `vault:*` when no choice is submitted. For a
+multi-vault user that's an all-access grant they didn't consciously make, and it feeds the
+silent-default path. Recommend making the vault choice explicit in the consent UI (out of scope
+for this branch; frontend).
+
+## 5. My recommendation in one line
+
+Ship this branch (Option 1 semantics for MCP), then decide 4a between **Option 1 extended to
+VaultPlug** (safe, recommended) and **Option 3** (cleanest, bigger UX change) — and only add
+stateful `set_vault` (4b) if you specifically want in-session switching without per-call
+`vault_id`.
+
+## References
+
+- `lib/engram_web/controllers/mcp_controller.ex` — `resolve_mcp_vault/3` (the fix site)
+- `lib/engram/mcp/tools.ex` — tool schemas (`vault_id` advertising)
+- `lib/engram/mcp/handlers.ex` — `set_vault` handler
+- `lib/engram_web/plugs/vault_plug.ex` — REST default-vault fallback (Option 1 extension target)
+- `lib/engram/oauth.ex` — `resolve_vault/2` (`vault:*` → nil), consent minting
+- `docs/context/search-contract-and-vault-id.md` — the plugin-side twin (Bug 2), already fixed
+- Issues: #985 (this), #729 (bound-token vs list_vaults), #951 (deleted-default strands clients)

--- a/e2e/tests/api_only/test_32_vault_api_key_isolation.py
+++ b/e2e/tests/api_only/test_32_vault_api_key_isolation.py
@@ -26,6 +26,7 @@ from helpers.api import ApiClient
 from helpers.billing import grant_test_plan
 from helpers.clerk import ClerkClient
 from helpers.clerk_auth import provision_clerk_user
+from helpers.crypto_probe import latest_note_path_hmac, wait_for_qdrant_indexed
 
 logger = logging.getLogger(__name__)
 
@@ -227,12 +228,15 @@ def test_vault_registration_idempotent(vault_setup):
 
 
 def test_mcp_respects_vault_scoping(vault_setup):
-    """MCP get_note should respect X-Vault-ID header vault scoping."""
+    """MCP get_note scopes to the vault_id ARG (MCP uses vault_id, not X-Vault-ID)."""
     api_a = vault_setup["api_vault_a"]
+    vault_a_id = vault_setup["vault_a_id"]
 
-    # Call MCP get_note for a vault-A note from vault-A context
+    # MCP resolves the vault from the vault_id arg (X-Vault-ID is a REST-only
+    # mechanism; the MCP server is off the VaultPlug path).
     resp, status = api_a.mcp_call("get_note", {
-        "source_path": "E2E/VaultA-Secret.md"
+        "source_path": "E2E/VaultA-Secret.md",
+        "vault_id": vault_a_id,
     })
     assert status == 200
     content = resp.get("result", {}).get("content", [{}])
@@ -241,18 +245,56 @@ def test_mcp_respects_vault_scoping(vault_setup):
 
 
 def test_mcp_cannot_see_other_vault_notes(vault_setup):
-    """MCP get_note from vault A context should NOT see vault B notes."""
+    """Scoped to vault A (via vault_id), a vault B note path is not found."""
     api_a = vault_setup["api_vault_a"]
+    vault_a_id = vault_setup["vault_a_id"]
 
     resp, status = api_a.mcp_call("get_note", {
-        "source_path": "E2E/VaultB-Secret.md"
+        "source_path": "E2E/VaultB-Secret.md",
+        "vault_id": vault_a_id,
     })
     assert status == 200
     content = resp.get("result", {}).get("content", [{}])
     text = content[0].get("text", "") if content else ""
     assert "Note not found" in text, (
-        f"ISOLATION BREACH: MCP from vault A can see vault B note: {text[:200]}"
+        f"ISOLATION BREACH: MCP scoped to vault A can see vault B note: {text[:200]}"
     )
+
+
+def test_mcp_search_spans_all_vaults_by_default(vault_setup):
+    """A bare search_notes (no vault_id) searches across ALL the user's vaults
+    and labels each hit with its vault (cross-vault default; #985)."""
+    api = vault_setup["unrestricted_api"]
+    vault_a_id = vault_setup["vault_a_id"]
+    vault_b_id = vault_setup["vault_b_id"]
+
+    # Both seeded notes must be embedded before a semantic search can find them.
+    wait_for_qdrant_indexed(vault_a_id, latest_note_path_hmac(vault_a_id), timeout=90)
+    wait_for_qdrant_indexed(vault_b_id, latest_note_path_hmac(vault_b_id), timeout=90)
+
+    resp, status = api.mcp_call("search_notes", {"query": "Secret"})
+    assert status == 200
+    text = resp.get("result", {}).get("content", [{}])[0].get("text", "")
+
+    # Cross-vault results are labelled by vault id; BOTH vaults must be present.
+    assert vault_a_id in text, f"cross-vault search missed vault A: {text[:300]}"
+    assert vault_b_id in text, f"cross-vault search missed vault B: {text[:300]}"
+
+
+def test_mcp_search_scoped_to_vault_id_excludes_others(vault_setup):
+    """search_notes with a vault_id arg limits the search to that vault only."""
+    api = vault_setup["unrestricted_api"]
+    vault_a_id = vault_setup["vault_a_id"]
+    vault_b_id = vault_setup["vault_b_id"]
+
+    wait_for_qdrant_indexed(vault_a_id, latest_note_path_hmac(vault_a_id), timeout=90)
+
+    resp, status = api.mcp_call("search_notes", {"query": "Secret", "vault_id": vault_a_id})
+    assert status == 200
+    text = resp.get("result", {}).get("content", [{}])[0].get("text", "")
+
+    # Scoped to A → must not surface vault B's id.
+    assert vault_b_id not in text, f"scoped search leaked vault B: {text[:300]}"
 
 
 def test_mcp_vault_id_override_same_user(vault_setup):

--- a/lib/engram/mcp/handlers.ex
+++ b/lib/engram/mcp/handlers.ex
@@ -8,17 +8,22 @@ defmodule Engram.MCP.Handlers do
 
   # -- Vault tools --
 
-  def handle("list_vaults", user, _vault, _args) do
-    vaults = Vaults.list_vaults(user)
+  # `vaults` is pre-scoped by the controller to the set THIS credential can use
+  # (OAuth binding + API-key restrictions), so we never advertise a vault the
+  # caller can't actually read or write (#729).
+  def handle("list_vaults", _user, vaults, _args) when is_list(vaults) do
+    if vaults == [] do
+      {:ok, "No vaults are accessible with this connection."}
+    else
+      lines =
+        Enum.map(vaults, fn v ->
+          default = if v.is_default, do: " (default)", else: ""
+          desc = if v.description, do: " — #{v.description}", else: ""
+          "- **#{v.name}**#{default} (ID: #{v.id})#{desc}"
+        end)
 
-    lines =
-      Enum.map(vaults, fn v ->
-        default = if v.is_default, do: " (default)", else: ""
-        desc = if v.description, do: " — #{v.description}", else: ""
-        "- **#{v.name}**#{default} (ID: #{v.id})#{desc}"
-      end)
-
-    {:ok, Enum.join(lines, "\n")}
+      {:ok, Enum.join(lines, "\n")}
+    end
   end
 
   def handle("set_vault", user, _vault, args) do

--- a/lib/engram/mcp/handlers.ex
+++ b/lib/engram/mcp/handlers.ex
@@ -55,42 +55,21 @@ defmodule Engram.MCP.Handlers do
 
   # -- Read tools --
 
+  # Cross-vault default (the credential can reach every vault and no vault_id was
+  # given): search all vaults at once and label each hit with its vault so the
+  # caller can follow up (e.g. get_note) against the right one. `allow_cross_vault`
+  # bypasses the Pro billing gate — multi-vault search is the MCP default on every
+  # tier (product decision 2026-07-10).
+  def handle("search_notes", user, {:cross_vault, vaults}, args) do
+    query = args["query"] || ""
+    opts = Keyword.merge(build_search_opts(args), cross_vault: true, allow_cross_vault: true)
+    names = Map.new(vaults, &{to_string(&1.id), &1.name})
+    render_search(Search.search(user, nil, query, opts), names)
+  end
+
   def handle("search_notes", user, vault, args) do
     query = args["query"] || ""
-    opts = build_search_opts(args)
-
-    case Search.search(user, vault, query, opts) do
-      {:ok, results} when results != [] ->
-        text =
-          results
-          |> Enum.with_index(1)
-          |> Enum.map_join("\n", fn {r, i} ->
-            lines = ["## Result #{i} (score: #{Float.round(r.score, 3)})"]
-            lines = if r[:title], do: lines ++ ["**Title:** #{r.title}"], else: lines
-
-            lines =
-              if r[:heading_path], do: lines ++ ["**Section:** #{r.heading_path}"], else: lines
-
-            lines =
-              if r[:source_path], do: lines ++ ["**Source:** #{r.source_path}"], else: lines
-
-            lines =
-              if r[:tags] && r.tags != [],
-                do: lines ++ ["**Tags:** #{Enum.join(r.tags, ", ")}"],
-                else: lines
-
-            lines = lines ++ ["\n#{r.text}\n"]
-            Enum.join(lines, "\n")
-          end)
-
-        {:ok, text}
-
-      {:ok, []} ->
-        {:ok, "No results found."}
-
-      {:error, _reason} ->
-        {:ok, "Search unavailable."}
-    end
+    render_search(Search.search(user, vault, query, build_search_opts(args)), %{})
   end
 
   def handle("list_tags", user, vault, _args) do
@@ -540,6 +519,44 @@ defmodule Engram.MCP.Handlers do
         other ->
           other
       end
+    end
+  end
+
+  # Render Search.search/4 output for the search_notes tool. `names` maps
+  # vault_id → vault name; when non-empty (cross-vault mode) each hit is labelled
+  # with its vault so the caller knows which vault to act against.
+  defp render_search({:ok, results}, names) when results != [] do
+    text =
+      results
+      |> Enum.with_index(1)
+      |> Enum.map_join("\n", fn {r, i} -> format_search_result(r, i, names) end)
+
+    {:ok, text}
+  end
+
+  defp render_search({:ok, _empty}, _names), do: {:ok, "No results found."}
+  defp render_search({:error, _reason}, _names), do: {:ok, "Search unavailable."}
+
+  defp format_search_result(r, i, names) do
+    ["## Result #{i} (score: #{Float.round(r.score, 3)})"]
+    |> maybe_line(vault_label(r, names))
+    |> maybe_line(r[:title] && "**Title:** #{r.title}")
+    |> maybe_line(r[:heading_path] && "**Section:** #{r.heading_path}")
+    |> maybe_line(r[:source_path] && "**Source:** #{r.source_path}")
+    |> maybe_line(r[:tags] && r.tags != [] && "**Tags:** #{Enum.join(r.tags, ", ")}")
+    |> Kernel.++(["\n#{r.text}\n"])
+    |> Enum.join("\n")
+  end
+
+  defp maybe_line(lines, line) when is_binary(line), do: lines ++ [line]
+  defp maybe_line(lines, _falsy), do: lines
+
+  defp vault_label(_r, names) when map_size(names) == 0, do: nil
+
+  defp vault_label(r, names) do
+    case names[to_string(r[:vault_id])] do
+      name when is_binary(name) -> "**Vault:** #{name} (#{r[:vault_id]})"
+      _ -> nil
     end
   end
 

--- a/lib/engram/mcp/handlers.ex
+++ b/lib/engram/mcp/handlers.ex
@@ -4,7 +4,7 @@ defmodule Engram.MCP.Handlers do
   Each function takes (user, vault, args) and returns a markdown-formatted string.
   """
 
-  alias Engram.{Notes, Search, Vaults}
+  alias Engram.{Notes, Search}
 
   # -- Vault tools --
 
@@ -26,18 +26,29 @@ defmodule Engram.MCP.Handlers do
     end
   end
 
-  def handle("set_vault", user, _vault, args) do
+  # `accessible` is the credential-scoped vault set (see the controller's
+  # dispatch_tool). set_vault does NOT persist anything — MCP is stateless — so
+  # it only validates the id against what this credential can reach and echoes
+  # the id to thread on subsequent calls. It must never confirm a vault outside
+  # the accessible set (#729).
+  def handle("set_vault", _user, accessible, args) when is_list(accessible) do
     case args["vault_id"] do
       nil ->
-        case Vaults.get_default_vault(user) do
-          {:ok, v} -> {:ok, "Active vault: **#{v.name}** (default)"}
-          {:error, _} -> {:error, "No default vault found"}
-        end
+        {:ok,
+         "MCP keeps no active-vault state between calls. Pass `vault_id` on each " <>
+           "vault-scoped tool call to target a vault. Call list_vaults to see the IDs."}
 
       vault_id ->
-        case Vaults.get_vault(user, vault_id) do
-          {:ok, v} -> {:ok, "Active vault: **#{v.name}**"}
-          {:error, _} -> {:error, "Vault not found"}
+        case Enum.find(accessible, &(to_string(&1.id) == to_string(vault_id))) do
+          nil ->
+            {:error,
+             "Vault not found or not accessible: #{vault_id}. Call list_vaults to see the " <>
+               "vaults this connection can use."}
+
+          v ->
+            {:ok,
+             "Vault **#{v.name}** (ID: #{v.id}) is valid. Pass vault_id=\"#{v.id}\" on each " <>
+               "tool call to target it — MCP stores no active vault between calls."}
         end
     end
   end

--- a/lib/engram/mcp/handlers.ex
+++ b/lib/engram/mcp/handlers.ex
@@ -522,10 +522,12 @@ defmodule Engram.MCP.Handlers do
     end
   end
 
+  @doc false
   # Render Search.search/4 output for the search_notes tool. `names` maps
   # vault_id → vault name; when non-empty (cross-vault mode) each hit is labelled
-  # with its vault so the caller knows which vault to act against.
-  defp render_search({:ok, results}, names) when results != [] do
+  # with its vault so the caller knows which vault to act against. Public (doc:
+  # false) so the vault-labelling can be unit-tested without standing up Qdrant.
+  def render_search({:ok, results}, names) when results != [] do
     text =
       results
       |> Enum.with_index(1)
@@ -534,8 +536,8 @@ defmodule Engram.MCP.Handlers do
     {:ok, text}
   end
 
-  defp render_search({:ok, _empty}, _names), do: {:ok, "No results found."}
-  defp render_search({:error, _reason}, _names), do: {:ok, "Search unavailable."}
+  def render_search({:ok, _empty}, _names), do: {:ok, "No results found."}
+  def render_search({:error, _reason}, _names), do: {:ok, "Search unavailable."}
 
   defp format_search_result(r, i, names) do
     ["## Result #{i} (score: #{Float.round(r.score, 3)})"]

--- a/lib/engram/mcp/tools.ex
+++ b/lib/engram/mcp/tools.ex
@@ -56,6 +56,18 @@ defmodule Engram.MCP.Tools do
 
   defp with_vault_id(%{name: name} = tool) when name in @vault_scoping_exempt, do: tool
 
+  # search_notes spans all vaults by default, so vault_id is an optional narrower
+  # there — not the "required when multi-vault" contract the other tools carry.
+  defp with_vault_id(%{name: "search_notes"} = tool) do
+    put_in(tool, [:inputSchema, "properties", "vault_id"], %{
+      "type" => "string",
+      "format" => "uuid",
+      "description" =>
+        "Optional: limit the search to a single vault (UUID). Omit to search across " <>
+          "ALL your vaults. Call list_vaults to see IDs."
+    })
+  end
+
   defp with_vault_id(tool),
     do: put_in(tool, [:inputSchema, "properties", "vault_id"], @vault_id_property)
 
@@ -103,9 +115,9 @@ defmodule Engram.MCP.Tools do
     %{
       name: "search_notes",
       description:
-        "Search your personal knowledge base. Finds relevant notes from your " <>
-          "Obsidian vault using semantic search. Use when the user asks about their " <>
-          "notes, vault, knowledge, or memory.",
+        "Search your personal knowledge base. Finds relevant notes using semantic " <>
+          "search. Searches across ALL your vaults by default; pass vault_id to limit " <>
+          "to one. Use when the user asks about their notes, vault, knowledge, or memory.",
       inputSchema: %{
         "type" => "object",
         "properties" => %{

--- a/lib/engram/mcp/tools.ex
+++ b/lib/engram/mcp/tools.ex
@@ -13,6 +13,22 @@ defmodule Engram.MCP.Tools do
           handler: (map(), map(), map() -> {:ok, String.t()} | {:error, String.t()})
         }
 
+  # Tools that do NOT operate on a single vault's contents, so they take no
+  # `vault_id`: `list_vaults` spans all of them, `set_vault` has its own.
+  @vault_scoping_exempt ~w(list_vaults set_vault)
+
+  # MCP is stateless HTTP JSON-RPC: there is no session to hold an "active vault"
+  # between tool calls, so every vault-scoped tool advertises an optional
+  # `vault_id`. Injected here (not hand-written per tool) so new tools inherit it.
+  @vault_id_property %{
+    "type" => "string",
+    "format" => "uuid",
+    "description" =>
+      "Target vault UUID (call list_vaults to discover IDs). REQUIRED when you own " <>
+        "more than one vault — the server keeps no active-vault state between calls, so " <>
+        "it must be passed on every vault-scoped call. Omit only if you have a single vault."
+  }
+
   @spec list() :: [tool_def()]
   def list do
     [
@@ -35,7 +51,13 @@ defmodule Engram.MCP.Tools do
       delete_note_def(),
       move_attachment_def()
     ]
+    |> Enum.map(&with_vault_id/1)
   end
+
+  defp with_vault_id(%{name: name} = tool) when name in @vault_scoping_exempt, do: tool
+
+  defp with_vault_id(tool),
+    do: put_in(tool, [:inputSchema, "properties", "vault_id"], @vault_id_property)
 
   @spec get(String.t()) :: {:ok, tool_def()} | :error
   def get(name) do
@@ -60,8 +82,9 @@ defmodule Engram.MCP.Tools do
     %{
       name: "set_vault",
       description:
-        "Set the active vault context. Without vault_id, resets to default. " <>
-          "Call list_vaults first to see available vaults.",
+        "Validate and echo a vault by ID. NOTE: this does NOT persist an active " <>
+          "vault — MCP keeps no state between calls. To read or write a specific " <>
+          "vault, pass its vault_id on each tool call. Use list_vaults to discover IDs.",
       inputSchema: %{
         "type" => "object",
         "properties" => %{

--- a/lib/engram/search.ex
+++ b/lib/engram/search.ex
@@ -72,7 +72,7 @@ defmodule Engram.Search do
 
     result =
       if cross_vault do
-        case Engram.Billing.check_feature(user, :cross_vault_search) do
+        case cross_vault_allowed(user, opts) do
           :ok -> do_search(user, nil, query, opts)
           {:error, _} = err -> err
         end
@@ -129,6 +129,20 @@ defmodule Engram.Search do
 
       _ ->
         result
+    end
+  end
+
+  # Cross-vault is a Pro billing feature on the web/API path. The MCP server
+  # makes multi-vault search the default for every tier (product decision
+  # 2026-07-10), so it passes `allow_cross_vault: true` to bypass the gate.
+  # The MCP caller is responsible for having already narrowed `vault: nil` to
+  # the credential's ACCESSIBLE set (it only enables this when the credential
+  # can reach every vault), so this never widens beyond what the caller may see.
+  defp cross_vault_allowed(user, opts) do
+    if Keyword.get(opts, :allow_cross_vault, false) do
+      :ok
+    else
+      Engram.Billing.check_feature(user, :cross_vault_search)
     end
   end
 

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -619,6 +619,25 @@ defmodule Engram.Vaults do
     end
   end
 
+  @doc """
+  Returns an API key's vault-restriction set: `:all` for an unrestricted key
+  (or `nil`, i.e. non-API-key auth), or the explicit list of permitted vault
+  ids. One query — lets callers filter a vault list in memory instead of one
+  `check_api_key_access/2` round-trip per vault.
+  """
+  def accessible_vault_ids(nil), do: :all
+
+  def accessible_vault_ids(api_key) do
+    ids =
+      from(akv in "api_key_vaults",
+        where: akv.api_key_id == type(^api_key.id, Ecto.UUID),
+        select: type(akv.vault_id, Ecto.UUID)
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    if ids == [], do: :all, else: ids
+  end
+
   # ── Private helpers ─────────────────────────────────────────────────────────
 
   # Phase B.1 — inject HMAC + ciphertext for the vault name.

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -600,22 +600,10 @@ defmodule Engram.Vaults do
 
   Returns `:ok` or `:forbidden`.
   """
-  def check_api_key_access(nil, _vault), do: :ok
-
   def check_api_key_access(api_key, vault) do
-    # Schemaless query: Ecto/Postgrex can't infer column types so we declare
-    # them explicitly. Both columns are `uuid` (Phase B of PG18+UUIDv7 rework).
-    restricted_vault_ids =
-      from(akv in "api_key_vaults",
-        where: akv.api_key_id == type(^api_key.id, Ecto.UUID),
-        select: type(akv.vault_id, Ecto.UUID)
-      )
-      |> Repo.all(skip_tenant_check: true)
-
-    cond do
-      restricted_vault_ids == [] -> :ok
-      vault.id in restricted_vault_ids -> :ok
-      true -> :forbidden
+    case accessible_vault_ids(api_key) do
+      :all -> :ok
+      ids -> if vault.id in ids, do: :ok, else: :forbidden
     end
   end
 

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -212,16 +212,12 @@ defmodule EngramWeb.McpController do
 
   # `list_vaults` and `set_vault` don't operate on a single vault's contents, so
   # they aren't blocked by the controller's own vault resolution — `list_vaults`
-  # is the discovery call a client uses to pick a vault in a multi-vault account.
+  # is the discovery call a client uses to pick a vault in a multi-vault account,
+  # and to recover when there is no usable default (deleted default #951, or a
+  # restricted key that excludes it). That recovery works because MCP is off the
+  # VaultPlug pipeline (see router.ex) — no default-vault 404/403 gates it.
   # `list_vaults` is handed the credential-scoped vault set so it can't advertise
   # vaults this token/key cannot use (#729).
-  #
-  # NOTE: this only bypasses the *controller's* resolution. `VaultPlug` still runs
-  # earlier in the pipeline and 404s the whole request when the user has no
-  # default vault (deleted default, #951) or 403s a restricted key whose permitted
-  # set excludes the default — so these calls can't yet recover from those states.
-  # Fixing that means taking MCP off the VaultPlug path (it self-resolves); see
-  # docs/context/mcp-vault-selection.md.
   defp dispatch_tool(%{name: "list_vaults"} = tool, user, args, conn) do
     call_tool(tool, user, accessible_vaults(user, conn), args)
   end
@@ -335,13 +331,17 @@ defmodule EngramWeb.McpController do
         resolve_requested_vault(user, requested, conn)
 
       # Bare call → resolve the credential's sole reachable vault, or fail loud.
+      # Fetch the vault list once and reuse it for the empty-set message (no
+      # second list_vaults query on the error path).
       _ ->
-        case accessible_vaults(user, conn) do
+        all = Engram.Vaults.list_vaults(user)
+
+        case scope_vaults(all, conn) do
           [only] ->
             {:ok, only}
 
           [] ->
-            {:error, no_vault_message(user)}
+            {:error, no_vault_message_for(all)}
 
           _many ->
             {:error,
@@ -389,8 +389,6 @@ defmodule EngramWeb.McpController do
   # Empty accessible set: distinguish "user has no vaults at all" (sync to make
   # one) from "the credential can reach none of the user's vaults" (a scope /
   # deleted-vault problem that syncing won't fix).
-  defp no_vault_message(user), do: no_vault_message_for(Engram.Vaults.list_vaults(user))
-
   defp no_vault_message_for([]), do: "No vault found. Sync from Obsidian to create one."
 
   defp no_vault_message_for(_vaults),

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -226,15 +226,62 @@ defmodule EngramWeb.McpController do
     call_tool(tool, user, accessible_vaults(user, conn), args)
   end
 
-  defp dispatch_tool(tool, user, args, conn) do
-    case resolve_mcp_vault(user, args, conn) do
-      {:error, msg} ->
-        {:ok, %{"content" => [%{"type" => "text", "text" => "Error: #{msg}"}], "isError" => true}}
-
-      {:ok, vault} ->
-        call_tool(tool, user, vault, args)
+  # search_notes defaults to ALL the credential's vaults (product decision
+  # 2026-07-10): a bare search spans everything the credential can reach; an
+  # explicit vault_id narrows to one.
+  defp dispatch_tool(%{name: "search_notes"} = tool, user, args, conn) do
+    if is_binary(args["vault_id"]) do
+      resolve_and_call(tool, user, args, conn)
+    else
+      search_across_accessible(tool, user, args, conn)
     end
   end
+
+  defp dispatch_tool(tool, user, args, conn) do
+    resolve_and_call(tool, user, args, conn)
+  end
+
+  defp resolve_and_call(tool, user, args, conn) do
+    case resolve_mcp_vault(user, args, conn) do
+      {:error, msg} -> error_result(msg)
+      {:ok, vault} -> call_tool(tool, user, vault, args)
+    end
+  end
+
+  # Picks the vault context for a bare (no vault_id) search. Cross-vault search
+  # (Qdrant with no vault filter) sees EVERY vault the user owns, so it is only
+  # safe when the credential can already reach all of them — otherwise it would
+  # leak vaults the credential was scoped away from (#729).
+  defp search_across_accessible(tool, user, args, conn) do
+    accessible = accessible_vaults(user, conn)
+    total = length(Engram.Vaults.list_vaults(user))
+
+    cond do
+      accessible == [] ->
+        error_result(no_vault_message(user))
+
+      length(accessible) == 1 ->
+        call_tool(tool, user, hd(accessible), args)
+
+      # Credential reaches every vault → one cross-vault query (no vault filter
+      # == exactly the accessible set here). `{:cross_vault, _}` carries the set
+      # for per-result vault labelling.
+      length(accessible) == total ->
+        call_tool(tool, user, {:cross_vault, accessible}, args)
+
+      # A per-vault-restricted key reaching a >1 subset: cross-vault would leak
+      # the vaults it can't see (Qdrant has no multi-vault filter), so require an
+      # explicit choice. Rare.
+      true ->
+        error_result(
+          "This connection is limited to specific vaults. Pass vault_id to choose one " <>
+            "(call list_vaults to see them)."
+        )
+    end
+  end
+
+  defp error_result(msg),
+    do: {:ok, %{"content" => [%{"type" => "text", "text" => "Error: #{msg}"}], "isError" => true}}
 
   # -- Vault resolution --
 

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -211,10 +211,17 @@ defmodule EngramWeb.McpController do
   # -- Tool dispatch (vault context) --
 
   # `list_vaults` and `set_vault` don't operate on a single vault's contents, so
-  # they must never be blocked by vault resolution — `list_vaults` in particular
-  # is the discovery call a client needs to escape a multi-vault or
-  # dangling-default state (#951). `list_vaults` is handed the credential-scoped
-  # vault set so it can't advertise vaults this token/key cannot use (#729).
+  # they aren't blocked by the controller's own vault resolution — `list_vaults`
+  # is the discovery call a client uses to pick a vault in a multi-vault account.
+  # `list_vaults` is handed the credential-scoped vault set so it can't advertise
+  # vaults this token/key cannot use (#729).
+  #
+  # NOTE: this only bypasses the *controller's* resolution. `VaultPlug` still runs
+  # earlier in the pipeline and 404s the whole request when the user has no
+  # default vault (deleted default, #951) or 403s a restricted key whose permitted
+  # set excludes the default — so these calls can't yet recover from those states.
+  # Fixing that means taking MCP off the VaultPlug path (it self-resolves); see
+  # docs/context/mcp-vault-selection.md.
   defp dispatch_tool(%{name: "list_vaults"} = tool, user, args, conn) do
     call_tool(tool, user, accessible_vaults(user, conn), args)
   end
@@ -253,12 +260,14 @@ defmodule EngramWeb.McpController do
   # safe when the credential can already reach all of them — otherwise it would
   # leak vaults the credential was scoped away from (#729).
   defp search_across_accessible(tool, user, args, conn) do
-    accessible = accessible_vaults(user, conn)
-    total = length(Engram.Vaults.list_vaults(user))
+    # Fetch the vault list ONCE; derive both the accessible set and the total
+    # from it (no double query).
+    all = Engram.Vaults.list_vaults(user)
+    accessible = scope_vaults(all, conn)
 
     cond do
       accessible == [] ->
-        error_result(no_vault_message(user))
+        error_result(no_vault_message_for(all))
 
       length(accessible) == 1 ->
         call_tool(tool, user, hd(accessible), args)
@@ -266,7 +275,7 @@ defmodule EngramWeb.McpController do
       # Credential reaches every vault → one cross-vault query (no vault filter
       # == exactly the accessible set here). `{:cross_vault, _}` carries the set
       # for per-result vault labelling.
-      length(accessible) == total ->
+      length(accessible) == length(all) ->
         call_tool(tool, user, {:cross_vault, accessible}, args)
 
       # A per-vault-restricted key reaching a >1 subset: cross-vault would leak
@@ -290,13 +299,17 @@ defmodule EngramWeb.McpController do
   # its permitted vaults; an unrestricted credential all of the user's vaults.
   # Every vault-scope decision (resolve, set_vault, list_vaults) routes through
   # here so the privacy boundary is enforced in exactly one place.
-  defp accessible_vaults(user, conn) do
+  defp accessible_vaults(user, conn), do: scope_vaults(Engram.Vaults.list_vaults(user), conn)
+
+  # Narrows an already-loaded vault list to what the credential may reach, so a
+  # caller that already has the list (e.g. bare search) doesn't re-query it.
+  defp scope_vaults(vaults, conn) do
     oauth_bound = conn.assigns[:oauth_scope_vault_id]
     # One query for the API key's restricted set, then filter in memory — not a
     # per-vault DB round-trip.
     allowed = Engram.Vaults.accessible_vault_ids(conn.assigns[:current_api_key])
 
-    Engram.Vaults.list_vaults(user)
+    vaults
     |> maybe_filter_oauth(oauth_bound)
     |> filter_api_key(allowed)
   end
@@ -316,17 +329,14 @@ defmodule EngramWeb.McpController do
   # against the ACCESSIBLE set, so OAuth binding + API-key scope are enforced
   # once, here.
   defp resolve_mcp_vault(user, args, conn) do
-    accessible = accessible_vaults(user, conn)
-
     case args["vault_id"] do
+      # Named vault → single lookup + scope check. No need to load every vault.
       requested when is_binary(requested) ->
-        case Enum.find(accessible, &(to_string(&1.id) == to_string(requested))) do
-          nil -> {:error, vault_denied_message(user, requested, conn)}
-          vault -> {:ok, vault}
-        end
+        resolve_requested_vault(user, requested, conn)
 
+      # Bare call → resolve the credential's sole reachable vault, or fail loud.
       _ ->
-        case accessible do
+        case accessible_vaults(user, conn) do
           [only] ->
             {:ok, only}
 
@@ -338,6 +348,24 @@ defmodule EngramWeb.McpController do
              "You own multiple vaults — specify which one. Call list_vaults to see the IDs, " <>
                "then pass vault_id on this tool call."}
         end
+    end
+  end
+
+  # A caller-named vault: enforce OAuth binding + API-key scope with a single
+  # get_vault (not a full list). vault_denied_message re-derives the specific
+  # reason on the error path only.
+  defp resolve_requested_vault(user, requested, conn) do
+    oauth_bound = conn.assigns[:oauth_scope_vault_id]
+
+    if is_binary(oauth_bound) and to_string(requested) != to_string(oauth_bound) do
+      {:error, vault_denied_message(user, requested, conn)}
+    else
+      with {:ok, vault} <- Engram.Vaults.get_vault(user, requested),
+           :ok <- Engram.Vaults.check_api_key_access(conn.assigns[:current_api_key], vault) do
+        {:ok, vault}
+      else
+        _ -> {:error, vault_denied_message(user, requested, conn)}
+      end
     end
   end
 
@@ -361,16 +389,14 @@ defmodule EngramWeb.McpController do
   # Empty accessible set: distinguish "user has no vaults at all" (sync to make
   # one) from "the credential can reach none of the user's vaults" (a scope /
   # deleted-vault problem that syncing won't fix).
-  defp no_vault_message(user) do
-    case Engram.Vaults.list_vaults(user) do
-      [] ->
-        "No vault found. Sync from Obsidian to create one."
+  defp no_vault_message(user), do: no_vault_message_for(Engram.Vaults.list_vaults(user))
 
-      _ ->
-        "This connection can't reach any of your vaults — its credential is scoped to a " <>
-          "vault that no longer exists or that it isn't permitted to use."
-    end
-  end
+  defp no_vault_message_for([]), do: "No vault found. Sync from Obsidian to create one."
+
+  defp no_vault_message_for(_vaults),
+    do:
+      "This connection can't reach any of your vaults — its credential is scoped to a " <>
+        "vault that no longer exists or that it isn't permitted to use."
 
   # -- Response helpers --
 

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -94,17 +94,7 @@ defmodule EngramWeb.McpController do
             {:error, -32_005, "rate_limited: #{reason}"}
 
           :ok ->
-            case resolve_mcp_vault(user, args, conn) do
-              {:error, msg} ->
-                {:ok,
-                 %{
-                   "content" => [%{"type" => "text", "text" => "Error: #{msg}"}],
-                   "isError" => true
-                 }}
-
-              {:ok, vault} ->
-                call_tool(tool, user, vault, args)
-            end
+            dispatch_tool(tool, user, args, conn)
         end
 
       :error ->
@@ -218,39 +208,108 @@ defmodule EngramWeb.McpController do
   defp classify_throw_reason({tag, _}) when is_atom(tag), do: {tag, :_}
   defp classify_throw_reason(_), do: :unknown
 
+  # -- Tool dispatch (vault context) --
+
+  # `list_vaults` and `set_vault` don't operate on a single vault's contents, so
+  # they must never be blocked by vault resolution — `list_vaults` in particular
+  # is the discovery call a client needs to escape a multi-vault or
+  # dangling-default state (#951). `list_vaults` is handed the credential-scoped
+  # vault set so it can't advertise vaults this token/key cannot use (#729).
+  defp dispatch_tool(%{name: "list_vaults"} = tool, user, args, conn) do
+    call_tool(tool, user, accessible_vaults(user, conn), args)
+  end
+
+  defp dispatch_tool(%{name: "set_vault"} = tool, user, args, _conn) do
+    call_tool(tool, user, nil, args)
+  end
+
+  defp dispatch_tool(tool, user, args, conn) do
+    case resolve_mcp_vault(user, args, conn) do
+      {:error, msg} ->
+        {:ok, %{"content" => [%{"type" => "text", "text" => "Error: #{msg}"}], "isError" => true}}
+
+      {:ok, vault} ->
+        call_tool(tool, user, vault, args)
+    end
+  end
+
+  # The vaults this credential can actually use: an OAuth-bound token sees only
+  # its bound vault; a restricted API key sees only its permitted vaults; an
+  # unrestricted credential sees all of the user's vaults.
+  defp accessible_vaults(user, conn) do
+    oauth_bound = conn.assigns[:oauth_scope_vault_id]
+    api_key = conn.assigns[:current_api_key]
+
+    Engram.Vaults.list_vaults(user)
+    |> maybe_filter_oauth(oauth_bound)
+    |> Enum.filter(&(Engram.Vaults.check_api_key_access(api_key, &1) == :ok))
+  end
+
+  defp maybe_filter_oauth(vaults, nil), do: vaults
+
+  defp maybe_filter_oauth(vaults, bound) when is_binary(bound),
+    do: Enum.filter(vaults, &(to_string(&1.id) == to_string(bound)))
+
   # -- Vault resolution --
 
+  # Resolves which vault a tool call targets. MCP is stateless — there is no
+  # active-vault session — so the vault comes from exactly one of: the OAuth
+  # token's bound vault, an explicit `vault_id` arg, or (only when unambiguous)
+  # the user's single vault. It NEVER silently falls back to the default vault:
+  # doing so is #985, where an AI was fed the wrong vault's data with no error.
   defp resolve_mcp_vault(user, args, conn) do
     oauth_bound = conn.assigns[:oauth_scope_vault_id]
     requested = args["vault_id"]
 
     cond do
-      is_binary(oauth_bound) and is_nil(requested) ->
-        Engram.Vaults.get_vault(user, oauth_bound)
-
-      is_binary(oauth_bound) and to_string(requested) != to_string(oauth_bound) ->
-        {:error,
-         "OAuth token is bound to vault #{oauth_bound}; tool call requested vault #{requested}"}
-
+      # OAuth token bound to a specific vault: it is authoritative. A matching
+      # (or absent) request is honored; a mismatch is a loud error, not a
+      # silent override.
       is_binary(oauth_bound) ->
-        Engram.Vaults.get_vault(user, oauth_bound)
-
-      is_nil(requested) ->
-        {:ok, conn.assigns.current_vault}
-
-      true ->
-        case Engram.Vaults.get_vault(user, requested) do
-          {:ok, vault} ->
-            api_key = conn.assigns[:current_api_key]
-
-            case Engram.Vaults.check_api_key_access(api_key, vault) do
-              :ok -> {:ok, vault}
-              :forbidden -> {:error, "API key does not have access to vault #{requested}"}
-            end
-
-          _ ->
-            {:ok, conn.assigns.current_vault}
+        if is_nil(requested) or to_string(requested) == to_string(oauth_bound) do
+          Engram.Vaults.get_vault(user, oauth_bound)
+        else
+          {:error,
+           "This connection is bound to vault #{oauth_bound} and cannot access vault " <>
+             "#{requested}. Reconnect with an all-vaults grant (or that vault) to switch."}
         end
+
+      # Unbound (all-vaults OAuth grant or API key): the caller selects per call.
+      is_binary(requested) ->
+        resolve_requested_vault(user, requested, conn)
+
+      # Nothing specified and nothing bound: unambiguous only when the credential
+      # can reach exactly one vault. Consider the ACCESSIBLE set (not every vault
+      # the user owns) so a restricted key with one permitted vault just works.
+      true ->
+        case accessible_vaults(user, conn) do
+          [only] ->
+            {:ok, only}
+
+          [] ->
+            {:error, "No vault found. Sync from Obsidian to create one."}
+
+          _many ->
+            {:error,
+             "You own multiple vaults — specify which one. Call list_vaults to see the IDs, " <>
+               "then pass vault_id on this tool call."}
+        end
+    end
+  end
+
+  defp resolve_requested_vault(user, requested, conn) do
+    case Engram.Vaults.get_vault(user, requested) do
+      {:ok, vault} ->
+        api_key = conn.assigns[:current_api_key]
+
+        case Engram.Vaults.check_api_key_access(api_key, vault) do
+          :ok -> {:ok, vault}
+          :forbidden -> {:error, "API key does not have access to vault #{requested}"}
+        end
+
+      _ ->
+        {:error,
+         "Vault not found: #{requested}. Call list_vaults to see the vault IDs you can use."}
     end
   end
 

--- a/lib/engram_web/controllers/mcp_controller.ex
+++ b/lib/engram_web/controllers/mcp_controller.ex
@@ -219,8 +219,11 @@ defmodule EngramWeb.McpController do
     call_tool(tool, user, accessible_vaults(user, conn), args)
   end
 
-  defp dispatch_tool(%{name: "set_vault"} = tool, user, args, _conn) do
-    call_tool(tool, user, nil, args)
+  defp dispatch_tool(%{name: "set_vault"} = tool, user, args, conn) do
+    # set_vault only validates + echoes, but it MUST respect the credential's
+    # scope — it sees the same accessible set as list_vaults, so a bound token
+    # can't confirm the name/existence of a vault it was scoped away from (#729).
+    call_tool(tool, user, accessible_vaults(user, conn), args)
   end
 
   defp dispatch_tool(tool, user, args, conn) do
@@ -233,16 +236,22 @@ defmodule EngramWeb.McpController do
     end
   end
 
-  # The vaults this credential can actually use: an OAuth-bound token sees only
-  # its bound vault; a restricted API key sees only its permitted vaults; an
-  # unrestricted credential sees all of the user's vaults.
+  # -- Vault resolution --
+
+  # The single source of truth for "which vaults can THIS credential reach":
+  # an OAuth-bound token sees only its bound vault; a restricted API key only
+  # its permitted vaults; an unrestricted credential all of the user's vaults.
+  # Every vault-scope decision (resolve, set_vault, list_vaults) routes through
+  # here so the privacy boundary is enforced in exactly one place.
   defp accessible_vaults(user, conn) do
     oauth_bound = conn.assigns[:oauth_scope_vault_id]
-    api_key = conn.assigns[:current_api_key]
+    # One query for the API key's restricted set, then filter in memory — not a
+    # per-vault DB round-trip.
+    allowed = Engram.Vaults.accessible_vault_ids(conn.assigns[:current_api_key])
 
     Engram.Vaults.list_vaults(user)
     |> maybe_filter_oauth(oauth_bound)
-    |> Enum.filter(&(Engram.Vaults.check_api_key_access(api_key, &1) == :ok))
+    |> filter_api_key(allowed)
   end
 
   defp maybe_filter_oauth(vaults, nil), do: vaults
@@ -250,44 +259,32 @@ defmodule EngramWeb.McpController do
   defp maybe_filter_oauth(vaults, bound) when is_binary(bound),
     do: Enum.filter(vaults, &(to_string(&1.id) == to_string(bound)))
 
-  # -- Vault resolution --
+  defp filter_api_key(vaults, :all), do: vaults
+  defp filter_api_key(vaults, ids), do: Enum.filter(vaults, &(&1.id in ids))
 
   # Resolves which vault a tool call targets. MCP is stateless — there is no
-  # active-vault session — so the vault comes from exactly one of: the OAuth
-  # token's bound vault, an explicit `vault_id` arg, or (only when unambiguous)
-  # the user's single vault. It NEVER silently falls back to the default vault:
-  # doing so is #985, where an AI was fed the wrong vault's data with no error.
+  # active-vault session — so the vault comes from either an explicit `vault_id`
+  # arg or (only when unambiguous) the credential's single reachable vault. It
+  # NEVER silently falls back to the default vault (#985). Both branches decide
+  # against the ACCESSIBLE set, so OAuth binding + API-key scope are enforced
+  # once, here.
   defp resolve_mcp_vault(user, args, conn) do
-    oauth_bound = conn.assigns[:oauth_scope_vault_id]
-    requested = args["vault_id"]
+    accessible = accessible_vaults(user, conn)
 
-    cond do
-      # OAuth token bound to a specific vault: it is authoritative. A matching
-      # (or absent) request is honored; a mismatch is a loud error, not a
-      # silent override.
-      is_binary(oauth_bound) ->
-        if is_nil(requested) or to_string(requested) == to_string(oauth_bound) do
-          Engram.Vaults.get_vault(user, oauth_bound)
-        else
-          {:error,
-           "This connection is bound to vault #{oauth_bound} and cannot access vault " <>
-             "#{requested}. Reconnect with an all-vaults grant (or that vault) to switch."}
+    case args["vault_id"] do
+      requested when is_binary(requested) ->
+        case Enum.find(accessible, &(to_string(&1.id) == to_string(requested))) do
+          nil -> {:error, vault_denied_message(user, requested, conn)}
+          vault -> {:ok, vault}
         end
 
-      # Unbound (all-vaults OAuth grant or API key): the caller selects per call.
-      is_binary(requested) ->
-        resolve_requested_vault(user, requested, conn)
-
-      # Nothing specified and nothing bound: unambiguous only when the credential
-      # can reach exactly one vault. Consider the ACCESSIBLE set (not every vault
-      # the user owns) so a restricted key with one permitted vault just works.
-      true ->
-        case accessible_vaults(user, conn) do
+      _ ->
+        case accessible do
           [only] ->
             {:ok, only}
 
           [] ->
-            {:error, "No vault found. Sync from Obsidian to create one."}
+            {:error, no_vault_message(user)}
 
           _many ->
             {:error,
@@ -297,19 +294,34 @@ defmodule EngramWeb.McpController do
     end
   end
 
-  defp resolve_requested_vault(user, requested, conn) do
-    case Engram.Vaults.get_vault(user, requested) do
-      {:ok, vault} ->
-        api_key = conn.assigns[:current_api_key]
+  # Explains why a requested vault isn't reachable — an OAuth binding, an
+  # API-key restriction, or a genuinely unknown vault — so the caller gets
+  # actionable guidance instead of a flat "not found".
+  defp vault_denied_message(user, requested, conn) do
+    cond do
+      is_binary(conn.assigns[:oauth_scope_vault_id]) ->
+        "This connection is bound to vault #{conn.assigns.oauth_scope_vault_id} and cannot " <>
+          "access vault #{requested}. Reconnect with an all-vaults grant (or that vault) to switch."
 
-        case Engram.Vaults.check_api_key_access(api_key, vault) do
-          :ok -> {:ok, vault}
-          :forbidden -> {:error, "API key does not have access to vault #{requested}"}
-        end
+      match?({:ok, _}, Engram.Vaults.get_vault(user, requested)) ->
+        "API key does not have access to vault #{requested}"
+
+      true ->
+        "Vault not found: #{requested}. Call list_vaults to see the vault IDs you can use."
+    end
+  end
+
+  # Empty accessible set: distinguish "user has no vaults at all" (sync to make
+  # one) from "the credential can reach none of the user's vaults" (a scope /
+  # deleted-vault problem that syncing won't fix).
+  defp no_vault_message(user) do
+    case Engram.Vaults.list_vaults(user) do
+      [] ->
+        "No vault found. Sync from Obsidian to create one."
 
       _ ->
-        {:error,
-         "Vault not found: #{requested}. Call list_vaults to see the vault IDs you can use."}
+        "This connection can't reach any of your vaults — its credential is scoped to a " <>
+          "vault that no longer exists or that it isn't permitted to use."
     end
   end
 

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -14,6 +14,25 @@ defmodule EngramWeb.Router do
     plug EngramWeb.Plugs.RateLimit, limit: 10, period: 60_000
   end
 
+  # Shared auth / abuse / onboarding / rate-limit stack for authenticated API
+  # endpoints. Used by BOTH the vault-scoped REST scope and the MCP scope so a
+  # new security control can't be added to one and silently missed on the other.
+  # Each scope appends its own tail (VaultPlug for REST; OAuthScopeEnforce for
+  # MCP) after this pipeline.
+  pipeline :authed_api do
+    plug EngramWeb.Plugs.PreAuthRateLimit
+    plug EngramWeb.Plugs.Auth
+    plug EngramWeb.Plugs.AccountDeleted
+    plug EngramWeb.Plugs.DeviceFingerprint
+    plug EngramWeb.Plugs.RotationLockCheck
+    plug EngramWeb.Plugs.RequireOnboarding
+    plug EngramWeb.Plugs.RequireActiveSubscription
+    plug EngramWeb.Plugs.BumpActivity
+    plug EngramWeb.Plugs.RequireApiRpsBudget
+    plug EngramWeb.Plugs.EnforceSearchCap
+    plug EngramWeb.Plugs.RequireApiWriteEnabled
+  end
+
   pipeline :require_admin do
     plug EngramWeb.Plugs.RequireAdmin
   end
@@ -331,17 +350,7 @@ defmodule EngramWeb.Router do
     # lib/engram/onboarding.ex).
     pipe_through [
       :api,
-      EngramWeb.Plugs.PreAuthRateLimit,
-      EngramWeb.Plugs.Auth,
-      EngramWeb.Plugs.AccountDeleted,
-      EngramWeb.Plugs.DeviceFingerprint,
-      EngramWeb.Plugs.RotationLockCheck,
-      EngramWeb.Plugs.RequireOnboarding,
-      EngramWeb.Plugs.RequireActiveSubscription,
-      EngramWeb.Plugs.BumpActivity,
-      EngramWeb.Plugs.RequireApiRpsBudget,
-      EngramWeb.Plugs.EnforceSearchCap,
-      EngramWeb.Plugs.RequireApiWriteEnabled,
+      :authed_api,
       EngramWeb.Plugs.VaultPlug,
       # Runs last so both current_user and current_vault are resolved:
       # stamps app.user_id AND app.vault_id on the request span.
@@ -419,17 +428,10 @@ defmodule EngramWeb.Router do
   scope "/api", EngramWeb do
     pipe_through [
       :api,
-      EngramWeb.Plugs.PreAuthRateLimit,
-      EngramWeb.Plugs.Auth,
-      EngramWeb.Plugs.AccountDeleted,
-      EngramWeb.Plugs.DeviceFingerprint,
-      EngramWeb.Plugs.RotationLockCheck,
-      EngramWeb.Plugs.RequireOnboarding,
-      EngramWeb.Plugs.RequireActiveSubscription,
-      EngramWeb.Plugs.BumpActivity,
-      EngramWeb.Plugs.RequireApiRpsBudget,
-      EngramWeb.Plugs.EnforceSearchCap,
-      EngramWeb.Plugs.RequireApiWriteEnabled,
+      :authed_api,
+      # No VaultPlug: McpController self-resolves the vault. TraceUserAttrs still
+      # stamps app.user_id (app.vault_id stays nil — MCP is multi-vault per
+      # connection, so there is no single request-level vault to tag).
       EngramWeb.Plugs.TraceUserAttrs,
       EngramWeb.Plugs.OAuthScopeEnforce
     ]

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -404,14 +404,37 @@ defmodule EngramWeb.Router do
 
     # Embedding status
     get "/embed-status", EmbedStatusController, :index
+  end
 
-    # MCP endpoint (JSON-RPC 2.0 over HTTP POST). OAuthScopeEnforce surfaces
-    # vault_id/scope claims from OAuth-issued JWTs so the controller can lock
-    # tool calls to the bound vault.
-    scope "/" do
-      pipe_through EngramWeb.Plugs.OAuthScopeEnforce
-      post "/mcp", McpController, :handle
-    end
+  # MCP endpoint (JSON-RPC 2.0 over HTTP POST). Same auth / onboarding /
+  # rate-limit stack as the vault-scoped API above, but deliberately WITHOUT
+  # VaultPlug: McpController resolves the target vault itself (from the tool's
+  # vault_id arg or the OAuth scope). VaultPlug would resolve the *default*
+  # vault up front and either 404 the whole request when there is no default
+  # (deleted default vault, #951) or 403 a restricted key whose permitted set
+  # excludes the default — blocking valid clients before the controller's own
+  # credential-scoped resolution (#729) can run. OAuthScopeEnforce surfaces the
+  # vault_id/scope claims from OAuth-issued JWTs so the controller can honor the
+  # bound vault.
+  scope "/api", EngramWeb do
+    pipe_through [
+      :api,
+      EngramWeb.Plugs.PreAuthRateLimit,
+      EngramWeb.Plugs.Auth,
+      EngramWeb.Plugs.AccountDeleted,
+      EngramWeb.Plugs.DeviceFingerprint,
+      EngramWeb.Plugs.RotationLockCheck,
+      EngramWeb.Plugs.RequireOnboarding,
+      EngramWeb.Plugs.RequireActiveSubscription,
+      EngramWeb.Plugs.BumpActivity,
+      EngramWeb.Plugs.RequireApiRpsBudget,
+      EngramWeb.Plugs.EnforceSearchCap,
+      EngramWeb.Plugs.RequireApiWriteEnabled,
+      EngramWeb.Plugs.TraceUserAttrs,
+      EngramWeb.Plugs.OAuthScopeEnforce
+    ]
+
+    post "/mcp", McpController, :handle
   end
 
   # MCP transport is POST-only JSON-RPC (see the authed scope above).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.660",
+      version: "0.5.661",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/mcp/handlers_search_mode_test.exs
+++ b/test/engram/mcp/handlers_search_mode_test.exs
@@ -20,6 +20,36 @@ defmodule Engram.MCP.HandlersSearchModeTest do
     assert vault_id["description"] =~ "ALL your vaults"
   end
 
+  describe "render_search/2 vault attribution (cross-vault mode)" do
+    test "labels each result with its vault when a names map is given" do
+      results =
+        {:ok,
+         [
+           %{score: 0.91, vault_id: "v1", source_path: "Health/A.md", text: "aaa", title: "A"},
+           %{score: 0.82, vault_id: "v2", source_path: "Work/B.md", text: "bbb"}
+         ]}
+
+      {:ok, text} = Handlers.render_search(results, %{"v1" => "Health", "v2" => "Work"})
+
+      assert text =~ "**Vault:** Health (v1)"
+      assert text =~ "**Vault:** Work (v2)"
+    end
+
+    test "single-vault mode (empty names) emits no vault label" do
+      results = {:ok, [%{score: 0.9, vault_id: "v1", source_path: "A.md", text: "x", title: "A"}]}
+
+      {:ok, text} = Handlers.render_search(results, %{})
+
+      refute text =~ "**Vault:**"
+      assert text =~ "**Title:** A"
+    end
+
+    test "empty and error results render human messages" do
+      assert Handlers.render_search({:ok, []}, %{"v1" => "Health"}) == {:ok, "No results found."}
+      assert Handlers.render_search({:error, :boom}, %{}) == {:ok, "Search unavailable."}
+    end
+  end
+
   test "mode arg maps to the Search opt (unknown falls back to hybrid)" do
     assert Handlers.search_mode(%{"mode" => "keyword"}) == :keyword
     assert Handlers.search_mode(%{"mode" => "vector"}) == :vector

--- a/test/engram/mcp/handlers_search_mode_test.exs
+++ b/test/engram/mcp/handlers_search_mode_test.exs
@@ -10,6 +10,16 @@ defmodule Engram.MCP.HandlersSearchModeTest do
     assert tool.inputSchema["properties"]["mode"]["default"] == "hybrid"
   end
 
+  test "search_notes vault_id is an OPTIONAL narrower (searches all vaults by default)" do
+    tool = Enum.find(Tools.list(), &(&1.name == "search_notes"))
+    vault_id = tool.inputSchema["properties"]["vault_id"]
+
+    assert vault_id["type"] == "string"
+    # Not required (unlike navigation/write tools, which need it when multi-vault).
+    refute "vault_id" in (tool.inputSchema["required"] || [])
+    assert vault_id["description"] =~ "ALL your vaults"
+  end
+
   test "mode arg maps to the Search opt (unknown falls back to hybrid)" do
     assert Handlers.search_mode(%{"mode" => "keyword"}) == :keyword
     assert Handlers.search_mode(%{"mode" => "vector"}) == :vector

--- a/test/engram/search_test.exs
+++ b/test/engram/search_test.exs
@@ -590,6 +590,29 @@ defmodule Engram.SearchTest do
                Search.search(user, vault, "query", cross_vault: true)
     end
 
+    test "allow_cross_vault bypasses the billing gate for a free-plan user (MCP path)", %{
+      bypass: bypass,
+      user: user,
+      vault: vault
+    } do
+      # The MCP server makes cross-vault the default on every tier, so it passes
+      # allow_cross_vault: true — a free user must get PAST the gate the web path
+      # still enforces (see the test above).
+      assert user.plan_id == nil
+
+      Engram.MockEmbedder
+      |> expect(:embed_texts, fn _, _ -> {:ok, [List.duplicate(0.1, 3)]} end)
+
+      Bypass.expect_once(bypass, "POST", "/collections/engram_notes/points/query", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, ~s({"result": []}))
+      end)
+
+      result = Search.search(user, vault, "query", cross_vault: true, allow_cross_vault: true)
+      refute result == {:error, :feature_not_available}
+    end
+
     test "cross-vault search proceeds past billing gate when feature enabled (pro plan)", %{
       bypass: bypass,
       vault: vault

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -193,6 +193,102 @@ defmodule EngramWeb.McpControllerTest do
   end
 
   # =========================================================================
+  # Multi-vault selection — regression for #985 (set_vault was cosmetic; reads
+  # silently hit the default vault). The account here owns two vaults.
+  # =========================================================================
+
+  describe "MCP multi-vault selection (#985)" do
+    # Self-contained fresh user (not the single-vault main-setup user, whose
+    # vaults_cap is already resolved at 1). Override is inserted BEFORE any
+    # create_vault so the cap resolves at 10 from the first call.
+    setup do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+
+      {:ok, default} = Engram.Vaults.create_vault(user, %{name: "Personal"})
+      {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "Health"})
+      {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "multi-key")
+      grant_api_write!(user)
+
+      # A note that lives ONLY in the default vault.
+      Engram.Notes.upsert_note(user, default, %{
+        "path" => "Health/Supplements.md",
+        "content" => "# Supplements\n\nOmega 3.",
+        "mtime" => 1_000.0
+      })
+
+      # A note that lives ONLY in vault_b, in a folder the default vault lacks.
+      Engram.Notes.upsert_note(user, vault_b, %{
+        "path" => "Journal/Checkup.md",
+        "content" => "# Checkup\n\nBlood pressure noted.",
+        "mtime" => 1_000.0
+      })
+
+      authed = build_conn() |> put_req_header("authorization", "Bearer #{api_key}")
+      %{conn: authed, user: user, vault_b: vault_b, default: default}
+    end
+
+    test "a read with no vault_id fails loud instead of silently using the default",
+         %{conn: conn} do
+      conn = call_tool(conn, "list_folders")
+      resp = json_response(conn, 200)
+
+      assert resp["result"]["isError"] == true
+      text = resp["result"]["content"] |> hd() |> Map.get("text")
+      assert text =~ "multiple vaults"
+      assert text =~ "list_vaults"
+    end
+
+    test "a read targets the requested non-default vault", %{conn: conn, vault_b: vault_b} do
+      conn = call_tool(conn, "list_folder", %{"folder" => "Journal", "vault_id" => vault_b.id})
+      text = tool_text(conn)
+
+      assert text =~ "Checkup"
+      refute text =~ "Error"
+    end
+
+    test "requesting vault B does NOT leak the default vault's content",
+         %{conn: conn, vault_b: vault_b} do
+      # The default vault has Health/Supplements.md; vault_b has no Health folder.
+      conn = call_tool(conn, "list_folder", %{"folder" => "Health", "vault_id" => vault_b.id})
+      text = tool_text(conn)
+
+      refute text =~ "Supplements"
+    end
+
+    test "requesting the default vault explicitly still returns its content",
+         %{conn: conn, default: default} do
+      conn = call_tool(conn, "list_folder", %{"folder" => "Health", "vault_id" => default.id})
+      text = tool_text(conn)
+
+      assert text =~ "Supplements"
+    end
+
+    test "an unknown vault_id fails loud (no silent default fallback)", %{conn: conn} do
+      conn =
+        call_tool(conn, "list_folder", %{
+          "folder" => "Health",
+          "vault_id" => "00000000-0000-0000-0000-000000000000"
+        })
+
+      resp = json_response(conn, 200)
+      assert resp["result"]["isError"] == true
+      text = resp["result"]["content"] |> hd() |> Map.get("text")
+      assert text =~ "Vault not found"
+    end
+
+    test "list_vaults advertises every vault for an unrestricted credential",
+         %{conn: conn, vault_b: vault_b, default: default} do
+      conn = call_tool(conn, "list_vaults")
+      text = tool_text(conn)
+
+      assert text =~ to_string(vault_b.id)
+      assert text =~ to_string(default.id)
+    end
+  end
+
+  # =========================================================================
   # Read tool tests (no Qdrant needed)
   # =========================================================================
 
@@ -641,6 +737,28 @@ defmodule EngramWeb.McpControllerTest do
 
       text = tool_text(conn)
       # Should succeed (list_vaults doesn't use vault_id arg, but validates it works)
+      refute text =~ "Error:"
+    end
+
+    test "list_vaults advertises only the vaults the restricted key can use (#729)",
+         %{conn: conn, vault_a: vault_a, vault_b: vault_b} do
+      conn = call_tool(conn, "list_vaults")
+      text = tool_text(conn)
+
+      refute text =~ "Error:"
+      assert text =~ to_string(vault_a.id)
+      # vault_b is restricted away — it must NOT announce itself to this key.
+      refute text =~ to_string(vault_b.id)
+    end
+
+    test "restricted key with no vault_id resolves to its single permitted vault",
+         %{conn: conn} do
+      # user owns 2 vaults but the key can reach only vault_a → unambiguous,
+      # so a bare read must succeed (not fail-loud) and hit vault_a.
+      conn = call_tool(conn, "list_folders")
+      text = tool_text(conn)
+
+      refute text =~ "multiple vaults"
       refute text =~ "Error:"
     end
   end

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -159,21 +159,25 @@ defmodule EngramWeb.McpControllerTest do
   end
 
   describe "set_vault tool" do
-    test "without vault_id returns default vault", %{conn: conn} do
+    test "without vault_id explains MCP keeps no active-vault state", %{conn: conn} do
       conn = call_tool(conn, "set_vault")
       text = tool_text(conn)
 
-      assert text =~ "Active vault:"
-      assert text =~ "(default)"
+      # It must NOT claim an active vault was set (MCP is stateless — #985).
+      refute text =~ "Active vault:"
+      assert text =~ "no active-vault state"
+      assert text =~ "list_vaults"
     end
 
-    test "with valid vault_id returns that vault", %{conn: conn, user: user} do
+    test "with valid vault_id validates it and echoes the id to thread",
+         %{conn: conn, user: user} do
       {:ok, vault} = Engram.Vaults.get_default_vault(user)
       conn = call_tool(conn, "set_vault", %{"vault_id" => vault.id})
       text = tool_text(conn)
 
-      assert text =~ "Active vault:"
+      refute text =~ "Active vault:"
       assert text =~ vault.name
+      assert text =~ vault.id
     end
 
     test "with invalid vault_id returns error", %{conn: conn} do
@@ -760,6 +764,17 @@ defmodule EngramWeb.McpControllerTest do
 
       refute text =~ "multiple vaults"
       refute text =~ "Error:"
+    end
+
+    test "set_vault cannot confirm a vault the restricted key can't reach (#729)",
+         %{conn: conn, vault_b: vault_b} do
+      conn = call_tool(conn, "set_vault", %{"vault_id" => vault_b.id})
+      text = tool_text(conn)
+
+      # Refused, and it must not echo vault B as a valid/named vault.
+      assert text =~ "Error:"
+      assert text =~ "not accessible"
+      refute text =~ "is valid"
     end
   end
 

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -835,6 +835,61 @@ defmodule EngramWeb.McpControllerTest do
     end
   end
 
+  # =========================================================================
+  # MCP is not gated by VaultPlug's default-vault resolution. Before MCP got its
+  # own (VaultPlug-free) pipeline, VaultPlug resolved the DEFAULT vault up front
+  # and 403'd a restricted key that couldn't reach the default (#729) or 404'd
+  # the whole request when there was no default (#951) — blocking the
+  # controller's own credential-scoped resolution.
+  # =========================================================================
+
+  describe "MCP reachable without a usable default vault (#729/#951)" do
+    test "a restricted key whose permitted vault is NOT the default still reaches MCP" do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      vault_a = insert(:vault, user: user, is_default: true, name: "A")
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      {:ok, vault_b} = Engram.Vaults.create_vault(user, %{name: "B"})
+      {:ok, api_key, key_rec} = Engram.Accounts.create_api_key(user, "b-only")
+      grant_api_write!(user)
+
+      # Restrict the key to vault B — which is NOT the account default (A).
+      Engram.Repo.insert_all("api_key_vaults", [
+        %{api_key_id: Ecto.UUID.dump!(key_rec.id), vault_id: Ecto.UUID.dump!(vault_b.id)}
+      ])
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", "Bearer #{api_key}")
+        |> call_tool("list_vaults")
+
+      # 200 (not VaultPlug's 403 on the forbidden default), scoped to B only.
+      text = tool_text(conn)
+      assert text =~ to_string(vault_b.id)
+      refute text =~ to_string(vault_a.id)
+    end
+
+    test "list_vaults works when the user has no default vault at all" do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+      v1 = insert(:vault, user: user, is_default: false, name: "One")
+      _v2 = insert(:vault, user: user, is_default: false, name: "Two")
+      {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "k")
+      grant_api_write!(user)
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", "Bearer #{api_key}")
+        |> call_tool("list_vaults")
+
+      # 200 (not VaultPlug's 404 for a dangling/absent default). The discovery
+      # call a client needs to recover is now reachable.
+      text = tool_text(conn)
+      assert text =~ to_string(v1.id)
+    end
+  end
+
   # Helper: rebuild authed conn (since conn is consumed after first request)
   defp build_authed(conn) do
     auth_header =

--- a/test/engram_web/controllers/mcp_controller_test.exs
+++ b/test/engram_web/controllers/mcp_controller_test.exs
@@ -233,7 +233,7 @@ defmodule EngramWeb.McpControllerTest do
       %{conn: authed, user: user, vault_b: vault_b, default: default}
     end
 
-    test "a read with no vault_id fails loud instead of silently using the default",
+    test "a navigation read with no vault_id fails loud instead of silently using the default",
          %{conn: conn} do
       conn = call_tool(conn, "list_folders")
       resp = json_response(conn, 200)
@@ -242,6 +242,23 @@ defmodule EngramWeb.McpControllerTest do
       text = resp["result"]["content"] |> hd() |> Map.get("text")
       assert text =~ "multiple vaults"
       assert text =~ "list_vaults"
+    end
+
+    test "search_notes with no vault_id routes to cross-vault, not the multi-vault guard",
+         %{conn: conn} do
+      # Unlike navigation reads, a bare search spans every vault the credential
+      # can reach. Search execution needs Qdrant/embedder (absent in unit tests),
+      # so the tool errors — but crucially NOT with the navigation fail-loud
+      # guard, which proves it routed INTO search rather than refusing. The
+      # trapped search-unavailable log is expected here and captured.
+      {resp, _log} =
+        ExUnit.CaptureLog.with_log(fn ->
+          call_tool(conn, "search_notes", %{"query" => "anything"}) |> json_response(200)
+        end)
+
+      text = resp["result"]["content"] |> hd() |> Map.get("text")
+      refute text =~ "multiple vaults"
+      refute text =~ "specify which one"
     end
 
     test "a read targets the requested non-default vault", %{conn: conn, vault_b: vault_b} do
@@ -775,6 +792,46 @@ defmodule EngramWeb.McpControllerTest do
       assert text =~ "Error:"
       assert text =~ "not accessible"
       refute text =~ "is valid"
+    end
+  end
+
+  # =========================================================================
+  # Cross-vault search must not leak vaults a restricted credential can't reach.
+  # A key permitted to a >1 SUBSET of the user's vaults cannot cross-vault
+  # search (Qdrant has no multi-vault filter), so it must be told to choose one
+  # rather than silently searching every vault (#729 privacy boundary).
+  # =========================================================================
+
+  describe "cross-vault search privacy for a subset-restricted key" do
+    setup do
+      user = insert(:user)
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+      insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => 10})
+
+      {:ok, va} = Engram.Vaults.create_vault(user, %{name: "A"})
+      {:ok, vb} = Engram.Vaults.create_vault(user, %{name: "B"})
+      {:ok, _vc} = Engram.Vaults.create_vault(user, %{name: "C"})
+
+      {:ok, api_key, key_rec} = Engram.Accounts.create_api_key(user, "subset-key")
+      grant_api_write!(user)
+
+      # Permit the key to A and B only — NOT C. accessible = 2, total = 3.
+      Engram.Repo.insert_all("api_key_vaults", [
+        %{api_key_id: Ecto.UUID.dump!(key_rec.id), vault_id: Ecto.UUID.dump!(va.id)},
+        %{api_key_id: Ecto.UUID.dump!(key_rec.id), vault_id: Ecto.UUID.dump!(vb.id)}
+      ])
+
+      %{conn: build_conn() |> put_req_header("authorization", "Bearer #{api_key}")}
+    end
+
+    test "bare search on a >1 vault subset refuses to cross-vault (asks to choose)",
+         %{conn: conn} do
+      conn = call_tool(conn, "search_notes", %{"query" => "anything"})
+      resp = json_response(conn, 200)
+      text = resp["result"]["content"] |> hd() |> Map.get("text")
+
+      assert resp["result"]["isError"] == true
+      assert text =~ "limited to specific vaults"
     end
   end
 

--- a/test/engram_web/controllers/mcp_oauth_scope_test.exs
+++ b/test/engram_web/controllers/mcp_oauth_scope_test.exs
@@ -106,12 +106,46 @@ defmodule EngramWeb.McpOAuthScopeTest do
     assert response_text <> error_msg =~ "bound to vault"
   end
 
-  test "unscoped internal JWT (no vault_id claim) keeps existing behavior", %{
+  test "OAuth-bound token cannot confirm a vault outside its binding via set_vault (#729)", %{
     conn: conn,
-    user: user
+    user: user,
+    vault_a: vault_a,
+    vault_b: vault_b
   } do
-    conn = conn |> unscoped_jwt(user) |> call_tool("list_folders", %{})
+    conn =
+      conn
+      |> oauth_authed(user, vault_a.id)
+      |> call_tool("set_vault", %{"vault_id" => vault_b.id})
+
     body = json_response(conn, 200)
-    refute Map.has_key?(body, "error")
+    text = body["result"]["content"] |> Kernel.||([]) |> Enum.map_join(" ", & &1["text"])
+
+    # Must be refused and must NOT echo vault B as valid — it was scoped away.
+    assert body["result"]["isError"] == true
+    refute text =~ "is valid"
+  end
+
+  test "all-vaults grant (no vault_id claim) with multiple vaults must specify a vault", %{
+    conn: conn,
+    user: user,
+    vault_a: vault_a
+  } do
+    # A vault:* / unscoped token over 2 vaults is ambiguous — fail loud instead
+    # of silently defaulting (#985), and succeed once a vault is named.
+    ambiguous =
+      conn |> unscoped_jwt(user) |> call_tool("list_folders", %{}) |> json_response(200)
+
+    text = ambiguous["result"]["content"] |> Kernel.||([]) |> Enum.map_join(" ", & &1["text"])
+    assert ambiguous["result"]["isError"] == true
+    assert text =~ "multiple vaults"
+
+    named =
+      build_conn()
+      |> unscoped_jwt(user)
+      |> call_tool("list_folders", %{"vault_id" => vault_a.id})
+      |> json_response(200)
+
+    refute Map.has_key?(named, "error")
+    refute named["result"]["isError"] == true
   end
 end


### PR DESCRIPTION
## Problem

**#985 (P0):** MCP `set_vault` was cosmetic. MCP is stateless HTTP JSON-RPC, so it persisted nothing; no tool advertised `vault_id`; and vault resolution silently fell back to the default vault, so a caller scoped to a non-default vault got default-vault data with **no error**.

**#729:** `list_vaults` advertised vaults the credential couldn't use; a restricted key excluding the default vault was 403'd before scoping ran.

**#951:** deleting the default vault 404'd every MCP call including `list_vaults` — no recovery path.

## What changed

- **Search fans out by default:** a bare `search_notes` searches across all vaults the credential can reach (all tiers via MCP; web keeps the Pro gate), each hit labelled with its vault. Pass `vault_id` to narrow.
- **Everything else is explicit + scoped:** optional `vault_id` on every vault-scoped tool; navigation/writes fail loud on multi-vault ambiguity instead of silent-defaulting; a single accessible vault is used unambiguously.
- **`accessible_vaults` is the single scope choke point** (resolve + search + set_vault + list_vaults) — OAuth binding + API-key restrictions enforced in one place; `list_vaults`/`set_vault` never advertise/confirm a vault the credential can't reach.
- **MCP is off the VaultPlug pipeline:** the controller self-resolves the vault, so MCP no longer gets VaultPlug's default-vault 403 (restricted key) / 404 (no default). Fixes the #729 restricted-key lockout and makes #951 recovery reachable.

## Privacy

Cross-vault search (Qdrant, no vault filter) sees every vault the user owns, so it only runs when the credential can already reach all of them; a restricted key reaching a >1 subset is told to pass `vault_id` rather than leaking vaults it can't see.

## Behavior change

Navigation/write calls with no `vault_id` on a multi-vault account now return a clear "specify which vault" prompt instead of silently hitting the default. (Search does not — it spans everything.) Cross-vault search is free on the MCP path (product decision).

## Not in this PR

The fate of the `is_default` flag is a separate decision; rationale + options in `docs/context/mcp-vault-selection.md`.

## Tests

MCP suite (67) + full backend suite (3592) green. Two high-effort code reviews + a coverage pass folded in: perf (single-vault lookup on resolve, no per-call decrypt-all), DRY (`accessible_vault_ids`), cross-vault attribution + billing-bypass unit tests, and VaultPlug-recovery tests. format + credo + sobelow clean.

Closes #985
Closes #729
Refs #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)