### PR TITLE
fix(crdt): guard WS sync channel against state-vector NIF DoS (P0 #989)

### DIFF
--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -76,13 +76,45 @@ defmodule Engram.Notes.CrdtTransport do
   # wire (a 0 still costs 1 byte per varUint), so a vector claiming N clients
   # must have at least 2*N bytes left after the count header — anything
   # short of that is rejected without ever calling the NIF.
+  @doc """
+  True when `sv` is a plausibly-sized y-protocols v1 state vector — the
+  declared client count is backed by enough remaining bytes. Guards the y_ex
+  NIF against a crafted vector whose count would trigger a ~150 GB pre-alloc
+  and `abort()` the whole VM. Public so the WS sync channel reuses the exact
+  same check via `safe_wire_frame?/1` (P0 #989).
+  """
   @spec plausible_state_vector?(binary()) :: boolean()
-  defp plausible_state_vector?(sv) do
+  def plausible_state_vector?(sv) do
     case read_leb128_varuint(sv) do
       {:ok, count, rest} -> byte_size(rest) >= count * 2
       :error -> false
     end
   end
+
+  @doc """
+  True when a decoded Yjs sync frame is safe to hand to the y_ex NIF.
+
+  A syncStep1 frame is `<<0, 0, varUint8Array(state_vector)>>`; its embedded
+  client state vector flows into `Yex.encode_state_as_update/2` — the same
+  crash path `read_delta/4` guards. This unwraps the length-prefixed vector
+  and validates it with `plausible_state_vector?/1`, rejecting a crafted or
+  malformed step1 BEFORE it reaches the NIF. Non-step1 frames (step2 / update
+  route through `apply_update`, not the vector path) are always allowed here;
+  a step1 with a malformed length prefix fails closed.
+  """
+  @spec safe_wire_frame?(binary()) :: boolean()
+  def safe_wire_frame?(<<0, 0, rest::binary>>) do
+    case read_leb128_varuint(rest) do
+      {:ok, sv_len, payload} when byte_size(payload) >= sv_len ->
+        <<sv::binary-size(sv_len), _::binary>> = payload
+        plausible_state_vector?(sv)
+
+      _ ->
+        false
+    end
+  end
+
+  def safe_wire_frame?(_frame), do: true
 
   # LEB128 varuint reader, capped at 10 continuation bytes (enough for any
   # 64-bit value) so a run of 0x80 bytes can't loop unbounded either.

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -17,6 +17,7 @@ defmodule EngramWeb.CrdtChannel do
   alias Engram.Logger.Metadata
   alias Engram.{Notes, Vaults}
   alias Engram.Notes.CrdtRegistry
+  alias Engram.Notes.CrdtTransport
   alias Yex.Sync.SharedDoc
 
   require Logger
@@ -118,12 +119,19 @@ defmodule EngramWeb.CrdtChannel do
     # cost, never at MB-scale decode cost.
     with :ok <- check_rate(socket, frame_class_b64(b64)),
          {:ok, frame} <- decode_frame(b64),
+         :ok <- guard_frame(frame),
          {:ok, socket, %{room: room}} <- ensure_room(socket, doc_id) do
       SharedDoc.send_yjs_message(room, frame)
       {:noreply, socket}
     else
       {:error, :rate_limited} ->
         {:reply, {:error, %{reason: "rate_limited"}}, socket}
+
+      {:error, :implausible_state_vector} ->
+        # A crafted syncStep1 whose state vector would OOM-abort the whole VM
+        # in the y_ex NIF (P0 #989). Rejected before it reaches SharedDoc.
+        log_dropped(socket, doc_id, :implausible_state_vector)
+        {:reply, {:error, %{reason: "implausible_state_vector"}}, socket}
 
       {:error, :frame_too_large} ->
         log_dropped(socket, doc_id, :frame_too_large)
@@ -303,6 +311,15 @@ defmodule EngramWeb.CrdtChannel do
       {:ok, frame} -> {:ok, frame}
       :error -> {:error, :bad_base64}
     end
+  end
+
+  # A syncStep1 frame carries a client state vector that reaches the y_ex NIF
+  # (SharedDoc.send_yjs_message -> encode_state_as_update). A crafted vector
+  # OOM-aborts the ENTIRE BEAM node, uncatchable — reuse the REST transport's
+  # plausibility guard to reject it before it is applied (P0 #989). Non-step1
+  # frames pass through unchanged.
+  defp guard_frame(frame) do
+    if CrdtTransport.safe_wire_frame?(frame), do: :ok, else: {:error, :implausible_state_vector}
   end
 
   # Lazily start + observe the room for `doc_id`, caching it in assigns. On the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.661",
+      version: "0.5.662",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_transport_test.exs
+++ b/test/engram/notes/crdt_transport_test.exs
@@ -189,4 +189,44 @@ defmodule Engram.Notes.CrdtTransportTest do
       assert heads1[b.id] == heads0[b.id], "untouched note's head must be stable"
     end
   end
+
+  describe "safe_wire_frame?/1 (P0 #989 — WS state-vector DoS guard)" do
+    test "non-step1 frames are always allowed (step2, update, non-sync)" do
+      assert CrdtTransport.safe_wire_frame?(<<0, 1, 5>>), "syncStep2"
+      assert CrdtTransport.safe_wire_frame?(<<0, 2, 9>>), "update"
+      assert CrdtTransport.safe_wire_frame?(<<7, 7, 7>>), "not a sync message"
+    end
+
+    test "a real step1 frame built by the library's own encoder is allowed" do
+      # Build the frame through y_ex's OWN encoder rather than hand-rolling the
+      # varUint8Array prefix, so this pins the guard's length-prefix unwrap to
+      # the actual library wire format — a future format drift breaks this test
+      # instead of silently diverging. message_encode is a pure NIF (no
+      # allocation bomb).
+      sv = Yex.encode_state_vector!(CrdtBridge.new_doc())
+      {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_step1, sv}})
+      assert <<0, 0, _::binary>> = frame
+      assert CrdtTransport.safe_wire_frame?(frame)
+    end
+
+    test "a step1 with a crafted implausible state vector is rejected (never reaches the NIF)" do
+      # DELIBERATELY DETERMINISTIC: <<128, 128, 128, 128, 15>> decodes as a
+      # vector claiming ~2^31 client entries in 5 bytes. Random bytes here have
+      # crashed the whole VM in the past; safe_wire_frame?/1 must reject via
+      # pure byte math, never handing this to Yex.encode_state_as_update/2.
+      malicious_sv = <<128, 128, 128, 128, 15>>
+      frame = <<0, 0, byte_size(malicious_sv)>> <> malicious_sv
+      refute CrdtTransport.safe_wire_frame?(frame)
+    end
+
+    test "a step1 whose length prefix claims more bytes than are present is rejected" do
+      # Claims a 10-byte state vector but only 2 bytes follow the prefix.
+      refute CrdtTransport.safe_wire_frame?(<<0, 0, 10, 1, 2>>)
+    end
+
+    test "a bare or empty-vector step1 fails closed" do
+      refute CrdtTransport.safe_wire_frame?(<<0, 0>>)
+      refute CrdtTransport.safe_wire_frame?(<<0, 0, 0>>)
+    end
+  end
 end

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -238,6 +238,25 @@ defmodule EngramWeb.CrdtChannelTest do
       assert CrdtRegistry.lookup(note.id) == nil
     end
 
+    test "a crafted syncStep1 with an implausible state vector is rejected before the NIF (P0 #989)",
+         %{socket: socket, doc_id: doc_id, note: note} do
+      # <<0, 0>> step1 + varUint8Array(<<128, 128, 128, 128, 15>>): a 5-byte
+      # state vector claiming ~2^31 client entries. Reaching the y_ex NIF
+      # (Yex.encode_state_as_update/2) would OOM-abort the ENTIRE node,
+      # uncatchable. The guard must reject it with an error reply and never
+      # start the room / touch the NIF. Deterministic bytes only — a random SV
+      # here has crashed the VM before.
+      malicious = <<0, 0, 5, 128, 128, 128, 128, 15>>
+
+      ref = push(socket, "crdt_msg", %{"doc_id" => doc_id, "b64" => Base.encode64(malicious)})
+
+      assert_reply ref, :error, %{reason: "implausible_state_vector"}, 3000
+
+      # Rejected before ensure_room, so the room never started and the frame
+      # never reached SharedDoc.send_yjs_message / the NIF.
+      assert CrdtRegistry.lookup(note.id) == nil
+    end
+
     # -------------------------------------------------------------------------
     # Log hygiene: doc_id (note_id) must appear in metadata, not the message body
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## P0: WS state-vector NIF DoS (#989)

Closes #989.

A crafted Yjs **syncStep1** frame on the `crdt:` channel carries a client state vector that flows into the `y_ex` NIF (`SharedDoc.send_yjs_message` → `encode_sync_step1_response_v1` → `StateVector::decode_v1`). A vector whose declared client count is unbacked by bytes (e.g. `<<128,128,128,128,15>>`, ~2³¹ entries in 5 bytes) makes yrs pre-allocate ~150 GB; the Rust OOM handler calls `abort()` → **the entire BEAM node dies**, uncatchable by `try/rescue`, taking down every user and connection. Any authenticated client can trigger it with a ~5-byte payload.

The REST transport was guarded in Phase 1 (#990); the live WS channel was still exposed.

## Fix

Reuse Phase 1's plausibility check on the WS path:
- Expose `CrdtTransport.plausible_state_vector?/1` and add `safe_wire_frame?/1` — it matches a step1 frame `<<0, 0, rest>>`, unwraps the `varUint8Array` length prefix (the same LEB128 `read_buf` the NIF applies), and validates the inner state vector. Non-step1 frames (step2 / update route to `apply_update`, not the vector path) and malformed/oversized-prefix step1 frames fail closed.
- Gate every `crdt_msg` in `CrdtChannel` with `:ok <- guard_frame(frame)` **before** `ensure_room` / `SharedDoc.send_yjs_message`, so an implausible frame is rejected (`implausible_state_vector` reply) and never reaches the NIF.

## Why the guard is byte-exact (parser-differential verified)

The guard must validate the *same* slice the NIF consumes. Traced end to end and confirmed against the Rust NIF (`deps/y_ex/native/yex/src/sync.rs`): `encode_sync_step1_response_v1` does `read_buf()` (unwrap the varUint8Array prefix) then `StateVector::decode_v1(sv_bytes)` — the exact inner slice `safe_wire_frame?/1` validates. The decode doctest (`message_decode(<<0,0,1,0>>) → {:sync_step1, <<0>>}`) locks the wire format. Same slice, same decode, guard fires first — no differential.

## Tests

Deterministic bytes only (a random SV has crashed the VM). 6 tests, all green:
- 5 unit tests on `safe_wire_frame?/1` (pure byte-math, never touches the NIF): non-step1 allowed; a real library-encoded step1 allowed (pins the unwrap to y_ex's own wire format); crafted implausible SV rejected; oversized length prefix rejected; bare/empty step1 fails closed.
- 1 channel test: a crafted step1 → `implausible_state_vector` error reply **and the room was never started** (`CrdtRegistry.lookup(note.id) == nil`), proving the frame never reached the NIF.

Transport 15/0, channel 25/0, credo/format/sobelow clean. Independent adversarial security review: no concatenation-frame bypass, no other unguarded inbound SV path, fails closed on all boundaries without rejecting legit frames — MERGE-READY.

## Follow-up (separate, not blocking)

The `apply_update` path (step2/update → `Update::decode_v1`) is a *plausible sibling* over-allocation DoS — different decode path, out of scope for #989 (state vector). Worth its own assessment; I'll file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
