### PR TITLE
fix(crdt): cheap vault_heads + per-socket room cap (sync memory hardening)

### DIFF
--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -115,7 +115,9 @@ defmodule Engram.Notes.CrdtPersistence do
           # tail = authoritative), so we never trust an off-by-one head. Guard on
           # not-nil so an already-invalidated hot note skips the write. Sets ONLY
           # crdt_head — no updated_at/version/seq churn (checkpoint owns those).
-          from(n in Note, where: n.id == ^note_id and not is_nil(n.crdt_head))
+          from(n in Note,
+            where: n.id == ^note_id and n.kind == "note" and not is_nil(n.crdt_head)
+          )
           |> Repo.update_all(set: [crdt_head: nil])
         end)
 

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -108,6 +108,15 @@ defmodule Engram.Notes.CrdtPersistence do
             update_nonce: nonce
           })
           |> Repo.insert!()
+
+          # Invalidate the cached head in the SAME txn as the tail append: this
+          # update advanced the doc, so any stored crdt_head is now stale.
+          # vault_heads self-heals the NULL by rebuilding once (snapshot + full
+          # tail = authoritative), so we never trust an off-by-one head. Guard on
+          # not-nil so an already-invalidated hot note skips the write. Sets ONLY
+          # crdt_head — no updated_at/version/seq churn (checkpoint owns those).
+          from(n in Note, where: n.id == ^note_id and not is_nil(n.crdt_head))
+          |> Repo.update_all(set: [crdt_head: nil])
         end)
 
       {:error, reason} ->

--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -16,7 +16,7 @@ defmodule Engram.Notes.CrdtTransport do
 
   alias Engram.{Crypto, Notes, Repo}
   alias Engram.Logger.Metadata
-  alias Engram.Notes.{CrdtBridge, CrdtPersistence, CrdtRegistry, Note}
+  alias Engram.Notes.{CrdtBridge, CrdtPersistence, CrdtRegistry, CrdtUpdateLog, Note}
   alias Yex.Sync.SharedDoc
 
   require Logger
@@ -224,28 +224,104 @@ defmodule Engram.Notes.CrdtTransport do
   @doc """
   Map every note in the vault to its head marker so a client can diff against
   its local per-note heads and learn which cold notes advanced.
+
+  Reads the persisted `crdt_head` column — O(notes) cheap row reads, NO doc
+  rebuilds. The column is NULLed on every CRDT-state change (`update_v1` on a
+  tail append; a `crdt_state_ciphertext` trigger on any snapshot write), and a
+  NULL is self-healed once here via `backfill_head/3`; the `BackfillCrdtHead`
+  worker warms NULLs in the background so a live poll rarely pays that cost. So
+  steady-state cost is O(notes changed since the last poll), not O(vault).
   """
   @spec vault_heads(map(), map()) :: %{String.t() => String.t()}
   def vault_heads(user, vault) do
-    # ponytail: rebuilds every note's doc read-only — O(notes) NIF work per call,
-    # and read_delta also decrypts each note's content it then discards. NO client
-    # polls this in Phase 1; it is dormant until Phase 3. Upgrade path (spec open
-    # Q#1): persist a `crdt_head` column updated in update_v1/checkpoint, or ETag
-    # the index, before any client polls it at scale.
-    {:ok, ids} =
+    {:ok, rows} =
       Repo.with_tenant(user.id, fn ->
         Note
         |> where(
           [n],
           n.vault_id == ^vault.id and n.user_id == ^user.id and is_nil(n.deleted_at)
         )
-        |> select([n], n.id)
+        |> select([n], {n.id, n.crdt_head})
         |> Repo.all()
       end)
 
-    Map.new(ids, fn note_id ->
-      {:ok, %{head: head}} = read_delta(user, vault, note_id, nil)
-      {note_id, head}
+    Enum.reduce(rows, %{}, fn
+      {note_id, nil}, acc ->
+        case backfill_head(user, vault, note_id) do
+          {:ok, head} -> Map.put(acc, note_id, head)
+          {:error, :not_found} -> acc
+        end
+
+      {note_id, head}, acc ->
+        Map.put(acc, note_id, head)
+    end)
+  end
+
+  @doc """
+  Rebuild a note's doc once, compute its head marker, persist it to the
+  `crdt_head` column, and return it. The self-heal path for a NULL column
+  (pre-migration notes, or notes never CRDT-written since the column landed).
+
+  Shared by `vault_heads/2`' inline self-heal and the `BackfillCrdtHead` worker
+  so the O(doc-rebuild) cost is paid at most once per note. The head equals what
+  `read_delta/4` computes for the same state (both are sha256 of the same state
+  vector), so self-healed heads never disagree with the transport's own.
+
+  CONCURRENCY: the tail high-watermark is snapshotted BEFORE the rebuild, and
+  the write is a compare-and-set (`store_head_if_unchanged/4`). A room edit that
+  lands after this reads the tail appends a row and — finding `crdt_head` already
+  NULL — no-op-invalidates; without the CAS this self-heal could clobber that
+  NULL with a now-stale head (silent missed cold-sync). If the tail advanced, we
+  leave the column NULL and the next poll re-heals. Returns `{:error, :not_found}`
+  if the note was deleted between selection and rebuild.
+  """
+  @spec backfill_head(map(), map(), String.t()) :: {:ok, String.t()} | {:error, :not_found}
+  def backfill_head(user, vault, note_id) do
+    watermark = tail_watermark(user, note_id)
+
+    case load_doc(user, vault, note_id) do
+      {:ok, doc} ->
+        head = head_marker(doc)
+        store_head_if_unchanged(user, note_id, head, watermark)
+        {:ok, head}
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  # Latest tail-row id for the note (uuidv7 → time-ordered, unique, monotonic on
+  # append; falls to a lower value / '' on prune). Captured BEFORE the rebuild so
+  # store_head_if_unchanged can detect a tail that advanced under it.
+  defp tail_watermark(user, note_id) do
+    {:ok, wm} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.one(
+          from l in CrdtUpdateLog,
+            where: l.note_id == ^note_id,
+            select: fragment("coalesce(max(?::text), '')", l.id)
+        )
+      end)
+
+    wm
+  end
+
+  # Persist the head ONLY if the column is still NULL (don't overwrite a peer
+  # self-heal) AND the tail hasn't advanced since `watermark` was taken (don't
+  # persist a head computed from a now-stale tail). A losing CAS leaves NULL for
+  # the next poll — bounded one-poll staleness instead of a persisted stale head.
+  defp store_head_if_unchanged(user, note_id, head, watermark) do
+    Repo.with_tenant(user.id, fn ->
+      from(n in Note,
+        where:
+          n.id == ^note_id and is_nil(n.crdt_head) and
+            fragment(
+              "(SELECT coalesce(max(id::text), '') FROM crdt_update_log WHERE note_id = ?) = ?",
+              n.id,
+              ^watermark
+            )
+      )
+      |> Repo.update_all(set: [crdt_head: head])
     end)
   end
 

--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -290,10 +290,14 @@ defmodule Engram.Notes.CrdtTransport do
     end
   end
 
-  # Latest tail-row id for the note (uuidv7 → time-ordered, unique, monotonic on
-  # append; falls to a lower value / '' on prune). Captured BEFORE the rebuild so
-  # store_head_if_unchanged can detect a tail that advanced under it.
-  defp tail_watermark(user, note_id) do
+  @doc """
+  Latest tail-row id for the note (uuidv7 → time-ordered, unique, monotonic on
+  append; falls to a lower value / '' on prune). Captured BEFORE a rebuild so
+  `store_head_if_unchanged/4` can detect a tail that advanced under it. Public
+  for the CAS regression tests.
+  """
+  @spec tail_watermark(map(), String.t()) :: String.t()
+  def tail_watermark(user, note_id) do
     {:ok, wm} =
       Repo.with_tenant(user.id, fn ->
         Repo.one(
@@ -306,11 +310,17 @@ defmodule Engram.Notes.CrdtTransport do
     wm
   end
 
-  # Persist the head ONLY if the column is still NULL (don't overwrite a peer
-  # self-heal) AND the tail hasn't advanced since `watermark` was taken (don't
-  # persist a head computed from a now-stale tail). A losing CAS leaves NULL for
-  # the next poll — bounded one-poll staleness instead of a persisted stale head.
-  defp store_head_if_unchanged(user, note_id, head, watermark) do
+  @doc """
+  Persist the head ONLY if the column is still NULL (don't overwrite a peer
+  self-heal) AND the tail hasn't advanced since `watermark` was taken (don't
+  persist a head computed from a now-stale tail). A losing CAS leaves NULL for
+  the next poll — bounded one-poll staleness instead of a persisted stale head.
+  Returns `{:ok, {count, nil}}` (count is 0 when the CAS rejects). Public for
+  the CAS regression tests.
+  """
+  @spec store_head_if_unchanged(map(), String.t(), String.t(), String.t()) ::
+          {:ok, {non_neg_integer(), nil}}
+  def store_head_if_unchanged(user, note_id, head, watermark) do
     Repo.with_tenant(user.id, fn ->
       from(n in Note,
         where:

--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -239,7 +239,8 @@ defmodule Engram.Notes.CrdtTransport do
         Note
         |> where(
           [n],
-          n.vault_id == ^vault.id and n.user_id == ^user.id and is_nil(n.deleted_at)
+          n.vault_id == ^vault.id and n.user_id == ^user.id and is_nil(n.deleted_at) and
+            n.kind == "note"
         )
         |> select([n], {n.id, n.crdt_head})
         |> Repo.all()
@@ -325,7 +326,7 @@ defmodule Engram.Notes.CrdtTransport do
     Repo.with_tenant(user.id, fn ->
       from(n in Note,
         where:
-          n.id == ^note_id and is_nil(n.crdt_head) and
+          n.id == ^note_id and n.kind == "note" and is_nil(n.crdt_head) and
             fragment(
               "(SELECT coalesce(max(id::text), '') FROM crdt_update_log WHERE note_id = ?) = ?",
               n.id,

--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -274,15 +274,19 @@ defmodule Engram.Notes.CrdtTransport do
   NULL with a now-stale head (silent missed cold-sync). If the tail advanced, we
   leave the column NULL and the next poll re-heals. Returns `{:error, :not_found}`
   if the note was deleted between selection and rebuild.
+
+  No @spec: the `BackfillCrdtHead` worker calls this with concrete
+  `%User{}`/`%Vault{}`, so a hand-written `map()/map()` contract is a supertype
+  of what Dialyzer infers (contract_supertype) — same reason `load_doc/3` omits
+  its spec.
   """
-  @spec backfill_head(map(), map(), String.t()) :: {:ok, String.t()} | {:error, :not_found}
   def backfill_head(user, vault, note_id) do
     watermark = tail_watermark(user, note_id)
 
     case load_doc(user, vault, note_id) do
       {:ok, doc} ->
         head = head_marker(doc)
-        store_head_if_unchanged(user, note_id, head, watermark)
+        _ = store_head_if_unchanged(user, note_id, head, watermark)
         {:ok, head}
 
       {:error, :not_found} ->
@@ -294,9 +298,8 @@ defmodule Engram.Notes.CrdtTransport do
   Latest tail-row id for the note (uuidv7 → time-ordered, unique, monotonic on
   append; falls to a lower value / '' on prune). Captured BEFORE a rebuild so
   `store_head_if_unchanged/4` can detect a tail that advanced under it. Public
-  for the CAS regression tests.
+  for the CAS regression tests. (No @spec — see backfill_head/3.)
   """
-  @spec tail_watermark(map(), String.t()) :: String.t()
   def tail_watermark(user, note_id) do
     {:ok, wm} =
       Repo.with_tenant(user.id, fn ->
@@ -316,10 +319,8 @@ defmodule Engram.Notes.CrdtTransport do
   persist a head computed from a now-stale tail). A losing CAS leaves NULL for
   the next poll — bounded one-poll staleness instead of a persisted stale head.
   Returns `{:ok, {count, nil}}` (count is 0 when the CAS rejects). Public for
-  the CAS regression tests.
+  the CAS regression tests. (No @spec — see backfill_head/3.)
   """
-  @spec store_head_if_unchanged(map(), String.t(), String.t(), String.t()) ::
-          {:ok, {non_neg_integer(), nil}}
   def store_head_if_unchanged(user, note_id, head, watermark) do
     Repo.with_tenant(user.id, fn ->
       from(n in Note,

--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -68,6 +68,16 @@ defmodule Engram.Notes.Note do
     field :crdt_state_ciphertext, :binary
     field :crdt_state_nonce, :binary
 
+    # Head marker of the canonical CRDT doc: sha256(state_vector) url-b64 (see
+    # CrdtTransport.head_marker/1). INVALIDATE-and-self-heal, not maintained: it
+    # is NULLed on every CRDT-state change (update_v1 on a tail append; a DB
+    # trigger on any crdt_state_ciphertext write), and vault_heads self-heals a
+    # NULL by rebuilding the doc once and storing the result — so a non-NULL
+    # value is a lazily-cached head, refreshed on the next poll after any edit.
+    # BackfillCrdtHead warms existing NULLs. Not encrypted: a hash of clock
+    # counts carries no note content.
+    field :crdt_head, :string
+
     field :type_ciphertext, :binary
     field :type_nonce, :binary
     field :type_hmac, :binary

--- a/lib/engram/workers/backfill_crdt_head.ex
+++ b/lib/engram/workers/backfill_crdt_head.ex
@@ -44,7 +44,7 @@ defmodule Engram.Workers.BackfillCrdtHead do
   def enqueue_all do
     pairs =
       from(n in Note,
-        where: is_nil(n.crdt_head) and is_nil(n.deleted_at),
+        where: n.kind == "note" and is_nil(n.crdt_head) and is_nil(n.deleted_at),
         group_by: [n.user_id, n.vault_id],
         select: {n.user_id, n.vault_id}
       )
@@ -95,8 +95,8 @@ defmodule Engram.Workers.BackfillCrdtHead do
       Repo.with_tenant(user.id, fn ->
         from(n in Note,
           where:
-            n.vault_id == ^vault.id and n.id > ^cursor and is_nil(n.crdt_head) and
-              is_nil(n.deleted_at),
+            n.vault_id == ^vault.id and n.kind == "note" and n.id > ^cursor and
+              is_nil(n.crdt_head) and is_nil(n.deleted_at),
           order_by: [asc: n.id],
           select: n.id,
           limit: ^limit

--- a/lib/engram/workers/backfill_crdt_head.ex
+++ b/lib/engram/workers/backfill_crdt_head.ex
@@ -109,9 +109,10 @@ defmodule Engram.Workers.BackfillCrdtHead do
     Enum.each(ids, fn id -> CrdtTransport.backfill_head(user, vault, id) end)
 
     if length(ids) == limit do
-      %{"user_id" => user.id, "vault_id" => vault.id, "cursor" => List.last(ids)}
-      |> __MODULE__.new()
-      |> Oban.insert()
+      _ =
+        %{"user_id" => user.id, "vault_id" => vault.id, "cursor" => List.last(ids)}
+        |> __MODULE__.new()
+        |> Oban.insert()
     end
 
     :ok

--- a/lib/engram/workers/backfill_crdt_head.ex
+++ b/lib/engram/workers/backfill_crdt_head.ex
@@ -108,12 +108,15 @@ defmodule Engram.Workers.BackfillCrdtHead do
     # it is called outside the batch-select transaction, once per note.
     Enum.each(ids, fn id -> CrdtTransport.backfill_head(user, vault, id) end)
 
-    if length(ids) == limit do
-      _ =
+    # A full batch means more remain — re-enqueue the next cursor. Bind the whole
+    # `if` (it yields the insert result or nil) so its value isn't a discarded
+    # non-trivial return (:unmatched_returns).
+    _ =
+      if length(ids) == limit do
         %{"user_id" => user.id, "vault_id" => vault.id, "cursor" => List.last(ids)}
         |> __MODULE__.new()
         |> Oban.insert()
-    end
+      end
 
     :ok
   end

--- a/lib/engram/workers/backfill_crdt_head.ex
+++ b/lib/engram/workers/backfill_crdt_head.ex
@@ -31,8 +31,13 @@ defmodule Engram.Workers.BackfillCrdtHead do
   alias Engram.Repo
   alias Engram.Vaults
 
-  @batch_size 100
+  @default_batch_size 100
   @start_cursor "00000000-0000-0000-0000-000000000000"
+
+  # Config-overridable so a test can exercise the cursor re-enqueue loop without
+  # inserting @default_batch_size+1 notes. Prod uses the default.
+  defp batch_size,
+    do: Application.get_env(:engram, :crdt_head_backfill_batch_size, @default_batch_size)
 
   @doc "Enqueue one job per (user, vault) that still has a NULL-crdt_head note. Returns the count."
   @spec enqueue_all() :: non_neg_integer()
@@ -84,6 +89,8 @@ defmodule Engram.Workers.BackfillCrdtHead do
   end
 
   defp backfill_batch(user, vault, cursor) do
+    limit = batch_size()
+
     {:ok, ids} =
       Repo.with_tenant(user.id, fn ->
         from(n in Note,
@@ -92,7 +99,7 @@ defmodule Engram.Workers.BackfillCrdtHead do
               is_nil(n.deleted_at),
           order_by: [asc: n.id],
           select: n.id,
-          limit: @batch_size
+          limit: ^limit
         )
         |> Repo.all()
       end)
@@ -101,7 +108,7 @@ defmodule Engram.Workers.BackfillCrdtHead do
     # it is called outside the batch-select transaction, once per note.
     Enum.each(ids, fn id -> CrdtTransport.backfill_head(user, vault, id) end)
 
-    if length(ids) == @batch_size do
+    if length(ids) == limit do
       %{"user_id" => user.id, "vault_id" => vault.id, "cursor" => List.last(ids)}
       |> __MODULE__.new()
       |> Oban.insert()

--- a/lib/engram/workers/backfill_crdt_head.ex
+++ b/lib/engram/workers/backfill_crdt_head.ex
@@ -1,0 +1,112 @@
+defmodule Engram.Workers.BackfillCrdtHead do
+  @moduledoc """
+  Warm the `notes.crdt_head` column so `CrdtTransport.vault_heads/2` never pays
+  an O(notes) doc-rebuild on a live poll.
+
+  Per (user, vault): walks notes whose `crdt_head` is still NULL, rebuilds each
+  doc ONCE via `CrdtTransport.backfill_head/3` (which persists the computed
+  head), cursor-batched, re-enqueuing itself until the vault is drained.
+
+  Idempotent: the `is_nil(crdt_head)` predicate drops any note already set (by
+  `update_v1` or a prior batch), so a retry or a second `enqueue_all/0` never
+  re-rebuilds a note.
+
+  Enqueue post-deploy via release rpc (no Mix in the release — plain function):
+
+      docker exec engram-saas /app/bin/engram rpc 'Engram.Workers.BackfillCrdtHead.enqueue_all()'
+  """
+
+  # No `unique`: a cursor worker re-enqueues its own successor mid-run, which
+  # collides with `:incomplete` uniqueness (the running job counts) and would
+  # drop the successor, killing the loop after one batch. The `is_nil(crdt_head)`
+  # filter already makes the work idempotent, so a duplicate enqueue_all just
+  # does converging, harmless re-scans — acceptable for a one-time backfill.
+  use Oban.Worker, queue: :crypto_backfill, max_attempts: 5
+
+  import Ecto.Query
+
+  alias Engram.Accounts
+  alias Engram.Crypto.RotationGate
+  alias Engram.Notes.{CrdtTransport, Note}
+  alias Engram.Repo
+  alias Engram.Vaults
+
+  @batch_size 100
+  @start_cursor "00000000-0000-0000-0000-000000000000"
+
+  @doc "Enqueue one job per (user, vault) that still has a NULL-crdt_head note. Returns the count."
+  @spec enqueue_all() :: non_neg_integer()
+  def enqueue_all do
+    pairs =
+      from(n in Note,
+        where: is_nil(n.crdt_head) and is_nil(n.deleted_at),
+        group_by: [n.user_id, n.vault_id],
+        select: {n.user_id, n.vault_id}
+      )
+      |> Repo.all(skip_tenant_check: true)
+
+    Enum.each(pairs, fn {user_id, vault_id} ->
+      %{"user_id" => user_id, "vault_id" => vault_id, "cursor" => @start_cursor}
+      |> __MODULE__.new()
+      |> Oban.insert()
+    end)
+
+    length(pairs)
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "vault_id" => vault_id} = args}) do
+    cursor = args["cursor"] || @start_cursor
+
+    # Gate DEK-touching work during a per-user rotation window (parity with
+    # BackfillContentHashHmac): backfill_head -> load_doc decrypts crdt_state,
+    # which can transiently fail mid-rotation. crdt_head itself is rotation-
+    # invariant (a hash of plaintext clock counts), so this is quiet-during-
+    # rotation, not a correctness gate.
+    case RotationGate.check(user_id) do
+      {:error, :rotation_in_progress} -> {:snooze, 60}
+      {:error, :user_not_found} -> {:discard, :user_deleted}
+      :ok -> run(user_id, vault_id, cursor)
+    end
+  end
+
+  defp run(user_id, vault_id, cursor) do
+    case Accounts.get_user(user_id) do
+      nil ->
+        {:discard, :user_deleted}
+
+      user ->
+        case Vaults.get_vault(user, vault_id) do
+          {:ok, vault} -> backfill_batch(user, vault, cursor)
+          {:error, :not_found} -> {:discard, :vault_deleted}
+        end
+    end
+  end
+
+  defp backfill_batch(user, vault, cursor) do
+    {:ok, ids} =
+      Repo.with_tenant(user.id, fn ->
+        from(n in Note,
+          where:
+            n.vault_id == ^vault.id and n.id > ^cursor and is_nil(n.crdt_head) and
+              is_nil(n.deleted_at),
+          order_by: [asc: n.id],
+          select: n.id,
+          limit: @batch_size
+        )
+        |> Repo.all()
+      end)
+
+    # backfill_head/3 manages its own tenant scoping (load_doc + store_head), so
+    # it is called outside the batch-select transaction, once per note.
+    Enum.each(ids, fn id -> CrdtTransport.backfill_head(user, vault, id) end)
+
+    if length(ids) == @batch_size do
+      %{"user_id" => user.id, "vault_id" => vault.id, "cursor" => List.last(ids)}
+      |> __MODULE__.new()
+      |> Oban.insert()
+    end
+
+    :ok
+  end
+end

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -41,6 +41,15 @@ defmodule EngramWeb.CrdtChannel do
   @msg_limit 240
   @msg_scale_ms 10_000
 
+  # Per-socket ceiling on distinct rooms (notes) a single connection may enroll.
+  # Each room pins a server Y.Doc + checkpoint timer, so an unbounded client
+  # (buggy or hostile) could STEP1 endlessly and exhaust node RAM + the DB pool.
+  # ponytail: sized as a high ABUSE ceiling, not a working limit — 4096 clears a
+  # 2400-note vault under today's enroll-everything client with headroom. Tighten
+  # toward the real active-set (~256) once lazy enrollment is the plugin default.
+  # Runtime-overridable via config so it can be lowered without a redeploy.
+  @default_max_rooms 4096
+
   # Handshake (STEP1/STEP2) budget — separate from @msg_limit so connect-time
   # enrollment (one STEP1 per note) can never starve edit frames (the
   # 2026-07-07 incident trigger on a ~230-note vault). 2400/10s enrolls a
@@ -136,6 +145,12 @@ defmodule EngramWeb.CrdtChannel do
       {:error, :frame_too_large} ->
         log_dropped(socket, doc_id, :frame_too_large)
         {:reply, {:error, %{reason: "frame_too_large"}}, socket}
+
+      {:error, :room_limit} ->
+        # This socket hit the per-connection room cap (abuse backstop). Reply so
+        # the client stops hammering; log_dropped emits an alertable :sync warn.
+        log_dropped(socket, doc_id, :room_limit)
+        {:reply, {:error, %{reason: "room_limit"}}, socket}
 
       {:error, :not_found} = err ->
         # Unknown note_id: the frame is undeliverable, and the SENDER is the
@@ -332,31 +347,42 @@ defmodule EngramWeb.CrdtChannel do
         {:ok, socket, entry}
 
       :error ->
-        %{vault: vault} = socket.assigns
-        user = socket.assigns.current_user
-
-        with {:ok, note_id} <- resolve_note_id(user, vault, doc_id),
-             {:ok, room} <- CrdtRegistry.ensure_observed(user.id, vault.id, note_id) do
-          # Watch the room: if it dies (crash, node loss), evict it from the cache so
-          # the next crdt_msg re-creates it. Without this, send_yjs_message casts to a
-          # dead pid return :ok and every subsequent edit is silently dropped.
-          _ref = Process.monitor(room)
-
-          entry = %{room: room, note_id: note_id}
-
-          socket =
-            socket
-            |> assign(:rooms, Map.put(socket.assigns.rooms, doc_id, entry))
-            |> assign(:room_doc, Map.put(socket.assigns.room_doc, room, doc_id))
-
-          # Announce to all OTHER clients on this vault's crdt: channel that a
-          # room is now active for doc_id. Recipients send a sync-step-1 (state
-          # vector) which the server answers with step-2 (the diff they're
-          # missing), so any device that doesn't yet have this note gets it.
-          broadcast_from!(socket, "crdt_doc_ready", %{"doc_id" => doc_id})
-
-          {:ok, socket, entry}
+        # Abuse backstop: refuse a new room once this socket already holds the max,
+        # so one connection can't pin unbounded Y.Docs + pool connections. Reply-
+        # carrying (see handle_in) so the client backs off. High ceiling for now.
+        if map_size(socket.assigns.rooms) >= max_rooms() do
+          {:error, :room_limit}
+        else
+          start_and_observe_room(socket, doc_id)
         end
+    end
+  end
+
+  defp start_and_observe_room(socket, doc_id) do
+    %{vault: vault} = socket.assigns
+    user = socket.assigns.current_user
+
+    with {:ok, note_id} <- resolve_note_id(user, vault, doc_id),
+         {:ok, room} <- CrdtRegistry.ensure_observed(user.id, vault.id, note_id) do
+      # Watch the room: if it dies (crash, node loss), evict it from the cache so
+      # the next crdt_msg re-creates it. Without this, send_yjs_message casts to a
+      # dead pid return :ok and every subsequent edit is silently dropped.
+      _ref = Process.monitor(room)
+
+      entry = %{room: room, note_id: note_id}
+
+      socket =
+        socket
+        |> assign(:rooms, Map.put(socket.assigns.rooms, doc_id, entry))
+        |> assign(:room_doc, Map.put(socket.assigns.room_doc, room, doc_id))
+
+      # Announce to all OTHER clients on this vault's crdt: channel that a
+      # room is now active for doc_id. Recipients send a sync-step-1 (state
+      # vector) which the server answers with step-2 (the diff they're
+      # missing), so any device that doesn't yet have this note gets it.
+      broadcast_from!(socket, "crdt_doc_ready", %{"doc_id" => doc_id})
+
+      {:ok, socket, entry}
     end
   end
 
@@ -375,6 +401,10 @@ defmodule EngramWeb.CrdtChannel do
         {:error, :bad_doc_id}
     end
   end
+
+  # Per-socket room ceiling. Read from config at call time (not compiled in) so
+  # ops can lower it live via Application.put_env under abuse, no redeploy.
+  defp max_rooms, do: Application.get_env(:engram, :max_rooms_per_socket, @default_max_rooms)
 
   # Test builds allow overriding the crdt_msg rate limit via
   # Application.put_env(:engram, :crdt_msg_rate_limit_override, n) so tests

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.662",
+      version: "0.5.663",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260710190000_add_crdt_head_to_notes_expand.exs
+++ b/priv/repo/migrations/20260710190000_add_crdt_head_to_notes_expand.exs
@@ -1,0 +1,67 @@
+defmodule Engram.Repo.Migrations.AddCrdtHeadToNotesExpand do
+  use Ecto.Migration
+
+  @moduledoc """
+  phase/expand — cheap head index for CrdtTransport.vault_heads.
+
+  `crdt_head` = sha256(state_vector) url-b64 (~43 chars), so a client can diff
+  its per-note heads to find cold notes that advanced WITHOUT the server
+  rebuilding every note's Y.Doc per poll. INVALIDATE-and-self-heal: it is NULLed
+  on every CRDT-state change, and `vault_heads` rebuilds a NULL once (lazily).
+
+  * Tail appends (room edits) — `CrdtPersistence.update_v1` NULLs the head in the
+    same txn as the tail-log insert.
+  * Snapshot writes (REST create/update via `maybe_merge_crdt`, checkpoint
+    compaction) — the trigger below NULLs the head structurally, so NO snapshot
+    writer (current or future) can leave a stale head.
+
+  `vault_heads` self-heals a NULL by rebuilding the doc once and storing the
+  result (compare-and-set against the tail high-watermark, so a concurrent edit
+  can't be clobbered); `Engram.Workers.BackfillCrdtHead` warms existing NULLs.
+
+  :text (not varchar) for Squawk's prefer-text rule; the schema field is
+  :string, which Ecto reads from text unchanged. The nullable column add is
+  metadata-only on PG11+ (no rewrite); `CREATE TRIGGER` briefly takes a SHARE
+  ROW EXCLUSIVE lock on `notes` (blocks writes for the DDL only — fast, not
+  lock-free), which is why this is expand-phase and deployed before readers.
+  """
+
+  def up do
+    alter table(:notes) do
+      add :crdt_head, :text
+    end
+
+    execute("""
+    CREATE OR REPLACE FUNCTION notes_null_crdt_head() RETURNS trigger AS $$
+    BEGIN
+      NEW.crdt_head := NULL;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    -- Pinned search_path (splinter: function_search_path_mutable). The body
+    -- assigns a column only, touching no schema-qualified object.
+    SET search_path = '';
+    """)
+
+    # BEFORE UPDATE OF crdt_state_ciphertext: the head is derived from the CRDT
+    # state, so any change to the snapshot invalidates it. Column-scoped + the
+    # IS DISTINCT guard so a no-op write (or an update_v1/self-heal write that
+    # touches only crdt_head) never fires it.
+    execute("""
+    CREATE TRIGGER notes_crdt_head_invalidate
+    BEFORE UPDATE OF crdt_state_ciphertext ON notes
+    FOR EACH ROW
+    WHEN (NEW.crdt_state_ciphertext IS DISTINCT FROM OLD.crdt_state_ciphertext)
+    EXECUTE FUNCTION notes_null_crdt_head();
+    """)
+  end
+
+  def down do
+    execute("DROP TRIGGER IF EXISTS notes_crdt_head_invalidate ON notes;")
+    execute("DROP FUNCTION IF EXISTS notes_null_crdt_head();")
+
+    alter table(:notes) do
+      remove :crdt_head
+    end
+  end
+end

--- a/test/engram/notes/crdt_transport_test.exs
+++ b/test/engram/notes/crdt_transport_test.exs
@@ -190,6 +190,109 @@ defmodule Engram.Notes.CrdtTransportTest do
     end
   end
 
+  describe "crdt_head maintenance + vault_heads memory hardening" do
+    test "a room edit invalidates a warmed crdt_head; vault_heads self-heals to the new head",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{path: "MH/A.md", content: "# A\n\nseed", mtime: 1_000.0})
+
+      on_exit(fn -> CrdtRegistry.terminate_room(note.id) end)
+
+      # Warm the column so we can prove the edit INVALIDATES it (not just that a
+      # never-set column stays NULL).
+      _ = CrdtTransport.vault_heads(user, vault)
+      {:ok, warmed} = Notes.get_note_by_id(user, vault, note.id)
+      refute is_nil(warmed.crdt_head)
+
+      {:ok, %{update: full}} = CrdtTransport.read_delta(user, vault, note.id, nil)
+      client = CrdtBridge.new_doc()
+      :ok = Yex.apply_update(client, full)
+      before_sv = Yex.encode_state_vector!(client)
+      CrdtBridge.ingest_plaintext(client, "# A\n\nseed and edit")
+      {:ok, upd} = Yex.encode_state_as_update(client, before_sv)
+
+      {:ok, %{head: head}} = CrdtTransport.apply_update(user, vault, note.id, upd)
+
+      # The tail append (update_v1) invalidated the stale head...
+      {:ok, invalidated} = Notes.get_note_by_id(user, vault, note.id)
+      assert is_nil(invalidated.crdt_head), "a room edit must invalidate the cached head"
+
+      # ...and vault_heads self-heals to the authoritative post-edit head.
+      heads = CrdtTransport.vault_heads(user, vault)
+      assert heads[note.id] == head
+    end
+
+    test "vault_heads self-heals a NULL crdt_head and persists it for cheap re-reads",
+         %{user: user, vault: vault} do
+      {:ok, a} =
+        Notes.upsert_note(user, vault, %{path: "MH/B.md", content: "# B", mtime: 1_000.0})
+
+      # A freshly upserted note is INSERTed (the invalidation trigger is
+      # BEFORE UPDATE, so it doesn't fire), so crdt_head starts NULL.
+      {:ok, a0} = Notes.get_note_by_id(user, vault, a.id)
+      assert is_nil(a0.crdt_head)
+
+      heads = CrdtTransport.vault_heads(user, vault)
+      assert is_binary(heads[a.id])
+
+      {:ok, a1} = Notes.get_note_by_id(user, vault, a.id)
+      assert a1.crdt_head == heads[a.id], "self-heal must persist the column"
+    end
+
+    test "vault_heads head equals read_delta's head for the same note",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{path: "MH/C.md", content: "# C", mtime: 1_000.0})
+
+      {:ok, %{head: rd_head}} = CrdtTransport.read_delta(user, vault, note.id, nil)
+      heads = CrdtTransport.vault_heads(user, vault)
+      assert heads[note.id] == rd_head
+    end
+
+    test "a REST edit invalidates the head so vault_heads reflects the new state",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{path: "MH/D.md", content: "# D\n\none", mtime: 1_000.0})
+
+      heads0 = CrdtTransport.vault_heads(user, vault)
+      h0 = heads0[note.id]
+      assert is_binary(h0)
+
+      # A REST update rewrites crdt_state via maybe_merge_crdt; the trigger
+      # nulls crdt_head so a stale head cannot survive the content change.
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{
+          path: "MH/D.md",
+          content: "# D\n\none two",
+          mtime: 2_000.0
+        })
+
+      {:ok, mid} = Notes.get_note_by_id(user, vault, note.id)
+      assert is_nil(mid.crdt_head), "trigger must invalidate crdt_head on a crdt_state change"
+
+      heads1 = CrdtTransport.vault_heads(user, vault)
+      assert heads1[note.id] != h0, "head must advance after a REST edit"
+    end
+
+    test "backfill_head computes, persists, and returns a head matching read_delta",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{path: "MH/E.md", content: "# E", mtime: 1_000.0})
+
+      assert {:ok, head} = CrdtTransport.backfill_head(user, vault, note.id)
+      {:ok, %{head: rd_head}} = CrdtTransport.read_delta(user, vault, note.id, nil)
+      assert head == rd_head
+
+      {:ok, reloaded} = Notes.get_note_by_id(user, vault, note.id)
+      assert reloaded.crdt_head == head
+    end
+
+    test "backfill_head returns :not_found for an unknown note", %{user: user, vault: vault} do
+      assert {:error, :not_found} =
+               CrdtTransport.backfill_head(user, vault, Ecto.UUID.generate())
+    end
+  end
+
   describe "safe_wire_frame?/1 (P0 #989 — WS state-vector DoS guard)" do
     test "non-step1 frames are always allowed (step2, update, non-sync)" do
       assert CrdtTransport.safe_wire_frame?(<<0, 1, 5>>), "syncStep2"

--- a/test/engram/notes/crdt_transport_test.exs
+++ b/test/engram/notes/crdt_transport_test.exs
@@ -4,7 +4,7 @@ defmodule Engram.Notes.CrdtTransportTest do
   use Engram.DataCase, async: false
 
   alias Engram.Notes
-  alias Engram.Notes.{CrdtBridge, CrdtRegistry, CrdtTransport}
+  alias Engram.Notes.{CrdtBridge, CrdtRegistry, CrdtTransport, CrdtUpdateLog, Note}
 
   setup do
     user = insert(:user)
@@ -12,6 +12,27 @@ defmodule Engram.Notes.CrdtTransportTest do
     {:ok, user} = Engram.Crypto.ensure_user_dek(user)
     {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "TransportTest"})
     %{user: user, vault: vault}
+  end
+
+  # Append a crdt_update_log (tail) row SYNCHRONOUSLY, to advance the tail
+  # watermark deterministically in the CAS tests. (A real apply_update settles
+  # the tail asynchronously — which is exactly the race the CAS guards, but it
+  # makes a watermark assertion non-deterministic.) Returns the new row's id.
+  defp append_tail_row(user, vault, note_id) do
+    {:ok, row} =
+      Repo.with_tenant(user.id, fn ->
+        %CrdtUpdateLog{}
+        |> CrdtUpdateLog.changeset(%{
+          note_id: note_id,
+          user_id: user.id,
+          vault_id: vault.id,
+          update_ciphertext: <<0>>,
+          update_nonce: <<0>>
+        })
+        |> Repo.insert!()
+      end)
+
+    row.id
   end
 
   describe "read_delta/4" do
@@ -290,6 +311,96 @@ defmodule Engram.Notes.CrdtTransportTest do
     test "backfill_head returns :not_found for an unknown note", %{user: user, vault: vault} do
       assert {:error, :not_found} =
                CrdtTransport.backfill_head(user, vault, Ecto.UUID.generate())
+    end
+
+    test "store_head_if_unchanged persists when the tail watermark still matches (CAS accept)",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          path: "MH/CAS1.md",
+          content: "# C\n\nseed",
+          mtime: 1_000.0
+        })
+
+      # Advance the tail so the watermark is a real row, then store against it.
+      append_tail_row(user, vault, note.id)
+      wm = CrdtTransport.tail_watermark(user, note.id)
+
+      assert {:ok, {1, nil}} = CrdtTransport.store_head_if_unchanged(user, note.id, "HEADX", wm)
+      {:ok, reloaded} = Notes.get_note_by_id(user, vault, note.id)
+      assert reloaded.crdt_head == "HEADX"
+    end
+
+    test "store_head_if_unchanged does NOT persist when the tail advanced under it (CAS reject)",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          path: "MH/CAS2.md",
+          content: "# C\n\none",
+          mtime: 1_000.0
+        })
+
+      append_tail_row(user, vault, note.id)
+      stale_wm = CrdtTransport.tail_watermark(user, note.id)
+
+      # A concurrent edit appends another tail row AFTER the watermark was taken —
+      # exactly the race the CAS guards. The self-heal's head (computed from the
+      # pre-edit tail) must be refused (0 rows), leaving NULL for the next poll.
+      append_tail_row(user, vault, note.id)
+
+      assert {:ok, {0, nil}} =
+               CrdtTransport.store_head_if_unchanged(user, note.id, "STALEHEAD", stale_wm)
+
+      {:ok, reloaded} = Notes.get_note_by_id(user, vault, note.id)
+      assert is_nil(reloaded.crdt_head), "a stale-watermark store must leave the column NULL"
+    end
+
+    test "any crdt_state_ciphertext write invalidates a warmed crdt_head (invalidation trigger)",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{path: "MH/TRG.md", content: "# T", mtime: 1_000.0})
+
+      _ = CrdtTransport.vault_heads(user, vault)
+      {:ok, warmed} = Notes.get_note_by_id(user, vault, note.id)
+      refute is_nil(warmed.crdt_head)
+
+      # Rewrite crdt_state_ciphertext directly, exactly as checkpoint compaction
+      # does — the BEFORE UPDATE OF crdt_state_ciphertext trigger must NULL
+      # crdt_head, structurally covering the checkpoint snapshot writer (and any
+      # future one), not just the REST maybe_merge_crdt path the round-trip test
+      # exercises.
+      {:ok, {1, nil}} =
+        Repo.with_tenant(user.id, fn ->
+          from(n in Note, where: n.id == ^note.id)
+          |> Repo.update_all(set: [crdt_state_ciphertext: <<9, 9, 9>>])
+        end)
+
+      {:ok, reloaded} = Notes.get_note_by_id(user, vault, note.id)
+
+      assert is_nil(reloaded.crdt_head),
+             "a crdt_state write must invalidate the head via the trigger"
+    end
+
+    test "a crdt_head-only write does NOT fire the invalidation trigger (column-scoped)",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{path: "MH/COL.md", content: "# C", mtime: 1_000.0})
+
+      _ = CrdtTransport.vault_heads(user, vault)
+      {:ok, warmed} = Notes.get_note_by_id(user, vault, note.id)
+      head = warmed.crdt_head
+      refute is_nil(head)
+
+      # Writing ONLY crdt_head (as update_v1/store_head do) must not re-trip the
+      # BEFORE UPDATE OF crdt_state_ciphertext trigger and null it back out.
+      {:ok, {1, nil}} =
+        Repo.with_tenant(user.id, fn ->
+          from(n in Note, where: n.id == ^note.id)
+          |> Repo.update_all(set: [crdt_head: "MANUAL"])
+        end)
+
+      {:ok, reloaded} = Notes.get_note_by_id(user, vault, note.id)
+      assert reloaded.crdt_head == "MANUAL", "trigger must not fire on a crdt_head-only write"
     end
   end
 

--- a/test/engram/workers/backfill_crdt_head_test.exs
+++ b/test/engram/workers/backfill_crdt_head_test.exs
@@ -50,6 +50,57 @@ defmodule Engram.Workers.BackfillCrdtHeadTest do
       )
     end
 
+    test "a full batch re-enqueues a successor at the last-processed cursor", %{
+      user: user,
+      vault: vault
+    } do
+      # Force a batch size of 1 so two notes span two batches without inserting 101.
+      Application.put_env(:engram, :crdt_head_backfill_batch_size, 1)
+      on_exit(fn -> Application.delete_env(:engram, :crdt_head_backfill_batch_size) end)
+
+      # uuidv7 ids are time-ordered, so `a` (created first) has the smaller id and
+      # is the sole member of the first (limit-1) batch.
+      {:ok, a} = Notes.upsert_note(user, vault, %{path: "B/a.md", content: "# A", mtime: 1_000.0})
+
+      {:ok, _b} =
+        Notes.upsert_note(user, vault, %{path: "B/b.md", content: "# B", mtime: 1_000.0})
+
+      assert :ok =
+               perform_job(BackfillCrdtHead, %{
+                 "user_id" => user.id,
+                 "vault_id" => vault.id,
+                 "cursor" => "00000000-0000-0000-0000-000000000000"
+               })
+
+      # Full batch (length == limit) → a successor job at cursor = last id processed.
+      assert_enqueued(
+        worker: BackfillCrdtHead,
+        args: %{"user_id" => user.id, "vault_id" => vault.id, "cursor" => a.id}
+      )
+    end
+
+    test "snoozes while a per-user DEK rotation is in progress", %{user: user, vault: vault} do
+      Repo.update!(Ecto.Changeset.change(user, dek_rotation_locked_at: DateTime.utc_now()))
+
+      assert {:snooze, 60} =
+               perform_job(BackfillCrdtHead, %{
+                 "user_id" => user.id,
+                 "vault_id" => vault.id,
+                 "cursor" => "00000000-0000-0000-0000-000000000000"
+               })
+    end
+
+    test "discards when the vault no longer exists", %{user: user} do
+      assert {:discard, :vault_deleted} =
+               perform_job(BackfillCrdtHead, %{
+                 "user_id" => user.id,
+                 "vault_id" => Ecto.UUID.generate(),
+                 "cursor" => "00000000-0000-0000-0000-000000000000"
+               })
+    end
+
+    # NOTE: this exercises RotationGate.check's user-not-found arm (which runs
+    # first), not run/3's own nil guard — both return the same discard reason.
     test "discards when the user no longer exists", %{vault: vault} do
       assert {:discard, :user_deleted} =
                perform_job(BackfillCrdtHead, %{
@@ -57,6 +108,33 @@ defmodule Engram.Workers.BackfillCrdtHeadTest do
                  "vault_id" => vault.id,
                  "cursor" => "00000000-0000-0000-0000-000000000000"
                })
+    end
+
+    test "enqueue_all fans out across tenants (one job per distinct user/vault)", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "B/x.md", content: "# X", mtime: 1_000.0})
+
+      other = insert(:user)
+      insert(:user_limit_override, user: other, key: "vaults_cap", value: %{"v" => -1})
+      {:ok, other} = Engram.Crypto.ensure_user_dek(other)
+      {:ok, other_vault} = Engram.Vaults.create_vault(other, %{name: "OtherVault"})
+
+      {:ok, _} =
+        Notes.upsert_note(other, other_vault, %{path: "B/y.md", content: "# Y", mtime: 1.0})
+
+      assert BackfillCrdtHead.enqueue_all() == 2
+
+      assert_enqueued(
+        worker: BackfillCrdtHead,
+        args: %{"user_id" => user.id, "vault_id" => vault.id}
+      )
+
+      assert_enqueued(
+        worker: BackfillCrdtHead,
+        args: %{"user_id" => other.id, "vault_id" => other_vault.id}
+      )
     end
   end
 end

--- a/test/engram/workers/backfill_crdt_head_test.exs
+++ b/test/engram/workers/backfill_crdt_head_test.exs
@@ -1,0 +1,62 @@
+defmodule Engram.Workers.BackfillCrdtHeadTest do
+  use Engram.DataCase, async: false
+  use Oban.Testing, repo: Engram.Repo
+
+  alias Engram.Notes
+  alias Engram.Notes.CrdtTransport
+  alias Engram.Workers.BackfillCrdtHead
+
+  setup do
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "BackfillTest"})
+    %{user: user, vault: vault}
+  end
+
+  describe "perform/1" do
+    test "populates a NULL crdt_head to match the authoritative read", %{user: user, vault: vault} do
+      {:ok, a} = Notes.upsert_note(user, vault, %{path: "B/A.md", content: "# A", mtime: 1_000.0})
+      {:ok, b} = Notes.upsert_note(user, vault, %{path: "B/B.md", content: "# B", mtime: 1_000.0})
+
+      {:ok, a0} = Notes.get_note_by_id(user, vault, a.id)
+      assert is_nil(a0.crdt_head), "a freshly-inserted note starts NULL"
+
+      assert :ok =
+               perform_job(BackfillCrdtHead, %{
+                 "user_id" => user.id,
+                 "vault_id" => vault.id,
+                 "cursor" => "00000000-0000-0000-0000-000000000000"
+               })
+
+      {:ok, a1} = Notes.get_note_by_id(user, vault, a.id)
+      {:ok, b1} = Notes.get_note_by_id(user, vault, b.id)
+      refute is_nil(a1.crdt_head)
+      refute is_nil(b1.crdt_head)
+
+      {:ok, %{head: rd}} = CrdtTransport.read_delta(user, vault, a.id, nil)
+      assert a1.crdt_head == rd, "backfilled head must equal the authoritative read_delta head"
+    end
+
+    test "enqueue_all enqueues one job per (user, vault) with a NULL-head note",
+         %{user: user, vault: vault} do
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "B/C.md", content: "# C", mtime: 1_000.0})
+
+      assert BackfillCrdtHead.enqueue_all() >= 1
+
+      assert_enqueued(
+        worker: BackfillCrdtHead,
+        args: %{"user_id" => user.id, "vault_id" => vault.id}
+      )
+    end
+
+    test "discards when the user no longer exists", %{vault: vault} do
+      assert {:discard, :user_deleted} =
+               perform_job(BackfillCrdtHead, %{
+                 "user_id" => Ecto.UUID.generate(),
+                 "vault_id" => vault.id,
+                 "cursor" => "00000000-0000-0000-0000-000000000000"
+               })
+    end
+  end
+end

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -699,4 +699,33 @@ defmodule EngramWeb.CrdtChannelTest do
       end
     end
   end
+
+  describe "per-socket room cap (abuse backstop)" do
+    test "rejects a new room once the socket hits max_rooms_per_socket",
+         %{socket: socket, user: user, vault: vault, note: note} do
+      Application.put_env(:engram, :max_rooms_per_socket, 1)
+      on_exit(fn -> Application.delete_env(:engram, :max_rooms_per_socket) end)
+      on_exit(fn -> CrdtRegistry.terminate_room(note.id) end)
+
+      {:ok, note2} = Notes.upsert_note(user, vault, %{"path" => "p2.md", "content" => "base2"})
+      on_exit(fn -> CrdtRegistry.terminate_room(note2.id) end)
+
+      step1_b64 = fn ->
+        client = CrdtBridge.new_doc()
+        {:ok, {:sync_step1, sv}} = Yex.Sync.get_sync_step1(client)
+        {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_step1, sv}})
+        Base.encode64(frame)
+      end
+
+      # First distinct note opens room #1 (rooms 0 < cap 1). The server answers a
+      # known note's step1 with a step2 push — wait for it so room #1 is up and
+      # in this socket's assigns before the next frame is handled.
+      push(socket, "crdt_msg", %{"doc_id" => note.id, "b64" => step1_b64.()})
+      assert_push "crdt_msg", %{"doc_id" => _, "b64" => _}, 3000
+
+      # Second distinct note would open room #2 (rooms 1 >= cap 1) → refused.
+      ref = push(socket, "crdt_msg", %{"doc_id" => note2.id, "b64" => step1_b64.()})
+      assert_reply ref, :error, %{reason: "room_limit"}, 3000
+    end
+  end
 end


### PR DESCRIPTION
## Problem

An audit of the sync engine found the live scaling bomb: **`CrdtTransport.vault_heads/2` rebuilt every note's Y.Doc** (decrypt + `yrs` NIF + tail replay) **on every call — and Phase-3a `coldReceive` polls it on every pull.** So every connected client drove an O(vault) decrypt+rebuild per poll cycle. The in-code `ponytail:` comment said it was "dormant until Phase 3," but Phase 3a shipped and now polls it unconditionally.

Separately, nothing capped how many rooms a socket could enroll, so one buggy/hostile client could pin unbounded server Y.Docs + DB-pool connections (the shape behind the #984 pool-exhaustion incident).

## Fix

**Cheap `vault_heads` via a persisted `notes.crdt_head` marker** (`sha256(state_vector)` url-b64), **invalidate-and-self-heal**:

- Every CRDT-state change NULLs `crdt_head`; `vault_heads` reads the column and rebuilds only NULLs (once), so steady-state cost is **O(notes changed since last poll)**, not O(vault).
- **Tail appends** (room edits) → `update_v1` NULLs it in the same txn as the log insert.
- **Snapshot writes** (REST `maybe_merge_crdt`, checkpoint) → a `BEFORE UPDATE OF crdt_state_ciphertext` **trigger** NULLs it structurally, so no writer — current or future — can leave a stale head.
- Self-heal is a **compare-and-set against the tail high-watermark** (uuidv7 `max`), so a concurrent edit racing the poll can't be clobbered with a stale head (a losing CAS leaves NULL for the next poll). Self-healed head == `read_delta`'s head.
- `BackfillCrdtHead` (Oban, RotationGate-gated) warms existing rows: `bin/engram rpc 'Engram.Workers.BackfillCrdtHead.enqueue_all()'`.

**Per-socket room cap** in `CrdtChannel.ensure_room` — config `:max_rooms_per_socket`, default **4096** (a high abuse ceiling that clears a 2400-note eager-enroll vault with headroom; tighten toward the active set once lazy enrollment is the plugin default). Over-limit frames get an `{:error, room_limit}` reply + an alertable `:sync` warn.

## Why invalidate, not maintain
TDD caught that `update_v1`'s persistence-callback `doc` computes an off-by-one head (pre- vs post-integration), which would silently drop cold updates. Nulling is state-independent — it can't be off-by-one — and `vault_heads` recomputes authoritatively via the same `load_doc` `read_delta` uses.

## Review
An adversarial review traced every `crdt_state_ciphertext` writer and the sole `crdt_update_log` inserter and confirmed invalidation is complete; it also caught a self-heal TOCTOU race (now fixed by the CAS above). Minor follow-ups applied: docstrings corrected to the invalidation model, `RotationGate` gate on the worker, `CREATE TRIGGER` lock noted in the migration.

## Testing
TDD throughout — transport (self-heal, invalidation, `read_delta` consistency, backfill), worker (populate, `enqueue_all`, discard), channel (cap rejects over-limit). Full `notes/` + `crdt_sync_controller` suites green (288). Gauntlet: compile-warnings-as-errors, format, credo `--strict`, sobelow all clean.

Refs #984 (pool exhaustion); part of the single-authority sync work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)