### PR TITLE
fix(e2e): OAuth identity-rebind ordering + verified restore + channel diagnostic

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -351,30 +351,33 @@ def _oauth_ws_warm(cdp_a, clerk_client):
         clerk_user_id, tokens = await provision_oauth_tokens(clerk_client, API_URL, label="warm")
         try:
             original = await swap_to_oauth(cdp_a, tokens)
-            # From here on cdp_a wears the throwaway OAuth identity, whose
-            # Clerk user the outer finally deletes. restore_auth must run on
-            # EVERY exit path, or the session-scoped cdp_a serves the rest of
-            # the suite as a deleted user and one diagnosable warm-up failure
-            # cascades into dozens of misleading auth errors downstream.
+            # From here on cdp_a wears the throwaway OAuth identity, whose Clerk
+            # user the outer finally deletes. restore_auth MUST run and MUST
+            # rebind cdp_a back to its original identity on every exit path, or
+            # the session-scoped cdp_a serves the rest of the suite cross-bound
+            # (or as a deleted user) and one warm-up hiccup cascades into dozens
+            # of misleading "Stream not connected" failures downstream.
+            warm_err: TimeoutError | None = None
             try:
                 await wait_for_stream(cdp_a, timeout=120)
             except TimeoutError as e:
+                warm_err = e
+
+            # Always restore, warm-up success or not. restore_auth now VERIFIES
+            # the rebind and raises on a cross-bind. We do NOT swallow that: a
+            # cross-bound session-scoped device poisons every later test, which
+            # is strictly worse than losing the warm-up error — so a restore
+            # failure is surfaced as primary (it names the real, session-level
+            # problem). A generous timeout covers the cold reconnect.
+            await restore_auth(cdp_a, original, verify_timeout=120)
+
+            if warm_err is not None:
                 raise TimeoutError(
                     "OAuth WS cold-boot warm-up (fixture _oauth_ws_warm) timed "
-                    f"out: {e}. This is one-time suite setup absorbing the "
+                    f"out: {warm_err}. This is one-time suite setup absorbing the "
                     "first-connect cost, not the behavior under test -- check "
                     "backend/Clerk health before assuming a real regression."
-                ) from e
-            finally:
-                try:
-                    await restore_auth(cdp_a, original)
-                except Exception as restore_exc:  # noqa: BLE001 - must not mask the warm-up error
-                    # Best-effort on the failure path: swallowing here keeps the
-                    # original timeout as the reported cause; the cascade risk it
-                    # leaves behind is exactly what this restore tried to avoid,
-                    # so make the attempt loudly visible.
-                    print(f"_oauth_ws_warm: restore_auth failed after warm-up error: {restore_exc}")
-            await wait_for_stream(cdp_a, timeout=120)
+                ) from warm_err
         finally:
             clerk_client.delete_user(clerk_user_id)
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -362,6 +362,12 @@ def _oauth_ws_warm(cdp_a, clerk_client):
                 await wait_for_stream(cdp_a, timeout=120)
             except TimeoutError as e:
                 warm_err = e
+                # Log now: if the restore below ALSO raises, it propagates as
+                # primary and the re-raise at line ~374 never runs, so this
+                # would otherwise be the only trace of the warm-up timeout.
+                logging.getLogger(__name__).warning(
+                    "OAuth WS warm-up timed out (restoring anyway): %s", e
+                )
 
             # Always restore, warm-up success or not. restore_auth now VERIFIES
             # the rebind and raises on a cross-bind. We do NOT swallow that: a

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -988,29 +988,19 @@ class CdpClient:
 
 
     async def reconnect_stream(self) -> None:
-        """Force a CLEAN reconnect of the real-time WebSocket channel.
+        """Reconnect the real-time stream after a disconnect.
 
-        `disconnect()` THEN `connect()` — not connect() alone. The plugin's
-        `channel.connect()` opens with `if (this.ws) return`, so calling it
-        while a socket object lingers but has not reached `connected`
-        (connecting / join-pending / join-rejected-pre-close) is a NO-OP: the
-        stream then stays down until its own up-to-60s reconnect backoff fires.
-        `disconnect()` nulls `this.ws` and clears the pending backoff timer, so
-        the following connect() reliably opens a fresh socket immediately. This
-        is what makes the test_84/85 "force a known-good connection" mitigation
-        actually forceful (e2e-clerk "Stream not connected after 20s" flake).
+        For WebSocket channels, connect() opens a new WebSocket and re-joins.
         """
-        await self.evaluate(f"{PLUGIN_PATH}.noteStream.disconnect()")
         await self.evaluate(f"{PLUGIN_PATH}.noteStream.connect()")
-        logger.info("Stream force-reconnect (disconnect+connect) on CDP port %d", self.port)
-        # Check before sleeping: a fast fresh join can be connected on the first
-        # poll. 15 attempts covers a fresh full handshake under CI load.
-        for _ in range(15):
+        logger.info("Stream reconnect initiated on CDP port %d", self.port)
+        # Wait for the connection to establish and trigger onStatusChange
+        for _ in range(10):
+            await asyncio.sleep(1)
             if await self.check_stream_connected():
                 logger.info("Stream reconnected on CDP port %d", self.port)
                 return
-            await asyncio.sleep(1)
-        logger.warning("Stream did not reconnect within 15s on CDP port %d", self.port)
+        logger.warning("Stream did not reconnect within 10s on CDP port %d", self.port)
 
 
     async def simulate_offline(self) -> None:

--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -747,6 +747,41 @@ class CdpClient:
         result = await self.evaluate(f"{PLUGIN_PATH}.isLiveConnected()")
         return result is True
 
+    async def _stream_diag(self) -> str:
+        """Best-effort snapshot of the live channel's internal state.
+
+        CI does not capture plugin-runtime logs, so a bare "Stream not
+        connected" timeout gives no clue WHICH stuck state the channel was in.
+        Read the observable channel fields (ws readyState, connected,
+        crdtJoined, crdtJoinFailedReason, pending reconnect) so a recurrence is
+        diagnosable from the assertion message alone.
+        """
+        try:
+            raw = await self.evaluate(
+                f"""
+                (() => {{
+                    const p = {PLUGIN_PATH};
+                    const ns = p && p.noteStream;
+                    if (!ns) return JSON.stringify({{error: 'no noteStream'}});
+                    return JSON.stringify({{
+                        isLiveConnected: typeof p.isLiveConnected === 'function' ? p.isLiveConnected() : null,
+                        wsReadyState: ns.ws ? ns.ws.readyState : null,
+                        connected: typeof ns.isConnected === 'function' ? ns.isConnected() : null,
+                        crdtJoined: typeof ns.isCrdtConnected === 'function' ? ns.isCrdtConnected() : null,
+                        crdtJoinFailedReason: ns.crdtJoinFailedReason ?? null,
+                        reconnectPending: ns.reconnectTimer != null,
+                        connId: typeof ns.getConnId === 'function' ? ns.getConnId() : null
+                    }});
+                }})()
+                """
+            )
+            return raw if isinstance(raw, str) else json.dumps(raw)
+        except Exception as e:  # noqa: BLE001
+            # Instrumentation must never mask the TimeoutError it annotates: a
+            # CDP evaluate can itself fail mid-teardown. Degrade to a reason
+            # string; the real timeout is still raised by the caller.
+            return f"<stream diag unavailable: {e!r}>"
+
     async def wait_for_stream_connected(self, timeout: float = 10) -> None:
         """Poll until the WebSocket channel reports connected.
 
@@ -759,8 +794,9 @@ class CdpClient:
             if await self.check_stream_connected():
                 return
             await asyncio.sleep(0.5)
+        diag = await self._stream_diag()
         raise TimeoutError(
-            f"Stream not connected after {timeout}s on CDP port {self.port}"
+            f"Stream not connected after {timeout}s on CDP port {self.port} — channel={diag}"
         )
 
 
@@ -952,19 +988,29 @@ class CdpClient:
 
 
     async def reconnect_stream(self) -> None:
-        """Reconnect the real-time stream after a disconnect.
+        """Force a CLEAN reconnect of the real-time WebSocket channel.
 
-        For WebSocket channels, connect() opens a new WebSocket and re-joins.
+        `disconnect()` THEN `connect()` — not connect() alone. The plugin's
+        `channel.connect()` opens with `if (this.ws) return`, so calling it
+        while a socket object lingers but has not reached `connected`
+        (connecting / join-pending / join-rejected-pre-close) is a NO-OP: the
+        stream then stays down until its own up-to-60s reconnect backoff fires.
+        `disconnect()` nulls `this.ws` and clears the pending backoff timer, so
+        the following connect() reliably opens a fresh socket immediately. This
+        is what makes the test_84/85 "force a known-good connection" mitigation
+        actually forceful (e2e-clerk "Stream not connected after 20s" flake).
         """
+        await self.evaluate(f"{PLUGIN_PATH}.noteStream.disconnect()")
         await self.evaluate(f"{PLUGIN_PATH}.noteStream.connect()")
-        logger.info("Stream reconnect initiated on CDP port %d", self.port)
-        # Wait for the connection to establish and trigger onStatusChange
-        for _ in range(10):
-            await asyncio.sleep(1)
+        logger.info("Stream force-reconnect (disconnect+connect) on CDP port %d", self.port)
+        # Check before sleeping: a fast fresh join can be connected on the first
+        # poll. 15 attempts covers a fresh full handshake under CI load.
+        for _ in range(15):
             if await self.check_stream_connected():
                 logger.info("Stream reconnected on CDP port %d", self.port)
                 return
-        logger.warning("Stream did not reconnect within 10s on CDP port %d", self.port)
+            await asyncio.sleep(1)
+        logger.warning("Stream did not reconnect within 15s on CDP port %d", self.port)
 
 
     async def simulate_offline(self) -> None:

--- a/e2e/helpers/oauth.py
+++ b/e2e/helpers/oauth.py
@@ -230,7 +230,7 @@ async def swap_to_oauth(cdp, tokens: dict) -> str:
     return original
 
 
-async def restore_auth(cdp, original_settings_json: str, verify_timeout: float = 30) -> None:
+async def restore_auth(cdp, original_settings_json: str, verify_timeout: float = 60) -> None:
     """Restore Obsidian plugin to its original auth settings via CDP.
 
     Like swap_to_oauth, this rotates the sync fingerprint back, so the
@@ -239,6 +239,11 @@ async def restore_auth(cdp, original_settings_json: str, verify_timeout: float =
     Verifies the restore rebound the channel (stream reconnects as the restored
     identity) and raises TimeoutError if not — a cross-bind must fail here, not
     silently poison every later test that reuses this session-scoped device.
+
+    verify_timeout defaults to 60s, not 30: under 2-worker load the OAuth
+    reconnect chain (getMe → socket connect → crdt join) intermittently takes
+    ~35s — flake #643 established 60 as the floor. A tighter budget here would
+    turn a legit-but-slow reconnect into a hard failure at the restore site.
     """
     settings = json.loads(original_settings_json)
     api_key = json.dumps(settings.get("apiKey", ""))

--- a/e2e/helpers/oauth.py
+++ b/e2e/helpers/oauth.py
@@ -203,7 +203,13 @@ async def swap_to_oauth(cdp, tokens: dict) -> str:
         plugin.settings.vaultId = {vault_id};
         plugin.settings.userEmail = {user_email};
         plugin.settings.authMethod = 'oauth';
-        await plugin.saveSettings();
+        // Wire the new auth provider onto plugin.api BEFORE saveSettings(): it
+        // rebuilds the note channel (setupNoteStream -> connectChannel), which
+        // freezes the channel's topic userId from api.getMe() at construction.
+        // With the OLD provider still active, getMe() resolves the old user and
+        // the channel is minted crdt:<oldUser>:<newVault> while the socket auths
+        // as the new user -> join rejected "unauthorized". Mirrors the prod fix
+        // in main.ts saveOAuthTokens (Engram-obsidian#229).
         plugin.authProvider = plugin.createAuthProvider();
         if (plugin.authProvider) {{
             plugin.api.setAuthProvider(plugin.authProvider);
@@ -211,6 +217,7 @@ async def swap_to_oauth(cdp, tokens: dict) -> str:
                 plugin.noteStream.setAuthProvider(plugin.authProvider);
             }}
         }}
+        await plugin.saveSettings();
         plugin.setupNoteStream();
         if (typeof plugin.markSyncGateAccepted === 'function') {{
             await plugin.markSyncGateAccepted();
@@ -223,11 +230,15 @@ async def swap_to_oauth(cdp, tokens: dict) -> str:
     return original
 
 
-async def restore_auth(cdp, original_settings_json: str) -> None:
+async def restore_auth(cdp, original_settings_json: str, verify_timeout: float = 30) -> None:
     """Restore Obsidian plugin to its original auth settings via CDP.
 
     Like swap_to_oauth, this rotates the sync fingerprint back, so the
     gate must be re-accepted to keep the engine sync-active.
+
+    Verifies the restore rebound the channel (stream reconnects as the restored
+    identity) and raises TimeoutError if not — a cross-bind must fail here, not
+    silently poison every later test that reuses this session-scoped device.
     """
     settings = json.loads(original_settings_json)
     api_key = json.dumps(settings.get("apiKey", ""))
@@ -250,7 +261,10 @@ async def restore_auth(cdp, original_settings_json: str) -> None:
         plugin.settings.vaultId = {vault_id};
         plugin.settings.userEmail = {user_email};
         plugin.settings.authMethod = {auth_method};
-        await plugin.saveSettings();
+        // Provider before saveSettings — same ordering invariant as swap_to_oauth
+        // (see the comment there): the channel-rebuilding saveSettings() must see
+        // the restored provider so getMe() freezes the RESTORED user's id into the
+        // topic, matching the restored token.
         plugin.authProvider = plugin.createAuthProvider();
         if (plugin.authProvider) {{
             plugin.api.setAuthProvider(plugin.authProvider);
@@ -258,6 +272,7 @@ async def restore_auth(cdp, original_settings_json: str) -> None:
                 plugin.noteStream.setAuthProvider(plugin.authProvider);
             }}
         }}
+        await plugin.saveSettings();
         plugin.setupNoteStream();
         if (typeof plugin.markSyncGateAccepted === 'function') {{
             await plugin.markSyncGateAccepted();
@@ -267,6 +282,16 @@ async def restore_auth(cdp, original_settings_json: str) -> None:
     """
     result = await cdp.evaluate(js, await_promise=True)
     logger.info("Plugin auth restored: %s", result)
+
+    # VERIFY the restore actually rebound: the channel must reconnect as the
+    # restored identity. A silent cross-bind (vaultId restored but token/userId
+    # not, or vice versa) leaves the session-scoped device joining the wrong
+    # `crdt:` topic — the backend rejects it "unauthorized" with no client error,
+    # and (before this check) nothing caught it, so every LATER test that reuses
+    # this device failed with a misleading "Stream not connected" (test_84/85).
+    # Fail loudly HERE, at the restore site, instead of 40 tests downstream. The
+    # timeout message carries the channel diagnostic (crdtJoinFailedReason etc).
+    await cdp.wait_for_stream_connected(timeout=verify_timeout)
 
 
 async def wait_for_stream(cdp, timeout: float = 60) -> None:

--- a/e2e/unit/test_cdp_stream.py
+++ b/e2e/unit/test_cdp_stream.py
@@ -1,19 +1,13 @@
-"""Unit tests for helpers.cdp stream-(re)connect helpers — no CI stack needed.
+"""Unit tests for helpers.cdp stream diagnostics — no CI stack needed.
 
-Regression lock for the e2e-clerk "Stream not connected after 20s" flake
-(test_37/78/84/85). Two independent guarantees:
-
-1. `reconnect_stream()` must FORCE a clean reconnect (disconnect THEN connect).
-   The plugin's `channel.connect()` bails on `if (this.ws) return`, so calling
-   connect() while a non-connected socket lingers is a no-op — the stream then
-   stays down until its own up-to-60s backoff fires, blowing the 20s wait.
-   Disconnecting first nulls `this.ws` + clears the backoff timer so connect()
-   reliably opens a fresh socket.
-
-2. `wait_for_stream_connected()` must dump the channel's internal state on
-   timeout, so a recurrence reports WHICH stuck state it hit (ws readyState,
-   connected, crdtJoined, crdtJoinFailedReason, pending reconnect) instead of a
-   bare timeout — CI does not capture plugin-runtime logs.
+`wait_for_stream_connected()` must dump the channel's internal state on timeout,
+so a recurrence of the e2e-clerk "Stream not connected after 20s" flake
+(test_37/78/84/85) reports WHICH stuck state it hit (ws readyState, connected,
+crdtJoined, crdtJoinFailedReason, pending reconnect) instead of a bare timeout —
+CI does not capture plugin-runtime logs. This diagnostic is what surfaced the
+real root cause: crdtJoinFailedReason="unauthorized" from an OAuth
+identity-rebind ordering bug (fix in helpers/oauth.py + Engram-obsidian#229;
+guarded by test_oauth_rebind.py).
 
 These fake the CDP layer; they run without any stack.
 """
@@ -60,22 +54,6 @@ def _client(check_result: bool) -> tuple[CdpClient, list[str]]:
     client.evaluate = fake_evaluate  # type: ignore[method-assign]
     client.check_stream_connected = fake_check  # type: ignore[method-assign]
     return client, calls
-
-
-def test_reconnect_stream_disconnects_before_connecting():
-    # Stream reports connected right after the forced reconnect, so the poll
-    # returns on the first check (no real sleeps).
-    client, calls = _client(check_result=True)
-
-    asyncio.run(client.reconnect_stream())
-
-    # Match the full method call: "connect()" is a substring of "disconnect()",
-    # so filter on the qualified name to tell the two calls apart.
-    dis = [i for i, c in enumerate(calls) if "noteStream.disconnect()" in c]
-    con = [i for i, c in enumerate(calls) if "noteStream.connect()" in c]
-    assert dis, "reconnect_stream must disconnect() first to null a lingering socket"
-    assert con, "reconnect_stream must connect() after disconnecting"
-    assert dis[0] < con[0], "disconnect() must run strictly before connect()"
 
 
 def test_wait_for_stream_connected_dumps_channel_diag_on_timeout():

--- a/e2e/unit/test_cdp_stream.py
+++ b/e2e/unit/test_cdp_stream.py
@@ -1,0 +1,99 @@
+"""Unit tests for helpers.cdp stream-(re)connect helpers — no CI stack needed.
+
+Regression lock for the e2e-clerk "Stream not connected after 20s" flake
+(test_37/78/84/85). Two independent guarantees:
+
+1. `reconnect_stream()` must FORCE a clean reconnect (disconnect THEN connect).
+   The plugin's `channel.connect()` bails on `if (this.ws) return`, so calling
+   connect() while a non-connected socket lingers is a no-op — the stream then
+   stays down until its own up-to-60s backoff fires, blowing the 20s wait.
+   Disconnecting first nulls `this.ws` + clears the backoff timer so connect()
+   reliably opens a fresh socket.
+
+2. `wait_for_stream_connected()` must dump the channel's internal state on
+   timeout, so a recurrence reports WHICH stuck state it hit (ws readyState,
+   connected, crdtJoined, crdtJoinFailedReason, pending reconnect) instead of a
+   bare timeout — CI does not capture plugin-runtime logs.
+
+These fake the CDP layer; they run without any stack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from helpers.cdp import CdpClient
+
+# Diagnostic JS reads these field names; the fake evaluate keys off them to
+# recognise the diag snippet vs the plain disconnect()/connect() calls.
+_DIAG_MARKERS = ("wsReadyState", "crdtJoinFailedReason")
+
+_FAKE_DIAG = {
+    "isLiveConnected": False,
+    "wsReadyState": 0,
+    "connected": False,
+    "crdtJoined": False,
+    "crdtJoinFailedReason": "rate_limited",
+    "reconnectPending": True,
+    "connId": None,
+}
+
+
+def _client(check_result: bool) -> tuple[CdpClient, list[str]]:
+    """A CdpClient whose evaluate() records exprs and whose stream-connected
+    probe returns ``check_result``. No websocket is opened."""
+    client = CdpClient(port=1234)
+    calls: list[str] = []
+
+    async def fake_evaluate(expr: str, await_promise: bool = False):
+        calls.append(expr)
+        if any(m in expr for m in _DIAG_MARKERS):
+            return json.dumps(_FAKE_DIAG)
+        return None
+
+    async def fake_check() -> bool:
+        return check_result
+
+    client.evaluate = fake_evaluate  # type: ignore[method-assign]
+    client.check_stream_connected = fake_check  # type: ignore[method-assign]
+    return client, calls
+
+
+def test_reconnect_stream_disconnects_before_connecting():
+    # Stream reports connected right after the forced reconnect, so the poll
+    # returns on the first check (no real sleeps).
+    client, calls = _client(check_result=True)
+
+    asyncio.run(client.reconnect_stream())
+
+    # Match the full method call: "connect()" is a substring of "disconnect()",
+    # so filter on the qualified name to tell the two calls apart.
+    dis = [i for i, c in enumerate(calls) if "noteStream.disconnect()" in c]
+    con = [i for i, c in enumerate(calls) if "noteStream.connect()" in c]
+    assert dis, "reconnect_stream must disconnect() first to null a lingering socket"
+    assert con, "reconnect_stream must connect() after disconnecting"
+    assert dis[0] < con[0], "disconnect() must run strictly before connect()"
+
+
+def test_wait_for_stream_connected_dumps_channel_diag_on_timeout():
+    client, _calls = _client(check_result=False)
+
+    with pytest.raises(TimeoutError) as exc:
+        # timeout=0 → the poll loop never runs, straight to the diag+raise path.
+        asyncio.run(client.wait_for_stream_connected(timeout=0))
+
+    msg = str(exc.value)
+    assert "Stream not connected" in msg
+    # The channel snapshot must be surfaced so the stuck state is diagnosable.
+    assert "crdtJoinFailedReason" in msg
+    assert "rate_limited" in msg
+    assert "wsReadyState" in msg
+
+
+def test_wait_for_stream_connected_returns_when_connected():
+    client, _calls = _client(check_result=True)
+    # Should return without raising when the stream is up.
+    asyncio.run(client.wait_for_stream_connected(timeout=5))

--- a/e2e/unit/test_oauth_rebind.py
+++ b/e2e/unit/test_oauth_rebind.py
@@ -1,0 +1,89 @@
+"""Unit tests for helpers.oauth swap/restore identity rebind — no CI stack.
+
+Regression lock for the e2e-clerk test_84/85 "Stream not connected" flake. The
+plugin freezes the WS channel's topic userId from api.getMe() when the channel
+is rebuilt by saveSettings(); if the auth provider is swapped AFTER that rebuild
+the channel carries the old user's id while the socket authenticates as the new
+user, and the join is rejected "unauthorized" (mirrors the prod bug fixed in
+Engram-obsidian#229 main.ts saveOAuthTokens).
+
+Two invariants:
+1. swap_to_oauth / restore_auth must wire the provider BEFORE saveSettings().
+2. restore_auth must VERIFY the rebind (stream reconnects) and raise on a
+   cross-bind, so a broken restore fails at the restore site instead of
+   silently poisoning every later test that reuses the session-scoped device.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from helpers.oauth import restore_auth, swap_to_oauth
+
+_ORIGINAL = json.dumps(
+    {
+        "apiKey": "k",
+        "refreshToken": "r",
+        "vaultId": "v",
+        "userEmail": "e@x.com",
+        "authMethod": "apikey",
+    }
+)
+
+
+class _FakeCdp:
+    """Records evaluate() JS; wait_for_stream_connected honours ``stream_ok``."""
+
+    def __init__(self, stream_ok: bool = True):
+        self.evals: list[str] = []
+        self.stream_ok = stream_ok
+
+    async def evaluate(self, expr: str, await_promise: bool = False):
+        self.evals.append(expr)
+        if "JSON.stringify({apiKey" in expr:
+            return _ORIGINAL
+        return "ok"
+
+    async def wait_for_stream_connected(self, timeout: float = 10) -> None:
+        if not self.stream_ok:
+            raise TimeoutError(
+                f"Stream not connected after {timeout}s — "
+                'channel={"crdtJoinFailedReason":"unauthorized"}'
+            )
+
+
+def _provider_before_save(js: str) -> bool:
+    # Match the actual `plugin.`-prefixed calls, not the bare names that also
+    # appear in explanatory comments.
+    prov = js.find("plugin.createAuthProvider()")
+    save = js.find("plugin.saveSettings()")
+    return prov != -1 and save != -1 and prov < save
+
+
+def test_swap_to_oauth_wires_provider_before_savesettings():
+    cdp = _FakeCdp()
+    asyncio.run(swap_to_oauth(cdp, {"refresh_token": "rt", "vault_id": "vid", "user_email": "u@e.com"}))
+    swap_js = next(e for e in cdp.evals if "createAuthProvider" in e)
+    assert _provider_before_save(swap_js), "swap must wire the provider before saveSettings()"
+
+
+def test_restore_auth_wires_provider_before_savesettings():
+    cdp = _FakeCdp()
+    asyncio.run(restore_auth(cdp, _ORIGINAL))
+    restore_js = next(e for e in cdp.evals if "auth restored" in e)
+    assert _provider_before_save(restore_js), "restore must wire the provider before saveSettings()"
+
+
+def test_restore_auth_verifies_and_returns_when_connected():
+    cdp = _FakeCdp(stream_ok=True)
+    # Should not raise: the restored identity's stream reconnects.
+    asyncio.run(restore_auth(cdp, _ORIGINAL))
+
+
+def test_restore_auth_raises_on_cross_bind():
+    cdp = _FakeCdp(stream_ok=False)
+    with pytest.raises(TimeoutError):
+        asyncio.run(restore_auth(cdp, _ORIGINAL))


### PR DESCRIPTION
## Root cause (found via the diagnostic in this PR)

The e2e-clerk `test_84/85` 'Stream not connected after 20s' flake was **not** a socket-lifecycle/backoff issue. A channel-state diagnostic added here turned the bare timeout into `crdtJoinFailedReason="unauthorized"` — an **OAuth identity mismatch**: the session-scoped device `cdp_a` joined a `crdt:<user>:<vault>` topic whose user_id didn't match its socket token's user.

**Why:** `swap_to_oauth`/`restore_auth` mutated settings then `await saveSettings()` — which rebuilds the note channel and freezes its topic `userId` from `getMe()` — **before** swapping the auth provider. So the rebuilt channel carried the old user's id vs the new token. A failed/partial `restore_auth` then left `cdp_a` cross-bound, and `_oauth_ws_warm` **swallowed** that failure and deleted the OAuth user → every later test reusing `cdp_a` failed with a misleading 'Stream not connected'.

The same ordering bug exists in **production** (`main.ts saveOAuthTokens`) — fixed in Engram-obsidian#229.

## Changes (e2e harness)

1. **Reorder `swap_to_oauth`/`restore_auth`**: wire the provider **before** `saveSettings()` so the channel rebuild's `getMe()` resolves the correct user (mirrors the prod fix).
2. **`restore_auth` verifies the rebind** (stream reconnects as the restored identity) and raises on cross-bind — fail at the restore site, not 40 tests downstream.
3. **`_oauth_ws_warm` no longer swallows** a failed restore into a `print`; a restore failure is surfaced as primary (it names the session-level problem).
4. **Channel diagnostic**: `wait_for_stream_connected` dumps `ws.readyState / connected / crdtJoined / crdtJoinFailedReason / pending-reconnect` on timeout (CI doesn't capture plugin-runtime logs). This is what cracked the root cause; kept as a permanent guard.

Reverted an earlier `reconnect_stream` disconnect+connect change (wrong hypothesis).

## Tests

Stack-free unit guards: `e2e/unit/test_oauth_rebind.py` (provider-before-saveSettings ordering + verified-restore-raises-on-cross-bind) and `test_cdp_stream.py` (diagnostic on timeout). Harness unit suite green (29 tests).

Pairs with **Engram-obsidian#229** (production `saveOAuthTokens` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)