### PR TITLE
feat(crdt): fan out per-note Yjs updates over the vault channel

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -941,6 +941,114 @@ class CdpClient:
         result = await self.evaluate(js)
         logger.info("Incoming sync resumed on CDP port %d: %s", self.port, result)
 
+    # ------------------------------------------------------------------
+    # Vault-channel fan-out isolation (crdt/test_crdt_sync.py)
+    # ------------------------------------------------------------------
+
+    async def suppress_fanout_backstops(self) -> str:
+        """Neutralize every idle-note convergence path EXCEPT the vault-channel
+        fan-out, so a disk-convergence assert on this instance becomes a TRUE
+        fan-out proof.
+
+        Under the vault-channel model an IDLE note (not open in the editor)
+        converges via the server's ``note_yjs_update`` broadcast → the plugin's
+        ``applyPushedNoteUpdate`` (sync.ts). TWO other paths also converge a cold
+        note off the ~5s checkpoint ``note_changed`` and would mask a broken
+        fan-out — every existing crdt test still passes at checkpoint latency
+        even if the fan-out is dead:
+
+          * ``pull()`` — its cursor-feed backfill (``flushFromCrdt`` on a
+            content_hash divergence) AND ``coldReceive()``, which ``pull()`` is
+            the sole caller of (invoked at its tail, sync.ts:2707).
+          * ``handleStreamEvent`` — the ``note_changed``/upsert handler, which
+            can STEP1-enroll the note's CRDT room (sync.ts:3246); an open room's
+            ``crdt_msg`` stream would then deliver the body independently.
+
+        This stubs ``pull()``, ``coldReceive()`` and ``handleStreamEvent`` to
+        no-ops (saving originals). The fan-out is a SEPARATE channel dispatch:
+        ``channel.ts`` routes ``note_yjs_update`` straight to ``onNoteYjsUpdate``
+        → ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
+        stays fully live. Idempotent.
+
+        Instances are SESSION-scoped and shared across tests, so every caller
+        MUST pair this with ``restore_fanout_backstops`` in a ``finally``.
+        """
+        js = f"""
+        (function() {{
+            const se = {ENGINE_PATH};
+            if (se.__fanoutIsolated) return 'already-isolated';
+            se.__fanoutIsolated = true;
+            se.__origPull = se.pull.bind(se);
+            se.__origColdReceive = se.coldReceive.bind(se);
+            se.__origHandleStreamEvent = se.handleStreamEvent.bind(se);
+            se.pull = async () => 0;
+            se.coldReceive = async () => 0;
+            se.handleStreamEvent = async () => {{}};
+            return 'isolated';
+        }})()
+        """
+        result = await self.evaluate(js)
+        logger.info("Fan-out backstops suppressed on CDP port %d: %s", self.port, result)
+        return result if isinstance(result, str) else "isolated"
+
+    async def restore_fanout_backstops(self) -> None:
+        """Restore the methods stubbed by suppress_fanout_backstops()."""
+        js = f"""
+        (function() {{
+            const se = {ENGINE_PATH};
+            if (!se.__fanoutIsolated) return 'not-isolated';
+            if (se.__origPull) se.pull = se.__origPull;
+            if (se.__origColdReceive) se.coldReceive = se.__origColdReceive;
+            if (se.__origHandleStreamEvent) se.handleStreamEvent = se.__origHandleStreamEvent;
+            delete se.__origPull;
+            delete se.__origColdReceive;
+            delete se.__origHandleStreamEvent;
+            delete se.__fanoutIsolated;
+            return 'restored';
+        }})()
+        """
+        result = await self.evaluate(js)
+        logger.info("Fan-out backstops restored on CDP port %d: %s", self.port, result)
+
+    async def get_note_id_for_path(self, path: str) -> str | None:
+        """Resolve the CRDT note_id the plugin has mapped for a vault path."""
+        return await self.evaluate(
+            f"{ENGINE_PATH}.noteIdMap "
+            f"? ({ENGINE_PATH}.noteIdMap.get({json.dumps(path)}) ?? null) : null"
+        )
+
+    async def get_enrolled_note_ids(self) -> list[str]:
+        """Snapshot CrdtEnrollment.enrolled — the note_ids this device has
+        STEP1-enrolled (opened a CRDT room for) this session."""
+        result = await self.evaluate(
+            f"{ENGINE_PATH}.crdtEnrollment "
+            f"? Array.from({ENGINE_PATH}.crdtEnrollment.enrolled) : []"
+        )
+        return result if isinstance(result, list) else []
+
+    async def is_crdt_doc_resident(self, note_id: str) -> bool:
+        """True when a Y.Doc for note_id is currently open in the CrdtManager.
+
+        The manager keys ``docs`` by the bare note_id (docId(noteId) === noteId,
+        manager.ts:198). ``closeDoc`` deletes the entry — so this going False is
+        the observable signal that ``hibernateIfIdle`` freed the doc.
+        """
+        return await self.evaluate(
+            f"Boolean({ENGINE_PATH}.crdt && {ENGINE_PATH}.crdt.docs && "
+            f"{ENGINE_PATH}.crdt.docs.has({json.dumps(note_id)}))"
+        ) is True
+
+    async def wait_for_crdt_doc_freed(self, note_id: str, timeout: float = 5) -> None:
+        """Poll until the CrdtManager no longer holds an open doc for note_id."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not await self.is_crdt_doc_resident(note_id):
+                return
+            await asyncio.sleep(0.2)
+        raise TimeoutError(
+            f"CRDT doc {note_id} still resident after {timeout}s on CDP port {self.port}"
+        )
+
     async def rename_file(self, old_path: str, new_path: str) -> None:
         """Rename a file through Obsidian's vault API (triggers handleRename)."""
         escaped_old = json.dumps(old_path)

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -140,3 +140,170 @@ async def test_edit_after_discovery_round_trips(vault_a, vault_b, cdp_a, cdp_b, 
 
     a_content = wait_for_content(vault_a, path, "appended on B", timeout=CRDT_TIMEOUT)
     assert "origin A" in a_content and "appended on B" in a_content
+
+
+# ---------------------------------------------------------------------------
+# Vault-channel fan-out isolation
+# ---------------------------------------------------------------------------
+#
+# The tests above prove eventual convergence but NOT that it rides the vault-
+# channel fan-out (`note_yjs_update` → applyPushedNoteUpdate). Two checkpoint-
+# driven backstops on the receiving device also converge a cold note: pull()'s
+# cursor-feed backfill (flushFromCrdt) and coldReceive() (invoked at pull()'s
+# tail). So if applyPushedNoteUpdate were completely broken, every test above
+# would STILL pass at ~5s checkpoint latency, masking a dead fan-out.
+#
+# The tests below suppress those backstops on the RECEIVING device via
+# cdp.suppress_fanout_backstops() (stubs pull, coldReceive AND handleStreamEvent
+# — the note_changed room-enroll path — while leaving applyPushedNoteUpdate
+# untouched, since the fan-out is a separate channel dispatch). With the
+# backstops dead, a disk-convergence assert can ONLY be satisfied by the
+# fan-out, so a broken fan-out actually FAILS. See helpers/cdp.py.
+
+
+async def _confirm_room_free(cdp, path):
+    """Precondition for a fan-out isolation test: the device has mapped +
+    confirmed `path` and holds NO CRDT room for it (so convergence can't ride a
+    crdt_msg room stream). Returns the note_id.
+
+    trigger_full_sync() drives the idle pull-discovery path, which maps +
+    confirms the note but does NOT STEP1-enroll a not-live-bound note
+    (sync.ts:3790/3820 guards) — so the note stays room-free.
+    """
+    await cdp.wait_for_stream_connected()
+    await cdp.trigger_full_sync()
+    note_id = await cdp.get_note_id_for_path(path)
+    assert note_id, f"device never mapped a note_id for {path} — cannot prove fan-out"
+    enrolled = await cdp.get_enrolled_note_ids()
+    assert note_id not in enrolled, (
+        f"precondition violated: device holds a CRDT room for idle note {path} "
+        f"(note_id={note_id}); convergence could ride crdt_msg, not the fan-out"
+    )
+    return note_id
+
+
+@pytest.mark.asyncio
+async def test_idle_note_converges_via_fanout_only(vault_a, vault_b, cdp_a, cdp_b, api_sync):
+    """[P0] A pre-existing IDLE note on B converges to A's edit via the vault-
+    channel fan-out ALONE.
+
+    B never opens or edits the note. Before A's edit we suppress every
+    checkpoint-driven backstop on B (pull() cursor-backfill + coldReceive, and
+    the note_changed room-enroll path). The ONLY path that can then converge B's
+    disk is the server's `note_yjs_update` broadcast → applyPushedNoteUpdate. So
+    a broken fan-out FAILS here instead of silently passing at checkpoint latency.
+    """
+    path = "E2E/Crdt/FanoutPassive.md"
+    await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "shared base\n", "shared base")
+    await _confirm_room_free(cdp_b, path)
+    try:
+        await cdp_b.suppress_fanout_backstops()
+
+        # A edits. With B's backstops dead, delivery can ONLY be the fan-out.
+        write_note(vault_a, path, "shared base\nFANOUT_ONLY\n")
+        b_final = wait_for_content(vault_b, path, "FANOUT_ONLY", timeout=CRDT_TIMEOUT)
+        assert "shared base" in b_final, f"base content lost on B: {b_final!r}"
+    finally:
+        await cdp_b.restore_fanout_backstops()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_edits_survive_over_fanout(vault_a, vault_b, cdp_a, cdp_b, api_sync):
+    """[P0] A and B concurrently edit the SAME note while NEITHER opens it, with
+    the checkpoint backstops suppressed on BOTH devices. Both edits survive on
+    both disks — proving the CRDT merge rides the vault-channel fan-out, not the
+    pull/coldReceive backstop.
+
+    New test — does NOT weaken test_concurrent_edits_both_survive (which permits
+    a backstop to converge); this is the strictly-fan-out variant.
+    """
+    path = "E2E/Crdt/FanoutMerge.md"
+    await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "shared base\n", "shared base")
+    await _confirm_room_free(cdp_a, path)
+    await _confirm_room_free(cdp_b, path)
+    try:
+        await cdp_a.suppress_fanout_backstops()
+        await cdp_b.suppress_fanout_backstops()
+
+        # Independent edits, close together so neither has seen the other's yet.
+        # Each side SENDS via handleModify/pushFile (untouched by suppression) and
+        # RECEIVES the other's over the fan-out (applyPushedNoteUpdate merges the
+        # remote delta after capturing local disk drift — both edits survive).
+        write_note(vault_a, path, "shared base\nFROM_A\n")
+        write_note(vault_b, path, "shared base\nFROM_B\n")
+
+        a_final = wait_for_content(vault_a, path, "FROM_B", timeout=CRDT_TIMEOUT)
+        b_final = wait_for_content(vault_b, path, "FROM_A", timeout=CRDT_TIMEOUT)
+        assert "FROM_A" in a_final and "FROM_B" in a_final, f"A lost an edit: {a_final!r}"
+        assert "FROM_A" in b_final and "FROM_B" in b_final, f"B lost an edit: {b_final!r}"
+    finally:
+        await cdp_a.restore_fanout_backstops()
+        await cdp_b.restore_fanout_backstops()
+
+
+@pytest.mark.asyncio
+async def test_cold_send_over_fanout_opens_no_room(vault_a, vault_b, cdp_a, cdp_b, api_sync):
+    """[P1] B edits a CLOSED note → A receives it via the fan-out, and B does NOT
+    STEP1-enroll a CRDT room for the note it cold-sent.
+
+    An idle SEND ships its edit channel-up / as a durable /updates entry and is
+    never required to enroll (sync.ts isCrdtManagedOffline: "Enrollment (STEP1)
+    is only the down-sync pull, never required to SEND"). We suppress backstops
+    on BOTH devices: on A so its receipt can ONLY be the fan-out, and on B so its
+    own checkpoint `note_changed` echo can't drive a RECEIVE-side enroll — the
+    enrolled-set assertion then isolates the SEND path. The negative signal is a
+    direct read of B's CrdtEnrollment.enrolled set (deterministic, no log-flush
+    timing dependency).
+    """
+    path = "E2E/Crdt/FanoutColdSend.md"
+    await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "origin\n", "origin")
+    note_id_b = await _confirm_room_free(cdp_b, path)
+    await _confirm_room_free(cdp_a, path)
+    try:
+        await cdp_a.suppress_fanout_backstops()
+        await cdp_b.suppress_fanout_backstops()
+
+        # B edits the CLOSED note (never opened in the editor).
+        write_note(vault_b, path, "origin\nCOLD_SEND_FROM_B\n")
+
+        a_final = wait_for_content(vault_a, path, "COLD_SEND_FROM_B", timeout=CRDT_TIMEOUT)
+        assert "origin" in a_final, f"base lost on A: {a_final!r}"
+
+        enrolled = await cdp_b.get_enrolled_note_ids()
+        assert note_id_b not in enrolled, (
+            f"B STEP1-enrolled a room for a cold SEND (note_id={note_id_b}); "
+            f"an idle send must stay room-free. enrolled={enrolled}"
+        )
+    finally:
+        await cdp_a.restore_fanout_backstops()
+        await cdp_b.restore_fanout_backstops()
+
+
+@pytest.mark.asyncio
+async def test_fanout_receive_after_hibernate_rehydrates(vault_a, vault_b, cdp_a, cdp_b, api_sync):
+    """[P1] A fan-out apply frees B's Y.Doc (applyPushedNoteUpdate →
+    hibernateIfIdle → closeDoc). A SECOND edit must still converge, proving the
+    apply-after-free path re-opens the doc from IndexedDB and merges correctly —
+    end to end, no process restart.
+    """
+    path = "E2E/Crdt/FanoutHibernate.md"
+    await _establish_on_both(vault_a, vault_b, cdp_b, api_sync, path, "base\n", "base")
+    note_id = await _confirm_room_free(cdp_b, path)
+    try:
+        await cdp_b.suppress_fanout_backstops()
+
+        # First remote edit converges via the fan-out, which then hibernates the
+        # idle doc after durably recording the head.
+        write_note(vault_a, path, "base\nEDIT_ONE\n")
+        wait_for_content(vault_b, path, "EDIT_ONE", timeout=CRDT_TIMEOUT)
+        await cdp_b.wait_for_crdt_doc_freed(note_id, timeout=CRDT_TIMEOUT)
+
+        # Second edit AFTER the doc was freed — must rehydrate from IndexedDB and
+        # merge, preserving the prior state.
+        write_note(vault_a, path, "base\nEDIT_ONE\nEDIT_TWO\n")
+        b_final = wait_for_content(vault_b, path, "EDIT_TWO", timeout=CRDT_TIMEOUT)
+        assert "EDIT_ONE" in b_final and "base" in b_final, (
+            f"rehydrated apply lost prior state: {b_final!r}"
+        )
+    finally:
+        await cdp_b.restore_fanout_backstops()

--- a/e2e/tests/crdt/test_web_to_obsidian_live.py
+++ b/e2e/tests/crdt/test_web_to_obsidian_live.py
@@ -77,16 +77,19 @@ async def test_web_edit_reaches_obsidian_live(web, vault_b, cdp_b, api_sync, syn
 async def test_web_edit_reaches_obsidian_that_missed_room_open(
     web, vault_b, cdp_b, api_sync, sync_vault_id
 ):
-    """Regression guard for the checkpoint-announce backstop (#940).
+    """Regression guard: a live web edit reaches an Obsidian instance that was
+    OFF the channel when the web opened the note's room.
 
-    Delivery of a live web edit to Obsidian normally rides the channel's
-    ROOM-OPEN announce (fired when the web opens the note) + observation. But if
-    Obsidian is OFF the channel at that instant, it misses the room-open announce
-    and does not observe the room. The ONLY thing that can then notify it of the
-    subsequent edit is the CHECKPOINT's own announce — the fix under test.
+    Under the vault-channel model B no longer relies on the old checkpoint-
+    ROOM-OPEN announce (#940). B is disconnected when the web opens the note, so
+    it misses any room-open announce and never observes the room. When B
+    reconnects, its reconnect catch-up runs pull() → coldReceive(), which diffs
+    the server head-index against B's persisted per-note crdtHead and pulls +
+    applies the web edit's Yjs delta — converging B's disk without B ever
+    opening the note's room.
 
-    So this FAILS on a backend without the checkpoint announce (the edit never
-    reaches B) and PASSES with it. Verified: red on 0.5.638, green on 0.5.639.
+    So this FAILS if the cold-receive reconnect path is broken (the edit never
+    reaches B) and PASSES with it.
     """
     path = "E2E/Crdt/WebMissedOpen.md"
 

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -62,8 +62,16 @@ defmodule Engram.Notes.CrdtDeliver do
     # the user's next real edit as an echo — silently dropping the write. Those
     # files sync via the legacy push path, so only deliver/announce for `.md`.
     if String.ends_with?(path, ".md") do
-      push_to_live_room(user_id, note_id, content)
-      fanout_idle(user_id, vault_id, note_id)
+      # A live room applies the committed state, and its `update_v1` already fans
+      # the resulting delta out over the SAME per-vault `sync:` channel. So the
+      # full-state `fanout_idle` is only needed when NO room exists (the
+      # first-delivery leg the room fan-out cannot cover) — running it alongside a
+      # live room would re-broadcast (and re-decrypt) the same note redundantly.
+      case push_to_live_room(user_id, note_id, content) do
+        :no_room -> fanout_idle(user_id, vault_id, note_id)
+        :room -> :ok
+      end
+
       announce(user_id, vault_id, note_id)
     end
 
@@ -136,10 +144,13 @@ defmodule Engram.Notes.CrdtDeliver do
   # the doubling corruption this module exists to prevent, and the announce
   # (step 2) still fires so enrolled clients re-pull. Every skip is logged at
   # :error (Sentry-visible) — a sustained fallback rate must be loud.
+  # Returns `:no_room` when no live room exists (the caller then runs the
+  # full-state `fanout_idle`), or `:room` when a room was found — its `update_v1`
+  # fans the delta out, so the caller skips the redundant idle fan-out.
   defp push_to_live_room(user_id, note_id, content) do
     case CrdtRegistry.lookup(note_id) do
       nil ->
-        :ok
+        :no_room
 
       room ->
         case load_merged_state(user_id, note_id) do
@@ -190,6 +201,8 @@ defmodule Engram.Notes.CrdtDeliver do
             # and the room must not survive: see quarantine_room/3.
             quarantine_room(room, note_id, reason)
         end
+
+        :room
     end
   end
 

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -62,16 +62,18 @@ defmodule Engram.Notes.CrdtDeliver do
     # the user's next real edit as an echo — silently dropping the write. Those
     # files sync via the legacy push path, so only deliver/announce for `.md`.
     if String.ends_with?(path, ".md") do
-      # A live room applies the committed state, and its `update_v1` already fans
-      # the resulting delta out over the SAME per-vault `sync:` channel. So the
-      # full-state `fanout_idle` is only needed when NO room exists (the
-      # first-delivery leg the room fan-out cannot cover) — running it alongside a
-      # live room would re-broadcast (and re-decrypt) the same note redundantly.
-      case push_to_live_room(user_id, note_id, content) do
-        :no_room -> fanout_idle(user_id, vault_id, note_id)
-        :room -> :ok
-      end
-
+      push_to_live_room(user_id, note_id, content)
+      # fanout_idle ALWAYS runs, even when a live room exists. It is NOT redundant
+      # with the room's `update_v1`: `update_v1` broadcasts a DELTA (converges a
+      # device that already holds the note, via gap-heal), while `fanout_idle`
+      # broadcasts FULL STATE — the only thing that makes a device which has NEVER
+      # seen the note history-FULL. Gating this off when a room exists left a
+      # first-delivery device history-LESS (delta into an empty doc), so a
+      # concurrent edit resolved to keep-both instead of a clean CRDT merge
+      # (e2e test_concurrent_edits_both_survive). The two broadcasts serve
+      # different device populations; the double-delivery for a device that has
+      # both is an idempotent Yjs re-apply.
+      fanout_idle(user_id, vault_id, note_id)
       announce(user_id, vault_id, note_id)
     end
 
@@ -144,13 +146,10 @@ defmodule Engram.Notes.CrdtDeliver do
   # the doubling corruption this module exists to prevent, and the announce
   # (step 2) still fires so enrolled clients re-pull. Every skip is logged at
   # :error (Sentry-visible) — a sustained fallback rate must be loud.
-  # Returns `:no_room` when no live room exists (the caller then runs the
-  # full-state `fanout_idle`), or `:room` when a room was found — its `update_v1`
-  # fans the delta out, so the caller skips the redundant idle fan-out.
   defp push_to_live_room(user_id, note_id, content) do
     case CrdtRegistry.lookup(note_id) do
       nil ->
-        :no_room
+        :ok
 
       room ->
         case load_merged_state(user_id, note_id) do
@@ -201,8 +200,6 @@ defmodule Engram.Notes.CrdtDeliver do
             # and the room must not survive: see quarantine_room/3.
             quarantine_room(room, note_id, reason)
         end
-
-        :room
     end
   end
 

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -39,7 +39,8 @@ defmodule Engram.Notes.CrdtDeliver do
 
   alias Engram.{Accounts, Crypto, Repo}
   alias Engram.Logger.Metadata
-  alias Engram.Notes.{CrdtBridge, CrdtRegistry, Note}
+  alias Engram.Notes.{CrdtBridge, CrdtRegistry, CrdtTransport, Note}
+  alias Engram.Sync.Broadcast
   alias Yex.Sync.SharedDoc
 
   require Logger
@@ -62,8 +63,48 @@ defmodule Engram.Notes.CrdtDeliver do
     # files sync via the legacy push path, so only deliver/announce for `.md`.
     if String.ends_with?(path, ".md") do
       push_to_live_room(user_id, note_id, content)
+      fanout_idle(user_id, vault_id, note_id)
       announce(user_id, vault_id, note_id)
     end
+
+    :ok
+  end
+
+  # Vault-channel fan-out for a NON-CRDT-origin write (REST / MCP / web / cascade):
+  # broadcast the note's just-committed Yjs state over the per-vault `sync:` topic
+  # so an IDLE device (one with no open room for this note) converges room-free by
+  # applying these bytes (`applyPushedNoteUpdate` on the client). This is the
+  # FIRST-DELIVERY leg the room's `update_v1` fan-out cannot cover: a REST/MCP/web
+  # create+update never enters a live room, so without this an idle device only
+  # ever learns the note through slow pull discovery (the announce enrolls it, but
+  # the plugin now leaves idle notes room-free under the fan-out model).
+  #
+  # Broadcasts the FULL committed state (not a delta) so a device that has never
+  # seen the note converges from an empty doc; the client skips it while the note
+  # is live-bound (its own room owns it). Emitted AFTER the `note_changed` upsert
+  # broadcast, on the SAME `sync:` topic (ordered delivery), so the client has
+  # already mapped + confirmed the note_id before these bytes arrive. Best-effort
+  # and post-commit like the rest of deliver-out: a state-less (legacy/lazy) row
+  # or a load failure simply skips — the announce still fires for enrolled clients.
+  defp fanout_idle(user_id, vault_id, note_id) do
+    _ =
+      with {:ok, state} when is_binary(state) <- load_merged_state(user_id, note_id) do
+        head =
+          case CrdtBridge.doc_from_state(state) do
+            {:ok, doc} -> CrdtTransport.head_marker(doc)
+            _ -> nil
+          end
+
+        Broadcast.emit(
+          "sync:#{user_id}:#{vault_id}",
+          "note_yjs_update",
+          %{
+            "note_id" => note_id,
+            "b64" => Base.encode64(state),
+            "head" => head
+          }
+        )
+      end
 
     :ok
   end

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -19,11 +19,13 @@ defmodule Engram.Notes.CrdtPersistence do
   import Ecto.Query
   alias Engram.{Accounts, Crypto, Repo}
   alias Engram.Logger.Metadata
+  alias Engram.Sync.Broadcast
 
   alias Engram.Notes.{
     CheckpointGate,
     CrdtBridge,
     CrdtCheckpointTimer,
+    CrdtTransport,
     CrdtUpdateLog,
     Enqueue,
     Note
@@ -92,7 +94,7 @@ defmodule Engram.Notes.CrdtPersistence do
         %{user_id: user_id, vault_id: vault_id, note_id: note_id} = state,
         update,
         _name,
-        _doc
+        doc
       ) do
     user = state[:user] || Accounts.get_user!(user_id)
 
@@ -120,6 +122,26 @@ defmodule Engram.Notes.CrdtPersistence do
           )
           |> Repo.update_all(set: [crdt_head: nil])
         end)
+
+        # Fan out the update to every device on this vault over the single
+        # per-vault sync channel (Relay's `document.updated` model). This is
+        # what lets an IDLE note (one the client never STEP1-enrolled) converge
+        # without opening its own CRDT room: the client applies these pushed
+        # bytes straight to the note's Y.Doc. Fires on EVERY update source
+        # (channel, REST /updates, deliver-out) because they all funnel here.
+        # base64 because the JSON serializer can't carry raw binary; `head` lets
+        # the client advance its per-note watermark without a REST round-trip.
+        # Self-echo is harmless: the client applies with REMOTE_ORIGIN (no
+        # re-broadcast) and Yjs re-apply is a no-op.
+        Broadcast.emit(
+          "sync:#{user_id}:#{vault_id}",
+          "note_yjs_update",
+          %{
+            "note_id" => note_id,
+            "b64" => Base.encode64(update),
+            "head" => CrdtTransport.head_marker(doc)
+          }
+        )
 
       {:error, reason} ->
         Logger.error(

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -133,6 +133,17 @@ defmodule Engram.Notes.CrdtPersistence do
         # the client advance its per-note watermark without a REST round-trip.
         # Self-echo is harmless: the client applies with REMOTE_ORIGIN (no
         # re-broadcast) and Yjs re-apply is a no-op.
+        #
+        # NOTE — `b64` here is the DELTA (this single update), paired with the
+        # FULL post-apply `head`. `CrdtDeliver.fanout_idle` sends FULL state under
+        # the same contract. A device behind the delta's causal deps (it never
+        # STEP1-enrolled and missed an earlier update) PENDS the delta in Yjs, so
+        # it does NOT actually reach `head`. The client MUST NOT blind-trust `head`
+        # in that case: `applyPushedNoteUpdate` checks `hasPendingGap` post-apply
+        # and, on a gap, pulls the full delta from its real state vector and
+        # advances the watermark only to the head it truly reached (plugin
+        # `e2304ed`). Without that client guard, the cheap cold-reconcile hash gate
+        # would skip a silently-partial note.
         Broadcast.emit(
           "sync:#{user_id}:#{vault_id}",
           "note_yjs_update",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.664",
+      version: "0.5.665",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -52,6 +52,45 @@ defmodule Engram.Notes.CrdtDeliverTest do
     end
   end
 
+  describe "deliver_out — vault-channel fan-out (idle first-delivery)" do
+    test "a REST write broadcasts note_yjs_update carrying the committed state on the sync topic",
+         %{user: user, vault: vault} do
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "fan.md",
+          "content" => "# Fan\n\nfanout body"
+        })
+
+      # note_changed fires first (maps + confirms the id on the client); the
+      # fan-out note_yjs_update follows on the SAME topic (ordered), carrying the
+      # full committed Yjs state so an idle device converges room-free.
+      assert_receive %Phoenix.Socket.Broadcast{event: "note_changed"}
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_yjs_update",
+        payload: %{"note_id" => note_id, "b64" => b64}
+      }
+
+      assert note_id == note.id
+      state = Base.decode64!(b64)
+      assert byte_size(state) > 0
+      {:ok, doc} = CrdtBridge.doc_from_state(state)
+      text = doc |> Yex.Doc.get_text(CrdtBridge.text_name()) |> Yex.Text.to_string()
+      assert text =~ "fanout body"
+    end
+
+    test "does NOT fan out for a non-.md note", %{user: user, vault: vault} do
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+      note_id = Ecto.UUID.generate()
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "board.canvas", note_id, "x")
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "note_yjs_update"}, 100
+    end
+  end
+
   describe "announce_ready/4 — discovery-only (checkpoint path)" do
     test "announces crdt_doc_ready for a .md note without touching any room",
          %{user: user, vault: vault} do

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -89,6 +89,61 @@ defmodule Engram.Notes.CrdtDeliverTest do
 
       refute_receive %Phoenix.Socket.Broadcast{event: "note_yjs_update"}, 100
     end
+
+    test "a state-less (legacy/lazy) row does NOT fan out note_yjs_update but still announces",
+         %{user: user, vault: vault} do
+      # load_merged_state returns {:ok, nil} for a row with no persisted CRDT
+      # state; the `with {:ok, state} when is_binary(state)` guard skips the
+      # broadcast (nothing to fan out), and the announce still lets enrolled
+      # clients re-pull. Locks the "never crash / graceful skip" fallback.
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "leg.md", "content" => "x"})
+
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(from(n in Note, where: n.id == ^note.id),
+            set: [crdt_state_ciphertext: nil, crdt_state_nonce: nil]
+          )
+        end)
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+      EngramWeb.Endpoint.subscribe("crdt:#{user.id}:#{vault.id}")
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "leg.md", note.id, "x")
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "note_yjs_update"}, 200
+      assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
+    end
+
+    test "a doc_from_state failure still broadcasts the state with head: nil (no raise)",
+         %{user: user, vault: vault} do
+      # Deep-corruption fallback: load_merged_state returns a binary that
+      # doc_from_state cannot parse (a shouldn't-happen state). fanout_idle must
+      # not raise the caller — it broadcasts the state with head: nil, and the
+      # client, unable to advance its watermark, re-pulls via coldReceive.
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "g.md", "content" => "x"})
+
+      {:ok, {ct, nonce}} = Engram.Crypto.encrypt_crdt_state("not a yjs update", user, note.id)
+
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(from(n in Note, where: n.id == ^note.id),
+            set: [crdt_state_ciphertext: ct, crdt_state_nonce: nonce]
+          )
+        end)
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "g.md", note.id, "x")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "note_yjs_update",
+                       payload: %{"note_id" => note_id, "head" => head}
+                     },
+                     1000
+
+      assert note_id == note.id
+      assert head == nil
+    end
   end
 
   describe "announce_ready/4 — discovery-only (checkpoint path)" do
@@ -184,6 +239,25 @@ defmodule Engram.Notes.CrdtDeliverTest do
       # ...but the announce always fires (twice total).
       assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
       assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
+    end
+
+    test "does NOT fan out the redundant note_yjs_update when a live room exists",
+         %{user: user, vault: vault} do
+      # A live room's own update_v1 fans the delta out over the SAME per-vault
+      # sync topic, so the full-state fanout_idle is gated off — else the same
+      # write re-broadcasts (and re-decrypts) the note. (The bare test room has no
+      # persistence, so update_v1 doesn't fire here; the point is only that the
+      # redundant fanout_idle does not.)
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "r.md", "content" => "body"})
+      _room = start_bare_room(note.id, "")
+
+      # Subscribe AFTER upsert so the upsert's own (room-less) fan-out is not
+      # counted — we only measure this direct deliver_out, which has a live room.
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "r.md", note.id, "body")
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "note_yjs_update"}, 200
     end
   end
 

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -241,23 +241,31 @@ defmodule Engram.Notes.CrdtDeliverTest do
       assert_receive %Phoenix.Socket.Broadcast{event: "crdt_doc_ready"}, 1000
     end
 
-    test "does NOT fan out the redundant note_yjs_update when a live room exists",
+    test "STILL fans out full state even when a live room exists (first-delivery coverage)",
          %{user: user, vault: vault} do
-      # A live room's own update_v1 fans the delta out over the SAME per-vault
-      # sync topic, so the full-state fanout_idle is gated off — else the same
-      # write re-broadcasts (and re-decrypts) the note. (The bare test room has no
-      # persistence, so update_v1 doesn't fire here; the point is only that the
-      # redundant fanout_idle does not.)
+      # fanout_idle is NOT gated off when a room exists: update_v1 only ships a
+      # DELTA, which converges a device that already holds the note, whereas the
+      # full-state fan-out is the only thing that makes a NEVER-SEEN device
+      # history-full. Suppressing it left first-delivery devices history-less and
+      # a concurrent edit resolved to keep-both instead of a clean merge (e2e
+      # test_concurrent_edits_both_survive). The double-delivery for a device that
+      # has both is an idempotent Yjs re-apply.
       {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "r.md", "content" => "body"})
       _room = start_bare_room(note.id, "")
 
-      # Subscribe AFTER upsert so the upsert's own (room-less) fan-out is not
-      # counted — we only measure this direct deliver_out, which has a live room.
+      # Subscribe AFTER upsert so only this direct deliver_out (with a live room)
+      # is measured.
       EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
 
       assert :ok = CrdtDeliver.deliver_out(user.id, vault.id, "r.md", note.id, "body")
 
-      refute_receive %Phoenix.Socket.Broadcast{event: "note_yjs_update"}, 200
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "note_yjs_update",
+                       payload: %{"note_id" => note_id}
+                     },
+                     1000
+
+      assert note_id == note.id
     end
   end
 

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -191,6 +191,34 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert {:ok, ^upd} = Crypto.decrypt_crdt_state(raw_note, user)
   end
 
+  test "update_v1/4 fans out the update over the vault sync channel", ctx do
+    %{user: user, note: note} = ctx
+    st = %{user_id: user.id, vault_id: note.vault_id, note_id: note.id}
+
+    {:ok, %{state: upd}} = CrdtBridge.merge_plaintext(nil, "hello fanout")
+
+    # Simulate the room: SharedDoc applies the update BEFORE calling update_v1,
+    # so head_marker(doc) reflects post-apply state.
+    doc = CrdtBridge.new_doc()
+    :ok = Yex.apply_update(doc, upd)
+
+    topic = "sync:#{user.id}:#{note.vault_id}"
+    EngramWeb.Endpoint.subscribe(topic)
+
+    _st2 = CrdtPersistence.update_v1(st, upd, note.id, doc)
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      topic: ^topic,
+      event: "note_yjs_update",
+      payload: %{"note_id" => note_id, "b64" => b64, "head" => head}
+    }
+
+    assert note_id == note.id
+    assert {:ok, ^upd} = Base.decode64(b64)
+    assert is_binary(head) and head != ""
+    assert head == Engram.Notes.CrdtTransport.head_marker(doc)
+  end
+
   test "update_v1/4 with cached user does not hit Accounts.get_user!", ctx do
     %{user: user, note: note} = ctx
     # Bind first so the cached user is in the state


### PR DESCRIPTION
## What

Server half of eliminating the vault-connect "storm." Broadcast each applied CRDT update over the single per-vault `sync` channel from the `CrdtPersistence.update_v1/4` chokepoint — every update source (crdt channel, REST `/updates`, deliver-out) funnels through this one function.

This is Relay's `document.updated` model: every device on a vault now receives every note's update bytes **without** STEP1-enrolling (observing) that note's room. Idle notes converge over the one channel the plugin already joins, instead of the plugin opening a `crdt:` room per note on connect.

## Payload

`note_yjs_update` on `sync:{user_id}:{vault_id}` → `%{"note_id", "b64", "head"}`
- `b64`: base64 of the raw v1 update (the JSON serializer can't carry raw binary)
- `head`: server post-apply head marker (`CrdtTransport.head_marker/1`) so the client advances its per-note watermark without a REST round-trip

Self-echo is harmless: the client applies with `REMOTE_ORIGIN` (no re-broadcast) and Yjs re-apply is a no-op.

## Pairs with

Plugin PR `feat/vault-channel-crdt-fanout` (same branch name → e2e auto-pairs). Backend #984 (bounded checkpoints) is the server-side companion already merged.

## Deliver-out leg (REST / MCP / web / cascade)

`update_v1` only fires for writes that pass through a live room. A REST/MCP/web create+update to an IDLE note never enters a room, so `CrdtDeliver.deliver_out` adds `fanout_idle`: it broadcasts the note's committed FULL state as `note_yjs_update` on the same `sync:` topic, after the `note_changed` upsert (ordered), so an idle device converges room-free. Best-effort and post-commit — a state-less/legacy row or a load failure simply skips; the `crdt_doc_ready` announce still backstops enrolled clients.

**`fanout_idle` runs even when a live room exists** (not gated). `update_v1` ships only a DELTA, which converges a device that already holds the note; `fanout_idle`'s FULL state is the only thing that makes a NEVER-SEEN device history-full. A gate that skipped it when a room existed left a first-delivery device history-less, so a concurrent edit resolved to keep-both instead of a clean merge (caught by e2e `test_concurrent_edits_both_survive`). The two broadcasts serve different device populations; the double-delivery for a device that has both is an idempotent Yjs re-apply.

**Delta vs full-state note (client contract):** a device behind the delta's causal deps PENDS it in Yjs and does not reach `head` — the client MUST NOT blind-trust the head there. The plugin's `applyPushedNoteUpdate` gap-heal (engram-obsidian#233, `e2304ed`) checks `hasPendingGap` and advances the watermark only to the head it truly reached. Documented at the emit site.

## Tests

- New: `update_v1` fan-out (topic/event/decodable `b64`/head, idempotent re-apply); `deliver_out` fan-out carries committed state; state-less row skips fan-out but still announces; `doc_from_state` failure broadcasts `head: nil` without raising; full state still fans out with a live room present.
- Full suite green; `mix format --check`, `credo --strict`, and `dialyzer` all clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
