### PR TITLE
feat: frontmatter resilience: degrade cleanly and surface parse reasons

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -17,17 +17,5 @@
   # binary-shape union from the leading three pattern matches, but the spec
   # has to remain `term()` so future callers don't fail type-check at the
   # boundary. Same pattern as the AAD helpers above.
-  {"lib/engram/crypto/key_provider.ex", :contract_supertype, 71},
-
-  # `decode_value/1`'s catch-all clause handles a Y.Map value written directly
-  # over the Yjs wire protocol (apply_update/2) by a buggy or hostile peer,
-  # bypassing Frontmatter's own JSON-string encoding entirely — e.g. a raw
-  # number/bool/nil/nested-map. Every ACTUAL lib/ call site happens to route
-  # through our own encode path (always a binary), so dialyzer's success
-  # typing (correctly, for the code it can see) concludes the clause is dead.
-  # It isn't: it's the only thing standing between a hostile CRDT write and a
-  # bricked note (emit/2 must stay total). Verified by deleting the clause —
-  # it breaks "emit degrades an unserializable value instead of raising" and
-  # "emit tolerates a non-binary value" in frontmatter_test.exs.
-  {"lib/engram/notes/frontmatter.ex", :pattern_match_cov, {418, 8}}
+  {"lib/engram/crypto/key_provider.ex", :contract_supertype, 71}
 ]

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -19,12 +19,15 @@
   # boundary. Same pattern as the AAD helpers above.
   {"lib/engram/crypto/key_provider.ex", :contract_supertype, 71},
 
-  # `use JokenJwks.DefaultStrategyTemplate` injects `init/1` via macro expansion.
-  # The injected callback's success typing (derived from the GenServer macro chain)
-  # doesn't match the module-level no_return inference that dialyzer makes for
-  # the module's `init/1` wrapper. This is a library-level type mismatch in
-  # JokenJwks that we cannot fix without patching the upstream dependency.
-  # Adding y_ex to mix.lock (CRDT PR) causes PLT rebuild which first exposes
-  # this pre-existing JokenJwks type issue.
-  {"lib/engram/auth/clerk_strategy.ex", :no_return, 10}
+  # `decode_value/1`'s catch-all clause handles a Y.Map value written directly
+  # over the Yjs wire protocol (apply_update/2) by a buggy or hostile peer,
+  # bypassing Frontmatter's own JSON-string encoding entirely — e.g. a raw
+  # number/bool/nil/nested-map. Every ACTUAL lib/ call site happens to route
+  # through our own encode path (always a binary), so dialyzer's success
+  # typing (correctly, for the code it can see) concludes the clause is dead.
+  # It isn't: it's the only thing standing between a hostile CRDT write and a
+  # bricked note (emit/2 must stay total). Verified by deleting the clause —
+  # it breaks "emit degrades an unserializable value instead of raising" and
+  # "emit tolerates a non-binary value" in frontmatter_test.exs.
+  {"lib/engram/notes/frontmatter.ex", :pattern_match_cov, {408, 8}}
 ]

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -29,5 +29,5 @@
   # bricked note (emit/2 must stay total). Verified by deleting the clause —
   # it breaks "emit degrades an unserializable value instead of raising" and
   # "emit tolerates a non-binary value" in frontmatter_test.exs.
-  {"lib/engram/notes/frontmatter.ex", :pattern_match_cov, {408, 8}}
+  {"lib/engram/notes/frontmatter.ex", :pattern_match_cov, {418, 8}}
 ]

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -818,7 +818,14 @@ jobs:
           echo "Version bumped: $MAIN_VERSION → $BRANCH_VERSION"
 
   e2e-clerk:
-    needs: [fingerprint, prebuild-ci-image]
+    # Also gate on the heavy non-e2e jobs (unit-tests ~6min, n1-compat ~3min).
+    # They saturate the shared runner VM's CPU, and when they run concurrently
+    # with e2e they starve its 30s live-delivery budgets — a rotating-victim
+    # flake (#355) that within-suite serialization alone can't fix (e.g. test_34
+    # materialized=no, test_edit_after_discovery). e2e needs a quiet VM, so it
+    # waits for the heavy jobs to finish. crdt gates on the same set; api/local/
+    # browser inherit the wait by chaining off clerk+crdt.
+    needs: [fingerprint, prebuild-ci-image, unit-tests, n1-compat]
     # Serialize the two heavy full-Obsidian suites (this + e2e-crdt) via a shared
     # per-ref concurrency group so they don't co-tenant the runner pool and starve
     # each other's timing budgets (the #355 rotating-victim flake). Queue, never
@@ -1606,8 +1613,10 @@ jobs:
     # runner-pool CPU: running two full Obsidian suites at once stretches every
     # timing budget (the #355 rotating-victim flake), so the shared per-ref
     # `concurrency` group below SERIALIZES this suite with e2e-clerk (queue, not
-    # cancel) rather than running them simultaneously.
-    needs: [fingerprint, prebuild-ci-image]
+    # cancel) rather than running them simultaneously. Also gate on the heavy
+    # non-e2e jobs (unit-tests, n1-compat) so e2e runs on a quiet VM — see the
+    # e2e-clerk needs comment (#355).
+    needs: [fingerprint, prebuild-ci-image, unit-tests, n1-compat]
     concurrency:
       group: e2e-obsidian-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1220,7 +1220,7 @@ jobs:
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/ --ignore=tests/api_only/ --ignore=tests/crdt/ \
             "${K_ARGS[@]}" \
-            -n "${E2E_WORKERS:-1}" --dist=loadfile \
+            -n "${E2E_WORKERS:-2}" --dist=loadfile \
             -v --timeout=300 -p no:cacheprovider --no-header
         env:
           E2E_PATTERN: ${{ needs.fingerprint.outputs.e2e-target-pattern }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1196,9 +1196,11 @@ jobs:
       - name: "Run Obsidian E2E tests"
         if: always()
         working-directory: e2e
-        # -n 2 --dist=loadfile: two xdist workers, each owns whole test files
-        # (preserves intra-file ordering for test_31 restart + test_50 smoke).
-        # E2E_WORKERS defaults to 2 but can be overridden to 1 for rollback.
+        # -n 1 --dist=loadfile: SINGLE worker. Two concurrent workers each drive
+        # their own Obsidian instance doing live Clerk auth + CRDT joins, which
+        # races identity-rebind / auth timing and tips a rotating clerk flake
+        # (#355 — e.g. test_84 crdtJoinFailedReason=unauthorized). Serializing the
+        # suite is the stability lever; set E2E_WORKERS=2 to restore parallelism.
         run: |
           # tests/crdt/ is the CRDT-only suite (spec §12a). It opts the plugin
           # into CRDT and uses eventually-consistent assertions, so it must NOT
@@ -1211,7 +1213,7 @@ jobs:
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/ --ignore=tests/api_only/ --ignore=tests/crdt/ \
             "${K_ARGS[@]}" \
-            -n "${E2E_WORKERS:-2}" --dist=loadfile \
+            -n "${E2E_WORKERS:-1}" --dist=loadfile \
             -v --timeout=300 -p no:cacheprovider --no-header
         env:
           E2E_PATTERN: ${{ needs.fingerprint.outputs.e2e-target-pattern }}

--- a/docs/superpowers/plans/2026-07-12-frontmatter-resilience-backend.md
+++ b/docs/superpowers/plans/2026-07-12-frontmatter-resilience-backend.md
@@ -1,0 +1,618 @@
+# Frontmatter Resilience + Note Diagnostics — Backend Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make note ingestion "degrade, don't detonate" — a note with unparseable frontmatter is stored as-is, its good keys still extracted, the bad key(s) preserved losslessly and reported with a structured reason, and no single note can ever 500 a batch or crash a room.
+
+**Architecture:** Make the `Frontmatter` codec total and per-key lenient (extract good keys, collect bad keys with their raw source for verbatim re-emit). Persist a `parse_status` + `parse_reason` on the note. Wrap the batch loop in per-note rescue so any future parser raise degrades one note instead of the batch. Echo the reason in the batch response and the sync feed.
+
+**Tech Stack:** Elixir 1.17 / Phoenix 1.8, Ecto/Postgres, Yex (Yjs), YamlElixir (parse), Ymlr (emit), Jason.
+
+## Global Constraints
+
+- Branch `feat/frontmatter-resilience`, already created off `origin/main` (d01f8711 = prod 0.5.665). Worktree: `engram/.worktrees/feat-frontmatter-resilience`.
+- One `mix.exs` version bump, only when the PR is opened. No per-task version bumps.
+- Before any push: `mix format`, `mix credo --strict`, `mix sobelow`, `mix dialyzer`, and the FULL `mix test` must pass (pre-push gates format+credo+sobelow; dialyzer + full test are additionally required).
+- Migrations are the **expand** phase (additive columns, defaults). PR needs the `phase/expand` label. Never edit a shipped migration.
+- No em dashes in user-facing copy (`message` strings): use periods, commas, colons.
+- `Frontmatter` functions must stay **total** (never raise) — every checkpoint/REST/CRDT write projects through them.
+
+---
+
+## Reason contract (produced here, consumed by plugin/web plans)
+
+```elixir
+# stored in notes.parse_reason (jsonb), echoed in batch response + sync feed
+%{
+  "code" => "frontmatter_unparseable_key" | "frontmatter_invalid_yaml" | "note_processing_failed",
+  "message" => "Frontmatter key \"date\" is not valid YAML.",   # human, no em dashes
+  "detail" => %{"key" => "date", "line" => 2, "snippet" => "date:YYYY-MM-DD"}  # optional fields
+}
+```
+`parse_status` is `"ok"` or `"degraded"`.
+
+---
+
+### Task 1: `encode_values/1` becomes total and per-key lenient
+
+**Files:**
+- Modify: `lib/engram/notes/frontmatter.ex` (`encode_values/1`, ~line 78-99)
+- Test: `test/engram/notes/frontmatter_test.exs`
+
+**Interfaces:**
+- Produces: `Frontmatter.encode_values(map) :: {values :: %{String.t()=>String.t()}, bad_keys :: [String.t()]}` — never raises. `values` holds only JSON-encodable keys; `bad_keys` lists keys whose value (or key type) could not be JSON-encoded.
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/engram/notes/frontmatter_test.exs
+describe "encode_values/1 leniency" do
+  test "keeps encodable keys and collects the unencodable ones without raising" do
+    map = %{"tags" => ["a", "b"], "weird" => {:a, :tuple}}
+    assert {values, bad_keys} = Frontmatter.encode_values(map)
+    assert values["tags"] == ~s(["a","b"])
+    refute Map.has_key?(values, "weird")
+    assert bad_keys == ["weird"]
+  end
+
+  test "an exotic (charlist/tuple) KEY in a nested map is collected, not raised" do
+    # mirrors the yamerl output that 500'd prod (date:YYYY-MM-DD)
+    map = %{"date" => %{~c"tag:yaml.org,2002:str" => "x"}}
+    assert {values, bad_keys} = Frontmatter.encode_values(map)
+    assert bad_keys == ["date"]
+    assert values == %{}
+  end
+
+  test "all-good map returns empty bad_keys" do
+    assert {values, []} = Frontmatter.encode_values(%{"a" => 1, "b" => "s"})
+    assert values == %{"a" => "1", "b" => ~s("s")}
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/engram/notes/frontmatter_test.exs -o "encode_values/1 leniency"`
+Expected: FAIL — current `encode_values` returns `{:ok, map} | :error` and raises on the exotic-key case.
+
+- [ ] **Step 3: Rewrite `encode_values/1`**
+
+```elixir
+# Encode each key's value to a JSON string. Total: a value (or exotic key inside
+# a nested map) that Jason cannot encode is COLLECTED into bad_keys instead of
+# raising or aborting. Returns {values, bad_keys}.
+@doc false
+def encode_values(map) do
+  Enum.reduce(map, {%{}, []}, fn {k, v}, {values, bad} ->
+    case safe_encode(deep_sort(v)) do
+      {:ok, json_str} -> {Map.put(values, k, json_str), bad}
+      :error -> {values, [k | bad]}
+    end
+  end)
+  |> then(fn {values, bad} -> {values, Enum.reverse(bad)} end)
+end
+
+# Jason.encode/1 returns {:error,_} for some terms but RAISES for others
+# (e.g. a charlist/tuple map KEY -> List.to_string/Protocol.UndefinedError).
+# Trap both so the codec is total.
+defp safe_encode(term) do
+  case Jason.encode(term) do
+    {:ok, s} -> {:ok, s}
+    {:error, _} -> :error
+  end
+rescue
+  _ -> :error
+end
+```
+
+Note: the `rescue` here converts an unexpected library raise into the graceful `:error` path. It is NOT swallowing a bug — surfacing the unencodable key IS the feature (Task 2 records which key). The underlying "why" is reported to the user, not hidden.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/engram/notes/frontmatter_test.exs -o "encode_values/1 leniency"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/notes/frontmatter.ex test/engram/notes/frontmatter_test.exs
+git commit -m "fix(frontmatter): make encode_values total + per-key lenient"
+```
+
+---
+
+### Task 2: `parse/1` returns degraded-key diagnostics; update callers
+
+**Files:**
+- Modify: `lib/engram/notes/frontmatter.ex` (`parse/1` ~line 60-76; add a raw-slice helper)
+- Modify: `lib/engram/notes/okf_fields.ex` (`extract/1`, the `with` ~line 30)
+- Modify: `lib/engram/notes/crdt_bridge.ex` (`ingest_plaintext/2` ~line 243, `normalize_doc/1` ~line 275)
+- Test: `test/engram/notes/frontmatter_test.exs`
+
+**Interfaces:**
+- Produces: `Frontmatter.parse(block) :: {:ok, order, values, degraded} | :error` where `degraded :: [%{key: String.t(), line: pos_integer() | nil, snippet: String.t()}]`. `:error` is returned ONLY when the block is not YAML-map-shaped at all (whole-block failure). A map that parses but has some unencodable keys returns `{:ok, order_of_good_keys, values, degraded}`.
+- Consumes: callers pattern-match the new 4-tuple.
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+test "parse/1 reports degraded keys with snippet + line, keeps good keys" do
+  block = "tags:\n  - a\ndate:YYYY-MM-DD\n"
+  assert {:ok, order, values, degraded} = Frontmatter.parse(block)
+  assert "tags" in order
+  assert values["tags"] == ~s(["a"])
+  assert [%{key: "date", snippet: "date:YYYY-MM-DD", line: 3}] = degraded
+  refute Map.has_key?(values, "date")
+end
+
+test "parse/1 returns :error only for non-map YAML" do
+  assert :error = Frontmatter.parse("just a scalar\n")
+end
+
+test "parse/1 empty block" do
+  assert {:ok, [], %{}, []} = Frontmatter.parse("")
+end
+```
+
+(Adjust `line: 3` to the emitted 1-based source line of the key within the block; the helper computes it from `String.split(block, "\n")`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mix test test/engram/notes/frontmatter_test.exs -o "parse/1"`
+Expected: FAIL — `parse/1` currently returns a 3-tuple and `:error` on any bad key.
+
+- [ ] **Step 3: Rewrite `parse/1` + add raw-slice helper**
+
+```elixir
+@spec parse(String.t()) ::
+        {:ok, [String.t()], %{String.t() => String.t()}, [map()]} | :error
+def parse(""), do: {:ok, [], %{}, []}
+
+def parse(block) when is_binary(block) do
+  case YamlElixir.read_from_string(block) do
+    {:ok, map} when is_map(map) ->
+      order = top_level_key_order(block, map)
+      {values, bad_keys} = encode_values(map)
+      degraded = Enum.map(bad_keys, &degraded_entry(&1, block))
+      # Good keys keep source order; bad keys are dropped from `values`/`order`
+      # but preserved via `degraded` (raw passthrough happens in emit, Task 3).
+      good_order = Enum.filter(order, &Map.has_key?(values, &1))
+      {:ok, good_order, values, degraded}
+
+    _ ->
+      :error
+  end
+end
+
+# Best-effort source location + raw slice for a top-level key.
+defp degraded_entry(key, block) do
+  lines = String.split(block, "\n")
+  idx = Enum.find_index(lines, fn l -> Regex.match?(~r/^#{Regex.escape(key)}\s*:/, l) end)
+  {line, snippet} =
+    case idx do
+      nil -> {nil, key}
+      i -> {i + 1, Enum.at(lines, i)}
+    end
+  %{key: key, line: line, snippet: snippet}
+end
+```
+
+- [ ] **Step 4: Update the two callers to the 4-tuple (behavior preserved)**
+
+`lib/engram/notes/okf_fields.ex` — the `with` clause:
+```elixir
+with {block, _body} when is_binary(block) <- Frontmatter.split(content),
+     {:ok, _order, values, _degraded} <- Frontmatter.parse(block) do
+```
+
+`lib/engram/notes/crdt_bridge.ex` `ingest_plaintext/2`:
+```elixir
+{order, values, body} =
+  case fm_block && Frontmatter.parse(fm_block) do
+    {:ok, order, values, _degraded} -> {order, values, body}
+    _ -> {[], %{}, plaintext}
+  end
+```
+
+`lib/engram/notes/crdt_bridge.ex` `normalize_doc/1`:
+```elixir
+case Frontmatter.parse(fm_block) do
+  {:ok, order, values, _degraded} ->
+    # ...existing body unchanged...
+  :error ->
+    :ok
+end
+```
+
+- [ ] **Step 5: Run the frontmatter + bridge + okf tests**
+
+Run: `mix test test/engram/notes/frontmatter_test.exs test/engram/notes/crdt_bridge_test.exs test/engram/notes/okf_fields_test.exs`
+Expected: PASS (existing bridge/okf behavior unchanged; new parse tests pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/engram/notes/frontmatter.ex lib/engram/notes/okf_fields.ex lib/engram/notes/crdt_bridge.ex test/engram/notes/frontmatter_test.exs
+git commit -m "feat(frontmatter): parse/1 reports degraded keys; update callers"
+```
+
+---
+
+### Task 3: Lossless raw passthrough for degraded keys (round-trip safety)
+
+**Files:**
+- Modify: `lib/engram/notes/frontmatter.ex` (`emit/2` ~line 126, `project/3`), add a raw-passthrough marker
+- Modify: `lib/engram/notes/crdt_bridge.ex` (`ingest_plaintext/2` — put degraded raw into the Y.Map + order)
+- Test: `test/engram/notes/frontmatter_test.exs`, `test/engram/notes/crdt_bridge_test.exs`
+
+**Interfaces:**
+- A degraded key is stored in the Y.Map `values` as a **passthrough marker** JSON string: `~s({"__engram_raw__":"<raw source line(s)>"})`. It appears in `order` at its source position. `emit/2` renders a passthrough marker verbatim (the raw text), never via Ymlr, so the exact bytes round-trip.
+- Produces: `Frontmatter.raw_marker(raw) :: String.t()` and `Frontmatter.raw_from_marker(json) :: {:ok, String.t()} | :error`.
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+```elixir
+test "a note with a good key + an unencodable key round-trips byte-identical" do
+  doc = Yex.Doc.new()
+  original = "---\ntags:\n  - a\ndate:YYYY-MM-DD\n---\nbody text\n"
+  :ok = Engram.Notes.CrdtBridge.ingest_plaintext(doc, original)
+  materialized = Engram.Notes.CrdtBridge.text_of(doc)
+  assert materialized == original
+end
+
+test "emit renders a raw-passthrough marker verbatim" do
+  order = ["tags", "date"]
+  values = %{"tags" => ~s(["a"]), "date" => Frontmatter.raw_marker("date:YYYY-MM-DD")}
+  assert Frontmatter.emit(order, values) == "tags:\n- a\ndate:YYYY-MM-DD\n"
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mix test test/engram/notes/frontmatter_test.exs test/engram/notes/crdt_bridge_test.exs -o passthrough`
+Expected: FAIL — no marker support yet; degraded key currently dropped (lossy).
+
+- [ ] **Step 3: Add marker helpers + emit handling in `frontmatter.ex`**
+
+```elixir
+@raw_key "__engram_raw__"
+
+@doc "Wrap a degraded key's raw source so emit re-renders it verbatim."
+def raw_marker(raw) when is_binary(raw), do: Jason.encode!(%{@raw_key => raw})
+
+def raw_from_marker(json) when is_binary(json) do
+  case Jason.decode(json) do
+    {:ok, %{@raw_key => raw}} when is_binary(raw) -> {:ok, raw}
+    _ -> :error
+  end
+end
+
+# in emit/2's per-key map_join, before the Ymlr path:
+decoded_or_raw =
+  case raw_from_marker(values[key]) do
+    {:ok, raw} -> {:raw, raw}
+    :error -> {:decoded, decode_value(values[key])}
+  end
+
+case decoded_or_raw do
+  {:raw, raw} -> ensure_trailing_newline(raw)
+  {:decoded, decoded} ->
+    try do
+      Ymlr.document!(%{key => decoded}, sort_maps: false)
+      |> String.replace_prefix("---\n", "")
+    rescue
+      _ -> "#{key}: #{inspect(decoded)}\n"
+    end
+end
+```
+
+(Refactor the existing `map_join` body to the branch above; keep `ensure_trailing_newline`.)
+
+- [ ] **Step 4: Store degraded raw in the Y.Map in `crdt_bridge.ex` `ingest_plaintext/2`**
+
+```elixir
+{order, values, body} =
+  case fm_block && Frontmatter.parse(fm_block) do
+    {:ok, good_order, good_values, degraded} ->
+      # Merge degraded keys back as raw passthrough so nothing is lost on emit.
+      raw_values =
+        Enum.reduce(degraded, good_values, fn %{key: k, snippet: raw}, acc ->
+          Map.put(acc, k, Frontmatter.raw_marker(raw))
+        end)
+      merged_order = merge_order(fm_block, Map.keys(raw_values))
+      {merged_order, raw_values, body}
+
+    _ ->
+      {[], %{}, plaintext}
+  end
+```
+
+Add `merge_order/2` (private) that re-derives full source order for all present keys via the same regex `top_level_key_order` uses (or expose `Frontmatter.key_order(block, keys)`). Prefer exposing `Frontmatter.key_order/2` and calling it here to keep ordering logic in one place.
+
+- [ ] **Step 5: Run tests**
+
+Run: `mix test test/engram/notes/frontmatter_test.exs test/engram/notes/crdt_bridge_test.exs`
+Expected: PASS (round-trip byte-identical; emit verbatim).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/engram/notes/frontmatter.ex lib/engram/notes/crdt_bridge.ex test/engram/notes/frontmatter_test.exs test/engram/notes/crdt_bridge_test.exs
+git commit -m "feat(frontmatter): lossless raw passthrough for degraded keys"
+```
+
+---
+
+### Task 4: Persist `parse_status` + `parse_reason` (migration + schema)
+
+**Files:**
+- Create: `priv/repo/migrations/<ts>_add_parse_status_to_notes_expand.exs`
+- Modify: `lib/engram/notes/note.ex` (add fields to schema + changeset cast)
+- Test: `test/engram/notes/note_test.exs` (or the existing schema/changeset test)
+
+**Interfaces:**
+- Produces: `notes.parse_status text not null default 'ok'`, `notes.parse_reason jsonb`. `Note` casts `:parse_status`, `:parse_reason`.
+
+- [ ] **Step 1: Write the migration** (expand phase, additive, safe defaults)
+
+```elixir
+defmodule Engram.Repo.Migrations.AddParseStatusToNotesExpand do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notes) do
+      add :parse_status, :text, null: false, default: "ok"
+      add :parse_reason, :map   # jsonb
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Add fields to `Note` schema + changeset**
+
+```elixir
+# in schema "notes" do ... (non-virtual, real columns)
+field :parse_status, :string, default: "ok"
+field :parse_reason, :map
+
+# in the changeset cast list, add :parse_status, :parse_reason
+```
+
+- [ ] **Step 3: Run migration + schema test**
+
+Run: `mix ecto.migrate && mix test test/engram/notes/note_test.exs`
+Expected: PASS; `\d notes` shows the two columns.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add priv/repo/migrations lib/engram/notes/note.ex test/engram/notes/note_test.exs
+git commit -m "feat(notes): add parse_status + parse_reason columns (expand)"
+```
+
+---
+
+### Task 5: Stamp `parse_status`/`parse_reason` at ingest (batch + single)
+
+**Files:**
+- Modify: `lib/engram/notes.ex` — batch insert row build (`build_batch_insert_row` ~line 2099, `inject_okf_fields` call) and the single-note upsert path (`upsert_note` ~line 565-576)
+- Modify: `lib/engram/notes/okf_fields.ex` — expose whether frontmatter degraded (reuse `Frontmatter.parse` degraded list)
+- Test: `test/engram/notes_test.exs`
+
+**Interfaces:**
+- Consumes: `Frontmatter.parse/1` degraded list (Task 2).
+- Produces: a note ingested with unparseable frontmatter has `parse_status: "degraded"` and `parse_reason` = the reason contract for the first degraded key; a clean note has `parse_status: "ok"`, `parse_reason: nil`.
+
+- [ ] **Step 1: Add a reason builder** in `lib/engram/notes/frontmatter.ex`
+
+```elixir
+@doc "Build the stored/echoed reason from a degraded-keys list (nil when empty)."
+def reason_for([]), do: nil
+def reason_for([%{key: key, line: line, snippet: snippet} | _] = degraded) do
+  %{
+    "code" => "frontmatter_unparseable_key",
+    "message" => "Frontmatter " <> key_phrase(degraded) <> " could not be parsed as YAML.",
+    "detail" => %{"key" => key, "line" => line, "snippet" => snippet}
+  }
+end
+defp key_phrase([_]), do: "key needs fixing"   # message stays generic; detail carries specifics
+defp key_phrase(list), do: "#{length(list)} keys need fixing"
+```
+
+- [ ] **Step 2: Write failing ingest test**
+
+```elixir
+test "ingesting a note with unparseable frontmatter stores it degraded with a reason" do
+  {:ok, note} = Notes.upsert_note(user, "T.md", %{content: "---\ndate:YYYY-MM-DD\n---\nx\n"})
+  assert note.parse_status == "degraded"
+  assert note.parse_reason["code"] == "frontmatter_unparseable_key"
+  assert note.parse_reason["detail"]["snippet"] == "date:YYYY-MM-DD"
+end
+
+test "a clean note is parse_status ok" do
+  {:ok, note} = Notes.upsert_note(user, "C.md", %{content: "---\ntags: [a]\n---\nx\n"})
+  assert note.parse_status == "ok"
+  assert note.parse_reason == nil
+end
+```
+
+- [ ] **Step 3: Compute + set the reason on both ingest paths**
+
+Derive degraded once from the note's frontmatter block during ingest (split -> parse), build `Frontmatter.reason_for/1`, and merge `%{parse_status: status, parse_reason: reason}` into the attrs passed to `Note.changeset` in both `build_batch_insert_row` and `upsert_note`. Prefer a single private helper `put_parse_status(attrs, content)` in `notes.ex` used by both paths (DRY).
+
+```elixir
+defp put_parse_status(attrs, content) do
+  degraded =
+    case Frontmatter.split(content) do
+      {block, _} when is_binary(block) ->
+        case Frontmatter.parse(block) do
+          {:ok, _o, _v, d} -> d
+          _ -> [%{key: "(frontmatter)", line: 1, snippet: String.slice(content, 0, 40)}]
+        end
+      _ -> []
+    end
+
+  case Frontmatter.reason_for(degraded) do
+    nil -> Map.merge(attrs, %{parse_status: "ok", parse_reason: nil})
+    reason -> Map.merge(attrs, %{parse_status: "degraded", parse_reason: reason})
+  end
+end
+```
+
+Note the whole-block `:error` case maps to `frontmatter_invalid_yaml` — extend `reason_for` to accept that sentinel, or synthesize the reason here with `code: "frontmatter_invalid_yaml"`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `mix test test/engram/notes_test.exs -o "parse_status"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/notes.ex lib/engram/notes/frontmatter.ex test/engram/notes_test.exs
+git commit -m "feat(notes): stamp parse_status + reason on ingest (batch + single)"
+```
+
+---
+
+### Task 6: Raise-proof the batch loop (defense in depth)
+
+**Files:**
+- Modify: `lib/engram/notes.ex` — `process_batch_entry` (the per-entry map_reduce inside `run_batch_upsert`)
+- Test: `test/engram/notes_test.exs`
+
+**Interfaces:**
+- Produces: a batch entry whose processing RAISES yields a per-note error result `{:error, note_ref, %{code: "note_processing_failed", message: ...}}` and is excluded from the transaction's committed rows; sibling entries still commit. The endpoint returns 200 with a per-note result list, never 500 on a single-note raise.
+
+- [ ] **Step 1: Write failing test** (inject a raise via a poison note that historically 500'd)
+
+```elixir
+test "one poison note degrades itself, batch still commits the rest" do
+  entries = [
+    %{path: "good.md", content: "---\ntags: [a]\n---\nok\n"},
+    %{path: "poison.md", content: "---\ndate:YYYY-MM-DD\n---\nx\n"}
+  ]
+  assert {:ok, results} = Notes.batch_upsert_notes(user, entries)
+  assert Enum.any?(results, &match?({:ok, _, _}, &1))          # good.md committed
+  # poison.md is committed-but-degraded (Task 5), NOT an error, since parse is now total:
+  poison = Enum.find(results, fn r -> elem(r, 0) == :ok and note_path(r) == "poison.md" end)
+  assert poison
+end
+
+test "a synthetic raise in one entry degrades only that entry" do
+  # Use a test hook / a content value that forces a raise in processing to prove
+  # the rescue isolates it. Assert the batch returns 200-shaped results and the
+  # sibling commits.
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mix test test/engram/notes_test.exs -o "batch"`
+Expected: FAIL on the synthetic-raise isolation test (current: raise aborts the whole transaction).
+
+- [ ] **Step 3: Wrap per-entry processing in rescue**
+
+In `process_batch_entry` (the fn passed to `Enum.map_reduce` inside `Repo.with_tenant`), wrap the body:
+
+```elixir
+try do
+  # ...existing per-entry processing...
+rescue
+  e ->
+    Logger.error("batch entry raised, degrading note",
+      category: :sync, error: Exception.message(e), path: entry.path)
+    {:error, entry.path,
+     %{"code" => "note_processing_failed",
+       "message" => "This note could not be processed and was skipped.",
+       "detail" => %{}}}
+end
+```
+
+Ensure the surrounding `map_reduce`/transaction treats an `{:error, ...}` entry as a per-note failure (collected into results), NOT a transaction rollback. If the current code uses `Repo.rollback` on `{:error, changeset}`, keep validation errors per-note (they already are) and make sure a rescued raise routes to the same per-note error accumulator, not a rollback. Verify with the sibling-commit test.
+
+- [ ] **Step 4: Run tests**
+
+Run: `mix test test/engram/notes_test.exs -o "batch"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram/notes.ex test/engram/notes_test.exs
+git commit -m "fix(notes): per-entry rescue so one raise can't fail a batch"
+```
+
+---
+
+### Task 7: Echo reason in batch response + expose on note read + sync feed
+
+**Files:**
+- Modify: the batch controller/serializer for `POST /api/notes/batch` (find via `grep -rn "do_batch_upsert\|batch" lib/engram_web/controllers/`)
+- Modify: the note JSON view/serializer (single note read) and the `/sync/changes` feed serializer (find via `grep -rn "note_changed\|changes\|render.*note" lib/engram_web/`)
+- Test: controller tests under `test/engram_web/controllers/`
+
+**Interfaces:**
+- Produces: batch response per-note objects include `"parse_status"` and `"parse_reason"`; single note read includes them; each `/sync/changes` entry includes them. (Web + plugin plans consume these.)
+
+- [ ] **Step 1: Write failing controller test**
+
+```elixir
+test "POST /api/notes/batch echoes parse_status + reason per note", %{conn: conn} do
+  body = %{notes: [%{path: "d.md", content: "---\ndate:YYYY-MM-DD\n---\nx\n"}]}
+  conn = post(conn, ~p"/api/notes/batch", body)
+  [note] = json_response(conn, 200)["results"]  # adjust to real response shape
+  assert note["parse_status"] == "degraded"
+  assert note["parse_reason"]["detail"]["snippet"] == "date:YYYY-MM-DD"
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mix test test/engram_web/controllers/note_controller_test.exs -o "parse_status"`
+Expected: FAIL — fields not serialized.
+
+- [ ] **Step 3: Add the fields to each serializer**
+
+Add `parse_status` + `parse_reason` to: the batch per-note result map, the single-note view map, and the `/sync/changes` entry map. Match the existing key casing/style in each serializer (read the neighboring fields first).
+
+- [ ] **Step 4: Run controller + sync tests**
+
+Run: `mix test test/engram_web/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/engram_web test/engram_web
+git commit -m "feat(api): expose parse_status + reason on batch, note read, sync feed"
+```
+
+---
+
+### Task 8: Full gate + open PR
+
+- [ ] **Step 1: Bump version once** in `mix.exs` (patch bump).
+- [ ] **Step 2: Run the full gate**
+
+```bash
+mix format --check-formatted && mix credo --strict && mix sobelow --exit && mix dialyzer && mix test
+```
+Expected: all green.
+
+- [ ] **Step 3: Commit + push + open PR** (labels: `phase/expand`; body references the incident + spec).
+
+```bash
+git add mix.exs && git commit -m "chore: bump version for frontmatter-resilience"
+git push -u origin feat/frontmatter-resilience
+gh pr create --label phase/expand --title "feat: frontmatter resilience + note parse diagnostics" --body "..."
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: degrade-don't-detonate (T1,T3,T5,T6), reason contract (T2,T5,T7), persistence-decision-A (T4,T5,T7), Approach-B leniency + passthrough (T1-T3), batch raise-proofing (T6), API/feed exposure (T7). Plugin + web surfaces are separate plans (consume T7's contract).
+- The single-note `POST/PUT /api/notes` + MCP `write_note` 500s (audit #2) are closed by T1 (total parse) + T5 (stamps them degraded); no separate task needed.
+- The CRDT room-crash on the legacy deliver path (audit #3) is closed by T1 (parse no longer raises inside `ingest_plaintext`).
+- Exact response/serializer shapes in T7 must be read from the codebase at execution time (grep hints given); do not assume key casing.

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -18,6 +18,7 @@ defmodule Engram.Notes do
     CrdtDeliver,
     CrdtPersistence,
     Enqueue,
+    Frontmatter,
     Helpers,
     Note,
     PathSanitizer
@@ -574,6 +575,7 @@ defmodule Engram.Notes do
           phase_b =
             inject_phase_b_fields(encrypted, user, note_id, sanitized_path, folder, crdt.tags)
             |> inject_okf_fields(user, note_id, crdt.merged_text)
+            |> put_parse_status(crdt.merged_text)
             |> Map.put(:crdt_state_ciphertext, crdt.crdt_state_ciphertext)
             |> Map.put(:crdt_state_nonce, crdt.crdt_state_nonce)
 
@@ -801,6 +803,7 @@ defmodule Engram.Notes do
             crdt.tags
           )
           |> inject_okf_fields(user, prior.id, crdt.merged_text)
+          |> put_parse_status(crdt.merged_text)
           |> Map.put(:crdt_state_ciphertext, crdt.crdt_state_ciphertext)
           |> Map.put(:crdt_state_nonce, crdt.crdt_state_nonce)
 
@@ -940,6 +943,7 @@ defmodule Engram.Notes do
             crdt.tags
           )
           |> inject_okf_fields(user, existing.id, crdt.merged_text)
+          |> put_parse_status(crdt.merged_text)
           |> Map.put(:crdt_state_ciphertext, crdt.crdt_state_ciphertext)
           |> Map.put(:crdt_state_nonce, crdt.crdt_state_nonce)
 
@@ -1751,7 +1755,9 @@ defmodule Engram.Notes do
     :description_ciphertext,
     :description_nonce,
     :resource_ciphertext,
-    :resource_nonce
+    :resource_nonce,
+    :parse_status,
+    :parse_reason
   ]
 
   @doc """
@@ -2097,6 +2103,7 @@ defmodule Engram.Notes do
         phase_b =
           inject_phase_b_fields(encrypted, user, note_id, entry.path, entry.folder, merged_tags)
           |> inject_okf_fields(user, note_id, crdt.merged_text)
+          |> put_parse_status(crdt.merged_text)
 
         changeset = Note.changeset(%Note{id: note_id}, phase_b)
 
@@ -3848,6 +3855,37 @@ defmodule Engram.Notes do
   # official public API.
   def inject_okf_fields_pub(attrs, user, note_id, content) do
     inject_okf_fields(attrs, user, note_id, content)
+  end
+
+  # Frontmatter-resilience (Task 5): stamp parse_status/parse_reason from the
+  # note's ACTUAL persisted content (the CRDT-merged text, same input
+  # inject_okf_fields/4 uses at every call site), not the raw incoming push.
+  # A clean re-write of a previously degraded note must reset both fields —
+  # every call site re-derives from scratch rather than patching prior state,
+  # so a fix silently self-heals on the next ingest.
+  defp put_parse_status(attrs, content) do
+    case Frontmatter.split(content) do
+      {nil, _body} ->
+        Map.merge(attrs, %{parse_status: "ok", parse_reason: nil})
+
+      {block, _body} ->
+        case Frontmatter.parse(block) do
+          {:ok, _order, _values, []} ->
+            Map.merge(attrs, %{parse_status: "ok", parse_reason: nil})
+
+          {:ok, _order, _values, degraded} ->
+            Map.merge(attrs, %{
+              parse_status: "degraded",
+              parse_reason: Frontmatter.reason_for(degraded)
+            })
+
+          :error ->
+            Map.merge(attrs, %{
+              parse_status: "degraded",
+              parse_reason: Frontmatter.invalid_yaml_reason(block)
+            })
+        end
+    end
   end
 
   # Returns a keyword list of Phase B field updates suitable for splicing into

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -62,7 +62,9 @@ defmodule Engram.Notes do
     :user_id,
     :vault_id,
     :created_at,
-    :updated_at
+    :updated_at,
+    :parse_status,
+    :parse_reason
   ]
 
   # Delete-wins window: an identical re-push at a path deleted within this many
@@ -2034,7 +2036,9 @@ defmodule Engram.Notes do
                 prev_hash: nil,
                 updated_at: now,
                 content: merged_text,
-                content_hash: content_hash
+                content_hash: content_hash,
+                parse_status: row.parse_status,
+                parse_reason: row.parse_reason
               }
 
               {%{entry | result: {:ok, info}}, [row | rows]}
@@ -2124,7 +2128,9 @@ defmodule Engram.Notes do
            prev_hash: prev_hash,
            updated_at: updated.updated_at,
            content: merged_text,
-           content_hash: content_hash
+           content_hash: content_hash,
+           parse_status: updated.parse_status,
+           parse_reason: updated.parse_reason
          }}
 
       {:error, changeset} ->
@@ -2332,7 +2338,9 @@ defmodule Engram.Notes do
             content_hash: info.content_hash,
             # Canonical (sanitized) path — differs from `path` when the
             # sanitizer rewrote the input; clients rename local files to it.
-            server_path: entry.path
+            server_path: entry.path,
+            parse_status: info.parse_status,
+            parse_reason: info.parse_reason
           }
 
         {:conflict, existing} ->
@@ -2581,7 +2589,9 @@ defmodule Engram.Notes do
       content: note.content,
       content_hash: note.content_hash,
       deleted: not is_nil(note.deleted_at),
-      updated_at: note.updated_at
+      updated_at: note.updated_at,
+      parse_status: note.parse_status,
+      parse_reason: note.parse_reason
     }
   end
 

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -929,8 +929,8 @@ defmodule Engram.Notes do
     # statement here (next_seq!'s UPDATE, or the Repo.update) rolls back to a
     # per-statement savepoint instead of poisoning the shared batch tx into
     # 25P02 and falsely failing sibling entries. Empty (default) on the
-    # single-note path, which owns its whole tx — no siblings to protect, no
-    # savepoint round-trip to pay for.
+    # single-note path, which owns its whole tx (no siblings to protect, no
+    # savepoint round-trip to pay for).
     db_opts =
       case Keyword.get(opts, :db_mode) do
         nil -> []
@@ -2074,7 +2074,7 @@ defmodule Engram.Notes do
   # (frontmatter parsing) was already made impossible by the total codec in
   # Frontmatter (Task 1). This exists for whatever future parser/crypto/CRDT
   # call in `fun` raises next, and it cleanly isolates that raise to ONE entry
-  # (per-note error result, siblings commit) — including a raise that came
+  # (per-note error result, siblings commit), including a raise that came
   # from a FAILED SQL STATEMENT, which a bare try/rescue could not contain.
   #
   # The batch runs each entry inside the SHARED Repo.with_tenant tx. Per-entry
@@ -2098,7 +2098,7 @@ defmodule Engram.Notes do
   #     unique_constraint), but the guarantee no longer depends on that.
   #
   # NOTE: a bare nested `Repo.transaction` does NOT isolate a failed RAW query
-  # (`Repo.query!`) — DBConnection breaks the connection and disconnects. Only
+  # (`Repo.query!`): DBConnection breaks the connection and disconnects. Only
   # `mode: :savepoint` on the failing operation recovers cleanly, which is why
   # the isolation lives on the DB writes, not around `fun`.
   #

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -2023,32 +2023,72 @@ defmodule Engram.Notes do
   end
 
   defp process_batch_entry(%{result: nil} = entry, existing_by_hmac, user, vault, now, rows) do
-    case Map.get(existing_by_hmac, entry.path_hmac) do
-      nil ->
-        case build_batch_insert_row(entry, user, vault, now) do
-          {:ok, id, row, merged_text, content_hash} ->
-            info = %{
-              id: id,
-              version: 1,
-              prev_hash: nil,
-              updated_at: now,
-              content: merged_text,
-              content_hash: content_hash
-            }
+    process_batch_entry_rescued(entry, rows, fn ->
+      case Map.get(existing_by_hmac, entry.path_hmac) do
+        nil ->
+          case build_batch_insert_row(entry, user, vault, now) do
+            {:ok, id, row, merged_text, content_hash} ->
+              info = %{
+                id: id,
+                version: 1,
+                prev_hash: nil,
+                updated_at: now,
+                content: merged_text,
+                content_hash: content_hash
+              }
 
-            {%{entry | result: {:ok, info}}, [row | rows]}
+              {%{entry | result: {:ok, info}}, [row | rows]}
 
-          {:error, errors} ->
-            {%{entry | result: {:error, errors}}, rows}
-        end
+            {:error, errors} ->
+              {%{entry | result: {:error, errors}}, rows}
+          end
 
-      existing ->
-        {%{entry | result: update_batch_entry(entry, existing, user)}, rows}
-    end
+        existing ->
+          {%{entry | result: update_batch_entry(entry, existing, user)}, rows}
+      end
+    end)
   end
 
   defp process_batch_entry(entry, _existing_by_hmac, _user, _vault, _now, rows),
     do: {entry, rows}
+
+  # Defense in depth (#task-6): the known raise this guards (frontmatter
+  # parsing) was already made impossible by the total codec in Frontmatter
+  # (Task 1) — this exists for whatever future parser/crypto/CRDT call in
+  # `fun` raises next. Isolates that ONE entry to a per-note error result
+  # instead of the raise propagating out of Repo.with_tenant and rolling
+  # back every sibling in the batch. `fun` is a thunk so this stays testable
+  # without a real reachable raise: pass a fn that raises on demand.
+  @doc false
+  @spec process_batch_entry_rescued(map(), list(), (-> {map(), list()})) :: {map(), list()}
+  def process_batch_entry_rescued(entry, rows, fun) do
+    fun.()
+  rescue
+    e ->
+      # Path goes in the message, not just metadata: the console formatter's
+      # metadata allowlist (config.exs) doesn't include `:path`/`:error`, so
+      # a path-only-in-metadata line renders invisibly outside prod's
+      # metadata: :all JSON formatter. Interpolating keeps it Sentry-visible
+      # AND directly greppable/testable in the plain-text console/CI logs.
+      Logger.error(
+        "batch entry raised, degrading note: #{entry.path}",
+        Metadata.with_category(:error, :sync,
+          path: entry.path,
+          error: Exception.message(e)
+        )
+      )
+
+      {%{
+         entry
+         | result:
+             {:error,
+              %{
+                "code" => "note_processing_failed",
+                "message" => "This note could not be processed and was skipped.",
+                "detail" => %{}
+              }}
+       }, rows}
+  end
 
   defp update_batch_entry(entry, existing, user) do
     base_attrs = batch_base_attrs(entry, user)

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -896,7 +896,9 @@ defmodule Engram.Notes do
         {:stale_base, existing}
 
       true ->
-        do_rewrite_note(existing, base_attrs, user, sanitized_path, folder)
+        do_rewrite_note(existing, base_attrs, user, sanitized_path, folder,
+          db_mode: Keyword.get(opts, :db_mode)
+        )
     end
   end
 
@@ -922,7 +924,19 @@ defmodule Engram.Notes do
     {:ok, {existing.content_hash, existing, base_attrs.content, existing.content_hash}}
   end
 
-  defp do_rewrite_note(existing, base_attrs, user, sanitized_path, folder) do
+  defp do_rewrite_note(existing, base_attrs, user, sanitized_path, folder, opts \\ []) do
+    # db_opts carries `mode: :savepoint` on the batch path so a failed SQL
+    # statement here (next_seq!'s UPDATE, or the Repo.update) rolls back to a
+    # per-statement savepoint instead of poisoning the shared batch tx into
+    # 25P02 and falsely failing sibling entries. Empty (default) on the
+    # single-note path, which owns its whole tx — no siblings to protect, no
+    # savepoint round-trip to pay for.
+    db_opts =
+      case Keyword.get(opts, :db_mode) do
+        nil -> []
+        mode -> [mode: mode]
+      end
+
     with {:ok, crdt} <- maybe_merge_crdt(existing, base_attrs.content, user, existing.id) do
       merged_title = Helpers.extract_title(crdt.merged_text, sanitized_path)
 
@@ -949,12 +963,12 @@ defmodule Engram.Notes do
           |> Map.put(:crdt_state_ciphertext, crdt.crdt_state_ciphertext)
           |> Map.put(:crdt_state_nonce, crdt.crdt_state_nonce)
 
-        seq = Engram.Vaults.next_seq!(existing.vault_id)
+        seq = Engram.Vaults.next_seq!(existing.vault_id, db_opts)
 
         existing
         |> Note.changeset(Map.put(phase_b, :version, existing.version + 1))
         |> Ecto.Changeset.put_change(:seq, seq)
-        |> Repo.update()
+        |> Repo.update(db_opts)
         |> case do
           # Thread crdt.content_hash (HMAC of projection) alongside merged_text
           # so callers can include the stored hash in broadcast digests without
@@ -2056,33 +2070,41 @@ defmodule Engram.Notes do
   defp process_batch_entry(entry, _existing_by_hmac, _user, _vault, _now, rows),
     do: {entry, rows}
 
-  # Defense in depth (#task-6): the known raise this guards (frontmatter
-  # parsing) was already made impossible by the total codec in Frontmatter
-  # (Task 1). This exists for whatever future parser/crypto/CRDT call in
-  # `fun` raises next, and it cleanly isolates a raise to that ONE entry
-  # (per-note error result, siblings commit) for every raise reachable via
-  # public input TODAY:
+  # Defense in depth (#task-6/#task-4): the known raise this guards
+  # (frontmatter parsing) was already made impossible by the total codec in
+  # Frontmatter (Task 1). This exists for whatever future parser/crypto/CRDT
+  # call in `fun` raises next, and it cleanly isolates that raise to ONE entry
+  # (per-note error result, siblings commit) — including a raise that came
+  # from a FAILED SQL STATEMENT, which a bare try/rescue could not contain.
+  #
+  # The batch runs each entry inside the SHARED Repo.with_tenant tx. Per-entry
+  # SAVEPOINT isolation makes that total across both branches:
   #
   #   - CREATE branch (build_batch_insert_row): does zero per-entry DB
-  #     writes (the insert_all runs AFTER the loop), so any raise here is
-  #     airtight-isolated.
-  #   - UPDATE branch (update_batch_entry): next_seq!'s only raise-shaped
-  #     hazard is a badmatch on an already-SUCCESSFUL query roundtrip, and
-  #     the realistic path-unique race is caught by unique_constraint, not a
-  #     raise. So no raise reachable today runs a FAILED SQL statement here.
+  #     writes (the insert_all runs AFTER the loop), so a raise here never
+  #     touched the tx state at all.
+  #   - UPDATE branch (update_batch_entry): next_seq! (UPDATE ... RETURNING)
+  #     and Repo.update() run synchronously inside `fun`. If one of those SQL
+  #     statements fails mid-tx, Postgres flips the whole tx into 25P02
+  #     (in_failed_sql_transaction) and every SUBSEQUENT statement fails too.
+  #     The batch UPDATE path runs both writes with `mode: :savepoint`
+  #     (threaded via `db_mode: :savepoint` through do_update_note ->
+  #     do_rewrite_note -> next_seq!/Repo.update), so a failed statement rolls
+  #     back to its OWN savepoint and the outer tx stays healthy. query!/update
+  #     still raise on failure, so this rescue degrades only THIS entry while
+  #     siblings (and previously-succeeded entries) commit. No raise reachable
+  #     via public input triggers this today (next_seq! only badmatches after a
+  #     SUCCESSFUL roundtrip; the realistic path-unique race is caught by
+  #     unique_constraint), but the guarantee no longer depends on that.
   #
-  # SCOPE CEILING: this is NOT a blanket "any raise, siblings always commit"
-  # guarantee. next_seq! (UPDATE ... RETURNING) and Repo.update() run
-  # synchronously inside `fun` in the UPDATE branch. If a FUTURE change made
-  # one of those SQL statements actually fail mid-transaction, Postgres would
-  # put the shared tx into 25P02 (in_failed_sql_transaction); we'd catch the
-  # raise here but every SUBSEQUENT entry's statement would then fail too and
-  # be falsely marked note_processing_failed. Isolating a failed-SQL raise
-  # would need per-entry SAVEPOINTs or deferring the UPDATE writes past the
-  # loop. Deliberately NOT built — unreachable today (see above).
+  # NOTE: a bare nested `Repo.transaction` does NOT isolate a failed RAW query
+  # (`Repo.query!`) — DBConnection breaks the connection and disconnects. Only
+  # `mode: :savepoint` on the failing operation recovers cleanly, which is why
+  # the isolation lives on the DB writes, not around `fun`.
   #
   # `fun` is a thunk so this stays testable without a real reachable raise:
-  # pass a fn that raises on demand.
+  # pass a fn that runs a real failing Repo query (a plain `raise` will NOT
+  # exercise the savepoint, since it never enters 25P02).
   @doc false
   @spec process_batch_entry_rescued(map(), list(), (-> {map(), list()})) :: {map(), list()}
   def process_batch_entry_rescued(entry, rows, fun) do
@@ -2119,7 +2141,12 @@ defmodule Engram.Notes do
   defp update_batch_entry(entry, existing, user) do
     base_attrs = batch_base_attrs(entry, user)
 
-    case do_update_note(existing, base_attrs, user, entry.path, entry.folder, entry.tags) do
+    # db_mode: :savepoint isolates this entry's UPDATE-branch DB writes so a
+    # failed SQL statement rolls back to a per-statement savepoint, leaving the
+    # shared batch tx healthy for sibling entries (see process_batch_entry_rescued).
+    case do_update_note(existing, base_attrs, user, entry.path, entry.folder, entry.tags,
+           db_mode: :savepoint
+         ) do
       {:ok, {prev_hash, updated, merged_text, content_hash}} ->
         {:ok,
          %{

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -2054,24 +2054,46 @@ defmodule Engram.Notes do
 
   # Defense in depth (#task-6): the known raise this guards (frontmatter
   # parsing) was already made impossible by the total codec in Frontmatter
-  # (Task 1) — this exists for whatever future parser/crypto/CRDT call in
-  # `fun` raises next. Isolates that ONE entry to a per-note error result
-  # instead of the raise propagating out of Repo.with_tenant and rolling
-  # back every sibling in the batch. `fun` is a thunk so this stays testable
-  # without a real reachable raise: pass a fn that raises on demand.
+  # (Task 1). This exists for whatever future parser/crypto/CRDT call in
+  # `fun` raises next, and it cleanly isolates a raise to that ONE entry
+  # (per-note error result, siblings commit) for every raise reachable via
+  # public input TODAY:
+  #
+  #   - CREATE branch (build_batch_insert_row): does zero per-entry DB
+  #     writes (the insert_all runs AFTER the loop), so any raise here is
+  #     airtight-isolated.
+  #   - UPDATE branch (update_batch_entry): next_seq!'s only raise-shaped
+  #     hazard is a badmatch on an already-SUCCESSFUL query roundtrip, and
+  #     the realistic path-unique race is caught by unique_constraint, not a
+  #     raise. So no raise reachable today runs a FAILED SQL statement here.
+  #
+  # SCOPE CEILING: this is NOT a blanket "any raise, siblings always commit"
+  # guarantee. next_seq! (UPDATE ... RETURNING) and Repo.update() run
+  # synchronously inside `fun` in the UPDATE branch. If a FUTURE change made
+  # one of those SQL statements actually fail mid-transaction, Postgres would
+  # put the shared tx into 25P02 (in_failed_sql_transaction); we'd catch the
+  # raise here but every SUBSEQUENT entry's statement would then fail too and
+  # be falsely marked note_processing_failed. Isolating a failed-SQL raise
+  # would need per-entry SAVEPOINTs or deferring the UPDATE writes past the
+  # loop. Deliberately NOT built — unreachable today (see above).
+  #
+  # `fun` is a thunk so this stays testable without a real reachable raise:
+  # pass a fn that raises on demand.
   @doc false
   @spec process_batch_entry_rescued(map(), list(), (-> {map(), list()})) :: {map(), list()}
   def process_batch_entry_rescued(entry, rows, fun) do
     fun.()
   rescue
     e ->
-      # Path goes in the message, not just metadata: the console formatter's
-      # metadata allowlist (config.exs) doesn't include `:path`/`:error`, so
-      # a path-only-in-metadata line renders invisibly outside prod's
-      # metadata: :all JSON formatter. Interpolating keeps it Sentry-visible
-      # AND directly greppable/testable in the plain-text console/CI logs.
+      # Path AND exception reason go in the message string, not metadata
+      # alone: neither `:path` nor `:error` is in the Sentry LoggerHandler
+      # metadata allowlist (application.ex), and the console formatter's
+      # allowlist (config.exs) drops them too. Interpolating keeps both
+      # Sentry-visible (on-call sees WHY it raised) AND greppable/testable
+      # in the plain-text console/CI logs. Metadata copies kept for prod's
+      # metadata: :all JSON formatter (Loki structured fields).
       Logger.error(
-        "batch entry raised, degrading note: #{entry.path}",
+        "batch entry raised, degrading note: #{entry.path} (#{Exception.message(e)})",
         Metadata.with_category(:error, :sync,
           path: entry.path,
           error: Exception.message(e)

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -878,7 +878,7 @@ defmodule Engram.Notes do
   # CRDT (Yjs) is the only content-sync path: merge_plaintext in do_update_note
   # IS the conflict resolution. A stale client_version never 409s — the diverging
   # write is merged convergently into crdt_state (no legacy conflict-copy flow).
-  defp do_update_note(existing, base_attrs, user, sanitized_path, folder, _tags, opts \\ []) do
+  defp do_update_note(existing, base_attrs, user, sanitized_path, folder, _tags, opts) do
     base_hash = Keyword.get(opts, :base_hash)
 
     cond do
@@ -924,7 +924,7 @@ defmodule Engram.Notes do
     {:ok, {existing.content_hash, existing, base_attrs.content, existing.content_hash}}
   end
 
-  defp do_rewrite_note(existing, base_attrs, user, sanitized_path, folder, opts \\ []) do
+  defp do_rewrite_note(existing, base_attrs, user, sanitized_path, folder, opts) do
     # db_opts carries `mode: :savepoint` on the batch path so a failed SQL
     # statement here (next_seq!'s UPDATE, or the Repo.update) rolls back to a
     # per-statement savepoint instead of poisoning the shared batch tx into

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3935,6 +3935,11 @@ defmodule Engram.Notes do
   # A clean re-write of a previously degraded note must reset both fields —
   # every call site re-derives from scratch rather than patching prior state,
   # so a fix silently self-heals on the next ingest.
+  # ponytail: re-runs Frontmatter.split + parse on `content` that
+  # inject_okf_fields/4 -> OkfFields.extract already parsed. Deliberately NOT
+  # threaded: the block is tiny (microsecond parse) and threading would couple
+  # OKF extraction to parse-status by changing extract/1's return contract and
+  # this pipe's shape. Thread it only if this ever shows up on a profile.
   defp put_parse_status(attrs, content) do
     case Frontmatter.split(content) do
       {nil, _body} ->

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -240,9 +240,12 @@ defmodule Engram.Notes.CrdtBridge do
     {fm_block, body} = Frontmatter.split(plaintext)
 
     {order, values, body} =
-      case fm_block && Frontmatter.parse(fm_block) do
-        {:ok, order, values, _degraded} -> {order, values, body}
-        # nil (no frontmatter) or :error (malformed) -> whole text is body
+      case fm_block && Frontmatter.parse_for_ingest(fm_block) do
+        # Degraded keys are stored as raw-passthrough markers so emit re-renders
+        # them verbatim (nothing lost). :error means no frontmatter, malformed,
+        # or a degraded key whose raw span can't be captured losslessly -> keep
+        # the whole text as body, which is also lossless.
+        {:ok, order, values} -> {order, values, body}
         _ -> {[], %{}, plaintext}
       end
 

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -19,6 +19,12 @@ defmodule Engram.Notes.CrdtBridge do
 
   @text_name "content"
   @frontmatter_name "frontmatter"
+  # Out-of-band store for degraded frontmatter keys' verbatim source spans,
+  # keyed by frontmatter key. Kept separate from @frontmatter_name so a NORMAL
+  # client-written value is never mis-read as a raw-passthrough marker on
+  # projection (a real value shaped like the old in-band marker would otherwise
+  # be dropped). emit/3 consults this map for verbatim re-render.
+  @raw_frontmatter_name "frontmatter_raw"
   @order_name "frontmatter_order"
   @doc_schema_version 2
   @flatten_bytes 500_000
@@ -46,6 +52,15 @@ defmodule Engram.Notes.CrdtBridge do
     order = doc |> Yex.Doc.get_array(@order_name) |> Yex.Array.to_list()
     values = doc |> Yex.Doc.get_map(@frontmatter_name) |> Yex.Map.to_map()
     {order, values}
+  end
+
+  @doc """
+  Out-of-band raw-passthrough map of a doc: degraded frontmatter keys mapped to
+  their verbatim source spans. Empty for a doc with no degraded keys.
+  """
+  @spec raw_frontmatter_of(Yex.Doc.t()) :: %{String.t() => String.t()}
+  def raw_frontmatter_of(%Yex.Doc{} = doc) do
+    doc |> Yex.Doc.get_map(@raw_frontmatter_name) |> Yex.Map.to_map()
   end
 
   @doc """
@@ -88,7 +103,7 @@ defmodule Engram.Notes.CrdtBridge do
   @spec project_doc(Yex.Doc.t()) :: String.t()
   def project_doc(%Yex.Doc{} = doc) do
     {order, values} = frontmatter_of(doc)
-    Frontmatter.project(order, values, body_of(doc))
+    Frontmatter.project(order, values, body_of(doc), raw_frontmatter_of(doc))
   end
 
   @doc "Full projected note plaintext (frontmatter + body)."
@@ -239,17 +254,17 @@ defmodule Engram.Notes.CrdtBridge do
   def ingest_plaintext(%Yex.Doc{} = doc, plaintext) when is_binary(plaintext) do
     {fm_block, body} = Frontmatter.split(plaintext)
 
-    {order, values, body} =
+    {order, values, raws, body} =
       case fm_block && Frontmatter.parse_for_ingest(fm_block) do
-        # Degraded keys are stored as raw-passthrough markers so emit re-renders
-        # them verbatim (nothing lost). :error means no frontmatter, malformed,
-        # or a degraded key whose raw span can't be captured losslessly -> keep
-        # the whole text as body, which is also lossless.
-        {:ok, order, values} -> {order, values, body}
-        _ -> {[], %{}, plaintext}
+        # Degraded keys are stored out of band (raws) so emit re-renders them
+        # verbatim (nothing lost). :error means no frontmatter, malformed, or a
+        # degraded key whose raw span can't be captured losslessly -> keep the
+        # whole text as body, which is also lossless.
+        {:ok, order, values, raws} -> {order, values, raws, body}
+        _ -> {[], %{}, %{}, plaintext}
       end
 
-    apply_frontmatter(doc, order, values)
+    apply_frontmatter(doc, order, values, raws)
     text = Yex.Doc.get_text(doc, @text_name)
     :ok = diff_into_text(text, body)
     :ok
@@ -273,16 +288,33 @@ defmodule Engram.Notes.CrdtBridge do
         :ok
 
       {fm_block, rest} ->
-        case Frontmatter.parse(fm_block) do
-          {:ok, order, values, _degraded} ->
+        # Route through the SAME lossless machinery as ingest so a degraded key
+        # (e.g. a nested non-binary key) is lifted into the out-of-band raw map
+        # rather than dropped. :error (non-map YAML, or a degraded span that
+        # can't be captured losslessly) leaves the doc untouched -> no strip,
+        # no data loss.
+        case Frontmatter.parse_for_ingest(fm_block) do
+          {:ok, order, values, raws} ->
             map = Yex.Doc.get_map(doc, @frontmatter_name)
+            raw_map = Yex.Doc.get_map(doc, @raw_frontmatter_name)
             arr = Yex.Doc.get_array(doc, @order_name)
             existing = Yex.Map.to_map(map)
+            existing_raw = Yex.Map.to_map(raw_map)
             existing_order = Yex.Array.to_list(arr)
 
-            # Y.Map wins: only lift keys not already present.
-            new_keys = Enum.filter(order, fn k -> not Map.has_key?(existing, k) end)
-            Enum.each(new_keys, fn k -> Yex.Map.set(map, k, Map.fetch!(values, k)) end)
+            # Y.Map wins: only lift keys not already present (in either store).
+            new_keys =
+              Enum.reject(order, fn k ->
+                Map.has_key?(existing, k) or Map.has_key?(existing_raw, k)
+              end)
+
+            Enum.each(new_keys, fn k ->
+              cond do
+                Map.has_key?(values, k) -> Yex.Map.set(map, k, Map.fetch!(values, k))
+                Map.has_key?(raws, k) -> Yex.Map.set(raw_map, k, Map.fetch!(raws, k))
+                true -> :ok
+              end
+            end)
 
             to_append = Enum.reject(new_keys, fn k -> k in existing_order end)
 
@@ -304,25 +336,31 @@ defmodule Engram.Notes.CrdtBridge do
     end
   end
 
-  defp apply_frontmatter(doc, order, values) do
-    map = Yex.Doc.get_map(doc, @frontmatter_name)
-    current = Yex.Map.to_map(map)
-
-    # Upsert changed keys.
-    Enum.each(values, fn {k, v} ->
-      if Map.get(current, k) != v, do: Yex.Map.set(map, k, v)
-    end)
-
-    # Delete keys no longer present.
-    Enum.each(Map.keys(current), fn k ->
-      unless Map.has_key?(values, k), do: Yex.Map.delete(map, k)
-    end)
+  defp apply_frontmatter(doc, order, values, raws) do
+    upsert_map(Yex.Doc.get_map(doc, @frontmatter_name), values)
+    upsert_map(Yex.Doc.get_map(doc, @raw_frontmatter_name), raws)
 
     # Replace the order array wholesale (small list; simplest correct form).
     arr = Yex.Doc.get_array(doc, @order_name)
     len = arr |> Yex.Array.to_list() |> length()
     if len > 0, do: Yex.Array.delete_range(arr, 0, len)
     if order != [], do: Yex.Array.insert_list(arr, 0, order)
+    :ok
+  end
+
+  # Converge a Y.Map to `desired`: upsert changed keys, delete keys no longer
+  # present. Used for both the good-value map and the out-of-band raw map.
+  defp upsert_map(map, desired) do
+    current = Yex.Map.to_map(map)
+
+    Enum.each(desired, fn {k, v} ->
+      if Map.get(current, k) != v, do: Yex.Map.set(map, k, v)
+    end)
+
+    Enum.each(Map.keys(current), fn k ->
+      unless Map.has_key?(desired, k), do: Yex.Map.delete(map, k)
+    end)
+
     :ok
   end
 

--- a/lib/engram/notes/crdt_bridge.ex
+++ b/lib/engram/notes/crdt_bridge.ex
@@ -241,7 +241,7 @@ defmodule Engram.Notes.CrdtBridge do
 
     {order, values, body} =
       case fm_block && Frontmatter.parse(fm_block) do
-        {:ok, order, values} -> {order, values, body}
+        {:ok, order, values, _degraded} -> {order, values, body}
         # nil (no frontmatter) or :error (malformed) -> whole text is body
         _ -> {[], %{}, plaintext}
       end
@@ -271,7 +271,7 @@ defmodule Engram.Notes.CrdtBridge do
 
       {fm_block, rest} ->
         case Frontmatter.parse(fm_block) do
-          {:ok, order, values} ->
+          {:ok, order, values, _degraded} ->
             map = Yex.Doc.get_map(doc, @frontmatter_name)
             arr = Yex.Doc.get_array(doc, @order_name)
             existing = Yex.Map.to_map(map)

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -115,7 +115,9 @@ defmodule Engram.Notes.Frontmatter do
   key to point at, so `detail.key` is nil and the snippet is the block's
   first line.
   """
-  @spec invalid_yaml_reason(String.t()) :: map()
+  @spec invalid_yaml_reason(String.t()) :: %{
+          String.t() => String.t() | %{String.t() => String.t() | pos_integer() | nil}
+        }
   def invalid_yaml_reason(block) when is_binary(block) do
     first_line = block |> String.split("\n", parts: 2) |> hd()
 

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -125,11 +125,20 @@ defmodule Engram.Notes.Frontmatter do
       {:ok, map} when is_map(map) ->
         {values, bad_keys} = encode_values(map)
 
-        if bad_keys == [] do
-          # No degraded keys: keep the existing structured behaviour exactly.
+        # A GOOD value can encode to JSON that raw_from_marker/1 mistakes for a
+        # passthrough marker (a map merely containing @raw_key). emit/2 would
+        # then render its inner raw and DROP the key. Route those through the
+        # same verbatim span-passthrough so they round-trip exactly. No marker
+        # format can disambiguate the exact single-key collision, so this is
+        # the robust fix, not tightening the pattern.
+        colliding = for {k, v} <- values, match?({:ok, _}, raw_from_marker(v)), do: k
+        passthrough_keys = bad_keys ++ colliding
+
+        if passthrough_keys == [] do
+          # No degraded/colliding keys: keep the existing structured behaviour.
           {:ok, top_level_key_order(block, map), values}
         else
-          ingest_with_passthrough(block, map, values, bad_keys)
+          ingest_with_passthrough(block, map, values, passthrough_keys)
         end
 
       _ ->
@@ -137,21 +146,24 @@ defmodule Engram.Notes.Frontmatter do
     end
   end
 
-  # Degraded keys present: require an exact column-0 line-tiling of the block
-  # so each degraded key's raw source span is captured byte-for-byte.
-  defp ingest_with_passthrough(block, map, values, bad_keys) do
+  # Passthrough keys present (degraded and/or marker-colliding): require an
+  # exact column-0 line-tiling of the block so each key's raw source span is
+  # captured byte-for-byte, then store each as a verbatim raw marker.
+  defp ingest_with_passthrough(block, map, values, passthrough_keys) do
     case raw_spans(block, map) do
       {:ok, order, spans} ->
         merged =
-          Enum.reduce(bad_keys, values, fn key, acc ->
+          Enum.reduce(passthrough_keys, values, fn key, acc ->
             case Map.fetch(spans, key) do
               {:ok, raw} -> Map.put(acc, key, raw_marker(raw))
               :error -> acc
             end
           end)
 
-        # Every degraded key must have a captured span, else it would vanish.
-        if Enum.all?(bad_keys, &Map.has_key?(merged, &1)),
+        # Every passthrough key must have a captured span, else it would vanish
+        # (degraded) or stay a false-marker good value (colliding). Either way
+        # fall back to the lossless whole-text-as-body path.
+        if Enum.all?(passthrough_keys, &match?({:ok, _}, Map.fetch(spans, &1))),
           do: {:ok, order, merged},
           else: :error
 

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -84,6 +84,48 @@ defmodule Engram.Notes.Frontmatter do
     end
   end
 
+  @doc """
+  Build the stored/echoed `parse_reason` from a degraded-keys list (`parse/1`'s
+  4th element). `nil` when the list is empty (clean parse). Reports the FIRST
+  degraded key's detail; a note with several bad keys still needs only one
+  actionable pointer. Reason shape is pinned (string keys, jsonb-storable):
+  `%{"code", "message", "detail" => %{"key", "line", "snippet"}}`.
+  """
+  @spec reason_for([map()]) :: map() | nil
+  def reason_for([]), do: nil
+
+  def reason_for([%{key: key, line: line, snippet: snippet} | _] = degraded) do
+    %{
+      "code" => "frontmatter_unparseable_key",
+      "message" => degraded_key_message(degraded),
+      "detail" => %{"key" => key, "line" => line, "snippet" => snippet}
+    }
+  end
+
+  defp degraded_key_message([_]), do: "A frontmatter key could not be parsed as YAML."
+
+  defp degraded_key_message(degraded) do
+    "#{length(degraded)} frontmatter keys could not be parsed as YAML."
+  end
+
+  @doc """
+  Build the `parse_reason` for the whole-block `parse/1` `:error` case (the
+  block isn't YAML-map-shaped at all, e.g. `date:YYYY-MM-DD` with no space).
+  Distinct code from `reason_for/1`'s per-key case: there is no single bad
+  key to point at, so `detail.key` is nil and the snippet is the block's
+  first line.
+  """
+  @spec invalid_yaml_reason(String.t()) :: map()
+  def invalid_yaml_reason(block) when is_binary(block) do
+    first_line = block |> String.split("\n", parts: 2) |> hd()
+
+    %{
+      "code" => "frontmatter_invalid_yaml",
+      "message" => "The note's frontmatter is not valid YAML.",
+      "detail" => %{"key" => nil, "line" => 1, "snippet" => first_line}
+    }
+  end
+
   @doc "Wrap a degraded key's raw source so emit/2 re-renders it verbatim."
   @spec raw_marker(String.t()) :: String.t()
   def raw_marker(raw) when is_binary(raw), do: Jason.encode!(%{@raw_key => raw})

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -124,7 +124,7 @@ defmodule Engram.Notes.Frontmatter do
     %{
       "code" => "frontmatter_invalid_yaml",
       "message" => "The note's frontmatter is not valid YAML.",
-      "detail" => %{"key" => nil, "line" => 1, "snippet" => first_line}
+      "detail" => %{"key" => nil, "line" => 1, "snippet" => truncate_snippet(first_line)}
     }
   end
 
@@ -277,7 +277,7 @@ defmodule Engram.Notes.Frontmatter do
   # like `[a, b]:`). Regex.escape/1 only accepts binaries, so guard first to
   # keep parse/1 total: report the inspected key, no source line.
   defp degraded_entry(key, _block) when not is_binary(key) do
-    %{key: inspect(key), line: nil, snippet: inspect(key)}
+    %{key: inspect(key), line: nil, snippet: truncate_snippet(inspect(key))}
   end
 
   defp degraded_entry(key, block) do
@@ -290,8 +290,18 @@ defmodule Engram.Notes.Frontmatter do
         i -> {i + 1, Enum.at(lines, i)}
       end
 
-    %{key: key, line: line, snippet: snippet}
+    %{key: key, line: line, snippet: truncate_snippet(snippet)}
   end
+
+  # `snippet` is a raw frontmatter source line for a diagnostic reason
+  # (`parse_reason`), re-echoed on every /sync/changes fetch for the note. A
+  # pathologically long single-line value must not balloon that jsonb column
+  # or the feed payload. This ONLY bounds the diagnostic copy: the verbatim
+  # raw span used for lossless passthrough (raw_marker/raw_spans, Task 3)
+  # is a separate value built from the same source line, not from this
+  # truncated one, so round-trip fidelity is unaffected.
+  @snippet_max_length 200
+  defp truncate_snippet(snippet), do: String.slice(snippet, 0, @snippet_max_length)
 
   # Encode each key's value to a JSON string. Total: a value (or exotic key inside
   # a nested map) that Jason cannot encode is COLLECTED into bad_keys instead of

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -80,6 +80,13 @@ defmodule Engram.Notes.Frontmatter do
   # Best-effort source location + raw slice for a top-level key that failed
   # to encode. Falls back to the bare key when the source line can't be
   # found (e.g. a key that only exists after YAML alias/anchor expansion).
+  # A top-level YAML key can itself be a non-binary (flow-style complex key
+  # like `[a, b]:`). Regex.escape/1 only accepts binaries, so guard first to
+  # keep parse/1 total: report the inspected key, no source line.
+  defp degraded_entry(key, _block) when not is_binary(key) do
+    %{key: inspect(key), line: nil, snippet: inspect(key)}
+  end
+
   defp degraded_entry(key, block) do
     lines = String.split(block, "\n")
     idx = Enum.find_index(lines, fn l -> Regex.match?(~r/^#{Regex.escape(key)}\s*:/, l) end)

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -9,6 +9,13 @@ defmodule Engram.Notes.Frontmatter do
   @fence_line_pattern ~r/\n---[ \t]*\r?\n/
   @fence_eof_pattern ~r/\n---[ \t]*\r?$/
 
+  # A column-0 `key:` line. Same shape top_level_key_order/2 keys on.
+  @top_key_pattern ~r/^([^\s:][^:]*):/
+
+  # Marker envelope for a degraded key's raw source, preserved verbatim so
+  # emit re-renders it byte-for-byte instead of dropping it.
+  @raw_key "__engram_raw__"
+
   @doc """
   Split a note into its frontmatter YAML block (text between the fences, without
   the `---` lines) and its body. Returns `{nil, full_text}` when there is no
@@ -75,6 +82,136 @@ defmodule Engram.Notes.Frontmatter do
       _ ->
         :error
     end
+  end
+
+  @doc "Wrap a degraded key's raw source so emit/2 re-renders it verbatim."
+  @spec raw_marker(String.t()) :: String.t()
+  def raw_marker(raw) when is_binary(raw), do: Jason.encode!(%{@raw_key => raw})
+
+  @doc """
+  Unwrap a raw-passthrough marker. `{:ok, raw}` for a marker produced by
+  `raw_marker/1`; `:error` for any other string (a normal JSON value).
+  """
+  @spec raw_from_marker(String.t()) :: {:ok, String.t()} | :error
+  def raw_from_marker(json) when is_binary(json) do
+    case Jason.decode(json) do
+      {:ok, %{@raw_key => raw}} when is_binary(raw) -> {:ok, raw}
+      _ -> :error
+    end
+  end
+
+  def raw_from_marker(_), do: :error
+
+  @doc """
+  Parse a frontmatter block for CRDT ingest, preserving degraded keys as raw
+  passthrough so nothing is lost when the Y.Map re-emits the note.
+
+  Returns `{:ok, order, values}` where `order` is the full source order of all
+  top-level keys and `values` maps each key to either its JSON-encoded value
+  (good keys) or a `raw_marker/1` of its verbatim source span (degraded keys).
+
+  Returns `:error` when the block is not a YAML map, OR when a degraded key's
+  raw source span cannot be captured losslessly (its column-0 line-tiling is
+  ambiguous with the parsed key set, e.g. a non-binary top-level key or a
+  multi-line flow value with an unindented continuation). The caller then
+  falls back to storing the whole text as body, which is also lossless.
+  """
+  @spec parse_for_ingest(String.t()) ::
+          {:ok, [String.t()], %{String.t() => String.t()}} | :error
+  def parse_for_ingest(""), do: {:ok, [], %{}}
+
+  def parse_for_ingest(block) when is_binary(block) do
+    case YamlElixir.read_from_string(block) do
+      {:ok, map} when is_map(map) ->
+        {values, bad_keys} = encode_values(map)
+
+        if bad_keys == [] do
+          # No degraded keys: keep the existing structured behaviour exactly.
+          {:ok, top_level_key_order(block, map), values}
+        else
+          ingest_with_passthrough(block, map, values, bad_keys)
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  # Degraded keys present: require an exact column-0 line-tiling of the block
+  # so each degraded key's raw source span is captured byte-for-byte.
+  defp ingest_with_passthrough(block, map, values, bad_keys) do
+    case raw_spans(block, map) do
+      {:ok, order, spans} ->
+        merged =
+          Enum.reduce(bad_keys, values, fn key, acc ->
+            case Map.fetch(spans, key) do
+              {:ok, raw} -> Map.put(acc, key, raw_marker(raw))
+              :error -> acc
+            end
+          end)
+
+        # Every degraded key must have a captured span, else it would vanish.
+        if Enum.all?(bad_keys, &Map.has_key?(merged, &1)),
+          do: {:ok, order, merged},
+          else: :error
+
+      :error ->
+        :error
+    end
+  end
+
+  # Tile the block by its column-0 `key:` lines. Returns `{:ok, order, spans}`
+  # only when that tiling is a bijection with the parsed map's keys (source
+  # order preserved), so each key owns exactly the lines from its own line up
+  # to the next key's line: a lossless span. Any ambiguity returns :error.
+  defp raw_spans(block, map) do
+    lines = String.split(block, "\n")
+
+    keyed =
+      lines
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {line, i} ->
+        case Regex.run(@top_key_pattern, line) do
+          [_, key] -> [{i, key}]
+          _ -> []
+        end
+      end)
+
+    col0_keys = Enum.map(keyed, fn {_i, k} -> k end)
+
+    if tileable?(keyed, col0_keys, map) do
+      idxs = Enum.map(keyed, fn {i, _k} -> i end)
+      bounds = Enum.zip(keyed, tl(idxs) ++ [length(lines)])
+
+      spans =
+        Map.new(bounds, fn {{i, key}, next} ->
+          # Strip only the single structural newline the trailing "" split
+          # element added, so an intentional blank line inside the value
+          # survives. emit/2 re-adds exactly one via ensure_trailing_newline/1.
+          raw =
+            lines
+            |> Enum.slice(i, next - i)
+            |> Enum.join("\n")
+            |> String.replace_suffix("\n", "")
+
+          {key, raw}
+        end)
+
+      {:ok, col0_keys, spans}
+    else
+      :error
+    end
+  end
+
+  # Exact tiling: first line is a key, no duplicate column-0 keys, and the
+  # column-0 key set is exactly the parsed map's key set (so no map key lives
+  # only in an alias/anchor, and no value's continuation masquerades as a key).
+  defp tileable?(keyed, col0_keys, map) do
+    keyed != [] and
+      elem(hd(keyed), 0) == 0 and
+      length(Enum.uniq(col0_keys)) == length(col0_keys) and
+      length(col0_keys) == map_size(map) and
+      MapSet.new(col0_keys) == MapSet.new(Map.keys(map))
   end
 
   # Best-effort source location + raw slice for a top-level key that failed
@@ -174,19 +311,31 @@ defmodule Engram.Notes.Frontmatter do
   def emit(order, values) when is_list(order) and is_map(values) do
     order
     |> Enum.filter(&Map.has_key?(values, &1))
-    |> Enum.map_join("", fn key ->
-      decoded = decode_value(values[key])
-
-      try do
-        Ymlr.document!(%{key => decoded}, sort_maps: false)
-        |> String.replace_prefix("---\n", "")
-      rescue
-        # Last resort for values Ymlr cannot serialize (e.g. Yex container
-        # refs): degrade to the inspected form rather than bricking the note.
-        _ -> "#{key}: #{inspect(decoded)}\n"
-      end
-    end)
+    |> Enum.map_join("", fn key -> emit_key(key, values[key]) end)
     |> ensure_trailing_newline()
+  end
+
+  # A degraded key is re-rendered from its verbatim source span (never via
+  # Ymlr, which would canonicalize/lose it); a good key is decoded then emitted
+  # as canonical YAML. ensure_trailing_newline/1 normalizes the final newline
+  # for both so a marker with or without a trailing newline round-trips.
+  defp emit_key(key, value) do
+    case raw_from_marker(value) do
+      {:ok, raw} ->
+        ensure_trailing_newline(raw)
+
+      :error ->
+        decoded = decode_value(value)
+
+        try do
+          Ymlr.document!(%{key => decoded}, sort_maps: false)
+          |> String.replace_prefix("---\n", "")
+        rescue
+          # Last resort for values Ymlr cannot serialize (e.g. Yex container
+          # refs): degrade to the inspected form rather than bricking the note.
+          _ -> "#{key}: #{inspect(decoded)}\n"
+        end
+    end
   end
 
   # Y.Map values are client-controlled: a buggy or hostile peer can store a

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -12,10 +12,6 @@ defmodule Engram.Notes.Frontmatter do
   # A column-0 `key:` line. Same shape top_level_key_order/2 keys on.
   @top_key_pattern ~r/^([^\s:][^:]*):/
 
-  # Marker envelope for a degraded key's raw source, preserved verbatim so
-  # emit re-renders it byte-for-byte instead of dropping it.
-  @raw_key "__engram_raw__"
-
   @doc """
   Split a note into its frontmatter YAML block (text between the fences, without
   the `---` lines) and its body. Returns `{nil, full_text}` when there is no
@@ -119,40 +115,29 @@ defmodule Engram.Notes.Frontmatter do
           String.t() => String.t() | %{String.t() => String.t() | pos_integer() | nil}
         }
   def invalid_yaml_reason(block) when is_binary(block) do
-    first_line = block |> String.split("\n", parts: 2) |> hd()
+    # Content-safe: never echo the raw block text. Frontmatter values are
+    # encrypted at rest and this reason is persisted PLAINTEXT + shipped on
+    # /sync/changes, so a secret in a malformed value must not leak here.
+    _ = block
 
     %{
       "code" => "frontmatter_invalid_yaml",
       "message" => "The note's frontmatter is not valid YAML.",
-      "detail" => %{"key" => nil, "line" => 1, "snippet" => truncate_snippet(first_line)}
+      "detail" => %{"key" => nil, "line" => 1, "snippet" => "<frontmatter>"}
     }
   end
-
-  @doc "Wrap a degraded key's raw source so emit/2 re-renders it verbatim."
-  @spec raw_marker(String.t()) :: String.t()
-  def raw_marker(raw) when is_binary(raw), do: Jason.encode!(%{@raw_key => raw})
-
-  @doc """
-  Unwrap a raw-passthrough marker. `{:ok, raw}` for a marker produced by
-  `raw_marker/1`; `:error` for any other string (a normal JSON value).
-  """
-  @spec raw_from_marker(String.t()) :: {:ok, String.t()} | :error
-  def raw_from_marker(json) when is_binary(json) do
-    case Jason.decode(json) do
-      {:ok, %{@raw_key => raw}} when is_binary(raw) -> {:ok, raw}
-      _ -> :error
-    end
-  end
-
-  def raw_from_marker(_), do: :error
 
   @doc """
   Parse a frontmatter block for CRDT ingest, preserving degraded keys as raw
   passthrough so nothing is lost when the Y.Map re-emits the note.
 
-  Returns `{:ok, order, values}` where `order` is the full source order of all
-  top-level keys and `values` maps each key to either its JSON-encoded value
-  (good keys) or a `raw_marker/1` of its verbatim source span (degraded keys).
+  Returns `{:ok, order, values, raws}` where `order` is the full source order
+  of all top-level keys, `values` maps each GOOD key to its JSON-encoded value,
+  and `raws` maps each DEGRADED key to its verbatim source span (stored out of
+  band from `values`). A key appears in exactly one of `values`/`raws`. Storing
+  raws out of band means `emit/3` never has to guess whether a `values` entry
+  is a real value or a passthrough marker, so a normal value shaped like the old
+  in-band marker can never be mis-rendered.
 
   Returns `:error` when the block is not a YAML map, OR when a degraded key's
   raw source span cannot be captured losslessly (its column-0 line-tiling is
@@ -161,28 +146,20 @@ defmodule Engram.Notes.Frontmatter do
   falls back to storing the whole text as body, which is also lossless.
   """
   @spec parse_for_ingest(String.t()) ::
-          {:ok, [String.t()], %{String.t() => String.t()}} | :error
-  def parse_for_ingest(""), do: {:ok, [], %{}}
+          {:ok, [String.t()], %{String.t() => String.t()}, %{String.t() => String.t()}}
+          | :error
+  def parse_for_ingest(""), do: {:ok, [], %{}, %{}}
 
   def parse_for_ingest(block) when is_binary(block) do
     case YamlElixir.read_from_string(block) do
       {:ok, map} when is_map(map) ->
         {values, bad_keys} = encode_values(map)
 
-        # A GOOD value can encode to JSON that raw_from_marker/1 mistakes for a
-        # passthrough marker (a map merely containing @raw_key). emit/2 would
-        # then render its inner raw and DROP the key. Route those through the
-        # same verbatim span-passthrough so they round-trip exactly. No marker
-        # format can disambiguate the exact single-key collision, so this is
-        # the robust fix, not tightening the pattern.
-        colliding = for {k, v} <- values, match?({:ok, _}, raw_from_marker(v)), do: k
-        passthrough_keys = bad_keys ++ colliding
-
-        if passthrough_keys == [] do
-          # No degraded/colliding keys: keep the existing structured behaviour.
-          {:ok, top_level_key_order(block, map), values}
+        if bad_keys == [] do
+          # No degraded keys: fully structured, no raw passthrough needed.
+          {:ok, top_level_key_order(block, map), values, %{}}
         else
-          ingest_with_passthrough(block, map, values, passthrough_keys)
+          ingest_with_passthrough(block, map, values, bad_keys)
         end
 
       _ ->
@@ -190,26 +167,20 @@ defmodule Engram.Notes.Frontmatter do
     end
   end
 
-  # Passthrough keys present (degraded and/or marker-colliding): require an
-  # exact column-0 line-tiling of the block so each key's raw source span is
-  # captured byte-for-byte, then store each as a verbatim raw marker.
+  # Degraded keys present: require an exact column-0 line-tiling of the block so
+  # each key's raw source span is captured byte-for-byte, then store each in the
+  # out-of-band `raws` map so emit/3 re-renders it verbatim.
   defp ingest_with_passthrough(block, map, values, passthrough_keys) do
     case raw_spans(block, map) do
       {:ok, order, spans} ->
-        merged =
-          Enum.reduce(passthrough_keys, values, fn key, acc ->
-            case Map.fetch(spans, key) do
-              {:ok, raw} -> Map.put(acc, key, raw_marker(raw))
-              :error -> acc
-            end
-          end)
-
-        # Every passthrough key must have a captured span, else it would vanish
-        # (degraded) or stay a false-marker good value (colliding). Either way
-        # fall back to the lossless whole-text-as-body path.
-        if Enum.all?(passthrough_keys, &match?({:ok, _}, Map.fetch(spans, &1))),
-          do: {:ok, order, merged},
-          else: :error
+        # Every degraded key must have a captured span, else it would vanish.
+        # Fall back to the lossless whole-text-as-body path when any is missing.
+        if Enum.all?(passthrough_keys, &Map.has_key?(spans, &1)) do
+          raws = Map.new(passthrough_keys, fn key -> {key, Map.fetch!(spans, key)} end)
+          {:ok, order, values, raws}
+        else
+          :error
+        end
 
       :error ->
         :error
@@ -270,9 +241,12 @@ defmodule Engram.Notes.Frontmatter do
       MapSet.new(col0_keys) == MapSet.new(Map.keys(map))
   end
 
-  # Best-effort source location + raw slice for a top-level key that failed
-  # to encode. Falls back to the bare key when the source line can't be
-  # found (e.g. a key that only exists after YAML alias/anchor expansion).
+  # Best-effort source LOCATION for a top-level key that failed to encode.
+  # `snippet` carries ONLY the key name, never the value: this entry feeds the
+  # PLAINTEXT `parse_reason` column that is echoed on /sync/changes, and note
+  # content is encrypted at rest, so a secret in a malformed value must not
+  # leak. The verbatim raw span used for lossless passthrough is captured
+  # separately (raw_spans/2), not from this diagnostic entry.
   # A top-level YAML key can itself be a non-binary (flow-style complex key
   # like `[a, b]:`). Regex.escape/1 only accepts binaries, so guard first to
   # keep parse/1 total: report the inspected key, no source line.
@@ -283,23 +257,13 @@ defmodule Engram.Notes.Frontmatter do
   defp degraded_entry(key, block) do
     lines = String.split(block, "\n")
     idx = Enum.find_index(lines, fn l -> Regex.match?(~r/^#{Regex.escape(key)}\s*:/, l) end)
-
-    {line, snippet} =
-      case idx do
-        nil -> {nil, key}
-        i -> {i + 1, Enum.at(lines, i)}
-      end
-
-    %{key: key, line: line, snippet: truncate_snippet(snippet)}
+    line = if idx, do: idx + 1, else: nil
+    %{key: key, line: line, snippet: truncate_snippet(key <> ":")}
   end
 
-  # `snippet` is a raw frontmatter source line for a diagnostic reason
-  # (`parse_reason`), re-echoed on every /sync/changes fetch for the note. A
-  # pathologically long single-line value must not balloon that jsonb column
-  # or the feed payload. This ONLY bounds the diagnostic copy: the verbatim
-  # raw span used for lossless passthrough (raw_marker/raw_spans, Task 3)
-  # is a separate value built from the same source line, not from this
-  # truncated one, so round-trip fidelity is unaffected.
+  # Bound the redacted `snippet` (a key name) so a pathologically long key
+  # can't balloon the plaintext `parse_reason` jsonb column or the /sync/changes
+  # feed payload. Never carries a frontmatter value (see degraded_entry/2).
   @snippet_max_length 200
   defp truncate_snippet(snippet), do: String.slice(snippet, 0, @snippet_max_length)
 
@@ -371,36 +335,39 @@ defmodule Engram.Notes.Frontmatter do
   and REST write projects through emit, so a single unserializable value would
   otherwise brick the note.
   """
-  @spec emit([String.t()], %{String.t() => term()}) :: String.t()
-  def emit([], _values), do: ""
+  @spec emit([String.t()], %{String.t() => term()}, %{String.t() => String.t()}) :: String.t()
+  def emit(order, values, raws \\ %{})
 
-  def emit(order, values) when is_list(order) and is_map(values) do
+  def emit([], _values, _raws), do: ""
+
+  def emit(order, values, raws)
+      when is_list(order) and is_map(values) and is_map(raws) do
     order
-    |> Enum.filter(&Map.has_key?(values, &1))
-    |> Enum.map_join("", fn key -> emit_key(key, values[key]) end)
+    |> Enum.filter(fn k -> Map.has_key?(raws, k) or Map.has_key?(values, k) end)
+    |> Enum.map_join("", fn key ->
+      case Map.fetch(raws, key) do
+        # A degraded key is re-rendered from its verbatim out-of-band source
+        # span (never via Ymlr, which would canonicalize/lose it).
+        {:ok, raw} -> ensure_trailing_newline(raw)
+        :error -> emit_key(key, values[key])
+      end
+    end)
     |> ensure_trailing_newline()
   end
 
-  # A degraded key is re-rendered from its verbatim source span (never via
-  # Ymlr, which would canonicalize/lose it); a good key is decoded then emitted
-  # as canonical YAML. ensure_trailing_newline/1 normalizes the final newline
-  # for both so a marker with or without a trailing newline round-trips.
+  # A good key is decoded then emitted as canonical YAML. Raw passthrough is
+  # handled out of band in emit/3 (the `raws` map), so a normal value here is
+  # NEVER mistaken for a marker: this path only ever sees real values.
   defp emit_key(key, value) do
-    case raw_from_marker(value) do
-      {:ok, raw} ->
-        ensure_trailing_newline(raw)
+    decoded = decode_value(value)
 
-      :error ->
-        decoded = decode_value(value)
-
-        try do
-          Ymlr.document!(%{key => decoded}, sort_maps: false)
-          |> String.replace_prefix("---\n", "")
-        rescue
-          # Last resort for values Ymlr cannot serialize (e.g. Yex container
-          # refs): degrade to the inspected form rather than bricking the note.
-          _ -> "#{key}: #{inspect(decoded)}\n"
-        end
+    try do
+      Ymlr.document!(%{key => decoded}, sort_maps: false)
+      |> String.replace_prefix("---\n", "")
+    rescue
+      # Last resort for values Ymlr cannot serialize (e.g. Yex container
+      # refs): degrade to the inspected form rather than bricking the note.
+      _ -> "#{key}: #{inspect(decoded)}\n"
     end
   end
 
@@ -423,12 +390,19 @@ defmodule Engram.Notes.Frontmatter do
     if String.ends_with?(s, "\n"), do: s, else: s <> "\n"
   end
 
-  @doc "Assemble full note plaintext from frontmatter parts and body."
-  @spec project([String.t()], %{String.t() => String.t()}, String.t()) :: String.t()
-  def project([], _values, body), do: body
+  @doc """
+  Assemble full note plaintext from frontmatter parts and body. `raws` (the
+  out-of-band degraded-key source spans) defaults to empty for good-only docs.
+  """
+  @spec project([String.t()], %{String.t() => String.t()}, String.t(), %{
+          String.t() => String.t()
+        }) :: String.t()
+  def project(order, values, body, raws \\ %{})
 
-  def project(order, values, body) when is_binary(body) do
-    case emit(order, values) do
+  def project([], _values, body, _raws), do: body
+
+  def project(order, values, body, raws) when is_binary(body) do
+    case emit(order, values, raws) do
       "" -> body
       block -> "---\n" <> block <> "---\n" <> body
     end

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -61,9 +61,11 @@ defmodule Engram.Notes.Frontmatter do
       {:ok, map} when is_map(map) ->
         order = top_level_key_order(block, map)
 
+        # Task 2 will rewrite parse/1 to surface bad_keys. For now keep the
+        # existing {:ok, ...} | :error contract: any bad key means :error.
         case encode_values(map) do
-          {:ok, values} -> {:ok, order, values}
-          :error -> :error
+          {values, []} -> {:ok, order, values}
+          {_values, _bad} -> :error
         end
 
       _ ->
@@ -71,31 +73,49 @@ defmodule Engram.Notes.Frontmatter do
     end
   end
 
-  # Encode all map values to JSON strings. Returns {:ok, values_map} on success,
-  # :error if any value cannot be encoded (unencodable exotic types like tuples).
+  # Encode each key's value to a JSON string. Total: a value (or exotic key inside
+  # a nested map) that Jason cannot encode is COLLECTED into bad_keys instead of
+  # raising or aborting. Returns {values, bad_keys}.
   # Values are deep-sorted before encoding so nested-map keys are canonical
   # (lexicographic, matching JS JSON.stringify with sorted keys in the plugin).
   @doc false
   def encode_values(map) do
-    result =
-      Enum.reduce_while(map, %{}, fn {k, v}, acc ->
-        case Jason.encode(deep_sort(v)) do
-          {:ok, json_str} -> {:cont, Map.put(acc, k, json_str)}
-          {:error, _} -> {:halt, :error}
-        end
-      end)
+    Enum.reduce(map, {%{}, []}, fn {k, v}, {values, bad} ->
+      case safe_encode(v) do
+        {:ok, json_str} -> {Map.put(values, k, json_str), bad}
+        :error -> {values, [k | bad]}
+      end
+    end)
+    |> then(fn {values, bad} -> {values, Enum.reverse(bad)} end)
+  end
 
-    case result do
-      :error -> :error
-      values_map -> {:ok, values_map}
+  # Deep-sort then JSON-encode a value. Jason.encode/1 returns {:error,_} for
+  # some terms but RAISES for others (e.g. a charlist/tuple map KEY ->
+  # List.to_string/Protocol.UndefinedError); deep_sort/1 also raises on a
+  # non-binary map key. deep_sort MUST run inside this rescue so its raise is
+  # trapped too, keeping the codec total.
+  defp safe_encode(term) do
+    case Jason.encode(deep_sort(term)) do
+      {:ok, s} -> {:ok, s}
+      {:error, _} -> :error
     end
+  rescue
+    _ -> :error
   end
 
   # Recursively sort map keys for canonical JSON encoding. Arrays keep their
   # order. Scalars (string, number, bool, nil) are returned as-is. Unencodable
   # values (e.g. tuples) pass through unchanged so Jason.encode still returns
-  # {:error, _} on them, preserving the :halt/:error path in encode_values/1.
+  # {:error, _} on them, routing the key into bad_keys via safe_encode/1.
   defp deep_sort(value) when is_map(value) do
+    # A non-binary map key (e.g. a charlist from exotic YAML like
+    # `date:YYYY-MM-DD`) is not a valid JSON object key. Jason.OrderedObject
+    # would silently coerce it to a string, hiding the bad term. Raise instead
+    # so safe_encode/1 traps it and collects the key into bad_keys.
+    unless Enum.all?(value, fn {k, _} -> is_binary(k) end) do
+      raise ArgumentError, "non-binary map key is not JSON-encodable"
+    end
+
     Jason.OrderedObject.new(
       value
       |> Enum.sort_by(fn {k, _} -> k end)

--- a/lib/engram/notes/frontmatter.ex
+++ b/lib/engram/notes/frontmatter.ex
@@ -48,29 +48,49 @@ defmodule Engram.Notes.Frontmatter do
   end
 
   @doc """
-  Parse a frontmatter YAML block into `{:ok, order, values}` where `values` maps
-  each top-level key to the JSON-encoded string of its parsed value, and `order` is
-  the source key order. Returns `:error` on malformed YAML or if any value cannot
-  be JSON-encoded.
+  Parse a frontmatter YAML block into `{:ok, order, values, degraded}`.
+  `values` maps each encodable top-level key to the JSON-encoded string of its
+  parsed value; `order` is the source order of those good keys. Keys whose
+  value cannot be JSON-encoded are dropped from `order`/`values` and reported
+  in `degraded` (a list of `%{key, line, snippet}`) instead.
+
+  Returns `:error` only when the block is not YAML-map-shaped at all (whole
+  block failure), never for a single bad key.
   """
-  @spec parse(String.t()) :: {:ok, [String.t()], %{String.t() => String.t()}} | :error
-  def parse(""), do: {:ok, [], %{}}
+  @spec parse(String.t()) ::
+          {:ok, [String.t()], %{String.t() => String.t()}, [map()]} | :error
+  def parse(""), do: {:ok, [], %{}, []}
 
   def parse(block) when is_binary(block) do
     case YamlElixir.read_from_string(block) do
       {:ok, map} when is_map(map) ->
         order = top_level_key_order(block, map)
-
-        # Task 2 will rewrite parse/1 to surface bad_keys. For now keep the
-        # existing {:ok, ...} | :error contract: any bad key means :error.
-        case encode_values(map) do
-          {values, []} -> {:ok, order, values}
-          {_values, _bad} -> :error
-        end
+        {values, bad_keys} = encode_values(map)
+        degraded = Enum.map(bad_keys, &degraded_entry(&1, block))
+        # Good keys keep source order; bad keys are dropped from `values`/
+        # `order` but preserved via `degraded` (raw passthrough is Task 3).
+        good_order = Enum.filter(order, &Map.has_key?(values, &1))
+        {:ok, good_order, values, degraded}
 
       _ ->
         :error
     end
+  end
+
+  # Best-effort source location + raw slice for a top-level key that failed
+  # to encode. Falls back to the bare key when the source line can't be
+  # found (e.g. a key that only exists after YAML alias/anchor expansion).
+  defp degraded_entry(key, block) do
+    lines = String.split(block, "\n")
+    idx = Enum.find_index(lines, fn l -> Regex.match?(~r/^#{Regex.escape(key)}\s*:/, l) end)
+
+    {line, snippet} =
+      case idx do
+        nil -> {nil, key}
+        i -> {i + 1, Enum.at(lines, i)}
+      end
+
+    %{key: key, line: line, snippet: snippet}
   end
 
   # Encode each key's value to a JSON string. Total: a value (or exotic key inside

--- a/lib/engram/notes/note.ex
+++ b/lib/engram/notes/note.ex
@@ -86,6 +86,13 @@ defmodule Engram.Notes.Note do
     field :resource_ciphertext, :binary
     field :resource_nonce, :binary
 
+    # Frontmatter-resilience (Task 4): stamped by ingest (Task 5) when a
+    # note's frontmatter couldn't be parsed cleanly, so the fallback is
+    # visible instead of silent. Plaintext: describes parser behavior, not
+    # note content.
+    field :parse_status, :string, default: "ok"
+    field :parse_reason, :map
+
     belongs_to :user, Engram.Accounts.User
     belongs_to :vault, Engram.Vaults.Vault
     has_many :chunks, Engram.Notes.Chunk
@@ -139,7 +146,9 @@ defmodule Engram.Notes.Note do
         :deleted_at,
         :kind,
         :fm_timestamp,
-        :fm_created
+        :fm_created,
+        :parse_status,
+        :parse_reason
       ] ++ @encryption_fields,
       empty_values: []
     )

--- a/lib/engram/notes/okf_fields.ex
+++ b/lib/engram/notes/okf_fields.ex
@@ -27,7 +27,7 @@ defmodule Engram.Notes.OkfFields do
   @spec extract(String.t()) :: t()
   def extract(content) when is_binary(content) do
     with {block, _body} when is_binary(block) <- Frontmatter.split(content),
-         {:ok, _order, values} <- Frontmatter.parse(block) do
+         {:ok, _order, values, _degraded} <- Frontmatter.parse(block) do
       decoded = decode_values(values)
 
       %{

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -109,12 +109,17 @@ defmodule Engram.Vaults do
   transaction so the bump participates in the same atomic unit as the row
   write it stamps (and inherits RLS tenant context). The row-level lock on
   the vault row serializes seq assignment per vault.
+
+  `opts` is passed straight to `Repo.query!/3` — the batch upsert path passes
+  `mode: :savepoint` so a failed bump (e.g. bigint overflow) rolls back to a
+  per-statement savepoint instead of poisoning the shared batch transaction.
   """
-  def next_seq!(vault_id) do
+  def next_seq!(vault_id, opts \\ []) do
     %{rows: [[seq]]} =
       Repo.query!(
         "UPDATE vaults SET change_seq = change_seq + 1 WHERE id = $1 RETURNING change_seq",
-        [Ecto.UUID.dump!(vault_id)]
+        [Ecto.UUID.dump!(vault_id)],
+        opts
       )
 
     seq

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -110,7 +110,7 @@ defmodule Engram.Vaults do
   write it stamps (and inherits RLS tenant context). The row-level lock on
   the vault row serializes seq assignment per vault.
 
-  `opts` is passed straight to `Repo.query!/3` — the batch upsert path passes
+  `opts` is passed straight to `Repo.query!/3`. The batch upsert path passes
   `mode: :savepoint` so a failed bump (e.g. bigint overflow) rolls back to a
   per-statement savepoint instead of poisoning the shared batch transaction.
   """

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -517,7 +517,9 @@ defmodule EngramWeb.NotesController do
       id: result.id,
       version: result.version,
       content_hash: result.content_hash,
-      server_path: result.server_path
+      server_path: result.server_path,
+      parse_status: result.parse_status,
+      parse_reason: result.parse_reason
     }
   end
 
@@ -690,7 +692,9 @@ defmodule EngramWeb.NotesController do
       description: note.description,
       resource: note.resource,
       fm_timestamp: note.fm_timestamp,
-      fm_created: note.fm_created
+      fm_created: note.fm_created,
+      parse_status: note.parse_status,
+      parse_reason: note.parse_reason
     }
   end
 
@@ -705,7 +709,9 @@ defmodule EngramWeb.NotesController do
       mtime: change.mtime,
       content_hash: change.content_hash,
       deleted: change.deleted,
-      updated_at: change.updated_at
+      updated_at: change.updated_at,
+      parse_status: change.parse_status,
+      parse_reason: change.parse_reason
     }
   end
 

--- a/lib/engram_web/schemas/common.ex
+++ b/lib/engram_web/schemas/common.ex
@@ -43,6 +43,17 @@ defmodule EngramWeb.Schemas.Note do
         format: :"date-time",
         nullable: true,
         description: "OKF frontmatter `created`/`date` field"
+      },
+      parse_status: %Schema{
+        type: :string,
+        enum: ["ok", "degraded"],
+        nullable: true,
+        description: "Frontmatter parse outcome"
+      },
+      parse_reason: %Schema{
+        type: :object,
+        nullable: true,
+        description: "Present when parse_status is \"degraded\": {code, message, detail}"
       }
     },
     required: [:path]
@@ -66,7 +77,18 @@ defmodule EngramWeb.Schemas.NoteMeta do
       version: %Schema{type: :integer, nullable: true},
       content_hash: %Schema{type: :string, nullable: true},
       mtime: %Schema{type: :number, format: :float},
-      updated_at: %Schema{type: :string, format: :"date-time", nullable: true}
+      updated_at: %Schema{type: :string, format: :"date-time", nullable: true},
+      parse_status: %Schema{
+        type: :string,
+        enum: ["ok", "degraded"],
+        nullable: true,
+        description: "Frontmatter parse outcome"
+      },
+      parse_reason: %Schema{
+        type: :object,
+        nullable: true,
+        description: "Present when parse_status is \"degraded\": {code, message, detail}"
+      }
     },
     required: [:path]
   })

--- a/lib/engram_web/schemas/notes.ex
+++ b/lib/engram_web/schemas/notes.ex
@@ -178,7 +178,18 @@ defmodule EngramWeb.Schemas.BatchUpsertResult do
       content_hash: %Schema{type: :string, nullable: true},
       server_path: %Schema{type: :string, nullable: true},
       errors: %Schema{type: :object, nullable: true},
-      server_note: %Schema{oneOf: [EngramWeb.Schemas.Note], nullable: true}
+      server_note: %Schema{oneOf: [EngramWeb.Schemas.Note], nullable: true},
+      parse_status: %Schema{
+        type: :string,
+        enum: ["ok", "degraded"],
+        nullable: true,
+        description: "Frontmatter parse outcome"
+      },
+      parse_reason: %Schema{
+        type: :object,
+        nullable: true,
+        description: "Present when parse_status is \"degraded\": {code, message, detail}"
+      }
     }
   })
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.667",
+      version: "0.5.668",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/openapi.json
+++ b/openapi.json
@@ -99,6 +99,24 @@
             "x-struct": null,
             "x-validate": null
           },
+          "parse_reason": {
+            "description": "Present when parse_status is \"degraded\": {code, message, detail}",
+            "nullable": true,
+            "type": "object",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "parse_status": {
+            "description": "Frontmatter parse outcome",
+            "enum": [
+              "ok",
+              "degraded"
+            ],
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "path": {
             "example": "Projects/engram.md",
             "type": "string",
@@ -236,6 +254,24 @@
           },
           "id": {
             "format": "uuid",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "parse_reason": {
+            "description": "Present when parse_status is \"degraded\": {code, message, detail}",
+            "nullable": true,
+            "type": "object",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "parse_status": {
+            "description": "Frontmatter parse outcome",
+            "enum": [
+              "ok",
+              "degraded"
+            ],
             "nullable": true,
             "type": "string",
             "x-struct": null,
@@ -2055,6 +2091,24 @@
           "mtime": {
             "format": "float",
             "type": "number",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "parse_reason": {
+            "description": "Present when parse_status is \"degraded\": {code, message, detail}",
+            "nullable": true,
+            "type": "object",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "parse_status": {
+            "description": "Frontmatter parse outcome",
+            "enum": [
+              "ok",
+              "degraded"
+            ],
+            "nullable": true,
+            "type": "string",
             "x-struct": null,
             "x-validate": null
           },

--- a/priv/repo/migrations/20260712120000_add_parse_status_to_notes_expand.exs
+++ b/priv/repo/migrations/20260712120000_add_parse_status_to_notes_expand.exs
@@ -1,0 +1,19 @@
+defmodule Engram.Repo.Migrations.AddParseStatusToNotesExpand do
+  use Ecto.Migration
+
+  # phase/expand — parse-status columns for frontmatter-resilience (Task 4).
+  #
+  # `parse_status` records whether the last ingest parsed this note's
+  # frontmatter cleanly ("ok") or fell back ("degraded" etc, stamped by
+  # Task 5). `parse_reason` is a jsonb blob with the structured failure
+  # detail for the web/plugin UI (Task 7 serializes it). Both are plaintext:
+  # they describe our own parser's behavior, not note content, so no
+  # encryption/HMAC is needed.
+
+  def change do
+    alter table(:notes) do
+      add :parse_status, :text, null: false, default: "ok"
+      add :parse_reason, :map
+    end
+  end
+end

--- a/priv/repo/migrations/20260712120000_add_parse_status_to_notes_expand.exs
+++ b/priv/repo/migrations/20260712120000_add_parse_status_to_notes_expand.exs
@@ -1,7 +1,7 @@
 defmodule Engram.Repo.Migrations.AddParseStatusToNotesExpand do
   use Ecto.Migration
 
-  # phase/expand — parse-status columns for frontmatter-resilience (Task 4).
+  # phase/expand: parse-status columns for frontmatter-resilience (Task 4).
   #
   # `parse_status` records whether the last ingest parsed this note's
   # frontmatter cleanly ("ok") or fell back ("degraded" etc, stamped by

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -87,6 +87,30 @@ defmodule Engram.Notes.CrdtBridgeTest do
     end
   end
 
+  describe "degraded frontmatter key raw passthrough (lossless round-trip)" do
+    test "single-line degraded value round-trips byte-identical" do
+      doc = CrdtBridge.new_doc()
+      original = "---\ntags:\n  - a\ndate: {[a, b]: 1}\n---\nbody text\n"
+      :ok = CrdtBridge.ingest_plaintext(doc, original)
+      assert CrdtBridge.text_of(doc) == original
+    end
+
+    test "multi-line degraded value round-trips byte-identical" do
+      doc = CrdtBridge.new_doc()
+      original = "---\ntags:\n  - a\ndate:\n  [a, b]: 1\n---\nbody text\n"
+      :ok = CrdtBridge.ingest_plaintext(doc, original)
+      assert CrdtBridge.text_of(doc) == original
+    end
+
+    test "un-locatable degraded key falls back to whole-text-as-body (still lossless)" do
+      doc = CrdtBridge.new_doc()
+      original = "---\n{[a, b]: 1}: {[c, d]: 2}\n---\nbody text\n"
+      :ok = CrdtBridge.ingest_plaintext(doc, original)
+      assert CrdtBridge.frontmatter_of(doc) == {[], %{}}
+      assert CrdtBridge.text_of(doc) == original
+    end
+  end
+
   describe "project_doc/1" do
     test "round-trips ingest then project back to equivalent plaintext" do
       doc = CrdtBridge.new_doc()

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -109,11 +109,17 @@ defmodule Engram.Notes.CrdtBridgeTest do
       assert CrdtBridge.text_of(doc) == original
     end
 
-    test "a marker-colliding map keeps its sibling keys" do
+    test "a marker-colliding map keeps its sibling keys (canonicalized, not dropped)" do
       doc = CrdtBridge.new_doc()
       original = "---\ndate:\n  __engram_raw__: x\n  y: 1\n---\nbody\n"
       :ok = CrdtBridge.ingest_plaintext(doc, original)
-      assert CrdtBridge.text_of(doc) == original
+      # This is a normal ENCODABLE value (a map that merely contains the old
+      # marker key), so it round-trips CANONICALLY through Ymlr, not verbatim:
+      # both sibling keys survive as data (emit never treats it as a marker).
+      # Byte-identity is only promised for DEGRADED keys (raw passthrough).
+      {_order, values} = CrdtBridge.frontmatter_of(doc)
+      assert Jason.decode!(values["date"]) == %{"__engram_raw__" => "x", "y" => 1}
+      assert CrdtBridge.body_of(doc) == "body\n"
     end
 
     test "pathologically long single-line degraded value round-trips byte-identical (reason snippet is bounded, raw span is not)" do
@@ -144,6 +150,26 @@ defmodule Engram.Notes.CrdtBridgeTest do
       doc = CrdtBridge.new_doc()
       :ok = CrdtBridge.ingest_plaintext(doc, "no frontmatter\n")
       assert CrdtBridge.project_doc(doc) == "no frontmatter\n"
+    end
+
+    test "a client-written value shaped like the old raw marker is NOT dropped on projection" do
+      # A hostile/buggy client can write this value straight into the Y.Map,
+      # bypassing the ingest guard. With out-of-band raws, projection must treat
+      # it as a normal value (emit canonically), never as a passthrough marker.
+      doc = CrdtBridge.new_doc()
+      map = Yex.Doc.get_map(doc, "frontmatter")
+      Yex.Map.set(map, "mykey", ~s({"__engram_raw__":"hello"}))
+      arr = Yex.Doc.get_array(doc, "frontmatter_order")
+      Yex.Array.insert_list(arr, 0, ["mykey"])
+
+      text = CrdtBridge.project_doc(doc)
+      assert text =~ "mykey"
+
+      # And it round-trips: re-ingesting yields the same value under the key.
+      doc2 = CrdtBridge.new_doc()
+      :ok = CrdtBridge.ingest_plaintext(doc2, text)
+      {_order, values} = CrdtBridge.frontmatter_of(doc2)
+      assert Jason.decode!(values["mykey"]) == %{"__engram_raw__" => "hello"}
     end
   end
 
@@ -236,6 +262,26 @@ defmodule Engram.Notes.CrdtBridgeTest do
       first = {CrdtBridge.frontmatter_of(doc), CrdtBridge.body_of(doc)}
       assert :ok = CrdtBridge.normalize_doc(doc)
       assert {CrdtBridge.frontmatter_of(doc), CrdtBridge.body_of(doc)} == first
+    end
+
+    test "lifts a DEGRADED leading-fence key losslessly (does not drop it)" do
+      # A legacy doc whose body begins with a fence containing an unencodable
+      # key (nested non-binary key). normalize must lift it via the out-of-band
+      # raw store, NOT strip-and-drop it. The key's data survives byte-for-byte.
+      original = "---\ntags:\n  - a\ndate: {[a, b]: 1}\n---\nbody\n"
+      doc = CrdtBridge.new_doc() |> seed_body(original)
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert CrdtBridge.text_of(doc) == original
+    end
+
+    test "leaves the doc untouched when a degraded key cannot be captured losslessly" do
+      # Non-binary top-level key: no column-0 span, parse_for_ingest -> :error.
+      # normalize must NOT strip the fence (that would lose the block).
+      original = "---\n{[a, b]: 1}: {[c, d]: 2}\n---\nbody\n"
+      doc = CrdtBridge.new_doc() |> seed_body(original)
+      assert :ok = CrdtBridge.normalize_doc(doc)
+      assert CrdtBridge.frontmatter_of(doc) == {[], %{}}
+      assert CrdtBridge.body_of(doc) == original
     end
 
     test "strips an empty frontmatter fence and terminates" do

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -116,6 +116,14 @@ defmodule Engram.Notes.CrdtBridgeTest do
       assert CrdtBridge.text_of(doc) == original
     end
 
+    test "pathologically long single-line degraded value round-trips byte-identical (reason snippet is bounded, raw span is not)" do
+      doc = CrdtBridge.new_doc()
+      padding = String.duplicate("x", 500)
+      original = "---\ntags:\n  - a\ndate: {[#{padding}]: 1}\n---\nbody text\n"
+      :ok = CrdtBridge.ingest_plaintext(doc, original)
+      assert CrdtBridge.text_of(doc) == original
+    end
+
     test "un-locatable degraded key falls back to whole-text-as-body (still lossless)" do
       doc = CrdtBridge.new_doc()
       original = "---\n{[a, b]: 1}: {[c, d]: 2}\n---\nbody text\n"

--- a/test/engram/notes/crdt_bridge_test.exs
+++ b/test/engram/notes/crdt_bridge_test.exs
@@ -102,6 +102,20 @@ defmodule Engram.Notes.CrdtBridgeTest do
       assert CrdtBridge.text_of(doc) == original
     end
 
+    test "a GOOD value that looks like a raw marker still round-trips (no false passthrough)" do
+      doc = CrdtBridge.new_doc()
+      original = "---\ndate:\n  __engram_raw__: x\n---\nbody\n"
+      :ok = CrdtBridge.ingest_plaintext(doc, original)
+      assert CrdtBridge.text_of(doc) == original
+    end
+
+    test "a marker-colliding map keeps its sibling keys" do
+      doc = CrdtBridge.new_doc()
+      original = "---\ndate:\n  __engram_raw__: x\n  y: 1\n---\nbody\n"
+      :ok = CrdtBridge.ingest_plaintext(doc, original)
+      assert CrdtBridge.text_of(doc) == original
+    end
+
     test "un-locatable degraded key falls back to whole-text-as-body (still lossless)" do
       doc = CrdtBridge.new_doc()
       original = "---\n{[a, b]: 1}: {[c, d]: 2}\n---\nbody text\n"

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -103,6 +103,26 @@ defmodule Engram.Notes.FrontmatterTest do
     test "parse/1 empty block" do
       assert {:ok, [], %{}, []} = Frontmatter.parse("")
     end
+
+    test "degraded key snippet is bounded to 200 chars even for a pathologically long source line" do
+      padding = String.duplicate("x", 500)
+      block = "tags:\n  - a\ndate: {[#{padding}]: 1}\n"
+
+      assert {:ok, _order, _values, degraded} = Frontmatter.parse(block)
+      assert [%{key: "date", line: 3, snippet: snippet}] = degraded
+      assert String.length(snippet) == 200
+
+      reason = Frontmatter.reason_for(degraded)
+      assert String.length(reason["detail"]["snippet"]) == 200
+    end
+  end
+
+  describe "invalid_yaml_reason/1" do
+    test "bounds the snippet to 200 chars for a pathologically long first line" do
+      long_line = String.duplicate("y", 500)
+      reason = Frontmatter.invalid_yaml_reason(long_line <> "\nmore\n")
+      assert String.length(reason["detail"]["snippet"]) == 200
+    end
   end
 
   describe "emit/2 and self-idempotency" do

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -124,18 +124,26 @@ defmodule Engram.Notes.FrontmatterTest do
     end
   end
 
-  describe "encode_values/1" do
-    # Route: YamlElixir special floats (.nan/.inf) are parsed to atoms, which
-    # Jason encodes as strings, so they do NOT trigger an encode error. The
-    # encode-failure branch is tested directly via a map containing a tuple
-    # value, which is unencodable by the Jason.Encoder protocol.
-    test "returns :error when a value is unencodable (e.g. a tuple)" do
-      assert Frontmatter.encode_values(%{"key" => {:not, :encodable}}) == :error
+  describe "encode_values/1 leniency" do
+    test "keeps encodable keys and collects the unencodable ones without raising" do
+      map = %{"tags" => ["a", "b"], "weird" => {:a, :tuple}}
+      assert {values, bad_keys} = Frontmatter.encode_values(map)
+      assert values["tags"] == ~s(["a","b"])
+      refute Map.has_key?(values, "weird")
+      assert bad_keys == ["weird"]
     end
 
-    test "returns {:ok, values_map} when all values are encodable" do
-      assert Frontmatter.encode_values(%{"a" => 1, "b" => "hello"}) ==
-               {:ok, %{"a" => "1", "b" => "\"hello\""}}
+    test "an exotic (charlist/tuple) KEY in a nested map is collected, not raised" do
+      # mirrors the yamerl output that 500'd prod (date:YYYY-MM-DD)
+      map = %{"date" => %{~c"tag:yaml.org,2002:str" => "x"}}
+      assert {values, bad_keys} = Frontmatter.encode_values(map)
+      assert bad_keys == ["date"]
+      assert values == %{}
+    end
+
+    test "all-good map returns empty bad_keys" do
+      assert {values, []} = Frontmatter.encode_values(%{"a" => 1, "b" => "s"})
+      assert values == %{"a" => "1", "b" => ~s("s")}
     end
   end
 

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -91,6 +91,15 @@ defmodule Engram.Notes.FrontmatterTest do
       assert :error = Frontmatter.parse("just a scalar\n")
     end
 
+    test "parse/1 stays total when a top-level KEY is itself non-binary" do
+      # Flow-style complex mapping key: a valid YAML map whose top-level key is
+      # a list, not a string. It cannot be JSON-encoded, so it must degrade
+      # (not raise) even though degraded_entry can't regex-match a non-binary.
+      assert {:ok, _order, values, degraded} = Frontmatter.parse("{[a, b]: 1}: {[c, d]: 2}\n")
+      assert values == %{}
+      assert [%{key: _, line: nil, snippet: _}] = degraded
+    end
+
     test "parse/1 empty block" do
       assert {:ok, [], %{}, []} = Frontmatter.parse("")
     end

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -40,11 +40,11 @@ defmodule Engram.Notes.FrontmatterTest do
   describe "parse/1" do
     test "returns ordered keys and JSON-encoded values" do
       assert Frontmatter.parse("title: Hi\ntags:\n  - a\n  - b\n") ==
-               {:ok, ["title", "tags"], %{"title" => "\"Hi\"", "tags" => "[\"a\",\"b\"]"}}
+               {:ok, ["title", "tags"], %{"title" => "\"Hi\"", "tags" => "[\"a\",\"b\"]"}, []}
     end
 
     test "empty block yields empty order and values" do
-      assert Frontmatter.parse("") == {:ok, [], %{}}
+      assert Frontmatter.parse("") == {:ok, [], %{}, []}
     end
 
     test "malformed yaml returns :error" do
@@ -53,26 +53,46 @@ defmodule Engram.Notes.FrontmatterTest do
 
     test "nested map value encodes to JSON, nested keys do not appear in order" do
       result = Frontmatter.parse("meta:\n  author: Todd\n")
-      assert result == {:ok, ["meta"], %{"meta" => "{\"author\":\"Todd\"}"}}
+      assert result == {:ok, ["meta"], %{"meta" => "{\"author\":\"Todd\"}"}, []}
     end
 
     test "nested map value uses recursively sorted keys (canonical JSON, matches plugin)" do
       result = Frontmatter.parse("meta:\n  b: 2\n  a: 1\n")
-      assert result == {:ok, ["meta"], %{"meta" => "{\"a\":1,\"b\":2}"}}
+      assert result == {:ok, ["meta"], %{"meta" => "{\"a\":1,\"b\":2}"}, []}
     end
 
     test "deeply nested map value uses recursively sorted keys at all levels" do
       result = Frontmatter.parse("outer:\n  z:\n    y: 1\n    x: 2\n")
-      assert result == {:ok, ["outer"], %{"outer" => "{\"z\":{\"x\":2,\"y\":1}}"}}
+      assert result == {:ok, ["outer"], %{"outer" => "{\"z\":{\"x\":2,\"y\":1}}"}, []}
     end
 
     test "inline colon in value extracts key correctly" do
       result = Frontmatter.parse("url: https://example.com\n")
-      assert result == {:ok, ["url"], %{"url" => "\"https://example.com\""}}
+      assert result == {:ok, ["url"], %{"url" => "\"https://example.com\""}, []}
     end
 
     test "bare list (not a map) returns :error" do
       assert Frontmatter.parse("- a\n- b\n") == :error
+    end
+
+    test "parse/1 reports degraded keys with snippet + line, keeps good keys" do
+      # `date`'s value is a nested map with a non-binary (list) key, which
+      # YAML supports (flow complex-key syntax) but JSON cannot express, so
+      # encode_values/1 collects it into bad_keys instead of raising.
+      block = "tags:\n  - a\ndate: {[a, b]: 1}\n"
+      assert {:ok, order, values, degraded} = Frontmatter.parse(block)
+      assert "tags" in order
+      assert values["tags"] == ~s(["a"])
+      assert [%{key: "date", snippet: "date: {[a, b]: 1}", line: 3}] = degraded
+      refute Map.has_key?(values, "date")
+    end
+
+    test "parse/1 returns :error only for non-map YAML" do
+      assert :error = Frontmatter.parse("just a scalar\n")
+    end
+
+    test "parse/1 empty block" do
+      assert {:ok, [], %{}, []} = Frontmatter.parse("")
     end
   end
 
@@ -81,7 +101,7 @@ defmodule Engram.Notes.FrontmatterTest do
       order = ["title", "tags"]
       values = %{"title" => "\"Hi\"", "tags" => "[\"a\",\"b\"]"}
       block = Frontmatter.emit(order, values)
-      assert {:ok, ^order, ^values} = Frontmatter.parse(block)
+      assert {:ok, ^order, ^values, []} = Frontmatter.parse(block)
     end
 
     test "empty inputs emit an empty string" do
@@ -92,14 +112,14 @@ defmodule Engram.Notes.FrontmatterTest do
       order = ["title", "missing_key"]
       values = %{"title" => "\"Hello\""}
       block = Frontmatter.emit(order, values)
-      assert {:ok, ["title"], %{"title" => "\"Hello\""}} = Frontmatter.parse(block)
+      assert {:ok, ["title"], %{"title" => "\"Hello\""}, []} = Frontmatter.parse(block)
     end
 
     test "nested map value round-trips" do
       order = ["meta"]
       values = %{"meta" => "{\"author\":\"Todd\"}"}
       block = Frontmatter.emit(order, values)
-      assert {:ok, ^order, ^values} = Frontmatter.parse(block)
+      assert {:ok, ^order, ^values, []} = Frontmatter.parse(block)
     end
 
     test "emit tolerates a non-JSON string value (degrades to raw string)" do
@@ -109,7 +129,7 @@ defmodule Engram.Notes.FrontmatterTest do
 
     test "degraded non-JSON string round-trips stably" do
       out = Frontmatter.emit(["k"], %{"k" => "not json"})
-      {:ok, order, values} = Frontmatter.parse(out)
+      {:ok, order, values, []} = Frontmatter.parse(out)
       assert Frontmatter.emit(order, values) == out
     end
 

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -83,7 +83,9 @@ defmodule Engram.Notes.FrontmatterTest do
       assert {:ok, order, values, degraded} = Frontmatter.parse(block)
       assert "tags" in order
       assert values["tags"] == ~s(["a"])
-      assert [%{key: "date", snippet: "date: {[a, b]: 1}", line: 3}] = degraded
+      # snippet is redacted to the KEY only (never the value): parse_reason is
+      # stored PLAINTEXT and echoed on /sync/changes, content is encrypted.
+      assert [%{key: "date", snippet: "date:", line: 3}] = degraded
       refute Map.has_key?(values, "date")
     end
 
@@ -104,24 +106,27 @@ defmodule Engram.Notes.FrontmatterTest do
       assert {:ok, [], %{}, []} = Frontmatter.parse("")
     end
 
-    test "degraded key snippet is bounded to 200 chars even for a pathologically long source line" do
+    test "degraded key snippet is REDACTED (key only), never the value, even for a long value" do
       padding = String.duplicate("x", 500)
       block = "tags:\n  - a\ndate: {[#{padding}]: 1}\n"
 
       assert {:ok, _order, _values, degraded} = Frontmatter.parse(block)
       assert [%{key: "date", line: 3, snippet: snippet}] = degraded
-      assert String.length(snippet) == 200
+      # No fragment of the value (the padding) appears in the diagnostic.
+      assert snippet == "date:"
+      refute snippet =~ "x"
 
       reason = Frontmatter.reason_for(degraded)
-      assert String.length(reason["detail"]["snippet"]) == 200
+      assert reason["detail"]["snippet"] == "date:"
     end
   end
 
   describe "invalid_yaml_reason/1" do
-    test "bounds the snippet to 200 chars for a pathologically long first line" do
-      long_line = String.duplicate("y", 500)
-      reason = Frontmatter.invalid_yaml_reason(long_line <> "\nmore\n")
-      assert String.length(reason["detail"]["snippet"]) == 200
+    test "redacts the block to a generic marker (never the raw block text)" do
+      secret = "apikey: sk-super-secret-value"
+      reason = Frontmatter.invalid_yaml_reason(secret <> "\n: : :\n")
+      assert reason["detail"]["snippet"] == "<frontmatter>"
+      refute reason["detail"]["snippet"] =~ "secret"
     end
   end
 
@@ -172,57 +177,54 @@ defmodule Engram.Notes.FrontmatterTest do
       assert out =~ "k:"
     end
 
-    test "emit renders a raw-passthrough marker verbatim" do
+    test "emit renders an out-of-band raw passthrough verbatim" do
       order = ["tags", "date"]
-      values = %{"tags" => ~s(["a"]), "date" => Frontmatter.raw_marker("date: {[a, b]: 1}")}
+      values = %{"tags" => ~s(["a"])}
+      raws = %{"date" => "date: {[a, b]: 1}"}
       # Good key emits canonically (Ymlr 2-space list indent); the degraded
       # key's raw source is re-rendered byte-for-byte (never via Ymlr).
-      assert Frontmatter.emit(order, values) == "tags:\n  - a\ndate: {[a, b]: 1}\n"
+      assert Frontmatter.emit(order, values, raws) == "tags:\n  - a\ndate: {[a, b]: 1}\n"
     end
 
-    test "emit renders a MULTI-LINE raw-passthrough marker verbatim" do
-      order = ["date"]
-      values = %{"date" => Frontmatter.raw_marker("date:\n  [a, b]: 1")}
-      assert Frontmatter.emit(order, values) == "date:\n  [a, b]: 1\n"
-    end
-  end
-
-  describe "raw marker helpers" do
-    test "raw_marker/raw_from_marker round-trip (incl. multi-line)" do
-      m = Frontmatter.raw_marker("date:\n  [a, b]: 1")
-      assert Frontmatter.raw_from_marker(m) == {:ok, "date:\n  [a, b]: 1"}
+    test "emit renders a MULTI-LINE out-of-band raw passthrough verbatim" do
+      raws = %{"date" => "date:\n  [a, b]: 1"}
+      assert Frontmatter.emit(["date"], %{}, raws) == "date:\n  [a, b]: 1\n"
     end
 
-    test "raw_from_marker rejects non-markers" do
-      assert Frontmatter.raw_from_marker("not json") == :error
-      assert Frontmatter.raw_from_marker(~s({"other":"x"})) == :error
-      assert Frontmatter.raw_from_marker(~s(["a"])) == :error
+    test "emit does NOT interpret a normal value shaped like the old marker" do
+      # A real value (a map that merely contains the old marker key) must emit
+      # as canonical YAML, not be dropped: raws is the ONLY passthrough source.
+      values = %{"mykey" => ~s({"__engram_raw__":"hello"})}
+      out = Frontmatter.emit(["mykey"], values)
+      assert out =~ "mykey:"
+      assert {:ok, ["mykey"], ^values, []} = Frontmatter.parse(out)
     end
   end
 
   describe "parse_for_ingest/1" do
-    test "empty block yields empty order and values" do
-      assert Frontmatter.parse_for_ingest("") == {:ok, [], %{}}
+    test "empty block yields empty order, values, and raws" do
+      assert Frontmatter.parse_for_ingest("") == {:ok, [], %{}, %{}}
     end
 
-    test "good-only block behaves like the structured parse path" do
+    test "good-only block behaves like the structured parse path (no raws)" do
       assert Frontmatter.parse_for_ingest("title: Hi\ntags:\n  - a\n") ==
-               {:ok, ["title", "tags"], %{"title" => "\"Hi\"", "tags" => "[\"a\"]"}}
+               {:ok, ["title", "tags"], %{"title" => "\"Hi\"", "tags" => "[\"a\"]"}, %{}}
     end
 
-    test "a degraded key is stored as a raw-passthrough marker at its source position" do
-      assert {:ok, ["tags", "date"], values} =
+    test "a degraded key is stored out of band (raws) at its source position" do
+      assert {:ok, ["tags", "date"], values, raws} =
                Frontmatter.parse_for_ingest("tags:\n  - a\ndate: {[a, b]: 1}\n")
 
       assert values["tags"] == ~s(["a"])
-      assert Frontmatter.raw_from_marker(values["date"]) == {:ok, "date: {[a, b]: 1}"}
+      refute Map.has_key?(values, "date")
+      assert raws["date"] == "date: {[a, b]: 1}"
     end
 
-    test "a MULTI-LINE degraded value captures its full source span" do
-      assert {:ok, ["tags", "date"], values} =
+    test "a MULTI-LINE degraded value captures its full source span out of band" do
+      assert {:ok, ["tags", "date"], _values, raws} =
                Frontmatter.parse_for_ingest("tags:\n  - a\ndate:\n  [a, b]: 1\n")
 
-      assert Frontmatter.raw_from_marker(values["date"]) == {:ok, "date:\n  [a, b]: 1"}
+      assert raws["date"] == "date:\n  [a, b]: 1"
     end
 
     test "returns :error (caller falls back to body) when a degraded key cannot be located" do

--- a/test/engram/notes/frontmatter_test.exs
+++ b/test/engram/notes/frontmatter_test.exs
@@ -151,6 +151,69 @@ defmodule Engram.Notes.FrontmatterTest do
       out = Frontmatter.emit(["k"], %{"k" => 42})
       assert out =~ "k:"
     end
+
+    test "emit renders a raw-passthrough marker verbatim" do
+      order = ["tags", "date"]
+      values = %{"tags" => ~s(["a"]), "date" => Frontmatter.raw_marker("date: {[a, b]: 1}")}
+      # Good key emits canonically (Ymlr 2-space list indent); the degraded
+      # key's raw source is re-rendered byte-for-byte (never via Ymlr).
+      assert Frontmatter.emit(order, values) == "tags:\n  - a\ndate: {[a, b]: 1}\n"
+    end
+
+    test "emit renders a MULTI-LINE raw-passthrough marker verbatim" do
+      order = ["date"]
+      values = %{"date" => Frontmatter.raw_marker("date:\n  [a, b]: 1")}
+      assert Frontmatter.emit(order, values) == "date:\n  [a, b]: 1\n"
+    end
+  end
+
+  describe "raw marker helpers" do
+    test "raw_marker/raw_from_marker round-trip (incl. multi-line)" do
+      m = Frontmatter.raw_marker("date:\n  [a, b]: 1")
+      assert Frontmatter.raw_from_marker(m) == {:ok, "date:\n  [a, b]: 1"}
+    end
+
+    test "raw_from_marker rejects non-markers" do
+      assert Frontmatter.raw_from_marker("not json") == :error
+      assert Frontmatter.raw_from_marker(~s({"other":"x"})) == :error
+      assert Frontmatter.raw_from_marker(~s(["a"])) == :error
+    end
+  end
+
+  describe "parse_for_ingest/1" do
+    test "empty block yields empty order and values" do
+      assert Frontmatter.parse_for_ingest("") == {:ok, [], %{}}
+    end
+
+    test "good-only block behaves like the structured parse path" do
+      assert Frontmatter.parse_for_ingest("title: Hi\ntags:\n  - a\n") ==
+               {:ok, ["title", "tags"], %{"title" => "\"Hi\"", "tags" => "[\"a\"]"}}
+    end
+
+    test "a degraded key is stored as a raw-passthrough marker at its source position" do
+      assert {:ok, ["tags", "date"], values} =
+               Frontmatter.parse_for_ingest("tags:\n  - a\ndate: {[a, b]: 1}\n")
+
+      assert values["tags"] == ~s(["a"])
+      assert Frontmatter.raw_from_marker(values["date"]) == {:ok, "date: {[a, b]: 1}"}
+    end
+
+    test "a MULTI-LINE degraded value captures its full source span" do
+      assert {:ok, ["tags", "date"], values} =
+               Frontmatter.parse_for_ingest("tags:\n  - a\ndate:\n  [a, b]: 1\n")
+
+      assert Frontmatter.raw_from_marker(values["date"]) == {:ok, "date:\n  [a, b]: 1"}
+    end
+
+    test "returns :error (caller falls back to body) when a degraded key cannot be located" do
+      # Non-binary top-level key: valid YAML map, but the degraded key has no
+      # column-0 source line, so an exact raw span cannot be guaranteed.
+      assert Frontmatter.parse_for_ingest("{[a, b]: 1}: {[c, d]: 2}\n") == :error
+    end
+
+    test "non-map YAML returns :error" do
+      assert Frontmatter.parse_for_ingest("just a scalar\n") == :error
+    end
   end
 
   describe "encode_values/1 leniency" do

--- a/test/engram/notes/note_parse_status_changeset_test.exs
+++ b/test/engram/notes/note_parse_status_changeset_test.exs
@@ -1,0 +1,23 @@
+defmodule Engram.Notes.NoteParseStatusChangesetTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Notes.Note
+
+  test "changeset casts parse_status and parse_reason" do
+    cs =
+      Note.changeset(%Note{}, %{
+        parse_status: "degraded",
+        parse_reason: %{"error" => "missing_closing_delimiter"}
+      })
+
+    assert Ecto.Changeset.get_change(cs, :parse_status) == "degraded"
+
+    assert Ecto.Changeset.get_change(cs, :parse_reason) == %{
+             "error" => "missing_closing_delimiter"
+           }
+  end
+
+  test "parse_status defaults to ok on a bare struct" do
+    assert %Note{}.parse_status == "ok"
+  end
+end

--- a/test/engram/notes/okf_fields_test.exs
+++ b/test/engram/notes/okf_fields_test.exs
@@ -62,6 +62,14 @@ defmodule Engram.Notes.OkfFieldsTest do
              @empty
   end
 
+  test "extracts a good OKF key even when a sibling frontmatter key is degraded" do
+    # Resilience improvement (Task 5): a single unencodable sibling key
+    # (nested non-binary key) no longer forces the whole block to @empty.
+    # The good `created` key still populates fm_created.
+    content = "---\ncreated: 2026-01-05\nbadkey: {[a, b]: 1}\n---\nbody\n"
+    assert OkfFields.extract(content).fm_created == ~U[2026-01-05 00:00:00Z]
+  end
+
   test "normalize_type is NFKC + lowercase" do
     assert OkfFields.normalize_type("Playbook") == "playbook"
     assert OkfFields.normalize_type("ＮＯＴＥ") == "note"

--- a/test/engram/notes_batch_upsert_test.exs
+++ b/test/engram/notes_batch_upsert_test.exs
@@ -485,4 +485,62 @@ defmodule Engram.NotesBatchUpsertTest do
              "row content must equal the doc projection, byte for byte"
     end
   end
+
+  describe "batch_upsert_notes/3 — parse_status stamping (Task 5)" do
+    test "batch insert of a clean note is parse_status ok", %{user: user, vault: vault} do
+      {:ok, _} =
+        Notes.batch_upsert_notes(user, vault, [
+          %{"path" => "batch-clean.md", "content" => "---\ntags: [a]\n---\nx\n"}
+        ])
+
+      {:ok, note} = Notes.get_note(user, vault, "batch-clean.md")
+      assert note.parse_status == "ok"
+      assert note.parse_reason == nil
+    end
+
+    test "batch insert of a whole-block malformed frontmatter stores frontmatter_invalid_yaml",
+         %{user: user, vault: vault} do
+      {:ok, _} =
+        Notes.batch_upsert_notes(user, vault, [
+          %{"path" => "batch-invalid.md", "content" => "---\ndate:YYYY-MM-DD\n---\nx\n"}
+        ])
+
+      {:ok, note} = Notes.get_note(user, vault, "batch-invalid.md")
+      assert note.parse_status == "degraded"
+      assert note.parse_reason["code"] == "frontmatter_invalid_yaml"
+    end
+
+    test "batch insert of a single unparseable key stores frontmatter_unparseable_key with detail",
+         %{user: user, vault: vault} do
+      {:ok, _} =
+        Notes.batch_upsert_notes(user, vault, [
+          %{"path" => "batch-badkey.md", "content" => "---\ndate: {[a, b]: 1}\n---\nx\n"}
+        ])
+
+      {:ok, note} = Notes.get_note(user, vault, "batch-badkey.md")
+      assert note.parse_status == "degraded"
+      assert note.parse_reason["code"] == "frontmatter_unparseable_key"
+      assert note.parse_reason["detail"]["key"] == "date"
+    end
+
+    test "batch update of an existing degraded note with clean frontmatter resets to ok",
+         %{user: user, vault: vault} do
+      {:ok, _} =
+        Notes.batch_upsert_notes(user, vault, [
+          %{"path" => "batch-fix.md", "content" => "---\ndate:YYYY-MM-DD\n---\nx\n"}
+        ])
+
+      {:ok, degraded} = Notes.get_note(user, vault, "batch-fix.md")
+      assert degraded.parse_status == "degraded"
+
+      {:ok, _} =
+        Notes.batch_upsert_notes(user, vault, [
+          %{"path" => "batch-fix.md", "content" => "---\ntitle: Fixed\n---\nx\n"}
+        ])
+
+      {:ok, fixed} = Notes.get_note(user, vault, "batch-fix.md")
+      assert fixed.parse_status == "ok"
+      assert fixed.parse_reason == nil
+    end
+  end
 end

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -103,6 +103,83 @@ defmodule Engram.NotesTest do
   end
 
   # ---------------------------------------------------------------------------
+  # batch_upsert_notes/3 — per-entry raise isolation (Task 6, defense in depth)
+  # ---------------------------------------------------------------------------
+
+  describe "batch_upsert_notes/3 — per-entry raise isolation" do
+    import ExUnit.CaptureLog
+
+    test "a historically-poisonous note commits degraded, sibling commits too", %{
+      user: user,
+      vault: vault
+    } do
+      assert {:ok, %{results: results}} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "good.md", "content" => "---\ntags: [a]\n---\nok\n", "mtime" => 1.0},
+                 %{
+                   "path" => "poison.md",
+                   "content" => "---\ndate:YYYY-MM-DD\n---\nx\n",
+                   "mtime" => 1.0
+                 }
+               ])
+
+      # Total parser (Task 1): the poison note commits degraded, not error.
+      assert Enum.all?(results, &(&1.status == :ok))
+      assert Enum.find(results, &(&1.path == "good.md"))
+      assert Enum.find(results, &(&1.path == "poison.md"))
+    end
+
+    test "process_batch_entry_rescued/3 catches a raise and degrades to a per-note error" do
+      entry = %{path: "poison.md", input_path: "poison.md", result: nil}
+
+      log =
+        capture_log(fn ->
+          assert {degraded, [:untouched_row]} =
+                   Notes.process_batch_entry_rescued(entry, [:untouched_row], fn ->
+                     raise "boom"
+                   end)
+
+          assert %{result: {:error, error}} = degraded
+          assert error["code"] == "note_processing_failed"
+          assert is_binary(error["message"])
+        end)
+
+      assert log =~ "batch entry raised"
+      assert log =~ "poison.md"
+    end
+
+    test "process_batch_entry_rescued/3 passes through a non-raising fn untouched" do
+      entry = %{path: "good.md", input_path: "good.md", result: nil}
+
+      assert {%{result: {:ok, :done}}, [:new_row]} =
+               Notes.process_batch_entry_rescued(entry, [], fn ->
+                 {%{entry | result: {:ok, :done}}, [:new_row]}
+               end)
+    end
+
+    test "a raising entry doesn't corrupt a sibling entry's already-accumulated row/result" do
+      good_entry = %{path: "good.md", input_path: "good.md", result: nil}
+      poison_entry = %{path: "poison.md", input_path: "poison.md", result: nil}
+
+      {good_out, rows_after_good} =
+        Notes.process_batch_entry_rescued(good_entry, [], fn ->
+          {%{good_entry | result: {:ok, :info}}, [:good_row]}
+        end)
+
+      {poison_out, rows_after_poison} =
+        Notes.process_batch_entry_rescued(poison_entry, rows_after_good, fn ->
+          raise "boom"
+        end)
+
+      assert good_out.result == {:ok, :info}
+      assert rows_after_good == [:good_row]
+      assert %{result: {:error, %{"code" => "note_processing_failed"}}} = poison_out
+      # The poison entry contributes no row of its own; the sibling's row survives.
+      assert rows_after_poison == rows_after_good
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # upsert_note/3
   # ---------------------------------------------------------------------------
 

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -499,6 +499,101 @@ defmodule Engram.NotesTest do
   end
 
   # ---------------------------------------------------------------------------
+  # upsert_note/3 — parse_status/parse_reason stamping (Task 5)
+  # ---------------------------------------------------------------------------
+
+  describe "upsert_note/3 — parse_status stamping" do
+    test "a clean note is stamped parse_status ok with no reason", %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Clean.md",
+          "content" => "---\ntags: [a]\n---\nx\n",
+          "mtime" => 1.0
+        })
+
+      assert note.parse_status == "ok"
+      assert note.parse_reason == nil
+    end
+
+    test "a note with no frontmatter at all is parse_status ok", %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "NoFrontmatter.md",
+          "content" => "just a body\n",
+          "mtime" => 1.0
+        })
+
+      assert note.parse_status == "ok"
+      assert note.parse_reason == nil
+    end
+
+    test "a whole-block malformed frontmatter (date:YYYY-MM-DD, no space) stores frontmatter_invalid_yaml",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "InvalidYaml.md",
+          "content" => "---\ndate:YYYY-MM-DD\n---\nx\n",
+          "mtime" => 1.0
+        })
+
+      assert note.parse_status == "degraded"
+      assert note.parse_reason["code"] == "frontmatter_invalid_yaml"
+      assert is_binary(note.parse_reason["message"])
+    end
+
+    test "a single unparseable key (non-binary map key) stores frontmatter_unparseable_key with the key's detail",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "UnparseableKey.md",
+          "content" => "---\ndate: {[a, b]: 1}\n---\nx\n",
+          "mtime" => 1.0
+        })
+
+      assert note.parse_status == "degraded"
+      assert note.parse_reason["code"] == "frontmatter_unparseable_key"
+      assert note.parse_reason["detail"]["key"] == "date"
+      assert note.parse_reason["detail"]["line"] == 1
+      assert note.parse_reason["detail"]["snippet"] == "date: {[a, b]: 1}"
+    end
+
+    test "a marker-colliding but encodable value stays parse_status ok (not a Task 3 passthrough concern)",
+         %{user: user, vault: vault} do
+      {:ok, note} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Colliding.md",
+          "content" => "---\ndate:\n  __engram_raw__: x\n  y: 1\n---\nbody\n",
+          "mtime" => 1.0
+        })
+
+      assert note.parse_status == "ok"
+      assert note.parse_reason == nil
+    end
+
+    test "rewriting a degraded note with clean frontmatter resets parse_status to ok",
+         %{user: user, vault: vault} do
+      {:ok, degraded} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Fixable.md",
+          "content" => "---\ndate:YYYY-MM-DD\n---\nx\n",
+          "mtime" => 1.0
+        })
+
+      assert degraded.parse_status == "degraded"
+
+      {:ok, fixed} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Fixable.md",
+          "content" => "---\ntitle: Fixed\n---\nx\n",
+          "mtime" => 2.0
+        })
+
+      assert fixed.parse_status == "ok"
+      assert fixed.parse_reason == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Note.changeset/2 defense-in-depth
   # ---------------------------------------------------------------------------
 

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -179,6 +179,66 @@ defmodule Engram.NotesTest do
       # The poison entry contributes no row of its own; the sibling's row survives.
       assert rows_after_poison == rows_after_good
     end
+
+    # Task 4: a plain `raise` (above) never poisons the shared tx — but a
+    # FAILED SQL STATEMENT does (Postgres flips the whole tx into 25P02
+    # in_failed_sql_transaction, so every subsequent statement in the SAME tx
+    # fails too). Driven end-to-end through the real batch path: one entry's
+    # UPDATE-branch next_seq! hits a genuine failed statement (bigint overflow,
+    # SQLSTATE 22003) while a sibling entry commits and the batch returns real
+    # partial success. Before the fix (db_mode: :savepoint on the UPDATE-branch
+    # writes) the overflow poisons the shared tx and the whole batch blows up
+    # at COMMIT; the savepoint rolls the failed statement back to just that
+    # entry.
+    test "a failed SQL statement in one entry's UPDATE branch is isolated; sibling commits", %{
+      user: user,
+      vault: vault
+    } do
+      # Seed two notes with plain (no-frontmatter) bodies via the real batch.
+      assert {:ok, %{results: seed}} =
+               Notes.batch_upsert_notes(user, vault, [
+                 %{"path" => "keep.md", "content" => "keep body", "mtime" => 1.0},
+                 %{"path" => "poison.md", "content" => "poison v1", "mtime" => 1.0}
+               ])
+
+      assert Enum.all?(seed, &(&1.status == :ok))
+
+      # Prime the next per-entry next_seq! UPDATE to overflow: change_seq is a
+      # bigint; `change_seq + 1` at MAX raises SQLSTATE 22003 — a real failed
+      # SQL statement mid-transaction, not a bare raise.
+      {:ok, _} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          Engram.Repo.query!(
+            "UPDATE vaults SET change_seq = $1 WHERE id = $2",
+            [9_223_372_036_854_775_807, Ecto.UUID.dump!(vault.id)]
+          )
+        end)
+
+      log =
+        capture_log(fn ->
+          # keep.md is a byte-identical re-push (idempotent_repush — no
+          # next_seq!, commits as a no-op :ok). poison.md changes content, so
+          # its UPDATE branch calls next_seq! → overflow. Neither is a new
+          # insert, so the post-loop insert_all (its own next_seq!) is skipped.
+          assert {:ok, %{results: results}} =
+                   Notes.batch_upsert_notes(user, vault, [
+                     %{"path" => "keep.md", "content" => "keep body", "mtime" => 2.0},
+                     %{"path" => "poison.md", "content" => "poison v2 CHANGED", "mtime" => 2.0}
+                   ])
+
+          keep = Enum.find(results, &(&1.path == "keep.md"))
+          poison = Enum.find(results, &(&1.path == "poison.md"))
+
+          # Real partial success: the sibling committed, the failed-SQL entry
+          # degraded to a per-note error, and the batch tx COMMITTED (returned
+          # {:ok, _} rather than raising 25P02 at COMMIT).
+          assert keep.status == :ok
+          assert poison.status == :error
+        end)
+
+      assert log =~ "batch entry raised"
+      assert log =~ "poison.md"
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -109,6 +109,8 @@ defmodule Engram.NotesTest do
   describe "batch_upsert_notes/3 — per-entry raise isolation" do
     import ExUnit.CaptureLog
 
+    # Task 5 regression check (not raise-isolation): parse is now total, so
+    # the historically-500ing poison note commits degraded end-to-end.
     test "a historically-poisonous note commits degraded, sibling commits too", %{
       user: user,
       vault: vault

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -180,7 +180,7 @@ defmodule Engram.NotesTest do
       assert rows_after_poison == rows_after_good
     end
 
-    # Task 4: a plain `raise` (above) never poisons the shared tx — but a
+    # Task 4: a plain `raise` (above) never poisons the shared tx, but a
     # FAILED SQL STATEMENT does (Postgres flips the whole tx into 25P02
     # in_failed_sql_transaction, so every subsequent statement in the SAME tx
     # fails too). Driven end-to-end through the real batch path: one entry's
@@ -204,7 +204,7 @@ defmodule Engram.NotesTest do
       assert Enum.all?(seed, &(&1.status == :ok))
 
       # Prime the next per-entry next_seq! UPDATE to overflow: change_seq is a
-      # bigint; `change_seq + 1` at MAX raises SQLSTATE 22003 — a real failed
+      # bigint; `change_seq + 1` at MAX raises SQLSTATE 22003, a real failed
       # SQL statement mid-transaction, not a bare raise.
       {:ok, _} =
         Engram.Repo.with_tenant(user.id, fn ->
@@ -216,7 +216,7 @@ defmodule Engram.NotesTest do
 
       log =
         capture_log(fn ->
-          # keep.md is a byte-identical re-push (idempotent_repush — no
+          # keep.md is a byte-identical re-push (idempotent_repush, no
           # next_seq!, commits as a no-op :ok). poison.md changes content, so
           # its UPDATE branch calls next_seq! → overflow. Neither is a new
           # insert, so the post-loop insert_all (its own next_seq!) is skipped.

--- a/test/engram/notes_test.exs
+++ b/test/engram/notes_test.exs
@@ -633,7 +633,8 @@ defmodule Engram.NotesTest do
       assert note.parse_reason["code"] == "frontmatter_unparseable_key"
       assert note.parse_reason["detail"]["key"] == "date"
       assert note.parse_reason["detail"]["line"] == 1
-      assert note.parse_reason["detail"]["snippet"] == "date: {[a, b]: 1}"
+      # snippet is redacted to the KEY only (parse_reason is stored plaintext).
+      assert note.parse_reason["detail"]["snippet"] == "date:"
     end
 
     test "a marker-colliding but encodable value stays parse_status ok (not a Task 3 passthrough concern)",

--- a/test/engram_web/controllers/notes_changes_pagination_test.exs
+++ b/test/engram_web/controllers/notes_changes_pagination_test.exs
@@ -86,6 +86,60 @@ defmodule EngramWeb.NotesChangesPaginationTest do
       assert change["path"] == "n1.md"
     end
 
+    test "each entry includes parse_status + parse_reason (default fields)", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, _clean} =
+        Engram.Notes.upsert_note(user, vault, %{
+          path: "clean.md",
+          content: "---\ntags: [a]\n---\nx\n",
+          mtime: 1.0
+        })
+
+      {:ok, _degraded} =
+        Engram.Notes.upsert_note(user, vault, %{
+          path: "degraded.md",
+          content: "---\ndate:YYYY-MM-DD\n---\nx\n",
+          mtime: 2.0
+        })
+
+      body =
+        conn
+        |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z")
+        |> json_response(200)
+
+      changes = Map.new(body["changes"], &{&1["path"], &1})
+
+      assert changes["clean.md"]["parse_status"] == "ok"
+      assert changes["clean.md"]["parse_reason"] == nil
+      assert changes["degraded.md"]["parse_status"] == "degraded"
+      assert changes["degraded.md"]["parse_reason"]["code"] == "frontmatter_invalid_yaml"
+    end
+
+    test "each entry includes parse_status + parse_reason (fields=meta)", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, _degraded} =
+        Engram.Notes.upsert_note(user, vault, %{
+          path: "degraded.md",
+          content: "---\ndate:YYYY-MM-DD\n---\nx\n",
+          mtime: 1.0
+        })
+
+      body =
+        conn
+        |> get(~p"/api/notes/changes?since=2020-01-01T00:00:00Z&fields=meta")
+        |> json_response(200)
+
+      assert [change] = body["changes"]
+      assert change["parse_status"] == "degraded"
+      assert change["parse_reason"]["code"] == "frontmatter_invalid_yaml"
+    end
+
     test "has_more responses anchor server_time at the last returned change (legacy convergence)",
          %{conn: conn, user: user, vault: vault} do
       seed(user, vault, 3)

--- a/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
+++ b/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
@@ -60,6 +60,27 @@ defmodule EngramWeb.NotesControllerBatchUpsertTest do
       |> json_response(400)
     end
 
+    test "echoes parse_status + parse_reason per note (ok and degraded)", %{conn: conn} do
+      notes = [
+        %{path: "clean.md", content: "---\ntags: [a]\n---\nx\n", mtime: 1.0},
+        %{path: "degraded.md", content: "---\ndate:YYYY-MM-DD\n---\nx\n", mtime: 1.0}
+      ]
+
+      body =
+        conn
+        |> put_req_header("x-idempotency-key", Ecto.UUID.generate())
+        |> post(~p"/api/notes/batch", %{notes: notes})
+        |> json_response(200)
+
+      assert [clean, degraded] = body["results"]
+      assert clean["parse_status"] == "ok"
+      assert clean["parse_reason"] == nil
+
+      assert degraded["parse_status"] == "degraded"
+      assert degraded["parse_reason"]["code"] == "frontmatter_invalid_yaml"
+      assert degraded["parse_reason"]["detail"]["snippet"] == "date:YYYY-MM-DD"
+    end
+
     test "oversized note becomes a per-note error without failing the batch", %{conn: conn} do
       big = String.duplicate("a", 10 * 1024 * 1024 + 1)
 

--- a/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
+++ b/test/engram_web/controllers/notes_controller_batch_upsert_test.exs
@@ -78,7 +78,9 @@ defmodule EngramWeb.NotesControllerBatchUpsertTest do
 
       assert degraded["parse_status"] == "degraded"
       assert degraded["parse_reason"]["code"] == "frontmatter_invalid_yaml"
-      assert degraded["parse_reason"]["detail"]["snippet"] == "date:YYYY-MM-DD"
+      # whole-block invalid YAML: snippet is a generic redacted marker, never
+      # the raw block text (parse_reason is stored plaintext + echoed on feed).
+      assert degraded["parse_reason"]["detail"]["snippet"] == "<frontmatter>"
     end
 
     test "oversized note becomes a per-note error without failing the batch", %{conn: conn} do

--- a/test/engram_web/controllers/notes_controller_test.exs
+++ b/test/engram_web/controllers/notes_controller_test.exs
@@ -279,6 +279,43 @@ defmodule EngramWeb.NotesControllerTest do
       assert json_response(conn, 404)
     end
 
+    test "includes parse_status ok + nil reason for a clean note", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, _note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "Clean.md",
+          "content" => "---\ntags: [a]\n---\nx\n",
+          "mtime" => 1.0
+        })
+
+      conn = get(conn, "/api/notes/Clean.md")
+      body = json_response(conn, 200)
+      assert body["parse_status"] == "ok"
+      assert body["parse_reason"] == nil
+    end
+
+    test "includes parse_status degraded + reason detail for a note with bad frontmatter", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      {:ok, _note} =
+        Engram.Notes.upsert_note(user, vault, %{
+          "path" => "Degraded.md",
+          "content" => "---\ndate:YYYY-MM-DD\n---\nx\n",
+          "mtime" => 1.0
+        })
+
+      conn = get(conn, "/api/notes/Degraded.md")
+      body = json_response(conn, 200)
+      assert body["parse_status"] == "degraded"
+      assert body["parse_reason"]["code"] == "frontmatter_invalid_yaml"
+      assert body["parse_reason"]["detail"]["snippet"] == "date:YYYY-MM-DD"
+    end
+
     test "returns 404 for deleted note", %{conn: conn} do
       post(conn, "/api/notes", %{path: "Test/Gone.md", content: "# Gone", mtime: 1_000.0})
       delete(conn, "/api/notes/Test/Gone.md")

--- a/test/engram_web/controllers/notes_controller_test.exs
+++ b/test/engram_web/controllers/notes_controller_test.exs
@@ -313,7 +313,8 @@ defmodule EngramWeb.NotesControllerTest do
       body = json_response(conn, 200)
       assert body["parse_status"] == "degraded"
       assert body["parse_reason"]["code"] == "frontmatter_invalid_yaml"
-      assert body["parse_reason"]["detail"]["snippet"] == "date:YYYY-MM-DD"
+      # redacted marker, never the raw frontmatter source (plaintext column).
+      assert body["parse_reason"]["detail"]["snippet"] == "<frontmatter>"
     end
 
     test "returns 404 for deleted note", %{conn: conn} do


### PR DESCRIPTION
## What
Clobbered frontmatter now degrades cleanly instead of 500ing the sync pipeline, and the server surfaces *why* a note's frontmatter failed to parse so clients can show it.

## Why
Prod incident: a note with exotic YAML frontmatter (yamerl key tuples/charlists that `Jason.encode` raises on) 500'd the whole `POST /api/notes/batch`, which the plugin then retried forever. Root cause: `Frontmatter.encode_values/1` let `Jason.encode` raise uncaught, taking down the batch.

## Changes (8 tasks, subagent-driven + reviewed)
- `encode_values/1` is now total and lenient: returns `{values, bad_keys}`, never raises.
- `parse/1` returns `{:ok, order, values, degraded}`; degraded keys carry `%{key, line, snippet}` with the snippet redacted to key-only (<=200 chars), so no plaintext frontmatter leaks into the reason.
- Raw source spans for degraded keys are preserved out-of-band in a `frontmatter_raw` Y.Map (CRDT), so they round-trip verbatim through emit/project instead of being dropped.
- New `parse_status` + `parse_reason` columns (expand-phase migration). Plaintext on purpose: they describe our parser's behavior, not note content, so no encryption/HMAC.
- Per-entry batch rescue with real SAVEPOINT isolation: a failed SQL statement in one entry no longer poisons the shared transaction and falsely fails its siblings (partial success is honest again).
- Audited other bad-parse-kills-pipeline sites; `okf_fields` extraction made lenient (a degraded sibling no longer drops good keys).

## Review
Built-in code review surfaced 3 must-fixes beyond the per-task gates (normalize_doc data loss, emit projection collision, plaintext leak in the reason). All fixed. SAVEPOINT isolation independently verified RED/GREEN against a real 25P02.

## Ships with
The plugin PR (engram-app/Engram-obsidian) consumes `parse_status`/`parse_reason` + the `frontmatter_raw` map. **Merge together** — the producer here is inert-to-harmful without the consumer.

## Test
`mix test` 3707/0; dialyzer clean; `mix compile --warnings-as-errors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)