### PR TITLE
fix(e2e): stabilize e2e suites — serialize suites on runner + Playwright workers cap + resumed-device vault isolation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1345,11 +1345,15 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   e2e-api:
-    needs: [fingerprint, prebuild-ci-image]
-    # Runs the api_only pytest suite in its own isolated job so it executes
-    # concurrently with e2e-clerk rather than serially inside it.
+    # Serialized after the clerk+crdt group (see #355): the self-hosted runner
+    # can't run >1 heavy e2e suite at once without starving tight delivery
+    # budgets, and a concurrency group tops out at 2 jobs, so the remaining
+    # suites chain via `needs`. `!cancelled()` keeps this suite's signal even
+    # when a predecessor fails (a failed `needs` would otherwise skip it).
+    needs: [fingerprint, prebuild-ci-image, e2e-clerk, e2e-crdt]
+    # Runs the api_only pytest suite in its own isolated job.
     # Same skip conditions as e2e-clerk (no Dependabot; cache-hit skip).
-    if: needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'clerk')
+    if: ${{ !cancelled() && needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'clerk') }}
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -3262,14 +3266,16 @@ jobs:
         run: bun run ci
 
   e2e-local:
-    needs: [fingerprint, prebuild-ci-image]
+    # Serialized after e2e-api (see #355 / e2e-api). `!cancelled()` preserves
+    # this suite's signal when a predecessor in the chain fails.
+    needs: [fingerprint, prebuild-ci-image, e2e-api]
     # Skip on cross-repo plugin dispatch — plugin uses Clerk JWTs in production,
     # so the local-auth API path is backend-internal.
     # Also skip via the per-job fingerprint (skip-e2e-local =
     # docker-image+elixir-src+e2e-harness+frontend; forced false on full runs), or
     # on a Dependabot PR (Phoenix webServer boot needs secrets Dependabot can't
     # access; unit-tests + lint cover the meaningful surface).
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-local != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'local')
+    if: ${{ !cancelled() && github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-local != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -3390,13 +3396,15 @@ jobs:
           find /tmp -maxdepth 1 -name '.ff*.node' -mmin +60 -delete 2>/dev/null || true
 
   e2e-browser:
-    needs: [fingerprint, prebuild-mix]
+    # Serialized last in the e2e chain, after e2e-local (see #355 / e2e-api).
+    # `!cancelled()` preserves this suite's signal when a predecessor fails.
+    needs: [fingerprint, prebuild-mix, e2e-local]
     # Skip on cross-repo plugin dispatch — Playwright targets backend's React
     # frontend, which the plugin (separate repo) cannot affect.
     # Also skip via the per-job fingerprint (skip-e2e-browser =
     # docker-image+elixir-src+e2e-harness+frontend; forced false on full runs), or
     # on Dependabot PRs (Phoenix webServer needs Clerk secrets Dependabot can't access).
-    if: github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-browser != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'browser')
+    if: ${{ !cancelled() && github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-browser != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'browser') }}
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -227,6 +227,27 @@ def isolation_user(ts, auth_provider):
     return email, provider_user_id, api_key
 
 
+@pytest.fixture(scope="session")
+def resumed_user(ts, auth_provider):
+    """Dedicated user for the resumed-device pair (fresh_instance_pair).
+
+    Kept OFF sync_user's shared vault on purpose: that vault accumulates
+    every note the suite creates (~1000 by the end of a full run), and
+    joining it late floods the resumed devices with a full-vault genesis
+    fan-out that starves the seed-note delivery inside the 30s Phase-1
+    budget (the test_82 timeout flake, Engram#977/#945). A private user +
+    vault keeps the resumed pair's genesis pull near-empty, so what the
+    test measures is resumed-device sync, not suite churn.
+
+    Returns: (email, provider_user_id, api_key)
+    """
+    email = f"e2e-resumed-{ts}+clerk_test@example.com"
+    password = secrets.token_urlsafe(32)
+    provider_user_id, api_key = auth_provider.provision_user(email, password)
+    grant_test_plan(email)
+    return email, provider_user_id, api_key
+
+
 # ---------------------------------------------------------------------------
 # Obsidian instances
 # ---------------------------------------------------------------------------
@@ -246,6 +267,17 @@ def iso_client_id(ts):
     max_vaults limit (which would fire if we created two distinct vaults).
     """
     return f"e2e-iso-pair-{ts}"
+
+
+@pytest.fixture(scope="session")
+def resumed_client_id(ts):
+    """Shared client_id for the resumed-device pair's single private vault.
+
+    ResumedA + ResumedB share it so /vaults/register upserts ONE vault
+    (idempotent by client_id) — the two-device shape under test — while
+    staying isolated from sync_user's accumulator vault.
+    """
+    return f"e2e-resumed-pair-{ts}"
 
 
 @pytest.fixture(scope="session")
@@ -399,10 +431,13 @@ def _oauth_ws_warm(cdp_a, clerk_client):
 #
 # A stop/mutate-data.json/restart cycle must never touch the session-scoped
 # A/B/C fixtures the rest of the suite depends on, so this is its own pair on
-# its own ports/displays. It shares sync_user/sync_client_id with session A/B
-# so it lands on the SAME server vault api_sync polls (client_id upsert is
-# idempotent — four "devices" on one vault is exactly the multi-device shape
-# under test).
+# its own ports/displays. It runs on a PRIVATE user+vault (resumed_user /
+# resumed_client_id), NOT sync_user's shared vault: that vault accumulates
+# ~1000 notes over a full run, and joining it late floods the resumed devices
+# with a full-vault genesis fan-out that starves the seed delivery inside the
+# 30s Phase-1 budget (Engram#977/#945). ResumedA + ResumedB still share one
+# client_id, so they land on ONE (near-empty) vault — the two-device shape
+# under test, minus the suite churn.
 # ---------------------------------------------------------------------------
 
 RESUMED_CDP_PORT_A = _worker_port("E2E_CDP_PORT_RESUMED_A", "9350")
@@ -414,10 +449,13 @@ assert RESUMED_DISPLAY_BASE - 1 >= 1, (
 
 
 @pytest.fixture
-def fresh_instance_pair(sync_user, sync_client_id):
+def fresh_instance_pair(resumed_user, resumed_client_id, resumed_api):
     """Dedicated A/B-shaped instance pair for tests that stop/restart a device.
 
     Function-scoped so a mid-test restart can't poison the session fixtures.
+    Runs on resumed_user's private vault (resumed_api pre-registers it) to
+    stay off the suite's shared accumulator vault — see the block comment
+    above and Engram#977/#945.
     """
     inst_a = ObsidianInstance(
         name="ResumedA",
@@ -425,10 +463,10 @@ def fresh_instance_pair(sync_user, sync_client_id):
         cdp_port=RESUMED_CDP_PORT_A,
         display=f":{RESUMED_DISPLAY_BASE}",
         api_url=API_URL,
-        api_key=sync_user[2],
+        api_key=resumed_user[2],
         plugin_src=PLUGIN_SRC,
         obsidian_bin=OBSIDIAN_BIN,
-        client_id=sync_client_id,
+        client_id=resumed_client_id,
         config_dir=Path(f"{CONFIG_PREFIX}-resumed-a"),
     )
     inst_b = ObsidianInstance(
@@ -437,10 +475,10 @@ def fresh_instance_pair(sync_user, sync_client_id):
         cdp_port=RESUMED_CDP_PORT_B,
         display=f":{RESUMED_DISPLAY_BASE - 1}",
         api_url=API_URL,
-        api_key=sync_user[2],
+        api_key=resumed_user[2],
         plugin_src=PLUGIN_SRC,
         obsidian_bin=OBSIDIAN_BIN,
-        client_id=sync_client_id,
+        client_id=resumed_client_id,
         config_dir=Path(f"{CONFIG_PREFIX}-resumed-b"),
     )
     inst_a.start()
@@ -512,6 +550,23 @@ def api_iso(isolation_user, iso_client_id):
     api = ApiClient(API_URL, isolation_user[2])
     try:
         api.register_vault(f"e2e-iso-vault-w{_WORKER}", iso_client_id)
+    except Exception:
+        pass
+    return api
+
+
+@pytest.fixture(scope="session")
+def resumed_api(resumed_user, resumed_client_id):
+    """API client for the resumed-device user's private vault.
+
+    test_82 verifies resumed B's PUSH landed server-side via this client,
+    so it must target the SAME (private) vault the resumed pair joins —
+    not sync_user's shared accumulator vault. Pre-registers the vault so
+    the plugin's own register is a no-op and vault-scoped polls don't 404.
+    """
+    api = ApiClient(API_URL, resumed_user[2])
+    try:
+        api.register_vault(f"e2e-resumed-vault-w{_WORKER}", resumed_client_id)
     except Exception:
         pass
     return api

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -241,7 +241,11 @@ def resumed_user(ts, auth_provider):
 
     Returns: (email, provider_user_id, api_key)
     """
-    email = f"e2e-resumed-{ts}+clerk_test@example.com"
+    # Short prefix on purpose: `ts` already runs ~44 chars, and the email
+    # local part must stay <= 64 (RFC 5321) or Clerk create_user 422s. With
+    # "+clerk_test" that budgets ~9 chars for the prefix (e2e-sync-/e2e-iso-
+    # sit right at the ceiling); "e2e-rsm-" keeps us at 63.
+    email = f"e2e-rsm-{ts}+clerk_test@example.com"
     password = secrets.token_urlsafe(32)
     provider_user_id, api_key = auth_provider.provision_user(email, password)
     grant_test_plan(email)

--- a/e2e/tests/test_82_resumed_device_stale_idmap.py
+++ b/e2e/tests/test_82_resumed_device_stale_idmap.py
@@ -65,7 +65,7 @@ async def _wait_for_persisted_cursor(cdp, inst, timeout: float = 60, interval: f
 
 
 async def test_resumed_device_with_stale_idmap_syncs_both_ways(
-    fresh_instance_pair, api_sync
+    fresh_instance_pair, resumed_api
 ):
     inst_a, inst_b, cdp_a, cdp_b = fresh_instance_pair
 
@@ -113,7 +113,7 @@ async def test_resumed_device_with_stale_idmap_syncs_both_ways(
     # note (its id is exactly what the wiped map no longer knows) and the
     # server must get it.
     write_note(inst_b.vault_path, "E2E/Resumed-push-seed.md", "# PushSeed\nedited on resumed B")
-    note = api_sync.wait_for_note_content(
+    note = resumed_api.wait_for_note_content(
         "E2E/Resumed-push-seed.md", "edited on resumed B", timeout=30
     )
     assert note is not None, "resumed B's push never reached the server"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,6 +18,12 @@ export default defineConfig({
 	expect: { timeout: 10_000 },
 	fullyParallel: false,
 	forbidOnly: isCI,
+	// One worker in CI. Each spec drives two browser contexts (tabs A+B) doing
+	// live CRDT, so running spec files in parallel piles context onto the shared
+	// self-hosted runner and starves the SPA's lazy note/editor load past the
+	// wait budgets (the note-live-update / tree-ops / note-properties flakes,
+	// issue #547). Locally, leave Playwright to pick worker count.
+	workers: isCI ? 1 : undefined,
 	retries: isCI ? 1 : 0,
 	reporter: isCI ? "github" : "html",
 	globalSetup: "./e2e/global-setup.ts",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.666",
+      version: "0.5.667",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Stabilizes two independent e2e flake families surfaced by #355, both amplified by the runner-pool contention window and by #997's genesis fan-out.

## e2e-browser (#547)
`workers: isCI ? 1 : undefined` in `playwright.config.ts`. Each spec drives two browser contexts doing live CRDT; running spec files in parallel piled context onto the shared self-hosted runner and starved the SPA's lazy note/editor load past the wait budgets (note-live-update / tree-ops / note-properties flakes). One worker in CI; local unchanged.

## e2e-clerk / test_82 (#977, #945)
`fresh_instance_pair` shared `sync_user`/`sync_client_id`, so the "fresh" resumed pair rejoined the suite's shared vault. That vault accumulates ~1000 notes over a full run; joining it late triggers a full-vault genesis fan-out (#997) that starves the Phase-1 seed delivery inside the 30s budget — the stale-map behavior under test (Phase 3) was never reached. Root cause was test isolation, not connect timing (so #977/#979's connect-gate remedies didn't hold).

Fix: dedicated `resumed_user` / `resumed_client_id` / `resumed_api` (mirroring the `isolation_user` trio) so the resumed pair joins a private, near-empty vault. `test_82` verifies B's push via `resumed_api` (same private vault) instead of `api_sync`.

## Notes
- Kept #999's clerk↔crdt concurrency group: it serializes those suites *within* a run as intended.
- Latent product issue filed separately: #997's genesis fan-out is un-throttled/un-prioritized, so a large-vault reconnect starves live edits ~30s+ (not a test blocker).

Closes #547
Closes #977