### PR TITLE
fix(ci): e2e suites silently skipped on main + plugin dispatch

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -841,7 +841,11 @@ jobs:
     # Per-job fingerprint skip (skip-e2e-clerk) replaces the coarse e2e-cache-hit:
     # skips only when this exact (docker-image+elixir-src+e2e-harness+plugin)
     # content already passed full on main; forced false on full runs.
-    if: needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'clerk')
+    # !cancelled(): the unit-tests/n1-compat needs are a QUIET-VM WAIT, not a
+    # success gate. Without it, a SKIPPED need skips this job too — n1-compat
+    # is branch-only, so every main push (and every plugin dispatch, where
+    # unit-tests skips) silently lost the Obsidian e2e suites (#355 fallout).
+    if: ${{ !cancelled() && needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'clerk') }}
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:
@@ -1601,7 +1605,9 @@ jobs:
     # Per-job skip (skip-e2e-crdt): same group as e2e-clerk; forced false on full runs.
     # Accepts BOTH the `crdt` and `local` targeted-e2e suites — each targets one
     # of this job's two pytest steps; the non-targeted step skips.
-    if: needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local')
+    # !cancelled(): same quiet-VM-wait rationale as e2e-clerk — without it the
+    # branch-only n1-compat need (skipped on main/dispatch) skips this job.
+    if: ${{ !cancelled() && needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
     runs-on: [self-hosted, linux, x64, isolated]
 
     env:


### PR DESCRIPTION
## Bug

The #355 quiet-VM gate (#1000) added `unit-tests` + `n1-compat` to `e2e-clerk`/`e2e-crdt` `needs:` without `!cancelled()`. A **skipped** need skips the dependent job:

- `n1-compat` is branch-only by design → **every main push since #1000 skipped both Obsidian e2e suites** (verified on runs 29307033720, 29306996435, 29305192905 + the post-merge run of #1006). Main is documented as the full-matrix safety net.
- `unit-tests` skips on `repository_dispatch` → **every plugin dispatch skipped `e2e-clerk`**, the plugin↔backend contract test, while `report-e2e-to-plugin` posted green ("skipped = cached pass" — untrue here).

## Fix

Wrap both `if:` expressions in `!cancelled()` — the exact pattern `e2e-api` already uses. The `needs` become what they were meant to be: a quiet-VM scheduling *wait*, not a success gate. Cancellation still skips.

## Verification

- Branch run proves no regression (n1-compat runs on branches, so the gate path is exercised).
- Real proof is the merge commit's main run: e2e-clerk + e2e-crdt must RUN there. I'll verify and report on the PR after merge.

Refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019omnopWqAww7rfxG9Yp47i