### PR TITLE
fix(crdt): ack crdt_msg + browser logs/traces + cut Oban trace noise

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1226,6 +1226,7 @@ jobs:
           ENGRAM_PLUGIN_SRC: ${{ github.workspace }}/plugin-src
           CI_POSTGRES_CONTAINER: ${{ env.CI_PROJECT }}-postgres-1
           CI_MINIO_CONTAINER: ${{ env.CI_PROJECT }}-minio-1
+          CI_ENGRAM_CONTAINER: ${{ env.CI_PROJECT }}-engram-1
           E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
           AUTH_PROVIDER: clerk
           E2E_VAULT_PREFIX: ${{ env.E2E_VAULT_PREFIX }}
@@ -1524,6 +1525,7 @@ jobs:
           AUTH_PROVIDER: clerk
           CI_POSTGRES_CONTAINER: ${{ env.CI_PROJECT }}-postgres-1
           CI_MINIO_CONTAINER: ${{ env.CI_PROJECT }}-minio-1
+          CI_ENGRAM_CONTAINER: ${{ env.CI_PROJECT }}-engram-1
           QDRANT_URL: http://10.0.20.201:6333
           QDRANT_COLLECTION: ${{ env.QDRANT_COLLECTION }}
           OLLAMA_URL: http://10.0.20.214:11434
@@ -1943,6 +1945,7 @@ jobs:
           AUTH_PROVIDER: local
           CI_POSTGRES_CONTAINER: ${{ env.CI_PROJECT }}-postgres-1
           CI_MINIO_CONTAINER: ${{ env.CI_PROJECT }}-minio-1
+          CI_ENGRAM_CONTAINER: ${{ env.CI_PROJECT }}-engram-1
           QDRANT_URL: http://10.0.20.201:6333
           QDRANT_COLLECTION: ${{ env.QDRANT_COLLECTION }}
           OLLAMA_URL: http://10.0.20.214:11434
@@ -2009,6 +2012,7 @@ jobs:
           ENGRAM_PLUGIN_SRC: ${{ github.workspace }}/plugin-src
           CI_POSTGRES_CONTAINER: ${{ env.CI_PROJECT }}-postgres-1
           CI_MINIO_CONTAINER: ${{ env.CI_PROJECT }}-minio-1
+          CI_ENGRAM_CONTAINER: ${{ env.CI_PROJECT }}-engram-1
           AUTH_PROVIDER: local
           E2E_ENABLE_CRDT: "true"
           E2E_VAULT_PREFIX: ${{ env.E2E_VAULT_PREFIX }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4453,6 +4453,11 @@ jobs:
           # by design (ships in the browser), so a variable not a secret.
           VITE_CLERK_PUBLISHABLE_KEY: ${{ vars.VITE_CLERK_PUBLISHABLE_KEY_PROD }}
           VITE_GIT_SHA: ${{ github.sha }}
+          # Light up browser->Tempo traces (traceparent header on authFetch +
+          # client span beacons via POST /api/telemetry/spans). Dark-launched
+          # until 2026-07-14: the deaf-note incident needed a CDP sniffer
+          # because the browser emitted no telemetry at all.
+          VITE_TRACING_ENABLED: 'true'
 
       - name: Deploy (wrangler)
         if: steps.guard.outputs.skip != 'true'

--- a/e2e/helpers/backend_rpc.py
+++ b/e2e/helpers/backend_rpc.py
@@ -1,0 +1,32 @@
+"""Run Elixir expressions inside the CI backend container via the release's
+`bin/engram rpc` (same docker-exec pattern as crypto_probe's psql probe).
+
+Used to stage server-side states a client API cannot reach — e.g. killing a
+CRDT room out from under a connected observer, or flipping a runtime rate
+limit — so failure modes that are timing-dependent in production become
+deterministic in a test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+CI_ENGRAM_CONTAINER = os.environ.get("CI_ENGRAM_CONTAINER", "engram-engram-1")
+
+
+def backend_rpc(expr: str, timeout: int = 20) -> str:
+    """Evaluate `expr` on the running backend node; returns stdout.
+
+    Raises on a non-zero exit so a mis-staged test fails loudly at the stage
+    step instead of producing a misleading assertion failure later.
+    """
+    result = subprocess.run(
+        ["docker", "exec", "-i", CI_ENGRAM_CONTAINER, "/app/bin/engram", "rpc", expr],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"backend_rpc({expr!r}) failed: {result.stderr.strip()}")
+    return result.stdout.strip()

--- a/e2e/helpers/web_spa.py
+++ b/e2e/helpers/web_spa.py
@@ -19,6 +19,7 @@ Requires Playwright + Chromium (already in the e2e requirements + CI image).
 from __future__ import annotations
 
 import logging
+import os
 import re
 
 from playwright.async_api import async_playwright
@@ -41,8 +42,14 @@ class WebSpaPeer:
     async def start(self) -> None:
         self._pw = await async_playwright().start()
         # --no-sandbox: headless Chromium under CI/container users; harmless locally.
+        # E2E_WEB_HEADED=1 launches headed (point DISPLAY at an Xvfb): on some
+        # dev hosts headless Chromium never produces compositor frames, so
+        # requestAnimationFrame stalls and every Playwright actionability wait
+        # (visible/enabled/STABLE needs two consecutive frames) times out at
+        # the sign-in click. CI runners tick fine headless; this is local-only.
+        headed = os.environ.get("E2E_WEB_HEADED") == "1"
         self._browser = await self._pw.chromium.launch(
-            headless=True, args=["--no-sandbox", "--disable-gpu"]
+            headless=not headed, args=["--no-sandbox", "--disable-gpu"]
         )
         self._ctx = await self._browser.new_context(base_url=self.base_url)
         self._page = await self._ctx.new_page()

--- a/e2e/tests/crdt/test_live_bound_both_ends.py
+++ b/e2e/tests/crdt/test_live_bound_both_ends.py
@@ -12,9 +12,13 @@ already-bound Y.Doc, so it diverges, the bounded retry exhausts, and the edit
 never lands until a full restart. This test opens the note in Obsidian's
 editor BEFORE the remote edit, which is the missing coverage.
 
-Marked xfail(strict=False): the bug is intermittent ("works after restart,
-degrades otherwise"), so this documents it without breaking CI. Flip to a hard
-assertion when #224 is fixed.
+Hard-gated since plugin #242 (the live-bound REST-converge fix for the
+2026-07-14 deaf-note incident). test_deaf_live_bound_note_converges_via_rest_catchup
+below stages the previously-intermittent wedge DETERMINISTICALLY: room killed
+server-side + handshake budget zeroed, so the old channel-heal path cannot
+succeed and only the REST catch-up can converge the note. It fails on
+pre-#242 plugins (which faked convergence after 3 re-handshakes) and passes
+with the fix.
 """
 
 from __future__ import annotations
@@ -23,6 +27,7 @@ import os
 
 import pytest
 
+from helpers.backend_rpc import backend_rpc
 from helpers.vault import wait_for_content
 
 pytestmark = pytest.mark.skipif(
@@ -42,11 +47,6 @@ def _note_id(api_sync, path: str) -> str:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="p0 engram-app/Engram-obsidian#224: live-bound receiver does not "
-    "converge on a remote edit without a restart",
-    strict=False,
-)
 async def test_remote_edit_converges_while_note_is_live_bound_in_obsidian(
     web, vault_b, cdp_b, api_sync, sync_vault_id
 ):
@@ -83,3 +83,75 @@ async def test_remote_edit_converges_while_note_is_live_bound_in_obsidian(
     # out (live-bound re-handshake never merges) until a hard restart.
     final = wait_for_content(vault_b, path, "EDIT-WHILE-B-LIVE-BOUND", timeout=CRDT_TIMEOUT)
     assert "base line" in final, f"base content lost on B: {final!r}"
+
+
+@pytest.mark.asyncio
+async def test_deaf_live_bound_note_converges_via_rest_catchup(
+    web, vault_b, cdp_b, api_sync, sync_vault_id
+):
+    """Deterministic regression stage for the 2026-07-14 deaf-note incident.
+
+    Production wedge: a note open in Obsidian's editor (live-bound) whose CRDT
+    room observation silently died. The plugin discards vault fan-out frames
+    for live-bound notes (the room "owns" them), its re-handshake could not
+    get through, and the old catch-up FAKED convergence after 3 attempts --
+    the note went one-way deaf until an Obsidian restart.
+
+    Deterministic stage: kill the note's room out from under B (B's client
+    keeps believing it is enrolled -- exactly the prod state) AND zero the
+    crdt handshake budget so a STEP1 re-handshake cannot heal the channel
+    path. The ONLY way B can converge is the plugin's REST delta catch-up
+    (plugin #242). Pre-#242 plugins time out here deterministically.
+    """
+    path = "E2E/Crdt/DeafLiveBound.md"
+
+    api_sync.create_note(path, "# Deaf Live Bound\nbase line.\n")
+    await cdp_b.trigger_full_sync()
+    wait_for_content(vault_b, path, "base line", timeout=CRDT_TIMEOUT)
+
+    # Live-bind the note in B's editor BEFORE the wedge, so B's Y.Doc owns it.
+    opened = await cdp_b.evaluate(
+        """
+        (async () => {
+          const f = app.vault.getAbstractFileByPath(%r);
+          if (!f) return "no-file";
+          await app.workspace.getLeaf(false).openFile(f);
+          return app.workspace.activeEditor?.file?.path ?? "no-active";
+        })()
+        """
+        % path,
+        await_promise=True,
+    )
+    assert opened == path, f"failed to live-bind note in Obsidian editor: {opened!r}"
+
+    note_id = _note_id(api_sync, path)
+    await web.open_note(note_id, sync_vault_id)
+
+    # Stage the deafness: the room dies (B is silently no longer an observer;
+    # the web's own next keystroke recreates it and re-observes only the web),
+    # and the handshake budget goes to zero (every STEP1 -> rate_limited), so
+    # the channel path cannot self-heal. put_env is node-local; the CI stack
+    # is single-node.
+    backend_rpc(f'Engram.Notes.CrdtRegistry.terminate_room("{note_id}")')
+    # Capture the pre-test override (the CI stack deliberately raises it, #999)
+    # so the finally-restore puts back the configured value, not a bare default.
+    prior = backend_rpc(
+        "IO.puts(inspect(Application.get_env(:engram, :crdt_hs_rate_limit_override)))"
+    ).strip()
+    backend_rpc("Application.put_env(:engram, :crdt_hs_rate_limit_override, 0)")
+    try:
+        await web.append("\nEDIT-WHILE-B-DEAF\n")
+
+        # Wait for the server row to materialize the edit (checkpoint debounce)
+        # so B's pull sees the diverged content_hash, then run B's sync. The
+        # pull IS the path under test: applyChange's live-bound branch must
+        # converge via the REST delta, not via the (blocked) re-handshake.
+        api_sync.wait_for_note_content(path, "EDIT-WHILE-B-DEAF", timeout=CRDT_TIMEOUT)
+        await cdp_b.trigger_full_sync()
+
+        final = wait_for_content(vault_b, path, "EDIT-WHILE-B-DEAF", timeout=CRDT_TIMEOUT)
+        assert "base line" in final, f"base content lost on B: {final!r}"
+    finally:
+        backend_rpc(
+            f"Application.put_env(:engram, :crdt_hs_rate_limit_override, {prior})"
+        )

--- a/frontend/src/api/channel-push-beacon.test.ts
+++ b/frontend/src/api/channel-push-beacon.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { beacon } from "../observability/trace";
+import { setTracingEnabled } from "./base";
+import { pushFailureBeacon } from "./channel";
+
+describe("pushFailureBeacon", () => {
+	afterEach(() => {
+		setTracingEnabled(false);
+		vi.restoreAllMocks();
+	});
+
+	it("no-ops entirely when tracing is disabled", () => {
+		setTracingEnabled(false);
+		const enqueue = vi.spyOn(beacon, "enqueue");
+		pushFailureBeacon("019f45c5-7818-771b-9242-9ae8c7fd214f", Date.now() * 1000, "timeout");
+		expect(enqueue).not.toHaveBeenCalled();
+	});
+
+	it("enqueues a web.crdt.push span with note_id + reason when tracing is on", () => {
+		setTracingEnabled(true);
+		const enqueue = vi.spyOn(beacon, "enqueue").mockImplementation(() => {});
+		pushFailureBeacon("019f45c5-7818-771b-9242-9ae8c7fd214f", Date.now() * 1000, "rate_limited");
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		const entry = enqueue.mock.calls[0]?.[0];
+		expect(entry?.name).toBe("web.crdt.push");
+		expect(entry?.attributes).toMatchObject({
+			"engram.surface": "web",
+			"engram.event_type": "push_failed",
+			"engram.note_id": "019f45c5-7818-771b-9242-9ae8c7fd214f",
+			"engram.reason": "rate_limited",
+		});
+		expect(entry?.trace_id).toMatch(/^[0-9a-f]{32}$/);
+		expect(entry?.parent_span_id).toMatch(/^[0-9a-f]{16}$/);
+	});
+
+	it("bounds the reason attribute to the sanitizer's 64-byte contract", () => {
+		setTracingEnabled(true);
+		const enqueue = vi.spyOn(beacon, "enqueue").mockImplementation(() => {});
+		pushFailureBeacon("019f45c5-7818-771b-9242-9ae8c7fd214f", Date.now() * 1000, "x".repeat(200));
+		const entry = enqueue.mock.calls[0]?.[0];
+		expect((entry?.attributes["engram.reason"] ?? "").length).toBeLessThanOrEqual(64);
+	});
+});

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -10,7 +10,8 @@ import {
 	startCrdtSession,
 	stopCrdtSession,
 } from "../crdt/session";
-import { beacon, parseTraceparent, tracingEnabled } from "../observability/trace";
+import { rlog } from "../observability/remote-log";
+import { beacon, newTraceContext, parseTraceparent, tracingEnabled } from "../observability/trace";
 import { getWsBase, joinWsUrl } from "./base";
 import { ROOT_FOLDER_ID } from "./queries";
 
@@ -140,6 +141,29 @@ function flushBatch(batch: PendingBatch): void {
 			refetchType: "all",
 		});
 	}
+}
+
+// Failure-only push beacon (web.crdt.push): OK pushes are per-keystroke
+// volume and would blow the 60/min beacon rate limit; the failures are the
+// signal. No-ops entirely (resolveTransport returns null) when tracing is off.
+function pushFailureBeacon(docId: string, startUs: number, reason: string): void {
+	if (!tracingEnabled()) {
+		return;
+	}
+	const ctx = newTraceContext();
+	beacon.enqueue({
+		trace_id: ctx.traceId,
+		parent_span_id: ctx.spanId,
+		name: "web.crdt.push",
+		start_us: startUs,
+		end_us: Date.now() * 1000,
+		attributes: {
+			"engram.surface": "web",
+			"engram.event_type": "push_failed",
+			"engram.note_id": docId,
+			"engram.reason": reason.slice(0, 64),
+		},
+	});
 }
 
 export const RECONNECT_JITTER_DEFAULT_MS = 5000;
@@ -399,9 +423,15 @@ export async function connectChannel({
 	startCrdtSession({
 		vaultId,
 		push: (docId, b64) => {
+			const startUs = Date.now() * 1000;
 			crdtChannel
 				?.push("crdt_msg", { doc_id: docId, b64 })
 				.receive("error", (resp: { reason?: string }) => {
+					rlog().warn(
+						"crdt",
+						`crdt_msg push rejected note=${docId} reason=${resp?.reason ?? "unknown"}`,
+					);
+					pushFailureBeacon(docId, startUs, resp?.reason ?? "error");
 					if (resp?.reason === "frame_too_large") {
 						// Retrying would re-send the same oversized diff and loop.
 						console.error(`CRDT frame rejected (frame_too_large) for ${docId} — edit not synced`);
@@ -411,7 +441,14 @@ export async function connectChannel({
 					// backoff re-derives whatever the server missed.
 					scheduleCrdtRehandshake(docId, resp?.reason === "rate_limited" ? 2000 : 1000);
 				})
-				.receive("timeout", () => scheduleCrdtRehandshake(docId, 1000));
+				.receive("timeout", () => {
+					// The server acks every routed crdt_msg (backend 2026-07-14), so a
+					// timeout is REAL non-delivery now, not the old always-fires noise
+					// that re-handshook every open note every ~3.5s forever.
+					rlog().warn("crdt", `crdt_msg push timeout note=${docId} — scheduling re-handshake`);
+					pushFailureBeacon(docId, startUs, "timeout");
+					scheduleCrdtRehandshake(docId, 1000);
+				});
 		},
 	});
 	const crdtTopic = `crdt:${userId}:${vaultId}`;
@@ -429,9 +466,11 @@ export async function connectChannel({
 	crdtChannel
 		.join()
 		.receive("ok", () => {
+			rlog().info("crdt", "crdt channel joined — live note sync active");
 			notifyCrdtChannelJoined();
 		})
 		.receive("error", (resp) => {
+			rlog().error("crdt", `crdt channel join FAILED: ${JSON.stringify(resp).slice(0, 200)}`);
 			notifyCrdtChannelError();
 			console.error("CRDT channel join failed", resp);
 		});

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -146,7 +146,8 @@ function flushBatch(batch: PendingBatch): void {
 // Failure-only push beacon (web.crdt.push): OK pushes are per-keystroke
 // volume and would blow the 60/min beacon rate limit; the failures are the
 // signal. No-ops entirely (resolveTransport returns null) when tracing is off.
-function pushFailureBeacon(docId: string, startUs: number, reason: string): void {
+// Exported as a test seam (same pattern as __getServerJitterMs).
+export function pushFailureBeacon(docId: string, startUs: number, reason: string): void {
 	if (!tracingEnabled()) {
 		return;
 	}

--- a/frontend/src/crdt/channel.ts
+++ b/frontend/src/crdt/channel.ts
@@ -1,6 +1,7 @@
 import * as decoding from "lib0/decoding";
 import * as encoding from "lib0/encoding";
 import * as syncProtocol from "y-protocols/sync";
+import { rlog } from "../observability/remote-log";
 import { type CrdtManager, REMOTE_ORIGIN } from "./manager";
 
 /** Outer y-protocols message-type tag — we only speak `messageSync`. */
@@ -64,6 +65,7 @@ export class CrdtChannel {
 			bytes = fromB64(b64);
 		} catch (err) {
 			console.warn("CRDT handleFrame: malformed base64 frame (dropped)", err);
+			rlog().warn("crdt", `handleFrame: malformed base64 frame dropped note=${path}`);
 			return;
 		}
 		const doc = await this.mgr.getDoc(path);
@@ -84,6 +86,7 @@ export class CrdtChannel {
 			}
 		} catch (err) {
 			console.warn("CRDT handleFrame: bad frame content (dropped)", err);
+			rlog().warn("crdt", `handleFrame: bad frame content dropped note=${path}`);
 		}
 	}
 }

--- a/frontend/src/crdt/session.ts
+++ b/frontend/src/crdt/session.ts
@@ -1,5 +1,6 @@
 import { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
+import { rlog } from "../observability/remote-log";
 import { CrdtChannel } from "./channel";
 import { CrdtEnrollment } from "./enrollment";
 import { CrdtManager } from "./manager";
@@ -214,6 +215,7 @@ export function scheduleRehandshake(docId: string, delayMs: number): void {
 	if (rehandshakeTimers.has(docId)) {
 		return;
 	}
+	rlog().info("crdt", `re-handshake scheduled note=${docId} delayMs=${delayMs}`);
 	rehandshakeTimers.set(
 		docId,
 		setTimeout(() => {
@@ -245,7 +247,11 @@ export function resyncOpenDocs(): void {
 	if (!session) {
 		return;
 	}
-	for (const id of session.awareness.keys()) {
+	const ids = [...session.awareness.keys()];
+	if (ids.length > 0) {
+		rlog().info("crdt", `reconnect resync: re-enrolling ${ids.length} open doc(s)`);
+	}
+	for (const id of ids) {
 		session.enrollment.reset(id); // clears enrolled set + CrdtChannel.initiated guard
 		session.enrollment.enroll(id); // re-sends STEP1 (idempotent; reset re-armed it)
 	}

--- a/frontend/src/observability/remote-log.test.ts
+++ b/frontend/src/observability/remote-log.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RemoteLogBuffer } from "./remote-log";
+
+const transport = {
+	url: "https://api.example",
+	token: "tok",
+	vaultId: "v-1",
+	deviceId: "d-1",
+};
+
+describe("RemoteLogBuffer", () => {
+	let calls: Array<{ url: string; init: RequestInit }>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		calls = [];
+		vi.stubGlobal("fetch", (url: string, init: RequestInit) => {
+			calls.push({ url, init });
+			return Promise.resolve(new Response("{}"));
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it("batches lines and flushes on the timer with auth + device headers", async () => {
+		const buf = new RemoteLogBuffer(async () => transport);
+		buf.log("warn", "crdt", "crdt_msg push timeout note=abc");
+		buf.log("info", "crdt", "re-handshake scheduled note=abc");
+		expect(calls).toHaveLength(0);
+
+		await vi.advanceTimersByTimeAsync(5000);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe("https://api.example/api/logs");
+		const headers = calls[0]?.init.headers as Record<string, string>;
+		expect(headers.Authorization).toBe("Bearer tok");
+		expect(headers["X-Vault-ID"]).toBe("v-1");
+		expect(headers["X-Device-Id"]).toBe("d-1");
+		const body = JSON.parse(String(calls[0]?.init.body));
+		expect(body.logs).toHaveLength(2);
+		expect(body.logs[0]).toMatchObject({
+			level: "warn",
+			category: "crdt",
+			platform: "web",
+		});
+	});
+
+	it("auto-flushes at the batch cap without waiting for the timer", async () => {
+		const buf = new RemoteLogBuffer(async () => transport);
+		for (let i = 0; i < 20; i++) {
+			buf.log("info", "crdt", `line ${i}`);
+		}
+		await vi.advanceTimersByTimeAsync(0);
+		expect(calls).toHaveLength(1);
+		expect(JSON.parse(String(calls[0]?.init.body)).logs).toHaveLength(20);
+	});
+
+	it("drops silently when signed out (no token) — never networks", async () => {
+		const buf = new RemoteLogBuffer(async () => ({ ...transport, token: null }));
+		buf.log("error", "crdt", "x");
+		await buf.flush();
+		expect(calls).toHaveLength(0);
+	});
+
+	it("bounds the queue: oldest lines drop when transport is wedged", async () => {
+		const buf = new RemoteLogBuffer(async () => ({ ...transport, token: null }));
+		for (let i = 0; i < 260; i++) {
+			buf.log("info", "crdt", `line ${i}`);
+		}
+		// Un-wedge and flush: only the newest MAX_QUEUE(200) minus already
+		// attempted flushes remain — assert the cap held, not an exact count.
+		const sent: number[] = [];
+		const buf2 = buf as unknown as { queue: unknown[] };
+		expect(buf2.queue.length).toBeLessThanOrEqual(200);
+		expect(sent).toHaveLength(0);
+	});
+
+	it("truncates oversized messages", async () => {
+		const buf = new RemoteLogBuffer(async () => transport);
+		buf.log("warn", "crdt", "x".repeat(2000));
+		await buf.flush();
+		const body = JSON.parse(String(calls[0]?.init.body));
+		expect(body.logs[0].message.length).toBeLessThanOrEqual(500);
+	});
+
+	it("a fetch failure never throws into the caller", async () => {
+		vi.stubGlobal("fetch", () => Promise.reject(new Error("network down")));
+		const buf = new RemoteLogBuffer(async () => transport);
+		buf.log("warn", "crdt", "x");
+		await expect(buf.flush()).resolves.toBeUndefined();
+	});
+});

--- a/frontend/src/observability/remote-log.test.ts
+++ b/frontend/src/observability/remote-log.test.ts
@@ -65,17 +65,21 @@ describe("RemoteLogBuffer", () => {
 		expect(calls).toHaveLength(0);
 	});
 
-	it("bounds the queue: oldest lines drop when transport is wedged", async () => {
+	it("bounds the queue at 200 with drop-oldest when the transport is wedged", async () => {
+		// Wedge the auto-flush (no token → flush drops nothing from the queue?
+		// No: flush SPLICES the batch then drops it on the floor when there is
+		// no token — so to accumulate past MAX_BATCH we must stop flush itself).
 		const buf = new RemoteLogBuffer(async () => ({ ...transport, token: null }));
+		const flushSpy = vi.spyOn(buf, "flush").mockResolvedValue(undefined);
 		for (let i = 0; i < 260; i++) {
 			buf.log("info", "crdt", `line ${i}`);
 		}
-		// Un-wedge and flush: only the newest MAX_QUEUE(200) minus already
-		// attempted flushes remain — assert the cap held, not an exact count.
-		const sent: number[] = [];
-		const buf2 = buf as unknown as { queue: unknown[] };
-		expect(buf2.queue.length).toBeLessThanOrEqual(200);
-		expect(sent).toHaveLength(0);
+		const queue = (buf as unknown as { queue: Array<{ message: string }> }).queue;
+		expect(queue.length).toBe(200);
+		// Drop-oldest: the newest breadcrumbs survive, the earliest are gone.
+		expect(queue[0]?.message).toBe("line 60");
+		expect(queue[199]?.message).toBe("line 259");
+		flushSpy.mockRestore();
 	});
 
 	it("truncates oversized messages", async () => {

--- a/frontend/src/observability/remote-log.test.ts
+++ b/frontend/src/observability/remote-log.test.ts
@@ -74,7 +74,7 @@ describe("RemoteLogBuffer", () => {
 		for (let i = 0; i < 260; i++) {
 			buf.log("info", "crdt", `line ${i}`);
 		}
-		const queue = (buf as unknown as { queue: Array<{ message: string }> }).queue;
+		const { queue } = buf as unknown as { queue: Array<{ message: string }> };
 		expect(queue.length).toBe(200);
 		// Drop-oldest: the newest breadcrumbs survive, the earliest are gone.
 		expect(queue[0]?.message).toBe("line 60");

--- a/frontend/src/observability/remote-log.ts
+++ b/frontend/src/observability/remote-log.ts
@@ -1,0 +1,133 @@
+// Batched remote logger for the web SPA — the browser-side sibling of the
+// Obsidian plugin's `rlog`. Ships breadcrumbs to the backend's authed
+// `POST /api/logs` ingest (the same `client_logs` pipeline the plugin uses:
+// rows are queryable per device via GET /api/logs, and warn+error re-emit
+// into the server log stream that ships to Loki).
+//
+// Motivation (2026-07-14 deaf-note incident): the browser was a black box —
+// diagnosing a one-directional live-sync failure required attaching a CDP
+// WebSocket sniffer to the user's tab. The CRDT lifecycle breadcrumbs wired
+// through this module make that hunt a Loki/`GET /api/logs` query instead.
+//
+// NOT gated on `tracingEnabled` — logs are the incident-response floor and
+// must flow on every deployment shape; the trace beacon stays dark-launched
+// separately. Transport mirrors `BeaconBuffer`: batched, keepalive fetch,
+// fire-and-forget, `pagehide` flush, never throws into a caller.
+import { getActiveVaultId } from "../api/active-vault";
+import { getApiBase } from "../api/base";
+import { getAuthToken } from "../api/client";
+import { getDeviceId } from "../api/device-id";
+
+const FLUSH_MS = 5000;
+const MAX_BATCH = 20;
+// Hard cap on buffered-but-unsent lines: a wedged transport (signed out,
+// offline) must not grow memory without bound. Oldest lines drop first —
+// the newest breadcrumbs are the ones an incident needs.
+const MAX_QUEUE = 200;
+const MAX_MESSAGE_CHARS = 500;
+
+function createRemoteLog(): RemoteLogBuffer {
+	const buf = new RemoteLogBuffer(async () => ({
+		url: getApiBase(),
+		token: await getAuthToken(),
+		vaultId: getActiveVaultId(),
+		deviceId: getDeviceId(),
+	}));
+	if (typeof window !== "undefined") {
+		window.addEventListener("pagehide", () => {
+			buf.flush();
+		});
+	}
+	return buf;
+}
+
+export type RemoteLogLevel = "info" | "warn" | "error";
+
+export interface RemoteLogEntry {
+	ts: string;
+	level: RemoteLogLevel;
+	category: string;
+	message: string;
+	platform: string;
+}
+
+export class RemoteLogBuffer {
+	private readonly queue: RemoteLogEntry[] = [];
+	private timer: ReturnType<typeof setTimeout> | null = null;
+
+	constructor(
+		private readonly resolveTransport: () => Promise<{
+			url: string;
+			token: string | null;
+			vaultId: string | null;
+			deviceId: string;
+		} | null>,
+	) {}
+
+	log(level: RemoteLogLevel, category: string, message: string): void {
+		this.queue.push({
+			ts: new Date().toISOString(),
+			level,
+			category,
+			message: message.slice(0, MAX_MESSAGE_CHARS),
+			platform: "web",
+		});
+		if (this.queue.length > MAX_QUEUE) {
+			this.queue.splice(0, this.queue.length - MAX_QUEUE);
+		}
+		if (this.queue.length >= MAX_BATCH) {
+			this.flush();
+		} else if (!this.timer) {
+			this.timer = setTimeout(() => {
+				this.flush();
+			}, FLUSH_MS);
+		}
+	}
+
+	async flush(): Promise<void> {
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+		if (this.queue.length === 0) {
+			return;
+		}
+		const batch = this.queue.splice(0, this.queue.length);
+		try {
+			const transport = await this.resolveTransport();
+			if (!transport?.token) {
+				return; // signed out / not ready: drop silently, never network
+			}
+			await fetch(`${transport.url}/api/logs`, {
+				method: "POST",
+				keepalive: true,
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${transport.token}`,
+					...(transport.vaultId ? { "X-Vault-ID": transport.vaultId } : {}),
+					"X-Device-Id": transport.deviceId,
+				},
+				body: JSON.stringify({ logs: batch }),
+			});
+		} catch {
+			// Best-effort: a logging failure must never surface into sync/UI.
+		}
+	}
+}
+
+export const remoteLog = createRemoteLog();
+
+/** Web-side `rlog`: `rlog().warn("crdt", "...")`. Info lines land in the
+ *  queryable `client_logs` table; warn/error additionally re-emit into the
+ *  server log stream shipped to Loki. */
+export function rlog(): {
+	info: (category: string, message: string) => void;
+	warn: (category: string, message: string) => void;
+	error: (category: string, message: string) => void;
+} {
+	return {
+		info: (category, message) => remoteLog.log("info", category, message),
+		warn: (category, message) => remoteLog.log("warn", category, message),
+		error: (category, message) => remoteLog.log("error", category, message),
+	};
+}

--- a/lib/engram/observability/beacon_sanitizer.ex
+++ b/lib/engram/observability/beacon_sanitizer.ex
@@ -8,8 +8,24 @@ defmodule Engram.Observability.BeaconSanitizer do
   security core.
   """
 
-  @allowed_attributes ["engram.surface", "engram.event_type", "engram.duration_ms"]
-  @allowed_names ["obsidian.push", "browser.live_sync.render"]
+  @allowed_attributes [
+    "engram.surface",
+    "engram.event_type",
+    "engram.duration_ms",
+    # Which note (UUID-validated below) and which route/reason — the
+    # 2026-07-14 deaf-note hunt stalled on beacons that carried none of these.
+    "engram.note_id",
+    "engram.route",
+    "engram.reason"
+  ]
+  @allowed_names [
+    "obsidian.push",
+    "browser.live_sync.render",
+    "web.crdt.push",
+    "web.crdt.apply",
+    "web.crdt.handshake"
+  ]
+  @uuid_re ~r/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
   @max_duration_us 30_000_000
   @max_skew_us 300_000_000
 
@@ -62,7 +78,12 @@ defmodule Engram.Observability.BeaconSanitizer do
   defp attributes(attrs) when is_map(attrs) do
     attrs
     |> Map.take(@allowed_attributes)
-    |> Enum.filter(fn {_k, v} -> safe_attr_value?(v) end)
+    |> Enum.filter(fn
+      # note_id must LOOK like a note id: anything else (a title, a path) is
+      # both a PII leak and an unbounded-cardinality label. Drop, don't reject.
+      {"engram.note_id", v} -> is_binary(v) and Regex.match?(@uuid_re, v)
+      {_k, v} -> safe_attr_value?(v)
+    end)
     |> Map.new()
   end
 

--- a/lib/engram/observability/trace_sampler.ex
+++ b/lib/engram/observability/trace_sampler.ex
@@ -53,9 +53,16 @@ defmodule Engram.Observability.TraceSampler do
   @impl :otel_sampler
   def description(_config), do: <<"EngramTraceSampler">>
 
+  # A repo.query as a ROOT span is background-poller noise: request-bound Ecto
+  # spans always hang off the Bandit server span, so the only orphan query
+  # roots are Oban's ~1s staging poll (engram.repo.query:oban_jobs/oban_peers)
+  # and its source-less begin/commit siblings. They dominated Tempo volume and
+  # buried real traces (2026-07-14). Prefix match keeps every :source variant.
+  @repo_query_prefix "engram.repo.query"
+
   @impl :otel_sampler
   def should_sample(ctx, trace_id, links, span_name, span_kind, attributes, config) do
-    if drop?(attributes) do
+    if drop?(attributes) or orphan_query?(span_name) do
       {:drop, [], :otel_span.tracestate(:otel_tracer.current_span_ctx(ctx))}
     else
       :otel_sampler_trace_id_ratio_based.should_sample(
@@ -85,4 +92,11 @@ defmodule Engram.Observability.TraceSampler do
 
   defp lookup_path(attributes) when is_map(attributes), do: Map.get(attributes, @path_key)
   defp lookup_path(_), do: nil
+
+  defp orphan_query?(span_name) when is_binary(span_name),
+    do: String.starts_with?(span_name, @repo_query_prefix)
+
+  # opentelemetry passes span names as atoms or iodata in some paths — treat
+  # anything non-binary as not-a-query rather than raising on the hot path.
+  defp orphan_query?(_), do: false
 end

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -132,7 +132,12 @@ defmodule EngramWeb.CrdtChannel do
          :ok <- guard_frame(frame),
          {:ok, socket, %{room: room}} <- ensure_room(socket, doc_id) do
       SharedDoc.send_yjs_message(room, frame)
-      {:noreply, socket}
+      # ACK the push. Clients attach reply handlers to distinguish delivery
+      # from loss; with no ack every successful push "times out" client-side —
+      # the web SPA re-handshook every open note every ~3.5s forever
+      # (2026-07-14). Routed-to-room is the honest ack point: the frame is in
+      # the owner process's mailbox and the room's update_v1 path persists it.
+      {:reply, {:ok, %{}}, socket}
     else
       {:error, :rate_limited} ->
         {:reply, {:error, %{reason: "rate_limited"}}, socket}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.670",
+      version: "0.5.671",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.669",
+      version: "0.5.670",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/observability/beacon_sanitizer_test.exs
+++ b/test/engram/observability/beacon_sanitizer_test.exs
@@ -136,4 +136,25 @@ defmodule Engram.Observability.BeaconSanitizerTest do
              "engram.reason" => "timeout"
            }
   end
+
+  test "drops oversized engram.route / engram.reason values (the frontend slices by chars, the cap is bytes)" do
+    entry =
+      put_in(base()["attributes"], %{
+        "engram.route" => String.duplicate("r", 65),
+        "engram.reason" => String.duplicate("x", 65)
+      })
+
+    assert {:ok, out} = S.sanitize(entry, @now_us)
+    assert out.attributes == %{}
+  end
+
+  test "drops an UPPERCASE UUID in engram.note_id (clients emit lowercase; anything else is untrusted)" do
+    entry =
+      put_in(base()["attributes"], %{
+        "engram.note_id" => "019F45C5-7818-771B-9242-9AE8C7FD214F"
+      })
+
+    assert {:ok, out} = S.sanitize(entry, @now_us)
+    refute Map.has_key?(out.attributes, "engram.note_id")
+  end
 end

--- a/test/engram/observability/beacon_sanitizer_test.exs
+++ b/test/engram/observability/beacon_sanitizer_test.exs
@@ -100,4 +100,40 @@ defmodule Engram.Observability.BeaconSanitizerTest do
              "engram.event_type" => "upsert"
            }
   end
+
+  test "accepts the web CRDT span names (browser live-sync observability)" do
+    for name <- ["web.crdt.push", "web.crdt.apply", "web.crdt.handshake"] do
+      assert {:ok, out} = S.sanitize(put_in(base()["name"], name), @now_us)
+      assert out.name == name
+    end
+  end
+
+  test "keeps engram.note_id only when it is a UUID (cardinality + PII guard)" do
+    ok =
+      put_in(base()["attributes"], %{
+        "engram.note_id" => "019f45c5-7818-771b-9242-9ae8c7fd214f"
+      })
+
+    assert {:ok, out} = S.sanitize(ok, @now_us)
+    assert out.attributes["engram.note_id"] == "019f45c5-7818-771b-9242-9ae8c7fd214f"
+
+    bad = put_in(base()["attributes"], %{"engram.note_id" => "Secret Note Title.md"})
+    assert {:ok, out} = S.sanitize(bad, @now_us)
+    refute Map.has_key?(out.attributes, "engram.note_id")
+  end
+
+  test "keeps engram.route and engram.reason short strings" do
+    entry =
+      put_in(base()["attributes"], %{
+        "engram.route" => "/notes/:id/updates",
+        "engram.reason" => "timeout"
+      })
+
+    assert {:ok, out} = S.sanitize(entry, @now_us)
+
+    assert out.attributes == %{
+             "engram.route" => "/notes/:id/updates",
+             "engram.reason" => "timeout"
+           }
+  end
 end

--- a/test/engram/observability/trace_sampler_test.exs
+++ b/test/engram/observability/trace_sampler_test.exs
@@ -75,6 +75,31 @@ defmodule Engram.Observability.TraceSamplerTest do
       assert decision == :record_and_sample
     end
 
+    test "drops orphan repo.query root spans (Oban poller noise)", %{config: config} do
+      # Request-bound Ecto spans always have a parent (the Bandit server span),
+      # so a repo.query arriving here as a ROOT is background-poller noise:
+      # Oban's staging poll emits engram.repo.query:oban_jobs / oban_peers and
+      # source-less begin/commit roots every second, drowning Tempo (the
+      # 2026-07-14 hunt paged through screens of them).
+      for name <- [
+            "engram.repo.query:oban_jobs",
+            "engram.repo.query:oban_peers",
+            "engram.repo.query"
+          ] do
+        {decision, _attrs, _tracestate} =
+          TraceSampler.should_sample(%{}, 123, [], name, :client, %{}, config)
+
+        assert decision == :drop, "expected root #{name} to be dropped"
+      end
+    end
+
+    test "keeps non-query root spans with no url.path (background jobs)", %{config: config} do
+      {decision, _attrs, _tracestate} =
+        TraceSampler.should_sample(%{}, 123, [], "checkpoint_note", :internal, %{}, config)
+
+      assert decision == :record_and_sample
+    end
+
     test "delegate honours ratio 0.0 (drops real paths too)" do
       config = TraceSampler.setup(%{ratio: 0.0})
 

--- a/test/engram/observability/trace_sampler_test.exs
+++ b/test/engram/observability/trace_sampler_test.exs
@@ -100,6 +100,16 @@ defmodule Engram.Observability.TraceSamplerTest do
       assert decision == :record_and_sample
     end
 
+    test "non-binary span names fall through to the ratio sampler (deliberate: never raise on the hot path)",
+         %{config: config} do
+      for name <- [:some_atom, ~c"engram.repo.query:oban_jobs"] do
+        {decision, _attrs, _tracestate} =
+          TraceSampler.should_sample(%{}, 123, [], name, :client, %{}, config)
+
+        assert decision == :record_and_sample
+      end
+    end
+
     test "delegate honours ratio 0.0 (drops real paths too)" do
       config = TraceSampler.setup(%{ratio: 0.0})
 

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -158,6 +158,19 @@ defmodule EngramWeb.CrdtChannelTest do
       assert CrdtBridge.text_of(client) == "base"
     end
 
+    test "a successfully routed crdt_msg is ACKED with :ok", %{socket: socket, doc_id: doc_id} do
+      # Without an ack, a client that attaches a reply/timeout handler treats
+      # every successful push as a timeout: the web SPA re-handshook every open
+      # note every ~3.5s forever (2026-07-14). The ack is the delivery signal.
+      client = CrdtBridge.new_doc()
+      {:ok, {:sync_step1, sv}} = Yex.Sync.get_sync_step1(client)
+      {:ok, frame} = Yex.Sync.message_encode({:sync, {:sync_step1, sv}})
+
+      ref = push(socket, "crdt_msg", %{"doc_id" => doc_id, "b64" => Base.encode64(frame)})
+
+      assert_reply ref, :ok, %{}, 3000
+    end
+
     # ---------------------------------------------------------------------
     # doc_id IS the note_id — ownership validation, not path_hmac lookup
     # ---------------------------------------------------------------------


### PR DESCRIPTION
## Three legs of the 2026-07-14 deaf-note incident's observability debt

### 1. `crdt_channel` ACKs every successfully routed `crdt_msg`

With no ack, a client that attaches a reply/timeout handler treats every successful push as a timeout. Captured live: the web SPA re-handshook every open note **every ~3.5s, forever** (STEP1/STEP2/STEP2/awareness round, byte-identical, ~17 rounds/min per note). Ack point is routed-to-room: the frame is in the owner process's mailbox and `update_v1` persists it. Timeouts are now real non-delivery signals; the web SPA's timeout handler comment updated to match.

### 2. Browser logs + traces (the browser was a black box)

Diagnosing the incident required attaching a CDP WebSocket sniffer to the user's live tab. Now:

- **`frontend/src/observability/remote-log.ts`** — batched web `rlog` shipping CRDT lifecycle breadcrumbs to `POST /api/logs` (same `client_logs` pipeline as the plugin; warn+ re-emits to Loki): channel join ok/fail, push rejection/timeout with reason + note_id, re-handshake scheduled, reconnect resync, dropped inbound frames. Bounded queue, keepalive fetch, pagehide flush, never throws.
- **Failure-only `web.crdt.push` beacons** join Tempo through the existing dark-launched beacon buffer (OK pushes are keystroke-volume and would blow the 60/min beacon budget; failures are the signal).
- **`VITE_TRACING_ENABLED=true`** in the saas build env — the entire web tracing skeleton (traceparent header on authFetch + beacon buffer) existed but was dark in prod (`config.json` never set the flag).
- **BeaconSanitizer** allowlists the web span names plus `engram.note_id` (UUID-validated: anything else is a PII/cardinality risk and is dropped), `engram.route`, `engram.reason`.

### 3. TraceSampler drops orphan `engram.repo.query*` root spans

Oban's ~1s staging poll emitted a junk single-span trace per query (`oban_jobs`/`oban_peers`/source-less begin/commit), drowning Tempo — paging through them cost real time during the incident. Request-bound Ecto spans always hang off the Bandit server span and are untouched; only parentless query roots drop.

Pairs with plugin PR (live-bound REST converge + fan-out skip logging). Format/credo/sobelow/dialyzer green; full `mix test` green; frontend vitest (787), build, biome green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPsYQart6AXhihbSjaqTqV
