### PR TITLE
fix(e2e): reap untagged Playwright Clerk users (#558 class recurrence)

### DIFF
--- a/e2e/helpers/clerk_constants.py
+++ b/e2e/helpers/clerk_constants.py
@@ -6,10 +6,16 @@ hard-coded list of email *prefixes*, and every new test suite added a prefix
 (e2e-conn-, e2e-free-signup-, e2e-cancel-free-, …) that one or both lists
 forgot — so those users leaked until the dev-tier 100-user cap was hit (#558).
 
-Every e2e Clerk user is minted with an ``e2e-`` local part AND the
+The pytest harness mints users with an ``e2e-`` local part AND the
 ``+clerk_test`` plus-tag (the dev-instance "don't deliver email" convention,
-see helpers/clerk.py + conftest.py). Matching on that signature is robust to
-new suites and cannot match a real user.
+see helpers/clerk.py + conftest.py). The Playwright browser suite
+(frontend/e2e/global-setup.ts + spec files) mints ``e2e-<suite>-<ts>@test.com``
+WITHOUT the tag — matching only the tag let those users leak past the reaper
+until the dev-tier 100-user cap was hit AGAIN on 2026-07-14 (same class as
+#558: every [clerk] browser test failed "No user found with email" because
+user creation was rejected at the cap). So: own the tag signature OR any
+``e2e-*@test.com`` address — ``@test.com`` is a test-only domain, no real
+user has it, and both arms still require the ``e2e-`` prefix.
 """
 
 from __future__ import annotations
@@ -17,4 +23,6 @@ from __future__ import annotations
 
 def is_e2e_clerk_email(email: str) -> bool:
     """True iff `email` belongs to an e2e-minted Clerk test user."""
-    return email.startswith("e2e-") and "+clerk_test@" in email
+    return email.startswith("e2e-") and (
+        "+clerk_test@" in email or email.endswith("@test.com")
+    )

--- a/e2e/unit/test_clerk_constants.py
+++ b/e2e/unit/test_clerk_constants.py
@@ -1,0 +1,33 @@
+"""is_e2e_clerk_email must own EVERY e2e-minted user shape.
+
+Regression guard for the #558 class recurring through the Playwright suite
+(2026-07-14): frontend/e2e mints `e2e-*@test.com` users WITHOUT the
+`+clerk_test` tag, so the reaper never deleted them — they accumulated to
+the Clerk dev-tier 100-user cap and user creation started failing
+("No user found with email" in every [clerk] browser test).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from helpers.clerk_constants import is_e2e_clerk_email  # noqa: E402
+
+
+def test_pytest_harness_shape_matches():
+    assert is_e2e_clerk_email("e2e-sync-123r777je2e-clerkw0+clerk_test@example.com")
+
+
+def test_playwright_untagged_shape_matches():
+    # frontend/e2e/global-setup.ts + spec files: e2e-<suite>-<ts>@test.com
+    assert is_e2e_clerk_email("e2e-browser-1784019046203@test.com")
+    assert is_e2e_clerk_email("e2e-props-crdt-1784019046203@test.com")
+    assert is_e2e_clerk_email("e2e-tree-delopen-1784019046203@test.com")
+
+
+def test_real_users_never_match():
+    assert not is_e2e_clerk_email("todd@example.com")
+    assert not is_e2e_clerk_email("e2e-fan@gmail.com")          # e2e- prefix alone is NOT enough
+    assert not is_e2e_clerk_email("someone+clerk_test@example.com")  # tag alone is NOT enough
+    assert not is_e2e_clerk_email("")


### PR DESCRIPTION
## Bug

`is_e2e_clerk_email` (the shared reaper/sweep filter from #558) requires the `+clerk_test` tag — but the **Playwright** suite mints `e2e-<suite>-<ts>@test.com` users **without it** (`frontend/e2e/global-setup.ts` + spec files). The reaper has never deleted a browser-suite user. They accumulated to the Clerk dev-tier **100-user cap**; on 2026-07-14 ~08:35 user creation started getting rejected and **all 9 `[clerk]` browser tests fail with "No user found with email"** — twice on main, persisting straight through an orphan-reaper run (which structurally could not see them).

## Fix

One line: also own `e2e-*@test.com` (test-only domain, `e2e-` prefix still required). Safety analysis:
- **Reaper** (`--older-than 1h`): digests the backlog, frees the cap.
- **In-run sweep**: still double-scoped by the `r<run>j<job>w` run marker, so concurrent runs' live users remain untouchable — browser users carry no marker and are skipped in scoped mode.
- New `e2e/unit/test_clerk_constants.py` locks all three shapes (TDD: failed before the fix, 32/32 after).

## Recovery sequence

Merge → trigger `clerk-orphans` (or wait for the :30 hourly) → backlog reaped → `e2e-browser` [clerk] recovers.

Refs #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019omnopWqAww7rfxG9Yp47i