### PR TITLE
fix(e2e): age-gate browser setup Clerk cleanup (concurrent runs deleted each other's users)

### DIFF
--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -214,8 +214,17 @@ async function waitUntilEmailResolvable(
 // Python E2E job which may be running in parallel on the same Clerk account.
 const E2E_PREFIXES = ["e2e-browser-"];
 
+// Only delete users older than this. Without an age gate, TWO CONCURRENT
+// e2e-browser jobs delete each other's freshly-minted users (hit 2x on
+// 2026-07-14: every [clerk] test failed "No user found with email" whenever
+// a second run's globalSetup fired mid-run — impossible in the old
+// single-runner world, routine with a multi-runner pool). Same 1h belt the
+// hourly reaper (e2e/scripts/cleanup_clerk_users.py --older-than 1h) wears.
+const CLEANUP_MIN_AGE_MS = 60 * 60 * 1000;
+
 async function cleanupOrphanedClerkUsers(secretKey: string) {
 	const headers = { Authorization: `Bearer ${secretKey}` };
+	const cutoff = Date.now() - CLEANUP_MIN_AGE_MS;
 	let deleted = 0;
 
 	for (let offset = 0; ; offset += 100) {
@@ -233,6 +242,12 @@ async function cleanupOrphanedClerkUsers(secretKey: string) {
 		for (const user of users) {
 			const emails: string[] =
 				user.email_addresses?.map((ea: { email_address: string }) => ea.email_address) ?? [];
+			// created_at is unix-millis (Clerk Backend API). Skip anything
+			// younger than the age gate — it may belong to a LIVE run.
+			const createdAt = typeof user.created_at === "number" ? user.created_at : 0;
+			if (createdAt >= cutoff) {
+				continue;
+			}
 			if (emails.some((e: string) => E2E_PREFIXES.some((p) => e.startsWith(p)))) {
 				const del = await fetch(`${CLERK_API}/users/${user.id}`, { method: "DELETE", headers });
 				if (del.ok) {

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.669",
+      version: "0.5.670",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Bug

`cleanupOrphanedClerkUsers` (browser `global-setup.ts`) deletes every `e2e-browser-*` Clerk user with **no age filter**. Two concurrent `e2e-browser` jobs therefore delete each other's freshly-created users. Invisible in the single-runner world (browser jobs never overlapped); routine with the multi-runner pool. Both main failures on 2026-07-14 (all 9 `[clerk]` tests, "No user found with email") happened exactly when another branch's e2e-browser job overlapped — the user was created successfully at setup and deleted server-side minutes later by the sibling's setup.

This closes the browser-failure investigation that #1010 started: #1010 fixed the *reaper blindness* (real, separate leak); this fixes the *live-user deletion race* that actually produced the failures.

## Fix

1h age gate on the setup-time cleanup (`created_at` unix-millis), matching the hourly reaper's `--older-than 1h` belt. Long-term leaks are the reaper's job (it owns `e2e-*@test.com` since #1010); setup cleanup must never eat a live sibling.

Biome + tsc clean. `mix.exs` 0.5.670 (frontend/ is a deployable path; test-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019omnopWqAww7rfxG9Yp47i