### PR TITLE
perf(ci): cache Elixir deps/_build on LAN MinIO via runs-on/cache

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -643,9 +643,20 @@ jobs:
           echo "build-dev=$DEV_KEY" >> "$GITHUB_OUTPUT"
           echo "build-test=$TEST_KEY" >> "$GITHUB_OUTPUT"
 
+      # runs-on/cache (SHA-pinned fork of actions/cache) stores the Elixir
+      # deps/ + _build caches on the FastRaid MinIO over LAN, not GitHub's
+      # Azure Blob backend. Self-hosted runners upload to GitHub's cache at
+      # ~0.2 MB/s (a ~240 MB _build took ~23 min/run); the LAN S3 path runs at
+      # 200+ MB/s. The runner injects the S3 config (RUNS_ON_S3_BUCKET_CACHE,
+      # endpoint, creds) via its environment, so no secret lives in this repo;
+      # if that env is absent (e.g. a GitHub-hosted runner) the action falls
+      # back transparently to the default GitHub cache. EVERY deps/_build/PLT
+      # save + restore below must stay on runs-on/cache — a save on S3 paired
+      # with a restore on GitHub is a guaranteed miss. (buildx cache stays on
+      # actions/cache; it is a separate, Docker-layer concern.)
       - name: Cache deps/
         id: cache-deps
-        uses: actions/cache@v6
+        uses: runs-on/cache@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: deps
           key: ${{ steps.keys.outputs.deps }}
@@ -653,7 +664,7 @@ jobs:
 
       - name: Cache _build/dev
         id: cache-build-dev
-        uses: actions/cache@v6
+        uses: runs-on/cache@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: _build/dev
           # No restore-keys: the key is mix.lock-scoped, so a restore-key prefix
@@ -665,7 +676,7 @@ jobs:
 
       - name: Cache _build/test
         id: cache-build-test
-        uses: actions/cache@v6
+        uses: runs-on/cache@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: _build/test
           # No restore-keys: see the _build/dev cache above. A restore-key hit
@@ -1965,7 +1976,7 @@ jobs:
       # BEAM files instead of recompiling.
       - name: Restore deps cache
         id: cache-deps
-        uses: actions/cache/restore@v6
+        uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: deps
           key: ${{ needs.prebuild-mix.outputs.deps-key }}
@@ -1973,7 +1984,7 @@ jobs:
             mix-deps-${{ needs.prebuild-mix.outputs.beam-tag }}-
 
       - name: Restore _build/test cache
-        uses: actions/cache/restore@v6
+        uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: _build/test
           key: ${{ needs.prebuild-mix.outputs.build-test-key }}
@@ -2214,7 +2225,7 @@ jobs:
       # re-validation (no --force; cache was built warnings-clean).
       - name: Restore deps cache
         id: cache-deps
-        uses: actions/cache/restore@v6
+        uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: deps
           key: ${{ needs.prebuild-mix.outputs.deps-key }}
@@ -2222,7 +2233,7 @@ jobs:
             mix-deps-${{ needs.prebuild-mix.outputs.beam-tag }}-
 
       - name: Restore _build/dev cache
-        uses: actions/cache/restore@v6
+        uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: _build/dev
           key: ${{ needs.prebuild-mix.outputs.build-dev-key }}
@@ -2239,7 +2250,7 @@ jobs:
         run: mix deps.get
 
       - name: Cache Dialyzer PLT
-        uses: actions/cache@v6
+        uses: runs-on/cache@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: priv/plts
           key: ${{ runner.os }}-dialyzer-${{ needs.prebuild-mix.outputs.beam-tag }}-${{ hashFiles('mix.lock') }}
@@ -2667,7 +2678,7 @@ jobs:
       - name: Restore deps cache
         if: steps.gate.outputs.proceed == 'true'
         id: cache-deps
-        uses: actions/cache/restore@v6
+        uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: deps
           key: ${{ needs.prebuild-mix.outputs.deps-key }}
@@ -2676,7 +2687,7 @@ jobs:
 
       - name: Restore _build/dev cache
         if: steps.gate.outputs.proceed == 'true'
-        uses: actions/cache/restore@v6
+        uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: _build/dev
           key: ${{ needs.prebuild-mix.outputs.build-dev-key }}
@@ -2886,7 +2897,7 @@ jobs:
           echo "pg_port=$PG_PORT" >> "$GITHUB_OUTPUT"
           echo "Postgres on port $PG_PORT (container: $PG_CONTAINER)"
 
-      - uses: actions/cache/restore@v6
+      - uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         if: steps.gate.outputs.proceed == 'true' && steps.prev.outputs.proceed == 'true'
         id: cache-deps
         with:
@@ -3129,7 +3140,7 @@ jobs:
       # instead of recompiling at boot.
       - name: Restore deps cache
         id: cache-deps
-        uses: actions/cache/restore@v6
+        uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: deps
           key: ${{ needs.prebuild-mix.outputs.deps-key }}
@@ -3137,7 +3148,7 @@ jobs:
             mix-deps-${{ needs.prebuild-mix.outputs.beam-tag }}-
 
       - name: Restore _build/dev cache
-        uses: actions/cache/restore@v6
+        uses: runs-on/cache/restore@eb4bb3ee6c5e2e1b25ef2e5ed39e028539016208 # v5.0.7
         with:
           path: _build/dev
           key: ${{ needs.prebuild-mix.outputs.build-dev-key }}


### PR DESCRIPTION
Swaps the mix `deps/`, `_build/dev`, `_build/test`, and Dialyzer PLT cache saves + all their downstream restores from `actions/cache` to `runs-on/cache` (SHA-pinned v5.0.7), which talks S3 directly to the FastRaid MinIO over LAN. buildx layer cache stays on actions/cache (separate concern).

**Why:** self-hosted runners upload to GitHub's Azure Blob cache at ~0.2 MB/s (a ~240 MB \_build took ~23 min/run); LAN S3 is 200+ MB/s, no 10 GB cap. Replaces the falcondev cache-server (needed a runner dll patch + forced ACTIONS_CACHE_SERVICE_V2; never routed reliably).

The runner injects the S3 config via its environment (homelab `feat/runs-on-cache-runner-env`), so no MinIO secret lives here; `runs-on/cache` falls back to GitHub cache when that env is absent.

> [!WARNING]
> **DO NOT MERGE until engram-infra#851 (allow `runs-on/*`) merges + tf-applies.** Otherwise every run startup-fails on the unpermitted action. Deploy the homelab runner-env change to actually route to MinIO (until then this falls back to GitHub cache, i.e. today's behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)