### PR TITLE
fix: e2e-clerk flake classes test_34 + test_84

### DIFF
--- a/e2e/tests/test_44_oauth_device_flow.py
+++ b/e2e/tests/test_44_oauth_device_flow.py
@@ -12,7 +12,6 @@ Skipped automatically if E2E_CLERK_SECRET_KEY is not set.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import secrets
@@ -23,6 +22,7 @@ import pytest
 import requests
 
 from helpers.device_flow import start_device_flow, poll_for_tokens
+from helpers.oauth import restore_auth, swap_to_oauth
 from helpers.vault import write_note
 
 logger = logging.getLogger(__name__)
@@ -35,9 +35,6 @@ pytestmark = pytest.mark.skipif(
     not CLERK_SECRET,
     reason="E2E_CLERK_SECRET_KEY not set — skipping device flow tests",
 )
-
-# CDP plugin path shorthand
-_P = "app.plugins.plugins['engram-vault-sync']"
 
 
 @pytest.fixture
@@ -111,16 +108,15 @@ async def test_full_device_flow(
         logger.info("Tokens received: vault_id=%s", tokens["vault_id"])
 
         # ── 6. Reconfigure Obsidian A to use OAuth ────────────────
-        original_settings = await cdp_a.evaluate(
-            f"JSON.stringify({{apiKey: {_P}.settings.apiKey, "
-            f"refreshToken: {_P}.settings.refreshToken, "
-            f"vaultId: {_P}.settings.vaultId, "
-            f"userEmail: {_P}.settings.userEmail, "
-            f"authMethod: {_P}.settings.authMethod || 'apikey'}})"
-        )
+        # Shared helper, NOT a local copy: this test's private
+        # _swap_to_oauth/_restore_auth duplicated the pre-#229 ordering
+        # (saveSettings before provider wiring), freezing the channel topic
+        # under the OLD userId and leaving the session-scoped instance
+        # cross-bound — every later test needing A's live stream then died
+        # with crdtJoinFailedReason=unauthorized (test_84's 7-failure class).
+        original_settings = await swap_to_oauth(cdp_a, tokens)
 
         try:
-            await _swap_to_oauth(cdp_a, tokens)
 
             # Write a test note and sync
             path = "E2E/OAuthDeviceFlowTest.md"
@@ -149,86 +145,12 @@ async def test_full_device_flow(
 
         finally:
             # ── 7. Restore original API key auth ──────────────────
-            await _restore_auth(cdp_a, original_settings)
+            # Shared restore also VERIFIES the stream reconnects as the
+            # restored identity, failing loudly here instead of poisoning
+            # downstream tests.
+            await restore_auth(cdp_a, original_settings)
 
     finally:
         # ── 8. Cleanup: delete Clerk user ─────────────────────────
         clerk_client.delete_user(clerk_user_id)
         logger.info("Clerk user cleaned up: %s", test_email)
-
-
-# ── Private helpers ───────────────────────────────────────────────
-
-
-async def _swap_to_oauth(cdp, tokens: dict) -> None:
-    """Reconfigure Obsidian plugin to use OAuth auth via CDP.
-
-    Re-accepts the sync gate after the swap because the fingerprint
-    rotates with the auth/vault change — without the accept,
-    syncBlocked stays true and the post-swap fullSync silently no-ops.
-    """
-    refresh_token = json.dumps(tokens["refresh_token"])
-    vault_id = json.dumps(str(tokens["vault_id"]))
-    user_email = json.dumps(tokens.get("user_email", ""))
-
-    # IMPORTANT: do NOT blank apiKey. createAuthProvider() at main.ts:541
-    # picks refreshToken first, so setting refreshToken is enough — keeping
-    # apiKey populated leaves a safety net on disk if restore_auth crashes
-    # mid-flight. (Without this, a single restore failure cascades 401s
-    # through every later test on the same worker.)
-    js = f"""
-    (async function() {{
-        const plugin = {_P};
-        plugin.settings.refreshToken = {refresh_token};
-        plugin.settings.vaultId = {vault_id};
-        plugin.settings.userEmail = {user_email};
-        plugin.settings.authMethod = 'oauth';
-        await plugin.saveSettings();
-        plugin.authProvider = plugin.createAuthProvider();
-        if (plugin.authProvider) {{
-            plugin.api.setAuthProvider(plugin.authProvider);
-            if (plugin.noteStream) {{
-                plugin.noteStream.setAuthProvider(plugin.authProvider);
-            }}
-        }}
-        await plugin.markSyncGateAccepted();
-        return 'oauth configured';
-    }})()
-    """
-    result = await cdp.evaluate(js, await_promise=True)
-    logger.info("Plugin reconfigured to OAuth: %s", result)
-    await cdp.wait_for_plugin_ready(timeout=15)
-
-
-async def _restore_auth(cdp, original_settings_json: str) -> None:
-    """Restore Obsidian plugin to original auth settings via CDP."""
-    settings = json.loads(original_settings_json)
-    api_key = json.dumps(settings.get("apiKey", ""))
-    refresh_token = json.dumps(settings.get("refreshToken", ""))
-    vault_id = json.dumps(settings.get("vaultId", ""))
-    user_email = json.dumps(settings.get("userEmail", ""))
-    auth_method = json.dumps(settings.get("authMethod", "apikey"))
-
-    js = f"""
-    (async function() {{
-        const plugin = {_P};
-        plugin.settings.apiKey = {api_key};
-        plugin.settings.refreshToken = {refresh_token};
-        plugin.settings.vaultId = {vault_id};
-        plugin.settings.userEmail = {user_email};
-        plugin.settings.authMethod = {auth_method};
-        await plugin.saveSettings();
-        plugin.authProvider = plugin.createAuthProvider();
-        if (plugin.authProvider) {{
-            plugin.api.setAuthProvider(plugin.authProvider);
-            if (plugin.noteStream) {{
-                plugin.noteStream.setAuthProvider(plugin.authProvider);
-            }}
-        }}
-        await plugin.markSyncGateAccepted();
-        return 'auth restored';
-    }})()
-    """
-    result = await cdp.evaluate(js, await_promise=True)
-    logger.info("Plugin auth restored: %s", result)
-    await cdp.wait_for_plugin_ready(timeout=15)

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3797,21 +3797,28 @@ defmodule Engram.Notes do
     # scrub below is the last line of defense (#738): a caller that reaches this
     # site with unscrubbed content (a direct DB or CRDT write) would otherwise
     # ship invalid bytes that crash the V2 JSON serializer and take down PubSub.
-    payload =
-      Helpers.scrub_broadcast_payload(%{
-        "event_type" => "upsert",
-        "id" => note.id,
-        "path" => path,
-        "vault_id" => vault_id,
-        "content" => note.content || "",
-        "content_hash" => note.content_hash,
-        "title" => note.title || "",
-        "folder" => note.folder || "",
-        "tags" => note.tags || [],
-        "mtime" => note.mtime,
-        "updated_at" => note.updated_at,
-        "version" => note.version
-      })
+    # `content: nil` means the row is meta-projected (the folder-rename
+    # cascade reads meta columns only, #863) — the body exists but was never
+    # loaded. Fabricating `""` here shipped an empty body next to the REAL
+    # content_hash, and receivers materialized 0-byte files that then read
+    # as converged forever (e2e test_34). Omit the key instead: the plugin's
+    # hash-only branch fetches the body when `content` is absent.
+    base = %{
+      "event_type" => "upsert",
+      "id" => note.id,
+      "path" => path,
+      "vault_id" => vault_id,
+      "content_hash" => note.content_hash,
+      "title" => note.title || "",
+      "folder" => note.folder || "",
+      "tags" => note.tags || [],
+      "mtime" => note.mtime,
+      "updated_at" => note.updated_at,
+      "version" => note.version
+    }
+
+    base = if is_binary(note.content), do: Map.put(base, "content", note.content), else: base
+    payload = Helpers.scrub_broadcast_payload(base)
 
     topic = "sync:#{user_id}:#{vault_id}"
 

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -681,7 +681,6 @@ defmodule EngramWeb.NotesController do
       folder: note.folder || "",
       tags: note.tags || [],
       version: note.version,
-      content: note.content || "",
       # Protocol rev — clients store the server hash per path so hash-only
       # broadcasts / fields=meta pages can be compared without refetching.
       # The hash is keyed server-side (HMAC); clients treat it as opaque.
@@ -696,7 +695,20 @@ defmodule EngramWeb.NotesController do
       parse_status: note.parse_status,
       parse_reason: note.parse_reason
     }
+    |> put_content(note.content)
   end
+
+  # Boundary guard, same rule as Notes.broadcast_change (e2e test_34 class):
+  # nil content means a meta-projected struct leaked here (body exists, never
+  # loaded) — omit the key so clients fall back to fetching the body, instead
+  # of fabricating "" beside the REAL content_hash and seeding 0-byte files
+  # as converged forever. Genuinely empty notes are "" (is_binary) and keep
+  # serializing as "". nil is unreachable through today's callers (all
+  # full-load + decrypt); this pins the boundary for future projections.
+  # Public for the regression test only.
+  @doc false
+  def put_content(map, content) when is_binary(content), do: Map.put(map, :content, content)
+  def put_content(map, nil), do: map
 
   defp change_json(change, :meta) do
     %{
@@ -718,7 +730,7 @@ defmodule EngramWeb.NotesController do
   defp change_json(change, :all) do
     change
     |> change_json(:meta)
-    |> Map.put(:content, change.content || "")
+    |> put_content(change.content)
   end
 
   defp format_errors(changeset), do: EngramWeb.format_errors(changeset)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.671",
+      version: "0.5.672",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes_broadcast_test.exs
+++ b/test/engram/notes_broadcast_test.exs
@@ -142,6 +142,38 @@ defmodule Engram.NotesBroadcastTest do
       assert payload["path"] == "New/Child.md"
     end
 
+    # e2e test_34 "received=yes materialized=no": the cascade broadcasts
+    # meta-projected rows (content never decrypted), and the upsert payload
+    # fabricated `"content" => ""` next to the REAL content_hash. Receivers
+    # took the empty body as authoritative and materialized 0-byte files,
+    # then read as converged forever (hash("") seeded against the real
+    # serverHash). The key must be ABSENT when content is unloaded — the
+    # plugin's hash-only branch fetches the body on absence.
+    test "cascade upsert omits the content key (never fabricates empty)", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, child} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Old/Child.md",
+          "content" => "# Child",
+          "mtime" => 1.0
+        })
+
+      EngramWeb.Endpoint.subscribe("sync:#{user.id}:#{vault.id}")
+
+      assert {:ok, 1} = Notes.rename_folder(user, vault, "Old", "New")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "note_changed",
+        payload: %{"event_type" => "upsert"} = payload
+      }
+
+      refute Map.has_key?(payload, "content")
+      assert payload["content_hash"] == child.content_hash
+      assert is_binary(payload["content_hash"])
+    end
+
     # #976: the old-path delete leg used to broadcast without the note id,
     # forcing receivers to resolve by path mid-relocation — the ambiguity
     # window the folder-rename resurrection bug lived in. The note still

--- a/test/engram_web/controllers/notes_controller_test.exs
+++ b/test/engram_web/controllers/notes_controller_test.exs
@@ -432,6 +432,38 @@ defmodule EngramWeb.NotesControllerTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Serializer nil-content boundary (same class as the broadcast_change fix,
+  # e2e test_34): a meta-projected struct whose content was never loaded must
+  # OMIT the content key, never fabricate "" beside a real content_hash.
+  # nil cannot reach note_json/change_json through today's callers (all of
+  # them full-load + decrypt), so this pins the boundary directly: a future
+  # projection leak fails as a missing key (the plugin fetches on absence)
+  # instead of a silent 0-byte file seeded as converged forever.
+  describe "serializer nil-content guard" do
+    test "put_content omits the key for nil and keeps genuinely empty content" do
+      refute Map.has_key?(EngramWeb.NotesController.put_content(%{}, nil), :content)
+      assert EngramWeb.NotesController.put_content(%{}, "") == %{content: ""}
+      assert EngramWeb.NotesController.put_content(%{}, "# X") == %{content: "# X"}
+    end
+
+    test "genuinely empty note keeps content == \"\" on GET and changes pages", %{
+      conn: conn
+    } do
+      post(conn, "/api/notes", %{path: "Test/Empty.md", content: "", mtime: 1_000.0})
+
+      body = conn |> get("/api/notes/Test/Empty.md") |> json_response(200)
+      assert body["content"] == ""
+
+      %{"changes" => changes} =
+        conn
+        |> get("/api/notes/changes?since=2020-01-01T00:00:00Z")
+        |> json_response(200)
+
+      change = Enum.find(changes, &(&1["path"] == "Test/Empty.md"))
+      assert change["content"] == ""
+    end
+  end
+
   # GET /notes/changes
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes two of the three dominant e2e-clerk CI flake classes from the 2026-07-14 triage (17 of 24 recent e2e-clerk failures were three deterministic code seams, not runner load). See `docs/context/e2e-clerk-failure-triage-2026-07-14.md` in engram-workspace for the full evidence chain.

## 1. test_34 class (6 recent failures): omit `content` on meta-projected upsert broadcasts

The folder-rename cascade broadcasts rows whose content was never decrypted (meta-only projection, #863), and `broadcast_change` fabricated `"content" => ""` next to the REAL `content_hash`. Receivers took the empty body as authoritative and materialized 0-byte files, then read as converged forever: hash("") was seeded against the real serverHash, so the pull backstop, push echo gate, and exists-checks all passed. Proof: `E2E/RenamedFolder34/Note1.md` is 0 bytes in run 29379404108's device-B vault tarball while the server had real content.

Fix: the payload omits the `content` key when `note.content` is nil. The plugin's hash-only branch already fetches the body when the key is absent (that branch's comment even names the folder-rename case). Genuinely empty notes still carry `content: ""` (real binary), behavior unchanged.

Audited the adjacent `CrdtDeliver.deliver_out(..., note.content || "")` for the same projection hole: safe as-is. Its `{:ok, nil}` + empty-content clause already skips exactly this case (the comment there cites the cascade), and the stored-state path never reads the content argument.

Regression test: cascade upsert broadcast must not contain a `content` key and must still carry the real `content_hash` (fails on main with `"content" => ""`).

## 2. test_84 class (7 recent failures): test_44 drops its private pre-fix OAuth helpers

test_44 kept private `_swap_to_oauth`/`_restore_auth` copies that missed the Engram-obsidian#229 ordering fix: `saveSettings()` ran BEFORE the new auth provider was wired, so the rebuilt channel froze its topic userId from the OLD identity. test_44 itself passed, leaving the session-scoped instance A cross-bound (run 29368833936: `sync:`/`user:`/`crdt:` joins all rejected unauthorized at 21:35:44), and every later test needing A's live stream died with `crdtJoinFailedReason:"unauthorized"`.

Fix: delete the private copies (~90 lines), use the shared `helpers/oauth.py` `swap_to_oauth`/`restore_auth`, which have the correct ordering, accessToken staleness clearing, and a restore-site stream verify that fails loudly in test_44 instead of 3 tests downstream.

A plugin sibling PR (Engram-obsidian) hardens the other half of this class: setting `identityMaybeStale` on an unauthorized CRDT join so any future ordering mistake self-heals in one backoff cycle.

## Gates

- mix format, credo --strict, sobelow, dialyzer: clean
- Full mix test: 3729 tests, 0 failures (8 excluded)


## Review follow-up: REST serializer boundary guard

The code review flagged that note_json and change_json(:all) kept the same `content || ""` fabrication the broadcast fix removed. Verified: nil content is unreachable at both sites today (every caller full-loads and decrypts; the changes endpoint loads full rows for the default fields mode, and soft delete only sets deleted_at). Added the guard anyway as defense at the boundary via a shared put_content/2 both serializers route through: nil omits the key (plugin falls back to a body fetch, SPA already does `content ?? ""`), genuinely empty notes still serialize `content: ""` (regression-tested on GET and changes pages). MCP has its own serializer whose callers also full-load; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019omnopWqAww7rfxG9Yp47i

