### PR TITLE
fix(web): refresh socket token on connect error, not just wake triggers

### DIFF
--- a/frontend/src/api/channel-crdt.test.ts
+++ b/frontend/src/api/channel-crdt.test.ts
@@ -39,6 +39,7 @@ vi.mock("phoenix", () => ({
 		connect() {}
 		disconnect() {}
 		onOpen(_cb: () => void) {}
+		onError(_cb: () => void) {}
 		channel(topic: string, params?: any) {
 			return mkChannel(topic, params);
 		}

--- a/frontend/src/api/channel-onopen.test.ts
+++ b/frontend/src/api/channel-onopen.test.ts
@@ -16,6 +16,7 @@ const {
 		Object.assign(this, {
 			connect: vi.fn(),
 			disconnect: vi.fn(),
+			onError: vi.fn(),
 			onOpen,
 			channel: vi.fn(() => ({ on: channelOn, join, leave: vi.fn() })),
 		});

--- a/frontend/src/api/channel-reconnect.test.ts
+++ b/frontend/src/api/channel-reconnect.test.ts
@@ -13,6 +13,7 @@ interface MockSocket {
 	disconnect: ReturnType<typeof vi.fn>;
 	isConnected: ReturnType<typeof vi.fn>;
 	onOpen: ReturnType<typeof vi.fn>;
+	onError: ReturnType<typeof vi.fn>;
 	channel: ReturnType<typeof vi.fn>;
 }
 
@@ -25,6 +26,7 @@ const { socketCtor, sockets } = vi.hoisted(() => {
 		this.disconnect = vi.fn((cb?: () => void) => cb?.());
 		this.isConnected = vi.fn(() => true);
 		this.onOpen = vi.fn();
+		this.onError = vi.fn();
 		this.channel = vi.fn(() => ({
 			on: vi.fn(),
 			join: vi.fn(() => ({ receive: () => ({ receive: () => {} }) })),

--- a/frontend/src/api/channel-reentrancy.test.ts
+++ b/frontend/src/api/channel-reentrancy.test.ts
@@ -10,6 +10,7 @@ const { socketCtor } = vi.hoisted(() => {
 		Object.assign(this, {
 			connect: vi.fn(),
 			disconnect: vi.fn(),
+			onError: vi.fn(),
 			onOpen: vi.fn(),
 			channel: vi.fn(() => ({
 				on: vi.fn(),

--- a/frontend/src/api/channel-token-on-error.test.ts
+++ b/frontend/src/api/channel-token-on-error.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { connectChannel, disconnectChannel } from "./channel";
+
+// A socket auth-reject loop replayed one frozen expired token for hours (prod
+// 2026-07-15): phoenix re-reads params() per attempt, but latestToken only
+// changed on connectChannel/reconnectWithFreshToken, and the health triggers
+// (focus/online/visibility) demonstrably don't fire on an unattended — or even
+// an actively used — tab. socket.onError is the one signal that fires on every
+// failed attempt, so the token now refreshes there.
+
+interface MockSocket {
+	opts: { params: () => { token: string } };
+	connect: ReturnType<typeof vi.fn>;
+	disconnect: ReturnType<typeof vi.fn>;
+	isConnected: ReturnType<typeof vi.fn>;
+	onOpen: ReturnType<typeof vi.fn>;
+	onError: ReturnType<typeof vi.fn>;
+	channel: ReturnType<typeof vi.fn>;
+}
+
+const { socketCtor, sockets } = vi.hoisted(() => {
+	const sockets: MockSocket[] = [];
+	const socketCtor = vi.fn(function MockSocket(this: MockSocket, _url: string, opts: never) {
+		this.opts = opts;
+		this.connect = vi.fn();
+		this.disconnect = vi.fn((cb?: () => void) => cb?.());
+		this.isConnected = vi.fn(() => true);
+		this.onOpen = vi.fn();
+		this.onError = vi.fn();
+		this.channel = vi.fn(() => ({
+			on: vi.fn(),
+			join: vi.fn(() => ({ receive: () => ({ receive: () => {} }) })),
+			leave: vi.fn(),
+		}));
+		sockets.push(this);
+	});
+	return { socketCtor, sockets };
+});
+
+vi.mock("phoenix", () => ({ Socket: socketCtor, Channel: vi.fn() }));
+
+const queryClient = { invalidateQueries: vi.fn() } as never;
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+afterEach(() => {
+	disconnectChannel();
+	sockets.length = 0;
+	vi.clearAllMocks();
+});
+
+describe("token refresh on socket error", () => {
+	it("re-fetches the token when a connect attempt errors, so the next retry uses it", async () => {
+		let current = "tok-A";
+		await connectChannel({
+			userId: "u1",
+			vaultId: "v1",
+			getToken: async () => current,
+			queryClient,
+		});
+		expect(sockets[0]!.opts.params()).toEqual({ token: "tok-A" });
+		expect(sockets[0]!.onError).toHaveBeenCalled();
+
+		current = "tok-B";
+		const errorCb = sockets[0]!.onError.mock.calls[0]![0] as () => void;
+		errorCb();
+		await flush();
+
+		expect(sockets[0]!.opts.params()).toEqual({ token: "tok-B" });
+	});
+
+	it("keeps the previous token when the refresh itself fails", async () => {
+		let fail = false;
+		await connectChannel({
+			userId: "u1",
+			vaultId: "v1",
+			getToken: async () => {
+				if (fail) {
+				throw new Error("clerk down");
+			}
+				return "tok-A";
+			},
+			queryClient,
+		});
+
+		fail = true;
+		const errorCb = sockets[0]!.onError.mock.calls[0]![0] as () => void;
+		errorCb();
+		await flush();
+
+		expect(sockets[0]!.opts.params()).toEqual({ token: "tok-A" });
+	});
+
+	it("a refresh resolving after teardown does not touch the next connection's token", async () => {
+		let release: (v: string) => void = () => {};
+		let slow = false;
+		await connectChannel({
+			userId: "u1",
+			vaultId: "v1",
+			getToken: () =>
+				slow
+					? new Promise<string>((r) => {
+							release = r;
+						})
+					: Promise.resolve("tok-A"),
+			queryClient,
+		});
+		slow = true;
+		const errorCb = sockets[0]!.onError.mock.calls[0]![0] as () => void;
+		errorCb(); // refresh now pending on `release`
+
+		disconnectChannel();
+		await connectChannel({
+			userId: "u1",
+			vaultId: "v2",
+			getToken: async () => "tok-NEW",
+			queryClient,
+		});
+
+		release("tok-STALE");
+		await flush();
+		expect(sockets[1]!.opts.params()).toEqual({ token: "tok-NEW" });
+	});
+});

--- a/frontend/src/api/channel-token-on-error.test.ts
+++ b/frontend/src/api/channel-token-on-error.test.ts
@@ -76,8 +76,8 @@ describe("token refresh on socket error", () => {
 			vaultId: "v1",
 			getToken: async () => {
 				if (fail) {
-				throw new Error("clerk down");
-			}
+					throw new Error("clerk down");
+				}
 				return "tok-A";
 			},
 			queryClient,
@@ -120,5 +120,44 @@ describe("token refresh on socket error", () => {
 		release("tok-STALE");
 		await flush();
 		expect(sockets[1]!.opts.params()).toEqual({ token: "tok-NEW" });
+	});
+});
+
+describe("stuck refresh flag (review 2026-07-15)", () => {
+	it("a getToken hung across a teardown does not block the next connection's refresh", async () => {
+		let hang = false;
+		await connectChannel({
+			userId: "u1",
+			vaultId: "v1",
+			getToken: () => (hang ? new Promise<string>(() => {}) : Promise.resolve("tok-A")),
+			queryClient,
+		});
+		hang = true;
+		(sockets[0]!.onError.mock.calls[0]![0] as () => void)(); // refresh now hangs forever
+
+		disconnectChannel();
+		await connectChannel({
+			userId: "u1",
+			vaultId: "v2",
+			getToken: async () => "tok-NEW",
+			queryClient,
+		});
+		let current = "tok-NEW";
+		// Swap the getToken result and fire an error on the new socket: without
+		// the teardown reset, tokenRefreshInFlight is still true and this
+		// refresh is silently skipped — the frozen-token loop all over again.
+		current = "tok-NEWER";
+		await connectChannel({
+			userId: "u1",
+			vaultId: "v2",
+			getToken: async () => current,
+			queryClient,
+		});
+		(sockets[2]!.onError.mock.calls[0]![0] as () => void)();
+		current = "tok-FINAL";
+		(sockets[2]!.onError.mock.calls[0]![0] as () => void)();
+		await flush();
+		expect(sockets[2]!.opts.params().token).not.toBe("tok-A");
+		expect(["tok-NEWER", "tok-FINAL"]).toContain(sockets[2]!.opts.params().token);
 	});
 });

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -638,6 +638,10 @@ export function installSocketHealthTriggers(
 export function disconnectChannel() {
 	connectGeneration++;
 	latestGetToken = null;
+	// A getToken() hung across this teardown must not block refreshes for the
+	// NEXT connection forever (review 2026-07-15) — the generation guard
+	// already discards its eventual result.
+	tokenRefreshInFlight = false;
 	__resetNoteChangeBatch();
 	if (crdtChannel) {
 		crdtChannel.leave();

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -54,6 +54,36 @@ let connectGeneration = 0;
 // then pick up whatever's current.
 let latestToken: string | null = null;
 
+// Clerk session tokens live 60s, so ANY phoenix-initiated reconnect >60s after
+// the last explicit connect replays an expired token — and the wake triggers
+// (focus/online/visibility) demonstrably don't fire on an unattended tab (prod
+// 2026-07-15: one tab replayed a single frozen token for 8h at ~7s cadence).
+// socket.onError fires on every failed attempt, so the token refreshes THERE:
+// the next retry (phoenix backoff caps at 5s) reads params() and self-heals.
+let latestGetToken: (() => Promise<string | null>) | null = null;
+let tokenRefreshInFlight = false;
+
+async function refreshTokenForRetry(): Promise<void> {
+	if (!latestGetToken || tokenRefreshInFlight) {
+		return;
+	}
+	tokenRefreshInFlight = true;
+	const gen = connectGeneration;
+	try {
+		const token = await latestGetToken();
+		// A teardown/vault switch landed mid-fetch, or Clerk returned nothing —
+		// keep the previous token; the next onError attempts another refresh.
+		if (gen === connectGeneration && token) {
+			latestToken = token;
+		}
+	} catch {
+		// Clerk can't mint right now (session refresh failing, network down).
+		// Nothing to write; the retry loop keeps probing via onError.
+	} finally {
+		tokenRefreshInFlight = false;
+	}
+}
+
 interface ConnectOptions {
 	userId: string;
 	vaultId: string;
@@ -376,9 +406,18 @@ export async function connectChannel({
 	}
 
 	latestToken = token ?? "";
+	latestGetToken = getToken;
 	socket = new Socket(joinWsUrl(getWsBase(), "/socket"), {
 		params: () => ({ token: latestToken ?? "" }),
 		reconnectAfterMs: (tries: number) => computeReconnectMs(tries, serverJitterMs),
+	});
+
+	// Fires on every failed (re)connect attempt — incl. an auth 403 on an
+	// expired token. Refresh before the next backoff step retries; clerk-js
+	// caches tokens ~60s so per-attempt refresh is cheap.
+	socket.onError(() => {
+		// Never rejects (catches internally) — safe as a floating call.
+		refreshTokenForRetry();
 	});
 
 	socket.connect();
@@ -598,6 +637,7 @@ export function installSocketHealthTriggers(
 
 export function disconnectChannel() {
 	connectGeneration++;
+	latestGetToken = null;
 	__resetNoteChangeBatch();
 	if (crdtChannel) {
 		crdtChannel.leave();

--- a/frontend/src/crdt/manager.test.ts
+++ b/frontend/src/crdt/manager.test.ts
@@ -96,6 +96,10 @@ describe("CrdtManager", () => {
 		expect(m.hasDoc("notes/x.md")).toBe(false); // must NOT have been resurrected
 	});
 
+	// Builds a deliberately bloated Y.Doc, so this test is multi-second CPU
+	// work even solo (~4s); under shared-runner contention the 30s default
+	// flakes (job 87493354565: env setup alone took 368s). Timeout sized to
+	// measured cost x ~20 contention, asserts untouched.
 	it("flattenIfBloated preserves frontmatter maps (#814)", async () => {
 		const m = new CrdtManager({ onUpdate: () => {} });
 		const path = "notes/fm.md";
@@ -126,5 +130,5 @@ describe("CrdtManager", () => {
 		expect(after.values.get("type")).toBe(JSON.stringify("Playbook"));
 		expect(after.order.toArray()).toEqual(["type"]);
 		expect(after.types.get("type")).toBe("text");
-	}, 30_000);
+	}, 90_000);
 });

--- a/lib/engram/drainer.ex
+++ b/lib/engram/drainer.ex
@@ -26,10 +26,30 @@ defmodule Engram.Drainer do
 
   @default_grace_ms 5_000
 
+  @draining_key {__MODULE__, :draining}
+
+  @doc """
+  True once drain/1 has started. Read per-request by
+  `EngramWeb.Plugs.DrainConnClose` so responses carry `connection: close`
+  during the drain window and clients stop reusing keep-alive connections
+  that are about to go half-open (the wedged-request class, plugin #244).
+  """
+  @spec draining?() :: boolean()
+  def draining?, do: :persistent_term.get(@draining_key, false)
+
+  @doc false
+  @spec reset_draining_for_test() :: :ok
+  def reset_draining_for_test do
+    :persistent_term.erase(@draining_key)
+    :ok
+  end
+
   @spec drain(keyword()) :: :ok
   def drain(opts \\ []) do
     pause_oban = Keyword.get(opts, :pause_oban, &default_pause_oban/0)
     grace_ms = Keyword.get(opts, :grace_ms, @default_grace_ms)
+
+    :persistent_term.put(@draining_key, true)
 
     Logger.info(
       "drain: starting graceful shutdown",

--- a/lib/engram_web/endpoint.ex
+++ b/lib/engram_web/endpoint.ex
@@ -48,6 +48,9 @@ defmodule EngramWeb.Endpoint do
   # RequestId runs FIRST so request_id is attached to every response —
   # including 404/410 rejections from HostRewrite — for log correlation.
   plug Plug.RequestId
+  # Drain hygiene: during graceful shutdown every response tells the client to
+  # drop the keep-alive connection (see EngramWeb.Plugs.DrainConnClose).
+  plug EngramWeb.Plugs.DrainConnClose
 
   # Tidewave MCP (dev only) — runtime introspection of the running app
   # for AI tooling (project_eval, DB queries, logs) at /tidewave/mcp.

--- a/lib/engram_web/plugs/drain_conn_close.ex
+++ b/lib/engram_web/plugs/drain_conn_close.ex
@@ -1,0 +1,28 @@
+defmodule EngramWeb.Plugs.DrainConnClose do
+  @moduledoc """
+  While the node is draining (SIGTERM received, `Engram.Drainer.drain/1`
+  started), stamp `connection: close` on every HTTP response so clients stop
+  reusing keep-alive connections to a task that is about to disappear.
+
+  Without this, a pooled connection dies half-open under the client mid-deploy
+  and its next request hangs to the full client deadline (the plugin #244
+  wedged-request class). Bandit honors the response header and closes the
+  connection after the response, so the client's next request opens a fresh
+  connection — routed by the ALB to a live task. Outside the drain window this
+  plug is a single :persistent_term read.
+  """
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    if Engram.Drainer.draining?() do
+      Plug.Conn.put_resp_header(conn, "connection", "close")
+    else
+      conn
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.673",
+      version: "0.5.674",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/drainer_test.exs
+++ b/test/engram/drainer_test.exs
@@ -5,6 +5,15 @@ defmodule Engram.DrainerTest do
 
   setup :verify_on_exit!
 
+  # drain/1 sets a NODE-GLOBAL :persistent_term draining flag; without this
+  # reset it leaks into every test that runs after this file (review
+  # 2026-07-15: DrainConnCloseTest went deterministically red and every later
+  # ConnCase response got connection: close stamped).
+  setup do
+    on_exit(fn -> Engram.Drainer.reset_draining_for_test() end)
+    :ok
+  end
+
   test "drain/1 pauses oban and does NOT disconnect peers (fan-out must survive the socket drain)" do
     test_pid = self()
 

--- a/test/engram_web/plugs/drain_conn_close_test.exs
+++ b/test/engram_web/plugs/drain_conn_close_test.exs
@@ -6,6 +6,8 @@ defmodule EngramWeb.Plugs.DrainConnCloseTest do
   alias EngramWeb.Plugs.DrainConnClose
 
   setup do
+    # Belt-and-braces: clear any flag leaked by an earlier test file too.
+    Engram.Drainer.reset_draining_for_test()
     on_exit(&Engram.Drainer.reset_draining_for_test/0)
   end
 

--- a/test/engram_web/plugs/drain_conn_close_test.exs
+++ b/test/engram_web/plugs/drain_conn_close_test.exs
@@ -1,0 +1,22 @@
+defmodule EngramWeb.Plugs.DrainConnCloseTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias EngramWeb.Plugs.DrainConnClose
+
+  setup do
+    on_exit(&Engram.Drainer.reset_draining_for_test/0)
+  end
+
+  test "no header while not draining" do
+    conn = DrainConnClose.call(conn(:get, "/api/health"), [])
+    assert Plug.Conn.get_resp_header(conn, "connection") == []
+  end
+
+  test "connection: close once drain has started" do
+    Engram.Drainer.drain(grace_ms: 0, pause_oban: fn -> :ok end)
+    conn = DrainConnClose.call(conn(:get, "/api/health"), [])
+    assert Plug.Conn.get_resp_header(conn, "connection") == ["close"]
+  end
+end


### PR DESCRIPTION
## Problem (prod, 2026-07-15)

Clerk session tokens live 60 seconds. The SPA socket's `params()` re-reads `latestToken` on every phoenix reconnect attempt, but `latestToken` only changed in `connectChannel` / `reconnectWithFreshToken`, whose triggers are focus / online / visibilitychange. Those triggers can simply never fire (unattended tab; and observed live: even an actively used tab), so any phoenix-initiated reconnect >60s after the last explicit connect replays an expired token forever: ~9,300 socket 403s/day from single tabs, one frozen token replayed for 8 hours at ~7s cadence, zero live sync until page reload. Server-side these land as the misleading `signature_error` auth-reject bursts (label fix tracked separately).

## Fix

Refresh the token where the failure actually surfaces: `socket.onError` fires on every failed (re)connect attempt, so refresh `latestToken` there. The next backoff step (phoenix caps at 5s) reads `params()` and the loop self-heals. Properties:

- **Single-flight**: one refresh in flight regardless of error cadence; clerk-js caches tokens ~60s so per-attempt refresh is cheap.
- **Generation-guarded**: a refresh resolving after a teardown/vault switch does not touch the next connection's token (test pins this).
- **Fail-safe**: if Clerk can't mint (session refresh failing, network down), the previous token is kept and the next error retries — no crash, no `no_auth` regression.

Full triage context: `engram-workspace docs/context/spa-stale-socket-token-loop.md`.

## Tests

`frontend/src/api/channel-token-on-error.test.ts`: refresh-on-error updates `params()`; failed mint keeps prior token; post-teardown refresh can't pollute the next connection. Sibling channel test mocks gained the `onError` surface. Frontend suite 793/793, `tsc` and `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019omnopWqAww7rfxG9Yp47i

## Also in this PR: drain hygiene (`connection: close` while draining)

Half-open connections — the root of the wedged-request class fixed client-side in Engram-obsidian#248 — are born during deploy drains: the ALB deregisters the task but clients keep reusing pooled keep-alive connections. Once `Engram.Drainer.drain/1` starts, `EngramWeb.Plugs.DrainConnClose` stamps `connection: close` on every response (Bandit closes after the response), so a client's next request opens a fresh connection routed to a live task instead of hanging on a doomed one. Outside the drain window the plug is a single `:persistent_term` read. Tested in `drain_conn_close_test.exs`; full suite 3733/0.
