### PR TITLE
fix(e2e): version-agnostic fanout-backstop stubs (coldReceive→catchupViaSocket)

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -964,7 +964,9 @@ class CdpClient:
             can STEP1-enroll the note's CRDT room (sync.ts:3246); an open room's
             ``crdt_msg`` stream would then deliver the body independently.
 
-        This stubs ``pull()``, ``coldReceive()`` and ``handleStreamEvent`` to
+        This stubs ``pull()``, the cold-apply backstop (``coldReceive()``
+        pre-rewire / ``catchupViaSocket()`` post-authoritative-rewire — stubs
+        whichever the paired plugin build exposes) and ``handleStreamEvent`` to
         no-ops (saving originals). The fan-out is a SEPARATE channel dispatch:
         ``channel.ts`` routes ``note_yjs_update`` straight to ``onNoteYjsUpdate``
         → ``applyPushedNoteUpdate`` and never touches any stubbed method, so it
@@ -978,12 +980,16 @@ class CdpClient:
             const se = {ENGINE_PATH};
             if (se.__fanoutIsolated) return 'already-isolated';
             se.__fanoutIsolated = true;
-            se.__origPull = se.pull.bind(se);
-            se.__origColdReceive = se.coldReceive.bind(se);
-            se.__origHandleStreamEvent = se.handleStreamEvent.bind(se);
-            se.pull = async () => 0;
-            se.coldReceive = async () => 0;
-            se.handleStreamEvent = async () => {{}};
+            // The cold-note apply backstop was renamed coldReceive ->
+            // catchupViaSocket in the authoritative-sync rewire. backend-main
+            // e2e pairs against EITHER plugin branch, so stub whichever method
+            // exists and never .bind() an absent one (guards future renames).
+            for (const m of ['pull', 'coldReceive', 'catchupViaSocket', 'handleStreamEvent']) {{
+                if (typeof se[m] === 'function') {{
+                    se['__orig_' + m] = se[m].bind(se);
+                    se[m] = m === 'handleStreamEvent' ? async () => {{}} : async () => 0;
+                }}
+            }}
             return 'isolated';
         }})()
         """
@@ -997,12 +1003,10 @@ class CdpClient:
         (function() {{
             const se = {ENGINE_PATH};
             if (!se.__fanoutIsolated) return 'not-isolated';
-            if (se.__origPull) se.pull = se.__origPull;
-            if (se.__origColdReceive) se.coldReceive = se.__origColdReceive;
-            if (se.__origHandleStreamEvent) se.handleStreamEvent = se.__origHandleStreamEvent;
-            delete se.__origPull;
-            delete se.__origColdReceive;
-            delete se.__origHandleStreamEvent;
+            for (const m of ['pull', 'coldReceive', 'catchupViaSocket', 'handleStreamEvent']) {{
+                const orig = se['__orig_' + m];
+                if (orig) {{ se[m] = orig; delete se['__orig_' + m]; }}
+            }}
             delete se.__fanoutIsolated;
             return 'restored';
         }})()


### PR DESCRIPTION
## What

`e2e/helpers/cdp.py::suppress_fanout_backstops()` hard-called `se.coldReceive.bind(se)`. The authoritative-sync rewire (plugin **#251**) renamed that cold-note apply backstop `coldReceive()` → `catchupViaSocket()`, so when backend-main e2e paired against the rewire branch the helper threw:

```
TypeError: Cannot read properties of undefined (reading 'bind')
```

…and aborted **before the fan-out was exercised**, failing all four fanout tests with a **stale-harness crash, not a real fan-out regression**:
`test_idle_note_converges_via_fanout_only`, `test_concurrent_cold_edits_survive_over_fanout`, `test_cold_send_over_fanout_opens_no_room`, `test_fanout_receive_after_hibernate_rehydrates`.

## Fix

Stub whichever of `pull` / `coldReceive` / `catchupViaSocket` / `handleStreamEvent` **exists** (typeof guard), so the helper pairs cleanly against plugin `main` (`coldReceive`) **and** the rewire branch (`catchupViaSocket`), and no future rename can hard-crash it. `catchupViaSocket` must be stubbed too — it's the checkpoint/reconnect backstop that would otherwise mask a broken fan-out, keeping the four tests true fan-out proofs.

## Why this lands first

Cross-repo ordering: this must be on backend `main` **before** #251 merges to plugin `main`, else the moment the rewire lands, backend-main e2e (paired vs plugin main = rewire) crashes those four tests again. Version-agnostic guarding satisfies both plugin branches simultaneously.

## Verification
- This branch's own CI pairs against plugin `main` → proves no regression on the `coldReceive` path.
- A `plugin_branch=feat/crdt-authoritative-rewire` dispatch verifies the four fanout tests now truly pass against the rewire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)