### PR TITLE
feat(sync): carry decrypted path in CRDT catch-up head map

### DIFF
--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -222,18 +222,36 @@ defmodule Engram.Notes.CrdtTransport do
   end
 
   @doc """
-  Map every note in the vault to its head marker so a client can diff against
-  its local per-note heads and learn which cold notes advanced.
+  Map every note in the vault to its decrypted `path` and head marker so a
+  client can (a) diff against its local per-note heads to learn which cold
+  notes advanced AND (b) DISCOVER + place a never-seen note from the head map
+  alone — no `/manifest` or `note_changed` round-trip needed for discovery.
 
-  Reads the persisted `crdt_head` column — O(notes) cheap row reads, NO doc
-  rebuilds. The column is NULLed on every CRDT-state change (`update_v1` on a
+  Reads the persisted `crdt_head` column (O(notes) cheap row reads, NO doc
+  rebuilds) and DECRYPTS each note's Phase-B `path_ciphertext` server-side with
+  the caller's DEK — the same per-path AES-GCM decrypt `/manifest` pays. Path
+  payloads decrypt in ~µs each; the added cost is bounded per-vault and matches
+  the manifest's, so this is no longer a pure column read.
+
+  The `crdt_head` column is NULLed on every CRDT-state change (`update_v1` on a
   tail append; a `crdt_state_ciphertext` trigger on any snapshot write), and a
   NULL is self-healed once here via `backfill_head/3`; the `BackfillCrdtHead`
   worker warms NULLs in the background so a live poll rarely pays that cost. So
-  steady-state cost is O(notes changed since the last poll), not O(vault).
+  steady-state head cost is O(notes changed since the last poll), not O(vault).
+
+  A note whose path is missing/undecryptable is SKIPPED (logged), never fatal —
+  one bad row must not sink the whole vault head map. No DEK (brand-new user,
+  zero writes) → empty map, same short-circuit `/manifest` uses.
   """
-  @spec vault_heads(map(), map()) :: %{String.t() => String.t()}
+  @spec vault_heads(map(), map()) :: %{String.t() => %{path: String.t(), head: String.t()}}
   def vault_heads(user, vault) do
+    case Crypto.get_dek(user) do
+      {:ok, dek} -> vault_heads_with_dek(user, vault, dek)
+      {:error, :no_dek} -> %{}
+    end
+  end
+
+  defp vault_heads_with_dek(user, vault, dek) do
     {:ok, rows} =
       Repo.with_tenant(user.id, fn ->
         Note
@@ -242,21 +260,71 @@ defmodule Engram.Notes.CrdtTransport do
           n.vault_id == ^vault.id and n.user_id == ^user.id and is_nil(n.deleted_at) and
             n.kind == "note"
         )
-        |> select([n], {n.id, n.crdt_head})
+        |> select([n], {n.id, n.crdt_head, n.dek_version, n.path_ciphertext, n.path_nonce})
         |> Repo.all()
       end)
 
-    Enum.reduce(rows, %{}, fn
-      {note_id, nil}, acc ->
-        case backfill_head(user, vault, note_id) do
-          {:ok, head} -> Map.put(acc, note_id, head)
-          {:error, :not_found} -> acc
-        end
-
-      {note_id, head}, acc ->
-        Map.put(acc, note_id, head)
+    Enum.reduce(rows, %{}, fn {note_id, crdt_head, dek_version, path_ct, path_nonce}, acc ->
+      # Path first: it's the cheap guarded decrypt, and a bad path skips the note
+      # BEFORE the expensive head self-heal (whose load_doc would itself raise on
+      # the same corrupt row). One bad row is dropped, the vault map survives.
+      with {:ok, path} <- decrypt_row_path(note_id, dek_version, path_ct, path_nonce, dek),
+           {:ok, head} <- resolve_head(user, vault, note_id, crdt_head) do
+        Map.put(acc, note_id, %{path: path, head: head})
+      else
+        _ -> acc
+      end
     end)
   end
+
+  # A warmed head passes through; a NULL is self-healed once (a deleted-note
+  # race returns :not_found → drop it from the map).
+  defp resolve_head(_user, _vault, _note_id, head) when is_binary(head), do: {:ok, head}
+
+  defp resolve_head(user, vault, note_id, nil) do
+    case backfill_head(user, vault, note_id) do
+      {:ok, head} -> {:ok, head}
+      {:error, :not_found} -> :skip
+    end
+  end
+
+  # Decrypt one note's path with the same AAD scheme /manifest uses (v ≥ 2 rows
+  # are AAD-bound to "notes:path:<id>"; legacy v = 1 rows decrypt with empty
+  # AAD). Unlike /manifest this NEVER raises: a missing/undecryptable path is
+  # logged and the note is skipped from the head map, so one corrupt row can't
+  # sink the whole vault's discovery feed.
+  defp decrypt_row_path(note_id, _dek_version, nil, _nonce, _dek) do
+    Logger.warning(
+      "vault_heads: note has no path ciphertext, skipping",
+      Metadata.with_category(:warn, :sync, note_id: note_id)
+    )
+
+    :error
+  end
+
+  defp decrypt_row_path(note_id, dek_version, path_ct, path_nonce, dek) do
+    aad = path_aad(note_id, dek_version)
+
+    case Crypto.Envelope.decrypt(path_ct, path_nonce, dek, aad) do
+      {:ok, path} ->
+        {:ok, path}
+
+      :error ->
+        Logger.warning(
+          "vault_heads: note path decrypt failed, skipping",
+          Metadata.with_category(:warn, :sync, note_id: note_id)
+        )
+
+        :error
+    end
+  end
+
+  # v ≥ 2 rows are AAD-bound to "notes:path:<id>"; legacy v = 1 rows used empty
+  # AAD. Mirrors SyncController.manifest's path_aad/3.
+  defp path_aad(note_id, dek_version) when is_integer(dek_version) and dek_version >= 2,
+    do: Crypto.aad_for_row(:notes, :path, note_id)
+
+  defp path_aad(_note_id, _dek_version), do: <<>>
 
   @doc """
   Rebuild a note's doc once, compute its head marker, persist it to the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.676",
+      version: "0.5.677",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_transport_test.exs
+++ b/test/engram/notes/crdt_transport_test.exs
@@ -206,8 +206,44 @@ defmodule Engram.Notes.CrdtTransportTest do
         Notes.upsert_note(user, vault, %{path: "H/A.md", content: "# A edited", mtime: 2_000.0})
 
       heads1 = CrdtTransport.vault_heads(user, vault)
-      assert heads1[a.id] != heads0[a.id], "edited note's head must advance"
-      assert heads1[b.id] == heads0[b.id], "untouched note's head must be stable"
+      assert heads1[a.id].head != heads0[a.id].head, "edited note's head must advance"
+      assert heads1[b.id].head == heads0[b.id].head, "untouched note's head must be stable"
+    end
+
+    test "each entry carries the note's DECRYPTED path alongside its head",
+         %{user: user, vault: vault} do
+      {:ok, a} =
+        Notes.upsert_note(user, vault, %{path: "H/nested/A.md", content: "# A", mtime: 1_000.0})
+
+      {:ok, b} = Notes.upsert_note(user, vault, %{path: "H/B.md", content: "# B", mtime: 1_000.0})
+
+      heads = CrdtTransport.vault_heads(user, vault)
+
+      assert %{path: "H/nested/A.md", head: ha} = heads[a.id]
+      assert %{path: "H/B.md", head: hb} = heads[b.id]
+      assert is_binary(ha) and byte_size(ha) > 0
+      assert is_binary(hb) and byte_size(hb) > 0
+    end
+
+    test "a note with an undecryptable path is skipped, not fatal for the vault",
+         %{user: user, vault: vault} do
+      {:ok, good} =
+        Notes.upsert_note(user, vault, %{path: "H/good.md", content: "# G", mtime: 1_000.0})
+
+      {:ok, bad} =
+        Notes.upsert_note(user, vault, %{path: "H/bad.md", content: "# B", mtime: 1_000.0})
+
+      # Corrupt only the bad note's path ciphertext so its decrypt fails.
+      {:ok, {1, nil}} =
+        Repo.with_tenant(user.id, fn ->
+          from(n in Note, where: n.id == ^bad.id)
+          |> Repo.update_all(set: [path_ciphertext: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>])
+        end)
+
+      heads = CrdtTransport.vault_heads(user, vault)
+
+      assert %{path: "H/good.md"} = heads[good.id], "healthy notes still resolve"
+      refute Map.has_key?(heads, bad.id), "the corrupt-path note is skipped"
     end
   end
 
@@ -240,7 +276,7 @@ defmodule Engram.Notes.CrdtTransportTest do
 
       # ...and vault_heads self-heals to the authoritative post-edit head.
       heads = CrdtTransport.vault_heads(user, vault)
-      assert heads[note.id] == head
+      assert heads[note.id].head == head
     end
 
     test "vault_heads self-heals a NULL crdt_head and persists it for cheap re-reads",
@@ -254,10 +290,10 @@ defmodule Engram.Notes.CrdtTransportTest do
       assert is_nil(a0.crdt_head)
 
       heads = CrdtTransport.vault_heads(user, vault)
-      assert is_binary(heads[a.id])
+      assert is_binary(heads[a.id].head)
 
       {:ok, a1} = Notes.get_note_by_id(user, vault, a.id)
-      assert a1.crdt_head == heads[a.id], "self-heal must persist the column"
+      assert a1.crdt_head == heads[a.id].head, "self-heal must persist the column"
     end
 
     test "vault_heads head equals read_delta's head for the same note",
@@ -267,7 +303,7 @@ defmodule Engram.Notes.CrdtTransportTest do
 
       {:ok, %{head: rd_head}} = CrdtTransport.read_delta(user, vault, note.id, nil)
       heads = CrdtTransport.vault_heads(user, vault)
-      assert heads[note.id] == rd_head
+      assert heads[note.id].head == rd_head
     end
 
     test "a REST edit invalidates the head so vault_heads reflects the new state",
@@ -276,7 +312,7 @@ defmodule Engram.Notes.CrdtTransportTest do
         Notes.upsert_note(user, vault, %{path: "MH/D.md", content: "# D\n\none", mtime: 1_000.0})
 
       heads0 = CrdtTransport.vault_heads(user, vault)
-      h0 = heads0[note.id]
+      h0 = heads0[note.id].head
       assert is_binary(h0)
 
       # A REST update rewrites crdt_state via maybe_merge_crdt; the trigger
@@ -292,7 +328,7 @@ defmodule Engram.Notes.CrdtTransportTest do
       assert is_nil(mid.crdt_head), "trigger must invalidate crdt_head on a crdt_state change"
 
       heads1 = CrdtTransport.vault_heads(user, vault)
-      assert heads1[note.id] != h0, "head must advance after a REST edit"
+      assert heads1[note.id].head != h0, "head must advance after a REST edit"
     end
 
     test "backfill_head computes, persists, and returns a head matching read_delta",

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -160,7 +160,7 @@ defmodule EngramWeb.CrdtChannelTest do
   end
 
   describe "crdt_catchup_heads" do
-    test "returns a head marker per live note in the vault", %{
+    test "returns a decrypted path + head marker per live note in the vault", %{
       socket: socket,
       user: user,
       vault: vault
@@ -171,8 +171,8 @@ defmodule EngramWeb.CrdtChannelTest do
       ref = push(socket, "crdt_catchup_heads", %{})
       assert_reply ref, :ok, %{heads: heads}
       assert is_map(heads)
-      assert Map.has_key?(heads, note.id)
-      assert is_binary(heads[note.id])
+      assert %{path: "Notes/h.md", head: head} = heads[note.id]
+      assert is_binary(head) and byte_size(head) > 0
     end
   end
 

--- a/test/engram_web/controllers/crdt_sync_controller_test.exs
+++ b/test/engram_web/controllers/crdt_sync_controller_test.exs
@@ -178,8 +178,9 @@ defmodule EngramWeb.CrdtSyncControllerTest do
       b = seed_note(user, vault, "H/B.md", "# B")
 
       heads = conn |> get("/api/vault/heads") |> json_response(200) |> Map.fetch!("heads")
-      assert Map.has_key?(heads, a.id)
-      assert Map.has_key?(heads, b.id)
+      assert %{"path" => "H/A.md", "head" => ha} = heads[a.id]
+      assert %{"path" => "H/B.md", "head" => hb} = heads[b.id]
+      assert is_binary(ha) and is_binary(hb)
     end
   end
 end


### PR DESCRIPTION
## Why now (unblocks plugin #251)

`crdt_catchup_heads` replies with `CrdtTransport.vault_heads = %{id => head}` — head only, **no path**. The CRDT-authoritative plugin (#251) makes the catch-up head map the **sole discovery source** for cold/first-discovery notes and needs `{path, head}` to place a never-seen note on disk. Without the path it gets the head but has nowhere to materialize the file, so a note created on another device while this one was offline never appears. This is the direct cause of e2e `test_48_oauth_reconnect_catchup`, `test_27_empty_note_sync`, and `test_85_missed_delivery` failing against #251.

## What

`vault_heads/2` now returns `%{id => %{path, head}}`, decrypting each note's Phase-B `path_ciphertext` server-side with the caller's DEK (the same per-path AES-GCM decrypt `/manifest` already pays). Reads the persisted `crdt_head` column (O(notes) cheap row reads, no doc rebuilds). A note whose path is missing/undecryptable is skipped and logged, never fatal. The `crdt_catchup_heads` channel reply and `GET /api/vault/heads` forward the richer shape; `read_delta`/`crdt_catchup_delta` untouched.

Previously-unmerged `feat/catchup-heads-path` commit (`d778cedc`), cherry-picked clean onto current main with the version bump reconciled to 0.5.677. Locally verified: compile (warnings-as-errors), format, credo all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)