### PR TITLE
feat(crdt): deleted_since tombstone cursor in catch-up heads

### DIFF
--- a/lib/engram/notes/crdt_transport.ex
+++ b/lib/engram/notes/crdt_transport.ex
@@ -14,7 +14,7 @@ defmodule Engram.Notes.CrdtTransport do
   import Bitwise
   import Ecto.Query
 
-  alias Engram.{Crypto, Notes, Repo}
+  alias Engram.{Crypto, Notes, Repo, Vaults}
   alias Engram.Logger.Metadata
   alias Engram.Notes.{CrdtBridge, CrdtPersistence, CrdtRegistry, CrdtUpdateLog, Note}
   alias Yex.Sync.SharedDoc
@@ -244,14 +244,65 @@ defmodule Engram.Notes.CrdtTransport do
   zero writes) → empty map, same short-circuit `/manifest` uses.
   """
   @spec vault_heads(map(), map()) :: %{String.t() => %{path: String.t(), head: String.t()}}
-  def vault_heads(user, vault) do
+  def vault_heads(user, vault), do: vault_heads(user, vault, nil)
+
+  @doc """
+  Catch-up bundle for a reconnecting client: surviving-note `heads`, the
+  cross-device `deleted` tombstones since the client's cursor, and the current
+  vault watermark `seq`.
+
+  A delete is an ABSENCE from `heads`, and absence is ambiguous (never synced vs
+  deleted-elsewhere), so a client that was offline while another device deleted a
+  note can't tell it should trash that note. This closes the gap.
+
+  Snapshots the vault `change_seq` FIRST, then bounds BOTH the heads read and the
+  tombstone read by that same `seq`, so a change committed between the two reads
+  is neither lost nor double-counted (a new write stamps a `seq` > snapshot and
+  is picked up on the next poll). `deleted_since` is the last per-vault seq the
+  client fully reconciled; `deleted` is the note_ids tombstoned in
+  (`deleted_since`, `seq`]. `nil` (fresh client) → `deleted: []` (nothing local
+  to trash) but still returns the current `seq` so the client seeds its cursor.
+  """
+  @spec vault_catchup(map(), map(), integer() | nil) ::
+          {%{String.t() => %{path: String.t(), head: String.t()}}, [String.t()], integer()}
+  def vault_catchup(user, vault, deleted_since) do
+    seq = Vaults.current_seq(user.id, vault.id)
+    heads = vault_heads(user, vault, seq)
+    deleted = deleted_note_ids(user, vault, deleted_since, seq)
+    {heads, deleted, seq}
+  end
+
+  # max_seq == nil ⇒ unbounded (the public vault_heads/2 shape). vault_catchup
+  # passes the snapshotted watermark so the heads and tombstone reads agree.
+  defp vault_heads(user, vault, max_seq) do
     case Crypto.get_dek(user) do
-      {:ok, dek} -> vault_heads_with_dek(user, vault, dek)
+      {:ok, dek} -> vault_heads_with_dek(user, vault, dek, max_seq)
       {:error, :no_dek} -> %{}
     end
   end
 
-  defp vault_heads_with_dek(user, vault, dek) do
+  # Tombstoned note_ids (`kind == "note"`, `deleted_at` set) in (since, max_seq].
+  # since == nil (fresh client) has nothing local to trash → []. Legacy rows with
+  # a NULL seq predate the change-log and can never fall in an open window.
+  defp deleted_note_ids(_user, _vault, nil, _max_seq), do: []
+
+  defp deleted_note_ids(user, vault, since, max_seq) do
+    {:ok, ids} =
+      Repo.with_tenant(user.id, fn ->
+        Note
+        |> where(
+          [n],
+          n.vault_id == ^vault.id and n.user_id == ^user.id and n.kind == "note" and
+            not is_nil(n.deleted_at) and n.seq > ^since and n.seq <= ^max_seq
+        )
+        |> select([n], n.id)
+        |> Repo.all()
+      end)
+
+    ids
+  end
+
+  defp vault_heads_with_dek(user, vault, dek, max_seq) do
     {:ok, rows} =
       Repo.with_tenant(user.id, fn ->
         Note
@@ -260,6 +311,7 @@ defmodule Engram.Notes.CrdtTransport do
           n.vault_id == ^vault.id and n.user_id == ^user.id and is_nil(n.deleted_at) and
             n.kind == "note"
         )
+        |> bound_by_seq(max_seq)
         |> select([n], {n.id, n.crdt_head, n.dek_version, n.path_ciphertext, n.path_nonce})
         |> Repo.all()
       end)
@@ -276,6 +328,14 @@ defmodule Engram.Notes.CrdtTransport do
       end
     end)
   end
+
+  # Bound the surviving-heads read by the snapshotted watermark so it agrees with
+  # the tombstone read (nil ⇒ unbounded, the public vault_heads/2 shape). Legacy
+  # rows with a NULL seq predate the change-log and are always in-window.
+  defp bound_by_seq(query, nil), do: query
+
+  defp bound_by_seq(query, max_seq),
+    do: where(query, [n], n.seq <= ^max_seq or is_nil(n.seq))
 
   # A warmed head passes through; a NULL is self-healed once (a deleted-note
   # race returns :not_found → drop it from the map).

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -254,13 +254,16 @@ defmodule EngramWeb.CrdtChannel do
   end
 
   @impl true
-  def handle_in("crdt_catchup_heads", _payload, socket) do
+  def handle_in("crdt_catchup_heads", payload, socket) do
     case check_rate(socket, :handshake) do
       :ok ->
         user = socket.assigns.current_user
         vault = socket.assigns.vault
-        heads = CrdtTransport.vault_heads(user, vault)
-        {:reply, {:ok, %{heads: heads}}, socket}
+        # deleted_since = the last per-vault seq the client fully reconciled;
+        # nil/absent/non-integer ⇒ fresh client (gets deleted: [] + the cursor).
+        deleted_since = cast_deleted_since(Map.get(payload, "deleted_since"))
+        {heads, deleted, seq} = CrdtTransport.vault_catchup(user, vault, deleted_since)
+        {:reply, {:ok, %{heads: heads, deleted: deleted, seq: seq}}, socket}
 
       {:error, :rate_limited} ->
         {:reply, {:error, %{reason: "rate_limited"}}, socket}
@@ -326,6 +329,11 @@ defmodule EngramWeb.CrdtChannel do
       :error -> {:error, :bad_doc_id}
     end
   end
+
+  # The client's tombstone cursor: the last per-vault seq it fully reconciled.
+  # Anything not a non-negative integer (absent, nil, junk) ⇒ fresh client.
+  defp cast_deleted_since(seq) when is_integer(seq) and seq >= 0, do: seq
+  defp cast_deleted_since(_), do: nil
 
   # nil / non-binary / blank-after-trim path is rejected before it ever
   # reaches genesis_crdt_note/4 — path may be cleartext, so the reply never

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.677",
+      version: "0.5.678",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_transport_test.exs
+++ b/test/engram/notes/crdt_transport_test.exs
@@ -3,7 +3,7 @@ defmodule Engram.Notes.CrdtTransportTest do
   # module on the shared-mode sandbox so room-spawning and read tests coexist.
   use Engram.DataCase, async: false
 
-  alias Engram.Notes
+  alias Engram.{Notes, Vaults}
   alias Engram.Notes.{CrdtBridge, CrdtRegistry, CrdtTransport, CrdtUpdateLog, Note}
 
   setup do
@@ -244,6 +244,76 @@ defmodule Engram.Notes.CrdtTransportTest do
 
       assert %{path: "H/good.md"} = heads[good.id], "healthy notes still resolve"
       refute Map.has_key?(heads, bad.id), "the corrupt-path note is skipped"
+    end
+  end
+
+  describe "vault_catchup/3 (deleted_since tombstone cursor)" do
+    test "a note deleted with seq in (since, current] appears in deleted",
+         %{user: user, vault: vault} do
+      {:ok, gone} = Notes.upsert_note(user, vault, %{path: "D/gone.md", content: "x", mtime: 1.0})
+      # Cursor snapshotted BEFORE the delete, so the delete's seq is > since.
+      since = Vaults.current_seq(user.id, vault.id)
+      :ok = Notes.delete_note(user, vault, "D/gone.md")
+
+      {heads, deleted, seq} = CrdtTransport.vault_catchup(user, vault, since)
+
+      assert gone.id in deleted
+      refute Map.has_key?(heads, gone.id), "a tombstoned note is absent from heads"
+      assert seq > since
+    end
+
+    test "a note deleted at seq <= since does NOT appear (already reconciled)",
+         %{user: user, vault: vault} do
+      {:ok, old} = Notes.upsert_note(user, vault, %{path: "D/old.md", content: "x", mtime: 1.0})
+      :ok = Notes.delete_note(user, vault, "D/old.md")
+      # Cursor snapshotted AFTER the delete: the client already reconciled it.
+      since = Vaults.current_seq(user.id, vault.id)
+
+      {_heads, deleted, _seq} = CrdtTransport.vault_catchup(user, vault, since)
+
+      refute old.id in deleted
+    end
+
+    test "a surviving note never appears in deleted", %{user: user, vault: vault} do
+      {:ok, live} = Notes.upsert_note(user, vault, %{path: "D/live.md", content: "x", mtime: 1.0})
+      since = Vaults.current_seq(user.id, vault.id)
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "D/live.md", content: "y", mtime: 2.0})
+
+      {heads, deleted, _seq} = CrdtTransport.vault_catchup(user, vault, since)
+
+      refute live.id in deleted
+      assert Map.has_key?(heads, live.id)
+    end
+
+    test "deleted_since: nil returns deleted: [] and a non-nil seq (fresh client)",
+         %{user: user, vault: vault} do
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "D/a.md", content: "x", mtime: 1.0})
+      :ok = Notes.delete_note(user, vault, "D/a.md")
+
+      {heads, deleted, seq} = CrdtTransport.vault_catchup(user, vault, nil)
+
+      assert deleted == [], "a fresh client has nothing local to trash"
+      assert is_integer(seq) and seq > 0, "still seeds the client's cursor"
+      assert is_map(heads)
+    end
+
+    test "the reply seq equals the snapshot and covers every head's row seq",
+         %{user: user, vault: vault} do
+      {:ok, _} = Notes.upsert_note(user, vault, %{path: "D/h.md", content: "x", mtime: 1.0})
+
+      snapshot = Vaults.current_seq(user.id, vault.id)
+      {heads, _deleted, seq} = CrdtTransport.vault_catchup(user, vault, nil)
+      assert seq == snapshot, "no write happened between the two reads, so seq is stable"
+
+      # Every surviving head was stamped with a seq at or below the watermark.
+      ids = Map.keys(heads)
+
+      {:ok, max_head_seq} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.one(from n in Note, where: n.id in ^ids, select: max(n.seq))
+        end)
+
+      assert max_head_seq <= seq
     end
   end
 

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -169,10 +169,30 @@ defmodule EngramWeb.CrdtChannelTest do
         Notes.upsert_note(user, vault, %{"path" => "Notes/h.md", "content" => "hello"})
 
       ref = push(socket, "crdt_catchup_heads", %{})
-      assert_reply ref, :ok, %{heads: heads}
+      assert_reply ref, :ok, %{heads: heads, deleted: [], seq: seq}
       assert is_map(heads)
+      assert is_integer(seq) and seq > 0
       assert %{path: "Notes/h.md", head: head} = heads[note.id]
       assert is_binary(head) and byte_size(head) > 0
+    end
+
+    test "deleted_since surfaces a cross-device delete since the client's cursor", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
+      {:ok, gone} =
+        Notes.upsert_note(user, vault, %{"path" => "Notes/gone.md", "content" => "bye"})
+
+      # Cursor snapshotted BEFORE the delete → the delete's seq is in-window.
+      since = Vaults.current_seq(user.id, vault.id)
+      :ok = Notes.delete_note(user, vault, "Notes/gone.md")
+
+      ref = push(socket, "crdt_catchup_heads", %{"deleted_since" => since})
+      assert_reply ref, :ok, %{heads: heads, deleted: deleted, seq: seq}
+      assert gone.id in deleted
+      refute Map.has_key?(heads, gone.id)
+      assert seq > since
     end
   end
 


### PR DESCRIPTION
## Why

`crdt_catchup_heads` conveyed only surviving notes, so a client could not learn about notes **deleted on another device while it was offline** (delete == absence, which is ambiguous vs. a first-discovery note). This adds a bounded tombstone cursor so the plugin can authoritatively trash cross-device deletes on catch-up — closing the offline-delete resurrection gap for the CRDT-sockets-only sync (#251).

## Contract

Request gains optional `deleted_since: integer | nil` (last per-vault `seq` the client reconciled). Reply:

```elixir
{:ok, %{heads: %{id => %{path, head}}, deleted: [note_id, ...], seq: <current vault change_seq>}}
```

`vault_catchup/3` snapshots `Vaults.current_seq` first, then bounds BOTH the heads read and the deleted read by that snapshot (no lost/double-counted rows). `deleted` = tombstoned note_ids in `(since, current]`. Fresh client (`nil`) → `deleted: []` + current `seq` to seed the cursor. `vault_heads/2` behavior unchanged (backward-compatible; plugin ignores the new fields until its consumer lands).

Backend-only. Plugin consumer (trash `deleted` ids, persist `seq`) is a separate task on #251. Uses `notes.seq` (per-vault monotonic, stamped on every change incl. delete). Local: compile (warnings-as-errors), format, credo, `mix test` (75/75) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)