### PR TITLE
feat(spa): rendered/raw/reading note editor + global route error boundary

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "engram-frontend",
       "dependencies": {
+        "@atomic-editor/editor": "0.6.2",
         "@clerk/react": "^6.7.2",
         "@clerk/themes": "^2.4.57",
         "@codemirror/lang-markdown": "^6.5.0",
@@ -96,6 +97,8 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "http://10.0.20.214:4873/@adobe/css-tools/-/css-tools-4.5.0.tgz", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "http://10.0.20.214:4873/@antfu/install-pkg/-/install-pkg-1.1.0.tgz", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@atomic-editor/editor": ["@atomic-editor/editor@0.6.2", "http://10.0.20.214:4873/@atomic-editor/editor/-/editor-0.6.2.tgz", { "peerDependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/lang-cpp": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-go": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-java": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-markdown": "^6.0.0", "@codemirror/lang-php": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-rust": "^6.0.0", "@codemirror/lang-sql": "^6.0.0", "@codemirror/lang-xml": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/highlight": "^1.0.0", "@lezer/markdown": "^1.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@codemirror/lang-cpp", "@codemirror/lang-css", "@codemirror/lang-go", "@codemirror/lang-html", "@codemirror/lang-java", "@codemirror/lang-javascript", "@codemirror/lang-json", "@codemirror/lang-php", "@codemirror/lang-python", "@codemirror/lang-rust", "@codemirror/lang-sql", "@codemirror/lang-xml", "@codemirror/lang-yaml", "@codemirror/legacy-modes"] }, "sha512-b4cZRduNOoZ5sJ7ywaANcnLLKP3EJYfMUm5BgYK3Wb+9jI+KUs04RZHzFMVcdedNjvfqBDbzW6KYAmq5bAayxw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "http://10.0.20.214:4873/@babel/code-frame/-/code-frame-7.29.7.tgz", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -57,6 +57,7 @@
         "y-codemirror.next": "^0.3.5",
         "y-indexeddb": "^9.0.12",
         "y-protocols": "^1.0.7",
+        "yaml": "^2.6.0",
         "yjs": "^13.6.31",
       },
       "devDependencies": {
@@ -2359,6 +2360,8 @@
     "y18n": ["y18n@5.0.8", "http://10.0.20.214:4873/y18n/-/y18n-5.0.8.tgz", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "http://10.0.20.214:4873/yallist/-/yallist-3.1.1.tgz", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.9.0", "http://10.0.20.214:4873/yaml/-/yaml-2.9.0.tgz", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.2", "http://10.0.20.214:4873/yargs/-/yargs-17.7.2.tgz", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -10,6 +10,7 @@
         "@clerk/themes": "^2.4.57",
         "@codemirror/commands": "^6.7.0",
         "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/lang-yaml": "^6.1.0",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.43.0",
         "@fontsource-variable/geist": "^5.2.9",
@@ -217,6 +218,8 @@
 
     "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "http://10.0.20.214:4873/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
 
+    "@codemirror/lang-yaml": ["@codemirror/lang-yaml@6.1.3", "http://10.0.20.214:4873/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.0.0", "@lezer/yaml": "^1.0.0" } }, "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ=="],
+
     "@codemirror/language": ["@codemirror/language@6.12.3", "http://10.0.20.214:4873/@codemirror/language/-/language-6.12.3.tgz", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
 
     "@codemirror/lint": ["@codemirror/lint@6.9.6", "http://10.0.20.214:4873/@codemirror/lint/-/lint-6.9.6.tgz", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A=="],
@@ -408,6 +411,8 @@
     "@lezer/lr": ["@lezer/lr@1.4.10", "http://10.0.20.214:4873/@lezer/lr/-/lr-1.4.10.tgz", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
 
     "@lezer/markdown": ["@lezer/markdown@1.6.4", "http://10.0.20.214:4873/@lezer/markdown/-/markdown-1.6.4.tgz", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA=="],
+
+    "@lezer/yaml": ["@lezer/yaml@1.0.4", "http://10.0.20.214:4873/@lezer/yaml/-/yaml-1.0.4.tgz", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
 
     "@lobehub/icons-static-svg": ["@lobehub/icons-static-svg@1.91.0", "http://10.0.20.214:4873/@lobehub/icons-static-svg/-/icons-static-svg-1.91.0.tgz", {}, "sha512-ZDflEq0uUvAkH4WK4h3qNvvY09ts4OqUb5azD7A0xKfcuYhffGwB1Q/As2RguZYq4Gh4v925CJ8iodiClzc4zw=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,6 +8,7 @@
         "@atomic-editor/editor": "0.6.2",
         "@clerk/react": "^6.7.2",
         "@clerk/themes": "^2.4.57",
+        "@codemirror/commands": "^6.7.0",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.43.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
 		"@clerk/themes": "^2.4.57",
 		"@codemirror/commands": "^6.7.0",
 		"@codemirror/lang-markdown": "^6.5.0",
+		"@codemirror/lang-yaml": "^6.1.0",
 		"@codemirror/state": "^6.6.0",
 		"@codemirror/view": "^6.43.0",
 		"@fontsource-variable/geist": "^5.2.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
 		"y-codemirror.next": "^0.3.5",
 		"y-indexeddb": "^9.0.12",
 		"y-protocols": "^1.0.7",
+		"yaml": "^2.6.0",
 		"yjs": "^13.6.31"
 	},
 	"devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
 	},
 	"keywords": [],
 	"dependencies": {
+		"@atomic-editor/editor": "0.6.2",
 		"@clerk/react": "^6.7.2",
 		"@clerk/themes": "^2.4.57",
 		"@codemirror/lang-markdown": "^6.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
 		"@atomic-editor/editor": "0.6.2",
 		"@clerk/react": "^6.7.2",
 		"@clerk/themes": "^2.4.57",
+		"@codemirror/commands": "^6.7.0",
 		"@codemirror/lang-markdown": "^6.5.0",
 		"@codemirror/state": "^6.6.0",
 		"@codemirror/view": "^6.43.0",

--- a/frontend/src/crdt/frontmatter-codec.test.ts
+++ b/frontend/src/crdt/frontmatter-codec.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { emitFrontmatter, parseFrontmatter, projectNote, splitFrontmatter } from "./frontmatter-codec";
+import { VECTORS } from "./frontmatter-codec.vectors";
+
+describe("frontmatter-codec vectors", () => {
+	for (const v of VECTORS) {
+		test(`split+parse: ${v.name}`, () => {
+			const { fmBlock, body } = splitFrontmatter(v.markdown);
+			expect(body).toBe(v.body);
+			const parsed = fmBlock === null ? { order: [], values: {} } : parseFrontmatter(fmBlock);
+			expect(parsed).not.toBeNull();
+			expect(parsed?.order).toEqual(v.order);
+			expect(parsed?.values).toEqual(v.values);
+		});
+
+		test(`round-trip re-projects stable order: ${v.name}`, () => {
+			const { fmBlock, body } = splitFrontmatter(v.markdown);
+			const parsed = fmBlock === null ? { order: [], values: {} } : parseFrontmatter(fmBlock);
+			expect(parsed).not.toBeNull();
+			const projected = projectNote(parsed!.order, parsed!.values, body);
+			// Re-splitting the projection yields the same structured form (idempotent).
+			const again = splitFrontmatter(projected);
+			const reparsed = again.fmBlock === null ? { order: [], values: {} } : parseFrontmatter(again.fmBlock);
+			expect(reparsed?.order).toEqual(v.order);
+			expect(reparsed?.values).toEqual(v.values);
+			expect(again.body).toBe(v.body);
+		});
+	}
+
+	test("emitFrontmatter re-renders a degraded key verbatim from raws", () => {
+		const out = emitFrontmatter(["good", "bad"], { good: JSON.stringify("x") }, { bad: "bad: [unclosed\n" });
+		expect(out).toContain("bad: [unclosed\n");
+		expect(out).toContain("good:");
+	});
+
+	test("parseFrontmatter returns null on invalid YAML", () => {
+		expect(parseFrontmatter("a: [unclosed\n")).toBeNull();
+	});
+});

--- a/frontend/src/crdt/frontmatter-codec.test.ts
+++ b/frontend/src/crdt/frontmatter-codec.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { emitFrontmatter, parseFrontmatter, projectNote, splitFrontmatter } from "./frontmatter-codec";
+import {
+	emitFrontmatter,
+	parseFrontmatter,
+	projectNote,
+	splitFrontmatter,
+} from "./frontmatter-codec";
 import { VECTORS } from "./frontmatter-codec.vectors";
 
 describe("frontmatter-codec vectors", () => {
@@ -20,7 +25,8 @@ describe("frontmatter-codec vectors", () => {
 			const projected = projectNote(parsed!.order, parsed!.values, body);
 			// Re-splitting the projection yields the same structured form (idempotent).
 			const again = splitFrontmatter(projected);
-			const reparsed = again.fmBlock === null ? { order: [], values: {} } : parseFrontmatter(again.fmBlock);
+			const reparsed =
+				again.fmBlock === null ? { order: [], values: {} } : parseFrontmatter(again.fmBlock);
 			expect(reparsed?.order).toEqual(v.order);
 			expect(reparsed?.values).toEqual(v.values);
 			expect(again.body).toBe(v.body);
@@ -28,7 +34,11 @@ describe("frontmatter-codec vectors", () => {
 	}
 
 	test("emitFrontmatter re-renders a degraded key verbatim from raws", () => {
-		const out = emitFrontmatter(["good", "bad"], { good: JSON.stringify("x") }, { bad: "bad: [unclosed\n" });
+		const out = emitFrontmatter(
+			["good", "bad"],
+			{ good: JSON.stringify("x") },
+			{ bad: "bad: [unclosed\n" },
+		);
 		expect(out).toContain("bad: [unclosed\n");
 		expect(out).toContain("good:");
 	});

--- a/frontend/src/crdt/frontmatter-codec.ts
+++ b/frontend/src/crdt/frontmatter-codec.ts
@@ -1,0 +1,112 @@
+// PORTED VERBATIM from plugin/src/crdt/frontmatter-codec.ts (which mirrors the
+// backend Elixir Engram.Notes.Frontmatter). Keep byte-compatible with both — a
+// divergence corrupts notes across web/plugin/backend. Shared vectors in
+// frontmatter-codec.vectors.ts pin the contract. Do not "improve" in isolation.
+import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+
+const FENCE = "---";
+const CLOSE_MID = /\n---[ \t]*\r?\n/;
+const CLOSE_EOF = /\n---[ \t]*\r?$/;
+
+export function splitFrontmatter(raw: string): { fmBlock: string | null; body: string } {
+	if (!raw.startsWith(`${FENCE}\n`)) return { fmBlock: null, body: raw };
+	const rest = raw.slice(FENCE.length + 1);
+	if (rest.startsWith(`${FENCE}\n`)) return { fmBlock: "", body: rest.slice(FENCE.length + 1) };
+	const mid = rest.match(CLOSE_MID);
+	if (mid && mid.index !== undefined) {
+		const block = `${rest.slice(0, mid.index)}\n`;
+		const body = rest.slice(mid.index + mid[0].length);
+		return { fmBlock: block, body };
+	}
+	const eof = rest.match(CLOSE_EOF);
+	if (eof && eof.index !== undefined) {
+		return { fmBlock: `${rest.slice(0, eof.index)}\n`, body: "" };
+	}
+	return { fmBlock: null, body: raw };
+}
+
+export function canonicalJson(value: unknown): string {
+	return JSON.stringify(sortDeep(value));
+}
+
+function sortDeep(v: unknown): unknown {
+	if (Array.isArray(v)) return v.map(sortDeep);
+	if (v !== null && typeof v === "object") {
+		const rec = v as Record<string, unknown>;
+		const out: Record<string, unknown> = {};
+		for (const k of Object.keys(rec).sort()) out[k] = sortDeep(rec[k]);
+		return out;
+	}
+	return v;
+}
+
+export function parseFrontmatter(
+	fmBlock: string,
+): { order: string[]; values: Record<string, string> } | null {
+	if (fmBlock === "") return { order: [], values: {} };
+	let doc: unknown;
+	try {
+		doc = yamlParse(fmBlock);
+	} catch {
+		return null;
+	}
+	if (!doc || typeof doc !== "object" || Array.isArray(doc)) return null;
+	const map = doc as Record<string, unknown>;
+	const order = topLevelKeyOrder(fmBlock, map);
+	const values: Record<string, string> = {};
+	for (const k of Object.keys(map)) values[k] = canonicalJson(map[k]);
+	return { order, values };
+}
+
+function topLevelKeyOrder(block: string, map: Record<string, unknown>): string[] {
+	const order: string[] = [];
+	for (const line of block.split("\n")) {
+		const m = line.match(/^([^\s:][^:]*):/);
+		if (!m) continue;
+		const key = m[1];
+		if (
+			key !== undefined &&
+			Object.prototype.hasOwnProperty.call(map, key) &&
+			!order.includes(key)
+		) {
+			order.push(key);
+		}
+	}
+	return order;
+}
+
+function ensureTrailingNewline(s: string): string {
+	if (s === "") return "";
+	return s.endsWith("\n") ? s : `${s}\n`;
+}
+
+function emitKey(key: string, valueJson: string): string {
+	const value: unknown = JSON.parse(valueJson);
+	return ensureTrailingNewline(yamlStringify({ [key]: value }));
+}
+
+export function emitFrontmatter(
+	order: string[],
+	values: Record<string, string>,
+	raws: Record<string, string> = {},
+): string {
+	const has = (m: Record<string, string>, k: string) =>
+		Object.prototype.hasOwnProperty.call(m, k);
+	const present = order.filter((k) => has(raws, k) || has(values, k));
+	if (present.length === 0) return "";
+	let out = "";
+	for (const key of present) {
+		out += has(raws, key) ? ensureTrailingNewline(raws[key]!) : emitKey(key, values[key]!);
+	}
+	return ensureTrailingNewline(out);
+}
+
+export function projectNote(
+	order: string[],
+	values: Record<string, string>,
+	body: string,
+	raws: Record<string, string> = {},
+): string {
+	const block = emitFrontmatter(order, values, raws);
+	return block === "" ? body : `${FENCE}\n${block}${FENCE}\n${body}`;
+}

--- a/frontend/src/crdt/frontmatter-codec.ts
+++ b/frontend/src/crdt/frontmatter-codec.ts
@@ -8,10 +8,56 @@ const FENCE = "---";
 const CLOSE_MID = /\n---[ \t]*\r?\n/;
 const CLOSE_EOF = /\n---[ \t]*\r?$/;
 
+function sortDeep(v: unknown): unknown {
+	if (Array.isArray(v)) {
+		return v.map(sortDeep);
+	}
+	if (v !== null && typeof v === "object") {
+		const rec = v as Record<string, unknown>;
+		const out: Record<string, unknown> = {};
+		for (const k of Object.keys(rec).sort()) {
+			out[k] = sortDeep(rec[k]);
+		}
+		return out;
+	}
+	return v;
+}
+
+function topLevelKeyOrder(block: string, map: Record<string, unknown>): string[] {
+	const order: string[] = [];
+	for (const line of block.split("\n")) {
+		const m = line.match(/^(?<key>[^\s:][^:]*):/);
+		if (!m) {
+			continue;
+		}
+		const { key } = m.groups ?? {};
+		if (key !== undefined && Object.hasOwn(map, key) && !order.includes(key)) {
+			order.push(key);
+		}
+	}
+	return order;
+}
+
+function ensureTrailingNewline(s: string): string {
+	if (s === "") {
+		return "";
+	}
+	return s.endsWith("\n") ? s : `${s}\n`;
+}
+
+function emitKey(key: string, valueJson: string): string {
+	const value: unknown = JSON.parse(valueJson);
+	return ensureTrailingNewline(yamlStringify({ [key]: value }));
+}
+
 export function splitFrontmatter(raw: string): { fmBlock: string | null; body: string } {
-	if (!raw.startsWith(`${FENCE}\n`)) return { fmBlock: null, body: raw };
+	if (!raw.startsWith(`${FENCE}\n`)) {
+		return { fmBlock: null, body: raw };
+	}
 	const rest = raw.slice(FENCE.length + 1);
-	if (rest.startsWith(`${FENCE}\n`)) return { fmBlock: "", body: rest.slice(FENCE.length + 1) };
+	if (rest.startsWith(`${FENCE}\n`)) {
+		return { fmBlock: "", body: rest.slice(FENCE.length + 1) };
+	}
 	const mid = rest.match(CLOSE_MID);
 	if (mid && mid.index !== undefined) {
 		const block = `${rest.slice(0, mid.index)}\n`;
@@ -29,60 +75,28 @@ export function canonicalJson(value: unknown): string {
 	return JSON.stringify(sortDeep(value));
 }
 
-function sortDeep(v: unknown): unknown {
-	if (Array.isArray(v)) return v.map(sortDeep);
-	if (v !== null && typeof v === "object") {
-		const rec = v as Record<string, unknown>;
-		const out: Record<string, unknown> = {};
-		for (const k of Object.keys(rec).sort()) out[k] = sortDeep(rec[k]);
-		return out;
-	}
-	return v;
-}
-
 export function parseFrontmatter(
 	fmBlock: string,
 ): { order: string[]; values: Record<string, string> } | null {
-	if (fmBlock === "") return { order: [], values: {} };
+	if (fmBlock === "") {
+		return { order: [], values: {} };
+	}
 	let doc: unknown;
 	try {
 		doc = yamlParse(fmBlock);
 	} catch {
 		return null;
 	}
-	if (!doc || typeof doc !== "object" || Array.isArray(doc)) return null;
+	if (!doc || typeof doc !== "object" || Array.isArray(doc)) {
+		return null;
+	}
 	const map = doc as Record<string, unknown>;
 	const order = topLevelKeyOrder(fmBlock, map);
 	const values: Record<string, string> = {};
-	for (const k of Object.keys(map)) values[k] = canonicalJson(map[k]);
-	return { order, values };
-}
-
-function topLevelKeyOrder(block: string, map: Record<string, unknown>): string[] {
-	const order: string[] = [];
-	for (const line of block.split("\n")) {
-		const m = line.match(/^([^\s:][^:]*):/);
-		if (!m) continue;
-		const key = m[1];
-		if (
-			key !== undefined &&
-			Object.prototype.hasOwnProperty.call(map, key) &&
-			!order.includes(key)
-		) {
-			order.push(key);
-		}
+	for (const k of Object.keys(map)) {
+		values[k] = canonicalJson(map[k]);
 	}
-	return order;
-}
-
-function ensureTrailingNewline(s: string): string {
-	if (s === "") return "";
-	return s.endsWith("\n") ? s : `${s}\n`;
-}
-
-function emitKey(key: string, valueJson: string): string {
-	const value: unknown = JSON.parse(valueJson);
-	return ensureTrailingNewline(yamlStringify({ [key]: value }));
+	return { order, values };
 }
 
 export function emitFrontmatter(
@@ -90,10 +104,11 @@ export function emitFrontmatter(
 	values: Record<string, string>,
 	raws: Record<string, string> = {},
 ): string {
-	const has = (m: Record<string, string>, k: string) =>
-		Object.prototype.hasOwnProperty.call(m, k);
+	const has = (m: Record<string, string>, k: string) => Object.hasOwn(m, k);
 	const present = order.filter((k) => has(raws, k) || has(values, k));
-	if (present.length === 0) return "";
+	if (present.length === 0) {
+		return "";
+	}
 	let out = "";
 	for (const key of present) {
 		out += has(raws, key) ? ensureTrailingNewline(raws[key]!) : emitKey(key, values[key]!);

--- a/frontend/src/crdt/frontmatter-codec.vectors.ts
+++ b/frontend/src/crdt/frontmatter-codec.vectors.ts
@@ -27,7 +27,8 @@ export const VECTORS: Vector[] = [
 	},
 	{
 		name: "string, list, number, bool, date",
-		markdown: '---\ntitle: Hi\ntags:\n  - a\n  - b\ncount: 3\ndone: true\ncreated: 2026-07-17\n---\nbody text\n',
+		markdown:
+			"---\ntitle: Hi\ntags:\n  - a\n  - b\ncount: 3\ndone: true\ncreated: 2026-07-17\n---\nbody text\n",
 		order: ["title", "tags", "count", "done", "created"],
 		values: {
 			title: JSON.stringify("Hi"),

--- a/frontend/src/crdt/frontmatter-codec.vectors.ts
+++ b/frontend/src/crdt/frontmatter-codec.vectors.ts
@@ -1,0 +1,57 @@
+// Shared frontmatter round-trip vectors. MUST stay identical in meaning to the
+// plugin (plugin/src/crdt/frontmatter-codec.test.ts) and backend
+// (Engram.Notes.Frontmatter tests). Edit in lockstep across all three surfaces.
+export interface Vector {
+	name: string;
+	markdown: string; // full note text (fence + body, or body-only)
+	order: string[]; // expected top-level key order
+	// expected canonical-JSON value strings, keyed by frontmatter key
+	values: Record<string, string>;
+	body: string; // expected body after split
+}
+
+export const VECTORS: Vector[] = [
+	{
+		name: "no frontmatter",
+		markdown: "just a body\n",
+		order: [],
+		values: {},
+		body: "just a body\n",
+	},
+	{
+		name: "empty frontmatter block",
+		markdown: "---\n---\nbody\n",
+		order: [],
+		values: {},
+		body: "body\n",
+	},
+	{
+		name: "string, list, number, bool, date",
+		markdown: '---\ntitle: Hi\ntags:\n  - a\n  - b\ncount: 3\ndone: true\ncreated: 2026-07-17\n---\nbody text\n',
+		order: ["title", "tags", "count", "done", "created"],
+		values: {
+			title: JSON.stringify("Hi"),
+			tags: JSON.stringify(["a", "b"]),
+			count: JSON.stringify(3),
+			done: JSON.stringify(true),
+			// the `yaml` package parses an unquoted ISO date to a Date; canonicalJson
+			// serializes it as an ISO string. Assert the shape the codec actually emits.
+			created: JSON.stringify(new Date("2026-07-17").toISOString().slice(0, 10)),
+		},
+		body: "body text\n",
+	},
+	{
+		name: "nested map",
+		markdown: "---\nmeta:\n  a: 1\n  b: 2\n---\n",
+		order: ["meta"],
+		values: { meta: JSON.stringify({ a: 1, b: 2 }) },
+		body: "",
+	},
+	{
+		name: "unicode + colon in value",
+		markdown: '---\nnote: "café: rebuilt"\n---\nx\n',
+		order: ["note"],
+		values: { note: JSON.stringify("café: rebuilt") },
+		body: "x\n",
+	},
+];

--- a/frontend/src/crdt/frontmatter-doc.test.ts
+++ b/frontend/src/crdt/frontmatter-doc.test.ts
@@ -141,7 +141,9 @@ describe("frontmatter apply-diff", () => {
 		const { values } = frontmatterMaps(doc);
 		const touched: string[] = [];
 		values.observe((e) => {
-			for (const k of e.keys.keys()) touched.push(k);
+			for (const k of e.keys.keys()) {
+				touched.push(k);
+			}
 		});
 		applyParsedFrontmatter(doc, {
 			order: ["title", "tags"],

--- a/frontend/src/crdt/frontmatter-doc.test.ts
+++ b/frontend/src/crdt/frontmatter-doc.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, test } from "vitest";
 import * as Y from "yjs";
 import {
 	addKey,
+	applyParsedFrontmatter,
+	emitFrontmatterText,
 	FRONTMATTER_KEY,
 	frontmatterMaps,
 	moveKey,
 	ORDER_KEY,
 	type PropertyRow,
+	rawMap,
+	readRaws,
 	readRows,
 	removeKey,
 	setType,
@@ -127,5 +131,73 @@ describe("sortRowsOkfFirst", () => {
 	test("is stable for custom keys and identity when no OKF keys present", () => {
 		const rows = ["b", "a", "c"].map(row);
 		expect(sortRowsOkfFirst(rows).map((r) => r.key)).toEqual(["b", "a", "c"]);
+	});
+});
+
+describe("frontmatter apply-diff", () => {
+	test("upserts changed keys and preserves untouched keys (no clobber)", () => {
+		const doc = new Y.Doc();
+		seed(doc); // title="Hi", tags=["a","b"]
+		const { values } = frontmatterMaps(doc);
+		const touched: string[] = [];
+		values.observe((e) => {
+			for (const k of e.keys.keys()) touched.push(k);
+		});
+		applyParsedFrontmatter(doc, {
+			order: ["title", "tags"],
+			values: { title: JSON.stringify("Bye"), tags: JSON.stringify(["a", "b"]) },
+		});
+		expect(readRows(doc)).toEqual([
+			{ key: "title", value: "Bye", typeOverride: "text" },
+			{ key: "tags", value: ["a", "b"], typeOverride: null },
+		]);
+		// The real proof: tags never got re-written even though it was re-submitted
+		// unchanged. A wholesale values.clear()+re-set would touch both keys and
+		// fail this assertion.
+		expect(touched).toContain("title");
+		expect(touched).not.toContain("tags");
+	});
+
+	test("deletes keys removed from the text unless preserved as raw", () => {
+		const doc = new Y.Doc();
+		seed(doc);
+		// "keepme" lives in BOTH the live values/order maps AND frontmatter_raw, so
+		// the delete loop actually iterates it and must consult the `!raws.has(key)`
+		// guard to skip deleting it. (A "keepme" that only ever existed in raws,
+		// never in values, never exercises the guard at all.)
+		const { values, order } = frontmatterMaps(doc);
+		values.set("keepme", JSON.stringify("v"));
+		order.push(["keepme"]);
+		rawMap(doc).set("keepme", "keepme: v\n");
+		applyParsedFrontmatter(doc, { order: ["title"], values: { title: JSON.stringify("Hi") } });
+		const keys = readRows(doc).map((r) => r.key);
+		expect(keys).toContain("title");
+		expect(keys).not.toContain("tags"); // removed, no raw to preserve it
+		// "keepme" drops out of `order` (order is wholesale-replaced to match
+		// parsed.order), but the `!raws.has(key)` guard must stop it from being
+		// deleted out of the live `values` map. Without the guard this is false.
+		expect(values.has("keepme")).toBe(true);
+		expect(readRaws(doc)).toHaveProperty("keepme");
+	});
+
+	test("does not double-encode: applied values are canonical JSON strings", () => {
+		const doc = new Y.Doc();
+		applyParsedFrontmatter(doc, { order: ["n"], values: { n: JSON.stringify(3) } });
+		expect(readRows(doc)).toEqual([{ key: "n", value: 3, typeOverride: null }]);
+	});
+
+	test("emitFrontmatterText renders live values verbatim, and raw spans verbatim over the live value", () => {
+		const doc = new Y.Doc();
+		seed(doc);
+		expect(emitFrontmatterText(doc)).toContain("title:");
+		expect(emitFrontmatterText(doc)).toContain("tags:");
+
+		// A key with BOTH a live value and a raw span renders the raw text
+		// verbatim (preserving unparseable/exotic YAML), not the re-encoded value.
+		const { values, order } = frontmatterMaps(doc);
+		values.set("weird", JSON.stringify("!!binary abc"));
+		order.push(["weird"]);
+		rawMap(doc).set("weird", "weird: !!binary abc\n");
+		expect(emitFrontmatterText(doc)).toContain("weird: !!binary abc");
 	});
 });

--- a/frontend/src/crdt/frontmatter-doc.ts
+++ b/frontend/src/crdt/frontmatter-doc.ts
@@ -1,4 +1,5 @@
 import type * as Y from "yjs";
+import { emitFrontmatter } from "./frontmatter-codec";
 import { coerceValue, type PropertyType } from "../viewer/property-types";
 
 const EMPTY_DEFAULT: Record<PropertyType, unknown> = {
@@ -127,6 +128,61 @@ export function setType(doc: Y.Doc, key: string, type: PropertyType): void {
 		types.set(key, type);
 		if (row) {
 			values.set(key, JSON.stringify(coerceValue(row.value, type)));
+		}
+	});
+}
+
+export const RAW_FRONTMATTER_KEY = "frontmatter_raw";
+
+export function rawMap(doc: Y.Doc): Y.Map<string> {
+	return doc.getMap<string>(RAW_FRONTMATTER_KEY);
+}
+
+export function readRaws(doc: Y.Doc): Record<string, string> {
+	const out: Record<string, string> = {};
+	rawMap(doc).forEach((v, k) => {
+		out[k] = v;
+	});
+	return out;
+}
+
+/** Emit the frontmatter block (inner YAML, no fences) from the live maps. */
+export function emitFrontmatterText(doc: Y.Doc): string {
+	const { values, order } = frontmatterMaps(doc);
+	const valuesRec: Record<string, string> = {};
+	values.forEach((v, k) => {
+		valuesRec[k] = v;
+	});
+	return emitFrontmatter(order.toArray(), valuesRec, readRaws(doc));
+}
+
+/**
+ * Apply a parsed frontmatter block to the Y.Map with a MINIMAL per-key diff, in
+ * one transaction. `parsed.values` are canonical-JSON strings (from
+ * parseFrontmatter) and are stored as-is — do NOT re-JSON.stringify. A concurrent
+ * pill edit to an untouched key is never clobbered; keys held in frontmatter_raw
+ * are preserved. Types are left to the pills.
+ */
+export function applyParsedFrontmatter(
+	doc: Y.Doc,
+	parsed: { order: string[]; values: Record<string, string> },
+): void {
+	const { values, order } = frontmatterMaps(doc);
+	const raws = rawMap(doc);
+	doc.transact(() => {
+		for (const key of Object.keys(parsed.values)) {
+			const next = parsed.values[key]!;
+			if (values.get(key) !== next) values.set(key, next);
+		}
+		for (const key of [...values.keys()]) {
+			if (!(key in parsed.values) && !raws.has(key)) values.delete(key);
+		}
+		const current = order.toArray();
+		const changed =
+			current.length !== parsed.order.length || current.some((k, i) => k !== parsed.order[i]);
+		if (changed) {
+			order.delete(0, order.length);
+			if (parsed.order.length > 0) order.insert(0, parsed.order);
 		}
 	});
 }

--- a/frontend/src/crdt/frontmatter-doc.ts
+++ b/frontend/src/crdt/frontmatter-doc.ts
@@ -1,6 +1,6 @@
 import type * as Y from "yjs";
-import { emitFrontmatter } from "./frontmatter-codec";
 import { coerceValue, type PropertyType } from "../viewer/property-types";
+import { emitFrontmatter } from "./frontmatter-codec";
 
 const EMPTY_DEFAULT: Record<PropertyType, unknown> = {
 	text: "",
@@ -172,17 +172,23 @@ export function applyParsedFrontmatter(
 	doc.transact(() => {
 		for (const key of Object.keys(parsed.values)) {
 			const next = parsed.values[key]!;
-			if (values.get(key) !== next) values.set(key, next);
+			if (values.get(key) !== next) {
+				values.set(key, next);
+			}
 		}
 		for (const key of [...values.keys()]) {
-			if (!(key in parsed.values) && !raws.has(key)) values.delete(key);
+			if (!(key in parsed.values || raws.has(key))) {
+				values.delete(key);
+			}
 		}
 		const current = order.toArray();
 		const changed =
 			current.length !== parsed.order.length || current.some((k, i) => k !== parsed.order[i]);
 		if (changed) {
 			order.delete(0, order.length);
-			if (parsed.order.length > 0) order.insert(0, parsed.order);
+			if (parsed.order.length > 0) {
+				order.insert(0, parsed.order);
+			}
 		}
 	});
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -121,8 +121,9 @@ function AppShell({ config }: { config: EngramConfig }) {
 	// Dev-only crash trigger for eyeballing ErrorFallback. Throws HERE, above
 	// RouterProvider, on purpose: a throwing *route* would be caught by React
 	// Router's own error boundary, not the outer RootErrorBoundary we're
-	// styling. Visit `?boom` to see the real crash page. Stripped from prod
-	// builds by the import.meta.env.DEV gate.
+	// styling. Visit `?boom` to see the real crash page; use `?routeboom`
+	// (router.tsx) for the route-level twin. Stripped from prod builds by the
+	// import.meta.env.DEV gate.
 	if (import.meta.env.DEV && new URLSearchParams(window.location.search).has("boom")) {
 		throw new Error("Intentional crash (?boom) — testing ErrorFallback");
 	}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,14 +9,15 @@ import { ConfigProvider } from "./config-context";
 import ErrorFallback from "./error-fallback";
 import LoadingScreen from "./layout/loading-screen";
 import { createAppRouter, installAppRouter } from "./router";
+import { captureError } from "./sentry";
 import { ThemeProvider } from "./theme/theme-provider";
 import "./main.css";
 
 // Stale-deploy self-heal. Every lazy() below (app shell, Clerk provider,
 // Toaster, upgrade dialog, …) is a hashed chunk that a deploy can rotate out
 // from under an open tab; without this, the next lazy render 404s and the
-// throw lands on React Router's default error page (no route defines
-// errorElement). Vite fires `vite:preloadError` for failed dynamic-import
+// throw lands on the route error boundary (router.tsx errorElement). Vite
+// fires `vite:preloadError` for failed dynamic-import
 // loads — reload once to pick up the fresh index.html + hashes.
 // preventDefault() suppresses the rethrow for the reload we handle; the
 // 30s guard means a genuinely broken asset host degrades back to the error
@@ -32,60 +33,10 @@ window.addEventListener("vite:preloadError", (event) => {
 	window.location.reload();
 });
 
-// Sentry — opt-in via VITE_SENTRY_DSN at build time. No-op (zero
-// network calls) when the env var is unset, so dev / self-host
-// builds are unaffected. Tracing + replay stay off in Tier 1;
-// OpenTelemetry → Tempo lands in Tier 2 with explicit sampling.
-//
-// Dynamically imported (like posthog below) so the SDK stays out of the eager
-// bundle that gates the sign-in page. The pre-init gap is bridged by the
-// early-error queue below: window error/unhandledrejection events that fire
-// before the chunk lands are buffered and flushed into captureException once
-// init runs, so bootstrap-window crashes still report. Resolves to null when
-// the chunk itself fails to load (ad-blockers match "sentry" in asset URLs;
-// stale-tab 404s) — callers must tolerate that, and it must NOT surface as an
-// unhandled rejection.
-const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
-
-type SentrySdk = typeof import("@sentry/react");
-
-const earlyErrors: unknown[] = [];
-const onEarlyError = (e: ErrorEvent) => earlyErrors.push(e.error ?? e.message);
-const onEarlyRejection = (e: PromiseRejectionEvent) => earlyErrors.push(e.reason);
-if (sentryDsn) {
-	window.addEventListener("error", onEarlyError);
-	window.addEventListener("unhandledrejection", onEarlyRejection);
-}
-
-const sentryReady: Promise<SentrySdk | null> | null = sentryDsn
-	? import("@sentry/react")
-			.then((Sentry) => {
-				Sentry.init({
-					dsn: sentryDsn,
-					environment: import.meta.env.MODE,
-					release: import.meta.env.VITE_GIT_SHA,
-					integrations: [],
-					// sendDefaultPii=false (SDK default) keeps cookies + the
-					// Authorization header out of breadcrumbs even if the SDK's
-					// own scrubbing misses something. Restated for documentation.
-					sendDefaultPii: false,
-				});
-				// The SDK's own global handlers are live from here; hand it the
-				// backlog and retire the temporary listeners.
-				window.removeEventListener("error", onEarlyError);
-				window.removeEventListener("unhandledrejection", onEarlyRejection);
-				for (const err of earlyErrors.splice(0)) {
-					Sentry.captureException(err);
-				}
-				return Sentry as SentrySdk;
-			})
-			.catch((err) => {
-				window.removeEventListener("error", onEarlyError);
-				window.removeEventListener("unhandledrejection", onEarlyRejection);
-				console.warn("[sentry] SDK failed to load — crash reporting disabled:", err);
-				return null;
-			})
-	: null;
+// Sentry lazy singleton + `captureError` reporter moved to ./sentry so the
+// route boundary (router.tsx) can report through the same SDK instance without
+// a cycle back into this entry module. Opt-in via VITE_SENTRY_DSN; no-op when
+// unset. See sentry.ts for the lazy-load + early-error-queue rationale.
 
 // Cloudflare Web Analytics — cookieless RUM beacon. Opt-in via
 // VITE_CF_BEACON_TOKEN at build time; no-op when unset so dev /
@@ -237,14 +188,13 @@ class RootErrorBoundary extends Component<{ children: ReactNode }, RootErrorBoun
 	}
 
 	componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
-		// captureReactException is what Sentry.ErrorBoundary itself uses — it
-		// attaches the React componentStack, which plain captureException drops.
-		sentryReady?.then((Sentry) => {
-			if (!Sentry) {
-				return;
+		// captureError passes errorInfo through to captureReactException (attaches
+		// the React componentStack), and resolves to an eventId only once the lazy
+		// SDK actually dispatched — so `reported` is never claimed falsely.
+		captureError(error, errorInfo).then((eventId) => {
+			if (eventId) {
+				this.setState({ eventId, reported: true });
 			}
-			const eventId = Sentry.captureReactException(error, errorInfo);
-			this.setState({ eventId, reported: true });
 		});
 	}
 

--- a/frontend/src/route-error-boundary.test.tsx
+++ b/frontend/src/route-error-boundary.test.tsx
@@ -1,28 +1,81 @@
-import { render, screen } from "@testing-library/react";
-import { createMemoryRouter, RouterProvider } from "react-router";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createMemoryRouter, type RouteObject, RouterProvider } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RouteErrorBoundary from "./route-error-boundary";
+import { captureError } from "./sentry";
 
-afterEach(() => vi.restoreAllMocks());
+// Mock the reporter so we can assert WHICH errors get reported without a real
+// Sentry SDK. Default: "delivered nothing" (resolves undefined).
+vi.mock("./sentry", () => ({ captureError: vi.fn(() => Promise.resolve(undefined)) }));
+const mockCapture = vi.mocked(captureError);
+
+beforeEach(() => {
+	// RR logs caught route errors to console.error; silence it (without hiding a
+	// real assertion failure).
+	vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	mockCapture.mockReset();
+	mockCapture.mockResolvedValue(undefined);
+});
 
 function Boom(): never {
 	throw new Error("route exploded");
 }
 
+function renderWithBoundary(route: RouteObject) {
+	const router = createMemoryRouter([{ ...route, errorElement: <RouteErrorBoundary /> }]);
+	return render(<RouterProvider router={router} />);
+}
+
+const heading = () => screen.findByRole("heading", { name: /something went wrong/iu });
+
 describe("RouteErrorBoundary", () => {
 	it("renders the app ErrorFallback when a route throws, not RR's default page", async () => {
-		// RR logs the caught route error to console.error; silence it so the test
-		// output stays clean without hiding a real failure.
-		vi.spyOn(console, "error").mockImplementation(() => {});
-		const router = createMemoryRouter([
-			{ path: "/", element: <Boom />, errorElement: <RouteErrorBoundary /> },
-		]);
-		render(<RouterProvider router={router} />);
-
+		renderWithBoundary({ path: "/", element: <Boom /> });
 		// The branded fallback — proves the route throw hit OUR boundary. RR's own
 		// default "Unexpected Application Error" page has no such heading.
-		expect(
-			await screen.findByRole("heading", { name: /something went wrong/iu }),
-		).toBeInTheDocument();
+		expect(await heading()).toBeInTheDocument();
+	});
+
+	it("reports a plain route crash through captureError", async () => {
+		renderWithBoundary({ path: "/", element: <Boom /> });
+		await heading();
+		expect(mockCapture).toHaveBeenCalledTimes(1);
+		expect(mockCapture).toHaveBeenCalledWith(expect.any(Error));
+	});
+
+	it("does NOT report a 404 Response — an expected client error, not a crash", async () => {
+		renderWithBoundary({
+			path: "/",
+			loader: () => {
+				throw new Response("nope", { status: 404 });
+			},
+			element: <p>unused</p>,
+		});
+		await heading();
+		expect(mockCapture).not.toHaveBeenCalled();
+	});
+
+	it("DOES report a 5xx Response — a real server failure", async () => {
+		renderWithBoundary({
+			path: "/",
+			loader: () => {
+				throw new Response("boom", { status: 503 });
+			},
+			element: <p>unused</p>,
+		});
+		await heading();
+		expect(mockCapture).toHaveBeenCalledTimes(1);
+	});
+
+	it("claims 'reported' with a reference id only after delivery resolves an id", async () => {
+		mockCapture.mockResolvedValue("evt-9");
+		renderWithBoundary({ path: "/", element: <Boom /> });
+		await heading();
+		// The honest flags flip only once captureError resolves a (delivered) id.
+		await waitFor(() => expect(screen.getByText(/has been reported/iu)).toBeInTheDocument());
+		expect(screen.getByText(/evt-9/u)).toBeInTheDocument();
 	});
 });

--- a/frontend/src/route-error-boundary.test.tsx
+++ b/frontend/src/route-error-boundary.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import RouteErrorBoundary from "./route-error-boundary";
+
+afterEach(() => vi.restoreAllMocks());
+
+function Boom(): never {
+	throw new Error("route exploded");
+}
+
+describe("RouteErrorBoundary", () => {
+	it("renders the app ErrorFallback when a route throws, not RR's default page", async () => {
+		// RR logs the caught route error to console.error; silence it so the test
+		// output stays clean without hiding a real failure.
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		const router = createMemoryRouter([
+			{ path: "/", element: <Boom />, errorElement: <RouteErrorBoundary /> },
+		]);
+		render(<RouterProvider router={router} />);
+
+		// The branded fallback — proves the route throw hit OUR boundary. RR's own
+		// default "Unexpected Application Error" page has no such heading.
+		expect(
+			await screen.findByRole("heading", { name: /something went wrong/iu }),
+		).toBeInTheDocument();
+	});
+});

--- a/frontend/src/route-error-boundary.tsx
+++ b/frontend/src/route-error-boundary.tsx
@@ -16,9 +16,16 @@ export default function RouteErrorBoundary() {
 	});
 
 	useEffect(() => {
-		// isRouteErrorResponse => an expected HTTP-shaped throw (404 / redirect
-		// Response), not a crash. Show the page but don't page Sentry for it.
-		if (isRouteErrorResponse(error)) {
+		// New route error → clear any prior error's eventId/reported. RR updates
+		// useRouteError in place (the errorElement instance persists across
+		// sequential route errors), so without this a later crash could briefly
+		// show the previous crash's reference id.
+		setReport({ reported: false });
+		// isRouteErrorResponse => an expected HTTP-shaped throw. Skip Sentry for
+		// CLIENT errors (404 / redirect); a SERVER error (5xx) is a real failure,
+		// so let it fall through and report. (Latent until a data loader throws a
+		// Response — element routes don't today.)
+		if (isRouteErrorResponse(error) && error.status < 500) {
 			return;
 		}
 		let alive = true;

--- a/frontend/src/route-error-boundary.tsx
+++ b/frontend/src/route-error-boundary.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { isRouteErrorResponse, useRouteError } from "react-router";
+import ErrorFallback from "./error-fallback";
+import { captureError } from "./sentry";
+
+// The router's global errorElement. React Router's data router intercepts any
+// throw during a route's render before it can reach the root RootErrorBoundary
+// (main.tsx), so without this a route crash (e.g. a decoration bug in the note
+// editor) fell through to React Router's bare default error page. Mounted once
+// at the root route, it catches every descendant route error and renders the
+// same ErrorFallback the root boundary uses — one crash page for the whole app.
+export default function RouteErrorBoundary() {
+	const error = useRouteError();
+	const [report, setReport] = useState<{ eventId?: string; reported: boolean }>({
+		reported: false,
+	});
+
+	useEffect(() => {
+		// isRouteErrorResponse => an expected HTTP-shaped throw (404 / redirect
+		// Response), not a crash. Show the page but don't page Sentry for it.
+		if (isRouteErrorResponse(error)) {
+			return;
+		}
+		let alive = true;
+		captureError(error).then((eventId) => {
+			if (alive && eventId) {
+				setReport({ eventId, reported: true });
+			}
+		});
+		return () => {
+			alive = false;
+		};
+	}, [error]);
+
+	return <ErrorFallback error={error} eventId={report.eventId} reported={report.reported} />;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,6 +8,7 @@ import WaitlistPage from "./auth/waitlist";
 import { UpgradeDialogProvider } from "./billing/upgrade-dialog-provider";
 import type { EngramConfig } from "./config";
 import LoadingScreen from "./layout/loading-screen";
+import RouteErrorBoundary from "./route-error-boundary";
 import { ROUTES } from "./routes";
 import LoadingPane from "./viewer/loading-pane";
 
@@ -113,6 +114,11 @@ export function createAppRouter(config: EngramConfig): AppRouter {
 	return createBrowserRouter([
 		{
 			element: <RootLayout />,
+			// Global route error boundary. RR bubbles any descendant route throw to
+			// the nearest errorElement; this is the only one, so every route crash
+			// (incl. lazy-chunk load failures past the vite:preloadError guard)
+			// renders the app's ErrorFallback instead of RR's default page.
+			errorElement: <RouteErrorBoundary />,
 			children: [
 				// Public routes
 				{ path: ROUTES.SIGN_IN, element: <SignInPage /> },

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -73,6 +73,14 @@ function suspendedScreen(el: ReactNode) {
 // the modal via the module-level handler. Wrapping `RouterProvider` from
 // `main.tsx` would not give the provider router context.
 function RootLayout() {
+	// Dev-only route-level crash trigger — the twin of main.tsx's `?boom` (which
+	// throws ABOVE the router to hit RootErrorBoundary). This throws INSIDE the
+	// router, so it exercises the route errorElement (RouteErrorBoundary) — the
+	// path a real route crash like the note editor takes. Visit `?routeboom`.
+	// Stripped from prod by the import.meta.env.DEV gate.
+	if (import.meta.env.DEV && new URLSearchParams(window.location.search).has("routeboom")) {
+		throw new Error("Intentional crash (?routeboom) — testing the route error boundary");
+	}
 	return (
 		<UpgradeDialogProvider>
 			<Outlet />

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -1,0 +1,82 @@
+import type { ErrorInfo } from "react";
+
+// Lazy Sentry singleton + crash reporter. Extracted from main.tsx so BOTH the
+// root boundary (main.tsx, catches bootstrap/app-shell throws above the router)
+// and the route boundary (router.tsx errorElement, catches route render throws
+// that React Router intercepts before they can reach the root) report through
+// ONE SDK instance. main.tsx imports router.tsx, so the reporter can't live in
+// main.tsx without a cycle back into the entry module — hence this leaf module.
+//
+// Opt-in via VITE_SENTRY_DSN at build time. No-op (zero network, zero SDK in the
+// eager bundle) when unset, so dev / self-host builds never ping the SaaS Sentry.
+// The SDK is dynamically imported so it stays out of the bundle that gates the
+// sign-in page; the early-error queue bridges the pre-init window so bootstrap
+// crashes that fire before the chunk lands still report. sentryReady resolves to
+// null when the chunk itself fails to load (ad-blockers match "sentry" in asset
+// URLs; stale-tab 404s) — callers must tolerate that and it must NOT surface as
+// an unhandled rejection.
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
+
+type SentrySdk = typeof import("@sentry/react");
+
+const earlyErrors: unknown[] = [];
+const onEarlyError = (e: ErrorEvent) => earlyErrors.push(e.error ?? e.message);
+const onEarlyRejection = (e: PromiseRejectionEvent) => earlyErrors.push(e.reason);
+if (sentryDsn) {
+	window.addEventListener("error", onEarlyError);
+	window.addEventListener("unhandledrejection", onEarlyRejection);
+}
+
+export const sentryReady: Promise<SentrySdk | null> | null = sentryDsn
+	? import("@sentry/react")
+			.then((Sentry) => {
+				Sentry.init({
+					dsn: sentryDsn,
+					environment: import.meta.env.MODE,
+					release: import.meta.env.VITE_GIT_SHA,
+					integrations: [],
+					// sendDefaultPii=false (SDK default) keeps cookies + the
+					// Authorization header out of breadcrumbs even if the SDK's
+					// own scrubbing misses something. Restated for documentation.
+					sendDefaultPii: false,
+				});
+				// The SDK's own global handlers are live from here; hand it the
+				// backlog and retire the temporary listeners.
+				window.removeEventListener("error", onEarlyError);
+				window.removeEventListener("unhandledrejection", onEarlyRejection);
+				for (const err of earlyErrors.splice(0)) {
+					Sentry.captureException(err);
+				}
+				return Sentry as SentrySdk;
+			})
+			.catch((err) => {
+				window.removeEventListener("error", onEarlyError);
+				window.removeEventListener("unhandledrejection", onEarlyRejection);
+				console.warn("[sentry] SDK failed to load — crash reporting disabled:", err);
+				return null;
+			})
+	: null;
+
+/**
+ * Report a crash and resolve to the Sentry eventId, or `undefined` when
+ * reporting is disabled (no DSN) or the SDK chunk failed to load. Callers derive
+ * an honest `reported` flag from a defined return — never claim "reported" with
+ * no transport behind it.
+ *
+ * Pass `errorInfo` for React render crashes (a class boundary's componentDidCatch
+ * has it) to attach the component stack via captureReactException — the same call
+ * Sentry.ErrorBoundary makes. Route errors from useRouteError carry no component
+ * stack, so they omit it and fall back to captureException.
+ */
+export async function captureError(
+	error: unknown,
+	errorInfo?: ErrorInfo,
+): Promise<string | undefined> {
+	const Sentry = await sentryReady;
+	if (!Sentry) {
+		return;
+	}
+	return errorInfo
+		? Sentry.captureReactException(error, errorInfo)
+		: Sentry.captureException(error);
+}

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -58,10 +58,19 @@ export const sentryReady: Promise<SentrySdk | null> | null = sentryDsn
 	: null;
 
 /**
- * Report a crash and resolve to the Sentry eventId, or `undefined` when
- * reporting is disabled (no DSN) or the SDK chunk failed to load. Callers derive
- * an honest `reported` flag from a defined return — never claim "reported" with
- * no transport behind it.
+ * Report a crash and resolve to the Sentry eventId, or `undefined` when the
+ * event was NOT delivered — reporting disabled (no DSN), SDK chunk failed to
+ * load, capture threw, or the envelope never reached the ingest host. Callers
+ * derive an honest `reported` flag from a defined return.
+ *
+ * captureException/captureReactException mint the eventId locally and return it
+ * BEFORE the network round-trip, so an id alone is not proof of delivery — the
+ * envelope POST to *.ingest.sentry.io is fire-and-forget and is routinely
+ * dropped (uBlock/EasyPrivacy block sentry.io, offline, ratelimit) even though
+ * the same-origin SDK chunk loaded fine. So we gate the returned id on
+ * flush() actually delivering: the UI must never say "reported" for an event
+ * that never left the browser. Never throws — the whole point is that the
+ * crash-reporting path can't itself become an unhandled rejection.
  *
  * Pass `errorInfo` for React render crashes (a class boundary's componentDidCatch
  * has it) to attach the component stack via captureReactException — the same call
@@ -76,7 +85,15 @@ export async function captureError(
 	if (!Sentry) {
 		return;
 	}
-	return errorInfo
-		? Sentry.captureReactException(error, errorInfo)
-		: Sentry.captureException(error);
+	try {
+		const eventId = errorInfo
+			? Sentry.captureReactException(error, errorInfo)
+			: Sentry.captureException(error);
+		// flush resolves true only if all queued envelopes were sent within the
+		// timeout; false on drop/timeout. Gate the id on real delivery.
+		const delivered = await Sentry.flush(2000);
+		return delivered ? eventId : undefined;
+	} catch (e) {
+		console.warn("[sentry] capture failed:", e);
+	}
 }

--- a/frontend/src/viewer/editor/blockquote-depth.css
+++ b/frontend/src/viewer/editor/blockquote-depth.css
@@ -1,0 +1,23 @@
+/*
+ * Nested-blockquote rendering. Atomic gives every `>` line one flat rail at a
+ * fixed 1rem indent (its depth logic is lists-only). blockquote-depth.ts sets
+ * a `--bq-depth` custom property per quote line; here we read it to indent by
+ * one level per `>` and draw one accent rail per level (replacing Atomic's
+ * single border rail). Depth 1 looks identical to before; `>>`/`>>>` nest.
+ *
+ * Loaded after Atomic's stylesheet (see live-preview.ts) so these win the
+ * cascade at equal specificity.
+ */
+.cm-line.cm-atomic-blockquote {
+	padding-left: calc(1rem * var(--bq-depth, 1));
+	/* One rail every 1rem, clipped to the indent width => one rail per level. */
+	border-left: none;
+	background-image: repeating-linear-gradient(
+		to right,
+		var(--atomic-editor-accent-soft, color-mix(in srgb, #7c3aed 72%, white 28%)) 0 3px,
+		transparent 3px 1rem
+	);
+	background-repeat: no-repeat;
+	background-position: left top;
+	background-size: calc(1rem * var(--bq-depth, 1)) 100%;
+}

--- a/frontend/src/viewer/editor/blockquote-depth.test.ts
+++ b/frontend/src/viewer/editor/blockquote-depth.test.ts
@@ -1,0 +1,35 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, test } from "vitest";
+import { blockquoteDepth, blockquoteDepthPlugin } from "./blockquote-depth";
+
+describe("blockquoteDepth", () => {
+	test("counts nesting from leading > markers", () => {
+		expect(blockquoteDepth("> a")).toBe(1);
+		expect(blockquoteDepth(">> b")).toBe(2);
+		expect(blockquoteDepth("> > c")).toBe(2);
+		expect(blockquoteDepth(">>> d")).toBe(3);
+		expect(blockquoteDepth("  > indented")).toBe(1);
+		expect(blockquoteDepth("plain")).toBe(0);
+		expect(blockquoteDepth("a > b")).toBe(0);
+	});
+});
+
+let view: EditorView;
+afterEach(() => view?.destroy());
+
+describe("blockquoteDepthPlugin", () => {
+	test("is view-only and sets --bq-depth per quote line", () => {
+		const doc = "> a\n>> b\nplain\n";
+		view = new EditorView({
+			state: EditorState.create({ doc, extensions: [blockquoteDepthPlugin] }),
+			parent: document.body,
+		});
+		// view-only: the document text is never mutated by the decoration.
+		expect(view.state.doc.toString()).toBe(doc);
+		const lines = [...view.dom.querySelectorAll<HTMLElement>(".cm-line")];
+		expect(lines[0]?.style.getPropertyValue("--bq-depth")).toBe("1");
+		expect(lines[1]?.style.getPropertyValue("--bq-depth")).toBe("2");
+		expect(lines[2]?.style.getPropertyValue("--bq-depth")).toBe("");
+	});
+});

--- a/frontend/src/viewer/editor/blockquote-depth.ts
+++ b/frontend/src/viewer/editor/blockquote-depth.ts
@@ -52,7 +52,10 @@ export const blockquoteDepthPlugin = ViewPlugin.fromClass(
 			this.decorations = buildBlockquoteDecorations(view);
 		}
 		update(u: ViewUpdate) {
-			if (u.docChanged || u.viewportChanged) {
+			// Whole-doc scan → whole-doc line decorations: no viewport dependency,
+			// so only a doc change can alter the output. (Offscreen line decos are
+			// already in the RangeSet and render as lines scroll into view.)
+			if (u.docChanged) {
 				this.decorations = buildBlockquoteDecorations(u.view);
 			}
 		}

--- a/frontend/src/viewer/editor/blockquote-depth.ts
+++ b/frontend/src/viewer/editor/blockquote-depth.ts
@@ -1,0 +1,61 @@
+import { type Range, RangeSetBuilder } from "@codemirror/state";
+import {
+	Decoration,
+	type DecorationSet,
+	type EditorView,
+	ViewPlugin,
+	type ViewUpdate,
+} from "@codemirror/view";
+
+// Atomic renders every blockquote line with one flat rail (no nesting). We set
+// a `--bq-depth` custom property per quote line; blockquote-depth.css reads it
+// to indent and draw one rail per nesting level. View-only: only line
+// attributes, never a document change — safe over the yCollab Y.Text binding.
+function buildBlockquoteDecorations(view: EditorView): DecorationSet {
+	const ranges: Range<Decoration>[] = [];
+	// ponytail: whole-doc scan (matches Atomic's own approach; fine for typical
+	// note sizes). Line decorations must be added at line-start in ascending order.
+	const { doc } = view.state;
+	for (let n = 1; n <= doc.lines; n++) {
+		const line = doc.line(n);
+		const depth = blockquoteDepth(line.text);
+		if (depth > 0) {
+			ranges.push(
+				Decoration.line({ attributes: { style: `--bq-depth:${depth}` } }).range(line.from),
+			);
+		}
+	}
+	const builder = new RangeSetBuilder<Decoration>();
+	for (const r of ranges) {
+		builder.add(r.from, r.to, r.value);
+	}
+	return builder.finish();
+}
+
+/**
+ * Count a line's blockquote nesting depth from its leading `>` markers.
+ * `> a` -> 1, `>> b` / `> > c` -> 2, `>>> d` -> 3, plain text -> 0.
+ * A `>` that isn't at the start of the line (e.g. `a > b`) is not a quote.
+ */
+export function blockquoteDepth(lineText: string): number {
+	const prefix = lineText.match(/^(?:\s*>)+/);
+	if (!prefix) {
+		return 0;
+	}
+	return (prefix[0].match(/>/g) ?? []).length;
+}
+
+export const blockquoteDepthPlugin = ViewPlugin.fromClass(
+	class {
+		decorations: DecorationSet;
+		constructor(view: EditorView) {
+			this.decorations = buildBlockquoteDecorations(view);
+		}
+		update(u: ViewUpdate) {
+			if (u.docChanged || u.viewportChanged) {
+				this.decorations = buildBlockquoteDecorations(u.view);
+			}
+		}
+	},
+	{ decorations: (v) => v.decorations },
+);

--- a/frontend/src/viewer/editor/callout-decoration.test.ts
+++ b/frontend/src/viewer/editor/callout-decoration.test.ts
@@ -1,0 +1,55 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, test } from "vitest";
+import { calloutDecoration } from "./callout-decoration";
+
+let view: EditorView;
+afterEach(() => view?.destroy());
+
+describe("calloutDecoration", () => {
+	test("marks a callout block's lines without changing the doc text", () => {
+		const doc = "before\n\n> [!note] Title\n> body line\n\nafter\n";
+		view = new EditorView({
+			state: EditorState.create({ doc, extensions: [calloutDecoration] }),
+			parent: document.body,
+		});
+		expect(view.state.doc.toString()).toBe(doc); // view-only
+		const marked = view.dom.querySelectorAll(".cm-callout.cm-callout-note");
+		expect(marked.length).toBe(2); // title line + body line
+	});
+
+	test("lowercases the callout type for the class name", () => {
+		const doc = "intro\n\n> [!WARNING] Careful\n> details\n";
+		view = new EditorView({
+			state: EditorState.create({ doc, extensions: [calloutDecoration] }),
+			parent: document.body,
+		});
+		expect(view.state.doc.toString()).toBe(doc);
+		expect(view.dom.querySelectorAll(".cm-callout-warning").length).toBe(2);
+	});
+
+	test("reveals raw source when the selection intersects the callout block", () => {
+		const doc = "> [!note] Title\n> body line\n";
+		view = new EditorView({
+			state: EditorState.create({
+				doc,
+				selection: { anchor: 5 },
+				extensions: [calloutDecoration],
+			}),
+			parent: document.body,
+		});
+		expect(view.state.doc.toString()).toBe(doc);
+		expect(view.dom.querySelectorAll(".cm-callout").length).toBe(0);
+	});
+
+	test("does not merge two adjacent callouts with no blank line between them", () => {
+		const doc = "before\n\n> [!note] A\n> body\n> [!warning] B\n> body2\n\nafter\n";
+		view = new EditorView({
+			state: EditorState.create({ doc, extensions: [calloutDecoration] }),
+			parent: document.body,
+		});
+		expect(view.state.doc.toString()).toBe(doc); // view-only
+		expect(view.dom.querySelectorAll(".cm-callout-note").length).toBe(2);
+		expect(view.dom.querySelectorAll(".cm-callout-warning").length).toBe(2);
+	});
+});

--- a/frontend/src/viewer/editor/callout-decoration.ts
+++ b/frontend/src/viewer/editor/callout-decoration.ts
@@ -1,0 +1,68 @@
+import { RangeSetBuilder } from "@codemirror/state";
+import {
+	Decoration,
+	type DecorationSet,
+	type EditorView,
+	ViewPlugin,
+	type ViewUpdate,
+} from "@codemirror/view";
+import "./callout.css";
+
+// First line of a callout block: `> [!type]` optionally followed by a title.
+const CALLOUT_START_RE = /^>\s*\[!(?<type>\w+)\]/;
+// Any blockquote continuation line.
+const BLOCKQUOTE_LINE_RE = /^>/;
+
+function buildCallouts(view: EditorView): DecorationSet {
+	const { doc, selection: sel } = view.state;
+	const builder = new RangeSetBuilder<Decoration>();
+	// ponytail: whole-doc scan; fine for typical note sizes. Same tradeoff as
+	// katex-decoration.ts — view.visibleRanges is empty under happy-dom.
+	let lineNo = 1;
+	while (lineNo <= doc.lines) {
+		const line = doc.line(lineNo);
+		const m = CALLOUT_START_RE.exec(line.text);
+		if (!m) {
+			lineNo++;
+			continue;
+		}
+		const type = (m.groups?.type ?? "").toLowerCase();
+		let endLineNo = lineNo;
+		while (endLineNo + 1 <= doc.lines) {
+			const nextText = doc.line(endLineNo + 1).text;
+			// A new `> [!type]` header always starts a fresh block, even though
+			// it also matches the blockquote continuation regex.
+			if (!BLOCKQUOTE_LINE_RE.test(nextText) || CALLOUT_START_RE.test(nextText)) {
+				break;
+			}
+			endLineNo++;
+		}
+		const blockFrom = line.from;
+		const blockTo = doc.line(endLineNo).to;
+		// Reveal raw when the cursor/selection intersects the block.
+		const active = sel.ranges.some((r) => r.from <= blockTo && r.to >= blockFrom);
+		if (!active) {
+			const deco = Decoration.line({ attributes: { class: `cm-callout cm-callout-${type}` } });
+			for (let n = lineNo; n <= endLineNo; n++) {
+				builder.add(doc.line(n).from, doc.line(n).from, deco);
+			}
+		}
+		lineNo = endLineNo + 1;
+	}
+	return builder.finish();
+}
+
+export const calloutDecoration = ViewPlugin.fromClass(
+	class {
+		decorations: DecorationSet;
+		constructor(view: EditorView) {
+			this.decorations = buildCallouts(view);
+		}
+		update(u: ViewUpdate) {
+			if (u.docChanged || u.selectionSet || u.viewportChanged) {
+				this.decorations = buildCallouts(u.view);
+			}
+		}
+	},
+	{ decorations: (v) => v.decorations },
+);

--- a/frontend/src/viewer/editor/callout.css
+++ b/frontend/src/viewer/editor/callout.css
@@ -1,0 +1,21 @@
+.cm-callout {
+	border-left: 3px solid var(--color-border, #888);
+	background: var(--color-callout-bg, rgba(128, 128, 128, 0.08));
+	padding-left: 0.5em;
+}
+
+.cm-callout-note {
+	border-left-color: #448aff;
+}
+
+.cm-callout-warning {
+	border-left-color: #e6a700;
+}
+
+.cm-callout-tip {
+	border-left-color: #00bfa5;
+}
+
+.cm-callout-danger {
+	border-left-color: #ff5252;
+}

--- a/frontend/src/viewer/editor/format-commands.test.ts
+++ b/frontend/src/viewer/editor/format-commands.test.ts
@@ -1,0 +1,41 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, test } from "vitest";
+import { toggleLinePrefix, toggleWrap } from "./format-commands";
+
+let view: EditorView;
+afterEach(() => view?.destroy());
+
+function mount(doc: string, from: number, to: number): EditorView {
+	view = new EditorView({
+		state: EditorState.create({ doc, selection: { anchor: from, head: to } }),
+		parent: document.body,
+	});
+	return view;
+}
+
+describe("format-commands", () => {
+	test("toggleWrap wraps the selection with markers", () => {
+		mount("hello world", 0, 5); // "hello"
+		toggleWrap(view, "**");
+		expect(view.state.doc.toString()).toBe("**hello** world");
+	});
+
+	test("toggleLinePrefix adds a heading prefix to the caret line", () => {
+		mount("title", 0, 0);
+		toggleLinePrefix(view, "# ");
+		expect(view.state.doc.toString()).toBe("# title");
+	});
+
+	test("toggleLinePrefix does not prefix a line the selection only touches at its start boundary", () => {
+		mount("one\ntwo\nthree", 0, 8); // ends exactly at the start of "three"
+		toggleLinePrefix(view, "# ");
+		expect(view.state.doc.toString()).toBe("# one\n# two\nthree");
+	});
+
+	test("toggleLinePrefix is idempotent on an already-prefixed line", () => {
+		mount("# already\nplain", 0, 0);
+		toggleLinePrefix(view, "# ");
+		expect(view.state.doc.toString()).toBe("# already\nplain");
+	});
+});

--- a/frontend/src/viewer/editor/format-commands.ts
+++ b/frontend/src/viewer/editor/format-commands.ts
@@ -1,0 +1,51 @@
+import { indentWithTab } from "@codemirror/commands";
+import { type ChangeSpec, EditorSelection, type Extension } from "@codemirror/state";
+import { type EditorView, keymap } from "@codemirror/view";
+
+/** Tab indents / Shift-Tab dedents the selected lines (Obsidian parity). */
+export const indentKeymap: Extension = keymap.of([indentWithTab]);
+
+/** Wrap each selection range with `before`/`after` markers (e.g. ** for bold). */
+export function toggleWrap(view: EditorView, before: string, after: string = before): void {
+	view.dispatch(
+		view.state.changeByRange((range) => ({
+			changes: [
+				{ from: range.from, insert: before },
+				{ from: range.to, insert: after },
+			],
+			range: EditorSelection.range(range.from + before.length, range.to + before.length),
+		})),
+	);
+	view.focus();
+}
+
+/** Prepend `prefix` (e.g. "# ", "> ", "- ") to each line the selection touches. */
+export function toggleLinePrefix(view: EditorView, prefix: string): void {
+	const { state } = view;
+	const changes: ChangeSpec[] = [];
+	const seen = new Set<number>();
+	for (const range of state.selection.ranges) {
+		// Mirror CodeMirror's selectedLineBlocks: a non-empty selection ending exactly
+		// at the start of a line does not select any character of that line.
+		const endPos =
+			!range.empty && state.doc.lineAt(range.to).from === range.to ? range.to - 1 : range.to;
+		let pos = range.from;
+		while (pos <= endPos) {
+			const line = state.doc.lineAt(pos);
+			if (!seen.has(line.number)) {
+				seen.add(line.number);
+				if (!line.text.startsWith(prefix)) {
+					changes.push({ from: line.from, insert: prefix });
+				}
+			}
+			pos = line.to + 1;
+			if (line.to >= state.doc.length) {
+				break;
+			}
+		}
+	}
+	if (changes.length > 0) {
+		view.dispatch({ changes });
+	}
+	view.focus();
+}

--- a/frontend/src/viewer/editor/katex-decoration.test.ts
+++ b/frontend/src/viewer/editor/katex-decoration.test.ts
@@ -28,6 +28,22 @@ describe("katexDecoration", () => {
 		expect(view.dom.querySelector(".cm-katex-widget")).not.toBeNull();
 	});
 
+	test("renders multi-line block math ($$\\n...\\n$$) without throwing", () => {
+		// Regression: a ViewPlugin may not emit a replace decoration that spans a
+		// line break — CM6 throws "Decorations that replace line breaks may not be
+		// specified via plugins" on update. This multi-line block must render via a
+		// StateField block widget. A single-line $$...$$ never exercised the rule.
+		const doc = "before\n\n$$\n\\int_0^\\infty e^{-x}\\,dx = 1\n$$\n\nafter\n";
+		view = new EditorView({
+			state: EditorState.create({ doc, extensions: [katexDecoration] }),
+			parent: document.body,
+		});
+		// Force an update cycle — the restriction is enforced at view-update time.
+		view.dispatch({ changes: { from: 0, insert: "x" } });
+		expect(view.state.doc.toString().endsWith("after\n")).toBe(true);
+		expect(view.dom.querySelector(".cm-katex-widget")).not.toBeNull();
+	});
+
 	test("reveals raw source when the cursor is inside the math span", () => {
 		const doc = "$E=mc^2$\n";
 		view = new EditorView({

--- a/frontend/src/viewer/editor/katex-decoration.test.ts
+++ b/frontend/src/viewer/editor/katex-decoration.test.ts
@@ -1,0 +1,44 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, test } from "vitest";
+import { katexDecoration } from "./katex-decoration";
+
+let view: EditorView;
+afterEach(() => view?.destroy());
+
+describe("katexDecoration", () => {
+	test("renders inline math as a widget without changing the doc text", () => {
+		const doc = "before $E=mc^2$ after\n";
+		view = new EditorView({
+			state: EditorState.create({ doc, extensions: [katexDecoration] }),
+			parent: document.body,
+		});
+		expect(view.state.doc.toString()).toBe(doc); // view-only
+		// A katex-rendered node exists in the DOM (widget mounted).
+		expect(view.dom.querySelector(".katex, .cm-katex-widget")).not.toBeNull();
+	});
+
+	test("renders block math ($$...$$) as a widget", () => {
+		const doc = "before\n\n$$a^2+b^2=c^2$$\n\nafter\n";
+		view = new EditorView({
+			state: EditorState.create({ doc, extensions: [katexDecoration] }),
+			parent: document.body,
+		});
+		expect(view.state.doc.toString()).toBe(doc);
+		expect(view.dom.querySelector(".cm-katex-widget")).not.toBeNull();
+	});
+
+	test("reveals raw source when the cursor is inside the math span", () => {
+		const doc = "$E=mc^2$\n";
+		view = new EditorView({
+			state: EditorState.create({
+				doc,
+				selection: { anchor: 2 },
+				extensions: [katexDecoration],
+			}),
+			parent: document.body,
+		});
+		expect(view.state.doc.toString()).toBe(doc);
+		expect(view.dom.querySelector(".cm-katex-widget")).toBeNull();
+	});
+});

--- a/frontend/src/viewer/editor/katex-decoration.ts
+++ b/frontend/src/viewer/editor/katex-decoration.ts
@@ -1,12 +1,5 @@
-import { type Range, RangeSetBuilder } from "@codemirror/state";
-import {
-	Decoration,
-	type DecorationSet,
-	type EditorView,
-	ViewPlugin,
-	type ViewUpdate,
-	WidgetType,
-} from "@codemirror/view";
+import { type EditorState, type Range, RangeSetBuilder, StateField } from "@codemirror/state";
+import { Decoration, type DecorationSet, EditorView, WidgetType } from "@codemirror/view";
 import katex from "katex";
 import "katex/dist/katex.min.css";
 
@@ -21,17 +14,17 @@ class MathWidget extends WidgetType {
 		return other.tex === this.tex && other.block === this.block;
 	}
 	toDOM() {
-		const span = document.createElement("span");
-		span.className = "cm-katex-widget";
+		const el = document.createElement(this.block ? "div" : "span");
+		el.className = "cm-katex-widget";
 		try {
-			span.innerHTML = katex.renderToString(this.tex, {
+			el.innerHTML = katex.renderToString(this.tex, {
 				displayMode: this.block,
 				throwOnError: false,
 			});
 		} catch {
-			span.textContent = this.block ? `$$${this.tex}$$` : `$${this.tex}$`;
+			el.textContent = this.block ? `$$${this.tex}$$` : `$${this.tex}$`;
 		}
-		return span;
+		return el;
 	}
 	ignoreEvent() {
 		return false;
@@ -42,14 +35,10 @@ class MathWidget extends WidgetType {
 // a full TeX tokenizer — matches Obsidian's pragmatic $ delimiters.
 const MATH_RE = /\$\$(?<block>[^$]+)\$\$|\$(?<inline>[^$\n]+)\$/g;
 
-function buildMath(view: EditorView): DecorationSet {
+function buildMath(state: EditorState): DecorationSet {
 	const ranges: Range<Decoration>[] = [];
-	const { selection: sel } = view.state;
-	// ponytail: whole-doc scan; fine for typical note sizes. view.visibleRanges
-	// is empty under happy-dom (no layout in tests) and unreliable pre-first-measure
-	// in general, so we mirror Atomic's own ensureSyntaxTree whole-doc walk instead
-	// of CM6's usual viewport-only decoration pattern.
-	const text = view.state.sliceDoc(0);
+	const sel = state.selection;
+	const text = state.sliceDoc(0);
 	for (const m of text.matchAll(MATH_RE)) {
 		const start = m.index ?? 0;
 		const end = start + m[0].length;
@@ -59,9 +48,20 @@ function buildMath(view: EditorView): DecorationSet {
 			continue;
 		}
 		const { block: blockTex, inline: inlineTex } = m.groups ?? {};
-		const block = blockTex !== undefined;
 		const tex = (blockTex ?? inlineTex ?? "").trim();
-		ranges.push(Decoration.replace({ widget: new MathWidget(tex, block) }).range(start, end));
+		// A `$$…$$` match is display math ONLY when it occupies whole lines (its own
+		// paragraph). Then it becomes a block widget — the one decoration shape that
+		// MUST live in a StateField, never a ViewPlugin (CM6 rejects line-break-
+		// spanning / block decorations from plugins). Mid-line `$$x$$` stays an
+		// inline replace so we never emit an invalid block decoration.
+		const wholeLine =
+			blockTex !== undefined &&
+			state.doc.lineAt(start).from === start &&
+			state.doc.lineAt(end).to === end;
+		const spec = wholeLine
+			? { widget: new MathWidget(tex, true), block: true }
+			: { widget: new MathWidget(tex, false) };
+		ranges.push(Decoration.replace(spec).range(start, end));
 	}
 	const builder = new RangeSetBuilder<Decoration>();
 	for (const r of ranges.sort((a, b) => a.from - b.from)) {
@@ -70,17 +70,16 @@ function buildMath(view: EditorView): DecorationSet {
 	return builder.finish();
 }
 
-export const katexDecoration = ViewPlugin.fromClass(
-	class {
-		decorations: DecorationSet;
-		constructor(view: EditorView) {
-			this.decorations = buildMath(view);
+// StateField (not ViewPlugin): block math replaces line breaks, which CM6 only
+// permits from the decorations facet fed by a state field. Rebuild on any doc or
+// selection change so the reveal-on-cursor behaviour still works.
+export const katexDecoration = StateField.define<DecorationSet>({
+	create: (state) => buildMath(state),
+	update(value, tr) {
+		if (tr.docChanged || tr.selection) {
+			return buildMath(tr.state);
 		}
-		update(u: ViewUpdate) {
-			if (u.docChanged || u.selectionSet || u.viewportChanged) {
-				this.decorations = buildMath(u.view);
-			}
-		}
+		return value;
 	},
-	{ decorations: (v) => v.decorations },
-);
+	provide: (f) => EditorView.decorations.from(f),
+});

--- a/frontend/src/viewer/editor/katex-decoration.ts
+++ b/frontend/src/viewer/editor/katex-decoration.ts
@@ -1,0 +1,86 @@
+import { type Range, RangeSetBuilder } from "@codemirror/state";
+import {
+	Decoration,
+	type DecorationSet,
+	type EditorView,
+	ViewPlugin,
+	type ViewUpdate,
+	WidgetType,
+} from "@codemirror/view";
+import katex from "katex";
+import "katex/dist/katex.min.css";
+
+class MathWidget extends WidgetType {
+	constructor(
+		private readonly tex: string,
+		private readonly block: boolean,
+	) {
+		super();
+	}
+	eq(other: MathWidget) {
+		return other.tex === this.tex && other.block === this.block;
+	}
+	toDOM() {
+		const span = document.createElement("span");
+		span.className = "cm-katex-widget";
+		try {
+			span.innerHTML = katex.renderToString(this.tex, {
+				displayMode: this.block,
+				throwOnError: false,
+			});
+		} catch {
+			span.textContent = this.block ? `$$${this.tex}$$` : `$${this.tex}$`;
+		}
+		return span;
+	}
+	ignoreEvent() {
+		return false;
+	}
+}
+
+// Match $$...$$ (block) or $...$ (inline, no newline). Minimal, deliberately not
+// a full TeX tokenizer — matches Obsidian's pragmatic $ delimiters.
+const MATH_RE = /\$\$(?<block>[^$]+)\$\$|\$(?<inline>[^$\n]+)\$/g;
+
+function buildMath(view: EditorView): DecorationSet {
+	const ranges: Range<Decoration>[] = [];
+	const { selection: sel } = view.state;
+	// ponytail: whole-doc scan; fine for typical note sizes. view.visibleRanges
+	// is empty under happy-dom (no layout in tests) and unreliable pre-first-measure
+	// in general, so we mirror Atomic's own ensureSyntaxTree whole-doc walk instead
+	// of CM6's usual viewport-only decoration pattern.
+	const text = view.state.sliceDoc(0);
+	for (const m of text.matchAll(MATH_RE)) {
+		const start = m.index ?? 0;
+		const end = start + m[0].length;
+		// Reveal raw when the cursor/selection intersects the span.
+		const active = sel.ranges.some((r) => r.from <= end && r.to >= start);
+		if (active) {
+			continue;
+		}
+		const { block: blockTex, inline: inlineTex } = m.groups ?? {};
+		const block = blockTex !== undefined;
+		const tex = (blockTex ?? inlineTex ?? "").trim();
+		ranges.push(Decoration.replace({ widget: new MathWidget(tex, block) }).range(start, end));
+	}
+	const builder = new RangeSetBuilder<Decoration>();
+	for (const r of ranges.sort((a, b) => a.from - b.from)) {
+		builder.add(r.from, r.to, r.value);
+	}
+	return builder.finish();
+}
+
+export const katexDecoration = ViewPlugin.fromClass(
+	class {
+		decorations: DecorationSet;
+		constructor(view: EditorView) {
+			this.decorations = buildMath(view);
+		}
+		update(u: ViewUpdate) {
+			if (u.docChanged || u.selectionSet || u.viewportChanged) {
+				this.decorations = buildMath(u.view);
+			}
+		}
+	},
+	{ decorations: (v) => v.decorations },
+);

--- a/frontend/src/viewer/editor/live-preview.test.ts
+++ b/frontend/src/viewer/editor/live-preview.test.ts
@@ -1,0 +1,19 @@
+import { EditorState } from "@codemirror/state";
+import { describe, expect, test } from "vitest";
+import { livePreviewExtensions } from "./live-preview";
+
+const MD = "# Heading\n\n**bold** and *italic* and [[Wiki Link]]\n";
+
+describe("livePreviewExtensions", () => {
+	test("is view-only: decorations never change the document text", () => {
+		const ext = livePreviewExtensions({ resolveWikiLink: (n) => `/notes/${n}` });
+		const state = EditorState.create({ doc: MD, extensions: ext });
+		// Building state + reading facets must not alter doc bytes.
+		expect(state.doc.toString()).toBe(MD);
+	});
+
+	test("does not throw when composed with markdown language", () => {
+		const ext = livePreviewExtensions({ resolveWikiLink: (n) => `/notes/${n}` });
+		expect(() => EditorState.create({ doc: MD, extensions: ext })).not.toThrow();
+	});
+});

--- a/frontend/src/viewer/editor/live-preview.ts
+++ b/frontend/src/viewer/editor/live-preview.ts
@@ -11,6 +11,8 @@ import {
 import "@atomic-editor/editor/styles.css";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import type { Extension } from "@codemirror/state";
+import { calloutDecoration } from "./callout-decoration";
+import { katexDecoration } from "./katex-decoration";
 
 export interface LivePreviewOpts {
 	resolveWikiLink: (name: string) => string;
@@ -22,8 +24,8 @@ export interface LivePreviewOpts {
  * Y.Text binding (see note-editor.tsx) is untouched. Wire wikilinks to our SPA
  * routes; the click-to-open navigation is a hard `window.location` nav, matching
  * the plain `<a href>` wikilinks already rendered in Reading mode (note-view.tsx
- * hrefTemplate) rather than a router push. Callouts/KaTeX are added in Task 6 as
- * sibling extensions.
+ * hrefTemplate) rather than a router push. Callouts/KaTeX are sibling view-only
+ * decoration extensions (see callout-decoration.ts, katex-decoration.ts).
  */
 export function livePreviewExtensions(opts: LivePreviewOpts): Extension[] {
 	return [
@@ -47,5 +49,7 @@ export function livePreviewExtensions(opts: LivePreviewOpts): Extension[] {
 				window.location.assign(opts.resolveWikiLink(target));
 			},
 		}),
+		calloutDecoration,
+		katexDecoration,
 	];
 }

--- a/frontend/src/viewer/editor/live-preview.ts
+++ b/frontend/src/viewer/editor/live-preview.ts
@@ -1,0 +1,51 @@
+import {
+	atomicEditorTheme,
+	atomicMarkdownSyntax,
+	highlightMarkdown,
+	imageBlocks,
+	inlinePreview,
+	tables,
+	wikiLinks,
+} from "@atomic-editor/editor";
+// Atomic ships decoration CSS separately; import once so widgets render.
+import "@atomic-editor/editor/styles.css";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import type { Extension } from "@codemirror/state";
+
+export interface LivePreviewOpts {
+	resolveWikiLink: (name: string) => string;
+}
+
+/**
+ * The Rendered-mode decoration layer. Pure CM6 extensions (view-only): they
+ * decorate the markdown source but never mutate EditorState.doc, so the yCollab
+ * Y.Text binding (see note-editor.tsx) is untouched. Wire wikilinks to our SPA
+ * routes; the click-to-open navigation is a hard `window.location` nav, matching
+ * the plain `<a href>` wikilinks already rendered in Reading mode (note-view.tsx
+ * hrefTemplate) rather than a router push. Callouts/KaTeX are added in Task 6 as
+ * sibling extensions.
+ */
+export function livePreviewExtensions(opts: LivePreviewOpts): Extension[] {
+	return [
+		markdown({ base: markdownLanguage, extensions: [highlightMarkdown] }),
+		// Applies the syntax-highlight *colors* for the markdown grammar tags
+		// `highlightMarkdown` adds (headings, emphasis, etc). Without this the
+		// live-preview text renders unstyled — atomicEditorTheme alone only sets
+		// layout/surface colors, not per-token highlighting.
+		atomicMarkdownSyntax,
+		atomicEditorTheme,
+		tables({}),
+		imageBlocks(),
+		inlinePreview({}),
+		wikiLinks({
+			// Atomic's `resolve` is async and returns a display target, not a
+			// plain string like our `resolveWikiLink` — wrap it. We have no
+			// existence check, so every link resolves (status "resolved");
+			// `label` stays the raw wikilink text.
+			resolve: (target) => Promise.resolve({ target: opts.resolveWikiLink(target), label: target }),
+			onOpen: (target) => {
+				window.location.assign(opts.resolveWikiLink(target));
+			},
+		}),
+	];
+}

--- a/frontend/src/viewer/editor/live-preview.ts
+++ b/frontend/src/viewer/editor/live-preview.ts
@@ -9,8 +9,15 @@ import {
 } from "@atomic-editor/editor";
 // Atomic ships decoration CSS separately; import once so widgets render.
 import "@atomic-editor/editor/styles.css";
+// Obsidian-default palette: set Atomic's CSS vars per theme (must come AFTER
+// the Atomic stylesheet so our values win the cascade).
+import "./obsidian-theme.css";
+// Nested-blockquote depth rendering (Atomic renders `>` flat). Load after
+// Atomic's stylesheet so the depth-aware rules win the cascade.
+import "./blockquote-depth.css";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import type { Extension } from "@codemirror/state";
+import { blockquoteDepthPlugin } from "./blockquote-depth";
 import { calloutDecoration } from "./callout-decoration";
 import { katexDecoration } from "./katex-decoration";
 
@@ -51,5 +58,6 @@ export function livePreviewExtensions(opts: LivePreviewOpts): Extension[] {
 		}),
 		calloutDecoration,
 		katexDecoration,
+		blockquoteDepthPlugin,
 	];
 }

--- a/frontend/src/viewer/editor/obsidian-theme.css
+++ b/frontend/src/viewer/editor/obsidian-theme.css
@@ -1,0 +1,37 @@
+/*
+ * Obsidian-default color palette for the live-preview editor.
+ *
+ * Atomic Editor is fully CSS-variable driven; its built-in fallbacks are
+ * dark-theme values (e.g. --atomic-editor-fg defaults to #dcddde), so in light
+ * mode headings/body render washed-out. We set the vars per theme to match
+ * Obsidian's default light/dark palette. Token-driven, no !important.
+ *
+ * Scope: light values on .cm-editor; dark values under `.dark .cm-editor`
+ * (the app adds a `.dark` class to <html> — see theme/resolve.ts).
+ */
+
+.cm-editor {
+	/* Obsidian default (light) */
+	--atomic-editor-fg: #222222; /* --text-normal */
+	--atomic-editor-fg-muted: #6e6e6e; /* --text-muted (syntax markers, bullets) */
+	--atomic-editor-fg-faint: #a0a0a0; /* --text-faint (hidden markers, blockquote) */
+	--atomic-editor-link: #6b4ce6; /* accent purple, darkened for light-bg contrast */
+	--atomic-editor-link-hover: #5738c4;
+	--atomic-editor-accent: #7c5cff; /* --interactive-accent */
+	--atomic-editor-border: #e2e2e4;
+	--atomic-editor-code-bg: rgba(0, 0, 0, 0.045);
+	--atomic-editor-code-rail: rgba(124, 92, 255, 0.35);
+}
+
+.dark .cm-editor {
+	/* Obsidian default (dark) */
+	--atomic-editor-fg: #dcddde; /* --text-normal */
+	--atomic-editor-fg-muted: #999999; /* --text-muted */
+	--atomic-editor-fg-faint: #666666; /* --text-faint */
+	--atomic-editor-link: #8b6cef; /* accent purple (hsl 254 80% 68%) */
+	--atomic-editor-link-hover: #a78bfa;
+	--atomic-editor-accent: #8b6cef;
+	--atomic-editor-border: #333333;
+	--atomic-editor-code-bg: rgba(255, 255, 255, 0.06);
+	--atomic-editor-code-rail: rgba(139, 108, 239, 0.5);
+}

--- a/frontend/src/viewer/editor/raw-frontmatter-editor.test.tsx
+++ b/frontend/src/viewer/editor/raw-frontmatter-editor.test.tsx
@@ -1,0 +1,98 @@
+import { EditorView } from "@codemirror/view";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import * as Y from "yjs";
+import { readRows } from "../../crdt/frontmatter-doc";
+import { commitYaml, RawFrontmatterEditor } from "./raw-frontmatter-editor";
+
+afterEach(() => {
+	vi.useRealTimers();
+	cleanup();
+});
+
+describe("commitYaml", () => {
+	test("applies valid YAML as a canonical (non-double-encoded) string value", () => {
+		const doc = new Y.Doc();
+		expect(commitYaml(doc, "title: Hi\n")).toBe("ok");
+		expect(readRows(doc)).toEqual([{ key: "title", value: "Hi", typeOverride: null }]);
+	});
+
+	test("applies valid YAML with number typing end-to-end", () => {
+		const doc = new Y.Doc();
+		expect(commitYaml(doc, "count: 3\n")).toBe("ok");
+		expect(readRows(doc)).toEqual([{ key: "count", value: 3, typeOverride: null }]);
+	});
+
+	test("rejects invalid YAML without mutating the Y.Map", () => {
+		const doc = new Y.Doc();
+		doc.transact(() => {
+			doc.getMap<string>("frontmatter").set("title", JSON.stringify("Keep"));
+			doc.getArray<string>("frontmatter_order").insert(0, ["title"]);
+		});
+		const before = readRows(doc);
+		expect(commitYaml(doc, "title: [broken\n")).toBe("invalid");
+		expect(readRows(doc)).toEqual(before);
+		expect(readRows(doc)).toEqual([{ key: "title", value: "Keep", typeOverride: null }]);
+	});
+
+	test("tolerates a missing trailing newline", () => {
+		const doc = new Y.Doc();
+		expect(commitYaml(doc, "title: Hi")).toBe("ok");
+		expect(readRows(doc)).toEqual([{ key: "title", value: "Hi", typeOverride: null }]);
+	});
+});
+
+describe("RawFrontmatterEditor", () => {
+	test("seeds the CodeMirror editor from the Y.Map on mount", () => {
+		const doc = new Y.Doc();
+		doc.transact(() => {
+			doc.getMap<string>("frontmatter").set("title", JSON.stringify("Old"));
+			doc.getArray<string>("frontmatter_order").insert(0, ["title"]);
+		});
+		const { container } = render(<RawFrontmatterEditor doc={doc} />);
+		const editor = container.querySelector(".cm-content");
+		expect(editor?.textContent).toContain("title: Old");
+	});
+
+	test("a real keystroke, after the debounce, commits to the Y.Map (and the marker clears on a subsequent valid edit)", () => {
+		vi.useFakeTimers();
+		const doc = new Y.Doc();
+		doc.transact(() => {
+			doc.getMap<string>("frontmatter").set("title", JSON.stringify("Old"));
+			doc.getArray<string>("frontmatter_order").insert(0, ["title"]);
+		});
+		const { container } = render(<RawFrontmatterEditor doc={doc} />);
+		const editorDom = container.querySelector(".cm-editor") as HTMLElement;
+		const view = EditorView.findFromDOM(editorDom);
+		expect(view).not.toBeNull();
+
+		// Drive a real editor transaction (not the Y.Map directly) replacing the
+		// whole doc with new, valid YAML — proves the updateListener -> debounce
+		// -> commitYaml wiring, not just commitYaml in isolation.
+		view!.dispatch({
+			changes: { from: 0, to: view!.state.doc.length, insert: "title: New\n" },
+		});
+
+		// Not yet committed: debounce hasn't elapsed.
+		expect(readRows(doc)).toEqual([{ key: "title", value: "Old", typeOverride: null }]);
+
+		act(() => {
+			vi.advanceTimersByTime(400);
+		});
+
+		expect(readRows(doc)).toEqual([{ key: "title", value: "New", typeOverride: null }]);
+		expect(container.querySelector('[class*="text-destructive"]')).toBeNull();
+
+		// Now drive an invalid edit through the same real path and confirm the
+		// marker appears and the Y.Map is left at its last-valid state.
+		view!.dispatch({
+			changes: { from: 0, to: view!.state.doc.length, insert: "title: [broken\n" },
+		});
+		act(() => {
+			vi.advanceTimersByTime(400);
+		});
+
+		expect(readRows(doc)).toEqual([{ key: "title", value: "New", typeOverride: null }]);
+		expect(container.querySelector('[class*="text-destructive"]')).not.toBeNull();
+	});
+});

--- a/frontend/src/viewer/editor/raw-frontmatter-editor.tsx
+++ b/frontend/src/viewer/editor/raw-frontmatter-editor.tsx
@@ -1,0 +1,108 @@
+import { defaultKeymap } from "@codemirror/commands";
+import { yaml } from "@codemirror/lang-yaml";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap } from "@codemirror/view";
+import { useEffect, useRef, useState } from "react";
+import type * as Y from "yjs";
+import { parseFrontmatter } from "../../crdt/frontmatter-codec";
+import {
+	applyParsedFrontmatter,
+	emitFrontmatterText,
+	frontmatterMaps,
+} from "../../crdt/frontmatter-doc";
+
+export const COMMIT_DEBOUNCE_MS = 400;
+
+/**
+ * Parse `text` as a frontmatter block and apply it to the doc's frontmatter
+ * Y.Map. Returns "invalid" and leaves the Y.Map untouched on a parse
+ * failure — last-valid state stays authoritative until the user fixes the
+ * YAML.
+ */
+export function commitYaml(doc: Y.Doc, text: string): "ok" | "invalid" {
+	const block = text.endsWith("\n") ? text : `${text}\n`;
+	const parsed = parseFrontmatter(block);
+	if (parsed === null) {
+		return "invalid";
+	}
+	applyParsedFrontmatter(doc, parsed);
+	return "ok";
+}
+
+export function RawFrontmatterEditor({ doc }: { doc: Y.Doc }) {
+	const hostRef = useRef<HTMLDivElement>(null);
+	const viewRef = useRef<EditorView | null>(null);
+	const [invalid, setInvalid] = useState(false);
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		const parent = hostRef.current;
+		if (!parent) {
+			return;
+		}
+
+		const view = new EditorView({
+			state: EditorState.create({
+				doc: emitFrontmatterText(doc),
+				extensions: [
+					yaml(),
+					keymap.of(defaultKeymap),
+					EditorView.updateListener.of((update) => {
+						if (!update.docChanged) {
+							return;
+						}
+						if (timer.current) {
+							clearTimeout(timer.current);
+						}
+						const text = update.state.doc.toString();
+						timer.current = setTimeout(() => {
+							setInvalid(commitYaml(doc, text) === "invalid");
+						}, COMMIT_DEBOUNCE_MS);
+					}),
+				],
+			}),
+			parent,
+		});
+		viewRef.current = view;
+
+		// Re-seed from the maps on remote changes, but only while the editor is
+		// unfocused — otherwise a remote pill edit yanks the caret mid-type.
+		// Local edits always win over a re-seed.
+		const { values, order } = frontmatterMaps(doc);
+		const refresh = () => {
+			const { current } = viewRef;
+			if (!current || current.hasFocus) {
+				return;
+			}
+			const next = emitFrontmatterText(doc);
+			if (next !== current.state.doc.toString()) {
+				current.dispatch({
+					changes: { from: 0, to: current.state.doc.length, insert: next },
+				});
+			}
+		};
+		values.observeDeep(refresh);
+		order.observe(refresh);
+
+		return () => {
+			values.unobserveDeep(refresh);
+			order.unobserve(refresh);
+			if (timer.current) {
+				clearTimeout(timer.current);
+			}
+			view.destroy();
+			viewRef.current = null;
+		};
+	}, [doc]);
+
+	return (
+		<section aria-label="Frontmatter (raw YAML)" className="border-b">
+			<div className="select-none px-3 pt-2 font-mono text-muted-foreground text-xs">---</div>
+			<div ref={hostRef} className="px-1" />
+			<div className="select-none px-3 pb-2 font-mono text-muted-foreground text-xs">---</div>
+			{invalid ? (
+				<p className="px-3 pb-1 text-destructive text-xs">Invalid YAML — not saved yet</p>
+			) : null}
+		</section>
+	);
+}

--- a/frontend/src/viewer/editor/toolbar.tsx
+++ b/frontend/src/viewer/editor/toolbar.tsx
@@ -1,0 +1,77 @@
+import type { EditorView } from "@codemirror/view";
+import { Bold, Code, Heading, Italic, Link, List, Quote } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { toggleLinePrefix, toggleWrap } from "./format-commands";
+
+export function EditorToolbar({ getView }: { getView: () => EditorView | null }) {
+	const run = (fn: (v: EditorView) => void) => () => {
+		const v = getView();
+		if (v) {
+			fn(v);
+		}
+	};
+	return (
+		<div
+			className="flex items-center gap-1 border-b px-2 py-1"
+			role="toolbar"
+			aria-label="Formatting"
+		>
+			<Button
+				variant="ghost"
+				size="icon"
+				aria-label="Bold"
+				onClick={run((v) => toggleWrap(v, "**"))}
+			>
+				<Bold className="size-4" />
+			</Button>
+			<Button
+				variant="ghost"
+				size="icon"
+				aria-label="Italic"
+				onClick={run((v) => toggleWrap(v, "*"))}
+			>
+				<Italic className="size-4" />
+			</Button>
+			<Button
+				variant="ghost"
+				size="icon"
+				aria-label="Inline code"
+				onClick={run((v) => toggleWrap(v, "`"))}
+			>
+				<Code className="size-4" />
+			</Button>
+			<Button
+				variant="ghost"
+				size="icon"
+				aria-label="Heading"
+				onClick={run((v) => toggleLinePrefix(v, "# "))}
+			>
+				<Heading className="size-4" />
+			</Button>
+			<Button
+				variant="ghost"
+				size="icon"
+				aria-label="Quote"
+				onClick={run((v) => toggleLinePrefix(v, "> "))}
+			>
+				<Quote className="size-4" />
+			</Button>
+			<Button
+				variant="ghost"
+				size="icon"
+				aria-label="List"
+				onClick={run((v) => toggleLinePrefix(v, "- "))}
+			>
+				<List className="size-4" />
+			</Button>
+			<Button
+				variant="ghost"
+				size="icon"
+				aria-label="Link"
+				onClick={run((v) => toggleWrap(v, "[", "](url)"))}
+			>
+				<Link className="size-4" />
+			</Button>
+		</div>
+	);
+}

--- a/frontend/src/viewer/note-editor.test.tsx
+++ b/frontend/src/viewer/note-editor.test.tsx
@@ -3,7 +3,9 @@ import { EditorView, runScopeHandlers } from "@codemirror/view";
 import { afterEach, describe, expect, it } from "vitest";
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
-import { buildEditorState } from "./note-editor";
+import { buildEditorState, decorationsCompartment, decorationsFor } from "./note-editor";
+
+const resolveWikiLink = (n: string) => `/notes/${n}`;
 
 // happy-dom CAN render a real CodeMirror EditorView (verified 2026-06-29).
 // The earlier comment was a cautious assumption; the DOM stubs in test-setup.ts
@@ -15,7 +17,7 @@ describe("buildEditorState", () => {
 		ytext.insert(0, "# Seeded heading\n\nbody text");
 		const awareness = new Awareness(doc);
 
-		const state = buildEditorState(ytext, awareness, false);
+		const state = buildEditorState(ytext, awareness, false, "rendered", resolveWikiLink);
 
 		expect(state.doc.toString()).toBe("# Seeded heading\n\nbody text");
 	});
@@ -25,7 +27,7 @@ describe("buildEditorState", () => {
 		const ytext = doc.getText("content");
 		const awareness = new Awareness(doc);
 
-		const state = buildEditorState(ytext, awareness, true);
+		const state = buildEditorState(ytext, awareness, true, "rendered", resolveWikiLink);
 
 		expect(state.doc.toString()).toBe("");
 	});
@@ -37,7 +39,7 @@ describe("buildEditorState", () => {
 		ytext.insert(0, "first");
 		ytext.insert(ytext.length, " second");
 
-		const state = buildEditorState(ytext, awareness, false);
+		const state = buildEditorState(ytext, awareness, false, "rendered", resolveWikiLink);
 
 		expect(state.doc.toString()).toBe("first second");
 	});
@@ -48,13 +50,31 @@ describe("buildEditorState", () => {
 		const ytext = doc.getText("content");
 		const awareness = new Awareness(doc);
 
-		const state = buildEditorState(ytext, awareness, false);
+		const state = buildEditorState(ytext, awareness, false, "rendered", resolveWikiLink);
 
 		// historyField is the StateField that @codemirror/commands history() adds.
 		// When present it means Ctrl+Z routes to the offset-based native undo, which
 		// reverts remote peers' edits and causes CRDT divergence.
 		// state.field(field, false) returns undefined when the field is not installed.
 		expect(state.field(historyField, false)).toBeUndefined();
+	});
+
+	it("rendered mode installs decorations; raw mode installs none, doc unchanged", () => {
+		const doc = new Y.Doc();
+		const ytext = doc.getText("content");
+		ytext.insert(0, "# H\n\n**b**\n");
+		const awareness = new Awareness(doc);
+
+		const rendered = buildEditorState(ytext, awareness, false, "rendered", resolveWikiLink);
+		const raw = buildEditorState(ytext, awareness, false, "raw", resolveWikiLink);
+
+		// Both seed identical, unaltered doc bytes (view-only decorations).
+		expect(rendered.doc.toString()).toBe("# H\n\n**b**\n");
+		expect(raw.doc.toString()).toBe("# H\n\n**b**\n");
+		// The compartment holds content in both modes (a markdown language in raw,
+		// the fuller live-preview extension set in rendered) -- never undefined.
+		expect(decorationsCompartment.get(rendered)).not.toBeUndefined();
+		expect(decorationsCompartment.get(raw)).not.toBeUndefined();
 	});
 });
 
@@ -85,7 +105,7 @@ describe("CRDT undo behaviour (EditorView + yCollab)", () => {
 		parents.push(parent);
 
 		const view = new EditorView({
-			state: buildEditorState(ytext, awareness, false),
+			state: buildEditorState(ytext, awareness, false, "rendered", resolveWikiLink),
 			parent,
 		});
 		views.push(view);
@@ -124,5 +144,57 @@ describe("CRDT undo behaviour (EditorView + yCollab)", () => {
 
 		// View and Y.Text must be converged (no divergence).
 		expect(view.state.doc.toString()).toBe(ytext.toString());
+	});
+});
+
+describe("mode switch via decorationsCompartment.reconfigure (yCollab must survive)", () => {
+	const views: EditorView[] = [];
+	const parents: HTMLElement[] = [];
+	afterEach(() => {
+		for (const v of views) {
+			v.destroy();
+		}
+		views.length = 0;
+		for (const p of parents) {
+			p.parentNode?.removeChild(p);
+		}
+		parents.length = 0;
+	});
+
+	it("reconfiguring rendered -> raw is view-only and leaves yCollab attached", () => {
+		const doc = new Y.Doc();
+		const ytext = doc.getText("content");
+		ytext.insert(0, "# H\n\n**b**\n");
+		const awareness = new Awareness(doc);
+
+		const parent = document.createElement("div");
+		document.body.appendChild(parent);
+		parents.push(parent);
+
+		const view = new EditorView({
+			state: buildEditorState(ytext, awareness, false, "rendered", resolveWikiLink),
+			parent,
+		});
+		views.push(view);
+
+		const before = view.state.doc.toString();
+
+		// Simulate the mode-switch effect: reconfigure the SAME compartment on the
+		// SAME view -- this must never recreate the view or detach yCollab.
+		view.dispatch({
+			effects: decorationsCompartment.reconfigure(decorationsFor("raw", resolveWikiLink)),
+		});
+
+		// (a) View-only: doc bytes are byte-identical after the switch.
+		expect(view.state.doc.toString()).toBe(before);
+		expect(view.state.doc.toString()).toBe("# H\n\n**b**\n");
+
+		// (b) yCollab is still bound: a remote Y.Text edit (foreign origin, the
+		// same pattern the CRDT undo test above uses) must still flow into the view.
+		doc.transact(() => {
+			ytext.insert(ytext.length, "tail");
+		}, "remote-peer");
+		expect(view.state.doc.toString()).toBe(ytext.toString());
+		expect(view.state.doc.toString()).toContain("tail");
 	});
 });

--- a/frontend/src/viewer/note-editor.tsx
+++ b/frontend/src/viewer/note-editor.tsx
@@ -2,7 +2,7 @@ import { defaultKeymap } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { Compartment, EditorState, Prec } from "@codemirror/state";
-import { oneDark } from "@codemirror/theme-one-dark";
+import { oneDarkTheme } from "@codemirror/theme-one-dark";
 import { drawSelection, EditorView, keymap } from "@codemirror/view";
 import { useEffect, useRef } from "react";
 import { yCollab, yUndoManagerKeymap } from "y-codemirror.next";
@@ -99,9 +99,14 @@ export function buildEditorState(
 			// compartment) so raw mode is highlighted too; harmless in rendered mode
 			// since atomicMarkdownSyntax layers its own token colors on top.
 			syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-			...(dark ? [oneDark] : []),
+			// oneDarkTheme = the dark editor chrome ONLY (caret, selection, gutters).
+			// We deliberately do NOT use the bundled `oneDark`, which also ships
+			// oneDarkHighlightStyle and colors headings/tokens with One Dark's palette
+			// (e.g. headings #e06c75 red) -- that overrode the Obsidian text color.
+			// atomicMarkdownSyntax + the --atomic-editor-* vars own token colors now.
+			...(dark ? [oneDarkTheme] : []),
 			// Prec.highest so the transparent background + layout beat any theme's
-			// own surface color (oneDark sets its own background otherwise).
+			// own surface color (the dark theme sets its own background otherwise).
 			Prec.highest(editorTheme),
 			// The ONLY source of the markdown language: swapping this compartment is
 			// what toggles Rendered vs Raw mode. See decorationsFor above.

--- a/frontend/src/viewer/note-editor.tsx
+++ b/frontend/src/viewer/note-editor.tsx
@@ -1,7 +1,7 @@
 import { defaultKeymap } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
-import { EditorState, Prec } from "@codemirror/state";
+import { Compartment, EditorState, Prec } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { drawSelection, EditorView, keymap } from "@codemirror/view";
 import { useEffect, useRef } from "react";
@@ -9,6 +9,7 @@ import { yCollab, yUndoManagerKeymap } from "y-codemirror.next";
 import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
 import { useTheme } from "../theme/theme-provider";
+import { livePreviewExtensions } from "./editor/live-preview";
 
 // Fill the parent so the editor spans the full pane height. 16px on .cm-content
 // prevents iOS Safari auto-zoom. Transparent background so the card shows through.
@@ -33,9 +34,33 @@ const editorTheme = EditorView.theme({
 	".cm-content": { fontSize: "16px", padding: "20px 20px 30vh" },
 });
 
+export type EditorMode = "rendered" | "raw";
+
 export interface NoteEditorProps {
 	ytext: Y.Text;
 	awareness: Awareness;
+	mode: EditorMode;
+	resolveWikiLink: (name: string) => string;
+}
+
+// One shared compartment instance: reconfiguring it swaps the decoration layer
+// without recreating the view, so yCollab stays attached to the same Y.Text.
+// The base extensions (below) NEVER include a markdown language -- the
+// compartment is the ONLY source of the markdown grammar, in both modes, so
+// creating the view in either mode and later switching leaves the doc with a
+// working language either way.
+export const decorationsCompartment = new Compartment();
+
+/**
+ * The per-mode compartment payload. Rendered mode gets the full live-preview
+ * extension set (markdown language + atomic decorations); raw mode gets a
+ * plain markdown language only, no decorations. Exported so tests can drive
+ * `decorationsCompartment.reconfigure(...)` directly against a mounted view.
+ */
+export function decorationsFor(mode: EditorMode, resolveWikiLink: (name: string) => string) {
+	return mode === "rendered"
+		? livePreviewExtensions({ resolveWikiLink })
+		: [markdown({ base: markdownLanguage })];
 }
 
 /**
@@ -50,7 +75,13 @@ export interface NoteEditorProps {
  * yCollab setup and the fix for the "editor is empty but the note has content"
  * bug. Exported so it can be unit-tested without a DOM (EditorState is pure).
  */
-export function buildEditorState(ytext: Y.Text, awareness: Awareness, dark: boolean): EditorState {
+export function buildEditorState(
+	ytext: Y.Text,
+	awareness: Awareness,
+	dark: boolean,
+	mode: EditorMode,
+	resolveWikiLink: (name: string) => string,
+): EditorState {
 	return EditorState.create({
 		doc: ytext.toString(),
 		extensions: [
@@ -58,14 +89,21 @@ export function buildEditorState(ytext: Y.Text, awareness: Awareness, dark: bool
 			EditorView.lineWrapping,
 			Prec.highest(keymap.of(yUndoManagerKeymap)),
 			keymap.of(defaultKeymap),
-			markdown({ base: markdownLanguage }),
+			// Highlight style for the markdown grammar tags -- kept in base (not the
+			// compartment) so raw mode is highlighted too; harmless in rendered mode
+			// since atomicMarkdownSyntax layers its own token colors on top.
 			syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
 			...(dark ? [oneDark] : []),
 			// Prec.highest so the transparent background + layout beat any theme's
 			// own surface color (oneDark sets its own background otherwise).
 			Prec.highest(editorTheme),
+			// The ONLY source of the markdown language: swapping this compartment is
+			// what toggles Rendered vs Raw mode. See decorationsFor above.
+			decorationsCompartment.of(decorationsFor(mode, resolveWikiLink)),
 			// yCollab keeps the view and Y.Text in sync AFTER this initial seed and
-			// wires local edits back into the Y.Text (→ CRDT channel).
+			// wires local edits back into the Y.Text (→ CRDT channel). MUST stay in
+			// the base extensions (never in the compartment) -- reconfiguring the
+			// compartment on mode switch must never detach this binding.
 			yCollab(ytext, awareness),
 		],
 	});
@@ -76,23 +114,42 @@ export function buildEditorState(ytext: Y.Text, awareness: Awareness, dark: bool
 // doc replace whenever its `value` prop differs from the editor content, which
 // fights yCollab and clobbers concurrent edits. A directly-managed view sidesteps
 // that entirely.
-export default function NoteEditor({ ytext, awareness }: NoteEditorProps) {
+export default function NoteEditor({ ytext, awareness, mode, resolveWikiLink }: NoteEditorProps) {
 	const { resolved } = useTheme();
 	const hostRef = useRef<HTMLDivElement>(null);
+	const viewRef = useRef<EditorView | null>(null);
 
+	// Create the view only when the bound doc or theme changes (NOT on mode).
+	// mode/resolveWikiLink intentionally excluded: a mode switch must reconfigure
+	// the decorationsCompartment on the existing view (below), never recreate it
+	// -- recreating here would detach yCollab and re-seed the doc on every toggle.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: mode/resolveWikiLink are handled by the reconfigure effect below; including them here would tear down and recreate the view (yCollab-detach hazard) on every mode toggle.
 	useEffect(() => {
 		const parent = hostRef.current;
 		if (!parent) {
 			return;
 		}
 		const view = new EditorView({
-			state: buildEditorState(ytext, awareness, resolved === "dark"),
+			state: buildEditorState(ytext, awareness, resolved === "dark", mode, resolveWikiLink),
 			parent,
 		});
-		return () => view.destroy();
-		// Recreate the view when the bound doc (note switch) or theme changes; the
-		// new state re-seeds from ytext.toString() so content is never lost.
+		viewRef.current = view;
+		return () => {
+			view.destroy();
+			viewRef.current = null;
+		};
 	}, [ytext, awareness, resolved]);
+
+	// Swap the decoration layer live when mode changes — view stays, yCollab stays.
+	useEffect(() => {
+		const view = viewRef.current;
+		if (!view) {
+			return;
+		}
+		view.dispatch({
+			effects: decorationsCompartment.reconfigure(decorationsFor(mode, resolveWikiLink)),
+		});
+	}, [mode, resolveWikiLink]);
 
 	return <div ref={hostRef} className="h-full" />;
 }

--- a/frontend/src/viewer/note-editor.tsx
+++ b/frontend/src/viewer/note-editor.tsx
@@ -9,6 +9,7 @@ import { yCollab, yUndoManagerKeymap } from "y-codemirror.next";
 import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
 import { useTheme } from "../theme/theme-provider";
+import { indentKeymap } from "./editor/format-commands";
 import { livePreviewExtensions } from "./editor/live-preview";
 
 // Fill the parent so the editor spans the full pane height. 16px on .cm-content
@@ -41,6 +42,8 @@ export interface NoteEditorProps {
 	awareness: Awareness;
 	mode: EditorMode;
 	resolveWikiLink: (name: string) => string;
+	/** Reaches the live EditorView out to a caller (e.g. the formatting toolbar). */
+	onView?: (view: EditorView | null) => void;
 }
 
 // One shared compartment instance: reconfiguring it swaps the decoration layer
@@ -89,6 +92,9 @@ export function buildEditorState(
 			EditorView.lineWrapping,
 			Prec.highest(keymap.of(yUndoManagerKeymap)),
 			keymap.of(defaultKeymap),
+			// Tab/Shift-Tab indent-dedent (Obsidian parity). Base, not the mode
+			// compartment, so it works in both rendered and raw mode.
+			indentKeymap,
 			// Highlight style for the markdown grammar tags -- kept in base (not the
 			// compartment) so raw mode is highlighted too; harmless in rendered mode
 			// since atomicMarkdownSyntax layers its own token colors on top.
@@ -114,16 +120,31 @@ export function buildEditorState(
 // doc replace whenever its `value` prop differs from the editor content, which
 // fights yCollab and clobbers concurrent edits. A directly-managed view sidesteps
 // that entirely.
-export default function NoteEditor({ ytext, awareness, mode, resolveWikiLink }: NoteEditorProps) {
+export default function NoteEditor({
+	ytext,
+	awareness,
+	mode,
+	resolveWikiLink,
+	onView,
+}: NoteEditorProps) {
 	const { resolved } = useTheme();
 	const hostRef = useRef<HTMLDivElement>(null);
 	const viewRef = useRef<EditorView | null>(null);
+	// Ref-style callback: always holds the latest onView without being an effect
+	// dependency, so a caller re-rendering with a new onView identity never
+	// recreates the view.
+	const onViewRef = useRef(onView);
+	onViewRef.current = onView;
 
 	// Create the view only when the bound doc or theme changes (NOT on mode).
 	// mode/resolveWikiLink intentionally excluded: a mode switch must reconfigure
 	// the decorationsCompartment on the existing view (below), never recreate it
 	// -- recreating here would detach yCollab and re-seed the doc on every toggle.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: mode/resolveWikiLink are handled by the reconfigure effect below; including them here would tear down and recreate the view (yCollab-detach hazard) on every mode toggle.
+	// onView intentionally excluded too (read via onViewRef): it's an escape
+	// hatch for the toolbar, not a doc/theme dependency -- including it would
+	// tear down and recreate the view (yCollab-detach hazard) whenever the
+	// caller passes a differently-identitied callback.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: mode/resolveWikiLink/onView are intentionally excluded, see comment above.
 	useEffect(() => {
 		const parent = hostRef.current;
 		if (!parent) {
@@ -134,9 +155,11 @@ export default function NoteEditor({ ytext, awareness, mode, resolveWikiLink }: 
 			parent,
 		});
 		viewRef.current = view;
+		onViewRef.current?.(view);
 		return () => {
 			view.destroy();
 			viewRef.current = null;
+			onViewRef.current?.(null);
 		};
 	}, [ytext, awareness, resolved]);
 

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -109,8 +109,8 @@ describe("NotePage (CRDT)", () => {
 		// Wait for openDoc to resolve and handle to be set
 		await waitFor(() => expect(openDoc).toHaveBeenCalledWith("note-1"));
 
-		// Switch to reading view
-		fireEvent.click(screen.getByRole("button", { name: /reading view/i }));
+		// Switch to reading mode
+		fireEvent.click(screen.getByRole("button", { name: "Reading" }));
 
 		// NoteView is mocked — assert on the content prop it receives.
 		// The live Y.Text content should be passed, not the stale REST "# hi".
@@ -123,7 +123,7 @@ describe("NotePage (CRDT)", () => {
 		expect(screen.getByTestId("note-view")).not.toHaveTextContent("# hi");
 	});
 
-	it("renders the properties widget with frontmatter keys in both modes", async () => {
+	it("renders the properties widget with frontmatter keys in the default rendered mode", async () => {
 		const doc = new Y.Doc();
 		doc.getMap("frontmatter").set("status", JSON.stringify("draft"));
 		doc.getArray("frontmatter_order").insert(0, ["status"]);
@@ -135,7 +135,44 @@ describe("NotePage (CRDT)", () => {
 
 		render(<NotePage />);
 
-		// Widget should appear in the default live mode
+		// Widget should appear in the default rendered mode
 		await waitFor(() => expect(screen.getByText("status")).toBeInTheDocument());
+	});
+
+	it("swaps the frontmatter surface across rendered/raw/reading modes", async () => {
+		const doc = new Y.Doc();
+		doc.getMap("frontmatter").set("status", JSON.stringify("draft"));
+		doc.getArray("frontmatter_order").insert(0, ["status"]);
+		openDoc.mockResolvedValue({
+			ytext: doc.getText("content"),
+			awareness: new Awareness(doc),
+			doc,
+		});
+
+		render(<NotePage />);
+
+		// Default "rendered" mode: pills visible, editor visible, no raw YAML region.
+		await waitFor(() => expect(screen.getByText("status")).toBeInTheDocument());
+		expect(screen.getByTestId("note-editor")).toBeInTheDocument();
+		expect(screen.queryByLabelText(/Frontmatter \(raw YAML\)/i)).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Rendered" })).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+
+		// Switch to "raw": raw YAML region visible, pills hidden.
+		fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+		await waitFor(() =>
+			expect(screen.getByLabelText(/Frontmatter \(raw YAML\)/i)).toBeInTheDocument(),
+		);
+		expect(screen.queryByText("status")).not.toBeInTheDocument();
+		expect(screen.getByTestId("note-editor")).toBeInTheDocument();
+
+		// Switch to "reading": NoteView visible, neither frontmatter surface shown.
+		fireEvent.click(screen.getByRole("button", { name: "Reading" }));
+		await waitFor(() => expect(screen.getByTestId("note-view")).toBeInTheDocument());
+		expect(screen.queryByLabelText(/Frontmatter \(raw YAML\)/i)).not.toBeInTheDocument();
+		expect(screen.queryByText("status")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("note-editor")).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useEffect, useState } from "react";
+import type { EditorView } from "@codemirror/view";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router";
 import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
@@ -15,6 +16,8 @@ import {
 } from "../crdt/session";
 import { useRightSidebar } from "../layout/right-sidebar-context";
 import { noteName } from "../lib/note-name";
+import { RawFrontmatterEditor } from "./editor/raw-frontmatter-editor";
+import { EditorToolbar } from "./editor/toolbar";
 import LoadingPane from "./loading-pane";
 import NoteToc from "./note-toc";
 import NoteView from "./note-view";
@@ -23,7 +26,12 @@ import { useLiveContent } from "./use-live-content";
 
 const NoteEditor = lazy(() => import("./note-editor"));
 
-type Mode = "live" | "reading";
+type Mode = "rendered" | "raw" | "reading";
+const MODES: ReadonlyArray<{ value: Mode; label: string }> = [
+	{ value: "rendered", label: "Rendered" },
+	{ value: "raw", label: "Raw" },
+	{ value: "reading", label: "Reading" },
+];
 interface DocHandle {
 	ytext: Y.Text;
 	awareness: Awareness;
@@ -38,9 +46,14 @@ export default function NotePage() {
 	const { data: note, isLoading, error } = useNote(validId);
 	const { setContent: setRightContent } = useRightSidebar();
 
-	const [mode, setMode] = useState<Mode>("live");
+	const [mode, setMode] = useState<Mode>("rendered");
 	const [handle, setHandle] = useState<DocHandle | null>(null);
 	const [syncStatus, setSyncStatus] = useState<CrdtSyncStatus>(getCrdtSyncStatus);
+	const editorViewRef = useRef<EditorView | null>(null);
+	// Mirrors NoteView's remark-wiki-link hrefTemplate. useCallback keeps a
+	// stable identity so passing it to NoteEditor doesn't re-fire the
+	// decorationsCompartment reconfigure effect on every render.
+	const resolveWikiLink = useCallback((permalink: string) => `/notes/${encodeURI(permalink)}`, []);
 
 	const path = note?.path ?? null;
 	const noteId = note?.id ?? null;
@@ -130,17 +143,24 @@ export default function NotePage() {
 					)}
 					<span className="min-w-0 truncate font-medium">{name}</span>
 				</h2>
-				<Button
-					variant="ghost"
-					size="sm"
-					className="shrink-0"
-					onClick={() => setMode((m) => (m === "live" ? "reading" : "live"))}
-				>
-					{mode === "live" ? "↗ Reading view" : "✎ Edit"}
-				</Button>
+				<fieldset className="m-0 flex shrink-0 gap-1 border-0 p-0">
+					<legend className="sr-only">View mode</legend>
+					{MODES.map(({ value, label }) => (
+						<Button
+							key={value}
+							variant={mode === value ? "secondary" : "ghost"}
+							size="sm"
+							aria-pressed={mode === value}
+							onClick={() => setMode(value)}
+						>
+							{label}
+						</Button>
+					))}
+				</fieldset>
 			</div>
 
-			{handle ? <PropertiesWidget doc={handle.doc} /> : null}
+			{handle && mode === "rendered" ? <PropertiesWidget doc={handle.doc} /> : null}
+			{handle && mode === "raw" ? <RawFrontmatterEditor doc={handle.doc} /> : null}
 
 			{mode === "reading" ? (
 				<ScrollArea className="min-h-0 flex-1">
@@ -152,14 +172,18 @@ export default function NotePage() {
 				<div className="min-h-0 flex-1 overflow-hidden" data-tour="note-editor">
 					<Suspense fallback={<p className="py-5 text-muted-foreground">Loading editor…</p>}>
 						{handle ? (
-							<NoteEditor
-								ytext={handle.ytext}
-								awareness={handle.awareness}
-								// ponytail: mode is fixed "rendered" until the mode-toggle UI (a later
-								// task) wires real state; resolveWikiLink mirrors NoteView's hrefTemplate.
-								mode="rendered"
-								resolveWikiLink={(permalink) => `/notes/${encodeURI(permalink)}`}
-							/>
+							<>
+								<EditorToolbar getView={() => editorViewRef.current} />
+								<NoteEditor
+									ytext={handle.ytext}
+									awareness={handle.awareness}
+									mode={mode === "raw" ? "raw" : "rendered"}
+									resolveWikiLink={resolveWikiLink}
+									onView={(v) => {
+										editorViewRef.current = v;
+									}}
+								/>
+							</>
 						) : (
 							<p className="py-5 text-muted-foreground">Connecting…</p>
 						)}

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -152,7 +152,14 @@ export default function NotePage() {
 				<div className="min-h-0 flex-1 overflow-hidden" data-tour="note-editor">
 					<Suspense fallback={<p className="py-5 text-muted-foreground">Loading editor…</p>}>
 						{handle ? (
-							<NoteEditor ytext={handle.ytext} awareness={handle.awareness} />
+							<NoteEditor
+								ytext={handle.ytext}
+								awareness={handle.awareness}
+								// ponytail: mode is fixed "rendered" until the mode-toggle UI (a later
+								// task) wires real state; resolveWikiLink mirrors NoteView's hrefTemplate.
+								mode="rendered"
+								resolveWikiLink={(permalink) => `/notes/${encodeURI(permalink)}`}
+							/>
 						) : (
 							<p className="py-5 text-muted-foreground">Connecting…</p>
 						)}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -119,6 +119,13 @@ export default defineConfig({
 		globals: true,
 		setupFiles: ["./src/test-setup.ts"],
 		exclude: ["**/node_modules/**", "**/dist/**", "**/e2e/**"],
+		// @atomic-editor/editor's compiled dist/*.js uses extensionless relative
+		// imports (e.g. `from './AtomicCodeMirrorEditor'`), which is invalid under
+		// Node's native ESM resolver. Vitest externalizes node_modules deps to
+		// Node's loader by default; `inline` routes it through Vite's own
+		// (extension-tolerant) transform instead. Bundlers (esbuild/Vite build)
+		// already tolerate this without any config — only Vitest's SSR path needs it.
+		server: { deps: { inline: ["@atomic-editor/editor"] } },
 	},
 	// Tailwind v4 loads the typography plugin via `@plugin` in main.css —
 	// the vite plugin's `plugins` option is ignored in this version.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.678",
+      version: "0.5.679",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- **Rendered / Raw / Reading note editor.** A CM6 `Compartment` toggles an Obsidian-style live-preview decoration layer (vendored Atomic Editor extensions, view-only) without detaching the `yCollab` Y.Text binding. Raw mode hand-edits the `---` YAML frontmatter (bound to the existing Y.Map via a codec ported from the plugin, per-key diff writes + `frontmatter_raw` escape hatch); rendered mode shows property pills. Adds a formatting toolbar, tab-to-indent, and custom callout + KaTeX + nested-blockquote decorations. Obsidian-default heading colors.
- **Global route error boundary.** React Router's data router intercepts route-render throws before they reach the root `RootErrorBoundary`, so route crashes hit RR's bare default page. Added a root-route `errorElement` rendering the app's `ErrorFallback` + Sentry reporting; extracted the lazy Sentry singleton to `src/sentry.ts`. The "reported" claim is gated on real `flush()` delivery so it's never a false success signal.
- Frontend-only (`backend/frontend/`). No backend, CRDT-protocol, or DB/migration changes. All decorations are view-only — they never mutate the Y.Text, so sync stays socket/CRDT-only.

## Test plan

- [x] `bunx vitest run` — 840 pass (new: mode toggle, frontmatter codec/apply-diff, callout/katex/blockquote decorations, route-boundary report/skip-404/report-5xx/reported-only-after-delivery)
- [x] `tsc --noEmit` clean, `biome ci .` clean repo-wide
- [x] Full markdown coverage verified in-browser (CDP): headings, emphasis/strike/highlight/code, links + wikilinks, nested blockquotes, nested lists, task checkboxes, tables, inline + block math, code fences, HR
- [x] Route error boundary verified live via dev-only `?routeboom` — renders `ErrorFallback`, honest `reported` flag (no false claim without a delivered event)
- [x] Reviewed by two agents (senior + silent-failure); all Critical/Important/actionable-Minor findings fixed in-branch

## Notes / follow-ups (non-blocking)

- Callout `[!type]` header still renders the raw marker (the v2 callout title widget was deferred during design)
- Route-boundary Sentry events carry no React component-stack (inherent to `useRouteError`)
