### PR TITLE
fix(e2e): poll for CRDT note content in test_44 (pairs plugin #254)

### DIFF
--- a/e2e/tests/test_44_oauth_device_flow.py
+++ b/e2e/tests/test_44_oauth_device_flow.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+import time
 from datetime import datetime
 from urllib.parse import quote
 
@@ -131,17 +132,33 @@ async def test_full_device_flow(
             # reached the server. Assert server-side arrival instead of the
             # (now-unreliable) push counter.
 
-            # Verify note reached server using OAuth access token
-            resp = requests.get(
-                f"{API_URL}/notes/{quote(path, safe='')}",
-                headers={
-                    "Authorization": f"Bearer {tokens['access_token']}",
-                    "X-Vault-ID": str(tokens["vault_id"]),
-                },
-                timeout=10,
+            # Verify note reached server using the OAuth access token. This is a
+            # CRDT note: `create` returns once the metadata row exists, but the
+            # body propagates asynchronously over the Yjs room, so a single GET
+            # right after the sync races the body and intermittently reads empty
+            # content (server GET 200, content=""). Poll the content instead —
+            # mirrors api.wait_for_note_content, but with the OAuth token +
+            # X-Vault-ID this test needs (the note lives in the OAuth vault, not
+            # the API-key session's default vault).
+            deadline = time.monotonic() + 15
+            server_content = ""
+            while time.monotonic() < deadline:
+                resp = requests.get(
+                    f"{API_URL}/notes/{quote(path, safe='')}",
+                    headers={
+                        "Authorization": f"Bearer {tokens['access_token']}",
+                        "X-Vault-ID": str(tokens["vault_id"]),
+                    },
+                    timeout=10,
+                )
+                assert resp.status_code == 200, f"Server GET returned {resp.status_code}"
+                server_content = resp.json().get("content", "")
+                if "OAuth Device Flow E2E" in server_content:
+                    break
+                time.sleep(0.5)
+            assert "OAuth Device Flow E2E" in server_content, (
+                f"note content did not reach server within 15s: {server_content[:200]!r}"
             )
-            assert resp.status_code == 200, f"Server GET returned {resp.status_code}"
-            assert "OAuth Device Flow E2E" in resp.json().get("content", "")
 
         finally:
             # ── 7. Restore original API key auth ──────────────────


### PR DESCRIPTION
## What
`test_44_oauth_device_flow` creates a **CRDT** note and then GETs its server content ~170ms later. A CRDT `create` returns once the metadata row exists, but the body propagates **asynchronously** over the Yjs room, so the single GET races the body and intermittently reads `content=""` (server GET 200, empty content). The final state converges correct.

Fix: poll the OAuth-authed GET until the content lands (mirrors `api.wait_for_note_content`, but keeps the OAuth token + `X-Vault-ID` this test needs — the note lives in the OAuth vault, not the API-key session's default vault).

## Why now
Surfaced by the e2e run for plugin **#254** (Phase C `applyOp` unification). Root-caused via the server-side client logs: the note's `CRDT create ok` fired, but the body hadn't propagated at the assertion GET; a later `Echo skip` shows the converged content hash is correct. The mechanism is **push-side / CRDT body propagation** — unrelated to #254's receive-side `applyOp` change. This is a pre-existing racy assertion (the test comment already notes they abandoned the push-counter for the same fragility).

## Pairing
Same-name branch as plugin `feat/crdt-apply-op` so the cross-repo e2e pairs; this run validates the hardened test_44 against the #254 plugin branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)