### PR TITLE
fix(e2e): age-gate worker-0 Clerk sweep so it can't delete live sibling-worker users

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -132,6 +132,13 @@ _RUN_ID = os.environ.get("GITHUB_RUN_ID", "local")
 # mid-suite Clerk session minter). "localjob" outside CI.
 _JOB_ID = os.environ.get("GITHUB_JOB", "localjob")
 
+# Age floor for worker-0's in-suite Clerk sweep. A concurrently-starting
+# sibling xdist worker's just-provisioned user is age ~0s and must survive;
+# a prior attempt's leftover (only reaped on a re-run) is minutes old. 120s
+# sits comfortably between the two. See cleanup_all_e2e_clerk_users (#160/#869
+# lineage + the worker-level race in run 29670308705).
+_SWEEP_MIN_AGE_SECONDS = 120
+
 
 # ---------------------------------------------------------------------------
 # Unique timestamp for this test run
@@ -168,7 +175,15 @@ def auth_provider():
         # Scope sweep to THIS run+job namespace — never touch sibling runs'
         # OR sibling jobs' users (issues #160, #869). Orphans from crashed
         # runs are reaped out-of-band by .github/workflows/clerk-orphans.yml.
-        provider.cleanup_all_e2e_users(run_id=_RUN_ID, job_id=_JOB_ID)
+        #
+        # min_age_seconds guards the worker-level race (run 29670308705): the
+        # run+job marker matches every worker, so without an age floor worker
+        # 0's session-start sweep deletes worker 1's just-provisioned live
+        # user. 120s >> worker-start skew (seconds) yet << job duration, so a
+        # prior attempt's leftovers (reaped on a re-run) are always older.
+        provider.cleanup_all_e2e_users(
+            run_id=_RUN_ID, job_id=_JOB_ID, min_age_seconds=_SWEEP_MIN_AGE_SECONDS
+        )
     return provider
 
 

--- a/e2e/helpers/auth_provider.py
+++ b/e2e/helpers/auth_provider.py
@@ -44,7 +44,9 @@ class AuthProvider(ABC):
         """Best-effort cleanup of a provisioned user."""
 
     @abstractmethod
-    def cleanup_all_e2e_users(self, run_id: str | None = None, job_id: str | None = None) -> int:
+    def cleanup_all_e2e_users(
+        self, run_id: str | None = None, job_id: str | None = None, min_age_seconds: float = 0
+    ) -> int:
         """Sweep e2e-* users for ``run_id`` (defaults to None = all runs).
 
         Callers in the pytest session pass the current run id so they only
@@ -108,9 +110,13 @@ class ClerkAuthProvider(AuthProvider):
         except Exception as e:
             logger.warning("Failed to delete Clerk user %s: %s", provider_user_id, e)
 
-    def cleanup_all_e2e_users(self, run_id: str | None = None, job_id: str | None = None) -> int:
+    def cleanup_all_e2e_users(
+        self, run_id: str | None = None, job_id: str | None = None, min_age_seconds: float = 0
+    ) -> int:
         from helpers.cleanup import cleanup_all_e2e_clerk_users
-        return cleanup_all_e2e_clerk_users(self.clerk_client, run_id=run_id, job_id=job_id)
+        return cleanup_all_e2e_clerk_users(
+            self.clerk_client, run_id=run_id, job_id=job_id, min_age_seconds=min_age_seconds
+        )
 
     def get_clerk_auth(self, clerk_user_id: str):
         """Return a ClerkAuth adapter for direct JWT auth (OAuth tests)."""
@@ -170,7 +176,9 @@ class LocalAuthProvider(AuthProvider):
         # Local users are cleaned up via DB cleanup in session teardown
         pass
 
-    def cleanup_all_e2e_users(self, run_id: str | None = None, job_id: str | None = None) -> int:  # noqa: ARG002
+    def cleanup_all_e2e_users(
+        self, run_id: str | None = None, job_id: str | None = None, min_age_seconds: float = 0  # noqa: ARG002
+    ) -> int:
         # No external service to clean — DB cleanup handles it
         return 0
 

--- a/e2e/helpers/cleanup.py
+++ b/e2e/helpers/cleanup.py
@@ -7,11 +7,29 @@ import os
 import re
 import shutil
 import subprocess
+from datetime import datetime
 from pathlib import Path
 
 from helpers.clerk_constants import is_e2e_clerk_email
 
 logger = logging.getLogger(__name__)
+
+# The per-run timestamp embedded at the front of every e2e email's ts segment
+# (conftest `ts` fixture: datetime.now().strftime("%Y%m%d%H%M%S%f") → 20 digits,
+# immediately followed by "r{run_id}"). Used to age-gate the in-suite sweep.
+_EMAIL_TS_RE = re.compile(r"(\d{20})r")
+
+
+def _email_age_seconds(email: str) -> float | None:
+    """Seconds since the e2e email's embedded timestamp, or None if absent/unparseable."""
+    m = _EMAIL_TS_RE.search(email)
+    if not m:
+        return None
+    try:
+        created = datetime.strptime(m.group(1), "%Y%m%d%H%M%S%f")
+    except ValueError:
+        return None
+    return (datetime.now() - created).total_seconds()
 
 VAULT_PATHS = [
     Path("/tmp/e2e-vault-a"),
@@ -95,13 +113,16 @@ def cleanup_clerk_users(clerk_client, clerk_user_ids: list[str]) -> None:
 
 
 def cleanup_all_e2e_clerk_users(
-    clerk_client, run_id: str | None = None, job_id: str | None = None
+    clerk_client,
+    run_id: str | None = None,
+    job_id: str | None = None,
+    min_age_seconds: float = 0,
 ) -> int:
     """Find and delete e2e-* users in the Clerk instance.
 
     By default scopes the sweep to ``run_id`` + ``job_id`` — only emails
     containing ``r{run_id}j{job_id}w`` are deleted. Weaker scoping caused
-    two cascades:
+    three cascades:
 
     - issue #160: no scoping — a run's worker-0 fixture nuked every e2e-*
       user, including sibling RUNS' active users (401 storms).
@@ -109,9 +130,20 @@ def cleanup_all_e2e_clerk_users(
       by all parallel JOBS of one workflow run, so the e2e-api job's setup
       sweep deleted the e2e-clerk job's live users mid-suite (POST
       /sessions 404 in test_49; every e2e-clerk teardown delete already 404).
+    - run 29670308705 (2026-07-19): run+job scoping is still WORKER-blind.
+      The marker anchors on the trailing ``w``, so ``r{run}j{job}w`` matches
+      every worker (``w0``, ``w1``). Under ``-n 2 --dist=loadfile`` only
+      worker 0 runs this sweep, but at session start it raced worker 1's
+      provisioning and deleted worker 1's freshly created live user →
+      worker 1's ``create_session`` 404'd until the retry budget exhausted.
 
-    ``job_id`` distinguishes sibling jobs; a job re-run (same run id, same
-    job id) still reaps its own previous attempt's leftovers.
+    ``job_id`` distinguishes sibling jobs. ``min_age_seconds`` distinguishes
+    a prior *attempt*'s leftovers (minutes old on a re-run — safe to reap)
+    from the *current* attempt's concurrently-provisioned users (age ~0s —
+    a live sibling worker; must survive). Users younger than the floor, or
+    whose embedded timestamp can't be parsed, are skipped (fail-safe: never
+    risk a live user; the hourly clerk-orphans reaper catches true stragglers).
+    Same ``--older-than`` discipline the standalone reaper already applies.
 
     Passing ``run_id=None`` restores the legacy nuclear behavior — useful
     only from the standalone reaper script (``scripts/cleanup_clerk_users.py``)
@@ -120,6 +152,7 @@ def cleanup_all_e2e_clerk_users(
     Returns the number of users deleted.
     """
     deleted = 0
+    skipped_recent = 0
     offset = 0
     # Anchor on the trailing ``w`` so that run id "123" never substring-matches
     # into another run's "r12345w0" segment. Worker suffix is always present.
@@ -143,6 +176,14 @@ def cleanup_all_e2e_clerk_users(
                 continue
             if run_marker is not None and not any(run_marker in e for e in emails):
                 continue
+            if min_age_seconds > 0:
+                # Age-gate on the youngest e2e email: a concurrently-starting
+                # sibling worker's just-provisioned user must not be reaped.
+                ages = [_email_age_seconds(e) for e in emails if is_e2e_clerk_email(e)]
+                parseable = [a for a in ages if a is not None]
+                if not parseable or min(parseable) < min_age_seconds:
+                    skipped_recent += 1
+                    continue
             try:
                 clerk_client.delete_user(user["id"])
                 deleted += 1
@@ -159,6 +200,12 @@ def cleanup_all_e2e_clerk_users(
         else:
             scope = "ALL runs"
         logger.info("Cleaned up %d orphaned e2e Clerk users (%s)", deleted, scope)
+    if skipped_recent:
+        logger.info(
+            "Sweep kept %d recent/unverifiable e2e user(s) younger than %.0fs "
+            "(live sibling-worker protection)",
+            skipped_recent, min_age_seconds,
+        )
     return deleted
 
 

--- a/e2e/helpers/cleanup.py
+++ b/e2e/helpers/cleanup.py
@@ -21,7 +21,14 @@ _EMAIL_TS_RE = re.compile(r"(\d{20})r")
 
 
 def _email_age_seconds(email: str) -> float | None:
-    """Seconds since the e2e email's embedded timestamp, or None if absent/unparseable."""
+    """Seconds since the e2e email's embedded timestamp, or None if absent/unparseable.
+
+    Load-bearing assumption: the ts is minted (conftest `ts` fixture) and this
+    sweep runs on the SAME host clock — naive-local `datetime.now()` on both
+    sides. That holds because xdist workers are subprocesses of one CI runner.
+    If the sweep ever moves to a different container/host than the minting
+    worker, ages break silently (and the fail-safe would mask it as "keep all").
+    """
     m = _EMAIL_TS_RE.search(email)
     if not m:
         return None

--- a/e2e/unit/test_cleanup_scope.py
+++ b/e2e/unit/test_cleanup_scope.py
@@ -11,7 +11,15 @@ must be scoped to run AND job.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+
 from helpers.cleanup import cleanup_all_e2e_clerk_users
+
+
+def _aged_email(age_seconds: float, run: str = "777", job: str = "e2e-clerk", worker: int = 0) -> str:
+    """Build an e2e email whose embedded 20-digit timestamp is `age_seconds` old."""
+    ts = (datetime.now() - timedelta(seconds=age_seconds)).strftime("%Y%m%d%H%M%S%f")
+    return f"e2e-sync-{ts}r{run}j{job}w{worker}+clerk_test@example.com"
 
 
 class _FakeClerkClient:
@@ -79,3 +87,63 @@ def test_nuclear_sweep_still_deletes_all_e2e_users() -> None:
 
     assert client.deleted == ["u_a", "u_b"]
     assert deleted == 2
+
+
+def test_min_age_protects_current_attempt_users() -> None:
+    """Regression lock for the THIRD #869 incarnation (worker-level race).
+
+    ``-n 2 --dist=loadfile`` runs 2 xdist workers. Only worker 0 runs the
+    in-suite sweep, but its marker ``r{run}j{job}w`` matches EVERY worker's
+    email (worker id comes after the ``w`` anchor). With no timing guard,
+    worker 0's session-start sweep deletes worker 1's freshly provisioned
+    live user → worker 1's ``create_session`` 404s until the retry budget
+    exhausts (observed run 29670308705). ``min_age_seconds`` protects any
+    user created within the window (a concurrently-starting worker) while
+    still reaping a prior attempt's leftovers (minutes old on a re-run).
+    """
+    client = _FakeClerkClient(
+        [
+            # Another worker's user, just created — MUST survive the sweep.
+            _user("u_live_sibling_worker", _aged_email(age_seconds=3, worker=1)),
+            # A prior attempt's leftover (same run+job, minutes old) — reap.
+            _user("u_prior_attempt", _aged_email(age_seconds=600, worker=0)),
+        ]
+    )
+
+    deleted = cleanup_all_e2e_clerk_users(
+        client, run_id="777", job_id="e2e-clerk", min_age_seconds=120
+    )
+
+    assert client.deleted == ["u_prior_attempt"]
+    assert deleted == 1
+
+
+def test_min_age_default_ignores_timestamp() -> None:
+    """Default min_age_seconds=0 preserves legacy behavior (delete on marker)."""
+    client = _FakeClerkClient(
+        [_user("u_fresh", _aged_email(age_seconds=1, worker=1))]
+    )
+
+    deleted = cleanup_all_e2e_clerk_users(client, run_id="777", job_id="e2e-clerk")
+
+    assert client.deleted == ["u_fresh"]
+    assert deleted == 1
+
+
+def test_min_age_skips_users_with_unparseable_timestamp() -> None:
+    """Fail-safe: when age can't be verified, don't delete (never risk a live user).
+
+    An out-of-band reaper (clerk-orphans.yml) still catches genuinely stale
+    orphans, so skipping an unparseable-timestamp user in-suite is the safe
+    choice — the alternative (delete anyway) reintroduces the race this guards.
+    """
+    client = _FakeClerkClient(
+        [_user("u_no_ts", "e2e-sync-123r777je2e-clerkw0+clerk_test@example.com")]
+    )
+
+    deleted = cleanup_all_e2e_clerk_users(
+        client, run_id="777", job_id="e2e-clerk", min_age_seconds=120
+    )
+
+    assert client.deleted == []
+    assert deleted == 0


### PR DESCRIPTION
## Problem

`e2e-clerk` is failing/flaky on `main` (runs 29670308705, 29663145169, 29658630822 …). The pytest capture shows worker-1's `create_session` 404'ing "No user found" for a user that the run's own orphan-cleanup **deleted at session start**, exhausting the 30s retry budget and erroring the suite.

## Root cause

The job runs `-n 2 --dist=loadfile` → 2 xdist workers, each provisioning its own Clerk users. Only worker 0 runs the in-suite orphan sweep (`auth_provider` fixture), but its scope marker `r{run}j{job}w` anchors on the trailing `w`, so it matches **every** worker's email (`…w0…`, `…w1…`). Worker 0's session-start sweep raced worker 1's provisioning and deleted worker 1's freshly-created **live** user.

This is the third incarnation of the same bug the cleanup docstring already tracks:
- #160 — no scoping (nuked sibling *runs*)
- #869 — run-only scoping (nuked sibling *jobs*)
- **now** — run+job scoping, still **worker**-blind

Worker id can't distinguish a live sibling worker from a prior attempt's leftover (both share run+job), so only **time** can.

## Fix

Add an optional `min_age_seconds` floor to `cleanup_all_e2e_clerk_users` (default `0` = unchanged; the nuclear reaper path and every existing caller are untouched). The e2e email already embeds a 20-digit `datetime.now()` stamp; worker 0's sweep now passes a **120s** floor and skips any user younger than that — or whose stamp can't be parsed (fail-safe).

`120s` >> worker-start skew (seconds) yet << job duration, so a prior attempt's leftovers (only seen on a re-run, minutes later) are still reaped, while the current attempt's concurrently-provisioned users always survive. Same `--older-than` discipline the standalone reaper already applies; genuine stragglers are still caught by the hourly `clerk-orphans` reaper.

## Tests

3 new regression-lock tests in `test_cleanup_scope.py` (live sibling-worker protected, prior-attempt still reaped, unparseable-stamp fail-safe). Full harness unit suite green (35 passed).

## Note

This greens `e2e-clerk` only. `e2e-crdt` is failing on `main` for an unrelated plugin-side CRDT base-loss race (`test_live_bound_both_ends.py`), tracked separately — `main` won't be fully green until that plugin fix lands too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kosypXtQRFzj9gvowKKgS