### PR TITLE
fix(embed): retry transient transport errors in the Ollama embedder

### DIFF
--- a/lib/engram/embedders/ollama.ex
+++ b/lib/engram/embedders/ollama.ex
@@ -11,12 +11,24 @@ defmodule Engram.Embedders.Ollama do
   @default_model "nomic-embed-text"
 
   # Index embeds run in Oban workers against an often-remote Ollama endpoint
-  # (e.g. FastRaid over the LAN). A single Req.TransportError otherwise fails
-  # the whole Oban attempt and waits out the job backoff (~30s), which can miss
-  # a downstream index probe (e2e test_32 flake). Mirror the Voyage index
-  # defaults: retry transient transport errors + 5xx a few times within the
-  # call. Explicit caller opts win (tests pass a `plug`/`retry_delay: 0`).
-  @request_defaults [receive_timeout: 120_000, retry: :transient, max_retries: 3]
+  # (e.g. FastRaid over the LAN). A single connection-level blip otherwise fails
+  # the whole Oban attempt and waits out the job backoff (~30s). Retry the FAST
+  # transient failures in-call so a bounced container / momentary 5xx doesn't
+  # burn an attempt. Explicit caller opts win (tests pass a `plug`/`retry_delay`).
+  defp request_defaults,
+    do: [receive_timeout: 120_000, retry: &__MODULE__.retry_fast_transient?/2, max_retries: 3]
+
+  # Retry only failures that fail FAST. A receive_timeout means Ollama accepted
+  # the connection but is hanging; retrying it up to max_retries would multiply
+  # the 120s timeout into a multi-minute stall — and a sustained outage is
+  # already covered by the outer Oban attempt + ReconcileEmbeddings. Connection
+  # blips (econnrefused/closed) and 5xx return immediately, so retrying THEM is
+  # cheap. Public (not private) only so it can be captured here and unit-tested.
+  @doc false
+  def retry_fast_transient?(_req, %Req.TransportError{reason: :timeout}), do: false
+  def retry_fast_transient?(_req, %Req.TransportError{}), do: true
+  def retry_fast_transient?(_req, %{status: status}) when status in [500, 502, 503, 504], do: true
+  def retry_fast_transient?(_req, _), do: false
 
   @impl true
   def model_info do
@@ -40,7 +52,7 @@ defmodule Engram.Embedders.Ollama do
     result =
       Req.post(
         "#{url}/api/embed",
-        [json: %{model: model, input: texts}] ++ Keyword.merge(@request_defaults, req_opts)
+        [json: %{model: model, input: texts}] ++ Keyword.merge(request_defaults(), req_opts)
       )
 
     case result do

--- a/lib/engram/embedders/ollama.ex
+++ b/lib/engram/embedders/ollama.ex
@@ -10,6 +10,14 @@ defmodule Engram.Embedders.Ollama do
   @default_url "http://localhost:11434"
   @default_model "nomic-embed-text"
 
+  # Index embeds run in Oban workers against an often-remote Ollama endpoint
+  # (e.g. FastRaid over the LAN). A single Req.TransportError otherwise fails
+  # the whole Oban attempt and waits out the job backoff (~30s), which can miss
+  # a downstream index probe (e2e test_32 flake). Mirror the Voyage index
+  # defaults: retry transient transport errors + 5xx a few times within the
+  # call. Explicit caller opts win (tests pass a `plug`/`retry_delay: 0`).
+  @request_defaults [receive_timeout: 120_000, retry: :transient, max_retries: 3]
+
   @impl true
   def model_info do
     %{
@@ -19,17 +27,20 @@ defmodule Engram.Embedders.Ollama do
   end
 
   @impl true
-  def embed_texts(texts, _opts) when is_list(texts), do: embed_texts(texts)
+  def embed_texts(texts) when is_list(texts), do: embed_texts(texts, [])
 
   @impl true
-  def embed_texts(texts) when is_list(texts) do
+  def embed_texts(texts, opts) when is_list(texts) do
     url = System.get_env("OLLAMA_URL", @default_url)
     model = Application.get_env(:engram, :embed_model, @default_model)
 
+    {req_opts, _} =
+      Keyword.split(opts, [:retry, :max_retries, :retry_delay, :receive_timeout, :plug])
+
     result =
-      Req.post("#{url}/api/embed",
-        json: %{model: model, input: texts},
-        receive_timeout: 120_000
+      Req.post(
+        "#{url}/api/embed",
+        [json: %{model: model, input: texts}] ++ Keyword.merge(@request_defaults, req_opts)
       )
 
     case result do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.682",
+      version: "0.5.683",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/embedders/ollama_test.exs
+++ b/test/engram/embedders/ollama_test.exs
@@ -1,0 +1,53 @@
+defmodule Engram.Embedders.OllamaTest do
+  use ExUnit.Case, async: true
+
+  alias Engram.Embedders.Ollama
+
+  # Stub the HTTP layer via Req's `plug:` adapter (routed through embed_texts
+  # opts) so these run async with no network and no OLLAMA_URL env mutation.
+  defp json_resp(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(status, Jason.encode!(body))
+  end
+
+  describe "embed_texts/2" do
+    test "returns vectors on success" do
+      plug = fn conn -> json_resp(conn, 200, %{"embeddings" => [[0.1, 0.2], [0.3, 0.4]]}) end
+      assert {:ok, [[0.1, 0.2], [0.3, 0.4]]} = Ollama.embed_texts(["a", "b"], plug: plug)
+    end
+
+    test "retries a transient 5xx and succeeds (Oban embeds must survive a blip to remote Ollama)" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      plug = fn conn ->
+        n = Agent.get_and_update(counter, &{&1 + 1, &1 + 1})
+        # First call: transient 503 (a FastRaid Ollama blip). Retry succeeds.
+        if n == 1,
+          do: json_resp(conn, 503, %{"error" => "loading"}),
+          else: json_resp(conn, 200, %{"embeddings" => [[1.0, 2.0]]})
+      end
+
+      # retry_delay 0 keeps the test instant; retry: :transient is the fix.
+      assert {:ok, [[1.0, 2.0]]} =
+               Ollama.embed_texts(["hi"], plug: plug, retry_delay: fn _ -> 0 end)
+
+      assert Agent.get(counter, & &1) == 2
+    end
+
+    test "gives up after max_retries on a persistent failure" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      plug = fn conn ->
+        Agent.update(counter, &(&1 + 1))
+        json_resp(conn, 503, %{"error" => "down"})
+      end
+
+      assert {:error, {503, _}} =
+               Ollama.embed_texts(["hi"], plug: plug, retry_delay: fn _ -> 0 end)
+
+      # 1 initial + 3 retries (max_retries: 3).
+      assert Agent.get(counter, & &1) == 4
+    end
+  end
+end

--- a/test/engram/embedders/ollama_test.exs
+++ b/test/engram/embedders/ollama_test.exs
@@ -50,4 +50,18 @@ defmodule Engram.Embedders.OllamaTest do
       assert Agent.get(counter, & &1) == 4
     end
   end
+
+  describe "retry_fast_transient?/2" do
+    test "retries fast failures but NOT a receive_timeout (no 120s amplification)" do
+      # A hang-to-timeout must not be retried, else max_retries multiplies the
+      # 120s receive_timeout into a multi-minute stall.
+      refute Ollama.retry_fast_transient?(nil, %Req.TransportError{reason: :timeout})
+      # Connection-level blips and 5xx fail fast → cheap to retry.
+      assert Ollama.retry_fast_transient?(nil, %Req.TransportError{reason: :econnrefused})
+      assert Ollama.retry_fast_transient?(nil, %Req.Response{status: 503})
+      # 4xx / success are not transient.
+      refute Ollama.retry_fast_transient?(nil, %Req.Response{status: 422})
+      refute Ollama.retry_fast_transient?(nil, %Req.Response{status: 200})
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`e2e` `test_32_vault_api_key_isolation::test_mcp_search_spans_all_vaults_by_default` flakes with:
```
TimeoutError: Qdrant never indexed vault ... within 90s
```
It surfaced on `main` after the e2e-clerk/e2e-crdt fixes landed (it was previously masked by the worker-race aborting the job earlier). Passes on re-run.

## Root cause (not a tight timeout)

The e2e CI stack embeds via a **remote Ollama** (`OLLAMA_URL` → FastRaid, over the LAN). The failed run's logs show the embed job dying on a transient `Req.TransportError` (status `null`) to that host, retried by Oban ~29s later, still failing — so the note never reached Qdrant inside the 90s probe.

The `Engram.Embedders.Ollama` `Req.post` had **no `retry:`**, and Req's default (`:safe_transient`) does **not** retry `POST`. So a single transport blip fails the whole Oban attempt and waits out the ~30s job backoff. On a clean run there's no blip → it passes → the flake.

The sibling `Engram.Embedders.Voyage` already guards this: `retry: :transient, max_retries: 3`.

## Fix

Give Ollama the same transient-retry Voyage has, so a brief blip is absorbed *within one Oban attempt* and the note indexes promptly. Also hardens **self-host prod**, which embeds via Ollama.

Request opts are threaded through `embed_texts/2` (mirroring Voyage's `Keyword.split`) so the retry is caller-overridable and unit-testable via Req's `plug`/`retry_delay`. Existing callers are unaffected — opts other than `[:retry,:max_retries,:retry_delay,:receive_timeout,:plug]` were already ignored (model comes from app env; Ollama has no query/index purposes).

This is **not** a test-loosen: it removes the failure mechanism.

## Tests / gates

- 3 new unit tests (`test/engram/embedders/ollama_test.exs`): retries a transient 5xx then succeeds; gives up after `max_retries`; success. Red → green.
- `mix format` / `credo` / `sobelow` / `dialyzer` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kosypXtQRFzj9gvowKKgS