### PR TITLE
test(e2e): assert live-bound convergence on the LIVE path, not the backstop

### DIFF
--- a/e2e/tests/crdt/test_live_bound_both_ends.py
+++ b/e2e/tests/crdt/test_live_bound_both_ends.py
@@ -79,23 +79,34 @@ async def test_remote_edit_converges_while_note_is_live_bound_in_obsidian(
     await web.open_note(note_id, sync_vault_id)
     await web.append("\nEDIT-WHILE-B-LIVE-BOUND\n")
 
-    # B receives the remote edit over the live CRDT fan-out (the edit MUST
-    # arrive — proves the live-bound delivery path). Under heavy suite churn the
-    # live-bound merge can occasionally reset B's Y.Doc and drop the preserved
-    # base (a pre-existing live-merge race — Engram-obsidian#256 — NOT a Bucket
-    # A regression: it reproduces only under the CI runners' parallel churn,
-    # never solo or in the full sequential suite). The product heals that
-    # deterministically via its catch-up backstop (the periodic poll / a
-    # reconnect -> catchUp -> restConvergeLiveBound), so assert the EVENTUALLY-
-    # converged state the product actually guarantees, driving one catch-up if
-    # the live path did not fully converge on its own. This still EXERCISES the
-    # live-bound catch-up heal (a broken heal fails to recover the base and the
-    # assert below fails) — it does not mask it.
-    final = wait_for_content(vault_b, path, "EDIT-WHILE-B-LIVE-BOUND", timeout=CRDT_TIMEOUT)
-    if "base line" not in final:
-        await cdp_b.trigger_full_sync()
-        final = wait_for_content(vault_b, path, "base line", timeout=CRDT_TIMEOUT)
-    assert "base line" in final, f"base content lost on B even after catch-up: {final!r}"
+    # B must converge on the LIVE CRDT fan-out alone: the remote edit arrives AND
+    # the preserved base survives the live-bound merge. No catch-up is driven.
+    #
+    # This previously fell back to `trigger_full_sync()` when the base went
+    # missing, asserting only the EVENTUALLY-converged state that the catch-up
+    # backstop guarantees (Engram-obsidian#256, a live-merge race that reproduces
+    # only under the CI runners' parallel churn). That fallback is gone: the
+    # backstop it leaned on (catchUp -> restConvergeLiveBound) is REST, and the
+    # sync path is converging on ONE socket CRDT path — a test that heals itself
+    # over REST permanently hides live-path data loss, which is the very class of
+    # bug #256 is. The live path is the product guarantee, so assert it directly.
+    #
+    # Engram-obsidian#256 fix: the 3s drift repair could truncate a live-bound
+    # editor down to an orphaned/empty Y.Text (base deleted, then autosaved); it
+    # now rebinds instead. If this test goes red under churn, that is the
+    # reproduction that never surfaced locally — look for the client log line
+    # `drift repair SKIPPED` to tell a healed orphan apart from a second,
+    # still-unknown mechanism. That line ships over the client-log endpoint
+    # (`api_sync.get_logs()`, the source helpers/log_oracle.py mines), NOT the
+    # `plugin.log` CI artifact, which is build output only.
+    #
+    # Wait for each marker separately: `wait_for_content` returns the snapshot at
+    # the instant its own marker appears, and the live path may materialize the
+    # edit and the base in two flushes. Waiting for base separately asserts the
+    # CONVERGED state instead of one instant, without driving a catch-up.
+    wait_for_content(vault_b, path, "EDIT-WHILE-B-LIVE-BOUND", timeout=CRDT_TIMEOUT)
+    final = wait_for_content(vault_b, path, "base line", timeout=CRDT_TIMEOUT)
+    assert "base line" in final, f"base content lost on B via the LIVE path: {final!r}"
     assert "EDIT-WHILE-B-LIVE-BOUND" in final, f"remote edit lost on B: {final!r}"
 
 


### PR DESCRIPTION
## Why

`test_remote_edit_converges_while_note_is_live_bound_in_obsidian` fell back to `trigger_full_sync()` when the base went missing, asserting only the *eventually*-converged state the catch-up backstop guarantees.

That backstop (`catchUp` → `restConvergeLiveBound`) is **REST**, and the markdown sync path is collapsing onto ONE socket CRDT path. A test that heals itself over the REST backstop permanently hides live-path data loss — which is exactly the class of bug Engram-obsidian#256 is. It masked the very regression it was added to cover.

## What

Assert the live CRDT fan-out directly: the remote edit arrives **and** the base survives the live-bound merge, with **no catch-up driven**.

Each marker is waited for separately, so the assertion is on the CONVERGED state rather than the instant one marker appears (the live path may materialize edit and base in two flushes). Still no `trigger_full_sync`, so this does not weaken the assert — it removes a spurious-failure mode without restoring the mask.

The setup-only `trigger_full_sync()` earlier in the test is unchanged and still correct (its comment — "the ASSERTION below uses no full-sync" — is now literally true).

Not touched: `test_deaf_live_bound_note_converges_via_rest_catchup`, which deliberately exercises the REST backstop. That test is Phase E's business.

## Pairing

Pairs engram-app/Engram-obsidian#264 (same branch name, so the cross-repo e2e pairs): the drift repair now rebinds an orphaned `Y.Text` instead of truncating the editor.

**This PR is the experiment.** #256 never reproduced locally — only under the parallel e2e runners. With the fallback gone:
- **Green** → the live path converges unaided.
- **Red** → that is the reproduction that has eluded us. Look for the client log line `drift repair SKIPPED` (shipped via `api_sync.get_logs()`, *not* the build-only `plugin.log` artifact) to tell a healed orphan apart from a second, still-unknown mechanism.

E2E-only change, so no `mix.exs` bump.

Refs Engram-obsidian#256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kosypXtQRFzj9gvowKKgS