### PR TITLE
fix(ci): repo-qualify gh in migration-gates and release-notes jobs

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -269,6 +269,15 @@ jobs:
     runs-on: [self-hosted, linux, x64, isolated]
     permissions:
       contents: write
+    env:
+      # `gh release create` below is unqualified, and `gh` resolves the repo
+      # from `git remote -v`. The runners rewrite github.com/engram-app/ to the
+      # LAN git cache via a system-wide url.*.insteadOf, which `git remote -v`
+      # displays, so gh sees an unknown host and fails. This step only runs when
+      # the release range carries phase/* labels, which is why it has not bitten
+      # yet: it is skipped on most releases. Same failure took out an
+      # Engram-obsidian release. See the matching note in verify.yml.
+      GH_REPO: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2687,6 +2687,19 @@ jobs:
       contents: read
       pull-requests: read
     env:
+      # `gh` resolves the target repo from `git remote -v` when no repo is
+      # given. Our self-hosted runners set a system-wide
+      #   url.<lan-git-cache>/engram-app/.insteadOf https://github.com/engram-app/
+      # to spare the GitHub rate limit, and `git remote -v` DISPLAYS the
+      # rewritten URL — so what actions/checkout wrote as github.com reads back
+      # as a LAN host, and every unqualified gh call fails with "none of the git
+      # remotes configured for this repository point to a known GitHub host".
+      # The `gh pr list` calls below would then yield an empty pr_number and
+      # report "no open PR found" on a PR that plainly exists, i.e. this gate
+      # would fail closed for the wrong reason. This broke the Engram-obsidian
+      # release job for real (assets never uploaded). GH_REPO makes resolution
+      # explicit and remote-independent; an explicit --repo flag still wins.
+      GH_REPO: ${{ github.repository }}
       PG_CONTAINER: engram-n1-compat-${{ github.run_id }}
       # Run-scoped path (matches PG_CONTAINER above), NOT a fixed /tmp path.
       # Concurrent runs share the host /tmp, so a fixed /tmp/prev-release let


### PR DESCRIPTION
Found while root-causing a broken Engram-obsidian release today. Same bug class exists here, latent.

## The bug

`gh` resolves the target repo from `git remote -v` when no repo is given. Our self-hosted runners set a system-wide

```
url.<lan-git-cache>/engram-app/.insteadOf https://github.com/engram-app/
```

to spare the GitHub rate limit (homelab runner_vm role). **`git remote -v` displays the rewritten URL**, so what `actions/checkout` wrote as `github.com` reads back as a LAN host, and every unqualified `gh` call fails with:

```
none of the git remotes configured for this repository point to a known GitHub host
```

In Engram-obsidian this was not theoretical: it skipped the release asset upload, and `1.13.1` published stable, "Latest", and completely unusable.

## Exposure here

Two jobs, neither yet bitten, both only because their steps are conditional:

| Job | Call | Why it hasn't fired |
|---|---|---|
| `migration-gates` | `gh pr list` (x3) | only on branches touching `priv/repo/migrations/*.exs` |
| `create-release-notes` | `gh release create` | only when the release range carries `phase/*` labels |

`migration-gates` fails **closed**, not open: an empty `pr_number` makes it report `no open PR found for branch <name>` on a PR that plainly exists. Wrong reason, right direction, but it would burn real time on the next migration PR.

`create-release-notes` would fail the prod release-notes step outright.

## The fix

Job-level `GH_REPO: ${{ github.repository }}` makes resolution explicit and remote-independent, and covers future `gh` calls in those jobs. An explicit `--repo` flag still takes precedence, so the cross-repo `--repo engram-app/engram-infra` merge calls are unaffected.

### Checked, no change needed

- `dependabot-auto-merge.yml` — passes a full PR URL, which `gh` resolves without remotes.
- `cron.yml` — its only `gh` mentions are comments.
- `deploy-prod.yml:185` — already `--repo engram-app/engram-infra`.

## No version bump

`.github/`-only change. The path-aware `version-check` gate requires a bump only when a runtime path moves, so this is correctly non-deployable.