### PR TITLE
fix(e2e): infra circuit breaker — abort the suite when the stack is provably dead

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -62,6 +62,68 @@ def pytest_configure(config):
             returncode=1,
         )
 
+# ---------------------------------------------------------------------------
+# Infra circuit breaker — stop the suite when the stack is provably dead
+# ---------------------------------------------------------------------------
+# 2026-07-21 triage: in 3 of 24 failed runs, 245 of 311 failure lines were
+# ConnectionError noise — the backend (or an Obsidian instance) died and every
+# remaining test still burned its full retry/timeout budget against a dead
+# endpoint. A refused connection is terminal, not a flake: probe the backend
+# once and stop the run instead of grinding out dozens of guaranteed failures.
+# Under xdist each worker trips independently (globals are per-process); with
+# the backend down, every worker trips on its next test.
+
+_CONN_REFUSED_MARKERS = ("Connection refused", "ConnectionRefusedError", "NewConnectionError")
+_OBSIDIAN_DEAD_THRESHOLD = 3
+_consecutive_conn_failures = 0
+
+
+def _backend_alive() -> bool:
+    import requests
+
+    try:
+        requests.get(f"{API_URL}/health", timeout=3)
+        return True
+    except requests.exceptions.ConnectionError:
+        return False
+    except Exception:
+        # Any HTTP-level answer (or timeout) means the socket is accepting;
+        # only a refused/unreachable connection counts as dead.
+        return True
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    global _consecutive_conn_failures
+    if rep.when == "call" and rep.passed:
+        _consecutive_conn_failures = 0
+        return
+    if not rep.failed:
+        return
+    text = repr(call.excinfo.value) if call.excinfo else str(rep.longrepr)
+    if not any(m in text for m in _CONN_REFUSED_MARKERS):
+        _consecutive_conn_failures = 0
+        return
+    if not _backend_alive():
+        item.session.shouldstop = (
+            f"INFRA DEAD: backend {API_URL} refuses connections "
+            f"(first seen in {item.nodeid}) — aborting the suite; every "
+            "remaining test would fail the same way. Check stack/compose logs."
+        )
+        logging.getLogger("conftest").error(item.session.shouldstop)
+        return
+    _consecutive_conn_failures += 1
+    if _consecutive_conn_failures >= _OBSIDIAN_DEAD_THRESHOLD:
+        item.session.shouldstop = (
+            f"INFRA DEAD: {_consecutive_conn_failures} consecutive "
+            f"connection-refused failures while the backend is healthy — an "
+            f"Obsidian/CDP instance is gone (last: {item.nodeid}). Aborting."
+        )
+        logging.getLogger("conftest").error(item.session.shouldstop)
+
+
 def _worker_index() -> int:
     """xdist worker number (0 for master / serial runs)."""
     worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")

--- a/e2e/tests/test_00_harness_circuit_breaker.py
+++ b/e2e/tests/test_00_harness_circuit_breaker.py
@@ -1,0 +1,87 @@
+"""Unit check for the conftest infra circuit breaker. Needs no stack.
+
+Drives the pytest_runtest_makereport hookwrapper directly with fake
+report/item objects, so the abort logic is exercised without killing a
+real run. Named test_00_* so it runs (and fails loudly) before anything
+that depends on the breaker's behavior.
+"""
+
+import conftest as harness
+
+
+class _Rep:
+    def __init__(self, when="call", passed=False, failed=True, longrepr=""):
+        self.when = when
+        self.passed = passed
+        self.failed = failed
+        self.longrepr = longrepr
+
+
+class _Outcome:
+    def __init__(self, rep):
+        self._rep = rep
+
+    def get_result(self):
+        return self._rep
+
+
+class _Session:
+    shouldstop = False
+
+
+class _Item:
+    def __init__(self, session):
+        self.session = session
+        self.nodeid = "fake.py::test_fake"
+
+
+class _Call:
+    excinfo = None
+
+
+def _drive(item, rep):
+    gen = harness.pytest_runtest_makereport(item, _Call())
+    next(gen)
+    try:
+        gen.send(_Outcome(rep))
+    except StopIteration:
+        pass
+
+
+_CONN_REP = _Rep(longrepr="ConnectionError: [Errno 111] Connection refused")
+
+
+def _reset(monkeypatch, alive):
+    harness._consecutive_conn_failures = 0
+    monkeypatch.setattr(harness, "_backend_alive", lambda: alive)
+
+
+def test_dead_backend_aborts_immediately(monkeypatch):
+    _reset(monkeypatch, alive=False)
+    item = _Item(_Session())
+    _drive(item, _CONN_REP)
+    assert item.session.shouldstop
+    assert "backend" in item.session.shouldstop
+
+
+def test_healthy_backend_needs_consecutive_failures(monkeypatch):
+    _reset(monkeypatch, alive=True)
+    item = _Item(_Session())
+    for _ in range(harness._OBSIDIAN_DEAD_THRESHOLD - 1):
+        _drive(item, _CONN_REP)
+    assert not item.session.shouldstop
+    _drive(item, _CONN_REP)
+    assert item.session.shouldstop
+    assert "Obsidian" in item.session.shouldstop
+
+
+def test_pass_and_unrelated_failure_reset_the_counter(monkeypatch):
+    _reset(monkeypatch, alive=True)
+    item = _Item(_Session())
+    _drive(item, _CONN_REP)
+    _drive(item, _Rep(passed=True, failed=False))
+    _drive(item, _CONN_REP)
+    _drive(item, _Rep(longrepr="AssertionError: something else"))
+    _drive(item, _CONN_REP)
+    assert harness._consecutive_conn_failures == 1
+    assert not item.session.shouldstop


### PR DESCRIPTION
## Why
In the 2026-07-21 e2e failure triage, 3 of 24 failed runs produced 245 of the 311 total failure lines — pure noise from a dead stack: the backend (or an Obsidian instance) died and every remaining test still polled its full 10-30s budget against a refused socket, then the next test did the same, ~40 times.

## What
A `pytest_runtest_makereport` hookwrapper in `e2e/conftest.py`:
- Test failed with a connection-refused signature → probe `GET /api/health` (3s timeout) once.
- Backend refuses → `session.shouldstop`: the whole run aborts with `INFRA DEAD: backend ... refuses connections`, remaining tests are reported as not-run instead of 40 fake reds.
- Backend healthy but **3 consecutive** connection-refused failures → an Obsidian/CDP instance is gone (run 29865240930's signature) → abort with the Obsidian variant.
- Any pass or non-connection failure resets the streak. Under xdist each worker trips independently.

Marks infra death loudly and early instead of masking it as dozens of test failures — triage reads one INFRA DEAD line instead of a 100-line FAILED histogram.

## Testing
`e2e/tests/test_00_harness_circuit_breaker.py` drives the hookwrapper with fake reports (no stack needed; in CI it runs inside the normal suite). All 3 branches covered: dead-backend abort, consecutive-threshold abort, streak reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJksd3C2xLkXyucHRRnuVC