### PR TITLE
feat(crdt): seq on live fan-out + gap-heal drop seam (single-path D2)

### DIFF
--- a/e2e/tests/crdt/test_seq_gap_heal.py
+++ b/e2e/tests/crdt/test_seq_gap_heal.py
@@ -1,0 +1,102 @@
+"""D2 seq-gap-heal proof (single-path CRDT sync, Phase D2).
+
+A live fan-out that never reaches a device must be healed by the NEXT
+delivered op: every live op carries the vault-global `seq`, the plugin
+compares it to its persisted catch-up cursor, and a `seq` ahead of the
+cursor fires the single-flight socket seq-replay (`crdt_catchup_since`).
+
+Deterministic stage: `FanoutPacer.test_drop_next/2` swallows note X's
+fan-out server-side (a lost broadcast — the real-world class behind the
+"received=no materialized=no" delivery flakes). A later edit to note Y
+fans out normally with a later seq; B is behind, heals, and the replay
+carries X's missed edit. No `trigger_full_sync` after the drop — the heal
+IS the assertion, and the client-log check pins the mechanism (a pre-D2
+plugin converges neither and logs no heal).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from helpers.backend_rpc import backend_rpc
+from helpers.vault import wait_for_content
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("E2E_ENABLE_CRDT") != "true",
+    reason="CRDT-only suite — set E2E_ENABLE_CRDT=true with a CRDT_ENABLED backend",
+)
+
+CRDT_TIMEOUT = 30
+
+
+def _note_id(api_sync, path: str) -> str:
+    note = api_sync.wait_for_note(path, timeout=CRDT_TIMEOUT)
+    inner = note.get("note", note) if isinstance(note, dict) else {}
+    nid = inner.get("id") or inner.get("note_id") or inner.get("uuid")
+    assert nid, f"no note id in GET /notes/{path}: {note}"
+    return str(nid)
+
+
+def _wait_for_heal_log(api_sync, note_ids: tuple[str, ...], timeout: float) -> None:
+    """Poll client logs for a gap-heal line naming one of `note_ids`.
+
+    The heal logs the note whose LIVE OP revealed the gap — that is the
+    trigger note (or the dropped note's own announce), so accept either.
+    """
+    deadline = time.time() + timeout
+    seen: list[str] = []
+    while time.time() < deadline:
+        logs = api_sync.get_logs(limit=500).get("logs", [])
+        for log in logs:
+            message = log.get("message", "")
+            if "gap-heal fired" in message:
+                seen.append(message)
+                if any(f"note={nid}" in message for nid in note_ids):
+                    return
+        time.sleep(1)
+    raise TimeoutError(
+        f"no 'gap-heal fired' client log naming {note_ids} within {timeout}s "
+        f"(gap-heal lines seen: {seen or 'none'})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dropped_fanout_heals_via_seq_replay(vault_b, cdp_b, api_sync):
+    path_x = "E2E/Crdt/SeqGapLost.md"
+    path_y = "E2E/Crdt/SeqGapTrigger.md"
+
+    # Establish both notes on B (setup may use full sync; the assertion must not).
+    api_sync.create_note(path_x, "# Seq Gap Lost\nbase line.\n")
+    api_sync.create_note(path_y, "# Seq Gap Trigger\nbase line.\n")
+    await cdp_b.trigger_full_sync()
+    wait_for_content(vault_b, path_x, "base line", timeout=CRDT_TIMEOUT)
+    wait_for_content(vault_b, path_y, "base line", timeout=CRDT_TIMEOUT)
+
+    note_id_x = _note_id(api_sync, path_x)
+    note_id_y = _note_id(api_sync, path_y)
+
+    # Arm the lost broadcast: X's next fan-out is swallowed server-side.
+    backend_rpc(f'Engram.Notes.FanoutPacer.test_drop_next("{note_id_x}", 1)')
+
+    # Edit X — the fan-out is dropped; the server materializes the edit but B
+    # receives nothing for X.
+    api_sync.append_note(path_x, "\nLOST-EDIT-X\n")
+    api_sync.wait_for_note_content(path_x, "LOST-EDIT-X", timeout=CRDT_TIMEOUT)
+
+    # Edit Y — delivered normally with a later vault seq. B's cursor is now
+    # provably behind; the plugin must fire the seq-replay, which carries X's
+    # missed edit. NO full sync from here on.
+    api_sync.append_note(path_y, "\nTRIGGER-EDIT-Y\n")
+
+    final_x = wait_for_content(vault_b, path_x, "LOST-EDIT-X", timeout=CRDT_TIMEOUT)
+    assert "base line" in final_x, f"base lost on B for {path_x}: {final_x!r}"
+    final_y = wait_for_content(vault_b, path_y, "TRIGGER-EDIT-Y", timeout=CRDT_TIMEOUT)
+    assert "base line" in final_y, f"base lost on B for {path_y}: {final_y!r}"
+
+    # Pin the MECHANISM, not just the converged content: the plugin must have
+    # logged a gap-heal for the vault (content could in principle converge via
+    # another backstop; the log line cannot).
+    _wait_for_heal_log(api_sync, (note_id_x, note_id_y), timeout=CRDT_TIMEOUT)

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -97,7 +97,7 @@ defmodule Engram.Notes.CrdtDeliver do
   # or a load failure simply skips — the announce still fires for enrolled clients.
   defp fanout_idle(user_id, vault_id, note_id) do
     _ =
-      with {:ok, state} when is_binary(state) <- load_merged_state(user_id, note_id) do
+      with {:ok, state, seq} when is_binary(state) <- load_merged_state(user_id, note_id) do
         head =
           case CrdtBridge.doc_from_state(state) do
             {:ok, doc} -> CrdtTransport.head_marker(doc)
@@ -111,7 +111,7 @@ defmodule Engram.Notes.CrdtDeliver do
             "note_id" => note_id,
             "b64" => Base.encode64(state),
             "head" => head,
-            "seq" => load_note_seq(user_id, note_id)
+            "seq" => seq
           },
           note_id
         )
@@ -154,7 +154,7 @@ defmodule Engram.Notes.CrdtDeliver do
 
       room ->
         case load_merged_state(user_id, note_id) do
-          {:ok, state} when is_binary(state) ->
+          {:ok, state, _seq} when is_binary(state) ->
             # The apply runs inside the room process (update_doc discards the
             # fun's return), so failure is signalled back by message. The
             # message is tagged with a per-call ref: if update_doc TIMES OUT,
@@ -181,7 +181,7 @@ defmodule Engram.Notes.CrdtDeliver do
               0 -> :ok
             end
 
-          {:ok, nil} when content == "" ->
+          {:ok, nil, _seq} when content == "" ->
             # Empty content on a room with NO persisted CRDT state is ambiguous:
             # either a genuinely empty note (ingesting "" is a no-op anyway) or a
             # caller that reached deliver-out with UNLOADED content. The
@@ -193,7 +193,7 @@ defmodule Engram.Notes.CrdtDeliver do
             # arrives as a CRDT edit, never through this deliver-out fallback.
             :ok
 
-          {:ok, nil} ->
+          {:ok, nil, _seq} ->
             room_apply(room, note_id, fn doc -> CrdtBridge.ingest_plaintext(doc, content) end)
 
           {:error, reason} ->
@@ -274,15 +274,21 @@ defmodule Engram.Notes.CrdtDeliver do
     end
   end
 
-  # Loads + decrypts the note's committed CRDT snapshot. Runs post-commit in
-  # the writer process, so the row read here is the state the write just
+  # Loads + decrypts the note's committed CRDT snapshot AND its current
+  # vault-global change seq (Vaults.next_seq!-assigned, the same field
+  # `list_changes_by_seq` orders by — carried on the fan-out payload for
+  # gap-heal, spec §3 Phase D2) in a SINGLE row read. Runs post-commit in the
+  # writer process, so the row read here is the state the write just
   # persisted. Returns:
-  #   {:ok, binary} — the merged state to apply (shared lineage)
-  #   {:ok, nil}    — the row has NO CRDT state (legacy/lazy row); plaintext
-  #                   ingest is the only delivery available and is safe
-  #   {:error, r}   — the state exists but could not be read (decrypt/KMS/
-  #                   missing row/raise) — logged here at :error; the caller
-  #                   must NOT fall back to a plaintext re-encode
+  #   {:ok, binary, seq} — the merged state to apply (shared lineage) + seq
+  #   {:ok, nil, seq}    — the row has NO CRDT state (legacy/lazy row);
+  #                        plaintext ingest is the only delivery available
+  #                        and is safe
+  #   {:error, r}        — the state exists but could not be read
+  #                        (decrypt/KMS/missing row/raise) — logged here at
+  #                        :error; the caller must NOT fall back to a
+  #                        plaintext re-encode. No seq: the fan-out is
+  #                        skipped entirely in this case (see fanout_idle).
   # Never raises/exits/throws (delivery must not fail the write).
   defp load_merged_state(user_id, note_id) do
     user = Accounts.get_user!(user_id)
@@ -293,13 +299,13 @@ defmodule Engram.Notes.CrdtDeliver do
           nil ->
             {:error, :missing_row}
 
-          %Note{crdt_state_ciphertext: nil} ->
-            {:ok, nil}
+          %Note{crdt_state_ciphertext: nil, seq: seq} ->
+            {:ok, nil, seq}
 
-          %Note{} = note ->
+          %Note{seq: seq} = note ->
             case Crypto.decrypt_crdt_state(note, user) do
-              {:ok, state} when is_binary(state) -> {:ok, state}
-              {:ok, nil} -> {:ok, nil}
+              {:ok, state} when is_binary(state) -> {:ok, state, seq}
+              {:ok, nil} -> {:ok, nil, seq}
               {:error, reason} -> {:error, reason}
             end
         end
@@ -307,8 +313,8 @@ defmodule Engram.Notes.CrdtDeliver do
 
     # with_tenant wraps the fun's return in {:ok, _} (Ecto transaction).
     case result do
-      {:ok, {:ok, state_or_nil}} ->
-        {:ok, state_or_nil}
+      {:ok, {:ok, state_or_nil, seq}} ->
+        {:ok, state_or_nil, seq}
 
       {:ok, {:error, reason}} ->
         log_state_load_failure(note_id, reason)
@@ -326,20 +332,6 @@ defmodule Engram.Notes.CrdtDeliver do
     kind, reason ->
       log_state_load_failure(note_id, {kind, reason})
       {:error, :caught}
-  end
-
-  # Reads the note's current vault-global change seq (Vaults.next_seq!-assigned,
-  # the same field `list_changes_by_seq` orders by) for the gap-heal `seq` key
-  # on the live fan-out payload (spec §3 Phase D2). Best-effort like the rest
-  # of deliver-out: a missing row (deleted mid-flight) or any failure yields
-  # nil rather than raising — a delivery must not fail the write.
-  defp load_note_seq(user_id, note_id) do
-    case Repo.with_tenant(user_id, fn -> Repo.get(Note, note_id) end) do
-      {:ok, %Note{seq: seq}} -> seq
-      _ -> nil
-    end
-  rescue
-    _ -> nil
   end
 
   defp log_state_load_failure(note_id, reason) do

--- a/lib/engram/notes/crdt_deliver.ex
+++ b/lib/engram/notes/crdt_deliver.ex
@@ -110,7 +110,8 @@ defmodule Engram.Notes.CrdtDeliver do
           %{
             "note_id" => note_id,
             "b64" => Base.encode64(state),
-            "head" => head
+            "head" => head,
+            "seq" => load_note_seq(user_id, note_id)
           },
           note_id
         )
@@ -325,6 +326,20 @@ defmodule Engram.Notes.CrdtDeliver do
     kind, reason ->
       log_state_load_failure(note_id, {kind, reason})
       {:error, :caught}
+  end
+
+  # Reads the note's current vault-global change seq (Vaults.next_seq!-assigned,
+  # the same field `list_changes_by_seq` orders by) for the gap-heal `seq` key
+  # on the live fan-out payload (spec §3 Phase D2). Best-effort like the rest
+  # of deliver-out: a missing row (deleted mid-flight) or any failure yields
+  # nil rather than raising — a delivery must not fail the write.
+  defp load_note_seq(user_id, note_id) do
+    case Repo.with_tenant(user_id, fn -> Repo.get(Note, note_id) end) do
+      {:ok, %Note{seq: seq}} -> seq
+      _ -> nil
+    end
+  rescue
+    _ -> nil
   end
 
   defp log_state_load_failure(note_id, reason) do

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -99,28 +99,38 @@ defmodule Engram.Notes.CrdtPersistence do
 
     case Crypto.encrypt_crdt_state(update, user, note_id) do
       {:ok, {ct, nonce}} ->
-        Repo.with_tenant(user_id, fn ->
-          %CrdtUpdateLog{}
-          |> CrdtUpdateLog.changeset(%{
-            note_id: note_id,
-            user_id: user_id,
-            vault_id: vault_id,
-            update_ciphertext: ct,
-            update_nonce: nonce
-          })
-          |> Repo.insert!()
+        {:ok, seq} =
+          Repo.with_tenant(user_id, fn ->
+            %CrdtUpdateLog{}
+            |> CrdtUpdateLog.changeset(%{
+              note_id: note_id,
+              user_id: user_id,
+              vault_id: vault_id,
+              update_ciphertext: ct,
+              update_nonce: nonce
+            })
+            |> Repo.insert!()
 
-          # Invalidate the cached head in the SAME txn as the tail append: this
-          # update advanced the doc, so any stored crdt_head is now stale.
-          # vault_heads self-heals the NULL by rebuilding once (snapshot + full
-          # tail = authoritative), so we never trust an off-by-one head. Guard on
-          # not-nil so an already-invalidated hot note skips the write. Sets ONLY
-          # crdt_head — no updated_at/version/seq churn (checkpoint owns those).
-          from(n in Note,
-            where: n.id == ^note_id and n.kind == "note" and not is_nil(n.crdt_head)
-          )
-          |> Repo.update_all(set: [crdt_head: nil])
-        end)
+            # Invalidate the cached head in the SAME txn as the tail append: this
+            # update advanced the doc, so any stored crdt_head is now stale.
+            # vault_heads self-heals the NULL by rebuilding once (snapshot + full
+            # tail = authoritative), so we never trust an off-by-one head. Guard on
+            # not-nil so an already-invalidated hot note skips the write. Sets ONLY
+            # crdt_head — no updated_at/version/seq churn (checkpoint owns those).
+            from(n in Note,
+              where: n.id == ^note_id and n.kind == "note" and not is_nil(n.crdt_head)
+            )
+            |> Repo.update_all(set: [crdt_head: nil])
+
+            # The note's current vault-global change seq (Vaults.next_seq!-
+            # assigned at the last write/checkpoint, the same field
+            # `list_changes_by_seq` orders by), carried on the fan-out payload
+            # below for gap-heal (spec §3 Phase D2). nil when the row is gone.
+            case Repo.get(Note, note_id) do
+              %Note{seq: seq} -> seq
+              nil -> nil
+            end
+          end)
 
         # Fan out the update to every device on this vault over the single
         # per-vault sync channel (Relay's `document.updated` model). This is
@@ -149,7 +159,8 @@ defmodule Engram.Notes.CrdtPersistence do
           %{
             "note_id" => note_id,
             "b64" => Base.encode64(update),
-            "head" => CrdtTransport.head_marker(doc)
+            "head" => CrdtTransport.head_marker(doc),
+            "seq" => seq
           },
           note_id
         )

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -132,10 +132,13 @@ defmodule Engram.Notes.CrdtPersistence do
             # and we fall back to a plain read. KNOWN COST: crdt_head starts
             # nil and is only repopulated by another device's head-read, so a
             # SOLO typing burst takes the fallback on every delta — one extra
-            # PK point-SELECT inside the already-open transaction. Accepted:
-            # seq is heal-trigger-only (staleness fine), and avoiding it would
-            # need per-room seq caching or a no-op UPDATE (MVCC/WAL churn),
-            # both worse than the read.
+            # seq-only point-SELECT inside the already-open transaction (NOT a
+            # full Note load — the Note row carries crdt_state_ciphertext, the
+            # encrypted CRDT snapshot, KBs-MBs, which a per-keystroke fallback
+            # must not drag across the connection). Accepted: seq is
+            # heal-trigger-only (staleness fine), and avoiding the read
+            # entirely would need per-room seq caching or a no-op UPDATE
+            # (MVCC/WAL churn), both worse than a select-only read.
             {_count, rows} =
               from(n in Note,
                 where: n.id == ^note_id and n.kind == "note" and not is_nil(n.crdt_head),
@@ -148,10 +151,7 @@ defmodule Engram.Notes.CrdtPersistence do
                 seq
 
               [] ->
-                case Repo.get(Note, note_id) do
-                  %Note{seq: seq} -> seq
-                  nil -> nil
-                end
+                Repo.one(from(n in Note, where: n.id == ^note_id, select: n.seq))
             end
           end)
 

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -117,18 +117,41 @@ defmodule Engram.Notes.CrdtPersistence do
             # tail = authoritative), so we never trust an off-by-one head. Guard on
             # not-nil so an already-invalidated hot note skips the write. Sets ONLY
             # crdt_head — no updated_at/version/seq churn (checkpoint owns those).
-            from(n in Note,
-              where: n.id == ^note_id and n.kind == "note" and not is_nil(n.crdt_head)
-            )
-            |> Repo.update_all(set: [crdt_head: nil])
-
+            #
             # The note's current vault-global change seq (Vaults.next_seq!-
             # assigned at the last write/checkpoint, the same field
             # `list_changes_by_seq` orders by), carried on the fan-out payload
-            # below for gap-heal (spec §3 Phase D2). nil when the row is gone.
-            case Repo.get(Note, note_id) do
-              %Note{seq: seq} -> seq
-              nil -> nil
+            # below for gap-heal (spec §3 Phase D2), rides this SAME update_all
+            # via a `select` on the query (update_all/delete_all have no
+            # `:returning` option — Ecto only returns a second element when the
+            # query itself carries a `select`) — this is the hot per-delta path
+            # (moduledoc: "cheap, frequent... O(append)", prior pool-exhaustion
+            # incident history), so a second unconditional Repo.get here would
+            # double the query cost of every keystroke. The guard skips rows
+            # whose crdt_head is already nil, so `rows` is empty in that case
+            # and we fall back to a plain read. KNOWN COST: crdt_head starts
+            # nil and is only repopulated by another device's head-read, so a
+            # SOLO typing burst takes the fallback on every delta — one extra
+            # PK point-SELECT inside the already-open transaction. Accepted:
+            # seq is heal-trigger-only (staleness fine), and avoiding it would
+            # need per-room seq caching or a no-op UPDATE (MVCC/WAL churn),
+            # both worse than the read.
+            {_count, rows} =
+              from(n in Note,
+                where: n.id == ^note_id and n.kind == "note" and not is_nil(n.crdt_head),
+                select: n.seq
+              )
+              |> Repo.update_all(set: [crdt_head: nil])
+
+            case rows do
+              [seq | _] ->
+                seq
+
+              [] ->
+                case Repo.get(Note, note_id) do
+                  %Note{seq: seq} -> seq
+                  nil -> nil
+                end
             end
           end)
 

--- a/lib/engram/notes/fanout_pacer.ex
+++ b/lib/engram/notes/fanout_pacer.ex
@@ -48,10 +48,14 @@ defmodule Engram.Notes.FanoutPacer do
   """
   @spec emit(String.t(), String.t(), map(), String.t()) :: :ok
   def emit(topic, event, payload, note_id) do
-    if pacing_enabled?() and cold?(note_id) do
-      GenServer.cast(__MODULE__, {:enqueue, topic, event, payload})
+    if test_dropped?(note_id) do
+      :ok
     else
-      Broadcast.emit(topic, event, payload)
+      if pacing_enabled?() and cold?(note_id) do
+        GenServer.cast(__MODULE__, {:enqueue, topic, event, payload})
+      else
+        Broadcast.emit(topic, event, payload)
+      end
     end
 
     :ok
@@ -60,6 +64,37 @@ defmodule Engram.Notes.FanoutPacer do
   @doc "Test helper: drop all queues and clear the hot table."
   @spec reset() :: :ok
   def reset, do: GenServer.call(__MODULE__, :reset)
+
+  @doc """
+  Test-only: silently drop the next `n` fan-out emits for `note_id`.
+
+  Simulates a lost live broadcast for the e2e seq-gap-heal proof: the client
+  misses this op, the NEXT delivered op for the vault carries a later `seq`,
+  and the client must detect it is behind and self-heal via
+  `crdt_catchup_since`. Armed via the e2e harness `backend_rpc`; a no-op in
+  normal operation (an unset `:persistent_term` read on the emit path).
+  """
+  @spec test_drop_next(String.t(), pos_integer()) :: :ok
+  def test_drop_next(note_id, n \\ 1)
+      when is_binary(note_id) and is_integer(n) and n > 0 do
+    :persistent_term.put({__MODULE__, :drop, note_id}, n)
+  end
+
+  defp test_dropped?(note_id) do
+    key = {__MODULE__, :drop, note_id}
+
+    case :persistent_term.get(key, 0) do
+      n when is_integer(n) and n > 0 ->
+        if n == 1, do: :persistent_term.erase(key), else: :persistent_term.put(key, n - 1)
+
+        Logger.warning("fanout pacer TEST-DROP note_id=#{note_id} (#{n - 1} more armed)")
+
+        true
+
+      _ ->
+        false
+    end
+  end
 
   # Marks `note_id` seen now and returns whether it was COLD (not seen within the
   # hot window). Benign lookup/insert race across concurrent emits for one note

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Engram.MixProject do
   def project do
     [
       app: :engram,
-      version: "0.5.688",
+      version: "0.5.689",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/engram/notes/crdt_deliver_test.exs
+++ b/test/engram/notes/crdt_deliver_test.exs
@@ -73,10 +73,14 @@ defmodule Engram.Notes.CrdtDeliverTest do
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "note_yjs_update",
-        payload: %{"note_id" => note_id, "b64" => b64}
+        payload: %{"note_id" => note_id, "b64" => b64, "seq" => seq}
       }
 
       assert note_id == note.id
+      # gap-heal (Phase D2): the fan-out carries the note's vault-global
+      # change seq (the same value list_changes_by_seq orders by) so a
+      # client can detect a missed/reordered live op and self-heal.
+      assert seq == note.seq
       state = Base.decode64!(b64)
       assert byte_size(state) > 0
       {:ok, doc} = CrdtBridge.doc_from_state(state)

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -223,6 +223,72 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert seq == note.seq
   end
 
+  test "update_v1/4 fans out the correct seq when crdt_head is already nil (returning: 0-rows fallback)",
+       ctx do
+    %{user: user, note: note} = ctx
+    st = %{user_id: user.id, vault_id: note.vault_id, note_id: note.id}
+
+    # A freshly-created note's crdt_head is nil (only ever set later by the
+    # transport self-heal read path), so the seq-fetching update_all's
+    # `not is_nil(n.crdt_head)` guard matches ZERO rows here and update_v1
+    # must fall back to a plain Repo.get to still surface the seq.
+    {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get(Note, note.id) end)
+    assert raw_note.crdt_head == nil
+
+    {:ok, %{state: upd}} = CrdtBridge.merge_plaintext(nil, "zero rows fallback")
+    doc = CrdtBridge.new_doc()
+    :ok = Yex.apply_update(doc, upd)
+
+    topic = "sync:#{user.id}:#{note.vault_id}"
+    EngramWeb.Endpoint.subscribe(topic)
+
+    _st2 = CrdtPersistence.update_v1(st, upd, note.id, doc)
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      topic: ^topic,
+      event: "note_yjs_update",
+      payload: %{"seq" => seq}
+    }
+
+    assert seq == note.seq
+  end
+
+  test "update_v1/4 fans out the correct seq via update_all returning: when crdt_head is set (non-empty rows)",
+       ctx do
+    %{user: user, note: note} = ctx
+    st = %{user_id: user.id, vault_id: note.vault_id, note_id: note.id}
+
+    # Simulate a note whose crdt_head cache is populated (set by the transport
+    # self-heal read path) BEFORE this live delta arrives — the common hot-path
+    # shape the `returning: [:seq]` clause targets: the update_all both
+    # invalidates crdt_head AND returns the row's seq in one query.
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(from(n in Note, where: n.id == ^note.id), set: [crdt_head: "stale-head"])
+      end)
+
+    {:ok, %{state: upd}} = CrdtBridge.merge_plaintext(nil, "returning path")
+    doc = CrdtBridge.new_doc()
+    :ok = Yex.apply_update(doc, upd)
+
+    topic = "sync:#{user.id}:#{note.vault_id}"
+    EngramWeb.Endpoint.subscribe(topic)
+
+    _st2 = CrdtPersistence.update_v1(st, upd, note.id, doc)
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      topic: ^topic,
+      event: "note_yjs_update",
+      payload: %{"seq" => seq}
+    }
+
+    assert seq == note.seq
+
+    # The stale head cache was invalidated by the same update_all.
+    {:ok, updated} = Repo.with_tenant(user.id, fn -> Repo.get(Note, note.id) end)
+    assert updated.crdt_head == nil
+  end
+
   test "update_v1/4 with cached user does not hit Accounts.get_user!", ctx do
     %{user: user, note: note} = ctx
     # Bind first so the cached user is in the state

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -210,13 +210,17 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert_receive %Phoenix.Socket.Broadcast{
       topic: ^topic,
       event: "note_yjs_update",
-      payload: %{"note_id" => note_id, "b64" => b64, "head" => head}
+      payload: %{"note_id" => note_id, "b64" => b64, "head" => head, "seq" => seq}
     }
 
     assert note_id == note.id
     assert {:ok, ^upd} = Base.decode64(b64)
     assert is_binary(head) and head != ""
     assert head == Engram.Notes.CrdtTransport.head_marker(doc)
+    # gap-heal (Phase D2): carries the note's current vault-global change
+    # seq (the same field `list_changes_by_seq` orders by) so a device can
+    # detect a missed/reordered live op and self-heal via catch-up.
+    assert seq == note.seq
   end
 
   test "update_v1/4 with cached user does not hit Accounts.get_user!", ctx do

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -223,7 +223,7 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert seq == note.seq
   end
 
-  test "update_v1/4 fans out the correct seq when crdt_head is already nil (returning: 0-rows fallback)",
+  test "update_v1/4 fans out the correct seq when crdt_head is already nil (select: 0-rows fallback)",
        ctx do
     %{user: user, note: note} = ctx
     st = %{user_id: user.id, vault_id: note.vault_id, note_id: note.id}
@@ -231,7 +231,7 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     # A freshly-created note's crdt_head is nil (only ever set later by the
     # transport self-heal read path), so the seq-fetching update_all's
     # `not is_nil(n.crdt_head)` guard matches ZERO rows here and update_v1
-    # must fall back to a plain Repo.get to still surface the seq.
+    # must fall back to a select-only query to still surface the seq.
     {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get(Note, note.id) end)
     assert raw_note.crdt_head == nil
 
@@ -253,14 +253,14 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert seq == note.seq
   end
 
-  test "update_v1/4 fans out the correct seq via update_all returning: when crdt_head is set (non-empty rows)",
+  test "update_v1/4 fans out the correct seq via update_all select: when crdt_head is set (non-empty rows)",
        ctx do
     %{user: user, note: note} = ctx
     st = %{user_id: user.id, vault_id: note.vault_id, note_id: note.id}
 
     # Simulate a note whose crdt_head cache is populated (set by the transport
     # self-heal read path) BEFORE this live delta arrives — the common hot-path
-    # shape the `returning: [:seq]` clause targets: the update_all both
+    # shape the `select: n.seq` clause targets: the update_all both
     # invalidates crdt_head AND returns the row's seq in one query.
     {:ok, _} =
       Repo.with_tenant(user.id, fn ->

--- a/test/engram/notes/fanout_pacer_test.exs
+++ b/test/engram/notes/fanout_pacer_test.exs
@@ -101,4 +101,22 @@ defmodule Engram.Notes.FanoutPacerTest do
     assert_receive(%Phoenix.Socket.Broadcast{topic: ^ta}, 200)
     assert_receive(%Phoenix.Socket.Broadcast{topic: ^tb}, 200)
   end
+
+  test "test_drop_next/2 swallows exactly n emits for that note, then resumes" do
+    Application.put_env(:engram, :fanout_pacing_enabled, false)
+    topic = "sync:u5:v1"
+    EngramWeb.Endpoint.subscribe(topic)
+
+    FanoutPacer.test_drop_next("doomed", 2)
+
+    FanoutPacer.emit(topic, "note_yjs_update", payload("doomed"), "doomed")
+    FanoutPacer.emit(topic, "note_yjs_update", payload("other"), "other")
+    FanoutPacer.emit(topic, "note_yjs_update", payload("doomed"), "doomed")
+    FanoutPacer.emit(topic, "note_yjs_update", payload("doomed"), "doomed")
+
+    # Other notes are untouched; the armed note loses exactly 2 frames.
+    assert_receive %Phoenix.Socket.Broadcast{payload: %{"note_id" => "other"}}, 200
+    assert_receive %Phoenix.Socket.Broadcast{payload: %{"note_id" => "doomed"}}, 200
+    refute_receive %Phoenix.Socket.Broadcast{payload: %{"note_id" => "doomed"}}, 100
+  end
 end


### PR DESCRIPTION
Phase D2 of the single-path CRDT migration (backend half; pairs with plugin PR of the same branch name).

## What
- Attach the vault-global change seq (`Note.seq`) to both `note_yjs_update` fan-out payloads (`crdt_deliver.ex` idle full-state + `crdt_persistence.ex` per-delta). Additive and backward-compatible: old plugins ignore the key; a missing row yields `"seq" => nil`.
- Seq fetch costs one query: folded into the existing crdt_head-invalidation `update_all` via `select: n.seq`, with a select-only fallback read when the guard skips (never drags `crdt_state_ciphertext`).
- `FanoutPacer.test_drop_next/2`: e2e-only drop seam (persistent_term toggle, production no-op) to stage a lost live broadcast deterministically.
- New deterministic e2e `test_seq_gap_heal.py`: drops note X's fan-out, edits note Y, asserts X converges on device B via socket seq-replay and that the plugin logged the heal (`gap-heal fired`), pinning the mechanism rather than eventual content.

## Design (user-approved: seq is a heal-trigger, never a gate)
The plugin applies every live Yjs delta unconditionally and uses seq purely as a behind-detector: an observed integer seq > cursor means unconsumed feed entries exist, firing its single-flight socket catch-up. Live ops never advance the cursor (the replay is the sole cursor writer) — this survives stale seqs between checkpoints, seq aliasing across write kinds, and the unordered cross-node multi-note stream.

This is the prerequisite that lets Phase E delete the plugin's REST recovery path without regressing deaf-note.

## Testing
- Full `mix test` 3779/0; format, credo --strict, dialyzer clean.
- New/extended unit tests for both fan-out payloads (seq value asserted, both select and fallback branches).
- Paired e2e runs against the same-name plugin branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK9qUcRtS3tiW9wNhw83y7