### PR TITLE
fix(crdt): seq-only fallback read + test naming

### DIFF
--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -129,13 +129,17 @@ defmodule Engram.Notes.CrdtPersistence do
             # incident history), so a second unconditional Repo.get here would
             # double the query cost of every keystroke. The guard skips rows
             # whose crdt_head is already nil, so `rows` is empty in that case
-            # and we fall back to a plain read. KNOWN COST: crdt_head starts
-            # nil and is only repopulated by another device's head-read, so a
-            # SOLO typing burst takes the fallback on every delta — one extra
-            # PK point-SELECT inside the already-open transaction. Accepted:
-            # seq is heal-trigger-only (staleness fine), and avoiding it would
-            # need per-room seq caching or a no-op UPDATE (MVCC/WAL churn),
-            # both worse than the read.
+            # and we fall back to a select-only read. KNOWN COST: crdt_head
+            # starts nil and is only repopulated by another device's
+            # head-read, so a SOLO typing burst takes the fallback on every
+            # delta — a seq-only point-SELECT inside the already-open
+            # transaction (NOT a full Note load — the Note row carries
+            # crdt_state_ciphertext, the encrypted CRDT snapshot, KBs-MBs,
+            # which a per-keystroke fallback must not drag across the
+            # connection). Accepted: seq is heal-trigger-only (staleness
+            # fine), and avoiding the read entirely would need per-room seq
+            # caching or a no-op UPDATE (MVCC/WAL churn), both worse than a
+            # select-only read.
             {_count, rows} =
               from(n in Note,
                 where: n.id == ^note_id and n.kind == "note" and not is_nil(n.crdt_head),
@@ -148,10 +152,7 @@ defmodule Engram.Notes.CrdtPersistence do
                 seq
 
               [] ->
-                case Repo.get(Note, note_id) do
-                  %Note{seq: seq} -> seq
-                  nil -> nil
-                end
+                Repo.one(from(n in Note, where: n.id == ^note_id, select: n.seq))
             end
           end)
 

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -223,7 +223,7 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert seq == note.seq
   end
 
-  test "update_v1/4 fans out the correct seq when crdt_head is already nil (returning: 0-rows fallback)",
+  test "update_v1/4 fans out the correct seq when crdt_head is already nil (select: 0-rows fallback)",
        ctx do
     %{user: user, note: note} = ctx
     st = %{user_id: user.id, vault_id: note.vault_id, note_id: note.id}
@@ -231,7 +231,7 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     # A freshly-created note's crdt_head is nil (only ever set later by the
     # transport self-heal read path), so the seq-fetching update_all's
     # `not is_nil(n.crdt_head)` guard matches ZERO rows here and update_v1
-    # must fall back to a plain Repo.get to still surface the seq.
+    # must fall back to a select-only query to still surface the seq.
     {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get(Note, note.id) end)
     assert raw_note.crdt_head == nil
 
@@ -253,14 +253,14 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert seq == note.seq
   end
 
-  test "update_v1/4 fans out the correct seq via update_all returning: when crdt_head is set (non-empty rows)",
+  test "update_v1/4 fans out the correct seq via update_all select: when crdt_head is set (non-empty rows)",
        ctx do
     %{user: user, note: note} = ctx
     st = %{user_id: user.id, vault_id: note.vault_id, note_id: note.id}
 
     # Simulate a note whose crdt_head cache is populated (set by the transport
     # self-heal read path) BEFORE this live delta arrives — the common hot-path
-    # shape the `returning: [:seq]` clause targets: the update_all both
+    # shape the `select: n.seq` clause targets: the update_all both
     # invalidates crdt_head AND returns the row's seq in one query.
     {:ok, _} =
       Repo.with_tenant(user.id, fn ->


### PR DESCRIPTION
Hardening port from the closed #1056 branch onto the merged seq gap-heal (#1058). Pairs with the plugin PR of the same branch name.

## What
- `update_v1/4`'s 0-rows fallback read (the common case: `crdt_head` starts nil and only another device's head-read repopulates it, so every solo-typing-burst delta takes this branch) was a full-row `Repo.get(Note, note_id)` — dragging `crdt_state_ciphertext` (KBs–MBs for large notes) across the connection inside the hot per-delta transaction. Replaced with a select-only read (`Repo.one(..., select: n.seq)`, nil-safe).
- Corrected the surrounding comment, which claimed the fallback was a "point-SELECT" (it was the full row).
- Renamed the two tests + comments that described a nonexistent `update_all returning:` mechanism; they now describe the select-based return actually used.

## Testing
Full `mix test` 3779 / 0 failures; targeted crdt_persistence + crdt_deliver 39/0; format, credo --strict, dialyzer clean. No version bump (release-please owns versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK9qUcRtS3tiW9wNhw83y7