### PR TITLE
fix(ci): job-level GH_REPO in release-please (gh repo-inference dead on LAN-rewrite runners)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,13 @@ permissions:
 jobs:
   release-please:
     runs-on: [self-hosted, linux, x64, isolated]
+    # Our runner VMs rewrite github.com/engram-app/ remotes to the LAN git
+    # cache (insteadOf), so `gh` cannot infer the repo from `git remote -v`
+    # ("none of the git remotes ... point to a known GitHub host") — every gh
+    # call needs the repo pinned explicitly. Same class as #1052; see
+    # docs/context/gh-cli-runner-url-rewrite-and-release-repair.md (workspace).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Mint App token
         id: app-token


### PR DESCRIPTION
Every `Release Please` run since #1022 landed has failed at `Prepend deterministic SCHEMA-IMPACT to the Release PR body`:

```
none of the git remotes configured for this repository point to a known GitHub host
```

Our runner VMs rewrite `github.com/engram-app/` remotes to the LAN git cache (`insteadOf`), so `gh` cannot infer the repo from `git remote -v`. #1052 fixed this class in migration-gates and release-notes but missed this workflow (it landed in the same wave). Job-level `GH_REPO: ${{ github.repository }}` pins every `gh` call in the job, including the release-cut step.

Effect of the outage: release PR #1057 ("chore(main): release 0.6.0") exists but its body never received the schema-impact notes, and the release-cut step has never executed. After this merges, the next main push (or a manual workflow rerun) heals it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJksd3C2xLkXyucHRRnuVC