### PR TITLE
fix(ci): run verify on release-please's PR branch (release PRs were unmergeable)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,6 +18,9 @@ on:
       - "perf/**"
       - "refactor/**"
       - "release/**"
+      # release-please's own PR branch — without this the release PR gets no CI,
+      # required checks never report, and the release can never merge (#1057).
+      - "release-please--**"
       - "revert/**"
       - "security/**"
       - "test/**"


### PR DESCRIPTION
The new release pipeline's PR branch `release-please--branches--main` matches no prefix in verify.yml's push allowlist (the deliberate fork-PR guard), so release PR #1057 got no CI run at all: required status checks never report and the PR sits `BLOCKED` with zero failures — the first 0.6.0 release cut cannot merge. Adds `release-please--**` to the allowlist. Same failure signature as the documented off-list-prefix class (workspace memory: branch-prefix CI gotcha).

After merge: re-run `Release Please` so it force-pushes the branch, which now triggers verify; once checks report green, #1057 merges normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJksd3C2xLkXyucHRRnuVC