### PR TITLE
feat(sync): manifest rows carry seq + crdt_head; since_seq unchanged short-circuit (Phase E1)

### DIFF
--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -15,40 +15,72 @@ defmodule EngramWeb.SyncController do
     operation_id: "sync-manifest",
     summary: "Get the full vault manifest",
     tags: ["Sync"],
-    description: "Every live note + attachment path and content hash, for sync reconciliation.",
+    description:
+      "Every live note + attachment path, content hash, and change seq, for sync " <>
+        "reconciliation. Pass `since_seq` (the `change_seq` of a previous manifest) to " <>
+        "short-circuit: when nothing has changed the response is just " <>
+        "`{unchanged: true, change_seq}` with the body omitted.",
+    parameters: [
+      since_seq: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "Watermark from a prior manifest's `change_seq`; invalid values are ignored.",
+        example: "1042"
+      ]
+    ],
     responses: [ok: {"Manifest", "application/json", Schemas.ManifestResponse}]
   )
 
-  def manifest(conn, _params) do
+  def manifest(conn, params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
+    current = Engram.Vaults.current_seq(user.id, vault.id)
 
-    # Phase B.3: paths live only as ciphertext. Project ONLY the columns we
-    # need (path ciphertext + nonce + content_hash) so a 10k-note vault
-    # doesn't pull megabyte-sized `content_ciphertext` blobs into BEAM.
-    # Decrypt path Elixir-side, then sort. Older `select: n` shape pulled
-    # full rows + sorted in Elixir — measurable OOM risk on the largest
-    # vault under load.
-    # No DEK = brand-new user with zero writes. No notes/attachments are
-    # possible without a DEK (every upsert provisions one), so short-circuit
-    # to an empty manifest instead of crashing on `{:ok, dek}` match.
-    case Crypto.get_dek(user) do
-      {:ok, dek} -> render_manifest(conn, user, vault, dek)
-      {:error, :no_dek} -> render_empty_manifest(conn, user, vault)
+    # Phase E1 (#1065): when the client's last-validated watermark still equals
+    # the vault's change_seq, nothing in the vault has changed — skip the
+    # decrypt-heavy full render entirely. Invalid/absent since_seq falls
+    # through to the full manifest, never errors.
+    if parse_since_seq(params["since_seq"]) == current do
+      json(conn, %{unchanged: true, change_seq: current})
+    else
+      # Phase B.3: paths live only as ciphertext. Project ONLY the columns we
+      # need (path ciphertext + nonce + content_hash) so a 10k-note vault
+      # doesn't pull megabyte-sized `content_ciphertext` blobs into BEAM.
+      # Decrypt path Elixir-side, then sort. Older `select: n` shape pulled
+      # full rows + sorted in Elixir — measurable OOM risk on the largest
+      # vault under load.
+      # No DEK = brand-new user with zero writes. No notes/attachments are
+      # possible without a DEK (every upsert provisions one), so short-circuit
+      # to an empty manifest instead of crashing on `{:ok, dek}` match.
+      case Crypto.get_dek(user) do
+        {:ok, dek} -> render_manifest(conn, user, vault, dek, current)
+        {:error, :no_dek} -> render_empty_manifest(conn, current)
+      end
     end
   end
 
-  defp render_empty_manifest(conn, user, vault) do
+  defp parse_since_seq(raw) when is_binary(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n >= 0 -> n
+      _ -> nil
+    end
+  end
+
+  defp parse_since_seq(_), do: nil
+
+  defp render_empty_manifest(conn, current_seq) do
     json(conn, %{
       notes: [],
       attachments: [],
       total_notes: 0,
       total_attachments: 0,
-      change_seq: Engram.Vaults.current_seq(user.id, vault.id)
+      change_seq: current_seq
     })
   end
 
-  defp render_manifest(conn, user, vault, dek) do
+  defp render_manifest(conn, user, vault, dek, current_seq) do
     # T3.6 — project `id` and `dek_version` so AAD-bound rows (v ≥ 2) can
     # reconstruct the bind string ("notes:path:<id>" / "attachments:path:<id>")
     # at decrypt time. Legacy rows (v = 1) decrypt with empty AAD.
@@ -59,7 +91,9 @@ defmodule EngramWeb.SyncController do
             where:
               n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
                 n.kind == "note",
-            select: {n.id, n.dek_version, n.path_ciphertext, n.path_nonce, n.content_hash}
+            select:
+              {n.id, n.dek_version, n.path_ciphertext, n.path_nonce, n.content_hash, n.seq,
+               n.crdt_head}
           )
         )
       end)
@@ -69,7 +103,7 @@ defmodule EngramWeb.SyncController do
         Repo.all(
           from(a in Attachment,
             where: a.user_id == ^user.id and a.vault_id == ^vault.id and is_nil(a.deleted_at),
-            select: {a.id, a.dek_version, a.path_ciphertext, a.path_nonce, a.content_hash}
+            select: {a.id, a.dek_version, a.path_ciphertext, a.path_nonce, a.content_hash, a.seq}
           )
         )
       end)
@@ -80,20 +114,20 @@ defmodule EngramWeb.SyncController do
     # the batch telemetry tells us if a real-world vault disagrees.
     notes =
       Crypto.measure_decrypt_batch(:manifest_notes, length(note_rows), fn ->
-        Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, hash} ->
+        Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, hash, seq, crdt_head} ->
           aad = path_aad(:notes, id, dek_version)
           path = decrypt_path!(path_ct, path_nonce, dek, aad)
-          %{id: id, path: path, content_hash: hash}
+          %{id: id, path: path, content_hash: hash, seq: seq, crdt_head: crdt_head}
         end)
       end)
       |> Enum.sort_by(& &1.path)
 
     attachments =
       Crypto.measure_decrypt_batch(:manifest_attachments, length(attachment_rows), fn ->
-        Enum.map(attachment_rows, fn {id, dek_version, path_ct, path_nonce, hash} ->
+        Enum.map(attachment_rows, fn {id, dek_version, path_ct, path_nonce, hash, seq} ->
           aad = path_aad(:attachments, id, dek_version)
           path = decrypt_path!(path_ct, path_nonce, dek, aad)
-          %{id: id, path: path, content_hash: hash}
+          %{id: id, path: path, content_hash: hash, seq: seq}
         end)
       end)
       |> Enum.sort_by(& &1.path)
@@ -103,7 +137,7 @@ defmodule EngramWeb.SyncController do
       attachments: attachments,
       total_notes: length(notes),
       total_attachments: length(attachments),
-      change_seq: Engram.Vaults.current_seq(user.id, vault.id)
+      change_seq: current_seq
     })
   end
 

--- a/lib/engram_web/schemas/sync.ex
+++ b/lib/engram_web/schemas/sync.ex
@@ -13,7 +13,21 @@ defmodule EngramWeb.Schemas.ManifestEntry do
         description: "Stable note/attachment id — lets a client reconcile its path↔id map."
       },
       path: %Schema{type: :string},
-      content_hash: %Schema{type: :string, nullable: true}
+      content_hash: %Schema{type: :string, nullable: true},
+      seq: %Schema{
+        type: :integer,
+        nullable: true,
+        description:
+          "Vault-global change sequence of the row's last write — integer-diff " <>
+            "validation hook (a client whose recorded seq is lower is behind)."
+      },
+      crdt_head: %Schema{
+        type: :string,
+        nullable: true,
+        description:
+          "CRDT head fingerprint (notes only) — equality with the client's " <>
+            "recorded head proves a live-bound doc is converged without content transfer."
+      }
     },
     required: [:id, :path]
   })
@@ -32,9 +46,16 @@ defmodule EngramWeb.Schemas.ManifestResponse do
       attachments: %Schema{type: :array, items: EngramWeb.Schemas.ManifestEntry},
       total_notes: %Schema{type: :integer},
       total_attachments: %Schema{type: :integer},
-      change_seq: %Schema{type: :integer, description: "Current per-vault sequence watermark."}
+      change_seq: %Schema{type: :integer, description: "Current per-vault sequence watermark."},
+      unchanged: %Schema{
+        type: :boolean,
+        nullable: true,
+        description:
+          "Present (true) only when `since_seq` equals the current watermark — " <>
+            "the manifest body is omitted because nothing changed."
+      }
     },
-    required: [:notes, :attachments, :total_notes, :total_attachments, :change_seq]
+    required: [:change_seq]
   })
 end
 

--- a/openapi.json
+++ b/openapi.json
@@ -591,6 +591,13 @@
             "x-struct": null,
             "x-validate": null
           },
+          "crdt_head": {
+            "description": "CRDT head fingerprint (notes only) — equality with the client's recorded head proves a live-bound doc is converged without content transfer.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "id": {
             "description": "Stable note/attachment id — lets a client reconcile its path↔id map.",
             "format": "uuid",
@@ -600,6 +607,13 @@
           },
           "path": {
             "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "seq": {
+            "description": "Vault-global change sequence of the row's last write — integer-diff validation hook (a client whose recorded seq is lower is behind).",
+            "nullable": true,
+            "type": "integer",
             "x-struct": null,
             "x-validate": null
           }
@@ -2196,13 +2210,16 @@
             "type": "integer",
             "x-struct": null,
             "x-validate": null
+          },
+          "unchanged": {
+            "description": "Present (true) only when `since_seq` equals the current watermark — the manifest body is omitted because nothing changed.",
+            "nullable": true,
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
           }
         },
         "required": [
-          "notes",
-          "attachments",
-          "total_notes",
-          "total_attachments",
           "change_seq"
         ],
         "title": "ManifestResponse",
@@ -2759,9 +2776,22 @@
     "/api/sync/manifest": {
       "get": {
         "callbacks": {},
-        "description": "Every live note + attachment path and content hash, for sync reconciliation.",
+        "description": "Every live note + attachment path, content hash, and change seq, for sync reconciliation. Pass `since_seq` (the `change_seq` of a previous manifest) to short-circuit: when nothing has changed the response is just `{unchanged: true, change_seq}` with the body omitted.",
         "operationId": "sync-manifest",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "Watermark from a prior manifest's `change_seq`; invalid values are ignored.",
+            "example": "1042",
+            "in": "query",
+            "name": "since_seq",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/test/engram_web/controllers/sync_controller_test.exs
+++ b/test/engram_web/controllers/sync_controller_test.exs
@@ -149,4 +149,51 @@ defmodule EngramWeb.SyncControllerTest do
       assert paths == ["Real.md"]
     end
   end
+
+  describe "GET /sync/manifest — seq-diff validator (Phase E1, #1065)" do
+    test "note rows carry seq + crdt_head; attachment rows carry seq", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Test/A.md", content: "# Alpha", mtime: 1_000.0})
+
+      body = conn |> get("/api/sync/manifest") |> json_response(200)
+      [note] = body["notes"]
+
+      assert is_integer(note["seq"]) and note["seq"] > 0
+      assert Map.has_key?(note, "crdt_head")
+    end
+
+    test "since_seq equal to the watermark short-circuits to unchanged", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Test/A.md", content: "# Alpha", mtime: 1_000.0})
+      %{"change_seq" => seq} = conn |> get("/api/sync/manifest") |> json_response(200)
+
+      body = conn |> get("/api/sync/manifest?since_seq=#{seq}") |> json_response(200)
+
+      assert body["unchanged"] == true
+      assert body["change_seq"] == seq
+      refute Map.has_key?(body, "notes")
+    end
+
+    test "stale since_seq returns the full manifest", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Test/A.md", content: "# Alpha", mtime: 1_000.0})
+
+      body = conn |> get("/api/sync/manifest?since_seq=0") |> json_response(200)
+
+      assert is_list(body["notes"])
+      refute body["unchanged"]
+    end
+
+    test "garbage since_seq is ignored (full manifest, no 500)", %{conn: conn} do
+      body = conn |> get("/api/sync/manifest?since_seq=abc") |> json_response(200)
+
+      assert is_list(body["notes"])
+    end
+
+    test "zero-write vault with since_seq=0 short-circuits (floor is the watermark)", %{
+      conn: conn
+    } do
+      body = conn |> get("/api/sync/manifest?since_seq=0") |> json_response(200)
+
+      assert body["unchanged"] == true
+      assert body["change_seq"] == 0
+    end
+  end
 end


### PR DESCRIPTION
Phase E1 of the single-path CRDT migration — the backend half of the seq-diff bulk vault validator (#1065, LOCKED addition). Pairs plugin branch `feat/crdt-manifest-seq-validator` (same name). Additive + backward-compatible: an old plugin ignores the new row fields and never sends `since_seq`.

## What
- Manifest note rows gain `seq` + `crdt_head`; attachment rows gain `seq` — projection-only (columns already exist; the `(vault_id, seq, id)` indexes already exist). No migration.
- `?since_seq=` equal to the vault `change_seq` watermark short-circuits to `{unchanged: true, change_seq}` BEFORE any row query or path decrypt — the common no-op poll costs one vault-row read. Invalid values are ignored (full manifest, never an error). The no-DEK path honors it too.
- `change_seq` (already in the response) serves as the spec's `as_of_seq` — reused, not duplicated.
- OpenAPI: `since_seq` param + row/response schema fields documented.

## Tests
5 new controller tests (row shape, equal/stale/garbage `since_seq`, zero-write floor). Full suite 3784 pass / 0 failures; format + credo --strict + dialyzer green. No version bump (release-please). Refs #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj