### PR TITLE
feat(crdt): delete the REST /notes/:id/updates transport (Phase E3)

### DIFF
--- a/e2e/tests/crdt/test_live_bound_both_ends.py
+++ b/e2e/tests/crdt/test_live_bound_both_ends.py
@@ -204,13 +204,11 @@ async def test_deaf_live_bound_note_converges_via_socket_replay(vault_b, cdp_b, 
     assert "base line" in final, f"base content lost on B: {final!r}"
     wait_for_content(vault_b, path_y, "TRIGGER-EDIT-Y", timeout=CRDT_TIMEOUT)
 
-    # Mechanism oracles. get_logs aggregates BOTH devices, and the user's other
-    # device (A) legitimately heals its cold (not-live-bound) copy of X via the
-    # REST catch-up leg until Phase E deletes it — so the absence assert targets
-    # the LIVE-BOUND REST backstop's line specifically (deleted in the paired
-    # plugin PR; only a regression can re-emit it), and the presence asserts pin
-    # B's heal to the socket primitive (only a live-bound diverged note logs
-    # "socket converge", and only B has X bound). All three are scoped to
+    # Mechanism oracles. get_logs aggregates BOTH devices — and with Phase E3
+    # the COLD REST catch-up leg is deleted too, so the absence assert broadens
+    # to EVERY "REST converge" line from ANY device on ANY leg (a pre-E3
+    # plugin, or a regression re-adding any REST delta pull, fails it). The
+    # presence asserts pin B's heal to the socket primitive. All are scoped to
     # `post_wedge` so the live-bind step's own pre-wedge open-heal line can't
     # satisfy them.
     wait_for_client_log(api_sync, "gap-heal fired", timeout=CRDT_TIMEOUT, after=post_wedge)
@@ -226,12 +224,9 @@ async def test_deaf_live_bound_note_converges_via_socket_replay(vault_b, cdp_b, 
     )
     logs = api_sync.get_logs(limit=1000).get("logs", [])
     rest_lines = [
-        log["message"]
-        for log in logs
-        if "REST converge: live-bound" in log.get("message", "")
-        and path_x in log.get("message", "")
+        log["message"] for log in logs if "REST converge" in log.get("message", "")
     ]
-    assert not rest_lines, f"live-bound REST backstop ran for {path_x}: {rest_lines}"
+    assert not rest_lines, f"REST converge ran on some device/leg (Phase E3): {rest_lines}"
 
 
 @pytest.mark.asyncio

--- a/lib/engram_web/controllers/crdt_sync_controller.ex
+++ b/lib/engram_web/controllers/crdt_sync_controller.ex
@@ -1,48 +1,15 @@
 defmodule EngramWeb.CrdtSyncController do
   @moduledoc """
-  REST transport for Yjs updates (single-authority sync, Phase 1). Thin wrapper
-  over `Engram.Notes.CrdtTransport`; auth + vault scoping come from the pipeline.
+  CRDT discovery probe (single-path sync). The REST update transport
+  (`POST`/`GET /notes/:id/updates`) was DELETED in Phase E3 — Yjs deltas
+  travel only over the `crdt:` socket topic. What remains is the
+  non-destructive `GET /vault/heads` discovery/capability probe, a thin
+  wrapper over `Engram.Notes.CrdtTransport.vault_heads/2`; auth + vault
+  scoping come from the pipeline.
   """
   use EngramWeb, :controller
 
   alias Engram.Notes.CrdtTransport
-
-  # POST /api/notes/:id/updates   body: {"update": "<base64 v1 update>"}
-  def post_update(conn, %{"id" => id, "update" => b64}) do
-    user = conn.assigns.current_user
-    vault = conn.assigns.current_vault
-
-    with {:ok, note_id} <- cast_uuid(id),
-         {:ok, update} <- decode_std(b64),
-         {:ok, %{head: head}} <- CrdtTransport.apply_update(user, vault, note_id, update) do
-      json(conn, %{head: head})
-    else
-      {:error, :bad_uuid} -> error(conn, 400, "invalid note id")
-      {:error, :bad_base64} -> error(conn, 400, "invalid base64 update")
-      {:error, :not_found} -> error(conn, 404, "note not found")
-      {:error, :invalid_update} -> error(conn, 422, "update failed to apply")
-      {:error, :room_unavailable} -> error(conn, 503, "sync room unavailable, retry")
-    end
-  end
-
-  def post_update(conn, %{"id" => _}), do: error(conn, 400, "missing update")
-
-  # GET /api/notes/:id/updates?since=<url-safe base64 state vector>
-  def get_updates(conn, %{"id" => id} = params) do
-    user = conn.assigns.current_user
-    vault = conn.assigns.current_vault
-
-    with {:ok, note_id} <- cast_uuid(id),
-         {:ok, since} <- decode_since(params["since"]),
-         {:ok, %{update: update, head: head}} <-
-           CrdtTransport.read_delta(user, vault, note_id, since) do
-      json(conn, %{update: Base.encode64(update), head: head})
-    else
-      {:error, :bad_uuid} -> error(conn, 400, "invalid note id")
-      {:error, :bad_since} -> error(conn, 400, "invalid since vector")
-      {:error, :not_found} -> error(conn, 404, "note not found")
-    end
-  end
 
   # GET /api/vault/heads
   def vault_heads(conn, _params) do
@@ -52,43 +19,5 @@ defmodule EngramWeb.CrdtSyncController do
     # next poll. Byte-identical `%{heads: ...}` shape.
     heads = CrdtTransport.vault_heads(user, vault)
     json(conn, %{heads: heads})
-  end
-
-  defp cast_uuid(id) do
-    case Ecto.UUID.cast(id) do
-      {:ok, uuid} -> {:ok, uuid}
-      :error -> {:error, :bad_uuid}
-    end
-  end
-
-  defp decode_std(b64) when is_binary(b64) do
-    case Base.decode64(b64) do
-      {:ok, bin} -> {:ok, bin}
-      :error -> {:error, :bad_base64}
-    end
-  end
-
-  defp decode_std(_), do: {:error, :bad_base64}
-
-  defp decode_since(nil), do: {:ok, nil}
-
-  # Accept BOTH base64 alphabets. The plugin encodes `since` with standard
-  # base64 (btoa -> +///), but this query-param path previously decoded only the
-  # url-safe alphabet, so every non-genesis cold-receive delta pull 400'd (empty
-  # "AA==" vectors have no +// and masked it). Try url-safe first (future-proof),
-  # fall back to standard (what deployed clients send) so all clients converge.
-  defp decode_since(sv) when is_binary(sv) do
-    with :error <- Base.url_decode64(sv, padding: false),
-         :error <- Base.decode64(sv, padding: false) do
-      {:error, :bad_since}
-    else
-      {:ok, bin} -> {:ok, bin}
-    end
-  end
-
-  defp decode_since(_), do: {:error, :bad_since}
-
-  defp error(conn, status, message) do
-    conn |> put_status(status) |> json(%{error: message})
   end
 end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -364,8 +364,8 @@ defmodule EngramWeb.Router do
     get "/notes/changes", NotesController, :changes
     get "/notes/by-id/:id", NotesController, :show_by_id
     delete "/notes/by-id/:id", NotesController, :delete_by_id
-    post "/notes/:id/updates", CrdtSyncController, :post_update
-    get "/notes/:id/updates", CrdtSyncController, :get_updates
+    # REST /notes/:id/updates DELETED (Phase E3) — Yjs deltas travel ONLY over
+    # the crdt: socket topic; the heads probe below is discovery, not delivery.
     get "/vault/heads", CrdtSyncController, :vault_heads
     get "/notes/*path", NotesController, :show
     delete "/notes/*path", NotesController, :delete

--- a/test/engram_web/controllers/crdt_sync_controller_test.exs
+++ b/test/engram_web/controllers/crdt_sync_controller_test.exs
@@ -1,11 +1,7 @@
 defmodule EngramWeb.CrdtSyncControllerTest do
-  # async: false — POST /updates starts a :global CRDT room that writes to the
-  # DB; shared-mode sandbox (non-async) lets that internal process use the
-  # owner's connection.
   use EngramWeb.ConnCase, async: false
 
   alias Engram.Notes
-  alias Engram.Notes.{CrdtBridge, CrdtRegistry}
 
   setup :authed_api_conn
 
@@ -14,160 +10,34 @@ defmodule EngramWeb.CrdtSyncControllerTest do
     note
   end
 
-  describe "GET /api/notes/:id/updates" do
-    test "returns full state that reconstructs the note", %{conn: conn, user: user, vault: vault} do
-      note = seed_note(user, vault, "T/A.md", "# A\n\nhello")
-
-      resp = conn |> get("/api/notes/#{note.id}/updates") |> json_response(200)
-      assert %{"update" => b64, "head" => head} = resp
-      assert is_binary(head)
-
-      {:ok, update} = Base.decode64(b64)
-      client = CrdtBridge.new_doc()
-      :ok = Yex.apply_update(client, update)
-      assert CrdtBridge.body_of(client) =~ "hello"
-    end
-
-    test "404 for an unknown note id", %{conn: conn} do
-      conn = get(conn, "/api/notes/#{Ecto.UUID.generate()}/updates")
-      assert json_response(conn, 404)
-    end
-
-    test "400 for a non-uuid id", %{conn: conn} do
-      conn = get(conn, "/api/notes/not-a-uuid/updates")
-      assert json_response(conn, 400)
-    end
-
-    test "400 (not 500) when since is a repeated (list) query param", %{
+  describe "REST /updates endpoints are DELETED (Phase E3 — socket is the only Yjs path)" do
+    # The dedicated routes are gone; the requests now fall through to the
+    # `/notes/*path` wildcard (a nonexistent note path) or the router's 404.
+    # The contract pinned here: no Yjs delta is ever SERVED or APPLIED over
+    # REST — a request to the old paths yields a plain 404 with no transport
+    # payload.
+    test "GET /api/notes/:id/updates no longer serves a delta", %{
       conn: conn,
       user: user,
       vault: vault
     } do
-      note = seed_note(user, vault, "T/H.md", "# H")
+      note = seed_note(user, vault, "T/A.md", "# A")
 
-      # ?since[]=x parses to a list, not a scalar string — must 400, not crash.
-      conn = get(conn, "/api/notes/#{note.id}/updates?since[]=x")
-      assert json_response(conn, 400)
+      body = conn |> get("/api/notes/#{note.id}/updates") |> json_response(404)
+      refute Map.has_key?(body, "update")
+      refute Map.has_key?(body, "head")
     end
 
-    test "400 (not 500) when since is valid base64 but not a real state vector", %{
+    test "POST /api/notes/:id/updates no longer applies an update", %{
       conn: conn,
       user: user,
       vault: vault
     } do
-      note = seed_note(user, vault, "T/I.md", "# I")
+      note = seed_note(user, vault, "T/B.md", "# B")
 
-      since = Base.url_encode64(:binary.copy(<<0x80>>, 10), padding: false)
-      conn = get(conn, "/api/notes/#{note.id}/updates?since=#{since}")
-      assert json_response(conn, 400)
-    end
-
-    test "400 (not a VM-crashing NIF call) when since claims an implausible entry count", %{
-      conn: conn,
-      user: user,
-      vault: vault
-    } do
-      note = seed_note(user, vault, "T/J.md", "# J")
-
-      # <<128, 128, 128, 128, 15>> decodes as a state vector claiming ~2^31
-      # client entries in 5 bytes — see CrdtTransport.plausible_state_vector?/1.
-      # Unguarded, this crashes the whole BEAM VM (Rust allocator abort), not
-      # just this request; this test proves the guard rejects it as bad input.
-      since = Base.url_encode64(<<128, 128, 128, 128, 15>>, padding: false)
-      conn = get(conn, "/api/notes/#{note.id}/updates?since=#{since}")
-      assert json_response(conn, 400)
-    end
-
-    test "accepts a STANDARD-base64 since vector (plugin encodes with btoa, not url-safe)",
-         %{conn: conn, user: user, vault: vault} do
-      note = seed_note(user, vault, "T/K.md", "# K\n\nhello")
-
-      # <<1, 1, 63>> is a valid 1-client state vector (id=1, clock=63) whose
-      # STANDARD base64 is "AQE/", which contains '/'; the url-safe alphabet
-      # lacks it. The plugin encodes `since` with standard base64 (btoa), so every
-      # non-genesis cold-receive delta pull 400'd here; empty "AA==" vectors have
-      # no +// and masked it. Regression guard for the e2e-clerk test_85
-      # missed-delivery convergence failure (cold-receive was 100% broken for
-      # non-empty state vectors).
-      since = Base.encode64(<<1, 1, 63>>)
-      assert String.contains?(since, "/")
-
-      resp =
-        conn
-        |> get("/api/notes/#{note.id}/updates?since=#{URI.encode_www_form(since)}")
-        |> json_response(200)
-
-      assert %{"update" => _} = resp
-    end
-  end
-
-  describe "POST /api/notes/:id/updates" do
-    test "applies a client update and round-trips through GET",
-         %{conn: conn, user: user, vault: vault} do
-      note = seed_note(user, vault, "T/B.md", "# B\n\nseed")
-      on_exit(fn -> CrdtRegistry.terminate_room(note.id) end)
-
-      # Build a real client update.
-      full = conn |> get("/api/notes/#{note.id}/updates") |> json_response(200)
-      {:ok, full_bytes} = Base.decode64(full["update"])
-      client = CrdtBridge.new_doc()
-      :ok = Yex.apply_update(client, full_bytes)
-      before_sv = Yex.encode_state_vector!(client)
-      CrdtBridge.ingest_plaintext(client, "# B\n\nseed plus edit")
-      {:ok, delta} = Yex.encode_state_as_update(client, before_sv)
-
-      post_resp =
-        conn
-        |> post("/api/notes/#{note.id}/updates", %{update: Base.encode64(delta)})
-        |> json_response(200)
-
-      assert %{"head" => _} = post_resp
-
-      # GET now serves the edit back.
-      after_full = conn |> get("/api/notes/#{note.id}/updates") |> json_response(200)
-      {:ok, after_bytes} = Base.decode64(after_full["update"])
-      reader = CrdtBridge.new_doc()
-      :ok = Yex.apply_update(reader, after_bytes)
-      assert CrdtBridge.body_of(reader) =~ "plus edit"
-    end
-
-    test "422 for an update that fails to apply", %{conn: conn, user: user, vault: vault} do
-      note = seed_note(user, vault, "T/C.md", "# C")
-      on_exit(fn -> CrdtRegistry.terminate_room(note.id) end)
-
-      conn =
-        post(conn, "/api/notes/#{note.id}/updates", %{update: Base.encode64(<<255, 254, 0, 1>>)})
-
-      assert json_response(conn, 422)
-    end
-
-    test "400 when the update field is missing", %{conn: conn, user: user, vault: vault} do
-      note = seed_note(user, vault, "T/E.md", "# E")
-      conn = post(conn, "/api/notes/#{note.id}/updates", %{})
-      assert json_response(conn, 400)
-    end
-
-    test "401 without auth", %{conn: conn, user: user, vault: vault} do
-      note = seed_note(user, vault, "T/F.md", "# F")
-
-      conn =
-        conn
-        |> delete_req_header("authorization")
-        |> post("/api/notes/#{note.id}/updates", %{update: Base.encode64(<<0, 0>>)})
-
-      assert json_response(conn, 401)
-    end
-
-    test "400 (not 500) when update is not a string", %{conn: conn, user: user, vault: vault} do
-      note = seed_note(user, vault, "T/G.md", "# G")
-
-      # A JSON integer (not a base64 string) must be rejected as bad input, not crash.
-      conn =
-        conn
-        |> put_req_header("content-type", "application/json")
-        |> post("/api/notes/#{note.id}/updates", Jason.encode!(%{"update" => 123}))
-
-      assert json_response(conn, 400)
+      resp = post(conn, "/api/notes/#{note.id}/updates", %{update: Base.encode64(<<0, 0>>)})
+      assert resp.status == 404
+      refute Map.has_key?(Jason.decode!(resp.resp_body), "head")
     end
   end
 


### PR DESCRIPTION
Phase E3 of the single-path CRDT migration (plan: workspace `docs/superpowers/plans/2026-07-22-crdt-single-path-phase-e.md`). Paired plugin PR: engram-app/Engram-obsidian#293 (same branch name — e2e auto-pairing). Merge THIS PR first, then re-trigger the plugin PR's e2e.

## What

- `POST /notes/:id/updates` and `GET /notes/:id/updates` routes deleted — Yjs deltas travel ONLY over the `crdt:` socket topic.
- `CrdtSyncController` keeps just the non-destructive `GET /vault/heads` discovery/capability probe.
- `CrdtTransport.apply_update`/`read_delta` REMAIN: they are the room-write/read primitives used by the invalidation-trigger tests, the `BackfillCrdtHead` worker chain, and the WS guard (`safe_wire_frame?`); only their HTTP exposure is gone.
- Controller tests now pin the deleted paths to plain 404s with no transport payload (`update`/`head`) ever served or applied.
- The deaf-gate e2e REST-absence oracle (`test_live_bound_both_ends.py`) broadens from the live-bound-specific line to EVERY `REST converge` client-log line on ANY device/leg — a pre-E3 plugin or any regression re-adding a REST delta pull fails it.

openapi.json is unchanged — these endpoints were never in the public spec (regen verified no diff).

## Gates

- `mix format --check-formatted`, `mix credo --strict` (no issues), `mix dialyzer` (passed), full `mix test`: 3777 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj