### PR TITLE
feat(ci): auto-alert on chronically flaky e2e suites

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3588,6 +3588,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, isolated, light]
     permissions:
       contents: write
+      issues: write   # auto-open/close a flaky-suite issue when a suite crosses the threshold
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}  # gh CLI can't infer repo from the LAN insteadOf-rewritten origin, see docs/context/gh-cli-runner-url-rewrite-and-release-repair.md
@@ -3608,6 +3609,13 @@ jobs:
           DATE=$(date -u +%F)
           RUN_ID="${GITHUB_RUN_ID}"
           SHA="${GITHUB_SHA}"
+
+          # Read the rate filter NOW, while the working tree is still on the
+          # default branch — the append step below checks out the ci-ledger
+          # orphan branch, which does not contain scripts/, so the file would
+          # vanish. Both consumers (summary table + alert gate) use this one
+          # program, so they can never disagree on a suite's flake rate.
+          RATES_JQ="$(cat scripts/flake_ledger_rates.jq)"
 
           # result must be one of success/failure/skipped for the ledger schema;
           # anything else (cancelled, timed_out, ...) folds into failure — it's
@@ -3681,26 +3689,65 @@ jobs:
 
           # Trailing-14-night flake rate per suite, from whatever ledger state
           # is on disk right now (the just-appended local copy either way).
-          # Dedup on (workflow_run_id, suite) before windowing: a manual re-run
-          # of a scheduled run appends a second line for the same night, which
-          # would double-count that night and push an older night out of the
-          # trailing-14 sample. The raw JSONL stays append-only; only this
-          # report's read is deduped.
+          # Dedup + windowing live in scripts/flake_ledger_rates.jq (tested by
+          # scripts/flake_ledger_rates_test.sh) so the table and the alert gate
+          # below share one definition. Emits one {suite,red,n,pct} per line.
+          RATES="$(jq -s "$RATES_JQ" flake-ledger.jsonl)"
+
           {
             echo "### Nightly e2e flake rate (trailing 14 nights)"
             echo
             echo "| suite | nights red | rate |"
             echo "|---|---|---|"
-            jq -s -r '
-              unique_by([.workflow_run_id, .suite]) |
-              group_by(.suite)[] |
-              (sort_by(.date) | .[-14:]) as $recent |
-              ($recent | length) as $n |
-              ([$recent[] | select(.result=="failure")] | length) as $red |
-              (if $n > 0 then (($red * 100 / $n) | floor) else 0 end) as $pct |
-              "| \(.[0].suite) | \($red)/\($n) | \($pct)% |"
-            ' flake-ledger.jsonl
+            printf '%s\n' "$RATES" | jq -r '"| \(.suite) | \(.red)/\(.n) | \(.pct)% |"'
           } >> "$GITHUB_STEP_SUMMARY"
+
+          # Auto-alert: one open `flaky-suite` issue per suite that is red on
+          # >=40% of the trailing 14 nights, once there are >=5 nights of data
+          # (below that the sample is too small — don't scream off one bad
+          # night). Recovered suites auto-close. This is the loop-closer: it
+          # turns the ledger from a branch nobody reads into a thing that pokes
+          # us only when a suite is genuinely misbehaving.
+          #
+          # Best-effort — a gh hiccup must never fail this measurement job, so
+          # disable -e for this block (mirrors the push retry's non-fatal stance).
+          THRESHOLD_PCT=40
+          MIN_NIGHTS=5
+          set +e
+          gh label create flaky-suite --color d73a4a \
+            --description "Nightly e2e suite over the flake threshold" >/dev/null 2>&1 || true
+          OPEN_ISSUES="$(gh issue list --label flaky-suite --state open --json number,title 2>/dev/null || echo '[]')"
+          printf '%s\n' "$RATES" | jq -c '.' | while IFS= read -r row; do
+            suite=$(printf '%s' "$row" | jq -r '.suite')
+            pct=$(printf '%s'   "$row" | jq -r '.pct')
+            red=$(printf '%s'   "$row" | jq -r '.red')
+            n=$(printf '%s'     "$row" | jq -r '.n')
+            title="Flaky suite: ${suite} (nightly e2e)"
+            num=$(printf '%s' "$OPEN_ISSUES" | jq -r --arg t "$title" '.[] | select(.title==$t) | .number' | head -n1)
+
+            if [ "$n" -ge "$MIN_NIGHTS" ] && [ "$pct" -ge "$THRESHOLD_PCT" ]; then
+              if [ -n "$num" ]; then
+                gh issue comment "$num" --body "Still over threshold on ${DATE}: **${pct}%** (${red}/${n} nights red, trailing 14)." \
+                  || echo "::warning::flaky-suite: comment on #$num failed"
+              else
+                # Build the body with printf (not a column-0 multiline string,
+                # which would terminate this YAML block scalar).
+                body=$(printf '%s\n' \
+                  "Suite \`${suite}\` is failing the nightly full-e2e run **${pct}%** of the trailing 14 nights (${red}/${n} red)." \
+                  "" \
+                  "Threshold: ${THRESHOLD_PCT}% over >=${MIN_NIGHTS} nights of data. Full per-night history is on the \`ci-ledger\` branch; rationale for report-only e2e is in \`docs/context/testing-architecture-migration.md\`." \
+                  "" \
+                  "Auto-filed by the \`ledger-append\` job in \`.github/workflows/verify.yml\`; auto-closes when the rate drops back under ${THRESHOLD_PCT}%.")
+                gh issue create --title "$title" --label flaky-suite --body "$body" \
+                  || echo "::warning::flaky-suite: create for ${suite} failed"
+              fi
+            elif [ -n "$num" ]; then
+              gh issue comment "$num" --body "Recovered on ${DATE}: **${pct}%** (${red}/${n}) — back under ${THRESHOLD_PCT}%. Closing." \
+                && gh issue close "$num" \
+                || echo "::warning::flaky-suite: close of #$num failed"
+            fi
+          done
+          set -e
 
   # Cache BOTH green-CI fingerprints so the next run with the same content
   # (typically the squash-merge to main) can skip the relevant slice.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2588,6 +2588,12 @@ jobs:
           fi
           echo "OK — no checkbox-as-TODO in root markdown."
 
+      - name: Flake-ledger rate logic self-check
+        # Guards scripts/flake_ledger_rates.jq (dedup + trailing-14 window +
+        # rate math). The ledger-append job that uses it is schedule-only, so
+        # without this a broken filter would hide until the next nightly.
+        run: bash scripts/flake_ledger_rates_test.sh
+
       - name: Scan CLAUDE.md / AGENTS.md files for known-stale facts
         run: |
           set -euo pipefail
@@ -3716,37 +3722,45 @@ jobs:
           set +e
           gh label create flaky-suite --color d73a4a \
             --description "Nightly e2e suite over the flake threshold" >/dev/null 2>&1 || true
-          OPEN_ISSUES="$(gh issue list --label flaky-suite --state open --json number,title 2>/dev/null || echo '[]')"
-          printf '%s\n' "$RATES" | jq -c '.' | while IFS= read -r row; do
-            suite=$(printf '%s' "$row" | jq -r '.suite')
-            pct=$(printf '%s'   "$row" | jq -r '.pct')
-            red=$(printf '%s'   "$row" | jq -r '.red')
-            n=$(printf '%s'     "$row" | jq -r '.n')
-            title="Flaky suite: ${suite} (nightly e2e)"
-            num=$(printf '%s' "$OPEN_ISSUES" | jq -r --arg t "$title" '.[] | select(.title==$t) | .number' | head -n1)
+          # A successful query returns at least "[]"; an empty string means the
+          # `gh` call failed. Do NOT treat failure as "no open issues" — that
+          # would look un-tracked and file a DUPLICATE issue for every
+          # over-threshold suite on a transient blip. Skip; retry tomorrow.
+          OPEN_ISSUES="$(gh issue list --label flaky-suite --state open --json number,title 2>/dev/null)"
+          if [ -z "$OPEN_ISSUES" ]; then
+            echo "::warning::flaky-suite: could not list open issues — skipping alert pass this run"
+          else
+            printf '%s\n' "$RATES" | jq -c '.' | while IFS= read -r row; do
+              suite=$(printf '%s' "$row" | jq -r '.suite')
+              pct=$(printf '%s'   "$row" | jq -r '.pct')
+              red=$(printf '%s'   "$row" | jq -r '.red')
+              n=$(printf '%s'     "$row" | jq -r '.n')
+              title="Flaky suite: ${suite} (nightly e2e)"
+              num=$(printf '%s' "$OPEN_ISSUES" | jq -r --arg t "$title" '.[] | select(.title==$t) | .number' | head -n1)
 
-            if [ "$n" -ge "$MIN_NIGHTS" ] && [ "$pct" -ge "$THRESHOLD_PCT" ]; then
-              if [ -n "$num" ]; then
-                gh issue comment "$num" --body "Still over threshold on ${DATE}: **${pct}%** (${red}/${n} nights red, trailing 14)." \
-                  || echo "::warning::flaky-suite: comment on #$num failed"
-              else
-                # Build the body with printf (not a column-0 multiline string,
-                # which would terminate this YAML block scalar).
-                body=$(printf '%s\n' \
-                  "Suite \`${suite}\` is failing the nightly full-e2e run **${pct}%** of the trailing 14 nights (${red}/${n} red)." \
-                  "" \
-                  "Threshold: ${THRESHOLD_PCT}% over >=${MIN_NIGHTS} nights of data. Full per-night history is on the \`ci-ledger\` branch; rationale for report-only e2e is in \`docs/context/testing-architecture-migration.md\`." \
-                  "" \
-                  "Auto-filed by the \`ledger-append\` job in \`.github/workflows/verify.yml\`; auto-closes when the rate drops back under ${THRESHOLD_PCT}%.")
-                gh issue create --title "$title" --label flaky-suite --body "$body" \
-                  || echo "::warning::flaky-suite: create for ${suite} failed"
+              if [ "$n" -ge "$MIN_NIGHTS" ] && [ "$pct" -ge "$THRESHOLD_PCT" ]; then
+                if [ -n "$num" ]; then
+                  gh issue comment "$num" --body "Still over threshold on ${DATE}: **${pct}%** (${red}/${n} nights red, trailing 14)." \
+                    || echo "::warning::flaky-suite: comment on #$num failed"
+                else
+                  # Build the body with printf (not a column-0 multiline string,
+                  # which would terminate this YAML block scalar).
+                  body=$(printf '%s\n' \
+                    "Suite \`${suite}\` is failing the nightly full-e2e run **${pct}%** of the trailing 14 nights (${red}/${n} red)." \
+                    "" \
+                    "Threshold: ${THRESHOLD_PCT}% over >=${MIN_NIGHTS} nights of data. Full per-night history is on the \`ci-ledger\` branch; rationale for report-only e2e is in \`docs/context/testing-architecture-migration.md\`." \
+                    "" \
+                    "Auto-filed by the \`ledger-append\` job in \`.github/workflows/verify.yml\`; auto-closes when the rate drops back under ${THRESHOLD_PCT}%.")
+                  gh issue create --title "$title" --label flaky-suite --body "$body" \
+                    || echo "::warning::flaky-suite: create for ${suite} failed"
+                fi
+              elif [ -n "$num" ]; then
+                gh issue comment "$num" --body "Recovered on ${DATE}: **${pct}%** (${red}/${n}) — back under ${THRESHOLD_PCT}%. Closing." \
+                  && gh issue close "$num" \
+                  || echo "::warning::flaky-suite: close of #$num failed"
               fi
-            elif [ -n "$num" ]; then
-              gh issue comment "$num" --body "Recovered on ${DATE}: **${pct}%** (${red}/${n}) — back under ${THRESHOLD_PCT}%. Closing." \
-                && gh issue close "$num" \
-                || echo "::warning::flaky-suite: close of #$num failed"
-            fi
-          done
+            done
+          fi
           set -e
 
   # Cache BOTH green-CI fingerprints so the next run with the same content

--- a/docs/context/testing-architecture-migration.md
+++ b/docs/context/testing-architecture-migration.md
@@ -1,0 +1,53 @@
+# Testing-architecture migration: report-only e2e + the flake ledger
+
+**Trigger:** you hit a comment in `verify.yml` pointing here, or you're asking
+"why doesn't a red e2e suite block my PR?" or "how do we know when to trust a
+flaky suite again?"
+
+## What changed
+
+The full-Obsidian e2e suites — `e2e-clerk`, `e2e-crdt`, `e2e-browser` — moved
+from **hard gate** to **report-only** in the `ci` aggregate job. They still run
+on every push and post their own PR checks, but a failure emits `::warning::`
+instead of failing the merge (see `verify.yml`, the `ci` job's "REPORT-ONLY"
+block). They remain the gate on **main / nightly / `release-v*`**.
+
+## Why
+
+Real Obsidian + Xvfb + CDP + Playwright on shared self-hosted runners is
+structurally nondeterministic — the suite flaked ~50% for reasons unrelated to
+the code under test (runner contention, boot timing, Clerk rate limits). A gate
+that's a coin-flip stops nothing real while blocking correct, unit-proven work.
+So convergence is now gated **deterministically** elsewhere, and the flaky
+integration suite became a signal, not a blocker.
+
+## What gates convergence now (deterministic, hard-required)
+
+- **`unit-tests`** — includes the CRDT head-consistency property test.
+- **plugin sim tier** — the differential gate in the plugin repo (`Engram-obsidian`).
+- **`headless-protocol`** — real plugin SyncEngine vs real backend over real
+  WebSockets with event barriers (no Obsidian, no wall-clock waits). Currently
+  report-only itself; promotion criterion is in its job header in `verify.yml`.
+
+## The safety net: nightly flake ledger + auto-alert
+
+Report-only can't mean "ignored forever". The `ledger-append` job (nightly,
+06:00 UTC) records each suite's pass/fail to the **`ci-ledger` orphan branch**
+(`flake-ledger.jsonl`, schema `{date, sha, workflow_run_id, suite, result,
+duration_s}`) and renders a **trailing-14-night flake rate** per suite.
+
+- Rate math lives in `scripts/flake_ledger_rates.jq` (dedup on
+  `(workflow_run_id, suite)` + 14-night window), tested offline by
+  `scripts/flake_ledger_rates_test.sh`.
+- **Auto-alert:** a suite red on **>=40%** of the trailing 14 nights (once
+  there are **>=5** nights of data) auto-opens a `flaky-suite` GitHub issue;
+  it auto-closes when the rate recovers. This is the only human touchpoint —
+  you don't watch the branch, the branch pokes you.
+
+## Promoting a suite back to gating
+
+Manual and deliberate — do NOT automate it (auto-promotion re-introduces a
+flaky gate). Flip a report-only suite to required only after ~10 consecutive
+**infra-clean** green runs, using the ledger's measured rate as evidence and
+excluding infra-only reds (docker `--wait` / `docker pull` / `bun install
+--frozen-lockfile`). Add it to `ci`'s `needs:` + the pass/fail loop.

--- a/scripts/flake_ledger_rates.jq
+++ b/scripts/flake_ledger_rates.jq
@@ -1,0 +1,16 @@
+# Trailing-14-night flake rate per suite, computed from the append-only ledger
+# JSONL (invoke with `jq -s -f`). Dedups on (workflow_run_id, suite) FIRST so a
+# manual re-run of a scheduled night can't double-count, then windows to the
+# most-recent 14 nights per suite. Emits one compact object per suite:
+#   {suite, red, n, pct}
+# Consumed twice by the ledger-append job (verify.yml): the step-summary table
+# and the flaky-suite auto-alert gate — one source of truth for "how flaky".
+unique_by([.workflow_run_id, .suite])
+| group_by(.suite)[]
+| (sort_by(.date) | .[-14:]) as $recent
+| ($recent | length) as $n
+| ([$recent[] | select(.result == "failure")] | length) as $red
+| { suite: .[0].suite,
+    red: $red,
+    n: $n,
+    pct: (if $n > 0 then (($red * 100 / $n) | floor) else 0 end) }

--- a/scripts/flake_ledger_rates.jq
+++ b/scripts/flake_ledger_rates.jq
@@ -1,5 +1,8 @@
 # Trailing-14-night flake rate per suite, computed from the append-only ledger
-# JSONL (invoke with `jq -s -f`). Dedups on (workflow_run_id, suite) FIRST so a
+# JSONL. Invoke with `jq -s -f` (the test), or `jq -s "$(cat ...)"` (the
+# ledger-append job, which reads this into a var before switching to the
+# ci-ledger orphan branch where scripts/ doesn't exist). Dedups on
+# (workflow_run_id, suite) FIRST so a
 # manual re-run of a scheduled night can't double-count, then windows to the
 # most-recent 14 nights per suite. Emits one compact object per suite:
 #   {suite, red, n, pct}

--- a/scripts/flake_ledger_rates_test.sh
+++ b/scripts/flake_ledger_rates_test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Self-check for flake_ledger_rates.jq: dedup + trailing-14 windowing + rate math.
+# The gnarly part of the flaky-suite monitor; a dispatch can't cheaply exercise
+# it (it drags the whole e2e matrix), so this runs the logic offline.
+#   Run: bash scripts/flake_ledger_rates_test.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fixture=$(mktemp)
+trap 'rm -f "$fixture"' EXIT
+
+{
+  # e2e-crdt: night 01 is the OLDEST and a failure -> must fall OUT of the
+  # 14-night window. Nights 02..15 (14 kept) hold 6 failures -> 6/14 = 42%.
+  echo '{"date":"2026-07-01","sha":"a","workflow_run_id":"1","suite":"e2e-crdt","result":"failure","duration_s":1}'
+  for i in 02 03 04 05 06 07 08 09 10 11 12 13 14 15; do
+    case $i in 04|06|08|10|12|14) r=failure ;; *) r=success ;; esac
+    echo "{\"date\":\"2026-07-$i\",\"sha\":\"a\",\"workflow_run_id\":\"$i\",\"suite\":\"e2e-crdt\",\"result\":\"$r\",\"duration_s\":1}"
+  done
+  # Duplicate of night 15 (same run_id+suite) -> must dedup, not double-count.
+  echo '{"date":"2026-07-15","sha":"a","workflow_run_id":"15","suite":"e2e-crdt","result":"success","duration_s":1}'
+  # e2e-clerk: 14 green -> 0%.
+  for i in 02 03 04 05 06 07 08 09 10 11 12 13 14 15; do
+    echo "{\"date\":\"2026-07-$i\",\"sha\":\"a\",\"workflow_run_id\":\"c$i\",\"suite\":\"e2e-clerk\",\"result\":\"success\",\"duration_s\":1}"
+  done
+  # e2e-browser: small sample (3 nights, 2 red) -> rate computed; caller applies MIN_NIGHTS.
+  echo '{"date":"2026-07-13","sha":"a","workflow_run_id":"b1","suite":"e2e-browser","result":"failure","duration_s":1}'
+  echo '{"date":"2026-07-14","sha":"a","workflow_run_id":"b2","suite":"e2e-browser","result":"failure","duration_s":1}'
+  echo '{"date":"2026-07-15","sha":"a","workflow_run_id":"b3","suite":"e2e-browser","result":"success","duration_s":1}'
+} >"$fixture"
+
+got=$(jq -s -f scripts/flake_ledger_rates.jq "$fixture" | jq -sc 'sort_by(.suite)')
+want='[{"suite":"e2e-browser","red":2,"n":3,"pct":66},{"suite":"e2e-clerk","red":0,"n":14,"pct":0},{"suite":"e2e-crdt","red":6,"n":14,"pct":42}]'
+
+if [ "$got" != "$want" ]; then
+  echo "FAIL"
+  echo "want: $want"
+  echo "got:  $got"
+  exit 1
+fi
+echo "PASS: flake_ledger_rates.jq dedup + trailing-14 window + rate math"


### PR DESCRIPTION
## What

Closes the loop on the nightly flake ledger (#1078). The ledger recorded suite pass/fail to the `ci-ledger` branch, but nothing read it — "monitoring" meant a human remembering to open the branch. Now it pokes us.

- **Auto-alert (`ledger-append`):** opens a `flaky-suite` GitHub issue for any suite red on **≥40%** of the trailing 14 nights (**min 5 nights** of data, so it can't scream off one bad night), and auto-closes it on recovery. Best-effort — a `gh` hiccup emits `::warning::`, never fails the measurement job.
- **`scripts/flake_ledger_rates.jq`:** extracted the trailing-14 dedup+window math so the step-summary table and the alert gate share one definition.
- **`scripts/flake_ledger_rates_test.sh`:** offline self-check (dedup, windowing, rate math). Runnable: `bash scripts/flake_ledger_rates_test.sh`.
- **`docs/context/testing-architecture-migration.md`:** the report-only-e2e rationale `verify.yml` referenced twice but that was never written.

## Notes

- The `ledger-append` job is schedule-only, so this can't be exercised in PR CI — hence the offline test. First real data lands on the next 06:00 UTC nightly; alerts stay silent until ≥5 nights accrue (warm-up guard).
- Gotcha handled: the job checks out the `ci-ledger` orphan branch mid-run (no `scripts/` there), so the jq filter is `cat`'d into a var before the branch switch.
- e2e suites are report-only, so this gates on unit/lint/etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)