### PR TITLE
fix(ci): dispatch-driven release-PR CI; stop duplicate e2e per main merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # actions:write — the "Kick CI on the Release PR branch" step dispatches
+  # verify.yml (GITHUB_TOKEN is an explicit exception to Actions' recursion
+  # guard for workflow_dispatch — same pattern as deploy-prod's e2e gate).
+  actions: write
 
 jobs:
   release-please:
@@ -32,6 +36,24 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
+
+      # Verify.yml deliberately does NOT push-trigger on release-please--**:
+      # the RP action updates its branch in two steps (ref update, then the
+      # release commit), and a push-triggered run raced onto the intermediate
+      # SHA — leaving the Release PR head with no checks and the PR
+      # unmergeable (#1057's symptom back again). Dispatching here, AFTER the
+      # RP action has finished pushing, pins CI to the branch's final tip.
+      # e2e-* skips itself on release-please-- refs (see verify.yml), so this
+      # run is the cheap deterministic gate only.
+      - name: Kick CI on the Release PR branch
+        if: steps.rp.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RP_PR: ${{ steps.rp.outputs.pr }}
+        run: |
+          set -euo pipefail
+          BRANCH=$(jq -r '.headBranchName' <<<"$RP_PR")
+          gh workflow run verify.yml --ref "$BRANCH"
 
       # Ungated: on a Release-PR MERGE push steps.rp.outputs.pr is EMPTY (the
       # `pr` output only fires when release-please opens/updates a PR, not on

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,9 +18,14 @@ on:
       - "perf/**"
       - "refactor/**"
       - "release/**"
-      # release-please's own PR branch — without this the release PR gets no CI,
-      # required checks never report, and the release can never merge (#1057).
-      - "release-please--**"
+      # NOTE: release-please's own PR branch (release-please--**) is
+      # deliberately NOT push-triggered. The RP action updates its branch in
+      # two steps (ref update to main tip, then the release commit), and the
+      # push-triggered run sometimes bound to the intermediate SHA — leaving
+      # the release PR's head with no checks and the PR unmergeable (the
+      # #1057 problem all over again, just racier). Instead release-please.yml
+      # explicitly workflow_dispatches this workflow on the branch AFTER the
+      # RP action finishes, so checks always attach to the real PR head.
       - "revert/**"
       - "security/**"
       - "test/**"
@@ -844,7 +849,11 @@ jobs:
     # trigger — the one event that MUST run this suite), and a skipped need
     # would otherwise auto-skip this job. Trade-off: a failed prebuild no
     # longer auto-skips this job either; it fails at image pull instead.
-    if: ${{ !cancelled() && needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'clerk') }}
+    # !startsWith(release-please--): the release PR branch is main's tip plus a
+    # version-bump commit — main just hard-gated the identical content on its
+    # own full run, and e2e is report-only on PRs anyway. Re-running the real-
+    # Obsidian suites there is pure duplicate spend (same guard on all e2e-*).
+    if: ${{ !cancelled() && !startsWith(github.ref_name, 'release-please--') && needs.fingerprint.outputs.skip-e2e-clerk != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'clerk') }}
     # `heavy` restricts placement to the 2 heavy-labeled runners per VM
     # (fastraid-1/2, slowraid runner-1/2): at most two heavy e2e suites can
     # co-tenant a 14-core VM, which is within budget — the #355 starvation
@@ -1403,7 +1412,8 @@ jobs:
     # of this job's two pytest steps; the non-targeted step skips.
     # !cancelled(): same repository_dispatch rationale as e2e-clerk —
     # prebuild-mix skips there and must not auto-skip this suite.
-    if: ${{ !cancelled() && needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
+    # release-please-- guard: see e2e-clerk.
+    if: ${{ !cancelled() && !startsWith(github.ref_name, 'release-please--') && needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
     runs-on: [self-hosted, linux, x64, isolated, heavy]
 
     env:
@@ -1918,7 +1928,8 @@ jobs:
     # ENGRAM_PLUGIN_SRC) into a bun process. Same local-auth stack, so it rides
     # the skip-e2e-crdt fingerprint signal. Minutes-bounded (each scenario < 1s).
     needs: [fingerprint, prebuild-ci-image]
-    if: ${{ !cancelled() && needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
+    # release-please-- guard: see e2e-clerk.
+    if: ${{ !cancelled() && !startsWith(github.ref_name, 'release-please--') && needs.fingerprint.outputs.skip-e2e-crdt != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'crdt' || needs.fingerprint.outputs.e2e-target-suite == 'local') }}
     runs-on: [self-hosted, linux, x64, isolated]
     timeout-minutes: 8
     env:
@@ -3320,7 +3331,8 @@ jobs:
     # Also skip via the per-job fingerprint (skip-e2e-browser =
     # docker-image+elixir-src+e2e-harness+frontend; forced false on full runs), or
     # on Dependabot PRs (Phoenix webServer needs Clerk secrets Dependabot can't access).
-    if: ${{ github.event_name != 'repository_dispatch' && needs.fingerprint.outputs.skip-e2e-browser != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'browser') }}
+    # release-please-- guard: see e2e-clerk.
+    if: ${{ github.event_name != 'repository_dispatch' && !startsWith(github.ref_name, 'release-please--') && needs.fingerprint.outputs.skip-e2e-browser != 'true' && github.actor != 'dependabot[bot]' && (needs.fingerprint.outputs.e2e-target-suite == '' || needs.fingerprint.outputs.e2e-target-suite == 'browser') }}
     runs-on: [self-hosted, linux, x64, isolated, heavy]
 
     env:

--- a/docs/context/ci-pipeline-gating.md
+++ b/docs/context/ci-pipeline-gating.md
@@ -30,6 +30,7 @@ Flaky is no longer blocking, but flaky is still **visible** and still hard-gates
 | `schedule` (06:00 UTC) | Nightly full run + flake measurement | ✅ forced |
 | `workflow_dispatch` `force_full=true` | Manual "run everything" | ✅ forced |
 | `repository_dispatch` | Backend runs e2e for a **plugin** PR, posts a `backend/e2e` status back | — |
+| `workflow_dispatch` on `release-please--**` | Release-PR validation — release-please.yml kicks it after updating its branch (NOT push-triggered: the RP action's two-step branch update raced push runs onto an intermediate SHA, leaving the Release PR head checkless/unmergeable). All e2e-* suites self-skip on this ref — main just hard-gated identical content, so only the deterministic gate runs | ❌ |
 | `release-v*` tag | `deploy-prod.yml` → release e2e gate → deploy | ✅ (force_full) |
 
 `is-full` (computed by the `fingerprint` job) forces the full suite to actually


### PR DESCRIPTION
## Problem

Every merge to main fires **three** pipelines, two nearly identical:

1. CI on `main` — the real hard gate (full e2e).
2. Release Please — updates the rolling release PR.
3. CI on `release-please--branches--main` (push-triggered) — **same content SHA as main's tip**, so e2e-clerk/e2e-crdt run twice per merge. The fingerprint can't dedupe because both start ~25s apart and markers only exist for *completed* jobs.

And a race: the RP action updates its branch in two steps (ref update → release commit). This cycle the push-triggered run bound to the intermediate SHA (`12db0971`), so the release PR #1086 head (`70346f2d`) has **no checks at all** → unmergeable. Same symptom #1057 fixed, back again via a different path. (Last cycle, 0.8.0, the race happened to go the right way.)

## Fix

- `verify.yml`: remove `release-please--**` from push triggers. `release-please.yml` now `workflow_dispatch`es verify.yml on the RP branch **after** the RP action finishes — checks always pin to the real PR head (GITHUB_TOKEN + `actions: write`, the same recursion-guard exception `deploy-prod.yml` documents).
- `e2e-clerk` / `e2e-crdt` / `e2e-browser` / `headless-protocol` self-skip on `release-please--` refs — e2e is report-only on PRs and main just hard-gated identical content; the release PR only needs the deterministic gate (`ci` normalizes skipped needs).
- Updated `docs/context/ci-pipeline-gating.md` trigger table.

## Effect

- Per main merge: 1× full run (main) + 1× cheap deterministic run (release branch) instead of 2× full-with-e2e.
- Merging this PR self-heals #1086: the main push reruns release-please → dispatch lands checks on the refreshed release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJgDzgBRa7gc4PEwxAUgoS