### PR TITLE
fix: gate crdt: channel writes on DEK rotation (T3.7, #1092)

### DIFF
--- a/lib/engram/crypto/user_dek_rotation.ex
+++ b/lib/engram/crypto/user_dek_rotation.ex
@@ -32,6 +32,7 @@ defmodule Engram.Crypto.UserDekRotation do
   import Ecto.Query, only: [from: 2]
 
   alias Engram.Accounts.User
+  alias Engram.Auth.SessionInvalidator
   alias Engram.Crypto
   alias Engram.Crypto.{DekCache, Envelope, RotationLock}
   alias Engram.Crypto.KeyProvider.Resolver
@@ -77,9 +78,9 @@ defmodule Engram.Crypto.UserDekRotation do
          {:ok, _locked_at} <- RotationLock.acquire(user_id) do
       # T3.7 (#1092): with the lock held, no new crdt: socket can join
       # (RotationGate on join). Drain the ones already open so live WS clients
-      # stop writing/encrypting mid-rotation — the socket id topic disconnects
-      # every socket for this user; they reconnect and hit the join gate.
-      _ = EngramWeb.Endpoint.broadcast("user_socket:#{user_id}", "disconnect", %{})
+      # stop writing/encrypting mid-rotation — they reconnect and hit the join
+      # gate. Same force-disconnect the entitlement/auth paths already use.
+      SessionInvalidator.disconnect_user(user_id)
 
       new_dek_version = (user.dek_version || 1) + 1
 

--- a/lib/engram/crypto/user_dek_rotation.ex
+++ b/lib/engram/crypto/user_dek_rotation.ex
@@ -75,6 +75,12 @@ defmodule Engram.Crypto.UserDekRotation do
   defp do_rotate(user_id) do
     with {:ok, user} <- load_user(user_id),
          {:ok, _locked_at} <- RotationLock.acquire(user_id) do
+      # T3.7 (#1092): with the lock held, no new crdt: socket can join
+      # (RotationGate on join). Drain the ones already open so live WS clients
+      # stop writing/encrypting mid-rotation — the socket id topic disconnects
+      # every socket for this user; they reconnect and hit the join gate.
+      _ = EngramWeb.Endpoint.broadcast("user_socket:#{user_id}", "disconnect", %{})
+
       new_dek_version = (user.dek_version || 1) + 1
 
       # B5: full try/rescue/catch so that :exit (pool exhaustion, SIGTERM) and

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -98,8 +98,10 @@ defmodule EngramWeb.CrdtChannel do
     # reconnect mid-rotation is caught even if the socket's user struct predates
     # the lock. In-flight sockets are drained separately (UserDekRotation).
     case RotationGate.check(user.id) do
-      :ok -> join_vault("crdt:" <> ids, user, user_id_str, socket)
-      {:error, _} -> {:error, %{reason: "rotation_in_progress"}}
+      {:error, :rotation_in_progress} -> {:error, %{reason: "rotation_in_progress"}}
+      # :ok, or {:error, :user_not_found} — let the vault-auth path decide
+      # (a missing user falls through to "unauthorized", not a rotation reason).
+      _ -> join_vault("crdt:" <> ids, user, user_id_str, socket)
     end
   end
 

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -14,6 +14,7 @@ defmodule EngramWeb.CrdtChannel do
   use Phoenix.Channel
 
   alias Engram.Crypto.HMAC
+  alias Engram.Crypto.RotationGate
   alias Engram.Logger.Metadata
   alias Engram.{Notes, Vaults}
   alias Engram.Notes.CrdtBridge
@@ -92,6 +93,17 @@ defmodule EngramWeb.CrdtChannel do
 
     user_id_str = to_string(user.id)
 
+    # T3.7 (#1092): the crdt: channel is the live write path — refuse to open it
+    # while a DEK rotation holds the user's lock. check/1 re-reads the row so a
+    # reconnect mid-rotation is caught even if the socket's user struct predates
+    # the lock. In-flight sockets are drained separately (UserDekRotation).
+    case RotationGate.check(user.id) do
+      :ok -> join_vault("crdt:" <> ids, user, user_id_str, socket)
+      {:error, _} -> {:error, %{reason: "rotation_in_progress"}}
+    end
+  end
+
+  defp join_vault("crdt:" <> ids, user, user_id_str, socket) do
     case String.split(ids, ":") do
       [^user_id_str, vid_str] ->
         case Ecto.UUID.cast(vid_str) do

--- a/test/engram/crypto/user_dek_rotation_test.exs
+++ b/test/engram/crypto/user_dek_rotation_test.exs
@@ -33,6 +33,30 @@ defmodule Engram.Crypto.UserDekRotationTest do
     {:ok, user: user}
   end
 
+  describe "rotate_user/1 — socket drain (#1092)" do
+    test "broadcasts a socket disconnect once the rotation lock is acquired", %{user: user} do
+      EngramWeb.Endpoint.subscribe("user_socket:#{user.id}")
+
+      assert :ok = UserDekRotation.rotate_user(user.id)
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
+    end
+
+    test "does NOT broadcast when the lock is already held", %{user: user} do
+      Repo.update_all(
+        from(u in Engram.Accounts.User, where: u.id == ^user.id),
+        [set: [dek_rotation_locked_at: DateTime.utc_now()]],
+        skip_tenant_check: true
+      )
+
+      EngramWeb.Endpoint.subscribe("user_socket:#{user.id}")
+
+      assert {:error, :rotation_in_progress} = UserDekRotation.rotate_user(user.id)
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "disconnect"}, 200
+    end
+  end
+
   describe "rotate_user/1 — lock handling" do
     test "returns {:error, :rotation_in_progress} when already locked", %{user: user} do
       Repo.update_all(

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -1164,22 +1164,60 @@ defmodule EngramWeb.CrdtChannelTest do
       user: user,
       vault: vault
     } do
+      # Build the socket from the ORIGINAL unlocked struct (its
+      # dek_rotation_locked_at is nil), THEN lock the DB row. Refusal here
+      # proves RotationGate.check/1 re-reads the row — a stale-struct check
+      # (check_user on socket.assigns) would wrongly allow this join, which is
+      # the exact long-lived-socket case #1092 is about.
+      socket = user_socket(user)
+
       Repo.update_all(
         from(u in Engram.Accounts.User, where: u.id == ^user.id),
         [set: [dek_rotation_locked_at: DateTime.utc_now()]],
         skip_tenant_check: true
       )
 
-      # Fresh struct, as a reconnecting socket would carry (connect reloads it).
-      locked = Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
-
       assert {:error, %{reason: "rotation_in_progress"}} =
                subscribe_and_join(
-                 user_socket(locked),
+                 socket,
                  EngramWeb.CrdtChannel,
                  "crdt:#{user.id}:#{vault.id}",
                  %{"crdt_proto" => 2}
                )
+    end
+
+    test "join is allowed again once the lock clears", %{user: user, vault: vault} do
+      # Lock, confirm refusal, then clear — a fresh join must succeed, proving
+      # the gate is not sticky.
+      Repo.update_all(
+        from(u in Engram.Accounts.User, where: u.id == ^user.id),
+        [set: [dek_rotation_locked_at: DateTime.utc_now()]],
+        skip_tenant_check: true
+      )
+
+      assert {:error, %{reason: "rotation_in_progress"}} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      Repo.update_all(
+        from(u in Engram.Accounts.User, where: u.id == ^user.id),
+        [set: [dek_rotation_locked_at: nil]],
+        skip_tenant_check: true
+      )
+
+      assert {:ok, _, joined} =
+               subscribe_and_join(
+                 user_socket(user),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+
+      Sandbox.allow(Repo, self(), joined.channel_pid)
     end
   end
 end

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -1154,4 +1154,32 @@ defmodule EngramWeb.CrdtChannelTest do
       assert_reply ref, :error, %{reason: "room_limit"}, 3000
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Rotation gate (T3.7, #1092) — DEK rotation must block the socket write path
+  # ---------------------------------------------------------------------------
+
+  describe "rotation gate" do
+    test "join is refused while a DEK rotation holds the user lock", %{
+      user: user,
+      vault: vault
+    } do
+      Repo.update_all(
+        from(u in Engram.Accounts.User, where: u.id == ^user.id),
+        [set: [dek_rotation_locked_at: DateTime.utc_now()]],
+        skip_tenant_check: true
+      )
+
+      # Fresh struct, as a reconnecting socket would carry (connect reloads it).
+      locked = Repo.get!(Engram.Accounts.User, user.id, skip_tenant_check: true)
+
+      assert {:error, %{reason: "rotation_in_progress"}} =
+               subscribe_and_join(
+                 user_socket(locked),
+                 EngramWeb.CrdtChannel,
+                 "crdt:#{user.id}:#{vault.id}",
+                 %{"crdt_proto" => 2}
+               )
+    end
+  end
 end


### PR DESCRIPTION
Closes #1092

## Problem

Found in #1088's review: the deleted `sync_channel` inbound ops were the only RotationGate-gated channel writes — but they had no callers. The real write path (`crdt_msg` / `crdt_create` / `crdt_delete` on the `crdt:` channel) had **no** rotation gating. During a DEK rotation a live WS client kept writing and encrypting mid-rotation — exactly what the T3.7 gates exist to prevent (the HTTP `RotationLockCheck` plug blocks even reads).

## Fix — two guards

1. **Join gate** — `join_authenticated` calls `RotationGate.check/1` (re-reads the user row, so a reconnect mid-rotation is caught even when the socket's user struct predates the lock) and refuses with `reason: "rotation_in_progress"` while the lock is held.
2. **Socket drain** — `rotate_user` broadcasts `"disconnect"` on the `user_socket:{id}` topic the instant the lock is acquired (the proven `SessionInvalidator` pattern; Phoenix's `Socket.__info__` terminates the socket). Drained clients reconnect → hit the join gate → refused until the lock releases.

Timing is safe: `DekCache.invalidate` and the lock release both happen at `final_flip` (rotation end), so during the sweep there is no live writer AND no reconnect can succeed; the first successful rejoin sees the new DEK as authoritative.

### Rejected: per-op check

A `RotationGate.check` on every `crdt_msg` frame would add a DB round-trip to the hottest edit path to close only a single in-flight frame at the drain instant. Drain-on-start is the issue's own suggested approach and is right-sized.

## Tests (TDD, RED first)

- `crdt_channel_test.exs` — join refused while the user lock is held (fresh struct, as a reconnect carries).
- `user_dek_rotation_test.exs` — `rotate_user` broadcasts the disconnect once the lock is acquired; does NOT broadcast when the lock is already held.

## Gauntlet

format · credo --strict (no issues) · dialyzer (passed) · `mix test` 3767 tests, 0 failures.