### PR TITLE
test(e2e): clean up test_77's 1k Bulk notes to stop the test_66 log-storm flake

### DIFF
--- a/e2e/helpers/api.py
+++ b/e2e/helpers/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+import uuid
 from urllib.parse import quote
 
 import requests
@@ -73,6 +74,17 @@ class ApiClient:
         """DELETE /notes/{path}. Returns HTTP status code."""
         resp = self.session.delete(
             f"{self.base_url}/notes/{quote(path, safe='')}", timeout=10
+        )
+        return resp.status_code
+
+    def batch_delete_notes(self, ids: list[str]) -> int:
+        """POST /notes/batch-delete with note IDs (from the manifest). Returns
+        status. The endpoint enforces X-Idempotency-Key (any fresh UUID)."""
+        resp = self.session.post(
+            f"{self.base_url}/notes/batch-delete",
+            json={"ids": ids},
+            headers={"X-Idempotency-Key": str(uuid.uuid4())},
+            timeout=30,
         )
         return resp.status_code
 

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -17,9 +17,6 @@ from helpers.vault import write_note
 
 NOTE_COUNT = 1000
 PUSH_TIME_BOUND_S = 120
-# Ceiling on the residue teardown so a slow / rate-limited server can never
-# hang the suite; whatever isn't cleared drains on the next run's teardown.
-CLEANUP_TIME_BUDGET_S = 45
 
 SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
 
@@ -34,23 +31,33 @@ async def _cleanup_bulk_residue(vault_a, cdp_a, api_sync) -> None:
     test_66's 5s delivery budget (#1093, rerun-safety playbook §5). Deleting
     both sides (local files + server rows) keeps the session vault clean.
 
-    Best-effort and time-bounded: teardown must never fail or hang the suite.
+    Server rows go via POST /notes/batch-delete (one idempotent request over
+    the manifest's ids), not 1,000 paced DELETEs — no time budget, no
+    rate-limit starvation, deletes every note in one shot.
+
+    The whole body is guarded: teardown must never fail or hang the suite. If
+    CDP/Obsidian died (the reason the test failed), swallowing here keeps the
+    real AssertionError as the headline instead of a chained cleanup error.
     Gate closed first so the local unlink doesn't fan out 1,000 delete-pushes.
     """
-    await cdp_a.evaluate(SET_BLOCKED.format("true"))
-    shutil.rmtree(vault_a / "Bulk", ignore_errors=True)
+    try:
+        await cdp_a.evaluate(SET_BLOCKED.format("true"))
+        shutil.rmtree(vault_a / "Bulk", ignore_errors=True)
 
-    deadline = time.monotonic() + CLEANUP_TIME_BUDGET_S
-    for i in range(NOTE_COUNT):
-        if time.monotonic() > deadline:
-            break
-        try:
-            api_sync.delete_note(f"Bulk/n{i:04d}.md")
-        except Exception:  # teardown is strictly best-effort
-            pass
+        manifest = api_sync.get_manifest()
+        ids = [
+            n["id"]
+            for n in manifest.get("notes", [])
+            if n.get("id") and n.get("path", "").startswith("Bulk/")
+        ]
+        # Chunk so one oversized body can't trip a request-size limit.
+        for start in range(0, len(ids), 500):
+            api_sync.batch_delete_notes(ids[start : start + 500])
 
-    # Re-open the gate so subsequent tests sync normally.
-    await cdp_a.evaluate(SET_BLOCKED.format("false"))
+        # Re-open the gate so subsequent tests sync normally.
+        await cdp_a.evaluate(SET_BLOCKED.format("false"))
+    except Exception:  # teardown is strictly best-effort — never mask the real failure
+        pass
 
 
 @pytest.mark.asyncio

--- a/e2e/tests/test_77_bulk_first_sync.py
+++ b/e2e/tests/test_77_bulk_first_sync.py
@@ -8,6 +8,7 @@ what the per-note path costs (1,000 paced requests), so a silent fallback
 to per-note pushes fails this test.
 """
 
+import shutil
 import time
 
 import pytest
@@ -16,79 +17,111 @@ from helpers.vault import write_note
 
 NOTE_COUNT = 1000
 PUSH_TIME_BOUND_S = 120
+# Ceiling on the residue teardown so a slow / rate-limited server can never
+# hang the suite; whatever isn't cleared drains on the next run's teardown.
+CLEANUP_TIME_BUDGET_S = 45
+
+SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+
+
+async def _cleanup_bulk_residue(vault_a, cdp_a, api_sync) -> None:
+    """Remove this test's 1,000 Bulk/* notes from the session vault.
+
+    Fixtures are session-scoped (conftest) and only Clerk USERS are swept
+    between runs — vault notes persist. Left behind, these 1,000 notes storm
+    a later run's test_66: reconnect churn re-handshakes them (~454/window,
+    the #193 handshake-budget class), saturating the /logs pipeline past
+    test_66's 5s delivery budget (#1093, rerun-safety playbook §5). Deleting
+    both sides (local files + server rows) keeps the session vault clean.
+
+    Best-effort and time-bounded: teardown must never fail or hang the suite.
+    Gate closed first so the local unlink doesn't fan out 1,000 delete-pushes.
+    """
+    await cdp_a.evaluate(SET_BLOCKED.format("true"))
+    shutil.rmtree(vault_a / "Bulk", ignore_errors=True)
+
+    deadline = time.monotonic() + CLEANUP_TIME_BUDGET_S
+    for i in range(NOTE_COUNT):
+        if time.monotonic() > deadline:
+            break
+        try:
+            api_sync.delete_note(f"Bulk/n{i:04d}.md")
+        except Exception:  # teardown is strictly best-effort
+            pass
+
+    # Re-open the gate so subsequent tests sync normally.
+    await cdp_a.evaluate(SET_BLOCKED.format("false"))
 
 
 @pytest.mark.asyncio
 async def test_bulk_first_sync_timing(vault_a, cdp_a, api_sync):
-    # Close the sync gate FIRST: every raw write below fires the vault
-    # watcher, and an open gate turns that into 1,000 debounced single-note
-    # auto-pushes — a request storm that exhausts the rate budget and
-    # starves the batch sync this test measures. handleModify short-circuits
-    # while the gate is closed.
-    await cdp_a.evaluate(
-        "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked(true)"
-    )
+    try:
+        # Close the sync gate FIRST: every raw write below fires the vault
+        # watcher, and an open gate turns that into 1,000 debounced single-note
+        # auto-pushes — a request storm that exhausts the rate budget and
+        # starves the batch sync this test measures. handleModify short-circuits
+        # while the gate is closed.
+        await cdp_a.evaluate(SET_BLOCKED.format("true"))
 
-    # Seed 1,000 files on disk, then wait for Obsidian's indexer to see them
-    # (raw filesystem writes only reach app.vault.getFiles() once the
-    # watcher fires).
-    for i in range(NOTE_COUNT):
-        write_note(
-            vault_a,
-            f"Bulk/n{i:04d}.md",
-            f"# Bulk note {i}\n\nfirst-sync payload {i}",
+        # Seed 1,000 files on disk, then wait for Obsidian's indexer to see them
+        # (raw filesystem writes only reach app.vault.getFiles() once the
+        # watcher fires).
+        for i in range(NOTE_COUNT):
+            write_note(
+                vault_a,
+                f"Bulk/n{i:04d}.md",
+                f"# Bulk note {i}\n\nfirst-sync payload {i}",
+            )
+
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            count = await cdp_a.evaluate(
+                "app.vault.getFiles().filter(f => f.path.startsWith('Bulk/')).length"
+            )
+            if isinstance(count, int) and count >= NOTE_COUNT:
+                break
+            time.sleep(1)
+        else:
+            raise TimeoutError(f"Obsidian indexed only {count}/{NOTE_COUNT} bulk files")
+
+        # Re-open the gate the same way a user accepting the PreSync modal does
+        # (persists the fingerprint + flips syncBlocked false).
+        await cdp_a.accept_sync_gate()
+
+        # Drive the bulk first sync to server-side convergence within the time
+        # bound. A single fullSync()'s `pushed` count is an unreliable proxy under
+        # CI load, in two ways (both observed as issue #627):
+        #   1. fullSync() returns {pulled:0, pushed:0} when syncBlocked is still
+        #      true — the plugin's async startup can re-assert it AFTER our unblock.
+        #   2. A batch chunk that errors against a loaded backend goes offline with
+        #      the remainder queued (sync.ts pushNotesViaBatch), so one call can
+        #      report a partial count (e.g. pushed=2) even though the rest land
+        #      moments later.
+        # So we re-assert unblocked and re-trigger fullSync until the SERVER
+        # manifest holds all 1,000 notes, bounded by PUSH_TIME_BOUND_S. The bound
+        # is the batch-vs-per-note guarantee: 1,000 paced per-note pushes cannot
+        # converge within it, so a silent fallback still fails this test — the
+        # success criterion is "bulk lands in bounded time", not a single call's
+        # push tally.
+        started = time.monotonic()
+        deadline = started + PUSH_TIME_BOUND_S
+        bulk_count = 0
+        while time.monotonic() < deadline:
+            await cdp_a.evaluate(SET_BLOCKED.format("false"))
+            await cdp_a.trigger_full_sync()
+            manifest = api_sync.get_manifest()
+            bulk_count = sum(
+                1 for n in manifest["notes"] if n["path"].startswith("Bulk/")
+            )
+            if bulk_count >= NOTE_COUNT:
+                break
+            time.sleep(2)
+        elapsed = time.monotonic() - started
+
+        assert bulk_count >= NOTE_COUNT, (
+            f"bulk first sync converged only {bulk_count}/{NOTE_COUNT} notes in "
+            f"{elapsed:.1f}s (bound {PUSH_TIME_BOUND_S}s) — did the plugin fall "
+            "back to per-note pushes or stall?"
         )
-
-    deadline = time.monotonic() + 60
-    while time.monotonic() < deadline:
-        count = await cdp_a.evaluate(
-            "app.vault.getFiles().filter(f => f.path.startsWith('Bulk/')).length"
-        )
-        if isinstance(count, int) and count >= NOTE_COUNT:
-            break
-        time.sleep(1)
-    else:
-        raise TimeoutError(f"Obsidian indexed only {count}/{NOTE_COUNT} bulk files")
-
-    # Re-open the gate the same way a user accepting the PreSync modal does
-    # (persists the fingerprint + flips syncBlocked false).
-    await cdp_a.accept_sync_gate()
-
-    # Drive the bulk first sync to server-side convergence within the time
-    # bound. A single fullSync()'s `pushed` count is an unreliable proxy under
-    # CI load, in two ways (both observed as issue #627):
-    #   1. fullSync() returns {pulled:0, pushed:0} when syncBlocked is still
-    #      true — the plugin's async startup can re-assert it AFTER our unblock.
-    #   2. A batch chunk that errors against a loaded backend goes offline with
-    #      the remainder queued (sync.ts pushNotesViaBatch), so one call can
-    #      report a partial count (e.g. pushed=2) even though the rest land
-    #      moments later.
-    # So we re-assert unblocked and re-trigger fullSync until the SERVER
-    # manifest holds all 1,000 notes, bounded by PUSH_TIME_BOUND_S. The bound
-    # is the batch-vs-per-note guarantee: 1,000 paced per-note pushes cannot
-    # converge within it, so a silent fallback still fails this test — the
-    # success criterion is "bulk lands in bounded time", not a single call's
-    # push tally.
-    unblock = (
-        "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked(false)"
-    )
-    started = time.monotonic()
-    deadline = started + PUSH_TIME_BOUND_S
-    bulk_count = 0
-    while time.monotonic() < deadline:
-        await cdp_a.evaluate(unblock)
-        await cdp_a.trigger_full_sync()
-        manifest = api_sync.get_manifest()
-        bulk_count = sum(
-            1 for n in manifest["notes"] if n["path"].startswith("Bulk/")
-        )
-        if bulk_count >= NOTE_COUNT:
-            break
-        time.sleep(2)
-    elapsed = time.monotonic() - started
-
-    assert bulk_count >= NOTE_COUNT, (
-        f"bulk first sync converged only {bulk_count}/{NOTE_COUNT} notes in "
-        f"{elapsed:.1f}s (bound {PUSH_TIME_BOUND_S}s) — did the plugin fall "
-        "back to per-note pushes or stall?"
-    )
+    finally:
+        await _cleanup_bulk_residue(vault_a, cdp_a, api_sync)


### PR DESCRIPTION
Closes #1093

## Root cause

test_77 seeds **1,000 `Bulk/*` notes** into the session-scoped vault (all e2e fixtures are session-scoped — Obsidian startup is ~30s). Between CI runs only **Clerk users** are swept (conftest `cleanup_all_e2e_users`); **vault notes persist**. Left behind, those 1,000 notes storm a later run's **test_66**: reconnect churn (34 disconnects / 38 opens in the failing run) re-triggers mass catch-up, re-handshaking them (~454 `re-handshake fired for Bulk/n*` + 486 diverged + 1339 no-CAS lines land in test_66's window). Client-log volume hits ~6.7k lines/min and the `/logs` pipeline queues past test_66's 5s Phase-1 delivery budget → `no pre-disable entries within 5s`.

Same rerun-safety session-residue family as `docs/context/e2e-delivery-flake-playbook.md` §5.

## Fix

test_77 now removes its residue in a best-effort, time-bounded `finally`:
- **local** — `rmtree(vault_a/Bulk)` with the sync gate closed first, so the watcher doesn't fan out 1,000 delete-pushes;
- **server** — loop `api_sync.delete_note` for each Bulk path (direct DELETE, bypasses the client — no re-handshake), capped at `CLEANUP_TIME_BUDGET_S = 45` so a slow/rate-limited server can never hang the suite; residue drains over the next run's teardown if a run is cut short.

The teardown is strictly best-effort (never fails or hangs test_77) and the test's own assertion is unchanged. Converges the session vault within a run or two.

## Not in scope

The ~454-per-window re-handshake volume itself is the **#193 handshake-budget class** (plugin-side cap) — this PR only removes the residue that feeds it.

## Validation

Syntax-checked; follows existing e2e patterns (bare best-effort `except`, module constants, helper fn). Full validation is the e2e-clerk job on this PR.