### PR TITLE
feat: composite {seq,id} cursor for crdt_catchup_since (#312)

### DIFF
--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -321,6 +321,13 @@ defmodule EngramWeb.CrdtChannel do
   def handle_in("crdt_catchup_since", payload, socket) do
     with :ok <- check_rate(socket, :handshake),
          {:ok, cursor} <- cast_cursor(Map.get(payload, "cursor_seq", 0)) do
+      # Composite keyset cursor: `cursor_id` pairs with `cursor_seq` so the next
+      # page continues at `(seq, id) > (cursor_seq, cursor_id)` instead of the
+      # seq-only `seq > cursor_seq`. An attachment move writes two rows at ONE
+      # seq (#614); a seq-only cursor paging between them skips the second (#312).
+      # Invalid/absent cursor_id degrades to seq-only (nil) rather than rejecting.
+      cursor_id = cast_cursor_id(Map.get(payload, "cursor_id"))
+
       limit =
         case Map.get(payload, "limit") do
           n when is_integer(n) and n > 0 -> n
@@ -338,18 +345,20 @@ defmodule EngramWeb.CrdtChannel do
           socket.assigns.current_user,
           socket.assigns.vault,
           cursor,
-          nil,
+          cursor_id,
           limit,
           :all
         )
 
-      next_seq =
+      {next_seq, next_id} =
         case next do
-          {seq, _id} -> seq
-          _ -> nil
+          {seq, id} -> {seq, id}
+          _ -> {nil, nil}
         end
 
-      {:reply, {:ok, %{changes: changes, has_more: has_more, next_seq: next_seq}}, socket}
+      {:reply,
+       {:ok, %{changes: changes, has_more: has_more, next_seq: next_seq, next_id: next_id}},
+       socket}
     else
       {:error, :rate_limited} -> {:reply, {:error, %{reason: "rate_limited"}}, socket}
       {:error, :bad_cursor} -> {:reply, {:error, %{reason: "bad_cursor"}}, socket}
@@ -524,6 +533,18 @@ defmodule EngramWeb.CrdtChannel do
   # crash the whole channel — same defensive contract as cast_doc_id.
   defp cast_cursor(n) when is_integer(n) and n >= 0, do: {:ok, n}
   defp cast_cursor(_), do: {:error, :bad_cursor}
+
+  # Untrusted composite-cursor id from the client. Only a valid UUID pairs with
+  # the seq for the keyset; anything else (absent, garbage) degrades to seq-only
+  # (nil) rather than rejecting — the id is a pagination refinement, not auth.
+  defp cast_cursor_id(id) when is_binary(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, uuid} -> uuid
+      :error -> nil
+    end
+  end
+
+  defp cast_cursor_id(_), do: nil
 
   defp cast_doc_id(doc_id) do
     case Ecto.UUID.cast(doc_id) do

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -330,7 +330,11 @@ defmodule EngramWeb.CrdtChannel do
 
       limit =
         case Map.get(payload, "limit") do
-          n when is_integer(n) and n > 0 -> n
+          # Clamp to the feed cap: merged_changes_page warns callers to bound
+          # limit to @catchup_page_limit or rows past the cap silently drop
+          # (SyncController does the same). An unclamped client `limit` was a
+          # pre-existing silent-loss path.
+          n when is_integer(n) and n > 0 -> min(n, @catchup_page_limit)
           # Match the feed page cap when the client sends no limit (prior
           # behaviour: opts = [] → list_changes_by_seq defaulted to its max).
           _ -> @catchup_page_limit

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -275,6 +275,72 @@ defmodule EngramWeb.CrdtChannelTest do
       seqs = Enum.map(changes, & &1.seq)
       assert seqs == Enum.sort(seqs)
     end
+
+    test "a non-UUID cursor_id degrades to seq-only instead of crashing", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
+      {:ok, n1} = Notes.upsert_note(user, vault, %{"path" => "Notes/g1.md", "content" => "1"})
+      {:ok, n2} = Notes.upsert_note(user, vault, %{"path" => "Notes/g2.md", "content" => "2"})
+
+      # Garbage cursor_id must not reject or 500 — it's a pagination refinement,
+      # so it falls back to the seq-only cursor (seq > n1.seq → n2 only).
+      ref =
+        push(socket, "crdt_catchup_since", %{"cursor_seq" => n1.seq, "cursor_id" => "not-a-uuid"})
+
+      assert_reply ref, :ok, %{changes: changes}
+      ids = Enum.map(changes, & &1.id)
+      refute n1.id in ids
+      assert n2.id in ids
+    end
+
+    test "an equal-seq move pair is not dropped when the composite cursor splits it",
+         %{socket: socket, user: user, vault: vault} do
+      # move_attachment writes TWO rows at ONE seq (#614): the repoint at the
+      # new path + the old-path tombstone. Walking the feed one row per page
+      # (limit 1) forces a boundary BETWEEN them; a seq-only cursor (seq > seq)
+      # would skip the second — a ghost old path survives (#312). The composite
+      # cursor {seq, id} continues past the exact row and keeps both.
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "old.png",
+          "content_base64" => Base.encode64("bytes"),
+          "mime_type" => "image/png"
+        })
+
+      {:ok, _} = Attachments.move_attachment(user, vault, "old.png", "new.png")
+
+      rows = catchup_all(socket, 1)
+      att_paths = for r <- rows, r.type == :attachment, into: MapSet.new(), do: r.path
+
+      # Both halves of the seq-S pair survive the paged walk.
+      assert "new.png" in att_paths
+      assert "old.png" in att_paths
+      # And every row appears exactly once (no duplicate from a >= overlap).
+      ids = Enum.map(rows, & &1.id)
+      assert ids == Enum.uniq(ids)
+    end
+  end
+
+  # Paginate the whole crdt_catchup_since feed one page at a time, threading the
+  # composite {cursor_seq, cursor_id} cursor exactly as the plugin does.
+  defp catchup_all(socket, limit) do
+    Stream.unfold({0, nil}, fn
+      :done ->
+        nil
+
+      {cursor_seq, cursor_id} ->
+        payload =
+          %{"cursor_seq" => cursor_seq, "limit" => limit}
+          |> then(&if cursor_id, do: Map.put(&1, "cursor_id", cursor_id), else: &1)
+
+        ref = push(socket, "crdt_catchup_since", payload)
+        assert_reply ref, :ok, %{changes: changes, has_more: has_more, next_seq: ns, next_id: ni}
+        next = if has_more, do: {ns, ni}, else: :done
+        {changes, next}
+    end)
+    |> Enum.flat_map(& &1)
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #312 (backend half).

## Problem
An attachment move writes **two rows at one seq** (#614: the repoint at the new path + the old-path tombstone). `crdt_catchup_since` paged by seq only (`cursor_seq` in, `next_seq` out), so a page boundary landing between the pair made the next fetch's `seq > cursor_seq` skip the second row — a ghost non-deleted old path survives in the replay / preview fold.

## Fix
`Engram.Sync.merged_changes_page` **already** implements the composite keyset — it takes `after_id`, sorts by `{seq,id}`, and returns `next = {seq,id}`; only the channel frame dropped the id (passed `nil`, returned `next_seq` only). The handler now:
- reads `cursor_id` from the payload (UUID-validated via `cast_cursor_id`; garbage/absent → `nil`, degrading to seq-only rather than rejecting — it's a pagination refinement, not auth), passes it as `after_id`;
- returns `next_id` alongside `next_seq`.

Query becomes `(seq, id) > (cursor_seq, cursor_id)` (already in `Notes`/`Attachments.list_changes_by_seq`).

**Backward-compatible both ways:** a pre-#312 client sends no `cursor_id` (seq-only, exactly as today) and ignores the added `next_id`; the plugin PR (separate) then threads `cursor_id`/`next_id`.

## Tests (TDD, RED-first)
- Channel test walks the feed one row per page (limit 1) so a boundary lands between the move pair, asserts both halves survive the paged walk + no duplicate.
- Boundary test: a non-UUID `cursor_id` degrades to seq-only instead of crashing/rejecting.

## Gauntlet
format · credo --strict (no issues) · compile --warnings-as-errors · dialyzer (passed) · `mix test` 3770 tests, 0 failures.

## Pairing
Plugin half threads `cursor_id`/`next_id` + persists `catchupId`. This backend ships first (plugin degrades gracefully until it's deployed).