### PR TITLE
fix(frontend): self-healing frontend-promote + shared build config

### DIFF
--- a/.github/workflows/frontend-promote.yml
+++ b/.github/workflows/frontend-promote.yml
@@ -4,8 +4,21 @@
 name: Frontend Promote
 
 on:
+  # Fired by engram-infra's prod `terraform (prod)` apply AFTER the backend ECS
+  # rollout proves healthy — preserves backend-before-frontend ordering.
   repository_dispatch:
     types: [frontend-promote]
+  # Manual recovery / re-promote. Use when a dispatched promote failed, or to
+  # promote a specific release commit whose worker aged out of Cloudflare's
+  # retained versions (the self-heal fallback below rebuilds it).
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Full 40-char release commit SHA to promote"
+        required: true
+      release_tag:
+        description: "release-v* tag (for the Discord announce; optional)"
+        required: false
 
 permissions:
   contents: read
@@ -14,46 +27,85 @@ concurrency:
   group: frontend-promote-prod
   cancel-in-progress: false
 
+env:
+  # Resolve the target from whichever event fired.
+  SHA: ${{ github.event.client_payload.sha || github.event.inputs.sha }}
+  RELEASE_TAG: ${{ github.event.client_payload.release_tag || github.event.inputs.release_tag }}
+  NOTES: ${{ github.event.client_payload.notes }}
+
 jobs:
   promote:
     runs-on: [self-hosted, linux, x64, isolated]
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.client_payload.sha }}
-      # bun is not global on the isolated runners (sibling deploy-frontend sets
-      # it up too); promote only shells out to `bunx wrangler`, so no bun install.
+          ref: ${{ env.SHA }}
       - uses: oven-sh/setup-bun@v2
         with: { bun-version: 1.3.11 }
-      - name: Resolve version for this commit
+
+      - name: Resolve uploaded version for this commit (fast path)
         id: v
         working-directory: frontend
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          SHA: ${{ github.event.client_payload.sha }}
         run: |
           set -euo pipefail
           SHORT=${SHA::7}
-          # Find the version uploaded by Task 1 for this commit (tag = sha-<7>).
+          # A sibling deploy-frontend (verify.yml) uploads a zero-traffic
+          # version tagged sha-<7> on every green main push. Normally it's
+          # still in Cloudflare's retained versions and we just promote it.
           VID=$(bunx wrangler versions list --json | jq -r \
             --arg t "sha-$SHORT" '[.[] | select(.annotations["workers/tag"]==$t)][0].id')
           if [ -z "$VID" ] || [ "$VID" = "null" ]; then
-            echo "::error::No uploaded frontend version for sha-$SHORT — did nightly upload run?"; exit 1
+            # Aged out (deploy lagged the upload — e.g. a delayed release) or
+            # never uploaded. The fallback rebuilds this exact commit + uploads.
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No retained frontend version for sha-$SHORT — rebuilding from the release commit."
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "vid=$VID" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rebuild + upload this commit's frontend (self-heal fallback)
+        id: rebuild
+        if: steps.v.outputs.found == 'false'
+        working-directory: frontend
+        env:
+          # Byte-identical to deploy-frontend: non-secret VITE_* come from the
+          # committed frontend/.env.production; only these two are injected.
+          VITE_CLERK_PUBLISHABLE_KEY: ${{ vars.VITE_CLERK_PUBLISHABLE_KEY_PROD }}
+          VITE_GIT_SHA: ${{ env.SHA }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          SHORT=${SHA::7}
+          bun install --frozen-lockfile
+          bun run build:saas
+          bunx wrangler versions upload --tag "sha-$SHORT"
+          # Re-resolve the id from the API rather than scraping upload stdout.
+          VID=$(bunx wrangler versions list --json | jq -r \
+            --arg t "sha-$SHORT" '[.[] | select(.annotations["workers/tag"]==$t)][0].id')
+          if [ -z "$VID" ] || [ "$VID" = "null" ]; then
+            echo "::error::Rebuilt + uploaded sha-$SHORT but could not resolve its version id."; exit 1
           fi
           echo "vid=$VID" >> "$GITHUB_OUTPUT"
+
       - name: Promote to 100% production
         working-directory: frontend
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bunx wrangler versions deploy "${{ steps.v.outputs.vid }}@100%" --yes
+          # Whichever path produced the id (fast path or self-heal fallback).
+          VID: ${{ steps.v.outputs.vid || steps.rebuild.outputs.vid }}
+        run: bunx wrangler versions deploy "${VID}@100%" --yes
+
       - name: Announce release complete (#releases)
         if: env.WEBHOOK != ''
         env:
           WEBHOOK: ${{ secrets.DISCORD_RELEASES_WEBHOOK_URL }}
-          TAG: ${{ github.event.client_payload.release_tag }}
-          NOTES: ${{ github.event.client_payload.notes }}
+          TAG: ${{ env.RELEASE_TAG }}
         run: |
           RELEASE_URL="https://github.com/engram-app/Engram/releases/tag/$TAG"
           # Discord's content cap is 2000 chars. NOTES is the full release
@@ -68,11 +120,12 @@ jobs:
           code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' --max-time 5 \
             --data "$(jq -nc --arg c "$CONTENT" '{content:$c}')" "$WEBHOOK")
           case "$code" in 2*) echo "Discord announced ($code)";; *) echo "::warning::Discord announce failed (HTTP $code)";; esac
+
       - name: Announce promote failure (#releases)
         if: failure() && env.WEBHOOK != ''
         env:
           WEBHOOK: ${{ secrets.DISCORD_RELEASES_WEBHOOK_URL }}
-          TAG: ${{ github.event.client_payload.release_tag }}
+          TAG: ${{ env.RELEASE_TAG }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           CONTENT=$(printf ':warning: frontend promote FAILED for `%s` — see %s' "$TAG" "$RUN_URL")

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4600,15 +4600,12 @@ jobs:
         working-directory: frontend
         run: bun run build:saas
         env:
-          VITE_AUTH_PROVIDER: clerk
-          VITE_BILLING_ENABLED: 'true'
-          VITE_CLERK_WAITLIST_MODE: 'false'
-          VITE_API_BASE: https://api.engram.page
-          VITE_WS_BASE: wss://api.engram.page
-          # VITE_INLINE_BOOTSTRAP_CONFIG=1 (inline config + Clerk preconnect +
-          # modulepreload) is set by the build:saas script itself so local saas
-          # builds produce the same artifact as CI. The plugin hard-fails the
-          # build if the VITE_* config above is missing.
+          # Non-secret VITE_* prod config (auth provider, api/ws base, billing,
+          # waitlist, tracing) lives in frontend/.env.production — the single
+          # source of truth loaded by vite's production mode, shared with the
+          # frontend-promote self-heal fallback so both builds are byte-identical.
+          # VITE_INLINE_BOOTSTRAP_CONFIG=1 is set by build:saas itself.
+          # Only the two dynamic/managed values are injected here:
           # PROD publishable key (pk_live_…). Distinct from the repo SECRET
           # `VITE_CLERK_PUBLISHABLE_KEY`, which is the pk_test the e2e CI uses
           # — baking that here would point the live app at the dev Clerk
@@ -4616,11 +4613,6 @@ jobs:
           # by design (ships in the browser), so a variable not a secret.
           VITE_CLERK_PUBLISHABLE_KEY: ${{ vars.VITE_CLERK_PUBLISHABLE_KEY_PROD }}
           VITE_GIT_SHA: ${{ github.sha }}
-          # Light up browser->Tempo traces (traceparent header on authFetch +
-          # client span beacons via POST /api/telemetry/spans). Dark-launched
-          # until 2026-07-14: the deaf-note incident needed a CDP sniffer
-          # because the browser emitted no telemetry at all.
-          VITE_TRACING_ENABLED: 'true'
 
       - name: Upload frontend version (nightly, zero-traffic)
         working-directory: frontend

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,20 @@
+# SaaS production build config — single source of truth.
+#
+# Loaded automatically by `vite build` (production mode) i.e. `bun run build:saas`.
+# `build:selfhost` runs with `--mode selfhost` so it does NOT inherit this file
+# (self-host resolves its API base from runtime /config.json, not baked env).
+#
+# Both the main-push upload (verify.yml `deploy-frontend`) and the
+# frontend-promote self-heal fallback build run `bun run build:saas`, so this
+# file guarantees they produce a byte-identical artifact. Do not re-add these
+# values to the workflow `env:` blocks — real env vars override this file, and
+# a drifted value would mean the promoted frontend differs from the warm one.
+#
+# Injected by CI (NOT committed here): VITE_CLERK_PUBLISHABLE_KEY (pk_live repo
+# VARIABLE from SOPS clerk_pk_live) and VITE_GIT_SHA (the deploy commit).
+VITE_AUTH_PROVIDER=clerk
+VITE_BILLING_ENABLED=true
+VITE_CLERK_WAITLIST_MODE=false
+VITE_API_BASE=https://api.engram.page
+VITE_WS_BASE=wss://api.engram.page
+VITE_TRACING_ENABLED=true

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,6 +1,9 @@
 node_modules
 dist
 .env.local
+# Committed: SaaS prod build config (single source of truth). Root .gitignore
+# ignores .env* broadly; re-include this one.
+!.env.production
 playwright-report
 test-results
 e2e/.auth-state.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,9 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "bun run build:selfhost",
-		"build:selfhost": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build",
-		"build:saas": "bun scripts/check-legal-manifest.ts && tsc --noEmit && VITE_INLINE_BOOTSTRAP_CONFIG=1 vite build --outDir dist --emptyOutDir && bun scripts/write-config-json.ts dist/config.json",
+		"build:selfhost": "bun scripts/check-legal-manifest.ts && tsc --noEmit && vite build --mode selfhost",
+		"build:saas": "bun --env-file=.env.production run build:saas:inner",
+		"build:saas:inner": "bun scripts/check-legal-manifest.ts && tsc --noEmit && VITE_INLINE_BOOTSTRAP_CONFIG=1 vite build --outDir dist --emptyOutDir && bun scripts/write-config-json.ts dist/config.json",
 		"preview": "vite preview",
 		"test": "vitest run",
 		"test:watch": "vitest",


### PR DESCRIPTION
## Problem

`frontend-promote` resolves a release's Cloudflare Worker version by `sha-<7>` from `wrangler versions list`, then shifts 100% traffic. When deploy lags the main-push upload, that version ages out of CF's retained versions and the promote fails: `No uploaded frontend version for sha-<7>`. The 2-day stuck deploy valve that froze prod at 0.5.685 exposed this — by the time 0.8.0 (`f6d279b`) actually deployed, its worker was long gone. **frontend-promote has in fact never once succeeded.**

## Fix

- **Self-healing promote** — fast path resolves the pre-uploaded version; if it's gone, it rebuilds the *exact* release commit (already checked out) and uploads a fresh `sha-<7>`, then promotes 100%. Robust to any deploy lag.
- **`workflow_dispatch` trigger** (`sha` + `release_tag`) for manual re-promote / recovery.
- **Shared build config** — non-secret `VITE_*` prod values move to committed `frontend/.env.production`, loaded via `bun --env-file` so the Node-side `inline-bootstrap` plugin + `write-config-json.ts` see them too. `deploy-frontend` and the promote fallback both run `bun run build:saas`, so the artifacts are byte-identical (guards against "promoted frontend differs from the warm one"). Only `pk_live` + `VITE_GIT_SHA` stay CI-injected.
- **`build:selfhost --mode selfhost`** so self-host never inherits the SaaS `.env.production` (keeps `api.engram.page` out of self-host bundles). SaaS stays on `production` mode, so the Sentry `environment` tag is unchanged.

## Verification (local)

- `build:saas` with only pk+sha injected → correct `config.json` (config from `.env.production`, injected pk wins); client bundle bakes the values.
- `build:selfhost --mode selfhost` → clean build, **zero** `api.engram.page` occurrences with/without the env file (no SaaS leak).
- Both workflows valid YAML; biome clean.

## Acceptance test (post-merge)

`workflow_dispatch` uses the default-branch workflow def, so after merge:
`gh workflow run frontend-promote.yml -f sha=<0.8.0 sha> -f release_tag=release-v0.8.0` → misses fast path → rebuilds 0.8.0's frontend → uploads `sha-f6d279b` → promotes 100% → first green promote, and finally promotes the 0.8.0 frontend.

## Out of scope

The deploy-valve deadlock (infra bot PR goes BEHIND → auto-merge never fires → prod freezes) is a separate initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)