### PR TITLE
test(e2e): fix test_cold_send room-free precondition race

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -1086,6 +1086,27 @@ class CdpClient:
             f"CRDT doc {note_id} still resident after {timeout}s on CDP port {self.port}"
         )
 
+    async def wait_for_room_free(self, note_id: str, timeout: float = 30) -> None:
+        """Poll until note_id is absent from CrdtEnrollment.enrolled.
+
+        A checkpoint-driven catch-up can open a TRANSIENT heal room for an idle
+        cold note (the diverged-cold-note re-handshake, sync.ts:5578, which is
+        NOT isLiveBound-gated by design). The plugin releases it asynchronously
+        once convergence commits (commitCrdtConvergence -> releaseHealRoom). A
+        single immediate get_enrolled_note_ids() sample right after
+        trigger_full_sync races that release; poll for it instead. A genuinely
+        stuck room still fails via timeout, so the invariant stays enforced.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if note_id not in await self.get_enrolled_note_ids():
+                return
+            await asyncio.sleep(0.2)
+        raise TimeoutError(
+            f"CRDT heal room for {note_id} not released after {timeout}s "
+            f"on CDP port {self.port}"
+        )
+
     async def rename_file(self, old_path: str, new_path: str) -> None:
         """Rename a file through Obsidian's vault API (triggers handleRename)."""
         escaped_old = json.dumps(old_path)

--- a/e2e/tests/crdt/test_crdt_sync.py
+++ b/e2e/tests/crdt/test_crdt_sync.py
@@ -167,18 +167,26 @@ async def _confirm_room_free(cdp, path):
     crdt_msg room stream). Returns the note_id.
 
     trigger_full_sync() drives the idle pull-discovery path, which maps +
-    confirms the note but does NOT STEP1-enroll a not-live-bound note
-    (sync.ts:3790/3820 guards) — so the note stays room-free.
+    confirms the note but does NOT STEP1-enroll a not-live-bound note via the
+    discovery path (sync.ts isLiveBound guard). A checkpoint-driven catch-up
+    CAN, however, open a TRANSIENT heal room via the diverged-cold-note
+    re-handshake (sync.ts:5578, deliberately un-gated); the plugin releases it
+    asynchronously once convergence commits (releaseHealRoom). So wait for that
+    release rather than sampling the enrolled set the instant the sync returns —
+    a single immediate snapshot races the async release (the source of this
+    test's flakiness). A genuinely stuck room still fails via timeout.
     """
     await cdp.wait_for_stream_connected()
     await cdp.trigger_full_sync()
     note_id = await cdp.get_note_id_for_path(path)
     assert note_id, f"device never mapped a note_id for {path} — cannot prove fan-out"
-    enrolled = await cdp.get_enrolled_note_ids()
-    assert note_id not in enrolled, (
-        f"precondition violated: device holds a CRDT room for idle note {path} "
-        f"(note_id={note_id}); convergence could ride crdt_msg, not the fan-out"
-    )
+    try:
+        await cdp.wait_for_room_free(note_id, timeout=CRDT_TIMEOUT)
+    except TimeoutError as e:
+        pytest.fail(
+            f"precondition violated: device holds a CRDT room for idle note {path} "
+            f"(note_id={note_id}); convergence could ride crdt_msg, not the fan-out — {e}"
+        )
     return note_id
 
 


### PR DESCRIPTION
## The flake

`test_cold_send_over_fanout_opens_no_room` (and the 3 sibling fan-out tests) intermittently failed with `precondition violated: device holds a CRDT room for idle note`. Root-caused from a failing run's client logs.

`_confirm_room_free` sampled `CrdtEnrollment.enrolled` **once, immediately** after `trigger_full_sync` and asserted the idle cold note held no room. But a checkpoint-driven catch-up legitimately opens a **transient** heal room via the diverged-cold-note re-handshake (`sync.ts:5578`, deliberately un-`isLiveBound`-gated), which the plugin releases **asynchronously** once convergence commits (`releaseHealRoom` — whose docstring names *this exact test* as its canary). The single immediate sample raced that release: slow runs sampled inside the enroll→release window and failed; fast runs passed.

**Not a plugin bug** — the plugin behaves as designed (transient room + async release); adding an `isLiveBound` guard to `sync.ts:5578` would break gap-heal for genuinely-diverged idle notes. Confirmed inert-vs-source: the failing run's logs show identical behavior to main.

## The fix

Poll for the release instead of sampling once — new `cdp.wait_for_room_free` (mirrors the existing `wait_for_crdt_doc_freed`). A genuinely-stuck room still fails via timeout, so the fan-out-isolation invariant is preserved. One shared-helper change fixes all 6 `_confirm_room_free` call sites (same race).

## Watch-item (not fixed here)

If the diverged branch stages content but no matching inbound frame ever arrives (already-converged doc → empty STEP2), `commitCrdtConvergence` defers indefinitely and the room is never released → the new wait would time out (a real plugin gap, not a flake). If CI shows the wait timing out rather than passing, that deferred-commit path is the next thing to harden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)