### PR TITLE
feat(crdt): canvas onto CRDT — backend skips markdown seed/projection for .canvas (#306 Phase B)

### DIFF
--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -133,25 +133,10 @@ defmodule Engram.Notes.CrdtCheckpoint do
               raw_note ->
                 {:ok, note} = Crypto.maybe_decrypt_note_fields(raw_note, user)
 
-                with {:ok, union_doc} <- union_with_row_state(note, live_state, user),
-                     text = CrdtBridge.text_of(union_doc),
-                     {:ok, raw_state} <- encode(union_doc),
-                     {_flat_doc, state} <- maybe_flatten(union_doc, raw_state, note_id),
-                     {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(state, user, note_id),
-                     {:ok, key} <- Crypto.dek_content_hash_key(user) do
-                  content_hash = Crypto.hmac_content_hash(key, text)
-                  tags = Helpers.extract_tags(text)
-
-                  checkpoint_write(note, vault_id, note_id, prune, opts, %{
-                    text: text,
-                    tags: tags,
-                    content_hash: content_hash,
-                    ct: ct,
-                    nonce: nonce,
-                    user: user
-                  })
+                if markdown?(note.path) do
+                  do_markdown_checkpoint(note, vault_id, note_id, live_state, prune, opts, user)
                 else
-                  err -> {:abort, err}
+                  do_structural_checkpoint(note, note_id, live_state, prune, user)
                 end
             end
           end)
@@ -211,6 +196,71 @@ defmodule Engram.Notes.CrdtCheckpoint do
       )
 
       :ok
+  end
+
+  # A CRDT room only ever holds a markdown (`.md`) doc or a structural doc
+  # (`.canvas`). Only markdown projects to/from `notes.content`. Mirrors
+  # CrdtDeliver's `.md` gate.
+  defp markdown?(path), do: is_binary(path) and String.ends_with?(path, ".md")
+
+  # Markdown checkpoint (unchanged behaviour): materialize the projected body into
+  # content/content_hash/title/tags, bump version/seq on a real change, else
+  # degrade to a snapshot-compaction write. Returns the same {prev, new, path}
+  # outcome tuple the caller's `case outcome` matches on.
+  defp do_markdown_checkpoint(note, vault_id, note_id, live_state, prune, opts, user) do
+    with {:ok, union_doc} <- union_with_row_state(note, live_state, user),
+         text = CrdtBridge.text_of(union_doc),
+         {:ok, raw_state} <- encode(union_doc),
+         {_flat_doc, state} <- maybe_flatten(union_doc, raw_state, note_id),
+         {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(state, user, note_id),
+         {:ok, key} <- Crypto.dek_content_hash_key(user) do
+      content_hash = Crypto.hmac_content_hash(key, text)
+      tags = Helpers.extract_tags(text)
+
+      checkpoint_write(note, vault_id, note_id, prune, opts, %{
+        text: text,
+        tags: tags,
+        content_hash: content_hash,
+        ct: ct,
+        nonce: nonce,
+        user: user
+      })
+    else
+      err -> {:abort, err}
+    end
+  end
+
+  # Structural (non-markdown, e.g. `.canvas`) checkpoint. The doc keeps its data
+  # in Y.Maps, not the markdown content Y.Text — so `text_of` would project ""
+  # and clobber notes.content, and `maybe_flatten` would reseed via project_doc
+  # and DESTROY the structure. So persist the Yjs snapshot opaquely (union-folded
+  # for monotonicity, same as markdown), prune the tail, and leave
+  # content/title/tags/version/seq untouched: notes.content is vestigial for
+  # canvas — a new device rebuilds the board from the persisted Yjs deltas
+  # (spec 2026-07-23). Returns equal hashes so the caller skips embed + announce.
+  #
+  # ponytail: no structural flatten yet. A canvas that crosses the client-id
+  # ceiling keeps its full state vector; add a structural (nodes/edges-preserving)
+  # flatten in Phase 2 if a real board ever hits it.
+  defp do_structural_checkpoint(note, note_id, live_state, prune, user) do
+    with {:ok, union_doc} <- union_with_row_state(note, live_state, user),
+         {:ok, raw_state} <- encode(union_doc),
+         {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(raw_state, user, note_id) do
+      {1, _} =
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note_id and n.kind == "note"),
+          set: [
+            crdt_state_ciphertext: ct,
+            crdt_state_nonce: nonce,
+            dek_version: Crypto.row_version_aad_bound()
+          ]
+        )
+
+      prune_tail(note_id, prune)
+      {note.content_hash, note.content_hash, note.path}
+    else
+      err -> {:abort, err}
+    end
   end
 
   # Folds the row's stored CRDT state with the live doc's encoded state into a

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -340,11 +340,22 @@ defmodule Engram.Notes.CrdtPersistence do
   # text JSON-safe. A nil/empty body seeds nothing (a blank note stays blank).
   defp seed_from_content(doc, %Note{} = note, user) do
     case Crypto.maybe_decrypt_note_fields(note, user) do
-      {:ok, %Note{content: content}} when is_binary(content) and content != "" ->
-        :ok = CrdtBridge.ingest_plaintext(doc, content)
+      {:ok, %Note{content: content, path: path}}
+      when is_binary(content) and content != "" ->
+        # Only MARKDOWN seeds through the frontmatter codec. A .canvas (or any
+        # non-md) note keeps its data in structural Y.Maps client-side and is
+        # client-seeded from its own file — ingesting its JSON as a markdown body
+        # would diff the whole blob into the content Y.Text and corrupt the doc.
+        if markdown?(path), do: :ok = CrdtBridge.ingest_plaintext(doc, content)
+        :ok
 
       _ ->
         :ok
     end
   end
+
+  # A CRDT room only ever holds a markdown (`.md`) doc or a structural doc
+  # (`.canvas`). Only markdown is projected to/from `notes.content` — everything
+  # else is opaque Yjs the client owns. Mirrors CrdtDeliver's `.md` gate.
+  defp markdown?(path), do: is_binary(path) and String.ends_with?(path, ".md")
 end

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -123,6 +123,48 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     assert doc_id == note.id
   end
 
+  test "checkpoint on a .canvas doc persists Yjs state without clobbering content or churning seq",
+       ctx do
+    %{user: user, vault: vault} = ctx
+    # A canvas doc keeps its data in Y.Maps (nodes/edges), not the markdown content
+    # Y.Text — so text_of projects "". The checkpoint must NOT materialize that ""
+    # over notes.content (a silent wipe of the canvas JSON) nor bump seq. It DOES
+    # persist the structural Yjs snapshot: notes.content is vestigial for canvas,
+    # a new device rebuilds the board from the persisted Yjs deltas.
+    canvas_json = ~s({"nodes":[{"id":"n1","type":"text","text":"hi"}],"edges":[]})
+
+    {:ok, note} =
+      Notes.upsert_note(user, vault, %{"path" => "board.canvas", "content" => canvas_json})
+
+    # Drop the REST-era crdt_state so the checkpoint folds only the live canvas doc.
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note.id),
+          set: [crdt_state_ciphertext: nil, crdt_state_nonce: nil]
+        )
+      end)
+
+    # A canvas-shaped live doc: structural data in a Y.Map, content Y.Text empty.
+    doc = CrdtBridge.new_doc()
+    Yex.Map.set(Yex.Doc.get_map(doc, "nodes"), "n1", "hi")
+
+    seq0 = Vaults.current_seq(user.id, vault.id)
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+
+    # content preserved verbatim — NOT projected to "" from the empty content Y.Text.
+    {:ok, fresh} = Notes.get_note(user, vault, "board.canvas")
+    assert fresh.content == canvas_json
+    # seq must NOT advance — structural doc, no phantom content edit.
+    assert Vaults.current_seq(user.id, vault.id) == seq0
+
+    # The structural Yjs state IS persisted (nodes map survived the checkpoint).
+    {:ok, raw} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, state} = Crypto.decrypt_crdt_state(raw, user)
+    {:ok, rebuilt} = CrdtBridge.doc_from_state(state)
+    assert Yex.Map.to_map(Yex.Doc.get_map(rebuilt, "nodes")) == %{"n1" => "hi"}
+  end
+
   test "checkpoint does NOT announce when text is unchanged (compaction — no re-pull spam)",
        ctx do
     %{user: user, vault: vault, note: note} = ctx

--- a/test/engram/notes/crdt_persistence_test.exs
+++ b/test/engram/notes/crdt_persistence_test.exs
@@ -156,6 +156,33 @@ defmodule Engram.Notes.CrdtPersistenceTest do
     assert CrdtBridge.text_of(doc) == ""
   end
 
+  test "bind/3 does NOT ingest a .canvas note's JSON as markdown body (structural, client-seeded)",
+       ctx do
+    %{user: user, vault: vault} = ctx
+    # A canvas note stores structural data (Y.Map nodes/edges) client-side; its
+    # notes.content is raw .canvas JSON. Seeding it through the markdown frontmatter
+    # codec would diff the whole JSON into the body Y.Text — corrupting the doc.
+    # Canvas rooms are client-seeded, so bind must NOT seed the body from content.
+    canvas_json = ~s({"nodes":[{"id":"n1","type":"text","text":"hi"}],"edges":[]})
+
+    {:ok, note2} =
+      Notes.upsert_note(user, vault, %{"path" => "board.canvas", "content" => canvas_json})
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note2.id),
+          set: [crdt_state_ciphertext: nil, crdt_state_nonce: nil]
+        )
+      end)
+
+    st = %{user_id: user.id, vault_id: note2.vault_id, note_id: note2.id}
+    doc = CrdtBridge.new_doc()
+    _returned = CrdtPersistence.bind(st, note2.id, doc)
+
+    assert CrdtBridge.body_of(doc) == ""
+  end
+
   test "bind/3 seeds when the snapshot exists but projects to EMPTY text and content is non-empty (#1087 empty-snapshot class)",
        ctx do
     %{user: user, vault: vault} = ctx


### PR DESCRIPTION
## What

Backend half of #306 "canvas as CRDT". Moves `.canvas` notes onto the same opaque Yjs CRDT transport markdown already uses, by teaching the two markdown-coupled seams to skip a non-markdown doc.

A canvas doc keeps its data in structural `Y.Map` nodes/edges, never the markdown `content` Y.Text — so `text_of/body_of` return `""` for canvas. Two seams still assumed markdown and would corrupt it:

- **`bind/3` `seed_from_content`** ingested `notes.content` through the frontmatter codec, diffing raw `.canvas` JSON into the body Y.Text.
- **the checkpoint** projected `text_of(doc) == ""` over `notes.content` (a silent wipe of the canvas JSON), and `maybe_flatten` would reseed via `project_doc` and destroy the structure.

Both are now gated on a single `markdown?/1` predicate (path ends with `.md`; mirrors `CrdtDeliver`'s existing `.md` gate). A non-markdown doc:
- skips the bind seed (canvas rooms are client-seeded from the `.canvas` file), and
- takes a new `do_structural_checkpoint` that persists the union-folded Yjs snapshot opaquely, prunes the tail, and leaves content/title/tags/version/seq untouched.

`notes.content` is deliberately **vestigial** for canvas — a new device rebuilds the board from the persisted Yjs deltas, not from `notes.content` (approved spec 2026-07-23). The transport (`crdt_create`/`crdt_msg`/`crdt_catchup`) was already opaque and needed no change.

## Why it's safe to land alone

No client routes `.canvas` into a CRDT room yet (the plugin still uses REST for canvas), so this is a prod no-op until the paired plugin PR ships. Backend-first is the designed sequence.

## Tests (TDD, RED-first)

- `bind/3` does NOT ingest a `.canvas` note's JSON as markdown body (`body_of(doc) == ""`).
- checkpoint on a `.canvas` doc preserves `notes.content` verbatim, does NOT churn `seq`, and DOES persist the structural Yjs state (rebuilt `nodes` map round-trips).

Full gauntlet green: `mix format`, `credo --strict`, `dialyzer`, full suite (3763 tests, 0 failures). Code-reviewer agent: clean, no findings.

Refs #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)