### PR TITLE
fix(web): 3 correctness fixes from reviewing the CRDT-migration PRs (#1100/#1102/#1106)

### DIFF
--- a/frontend/src/api/channel-onopen.test.ts
+++ b/frontend/src/api/channel-onopen.test.ts
@@ -41,7 +41,7 @@ describe("connectChannel onOpen — structural backfill", () => {
 	// they refetch current state. This replaced the deleted /sync/changes cursor
 	// feed (backend #1036): folder markers never rode that feed anyway (#976), and
 	// note/attachment structural changes are covered the same snapshot-diff way.
-	it("invalidates folders, folderNotes, and attachments on (re)connect", async () => {
+	it("invalidates folders, folderNotes, folder-notes-by-id, and attachments on (re)connect", async () => {
 		const invalidateQueries = vi.fn();
 		const queryClient = { invalidateQueries } as never;
 
@@ -58,5 +58,13 @@ describe("connectChannel onOpen — structural backfill", () => {
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["folders", "v1"] });
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["folderNotes", "v1"] });
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["attachments", "v1"] });
+			// The sidebar tree renders note rows from the id-keyed family, and its
+			// expanded-but-observer-less subfolders only refetch under refetchType
+			// "all" (matching flushBatch). Missing this = stale tree membership after
+			// a sleep/offline catch-up until a full reload.
+			expect(invalidateQueries).toHaveBeenCalledWith({
+				queryKey: ["folder-notes-by-id", "v1"],
+				refetchType: "all",
+			});
 	});
 });

--- a/frontend/src/api/channel-onopen.test.ts
+++ b/frontend/src/api/channel-onopen.test.ts
@@ -58,13 +58,13 @@ describe("connectChannel onOpen — structural backfill", () => {
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["folders", "v1"] });
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["folderNotes", "v1"] });
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["attachments", "v1"] });
-			// The sidebar tree renders note rows from the id-keyed family, and its
-			// expanded-but-observer-less subfolders only refetch under refetchType
-			// "all" (matching flushBatch). Missing this = stale tree membership after
-			// a sleep/offline catch-up until a full reload.
-			expect(invalidateQueries).toHaveBeenCalledWith({
-				queryKey: ["folder-notes-by-id", "v1"],
-				refetchType: "all",
-			});
+		// The sidebar tree renders note rows from the id-keyed family, and its
+		// expanded-but-observer-less subfolders only refetch under refetchType
+		// "all" (matching flushBatch). Missing this = stale tree membership after
+		// a sleep/offline catch-up until a full reload.
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["folder-notes-by-id", "v1"],
+			refetchType: "all",
+		});
 	});
 });

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -229,6 +229,13 @@ export function backfillStructural(queryClient: QueryClient, vaultId: string): v
 	queryClient.invalidateQueries({ queryKey: ["folders", vaultId] });
 	queryClient.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 	queryClient.invalidateQueries({ queryKey: ["attachments", vaultId] });
+	// The sidebar tree renders note rows from the id-keyed family, not the
+	// name-keyed ["folderNotes"] above (that feeds the dashboard). Its expanded
+	// subfolders have no mounted observer, so a default ("active") invalidate
+	// leaves them stale-but-unfetched forever — refetchType "all" forces the
+	// refetch, exactly as flushBatch does. Without it a sleep/offline catch-up
+	// never converges tree membership until a full page reload.
+	queryClient.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId], refetchType: "all" });
 }
 
 export function clampReconnectJitter(raw: unknown): number | null {

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -574,6 +574,15 @@ export async function crdtCreateNoteWithContent(
 	if (!r || r.status === "error") {
 		throw new CrdtOpError(r?.reason ?? "create_failed", "crdt_create_batch");
 	}
+	// ADOPT guard: unlike a bare crdt_create (adopt-safe — no content to lose),
+	// a create-WITH-content that adopts a DIFFERENT note at an occupied path
+	// silently drops our genesis frame (backend skips seeding a non-empty doc,
+	// or worse seeds our content into an unrelated empty occupant). A mismatched
+	// doc_id means the path was taken — surface it as the same conflict the old
+	// POST /notes 409 produced so the caller can toast, not vanish the copy.
+	if (r.doc_id !== docId) {
+		throw new CrdtOpError("create_failed", "crdt_create_batch");
+	}
 	return r.doc_id;
 }
 

--- a/frontend/src/api/crdt-write-ops.test.ts
+++ b/frontend/src/api/crdt-write-ops.test.ts
@@ -107,9 +107,9 @@ describe("crdtCreateNoteWithContent — adopt detection (occupied path)", () => 
 		h.joins.ok?.();
 		h.crdtPush.mockReturnValue(batchReply({ doc_id: "minted-new", status: "ok" }));
 
-		await expect(
-			crdtCreateNoteWithContent("minted-new", "folder/copy.md", "# copy"),
-		).resolves.toBe("minted-new");
+		await expect(crdtCreateNoteWithContent("minted-new", "folder/copy.md", "# copy")).resolves.toBe(
+			"minted-new",
+		);
 	});
 
 	it("throws create_failed when the server ADOPTS a different note (occupied path)", async () => {

--- a/frontend/src/api/crdt-write-ops.test.ts
+++ b/frontend/src/api/crdt-write-ops.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { connectChannel, crdtCreateNote, crdtDeleteNote, disconnectChannel } from "./channel";
+import {
+	connectChannel,
+	crdtCreateNote,
+	crdtCreateNoteWithContent,
+	crdtDeleteNote,
+	disconnectChannel,
+} from "./channel";
 
 // Phoenix mock that distinguishes the crdt channel (joined with { crdt_proto: 2 })
 // so the test can drive its join outcome and capture its push. vi.hoisted +
@@ -83,5 +89,38 @@ describe("crdtCreateNote / crdtDeleteNote — offline gate", () => {
 
 		await expect(crdtDeleteNote("n1")).rejects.toThrow(/not joined|disconnect/i);
 		expect(h.crdtPush).not.toHaveBeenCalled();
+	});
+});
+
+describe("crdtCreateNoteWithContent — adopt detection (occupied path)", () => {
+	const batchReply = (entry: { doc_id: string; status: "ok" | "error"; reason?: string }) => ({
+		receive(status: string, cb: (r?: unknown) => void) {
+			if (status === "ok") {
+				cb({ results: [entry] });
+			}
+			return this;
+		},
+	});
+
+	it("returns the doc_id when the server CREATES our note (id echoed back)", async () => {
+		await connectChannel(opts);
+		h.joins.ok?.();
+		h.crdtPush.mockReturnValue(batchReply({ doc_id: "minted-new", status: "ok" }));
+
+		await expect(
+			crdtCreateNoteWithContent("minted-new", "folder/copy.md", "# copy"),
+		).resolves.toBe("minted-new");
+	});
+
+	it("throws create_failed when the server ADOPTS a different note (occupied path)", async () => {
+		await connectChannel(opts);
+		h.joins.ok?.();
+		// Path already held by another live note → backend genesis_adopt_or_insert
+		// returns {:ok, live} with the OCCUPANT's id, never seeding our content.
+		h.crdtPush.mockReturnValue(batchReply({ doc_id: "existing-occupant", status: "ok" }));
+
+		await expect(
+			crdtCreateNoteWithContent("minted-new", "folder/taken.md", "# copy"),
+		).rejects.toMatchObject({ reason: "create_failed" });
 	});
 });

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -861,6 +861,28 @@ describe("useBatchDeleteNotes", () => {
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folder-notes-by-id", "42"] });
 	});
 
+	it("reconciles server truth even on a (partial) failure — Promise.all is not atomic", async () => {
+		// A mid-batch reject leaves some ids already deleted server-side while
+		// onError restores EVERY optimistically-removed row (including the gone
+		// ones). Reconciliation must run on the failure path too, else the tree
+		// shows phantom notes (404 on click) until an unrelated refetch.
+		seedFolderNotesById("5", [{ id: "1" }, { id: "2" }]);
+		crdtDeleteNote.mockRejectedValue(new CrdtOpError("rate_limited", "crdt_delete"));
+		const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+		const { result } = renderHook(() => useBatchDeleteNotes(), { wrapper });
+		await act(async () => {
+			try {
+				await result.current.mutateAsync({ ids: ["1", "2"] });
+			} catch {
+				// expected
+			}
+		});
+
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folder-notes-by-id", "42"] });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
+	});
+
 	it("optimistically strips deleted root notes from the by-id root list", async () => {
 		// Root notes share the one id-keyed cache under the 'root' sentinel.
 		seedFolderNotesById("root", [

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1935,8 +1935,10 @@ export function useBatchDeleteNotes() {
 		// No batch crdt op — one crdt_delete per id, concurrently (replaces
 		// POST /notes/batch-delete). ponytail: N round trips + non-atomic — a
 		// mid-batch reject fails the whole Promise.all → onError rollback; the
-		// onSuccess invalidation reconciles server truth. Fine for typical
-		// multi-selects; add a server batch op if very large selections appear.
+		// onSettled invalidation reconciles server truth on BOTH paths (a partial
+		// failure leaves some ids deleted while onError restores every row).
+		// Fine for typical multi-selects; add a server batch op if very large
+		// selections appear.
 		mutationFn: async ({ ids }) => {
 			await Promise.all(ids.map((id) => crdtDeleteNote(id)));
 			return { deleted: ids.length };
@@ -1985,7 +1987,9 @@ export function useBatchDeleteNotes() {
 			}
 			toast.error("Batch delete failed.");
 		},
-		onSuccess: () => {
+		onSettled: () => {
+			// Reconcile after success AND partial failure — Promise.all is not
+			// atomic, so onError's full restore can resurrect already-deleted rows.
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });


### PR DESCRIPTION
Follow-up to the web REST→CRDT migration (#1100, #1102, #1105, #1106). A post-merge code review of those PRs surfaced three real correctness bugs — all frontend-only, each TDD'd (failing test first).

### 1. Duplicate onto an occupied path silently dropped the copy (from #1106)
`crdtCreateNoteWithContent` minted a fresh id, so the backend always hit `genesis_adopt_or_insert`; on an occupied path that **adopts the existing note** and returns `{:ok, live}` (status `"ok"`) with the occupant's id. The wrapper returned that as success → the copied content was silently discarded, and if the occupant was empty, our content was seeded into an unrelated note. The old `POST /notes` returned a 409.
**Fix:** a returned `doc_id !== docId` means the path was taken → throw `CrdtOpError("create_failed")` so `useDuplicateNote` fires the existing conflict toast. (Bare `crdt_create` stays adopt-safe — no content to lose.)

### 2. Reconnect backfill never converged the sidebar tree (from #1100)
`backfillStructural` invalidated `["folderNotes"]` (dashboard) but not the id-keyed `["folder-notes-by-id"]` the sidebar tree renders from, and used default `refetchType: "active"` — so expanded, observer-less subfolders stayed stale-but-unfetched. After a sleep/offline window during which another device changed notes, the tree showed stale membership until a full reload.
**Fix:** invalidate `folder-notes-by-id` with `refetchType: "all"`, mirroring `flushBatch`.

### 3. Batch-delete left phantom notes on partial failure (from #1102)
`useBatchDeleteNotes` put its reconciliation `invalidateQueries` in `onSuccess`, which never runs when `Promise.all` rejects mid-batch. `crdt_delete` is durable and non-atomic, so a mid-batch reject left some ids deleted while `onError` restored **every** row — with no reconcile → phantom notes (404 on click) until an unrelated refetch.
**Fix:** move the invalidations to `onSettled` (both paths), matching sibling `useDeleteNote`.

#1105 (rename/move) reviewed clean — no changes.

Tests: 3 new failing-first tests (adopt-detection, backfill key, partial-failure reconcile). Full frontend gate green locally — biome ci, tsc, 849 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)