### PR TITLE
fix(web): batch-delete folders/attachments reconcile on onSettled (harden after #1108)

### DIFF
--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1403,6 +1403,30 @@ describe("useBatchDeleteFolders", () => {
 		const folders = qc.getQueryData<{ folders: Folder[] }>(["folders", "42"]);
 		expect(folders?.folders.map((f) => f.id).sort()).toEqual(["7", "9"]);
 	});
+
+	it("reconciles server truth on the error path (lost ack after a committed delete)", async () => {
+		// A single atomic POST, but a network error AFTER the server commits (or a
+		// non-transactional partial delete) makes onError restore the folders while
+		// the server actually dropped them → phantom folders until an unrelated
+		// refetch. Reconciliation must run on the error path too.
+		qc.setQueryData(["folders", "42"], {
+			folders: [{ id: "7", parent_id: null, name: "top", count: 0 }],
+		});
+		post.mockRejectedValue(new ApiError(500, "boom"));
+		const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+		const { result } = renderHook(() => useBatchDeleteFolders(), { wrapper });
+		await act(async () => {
+			try {
+				await result.current.mutateAsync({ ids: ["7"] });
+			} catch {
+				// expected
+			}
+		});
+
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folder-notes-by-id", "42"] });
+	});
 });
 
 describe("useBatchMoveFolders", () => {
@@ -1725,6 +1749,25 @@ describe("useBatchDeleteAttachments", () => {
 		});
 
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["attachments", "42"] });
+	});
+
+	it("reconciles the attachments list on the error path (lost ack after a committed delete)", async () => {
+		// No optimistic removal here, so a lost ack (server committed, client saw a
+		// network error) leaves the DELETED attachments still showing until a
+		// refetch — onSuccess-only reconcile never fires. Reconcile on both paths.
+		post.mockRejectedValue(new ApiError(500, "boom"));
+		const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+		const { result } = renderHook(() => useBatchDeleteAttachments(), { wrapper });
+		await act(async () => {
+			try {
+				await result.current.mutateAsync({ paths: ["a.png"] });
+			} catch {
+				// expected
+			}
+		});
+
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["attachments", "42"] });
 	});
 });

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -2218,7 +2218,10 @@ export function useBatchDeleteFolders() {
 			}
 			toast.error("Batch delete failed.");
 		},
-		onSuccess: () => {
+		onSettled: () => {
+			// Reconcile on both paths: a lost ack (server committed, client saw a
+			// network error) or a non-transactional partial delete would otherwise
+			// leave onError's restore showing folders the server actually dropped.
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
@@ -2376,7 +2379,10 @@ export function useBatchDeleteAttachments() {
 	return useMutation<{ deleted: number }, ApiError, { paths: string[] }>({
 		mutationFn: ({ paths }) =>
 			api.post<{ deleted: number }>("/attachments/batch-delete", { paths }, idempotencyHeaders()),
-		onSuccess: () => {
+		onSettled: () => {
+			// Reconcile on both paths: no optimistic removal here, so a lost ack
+			// (server committed, client saw a network error) would otherwise leave
+			// the deleted attachments visible until an unrelated refetch.
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["attachments", vaultId] });


### PR DESCRIPTION
Follow-up to #1108. Applies the same reconcile-on-`onSettled` fix to the two remaining batch-delete mutations flagged during that review.

`useBatchDeleteFolders` and `useBatchDeleteAttachments` are single atomic `POST`s (not the notes' client-side `Promise.all`), so #1108's guaranteed partial-failure vector doesn't apply here. But both put their reconciliation `invalidateQueries` in `onSuccess` only, which leaves a real gap:

- A **network error after the server commits** (lost ack), or a non-transactional partial delete, runs `onError` instead — which for folders restores the optimistically-removed rows, and for attachments does nothing — so items the server actually dropped stay visible until an unrelated refetch.

**Fix:** move the invalidations to `onSettled` (fires on both paths). The endpoints already send idempotency headers, so this is purely a client-cache-convergence hardening. Matches `useDeleteNote` / `useBatchDeleteNotes`.

TDD: 2 new failing-first tests asserting reconciliation fires on the error path. Full frontend gate green locally — biome ci, tsc, 851 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)