### PR TITLE
test(e2e): canvas syncs via CRDT, not server-materialized content (#306)

### DIFF
--- a/e2e/tests/test_41_canvas_sync.py
+++ b/e2e/tests/test_41_canvas_sync.py
@@ -1,9 +1,11 @@
 """Test 41: Canvas files (.canvas) sync between A and B.
 
-Canvas files are JSON text treated as TEXT_EXTENSIONS in the plugin.
-They sync through the same pushNote path as markdown but with a
-different extension. Verifies the full round-trip preserves JSON structure,
-received live on B with no manual pull.
+Since #306 canvas syncs over the CRDT transport (structural Yjs — nodes/edges
+Y.Maps), NOT the legacy REST pushNote path. The backend persists the canvas Yjs
+state opaquely and keeps notes.content VESTIGIAL for canvas (it never
+materializes canvas edits into notes.content — a new device rebuilds the board
+from the Yjs deltas). So these tests assert CONVERGENCE on device B's disk, not
+that the server's notes.content reflects the edit.
 """
 
 import json
@@ -68,12 +70,14 @@ async def test_canvas_modify_sync(vault_a, vault_b, cdp_a, cdp_b, api_sync):
     })
     write_note(vault_a, path, json.dumps(modified, indent=2))
 
-    api_sync.wait_for_note_content(path, "New node", timeout=10)
-
-    # B receives the modification live. B's file already exists (from the
-    # base canvas above) so the delivery oracle's non-empty guard can't
-    # detect this specific update; wait_for_content polls for the new node's
-    # text instead — still a pure vault-disk poll, no pull involved.
+    # NOTE: we do NOT assert the edit reaches the server's notes.content — since
+    # #306 canvas content is vestigial on the server (the edit lives in the Yjs
+    # state, not notes.content). Convergence is verified on B's disk below.
+    #
+    # B receives the modification live over the CRDT fan-out. B's file already
+    # exists (from the base canvas above) so the delivery oracle's non-empty guard
+    # can't detect this specific update; wait_for_content polls for the new node's
+    # text instead — a pure vault-disk poll, no pull involved.
     b_raw = wait_for_content(vault_b, path, "New node", timeout=30)
     b_data = json.loads(b_raw)
     assert len(b_data["nodes"]) == 3, "Modified canvas should have 3 nodes"


### PR DESCRIPTION
Since the canvas-CRDT migration (plugin engram-app/Engram-obsidian#321 + backend #1107, merged), canvas rides the Yjs transport and the backend keeps `notes.content` **vestigial** for canvas — it never materializes a canvas edit into `notes.content` (the edit lives in the Yjs state; a new device rebuilds the board from the deltas).

`test_41_canvas_sync.py::test_canvas_modify_sync` asserted `wait_for_note_content(path, "New node", ... on server)`, which tested the pre-CRDT behavior (server materializes canvas content) and now times out.

This drops that server-content assertion. The test still verifies the real behavior — that the edit **converges to device B's disk** (`wait_for_content`, unchanged). Compatible with both the pre-CRDT REST path (plugin main) and the CRDT path (#321), so it lands independently.

Paired with plugin #321 (unblocks its canvas e2e). Refs #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)