### PR TITLE
fix(web): batch-move mutations reconcile on onSettled (complete the #1108/#1109 sweep)

### DIFF
--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1325,6 +1325,31 @@ describe("useBatchMoveNotes", () => {
 
 		resolvePost({ moved: 1 });
 	});
+
+	it("reconciles server truth even on a (partial) failure — crdt_create per id is not atomic", async () => {
+		// Promise.all over per-id crdt_create: a mid-batch reject leaves some ids
+		// moved server-side while onError restores every optimistically re-pathed
+		// row → notes shown in the OLD folder until an unrelated refetch. Reconcile
+		// must run on the failure path too.
+		crdtCreateNote.mockRejectedValue(new CrdtOpError("create_failed", "crdt_create"));
+		const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+		const { result } = renderHook(() => useBatchMoveNotes(), { wrapper });
+		await act(async () => {
+			try {
+				await result.current.mutateAsync({
+					ids: ["1"],
+					target_folder: "dst",
+					paths: { "1": "src/a.md" },
+				});
+			} catch {
+				// expected
+			}
+		});
+
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folder-notes-by-id", "42"] });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
+	});
 });
 
 describe("useBatchDeleteFolders", () => {
@@ -1551,6 +1576,30 @@ describe("useBatchMoveFolders", () => {
 		expect(folders?.folders.find((f) => f.id === "7")?.parent_id).toBeNull();
 		expect(folders?.folders.find((f) => f.id === "8")?.name).toBe("src/sub");
 	});
+
+	it("reconciles server truth on the error path (lost ack after a committed move)", async () => {
+		// Single atomic POST, but a network error after the server commits (or a
+		// non-transactional partial move) runs onError, which restores the
+		// optimistically re-pathed folders the server actually moved → phantom
+		// state until an unrelated refetch. Reconcile on both paths.
+		qc.setQueryData(["folders", "42"], {
+			folders: [{ id: "7", parent_id: null, name: "src", count: 0 }],
+		});
+		post.mockRejectedValue(new ApiError(500, "boom"));
+		const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+		const { result } = renderHook(() => useBatchMoveFolders(), { wrapper });
+		await act(async () => {
+			try {
+				await result.current.mutateAsync({ ids: ["7"], target_parent: "dst" });
+			} catch {
+				// expected
+			}
+		});
+
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folder-notes-by-id", "42"] });
+	});
 });
 
 describe("useSearch", () => {
@@ -1715,6 +1764,22 @@ describe("useBatchMoveAttachments", () => {
 		});
 
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["attachments", "42"] });
+	});
+
+	it("reconciles the attachments list on the error path (lost ack after a committed move)", async () => {
+		post.mockRejectedValue(new ApiError(500, "boom"));
+		const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+		const { result } = renderHook(() => useBatchMoveAttachments(), { wrapper });
+		await act(async () => {
+			try {
+				await result.current.mutateAsync({ paths: ["a.png"], target_folder: "img" });
+			} catch {
+				// expected
+			}
+		});
+
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["attachments", "42"] });
 	});
 });

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -2160,7 +2160,10 @@ export function useBatchMoveNotes() {
 			}
 			toast.error("Batch move failed.");
 		},
-		onSuccess: () => {
+		onSettled: () => {
+			// crdt_create per id is non-atomic (Promise.all): a mid-batch reject
+			// leaves some ids moved server-side while onError restores every row,
+			// so reconcile must run on both paths.
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
@@ -2322,7 +2325,10 @@ export function useBatchMoveFolders() {
 			}
 			toast.error("Batch move failed.");
 		},
-		onSuccess: () => {
+		onSettled: () => {
+			// Reconcile on both paths: a lost ack (server committed, client saw a
+			// network error) leaves onError's restore showing folders the server
+			// actually moved until an unrelated refetch.
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
@@ -2361,7 +2367,10 @@ export function useBatchMoveAttachments() {
 				{ paths, target_folder },
 				idempotencyHeaders(),
 			),
-		onSuccess: () => {
+		onSettled: () => {
+			// Reconcile on both paths: a lost ack (server committed, client saw a
+			// network error) leaves the attachments shown at their old paths until
+			// an unrelated refetch.
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["attachments", vaultId] });


### PR DESCRIPTION
Completes the `onSuccess`→`onSettled` reconcile sweep from #1108/#1109 — the batch-**move** mutations were missed. All three reconciled in `onSuccess` only:

- **`useBatchMoveNotes`** — CRDT, one `crdt_create` per id via `Promise.all` → client-side **non-atomic**, so a mid-batch reject *guarantees* partial state while `onError` restores every re-pathed row. Same class as #1108's batch-delete bug: notes show in the old folder until an unrelated refetch.
- **`useBatchMoveFolders` / `useBatchMoveAttachments`** — single atomic POSTs, but a lost ack (server committed, client saw a network error) runs `onError` and leaves items at their old location. Same as #1109's deletes.

Fix: move the reconciliation `invalidateQueries` to `onSettled` (fires on both paths).

Found during a full REST→CRDT straggler sweep of the SPA — the migration itself has no remaining stragglers; this is the last of the reconcile-consistency gaps.

TDD: 3 new failing-first tests (error-path reconcile per mutation). Full frontend gate green locally — biome ci, tsc, 854 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)