### PR TITLE
fix(ci): serialize e2e-clerk (E2E_WORKERS 2→1) for #355 stability

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1261,11 +1261,18 @@ jobs:
       - name: "Run Obsidian E2E tests"
         if: always()
         working-directory: e2e
-        # -n 1 --dist=loadfile: SINGLE worker. Two concurrent workers each drive
-        # their own Obsidian instance doing live Clerk auth + CRDT joins, which
-        # races identity-rebind / auth timing and tips a rotating clerk flake
-        # (#355 — e.g. test_84 crdtJoinFailedReason=unauthorized). Serializing the
-        # suite is the stability lever; set E2E_WORKERS=2 to restore parallelism.
+        # -n 1 --dist=loadfile: SINGLE worker (default). Under -n 2, two workers
+        # each drive their own Obsidian instance doing live Clerk auth + CRDT
+        # joins, which races identity-rebind / auth timing and tips a rotating
+        # clerk flake (#355 — a different test fails each run: test_84
+        # crdtJoinFailedReason=unauthorized, test_09 delivery miss, test_51
+        # first-sync race). Serial is the stability lever: it matches the
+        # sibling e2e-crdt suite (also single-process below) which stays green.
+        # Restoring -n 2 needs the flake root-caused away first — the Clerk
+        # user pool (#809, pre-minted tokens removes the per-test create_user →
+        # create_session propagation round-trip that races under load) is the
+        # lead candidate, but -n 2 must be re-proven stable before flipping
+        # E2E_WORKERS=2 back.
         run: |
           # tests/crdt/ is the CRDT-only suite (spec §12a). It opts the plugin
           # into CRDT and uses eventually-consistent assertions, so it must NOT
@@ -1278,7 +1285,7 @@ jobs:
           K_ARGS=(); [ -n "$E2E_K" ] && K_ARGS=(-k "$E2E_K")
           python3 -m pytest tests/ --ignore=tests/api_only/ --ignore=tests/crdt/ \
             "${K_ARGS[@]}" \
-            -n "${E2E_WORKERS:-2}" --dist=loadfile \
+            -n "${E2E_WORKERS:-1}" --dist=loadfile \
             -v --timeout=300 -p no:cacheprovider --no-header
         env:
           E2E_PATTERN: ${{ needs.fingerprint.outputs.e2e-target-pattern }}
@@ -1812,9 +1819,9 @@ jobs:
       - name: "Run CRDT E2E tests"
         if: always() && needs.fingerprint.outputs.e2e-target-suite != 'local'
         working-directory: e2e
-        # -n 2 --dist=loadfile: two xdist workers, each owns whole test files
-        # (preserves intra-file ordering). E2E_WORKERS defaults to 2 but can be
-        # overridden to 1 for rollback.
+        # Single-process (no -n): the CRDT suite runs serially. It stays green
+        # this way, and is the stability reference the e2e-clerk suite above now
+        # matches (E2E_WORKERS default 1, #355).
         run: |
           # tests/crdt/ is the CRDT-only suite (spec §12a). It opts the plugin
           # into CRDT (E2E_ENABLE_CRDT=true) and uses eventually-consistent


### PR DESCRIPTION
## Root cause (#355)

The `e2e-clerk` pytest step (`verify.yml`) defaulted to **`-n 2`** (`E2E_WORKERS:-2`) — two parallel xdist workers — despite the adjacent comment already prescribing single-worker as the #355 stability lever. Under `-n 2`, the two workers each drive their own Obsidian instance doing **live Clerk auth + CRDT joins**, racing identity-rebind / auth timing. That's the "**different test fails each run**" signature (same SHA passes and fails across runs = environmental): `test_84` `crdtJoinFailedReason=unauthorized`, `test_09` delivery miss, `test_51` first-sync race.

Confirmed today on plugin PR #323: the identical plugin SHA passed a full `e2e-clerk` run once and failed twice — on **two different tests**.

## Fix

Default `E2E_WORKERS` **2 → 1** (serial), matching the code's own documented lever. Serial is the **proven-stable model**: the sibling `e2e-crdt` suite runs single-process (no `-n`) and stays green — this aligns `e2e-clerk` with it. (Also corrected the stale `e2e-crdt` comment, which claimed `-n 2` but the command runs serial — the very thing that had obscured this.)

`api_only` (`E2E_API_WORKERS:-2`) is **unchanged** — it has no Obsidian instances and is stable under `-n 2`.

## Tradeoff

`e2e-clerk` runs ~2× wall-clock. Restoring parallelism is deferred to the **Clerk user pool (#809)** — pre-minted tokens remove the per-test `create_user → create_session` propagation round-trip that races under load — after which `-n 2` must be **re-proven** stable before flipping the default back.

Refs #355, #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)