### PR TITLE
feat(web): durable + acked + bounded CRDT op queue for the SPA (#1030)

### DIFF
--- a/frontend/src/api/channel-crdt.test.ts
+++ b/frontend/src/api/channel-crdt.test.ts
@@ -56,6 +56,8 @@ const sessionMock = vi.hoisted(() => ({
 	notifyCrdtChannelError: vi.fn(),
 	resyncOpenDocs: vi.fn(),
 	scheduleRehandshake: vi.fn(),
+	getCrdtSyncStatus: vi.fn(() => "connecting"),
+	subscribeToCrdtSyncStatus: vi.fn(() => () => {}),
 }));
 vi.mock("../crdt/session", () => sessionMock);
 

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -1,6 +1,9 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { type Channel, Socket } from "phoenix";
+import { toast } from "sonner";
 import { buildGenesisFrame } from "../crdt/genesis";
+import { CrdtOpQueueController } from "../crdt/op-queue-controller";
+import { createIndexedDbPersister } from "../crdt/op-queue-persist";
 import {
 	enrollIfLive as crdtEnrollIfLive,
 	handleFrame as crdtHandleFrame,
@@ -11,7 +14,9 @@ import {
 	scheduleRehandshake as scheduleCrdtRehandshake,
 	startCrdtSession,
 	stopCrdtSession,
+	subscribeToCrdtSyncStatus,
 } from "../crdt/session";
+import { uuid7 } from "../crdt/uuid7";
 import { rlog } from "../observability/remote-log";
 import { beacon, newTraceContext, parseTraceparent, tracingEnabled } from "../observability/trace";
 import { getWsBase, joinWsUrl } from "./base";
@@ -47,6 +52,11 @@ let serverJitterMs: number | null = null;
 let socket: Socket | null = null;
 let channel: Channel | null = null;
 let crdtChannel: Channel | null = null;
+// Durable, acked, bounded outbound queue for terminal CRDT ops (create/delete)
+// — issue #1030. Instantiated per connection; ops issued while the topic isn't
+// joined are held and delivered on reconnect instead of being dropped.
+let opQueue: CrdtOpQueueController | null = null;
+let opQueueUnsub: (() => void) | null = null;
 
 // Bumped by disconnectChannel (which connectChannel calls at entry, and which
 // also runs on effect teardown / vault switch). connectChannel captures it
@@ -75,8 +85,9 @@ let tokenRefreshInFlight = false;
 
 // The crdt room is reliably usable only once its join succeeded (sync status
 // "synced"). A non-null-but-connecting/errored channel would accept a push that
-// silently times out ~10s later; gating on status fails fast instead — the
-// chosen offline policy (disable + surface reconnecting, no durable queue).
+// silently times out ~10s later; gating on status returns null instead, which
+// the durable op queue (#1030) treats as "hold and retry" — so a send issued
+// before the room is joined is buffered, not lost.
 function joinedCrdtChannel(): PushChannel | null {
 	return getCrdtSyncStatus() === "synced" ? (crdtChannel as unknown as PushChannel | null) : null;
 }
@@ -520,6 +531,52 @@ export async function connectChannel({ userId, vaultId, getToken, queryClient }:
 	});
 	const crdtTopic = `crdt:${userId}:${vaultId}`;
 	crdtChannel = socket.channel(crdtTopic, { crdt_proto: 2 });
+
+	// Durable outbound queue (#1030): create/delete ops route through here so a
+	// send issued while the topic isn't joined is HELD and delivered on join,
+	// acked + retried with backoff, bounded + TTL'd. The caller (mutation) owns
+	// its own cache reconciliation via the settled promise, so remapId is a
+	// no-op; drops just get logged, and a plan-cap block surfaces the upgrade toast.
+	opQueue = new CrdtOpQueueController({
+		channel: () => {
+			const ch = joinedCrdtChannel();
+			return ch
+				? {
+						crdtCreate: (id, p) => sendCrdtCreate(ch, id, p),
+						crdtDelete: (id) => sendCrdtDelete(ch, id),
+					}
+				: null;
+		},
+		remapId: () => {
+			// no-op: the calling mutation swaps the optimistic id for the settled
+			// server id (adopt included) via the promise this returns.
+		},
+		onDropSurfaced: (op, reason) =>
+			rlog().warn("crdt", `crdt_${op.kind} dropped (${reason}) undelivered: ${op.docId}`),
+		onLimitSurfaced: () => toast.error("You've hit your note limit — upgrade to add more."),
+		persister: createIndexedDbPersister(userId, vaultId),
+		mintId: () => uuid7(),
+	});
+	const queue = opQueue;
+	opQueue.start().catch(() => {
+		// start() only reads persisted ops; a failure just means no restore
+	});
+	// Drive the queue's join gate off the CRDT sync status — the same source of
+	// truth joinedCrdtChannel() gates sends on. "synced" flushes held ops; any
+	// other state holds them (so a disconnect doesn't burn the retry budget).
+	const driveJoinGate = (s: string) => {
+		if (s === "synced") {
+			queue.joined().catch(() => {
+				// a flush error is transient; the 5s ticker re-drives due ops
+			});
+		} else {
+			queue.left();
+		}
+	};
+	opQueueUnsub = subscribeToCrdtSyncStatus(driveJoinGate);
+	// subscribe() doesn't fire for the current value — cover the (rare) case where
+	// the topic is already joined by the time we wired up.
+	driveJoinGate(getCrdtSyncStatus());
 	// doc_id IS the note_id on the wire (id-keyed CRDT doc_id) — no path
 	// splitting needed.
 	crdtChannel.on("crdt_msg", (p: { doc_id: string; b64: string }) => {
@@ -546,15 +603,23 @@ export async function connectChannel({ userId, vaultId, getToken, queryClient }:
 /**
  * CRDT note create/delete over the live `crdt:` channel — the socket-native
  * replacement for REST `POST /notes` / `/notes/batch-delete` / `DELETE
- * /notes/by-id` (web REST-purge, issue #1101). Reject fast when the room is not
- * joined; `crdtCreateNote` returns the server's authoritative doc_id (ADOPT-safe).
+ * /notes/by-id` (web REST-purge, issue #1101).
+ *
+ * Routed through the durable op queue (#1030): the returned promise settles on
+ * the op's FINAL outcome — resolving with the authoritative doc_id (ADOPT-safe)
+ * once the server acks, or rejecting on a terminal reason / ttl / overflow /
+ * max-attempts drop. An op issued while the topic isn't joined is HELD and
+ * delivered on reconnect, not dropped. Falls back to a direct (reject-fast) send
+ * only when no connection/queue exists.
  */
 export function crdtCreateNote(docId: string, path: string): Promise<string> {
-	return sendCrdtCreate(joinedCrdtChannel(), docId, path);
+	return opQueue
+		? opQueue.enqueueCreate(docId, path)
+		: sendCrdtCreate(joinedCrdtChannel(), docId, path);
 }
 
 export function crdtDeleteNote(docId: string): Promise<{ doc_id: string }> {
-	return sendCrdtDelete(joinedCrdtChannel(), docId);
+	return opQueue ? opQueue.enqueueDelete(docId) : sendCrdtDelete(joinedCrdtChannel(), docId);
 }
 
 export function crdtCreateNotesBatch(
@@ -720,6 +785,14 @@ export function disconnectChannel() {
 	// already discards its eventual result.
 	tokenRefreshInFlight = false;
 	__resetNoteChangeBatch();
+	if (opQueueUnsub) {
+		opQueueUnsub();
+		opQueueUnsub = null;
+	}
+	if (opQueue) {
+		opQueue.stop();
+		opQueue = null;
+	}
 	if (crdtChannel) {
 		crdtChannel.leave();
 		crdtChannel = null;

--- a/frontend/src/api/crdt-write-ops.test.ts
+++ b/frontend/src/api/crdt-write-ops.test.ts
@@ -83,12 +83,28 @@ describe("crdtCreateNote / crdtDeleteNote — offline gate", () => {
 		expect(h.crdtPush).toHaveBeenCalledWith("crdt_create", { doc_id: "n1", path: "folder/a.md" });
 	});
 
-	it("rejects create/delete without pushing when the channel is not joined", async () => {
+	it("HOLDS a delete while not joined, then delivers it on join (durable, not dropped)", async () => {
+		// Durable op queue (#1030): a terminal op issued before the topic is joined
+		// is buffered and flushed on join — NOT rejected/dropped like the old
+		// reject-fast gate.
 		await connectChannel(opts);
 		h.joins.error?.({}); // crdt channel join failed → sync status "error"
+		h.crdtPush.mockReturnValue({
+			receive(status: string, cb: (r?: unknown) => void) {
+				if (status === "ok") {
+					cb({ doc_id: "n1" });
+				}
+				return this;
+			},
+		});
 
-		await expect(crdtDeleteNote("n1")).rejects.toThrow(/not joined|disconnect/i);
-		expect(h.crdtPush).not.toHaveBeenCalled();
+		const p = crdtDeleteNote("n1");
+		await Promise.resolve();
+		expect(h.crdtPush).not.toHaveBeenCalled(); // held — not joined
+
+		h.joins.ok?.(); // topic joins → queue flushes held ops
+		await expect(p).resolves.toEqual({ doc_id: "n1" });
+		expect(h.crdtPush).toHaveBeenCalledWith("crdt_delete", { doc_id: "n1" });
 	});
 });
 

--- a/frontend/src/crdt/op-dispatch.test.ts
+++ b/frontend/src/crdt/op-dispatch.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { CrdtOpError } from "../api/crdt-ops";
+import { type CrdtOpChannel, makeCrdtOpSend } from "./op-dispatch";
+import type { CrdtOp } from "./op-queue";
+
+function op(kind: CrdtOp["kind"], docId = "n1", path = "a.md"): CrdtOp {
+	return { id: `op-${docId}`, kind, docId, payload: { path }, enqueuedAt: 0, attempts: 0 };
+}
+
+function chan(over: Partial<CrdtOpChannel> = {}): CrdtOpChannel {
+	return {
+		crdtCreate: vi.fn(async (docId: string) => docId),
+		crdtDelete: vi.fn(async (docId: string) => ({ doc_id: docId })),
+		...over,
+	};
+}
+
+describe("makeCrdtOpSend — success", () => {
+	it("create → ok, resolves onCreated with the authoritative server id (adopt)", async () => {
+		const onCreated = vi.fn();
+		const ch = chan({ crdtCreate: vi.fn(async () => "server-id") });
+		const send = makeCrdtOpSend({ channel: () => ch, onCreated, onTerminal: vi.fn() });
+
+		expect(await send(op("create", "local-id"))).toBe("ok");
+		expect(onCreated).toHaveBeenCalledWith("local-id", "server-id", "a.md");
+	});
+
+	it("delete → ok, fires onDeleted", async () => {
+		const onDeleted = vi.fn();
+		const send = makeCrdtOpSend({
+			channel: () => chan(),
+			onCreated: vi.fn(),
+			onDeleted,
+			onTerminal: vi.fn(),
+		});
+		expect(await send(op("delete"))).toBe("ok");
+		expect(onDeleted).toHaveBeenCalledWith("n1");
+	});
+
+	it("a post-ack onCreated throw is swallowed — the create still counts as ok", async () => {
+		const send = makeCrdtOpSend({
+			channel: () => chan(),
+			onCreated: vi.fn(async () => {
+				throw new Error("body seed failed");
+			}),
+			onTerminal: vi.fn(),
+		});
+		expect(await send(op("create"))).toBe("ok");
+	});
+});
+
+describe("makeCrdtOpSend — no socket", () => {
+	it("returns error (hold + retry) when the channel is null", async () => {
+		const send = makeCrdtOpSend({ channel: () => null, onCreated: vi.fn(), onTerminal: vi.fn() });
+		expect(await send(op("create"))).toBe("error");
+	});
+});
+
+describe("makeCrdtOpSend — error taxonomy", () => {
+	function sendThatRejects(reason: string) {
+		const ch = chan({
+			crdtCreate: vi.fn(async () => {
+				throw new CrdtOpError(reason, "crdt_create");
+			}),
+		});
+		return { ch };
+	}
+
+	it("terminal reason → ok (removed) AND onTerminal fires", async () => {
+		const onTerminal = vi.fn();
+		const { ch } = sendThatRejects("id_conflict");
+		const send = makeCrdtOpSend({ channel: () => ch, onCreated: vi.fn(), onTerminal });
+		expect(await send(op("create"))).toBe("ok");
+		expect(onTerminal).toHaveBeenCalledWith(
+			expect.objectContaining({ docId: "n1" }),
+			"id_conflict",
+		);
+	});
+
+	it("limit reason → error (retryable) AND onLimit fires once across retries", async () => {
+		const onLimit = vi.fn();
+		const { ch } = sendThatRejects("notes_cap_reached");
+		const send = makeCrdtOpSend({
+			channel: () => ch,
+			onCreated: vi.fn(),
+			onTerminal: vi.fn(),
+			onLimit,
+		});
+		const o = op("create");
+		expect(await send(o)).toBe("error");
+		expect(await send(o)).toBe("error"); // retry
+		expect(onLimit).toHaveBeenCalledTimes(1); // surfaced once per op
+	});
+
+	it("timeout reason → timeout (retryable)", async () => {
+		const { ch } = sendThatRejects("timeout");
+		const send = makeCrdtOpSend({ channel: () => ch, onCreated: vi.fn(), onTerminal: vi.fn() });
+		expect(await send(op("create"))).toBe("timeout");
+	});
+
+	it("unknown/transient reason (rate_limited) → error (retryable)", async () => {
+		const { ch } = sendThatRejects("rate_limited");
+		const send = makeCrdtOpSend({ channel: () => ch, onCreated: vi.fn(), onTerminal: vi.fn() });
+		expect(await send(op("create"))).toBe("error");
+	});
+});

--- a/frontend/src/crdt/op-dispatch.ts
+++ b/frontend/src/crdt/op-dispatch.ts
@@ -1,0 +1,112 @@
+/**
+ * The `send` function for the durable CrdtOpQueue: dispatches a held CRDT op
+ * (create / delete) over the current channel and maps the outcome to the
+ * queue's tri-state result. Mirrors the plugin's `crdt-op-dispatch.ts` error
+ * taxonomy exactly (issue #1030) so the two interfaces retry/drop identically.
+ *
+ * Pure aside from the injected `channel()` / hooks, so the taxonomy is
+ * unit-testable without a real socket.
+ *
+ * Error taxonomy (backend reasons from crdt_channel.ex):
+ *  - server ok                       → "ok"  (delivered; queue drops it)
+ *  - RETRYABLE reject                → "error" / "timeout" (queue retries):
+ *      rate_limited, recently_deleted (delete-wins window), the synthetic
+ *      `disconnected` (no socket), any unstructured failure; a timeout.
+ *  - LIMIT reject                    → "error" (RETRYABLE) AND routed through
+ *      onLimit so the user is TOLD once: notes_cap_reached is a transient plan
+ *      cap that self-delivers once the user frees a note / upgrades.
+ *  - TERMINAL reject                 → "ok" to REMOVE it (retrying cannot help)
+ *      BUT routed through onTerminal so it is logged, never silently vanished:
+ *      id_conflict, version_conflict, bad_doc_id, implausible_state_vector.
+ *
+ * A stuck retryable/limit op is still bounded: the queue drops it after
+ * MAX_ATTEMPTS or OP_TTL_MS, so nothing retries forever.
+ */
+
+import { CrdtOpError } from "../api/crdt-ops";
+import type { CrdtOp, SendResult } from "./op-queue";
+
+/** Server reasons where a retry cannot succeed. Remove the op (surfaced). */
+export const TERMINAL_REASONS: ReadonlySet<string> = new Set([
+	"id_conflict",
+	"version_conflict",
+	"bad_doc_id",
+	"implausible_state_vector",
+]);
+
+/** Server reasons that are TRANSIENT plan limits: the user can clear them (free
+ *  a note, upgrade). Retry (bounded) AND surface to the user, never drop after
+ *  one attempt like a terminal reason. */
+export const LIMIT_REASONS: ReadonlySet<string> = new Set(["notes_cap_reached"]);
+
+/** The two acked socket calls the queue dispatches over. `docId → serverId`
+ *  for create (the authoritative id, DIFFERENT on adopt); delete just acks. */
+export interface CrdtOpChannel {
+	crdtCreate(docId: string, path: string): Promise<string>;
+	crdtDelete(docId: string): Promise<{ doc_id: string }>;
+}
+
+export interface CrdtSendHooks {
+	/** The current channel, or null when no socket is up (→ hold + retry). */
+	channel: () => CrdtOpChannel | null;
+	/** A create acked: serverId is AUTHORITATIVE (differs on ADOPT). Resolves the
+	 *  caller's promise + remaps the cache id. A throw here is swallowed — the
+	 *  row already exists, the create must not retry. */
+	onCreated: (localId: string, serverId: string, path: string) => void | Promise<void>;
+	/** A delete acked. Resolves the caller's promise. */
+	onDeleted?: (docId: string) => void;
+	/** A terminally-failed op about to be dropped. Surface it (error log). */
+	onTerminal: (op: CrdtOp, reason: string) => void;
+	/** A retryable PLAN-LIMIT reject (e.g. notes_cap_reached). Surface once (toast);
+	 *  the op is still retried (bounded) so it delivers once the cap clears. */
+	onLimit?: (op: CrdtOp, reason: string) => void;
+}
+
+/** The server `reason` from a rejection, or null for an unstructured failure. */
+export function crdtOpFailureReason(err: unknown): string | null {
+	return err instanceof CrdtOpError ? err.reason : null;
+}
+
+/** Build the queue's `send`. */
+export function makeCrdtOpSend(hooks: CrdtSendHooks): (op: CrdtOp) => Promise<SendResult> {
+	// Surface each op's limit block ONCE: the queue retries it on backoff up to
+	// MAX_ATTEMPTS, and a toast per retry would spam the user.
+	const limitSurfaced = new Set<string>();
+	return async (op) => {
+		const ch = hooks.channel();
+		if (!ch) {
+			return "error"; // no socket yet — hold and retry on the next tick
+		}
+		try {
+			if (op.kind === "create") {
+				const path = (op.payload as { path?: string })?.path ?? "";
+				const serverId = await ch.crdtCreate(op.docId, path);
+				try {
+					await hooks.onCreated(op.docId, serverId, path);
+				} catch {
+					// crdtCreate already ACKED: the row exists (possibly remapped). A
+					// post-ack step throwing must NOT retry the create — that would
+					// duplicate/misroute the row. The body self-heals on the next edit.
+				}
+			} else {
+				await ch.crdtDelete(op.docId);
+				hooks.onDeleted?.(op.docId);
+			}
+			return "ok";
+		} catch (err) {
+			const reason = crdtOpFailureReason(err);
+			if (reason && LIMIT_REASONS.has(reason)) {
+				if (!limitSurfaced.has(op.id)) {
+					limitSurfaced.add(op.id);
+					hooks.onLimit?.(op, reason); // tell the user, once
+				}
+				return "error"; // RETRYABLE (bounded): the cap clears when a note is freed
+			}
+			if (reason && TERMINAL_REASONS.has(reason)) {
+				hooks.onTerminal(op, reason); // must not vanish; must not retry forever
+				return "ok"; // remove from the queue
+			}
+			return reason === "timeout" ? "timeout" : "error";
+		}
+	};
+}

--- a/frontend/src/crdt/op-queue-controller.test.ts
+++ b/frontend/src/crdt/op-queue-controller.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { CrdtOpError } from "../api/crdt-ops";
+import type { CrdtOpChannel } from "./op-dispatch";
+import type { CrdtOp } from "./op-queue";
+import { CrdtOpQueueController, type CrdtOpQueueControllerDeps } from "./op-queue-controller";
+import type { Persister } from "./op-queue-persist";
+
+const memPersister = (): Persister => {
+	let ops: CrdtOp[] = [];
+	return {
+		load: async () => ops,
+		save: async (o) => {
+			ops = o;
+		},
+		clear: async () => {
+			ops = [];
+		},
+	};
+};
+
+let idc = 0;
+function makeController(over: Partial<CrdtOpQueueControllerDeps> = {}) {
+	idc = 0;
+	const remapId = vi.fn();
+	const onDropSurfaced = vi.fn();
+	const onLimitSurfaced = vi.fn();
+	const ctrl = new CrdtOpQueueController({
+		channel: over.channel ?? (() => okChannel),
+		remapId,
+		onDropSurfaced,
+		onLimitSurfaced,
+		persister: over.persister ?? memPersister(),
+		mintId: () => `op-${++idc}`,
+		now: () => 1000,
+		tickMs: 1_000_000, // never auto-tick; drive via joined()/enqueue kick
+		queueOptions: over.queueOptions,
+	});
+	return { ctrl, remapId, onDropSurfaced, onLimitSurfaced };
+}
+
+const okChannel: CrdtOpChannel = {
+	crdtCreate: async (docId: string) => docId, // echoes id (no adopt)
+	crdtDelete: async (docId: string) => ({ doc_id: docId }),
+};
+
+describe("CrdtOpQueueController — settlement", () => {
+	it("holds a create until joined, then resolves with the server id", async () => {
+		const { ctrl } = makeController();
+		const p = ctrl.enqueueCreate("a", "a.md");
+		expect(ctrl.size()).toBe(1); // held — not joined
+		let settled = false;
+		p.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		await ctrl.joined();
+		await expect(p).resolves.toBe("a");
+		expect(ctrl.size()).toBe(0);
+	});
+
+	it("remaps the cache id and resolves with the server id on ADOPT", async () => {
+		const adoptChannel: CrdtOpChannel = {
+			crdtCreate: async () => "server-adopted",
+			crdtDelete: async (d) => ({ doc_id: d }),
+		};
+		const { ctrl, remapId } = makeController({ channel: () => adoptChannel });
+		await ctrl.joined();
+		await expect(ctrl.enqueueCreate("local", "a.md")).resolves.toBe("server-adopted");
+		expect(remapId).toHaveBeenCalledWith("local", "server-adopted");
+	});
+
+	it("resolves a delete once acked", async () => {
+		const { ctrl } = makeController();
+		await ctrl.joined();
+		await expect(ctrl.enqueueDelete("a")).resolves.toEqual({ doc_id: "a" });
+	});
+
+	it("rejects with the server reason on a terminal failure and surfaces it", async () => {
+		const terminalChannel: CrdtOpChannel = {
+			crdtCreate: async () => {
+				throw new CrdtOpError("id_conflict", "crdt_create");
+			},
+			crdtDelete: async (d) => ({ doc_id: d }),
+		};
+		const { ctrl, onDropSurfaced } = makeController({ channel: () => terminalChannel });
+		await ctrl.joined();
+		await expect(ctrl.enqueueCreate("a", "a.md")).rejects.toMatchObject({ reason: "id_conflict" });
+		expect(onDropSurfaced).toHaveBeenCalledWith(
+			expect.objectContaining({ docId: "a" }),
+			"terminal",
+		);
+	});
+
+	it("rejects the prior caller as superseded when a newer op replaces it", async () => {
+		const { ctrl } = makeController();
+		const create = ctrl.enqueueCreate("a", "a.md"); // held (not joined)
+		const del = ctrl.enqueueDelete("a"); // supersedes the create
+		await expect(create).rejects.toMatchObject({ reason: "superseded" });
+		await ctrl.joined();
+		await expect(del).resolves.toEqual({ doc_id: "a" });
+	});
+
+	it("rejects a dropped op (overflow) and surfaces the drop", async () => {
+		const { ctrl, onDropSurfaced } = makeController({ queueOptions: { maxQueue: 1 } });
+		const first = ctrl.enqueueCreate("a", "a.md"); // held
+		const second = ctrl.enqueueCreate("b", "b.md"); // overflow → evicts "a"
+		await expect(first).rejects.toMatchObject({ reason: "overflow" });
+		expect(onDropSurfaced).toHaveBeenCalledWith(
+			expect.objectContaining({ docId: "a" }),
+			"overflow",
+		);
+		// second still deliverable
+		await ctrl.joined();
+		await expect(second).resolves.toBe("b");
+	});
+
+	it("surfaces a plan-limit reject once and keeps the op pending (retryable)", async () => {
+		const limitChannel: CrdtOpChannel = {
+			crdtCreate: async () => {
+				throw new CrdtOpError("notes_cap_reached", "crdt_create");
+			},
+			crdtDelete: async (d) => ({ doc_id: d }),
+		};
+		const { ctrl, onLimitSurfaced } = makeController({ channel: () => limitChannel });
+		await ctrl.joined();
+		const p = ctrl.enqueueCreate("a", "a.md");
+		let settled = false;
+		p.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+		await Promise.resolve();
+		expect(settled).toBe(false); // still pending — will retry
+		expect(onLimitSurfaced).toHaveBeenCalledWith(
+			expect.objectContaining({ docId: "a" }),
+			"notes_cap_reached",
+		);
+		expect(ctrl.size()).toBe(1);
+	});
+
+	it("stop() rejects still-pending callers as disconnected", async () => {
+		const { ctrl } = makeController();
+		const p = ctrl.enqueueCreate("a", "a.md"); // held
+		ctrl.stop();
+		await expect(p).rejects.toMatchObject({ reason: "disconnected" });
+	});
+
+	it("start() restores persisted ops", async () => {
+		const persister = memPersister();
+		await persister.save([
+			{
+				id: "op-x",
+				kind: "create",
+				docId: "x",
+				payload: { path: "x.md" },
+				enqueuedAt: 1000,
+				attempts: 0,
+			},
+		]);
+		const { ctrl } = makeController({ persister });
+		await ctrl.start();
+		expect(ctrl.size()).toBe(1);
+		await ctrl.joined();
+		expect(ctrl.size()).toBe(0); // delivered
+		ctrl.stop();
+	});
+});

--- a/frontend/src/crdt/op-queue-controller.ts
+++ b/frontend/src/crdt/op-queue-controller.ts
@@ -1,0 +1,186 @@
+/**
+ * Owns the durable CrdtOpQueue for one live connection and bridges it to the
+ * callers (issue #1030). `enqueueCreate` / `enqueueDelete` return a promise that
+ * settles on the op's FINAL outcome — resolve on server ack (the authoritative
+ * id for create), reject on terminal drop (ttl / overflow / max-attempts /
+ * terminal server reason). So the TanStack mutations keep their optimistic /
+ * rollback shape: the promise just stays pending while offline (the op is HELD)
+ * and completes on reconnect instead of rejecting.
+ *
+ * The queue + dispatch + persister are all deterministic/injected, so this
+ * controller is unit-testable without a real socket or IndexedDB.
+ */
+
+import { CrdtOpError } from "../api/crdt-ops";
+import { type CrdtOpChannel, type CrdtSendHooks, makeCrdtOpSend } from "./op-dispatch";
+import { type CrdtOp, CrdtOpQueue, type CrdtOpQueueOptions, type DropReason } from "./op-queue";
+import type { Persister } from "./op-queue-persist";
+
+interface Deferred<T> {
+	resolve: (v: T) => void;
+	reject: (e: unknown) => void;
+}
+
+function opEvent(op: CrdtOp): string {
+	return op.kind === "create" ? "crdt_create" : "crdt_delete";
+}
+
+/** How often (ms) to drive queued retries while joined. Matches the plugin. */
+export const TICK_MS = 5000;
+
+export interface CrdtOpQueueControllerDeps {
+	/** The joined channel adapter, or null when no socket is up. */
+	channel: () => CrdtOpChannel | null;
+	/** Remap the cache id when a create ADOPTS a different live note (serverId
+	 *  differs from the minted localId). */
+	remapId: (localId: string, serverId: string) => void;
+	/** An op dropped without delivery — surface it (log + reconcile cache). */
+	onDropSurfaced: (op: CrdtOp, reason: DropReason | "terminal") => void;
+	/** A transient plan-limit block — surface once (upgrade toast). */
+	onLimitSurfaced: (op: CrdtOp, reason: string) => void;
+	persister: Persister;
+	mintId: () => string;
+	now?: () => number;
+	tickMs?: number;
+	queueOptions?: Partial<CrdtOpQueueOptions>;
+}
+
+export class CrdtOpQueueController {
+	private readonly queue: CrdtOpQueue;
+	private readonly deferreds = new Map<string, Deferred<unknown>>();
+	private readonly persister: Persister;
+	private readonly mintId: () => string;
+	private readonly now: () => number;
+	private readonly tickMs: number;
+	private tickTimer: ReturnType<typeof setInterval> | null = null;
+
+	constructor(deps: CrdtOpQueueControllerDeps) {
+		this.persister = deps.persister;
+		this.mintId = deps.mintId;
+		this.now = deps.now ?? (() => Date.now());
+		this.tickMs = deps.tickMs ?? TICK_MS;
+
+		const hooks: CrdtSendHooks = {
+			channel: deps.channel,
+			onCreated: (localId, serverId) => {
+				if (serverId !== localId) {
+					deps.remapId(localId, serverId);
+				}
+				this.settleResolve(localId, serverId);
+			},
+			onDeleted: (docId) => this.settleResolve(docId, { doc_id: docId }),
+			onTerminal: (op, reason) => {
+				this.settleReject(op.docId, new CrdtOpError(reason, opEvent(op)));
+				deps.onDropSurfaced(op, "terminal");
+			},
+			onLimit: (op, reason) => deps.onLimitSurfaced(op, reason),
+		};
+
+		this.queue = new CrdtOpQueue({
+			send: makeCrdtOpSend(hooks),
+			now: this.now,
+			options: deps.queueOptions,
+			onDrop: (op, reason) => {
+				this.settleReject(op.docId, new CrdtOpError(reason, opEvent(op)));
+				deps.onDropSurfaced(op, reason);
+			},
+		});
+	}
+
+	/** Load persisted ops, wire persistence, and start the retry ticker. */
+	async start(): Promise<void> {
+		this.queue.load(await this.persister.load());
+		this.queue.setPersist((ops) => this.persister.save(ops));
+		this.tickTimer = setInterval(() => this.kickTick(), this.tickMs);
+	}
+
+	/** Drive a flush, swallowing errors — retries resume on the next tick. */
+	private kickTick(): void {
+		this.queue.tick().catch(() => {
+			// a flush error is transient; the next tick re-drives due ops
+		});
+	}
+
+	/** CRDT topic (re)joined → flush held ops. */
+	joined(): Promise<void> {
+		return this.queue.onJoined();
+	}
+
+	/** CRDT topic dropped → hold sends until the next join. */
+	left(): void {
+		this.queue.onLeft();
+	}
+
+	/** Number of pending ops (for diagnostics / tests). */
+	size(): number {
+		return this.queue.size();
+	}
+
+	/**
+	 * Stop the ticker and reject any still-pending caller promises — the
+	 * connection is going away (teardown / vault switch); a held op belongs to the
+	 * OLD context and its persisted copy will reload under the new controller.
+	 */
+	stop(): void {
+		if (this.tickTimer !== null) {
+			clearInterval(this.tickTimer);
+			this.tickTimer = null;
+		}
+		this.queue.dispose();
+		for (const [docId, d] of this.deferreds) {
+			d.reject(new CrdtOpError("disconnected", `crdt_op:${docId}`));
+		}
+		this.deferreds.clear();
+	}
+
+	/** Enqueue a genesis create; resolves with the authoritative server id. */
+	enqueueCreate(docId: string, path: string): Promise<string> {
+		return this.enqueue<string>({ kind: "create", docId, payload: { path } });
+	}
+
+	/** Enqueue a delete; resolves once the server acks. */
+	enqueueDelete(docId: string): Promise<{ doc_id: string }> {
+		return this.enqueue<{ doc_id: string }>({ kind: "delete", docId, payload: {} });
+	}
+
+	private enqueue<T>(spec: Pick<CrdtOp, "kind" | "docId" | "payload">): Promise<T> {
+		// A newer op for the same doc supersedes the queued one — settle the prior
+		// caller so its promise doesn't hang (the note's fate is now the new op's).
+		const prior = this.deferreds.get(spec.docId);
+		if (prior) {
+			this.deferreds.delete(spec.docId);
+			prior.reject(new CrdtOpError("superseded", `crdt_op:${spec.docId}`));
+		}
+		const op: CrdtOp = {
+			id: this.mintId(),
+			kind: spec.kind,
+			docId: spec.docId,
+			payload: spec.payload,
+			enqueuedAt: this.now(),
+			attempts: 0,
+		};
+		return new Promise<T>((resolve, reject) => {
+			this.deferreds.set(spec.docId, { resolve: resolve as (v: unknown) => void, reject });
+			this.queue.enqueue(op);
+			// Kick an immediate flush so an op issued while joined sends now rather
+			// than waiting up to tickMs; a no-op when the topic isn't joined (held).
+			this.kickTick();
+		});
+	}
+
+	private settleResolve(docId: string, value: unknown): void {
+		const d = this.deferreds.get(docId);
+		if (d) {
+			this.deferreds.delete(docId);
+			d.resolve(value);
+		}
+	}
+
+	private settleReject(docId: string, err: unknown): void {
+		const d = this.deferreds.get(docId);
+		if (d) {
+			this.deferreds.delete(docId);
+			d.reject(err);
+		}
+	}
+}

--- a/frontend/src/crdt/op-queue-persist.test.ts
+++ b/frontend/src/crdt/op-queue-persist.test.ts
@@ -1,0 +1,57 @@
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { CrdtOp } from "./op-queue";
+import { createIndexedDbPersister } from "./op-queue-persist";
+
+function op(docId: string): CrdtOp {
+	return {
+		id: `op-${docId}`,
+		kind: "create",
+		docId,
+		payload: { path: `${docId}.md` },
+		enqueuedAt: 1,
+		attempts: 0,
+	};
+}
+
+// Fresh DB per test so state never bleeds.
+beforeEach(async () => {
+	await new Promise<void>((resolve) => {
+		const req = indexedDB.deleteDatabase("engram-crdt-queue");
+		req.onsuccess = () => resolve();
+		req.onerror = () => resolve();
+		req.onblocked = () => resolve();
+	});
+});
+
+describe("createIndexedDbPersister", () => {
+	it("round-trips a saved op list", async () => {
+		const p = createIndexedDbPersister("u1", "v1");
+		expect(await p.load()).toEqual([]); // empty to start
+		await p.save([op("a"), op("b")]);
+		expect(await p.load()).toEqual([op("a"), op("b")]);
+	});
+
+	it("scopes by (user, vault) — a different vault sees its own queue", async () => {
+		const p1 = createIndexedDbPersister("u1", "v1");
+		const p2 = createIndexedDbPersister("u1", "v2");
+		await p1.save([op("a")]);
+		await p2.save([op("z")]);
+		expect(await p1.load()).toEqual([op("a")]);
+		expect(await p2.load()).toEqual([op("z")]);
+	});
+
+	it("saving an empty list clears the key (no residue)", async () => {
+		const p = createIndexedDbPersister("u1", "v1");
+		await p.save([op("a")]);
+		await p.save([]);
+		expect(await p.load()).toEqual([]);
+	});
+
+	it("clear() removes the persisted queue", async () => {
+		const p = createIndexedDbPersister("u1", "v1");
+		await p.save([op("a")]);
+		await p.clear();
+		expect(await p.load()).toEqual([]);
+	});
+});

--- a/frontend/src/crdt/op-queue-persist.ts
+++ b/frontend/src/crdt/op-queue-persist.ts
@@ -1,0 +1,111 @@
+/**
+ * IndexedDB persistence for the durable CRDT op queue (#1030). The queue holds
+ * only op DESCRIPTORS (create → { path }, delete → {}) — no note content — so
+ * this stores a tiny per-(user, vault) `CrdtOp[]` blob that survives a page
+ * reload. IndexedDB (not localStorage) because it is async, service-worker
+ * reachable, and the substrate a future PWA offline-vault will extend.
+ *
+ * Degrades to a no-op when IndexedDB is unavailable (private mode / SSR): the
+ * queue simply loses durability-across-reloads, keeping its in-memory guarantee.
+ */
+
+import type { CrdtOp } from "./op-queue";
+
+const DB_NAME = "engram-crdt-queue";
+const STORE = "ops";
+const DB_VERSION = 1;
+
+/** IndexedDB handle, or null when the API is absent. Opened lazily, once. */
+function openDb(): Promise<IDBDatabase | null> {
+	if (typeof indexedDB === "undefined") {
+		return Promise.resolve(null);
+	}
+	return new Promise((resolve) => {
+		let req: IDBOpenDBRequest;
+		try {
+			req = indexedDB.open(DB_NAME, DB_VERSION);
+		} catch {
+			resolve(null);
+			return;
+		}
+		req.onupgradeneeded = () => {
+			if (!req.result.objectStoreNames.contains(STORE)) {
+				req.result.createObjectStore(STORE);
+			}
+		};
+		req.onsuccess = () => resolve(req.result);
+		req.onerror = () => resolve(null); // treat any open failure as "no store"
+		req.onblocked = () => resolve(null);
+	});
+}
+
+function tx<T>(
+	db: IDBDatabase,
+	mode: IDBTransactionMode,
+	run: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const store = db.transaction(STORE, mode).objectStore(STORE);
+		const req = run(store);
+		req.onsuccess = () => resolve(req.result);
+		req.onerror = () => reject(req.error);
+	});
+}
+
+/**
+ * Open the DB, run `fn`, and ALWAYS close the connection afterwards — a lingering
+ * open handle blocks `deleteDatabase` and later `versionchange` upgrades. Returns
+ * `fallback` when the API is absent or anything throws (best-effort persistence).
+ */
+async function withDb<T>(fallback: T, fn: (db: IDBDatabase) => Promise<T>): Promise<T> {
+	const db = await openDb();
+	if (!db) {
+		return fallback;
+	}
+	try {
+		return await fn(db);
+	} catch {
+		return fallback;
+	} finally {
+		db.close();
+	}
+}
+
+/** A load/save target for the queue's persisted op list. */
+export interface Persister {
+	load(): Promise<CrdtOp[]>;
+	save(ops: CrdtOp[]): Promise<void>;
+	clear(): Promise<void>;
+}
+
+/**
+ * Build a Persister scoped to one (userId, vaultId) — its own key in the shared
+ * store, so switching vault / user reads a different queue and never bleeds ops
+ * across contexts.
+ */
+export function createIndexedDbPersister(userId: string, vaultId: string): Persister {
+	const key = `${userId}:${vaultId}`;
+	return {
+		load(): Promise<CrdtOp[]> {
+			return withDb<CrdtOp[]>([], async (db) => {
+				const raw = await tx<CrdtOp[] | undefined>(db, "readonly", (s) => s.get(key));
+				return Array.isArray(raw) ? raw : [];
+			});
+		},
+		save(ops: CrdtOp[]): Promise<void> {
+			return withDb<void>(undefined, async (db) => {
+				// Empty → delete the key so a drained queue leaves no residue.
+				if (ops.length > 0) {
+					await tx(db, "readwrite", (s) => s.put(ops, key));
+				} else {
+					await tx(db, "readwrite", (s) => s.delete(key));
+				}
+			});
+		},
+		clear(): Promise<void> {
+			return withDb<void>(undefined, async (db) => {
+				await tx(db, "readwrite", (s) => s.delete(key));
+			});
+		},
+	};
+}

--- a/frontend/src/crdt/op-queue.test.ts
+++ b/frontend/src/crdt/op-queue.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	BASE_BACKOFF_MS,
+	type CrdtOp,
+	CrdtOpQueue,
+	MAX_ATTEMPTS,
+	type SendResult,
+} from "./op-queue";
+
+// Deterministic clock: tests advance `clock` and call tick()/onJoined() to drive
+// retries — no real timers.
+let clock = 0;
+const now = () => clock;
+
+function op(docId: string, kind: CrdtOp["kind"] = "create", enqueuedAt = clock): CrdtOp {
+	return {
+		id: `op-${docId}`,
+		kind,
+		docId,
+		payload: { path: `${docId}.md` },
+		enqueuedAt,
+		attempts: 0,
+	};
+}
+
+beforeEach(() => {
+	clock = 0;
+});
+
+describe("CrdtOpQueue — enqueue-until-joined", () => {
+	it("holds ops until joined, then flushes them FIFO", async () => {
+		const sent: string[] = [];
+		const send = vi.fn(async (o: CrdtOp): Promise<SendResult> => {
+			sent.push(o.docId);
+			return "ok";
+		});
+		const q = new CrdtOpQueue({ send, now });
+
+		q.enqueue(op("a"));
+		q.enqueue(op("b"));
+		expect(send).not.toHaveBeenCalled(); // held — not joined
+		expect(q.size()).toBe(2);
+
+		await q.onJoined();
+		expect(sent).toEqual(["a", "b"]); // FIFO
+		expect(q.size()).toBe(0); // acked → removed
+	});
+
+	it("does not send after onLeft until the next join", async () => {
+		const send = vi.fn(async (): Promise<SendResult> => "ok");
+		const q = new CrdtOpQueue({ send, now });
+		await q.onJoined();
+		q.onLeft();
+		q.enqueue(op("a"));
+		await q.tick();
+		expect(send).not.toHaveBeenCalled();
+		await q.onJoined();
+		expect(send).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("CrdtOpQueue — ack + retry", () => {
+	it("removes an op only on ok and fires onAck", async () => {
+		const acked: string[] = [];
+		const send = vi.fn(async (): Promise<SendResult> => "ok");
+		const q = new CrdtOpQueue({ send, now, onAck: (o) => acked.push(o.docId) });
+		q.enqueue(op("a"));
+		await q.onJoined();
+		expect(acked).toEqual(["a"]);
+		expect(q.size()).toBe(0);
+	});
+
+	it("retries a failed op with exponential backoff, keeping it queued", async () => {
+		let result: SendResult = "error";
+		const send = vi.fn(async (): Promise<SendResult> => result);
+		const q = new CrdtOpQueue({ send, now });
+		q.enqueue(op("a"));
+
+		await q.onJoined(); // attempt 1 fails
+		expect(send).toHaveBeenCalledTimes(1);
+		expect(q.size()).toBe(1); // still queued
+
+		// Not yet due — backoff is BASE_BACKOFF_MS after the first failure.
+		clock += BASE_BACKOFF_MS - 1;
+		await q.tick();
+		expect(send).toHaveBeenCalledTimes(1); // not due
+
+		clock += 1; // now due
+		result = "ok";
+		await q.tick();
+		expect(send).toHaveBeenCalledTimes(2);
+		expect(q.size()).toBe(0);
+	});
+
+	it("treats timeout like a retryable error", async () => {
+		let result: SendResult = "timeout";
+		const send = vi.fn(async (): Promise<SendResult> => result);
+		const q = new CrdtOpQueue({ send, now });
+		q.enqueue(op("a"));
+		await q.onJoined();
+		expect(q.size()).toBe(1);
+		clock += BASE_BACKOFF_MS;
+		result = "ok";
+		await q.tick();
+		expect(q.size()).toBe(0);
+	});
+
+	it("drops after MAX_ATTEMPTS failures with onDrop 'max-attempts'", async () => {
+		const dropped: { docId: string; reason: string }[] = [];
+		const send = vi.fn(async (): Promise<SendResult> => "error");
+		const q = new CrdtOpQueue({
+			send,
+			now,
+			onDrop: (o, r) => dropped.push({ docId: o.docId, reason: r }),
+			options: { opTtlMs: 10_000_000 }, // large TTL so only max-attempts can drop it
+		});
+		q.enqueue(op("a"));
+		await q.onJoined();
+		// Drive enough ticks (advancing past each backoff) to exhaust attempts.
+		for (let i = 0; i < MAX_ATTEMPTS + 2; i++) {
+			clock += 60_000; // past any backoff ceiling
+			await q.tick();
+		}
+		expect(send).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+		expect(q.size()).toBe(0);
+		expect(dropped).toEqual([{ docId: "a", reason: "max-attempts" }]);
+	});
+});
+
+describe("CrdtOpQueue — coalesce + bounds", () => {
+	it("coalesces one op per docId (delete supersedes a pending create)", async () => {
+		const sent: CrdtOp[] = [];
+		const send = vi.fn(async (o: CrdtOp): Promise<SendResult> => {
+			sent.push(o);
+			return "ok";
+		});
+		const q = new CrdtOpQueue({ send, now });
+		q.enqueue(op("a", "create"));
+		q.enqueue(op("a", "delete")); // supersede
+		expect(q.size()).toBe(1);
+		await q.onJoined();
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.kind).toBe("delete");
+	});
+
+	it("drops the oldest pending op on overflow (onDrop 'overflow')", async () => {
+		const dropped: string[] = [];
+		const send = vi.fn(async (): Promise<SendResult> => "ok");
+		const q = new CrdtOpQueue({
+			send,
+			now,
+			onDrop: (o, r) => r === "overflow" && dropped.push(o.docId),
+			options: { maxQueue: 2 },
+		});
+		q.enqueue(op("a"));
+		q.enqueue(op("b"));
+		q.enqueue(op("c")); // overflow → evict oldest "a"
+		expect(q.size()).toBe(2);
+		expect(dropped).toEqual(["a"]);
+	});
+});
+
+describe("CrdtOpQueue — TTL", () => {
+	it("drops an op past its TTL on flush instead of sending it (onDrop 'ttl')", async () => {
+		const dropped: string[] = [];
+		const send = vi.fn(async (): Promise<SendResult> => "ok");
+		const q = new CrdtOpQueue({
+			send,
+			now,
+			onDrop: (o, r) => r === "ttl" && dropped.push(o.docId),
+			options: { opTtlMs: 1000 },
+		});
+		q.enqueue(op("a", "create", 0));
+		clock = 1001; // aged past TTL while offline
+		await q.onJoined();
+		expect(send).not.toHaveBeenCalled();
+		expect(dropped).toEqual(["a"]);
+		expect(q.size()).toBe(0);
+	});
+});
+
+describe("CrdtOpQueue — load (restore)", () => {
+	it("prunes TTL-expired ops, resets attempts, and honors maxQueue", async () => {
+		const dropped: { docId: string; reason: string }[] = [];
+		const send = vi.fn(async (): Promise<SendResult> => "ok");
+		clock = 10_000;
+		const q = new CrdtOpQueue({
+			send,
+			now,
+			onDrop: (o, r) => dropped.push({ docId: o.docId, reason: r }),
+			options: { opTtlMs: 5000, maxQueue: 2 },
+		});
+		q.load([
+			{ ...op("stale", "create", 0), attempts: 4 }, // 10s old > 5s TTL → pruned
+			{ ...op("x", "create", 8000), attempts: 4 },
+			{ ...op("y", "create", 9000), attempts: 4 },
+			{ ...op("z", "create", 9500), attempts: 4 }, // over maxQueue → evict oldest kept
+		]);
+		expect(dropped).toContainEqual({ docId: "stale", reason: "ttl" });
+		expect(q.size()).toBe(2);
+		// attempts reset → all deliver in one joined flush
+		await q.onJoined();
+		expect(q.size()).toBe(0);
+	});
+});
+
+describe("CrdtOpQueue — persistence", () => {
+	it("debounces persist writes across rapid mutations", async () => {
+		vi.useFakeTimers();
+		try {
+			const persist = vi.fn();
+			const send = vi.fn(async (): Promise<SendResult> => "ok");
+			const q = new CrdtOpQueue({ send, now, persistDelayMs: 1000 });
+			q.setPersist(persist);
+			q.enqueue(op("a"));
+			q.enqueue(op("b"));
+			q.enqueue(op("c"));
+			expect(persist).not.toHaveBeenCalled(); // debounced
+			vi.advanceTimersByTime(1000);
+			expect(persist).toHaveBeenCalledTimes(1);
+			expect(persist.mock.calls[0]?.[0]).toHaveLength(3);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/frontend/src/crdt/op-queue.ts
+++ b/frontend/src/crdt/op-queue.ts
@@ -1,0 +1,305 @@
+/**
+ * CRDT outbound op queue: a durable, bounded, hold-and-retry buffer for the web
+ * SPA's terminal CRDT socket ops (create / delete). A faithful mirror of the
+ * plugin's `crdt-op-queue.ts` (Engram-obsidian #251) — hold the constants and
+ * semantics identical so the two interfaces give the same reliability guarantee
+ * (issue #1030).
+ *
+ * Ops enqueued while the CRDT topic is not joined are HELD; nothing is sent
+ * until `onJoined()` fires. Sends are retried with exponential backoff on
+ * failure, coalesced per docId (one pending op per docId, newest supersedes),
+ * bounded in count, and dropped once they age past a TTL.
+ *
+ * Pure logic: every side-effecting dep (send, clock, drop/ack notify) is
+ * injected and retries are driven off the injected clock via `tick()`, so the
+ * whole thing is deterministic under test — no real timers, no real socket.
+ *
+ * Live-edit `crdt_msg` updates are deliberately NOT queued here (they self-heal
+ * via the Yjs sync protocol on reconnect) — matching the plugin. Only genesis
+ * create + delete ride this queue.
+ */
+
+/** One outbound CRDT op. `attempts` counts failed send attempts so far. */
+export interface CrdtOp {
+	id: string;
+	kind: "create" | "delete";
+	docId: string;
+	payload: unknown;
+	enqueuedAt: number;
+	attempts: number;
+}
+
+/** Why an op was dropped without being acked. */
+export type DropReason = "ttl" | "overflow" | "max-attempts";
+
+/** Result of an outbound send attempt. */
+export type SendResult = "ok" | "error" | "timeout";
+
+/** Max distinct pending docId ops. Bounds memory across long offline spells;
+ *  overflow drops the oldest pending op rather than growing unbounded. */
+export const MAX_QUEUE = 500;
+
+/** Ops older than this (by `enqueuedAt`) are stale and dropped, never sent. A
+ *  CRDT op held 5 min past creation is better dropped than delivered late — the
+ *  peer reconverges via full sync, so a late op only causes churn. */
+export const OP_TTL_MS = 5 * 60 * 1000;
+
+/** Give up (drop + notify) after this many failed send attempts. */
+export const MAX_ATTEMPTS = 8;
+
+/** First retry delay; each subsequent retry doubles it up to MAX_BACKOFF_MS. */
+export const BASE_BACKOFF_MS = 500;
+
+/** Ceiling on retry backoff so a persistently-failing op still gets retried
+ *  roughly twice a minute rather than backing off into hours. */
+export const MAX_BACKOFF_MS = 30_000;
+
+/** Default persist debounce, coalescing rapid mutations into one write. */
+export const PERSIST_DELAY_MS = 1000;
+
+export interface CrdtOpQueueOptions {
+	maxQueue: number;
+	opTtlMs: number;
+	maxAttempts: number;
+	baseBackoffMs: number;
+	maxBackoffMs: number;
+}
+
+export interface CrdtOpQueueDeps {
+	send: (op: CrdtOp) => Promise<SendResult>;
+	now: () => number;
+	/** An op removed from the queue on a server `ok` (delivered). */
+	onAck?: (op: CrdtOp) => void;
+	/** An op dropped without delivery (ttl / overflow / max-attempts). */
+	onDrop?: (op: CrdtOp, reason: DropReason) => void;
+	options?: Partial<CrdtOpQueueOptions>;
+	persistDelayMs?: number;
+}
+
+export const DEFAULT_OPTIONS: CrdtOpQueueOptions = {
+	maxQueue: MAX_QUEUE,
+	opTtlMs: OP_TTL_MS,
+	maxAttempts: MAX_ATTEMPTS,
+	baseBackoffMs: BASE_BACKOFF_MS,
+	maxBackoffMs: MAX_BACKOFF_MS,
+};
+
+/** Internal record: the op plus the clock time at which it may next be sent. */
+export interface Entry {
+	op: CrdtOp;
+	nextAttemptAt: number;
+}
+
+export class CrdtOpQueue {
+	/** Keyed by docId → at most one pending op per doc (newest supersedes). */
+	private readonly entries: Map<string, Entry> = new Map();
+	private joined = false;
+	/** Re-entrancy guard so overlapping flush/tick calls don't double-send. */
+	private flushing = false;
+
+	private readonly send: (op: CrdtOp) => Promise<SendResult>;
+	private readonly now: () => number;
+	private readonly onAck?: (op: CrdtOp) => void;
+	private readonly onDrop?: (op: CrdtOp, reason: DropReason) => void;
+	private readonly opts: CrdtOpQueueOptions;
+
+	private persistFn: ((ops: CrdtOp[]) => Promise<void> | void) | null = null;
+	private persistTimer: ReturnType<typeof setTimeout> | null = null;
+	private readonly persistDelayMs: number;
+
+	constructor(deps: CrdtOpQueueDeps) {
+		this.send = deps.send;
+		this.now = deps.now;
+		this.onAck = deps.onAck;
+		this.onDrop = deps.onDrop;
+		this.opts = { ...DEFAULT_OPTIONS, ...deps.options };
+		this.persistDelayMs = deps.persistDelayMs ?? PERSIST_DELAY_MS;
+	}
+
+	/** Number of distinct pending ops (docIds). */
+	size(): number {
+		return this.entries.size;
+	}
+
+	/** Flat snapshot of pending ops, for the persist blob. */
+	all(): CrdtOp[] {
+		return this.pending();
+	}
+
+	/** Register a callback to persist the flat pending op list. */
+	setPersist(fn: (ops: CrdtOp[]) => Promise<void> | void): void {
+		this.persistFn = fn;
+	}
+
+	/**
+	 * Restore persisted ops on startup. Prunes any op already past `opTtlMs`
+	 * (fires onDrop "ttl") so a long downtime never resurrects stale ops, and
+	 * never restores more than `maxQueue` (oldest-first, dropping the excess).
+	 * `attempts`/`nextAttemptAt` are transient scheduling state and are reset: a
+	 * reloaded op gets a fresh retry budget and is due immediately.
+	 */
+	load(ops: CrdtOp[]): void {
+		this.entries.clear();
+		const now = this.now();
+		for (const op of ops) {
+			if (now - op.enqueuedAt > this.opts.opTtlMs) {
+				this.onDrop?.(op, "ttl");
+				continue;
+			}
+			if (this.entries.size >= this.opts.maxQueue) {
+				this.evictOldest();
+			}
+			this.entries.set(op.docId, { op: { ...op, attempts: 0 }, nextAttemptAt: 0 });
+		}
+	}
+
+	/** Cancel any pending persist timer. Call on teardown / vault switch. */
+	dispose(): void {
+		if (this.persistTimer !== null) {
+			clearTimeout(this.persistTimer);
+			this.persistTimer = null;
+		}
+	}
+
+	/**
+	 * Add an op. Coalesced by docId: a newer op replaces any pending op for the
+	 * same doc (delete supersedes create, latest wins). A brand-new docId beyond
+	 * `maxQueue` evicts the oldest pending op (onDrop "overflow"). Does not send
+	 * until the channel is joined.
+	 */
+	enqueue(op: CrdtOp): void {
+		const existing = this.entries.get(op.docId);
+		if (existing) {
+			// Supersede in place; Map keeps the original FIFO slot for this docId.
+			this.entries.set(op.docId, { op, nextAttemptAt: 0 });
+			this.schedulePersist();
+			return;
+		}
+		if (this.entries.size >= this.opts.maxQueue) {
+			this.evictOldest();
+		}
+		this.entries.set(op.docId, { op, nextAttemptAt: 0 });
+		this.schedulePersist();
+	}
+
+	/** Channel joined: flush all held ops FIFO, retrying failures via backoff. */
+	async onJoined(): Promise<void> {
+		this.joined = true;
+		await this.flush();
+	}
+
+	/** Channel dropped: hold further sends until the next join. */
+	onLeft(): void {
+		this.joined = false;
+	}
+
+	/**
+	 * Drive retries: send every op that is due (nextAttemptAt <= now) and not
+	 * TTL-expired. Call after advancing the clock. No-op until joined.
+	 */
+	async tick(): Promise<void> {
+		await this.flush();
+	}
+
+	private evictOldest(): void {
+		const first = this.entries.keys().next();
+		if (first.done) {
+			return;
+		}
+		const entry = this.entries.get(first.value);
+		this.entries.delete(first.value);
+		if (entry) {
+			this.onDrop?.(entry.op, "overflow");
+		}
+		this.schedulePersist();
+	}
+
+	/** Drop and notify if the op has aged past its TTL. Returns true if dropped. */
+	private dropIfExpired(docId: string, entry: Entry): boolean {
+		if (this.now() - entry.op.enqueuedAt <= this.opts.opTtlMs) {
+			return false;
+		}
+		this.entries.delete(docId);
+		this.onDrop?.(entry.op, "ttl");
+		this.schedulePersist();
+		return true;
+	}
+
+	/** Flat snapshot of pending ops, for persistence. */
+	private pending(): CrdtOp[] {
+		return [...this.entries.values()].map((e) => e.op);
+	}
+
+	/** Debounced persist: coalesces rapid mutations into one write. */
+	private schedulePersist(): void {
+		if (!this.persistFn || this.persistTimer !== null) {
+			return;
+		}
+		this.persistTimer = setTimeout(() => {
+			this.persistTimer = null;
+			// Fire the (possibly async) persister; swallow its rejection — a failed
+			// write just means the queue isn't durable across a reload this once.
+			const written = this.persistFn?.(this.pending());
+			if (written instanceof Promise) {
+				written.catch(() => {
+					// best-effort persistence; a failed write just skips durability once
+				});
+			}
+		}, this.persistDelayMs);
+	}
+
+	private backoffFor(attempts: number): number {
+		// attempts = number of failures so far (>=1): base, base*2, base*4, ...
+		const delay = this.opts.baseBackoffMs * 2 ** (attempts - 1);
+		return Math.min(delay, this.opts.maxBackoffMs);
+	}
+
+	private async flush(): Promise<void> {
+		if (!this.joined || this.flushing) {
+			return;
+		}
+		this.flushing = true;
+		try {
+			// Snapshot keys so eviction/supersede during iteration is safe.
+			for (const docId of [...this.entries.keys()]) {
+				const entry = this.entries.get(docId);
+				if (!entry) {
+					continue;
+				}
+				if (this.dropIfExpired(docId, entry)) {
+					continue;
+				}
+				if (entry.nextAttemptAt > this.now()) {
+					continue;
+				}
+				await this.attempt(docId, entry);
+			}
+		} finally {
+			this.flushing = false;
+		}
+	}
+
+	private async attempt(docId: string, entry: Entry): Promise<void> {
+		const result = await this.send(entry.op);
+		// The op may have been superseded/evicted while send was in flight; only
+		// act on it if this exact entry is still the pending one.
+		if (this.entries.get(docId) !== entry) {
+			return;
+		}
+
+		if (result === "ok") {
+			this.entries.delete(docId);
+			this.onAck?.(entry.op);
+			this.schedulePersist();
+			return;
+		}
+		entry.op.attempts += 1;
+		if (entry.op.attempts >= this.opts.maxAttempts) {
+			this.entries.delete(docId);
+			this.onDrop?.(entry.op, "max-attempts");
+			this.schedulePersist();
+			return;
+		}
+		entry.nextAttemptAt = this.now() + this.backoffFor(entry.op.attempts);
+	}
+}


### PR DESCRIPTION
Closes #1030 (P0). Gives the web SPA the same durable-socket-op reliability the plugin got in Engram-obsidian #251, so terminal CRDT ops (create/delete) are never silently lost under reconnect churn.

## The contract (mirrors the plugin)
- **Enqueue-until-joined** — an op issued before the CRDT topic is joined is HELD and flushed on join, not dropped.
- **Ack + retry** — each op awaits the server `ok`; on error/timeout/disconnect it retries with exponential backoff (500ms→30s) and re-flushes on reconnect; removed only on ack.
- **Idempotent at-least-once** → exactly-once outcome (dup update no-op, delete-of-deleted no-op, genesis adopt).
- **Bounded + strict TTL** — MAX_QUEUE=500 (drop-oldest overflow), OP_TTL_MS=5min, MAX_ATTEMPTS=8. Nothing retained forever; drops are logged (`rlog`), plan-cap blocks surface the upgrade toast. Constants held byte-identical to the plugin.

## Design
Built in 5 tested phases, all constants/taxonomy mirrored from the plugin so the two never diverge:
1. `crdt/op-queue.ts` — the pure bounded/TTL/backoff core (deterministic under an injected clock). **11 tests**
2. `crdt/op-dispatch.ts` — the queue's `send` + error taxonomy (terminal→remove+log, limit→retry+toast-once, timeout→retry). **8 tests**
3. `crdt/op-queue-persist.ts` — **IndexedDB** persister (not localStorage: async, service-worker-reachable, the substrate a future PWA offline-vault extends). Holds only op *descriptors* — no note content at rest. **4 tests**
4. `crdt/op-queue-controller.ts` — owns the queue for one connection; `enqueueCreate`/`enqueueDelete` return a promise that settles on final delivery (Model A), so the TanStack mutations keep their optimistic/rollback shape. **9 tests**
5. `api/channel.ts` wiring — instantiate per connection, drive the join gate off the CRDT sync-status subscription, 5s ticker, teardown on vault switch; flip `crdtCreateNote`/`crdtDeleteNote` to the queue.

**Scope:** create + delete only (faithful plugin mirror). Live-edit `crdt_msg` stays fire-and-forget (Yjs re-syncs on reconnect). Duplicate/`create_batch` (the one content-bearing op) stays reject-fast — a clean fast-follow.

## Behavior changes (both mirror the plugin)
- An offline create/delete **survives a reconnect** instead of rolling back (replaces the MVP "disable + reconnecting" policy).
- `notes_cap_reached` is **retryable** (immediate upgrade toast + bounded retry, self-delivers if the user frees a note) rather than an instant reject.

## Tests
32 new unit tests; updated `crdt-write-ops` + `channel-crdt` to the durable contract. Full frontend suite **886 green**, biome + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)