### PR TITLE
fix(crdt): guard checkpoint get_user raise from escaping terminate/2 (Refs #983)

### DIFF
--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -67,6 +67,19 @@ defmodule Engram.Notes.CrdtCheckpoint do
       user ->
         do_checkpoint(user, user_id, vault_id, note_id, doc, opts)
     end
+  rescue
+    # The user-resolve above is the ONE DB call outside do_checkpoint's rescue.
+    # Under pool starvation Accounts.get_user raises DBConnection.ConnectionError
+    # straight out of terminate/2 (the 2026-07-09 incident frame). Swallow ANY
+    # raise here so unbind/checkpoint always degrades to :ok — the tail-WAL is
+    # untouched (nothing pruned), so the flush replays on the next room bind.
+    err ->
+      Logger.error(
+        "crdt checkpoint raised resolving user note_id=#{note_id} error=#{Exception.format(:error, err, __STACKTRACE__)}",
+        Metadata.with_category(:error, :sync, note_id: note_id)
+      )
+
+      :ok
   end
 
   defp do_checkpoint(user, user_id, vault_id, note_id, doc, opts) do

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -1,5 +1,13 @@
 defmodule Engram.BillingTest do
-  use Engram.DataCase, async: true
+  # async: false — the "plan limit caching" tests exercise PlanCache, which lives
+  # in node-global :persistent_term, and one test calls the node-wide
+  # PlanCache.invalidate_all/0. A cache that is global and globally-invalidated is
+  # not isolatable per-test, so concurrent modules can wipe a warmed entry between
+  # a test's warm-read and its cached-read assertion (flaky `left: 99, right: 7`
+  # at "invalidate/1 reflects a runtime limit change"). This module is green in
+  # isolation; running it non-async keeps it that way. ponytail: async:false is
+  # the minimal fix; per-test PlanCache isolation would let it go async again.
+  use Engram.DataCase, async: false
 
   import Mox
 

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -94,6 +94,55 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     assert tail_count_after == 0
   end
 
+  # ── #983 task 2: user-resolve raise must NOT escape terminate/2 ────────────
+  # `checkpoint/5` runs on the room's `terminate/2` (unbind path). Its ONE DB
+  # call outside `do_checkpoint`'s rescue is `Accounts.get_user/1`. Under pool
+  # starvation that raises `DBConnection.ConnectionError` straight out of
+  # terminate/2 (the 2026-07-09 incident stack frame). It must degrade to `:ok`
+  # like `do_checkpoint` already does. A raising `get_user` is forced here with
+  # an un-castable id (any raise from the resolve step must be swallowed, not
+  # just ConnectionError) — the fix is a blanket function-level rescue.
+  test "checkpoint returns :ok (does not raise) when get_user raises", ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    {:ok, raw_note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, raw_state} = Crypto.decrypt_crdt_state(raw_note, user)
+    {:ok, doc} = CrdtBridge.doc_from_state(raw_state)
+    :ok = CrdtBridge.diff_into_text(Yex.Doc.get_text(doc, CrdtBridge.text_name()), "before AFTER")
+
+    # Seed a tail row so we can prove the degraded no-op does NOT prune it.
+    {:ok, {ct, n}} = Crypto.encrypt_crdt_state("fake_update", user, note.id)
+
+    Repo.with_tenant(user.id, fn ->
+      Repo.insert_all(CrdtUpdateLog, [
+        %{
+          id: Ecto.UUID.generate(),
+          note_id: note.id,
+          user_id: user.id,
+          vault_id: vault.id,
+          update_ciphertext: ct,
+          update_nonce: n,
+          inserted_at: DateTime.utc_now()
+        }
+      ])
+    end)
+
+    # "not-a-uuid" makes Accounts.get_user/1 raise Ecto.Query.CastError, standing
+    # in for the prod DBConnection.ConnectionError — both must be swallowed.
+    assert :ok = CrdtCheckpoint.checkpoint("not-a-uuid", vault.id, note.id, doc)
+
+    # Degraded to a no-op: content untouched and the tail row survives (data safe).
+    {:ok, fresh} = Notes.get_note(user, vault, "p.md")
+    assert fresh.content == "before"
+
+    {:ok, tail_after} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.aggregate(from(l in CrdtUpdateLog, where: l.note_id == ^note.id), :count)
+      end)
+
+    assert tail_after == 1
+  end
+
   # ── deliver-out gap: a web-editor edit (CRDT checkpoint) must reach clients ─
   # that are not actively enrolled in the note's room (e.g. Obsidian). REST/MCP
   # writes announce via CrdtDeliver; the checkpoint is the ONLY path that


### PR DESCRIPTION
## What

Closes the last open backend seam of the #983 p0 (unbind-checkpoint pool exhaustion). The bounding + Oban overflow half shipped in #984; this is **task 2** — the unguarded `get_user` raise.

`CrdtCheckpoint.checkpoint/5` runs on the CRDT room's `terminate/2` (unbind path). Its one DB call outside `do_checkpoint`'s rescue, `Accounts.get_user/1`, handled a `nil` (deleted user) but **not a raise**: under pool starvation it raises `DBConnection.ConnectionError` straight out of `terminate/2` — the exact frame in the 2026-07-09 incident stack. The `CheckpointGate` bounding reduces the storm but doesn't stop *other* load (REST/search/Oban) from starving this one read.

## Fix

A function-level `rescue` on `checkpoint/5` that logs and returns `:ok`, mirroring `do_checkpoint`. Any raise from the user-resolve now degrades to a no-op; the tail-WAL is untouched (nothing pruned), so the flush replays on the next room bind — **loss-free**.

## Tests

- New: `checkpoint returns :ok (does not raise) when get_user raises` — reproduces the raise-out (forces `get_user` to raise) and asserts `:ok` + content/tail preserved. Confirmed it fails (`CastError` at `crdt_checkpoint.ex:58`) before the fix, passes after.
- Acceptance #1 (bounded storm) and #3 (abort doesn't prune) already covered by existing backpressure/checkpoint tests.

## Also: BillingTest flake (surfaced by the full-suite gate)

The full suite had a pre-existing 1/3764 async flake: `BillingTest` "plan limit caching" exercises the node-global `:persistent_term` `PlanCache` and calls the node-wide `invalidate_all/0`, so a concurrent module could wipe a warmed entry mid-test (`left: 99, right: 7`). The module is green in isolation → made it `async: false`. Unrelated to the CRDT change but bundled so the suite is green here (per maintainer call).

## Scope notes

- Task 3 (batch per-user checkpoints) deliberately **not** done — the Oban overflow already caps pool pressure; per-user txn batching is speculative complexity. Left as a tuning knob on #983.
- Task 5 (lazy-enrollment) is plugin-side (flag-off in engram-app/Engram-obsidian#222).
- `Refs #983` not `Closes` — the umbrella issue also tracks the plugin lazy-enrollment work.

## Verification

- `mix test` (full): **3764 tests, 0 failures**
- `mix dialyzer`: **passed**
- `mix format --check-formatted` + `mix credo`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)