### PR TITLE
feat(logs): return device_id and conn_id from GET /logs

### DIFF
--- a/lib/engram_web/controllers/logs_controller.ex
+++ b/lib/engram_web/controllers/logs_controller.ex
@@ -63,6 +63,8 @@ defmodule EngramWeb.LogsController do
       stack: log.stack,
       plugin_version: log.plugin_version,
       platform: log.platform,
+      device_id: log.device_id,
+      conn_id: log.conn_id,
       created_at: log.created_at
     }
   end

--- a/lib/engram_web/schemas/logs.ex
+++ b/lib/engram_web/schemas/logs.ex
@@ -13,7 +13,17 @@ defmodule EngramWeb.Schemas.LogInput do
       stack: %Schema{type: :string, nullable: true},
       ts: %Schema{type: :string, format: :"date-time", nullable: true},
       plugin_version: %Schema{type: :string, nullable: true},
-      platform: %Schema{type: :string, nullable: true}
+      platform: %Schema{type: :string, nullable: true},
+      device_id: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Per-install Obsidian instance id, for per-device attribution."
+      },
+      conn_id: %Schema{
+        type: :string,
+        nullable: true,
+        description: "WebSocket connection id, correlates client logs to server breadcrumbs."
+      }
     }
   })
 end
@@ -64,6 +74,8 @@ defmodule EngramWeb.Schemas.LogRecord do
       stack: %Schema{type: :string, nullable: true},
       plugin_version: %Schema{type: :string, nullable: true},
       platform: %Schema{type: :string, nullable: true},
+      device_id: %Schema{type: :string, nullable: true},
+      conn_id: %Schema{type: :string, nullable: true},
       created_at: %Schema{type: :string, format: :"date-time", nullable: true}
     }
   })

--- a/openapi.json
+++ b/openapi.json
@@ -1245,8 +1245,20 @@
             "x-struct": null,
             "x-validate": null
           },
+          "conn_id": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "created_at": {
             "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "device_id": {
             "nullable": true,
             "type": "string",
             "x-struct": null,
@@ -1805,6 +1817,20 @@
       "LogInput": {
         "properties": {
           "category": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "conn_id": {
+            "description": "WebSocket connection id, correlates client logs to server breadcrumbs.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "device_id": {
+            "description": "Per-install Obsidian instance id, for per-device attribution.",
             "nullable": true,
             "type": "string",
             "x-struct": null,

--- a/test/engram_web/controllers/logs_controller_test.exs
+++ b/test/engram_web/controllers/logs_controller_test.exs
@@ -153,6 +153,57 @@ defmodule EngramWeb.LogsControllerTest do
       assert Map.has_key?(entry, "platform")
     end
 
+    test "returns device_id and conn_id when present, null otherwise", %{conn: conn} do
+      conn = get(conn, "/api/logs")
+      body = json_response(conn, 200)
+
+      # Seeded logs (msg1/msg2/msg3) carry no device_id/conn_id.
+      Enum.each(body["logs"], fn entry ->
+        assert Map.has_key?(entry, "device_id")
+        assert Map.has_key?(entry, "conn_id")
+        assert entry["device_id"] == nil
+        assert entry["conn_id"] == nil
+      end)
+    end
+
+    test "filters can attribute rows to a specific instance by device_id, two instances sharing one user",
+         %{conn: conn} do
+      post(conn, "/api/logs", %{
+        logs: [
+          %{
+            ts: "2026-04-03T01:03:00Z",
+            level: "info",
+            category: "channel",
+            message: "Event: note_changed path=A.md",
+            platform: "desktop",
+            device_id: "instance-a",
+            conn_id: "conn-a-1"
+          },
+          %{
+            ts: "2026-04-03T01:03:01Z",
+            level: "info",
+            category: "pull",
+            message: "Applied: A.md | localLen=10 | remoteLen=10",
+            platform: "desktop",
+            device_id: "instance-b",
+            conn_id: "conn-b-1"
+          }
+        ]
+      })
+
+      conn = get(conn, "/api/logs")
+      body = json_response(conn, 200)
+
+      instance_b_rows = Enum.filter(body["logs"], &(&1["device_id"] == "instance-b"))
+      assert length(instance_b_rows) == 1
+      assert hd(instance_b_rows)["message"] == "Applied: A.md | localLen=10 | remoteLen=10"
+      assert hd(instance_b_rows)["conn_id"] == "conn-b-1"
+
+      instance_a_rows = Enum.filter(body["logs"], &(&1["device_id"] == "instance-a"))
+      assert length(instance_a_rows) == 1
+      assert hd(instance_a_rows)["message"] == "Event: note_changed path=A.md"
+    end
+
     test "multi-tenant isolation — user B cannot see user A's logs", %{conn: _conn} do
       user_b = insert(:user)
       insert(:vault, user: user_b, is_default: true)


### PR DESCRIPTION
Completes a half-shipped feature: `client_logs` already **stores** `device_id` and `conn_id` (columns + changeset cast on `main`), but `serialize_log/1` dropped them, so the API threw the attribution away at the boundary.

Adds both fields to the `GET /logs` response and to the OpenApiSpex `LogInput`/`LogRecord` schemas, plus controller tests covering the null case and two-instances-one-user attribution.

**Why it matters:** per-device and per-connection correlation is exactly what's been missing when tracing plugin client logs against server breadcrumbs.

### Revival notes (2026-07-26)
Originally parked from a worktree cleanup (branched 2026-07-04, no PR). Since revived:
- Rebased onto `main`.
- Dropped the stale `mix.exs` `0.5.624` bump — release-please owns the backend version now (`main` is at `0.11.0`).
- Verified the write path still casts both fields (`lib/engram/logs/client_log.ex`), so read and write agree.
- Local: `mix test test/engram_web/controllers/logs_controller_test.exs` 13/13, `mix format --check-formatted` clean, `mix credo --strict` clean.

Production diff is 2 lines; the rest is schema documentation and tests.
