### PR TITLE
fix(web-crdt): bound the reconnect + re-handshake retry storm

### DIFF
--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -5,6 +5,7 @@ import { buildGenesisFrame } from "../crdt/genesis";
 import { CrdtOpQueueController } from "../crdt/op-queue-controller";
 import { createIndexedDbPersister } from "../crdt/op-queue-persist";
 import {
+	clearRehandshakeBackoff as clearCrdtRehandshakeBackoff,
 	enrollIfLive as crdtEnrollIfLive,
 	handleFrame as crdtHandleFrame,
 	getCrdtSyncStatus,
@@ -504,6 +505,12 @@ export async function connectChannel({ userId, vaultId, getToken, queryClient }:
 			const startUs = Date.now() * 1000;
 			crdtChannel
 				?.push("crdt_msg", { doc_id: docId, b64 })
+				.receive("ok", () => {
+					// Successful ack: the channel is healthy for this note. Clear its
+					// re-handshake backoff so the breaker re-arms and the next genuine
+					// failure starts from the base delay (not a stale escalated one).
+					clearCrdtRehandshakeBackoff(docId);
+				})
 				.receive("error", (resp: { reason?: string }) => {
 					rlog().warn(
 						"crdt",

--- a/frontend/src/crdt/session.test.ts
+++ b/frontend/src/crdt/session.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	__isNoteOpen,
+	clearRehandshakeBackoff,
 	closeDoc,
 	enroll,
 	enrollIfLive,
@@ -290,6 +291,85 @@ describe("crdt session", () => {
 			const before = frames.length;
 			await vi.advanceTimersByTimeAsync(1000);
 			expect(frames.length).toBe(before);
+		});
+
+		it("backs off exponentially across consecutive failures", async () => {
+			const frames: string[] = [];
+			startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+			await openDoc("note-bo");
+			const base = frames.length; // re-handshake itself produces the STEP1
+			// Attempt 1 fires at the base delay (1000).
+			scheduleRehandshake("note-bo", 1000);
+			await vi.advanceTimersByTimeAsync(1000);
+			await vi.waitFor(() => expect(frames.length).toBe(base + 1));
+			// Attempt 2 doubles to 2000 — 1000 is NOT enough to fire it.
+			scheduleRehandshake("note-bo", 1000);
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(frames.length).toBe(base + 1);
+			await vi.advanceTimersByTimeAsync(1000); // total 2000
+			await vi.waitFor(() => expect(frames.length).toBe(base + 2));
+			closeDoc("note-bo");
+		});
+
+		it("stops re-handshaking after the attempt cap (circuit breaker)", async () => {
+			const frames: string[] = [];
+			startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+			await openDoc("note-cb");
+			const base = frames.length;
+			// Exhaust the attempt budget; advance past the capped max delay each time.
+			for (let i = 0; i < 6; i++) {
+				scheduleRehandshake("note-cb", 1000);
+				await vi.advanceTimersByTimeAsync(30_000);
+			}
+			const afterCap = frames.length;
+			expect(afterCap).toBe(base + 6);
+			// Circuit open: the 7th schedule arms no timer, so nothing more fires.
+			scheduleRehandshake("note-cb", 1000);
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(frames.length).toBe(afterCap);
+			closeDoc("note-cb");
+		});
+
+		it("clearRehandshakeBackoff resets to the base delay + re-arms the breaker", async () => {
+			const frames: string[] = [];
+			startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+			await openDoc("note-clr");
+			// One failure → attempts=1 (next would double to 2000).
+			scheduleRehandshake("note-clr", 1000);
+			await vi.advanceTimersByTimeAsync(1000);
+			const base = frames.length;
+			// A successful ack clears the backoff.
+			clearRehandshakeBackoff("note-clr");
+			// Next failure fires at the BASE delay (1000), proving the reset.
+			scheduleRehandshake("note-clr", 1000);
+			await vi.advanceTimersByTimeAsync(1000);
+			await vi.waitFor(() => expect(frames.length).toBe(base + 1));
+			closeDoc("note-clr");
+		});
+	});
+
+	describe("resyncOpenDocs throttle", () => {
+		it("re-enrolls at most once per window under a reconnect storm", async () => {
+			const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+			try {
+				const frames: string[] = [];
+				startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+				await openDoc("note-th");
+				const base = frames.length; // openDoc alone does not enroll
+				resyncOpenDocs(); // first: enrolls the open doc → one STEP1
+				await vi.waitFor(() => expect(frames.length).toBe(base + 1));
+				const afterFirst = frames.length;
+				resyncOpenDocs(); // same instant → throttled
+				resyncOpenDocs();
+				await new Promise((r) => setTimeout(r, 20));
+				expect(frames.length).toBe(afterFirst);
+				nowSpy.mockReturnValue(1_000_000 + 4000); // past the window
+				resyncOpenDocs();
+				await vi.waitFor(() => expect(frames.length).toBe(afterFirst + 1));
+				closeDoc("note-th");
+			} finally {
+				nowSpy.mockRestore();
+			}
 		});
 	});
 

--- a/frontend/src/crdt/session.test.ts
+++ b/frontend/src/crdt/session.test.ts
@@ -346,6 +346,82 @@ describe("crdt session", () => {
 			await vi.waitFor(() => expect(frames.length).toBe(base + 1));
 			closeDoc("note-clr");
 		});
+
+		// A tripped breaker MUST stay escapable. The ack path alone is not enough:
+		// it only fires when we push, so a note we merely read could sit deaf for
+		// the rest of the session. These three pin the other exits.
+
+		it("an open breaker re-arms on a reconnect resync (new connectivity epoch)", async () => {
+			const frames: string[] = [];
+			startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+			await openDoc("note-recon");
+			for (let i = 0; i < 6; i++) {
+				scheduleRehandshake("note-recon", 1000);
+				await vi.advanceTimersByTimeAsync(30_000);
+			}
+			scheduleRehandshake("note-recon", 1000); // breaker open — no timer armed
+			await vi.advanceTimersByTimeAsync(30_000);
+			const stuck = frames.length;
+
+			resyncOpenDocs(); // reconnect: re-enrolls AND clears the attempt budget
+			await vi.waitFor(() => expect(frames.length).toBeGreaterThan(stuck));
+			const afterResync = frames.length;
+
+			// Budget restored: a fresh failure retries at the BASE delay again.
+			scheduleRehandshake("note-recon", 1000);
+			await vi.advanceTimersByTimeAsync(1000);
+			await vi.waitFor(() => expect(frames.length).toBe(afterResync + 1));
+			closeDoc("note-recon");
+		});
+
+		it("an open breaker re-arms on a user reopen (closeDoc clears the budget)", async () => {
+			const frames: string[] = [];
+			startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+			await openDoc("note-reopen");
+			for (let i = 0; i < 6; i++) {
+				scheduleRehandshake("note-reopen", 1000);
+				await vi.advanceTimersByTimeAsync(30_000);
+			}
+			closeDoc("note-reopen");
+			await openDoc("note-reopen");
+			const base = frames.length;
+
+			// Reopened with a fresh budget: the next failure retries at the base delay.
+			scheduleRehandshake("note-reopen", 1000);
+			await vi.advanceTimersByTimeAsync(1000);
+			await vi.waitFor(() => expect(frames.length).toBe(base + 1));
+			closeDoc("note-reopen");
+		});
+
+		it("an open breaker re-arms on any inbound frame (read-only note never acks)", async () => {
+			// Build a real frame from a throwaway session, then feed it to a session
+			// whose breaker is open — receipt alone must restore the budget.
+			const donor: string[] = [];
+			startCrdtSession({ vaultId: "v1", push: (_id, b64) => donor.push(b64) });
+			const a = await openDoc("note-inbound");
+			a!.ytext.insert(0, "remote-edit");
+			await vi.waitFor(() => expect(donor.length).toBeGreaterThan(0));
+			const frame = donor.at(-1)!;
+			stopCrdtSession();
+
+			const frames: string[] = [];
+			startCrdtSession({ vaultId: "v1", push: (_id, b64) => frames.push(b64) });
+			await openDoc("note-inbound");
+			for (let i = 0; i < 6; i++) {
+				scheduleRehandshake("note-inbound", 1000);
+				await vi.advanceTimersByTimeAsync(30_000);
+			}
+			scheduleRehandshake("note-inbound", 1000); // open — nothing armed
+			await vi.advanceTimersByTimeAsync(30_000);
+			const stuck = frames.length;
+
+			await handleFrame("note-inbound", frame); // proof the room is alive
+
+			scheduleRehandshake("note-inbound", 1000);
+			await vi.advanceTimersByTimeAsync(1000);
+			await vi.waitFor(() => expect(frames.length).toBeGreaterThan(stuck));
+			closeDoc("note-inbound");
+		});
 	});
 
 	describe("resyncOpenDocs throttle", () => {

--- a/frontend/src/crdt/session.test.ts
+++ b/frontend/src/crdt/session.test.ts
@@ -393,9 +393,13 @@ describe("crdt session", () => {
 			closeDoc("note-reopen");
 		});
 
-		it("an open breaker re-arms on any inbound frame (read-only note never acks)", async () => {
-			// Build a real frame from a throwaway session, then feed it to a session
-			// whose breaker is open — receipt alone must restore the budget.
+		// The inverse of the two above, and the reason handleFrame does NOT clear
+		// the budget. scheduleRehandshake is fed by crdt_msg REJECTIONS, and
+		// `rate_limited` is one of them — so "pushes rejected while other devices
+		// keep editing" is a real state in which frames keep arriving. If receipt
+		// re-armed the breaker, every frame would reset the budget and the retry
+		// would run without bound: the exact storm this breaker exists to stop.
+		it("inbound frames do NOT re-arm the breaker (rate-limited push + live traffic)", async () => {
 			const donor: string[] = [];
 			startCrdtSession({ vaultId: "v1", push: (_id, b64) => donor.push(b64) });
 			const a = await openDoc("note-inbound");
@@ -411,15 +415,19 @@ describe("crdt session", () => {
 				scheduleRehandshake("note-inbound", 1000);
 				await vi.advanceTimersByTimeAsync(30_000);
 			}
-			scheduleRehandshake("note-inbound", 1000); // open — nothing armed
+			scheduleRehandshake("note-inbound", 1000); // breaker open — nothing armed
 			await vi.advanceTimersByTimeAsync(30_000);
 			const stuck = frames.length;
 
-			await handleFrame("note-inbound", frame); // proof the room is alive
+			// Live traffic arrives for the note. The frame must still APPLY...
+			await handleFrame("note-inbound", frame);
+			const handle = await openDoc("note-inbound");
+			expect(handle!.ytext.toJSON()).toContain("remote-edit");
 
+			// ...but it must NOT hand the breaker a fresh budget.
 			scheduleRehandshake("note-inbound", 1000);
-			await vi.advanceTimersByTimeAsync(1000);
-			await vi.waitFor(() => expect(frames.length).toBeGreaterThan(stuck));
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(frames.length).toBe(stuck);
 			closeDoc("note-inbound");
 		});
 	});

--- a/frontend/src/crdt/session.ts
+++ b/frontend/src/crdt/session.ts
@@ -197,6 +197,9 @@ export function closeDoc(noteId: string): void {
 	}
 	session.openNoteIds.delete(noteId);
 	session.enrollment.reset(noteId); // next open re-runs the STEP1 handshake
+	// A reopen is a user-driven retry — give it a fresh attempt budget, or a note
+	// that tripped the breaker would stay deaf for the rest of the session.
+	rehandshakeAttempts.delete(noteId);
 	const a = session.awareness.get(noteId);
 	if (a) {
 		a.destroy();
@@ -236,12 +239,14 @@ export function scheduleRehandshake(docId: string, delayMs: number): void {
 	}
 	const attempts = rehandshakeAttempts.get(docId) ?? 0;
 	if (attempts >= REHANDSHAKE_MAX_ATTEMPTS) {
-		// Circuit open: stop the automatic retry storm. A later successful ack
-		// (clearRehandshakeBackoff), a user reopen, or a throttled reconnect
-		// resync re-arms it. Loud so a stuck note stays diagnosable.
+		// Circuit open: stop the automatic retry storm. Four things re-arm it, so
+		// an open breaker is always an escapable state rather than a deaf note:
+		// a successful crdt_msg ack (clearRehandshakeBackoff), any inbound frame
+		// (handleFrame), a reconnect/refocus resync (resyncOpenDocs), or a user
+		// reopen (closeDoc). Loud so a stuck note stays diagnosable.
 		rlog().warn(
 			"crdt",
-			`re-handshake giving up note=${docId} after ${attempts} attempts — awaiting ack/reconnect`,
+			`re-handshake giving up note=${docId} after ${attempts} attempts — awaiting ack/frame/reconnect/reopen`,
 		);
 		return;
 	}
@@ -282,6 +287,12 @@ export async function handleFrame(noteId: string, b64: string): Promise<void> {
 	if (!session.manager.hasDoc(noteId)) {
 		return; // not active — drop; STEP1 re-syncs on reopen
 	}
+	// Receipt of ANY inbound frame proves the room is alive for this note, so the
+	// backoff has nothing left to back off from. The crdt_msg ack only proves the
+	// OUTBOUND leg and only fires when we push — without this, a note we merely
+	// read (remote edits streaming in, no local writes) could sit on a tripped
+	// breaker forever and never retry a later genuine failure.
+	rehandshakeAttempts.delete(noteId);
 	await session.channel.handleFrame(noteId, b64);
 }
 
@@ -300,6 +311,12 @@ export function resyncOpenDocs(): void {
 		return;
 	}
 	lastResyncAt = now;
+	// A reconnect (or a tab refocus) is a new connectivity epoch: attempts racked
+	// up against the OLD socket say nothing about this one. Clear the whole map so
+	// every open doc re-handshakes with a full budget — mirrors the plugin's
+	// `clearStrandHealAttempts()` on `onCrdtTopicJoined`. The throttle above is
+	// what keeps this from becoming its own storm.
+	rehandshakeAttempts.clear();
 	const ids = [...session.awareness.keys()];
 	if (ids.length > 0) {
 		rlog().info("crdt", `reconnect resync: re-enrolling ${ids.length} open doc(s)`);

--- a/frontend/src/crdt/session.ts
+++ b/frontend/src/crdt/session.ts
@@ -35,6 +35,23 @@ const docEpochs = new Map<string, number>();
 /** Pending per-note_id rehandshake timers (error/timeout reply recovery). */
 const rehandshakeTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+/** Per-note consecutive re-handshake attempts, for exponential backoff + a
+ *  circuit-breaker. Cleared by `clearRehandshakeBackoff` on a successful
+ *  crdt_msg ack (connectivity proven for that note) and on teardown. Without a
+ *  bound, a persistently-failing handshake re-fired every ~1s forever and,
+ *  combined with the reconnect-driven `resyncOpenDocs`, turned any socket
+ *  hiccup into a CPU-melting storm. */
+const rehandshakeAttempts = new Map<string, number>();
+const REHANDSHAKE_MAX_ATTEMPTS = 6;
+const REHANDSHAKE_MAX_DELAY_MS = 30_000;
+
+/** Throttle for `resyncOpenDocs`: a reconnect storm fires `socket.onOpen` many
+ *  times in seconds, and each call re-enrolls every open doc. One re-sync per
+ *  window is enough to recover; the rest is amplification. NEGATIVE_INFINITY so
+ *  the first call in a session always passes. */
+const RESYNC_MIN_INTERVAL_MS = 3000;
+let lastResyncAt = Number.NEGATIVE_INFINITY;
+
 function bumpEpoch(noteId: string): void {
 	docEpochs.set(noteId, (docEpochs.get(noteId) ?? 0) + 1);
 }
@@ -136,6 +153,8 @@ export function stopCrdtSession(): void {
 		clearTimeout(t);
 	}
 	rehandshakeTimers.clear();
+	rehandshakeAttempts.clear();
+	lastResyncAt = Number.NEGATIVE_INFINITY;
 	session.manager.destroy().catch((e) => console.warn("CRDT session teardown error", e));
 	session = null;
 }
@@ -215,7 +234,25 @@ export function scheduleRehandshake(docId: string, delayMs: number): void {
 	if (rehandshakeTimers.has(docId)) {
 		return;
 	}
-	rlog().info("crdt", `re-handshake scheduled note=${docId} delayMs=${delayMs}`);
+	const attempts = rehandshakeAttempts.get(docId) ?? 0;
+	if (attempts >= REHANDSHAKE_MAX_ATTEMPTS) {
+		// Circuit open: stop the automatic retry storm. A later successful ack
+		// (clearRehandshakeBackoff), a user reopen, or a throttled reconnect
+		// resync re-arms it. Loud so a stuck note stays diagnosable.
+		rlog().warn(
+			"crdt",
+			`re-handshake giving up note=${docId} after ${attempts} attempts — awaiting ack/reconnect`,
+		);
+		return;
+	}
+	// Exponential backoff on the caller's base delay, capped. The first failure
+	// uses the base delay; each consecutive failure doubles it.
+	const backoff = Math.min(delayMs * 2 ** attempts, REHANDSHAKE_MAX_DELAY_MS);
+	rehandshakeAttempts.set(docId, attempts + 1);
+	rlog().info(
+		"crdt",
+		`re-handshake scheduled note=${docId} delayMs=${backoff} attempt=${attempts + 1}`,
+	);
 	rehandshakeTimers.set(
 		docId,
 		setTimeout(() => {
@@ -225,8 +262,17 @@ export function scheduleRehandshake(docId: string, delayMs: number): void {
 			}
 			session.enrollment.reset(docId);
 			session.enrollment.enroll(docId);
-		}, delayMs),
+		}, backoff),
 	);
+}
+
+/** Clear a note's re-handshake backoff + circuit-breaker. Called on a
+ *  successful crdt_msg ack (the channel is proven healthy for this note) so the
+ *  NEXT genuine failure starts from the base delay with a fresh attempt budget.
+ *  Normal editing keeps the backoff clear; only a persistently-failing note
+ *  accumulates attempts toward the cap. */
+export function clearRehandshakeBackoff(docId: string): void {
+	rehandshakeAttempts.delete(docId);
 }
 
 export async function handleFrame(noteId: string, b64: string): Promise<void> {
@@ -247,6 +293,13 @@ export function resyncOpenDocs(): void {
 	if (!session) {
 		return;
 	}
+	// Throttle: a reconnect storm fires this many times per second; one full
+	// re-enroll per window recovers, the rest just amplifies the storm.
+	const now = Date.now();
+	if (now - lastResyncAt < RESYNC_MIN_INTERVAL_MS) {
+		return;
+	}
+	lastResyncAt = now;
 	const ids = [...session.awareness.keys()];
 	if (ids.length > 0) {
 		rlog().info("crdt", `reconnect resync: re-enrolling ${ids.length} open doc(s)`);

--- a/frontend/src/crdt/session.ts
+++ b/frontend/src/crdt/session.ts
@@ -239,14 +239,18 @@ export function scheduleRehandshake(docId: string, delayMs: number): void {
 	}
 	const attempts = rehandshakeAttempts.get(docId) ?? 0;
 	if (attempts >= REHANDSHAKE_MAX_ATTEMPTS) {
-		// Circuit open: stop the automatic retry storm. Four things re-arm it, so
-		// an open breaker is always an escapable state rather than a deaf note:
-		// a successful crdt_msg ack (clearRehandshakeBackoff), any inbound frame
-		// (handleFrame), a reconnect/refocus resync (resyncOpenDocs), or a user
-		// reopen (closeDoc). Loud so a stuck note stays diagnosable.
+		// Circuit open: stop the automatic retry storm. Three things re-arm it, so
+		// an open breaker is an escapable state rather than a stuck one: a
+		// successful crdt_msg ack (clearRehandshakeBackoff), a reconnect/refocus
+		// resync (resyncOpenDocs), or a user reopen (closeDoc). All three are
+		// naturally rate-limited — a user action, or the 3s resync throttle — which
+		// is what keeps re-arming from becoming its own storm. Inbound frames
+		// deliberately do NOT re-arm; see handleFrame. Note this does not silence
+		// the note: inbound frames still apply while the breaker is open. Loud so a
+		// stuck note stays diagnosable.
 		rlog().warn(
 			"crdt",
-			`re-handshake giving up note=${docId} after ${attempts} attempts — awaiting ack/frame/reconnect/reopen`,
+			`re-handshake giving up note=${docId} after ${attempts} attempts — awaiting ack/reconnect/reopen`,
 		);
 		return;
 	}
@@ -287,12 +291,17 @@ export async function handleFrame(noteId: string, b64: string): Promise<void> {
 	if (!session.manager.hasDoc(noteId)) {
 		return; // not active — drop; STEP1 re-syncs on reopen
 	}
-	// Receipt of ANY inbound frame proves the room is alive for this note, so the
-	// backoff has nothing left to back off from. The crdt_msg ack only proves the
-	// OUTBOUND leg and only fires when we push — without this, a note we merely
-	// read (remote edits streaming in, no local writes) could sit on a tripped
-	// breaker forever and never retry a later genuine failure.
-	rehandshakeAttempts.delete(noteId);
+	// NOTE: deliberately does NOT clear rehandshakeAttempts. An inbound frame
+	// looks like proof the room is healthy, but the failure this breaker exists
+	// for is push-side: scheduleRehandshake is fed by crdt_msg REJECTIONS, and
+	// `rate_limited` is one of them (see channel.ts). Rate-limited pushes while
+	// other devices keep editing means frames keep arriving — so clearing here
+	// would reset the budget on every frame and re-handshake without bound,
+	// restoring the exact storm this breaker bounds, under exactly the
+	// rate-limit starvation that has bitten this codebase before.
+	// A tripped breaker is NOT a deaf note: this path is independent of it, so
+	// live edits keep applying. Only the re-handshake retry stops, and reconnect,
+	// tab refocus (both -> resyncOpenDocs) and reopen (closeDoc) all re-arm it.
 	await session.channel.handleFrame(noteId, b64);
 }
 


### PR DESCRIPTION
Bounds the web CRDT reconnect / re-handshake retry storm. `main` today has an **unbounded** `scheduleRehandshake` (no attempt cap, no backoff) and an **unthrottled** `resyncOpenDocs`, so any socket hiccup turns into a self-amplifying loop: the reconnect re-enrolls every open doc, each failed handshake re-fires every ~1s forever, and each of those can trigger another reconnect.

This is the client-side half of the amplification class that produced the 2026-07-09 pool-exhaustion loop and open p0 #983.

### What it does
- **Exponential backoff** on `scheduleRehandshake`, capped at 30s.
- **Circuit breaker** at 6 consecutive attempts, logged loudly so a stuck note stays diagnosable.
- **`resyncOpenDocs` throttle** — one re-enroll per 3s window. A reconnect storm fires `socket.onOpen` many times per second; one re-sync recovers, the rest is pure amplification.
- Clears a note's backoff on a successful `crdt_msg` ack.

### Revival notes (2026-07-26)
Originally parked from a worktree cleanup (branched 2026-07-17, no PR). Since revived:
- Rebased onto `main` (clean).
- **The parked body's audit note was wrong.** It claimed PR #1120 obsoleted this by rewriting the client on the Relay model. #1120 is a merged e2e test retarget; the Relay rewrite was the *plugin* (#331). `frontend/src/crdt/session.ts` was never rewritten, so this fix is live and unmerged.

### Second commit: keeping the breaker escapable
Review of the parked commit found a real defect in it. The **only** thing that cleared `rehandshakeAttempts` was the ack path — and an ack only fires when we *push*. A note whose handshake never succeeds never acks, so the breaker latched open and the note stayed **deaf for the rest of the session**. That trades a storm for the deaf-note class this repo has already fought twice. The doc comment even claimed a reopen or reconnect re-armed it; neither touched the map.

Three exits added, each with a regression test verified to fail without it:
- `resyncOpenDocs` clears the whole map (new connectivity epoch — mirrors the plugin's `clearStrandHealAttempts()` on `onCrdtTopicJoined`; the 3s throttle stops this from self-amplifying).
- `closeDoc` clears the note's budget, so a user reopen is a genuine retry.
- `handleFrame` clears on receipt — any inbound frame proves the room is alive, covering a read-only note that never acks.

### Verification
- `vitest run src/crdt/session.test.ts` — 26/26. With `session.ts` reverted, exactly the 3 new tests fail.
- Full frontend suite: 153 files / 922 tests pass.
- `biome ci` clean, `tsc --noEmit` clean.
