### PR TITLE
test(e2e): CRDT drift self-heal regression (rename-orphan)

### DIFF
--- a/e2e/tests/crdt/test_drift_self_heal.py
+++ b/e2e/tests/crdt/test_drift_self_heal.py
@@ -1,0 +1,54 @@
+"""CRDT drift self-heal (rc.3 rename-orphan regression).
+
+Reproduces the production bug where a device loses a note's id->path mapping
+mid-session (the "drift" that a rename or a diverged local id can cause). Once
+that happens, inbound CRDT content for the note's id can no longer resolve a
+disk path, so `onFlushToDisk` strands it ("no known path") and the note goes
+laggy / duplicates. The map must re-resolve the id from the server manifest
+when a strand is detected, instead of stranding forever.
+
+The rc.3 once-per-session reconcile only repairs the map on the first connect,
+so a mid-session drift never self-heals. This test drives that exact state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from helpers.vault import wait_for_content, write_note
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("E2E_ENABLE_CRDT") != "true",
+    reason="CRDT-only suite — set E2E_ENABLE_CRDT=true with a CRDT_ENABLED backend",
+)
+
+CRDT_TIMEOUT = 30
+PLUGIN = "app.plugins.plugins['engram-vault-sync']"
+
+
+@pytest.mark.asyncio
+async def test_drifted_map_self_heals_on_inbound_edit(vault_a, vault_b, cdp_a, cdp_b, api_sync):
+    path = "E2E/Crdt/Drift.md"
+
+    # Shared CRDT base on both devices.
+    write_note(vault_a, path, "# Drift\nbase.\n")
+    api_sync.wait_for_note_content(path, "base", timeout=CRDT_TIMEOUT)
+    await cdp_b.trigger_full_sync()
+    wait_for_content(vault_b, path, "base", timeout=CRDT_TIMEOUT)
+
+    # Drift: B loses the id->path mapping for this note (the diverged state).
+    note_id = await cdp_b.evaluate(f"{PLUGIN}.noteIdMap.get({json.dumps(path)})")
+    assert note_id, "B should have mapped the note before drift"
+    await cdp_b.evaluate(f"{PLUGIN}.noteIdMap.delete({json.dumps(path)})")
+    after = await cdp_b.evaluate(f"{PLUGIN}.noteIdMap.pathForId({json.dumps(note_id)})")
+    assert after is None, "drift injection should have removed the reverse mapping"
+
+    # A edits over CRDT. B must re-resolve id->path and materialize the edit,
+    # not strand it forever.
+    write_note(vault_a, path, "# Drift\nbase.\nEDIT-AFTER-DRIFT\n")
+    final = wait_for_content(vault_b, path, "EDIT-AFTER-DRIFT", timeout=CRDT_TIMEOUT)
+    # No duplication: the base line survives exactly once.
+    assert final.count("base.") == 1, f"content duplicated on B: {final!r}"


### PR DESCRIPTION
Adds `e2e/tests/crdt/test_drift_self_heal.py` — a regression test for the rename-orphan drift class: a device loses a note's `id -> path` mapping mid-session, so inbound CRDT content can no longer resolve a disk path and `onFlushToDisk` strands it ("no known path"), leaving the note laggy or duplicated.

The test injects the drift directly (deletes the reverse mapping via CDP), then edits from the other device and asserts the content materializes exactly once.

Pure test addition — no production code.

### Revival notes (2026-07-26)
Originally parked from a worktree cleanup (branched 2026-07-07, no PR). Since revived:
- Rebased onto `main` (clean).
- **Reclassified.** The parked body described this as reproducing an OPEN bug: "the rc.3 once-per-session reconcile only repairs the map on the first connect, so a mid-session drift never self-heals." That has since been fixed on both sides — `plugin/src/main.ts` `onCrdtTopicJoined` now runs a throttled manifest reconcile before re-enrolling, and `plugin/src/crdt/wiring.ts` has attempt-capped mid-session strand healing (`clearStrandHealAttempts`). So this is now a **regression test for shipped behavior**, not a repro of a live defect — still worth having, given what that bug class cost.
- Verified the harness API it depends on still exists on `main`: `helpers.vault.write_note`/`wait_for_content`, fixtures `vault_a`/`vault_b`/`cdp_a`/`cdp_b`/`api_sync`, `cdp.trigger_full_sync()`, `api.wait_for_note_content()`, and the plugin surface it pokes (`noteIdMap` on the plugin instance).
- Gate matches the rest of `tests/crdt/` (`E2E_ENABLE_CRDT=true`), so it runs in the `e2e-crdt` job.

**This PR is the verification** — it has not been run locally (needs the full CI stack + Obsidian + Xvfb). If `e2e-crdt` comes back red, that is information worth having either way and this becomes a bug report rather than a merge.
