### PR TITLE
ci: push-trigger release-please PR branches

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,14 +18,21 @@ on:
       - "perf/**"
       - "refactor/**"
       - "release/**"
-      # NOTE: release-please's own PR branch (release-please--**) is
-      # deliberately NOT push-triggered. The RP action updates its branch in
-      # two steps (ref update to main tip, then the release commit), and the
-      # push-triggered run sometimes bound to the intermediate SHA — leaving
-      # the release PR's head with no checks and the PR unmergeable (the
-      # #1057 problem all over again, just racier). Instead release-please.yml
-      # explicitly workflow_dispatches this workflow on the branch AFTER the
-      # RP action finishes, so checks always attach to the real PR head.
+      # release-please's own PR branch MUST be push-triggered. It was excluded
+      # once (the RP action updates its branch in two steps — ref update to
+      # main tip, then the release commit — and a push run could bind to the
+      # intermediate SHA), with release-please.yml workflow_dispatching this
+      # workflow instead. That dispatch does attach check runs to the real PR
+      # head, but a `workflow_dispatch` check suite is NOT counted toward a
+      # PR's required status checks: only `push`/`pull_request` suites enter
+      # the rollup. So every release PR sat at mergeStateStatus=BLOCKED with
+      # lint/ci/unit-tests green-but-invisible, mergeable only by an org-admin
+      # ruleset bypass (#1119; #1103 before it). Push-triggering costs at worst
+      # one extra cheap run on the intermediate SHA — e2e-* already skips
+      # itself on release-please-- refs — and the final push (the release
+      # commit) lands a counting suite on the head the PR actually merges.
+      # The dispatch in release-please.yml stays as belt-and-braces.
+      - "release-please--**"
       - "revert/**"
       - "security/**"
       - "test/**"

--- a/docs/context/ci-pipeline-gating.md
+++ b/docs/context/ci-pipeline-gating.md
@@ -30,7 +30,7 @@ Flaky is no longer blocking, but flaky is still **visible** and still hard-gates
 | `schedule` (06:00 UTC) | Nightly full run + flake measurement | ✅ forced |
 | `workflow_dispatch` `force_full=true` | Manual "run everything" | ✅ forced |
 | `repository_dispatch` | Backend runs e2e for a **plugin** PR, posts a `backend/e2e` status back | — |
-| `workflow_dispatch` on `release-please--**` | Release-PR validation — release-please.yml kicks it after updating its branch (NOT push-triggered: the RP action's two-step branch update raced push runs onto an intermediate SHA, leaving the Release PR head checkless/unmergeable). All e2e-* suites self-skip on this ref — main just hard-gated identical content, so only the deterministic gate runs | ❌ |
+| push to `release-please--**` | Release-PR validation. **Must** be push-triggered — see "Why a dispatched check does not count" below. release-please.yml also dispatches the same workflow as belt-and-braces. All e2e-* suites self-skip on this ref (the guard is on `github.ref_name`, not the event, so it holds under either trigger) — main just hard-gated identical content, so only the deterministic gate runs | ❌ |
 | `release-v*` tag | `deploy-prod.yml` → release e2e gate → deploy | ✅ (force_full) |
 
 `is-full` (computed by the `fingerprint` job) forces the full suite to actually
@@ -93,6 +93,37 @@ static-checks]`. It exits non-zero only if a **deterministic** need failed;
 
 A **skipped** required check counts as passing to GitHub rulesets, which is why
 a workflow-only or cache-skipped PR shows `ci: skipped` yet is mergeable.
+
+## Why a dispatched check does not count
+
+A `workflow_dispatch` check suite attaches its check runs to the head SHA, is
+associated with the PR, and is visible via
+`GET /commits/{sha}/check-runs` — but it **never enters the PR's status-check
+rollup**. Only `push` and `pull_request` suites do. Branch protection reads the
+rollup, so a dispatch-only required check is green everywhere except where it
+matters.
+
+This silently broke every release PR. `release-please--**` had been cut from
+verify.yml's push trigger, leaving `workflow_dispatch` as its only CI source, so
+each release PR sat at `mergeStateStatus: BLOCKED` with `lint`/`ci`/`unit-tests`
+green-but-invisible. The releases still shipped because `protect-main` grants
+`OrganizationAdmin` `bypass_mode: pull_request` — the bypass masked the defect
+for several releases (#1103, then #1119, which is where it was finally caught).
+Fixed by restoring the push trigger.
+
+Diagnosing this class: compare `gh pr checks <n>` (rollup — what protection
+sees) against `gh api repos/{o}/{r}/commits/{sha}/check-runs` (everything on the
+SHA). If the second list is much longer, look at the `event` of the runs that
+are missing:
+
+```bash
+gh api "repos/{owner}/{repo}/actions/runs?head_sha=$SHA" \
+  -q '.workflow_runs[] | "\(.name) | event=\(.event) | \(.conclusion)"'
+```
+
+A green required check whose run shows `event=workflow_dispatch` is the tell.
+Contrast with any normal `feat/**` PR, whose CI shows `event=push` and merges
+fine — that control comparison is what isolates it.
 
 ## Gate summary by context
 


### PR DESCRIPTION
## Problem

Every release-please PR in this repo is unmergeable through the front door.

`verify.yml` deliberately excluded `release-please--**` from its `push` trigger, relying instead on `release-please.yml` explicitly `workflow_dispatch`ing CI on the branch. That dispatch does attach check runs to the real PR head — but **a `workflow_dispatch` check suite never enters the PR's status-check rollup**. Only `push` and `pull_request` suites do.

Result: `lint` / `ci` / `unit-tests` run green, land on the correct SHA, are associated with the PR — and branch protection still reads them as missing.

## Evidence

On #1119 (release 0.11.0), head `13d4f61`:

- Suite `81888029946` (run `30219151606`, `event=workflow_dispatch`) — contains `lint`, `ci`, `unit-tests`, all `success`.
- `gh pr checks 1119` shows **2 of 24** check runs: only `require-notes` and `auto-merge`, both from `pull_request`-triggered workflows.
- `mergeStateStatus: BLOCKED`, `mergeable: MERGEABLE`, commit signed, branch 1 ahead / 0 behind `main`, zero review threads, `required_approving_review_count: 0`.
- Re-dispatched CI (run `30225133494`) — green again, still invisible.

Control, PR #1121 (a normal `feat/**` branch): CI ran with `event=push`, its suite counted, merged normally.

The `protect-main` ruleset grants `OrganizationAdmin` `bypass_mode: pull_request`, which is how #1103 (release 0.10.0) got merged. The bypass has been silently masking this since release-please was adopted.

## Fix

Add `release-please--**` back to the `push` trigger.

The intermediate-SHA race that motivated the original exclusion is not a regression risk here: all four e2e jobs guard on `!startsWith(github.ref_name, 'release-please--')`, which is **ref-based, not event-based**, so push-triggering does not unleash the expensive suites. Worst case is one extra cheap deterministic-gate run on the intermediate SHA; the final push (the release commit) lands a counting suite on the SHA the PR actually merges.

`version-check` now newly fires on release branches (it keys on `event_name == 'push'`), and passes — it only asserts `mix.exs` holds valid semver, which release-please always writes.

The dispatch in `release-please.yml` is left in place as belt-and-braces.

## Verification

The real proof is #1119 itself: once this merges, release-please regenerates that PR on a new head SHA, the push trigger fires, and the required contexts should finally appear in `gh pr checks 1119`.

No test added — this is a workflow trigger list, and the repo has no existing harness for asserting workflow content. The inline comment records why the exclusion is wrong, since it was introduced deliberately once already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fXPYtAKeUBLKjW9QmVRpZ