### PR TITLE
fix(deploy): close the prod deploy valve + drop the redundant Release-PR dispatch

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -242,7 +242,7 @@ jobs:
       # needs no AWS creds here and fails loudly if the image was never built.
       # On the rollback recipe the tagged SHA's main run is long since
       # complete, so this returns on the first poll.
-      # See docs/context/deploy-guardrails.md.
+      # See engram-workspace/docs/context/deploy-guardrails.md.
       - name: Wait for main CI to publish this commit's image
         env:
           GH_REPO: ${{ github.repository }}
@@ -282,7 +282,7 @@ jobs:
                 exit 0
                 ;;
               completed/*)
-                echo "::error::build-and-publish-image on run ${run_id} ended '${job}' — ${IMAGE_TAG} was never published. Refusing to pin a non-existent image (ECS would ImagePull-fail; see docs/context/deploy-guardrails.md)."
+                echo "::error::build-and-publish-image on run ${run_id} ended '${job}' — ${IMAGE_TAG} was never published. Refusing to pin a non-existent image (ECS would ImagePull-fail; see engram-workspace/docs/context/deploy-guardrails.md)."
                 exit 1
                 ;;
               *)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -202,6 +202,9 @@ jobs:
     # happy path below is byte-for-byte what it was before the gate existed.
     needs: release-e2e-gate
     runs-on: [self-hosted, linux, x64, isolated]
+    permissions:
+      contents: read
+      actions: read   # read main CI's build-and-publish-image conclusion
     steps:
       - name: Checkout engram (tagged commit)
         uses: actions/checkout@v7
@@ -222,6 +225,74 @@ jobs:
           echo "release_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
           echo "release=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           echo "Deploying $GITHUB_REF_NAME → image sha-$SHA (release=$FULL_SHA)"
+
+      # THE TAG DOES NOT BUILD THE IMAGE — main CI does, and this workflow
+      # races it. release-please.yml pushes release-v* the instant the release
+      # commit lands on main, i.e. the SAME push that starts main CI. There,
+      # build-and-publish-image `needs: [fingerprint, ci]`, so it is the LAST
+      # thing to run: the image reaches ECR ~20 min after the push, while the
+      # e2e gate above only absorbs ~14 min of that. On release-v0.11.0 the
+      # infra PR opened at 00:11:13 and terraform planned at 00:12:55, but the
+      # image did not land until 00:17:18 — data.aws_ecr_image.engram_pin_check
+      # failed the plan and the deploy stalled until a human re-ran it.
+      # release-v0.10.0 died the same way.
+      #
+      # So: never write the pin until the job that publishes the image has
+      # actually succeeded. Gating on the producer (rather than polling ECR)
+      # needs no AWS creds here and fails loudly if the image was never built.
+      # On the rollback recipe the tagged SHA's main run is long since
+      # complete, so this returns on the first poll.
+      # See docs/context/deploy-guardrails.md.
+      - name: Wait for main CI to publish this commit's image
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.sha }}
+          IMAGE_TAG: ${{ steps.tags.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          echo "Waiting for ${IMAGE_TAG} to be published by main CI…"
+          for i in $(seq 1 60); do   # 60 * 30s = 30 min ceiling
+            # Query by head_sha (not `gh run list --limit N`) so a rollback to
+            # an old commit still resolves its run regardless of how many main
+            # runs have happened since.
+            #
+            # branch=main is LOAD-BEARING, not decoration. Several CI runs share
+            # a release commit's head_sha (the main push, plus repository_dispatch
+            # runs from plugin PRs, plus the release-v* workflow_dispatch e2e
+            # gate). Only the main-branch push run builds the image — every other
+            # one reports build-and-publish-image as `skipped`, which the case
+            # below (correctly) treats as fatal. Without this filter the newest
+            # run wins and the deploy hard-fails on a perfectly good release.
+            run_id=$(gh api \
+              "repos/${GH_REPO}/actions/runs?head_sha=${HEAD_SHA}&event=push&branch=main&per_page=100" \
+              -q '[.workflow_runs[] | select(.name=="CI") | select(.head_branch=="main")] | sort_by(.created_at) | last | .id' \
+              2>/dev/null || echo "")
+            if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+              echo "  no main CI run for ${HEAD_SHA} yet (poll $i)"
+              sleep 30
+              continue
+            fi
+            job=$(gh run view "$run_id" --repo "$GH_REPO" --json jobs \
+              -q '.jobs[] | select(.name=="build-and-publish-image") | "\(.status)/\(.conclusion)"' \
+              2>/dev/null || echo "")
+            case "$job" in
+              completed/success)
+                echo "${IMAGE_TAG} published by run ${run_id}."
+                exit 0
+                ;;
+              completed/*)
+                echo "::error::build-and-publish-image on run ${run_id} ended '${job}' — ${IMAGE_TAG} was never published. Refusing to pin a non-existent image (ECS would ImagePull-fail; see docs/context/deploy-guardrails.md)."
+                exit 1
+                ;;
+              *)
+                echo "  run ${run_id}: build-and-publish-image=${job:-pending} (poll $i)"
+                ;;
+            esac
+            sleep 30
+          done
+          echo "::error::Timed out after 30 min waiting for build-and-publish-image on ${HEAD_SHA}. Prod NOT moved."
+          exit 1
 
       # Mint a short-lived installation token for the engram-infra-tf
       # GitHub App, scoped to engram-app/engram-infra only. Required

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # actions:write — the "Kick CI on the Release PR branch" step dispatches
-  # verify.yml (GITHUB_TOKEN is an explicit exception to Actions' recursion
-  # guard for workflow_dispatch — same pattern as deploy-prod's e2e gate).
-  actions: write
 
 jobs:
   release-please:
@@ -37,23 +33,14 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
 
-      # Verify.yml deliberately does NOT push-trigger on release-please--**:
-      # the RP action updates its branch in two steps (ref update, then the
-      # release commit), and a push-triggered run raced onto the intermediate
-      # SHA — leaving the Release PR head with no checks and the PR
-      # unmergeable (#1057's symptom back again). Dispatching here, AFTER the
-      # RP action has finished pushing, pins CI to the branch's final tip.
-      # e2e-* skips itself on release-please-- refs (see verify.yml), so this
-      # run is the cheap deterministic gate only.
-      - name: Kick CI on the Release PR branch
-        if: steps.rp.outputs.pr != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RP_PR: ${{ steps.rp.outputs.pr }}
-        run: |
-          set -euo pipefail
-          BRANCH=$(jq -r '.headBranchName' <<<"$RP_PR")
-          gh workflow run verify.yml --ref "$BRANCH"
+      # No "kick CI on the Release PR branch" step here: verify.yml
+      # push-triggers on release-please--** directly (#1131). This used to
+      # workflow_dispatch verify.yml, which attached check runs to the PR head
+      # but left them OUT of the PR's status-check rollup — dispatch suites do
+      # not count toward required status checks, so every Release PR was
+      # unmergeable without an org-admin bypass. Do not reintroduce it: see
+      # docs/context/ci-pipeline-gating.md → "Why a dispatched check does not
+      # count".
 
       # Ungated: on a Release-PR MERGE push steps.rp.outputs.pr is EMPTY (the
       # `pr` output only fires when release-please opens/updates a PR, not on

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -35,12 +35,16 @@ on:
       - "revert/**"
       - "security/**"
       - "test/**"
-    # `v*` covers semver release tags applied for marketing/audit.
-    # `release-v*` is the deploy trigger — CI already ran on the
-    # merge commit the tag points at, no need to rerun (and the
-    # version-check job mistakenly fires on the tag because the
-    # mix.exs version still matches main).
-    tags-ignore: ["v*", "release-v*"]
+    # NO tag should start this workflow. Every tag we push points at a commit
+    # already on main, which CI has gated — rerunning is pure waste (and the
+    # version-check job mistakenly fires on a tag because the mix.exs version
+    # still matches main).
+    #
+    # This was `["v*", "release-v*"]`, which missed release-please's own tag:
+    # it publishes BARE semver (`0.11.0`, no `v`), so every release quietly
+    # spawned a second full CI run on head_branch=0.11.0. `**` is exhaustive
+    # and needs no upkeep when a new tag shape appears.
+    tags-ignore: ["**"]
   repository_dispatch:
     types: [plugin-e2e-trigger]
   # Nightly full-e2e convergence run + flake ledger (measurement, non-gating —

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,7 +31,6 @@ on:
       # one extra cheap run on the intermediate SHA — e2e-* already skips
       # itself on release-please-- refs — and the final push (the release
       # commit) lands a counting suite on the head the PR actually merges.
-      # The dispatch in release-please.yml stays as belt-and-braces.
       - "release-please--**"
       - "revert/**"
       - "security/**"

--- a/docs/context/ci-pipeline-gating.md
+++ b/docs/context/ci-pipeline-gating.md
@@ -30,7 +30,7 @@ Flaky is no longer blocking, but flaky is still **visible** and still hard-gates
 | `schedule` (06:00 UTC) | Nightly full run + flake measurement | ✅ forced |
 | `workflow_dispatch` `force_full=true` | Manual "run everything" | ✅ forced |
 | `repository_dispatch` | Backend runs e2e for a **plugin** PR, posts a `backend/e2e` status back | — |
-| push to `release-please--**` | Release-PR validation. **Must** be push-triggered — see "Why a dispatched check does not count" below. release-please.yml also dispatches the same workflow as belt-and-braces. All e2e-* suites self-skip on this ref (the guard is on `github.ref_name`, not the event, so it holds under either trigger) — main just hard-gated identical content, so only the deterministic gate runs | ❌ |
+| push to `release-please--**` | Release-PR validation. **Must** be push-triggered — see "Why a dispatched check does not count" below. All e2e-* suites self-skip on this ref (the guard is on `github.ref_name`, not the event) — main just hard-gated identical content, so only the deterministic gate runs | ❌ |
 | `release-v*` tag | `deploy-prod.yml` → release e2e gate → deploy | ✅ (force_full) |
 
 `is-full` (computed by the `fingerprint` job) forces the full suite to actually

--- a/docs/context/deploy-prod.md
+++ b/docs/context/deploy-prod.md
@@ -18,6 +18,16 @@ The OIDC build role (`engram-saas-prod-ecr-push`) trusts `refs/heads/main` + `re
 
 ## Release recipe
 
+**The normal path is automatic — you do not tag by hand.** Merging the
+release-please PR makes release-please.yml push `release-v<version>` itself, so
+`deploy-prod.yml` fires without anyone running the commands below.
+
+That is also why deploy-prod cannot assume the image already exists: the tag is
+pushed by the *same* main push that starts main CI, and `build-and-publish-image`
+runs last in that CI. `open-infra-pr` therefore waits for that job to succeed
+before writing the pin (see "Failure modes"). The manual recipe below is for a
+rollback or a re-release of an older commit.
+
 ```bash
 # Pull latest main, confirm CI is green, confirm the image is in ECR
 git checkout main && git pull
@@ -84,7 +94,7 @@ Operator AWS profile is `engram-infra-operator` (read-only — `operator-cheatsh
 
 - **`deploy-prod.yml` step "Rewrite engram_image_tag default" fails** — regex regression. Check `main/envs/prod/variables.tf` shape in engram-infra; the workflow expects exactly one `variable "engram_image_tag"` block with a `default = "..."` line.
 - **Bot PR opens but doesn't auto-merge** — engram-infra CI failing (typically tflint or terraform plan). Open the PR, read the failing check, fix root cause in engram-infra. The bot will reuse the `bot/bump-engram-prod` branch on the next release tag.
-- **`terraform apply` on engram-infra fails on `ResourceNotFoundException`** — `sha-<7>` image isn't in ECR. The `build-and-publish-image` job in `verify.yml` for that commit hasn't finished (or never ran). Confirm with `aws ecr describe-images`; rerun the `verify.yml` run (or its `build-and-publish-image` job) if needed.
+- **`terraform (prod)` fails on `reading ECR Images: couldn't find resource`** — the `sha-<7>` image isn't in ECR, so `data.aws_ecr_image.engram_pin_check` (ecs.tf) and `engram_image_pin` (ecr.tf) fail the plan. This used to happen on *every* release: the tag is pushed the instant the release commit lands on main, and `build-and-publish-image` finishes ~20 min later, while the release e2e gate only absorbed ~14 min — `release-v0.10.0` and `release-v0.11.0` both died this way. `open-infra-pr` now waits for that job before writing the pin, so a fresh occurrence means the wait timed out (>30 min) or the job genuinely failed. Confirm with `aws ecr describe-images`, then re-run the failed `terraform (prod)` check — or, if the bot PR has gone behind main, `gh pr update-branch <n>` in engram-infra, which re-runs the checks and lets auto-merge finish.
 - **Service crash-loops after deploy** — task running but health checks fail. Check CloudWatch Logs `/ecs/engram-saas-prod`, then forward-roll to the last-known-good `sha-<7>` via a new release tag.
 - **App token mint step 403s** — `engram-infra-tf` App permissions changed. Required: `contents: read & write` + `pull-requests: read & write` on engram-infra. Adjust at https://github.com/organizations/engram-app/settings/apps/engram-infra-tf.
 


### PR DESCRIPTION
Both follow-ups from the 0.11.0 release, plus two defects found while verifying them.

## 1. The prod deploy valve (the real bug)

`release-please.yml` pushes `release-v*` the instant the release commit lands on main — the **same push** that starts main CI. In that CI, `build-and-publish-image` has `needs: [fingerprint, ci]`, so it runs *last*: the image reaches ECR ~20 min after the push, while `release-e2e-gate` only absorbs ~14 min.

On `release-v0.11.0`:

| Event | Time (UTC) |
|---|---|
| release e2e gate finishes | 00:10:41 |
| infra PR opened | 00:11:13 |
| `terraform (prod)` plans → **fails** | 00:12:55–00:13:19 |
| image actually lands in ECR | **00:17:18** |

`data.aws_ecr_image.engram_pin_check` correctly refused to plan against an image that didn't exist. `release-v0.10.0` died identically — this has now stalled two consecutive releases, each needing a manual recovery.

**Fix:** `open-infra-pr` waits for `build-and-publish-image` to actually succeed before writing the pin. Gating on the producing job (rather than polling ECR) keeps AWS creds out of this workflow and fails *loudly* when no image was ever built, instead of pinning a tag ECS can only ImagePull-fail on.

Alternatives rejected: delaying the tag push (invasive, also delays the GitHub Release) and making terraform retry (wrong repo, hides the cause).

## 2. Redundant Release-PR dispatch — closes #1132

`verify.yml` push-triggers on `release-please--**` since #1131, so the `workflow_dispatch` kick just burned a second set of runners per Release PR. Its checks were never counted anyway — that's what #1131 was about. `actions: write` goes too; that step was its only consumer.

## 3. `tags-ignore` missed release-please's own tag

Found while validating #1. `tags-ignore` was `["v*", "release-v*"]`, but release-please publishes **bare** semver (`0.11.0`, no `v`), so every release quietly spawned a second full CI run — run `30226305071` on `head_branch=0.11.0`, right next to the real main run. Now `["**"]`: no tag should start this workflow, and it needs no upkeep when a new tag shape appears. `deploy-prod.yml` keeps its own `release-v*` trigger and is unaffected.

## 4. A bug in my own fix, caught by testing against real data

My first version of the wait resolved run `30226305071` — the bare-semver **tag** run — whose `build-and-publish-image` is `skipped`, which the step treats as fatal. It would have hard-failed **every** release.

A release commit's `head_sha` carries several CI runs: the main push, `repository_dispatch` runs from plugin PRs, the `release-v*` `workflow_dispatch` e2e gate, and the bare-tag push. Only the main-branch push builds the image. Hence the `branch=main` filter, which is load-bearing and commented as such.

Verified against real data — all resolve the main run and pass on the first poll:

| Commit | Run | `build-and-publish-image` |
|---|---|---|
| `82a54b38` (0.11.0) | `30226296391` | `completed/success` |
| `219eccd8` (0.10.0) | `30140207458` | `completed/success` |
| `b7165532` (#1131) | `30225870487` | `completed/success` |

The `case` branching was exercised across all seven job states — `completed/{success,failure,skipped,cancelled}`, `in_progress/`, `queued/`, and empty — confirming terminal non-success fails loudly rather than hanging, and in-flight/absent keeps polling.

## Docs

`docs/context/deploy-prod.md` presented hand-tagging as the normal path; release-please has owned it for a while, which is *why* the race exists. Corrected, and the ECR failure mode rewritten with the real error string and the `gh pr update-branch` recovery. `ci-pipeline-gating.md` drops its now-stale belt-and-braces note.

## Testing

No new automated test: these are workflow triggers and a polling step, and the repo has no harness for asserting workflow behaviour. The verification above was done against live API data instead, and the reasoning is recorded inline so the `branch=main` filter and the `**` glob aren't "simplified" away later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fXPYtAKeUBLKjW9QmVRpZ