### PR TITLE
feat(web): vault-scoped URLs (/:slug/:itemId) + settings as a hash overlay

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -233,7 +233,7 @@ config :engram, :default_registration_mode, default_registration_mode
 # SaaS points at the in-app billing page; self-hosters can override or set to nil.
 config :engram,
        :upgrade_url,
-       System.get_env("ENGRAM_UPGRADE_URL", "https://app.engram.page/settings/billing")
+       System.get_env("ENGRAM_UPGRADE_URL", "https://app.engram.page/#settings/billing")
 
 # Email transactional provider (pricing v2 §C). Default: NoOp for self-host;
 # Resend when RESEND_API_KEY is set.

--- a/docs/context/environment-variables.md
+++ b/docs/context/environment-variables.md
@@ -46,7 +46,7 @@ Live. This is regenerated from `config/runtime.exs` (the ~90 vars it reads), wit
 | `ENGRAM_HOST_REWRITE_MCP_HOST` | `mcp.engram.page` | MCP host for path rewrite (:696). |
 | `ENGRAM_ALLOWED_EXTRA_HOSTS` | unset | Comma-sep extra allowed hosts (:688). |
 | `ENGRAM_FRONTEND_URL` | unset | Absolute SPA base URL for cross-origin OAuth `/authorize` 302 (post-eject) (:706). |
-| `ENGRAM_UPGRADE_URL` | `https://app.engram.page/settings/billing` | Upgrade URL surfaced in 402 limit-exceeded responses (:198-200). |
+| `ENGRAM_UPGRADE_URL` | `https://app.engram.page/#settings/billing` | Upgrade URL surfaced in 402 limit-exceeded responses (:198-200). |
 | `TRUST_CF_CONNECTING_IP` | `false` | Prod-only: trust `CF-Connecting-IP` for rate-limit client IP. Safe only under Cloudflare AOP `verify` (:534). |
 
 ## Storage / Attachments

--- a/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
+++ b/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
@@ -1689,6 +1689,48 @@ children: [
 
 Check `note-page.tsx` and `attachment-page.tsx` for their own `useParams()` calls and apply the same rename. Run `cd backend/frontend && grep -rn 'useParams' src/viewer/` to find them all.
 
+- [ ] **Step 3b: Make VaultSwitcher navigate. THIS MUST LAND IN THE SAME COMMIT AS THE ROUTES.**
+
+`layout/vault-switcher.tsx:74` currently calls `setActiveVaultId(next)` directly with no
+navigation. The moment `VaultRoute` is wired in, that becomes an unrecoverable hang: the
+store is mutated externally while the URL slug stays put, so `activeId !== vault.id` is
+permanently true and `VaultRoute` renders `LoadingPane` forever. Its effect only re-fires
+on `[vault]`, which does not change because the URL did not change. No test catches this,
+because nothing exercises vault switching through the real router.
+
+Contrast `onboarding/onboard-vault-page.tsx:87,97` and `device/device-link-page.tsx:170`,
+which are safe: each follows `setActiveVaultId` with `navigate("/")`, round-tripping
+through `VaultRedirect` back into a URL. The switcher has no such round-trip.
+
+Replace the `onValueChange` handler body:
+
+```tsx
+onValueChange={(next) => {
+	if (next === active.id) {
+		return;
+	}
+	const target = vaults.find((v) => v.id === next);
+	if (!target) {
+		return;
+	}
+	// Navigate; VaultRoute writes the active-vault store. Land on the vault
+	// root, not the current note, whose id does not exist in the new vault.
+	navigate(`/${target.slug}`);
+	qc.invalidateQueries();
+	window.dispatchEvent(
+		new CustomEvent("engram:vault-switched", { detail: { from: active.id, to: next } }),
+	);
+}}
+```
+
+Add `useNavigate` to the `react-router` import, add `const navigate = useNavigate();`, and
+drop the now-unused `setActiveVaultId` import. Also delete the reconciliation effect at
+`vault-switcher.tsx:19-31`: `VaultRedirect` now owns choosing a vault when none is valid,
+and it does so by navigating rather than writing the store.
+
+Add a test asserting the switcher NAVIGATES rather than writing the store, and that it
+lands on the vault root rather than carrying the old note id across.
+
 - [ ] **Step 4: Verify build and full suite**
 
 Run: `cd backend/frontend && bun run build && bun run test`
@@ -1765,7 +1807,13 @@ Add a `LocationProbe` to the file if absent (same shape as Task 5).
 Run: `cd backend/frontend && bun run test -- vault-switcher`
 Expected: FAIL, location stays `/work/note-1`.
 
-- [ ] **Step 4: Rework the switcher**
+- [ ] **Step 4: (MOVED TO TASK 11) Rework the switcher**
+
+> This step was moved into Task 11 Step 3b. Leaving `setActiveVaultId` in the switcher for
+> even one commit after the vault routes go live hangs the app on every vault switch, with
+> no test to catch it. If Task 11 already did this, skip. The original text follows for
+> reference only.
+
 
 In `backend/frontend/src/layout/vault-switcher.tsx`:
 

--- a/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
+++ b/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
@@ -1026,6 +1026,21 @@ In `backend/lib/engram_web/router.ex`, inside the existing `scope "/", EngramWeb
     match :*, "/oauth/*path", SpaController, :not_found
     match :*, "/webhooks/*path", SpaController, :not_found
     match :*, "/.well-known/*path", SpaController, :not_found
+    # /assets is NOT a router scope, it is Plug.Static mounted in endpoint.ex,
+    # which makes it easy to miss when enumerating prefixes from `scope`
+    # declarations. Plug.Static only serves files that EXIST; on a miss it falls
+    # through to the router, so without this a stale <script src="/assets/old.js">
+    # would match /:slug/:id and get an HTML 200 that the browser then fails to
+    # parse as JavaScript.
+    match :*, "/assets/*path", SpaController, :not_found
+    # /email is also Plug.Static-served (see EngramWeb.static_paths/0) and is a
+    # DIRECTORY, so /email/engram-mark.png is two segments and collides with
+    # /:slug/:id. These URLs are embedded in emails and fetched by third-party
+    # image proxies that cache responses, so a masked HTML 200 is worse here
+    # than a clean 404. The single-segment static_paths entries (favicon.ico,
+    # favicon.svg, engram-mark.svg, robots.txt) deliberately get NO entry: a
+    # miss there is cosmetic and means a broken build, not a live failure.
+    match :*, "/email/*path", SpaController, :not_found
 
     # Vault-scoped SPA routes. `/:slug` is a vault, `/:slug/:id` a note or
     # attachment. Kept last so every static route above wins.

--- a/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
+++ b/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
@@ -888,6 +888,31 @@ In `vault_deleted_email.ex:42`:
 manage_url = EngramWeb.Endpoint.url() <> "/?highlight=#{vault.id}#settings/vaults"
 ```
 
+- [ ] **Step 4b: Update the config default (the one a literal grep misses)**
+
+In `config/runtime.exs:236`, the `:upgrade_url` default becomes:
+
+```elixir
+System.get_env("ENGRAM_UPGRADE_URL", "https://app.engram.page/#settings/billing")
+```
+
+This is the most important site in this task and the easiest to miss. The three plug
+literals above cover only the PAT and API-write 402s. Every other 402 (connection cap,
+device cap, notes cap, vaults cap, attachments) reads `:upgrade_url` from application
+config via `lib/engram_web/limit_response.ex:30`, sourced from this line. Grepping for
+the literal `/settings/billing` finds the plugs and misses this, because the value
+arrives through an indirection.
+
+Two of the three e2e assertions in `test_71_connections.py` (connection cap and device
+cap) assert against THIS value, not the plug literals, so they fail in Task 13 unless
+this changes.
+
+> **Deployment follow-up, outside this repo.** If `ENGRAM_UPGRADE_URL` is set as an env
+> var in engram-infra, that override still carries the old path form and must be updated
+> there separately. It degrades gracefully rather than breaking, because
+> `LegacySettingsRedirect` bounces `/settings/billing` to the hash form, but the extra
+> redirect hop remains until infra is updated.
+
 - [ ] **Step 5: Run to verify they pass**
 
 Run: `cd backend && python -m pytest e2e/tests/api_only/test_71_connections.py -k upgrade -v && mix test`

--- a/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
+++ b/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
@@ -1670,8 +1670,11 @@ children: [
 	// Bare `/` picks a vault; `/note/:id` is the pre-vault-scoping URL shape.
 	{ path: ROUTES.HOME, element: suspended(<VaultRedirect />) },
 	{ path: "/note/:id", element: suspended(<LegacyNoteRedirect />) },
-	// Vault-scoped. Kept LAST so every static route above wins RR's
-	// static-over-dynamic ranking.
+	// Vault-scoped. Listed last for readability only. NOTE: React Router's
+	// route ranking (computeScore) already scores static segments above
+	// dynamic ones as part of matching, independent of array order, so
+	// declaration order does NOT decide this. Verified against the installed
+	// react-router 8.3.0 matchRoutes: both orderings resolve identically.
 	{
 		path: "/:slug",
 		element: suspended(<VaultRoute />),

--- a/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
+++ b/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
@@ -1,0 +1,1876 @@
+# Vault-Scoped SPA URLs + Settings Hash Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the SPA URL describe what the user is looking at: vault-scoped note paths (`/:slug/:noteId`) with the URL as the source of truth for the active vault, and settings addressed by hash (`#settings/<section>`) so it overlays the current page instead of replacing it.
+
+**Architecture:** `useActiveVaultId()` has 30+ consumers that stay untouched; only the *writer* changes, from `localStorage` to a new `VaultRoute` component that resolves the URL slug. Settings stays the Radix `Dialog` it already is, but moves from a path route to a hash-driven overlay mounted above the app shell so it works on `/link` and `/oauth/consent` too. Phoenix gets an explicit deny-list so the new dynamic SPA routes cannot swallow typo'd API paths.
+
+**Tech Stack:** React 19, React Router 7, TanStack Query 5, Radix UI, Vitest + Testing Library (frontend); Elixir 1.17 / Phoenix 1.8, ExUnit (backend); pytest + Playwright (E2E).
+
+**Spec:** Engram vault, `50 Engineering/_Superpowers Specs/2026-07-28-frontend-vault-scoped-urls-design.md`
+
+## Global Constraints
+
+- Repo: `engram-app/engram`. Work in a git worktree (`~/documents/code-projects/engram/.worktrees/<branch>`), never the shared `backend/` symlink checkout. Copy `.env.local-selfhost` into the worktree before any `make saas-dev` run; it is gitignored so `git worktree add` will not bring it.
+- Branch: `feat/vault-scoped-urls`. Conventional commits, subject under 50 chars.
+- ONE PR for the whole plan. Do not open intermediate PRs.
+- Do NOT bump `mix.exs` version in feature commits; the release flow owns it.
+- Frontend lint/format: `./node_modules/.bin/biome ci` (never `bunx biome`, wrong version). Run `bun run lint:css` and `bun run lint:obsidian` if present.
+- Backend before push: `mix format`, `mix credo`, `mix dialyzer`, and the FULL `mix test`.
+- The vault segment is `Vault.slug` (plaintext, per-user unique). Never `Vault.name` (encrypted, virtual).
+- Unknown vault slug renders the existing `NotFoundPage`. Never silently redirect to the default vault.
+- No `!important` in CSS. No em dashes in user-facing copy.
+- `@testing-library/user-event` is NOT a dependency. Use `fireEvent` from `@testing-library/react`, the existing convention across the suite. Add it to the file's existing `@testing-library/react` import where a snippet below uses it.
+- Nav links inside the settings dialog must be react-router `<Link>`, never a plain `<a href="#...">`. React Router v8's browser history listens to `popstate` only (`node_modules/react-router/dist/development/lib/router/history.js:335`); a native anchor hash navigation fires `hashchange` but not `popstate`, so `useLocation()` would go stale and `SettingsOverlayHost` would stop switching sections. `<Link to="#settings/x">` resolves to `<pathname>#settings/x`, so assert href with a suffix match, never string equality against a bare hash.
+- Reserved slug list, verbatim, identical in Elixir and TypeScript:
+  `sign-in sign-up waitlist link oauth onboard reset-password note search billing settings api webhooks .well-known`
+
+---
+
+## File Structure
+
+**Create (frontend, `backend/frontend/src/`):**
+
+| Path | Responsibility |
+|---|---|
+| `settings/settings-hash.ts` | Parse and build `#settings/<section>`. Pure, no React. |
+| `settings/settings-overlay-host.tsx` | Renders `<Outlet/>` plus the settings dialog when the hash matches. |
+| `settings/legacy-settings-redirect.tsx` | `/settings/*` to `/#settings/<section>`. |
+| `api/vault-slug.ts` | `vaultBySlug`, `preferredVault` (pure, Task 9) plus the `useActiveVaultSlug` hook (Task 12). |
+| `api/reserved-slugs.ts` | TS mirror of the Elixir reserved list. |
+| `viewer/vault-route.tsx` | Resolves `:slug`, writes the active-vault store, holds children until it agrees. |
+| `viewer/vault-redirect.tsx` | Bare `/` to `/<slug>`. |
+| `viewer/legacy-note-redirect.tsx` | `/note/:id` to `/<slug>/:id`. |
+
+**Modify (frontend):** `settings/settings-layout.tsx` (dialog takes a `section` prop, renders the section body directly, close strips the hash), `settings/sections.ts` (add the `key` field), `router.tsx`, `layout/vault-switcher.tsx`, `layout/rail.tsx`, `layout/user-menu.tsx`, `layout/app-sidebar.tsx`, `layout/empty-vault-state.tsx`, `layout/search-panel.tsx`, `billing/upgrade-required-dialog.tsx`, `device/device-link-page.tsx`, `oauth/oauth-authorize-page.tsx`, `settings/connections-page.tsx`, `settings/vaults/active-vaults-section.tsx`, `settings/account/connected-accounts-section.tsx`, `api/queries.ts`, `viewer/dashboard.tsx`, `viewer/tree/tree-row.tsx`, `onboarding/onboarding-shell.tsx`, `onboarding/tour/controller.tsx`.
+
+**Modify (backend):** `lib/engram_web/router.ex`, `lib/engram_web/controllers/spa_controller.ex`, `lib/engram/vaults/vault.ex`, `lib/engram_web/plugs/enforce_pat_creation.ex`, `lib/engram_web/plugs/require_api_write_enabled.ex`, `lib/engram_web/plugs/enforce_connection_cap.ex`, `lib/engram/workers/vault_deleted_email.ex`, `e2e/helpers/web_spa.py`, `e2e/tests/api_only/test_71_connections.py`.
+
+---
+
+## Task 1: Settings hash parsing
+
+**Files:**
+- Create: `backend/frontend/src/settings/settings-hash.ts`
+- Modify: `backend/frontend/src/settings/sections.ts`
+- Test: `backend/frontend/src/settings/settings-hash.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `type SettingsSectionKey = "account" | "vaults" | "connections" | "billing" | "admin"`; `isSettingsHash(hash: string): boolean`; `parseSettingsHash(hash: string): SettingsSectionKey | null`; `settingsHash(section: SettingsSectionKey): string`. `sections.ts` gains `SettingsSection.key: SettingsSectionKey` alongside the existing `to` and `label`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/frontend/src/settings/settings-hash.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { isSettingsHash, parseSettingsHash, settingsHash } from "./settings-hash";
+
+describe("isSettingsHash", () => {
+	it("matches the bare prefix and sectioned forms", () => {
+		expect(isSettingsHash("#settings")).toBe(true);
+		expect(isSettingsHash("#settings/billing")).toBe(true);
+	});
+
+	it("rejects empty, unrelated, and prefix-lookalike hashes", () => {
+		expect(isSettingsHash("")).toBe(false);
+		expect(isSettingsHash("#tour")).toBe(false);
+		expect(isSettingsHash("#settingsfoo")).toBe(false);
+	});
+});
+
+describe("parseSettingsHash", () => {
+	it("returns null for a non-settings hash", () => {
+		expect(parseSettingsHash("")).toBeNull();
+		expect(parseSettingsHash("#tour")).toBeNull();
+	});
+
+	it("defaults a bare prefix to account", () => {
+		expect(parseSettingsHash("#settings")).toBe("account");
+		expect(parseSettingsHash("#settings/")).toBe("account");
+	});
+
+	it("returns each known section", () => {
+		expect(parseSettingsHash("#settings/account")).toBe("account");
+		expect(parseSettingsHash("#settings/vaults")).toBe("vaults");
+		expect(parseSettingsHash("#settings/connections")).toBe("connections");
+		expect(parseSettingsHash("#settings/billing")).toBe("billing");
+		expect(parseSettingsHash("#settings/admin")).toBe("admin");
+	});
+
+	it("maps the legacy api-keys alias to connections", () => {
+		expect(parseSettingsHash("#settings/api-keys")).toBe("connections");
+	});
+
+	it("falls back to account for an unknown section", () => {
+		expect(parseSettingsHash("#settings/garbage")).toBe("account");
+	});
+});
+
+describe("settingsHash", () => {
+	it("round-trips through parseSettingsHash", () => {
+		expect(settingsHash("billing")).toBe("#settings/billing");
+		expect(parseSettingsHash(settingsHash("vaults"))).toBe("vaults");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bun run test -- settings-hash`
+Expected: FAIL, "Failed to resolve import ./settings-hash".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `backend/frontend/src/settings/settings-hash.ts`:
+
+```ts
+// Settings is addressed by hash, not path, so the dialog overlays whatever page
+// you were on and closing can simply strip the hash instead of inventing a
+// destination (the old `/settings/*` path route hardcoded `navigate("/")`,
+// which dumped you on the dashboard even if you came from a note).
+const PREFIX = "#settings";
+
+export type SettingsSectionKey = "account" | "vaults" | "connections" | "billing" | "admin";
+
+const KNOWN: readonly string[] = ["account", "vaults", "connections", "billing", "admin"];
+
+// Carried over from the old `/settings/api-keys` route alias so existing links
+// and bookmarks keep landing on Connections.
+const ALIASES: Record<string, SettingsSectionKey> = { "api-keys": "connections" };
+
+export function isSettingsHash(hash: string): boolean {
+	return hash === PREFIX || hash.startsWith(`${PREFIX}/`);
+}
+
+export function parseSettingsHash(hash: string): SettingsSectionKey | null {
+	if (!isSettingsHash(hash)) {
+		return null;
+	}
+	const raw = hash.slice(PREFIX.length).replace(/^\//, "");
+	if (raw === "") {
+		return "account";
+	}
+	const resolved = ALIASES[raw] ?? raw;
+	// An unknown section is a typo or a stale link, not a reason to render
+	// nothing: open on Account rather than an empty dialog body.
+	return KNOWN.includes(resolved) ? (resolved as SettingsSectionKey) : "account";
+}
+
+export function settingsHash(section: SettingsSectionKey): string {
+	return `${PREFIX}/${section}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend/frontend && bun run test -- settings-hash`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Add the `key` field to sections**
+
+Replace `backend/frontend/src/settings/sections.ts` entirely:
+
+```ts
+import type { EngramConfig } from "../config";
+import type { SettingsSectionKey } from "./settings-hash";
+
+export interface SettingsSection {
+	key: SettingsSectionKey;
+	label: string;
+}
+
+export function buildSettingsSections(
+	authProvider: EngramConfig["authProvider"],
+	billingEnabled: boolean,
+	isAdmin = false,
+): SettingsSection[] {
+	const sections: SettingsSection[] = [
+		{ key: "account", label: "Account" },
+		{ key: "vaults", label: "Vaults" },
+		{ key: "connections", label: "Connections" },
+	];
+
+	if (billingEnabled) {
+		sections.push({ key: "billing", label: "Billing" });
+	}
+
+	if (authProvider === "local" && isAdmin) {
+		sections.push({ key: "admin", label: "Administration" });
+	}
+
+	return sections;
+}
+```
+
+- [ ] **Step 6: Fix the existing sections test**
+
+Run: `cd backend/frontend && bun run test -- sections`
+If `sections.test.ts` exists and asserts on `to`, change each `to:` assertion to `key:`. The values are identical strings, so only the property name changes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/settings/settings-hash.ts src/settings/settings-hash.test.ts src/settings/sections.ts
+git commit -m "feat(settings): add hash addressing helpers"
+```
+
+---
+
+## Task 2: Settings dialog renders a section by prop
+
+**Files:**
+- Modify: `backend/frontend/src/settings/settings-layout.tsx`
+- Test: `backend/frontend/src/settings/settings-layout.test.tsx`
+
+**Interfaces:**
+- Consumes: `SettingsSectionKey`, `settingsHash`, `parseSettingsHash` from Task 1; `buildSettingsSections` with the new `key` field.
+- Produces: `settings-layout.tsx` default-exports `SettingsDialog({ section }: { section: SettingsSectionKey })`. It no longer renders `<Outlet/>` and no longer requires child routes.
+
+The dialog currently gets its body from React Router's `<Outlet/>` (child routes in `router.tsx`). With settings off the path, there are no child routes, so the dialog maps the section to a component itself.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the body of `backend/frontend/src/settings/settings-layout.test.tsx`'s `renderAt` helper and add these cases. Keep the existing `vi.mock` and `testConfig` at the top of the file:
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
+import { describe, expect, it } from "vitest";
+// NOTE: `@testing-library/user-event` is NOT a dependency of this repo. Use
+// `fireEvent`, which is the existing convention across the frontend suite.
+import { ConfigProvider } from "../config-context";
+import { ThemeProvider } from "../theme/theme-provider";
+import SettingsDialog from "./settings-layout";
+import type { SettingsSectionKey } from "./settings-hash";
+
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.hash}`}</output>;
+}
+
+function renderDialog(section: SettingsSectionKey, initialEntry = "/work/note-1#settings/account") {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<ConfigProvider config={testConfig}>
+			<QueryClientProvider client={client}>
+				<ThemeProvider>
+					<MemoryRouter initialEntries={[initialEntry]}>
+						<LocationProbe />
+						<SettingsDialog section={section} />
+					</MemoryRouter>
+				</ThemeProvider>
+			</QueryClientProvider>
+		</ConfigProvider>,
+	);
+}
+
+describe("SettingsDialog", () => {
+	it("renders the nav with a link per section", async () => {
+		renderDialog("account");
+		// `<Link to="#settings/billing">` resolves against the current location, so
+		// the href is `/work/note-1#settings/billing`, not a bare hash. Assert the
+		// suffix: the requirement is "targets billing from wherever you are".
+		const link = await screen.findByRole("link", { name: "Billing" });
+		expect(link.getAttribute("href")).toMatch(/#settings\/billing$/);
+	});
+
+	it("switches section on click without leaving the page", () => {
+		renderDialog("account", "/work/note-1#settings/account");
+		fireEvent.click(screen.getByRole("link", { name: "Billing" }));
+		// Guards against dropping out of the router to a plain <a>: react-router v8
+		// listens to popstate ONLY (no hashchange listener), so a native anchor hash
+		// nav would update window.location.hash while useLocation() stayed stale,
+		// and SettingsOverlayHost (Task 3) reads useLocation().hash.
+		expect(screen.getByTestId("loc")).toHaveTextContent("/work/note-1#settings/billing");
+	});
+
+	it("marks the current section as the active nav item", async () => {
+		renderDialog("vaults");
+		expect(await screen.findByRole("link", { name: "Vaults" })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.getByRole("link", { name: "Account" })).not.toHaveAttribute("aria-current");
+	});
+
+	it("strips the hash on close and keeps you on the same page", async () => {
+		renderDialog("account", "/work/note-1#settings/account");
+		fireEvent.click(screen.getByRole("button", { name: /close settings/i }));
+		// The close is deferred by CLOSE_ANIMATION_MS so the Radix exit
+		// transition plays; findBy* polls past it.
+		expect(await screen.findByText("/work/note-1")).toBeInTheDocument();
+	});
+
+	it("falls back to account when the section is unavailable in this config", async () => {
+		const localConfig = { ...testConfig, authProvider: "local" as const, billingEnabled: false };
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(
+			<ConfigProvider config={localConfig}>
+				<QueryClientProvider client={client}>
+					<ThemeProvider>
+						<MemoryRouter initialEntries={["/work#settings/billing"]}>
+							<SettingsDialog section="billing" />
+						</MemoryRouter>
+					</ThemeProvider>
+				</QueryClientProvider>
+			</ConfigProvider>,
+		);
+		// Billing is not a section on a self-host build, so the nav must not
+		// offer it and the body must not be the billing page.
+		expect(screen.queryByRole("link", { name: "Billing" })).toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bun run test -- settings-layout`
+Expected: FAIL. `SettingsDialog` does not accept a `section` prop and the nav still emits `href="/settings/billing"`.
+
+- [ ] **Step 3: Rework the component**
+
+In `backend/frontend/src/settings/settings-layout.tsx`:
+
+Add these imports at the top, next to the existing ones:
+
+```tsx
+import { lazy, Suspense, useEffect, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router";
+import { type SettingsSectionKey, settingsHash } from "./settings-hash";
+```
+
+Remove `NavLink` and `Outlet` from the `react-router` import.
+
+Add the lazy section bodies at module scope, below the imports. These are the exact modules `router.tsx` lazy-loads today:
+
+```tsx
+const AccountPage = lazy(() => import("./account-page"));
+const AccountPageLocal = lazy(() => import("./account-page-local"));
+const VaultsPage = lazy(() => import("./vaults-page"));
+const ConnectionsPage = lazy(() => import("./connections-page"));
+const BillingPage = lazy(() => import("../billing/billing-page"));
+const AdminPanel = lazy(() => import("../features/admin/AdminPanel"));
+
+function SectionBody({ section }: { section: SettingsSectionKey }) {
+	const config = useConfig();
+	switch (section) {
+		case "vaults":
+			return <VaultsPage />;
+		case "connections":
+			return <ConnectionsPage />;
+		case "billing":
+			return <BillingPage />;
+		case "admin":
+			return <AdminPanel />;
+		default:
+			return config.authProvider === "clerk" ? <AccountPage /> : <AccountPageLocal />;
+	}
+}
+```
+
+Replace `SettingsNavList` so it links by hash and computes its own active state. `NavLink`'s `isActive` compares pathname only, which is always the underlying page here, so it can never match:
+
+```tsx
+function SettingsNavList({
+	sections,
+	current,
+	onNavigate,
+}: {
+	sections: SettingsSection[];
+	current: SettingsSectionKey;
+	onNavigate?: () => void;
+}) {
+	return (
+		<ul className="space-y-1">
+			{sections.map((s) => {
+				const active = s.key === current;
+				return (
+					<li key={s.key}>
+						<Link
+							to={settingsHash(s.key)}
+							onClick={onNavigate}
+							aria-current={active ? "page" : undefined}
+							className={`block rounded-md px-3 py-2 text-sm transition-colors ${
+								active
+									? "bg-primary/10 font-medium text-primary"
+									: "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+							}`}
+						>
+							{s.label}
+						</Link>
+					</li>
+				);
+			})}
+		</ul>
+	);
+}
+```
+
+Change the component signature and the close effect. Everything between `<Dialog>` and `</Dialog>` stays byte-identical except the two `SettingsNavList` call sites (which gain `current={current}`) and the `<Outlet />` at line 135:
+
+```tsx
+export default function SettingsDialog({ section }: { section: SettingsSectionKey }) {
+	const config = useConfig();
+	const { data: me } = useMe();
+	const isAdmin = me?.role === "admin";
+	const sections = buildSettingsSections(config.authProvider, config.billingEnabled, isAdmin);
+	const [navOpen, setNavOpen] = useState(false);
+	const [open, setOpen] = useState(true);
+	const navigate = useNavigate();
+	const location = useLocation();
+
+	// A hash can name a section this build does not have (`#settings/billing` on
+	// self-host, `#settings/admin` as a non-admin). Fall back rather than render
+	// an empty dialog body.
+	const current = sections.some((s) => s.key === section) ? section : "account";
+
+	// Close = strip the hash. Deferred by CLOSE_ANIMATION_MS so the Radix exit
+	// transition plays. This replaces the old `navigate("/")`, which threw away
+	// whatever page the user opened settings from.
+	useEffect(() => {
+		if (open) {
+			return;
+		}
+		const t = setTimeout(
+			() => navigate({ pathname: location.pathname, search: location.search, hash: "" }),
+			CLOSE_ANIMATION_MS,
+		);
+		return () => clearTimeout(t);
+	}, [open, navigate, location.pathname, location.search]);
+```
+
+Replace `<Outlet />` (line 135) with:
+
+```tsx
+<Suspense fallback={<p className="text-muted-foreground">Loading…</p>}>
+	<SectionBody section={current} />
+</Suspense>
+```
+
+Update both `<SettingsNavList sections={sections} .../>` call sites to pass `current={current}`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend/frontend && bun run test -- settings-layout`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/settings/settings-layout.tsx src/settings/settings-layout.test.tsx
+git commit -m "feat(settings): render section by prop, close strips hash"
+```
+
+---
+
+## Task 3: Settings overlay host and legacy redirect
+
+**Files:**
+- Create: `backend/frontend/src/settings/settings-overlay-host.tsx`
+- Create: `backend/frontend/src/settings/legacy-settings-redirect.tsx`
+- Test: `backend/frontend/src/settings/settings-overlay-host.test.tsx`
+
+**Interfaces:**
+- Consumes: `parseSettingsHash`, `settingsHash` (Task 1); `SettingsDialog` (Task 2).
+- Produces: `SettingsOverlayHost` (default export, renders `<Outlet/>` plus the dialog); `LegacySettingsRedirect` (default export).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/frontend/src/settings/settings-overlay-host.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import LegacySettingsRedirect from "./legacy-settings-redirect";
+import SettingsOverlayHost from "./settings-overlay-host";
+
+// The dialog pulls the whole settings surface (Clerk hooks, billing, admin);
+// stub it so this file tests only the host's mount decision.
+vi.mock("./settings-layout", () => ({
+	default: ({ section }: { section: string }) => <p data-testid="dialog">section:{section}</p>,
+}));
+
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.search}${loc.hash}`}</output>;
+}
+
+function renderHost(entry: string) {
+	return render(
+		<MemoryRouter initialEntries={[entry]}>
+			<Routes>
+				<Route element={<SettingsOverlayHost />}>
+					<Route path="/work/:id" element={<p>note body</p>} />
+				</Route>
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("SettingsOverlayHost", () => {
+	it("renders the page alone when there is no settings hash", () => {
+		renderHost("/work/note-1");
+		expect(screen.getByText("note body")).toBeInTheDocument();
+		expect(screen.queryByTestId("dialog")).toBeNull();
+	});
+
+	it("keeps the page mounted underneath when settings is open", () => {
+		renderHost("/work/note-1#settings/billing");
+		expect(screen.getByText("note body")).toBeInTheDocument();
+		expect(screen.getByTestId("dialog")).toHaveTextContent("section:billing");
+	});
+
+	it("ignores unrelated hashes", () => {
+		renderHost("/work/note-1#tour");
+		expect(screen.queryByTestId("dialog")).toBeNull();
+	});
+});
+
+describe("LegacySettingsRedirect", () => {
+	function renderRedirect(entry: string) {
+		return render(
+			<MemoryRouter initialEntries={[entry]}>
+				<LocationProbe />
+				<Routes>
+					<Route path="/settings" element={<LegacySettingsRedirect />} />
+					<Route path="/settings/*" element={<LegacySettingsRedirect />} />
+					<Route path="/" element={<p>root</p>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+	}
+
+	it("maps a bare /settings to the account hash", () => {
+		renderRedirect("/settings");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/#settings/account");
+	});
+
+	it("maps a section path to its hash", () => {
+		renderRedirect("/settings/billing");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/#settings/billing");
+	});
+
+	it("maps the legacy api-keys path to connections", () => {
+		renderRedirect("/settings/api-keys");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/#settings/connections");
+	});
+
+	it("preserves the query string", () => {
+		renderRedirect("/settings/vaults?highlight=abc");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/?highlight=abc#settings/vaults");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bun run test -- settings-overlay-host`
+Expected: FAIL, "Failed to resolve import ./settings-overlay-host".
+
+- [ ] **Step 3: Write the host**
+
+Create `backend/frontend/src/settings/settings-overlay-host.tsx`:
+
+```tsx
+import { lazy, Suspense } from "react";
+import { Outlet, useLocation } from "react-router";
+import { parseSettingsHash } from "./settings-hash";
+
+// Settings is a hash overlay, not a page: the route underneath stays mounted, so
+// closing returns you exactly where you were. Mounted at the AuthGuard level
+// rather than inside AppLayout because /link and /oauth/consent both link to
+// `#settings/billing` and live outside the app shell.
+const SettingsDialog = lazy(() => import("./settings-layout"));
+
+export default function SettingsOverlayHost() {
+	const { hash } = useLocation();
+	const section = parseSettingsHash(hash);
+
+	return (
+		<>
+			<Outlet />
+			{section !== null && (
+				<Suspense fallback={null}>
+					<SettingsDialog section={section} />
+				</Suspense>
+			)}
+		</>
+	);
+}
+```
+
+- [ ] **Step 4: Write the legacy redirect**
+
+Create `backend/frontend/src/settings/legacy-settings-redirect.tsx`:
+
+```tsx
+import { Navigate, useLocation } from "react-router";
+import { parseSettingsHash, settingsHash } from "./settings-hash";
+
+// `/settings/*` was the old path route. Phoenix still serves the SPA for those
+// paths (see router.ex) so existing bookmarks boot, and this bounces them to the
+// hash form. Redirects to `/`, which VaultRedirect then resolves to the user's
+// vault while preserving the hash.
+export default function LegacySettingsRedirect() {
+	const location = useLocation();
+	const tail = location.pathname.replace(/^\/settings\/?/, "");
+	const section = parseSettingsHash(tail === "" ? "#settings" : `#settings/${tail}`) ?? "account";
+
+	return (
+		<Navigate
+			to={{ pathname: "/", search: location.search, hash: settingsHash(section) }}
+			replace
+		/>
+	);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend/frontend && bun run test -- settings-overlay-host`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/settings/settings-overlay-host.tsx src/settings/legacy-settings-redirect.tsx src/settings/settings-overlay-host.test.tsx
+git commit -m "feat(settings): add hash overlay host and legacy redirect"
+```
+
+---
+
+## Task 4: Wire the overlay into the router
+
+**Files:**
+- Modify: `backend/frontend/src/router.tsx`
+- Modify: `backend/frontend/src/layout/app-shell.ts`
+- Test: `backend/frontend/src/router.test.tsx` (create if absent)
+
+**Interfaces:**
+- Consumes: `SettingsOverlayHost`, `LegacySettingsRedirect` (Task 3).
+- Produces: a router where `/settings` and `/settings/*` redirect, and every authenticated route can host the settings hash.
+
+- [ ] **Step 1: Remove the settings path subtree**
+
+In `backend/frontend/src/router.tsx`, delete the entire `settings` route object (lines 185-216: the `{ path: "settings", element: suspended(<SettingsLayout />), children: [...] }` block) from `AppLayout`'s children. Also delete these now-unused lazy declarations: `SettingsLayout` (lines 32-34), `BillingPage` (46), `AdminPanel` (47), `ConnectionsPage` (50), `VaultsPage` (51), and the `AccountPage` lazy inside `createAppRouter` (lines 116-120). Task 2 moved all of them into `settings-layout.tsx`.
+
+This removes every use of `config` inside `createAppRouter` (the account-page branch at 116-120, `config.billingEnabled` at 209, `config.authProvider` at 212 were the only three). Keep the `createAppRouter(config: EngramConfig)` signature anyway: `main.tsx` and `BootstrapGate` call it with an argument. If biome flags the now-unused parameter, rename it to `_config` rather than changing the call sites.
+
+- [ ] **Step 2: Add the host and the legacy redirect**
+
+Add to the imports at the top of `router.tsx`:
+
+```tsx
+const SettingsOverlayHost = lazy(() => import("./settings/settings-overlay-host"));
+const LegacySettingsRedirect = lazy(() => import("./settings/legacy-settings-redirect"));
+```
+
+Wrap the `AuthGuard` children in the host. The `AuthGuard` route object becomes:
+
+```tsx
+{
+	element: <AuthGuard />,
+	children: [
+		{
+			// Hash-addressed settings overlays EVERY authenticated route, including
+			// /link and /oauth/consent which sit outside the app shell and link to
+			// `#settings/billing`.
+			element: suspendedScreen(<SettingsOverlayHost />),
+			children: [
+				// ...every existing AuthGuard child moves in here verbatim:
+				// /onboard subtree, ROUTES.DEVICE_LINK, ROUTES.OAUTH_CONSENT,
+				// and the OnboardingGate subtree.
+
+				// Legacy path settings — Phoenix still serves the SPA for these
+				// (router.ex) so old bookmarks boot and land on the hash form.
+				{ path: "/settings", element: suspended(<LegacySettingsRedirect />) },
+				{ path: "/settings/*", element: suspended(<LegacySettingsRedirect />) },
+			],
+		},
+	],
+},
+```
+
+- [ ] **Step 3: Remove the SettingsLayout barrel export**
+
+In `backend/frontend/src/layout/app-shell.ts`, delete line 11:
+
+```ts
+export { default as SettingsLayout } from "../settings/settings-layout";
+```
+
+- [ ] **Step 4: Verify the build and full suite**
+
+Run: `cd backend/frontend && bun run build && bun run test`
+Expected: build succeeds with no unused-import errors; all tests pass. Any test that rendered the old `/settings/account` route will fail here. Update those to render `/` with `hash: "#settings/account"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/router.tsx src/layout/app-shell.ts
+git commit -m "feat(router): mount settings as a hash overlay"
+```
+
+---
+
+## Task 5: Update frontend settings link sites
+
+**Files:**
+- Modify: `backend/frontend/src/layout/user-menu.tsx:55`, `layout/rail.tsx:20,64`, `layout/app-sidebar.tsx:19`, `layout/empty-vault-state.tsx:12`, `billing/upgrade-required-dialog.tsx:59`, `settings/vaults/active-vaults-section.tsx:129`, `settings/connections-page.tsx:199`, `settings/account/connected-accounts-section.tsx:89`, `device/device-link-page.tsx:234,236,254,256,304,307`, `oauth/oauth-authorize-page.tsx:261,264,363`
+- Test: `backend/frontend/src/layout/rail.test.tsx`
+
+**Interfaces:**
+- Consumes: `settingsHash`, `isSettingsHash` (Task 1).
+- Produces: no new exports.
+
+Mechanical replacement, plus one real bug fix in `rail.tsx`.
+
+- [ ] **Step 1: Write the failing rail test**
+
+`rail.tsx:20` decides "is settings open" with `location.pathname.startsWith("/settings")` and `rail.tsx:26` responds to a view-button click with `navigate("/")`. That is the same lose-your-place bug as the dialog close. Add to `backend/frontend/src/layout/rail.test.tsx`:
+
+```tsx
+it("closes settings without leaving the current note", async () => {
+	render(
+		<MemoryRouter initialEntries={["/work/note-1#settings/account"]}>
+			<LocationProbe />
+			<RailViewProvider>
+				<Rail />
+			</RailViewProvider>
+		</MemoryRouter>,
+	);
+	fireEvent.click(screen.getByRole("button", { name: /files/i }));
+	expect(screen.getByTestId("loc")).toHaveTextContent("/work/note-1");
+	expect(screen.getByTestId("loc")).not.toHaveTextContent("#settings");
+});
+```
+
+Add a `LocationProbe` to the file if it does not already have one:
+
+```tsx
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.hash}`}</output>;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bun run test -- rail`
+Expected: FAIL, location is `/` instead of `/work/note-1`.
+
+- [ ] **Step 3: Fix rail.tsx**
+
+Replace the `onSettings` derivation and `onClick` in `ViewButton`:
+
+```tsx
+const { view, setView } = useRailView();
+const location = useLocation();
+const navigate = useNavigate();
+const onSettings = isSettingsHash(location.hash);
+const active = view === id && !onSettings;
+const onClick = () => {
+	setView(id);
+	if (onSettings) {
+		// Strip the settings hash, stay on the page underneath.
+		navigate({ pathname: location.pathname, search: location.search, hash: "" });
+	}
+};
+```
+
+Add `import { isSettingsHash } from "../settings/settings-hash";` and change the settings `NavLink` at line 64 from `to="/settings"` to `to={settingsHash("account")}` (importing `settingsHash` too). Because it is now a hash link, its `NavLink` active styling must also switch to `onSettings` rather than `isActive`; use a plain `Link` with `aria-current={onSettings ? "page" : undefined}` and the same className branch the other buttons use.
+
+- [ ] **Step 4: Replace the remaining link sites**
+
+Apply verbatim:
+
+| File:line | From | To |
+|---|---|---|
+| `layout/user-menu.tsx:55` | `to="/settings"` | `to={settingsHash("account")}` |
+| `layout/app-sidebar.tsx:19` | `to="/settings/billing"` | `to={settingsHash("billing")}` |
+| `layout/empty-vault-state.tsx:12` | `to="/settings/vaults"` | `to={settingsHash("vaults")}` |
+| `billing/upgrade-required-dialog.tsx:59` | `navigate("/settings/billing")` | `navigate({ hash: settingsHash("billing") })` |
+| `settings/vaults/active-vaults-section.tsx:129` | `href="/settings/billing"` | `href={settingsHash("billing")}` |
+| `settings/connections-page.tsx:199` | `href="/settings/billing"` | `href={settingsHash("billing")}` |
+| `device/device-link-page.tsx:236,256,304` | `href="/settings/billing"` | `href={settingsHash("billing")}` |
+| `device/device-link-page.tsx:234,254,307` | `navigate("/settings/billing")` | `navigate({ hash: settingsHash("billing") })` |
+| `oauth/oauth-authorize-page.tsx:264` | `href="/settings/billing"` | `href={settingsHash("billing")}` |
+| `oauth/oauth-authorize-page.tsx:261,363` | `navigate("/settings/billing")` | `navigate({ hash: settingsHash("billing") })` |
+| `settings/account/connected-accounts-section.tsx:89` | `` `${window.location.origin}/settings/account` `` | `` `${window.location.origin}/${settingsHash("account")}` `` |
+
+Add `import { settingsHash } from "@/settings/settings-hash";` (or the correct relative path) to each file.
+
+Note the Clerk `redirectUrl` produces `https://host/#settings/account`. That is intentional: Clerk returns to the origin root and the SPA reopens the dialog from the hash.
+
+- [ ] **Step 5: Verify no path references remain**
+
+Run: `cd backend/frontend && grep -rn '"/settings\|`/settings\|to="/settings\|navigate("/settings' src/ --include=*.ts --include=*.tsx | grep -v legacy-settings-redirect | grep -v '\.test\.'`
+Expected: no output.
+
+- [ ] **Step 6: Run tests, lint, commit**
+
+```bash
+cd backend/frontend && bun run test && ./node_modules/.bin/biome ci
+git add -A src/
+git commit -m "refactor(settings): point all links at the hash"
+```
+
+---
+
+## Task 6: Backend settings URLs
+
+**Files:**
+- Modify: `backend/lib/engram_web/plugs/enforce_pat_creation.ex:12,19`
+- Modify: `backend/lib/engram_web/plugs/require_api_write_enabled.ex:10,48`
+- Modify: `backend/lib/engram_web/plugs/enforce_connection_cap.ex:19`
+- Modify: `backend/lib/engram/workers/vault_deleted_email.ex:42`
+- Test: `backend/e2e/tests/api_only/test_71_connections.py:417,443,700`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `upgrade_url` values now end with `/#settings/billing`.
+
+- [ ] **Step 1: Update the e2e assertions first**
+
+In `backend/e2e/tests/api_only/test_71_connections.py`, change all three assertions (lines 417, 443, 700) and their preceding comments from `"/settings/billing"` to `"/#settings/billing"`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd backend && make ci-up && python -m pytest e2e/tests/api_only/test_71_connections.py -k upgrade -v`
+Expected: FAIL, actual value is `/settings/billing`.
+
+- [ ] **Step 3: Update the plugs**
+
+In `enforce_pat_creation.ex`, change line 19 and the docstring on line 12:
+
+```elixir
+@upgrade_url "/#settings/billing"
+```
+
+In `require_api_write_enabled.ex`, change line 48 and the docstring on line 10:
+
+```elixir
+upgrade_url: "/#settings/billing"
+```
+
+In `enforce_connection_cap.ex`, change the docstring on line 19 to `"upgrade_url": "/#settings/billing"`.
+
+- [ ] **Step 4: Update the vault-deleted email**
+
+In `vault_deleted_email.ex:42`:
+
+```elixir
+# The section goes in the hash and `highlight` stays in the real query string:
+# a query placed INSIDE a hash is not parsed by location.search, so the SPA
+# would never see it.
+manage_url = EngramWeb.Endpoint.url() <> "/?highlight=#{vault.id}#settings/vaults"
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `cd backend && python -m pytest e2e/tests/api_only/test_71_connections.py -k upgrade -v && mix test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/engram_web/plugs/ lib/engram/workers/vault_deleted_email.ex e2e/tests/api_only/test_71_connections.py
+git commit -m "fix(billing): emit hash-addressed settings URLs"
+```
+
+---
+
+## Task 7: Phoenix deny-list and dynamic SPA routes
+
+**Files:**
+- Modify: `backend/lib/engram_web/router.ex:458-478`
+- Modify: `backend/lib/engram_web/controllers/spa_controller.ex`
+- Test: `backend/test/engram_web/controllers/spa_controller_test.exs` (create if absent)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SpaController.not_found/2`; SPA served for `/:slug` and `/:slug/:id`.
+
+The SPA whitelist is deliberately not a catch-all (`router.ex:454-457`, per #858): unknown URLs must 404 rather than render HTML 200 over a typo'd API request. Adding `get "/:slug/:id"` breaks that, because a typo'd `/api/notez` is two segments with no matching API route. The deny-list restores the guarantee.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/test/engram_web/controllers/spa_controller_test.exs`:
+
+```elixir
+defmodule EngramWeb.SpaControllerTest do
+  use EngramWeb.ConnCase, async: true
+
+  describe "vault-scoped SPA routes" do
+    test "serves the SPA for a bare vault slug", %{conn: conn} do
+      conn = get(conn, "/my-vault")
+      assert html_response(conn, 200) =~ "__ENGRAM_CONFIG__"
+    end
+
+    test "serves the SPA for a vault-scoped note", %{conn: conn} do
+      conn = get(conn, "/my-vault/018f2b3c-0000-7000-8000-000000000000")
+      assert html_response(conn, 200) =~ "__ENGRAM_CONFIG__"
+    end
+  end
+
+  describe "non-SPA prefixes must not fall through to /:slug (#858)" do
+    # Regression guard: without the deny-list these two-segment typos match
+    # `get "/:slug/:id"` and return an HTML 200, masking a broken API call.
+    test "a typo'd API path 404s instead of serving HTML", %{conn: conn} do
+      conn = get(conn, "/api/notez")
+      assert response(conn, 404)
+      refute response_content_type(conn, :html) =~ "text/html"
+    end
+
+    test "a typo'd webhooks path 404s", %{conn: conn} do
+      assert conn |> get("/webhooks/bogus") |> response(404)
+    end
+
+    test "a typo'd well-known path 404s", %{conn: conn} do
+      assert conn |> get("/.well-known/bogus") |> response(404)
+    end
+
+    test "a typo'd oauth path 404s", %{conn: conn} do
+      assert conn |> get("/oauth/bogus") |> response(404)
+    end
+
+    test "but /oauth/consent still serves the SPA", %{conn: conn} do
+      conn = get(conn, "/oauth/consent")
+      assert html_response(conn, 200) =~ "__ENGRAM_CONFIG__"
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && mix test test/engram_web/controllers/spa_controller_test.exs`
+Expected: FAIL. The `/my-vault` cases raise `Phoenix.Router.NoRouteError`.
+
+- [ ] **Step 3: Add the not_found action**
+
+In `backend/lib/engram_web/controllers/spa_controller.ex`, add below `index/2`:
+
+```elixir
+  @doc """
+  404 for non-SPA prefixes.
+
+  The `/:slug` and `/:slug/:id` SPA routes are dynamic, so without an explicit
+  deny-list ahead of them a typo'd `/api/notez` would match `/:slug/:id` and get
+  an HTML 200, masking a broken API call. See router.ex and #858.
+  """
+  def not_found(conn, _params) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(404, "Not Found")
+  end
+```
+
+- [ ] **Step 4: Add the routes**
+
+In `backend/lib/engram_web/router.ex`, inside the existing `scope "/", EngramWeb do pipe_through :spa`, append after the `get "/oauth/consent"` line and before the closing `end`:
+
+```elixir
+    # Deny-list. MUST stay above the dynamic /:slug routes below: those are
+    # 1- and 2-segment wildcards, so without this a typo'd /api/notez would
+    # match /:slug/:id and serve an HTML 200 (the exact regression #858
+    # removed). EVERY new non-SPA top-level prefix must be added here.
+    match :*, "/api/*path", SpaController, :not_found
+    match :*, "/oauth/*path", SpaController, :not_found
+    match :*, "/webhooks/*path", SpaController, :not_found
+    match :*, "/.well-known/*path", SpaController, :not_found
+
+    # Vault-scoped SPA routes. `/:slug` is a vault, `/:slug/:id` a note or
+    # attachment. Kept last so every static route above wins.
+    get "/:slug", SpaController, :index
+    get "/:slug/:id", SpaController, :index
+```
+
+Leave `get "/settings"`, `get "/settings/*path"`, and `get "/note/*path"` in place: they serve the SPA so legacy bookmarks boot and get redirected client-side.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && mix test test/engram_web/controllers/spa_controller_test.exs`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Run the full backend suite**
+
+Run: `cd backend && mix format && mix credo && mix test`
+Expected: all green. If any existing test asserted a 404 for a path now matched by `/:slug`, it will fail here. Those are two-segment paths under a denied prefix (already covered) or genuine single-segment typos that now render the SPA and 404 client-side. Update the assertion to expect a 200 and note why.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/engram_web/router.ex lib/engram_web/controllers/spa_controller.ex test/engram_web/controllers/spa_controller_test.exs
+git commit -m "feat(router): serve SPA at /:slug with a deny-list guard"
+```
+
+---
+
+## Task 8: Reserved vault slugs
+
+**Files:**
+- Modify: `backend/lib/engram/vaults/vault.ex:34-56`
+- Create: `backend/frontend/src/api/reserved-slugs.ts`
+- Modify: `backend/frontend/src/components/vault-create-form.tsx`
+- Test: `backend/test/engram/vaults/vault_test.exs`, `backend/frontend/src/api/reserved-slugs.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `RESERVED_SLUGS: readonly string[]` and `isReservedSlug(slug: string): boolean` from `api/reserved-slugs.ts`.
+
+React Router ranks static segments above dynamic ones, so `/link` beats `/:slug` automatically. A vault slugged `link` would not crash the app, it would just be unreachable by URL. This is a UX guard, not a correctness fix.
+
+- [ ] **Step 1: Write the failing Elixir test**
+
+Add to `backend/test/engram/vaults/vault_test.exs` (create the file with `use Engram.DataCase, async: true` and `alias Engram.Vaults.Vault` if absent):
+
+```elixir
+  describe "reserved slugs" do
+    @valid %{
+      user_id: Ecto.UUID.generate(),
+      name_ciphertext: <<1>>,
+      name_nonce: <<2>>,
+      name_hmac: <<3>>
+    }
+
+    test "rejects a slug that would be shadowed by a static SPA route" do
+      for slug <- ~w(settings link oauth onboard note api sign-in) do
+        cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, slug))
+        refute cs.valid?, "expected #{slug} to be rejected"
+        assert "is reserved" in errors_on(cs).slug
+      end
+    end
+
+    test "accepts an ordinary slug" do
+      cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, "work"))
+      assert cs.valid?
+    end
+
+    test "rejection is case-insensitive" do
+      cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, "Settings"))
+      refute cs.valid?
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && mix test test/engram/vaults/vault_test.exs`
+Expected: FAIL, the changeset is valid for `settings`.
+
+- [ ] **Step 3: Add the validation**
+
+In `backend/lib/engram/vaults/vault.ex`, add above `def changeset`:
+
+```elixir
+  # Slugs that a static SPA route would shadow. React Router ranks static
+  # segments above `/:slug`, so a vault named one of these would not break the
+  # app, it would simply be unreachable by URL. Keep in sync with
+  # frontend/src/api/reserved-slugs.ts.
+  @reserved_slugs ~w(
+    sign-in sign-up waitlist link oauth onboard reset-password
+    note search billing settings api webhooks .well-known
+  )
+```
+
+And in the changeset pipeline, between `validate_required` and the first `unique_constraint`:
+
+```elixir
+    |> update_change(:slug, &String.downcase/1)
+    |> validate_exclusion(:slug, @reserved_slugs, message: "is reserved")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && mix test test/engram/vaults/vault_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Mirror the list on the frontend**
+
+Create `backend/frontend/src/api/reserved-slugs.ts`:
+
+```ts
+// Mirror of @reserved_slugs in lib/engram/vaults/vault.ex. Duplicated because
+// the check spans two languages; the backend changeset is authoritative and
+// this exists only to fail fast in the create/rename form.
+export const RESERVED_SLUGS: readonly string[] = [
+	"sign-in",
+	"sign-up",
+	"waitlist",
+	"link",
+	"oauth",
+	"onboard",
+	"reset-password",
+	"note",
+	"search",
+	"billing",
+	"settings",
+	"api",
+	"webhooks",
+	".well-known",
+];
+
+export function isReservedSlug(slug: string): boolean {
+	return RESERVED_SLUGS.includes(slug.trim().toLowerCase());
+}
+```
+
+Create `backend/frontend/src/api/reserved-slugs.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { isReservedSlug } from "./reserved-slugs";
+
+describe("isReservedSlug", () => {
+	it("rejects reserved slugs regardless of case or padding", () => {
+		expect(isReservedSlug("settings")).toBe(true);
+		expect(isReservedSlug("Settings")).toBe(true);
+		expect(isReservedSlug("  link  ")).toBe(true);
+	});
+
+	it("accepts ordinary slugs", () => {
+		expect(isReservedSlug("work")).toBe(false);
+		expect(isReservedSlug("settings-archive")).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 6: Wire it into the create form**
+
+In `backend/frontend/src/components/vault-create-form.tsx`, add the import and reject before submit, surfacing the message next to the slug field:
+
+```tsx
+import { isReservedSlug } from "@/api/reserved-slugs";
+
+// ...inside the submit handler, before the mutation call:
+if (isReservedSlug(slug)) {
+	setSlugError(`"${slug}" is reserved and would make the vault unreachable by URL.`);
+	return;
+}
+```
+
+If the form has no `slugError` state, add `const [slugError, setSlugError] = useState<string | null>(null);` and render it with the same markup the form's other field errors use. Clear it at the top of the handler.
+
+- [ ] **Step 7: Run tests, lint, commit**
+
+```bash
+cd backend && mix format && mix test test/engram/vaults/vault_test.exs
+cd frontend && bun run test -- reserved-slugs && ./node_modules/.bin/biome ci
+git add -A
+git commit -m "feat(vaults): reject reserved slugs"
+```
+
+---
+
+## Task 9: Vault slug resolution helpers
+
+**Files:**
+- Create: `backend/frontend/src/api/vault-slug.ts`
+- Test: `backend/frontend/src/api/vault-slug.test.ts`
+
+**Interfaces:**
+- Consumes: `Vault` from `api/queries.ts`.
+- Produces: `vaultBySlug(vaults: Vault[] | undefined, slug: string | undefined): Vault | null`; `preferredVault(vaults: Vault[] | undefined, hintId: string | null): Vault | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/frontend/src/api/vault-slug.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { Vault } from "./queries";
+import { preferredVault, vaultBySlug } from "./vault-slug";
+
+function v(id: string, slug: string, is_default = false): Vault {
+	return { id, slug, is_default, name: slug } as Vault;
+}
+
+const vaults = [v("id-a", "work"), v("id-b", "personal", true), v("id-c", "archive")];
+
+describe("vaultBySlug", () => {
+	it("finds a vault by slug", () => {
+		expect(vaultBySlug(vaults, "personal")?.id).toBe("id-b");
+	});
+
+	it("returns null for an unknown slug", () => {
+		expect(vaultBySlug(vaults, "nope")).toBeNull();
+	});
+
+	it("returns null when vaults or slug are missing", () => {
+		expect(vaultBySlug(undefined, "work")).toBeNull();
+		expect(vaultBySlug(vaults, undefined)).toBeNull();
+	});
+});
+
+describe("preferredVault", () => {
+	it("prefers the hinted vault", () => {
+		expect(preferredVault(vaults, "id-c")?.slug).toBe("archive");
+	});
+
+	it("falls back to the default when the hint is stale", () => {
+		expect(preferredVault(vaults, "id-gone")?.slug).toBe("personal");
+	});
+
+	it("falls back to the default when there is no hint", () => {
+		expect(preferredVault(vaults, null)?.slug).toBe("personal");
+	});
+
+	it("falls back to the first vault when none is marked default", () => {
+		expect(preferredVault([v("id-a", "work"), v("id-c", "archive")], null)?.slug).toBe("work");
+	});
+
+	it("returns null when there are no vaults", () => {
+		expect(preferredVault([], null)).toBeNull();
+		expect(preferredVault(undefined, "id-a")).toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bun run test -- vault-slug`
+Expected: FAIL, "Failed to resolve import ./vault-slug".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `backend/frontend/src/api/vault-slug.ts`:
+
+```ts
+import type { Vault } from "./queries";
+
+export function vaultBySlug(vaults: Vault[] | undefined, slug: string | undefined): Vault | null {
+	if (!vaults || !slug) {
+		return null;
+	}
+	return vaults.find((v) => v.slug === slug) ?? null;
+}
+
+// Used only where the URL does NOT name a vault: the bare `/` redirect and the
+// legacy `/note/:id` redirect. `hintId` is the last-used vault (localStorage via
+// the active-vault store); it is a hint, not authority, so a stale id silently
+// degrades to the default vault.
+export function preferredVault(vaults: Vault[] | undefined, hintId: string | null): Vault | null {
+	if (!vaults || vaults.length === 0) {
+		return null;
+	}
+	return (
+		(hintId ? vaults.find((v) => v.id === hintId) : undefined) ??
+		vaults.find((v) => v.is_default) ??
+		vaults[0] ??
+		null
+	);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend/frontend && bun run test -- vault-slug`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/vault-slug.ts src/api/vault-slug.test.ts
+git commit -m "feat(vaults): add slug resolution helpers"
+```
+
+---
+
+## Task 10: VaultRoute, VaultRedirect, LegacyNoteRedirect
+
+**Files:**
+- Create: `backend/frontend/src/viewer/vault-route.tsx`
+- Create: `backend/frontend/src/viewer/vault-redirect.tsx`
+- Create: `backend/frontend/src/viewer/legacy-note-redirect.tsx`
+- Test: `backend/frontend/src/viewer/vault-route.test.tsx`
+
+**Interfaces:**
+- Consumes: `vaultBySlug`, `preferredVault` (Task 9); `useVaults` from `api/queries`; `getActiveVaultId`, `setActiveVaultId`, `useActiveVaultId` from `api/active-vault`; `NotFoundPage` from `../not-found`; `LoadingPane` from `./loading-pane`; `EmptyVaultState` from `../layout/empty-vault-state`.
+- Produces: three default-exported components.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/frontend/src/viewer/vault-route.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getActiveVaultId, setActiveVaultId } from "../api/active-vault";
+import LegacyNoteRedirect from "./legacy-note-redirect";
+import VaultRedirect from "./vault-redirect";
+import VaultRoute from "./vault-route";
+
+const vaults = [
+	{ id: "id-a", slug: "work", is_default: false, name: "Work" },
+	{ id: "id-b", slug: "personal", is_default: true, name: "Personal" },
+];
+
+let mockVaults: unknown[] | undefined = vaults;
+let mockPending = false;
+
+vi.mock("../api/queries", () => ({
+	useVaults: () => ({ data: mockVaults, isPending: mockPending }),
+}));
+
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.search}${loc.hash}`}</output>;
+}
+
+// Records the active vault id at RENDER time, not in an effect, so the test can
+// prove no child ever renders under the wrong vault.
+function VaultProbe() {
+	return <output data-testid="child">{String(getActiveVaultId())}</output>;
+}
+
+beforeEach(() => {
+	mockVaults = vaults;
+	mockPending = false;
+	setActiveVaultId(null);
+});
+
+describe("VaultRoute", () => {
+	function renderRoute(entry: string) {
+		return render(
+			<MemoryRouter initialEntries={[entry]}>
+				<Routes>
+					<Route path="/:slug" element={<VaultRoute />}>
+						<Route index element={<VaultProbe />} />
+					</Route>
+				</Routes>
+			</MemoryRouter>,
+		);
+	}
+
+	it("resolves the slug and renders children under that vault", async () => {
+		renderRoute("/work");
+		expect(await screen.findByTestId("child")).toHaveTextContent("id-a");
+	});
+
+	it("never renders children under the previous vault", async () => {
+		setActiveVaultId("id-b");
+		renderRoute("/work");
+		const child = await screen.findByTestId("child");
+		// If VaultRoute rendered its Outlet before the store caught up, this
+		// would have been "id-b" for one pass and ~25 queries would have fired
+		// against the wrong vault.
+		expect(child).toHaveTextContent("id-a");
+	});
+
+	it("404s on an unknown slug", () => {
+		renderRoute("/nope");
+		expect(screen.queryByTestId("child")).toBeNull();
+		expect(screen.getByText(/not found/i)).toBeInTheDocument();
+	});
+
+	it("waits rather than 404ing while the vault list is loading", () => {
+		mockVaults = undefined;
+		mockPending = true;
+		renderRoute("/work");
+		expect(screen.queryByText(/not found/i)).toBeNull();
+		expect(screen.queryByTestId("child")).toBeNull();
+	});
+});
+
+describe("VaultRedirect", () => {
+	function renderRedirect(entry: string) {
+		return render(
+			<MemoryRouter initialEntries={[entry]}>
+				<LocationProbe />
+				<Routes>
+					<Route path="/" element={<VaultRedirect />} />
+					<Route path="/:slug" element={<p>vault page</p>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+	}
+
+	it("redirects to the hinted vault", async () => {
+		setActiveVaultId("id-a");
+		renderRedirect("/");
+		expect(await screen.findByTestId("loc")).toHaveTextContent("/work");
+	});
+
+	it("redirects to the default vault with no hint", async () => {
+		renderRedirect("/");
+		expect(await screen.findByTestId("loc")).toHaveTextContent("/personal");
+	});
+
+	it("preserves search and hash across the bounce", async () => {
+		renderRedirect("/?highlight=abc#settings/vaults");
+		expect(await screen.findByTestId("loc")).toHaveTextContent(
+			"/personal?highlight=abc#settings/vaults",
+		);
+	});
+
+	it("renders the empty state when there are no vaults", () => {
+		mockVaults = [];
+		renderRedirect("/");
+		expect(screen.getByText(/no vaults/i)).toBeInTheDocument();
+	});
+});
+
+describe("LegacyNoteRedirect", () => {
+	it("rewrites /note/:id to /:slug/:id using the hinted vault", async () => {
+		setActiveVaultId("id-a");
+		render(
+			<MemoryRouter initialEntries={["/note/n-1"]}>
+				<LocationProbe />
+				<Routes>
+					<Route path="/note/:id" element={<LegacyNoteRedirect />} />
+					<Route path="/:slug/:itemId" element={<p>note page</p>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+		expect(await screen.findByTestId("loc")).toHaveTextContent("/work/n-1");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/frontend && bun run test -- vault-route`
+Expected: FAIL, "Failed to resolve import ./legacy-note-redirect".
+
+- [ ] **Step 3: Write VaultRoute**
+
+Create `backend/frontend/src/viewer/vault-route.tsx`:
+
+```tsx
+import { useEffect } from "react";
+import { Outlet, useParams } from "react-router";
+import { setActiveVaultId, useActiveVaultId } from "../api/active-vault";
+import { useVaults } from "../api/queries";
+import { vaultBySlug } from "../api/vault-slug";
+import NotFoundPage from "../not-found";
+import LoadingPane from "./loading-pane";
+
+// The URL is the source of truth for the active vault. This is the ONLY place
+// that writes the store from a route; ~30 consumers (queries.ts, use-channel,
+// folder-tree, trace, remote-log) read it unchanged.
+export default function VaultRoute() {
+	const { slug } = useParams();
+	const { data: vaults, isPending } = useVaults();
+	const activeId = useActiveVaultId();
+	const vault = vaultBySlug(vaults, slug);
+
+	useEffect(() => {
+		if (vault) {
+			setActiveVaultId(vault.id);
+		}
+	}, [vault]);
+
+	// The list is normally already warm: useAppBootstrap seeds ["vaults"] and
+	// runs in OnboardingGate, above this route. This only gates a genuine cold
+	// fetch, and must come before the 404 so a slow list is not mistaken for a
+	// bad slug.
+	if (isPending && !vaults) {
+		return <LoadingPane />;
+	}
+	if (!vault) {
+		return <NotFoundPage />;
+	}
+	// Load-bearing: the effect above lands AFTER this render. Without the hold,
+	// one pass escapes with the PREVIOUS vault id and every descendant query and
+	// the channel join fire against the wrong vault.
+	if (activeId !== vault.id) {
+		return <LoadingPane />;
+	}
+	return <Outlet />;
+}
+```
+
+- [ ] **Step 4: Write VaultRedirect and LegacyNoteRedirect**
+
+Create `backend/frontend/src/viewer/vault-redirect.tsx`:
+
+```tsx
+import { Navigate, useLocation } from "react-router";
+import { getActiveVaultId } from "../api/active-vault";
+import { useVaults } from "../api/queries";
+import { preferredVault } from "../api/vault-slug";
+import { EmptyVaultState } from "../layout/empty-vault-state";
+import LoadingPane from "./loading-pane";
+
+// Bare `/` does not name a vault, so pick one: last-used, else default, else
+// first. Search and hash are carried across so links like
+// `/?highlight=<id>#settings/vaults` (the vault-deleted email) survive.
+export default function VaultRedirect() {
+	const { data: vaults, isPending } = useVaults();
+	const location = useLocation();
+
+	if (isPending && !vaults) {
+		return <LoadingPane />;
+	}
+	const vault = preferredVault(vaults, getActiveVaultId());
+	if (!vault) {
+		return <EmptyVaultState />;
+	}
+	return (
+		<Navigate
+			to={{ pathname: `/${vault.slug}`, search: location.search, hash: location.hash }}
+			replace
+		/>
+	);
+}
+```
+
+Create `backend/frontend/src/viewer/legacy-note-redirect.tsx`:
+
+```tsx
+import { Navigate, useLocation, useParams } from "react-router";
+import { getActiveVaultId } from "../api/active-vault";
+import { useVaults } from "../api/queries";
+import { preferredVault } from "../api/vault-slug";
+import NotFoundPage from "../not-found";
+import LoadingPane from "./loading-pane";
+
+// Old `/note/:id` links. A note id alone does not name its vault, so this is
+// best effort: resolve the last-used vault and rewrite. If the note actually
+// lives elsewhere the note fetch 404s, which is exactly what happened before
+// this change, so no regression. A server-side note-to-vault lookup would make
+// it exact and is deliberately out of scope.
+export default function LegacyNoteRedirect() {
+	const { id } = useParams();
+	const { data: vaults, isPending } = useVaults();
+	const location = useLocation();
+
+	if (isPending && !vaults) {
+		return <LoadingPane />;
+	}
+	const vault = preferredVault(vaults, getActiveVaultId());
+	if (!vault || !id) {
+		return <NotFoundPage />;
+	}
+	return (
+		<Navigate
+			to={{ pathname: `/${vault.slug}/${id}`, search: location.search, hash: location.hash }}
+			replace
+		/>
+	);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend/frontend && bun run test -- vault-route`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/viewer/vault-route.tsx src/viewer/vault-redirect.tsx src/viewer/legacy-note-redirect.tsx src/viewer/vault-route.test.tsx
+git commit -m "feat(vaults): add URL-driven vault resolution routes"
+```
+
+---
+
+## Task 11: Wire vault routes into the router
+
+**Files:**
+- Modify: `backend/frontend/src/router.tsx`
+
+**Interfaces:**
+- Consumes: `VaultRoute`, `VaultRedirect`, `LegacyNoteRedirect` (Task 10).
+- Produces: live `/:slug` and `/:slug/:itemId` routes.
+
+- [ ] **Step 1: Add the lazy imports**
+
+In `backend/frontend/src/router.tsx`, next to the other lazy declarations:
+
+```tsx
+const VaultRoute = lazy(() => import("./viewer/vault-route"));
+const VaultRedirect = lazy(() => import("./viewer/vault-redirect"));
+const LegacyNoteRedirect = lazy(() => import("./viewer/legacy-note-redirect"));
+```
+
+- [ ] **Step 2: Replace AppLayout's children**
+
+Replace the `AppLayout` children array (which after Task 4 holds only `ROUTES.HOME` and `/note/:id`) with:
+
+```tsx
+children: [
+	// Bare `/` picks a vault; `/note/:id` is the pre-vault-scoping URL shape.
+	{ path: ROUTES.HOME, element: suspended(<VaultRedirect />) },
+	{ path: "/note/:id", element: suspended(<LegacyNoteRedirect />) },
+	// Vault-scoped. Kept LAST so every static route above wins RR's
+	// static-over-dynamic ranking.
+	{
+		path: "/:slug",
+		element: suspended(<VaultRoute />),
+		children: [
+			{ index: true, element: suspended(<Dashboard />) },
+			{ path: ":itemId", element: suspended(<VaultItemPage />) },
+		],
+	},
+],
+```
+
+- [ ] **Step 3: Update the VaultItemPage param name**
+
+`VaultItemPage` reads `const { id } = useParams()` (`vault-item-page.tsx:18`). The param is now `itemId`. Change it to `const { itemId: id } = useParams();` and update the comment on line 11 from `/note/:id` to `/:slug/:itemId`.
+
+Check `note-page.tsx` and `attachment-page.tsx` for their own `useParams()` calls and apply the same rename. Run `cd backend/frontend && grep -rn 'useParams' src/viewer/` to find them all.
+
+- [ ] **Step 4: Verify build and full suite**
+
+Run: `cd backend/frontend && bun run build && bun run test`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/router.tsx src/viewer/
+git commit -m "feat(router): serve notes at /:slug/:itemId"
+```
+
+---
+
+## Task 12: Vault-scoped note links and vault switching
+
+**Files:**
+- Modify: `backend/frontend/src/layout/vault-switcher.tsx`
+- Modify: `backend/frontend/src/layout/search-panel.tsx:170`, `api/queries.ts:626`, `viewer/dashboard.tsx:24`, `viewer/tree/tree-row.tsx:230,273`
+- Modify: `backend/frontend/src/onboarding/onboarding-shell.tsx:37`, `onboarding/tour/controller.tsx:35`
+- Test: `backend/frontend/src/layout/vault-switcher.test.tsx`
+
+**Interfaces:**
+- Consumes: `useVaults`, `useActiveVaultId`, `vaultBySlug`.
+- Produces: no new exports.
+
+Every note link needs the active vault's slug. Add a tiny hook rather than repeating the lookup at six sites.
+
+- [ ] **Step 1: Add the hook**
+
+Append to `backend/frontend/src/api/vault-slug.ts`:
+
+```ts
+import { useActiveVaultId } from "./active-vault";
+import { useVaults } from "./queries";
+
+// Slug of the vault currently in the store, for building note hrefs. Returns
+// null only before the vault list lands, which in practice does not happen
+// inside AppLayout (useAppBootstrap seeds it above).
+export function useActiveVaultSlug(): string | null {
+	const vaults = useVaults().data;
+	const activeId = useActiveVaultId();
+	return vaults?.find((v) => v.id === activeId)?.slug ?? null;
+}
+```
+
+Add a test to `vault-slug.test.ts` is not required here; the hook is exercised by the link-site tests below and by `vault-switcher.test.tsx`.
+
+- [ ] **Step 2: Write the failing switcher test**
+
+Add to `backend/frontend/src/layout/vault-switcher.test.tsx`:
+
+```tsx
+it("navigates to the new vault instead of writing the store directly", async () => {
+	render(
+		<MemoryRouter initialEntries={["/work/note-1"]}>
+			<LocationProbe />
+			<VaultSwitcher />
+		</MemoryRouter>,
+	);
+	fireEvent.click(screen.getByRole("button", { name: /vault/i }));
+	fireEvent.click(screen.getByRole("menuitemradio", { name: /personal/i }));
+	// Switching vaults leaves the old note behind: its id is meaningless in the
+	// new vault, so land on the vault root.
+	expect(screen.getByTestId("loc")).toHaveTextContent("/personal");
+	expect(screen.getByTestId("loc")).not.toHaveTextContent("note-1");
+});
+```
+
+Add a `LocationProbe` to the file if absent (same shape as Task 5).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd backend/frontend && bun run test -- vault-switcher`
+Expected: FAIL, location stays `/work/note-1`.
+
+- [ ] **Step 4: Rework the switcher**
+
+In `backend/frontend/src/layout/vault-switcher.tsx`:
+
+Delete the reconciliation effect at lines 19-31 entirely. `VaultRedirect` now owns choosing a vault when none is valid, and it does so by navigating rather than writing the store.
+
+Replace the `onValueChange` handler:
+
+```tsx
+onValueChange={(next) => {
+	if (next === active.id) {
+		return;
+	}
+	const target = vaults.find((v) => v.id === next);
+	if (!target) {
+		return;
+	}
+	// Navigate; VaultRoute writes the active-vault store. Land on the vault
+	// root, not the current note, whose id does not exist in the new vault.
+	navigate(`/${target.slug}`);
+	qc.invalidateQueries();
+	// Onboarding tour gates step 0 on a real switch; emit a DOM event the
+	// controller can listen for without coupling layers.
+	window.dispatchEvent(
+		new CustomEvent("engram:vault-switched", { detail: { from: active.id, to: next } }),
+	);
+}}
+```
+
+Add `import { useNavigate } from "react-router";` and `const navigate = useNavigate();`. Remove the now-unused `setActiveVaultId` import.
+
+- [ ] **Step 5: Update the note link sites**
+
+In each file, get the slug with `const slug = useActiveVaultSlug();` and build the href. Where `slug` can be null, fall back to the legacy shape so the link still resolves through `LegacyNoteRedirect` rather than producing `/null/<id>`:
+
+| File:line | From | To |
+|---|---|---|
+| `layout/search-panel.tsx:170` | `` const href = `/note/${result.id}` `` | `` const href = slug ? `/${slug}/${result.id}` : `/note/${result.id}` `` |
+| `viewer/dashboard.tsx:24` | ``to={`/note/${note.id}`}`` | ``to={slug ? `/${slug}/${note.id}` : `/note/${note.id}`}`` |
+| `viewer/tree/tree-row.tsx:230,273` | ``to={`/note/${item.id}`}`` | ``to={slug ? `/${slug}/${item.id}` : `/note/${item.id}`}`` |
+
+`api/queries.ts:626` is inside a mutation callback, not a component, so it cannot use the hook. Change `navigate(\`/note/${id}\`)` to use the vault already in scope at that call site:
+
+```ts
+// vaultId is already resolved in this mutation's closure; look up its slug from
+// the cache rather than re-deriving it.
+const slug = qc.getQueryData<Vault[]>(["vaults"])?.find((v) => v.id === vaultId)?.slug;
+navigate(slug ? `/${slug}/${id}` : `/note/${id}`);
+```
+
+- [ ] **Step 6: Update the tour comments**
+
+Comments only. There is no `/note/` path logic anywhere in `src/onboarding/`: every navigation there targets `/` or `/onboard/*`, and `/` now routes through `VaultRedirect`, so the tour needs no behavioral change. The demo vaults already carry distinct slugs (`queries.ts:1205,1212`), so demo routing works unmodified.
+
+- `onboarding-shell.tsx:37`: change `` The tour walks through a demo note (`/note/<id>`) that doesn't exist `` to `` The tour walks through a demo note (`/<slug>/<id>`) that doesn't exist ``
+- `tour/controller.tsx:35`: change `we're on /note/<id> and Joyride times out waiting for that target.` to `we're on /<slug>/<id> and Joyride times out waiting for that target.`
+
+Verify nothing else: `grep -rn '/note' src/onboarding/` should return only these two lines before the edit and nothing after.
+
+- [ ] **Step 7: Verify no stale note links remain**
+
+Run: `cd backend/frontend && grep -rn '`/note/' src/ --include=*.tsx --include=*.ts | grep -v legacy-note-redirect | grep -v '\.test\.'`
+Expected: only the fallback branches added above.
+
+- [ ] **Step 8: Run tests, lint, commit**
+
+```bash
+cd backend/frontend && bun run test && bun run build && ./node_modules/.bin/biome ci
+git add -A src/
+git commit -m "feat(vaults): make note links vault-scoped"
+```
+
+---
+
+## Task 13: E2E helper and full verification
+
+**Files:**
+- Modify: `backend/e2e/helpers/web_spa.py:66,78`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: no new exports.
+
+`open_note(note_id, vault_id)` already seeds `engram.activeVaultId` before sign-in, so `LegacyNoteRedirect` resolves the right slug and rewrites the URL. Only the post-sign-in URL assertion needs to accept the rewritten shape.
+
+- [ ] **Step 1: Widen the wait_for_url assertion**
+
+In `backend/e2e/helpers/web_spa.py`, replace line 78:
+
+```python
+        # The seeded activeVaultId lets LegacyNoteRedirect rewrite /note/<id> to
+        # /<vault-slug>/<id>, so match on the id with a boundary rather than the
+        # old fixed /note/ prefix. Accepts both shapes.
+        await page.wait_for_url(
+            re.compile(rf"/{re.escape(str(note_id))}(?:[?#]|$)"), timeout=15_000
+        )
+```
+
+Update the docstring on line 57 to say it opens the note at its vault-scoped URL.
+
+- [ ] **Step 2: Run the E2E suite**
+
+```bash
+cd /home/open-claw/documents/code-projects/engram-workspace
+make ci-up
+make e2e
+```
+
+Expected: green. If a test fails on a URL assertion, fix the assertion; do not loosen a behavioral assert.
+
+- [ ] **Step 3: Manual smoke against saas-dev**
+
+```bash
+cd /home/open-claw/documents/code-projects/engram-workspace
+make saas-dev BACKEND_DIR=~/documents/code-projects/engram/.worktrees/feat-vault-scoped-urls
+```
+
+Walk through and confirm each:
+
+1. Sign in, land on `/<your-default-slug>`.
+2. Open a note, URL is `/<slug>/<uuid>`.
+3. Open settings from the note. URL gains `#settings/account`, the note stays visible behind the dialog.
+4. Close settings. You are back on the note, not the dashboard.
+5. Browser Back reopens settings; Forward closes it again.
+6. Switch vaults. URL becomes `/<other-slug>`, the tree reloads, no 404s in the network panel.
+7. Paste `/<other-slug>/<a-note-id-from-the-first-vault>`. You get a note-not-found, not a blank page.
+8. Hard-refresh on `/<slug>/<uuid>`. The SPA boots (this exercises the new Phoenix route).
+9. Visit `/settings/billing`. You are redirected to `/<slug>#settings/billing`.
+10. Visit `/note/<uuid>`. You are redirected to `/<slug>/<uuid>`.
+11. Visit `/api/notez`. You get a plain-text 404, NOT the SPA.
+12. Try creating a vault with slug `settings`. The form rejects it.
+
+- [ ] **Step 4: Full gauntlet**
+
+```bash
+cd backend && mix format && mix credo && mix dialyzer && mix test
+cd frontend && bun run test && bun run build && ./node_modules/.bin/biome ci
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit and open the PR**
+
+```bash
+git add e2e/helpers/web_spa.py
+git commit -m "test(e2e): accept vault-scoped note URLs"
+git push -u origin feat/vault-scoped-urls
+gh pr create --title "feat: vault-scoped SPA URLs + settings hash overlay" --body "..."
+```
+
+PR body must state: the URL is now the source of truth for the active vault; settings moved from a path route to a `#settings/<section>` overlay; and the Phoenix deny-list is a standing obligation, so any future non-SPA top-level prefix must be added to it.
+
+---
+
+## Self-Review Notes
+
+Spec sections mapped to tasks:
+
+| Spec section | Task(s) |
+|---|---|
+| Direction of data flow | 9, 10, 11, 12 |
+| Route tree | 4, 11 |
+| `VaultRoute` incl. hold-until-resolved | 10 |
+| `VaultRedirect`, `LegacyNoteRedirect` | 10 |
+| `LegacySettingsRedirect` | 3 |
+| `SettingsOverlayHost` | 3, 4 |
+| Settings overlay behavior | 1, 2 |
+| Vault switching | 12 |
+| Demo vaults / tour | 12 |
+| Phoenix routing + deny-list | 7 |
+| Reserved slugs | 8 |
+| Backend link updates | 6 |
+| Frontend link updates | 5, 12 |
+| Testing (frontend unit) | 1, 2, 3, 5, 9, 10, 12 |
+| Testing (backend) | 6, 7, 8 |
+| Testing (E2E) | 13 |
+
+Deviation from the spec worth noting: the spec listed `useActiveVaultSlug` nowhere; it was added in Task 12 to avoid repeating the same vault lookup at six link sites. It is a thin wrapper over `useVaults` and `useActiveVaultId`, both already in the spec.

--- a/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
+++ b/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
@@ -299,11 +299,23 @@ describe("SettingsDialog", () => {
 	});
 
 	it("strips the hash on close and keeps you on the same page", async () => {
-		renderDialog("account", "/work/note-1#settings/account");
-		fireEvent.click(screen.getByRole("button", { name: /close settings/i }));
-		// The close is deferred by CLOSE_ANIMATION_MS so the Radix exit
-		// transition plays; findBy* polls past it.
-		expect(await screen.findByText("/work/note-1")).toBeInTheDocument();
+		// The close navigate is deferred by CLOSE_ANIMATION_MS so the Radix exit
+		// transition plays. Advance the clock explicitly rather than waiting on
+		// it: with real timers this asserts a deterministic behavior by racing
+		// the wall clock, and under full-suite parallel load the event loop
+		// starves past findBy*'s 1000ms default. Measured ~17% flake rate that
+		// way. Fake timers remove the race instead of widening the window.
+		vi.useFakeTimers();
+		try {
+			renderDialog("account", "/work/note-1#settings/account");
+			fireEvent.click(screen.getByRole("button", { name: /close settings/i }));
+			await act(async () => {
+				vi.advanceTimersByTime(CLOSE_ANIMATION_MS);
+			});
+			expect(screen.getByText("/work/note-1")).toBeInTheDocument();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("falls back to account when the section is unavailable in this config", async () => {

--- a/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
+++ b/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
@@ -520,10 +520,14 @@ describe("SettingsOverlayHost", () => {
 		expect(screen.queryByTestId("dialog")).toBeNull();
 	});
 
-	it("keeps the page mounted underneath when settings is open", () => {
+	it("keeps the page mounted underneath when settings is open", async () => {
 		renderHost("/work/note-1#settings/billing");
+		// The page underneath is synchronous (plain Outlet), but the dialog is
+		// lazy(), so it sits behind a Suspense boundary that resolves on a
+		// microtask. `vi.mock` does not make the dynamic import synchronous.
+		// Await the dialog; asserting it with a sync getBy* would always throw.
 		expect(screen.getByText("note body")).toBeInTheDocument();
-		expect(screen.getByTestId("dialog")).toHaveTextContent("section:billing");
+		expect(await screen.findByTestId("dialog")).toHaveTextContent("section:billing");
 	});
 
 	it("ignores unrelated hashes", () => {

--- a/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
+++ b/docs/superpowers/plans/2026-07-28-vault-scoped-urls.md
@@ -24,7 +24,11 @@
 - `@testing-library/user-event` is NOT a dependency. Use `fireEvent` from `@testing-library/react`, the existing convention across the suite. Add it to the file's existing `@testing-library/react` import where a snippet below uses it.
 - Nav links inside the settings dialog must be react-router `<Link>`, never a plain `<a href="#...">`. React Router v8's browser history listens to `popstate` only (`node_modules/react-router/dist/development/lib/router/history.js:335`); a native anchor hash navigation fires `hashchange` but not `popstate`, so `useLocation()` would go stale and `SettingsOverlayHost` would stop switching sections. `<Link to="#settings/x">` resolves to `<pathname>#settings/x`, so assert href with a suffix match, never string equality against a bare hash.
 - Reserved slug list, verbatim, identical in Elixir and TypeScript:
-  `sign-in sign-up waitlist link oauth onboard reset-password note search billing settings api webhooks .well-known`
+  `sign-in sign-up waitlist link oauth onboard reset-password note search billing settings api webhooks .well-known assets email socket`
+  (`assets`, `email`, and `socket` were added after Task 7 discovered them as non-SPA
+  prefixes. They are MORE important than the frontend-derived entries: those merely get
+  shadowed, but these now hit a hard 404 from the deny-list, so a vault slugged `assets`
+  would be completely unreachable rather than just awkward.)
 
 ---
 
@@ -1041,6 +1045,14 @@ In `backend/lib/engram_web/router.ex`, inside the existing `scope "/", EngramWeb
     # favicon.svg, engram-mark.svg, robots.txt) deliberately get NO entry: a
     # miss there is cosmetic and means a broken build, not a live failure.
     match :*, "/email/*path", SpaController, :not_found
+    # /socket is claimed by `socket_dispatch` in endpoint.ex, but ONLY for the
+    # exact transport subpath /socket/websocket. Bare /socket, /socket/bogus,
+    # and the second mount /socket/origin-probe all fall through to the router.
+    # The repo already treats this as a top-level prefix: see @api_allowed_prefixes
+    # in lib/engram_web/plugs/host_rewrite.ex. Adding this entry is safe because
+    # socket_dispatch runs BEFORE the router, so the real transport path never
+    # reaches here, but that MUST be covered by a test.
+    match :*, "/socket/*path", SpaController, :not_found
 
     # Vault-scoped SPA routes. `/:slug` is a vault, `/:slug/:id` a note or
     # attachment. Kept last so every static route above wins.
@@ -1133,6 +1145,7 @@ In `backend/lib/engram/vaults/vault.ex`, add above `def changeset`:
   @reserved_slugs ~w(
     sign-in sign-up waitlist link oauth onboard reset-password
     note search billing settings api webhooks .well-known
+    assets email socket
   )
 ```
 

--- a/e2e/helpers/web_spa.py
+++ b/e2e/helpers/web_spa.py
@@ -55,7 +55,7 @@ class WebSpaPeer:
         self._page = await self._ctx.new_page()
 
     async def open_note(self, note_id: str, vault_id: str) -> None:
-        """Sign in (if needed) and open ``/note/<note_id>`` in the editor.
+        """Sign in (if needed) and open the note at its vault-scoped URL.
 
         Mirrors ``signInForNote``: navigate to the note, get bounced to the
         sign-in page, seed ``engram.activeVaultId`` BEFORE completing sign-in so
@@ -75,7 +75,12 @@ class WebSpaPeer:
         await page.get_by_label("Password", exact=True).fill(self.password)
         await page.get_by_role("button", name=re.compile("sign in", re.I)).click()
 
-        await page.wait_for_url(re.compile(rf"/note/{re.escape(str(note_id))}"), timeout=15_000)
+        # The seeded activeVaultId lets LegacyNoteRedirect rewrite /note/<id> to
+        # /<vault-slug>/<id>, so match on the id with a boundary rather than the
+        # old fixed /note/ prefix. Accepts both shapes.
+        await page.wait_for_url(
+            re.compile(rf"/{re.escape(str(note_id))}(?:[?#]|$)"), timeout=15_000
+        )
         await self._editor().wait_for(state="visible", timeout=15_000)
 
     def _editor(self):

--- a/e2e/tests/api_only/test_71_connections.py
+++ b/e2e/tests/api_only/test_71_connections.py
@@ -411,11 +411,11 @@ async def test_free_tier_cap_blocks_second_mcp_consent(clerk_client):
         assert body["limit"] == 1
         assert body["tier"] == "free"
         # upgrade_url is config-driven (ENGRAM_UPGRADE_URL); SaaS default is
-        # the full https://app.engram.page/settings/billing URL, self-host
+        # the full https://app.engram.page/#settings/billing URL, self-host
         # can override. Assert the path suffix only.
         assert body["upgrade_url"] and body["upgrade_url"].endswith(
-            "/settings/billing"
-        ), f"upgrade_url should end with /settings/billing; got {body['upgrade_url']!r}"
+            "/#settings/billing"
+        ), f"upgrade_url should end with /#settings/billing; got {body['upgrade_url']!r}"
     finally:
         clerk_client.delete_user(clerk_user_id)
 
@@ -437,11 +437,11 @@ async def test_free_tier_pat_minting_blocked(clerk_client):
         body = resp.json()
         assert body["error"] == "pat_disabled_on_free"
         # upgrade_url is config-driven (ENGRAM_UPGRADE_URL); SaaS default is
-        # the full https://app.engram.page/settings/billing URL, self-host
+        # the full https://app.engram.page/#settings/billing URL, self-host
         # can override. Assert the path suffix only.
         assert body["upgrade_url"] and body["upgrade_url"].endswith(
-            "/settings/billing"
-        ), f"upgrade_url should end with /settings/billing; got {body['upgrade_url']!r}"
+            "/#settings/billing"
+        ), f"upgrade_url should end with /#settings/billing; got {body['upgrade_url']!r}"
     finally:
         clerk_client.delete_user(clerk_user_id)
 
@@ -694,10 +694,10 @@ async def test_free_tier_cap_blocks_second_device_authorize(clerk_client):
         assert body["current"] == 1
         assert body["limit"] == 1
         # upgrade_url is config-driven (ENGRAM_UPGRADE_URL); SaaS default is
-        # the full https://app.engram.page/settings/billing URL, self-host
+        # the full https://app.engram.page/#settings/billing URL, self-host
         # can override. Assert the path suffix only.
         assert body["upgrade_url"] and body["upgrade_url"].endswith(
-            "/settings/billing"
-        ), f"upgrade_url should end with /settings/billing; got {body['upgrade_url']!r}"
+            "/#settings/billing"
+        ), f"upgrade_url should end with /#settings/billing; got {body['upgrade_url']!r}"
     finally:
         clerk_client.delete_user(clerk_user_id)

--- a/e2e/tests/crdt/test_web_to_obsidian_live.py
+++ b/e2e/tests/crdt/test_web_to_obsidian_live.py
@@ -40,7 +40,8 @@ CRDT_TIMEOUT = DELIVERY_TIMEOUT  # true-breakage bound, not a latency assert
 
 
 def _note_id(api_sync, path: str) -> str:
-    """Server note id for `path` (the SPA opens /note/<id>). Shape-robust."""
+    """Server note id for `path` (the SPA opens the note at its vault-scoped
+    URL; /note/<id> only redirects there). Shape-robust."""
     note = api_sync.wait_for_note(path, timeout=CRDT_TIMEOUT)
     inner = note.get("note", note) if isinstance(note, dict) else {}
     nid = inner.get("id") or inner.get("note_id") or inner.get("uuid")

--- a/frontend/e2e/note-properties.spec.ts
+++ b/frontend/e2e/note-properties.spec.ts
@@ -1,4 +1,8 @@
 import { expect, type Page, test } from "@playwright/test";
+// The URL-shape matcher is imported rather than copied: the note route moved
+// once already (/note/:id -> /:vaultSlug/:noteId) and a duplicated regex here
+// is exactly what went stale last time.
+import { noteUrlRe } from "./support/api";
 
 /**
  * E2e coverage for the PropertiesWidget (#frontmatter-properties).
@@ -97,8 +101,9 @@ async function upsertNote(
 }
 
 /**
- * Navigate to the note URL; AuthGuard redirects to /sign-in, complete sign-in,
- * and land back on /note/:id. Seeds engram.activeVaultId before sign-in so the
+ * Navigate to the legacy /note/:id URL; AuthGuard redirects to /sign-in,
+ * complete sign-in, and land on the note — the legacy-note redirect resolves
+ * it to /:vaultSlug/:noteId. Seeds engram.activeVaultId before sign-in so the
  * post-redirect render uses the correct vault.
  */
 async function signInForNote(
@@ -118,7 +123,7 @@ async function signInForNote(
 	await page.getByLabel("Password", { exact: true }).fill(PASS);
 	await page.getByRole("button", { name: /sign in/i }).click();
 
-	await expect(page).toHaveURL(new RegExp(`/note/${noteId}`), { timeout: 10_000 });
+	await expect(page).toHaveURL(noteUrlRe(noteId), { timeout: 10_000 });
 }
 
 /**
@@ -217,7 +222,7 @@ test.describe("PropertiesWidget e2e", () => {
 		// Reload the page — y-indexeddb restores the Y.Doc (including frontmatter_types)
 		// from IndexedDB; the type override must survive.
 		await page.reload();
-		await expect(page).toHaveURL(new RegExp(`/note/${noteId}`), { timeout: 10_000 });
+		await expect(page).toHaveURL(noteUrlRe(noteId), { timeout: 10_000 });
 
 		// Wait for the widget to re-render with the same note after reload.
 		await waitForProperty(page, "due");

--- a/frontend/e2e/support/api.ts
+++ b/frontend/e2e/support/api.ts
@@ -104,12 +104,21 @@ export async function createFolder(
 	}
 }
 
-// Navigates straight to /note/:id, which the AuthGuard redirects to
+// Matches "the browser is on this note's page" without hardcoding the URL
+// shape. Notes are served at /:vaultSlug/:noteId, and specs do not know the
+// slug; anchoring on the trailing id keeps these assertions working the next
+// time the shape moves (it already moved once, from the old /note/:id).
+export function noteUrlRe(noteId: number | string): RegExp {
+	return new RegExp(`/${noteId}(?:[?#]|$)`);
+}
+
+// Navigates straight to the legacy /note/:id, which the AuthGuard redirects to
 // /sign-in. Seeds localStorage["engram.activeVaultId"] on the sign-in page
 // BEFORE completing sign-in, not after, so the value survives the
 // post-sign-in redirect and NotePage's first query targets the right vault.
 // The vault-switcher's auto-select would not pick the newly created vault in
-// time otherwise. Then signs in and asserts arrival back at /note/:id.
+// time otherwise. Then signs in and asserts arrival on the note — via the
+// legacy-note redirect, which lands on /:vaultSlug/:noteId.
 export async function signInForNote(
 	page: Page,
 	email: string,
@@ -127,5 +136,5 @@ export async function signInForNote(
 	await page.getByLabel("Password", { exact: true }).fill(PASS);
 	await page.getByRole("button", { name: /sign in/iu }).click();
 
-	await expect(page).toHaveURL(new RegExp(`/note/${noteId}`), { timeout: 10_000 });
+	await expect(page).toHaveURL(noteUrlRe(noteId), { timeout: 10_000 });
 }

--- a/frontend/e2e/tree-ops-sync.spec.ts
+++ b/frontend/e2e/tree-ops-sync.spec.ts
@@ -2,6 +2,7 @@ import { expect, type Page, test } from "@playwright/test";
 import {
 	createFolder,
 	createVault,
+	noteUrlRe,
 	registerAndLogin,
 	signInForNote,
 	upsertNote,
@@ -211,10 +212,10 @@ test.describe("web tree ops sync (web to web)", () => {
 		// route/URL is left untouched (no redirect). That is the graceful
 		// state this test locks in: no dead editor showing stale content, no
 		// crash, no infinite spinner, just an explicit not-found message.
-		await expect(pageA).toHaveURL(new RegExp(`/note/${doomedId}`));
+		await expect(pageA).toHaveURL(noteUrlRe(doomedId));
 		await expect(pageA.getByText(/Failed to load note/u)).toBeVisible({ timeout: 10_000 });
 
-		await expect(pageB).toHaveURL(new RegExp(`/note/${doomedId}`));
+		await expect(pageB).toHaveURL(noteUrlRe(doomedId));
 		await expect(pageB.getByText(/Failed to load note/u)).toBeVisible({ timeout: 10_000 });
 
 		// No crash in either tab: the CRDT doc teardown (closeDoc fires from the
@@ -279,7 +280,8 @@ test.describe("web tree ops sync (web to web)", () => {
 		await expect(row(pageB, "mover")).toHaveCount(0, { timeout: 10_000 });
 
 		// Content sync must survive the move. Both tabs are anchored on the note
-		// (/note/:id, id stable across the move), so the editor stays bound.
+		// (/:vaultSlug/:noteId, id stable across the move), so the editor stays
+		// bound — the move changes the note's path, not its id.
 		// Edit in tab A and confirm it converges in tab B: a regression here means
 		// the move broke the note's live content channel.
 		const edA = pageA.locator(".cm-content");

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -8,6 +8,7 @@ import {
 	type Folder,
 	type Note,
 	useAcceptTerms,
+	useAppBootstrap,
 	useAttachments,
 	useBatchDeleteAttachments,
 	useBatchDeleteFolders,
@@ -31,6 +32,7 @@ import {
 	useReverseCancel,
 	useSearch,
 	useUploadAttachment,
+	useVaults,
 } from "./queries";
 
 vi.mock("sonner", () => ({
@@ -42,8 +44,10 @@ vi.mock("sonner", () => ({
 }));
 
 // queries.ts pulls useNavigate from react-router (useCreateNote). Stub it so
-// the hooks render without a Router in these unit tests.
-vi.mock("react-router", () => ({ useNavigate: () => () => {} }));
+// the hooks render without a Router in these unit tests. A shared spy (not a
+// bare no-op) so tests can assert what useCreateNote navigates to.
+const navigateSpy = vi.hoisted(() => vi.fn());
+vi.mock("react-router", () => ({ useNavigate: () => navigateSpy }));
 
 // Pin the active vault id so cache keys are deterministic for the
 // optimistic-update tests below. The hook reads from a module-scoped
@@ -93,6 +97,7 @@ beforeEach(() => {
 	crdtCreateNoteWithContent
 		.mockReset()
 		.mockImplementation((docId: string) => Promise.resolve(docId));
+	navigateSpy.mockClear();
 	qc = new QueryClient();
 });
 
@@ -1032,6 +1037,24 @@ describe("useCreateNote — optimistic placeholder", () => {
 			expect(root?.[0]?.id).toBe(MINTED_ID);
 			expect(root?.[0]?.pending).toBe(false);
 		});
+	});
+
+	// getQueryData(["vaults"]) bypasses useVaults's `select`, so the cache still
+	// holds the wire shape ({ vaults: [...] }), not the post-select array. This
+	// is the shape the key actually has whenever it was last populated by the
+	// real queryFn or by useAppBootstrap's seed (see the useVaults describe
+	// block below); reading it as a bare array throws inside onSuccess and
+	// silently kills the navigate call.
+	it("navigates to the vault-scoped route using the raw { vaults } cache shape", async () => {
+		qc.setQueryData(["folder-notes-by-id", "42", "root"], []);
+		qc.setQueryData(["vaults"], { vaults: [{ id: "42", slug: "work" }] });
+
+		const { result } = renderHook(() => useCreateNote(), { wrapper });
+		await act(async () => {
+			await result.current.mutateAsync({ folder: "", id: MINTED_ID });
+		});
+
+		expect(navigateSpy).toHaveBeenCalledWith(`/work/${MINTED_ID}`);
 	});
 
 	// `/api/folders` returns DERIVED folders (ones holding no note directly) with
@@ -2003,5 +2026,27 @@ describe("useUploadAttachment", () => {
 		expect(spy).toHaveBeenCalledWith({ queryKey: ["folders", "42"] });
 		expect(spy).toHaveBeenCalledWith({ queryKey: ["folderNotes", "42"] });
 		expect(spy).toHaveBeenCalledWith({ queryKey: ["attachments", "42"] });
+	});
+});
+
+describe("useAppBootstrap seeding useVaults", () => {
+	// Regression guard: useAppBootstrap seeds the ["vaults"] cache key with the
+	// same wire shape ({ vaults: [...] }) the /vaults queryFn itself returns, so
+	// useVaults's `select` unwraps it into the array on the very first render,
+	// with no extra fetch. If the seed is ever "simplified" to a bare array,
+	// `select` returns undefined and every vault-list consumer breaks silently.
+	it("useVaults resolves the seeded vault array, not undefined", async () => {
+		get.mockResolvedValueOnce({
+			onboarding: { enabled: false },
+			capabilities: { tier: "free", limits: {} },
+			vaults: { vaults: [{ id: "42", slug: "work", name: "Work" }] },
+		});
+
+		const boot = renderHook(() => useAppBootstrap(), { wrapper });
+		await waitFor(() => expect(boot.result.current.isSuccess).toBe(true));
+
+		const vaults = renderHook(() => useVaults(), { wrapper });
+		await waitFor(() => expect(vaults.result.current.isFetching).toBe(false));
+		expect(vaults.result.current.data).toEqual([{ id: "42", slug: "work", name: "Work" }]);
 	});
 });

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -626,7 +626,11 @@ export function useCreateNote() {
 			// vaultId is already resolved in this mutation's closure; look up its
 			// slug from the cache rather than re-deriving it (a hook is
 			// unavailable here, since this runs inside a mutation callback).
-			const slug = qc.getQueryData<Vault[]>(["vaults"])?.find((v) => v.id === vaultId)?.slug;
+			// getQueryData bypasses useVaults's `select`, so the raw cache entry
+			// is still the wire shape ({ vaults }), not the post-select array.
+			const slug = qc
+				.getQueryData<{ vaults: Vault[] }>(["vaults"])
+				?.vaults?.find((v) => v.id === vaultId)?.slug;
 			navigate(slug ? `/${slug}/${id}` : `/note/${id}`);
 		},
 		onError: (err, _vars, ctx) => {

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -623,7 +623,11 @@ export function useCreateNote() {
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			// Keep the path-keyed list fresh for the dashboard folder-browse view.
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId, vars.folder] });
-			navigate(`/note/${id}`);
+			// vaultId is already resolved in this mutation's closure; look up its
+			// slug from the cache rather than re-deriving it (a hook is
+			// unavailable here, since this runs inside a mutation callback).
+			const slug = qc.getQueryData<Vault[]>(["vaults"])?.find((v) => v.id === vaultId)?.slug;
+			navigate(slug ? `/${slug}/${id}` : `/note/${id}`);
 		},
 		onError: (err, _vars, ctx) => {
 			if (ctx) {

--- a/frontend/src/api/reserved-slugs.test.ts
+++ b/frontend/src/api/reserved-slugs.test.ts
@@ -16,6 +16,10 @@ describe("isReservedSlug", () => {
 		expect(isReservedSlug(".well-known")).toBe(true);
 	});
 
+	it("rejects the metrics slug the PromEx forward 401s on", () => {
+		expect(isReservedSlug("metrics")).toBe(true);
+	});
+
 	it("accepts ordinary slugs", () => {
 		expect(isReservedSlug("work")).toBe(false);
 		expect(isReservedSlug("settings-archive")).toBe(false);
@@ -26,7 +30,7 @@ describe("isReservedSlug", () => {
 		expect(RESERVED_SLUGS.length).toBeGreaterThan(0);
 	});
 
-	// Pins the exact 17-entry list. Written as a literal, not derived from
+	// Pins the exact 18-entry list. Written as a literal, not derived from
 	// RESERVED_SLUGS, so a deleted entry breaks this test instead of silently
 	// passing. Mirrored 1:1 in vault_test.exs (Elixir) - a human dropping an
 	// entry from either list must edit both and notice.
@@ -49,6 +53,7 @@ describe("isReservedSlug", () => {
 			"assets",
 			"email",
 			"socket",
+			"metrics",
 		]);
 	});
 });

--- a/frontend/src/api/reserved-slugs.test.ts
+++ b/frontend/src/api/reserved-slugs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isReservedSlug, RESERVED_SLUGS } from "./reserved-slugs";
+
+describe("isReservedSlug", () => {
+	it("rejects reserved slugs regardless of case or padding", () => {
+		expect(isReservedSlug("settings")).toBe(true);
+		expect(isReservedSlug("Settings")).toBe(true);
+		expect(isReservedSlug("  link  ")).toBe(true);
+	});
+
+	it("rejects the backend deny-listed prefixes too (Task 7)", () => {
+		expect(isReservedSlug("assets")).toBe(true);
+		expect(isReservedSlug("email")).toBe(true);
+		expect(isReservedSlug("socket")).toBe(true);
+		expect(isReservedSlug("webhooks")).toBe(true);
+		expect(isReservedSlug(".well-known")).toBe(true);
+	});
+
+	it("accepts ordinary slugs", () => {
+		expect(isReservedSlug("work")).toBe(false);
+		expect(isReservedSlug("settings-archive")).toBe(false);
+	});
+
+	it("exports the raw list for consumers that need it directly", () => {
+		expect(RESERVED_SLUGS).toContain("settings");
+		expect(RESERVED_SLUGS.length).toBeGreaterThan(0);
+	});
+});

--- a/frontend/src/api/reserved-slugs.test.ts
+++ b/frontend/src/api/reserved-slugs.test.ts
@@ -25,4 +25,30 @@ describe("isReservedSlug", () => {
 		expect(RESERVED_SLUGS).toContain("settings");
 		expect(RESERVED_SLUGS.length).toBeGreaterThan(0);
 	});
+
+	// Pins the exact 17-entry list. Written as a literal, not derived from
+	// RESERVED_SLUGS, so a deleted entry breaks this test instead of silently
+	// passing. Mirrored 1:1 in vault_test.exs (Elixir) - a human dropping an
+	// entry from either list must edit both and notice.
+	it("the reserved list is exactly this set", () => {
+		expect(RESERVED_SLUGS).toEqual([
+			"sign-in",
+			"sign-up",
+			"waitlist",
+			"link",
+			"oauth",
+			"onboard",
+			"reset-password",
+			"note",
+			"search",
+			"billing",
+			"settings",
+			"api",
+			"webhooks",
+			".well-known",
+			"assets",
+			"email",
+			"socket",
+		]);
+	});
 });

--- a/frontend/src/api/reserved-slugs.ts
+++ b/frontend/src/api/reserved-slugs.ts
@@ -1,10 +1,14 @@
 // Mirror of @reserved_slugs in lib/engram/vaults/vault.ex. Duplicated because
-// the check spans two languages; the backend changeset is authoritative and
-// this exists only to fail fast in the UI. Keep both lists identical:
+// the check spans two languages; the backend changeset is authoritative, and
+// this list currently has no runtime consumer in the SPA (the vault create
+// form has no slug field) - it exists as the cross-language mirror of the
+// Elixir list. Keep both lists identical:
 //   - Frontend-shadowed (sign-in..settings): React Router ranks static
 //     segments above `/:slug`, so these are simply unreachable by URL.
 //   - Backend-denied (api..socket): Task 7's Phoenix deny-list 404s these
 //     prefixes before the SPA ever loads.
+//   - Backend-forwarded (metrics): a bearer-auth-gated `forward` mounted
+//     ahead of the vault route 401s these before the SPA ever loads.
 export const RESERVED_SLUGS: readonly string[] = [
 	"sign-in",
 	"sign-up",
@@ -23,6 +27,7 @@ export const RESERVED_SLUGS: readonly string[] = [
 	"assets",
 	"email",
 	"socket",
+	"metrics",
 ];
 
 export function isReservedSlug(slug: string): boolean {

--- a/frontend/src/api/reserved-slugs.ts
+++ b/frontend/src/api/reserved-slugs.ts
@@ -1,0 +1,30 @@
+// Mirror of @reserved_slugs in lib/engram/vaults/vault.ex. Duplicated because
+// the check spans two languages; the backend changeset is authoritative and
+// this exists only to fail fast in the UI. Keep both lists identical:
+//   - Frontend-shadowed (sign-in..settings): React Router ranks static
+//     segments above `/:slug`, so these are simply unreachable by URL.
+//   - Backend-denied (api..socket): Task 7's Phoenix deny-list 404s these
+//     prefixes before the SPA ever loads.
+export const RESERVED_SLUGS: readonly string[] = [
+	"sign-in",
+	"sign-up",
+	"waitlist",
+	"link",
+	"oauth",
+	"onboard",
+	"reset-password",
+	"note",
+	"search",
+	"billing",
+	"settings",
+	"api",
+	"webhooks",
+	".well-known",
+	"assets",
+	"email",
+	"socket",
+];
+
+export function isReservedSlug(slug: string): boolean {
+	return RESERVED_SLUGS.includes(slug.trim().toLowerCase());
+}

--- a/frontend/src/api/reserved-slugs.ts
+++ b/frontend/src/api/reserved-slugs.ts
@@ -3,8 +3,13 @@
 // this list currently has no runtime consumer in the SPA (the vault create
 // form has no slug field) - it exists as the cross-language mirror of the
 // Elixir list. Keep both lists identical:
-//   - Frontend-shadowed (sign-in..settings): React Router ranks static
-//     segments above `/:slug`, so these are simply unreachable by URL.
+//   - Route-shadowed (sign-in..settings): some of these have a top-level
+//     static React Router route that beats `/:slug` (e.g. `/link`), making a
+//     same-named vault unreachable by URL. Others (`search`, `billing`) have
+//     NO such static route (`billing` only exists nested under
+//     `/onboard/billing`; `search` is a rail-toggled panel, not a route), so
+//     `/:slug` would actually match them; the real protection for those is
+//     `validate_exclusion` in the backend changeset, not routing.
 //   - Backend-denied (api..socket): Task 7's Phoenix deny-list 404s these
 //     prefixes before the SPA ever loads.
 //   - Backend-forwarded (metrics): a bearer-auth-gated `forward` mounted

--- a/frontend/src/api/vault-slug.test.ts
+++ b/frontend/src/api/vault-slug.test.ts
@@ -1,10 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setActiveVaultId } from "./active-vault";
 import type { Vault } from "./queries";
-import { preferredVault, vaultBySlug } from "./vault-slug";
+import { preferredVault, useActiveVaultSlug, vaultBySlug } from "./vault-slug";
 
 function v(id: string, slug: string, is_default = false): Vault {
 	return { id, slug, is_default, name: slug } as Vault;
 }
+
+// useActiveVaultSlug is the sole slug source for four link sites and every
+// consumer test mocks it, so it needs its own coverage: a rename of
+// Vault.slug should not be able to ship green.
+let mockVaults: Vault[] | undefined;
+
+vi.mock("./queries", () => ({
+	useVaults: () => ({ data: mockVaults }),
+}));
 
 const vaults = [v("id-a", "work"), v("id-b", "personal", true), v("id-c", "archive")];
 
@@ -43,5 +54,32 @@ describe("preferredVault", () => {
 	it("returns null when there are no vaults", () => {
 		expect(preferredVault([], null)).toBeNull();
 		expect(preferredVault(undefined, "id-a")).toBeNull();
+	});
+});
+
+describe("useActiveVaultSlug", () => {
+	beforeEach(() => {
+		mockVaults = undefined;
+		setActiveVaultId(null);
+	});
+
+	it("returns null before the vault list loads", () => {
+		setActiveVaultId("id-a");
+		const { result } = renderHook(() => useActiveVaultSlug());
+		expect(result.current).toBeNull();
+	});
+
+	it("returns the slug of the active vault", () => {
+		mockVaults = vaults;
+		setActiveVaultId("id-b");
+		const { result } = renderHook(() => useActiveVaultSlug());
+		expect(result.current).toBe("personal");
+	});
+
+	it("returns null when the active id matches no vault", () => {
+		mockVaults = vaults;
+		setActiveVaultId("id-gone");
+		const { result } = renderHook(() => useActiveVaultSlug());
+		expect(result.current).toBeNull();
 	});
 });

--- a/frontend/src/api/vault-slug.test.ts
+++ b/frontend/src/api/vault-slug.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { Vault } from "./queries";
+import { preferredVault, vaultBySlug } from "./vault-slug";
+
+function v(id: string, slug: string, is_default = false): Vault {
+	return { id, slug, is_default, name: slug } as Vault;
+}
+
+const vaults = [v("id-a", "work"), v("id-b", "personal", true), v("id-c", "archive")];
+
+describe("vaultBySlug", () => {
+	it("finds a vault by slug", () => {
+		expect(vaultBySlug(vaults, "personal")?.id).toBe("id-b");
+	});
+
+	it("returns null for an unknown slug", () => {
+		expect(vaultBySlug(vaults, "nope")).toBeNull();
+	});
+
+	it("returns null when vaults or slug are missing", () => {
+		expect(vaultBySlug(undefined, "work")).toBeNull();
+		expect(vaultBySlug(vaults, undefined)).toBeNull();
+	});
+});
+
+describe("preferredVault", () => {
+	it("prefers the hinted vault", () => {
+		expect(preferredVault(vaults, "id-c")?.slug).toBe("archive");
+	});
+
+	it("falls back to the default when the hint is stale", () => {
+		expect(preferredVault(vaults, "id-gone")?.slug).toBe("personal");
+	});
+
+	it("falls back to the default when there is no hint", () => {
+		expect(preferredVault(vaults, null)?.slug).toBe("personal");
+	});
+
+	it("falls back to the first vault when none is marked default", () => {
+		expect(preferredVault([v("id-a", "work"), v("id-c", "archive")], null)?.slug).toBe("work");
+	});
+
+	it("returns null when there are no vaults", () => {
+		expect(preferredVault([], null)).toBeNull();
+		expect(preferredVault(undefined, "id-a")).toBeNull();
+	});
+});

--- a/frontend/src/api/vault-slug.ts
+++ b/frontend/src/api/vault-slug.ts
@@ -1,0 +1,24 @@
+import type { Vault } from "./queries";
+
+export function vaultBySlug(vaults: Vault[] | undefined, slug: string | undefined): Vault | null {
+	if (!(vaults && slug)) {
+		return null;
+	}
+	return vaults.find((v) => v.slug === slug) ?? null;
+}
+
+// Used only where the URL does NOT name a vault: the bare `/` redirect and the
+// legacy `/note/:id` redirect. `hintId` is the last-used vault (localStorage via
+// the active-vault store); it is a hint, not authority, so a stale id silently
+// degrades to the default vault.
+export function preferredVault(vaults: Vault[] | undefined, hintId: string | null): Vault | null {
+	if (!vaults || vaults.length === 0) {
+		return null;
+	}
+	return (
+		(hintId ? vaults.find((v) => v.id === hintId) : undefined) ??
+		vaults.find((v) => v.is_default) ??
+		vaults[0] ??
+		null
+	);
+}

--- a/frontend/src/api/vault-slug.ts
+++ b/frontend/src/api/vault-slug.ts
@@ -1,4 +1,6 @@
+import { useActiveVaultId } from "./active-vault";
 import type { Vault } from "./queries";
+import { useVaults } from "./queries";
 
 export function vaultBySlug(vaults: Vault[] | undefined, slug: string | undefined): Vault | null {
 	if (!(vaults && slug)) {
@@ -21,4 +23,13 @@ export function preferredVault(vaults: Vault[] | undefined, hintId: string | nul
 		vaults[0] ??
 		null
 	);
+}
+
+// Slug of the vault currently in the store, for building note hrefs. Returns
+// null only before the vault list lands, which in practice does not happen
+// inside AppLayout (useAppBootstrap seeds it above).
+export function useActiveVaultSlug(): string | null {
+	const vaults = useVaults().data;
+	const activeId = useActiveVaultId();
+	return vaults?.find((v) => v.id === activeId)?.slug ?? null;
 }

--- a/frontend/src/billing/upgrade-required-dialog.test.tsx
+++ b/frontend/src/billing/upgrade-required-dialog.test.tsx
@@ -1,15 +1,18 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { describe, expect, it } from "vitest";
 import { UpgradeRequiredDialog } from "./upgrade-required-dialog";
+
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.hash}`}</output>;
+}
 
 function renderWithRouter(ui: React.ReactNode) {
 	return render(
 		<MemoryRouter initialEntries={["/start"]}>
-			<Routes>
-				<Route path="/start" element={ui} />
-				<Route path="/settings/billing" element={<div data-testid="billing-page">billing</div>} />
-			</Routes>
+			<LocationProbe />
+			{ui}
 		</MemoryRouter>,
 	);
 }
@@ -22,12 +25,12 @@ describe("UpgradeRequiredDialog", () => {
 		expect(screen.getByText(/pro feature/iu)).toBeInTheDocument();
 	});
 
-	it("Upgrade button navigates to /settings/billing", async () => {
+	it("Upgrade button navigates to the settings billing hash", () => {
 		renderWithRouter(
 			<UpgradeRequiredDialog reason="notes_cap_exceeded" open={true} onOpenChange={() => {}} />,
 		);
 		fireEvent.click(screen.getByRole("button", { name: /upgrade/iu }));
-		expect(await screen.findByTestId("billing-page")).toBeInTheDocument();
+		expect(screen.getByTestId("loc")).toHaveTextContent("/start#settings/billing");
 	});
 
 	it("has no explicit Dismiss button — X / outside click / Escape still close", () => {

--- a/frontend/src/billing/upgrade-required-dialog.tsx
+++ b/frontend/src/billing/upgrade-required-dialog.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -9,7 +9,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { settingsHash } from "@/settings/settings-hash";
+import { settingsTo } from "@/settings/settings-hash";
 
 import { ExistingConnectionsPanel } from "./existing-connections-panel";
 import { copyFor } from "./limit-copy";
@@ -38,6 +38,7 @@ export interface UpgradeRequiredDialogProps {
 
 export function UpgradeRequiredDialog({ reason, open, onOpenChange }: UpgradeRequiredDialogProps) {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const { title, body } = copyFor(reason);
 	const connKind = isConnectionCap(reason);
 
@@ -57,7 +58,7 @@ export function UpgradeRequiredDialog({ reason, open, onOpenChange }: UpgradeReq
 					<Button
 						onClick={() => {
 							onOpenChange(false);
-							navigate({ hash: settingsHash("billing") });
+							navigate(settingsTo("billing", location.search));
 						}}
 					>
 						Upgrade

--- a/frontend/src/billing/upgrade-required-dialog.tsx
+++ b/frontend/src/billing/upgrade-required-dialog.tsx
@@ -9,6 +9,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import { settingsHash } from "@/settings/settings-hash";
 
 import { ExistingConnectionsPanel } from "./existing-connections-panel";
 import { copyFor } from "./limit-copy";
@@ -56,7 +57,7 @@ export function UpgradeRequiredDialog({ reason, open, onOpenChange }: UpgradeReq
 					<Button
 						onClick={() => {
 							onOpenChange(false);
-							navigate("/settings/billing");
+							navigate({ hash: settingsHash("billing") });
 						}}
 					>
 						Upgrade

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -14,6 +14,7 @@ import AuthPanel from "../layout/auth-panel";
 import AuthShell from "../layout/auth-shell";
 import { SyncStatusPill } from "../onboarding/sync-status-pill";
 import { useVaultReadyEvents } from "../onboarding/use-vault-ready-events";
+import { settingsHash } from "../settings/settings-hash";
 
 interface Vault {
 	id: string;
@@ -231,9 +232,9 @@ function DeviceLinkPage() {
 							className="underline underline-offset-4"
 							onClick={(e) => {
 								e.preventDefault();
-								navigate("/settings/billing");
+								navigate({ hash: settingsHash("billing") });
 							}}
-							href="/settings/billing"
+							href={settingsHash("billing")}
 						>
 							Upgrade
 						</a>{" "}
@@ -251,9 +252,9 @@ function DeviceLinkPage() {
 							className="underline underline-offset-4"
 							onClick={(e) => {
 								e.preventDefault();
-								navigate("/settings/billing");
+								navigate({ hash: settingsHash("billing") });
 							}}
-							href="/settings/billing"
+							href={settingsHash("billing")}
 						>
 							Upgrade
 						</a>{" "}
@@ -301,10 +302,10 @@ function DeviceLinkPage() {
 								Your Free plan includes 1 vault — link into the existing one above, or{" "}
 								<a
 									className="underline underline-offset-4"
-									href="/settings/billing"
+									href={settingsHash("billing")}
 									onClick={(e) => {
 										e.preventDefault();
-										navigate("/settings/billing");
+										navigate({ hash: settingsHash("billing") });
 									}}
 								>
 									upgrade

--- a/frontend/src/device/device-link-page.tsx
+++ b/frontend/src/device/device-link-page.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import { destructiveAlert, fieldInput, heading, selectableRow } from "@/lib/ui-classes";
 import { cn } from "@/lib/utils";
@@ -14,7 +14,7 @@ import AuthPanel from "../layout/auth-panel";
 import AuthShell from "../layout/auth-shell";
 import { SyncStatusPill } from "../onboarding/sync-status-pill";
 import { useVaultReadyEvents } from "../onboarding/use-vault-ready-events";
-import { settingsHash } from "../settings/settings-hash";
+import { settingsHash, settingsTo } from "../settings/settings-hash";
 
 interface Vault {
 	id: string;
@@ -27,6 +27,7 @@ type Step = "enter-code" | "pick-vault" | "success" | "error";
 function DeviceLinkPage() {
 	const { isSignedIn } = useAuthAdapter();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const qc = useQueryClient();
 	const [step, setStep] = useState<Step>("enter-code");
 	// RFC 8628 verification_uri_complete: if the plugin sends the user to
@@ -232,9 +233,9 @@ function DeviceLinkPage() {
 							className="underline underline-offset-4"
 							onClick={(e) => {
 								e.preventDefault();
-								navigate({ hash: settingsHash("billing") });
+								navigate(settingsTo("billing", location.search));
 							}}
-							href={settingsHash("billing")}
+							href={`${location.search}${settingsHash("billing")}`}
 						>
 							Upgrade
 						</a>{" "}
@@ -252,9 +253,9 @@ function DeviceLinkPage() {
 							className="underline underline-offset-4"
 							onClick={(e) => {
 								e.preventDefault();
-								navigate({ hash: settingsHash("billing") });
+								navigate(settingsTo("billing", location.search));
 							}}
-							href={settingsHash("billing")}
+							href={`${location.search}${settingsHash("billing")}`}
 						>
 							Upgrade
 						</a>{" "}
@@ -302,10 +303,10 @@ function DeviceLinkPage() {
 								Your Free plan includes 1 vault — link into the existing one above, or{" "}
 								<a
 									className="underline underline-offset-4"
-									href={settingsHash("billing")}
+									href={`${location.search}${settingsHash("billing")}`}
 									onClick={(e) => {
 										e.preventDefault();
-										navigate({ hash: settingsHash("billing") });
+										navigate(settingsTo("billing", location.search));
 									}}
 								>
 									upgrade

--- a/frontend/src/layout/app-shell.ts
+++ b/frontend/src/layout/app-shell.ts
@@ -8,5 +8,4 @@
 
 export { default as OnboardingGate } from "../onboarding/onboarding-gate";
 export { OnboardingShell } from "../onboarding/onboarding-shell";
-export { default as SettingsLayout } from "../settings/settings-layout";
 export { default as AppLayout } from "./app-layout";

--- a/frontend/src/layout/app-sidebar.test.tsx
+++ b/frontend/src/layout/app-sidebar.test.tsx
@@ -95,7 +95,7 @@ describe("AppSidebar — Free-tier footer", () => {
 
 		expect(screen.getByText(/free tier.*1 connection/iu)).toBeInTheDocument();
 		const link = screen.getByRole("link", { name: /upgrade/iu });
-		expect(link).toHaveAttribute("href", "/settings/billing");
+		expect(link).toHaveAttribute("href", "/#settings/billing");
 	});
 
 	it("does not render the footer when tier=pro", () => {

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -1,6 +1,6 @@
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import { useIsFreeTier } from "../billing/use-is-free-tier";
-import { settingsHash } from "../settings/settings-hash";
+import { settingsTo } from "../settings/settings-hash";
 import FilesPanel from "./files-panel";
 import Rail from "./rail";
 import { useRailView } from "./rail-view-context";
@@ -9,6 +9,7 @@ import SearchPanel from "./search-panel";
 export default function AppSidebarPanel() {
 	const { view } = useRailView();
 	const showFreeFooter = useIsFreeTier();
+	const location = useLocation();
 
 	return (
 		<div className="flex h-full flex-col">
@@ -17,7 +18,7 @@ export default function AppSidebarPanel() {
 				<div className="border-border border-t px-3 py-2 text-muted-foreground text-xs">
 					Free tier: 1 connection.{" "}
 					<Link
-						to={settingsHash("billing")}
+						to={settingsTo("billing", location.search)}
 						className="font-medium text-foreground underline underline-offset-4"
 					>
 						Upgrade

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import { useIsFreeTier } from "../billing/use-is-free-tier";
+import { settingsHash } from "../settings/settings-hash";
 import FilesPanel from "./files-panel";
 import Rail from "./rail";
 import { useRailView } from "./rail-view-context";
@@ -16,7 +17,7 @@ export default function AppSidebarPanel() {
 				<div className="border-border border-t px-3 py-2 text-muted-foreground text-xs">
 					Free tier: 1 connection.{" "}
 					<Link
-						to="/settings/billing"
+						to={settingsHash("billing")}
 						className="font-medium text-foreground underline underline-offset-4"
 					>
 						Upgrade

--- a/frontend/src/layout/empty-vault-state.test.tsx
+++ b/frontend/src/layout/empty-vault-state.test.tsx
@@ -12,6 +12,6 @@ describe("EmptyVaultState", () => {
 		);
 		expect(screen.getByText(/no vaults/iu)).toBeInTheDocument();
 		const link = screen.getByRole("link", { name: /create a vault/iu });
-		expect(link).toHaveAttribute("href", "/settings/vaults");
+		expect(link).toHaveAttribute("href", "/#settings/vaults");
 	});
 });

--- a/frontend/src/layout/empty-vault-state.tsx
+++ b/frontend/src/layout/empty-vault-state.tsx
@@ -1,8 +1,9 @@
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import { Button } from "@/components/ui/button";
-import { settingsHash } from "@/settings/settings-hash";
+import { settingsTo } from "@/settings/settings-hash";
 
 export function EmptyVaultState() {
+	const location = useLocation();
 	return (
 		<section className="flex flex-col items-center justify-center gap-3 py-16 text-center">
 			<h2 className="font-semibold text-foreground text-lg">No vaults</h2>
@@ -10,7 +11,7 @@ export function EmptyVaultState() {
 				You don't have any vaults right now. Create one to start syncing and searching your notes.
 			</p>
 			<Button asChild>
-				<Link to={settingsHash("vaults")}>Create a vault</Link>
+				<Link to={settingsTo("vaults", location.search)}>Create a vault</Link>
 			</Button>
 		</section>
 	);

--- a/frontend/src/layout/empty-vault-state.tsx
+++ b/frontend/src/layout/empty-vault-state.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import { Button } from "@/components/ui/button";
+import { settingsHash } from "@/settings/settings-hash";
 
 export function EmptyVaultState() {
 	return (
@@ -9,7 +10,7 @@ export function EmptyVaultState() {
 				You don't have any vaults right now. Create one to start syncing and searching your notes.
 			</p>
 			<Button asChild>
-				<Link to="/settings/vaults">Create a vault</Link>
+				<Link to={settingsHash("vaults")}>Create a vault</Link>
 			</Button>
 		</section>
 	);

--- a/frontend/src/layout/rail.test.tsx
+++ b/frontend/src/layout/rail.test.tsx
@@ -7,6 +7,11 @@ import Rail from "./rail";
 import { RailViewProvider, useRailView } from "./rail-view-context";
 import { RightToolsProvider, useRightTools } from "./right-tools-context";
 
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.hash}`}</output>;
+}
+
 vi.mock("../auth/use-auth-adapter", () => ({
 	useAuthAdapter: () => ({ user: { email: "todd@example.com" }, logout: vi.fn() }),
 }));
@@ -151,7 +156,10 @@ describe("Rail", () => {
 		expect(screen.getByRole("link", { name: /home/iu })).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Files" })).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "Settings" })).toHaveAttribute("href", "/settings");
+		expect(screen.getByRole("link", { name: "Settings" })).toHaveAttribute(
+			"href",
+			"/#settings/account",
+		);
 		expect(screen.getByRole("button", { name: "User menu" })).toBeInTheDocument();
 	});
 
@@ -190,29 +198,43 @@ describe("Rail", () => {
 		expect(screen.getByRole("button", { name: "Search" })).toHaveAttribute("data-tour", "search");
 	});
 
-	it("clicking Files from /settings navigates back to /", () => {
+	it("clicking Files from the settings hash strips the hash and stays on /", () => {
 		render(
-			<Wrap initialEntries={["/settings"]}>
+			<Wrap initialEntries={["/#settings/account"]}>
 				<Rail />
-				<PathProbe />
+				<LocationProbe />
 			</Wrap>,
 		);
-		expect(screen.getByTestId("pathname").textContent).toBe("/settings");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/#settings/account");
 		fireEvent.click(screen.getByRole("button", { name: "Files" }));
-		expect(screen.getByTestId("pathname").textContent).toBe("/");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/");
+		expect(screen.getByTestId("loc")).not.toHaveTextContent("#settings");
 	});
 
-	it("clicking Search from /settings navigates back to / and sets view to search", () => {
+	it("clicking Search from the settings hash strips the hash and sets view to search", () => {
 		render(
-			<Wrap initialEntries={["/settings"]}>
+			<Wrap initialEntries={["/#settings/account"]}>
 				<Rail />
-				<PathProbe />
+				<LocationProbe />
 				<ActiveProbe />
 			</Wrap>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Search" }));
-		expect(screen.getByTestId("pathname").textContent).toBe("/");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/");
+		expect(screen.getByTestId("loc")).not.toHaveTextContent("#settings");
 		expect(screen.getByTestId("view").textContent).toBe("search");
+	});
+
+	it("closes settings without leaving the current note", () => {
+		render(
+			<Wrap initialEntries={["/work/note-1#settings/account"]}>
+				<LocationProbe />
+				<Rail />
+			</Wrap>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /files/i }));
+		expect(screen.getByTestId("loc")).toHaveTextContent("/work/note-1");
+		expect(screen.getByTestId("loc")).not.toHaveTextContent("#settings");
 	});
 
 	it("clicking Files from / does NOT change the pathname", () => {

--- a/frontend/src/layout/rail.tsx
+++ b/frontend/src/layout/rail.tsx
@@ -1,6 +1,6 @@
 import { FolderTree, Search, Settings } from "lucide-react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router";
-import { isSettingsHash, settingsHash } from "../settings/settings-hash";
+import { isSettingsHash, settingsTo } from "../settings/settings-hash";
 import { type RailView, useRailView } from "./rail-view-context";
 import { RIGHT_TOOLS, type RightToolDescriptor, useRightTools } from "./right-tools-context";
 import UserMenu from "./user-menu";
@@ -106,7 +106,7 @@ export default function Rail() {
 
 			<div className="flex-1" />
 			<Link
-				to={settingsHash("account")}
+				to={settingsTo("account", location.search)}
 				aria-label="Settings"
 				title="Settings"
 				aria-current={onSettings ? "page" : undefined}

--- a/frontend/src/layout/rail.tsx
+++ b/frontend/src/layout/rail.tsx
@@ -1,5 +1,6 @@
 import { FolderTree, Search, Settings } from "lucide-react";
-import { NavLink, useLocation, useNavigate } from "react-router";
+import { Link, NavLink, useLocation, useNavigate } from "react-router";
+import { isSettingsHash, settingsHash } from "../settings/settings-hash";
 import { type RailView, useRailView } from "./rail-view-context";
 import { RIGHT_TOOLS, type RightToolDescriptor, useRightTools } from "./right-tools-context";
 import UserMenu from "./user-menu";
@@ -33,12 +34,13 @@ function ViewButton({
 	const { view, setView } = useRailView();
 	const location = useLocation();
 	const navigate = useNavigate();
-	const onSettings = location.pathname.startsWith("/settings");
+	const onSettings = isSettingsHash(location.hash);
 	const active = view === id && !onSettings;
 	const onClick = () => {
 		setView(id);
 		if (onSettings) {
-			navigate("/");
+			// Strip the settings hash, stay on the page underneath.
+			navigate({ pathname: location.pathname, search: location.search, hash: "" });
 		}
 	};
 	return (
@@ -78,6 +80,8 @@ function ToolButton({ tool }: { tool: RightToolDescriptor }) {
 }
 
 export default function Rail() {
+	const location = useLocation();
+	const onSettings = isSettingsHash(location.hash);
 	return (
 		<nav
 			aria-label="App navigation"
@@ -101,14 +105,15 @@ export default function Rail() {
 			))}
 
 			<div className="flex-1" />
-			<NavLink
-				to="/settings"
+			<Link
+				to={settingsHash("account")}
 				aria-label="Settings"
 				title="Settings"
-				className={({ isActive }) => railButtonClass(isActive)}
+				aria-current={onSettings ? "page" : undefined}
+				className={railButtonClass(onSettings)}
 			>
 				<Settings className="h-5 w-5" />
-			</NavLink>
+			</Link>
 			<UserMenu />
 		</nav>
 	);

--- a/frontend/src/layout/search-panel.test.tsx
+++ b/frontend/src/layout/search-panel.test.tsx
@@ -28,6 +28,12 @@ vi.mock("../api/queries", () => ({
 	useSearch: (q: string, filters: unknown) => useSearchSpy(q, filters),
 }));
 
+// ResultRow reads the active vault slug to build note hrefs. Default to null
+// (the fallback/legacy shape) so existing behavior is unaffected; the one
+// test below overrides it to check the vault-scoped shape.
+const activeSlugMock = vi.fn<() => string | null>(() => null);
+vi.mock("../api/vault-slug", () => ({ useActiveVaultSlug: () => activeSlugMock() }));
+
 function ViewProbe() {
 	const { view } = useRailView();
 	return <span data-testid="view">{view}</span>;
@@ -51,6 +57,7 @@ describe("SearchPanel", () => {
 	beforeEach(() => {
 		window.localStorage.clear();
 		useSearchSpy.mockClear();
+		activeSlugMock.mockReturnValue(null);
 	});
 
 	it('renders header "Search" and an [x] return-to-files control', () => {
@@ -72,6 +79,23 @@ describe("SearchPanel", () => {
 		fireEvent.change(input, { target: { value: "hello" } });
 		expect(await screen.findByText("note")).toBeInTheDocument();
 		expect(screen.queryByText("Some H1 Heading")).not.toBeInTheDocument();
+	});
+
+	it("links a result to the legacy note route before the vault slug loads", async () => {
+		renderPanel();
+		const input = screen.getByPlaceholderText(/search your notes/iu) as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "hello" } });
+		const link = (await screen.findByText("note")).closest("a") as HTMLAnchorElement;
+		expect(link.getAttribute("href")).toBe("/note/7");
+	});
+
+	it("links a result to the vault-scoped route once the active vault slug loads", async () => {
+		activeSlugMock.mockReturnValue("work");
+		renderPanel();
+		const input = screen.getByPlaceholderText(/search your notes/iu) as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "hello" } });
+		const link = (await screen.findByText("note")).closest("a") as HTMLAnchorElement;
+		expect(link.getAttribute("href")).toBe("/work/7");
 	});
 
 	it("[x] returns to Files view", () => {

--- a/frontend/src/layout/search-panel.tsx
+++ b/frontend/src/layout/search-panel.tsx
@@ -6,6 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { noteName } from "@/lib/note-name";
 import { useDebouncedValue } from "@/lib/use-debounced-value";
 import { type SearchFilters, type SearchResult, useSearch } from "../api/queries";
+import { useActiveVaultSlug } from "../api/vault-slug";
 import { useRailView } from "./rail-view-context";
 import { pushRecent, readRecent } from "./recent-searches";
 
@@ -163,11 +164,12 @@ function RecentList({ recent, onPick }: { recent: string[]; onPick: (q: string) 
 }
 
 function ResultRow({ result }: { result: SearchResult }) {
+	const slug = useActiveVaultSlug();
 	// Orphan hits (no id) are unreachable — render nothing.
 	if (result.id === null) {
 		return null;
 	}
-	const href = `/note/${result.id}`;
+	const href = slug ? `/${slug}/${result.id}` : `/note/${result.id}`;
 	return (
 		<Link
 			to={href}

--- a/frontend/src/layout/user-menu.tsx
+++ b/frontend/src/layout/user-menu.tsx
@@ -11,6 +11,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAuthAdapter } from "../auth/use-auth-adapter";
+import { settingsHash } from "../settings/settings-hash";
 import type { ThemeChoice } from "../theme/storage";
 import { useTheme } from "../theme/theme-provider";
 
@@ -52,7 +53,7 @@ export default function UserMenu() {
 				</DropdownMenuLabel>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem asChild className="gap-2.5 px-3 py-2.5 text-sm">
-					<Link to="/settings">
+					<Link to={settingsHash("account")}>
 						<Settings className="h-4 w-4" />
 						Settings
 					</Link>

--- a/frontend/src/layout/user-menu.tsx
+++ b/frontend/src/layout/user-menu.tsx
@@ -1,5 +1,5 @@
 import { LogOut, Monitor, Moon, Settings, Sun } from "lucide-react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -11,7 +11,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAuthAdapter } from "../auth/use-auth-adapter";
-import { settingsHash } from "../settings/settings-hash";
+import { settingsTo } from "../settings/settings-hash";
 import type { ThemeChoice } from "../theme/storage";
 import { useTheme } from "../theme/theme-provider";
 
@@ -30,6 +30,7 @@ const THEME_OPTIONS: ReadonlyArray<{ value: ThemeChoice; label: string; Icon: ty
 export default function UserMenu() {
 	const { user, logout } = useAuthAdapter();
 	const { theme, setTheme } = useTheme();
+	const location = useLocation();
 	const initial = user?.email?.[0]?.toUpperCase() ?? "?";
 
 	return (
@@ -53,7 +54,7 @@ export default function UserMenu() {
 				</DropdownMenuLabel>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem asChild className="gap-2.5 px-3 py-2.5 text-sm">
-					<Link to={settingsHash("account")}>
+					<Link to={settingsTo("account", location.search)}>
 						<Settings className="h-4 w-4" />
 						Settings
 					</Link>

--- a/frontend/src/layout/vault-switcher.test.tsx
+++ b/frontend/src/layout/vault-switcher.test.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import VaultSwitcher from "./vault-switcher";
+
+// Switching vaults must NAVIGATE (VaultRoute owns writing the active-vault
+// store from the URL). A direct setActiveVaultId write with no URL change is
+// the unrecoverable-spinner bug: the store and the URL disagree forever and
+// VaultRoute holds its Outlet in LoadingPane.
+const { navigate, setActiveVaultId } = vi.hoisted(() => ({
+	navigate: vi.fn(),
+	setActiveVaultId: vi.fn(),
+}));
+
+vi.mock("react-router", async () => {
+	const actual = await vi.importActual<typeof import("react-router")>("react-router");
+	return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock("../api/active-vault", () => ({
+	useActiveVaultId: () => "id-a",
+	setActiveVaultId,
+}));
+
+const vaults = [
+	{ id: "id-a", slug: "work", is_default: true, name: "Work" },
+	{ id: "id-b", slug: "personal", is_default: false, name: "Personal" },
+];
+vi.mock("../api/queries", () => ({
+	useVaults: () => ({ data: vaults, isLoading: false }),
+}));
+
+function renderSwitcher() {
+	const qc = new QueryClient();
+	return render(
+		<QueryClientProvider client={qc}>
+			{/* Current URL carries a note id from the vault being left, and the
+			 * switch must not carry it into the new vault's URL. */}
+			<MemoryRouter initialEntries={["/work/old-note-id"]}>
+				<VaultSwitcher />
+			</MemoryRouter>
+		</QueryClientProvider>,
+	);
+}
+
+describe("VaultSwitcher", () => {
+	it("navigates to the target vault's root instead of writing the store", async () => {
+		renderSwitcher();
+		const trigger = screen.getByRole("button", { name: /vault/i });
+		// Radix DropdownMenu opens on pointerdown in happy-dom.
+		fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+		fireEvent.click(trigger);
+		const item = await screen.findByRole("menuitemradio", { name: "Personal" });
+		fireEvent.click(item);
+
+		expect(navigate).toHaveBeenCalledWith("/personal");
+		expect(setActiveVaultId).not.toHaveBeenCalled();
+	});
+
+	it("does not carry the previous vault's note id into the target URL", async () => {
+		renderSwitcher();
+		const trigger = screen.getByRole("button", { name: /vault/i });
+		fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+		fireEvent.click(trigger);
+		const item = await screen.findByRole("menuitemradio", { name: "Personal" });
+		fireEvent.click(item);
+
+		const target = navigate.mock.calls[0]?.[0];
+		expect(target).not.toContain("old-note-id");
+	});
+});

--- a/frontend/src/layout/vault-switcher.tsx
+++ b/frontend/src/layout/vault-switcher.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, Lock } from "lucide-react";
-import { useEffect } from "react";
+import { useNavigate } from "react-router";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -8,27 +8,14 @@ import {
 	DropdownMenuRadioItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { setActiveVaultId, useActiveVaultId } from "../api/active-vault";
+import { useActiveVaultId } from "../api/active-vault";
 import { useVaults, type Vault } from "../api/queries";
 
 function VaultSwitcher() {
 	const { data: vaults, isLoading } = useVaults();
 	const activeId = useActiveVaultId();
 	const qc = useQueryClient();
-
-	useEffect(() => {
-		if (!vaults || vaults.length === 0) {
-			return;
-		}
-		const stillValid = activeId !== null && vaults.some((v) => v.id === activeId);
-		if (stillValid) {
-			return;
-		}
-		const fallback = vaults.find((v) => v.is_default) ?? vaults[0];
-		if (fallback) {
-			setActiveVaultId(fallback.id);
-		}
-	}, [vaults, activeId]);
+	const navigate = useNavigate();
 
 	if (isLoading) {
 		return <p className="px-3 py-2 text-muted-foreground text-xs">Loading vaults…</p>;
@@ -66,12 +53,18 @@ function VaultSwitcher() {
 				>
 					<DropdownMenuRadioGroup
 						value={active.id}
-						onValueChange={(v) => {
-							const next = v;
+						onValueChange={(next) => {
 							if (next === active.id) {
 								return;
 							}
-							setActiveVaultId(next);
+							const target = vaults.find((v) => v.id === next);
+							if (!target) {
+								return;
+							}
+							// Navigate; VaultRoute writes the active-vault store. Land on the
+							// vault root, not the current note, whose id does not exist in
+							// the new vault.
+							navigate(`/${target.slug}`);
 							qc.invalidateQueries();
 							// Onboarding tour gates step 0 on a real switch; emit a DOM
 							// event the controller can listen for without coupling layers.

--- a/frontend/src/oauth/oauth-authorize-page.test.tsx
+++ b/frontend/src/oauth/oauth-authorize-page.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import OAuthAuthorizePage from "./oauth-authorize-page";
 
@@ -90,6 +90,29 @@ function renderAt(qs: string) {
 	return render(
 		<QueryClientProvider client={qc}>
 			<MemoryRouter initialEntries={[`/oauth/consent${qs}`]}>
+				<OAuthAuthorizePage />
+			</MemoryRouter>
+		</QueryClientProvider>,
+	);
+}
+
+function LocationProbe() {
+	const location = useLocation();
+	return (
+		<div data-testid="location-probe">
+			{location.pathname}
+			{location.search}
+			{location.hash}
+		</div>
+	);
+}
+
+function renderWithProbeAt(qs: string) {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<MemoryRouter initialEntries={[`/oauth/consent${qs}`]}>
+				<LocationProbe />
 				<OAuthAuthorizePage />
 			</MemoryRouter>
 		</QueryClientProvider>,
@@ -223,6 +246,36 @@ describe("OAuthAuthorizePage", () => {
 		expect(consentOrder).toBeDefined();
 		expect(delOrder!).toBeLessThan(consentOrder!);
 		await waitFor(() => expect(assign).toHaveBeenCalledWith("https://app/cb?code=ok"));
+	});
+
+	it("clicking Upgrade in the at-cap banner keeps the OAuth query params (regression: settingsTo)", async () => {
+		// Regression for the bug where `navigate({ hash: settingsHash("billing") })`
+		// dropped the query string (react-router's resolvePath inherits pathname
+		// but not search). Losing client_id/redirect_uri/etc mid-consent re-renders
+		// this page into "Invalid authorization request", destroying the flow.
+		billingState.current = {
+			caps: { obsidian_connections: 1, mcp_connections: 1, api_write_enabled: true, vaults: null },
+			current_connections: { obsidian: 0, mcp: 1 },
+			device_swap_cooldown_remaining_hours: null,
+		};
+		fetchOAuthClient.mockResolvedValue({
+			client_id: "cli",
+			client_name: "Claude Desktop",
+			kind: "mcp",
+		});
+
+		renderWithProbeAt(VALID_QS);
+		const upgrade = await screen.findByRole("link", { name: /upgrade/iu });
+		fireEvent.click(upgrade);
+
+		const probe = screen.getByTestId("location-probe").textContent ?? "";
+		expect(probe).toContain("client_id=cli");
+		expect(probe).toContain("redirect_uri=");
+		expect(probe).toContain("state=xyz");
+		expect(probe).toContain("#settings/billing");
+		expect(
+			screen.queryByRole("heading", { name: /invalid authorization request/iu }),
+		).not.toBeInTheDocument();
 	});
 
 	it("cancels by redirecting back with access_denied", async () => {

--- a/frontend/src/oauth/oauth-authorize-page.tsx
+++ b/frontend/src/oauth/oauth-authorize-page.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -19,7 +19,7 @@ import { connectionId as oauthConnectionId } from "../billing/existing-connectio
 import { useConnectionCap } from "../billing/use-connection-cap";
 import AuthPanel from "../layout/auth-panel";
 import AuthShell from "../layout/auth-shell";
-import { settingsHash } from "../settings/settings-hash";
+import { settingsHash, settingsTo } from "../settings/settings-hash";
 
 const REQUIRED_PARAMS = [
 	"client_id",
@@ -79,6 +79,7 @@ export default function OAuthAuthorizePage() {
 	const meQuery = useMe();
 	const vaultsQuery = useVaults();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const qc = useQueryClient();
 
 	// Proactive cap check — kind comes from the OAuth client metadata so we
@@ -259,10 +260,10 @@ export default function OAuthAuthorizePage() {
 								will stop having access.{" "}
 								<a
 									className="underline underline-offset-4"
-									href={settingsHash("billing")}
+									href={`${location.search}${settingsHash("billing")}`}
 									onClick={(e) => {
 										e.preventDefault();
-										navigate({ hash: settingsHash("billing") });
+										navigate(settingsTo("billing", location.search));
 									}}
 								>
 									Upgrade
@@ -361,7 +362,7 @@ export default function OAuthAuthorizePage() {
 								variant="outline"
 								onClick={() => {
 									setShowSwapConfirm(false);
-									navigate({ hash: settingsHash("billing") });
+									navigate(settingsTo("billing", location.search));
 								}}
 								disabled={submitting}
 								className="w-full"

--- a/frontend/src/oauth/oauth-authorize-page.tsx
+++ b/frontend/src/oauth/oauth-authorize-page.tsx
@@ -19,6 +19,7 @@ import { connectionId as oauthConnectionId } from "../billing/existing-connectio
 import { useConnectionCap } from "../billing/use-connection-cap";
 import AuthPanel from "../layout/auth-panel";
 import AuthShell from "../layout/auth-shell";
+import { settingsHash } from "../settings/settings-hash";
 
 const REQUIRED_PARAMS = [
 	"client_id",
@@ -258,10 +259,10 @@ export default function OAuthAuthorizePage() {
 								will stop having access.{" "}
 								<a
 									className="underline underline-offset-4"
-									href="/settings/billing"
+									href={settingsHash("billing")}
 									onClick={(e) => {
 										e.preventDefault();
-										navigate("/settings/billing");
+										navigate({ hash: settingsHash("billing") });
 									}}
 								>
 									Upgrade
@@ -360,7 +361,7 @@ export default function OAuthAuthorizePage() {
 								variant="outline"
 								onClick={() => {
 									setShowSwapConfirm(false);
-									navigate("/settings/billing");
+									navigate({ hash: settingsHash("billing") });
 								}}
 								disabled={submitting}
 								className="w-full"

--- a/frontend/src/onboarding/onboarding-shell.test.tsx
+++ b/frontend/src/onboarding/onboarding-shell.test.tsx
@@ -1,9 +1,19 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setActiveVaultId } from "../api/active-vault";
+import type { Vault } from "../api/queries";
+import VaultRoute from "../viewer/vault-route";
 import { OnboardingShell } from "./onboarding-shell";
+
+// NotFoundPage (rendered if VaultRoute 404s) pulls in ThemeToggle via
+// AuthShell, which needs a ThemeProvider we are not wiring up here. Same
+// mock as src/viewer/vault-route.test.tsx.
+vi.mock("../theme/theme-toggle", () => ({
+	default: () => <button type="button">theme</button>,
+}));
 
 function renderShell(ui: ReactElement) {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -15,10 +25,16 @@ function renderShell(ui: ReactElement) {
 }
 
 const mockRecord = vi.fn(() => Promise.resolve());
+// Mutable so the "real router" describe block below can simulate a user who
+// already has a vault (vaultCount: 1), skipping the first-vault modal that
+// would otherwise aria-hide the checklist behind it.
+let mockVaultCount = 0;
 vi.mock("./use-onboarding-actions", () => ({
 	useOnboardingActions: () => ({
 		isLoading: false,
-		vaultCount: 0,
+		get vaultCount() {
+			return mockVaultCount;
+		},
 		has: () => false,
 		record: mockRecord,
 		recordAsync: mockRecord,
@@ -33,14 +49,23 @@ vi.mock("./tour/controller", () => ({
 }));
 
 // The checklist widget has its own dedicated suite — stub here so this test
-// stays focused on the shell's modal/orchestration behaviour.
+// stays focused on the shell's modal/orchestration behaviour. The stub still
+// exposes `onStartTour` via a real button so the router test below can drive
+// tour entry the same way a user click does.
 vi.mock("./checklist-widget", () => ({
-	ChecklistWidget: () => <div data-testid="checklist-widget" />,
+	ChecklistWidget: ({ onStartTour }: { onStartTour: () => void }) => (
+		<div data-testid="checklist-widget">
+			<button type="button" onClick={onStartTour}>
+				Start tour
+			</button>
+		</div>
+	),
 }));
 
 describe("OnboardingShell", () => {
 	beforeEach(() => {
 		mockRecord.mockClear();
+		mockVaultCount = 0;
 	});
 
 	it("renders the vault modal when vault_count is zero", () => {
@@ -60,5 +85,84 @@ describe("OnboardingShell", () => {
 		);
 		expect(screen.getByText("dashboard")).toBeInTheDocument();
 		expect(screen.getByTestId("checklist-widget")).toBeInTheDocument();
+	});
+});
+
+// Regression test for the tour-from-a-real-vault-URL 404: demo mode makes
+// useVaults() return ONLY the two synthetic demo vaults, so a real slug like
+// `/work` stops resolving in VaultRoute once the tour activates. Drives tour
+// entry through an actual router (VaultRoute + real useVaults/useDemoVault),
+// which no other test does.
+describe("starting the tour from a real vault URL", () => {
+	const vaults: Vault[] = [
+		{
+			id: "vault-1",
+			name: "Work",
+			slug: "work",
+			description: null,
+			is_default: true,
+			created_at: new Date(0).toISOString(),
+			encrypted: false,
+			encryption_status: "none",
+			encrypted_at: null,
+			decrypt_requested_at: null,
+			last_toggle_at: null,
+			cooldown_days: null,
+		},
+	];
+
+	beforeEach(() => {
+		// A user already has a vault at this URL, so skip the first-vault modal,
+		// which otherwise aria-hides the checklist button behind it.
+		mockVaultCount = 1;
+		setActiveVaultId(null);
+		globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("/demo-vault.json")) {
+				return Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							vault: { id: "demo-vault", name: "Demo Vault" },
+							folders: [],
+							notes: [],
+						}),
+				} as Response);
+			}
+			if (url.includes("/api/vaults")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ vaults }) } as Response);
+			}
+			return Promise.reject(new Error(`unexpected fetch in test: ${url}`));
+		}) as unknown as typeof fetch;
+	});
+
+	function renderAtWork() {
+		const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		return render(
+			<QueryClientProvider client={qc}>
+				<MemoryRouter initialEntries={["/work"]}>
+					<Routes>
+						<Route element={<OnboardingShell>{<Outlet />}</OnboardingShell>}>
+							<Route path="/" element={<p>home</p>} />
+							<Route path="/:slug" element={<VaultRoute />}>
+								<Route index element={<p>vault dashboard</p>} />
+							</Route>
+						</Route>
+					</Routes>
+				</MemoryRouter>
+			</QueryClientProvider>,
+		);
+	}
+
+	it("does not land on the 404 page after clicking Take the tour", async () => {
+		renderAtWork();
+		expect(await screen.findByText("vault dashboard")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /start tour/iu }));
+
+		await waitFor(() => {
+			expect(screen.getByText("home")).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/page not found/iu)).toBeNull();
 	});
 });

--- a/frontend/src/onboarding/onboarding-shell.tsx
+++ b/frontend/src/onboarding/onboarding-shell.tsx
@@ -34,7 +34,7 @@ function ShellInner({ children }: { children: ReactNode }) {
 		}
 		setTourActive(false);
 		demo.deactivate();
-		// The tour walks through a demo note (`/note/<id>`) that doesn't exist
+		// The tour walks through a demo note (`/<slug>/<id>`) that doesn't exist
 		// in the real backend. Bounce back to the dashboard so useNote doesn't
 		// 404 once the demo wrap drops.
 		navigate("/", { replace: true });

--- a/frontend/src/onboarding/onboarding-shell.tsx
+++ b/frontend/src/onboarding/onboarding-shell.tsx
@@ -26,6 +26,11 @@ function ShellInner({ children }: { children: ReactNode }) {
 	const startTour = async () => {
 		await demo.activate();
 		setTourActive(true);
+		// Demo mode makes useVaults return ONLY the synthetic demo vaults, so any
+		// real vault slug in the URL stops resolving and VaultRoute 404s. Bounce
+		// through / so VaultRedirect re-picks from the demo list. Same batch, so
+		// this renders once. onTourExit does the mirror of this on the way out.
+		navigate("/", { replace: true });
 	};
 
 	const onTourExit = (reachedEnd: boolean) => {

--- a/frontend/src/onboarding/tour/controller.tsx
+++ b/frontend/src/onboarding/tour/controller.tsx
@@ -32,7 +32,7 @@ export function TourController({ active, onExit, setReachedEnd }: Props) {
 
 	// The final step targets `[data-tour="dashboard-root"]` which only exists
 	// on the dashboard route. If the user opened a demo note during step 1,
-	// we're on /note/<id> and Joyride times out waiting for that target.
+	// we're on /<slug>/<id> and Joyride times out waiting for that target.
 	// Bounce back to / when we land on the final step.
 	useEffect(() => {
 		if (!active) {

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -52,15 +52,30 @@ describe("createAppRouter - settings overlay mount point", () => {
 	// shell. If SettingsOverlayHost were moved inside AppLayout, these two
 	// routes would never see it and #settings/billing would be a silent
 	// no-op on both. That regression is exactly what this test guards.
+	// These wait on a CHAIN of two dynamic imports behind two Suspense
+	// boundaries: SettingsOverlayHost is lazy() in router.tsx, and the dialog
+	// is lazy() again inside the host. There is no fixed delay to advance, so
+	// fake timers cannot help; the only correct bound is one generous enough
+	// to survive suite contention. findBy*'s 1000ms default is arbitrary and
+	// too tight: this test was observed timing out under parallel load while
+	// taking 6.96s in isolation.
 	it("overlays the settings dialog atop /link (outside the app shell)", async () => {
 		renderAt("/link#settings/billing");
-		expect(await screen.findByTestId("device-link")).toBeInTheDocument();
-		expect(await screen.findByTestId("dialog")).toHaveTextContent("section:billing");
+		expect(
+			await screen.findByTestId("device-link", undefined, { timeout: 15_000 }),
+		).toBeInTheDocument();
+		expect(await screen.findByTestId("dialog", undefined, { timeout: 15_000 })).toHaveTextContent(
+			"section:billing",
+		);
 	});
 
 	it("overlays the settings dialog atop /oauth/consent (outside the app shell)", async () => {
 		renderAt("/oauth/consent#settings/billing");
-		expect(await screen.findByTestId("oauth-consent")).toBeInTheDocument();
-		expect(await screen.findByTestId("dialog")).toHaveTextContent("section:billing");
+		expect(
+			await screen.findByTestId("oauth-consent", undefined, { timeout: 15_000 }),
+		).toBeInTheDocument();
+		expect(await screen.findByTestId("dialog", undefined, { timeout: 15_000 })).toHaveTextContent(
+			"section:billing",
+		);
 	});
 });

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { RouterProvider } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { EngramConfig } from "./config";
+import { createAppRouter } from "./router";
+
+// AuthGuard's only dependency. Stub it signed-in so the route tree past it
+// renders instead of redirecting to /sign-in.
+vi.mock("./auth/use-auth-adapter", () => ({
+	useAuthAdapter: () => ({ isLoaded: true, isSignedIn: true }),
+}));
+
+// The dialog pulls the whole settings surface (Clerk hooks, billing, admin);
+// stub it the same way settings-overlay-host.test.tsx does, so this file
+// only proves the ROUTE WIRING, not settings' internals.
+vi.mock("./settings/settings-layout", () => ({
+	default: ({ section }: { section: string }) => <p data-testid="dialog">section:{section}</p>,
+}));
+
+// /link and /oauth/consent each have their own dedicated test file covering
+// behavior; both pull in react-query + API calls this file has no reason to
+// wire up. Stub them to a marker so we only assert THEY mounted at all.
+vi.mock("./device/device-link-page", () => ({
+	default: () => <p data-testid="device-link">device link page</p>,
+}));
+vi.mock("./oauth/oauth-authorize-page", () => ({
+	default: () => <p data-testid="oauth-consent">oauth consent page</p>,
+}));
+
+const config: EngramConfig = {
+	authProvider: "local",
+	clerkPublishableKey: "",
+	billingEnabled: false,
+	clerkWaitlistMode: false,
+	apiBase: "",
+	wsBase: "",
+	tracingEnabled: false,
+};
+
+// createAppRouter builds a createBrowserRouter, which reads its initial
+// location off the real window at construction time. pushState first, then
+// build; mirrors createMemoryRouter's initialEntries without reshaping the
+// production router to accept injected history.
+function renderAt(entry: string) {
+	window.history.pushState({}, "", entry);
+	return render(<RouterProvider router={createAppRouter(config)} />);
+}
+
+describe("createAppRouter - settings overlay mount point", () => {
+	// The overlay must sit ABOVE AuthGuard's other children, not inside
+	// AppLayout, because /link and /oauth/consent render outside the app
+	// shell. If SettingsOverlayHost were moved inside AppLayout, these two
+	// routes would never see it and #settings/billing would be a silent
+	// no-op on both. That regression is exactly what this test guards.
+	it("overlays the settings dialog atop /link (outside the app shell)", async () => {
+		renderAt("/link#settings/billing");
+		expect(await screen.findByTestId("device-link")).toBeInTheDocument();
+		expect(await screen.findByTestId("dialog")).toHaveTextContent("section:billing");
+	});
+
+	it("overlays the settings dialog atop /oauth/consent (outside the app shell)", async () => {
+		renderAt("/oauth/consent#settings/billing");
+		expect(await screen.findByTestId("oauth-consent")).toBeInTheDocument();
+		expect(await screen.findByTestId("dialog")).toHaveTextContent("section:billing");
+	});
+});

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -37,9 +37,12 @@ const OnboardRedirect = lazy(() =>
 	import("./onboarding/onboard-entry").then((m) => ({ default: m.OnboardRedirect })),
 );
 const Dashboard = lazy(() => import("./viewer/dashboard"));
-// /note/:id resolves to the note OR attachment viewer (VaultItemPage owns the
-// lazy NotePage/AttachmentPage chunks).
+// /:slug/:itemId resolves to the note OR attachment viewer (VaultItemPage owns
+// the lazy NotePage/AttachmentPage chunks).
 const VaultItemPage = lazy(() => import("./viewer/vault-item-page"));
+const VaultRoute = lazy(() => import("./viewer/vault-route"));
+const VaultRedirect = lazy(() => import("./viewer/vault-redirect"));
+const LegacyNoteRedirect = lazy(() => import("./viewer/legacy-note-redirect"));
 const ResetPasswordPage = lazy(() => import("./features/auth/ResetPasswordPage"));
 const DeviceLinkPage = lazy(() => import("./device/device-link-page"));
 const OAuthAuthorizePage = lazy(() => import("./oauth/oauth-authorize-page"));
@@ -183,8 +186,19 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 												{
 													element: suspendedScreen(<AppLayout />),
 													children: [
-														{ path: ROUTES.HOME, element: suspended(<Dashboard />) },
-														{ path: "/note/:id", element: suspended(<VaultItemPage />) },
+														// Bare `/` picks a vault; `/note/:id` is the pre-vault-scoping URL shape.
+														{ path: ROUTES.HOME, element: suspended(<VaultRedirect />) },
+														{ path: "/note/:id", element: suspended(<LegacyNoteRedirect />) },
+														// Vault-scoped. Kept LAST so every static route above wins RR's
+														// static-over-dynamic ranking.
+														{
+															path: "/:slug",
+															element: suspended(<VaultRoute />),
+															children: [
+																{ index: true, element: suspended(<Dashboard />) },
+																{ path: ":itemId", element: suspended(<VaultItemPage />) },
+															],
+														},
 													],
 												},
 											],

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -189,8 +189,11 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 														// Bare `/` picks a vault; `/note/:id` is the pre-vault-scoping URL shape.
 														{ path: ROUTES.HOME, element: suspended(<VaultRedirect />) },
 														{ path: "/note/:id", element: suspended(<LegacyNoteRedirect />) },
-														// Vault-scoped. Kept LAST so every static route above wins RR's
-														// static-over-dynamic ranking.
+														// Vault-scoped. Listed last for readability only. React Router's
+														// route ranking already scores static segments above dynamic ones
+														// as part of matching, independent of declaration order, so
+														// position does not decide this. Verified against react-router
+														// 8.3.0's computeScore.
 														{
 															path: "/:slug",
 															element: suspended(<VaultRoute />),

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -192,7 +192,7 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 									],
 								},
 
-								// Legacy path settings — Phoenix still serves the SPA for these
+								// Legacy path settings. Phoenix still serves the SPA for these
 								// (router.ex) so old bookmarks boot and land on the hash form.
 								{ path: "/settings", element: suspended(<LegacySettingsRedirect />) },
 								{ path: "/settings/*", element: suspended(<LegacySettingsRedirect />) },

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,5 +1,5 @@
 import { lazy, type ReactNode, Suspense } from "react";
-import { createBrowserRouter, Navigate, Outlet } from "react-router";
+import { createBrowserRouter, Outlet } from "react-router";
 import AuthGuard from "./auth/auth-guard";
 import CatchAllRoute from "./auth/catch-all-route";
 import SignInPage from "./auth/sign-in";
@@ -29,9 +29,6 @@ const OnboardingGate = lazy(() =>
 const OnboardingShell = lazy(() =>
 	import("./layout/app-shell").then((m) => ({ default: m.OnboardingShell })),
 );
-const SettingsLayout = lazy(() =>
-	import("./layout/app-shell").then((m) => ({ default: m.SettingsLayout })),
-);
 // Onboarding entry surface — same one-chunk barrel pattern.
 const OnboardLayout = lazy(() =>
 	import("./onboarding/onboard-entry").then((m) => ({ default: m.OnboardLayout })),
@@ -43,13 +40,16 @@ const Dashboard = lazy(() => import("./viewer/dashboard"));
 // /note/:id resolves to the note OR attachment viewer (VaultItemPage owns the
 // lazy NotePage/AttachmentPage chunks).
 const VaultItemPage = lazy(() => import("./viewer/vault-item-page"));
-const BillingPage = lazy(() => import("./billing/billing-page"));
-const AdminPanel = lazy(() => import("./features/admin/AdminPanel"));
 const ResetPasswordPage = lazy(() => import("./features/auth/ResetPasswordPage"));
 const DeviceLinkPage = lazy(() => import("./device/device-link-page"));
-const ConnectionsPage = lazy(() => import("./settings/connections-page"));
-const VaultsPage = lazy(() => import("./settings/vaults-page"));
 const OAuthAuthorizePage = lazy(() => import("./oauth/oauth-authorize-page"));
+// Settings is a hash overlay mounted at the AuthGuard level (not inside
+// AppLayout) so /link and /oauth/consent, which sit outside the app shell
+// and link to `#settings/billing`, still resolve the overlay.
+const SettingsOverlayHost = lazy(() => import("./settings/settings-overlay-host"));
+// `/settings` and `/settings/*` are the old path route. Phoenix still serves
+// the SPA for those paths, so old bookmarks boot and land here.
+const LegacySettingsRedirect = lazy(() => import("./settings/legacy-settings-redirect"));
 const AgreementPage = lazy(() => import("./onboarding/agreement-page"));
 const OnboardBillingPage = lazy(() => import("./onboarding/onboard-billing-page"));
 const OnboardToolsPage = lazy(() => import("./onboarding/onboard-tools-page"));
@@ -110,15 +110,12 @@ export function getAppRouter(): AppRouter {
 	return _appRouter;
 }
 
-export function createAppRouter(config: EngramConfig): AppRouter {
-	// Lazy so Clerk-only code (the account page pulls in @clerk/react hooks)
-	// stays out of the main chunk for local self-host builds.
-	const AccountPage = lazy(() =>
-		config.authProvider === "clerk"
-			? import("./settings/account-page")
-			: import("./settings/account-page-local"),
-	);
-
+// ponytail: `config` is unused now that settings (the only config-branching
+// route) moved into settings-layout.tsx. Kept as a parameter (renamed with
+// the `_` prefix biome expects for intentionally-unused args) because
+// main.tsx and BootstrapGate call createAppRouter(config) and a future
+// config-gated route is a plausible reason to re-add branching here.
+export function createAppRouter(_config: EngramConfig): AppRouter {
 	return createBrowserRouter([
 		{
 			element: <RootLayout />,
@@ -139,85 +136,66 @@ export function createAppRouter(config: EngramConfig): AppRouter {
 				{
 					element: <AuthGuard />,
 					children: [
-						// Onboarding wizard — itself protected by AuthGuard, but NOT by
-						// OnboardingGate (would redirect-loop).
 						{
-							path: "/onboard",
-							element: suspendedScreen(<OnboardLayout />),
+							// Hash-addressed settings overlays EVERY authenticated route,
+							// including /link and /oauth/consent which sit outside the app
+							// shell and link to `#settings/billing`.
+							element: suspendedScreen(<SettingsOverlayHost />),
 							children: [
-								{ index: true, element: suspended(<OnboardRedirect />) },
-								{ path: "agreement", element: suspended(<AgreementPage />) },
-								{ path: "billing", element: suspended(<OnboardBillingPage />) },
-								{ path: "tools", element: suspended(<OnboardToolsPage />) },
-								{ path: "vault", element: suspended(<OnboardVaultPage />) },
-							],
-						},
-
-						// /link is reachable mid-onboarding — the wizard's Obsidian branch
-						// requires the user to complete device-flow here before progressing.
-						// Sits OUTSIDE the OnboardingGate to dodge the redirect-to-/onboard.
-						{ path: ROUTES.DEVICE_LINK, element: suspended(<DeviceLinkPage />) },
-
-						// OAuth consent — reachable mid-onboarding so an MCP client (e.g.
-						// Claude Desktop) initiating a connection during signup can complete
-						// the OAuth dance without being bounced to /onboard.
-						{ path: ROUTES.OAUTH_CONSENT, element: suspended(<OAuthAuthorizePage />) },
-
-						// Dashboard tree — gated by OnboardingGate.
-						{
-							element: suspendedScreen(<OnboardingGate />),
-							children: [
+								// Onboarding wizard — itself protected by AuthGuard, but NOT by
+								// OnboardingGate (would redirect-loop).
 								{
-									// OnboardingShell wraps the dashboard tree so the tour offer,
-									// first-vault modal, and checklist only mount on the main app
-									// surface — NOT on /settings/*, /device-link, or /oauth.
-									element: suspendedScreen(
-										<OnboardingShell>
-											<Outlet />
-										</OnboardingShell>,
-									),
+									path: "/onboard",
+									element: suspendedScreen(<OnboardLayout />),
+									children: [
+										{ index: true, element: suspended(<OnboardRedirect />) },
+										{ path: "agreement", element: suspended(<AgreementPage />) },
+										{ path: "billing", element: suspended(<OnboardBillingPage />) },
+										{ path: "tools", element: suspended(<OnboardToolsPage />) },
+										{ path: "vault", element: suspended(<OnboardVaultPage />) },
+									],
+								},
+
+								// /link is reachable mid-onboarding — the wizard's Obsidian branch
+								// requires the user to complete device-flow here before progressing.
+								// Sits OUTSIDE the OnboardingGate to dodge the redirect-to-/onboard.
+								{ path: ROUTES.DEVICE_LINK, element: suspended(<DeviceLinkPage />) },
+
+								// OAuth consent — reachable mid-onboarding so an MCP client (e.g.
+								// Claude Desktop) initiating a connection during signup can complete
+								// the OAuth dance without being bounced to /onboard.
+								{ path: ROUTES.OAUTH_CONSENT, element: suspended(<OAuthAuthorizePage />) },
+
+								// Dashboard tree — gated by OnboardingGate.
+								{
+									element: suspendedScreen(<OnboardingGate />),
 									children: [
 										{
-											element: suspendedScreen(<AppLayout />),
+											// OnboardingShell wraps the dashboard tree so the tour offer,
+											// first-vault modal, and checklist only mount on the main app
+											// surface — NOT on /settings/*, /device-link, or /oauth.
+											element: suspendedScreen(
+												<OnboardingShell>
+													<Outlet />
+												</OnboardingShell>,
+											),
 											children: [
-												{ path: ROUTES.HOME, element: suspended(<Dashboard />) },
-												{ path: "/note/:id", element: suspended(<VaultItemPage />) },
 												{
-													path: "settings",
-													element: suspended(<SettingsLayout />),
+													element: suspendedScreen(<AppLayout />),
 													children: [
-														{
-															index: true,
-															element: <Navigate to="account" replace />,
-														},
-														{
-															path: "account",
-															element: (
-																<Suspense
-																	fallback={<p className="text-muted-foreground">Loading…</p>}
-																>
-																	<AccountPage />
-																</Suspense>
-															),
-														},
-														{ path: "vaults", element: suspended(<VaultsPage />) },
-														{ path: "connections", element: suspended(<ConnectionsPage />) },
-														{
-															path: "api-keys",
-															element: <Navigate to="/settings/connections" replace />,
-														},
-														...(config.billingEnabled
-															? [{ path: "billing", element: suspended(<BillingPage />) }]
-															: []),
-														...(config.authProvider === "local"
-															? [{ path: "admin", element: suspended(<AdminPanel />) }]
-															: []),
+														{ path: ROUTES.HOME, element: suspended(<Dashboard />) },
+														{ path: "/note/:id", element: suspended(<VaultItemPage />) },
 													],
 												},
 											],
 										},
 									],
 								},
+
+								// Legacy path settings — Phoenix still serves the SPA for these
+								// (router.ex) so old bookmarks boot and land on the hash form.
+								{ path: "/settings", element: suspended(<LegacySettingsRedirect />) },
+								{ path: "/settings/*", element: suspended(<LegacySettingsRedirect />) },
 							],
 						},
 					],

--- a/frontend/src/settings/account/connected-accounts-section.tsx
+++ b/frontend/src/settings/account/connected-accounts-section.tsx
@@ -4,6 +4,7 @@ import type { OAuthStrategy } from "@clerk/shared/types";
 import type { ReactNode } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { settingsHash } from "../settings-hash";
 import { DiscordIcon } from "./discord-icon";
 import { SettingsSectionCard } from "./section-card";
 
@@ -86,7 +87,7 @@ export function ConnectedAccountsSection({ providers }: { providers: OAuthStrate
 		try {
 			const acct = await createExternalAccount({
 				strategy,
-				redirectUrl: `${window.location.origin}/settings/account`,
+				redirectUrl: `${window.location.origin}/${settingsHash("account")}`,
 			});
 			const url = acct?.verification?.externalVerificationRedirectURL;
 			if (url) {

--- a/frontend/src/settings/connections-page.test.tsx
+++ b/frontend/src/settings/connections-page.test.tsx
@@ -1,8 +1,15 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import ConnectionsPage from "./connections-page";
+
+// Records the router's current hash so a test can prove a click actually
+// navigated (via history.push), not merely that the link's href looked right.
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc-hash">{loc.hash}</output>;
+}
 
 // ── Controllable mock state ───────────────────────────────────
 // vi.mock is hoisted; we use these module-level variables to vary
@@ -114,6 +121,7 @@ function renderPage() {
 	return render(
 		<QueryClientProvider client={qc}>
 			<MemoryRouter>
+				<LocationProbe />
 				<ConnectionsPage />
 			</MemoryRouter>
 		</QueryClientProvider>,
@@ -169,6 +177,15 @@ describe("ConnectionsPage", () => {
 		renderPage();
 		expect(screen.getByText(/Upgrade to Starter to create API keys/iu)).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: /\+ New Key/iu })).not.toBeInTheDocument();
+	});
+
+	it("Upgrade CTA click actually navigates (not just a correct href)", () => {
+		mockConnections.splice(0, mockConnections.length, basePat);
+		mockTier = "free";
+		renderPage();
+		expect(screen.getByTestId("loc-hash")).toHaveTextContent("");
+		fireEvent.click(screen.getByRole("link", { name: /upgrade/iu }));
+		expect(screen.getByTestId("loc-hash")).toHaveTextContent("#settings/billing");
 	});
 
 	it("shows unverified badge for MCP connection with verified=false", () => {

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -1,6 +1,6 @@
 import { Plug } from "lucide-react";
 import { useRef, useState } from "react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -24,7 +24,7 @@ import {
 	useRevokePat,
 } from "../api/queries";
 import { useIsFreeTier } from "../billing/use-is-free-tier";
-import { settingsHash } from "./settings-hash";
+import { settingsTo } from "./settings-hash";
 
 // ── Tier caps ─────────────────────────────────────────────────
 
@@ -184,6 +184,7 @@ function PatSection({
 }) {
 	const [showCreate, setShowCreate] = useState(false);
 	const [newKey, setNewKey] = useState<{ key: string; id: string; name: string } | null>(null);
+	const location = useLocation();
 
 	return (
 		<SettingsSectionCard
@@ -198,7 +199,7 @@ function PatSection({
 						Upgrade to Starter to create API keys for scripting and external integrations.
 					</p>
 					<Link
-						to={settingsHash("billing")}
+						to={settingsTo("billing", location.search)}
 						className="shrink-0 rounded-md bg-primary px-3 py-1.5 font-medium text-primary-foreground text-sm hover:bg-primary/90"
 					>
 						Upgrade

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -1,5 +1,6 @@
 import { Plug } from "lucide-react";
 import { useRef, useState } from "react";
+import { Link } from "react-router";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -196,12 +197,12 @@ function PatSection({
 					<p className="text-muted-foreground text-sm">
 						Upgrade to Starter to create API keys for scripting and external integrations.
 					</p>
-					<a
-						href={settingsHash("billing")}
+					<Link
+						to={settingsHash("billing")}
 						className="shrink-0 rounded-md bg-primary px-3 py-1.5 font-medium text-primary-foreground text-sm hover:bg-primary/90"
 					>
 						Upgrade
-					</a>
+					</Link>
 				</aside>
 			)}
 

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -23,6 +23,7 @@ import {
 	useRevokePat,
 } from "../api/queries";
 import { useIsFreeTier } from "../billing/use-is-free-tier";
+import { settingsHash } from "./settings-hash";
 
 // ── Tier caps ─────────────────────────────────────────────────
 
@@ -196,7 +197,7 @@ function PatSection({
 						Upgrade to Starter to create API keys for scripting and external integrations.
 					</p>
 					<a
-						href="/settings/billing"
+						href={settingsHash("billing")}
 						className="shrink-0 rounded-md bg-primary px-3 py-1.5 font-medium text-primary-foreground text-sm hover:bg-primary/90"
 					>
 						Upgrade

--- a/frontend/src/settings/legacy-settings-redirect.tsx
+++ b/frontend/src/settings/legacy-settings-redirect.tsx
@@ -1,0 +1,19 @@
+import { Navigate, useLocation } from "react-router";
+import { parseSettingsHash, settingsHash } from "./settings-hash";
+
+// `/settings/*` was the old path route. Phoenix still serves the SPA for those
+// paths (see router.ex) so existing bookmarks boot, and this bounces them to the
+// hash form. Redirects to `/`, which VaultRedirect then resolves to the user's
+// vault while preserving the hash.
+export default function LegacySettingsRedirect() {
+	const location = useLocation();
+	const tail = location.pathname.replace(/^\/settings\/?/, "");
+	const section = parseSettingsHash(tail === "" ? "#settings" : `#settings/${tail}`) ?? "account";
+
+	return (
+		<Navigate
+			to={{ pathname: "/", search: location.search, hash: settingsHash(section) }}
+			replace
+		/>
+	);
+}

--- a/frontend/src/settings/sections.test.ts
+++ b/frontend/src/settings/sections.test.ts
@@ -4,35 +4,35 @@ import { buildSettingsSections } from "./sections";
 describe("buildSettingsSections", () => {
 	it("includes Account first for local auth", () => {
 		const sections = buildSettingsSections("local", false, false);
-		expect(sections[0]).toEqual({ to: "account", label: "Account" });
-		expect(sections.map((s) => s.to)).toContain("vaults");
-		expect(sections.map((s) => s.to)).toContain("connections");
+		expect(sections[0]).toEqual({ key: "account", label: "Account" });
+		expect(sections.map((s) => s.key)).toContain("vaults");
+		expect(sections.map((s) => s.key)).toContain("connections");
 	});
 
 	it("includes Account first for clerk", () => {
 		const sections = buildSettingsSections("clerk", true, false);
-		expect(sections[0]).toEqual({ to: "account", label: "Account" });
-		expect(sections.map((s) => s.to)).toContain("billing");
-		expect(sections.map((s) => s.to)).toContain("connections");
+		expect(sections[0]).toEqual({ key: "account", label: "Account" });
+		expect(sections.map((s) => s.key)).toContain("billing");
+		expect(sections.map((s) => s.key)).toContain("connections");
 	});
 
 	it("omits Billing when billing is disabled (self-host)", () => {
 		const sections = buildSettingsSections("local", false, false);
-		expect(sections.map((s) => s.to)).not.toContain("billing");
+		expect(sections.map((s) => s.key)).not.toContain("billing");
 	});
 
 	it("keeps Account but drops Billing for clerk with billing disabled", () => {
 		const sections = buildSettingsSections("clerk", false, false);
-		expect(sections.map((s) => s.to)).toEqual(["account", "vaults", "connections"]);
+		expect(sections.map((s) => s.key)).toEqual(["account", "vaults", "connections"]);
 	});
 
 	it("appends Administration for local admins", () => {
 		const sections = buildSettingsSections("local", false, true);
-		expect(sections.map((s) => s.to)).toContain("admin");
+		expect(sections.map((s) => s.key)).toContain("admin");
 	});
 
 	it("does not include Administration for clerk", () => {
 		const sections = buildSettingsSections("clerk", true, true);
-		expect(sections.map((s) => s.to)).not.toContain("admin");
+		expect(sections.map((s) => s.key)).not.toContain("admin");
 	});
 });

--- a/frontend/src/settings/sections.test.ts
+++ b/frontend/src/settings/sections.test.ts
@@ -4,14 +4,14 @@ import { buildSettingsSections } from "./sections";
 describe("buildSettingsSections", () => {
 	it("includes Account first for local auth", () => {
 		const sections = buildSettingsSections("local", false, false);
-		expect(sections[0]).toEqual({ key: "account", label: "Account" });
+		expect(sections[0]).toMatchObject({ key: "account", label: "Account" });
 		expect(sections.map((s) => s.key)).toContain("vaults");
 		expect(sections.map((s) => s.key)).toContain("connections");
 	});
 
 	it("includes Account first for clerk", () => {
 		const sections = buildSettingsSections("clerk", true, false);
-		expect(sections[0]).toEqual({ key: "account", label: "Account" });
+		expect(sections[0]).toMatchObject({ key: "account", label: "Account" });
 		expect(sections.map((s) => s.key)).toContain("billing");
 		expect(sections.map((s) => s.key)).toContain("connections");
 	});
@@ -29,6 +29,25 @@ describe("buildSettingsSections", () => {
 	it("appends Administration for local admins", () => {
 		const sections = buildSettingsSections("local", false, true);
 		expect(sections.map((s) => s.key)).toContain("admin");
+	});
+
+	// Guards the omission case: a section pushed without an icon. Only
+	// `toBeDefined` — a lucide icon is a forwardRef *object*, not a function,
+	// so a typeof check would be asserting the wrong thing. That it actually
+	// renders is covered in settings-layout.test.tsx, where the nav is mounted.
+	// Billing + admin are on so every branch is built in a single pass.
+	it("gives every section an icon", () => {
+		const sections = buildSettingsSections("local", true, true);
+		expect(sections.map((s) => s.key)).toEqual([
+			"account",
+			"vaults",
+			"connections",
+			"billing",
+			"admin",
+		]);
+		for (const s of sections) {
+			expect(s.icon, `section "${s.key}" has no icon`).toBeDefined();
+		}
 	});
 
 	it("does not include Administration for clerk", () => {

--- a/frontend/src/settings/sections.ts
+++ b/frontend/src/settings/sections.ts
@@ -1,7 +1,8 @@
 import type { EngramConfig } from "../config";
+import type { SettingsSectionKey } from "./settings-hash";
 
 export interface SettingsSection {
-	to: string;
+	key: SettingsSectionKey;
 	label: string;
 }
 
@@ -11,17 +12,17 @@ export function buildSettingsSections(
 	isAdmin = false,
 ): SettingsSection[] {
 	const sections: SettingsSection[] = [
-		{ to: "account", label: "Account" },
-		{ to: "vaults", label: "Vaults" },
-		{ to: "connections", label: "Connections" },
+		{ key: "account", label: "Account" },
+		{ key: "vaults", label: "Vaults" },
+		{ key: "connections", label: "Connections" },
 	];
 
 	if (billingEnabled) {
-		sections.push({ to: "billing", label: "Billing" });
+		sections.push({ key: "billing", label: "Billing" });
 	}
 
 	if (authProvider === "local" && isAdmin) {
-		sections.push({ to: "admin", label: "Administration" });
+		sections.push({ key: "admin", label: "Administration" });
 	}
 
 	return sections;

--- a/frontend/src/settings/sections.ts
+++ b/frontend/src/settings/sections.ts
@@ -1,9 +1,13 @@
+import { CreditCard, type LucideIcon, Plug, ShieldCheck, User, Vault } from "lucide-react";
 import type { EngramConfig } from "../config";
 import type { SettingsSectionKey } from "./settings-hash";
 
 export interface SettingsSection {
 	key: SettingsSectionKey;
 	label: string;
+	// The nav's leading glyph. Lives here rather than in settings-layout so the
+	// section list stays the single place a new section is declared.
+	icon: LucideIcon;
 }
 
 export function buildSettingsSections(
@@ -12,17 +16,17 @@ export function buildSettingsSections(
 	isAdmin = false,
 ): SettingsSection[] {
 	const sections: SettingsSection[] = [
-		{ key: "account", label: "Account" },
-		{ key: "vaults", label: "Vaults" },
-		{ key: "connections", label: "Connections" },
+		{ key: "account", label: "Account", icon: User },
+		{ key: "vaults", label: "Vaults", icon: Vault },
+		{ key: "connections", label: "Connections", icon: Plug },
 	];
 
 	if (billingEnabled) {
-		sections.push({ key: "billing", label: "Billing" });
+		sections.push({ key: "billing", label: "Billing", icon: CreditCard });
 	}
 
 	if (authProvider === "local" && isAdmin) {
-		sections.push({ key: "admin", label: "Administration" });
+		sections.push({ key: "admin", label: "Administration", icon: ShieldCheck });
 	}
 
 	return sections;

--- a/frontend/src/settings/settings-hash.test.ts
+++ b/frontend/src/settings/settings-hash.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { isSettingsHash, parseSettingsHash, settingsHash } from "./settings-hash";
+
+describe("isSettingsHash", () => {
+	it("matches the bare prefix and sectioned forms", () => {
+		expect(isSettingsHash("#settings")).toBe(true);
+		expect(isSettingsHash("#settings/billing")).toBe(true);
+	});
+
+	it("rejects empty, unrelated, and prefix-lookalike hashes", () => {
+		expect(isSettingsHash("")).toBe(false);
+		expect(isSettingsHash("#tour")).toBe(false);
+		expect(isSettingsHash("#settingsfoo")).toBe(false);
+	});
+});
+
+describe("parseSettingsHash", () => {
+	it("returns null for a non-settings hash", () => {
+		expect(parseSettingsHash("")).toBeNull();
+		expect(parseSettingsHash("#tour")).toBeNull();
+	});
+
+	it("defaults a bare prefix to account", () => {
+		expect(parseSettingsHash("#settings")).toBe("account");
+		expect(parseSettingsHash("#settings/")).toBe("account");
+	});
+
+	it("returns each known section", () => {
+		expect(parseSettingsHash("#settings/account")).toBe("account");
+		expect(parseSettingsHash("#settings/vaults")).toBe("vaults");
+		expect(parseSettingsHash("#settings/connections")).toBe("connections");
+		expect(parseSettingsHash("#settings/billing")).toBe("billing");
+		expect(parseSettingsHash("#settings/admin")).toBe("admin");
+	});
+
+	it("maps the legacy api-keys alias to connections", () => {
+		expect(parseSettingsHash("#settings/api-keys")).toBe("connections");
+	});
+
+	it("falls back to account for an unknown section", () => {
+		expect(parseSettingsHash("#settings/garbage")).toBe("account");
+	});
+});
+
+describe("settingsHash", () => {
+	it("round-trips through parseSettingsHash", () => {
+		expect(settingsHash("billing")).toBe("#settings/billing");
+		expect(parseSettingsHash(settingsHash("vaults"))).toBe("vaults");
+	});
+});

--- a/frontend/src/settings/settings-hash.ts
+++ b/frontend/src/settings/settings-hash.ts
@@ -1,0 +1,35 @@
+// Settings is addressed by hash, not path, so the dialog overlays whatever page
+// you were on and closing can simply strip the hash instead of inventing a
+// destination (the old `/settings/*` path route hardcoded `navigate("/")`,
+// which dumped you on the dashboard even if you came from a note).
+const PREFIX = "#settings";
+
+const KNOWN: readonly string[] = ["account", "vaults", "connections", "billing", "admin"];
+
+// Carried over from the old `/settings/api-keys` route alias so existing links
+// and bookmarks keep landing on Connections.
+const ALIASES: Record<string, string> = { "api-keys": "connections" };
+
+export type SettingsSectionKey = "account" | "vaults" | "connections" | "billing" | "admin";
+
+export function isSettingsHash(hash: string): boolean {
+	return hash === PREFIX || hash.startsWith(`${PREFIX}/`);
+}
+
+export function parseSettingsHash(hash: string): SettingsSectionKey | null {
+	if (!isSettingsHash(hash)) {
+		return null;
+	}
+	const raw = hash.slice(PREFIX.length).replace(/^\//, "");
+	if (raw === "") {
+		return "account";
+	}
+	const resolved = ALIASES[raw] ?? raw;
+	// An unknown section is a typo or a stale link, not a reason to render
+	// nothing: open on Account rather than an empty dialog body.
+	return KNOWN.includes(resolved) ? (resolved as SettingsSectionKey) : "account";
+}
+
+export function settingsHash(section: SettingsSectionKey): string {
+	return `${PREFIX}/${section}`;
+}

--- a/frontend/src/settings/settings-hash.ts
+++ b/frontend/src/settings/settings-hash.ts
@@ -33,3 +33,15 @@ export function parseSettingsHash(hash: string): SettingsSectionKey | null {
 export function settingsHash(section: SettingsSectionKey): string {
 	return `${PREFIX}/${section}`;
 }
+
+/**
+ * Build a react-router `To` for opening settings that PRESERVES the current
+ * query string. React Router's resolvePath inherits `pathname` from the current
+ * location but NOT `search` (it defaults to ""), so a bare hash target silently
+ * drops the query. That breaks any page whose state lives in the URL, most
+ * severely /oauth/consent, which reads its params via useSearchParams and errors
+ * out the moment they vanish. Callers pass `location.search` from useLocation().
+ */
+export function settingsTo(section: SettingsSectionKey, search: string) {
+	return { search, hash: settingsHash(section) };
+}

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -56,8 +56,8 @@ describe("SettingsDialog", () => {
 		renderDialog("account");
 		// react-router's <Link> resolves a hash-only `to` against the current
 		// pathname, so the href is "/work/note-1#settings/billing", not a bare
-		// hash. Assert the suffix — the real requirement is "this link targets
-		// the billing section" — not the page underneath.
+		// hash. Assert the suffix: the real requirement is "this link targets
+		// the billing section," not the page underneath.
 		const link = await screen.findByRole("link", { name: "Billing" });
 		expect(link.getAttribute("href")).toMatch(/#settings\/billing$/);
 	});
@@ -74,7 +74,7 @@ describe("SettingsDialog", () => {
 	it("clicking a nav link actually switches the router location's hash", async () => {
 		// Regression guard: a plain <a href="#settings/billing"> changes
 		// window.location.hash via native same-document navigation, which fires
-		// `hashchange` but NOT `popstate` — and react-router's history only
+		// `hashchange` but NOT `popstate`, and react-router's history only
 		// listens for `popstate`. That leaves useLocation() stale even though the
 		// URL bar changed, so the dialog would silently fail to switch sections.
 		// This must go through react-router's <Link> (history.push) instead.

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -1,12 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
 import { MemoryRouter, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EngramConfig } from "../config";
 import { ConfigProvider } from "../config-context";
 import { ThemeProvider } from "../theme/theme-provider";
 import type { SettingsSectionKey } from "./settings-hash";
-import SettingsDialog from "./settings-layout";
+import SettingsDialog, { CLOSE_ANIMATION_MS } from "./settings-layout";
 
 vi.mock("../auth/use-auth-adapter", () => ({
 	useAuthAdapter: () => ({ user: { email: "todd@example.com" }, logout: vi.fn() }),
@@ -84,11 +85,22 @@ describe("SettingsDialog", () => {
 	});
 
 	it("strips the hash on close and keeps you on the same page", async () => {
-		renderDialog("account", "/work/note-1#settings/account");
-		fireEvent.click(screen.getByRole("button", { name: /close settings/i }));
-		// The close is deferred by CLOSE_ANIMATION_MS so the Radix exit
-		// transition plays; findBy* polls past it.
-		expect(await screen.findByText("/work/note-1")).toBeInTheDocument();
+		// The close navigate is deferred by CLOSE_ANIMATION_MS so the Radix exit
+		// transition plays. Advance the clock explicitly rather than waiting on it:
+		// with real timers this asserts deterministic behavior by racing the wall
+		// clock, and under full suite parallel load the event loop starves past
+		// findBy*'s 1000ms default. Measured about 17 percent flake rate that way.
+		vi.useFakeTimers();
+		try {
+			renderDialog("account", "/work/note-1#settings/account");
+			fireEvent.click(screen.getByRole("button", { name: /close settings/i }));
+			await act(async () => {
+				vi.advanceTimersByTime(CLOSE_ANIMATION_MS);
+			});
+			expect(screen.getByText("/work/note-1")).toBeInTheDocument();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("falls back to account when the section is unavailable in this config", async () => {

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -1,11 +1,12 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EngramConfig } from "../config";
 import { ConfigProvider } from "../config-context";
 import { ThemeProvider } from "../theme/theme-provider";
-import SettingsLayout from "./settings-layout";
+import type { SettingsSectionKey } from "./settings-hash";
+import SettingsDialog from "./settings-layout";
 
 vi.mock("../auth/use-auth-adapter", () => ({
 	useAuthAdapter: () => ({ user: { email: "todd@example.com" }, logout: vi.fn() }),
@@ -21,20 +22,20 @@ const testConfig: EngramConfig = {
 	tracingEnabled: false,
 };
 
-function renderAt(path: string) {
-	// SettingsLayout now calls useMe(); give it a query client with retry off so
-	// an unmocked /api/me fetch fails fast rather than retrying through the test.
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.hash}`}</output>;
+}
+
+function renderDialog(section: SettingsSectionKey, initialEntry = "/work/note-1#settings/account") {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	return render(
 		<ConfigProvider config={testConfig}>
 			<QueryClientProvider client={client}>
 				<ThemeProvider>
-					<MemoryRouter initialEntries={[path]}>
-						<Routes>
-							<Route path="/settings" element={<SettingsLayout />}>
-								<Route path="api-keys" element={<p>api keys body</p>} />
-							</Route>
-						</Routes>
+					<MemoryRouter initialEntries={[initialEntry]}>
+						<LocationProbe />
+						<SettingsDialog section={section} />
 					</MemoryRouter>
 				</ThemeProvider>
 			</QueryClientProvider>
@@ -42,7 +43,7 @@ function renderAt(path: string) {
 	);
 }
 
-describe("SettingsLayout", () => {
+describe("SettingsDialog", () => {
 	beforeEach(() => {
 		window.matchMedia = vi.fn().mockReturnValue({
 			matches: true,
@@ -51,14 +52,47 @@ describe("SettingsLayout", () => {
 		}) as any;
 	});
 
-	it("renders as a dialog with the settings nav + routed section", () => {
-		renderAt("/settings/api-keys");
-		// SettingsLayout is now a Radix Dialog overlaying whatever underlying
-		// app route is showing — the Rail lives on AppLayout (parent route), so
-		// assert on the dialog + section nav + routed body.
-		expect(screen.getByRole("dialog")).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "Account" })).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "Billing" })).toBeInTheDocument();
-		expect(screen.getByText("api keys body")).toBeInTheDocument();
+	it("renders the nav with a link per section", async () => {
+		renderDialog("account");
+		expect(await screen.findByRole("link", { name: "Billing" })).toHaveAttribute(
+			"href",
+			"#settings/billing",
+		);
+	});
+
+	it("marks the current section as the active nav item", async () => {
+		renderDialog("vaults");
+		expect(await screen.findByRole("link", { name: "Vaults" })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.getByRole("link", { name: "Account" })).not.toHaveAttribute("aria-current");
+	});
+
+	it("strips the hash on close and keeps you on the same page", async () => {
+		renderDialog("account", "/work/note-1#settings/account");
+		fireEvent.click(screen.getByRole("button", { name: /close settings/i }));
+		// The close is deferred by CLOSE_ANIMATION_MS so the Radix exit
+		// transition plays; findBy* polls past it.
+		expect(await screen.findByText("/work/note-1")).toBeInTheDocument();
+	});
+
+	it("falls back to account when the section is unavailable in this config", async () => {
+		const localConfig = { ...testConfig, authProvider: "local" as const, billingEnabled: false };
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(
+			<ConfigProvider config={localConfig}>
+				<QueryClientProvider client={client}>
+					<ThemeProvider>
+						<MemoryRouter initialEntries={["/work#settings/billing"]}>
+							<SettingsDialog section="billing" />
+						</MemoryRouter>
+					</ThemeProvider>
+				</QueryClientProvider>
+			</ConfigProvider>,
+		);
+		// Billing is not a section on a self-host build, so the nav must not
+		// offer it and the body must not be the billing page.
+		expect(screen.queryByRole("link", { name: "Billing" })).toBeNull();
 	});
 });

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -54,10 +54,12 @@ describe("SettingsDialog", () => {
 
 	it("renders the nav with a link per section", async () => {
 		renderDialog("account");
-		expect(await screen.findByRole("link", { name: "Billing" })).toHaveAttribute(
-			"href",
-			"#settings/billing",
-		);
+		// react-router's <Link> resolves a hash-only `to` against the current
+		// pathname, so the href is "/work/note-1#settings/billing", not a bare
+		// hash. Assert the suffix — the real requirement is "this link targets
+		// the billing section" — not the page underneath.
+		const link = await screen.findByRole("link", { name: "Billing" });
+		expect(link.getAttribute("href")).toMatch(/#settings\/billing$/);
 	});
 
 	it("marks the current section as the active nav item", async () => {
@@ -67,6 +69,18 @@ describe("SettingsDialog", () => {
 			"page",
 		);
 		expect(screen.getByRole("link", { name: "Account" })).not.toHaveAttribute("aria-current");
+	});
+
+	it("clicking a nav link actually switches the router location's hash", async () => {
+		// Regression guard: a plain <a href="#settings/billing"> changes
+		// window.location.hash via native same-document navigation, which fires
+		// `hashchange` but NOT `popstate` — and react-router's history only
+		// listens for `popstate`. That leaves useLocation() stale even though the
+		// URL bar changed, so the dialog would silently fail to switch sections.
+		// This must go through react-router's <Link> (history.push) instead.
+		renderDialog("account", "/work/note-1#settings/account");
+		fireEvent.click(await screen.findByRole("link", { name: "Billing" }));
+		expect(await screen.findByText("/work/note-1#settings/billing")).toBeInTheDocument();
 	});
 
 	it("strips the hash on close and keeps you on the same page", async () => {

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -25,7 +25,7 @@ const testConfig: EngramConfig = {
 
 function LocationProbe() {
 	const loc = useLocation();
-	return <output data-testid="loc">{`${loc.pathname}${loc.hash}`}</output>;
+	return <output data-testid="loc">{`${loc.pathname}${loc.search}${loc.hash}`}</output>;
 }
 
 function renderDialog(section: SettingsSectionKey, initialEntry = "/work/note-1#settings/account") {
@@ -82,6 +82,19 @@ describe("SettingsDialog", () => {
 		renderDialog("account", "/work/note-1#settings/account");
 		fireEvent.click(await screen.findByRole("link", { name: "Billing" }));
 		expect(await screen.findByText("/work/note-1#settings/billing")).toBeInTheDocument();
+	});
+
+	it("clicking a nav link preserves the current query string (settingsTo regression)", async () => {
+		// react-router's resolvePath inherits pathname from the current location
+		// but NOT search, so a bare `to={settingsHash(...)}` silently dropped
+		// `?highlight=<id>` (e.g. from the vault-deleted email) the moment the
+		// user switched settings sections. SettingsNavList must thread
+		// location.search through settingsTo.
+		renderDialog("account", "/work/note-1?highlight=abc123#settings/account");
+		fireEvent.click(await screen.findByRole("link", { name: "Billing" }));
+		expect(
+			await screen.findByText("/work/note-1?highlight=abc123#settings/billing"),
+		).toBeInTheDocument();
 	});
 
 	it("strips the hash on close and keeps you on the same page", async () => {

--- a/frontend/src/settings/settings-layout.test.tsx
+++ b/frontend/src/settings/settings-layout.test.tsx
@@ -63,6 +63,20 @@ describe("SettingsDialog", () => {
 		expect(link.getAttribute("href")).toMatch(/#settings\/billing$/);
 	});
 
+	it("renders an icon inside every nav link", async () => {
+		renderDialog("account");
+		await screen.findByRole("link", { name: "Billing" });
+
+		// The icon is aria-hidden (the label already names the section), so it is
+		// unreachable by role/name — query the rendered svg directly. Checking
+		// every link, not just one, is the point: a section declared without an
+		// icon would otherwise render a silent hole in the nav.
+		for (const name of ["Account", "Vaults", "Connections", "Billing"]) {
+			const link = screen.getByRole("link", { name });
+			expect(link.querySelector("svg"), `"${name}" nav link has no icon`).not.toBeNull();
+		}
+	});
+
 	it("marks the current section as the active nav item", async () => {
 		renderDialog("vaults");
 		expect(await screen.findByRole("link", { name: "Vaults" })).toHaveAttribute(

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -62,6 +62,7 @@ function SettingsNavList({
 		<ul className="space-y-1">
 			{sections.map((s) => {
 				const active = s.key === current;
+				const Icon = s.icon;
 				return (
 					<li key={s.key}>
 						{/* react-router's <Link>, not a plain <a>: a native anchor's
@@ -77,12 +78,15 @@ function SettingsNavList({
 							to={settingsTo(s.key, location.search)}
 							onClick={onNavigate}
 							aria-current={active ? "page" : undefined}
-							className={`block rounded-md px-3 py-2 text-sm transition-colors ${
+							className={`flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors ${
 								active
 									? "bg-primary/10 font-medium text-primary"
 									: "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
 							}`}
 						>
+							{/* Decorative: the adjacent label already names the section, so
+							announcing the glyph would just duplicate it for screen readers. */}
+							<Icon className="size-4 shrink-0" aria-hidden="true" />
 							{s.label}
 						</Link>
 					</li>

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -31,9 +31,9 @@ function SettingsNavList({
 	return (
 		<ul className="space-y-1">
 			{sections.map((s) => (
-				<li key={s.to}>
+				<li key={s.key}>
 					<NavLink
-						to={s.to}
+						to={s.key}
 						onClick={onNavigate}
 						className={({ isActive }) =>
 							`block rounded-md px-3 py-2 text-sm transition-colors ${

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -15,14 +15,16 @@ import {
 import { useMe } from "../api/queries";
 import { useConfig } from "../config-context";
 import { buildSettingsSections, type SettingsSection } from "./sections";
-import { type SettingsSectionKey, settingsHash } from "./settings-hash";
+import { type SettingsSectionKey, settingsTo } from "./settings-hash";
 
 // Keep this in sync with the duration-200 class on DialogPrimitive.Content
 // below — we hold the dialog mounted for one animation cycle after
 // onOpenChange(false) so Radix's exit transition plays before we navigate.
 const CLOSE_ANIMATION_MS = 200;
 
-// These are the exact modules router.tsx lazy-loads today.
+// These are the settings section bodies, lazily loaded here. Settings
+// stopped being a path route, so router.tsx no longer references any of
+// them; this component owns the section bodies exclusively.
 const AccountPage = lazy(() => import("./account-page"));
 const AccountPageLocal = lazy(() => import("./account-page-local"));
 const VaultsPage = lazy(() => import("./vaults-page"));
@@ -55,6 +57,7 @@ function SettingsNavList({
 	current: SettingsSectionKey;
 	onNavigate?: () => void;
 }) {
+	const location = useLocation();
 	return (
 		<ul className="space-y-1">
 			{sections.map((s) => {
@@ -67,9 +70,11 @@ function SettingsNavList({
 						would silently desync useLocation()). Link always resolves `to`
 						against the current pathname (so href is e.g.
 						"/work/note-1#settings/billing", not a bare hash), but it's
-						routed through history.push, which react-router does see. */}
+						routed through history.push, which react-router does see. `to`
+						also carries `search` explicitly: resolvePath does NOT inherit
+						the query string, only the pathname (see settingsTo). */}
 						<Link
-							to={settingsHash(s.key)}
+							to={settingsTo(s.key, location.search)}
 							onClick={onNavigate}
 							aria-current={active ? "page" : undefined}
 							className={`block rounded-md px-3 py-2 text-sm transition-colors ${

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -87,6 +87,10 @@ function SettingsNavList({
 	);
 }
 
+// Re-exported (rather than `export const` at the declaration site above) so
+// this stays after all non-export statements, per biome's useExportsLast.
+export { CLOSE_ANIMATION_MS };
+
 export default function SettingsDialog({ section }: { section: SettingsSectionKey }) {
 	const config = useConfig();
 	const { data: me } = useMe();

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -1,7 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Menu, X } from "lucide-react";
 import { lazy, Suspense, useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { Link, useLocation, useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogOverlay } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -61,14 +61,15 @@ function SettingsNavList({
 				const active = s.key === current;
 				return (
 					<li key={s.key}>
-						{/* Plain <a>, not react-router's <Link>: Link always resolves
-						`to` against the current pathname, so a hash-only `to` still
-						renders `href="/current/path#settings/x"`. A native anchor with
-						a bare fragment href lets the browser do same-document hash
-						navigation (pathname untouched, no reload); BrowserRouter's
-						popstate listener picks up the resulting URL change. */}
-						<a
-							href={settingsHash(s.key)}
+						{/* react-router's <Link>, not a plain <a>: a native anchor's
+						fragment-only navigation fires `hashchange`, not `popstate`, and
+						react-router's history only listens for `popstate` — a plain <a>
+						would silently desync useLocation(). Link always resolves `to`
+						against the current pathname (so href is e.g.
+						"/work/note-1#settings/billing", not a bare hash), but it's
+						routed through history.push, which react-router does see. */}
+						<Link
+							to={settingsHash(s.key)}
 							onClick={onNavigate}
 							aria-current={active ? "page" : undefined}
 							className={`block rounded-md px-3 py-2 text-sm transition-colors ${
@@ -78,7 +79,7 @@ function SettingsNavList({
 							}`}
 						>
 							{s.label}
-						</a>
+						</Link>
 					</li>
 				);
 			})}

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -63,8 +63,8 @@ function SettingsNavList({
 					<li key={s.key}>
 						{/* react-router's <Link>, not a plain <a>: a native anchor's
 						fragment-only navigation fires `hashchange`, not `popstate`, and
-						react-router's history only listens for `popstate` — a plain <a>
-						would silently desync useLocation(). Link always resolves `to`
+						react-router's history only listens for `popstate` (a plain <a>
+						would silently desync useLocation()). Link always resolves `to`
 						against the current pathname (so href is e.g.
 						"/work/note-1#settings/billing", not a bare hash), but it's
 						routed through history.push, which react-router does see. */}

--- a/frontend/src/settings/settings-layout.tsx
+++ b/frontend/src/settings/settings-layout.tsx
@@ -1,7 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Menu, X } from "lucide-react";
-import { useEffect, useState } from "react";
-import { NavLink, Outlet, useNavigate } from "react-router";
+import { lazy, Suspense, useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogOverlay } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -15,43 +15,78 @@ import {
 import { useMe } from "../api/queries";
 import { useConfig } from "../config-context";
 import { buildSettingsSections, type SettingsSection } from "./sections";
+import { type SettingsSectionKey, settingsHash } from "./settings-hash";
 
 // Keep this in sync with the duration-200 class on DialogPrimitive.Content
 // below — we hold the dialog mounted for one animation cycle after
 // onOpenChange(false) so Radix's exit transition plays before we navigate.
 const CLOSE_ANIMATION_MS = 200;
 
+// These are the exact modules router.tsx lazy-loads today.
+const AccountPage = lazy(() => import("./account-page"));
+const AccountPageLocal = lazy(() => import("./account-page-local"));
+const VaultsPage = lazy(() => import("./vaults-page"));
+const ConnectionsPage = lazy(() => import("./connections-page"));
+const BillingPage = lazy(() => import("../billing/billing-page"));
+const AdminPanel = lazy(() => import("../features/admin/AdminPanel"));
+
+function SectionBody({ section }: { section: SettingsSectionKey }) {
+	const config = useConfig();
+	switch (section) {
+		case "vaults":
+			return <VaultsPage />;
+		case "connections":
+			return <ConnectionsPage />;
+		case "billing":
+			return <BillingPage />;
+		case "admin":
+			return <AdminPanel />;
+		default:
+			return config.authProvider === "clerk" ? <AccountPage /> : <AccountPageLocal />;
+	}
+}
+
 function SettingsNavList({
 	sections,
+	current,
 	onNavigate,
 }: {
 	sections: SettingsSection[];
+	current: SettingsSectionKey;
 	onNavigate?: () => void;
 }) {
 	return (
 		<ul className="space-y-1">
-			{sections.map((s) => (
-				<li key={s.key}>
-					<NavLink
-						to={s.key}
-						onClick={onNavigate}
-						className={({ isActive }) =>
-							`block rounded-md px-3 py-2 text-sm transition-colors ${
-								isActive
+			{sections.map((s) => {
+				const active = s.key === current;
+				return (
+					<li key={s.key}>
+						{/* Plain <a>, not react-router's <Link>: Link always resolves
+						`to` against the current pathname, so a hash-only `to` still
+						renders `href="/current/path#settings/x"`. A native anchor with
+						a bare fragment href lets the browser do same-document hash
+						navigation (pathname untouched, no reload); BrowserRouter's
+						popstate listener picks up the resulting URL change. */}
+						<a
+							href={settingsHash(s.key)}
+							onClick={onNavigate}
+							aria-current={active ? "page" : undefined}
+							className={`block rounded-md px-3 py-2 text-sm transition-colors ${
+								active
 									? "bg-primary/10 font-medium text-primary"
 									: "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-							}`
-						}
-					>
-						{s.label}
-					</NavLink>
-				</li>
-			))}
+							}`}
+						>
+							{s.label}
+						</a>
+					</li>
+				);
+			})}
 		</ul>
 	);
 }
 
-export default function SettingsLayout() {
+export default function SettingsDialog({ section }: { section: SettingsSectionKey }) {
 	const config = useConfig();
 	const { data: me } = useMe();
 	const isAdmin = me?.role === "admin";
@@ -59,14 +94,26 @@ export default function SettingsLayout() {
 	const [navOpen, setNavOpen] = useState(false);
 	const [open, setOpen] = useState(true);
 	const navigate = useNavigate();
+	const location = useLocation();
 
+	// A hash can name a section this build does not have (`#settings/billing` on
+	// self-host, `#settings/admin` as a non-admin). Fall back rather than render
+	// an empty dialog body.
+	const current = sections.some((s) => s.key === section) ? section : "account";
+
+	// Close = strip the hash. Deferred by CLOSE_ANIMATION_MS so the Radix exit
+	// transition plays. This replaces the old `navigate("/")`, which threw away
+	// whatever page the user opened settings from.
 	useEffect(() => {
 		if (open) {
 			return;
 		}
-		const t = setTimeout(() => navigate("/"), CLOSE_ANIMATION_MS);
+		const t = setTimeout(
+			() => navigate({ pathname: location.pathname, search: location.search, hash: "" }),
+			CLOSE_ANIMATION_MS,
+		);
 		return () => clearTimeout(t);
-	}, [open, navigate]);
+	}, [open, navigate, location.pathname, location.search]);
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
@@ -107,7 +154,11 @@ export default function SettingsLayout() {
 								</SheetTitle>
 								<SheetDescription className="sr-only">Settings sections</SheetDescription>
 								<nav aria-label="Settings sections" className="p-3">
-									<SettingsNavList sections={sections} onNavigate={() => setNavOpen(false)} />
+									<SettingsNavList
+										sections={sections}
+										current={current}
+										onNavigate={() => setNavOpen(false)}
+									/>
 								</nav>
 							</SheetContent>
 						</Sheet>
@@ -125,14 +176,16 @@ export default function SettingsLayout() {
 									<h2 className="mb-3 px-3 font-semibold text-muted-foreground text-xs uppercase tracking-wide">
 										Settings
 									</h2>
-									<SettingsNavList sections={sections} />
+									<SettingsNavList sections={sections} current={current} />
 								</div>
 							</ScrollArea>
 						</nav>
 
 						<ScrollArea className="min-h-0 min-w-0 flex-1">
 							<div className="p-4 sm:p-6">
-								<Outlet />
+								<Suspense fallback={<p className="text-muted-foreground">Loading…</p>}>
+									<SectionBody section={current} />
+								</Suspense>
 							</div>
 						</ScrollArea>
 					</div>

--- a/frontend/src/settings/settings-overlay-host.test.tsx
+++ b/frontend/src/settings/settings-overlay-host.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import LegacySettingsRedirect from "./legacy-settings-redirect";
+import SettingsOverlayHost from "./settings-overlay-host";
+
+// The dialog pulls the whole settings surface (Clerk hooks, billing, admin);
+// stub it so this file tests only the host's mount decision.
+vi.mock("./settings-layout", () => ({
+	default: ({ section }: { section: string }) => <p data-testid="dialog">section:{section}</p>,
+}));
+
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.search}${loc.hash}`}</output>;
+}
+
+function renderHost(entry: string) {
+	return render(
+		<MemoryRouter initialEntries={[entry]}>
+			<Routes>
+				<Route element={<SettingsOverlayHost />}>
+					<Route path="/work/:id" element={<p>note body</p>} />
+				</Route>
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("SettingsOverlayHost", () => {
+	it("renders the page alone when there is no settings hash", () => {
+		renderHost("/work/note-1");
+		expect(screen.getByText("note body")).toBeInTheDocument();
+		expect(screen.queryByTestId("dialog")).toBeNull();
+	});
+
+	it("keeps the page mounted underneath when settings is open", () => {
+		renderHost("/work/note-1#settings/billing");
+		expect(screen.getByText("note body")).toBeInTheDocument();
+		expect(screen.getByTestId("dialog")).toHaveTextContent("section:billing");
+	});
+
+	it("ignores unrelated hashes", () => {
+		renderHost("/work/note-1#tour");
+		expect(screen.queryByTestId("dialog")).toBeNull();
+	});
+});
+
+describe("LegacySettingsRedirect", () => {
+	function renderRedirect(entry: string) {
+		return render(
+			<MemoryRouter initialEntries={[entry]}>
+				<LocationProbe />
+				<Routes>
+					<Route path="/settings" element={<LegacySettingsRedirect />} />
+					<Route path="/settings/*" element={<LegacySettingsRedirect />} />
+					<Route path="/" element={<p>root</p>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+	}
+
+	it("maps a bare /settings to the account hash", () => {
+		renderRedirect("/settings");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/#settings/account");
+	});
+
+	it("maps a section path to its hash", () => {
+		renderRedirect("/settings/billing");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/#settings/billing");
+	});
+
+	it("maps the legacy api-keys path to connections", () => {
+		renderRedirect("/settings/api-keys");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/#settings/connections");
+	});
+
+	it("preserves the query string", () => {
+		renderRedirect("/settings/vaults?highlight=abc");
+		expect(screen.getByTestId("loc")).toHaveTextContent("/?highlight=abc#settings/vaults");
+	});
+});

--- a/frontend/src/settings/settings-overlay-host.test.tsx
+++ b/frontend/src/settings/settings-overlay-host.test.tsx
@@ -34,10 +34,14 @@ describe("SettingsOverlayHost", () => {
 		expect(screen.queryByTestId("dialog")).toBeNull();
 	});
 
-	it("keeps the page mounted underneath when settings is open", () => {
+	it("keeps the page mounted underneath when settings is open", async () => {
 		renderHost("/work/note-1#settings/billing");
+		// The page underneath is synchronous (plain Outlet), but the dialog is
+		// lazy(), so it sits behind a Suspense boundary that resolves on a
+		// microtask. `vi.mock` does not make the dynamic import synchronous.
+		// Await the dialog; asserting it with a sync getBy* would always throw.
 		expect(screen.getByText("note body")).toBeInTheDocument();
-		expect(screen.getByTestId("dialog")).toHaveTextContent("section:billing");
+		expect(await screen.findByTestId("dialog")).toHaveTextContent("section:billing");
 	});
 
 	it("ignores unrelated hashes", () => {

--- a/frontend/src/settings/settings-overlay-host.tsx
+++ b/frontend/src/settings/settings-overlay-host.tsx
@@ -1,0 +1,25 @@
+import { lazy, Suspense } from "react";
+import { Outlet, useLocation } from "react-router";
+import { parseSettingsHash } from "./settings-hash";
+
+// Settings is a hash overlay, not a page: the route underneath stays mounted, so
+// closing returns you exactly where you were. Mounted at the AuthGuard level
+// rather than inside AppLayout because /link and /oauth/consent both link to
+// `#settings/billing` and live outside the app shell.
+const SettingsDialog = lazy(() => import("./settings-layout"));
+
+export default function SettingsOverlayHost() {
+	const { hash } = useLocation();
+	const section = parseSettingsHash(hash);
+
+	return (
+		<>
+			<Outlet />
+			{section !== null && (
+				<Suspense fallback={null}>
+					<SettingsDialog section={section} />
+				</Suspense>
+			)}
+		</>
+	);
+}

--- a/frontend/src/settings/vaults/active-vaults-section.test.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.test.tsx
@@ -1,6 +1,23 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActiveVaultsSection } from "./active-vaults-section";
+
+// Records the router's current hash so a test can prove a click actually
+// navigated (via history.push), not merely that the link's href looked right.
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc-hash">{loc.hash}</output>;
+}
+
+function renderSection() {
+	return render(
+		<MemoryRouter>
+			<LocationProbe />
+			<ActiveVaultsSection />
+		</MemoryRouter>,
+	);
+}
 
 const deleteMutate = vi.fn();
 const updateMutate = vi.fn();
@@ -56,7 +73,7 @@ describe("ActiveVaultsSection", () => {
 	});
 
 	it("lists vaults with counts and marks the default", () => {
-		render(<ActiveVaultsSection />);
+		renderSection();
 		const workRow = within(screen.getByText("Work").closest("tr") as HTMLElement);
 		expect(workRow.getByText("12")).toBeInTheDocument();
 		expect(workRow.getByText("3")).toBeInTheDocument();
@@ -64,7 +81,7 @@ describe("ActiveVaultsSection", () => {
 	});
 
 	it("opens the delete dialog and deletes after typing the name", async () => {
-		render(<ActiveVaultsSection />);
+		renderSection();
 		const workRow = within(screen.getByText("Work").closest("tr") as HTMLElement);
 		fireEvent.click(workRow.getByRole("button", { name: /delete .*work/iu }));
 		const confirmBtn = screen.getByRole("button", { name: /delete vault/iu });
@@ -77,7 +94,7 @@ describe("ActiveVaultsSection", () => {
 	});
 
 	it("sets a non-default vault as default", () => {
-		render(<ActiveVaultsSection />);
+		renderSection();
 		fireEvent.click(screen.getByRole("button", { name: /set .*personal.* as default/iu }));
 		expect(updateMutate).toHaveBeenCalledWith({ id: 2, is_default: true }, expect.anything());
 	});
@@ -85,7 +102,7 @@ describe("ActiveVaultsSection", () => {
 	it("shows the upgrade banner and hides New vault when at Free cap", () => {
 		// 2 vaults in setup; pin Free cap=1 so we're over.
 		billingState.current = { caps: { vaults: 1 } };
-		render(<ActiveVaultsSection />);
+		renderSection();
 		expect(screen.queryByRole("button", { name: /new vault/iu })).not.toBeInTheDocument();
 		expect(screen.getByText(/Free plan allows 1 vault/iu)).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: /upgrade/iu })).toBeInTheDocument();
@@ -93,9 +110,17 @@ describe("ActiveVaultsSection", () => {
 		expect(screen.getByText(/Vaults \(2 \/ 1\)/iu)).toBeInTheDocument();
 	});
 
+	it("Upgrade CTA click actually navigates (not just a correct href)", () => {
+		billingState.current = { caps: { vaults: 1 } };
+		renderSection();
+		expect(screen.getByTestId("loc-hash")).toHaveTextContent("");
+		fireEvent.click(screen.getByRole("link", { name: /upgrade/iu }));
+		expect(screen.getByTestId("loc-hash")).toHaveTextContent("#settings/billing");
+	});
+
 	it("keeps New vault enabled when below cap", () => {
 		billingState.current = { caps: { vaults: 5 } };
-		render(<ActiveVaultsSection />);
+		renderSection();
 		expect(screen.getByRole("button", { name: /new vault/iu })).toBeInTheDocument();
 		expect(screen.queryByText(/Free plan allows/iu)).not.toBeInTheDocument();
 		expect(screen.getByText(/Vaults \(2 \/ 5\)/iu)).toBeInTheDocument();

--- a/frontend/src/settings/vaults/active-vaults-section.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.tsx
@@ -1,5 +1,6 @@
 import { Pencil, Star, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { Link } from "react-router";
 import { toast } from "sonner";
 import { useBillingStatus, useUpdateVault, useVaults, type Vault } from "@/api/queries";
 import { Button } from "@/components/ui/button";
@@ -126,12 +127,12 @@ export function ActiveVaultsSection() {
 					<p className="text-foreground text-sm">
 						Your Free plan allows {vaultsCap} vault. Upgrade to Starter for more vaults.
 					</p>
-					<a
-						href={settingsHash("billing")}
+					<Link
+						to={settingsHash("billing")}
 						className="shrink-0 rounded-md bg-primary px-3 py-1.5 font-medium text-primary-foreground text-sm hover:bg-primary/90"
 					>
 						Upgrade
-					</a>
+					</Link>
 				</aside>
 			)}
 			{createOpen && !atCap && (

--- a/frontend/src/settings/vaults/active-vaults-section.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { VaultCreateForm } from "@/components/vault-create-form";
 import { useAutofocus } from "@/hooks/use-autofocus";
 import { SettingsSectionCard } from "@/settings/account/section-card";
+import { settingsHash } from "../settings-hash";
 import { DeleteVaultDialog } from "./delete-vault-dialog";
 
 const inputClass =
@@ -126,7 +127,7 @@ export function ActiveVaultsSection() {
 						Your Free plan allows {vaultsCap} vault. Upgrade to Starter for more vaults.
 					</p>
 					<a
-						href="/settings/billing"
+						href={settingsHash("billing")}
 						className="shrink-0 rounded-md bg-primary px-3 py-1.5 font-medium text-primary-foreground text-sm hover:bg-primary/90"
 					>
 						Upgrade

--- a/frontend/src/settings/vaults/active-vaults-section.tsx
+++ b/frontend/src/settings/vaults/active-vaults-section.tsx
@@ -1,13 +1,13 @@
 import { Pencil, Star, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import { toast } from "sonner";
 import { useBillingStatus, useUpdateVault, useVaults, type Vault } from "@/api/queries";
 import { Button } from "@/components/ui/button";
 import { VaultCreateForm } from "@/components/vault-create-form";
 import { useAutofocus } from "@/hooks/use-autofocus";
 import { SettingsSectionCard } from "@/settings/account/section-card";
-import { settingsHash } from "../settings-hash";
+import { settingsTo } from "../settings-hash";
 import { DeleteVaultDialog } from "./delete-vault-dialog";
 
 const inputClass =
@@ -104,6 +104,7 @@ export function ActiveVaultsSection() {
 	const { data: billing } = useBillingStatus();
 	const [deleteTarget, setDeleteTarget] = useState<Vault | null>(null);
 	const [createOpen, setCreateOpen] = useState(false);
+	const location = useLocation();
 
 	const vaultsCap = billing?.caps.vaults ?? null;
 	const vaultCount = vaults?.length ?? 0;
@@ -128,7 +129,7 @@ export function ActiveVaultsSection() {
 						Your Free plan allows {vaultsCap} vault. Upgrade to Starter for more vaults.
 					</p>
 					<Link
-						to={settingsHash("billing")}
+						to={settingsTo("billing", location.search)}
 						className="shrink-0 rounded-md bg-primary px-3 py-1.5 font-medium text-primary-foreground text-sm hover:bg-primary/90"
 					>
 						Upgrade

--- a/frontend/src/viewer/attachment-page.test.tsx
+++ b/frontend/src/viewer/attachment-page.test.tsx
@@ -41,9 +41,9 @@ beforeEach(() => {
 
 function renderAt(id: string) {
 	return render(
-		<MemoryRouter initialEntries={[`/note/${id}`]}>
+		<MemoryRouter initialEntries={[`/work/${id}`]}>
 			<Routes>
-				<Route path="/note/:id" element={<AttachmentPage />} />
+				<Route path="/:slug/:itemId" element={<AttachmentPage />} />
 			</Routes>
 		</MemoryRouter>,
 	);

--- a/frontend/src/viewer/attachment-page.tsx
+++ b/frontend/src/viewer/attachment-page.tsx
@@ -15,7 +15,7 @@ const PdfView = lazy(() => import("./pdf-view"));
 // warm), then streams raw bytes (?raw=1) as a typed Blob so the browser renders
 // images / PDFs natively; unsupported types fall back to a download link.
 export default function AttachmentPage() {
-	const { id } = useParams();
+	const { itemId: id } = useParams();
 	const { data: attachments, isLoading } = useAttachments();
 	const att = attachments?.find((a) => a.id === id);
 	const path = att?.path ?? "";

--- a/frontend/src/viewer/dashboard.tsx
+++ b/frontend/src/viewer/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Link, useSearchParams } from "react-router";
 import { type NoteSummary, useFolderNotes, useVaults } from "../api/queries";
+import { useActiveVaultSlug } from "../api/vault-slug";
 import { EmptyVaultState } from "../layout/empty-vault-state";
 import { useRightTools } from "../layout/right-tools-context";
 import { noteName } from "../lib/note-name";
@@ -19,9 +20,13 @@ interface NoteRowProps {
 }
 
 function NoteRow({ note }: NoteRowProps) {
+	const slug = useActiveVaultSlug();
 	return (
 		<article className="border-gray-100 border-b py-3 last:border-0 dark:border-gray-800">
-			<Link to={`/note/${note.id}`} className="block hover:text-blue-700">
+			<Link
+				to={slug ? `/${slug}/${note.id}` : `/note/${note.id}`}
+				className="block hover:text-blue-700"
+			>
 				<h3 className="font-medium text-gray-900 text-sm dark:text-gray-100">
 					{noteName(note.path) || note.path}
 				</h3>

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -82,7 +82,7 @@ export default function FolderTree() {
 	const vaultId = useActiveVaultId();
 	const qc = useQueryClient();
 	const params = useParams();
-	const selectedNoteId = params.id ?? null;
+	const selectedNoteId = params.itemId ?? null;
 
 	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const [dialog, setDialog] = useState<DialogState>({ kind: "none" });

--- a/frontend/src/viewer/legacy-note-redirect.tsx
+++ b/frontend/src/viewer/legacy-note-redirect.tsx
@@ -1,0 +1,31 @@
+import { Navigate, useLocation, useParams } from "react-router";
+import { getActiveVaultId } from "../api/active-vault";
+import { useVaults } from "../api/queries";
+import { preferredVault } from "../api/vault-slug";
+import NotFoundPage from "../not-found";
+import LoadingPane from "./loading-pane";
+
+// Old `/note/:id` links. A note id alone does not name its vault, so this is
+// best effort: resolve the last-used vault and rewrite. If the note actually
+// lives elsewhere the note fetch 404s, which is exactly what happened before
+// this change, so no regression. A server-side note-to-vault lookup would make
+// it exact and is deliberately out of scope.
+export default function LegacyNoteRedirect() {
+	const { id } = useParams();
+	const { data: vaults, isPending } = useVaults();
+	const location = useLocation();
+
+	if (isPending && !vaults) {
+		return <LoadingPane />;
+	}
+	const vault = preferredVault(vaults, getActiveVaultId());
+	if (!(vault && id)) {
+		return <NotFoundPage />;
+	}
+	return (
+		<Navigate
+			to={{ pathname: `/${vault.slug}/${id}`, search: location.search, hash: location.hash }}
+			replace
+		/>
+	);
+}

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -55,7 +55,7 @@ vi.mock("../api/queries", () => ({
 	useNote: (...a: unknown[]) => useNoteMock(...a),
 	useRenameNote: () => ({ mutate: renameNoteMutate, isPending: false }),
 }));
-vi.mock("react-router", () => ({ useParams: () => ({ id: "note-1" }) }));
+vi.mock("react-router", () => ({ useParams: () => ({ itemId: "note-1" }) }));
 
 const NOTE = {
 	id: "note-1",

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -43,7 +43,7 @@ interface DocHandle {
 
 export default function NotePage() {
 	const params = useParams();
-	const idStr = params.id;
+	const idStr = params.itemId;
 	const validId = idStr && idStr.length > 0 ? idStr : null;
 
 	const { data: note, isLoading, error } = useNote(validId);

--- a/frontend/src/viewer/tree/tree-row.test.tsx
+++ b/frontend/src/viewer/tree/tree-row.test.tsx
@@ -6,6 +6,12 @@ import type { LoaderItem } from "./loader";
 import { TreeRow } from "./tree-row";
 import type { TreeItem } from "./types";
 
+// TreeRow reads the active vault slug to build note hrefs. Default to null
+// (the fallback/legacy shape) so the existing href assertions below stay
+// valid; individual tests override with mockReturnValueOnce.
+const activeSlugMock = vi.fn<() => string | null>(() => null);
+vi.mock("../../api/vault-slug", () => ({ useActiveVaultSlug: () => activeSlugMock() }));
+
 const folderItem: TreeItem = {
 	kind: "folder",
 	id: "1",
@@ -112,6 +118,18 @@ describe("TreeRow", () => {
 		const link = screen.getByRole("link") as HTMLAnchorElement;
 		expect(link.getAttribute("href")).toBe("/note/100");
 		expect(screen.getByText("a")).toBeInTheDocument();
+	});
+
+	it("renders note as a vault-scoped link once the active vault slug loads", () => {
+		activeSlugMock.mockReturnValueOnce("work");
+		const instance = mockInstance({ data: noteItem });
+		render(
+			<MemoryRouter>
+				<TreeRow instance={instance} />
+			</MemoryRouter>,
+		);
+		const link = screen.getByRole("link") as HTMLAnchorElement;
+		expect(link.getAttribute("href")).toBe("/work/100");
 	});
 
 	it("shows uppercase ext badge for non-md notes", () => {
@@ -413,6 +431,18 @@ describe("TreeRow", () => {
 		// Base name only — the extension lives in the badge beside it.
 		expect(screen.getByText("a")).toBeInTheDocument();
 		expect(screen.queryByText("a.png")).not.toBeInTheDocument();
+	});
+
+	it("renders attachment as a vault-scoped link once the active vault slug loads", () => {
+		activeSlugMock.mockReturnValueOnce("work");
+		const instance = mockInstance({ data: attachmentItem });
+		render(
+			<MemoryRouter>
+				<TreeRow instance={instance} />
+			</MemoryRouter>,
+		);
+		const link = screen.getByRole("link") as HTMLAnchorElement;
+		expect(link.getAttribute("href")).toBe("/work/att-1");
 	});
 
 	it("shows uppercase ext badge for attachment", () => {

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -2,6 +2,7 @@ import type { ItemInstance } from "@headless-tree/core";
 import { ChevronRight, File, FileText, Image } from "lucide-react";
 import type React from "react";
 import { Link } from "react-router";
+import { useActiveVaultSlug } from "../../api/vault-slug";
 import { noteName } from "../../lib/note-name";
 import { RenameInput } from "../tree-actions/rename-input";
 import { useLongPress } from "../tree-actions/use-long-press";
@@ -122,6 +123,7 @@ export function TreeRow({
 	onFolderHover,
 }: Props) {
 	const itemId = instance.getId();
+	const slug = useActiveVaultSlug();
 	const longPressHandlers = useLongPress({
 		onLongPress: () => onLongPress?.(itemId),
 	});
@@ -227,7 +229,7 @@ export function TreeRow({
 		// path-keyed (internal tree machinery).
 		return (
 			<Link
-				to={`/note/${item.id}`}
+				to={slug ? `/${slug}/${item.id}` : `/note/${item.id}`}
 				{...instance.getProps()}
 				{...longPressProps}
 				onContextMenu={contextMenuHandler}
@@ -270,7 +272,7 @@ export function TreeRow({
 
 	return (
 		<Link
-			to={`/note/${item.id}`}
+			to={slug ? `/${slug}/${item.id}` : `/note/${item.id}`}
 			{...htProps}
 			{...longPressProps}
 			onContextMenu={contextMenuHandler}

--- a/frontend/src/viewer/tree/tree-row.tsx
+++ b/frontend/src/viewer/tree/tree-row.tsx
@@ -141,8 +141,8 @@ export function TreeRow({
 
 	const data = instance.getItemData();
 	const { item } = data;
-	// Folders are never the "open" thing — only notes and attachments route to
-	// /note/:id — so expanding one can't move the highlight.
+	// Folders are never the "open" thing: only notes and attachments route to
+	// /:vaultSlug/:itemId, so expanding one can't move the highlight.
 	const active = item.kind !== "folder" && item.id === activeId;
 	const menuOpen = itemId === menuOpenId;
 	const depth = instance.getItemMeta()?.level ?? 0;
@@ -224,9 +224,11 @@ export function TreeRow({
 			: item.mime === "application/pdf"
 				? FileText
 				: File;
-		// Routed by uuid under the unified /note/:id (VaultItemPage resolves
-		// note-vs-file) so the URL survives a rename/move. The HT itemId stays
-		// path-keyed (internal tree machinery).
+		// Routed by uuid under the unified /:vaultSlug/:itemId (VaultItemPage
+		// resolves note-vs-file) so the URL survives a rename/move. Falls back to
+		// the legacy /note/:id, which redirects, while the active vault's slug is
+		// still resolving. The HT itemId stays path-keyed (internal tree
+		// machinery).
 		return (
 			<Link
 				to={slug ? `/${slug}/${item.id}` : `/note/${item.id}`}

--- a/frontend/src/viewer/vault-item-page.test.tsx
+++ b/frontend/src/viewer/vault-item-page.test.tsx
@@ -31,9 +31,9 @@ beforeEach(() => {
 
 function renderAt(id: string) {
 	return render(
-		<MemoryRouter initialEntries={[`/note/${id}`]}>
+		<MemoryRouter initialEntries={[`/work/${id}`]}>
 			<Routes>
-				<Route path="/note/:id" element={<VaultItemPage />} />
+				<Route path="/:slug/:itemId" element={<VaultItemPage />} />
 			</Routes>
 		</MemoryRouter>,
 	);

--- a/frontend/src/viewer/vault-item-page.tsx
+++ b/frontend/src/viewer/vault-item-page.tsx
@@ -8,14 +8,14 @@ import LoadingPane from "./loading-pane";
 const NotePage = lazy(() => import("./note-page"));
 const AttachmentPage = lazy(() => import("./attachment-page"));
 
-// Resolver behind the unified /note/:id route. Notes and attachments share one
+// Resolver behind the unified /:slug/:itemId route. Notes and attachments share one
 // URL shape (like Obsidian, where everything is a vault item) — decide which
 // viewer to mount by checking the loaded attachments list. The tree sidebar
 // keeps that list warm, so in-app navigation resolves instantly; a cold
 // deep-link to an attachment briefly renders NotePage until the list lands,
 // then re-resolves (the common case — a note — is never delayed).
 export default function VaultItemPage() {
-	const { id } = useParams();
+	const { itemId: id } = useParams();
 	const { data: attachments, isLoading } = useAttachments();
 
 	// Until the attachments list has loaded we can't tell a note id from an

--- a/frontend/src/viewer/vault-redirect.tsx
+++ b/frontend/src/viewer/vault-redirect.tsx
@@ -1,0 +1,28 @@
+import { Navigate, useLocation } from "react-router";
+import { getActiveVaultId } from "../api/active-vault";
+import { useVaults } from "../api/queries";
+import { preferredVault } from "../api/vault-slug";
+import { EmptyVaultState } from "../layout/empty-vault-state";
+import LoadingPane from "./loading-pane";
+
+// Bare `/` does not name a vault, so pick one: last-used, else default, else
+// first. Search and hash are carried across so links like
+// `/?highlight=<id>#settings/vaults` (the vault-deleted email) survive.
+export default function VaultRedirect() {
+	const { data: vaults, isPending } = useVaults();
+	const location = useLocation();
+
+	if (isPending && !vaults) {
+		return <LoadingPane />;
+	}
+	const vault = preferredVault(vaults, getActiveVaultId());
+	if (!vault) {
+		return <EmptyVaultState />;
+	}
+	return (
+		<Navigate
+			to={{ pathname: `/${vault.slug}`, search: location.search, hash: location.hash }}
+			replace
+		/>
+	);
+}

--- a/frontend/src/viewer/vault-route.test.tsx
+++ b/frontend/src/viewer/vault-route.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getActiveVaultId, setActiveVaultId } from "../api/active-vault";
+import LegacyNoteRedirect from "./legacy-note-redirect";
+import VaultRedirect from "./vault-redirect";
+import VaultRoute from "./vault-route";
+
+const vaults = [
+	{ id: "id-a", slug: "work", is_default: false, name: "Work" },
+	{ id: "id-b", slug: "personal", is_default: true, name: "Personal" },
+];
+
+let mockVaults: unknown[] | undefined = vaults;
+let mockPending = false;
+
+vi.mock("../api/queries", () => ({
+	useVaults: () => ({ data: mockVaults, isPending: mockPending }),
+}));
+
+// NotFoundPage (rendered on the 404 path) pulls in ThemeToggle, which needs a
+// ThemeProvider we are not wiring up here. Same mock as src/not-found.test.tsx.
+vi.mock("../theme/theme-toggle", () => ({
+	default: () => <button type="button">theme</button>,
+}));
+
+function LocationProbe() {
+	const loc = useLocation();
+	return <output data-testid="loc">{`${loc.pathname}${loc.search}${loc.hash}`}</output>;
+}
+
+// Records the active vault id at RENDER time, not in an effect, so the test can
+// prove no child ever renders under the wrong vault.
+function VaultProbe() {
+	return <output data-testid="child">{String(getActiveVaultId())}</output>;
+}
+
+beforeEach(() => {
+	mockVaults = vaults;
+	mockPending = false;
+	setActiveVaultId(null);
+});
+
+describe("VaultRoute", () => {
+	function renderRoute(entry: string) {
+		return render(
+			<MemoryRouter initialEntries={[entry]}>
+				<Routes>
+					<Route path="/:slug" element={<VaultRoute />}>
+						<Route index element={<VaultProbe />} />
+					</Route>
+				</Routes>
+			</MemoryRouter>,
+		);
+	}
+
+	it("resolves the slug and renders children under that vault", async () => {
+		renderRoute("/work");
+		expect(await screen.findByTestId("child")).toHaveTextContent("id-a");
+	});
+
+	it("never renders children under the previous vault", async () => {
+		setActiveVaultId("id-b");
+		renderRoute("/work");
+		const child = await screen.findByTestId("child");
+		// If VaultRoute rendered its Outlet before the store caught up, this
+		// would have been "id-b" for one pass and ~25 queries would have fired
+		// against the wrong vault.
+		expect(child).toHaveTextContent("id-a");
+	});
+
+	it("404s on an unknown slug", () => {
+		renderRoute("/nope");
+		expect(screen.queryByTestId("child")).toBeNull();
+		expect(screen.getByText(/not found/i)).toBeInTheDocument();
+	});
+
+	it("waits rather than 404ing while the vault list is loading", () => {
+		mockVaults = undefined;
+		mockPending = true;
+		renderRoute("/work");
+		expect(screen.queryByText(/not found/i)).toBeNull();
+		expect(screen.queryByTestId("child")).toBeNull();
+	});
+});
+
+describe("VaultRedirect", () => {
+	function renderRedirect(entry: string) {
+		return render(
+			<MemoryRouter initialEntries={[entry]}>
+				<LocationProbe />
+				<Routes>
+					<Route path="/" element={<VaultRedirect />} />
+					<Route path="/:slug" element={<p>vault page</p>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+	}
+
+	it("redirects to the hinted vault", async () => {
+		setActiveVaultId("id-a");
+		renderRedirect("/");
+		expect(await screen.findByTestId("loc")).toHaveTextContent("/work");
+	});
+
+	it("redirects to the default vault with no hint", async () => {
+		renderRedirect("/");
+		expect(await screen.findByTestId("loc")).toHaveTextContent("/personal");
+	});
+
+	it("preserves search and hash across the bounce", async () => {
+		renderRedirect("/?highlight=abc#settings/vaults");
+		expect(await screen.findByTestId("loc")).toHaveTextContent(
+			"/personal?highlight=abc#settings/vaults",
+		);
+	});
+
+	it("renders the empty state when there are no vaults", () => {
+		mockVaults = [];
+		renderRedirect("/");
+		expect(screen.getByText(/no vaults/i)).toBeInTheDocument();
+	});
+});
+
+describe("LegacyNoteRedirect", () => {
+	it("rewrites /note/:id to /:slug/:id using the hinted vault", async () => {
+		setActiveVaultId("id-a");
+		render(
+			<MemoryRouter initialEntries={["/note/n-1"]}>
+				<LocationProbe />
+				<Routes>
+					<Route path="/note/:id" element={<LegacyNoteRedirect />} />
+					<Route path="/:slug/:itemId" element={<p>note page</p>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+		expect(await screen.findByTestId("loc")).toHaveTextContent("/work/n-1");
+	});
+});

--- a/frontend/src/viewer/vault-route.tsx
+++ b/frontend/src/viewer/vault-route.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import { Outlet, useParams } from "react-router";
+import { setActiveVaultId, useActiveVaultId } from "../api/active-vault";
+import { useVaults } from "../api/queries";
+import { vaultBySlug } from "../api/vault-slug";
+import NotFoundPage from "../not-found";
+import LoadingPane from "./loading-pane";
+
+// The URL is the source of truth for the active vault. This is the ONLY place
+// that writes the store from a route; ~30 consumers (queries.ts, use-channel,
+// folder-tree, trace, remote-log) read it unchanged.
+export default function VaultRoute() {
+	const { slug } = useParams();
+	const { data: vaults, isPending } = useVaults();
+	const activeId = useActiveVaultId();
+	const vault = vaultBySlug(vaults, slug);
+
+	useEffect(() => {
+		if (vault) {
+			setActiveVaultId(vault.id);
+		}
+	}, [vault]);
+
+	// The list is normally already warm: useAppBootstrap seeds ["vaults"] and
+	// runs in OnboardingGate, above this route. This only gates a genuine cold
+	// fetch, and must come before the 404 so a slow list is not mistaken for a
+	// bad slug.
+	if (isPending && !vaults) {
+		return <LoadingPane />;
+	}
+	if (!vault) {
+		return <NotFoundPage />;
+	}
+	// Load-bearing: the effect above lands AFTER this render. Without the hold,
+	// one pass escapes with the PREVIOUS vault id and every descendant query and
+	// the channel join fire against the wrong vault.
+	if (activeId !== vault.id) {
+		return <LoadingPane />;
+	}
+	return <Outlet />;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -178,7 +178,15 @@ export default defineConfig({
 			// changeOrigin rewrites the Host header to the target — required when
 			// VITE_API_TARGET points at a remote host routed by Host (e.g. Cloudflare);
 			// harmless against localhost.
-			"/api": {
+			//
+			// Anchored as a RegExp (a leading ^ makes Vite treat the key as one)
+			// because a bare "/api" is a PREFIX match, which also swallows vault
+			// slugs like /api-2. Reserved slugs stop a vault from being exactly
+			// "api", but `unique_slug` hands out api-2 for a vault named "api",
+			// and that must render the SPA, not proxy to Phoenix. Proxying it
+			// serves Phoenix's prebuilt index.html into the dev server, whose
+			// hashed asset URLs 404 — the app then hangs on "Loading…".
+			"^/api(/|$)": {
 				target: apiTarget,
 				changeOrigin: true,
 			},
@@ -192,7 +200,9 @@ export default defineConfig({
 				target: apiTarget,
 				changeOrigin: true,
 			},
-			"/socket": {
+			// Anchored for the same reason as /api above: a slug like /socket-2
+			// must reach the SPA, not the WebSocket proxy.
+			"^/socket(/|$)": {
 				target: apiTarget,
 				changeOrigin: true,
 				ws: true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -186,7 +186,11 @@ export default defineConfig({
 			// and that must render the SPA, not proxy to Phoenix. Proxying it
 			// serves Phoenix's prebuilt index.html into the dev server, whose
 			// hashed asset URLs 404 — the app then hangs on "Loading…".
-			"^/api(/|$)": {
+			//
+			// The `?` in the class matters: Vite matches against the RAW req.url,
+			// query string included, so `[/?]` is what keeps /api?foo=1 proxied
+			// while /api-2?foo=1 still reaches the SPA.
+			"^/api(?:$|[/?])": {
 				target: apiTarget,
 				changeOrigin: true,
 			},
@@ -201,8 +205,10 @@ export default defineConfig({
 				changeOrigin: true,
 			},
 			// Anchored for the same reason as /api above: a slug like /socket-2
-			// must reach the SPA, not the WebSocket proxy.
-			"^/socket(/|$)": {
+			// must reach the SPA, not the WebSocket proxy. The upgrade handler
+			// matches on the raw req.url too, so /socket/websocket?vsn=2.0.0
+			// still proxies.
+			"^/socket(?:$|[/?])": {
 				target: apiTarget,
 				changeOrigin: true,
 				ws: true,

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -769,7 +769,10 @@ defmodule Engram.Vaults do
         query
       end
 
-    existing = Repo.all(query)
+    # A reserved slug (see Vault.reserved_slugs/0) isn't in the DB, but it's
+    # unreachable/broken the same way a taken one is, so it's folded into the
+    # same collision set and gets the same -2, -3... dedup treatment.
+    existing = Repo.all(query) ++ Vault.reserved_slugs()
 
     if base_slug in existing do
       Enum.find_value(2..1000, fn n ->

--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -30,6 +30,23 @@ defmodule Engram.Vaults.Vault do
     timestamps(type: :utc_datetime, inserted_at: :created_at)
   end
 
+  # Slugs that would make a vault unreachable. Two failure modes:
+  #   - Frontend-shadowed (sign-in..settings): React Router ranks static
+  #     segments above `/:slug`, so e.g. `/link` beats `/:slug` and the vault
+  #     is simply unreachable by URL.
+  #   - Backend-denied (api..socket): Task 7's Phoenix deny-list 404s these
+  #     prefixes before the SPA ever loads, so a vault slugged `assets` is
+  #     completely broken, not just awkward.
+  # Keep in sync with frontend/src/api/reserved-slugs.ts.
+  @reserved_slugs ~w(
+    sign-in sign-up waitlist link oauth onboard reset-password
+    note search billing settings api webhooks .well-known
+    assets email socket
+  )
+
+  @doc "Exposes the reserved-slug list so slug generation can dedup around it, same as a taken slug."
+  def reserved_slugs, do: @reserved_slugs
+
   def changeset(vault, attrs) do
     vault
     |> cast(attrs, [
@@ -51,6 +68,8 @@ defmodule Engram.Vaults.Vault do
       :name_nonce,
       :name_hmac
     ])
+    |> update_change(:slug, &String.downcase/1)
+    |> validate_exclusion(:slug, @reserved_slugs, message: "is reserved")
     |> unique_constraint([:user_id, :slug], name: :vaults_user_id_slug_index)
     |> unique_constraint([:user_id, :client_id], name: :vaults_user_id_client_id_index)
   end

--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -30,18 +30,23 @@ defmodule Engram.Vaults.Vault do
     timestamps(type: :utc_datetime, inserted_at: :created_at)
   end
 
-  # Slugs that would make a vault unreachable. Two failure modes:
+  # Slugs that would make a vault unreachable. Three failure modes:
   #   - Frontend-shadowed (sign-in..settings): React Router ranks static
   #     segments above `/:slug`, so e.g. `/link` beats `/:slug` and the vault
   #     is simply unreachable by URL.
   #   - Backend-denied (api..socket): Task 7's Phoenix deny-list 404s these
   #     prefixes before the SPA ever loads, so a vault slugged `assets` is
   #     completely broken, not just awkward.
+  #   - Backend-forwarded (metrics): router.ex mounts `forward "/metrics",
+  #     PromEx.Plug` behind bearer auth, ahead of the vault route, so
+  #     `/metrics` and everything under it 401s before the SPA loads. No
+  #     deny-list entry needed for this one, the forward already wins by
+  #     declaration order.
   # Keep in sync with frontend/src/api/reserved-slugs.ts.
   @reserved_slugs ~w(
     sign-in sign-up waitlist link oauth onboard reset-password
     note search billing settings api webhooks .well-known
-    assets email socket
+    assets email socket metrics
   )
 
   @doc "Exposes the reserved-slug list so slug generation can dedup around it, same as a taken slug."

--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -68,7 +68,7 @@ defmodule Engram.Vaults.Vault do
       :name_nonce,
       :name_hmac
     ])
-    |> update_change(:slug, &String.downcase/1)
+    |> update_change(:slug, &(&1 |> String.trim() |> String.downcase()))
     |> validate_exclusion(:slug, @reserved_slugs, message: "is reserved")
     |> unique_constraint([:user_id, :slug], name: :vaults_user_id_slug_index)
     |> unique_constraint([:user_id, :client_id], name: :vaults_user_id_client_id_index)

--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -31,9 +31,14 @@ defmodule Engram.Vaults.Vault do
   end
 
   # Slugs that would make a vault unreachable. Three failure modes:
-  #   - Frontend-shadowed (sign-in..settings): React Router ranks static
-  #     segments above `/:slug`, so e.g. `/link` beats `/:slug` and the vault
-  #     is simply unreachable by URL.
+  #   - Route-shadowed (sign-in..settings): some of these have a top-level
+  #     static React Router route that beats `/:slug` (e.g. `/link`), making a
+  #     same-named vault unreachable by URL. Others (`search`, `billing`) have
+  #     NO such static route (`billing` only exists nested under
+  #     `/onboard/billing`; `search` is a rail-toggled panel, not a route), so
+  #     `/:slug` would actually match them; what actually stops a vault
+  #     from ever holding one of these slugs is `validate_exclusion` below,
+  #     not routing.
   #   - Backend-denied (api..socket): Task 7's Phoenix deny-list 404s these
   #     prefixes before the SPA ever loads, so a vault slugged `assets` is
   #     completely broken, not just awkward.

--- a/lib/engram/workers/vault_deleted_email.ex
+++ b/lib/engram/workers/vault_deleted_email.ex
@@ -39,7 +39,11 @@ defmodule Engram.Workers.VaultDeletedEmail do
       true ->
         purge_at = DateTime.add(vault.deleted_at, @retention_days * 86_400, :second)
         purge_date = Calendar.strftime(purge_at, "%B %-d, %Y")
-        manage_url = EngramWeb.Endpoint.url() <> "/settings/vaults?highlight=#{vault.id}"
+
+        # The section goes in the hash and `highlight` stays in the real query
+        # string: a query placed inside a hash is never parsed by
+        # location.search, so the SPA would never see it there.
+        manage_url = EngramWeb.Endpoint.url() <> "/?highlight=#{vault.id}#settings/vaults"
 
         _ =
           Mailer.send_vault_deletion_notice(user, vault_name(vault, user), purge_date, manage_url)

--- a/lib/engram_web/controllers/spa_controller.ex
+++ b/lib/engram_web/controllers/spa_controller.ex
@@ -7,6 +7,20 @@ defmodule EngramWeb.SpaController do
     |> send_resp(200, injected_html())
   end
 
+  @doc """
+  404 for non-SPA prefixes.
+
+  The router's `/:slug` and `/:slug/:id` SPA routes are dynamic wildcards,
+  so without an explicit deny-list ahead of them a typo'd `/api/notez`
+  would match `/:slug/:id` and get an HTML 200, masking a broken API
+  call. See the deny-list comment in router.ex and #858.
+  """
+  def not_found(conn, _params) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(404, "Not Found")
+  end
+
   defp injected_html do
     {pre, post} = cached_split()
     pre <> config_script() <> post

--- a/lib/engram_web/plugs/enforce_connection_cap.ex
+++ b/lib/engram_web/plugs/enforce_connection_cap.ex
@@ -16,7 +16,7 @@ defmodule EngramWeb.Plugs.EnforceConnectionCap do
        "tier": "free" | "starter" | "pro",
        "current": <integer>,
        "limit": <integer>,
-       "upgrade_url": "/settings/billing"}
+       "upgrade_url": "/#settings/billing"}
 
   Missing or unknown `client_id`: HTTP 400 with
       {"error": "missing_or_invalid_client_id"}

--- a/lib/engram_web/plugs/enforce_pat_creation.ex
+++ b/lib/engram_web/plugs/enforce_pat_creation.ex
@@ -9,14 +9,14 @@ defmodule EngramWeb.Plugs.EnforcePatCreation do
   the JWT-authed `POST /api/connections/pat` route only.
 
   Rejection: HTTP 402 with
-  `{"error": "pat_disabled_on_free", "upgrade_url": "/settings/billing"}`.
+  `{"error": "pat_disabled_on_free", "upgrade_url": "/#settings/billing"}`.
   """
 
   import Plug.Conn
 
   alias Engram.Billing
 
-  @upgrade_url "/settings/billing"
+  @upgrade_url "/#settings/billing"
 
   def init(opts), do: opts
 

--- a/lib/engram_web/plugs/require_api_write_enabled.ex
+++ b/lib/engram_web/plugs/require_api_write_enabled.ex
@@ -7,7 +7,7 @@ defmodule EngramWeb.Plugs.RequireApiWriteEnabled do
 
   Free's default is `api_write_enabled = false` — Starter and Pro both
   default `true`. Rejection: HTTP 402 with
-  `{"error": "api_write_not_available", "upgrade_url": "/settings/billing"}`.
+  `{"error": "api_write_not_available", "upgrade_url": "/#settings/billing"}`.
 
   POST `/api/search` is explicitly exempt: it's a read despite being a
   POST (encrypted query body). All other non-GET routes on the
@@ -45,7 +45,7 @@ defmodule EngramWeb.Plugs.RequireApiWriteEnabled do
           402,
           Jason.encode!(%{
             error: "api_write_not_available",
-            upgrade_url: "/settings/billing"
+            upgrade_url: "/#settings/billing"
           })
         )
         |> halt()

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -460,7 +460,8 @@ defmodule EngramWeb.Router do
   # Below the whitelist, `/:slug` and `/:slug/:id` are dynamic vault-scoped
   # routes (vault, and vault+note-or-attachment). Those are wildcards, so a
   # deny-list for every non-SPA top-level prefix sits between the whitelist
-  # and the wildcards; see its comment for why order matters.
+  # and the wildcards; see its comment for why order matters (it must stay
+  # BELOW the static whitelist above and ABOVE the wildcards below).
   scope "/", EngramWeb do
     pipe_through :spa
 
@@ -484,14 +485,26 @@ defmodule EngramWeb.Router do
     # /:slug/:id route below like any other slug; that's expected, not a
     # revival of this feature.)
 
-    # Deny-list. MUST stay above the dynamic /:slug routes below: those are
+    # Deny-list. MUST stay BELOW the static whitelist above (so a real
+    # static route like /oauth/consent still wins over its own prefix's
+    # deny entry) and ABOVE the dynamic /:slug routes below (those are
     # 1- and 2-segment wildcards, so without this a typo'd /api/notez would
-    # match /:slug/:id and serve an HTML 200 (the exact regression #858
+    # match /:slug/:id and serve an HTML 200, the exact regression #858
     # removed). EVERY new non-SPA top-level prefix must be added here.
     match :*, "/api/*path", SpaController, :not_found
     match :*, "/oauth/*path", SpaController, :not_found
     match :*, "/webhooks/*path", SpaController, :not_found
     match :*, "/.well-known/*path", SpaController, :not_found
+    # /socket is registered by the `socket "/socket", EngramWeb.UserSocket`
+    # macro in endpoint.ex, not a router scope, so it doesn't show up when
+    # enumerating scope declarations either. Endpoint-level socket dispatch
+    # only claims the exact transport subpath (/socket/websocket); every
+    # other /socket/* request (bare /socket, typos, /socket/origin-probe
+    # without its own /websocket suffix) falls through to the router same as
+    # /assets and /email. HostRewrite already treats /socket as a first-class
+    # top-level prefix (@api_allowed_prefixes in host_rewrite.ex); the SPA
+    # deny-list needs the same entry for the same reason.
+    match :*, "/socket/*path", SpaController, :not_found
     # /assets isn't a router scope (it's Plug.Static mounted in
     # endpoint.ex), so it's easy to miss here. Plug.Static only intercepts
     # requests for files that exist; a mistyped/missing asset path falls

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -451,10 +451,16 @@ defmodule EngramWeb.Router do
     delete "/mcp", McpController, :unsupported_transport
   end
 
-  # SPA routes — every path here mounts the React app. Whitelisted (not a
-  # blanket /*path catch-all) so unknown URLs hit Phoenix's default 404
-  # instead of silently rendering an HTML 200 over a typo'd API/OAuth/asset
-  # request. Every new top-level SPA route must be added here.
+  # SPA routes, every path here mounts the React app. The static entries
+  # below are whitelisted (not a blanket /*path catch-all) so unknown URLs
+  # hit Phoenix's default 404 instead of silently rendering an HTML 200
+  # over a typo'd API/OAuth/asset request. Every new top-level static SPA
+  # route must be added here.
+  #
+  # Below the whitelist, `/:slug` and `/:slug/:id` are dynamic vault-scoped
+  # routes (vault, and vault+note-or-attachment). Those are wildcards, so a
+  # deny-list for every non-SPA top-level prefix sits between the whitelist
+  # and the wildcards; see its comment for why order matters.
   scope "/", EngramWeb do
     pipe_through :spa
 
@@ -473,6 +479,30 @@ defmodule EngramWeb.Router do
     get "/oauth/consent", SpaController, :index
     # NOTE: no /share/* route: sharing doesn't exist yet (no /api/share*,
     # no schema, no SPA page). Removed 2026-07-02 (#858) after shipping as a
-    # vestigial whitelist entry; re-add alongside the actual feature.
+    # vestigial whitelist entry; re-add alongside the actual feature. (A
+    # bare 2-segment /share/:x now falls through to the vault-scoped
+    # /:slug/:id route below like any other slug; that's expected, not a
+    # revival of this feature.)
+
+    # Deny-list. MUST stay above the dynamic /:slug routes below: those are
+    # 1- and 2-segment wildcards, so without this a typo'd /api/notez would
+    # match /:slug/:id and serve an HTML 200 (the exact regression #858
+    # removed). EVERY new non-SPA top-level prefix must be added here.
+    match :*, "/api/*path", SpaController, :not_found
+    match :*, "/oauth/*path", SpaController, :not_found
+    match :*, "/webhooks/*path", SpaController, :not_found
+    match :*, "/.well-known/*path", SpaController, :not_found
+    # /assets isn't a router scope (it's Plug.Static mounted in
+    # endpoint.ex), so it's easy to miss here. Plug.Static only intercepts
+    # requests for files that exist; a mistyped/missing asset path falls
+    # through to the router and, without this entry, would match
+    # /:slug/:id and serve an HTML 200 for a broken <script src>.
+    match :*, "/assets/*path", SpaController, :not_found
+
+    # Vault-scoped SPA routes. `/:slug` is a vault, `/:slug/:id` a note or
+    # attachment. Kept last so every static route and the deny-list above
+    # wins.
+    get "/:slug", SpaController, :index
+    get "/:slug/:id", SpaController, :index
   end
 end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -519,6 +519,15 @@ defmodule EngramWeb.Router do
     # can get cached remotely, not just seen once by a browser.
     match :*, "/email/*path", SpaController, :not_found
 
+    # The remaining EngramWeb.static_paths/0 entries are single-segment, so they
+    # need exact matches rather than the /prefix/*path shape above. Plug.Static
+    # only serves files that exist; on a miss (broken build, deploy skew) these
+    # would otherwise fall through to get "/:slug" and return an HTML 200.
+    match :*, "/favicon.ico", SpaController, :not_found
+    match :*, "/favicon.svg", SpaController, :not_found
+    match :*, "/engram-mark.svg", SpaController, :not_found
+    match :*, "/robots.txt", SpaController, :not_found
+
     # Vault-scoped SPA routes. `/:slug` is a vault, `/:slug/:id` a note or
     # attachment. Kept last so every static route and the deny-list above
     # wins.

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -498,6 +498,13 @@ defmodule EngramWeb.Router do
     # through to the router and, without this entry, would match
     # /:slug/:id and serve an HTML 200 for a broken <script src>.
     match :*, "/assets/*path", SpaController, :not_found
+    # /email is also Plug.Static-served (see static_paths() in
+    # lib/engram_web.ex), same pass-through-on-miss shape as /assets. These
+    # paths are embedded in outbound email HTML and fetched by third-party
+    # mail proxies (Gmail image proxy, etc.), which may cache a 200 response.
+    # A masked HTML 200 there is worse than the usual case: the bad result
+    # can get cached remotely, not just seen once by a browser.
+    match :*, "/email/*path", SpaController, :not_found
 
     # Vault-scoped SPA routes. `/:slug` is a vault, `/:slug/:id` a note or
     # attachment. Kept last so every static route and the deny-list above

--- a/test/engram/mailer_test.exs
+++ b/test/engram/mailer_test.exs
@@ -205,7 +205,7 @@ defmodule Engram.MailerTest do
         assert subject =~ "vault was deleted"
         assert html =~ "My Vault"
         assert html =~ "June 27, 2026"
-        assert html =~ "https://app.engram.page/settings/vaults?highlight=1"
+        assert html =~ "https://app.engram.page/?highlight=1#settings/vaults"
         refute subject =~ "—", "house style: no em dashes in copy"
         refute html =~ "—", "house style: no em dashes in copy"
         :ok
@@ -216,7 +216,7 @@ defmodule Engram.MailerTest do
                  user,
                  "My Vault",
                  "June 27, 2026",
-                 "https://app.engram.page/settings/vaults?highlight=1"
+                 "https://app.engram.page/?highlight=1#settings/vaults"
                )
     end
 
@@ -234,7 +234,7 @@ defmodule Engram.MailerTest do
                  user,
                  "<script>alert(1)</script>",
                  "June 27, 2026",
-                 "https://app.engram.page/settings/vaults?highlight=1"
+                 "https://app.engram.page/?highlight=1#settings/vaults"
                )
     end
   end

--- a/test/engram/notes/helpers_test.exs
+++ b/test/engram/notes/helpers_test.exs
@@ -130,9 +130,18 @@ defmodule Engram.Notes.HelpersTest do
       assert log =~ "invalid UTF-8"
     end
 
+    # Partial match, not `== ""`: capture_log is node-global, so in an async
+    # module a sibling test's log line lands in this capture and an
+    # emptiness assertion flakes. `log_write_scrub/0` is the only Logger call
+    # in scrub_utf8/2, so refuting its message is the assertion that actually
+    # binds the code under test. (ExUnit.CaptureLog docs prescribe exactly
+    # this: "consider such cases in your assertions, typically by using the
+    # =~/2 operator to perform partial matches".)
     test "stays silent on read/search boundaries (counter-only, avoids log spam)" do
-      assert capture_log(fn -> Helpers.scrub_utf8("x" <> <<0xE2>>, :read) end) == ""
-      assert capture_log(fn -> Helpers.scrub_utf8("x" <> <<0xE2>>, :search) end) == ""
+      refute capture_log(fn -> Helpers.scrub_utf8("x" <> <<0xE2>>, :read) end) =~ "invalid UTF-8"
+
+      refute capture_log(fn -> Helpers.scrub_utf8("x" <> <<0xE2>>, :search) end) =~
+               "invalid UTF-8"
     end
   end
 

--- a/test/engram/vaults/vault_test.exs
+++ b/test/engram/vaults/vault_test.exs
@@ -1,0 +1,40 @@
+defmodule Engram.Vaults.VaultTest do
+  use Engram.DataCase, async: true
+
+  alias Engram.Vaults.Vault
+
+  @valid %{
+    user_id: Ecto.UUID.generate(),
+    name_ciphertext: <<1>>,
+    name_nonce: <<2>>,
+    name_hmac: <<3>>
+  }
+
+  describe "reserved slugs" do
+    test "rejects a slug that would be shadowed by a static SPA route" do
+      for slug <- ~w(settings link oauth onboard note api sign-in) do
+        cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, slug))
+        refute cs.valid?, "expected #{slug} to be rejected"
+        assert "is reserved" in errors_on(cs).slug
+      end
+    end
+
+    test "rejects a slug that Task 7's backend deny-list 404s on" do
+      for slug <- ~w(webhooks assets email socket) do
+        cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, slug))
+        refute cs.valid?, "expected #{slug} to be rejected"
+        assert "is reserved" in errors_on(cs).slug
+      end
+    end
+
+    test "accepts an ordinary slug" do
+      cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, "work"))
+      assert cs.valid?
+    end
+
+    test "rejection is case-insensitive" do
+      cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, "Settings"))
+      refute cs.valid?
+    end
+  end
+end

--- a/test/engram/vaults/vault_test.exs
+++ b/test/engram/vaults/vault_test.exs
@@ -27,6 +27,12 @@ defmodule Engram.Vaults.VaultTest do
       end
     end
 
+    test "rejects a slug that the metrics forward 401s on" do
+      cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, "metrics"))
+      refute cs.valid?
+      assert "is reserved" in errors_on(cs).slug
+    end
+
     test "accepts an ordinary slug" do
       cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, "work"))
       assert cs.valid?
@@ -43,7 +49,7 @@ defmodule Engram.Vaults.VaultTest do
       assert "is reserved" in errors_on(cs).slug
     end
 
-    # Pins the exact 17-entry list. Written as a literal, not derived from
+    # Pins the exact 18-entry list. Written as a literal, not derived from
     # @reserved_slugs, so a deleted entry breaks this test instead of
     # silently passing. Mirrored 1:1 in reserved-slugs.test.ts, a human
     # dropping an entry from either list must edit both and notice.
@@ -51,7 +57,7 @@ defmodule Engram.Vaults.VaultTest do
       assert Vault.reserved_slugs() == ~w(
                sign-in sign-up waitlist link oauth onboard reset-password
                note search billing settings api webhooks .well-known
-               assets email socket
+               assets email socket metrics
              )
     end
   end

--- a/test/engram/vaults/vault_test.exs
+++ b/test/engram/vaults/vault_test.exs
@@ -36,5 +36,23 @@ defmodule Engram.Vaults.VaultTest do
       cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, "Settings"))
       refute cs.valid?
     end
+
+    test "rejection trims whitespace, matching the TS mirror's .trim()" do
+      cs = Vault.changeset(%Vault{}, Map.put(@valid, :slug, "  settings  "))
+      refute cs.valid?
+      assert "is reserved" in errors_on(cs).slug
+    end
+
+    # Pins the exact 17-entry list. Written as a literal, not derived from
+    # @reserved_slugs, so a deleted entry breaks this test instead of
+    # silently passing. Mirrored 1:1 in reserved-slugs.test.ts, a human
+    # dropping an entry from either list must edit both and notice.
+    test "the reserved list is exactly this set" do
+      assert Vault.reserved_slugs() == ~w(
+               sign-in sign-up waitlist link oauth onboard reset-password
+               note search billing settings api webhooks .well-known
+               assets email socket
+             )
+    end
   end
 end

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -115,6 +115,18 @@ defmodule Engram.VaultsTest do
       assert v3.slug == "notes-3"
     end
 
+    test "slug that would collide with a reserved word gets a numeric suffix instead of being rejected",
+         %{
+           user: user
+         } do
+      # Users never type a slug directly (see vault-create-form.tsx) so a plain
+      # rejection here would be a dead end: "Settings" always slugifies to
+      # "settings" and the user has no field to fix. Route reserved words
+      # through the same dedup path as a taken slug.
+      assert {:ok, vault} = Vaults.create_vault(user, %{name: "Settings"})
+      assert vault.slug == "settings-2"
+    end
+
     test "slug strips special characters", %{user: user} do
       assert {:ok, vault} = Vaults.create_vault(user, %{name: "My Vault!"})
       assert vault.slug == "my-vault"
@@ -490,6 +502,15 @@ defmodule Engram.VaultsTest do
 
       assert {:ok, updated} = Vaults.update_vault(user, vault.id, %{name: "Renamed Vault"})
       assert updated.slug == "renamed-vault"
+    end
+
+    test "renaming into a reserved word gets a numeric suffix instead of being rejected", %{
+      user: user
+    } do
+      {:ok, vault} = Vaults.create_vault(user, %{name: "Original"})
+
+      assert {:ok, updated} = Vaults.update_vault(user, vault.id, %{name: "Search"})
+      assert updated.slug == "search-2"
     end
 
     test "setting is_default clears other defaults", %{user: user} do

--- a/test/engram/workers/vault_deleted_email_test.exs
+++ b/test/engram/workers/vault_deleted_email_test.exs
@@ -60,4 +60,24 @@ defmodule Engram.Workers.VaultDeletedEmailTest do
     job = %Oban.Job{args: %{"user_id" => user.id, "vault_id" => Ecto.UUID.generate()}}
     assert :ok = VaultDeletedEmail.perform(job)
   end
+
+  test "manage_url keeps the query ahead of the fragment so location.search can parse it",
+       %{user: user} do
+    {:ok, v} = Vaults.create_vault(user, %{name: "Gone"})
+    {:ok, _} = Vaults.delete_vault(user, v.id)
+
+    expect(Engram.Email.ProviderMock, :send, 1, fn _to, _subject, html, _opts ->
+      # `/#settings/vaults?highlight=<id>` would be WRONG: everything after `#`
+      # is fragment, so the SPA's location.search never sees `highlight`.
+      [manage_url] =
+        Regex.run(~r{href="([^"]*highlight=#{v.id}[^"]*)"}, html, capture: :all_but_first)
+
+      assert manage_url =~ ~r{/\?highlight=#{v.id}#settings/vaults\z}
+      refute manage_url =~ ~r{#.*\?}
+      :ok
+    end)
+
+    job = %Oban.Job{args: %{"user_id" => user.id, "vault_id" => v.id}}
+    assert :ok = VaultDeletedEmail.perform(job)
+  end
 end

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -926,10 +926,22 @@ defmodule EngramWeb.CrdtChannelTest do
       update_b64 = Base.encode64(<<0, 2, 0>>)
       absent = Ecto.UUID.generate()
 
-      # 4 handshake frames — double the edit override of 2 — all must pass.
-      for b64 <- [step1_b64, step1_b64, step2_b64, step2_b64] do
+      # 4 handshake frames — double the edit override of 2 — all must pass the
+      # limiter. Asserted positively (each frame reaches its post-limiter
+      # outcome) rather than refuting "rate_limited": a refute with a timeout
+      # also passes when the channel is starved and never replies, so it could
+      # not tell "not rate limited" from "not run". The two reasons differ
+      # because only step1 carries a state vector: <<0, 0, 0>> unwraps to an
+      # EMPTY vector, which safe_wire_frame?/1 fails closed on, while step2
+      # takes the always-allowed non-step1 path and reaches the absent doc_id.
+      for {b64, reason} <- [
+            {step1_b64, "implausible_state_vector"},
+            {step1_b64, "implausible_state_vector"},
+            {step2_b64, "note_not_found"},
+            {step2_b64, "note_not_found"}
+          ] do
         ref = push(socket, "crdt_msg", %{"doc_id" => absent, "b64" => b64})
-        refute_reply ref, :error, %{reason: "rate_limited"}, 100
+        assert_reply ref, :error, %{reason: ^reason}, 3000
       end
 
       # The edit budget (2) is UNTOUCHED by those handshakes: two updates pass,
@@ -1024,8 +1036,13 @@ defmodule EngramWeb.CrdtChannelTest do
 
       Sandbox.allow(Repo, self(), sock_a.channel_pid)
 
-      push(sock_a, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
-      push(sock_a, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
+      # Await each reply (see the user-scoped test below for why): the two
+      # allowed frames are asserted ALLOWED, and each frame gets its own
+      # timeout instead of all three sharing one 3s window.
+      ref_a1 = push(sock_a, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
+      assert_reply ref_a1, :error, %{reason: "note_not_found"}, 3000
+      ref_a2 = push(sock_a, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
+      assert_reply ref_a2, :error, %{reason: "note_not_found"}, 3000
       ref_a = push(sock_a, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
       assert_reply ref_a, :error, %{reason: "rate_limited"}, 3000
 
@@ -1038,8 +1055,12 @@ defmodule EngramWeb.CrdtChannelTest do
 
       Sandbox.allow(Repo, self(), sock_b.channel_pid)
 
+      # Positive assertion, not a refute: device B's frame must be seen to be
+      # ALLOWED (it passes check_rate and reaches ensure_room, which answers
+      # note_not_found for the absent doc_id). A refute with a timeout passes
+      # vacuously when the channel is starved and replies nothing at all.
       ref_b = push(sock_b, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
-      refute_reply ref_b, :error, %{reason: "rate_limited"}, 300
+      assert_reply ref_b, :error, %{reason: "note_not_found"}, 3000
     end
 
     @tag capture_log: true
@@ -1064,18 +1085,30 @@ defmodule EngramWeb.CrdtChannelTest do
 
       Sandbox.allow(Repo, self(), atk_sock.channel_pid)
 
-      # Attacker exhausts its OWN (user-scoped) bucket (override = 2).
-      push(atk_sock, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
-      push(atk_sock, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
+      # Attacker exhausts its OWN (user-scoped) bucket (override = 2). Each
+      # reply is awaited before the next push: the two allowed frames must be
+      # seen to be ALLOWED (they reach ensure_room and come back note_not_found
+      # for the absent doc_id), which the previous fire-and-forget form never
+      # checked — an off-by-one that rejected frame 1 still left frame 3
+      # rate_limited and the test green. Awaiting also gives each frame its own
+      # timeout budget instead of requiring all three inside one 3s window,
+      # where a scheduler-starved channel produced an empty mailbox and a flake.
+      ref1 = push(atk_sock, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
+      assert_reply ref1, :error, %{reason: "note_not_found"}, 3000
+      ref2 = push(atk_sock, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
+      assert_reply ref2, :error, %{reason: "note_not_found"}, 3000
       ref_atk = push(atk_sock, "crdt_msg", %{"doc_id" => absent, "b64" => tiny_b64})
       assert_reply ref_atk, :error, %{reason: "rate_limited"}, 3000
 
       # The victim's bucket is untouched — the server-derived user_id prefix
-      # means the forged device_id landed in the attacker's own tenant. The
-      # victim pushes an absent note_id too (limiter counts it, no room).
+      # means the forged device_id landed in the attacker's own tenant. Assert
+      # the frame was ALLOWED (note_not_found: it passed check_rate and reached
+      # ensure_room) rather than refuting a rate_limited reply: a refute with a
+      # timeout passes vacuously when the channel is starved and never replies
+      # at all, so it could not distinguish "not rate limited" from "not run".
       victim_absent = Ecto.UUID.generate()
       ref_victim = push(socket, "crdt_msg", %{"doc_id" => victim_absent, "b64" => tiny_b64})
-      refute_reply ref_victim, :error, %{reason: "rate_limited"}, 300
+      assert_reply ref_victim, :error, %{reason: "note_not_found"}, 3000
     end
   end
 

--- a/test/engram_web/controllers/connections_controller_test.exs
+++ b/test/engram_web/controllers/connections_controller_test.exs
@@ -309,7 +309,7 @@ defmodule EngramWeb.ConnectionsControllerTest do
 
       body = json_response(conn, 402)
       assert body["error"] == "pat_disabled_on_free"
-      assert body["upgrade_url"] == "/settings/billing"
+      assert body["upgrade_url"] == "/#settings/billing"
     end
 
     test "201 on paid tier, returns raw key once", %{conn: conn} do

--- a/test/engram_web/controllers/notes_controller_test.exs
+++ b/test/engram_web/controllers/notes_controller_test.exs
@@ -602,7 +602,7 @@ defmodule EngramWeb.NotesControllerTest do
       assert body["limit_key"] == "notes_cap"
       assert body["limit"] == 10_000
       assert body["current"] == 10_000
-      assert body["upgrade_url"] =~ "/settings/billing"
+      assert body["upgrade_url"] =~ "/#settings/billing"
     end
   end
 

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -22,13 +22,18 @@ defmodule EngramWeb.SpaControllerTest do
     assert response(conn, 200) =~ "<!DOCTYPE html>"
   end
 
-  test "GET /share/* is gone: no share feature exists behind it (#858)", %{conn: conn} do
-    # The whitelist entry was vestigial: no /api/share* endpoints, no share
-    # schema, no SPA route. Advertising the path without the feature ships
-    # ambiguous intent; re-add the route when sharing is actually designed.
-    # Nested path asserted too so a future narrower route (e.g. /share/:id)
-    # can't silently change deep-link behavior without touching this test.
-    assert conn |> get("/share/abc123") |> response(404)
+  test "GET /share/abc123 now serves the SPA as a vault-scoped route", %{conn: conn} do
+    # Was a dedicated 404 test pre-Task-7: the whitelist had no /share entry
+    # and there was no catch-all, so it 404'd. Task 7 adds /:slug/:id as a
+    # generic 2-segment dynamic route for ANY slug, so /share/abc123 is now
+    # indistinguishable from /my-vault/<id> at the router level ("share" is
+    # just a slug value). No share feature was revived; the frontend/vault
+    # lookup decides what "share" resolves to. Deeper (3+ segment) paths
+    # still have no matching route and 404, asserted below.
+    assert conn |> get("/share/abc123") |> response(200)
+  end
+
+  test "GET /share/abc123/folder/note still 404s (no 3-segment SPA route)", %{conn: conn} do
     assert conn |> get("/share/abc123/folder/note") |> response(404)
   end
 
@@ -154,6 +159,54 @@ defmodule EngramWeb.SpaControllerTest do
       conn = get(conn, "/assets/this-file-does-not-exist.js")
       assert conn.status == 404
       refute response(conn, 404) =~ "<div id=\"root\">"
+    end
+  end
+
+  describe "vault-scoped SPA routes" do
+    test "serves the SPA for a bare vault slug", %{conn: conn} do
+      conn = get(conn, "/my-vault")
+      assert html_response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
+    end
+
+    test "serves the SPA for a vault-scoped note", %{conn: conn} do
+      conn = get(conn, "/my-vault/018f2b3c-0000-7000-8000-000000000000")
+      assert html_response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
+    end
+  end
+
+  describe "non-SPA prefixes must not fall through to /:slug (#858)" do
+    # Regression guard: without the deny-list these two-segment typos match
+    # `get "/:slug/:id"` and return an HTML 200, masking a broken API call.
+    test "a typo'd API path 404s instead of serving HTML", %{conn: conn} do
+      conn = get(conn, "/api/notez")
+      assert response(conn, 404)
+      [content_type] = get_resp_header(conn, "content-type")
+      refute content_type =~ "text/html"
+    end
+
+    test "a typo'd webhooks path 404s", %{conn: conn} do
+      assert conn |> get("/webhooks/bogus") |> response(404)
+    end
+
+    test "a typo'd well-known path 404s", %{conn: conn} do
+      assert conn |> get("/.well-known/bogus") |> response(404)
+    end
+
+    test "a typo'd oauth path 404s", %{conn: conn} do
+      assert conn |> get("/oauth/bogus") |> response(404)
+    end
+
+    test "a missing asset path 404s (fifth prefix: /assets is Plug.Static, not a router scope)",
+         %{conn: conn} do
+      # Plug.Static only intercepts requests for files that exist; a
+      # mistyped/missing asset path falls through to the router and needs
+      # its own deny-list entry or it would match /:slug/:id.
+      assert conn |> get("/assets/bogus.js") |> response(404)
+    end
+
+    test "but /oauth/consent still serves the SPA", %{conn: conn} do
+      conn = get(conn, "/oauth/consent")
+      assert html_response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
     end
   end
 end

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -204,6 +204,18 @@ defmodule EngramWeb.SpaControllerTest do
       assert conn |> get("/assets/bogus.js") |> response(404)
     end
 
+    test "a missing email asset path 404s and is not HTML (sixth prefix: /email)",
+         %{conn: conn} do
+      # /email is also Plug.Static-served via static_paths() (lib/engram_web.ex)
+      # and referenced from outbound email HTML. A masked HTML 200 there can
+      # get cached by a third-party mail proxy, so this asserts content-type
+      # too, not just status.
+      conn = get(conn, "/email/missing.png")
+      assert response(conn, 404)
+      [content_type] = get_resp_header(conn, "content-type")
+      refute content_type =~ "text/html"
+    end
+
     test "but /oauth/consent still serves the SPA", %{conn: conn} do
       conn = get(conn, "/oauth/consent")
       assert html_response(conn, 200) =~ "window.__ENGRAM_CONFIG__="

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -243,6 +243,75 @@ defmodule EngramWeb.SpaControllerTest do
     end
   end
 
+  describe "single-segment static_paths() get exact deny entries too" do
+    # EngramWeb.static_paths/0 lists favicon.ico, favicon.svg, engram-mark.svg,
+    # robots.txt (and email, covered above). These are single-segment, so they
+    # need an exact match rather than the /prefix/*path shape used elsewhere in
+    # the deny-list. All four real files exist on disk in this test env
+    # (priv/static/), so Plug.Static (mounted ahead of the router in the
+    # endpoint) always wins for these requests. The tests below prove that's
+    # still true after adding the router-level entries.
+    test "GET /favicon.ico still serves the real file, not the SPA", %{conn: conn} do
+      conn = get(conn, "/favicon.ico")
+      assert conn.status == 200
+      [content_type] = get_resp_header(conn, "content-type")
+      refute content_type =~ "text/html"
+      refute response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
+    end
+
+    test "GET /favicon.svg still serves the real file, not the SPA", %{conn: conn} do
+      conn = get(conn, "/favicon.svg")
+      assert conn.status == 200
+      [content_type] = get_resp_header(conn, "content-type")
+      refute content_type =~ "text/html"
+      refute response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
+    end
+
+    test "GET /engram-mark.svg still serves the real file, not the SPA", %{conn: conn} do
+      conn = get(conn, "/engram-mark.svg")
+      assert conn.status == 200
+      [content_type] = get_resp_header(conn, "content-type")
+      refute content_type =~ "text/html"
+      refute response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
+    end
+
+    test "GET /robots.txt still serves the real file, not the SPA", %{conn: conn} do
+      conn = get(conn, "/robots.txt")
+      assert conn.status == 200
+      [content_type] = get_resp_header(conn, "content-type")
+      refute content_type =~ "text/html"
+      refute response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
+    end
+
+    test "a bogus sibling single-segment path still reaches the SPA", %{conn: conn} do
+      # /nonexistent.txt isn't a real static file and isn't in the deny-list,
+      # so it must still fall through to the vault-scoped /:slug route like
+      # any other unrecognized single segment. Proves the new exact entries
+      # above are scoped to their four literal paths, not a blanket sweep.
+      conn = get(conn, "/nonexistent.txt")
+      assert html_response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
+    end
+
+    test "on a Plug.Static miss (deploy skew), the router-level entries 404 instead of an HTML 200" do
+      # Plug.Static always wins while the real file exists (proven above), so
+      # the only way to exercise the router-level deny entries themselves is
+      # to bypass the endpoint's Plug.Static plug and hit the router
+      # directly, simulating the deploy-skew scenario (file missing from
+      # priv/static) without deleting a real file on disk.
+      for path <- ~w(/favicon.ico /favicon.svg /engram-mark.svg /robots.txt) do
+        conn =
+          Phoenix.ConnTest.build_conn(:get, path)
+          |> EngramWeb.Router.call(EngramWeb.Router.init([]))
+
+        assert conn.status == 404, "expected #{path} to 404 at the router level"
+        [content_type] = get_resp_header(conn, "content-type")
+
+        refute content_type =~ "text/html",
+               "expected #{path} not to serve HTML at the router level"
+      end
+    end
+  end
+
   defp assert_not_found_not_html(conn) do
     assert response(conn, 404)
     [content_type] = get_resp_header(conn, "content-type")

--- a/test/engram_web/controllers/spa_controller_test.exs
+++ b/test/engram_web/controllers/spa_controller_test.exs
@@ -177,23 +177,24 @@ defmodule EngramWeb.SpaControllerTest do
   describe "non-SPA prefixes must not fall through to /:slug (#858)" do
     # Regression guard: without the deny-list these two-segment typos match
     # `get "/:slug/:id"` and return an HTML 200, masking a broken API call.
+    # Every case asserts BOTH status and content-type: a status-only check
+    # would not catch a regression where not_found/2 started returning
+    # text/html with a 404 status, which is exactly the "masked as success"
+    # failure mode this guard exists to prevent.
     test "a typo'd API path 404s instead of serving HTML", %{conn: conn} do
-      conn = get(conn, "/api/notez")
-      assert response(conn, 404)
-      [content_type] = get_resp_header(conn, "content-type")
-      refute content_type =~ "text/html"
+      conn |> get("/api/notez") |> assert_not_found_not_html()
     end
 
     test "a typo'd webhooks path 404s", %{conn: conn} do
-      assert conn |> get("/webhooks/bogus") |> response(404)
+      conn |> get("/webhooks/bogus") |> assert_not_found_not_html()
     end
 
     test "a typo'd well-known path 404s", %{conn: conn} do
-      assert conn |> get("/.well-known/bogus") |> response(404)
+      conn |> get("/.well-known/bogus") |> assert_not_found_not_html()
     end
 
     test "a typo'd oauth path 404s", %{conn: conn} do
-      assert conn |> get("/oauth/bogus") |> response(404)
+      conn |> get("/oauth/bogus") |> assert_not_found_not_html()
     end
 
     test "a missing asset path 404s (fifth prefix: /assets is Plug.Static, not a router scope)",
@@ -201,24 +202,51 @@ defmodule EngramWeb.SpaControllerTest do
       # Plug.Static only intercepts requests for files that exist; a
       # mistyped/missing asset path falls through to the router and needs
       # its own deny-list entry or it would match /:slug/:id.
-      assert conn |> get("/assets/bogus.js") |> response(404)
+      conn |> get("/assets/bogus.js") |> assert_not_found_not_html()
     end
 
     test "a missing email asset path 404s and is not HTML (sixth prefix: /email)",
          %{conn: conn} do
       # /email is also Plug.Static-served via static_paths() (lib/engram_web.ex)
       # and referenced from outbound email HTML. A masked HTML 200 there can
-      # get cached by a third-party mail proxy, so this asserts content-type
-      # too, not just status.
-      conn = get(conn, "/email/missing.png")
-      assert response(conn, 404)
-      [content_type] = get_resp_header(conn, "content-type")
-      refute content_type =~ "text/html"
+      # get cached by a third-party mail proxy, so content-type matters even
+      # more here than for /assets.
+      conn |> get("/email/missing.png") |> assert_not_found_not_html()
+    end
+
+    test "a bare /socket path 404s (seventh prefix: socket dispatch only claims /socket/websocket)",
+         %{conn: conn} do
+      conn |> get("/socket") |> assert_not_found_not_html()
+    end
+
+    test "a typo'd /socket path 404s", %{conn: conn} do
+      conn |> get("/socket/bogus") |> assert_not_found_not_html()
     end
 
     test "but /oauth/consent still serves the SPA", %{conn: conn} do
       conn = get(conn, "/oauth/consent")
       assert html_response(conn, 200) =~ "window.__ENGRAM_CONFIG__="
     end
+
+    test "/socket/websocket still reaches the transport, unaffected by the deny-list", %{
+      conn: conn
+    } do
+      # socket_dispatch (from the `socket "/socket", EngramWeb.UserSocket`
+      # macro in endpoint.ex) claims this exact path BEFORE the router runs,
+      # so the new /socket/*path deny entry below it must never see this
+      # request. A plain GET with no Upgrade/Origin header hits the
+      # transport's own origin check and 403s, same as before this deny
+      # entry existed, proving the router-level deny-list never got a
+      # chance to intercept it.
+      conn = get(conn, "/socket/websocket")
+      assert conn.status == 403
+    end
+  end
+
+  defp assert_not_found_not_html(conn) do
+    assert response(conn, 404)
+    [content_type] = get_resp_header(conn, "content-type")
+    refute content_type =~ "text/html"
+    conn
   end
 end

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -368,7 +368,7 @@ defmodule EngramWeb.VaultsControllerTest do
       assert body["limit_key"] == "vaults_cap"
       assert body["limit"] == 1
       assert body["current"] == 1
-      assert body["upgrade_url"] =~ "/settings/billing"
+      assert body["upgrade_url"] =~ "/#settings/billing"
     end
   end
 end

--- a/test/engram_web/limit_response_test.exs
+++ b/test/engram_web/limit_response_test.exs
@@ -19,7 +19,7 @@ defmodule EngramWeb.LimitResponseTest do
                "limit_key" => "notes_cap",
                "limit" => 10_000,
                "current" => 10_000,
-               "upgrade_url" => "https://app.engram.page/settings/billing"
+               "upgrade_url" => "https://app.engram.page/#settings/billing"
              }
     end
 
@@ -44,7 +44,7 @@ defmodule EngramWeb.LimitResponseTest do
       Application.put_env(:engram, :upgrade_url, nil)
 
       on_exit(fn ->
-        Application.put_env(:engram, :upgrade_url, "https://app.engram.page/settings/billing")
+        Application.put_env(:engram, :upgrade_url, "https://app.engram.page/#settings/billing")
       end)
 
       user = insert(:user, free_tier_accepted_at: DateTime.utc_now())

--- a/test/engram_web/plugs/enforce_connection_cap_test.exs
+++ b/test/engram_web/plugs/enforce_connection_cap_test.exs
@@ -50,7 +50,7 @@ defmodule EngramWeb.Plugs.EnforceConnectionCapTest do
       assert body["limit_key"] == "obsidian_connections_cap"
       assert body["current"] == 1
       assert body["limit"] == 1
-      assert body["upgrade_url"] == "https://app.engram.page/settings/billing"
+      assert body["upgrade_url"] == "https://app.engram.page/#settings/billing"
       assert body["tier"] == "free"
     end
 

--- a/test/engram_web/plugs/enforce_device_cap_test.exs
+++ b/test/engram_web/plugs/enforce_device_cap_test.exs
@@ -16,7 +16,7 @@ defmodule EngramWeb.Plugs.EnforceDeviceCapTest do
   # Pin upgrade_url for assertions; default is nil in test env.
   setup do
     prev = Application.get_env(:engram, :upgrade_url)
-    Application.put_env(:engram, :upgrade_url, "https://app.engram.page/settings/billing")
+    Application.put_env(:engram, :upgrade_url, "https://app.engram.page/#settings/billing")
     on_exit(fn -> Application.put_env(:engram, :upgrade_url, prev) end)
     :ok
   end
@@ -93,7 +93,7 @@ defmodule EngramWeb.Plugs.EnforceDeviceCapTest do
       assert body["limit_key"] == "concurrent_devices"
       assert body["limit"] == 1
       assert body["current"] == 1
-      assert body["upgrade_url"] == "https://app.engram.page/settings/billing"
+      assert body["upgrade_url"] == "https://app.engram.page/#settings/billing"
     end
 
     test "halts 402 with device_swap_cooldown when at cap and a recent revoke is within the window" do
@@ -135,7 +135,7 @@ defmodule EngramWeb.Plugs.EnforceDeviceCapTest do
       assert body["limit"] == 24
       # Should be roughly 22 hours remaining (allow tiny clock skew).
       assert body["current"] in [22, 23]
-      assert body["upgrade_url"] == "https://app.engram.page/settings/billing"
+      assert body["upgrade_url"] == "https://app.engram.page/#settings/billing"
     end
 
     test "halts 402 with concurrent_devices_exceeded when recent revoke is past the cooldown window" do

--- a/test/engram_web/plugs/enforce_pat_creation_test.exs
+++ b/test/engram_web/plugs/enforce_pat_creation_test.exs
@@ -20,7 +20,7 @@ defmodule EngramWeb.Plugs.EnforcePatCreationTest do
       assert conn.status == 402
       body = Phoenix.ConnTest.json_response(conn, 402)
       assert body["error"] == "pat_disabled_on_free"
-      assert body["upgrade_url"] == "/settings/billing"
+      assert body["upgrade_url"] == "/#settings/billing"
     end
 
     test "passes through when api_write_enabled is true (override grant)", %{conn: conn} do

--- a/test/engram_web/plugs/host_rewrite_test.exs
+++ b/test/engram_web/plugs/host_rewrite_test.exs
@@ -313,7 +313,14 @@ defmodule EngramWeb.Plugs.HostRewriteTest do
         EngramWeb.Router.__routes__()
         |> Enum.filter(&String.starts_with?(&1.path, "/api/"))
         |> Enum.map(&(&1.path |> String.split("/", trim: true) |> Enum.at(1)))
-        |> Enum.reject(&is_nil/1)
+        # Task 7's SPA-scope deny-list registers `/api/*path` as a literal
+        # catch-all fallback (matched only when nothing in the real /api
+        # scopes above it matched) so typo'd API paths 404 instead of
+        # falling through to the vault-scoped /:slug SPA route (#858). It
+        # isn't a named resource segment, so it has nothing to add to
+        # @api_top_segments: HostRewrite already passes any already-/api
+        # path through unmodified before this route is ever reached.
+        |> Enum.reject(&(is_nil(&1) or String.starts_with?(&1, "*")))
         |> MapSet.new()
 
       plug_segments = MapSet.new(HostRewrite.__api_top_segments__())

--- a/test/engram_web/plugs/require_active_subscription_test.exs
+++ b/test/engram_web/plugs/require_active_subscription_test.exs
@@ -8,7 +8,7 @@ defmodule EngramWeb.Plugs.RequireActiveSubscriptionTest do
 
   setup do
     prev = Application.get_env(:engram, :upgrade_url)
-    Application.put_env(:engram, :upgrade_url, "https://app.engram.page/settings/billing")
+    Application.put_env(:engram, :upgrade_url, "https://app.engram.page/#settings/billing")
     on_exit(fn -> Application.put_env(:engram, :upgrade_url, prev) end)
     :ok
   end
@@ -59,7 +59,7 @@ defmodule EngramWeb.Plugs.RequireActiveSubscriptionTest do
       assert body["error"] == "limit_exceeded"
       assert body["reason"] == "account_suspended"
       assert body["tier"] == "free"
-      assert body["upgrade_url"] =~ "/settings/billing"
+      assert body["upgrade_url"] =~ "/#settings/billing"
     end
   end
 end

--- a/test/engram_web/plugs/require_api_write_enabled_test.exs
+++ b/test/engram_web/plugs/require_api_write_enabled_test.exs
@@ -61,7 +61,7 @@ defmodule EngramWeb.Plugs.RequireApiWriteEnabledTest do
       assert conn.status == 402
       body = Phoenix.ConnTest.json_response(conn, 402)
       assert body["error"] == "api_write_not_available"
-      assert body["upgrade_url"] == "/settings/billing"
+      assert body["upgrade_url"] == "/#settings/billing"
     end
 
     test "halts 402 on DELETE /api/notes/foo", %{conn: conn, user: user, api_key: api_key} do


### PR DESCRIPTION
## Summary

- **URLs are now vault-scoped.** Notes and attachments live at `/:slug/:itemId`, with the URL as the source of truth for the active vault — navigating to another vault's slug switches vaults, rather than the switcher owning that state. Unknown slugs render a 404 page.
- **Settings became a hash overlay.** `#settings/<section>` layers a dialog over whatever route you're on instead of replacing it, so the underlying view (and its query string) survives. Legacy `/settings/*` paths redirect.
- **Reserved slugs + a Phoenix deny-list** keep the new `/:slug` catch-all from swallowing real routes. `Vaults.unique_slug/3` folds reserved words into the same dedup path as taken slugs, so a vault named "api" gets `api-2` rather than an unreachable URL.

Also bundles a test-only commit fixing two pre-existing flakes found while getting this branch green (see the last commit message for the full root-cause writeup). Both were defective tests, not product bugs, and both fixes make the assertions *stronger* — an A/B with a deliberately broken rate-limit bucket shows the old form passing and the new form failing.

## Test plan

- [x] Backend `mix test` — 3795 tests, 0 failures
- [x] Frontend — 1120 tests / 166 files passing
- [x] `mix format`, `credo --strict` (3963 mods/funs, no issues), `tsc --noEmit`, `biome ci` (476 files), production build
- [x] Rebased onto main (picks up #1142); conflicts in `rail.tsx` and `note-page.test.tsx` resolved
- [x] Live route probe against a self-hosted dev stack:
  - `/`, `/:slug`, `/:slug/:itemId` → 200 SPA
  - `/api/health`, `/favicon.ico`, `/robots.txt` → 200 (not swallowed by the catch-all)
  - `/assets/does-not-exist.js` → **404** (deny-list holds; without it a missing asset would return HTML with a 200 and fail silently)
- [x] **Manual browser smoke — done** (real Chrome, local-auth stack, two vaults `alpha` + `api-2`): deep-link `/:slug` and `/:slug/:itemId`; vault switch driven by URL; settings overlay preserves `?query` on open **and** close; close strips only the hash and stays on the note; back reopens / forward closes across the hash; unknown slug → 404; `/settings/api-keys?highlight=abc` → `/api-2?highlight=abc#settings/connections` (alias + query + current-vault slug all correct)
- [x] **Reserved-slug folding verified live** — a vault named "api" received slug `api-2`, so `/api/*` stays reachable
- [x] **E2E suite ran and passed.** `test_71_connections.py` (including the three `upgrade_url` assertions) executed green in `e2e-clerk`

**Found by the browser smoke, fixed here:** a bare `"/api"` Vite proxy key is a *prefix* match, so the dev server also proxied vault slugs like `/api-2` to Phoenix, which answered with its prebuilt `index.html` whose hashed asset URLs 404 on the dev server — the SPA then hung forever on an unstyled "Loading…". Both `/api` and `/socket` are now anchored RegExps. Dev-only (prod serves index + matching assets together), but this PR is what turns slugs into top-level paths, so the collision was newly reachable. Note `/api-2` returned **200** throughout — the status was never wrong, only the document, which is why the status-code route probe above could not see it.

### Reviewer notes

- ~~`ENGRAM_UPGRADE_URL` in engram-infra may still carry the old `/settings/billing` path~~ — **checked, no action needed.** `ENGRAM_UPGRADE_URL` is not set anywhere in engram-infra (no Terraform, tfvars, or SOPS `secrets/` entry — SOPS keeps keys in plaintext, so it would be visible). The app-side default in `config/runtime.exs` is authoritative and now uses `/#settings/billing`.
- Two plug tests (`enforce_device_cap_test`, `require_active_subscription_test`) still pinned the pre-hash `upgrade_url`; they set the env themselves so they passed either way, but they encoded the old convention. Now on the hash form.
- The `settingsTo(section, search)` helper exists because `resolvePath` inherits `pathname` but **not** `search` — opening settings via a bare hash dropped the query string and killed in-flight OAuth consent. Applied at 17 call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ekpc5LX9FKiBiu6ZiUXsqb
