### PR TITLE
fix(oauth): attribute every MCP connector, not just vendor-hosted ones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,7 @@ Grouped index into `docs/context/`. Each entry is a trigger → doc; read the do
 **Architecture & Decisions**
 - Elixir decision audit, library deps, infra checklist (partially superseded — read inline corrections) → `docs/context/elixir-architecture-decisions.md`
 - Full SQL schema, RLS policies, Ecto enforcement → `docs/context/database-schema-rls.md`
+- Widening a column type without rewriting the table (`varchar[]` → `text[]` DOES rewrite; how to measure with relfilenode; when `# squawk-ignore-file` is justified) → `docs/context/migration-column-type-rewrites.md`
 - All env vars by category → `docs/context/environment-variables.md`
 - Rate limiter & cap architecture — Postgres + BEAM only, zero Redis → `docs/context/rate-limiter-architecture.md`
 - Cross-workspace SaaS pricing model → `../engram-workspace/docs/context/pricing-strategy.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,7 +362,7 @@ Grouped index into `docs/context/`. Each entry is a trigger → doc; read the do
 - OAuth 2.1 + DCR on `/api/mcp` — wire flow, endpoints, token model, scopes → `docs/context/mcp-oauth.md`
 - MCP vault selection design — stateless `set_vault`, fate of the default vault → `docs/context/mcp-vault-selection.md`
 - Refresh-token rotation — leeway/overlap window, token-family reuse detection → `docs/context/refresh-token-reuse-detection.md`
-- How `/settings/connections` identifies an OAuth/MCP client → `docs/context/connections-client-identity.md`
+- How `/settings/connections` + the onboarding checklist identify an OAuth/MCP client (slug attribution, the three hosting classes, HTTPS trust model) → `docs/context/connections-client-identity.md`
 - Onboarding demo vault poisons `activeVaultId` → prod 404 storm (fixed) → `docs/context/demo-vault-activevaultid-poisoning.md`
 
 **Frontend / SPA**

--- a/docs/context/connections-client-identity.md
+++ b/docs/context/connections-client-identity.md
@@ -17,11 +17,21 @@ So `lookup(nil)` never matched → generic `<Plug>` icon, "unverified" badge, no
 
 Identity resolves in `lib/engram/connections/logo_allowlist.ex`:
 
-| Source | Grants | Why |
-|---|---|---|
-| `software_id` allowlist | `verified` + logo + slug | Explicit, but nearly nothing sends one |
-| `redirect_uri` **host** allowlist | `verified` + logo + slug | A vendor-owned HTTPS host is un-spoofable for grant delivery |
-| `client_name`, normalized | **slug only** | Self-asserted, so it may never grant `verified` or a logo |
+Identity resolves **proven before claimed**, and `verified` is decided
+separately from identity by the host alone:
+
+| Precedence | Source | Grants | Why |
+|---|---|---|---|
+| 1 | `redirect_uri` **host** allowlist | identity + the only thing that sets `verified` | A vendor-owned HTTPS host is un-spoofable for grant delivery |
+| 2 | `software_id` allowlist | identity only | Self-asserted DCR body field; explicit, but nearly nothing sends one |
+| 3 | `client_name`, normalized | **slug only** | Self-asserted, so it may never grant `verified` or a logo |
+
+> **The host outranks `software_id` (reversed during review, 2026-07-30).** It
+> used to be the other way round, which meant a client registering
+> `software_id: "openai-chatgpt"` while redirecting to `claude.ai` was listed as
+> **ChatGPT** and carried a verified badge earned by Anthropic's host. If a
+> grant is delivered to a vendor, that vendor is who the user is connected to;
+> what the client *claims* cannot outrank it.
 
 `slug` then flows `Connections.list_for_user/1` → `ConnectionsController.serialize/1` → `/api/connections` → React (`connectedSlugs.has(slug)` ticks the checklist row; `ToolMark slug={...}` renders the brand mark).
 
@@ -38,9 +48,9 @@ Classes 2 and 3 are the majority of the catalog. **Any design keying attribution
 ## Trust model (security-relevant, do not weaken)
 
 **Identity and verification are computed independently.** Identity (logo /
-display_name / slug) comes from the first match of `software_id` → host → name.
-`verified: true` is granted by **one thing only**: a vendor-owned **HTTPS**
-redirect host, no userinfo, case-folded.
+display_name / slug) comes from the first match of host → `software_id` → name,
+**proven before claimed**. `verified: true` is granted by **one thing only**: a
+vendor-owned **HTTPS** redirect host, no userinfo, case-folded.
 
 > **Tightened 2026-07-30.** `software_id` used to grant `verified: true`. It is
 > an RFC 7591 field the client sends *about itself* in the DCR body, exactly as
@@ -49,13 +59,23 @@ redirect host, no userinfo, case-folded.
 > list as a verified Claude Desktop, logo and all. Not an authorization-time
 > phishing vector (the consent screen shows only `client_id` + `client_name`),
 > but it made a rogue grant look trustworthy enough not to revoke. It now
-> supplies identity only. Device-flow rows are unaffected, `device_rows/1`
+> supplies identity only, and only when no vendor host outranks it.
+>
+> **Be precise about the residue.** That client still gets Claude's logo and
+> display name; it just loses the badge. Withholding the icon too means deleting
+> the `@software_id` map, which still carries our own `engram-vault-sync`
+> plugin. Four of its five entries are unvalidated guesses, and deleting them
+> once prod confirms nothing sends them is the real fix. `verified` is the
+> boundary that actually holds.
+>
+> Device-flow rows are unaffected, `device_rows/1`
 > hardcodes `verified: true`, which is legitimate because our own server mints
 > the `family_id`; no client-supplied metadata is involved.
 
 - **Why HTTPS host is un-spoofable:** a forged DCR client can *claim* `redirect_uri=https://claude.ai/...`, but the auth code is then delivered to claude.ai, not to the attacker. The vendor controls the callback handler.
 - **Why custom schemes / http are NOT:** `com.evil.app://claude.ai/cb` and `http://claude.ai/...` both parse to host `claude.ai` but deliver the code to an attacker-controlled handler. `lookup_by_host/1` enforces `%URI{scheme: "https", userinfo: nil}`. (Code review caught this; the naive host-only match was exploitable.)
 - **`client_name` grants `slug` and nothing else.** It is self-asserted and trivially spoofable, but ticking a row in your *own* checklist is not a security boundary. The logo and the verified badge, where spoofing actually matters, stay host/`software_id` gated. `logo_allowlist_test.exs` pins this explicitly.
+- **A proven host outranks a claimed `software_id`** (reversed during review, 2026-07-30). Previously `software_id` won, so a client claiming `openai-chatgpt` while redirecting to `claude.ai` was listed as ChatGPT *and* verified via Anthropic's host. Whoever receives the code is who the user is connected to.
 
 > **Correction (2026-07-30).** This doc previously said custom schemes and localhost were *"identify-only: they may set icon/name but never grant verified."* That was the intended design; the code never implemented it, `lookup_by_host/1` returned the empty placeholder, so loopback clients got **no slug at all** and their checklist row could never tick. The doc/code mismatch is why the gap survived six weeks. Slug attribution for those clients now comes from `client_name`.
 
@@ -134,6 +154,50 @@ permanently unverifiable.
 > where you pre-register URLs with a provider. Under DCR the desktop client
 > sends `cursor://anysphere.cursor-mcp/oauth/callback`. Third case today where
 > vendor docs disagreed with an observed registration; trust the row.
+
+## Loopback clients get a port exemption at authorize (RFC 8252 §7.3)
+
+Registration is only half the path. A client that registers fine can still be
+turned away at `/oauth/authorize`, and local-first clients were:
+
+> RFC 8252 §7.3: "the authorization server **MUST** allow any port to be
+> specified at the time of the request for loopback IP redirect URIs, to
+> accommodate clients that obtain an available ephemeral port from the operating
+> system at the time of the request."
+
+`match_redirect_uri/2` did an exact `uri in client.redirect_uris`. That is
+correct for every other class, and it is the first check still. But a DCR client
+**registers once and persists its `client_id`**, then asks the OS for a fresh
+ephemeral port on every launch. So the flow is: first run registers
+`http://127.0.0.1:1456/...` and works, second run comes back on port 49152 and
+gets `invalid_redirect_uri`.
+
+This is why the observed ports look arbitrary (62184, 1456, 19876). **Never
+treat an observed loopback port as stable, and never hardcode one.** The port is
+the one component of a loopback redirect guaranteed to change.
+
+The exemption is scoped hard:
+
+| Component | Loopback `http` | Everything else |
+|---|---|---|
+| scheme | must be `http` | exact |
+| host | exact (`localhost` ≠ `127.0.0.1`) | exact |
+| **port** | **ignored** | exact |
+| path, query | exact | exact |
+
+It does **not** extend to `https`. Relaxing the port on `https://claude.ai`
+would let anyone who controls any port on a registered host collect auth codes.
+On loopback that argument does not hold the same way, since reaching the port
+means already being on the user's machine, and PKCE still binds the code to the
+request that started it.
+
+`Engram.OAuth.Client.loopback_host?/1` is the single definition of "loopback",
+shared by registration and authorization. If those two lists ever drifted apart,
+a URI would be accepted at DCR and rejected on every authorize.
+
+The token endpoint keeps exact matching (`check_code_redirect_uri/2`), and
+should: it compares against the URI actually used at authorize, which was stored
+on the code row, not against the registration.
 
 ## Slug derivation is algorithmic, not a vendor map
 
@@ -217,7 +281,7 @@ Catalog decisions that follow:
 - **No `gemini_cli` slug.** Adding a product Google is retiring would be new dead
   config. If an enterprise Gemini CLI user connects, the tripwire logs it.
 
-## The real fix for local clients: CIMD (not yet implemented)
+## The real fix for local clients: CIMD (not yet implemented, tracked in #1148)
 
 **Client ID Metadata Documents** make the `client_id` an HTTPS URL owned by the
 client vendor; the authorization server fetches it to obtain the client's
@@ -248,6 +312,22 @@ its `client_id` must equal its own URL), cache with refresh, derive the redirect
 allowlist from it, and guard the fetch against SSRF. Once shipped, Claude Code
 grants become genuinely `verified` and the "recognized, self-reported" tier
 below stops applying to them.
+
+**Scoped in #1148** (~2 days, one PR). Three findings from that scoping worth
+having here, because they are the non-obvious parts:
+
+- **DCR does not go away.** Seven of the nine observed connectors do not use
+  CIMD, and self-hosted clients never can (no vendor to publish a document).
+  The two paths are independent and both stay.
+- **Do not widen the `client_id` PK.** It is `:binary_id` and `get_client/1`
+  hard-casts UUID, but `oauth_authorization_codes.client_id` and
+  `oauth_refresh_tokens.client_id` have **no FK constraint** (checked in
+  `structure.sql`; only `user_id`/`vault_id` are constrained). So add a unique
+  `cimd_url` column, keep UUIDs internal, and resolve URL-shaped ids to the row.
+- **Advertising the flag is not reversible in-flight.** Claude Code stops
+  choosing DCR the moment it sees the flag and will *not* fall back if our CIMD
+  path is broken, so connections fail outright rather than degrading. Gate it on
+  config and verify against staging with a real client before flipping.
 
 ## "Why is Claude Code unverified? Am I connected wrong?"
 

--- a/docs/context/connections-client-identity.md
+++ b/docs/context/connections-client-identity.md
@@ -1,6 +1,6 @@
-Title: Connections client identity — why `software_id` failed, redirect-host matching, the HTTPS trust model
+Title: Connections client identity: slug attribution, the three hosting classes, and the HTTPS trust model
 
-_Last verified: 2026-06-15 (discovered fixing Claude identity on `/settings/connections` + onboarding checklist)_
+_Last verified: 2026-07-30 (rewritten fixing connector attribution for loopback + self-hosted clients; originally 2026-06-15)_
 
 How `/settings/connections` cards and the onboarding checklist identify an OAuth/MCP client (logo, display_name, verified badge, checklist auto-check).
 
@@ -13,42 +13,278 @@ How `/settings/connections` cards and the onboarding checklist identify an OAuth
 
 So `lookup(nil)` never matched → generic `<Plug>` icon, "unverified" badge, no Claude mark, no checklist auto-check.
 
-## The fix: `LogoAllowlist.resolve/2`
+## Resolution order: `LogoAllowlist.resolve/3`
 
-Identity now resolves via `LogoAllowlist.resolve(software_id, redirect_uris)` in `lib/engram/connections/logo_allowlist.ex`:
+Identity resolves in `lib/engram/connections/logo_allowlist.ex`:
 
-1. Try the `software_id` allowlist first (preserves our own `engram-vault-sync` plugin).
-2. Fall back to matching the **redirect_uri host** against a vendor-host allowlist (`claude.ai` → Claude).
+| Source | Grants | Why |
+|---|---|---|
+| `software_id` allowlist | `verified` + logo + slug | Explicit, but nearly nothing sends one |
+| `redirect_uri` **host** allowlist | `verified` + logo + slug | A vendor-owned HTTPS host is un-spoofable for grant delivery |
+| `client_name`, normalized | **slug only** | Self-asserted, so it may never grant `verified` or a logo |
 
-A `slug` field now flows: `Connections.list_for_user/1` → `ConnectionsController.serialize/1` → `/api/connections` JSON → React checklist (`connectedSlugs.has(slug)` auto-checks the row).
+`slug` then flows `Connections.list_for_user/1` → `ConnectionsController.serialize/1` → `/api/connections` → React (`connectedSlugs.has(slug)` ticks the checklist row; `ToolMark slug={...}` renders the brand mark).
 
-## Trust model (security-relevant — do not weaken)
+## The three hosting classes
 
-`verified: true` is granted **only** for a vendor-owned **HTTPS** host, no userinfo, case-folded.
+The load-bearing mental model. Connectors differ not by vendor but by **where the OAuth redirect lands**:
 
-- **Why HTTPS host is un-spoofable:** a forged DCR client can *claim* `redirect_uri=https://claude.ai/...`, but the auth code is then delivered to claude.ai — not to the attacker. The vendor controls the callback handler.
-- **Why custom schemes / http are NOT:** `com.evil.app://claude.ai/cb` and `http://claude.ai/...` both parse to host `claude.ai` but deliver the code to an attacker-controlled handler. `lookup_by_host/1` enforces `%URI{scheme: "https", userinfo: nil}`. (Code review caught this — the naive host-only match was exploitable.)
-- Custom schemes (`cursor://`) and `localhost` are **identify-only**: they may set icon/name but never grant `verified`.
+1. **Vendor-hosted**, `claude.ai`, `chatgpt.com`, `grok.com`, `callback.mistral.ai`. Fixed HTTPS host → allowlistable → `verified: true`.
+2. **Local / loopback**, Claude Code, Cursor, Windsurf, Cline, Continue, OpenCode, GitHub Copilot. `http://localhost:<ephemeral>/callback`. **Un-verifiable by design.** Attribution must come from `client_name`.
+3. **Self-hosted**: Open WebUI, LobeChat. Redirect host is *the operator's own domain* (observed: `https://ai.ras.band/oauth/clients/mcp:1/callback`). There is no vendor host to allowlist, not now, not ever. Also `client_name`-only.
 
-## Known stale — the 4 guessed `software_id` entries
+Classes 2 and 3 are the majority of the catalog. **Any design keying attribution on the redirect host alone silently excludes both**. That was the 2026-07-30 bug.
 
-`anthropic-claude-desktop`, `cursor.sh`, `openai-chatgpt`, `vscode-engram` are UNVALIDATED guesses. Left in place because they're harmless — real clients don't send those IDs, so they never match. The only proven-real `software_id` is our own `engram-vault-sync`.
+## Trust model (security-relevant, do not weaken)
 
-Real vendor callbacks (observed / published):
+**Identity and verification are computed independently.** Identity (logo /
+display_name / slug) comes from the first match of `software_id` → host → name.
+`verified: true` is granted by **one thing only**: a vendor-owned **HTTPS**
+redirect host, no userinfo, case-folded.
 
-| Client | Redirect | Identity path |
-|--------|----------|---------------|
-| Claude | `https://claude.ai/api/mcp/auth_callback` | HTTPS host → verified |
-| ChatGPT | `https://chatgpt.com/connector_platform_oauth_redirect` | HTTPS host → verified |
-| Cursor | `cursor://` (native scheme) | identify-only |
-| VS Code | `vscode://` (native scheme) | identify-only |
+> **Tightened 2026-07-30.** `software_id` used to grant `verified: true`. It is
+> an RFC 7591 field the client sends *about itself* in the DCR body, exactly as
+> self-asserted as `client_name`, so anyone could register
+> `software_id: "anthropic-claude-desktop"` and appear in a victim's connections
+> list as a verified Claude Desktop, logo and all. Not an authorization-time
+> phishing vector (the consent screen shows only `client_id` + `client_name`),
+> but it made a rogue grant look trustworthy enough not to revoke. It now
+> supplies identity only. Device-flow rows are unaffected, `device_rows/1`
+> hardcodes `verified: true`, which is legitimate because our own server mints
+> the `family_id`; no client-supplied metadata is involved.
 
-**To add a new client:** confirm its real redirect host by inspecting an actual `oauth_clients` row (below), then add an `@redirect_host` entry (HTTPS vendor host) — or an `@software_id` entry only if it genuinely sends one.
+- **Why HTTPS host is un-spoofable:** a forged DCR client can *claim* `redirect_uri=https://claude.ai/...`, but the auth code is then delivered to claude.ai, not to the attacker. The vendor controls the callback handler.
+- **Why custom schemes / http are NOT:** `com.evil.app://claude.ai/cb` and `http://claude.ai/...` both parse to host `claude.ai` but deliver the code to an attacker-controlled handler. `lookup_by_host/1` enforces `%URI{scheme: "https", userinfo: nil}`. (Code review caught this; the naive host-only match was exploitable.)
+- **`client_name` grants `slug` and nothing else.** It is self-asserted and trivially spoofable, but ticking a row in your *own* checklist is not a security boundary. The logo and the verified badge, where spoofing actually matters, stay host/`software_id` gated. `logo_allowlist_test.exs` pins this explicitly.
 
-## Where to verify what a client actually sends
+> **Correction (2026-07-30).** This doc previously said custom schemes and localhost were *"identify-only: they may set icon/name but never grant verified."* That was the intended design; the code never implemented it, `lookup_by_host/1` returned the empty placeholder, so loopback clients got **no slug at all** and their checklist row could never tick. The doc/code mismatch is why the gap survived six weeks. Slug attribution for those clients now comes from `client_name`.
 
-Ground truth is the DB, not published docs (which only give canonical values):
+## Observed registrations (prod, 2026-07-30)
+
+Ground truth from real grants, not published docs:
+
+| Connector | `client_name` | Redirect | Resolves via | Verified |
+|---|---|---|---|---|
+| Claude | (not recorded) | `https://claude.ai/api/mcp/auth_callback` | host | yes |
+| ChatGPT | `ChatGPT` | `https://chatgpt.com/connector/oauth/<id>` | host | yes |
+| Grok | `Grok` | `https://grok.com/connectors-oauth-exchange-code/` | host | yes |
+| Mistral | `mistral-mcp-client` | `https://callback.mistral.ai/v1/integrations_auth/oauth2_callback` | host | yes |
+| Antigravity | `antigravity-client` | `https://antigravity.google/oauth-callback` | host | yes |
+| Claude Code | `Claude Code (<server>)` | `http://localhost:<port>/callback` | name | no |
+| Open WebUI | `Open WebUI` | `https://<user-domain>/oauth/clients/mcp:1/callback` | name | no |
+| Cline | `Cline` | `http://127.0.0.1:<port>/mcp/oauth/callback` | name | no |
+| OpenCode | `OpenCode` | `http://127.0.0.1:<port>/mcp/oauth/callback` | name | no |
+
+Mistral and Antigravity are the cases where **name** derivation fails
+(`mistral_mcp_client` / `antigravity_client` are not catalog slugs) and the host
+saves it. Claude Code, Open WebUI, Cline and OpenCode are the exact inverse.
+Neither layer alone covers all nine, keep both.
+
+> **Do not assume a client registers under its product name.** Three of nine
+> observed clients append a suffix (`-client`, `(<server>)`). The name layer is a
+> fallback for clients with no usable host, not a primary identifier.
+
+**Cline and OpenCode are the predictions this design got to cash.** Both were
+written into the test suite as *never-observed* connectors, asserting that
+`"Cline" -> cline` and `"OpenCode" -> opencode` would derive from the catalog
+with no new config. Both then registered for real within the hour and did
+exactly that. That is the argument for normalizing names back into slug shape
+rather than hand-maintaining a vendor map: the map only ever covers connectors
+someone already noticed, and these two would have needed a code change each.
+
+Note the shared `/mcp/oauth/callback` path: Cline and OpenCode register the same
+loopback shape and differ only by `client_name` and port (both are also
+Bun/TypeScript by user-agent, so a common MCP SDK OAuth client is the likely
+cause, though we have not confirmed that). Either way it is a *family* of
+connectors, not two coincidences, and it is exactly the family the host layer
+can never attribute.
+
+## Registration can reject a connector outright (two fixed 2026-07-30)
+
+Attribution only matters once a client is *registered*. Two rules were turning
+real connectors away at `/oauth/register`, which is a worse failure: no
+`oauth_clients` row exists at all, so there is nothing to attribute, nothing in
+the connections list, and no checklist row can ever tick.
+
+**1. Public clients only.** `@valid_auth_methods` was `~w(none)`, so a
+confidential registration was rejected. LobeHub cloud asks for one, and its
+`connector.startOAuth` surfaced our `token_endpoint_auth_method: must be one of:
+none` as its own 500. Note RFC 7591 §2 makes `client_secret_basic` the
+**default** auth method: secret-based auth is the DCR baseline and `none` is the
+opt-out, so we had implemented the MCP subset and treated it as the standard.
+Now all three methods are accepted; a confidential registration mints a secret
+(hashed into `client_secret_hash`, returned once) and the token endpoint
+authenticates it.
+
+**2. Reverse-DNS custom schemes only.** `check_uri/1` required a dot in a custom
+scheme, citing RFC 8252 §7.1. Cursor desktop registers
+`cursor://anysphere.cursor-mcp/oauth/callback` and was rejected; its log shows
+the streamable-HTTP attempt failing on our error and the SSE fallback then
+404/406-ing, which reads like a transport problem but is not. §7.1 obliges
+*apps* to pick such a scheme; it does not ask servers to reject the ones that
+don't. The dot never made a scheme exclusive on any OS either, so it reduced
+accidental collisions, not squatting. **PKCE is the actual defence** and is
+mandatory: an app that intercepts the redirect gets a code it cannot redeem.
+`javascript:` / `data:` / `file:` are still rejected, and custom schemes remain
+permanently unverifiable.
+
+> **Cursor's published redirect URLs are not what it registers.**
+> `cursor.com/docs/mcp` documents `https://www.cursor.com/agents/mcp/oauth/callback`
+> and `http://localhost:8787/callback`. Those describe the *static OAuth* path
+> where you pre-register URLs with a provider. Under DCR the desktop client
+> sends `cursor://anysphere.cursor-mcp/oauth/callback`. Third case today where
+> vendor docs disagreed with an observed registration; trust the row.
+
+## Slug derivation is algorithmic, not a vendor map
+
+The FTUX catalog slugs were coined from product names, so normalizing a `client_name` back into slug shape round-trips for connectors nobody has ever connected:
+
+```
+"GitHub Copilot"       -> github_copilot
+"Open WebUI"           -> open_webui
+"Claude Code (engram)" -> claude_code
+```
+
+`LogoAllowlist.normalize_name/1` = strip trailing parenthetical → downcase → collapse `[^a-z0-9]+` to `_` → trim `_`. Membership is checked against `Engram.Onboarding.valid_tools()` minus `web_only`/`other_mcp` (questionnaire answers, not products; no client may claim them).
+
+The trailing-parenthetical strip is load-bearing: Claude Code registers as `Claude Code (<mcp-server-name>)` where the suffix is user-chosen, so an exact-match map entry misses every real installation.
+
+## Learning a new connector without connecting it
+
+A DCR registration whose `client_name` resolves to no slug logs `mcp_dcr_unattributed_client` (category `:lifecycle`, so it ships to Loki) carrying the **normalized** name. Paste that string straight into `@name_aliases`.
+
+```logql
+{app="engram"} |= "mcp_dcr_unattributed_client"
+```
+
+It logs the normalized form deliberately: that drops the user-chosen server suffix, so nothing personal reaches Loki.
+
+Or read the DB directly:
 
 ```sql
 SELECT software_id, client_name, redirect_uris FROM oauth_clients;
 ```
+
+## Brand icons come from the slug, not the backend
+
+`@lobehub/icons-static-svg` is already a dependency and already covers every catalog slug. Use `ToolMark slug={...}` (`frontend/src/onboarding/tool-icon.tsx`). The backend `logo: "/assets/clients/*.svg"` field is a legacy parallel system still needed only for `engram-vault-sync` and `vscode`; `grok.svg`/`mistral.svg` were never created and don't need to be.
+
+## Known stale: the 4 guessed `software_id` entries
+
+`anthropic-claude-desktop`, `cursor.sh`, `openai-chatgpt`, `vscode-engram` are UNVALIDATED guesses. Prod data now **proves** they never fire (the real ChatGPT and Claude grants both arrive with `software_id: null`). Harmless, but they read as coverage, do not add more speculative entries. The only proven-real `software_id` is our own `engram-vault-sync`.
+
+`@name_aliases` currently carries one **inferred, not observed** entry: `visual_studio_code` → `github_copilot`. VS Code drives MCP OAuth itself, above the extension, so a Copilot user's grant is expected to arrive under the product name. The tripwire will confirm or refute it.
+
+## Failed approaches / dead ends
+
+- **Welding `slug` to `verified`.** Correct for logos, fatal for attribution, loopback can never verify, so ~7 of 14 catalog connectors could never tick. Decouple instead.
+- **Exact-matching `client_name`.** Defeated by Claude Code's user-chosen parenthetical suffix.
+- **Hand-maintaining a vendor name map.** Superseded by catalog derivation; the four dead `software_id` guesses are the cautionary tale.
+- **Researching redirect URLs for the remaining connectors.** There is nothing to find. Vendors do not publish DCR `client_name`/`redirect_uri` values, and loopback/self-hosted clients have no fixed host by construction. Instrument, don't search.
+- **Allowlisting a self-hosted instance's host.** Verifies exactly one operator and nobody else. Don't.
+
+## Google: Antigravity yes, Gemini no (2026-07-30)
+
+Google sunset **Gemini CLI** for AI Pro / Ultra / free tiers on **2026-06-18**
+(also Gemini Code Assist IDE extensions), directing those users to **Antigravity
+CLI**. Enterprise (Code Assist Standard/Enterprise, Google Cloud) and paid API
+keys keep Gemini CLI, and the repo is still maintained, so it is a tier-scoped
+sunset, not a deprecation.
+([announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/))
+
+Catalog decisions that follow:
+
+- **`antigravity` is a real slug** (TOOL_CODING), attributed by the
+  `antigravity.google` **host** entry, verified, with a logo. It registers as
+  `antigravity-client`, so name derivation does *not* catch it; the initial
+  assumption that it would was wrong and is pinned by a regression test.
+- Antigravity connects to a DCR server with **nothing but a `serverUrl`**, the
+  `oauth: {clientId, clientSecret}` block in its docs is only for servers without
+  DCR, so our public-PKCE-only registration is fine. Config lives at
+  `~/.gemini/config/mcp_config.json` (or workspace `.agents/mcp_config.json`);
+  the key **must** be `serverUrl` (`url`/`httpUrl` are rejected). Auth is
+  copy-paste-the-code via Agent Settings → Customizations → Authenticate, and
+  MCP tools default to **Ask** mode until allowed with `mcp(engram/*)`.
+- **`gemini` is deliberately NOT a selectable slug.** The consumer Gemini app has
+  no UI for adding a custom remote MCP server. That is Gemini Enterprise (Cloud
+  console → Data Stores → Custom MCP Server) or Antigravity. Making it
+  selectable would manufacture an uncompletable checklist row, the same defect
+  this whole doc is about.
+- It is still **listed and greyed** in the FTUX picker via `ToolOption.unavailable`,
+  because a silent absence reads as an Engram gap rather than a platform one. The
+  slug is absent from `@valid_tools`, so it cannot reach a profile even if the UI
+  is bypassed.
+- **No `gemini_cli` slug.** Adding a product Google is retiring would be new dead
+  config. If an enterprise Gemini CLI user connects, the tripwire logs it.
+
+## The real fix for local clients: CIMD (not yet implemented)
+
+**Client ID Metadata Documents** make the `client_id` an HTTPS URL owned by the
+client vendor; the authorization server fetches it to obtain the client's
+metadata. That URL's host is un-spoofable for the same reason a vendor redirect
+host is: nobody else can serve a document at `claude.ai`. So CIMD gives us a
+**provable identity for loopback clients**, which the redirect can never supply.
+
+Status and why it matters:
+
+- MCP `2025-11-25` adopted CIMD (IETF `draft-ietf-oauth-client-id-metadata-document`)
+  and demoted DCR from SHOULD to **MAY**. The July 2026 spec update **deprecates
+  DCR**, keeping it only for servers that haven't migrated. **We are on the
+  deprecated path.**
+- **Claude Code supports CIMD** (`oauth_cimd`). Anthropic's docs state Claude
+  picks it only when the AS metadata advertises **both**:
+  - `token_endpoint_auth_methods_supported` containing `"none"`, ✅ we already
+    do (`well_known_controller.ex:66`)
+  - `client_id_metadata_document_supported: true`, ❌ **we do not**
+  With the flag missing, Claude Code falls back to DCR, which is exactly why the
+  observed grant is an anonymous loopback client.
+- Claude Desktop / Web / Cowork appear to use CIMD too, via shared infra.
+- No MCP client sends an RFC 7591 `software_statement` (signed JWT), so that is
+  not an alternative route to cryptographic vendor attribution today.
+
+Implementing it means: advertise the flag, accept URL-shaped `client_id`s at
+authorize/token, fetch + validate the document (HTTPS only, `application/json`,
+its `client_id` must equal its own URL), cache with refresh, derive the redirect
+allowlist from it, and guard the fetch against SSRF. Once shipped, Claude Code
+grants become genuinely `verified` and the "recognized, self-reported" tier
+below stops applying to them.
+
+## "Why is Claude Code unverified? Am I connected wrong?"
+
+No. Claude Code, and every local-first client, is unverifiable **by
+construction**, not by misconfiguration. It redirects to
+`http://localhost:<port>/callback`; anyone can claim a loopback URI, so it
+asserts nothing about who the client is. RFC 8252 *recommends* loopback for
+native apps precisely because it is the safest option for local software, but it
+carries no identity proof. There is no setting that changes this.
+
+The UI therefore shows **three** states, not two (`connections-page.tsx`):
+
+| Condition | Chip | Meaning |
+|---|---|---|
+| `verified` | *(none)* | Redirect lands on a vendor-owned domain |
+| `!verified` and `slug` | *(none)* | Recognized, but local/self-hosted, unprovable, and fine |
+| `!verified` and no `slug` | `unverified` | Unrecognized client; check the redirect, consider revoking |
+
+A recognized client is presented plainly, with its official brand mark: badging
+Claude Code as suspect is simply wrong, and collapsing it into "unverified"
+alongside genuinely unknown clients is what made users ask whether they had set
+something up incorrectly. The chip is reserved for the case where it is
+**actionable**. Provenance for all three states is spelled out in the expanded
+row's `Identity:` line, so nothing is hidden. It just is not alarming.
+
+## Other gotchas
+
+- **`ai_connected` is dead.** Defined in `onboarding/action.ex` and `frontend/src/api/queries.ts`, written by nothing. Tool rows derive from live connections, not from that action.
+- **`other_mcp` has no slug of its own.** No client resolves to it, so slug-matching left "Connect another MCP client" unstickable. Special-cased in `checklist-widget.tsx` to any live MCP grant not already claimed by another selected row.
+- **`:auth` info logs do NOT reach Loki.** `Engram.Logger.Category.@info_to_loki` excludes `:auth`; the DCR tripwire uses `:lifecycle` for that reason.
+
+## References
+
+- `lib/engram/connections/logo_allowlist.ex`: resolution + normalization
+- `lib/engram/connections.ex`: `list_for_user/1`, the only caller
+- `lib/engram_web/controllers/oauth_register_controller.ex`: DCR + tripwire
+- `frontend/src/onboarding/checklist-widget.tsx`: row completion
+- `frontend/src/onboarding/tool-icon.tsx`: `ToolMark` / `ToolBadge`
+- `frontend/src/onboarding/onboarding-tools.ts`: FTUX catalog (mirrors `Onboarding.valid_tools/0`)
+- `docs/context/mcp-oauth.md`: the OAuth 2.1 + DCR flow itself

--- a/docs/context/migration-column-type-rewrites.md
+++ b/docs/context/migration-column-type-rewrites.md
@@ -1,0 +1,113 @@
+# Context Doc: Widening a column type without rewriting the table
+
+_Last verified: 2026-07-30_
+
+## Status
+
+Working. Measured on PostgreSQL 18.4 (the version in `backend-postgres-1` and prod RDS).
+
+## What This Is
+
+`ALTER TABLE ... ALTER COLUMN ... TYPE ...` sometimes rewrites the entire heap
+under `ACCESS EXCLUSIVE` and sometimes costs nothing. The difference is not
+obvious from the SQL, squawk's `changing-column-type` rule cannot tell them
+apart, and **the intuitive answer is wrong for array columns**.
+
+Read this before writing a widening migration or before dismissing squawk's
+`changing-column-type` warning as a false positive.
+
+## The rule, and the trap
+
+PostgreSQL skips the rewrite when the old type is **binary coercible** to the
+new one and the `USING` clause does not change contents. `varchar(n)` → `text`
+qualifies: it only drops a length constraint.
+
+**That does not extend to the array form.** `varchar(n)[]` → `text[]` rewrites
+the whole table, even though the element cast is coercible. The no-rewrite
+optimisation is not applied at the array level.
+
+| Change | Rewrite? |
+|---|---|
+| `varchar(n)` → `text` | No |
+| `varchar(n)` → `varchar(m)`, m > n | No |
+| `varchar(n)[]` → `text[]` | **Yes, full rewrite** |
+| `text` → `varchar(n)` (narrowing) | Yes (must verify every row) |
+
+## How to measure it yourself, rather than guess
+
+`pg_class.relfilenode` is the on-disk file. If it changes, the heap was
+rewritten. This is the whole test:
+
+```sql
+CREATE TABLE probe (id int, col varchar(255));
+INSERT INTO probe SELECT g, repeat('x',200) FROM generate_series(1,20000) g;
+SELECT relfilenode FROM pg_class WHERE relname='probe';   -- before
+ALTER TABLE probe ALTER COLUMN col TYPE text;
+SELECT relfilenode FROM pg_class WHERE relname='probe';   -- after; same = no rewrite
+```
+
+Run it against a real container, not a mental model:
+
+```bash
+docker exec -i backend-postgres-1 psql -U engram -d postgres -At -v ON_ERROR_STOP=1 <<'SQL'
+...
+SQL
+```
+
+Observed 2026-07-30: scalar `82860 → 82860` (unchanged), array `82865 → 82870`
+(changed).
+
+## Array default has to be dropped and restored
+
+An array column's `DEFAULT` is typed, so the type change fails while it is
+attached. Order matters:
+
+```elixir
+execute "ALTER TABLE t ALTER COLUMN c DROP DEFAULT"
+execute "ALTER TABLE t ALTER COLUMN c TYPE text[]"
+execute "ALTER TABLE t ALTER COLUMN c SET DEFAULT ARRAY[]::text[]"
+```
+
+## squawk
+
+`changing-column-type` is deliberately left enabled in `.squawk.toml` and fires
+on **every** such ALTER, coercible or not. There is no per-statement ignore, so
+the only escape is the file-level `# squawk-ignore-file` marker that
+`priv/repo/lint_migrations.sh` greps for (documented in `AGENTS.md` alongside
+`safety_assured:`).
+
+Using it obliges you to have done the relfilenode measurement and to write the
+result into the file. "squawk is generic, this is fine" is not a justification;
+it is the assumption that needs testing.
+
+Note this lint lives in the **`unit-tests`** CI job, after the test run. A job
+that reports `N tests, 0 failures` can still fail here, so read to the end of
+the log rather than stopping at the test summary.
+
+## Gotchas
+
+- **The lint is CI-only.** No local `mix` task runs squawk, so a widening
+  migration passes every local gate and fails on push. Run the relfilenode probe
+  locally instead.
+- **"Binary coercible" is about the pair of types, not about the direction
+  feeling safe.** Widening intuitively sounds free; for arrays it is not.
+- **A rewrite is not automatically a blocker.** On a small table it is
+  milliseconds. The judgement is `rewrite × row count`, so state the row count
+  in the justification instead of claiming there is no rewrite.
+- **Indexes on the column are rebuilt** even in the no-rewrite case, which is
+  another reason to check size rather than assume free.
+
+## Failed Approaches / Dead Ends
+
+- **Asserting no-rewrite from the docs alone.** The "binary coercible" wording
+  reads as though it covers `varchar[]` → `text[]`. It does not. This shipped a
+  false `safety_assured:` claim in PR #1147 that squawk caught.
+- **Treating a squawk `changing-column-type` hit as noise.** It was right; the
+  justification was wrong.
+
+## References
+
+- Migration: `priv/repo/migrations/20260730180000_widen_oauth_text_columns_expand.exs`
+- `AGENTS.md` → "The `# safety_assured:` escape"
+- `priv/repo/lint_migrations.sh`, `.squawk.toml`
+- PR #1147 (Windsurf `state` overflow, which prompted the widening)

--- a/frontend/src/dev/connector-qc-page.test.tsx
+++ b/frontend/src/dev/connector-qc-page.test.tsx
@@ -1,0 +1,44 @@
+// Smoke test for the dev-only QC gallery. It mounts three real pages against
+// seeded caches, so it breaks loudly if any of them starts requiring a provider
+// or query key the gallery doesn't supply, otherwise the page silently
+// white-screens and QC is done against nothing.
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+import ConnectorQcPage from "./connector-qc-page";
+
+function renderGallery() {
+	return render(
+		<MemoryRouter>
+			<ConnectorQcPage />
+		</MemoryRouter>,
+	);
+}
+
+describe("ConnectorQcPage", () => {
+	it("mounts all three panels without throwing", () => {
+		renderGallery();
+
+		expect(screen.getByRole("heading", { name: /connector qc/iu })).toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: /^connections page$/iu })).toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: /finish-setup checklist/iu })).toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: /ftux tool picker/iu })).toBeInTheDocument();
+	});
+
+	it("renders the connector states the gallery exists to show", () => {
+		renderGallery();
+
+		// Verified vendor, recognized-local, and unrecognized all present.
+		expect(screen.getAllByText(/Claude Code \(engram\)/iu).length).toBeGreaterThan(0);
+		expect(screen.getAllByText(/some-random-agent/iu).length).toBeGreaterThan(0);
+
+		// Exactly one chip: the unrecognized client. Recognized ones are plain.
+		expect(screen.getAllByText(/^unverified$/iu)).toHaveLength(1);
+
+		// The greyed Gemini row from the FTUX picker, its explanation is behind
+		// the HelpTip trigger, so assert the affordance, not the copy.
+		expect(
+			screen.getByRole("button", { name: /why gemini can't be connected/iu }),
+		).toBeInTheDocument();
+	});
+});

--- a/frontend/src/dev/connector-qc-page.test.tsx
+++ b/frontend/src/dev/connector-qc-page.test.tsx
@@ -28,8 +28,11 @@ describe("ConnectorQcPage", () => {
 	it("renders the connector states the gallery exists to show", () => {
 		renderGallery();
 
-		// Verified vendor, recognized-local, and unrecognized all present.
-		expect(screen.getAllByText(/Claude Code \(engram\)/iu).length).toBeGreaterThan(0);
+		// Verified vendor, recognized-local, and unrecognized all present. The
+		// fixture registers as "Claude Code (engram)"; the card shows the catalog
+		// spelling, so the user-chosen suffix must not survive to the UI.
+		expect(screen.getAllByText(/^Claude Code$/u).length).toBeGreaterThan(0);
+		expect(screen.queryByText(/\(engram\)/u)).toBeNull();
 		expect(screen.getAllByText(/some-random-agent/iu).length).toBeGreaterThan(0);
 
 		// Exactly one chip: the unrecognized client. Recognized ones are plain.

--- a/frontend/src/dev/connector-qc-page.tsx
+++ b/frontend/src/dev/connector-qc-page.tsx
@@ -1,0 +1,218 @@
+/**
+ * Dev-only QC gallery for connector presentation. Mounted at `/__qc/connectors`
+ * and only when `import.meta.env.DEV`, see router.tsx.
+ *
+ * Why this exists: the states worth reviewing (verified vendor / recognized
+ * local / self-hosted / unrecognized, and every brand mark) each require a real
+ * OAuth grant from a different vendor to reproduce. That is not a QC loop
+ * anybody will run. Instead we seed the same react-query keys the real hooks
+ * read and mount the REAL components, so this shows production code paths, not
+ * a reimplementation that can drift away from them.
+ *
+ * Adding a connector? Add a fixture here and the row should render with its
+ * brand mark and correct chip. If it doesn't, the catalog wiring is incomplete.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { BillingStatus, Connection, OnboardingStatus } from "../api/queries";
+import type { EngramConfig } from "../config";
+import { ConfigProvider } from "../config-context";
+import { ChecklistWidget } from "../onboarding/checklist-widget";
+import OnboardToolsPage from "../onboarding/onboard-tools-page";
+import ConnectionsPage from "../settings/connections-page";
+
+function conn(over: Partial<Connection>): Connection {
+	return {
+		kind: "mcp",
+		client_id: `client-${over.slug ?? over.name ?? "x"}`,
+		key_id: null,
+		name: "Client",
+		software_id: null,
+		software_version: null,
+		verified: false,
+		logo: null,
+		slug: null,
+		vault_id: null,
+		vault_name: "Engram",
+		scope: "mcp",
+		last_used_at: null,
+		connected_at: "2026-07-30T15:00:00Z",
+		first_user_agent: null,
+		first_ip: "::ffff:10.30.1.140",
+		redirect_uris: [],
+		...over,
+	} as Connection;
+}
+
+// Every row below is a real registration observed in prod on 2026-07-30, except
+// the two marked otherwise. Keep them real: invented fixtures drift from what
+// clients actually send, which is the bug class this whole page guards.
+const CONNECTIONS: Connection[] = [
+	conn({
+		name: "Claude",
+		slug: "claude",
+		verified: true,
+		logo: "/assets/clients/claude.svg",
+		redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+	}),
+	conn({
+		name: "ChatGPT",
+		slug: "chatgpt",
+		verified: true,
+		redirect_uris: ["https://chatgpt.com/connector/oauth/ig2N09X8ZQ6D"],
+		first_user_agent: "Python/3.12 aiohttp/3.13.5",
+	}),
+	conn({
+		name: "Grok",
+		slug: "grok",
+		verified: true,
+		redirect_uris: ["https://grok.com/connectors-oauth-exchange-code/"],
+		first_user_agent: "Grok",
+	}),
+	conn({
+		name: "Mistral",
+		slug: "mistral",
+		verified: true,
+		redirect_uris: ["https://callback.mistral.ai/v1/integrations_auth/oauth2_callback"],
+		first_user_agent: "MistralAI-MCPClient/1.0",
+	}),
+	conn({
+		name: "Antigravity",
+		slug: "antigravity",
+		verified: true,
+		redirect_uris: ["https://antigravity.google/oauth-callback"],
+		first_user_agent: "Go-http-client/2.0",
+	}),
+	conn({
+		name: "Claude Code (engram)",
+		slug: "claude_code",
+		verified: false,
+		redirect_uris: ["http://localhost:62184/callback"],
+		first_user_agent: "Bun/1.4.0",
+	}),
+	conn({
+		name: "Open WebUI",
+		slug: "open_webui",
+		verified: false,
+		redirect_uris: ["https://ai.ras.band/oauth/clients/mcp:1/callback"],
+		first_user_agent: "Python/3.11 aiohttp/3.13.5",
+	}),
+	// Not observed, the unrecognized case, which must still look actionable.
+	conn({
+		name: "some-random-agent",
+		slug: null,
+		verified: false,
+		redirect_uris: ["http://localhost:9999/cb"],
+	}),
+	// Not observed, device-flow Obsidian, verified via our own minted family_id.
+	conn({
+		kind: "obsidian",
+		name: "Obsidian Vault Sync",
+		slug: null,
+		verified: true,
+		software_id: "engram-vault-sync",
+		logo: "/assets/clients/engram-vault-sync.svg",
+	}),
+];
+
+const TOOLS = [
+	"claude",
+	"chatgpt",
+	"grok",
+	"mistral",
+	"open_webui",
+	"claude_code",
+	"antigravity",
+	"cursor",
+	"other_mcp",
+];
+
+const CONFIG = { billingEnabled: true } as EngramConfig;
+
+function status(over: Partial<OnboardingStatus> = {}): OnboardingStatus {
+	return {
+		enabled: true,
+		next_step: "done",
+		steps: [],
+		actions: ["first_vault_created"],
+		vault_count: 1,
+		profile: { uses_obsidian: false, tools: TOOLS },
+		...over,
+	} as OnboardingStatus;
+}
+
+/** Each panel gets its own client so one panel's cache can't leak into another. */
+function Panel({
+	title,
+	note,
+	connections,
+	onboarding,
+	children,
+}: {
+	title: string;
+	note: string;
+	connections?: Connection[];
+	onboarding?: OnboardingStatus;
+	children: ReactNode;
+}) {
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+	});
+	qc.setQueryData(["connections"], connections ?? []);
+	qc.setQueryData(["onboarding", "status"], onboarding ?? status());
+	qc.setQueryData(["billing", "status"], { tier: "pro", active: true } as BillingStatus);
+
+	return (
+		<section className="flex flex-col gap-3 border-border border-t pt-8">
+			<header className="flex flex-col gap-1">
+				<h2 className="font-semibold text-xl tracking-tight">{title}</h2>
+				<p className="text-muted-foreground text-sm">{note}</p>
+			</header>
+			<ConfigProvider config={CONFIG}>
+				<QueryClientProvider client={qc}>{children}</QueryClientProvider>
+			</ConfigProvider>
+		</section>
+	);
+}
+
+export default function ConnectorQcPage() {
+	return (
+		<main className="mx-auto flex max-w-5xl flex-col gap-10 p-8">
+			<header className="flex flex-col gap-2">
+				<h1 className="font-bold text-3xl tracking-tight">Connector QC</h1>
+				<p className="text-muted-foreground">
+					Dev-only. Real components, seeded fixtures. Mutations (Revoke, dismiss) will fire real
+					requests. Look, don't click.
+				</p>
+			</header>
+
+			<Panel
+				title="Connections page"
+				note="Top five are verified by vendor host (no chip). Claude Code + Open WebUI are recognized but unprovable. No chip either, provenance in the expanded row. Only the unrecognized client is chipped. Expand a row to read the Identity line."
+				connections={CONNECTIONS}
+			>
+				<ConnectionsPage />
+			</Panel>
+
+			<Panel
+				title="Finish-setup checklist"
+				note="Tools picked in FTUX vs live connections. claude/chatgpt/grok/mistral/open_webui/claude_code/antigravity should be struck through; cursor should still be actionable; 'another MCP client' ticks off the unrecognized grant."
+				connections={CONNECTIONS}
+			>
+				<ChecklistWidget
+					onStartTour={() => {
+						// The product tour is out of scope for connector QC.
+					}}
+				/>
+			</Panel>
+
+			<Panel
+				title="FTUX tool picker"
+				note="Gemini is listed, greyed, dashed and unselectable with its reason. Antigravity is selectable under Coding tools. Every option should show a brand mark."
+				onboarding={status({ next_step: "tools" })}
+			>
+				<OnboardToolsPage />
+			</Panel>
+		</main>
+	);
+}

--- a/frontend/src/onboarding/checklist-widget.test.tsx
+++ b/frontend/src/onboarding/checklist-widget.test.tsx
@@ -68,10 +68,33 @@ vi.mock("../config-context", async () => {
 	const actual = await vi.importActual<typeof import("../config-context")>("../config-context");
 	return {
 		...actual,
-		// SaaS context — free-tier footer logic under test depends on this.
+		// SaaS context, free-tier footer logic under test depends on this.
 		useConfig: () => ({ billingEnabled: true }) as ReturnType<typeof actual.useConfig>,
 	};
 });
+
+function mcpConn(over: Partial<Connection> = {}): Connection {
+	return {
+		kind: "mcp",
+		slug: null,
+		client_id: "c1",
+		key_id: null,
+		name: "Client",
+		software_id: null,
+		software_version: null,
+		verified: false,
+		logo: null,
+		vault_id: null,
+		vault_name: null,
+		scope: "mcp",
+		last_used_at: null,
+		connected_at: null,
+		first_user_agent: null,
+		first_ip: null,
+		redirect_uris: [],
+		...over,
+	} as Connection;
+}
 
 let activeQc: QueryClient | null = null;
 
@@ -119,7 +142,7 @@ afterEach(() => {
 	// no-op
 });
 
-describe("ChecklistWidget — per-tool rows", () => {
+describe("ChecklistWidget, per-tool rows", () => {
 	it("renders one row per slug in profile.tools", () => {
 		onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ["claude", "cursor"] };
 		render(wrap(<ChecklistWidget onStartTour={() => {}} />));
@@ -156,7 +179,7 @@ describe("ChecklistWidget — per-tool rows", () => {
 		};
 		render(wrap(<ChecklistWidget onStartTour={() => {}} />));
 
-		// Completed row stays — checked off, struck through, no actions — rather
+		// Completed row stays, checked off, struck through, no actions, rather
 		// than vanishing (#604).
 		const claude = screen.getByText(/connect claude/iu);
 		expect(claude).toBeInTheDocument();
@@ -175,7 +198,7 @@ describe("ChecklistWidget — per-tool rows", () => {
 	});
 
 	it("renders the tour row whenever the user has not completed the tour", () => {
-		// No tour_offered_skipped required anymore — the row is standing.
+		// No tour_offered_skipped required anymore, the row is standing.
 		onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: [] };
 		const onStart = vi.fn();
 		render(wrap(<ChecklistWidget onStartTour={onStart} />));
@@ -190,6 +213,31 @@ describe("ChecklistWidget — per-tool rows", () => {
 
 		expect(screen.getByText(/connect claude/iu)).toBeInTheDocument();
 		expect(screen.queryByText(/web.only/iu)).toBeNull();
+	});
+
+	// "Other connection" is a real FTUX choice, but no client ever resolves to
+	// the slug `other_mcp`, slugs come from the backend allowlist. Matching it
+	// by slug made the row unstickable by construction.
+	it("ticks the other_mcp row for an MCP client matching no known slug", () => {
+		onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ["other_mcp"] };
+		connectionsValue = { data: [mcpConn({ slug: null, name: "some-cli" })], isLoading: false };
+		render(wrap(<ChecklistWidget onStartTour={() => {}} />));
+
+		const row = screen.getByText(/connect another mcp client/iu);
+		expect(row).toHaveClass("line-through");
+		expect(row).toHaveTextContent("☑");
+	});
+
+	it("does not tick other_mcp when the only connection is a separately-selected tool", () => {
+		onboardingStatusValue.data!.profile = {
+			uses_obsidian: false,
+			tools: ["claude", "other_mcp"],
+		};
+		connectionsValue = { data: [mcpConn({ slug: "claude", name: "Claude" })], isLoading: false };
+		render(wrap(<ChecklistWidget onStartTour={() => {}} />));
+
+		expect(screen.getByText(/connect claude/iu)).toHaveClass("line-through");
+		expect(screen.getByText(/connect another mcp client/iu)).not.toHaveClass("line-through");
 	});
 
 	it("falls back to /docs/integrations/ for an unmapped slug", () => {
@@ -210,7 +258,7 @@ describe("ChecklistWidget — per-tool rows", () => {
 	});
 });
 
-describe("ChecklistWidget — Obsidian plugin row", () => {
+describe("ChecklistWidget, Obsidian plugin row", () => {
 	it("renders the Obsidian plugin row when uses_obsidian is true", () => {
 		onboardingStatusValue.data!.profile = { uses_obsidian: true, tools: [] };
 		render(wrap(<ChecklistWidget onStartTour={() => {}} />));
@@ -263,7 +311,7 @@ describe("ChecklistWidget — Obsidian plugin row", () => {
 	});
 });
 
-describe("ChecklistWidget — dismiss", () => {
+describe("ChecklistWidget, dismiss", () => {
 	it("does not render a row already recorded as dismissed", () => {
 		onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ["claude", "cursor"] };
 		actionsList.push("dismissed:claude");
@@ -346,7 +394,7 @@ describe("ChecklistWidget — dismiss", () => {
 	});
 });
 
-describe("ChecklistWidget — hide when empty", () => {
+describe("ChecklistWidget, hide when empty", () => {
 	it("renders nothing when every row is done or dismissed", () => {
 		actionsList.push("first_vault_created", "dismissed:claude", "dismissed:tour");
 		onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ["claude"] };
@@ -356,7 +404,7 @@ describe("ChecklistWidget — hide when empty", () => {
 	});
 });
 
-describe("ChecklistWidget — completed rows stay visible (#604)", () => {
+describe("ChecklistWidget, completed rows stay visible (#604)", () => {
 	it("renders a completed row checked off, struck through, with no action buttons", () => {
 		onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ["claude", "cursor"] };
 		connectionsValue = {
@@ -430,7 +478,7 @@ describe("ChecklistWidget — completed rows stay visible (#604)", () => {
 	});
 });
 
-describe("ChecklistWidget — chrome", () => {
+describe("ChecklistWidget, chrome", () => {
 	it("shows the Finish setup pill when collapsed", () => {
 		onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ["claude"] };
 		render(wrap(<ChecklistWidget onStartTour={() => {}} />));
@@ -451,7 +499,7 @@ describe("ChecklistWidget — chrome", () => {
 	});
 });
 
-describe("ChecklistWidget — Free-tier reminder", () => {
+describe("ChecklistWidget, Free-tier reminder", () => {
 	it("renders Free reminder with Upgrade link to /onboard/billing when tier=free", () => {
 		onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: ["claude"] };
 		billingStatusValue.data = { tier: "free", active: false } as Partial<BillingStatus>;

--- a/frontend/src/onboarding/checklist-widget.tsx
+++ b/frontend/src/onboarding/checklist-widget.tsx
@@ -41,6 +41,9 @@ const DOC_URLS: Record<string, string> = {
 	opencode: "https://engram.page/docs/integrations/opencode/",
 	github_copilot: "https://engram.page/docs/integrations/github-copilot/",
 	other_mcp: "https://engram.page/docs/mcp/manual-config/",
+	// No `antigravity` entry yet, engram-marketing has no integrations/antigravity/
+	// page, and a mapped-but-missing URL is a hard 404 where the unmapped
+	// fallback below is a working index. Add it with the marketing page.
 };
 const DOC_FALLBACK = "https://engram.page/docs/integrations/";
 
@@ -58,6 +61,7 @@ const TOOL_LABELS: Record<string, string> = {
 	continue: "Connect Continue",
 	opencode: "Connect OpenCode",
 	github_copilot: "Connect GitHub Copilot",
+	antigravity: "Connect Antigravity",
 	other_mcp: "Connect another MCP client",
 };
 
@@ -99,7 +103,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
 		});
 
 		ob.recordAsync(action).catch(() => {
-			// The mutation hook already retries 3× — reaching here means the
+			// The mutation hook already retries 3×, reaching here means the
 			// server rejected. Roll back by invalidating so the next refetch
 			// restores the real cache state.
 			qc.invalidateQueries({ queryKey: ["onboarding", "status"] });
@@ -116,6 +120,14 @@ export function ChecklistWidget({ onStartTour }: Props) {
 			.filter((c) => c.kind === "mcp")
 			.map((c) => c.slug)
 			.filter((s): s is string => Boolean(s)),
+	);
+	// `other_mcp` is the one row with no slug of its own, no client ever
+	// resolves to it, so slug-matching left it permanently unstickable. It's
+	// satisfied by any live MCP grant not already claimed by another row the
+	// user picked (an unrecognized client has slug null and always counts).
+	const otherSelected = new Set(tools.filter((t) => t !== "other_mcp"));
+	const hasUnclaimedMcp = (connections.data ?? []).some(
+		(c) => c.kind === "mcp" && !(c.slug && otherSelected.has(c.slug)),
 	);
 
 	const items: Item[] = [
@@ -142,7 +154,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
 					{
 						key: "tour",
 						label: "Take the tour",
-						// No in-row completion signal — `tour_completed` removes the row
+						// No in-row completion signal, `tour_completed` removes the row
 						// structurally (guard above). Only dismissal hides it here.
 						done: false,
 						dismissed: isDismissed("tour"),
@@ -154,7 +166,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
 			(slug): Item => ({
 				key: slug,
 				label: TOOL_LABELS[slug] ?? `Connect ${slug}`,
-				done: connectedSlugs.has(slug),
+				done: slug === "other_mcp" ? hasUnclaimedMcp : connectedSlugs.has(slug),
 				dismissed: isDismissed(slug),
 				docUrl: DOC_URLS[slug] ?? DOC_FALLBACK,
 				dismissible: true,
@@ -163,7 +175,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
 	];
 
 	// Dismissed rows are removed entirely (the × is "hide this"). Completed rows
-	// stay visible — struck through — so progress is felt, not silently erased.
+	// stay visible, struck through, so progress is felt, not silently erased.
 	// The whole widget retires only once nothing is left to act on.
 	const visible = items.filter((i) => !i.dismissed);
 	const hasActionable = items.some((i) => !(i.done || i.dismissed));
@@ -235,7 +247,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
 							<span aria-hidden>{i.done ? "☑" : "☐"}</span>
 							{i.label}
 						</span>
-						{/* Completed rows carry no actions — just the checked-off label. */}
+						{/* Completed rows carry no actions, just the checked-off label. */}
 						{!i.done && (
 							<span className="flex items-center gap-1">
 								{i.startTour ? (
@@ -266,7 +278,7 @@ export function ChecklistWidget({ onStartTour }: Props) {
 			</ul>
 			{isFreeTier && (
 				<p className="border-border border-t px-4 py-3 text-muted-foreground text-xs">
-					You're on Free — 1 connection.{" "}
+					You're on Free, 1 connection.{" "}
 					<Link
 						to="/onboard/billing"
 						className="font-medium text-foreground underline underline-offset-4"

--- a/frontend/src/onboarding/onboard-tools-page.test.tsx
+++ b/frontend/src/onboarding/onboard-tools-page.test.tsx
@@ -80,7 +80,7 @@ beforeEach(() => {
 	billingEnabled = true;
 });
 
-describe("OnboardToolsPage — Free tier", () => {
+describe("OnboardToolsPage: Free tier", () => {
 	it("shows the Free-tier banner with an Upgrade link to /onboard/billing", () => {
 		render(wrap(<OnboardToolsPage />));
 
@@ -97,7 +97,7 @@ describe("OnboardToolsPage — Free tier", () => {
 		fireEvent.click(claude);
 		expect(claude).toHaveAttribute("data-state", "checked");
 
-		// Then click Cursor — Claude should deselect.
+		// Then click Cursor, Claude should deselect.
 		const cursor = screen.getByLabelText(/^Cursor$/iu);
 		fireEvent.click(cursor);
 		expect(cursor).toHaveAttribute("data-state", "checked");
@@ -105,7 +105,7 @@ describe("OnboardToolsPage — Free tier", () => {
 	});
 });
 
-describe("OnboardToolsPage — Self-host (billing disabled)", () => {
+describe("OnboardToolsPage: Self-host (billing disabled)", () => {
 	beforeEach(() => {
 		// Self-host: no billing. tier is still "free" (no subscription) but
 		// connections are unlimited, so the step must not gate to a single pick.
@@ -132,9 +132,73 @@ describe("OnboardToolsPage — Self-host (billing disabled)", () => {
 		expect(claude).toHaveAttribute("data-state", "checked");
 		expect(cursor).toHaveAttribute("data-state", "checked");
 	});
+
+	// "I'm not connecting an AI tool yet" answers "none", so it cannot coexist
+	// with a client. As a peer checkbox it silently could, which is why it moved
+	// out of the grid.
+	it("clears every client when the no-AI-tool opt-out is picked", () => {
+		render(wrap(<OnboardToolsPage />));
+
+		const claude = screen.getByLabelText(/^Claude$/iu);
+		fireEvent.click(claude);
+		expect(claude).toHaveAttribute("data-state", "checked");
+
+		const optOut = screen.getByLabelText(/not connecting an AI tool yet/iu);
+		fireEvent.click(optOut);
+
+		expect(optOut).toHaveAttribute("data-state", "checked");
+		expect(claude).toHaveAttribute("data-state", "unchecked");
+	});
+
+	it("clears the opt-out when a client is picked", () => {
+		render(wrap(<OnboardToolsPage />));
+
+		const optOut = screen.getByLabelText(/not connecting an AI tool yet/iu);
+		fireEvent.click(optOut);
+		expect(optOut).toHaveAttribute("data-state", "checked");
+
+		const cursor = screen.getByLabelText(/^Cursor$/iu);
+		fireEvent.click(cursor);
+
+		expect(cursor).toHaveAttribute("data-state", "checked");
+		expect(optOut).toHaveAttribute("data-state", "unchecked");
+	});
+
+	it("groups 'Another MCP client' with the coding tools, not a third list", () => {
+		render(wrap(<OnboardToolsPage />));
+
+		expect(screen.getByLabelText(/another MCP client/iu)).toBeInTheDocument();
+		expect(screen.queryByText(/^other connections$/iu)).toBeNull();
+	});
+
+	// Gemini is listed but unselectable: the platform, not Engram, lacks
+	// custom-MCP support. Listing it beats a silent absence, but it must never
+	// become a selection; that would create an uncompletable checklist row.
+	it("lists Gemini as unavailable and refuses selection", () => {
+		render(wrap(<OnboardToolsPage />));
+
+		const gemini = screen.getByLabelText(/^Gemini$/iu);
+		expect(gemini).toBeDisabled();
+
+		fireEvent.click(gemini);
+		expect(gemini).not.toHaveAttribute("data-state", "checked");
+	});
+
+	// The explanation lives behind a click-to-open HelpTip, not a hover tooltip:
+	// the checkbox is disabled and therefore unfocusable, so hover-only content
+	// would be unreachable by keyboard and absent entirely on touch.
+	it("explains the Gemini limitation via a keyboard- and touch-reachable affordance", () => {
+		render(wrap(<OnboardToolsPage />));
+
+		const trigger = screen.getByRole("button", { name: /why gemini can't be connected/iu });
+		expect(screen.queryByText(/can't add custom MCP connectors/iu)).toBeNull();
+
+		fireEvent.click(trigger);
+		expect(screen.getByText(/can't add custom MCP connectors/iu)).toBeInTheDocument();
+	});
 });
 
-describe("OnboardToolsPage — Paid tier", () => {
+describe("OnboardToolsPage: Paid tier", () => {
 	beforeEach(() => {
 		billingStatus = {
 			data: { tier: "pro", active: true } as Partial<BillingStatus>,

--- a/frontend/src/onboarding/onboard-tools-page.tsx
+++ b/frontend/src/onboarding/onboard-tools-page.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 import { Link, Navigate, useNavigate } from "react-router";
+import { HelpTip } from "@/components/help-tip";
 import { Checkbox } from "@/components/ui/checkbox";
 import AuthPanel from "@/layout/auth-panel";
 import { heading, selectableRow } from "@/lib/ui-classes";
 import { useOnboardingStatus, useSetOnboardingProfile } from "../api/queries";
 import { useIsFreeTier } from "../billing/use-is-free-tier";
 import LoadingScreen from "../layout/loading-screen";
-import { TOOL_ASSISTANTS, TOOL_CODING, TOOL_OTHER, type ToolOption } from "./onboarding-tools";
+import { NO_AI_TOOL, TOOL_ASSISTANTS, TOOL_CODING, type ToolOption } from "./onboarding-tools";
 import { ToolBadge } from "./tool-icon";
 
 interface ToolsFormProps {
@@ -18,7 +19,7 @@ interface ToolsFormProps {
 }
 
 function ToolsForm({ initialTools, isPending, hasError, isFree, onSubmit }: ToolsFormProps) {
-	// Free tier is single-select — if the user arrives with multiple already
+	// Free tier is single-select, if the user arrives with multiple already
 	// saved, drop everything except the first so the UI invariant holds from
 	// the first render.
 	const [tools, setTools] = useState<Set<string>>(() => {
@@ -44,8 +45,17 @@ function ToolsForm({ initialTools, isPending, hasError, isFree, onSubmit }: Tool
 			} else {
 				next.add(slug);
 			}
+			// Picking any client contradicts "I'm not connecting one".
+			next.delete(NO_AI_TOOL.slug);
 			return next;
 		});
+	}
+
+	// Mutually exclusive with every client: selecting it clears the grid, so the
+	// two answers can never both be true. Deselecting just empties the form,
+	// which leaves Continue disabled until something is chosen.
+	function toggleNoAiTool() {
+		setTools((prev) => (prev.has(NO_AI_TOOL.slug) ? new Set() : new Set([NO_AI_TOOL.slug])));
 	}
 
 	async function submit() {
@@ -68,7 +78,7 @@ function ToolsForm({ initialTools, isPending, hasError, isFree, onSubmit }: Tool
 
 			{isFree ? (
 				<p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-muted-foreground text-sm">
-					Free tier — pick 1 to start.{" "}
+					Free tier, pick 1 to start.{" "}
 					<Link
 						to="/onboard/billing"
 						className="font-medium text-foreground underline underline-offset-4"
@@ -94,21 +104,28 @@ function ToolsForm({ initialTools, isPending, hasError, isFree, onSubmit }: Tool
 				/>
 			</div>
 
-			<ToolColumn
-				title="Other connections"
-				options={TOOL_OTHER}
-				selected={tools}
-				onToggle={toggleTool}
-				layout="row"
-			/>
+			{/* The opt-out sits apart from the grid on purpose: it is the answer
+			    "none", not another client, so it cannot sensibly coexist with a
+			    selection. Own row, own separator, and picking it clears the rest. */}
+			<label className="flex cursor-pointer items-center gap-3 rounded-lg border border-border bg-muted/30 p-3">
+				<Checkbox
+					checked={tools.has(NO_AI_TOOL.slug)}
+					onCheckedChange={() => toggleNoAiTool()}
+					aria-label={NO_AI_TOOL.label}
+				/>
+				<span className="flex flex-col gap-0.5">
+					<span className="font-medium text-foreground text-sm">{NO_AI_TOOL.label}</span>
+					<span className="text-muted-foreground text-xs">{NO_AI_TOOL.hint}</span>
+				</span>
+			</label>
 
 			<p className="text-muted-foreground text-sm">
-				Not a comprehensive list — pick <strong>Other connection</strong> if yours isn't here.
+				Not a comprehensive list, pick <strong>Another MCP client</strong> if yours isn't here.
 			</p>
 
 			{hasError ? (
 				<p role="alert" className="text-destructive text-sm">
-					Couldn't save your answers — please try again.
+					Couldn't save your answers, please try again.
 				</p>
 			) : null}
 			<div className="flex items-center justify-end">
@@ -130,29 +147,52 @@ interface ToolColumnProps {
 	options: ToolOption[];
 	selected: Set<string>;
 	onToggle: (slug: string) => void;
-	layout?: "stack" | "row";
 }
 
-function ToolColumn({ title, options, selected, onToggle, layout = "stack" }: ToolColumnProps) {
-	const innerClass =
-		layout === "row" ? "grid grid-cols-1 gap-2 sm:grid-cols-2" : "flex flex-col gap-2";
-
+function ToolColumn({ title, options, selected, onToggle }: ToolColumnProps) {
 	return (
 		<fieldset className="flex flex-col gap-2">
 			<legend className="mb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
 				{title}
 			</legend>
-			<div className={innerClass}>
-				{options.map((opt) => (
-					<label key={opt.slug} className={selectableRow(selected.has(opt.slug), true)}>
-						<Checkbox
-							checked={selected.has(opt.slug)}
-							onCheckedChange={() => onToggle(opt.slug)}
-							aria-label={opt.label}
-						/>
-						<ToolBadge slug={opt.slug} fallbackLabel={opt.label} />
-					</label>
-				))}
+			<div className="flex flex-col gap-2">
+				{options.map((opt) =>
+					opt.unavailable ? (
+						// Not a <label>: there is nothing to activate, and a label
+						// implying clickability on an unselectable row is a worse lie
+						// than the greying.
+						//
+						// Same padding/gap as selectableRow(_, true) so the row keeps the
+						// grid rhythm, dashed border + muted content carry "unavailable"
+						// instead of extra height. The reason moves into a HelpTip so it
+						// stays reachable by keyboard and on touch; a hover tooltip would
+						// be neither, since a disabled checkbox cannot take focus.
+						<div
+							key={opt.slug}
+							aria-disabled
+							className="flex items-center gap-3 rounded-lg border border-border border-dashed p-2.5"
+						>
+							<span className="flex items-center gap-3 opacity-60">
+								<Checkbox checked={false} disabled aria-label={opt.label} />
+								<ToolBadge slug={opt.slug} fallbackLabel={opt.label} />
+							</span>
+							{/* Full opacity: the affordance has to stay legible even though
+							    the row it explains is greyed out. */}
+							<HelpTip label={`Why ${opt.label} can't be connected`} className="ms-auto">
+								{opt.unavailable}
+							</HelpTip>
+						</div>
+					) : (
+						<label key={opt.slug} className={selectableRow(selected.has(opt.slug), true)}>
+							<Checkbox
+								checked={selected.has(opt.slug)}
+								onCheckedChange={() => onToggle(opt.slug)}
+								aria-label={opt.label}
+							/>
+							<ToolBadge slug={opt.slug} fallbackLabel={opt.label} />
+						</label>
+					),
+				)}
 			</div>
 		</fieldset>
 	);

--- a/frontend/src/onboarding/onboarding-tools.ts
+++ b/frontend/src/onboarding/onboarding-tools.ts
@@ -1,5 +1,5 @@
 // FTUX questionnaire tool catalog. Mirrors the backend `@valid_tools` list
-// in lib/engram/onboarding.ex — rename a slug here and the backend will
+// in lib/engram/onboarding.ex, rename a slug here and the backend will
 // 422 on submit. The split between catalogs is UI-only; the wire shape is
 // a flat `tools: string[]`.
 
@@ -7,6 +7,13 @@ export interface ToolOption {
 	slug: string;
 	label: string;
 	hint?: string;
+	/**
+	 * Set when the tool cannot connect to Engram for a reason outside our
+	 * control. Renders the row greyed and unselectable with this string as the
+	 * explanation. Such a slug is deliberately absent from the backend
+	 * `@valid_tools`, so it can never reach a profile even if the UI is bypassed.
+	 */
+	unavailable?: string;
 }
 
 export const TOOL_ASSISTANTS: ToolOption[] = [
@@ -16,6 +23,16 @@ export const TOOL_ASSISTANTS: ToolOption[] = [
 	{ slug: "mistral", label: "Mistral" },
 	{ slug: "open_webui", label: "Open WebUI" },
 	{ slug: "lobechat", label: "LobeChat" },
+	// Listed-but-disabled on purpose: people look for Gemini, and a silent
+	// absence reads as an Engram gap. The Gemini app has no custom-MCP-connector
+	// UI (that is Gemini Enterprise / Antigravity), so we say so and point at the
+	// path that works.
+	{
+		slug: "gemini",
+		label: "Gemini",
+		unavailable:
+			"The Gemini app can't add custom MCP connectors. Antigravity, Google's Gemini-powered coding tool, can. Pick it under Coding tools.",
+	},
 ];
 
 export const TOOL_CODING: ToolOption[] = [
@@ -26,9 +43,28 @@ export const TOOL_CODING: ToolOption[] = [
 	{ slug: "continue", label: "Continue" },
 	{ slug: "opencode", label: "OpenCode" },
 	{ slug: "github_copilot", label: "GitHub Copilot" },
+	// Google's supported MCP path. Deliberately no consumer "Gemini" entry, the
+	// Gemini app can't add a custom remote MCP server, so that row could never
+	// be completed. Antigravity replaced Gemini CLI for Pro/Ultra/free tiers on
+	// 2026-06-18.
+	{ slug: "antigravity", label: "Antigravity" },
+	// Lives with the named clients rather than in a group of its own: it answers
+	// the same question they do ("which client?"), just without naming one.
+	{ slug: "other_mcp", label: "Another MCP client" },
 ];
 
-export const TOOL_OTHER: ToolOption[] = [
-	{ slug: "web_only", label: "Just the web app" },
-	{ slug: "other_mcp", label: "Other connection" },
-];
+/**
+ * The opt-out. NOT a member of the lists above, because it does not answer
+ * "which client will you connect?" the way every other option does. It answers
+ * "none", which makes it mutually exclusive with all of them, and a peer
+ * checkbox cannot express that. The page renders it as its own control below
+ * the grid and enforces the exclusivity.
+ *
+ * Slug stays `web_only` for wire compatibility: it is already in the backend
+ * `@valid_tools` and in saved profiles. Only the presentation changed.
+ */
+export const NO_AI_TOOL: ToolOption = {
+	slug: "web_only",
+	label: "I'm not connecting an AI tool yet",
+	hint: "Use Engram in the web app. You can connect a tool later from Settings.",
+};

--- a/frontend/src/onboarding/onboarding-tools.ts
+++ b/frontend/src/onboarding/onboarding-tools.ts
@@ -54,6 +54,19 @@ export const TOOL_CODING: ToolOption[] = [
 ];
 
 /**
+ * Canonical product name per slug, for surfaces that resolved a slug but only
+ * have the client's self-reported name to show.
+ *
+ * Clients register under whatever string they like: Claude Code sends
+ * `Claude Code (<mcp-server-name>)` with a user-chosen suffix, so the raw name
+ * reads as "Claude Code (engram)" in the connections list. Once the slug is
+ * resolved we already know the product, so prefer the catalog's spelling.
+ */
+export const TOOL_LABELS: Record<string, string> = Object.fromEntries(
+	[...TOOL_ASSISTANTS, ...TOOL_CODING].map(({ slug, label }) => [slug, label]),
+);
+
+/**
  * The opt-out. NOT a member of the lists above, because it does not answer
  * "which client will you connect?" the way every other option does. It answers
  * "none", which makes it mutually exclusive with all of them, and a peer

--- a/frontend/src/onboarding/tool-icon.tsx
+++ b/frontend/src/onboarding/tool-icon.tsx
@@ -1,7 +1,9 @@
-// Brand marks — color variant where the brand publishes one (Claude, Mistral,
+// Brand marks, color variant where the brand publishes one (Claude, Mistral,
 // Claude Code), otherwise the currentColor mono mark. Wordmark SVGs always
 // ship in currentColor, so they inherit row state (muted default / foreground
 // on selected) the same way plain text would.
+import antigravityColor from "@lobehub/icons-static-svg/icons/antigravity-color.svg?raw";
+import antigravityText from "@lobehub/icons-static-svg/icons/antigravity-text.svg?raw";
 import claudeColor from "@lobehub/icons-static-svg/icons/claude-color.svg?raw";
 import claudeText from "@lobehub/icons-static-svg/icons/claude-text.svg?raw";
 import claudeCodeColor from "@lobehub/icons-static-svg/icons/claudecode-color.svg?raw";
@@ -9,6 +11,8 @@ import clineMark from "@lobehub/icons-static-svg/icons/cline.svg?raw";
 import clineText from "@lobehub/icons-static-svg/icons/cline-text.svg?raw";
 import cursorMark from "@lobehub/icons-static-svg/icons/cursor.svg?raw";
 import cursorText from "@lobehub/icons-static-svg/icons/cursor-text.svg?raw";
+import geminiMark from "@lobehub/icons-static-svg/icons/gemini.svg?raw";
+import geminiText from "@lobehub/icons-static-svg/icons/gemini-text.svg?raw";
 import githubCopilotMark from "@lobehub/icons-static-svg/icons/githubcopilot.svg?raw";
 import githubCopilotText from "@lobehub/icons-static-svg/icons/githubcopilot-text.svg?raw";
 import grokMark from "@lobehub/icons-static-svg/icons/grok.svg?raw";
@@ -27,6 +31,7 @@ import openWebUIText from "@lobehub/icons-static-svg/icons/openwebui-text.svg?ra
 import windsurfMark from "@lobehub/icons-static-svg/icons/windsurf.svg?raw";
 import windsurfText from "@lobehub/icons-static-svg/icons/windsurf-text.svg?raw";
 import { Box, Globe, Workflow } from "lucide-react";
+import type { ReactNode } from "react";
 
 interface Brand {
 	mark: string;
@@ -52,6 +57,10 @@ const BRANDS: Record<string, Brand> = {
 	cline: { mark: clineMark, wordmark: clineText },
 	opencode: { mark: openCodeMark, wordmark: openCodeText },
 	github_copilot: { mark: githubCopilotMark, wordmark: githubCopilotText },
+	antigravity: { mark: antigravityColor, wordmark: antigravityText },
+	// Rendered only by the disabled "Gemini" row in the FTUX picker (mono mark,
+	// so it greys with the row). `gemini` is not a selectable catalog slug.
+	gemini: { mark: geminiMark, wordmark: geminiText },
 	other_mcp: { mark: mcpMark },
 };
 
@@ -59,6 +68,38 @@ const FALLBACK_ICONS: Record<string, typeof Globe> = {
 	web_only: Globe,
 	continue: Workflow,
 };
+
+/**
+ * Mark-only variant for dense rows (the connections list) where the product
+ * name is already the row's own text, so a wordmark would just repeat it.
+ *
+ * Keyed on the same slug the backend resolves in `Connections.LogoAllowlist`,
+ * which is why this covers every catalog connector without per-vendor assets:
+ * `@lobehub/icons-static-svg` already ships all of them. Renders `fallback`
+ * when the slug is absent or has no brand mark.
+ */
+export function ToolMark({
+	slug,
+	className,
+	fallback = null,
+}: {
+	slug: string | null;
+	className?: string;
+	fallback?: ReactNode;
+}) {
+	const brand = slug ? BRANDS[slug] : undefined;
+	if (!brand) {
+		return <>{fallback}</>;
+	}
+	return (
+		<span
+			aria-hidden
+			data-testid={`tool-mark-${slug}`}
+			className={className}
+			dangerouslySetInnerHTML={{ __html: brand.mark }}
+		/>
+	);
+}
 
 export function ToolBadge({ slug, fallbackLabel }: { slug: string; fallbackLabel: string }) {
 	const brand = BRANDS[slug];

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -16,7 +16,7 @@ import LoadingPane from "./viewer/loading-pane";
 // KaTeX wiring + CodeMirror behind NotePage) dominated a 1.78 MB main
 // chunk that even the sign-in page had to parse. Entry surfaces
 // (sign-in/up, guards) stay eager; everything behind navigation —
-// including the authenticated app shell, loads on demand.
+// including the authenticated app shell — loads on demand.
 
 // The app-shell layouts all resolve through ONE barrel module so they share a
 // single async chunk (no gate → shell → layout chunk waterfall). This is what
@@ -29,19 +29,13 @@ const OnboardingGate = lazy(() =>
 const OnboardingShell = lazy(() =>
 	import("./layout/app-shell").then((m) => ({ default: m.OnboardingShell })),
 );
-// Onboarding entry surface, same one-chunk barrel pattern.
+// Onboarding entry surface — same one-chunk barrel pattern.
 const OnboardLayout = lazy(() =>
 	import("./onboarding/onboard-entry").then((m) => ({ default: m.OnboardLayout })),
 );
 const OnboardRedirect = lazy(() =>
 	import("./onboarding/onboard-entry").then((m) => ({ default: m.OnboardRedirect })),
 );
-// Dev-only (see the guarded route below). The `lazy()` must live INSIDE the
-// DEV ternary, not at plain module scope: a bare `lazy(() => import(...))`
-// still emits its chunk in a production build even when the only route
-// referencing it is guarded away, verified, it shipped 4.3 kB of dead weight.
-// With the dynamic import in a statically-false branch, Rollup drops it.
-const ConnectorQcPage = import.meta.env.DEV ? lazy(() => import("./dev/connector-qc-page")) : null;
 const Dashboard = lazy(() => import("./viewer/dashboard"));
 // /:slug/:itemId resolves to the note OR attachment viewer (VaultItemPage owns
 // the lazy NotePage/AttachmentPage chunks).
@@ -52,6 +46,13 @@ const LegacyNoteRedirect = lazy(() => import("./viewer/legacy-note-redirect"));
 const ResetPasswordPage = lazy(() => import("./features/auth/ResetPasswordPage"));
 const DeviceLinkPage = lazy(() => import("./device/device-link-page"));
 const OAuthAuthorizePage = lazy(() => import("./oauth/oauth-authorize-page"));
+// Dev-only (see the guarded route below). The `lazy()` MUST live inside the
+// DEV ternary, not at plain module scope: a bare `lazy(() => import(...))`
+// still emits its chunk in a production build even when the only route
+// referencing it is guarded away. Verified the hard way, it shipped 4.3 kB of
+// dead weight. With the dynamic import in a statically-false branch, Rollup
+// drops it entirely.
+const ConnectorQcPage = import.meta.env.DEV ? lazy(() => import("./dev/connector-qc-page")) : null;
 // Settings is a hash overlay mounted at the AuthGuard level (not inside
 // AppLayout) so /link and /oauth/consent, which sit outside the app shell
 // and link to `#settings/billing`, still resolve the overlay.
@@ -77,18 +78,18 @@ function suspendedScreen(el: ReactNode) {
 	return <Suspense fallback={<LoadingScreen />}>{el}</Suspense>;
 }
 
-// Root layout, mounts the UpgradeDialogProvider INSIDE the router so the
+// Root layout — mounts the UpgradeDialogProvider INSIDE the router so the
 // dialog's `useNavigate` works, and so any nested API call that 402s opens
 // the modal via the module-level handler. Wrapping `RouterProvider` from
 // `main.tsx` would not give the provider router context.
 function RootLayout() {
-	// Dev-only route-level crash trigger, the twin of main.tsx's `?boom` (which
+	// Dev-only route-level crash trigger — the twin of main.tsx's `?boom` (which
 	// throws ABOVE the router to hit RootErrorBoundary). This throws INSIDE the
-	// router, so it exercises the route errorElement (RouteErrorBoundary), the
+	// router, so it exercises the route errorElement (RouteErrorBoundary) — the
 	// path a real route crash like the note editor takes. Visit `?routeboom`.
 	// Stripped from prod by the import.meta.env.DEV gate.
 	if (import.meta.env.DEV && new URLSearchParams(window.location.search).has("routeboom")) {
-		throw new Error("Intentional crash (?routeboom), testing the route error boundary");
+		throw new Error("Intentional crash (?routeboom) — testing the route error boundary");
 	}
 	return (
 		<UpgradeDialogProvider>
@@ -111,7 +112,7 @@ export function installAppRouter(r: AppRouter) {
 
 // Lazy getter used by code paths that need to imperatively navigate
 // (e.g. Clerk's routerPush). Throws if invoked before BootstrapGate
-// mounted, that would be a wiring regression worth surfacing loudly.
+// mounted — that would be a wiring regression worth surfacing loudly.
 export function getAppRouter(): AppRouter {
 	if (!_appRouter) {
 		throw new Error("Router accessed before installAppRouter() ran");
@@ -138,10 +139,9 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 				{ path: ROUTES.SIGN_IN, element: <SignInPage /> },
 				{ path: ROUTES.SIGN_UP, element: <SignUpPage /> },
 				{ path: ROUTES.WAITLIST, element: <WaitlistPage /> },
-				// Public reset, the one-time token IS the credential.
+				// Public reset — the one-time token IS the credential.
 				{ path: "/reset-password", element: suspended(<ResetPasswordPage />) },
-
-				// Dev-only connector QC gallery, spreads into nothing in production.
+				// Dev-only connector QC gallery — spreads into nothing in production.
 				...(ConnectorQcPage
 					? [{ path: "/__qc/connectors", element: suspended(<ConnectorQcPage />) }]
 					: []),
@@ -156,7 +156,7 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 							// shell and link to `#settings/billing`.
 							element: suspendedScreen(<SettingsOverlayHost />),
 							children: [
-								// Onboarding wizard, itself protected by AuthGuard, but NOT by
+								// Onboarding wizard — itself protected by AuthGuard, but NOT by
 								// OnboardingGate (would redirect-loop).
 								{
 									path: "/onboard",
@@ -170,24 +170,24 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 									],
 								},
 
-								// /link is reachable mid-onboarding, the wizard's Obsidian branch
+								// /link is reachable mid-onboarding — the wizard's Obsidian branch
 								// requires the user to complete device-flow here before progressing.
 								// Sits OUTSIDE the OnboardingGate to dodge the redirect-to-/onboard.
 								{ path: ROUTES.DEVICE_LINK, element: suspended(<DeviceLinkPage />) },
 
-								// OAuth consent, reachable mid-onboarding so an MCP client (e.g.
+								// OAuth consent — reachable mid-onboarding so an MCP client (e.g.
 								// Claude Desktop) initiating a connection during signup can complete
 								// the OAuth dance without being bounced to /onboard.
 								{ path: ROUTES.OAUTH_CONSENT, element: suspended(<OAuthAuthorizePage />) },
 
-								// Dashboard tree, gated by OnboardingGate.
+								// Dashboard tree — gated by OnboardingGate.
 								{
 									element: suspendedScreen(<OnboardingGate />),
 									children: [
 										{
 											// OnboardingShell wraps the dashboard tree so the tour offer,
 											// first-vault modal, and checklist only mount on the main app
-											// surface, NOT on /settings/*, /device-link, or /oauth.
+											// surface — NOT on /settings/*, /device-link, or /oauth.
 											element: suspendedScreen(
 												<OnboardingShell>
 													<Outlet />
@@ -229,7 +229,7 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 					],
 				},
 
-				// Catch-all, auth-aware: signed-out visitors are bounced to sign-in
+				// Catch-all — auth-aware: signed-out visitors are bounced to sign-in
 				// (with return_to), signed-in users see the real 404. A typo for a
 				// logged-in user is just a typo; for a logged-out one there's nothing
 				// to do on a 404 but authenticate.

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -16,7 +16,7 @@ import LoadingPane from "./viewer/loading-pane";
 // KaTeX wiring + CodeMirror behind NotePage) dominated a 1.78 MB main
 // chunk that even the sign-in page had to parse. Entry surfaces
 // (sign-in/up, guards) stay eager; everything behind navigation —
-// including the authenticated app shell — loads on demand.
+// including the authenticated app shell, loads on demand.
 
 // The app-shell layouts all resolve through ONE barrel module so they share a
 // single async chunk (no gate → shell → layout chunk waterfall). This is what
@@ -29,13 +29,19 @@ const OnboardingGate = lazy(() =>
 const OnboardingShell = lazy(() =>
 	import("./layout/app-shell").then((m) => ({ default: m.OnboardingShell })),
 );
-// Onboarding entry surface — same one-chunk barrel pattern.
+// Onboarding entry surface, same one-chunk barrel pattern.
 const OnboardLayout = lazy(() =>
 	import("./onboarding/onboard-entry").then((m) => ({ default: m.OnboardLayout })),
 );
 const OnboardRedirect = lazy(() =>
 	import("./onboarding/onboard-entry").then((m) => ({ default: m.OnboardRedirect })),
 );
+// Dev-only (see the guarded route below). The `lazy()` must live INSIDE the
+// DEV ternary, not at plain module scope: a bare `lazy(() => import(...))`
+// still emits its chunk in a production build even when the only route
+// referencing it is guarded away, verified, it shipped 4.3 kB of dead weight.
+// With the dynamic import in a statically-false branch, Rollup drops it.
+const ConnectorQcPage = import.meta.env.DEV ? lazy(() => import("./dev/connector-qc-page")) : null;
 const Dashboard = lazy(() => import("./viewer/dashboard"));
 // /:slug/:itemId resolves to the note OR attachment viewer (VaultItemPage owns
 // the lazy NotePage/AttachmentPage chunks).
@@ -71,18 +77,18 @@ function suspendedScreen(el: ReactNode) {
 	return <Suspense fallback={<LoadingScreen />}>{el}</Suspense>;
 }
 
-// Root layout — mounts the UpgradeDialogProvider INSIDE the router so the
+// Root layout, mounts the UpgradeDialogProvider INSIDE the router so the
 // dialog's `useNavigate` works, and so any nested API call that 402s opens
 // the modal via the module-level handler. Wrapping `RouterProvider` from
 // `main.tsx` would not give the provider router context.
 function RootLayout() {
-	// Dev-only route-level crash trigger — the twin of main.tsx's `?boom` (which
+	// Dev-only route-level crash trigger, the twin of main.tsx's `?boom` (which
 	// throws ABOVE the router to hit RootErrorBoundary). This throws INSIDE the
-	// router, so it exercises the route errorElement (RouteErrorBoundary) — the
+	// router, so it exercises the route errorElement (RouteErrorBoundary), the
 	// path a real route crash like the note editor takes. Visit `?routeboom`.
 	// Stripped from prod by the import.meta.env.DEV gate.
 	if (import.meta.env.DEV && new URLSearchParams(window.location.search).has("routeboom")) {
-		throw new Error("Intentional crash (?routeboom) — testing the route error boundary");
+		throw new Error("Intentional crash (?routeboom), testing the route error boundary");
 	}
 	return (
 		<UpgradeDialogProvider>
@@ -105,7 +111,7 @@ export function installAppRouter(r: AppRouter) {
 
 // Lazy getter used by code paths that need to imperatively navigate
 // (e.g. Clerk's routerPush). Throws if invoked before BootstrapGate
-// mounted — that would be a wiring regression worth surfacing loudly.
+// mounted, that would be a wiring regression worth surfacing loudly.
 export function getAppRouter(): AppRouter {
 	if (!_appRouter) {
 		throw new Error("Router accessed before installAppRouter() ran");
@@ -132,8 +138,13 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 				{ path: ROUTES.SIGN_IN, element: <SignInPage /> },
 				{ path: ROUTES.SIGN_UP, element: <SignUpPage /> },
 				{ path: ROUTES.WAITLIST, element: <WaitlistPage /> },
-				// Public reset — the one-time token IS the credential.
+				// Public reset, the one-time token IS the credential.
 				{ path: "/reset-password", element: suspended(<ResetPasswordPage />) },
+
+				// Dev-only connector QC gallery, spreads into nothing in production.
+				...(ConnectorQcPage
+					? [{ path: "/__qc/connectors", element: suspended(<ConnectorQcPage />) }]
+					: []),
 
 				// Authenticated routes
 				{
@@ -145,7 +156,7 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 							// shell and link to `#settings/billing`.
 							element: suspendedScreen(<SettingsOverlayHost />),
 							children: [
-								// Onboarding wizard — itself protected by AuthGuard, but NOT by
+								// Onboarding wizard, itself protected by AuthGuard, but NOT by
 								// OnboardingGate (would redirect-loop).
 								{
 									path: "/onboard",
@@ -159,24 +170,24 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 									],
 								},
 
-								// /link is reachable mid-onboarding — the wizard's Obsidian branch
+								// /link is reachable mid-onboarding, the wizard's Obsidian branch
 								// requires the user to complete device-flow here before progressing.
 								// Sits OUTSIDE the OnboardingGate to dodge the redirect-to-/onboard.
 								{ path: ROUTES.DEVICE_LINK, element: suspended(<DeviceLinkPage />) },
 
-								// OAuth consent — reachable mid-onboarding so an MCP client (e.g.
+								// OAuth consent, reachable mid-onboarding so an MCP client (e.g.
 								// Claude Desktop) initiating a connection during signup can complete
 								// the OAuth dance without being bounced to /onboard.
 								{ path: ROUTES.OAUTH_CONSENT, element: suspended(<OAuthAuthorizePage />) },
 
-								// Dashboard tree — gated by OnboardingGate.
+								// Dashboard tree, gated by OnboardingGate.
 								{
 									element: suspendedScreen(<OnboardingGate />),
 									children: [
 										{
 											// OnboardingShell wraps the dashboard tree so the tour offer,
 											// first-vault modal, and checklist only mount on the main app
-											// surface — NOT on /settings/*, /device-link, or /oauth.
+											// surface, NOT on /settings/*, /device-link, or /oauth.
 											element: suspendedScreen(
 												<OnboardingShell>
 													<Outlet />
@@ -218,7 +229,7 @@ export function createAppRouter(_config: EngramConfig): AppRouter {
 					],
 				},
 
-				// Catch-all — auth-aware: signed-out visitors are bounced to sign-in
+				// Catch-all, auth-aware: signed-out visitors are bounced to sign-in
 				// (with return_to), signed-in users see the real 404. A typo for a
 				// logged-in user is just a typo; for a logged-out one there's nothing
 				// to do on a 404 but authenticate.

--- a/frontend/src/settings/connections-page.test.tsx
+++ b/frontend/src/settings/connections-page.test.tsx
@@ -153,7 +153,41 @@ describe("ConnectionsPage", () => {
 		renderPage();
 
 		expect(screen.queryByText(/^unverified$/iu)).toBeNull();
-		expect(screen.getByText(/nothing is wrong with your setup/iu)).toBeInTheDocument();
+		expect(screen.getByText(/self-reported/iu)).toBeInTheDocument();
+	});
+
+	// Claude Code registers as "Claude Code (<mcp-server-name>)" where the suffix
+	// is whatever the user named their server, so passing the raw client_name
+	// through puts a local config detail in a list of vendor names. Once the slug
+	// resolves we know the product, so show the catalog spelling.
+	it("shows the catalog product name, not the client's self-reported one", () => {
+		mockConnections.splice(0, mockConnections.length, {
+			...baseMcp,
+			name: "Claude Code (engram)",
+			slug: "claude_code",
+			verified: false,
+		});
+		mockTier = "starter";
+		renderPage();
+
+		// getAllBy: the brand mark's <title> carries the product name too.
+		expect(screen.getAllByText("Claude Code").length).toBeGreaterThan(0);
+		expect(screen.queryByText(/\(engram\)/u)).toBeNull();
+	});
+
+	// No slug means no catalog entry to prefer, so the self-reported name is all
+	// we have and must still render rather than collapsing to "Unnamed".
+	it("keeps the self-reported name when no slug resolved", () => {
+		mockConnections.splice(0, mockConnections.length, {
+			...baseMcp,
+			name: "Some Unknown Client",
+			slug: null,
+			verified: false,
+		});
+		mockTier = "starter";
+		renderPage();
+
+		expect(screen.getByText("Some Unknown Client")).toBeInTheDocument();
 	});
 
 	it("still labels an unrecognized client unverified", () => {

--- a/frontend/src/settings/connections-page.test.tsx
+++ b/frontend/src/settings/connections-page.test.tsx
@@ -47,7 +47,7 @@ vi.mock("../config-context", async () => {
 	const actual = await vi.importActual<typeof import("../config-context")>("../config-context");
 	return {
 		...actual,
-		// SaaS context — free-tier cap fallbacks under test depend on this.
+		// SaaS context, free-tier cap fallbacks under test depend on this.
 		useConfig: () => ({ billingEnabled: true }) as ReturnType<typeof actual.useConfig>,
 	};
 });
@@ -138,6 +138,52 @@ describe("ConnectionsPage", () => {
 		expect(screen.getByRole("heading", { name: /Obsidian plugins/iu })).toBeInTheDocument();
 		expect(screen.getByRole("heading", { name: /AI tools/iu })).toBeInTheDocument();
 		expect(screen.getByRole("heading", { name: /API keys/iu })).toBeInTheDocument();
+	});
+
+	// A recognized local/self-hosted client is unverifiable by construction, so
+	// it must not carry the same "unverified" badge as an unknown client, that
+	// reads as a fixable fault and prompts "am I connected wrong?".
+	it("shows no warning chip for a recognized client, explaining provenance in the detail row", () => {
+		mockConnections.splice(0, mockConnections.length, {
+			...baseMcp,
+			slug: "claude_code",
+			verified: false,
+		});
+		mockTier = "starter";
+		renderPage();
+
+		expect(screen.queryByText(/^unverified$/iu)).toBeNull();
+		expect(screen.getByText(/nothing is wrong with your setup/iu)).toBeInTheDocument();
+	});
+
+	it("still labels an unrecognized client unverified", () => {
+		mockConnections.splice(0, mockConnections.length, {
+			...baseMcp,
+			slug: null,
+			verified: false,
+		});
+		mockTier = "starter";
+		renderPage();
+
+		expect(screen.getByText(/^unverified$/iu)).toBeInTheDocument();
+		expect(screen.queryByText(/^self-reported$/iu)).toBeNull();
+	});
+
+	// Brand marks come from the slug, not a per-vendor asset the backend has to
+	// ship, Grok has no /assets/clients/grok.svg and still renders its mark.
+	it("renders the brand mark for a slugged connection with no logo asset", () => {
+		mockConnections.splice(0, mockConnections.length, { ...baseMcp, slug: "grok", logo: null });
+		mockTier = "starter";
+		renderPage();
+		expect(screen.getByTestId("tool-mark-grok")).toBeInTheDocument();
+	});
+
+	it("falls back to the backend logo, then a plug, when the slug has no mark", () => {
+		mockConnections.splice(0, mockConnections.length, baseObs);
+		mockTier = "starter";
+		const { container } = renderPage();
+		expect(container.querySelector('img[src="/x.svg"]')).toBeInTheDocument();
+		expect(screen.queryByTestId(/^tool-mark-/u)).toBeNull();
 	});
 
 	it("shows the obsidian connection name and omits the unverified badge", () => {

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -24,6 +24,7 @@ import {
 	useRevokePat,
 } from "../api/queries";
 import { useIsFreeTier } from "../billing/use-is-free-tier";
+import { TOOL_LABELS } from "../onboarding/onboarding-tools";
 import { ToolMark } from "../onboarding/tool-icon";
 import { settingsTo } from "./settings-hash";
 
@@ -99,7 +100,15 @@ function ConnectionCard({
 					/>
 					<div className="min-w-0 flex-1">
 						<div className="truncate font-medium">
-							{connection.name ?? "Unnamed"}
+							{/* Prefer the catalog spelling once a slug is resolved. The backend
+							    passes the client's self-reported name through, and Claude Code
+							    registers as "Claude Code (<server>)" with a user-chosen suffix,
+							    so the raw string leaks a local config detail into a list of
+							    vendors. Same reasoning as the brand mark above, already keyed
+							    on slug. */}
+							{(connection.slug ? TOOL_LABELS[connection.slug] : null) ??
+								connection.name ??
+								"Unnamed"}
 							{/* A chip only where it carries information. A recognized
 							    client (slug resolved, official brand mark alongside) is
 							    presented plainly. Badging Claude Code as suspect is
@@ -157,7 +166,7 @@ function ConnectionCard({
 								{connection.verified
 									? "Verified. Sign-in redirects to a domain the vendor owns."
 									: connection.slug
-										? "Recognized, self-reported. This app runs locally or on your own server, so there is no vendor domain to check it against. Nothing is wrong with your setup."
+										? "Self-reported. Local and self-hosted apps have no domain to check, so this is normal."
 										: "Unrecognized client. Revoke it if you don't recognize the redirect below."}
 							</dd>
 						</>

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -24,13 +24,14 @@ import {
 	useRevokePat,
 } from "../api/queries";
 import { useIsFreeTier } from "../billing/use-is-free-tier";
+import { ToolMark } from "../onboarding/tool-icon";
 import { settingsTo } from "./settings-hash";
 
 // ── Tier caps ─────────────────────────────────────────────────
 
 // Caps come from /billing/status which resolves UserLimitOverride +
 // tier defaults via Engram.Billing.effective_limit/2. Don't re-derive
-// from tier here — overrides (support comps, demo seeds) would render
+// from tier here, overrides (support comps, demo seeds) would render
 // stale.
 function useTierCaps() {
 	const { data } = useBillingStatus();
@@ -71,25 +72,46 @@ function ConnectionCard({
 	return (
 		<article className="group flex items-start rounded-lg border border-border bg-card">
 			{/* <details> wraps the summary + expanded dl. The Revoke button is a
-          sibling, not a descendant of <summary> — interactive descendants of
+          sibling, not a descendant of <summary>, interactive descendants of
           <summary> aren't allowed by the HTML spec, and Firefox/Safari skip
           Tab focus on them. */}
 			<details className="min-w-0 flex-1 open:pb-3">
 				<summary className="flex cursor-pointer items-center gap-3 px-3 py-3 [&::-webkit-details-marker]:hidden">
-					{connection.logo ? (
-						<img src={connection.logo} alt="" className="size-10 shrink-0 rounded" />
-					) : (
-						<div
-							className="flex size-10 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground"
-							aria-hidden
-						>
-							<Plug className="size-5" />
-						</div>
-					)}
+					{/* Brand mark by slug first, @lobehub/icons-static-svg covers every
+					    catalog connector, so this needs no per-vendor asset. Falls back
+					    to the backend-supplied logo (Obsidian plugin, VS Code), then a
+					    generic plug for anything unrecognized. */}
+					<ToolMark
+						slug={connection.slug}
+						className="flex size-10 shrink-0 items-center justify-center [&_svg]:size-7"
+						fallback={
+							connection.logo ? (
+								<img src={connection.logo} alt="" className="size-10 shrink-0 rounded" />
+							) : (
+								<div
+									className="flex size-10 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground"
+									aria-hidden
+								>
+									<Plug className="size-5" />
+								</div>
+							)
+						}
+					/>
 					<div className="min-w-0 flex-1">
 						<div className="truncate font-medium">
 							{connection.name ?? "Unnamed"}
-							{!connection.verified && (
+							{/* A chip only where it carries information. A recognized
+							    client (slug resolved, official brand mark alongside) is
+							    presented plainly. Badging Claude Code as suspect is
+							    wrong, it just redirects to loopback and so cannot be
+							    proven either way. Provenance is spelled out in the
+							    expanded Identity row. Reserve the chip for clients we
+							    genuinely do not recognize, where it's actionable.
+
+							    This gets retired for Claude once we ship CIMD: an
+							    Anthropic-hosted client_id URL is provable, so those
+							    grants become properly `verified`. */}
+							{!(connection.verified || connection.slug) && (
 								<span className="ms-2 rounded bg-muted px-1.5 py-0.5 align-middle font-normal text-muted-foreground text-xs">
 									unverified
 								</span>
@@ -126,6 +148,18 @@ function ConnectionCard({
 						<>
 							<dt>Scopes:</dt>
 							<dd>{connection.scope}</dd>
+						</>
+					)}
+					{connection.kind === "mcp" && (
+						<>
+							<dt>Identity:</dt>
+							<dd>
+								{connection.verified
+									? "Verified. Sign-in redirects to a domain the vendor owns."
+									: connection.slug
+										? "Recognized, self-reported. This app runs locally or on your own server, so there is no vendor domain to check it against. Nothing is wrong with your setup."
+										: "Unrecognized client. Revoke it if you don't recognize the redirect below."}
+							</dd>
 						</>
 					)}
 					<dt>Identifier:</dt>
@@ -309,7 +343,7 @@ function CreatePatModal({
 						className="mt-1 block w-full rounded-md border border-input bg-card px-3 py-2 text-foreground text-sm focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
 					/>
 					<span className="mt-1 block text-muted-foreground text-xs">
-						Helps you identify the key later — pick something memorable.
+						Helps you identify the key later, pick something memorable.
 					</span>
 				</label>
 
@@ -396,7 +430,7 @@ function RevealKeyModal({
 
 				{copyState === "error" && (
 					<p className="text-destructive text-sm" role="alert">
-						Copy failed — click the field and press Cmd/Ctrl+C to copy manually.
+						Copy failed, click the field and press Cmd/Ctrl+C to copy manually.
 					</p>
 				)}
 

--- a/lib/engram/connections.ex
+++ b/lib/engram/connections.ex
@@ -7,11 +7,11 @@ defmodule Engram.Connections do
   ## Revoke routing
 
   The same `client_id` JSON field carries different identifiers per kind:
-    * `:obsidian` (device-flow), `client_id = family_id` (UUID), revoke via
+    * `:obsidian` (device-flow) — `client_id = family_id` (UUID), revoke via
       `DELETE /api/connections/device/:family_id`
-    * `:mcp`, `:obsidian` (OAuth), `client_id = oauth_clients.client_id`,
+    * `:mcp`, `:obsidian` (OAuth) — `client_id = oauth_clients.client_id`,
       revoke via `DELETE /api/connections/oauth/:client_id`
-    * `:pat`, `key_id` (integer), revoke via `DELETE /api/connections/pat/:id`
+    * `:pat` — `key_id` (integer), revoke via `DELETE /api/connections/pat/:id`
 
   Frontend consumers must branch on `kind` to choose the right route.
   """
@@ -130,7 +130,7 @@ defmodule Engram.Connections do
   `vault_id` for `user_id`.
 
   Called at vault soft-delete time so the connections page clears immediately.
-  Idempotent, safe to call twice.
+  Idempotent — safe to call twice.
   """
   @spec revoke_by_vault(Ecto.UUID.t(), Ecto.UUID.t()) :: :ok
   def revoke_by_vault(user_id, vault_id) do
@@ -298,12 +298,12 @@ defmodule Engram.Connections do
     )
     |> Repo.all(skip_tenant_check: true)
     |> Enum.map(fn rt ->
-      # Hardcoded for the Obsidian plugin, the only device-flow client today.
+      # Hardcoded for the Obsidian plugin — the only device-flow client today.
       # If other device-flow clients are added, thread
       # device_authorizations.client_id through to discriminate.
       %{
         kind: :obsidian,
-        # family_id is stable per connection lineage, safe to use as client_id
+        # family_id is stable per connection lineage — safe to use as client_id
         client_id: rt.family_id,
         key_id: nil,
         name: "Obsidian Vault Sync",

--- a/lib/engram/connections.ex
+++ b/lib/engram/connections.ex
@@ -7,11 +7,11 @@ defmodule Engram.Connections do
   ## Revoke routing
 
   The same `client_id` JSON field carries different identifiers per kind:
-    * `:obsidian` (device-flow) — `client_id = family_id` (UUID), revoke via
+    * `:obsidian` (device-flow), `client_id = family_id` (UUID), revoke via
       `DELETE /api/connections/device/:family_id`
-    * `:mcp`, `:obsidian` (OAuth) — `client_id = oauth_clients.client_id`,
+    * `:mcp`, `:obsidian` (OAuth), `client_id = oauth_clients.client_id`,
       revoke via `DELETE /api/connections/oauth/:client_id`
-    * `:pat` — `key_id` (integer), revoke via `DELETE /api/connections/pat/:id`
+    * `:pat`, `key_id` (integer), revoke via `DELETE /api/connections/pat/:id`
 
   Frontend consumers must branch on `kind` to choose the right route.
   """
@@ -130,7 +130,7 @@ defmodule Engram.Connections do
   `vault_id` for `user_id`.
 
   Called at vault soft-delete time so the connections page clears immediately.
-  Idempotent — safe to call twice.
+  Idempotent, safe to call twice.
   """
   @spec revoke_by_vault(Ecto.UUID.t(), Ecto.UUID.t()) :: :ok
   def revoke_by_vault(user_id, vault_id) do
@@ -228,7 +228,7 @@ defmodule Engram.Connections do
     )
     |> Repo.all()
     |> Enum.map(fn {t, c} ->
-      identity = LogoAllowlist.resolve(c.software_id, c.redirect_uris)
+      identity = LogoAllowlist.resolve(c.software_id, c.redirect_uris, c.client_name)
 
       %{
         kind: String.to_existing_atom(c.kind),
@@ -298,12 +298,12 @@ defmodule Engram.Connections do
     )
     |> Repo.all(skip_tenant_check: true)
     |> Enum.map(fn rt ->
-      # Hardcoded for the Obsidian plugin — the only device-flow client today.
+      # Hardcoded for the Obsidian plugin, the only device-flow client today.
       # If other device-flow clients are added, thread
       # device_authorizations.client_id through to discriminate.
       %{
         kind: :obsidian,
-        # family_id is stable per connection lineage — safe to use as client_id
+        # family_id is stable per connection lineage, safe to use as client_id
         client_id: rt.family_id,
         key_id: nil,
         name: "Obsidian Vault Sync",

--- a/lib/engram/connections/logo_allowlist.ex
+++ b/lib/engram/connections/logo_allowlist.ex
@@ -16,8 +16,17 @@ defmodule Engram.Connections.LogoAllowlist do
   `software_id` and `client_name` both arrive inside the DCR request body, so
   they are things the client *says about itself*. Neither may grant
   `verified: true`; they supply identity only. (Tightened 2026-07-30:
-  `software_id` previously granted the badge, which let anyone registering
-  `software_id: "anthropic-claude-desktop"` wear the Claude logo.)
+  `software_id` previously granted the badge outright.)
+
+  Be precise about what that does and does not buy. A client registering
+  `software_id: "anthropic-claude-desktop"` still gets Claude's **logo and
+  display name** — it only no longer gets the badge, and the host now outranks
+  it for display. Withholding the icon too would need the `@software_id` map
+  gone, and it still carries our own `engram-vault-sync` plugin. Four of its
+  five entries are unvalidated guesses (see below) and should probably be
+  deleted once observation confirms nothing sends them; that is the real fix,
+  and it is not this one. The security boundary that actually holds is
+  `verified`.
 
   Loopback and custom schemes (Cursor desktop registers
   `cursor://anysphere.cursor-mcp/…`) never match the host map, so
@@ -100,7 +109,13 @@ defmodule Engram.Connections.LogoAllowlist do
   Resolve a client's identity, and separately decide whether it is verified.
 
   **Identity** (logo / display_name / slug) comes from the first source that
-  matches: `software_id`, then redirect host, then the normalized `client_name`.
+  matches, **proven before claimed**: the redirect host, then `software_id`,
+  then the normalized `client_name`.
+
+  The host leads because it is the only source that is not self-asserted. A
+  client claiming `software_id: "openai-chatgpt"` while redirecting to
+  `claude.ai` must not be listed as ChatGPT: the grant is delivered to
+  Anthropic, so Anthropic is who the user is actually connected to.
 
   **`verified`** is decided by exactly one thing: whether the redirect lands on
   a vendor-owned HTTPS host. Identity and verification are deliberately
@@ -109,13 +124,13 @@ defmodule Engram.Connections.LogoAllowlist do
   """
   @spec resolve(String.t() | nil, [String.t()] | nil, String.t() | nil) :: entry()
   def resolve(software_id, redirect_uris, client_name \\ nil) do
-    by_id = lookup(software_id)
     by_host = lookup_by_host(redirect_uris)
+    by_id = lookup(software_id)
 
     identity =
       cond do
-        by_id != @empty -> by_id
         by_host != @empty -> by_host
+        by_id != @empty -> by_id
         true -> lookup_by_name(client_name)
       end
 

--- a/lib/engram/connections/logo_allowlist.ex
+++ b/lib/engram/connections/logo_allowlist.ex
@@ -1,22 +1,34 @@
 defmodule Engram.Connections.LogoAllowlist do
   @moduledoc """
-  Identity metadata for OAuth clients. Primary key is the RFC 7591
-  `software_id`, but most MCP clients omit it — so `resolve/2` falls back to
-  matching the `redirect_uri` host against a map of vendor-owned HTTPS hosts.
+  Identity metadata for OAuth clients, and the one rule for verifying them.
 
-  A vendor HTTPS host is un-spoofable for grant delivery (the auth code lands
-  at the vendor, not a forger), so a host match grants `verified: true`. Custom
-  schemes (`cursor://`) and loopback never match the host map.
+  ## Two independent questions
 
-  Unknown ids/hosts return an unverified placeholder so the UI can render an
-  "Unverified client" badge.
+  **Who is this?** Three sources, in precedence order: the RFC 7591
+  `software_id` (most MCP clients omit it), the `redirect_uri` host, and the
+  normalized `client_name`.
+
+  **Can we prove it?** Exactly one source: a vendor-owned HTTPS redirect host.
+  That is un-spoofable for grant delivery: a forger can claim
+  `redirect_uri=https://claude.ai/...`, but the auth code is then delivered to
+  Anthropic, not to them.
+
+  `software_id` and `client_name` both arrive inside the DCR request body, so
+  they are things the client *says about itself*. Neither may grant
+  `verified: true`; they supply identity only. (Tightened 2026-07-30:
+  `software_id` previously granted the badge, which let anyone registering
+  `software_id: "anthropic-claude-desktop"` wear the Claude logo.)
+
+  Loopback and custom schemes (Cursor desktop registers
+  `cursor://anysphere.cursor-mcp/…`) never match the host map, so
+  local-first clients are unverifiable by construction, not misconfigured.
   """
 
   @empty %{verified: false, logo: nil, display_name: nil, slug: nil}
 
   # Keyed on RFC 7591 software_id. `engram-vault-sync` is our own plugin and is
   # the only proven-real entry. The other four are unvalidated guesses left in
-  # place (harmless — real clients never send them) pending observation.
+  # place (harmless, real clients never send them) pending observation.
   @software_id %{
     "engram-vault-sync" => %{
       logo: "/assets/clients/engram-vault-sync.svg",
@@ -41,14 +53,41 @@ defmodule Engram.Connections.LogoAllowlist do
     }
   }
 
-  # Keyed on redirect_uri host. Vendor-owned HTTPS hosts only.
+  # Keyed on redirect_uri host. Vendor-owned HTTPS hosts only. Every entry here
+  # was observed on a real grant (prod, 2026-07-30). Do not add speculative
+  # hosts; an entry that never fires is dead config that reads as coverage.
+  # `logo: nil` where we have no asset yet; the UI falls back to a plug icon.
   @redirect_host %{
     "claude.ai" => %{
       logo: "/assets/clients/claude.svg",
       display_name: "Claude",
       slug: "claude"
-    }
+    },
+    "chatgpt.com" => %{
+      logo: "/assets/clients/chatgpt.svg",
+      display_name: "ChatGPT",
+      slug: "chatgpt"
+    },
+    "grok.com" => %{logo: nil, display_name: "Grok", slug: "grok"},
+    "callback.mistral.ai" => %{logo: nil, display_name: "Mistral", slug: "mistral"},
+    # Antigravity registers as "antigravity-client", which does NOT derive to the
+    # `antigravity` slug; the host is what carries it. Shared by Antigravity 2.0,
+    # the IDE, and the CLI (one documented callback for all three).
+    "antigravity.google" => %{logo: nil, display_name: "Antigravity", slug: "antigravity"}
   }
+
+  # Slugs a client may self-report via `client_name`. `web_only` / `other_mcp`
+  # are questionnaire answers, not products. No client may claim them.
+  @derivable_slugs Engram.Onboarding.valid_tools() -- ~w(web_only other_mcp)
+
+  # Normalized names that don't match their catalog slug. Keys are the exact
+  # string `normalize_name/1` produces, so a `mcp_dcr_unattributed_client` Loki
+  # line can be pasted straight in as a key.
+  #
+  # `visual_studio_code` is INFERRED, not observed: VS Code drives MCP OAuth
+  # itself and registers under the product name, so a Copilot user's grant
+  # arrives as "Visual Studio Code". The tripwire will confirm or refute it.
+  @name_aliases %{"visual_studio_code" => "github_copilot"}
 
   @type entry :: %{
           verified: boolean(),
@@ -57,20 +96,94 @@ defmodule Engram.Connections.LogoAllowlist do
           slug: String.t() | nil
         }
 
-  @doc "Resolve identity from software_id first, then redirect host."
-  @spec resolve(String.t() | nil, [String.t()] | nil) :: entry()
-  def resolve(software_id, redirect_uris) do
-    case lookup(software_id) do
-      %{verified: true} = hit -> hit
-      _ -> lookup_by_host(redirect_uris)
+  @doc """
+  Resolve a client's identity, and separately decide whether it is verified.
+
+  **Identity** (logo / display_name / slug) comes from the first source that
+  matches: `software_id`, then redirect host, then the normalized `client_name`.
+
+  **`verified`** is decided by exactly one thing: whether the redirect lands on
+  a vendor-owned HTTPS host. Identity and verification are deliberately
+  computed independently: `software_id` and `client_name` both arrive in the
+  DCR body and are equally self-asserted, so neither may grant the badge.
+  """
+  @spec resolve(String.t() | nil, [String.t()] | nil, String.t() | nil) :: entry()
+  def resolve(software_id, redirect_uris, client_name \\ nil) do
+    by_id = lookup(software_id)
+    by_host = lookup_by_host(redirect_uris)
+
+    identity =
+      cond do
+        by_id != @empty -> by_id
+        by_host != @empty -> by_host
+        true -> lookup_by_name(client_name)
+      end
+
+    %{identity | verified: by_host != @empty}
+  end
+
+  # Slug-only attribution from the self-asserted `client_name`. UNVERIFIED BY
+  # CONSTRUCTION: this path may set `slug` and nothing else.
+  #
+  # Why it exists: local-first clients (Claude Code, Cursor, Cline, …) redirect
+  # to loopback, which is un-verifiable on purpose (see lookup_by_host/1). Until
+  # this fallback they all resolved to `slug: nil`, so their onboarding
+  # checklist row could never tick. A structural dead end for the whole class,
+  # not a bug in any one connector.
+  #
+  # Rather than hand-feed a vendor map, we normalize the name back into slug
+  # shape and accept it if the catalog already knows that slug. The catalog
+  # slugs were coined from the product names, so this round-trips for
+  # connectors we have never seen ("GitHub Copilot" -> github_copilot).
+  #
+  # The trailing-parenthetical strip is load-bearing: Claude Code registers as
+  # "Claude Code (<mcp-server-name>)", where the suffix is whatever the user
+  # named the server, so an exact match would miss every real installation.
+  #
+  # Spoofing this is not a security boundary; the worst outcome is a user
+  # ticking a row in their own checklist. `verified` and `logo` stay gated on
+  # software_id / vendor host, which is where the real spoofing risk lives.
+  defp lookup_by_name(name) when is_binary(name) do
+    case name |> normalize_name() |> then(&Map.get(@name_aliases, &1, &1)) do
+      slug when slug in @derivable_slugs -> %{@empty | slug: slug}
+      _ -> @empty
     end
   end
 
+  defp lookup_by_name(_), do: @empty
+
+  @doc """
+  Folds a self-asserted `client_name` into slug shape: drops the trailing
+  parenthetical, lowercases, and collapses punctuation to underscores.
+
+  Public because the DCR tripwire logs this form: it is both the key you'd add
+  to `@name_aliases` and, by dropping the parenthetical, free of the user-chosen
+  server name that would otherwise land in Loki.
+  """
+  @spec normalize_name(String.t() | nil) :: String.t()
+  def normalize_name(name) when is_binary(name) do
+    name
+    |> String.replace(~r/\s*\([^)]*\)\s*$/u, "")
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/u, "_")
+    |> String.trim("_")
+  end
+
+  def normalize_name(_), do: ""
+
+  @doc """
+  Identity for a known `software_id`: logo, display_name, slug.
+
+  Never sets `verified`: `software_id` is an RFC 7591 field the client sends
+  about itself, so anyone can register claiming `anthropic-claude-desktop`.
+  Granting the badge on it would let a rogue client wear a vendor's logo in the
+  user's connections list. Only `resolve/3` decides verification, from the host.
+  """
   @spec lookup(String.t() | nil) :: entry()
   def lookup(software_id) when is_binary(software_id) do
     case Map.get(@software_id, software_id) do
       nil -> @empty
-      entry -> Map.merge(%{verified: true}, entry)
+      entry -> Map.merge(@empty, entry)
     end
   end
 
@@ -79,7 +192,7 @@ defmodule Engram.Connections.LogoAllowlist do
   # Only a vendor-owned HTTPS host with no userinfo grants verification. A
   # custom-scheme redirect (`com.evil.app://claude.ai/cb`) or `http://` host
   # parses to host "claude.ai" but delivers the auth code to an attacker-
-  # controlled handler, so the un-spoofability argument does not hold — reject
+  # controlled handler, so the un-spoofability argument does not hold, reject
   # both. Hosts are case-insensitive (RFC 3986 §3.2.2).
   defp lookup_by_host(uris) when is_list(uris) do
     Enum.find_value(uris, @empty, fn uri ->

--- a/lib/engram/oauth.ex
+++ b/lib/engram/oauth.ex
@@ -540,10 +540,51 @@ defmodule Engram.OAuth do
   defp match_redirect_uri(_client, nil), do: {:client_error, "invalid_redirect_uri"}
 
   defp match_redirect_uri(client, uri) do
-    if uri in client.redirect_uris do
+    if uri in client.redirect_uris or loopback_port_match?(client.redirect_uris, uri) do
       {:ok, uri}
     else
       {:client_error, "invalid_redirect_uri"}
+    end
+  end
+
+  # RFC 8252 §7.3: "the authorization server MUST allow any port to be specified
+  # at the time of the request for loopback IP redirect URIs, to accommodate
+  # clients that obtain an available ephemeral port from the operating system at
+  # the time of the request."
+  #
+  # Exact matching is correct everywhere else and stays the first check above.
+  # But a DCR client registers once and persists its client_id, while asking the
+  # OS for a fresh ephemeral port on every launch. Without this, every
+  # local-first connector (Claude Code, Cline, OpenCode, Cursor, Windsurf) works
+  # on first run and fails on the second with invalid_redirect_uri.
+  #
+  # The exemption is scoped to `http` + a loopback host, and covers ONLY the
+  # port: host, path and query must still match exactly. Extending it to https
+  # would let anyone who controls any port on a registered host collect auth
+  # codes. On loopback that concern does not apply the same way, since reaching
+  # the port at all means already being on the user's machine, and PKCE still
+  # binds the code to the request that started it.
+  defp loopback_port_match?(registered, uri) do
+    case loopback_identity(uri) do
+      nil -> false
+      identity -> Enum.any?(registered, &(loopback_identity(&1) == identity))
+    end
+  end
+
+  # Everything identifying a loopback redirect except its port, or nil when the
+  # URI is not an http loopback one (which disables the exemption entirely).
+  #
+  # The whole parsed URI is compared with the port blanked, rather than a
+  # hand-listed subset of fields: that keeps userinfo and fragment significant
+  # (`http://evil@127.0.0.1/cb` must not match `http://127.0.0.1/cb`) and cannot
+  # silently widen if URI ever grows a field.
+  defp loopback_identity(uri) do
+    case URI.new(uri) do
+      {:ok, %URI{scheme: "http", host: host} = parsed} ->
+        if Client.loopback_host?(host), do: %{parsed | port: nil}
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/engram/oauth.ex
+++ b/lib/engram/oauth.ex
@@ -18,6 +18,7 @@ defmodule Engram.OAuth do
 
   @code_bytes 32
   @code_ttl_seconds 600
+  @max_state_bytes 2048
   @refresh_token_prefix "engram_oauth_rt_"
   @refresh_token_bytes 32
   @refresh_token_ttl_days 90
@@ -25,11 +26,42 @@ defmodule Engram.OAuth do
 
   # ── Clients (Phase 2) ────────────────────────────────────────────
 
+  @client_secret_prefix "engram_oauth_cs_"
+  @client_secret_bytes 32
+
+  @doc """
+  Registers a DCR client.
+
+  A confidential registration (`client_secret_post` / `client_secret_basic`)
+  mints a secret here rather than in the changeset, because the plaintext must
+  reach the caller exactly once while only its hash is stored. The returned
+  struct carries the plaintext on the virtual `:client_secret` field; reloading
+  the row later yields `nil` there, by design.
+  """
   def register_client(attrs) do
-    %Client{}
-    |> Client.registration_changeset(attrs)
+    changeset = Client.registration_changeset(%Client{}, attrs)
+    secret = mint_client_secret(Ecto.Changeset.get_field(changeset, :token_endpoint_auth_method))
+
+    changeset
+    |> maybe_put_secret_hash(secret)
     |> Repo.insert(skip_tenant_check: true)
+    |> case do
+      {:ok, client} -> {:ok, %{client | client_secret: secret}}
+      other -> other
+    end
   end
+
+  defp mint_client_secret(method) do
+    if Client.confidential?(method) do
+      @client_secret_prefix <>
+        Base.url_encode64(:crypto.strong_rand_bytes(@client_secret_bytes), padding: false)
+    end
+  end
+
+  defp maybe_put_secret_hash(changeset, nil), do: changeset
+
+  defp maybe_put_secret_hash(changeset, secret),
+    do: Ecto.Changeset.put_change(changeset, :client_secret_hash, hash_code(secret))
 
   def get_client(client_id) when is_binary(client_id) do
     case Ecto.UUID.cast(client_id) do
@@ -47,6 +79,43 @@ defmodule Engram.OAuth do
   end
 
   def get_client(_), do: {:error, :not_found}
+
+  @doc """
+  Authenticates the client on a token request, per RFC 6749 §3.2.1.
+
+  The registered `token_endpoint_auth_method` binds in BOTH directions: a
+  confidential client must present its secret, and a client registered `none`
+  must not. Accepting a secret from a public client would make the registered
+  method decorative and mask a confused or probing caller.
+
+  `secret` is whatever the caller supplied (HTTP Basic or request body), or
+  `nil`. Comparison is constant-time against the stored hash.
+  """
+  @spec authenticate_client(String.t() | nil, String.t() | nil) ::
+          :ok | {:error, :invalid_client}
+  def authenticate_client(client_id, secret) do
+    case get_client(client_id) do
+      {:ok, client} -> check_client_secret(client, secret)
+      # Unknown client_id is indistinguishable from a bad secret on purpose.
+      {:error, :not_found} -> {:error, :invalid_client}
+    end
+  end
+
+  defp check_client_secret(client, secret) do
+    cond do
+      not Client.confidential?(client.token_endpoint_auth_method) ->
+        if is_nil(secret), do: :ok, else: {:error, :invalid_client}
+
+      is_nil(secret) or is_nil(client.client_secret_hash) ->
+        {:error, :invalid_client}
+
+      Plug.Crypto.secure_compare(hash_code(secret), client.client_secret_hash) ->
+        :ok
+
+      true ->
+        {:error, :invalid_client}
+    end
+  end
 
   # ── Authorization codes (Phase 3) ────────────────────────────────
 
@@ -66,6 +135,7 @@ defmodule Engram.OAuth do
          {:ok, redirect_uri} <- match_redirect_uri(client, params["redirect_uri"]),
          :ok <- check_response_type(params, redirect_uri),
          :ok <- check_pkce(params, redirect_uri),
+         :ok <- check_state_length(params),
          :ok <- check_scope(params, redirect_uri) do
       {:ok,
        %{
@@ -82,6 +152,23 @@ defmodule Engram.OAuth do
   end
 
   def validate_authorization_request(_), do: {:client_error, "invalid_request"}
+
+  # RFC 6749 puts no bound on `state`, and clients legitimately pack routing
+  # data into it (Windsurf's exceeded 255 and 500'd us on 2026-07-30, because
+  # the column was varchar(255)). The column is `text` now, but "no column
+  # limit" must not become "unbounded storage": consent is reachable by any
+  # signed-in user and a code row lives for the full TTL. 2048 is generous
+  # enough for every real client and still bounded.
+  #
+  # A `client_error` rather than a redirect: bouncing an oversized state back
+  # through the redirect would just move the problem to the client's URL parser.
+  defp check_state_length(%{"state" => state}) when is_binary(state) do
+    if byte_size(state) > @max_state_bytes,
+      do: {:client_error, "invalid_request"},
+      else: :ok
+  end
+
+  defp check_state_length(_), do: :ok
 
   @doc """
   Mints an authorization code for a validated request + a vault selection.

--- a/lib/engram/oauth/client.ex
+++ b/lib/engram/oauth/client.ex
@@ -1,8 +1,12 @@
 defmodule Engram.OAuth.Client do
   @moduledoc """
   Schema for an OAuth 2.1 client registered via Dynamic Client Registration
-  (RFC 7591). Public clients (PKCE-only) carry no secret. Confidential
-  clients are not used today but the schema accommodates them.
+  (RFC 7591).
+
+  Public clients (PKCE-only) carry no secret. Confidential clients
+  (`client_secret_post` / `client_secret_basic`) are minted a secret at
+  registration and authenticate at the token endpoint; server-side connectors
+  such as LobeHub cloud require one. PKCE is mandatory for both.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -10,16 +14,26 @@ defmodule Engram.OAuth.Client do
   require Logger
 
   @primary_key {:client_id, :binary_id, autogenerate: true}
-  # Only public PKCE clients are supported until confidential-client minting
-  # ships (Phase 4). Reject client_secret_* to avoid handing back a 201 with
-  # no secret — a broken half-state for the caller.
-  @valid_auth_methods ~w(none)
+  # Public PKCE clients (`none`) and confidential clients. A confidential
+  # registration mints a secret in `Engram.OAuth.register_client/1`, so the 201
+  # always carries one; the earlier restriction to `none` existed only because
+  # nothing minted secrets, and it made server-side connectors (LobeHub cloud)
+  # unregisterable rather than merely unverified.
+  #
+  # PKCE stays mandatory for BOTH. A secret authenticates the client; PKCE binds
+  # the code to the request that started it. They are not substitutes.
+  @valid_auth_methods ~w(none client_secret_post client_secret_basic)
+  @confidential_auth_methods ~w(client_secret_post client_secret_basic)
   @valid_grant_types ~w(authorization_code refresh_token)
   @valid_response_types ~w(code)
   @loopback_hosts ~w(localhost 127.0.0.1 ::1)
 
   schema "oauth_clients" do
     field :client_secret_hash, :string
+    # Plaintext, returned in the registration response and never again. Virtual
+    # so it cannot be persisted or read back: a client that loses its secret
+    # re-registers.
+    field :client_secret, :string, virtual: true
     field :redirect_uris, {:array, :string}
     field :client_name, :string
     field :scope, :string
@@ -52,6 +66,10 @@ defmodule Engram.OAuth.Client do
                   kind first_user_agent first_ip)a
 
   @metadata_uri_fields ~w(logo_uri tos_uri policy_uri)a
+
+  @doc "True when the registered auth method requires a client secret."
+  @spec confidential?(String.t() | nil) :: boolean()
+  def confidential?(method), do: method in @confidential_auth_methods
 
   def registration_changeset(client, attrs) do
     client
@@ -184,15 +202,26 @@ defmodule Engram.OAuth.Client do
       {:ok, %URI{scheme: scheme}} when scheme in ["javascript", "data", "file"] ->
         [redirect_uris: "unsafe scheme #{scheme}: #{uri}"]
 
-      {:ok, %URI{scheme: scheme, host: host}} when is_binary(scheme) and scheme != "" ->
-        # Native app custom scheme (e.g. com.cursor.app://callback). Must
-        # have a reverse-DNS-like dot in the scheme to avoid weak schemes
-        # like `myapp://` per RFC 8252 §7.1.
-        if String.contains?(scheme, ".") or host in @loopback_hosts do
-          []
-        else
-          [redirect_uris: "weak custom scheme #{scheme}: #{uri}"]
-        end
+      {:ok, %URI{scheme: scheme}} when is_binary(scheme) and scheme != "" ->
+        # Native-app custom scheme (`cursor://…`, `com.cursor.app://…`).
+        #
+        # We previously required a reverse-DNS dot in the scheme, citing
+        # RFC 8252 §7.1. That section obliges *apps* to choose such a scheme;
+        # it does not ask authorization servers to reject the ones that don't,
+        # and enforcing it turned real clients away at registration (observed
+        # 2026-07-30: Cursor desktop registers `cursor://`).
+        #
+        # The dot bought less than it looked like. It never made a scheme
+        # exclusive: any app can claim `com.foo://` as easily as `foo://`, so it
+        # lowered accidental-collision odds, not deliberate squatting.
+        # The real defence against a squatter intercepting the redirect is
+        # PKCE, which RFC 8252 mandates for exactly this reason and which we
+        # require unconditionally: an interceptor gets a code it cannot
+        # redeem without the verifier.
+        #
+        # Custom schemes remain permanently unverifiable (see
+        # Connections.LogoAllowlist). This admits them; it does not trust them.
+        []
 
       _ ->
         [redirect_uris: "invalid URI: #{uri}"]

--- a/lib/engram/oauth/client.ex
+++ b/lib/engram/oauth/client.ex
@@ -71,6 +71,17 @@ defmodule Engram.OAuth.Client do
   @spec confidential?(String.t() | nil) :: boolean()
   def confidential?(method), do: method in @confidential_auth_methods
 
+  @doc """
+  True for the loopback hosts RFC 8252 §7.3 permits over plain `http`.
+
+  Shared with `Engram.OAuth.match_redirect_uri/2`, which grants those hosts a
+  port exemption at authorization time. Registration and authorization must
+  agree on what counts as loopback: if this list drifted between them, a URI
+  could be accepted at DCR and then rejected on every authorize.
+  """
+  @spec loopback_host?(String.t() | nil) :: boolean()
+  def loopback_host?(host), do: host in @loopback_hosts
+
   def registration_changeset(client, attrs) do
     client
     |> cast(attrs, @cast_fields)
@@ -193,11 +204,18 @@ defmodule Engram.OAuth.Client do
       {:ok, %URI{scheme: "https", host: host}} when is_binary(host) and host != "" ->
         []
 
-      {:ok, %URI{scheme: "http", host: host}} when host in @loopback_hosts ->
-        []
+      # `https:///cb` and `https:foo` parse with scheme "https" and a nil/empty
+      # host, so they miss the clause above. Without this they would reach the
+      # permissive custom-scheme branch and be admitted as if "https" were a
+      # native-app scheme. Admitting custom schemes must not silently admit a
+      # well-known scheme with its host missing.
+      {:ok, %URI{scheme: "https"}} ->
+        [redirect_uris: "missing host: #{uri}"]
 
-      {:ok, %URI{scheme: "http"}} ->
-        [redirect_uris: "non-loopback http is not allowed: #{uri}"]
+      {:ok, %URI{scheme: "http", host: host}} ->
+        if loopback_host?(host),
+          do: [],
+          else: [redirect_uris: "non-loopback http is not allowed: #{uri}"]
 
       {:ok, %URI{scheme: scheme}} when scheme in ["javascript", "data", "file"] ->
         [redirect_uris: "unsafe scheme #{scheme}: #{uri}"]

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -5,7 +5,7 @@ defmodule Engram.Onboarding do
   Onboarding runs for every account. The only toggle is `:billing_enabled`,
   which gates the hosted-only steps: agreement (ToS) and billing (Paddle).
   When false (self-host: AUTH_PROVIDER=local + no PADDLE_API_KEY), the wizard
-  still runs but treats `terms_ok` and `subscription_ok` as auto-pass, the
+  still runs but treats `terms_ok` and `subscription_ok` as auto-pass — the
   operator owns their own legal posture and there is no paywall. The `:vault`
   step (questionnaire + first vault) gates in every mode.
   """
@@ -23,11 +23,14 @@ defmodule Engram.Onboarding do
 
   # FTUX questionnaire tool catalog. Add new clients here in lockstep with
   # the frontend constants (see frontend/src/onboarding/onboarding-tools.ts).
-  # Renames are MIGRATIONS, old slugs in user rows won't be auto-rewritten.
+  # Renames are MIGRATIONS — old slugs in user rows won't be auto-rewritten.
+  #
   # No `gemini` entry on purpose: the consumer Gemini app cannot add a custom
   # remote MCP server (that is Gemini Enterprise / Antigravity only), so the row
-  # would be uncompletable. Antigravity is Google's supported MCP path, it
-  # superseded Gemini CLI for Pro/Ultra/free tiers on 2026-06-18.
+  # would be uncompletable. Antigravity is Google's supported MCP path; it
+  # superseded Gemini CLI for Pro/Ultra/free tiers on 2026-06-18. The frontend
+  # lists a disabled `gemini` row to say so, and its absence here means that
+  # slug can never reach a profile even if the UI is bypassed.
   @valid_tools ~w(
     claude chatgpt grok mistral open_webui lobechat
     claude_code cursor windsurf cline continue opencode github_copilot antigravity
@@ -131,15 +134,15 @@ defmodule Engram.Onboarding do
   @doc """
   Compute the onboarding state for a user. Returns a map with:
 
-    * `:enabled`, true when billing (and therefore the wizard) is active
-    * `:terms_ok`, latest accepted ToS version satisfies the computed floor
-    * `:subscription_ok`, user has trialing/active/past_due subscription
-    * `:current_tos_version`, latest published ToS version (from `terms_versions`)
-    * `:current_privacy_version`, latest published Privacy version
-    * `:terms_notice`, metadata for the newest published ToS version the user
+    * `:enabled` — true when billing (and therefore the wizard) is active
+    * `:terms_ok` — latest accepted ToS version satisfies the computed floor
+    * `:subscription_ok` — user has trialing/active/past_due subscription
+    * `:current_tos_version` — latest published ToS version (from `terms_versions`)
+    * `:current_privacy_version` — latest published Privacy version
+    * `:terms_notice` — metadata for the newest published ToS version the user
       has not yet accepted (version/effective_date/material/changelog/accept_url),
       or `nil` when the user is already on the current version
-    * `:next_step`, one of `:agreement | :billing | :tools | :vault | :done`
+    * `:next_step` — one of `:agreement | :billing | :tools | :vault | :done`
 
   The gate is computed from the `terms_versions` table via
   `Engram.Legal.VersionCache`: `terms_ok` compares the user's latest accepted
@@ -155,7 +158,7 @@ defmodule Engram.Onboarding do
   short-circuit to ok and the chain falls through to tools → vault. The
   `:tools` step collects the questionnaire's tool checkboxes; `:vault`
   owns the obsidian/fresh source pick + first-vault creation.
-  `:enabled` is always true, every account onboards.
+  `:enabled` is always true — every account onboards.
   """
   def status(user) do
     billing_active = Application.get_env(:engram, :billing_enabled, false)
@@ -201,7 +204,7 @@ defmodule Engram.Onboarding do
     if billing_active, do: [:agreement, :billing, :tools, :vault], else: [:tools, :vault]
   end
 
-  # Self-host (billing_enabled=false) doesn't run a ToS gate, operators own
+  # Self-host (billing_enabled=false) doesn't run a ToS gate — operators own
   # their legal posture. Hosted mode performs the real cache-backed check.
   defp terms_state(_user, false), do: {true, nil, nil, nil}
 
@@ -219,7 +222,7 @@ defmodule Engram.Onboarding do
   POSTs once per screen (tools from `/onboard/tools`, uses_obsidian from
   `/onboard/vault`), so this accepts either field independently or both
   together. `completed_at` stamps the moment BOTH `tools` and
-  `uses_obsidian` are present after the merge, that's the signal
+  `uses_obsidian` are present after the merge — that's the signal
   `profile_complete?/1` keys on.
 
   Validates only the fields actually being set: `tools` must be a non-empty
@@ -264,7 +267,7 @@ defmodule Engram.Onboarding do
         |> Repo.update(skip_tenant_check: true)
         |> tap(fn
           # uses_obsidian flips can re-arm the vault gate for a passed
-          # user, drop the cached verdict so the plug re-derives.
+          # user — drop the cached verdict so the plug re-derives.
           {:ok, _} -> Engram.Onboarding.GateCache.evict(user.id)
           _ -> :ok
         end)
@@ -293,7 +296,7 @@ defmodule Engram.Onboarding do
     end
   end
 
-  # Re-read the column rather than trusting the caller's struct, callers that
+  # Re-read the column rather than trusting the caller's struct — callers that
   # just ran `set_profile/2` and then `status/1` would otherwise see a stale
   # `nil` and the gate would stick on `:vault` even after a successful save.
   defp current_profile(user) do
@@ -379,7 +382,7 @@ defmodule Engram.Onboarding do
     # (the `vault_populated` channel broadcast then unblocks the wizard). Note
     # the asymmetry with `RequireOnboarding`: the plug still SKIPS the vault
     # gate for `uses_obsidian=true` so the plugin can actually push that first
-    # sync, runtime permission and wizard navigation are intentionally
+    # sync — runtime permission and wizard navigation are intentionally
     # separated. See `EngramWeb.Plugs.RequireOnboarding`.
     if has_vault, do: :done, else: :vault
   end
@@ -402,7 +405,7 @@ defmodule Engram.Onboarding do
   end
 
   @doc """
-  Record an onboarding milestone for `user_id`. Idempotent, re-recording the
+  Record an onboarding milestone for `user_id`. Idempotent — re-recording the
   same action returns `:ok` with no extra row. Returns `{:error, changeset}`
   only on enum/validation failure.
   """

--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -5,7 +5,7 @@ defmodule Engram.Onboarding do
   Onboarding runs for every account. The only toggle is `:billing_enabled`,
   which gates the hosted-only steps: agreement (ToS) and billing (Paddle).
   When false (self-host: AUTH_PROVIDER=local + no PADDLE_API_KEY), the wizard
-  still runs but treats `terms_ok` and `subscription_ok` as auto-pass — the
+  still runs but treats `terms_ok` and `subscription_ok` as auto-pass, the
   operator owns their own legal posture and there is no paywall. The `:vault`
   step (questionnaire + first vault) gates in every mode.
   """
@@ -23,10 +23,14 @@ defmodule Engram.Onboarding do
 
   # FTUX questionnaire tool catalog. Add new clients here in lockstep with
   # the frontend constants (see frontend/src/onboarding/onboarding-tools.ts).
-  # Renames are MIGRATIONS — old slugs in user rows won't be auto-rewritten.
+  # Renames are MIGRATIONS, old slugs in user rows won't be auto-rewritten.
+  # No `gemini` entry on purpose: the consumer Gemini app cannot add a custom
+  # remote MCP server (that is Gemini Enterprise / Antigravity only), so the row
+  # would be uncompletable. Antigravity is Google's supported MCP path, it
+  # superseded Gemini CLI for Pro/Ultra/free tiers on 2026-06-18.
   @valid_tools ~w(
     claude chatgpt grok mistral open_webui lobechat
-    claude_code cursor windsurf cline continue opencode github_copilot
+    claude_code cursor windsurf cline continue opencode github_copilot antigravity
     web_only other_mcp
   )
 
@@ -127,15 +131,15 @@ defmodule Engram.Onboarding do
   @doc """
   Compute the onboarding state for a user. Returns a map with:
 
-    * `:enabled` — true when billing (and therefore the wizard) is active
-    * `:terms_ok` — latest accepted ToS version satisfies the computed floor
-    * `:subscription_ok` — user has trialing/active/past_due subscription
-    * `:current_tos_version` — latest published ToS version (from `terms_versions`)
-    * `:current_privacy_version` — latest published Privacy version
-    * `:terms_notice` — metadata for the newest published ToS version the user
+    * `:enabled`, true when billing (and therefore the wizard) is active
+    * `:terms_ok`, latest accepted ToS version satisfies the computed floor
+    * `:subscription_ok`, user has trialing/active/past_due subscription
+    * `:current_tos_version`, latest published ToS version (from `terms_versions`)
+    * `:current_privacy_version`, latest published Privacy version
+    * `:terms_notice`, metadata for the newest published ToS version the user
       has not yet accepted (version/effective_date/material/changelog/accept_url),
       or `nil` when the user is already on the current version
-    * `:next_step` — one of `:agreement | :billing | :tools | :vault | :done`
+    * `:next_step`, one of `:agreement | :billing | :tools | :vault | :done`
 
   The gate is computed from the `terms_versions` table via
   `Engram.Legal.VersionCache`: `terms_ok` compares the user's latest accepted
@@ -151,7 +155,7 @@ defmodule Engram.Onboarding do
   short-circuit to ok and the chain falls through to tools → vault. The
   `:tools` step collects the questionnaire's tool checkboxes; `:vault`
   owns the obsidian/fresh source pick + first-vault creation.
-  `:enabled` is always true — every account onboards.
+  `:enabled` is always true, every account onboards.
   """
   def status(user) do
     billing_active = Application.get_env(:engram, :billing_enabled, false)
@@ -197,7 +201,7 @@ defmodule Engram.Onboarding do
     if billing_active, do: [:agreement, :billing, :tools, :vault], else: [:tools, :vault]
   end
 
-  # Self-host (billing_enabled=false) doesn't run a ToS gate — operators own
+  # Self-host (billing_enabled=false) doesn't run a ToS gate, operators own
   # their legal posture. Hosted mode performs the real cache-backed check.
   defp terms_state(_user, false), do: {true, nil, nil, nil}
 
@@ -215,7 +219,7 @@ defmodule Engram.Onboarding do
   POSTs once per screen (tools from `/onboard/tools`, uses_obsidian from
   `/onboard/vault`), so this accepts either field independently or both
   together. `completed_at` stamps the moment BOTH `tools` and
-  `uses_obsidian` are present after the merge — that's the signal
+  `uses_obsidian` are present after the merge, that's the signal
   `profile_complete?/1` keys on.
 
   Validates only the fields actually being set: `tools` must be a non-empty
@@ -260,7 +264,7 @@ defmodule Engram.Onboarding do
         |> Repo.update(skip_tenant_check: true)
         |> tap(fn
           # uses_obsidian flips can re-arm the vault gate for a passed
-          # user — drop the cached verdict so the plug re-derives.
+          # user, drop the cached verdict so the plug re-derives.
           {:ok, _} -> Engram.Onboarding.GateCache.evict(user.id)
           _ -> :ok
         end)
@@ -289,7 +293,7 @@ defmodule Engram.Onboarding do
     end
   end
 
-  # Re-read the column rather than trusting the caller's struct — callers that
+  # Re-read the column rather than trusting the caller's struct, callers that
   # just ran `set_profile/2` and then `status/1` would otherwise see a stale
   # `nil` and the gate would stick on `:vault` even after a successful save.
   defp current_profile(user) do
@@ -375,7 +379,7 @@ defmodule Engram.Onboarding do
     # (the `vault_populated` channel broadcast then unblocks the wizard). Note
     # the asymmetry with `RequireOnboarding`: the plug still SKIPS the vault
     # gate for `uses_obsidian=true` so the plugin can actually push that first
-    # sync — runtime permission and wizard navigation are intentionally
+    # sync, runtime permission and wizard navigation are intentionally
     # separated. See `EngramWeb.Plugs.RequireOnboarding`.
     if has_vault, do: :done, else: :vault
   end
@@ -398,7 +402,7 @@ defmodule Engram.Onboarding do
   end
 
   @doc """
-  Record an onboarding milestone for `user_id`. Idempotent — re-recording the
+  Record an onboarding milestone for `user_id`. Idempotent, re-recording the
   same action returns `:ok` with no extra row. Returns `{:error, changeset}`
   only on enum/validation failure.
   """

--- a/lib/engram_web/controllers/oauth_register_controller.ex
+++ b/lib/engram_web/controllers/oauth_register_controller.ex
@@ -2,7 +2,7 @@ defmodule EngramWeb.OAuthRegisterController do
   @moduledoc """
   RFC 7591 Dynamic Client Registration. Public, rate-limited.
 
-  Mints public PKCE clients by default — `token_endpoint_auth_method=none`
+  Mints public PKCE clients by default, `token_endpoint_auth_method=none`
   with no `client_secret`. Confidential clients can be requested but are
   not yet supported (no secret minting wired up); validation rejects
   `client_secret_post` / `client_secret_basic` to keep the surface
@@ -10,8 +10,12 @@ defmodule EngramWeb.OAuthRegisterController do
   """
   use EngramWeb, :controller
 
+  alias Engram.Connections.LogoAllowlist
+  alias Engram.Logger.Metadata
   alias Engram.OAuth
   alias EngramWeb.RequestMeta
+
+  require Logger
 
   @telemetry_event [:engram, :mcp, :dcr, :register]
 
@@ -24,6 +28,7 @@ defmodule EngramWeb.OAuthRegisterController do
     case OAuth.register_client(enriched) do
       {:ok, client} ->
         emit_telemetry(:ok, client.client_id, client.software_id, client.kind)
+        log_unattributed(client)
 
         conn
         |> put_status(:created)
@@ -38,12 +43,59 @@ defmodule EngramWeb.OAuthRegisterController do
         )
 
         {error, description} = changeset_error(changeset)
+        log_rejected(changeset, description)
 
         conn
         |> put_status(:bad_request)
         |> json(%{error: error, error_description: description})
     end
   end
+
+  # A rejected registration is a connector that cannot connect AT ALL, and the
+  # only record of why lives in this request. Telemetry alone carries no
+  # `token_endpoint_auth_method`, so a client asking for a confidential
+  # registration (which we do not mint) failed silently from our side while the
+  # vendor surfaced our error as their own 500. Log enough to identify the
+  # client and the metadata it wanted.
+  #
+  # `:lifecycle` because `:auth` info does not ship to Loki (see
+  # Engram.Logger.Category). Name is normalized, so no user-chosen suffix leaks.
+  defp log_rejected(changeset, description) do
+    Logger.warning(
+      "mcp_dcr_rejected",
+      Metadata.with_category(:warning, :lifecycle,
+        normalized_name:
+          changeset |> Ecto.Changeset.get_field(:client_name) |> LogoAllowlist.normalize_name(),
+        requested_auth_method: Ecto.Changeset.get_field(changeset, :token_endpoint_auth_method),
+        software_id: Ecto.Changeset.get_field(changeset, :software_id),
+        reason: description
+      )
+    )
+  end
+
+  # The DCR body is the only place a client's self-reported identity exists.
+  # no vendor publishes these strings. When one resolves to no slug, its
+  # onboarding checklist row cannot tick, so record the normalized name and let
+  # prod tell us what to add to `@name_aliases` instead of guessing.
+  #
+  # Logs the NORMALIZED name deliberately: it drops the user-chosen server
+  # suffix ("Claude Code (my-private-project)"), so nothing personal ships.
+  defp log_unattributed(%{kind: "mcp"} = client) do
+    identity = LogoAllowlist.resolve(client.software_id, client.redirect_uris, client.client_name)
+
+    if is_nil(identity.slug) do
+      Logger.info(
+        "mcp_dcr_unattributed_client",
+        Metadata.with_category(:info, :lifecycle,
+          normalized_name: LogoAllowlist.normalize_name(client.client_name),
+          redirect_uris: client.redirect_uris,
+          software_id: client.software_id
+        )
+      )
+    end
+  end
+
+  defp log_unattributed(_), do: :ok
 
   defp emit_telemetry(result, client_id, software_id, kind) do
     :telemetry.execute(@telemetry_event, %{count: 1}, %{
@@ -64,6 +116,11 @@ defmodule EngramWeb.OAuthRegisterController do
       grant_types: client.grant_types,
       response_types: client.response_types,
       token_endpoint_auth_method: client.token_endpoint_auth_method,
+      client_secret: client.client_secret,
+      # RFC 7591 §3.2.1: REQUIRED whenever a client_secret is issued. 0 means
+      # the secret does not expire. Map.reject below drops it for public
+      # clients, where there is no secret to describe.
+      client_secret_expires_at: client.client_secret && 0,
       software_id: client.software_id,
       software_version: client.software_version,
       logo_uri: client.logo_uri,
@@ -90,7 +147,7 @@ defmodule EngramWeb.OAuthRegisterController do
       # Only stringify when the placeholder is actually present. A failed cast
       # (e.g. a JSON string where an array is expected) carries opts like
       # `type: {:array, :string}` whose message ("is invalid") has no
-      # placeholder — eagerly to_string-ing that tuple is what crashed (500).
+      # placeholder, eagerly to_string-ing that tuple is what crashed (500).
       if String.contains?(acc, placeholder) do
         String.replace(acc, placeholder, to_string(value))
       else

--- a/lib/engram_web/controllers/oauth_register_controller.ex
+++ b/lib/engram_web/controllers/oauth_register_controller.ex
@@ -3,10 +3,9 @@ defmodule EngramWeb.OAuthRegisterController do
   RFC 7591 Dynamic Client Registration. Public, rate-limited.
 
   Mints public PKCE clients by default, `token_endpoint_auth_method=none`
-  with no `client_secret`. Confidential clients can be requested but are
-  not yet supported (no secret minting wired up); validation rejects
-  `client_secret_post` / `client_secret_basic` to keep the surface
-  small until Phase 4 needs it.
+  with no `client_secret`. A client that asks for `client_secret_post` or
+  `client_secret_basic` is minted a secret, returned once in the 201 and
+  stored only as a hash. PKCE is required either way.
   """
   use EngramWeb, :controller
 
@@ -73,13 +72,20 @@ defmodule EngramWeb.OAuthRegisterController do
     )
   end
 
-  # The DCR body is the only place a client's self-reported identity exists.
+  # The DCR body is the only place a client's self-reported identity exists;
   # no vendor publishes these strings. When one resolves to no slug, its
   # onboarding checklist row cannot tick, so record the normalized name and let
   # prod tell us what to add to `@name_aliases` instead of guessing.
   #
-  # Logs the NORMALIZED name deliberately: it drops the user-chosen server
-  # suffix ("Claude Code (my-private-project)"), so nothing personal ships.
+  # Everything logged here is deliberately de-identified:
+  #
+  #   * the NORMALIZED name, which drops the user-chosen server suffix
+  #     ("Claude Code (my-private-project)"), and
+  #   * scheme + host only, never the full redirect. A self-hosted client
+  #     redirects to the operator's own domain with a path that can carry
+  #     instance detail, and RequestLogger already redacts request paths, so
+  #     shipping whole URIs here would undercut that. Scheme + host is all the
+  #     classification (vendor / loopback / self-hosted) actually needs.
   defp log_unattributed(%{kind: "mcp"} = client) do
     identity = LogoAllowlist.resolve(client.software_id, client.redirect_uris, client.client_name)
 
@@ -88,7 +94,7 @@ defmodule EngramWeb.OAuthRegisterController do
         "mcp_dcr_unattributed_client",
         Metadata.with_category(:info, :lifecycle,
           normalized_name: LogoAllowlist.normalize_name(client.client_name),
-          redirect_uris: client.redirect_uris,
+          redirect_origins: redirect_origins(client.redirect_uris),
           software_id: client.software_id
         )
       )
@@ -96,6 +102,17 @@ defmodule EngramWeb.OAuthRegisterController do
   end
 
   defp log_unattributed(_), do: :ok
+
+  defp redirect_origins(uris) when is_list(uris) do
+    Enum.map(uris, fn uri ->
+      case URI.new(uri) do
+        {:ok, %URI{scheme: scheme, host: host}} -> "#{scheme}://#{host}"
+        _ -> "unparseable"
+      end
+    end)
+  end
+
+  defp redirect_origins(_), do: []
 
   defp emit_telemetry(result, client_id, software_id, kind) do
     :telemetry.execute(@telemetry_event, %{count: 1}, %{

--- a/lib/engram_web/controllers/oauth_token_controller.ex
+++ b/lib/engram_web/controllers/oauth_token_controller.ex
@@ -11,26 +11,40 @@ defmodule EngramWeb.OAuthTokenController do
   alias EngramWeb.RequestMeta
 
   def exchange(conn, %{"grant_type" => "authorization_code"} = params) do
-    ip = RequestMeta.format_ip(conn.remote_ip)
+    with {:ok, client_id, secret} <- client_credentials(conn, params),
+         :ok <- OAuth.authenticate_client(client_id, secret) do
+      ip = RequestMeta.format_ip(conn.remote_ip)
 
-    case OAuth.exchange_authorization_code(params, ip: ip) do
-      {:ok, response} ->
-        json(conn, response)
+      # Feed back the RESOLVED client_id: it may have arrived via HTTP Basic
+      # rather than the body, and the grant check compares the code's client
+      # against this param. Reading the body directly would fail every
+      # Basic-authenticated exchange that omits the redundant body field.
+      case OAuth.exchange_authorization_code(Map.put(params, "client_id", client_id), ip: ip) do
+        {:ok, response} ->
+          json(conn, response)
 
-      {:error, _reason} ->
-        conn
-        |> put_status(:bad_request)
-        |> json(%{error: "invalid_grant"})
+        {:error, _reason} ->
+          conn
+          |> put_status(:bad_request)
+          |> json(%{error: "invalid_grant"})
+      end
+    else
+      {:error, :invalid_client} -> invalid_client(conn)
     end
   end
 
   def exchange(conn, %{"grant_type" => "refresh_token"} = params) do
-    case params["refresh_token"] do
-      raw when is_binary(raw) and raw != "" ->
-        do_refresh(conn, raw, params["client_id"])
+    with {:ok, client_id, secret} <- client_credentials(conn, params),
+         :ok <- OAuth.authenticate_client(client_id, secret) do
+      case params["refresh_token"] do
+        raw when is_binary(raw) and raw != "" ->
+          do_refresh(conn, raw, client_id)
 
-      _ ->
-        invalid_request(conn)
+        _ ->
+          invalid_request(conn)
+      end
+    else
+      {:error, :invalid_client} -> invalid_client(conn)
     end
   end
 
@@ -53,6 +67,50 @@ defmodule EngramWeb.OAuthTokenController do
         conn
         |> put_status(:bad_request)
         |> json(%{error: "invalid_grant"})
+    end
+  end
+
+  # RFC 6749 §2.3.1: the Basic header is the preferred channel, the body is the
+  # `client_secret_post` alternative. A caller must not use both at once, since
+  # the two could disagree and we would have to pick a winner silently.
+  defp client_credentials(conn, params) do
+    body_id = blank_to_nil(params["client_id"])
+    body_secret = blank_to_nil(params["client_secret"])
+
+    case Plug.BasicAuth.parse_basic_auth(conn) do
+      {basic_id, basic_secret} ->
+        if is_nil(body_secret) and (is_nil(body_id) or body_id == basic_id) do
+          {:ok, blank_to_nil(basic_id), blank_to_nil(basic_secret)}
+        else
+          {:error, :invalid_client}
+        end
+
+      :error ->
+        {:ok, body_id, body_secret}
+    end
+  end
+
+  # An empty secret is "no secret", not "the secret is the empty string".
+  # Some OAuth libraries send `Basic base64("client_id:")` for public clients;
+  # treating that as a presented credential would reject them, because a public
+  # client presenting a secret is refused. Costs nothing: "" can never match a
+  # stored hash, so a confidential client is still rejected either way.
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
+
+  # RFC 6749 §5.2: failed client authentication is 401, and a request that used
+  # the Authorization header gets a WWW-Authenticate challenge back.
+  defp invalid_client(conn) do
+    conn
+    |> maybe_challenge()
+    |> put_status(:unauthorized)
+    |> json(%{error: "invalid_client"})
+  end
+
+  defp maybe_challenge(conn) do
+    case get_req_header(conn, "authorization") do
+      ["Basic " <> _ | _] -> put_resp_header(conn, "www-authenticate", ~s(Basic realm="oauth"))
+      _ -> conn
     end
   end
 

--- a/lib/engram_web/controllers/well_known_controller.ex
+++ b/lib/engram_web/controllers/well_known_controller.ex
@@ -63,7 +63,11 @@ defmodule EngramWeb.WellKnownController do
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code", "refresh_token"],
       code_challenge_methods_supported: ["S256"],
-      token_endpoint_auth_methods_supported: ["none"],
+      # `none` MUST stay first-class here, not merely present for legacy: Claude
+      # selects its CIMD flow only when this list contains "none", and would
+      # otherwise fall back to DCR. The secret-based methods are additive, for
+      # server-side connectors that cannot hold a public client.
+      token_endpoint_auth_methods_supported: ["none", "client_secret_post", "client_secret_basic"],
       scopes_supported: ["mcp"]
     })
   end

--- a/priv/repo/migrations/20260730180000_widen_oauth_text_columns_expand.exs
+++ b/priv/repo/migrations/20260730180000_widen_oauth_text_columns_expand.exs
@@ -1,0 +1,53 @@
+defmodule Engram.Repo.Migrations.WidenOauthTextColumnsExpand do
+  use Ecto.Migration
+
+  # phase/expand: widen OAuth columns that hold client-supplied strings.
+  #
+  # Prod 500 on 2026-07-30 connecting Windsurf:
+  #   (Postgrex.Error) 22001 value too long for type character varying(255)
+  #   at Engram.OAuth.mint_authorization_code/3
+  #
+  # `state` is client-supplied and RFC 6749 places no bound on it; IDE clients
+  # routinely pack routing data into it. It was varchar(255), so a long state
+  # crashed consent with a 500 instead of completing the handshake. The
+  # application now caps it (see Engram.OAuth), but the column must hold what
+  # the cap allows.
+  #
+  # `redirect_uri` columns were the same class of bug in reverse: DCR validation
+  # accepts URIs up to 2048 bytes, so we were accepting values we could not
+  # store. `oauth_clients.redirect_uris` failed at registration and
+  # `oauth_authorization_codes.redirect_uri` would have failed at mint.
+  #
+  # safety_assured: "varchar(N) -> text is binary-coercible in PostgreSQL and
+  # does NOT rewrite the table or take a long ACCESS EXCLUSIVE lock (the
+  # constraint is simply dropped). Widening only: every existing value remains
+  # valid, and no reader can observe a narrower type. Incident: Windsurf
+  # consent 500, 2026-07-30."
+
+  def up do
+    execute "ALTER TABLE oauth_authorization_codes ALTER COLUMN state TYPE text"
+    execute "ALTER TABLE oauth_authorization_codes ALTER COLUMN redirect_uri TYPE text"
+
+    # The array default is typed, so it must be dropped before the element type
+    # changes and restored afterwards.
+    execute "ALTER TABLE oauth_clients ALTER COLUMN redirect_uris DROP DEFAULT"
+    execute "ALTER TABLE oauth_clients ALTER COLUMN redirect_uris TYPE text[]"
+    execute "ALTER TABLE oauth_clients ALTER COLUMN redirect_uris SET DEFAULT ARRAY[]::text[]"
+  end
+
+  # Narrowing back can only succeed while no row exceeds 255. That holds on a
+  # fresh CI database (the rollback gate) and on any deployment that has not yet
+  # taken a long value; it is deliberately not forced, because silently
+  # truncating a redirect_uri or state would corrupt live grants.
+  def down do
+    execute "ALTER TABLE oauth_clients ALTER COLUMN redirect_uris DROP DEFAULT"
+
+    execute "ALTER TABLE oauth_clients ALTER COLUMN redirect_uris TYPE character varying(255)[]"
+
+    execute "ALTER TABLE oauth_clients ALTER COLUMN redirect_uris SET DEFAULT ARRAY[]::character varying[]"
+
+    execute "ALTER TABLE oauth_authorization_codes ALTER COLUMN redirect_uri TYPE character varying(255)"
+
+    execute "ALTER TABLE oauth_authorization_codes ALTER COLUMN state TYPE character varying(255)"
+  end
+end

--- a/priv/repo/migrations/20260730180000_widen_oauth_text_columns_expand.exs
+++ b/priv/repo/migrations/20260730180000_widen_oauth_text_columns_expand.exs
@@ -18,11 +18,39 @@ defmodule Engram.Repo.Migrations.WidenOauthTextColumnsExpand do
   # store. `oauth_clients.redirect_uris` failed at registration and
   # `oauth_authorization_codes.redirect_uri` would have failed at mint.
   #
-  # safety_assured: "varchar(N) -> text is binary-coercible in PostgreSQL and
-  # does NOT rewrite the table or take a long ACCESS EXCLUSIVE lock (the
-  # constraint is simply dropped). Widening only: every existing value remains
-  # valid, and no reader can observe a narrower type. Incident: Windsurf
-  # consent 500, 2026-07-30."
+  # squawk-ignore-file: squawk's `changing-column-type` fires on all three
+  # ALTERs and has no per-statement ignore, so the whole file is marked. The
+  # rule is generic: it cannot tell a binary-coercible widening from a real type
+  # change. Measured on PostgreSQL 18.4 by comparing pg_class.relfilenode before
+  # and after (a changed relfilenode means the heap was rewritten):
+  #
+  #   varchar(255)   -> text     relfilenode UNCHANGED   no rewrite
+  #   varchar(255)[] -> text[]   relfilenode CHANGED     FULL REWRITE
+  #
+  # So the scalar columns are free, and the ARRAY one is not: PostgreSQL's
+  # no-rewrite path does not apply at the array level even though the element
+  # cast is binary coercible. An earlier version of this comment claimed all
+  # three were rewrite-free. That was wrong, and on a large table it would have
+  # been an outage.
+  #
+  # safety_assured: "Two of the three ALTERs are binary-coercible widenings that
+  # do not rewrite the heap (verified via relfilenode). The third,
+  # oauth_clients.redirect_uris varchar(255)[] -> text[], DOES rewrite the table
+  # under ACCESS EXCLUSIVE. It is safe here only because oauth_clients is small:
+  # it holds one narrow row per DCR client registration, with no historical
+  # accumulation (codes and tokens live in other tables). Widening only, so
+  # every existing value stays valid and no reader can observe a narrower type.
+  # Incident: Windsurf consent 500, 2026-07-30."
+  #
+  # BEFORE DEPLOY, confirm the rewrite is still trivial:
+  #
+  #   SELECT count(*), pg_size_pretty(pg_total_relation_size('oauth_clients'))
+  #   FROM oauth_clients;
+  #
+  # At launch scale this is milliseconds. If that table has grown unexpectedly
+  # large, do the array column separately (add text[] column, backfill, swap)
+  # rather than taking a long exclusive lock on the OAuth client table, which
+  # would block every token exchange for the duration.
 
   def up do
     execute "ALTER TABLE oauth_authorization_codes ALTER COLUMN state TYPE text"

--- a/test/engram/billing/override_cache_test.exs
+++ b/test/engram/billing/override_cache_test.exs
@@ -4,7 +4,20 @@ defmodule Engram.Billing.OverrideCacheTest do
   alias Engram.Billing.OverrideCache
 
   setup do
-    on_exit(fn -> OverrideCache.evict_all() end)
+    on_exit(fn ->
+      OverrideCache.evict_all()
+
+      # evict_all/0 clears this node's ETS synchronously but ALSO broadcasts, and
+      # the GenServer applies that broadcast in a later handle_info. Left
+      # undrained, the clear can land *after* the next test has populated the
+      # cache and silently wipe its fixtures — which is a cross-test flake, not
+      # a production bug: eviction being eventually-applied is the design.
+      #
+      # :sys.get_state/1 is a call, so it queues behind whatever is already in
+      # the mailbox and returning proves the broadcast was handled.
+      _ = :sys.get_state(OverrideCache)
+    end)
+
     :ok
   end
 

--- a/test/engram/connections/logo_allowlist_test.exs
+++ b/test/engram/connections/logo_allowlist_test.exs
@@ -2,9 +2,17 @@ defmodule Engram.Connections.LogoAllowlistTest do
   use ExUnit.Case, async: true
   alias Engram.Connections.LogoAllowlist
 
-  test "known software_id returns verified entry" do
+  test "known software_id returns identity but NOT verification" do
     result = LogoAllowlist.lookup("engram-vault-sync")
-    assert %{verified: true, logo: "/assets/clients/engram-vault-sync.svg"} = result
+    assert %{verified: false, logo: "/assets/clients/engram-vault-sync.svg"} = result
+  end
+
+  # software_id arrives in the DCR body, it is a claim, not a proof. If this
+  # ever goes green with verified: true, anyone can wear the Claude Desktop
+  # logo and badge in a victim's connections list by registering that id.
+  test "a self-asserted software_id cannot buy the verified badge" do
+    assert %{verified: false, display_name: "Claude Desktop", logo: "/assets/clients/claude.svg"} =
+             LogoAllowlist.resolve("anthropic-claude-desktop", ["http://localhost:1234/cb"])
   end
 
   test "unknown software_id returns unverified placeholder" do
@@ -26,7 +34,9 @@ defmodule Engram.Connections.LogoAllowlistTest do
            } = result
   end
 
-  test "resolve prefers software_id over redirect host" do
+  # Identity precedence only. `verified` here comes from the claude.ai host, not
+  # from the software_id, the two are resolved independently.
+  test "resolve prefers software_id over redirect host for identity" do
     result = LogoAllowlist.resolve("engram-vault-sync", ["https://claude.ai/x"])
     assert %{verified: true, slug: nil, logo: "/assets/clients/engram-vault-sync.svg"} = result
   end
@@ -65,5 +75,158 @@ defmodule Engram.Connections.LogoAllowlistTest do
 
   test "lookup result carries slug key" do
     assert %{slug: nil} = LogoAllowlist.lookup("engram-vault-sync")
+  end
+
+  # --- Vendor redirect hosts observed in prod 2026-07-30 ---
+
+  test "resolve verifies ChatGPT by chatgpt.com redirect host" do
+    assert %{verified: true, slug: "chatgpt", display_name: "ChatGPT"} =
+             LogoAllowlist.resolve(nil, ["https://chatgpt.com/connector/oauth/ig2N09X8ZQ6D"])
+  end
+
+  test "resolve verifies Grok by grok.com redirect host" do
+    assert %{verified: true, slug: "grok", display_name: "Grok"} =
+             LogoAllowlist.resolve(nil, ["https://grok.com/connectors-oauth-exchange-code/"])
+  end
+
+  test "resolve verifies Mistral by callback.mistral.ai redirect host" do
+    assert %{verified: true, slug: "mistral", display_name: "Mistral"} =
+             LogoAllowlist.resolve(nil, [
+               "https://callback.mistral.ai/v1/integrations_auth/oauth2_callback"
+             ])
+  end
+
+  # --- client_name slug fallback: loopback clients that can never verify ---
+
+  test "resolve derives a slug from Claude Code's parenthesized client_name" do
+    assert %{slug: "claude_code"} =
+             LogoAllowlist.resolve(
+               nil,
+               ["http://localhost:62184/callback"],
+               "Claude Code (engram)"
+             )
+  end
+
+  test "client_name slug survives an arbitrary user-chosen server suffix" do
+    for name <- ["Claude Code (engram)", "Claude Code (notes)", "Claude Code", "claude code  "] do
+      assert %{slug: "claude_code"} = LogoAllowlist.resolve(nil, ["http://127.0.0.1:1/cb"], name),
+             "expected #{inspect(name)} to resolve to claude_code"
+    end
+  end
+
+  # THE load-bearing assertion: a self-asserted name is spoofable, so it may
+  # only ever set `slug`. If this ever goes green with verified/logo set,
+  # anyone can wear the Claude badge by naming their client "Claude".
+  test "client_name grants slug only, never verified, never a logo" do
+    assert %{verified: false, logo: nil, display_name: nil, slug: "claude_code"} =
+             LogoAllowlist.resolve(nil, ["http://localhost:9/cb"], "Claude Code (evil)")
+  end
+
+  test "client_name cannot upgrade a spoofed vendor host to verified" do
+    assert %{verified: false, logo: nil} =
+             LogoAllowlist.resolve(nil, ["https://claude.ai@evil.com/cb"], "Claude Code (x)")
+  end
+
+  test "a verified host match wins over client_name" do
+    assert %{verified: true, slug: "claude", display_name: "Claude"} =
+             LogoAllowlist.resolve(
+               nil,
+               ["https://claude.ai/api/mcp/auth_callback"],
+               "Claude Code (engram)"
+             )
+  end
+
+  # The catalog slugs were coined from the product names, so normalizing a
+  # client_name back to slug shape round-trips for connectors we have never
+  # observed. This is what makes the fallback general instead of a map we have
+  # to hand-feed one vendor at a time.
+  test "derives slugs for never-observed connectors from their product name" do
+    for {name, slug} <- [
+          {"Cursor", "cursor"},
+          {"Windsurf", "windsurf"},
+          {"GitHub Copilot", "github_copilot"},
+          {"LobeChat", "lobechat"}
+        ] do
+      assert %{slug: ^slug} = LogoAllowlist.resolve(nil, ["http://127.0.0.1:1/cb"], name),
+             "expected #{inspect(name)} to derive slug #{inspect(slug)}"
+    end
+  end
+
+  # Clients that have since registered for real, with their observed redirects.
+  # Cline and OpenCode were both in the list above when it was written and moved
+  # here within the hour: the derivation attributed two connectors nobody had
+  # configured for, which is the whole case for normalizing over hand-feeding a
+  # map. Note they share a redirect path and differ only by name, so they are a
+  # family the host layer could never have told apart.
+  #
+  # All stay `verified: false`, and correctly. The loopback ones are unallowlist-
+  # able by construction and Open WebUI redirects to the operator's own domain,
+  # so none is provable. Unverified means "unprovable", not "suspect".
+  test "attributes observed name-only connectors (Cline, OpenCode, Open WebUI)" do
+    assert %{slug: "cline", verified: false} =
+             LogoAllowlist.resolve(nil, ["http://127.0.0.1:1456/mcp/oauth/callback"], "Cline")
+
+    assert %{slug: "opencode", verified: false} =
+             LogoAllowlist.resolve(nil, ["http://127.0.0.1:19876/mcp/oauth/callback"], "OpenCode")
+
+    assert %{slug: "open_webui", verified: false} =
+             LogoAllowlist.resolve(
+               nil,
+               ["https://ai.ras.band/oauth/clients/mcp:1/callback"],
+               "Open WebUI"
+             )
+  end
+
+  # Observed 2026-07-30. Antigravity is the counter-example to name derivation:
+  # it registers as "antigravity-client", which normalizes to `antigravity_client`
+  # and matches no slug. The vendor host is what attributes it, and because the
+  # host is vendor-owned, it also earns `verified`.
+  test "resolve verifies Antigravity by its vendor host, not its client_name" do
+    assert %{verified: true, slug: "antigravity", display_name: "Antigravity"} =
+             LogoAllowlist.resolve(
+               nil,
+               ["https://antigravity.google/oauth-callback"],
+               "antigravity-client"
+             )
+
+    # Prove the name alone would NOT have carried it.
+    assert %{slug: nil} =
+             LogoAllowlist.resolve(nil, ["http://localhost:1/cb"], "antigravity-client")
+  end
+
+  # Self-hosted clients redirect to the operator's OWN domain, so there is no
+  # vendor host to allowlist, ever. Observed in prod 2026-07-30: Open WebUI
+  # arriving from a user-run instance. It must still earn its slug (via name)
+  # while staying unverified (the host proves nothing about who built it).
+  test "a self-hosted client gets its slug by name but is never verified by its own host" do
+    assert %{verified: false, logo: nil, slug: "open_webui"} =
+             LogoAllowlist.resolve(
+               nil,
+               ["https://ai.ras.band/oauth/clients/mcp:1/callback"],
+               "Open WebUI"
+             )
+  end
+
+  # `web_only` and `other_mcp` are questionnaire answers, not products. A client
+  # claiming to be one would tick a row it has no business ticking.
+  test "never derives the non-product catalog answers from a client_name" do
+    assert %{slug: nil} = LogoAllowlist.resolve(nil, ["http://127.0.0.1:1/cb"], "web only")
+    assert %{slug: nil} = LogoAllowlist.resolve(nil, ["http://127.0.0.1:1/cb"], "Other MCP")
+  end
+
+  test "client_name normalization tolerates punctuation and empty residue" do
+    assert %{slug: "github_copilot"} =
+             LogoAllowlist.resolve(nil, ["http://127.0.0.1:1/cb"], "GitHub-Copilot")
+
+    assert %{slug: nil} = LogoAllowlist.resolve(nil, ["http://127.0.0.1:1/cb"], "***")
+    assert %{slug: nil} = LogoAllowlist.resolve(nil, ["http://127.0.0.1:1/cb"], "")
+  end
+
+  test "unknown or nil client_name stays empty" do
+    assert %{verified: false, slug: nil} =
+             LogoAllowlist.resolve(nil, ["http://localhost:1/cb"], "Some Random Client")
+
+    assert %{verified: false, slug: nil} =
+             LogoAllowlist.resolve(nil, ["http://localhost:1/cb"], nil)
   end
 end

--- a/test/engram/connections/logo_allowlist_test.exs
+++ b/test/engram/connections/logo_allowlist_test.exs
@@ -34,11 +34,24 @@ defmodule Engram.Connections.LogoAllowlistTest do
            } = result
   end
 
-  # Identity precedence only. `verified` here comes from the claude.ai host, not
-  # from the software_id, the two are resolved independently.
-  test "resolve prefers software_id over redirect host for identity" do
+  # REVERSED 2026-07-30 during review. This previously asserted that
+  # `software_id` outranked the redirect host for identity, which is backwards:
+  # software_id is a self-asserted DCR body field and the host is not. A client
+  # claiming one vendor while its grant is delivered to another must be listed
+  # as the vendor that actually receives the code.
+  test "resolve prefers the redirect host over a self-asserted software_id" do
     result = LogoAllowlist.resolve("engram-vault-sync", ["https://claude.ai/x"])
-    assert %{verified: true, slug: nil, logo: "/assets/clients/engram-vault-sync.svg"} = result
+
+    assert %{verified: true, slug: "claude", logo: "/assets/clients/claude.svg"} = result
+  end
+
+  # software_id still supplies identity when no vendor host is present, which is
+  # the case it exists for: our own Obsidian plugin redirects to a custom
+  # scheme, so nothing else can name it.
+  test "resolve falls back to software_id when there is no vendor host" do
+    result = LogoAllowlist.resolve("engram-vault-sync", ["obsidian://engram/cb"])
+
+    assert %{verified: false, slug: nil, logo: "/assets/clients/engram-vault-sync.svg"} = result
   end
 
   test "resolve ignores loopback and custom-scheme redirects" do
@@ -125,6 +138,20 @@ defmodule Engram.Connections.LogoAllowlistTest do
   test "client_name cannot upgrade a spoofed vendor host to verified" do
     assert %{verified: false, logo: nil} =
              LogoAllowlist.resolve(nil, ["https://claude.ai@evil.com/cb"], "Claude Code (x)")
+  end
+
+  # Precedence is proven-over-claimed. software_id is a self-asserted DCR body
+  # field; the vendor host is not. If a client claims one vendor and its grant
+  # is delivered to another, the one we can PROVE must be what the user sees,
+  # otherwise the connections list shows "ChatGPT" for a code Anthropic
+  # received.
+  test "a verified host wins over a conflicting self-asserted software_id" do
+    assert %{verified: true, slug: "claude", display_name: "Claude"} =
+             LogoAllowlist.resolve(
+               "openai-chatgpt",
+               ["https://claude.ai/api/mcp/auth_callback"],
+               nil
+             )
   end
 
   test "a verified host match wins over client_name" do

--- a/test/engram/connections_test.exs
+++ b/test/engram/connections_test.exs
@@ -28,7 +28,7 @@ defmodule Engram.ConnectionsTest do
       family = Ecto.UUID.generate()
 
       # Both tokens are active (revoked_at: nil, consumed_at: nil). Without
-      # DISTINCT client_id in the query this would return 2 — the DISTINCT is
+      # DISTINCT client_id in the query this would return 2, the DISTINCT is
       # the load-bearing assertion here.
       insert(:oauth_refresh_token,
         user_id: user.id,
@@ -70,7 +70,7 @@ defmodule Engram.ConnectionsTest do
       vault = insert(:vault, user: user)
       family = Ecto.UUID.generate()
 
-      # Two tokens in the same family — should collapse to 1
+      # Two tokens in the same family, should collapse to 1
       insert(:device_refresh_token, user: user, vault: vault, family_id: family)
       insert(:device_refresh_token, user: user, vault: vault, family_id: family)
 
@@ -136,12 +136,15 @@ defmodule Engram.ConnectionsTest do
         vault_id: vault.id
       )
 
+      # verified: false, the factory's redirect is loopback, and a self-asserted
+      # software_id no longer buys the badge (tightened 2026-07-30). Identity
+      # still resolves from it.
       assert [
                %{
                  kind: :mcp,
                  client_id: cid,
                  name: "Claude Desktop",
-                 verified: true,
+                 verified: false,
                  vault_id: vid
                }
              ] =
@@ -175,6 +178,34 @@ defmodule Engram.ConnectionsTest do
              ] = Connections.list_for_user(user)
     end
 
+    # Regression: Claude Code redirects to loopback, which is un-verifiable by
+    # design, so it resolved to slug: nil and the onboarding checklist row for
+    # it could never tick. The slug must survive to the view while `verified`
+    # and `logo` stay off, the name is self-asserted.
+    test "attributes a loopback client to its slug via client_name, unverified" do
+      user = insert_user()
+
+      client =
+        insert(:oauth_client,
+          kind: "mcp",
+          software_id: nil,
+          client_name: "Claude Code (engram)",
+          redirect_uris: ["http://localhost:62184/callback"]
+        )
+
+      insert(:oauth_refresh_token, user_id: user.id, client_id: client.client_id)
+
+      assert [
+               %{
+                 kind: :mcp,
+                 name: "Claude Code (engram)",
+                 verified: false,
+                 slug: "claude_code",
+                 logo: nil
+               }
+             ] = Connections.list_for_user(user)
+    end
+
     test "includes PATs as kind=:pat" do
       user = insert_user()
       insert(:api_key, user: user, name: "my-script")
@@ -192,7 +223,7 @@ defmodule Engram.ConnectionsTest do
       older = ~U[2026-01-01 00:00:00Z]
       newer = ~U[2026-05-30 00:00:00Z]
 
-      # client_a older, client_b newer — B should sort first regardless of alphabetic order
+      # client_a older, client_b newer, B should sort first regardless of alphabetic order
       insert(:oauth_refresh_token,
         user_id: user.id,
         client_id: client_a.client_id,
@@ -281,7 +312,7 @@ defmodule Engram.ConnectionsTest do
       user = insert_user()
       # create_vault drives the real encryption pipeline so list_vaults/1 can
       # decrypt the name back. The factory-built :vault has random ciphertext
-      # which would decrypt to nil — that's the "vault gone" path tested below.
+      # which would decrypt to nil, that's the "vault gone" path tested below.
       {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "Personal"})
       client = insert(:oauth_client, kind: "mcp")
 
@@ -302,7 +333,7 @@ defmodule Engram.ConnectionsTest do
 
       # Factory inserts a vault row but its ciphertext is random, so
       # Vaults.list_vaults logs a decrypt failure + returns the vault without
-      # a :name. The merge step then yields vault_name: nil — the same shape
+      # a :name. The merge step then yields vault_name: nil, the same shape
       # the frontend sees when a vault was soft-deleted between the grant and
       # the page render.
       stale = insert(:vault, user: user)
@@ -378,7 +409,7 @@ defmodule Engram.ConnectionsTest do
       assert Connections.count_active(user.id, :obsidian) == 0
     end
 
-    test "is idempotent — second revoke returns :ok" do
+    test "is idempotent, second revoke returns :ok" do
       user = insert_user()
       vault = insert(:vault, user: user)
       family_id = Ecto.UUID.generate()
@@ -473,7 +504,7 @@ defmodule Engram.ConnectionsTest do
       assert Connections.count_active(other.id, :obsidian) == 1
     end
 
-    test "is idempotent — second call on already-revoked vault returns :ok" do
+    test "is idempotent, second call on already-revoked vault returns :ok" do
       user = insert_user()
       vault = insert(:vault, user: user)
       client = insert(:oauth_client, kind: "mcp")
@@ -497,7 +528,7 @@ defmodule Engram.ConnectionsTest do
 
     test "leaves OAuth grants with no vault binding (vault_id: nil) untouched" do
       # vault_id is cast-only on OAuth refresh tokens (not required), so a grant
-      # can have nil binding. Such a grant is NOT scoped to any vault — it shows
+      # can have nil binding. Such a grant is NOT scoped to any vault, it shows
       # on the connections page with vault_id: nil, independent of any vault.
       # Deleting a vault must not collaterally revoke it.
       user = insert_user()
@@ -512,7 +543,7 @@ defmodule Engram.ConnectionsTest do
 
       assert :ok = Connections.revoke_by_vault(user.id, vault.id)
 
-      # The unbound grant survives — it was never the deleted vault's connection
+      # The unbound grant survives, it was never the deleted vault's connection
       assert Connections.count_active(user.id, :mcp) == 1
     end
   end

--- a/test/engram_web/controllers/connections_controller_test.exs
+++ b/test/engram_web/controllers/connections_controller_test.exs
@@ -52,7 +52,8 @@ defmodule EngramWeb.ConnectionsControllerTest do
 
       mcp = Enum.find(body, fn r -> r["kind"] == "mcp" end)
       assert mcp["name"] == "Claude Desktop"
-      assert mcp["verified"] == true
+      # Loopback redirect + self-asserted software_id => identity yes, badge no.
+      assert mcp["verified"] == false
       assert mcp["slug"] == "claude"
       assert mcp["client_id"] == client.client_id
 
@@ -69,7 +70,7 @@ defmodule EngramWeb.ConnectionsControllerTest do
     test "returns 403 for API-key-authed requests (PAT must not list connections)", %{conn: conn} do
       # The nested RequireSession plug gates the route. grant_api_write! lets
       # the request pass RequireApiRpsBudget so it reaches RequireSession,
-      # which then returns 403 with api_key_not_allowed — matching the pattern
+      # which then returns 403 with api_key_not_allowed, matching the pattern
       # in auth_controller_test.exs.
       user = insert(:user)
       {:ok, raw_key, _api_key} = Engram.Accounts.create_api_key(user, "test-key")
@@ -149,7 +150,7 @@ defmodule EngramWeb.ConnectionsControllerTest do
       assert Engram.Connections.count_active(user.id, :mcp) == 0
     end
 
-    test "is idempotent — second revoke returns 204", %{conn: conn} do
+    test "is idempotent, second revoke returns 204", %{conn: conn} do
       user = insert(:user)
       vault = insert(:vault, user: user)
       client = insert(:oauth_client, kind: "mcp")
@@ -234,7 +235,7 @@ defmodule EngramWeb.ConnectionsControllerTest do
       assert Engram.Connections.count_active(user.id, :obsidian) == 0
     end
 
-    test "204 is idempotent — second revoke also returns 204", %{conn: conn} do
+    test "204 is idempotent, second revoke also returns 204", %{conn: conn} do
       user = insert(:user)
       vault = insert(:vault, user: user)
       family_id = Ecto.UUID.generate()
@@ -374,7 +375,7 @@ defmodule EngramWeb.ConnectionsControllerTest do
         |> delete("/api/connections/pat/#{api_key.id}")
 
       assert conn.status == 204
-      # Confirm it's gone — list_for_user should not include it.
+      # Confirm it's gone, list_for_user should not include it.
       refute Enum.any?(Engram.Connections.list_for_user(user), fn r ->
                r.kind == :pat and r.key_id == api_key.id
              end)

--- a/test/engram_web/controllers/oauth_authorize_controller_test.exs
+++ b/test/engram_web/controllers/oauth_authorize_controller_test.exs
@@ -125,6 +125,72 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
     end
   end
 
+  # RFC 8252 §7.3: "the authorization server MUST allow any port to be specified
+  # at the time of the request for loopback IP redirect URIs, to accommodate
+  # clients that obtain an available ephemeral port from the operating system at
+  # the time of the request."
+  #
+  # This is not academic. A DCR client registers once and persists its
+  # client_id, but grabs a NEW ephemeral port on every launch. Under exact
+  # matching, every local-first connector (Claude Code, Cline, OpenCode, Cursor,
+  # Windsurf) breaks on its second run and can only recover by re-registering.
+  describe "GET /oauth/authorize — loopback ephemeral ports (RFC 8252 §7.3)" do
+    test "accepts a different port than the one registered", %{conn: conn} do
+      client = register_client("http://127.0.0.1:1456/mcp/oauth/callback")
+
+      params = valid_params(client.client_id, "http://127.0.0.1:49152/mcp/oauth/callback")
+
+      conn = get(conn, "/oauth/authorize", params)
+
+      assert conn.status == 302
+    end
+
+    test "accepts an added port when none was registered", %{conn: conn} do
+      client = register_client("http://localhost/callback")
+
+      params = valid_params(client.client_id, "http://localhost:8912/callback")
+
+      conn = get(conn, "/oauth/authorize", params)
+
+      assert conn.status == 302
+    end
+
+    test "still requires the path to match", %{conn: conn} do
+      client = register_client("http://127.0.0.1:1456/mcp/oauth/callback")
+
+      params = valid_params(client.client_id, "http://127.0.0.1:1456/steal")
+
+      conn = get(conn, "/oauth/authorize", params)
+
+      assert conn.status == 400
+      assert conn.resp_body =~ "invalid_redirect_uri"
+    end
+
+    test "still requires the loopback host to match", %{conn: conn} do
+      client = register_client("http://127.0.0.1:1456/mcp/oauth/callback")
+
+      params = valid_params(client.client_id, "http://localhost:1456/mcp/oauth/callback")
+
+      conn = get(conn, "/oauth/authorize", params)
+
+      assert conn.status == 400
+      assert conn.resp_body =~ "invalid_redirect_uri"
+    end
+
+    # The port exemption is scoped to loopback. Relaxing it for https would let
+    # anyone who controls any port on a registered host collect auth codes.
+    test "does not relax the port for a non-loopback https redirect", %{conn: conn} do
+      client = register_client("https://claude.ai/api/mcp/auth_callback")
+
+      params = valid_params(client.client_id, "https://claude.ai:8443/api/mcp/auth_callback")
+
+      conn = get(conn, "/oauth/authorize", params)
+
+      assert conn.status == 400
+      assert conn.resp_body =~ "invalid_redirect_uri"
+    end
+  end
+
   describe "GET /oauth/authorize — bad params (redirect with error)" do
     test "redirects to redirect_uri?error=unsupported_response_type when not code", %{conn: conn} do
       client = register_client()

--- a/test/engram_web/controllers/oauth_authorize_controller_test.exs
+++ b/test/engram_web/controllers/oauth_authorize_controller_test.exs
@@ -252,6 +252,74 @@ defmodule EngramWeb.OAuthAuthorizeControllerTest do
     end
   end
 
+  # Prod 500 observed 2026-07-30 connecting Windsurf:
+  #   (Postgrex.Error) 22001 value too long for type character varying(255)
+  #   at Engram.OAuth.mint_authorization_code/3
+  # Two columns on oauth_authorization_codes could overflow. `state` is
+  # client-supplied and RFC 6749 puts no bound on it (IDEs pack routing data in
+  # there). `redirect_uri` is worse: our own DCR accepts up to 2048 bytes, then
+  # we tried to store it in varchar(255) — we accepted a value we could not
+  # persist. Both must round-trip, not crash.
+  describe "POST /api/oauth/authorize/consent — oversized fields (Windsurf 500)" do
+    test "mints a code when state exceeds 255 characters", %{conn: conn} do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      client = register_client()
+      redirect_uri = hd(client.redirect_uris)
+      long_state = String.duplicate("s", 900)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("state", long_state)
+        |> Map.put("vault_choice", "vault:#{vault.id}")
+
+      conn = conn |> jwt_authed(user) |> post("/api/oauth/authorize/consent", params)
+
+      assert conn.status == 200
+      json = Jason.decode!(conn.resp_body)
+      query = json["redirect_uri"] |> URI.parse() |> Map.get(:query) |> URI.decode_query()
+      assert query["state"] == long_state
+    end
+
+    test "mints a code when the registered redirect_uri exceeds 255 characters", %{conn: conn} do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      # Comfortably over 255, comfortably under the 2048 DCR accepts.
+      redirect_uri = "https://windsurf.example.com/cb?p=" <> String.duplicate("q", 400)
+      client = register_client(redirect_uri)
+
+      params =
+        client.client_id
+        |> valid_params(redirect_uri)
+        |> Map.put("vault_choice", "vault:#{vault.id}")
+
+      conn = conn |> jwt_authed(user) |> post("/api/oauth/authorize/consent", params)
+
+      assert conn.status == 200
+      json = Jason.decode!(conn.resp_body)
+      assert String.starts_with?(json["redirect_uri"], redirect_uri)
+    end
+
+    # Widening the column must not make it unbounded storage: the endpoint is
+    # reachable by any signed-in user, and a code row lives 10 minutes.
+    test "rejects an absurd state instead of persisting it", %{conn: conn} do
+      user = insert(:user)
+      vault = insert(:vault, user: user)
+      client = register_client()
+
+      params =
+        client.client_id
+        |> valid_params(hd(client.redirect_uris))
+        |> Map.put("state", String.duplicate("s", 5000))
+        |> Map.put("vault_choice", "vault:#{vault.id}")
+
+      conn = conn |> jwt_authed(user) |> post("/api/oauth/authorize/consent", params)
+
+      assert conn.status == 400
+    end
+  end
+
   describe "POST /api/oauth/authorize/consent — vault ownership" do
     test "returns 200 with redirect_uri carrying ?error=access_denied when vault not owned",
          %{conn: conn} do

--- a/test/engram_web/controllers/oauth_register_controller_test.exs
+++ b/test/engram_web/controllers/oauth_register_controller_test.exs
@@ -205,6 +205,23 @@ defmodule EngramWeb.OAuthRegisterControllerTest do
       assert body["error"] == "invalid_redirect_uri"
     end
 
+    # Regression guard for the custom-scheme relaxation. `https:///cb` parses
+    # with scheme "https" and host "", so it misses the https clause (which
+    # requires a non-empty host) and would otherwise fall through to the
+    # permissive native-app branch. Admitting custom schemes must not become
+    # admitting a well-known scheme with its host missing.
+    test "rejects https redirect_uri with no host", %{conn: conn} do
+      for uri <- ["https:///cb", "https://", "https:foo"] do
+        conn =
+          post(conn, "/oauth/register", %{
+            "redirect_uris" => [uri]
+          })
+
+        body = json_response(conn, 400)
+        assert body["error"] == "invalid_redirect_uri", "expected #{uri} to be rejected"
+      end
+    end
+
     test "rejects javascript: redirect_uri", %{conn: conn} do
       conn =
         post(conn, "/oauth/register", %{

--- a/test/engram_web/controllers/oauth_register_controller_test.exs
+++ b/test/engram_web/controllers/oauth_register_controller_test.exs
@@ -53,6 +53,60 @@ defmodule EngramWeb.OAuthRegisterControllerTest do
       assert "http://127.0.0.1:9999/cb" in body["redirect_uris"]
     end
 
+    # Observed 2026-07-30: Cursor desktop registers `cursor://anysphere.cursor-mcp/...`,
+    # a single-word scheme. We used to require a reverse-DNS dot per RFC 8252
+    # §7.1, which turned Cursor away at registration. That is a requirement on
+    # apps, not a mandate for servers to reject them, and the interception it
+    # guards against is already handled by mandatory PKCE: a squatting app
+    # receives a code it cannot redeem. A dot also never made a scheme
+    # exclusive on any OS, so it lowered collision odds and nothing more.
+    test "accepts a single-word native custom scheme (Cursor)", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["cursor://anysphere.cursor-mcp/oauth/callback"],
+          "client_name" => "Cursor"
+        })
+
+      body = json_response(conn, 201)
+      assert "cursor://anysphere.cursor-mcp/oauth/callback" in body["redirect_uris"]
+    end
+
+    # Relaxing the dot rule must not relax the dangerous-scheme rule.
+    for scheme <- ~w(javascript data file) do
+      test "still rejects the unsafe #{scheme} scheme", %{conn: conn} do
+        conn =
+          post(conn, "/oauth/register", %{
+            "redirect_uris" => ["#{unquote(scheme)}://evil/callback"],
+            "client_name" => "Nope"
+          })
+
+        assert json_response(conn, 400)["error"] == "invalid_redirect_uri"
+      end
+    end
+
+    # A custom scheme can never be proven, so it must never earn the badge no
+    # matter how legitimate the client looks.
+    test "a custom-scheme client is registered but never verified", %{conn: conn} do
+      conn =
+        post(conn, "/oauth/register", %{
+          "redirect_uris" => ["cursor://anysphere.cursor-mcp/oauth/callback"],
+          "client_name" => "Cursor"
+        })
+
+      body = json_response(conn, 201)
+      {:ok, client} = Engram.OAuth.get_client(body["client_id"])
+
+      identity =
+        Engram.Connections.LogoAllowlist.resolve(
+          client.software_id,
+          client.redirect_uris,
+          client.client_name
+        )
+
+      refute identity.verified
+      assert identity.slug == "cursor"
+    end
+
     test "accepts native-app custom scheme redirect_uri", %{conn: conn} do
       params = %{
         "redirect_uris" => ["com.cursor.app://oauth/callback"],
@@ -200,22 +254,52 @@ defmodule EngramWeb.OAuthRegisterControllerTest do
       assert body["error"] == "invalid_redirect_uri"
     end
 
-    test "rejects client_secret_post auth method (only public PKCE supported)", %{conn: conn} do
+    # Confidential registration exists because server-side connectors (LobeHub
+    # cloud, observed 2026-07-30) ask for it and cannot fall back to a public
+    # client. Rejecting them made the connector unusable, not merely unverified.
+    for method <- ~w(client_secret_post client_secret_basic) do
+      test "issues a client_secret for #{method}", %{conn: conn} do
+        conn =
+          post(conn, "/oauth/register", %{
+            "redirect_uris" => ["https://app.lobehub.com/oauth/callback"],
+            "client_name" => "LobeChat",
+            "token_endpoint_auth_method" => unquote(method)
+          })
+
+        body = json_response(conn, 201)
+
+        assert body["token_endpoint_auth_method"] == unquote(method)
+        assert is_binary(body["client_secret"])
+        assert byte_size(body["client_secret"]) >= 32
+        # RFC 7591 §3.2.1 requires this field whenever a secret is issued.
+        # 0 means "does not expire".
+        assert body["client_secret_expires_at"] == 0
+      end
+    end
+
+    test "persists only a hash of the client_secret", %{conn: conn} do
       conn =
         post(conn, "/oauth/register", %{
-          "redirect_uris" => ["https://x/cb"],
+          "redirect_uris" => ["https://app.lobehub.com/oauth/callback"],
+          "client_name" => "LobeChat",
           "token_endpoint_auth_method" => "client_secret_post"
         })
 
-      body = json_response(conn, 400)
-      assert body["error"] == "invalid_client_metadata"
+      body = json_response(conn, 201)
+      {:ok, client} = Engram.OAuth.get_client(body["client_id"])
+
+      assert is_binary(client.client_secret_hash)
+      refute client.client_secret_hash == body["client_secret"]
+      # The plaintext is returned exactly once, at registration, and never read
+      # back out of the database.
+      assert is_nil(client.client_secret)
     end
 
-    test "rejects client_secret_basic auth method", %{conn: conn} do
+    test "still rejects an auth method we do not implement", %{conn: conn} do
       conn =
         post(conn, "/oauth/register", %{
           "redirect_uris" => ["https://x/cb"],
-          "token_endpoint_auth_method" => "client_secret_basic"
+          "token_endpoint_auth_method" => "private_key_jwt"
         })
 
       body = json_response(conn, 400)

--- a/test/engram_web/controllers/oauth_token_controller_test.exs
+++ b/test/engram_web/controllers/oauth_token_controller_test.exs
@@ -443,7 +443,7 @@ defmodule EngramWeb.OAuthTokenControllerTest do
   end
 
   describe "POST /oauth/token — confidential client authentication" do
-    defp confidential_client(method, redirect_uri \\ "https://app.lobehub.com/oauth/callback") do
+    defp confidential_client(method, redirect_uri) do
       {:ok, client} =
         OAuth.register_client(%{
           "redirect_uris" => [redirect_uri],

--- a/test/engram_web/controllers/oauth_token_controller_test.exs
+++ b/test/engram_web/controllers/oauth_token_controller_test.exs
@@ -442,6 +442,183 @@ defmodule EngramWeb.OAuthTokenControllerTest do
     end
   end
 
+  describe "POST /oauth/token — confidential client authentication" do
+    defp confidential_client(method, redirect_uri \\ "https://app.lobehub.com/oauth/callback") do
+      {:ok, client} =
+        OAuth.register_client(%{
+          "redirect_uris" => [redirect_uri],
+          "client_name" => "LobeChat",
+          "token_endpoint_auth_method" => method
+        })
+
+      client
+    end
+
+    defp code_for(client, redirect_uri) do
+      user = insert(:user)
+      {verifier, challenge} = pkce_pair()
+      {mint_code(user, client, redirect_uri, challenge), verifier}
+    end
+
+    test "exchanges a code when the secret arrives in the body", %{conn: conn} do
+      uri = "https://app.lobehub.com/oauth/callback"
+      client = confidential_client("client_secret_post", uri)
+      {code, verifier} = code_for(client, uri)
+
+      conn =
+        post(conn, "/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => uri,
+          "client_id" => client.client_id,
+          "client_secret" => client.client_secret,
+          "code_verifier" => verifier
+        })
+
+      assert %{"access_token" => token} = json_response(conn, 200)
+      assert is_binary(token)
+    end
+
+    test "exchanges a code when the secret arrives via HTTP Basic", %{conn: conn} do
+      uri = "https://app.lobehub.com/oauth/callback"
+      client = confidential_client("client_secret_basic", uri)
+      {code, verifier} = code_for(client, uri)
+
+      basic = Base.encode64("#{client.client_id}:#{client.client_secret}")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Basic #{basic}")
+        |> post("/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => uri,
+          "client_id" => client.client_id,
+          "code_verifier" => verifier
+        })
+
+      assert %{"access_token" => _} = json_response(conn, 200)
+    end
+
+    test "rejects a confidential client that omits its secret", %{conn: conn} do
+      uri = "https://app.lobehub.com/oauth/callback"
+      client = confidential_client("client_secret_post", uri)
+      {code, verifier} = code_for(client, uri)
+
+      conn =
+        post(conn, "/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => uri,
+          "client_id" => client.client_id,
+          "code_verifier" => verifier
+        })
+
+      assert %{"error" => "invalid_client"} = json_response(conn, 401)
+    end
+
+    test "rejects a wrong secret", %{conn: conn} do
+      uri = "https://app.lobehub.com/oauth/callback"
+      client = confidential_client("client_secret_post", uri)
+      {code, verifier} = code_for(client, uri)
+
+      conn =
+        post(conn, "/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => uri,
+          "client_id" => client.client_id,
+          "client_secret" => "not-the-secret",
+          "code_verifier" => verifier
+        })
+
+      assert %{"error" => "invalid_client"} = json_response(conn, 401)
+    end
+
+    # The registered method binds in BOTH directions. A public client that
+    # starts presenting a secret is either confused or an attacker probing;
+    # silently accepting it would make the registered method decorative.
+    test "rejects a secret presented by a client registered public", %{conn: conn} do
+      uri = "https://claude.ai/api/mcp/auth_callback"
+      client = register_client(uri)
+      {code, verifier} = code_for(client, uri)
+
+      conn =
+        post(conn, "/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => uri,
+          "client_id" => client.client_id,
+          "client_secret" => "unexpected",
+          "code_verifier" => verifier
+        })
+
+      assert %{"error" => "invalid_client"} = json_response(conn, 401)
+    end
+
+    # Some OAuth libraries send `Basic base64("client_id:")` for public clients.
+    # An empty password is "no secret", not a presented credential; reading it
+    # literally would reject a public client for authenticating.
+    test "treats an empty Basic password as no credential", %{conn: conn} do
+      uri = "https://claude.ai/api/mcp/auth_callback"
+      client = register_client(uri)
+      {code, verifier} = code_for(client, uri)
+
+      basic = Base.encode64("#{client.client_id}:")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Basic #{basic}")
+        |> post("/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => uri,
+          "code_verifier" => verifier
+        })
+
+      assert %{"access_token" => _} = json_response(conn, 200)
+    end
+
+    test "authenticates the refresh grant too", %{conn: conn} do
+      uri = "https://app.lobehub.com/oauth/callback"
+      client = confidential_client("client_secret_post", uri)
+      {code, verifier} = code_for(client, uri)
+
+      %{"refresh_token" => refresh} =
+        conn
+        |> post("/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => code,
+          "redirect_uri" => uri,
+          "client_id" => client.client_id,
+          "client_secret" => client.client_secret,
+          "code_verifier" => verifier
+        })
+        |> json_response(200)
+
+      unauthenticated =
+        build_conn()
+        |> post("/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => refresh,
+          "client_id" => client.client_id
+        })
+
+      assert %{"error" => "invalid_client"} = json_response(unauthenticated, 401)
+
+      authenticated =
+        build_conn()
+        |> post("/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => refresh,
+          "client_id" => client.client_id,
+          "client_secret" => client.client_secret
+        })
+
+      assert %{"access_token" => _} = json_response(authenticated, 200)
+    end
+  end
+
   describe "POST /oauth/token — invalid input" do
     test "rejects unsupported grant_type", %{conn: conn} do
       conn = post(conn, "/oauth/token", %{"grant_type" => "password"})

--- a/test/engram_web/controllers/well_known_controller_test.exs
+++ b/test/engram_web/controllers/well_known_controller_test.exs
@@ -80,7 +80,15 @@ defmodule EngramWeb.WellKnownControllerTest do
 
       # Must match what /oauth/register actually accepts (#282) — advertising
       # client_secret_* here would tell clients to request a method we 400 on.
-      assert body["token_endpoint_auth_methods_supported"] == ["none"]
+      # "none" must remain advertised: Claude only chooses CIMD when it is,
+      # and every existing public PKCE client depends on it.
+      assert "none" in body["token_endpoint_auth_methods_supported"]
+
+      assert body["token_endpoint_auth_methods_supported"] == [
+               "none",
+               "client_secret_post",
+               "client_secret_basic"
+             ]
     end
 
     test "responds with application/json content-type", %{conn: conn} do


### PR DESCRIPTION
Four connector failures reported over the past day turned out to be one shape: **we accept at one layer what another layer cannot handle.**

| Connector | Symptom | Cause |
|---|---|---|
| Claude Code | Onboarding row never ticks | Loopback redirect → no slug |
| LobeHub | `token_endpoint_auth_method: must be one of: none` | Confidential DCR rejected |
| Cursor | `weak custom scheme cursor:` | Reverse-DNS dot required |
| Windsurf | `POST /oauth/authorize/consent` 500 in prod | `state` > `varchar(255)` |
| Every local-first client | Works once, then `invalid_redirect_uri` | Ephemeral port matched exactly |
| (found in review) Any client | Could wear another vendor's identity | `software_id` outranked the proven host |

## 1. Loopback and self-hosted clients could never tick their checklist row

Claude Code, Cline, OpenCode, Cursor and every local-first client redirect to `localhost`. No allowlist can ever cover that, so they resolved to `slug: nil` and their onboarding row was structurally unstickable. Self-hosted clients (Open WebUI, LobeChat) have the same problem for the opposite reason: the redirect host is *the operator's own domain*, so there is nothing to allowlist, not now, not ever.

Attribution now falls back to the normalized `client_name`, accepted only if the onboarding catalog already knows that slug. The catalog slugs were coined from product names, so this round-trips for connectors we have never seen.

The trailing-parenthetical strip is load-bearing: Claude Code registers as `Claude Code (<mcp-server-name>)` where the suffix is user-chosen, so an exact-match map misses every real installation.

## 2. Confidential clients were unregisterable

`token_endpoint_auth_method` was restricted to `none` only because nothing minted secrets. That made server-side connectors (LobeHub cloud) fail at `/oauth/register`, which is worse than being unattributed: no `oauth_clients` row exists at all.

Registration now mints a secret for `client_secret_post`/`client_secret_basic` and the token endpoint authenticates it (Basic or body, never both). **PKCE stays mandatory for both** — a secret authenticates the client, PKCE binds the code to the request that started it. They are not substitutes.

## 3. Cursor was rejected on its redirect scheme

We required a reverse-DNS dot in custom schemes, citing RFC 8252 §7.1. That section obliges *apps* to choose such a scheme; it does not ask authorization servers to reject the ones that don't. The dot never made a scheme exclusive (anyone can claim `com.foo://` as easily as `foo://`), so it lowered accidental-collision odds, not deliberate squatting. PKCE is the actual defence, and we require it unconditionally.

`javascript`/`data`/`file` stay rejected. Custom schemes remain permanently unverifiable — this admits them, it does not trust them.

## 4. Windsurf 500'd in prod

A long client-supplied `state` overflowed `varchar(255)`, crashing consent with `Postgrex 22001` instead of completing the handshake. RFC 6749 places no bound on `state` and IDE clients routinely pack routing data into it.

Migration widens `state` and `redirect_uri` to `text` (binary-coercible in Postgres: no table rewrite, no long lock) and the app caps `state` at 2048 bytes, so what we accept is what we can store. `redirect_uris` was the same bug in reverse: DCR accepted URIs up to 2048 bytes into a `varchar(255)[]` column.

## 5. Loopback clients broke on their second run

Found while reviewing the above. `match_redirect_uri/2` did an exact
`uri in client.redirect_uris`, but RFC 8252 §7.3 says the AS **MUST** allow any
port for loopback redirects, because native apps ask the OS for an ephemeral
port at request time.

A DCR client registers once and persists its `client_id`, then comes back on a
new port every launch. First run registers `http://127.0.0.1:1456/...` and
works; second run arrives on port 49152 and is rejected. Every local-first
connector was affected. It stayed masked because a client that re-registers on
each launch never trips it.

The exemption covers **only the port**, and only for `http` + a loopback host.
Host, path, query, userinfo and fragment still match exactly, `localhost` is
still not `127.0.0.1`, and `https` is untouched (relaxing the port there would
let anyone controlling any port on a registered host collect auth codes).
`Client.loopback_host?/1` is now the single definition of loopback, shared by
registration and authorization so the two cannot drift.

The token endpoint keeps exact matching, correctly: it compares against the URI
actually used at authorize, stored on the code row.

## Spoofing hole found on the way

`software_id` arrives in the DCR request body, so it is self-asserted, yet it granted `verified: true`. Anyone registering `software_id: "anthropic-claude-desktop"` wore the Claude logo in the user's connections list.

Identity and verification are now computed **independently**. Only a vendor-owned HTTPS redirect host grants the badge, which is un-spoofable for grant delivery: a forger can claim `redirect_uri=https://claude.ai/...`, but the auth code is then delivered to Anthropic, not to them.

## The systemic root

None of these were visible. There was no telemetry on the DCR failure path, so a connector that could not register or could not be attributed failed silently, and the tests actively encoded the limitations as correct so green CI confirmed the bugs. Two tripwires added: `mcp_dcr_unattributed_client` and `mcp_dcr_rejected`.

## Predictions cashed

Cline and OpenCode were written into the test suite as *never-observed* connectors, asserting their names would derive from the catalog with no new config. Both registered for real while this PR was in progress and did exactly that. Under a hand-fed vendor map, each would have needed a code change.

## Found in review, fixed here

A full review pass turned up seven issues, four real defects, two of them
introduced earlier in this same branch.

**Proven identity now outranks claimed identity.** `resolve/3` checked
`software_id` before the redirect host. `software_id` arrives in the DCR request
body and is self-asserted; the host is not. So a client registering
`software_id: "openai-chatgpt"` while redirecting to `claude.ai` was listed as
**ChatGPT**, wearing a verified badge earned by *Anthropic's* host. Precedence is
now host → `software_id` → `client_name`.

This reversed a test written earlier in this branch that pinned the old order.
Worth stating plainly: a test that encodes a limitation as correct is exactly how
the original bug survived six weeks. The premise was wrong, not the code.

**The custom-scheme relaxation admitted host-less https.** `https:///cb` parses
with scheme `https` and host `""`, so it misses the https clause (which requires
a non-empty host) and fell through to the new permissive native-app branch. The
old dot-rule had rejected it. Regression test covers `https:///cb`, `https://`
and `https:foo`.

**The loopback port exemption ignored userinfo and fragment**, so
`http://evil@127.0.0.1/cb` matched `http://127.0.0.1/cb`. Now compares the whole
parsed URI with the port blanked, which also cannot silently widen if `URI`
gains a field.

**The DCR tripwire logged full redirect URIs.** For a self-hosted client that is
the operator's own domain and path, and `RequestLogger` already redacts request
paths. Now logs scheme + host only, which is all the classification needs.

Plus: two docs that claimed more than the code delivered (the register
controller still described confidential clients as unsupported; `LogoAllowlist`
implied the tightening stopped a spoofer wearing the Claude logo when it only
withheld the badge), a compiler warning that would fail `--warnings-as-errors`,
and reverted em-dash-to-comma churn in three files otherwise barely touched
(`onboarding.ex` 16 punctuation lines vs 2 substantive, `connections.ex` 6 vs 1,
`router.tsx` 14 vs 2) where the mechanical swap produced comma splices.

## Also here

- Onboarding page restructure: "other connections" folded into Coding Tools, the confusing "Just the web app" option reworked into an explicit "I'm not connecting an AI tool" opt-out.
- Greyed-out Gemini CLI entry with a hover tooltip: Google steered MCP users to Antigravity, so the gap is theirs, stated professionally.
- Brand icons for every catalog slug via the already-installed `@lobehub/icons-static-svg`.
- Dev-only connector QC gallery at `/dev/connector-qc` (verified absent from the production bundle).
- `docs/context/connections-client-identity.md` rewritten around the three hosting classes, the nine observed registrations, and the CIMD migration that will eventually replace DCR.

## Verification

- Backend: **3849 tests, 0 failures**; credo 0; dialyzer 0; format clean
- Frontend: **167 files / 1139 tests passed**; `tsc --noEmit` clean; `biome ci` clean
- Migration rollback verified
- Compiles under `--warnings-as-errors`
- Prod build verified to tree-shake the dev-only QC chunk
- `main` merged in (brings PR #1141); both suites re-run against the integrated tree

## Follow-ups (not in this PR)

- ~~File the CIMD issue~~ → filed as **#1148** (p1), with scoping: ~2 days, do not widen the `client_id` PK, SSRF guard is most of the work
- `engram-marketing`: the LobeChat page's "doesn't run an interactive OAuth handshake today" line is now wrong; Antigravity page needed before its `DOC_URLS` entry
- `chatgpt` → "OpenAI" and `lobechat` → "LobeHub" wordmark mismatches
