### PR TITLE
fix(onboarding): give the Antigravity checklist row its docs link

### DIFF
--- a/frontend/src/onboarding/checklist-widget.test.tsx
+++ b/frontend/src/onboarding/checklist-widget.test.tsx
@@ -5,7 +5,8 @@ import { useSyncExternalStore } from "react";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BillingStatus, Connection, OnboardingAction, OnboardingStatus } from "../api/queries";
-import { ChecklistWidget } from "./checklist-widget";
+import { ChecklistWidget, DOC_URLS } from "./checklist-widget";
+import { TOOL_ASSISTANTS, TOOL_CODING } from "./onboarding-tools";
 import type { useOnboardingActions } from "./use-onboarding-actions";
 
 let actionsList: OnboardingAction[] = [];
@@ -246,6 +247,26 @@ describe("ChecklistWidget, per-tool rows", () => {
 
 		const link = screen.getByRole("link", { name: /setup guide/iu });
 		expect(link).toHaveAttribute("href", "https://engram.page/docs/integrations/");
+	});
+
+	// #1157: `antigravity` sat in the widget's label map with no DOC_URLS entry,
+	// so its row silently rendered the generic index instead of its own guide.
+	// Asserted against the canonical FTUX catalog rather than a hand-copied
+	// list, so the next connector added there fails here until it is mapped.
+	//
+	// Deliberately a map-parity check and NOT a render: rendering all 14 rows
+	// costs enough CPU to starve a sibling suite's real-timer chain (it tipped
+	// agreement-page.flow.test.tsx over its waitFor budget under full-suite
+	// parallelism). Nothing here needs the DOM.
+	it("maps every selectable catalog tool to its own doc URL", () => {
+		const missing = [...TOOL_ASSISTANTS, ...TOOL_CODING]
+			// `unavailable` tools are absent from the backend @valid_tools and can
+			// never reach a saved profile, so they render no row to link.
+			.filter((t) => !t.unavailable)
+			.map((t) => t.slug)
+			.filter((slug) => !DOC_URLS[slug]);
+
+		expect(missing).toEqual([]);
 	});
 
 	it("per-tool CTA opens in a new tab with rel=noreferrer", () => {

--- a/frontend/src/onboarding/checklist-widget.tsx
+++ b/frontend/src/onboarding/checklist-widget.tsx
@@ -25,6 +25,9 @@ interface Item {
 	dismissible?: boolean;
 }
 
+// Every selectable slug in the FTUX catalog (onboarding-tools.ts) must have an
+// entry here, or its row silently renders the generic index instead of its own
+// guide (#1157). Exported at the foot of the file for the parity test.
 const DOC_URLS: Record<string, string> = {
 	install_obsidian_plugin: "https://engram.page/docs/obsidian/install/",
 	claude: "https://engram.page/docs/integrations/claude-desktop/",
@@ -40,10 +43,8 @@ const DOC_URLS: Record<string, string> = {
 	continue: "https://engram.page/docs/integrations/continue/",
 	opencode: "https://engram.page/docs/integrations/opencode/",
 	github_copilot: "https://engram.page/docs/integrations/github-copilot/",
+	antigravity: "https://engram.page/docs/integrations/antigravity/",
 	other_mcp: "https://engram.page/docs/mcp/manual-config/",
-	// No `antigravity` entry yet, engram-marketing has no integrations/antigravity/
-	// page, and a mapped-but-missing URL is a hard 404 where the unmapped
-	// fallback below is a working index. Add it with the marketing page.
 };
 const DOC_FALLBACK = "https://engram.page/docs/integrations/";
 
@@ -290,3 +291,8 @@ export function ChecklistWidget({ onStartTour }: Props) {
 		</section>
 	);
 }
+
+// Test-only surface. Kept here rather than inline on the declaration to
+// satisfy biome's useExportsLast, and out of the widget's public API since
+// nothing else in the app reads the map.
+export { DOC_URLS };

--- a/frontend/src/onboarding/tool-icon.tsx
+++ b/frontend/src/onboarding/tool-icon.tsx
@@ -41,6 +41,12 @@ interface Brand {
 // Skipping the MCP wordmark deliberately: ships as "ModelContextProtocol"
 // (335px viewBox) which dominates the row and isn't the label we want here
 // anyway. We fall through to the plain `fallbackLabel`.
+// `chatgpt` and `lobechat` intentionally wear their VENDOR's mark (OpenAI,
+// LobeHub) rather than the product's. Checked 2026-07-31 (#1157): the
+// package ships no `chatgpt-*` or `lobechat-*` asset at all, only
+// `openai*.svg` and `lobehub*.svg`, so the vendor mark is the whole of what
+// is available. Not drift, and not worth re-investigating — it changes only
+// if @lobehub/icons-static-svg adds product-specific assets.
 const BRANDS: Record<string, Brand> = {
 	claude: { mark: claudeColor, wordmark: claudeText },
 	chatgpt: { mark: openaiMark, wordmark: openaiText },


### PR DESCRIPTION
Closes #1157.

## The fix

`antigravity` was in the widget's `TOOL_LABELS` but missing from `DOC_URLS`, so its row fell through to `DOC_FALLBACK` and pointed at the generic integrations index instead of its own guide.

The comment explaining the omission was written during #1147 and went stale before that PR merged. Re-verified before adding the entry:

```
$ curl -sL -o /dev/null -w '%{http_code}' https://engram.page/docs/integrations/antigravity/
200
```

That check mattered — the stale comment's reasoning ("a mapped-but-missing URL is a hard 404 where the unmapped fallback is a working index") was *correct*, it had just expired.

## The regression test, and why it is a map comparison

The bug class is **drift between two maps that must agree**: `TOOL_LABELS` (and the canonical FTUX catalog in `onboarding-tools.ts`) versus `DOC_URLS`. A test that only pinned `antigravity` would let the next connector drift the same way.

So the test asserts every selectable slug in the **canonical catalog** has a `DOC_URLS` entry — asserted against the catalog rather than a hand-copied list, because a hand-copied list is the same drift again. It reports the offenders by name:

```
AssertionError: expected [ 'antigravity' ] to deeply equal []
```

`unavailable` catalog entries (currently `gemini`) are excluded: they're absent from the backend `@valid_tools` and can never reach a saved profile, so they render no row to link.

## A note on the first version of this test

I originally wrote it as a render — set `profile.tools` to all 14 slugs, assert no `Setup guide` href equals the fallback. It worked, but it made the **full suite go red** in `agreement-page.flow.test.tsx`:

```
TestingLibraryElementError: Unable to find an element by: [data-testid="billing-landed"]
```

That test chains ~100ms of real `setTimeout` inside a `waitFor` (1000ms default). Rendering 14 rows added enough CPU load under vitest's parallel workers to starve it past the budget.

Measured rather than assumed, since it looked like an unrelated flake:

| | full-suite result |
|---|---|
| `main`, unmodified | **2/2 green** |
| this branch, render version | **0/2** — same test, same assertion |
| this branch, map-comparison version | **2/2 green** (1140 tests) |

Nothing being asserted here needs the DOM, so the map comparison is both cheaper and more direct. **`agreement-page.flow.test.tsx` remains latently load-sensitive** and I have not touched it — that's a real fragility, but it's a separate concern from a docs URL and deserves its own change. Worth filing if it resurfaces.

`DOC_URLS` is exported at the foot of the file (biome's `useExportsLast`) and marked test-only; nothing else in the app reads it.

## Also: the wordmark question from the issue

The issue asked for an eyeball on two suspected brand mismatches. Both suspicions are **correct but not fixable**, and that is now recorded in `tool-icon.tsx` rather than left to be re-investigated:

- `chatgpt` → `openai.svg` / `openai-text.svg`
- `lobechat` → `lobehub-color.svg` / `lobehub-text.svg`

`@lobehub/icons-static-svg` ships **no** `chatgpt-*` or `lobechat-*` asset at all — only `openai*` and `lobehub*`. The vendor mark is the whole of what's available, so this is a dependency constraint, not drift.

## Gate

| check | result |
|---|---|
| `biome ci .` | pass (478 files) |
| `tsc --noEmit` | pass |
| `vitest run` (full) | **167 files, 1140 tests, 0 failures** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvUvadaneVBQXax8NfeNJU