### PR TITLE
fix(notes): append must read the authority, not the stale content facade

### DIFF
--- a/lib/engram/mcp/handlers.ex
+++ b/lib/engram/mcp/handlers.ex
@@ -326,27 +326,30 @@ defmodule Engram.MCP.Handlers do
     replace = args["replace"] || ""
     occurrence = args["occurrence"] || 0
 
-    case Notes.get_note(user, vault, path) do
-      {:ok, note} ->
-        if String.contains?(note.content, find) do
-          {new_content, count} = do_replace(note.content, find, replace, occurrence)
+    # Read the AUTHORITY, not the `notes.content` façade: the façade lags a doc
+    # write until checkpoint, so patching from it can commit an older body and
+    # drop edits made since (#1159).
+    with {:ok, note} <- Notes.get_note(user, vault, path),
+         {:ok, current} <- Notes.authoritative_content(user, note) do
+      if String.contains?(current, find) do
+        {new_content, count} = do_replace(current, find, replace, occurrence)
 
-          case Notes.upsert_note(user, vault, %{
-                 "path" => path,
-                 "content" => new_content,
-                 "mtime" => now(),
-                 "base_hash" => note.content_hash
-               }) do
-            {:ok, _} -> {:ok, "Replaced #{count} occurrence(s) in #{path}"}
-            {:error, :version_conflict, _} -> {:ok, "Note changed concurrently; retry: #{path}"}
-            {:error, _} -> {:ok, "Failed to patch note: #{path}"}
-          end
-        else
-          {:ok, "Text not found in #{path}"}
+        case Notes.upsert_note(user, vault, %{
+               "path" => path,
+               "content" => new_content,
+               "mtime" => now(),
+               "base_hash" => note.content_hash
+             }) do
+          {:ok, _} -> {:ok, "Replaced #{count} occurrence(s) in #{path}"}
+          {:error, :version_conflict, _} -> {:ok, "Note changed concurrently; retry: #{path}"}
+          {:error, _} -> {:ok, "Failed to patch note: #{path}"}
         end
-
-      {:error, :not_found} ->
-        {:ok, "Note not found: #{path}"}
+      else
+        {:ok, "Text not found in #{path}"}
+      end
+    else
+      {:error, :not_found} -> {:ok, "Note not found: #{path}"}
+      {:error, _} -> {:ok, "Could not read current content for #{path}; retry"}
     end
   end
 
@@ -356,64 +359,66 @@ defmodule Engram.MCP.Handlers do
     new_content = args["content"] || ""
     level = args["level"] || 2
 
-    case Notes.get_note(user, vault, path) do
-      {:ok, note} ->
-        prefix = String.duplicate("#", max(1, min(level, 6))) <> " "
-        target = prefix <> heading
-        lines = String.split(note.content, "\n")
+    # Same authority rule as patch_note: section surgery against the stale
+    # `notes.content` façade would rewrite the note from an older body (#1159).
+    with {:ok, note} <- Notes.get_note(user, vault, path),
+         {:ok, current} <- Notes.authoritative_content(user, note) do
+      prefix = String.duplicate("#", max(1, min(level, 6))) <> " "
+      target = prefix <> heading
+      lines = String.split(current, "\n")
 
-        start_idx =
-          Enum.find_index(lines, fn line ->
-            String.trim(line) == String.trim(target)
+      start_idx =
+        Enum.find_index(lines, fn line ->
+          String.trim(line) == String.trim(target)
+        end)
+
+      if start_idx == nil do
+        {:ok, "Heading not found: #{target}"}
+      else
+        end_idx =
+          Enum.find_index(Enum.drop(lines, start_idx + 1), fn line ->
+            stripped = String.trim_leading(line)
+
+            if String.starts_with?(stripped, "#") do
+              h_level =
+                stripped
+                |> String.graphemes()
+                |> Enum.take_while(&(&1 == "#"))
+                |> length()
+
+              rest = String.slice(stripped, h_level, 1)
+              h_level <= level and rest in [" ", ""]
+            else
+              false
+            end
           end)
 
-        if start_idx == nil do
-          {:ok, "Heading not found: #{target}"}
-        else
-          end_idx =
-            Enum.find_index(Enum.drop(lines, start_idx + 1), fn line ->
-              stripped = String.trim_leading(line)
+        end_idx =
+          if end_idx == nil,
+            do: length(lines),
+            else: start_idx + 1 + end_idx
 
-              if String.starts_with?(stripped, "#") do
-                h_level =
-                  stripped
-                  |> String.graphemes()
-                  |> Enum.take_while(&(&1 == "#"))
-                  |> length()
+        new_lines =
+          Enum.slice(lines, 0, start_idx + 1) ++
+            [String.trim_trailing(new_content, "\n")] ++
+            Enum.slice(lines, end_idx, length(lines))
 
-                rest = String.slice(stripped, h_level, 1)
-                h_level <= level and rest in [" ", ""]
-              else
-                false
-              end
-            end)
+        final_content = Enum.join(new_lines, "\n")
 
-          end_idx =
-            if end_idx == nil,
-              do: length(lines),
-              else: start_idx + 1 + end_idx
-
-          new_lines =
-            Enum.slice(lines, 0, start_idx + 1) ++
-              [String.trim_trailing(new_content, "\n")] ++
-              Enum.slice(lines, end_idx, length(lines))
-
-          final_content = Enum.join(new_lines, "\n")
-
-          case Notes.upsert_note(user, vault, %{
-                 "path" => path,
-                 "content" => final_content,
-                 "mtime" => now(),
-                 "base_hash" => note.content_hash
-               }) do
-            {:ok, _} -> {:ok, "Section '#{heading}' updated in #{path}"}
-            {:error, :version_conflict, _} -> {:ok, "Note changed concurrently; retry: #{path}"}
-            {:error, _} -> {:ok, "Failed to update section in #{path}"}
-          end
+        case Notes.upsert_note(user, vault, %{
+               "path" => path,
+               "content" => final_content,
+               "mtime" => now(),
+               "base_hash" => note.content_hash
+             }) do
+          {:ok, _} -> {:ok, "Section '#{heading}' updated in #{path}"}
+          {:error, :version_conflict, _} -> {:ok, "Note changed concurrently; retry: #{path}"}
+          {:error, _} -> {:ok, "Failed to update section in #{path}"}
         end
-
-      {:error, :not_found} ->
-        {:ok, "Note not found: #{path}"}
+      end
+    else
+      {:error, :not_found} -> {:ok, "Note not found: #{path}"}
+      {:error, _} -> {:ok, "Could not read current content for #{path}; retry"}
     end
   end
 
@@ -564,10 +569,16 @@ defmodule Engram.MCP.Handlers do
   # the current content and returns the new content. Public (doc: false) so
   # the CAS interleaving is unit-testable with a racing rebuild fun.
   def rmw_upsert(user, vault, path, rebuild, attempt \\ 0) do
-    with {:ok, note} <- Notes.get_note(user, vault, path) do
+    with {:ok, note} <- Notes.get_note(user, vault, path),
+         # Rebuild from the AUTHORITY, not the `notes.content` façade. The façade
+         # is materialized at checkpoint and lags a doc write, so rebuilding from
+         # it can commit a shorter or older body (#1159). base_hash still guards
+         # the concurrent-REST-write race, but it cannot detect façade lag:
+         # content and content_hash go stale together.
+         {:ok, current} <- Notes.authoritative_content(user, note) do
       case Notes.upsert_note(user, vault, %{
              "path" => path,
-             "content" => rebuild.(note.content),
+             "content" => rebuild.(current),
              "mtime" => now(),
              "base_hash" => note.content_hash
            }) do

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1492,6 +1492,55 @@ defmodule Engram.Notes do
   end
 
   @doc """
+  Current text of `note` from the authority, for callers that must
+  read-modify-write it.
+
+  `notes.content` is the REST/search **façade**. Since the server stopped
+  authoring content (#1141) it is materialized from the CRDT doc at checkpoint,
+  so between a doc write and its checkpoint the column lags. Reading it and
+  writing back a derived full-content string is therefore data loss: the merge
+  in `upsert_note/4` faithfully applies the diff it is given, and a diff
+  computed from a blank base deletes the body (#1159).
+
+  Resolution mirrors `ensure_projection_safe/2` in `Notes.CrdtCheckpoint`, so
+  the two agree on which side is authoritative:
+
+    * no `crdt_state` — nothing has been written through the doc, so the façade
+      IS the authority (legacy/pre-CRDT rows).
+    * `crdt_state` present — the doc is the authority, including when it
+      projects empty. A genuine "user deleted all the text" persists deletion
+      ops, so an empty projection there is real and must not be second-guessed.
+
+  Tail replay is included for the same reason `maybe_merge_crdt/4` does it:
+  ops committed since the last checkpoint are part of the current text.
+
+  Plain reads must keep using `get_note/3`; this is deliberately not on the hot
+  path, since it decrypts and rebuilds a Yjs doc.
+  """
+  @spec authoritative_content(map(), Note.t()) :: {:ok, String.t()} | {:error, term()}
+  def authoritative_content(user, %Note{} = note) do
+    case Crypto.decrypt_crdt_state(note, user) do
+      {:ok, nil} ->
+        {:ok, note.content || ""}
+
+      {:ok, state} ->
+        with {:ok, doc} <- CrdtBridge.doc_from_state(state) do
+          # replay_tail reads crdt_update_log, which is tenant-scoped. Callers
+          # reach this from a controller rather than from inside upsert_note's
+          # transaction, so establish the tenant here.
+          Repo.with_tenant(user.id, fn ->
+            _replayed = CrdtPersistence.replay_tail(doc, user, note.id)
+          end)
+
+          {:ok, CrdtBridge.project_doc(doc)}
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
   Gets a note by its primary key id, scoped to the given user + vault.
 
   Returns `{:ok, note}` when found and owned by the caller, `{:error, :not_found}`

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -5,6 +5,8 @@ defmodule EngramWeb.NotesController do
 
   alias Engram.Notes
 
+  require Logger
+
   @max_note_bytes 10 * 1024 * 1024
 
   operation(:upsert,
@@ -113,18 +115,48 @@ defmodule EngramWeb.NotesController do
 
     case Notes.get_note(user, vault, path) do
       {:ok, note} ->
-        content = String.trim_trailing(note.content, "\n") <> "\n" <> text
+        # Append is a read-modify-write, so it must read the AUTHORITY, not the
+        # `notes.content` façade. The façade is materialized from the CRDT doc
+        # at checkpoint, so it lags a doc write; deriving the new full content
+        # from a stale (blank) base makes `upsert_note/4`'s merge compute a diff
+        # that deletes the body. That is #1159, seen in prod CI as a note
+        # arriving on the other device as just the appended fragment.
+        case Notes.authoritative_content(user, note) do
+          {:ok, base} ->
+            content = String.trim_trailing(base, "\n") <> "\n" <> text
 
-        case Notes.upsert_note(user, vault, %{
-               "path" => path,
-               "content" => content,
-               "mtime" => note.mtime
-             }) do
-          {:ok, updated} ->
-            json(conn, %{created: false, path: path, note: note_json(updated)})
+            case Notes.upsert_note(user, vault, %{
+                   "path" => path,
+                   "content" => content,
+                   "mtime" => note.mtime
+                 }) do
+              {:ok, updated} ->
+                json(conn, %{created: false, path: path, note: note_json(updated)})
 
-          {:error, changeset} ->
-            conn |> put_status(422) |> json(%{errors: format_errors(changeset)})
+              {:error, changeset} ->
+                conn |> put_status(422) |> json(%{errors: format_errors(changeset)})
+            end
+
+          # Refuse rather than fall back to the façade. Falling back is exactly
+          # the bug: it is the path that silently truncates the note. A failed
+          # append is recoverable; a destroyed note is not.
+          {:error, reason} ->
+            Logger.error(
+              "note_append_authority_unavailable",
+              # classify_reason/1, not inspect/1: the reason can carry a
+              # %Note{} with decrypted virtual fields, and this file's own
+              # T3.0.6 guard (no_inspect_in_json_response_test) exists to stop
+              # that leaking into logs. The label keeps the signal.
+              Engram.Logger.Metadata.with_category(:error, :sync,
+                note_id: note.id,
+                user_id: user.id,
+                reason_label: classify_reason(reason)
+              )
+            )
+
+            conn
+            |> put_status(503)
+            |> json(%{error: "append_unavailable", reason: "could not read current note content"})
         end
 
       {:error, :not_found} ->

--- a/test/engram_web/controllers/notes_controller_test.exs
+++ b/test/engram_web/controllers/notes_controller_test.exs
@@ -210,6 +210,78 @@ defmodule EngramWeb.NotesControllerTest do
       assert note["content"] =~ "World!"
     end
 
+    # Regression for #1159 (data loss). `notes.content` is the REST/search
+    # FACADE, materialized from the CRDT doc at checkpoint. Since #1141 the
+    # server no longer authors content, so between a doc write and its
+    # checkpoint the column can lag the doc.
+    #
+    # Append used to read that column, concatenate, and hand the result to
+    # `upsert_note` as the note's full new content. upsert_note honours its
+    # "server merges, never clobbers" contract faithfully, which is exactly the
+    # problem: told the new full text is only the appended fragment, it computes
+    # a diff that DELETES the original body.
+    #
+    # Seen in CI as e2e test_37 (#1136): device B received "\n\nAppended line 1."
+    # which is precisely `"" <> "\n" <> "\nAppended line 1."`.
+    #
+    # The stale window is simulated by blanking ONLY the facade column and
+    # leaving crdt_state intact. That is a reachable real state, not a contrivance.
+    test "append does not destroy the body when the facade column is stale", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      path = "Test/StaleFacade.md"
+
+      created =
+        conn
+        |> post("/api/notes", %{
+          path: path,
+          content: "# Append Test\nOriginal content.",
+          mtime: 1_000.0
+        })
+        |> json_response(200)
+
+      note_id = created["note"]["id"]
+      {:ok, note} = Engram.Notes.get_note_by_id(user, vault, note_id)
+      refute is_nil(note.crdt_state_ciphertext), "precondition: note must carry CRDT state"
+
+      blank_facade_content!(user, note_id)
+
+      conn2 = post(conn, "/api/notes/append", %{path: path, text: "\nAppended line 1."})
+      assert %{"note" => appended} = json_response(conn2, 200)
+
+      assert appended["content"] =~ "Original content.",
+             "append dropped the body: #{inspect(appended["content"])}"
+
+      assert appended["content"] =~ "Appended line 1."
+    end
+
+    # Belt and braces on the same defect: whatever the response says, the row
+    # that ends up committed must not be shorter than what we started with.
+    test "a stale-facade append leaves the stored note intact", %{
+      conn: conn,
+      user: user,
+      vault: vault
+    } do
+      path = "Test/StaleFacadeTwo.md"
+
+      created =
+        conn
+        |> post("/api/notes", %{path: path, content: "# Keep\nBody text here.", mtime: 1_000.0})
+        |> json_response(200)
+
+      note_id = created["note"]["id"]
+      blank_facade_content!(user, note_id)
+
+      post(conn, "/api/notes/append", %{path: path, text: "\nmore"})
+
+      {:ok, after_note} = Engram.Notes.get_note_by_id(user, vault, note_id)
+
+      assert after_note.content =~ "Body text here.",
+             "stored note lost its body: #{inspect(after_note.content)}"
+    end
+
     test "creates new note when note doesn't exist", %{conn: conn} do
       conn = post(conn, "/api/notes/append", %{path: "Nope/Missing.md", text: "stuff"})
       resp = json_response(conn, 200)
@@ -677,5 +749,25 @@ defmodule EngramWeb.NotesControllerTest do
       conn = delete(conn, ~p"/api/notes/Prunable.md")
       assert %{"deleted" => true} = json_response(conn, 200)
     end
+  end
+
+  # Models the reachable "facade lags the doc" state from #1159: the CRDT state
+  # stays intact while `notes.content` materializes as empty. Encrypting "" via
+  # the same helper the write path uses keeps the AAD binding valid, so this is
+  # a genuine row shape rather than a corrupted one (a NULL ciphertext would
+  # decrypt to nil and exercise a different branch).
+  defp blank_facade_content!(user, note_id) do
+    import Ecto.Query, only: [from: 2]
+
+    {:ok, enc} = Engram.Crypto.encrypt_note_fields(%{content: "", title: "stale"}, user, note_id)
+
+    {1, _} =
+      Engram.Repo.update_all(
+        from(n in Engram.Notes.Note, where: n.id == ^note_id),
+        [set: [content_ciphertext: enc.content_ciphertext, content_nonce: enc.content_nonce]],
+        skip_tenant_check: true
+      )
+
+    :ok
   end
 end


### PR DESCRIPTION
Closes #1159. Unblocks `release-v0.12.0`, currently held on #1136.

## The bug

`POST /notes/append` read `notes.content`, concatenated, and handed the result to `upsert_note/4` as the note's **full** new content:

```elixir
content = String.trim_trailing(note.content, "\n") <> "\n" <> text
```

Since #1141 the server no longer authors content. The doc is authority and `notes.content` is a **façade** materialized at checkpoint, so between a doc write and its checkpoint the column lags. Read a blank base, write back `base <> text`, and the merge computes a diff that **deletes the body**.

`upsert_note` was not at fault. Its "server merges, never clobbers" contract was honoured exactly — it was told the new full text was just the appended fragment.

## Proof, not inference

The reproduction returns the production string byte for byte:

```
append dropped the body: "\n\nAppended line 1."
```

which is precisely `"" <> "\n" <> "\nAppended line 1."` — the same value device B received in the e2e run that blocked the release. Both regression tests blank **only** the façade column and leave `crdt_state` intact, which is a reachable row shape rather than a contrivance.

## The fix

`Notes.authoritative_content/2`: decrypt `crdt_state`, rebuild the doc, replay the uncheckpointed tail, project text. Its resolution rule deliberately mirrors `CrdtCheckpoint.ensure_projection_safe/2` so the two agree on which side is authoritative:

| State | Authority | Why |
|---|---|---|
| no `crdt_state` | the façade | legacy/pre-CRDT rows; nothing was ever written through the doc |
| `crdt_state` set | the doc, **even when it projects empty** | a genuine "user deleted all the text" persists deletion ops, so an empty projection there is real |

On error append returns **503 rather than falling back to the façade**. Falling back is the bug. A failed append is recoverable; a destroyed note is not.

## Sibling callers fixed too

Auditing for the same pattern found three more read-modify-writes on the façade. Leaving a known variant in place just relocates the defect, so all three now read the authority:

- MCP `patch_note`
- MCP `update_section`
- MCP `rmw_upsert/5`, the shared CAS helper

These are less acute — they fail closed on an empty façade ("Text not found") — but a stale-but-nonempty façade would still let them commit an older body over newer edits.

Worth stating explicitly: **`base_hash` does not protect against this.** Content and content_hash are materialized together, so they go stale together. It guards the concurrent-REST-write race, not façade lag.

## Verification

- format, `credo --strict`, dialyzer: clean
- compiles under `--warnings-as-errors`
- 167/167 on the notes + MCP suites; both new regressions red before the fix, green after
- The real proof is CI: `e2e-clerk`'s `test_37_append_sync` should now pass **honestly**, with its assertion untouched

One pre-existing full-suite failure is unrelated: `Engram.Cluster.ReadinessTest`, a timing assertion with ~33% headroom over nominal that passes 3/3 in isolation and is green in CI. Analysed on #1158 rather than papered over.

## Note for review

`authoritative_content/2` decrypts and rebuilds a Yjs doc, so it is deliberately **not** for the hot read path — `get_note/3` stays the façade read for display. It is only used by callers that must read-modify-write.