### PR TITLE
fix(connections): delete the guessed software_id entries, link Antigravity docs

### DIFF
--- a/docs/context/connections-client-identity.md
+++ b/docs/context/connections-client-identity.md
@@ -233,9 +233,15 @@ SELECT software_id, client_name, redirect_uris FROM oauth_clients;
 
 `@lobehub/icons-static-svg` is already a dependency and already covers every catalog slug. Use `ToolMark slug={...}` (`frontend/src/onboarding/tool-icon.tsx`). The backend `logo: "/assets/clients/*.svg"` field is a legacy parallel system still needed only for `engram-vault-sync` and `vscode`; `grok.svg`/`mistral.svg` were never created and don't need to be.
 
-## Known stale: the 4 guessed `software_id` entries
+## The 4 guessed `software_id` entries were DELETED (2026-07-31, #1156)
 
-`anthropic-claude-desktop`, `cursor.sh`, `openai-chatgpt`, `vscode-engram` are UNVALIDATED guesses. Prod data now **proves** they never fire (the real ChatGPT and Claude grants both arrive with `software_id: null`). Harmless, but they read as coverage, do not add more speculative entries. The only proven-real `software_id` is our own `engram-vault-sync`.
+`anthropic-claude-desktop`, `cursor.sh`, `openai-chatgpt` and `vscode-engram` were unvalidated guesses. Prod proved they never fire: all nine observed connectors are attributed by redirect host or by `client_name`, and **not one sends `software_id` at all** (the real ChatGPT and Claude grants both arrive with `software_id: null`).
+
+This section used to call them "harmless". They were not. Because `software_id` is self-asserted, each entry was a standing offer: register claiming `anthropic-claude-desktop` and the connections list hands you Claude's logo and display name, with no `unverified` chip (the chip is suppressed whenever a slug resolves, so Claude Code is not badged as suspect). They attributed nobody real, while giving anyone who read the source a free vendor identity.
+
+`@software_id` now holds exactly **one** entry, our own `engram-vault-sync`, which genuinely needs it: the plugin redirects to a custom scheme, so no host identifies it and name derivation does not cover it.
+
+> **Do not re-add a vendor entry speculatively.** An entry here is a claim we have agreed to render, not a fact. Add one only after `mcp_dcr_unattributed_client` shows a real client that needs it AND nothing else can attribute it. `logo_allowlist_test.exs` pins all four deleted ids as conferring no branding.
 
 `@name_aliases` currently carries one **inferred, not observed** entry: `visual_studio_code` → `github_copilot`. VS Code drives MCP OAuth itself, above the extension, so a Copilot user's grant is expected to arrive under the product name. The tripwire will confirm or refute it.
 

--- a/frontend/src/onboarding/checklist-widget.test.tsx
+++ b/frontend/src/onboarding/checklist-widget.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BillingStatus, Connection, OnboardingAction, OnboardingStatus } from "../api/queries";
 import { ChecklistWidget } from "./checklist-widget";
+import { TOOL_ASSISTANTS, TOOL_CODING } from "./onboarding-tools";
 import type { useOnboardingActions } from "./use-onboarding-actions";
 
 let actionsList: OnboardingAction[] = [];
@@ -238,6 +239,36 @@ describe("ChecklistWidget, per-tool rows", () => {
 
 		expect(screen.getByText(/connect claude/iu)).toHaveClass("line-through");
 		expect(screen.getByText(/connect another mcp client/iu)).not.toHaveClass("line-through");
+	});
+
+	// Structural guard for #1157. Antigravity shipped with a catalog entry, a
+	// label and an icon, but no DOC_URLS mapping, so its row silently rendered the
+	// generic index instead of its own guide. Nothing failed, because the fallback
+	// made the gap invisible.
+	//
+	// The fallback exists for slugs we do not recognise (a stale profile from an
+	// older release). It must never be what a CURRENT catalog connector resolves
+	// to, so assert per-slug instead of trusting the map to be complete by eye.
+	//
+	// `unavailable` entries are excluded: Gemini is listed to explain that it
+	// cannot connect, and deliberately has no guide.
+	it("every selectable catalog connector maps to its own doc URL, not the fallback", () => {
+		const selectable = [...TOOL_ASSISTANTS, ...TOOL_CODING].filter((t) => !t.unavailable);
+
+		expect(selectable.length).toBeGreaterThan(10);
+
+		for (const { slug, label } of selectable) {
+			onboardingStatusValue.data!.profile = { uses_obsidian: false, tools: [slug] };
+			const { unmount } = render(wrap(<ChecklistWidget onStartTour={() => {}} />));
+
+			const link = screen.getByRole("link", { name: /setup guide/iu });
+			expect(
+				link.getAttribute("href"),
+				`${label} (${slug}) has no DOC_URLS entry, so its row falls back to the docs index`,
+			).not.toBe("https://engram.page/docs/integrations/");
+
+			unmount();
+		}
 	});
 
 	it("falls back to /docs/integrations/ for an unmapped slug", () => {

--- a/frontend/src/onboarding/checklist-widget.tsx
+++ b/frontend/src/onboarding/checklist-widget.tsx
@@ -40,10 +40,8 @@ const DOC_URLS: Record<string, string> = {
 	continue: "https://engram.page/docs/integrations/continue/",
 	opencode: "https://engram.page/docs/integrations/opencode/",
 	github_copilot: "https://engram.page/docs/integrations/github-copilot/",
+	antigravity: "https://engram.page/docs/integrations/antigravity/",
 	other_mcp: "https://engram.page/docs/mcp/manual-config/",
-	// No `antigravity` entry yet, engram-marketing has no integrations/antigravity/
-	// page, and a mapped-but-missing URL is a hard 404 where the unmapped
-	// fallback below is a working index. Add it with the marketing page.
 };
 const DOC_FALLBACK = "https://engram.page/docs/integrations/";
 

--- a/lib/engram/connections/logo_allowlist.ex
+++ b/lib/engram/connections/logo_allowlist.ex
@@ -35,29 +35,26 @@ defmodule Engram.Connections.LogoAllowlist do
 
   @empty %{verified: false, logo: nil, display_name: nil, slug: nil}
 
-  # Keyed on RFC 7591 software_id. `engram-vault-sync` is our own plugin and is
-  # the only proven-real entry. The other four are unvalidated guesses left in
-  # place (harmless, real clients never send them) pending observation.
+  # Keyed on RFC 7591 software_id.
+  #
+  # ONE entry, deliberately: our own Obsidian plugin, which needs it because it
+  # redirects to a custom scheme and so has no host to be identified by.
+  #
+  # Four vendor guesses (`anthropic-claude-desktop`, `cursor.sh`,
+  # `openai-chatgpt`, `vscode-engram`) were deleted 2026-07-31 (#1156). None had
+  # ever been observed on a real registration: all nine connectors seen in prod
+  # are attributed by redirect host or by `client_name`, and not one sends
+  # software_id. They therefore attributed nobody, while handing anyone who read
+  # this file a free vendor logo and display name just by claiming the id.
+  #
+  # Do not re-add a vendor entry speculatively. `software_id` is self-asserted,
+  # so an entry here is a claim we have agreed to render, not a fact. Add one
+  # only once `mcp_dcr_unattributed_client` shows a real client that needs it
+  # AND nothing else can attribute it.
   @software_id %{
     "engram-vault-sync" => %{
       logo: "/assets/clients/engram-vault-sync.svg",
       display_name: "Obsidian Vault Sync",
-      slug: nil
-    },
-    "anthropic-claude-desktop" => %{
-      logo: "/assets/clients/claude.svg",
-      display_name: "Claude Desktop",
-      slug: "claude"
-    },
-    "cursor.sh" => %{logo: "/assets/clients/cursor.svg", display_name: "Cursor", slug: "cursor"},
-    "openai-chatgpt" => %{
-      logo: "/assets/clients/chatgpt.svg",
-      display_name: "ChatGPT",
-      slug: "chatgpt"
-    },
-    "vscode-engram" => %{
-      logo: "/assets/clients/vscode.svg",
-      display_name: "VS Code (Engram)",
       slug: nil
     }
   }

--- a/test/engram/connections/logo_allowlist_test.exs
+++ b/test/engram/connections/logo_allowlist_test.exs
@@ -7,12 +7,28 @@ defmodule Engram.Connections.LogoAllowlistTest do
     assert %{verified: false, logo: "/assets/clients/engram-vault-sync.svg"} = result
   end
 
-  # software_id arrives in the DCR body, it is a claim, not a proof. If this
-  # ever goes green with verified: true, anyone can wear the Claude Desktop
-  # logo and badge in a victim's connections list by registering that id.
-  test "a self-asserted software_id cannot buy the verified badge" do
-    assert %{verified: false, display_name: "Claude Desktop", logo: "/assets/clients/claude.svg"} =
-             LogoAllowlist.resolve("anthropic-claude-desktop", ["http://localhost:1234/cb"])
+  # software_id arrives in the DCR body: a claim, not a proof.
+  #
+  # Tightened twice. #1147 stopped it granting `verified`, but it still handed
+  # over the vendor's logo and display name. #1156 deleted the four guessed
+  # vendor entries outright, so claiming one now buys NOTHING: no badge, no
+  # logo, no name, no slug.
+  #
+  # If any of these start returning vendor branding again, someone has re-added
+  # a speculative @software_id entry and reopened the hole.
+  test "claiming a vendor software_id buys no branding at all" do
+    for claimed <- ~w(anthropic-claude-desktop cursor.sh openai-chatgpt vscode-engram) do
+      assert %{verified: false, display_name: nil, logo: nil, slug: nil} =
+               LogoAllowlist.resolve(claimed, ["http://localhost:1234/cb"]),
+             "#{claimed} must not confer branding"
+    end
+  end
+
+  # Our own plugin is the one legitimate entry: it redirects to a custom scheme,
+  # so no host identifies it and client_name derivation does not cover it.
+  test "our own plugin is still identified by software_id" do
+    assert %{verified: false, display_name: "Obsidian Vault Sync", slug: nil} =
+             LogoAllowlist.resolve("engram-vault-sync", ["obsidian://engram/cb"])
   end
 
   test "unknown software_id returns unverified placeholder" do

--- a/test/engram_web/controllers/connections_controller_test.exs
+++ b/test/engram_web/controllers/connections_controller_test.exs
@@ -29,11 +29,15 @@ defmodule EngramWeb.ConnectionsControllerTest do
     test "returns oauth + pat rows for the authenticated user", %{conn: conn} do
       user = insert(:user)
 
+      # Mirrors a real observed registration rather than a synthetic one: no
+      # software_id (not one connector seen in prod sends it) plus a loopback
+      # redirect, so attribution comes from client_name. The trailing
+      # parenthetical is the user-chosen server name Claude Code appends.
       client =
         insert(:oauth_client,
           kind: "mcp",
-          software_id: "anthropic-claude-desktop",
-          client_name: "Claude Desktop"
+          software_id: nil,
+          client_name: "Claude Code (engram)"
         )
 
       insert(:oauth_refresh_token, user_id: user.id, client_id: client.client_id)
@@ -51,10 +55,11 @@ defmodule EngramWeb.ConnectionsControllerTest do
       assert is_list(body)
 
       mcp = Enum.find(body, fn r -> r["kind"] == "mcp" end)
-      assert mcp["name"] == "Claude Desktop"
-      # Loopback redirect + self-asserted software_id => identity yes, badge no.
+      assert mcp["name"] == "Claude Code (engram)"
+      # Loopback redirect is unverifiable by construction, so: slug yes (the
+      # checklist row can tick), badge no.
       assert mcp["verified"] == false
-      assert mcp["slug"] == "claude"
+      assert mcp["slug"] == "claude_code"
       assert mcp["client_id"] == client.client_id
 
       pat = Enum.find(body, fn r -> r["kind"] == "pat" end)


### PR DESCRIPTION
Two follow-ups from the #1147 review. Closes #1156, closes #1157.

## 1. A self-asserted `software_id` no longer buys vendor branding (#1156)

`@software_id` carried four vendor guesses — `anthropic-claude-desktop`, `cursor.sh`, `openai-chatgpt`, `vscode-engram` — that had **never** been seen on a real registration. All nine connectors observed in prod are attributed by redirect host or by `client_name`, and not one sends `software_id` at all.

They were previously documented as "harmless". They were not.

`software_id` arrives in the DCR request body, so it is self-asserted. Each entry was a standing offer: register claiming `anthropic-claude-desktop` and the connections list hands you Claude's **logo and display name**, with no `unverified` chip — because the chip is deliberately suppressed whenever a slug resolves, so that Claude Code isn't badged as suspect. So they attributed nobody real, while giving anyone who read the source a free vendor identity.

#1147 stopped `software_id` granting the `verified` badge. This closes the rest of it.

One entry remains: our own `engram-vault-sync`, which genuinely needs it — the plugin redirects to a custom scheme, so no host identifies it and name derivation doesn't cover it.

A test pins all four deleted ids as conferring **nothing**: no badge, no logo, no name, no slug. If vendor branding comes back, someone has re-added a speculative entry.

### Test fixture change worth reviewing

`connections_controller_test` used `software_id: "anthropic-claude-desktop"` to assert the endpoint serializes `slug`. That fixture depended on a deleted guess, so I re-pointed it at a **real observed shape** (no `software_id`, loopback redirect, `client_name: "Claude Code (engram)"`). It proves the same thing — the endpoint serializes `slug` — without asserting a mapping that no longer exists.

## 2. Antigravity's checklist row had no docs link (#1157)

Adds the `DOC_URLS` entry and deletes the comment claiming the marketing page doesn't exist. It does, and returns 200 — the comment went stale during #1147.

**The entry is the trivial part; the guard is the point.** `DOC_URLS[slug] ?? DOC_FALLBACK` renders the generic docs index for an unmapped slug, so a missing entry fails *invisibly*. That is precisely why nobody noticed.

Added a test asserting every selectable catalog connector resolves to its own URL rather than the fallback, and verified it catches the defect by reverting the entry:

```
AssertionError: Antigravity (antigravity) has no DOC_URLS entry,
so its row falls back to the docs index
```

`unavailable` entries are excluded — Gemini is listed to explain that it *can't* connect, and deliberately has no guide.

## Verification

- Backend: **3852 tests, 0 failures**; credo `--strict` + format clean
- Frontend: `tsc --noEmit` + `biome ci` clean; 186 tests across onboarding + settings
- Guard proven to fail without the fix (above)

Context doc updated: the section that called the entries "harmless" now records why that was wrong, and carries a do-not-re-add rule.