### PR TITLE
fix(e2e): converge folder expansion instead of racing it

### DIFF
--- a/frontend/e2e/support/tree.ts
+++ b/frontend/e2e/support/tree.ts
@@ -1,5 +1,32 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
+/**
+ * Drive a folder row to `want`, tolerating the app changing it underneath us.
+ *
+ * Folder rows TOGGLE on click, so "read the state, then click if it's wrong" is
+ * a check-then-act race: the app auto-expands the chain leading to the active
+ * note once that note's fetch resolves (see folder-tree.tsx), which can land
+ * between the read and the click. The click then toggles the folder the wrong
+ * way, and because the auto-expand is gated to fire once per note, nothing ever
+ * puts it back — the row stays wrong forever rather than converging (#1178).
+ *
+ * `toPass` re-runs the read AND the click together, so a toggle that lands on
+ * the wrong side is simply corrected on the next attempt.
+ */
+async function setFolderExpanded(page: Page, name: string, want: boolean): Promise<void> {
+	const folder = row(page, name);
+	await expect(folder).toBeVisible();
+	const target = want ? "true" : "false";
+	await expect(async () => {
+		if ((await folder.getAttribute("aria-expanded")) !== target) {
+			await folder.click();
+		}
+		// Short per-attempt timeout: if this click toggled the wrong way we want to
+		// retry quickly, not sit on one bad attempt for the whole budget.
+		await expect(folder).toHaveAttribute("aria-expanded", target, { timeout: 2000 });
+	}).toPass({ timeout: 20_000 });
+}
+
 export function treeRoot(page: Page): Locator {
 	return page.getByTestId("folder-tree-root");
 }
@@ -10,15 +37,12 @@ export function row(page: Page, name: string): Locator {
 	return page.getByRole("treeitem", { name, exact: true });
 }
 
-// Folder rows toggle expansion on click. Only click when collapsed so we do
-// not accidentally collapse an already-open folder.
 export async function expandFolder(page: Page, name: string): Promise<void> {
-	const folder = row(page, name);
-	await expect(folder).toBeVisible();
-	if ((await folder.getAttribute("aria-expanded")) !== "true") {
-		await folder.click();
-		await expect(folder).toHaveAttribute("aria-expanded", "true");
-	}
+	await setFolderExpanded(page, name, true);
+}
+
+export async function collapseFolder(page: Page, name: string): Promise<void> {
+	await setFolderExpanded(page, name, false);
 }
 
 export async function openContextMenu(page: Page, name: string): Promise<void> {

--- a/frontend/e2e/tree-ops-sync.spec.ts
+++ b/frontend/e2e/tree-ops-sync.spec.ts
@@ -8,6 +8,7 @@ import {
 	upsertNote,
 } from "./support/api";
 import {
+	collapseFolder,
 	commitRename,
 	confirmDelete,
 	expandFolder,
@@ -274,8 +275,7 @@ test.describe("web tree ops sync (web to web)", () => {
 		// Old folder must no longer contain the note. Collapse Dest so the only
 		// visible "mover" row would be under Source, then assert it is gone when
 		// Source is expanded and Dest collapsed.
-		await row(pageB, "Dest").click(); // collapse Dest
-		await expect(row(pageB, "Dest")).toHaveAttribute("aria-expanded", "false");
+		await collapseFolder(pageB, "Dest");
 		await expandFolder(pageB, "Source");
 		await expect(row(pageB, "mover")).toHaveCount(0, { timeout: 10_000 });
 
@@ -389,8 +389,7 @@ test.describe("web tree ops sync (web to web)", () => {
 		// Old location clears: Movable is no longer a root-level folder. Collapse
 		// Parent so its subtree hides; Movable must then be absent (it now exists
 		// only under the collapsed Parent, not at root).
-		await row(pageB, "Parent").click();
-		await expect(row(pageB, "Parent")).toHaveAttribute("aria-expanded", "false");
+		await collapseFolder(pageB, "Parent");
 		await expect(row(pageB, "Movable")).toHaveCount(0, { timeout: 10_000 });
 
 		// Content sync must survive the folder move. Tabs are anchored on the leaf

--- a/frontend/src/viewer/tree/use-engram-tree.test.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.test.ts
@@ -2,7 +2,53 @@ import { QueryClient } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { Folder, NoteSummary } from "../../api/queries";
-import { treeStructureKey, useEngramTree } from "./use-engram-tree";
+import { formatItemId } from "./types";
+import { createTreeDataLoader, treeStructureKey, useEngramTree } from "./use-engram-tree";
+
+describe("createTreeDataLoader", () => {
+	// An `inner` that knows nothing — models the window where the folders query
+	// has been re-keyed or is refetching, so `deps.folders` cannot resolve an id
+	// the tree is still displaying.
+	const emptyInner = { getItem: () => undefined, getChildren: () => [] };
+
+	// #1178. The placeholder used to hardcode `isFolder: false`, which made a
+	// folder row briefly claim to be a LEAF. headless-tree reads `isItemFolder`
+	// at click time, so a click landing in that window took the leaf branch: it
+	// selected the row and never toggled expansion, and since nothing re-clicks,
+	// the folder stayed shut forever. Folder-ness is encoded in the item id, so
+	// it is knowable with zero loaded data and must never be guessed.
+	it("reports a folder as a folder even when its data has not landed", () => {
+		const loader = createTreeDataLoader(emptyInner);
+		const item = loader.getItem(formatItemId({ kind: "folder", id: "f-source" }));
+		expect(item.isFolder).toBe(true);
+	});
+
+	it("keeps the placeholder's rendered kind consistent with isFolder", () => {
+		const loader = createTreeDataLoader(emptyInner);
+		const item = loader.getItem(formatItemId({ kind: "folder", id: "f-source" }));
+		// The render path switches on `item.kind`; HT switches on `isFolder`. If
+		// these disagree the row draws a chevron it will not honour.
+		expect(item.item.kind === "folder").toBe(item.isFolder);
+	});
+
+	it("does not turn an unresolved note into a folder", () => {
+		const loader = createTreeDataLoader(emptyInner);
+		const item = loader.getItem(formatItemId({ kind: "note", id: "n1" }));
+		expect(item.isFolder).toBe(false);
+		expect(item.item.kind === "folder").toBe(false);
+	});
+
+	it("prefers real data over the placeholder once it lands", () => {
+		const id = formatItemId({ kind: "folder", id: "f-real" });
+		const real = {
+			itemId: id,
+			item: { kind: "folder" as const, id: "f-real", path: "Real", name: "Real", count: 0 },
+			isFolder: true,
+		};
+		const loader = createTreeDataLoader({ getItem: () => real, getChildren: () => [] });
+		expect(loader.getItem(id)).toBe(real);
+	});
+});
 
 describe("treeStructureKey", () => {
 	it("changes when a folder count changes (so a move rebuilds the tree)", () => {

--- a/frontend/src/viewer/tree/use-engram-tree.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.ts
@@ -22,7 +22,7 @@ import {
 import { resolveDropMove } from "./drop-redirect";
 import { buildLoader, type LoaderItem, type SortKey } from "./loader";
 import { TREE_SLOT_HEIGHT } from "./row-metrics";
-import { ROOT_ID } from "./types";
+import { type ParsedItemId, parseItemId, ROOT_ID } from "./types";
 
 interface Deps {
 	folders: Folder[];
@@ -67,6 +67,62 @@ function attachmentsFingerprint(attachments?: AttachmentSummary[]): string {
 	return `${attachments.length}:${max}`;
 }
 
+type TreeLoader = ReturnType<typeof buildLoader>;
+
+/**
+ * Stand-in row for an id whose data has not landed yet — the folders query is
+ * refetching, or `inner` was just rebuilt (its `childIndex` starts empty), so
+ * the id cannot be resolved for a tick even though the row is on screen.
+ *
+ * The kind is encoded in the id, so it is knowable with ZERO loaded data.
+ * Deriving it is the whole point: this used to hardcode
+ * `item.kind: "folder"` + `isFolder: false`, which is self-contradictory. The
+ * render path switches on `item.kind` and drew a chevron, while headless-tree
+ * switches on `isItemFolder` and saw a LEAF — and HT reads that at click time.
+ * A click landing inside the window therefore took the leaf branch: it selected
+ * the row and never toggled expansion. Nothing re-clicks, so the folder stayed
+ * shut until the user clicked again (#1178, seen as a `move note propagates to
+ * a second tab` e2e flake).
+ *
+ * `parseItemId` throws on a malformed id; this must stay total, because its
+ * only job is to keep HT from crashing mid-render.
+ */
+function placeholderItem(itemId: string): Data {
+	let parsed: ParsedItemId | null = null;
+	try {
+		parsed = parseItemId(itemId);
+	} catch {
+		// Unknown id shape. Fall through to the leaf placeholder below: a leaf is
+		// the safe default for something we cannot name, since claiming it is a
+		// folder would invite HT to ask for children that will never exist.
+	}
+	if (parsed?.kind === "folder") {
+		return {
+			itemId,
+			item: { kind: "folder", id: parsed.id, path: "", name: itemId, count: 0 },
+			isFolder: true,
+		};
+	}
+	if (parsed?.kind === "attachment") {
+		return {
+			itemId,
+			item: { kind: "attachment", id: itemId, path: parsed.path, mime: "", size: 0 },
+			isFolder: false,
+		};
+	}
+	return {
+		itemId,
+		item: {
+			kind: "note",
+			id: parsed?.kind === "note" ? parsed.id : itemId,
+			path: "",
+			title: itemId,
+			ext: null,
+		},
+		isFolder: false,
+	};
+}
+
 export function treeStructureKey(
 	folders: Pick<Folder, "id" | "count" | "parent_id">[],
 	sort: SortKey,
@@ -101,45 +157,7 @@ export function useEngramTree(deps: Deps) {
 		[deps.folders, deps.qc, deps.vaultId, deps.sort, deps.attachments, deps.fetchFolderNotes],
 	);
 
-	// Bridge our LoaderItem-returning loader to HT's TreeDataLoader<T> shape
-	// (getItem -> T, getChildren -> string[]). We index getChildren results
-	// by itemId so a subsequent getItem(id) lookup hits the same row data.
-	const dataLoader = useMemo(() => {
-		const childIndex = new Map<string, LoaderItem>();
-		return {
-			getItem(itemId: string): Data {
-				if (itemId === ROOT_ID) {
-					return {
-						itemId: ROOT_ID,
-						item: { kind: "folder", id: "root", path: "", name: "", count: 0 },
-						isFolder: true,
-					};
-				}
-				const cached = childIndex.get(itemId);
-				if (cached) {
-					return cached;
-				}
-				const direct = inner.getItem(itemId);
-				if (direct) {
-					childIndex.set(itemId, direct);
-					return direct;
-				}
-				// Fallback placeholder so HT doesn't crash before data lands.
-				return {
-					itemId,
-					item: { kind: "folder", id: itemId, path: "", name: itemId, count: 0 },
-					isFolder: false,
-				};
-			},
-			getChildren(itemId: string): string[] {
-				const kids = inner.getChildren(itemId);
-				for (const k of kids) {
-					childIndex.set(k.itemId, k);
-				}
-				return kids.map((k) => k.itemId);
-			},
-		};
-	}, [inner]);
+	const dataLoader = useMemo(() => createTreeDataLoader(inner), [inner]);
 
 	const tree = useTree<Data>({
 		rootItemId: ROOT_ID,
@@ -264,4 +282,39 @@ export function useEngramTree(deps: Deps) {
 	});
 
 	return { tree, virtualizer, items };
+}
+
+// Bridge our LoaderItem-returning loader to HT's TreeDataLoader<T> shape
+// (getItem -> T, getChildren -> string[]). We index getChildren results
+// by itemId so a subsequent getItem(id) lookup hits the same row data.
+export function createTreeDataLoader(inner: Pick<TreeLoader, "getItem" | "getChildren">) {
+	const childIndex = new Map<string, LoaderItem>();
+	return {
+		getItem(itemId: string): Data {
+			if (itemId === ROOT_ID) {
+				return {
+					itemId: ROOT_ID,
+					item: { kind: "folder", id: "root", path: "", name: "", count: 0 },
+					isFolder: true,
+				};
+			}
+			const cached = childIndex.get(itemId);
+			if (cached) {
+				return cached;
+			}
+			const direct = inner.getItem(itemId);
+			if (direct) {
+				childIndex.set(itemId, direct);
+				return direct;
+			}
+			return placeholderItem(itemId);
+		},
+		getChildren(itemId: string): string[] {
+			const kids = inner.getChildren(itemId);
+			for (const k of kids) {
+				childIndex.set(k.itemId, k);
+			}
+			return kids.map((k) => k.itemId);
+		},
+	};
 }


### PR DESCRIPTION
## Root cause

Folder rows **toggle** on click. `expandFolder` read `aria-expanded`, then clicked if it wasn't already open — a check-then-act race:

```ts
if ((await folder.getAttribute("aria-expanded")) !== "true") {
    await folder.click();          // <- state may have changed since the read
    await expect(folder).toHaveAttribute("aria-expanded", "true");
}
```

`folder-tree.tsx` auto-expands the chain leading to the active note once that note's fetch resolves. The failing test signs a second tab in pointed at `Source/mover.md`, so `Source` expands on its own. When that lands between the read and the click, the click toggles it **closed**.

It never recovers because the auto-expand is deliberately gated to fire once per `selectedNoteId` (`autoExpandedForNoteRef`), so nothing re-opens it. Hence the row sitting at `aria-selected="true"` / `aria-expanded="false"` for all 24 polls rather than converging.

**The app is correct here.** Revealing the active note's folder is intended behaviour, and toggling on click is what a tree should do. The helper encoded an assumption the app never promised.

## Fix

Wrap the read *and* the click in `toPass`, so a toggle that lands the wrong way is corrected on the next attempt instead of wedging.

Adds `collapseFolder` and uses it for the two raw click-to-collapse sites in `tree-ops-sync.spec.ts` — identical defect in the other direction: if the folder wasn't open at click time, the click *expanded* it and the next assertion failed.

## Correction

The first commit here (`c3356643`) was a **wrong diagnosis** of #1178. I concluded the tree's fallback placeholder was at fault and shipped it; the same spec then failed byte-identically, which falsified it.

That commit is kept because it fixes a genuine, separate inconsistency found on the way: the placeholder returned `item.kind: "folder"` together with `isFolder: false`, so the render path and headless-tree disagreed about the same row, and an unresolved *note* id was handed back as `kind: "folder"` (a note row drawing a folder chevron). It is real, it is tested, and it is not what caused #1178.

What settled the actual cause was reading headless-tree's click handler instead of inferring it:

```js
if (!item.isFolder()) return;
if (item.isExpanded()) { item.collapse(); } else { item.expand(); }
```

## Verification

- `biome ci` and `tsc --noEmit` clean.
- Frontend unit suite: 1151 passed (167 files).
- The meaningful check is `e2e-browser` on this PR — `tree-ops-sync.spec.ts:231` is the exact test.

Closes #1178