### PR TITLE
fix(ci): stop two false reds — n1-compat port race and a mis-sized test budget

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3157,12 +3157,36 @@ jobs:
         id: pg
         run: |
           docker rm -f "$PG_CONTAINER" 2>/dev/null || true
-          docker run -d --name "$PG_CONTAINER" \
-            -e POSTGRES_USER=engram \
-            -e POSTGRES_PASSWORD=engram \
-            -e POSTGRES_DB=engram_n1 \
-            -P \
-            postgres:18.4
+
+          # Same port race as the unit-tests job's ephemeral postgres, and the
+          # same fix. `-P` lets docker auto-allocate a host port, but between
+          # resolving one and binding it another runner on this shared VM can
+          # claim it, and rootless docker surfaces that as a hard failure:
+          #
+          #   RootlessKit PortManager.AddPort(): listen tcp4 0.0.0.0:32814:
+          #   bind: address already in use
+          #
+          # That is a job-level red on a PR whose migrations are fine, which is
+          # the worst kind of red: it costs a human a full investigation to
+          # learn nothing. Observed on run 30662527833. Retry up to 5 times;
+          # each attempt gets a fresh allocation.
+          for attempt in 1 2 3 4 5; do
+            if docker run -d --name "$PG_CONTAINER" \
+                -e POSTGRES_USER=engram \
+                -e POSTGRES_PASSWORD=engram \
+                -e POSTGRES_DB=engram_n1 \
+                -P \
+                postgres:18.4; then
+              break
+            fi
+            echo "Attempt $attempt: docker run failed (likely port race) — cleaning up + retrying"
+            docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+            sleep 1
+            if [ "$attempt" = "5" ]; then
+              echo "::error::Postgres container failed to start after 5 attempts"
+              exit 1
+            fi
+          done
           # Wait for ready
           for i in $(seq 1 30); do
             if docker exec "$PG_CONTAINER" pg_isready -U engram >/dev/null 2>&1; then

--- a/frontend/src/viewer/reference/markdown-reference-panel.test.tsx
+++ b/frontend/src/viewer/reference/markdown-reference-panel.test.tsx
@@ -8,6 +8,23 @@ import { ActiveEditorProvider, useActiveEditor } from "../editor/active-editor-c
 import MarkdownReferencePanel from "./markdown-reference-panel";
 import { SYNTAX_ENTRIES } from "./markdown-syntax";
 
+// Vitest's default 5s per-test budget is mis-sized for this file, which is the
+// one place that drives the REAL markdown pipeline (remark/rehype +
+// @portaljs/remark-callouts) through jsdom, dozens of times over.
+//
+// Measured locally on an idle machine: 19.4s of test time across 39 tests, with
+// the slowest single test at 3821ms — 76% of the default budget already spent
+// before any contention. On a shared runner that tips over, and it did:
+// "renders the callout as an actual callout" failed with "Test timed out in
+// 5000ms" while passing 39/39 locally.
+//
+// This raises the CEILING, not the bar. Every assertion is unchanged, and a test
+// that genuinely hangs still fails — it just no longer fails for being honestly
+// slow on a loaded box. The alternative, mocking the markdown pipeline, would
+// delete the only thing these tests exist to prove: that "> [!tip]" really does
+// become a callout.
+vi.setConfig({ testTimeout: 20_000 });
+
 // The real NoteView renders the previews (that is the point of this panel), but
 // its free-tier attachment gate needs billing + query context this harness has
 // no business standing up.


### PR DESCRIPTION
Two CI failures that had nothing to do with the code being tested. Both hit PR #1167; both cost a full investigation to learn nothing.

## 1. `migration gates` — ephemeral postgres had no retry

```
RootlessKit PortManager.AddPort(): listen tcp4 0.0.0.0:32814: bind: address already in use
```

`docker run -P` auto-allocates a host port, and between resolving one and binding it another runner on the shared VM can take it. Rootless docker makes that fatal rather than retrying.

The `unit-tests` job already hit this and already fixed it — there is a 5-attempt retry loop at its own `Start ephemeral postgres` step with a comment describing this exact race. The fix was simply never applied to the `n1-compat` copy. Same loop, now in both places.

Observed: run 30662527833, passed on rerun with no code change.

## 2. `frontend lint+types+unit` — markdown-reference-panel against the 5s default

This is the one test file that drives the **real** markdown pipeline (remark/rehype + `@portaljs/remark-callouts`) through jsdom, dozens of times over. Measured on an idle machine:

- 19.4s of test time across 39 tests
- slowest single test **3821ms** — 76% of vitest's 5s default, before any contention exists

On a shared runner that tips over, and it did: `renders the callout as an actual callout` failed with `Test timed out in 5000ms` while passing 39/39 locally.

`vi.setConfig({ testTimeout: 20_000 })`, scoped to this file rather than the global config, so nothing else loses its hang detection.

**This raises the ceiling, not the bar.** Every assertion is unchanged and a genuine hang still fails — it just no longer fails for being honestly slow. The alternative was mocking the pipeline, which would delete the only thing these tests exist to prove: that `> [!tip]` really does become a callout.

## Verification

- 39/39 frontend tests pass with the new budget (30.4s)
- `tsc --noEmit` clean
- `biome ci` clean
- `verify.yml` parses as valid YAML, 23 jobs

Refs #1167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ4aJGK1eWxoghJLrw8Fuc