### PR TITLE
fix(oauth): resolve CIMD clients in the consent connection-cap plug

### DIFF
--- a/lib/engram_web/plugs/enforce_connection_cap.ex
+++ b/lib/engram_web/plugs/enforce_connection_cap.ex
@@ -36,9 +36,8 @@ defmodule EngramWeb.Plugs.EnforceConnectionCap do
   """
 
   import Plug.Conn
-  import Ecto.Query
 
-  alias Engram.{Billing, Connections, Repo}
+  alias Engram.{Billing, Connections, OAuth}
   alias Engram.OAuth.Client
 
   def init(opts), do: opts
@@ -118,18 +117,17 @@ defmodule EngramWeb.Plugs.EnforceConnectionCap do
     :unlimited
   end
 
+  # Delegates rather than querying directly: `client_id` on the wire is either a
+  # DCR UUID or a CIMD metadata-document URL, and `OAuth.get_client/1` is the one
+  # place that knows both shapes. This plug previously ran its own
+  # `Ecto.UUID.cast/1`-gated query, so every CIMD client failed here with 400
+  # while `GET /oauth/authorize` succeeded — Claude Code reached consent and
+  # could never complete it. Any future client_id shape is now handled in one
+  # place instead of two that must be kept in step.
   defp lookup_client(%{"client_id" => client_id}) when is_binary(client_id) do
-    case Ecto.UUID.cast(client_id) do
-      {:ok, _} ->
-        case Repo.one(from(c in Client, where: c.client_id == ^client_id),
-               skip_tenant_check: true
-             ) do
-          nil -> :error
-          client -> {:ok, client}
-        end
-
-      :error ->
-        :error
+    case OAuth.get_client(client_id) do
+      {:ok, client} -> {:ok, client}
+      {:error, :not_found} -> :error
     end
   end
 

--- a/test/engram_web/plugs/enforce_connection_cap_test.exs
+++ b/test/engram_web/plugs/enforce_connection_cap_test.exs
@@ -98,6 +98,66 @@ defmodule EngramWeb.Plugs.EnforceConnectionCapTest do
       assert conn.status == 400
     end
 
+    # Regression: a CIMD client's wire client_id is an HTTPS metadata-document
+    # URL, not a UUID. This plug used to gate its lookup on `Ecto.UUID.cast/1`
+    # and treat every non-UUID as unknown, so consent 400'd for EVERY CIMD
+    # client while `GET /oauth/authorize` succeeded — Claude Code reached the
+    # consent screen and could never get past it.
+    test "resolves a CIMD client by its URL-shaped client_id", %{conn: conn, user: user} do
+      url = "https://claude.ai/oauth/claude-code-client-metadata"
+      insert(:oauth_client, kind: "mcp", cimd_url: url)
+
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/oauth/authorize/consent")
+        |> Map.put(:params, %{"client_id" => url})
+        |> assign(:current_user, user)
+        |> EnforceConnectionCap.call([])
+
+      refute conn.halted
+    end
+
+    # The cap must apply to CIMD clients too. Resolving the URL is only half the
+    # fix: if it resolved but counted against nothing, CIMD would be an
+    # accidental bypass of the paid tier.
+    test "enforces the mcp cap for a CIMD client at its limit", %{conn: conn, user: user} do
+      url = "https://claude.ai/oauth/claude-code-client-metadata"
+      client = insert(:oauth_client, kind: "mcp", cimd_url: url)
+      insert(:oauth_refresh_token, user_id: user.id, client_id: client.client_id)
+
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/oauth/authorize/consent")
+        |> Map.put(:params, %{"client_id" => url})
+        |> assign(:current_user, user)
+        |> EnforceConnectionCap.call([])
+
+      assert conn.halted
+      assert conn.status == 402
+      body = Phoenix.ConnTest.json_response(conn, 402)
+      assert body["reason"] == "mcp_connections_exceeded"
+    end
+
+    # A non-UUID that is also not a CIMD URL stays unknown — the fix must widen
+    # the lookup to URLs, not open it to arbitrary strings.
+    test "still returns 400 for a non-UUID, non-CIMD client_id", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> Map.put(:method, "POST")
+        |> Map.put(:request_path, "/api/oauth/authorize/consent")
+        |> Map.put(:params, %{"client_id" => "not-a-uuid-and-not-a-url"})
+        |> assign(:current_user, user)
+        |> EnforceConnectionCap.call([])
+
+      assert conn.halted
+      assert conn.status == 400
+
+      assert Phoenix.ConnTest.json_response(conn, 400)["error"] ==
+               "missing_or_invalid_client_id"
+    end
+
     test "passes when limits_enforced is false (self-host / unlimited tier)", %{
       conn: conn,
       user: user,


### PR DESCRIPTION
**CIMD is live on staging and broken at the last step.** `GET /oauth/authorize` succeeds, the consent screen renders, and `POST /api/oauth/authorize/consent` returns 400 every time. Claude Code can start the flow and never finish it.

Found by connecting Claude Code to staging after 0.12.2 deployed.

## Cause

`EnforceConnectionCap` is mounted on `:consent` only — that asymmetry is why GET worked and POST didn't. It ran its own client lookup:

```elixir
case Ecto.UUID.cast(client_id) do
  {:ok, _} -> Repo.one(from c in Client, where: c.client_id == ^client_id)
  :error   -> :error
end
```

A CIMD client's wire `client_id` is its metadata-document URL, not a UUID. `cast` fails, the plug halts `missing_or_invalid_client_id`. Observed on staging with `client_id=https://claude.ai/oauth/claude-code-client-metadata`.

## Fix

**The duplication was the bug, so this deletes it** rather than adding a second CIMD branch. `Engram.OAuth.get_client/1` already resolves both shapes — UUID against the primary key, URL against `cimd_url` — and its docstring says exactly that. The plug now delegates; `Repo` and `import Ecto.Query` became dead and are removed.

Net −13 lines of production code. Any future `client_id` shape is taught in one place instead of two that have to be kept in step.

## Why the original CIMD audit missed it

Widening `client_id` from "always a UUID" to "UUID or URL" turns every UUID-assuming site into a latent break. Four were found and fixed by auditing the OAuth context (`get_client/1`, `check_code_client/2`, `rotate_refresh_token/3`, `revoke_token/3`). This one lives in a **plug**, bypasses the context with its own `Repo.one`, and is mounted on a single action — invisible to a context-level grep.

The tell was the timing: `GET 302` in 158ms (a real document fetch) versus `POST 400` in **5ms**. Too fast to have queried anything, so it had to be a local `cast` failing, not a lookup missing.

## Rest of the bug class swept, nothing else found

- The four `Ecto.UUID.cast(client_id)` sites in `notes.ex` are a **different** `client_id` — the client-supplied *note* uuid for offline minting.
- Both `Client` joins in `connections.ex` key on the internal uuid that refresh tokens store, which is correct.

## Tests

Written first; the first two failed before the fix.

- `resolves a CIMD client by its URL-shaped client_id`
- `enforces the mcp cap for a CIMD client at its limit` — resolving is only half the fix. If it resolved but counted against nothing, CIMD would be a silent bypass of the paid tier.
- `still returns 400 for a non-UUID, non-CIMD client_id` — widen the lookup to URLs, not to arbitrary strings.

## Verification

`mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), **3938 tests / 0 failures**, `mix dialyzer` (passed).

## Prod is not affected

Prod is still on 0.11.0, which has no CIMD. The staging-first promotion gate added in #1160 is what surfaced this before prod moved — engram-infra PR #890 is still sitting unmerged.

Refs #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ4aJGK1eWxoghJLrw8Fuc