### PR TITLE
fix(mcp): make third-party MCP clients connect and attribute correctly (Cursor 406, Devin + LobeHub)

### DIFF
--- a/docs/context/connections-client-identity.md
+++ b/docs/context/connections-client-identity.md
@@ -95,7 +95,7 @@ Nothing else may ever grant it.
 
 > **Correction (2026-07-30).** This doc previously said custom schemes and localhost were *"identify-only: they may set icon/name but never grant verified."* That was the intended design; the code never implemented it, `lookup_by_host/1` returned the empty placeholder, so loopback clients got **no slug at all** and their checklist row could never tick. The doc/code mismatch is why the gap survived six weeks. Slug attribution for those clients now comes from `client_name`.
 
-## Observed registrations (prod, 2026-07-30)
+## Observed registrations (prod 2026-07-30, staging 2026-08-01)
 
 Ground truth from real grants, not published docs:
 
@@ -106,15 +106,36 @@ Ground truth from real grants, not published docs:
 | Grok | `Grok` | `https://grok.com/connectors-oauth-exchange-code/` | host | yes |
 | Mistral | `mistral-mcp-client` | `https://callback.mistral.ai/v1/integrations_auth/oauth2_callback` | host | yes |
 | Antigravity | `antigravity-client` | `https://antigravity.google/oauth-callback` | host | yes |
-| Claude Code | `Claude Code (<server>)` | `http://localhost:<port>/callback` | name | no |
+| Devin | `Devin` | `https://api.devin.ai/mcp/oauth/callback` | host | yes |
+| LobeHub | `LobeHub` | `https://app.lobehub.com/oauth/connector/callback` | host | yes |
+| Claude Code | `Claude Code (<server>)` | `http://localhost:<port>/callback` | name, then CIMD | yes (CIMD) |
 | Open WebUI | `Open WebUI` | `https://<user-domain>/oauth/clients/mcp:1/callback` | name | no |
 | Cline | `Cline` | `http://127.0.0.1:<port>/mcp/oauth/callback` | name | no |
 | OpenCode | `OpenCode` | `http://127.0.0.1:<port>/mcp/oauth/callback` | name | no |
 
 Mistral and Antigravity are the cases where **name** derivation fails
 (`mistral_mcp_client` / `antigravity_client` are not catalog slugs) and the host
-saves it. Claude Code, Open WebUI, Cline and OpenCode are the exact inverse.
-Neither layer alone covers all nine, keep both.
+saves it. Open WebUI, Cline and OpenCode are the exact inverse. Neither layer
+alone covers all of them, keep both.
+
+**Devin and LobeHub added 2026-08-01** (staging), both by vendor host. Two
+things they illustrate:
+
+- **Devin carries `slug: nil`.** There is no `devin` in
+  `Engram.Onboarding.valid_tools/0`, and adding one is gated on a
+  `/docs/integrations/devin/` page existing — `checklist-widget.tsx` has a
+  parity test (#1157) requiring every selectable slug to own a doc URL, and that
+  page 404s today. Attribution and the badge do not depend on the slug, so the
+  entry is useful without a checklist row.
+- **LobeHub maps to the `lobechat` slug.** LobeHub is the cloud host, LobeChat
+  the product and the catalog slug. The observed `client_name` is `"LobeHub"`,
+  which does *not* derive to `lobechat`, so the host map carries it. This is
+  cloud-only: a **self-hosted** LobeChat redirects to the operator's own domain,
+  matches nothing, and stays unverified — same boundary as Open WebUI. There is
+  a test pinning that.
+
+**Claude Code is now verified via CIMD**, not by redirect (it is loopback, which
+can never prove anything). It is the worked example of why CIMD exists.
 
 > **Do not assume a client registers under its product name.** Three of nine
 > observed clients append a suffix (`-client`, `(<server>)`). The name layer is a

--- a/lib/engram/connections/logo_allowlist.ex
+++ b/lib/engram/connections/logo_allowlist.ex
@@ -69,8 +69,12 @@ defmodule Engram.Connections.LogoAllowlist do
   }
 
   # Keyed on redirect_uri host. Vendor-owned HTTPS hosts only. Every entry here
-  # was observed on a real grant (prod, 2026-07-30). Do not add speculative
-  # hosts; an entry that never fires is dead config that reads as coverage.
+  # was observed on a real grant — the first five in prod on 2026-07-30, Devin
+  # and LobeHub on staging on 2026-08-01. Staging counts because what the rule
+  # is actually guarding is "a real client really redirected here", not which
+  # environment answered; a guessed host is the thing that must never land. Do
+  # not add speculative hosts; an entry that never fires is dead config that
+  # reads as coverage.
   # `logo: nil` where we have no asset yet; the UI falls back to a plug icon.
   @redirect_host %{
     "claude.ai" => %{

--- a/lib/engram/connections/logo_allowlist.ex
+++ b/lib/engram/connections/logo_allowlist.ex
@@ -88,7 +88,20 @@ defmodule Engram.Connections.LogoAllowlist do
     # Antigravity registers as "antigravity-client", which does NOT derive to the
     # `antigravity` slug; the host is what carries it. Shared by Antigravity 2.0,
     # the IDE, and the CLI (one documented callback for all three).
-    "antigravity.google" => %{logo: nil, display_name: "Antigravity", slug: "antigravity"}
+    "antigravity.google" => %{logo: nil, display_name: "Antigravity", slug: "antigravity"},
+    # Devin registers `client_name: "Devin"`, which does not derive to a catalog
+    # slug because there is no `devin` tool in `Engram.Onboarding.valid_tools/0`
+    # — so `slug: nil` and it gets no checklist row. Adding one would need a
+    # `/docs/integrations/devin/` page first: `checklist-widget.tsx` has a parity
+    # test (#1157) requiring every selectable slug to carry its own doc URL, and
+    # that page currently 404s. Attribution and the verified badge do not depend
+    # on the slug, so this entry is useful on its own.
+    "api.devin.ai" => %{logo: nil, display_name: "Devin", slug: nil},
+    # LobeHub is the cloud host; LobeChat is the product and the catalog slug, so
+    # the row already exists in onboarding and this host ticks it. The observed
+    # `client_name` is "LobeHub", which is why the host map has to carry the
+    # mapping — the name does not derive to `lobechat`.
+    "app.lobehub.com" => %{logo: nil, display_name: "LobeChat", slug: "lobechat"}
   }
 
   # Slugs a client may self-report via `client_name`. `web_only` / `other_mcp`

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -10,6 +10,19 @@ defmodule EngramWeb.Router do
     }
   end
 
+  # Same as `:api` minus content negotiation. Used only by the MCP
+  # method-not-allowed routes below: a Streamable-HTTP client opens the
+  # server→client stream with `Accept: text/event-stream`, which
+  # `plug :accepts, ["json"]` answers 406 — before the controller that would
+  # have told it "POST-only". Negotiating a representation for a request we are
+  # rejecting on method alone is meaningless, so this pipeline simply does not.
+  pipeline :api_any_accept do
+    plug :put_secure_browser_headers, %{
+      "x-content-type-options" => "nosniff",
+      "x-frame-options" => "DENY"
+    }
+  end
+
   pipeline :rate_limit_auth do
     plug EngramWeb.Plugs.RateLimit, limit: 10, period: 60_000
   end
@@ -445,8 +458,14 @@ defmodule EngramWeb.Router do
   # Allow here rather than letting GET/DELETE fall through to Phoenix's 404,
   # which clients treat as a missing endpoint and abort. Auth-free on
   # purpose: an unsupported method is a method-level fact, not an authz one.
+  #
+  # `:api_any_accept`, NOT `:api`: the GET that opens the stream carries
+  # `Accept: text/event-stream`, and `plug :accepts, ["json"]` 406s it before
+  # this controller runs. That made the 405 above unreachable for precisely the
+  # clients it exists to serve — observed with Cursor, which falls back to the
+  # legacy HTTP+SSE transport and aborts on the 406.
   scope "/api", EngramWeb do
-    pipe_through :api
+    pipe_through :api_any_accept
     get "/mcp", McpController, :unsupported_transport
     delete "/mcp", McpController, :unsupported_transport
   end

--- a/test/engram/connections/logo_allowlist_test.exs
+++ b/test/engram/connections/logo_allowlist_test.exs
@@ -235,6 +235,48 @@ defmodule Engram.Connections.LogoAllowlistTest do
              LogoAllowlist.resolve(nil, ["http://localhost:1/cb"], "antigravity-client")
   end
 
+  # Observed 2026-08-01 on staging, both previously rendering as "Unrecognized
+  # client". Devin has no catalog slug: `Engram.Onboarding.valid_tools/0` has no
+  # `devin`, and adding one needs a /docs/integrations/devin/ page first
+  # (checklist-widget's #1157 parity test). Attribution and the badge do not
+  # depend on the slug, so the entry stands on its own.
+  test "resolve verifies Devin by its vendor host, with no catalog slug" do
+    assert %{verified: true, display_name: "Devin", slug: nil} =
+             LogoAllowlist.resolve(
+               nil,
+               ["https://api.devin.ai/mcp/oauth/callback"],
+               "Devin"
+             )
+  end
+
+  # LobeHub is the cloud host, LobeChat the product and the catalog slug — so
+  # this host ticks an onboarding row that already exists. The observed
+  # client_name is "LobeHub", which does NOT derive to `lobechat`, so the host
+  # map is what carries the mapping.
+  test "resolve verifies LobeHub by its vendor host and maps it to the lobechat slug" do
+    assert %{verified: true, display_name: "LobeChat", slug: "lobechat"} =
+             LogoAllowlist.resolve(
+               nil,
+               ["https://app.lobehub.com/oauth/connector/callback"],
+               "LobeHub"
+             )
+
+    # Prove the name alone would NOT have carried the slug.
+    assert %{slug: nil, verified: false} =
+             LogoAllowlist.resolve(nil, ["http://localhost:1/cb"], "LobeHub")
+  end
+
+  # Self-hosted LobeChat redirects to the operator's own domain, so it must stay
+  # unverified — the cloud entry above must not leak the badge to every install.
+  test "self-hosted LobeChat on an operator domain stays unverified" do
+    assert %{verified: false} =
+             LogoAllowlist.resolve(
+               nil,
+               ["https://lobe.mycompany.example/oauth/connector/callback"],
+               "LobeHub"
+             )
+  end
+
   # Self-hosted clients redirect to the operator's OWN domain, so there is no
   # vendor host to allowlist, ever. Observed in prod 2026-07-30: Open WebUI
   # arriving from a user-run instance. It must still earn its slug (via name)

--- a/test/engram_web/controllers/mcp_transport_test.exs
+++ b/test/engram_web/controllers/mcp_transport_test.exs
@@ -17,5 +17,46 @@ defmodule EngramWeb.McpTransportTest do
       assert conn.status == 405
       assert get_resp_header(conn, "allow") == ["POST"]
     end
+
+    # Regression. The two tests above pass with a bare test conn, which sends no
+    # Accept header — so they never exercised the header a REAL client sends.
+    # A Streamable-HTTP client opens the server→client stream with
+    # `Accept: text/event-stream`, and while these routes piped through `:api`
+    # (`plug :accepts, ["json"]`) that produced a 406 before this controller ran.
+    # The 405 was therefore unreachable for exactly the clients it exists for.
+    # Observed 2026-08-01: Cursor fell back to the legacy HTTP+SSE transport and
+    # aborted on "Non-200 status code (406)".
+    test "GET with Accept: text/event-stream still returns 405, not 406", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "text/event-stream")
+        |> get("/api/mcp")
+
+      assert conn.status == 405
+      assert get_resp_header(conn, "allow") == ["POST"]
+    end
+
+    test "DELETE with Accept: text/event-stream still returns 405, not 406", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "text/event-stream")
+        |> delete("/api/mcp")
+
+      assert conn.status == 405
+      assert get_resp_header(conn, "allow") == ["POST"]
+    end
+
+    # The spec-conformant Accept for the stream-open GET lists both types. It
+    # worked before (json satisfies `:accepts`) and must keep working — the fix
+    # widens what is tolerated, it does not move the answer.
+    test "GET with the spec's dual Accept returns 405", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "application/json, text/event-stream")
+        |> get("/api/mcp")
+
+      assert conn.status == 405
+      assert get_resp_header(conn, "allow") == ["POST"]
+    end
   end
 end


### PR DESCRIPTION
Two fixes from one session of connecting third-party MCP clients to staging. Both are "the client reached us and we answered wrong", so they ship together.

**Supersedes #1192** (the 406 fix, now the second commit here).

---

## 1. Cursor could not connect at all — 406 instead of 405

PR #340 added `GET/DELETE /api/mcp` → **405 + `Allow: POST`** so a Streamable-HTTP client learns "POST-only, carry on" instead of treating the endpoint as dead. **That handler has been unreachable for the only clients it was written for.**

A Streamable-HTTP client opens the server→client stream with `Accept: text/event-stream`. Those routes piped through `:api`, whose first plug is `plug :accepts, ["json"]`, so the request is rejected **406** before `McpController.unsupported_transport/2` ever runs.

Measured against live staging (0.12.3):

| Method | Accept | Result |
|---|---|---|
| GET | `text/event-stream` | **406** |
| GET | `application/json` | 405 `Allow: POST` |
| GET | `*/*` | 405 `Allow: POST` |
| GET | `application/json, text/event-stream` | 405 `Allow: POST` |

Cursor's log: Streamable-HTTP POST failed → fell back to legacy HTTP+SSE → `SSE error: Non-200 status code (406)` → `Connection failed`.

**Fix:** a second pipeline, `:api_any_accept`, identical to `:api` minus content negotiation, used only by these two routes. Negotiating a representation for a request rejected on **method** alone is meaningless — the answer is 405 + `Allow` regardless of what the client would have accepted.

**Deliberately narrow.** `POST /api/mcp` with `Accept: text/event-stream` alone also 406s, and that is left alone: the MCP spec requires clients to accept `application/json` on POST, and that route shares the big vault-scoped authed scope with notes/search/folders — widening negotiation there for an out-of-spec header is not worth the blast radius.

**Why existing tests missed it:** `mcp_transport_test.exs` uses a bare test conn, which sends **no Accept header**, so it never exercised what a real client sends. The two new negative tests fail on the old router with `Expected one of ["json"]`; a third pins that the spec-conformant dual Accept keeps working, so this widens tolerance rather than moving the answer.

---

## 2. Devin and LobeHub rendered as "Unrecognized client"

Both connected to staging on 2026-08-01 and showed *"Unrecognized client. Revoke it if you don't recognize the redirect below."* Both redirect to a vendor-owned HTTPS host — the proof `verified` already accepts — so they were unattributed only because `@redirect_host` had no entry.

| Host | Observed redirect | UA |
|---|---|---|
| `api.devin.ai` | `https://api.devin.ai/mcp/oauth/callback` | `python-httpx/0.28.1` |
| `app.lobehub.com` | `https://app.lobehub.com/oauth/connector/callback` | `node` |

Both **observed on real grants**, which is the bar that map documents: *"Every entry here was observed on a real grant. Do not add speculative hosts."*

**LobeHub → the existing `lobechat` slug.** LobeHub is the cloud host; LobeChat is the product and the catalog slug, so this also ticks an onboarding checklist row that already exists. The mapping must live in the host map because the observed `client_name` is `"LobeHub"`, which does not derive to `lobechat`.

**Devin gets `slug: nil` on purpose.** There is no `devin` in `Engram.Onboarding.valid_tools/0`, and adding one is not a one-liner: `checklist-widget.tsx` has a parity test (#1157) requiring every selectable slug to carry its own doc URL, and `https://engram.page/docs/integrations/devin/` currently **404s**. A checklist row pointing at a dead page is worse than no row. Attribution and the badge do not depend on the slug, so the entry stands alone; the onboarding row can follow a docs page.

`logo: nil` for both, matching Grok / Mistral / Antigravity (UI falls back to a plug icon).

---

## Tests

- GET and DELETE with `Accept: text/event-stream` return 405, not 406 — **both fail on the old router**
- GET with the spec's dual Accept still returns 405
- Devin verified by host, slug stays `nil`
- LobeHub verified by host and mapped to `lobechat`, plus proof the `client_name` alone would not have carried the slug
- **self-hosted LobeChat on an operator domain stays unverified** — the cloud entry must not leak the badge to every install

## Verification

`mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), **3944 tests / 0 failures**.

---

> **Not in scope, for the record:** the primary blocker in the reported Cursor session was a burst of Cloudflare **523 origin-unreachable** errors, 14:46–16:00 local. No request reached the app or NPM in that window, so the break was between Cloudflare and the origin, upstream of the proxy — self-recovered, infrastructure-side, nothing in this diff addresses it. The 406 fix matters for the next attempt, once the origin is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ4aJGK1eWxoghJLrw8Fuc