### PR TITLE
refactor(web): dedupe plug halts + batch-op helpers

### DIFF
--- a/e2e/tests/api_only/local/test_62_local_account_settings.py
+++ b/e2e/tests/api_only/local/test_62_local_account_settings.py
@@ -127,7 +127,9 @@ class TestProfileUpdate:
             timeout=10,
         )
         assert patch.status_code == 422
-        assert patch.json()["error"] == "validation_failed"
+        # Sibling-controller 422 shape (errors map keyed by field) since the
+        # web-layer DRY pass unified PATCH /me with every other controller.
+        assert "display_name" in patch.json()["errors"]
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -77,6 +77,22 @@ describe("api client 402 handling", () => {
 		await expect(api.get("/x")).rejects.toBeInstanceOf(ApiError);
 	});
 
+	it("derives the ApiError message from a 422 errors map when error is absent", async () => {
+		// The unified controller shape is %{errors: %{field => [messages]}} with
+		// no top-level `error` key — the message must surface the field detail,
+		// not degrade to the generic statusText.
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(
+					JSON.stringify({ errors: { display_name: ["should be at most 80 character(s)"] } }),
+					{ status: 422, statusText: "Unprocessable Entity" },
+				),
+			);
+
+		await expect(api.get("/x")).rejects.toThrow("display_name: should be at most 80 character(s)");
+	});
+
 	it("sends an X-Device-Id header on every request", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
 		globalThis.fetch = fetchMock;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -12,6 +12,21 @@ let tokenGetter: (() => Promise<string | null>) | null = null;
 // than an event bus to stay simple and tree-shakeable.
 let upgradeHandler: ((reason: string) => void) | null = null;
 
+/** First "field: message" from the unified 422 shape %{errors: %{field => [msgs]}}.
+ *  Controllers return this shape with no top-level `error` key, so the generic
+ *  error surface must read it or validation toasts degrade to bare statusText. */
+function firstValidationError(errors: unknown): string | undefined {
+	if (typeof errors !== "object" || errors === null) {
+		return;
+	}
+	const [field, msgs] = Object.entries(errors)[0] ?? [];
+	if (!field) {
+		return;
+	}
+	const msg = Array.isArray(msgs) ? msgs[0] : msgs;
+	return typeof msg === "string" ? `${field}: ${msg}` : field;
+}
+
 async function authFetch(path: string, options: RequestInit = {}): Promise<Response> {
 	const token = await getAuthToken();
 
@@ -53,7 +68,10 @@ async function authFetch(path: string, options: RequestInit = {}): Promise<Respo
 				body.upgrade_url ?? null,
 			);
 		}
-		throw new ApiError(response.status, body.error ?? response.statusText);
+		throw new ApiError(
+			response.status,
+			body.error ?? firstValidationError(body.errors) ?? response.statusText,
+		);
 	}
 
 	return response;

--- a/lib/engram_web/controllers/batch_ops.ex
+++ b/lib/engram_web/controllers/batch_ops.ex
@@ -1,0 +1,49 @@
+defmodule EngramWeb.BatchOps do
+  @moduledoc """
+  Shared helpers for the notes/folders batch endpoints (`batch_delete` /
+  `batch_move`): input parsing and the post-commit PubSub fan-out. The
+  response-shaping (`send_move_result`) stays in each controller — the two
+  success bodies and error-clause sets genuinely differ (folders reports
+  `moved_attachments` and maps cycle/bare-atom attachment-leg errors).
+  """
+
+  @doc """
+  Casts a list of raw ids to UUIDs, rejecting the whole batch (`:error`)
+  on the first non-UUID entry.
+  """
+  def parse_uuid_list(list) when is_list(list) do
+    Enum.reduce_while(list, {:ok, []}, fn item, {:ok, acc} ->
+      case parse_uuid(item) do
+        {:ok, n} -> {:cont, {:ok, [n | acc]}}
+        :error -> {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, Enum.reverse(acc)}
+      :error -> :error
+    end
+  end
+
+  @doc "Casts a single raw id to a UUID; non-binaries are `:error`."
+  def parse_uuid(s) when is_binary(s), do: Ecto.UUID.cast(s)
+  def parse_uuid(_), do: :error
+
+  # Move target is either a folder-marker UUID or the literal "root" sentinel
+  # (vault root / top level — no marker). "root" must bypass the UUID cast.
+  @doc "Parses a batch-move target: a marker UUID or the literal `\"root\"`."
+  def parse_move_target("root"), do: {:ok, "root"}
+  def parse_move_target(s) when is_binary(s), do: parse_uuid(s)
+  def parse_move_target(_), do: :error
+
+  @doc """
+  Fans a committed batch op out to the user's sync channel. `event` is the
+  per-resource name (`"notes.batch"` / `"folders.batch"`).
+  """
+  def broadcast_batch(user, vault, event, payload) do
+    EngramWeb.Endpoint.broadcast!(
+      "sync:#{user.id}:#{vault.id}",
+      event,
+      payload
+    )
+  end
+end

--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -4,6 +4,7 @@ defmodule EngramWeb.FoldersController do
 
   alias Engram.Folders
   alias Engram.Notes
+  alias EngramWeb.BatchOps
   alias EngramWeb.Schemas
 
   operation(:index,
@@ -155,7 +156,10 @@ defmodule EngramWeb.FoldersController do
       {:ok, marker} ->
         # Same event the batch ops emit — lets connected devices (plugin/web)
         # materialize the empty folder live instead of on the next pull.
-        broadcast_batch(user, vault, %{op: "create", folder: marker.folder})
+        BatchOps.broadcast_batch(user, vault, "folders.batch", %{
+          op: "create",
+          folder: marker.folder
+        })
 
         conn
         |> put_status(:created)
@@ -200,7 +204,7 @@ defmodule EngramWeb.FoldersController do
         # waiting for their next pull. Only on a REAL delete — broadcasting on a
         # no-op (:not_found) would fan out a phantom "delete folder" that triggers
         # spurious client resyncs (and, plugin-side, a folder-delete echo).
-        broadcast_batch(user, vault, %{op: "delete", folder: folder})
+        BatchOps.broadcast_batch(user, vault, "folders.batch", %{op: "delete", folder: folder})
 
         send_resp(conn, 204, "")
 
@@ -294,7 +298,7 @@ defmodule EngramWeb.FoldersController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    case parse_uuid_list(ids) do
+    case BatchOps.parse_uuid_list(ids) do
       :error ->
         conn |> put_status(400) |> json(%{error: "invalid_ids"})
 
@@ -309,7 +313,7 @@ defmodule EngramWeb.FoldersController do
               %{status: 200, body: body}
             )
 
-            broadcast_batch(user, vault, %{op: "delete", ids: ids})
+            BatchOps.broadcast_batch(user, vault, "folders.batch", %{op: "delete", ids: ids})
             json(conn, body)
 
           {:error, {:not_found, id}} ->
@@ -361,7 +365,7 @@ defmodule EngramWeb.FoldersController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    case parse_uuid_list(ids) do
+    case BatchOps.parse_uuid_list(ids) do
       {:ok, ids} ->
         result = Folders.batch_move(user, vault, ids, {:path, folder})
         send_move_result(conn, user, vault, ids, result, %{target_parent: folder})
@@ -375,8 +379,8 @@ defmodule EngramWeb.FoldersController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    with {:ok, ids} <- parse_uuid_list(ids),
-         {:ok, tgt} <- parse_move_target(tgt) do
+    with {:ok, ids} <- BatchOps.parse_uuid_list(ids),
+         {:ok, tgt} <- BatchOps.parse_move_target(tgt) do
       result = Folders.batch_move(user, vault, ids, tgt)
       send_move_result(conn, user, vault, ids, result, %{target_parent_id: tgt})
     else
@@ -402,7 +406,13 @@ defmodule EngramWeb.FoldersController do
           body: body
         })
 
-        broadcast_batch(user, vault, Map.merge(%{op: "move", ids: ids}, broadcast_extra))
+        BatchOps.broadcast_batch(
+          user,
+          vault,
+          "folders.batch",
+          Map.merge(%{op: "move", ids: ids}, broadcast_extra)
+        )
+
         json(conn, body)
 
       {:error, {:not_found, id}} ->
@@ -433,36 +443,6 @@ defmodule EngramWeb.FoldersController do
   defp format_error(atom) when is_atom(atom), do: Atom.to_string(atom)
   defp format_error(binary) when is_binary(binary), do: binary
   defp format_error(_), do: "internal_error"
-
-  defp parse_uuid_list(list) when is_list(list) do
-    Enum.reduce_while(list, {:ok, []}, fn item, {:ok, acc} ->
-      case parse_uuid(item) do
-        {:ok, n} -> {:cont, {:ok, [n | acc]}}
-        :error -> {:halt, :error}
-      end
-    end)
-    |> case do
-      {:ok, acc} -> {:ok, Enum.reverse(acc)}
-      :error -> :error
-    end
-  end
-
-  defp parse_uuid(s) when is_binary(s), do: Ecto.UUID.cast(s)
-  defp parse_uuid(_), do: :error
-
-  # Move target is either a folder-marker UUID or the literal "root" sentinel
-  # (top level — no parent marker). "root" must bypass the UUID cast.
-  defp parse_move_target("root"), do: {:ok, "root"}
-  defp parse_move_target(s) when is_binary(s), do: parse_uuid(s)
-  defp parse_move_target(_), do: :error
-
-  defp broadcast_batch(user, vault, payload) do
-    EngramWeb.Endpoint.broadcast!(
-      "sync:#{user.id}:#{vault.id}",
-      "folders.batch",
-      payload
-    )
-  end
 
   defp note_summary(note) do
     %{

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -4,6 +4,7 @@ defmodule EngramWeb.NotesController do
   alias EngramWeb.Schemas
 
   alias Engram.Notes
+  alias EngramWeb.BatchOps
 
   require Logger
 
@@ -475,7 +476,7 @@ defmodule EngramWeb.NotesController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    case parse_uuid_list(ids) do
+    case BatchOps.parse_uuid_list(ids) do
       :error ->
         conn |> put_status(400) |> json(%{error: "invalid_ids"})
 
@@ -490,7 +491,7 @@ defmodule EngramWeb.NotesController do
               %{status: 200, body: body}
             )
 
-            broadcast_batch(user, vault, %{op: "delete", ids: ids})
+            BatchOps.broadcast_batch(user, vault, "notes.batch", %{op: "delete", ids: ids})
             json(conn, body)
 
           {:error, {:not_found, id}} ->
@@ -534,7 +535,7 @@ defmodule EngramWeb.NotesController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    case parse_uuid_list(ids) do
+    case BatchOps.parse_uuid_list(ids) do
       {:ok, ids} ->
         result = Notes.batch_move_notes(user, vault, ids, {:path, folder})
         send_move_result(conn, user, vault, ids, result, %{target_folder: folder})
@@ -548,8 +549,8 @@ defmodule EngramWeb.NotesController do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
 
-    with {:ok, ids} <- parse_uuid_list(ids),
-         {:ok, tgt} <- parse_move_target(tgt) do
+    with {:ok, ids} <- BatchOps.parse_uuid_list(ids),
+         {:ok, tgt} <- BatchOps.parse_move_target(tgt) do
       result = Notes.batch_move_notes(user, vault, ids, tgt)
       send_move_result(conn, user, vault, ids, result, %{target_folder_id: tgt})
     else
@@ -575,7 +576,13 @@ defmodule EngramWeb.NotesController do
           body: body
         })
 
-        broadcast_batch(user, vault, Map.merge(%{op: "move", ids: ids}, broadcast_extra))
+        BatchOps.broadcast_batch(
+          user,
+          vault,
+          "notes.batch",
+          Map.merge(%{op: "move", ids: ids}, broadcast_extra)
+        )
+
         json(conn, body)
 
       {:error, {:not_found, id}} ->
@@ -661,34 +668,4 @@ defmodule EngramWeb.NotesController do
   # error logger crashing itself. error_kind/1 is total and leak-safe (only a
   # bounded atom escapes; a %Note{} buried in a reason tuple never does).
   defp classify_reason(reason), do: Engram.Telemetry.error_kind(reason)
-
-  defp parse_uuid_list(list) when is_list(list) do
-    Enum.reduce_while(list, {:ok, []}, fn item, {:ok, acc} ->
-      case parse_uuid(item) do
-        {:ok, n} -> {:cont, {:ok, [n | acc]}}
-        :error -> {:halt, :error}
-      end
-    end)
-    |> case do
-      {:ok, acc} -> {:ok, Enum.reverse(acc)}
-      :error -> :error
-    end
-  end
-
-  defp parse_uuid(s) when is_binary(s), do: Ecto.UUID.cast(s)
-  defp parse_uuid(_), do: :error
-
-  # Move target is either a folder-marker UUID or the literal "root" sentinel
-  # (vault root — no marker). "root" must bypass the UUID cast.
-  defp parse_move_target("root"), do: {:ok, "root"}
-  defp parse_move_target(s) when is_binary(s), do: parse_uuid(s)
-  defp parse_move_target(_), do: :error
-
-  defp broadcast_batch(user, vault, payload) do
-    EngramWeb.Endpoint.broadcast!(
-      "sync:#{user.id}:#{vault.id}",
-      "notes.batch",
-      payload
-    )
-  end
 end

--- a/lib/engram_web/controllers/users_controller.ex
+++ b/lib/engram_web/controllers/users_controller.ex
@@ -37,7 +37,7 @@ defmodule EngramWeb.UsersController do
       {"Profile fields", "application/json", Schemas.UpdateProfileRequest, required: true},
     responses: [
       ok: {"Updated user", "application/json", Schemas.UserResponse},
-      unprocessable_entity: {"Validation error", "application/json", Schemas.ValidationError}
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
     ]
   )
 
@@ -57,16 +57,11 @@ defmodule EngramWeb.UsersController do
         })
 
       {:error, %Ecto.Changeset{} = cs} ->
-        details =
-          Ecto.Changeset.traverse_errors(cs, fn {msg, opts} ->
-            Enum.reduce(opts, msg, fn {k, v}, acc ->
-              String.replace(acc, "%{#{k}}", to_string(v))
-            end)
-          end)
-
+        # Sibling-controller 422 shape (%{errors: field → messages}) — this was
+        # the one endpoint returning %{error: "validation_failed", details: ...}.
         conn
         |> put_status(422)
-        |> json(%{error: "validation_failed", details: details})
+        |> json(%{errors: EngramWeb.format_errors(cs)})
     end
   end
 

--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -414,11 +414,5 @@ defmodule EngramWeb.VaultsController do
 
   defp parse_id(id) when is_binary(id), do: Ecto.UUID.cast(id)
 
-  defp format_errors(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-      Enum.reduce(opts, msg, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", to_string(value))
-      end)
-    end)
-  end
+  defp format_errors(changeset), do: EngramWeb.format_errors(changeset)
 end

--- a/lib/engram_web/plugs/account_deleted.ex
+++ b/lib/engram_web/plugs/account_deleted.ex
@@ -8,19 +8,17 @@ defmodule EngramWeb.Plugs.AccountDeleted do
   allowed and produces a fresh vault.
   """
 
-  import Plug.Conn
-  alias Phoenix.Controller
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
+  # Halt.json emits the identical wire response to the Phoenix.Controller.json
+  # this replaced (same content type incl. charset, same Jason-encoded body).
   def call(%Plug.Conn{assigns: %{current_user: %{deleted_at: %DateTime{}}}} = conn, _opts) do
-    conn
-    |> put_status(410)
-    |> Controller.json(%{
+    Halt.json(conn, 410, %{
       error: "account_deleted",
       message: "Your vault was auto-deleted after 90 days of inactivity. You can re-signup."
     })
-    |> halt()
   end
 
   def call(conn, _opts), do: conn

--- a/lib/engram_web/plugs/account_lifecycle.ex
+++ b/lib/engram_web/plugs/account_lifecycle.ex
@@ -27,8 +27,7 @@ defmodule EngramWeb.Plugs.AccountLifecycle do
   Deleted takes precedence over suspended.
   """
 
-  import Plug.Conn
-  alias Phoenix.Controller
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
@@ -64,10 +63,10 @@ defmodule EngramWeb.Plugs.AccountLifecycle do
   defp suspension_exempt?(%Plug.Conn{request_path: path}),
     do: String.starts_with?(path, "/api/billing/")
 
+  # Halt.json (put_resp_content_type + send_resp) emits the identical wire
+  # response to the Phoenix.Controller.json this replaced: same
+  # `application/json; charset=utf-8` content type, same Jason-encoded body.
   defp deny(conn, status, error, message) do
-    conn
-    |> put_status(status)
-    |> Controller.json(%{error: error, message: message})
-    |> halt()
+    Halt.json(conn, status, %{error: error, message: message})
   end
 end

--- a/lib/engram_web/plugs/auth.ex
+++ b/lib/engram_web/plugs/auth.ex
@@ -13,6 +13,9 @@ defmodule EngramWeb.Plugs.Auth do
   """
 
   import Plug.Conn
+
+  alias EngramWeb.Plugs.Halt
+
   require Logger
 
   def init(opts), do: opts
@@ -48,10 +51,7 @@ defmodule EngramWeb.Plugs.Auth do
         # Alertable counter (the log is grep-only). Coarse bounded reason tag.
         _ = Engram.Auth.emit_rejected(reason, :http)
 
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(401, Jason.encode!(%{error: "unauthorized"}))
-        |> halt()
+        Halt.json(conn, 401, %{error: "unauthorized"})
     end
   end
 

--- a/lib/engram_web/plugs/enforce_connection_cap.ex
+++ b/lib/engram_web/plugs/enforce_connection_cap.ex
@@ -35,10 +35,9 @@ defmodule EngramWeb.Plugs.EnforceConnectionCap do
   path. Document tracked in the design spec.
   """
 
-  import Plug.Conn
-
   alias Engram.{Billing, Connections, OAuth}
   alias Engram.OAuth.Client
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
@@ -81,7 +80,7 @@ defmodule EngramWeb.Plugs.EnforceConnectionCap do
         end
 
       :error ->
-        send_json(conn, 400, %{error: "missing_or_invalid_client_id"})
+        Halt.json(conn, 400, %{error: "missing_or_invalid_client_id"})
     end
   end
 
@@ -132,11 +131,4 @@ defmodule EngramWeb.Plugs.EnforceConnectionCap do
   end
 
   defp lookup_client(_), do: :error
-
-  defp send_json(conn, status, body) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(status, Jason.encode!(body))
-    |> halt()
-  end
 end

--- a/lib/engram_web/plugs/enforce_pat_creation.ex
+++ b/lib/engram_web/plugs/enforce_pat_creation.ex
@@ -12,9 +12,8 @@ defmodule EngramWeb.Plugs.EnforcePatCreation do
   `{"error": "pat_disabled_on_free", "upgrade_url": "/#settings/billing"}`.
   """
 
-  import Plug.Conn
-
   alias Engram.Billing
+  alias EngramWeb.Plugs.Halt
 
   @upgrade_url "/#settings/billing"
 
@@ -26,16 +25,7 @@ defmodule EngramWeb.Plugs.EnforcePatCreation do
         conn
 
       _ ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(
-          402,
-          Jason.encode!(%{
-            error: "pat_disabled_on_free",
-            upgrade_url: @upgrade_url
-          })
-        )
-        |> halt()
+        Halt.json(conn, 402, %{error: "pat_disabled_on_free", upgrade_url: @upgrade_url})
     end
   end
 

--- a/lib/engram_web/plugs/halt.ex
+++ b/lib/engram_web/plugs/halt.ex
@@ -1,0 +1,22 @@
+defmodule EngramWeb.Plugs.Halt do
+  @moduledoc """
+  The one halt-with-JSON idiom shared by every plug that rejects a request:
+  set the JSON content type, send the encoded body, halt the pipeline.
+
+  Anything beyond the idiom (extra response headers like `Retry-After`,
+  assigns for RequestLogger, logging/telemetry) stays at the call site —
+  headers put on the conn before calling `json/3` are preserved by
+  `send_resp/3`. `EngramWeb.LimitResponse` intentionally does NOT go
+  through here: it owns additional header semantics.
+  """
+
+  import Plug.Conn
+
+  @spec json(Plug.Conn.t(), pos_integer(), term()) :: Plug.Conn.t()
+  def json(conn, status, body) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Jason.encode!(body))
+    |> halt()
+  end
+end

--- a/lib/engram_web/plugs/host_rewrite.ex
+++ b/lib/engram_web/plugs/host_rewrite.ex
@@ -20,7 +20,7 @@ defmodule EngramWeb.Plugs.HostRewrite do
   When unset (default), the plug is a strict no-op — selfhost releases never
   touch the rewrite path.
   """
-  import Plug.Conn
+  alias EngramWeb.Plugs.Halt
 
   # Allowed top-level scopes that should pass through unmodified on
   # `api.engram.page`. Matched with `under?/2` (exact match OR followed
@@ -114,17 +114,11 @@ defmodule EngramWeb.Plugs.HostRewrite do
   end
 
   defp reject_unknown(conn, api_host) do
-    body =
-      Jason.encode!(%{
-        error: "gone",
-        message: "This host no longer serves the web app. Use #{api_host} for API access.",
-        api_host: api_host
-      })
-
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(410, body)
-    |> halt()
+    Halt.json(conn, 410, %{
+      error: "gone",
+      message: "This host no longer serves the web app. Use #{api_host} for API access.",
+      api_host: api_host
+    })
   end
 
   defp handle_api_host(conn) do
@@ -178,10 +172,9 @@ defmodule EngramWeb.Plugs.HostRewrite do
     %{conn | request_path: new_path, path_info: new_info}
   end
 
+  # Jason.encode!(%{error: "not_found"}) emits exactly the ~s({"error":"not_found"})
+  # literal this previously hand-rolled — same bytes on the wire.
   defp reject(conn) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(404, ~s({"error":"not_found"}))
-    |> halt()
+    Halt.json(conn, 404, %{error: "not_found"})
   end
 end

--- a/lib/engram_web/plugs/idempotency_key.ex
+++ b/lib/engram_web/plugs/idempotency_key.ex
@@ -6,6 +6,7 @@ defmodule EngramWeb.Plugs.IdempotencyKey do
   """
   import Plug.Conn
   alias Engram.Idempotency
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
@@ -28,10 +29,7 @@ defmodule EngramWeb.Plugs.IdempotencyKey do
     # before this plug), so one tenant can never replay another's response.
     case Idempotency.lookup(conn.assigns.current_user, key) do
       {:ok, %{status: status, body: body}} ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(status, Jason.encode!(body))
-        |> halt()
+        Halt.json(conn, status, body)
 
       :miss ->
         assign(conn, :idempotency_key, key)
@@ -39,9 +37,6 @@ defmodule EngramWeb.Plugs.IdempotencyKey do
   end
 
   defp reject(conn, code) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(400, Jason.encode!(%{error: code}))
-    |> halt()
+    Halt.json(conn, 400, %{error: code})
   end
 end

--- a/lib/engram_web/plugs/pre_auth_rate_limit.ex
+++ b/lib/engram_web/plugs/pre_auth_rate_limit.ex
@@ -53,6 +53,8 @@ defmodule EngramWeb.Plugs.PreAuthRateLimit do
 
   import Plug.Conn
 
+  alias EngramWeb.Plugs.Halt
+
   @default_limit 600
   @default_period_ms 60_000
 
@@ -86,9 +88,7 @@ defmodule EngramWeb.Plugs.PreAuthRateLimit do
         |> put_resp_header("x-ratelimit-limit", Integer.to_string(limit))
         |> put_resp_header("x-ratelimit-remaining", "0")
         |> put_resp_header("x-engram-error", "rate_limited")
-        |> put_resp_content_type("application/json")
-        |> send_resp(429, Jason.encode!(%{error: "rate_limited"}))
-        |> halt()
+        |> Halt.json(429, %{error: "rate_limited"})
     end
   end
 

--- a/lib/engram_web/plugs/rate_limit.ex
+++ b/lib/engram_web/plugs/rate_limit.ex
@@ -4,7 +4,7 @@ defmodule EngramWeb.Plugs.RateLimit do
   Usage: `plug EngramWeb.Plugs.RateLimit, limit: 10, period: 60_000`
   """
 
-  import Plug.Conn
+  alias EngramWeb.Plugs.Halt
 
   # Bake the build env into the module at compile time.
   # This ensures :rate_limit_override is structurally impossible in non-test builds.
@@ -28,10 +28,7 @@ defmodule EngramWeb.Plugs.RateLimit do
         conn
 
       {:deny, _retry_after_ms} ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(429, Jason.encode!(%{error: "rate_limited"}))
-        |> halt()
+        Halt.json(conn, 429, %{error: "rate_limited"})
     end
   end
 

--- a/lib/engram_web/plugs/require_admin.ex
+++ b/lib/engram_web/plugs/require_admin.ex
@@ -4,24 +4,20 @@ defmodule EngramWeb.Plugs.RequireAdmin do
   under Clerk). 403 unless current_user is an active (non-suspended) admin.
   Run AFTER EngramWeb.Plugs.Auth so current_user is loaded.
   """
-  import Plug.Conn
-  import Phoenix.Controller, only: [json: 2]
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
   def call(conn, _opts) do
     cond do
       not Engram.Auth.supports_credentials?() ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(404, Jason.encode!(%{error: "not_found"}))
-        |> halt()
+        Halt.json(conn, 404, %{error: "not_found"})
 
       admin?(conn.assigns[:current_user]) ->
         conn
 
       true ->
-        conn |> put_status(403) |> json(%{error: "forbidden"}) |> halt()
+        Halt.json(conn, 403, %{error: "forbidden"})
     end
   end
 

--- a/lib/engram_web/plugs/require_api_rps_budget.ex
+++ b/lib/engram_web/plugs/require_api_rps_budget.ex
@@ -15,9 +15,8 @@ defmodule EngramWeb.Plugs.RequireApiRpsBudget do
   `:unlimited` via `Billing.effective_limit/2` — no rate-limiter call.
   """
 
-  import Plug.Conn
-
   alias Engram.Billing
+  alias EngramWeb.Plugs.Halt
 
   @default_period_ms 1_000
 
@@ -61,16 +60,6 @@ defmodule EngramWeb.Plugs.RequireApiRpsBudget do
   end
 
   defp deny(conn, limit) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(
-      429,
-      Jason.encode!(%{
-        error: "api_rps_exceeded",
-        limit: limit,
-        period_ms: period_ms()
-      })
-    )
-    |> halt()
+    Halt.json(conn, 429, %{error: "api_rps_exceeded", limit: limit, period_ms: period_ms()})
   end
 end

--- a/lib/engram_web/plugs/require_api_write_enabled.ex
+++ b/lib/engram_web/plugs/require_api_write_enabled.ex
@@ -14,9 +14,8 @@ defmodule EngramWeb.Plugs.RequireApiWriteEnabled do
   vault-scoped pipeline are gated.
   """
 
-  import Plug.Conn
-
   alias Engram.Billing
+  alias EngramWeb.Plugs.Halt
 
   @read_post_paths ~w(/api/search)
 
@@ -39,16 +38,10 @@ defmodule EngramWeb.Plugs.RequireApiWriteEnabled do
         conn
 
       _ ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(
-          402,
-          Jason.encode!(%{
-            error: "api_write_not_available",
-            upgrade_url: "/#settings/billing"
-          })
-        )
-        |> halt()
+        Halt.json(conn, 402, %{
+          error: "api_write_not_available",
+          upgrade_url: "/#settings/billing"
+        })
     end
   end
 end

--- a/lib/engram_web/plugs/require_local_auth.ex
+++ b/lib/engram_web/plugs/require_local_auth.ex
@@ -6,7 +6,7 @@ defmodule EngramWeb.Plugs.RequireLocalAuth do
   so they are unreachable in Clerk deployments regardless of compile-time config.
   """
 
-  import Plug.Conn
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
@@ -14,10 +14,7 @@ defmodule EngramWeb.Plugs.RequireLocalAuth do
     if Engram.Auth.supports_credentials?() do
       conn
     else
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(404, Jason.encode!(%{error: "not_found"}))
-      |> halt()
+      Halt.json(conn, 404, %{error: "not_found"})
     end
   end
 end

--- a/lib/engram_web/plugs/require_onboarding.ex
+++ b/lib/engram_web/plugs/require_onboarding.ex
@@ -13,20 +13,16 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
   no vault is resolved for users we'll 403.
   """
 
-  import Plug.Conn
-
   alias Engram.Onboarding
   alias Engram.Onboarding.GateCache
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
   def call(conn, _opts) do
     case conn.assigns[:current_user] do
       nil ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(401, Jason.encode!(%{error: "authentication_required"}))
-        |> halt()
+        Halt.json(conn, 401, %{error: "authentication_required"})
 
       user ->
         # Deriving status costs ~3 DB round-trips (profile re-read +
@@ -78,12 +74,11 @@ defmodule EngramWeb.Plugs.RequireOnboarding do
       :ok = GateCache.mark_passed(user.id)
       conn
     else
-      body = %{error: "onboarding_required", missing: missing, next_step: next_step}
-
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(403, Jason.encode!(body))
-      |> halt()
+      Halt.json(conn, 403, %{
+        error: "onboarding_required",
+        missing: missing,
+        next_step: next_step
+      })
     end
   end
 end

--- a/lib/engram_web/plugs/rotation_lock_check.ex
+++ b/lib/engram_web/plugs/rotation_lock_check.ex
@@ -14,6 +14,7 @@ defmodule EngramWeb.Plugs.RotationLockCheck do
   import Plug.Conn
 
   alias Engram.Accounts.User
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
@@ -22,9 +23,7 @@ defmodule EngramWeb.Plugs.RotationLockCheck do
       %User{dek_rotation_locked_at: %DateTime{}} ->
         conn
         |> put_resp_header("retry-after", "60")
-        |> put_resp_content_type("application/json")
-        |> send_resp(503, Jason.encode!(%{error: "rotation_in_progress"}))
-        |> halt()
+        |> Halt.json(503, %{error: "rotation_in_progress"})
 
       _ ->
         conn

--- a/lib/engram_web/plugs/vault_plug.ex
+++ b/lib/engram_web/plugs/vault_plug.ex
@@ -14,6 +14,7 @@ defmodule EngramWeb.Plugs.VaultPlug do
   import Plug.Conn
 
   alias Engram.Vaults
+  alias EngramWeb.Plugs.Halt
 
   def init(opts), do: opts
 
@@ -25,8 +26,11 @@ defmodule EngramWeb.Plugs.VaultPlug do
         api_key = conn.assigns[:current_api_key]
 
         case Vaults.check_api_key_access(api_key, vault) do
-          :ok -> assign(conn, :current_vault, vault)
-          :forbidden -> halt_with(conn, 403, "API key does not have access to this vault")
+          :ok ->
+            assign(conn, :current_vault, vault)
+
+          :forbidden ->
+            Halt.json(conn, 403, %{error: "API key does not have access to this vault"})
         end
 
       # A non-UUID X-Vault-ID (e.g. a client sending a stale/placeholder id like
@@ -67,13 +71,6 @@ defmodule EngramWeb.Plugs.VaultPlug do
   defp reject(conn, reason, message) do
     conn
     |> assign(:reject_reason, reason)
-    |> halt_with(404, message)
-  end
-
-  defp halt_with(conn, status, message) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(status, Jason.encode!(%{error: message}))
-    |> halt()
+    |> Halt.json(404, %{error: message})
   end
 end

--- a/lib/engram_web/schemas/account.ex
+++ b/lib/engram_web/schemas/account.ex
@@ -68,22 +68,6 @@ defmodule EngramWeb.Schemas.OkFlag do
   })
 end
 
-defmodule EngramWeb.Schemas.ValidationError do
-  @moduledoc "422 body carrying a top-level message and a field→messages detail map."
-  alias OpenApiSpex.Schema
-  require OpenApiSpex
-
-  OpenApiSpex.schema(%{
-    title: "ValidationError",
-    type: :object,
-    properties: %{
-      error: %Schema{type: :string, example: "validation_failed"},
-      details: %Schema{type: :object, description: "field → [messages]"}
-    },
-    required: [:error]
-  })
-end
-
 defmodule EngramWeb.Schemas.StorageUsage do
   @moduledoc "Per-user attachment storage usage and caps (bytes)."
   alias OpenApiSpex.Schema

--- a/openapi.json
+++ b/openapi.json
@@ -1757,29 +1757,6 @@
         "x-struct": "Elixir.EngramWeb.Schemas.ApiKeysResponse",
         "x-validate": null
       },
-      "ValidationError": {
-        "properties": {
-          "details": {
-            "description": "field → [messages]",
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "error": {
-            "example": "validation_failed",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": [
-          "error"
-        ],
-        "title": "ValidationError",
-        "type": "object",
-        "x-struct": "Elixir.EngramWeb.Schemas.ValidationError",
-        "x-validate": null
-      },
       "DeletedCount": {
         "properties": {
           "deleted": {
@@ -3477,7 +3454,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
+                  "$ref": "#/components/schemas/Error"
                 }
               }
             },

--- a/test/engram_web/controllers/users_controller_test.exs
+++ b/test/engram_web/controllers/users_controller_test.exs
@@ -47,7 +47,9 @@ defmodule EngramWeb.UsersControllerTest do
         |> put_req_header("content-type", "application/json")
         |> patch("/api/me", Jason.encode!(%{display_name: String.duplicate("x", 81)}))
 
-      assert %{"error" => "validation_failed"} = json_response(conn, 422)
+      # Sibling-controller 422 shape (%{errors: field → [messages]}) — unified
+      # from the old one-off %{error: "validation_failed", details: ...}.
+      assert %{"errors" => %{"display_name" => [_ | _]}} = json_response(conn, 422)
     end
 
     test "401 without bearer" do

--- a/test/engram_web/plugs/halt_test.exs
+++ b/test/engram_web/plugs/halt_test.exs
@@ -1,0 +1,34 @@
+defmodule EngramWeb.Plugs.HaltTest do
+  use EngramWeb.ConnCase, async: true
+
+  alias EngramWeb.Plugs.Halt
+
+  test "sends the encoded body with the given status and halts", %{conn: conn} do
+    conn = Halt.json(conn, 402, %{error: "nope", upgrade_url: "/x"})
+
+    assert conn.halted
+    assert conn.status == 402
+    assert json_response(conn, 402) == %{"error" => "nope", "upgrade_url" => "/x"}
+  end
+
+  test "sets the charset-qualified JSON content type", %{conn: conn} do
+    # Pins the wire contract shared with Phoenix.Controller.json — both emit
+    # `application/json; charset=utf-8`, which is what let the Controller.json
+    # call sites (AccountLifecycle, AccountDeleted) convert to this helper
+    # without a byte of response drift.
+    conn = Halt.json(conn, 401, %{error: "unauthorized"})
+
+    assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+  end
+
+  test "preserves response headers put before the call", %{conn: conn} do
+    # RotationLockCheck / PreAuthRateLimit set Retry-After etc. before
+    # delegating; the helper must not clobber them.
+    conn =
+      conn
+      |> put_resp_header("retry-after", "60")
+      |> Halt.json(503, %{error: "rotation_in_progress"})
+
+    assert get_resp_header(conn, "retry-after") == ["60"]
+  end
+end


### PR DESCRIPTION
## Summary

PR B of the review-remediation series (stacked on #1188 — merge that first; GitHub will auto-retarget this to main). Web-layer DRY pass, behavior-identical on the wire except one deliberate change:

- **`EngramWeb.Plugs.Halt.json/3`** — the shared put_resp_content_type + send_resp + halt idiom, replacing 16 hand-rolled copies across the plugs directory (incl. `require_admin`'s two mismatched idioms in one file). Extra headers (`Retry-After`, `X-RateLimit-*`) stay at call sites; `LimitResponse` keeps its own header semantics, untouched. `AccountLifecycle`/`AccountDeleted` moved off `Phoenix.Controller.json` — wire-identical, pinned by the new halt test.
- **`format_errors` dedup** — deleted the private reimplementation in `vaults_controller` and the inline `traverse_errors` in `users_controller`; both call the canonical `EngramWeb.format_errors/1`.
- **BEHAVIOR CHANGE:** `PATCH /api/me` 422 now returns the sibling shape `%{errors: ...}` instead of the one-off `%{error: "validation_failed", details: ...}`. Frontend audited: the SPA only reads the generic `body.error` fallback, nothing parses the old shape. OpenAPI schema updated, unused `Schemas.ValidationError` deleted. TDD (test flipped first, watched red).
- **`EngramWeb.BatchOps`** — byte-identical `parse_uuid_list/parse_uuid/parse_move_target` plus event-parameterized `broadcast_batch` extracted out of the notes/folders controllers. `send_move_result` deliberately NOT unified: success bodies and error-clause sets genuinely differ (`moved_attachments`, `cycle`/attachment-leg errors vs `batch_too_large`) — documented in the moduledoc.

Net −33 lines.

## Test plan
- New halt-helper unit test (status/body/content-type/halted) pins the wire format.
- Users 422 shape change done test-first.
- Gauntlet: format, compile --warnings-as-errors, credo --strict clean; full suite 3952 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015buSiNhFQTvQ8ELdkTuLpz