### PR TITLE
refactor: dedupe crypto hashing + worker scaffolds

### DIFF
--- a/lib/engram/accounts.ex
+++ b/lib/engram/accounts.ex
@@ -496,9 +496,7 @@ defmodule Engram.Accounts do
   end
 
   @doc "SHA-256 hash a raw refresh token for storage/lookup."
-  def hash_refresh_token(raw_token) do
-    :crypto.hash(:sha256, raw_token) |> Base.encode16(case: :lower)
-  end
+  def hash_refresh_token(raw_token), do: Engram.Crypto.sha256_hex(raw_token)
 
   # ── Encryption ─────────────────────────────────────────────────
 
@@ -610,9 +608,7 @@ defmodule Engram.Accounts do
     end
   end
 
-  defp hash_api_key(raw_key) do
-    :crypto.hash(:sha256, raw_key) |> Base.encode16(case: :lower)
-  end
+  defp hash_api_key(raw_key), do: Engram.Crypto.sha256_hex(raw_key)
 
   # ── Admin user management (self-host) ──────────────────────────
 

--- a/lib/engram/accounts/password_reset.ex
+++ b/lib/engram/accounts/password_reset.ex
@@ -107,5 +107,5 @@ defmodule Engram.Accounts.PasswordReset do
   defp normalize({:error, :invalid}), do: {:error, :invalid}
   defp normalize({:error, other}), do: {:error, other}
 
-  defp hash_token(raw), do: :crypto.hash(:sha256, raw) |> Base.encode16(case: :lower)
+  defp hash_token(raw), do: Engram.Crypto.sha256_hex(raw)
 end

--- a/lib/engram/auth/device_flow.ex
+++ b/lib/engram/auth/device_flow.ex
@@ -284,9 +284,7 @@ defmodule Engram.Auth.DeviceFlow do
     {raw, token_hash}
   end
 
-  defp hash_token(raw) do
-    :crypto.hash(:sha256, raw) |> Base.encode16(case: :lower)
-  end
+  defp hash_token(raw), do: Engram.Crypto.sha256_hex(raw)
 
   # User codes are typed by a human to authorize a device, so a predictable
   # PRNG (Enum.random/:rand) is a brute-force/guessing weakness. Draw each

--- a/lib/engram/auth/providers/claims.ex
+++ b/lib/engram/auth/providers/claims.ex
@@ -1,0 +1,32 @@
+defmodule Engram.Auth.Providers.Claims do
+  @moduledoc """
+  Shared claim-shape handling for token-verifying auth providers.
+
+  Clerk (RS256 via JWKS) and Local (HS256) verify tokens differently, but
+  both must extract the same `{sub, email}` identity shape from the claims.
+  Keeping the extraction here means the two providers can't drift on what
+  counts as a complete identity (e.g. one accepting an empty email).
+  """
+
+  @typedoc "Provider identity extracted from verified JWT claims."
+  @type identity :: %{external_id: String.t(), email: String.t()}
+
+  @doc """
+  Maps a verify-call result into the provider identity.
+
+  `sub` must be a binary and `email` a non-empty binary; anything else is
+  `{:error, :missing_claims}`. Verify errors pass through unchanged.
+  """
+  @spec to_identity({:ok, map()} | {:error, term()}) :: {:ok, identity()} | {:error, term()}
+  def to_identity({:ok, claims}) do
+    case {claims["sub"], claims["email"]} do
+      {ext_id, email} when is_binary(ext_id) and is_binary(email) and email != "" ->
+        {:ok, %{external_id: ext_id, email: email}}
+
+      _ ->
+        {:error, :missing_claims}
+    end
+  end
+
+  def to_identity({:error, reason}), do: {:error, reason}
+end

--- a/lib/engram/auth/providers/clerk.ex
+++ b/lib/engram/auth/providers/clerk.ex
@@ -8,19 +8,9 @@ defmodule Engram.Auth.Providers.Clerk do
 
   @impl true
   def verify_token(token) do
-    case Engram.Auth.ClerkToken.verify_clerk_jwt(token) do
-      {:ok, claims} ->
-        case {claims["sub"], claims["email"]} do
-          {ext_id, email} when is_binary(ext_id) and is_binary(email) and email != "" ->
-            {:ok, %{external_id: ext_id, email: email}}
-
-          _ ->
-            {:error, :missing_claims}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    token
+    |> Engram.Auth.ClerkToken.verify_clerk_jwt()
+    |> Engram.Auth.Providers.Claims.to_identity()
   end
 
   @impl true

--- a/lib/engram/auth/providers/local.ex
+++ b/lib/engram/auth/providers/local.ex
@@ -8,19 +8,9 @@ defmodule Engram.Auth.Providers.Local do
 
   @impl true
   def verify_token(token) do
-    case Engram.Token.verify_and_validate(token) do
-      {:ok, claims} ->
-        case {claims["sub"], claims["email"]} do
-          {ext_id, email} when is_binary(ext_id) and is_binary(email) and email != "" ->
-            {:ok, %{external_id: ext_id, email: email}}
-
-          _ ->
-            {:error, :missing_claims}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    token
+    |> Engram.Token.verify_and_validate()
+    |> Engram.Auth.Providers.Claims.to_identity()
   end
 
   @impl true

--- a/lib/engram/billing.ex
+++ b/lib/engram/billing.ex
@@ -488,19 +488,7 @@ defmodule Engram.Billing do
           custom_data: data["custom_data"] || %{}
         }
 
-        attrs =
-          case tier_from_subscription(data) do
-            {:ok, tier} ->
-              Map.put(base_attrs, :tier, Atom.to_string(tier))
-
-            {:error, :unknown_price_id} ->
-              _ =
-                Sentry.capture_message("Unknown Paddle price_id, tier unchanged",
-                  extra: %{user_id: user_id, payload_keys: Map.keys(data)}
-                )
-
-              base_attrs
-          end
+        attrs = attrs_with_tier(base_attrs, data, user_id)
 
         # Omit :custom_data from the replace list. Paddle delivers at-least-once,
         # so a retried subscription.created must NOT clobber the affiliate /
@@ -538,12 +526,7 @@ defmodule Engram.Billing do
   end
 
   def upsert_from_paddle_event(%{"event_type" => "subscription.canceled", "data" => data}) do
-    subscription_id = data["id"]
-
-    case Repo.one(
-           from(s in Subscription, where: s.paddle_subscription_id == ^subscription_id),
-           skip_tenant_check: true
-         ) do
+    case get_subscription_by_paddle_id(data["id"]) do
       %Subscription{} = sub ->
         sub_with_user = Repo.preload(sub, :user, skip_tenant_check: true)
         user = sub_with_user.user
@@ -554,19 +537,7 @@ defmodule Engram.Billing do
           current_period_end: parse_period_end(data)
         }
 
-        update_attrs =
-          case tier_from_subscription(data) do
-            {:ok, tier_atom} ->
-              Map.put(base_attrs, :tier, Atom.to_string(tier_atom))
-
-            {:error, :unknown_price_id} ->
-              _ =
-                Sentry.capture_message("Unknown Paddle price_id, tier unchanged",
-                  extra: %{user_id: sub.user_id, payload_keys: Map.keys(data)}
-                )
-
-              base_attrs
-          end
+        update_attrs = attrs_with_tier(base_attrs, data, sub.user_id)
 
         # Flip the user to Free at cancellation (period end per Paddle's engine).
         # `free_tier_accepted_at` is stamped only when nil so a user who had
@@ -619,31 +590,14 @@ defmodule Engram.Billing do
 
   def upsert_from_paddle_event(%{"event_type" => type, "data" => data})
       when type in ~w(subscription.activated subscription.updated subscription.past_due) do
-    subscription_id = data["id"]
-
-    case Repo.one(
-           from(s in Subscription, where: s.paddle_subscription_id == ^subscription_id),
-           skip_tenant_check: true
-         ) do
+    case get_subscription_by_paddle_id(data["id"]) do
       %Subscription{tier: prev_tier, status: prev_status} = sub ->
         base_attrs = %{
           status: data["status"],
           current_period_end: parse_period_end(data)
         }
 
-        update_attrs =
-          case tier_from_subscription(data) do
-            {:ok, tier} ->
-              Map.put(base_attrs, :tier, Atom.to_string(tier))
-
-            {:error, :unknown_price_id} ->
-              _ =
-                Sentry.capture_message("Unknown Paddle price_id, tier unchanged",
-                  extra: %{user_id: sub.user_id, payload_keys: Map.keys(data)}
-                )
-
-              base_attrs
-          end
+        update_attrs = attrs_with_tier(base_attrs, data, sub.user_id)
 
         result =
           sub
@@ -677,6 +631,34 @@ defmodule Engram.Billing do
   end
 
   def upsert_from_paddle_event(_event), do: {:ok, :ignored}
+
+  # Resolve the tier from the event's price_id and merge it into `base_attrs`.
+  # An unknown price_id leaves the tier UNCHANGED (attrs without :tier) rather
+  # than downgrading — a misconfigured price map must never strip a paying
+  # user's tier — and pages via Sentry so ops fixes the mapping.
+  defp attrs_with_tier(base_attrs, data, user_id) do
+    case tier_from_subscription(data) do
+      {:ok, tier} ->
+        Map.put(base_attrs, :tier, Atom.to_string(tier))
+
+      {:error, :unknown_price_id} ->
+        _ =
+          Sentry.capture_message("Unknown Paddle price_id, tier unchanged",
+            extra: %{user_id: user_id, payload_keys: Map.keys(data)}
+          )
+
+        base_attrs
+    end
+  end
+
+  # Webhook-side lookup: Paddle's subscription id is the only key we have at
+  # this point (no user in scope yet), hence skip_tenant_check.
+  defp get_subscription_by_paddle_id(subscription_id) do
+    Repo.one(
+      from(s in Subscription, where: s.paddle_subscription_id == ^subscription_id),
+      skip_tenant_check: true
+    )
+  end
 
   # Notify the user's open browser tabs that their subscription state
   # changed server-side, so the activation overlay can hand off to the

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -858,6 +858,20 @@ defmodule Engram.Crypto do
   defp safe_decode64(s) when is_binary(s), do: Base.decode64(s)
   defp safe_decode64(_), do: :error
 
+  @doc """
+  Lowercase-hex SHA-256 digest of `data`.
+
+  Canonical helper for secret-token fingerprints stored for indexed DB
+  lookup (refresh tokens, API keys, invite / password-reset / device-flow
+  tokens, OAuth authorization codes). The raw secret never touches the DB;
+  only this digest does. NOT for note-content hashing — that is per-user
+  keyed to defeat cross-user correlation (see `hmac_content_hash/2`).
+  """
+  @spec sha256_hex(iodata()) :: String.t()
+  def sha256_hex(data) do
+    :crypto.hash(:sha256, data) |> Base.encode16(case: :lower)
+  end
+
   @filter_key_info "engram-filter-v1"
   @content_hash_info "engram-content-hash-v1"
 

--- a/lib/engram/crypto/aad_rebind.ex
+++ b/lib/engram/crypto/aad_rebind.ex
@@ -35,6 +35,7 @@ defmodule Engram.Crypto.AadRebind do
   alias Engram.Crypto
   alias Engram.Crypto.Envelope
   alias Engram.Crypto.KeyProvider.Resolver
+  alias Engram.Crypto.MigrationRunner
   alias Engram.Notes.Note
   alias Engram.Repo
   alias Engram.Vaults.Vault
@@ -58,7 +59,7 @@ defmodule Engram.Crypto.AadRebind do
   def rebind_all(opts \\ []) do
     batch_size = Keyword.get(opts, :batch_size, 100)
 
-    drive_loop("00000000-0000-0000-0000-000000000000", batch_size, %{ok: 0, skipped: 0, failed: 0})
+    MigrationRunner.drive(&provisioned_ids(&1, batch_size), &rebind_user/1)
   end
 
   @doc "Rebind a single user. Idempotent — already-rebound users return `:skipped`."
@@ -68,7 +69,7 @@ defmodule Engram.Crypto.AadRebind do
   def rebind_user(user_id) when is_binary(user_id) do
     started_at = System.monotonic_time()
     result = do_rebind(user_id)
-    duration_us = duration_us_since(started_at)
+    duration_us = MigrationRunner.duration_us_since(started_at)
     emit_telemetry(user_id, result, duration_us)
 
     case result do
@@ -337,40 +338,16 @@ defmodule Engram.Crypto.AadRebind do
     end
   end
 
-  defp drive_loop(last_id, batch_size, acc) do
-    ids =
-      from(u in User,
-        where: not is_nil(u.encrypted_dek) and u.id > ^last_id,
-        select: u.id,
-        order_by: u.id,
-        limit: ^batch_size
-      )
-      |> Repo.all(skip_tenant_check: true)
-
-    case ids do
-      [] ->
-        acc
-
-      _ ->
-        acc =
-          Enum.reduce(ids, acc, fn id, a ->
-            case rebind_user(id) do
-              :ok -> Map.update!(a, :ok, &(&1 + 1))
-              :skipped -> Map.update!(a, :skipped, &(&1 + 1))
-              {:error, _} -> Map.update!(a, :failed, &(&1 + 1))
-            end
-          end)
-
-        drive_loop(List.last(ids), batch_size, acc)
-    end
-  end
-
-  defp duration_us_since(started_at) do
-    System.convert_time_unit(
-      System.monotonic_time() - started_at,
-      :native,
-      :microsecond
+  # Next id-ordered page of users holding a wrapped DEK — every provisioned
+  # user is a rebind candidate; per-user idempotency lives in rebind_user/1.
+  defp provisioned_ids(last_id, batch_size) do
+    from(u in User,
+      where: not is_nil(u.encrypted_dek) and u.id > ^last_id,
+      select: u.id,
+      order_by: u.id,
+      limit: ^batch_size
     )
+    |> Repo.all(skip_tenant_check: true)
   end
 
   defp emit_telemetry(user_id, {:rebound, _}, duration_us) do

--- a/lib/engram/crypto/master_rotation.ex
+++ b/lib/engram/crypto/master_rotation.ex
@@ -38,6 +38,7 @@ defmodule Engram.Crypto.MasterRotation do
   alias Engram.Accounts
   alias Engram.Accounts.User
   alias Engram.Crypto.KeyProvider.Resolver
+  alias Engram.Crypto.MigrationRunner
   alias Engram.Repo
 
   require Logger
@@ -65,7 +66,7 @@ defmodule Engram.Crypto.MasterRotation do
 
     started_at = System.monotonic_time()
     result = do_rotate(user_id, target_version)
-    duration_us = duration_us_since(started_at)
+    duration_us = MigrationRunner.duration_us_since(started_at)
     emit_telemetry(user_id, result, duration_us)
 
     case result do
@@ -91,11 +92,9 @@ defmodule Engram.Crypto.MasterRotation do
       when is_integer(target_version) and target_version >= 1 do
     batch_size = Keyword.get(opts, :batch_size, 100)
 
-    drive_loop(
-      target_version,
-      "00000000-0000-0000-0000-000000000000",
-      batch_size,
-      %{ok: 0, skipped: 0, failed: 0}
+    MigrationRunner.drive(
+      &below_target_ids(target_version, &1, batch_size),
+      &rotate_user(&1, target_version)
     )
   end
 
@@ -137,15 +136,7 @@ defmodule Engram.Crypto.MasterRotation do
   end
 
   defp enqueue_loop(target_version, last_id, batch_size, total) do
-    ids =
-      from(u in User,
-        where: not is_nil(u.encrypted_dek) and u.dek_version < ^target_version,
-        where: u.id > ^last_id,
-        select: u.id,
-        order_by: u.id,
-        limit: ^batch_size
-      )
-      |> Repo.all(skip_tenant_check: true)
+    ids = below_target_ids(target_version, last_id, batch_size)
 
     case ids do
       [] ->
@@ -219,41 +210,17 @@ defmodule Engram.Crypto.MasterRotation do
     end
   end
 
-  defp drive_loop(target_version, last_id, batch_size, acc) do
-    ids =
-      from(u in User,
-        where: not is_nil(u.encrypted_dek) and u.dek_version < ^target_version,
-        where: u.id > ^last_id,
-        select: u.id,
-        order_by: u.id,
-        limit: ^batch_size
-      )
-      |> Repo.all(skip_tenant_check: true)
-
-    case ids do
-      [] ->
-        acc
-
-      _ ->
-        acc =
-          Enum.reduce(ids, acc, fn id, a ->
-            case rotate_user(id, target_version) do
-              :ok -> Map.update!(a, :ok, &(&1 + 1))
-              :skipped -> Map.update!(a, :skipped, &(&1 + 1))
-              {:error, _} -> Map.update!(a, :failed, &(&1 + 1))
-            end
-          end)
-
-        drive_loop(target_version, List.last(ids), batch_size, acc)
-    end
-  end
-
-  defp duration_us_since(started_at) do
-    System.convert_time_unit(
-      System.monotonic_time() - started_at,
-      :native,
-      :microsecond
+  # Next id-ordered page of users still below `target_version`. Shared by the
+  # in-process drive loop and the Oban enqueue loop — same fleet filter.
+  defp below_target_ids(target_version, last_id, batch_size) do
+    from(u in User,
+      where: not is_nil(u.encrypted_dek) and u.dek_version < ^target_version,
+      where: u.id > ^last_id,
+      select: u.id,
+      order_by: u.id,
+      limit: ^batch_size
     )
+    |> Repo.all(skip_tenant_check: true)
   end
 
   defp emit_telemetry(user_id, {:rotated, _}, duration_us) do

--- a/lib/engram/crypto/master_rotation.ex
+++ b/lib/engram/crypto/master_rotation.ex
@@ -87,7 +87,10 @@ defmodule Engram.Crypto.MasterRotation do
 
   Returns the aggregate `counts` map.
   """
-  @spec rotate_all(pos_integer(), keyword()) :: counts() | {:error, term()}
+  # No {:error, _} arm: per-user failures count into :failed (unchanged from
+  # the pre-MigrationRunner loop); the old spec's error arm was always dead —
+  # dialyzer can now prove it through MigrationRunner.drive/2's spec.
+  @spec rotate_all(pos_integer(), keyword()) :: counts()
   def rotate_all(target_version, opts \\ [])
       when is_integer(target_version) and target_version >= 1 do
     batch_size = Keyword.get(opts, :batch_size, 100)

--- a/lib/engram/crypto/migration_runner.ex
+++ b/lib/engram/crypto/migration_runner.ex
@@ -1,0 +1,69 @@
+defmodule Engram.Crypto.MigrationRunner do
+  @moduledoc """
+  Shared scaffolding for the per-user crypto migration drivers
+  (`MasterRotation`, `ProviderMigration`, `AadRebind`, `UserDekRotation`).
+
+  Only the trivially identical pieces live here: the cursor-driven fleet
+  loop and the monotonic duration helper. Telemetry emission and reason
+  classification deliberately stay in each migration module — their event
+  names, metadata shapes, and reason-label sets differ per migration and
+  are contractual (dashboards/alerts key on them), so a shared emitter
+  would either change wire shapes or need one parameter per divergence.
+  """
+
+  # UUIDv7 ids sort above the all-zero UUID, so this is the cursor floor.
+  @zero_uuid "00000000-0000-0000-0000-000000000000"
+
+  @typedoc "Aggregate tally from streaming a migration over the user fleet."
+  @type counts :: %{ok: non_neg_integer(), skipped: non_neg_integer(), failed: non_neg_integer()}
+
+  @doc """
+  Cursor-driven fleet loop shared by the `*_all` drivers.
+
+  `fetch_ids.(last_id)` returns the next batch of user ids strictly above
+  `last_id` in ascending order (the caller's query closes over its own
+  filter + batch size); an empty batch terminates the loop. `per_id.(id)`
+  runs one per-user migration — each in its own transaction, exactly as
+  before — and its `:ok | :skipped | {:error, _}` result is tallied.
+
+  `initial` seeds the tally: `ProviderMigration.migrate_all/2` pre-counts
+  already-at-target users as `:skipped` without visiting them.
+  """
+  @spec drive(
+          (String.t() -> [String.t()]),
+          (String.t() -> :ok | :skipped | {:error, term()}),
+          counts()
+        ) :: counts()
+  def drive(fetch_ids, per_id, initial \\ %{ok: 0, skipped: 0, failed: 0}) do
+    drive_loop(fetch_ids, per_id, @zero_uuid, initial)
+  end
+
+  defp drive_loop(fetch_ids, per_id, last_id, acc) do
+    case fetch_ids.(last_id) do
+      [] ->
+        acc
+
+      ids ->
+        acc =
+          Enum.reduce(ids, acc, fn id, a ->
+            case per_id.(id) do
+              :ok -> Map.update!(a, :ok, &(&1 + 1))
+              :skipped -> Map.update!(a, :skipped, &(&1 + 1))
+              {:error, _} -> Map.update!(a, :failed, &(&1 + 1))
+            end
+          end)
+
+        drive_loop(fetch_ids, per_id, List.last(ids), acc)
+    end
+  end
+
+  @doc "Microseconds elapsed since a `System.monotonic_time/0` capture."
+  @spec duration_us_since(integer()) :: integer()
+  def duration_us_since(started_at) do
+    System.convert_time_unit(
+      System.monotonic_time() - started_at,
+      :native,
+      :microsecond
+    )
+  end
+end

--- a/lib/engram/crypto/provider_migration.ex
+++ b/lib/engram/crypto/provider_migration.ex
@@ -83,7 +83,9 @@ defmodule Engram.Crypto.ProviderMigration do
   users and users without an `encrypted_dek` (latter is rare; counted as
   skipped because the fleet drain semantically completes for them).
   """
-  @spec migrate_all(provider_atom(), keyword()) :: counts() | {:error, term()}
+  # No {:error, _} arm — same reasoning as MasterRotation.rotate_all/2:
+  # per-user failures land in :failed; the error arm was always dead.
+  @spec migrate_all(provider_atom(), keyword()) :: counts()
   def migrate_all(target_provider, opts \\ []) when target_provider in [:local, :aws_kms] do
     batch_size = Keyword.get(opts, :batch_size, 100)
     target_name = Atom.to_string(target_provider)

--- a/lib/engram/crypto/provider_migration.ex
+++ b/lib/engram/crypto/provider_migration.ex
@@ -42,7 +42,7 @@ defmodule Engram.Crypto.ProviderMigration do
 
   alias Engram.Accounts
   alias Engram.Accounts.User
-  alias Engram.Crypto.{Config, KeyProvider}
+  alias Engram.Crypto.{Config, KeyProvider, MigrationRunner}
   alias Engram.Crypto.KeyProvider.{AwsKms, Local}
   alias Engram.Repo
 
@@ -65,7 +65,7 @@ defmodule Engram.Crypto.ProviderMigration do
 
     started_at = System.monotonic_time()
     result = do_migrate(user_id, target_provider)
-    duration_us = duration_us_since(started_at)
+    duration_us = MigrationRunner.duration_us_since(started_at)
     emit_telemetry(user_id, target_provider, result, duration_us)
 
     case result do
@@ -95,11 +95,11 @@ defmodule Engram.Crypto.ProviderMigration do
       )
       |> Repo.one(skip_tenant_check: true)
 
-    drive_loop(target_provider, "00000000-0000-0000-0000-000000000000", batch_size, %{
-      ok: 0,
-      skipped: already_at_target || 0,
-      failed: 0
-    })
+    MigrationRunner.drive(
+      &off_target_ids(target_name, &1, batch_size),
+      &migrate_user(&1, target_provider),
+      %{ok: 0, skipped: already_at_target || 0, failed: 0}
+    )
   end
 
   @doc """
@@ -205,14 +205,6 @@ defmodule Engram.Crypto.ProviderMigration do
   defp module_for(:local), do: Local
   defp module_for(:aws_kms), do: AwsKms
 
-  defp duration_us_since(started_at) do
-    System.convert_time_unit(
-      System.monotonic_time() - started_at,
-      :native,
-      :microsecond
-    )
-  end
-
   defp emit_telemetry(user_id, target_provider, {:migrated, _}, duration_us) do
     :telemetry.execute(
       [:engram, :crypto, :migrate_provider, :user],
@@ -267,47 +259,21 @@ defmodule Engram.Crypto.ProviderMigration do
 
   defp classify_reason(_other), do: "other"
 
-  defp drive_loop(target_provider, last_id, batch_size, acc) do
-    target_name = Atom.to_string(target_provider)
-
-    ids =
-      from(u in User,
-        where: not is_nil(u.encrypted_dek) and u.key_provider != ^target_name,
-        where: u.id > ^last_id,
-        select: u.id,
-        order_by: u.id,
-        limit: ^batch_size
-      )
-      |> Repo.all(skip_tenant_check: true)
-
-    case ids do
-      [] ->
-        acc
-
-      _ ->
-        acc =
-          Enum.reduce(ids, acc, fn id, a ->
-            case migrate_user(id, target_provider) do
-              :ok -> Map.update!(a, :ok, &(&1 + 1))
-              :skipped -> Map.update!(a, :skipped, &(&1 + 1))
-              {:error, _} -> Map.update!(a, :failed, &(&1 + 1))
-            end
-          end)
-
-        drive_loop(target_provider, List.last(ids), batch_size, acc)
-    end
+  # Next id-ordered page of users whose wrap is not yet under `target_name`.
+  # Shared by the in-process drive loop and the Oban enqueue loop.
+  defp off_target_ids(target_name, last_id, batch_size) do
+    from(u in User,
+      where: not is_nil(u.encrypted_dek) and u.key_provider != ^target_name,
+      where: u.id > ^last_id,
+      select: u.id,
+      order_by: u.id,
+      limit: ^batch_size
+    )
+    |> Repo.all(skip_tenant_check: true)
   end
 
   defp enqueue_loop(target_provider, target_name, last_id, batch_size, total) do
-    ids =
-      from(u in User,
-        where: not is_nil(u.encrypted_dek) and u.key_provider != ^target_name,
-        where: u.id > ^last_id,
-        select: u.id,
-        order_by: u.id,
-        limit: ^batch_size
-      )
-      |> Repo.all(skip_tenant_check: true)
+    ids = off_target_ids(target_name, last_id, batch_size)
 
     case ids do
       [] ->

--- a/lib/engram/crypto/user_dek_rotation.ex
+++ b/lib/engram/crypto/user_dek_rotation.ex
@@ -34,7 +34,7 @@ defmodule Engram.Crypto.UserDekRotation do
   alias Engram.Accounts.User
   alias Engram.Auth.SessionInvalidator
   alias Engram.Crypto
-  alias Engram.Crypto.{DekCache, Envelope, RotationLock}
+  alias Engram.Crypto.{DekCache, Envelope, MigrationRunner, RotationLock}
   alias Engram.Crypto.KeyProvider.Resolver
   alias Engram.Logger.Metadata
   alias Engram.Repo
@@ -60,15 +60,15 @@ defmodule Engram.Crypto.UserDekRotation do
 
     try do
       result = do_rotate(user_id)
-      emit_telemetry(user_id, result, duration_us_since(started_at))
+      emit_telemetry(user_id, result, MigrationRunner.duration_us_since(started_at))
       result
     rescue
       e ->
-        emit_telemetry(user_id, {:error, :crashed}, duration_us_since(started_at))
+        emit_telemetry(user_id, {:error, :crashed}, MigrationRunner.duration_us_since(started_at))
         reraise e, __STACKTRACE__
     catch
       kind, reason ->
-        emit_telemetry(user_id, {:error, :crashed}, duration_us_since(started_at))
+        emit_telemetry(user_id, {:error, :crashed}, MigrationRunner.duration_us_since(started_at))
         :erlang.raise(kind, reason, __STACKTRACE__)
     end
   end
@@ -1132,14 +1132,6 @@ defmodule Engram.Crypto.UserDekRotation do
       {:error, reason} ->
         {:error, reason}
     end
-  end
-
-  defp duration_us_since(started_at) do
-    System.convert_time_unit(
-      System.monotonic_time() - started_at,
-      :native,
-      :microsecond
-    )
   end
 
   defp emit_telemetry(user_id, :ok, duration_us) do

--- a/lib/engram/invites.ex
+++ b/lib/engram/invites.ex
@@ -117,5 +117,5 @@ defmodule Engram.Invites do
     )
   end
 
-  defp hash_token(raw), do: :crypto.hash(:sha256, raw) |> Base.encode16(case: :lower)
+  defp hash_token(raw), do: Engram.Crypto.sha256_hex(raw)
 end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -1581,6 +1581,27 @@ defmodule Engram.Notes do
   end
 
   @doc """
+  Worker-side note fetch: loads by id with `skip_tenant_check` (trusted
+  internal workers scope by note_id, not tenant) and maps the two dead-end
+  states to an Oban `{:discard, reason}` — a vanished note or a soft-deleted
+  one is permanently un-processable, so retrying would only burn attempts.
+  Used by `Engram.Workers.EmbedNote` and `Engram.Workers.RepathNoteIndex`.
+  """
+  @spec fetch_note_for_worker(String.t()) :: {:ok, Note.t()} | {:discard, String.t()}
+  def fetch_note_for_worker(note_id) do
+    case Repo.get(Note, note_id, skip_tenant_check: true) do
+      nil ->
+        {:discard, "note #{note_id} not found"}
+
+      %Note{deleted_at: deleted_at} when deleted_at != nil ->
+        {:discard, "note #{note_id} is soft-deleted"}
+
+      note ->
+        {:ok, note}
+    end
+  end
+
+  @doc """
   True when a live note with `note_id` exists in `vault_id` for `user`.
 
   Ownership check for the CRDT channel: doc_id is now the note_id, so the

--- a/lib/engram/oauth.ex
+++ b/lib/engram/oauth.ex
@@ -707,5 +707,5 @@ defmodule Engram.OAuth do
     base <> sep <> URI.encode_query(cleaned)
   end
 
-  defp hash_code(raw), do: :crypto.hash(:sha256, raw) |> Base.encode16(case: :lower)
+  defp hash_code(raw), do: Engram.Crypto.sha256_hex(raw)
 end

--- a/lib/engram/paddle/client/http.ex
+++ b/lib/engram/paddle/client/http.ex
@@ -16,110 +16,69 @@ defmodule Engram.Paddle.Client.HTTP do
 
   @impl true
   def create_customer_portal_session(customer_id) when is_binary(customer_id) do
-    with {:ok, api_key} <- fetch_api_key() do
-      url = base_url() <> "/customers/" <> customer_id <> "/portal-sessions"
-
-      case Req.post(url, headers: headers(api_key), json: %{}, receive_timeout: 10_000) do
-        {:ok,
-         %Req.Response{
-           status: 201,
-           body: %{"data" => %{"urls" => %{"general" => %{"overview" => overview}}}}
-         }} ->
+    request(
+      :post,
+      "/customers/" <> customer_id <> "/portal-sessions",
+      "portal-session",
+      fn
+        %Req.Response{
+          status: 201,
+          body: %{"data" => %{"urls" => %{"general" => %{"overview" => overview}}}}
+        } ->
           {:ok, overview}
 
-        {:ok, %Req.Response{status: status, body: body}} ->
-          Logger.warning(
-            "Paddle portal-session non-201",
-            Metadata.with_category(:warning, :billing,
-              status: status,
-              reason_label: inspect(body)
-            )
-          )
-
-          {:error, {:paddle_error, status, body}}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
-    end
+        _ ->
+          :error
+      end,
+      json: %{},
+      # This endpoint predates log_non_2xx and logged "non-201"; the message
+      # is kept verbatim so log-based alerting/queries don't silently break.
+      log_message: "Paddle portal-session non-201"
+    )
   end
 
   @impl true
   def get_subscription(subscription_id) when is_binary(subscription_id) do
-    with {:ok, api_key} <- fetch_api_key() do
-      url = base_url() <> "/subscriptions/" <> subscription_id
-
-      case Req.get(url, headers: headers(api_key), receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
-          {:ok, data}
-
-        {:ok, %Req.Response{status: status, body: body}} ->
-          log_non_2xx("subscription", status, body)
-          {:error, {:paddle_error, status, body}}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
-    end
+    request(:get, "/subscriptions/" <> subscription_id, "subscription", fn
+      %Req.Response{status: 200, body: %{"data" => data}} -> {:ok, data}
+      _ -> :error
+    end)
   end
 
   @impl true
   def list_transactions(subscription_id) when is_binary(subscription_id) do
-    with {:ok, api_key} <- fetch_api_key() do
-      url = base_url() <> "/transactions"
-
-      params = [subscription_id: subscription_id, order_by: "billed_at[DESC]", per_page: 50]
-
-      case Req.get(url, headers: headers(api_key), params: params, receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} when is_list(data) ->
-          {:ok, data}
-
-        {:ok, %Req.Response{status: status, body: body}} ->
-          log_non_2xx("transactions", status, body)
-          {:error, {:paddle_error, status, body}}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
-    end
+    request(
+      :get,
+      "/transactions",
+      "transactions",
+      fn
+        %Req.Response{status: 200, body: %{"data" => data}} when is_list(data) -> {:ok, data}
+        _ -> :error
+      end,
+      params: [subscription_id: subscription_id, order_by: "billed_at[DESC]", per_page: 50]
+    )
   end
 
   @impl true
   def get_transaction_invoice(transaction_id) when is_binary(transaction_id) do
-    with {:ok, api_key} <- fetch_api_key() do
-      url = base_url() <> "/transactions/" <> transaction_id <> "/invoice"
-
-      case Req.get(url, headers: headers(api_key), receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 200, body: %{"data" => %{"url" => invoice_url}}}} ->
-          {:ok, invoice_url}
-
-        {:ok, %Req.Response{status: status, body: body}} ->
-          log_non_2xx("transaction-invoice", status, body)
-          {:error, {:paddle_error, status, body}}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
-    end
+    request(:get, "/transactions/" <> transaction_id <> "/invoice", "transaction-invoice", fn
+      %Req.Response{status: 200, body: %{"data" => %{"url" => invoice_url}}} -> {:ok, invoice_url}
+      _ -> :error
+    end)
   end
 
   @impl true
   def get_portal_session(customer_id) when is_binary(customer_id) do
-    with {:ok, api_key} <- fetch_api_key() do
-      url = base_url() <> "/customers/" <> customer_id <> "/portal-sessions"
-
-      case Req.post(url, headers: headers(api_key), json: %{}, receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 201, body: %{"data" => %{"urls" => urls}}}} ->
-          {:ok, urls}
-
-        {:ok, %Req.Response{status: status, body: body}} ->
-          log_non_2xx("portal-session", status, body)
-          {:error, {:paddle_error, status, body}}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
-    end
+    request(
+      :post,
+      "/customers/" <> customer_id <> "/portal-sessions",
+      "portal-session",
+      fn
+        %Req.Response{status: 201, body: %{"data" => %{"urls" => urls}}} -> {:ok, urls}
+        _ -> :error
+      end,
+      json: %{}
+    )
   end
 
   @impl true
@@ -210,80 +169,82 @@ defmodule Engram.Paddle.Client.HTTP do
 
   @impl true
   def get_update_payment_transaction(subscription_id) when is_binary(subscription_id) do
-    with {:ok, api_key} <- fetch_api_key() do
-      url =
-        base_url() <>
-          "/subscriptions/" <> subscription_id <> "/update-payment-method-transaction"
-
-      case Req.get(url, headers: headers(api_key), receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
-          {:ok, data}
-
-        {:ok, %Req.Response{status: status, body: body}} ->
-          log_non_2xx("update-payment-transaction", status, body)
-          {:error, {:paddle_error, status, body}}
-
-        {:error, reason} ->
-          {:error, reason}
+    request(
+      :get,
+      "/subscriptions/" <> subscription_id <> "/update-payment-method-transaction",
+      "update-payment-transaction",
+      fn
+        %Req.Response{status: 200, body: %{"data" => data}} -> {:ok, data}
+        _ -> :error
       end
-    end
+    )
   end
 
   @impl true
   def cancel_subscription(subscription_id, effective_from, opts \\ [])
       when is_binary(subscription_id) and effective_from in [:immediately, :next_billing_period] do
-    with {:ok, api_key} <- fetch_api_key() do
-      url = base_url() <> "/subscriptions/" <> subscription_id <> "/cancel"
-
-      body = %{effective_from: Atom.to_string(effective_from)}
-
-      req_headers =
-        case Keyword.get(opts, :idempotency_key) do
-          key when is_binary(key) -> headers(api_key) ++ [{"paddle-ik", key}]
-          _ -> headers(api_key)
-        end
-
-      case Req.post(url, headers: req_headers, json: body, receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
-          {:ok, data}
-
-        {:ok, %Req.Response{status: status, body: body}} ->
-          log_non_2xx("subscription-cancel", status, body)
-          {:error, {:paddle_error, status, body}}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
-    end
+    request(
+      :post,
+      "/subscriptions/" <> subscription_id <> "/cancel",
+      "subscription-cancel",
+      fn
+        %Req.Response{status: 200, body: %{"data" => data}} -> {:ok, data}
+        _ -> :error
+      end,
+      json: %{effective_from: Atom.to_string(effective_from)},
+      idempotency_key: Keyword.get(opts, :idempotency_key)
+    )
   end
 
   @impl true
   def preview_subscription_update(subscription_id, items, opts \\ [])
       when is_binary(subscription_id) and is_list(items) do
-    with {:ok, api_key} <- fetch_api_key() do
-      url = base_url() <> "/subscriptions/" <> subscription_id <> "/preview"
-      body = subscription_update_body(items, opts)
-
-      case Req.patch(url, headers: headers(api_key), json: body, receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
-          {:ok, data}
-
-        {:ok, %Req.Response{status: status, body: body}} ->
-          log_non_2xx("subscription-preview", status, body)
-          {:error, {:paddle_error, status, body}}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
-    end
+    request(
+      :patch,
+      "/subscriptions/" <> subscription_id <> "/preview",
+      "subscription-preview",
+      fn
+        %Req.Response{status: 200, body: %{"data" => data}} -> {:ok, data}
+        _ -> :error
+      end,
+      json: subscription_update_body(items, opts)
+    )
   end
 
   @impl true
   def update_subscription(subscription_id, items, opts \\ [])
       when is_binary(subscription_id) and is_list(items) do
+    request(
+      :patch,
+      "/subscriptions/" <> subscription_id,
+      "subscription-update",
+      fn
+        %Req.Response{status: 200, body: %{"data" => data}} -> {:ok, data}
+        _ -> :error
+      end,
+      json: subscription_update_body(items, opts),
+      idempotency_key: Keyword.get(opts, :idempotency_key)
+    )
+  end
+
+  # ── shared request driver ─────────────────────────────────────────
+  #
+  # Every non-paginated Paddle call is the same shape: fetch the API key,
+  # build URL + headers, issue one Req call, pattern-match the single success
+  # shape, and map everything else to a warning log +
+  # `{:error, {:paddle_error, status, body}}`. `extract` matches ONLY the
+  # success response (status AND body shape) and returns `{:ok, result}`;
+  # any other response — wrong status, or a 2xx with an unexpected body —
+  # returns `:error` and takes the same non-2xx path the hand-rolled
+  # versions did. (`list_subscriptions/1` stays hand-rolled: pagination.)
+  #
+  # Options: `:json` (request body), `:params` (query params),
+  # `:idempotency_key` (adds the `paddle-ik` header when a binary),
+  # `:log_message` (verbatim warning-message override — see
+  # create_customer_portal_session/1).
+  defp request(verb, path, label, extract, opts \\ []) do
     with {:ok, api_key} <- fetch_api_key() do
-      url = base_url() <> "/subscriptions/" <> subscription_id
-      body = subscription_update_body(items, opts)
+      url = base_url() <> path
 
       req_headers =
         case Keyword.get(opts, :idempotency_key) do
@@ -291,19 +252,34 @@ defmodule Engram.Paddle.Client.HTTP do
           _ -> headers(api_key)
         end
 
-      case Req.patch(url, headers: req_headers, json: body, receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
-          {:ok, data}
+      req_opts =
+        [headers: req_headers, receive_timeout: 10_000] ++
+          Keyword.take(opts, [:json, :params])
 
-        {:ok, %Req.Response{status: status, body: body}} ->
-          log_non_2xx("subscription-update", status, body)
-          {:error, {:paddle_error, status, body}}
+      case do_req(verb, url, req_opts) do
+        {:ok, %Req.Response{status: status, body: body} = resp} ->
+          case extract.(resp) do
+            {:ok, _} = ok ->
+              ok
+
+            :error ->
+              case Keyword.get(opts, :log_message) do
+                nil -> log_non_2xx(label, status, body)
+                message -> log_paddle_warning(message, status, body)
+              end
+
+              {:error, {:paddle_error, status, body}}
+          end
 
         {:error, reason} ->
           {:error, reason}
       end
     end
   end
+
+  defp do_req(:get, url, opts), do: Req.get(url, opts)
+  defp do_req(:post, url, opts), do: Req.post(url, opts)
+  defp do_req(:patch, url, opts), do: Req.patch(url, opts)
 
   # Paddle PATCH /subscriptions/{id} treats `items` as REPLACE (not merge), so
   # an empty list either 422s ('items must be non-empty') or wipes the
@@ -329,9 +305,12 @@ defmodule Engram.Paddle.Client.HTTP do
     end
   end
 
-  defp log_non_2xx(label, status, body) do
+  defp log_non_2xx(label, status, body),
+    do: log_paddle_warning("Paddle #{label} non-2xx", status, body)
+
+  defp log_paddle_warning(message, status, body) do
     Logger.warning(
-      "Paddle #{label} non-2xx",
+      message,
       Metadata.with_category(:warning, :billing, status: status, reason_label: inspect(body))
     )
   end

--- a/lib/engram/rerankers/jina.ex
+++ b/lib/engram/rerankers/jina.ex
@@ -9,6 +9,7 @@ defmodule Engram.Rerankers.Jina do
   @behaviour Engram.Reranker
 
   alias Engram.Logger.Metadata
+  alias Engram.Rerankers.None
 
   require Logger
 
@@ -47,7 +48,9 @@ defmodule Engram.Rerankers.Jina do
           Metadata.with_category(:warning, :search, status: status)
         )
 
-        {:ok, candidates |> Enum.sort_by(& &1.score, :desc) |> Enum.take(top_n)}
+        # Vector-only fallback IS the None reranker's behavior — delegate so
+        # the sort/truncate semantics can't drift between the two modules.
+        None.rerank(query, candidates, top_n)
 
       {:error, reason} ->
         Logger.warning(
@@ -55,7 +58,7 @@ defmodule Engram.Rerankers.Jina do
           Metadata.with_category(:warning, :search, reason: inspect(reason))
         )
 
-        {:ok, candidates |> Enum.sort_by(& &1.score, :desc) |> Enum.take(top_n)}
+        None.rerank(query, candidates, top_n)
     end
   rescue
     e ->
@@ -67,7 +70,7 @@ defmodule Engram.Rerankers.Jina do
         )
       )
 
-      {:ok, candidates |> Enum.sort_by(& &1.score, :desc) |> Enum.take(top_n)}
+      None.rerank(query, candidates, top_n)
   end
 
   defp blend_scores(candidates, jina_results) do

--- a/lib/engram/workers/embed_note.ex
+++ b/lib/engram/workers/embed_note.ex
@@ -44,20 +44,16 @@ defmodule Engram.Workers.EmbedNote do
     # T3.2 — `old_path_hmac` is a base64-encoded HMAC, never plaintext path.
     old_path_hmac_b64 = args["old_path_hmac"]
 
-    # skip_tenant_check: trusted internal worker — queries already scoped to note_id/user_id
-    case Repo.get(Note, note_id, skip_tenant_check: true) do
-      nil ->
-        {:discard, "note #{note_id} not found"}
+    case Engram.Notes.fetch_note_for_worker(note_id) do
+      {:discard, _reason} = discard ->
+        discard
 
-      %Note{deleted_at: deleted_at} when deleted_at != nil ->
-        {:discard, "note #{note_id} is soft-deleted"}
-
-      %Note{content_hash: hash, embed_hash: hash}
+      {:ok, %Note{content_hash: hash, embed_hash: hash}}
       when hash != nil and is_nil(old_path_hmac_b64) ->
         # Already embedded this exact content and no rename pending — skip
         :ok
 
-      note ->
+      {:ok, note} ->
         # T3.7 — gate writes during DEK rotation. The worker may have been
         # enqueued before the lock was acquired; re-check the live row.
         case RotationGate.check(note.user_id) do

--- a/lib/engram/workers/inactivity_cleanup.ex
+++ b/lib/engram/workers/inactivity_cleanup.ex
@@ -50,43 +50,31 @@ defmodule Engram.Workers.InactivityCleanup do
   end
 
   defp sweep_60_day_warning do
-    cutoff = days_ago(@days_60)
-    floor_cutoff = days_ago(@days_80)
-
-    users =
-      Repo.all(
-        from(u in User,
-          join: m in "usage_meters",
-          on: m.user_id == u.id,
-          where:
-            is_nil(u.deleted_at) and
-              is_nil(u.inactivity_warning_60_at) and
-              m.last_active_at < ^cutoff and
-              m.last_active_at >= ^floor_cutoff
-        ),
-        skip_tenant_check: true
-      )
-
-    Enum.each(users, fn user ->
-      if warn_enabled?(user) do
-        _ = Mailer.send_inactivity_warning_60(user)
-
-        user
-        |> Ecto.Changeset.change(%{inactivity_warning_60_at: DateTime.utc_now()})
-        |> Repo.update!(skip_tenant_check: true)
-
-        :telemetry.execute(
-          [:engram, :abuse, :inactivity_warning],
-          %{count: 1, days: @days_60},
-          %{user_id: user.id}
-        )
-      end
-    end)
+    sweep_warning(
+      @days_60,
+      @days_80,
+      :inactivity_warning_60_at,
+      &Mailer.send_inactivity_warning_60/1
+    )
   end
 
   defp sweep_80_day_warning do
-    cutoff = days_ago(@days_80)
-    floor_cutoff = days_ago(@days_90)
+    sweep_warning(
+      @days_80,
+      @days_90,
+      :inactivity_warning_80_at,
+      &Mailer.send_inactivity_warning_80/1
+    )
+  end
+
+  # Both warning rungs are the same sweep: find live users whose last activity
+  # falls inside [floor_days, days) who haven't been stamped yet, mail them,
+  # stamp `warned_field`. The floor keeps the rungs disjoint — a user already
+  # past the next rung's threshold gets that rung's (sterner) email instead of
+  # both.
+  defp sweep_warning(days, floor_days, warned_field, mailer_fun) do
+    cutoff = days_ago(days)
+    floor_cutoff = days_ago(floor_days)
 
     users =
       Repo.all(
@@ -95,7 +83,7 @@ defmodule Engram.Workers.InactivityCleanup do
           on: m.user_id == u.id,
           where:
             is_nil(u.deleted_at) and
-              is_nil(u.inactivity_warning_80_at) and
+              is_nil(field(u, ^warned_field)) and
               m.last_active_at < ^cutoff and
               m.last_active_at >= ^floor_cutoff
         ),
@@ -104,15 +92,15 @@ defmodule Engram.Workers.InactivityCleanup do
 
     Enum.each(users, fn user ->
       if warn_enabled?(user) do
-        _ = Mailer.send_inactivity_warning_80(user)
+        _ = mailer_fun.(user)
 
         user
-        |> Ecto.Changeset.change(%{inactivity_warning_80_at: DateTime.utc_now()})
+        |> Ecto.Changeset.change(%{warned_field => DateTime.utc_now()})
         |> Repo.update!(skip_tenant_check: true)
 
         :telemetry.execute(
           [:engram, :abuse, :inactivity_warning],
-          %{count: 1, days: @days_80},
+          %{count: 1, days: days},
           %{user_id: user.id}
         )
       end

--- a/lib/engram/workers/repath_note_index.ex
+++ b/lib/engram/workers/repath_note_index.ex
@@ -34,7 +34,6 @@ defmodule Engram.Workers.RepathNoteIndex do
   alias Engram.Logger.Metadata
   alias Engram.Notes.Enqueue
   alias Engram.Notes.Note
-  alias Engram.Repo
   alias Engram.Workers.EmbedNote
 
   require Logger
@@ -54,15 +53,11 @@ defmodule Engram.Workers.RepathNoteIndex do
     note_id = args["note_id"]
     old_path_hmac = args["old_path_hmac"]
 
-    # skip_tenant_check: trusted internal worker, scoped by note_id.
-    case Repo.get(Note, note_id, skip_tenant_check: true) do
-      nil ->
-        {:discard, "note #{note_id} not found"}
+    case Engram.Notes.fetch_note_for_worker(note_id) do
+      {:discard, _reason} = discard ->
+        discard
 
-      %Note{deleted_at: deleted_at} when deleted_at != nil ->
-        {:discard, "note #{note_id} is soft-deleted"}
-
-      note ->
+      {:ok, note} ->
         case Indexing.count_points_by_path_hmac(note, old_path_hmac) do
           {:ok, count} when count > 0 ->
             case Indexing.repath_points(note, old_path_hmac) do

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -697,4 +697,19 @@ defmodule Engram.CryptoTest do
       assert first_count == second_count
     end
   end
+
+  describe "sha256_hex/1" do
+    test "matches the known SHA-256 vector for \"abc\", lowercase hex" do
+      # FIPS 180-2 test vector — pins both the digest and the hex casing so a
+      # helper regression (e.g. accidental uppercase) can't silently break
+      # every stored token/key fingerprint lookup.
+      assert Crypto.sha256_hex("abc") ==
+               "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    end
+
+    test "hashes the empty binary" do
+      assert Crypto.sha256_hex("") ==
+               "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

PR C of the review-remediation series (stacked on #1188 like #1190 — merge #1188 first; GitHub auto-retargets). Core-context DRY pass, strictly behavior-identical:

- **`Engram.Crypto.sha256_hex/1`** — the token/key/code at-rest hashing primitive, previously 6 independent private copies (accounts ×2, device_flow, invites, password_reset, oauth). All now one audited function, pinned by FIPS 180-2 known-vector tests (including the lowercase casing).
- **Jina reranker** fallbacks (3 sites) delegate to `Rerankers.None.rerank/3` instead of restating it.
- **Auth providers**: shared `Providers.Claims.to_identity/1` — Clerk/Local claim extraction was verbatim-identical.
- **Inactivity sweeps**: 60/80-day warning sweeps collapsed into one parameterized `sweep_warning/4` (telemetry unchanged).
- **`Notes.fetch_note_for_worker/1`**: the verbatim fetch→nil/soft-deleted→`{:discard, reason}` guard shared by EmbedNote + RepathNoteIndex.
- **Paddle HTTP client**: one private `request/5` driver replaces the 9 copy-pasted with/case blocks; per-endpoint success extractors keep the exact status+body-shape semantics and log messages (incl. the one deviant portal-session message).
- **Billing**: `attrs_with_tier/3` (3 copies of the tier+Sentry block) and `get_subscription_by_paddle_id/1` (2 copies of the lookup).
- **`Engram.Crypto.MigrationRunner`** — only the trivially identical rotation scaffolding: `duration_us_since/1` (was 4 copies) and the cursor fleet-drive loop (was 3). **Deliberately NOT consolidated:** the per-module telemetry emitters/reason classifiers (event names + metadata shapes are dashboard-contractual and genuinely differ) and the 5× dual-DEK rewrap block inside `user_dek_rotation.ex` (needs a dedicated, carefully-tested PR — flagged as follow-up).

22 files, +418/−448.

## Test plan
- New known-vector tests for `sha256_hex/1`; all touched modules' targeted tests green (313).
- Gauntlet: format, compile --warnings-as-errors, credo --strict (0 issues), full suite 3951 tests 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015buSiNhFQTvQ8ELdkTuLpz