### PR TITLE
fix(mcp): answer 405 for the stream-open GET instead of 406

### DIFF
--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -10,6 +10,19 @@ defmodule EngramWeb.Router do
     }
   end
 
+  # Same as `:api` minus content negotiation. Used only by the MCP
+  # method-not-allowed routes below: a Streamable-HTTP client opens the
+  # server→client stream with `Accept: text/event-stream`, which
+  # `plug :accepts, ["json"]` answers 406 — before the controller that would
+  # have told it "POST-only". Negotiating a representation for a request we are
+  # rejecting on method alone is meaningless, so this pipeline simply does not.
+  pipeline :api_any_accept do
+    plug :put_secure_browser_headers, %{
+      "x-content-type-options" => "nosniff",
+      "x-frame-options" => "DENY"
+    }
+  end
+
   pipeline :rate_limit_auth do
     plug EngramWeb.Plugs.RateLimit, limit: 10, period: 60_000
   end
@@ -445,8 +458,14 @@ defmodule EngramWeb.Router do
   # Allow here rather than letting GET/DELETE fall through to Phoenix's 404,
   # which clients treat as a missing endpoint and abort. Auth-free on
   # purpose: an unsupported method is a method-level fact, not an authz one.
+  #
+  # `:api_any_accept`, NOT `:api`: the GET that opens the stream carries
+  # `Accept: text/event-stream`, and `plug :accepts, ["json"]` 406s it before
+  # this controller runs. That made the 405 above unreachable for precisely the
+  # clients it exists to serve — observed with Cursor, which falls back to the
+  # legacy HTTP+SSE transport and aborts on the 406.
   scope "/api", EngramWeb do
-    pipe_through :api
+    pipe_through :api_any_accept
     get "/mcp", McpController, :unsupported_transport
     delete "/mcp", McpController, :unsupported_transport
   end

--- a/test/engram_web/controllers/mcp_transport_test.exs
+++ b/test/engram_web/controllers/mcp_transport_test.exs
@@ -17,5 +17,46 @@ defmodule EngramWeb.McpTransportTest do
       assert conn.status == 405
       assert get_resp_header(conn, "allow") == ["POST"]
     end
+
+    # Regression. The two tests above pass with a bare test conn, which sends no
+    # Accept header — so they never exercised the header a REAL client sends.
+    # A Streamable-HTTP client opens the server→client stream with
+    # `Accept: text/event-stream`, and while these routes piped through `:api`
+    # (`plug :accepts, ["json"]`) that produced a 406 before this controller ran.
+    # The 405 was therefore unreachable for exactly the clients it exists for.
+    # Observed 2026-08-01: Cursor fell back to the legacy HTTP+SSE transport and
+    # aborted on "Non-200 status code (406)".
+    test "GET with Accept: text/event-stream still returns 405, not 406", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "text/event-stream")
+        |> get("/api/mcp")
+
+      assert conn.status == 405
+      assert get_resp_header(conn, "allow") == ["POST"]
+    end
+
+    test "DELETE with Accept: text/event-stream still returns 405, not 406", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "text/event-stream")
+        |> delete("/api/mcp")
+
+      assert conn.status == 405
+      assert get_resp_header(conn, "allow") == ["POST"]
+    end
+
+    # The spec-conformant Accept for the stream-open GET lists both types. It
+    # worked before (json satisfies `:accepts`) and must keep working — the fix
+    # widens what is tolerated, it does not move the answer.
+    test "GET with the spec's dual Accept returns 405", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "application/json, text/event-stream")
+        |> get("/api/mcp")
+
+      assert conn.status == 405
+      assert get_resp_header(conn, "allow") == ["POST"]
+    end
   end
 end


### PR DESCRIPTION
Found while diagnosing a failed **Cursor** connection to staging.

PR #340 added `GET/DELETE /api/mcp` → **405 + `Allow: POST`** so a Streamable-HTTP client learns "POST-only, carry on" instead of treating the endpoint as dead. **That handler has been unreachable for the only clients it was written for.**

A Streamable-HTTP client opens the server→client stream with `Accept: text/event-stream`. Those routes piped through `:api`, whose first plug is `plug :accepts, ["json"]` — so the request is rejected **406** before `McpController.unsupported_transport/2` ever runs.

## Measured against live staging (0.12.3)

| Method | Accept | Result |
|---|---|---|
| GET | `text/event-stream` | **406** |
| GET | `application/json` | 405 `Allow: POST` |
| GET | `*/*` | 405 `Allow: POST` |
| GET | `application/json, text/event-stream` | 405 `Allow: POST` |

Cursor's log, 2026-08-01: Streamable-HTTP POST failed → fell back to the legacy HTTP+SSE transport → `SSE error: Non-200 status code (406)` → `Connection failed`.

## Fix

A second pipeline, `:api_any_accept` — identical to `:api` minus content negotiation — used only by these two routes. Negotiating a representation for a request being rejected on **method** alone is meaningless; the answer is 405 + `Allow` regardless of what the client would have accepted.

## Deliberately narrow

`POST /api/mcp` with `Accept: text/event-stream` **alone** also 406s, and I left that alone:

- the MCP spec requires clients to accept `application/json` on POST, so a conformant client sends both types and already works;
- that route lives in the big vault-scoped authed scope shared with notes/search/folders, and widening negotiation there to accommodate an out-of-spec Accept is not worth the blast radius.

Happy to revisit if a real client turns out to need it.

## Why the existing tests missed it

`mcp_transport_test.exs` uses a bare test conn, which sends **no Accept header** — so it never exercised the header a real client sends. The two new negative tests fail on the old router with `Expected one of ["json"]`. A third pins that the spec-conformant dual Accept keeps working, so this widens what is tolerated rather than moving the answer.

## Verification

`mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), 3941 tests.

One unrelated failure in the full run: `Cluster.ReadinessTest`'s wall-clock resolver bound (2.66s vs 2.0s). It reproduces only under the load of back-to-back full suites and passes **3/3 in isolation**; #1177 documents that exact cause. Nothing in this diff touches DNS resolution.

> Note: the 406 was **not** the primary blocker in the reported Cursor session — that was a burst of Cloudflare **523 origin-unreachable** errors between 14:46 and 16:00 local. No request reached the app or NPM during that window, so the break was between Cloudflare and the origin, upstream of the proxy. Separate, infrastructure-side, and self-recovered. This fix matters for the next attempt, once the origin is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ4aJGK1eWxoghJLrw8Fuc