### PR TITLE
fix(telemetry): correct the profiler's sample rate + stop shipping a TLS cert on every log line

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -14,7 +14,23 @@ config :logger, level: :info
 # `new/1` is not callable in config files, so the {module, opts} tuple form is
 # used. This sets the formatter on the standard :logger :default_handler,
 # overriding the text :default_formatter from config/config.exs for prod only.
-config :logger, :default_handler, formatter: {LoggerJSON.Formatters.Basic, metadata: :all}
+#
+# `:__sentry__` is EXCLUDED. Sentry.PlugContext writes the whole request
+# context into Logger metadata — headers, cookies, query string, client IP.
+# With `metadata: :all` that blob was serialized into every single log line,
+# and behind mTLS the `x-amzn-mtls-clientcert-leaf` header is a ~2.5KB base64
+# PEM. It is the same constant cert on every line: measured 2026-08-01, the
+# average app log line was 3,858 bytes and roughly half of all app log volume
+# (16MB of 32.8MB over 7d) was that one certificate repeated ~6,500 times.
+#
+# It carries no signal either — Engram.Sentry.Scrubber already drops
+# `event.request` wholesale for Sentry events on the grounds that "none of it
+# carries signal you can't get from structured logger metadata". Same
+# reasoning, same blob; the log path just never got the same treatment. This
+# also keeps request headers and client IPs out of Loki, which the scrubber
+# was explicitly written to prevent for Sentry.
+config :logger, :default_handler,
+  formatter: {LoggerJSON.Formatters.Basic, metadata: {:all_except, [:__sentry__]}}
 
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.

--- a/lib/engram/observability/pyroscope.ex
+++ b/lib/engram/observability/pyroscope.ex
@@ -22,17 +22,33 @@ defmodule Engram.Observability.Pyroscope do
 
   ## How it samples
 
-  Every 10ms we walk `Process.list/0` and grab each process's
-  `:current_stacktrace`. For every sample we increment a counter
-  keyed by the collapsed stack (`mod:fun/arity;mod:fun/arity;...`).
-  After a configurable window (default 10s) we serialize the
-  accumulator as Pyroscope's `folded` (collapsed-stack) text format
-  and POST it to `${GRAFANA_PYROSCOPE_URL}/ingest`. Counters reset
-  on push.
+  Every `PYROSCOPE_SAMPLE_INTERVAL_MS` (prod: 2000) we walk
+  `Process.list/0` and grab each process's `:current_stacktrace`. For
+  every sample we increment a counter keyed by the collapsed stack
+  (`mod:fun/arity;mod:fun/arity;...`). After a configurable window
+  (default 10s) we serialize the accumulator as Pyroscope's `folded`
+  (collapsed-stack) text format and POST it to
+  `${GRAFANA_PYROSCOPE_URL}/ingest`. Counters reset on push.
 
-  Sampling at 100Hz across N processes yields N×100 samples/sec.
-  Pyroscope normalizes via the `sampleRate=100` query param so flame
-  widths read as wall-clock proportions, not raw counts.
+  ## Sample rate is measured, not assumed
+
+  We always declare `sampleRate=100` and rescale counts to match (see
+  `scale_counts/3`), rather than deriving the rate from the configured
+  interval. Two reasons, both of which produced wrong flame graphs:
+
+    * Pyroscope parses `sampleRate` as an **integer**. Prod samples at
+      0.5Hz, so the honest rate is not expressible — `div(1000, 2000)`
+      floors to `0`, and clamping that to `1` made every absolute time
+      read 2x low.
+    * The configured interval is not the achieved one. `schedule_sample/1`
+      fires *after* a pass completes, so the real period is
+      `interval + pass_duration`. At the old 50ms setting with a ~15ms
+      pass that is 15.4Hz, not the 20Hz the code claimed — a 23% error.
+
+  Scaling from `passes / measured_window` removes both. It also gives the
+  sampler implicit backpressure for free: if passes get slower, fewer land
+  in the window and the scale factor grows to compensate, instead of the
+  profiler silently drifting off its own stated units.
 
   ## What's profiled
 
@@ -67,10 +83,32 @@ defmodule Engram.Observability.Pyroscope do
 
   require Logger
 
-  # 100Hz CPU sampling — matches the convention every Pyroscope agent
-  # uses, so flame widths read directly as a fraction of wall-clock
-  # CPU time (1 sample ≈ 10ms of work).
-  @default_sample_interval_ms 10
+  # 1Hz. NOT the 100Hz Pyroscope-agent convention, deliberately: those
+  # agents sample via an OS signal timer and cost microseconds. We have no
+  # such hook from the BEAM, so a pass walks Process.list/0 and calls
+  # Process.info(:current_stacktrace) on every process — O(processes), and
+  # measured at ~15ms against ~745 live processes in prod.
+  #
+  # At a 10ms default (the old value) that is ~60% of a vCPU, and the
+  # sampler is slower than its own interval. A 2026-07-04 prod regression
+  # at 50ms already cost ~23% of a vCPU sustained (ECS avg CPU 3% -> 38%)
+  # and ran for hours. Prod now sets PYROSCOPE_SAMPLE_INTERVAL_MS=2000.
+  #
+  # This default only applies when the env var is absent, i.e. exactly the
+  # misconfiguration that would otherwise pin a scheduler. Start safe; an
+  # operator who wants resolution sets the env var deliberately.
+  @default_sample_interval_ms 1_000
+
+  # The sampleRate we DECLARE to Pyroscope, with counts scaled to match
+  # (see scale_counts/4). Pyroscope's ingest API parses sampleRate as an
+  # integer, so a sub-1Hz sampler cannot state its true rate — prod runs
+  # 0.5Hz, div(1000, 2000) floors to 0, and the old `max(1, ...)` clamp
+  # reported 1Hz. Every absolute time in the flame graph read 2x low.
+  #
+  # Declaring a fixed rate and scaling counts sidesteps the integer floor
+  # entirely, and lets us derive the scale from the rate we ACTUALLY
+  # achieved rather than the one we configured.
+  @declared_sample_rate 100
 
   # Push every 10s. Pyroscope's UI buckets profiles at this granularity
   # by default; shorter pushes increase ingest volume without UI win.
@@ -92,11 +130,15 @@ defmodule Engram.Observability.Pyroscope do
     :sample_interval_ms,
     :push_interval_ms,
     :spy_name,
-    :sample_rate,
     :window_started_at_ms,
     :sample_timer_ref,
     :push_timer_ref,
-    counters: %{}
+    counters: %{},
+    # Passes actually completed this window. Divided by the measured window
+    # duration at push time to get the achieved sample rate — which is never
+    # the configured one, because schedule_sample/1 fires AFTER the pass
+    # completes, so the real period is interval + pass_duration.
+    passes_in_window: 0
   ]
 
   # ── Public API ────────────────────────────────────────────────────
@@ -188,15 +230,11 @@ defmodule Engram.Observability.Pyroscope do
       sample_interval_ms: sample_interval,
       push_interval_ms: push_interval,
       spy_name: Keyword.get(cfg, :spy_name, @default_spy_name),
-      # Clamp to at least 1: an operator-supplied interval above 1000ms
-      # would otherwise floor to 0 and report a bogus sampleRate=0 to
-      # Pyroscope. Intended range is 10-50ms, so this only guards a
-      # fat-fingered env value.
-      sample_rate: max(1, div(1_000, sample_interval)),
       window_started_at_ms: now_ms(),
       sample_timer_ref: nil,
       push_timer_ref: nil,
-      counters: %{}
+      counters: %{},
+      passes_in_window: 0
     }
 
     Logger.debug(
@@ -209,8 +247,7 @@ defmodule Engram.Observability.Pyroscope do
 
   @impl true
   def handle_info(:sample, state) do
-    process_count = length(Process.list())
-    {duration_us, counters} = :timer.tc(fn -> take_sample(state.counters) end)
+    {duration_us, {counters, process_count}} = :timer.tc(fn -> take_sample(state.counters) end)
 
     :telemetry.execute(
       [:engram, :pyroscope, :sample],
@@ -218,21 +255,29 @@ defmodule Engram.Observability.Pyroscope do
       %{}
     )
 
-    {:noreply, %{state | counters: counters, sample_timer_ref: schedule_sample(state)}}
+    {:noreply,
+     %{
+       state
+       | counters: counters,
+         passes_in_window: state.passes_in_window + 1,
+         sample_timer_ref: schedule_sample(state)
+     }}
   end
 
   @impl true
   def handle_info(:push, state) do
     {counters_to_push, window_started_at_ms} = {state.counters, state.window_started_at_ms}
+    passes = state.passes_in_window
     push_window_end_ms = now_ms()
 
     spawn(fn ->
-      do_push(state, counters_to_push, window_started_at_ms, push_window_end_ms)
+      do_push(state, counters_to_push, passes, window_started_at_ms, push_window_end_ms)
     end)
 
     new_state = %{
       state
       | counters: %{},
+        passes_in_window: 0,
         window_started_at_ms: push_window_end_ms,
         push_timer_ref: schedule_push(state)
     }
@@ -246,24 +291,52 @@ defmodule Engram.Observability.Pyroscope do
   # Snapshot every process's current stacktrace and increment the
   # counter keyed by the collapsed stack. We skip our own pid so the
   # sampler doesn't profile itself dominating its own flame.
-  @spec take_sample(map()) :: map()
+  # Returns {counters, process_count}. The count rides out of the same
+  # Process.list/0 walk that does the sampling — computing it separately
+  # meant snapshotting the whole process table twice per pass purely to
+  # feed a telemetry gauge.
+  @spec take_sample(map()) :: {map(), non_neg_integer()}
   def take_sample(counters) do
     self_pid = self()
 
-    Enum.reduce(Process.list(), counters, fn pid, acc ->
+    Enum.reduce(Process.list(), {counters, 0}, fn pid, {acc, n} ->
       if pid == self_pid do
-        acc
+        {acc, n + 1}
       else
         case Process.info(pid, :current_stacktrace) do
           {:current_stacktrace, [_ | _] = stack} ->
             key = collapse(stack)
-            Map.update(acc, key, 1, &(&1 + 1))
+            {Map.update(acc, key, 1, &(&1 + 1)), n + 1}
 
           _ ->
-            acc
+            {acc, n + 1}
         end
       end
     end)
+  end
+
+  @doc false
+  # Rescale raw sample counts so `count / @declared_sample_rate` equals the
+  # real wall-clock time that stack was observed for.
+  #
+  # Necessary because Pyroscope's ingest API takes sampleRate as an integer
+  # and our real rate is often not one — prod samples at ~0.5Hz. Deriving
+  # the scale from `passes / window_ms` rather than from the configured
+  # interval also absorbs timer drift: schedule_sample/1 fires AFTER a pass
+  # completes, so a 50ms interval with a 15ms pass runs at 15.4Hz, not 20Hz,
+  # and the old code would have overstated the rate by 23%.
+  #
+  # max(1, ...) keeps a stack seen exactly once from rounding away to zero
+  # and vanishing from the flame graph entirely.
+  @spec scale_counts(map(), non_neg_integer(), integer()) :: map()
+  def scale_counts(counters, passes, window_ms)
+      when passes <= 0 or window_ms <= 0,
+      do: counters
+
+  def scale_counts(counters, passes, window_ms) do
+    factor = @declared_sample_rate * (window_ms / 1_000) / passes
+
+    Map.new(counters, fn {stack, count} -> {stack, max(1, round(count * factor))} end)
   end
 
   # Pyroscope "folded" / "collapsed stack" format: each *line* is one
@@ -297,15 +370,19 @@ defmodule Engram.Observability.Pyroscope do
     |> Enum.map(fn {stack, count} -> [stack, ?\s, Integer.to_string(count), ?\n] end)
   end
 
-  defp do_push(_state, counters, _from, _until) when map_size(counters) == 0 do
+  defp do_push(_state, counters, _passes, _from, _until) when map_size(counters) == 0 do
     # Empty window — nothing to push. Happens during startup before
     # the first sample fires, or if every Process.list/0 frame was
     # filtered (unlikely outside tests).
     :ok
   end
 
-  defp do_push(state, counters, from_ms, until_ms) do
-    body = render_folded(counters)
+  defp do_push(state, counters, passes, from_ms, until_ms) do
+    body =
+      counters
+      |> scale_counts(passes, until_ms - from_ms)
+      |> render_folded()
+
     name_with_tags = "#{state.app_name}{#{state.tags}}"
 
     query = [
@@ -314,7 +391,7 @@ defmodule Engram.Observability.Pyroscope do
       {"until", to_seconds(until_ms)},
       {"format", "folded"},
       {"spyName", state.spy_name},
-      {"sampleRate", state.sample_rate},
+      {"sampleRate", @declared_sample_rate},
       {"units", @default_units},
       {"aggregationType", "sum"},
       {"profileType", @profile_kind}

--- a/test/engram/logger/json_format_test.exs
+++ b/test/engram/logger/json_format_test.exs
@@ -41,4 +41,52 @@ defmodule Engram.Logger.JsonFormatTest do
     # request_id rides along under metadata too (metadata: :all)
     assert decoded["metadata"]["request_id"] == "F-abc123"
   end
+
+  # Mirrors the option in config/prod.exs. Same convention as the test above:
+  # the formatter is exercised directly so this is MIX_ENV-independent, and
+  # `MIX_ENV=prod mix compile` is what proves the wiring matches.
+  @prod_metadata {:all_except, [:__sentry__]}
+
+  test "the Sentry request-context blob is excluded from prod log lines" do
+    {formatter_mod, formatter_cfg} = LoggerJSON.Formatters.Basic.new(metadata: @prod_metadata)
+
+    event = %{
+      level: :warning,
+      msg: {:string, "POST 401 in 0ms"},
+      meta: %{
+        category: :http,
+        status: 401,
+        loki_ship: true,
+        # What Sentry.PlugContext actually injects. The mTLS leaf header is a
+        # ~2.5KB base64 PEM, identical on every request behind the ALB, and it
+        # was riding every single log line under `metadata: :all`.
+        __sentry__: %{
+          request: %{
+            url: "http://api.engram.page/api/attachments",
+            headers: %{
+              "x-amzn-mtls-clientcert-leaf" =>
+                "-----BEGIN%20CERTIFICATE-----" <> String.duplicate("MIIEeDCCAmCg", 200),
+              "cf-connecting-ip" => "203.0.113.7",
+              "authorization" => "Bearer secret-token"
+            }
+          }
+        }
+      }
+    }
+
+    json = event |> formatter_mod.format(formatter_cfg) |> IO.iodata_to_binary() |> String.trim()
+
+    # The blob is gone, and so is everything nested inside it.
+    refute json =~ "__sentry__"
+    refute json =~ "CERTIFICATE"
+    refute json =~ "cf-connecting-ip"
+    refute json =~ "secret-token"
+
+    # ...while the fields we actually triage on still ship.
+    decoded = Jason.decode!(json)
+    assert decoded["message"] == "POST 401 in 0ms"
+    assert decoded["metadata"]["category"] == "http"
+    assert decoded["metadata"]["status"] == 401
+    assert decoded["metadata"]["loki_ship"] == true
+  end
 end

--- a/test/engram/observability/pyroscope_test.exs
+++ b/test/engram/observability/pyroscope_test.exs
@@ -105,9 +105,12 @@ defmodule Engram.Observability.PyroscopeTest do
       # a unit test (any GenServer in the VM contributes a frame), so
       # we just assert the invariant: counter values are non-negative
       # integers and the keyset is non-empty when other processes exist.
-      counters = Pyroscope.take_sample(%{})
+      {counters, process_count} = Pyroscope.take_sample(%{})
       assert is_map(counters)
       assert map_size(counters) > 0
+      # The count rides out of the same walk that samples, so it must
+      # cover at least the processes we actually folded in.
+      assert process_count >= map_size(counters)
 
       Enum.each(counters, fn {k, v} ->
         assert is_binary(k)
@@ -116,7 +119,7 @@ defmodule Engram.Observability.PyroscopeTest do
 
       # Running another tick on top of the first should never decrease
       # any existing counter — it's monotonic until the next push.
-      counters2 = Pyroscope.take_sample(counters)
+      {counters2, _} = Pyroscope.take_sample(counters)
       assert map_size(counters2) >= map_size(counters)
     end
 
@@ -124,7 +127,7 @@ defmodule Engram.Observability.PyroscopeTest do
       # Drive a sample from a known pid. The collapsed stack for *that*
       # pid will mention this test process and ExUnit framework code;
       # it must NOT appear in the counters because we filter `self()`.
-      counters = Pyroscope.take_sample(%{})
+      {counters, _} = Pyroscope.take_sample(%{})
 
       # No counter key should contain the test module name in the leaf
       # position (the test runner's current frame at sample time).
@@ -210,8 +213,9 @@ defmodule Engram.Observability.PyroscopeTest do
       assert query =~ "name=engram-test"
       assert query =~ "format=folded"
       assert query =~ "spyName=elixirspy"
-      # 1000ms / 5ms sample = 200Hz
-      assert query =~ "sampleRate=200"
+      # sampleRate is now a DECLARED constant with counts scaled to match,
+      # not derived from the configured interval — see scale_counts/3.
+      assert query =~ "sampleRate=100"
       assert query =~ ~r/from=\d+/
       assert query =~ ~r/until=\d+/
 
@@ -250,6 +254,64 @@ defmodule Engram.Observability.PyroscopeTest do
       assert_receive {[:engram, :pyroscope, :sample], ^ref, measurements, _meta}, 1_000
       assert is_float(measurements.duration_ms) and measurements.duration_ms >= 0.0
       assert is_integer(measurements.process_count) and measurements.process_count > 0
+    end
+  end
+
+  describe "scale_counts/3 — sample rate is measured, not assumed" do
+    # Pyroscope computes time as `count / sampleRate`. We always declare
+    # sampleRate=100, so the invariant every case below checks is:
+    #
+    #     scaled_count / 100 == seconds that stack was actually observed
+    @declared 100
+
+    test "a sub-1Hz sampler reports true wall-clock time" do
+      # Prod shape: PYROSCOPE_SAMPLE_INTERVAL_MS=2000 over a 10s window
+      # => 5 passes, 2s per sample. A stack seen in 3 of them was live
+      # for 6 seconds.
+      #
+      # This is the regression that motivated scale_counts/3: the old code
+      # did `max(1, div(1_000, 2_000))` => sampleRate=1, so 3 counts read
+      # as 3 seconds instead of 6 — every absolute time 2x low.
+      scaled = Pyroscope.scale_counts(%{"a;b" => 3}, 5, 10_000)
+
+      assert scaled["a;b"] / @declared == 6.0
+    end
+
+    test "the achieved rate is used, not the configured one" do
+      # A 50ms configured interval with a ~15ms pass really runs at
+      # ~15.4Hz, not 20Hz, because schedule_sample/1 fires AFTER the pass.
+      # 154 passes in a 10s window => 64.9ms per sample.
+      scaled = Pyroscope.scale_counts(%{"hot" => 154}, 154, 10_000)
+
+      # 154 samples x 64.9ms each == the full 10s window.
+      assert_in_delta scaled["hot"] / @declared, 10.0, 0.01
+    end
+
+    test "a stack seen once never rounds away to zero" do
+      # Fast sampling makes the factor tiny (here 100 * 0.001 = 0.1).
+      # round/1 would take a single sighting to 0 and drop the stack from
+      # the flame graph entirely, which is worse than a rounding error.
+      scaled = Pyroscope.scale_counts(%{"rare" => 1}, 1_000, 1_000)
+
+      assert scaled["rare"] >= 1
+    end
+
+    test "relative proportions between stacks are preserved" do
+      scaled = Pyroscope.scale_counts(%{"hot" => 90, "cold" => 10}, 10, 10_000)
+
+      assert scaled["hot"] / scaled["cold"] == 9.0
+    end
+
+    test "degenerate windows pass counts through instead of dividing by zero" do
+      # Can happen if :push fires before any :sample has landed, or if the
+      # monotonic clock reports a zero-width window.
+      assert Pyroscope.scale_counts(%{"a" => 2}, 0, 10_000) == %{"a" => 2}
+      assert Pyroscope.scale_counts(%{"a" => 2}, 5, 0) == %{"a" => 2}
+      assert Pyroscope.scale_counts(%{"a" => 2}, 5, -1) == %{"a" => 2}
+    end
+
+    test "an empty counter map stays empty" do
+      assert Pyroscope.scale_counts(%{}, 5, 10_000) == %{}
     end
   end
 end


### PR DESCRIPTION
Backend half of a prod telemetry signal-to-noise audit (2026-08-01). Infra half: engram-app/engram-infra#TBD.

## What the audit found

Prod ships ~9.1 MB/day of logs. **92% of the lines were Synthetic Monitoring probe chatter**, and of the 8% that was the app, roughly **half the bytes were one TLS certificate repeated ~6,500 times**. Separately, the BEAM profiler has been reporting every absolute time ~2x low since the July interval rollback.

Cost was never the issue — this is 0.5% of the Loki free tier. It's that nothing in Loki was readable.

## 1. `sampleRate` is now measured, not assumed

Pyroscope parses `sampleRate` as an **integer**, and prod samples at 0.5Hz (`PYROSCOPE_SAMPLE_INTERVAL_MS=2000`):

```elixir
sample_rate: max(1, div(1_000, sample_interval))   # div(1000, 2000) == 0 -> clamped to 1
```

So Pyroscope is told each sample is 1 second of work when it's ~2. The comment on that clamp read *"Intended range is 10-50ms, so this only guards a fat-fingered env value"* — prod has been at 2000ms since the 2026-07-04 CPU-regression rollback, squarely in the case the comment dismissed as impossible.

The configured interval was never the achieved one either. `schedule_sample/1` fires **after** a pass completes, so the real period is `interval + pass_duration`. At the old 50ms setting with a measured ~15ms pass that's 15.4Hz, not 20Hz — a 23% error at the interval the comment called intended.

Fix: declare `sampleRate=100` and rescale counts from `passes / measured_window`. Both error sources go, and *any* interval is now correct rather than only those dividing 1000ms evenly.

## 2. Default interval 10ms -> 1000ms

At ~15ms/pass over ~745 processes, a 10ms default is ~60% of a vCPU and the sampler is slower than its own interval. It only applies when the env var is absent — exactly the misconfiguration that would pin a scheduler.

## 3. `take_sample/1` returns `{counters, process_count}`

The count came from a second `length(Process.list())`, snapshotting the whole process table twice per pass to feed a telemetry gauge.

## 4. The Sentry request blob no longer rides every log line

`metadata: :all` serialized `:__sentry__` — URL, cookies, client IP, every header. Behind the ALB's mTLS that includes `x-amzn-mtls-clientcert-leaf`, a ~2.5KB base64 PEM, byte-identical on every request. Measured: 32.8MB of app logs over 7d, ~16MB of it that one cert.

`Engram.Sentry.Scrubber` already made this exact call for Sentry events (`request: nil`, *"none of it carries signal you can't get from structured logger metadata"*). Same blob, same argument — the log path just never got it. Also stops shipping request headers and client IPs to Loki.

## Deliberately NOT done

**The duplicate `auth rejected` log stays.** It doubles every 401 (`plugs/auth.ex` + `RequestLogger`), and cutting it was the obvious next win — but `auth-failure-burst` filters on `metadata_category="auth"` sourced from exactly that call site, with `user_socket.ex` already excluded. Deleting it leaves the rule matching nothing, silently. Each line is ~1/5 the size now anyway; the alert's real problem is its filter, fixed in the infra PR.

## Verification

- `mix format --check-formatted` clean
- `mix credo --strict` — no issues
- `mix test --warnings-as-errors` — 3,951 tests, 0 failures
- `mix dialyzer` — passed
- `MIX_ENV=prod mix compile` — verifies the logger wiring
- New `scale_counts/3` tests cover the 0.5Hz case that was silently wrong, the drift case, proportion preservation, and the degenerate zero-window guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvUvadaneVBQXax8NfeNJU