### PR TITLE
feat(otel): name the RLS tenant spans

### DIFF
--- a/lib/engram/repo.ex
+++ b/lib/engram/repo.ex
@@ -81,31 +81,47 @@ defmodule Engram.Repo do
     Process.put(:engram_tenant, uuid)
 
     try do
-      transaction(fn ->
-        # `set_config(..., true)` == SET LOCAL, but as a regular SELECT it
-        # takes a bind parameter (no string interpolation) and applies the
-        # tenant + the engram_app role drop in a single round trip.
-        # Superusers bypass RLS even with FORCE — the role drop scopes
-        # enforcement to this transaction.
-        _ =
-          query!(
-            "SELECT set_config('app.current_tenant', $1, true), " <>
-              "set_config('role', 'engram_app', true)",
-            [uuid]
-          )
+      # `source:` is purely observability. Ecto reads it straight off the query
+      # opts (`Ecto.Adapters.SQL.log/5`) and opentelemetry_ecto appends it to
+      # the span name — there is no per-query naming hook, so without it these
+      # statements render as bare `engram.repo.query`. Transaction opts reach
+      # the same code path via `checkout_or_transaction/4`, so this also names
+      # the begin/commit pair.
+      #
+      # Worth the three keywords: a 2026-08-02 trace audit found 3,069 of 5,389
+      # repo.query spans anonymous over 23h, almost all of them this block on
+      # the hot path (13 per GET /api/sync/manifest). Anonymous spans got read
+      # as background-job noise; they are actually 7.9ms of tenant setup
+      # against 5.1ms of real data queries.
+      transaction(
+        fn ->
+          # `set_config(..., true)` == SET LOCAL, but as a regular SELECT it
+          # takes a bind parameter (no string interpolation) and applies the
+          # tenant + the engram_app role drop in a single round trip.
+          # Superusers bypass RLS even with FORCE — the role drop scopes
+          # enforcement to this transaction.
+          _ =
+            query!(
+              "SELECT set_config('app.current_tenant', $1, true), " <>
+                "set_config('role', 'engram_app', true)",
+              [uuid],
+              source: "tenant_enter"
+            )
 
-        result = fun.()
-        # In Ecto Sandbox (tests), this transaction runs as a savepoint.
-        # PostgreSQL's transaction-local settings span the full outer
-        # transaction, so RELEASE SAVEPOINT would leak `engram_app` into
-        # the sandbox transaction. Resetting the role INSIDE the
-        # transaction (`set_config('role', 'none', true)` == SET LOCAL
-        # ROLE NONE) ensures the last local setting that persists is the
-        # default. In production this runs inside a real transaction and
-        # is harmless.
-        _ = query!("SELECT set_config('role', 'none', true)")
-        result
-      end)
+          result = fun.()
+          # In Ecto Sandbox (tests), this transaction runs as a savepoint.
+          # PostgreSQL's transaction-local settings span the full outer
+          # transaction, so RELEASE SAVEPOINT would leak `engram_app` into
+          # the sandbox transaction. Resetting the role INSIDE the
+          # transaction (`set_config('role', 'none', true)` == SET LOCAL
+          # ROLE NONE) ensures the last local setting that persists is the
+          # default. In production this runs inside a real transaction and
+          # is harmless.
+          _ = query!("SELECT set_config('role', 'none', true)", [], source: "tenant_exit")
+          result
+        end,
+        source: "tenant_txn"
+      )
     after
       Process.delete(:engram_tenant)
     end

--- a/test/engram/repo_tenant_span_naming_test.exs
+++ b/test/engram/repo_tenant_span_naming_test.exs
@@ -1,0 +1,105 @@
+defmodule Engram.RepoTenantSpanNamingTest do
+  @moduledoc """
+  `Repo.with_tenant/2`'s own SQL must carry a `:source` so its spans are named.
+
+  `opentelemetry_ecto` builds the span name as
+  `span_prefix <> if(source, do: ":\#{source}", else: "")` — there is no
+  per-query naming hook, so an absent `:source` yields a bare
+  `engram.repo.query` span. The RLS block issues four such statements per
+  invocation (begin, set tenant+role, reset role, commit), none of which is
+  schema-backed, so before this they were all anonymous.
+
+  That mattered in practice: a 2026-08-02 trace audit found 3,069 of 5,389
+  repo.query spans unnamed over 23h, and reading them as "Oban noise" was the
+  first wrong guess. They were RLS plumbing on the hot request path — 13 per
+  `GET /api/sync/manifest`, 7.9ms of query time against 5.1ms for the actual
+  data queries.
+
+  `source` for a raw query is plain `Keyword.get(opts, :source)` in
+  `Ecto.Adapters.SQL.log/5`, and transaction opts reach the same call for
+  begin/commit via `checkout_or_transaction/4`.
+  """
+  use Engram.DataCase, async: false
+
+  @event [:engram, :repo, :query]
+
+  setup do
+    parent = self()
+    ref = make_ref()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      @event,
+      fn _event, _measurements, metadata, _cfg ->
+        send(parent, {ref, metadata.source, to_string(metadata.query)})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+    %{ref: ref}
+  end
+
+  defp drain(ref, acc \\ []) do
+    receive do
+      {^ref, source, query} -> drain(ref, [{source, query} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  describe "with_tenant/2 span naming" do
+    test "every statement the RLS block issues carries a source", %{ref: ref} do
+      user = insert(:user)
+
+      {:ok, :ok} = Repo.with_tenant(user.id, fn -> :ok end)
+
+      events = drain(ref)
+      assert events != [], "expected with_tenant to emit repo.query telemetry"
+
+      unnamed = for {nil, query} <- events, do: query
+
+      assert unnamed == [],
+             """
+             with_tenant emitted statements with no :source, which render as
+             bare `engram.repo.query` spans in Tempo:
+
+             #{Enum.map_join(unnamed, "\n", &("  - " <> &1))}
+             """
+    end
+
+    test "the sources are the RLS ones, not a schema table", %{ref: ref} do
+      user = insert(:user)
+
+      {:ok, :ok} = Repo.with_tenant(user.id, fn -> :ok end)
+
+      sources = ref |> drain() |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
+
+      # Sandbox runs the block as a savepoint, so begin/commit may surface as
+      # savepoint statements or be absent entirely — assert on the two
+      # set_config statements we always issue ourselves, and that whatever
+      # else fires is still named.
+      assert "tenant_enter" in sources
+      assert "tenant_exit" in sources
+      refute nil in sources
+    end
+
+    test "a nested same-tenant call adds no extra RLS statements", %{ref: ref} do
+      user = insert(:user)
+
+      {:ok, :ok} =
+        Repo.with_tenant(user.id, fn ->
+          {:ok, :ok} = Repo.with_tenant(user.id, fn -> :ok end)
+          :ok
+        end)
+
+      sources = ref |> drain() |> Enum.map(&elem(&1, 0))
+
+      # Re-entrancy is what makes collapsing call sites cheap — if this ever
+      # regresses, every nested call starts paying four round trips again.
+      assert Enum.count(sources, &(&1 == "tenant_enter")) == 1
+      assert Enum.count(sources, &(&1 == "tenant_exit")) == 1
+    end
+  end
+end


### PR DESCRIPTION
Follow-on from the 2026-08-02 telemetry audit.

## The finding

**3,069 of 5,389 `repo.query` spans over 23h were anonymous** `engram.repo.query`. My first read of them was "background Oban noise." Wrong — there were **78** `oban_jobs` spans in that window. The anonymous ones are `Repo.with_tenant/2`'s own SQL, sitting on the hot request path.

Per `GET /api/sync/manifest`: 18 Ecto spans, **13 anonymous**, and those 13 are:

| | query time |
|---|---|
| 13 anonymous (RLS plumbing) | **7.9 ms** |
| 5 named (actual data) | **5.1 ms** |

Tenant setup costs more than the work it protects, and none of it was labelled — so it read as noise instead of as a number worth looking at.

## Why they were anonymous

`opentelemetry_ecto` builds the span name as:

```elixir
span_prefix <> if(source != nil, do: ":#{source}", else: "")
```

No per-query naming hook, and raw SQL has no schema source. So all four statements the RLS block issues — `begin`, set tenant+role, reset role, `commit` — render bare.

## The fix

Three keyword options. `source` for a raw query is plain `Keyword.get(opts, :source)` in `Ecto.Adapters.SQL.log/5`, and transaction opts reach the same call for `begin`/`commit` via `checkout_or_transaction/4`:

| span | statement |
|---|---|
| `engram.repo.query:tenant_txn` | begin / commit |
| `engram.repo.query:tenant_enter` | set `app.current_tenant` + role |
| `engram.repo.query:tenant_exit` | reset role |

Observability only — no SQL text, control flow, or timing change. `source` feeds telemetry metadata and constraint-error mapping; `set_config` can't raise a constraint error, so the latter is inert.

## Tests

Assert the block is *fully* named rather than pinning exact statements (sandbox runs it as a savepoint, so begin/commit may surface differently). One test covers `with_tenant`'s re-entrancy — that property is what would make collapsing adjacent call sites cheap later, and if it regresses every nested call silently resumes paying four round trips.

## Deliberately not included

Reducing the *number* of `with_tenant` blocks per request. That's the real ~5ms win, but the naive version — one outer transaction around the action — holds a DB connection across the Elixir-side decrypt loop. That's the exact shape behind the July pool-exhaustion incident against a 10-connection pool. Separate change, done carefully.

## Verification

- `mix format --check-formatted` clean
- `mix credo --strict` — no issues
- `mix test --warnings-as-errors` — **3,999 tests, 0 failures**
- `mix dialyzer` — passed

⚠️ **Two pre-existing flakes on `main`, surfaced not swept.** An earlier run of this branch showed 2 failures; I lost the detail by piping through `tail`, re-ran clean, then ran unmodified `main` to isolate. `main` fails the same two:

1. `EngramWeb.OpenApiEndpointTest` — `ExUnit.TimeoutError` at 60s, stuck in `:code_server.call/1` → `:code.ensure_loaded/1` inside OpenApiSpex schema resolution. Cold module-load contention.
2. `Engram.Cluster.ReadinessTest` — `assert elapsed_us < 2_000_000`, got **2,224,917**. A real `:inet_res` call against a 2s wall-clock bound, 11% over. #1177 already hardened this once; it's a recurrence.

Both load-sensitive, both reproduced on unmodified `main`, neither reachable from a diff that adds keyword options to telemetry metadata. Flagging rather than claiming a clean bill — #2 in particular looks like it wants a real fix, not another window widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvUvadaneVBQXax8NfeNJU