### PR TITLE
fix: key vault-name validation errors on the public name field

### DIFF
--- a/lib/engram/vaults/vault.ex
+++ b/lib/engram/vaults/vault.ex
@@ -71,16 +71,26 @@ defmodule Engram.Vaults.Vault do
       :name_hmac,
       :dek_version
     ])
-    |> validate_required([
-      :slug,
-      :user_id,
-      :name_ciphertext,
-      :name_nonce,
-      :name_hmac
-    ])
+    |> validate_required([:slug, :user_id])
+    |> validate_encrypted_name()
     |> update_change(:slug, &(&1 |> String.trim() |> String.downcase()))
     |> validate_exclusion(:slug, @reserved_slugs, message: "is reserved")
     |> unique_constraint([:user_id, :slug], name: :vaults_user_id_slug_index)
     |> unique_constraint([:user_id, :client_id], name: :vaults_user_id_client_id_index)
+  end
+
+  # Phase B invariant: a vault row must carry the encrypted-name trio. The trio
+  # is populated by inject_name_phase_b/3 from the client-supplied `name`, so a
+  # missing trio means the caller omitted `name` — error on the public virtual
+  # field rather than leaking internal column names into 422 bodies.
+  defp validate_encrypted_name(changeset) do
+    if Enum.all?(
+         [:name_ciphertext, :name_nonce, :name_hmac],
+         &(get_field(changeset, &1) not in [nil, ""])
+       ) do
+      changeset
+    else
+      add_error(changeset, :name, "can't be blank", validation: :required)
+    end
   end
 end

--- a/test/engram/billing/plan_cache_test.exs
+++ b/test/engram/billing/plan_cache_test.exs
@@ -1,0 +1,118 @@
+defmodule Engram.Billing.PlanCacheTest do
+  # async: false — PlanCache lives in node-global :persistent_term, and one
+  # test calls the node-wide PlanCache.invalidate_all/0. A cache that is global
+  # and globally-invalidated is not isolatable per-test, so concurrent modules
+  # can wipe a warmed entry between a test's warm-read and its cached-read
+  # assertion (flaky `left: 99, right: 7` at "invalidate/1 reflects a runtime
+  # limit change"). This module is green in isolation; running it non-async
+  # keeps it that way. ponytail: async:false is the minimal fix; per-test
+  # PlanCache isolation would let it go async again.
+  use Engram.DataCase, async: false
+
+  alias Engram.Billing
+  alias Engram.Billing.LimitKeys
+  alias Engram.Billing.Plan
+  alias Engram.Billing.PlanCache
+  alias Engram.Repo
+
+  setup do
+    plan =
+      Repo.insert!(%Plan{
+        name: "pro_#{System.unique_integer([:positive])}",
+        limits: %{"vaults_cap" => 7, "cross_vault_search" => false}
+      })
+
+    user = insert(:user) |> Ecto.Changeset.change(plan_id: plan.id) |> Repo.update!()
+    on_exit(fn -> PlanCache.invalidate(plan.id) end)
+    %{plan: plan, user: user}
+  end
+
+  test "resolves plan limits and caches them after the first lookup", %{plan: plan, user: user} do
+    PlanCache.invalidate(plan.id)
+
+    {first, q1} =
+      with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
+
+    assert first == 7
+    assert q1 == 1
+
+    {second, q2} =
+      with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
+
+    assert second == 7
+    assert q2 == 0
+  end
+
+  test "cached lookup preserves false plan values (not treated as missing)", %{user: user} do
+    assert Billing.effective_limit(user, :cross_vault_search) == false
+    assert Billing.effective_limit(user, :cross_vault_search) == false
+  end
+
+  test "missing plan key falls through to the default", %{user: user} do
+    # vault_scoped_keys is not set on this plan → default for tier.
+    assert Billing.effective_limit(user, :vault_scoped_keys) ==
+             LimitKeys.default_for(:vault_scoped_keys, :free)
+  end
+
+  test "invalidate/1 forces a re-read", %{plan: plan, user: user} do
+    Billing.effective_limit(user, :vaults_cap)
+    PlanCache.invalidate(plan.id)
+
+    {_, q} = with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
+    assert q == 1
+  end
+
+  test "invalidate/1 reflects a runtime limit change (not just a re-query)",
+       %{plan: plan, user: user} do
+    assert Billing.effective_limit(user, :vaults_cap) == 7
+
+    plan |> Ecto.Changeset.change(limits: %{"vaults_cap" => 99}) |> Repo.update!()
+    # Still cached → stale value until invalidated.
+    assert Billing.effective_limit(user, :vaults_cap) == 7
+
+    PlanCache.invalidate(plan.id)
+    assert Billing.effective_limit(user, :vaults_cap) == 99
+  end
+
+  test "invalidate_all/0 drops every cached plan", %{plan: plan, user: user} do
+    assert Billing.effective_limit(user, :vaults_cap) == 7
+
+    plan |> Ecto.Changeset.change(limits: %{"vaults_cap" => 42}) |> Repo.update!()
+    PlanCache.invalidate_all()
+
+    assert Billing.effective_limit(user, :vaults_cap) == 42
+  end
+
+  test "an unknown plan id resolves to an empty limits map (falls to defaults)" do
+    missing_id = "00000000-0000-0000-0000-000020000000"
+    PlanCache.invalidate(missing_id)
+    assert PlanCache.limits(missing_id) == %{}
+  end
+
+  # Counts Repo queries against `source` emitted while `fun` runs. Telemetry
+  # handlers run synchronously in the process that emitted the query, so we
+  # scope counting to this test's pid — otherwise concurrent async tests
+  # (running in their own processes) leak into the count.
+  defp with_query_count(source, fun) do
+    test_pid = self()
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    handler_id = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:engram, :repo, :query],
+      fn _event, _measurements, %{source: src}, _config ->
+        if src == source and self() == test_pid, do: Agent.update(counter, &(&1 + 1))
+      end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, Agent.get(counter, & &1)}
+    after
+      :telemetry.detach(handler_id)
+      Agent.stop(counter)
+    end
+  end
+end

--- a/test/engram/billing_test.exs
+++ b/test/engram/billing_test.exs
@@ -1,20 +1,14 @@
 defmodule Engram.BillingTest do
-  # async: false — the "plan limit caching" tests exercise PlanCache, which lives
-  # in node-global :persistent_term, and one test calls the node-wide
-  # PlanCache.invalidate_all/0. A cache that is global and globally-invalidated is
-  # not isolatable per-test, so concurrent modules can wipe a warmed entry between
-  # a test's warm-read and its cached-read assertion (flaky `left: 99, right: 7`
-  # at "invalidate/1 reflects a runtime limit change"). This module is green in
-  # isolation; running it non-async keeps it that way. ponytail: async:false is
-  # the minimal fix; per-test PlanCache isolation would let it go async again.
+  # async: false — the "user override caching" tests exercise OverrideCache's
+  # node-global ETS table (evict_all/0 in on_exit), and their query-count
+  # assertions depend on cache warm/cold state no concurrent module may
+  # perturb. (PlanCache's equivalent tests live in Engram.Billing.PlanCacheTest,
+  # non-async for the same reason.)
   use Engram.DataCase, async: false
 
   import Mox
 
   alias Engram.Billing
-  alias Engram.Billing.LimitKeys
-  alias Engram.Billing.Plan
-  alias Engram.Billing.PlanCache
   alias Engram.Billing.Subscription
   alias Engram.Repo
 
@@ -894,82 +888,6 @@ defmodule Engram.BillingTest do
 
       assert %Subscription{} = result
       assert queries == 1
-    end
-  end
-
-  describe "plan limit caching" do
-    setup do
-      plan =
-        Repo.insert!(%Plan{
-          name: "pro_#{System.unique_integer([:positive])}",
-          limits: %{"vaults_cap" => 7, "cross_vault_search" => false}
-        })
-
-      user = insert(:user) |> Ecto.Changeset.change(plan_id: plan.id) |> Repo.update!()
-      on_exit(fn -> PlanCache.invalidate(plan.id) end)
-      %{plan: plan, user: user}
-    end
-
-    test "resolves plan limits and caches them after the first lookup", %{plan: plan, user: user} do
-      PlanCache.invalidate(plan.id)
-
-      {first, q1} =
-        with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
-
-      assert first == 7
-      assert q1 == 1
-
-      {second, q2} =
-        with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
-
-      assert second == 7
-      assert q2 == 0
-    end
-
-    test "cached lookup preserves false plan values (not treated as missing)", %{user: user} do
-      assert Billing.effective_limit(user, :cross_vault_search) == false
-      assert Billing.effective_limit(user, :cross_vault_search) == false
-    end
-
-    test "missing plan key falls through to the default", %{user: user} do
-      # vault_scoped_keys is not set on this plan → default for tier.
-      assert Billing.effective_limit(user, :vault_scoped_keys) ==
-               LimitKeys.default_for(:vault_scoped_keys, :free)
-    end
-
-    test "invalidate/1 forces a re-read", %{plan: plan, user: user} do
-      Billing.effective_limit(user, :vaults_cap)
-      PlanCache.invalidate(plan.id)
-
-      {_, q} = with_query_count("plans", fn -> Billing.effective_limit(user, :vaults_cap) end)
-      assert q == 1
-    end
-
-    test "invalidate/1 reflects a runtime limit change (not just a re-query)",
-         %{plan: plan, user: user} do
-      assert Billing.effective_limit(user, :vaults_cap) == 7
-
-      plan |> Ecto.Changeset.change(limits: %{"vaults_cap" => 99}) |> Repo.update!()
-      # Still cached → stale value until invalidated.
-      assert Billing.effective_limit(user, :vaults_cap) == 7
-
-      PlanCache.invalidate(plan.id)
-      assert Billing.effective_limit(user, :vaults_cap) == 99
-    end
-
-    test "invalidate_all/0 drops every cached plan", %{plan: plan, user: user} do
-      assert Billing.effective_limit(user, :vaults_cap) == 7
-
-      plan |> Ecto.Changeset.change(limits: %{"vaults_cap" => 42}) |> Repo.update!()
-      PlanCache.invalidate_all()
-
-      assert Billing.effective_limit(user, :vaults_cap) == 42
-    end
-
-    test "an unknown plan id resolves to an empty limits map (falls to defaults)" do
-      missing_id = "00000000-0000-0000-0000-000020000000"
-      PlanCache.invalidate(missing_id)
-      assert PlanCache.limits(missing_id) == %{}
     end
   end
 

--- a/test/engram/cache/node_local_ets_test.exs
+++ b/test/engram/cache/node_local_ets_test.exs
@@ -1,0 +1,107 @@
+defmodule Engram.Cache.NodeLocalEtsTest do
+  # Direct tests for the `use Engram.Cache.NodeLocalEts` scaffolding itself,
+  # via throwaway cache modules. The real cache modules cover their own
+  # semantics; this pins the macro's contract — guarded degradation on an
+  # absent table, TTL rows, and the delete_local/1 override seam.
+  use ExUnit.Case, async: true
+
+  defmodule TtlCache do
+    use Engram.Cache.NodeLocalEts, table: :nle_test_ttl_cache, ttl: 50
+  end
+
+  defmodule OverridingCache do
+    use Engram.Cache.NodeLocalEts, table: :nle_test_overriding_cache, ttl: 60_000
+
+    # Storage key is {user_id, subkey}; eviction key is just user_id — the
+    # same shape OverrideCache uses in production.
+    def delete_local(user_id) do
+      :ets.match_delete(:nle_test_overriding_cache, {{user_id, :_}, :_, :_})
+    rescue
+      ArgumentError -> true
+    end
+  end
+
+  # Never started — its table never exists, exercising the rescue guards.
+  defmodule DeadCache do
+    use Engram.Cache.NodeLocalEts, table: :nle_test_dead_cache, ttl: 50
+  end
+
+  describe "TTL primitives" do
+    setup do
+      start_supervised!(TtlCache)
+      :ok
+    end
+
+    test "cache_put/cache_lookup round-trips within the TTL" do
+      assert TtlCache.cache_put(:k, %{v: 1}) == :ok
+      assert TtlCache.cache_lookup(:k) == {:ok, %{v: 1}}
+    end
+
+    test "cache_lookup returns :stale after the TTL elapses" do
+      TtlCache.cache_put(:expiring, :v)
+      Process.sleep(60)
+      assert TtlCache.cache_lookup(:expiring) == :stale
+    end
+
+    test "cache_lookup on a missing key is :stale" do
+      assert TtlCache.cache_lookup(:never_written) == :stale
+    end
+
+    test "cache_fetch computes on miss, then serves the cached value" do
+      counter = :counters.new(1, [])
+
+      loader = fn ->
+        :counters.add(counter, 1, 1)
+        :loaded
+      end
+
+      assert TtlCache.cache_fetch(:fetched, loader) == :loaded
+      assert TtlCache.cache_fetch(:fetched, loader) == :loaded
+      assert :counters.get(counter, 1) == 1
+    end
+
+    test "clear_local/0 drops every entry" do
+      TtlCache.cache_put(:a, 1)
+      TtlCache.cache_put(:b, 2)
+      TtlCache.clear_local()
+      assert TtlCache.cache_lookup(:a) == :stale
+      assert TtlCache.cache_lookup(:b) == :stale
+    end
+
+    test "delete_local/1 drops only the given key" do
+      TtlCache.cache_put(:keep, 1)
+      TtlCache.cache_put(:drop, 2)
+      TtlCache.delete_local(:drop)
+      assert TtlCache.cache_lookup(:drop) == :stale
+      assert TtlCache.cache_lookup(:keep) == {:ok, 1}
+    end
+  end
+
+  describe "delete_local/1 override" do
+    test "evicts by user while other users' entries survive" do
+      start_supervised!(OverridingCache)
+
+      OverridingCache.cache_put({:u1, :a}, 1)
+      OverridingCache.cache_put({:u1, :b}, 2)
+      OverridingCache.cache_put({:u2, :a}, 3)
+
+      OverridingCache.delete_local(:u1)
+
+      assert OverridingCache.cache_lookup({:u1, :a}) == :stale
+      assert OverridingCache.cache_lookup({:u1, :b}) == :stale
+      assert OverridingCache.cache_lookup({:u2, :a}) == {:ok, 3}
+    end
+  end
+
+  describe "absent table (cache process down)" do
+    test "every primitive degrades instead of crashing the caller" do
+      assert DeadCache.ets_lookup(:k) == []
+      assert DeadCache.ets_insert({:k, :v}) == :ok
+      assert DeadCache.cache_lookup(:k) == :stale
+      assert DeadCache.cache_put(:k, :v) == :ok
+      assert DeadCache.cache_fetch(:k, fn -> :from_source end) == :from_source
+      assert DeadCache.delete_local(:k) == true
+      assert DeadCache.clear_local() == true
+    end
+  end
+end

--- a/test/engram/vaults_test.exs
+++ b/test/engram/vaults_test.exs
@@ -150,12 +150,13 @@ defmodule Engram.VaultsTest do
     end
 
     test "requires a name", %{user: user} do
-      # Phase B.3: name is virtual; the changeset surfaces the missing
-      # ciphertext/nonce/hmac instead. Empty input therefore lands as a
-      # "can't be blank" error on `name_ciphertext` and friends.
+      # Phase B.3: name is virtual — a missing name means the encrypted trio
+      # never gets injected, and the changeset surfaces that on the public
+      # `name` field (never the internal ciphertext/nonce/hmac column names).
       assert {:error, changeset} = Vaults.create_vault(user, %{})
       errors = errors_on(changeset)
-      assert "can't be blank" in (errors[:name_ciphertext] || [])
+      assert errors[:name] == ["can't be blank"]
+      refute Map.has_key?(errors, :name_ciphertext)
     end
   end
 

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -163,11 +163,7 @@ defmodule EngramWeb.VaultsControllerTest do
       conn = post(conn, "/api/vaults", %{})
 
       assert json_response(conn, 422) == %{
-               "errors" => %{
-                 "name_ciphertext" => ["can't be blank"],
-                 "name_hmac" => ["can't be blank"],
-                 "name_nonce" => ["can't be blank"]
-               }
+               "errors" => %{"name" => ["can't be blank"]}
              }
     end
   end


### PR DESCRIPTION
## Summary
Two deferred cleanups from the 2026-08-01 review-remediation wave:

**Vaults 422 internal-field leak.** `POST /api/vaults` with a missing `name` returned a 422 whose error keys were the internal encrypted columns (`name_ciphertext`, `name_nonce`, `name_hmac`) — leaking schema internals into the public API. The trio is populated by `inject_name_phase_b/3` from the client-supplied `name`, so a missing trio means the caller omitted `name`. `Vault.changeset/2` now validates that as a single error on the virtual `:name` field (`validate_encrypted_name/1`), keeping the Phase B trio invariant enforced. TDD: flipped the two pins (`vaults_controller_test.exs` from #1200, `vaults_test.exs`) first, watched RED, then fixed.

**Cache test coverage.**
- The "plan limit caching" describe moves from `billing_test.exs` into a dedicated `test/engram/billing/plan_cache_test.exs` (unchanged assertions; doubles as direct coverage of the `Engram.Cache.PersistentTerm` macro). `billing_test.exs` stays `async: false` for its OverrideCache tests; header comment updated.
- New `test/engram/cache/node_local_ets_test.exs` pins the `Engram.Cache.NodeLocalEts` macro contract directly via throwaway cache modules: TTL round-trip/expiry, `cache_fetch/2` read-through, `clear_local/0`/`delete_local/1`, the `delete_local/1` override seam (user-keyed eviction), and rescue-guard degradation when the table is absent.

## Test plan
- `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer` all clean
- Full `mix test --warnings-as-errors`: 4004 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015buSiNhFQTvQ8ELdkTuLpz