### PR TITLE
fix(test): delete the readiness wall-clock assertion, test the wiring instead

### DIFF
--- a/lib/engram/cluster/readiness.ex
+++ b/lib/engram/cluster/readiness.ex
@@ -114,13 +114,30 @@ defmodule Engram.Cluster.Readiness do
   # contract_supertype.
   def resolve_budget_ms, do: @resolve_timeout_ms * @resolve_retry
 
+  @doc """
+  The options `resolve_a/2` hands to `:inet_res`, with the shipped bound
+  applied and caller opts taking precedence.
+
+  Split out so the suite can assert the bound actually reaches the resolver
+  WITHOUT a clock. This is the only Engram logic in `resolve_a/2` — everything
+  else is a stdlib call — and it is the one thing that can silently break the
+  budget: drop this merge and lookups quietly fall back to `:inet_res`'s own
+  defaults while `resolve_budget_ms/0` keeps reporting the intended number.
+
+  The wall-clock test that used to sit here could not catch that (a lookup at
+  the 1_500ms default still finished inside its 2s assertion) and flaked three
+  times trying. See the comment in `test/engram/cluster/readiness_test.exs`.
+  """
+  @spec resolve_opts(keyword()) :: keyword()
+  def resolve_opts(opts \\ []) do
+    Keyword.merge([timeout: @resolve_timeout_ms, retry: @resolve_retry], opts)
+  end
+
   @doc false
   def resolve_a(query, opts \\ []) do
-    resolve_opts = Keyword.merge([timeout: @resolve_timeout_ms, retry: @resolve_retry], opts)
-
     query
     |> to_charlist()
-    |> :inet_res.lookup(:in, :a, resolve_opts)
+    |> :inet_res.lookup(:in, :a, resolve_opts(opts))
     |> Enum.map(&to_string(:inet.ntoa(&1)))
   end
 

--- a/test/engram/cluster/readiness_test.exs
+++ b/test/engram/cluster/readiness_test.exs
@@ -127,32 +127,77 @@ defmodule Engram.Cluster.ReadinessTest do
                "out of rotation"
     end
 
-    # And prove the bound is honoured, with a SMALL window.
+    # The wall-clock half of this test is GONE. History, so it does not come
+    # back:
     #
-    # This used to run the production 1_500ms timeout and assert < 4s. Nominal
-    # is 1.50s (measured), so ~2.7x headroom, which sounds ample but it is wall
-    # clock around a real network call inside a parallel suite: on a loaded
-    # machine it recorded 4.08s and 5.50s and went red twice (#1158).
+    #   - originally ran the production 1_500ms timeout and asserted < 4s.
+    #     Went red twice on a loaded machine at 4.08s and 5.50s (#1158).
+    #   - #1177 split the arithmetic invariant out (the test above) and shrank
+    #     this one to a 300ms nominal against a 2s assertion — ~6.6x headroom.
+    #   - it went red again anyway on 2026-08-02, at 2,224,917us.
     #
-    # 300ms nominal against a 2s assertion is ~6.6x headroom for identical
-    # coverage. :inet_res rejects retry: 0, so shrinking `timeout` is the only
-    # lever available. Do NOT answer a future flake here by raising the
-    # threshold: shrink the window, or the assertion stops meaning anything.
-    test "fails open (returns []) within its configured bound against an unresponsive resolver" do
+    # Shrinking the window a third time would not help, because the overshoot
+    # was never the DNS call. 300ms nominal overrunning to 2.2s is ~7x, and
+    # that is scheduler starvation in a parallel suite, not a slow resolver.
+    # There is no window small enough to outrun CPU contention.
+    #
+    # The deeper problem is that the assertion was not earning its keep:
+    #
+    #   1. The invariant it nominally guarded — "we did not ship an unbounded
+    #      resolver" — is the arithmetic test above. That one fails the moment
+    #      someone raises @resolve_timeout_ms, and cannot flake.
+    #   2. What remained was proof that :inet_res honours its own `timeout`
+    #      option. That is OTP's contract, not ours. resolve_a/2 is a
+    #      Keyword.merge and a stdlib call with no logic in between.
+    #   3. It could not even catch the one wiring bug worth catching. Delete
+    #      the Keyword.merge so opts never reach :inet_res, and the call falls
+    #      back to the 1_500ms default — still under the 2s assertion. Green.
+    #
+    # So it cost three red builds and bought nothing the arithmetic test does
+    # not already buy. What IS ours, and IS deterministic, is failing open:
+    # returning [] instead of raising when the resolver never answers. That is
+    # the Enum.map over a dead lookup, and it is what the test below asserts.
+    #
+    # If you ever need to prove the bound empirically again, do it as a
+    # benchmark or a manual check — not as a wall-clock assertion inside the
+    # parallel suite.
+    test "fails open (returns []) against an unresponsive resolver" do
       # 192.0.2.0/24 is TEST-NET-1 (RFC 5737): reserved and guaranteed
       # non-routable, so this never gets an answer — the same path a hung
-      # resolver takes.
-      {elapsed_us, result} =
-        :timer.tc(fn ->
-          Readiness.resolve_a(~c"example.invalid",
-            nameservers: [{{192, 0, 2, 1}, 53}],
-            timeout: 300,
-            retry: 1
-          )
-        end)
+      # resolver takes. Kept short so the suite does not wait on it; the
+      # duration is incidental now, not asserted.
+      result =
+        Readiness.resolve_a(~c"example.invalid",
+          nameservers: [{{192, 0, 2, 1}, 53}],
+          timeout: 100,
+          retry: 1
+        )
 
       assert result == [], "an unresponsive resolver must fail open, not raise"
-      assert elapsed_us < 2_000_000
+    end
+
+    # This is the coverage the wall-clock assertion was supposed to provide and
+    # never did: proof that the shipped bound actually REACHES :inet_res.
+    # Deterministic, no clock, and it fails on the exact regression the timing
+    # test slept through — dropping the merge so lookups silently run on
+    # :inet_res's own defaults while resolve_budget_ms/0 keeps reporting the
+    # intended number.
+    test "the shipped bound is actually handed to the resolver" do
+      opts = Readiness.resolve_opts()
+
+      assert Keyword.fetch!(opts, :timeout) * Keyword.fetch!(opts, :retry) ==
+               Readiness.resolve_budget_ms(),
+             "resolve_a/2 must pass the same budget that resolve_budget_ms/0 advertises, " <>
+               "got #{inspect(opts)} against #{Readiness.resolve_budget_ms()}ms"
+    end
+
+    test "caller options override the shipped defaults" do
+      opts = Readiness.resolve_opts(timeout: 50, nameservers: [{{192, 0, 2, 1}, 53}])
+
+      assert Keyword.fetch!(opts, :timeout) == 50
+      assert Keyword.fetch!(opts, :nameservers) == [{{192, 0, 2, 1}, 53}]
+      # Unspecified defaults survive the merge.
+      assert Keyword.fetch!(opts, :retry) == 1
     end
   end
 end


### PR DESCRIPTION
Third red build from one assertion. Surfaced again during #1205 verification.

## Why not just shrink the window again

| | |
|---|---|
| #1158 | production 1_500ms timeout, asserted < 4s — red twice at **4.08s** and **5.50s** |
| #1177 | split the arithmetic invariant out, shrank this to 300ms nominal vs 2s — ~6.6x headroom |
| today | red again at **2,224,917us** |

300ms nominal overrunning to 2.2s is ~7x. That is scheduler starvation in a parallel suite, not a slow resolver — there is no window small enough to outrun CPU contention. The existing comment says *"Do NOT answer a future flake here by raising the threshold: shrink the window"*. That advice was right, and it has run out of room.

## The assertion was not earning its keep

1. **The invariant it nominally guarded is already covered.** `resolve_budget_ms() <= 2_000` sits directly above it, derives from the constants, fails the moment someone raises `@resolve_timeout_ms`, and cannot flake.
2. **What was left tests OTP, not us.** `resolve_a/2` is a `Keyword.merge` and a `:inet_res.lookup` with nothing in between. The assertion proved `:inet_res` honours its own `timeout` option.
3. **It could not catch the regression that matters.** Drop the merge so opts never reach `:inet_res`, and the lookup runs at the 1_500ms default — still inside the 2s assertion. Passes.

## What replaces it

`resolve_opts/1` is split out — the only Engram logic in `resolve_a/2` — and asserted directly, with no clock:

- the shipped budget actually reaches the resolver (`timeout * retry == resolve_budget_ms()`)
- caller opts override defaults, unspecified defaults survive the merge

**Verified by sabotage.** Dropping `timeout:` from the merge fails the new test with `KeyError: key :timeout not found in: [retry: 1]`. The old wall-clock assertion passed that same sabotage — which is the whole argument for the swap.

The behavioural half is kept: fail open with `[]` rather than raising when the resolver never answers. That is our `Enum.map` over a dead lookup, and it is deterministic.

## Tradeoff, stated plainly

This removes an empirical timing check. If `:inet_res` ever stopped honouring `timeout`, nothing here would notice. I think that is the right trade: it was a stdlib contract, it cost three red builds, and the thing that can actually break on our side is now covered and was not before. If you want the empirical proof back, it belongs in a benchmark or a manual check, not a wall-clock assertion inside the parallel suite.

Net: 13 tests to 15, one flake class gone, one real regression newly covered.

## Verification

- `mix format --check-formatted` clean
- `mix credo --strict` — no issues
- `mix test --warnings-as-errors` — **4,016 tests, 0 failures**
- `mix dialyzer` — passed

Closes the ReadinessTest half of the flakes found in #1205. The other half is #1210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvUvadaneVBQXax8NfeNJU