### PR TITLE
refactor: remove chunk-stamping from bulk writes

### DIFF
--- a/docs/context/batch-write-caps-and-chunk-stamping.md
+++ b/docs/context/batch-write-caps-and-chunk-stamping.md
@@ -1,19 +1,25 @@
 # Batch-write caps + chunk-stamped tombstones — the fewer-than-500-rows-per-TIMESTAMP invariant
 
-_Last verified: 2026-08-01_
+_Last verified: 2026-08-02_
 
-**Status:** shipped on PR #1188 (review-remediation bundle); #1194 (batch
-write-path perf rewrite) builds on the same mechanism.
-**Symptom class:** a legacy (pre-pagination) client's change-feed pull loops
-forever on one page; or, the day-one version of the trap, e2e teardown gets
-422 `batch_too_large` on a legitimate 1100-id bulk delete.
+**Status:** HISTORICAL. Chunk-stamping shipped on PR #1188 (review-remediation
+bundle), #1194 (batch write-path perf rewrite) built on it — and it was
+**removed entirely** once the feed it protected was retired (see banner).
+**Symptom class (historical):** a legacy (pre-pagination) client's change-feed
+pull loops forever on one page; or, the day-one version of the trap, e2e
+teardown gets 422 `batch_too_large` on a legitimate 1100-id bulk delete.
 
 ## The invariant
 
-> **2026-08-02:** the legacy feed itself is RETIRED — `GET /notes/changes` /
-> `GET /attachments/changes` now always return 410 Gone. The chunk-stamping
-> mechanism below still exists (removing it is a follow-up PR); this section
-> is the historical WHY.
+> **2026-08-02:** the legacy feed is RETIRED — `GET /notes/changes` /
+> `GET /attachments/changes` now always return 410 Gone (PR #1215) — and the
+> chunk-stamping mechanism below is **REMOVED** (the follow-up PR to #1215):
+> `Notes.bulk_stamp/2`, `@stamp_chunk`, and all per-chunk/per-row stamping are
+> gone. Bulk deletes, batch upserts, and folder-rename cascades now share ONE
+> `DateTime.utc_now()` per operation — the seq feed (`list_changes_by_seq`)
+> orders by `(seq, id)` and does not care about `updated_at` distinctness.
+> Only `@max_batch_entries 500` (the upsert compute-DoS cap) survives.
+> Everything below is the historical WHY.
 
 The legacy change feed (`GET /notes/changes`) paged by **timestamp** with an
 **inclusive** boundary: legacy clients advanced `since = server_time` after

--- a/docs/context/batch-write-caps-and-chunk-stamping.md
+++ b/docs/context/batch-write-caps-and-chunk-stamping.md
@@ -60,7 +60,7 @@ The cap broke e2e on day one.
 contract (caps, status codes, param semantics), grep `e2e/` for usage — not
 just `frontend/` and the plugin.
 
-## The fix — chunk-stamp instead of reject
+## The fix — chunk-stamp instead of reject (historical)
 
 `batch_delete_notes/3` (`lib/engram/notes.ex`) now accepts any request size
 and enforces the invariant directly: tombstones are stamped in

--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -655,9 +655,8 @@ defmodule Engram.Attachments do
   mid-loop failure still rolls the whole op back. Reusing `batch_delete/3` keeps
   one delete path instead of a bespoke single-seq `update_all`.
   """
-  # Shared with Engram.Notes' batch caps: 500 = the (now retired, 410) legacy
-  # change feed's convergence bound (>500 rows on one server timestamp could
-  # loop a pull).
+  # Cheap request-size guard (chunk-stamping and the legacy feed it protected
+  # are gone; no bulk consumer exceeds this).
   @max_batch_entries 500
 
   @spec delete_folder(map(), map(), String.t()) :: {:ok, non_neg_integer()} | {:error, term()}
@@ -686,9 +685,8 @@ defmodule Engram.Attachments do
     end
   end
 
-  # Shared with Engram.Notes' batch caps: 500 = the (now retired, 410) legacy
-  # change feed's convergence bound (>500 rows on one server timestamp could
-  # loop a pull).
+  # Cheap request-size guard (chunk-stamping and the legacy feed it protected
+  # are gone; no bulk consumer exceeds this).
   @max_batch_entries 500
 
   @doc """

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -107,30 +107,11 @@ defmodule Engram.Notes do
     from(n in scoped(user, vault), where: is_nil(n.deleted_at))
   end
 
-  # 500 = the (now retired, 410) legacy change feed's convergence bound:
-  # >500 rows stamped on one server timestamp could make a legacy
-  # `updated_at >= since` pull re-serve the same page forever. Kept until the
-  # chunk-stamping follow-up removes it. Used two ways:
-  #   * batch_delete_notes chunk-stamps tombstones @stamp_chunk per
-  #     timestamp, so ANY request size is safe (e2e teardown legitimately
-  #     sends >1000 ids);
-  #   * batch_upsert_notes hard-caps at 500 — each entry costs an encrypt +
-  #     CRDT merge, so unbounded requests are a compute-DoS vector, and no
-  #     client sends >500 (the plugin chunks at ≤100) — and stamps its
-  #     creates through the same @stamp_chunk grouping.
+  # batch_upsert_notes hard cap: each entry costs an encrypt + CRDT merge, so
+  # unbounded requests are a compute-DoS vector, and no client sends >500 (the
+  # plugin chunks at ≤100). Delete/move accept ANY size — the seq feed orders
+  # by (seq, id) and doesn't care how many rows share a timestamp.
   @max_batch_entries 500
-
-  # Rows per shared timestamp for bulk writes. STRICTLY below the retired
-  # feed's 500-row page: its inclusive `since` boundary meant a same-stamp run
-  # of EXACTLY page size re-served the same page forever. Removal is the
-  # chunk-stamping follow-up.
-  @stamp_chunk 400
-
-  @doc false
-  # Timestamp for the i-th row of a bulk write: base + one µs per
-  # @stamp_chunk rows. Distinct-by-construction even when consecutive
-  # utc_now() calls collide in the same microsecond.
-  def bulk_stamp(base, i), do: DateTime.add(base, div(i, @stamp_chunk), :microsecond)
 
   @doc """
   #590: maps Qdrant point ids → the owning note's decrypted display fields
@@ -2081,29 +2062,14 @@ defmodule Engram.Notes do
           case Enum.find(ids, &(not MapSet.member?(found, &1))) do
             nil ->
               seq = Engram.Vaults.next_seq!(vault.id)
-              base_now = DateTime.utc_now()
+              now = DateTime.utc_now()
 
-              # Stamp tombstones in @stamp_chunk-row chunks with DISTINCT
-              # timestamps: the legacy `updated_at >= since` feed pages by
-              # timestamp with an INCLUSIVE boundary, so a same-stamp run of
-              # page size or longer re-serves the same page forever
-              # (changes_server_time). +1 µs per chunk guarantees distinct
-              # stamps even when consecutive utc_now() calls collide.
-              updated =
-                notes
-                |> Enum.map(& &1.id)
-                |> Enum.chunk_every(@stamp_chunk)
-                |> Enum.with_index()
-                |> Enum.map(fn {chunk_ids, i} ->
-                  now_i = DateTime.add(base_now, i, :microsecond)
-
-                  {n, _} =
-                    from(n in Note, where: n.id in ^chunk_ids and is_nil(n.deleted_at))
-                    |> Repo.update_all(set: [deleted_at: now_i, updated_at: now_i, seq: seq])
-
-                  n
-                end)
-                |> Enum.sum()
+              # One shared timestamp for every tombstone — the seq feed orders
+              # by (seq, id), so same-stamp runs are harmless (the timestamp
+              # chunking that used to live here served the retired legacy feed).
+              {updated, _} =
+                from(n in Note, where: n.id in ^ids and is_nil(n.deleted_at))
+                |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
 
               :ok = UsageMeters.dec_notes_count(user.id, updated)
 
@@ -2487,14 +2453,11 @@ defmodule Engram.Notes do
 
     now = DateTime.utc_now()
 
-    # Per-entry bulk_stamp/2 instead of one shared `now`: a full 500-entry
-    # batch stamping one timestamp is EXACTLY the legacy page size, which
-    # wedges the inclusive `updated_at >= since` feed (changes_server_time).
+    # One shared `now` for the whole batch — the seq feed orders by (seq, id),
+    # so same-stamp runs are harmless.
     {entries, insert_rows} =
-      entries
-      |> Enum.with_index()
-      |> Enum.map_reduce([], fn {entry, i}, rows ->
-        process_batch_entry(entry, existing_by_hmac, user, vault, bulk_stamp(now, i), rows)
+      Enum.map_reduce(entries, [], fn entry, rows ->
+        process_batch_entry(entry, existing_by_hmac, user, vault, now, rows)
       end)
 
     # on_conflict: :nothing — a PK collision (client-supplied id already in
@@ -3579,10 +3542,7 @@ defmodule Engram.Notes do
   ]
 
   # Statement-size bound for the VALUES join: 500 rows × ≤16 params stays
-  # well under Postgres's 65535-bind-param protocol limit. Timestamp chunking
-  # is independent of this: each row carries its own bulk_stamp/2 updated_at
-  # (grouped @stamp_chunk rows per stamp), so SQL chunk size never creates a
-  # same-stamp run.
+  # well under Postgres's 65535-bind-param protocol limit.
   @rename_update_chunk 500
 
   defp do_rename_folder(user, vault, old_folder, old_prefix, new_folder, rows) do
@@ -3710,18 +3670,14 @@ defmodule Engram.Notes do
             end)
             |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
 
-          # Chunk-stamp every row this cascade writes — all three row-classes
-          # AND the old-path tombstones below — through bulk_stamp/2 under ONE
-          # global row counter, so no @stamp_chunk-crossing run shares an
-          # updated_at (a single shared `now` puts an unbounded cascade on one
-          # timestamp and wedges the legacy `updated_at >= since` feed, same
-          # class as batch_delete_notes' tombstone chunking). Only the
-          # timestamps vary: `seq` stays IDENTICAL for every row — the #614
+          # One shared `now` for every row this cascade writes — renamed rows
+          # AND tombstones. The seq feed orders by (seq, id), so same-stamp
+          # runs are harmless. `seq` stays IDENTICAL for every row — the #614
           # one-op-one-seq contract that keeps a cursor pull from splitting
           # the renamed rows from their tombstones.
-          {marker_rows, offset} = stamp_rename_rows(grouped[:marker] || [], now, 0)
-          {v2_rows, offset} = stamp_rename_rows(grouped[:v2] || [], now, offset)
-          {v1_rows, offset} = stamp_rename_rows(grouped[:v1] || [], now, offset)
+          marker_rows = stamp_rename_rows(grouped[:marker] || [], now)
+          v2_rows = stamp_rename_rows(grouped[:v2] || [], now)
+          v1_rows = stamp_rename_rows(grouped[:v1] || [], now)
 
           bulk_rename_update!(marker_rows, @marker_rename_cols, seq)
           bulk_rename_update!(v2_rows, @v2_rename_cols, seq)
@@ -3734,12 +3690,9 @@ defmodule Engram.Notes do
           # are full-row inserts so each must carry the encrypted
           # path/folder/tags fields too. Marker rows have no path to
           # tombstone — skip them. Built in-memory from `real_note_updates`,
-          # stamped with the same `seq` as the renamed rows; their timestamps
-          # continue the global bulk_stamp counter started above.
+          # stamped with the same `seq` and `now` as the renamed rows.
           tombstones =
-            real_note_updates
-            |> Enum.with_index(offset)
-            |> Enum.map(fn {{_note, old_path, _new_path, _new_folder, _title}, i} ->
+            Enum.map(real_note_updates, fn {_note, old_path, _new_path, _new_folder, _title} ->
               # T3.6 — pre-allocate the tombstone id so the AAD bind string can
               # be constructed before insert. Tombstones are full-row inserts
               # written with empty content/title/tags but the row-id-bound AAD
@@ -3747,7 +3700,6 @@ defmodule Engram.Notes do
               # from any other AAD-bound row at read time.
               tomb_id = mint_id()
               old_path_folder = Helpers.extract_folder(old_path)
-              stamp = bulk_stamp(now, i)
 
               full_kw =
                 full_aad_bound_kw(user, tomb_id, "", "", old_path, old_path_folder, [])
@@ -3758,9 +3710,9 @@ defmodule Engram.Notes do
                 mtime: mtime_float,
                 user_id: user.id,
                 vault_id: vault.id,
-                created_at: stamp,
-                updated_at: stamp,
-                deleted_at: stamp,
+                created_at: now,
+                updated_at: now,
+                deleted_at: now,
                 seq: seq
               }
 
@@ -4553,18 +4505,10 @@ defmodule Engram.Notes do
   defp rename_col_sql_type(:dek_version), do: "integer"
   defp rename_col_sql_type(_col), do: "bytea"
 
-  # Attaches a bulk_stamp/2 timestamp to each {id, kw} rename row, continuing
-  # a global row counter across the caller's row-classes (see
-  # do_rename_folder): row i gets `bulk_stamp(base, offset + local_i)`, and
-  # the returned offset lets the next class (or the tombstone builder) keep
-  # counting so no @stamp_chunk-sized run repeats across classes.
-  defp stamp_rename_rows(rows, base, offset) do
-    stamped =
-      rows
-      |> Enum.with_index(offset)
-      |> Enum.map(fn {{id, kw}, i} -> {id, bulk_stamp(base, i), kw} end)
-
-    {stamped, offset + length(rows)}
+  # Attaches the cascade's shared timestamp to each {id, kw} rename row,
+  # producing the [{id, stamp, kw}] shape bulk_rename_update! consumes.
+  defp stamp_rename_rows(rows, now) do
+    Enum.map(rows, fn {id, kw} -> {id, now, kw} end)
   end
 
   # One `UPDATE notes ... FROM (VALUES ...)` per ≤500-row chunk. Every row in a
@@ -4572,8 +4516,7 @@ defmodule Engram.Notes do
   # it must not be one UPDATE per note either (the N+1 this replaces). Runs
   # inside the caller's with_tenant transaction: the RLS role restricts the raw
   # UPDATE to the tenant's rows, and the shared `seq` keeps the #614
-  # one-op-one-seq contract (each row carries its OWN chunk-grouped updated_at
-  # stamp — see stamp_rename_rows). `rows` is [{note_id, stamp, kw}] where `kw`
+  # one-op-one-seq contract. `rows` is [{note_id, stamp, kw}] where `kw`
   # holds a value for every column in `cols`. A nested-collision unique
   # violation raises Postgrex.Error exactly like the per-note update_all did.
   defp bulk_rename_update!([], _cols, _seq), do: :ok

--- a/test/engram/notes_batch_test.exs
+++ b/test/engram/notes_batch_test.exs
@@ -583,13 +583,11 @@ defmodule Engram.NotesBatchSetBasedTest do
 
   describe "batch size limits (context boundary)" do
     # Delete/move accept ANY size — real consumers (e2e harness cleanup,
-    # test_77 bulk teardown) legitimately send >1000 ids in one request. The
-    # actual invariant is ≤500 rows per server TIMESTAMP (the legacy
-    # `updated_at >= since` feed re-serves the same page forever if a
-    # same-stamp run exceeds the page size — notes_controller.ex
-    # changes_server_time), so bulk deletes stamp tombstones in ≤500-row
-    # chunks with distinct timestamps instead of rejecting the request.
-    test "batch_delete_notes accepts >500 ids and chunk-stamps tombstones", %{
+    # test_77 bulk teardown) legitimately send >1000 ids in one request.
+    # Rows may share one timestamp: the seq feed orders by (seq, id), so
+    # same-stamp runs are harmless (the distinct-stamp invariant died with
+    # the legacy `updated_at >= since` feed, retired in #1215).
+    test "batch_delete_notes accepts >500 ids", %{
       user: user,
       vault: vault
     } do
@@ -597,44 +595,13 @@ defmodule Engram.NotesBatchSetBasedTest do
       ids = Enum.map(notes, & &1.id)
 
       assert {:ok, %{deleted: 501}} = Notes.batch_delete_notes(user, vault, ids)
-
-      stamp_runs = stamp_run_sizes(user, ids)
-
-      # STRICTLY fewer than the 500-row legacy page per stamp: the since
-      # boundary is inclusive, so a run of EXACTLY page-size wedges too.
-      assert length(stamp_runs) >= 2,
-             ">500 tombstones must not share one timestamp (legacy-feed wedge)"
-
-      assert Enum.max(stamp_runs) < 500,
-             "a same-stamp run of exactly page size (500) re-serves forever"
-    end
-
-    test "batch_upsert_notes stamps creates in <500-row timestamp runs", %{
-      user: user,
-      vault: vault
-    } do
-      params = for i <- 1..401, do: %{path: "stampchunk/n#{i}.md"}
-      assert {:ok, %{results: results}} = Notes.batch_upsert_notes(user, vault, params)
-      ids = results |> Enum.filter(&(&1.status == :ok)) |> Enum.map(& &1.id)
-      assert length(ids) == 401
-
-      stamp_runs = stamp_run_sizes(user, ids)
-
-      assert length(stamp_runs) >= 2,
-             "bulk creates must not all share one updated_at (legacy-feed wedge)"
-
-      assert Enum.max(stamp_runs) < 500
     end
 
     @tag timeout: 120_000
-    test "rename_folder chunk-stamps >500-row cascades (rows + tombstones)", %{
+    test "rename_folder handles >500-row cascades (rows + tombstones)", %{
       user: user,
       vault: vault
     } do
-      # do_rename_folder stamps EVERY touched row (marker + renamed rows +
-      # old-path tombstones) in one cascade; a single shared `now` puts >500
-      # rows on one timestamp and wedges the legacy `updated_at >= since`
-      # feed exactly like an unchunked batch delete would.
       {:ok, %{results: r1}} =
         Notes.batch_upsert_notes(user, vault, for(i <- 1..500, do: %{path: "BigStamp/n#{i}.md"}))
 
@@ -645,7 +612,7 @@ defmodule Engram.NotesBatchSetBasedTest do
 
       assert {:ok, _} = Notes.rename_folder(user, vault, "BigStamp", "BigStampMoved")
 
-      # Every note row in the vault now carries a rename-time stamp: the
+      # Every note row in the vault was touched by the cascade: the
       # marker + 501 renamed rows + 501 tombstones.
       {:ok, ids} =
         Repo.with_tenant(user.id, fn ->
@@ -655,14 +622,6 @@ defmodule Engram.NotesBatchSetBasedTest do
         end)
 
       assert length(ids) == 1003
-
-      stamp_runs = stamp_run_sizes(user, ids)
-
-      assert length(stamp_runs) >= 2,
-             "a >500-row rename cascade must not share one updated_at (legacy-feed wedge)"
-
-      assert Enum.max(stamp_runs) < 500,
-             "a same-stamp run of exactly page size (500) re-serves forever"
     end
 
     # Upsert keeps a hard cap: each entry costs an encrypt + CRDT merge, so
@@ -672,21 +631,5 @@ defmodule Engram.NotesBatchSetBasedTest do
       params = for i <- 1..501, do: %{path: "bulk/n#{i}.md"}
       assert {:error, :batch_too_large} = Notes.batch_upsert_notes(user, vault, params)
     end
-  end
-
-  # Sizes of each distinct-updated_at group among the given note ids.
-  defp stamp_run_sizes(user, ids) do
-    Repo.with_tenant(user.id, fn ->
-      import Ecto.Query
-
-      Repo.all(
-        from(n in Engram.Notes.Note,
-          where: n.id in ^ids,
-          group_by: n.updated_at,
-          select: count(n.id)
-        )
-      )
-    end)
-    |> elem(1)
   end
 end


### PR DESCRIPTION
## Summary
Follow-up to #1215. `bulk_stamp/2` + `@stamp_chunk 400` existed only to keep same-timestamp runs under the retired feed's 500-row page (the inclusive-boundary wedge). The seq feed orders by `(seq, id)`, so bulk deletes, batch upserts, and folder-rename cascades now share one `DateTime.utc_now/0`.

- Kept: `@max_batch_entries 500` upsert cap (compute-DoS guard) + its `batch_too_large` test, all seq-block and cascade-correctness assertions (>500-id delete acceptance, 1003-row rename cascade).
- Deleted: the distinct-`updated_at` pins — each observed FAILING against the new code before deletion, proving the stamping actually stopped.
- `lib/engram/attachments.ex` needed no changes (its #1194 batch delete already shares one timestamp; distinctness there is seq-only).
- `docs/context/batch-write-caps-and-chunk-stamping.md` flipped to HISTORICAL.

## Test plan
- Full gauntlet clean: format / compile `--warnings-as-errors` / credo `--strict` / dialyzer
- `MIX_TEST_PARTITION=6 mix test --warnings-as-errors`: 3981 tests + 1 property, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015buSiNhFQTvQ8ELdkTuLpz