### PR TITLE
fix(test): root-cause the two suite-under-load flakes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,8 @@ Grouped index into `docs/context/`. Each entry is a trigger → doc; read the do
 - Server-side sync protocol — seq change-log, cursor-pull, manifest, realtime channel (start here for sync work) → `docs/context/sync-protocol.md`
 - Phoenix Channel events, conflict flow, plugin integration → `docs/context/channel-event-contract.md`
 - Parallelising channel work (`Task.async_stream`) without starving the DB pool / killing the channel → `docs/context/channel-parallelism-db-pool.md`
+- Unit-suite flake `could not checkout the connection owned by #PID` (sandbox shares the owner's connection — `pool_size` is NOT the lever) → `docs/context/channel-parallelism-db-pool.md`
+- FanoutPacer hot/cold rules, why a note won't warm to HOT, testing it without flaking → `docs/context/fanout-pacer-hot-cold-and-testing.md`
 - CRDT lineage doubling — why the same edit must be encoded exactly once (PR #846) → `docs/context/crdt-lineage-doubling.md`
 - CRDT id-keyed rename old-path resurrection race (plugin #183) → `docs/context/crdt-id-keyed-rename-resurrection.md`
 - CRDT note_id-collision corruption incident, the id-keying cutover day (2026-07-06) → `docs/context/crdt-id-collision-corruption-2026-07-06.md`

--- a/config/test.exs
+++ b/config/test.exs
@@ -78,7 +78,31 @@ config :engram,
          #
          # Raising the checkout timeout instead would only lengthen the queue wait —
          # it hides the contention rather than removing it.
-         pool_size: System.schedulers_online() * 2 + 10
+         pool_size: System.schedulers_online() * 2 + 10,
+
+         # A DIFFERENT mechanism from the pool sizing above, and the pool_size
+         # knob cannot help it: processes a test spawns do not take their own
+         # connection, they share the OWNER's single checked-out one. So a batch
+         # that fans out to N processes (crdt_create_batch → one crdt_doc process
+         # per entry) serializes all N transactions through one connection, and
+         # queueing there is the designed behaviour rather than a shortage.
+         #
+         # DBConnection's defaults (queue_target 50ms / queue_interval 1000ms)
+         # are a PRODUCTION backpressure heuristic: once waits exceed the target
+         # it shirks requests instead of queueing them, so an overloaded pool
+         # sheds load rather than stalling. Against a shared sandbox connection
+         # that heuristic has nothing useful to shed — under full-suite load the
+         # honest serialization wait crosses 50ms and entries fail with
+         # "connection not available and request was dropped from queue after
+         # ~101ms", which surfaces as a flaky assertion about batch results.
+         #
+         # Verified as the mechanism, not a guess: forcing queue_target: 8
+         # reproduces that exact error with no load at all.
+         #
+         # Deliberately still bounded — the 15s checkout timeout is untouched, so
+         # a genuine deadlock or a leaked connection still fails the run.
+         queue_target: 5_000,
+         queue_interval: 30_000
        )
 
 # We don't run a server during test. If one is required,

--- a/docs/context/channel-parallelism-db-pool.md
+++ b/docs/context/channel-parallelism-db-pool.md
@@ -1,6 +1,6 @@
 # Context Doc: Parallelising channel work against the DB pool
 
-_Last verified: 2026-08-02_
+_Last verified: 2026-08-03_
 
 ## Status
 
@@ -112,6 +112,44 @@ grep -oE "DBConnection[A-Za-z.]*|GenServer [^ ]+ terminating" docker-compose.log
   process: `SharedDoc.observe`/`Process.monitor` have to register the channel
   pid, and socket assigns are mutated there. A task pid would swallow the
   room's `{:yjs, ...}` fan-out.
+
+## The test-sandbox variant (different mechanism, near-identical error)
+
+The note above — "a unit test will not reproduce pool starvation" — is true, and
+that is exactly what makes this trap expensive. The unit suite *does* produce an
+error that reads like pool starvation, from an unrelated cause, so the reflex
+fix (raise `pool_size`) cannot work no matter how far you raise it.
+
+Under `Ecto.Adapters.SQL.Sandbox`, a process a test spawns does **not** check out
+its own connection — it shares the **owner's** single checked-out one. So
+`crdt_create_batch` fanning out to one `crdt_doc` process per entry serialises
+every transaction through one connection. Queueing there is the designed
+behaviour, not a shortage, and `pool_size` is not in the picture at all.
+
+What then fails is `DBConnection`'s **overload-shedding heuristic**. Its defaults
+(`queue_target: 50ms`, `queue_interval: 1000ms`) are meant for a production pool:
+once waits exceed the target it starts dropping requests so an overloaded pool
+degrades instead of stalling. Against a shared sandbox connection there is
+nothing useful to shed — under full-suite load (`max_cases: 20`) the honest
+serialisation wait crosses 50ms and entries die with:
+
+```
+** (DBConnection.ConnectionError) could not checkout the connection owned by
+   #PID<...> (:proc_lib). When using the sandbox, connections are shared, so
+   this may imply another process is using a connection. Reason: connection not
+   available and request was dropped from queue after 101ms
+```
+
+**The distinguishing tell is `could not checkout the connection owned by #PID`.**
+Pool starvation says the pool is empty; this says a specific owner's connection
+was contended. Same second sentence, completely different lever.
+
+Fixed in PR #1218 by raising `queue_target`/`queue_interval` to 5s/30s in
+`config/test.exs` — sandbox only. The 15s checkout timeout is deliberately left
+alone, so a genuine deadlock or leaked connection still fails the run rather than
+hanging. Confirmed as the mechanism rather than assumed: forcing
+`queue_target: 8` reproduces that exact error with no load at all, which is the
+cheapest way to re-verify it if this resurfaces.
 
 ## Failed Approaches / Dead Ends
 

--- a/docs/context/fanout-pacer-hot-cold-and-testing.md
+++ b/docs/context/fanout-pacer-hot-cold-and-testing.md
@@ -1,0 +1,101 @@
+# Context Doc: FanoutPacer — hot/cold classification and how to test it
+
+_Last verified: 2026-08-03_
+
+## Status
+
+Working. Pacing is ON by default in prod (`Engram.Notes.FanoutPacer`, shipped
+#1002 / #1003). Ops-hardening follow-ups are tracked in
+[#1004](https://github.com/engram-app/Engram/issues/1004) and are **not done** —
+notably there is still no telemetry gauge for cold-queue depth, so a backing-up
+queue is invisible in prod.
+
+## What This Is
+
+The vault-channel fan-out pacer classifies every frame HOT or COLD and treats
+them differently, which is the source of both its value and its testing traps.
+
+- **HOT** — the note had a fan-out within `fanout_hot_window_ms`. Someone is
+  actively editing it, so the frame broadcasts **inline** and never enters the
+  GenServer. This is the latency-critical path.
+- **COLD** — not seen recently. The frame is enqueued and drained in batches of
+  `fanout_drain_batch` every `fanout_drain_interval_ms`, so a genesis flood of a
+  large vault cannot flood the channel.
+
+## The short-circuit trap (bit us in PR #1218)
+
+`emit/4` is written as:
+
+```elixir
+if pacing_enabled?() and cold?(note_id) do
+```
+
+`cold?/1` is what **writes the ETS hot-mark** — it records "note seen now" as a
+side effect of classifying. Because `and` short-circuits, disabling pacing means
+`cold?/1` is *never called*, so nothing is ever marked seen.
+
+**Consequence for tests:** you cannot warm a note to HOT via the inline path. A
+test that flips `:fanout_pacing_enabled` to `false`, emits, then flips it back
+expecting a HOT note gets a **COLD** one, and any "hot frame bypasses" assertion
+built on it is either failing or, worse, passing for the wrong reason. Warming a
+note to HOT necessarily goes through the paced path, and that first frame is by
+definition cold — so it will be queued and delivered on a drain tick.
+
+## Testing the pacer without flaking
+
+A drain tick is load-variable work. Never put one inside a timed
+`assert_receive`: under full-suite load (`max_cases: 20`) it drifts past a tight
+window and the test fails on its *setup*, not on the property it exists to prove.
+That was the `#1002` bypass test's flake — the failing assert was the warm-up.
+
+**Pattern that works** — keep the warm-up out of the mailbox entirely rather than
+widening a timeout:
+
+```elixir
+# Emit BEFORE subscribing: broadcast to nobody, mailbox stays clean.
+FanoutPacer.emit(topic, "note_yjs_update", payload("live"), "live")
+await_drained(topic)
+EngramWeb.Endpoint.subscribe(topic)
+```
+
+`await_drained/1` polls a **condition**, not a guessed sleep:
+
+```elixir
+not Map.has_key?(:sys.get_state(FanoutPacer).queues, topic)
+```
+
+This is sound because `handle_info(:drain)` calls `Broadcast.emit` synchronously
+in `drain_topic/3` and only then rebuilds its queue map with emptied topics
+rejected. So an absent topic key proves those frames are already broadcast.
+
+Verify such a test by **mutation**, since a timing test going green proves very
+little: delete the `:ets.insert` hot-mark in `cold?/1` so nothing can ever become
+HOT, and confirm the bypass assert fails. (Avoid mutating the `and` expression
+itself — `cold?(note_id) || true` trips warnings-as-errors and never compiles.)
+
+## Gotchas
+
+- `FanoutPacer.reset/0` clears the hot ETS table as well as the queues, so it
+  cannot be used to drain a warm-up frame while keeping a note HOT.
+- The test module is `async: false` on purpose — it shares the named process,
+  global ETS, and application env.
+- Config is read at **call time** (`Application.get_env` per emit/tick), not
+  cached at boot. That is what makes `FANOUT_PACING_ENABLED` an instant rollback
+  lever with no restart, and it is why tests can flip knobs mid-run.
+
+## Rollback lever
+
+`FANOUT_PACING_ENABLED=false` falls back to unpaced inline broadcast for every
+note. Kept deliberately (PR #1217) even though it is unset in every deploy:
+[#1004](https://github.com/engram-app/Engram/issues/1004) asks for a documented
+config path rather than a per-node remote-console `Application.put_env`, and
+until its cold-queue depth gauge lands we are blind to the queue backing up —
+which makes the lever worth more, not less.
+
+## References
+
+- `lib/engram/notes/fanout_pacer.ex` — `emit/4`, `cold?/1`, `handle_info(:drain)`
+- `test/engram/notes/fanout_pacer_test.exs` — `await_drained/2`
+- PRs #1002 / #1003 (pacer), #1217 (flag kept + documented), #1218 (flake fix)
+- Issue #1004 — ops hardening (telemetry gauge, bounded-queue alarm)
+- `docs/context/environment-variables.md` — the knob table

--- a/test/engram/notes/fanout_pacer_test.exs
+++ b/test/engram/notes/fanout_pacer_test.exs
@@ -20,6 +20,26 @@ defmodule Engram.Notes.FanoutPacerTest do
 
   defp payload(note_id), do: %{"note_id" => note_id, "b64" => "x", "head" => "h"}
 
+  # Block until the pacer has broadcast everything queued for `topic`.
+  #
+  # Polls a condition instead of sleeping a guessed interval: handle_info(:drain)
+  # broadcasts synchronously and then rebuilds its queue map without the emptied
+  # topics, so the topic key being absent means those frames are already out.
+  # Bounded so a pacer that never drains fails loudly instead of hanging.
+  defp await_drained(topic, tries \\ 200) do
+    cond do
+      not Map.has_key?(:sys.get_state(FanoutPacer).queues, topic) ->
+        :ok
+
+      tries == 0 ->
+        flunk("FanoutPacer never drained #{topic}")
+
+      true ->
+        Process.sleep(10)
+        await_drained(topic, tries - 1)
+    end
+  end
+
   test "when pacing disabled, emit/4 broadcasts inline immediately" do
     Application.put_env(:engram, :fanout_pacing_enabled, false)
     topic = "sync:u1:v1"
@@ -65,12 +85,23 @@ defmodule Engram.Notes.FanoutPacerTest do
     Application.put_env(:engram, :fanout_drain_interval_ms, 80)
 
     topic = "sync:u3:v3"
-    EngramWeb.Endpoint.subscribe(topic)
 
-    # Warm note "live" so it is HOT (seen within the window). This first frame is
-    # cold (paced), so drain it before asserting the bypass on the SECOND frame.
+    # Warm note "live" so it is HOT (seen within the window). Hotness is written
+    # by cold?/1 during emit, but this first frame is itself cold, so the pacer
+    # queues it and broadcasts it on a drain tick.
+    #
+    # Subscribe only AFTER that frame is gone. Waiting for it in the mailbox
+    # instead put a drain tick — load-variable work — inside a timed assert, and
+    # under full-suite concurrency it landed just past the window (this is the
+    # flake). Emitting before subscribing keeps the warm-up out of the mailbox
+    # entirely, so the assert below can only ever match the bypass frame.
+    #
+    # Note the warm-up MUST be paced: emit/4 short-circuits on
+    # `pacing_enabled?() and cold?(note_id)`, so warming with pacing disabled
+    # would skip cold?/1, never mark the note seen, and leave it COLD.
     FanoutPacer.emit(topic, "note_yjs_update", payload("live"), "live")
-    assert_receive(%Phoenix.Socket.Broadcast{payload: %{"note_id" => "live"}}, 300)
+    await_drained(topic)
+    EngramWeb.Endpoint.subscribe(topic)
 
     # A big genesis flood of distinct COLD notes.
     for i <- 1..20, do: FanoutPacer.emit(topic, "note_yjs_update", payload("g#{i}"), "g#{i}")


### PR DESCRIPTION
Two tests failed only when the full suite ran at `max_cases: 20` — 1–2 failures across 5 runs, both passing 3/3 in isolation. They surfaced during the #1217 config audit; neither is caused by that branch, and neither is fixed by loosening an assertion.

No `lib/` changes. The diff is one test file and the test-env repo config.

## `FanoutPacerTest` — "hot frame bypasses … cold flood (#1002)"

**The assert that failed was the warm-up, not the property under test.** Warming note `"live"` to HOT has to go through the paced path: `emit/4` short-circuits on `pacing_enabled?() and cold?(note_id)`, so warming with pacing *disabled* would skip `cold?/1` entirely and leave the note COLD. That means the warm-up frame is queued and delivered on a drain tick — and the test waited for it in the mailbox inside a 300ms `assert_receive`. A drain tick is load-variable work sitting inside a timed window; under suite concurrency it landed just past it (`Found message ... after 300ms`).

Fixed by **removing the wait rather than widening it**: emit the warm-up frame *before* subscribing, so it is broadcast to nobody and never enters the mailbox, then gate the subscribe on a polled condition — the pacer's queue map no longer holding the topic. `handle_info(:drain)` broadcasts synchronously and only then rebuilds the map without emptied topics, so an absent topic key proves those frames are already out. The bypass assertion itself is untouched at 150ms.

**Verified by mutation, not just by going green.** Deleting the ETS hot-mark so nothing can ever become HOT makes the test fail at the bypass assert — and the mailbox in that failure holds *exactly one* message (a flood frame), which proves the warm-up frame is genuinely gone rather than merely arriving early.

## `CrdtChannelTest` — "reply preserves per-entry input order"

**Not pool exhaustion**, so the `pool_size` headroom above it (#1158) could never have helped: processes a test spawns don't take their own connection, they share the **owner's** single checked-out one. `crdt_create_batch` fans out to one `crdt_doc` process per entry, so nine transactions serialize through one connection — queueing there is the designed behaviour, not a shortage.

DBConnection's `queue_target`/`queue_interval` defaults (50ms/1000ms) are a **production backpressure heuristic**: past the target it sheds requests so an overloaded pool degrades instead of stalling. Against a shared sandbox connection there is nothing useful to shed — under load the honest serialization wait crosses 50ms and entries die with `connection not available and request was dropped from queue after ~101ms`, surfacing as a flaky assertion about batch results.

**Confirmed as the mechanism rather than assumed:** forcing `queue_target: 8` reproduces that exact error with no load at all. Raised to 5s/30s for the sandbox only; the 15s checkout timeout is deliberately untouched, so a real deadlock or a leaked connection still fails the run.

## Verification

`mix format --check-formatted` and `credo --strict` clean. Full `mix test --warnings-as-errors` run 3 consecutive times: **3983 tests, 0 failures each**, real exit codes (not piped). Prior to the fix the same suite produced 1–2 failures across 5 runs on the same machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyirNUaZY19uVvzwBL8yX4