### PR TITLE
feat(editor): Obsidian-style note header, inline title, and Properties block

### DIFF
--- a/docs/context/ci-registry-down-during-appdata-backup.md
+++ b/docs/context/ci-registry-down-during-appdata-backup.md
@@ -1,0 +1,82 @@
+# `prebuild-ci-image` fails ~04:00-04:30 local: the nightly appdata backup stopped the registry
+
+**Trigger:** CI fails with the image *built fine* and only the push failing:
+
+```
+The push refers to repository [10.0.20.214:5001/engram-ci]
+Get "http://10.0.20.214:5001/v2/": dial tcp 10.0.20.214:5001: connect: connection refused
+```
+
+Every e2e job (`e2e-browser`, `e2e-crdt`, `e2e-clerk`, `headless-protocol`) then reports **skipping**, because they depend on that image. `record-pass` fails. The PR looks broken; nothing is wrong with the code.
+
+## Cause
+
+FastRaid (`10.0.20.214`) is Unraid, and the **Appdata Backup plugin** runs at **04:00 local**. It stops each container in turn, tars its appdata, and starts it again:
+
+```
+04:00  php /usr/local/emhttp/plugins/appdata.backup/scripts/backup.php
+04:05  tar -c -z -f /mnt/main-pool/appdata-backups/ab_<date>/LocalCIRegistry.tar.gz \
+                    /mnt/cache/appdata/local-ci-registry
+```
+
+`LocalCIRegistry` serves `:5001`. While its tar runs, the port is dead and any CI push fails.
+
+## How to recognise it (vs a real registry problem)
+
+```bash
+ssh root@10.0.20.214 'docker inspect LocalCIRegistry \
+  --format "policy={{.HostConfig.RestartPolicy.Name}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} restarts={{.RestartCount}}"'
+# policy=unless-stopped exit=2 oom=false restarts=0
+```
+
+`restarts=0` under `unless-stopped` is the tell: **Docker treats it as deliberately stopped.** `unless-stopped` does not auto-restart a container that something ran `docker stop` on, so a crash-looping registry would show a non-zero `RestartCount` and a real fault would usually show `oom=true` or a full volume. Confirm with:
+
+```bash
+ssh root@10.0.20.214 'ps aux | grep -iE "appdata|backup|tar " | grep -v grep'
+```
+
+A live `tar ... LocalCIRegistry.tar.gz` line is the smoking gun. Several unrelated containers showing `Up N minutes` at the same moment is the corroborating signal — that is the plugin working its way down the list.
+
+## Do NOT start the container
+
+`docker start LocalCIRegistry` while its tar is running:
+
+1. corrupts that night's backup — the registry writes into the directory `tar` is mid-read on, so the archive captures a torn state, and
+2. fights the plugin, which starts the container itself when the tar finishes.
+
+**Wait it out.** Poll until it returns, then re-run the failed job:
+
+```bash
+until ssh root@10.0.20.214 'docker ps --filter name=LocalCIRegistry --filter status=running -q' | grep -q .; do sleep 60; done
+gh run rerun <run-id> --failed
+```
+
+## How long the outage lasts
+
+Longer than you would guess, because this container is the whole backup:
+
+```
+/mnt/cache/appdata/local-ci-registry      62G      <- CI image layers
+next largest (stable-diffusion)          434M
+GitCdn                                   165M
+AdGuard-Home                              64M
+```
+
+Measured 2026-08-03: `:5001` went down at **04:05** and answered again at **04:56** — a **51-minute** outage from one container's tar. Every other container in the run finished in about a minute. Any CI push landing in that window fails, so an overnight or autonomous session will hit it.
+
+## Prevention
+
+The fix is configuration, not code. In order of value:
+
+1. **Exclude `local-ci-registry` from appdata backup.** It is 62G of *rebuildable* image layers — restoring it from a tarball is never the right recovery move (you re-push instead), so the backup buys nothing and costs a nightly CI outage plus ~90% of the backup window.
+2. Failing that, move the 04:00 window off the hours when overnight/autonomous CI runs.
+
+Separately: 62G suggests the registry has **no garbage collection** — CI images from every branch accumulating since the runner pool was built. Worth a `registry garbage-collect` pass and a retention policy regardless of the backup question.
+
+Neither is done yet. Raise both before the next unattended overnight session.
+
+## Related
+
+- `runner-vm-setup.md` — the runners that push to this registry
+- `ci-pipeline-gating.md` — which jobs gate, and what a `skipping` really means
+- `fastraid-deploy.md` — the rest of the FastRaid host layout

--- a/docs/context/mobile-keyboard-inset-apis.md
+++ b/docs/context/mobile-keyboard-inset-apis.md
@@ -1,0 +1,94 @@
+# Positioning UI above the mobile keyboard: which API, and what we already ship
+
+Researched 2026-08-02 while deciding where the formatting toolbar should live
+on mobile. Written down because the obvious-looking API is the wrong bet, and
+because we already ship one of the three without it being obvious what it does
+or does not cover.
+
+## The three mechanisms
+
+| | Venue | Status | Chromium | Firefox | Safari / iOS |
+|---|---|---|---|---|---|
+| `interactive-widget` viewport meta key | W3C CSSWG, css-viewport-1 | **standards track** (WD) | yes | implementing (bugzilla 1831649) | **no** — webkit 259770 |
+| `navigator.virtualKeyboard` + `env(keyboard-inset-*)` | WICG incubation | **not standards track** | yes | no signal | **no** — webkit 230225 |
+| `window.visualViewport` | WHATWG HTML + css-viewport-1 | living standard | yes | yes | **yes** |
+
+Spec: <https://drafts.csswg.org/css-viewport-1/#interactive-widget-section>
+
+**Do not build on `navigator.virtualKeyboard`.** It reads like the clean
+declarative answer — set `overlaysContent = true`, then
+`bottom: env(keyboard-inset-height, 0px)` — but it is a WICG incubation that
+neither Apple nor Mozilla has committed to. Both point at the CSSWG viewport
+key instead. The `keyboard-inset-*` env vars are defined by that same
+incubation, so they inherit its support story.
+
+**WebKit status, checked 2026-08-02.** Bug 259770 (`interactive-widget`) was
+filed 2023-08-03 and is still `NEW` and unassigned, with pings in 2025-03,
+2026-01, 2026-02, 2026-04 and 2026-06 and no Apple response. Bug 230225
+(VirtualKeyboard API) is likewise `NEW`. Re-check before assuming either has
+landed; nothing about iOS below is safe to assume forward.
+
+## What we already ship
+
+`frontend/index.html`:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
+```
+
+Added in `d4eaa43c` (#663, "mobile UI polish") for the onboarding flow, whose
+commit message reads "auth shell/layout use h-dvh + viewport interactive-widget
+fix so the mobile keyboard no longer overlaps inputs".
+
+That is two fixes, and they do **not** split evenly:
+
+- `interactive-widget=resizes-content` — Chromium only. Inert on iOS.
+- `h-dvh` — everywhere.
+
+So the on-device iOS verification in that PR was carried by `h-dvh`. Do not
+read the meta tag as evidence that keyboard overlap is handled on iOS.
+
+Nothing else in the codebase touches any of the three: no `visualViewport`, no
+`navigator.virtualKeyboard`, and the Obsidian plugin has none of them.
+
+## The interaction worth knowing
+
+`resizes-content` makes the keyboard shrink the **layout** viewport, not just
+the visual one. Consequences:
+
+- **Android**: `position: fixed; bottom: 0` already sits above the keyboard.
+  No JavaScript needed.
+- **iOS**: layout viewport is untouched, so a fixed-bottom element stays
+  behind the keyboard. Needs the `visualViewport` fallback.
+
+The usual iOS fallback measures the keyboard indirectly:
+
+```js
+const inset = Math.max(0, window.innerHeight - (visualViewport.height + visualViewport.offsetTop));
+el.style.transform = `translateY(-${inset}px)`;
+```
+
+**This composes correctly with our meta tag rather than fighting it.** On
+Android `innerHeight` shrinks in step with `visualViewport.height`, so `inset`
+computes to ~0 and no transform is applied — correct, because the layout
+already moved. On iOS `innerHeight` is unchanged, so `inset` is the real
+keyboard height. One code path, right on both, *because* of
+`resizes-content`. If someone ever changes that value to `resizes-visual` or
+`overlays-content`, this formula starts double-counting on Android.
+
+## Gotchas for a format toolbar specifically
+
+Different from the usual chat-composer case:
+
+1. **Buttons must not take focus.** Tapping Bold with a focusable button
+   dismisses the keyboard and drops the selection. Needs
+   `onPointerDown={e => e.preventDefault()}` per button.
+   `viewer/editor/toolbar.tsx` does **not** do this today — it never mattered
+   while the toolbar was docked under the header.
+2. **`visualViewport` also fires on pinch-zoom**, so an unguarded handler
+   slides the toolbar around during an ordinary zoom. Gate on the editor
+   actually having focus.
+3. **Listen to `scroll` as well as `resize`.** iOS auto-scrolls the caret into
+   view, which changes `offsetTop` without firing a resize.
+4. Combine with `env(safe-area-inset-bottom)` so the toolbar clears the home
+   indicator when the keyboard is closed.

--- a/docs/context/obsidian-properties-parity.md
+++ b/docs/context/obsidian-properties-parity.md
@@ -1,0 +1,82 @@
+# Reading Obsidian's real CSS, and the Properties geometry we copied
+
+Done 2026-08-02 to make the web app's frontmatter block look like Obsidian's
+Properties. The useful half of this doc is the extraction recipe — the docs
+site lists the CSS variable *names* but none of their values, and blog posts
+mostly quote people's custom snippets rather than the defaults.
+
+## Getting the authoritative CSS
+
+`docs.obsidian.md` is an Obsidian Publish site rendered client-side, so
+scraping it yields an empty shell. The developer-docs markdown on GitHub has
+the variable names but, again, no values.
+
+The real file is `app.css` inside the app bundle:
+
+```bash
+# The AppImage lives at ~/Applications/Obsidian.AppImage on this machine.
+cd /tmp/scratch
+~/Applications/Obsidian.AppImage --appimage-extract resources/obsidian.asar
+bunx --bun @electron/asar extract-file squashfs-root/resources/obsidian.asar app.css
+```
+
+That drops a ~600KB `app.css`. From there:
+
+```bash
+grep -o -- '--metadata-[a-z-]*:[^;]*;' app.css | sort -u   # every default value
+grep -n '^\.metadata-' app.css                             # rule line numbers
+```
+
+Note `grep`ping the `.asar` directly finds the *JavaScript* copies of those
+class names, not the stylesheet — extract `app.css` properly or you will read
+bundled JS and conclude the rules do not exist.
+
+## The Properties geometry (Obsidian defaults)
+
+| What | Obsidian | Ours |
+|---|---|---|
+| container padding | `--metadata-padding: 8px 0` | `py-2` |
+| gap down to the body | `margin-block-end: 2rem` | `mb-8` |
+| container background / border | transparent, `border-width: 0` | none |
+| gap between rows | `--metadata-gap: 3px` | `gap-[3px]` |
+| row radius | `--metadata-property-radius: 6px` | `rounded-md` |
+| row layout | `display: flex; align-items: start` | same |
+| key column width | `--metadata-label-width: 9em` → 144px, `flex-shrink: 0` | `w-36 min-w-36 shrink-0` |
+| key font size | `--font-smaller: 0.875em` → 14px | `text-sm` |
+| key colour | `--text-muted` | `text-muted-foreground` |
+| cell padding | `--metadata-input-padding: 4px 8px` | `px-2 py-1` |
+| row height | `--metadata-input-height: calc(16px * 1.75)` → 28px | `min-h-7` |
+| value cell | `flex: 1 1 auto; gap: 4px` | `flex-1 gap-1` |
+| value inputs | `background: transparent; border-width: 0` | same |
+
+## The surprising part: the default has no hover or focus feedback
+
+Every one of these resolves to `transparent`:
+
+- `--metadata-property-background` / `-hover`
+- `--metadata-label-background` / `-hover`
+- `--metadata-input-background` / `-hover`
+- `--metadata-divider-width: 0` (so no rules between properties either)
+
+The only non-transparent states are `--metadata-label-background-active` and
+`--metadata-input-background-active` (both `--background-modifier-hover`), and
+`.metadata-property-value .metadata-input-text:focus` explicitly forces the
+value back to transparent. So focusing a *value* tints nothing at all — the
+caret is the entire affordance.
+
+This is why so many community CSS snippets exist for "properties on hover":
+the stock look is deliberately bare. We replicated it as-is. If it reads as
+too flat for the web app, the one-line change is a `hover:bg-muted` on the row
+in `properties-widget.tsx` — that is what the popular snippets do.
+
+## Where we deliberately diverge
+
+- **Row actions.** Obsidian puts move/remove in a right-click menu and shows
+  nothing in the row. We keep the `^ v x` buttons but reveal them on
+  hover/focus, so the resting state matches without losing the capability.
+- **Key text is not editable.** Obsidian's key is an `input`
+  (`.metadata-property-key-input`) you can retype to rename the property. Ours
+  is a `<span>`. Renaming a key was out of scope.
+- **Semantics.** Obsidian uses divs throughout; we keep `dl`/`dt`/`dd`, with
+  each row a `div` wrapping its `dt`+`dd` (valid since HTML 5.2) so the row
+  still has a box to carry radius and hover state.

--- a/docs/context/radix-modal-menu-vs-blur-committing-input.md
+++ b/docs/context/radix-modal-menu-vs-blur-committing-input.md
@@ -1,0 +1,65 @@
+# A Radix menu item that opens an inline editor needs `modal={false}`
+
+Found building the note-page kebab (`frontend/src/viewer/note-menu.tsx`). The
+"Rename" item set state that mounts `RenameInput` in the inline title, and the
+rename box vanished in the same tick it appeared — no error, no failed
+mutation, just a menu that appeared to do nothing.
+
+## The mechanism
+
+`DropdownMenu` defaults to `modal={true}`, which wraps the content in a Radix
+`FocusScope` with `trapped`. The trap listens for focus leaving the menu and
+forces it back in.
+
+The order that kills you:
+
+1. Click the item → `onSelect` → `setRenamingFor(id)`, and Radix begins closing.
+2. React commits: `RenameInput` mounts and its mount effect calls `el.focus()`.
+3. The **still-mounted** focus trap sees focus land outside the menu and yanks
+   it back.
+4. That yank blurs the input. `RenameInput` has `commitOnBlur` and settles
+   commit-or-cancel on blur, so it calls `onCancel` → `setRenamingFor(null)`.
+
+The box is gone before a human could see it. Nothing throws; the value was
+unchanged so `onCancel` fires rather than `onCommit`, and no mutation runs to
+leave a trace.
+
+## The fix
+
+```tsx
+<DropdownMenu modal={false}>
+```
+
+That is the whole fix. A kebab has no reason to trap focus or lock background
+scroll.
+
+## What does NOT fix it
+
+`onCloseAutoFocus={(e) => e.preventDefault()}` on `DropdownMenuContent`. That
+is the usual advice for "the menu steals focus back on close", and it is
+answering a different question — the yank here happens while the menu is still
+open, not during its close-time focus restore. Prop forwarding is fine (the
+shadcn wrapper spreads `...props` onto `DropdownMenuPrimitive.Content`); it
+just addresses the wrong moment. Tested: it leaves the bug in place, and
+`modal={false}` alone is sufficient without it.
+
+## The general shape
+
+Any Radix overlay defaulting to modal + any input that mutates state on blur =
+this bug. In this repo the blur-committing input is `RenameInput`
+(`frontend/src/viewer/tree-actions/rename-input.tsx`), whose `commitOnBlur` is
+opt-in precisely because the two callers want opposite things. If a future menu
+item opens that box — or any autofocusing surface that is not itself a Radix
+overlay — it needs the same `modal={false}`.
+
+Radix dialogs are exempt: they mount their own focus scope, so the outgoing
+menu's trap has somewhere legitimate to hand off to. The move and delete
+actions in the same kebab never showed the bug for that reason.
+
+## Regression test
+
+`frontend/src/viewer/note-page.test.tsx` → `kebab > starts a rename from the
+menu`. It fails if `modal` goes back to its default. Note it only catches this
+because the test asserts the textbox is present *synchronously* after the
+click; an `await findBy...` would race the same teardown and could pass by
+accident.

--- a/docs/context/text-to-control-breaks-locators-and-a11y.md
+++ b/docs/context/text-to-control-breaks-locators-and-a11y.md
@@ -1,0 +1,72 @@
+# Turning displayed text into a control breaks locators and accessibility
+
+**Trigger:** you replaced a string the UI used to *render as text* with an input, an icon, or any other control — and now an e2e test can't find it, or a screen reader can't read it.
+
+Hit twice in one PR (#1219, the note-header/Properties rework), both times in the same widget, both times silently.
+
+## What actually happens
+
+A string sitting in the DOM as text is legible through three channels at once:
+
+| Channel | Text node | `<input value>` | Icon |
+|---|---|---|---|
+| Playwright `hasText` / `toHaveText` | yes | **no** | **no** |
+| Testing Library `getByText` | yes | **no** | **no** |
+| Screen reader | yes | yes (as the field's value) | **no** |
+
+Converting text → control silently drops it out of the channels you were relying on. Nothing errors. The component looks right on screen, which is exactly why this survives review.
+
+### Case 1 — text became an input
+
+The property key was rendered as `<dt>due</dt>`. Making it renameable in place turned it into `<input value="due">`.
+
+```ts
+// Could never pass again — an input's value is not text content.
+page.getByRole("term").filter({ hasText: key })
+
+// Reads the channel the value actually lives in now.
+page.getByRole("textbox", { name: `Rename ${key}` })
+```
+
+### Case 2 — text became an icon (the real bug)
+
+The property *type* used to render as the word `text` / `date`. Matching Obsidian meant replacing it with an icon:
+
+```tsx
+// The type is now conveyed by pixels ONLY. aria-hidden on the icon, and a
+// static name on the button, means AT is told a type picker exists but never
+// which type the property already is.
+<DropdownMenuTrigger aria-label="Property type">
+  <Icon aria-hidden="true" />
+</DropdownMenuTrigger>
+```
+
+Fix: put the value in the accessible name, which is the one channel that survives the swap.
+
+```tsx
+<DropdownMenuTrigger aria-label={`Property type: ${value}`}>
+```
+
+That restores the information *and* gives the e2e something honest to assert:
+
+```ts
+await expect(typeButton).toHaveAccessibleName("Property type: date");  // not toHaveText
+```
+
+## Why the tests didn't catch it
+
+The unit test was named `shows current type and emits a new one on select`. It only ever asserted the **select**. The display half of its own name was never checked, so removing the display broke nothing locally and `e2e-browser` was the first thing to notice — after the PR was already open.
+
+A test whose name claims two behaviours and asserts one is worse than a missing test: it reads as coverage.
+
+## Rules
+
+1. Swapping text for a control? Add or fix an assertion on the **accessible name** in the same commit. It is the only channel that survives text → input → icon.
+2. Icon-only controls must carry their *state* in the name, not just their purpose. `"Property type"` names the control; `"Property type: date"` names the control and answers the question the icon was drawn to answer.
+3. Prefer `toHaveAccessibleName` over `toHaveText` for anything that might become a control later. `toHaveText` silently encodes "this is a text node" as a contract.
+4. When a test comment documents a DOM assumption (`the <dt> text`), treat it as a tripwire — if that sentence stops being true, the test is already wrong.
+
+## Related
+
+- `frontend-architecture.md` — where the viewer components live
+- `obsidian-properties-parity.md` — why the type label became an icon in the first place

--- a/docs/superpowers/plans/2026-08-02-note-header-inline-title-kebab.md
+++ b/docs/superpowers/plans/2026-08-02-note-header-inline-title-kebab.md
@@ -1,0 +1,1140 @@
+# Note Page Inline Title + Kebab Menu Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the web SPA note page read like Obsidian — a thin chrome bar, a large document title that scrolls with the content above the frontmatter, and a kebab menu that absorbs the view-mode toggle plus the file actions.
+
+**Architecture:** CodeMirror currently owns its own scrollbar (`height: 100%` + `.cm-scroller { overflow: auto }`), which is why anything rendered above it stays pinned. We flip CodeMirror to grow with its content (`height: auto`, `overflow: visible`) and give `note-page.tsx` a single `ScrollArea` that wraps title, properties, and body for all three view modes. The kebab reuses the file tree's existing action vocabulary (`action-list.ts`) and its existing dialogs (`MoveDialog`, `DeleteConfirm`, `RenameInput`) rather than inventing new ones.
+
+**Tech Stack:** React 19, TypeScript, Vite, Tailwind, shadcn/ui (Radix), CodeMirror 6, Yjs, TanStack Query, react-router 8, Vitest + Testing Library.
+
+## Global Constraints
+
+- Spec: Engram vault → `50 Engineering/_Superpowers Specs/2026-08-02-note-header-inline-title-kebab-design.md`.
+- Repo: `engram` (Elixir app root; frontend lives at `frontend/`). Worktree: `.worktrees/feat-note-header-kebab`, branch `feat/note-header-inline-title-kebab`.
+- All commands run from `frontend/`. Test runner is `bun run test` (`vitest run`). Lint is `./node_modules/.bin/biome ci .` — never `bunx biome` (wrong version).
+- **NO version bumps.** release-please owns versioning.
+- TDD is mandatory: write the failing test, watch it fail, then implement.
+- Conventional commits, subject under 50 chars.
+- Do not modify tests to make bad code pass. Fix the implementation.
+- Baseline at branch point: 167 test files, 1166 tests, 0 failures. Any red at the end is in scope, not "pre-existing".
+- Out of scope: hiding the formatting toolbar (Unit B), frontmatter-on-demand via `---` (Unit C). `EditorToolbar` stays exactly where it is.
+
+---
+
+### Task 1: Extend the action vocabulary
+
+The kebab shows the file actions plus "Add property" plus the three view modes. On mobile it reuses `ActionDrawer`, which does `const Icon = ACTION_ICONS[a.id]` and then renders `<Icon />` — an id with no icon entry renders `undefined` and throws. So every id the kebab can show must exist in `ActionId` and `ACTION_ICONS`.
+
+Adding ids to the union does **not** leak them into the tree's menus: `actionsFor()` is the gate that decides what each surface lists, and it is left untouched.
+
+**Files:**
+- Modify: `frontend/src/viewer/tree-actions/action-list.ts`
+- Test: `frontend/src/viewer/tree-actions/action-list.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ActionId` gains `"add-property" | "view-rendered" | "view-raw" | "view-reading"`; `ACTION_ICONS` gains entries for all four; new export `noteMenuActions(mode: "rendered" | "raw" | "reading"): readonly Action[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/viewer/tree-actions/action-list.test.ts`:
+
+```ts
+import { ACTION_ICONS, actionsFor, noteMenuActions } from "./action-list";
+
+describe("noteMenuActions", () => {
+	it("lists the three view modes, the file actions, and add-property", () => {
+		const ids = noteMenuActions("rendered").map((a) => a.id);
+		expect(ids).toEqual([
+			"view-rendered",
+			"view-raw",
+			"view-reading",
+			"rename",
+			"move",
+			"duplicate",
+			"copy-wikilink",
+			"add-property",
+			"delete",
+		]);
+	});
+
+	it("marks the active mode so the menu can show a checkmark", () => {
+		const raw = noteMenuActions("raw").find((a) => a.id === "view-raw");
+		const rendered = noteMenuActions("raw").find((a) => a.id === "view-rendered");
+		expect(raw?.active).toBe(true);
+		expect(rendered?.active).toBe(false);
+	});
+
+	// ActionDrawer renders ACTION_ICONS[id] unconditionally — a missing entry
+	// is a crash, not a degraded menu.
+	it("has an icon for every action it can render", () => {
+		for (const action of noteMenuActions("rendered")) {
+			expect(ACTION_ICONS[action.id]).toBeDefined();
+		}
+	});
+
+	// The tree's menus must not grow the new entries.
+	it("leaves the tree's file menu unchanged", () => {
+		const ids = actionsFor({ kind: "file" }).map((a) => a.id);
+		expect(ids).toEqual(["rename", "move", "duplicate", "copy-wikilink", "delete"]);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test -- action-list`
+Expected: FAIL — `noteMenuActions is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `frontend/src/viewer/tree-actions/action-list.ts`, extend the icon import, the union, the icon map, and add the builder.
+
+Change the lucide import to add the four new icons:
+
+```ts
+import {
+	Copy,
+	Eye,
+	FilePlus,
+	FileText,
+	FolderInput,
+	FolderPlus,
+	Link2,
+	ListPlus,
+	type LucideIcon,
+	Pencil,
+	SquareCode,
+	Trash2,
+} from "lucide-react";
+```
+
+Extend the union:
+
+```ts
+export type ActionId =
+	| "new-note"
+	| "new-folder"
+	| "rename"
+	| "move"
+	| "duplicate"
+	| "copy-wikilink"
+	| "delete"
+	| "add-property"
+	| "view-rendered"
+	| "view-raw"
+	| "view-reading";
+```
+
+Add an `active` flag to `Action` (used only by the note menu; the tree never sets it):
+
+```ts
+export interface Action {
+	id: ActionId;
+	label: string;
+	destructive?: boolean;
+	/** Set by `noteMenuActions` for the current view mode. The tree omits it. */
+	active?: boolean;
+}
+```
+
+Extend the icon map:
+
+```ts
+const ACTION_ICONS: Record<ActionId, LucideIcon> = {
+	"new-note": FilePlus,
+	"new-folder": FolderPlus,
+	rename: Pencil,
+	move: FolderInput,
+	duplicate: Copy,
+	"copy-wikilink": Link2,
+	delete: Trash2,
+	"add-property": ListPlus,
+	"view-rendered": FileText,
+	"view-raw": SquareCode,
+	"view-reading": Eye,
+};
+```
+
+Append the builder at the end of the file, before the `export { ACTION_ICONS }` line:
+
+```ts
+export type ViewMode = "rendered" | "raw" | "reading";
+
+// The note page's kebab. Deliberately NOT part of `actionsFor` — that function
+// answers "what can you do to a tree node", and the view modes are a property
+// of the open editor, not of the file.
+export function noteMenuActions(mode: ViewMode): readonly Action[] {
+	return [
+		{ id: "view-rendered", label: "Rendered", active: mode === "rendered" },
+		{ id: "view-raw", label: "Raw", active: mode === "raw" },
+		{ id: "view-reading", label: "Reading", active: mode === "reading" },
+		{ id: "rename", label: "Rename" },
+		{ id: "move", label: "Move to…" },
+		{ id: "duplicate", label: "Duplicate" },
+		{ id: "copy-wikilink", label: "Copy wikilink" },
+		{ id: "add-property", label: "Add property" },
+		{ id: "delete", label: "Delete", destructive: true },
+	];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test -- action-list`
+Expected: PASS, including the pre-existing `actionsFor` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/tree-actions/action-list.ts frontend/src/viewer/tree-actions/action-list.test.ts
+git commit -m "feat(editor): add note-menu action vocabulary"
+```
+
+---
+
+### Task 2: InlineTitle component
+
+A presentational title that swaps to the existing `RenameInput` when renaming. `RenameInput` already calls `el.focus()` and `el.setSelectionRange(0, initial.length)` on mount, so selection-on-open needs no work here.
+
+**Files:**
+- Create: `frontend/src/viewer/inline-title.tsx`
+- Test: `frontend/src/viewer/inline-title.test.tsx`
+
+**Interfaces:**
+- Consumes: `RenameInput` from `./tree-actions/rename-input`.
+- Produces: `InlineTitle({ name, renaming, onStartRename, onCommitRename, onCancelRename })`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/viewer/inline-title.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { InlineTitle } from "./inline-title";
+
+const props = {
+	name: "My Note",
+	renaming: false,
+	onStartRename: vi.fn(),
+	onCommitRename: vi.fn(),
+	onCancelRename: vi.fn(),
+};
+
+describe("InlineTitle", () => {
+	it("renders the name as a level-1 heading", () => {
+		render(<InlineTitle {...props} />);
+		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("My Note");
+	});
+
+	it("starts a rename when clicked", () => {
+		const onStartRename = vi.fn();
+		render(<InlineTitle {...props} onStartRename={onStartRename} />);
+		fireEvent.click(screen.getByRole("button", { name: "My Note" }));
+		expect(onStartRename).toHaveBeenCalled();
+	});
+
+	it("shows an input seeded with the name, fully selected, while renaming", () => {
+		render(<InlineTitle {...props} renaming />);
+		const input = screen.getByRole("textbox") as HTMLInputElement;
+		expect(input.value).toBe("My Note");
+		// Typing must replace the name, which is what the selection buys.
+		expect(input.selectionStart).toBe(0);
+		expect(input.selectionEnd).toBe("My Note".length);
+	});
+
+	it("commits the typed name on Enter", () => {
+		const onCommitRename = vi.fn();
+		render(<InlineTitle {...props} renaming onCommitRename={onCommitRename} />);
+		const input = screen.getByRole("textbox");
+		fireEvent.change(input, { target: { value: "Renamed" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onCommitRename).toHaveBeenCalledWith("Renamed");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test -- inline-title`
+Expected: FAIL — cannot resolve `./inline-title`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `frontend/src/viewer/inline-title.tsx`:
+
+```tsx
+import { RenameInput } from "./tree-actions/rename-input";
+
+interface Props {
+	/** Base name, no extension — the caller strips it. */
+	name: string;
+	renaming: boolean;
+	onStartRename: () => void;
+	onCommitRename: (next: string) => void;
+	onCancelRename: () => void;
+}
+
+/**
+ * Obsidian-style inline title: part of the document flow, not the chrome, so
+ * it scrolls away with the content. Click to rename — `commitOnBlur` because
+ * this reads as a title field you retype and then click into the body from,
+ * where losing the edit would be a surprise.
+ */
+export function InlineTitle({
+	name,
+	renaming,
+	onStartRename,
+	onCommitRename,
+	onCancelRename,
+}: Props) {
+	return (
+		<h1 className="px-5 pt-6 pb-1 font-semibold text-3xl tracking-tight">
+			{renaming ? (
+				<RenameInput
+					initial={name}
+					kind="file"
+					commitOnBlur
+					onCommit={onCommitRename}
+					onCancel={onCancelRename}
+				/>
+			) : (
+				<button
+					type="button"
+					// -mx-1 cancels the padding so the hover target is roomier than the
+					// text without shifting the title off the left margin.
+					className="-mx-1 block w-full truncate rounded px-1 text-left hover:bg-accent"
+					title="Click to rename"
+					onClick={onStartRename}
+				>
+					{name}
+				</button>
+			)}
+		</h1>
+	);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test -- inline-title`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/inline-title.tsx frontend/src/viewer/inline-title.test.tsx
+git commit -m "feat(editor): add InlineTitle component"
+```
+
+---
+
+### Task 3: NoteMenu component
+
+Desktop renders a Radix dropdown; mobile renders the existing `ActionDrawer` bottom sheet, matching the file tree's long-press behaviour.
+
+**Files:**
+- Create: `frontend/src/viewer/note-menu.tsx`
+- Test: `frontend/src/viewer/note-menu.test.tsx`
+
+**Interfaces:**
+- Consumes: `noteMenuActions`, `ACTION_ICONS`, `ActionId`, `ViewMode` from Task 1; `ActionDrawer`; `useMediaQuery` from `@/hooks/use-media-query`.
+- Produces: `NoteMenu({ mode, title, onPick })` where `onPick: (id: ActionId) => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/viewer/note-menu.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NoteMenu } from "./note-menu";
+
+const matches = vi.fn();
+vi.mock("@/hooks/use-media-query", () => ({
+	useMediaQuery: () => matches(),
+}));
+
+describe("NoteMenu", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		matches.mockReturnValue(true); // desktop by default
+	});
+
+	it("opens a dropdown on desktop and reports the picked action", () => {
+		const onPick = vi.fn();
+		render(<NoteMenu mode="rendered" title="note" onPick={onPick} />);
+		fireEvent.click(screen.getByRole("button", { name: "Note options" }));
+		fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
+		expect(onPick).toHaveBeenCalledWith("duplicate");
+	});
+
+	it("marks the active view mode", () => {
+		render(<NoteMenu mode="raw" title="note" onPick={vi.fn()} />);
+		fireEvent.click(screen.getByRole("button", { name: "Note options" }));
+		expect(screen.getByRole("menuitem", { name: "Raw" })).toHaveAttribute(
+			"aria-current",
+			"true",
+		);
+	});
+
+	it("uses the bottom-sheet drawer on mobile", () => {
+		matches.mockReturnValue(false);
+		const onPick = vi.fn();
+		render(<NoteMenu mode="rendered" title="note" onPick={onPick} />);
+		fireEvent.click(screen.getByRole("button", { name: "Note options" }));
+		// The drawer renders its own backdrop; the dropdown does not.
+		expect(screen.getByTestId("action-drawer-backdrop")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		expect(onPick).toHaveBeenCalledWith("delete");
+	});
+
+	it("closes the drawer after a pick", () => {
+		matches.mockReturnValue(false);
+		render(<NoteMenu mode="rendered" title="note" onPick={vi.fn()} />);
+		fireEvent.click(screen.getByRole("button", { name: "Note options" }));
+		fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+		expect(screen.queryByTestId("action-drawer-backdrop")).not.toBeInTheDocument();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test -- note-menu`
+Expected: FAIL — cannot resolve `./note-menu`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `frontend/src/viewer/note-menu.tsx`:
+
+```tsx
+import { MoreVertical } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { ActionDrawer } from "./tree-actions/action-drawer";
+import { ACTION_ICONS, type ActionId, noteMenuActions, type ViewMode } from "./tree-actions/action-list";
+
+interface Props {
+	mode: ViewMode;
+	/** Shown as the drawer's heading on mobile. */
+	title: string;
+	onPick: (id: ActionId) => void;
+}
+
+/**
+ * The note page's kebab. Desktop gets a dropdown; mobile gets the same
+ * bottom-sheet the file tree already uses on long-press, so the two menu
+ * surfaces in the app behave identically on touch.
+ */
+export function NoteMenu({ mode, title, onPick }: Props) {
+	const isDesktop = useMediaQuery("(min-width: 768px)");
+	const [drawerOpen, setDrawerOpen] = useState(false);
+	const actions = noteMenuActions(mode);
+
+	if (!isDesktop) {
+		return (
+			<>
+				<Button
+					variant="ghost"
+					size="icon"
+					aria-label="Note options"
+					onClick={() => setDrawerOpen(true)}
+				>
+					<MoreVertical className="size-4" />
+				</Button>
+				{drawerOpen ? (
+					<ActionDrawer
+						title={title}
+						actions={actions}
+						onPick={onPick}
+						onClose={() => setDrawerOpen(false)}
+					/>
+				) : null}
+			</>
+		);
+	}
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="ghost" size="icon" aria-label="Note options">
+					<MoreVertical className="size-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				{actions.map((action, i) => {
+					const Icon = ACTION_ICONS[action.id];
+					// Separate the view-mode group from the file actions, and the
+					// destructive one from everything above it.
+					const separatorBefore = action.id === "rename" || action.destructive;
+					return (
+						<div key={action.id} className="contents">
+							{separatorBefore && i > 0 ? <DropdownMenuSeparator /> : null}
+							<DropdownMenuItem
+								// aria-current rather than a checkbox item: the modes are a
+								// single-select group, and this keeps one code path for
+								// every row in the menu.
+								aria-current={action.active ? "true" : undefined}
+								variant={action.destructive ? "destructive" : "default"}
+								onSelect={() => onPick(action.id)}
+							>
+								<Icon aria-hidden="true" className="size-4" />
+								{action.label}
+							</DropdownMenuItem>
+						</div>
+					);
+				})}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test -- note-menu`
+Expected: PASS (4 tests).
+
+If `DropdownMenuItem` rejects `variant="default"`, drop the prop entirely and keep only `variant="destructive"` when `action.destructive` is set — check the component's own prop types in `components/ui/dropdown-menu.tsx` rather than guessing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/viewer/note-menu.tsx frontend/src/viewer/note-menu.test.tsx
+git commit -m "feat(editor): add NoteMenu kebab component"
+```
+
+---
+
+### Task 4: Hand the scrollbar to the page
+
+The substance of the unit. CodeMirror stops scrolling itself; one `ScrollArea` in `note-page.tsx` scrolls title + properties + body together, for all three modes.
+
+**Files:**
+- Modify: `frontend/src/viewer/note-editor.tsx` (editor theme; the `h-full` host div)
+- Modify: `frontend/src/viewer/note-page.tsx:166-251` (the returned JSX)
+- Test: `frontend/src/viewer/note-page.test.tsx`
+
+**Interfaces:**
+- Consumes: `InlineTitle` from Task 2.
+- Produces: the note page renders `<InlineTitle>` above the properties widget inside a single scroll container. `data-tour="note-editor"` still exists on a rendered node.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/viewer/note-page.test.tsx`:
+
+```tsx
+describe("NotePage layout", () => {
+	it("renders the note name as an inline h1, not just chrome text", async () => {
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("note"),
+		);
+	});
+
+	it("puts the title above the properties widget in document order", async () => {
+		renderPage();
+		const title = await screen.findByRole("heading", { level: 1 });
+		const properties = await screen.findByTestId("note-properties");
+		// Node.compareDocumentPosition: 4 = "properties FOLLOWS title".
+		expect(title.compareDocumentPosition(properties)).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING,
+		);
+	});
+
+	it("keeps the onboarding tour anchor present", async () => {
+		renderPage();
+		await waitFor(() =>
+			expect(document.querySelector('[data-tour="note-editor"]')).toBeInTheDocument(),
+		);
+	});
+
+	it("shows the title in reading mode too", async () => {
+		renderPage();
+		await screen.findByTestId("note-editor");
+		fireEvent.click(screen.getByRole("button", { name: "Note options" }));
+		fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
+		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("note");
+	});
+});
+```
+
+Note: the last test depends on Task 5's menu wiring. Write it now and expect it to stay red until Task 5 — or move it to Task 5 if executing strictly task-by-task. The first three must pass at the end of this task.
+
+Add `data-testid="note-properties"` to the `PropertiesWidget` root in `frontend/src/viewer/properties-widget.tsx` so the ordering assertion has a stable handle:
+
+```tsx
+<div className="border-border border-b px-5 py-3" data-testid="note-properties">
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test -- note-page`
+Expected: FAIL — no `heading` role (the title is currently an `h2` in chrome with the name inside a button).
+
+- [ ] **Step 3: Change the editor theme so CodeMirror grows**
+
+In `frontend/src/viewer/note-editor.tsx`, in the `editorTheme` object:
+
+```ts
+	// height:auto + overflow:visible hand scrolling to the page's ScrollArea, so
+	// the inline title and properties scroll with the text instead of staying
+	// pinned above it. CodeMirror still viewport-renders against the scrolling
+	// ancestor.
+	"&": { height: "auto", backgroundColor: "transparent" },
+	".cm-scroller": {
+		overflow: "visible",
+		...
+```
+
+Leave the scrollbar-styling rules in place — they become inert but cost nothing and matter again if we ever revert.
+
+Change the host div at the bottom of the file so it no longer forces full height:
+
+```tsx
+	return <div ref={hostRef} />;
+```
+
+- [ ] **Step 4: Restructure the note page JSX**
+
+In `frontend/src/viewer/note-page.tsx`, import the title component:
+
+```tsx
+import { InlineTitle } from "./inline-title";
+```
+
+Replace the entire returned JSX (currently lines 166-251) with:
+
+```tsx
+	return (
+		<section className="mx-auto flex h-full min-h-0 w-full min-w-0 max-w-[840px] flex-col overflow-hidden border-border border-x bg-card text-card-foreground md:-my-6 md:h-[calc(100%+3rem)]">
+			{syncStatus === "error" && (
+				<p role="status" className="shrink-0 bg-destructive/10 px-4 py-1 text-destructive text-xs">
+					Not syncing - reconnecting...
+				</p>
+			)}
+
+			{/* Chrome is now just the breadcrumb and the kebab — the title moved
+			    into the document so it scrolls. */}
+			<div className="flex shrink-0 items-center gap-2 border-border border-b px-4 py-2">
+				<p className="min-w-0 flex-1 truncate text-muted-foreground text-sm" title={titlePath}>
+					{note.folder ? `${note.folder}/` : ""}
+				</p>
+			</div>
+
+			{mode !== "reading" && handle ? (
+				<EditorToolbar getView={() => editorViewRef.current} />
+			) : null}
+
+			<ScrollArea className="min-h-0 flex-1">
+				<div className="w-full pb-5" data-tour="note-editor">
+					<InlineTitle
+						name={name}
+						renaming={renamingFor === note.id}
+						onStartRename={() => setRenamingFor(note.id)}
+						onCommitRename={commitRename}
+						onCancelRename={() => setRenamingFor(null)}
+					/>
+
+					{handle && mode === "rendered" ? <PropertiesWidget doc={handle.doc} /> : null}
+					{handle && mode === "raw" ? <RawFrontmatterEditor doc={handle.doc} /> : null}
+
+					{mode === "reading" ? (
+						<div className="px-5 pt-2">
+							<NoteView content={liveContent} tags={note.tags} />
+						</div>
+					) : (
+						<Suspense fallback={<p className="px-5 py-5 text-muted-foreground">Loading editor…</p>}>
+							{handle ? (
+								<NoteEditor
+									ytext={handle.ytext}
+									awareness={handle.awareness}
+									mode={mode === "raw" ? "raw" : "rendered"}
+									resolveWikiLink={resolveWikiLink}
+									onView={(v) => {
+										editorViewRef.current = v;
+									}}
+								/>
+							) : (
+								<p className="px-5 py-5 text-muted-foreground">Connecting…</p>
+							)}
+						</Suspense>
+					)}
+				</div>
+			</ScrollArea>
+		</section>
+	);
+```
+
+The kebab is not wired yet — Task 5 adds it to the chrome bar. `MODES`, the `fieldset` of mode buttons, and the `Button` import all disappear in Task 5, not here; leaving them briefly unused is fine mid-task but must be gone before Task 5's commit.
+
+- [ ] **Step 5: Run the full frontend suite**
+
+Run: `bun run test`
+Expected: the three layout tests pass. `note-editor.test.tsx` must stay green. Investigate any other failure rather than adjusting the assertion — a test that broke here is telling you the restructure changed real behaviour.
+
+- [ ] **Step 6: Verify scrolling by hand**
+
+The two risks in the spec are not test-detectable in jsdom. With the dev stack running (`make dev-selfhost` from the workspace root, browse `http://127.0.0.1:5173`):
+
+1. Open a long note (paste ~500 lines). Confirm the title scrolls out of view, scrolling is smooth, and there is exactly one scrollbar on the note column.
+2. Click into the editor, hold the down arrow past the bottom edge. Confirm the container follows the caret. If it does not, CodeMirror is not finding the Radix viewport as its scroll parent — record the finding and stop; the fallback is the block-widget approach in the spec.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/viewer/note-page.tsx frontend/src/viewer/note-editor.tsx frontend/src/viewer/properties-widget.tsx frontend/src/viewer/note-page.test.tsx
+git commit -m "feat(editor): scroll title and properties with content"
+```
+
+---
+
+### Task 5: Wire the kebab into the note page
+
+**Files:**
+- Modify: `frontend/src/viewer/note-page.tsx`
+- Test: `frontend/src/viewer/note-page.test.tsx`
+
+**Interfaces:**
+- Consumes: `NoteMenu` (Task 3); `MoveDialog`, `DeleteConfirm`, `nextCopyName` from `./tree-actions/*`; `addKey` from `../crdt/frontmatter-doc`; `useBatchMoveNotes`, `useDeleteNote`, `useDuplicateNote`, `useFolders` from `../api/queries`.
+- Produces: the three mode buttons are gone from the chrome; every kebab action is handled.
+
+- [ ] **Step 1: Extend the test mocks, then write the failing tests**
+
+The existing `../api/queries` mock exports only `useNote` and `useRenameNote`; adding hooks to the component without adding them here throws. Replace that mock block in `frontend/src/viewer/note-page.test.tsx`:
+
+```tsx
+const useNoteMock = vi.fn();
+const { renameNoteMutate, deleteNoteMutate, duplicateNoteMutate, batchMoveMutate } = vi.hoisted(
+	() => ({
+		renameNoteMutate: vi.fn(),
+		deleteNoteMutate: vi.fn(),
+		duplicateNoteMutate: vi.fn(),
+		batchMoveMutate: vi.fn(),
+	}),
+);
+vi.mock("../api/queries", () => ({
+	useNote: (...a: unknown[]) => useNoteMock(...a),
+	useRenameNote: () => ({ mutate: renameNoteMutate, isPending: false }),
+	useDeleteNote: () => ({ mutate: deleteNoteMutate, isPending: false }),
+	useDuplicateNote: () => ({ mutateAsync: duplicateNoteMutate, isPending: false }),
+	useBatchMoveNotes: () => ({ mutate: batchMoveMutate, isPending: false }),
+	useFolders: () => ({ data: [{ name: "folder" }, { name: "other" }], isLoading: false }),
+}));
+vi.mock("react-router", () => ({
+	useParams: () => ({ itemId: "note-1", slug: "my-vault" }),
+	useNavigate: () => navigateMock,
+	useLocation: () => locationMock(),
+}));
+```
+
+Add the two new mocks alongside the others. **Both must go through `vi.hoisted`** — `vi.mock` factories are hoisted above plain `const` declarations, so a non-hoisted `locationMock` throws "Cannot access before initialization" at import time:
+
+```tsx
+const { navigateMock, locationMock } = vi.hoisted(() => ({
+	navigateMock: vi.fn(),
+	locationMock: vi.fn(() => ({ pathname: "/my-vault/note-1", state: null })),
+}));
+```
+
+Then append the behaviour tests:
+
+```tsx
+describe("NotePage kebab", () => {
+	const openMenu = async () => {
+		await screen.findByTestId("note-editor");
+		fireEvent.click(screen.getByRole("button", { name: "Note options" }));
+	};
+
+	it("switches view mode from the menu", async () => {
+		renderPage();
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
+		expect(screen.getByTestId("note-view")).toBeInTheDocument();
+	});
+
+	it("no longer shows the old mode buttons in the header", async () => {
+		renderPage();
+		await screen.findByTestId("note-editor");
+		expect(screen.queryByRole("button", { name: "Rendered" })).not.toBeInTheDocument();
+	});
+
+	it("starts a rename from the menu", async () => {
+		renderPage();
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+		expect(screen.getByRole("textbox")).toHaveValue("note");
+	});
+
+	it("duplicates with a collision-safe name", async () => {
+		duplicateNoteMutate.mockResolvedValue({ id: "n2", path: "folder/note 1.md" });
+		renderPage();
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
+		expect(duplicateNoteMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ src_path: "folder/note.md" }),
+		);
+	});
+
+	it("moves the note to the folder picked in the dialog", async () => {
+		renderPage();
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Move to…" }));
+		fireEvent.click(await screen.findByRole("option", { name: "other" }));
+		expect(batchMoveMutate).toHaveBeenCalledWith({
+			ids: ["note-1"],
+			target_folder: "other",
+			paths: { "note-1": "folder/note.md" },
+		});
+	});
+
+	it("deletes only after confirmation, then leaves the dead route", async () => {
+		renderPage();
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		expect(deleteNoteMutate).not.toHaveBeenCalled();
+		fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
+		expect(deleteNoteMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "note-1", path: "folder/note.md" }),
+		);
+		expect(navigateMock).toHaveBeenCalledWith("/my-vault");
+	});
+
+	it("adds a property to the frontmatter doc", async () => {
+		renderPage();
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
+		expect(await screen.findByTestId("note-properties")).toHaveTextContent("new-property");
+	});
+});
+```
+
+Check `MoveDialog`'s rendered roles before finalising the move test — if its folder rows are not `option`, match what the component actually renders rather than changing the component.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun run test -- note-page`
+Expected: FAIL — no "Note options" button.
+
+- [ ] **Step 3: Implement**
+
+Add imports to `frontend/src/viewer/note-page.tsx`:
+
+```tsx
+import { useLocation, useNavigate, useParams } from "react-router";
+import { toast } from "sonner";
+import {
+	useBatchMoveNotes,
+	useDeleteNote,
+	useDuplicateNote,
+	useFolders,
+	useNote,
+	useRenameNote,
+} from "../api/queries";
+import { addKey } from "../crdt/frontmatter-doc";
+import { NoteMenu } from "./note-menu";
+import type { ActionId } from "./tree-actions/action-list";
+import { DeleteConfirm } from "./tree-actions/delete-confirm";
+import { nextCopyName } from "./tree-actions/duplicate";
+import { MoveDialog } from "./tree-actions/move-dialog";
+```
+
+Add state and hooks next to the existing ones:
+
+```tsx
+	const navigate = useNavigate();
+	const slug = params.slug;
+	const { data: folders } = useFolders();
+	const deleteNote = useDeleteNote();
+	const duplicateNote = useDuplicateNote();
+	const batchMoveNotes = useBatchMoveNotes();
+	const [dialog, setDialog] = useState<"move" | "delete" | null>(null);
+```
+
+Add the handler below `commitRename`:
+
+```tsx
+	// Deliberately NOT shared with folder-tree.tsx's handleActionPick: that one
+	// is welded to tree state (getItemInstance().startRenaming(), rowsFor, its
+	// own dialog reducer). The portable parts — the action list and the dialog
+	// components — are already reused. See the design spec.
+	const handleAction = (action: ActionId) => {
+		switch (action) {
+			case "view-rendered":
+				setMode("rendered");
+				break;
+			case "view-raw":
+				setMode("raw");
+				break;
+			case "view-reading":
+				setMode("reading");
+				break;
+			case "rename":
+				setRenamingFor(note.id);
+				break;
+			case "move":
+				setDialog("move");
+				break;
+			case "delete":
+				setDialog("delete");
+				break;
+			case "duplicate": {
+				// No reliable sibling-name set on hand — pass an empty Set and let the
+				// backend reject a collision; the toast surfaces it. Mirrors the tree.
+				const new_path = nextCopyName(note.path, new Set<string>());
+				duplicateNote
+					.mutateAsync({ src_path: note.path, new_path })
+					.then(() => toast.success("Duplicated"))
+					.catch(() => toast.error("Duplicate failed"));
+				break;
+			}
+			case "copy-wikilink":
+				// Wikilinks resolve by filename in Obsidian, never by H1 title.
+				navigator.clipboard
+					.writeText(`[[${name || note.path}]]`)
+					.then(() => toast.success("Copied wikilink"))
+					.catch(() => toast.error("Copy failed"));
+				break;
+			case "add-property":
+				if (handle) {
+					addKey(handle.doc, "new-property", "text");
+				}
+				break;
+			default:
+				break;
+		}
+	};
+```
+
+Put the kebab in the chrome bar, after the breadcrumb paragraph:
+
+```tsx
+				<NoteMenu mode={mode} title={name} onPick={handleAction} />
+```
+
+Render the dialogs just before the closing `</section>`:
+
+```tsx
+			{dialog === "move" ? (
+				<MoveDialog
+					folders={folders ?? []}
+					nodes={[{ kind: "file", path: note.path }]}
+					onPick={(folder) => {
+						setDialog(null);
+						batchMoveNotes.mutate({
+							ids: [note.id],
+							target_folder: folder,
+							paths: { [note.id]: note.path },
+						});
+					}}
+					onCancel={() => setDialog(null)}
+				/>
+			) : null}
+
+			{dialog === "delete" ? (
+				<DeleteConfirm
+					nodes={[{ kind: "file", path: note.path }]}
+					onConfirm={() => {
+						setDialog(null);
+						deleteNote.mutate({ id: note.id, path: note.path });
+						// useDeleteNote does not navigate — from the tree the deleted note
+						// usually isn't open, but here it is, so staying would strand the
+						// user on a dead route.
+						navigate(slug ? `/${slug}` : "/");
+					}}
+					onCancel={() => setDialog(null)}
+				/>
+			) : null}
+```
+
+Delete the now-dead `MODES` constant, the `fieldset` of mode buttons, and the `Button` import if nothing else uses it.
+
+Also replace the file-local `type Mode = "rendered" | "raw" | "reading"` with the shared `ViewMode` from `./tree-actions/action-list`, and use it for the `useState<ViewMode>` declaration. The two are structurally identical so TypeScript accepts either, which is exactly why they will drift if both survive:
+
+```tsx
+import { type ActionId, type ViewMode } from "./tree-actions/action-list";
+// ...
+const [mode, setMode] = useState<ViewMode>("rendered");
+```
+
+Confirm `MoveDialog`'s `nodes` prop accepts `{ kind: "file", path }` — check `MoveNode` in `move-path.ts` and match its actual shape.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun run test`
+Expected: PASS. Also run `bun run test -- folder-tree` explicitly — Task 1 touched shared types.
+
+- [ ] **Step 5: Lint**
+
+Run: `./node_modules/.bin/biome ci .`
+Expected: clean. Do not use `bunx biome`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/viewer/note-page.tsx frontend/src/viewer/note-page.test.tsx
+git commit -m "feat(editor): move view modes and file actions into kebab"
+```
+
+---
+
+### Task 6: New note opens with its title selected
+
+**Files:**
+- Modify: `frontend/src/api/queries.ts:682`
+- Modify: `frontend/src/viewer/note-page.tsx`
+- Test: `frontend/src/viewer/note-page.test.tsx`
+
+**Interfaces:**
+- Consumes: `InlineTitle`'s `renaming` prop (Task 2); `useLocation` (mocked in Task 5).
+- Produces: navigation state `{ justCreated: true }` set by `useCreateNote`, consumed once by the note page.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `frontend/src/viewer/note-page.test.tsx`:
+
+```tsx
+describe("NotePage new-note rename", () => {
+	it("opens the title in rename mode when navigated to as just-created", async () => {
+		locationMock.mockReturnValue({
+			pathname: "/my-vault/note-1",
+			state: { justCreated: true },
+		});
+		renderPage();
+		const input = (await screen.findByRole("textbox")) as HTMLInputElement;
+		expect(input.value).toBe("note");
+		expect(input.selectionStart).toBe(0);
+		expect(input.selectionEnd).toBe("note".length);
+	});
+
+	it("clears the flag so a back-navigation does not reopen the rename box", async () => {
+		locationMock.mockReturnValue({
+			pathname: "/my-vault/note-1",
+			state: { justCreated: true },
+		});
+		renderPage();
+		await screen.findByRole("textbox");
+		expect(navigateMock).toHaveBeenCalledWith("/my-vault/note-1", {
+			replace: true,
+			state: {},
+		});
+	});
+
+	it("does not start renaming on an ordinary navigation", async () => {
+		locationMock.mockReturnValue({ pathname: "/my-vault/note-1", state: null });
+		renderPage();
+		await screen.findByTestId("note-editor");
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+	});
+});
+```
+
+Add a `locationMock.mockReturnValue({ pathname: "/my-vault/note-1", state: null })` reset to the top-level `beforeEach` so these cases don't leak into earlier tests.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun run test -- note-page`
+Expected: FAIL — no textbox; the title renders as a button.
+
+- [ ] **Step 3: Set the flag at the single creation seam**
+
+In `frontend/src/api/queries.ts`, in `useCreateNote`'s `onSuccess` (line ~682):
+
+```ts
+			// `justCreated` puts the note page's inline title straight into rename
+			// mode with "Untitled" selected. Carried as navigation state rather than
+			// a context because it must fire exactly once, and router state is
+			// already scoped to a single navigation. Both creation entry points (the
+			// tree's context menu and the sidebar button) route through here.
+			navigate(slug ? `/${slug}/${id}` : `/note/${id}`, { state: { justCreated: true } });
+```
+
+- [ ] **Step 4: Consume it once in the note page**
+
+In `frontend/src/viewer/note-page.tsx`, add below the other effects:
+
+```tsx
+	// Consume the just-created flag exactly once: start renaming, then strip the
+	// state so a later back-navigation to this history entry doesn't reopen the
+	// rename box on a note the user already named.
+	const location = useLocation();
+	const justCreated = Boolean((location.state as { justCreated?: boolean } | null)?.justCreated);
+	useEffect(() => {
+		if (!(justCreated && noteId)) {
+			return;
+		}
+		setRenamingFor(noteId);
+		navigate(location.pathname, { replace: true, state: {} });
+	}, [justCreated, noteId, navigate, location.pathname]);
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `bun run test`
+Expected: PASS, all 1166+ tests.
+
+- [ ] **Step 6: Verify by hand**
+
+With the dev stack running, click "New note" in the sidebar and again from the tree's right-click. In both cases the note opens with the title in an input, "Untitled" selected, and typing replaces it.
+
+- [ ] **Step 7: Lint, then commit**
+
+```bash
+./node_modules/.bin/biome ci .
+git add frontend/src/api/queries.ts frontend/src/viewer/note-page.tsx frontend/src/viewer/note-page.test.tsx
+git commit -m "feat(editor): open new notes with the title selected"
+```
+
+---
+
+### Task 7: Final verification and PR
+
+- [ ] **Step 1: Full suite from a clean state**
+
+```bash
+cd frontend && bun run test 2>&1 | tail -5
+```
+
+Expected: 0 failures. The baseline was 167 files / 1166 tests; the count should have grown, never shrunk.
+
+- [ ] **Step 2: Lint and typecheck**
+
+```bash
+./node_modules/.bin/biome ci .
+bun run build   # tsc runs as part of the production build
+```
+
+- [ ] **Step 3: Manual pass against the spec's risk list**
+
+1. Long note scrolls smoothly, one scrollbar, title scrolls away.
+2. Caret arrow-key past the bottom edge scrolls the container.
+3. Onboarding tour still anchors (`[data-tour="note-editor"]` present and visible).
+4. Mobile viewport (DevTools device emulation, <768px): kebab opens the bottom sheet, every action works.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/note-header-inline-title-kebab
+gh pr create --title "feat(editor): Obsidian-style inline title and kebab menu" --body "..."
+```
+
+Body should link the spec, list what shipped, and state explicitly that Unit B (toolbar) and Unit C (frontmatter on demand) are deliberately not in this PR.
+
+---
+
+## Notes for the implementer
+
+- **Do not** try to unify `handleAction` with `folder-tree.tsx`'s `handleActionPick`. The duplication is deliberate and documented in the spec.
+- If CodeMirror's `height: auto` causes visible stutter on a long note, stop and report. The fallback (rendering title and properties as CodeMirror block widgets at position 0) is a different task, not an in-place patch.
+- The `../api/queries` and `react-router` mocks in `note-page.test.tsx` are module-level. Any hook you add to the component must be added to the mock in the same commit, or every test in the file fails at import time with a confusing error.

--- a/frontend/e2e/note-properties.spec.ts
+++ b/frontend/e2e/note-properties.spec.ts
@@ -127,11 +127,17 @@ async function signInForNote(
 }
 
 /**
- * Wait for the PropertiesWidget to show the given key (the <dt> text) so we
- * know the CRDT frontmatter maps have been seeded from the backend.
+ * Wait for the PropertiesWidget to show the given key so we know the CRDT
+ * frontmatter maps have been seeded from the backend.
+ *
+ * Matched on the rename box's accessible name, NOT the <dt>'s text: the key is
+ * an editable input now, and an input's value is not text content, so a
+ * hasText filter over the <dt> matches nothing however well the widget works.
  */
 async function waitForProperty(page: Page, key: string): Promise<void> {
-	await expect(page.getByRole("term").filter({ hasText: key })).toBeVisible({ timeout: 10_000 });
+	await expect(page.getByRole("textbox", { name: `Rename ${key}` })).toBeVisible({
+		timeout: 10_000,
+	});
 }
 
 test.describe("PropertiesWidget e2e", () => {
@@ -204,10 +210,11 @@ test.describe("PropertiesWidget e2e", () => {
 		// Wait for the PropertiesWidget to render the "due" property.
 		await waitForProperty(page, "due");
 
-		// Verify the initial inferred type is "text" (the trigger label shows the current type).
+		// Verify the initial inferred type is "text". The trigger is an icon now, so
+		// the current type rides in its accessible name rather than its text.
 		const row = page.getByTestId("property-row-due");
-		const typeButton = row.getByRole("button", { name: "Property type" });
-		await expect(typeButton).toHaveText("text", { timeout: 5000 });
+		const typeButton = row.getByRole("button", { name: /^Property type/ });
+		await expect(typeButton).toHaveAccessibleName("Property type: text", { timeout: 5000 });
 
 		// Open the type dropdown and select "date".
 		await typeButton.click();
@@ -215,7 +222,7 @@ test.describe("PropertiesWidget e2e", () => {
 
 		// After override: the type button should now read "date" and the value
 		// input should be type="date" (the ScalarField renders htmlType="date").
-		await expect(typeButton).toHaveText("date", { timeout: 5000 });
+		await expect(typeButton).toHaveAccessibleName("Property type: date", { timeout: 5000 });
 		const dateInput = row.locator('dd input[type="date"]');
 		await expect(dateInput).toBeVisible({ timeout: 5000 });
 
@@ -230,8 +237,10 @@ test.describe("PropertiesWidget e2e", () => {
 		// The type override stored in Y.Map("frontmatter_types") should still be "date".
 		// If this assertion fails it is a real persistence bug — do NOT weaken it.
 		const rowAfter = page.getByTestId("property-row-due");
-		const typeButtonAfter = rowAfter.getByRole("button", { name: "Property type" });
-		await expect(typeButtonAfter).toHaveText("date", { timeout: 10_000 });
+		const typeButtonAfter = rowAfter.getByRole("button", { name: /^Property type/ });
+		await expect(typeButtonAfter).toHaveAccessibleName("Property type: date", {
+			timeout: 10_000,
+		});
 		const dateInputAfter = rowAfter.locator('dd input[type="date"]');
 		await expect(dateInputAfter).toBeVisible({ timeout: 5000 });
 

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1057,7 +1057,12 @@ describe("useCreateNote — optimistic placeholder", () => {
 			await result.current.mutateAsync({ folder: "", id: MINTED_ID });
 		});
 
-		expect(navigateSpy).toHaveBeenCalledWith(`/work/${MINTED_ID}`);
+		// The `justCreated` state is what puts the note page's inline title into
+		// rename mode with "Untitled" selected — part of the create contract, not
+		// incidental, so assert it rather than loosening to the path alone.
+		expect(navigateSpy).toHaveBeenCalledWith(`/work/${MINTED_ID}`, {
+			state: { justCreated: true },
+		});
 	});
 
 	// `/api/folders` returns DERIVED folders (ones holding no note directly) with

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -679,7 +679,12 @@ export function useCreateNote() {
 			const slug = qc
 				.getQueryData<{ vaults: Vault[] }>(["vaults"])
 				?.vaults?.find((v) => v.id === vaultId)?.slug;
-			navigate(slug ? `/${slug}/${id}` : `/note/${id}`);
+			// `justCreated` puts the note page's inline title straight into rename
+			// mode with "Untitled" selected. Carried as navigation state rather than
+			// a context because it must fire exactly once, and router state is
+			// already scoped to a single navigation. Both creation entry points (the
+			// tree's context menu and the sidebar button) route through here.
+			navigate(slug ? `/${slug}/${id}` : `/note/${id}`, { state: { justCreated: true } });
 		},
 		onError: (err, _vars, ctx) => {
 			if (ctx) {

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -32,7 +32,12 @@ function DropdownMenuContent({
 				sideOffset={sideOffset}
 				align={align}
 				className={cn(
-					"data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-closed:animate-out data-open:animate-in data-[state=closed]:overflow-hidden",
+					// No width pinned to the trigger: every menu here but the vault
+					// switcher hangs off an icon button, so matching the trigger left
+					// them all at the min-w-32 floor and wrapped any label longer than
+					// that. Menus size to their content; the switcher, which wants to
+					// line up with its full-width trigger, asks for that explicitly.
+					"data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-y-auto overflow-x-hidden whitespace-nowrap rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-closed:animate-out data-open:animate-in data-[state=closed]:overflow-hidden",
 					className,
 				)}
 				{...props}

--- a/frontend/src/crdt/frontmatter-doc.test.ts
+++ b/frontend/src/crdt/frontmatter-doc.test.ts
@@ -13,6 +13,7 @@ import {
 	readRaws,
 	readRows,
 	removeKey,
+	renameKey,
 	setType,
 	setValue,
 	sortRowsOkfFirst,
@@ -103,6 +104,40 @@ describe("frontmatter-doc mutations", () => {
 		expect(readRows(doc).map((r) => r.key)).toEqual(["b", "a"]);
 		moveKey(doc, "b", "up");
 		expect(readRows(doc).map((r) => r.key)).toEqual(["b", "a"]);
+	});
+
+	test("renameKey keeps the value, the type and the position", () => {
+		const doc = new Y.Doc();
+		addKey(doc, "a", "text");
+		addKey(doc, "status", "list");
+		addKey(doc, "z", "text");
+		setValue(doc, "status", ["draft"]);
+
+		expect(renameKey(doc, "status", "state")).toBe(true);
+
+		const rows = readRows(doc);
+		// Renaming is not remove-then-add: it must not fall to the end.
+		expect(rows.map((r) => r.key)).toEqual(["a", "state", "z"]);
+		const renamed = rows.find((r) => r.key === "state");
+		expect(renamed?.value).toEqual(["draft"]);
+		expect(renamed?.typeOverride).toBe("list");
+	});
+
+	test("renameKey refuses an empty, unchanged or colliding name", () => {
+		const doc = new Y.Doc();
+		addKey(doc, "a", "text");
+		addKey(doc, "b", "text");
+		expect(renameKey(doc, "a", "   ")).toBe(false);
+		expect(renameKey(doc, "a", "b")).toBe(false);
+		expect(renameKey(doc, "a", "a")).toBe(false);
+		expect(readRows(doc).map((r) => r.key)).toEqual(["a", "b"]);
+	});
+
+	test("renameKey trims, so a stray space cannot mint a second property", () => {
+		const doc = new Y.Doc();
+		addKey(doc, "a", "text");
+		expect(renameKey(doc, "a", "  b  ")).toBe(true);
+		expect(readRows(doc).map((r) => r.key)).toEqual(["b"]);
 	});
 
 	test("setType coerces the stored value", () => {

--- a/frontend/src/crdt/frontmatter-doc.test.ts
+++ b/frontend/src/crdt/frontmatter-doc.test.ts
@@ -123,6 +123,31 @@ describe("frontmatter-doc mutations", () => {
 		expect(renamed?.typeOverride).toBe("list");
 	});
 
+	// A degraded key lives in `order` + the raw map and deliberately NOT in
+	// `values`, so a collision check that only consults `values` waves it
+	// through: `order` ends up with the name twice, the raw wins in
+	// emitFrontmatter, and the renamed property's value is gone from the note.
+	test("renameKey refuses a name held by a degraded key", () => {
+		const doc = new Y.Doc();
+		addKey(doc, "good", "text");
+		setValue(doc, "good", "keepme");
+		rawMap(doc).set("weird", "weird: !!binary |\n  Zm9v\n");
+		frontmatterMaps(doc).order.push(["weird"]);
+
+		expect(renameKey(doc, "good", "weird")).toBe(false);
+		expect(frontmatterMaps(doc).order.toArray()).toEqual(["good", "weird"]);
+		expect(readRows(doc).find((r) => r.key === "good")?.value).toBe("keepme");
+	});
+
+	test("addKey refuses a name held by a degraded key", () => {
+		const doc = new Y.Doc();
+		rawMap(doc).set("weird", "weird: !!binary |\n  Zm9v\n");
+		frontmatterMaps(doc).order.push(["weird"]);
+
+		expect(addKey(doc, "weird", "text")).toBe(false);
+		expect(frontmatterMaps(doc).order.toArray()).toEqual(["weird"]);
+	});
+
 	test("renameKey refuses an empty, unchanged or colliding name", () => {
 		const doc = new Y.Doc();
 		addKey(doc, "a", "text");

--- a/frontend/src/crdt/frontmatter-doc.ts
+++ b/frontend/src/crdt/frontmatter-doc.ts
@@ -94,6 +94,42 @@ export function removeKey(doc: Y.Doc, key: string): void {
 	});
 }
 
+/**
+ * Rename a property, keeping its value, its type and where it sits.
+ *
+ * Deliberately NOT removeKey + addKey: that would drop the value and push the
+ * property to the end of the order, so renaming a key would silently reshuffle
+ * the frontmatter. One transaction, so peers never observe the old and new
+ * names at once.
+ */
+export function renameKey(doc: Y.Doc, from: string, to: string): boolean {
+	const trimmed = to.trim();
+	const { values, order, types } = frontmatterMaps(doc);
+	if (trimmed === "" || trimmed === from || !values.has(from) || values.has(trimmed)) {
+		return false;
+	}
+	doc.transact(() => {
+		const value = values.get(from);
+		const type = types.get(from);
+		if (value !== undefined) {
+			values.set(trimmed, value);
+		}
+		if (type !== undefined) {
+			types.set(trimmed, type);
+		}
+		values.delete(from);
+		types.delete(from);
+		const idx = order.toArray().indexOf(from);
+		if (idx >= 0) {
+			order.delete(idx, 1);
+			order.insert(idx, [trimmed]);
+		} else {
+			order.push([trimmed]);
+		}
+	});
+	return true;
+}
+
 export function moveKey(doc: Y.Doc, key: string, dir: "up" | "down"): void {
 	const { order } = frontmatterMaps(doc);
 	const arr = order.toArray();

--- a/frontend/src/crdt/frontmatter-doc.ts
+++ b/frontend/src/crdt/frontmatter-doc.ts
@@ -15,6 +15,20 @@ const EMPTY_DEFAULT: Record<PropertyType, unknown> = {
 // spec order. Custom keys follow in their user-defined order.
 const OKF_KEY_ORDER = ["type", "description", "resource", "timestamp", "created", "tags"] as const;
 
+/**
+ * Is this name already spoken for?
+ *
+ * Checking `values` alone is NOT enough: a DEGRADED key — one whose YAML we
+ * could not model, kept verbatim — lives in `order` and the raw map and
+ * deliberately never appears in `values`. Waving one of those through puts the
+ * name in `order` twice, and since `emitFrontmatter` gives raws precedence the
+ * other property's value stops being emitted at all. That corruption then
+ * materialises and syncs out to the vault.
+ */
+function isTaken(doc: Y.Doc, key: string): boolean {
+	return frontmatterMaps(doc).values.has(key) || rawMap(doc).has(key);
+}
+
 export const CONTENT_KEY = "content";
 export const FRONTMATTER_KEY = "frontmatter";
 export const ORDER_KEY = "frontmatter_order";
@@ -71,7 +85,7 @@ export function addKey(doc: Y.Doc, key: string, type: PropertyType): boolean {
 		return false;
 	}
 	const { values, order, types } = frontmatterMaps(doc);
-	if (values.has(trimmed)) {
+	if (isTaken(doc, trimmed)) {
 		return false;
 	}
 	doc.transact(() => {
@@ -105,7 +119,7 @@ export function removeKey(doc: Y.Doc, key: string): void {
 export function renameKey(doc: Y.Doc, from: string, to: string): boolean {
 	const trimmed = to.trim();
 	const { values, order, types } = frontmatterMaps(doc);
-	if (trimmed === "" || trimmed === from || !values.has(from) || values.has(trimmed)) {
+	if (trimmed === "" || trimmed === from || !values.has(from) || isTaken(doc, trimmed)) {
 		return false;
 	}
 	doc.transact(() => {

--- a/frontend/src/layout/folder-actions.test.tsx
+++ b/frontend/src/layout/folder-actions.test.tsx
@@ -118,7 +118,9 @@ describe("FolderActions", () => {
 			expect(crdtCreateNote).toHaveBeenCalled();
 		});
 		const mintedId = crdtCreateNote.mock.calls[0]?.[0];
-		expect(navigate).toHaveBeenCalledWith(`/note/${mintedId}`);
+		expect(navigate).toHaveBeenCalledWith(`/note/${mintedId}`, {
+			state: { justCreated: true },
+		});
 	});
 
 	it("opens the upload flow targeting the vault root when Upload is clicked", () => {

--- a/frontend/src/lib/clipboard.test.ts
+++ b/frontend/src/lib/clipboard.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { copyToClipboard } from "./clipboard";
+
+const realClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+function setClipboard(value: unknown) {
+	Object.defineProperty(navigator, "clipboard", { value, configurable: true });
+}
+
+afterEach(() => {
+	if (realClipboard) {
+		Object.defineProperty(navigator, "clipboard", realClipboard);
+	} else {
+		setClipboard(undefined);
+	}
+	vi.restoreAllMocks();
+});
+
+describe("copyToClipboard", () => {
+	test("uses the async clipboard API when it is available", async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		setClipboard({ writeText });
+
+		await expect(copyToClipboard("[[note]]")).resolves.toBe(true);
+		expect(writeText).toHaveBeenCalledWith("[[note]]");
+	});
+
+	// The self-host case: a LAN box on plain http is a non-secure origin, where
+	// the whole `navigator.clipboard` namespace is absent. Reaching through it
+	// throws synchronously, so a caller's .catch() never sees the failure.
+	test("falls back to execCommand when there is no clipboard namespace", async () => {
+		setClipboard(undefined);
+		const execCommand = vi.fn().mockReturnValue(true);
+		document.execCommand = execCommand;
+
+		await expect(copyToClipboard("[[note]]")).resolves.toBe(true);
+		expect(execCommand).toHaveBeenCalledWith("copy");
+	});
+
+	test("falls back when the async API rejects", async () => {
+		setClipboard({ writeText: vi.fn().mockRejectedValue(new Error("denied")) });
+		const execCommand = vi.fn().mockReturnValue(true);
+		document.execCommand = execCommand;
+
+		await expect(copyToClipboard("[[note]]")).resolves.toBe(true);
+		expect(execCommand).toHaveBeenCalled();
+	});
+
+	// Reporting a copy that did not happen is worse than reporting a failure —
+	// the user walks away believing the link is on their clipboard.
+	test("reports failure rather than throwing when nothing works", async () => {
+		setClipboard(undefined);
+		document.execCommand = vi.fn().mockReturnValue(false);
+
+		await expect(copyToClipboard("[[note]]")).resolves.toBe(false);
+	});
+});

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,41 @@
+/**
+ * Copy text, degrading to the legacy path where the async API is unavailable.
+ *
+ * `navigator.clipboard` does not exist on a NON-SECURE ORIGIN, which is the
+ * normal case for self-host: a box on the LAN served over plain http. Reaching
+ * straight for `navigator.clipboard.writeText` there throws a synchronous
+ * TypeError off the undefined namespace — a `.catch()` on the call never runs,
+ * because no promise was ever created — so the copy did not merely fail, it
+ * escaped as an uncaught error.
+ *
+ * Returns whether the text landed, rather than throwing, so callers can report
+ * honestly instead of claiming success they cannot see.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch {
+			// Permission denied or a non-focused document — the legacy path below
+			// is still worth a try.
+		}
+	}
+
+	try {
+		const ta = document.createElement("textarea");
+		ta.value = text;
+		ta.setAttribute("readonly", "");
+		ta.style.position = "fixed";
+		ta.style.top = "0";
+		ta.style.left = "0";
+		ta.style.opacity = "0";
+		document.body.appendChild(ta);
+		ta.select();
+		const ok = document.execCommand("copy");
+		document.body.removeChild(ta);
+		return ok;
+	} catch {
+		return false;
+	}
+}

--- a/frontend/src/settings/connections-page.tsx
+++ b/frontend/src/settings/connections-page.tsx
@@ -11,6 +11,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { useAutofocus } from "@/hooks/use-autofocus";
+import { copyToClipboard } from "@/lib/clipboard";
 import { SettingsSectionCard } from "@/settings/account/section-card";
 import { ApiError } from "../api/client";
 import {
@@ -523,34 +524,6 @@ function CopyIcon({ copied }: { copied: boolean }) {
 			<path d="M3 7a2 2 0 012-2h.5a.5.5 0 010 1H5a1 1 0 00-1 1v9a1 1 0 001 1h7a1 1 0 001-1v-.5a.5.5 0 011 0v.5a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
 		</svg>
 	);
-}
-
-async function copyToClipboard(text: string): Promise<boolean> {
-	if (navigator.clipboard?.writeText) {
-		try {
-			await navigator.clipboard.writeText(text);
-			return true;
-		} catch {
-			// fall through to legacy fallback
-		}
-	}
-
-	try {
-		const ta = document.createElement("textarea");
-		ta.value = text;
-		ta.setAttribute("readonly", "");
-		ta.style.position = "fixed";
-		ta.style.top = "0";
-		ta.style.left = "0";
-		ta.style.opacity = "0";
-		document.body.appendChild(ta);
-		ta.select();
-		const ok = document.execCommand("copy");
-		document.body.removeChild(ta);
-		return ok;
-	} catch {
-		return false;
-	}
 }
 
 function ConfirmRevokeModal({

--- a/frontend/src/viewer/editor/frontmatter-shortcut.test.ts
+++ b/frontend/src/viewer/editor/frontmatter-shortcut.test.ts
@@ -1,0 +1,96 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { frontmatterShortcut } from "./frontmatter-shortcut";
+
+let view: EditorView | null = null;
+
+afterEach(() => {
+	view?.destroy();
+	view = null;
+});
+
+const mount = (doc: string, onTrigger: () => boolean) => {
+	view = new EditorView({
+		state: EditorState.create({ doc, extensions: [frontmatterShortcut(onTrigger)] }),
+		parent: document.body,
+	});
+	return view;
+};
+
+// The fence is removed from a queued microtask — dispatching inside an
+// update listener is illegal in CodeMirror.
+const settle = () => Promise.resolve();
+
+const edit = (v: EditorView, from: number, insert: string, userEvent = "input.type") => {
+	v.dispatch({ changes: { from, insert }, userEvent });
+};
+
+describe("frontmatterShortcut", () => {
+	it("consumes a --- typed on the first line", async () => {
+		const onTrigger = vi.fn(() => true);
+		const v = mount("--", onTrigger);
+		edit(v, 2, "-");
+		await settle();
+		expect(onTrigger).toHaveBeenCalled();
+		expect(v.state.doc.toString()).toBe("");
+	});
+
+	it("takes the newline with it, leaving the body untouched", async () => {
+		const v = mount("--\nbody", () => true);
+		edit(v, 2, "-");
+		await settle();
+		expect(v.state.doc.toString()).toBe("body");
+	});
+
+	// The caller declines when the note already has frontmatter, and then the
+	// fence has to survive as an ordinary horizontal rule.
+	it("leaves the fence alone when the caller declines", async () => {
+		const onTrigger = vi.fn(() => false);
+		const v = mount("--", onTrigger);
+		edit(v, 2, "-");
+		await settle();
+		expect(onTrigger).toHaveBeenCalled();
+		expect(v.state.doc.toString()).toBe("---");
+	});
+
+	it("ignores a fence on any line but the first", async () => {
+		const onTrigger = vi.fn(() => true);
+		const v = mount("body\n--", onTrigger);
+		edit(v, 7, "-");
+		await settle();
+		expect(onTrigger).not.toHaveBeenCalled();
+		expect(v.state.doc.toString()).toBe("body\n---");
+	});
+
+	// The guard that matters most: a note whose body legitimately opens with a
+	// horizontal rule must not lose it the moment you type anywhere else.
+	it("ignores edits elsewhere in a document that already starts with ---", async () => {
+		const onTrigger = vi.fn(() => true);
+		const v = mount("---\nbody", onTrigger);
+		edit(v, 8, "!");
+		await settle();
+		expect(onTrigger).not.toHaveBeenCalled();
+		expect(v.state.doc.toString()).toBe("---\nbody!");
+	});
+
+	it("ignores pasted text", async () => {
+		const onTrigger = vi.fn(() => true);
+		const v = mount("", onTrigger);
+		edit(v, 0, "---", "input.paste");
+		await settle();
+		expect(onTrigger).not.toHaveBeenCalled();
+		expect(v.state.doc.toString()).toBe("---");
+	});
+
+	// Undo restores the fence. Re-firing there would delete it again and the
+	// two would fight forever.
+	it("ignores an undo that restores the fence", async () => {
+		const onTrigger = vi.fn(() => true);
+		const v = mount("", onTrigger);
+		edit(v, 0, "---", "undo");
+		await settle();
+		expect(onTrigger).not.toHaveBeenCalled();
+		expect(v.state.doc.toString()).toBe("---");
+	});
+});

--- a/frontend/src/viewer/editor/frontmatter-shortcut.test.ts
+++ b/frontend/src/viewer/editor/frontmatter-shortcut.test.ts
@@ -74,6 +74,18 @@ describe("frontmatterShortcut", () => {
 		expect(v.state.doc.toString()).toBe("---\nbody!");
 	});
 
+	// Pressing Enter at the END of a legitimate horizontal rule is an insertion
+	// at the line's boundary, not an edit of it. Counting that as touching line
+	// 0 deleted the rule out from under the user.
+	it("ignores an insertion at the end of an existing fence line", async () => {
+		const onTrigger = vi.fn(() => true);
+		const v = mount("---\nsome text", onTrigger);
+		edit(v, 3, "\n");
+		await settle();
+		expect(onTrigger).not.toHaveBeenCalled();
+		expect(v.state.doc.toString()).toBe("---\n\nsome text");
+	});
+
 	it("ignores pasted text", async () => {
 		const onTrigger = vi.fn(() => true);
 		const v = mount("", onTrigger);

--- a/frontend/src/viewer/editor/frontmatter-shortcut.ts
+++ b/frontend/src/viewer/editor/frontmatter-shortcut.ts
@@ -1,0 +1,61 @@
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+export const FRONTMATTER_FENCE = "---";
+
+/**
+ * Obsidian's gesture: typing `---` on the first line opens the properties
+ * editor rather than leaving a horizontal rule behind.
+ *
+ * Frontmatter is NOT part of the body here — it lives in its own Y.Map /
+ * Y.Array (see `crdt/frontmatter-doc`). So the fence can never become
+ * frontmatter by being typed; it is a trigger, and this extension's job is to
+ * report it and then take the characters back out of the body.
+ *
+ * `onTrigger` decides whether the gesture applies — it declines when the note
+ * already has frontmatter, in which case the fence stays as an ordinary rule.
+ * Only a `true` return removes it.
+ */
+export function frontmatterShortcut(onTrigger: () => boolean): Extension {
+	return EditorView.updateListener.of((update) => {
+		if (!update.docChanged) {
+			return;
+		}
+		// Typed only. A paste keeps its literal `---`, and an undo restoring the
+		// fence must not re-fire — that would delete it again and the two would
+		// fight forever.
+		if (!update.transactions.some((tr) => tr.isUserEvent("input.type"))) {
+			return;
+		}
+		const first = update.state.doc.lineAt(0);
+		if (first.text !== FRONTMATTER_FENCE) {
+			return;
+		}
+		// A body that legitimately opens with a horizontal rule would otherwise
+		// lose it the moment you typed anywhere else in the note: the first line
+		// reads `---` on every keystroke. Only react when the edit actually
+		// landed on that line (range is in pre-change coordinates).
+		if (!update.changes.touchesRange(0, first.to)) {
+			return;
+		}
+		if (!onTrigger()) {
+			return;
+		}
+		// Deferred: dispatching inside an update listener throws.
+		queueMicrotask(() => {
+			const { view } = update;
+			const line = view.state.doc.lineAt(0);
+			// Re-checked because anything — a remote CRDT delta, an undo — may
+			// have landed between the update and this microtask.
+			if (line.text !== FRONTMATTER_FENCE) {
+				return;
+			}
+			view.dispatch({
+				// Takes the trailing newline too, so the body does not inherit a
+				// blank first line.
+				changes: { from: 0, to: Math.min(view.state.doc.length, line.to + 1) },
+				userEvent: "delete.frontmatter",
+			});
+		});
+	});
+}

--- a/frontend/src/viewer/editor/frontmatter-shortcut.ts
+++ b/frontend/src/viewer/editor/frontmatter-shortcut.ts
@@ -34,8 +34,20 @@ export function frontmatterShortcut(onTrigger: () => boolean): Extension {
 		// A body that legitimately opens with a horizontal rule would otherwise
 		// lose it the moment you typed anywhere else in the note: the first line
 		// reads `---` on every keystroke. Only react when the edit actually
-		// landed on that line (range is in pre-change coordinates).
-		if (!update.changes.touchesRange(0, first.to)) {
+		// landed INSIDE that line.
+		//
+		// Not `touchesRange`: it takes pre-change coordinates while `first` is
+		// post-change, and it counts an insertion AT the endpoint as touching —
+		// so pressing Enter at the end of an existing `---` rule deleted it.
+		// iterChanges reports fromB/toB in the new document, and the comparison
+		// is exclusive at both ends.
+		let touchedFence = false;
+		update.changes.iterChanges((_fromA, _toA, fromB, toB) => {
+			if (fromB < first.to && toB > first.from) {
+				touchedFence = true;
+			}
+		});
+		if (!touchedFence) {
 			return;
 		}
 		if (!onTrigger()) {

--- a/frontend/src/viewer/editor/raw-frontmatter-editor.tsx
+++ b/frontend/src/viewer/editor/raw-frontmatter-editor.tsx
@@ -96,7 +96,7 @@ export function RawFrontmatterEditor({ doc }: { doc: Y.Doc }) {
 	}, [doc]);
 
 	return (
-		<section aria-label="Frontmatter (raw YAML)" className="border-b">
+		<section aria-label="Frontmatter (raw YAML)">
 			<div className="select-none px-3 pt-2 font-mono text-muted-foreground text-xs">---</div>
 			<div ref={hostRef} className="px-1" />
 			<div className="select-none px-3 pb-2 font-mono text-muted-foreground text-xs">---</div>

--- a/frontend/src/viewer/editor/toolbar.tsx
+++ b/frontend/src/viewer/editor/toolbar.tsx
@@ -3,6 +3,13 @@ import { Bold, Code, Heading, Italic, Link, List, Quote } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toggleLinePrefix, toggleWrap } from "./format-commands";
 
+/**
+ * PARKED — intentionally not mounted anywhere right now. Do not delete as
+ * dead code; the commands it drives (`./format-commands`) are tested and the
+ * component is the intended body of a mobile-only toolbar docked above the
+ * on-screen keyboard. Removing it from `note-page.tsx` was a placement
+ * decision, not a verdict on the feature.
+ */
 export function EditorToolbar({ getView }: { getView: () => EditorView | null }) {
 	const run = (fn: (v: EditorView) => void) => () => {
 		const v = getView();

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -29,6 +29,7 @@ import {
 } from "../api/queries";
 import { uuid7 } from "../crdt/uuid7";
 import { useFolderTreeState } from "../layout/folder-tree-context";
+import { copyToClipboard } from "../lib/clipboard";
 import { noteName } from "../lib/note-name";
 import {
 	isSyntheticFolderId,
@@ -522,10 +523,9 @@ export default function FolderTree() {
 				}
 				// Wikilinks resolve by filename in Obsidian, never by H1 title.
 				const label = noteName(note.path) || note.path;
-				navigator.clipboard
-					.writeText(`[[${label}]]`)
-					.then(() => toast.success("Copied wikilink"))
-					.catch(() => toast.error("Copy failed"));
+				copyToClipboard(`[[${label}]]`).then((ok) =>
+					ok ? toast.success("Copied wikilink") : toast.error("Copy failed"),
+				);
 				break;
 			}
 			default:

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -506,10 +506,13 @@ export default function FolderTree() {
 				// No reliable sibling-name set on hand — pass an empty Set and let
 				// the backend reject if collision happens; the toast surfaces it.
 				const new_path = nextCopyName(note.path, new Set<string>());
-				duplicateNote
-					.mutateAsync({ src_path: note.path, new_path })
-					.then(() => toast.success("Duplicated"))
-					.catch(() => toast.error("Duplicate failed"));
+				// `mutate`, not `mutateAsync` — the hook's onError already toasts, and
+				// it distinguishes a name collision from a general failure. Catching
+				// here too put a second, vaguer toast on top of the useful one.
+				duplicateNote.mutate(
+					{ src_path: note.path, new_path },
+					{ onSuccess: () => toast.success("Duplicated") },
+				);
 				break;
 			}
 			case "copy-wikilink": {

--- a/frontend/src/viewer/inline-title.test.tsx
+++ b/frontend/src/viewer/inline-title.test.tsx
@@ -16,6 +16,16 @@ describe("InlineTitle", () => {
 		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("My Note");
 	});
 
+	// The title should look like text you can type into, not like a control:
+	// the whole line is the target, but nothing lights up under the pointer —
+	// the caret cursor is the only affordance.
+	it("presents the whole line as an editable target with no hover chrome", () => {
+		render(<InlineTitle {...props} />);
+		const line = screen.getByRole("button", { name: "My Note" });
+		expect(line).toHaveClass("w-full", "cursor-text");
+		expect(line.className).not.toMatch(/hover:/);
+	});
+
 	it("starts a rename when clicked", () => {
 		const onStartRename = vi.fn();
 		render(<InlineTitle {...props} onStartRename={onStartRename} />);

--- a/frontend/src/viewer/inline-title.test.tsx
+++ b/frontend/src/viewer/inline-title.test.tsx
@@ -32,6 +32,28 @@ describe("InlineTitle", () => {
 		expect(input.selectionEnd).toBe("My Note".length);
 	});
 
+	// Renaming should read as typing into the title, not as a form field
+	// appearing where the title was.
+	it("renders the rename box as the title itself, not as a boxed input", () => {
+		render(<InlineTitle {...props} renaming />);
+		const input = screen.getByRole("textbox");
+		const heading = render(<InlineTitle {...props} />).container.querySelector("h1");
+
+		// Same typography as the h1 it stands in for, from the same constant.
+		for (const cls of (heading?.className ?? "")
+			.split(" ")
+			.filter(
+				(c) =>
+					c.startsWith("text-3xl") || c.startsWith("font-semibold") || c.startsWith("tracking-"),
+			)) {
+			expect(input).toHaveClass(cls);
+		}
+		// No input chrome — twMerge must REPLACE the defaults, not append.
+		expect(input).toHaveClass("bg-transparent");
+		expect(input.className).not.toMatch(/\bbg-background\b/);
+		expect(input.className).not.toMatch(/\btext-sm\b/);
+	});
+
 	it("commits the typed name on Enter", () => {
 		const onCommitRename = vi.fn();
 		render(<InlineTitle {...props} renaming onCommitRename={onCommitRename} />);

--- a/frontend/src/viewer/inline-title.test.tsx
+++ b/frontend/src/viewer/inline-title.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { InlineTitle } from "./inline-title";
+
+const props = {
+	name: "My Note",
+	renaming: false,
+	onStartRename: vi.fn(),
+	onCommitRename: vi.fn(),
+	onCancelRename: vi.fn(),
+};
+
+describe("InlineTitle", () => {
+	it("renders the name as a level-1 heading", () => {
+		render(<InlineTitle {...props} />);
+		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("My Note");
+	});
+
+	it("starts a rename when clicked", () => {
+		const onStartRename = vi.fn();
+		render(<InlineTitle {...props} onStartRename={onStartRename} />);
+		fireEvent.click(screen.getByRole("button", { name: "My Note" }));
+		expect(onStartRename).toHaveBeenCalled();
+	});
+
+	it("shows an input seeded with the name, fully selected, while renaming", () => {
+		render(<InlineTitle {...props} renaming />);
+		const input = screen.getByRole("textbox") as HTMLInputElement;
+		expect(input.value).toBe("My Note");
+		// Typing must replace the name, which is what the selection buys.
+		expect(input.selectionStart).toBe(0);
+		expect(input.selectionEnd).toBe("My Note".length);
+	});
+
+	it("commits the typed name on Enter", () => {
+		const onCommitRename = vi.fn();
+		render(<InlineTitle {...props} renaming onCommitRename={onCommitRename} />);
+		const input = screen.getByRole("textbox");
+		fireEvent.change(input, { target: { value: "Renamed" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onCommitRename).toHaveBeenCalledWith("Renamed");
+	});
+});

--- a/frontend/src/viewer/inline-title.tsx
+++ b/frontend/src/viewer/inline-title.tsx
@@ -1,0 +1,58 @@
+import { RenameInput } from "./tree-actions/rename-input";
+
+interface Props {
+	/** Base name, no extension — the caller strips it. */
+	name: string;
+	renaming: boolean;
+	onStartRename: () => void;
+	onCommitRename: (next: string) => void;
+	onCancelRename: () => void;
+}
+
+const FRAME = "px-5 pt-6 pb-1";
+
+/**
+ * Obsidian-style inline title: part of the document flow, not the chrome, so
+ * it scrolls away with the content. Click to rename — `commitOnBlur` because
+ * this reads as a title field you retype and then click into the body from,
+ * where losing the edit would be a surprise.
+ *
+ * The rename box replaces the `h1` rather than nesting inside it: `h1` takes
+ * phrasing content only, and an input that IS the heading is not a heading.
+ */
+export function InlineTitle({
+	name,
+	renaming,
+	onStartRename,
+	onCommitRename,
+	onCancelRename,
+}: Props) {
+	if (renaming) {
+		return (
+			<section className={FRAME} aria-label="Rename note">
+				<RenameInput
+					initial={name}
+					kind="file"
+					commitOnBlur
+					onCommit={onCommitRename}
+					onCancel={onCancelRename}
+				/>
+			</section>
+		);
+	}
+
+	return (
+		<h1 className={`${FRAME} font-semibold text-3xl tracking-tight`}>
+			<button
+				type="button"
+				// -mx-1 cancels the padding so the hover target is roomier than the
+				// text without shifting the title off the left margin.
+				className="-mx-1 block w-full truncate rounded px-1 text-left hover:bg-accent"
+				title="Click to rename"
+				onClick={onStartRename}
+			>
+				{name}
+			</button>
+		</h1>
+	);
+}

--- a/frontend/src/viewer/inline-title.tsx
+++ b/frontend/src/viewer/inline-title.tsx
@@ -52,9 +52,11 @@ export function InlineTitle({
 		<h1 className={`${FRAME} ${TITLE_TYPE}`}>
 			<button
 				type="button"
-				// -mx-1 cancels the padding so the hover target is roomier than the
-				// text without shifting the title off the left margin.
-				className="-mx-1 block w-full truncate rounded px-1 text-left hover:bg-accent"
+				// Deliberately undecorated: the whole line is the target, but nothing
+				// lights up under the pointer. cursor-text is the only affordance,
+				// which is the point — this should read as a line of text you can
+				// type into, not as a control that happens to look like a title.
+				className="block w-full cursor-text truncate text-left"
 				title="Click to rename"
 				onClick={onStartRename}
 			>

--- a/frontend/src/viewer/inline-title.tsx
+++ b/frontend/src/viewer/inline-title.tsx
@@ -9,7 +9,9 @@ interface Props {
 	onCancelRename: () => void;
 }
 
-const FRAME = "px-5 pt-6 pb-1";
+// pb sets the gap down to whatever follows — the properties widget, or the
+// body. Tune here; it is the single knob for all three view modes.
+const FRAME = "px-5 pt-6 pb-4";
 // One source for the heading's type so the rename box cannot drift out of
 // step with the h1 it stands in for.
 const TITLE_TYPE = "font-semibold text-3xl tracking-tight";

--- a/frontend/src/viewer/inline-title.tsx
+++ b/frontend/src/viewer/inline-title.tsx
@@ -10,6 +10,9 @@ interface Props {
 }
 
 const FRAME = "px-5 pt-6 pb-1";
+// One source for the heading's type so the rename box cannot drift out of
+// step with the h1 it stands in for.
+const TITLE_TYPE = "font-semibold text-3xl tracking-tight";
 
 /**
  * Obsidian-style inline title: part of the document flow, not the chrome, so
@@ -34,6 +37,10 @@ export function InlineTitle({
 					initial={name}
 					kind="file"
 					commitOnBlur
+					// Chromeless: no border, no fill, no padding of its own, so the
+					// caret simply appears in the title. p-0 also keeps the text on
+					// the same left edge as the button it replaced.
+					className={`${TITLE_TYPE} rounded-none border-0 bg-transparent p-0`}
 					onCommit={onCommitRename}
 					onCancel={onCancelRename}
 				/>
@@ -42,7 +49,7 @@ export function InlineTitle({
 	}
 
 	return (
-		<h1 className={`${FRAME} font-semibold text-3xl tracking-tight`}>
+		<h1 className={`${FRAME} ${TITLE_TYPE}`}>
 			<button
 				type="button"
 				// -mx-1 cancels the padding so the hover target is roomier than the

--- a/frontend/src/viewer/note-editor.tsx
+++ b/frontend/src/viewer/note-editor.tsx
@@ -12,13 +12,18 @@ import { useTheme } from "../theme/theme-provider";
 import { indentKeymap } from "./editor/format-commands";
 import { livePreviewExtensions } from "./editor/live-preview";
 
-// Fill the parent so the editor spans the full pane height. 16px on .cm-content
-// prevents iOS Safari auto-zoom. Transparent background so the card shows through.
+// height:auto + overflow:visible hand scrolling to the page's ScrollArea, so
+// the inline title and properties scroll with the text instead of staying
+// pinned above it. CodeMirror still viewport-renders against the scrolling
+// ancestor. 16px on .cm-content prevents iOS Safari auto-zoom. Transparent
+// background so the card shows through.
 const editorTheme = EditorView.theme({
-	"&": { height: "100%", backgroundColor: "transparent" },
+	"&": { height: "auto", backgroundColor: "transparent" },
 	".cm-scroller": {
 		fontFamily: "inherit",
-		overflow: "auto",
+		// Inert while the page owns the scrollbar; the styling rules below are
+		// likewise inert but cost nothing and matter again if this is reverted.
+		overflow: "visible",
 		backgroundColor: "transparent",
 		scrollbarWidth: "thin",
 		scrollbarColor: "var(--border) transparent",
@@ -179,5 +184,5 @@ export default function NoteEditor({
 		});
 	}, [mode, resolveWikiLink]);
 
-	return <div ref={hostRef} className="h-full" />;
+	return <div ref={hostRef} />;
 }

--- a/frontend/src/viewer/note-editor.tsx
+++ b/frontend/src/viewer/note-editor.tsx
@@ -10,6 +10,7 @@ import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
 import { useTheme } from "../theme/theme-provider";
 import { indentKeymap } from "./editor/format-commands";
+import { frontmatterShortcut } from "./editor/frontmatter-shortcut";
 import { livePreviewExtensions } from "./editor/live-preview";
 
 // height:auto + overflow:visible hand scrolling to the page's ScrollArea, so
@@ -49,6 +50,12 @@ export interface NoteEditorProps {
 	resolveWikiLink: (name: string) => string;
 	/** Reaches the live EditorView out to a caller (e.g. the formatting toolbar). */
 	onView?: (view: EditorView | null) => void;
+	/**
+	 * `---` was typed on the first line. Return true to accept the gesture, in
+	 * which case the fence is removed from the body; false leaves it as an
+	 * ordinary horizontal rule. See `editor/frontmatter-shortcut`.
+	 */
+	onFrontmatterShortcut?: () => boolean;
 }
 
 // One shared compartment instance: reconfiguring it swaps the decoration layer
@@ -89,10 +96,12 @@ export function buildEditorState(
 	dark: boolean,
 	mode: EditorMode,
 	resolveWikiLink: (name: string) => string,
+	onFrontmatterShortcut?: () => boolean,
 ): EditorState {
 	return EditorState.create({
 		doc: ytext.toString(),
 		extensions: [
+			...(onFrontmatterShortcut ? [frontmatterShortcut(onFrontmatterShortcut)] : []),
 			drawSelection(),
 			EditorView.lineWrapping,
 			Prec.highest(keymap.of(yUndoManagerKeymap)),
@@ -136,6 +145,7 @@ export default function NoteEditor({
 	mode,
 	resolveWikiLink,
 	onView,
+	onFrontmatterShortcut,
 }: NoteEditorProps) {
 	const { resolved } = useTheme();
 	const hostRef = useRef<HTMLDivElement>(null);
@@ -145,6 +155,11 @@ export default function NoteEditor({
 	// recreates the view.
 	const onViewRef = useRef(onView);
 	onViewRef.current = onView;
+	// Same treatment: the extension is baked into the state at creation, so it
+	// must read through a ref or a new callback identity would force a rebuild
+	// and detach yCollab.
+	const onShortcutRef = useRef(onFrontmatterShortcut);
+	onShortcutRef.current = onFrontmatterShortcut;
 
 	// Create the view only when the bound doc or theme changes (NOT on mode).
 	// mode/resolveWikiLink intentionally excluded: a mode switch must reconfigure
@@ -161,7 +176,9 @@ export default function NoteEditor({
 			return;
 		}
 		const view = new EditorView({
-			state: buildEditorState(ytext, awareness, resolved === "dark", mode, resolveWikiLink),
+			state: buildEditorState(ytext, awareness, resolved === "dark", mode, resolveWikiLink, () =>
+				Boolean(onShortcutRef.current?.()),
+			),
 			parent,
 		});
 		viewRef.current = view;

--- a/frontend/src/viewer/note-menu.test.tsx
+++ b/frontend/src/viewer/note-menu.test.tsx
@@ -36,9 +36,7 @@ describe("NoteMenu", () => {
 			"aria-current",
 			"true",
 		);
-		expect(screen.getByRole("menuitem", { name: "Rendered" })).not.toHaveAttribute(
-			"aria-current",
-		);
+		expect(screen.getByRole("menuitem", { name: "Rendered" })).not.toHaveAttribute("aria-current");
 	});
 
 	it("uses the bottom-sheet drawer on mobile", () => {

--- a/frontend/src/viewer/note-menu.test.tsx
+++ b/frontend/src/viewer/note-menu.test.tsx
@@ -29,6 +29,16 @@ describe("NoteMenu", () => {
 		expect(onPick).toHaveBeenCalledWith("duplicate");
 	});
 
+	// The menu hangs off a 32px icon button. Sizing to the trigger pinned it to
+	// the min-width floor and wrapped "Copy wikilink" onto two lines.
+	it("sizes to its content rather than to the icon trigger", async () => {
+		render(<NoteMenu mode="rendered" title="note" onPick={vi.fn()} />);
+		openMenu();
+		const menu = await screen.findByRole("menu");
+		expect(menu.className).not.toMatch(/radix-dropdown-menu-trigger-width/);
+		expect(menu).toHaveClass("whitespace-nowrap");
+	});
+
 	it("marks the active view mode", async () => {
 		render(<NoteMenu mode="raw" title="note" onPick={vi.fn()} />);
 		openMenu();

--- a/frontend/src/viewer/note-menu.test.tsx
+++ b/frontend/src/viewer/note-menu.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NoteMenu } from "./note-menu";
+
+const matches = vi.fn();
+vi.mock("@/hooks/use-media-query", () => ({
+	useMediaQuery: () => matches(),
+}));
+
+// Radix DropdownMenu opens on pointerdown in happy-dom; the mobile drawer is a
+// plain button, so it needs the click only.
+const openMenu = () => {
+	const trigger = screen.getByRole("button", { name: "Note options" });
+	fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+	fireEvent.click(trigger);
+};
+
+describe("NoteMenu", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		matches.mockReturnValue(true); // desktop by default
+	});
+
+	it("opens a dropdown on desktop and reports the picked action", async () => {
+		const onPick = vi.fn();
+		render(<NoteMenu mode="rendered" title="note" onPick={onPick} />);
+		openMenu();
+		fireEvent.click(await screen.findByRole("menuitem", { name: "Duplicate" }));
+		expect(onPick).toHaveBeenCalledWith("duplicate");
+	});
+
+	it("marks the active view mode", async () => {
+		render(<NoteMenu mode="raw" title="note" onPick={vi.fn()} />);
+		openMenu();
+		expect(await screen.findByRole("menuitem", { name: "Raw" })).toHaveAttribute(
+			"aria-current",
+			"true",
+		);
+		expect(screen.getByRole("menuitem", { name: "Rendered" })).not.toHaveAttribute(
+			"aria-current",
+		);
+	});
+
+	it("uses the bottom-sheet drawer on mobile", () => {
+		matches.mockReturnValue(false);
+		const onPick = vi.fn();
+		render(<NoteMenu mode="rendered" title="note" onPick={onPick} />);
+		openMenu();
+		// The drawer renders its own backdrop; the dropdown does not.
+		expect(screen.getByTestId("action-drawer-backdrop")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		expect(onPick).toHaveBeenCalledWith("delete");
+	});
+
+	it("closes the drawer after a pick", () => {
+		matches.mockReturnValue(false);
+		render(<NoteMenu mode="rendered" title="note" onPick={vi.fn()} />);
+		openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+		expect(screen.queryByTestId("action-drawer-backdrop")).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/viewer/note-menu.tsx
+++ b/frontend/src/viewer/note-menu.tsx
@@ -1,0 +1,93 @@
+import { MoreVertical } from "lucide-react";
+import { Fragment, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { ActionDrawer } from "./tree-actions/action-drawer";
+import {
+	ACTION_ICONS,
+	type ActionId,
+	noteMenuActions,
+	type ViewMode,
+} from "./tree-actions/action-list";
+
+interface Props {
+	mode: ViewMode;
+	/** Shown as the drawer's heading on mobile. */
+	title: string;
+	onPick: (id: ActionId) => void;
+}
+
+/**
+ * The note page's kebab. Desktop gets a dropdown; mobile gets the same
+ * bottom-sheet the file tree already uses on long-press, so the two menu
+ * surfaces in the app behave identically on touch.
+ */
+export function NoteMenu({ mode, title, onPick }: Props) {
+	const isDesktop = useMediaQuery("(min-width: 768px)");
+	const [drawerOpen, setDrawerOpen] = useState(false);
+	const actions = noteMenuActions(mode);
+
+	if (!isDesktop) {
+		return (
+			<>
+				<Button
+					variant="ghost"
+					size="icon"
+					aria-label="Note options"
+					onClick={() => setDrawerOpen(true)}
+				>
+					<MoreVertical className="size-4" />
+				</Button>
+				{drawerOpen ? (
+					<ActionDrawer
+						title={title}
+						actions={actions}
+						onPick={onPick}
+						onClose={() => setDrawerOpen(false)}
+					/>
+				) : null}
+			</>
+		);
+	}
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="ghost" size="icon" aria-label="Note options">
+					<MoreVertical className="size-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				{actions.map((action, i) => {
+					const Icon = ACTION_ICONS[action.id];
+					// Separate the view-mode group from the file actions, and the
+					// destructive one from everything above it.
+					const separatorBefore = action.id === "rename" || action.destructive;
+					return (
+						<Fragment key={action.id}>
+							{separatorBefore && i > 0 ? <DropdownMenuSeparator /> : null}
+							<DropdownMenuItem
+								// aria-current rather than a checkbox item: the modes are a
+								// single-select group, and this keeps one code path for
+								// every row in the menu.
+								aria-current={action.active ? "true" : undefined}
+								variant={action.destructive ? "destructive" : "default"}
+								onSelect={() => onPick(action.id)}
+							>
+								<Icon aria-hidden="true" className="size-4" />
+								{action.label}
+							</DropdownMenuItem>
+						</Fragment>
+					);
+				})}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/frontend/src/viewer/note-menu.tsx
+++ b/frontend/src/viewer/note-menu.tsx
@@ -58,7 +58,12 @@ export function NoteMenu({ mode, title, onPick }: Props) {
 	}
 
 	return (
-		<DropdownMenu>
+		// modal={false} turns OFF Radix's focus trap. With it on, "Rename" opened
+		// the inline title's input, the still-mounted trap yanked focus back into
+		// the menu, and RenameInput's commit-or-cancel-on-blur closed the box in
+		// the same tick — rename from the kebab was unusable. A kebab does not
+		// need to trap focus or lock scroll.
+		<DropdownMenu modal={false}>
 			<DropdownMenuTrigger asChild>
 				<Button variant="ghost" size="icon" aria-label="Note options">
 					<MoreVertical className="size-4" />

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -50,12 +50,37 @@ vi.mock("../crdt/session", () => ({
 }));
 
 const useNoteMock = vi.fn();
-const { renameNoteMutate } = vi.hoisted(() => ({ renameNoteMutate: vi.fn() }));
+const { renameNoteMutate, deleteNoteMutate, duplicateNoteMutate, batchMoveMutate } = vi.hoisted(
+	() => ({
+		renameNoteMutate: vi.fn(),
+		deleteNoteMutate: vi.fn(),
+		duplicateNoteMutate: vi.fn(),
+		batchMoveMutate: vi.fn(),
+	}),
+);
 vi.mock("../api/queries", () => ({
 	useNote: (...a: unknown[]) => useNoteMock(...a),
 	useRenameNote: () => ({ mutate: renameNoteMutate, isPending: false }),
+	useDeleteNote: () => ({ mutate: deleteNoteMutate, isPending: false }),
+	useDuplicateNote: () => ({ mutateAsync: duplicateNoteMutate, isPending: false }),
+	useBatchMoveNotes: () => ({ mutate: batchMoveMutate, isPending: false }),
+	useFolders: () => ({ data: [{ name: "folder" }, { name: "other" }], isLoading: false }),
 }));
-vi.mock("react-router", () => ({ useParams: () => ({ itemId: "note-1" }) }));
+
+// Both must go through vi.hoisted — vi.mock factories are hoisted above plain
+// `const` declarations, so a non-hoisted locationMock throws "Cannot access
+// before initialization" at import time.
+const { navigateMock, locationMock } = vi.hoisted(() => ({
+	navigateMock: vi.fn(),
+	locationMock: vi.fn(() => ({ pathname: "/my-vault/note-1", state: null })),
+}));
+vi.mock("react-router", () => ({
+	useParams: () => ({ itemId: "note-1", slug: "my-vault" }),
+	useNavigate: () => navigateMock,
+	useLocation: () => locationMock(),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 const NOTE = {
 	id: "note-1",
@@ -68,8 +93,18 @@ const NOTE = {
 };
 
 describe("NotePage (CRDT)", () => {
+	// Radix DropdownMenu opens on pointerdown in happy-dom; the mobile drawer is
+	// a plain button, so sending both covers whichever branch the viewport picks.
+	const openMenu = async () => {
+		const trigger = await screen.findByRole("button", { name: "Note options" });
+		fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+		fireEvent.click(trigger);
+		await screen.findByRole("menuitem", { name: "Rendered" });
+	};
+
 	beforeEach(() => {
 		vi.clearAllMocks();
+		locationMock.mockReturnValue({ pathname: "/my-vault/note-1", state: null });
 		const doc = new Y.Doc();
 		openDoc.mockResolvedValue({
 			ytext: doc.getText("content"),
@@ -129,7 +164,8 @@ describe("NotePage (CRDT)", () => {
 		await waitFor(() => expect(openDoc).toHaveBeenCalledWith("note-1"));
 
 		// Switch to reading mode
-		fireEvent.click(screen.getByRole("button", { name: "Reading" }));
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
 
 		// NoteView is mocked — assert on the content prop it receives.
 		// The live Y.Text content should be passed, not the stale REST "# hi".
@@ -150,10 +186,12 @@ describe("NotePage (CRDT)", () => {
 		// Reading mode swaps the editor out for NoteView — nothing to insert into,
 		// so the reference panel's Insert action must go disabled rather than
 		// silently no-op against a torn-down view.
-		fireEvent.click(screen.getByRole("button", { name: "Reading" }));
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
 		await waitFor(() => expect(screen.getByTestId("has-editor")).toHaveTextContent("false"));
 
-		fireEvent.click(screen.getByRole("button", { name: "Rendered" }));
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Rendered" }));
 		await waitFor(() => expect(screen.getByTestId("has-editor")).toHaveTextContent("true"));
 	});
 
@@ -258,13 +296,14 @@ describe("NotePage (CRDT)", () => {
 		await waitFor(() => expect(screen.getByText("status")).toBeInTheDocument());
 		expect(screen.getByTestId("note-editor")).toBeInTheDocument();
 		expect(screen.queryByLabelText(/Frontmatter \(raw YAML\)/i)).not.toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Rendered" })).toHaveAttribute(
-			"aria-pressed",
+		await openMenu();
+		expect(screen.getByRole("menuitem", { name: "Rendered" })).toHaveAttribute(
+			"aria-current",
 			"true",
 		);
 
 		// Switch to "raw": raw YAML region visible, pills hidden.
-		fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+		fireEvent.click(screen.getByRole("menuitem", { name: "Raw" }));
 		await waitFor(() =>
 			expect(screen.getByLabelText(/Frontmatter \(raw YAML\)/i)).toBeInTheDocument(),
 		);
@@ -272,7 +311,8 @@ describe("NotePage (CRDT)", () => {
 		expect(screen.getByTestId("note-editor")).toBeInTheDocument();
 
 		// Switch to "reading": NoteView visible, neither frontmatter surface shown.
-		fireEvent.click(screen.getByRole("button", { name: "Reading" }));
+		await openMenu();
+		fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
 		await waitFor(() => expect(screen.getByTestId("note-view")).toBeInTheDocument());
 		expect(screen.queryByLabelText(/Frontmatter \(raw YAML\)/i)).not.toBeInTheDocument();
 		expect(screen.queryByText("status")).not.toBeInTheDocument();
@@ -300,6 +340,83 @@ describe("NotePage (CRDT)", () => {
 			await waitFor(() =>
 				expect(document.querySelector('[data-tour="note-editor"]')).toBeInTheDocument(),
 			);
+		});
+
+		it("shows the title in reading mode too", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
+			expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("note");
+		});
+	});
+
+	describe("kebab", () => {
+		it("switches view mode from the menu", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
+			expect(screen.getByTestId("note-view")).toBeInTheDocument();
+		});
+
+		it("no longer shows the old mode buttons in the header", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			expect(screen.queryByRole("button", { name: "Rendered" })).not.toBeInTheDocument();
+		});
+
+		it("starts a rename from the menu", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+			expect(screen.getByRole("textbox", { name: "Rename file" })).toHaveValue("note");
+		});
+
+		it("duplicates with a collision-safe name", async () => {
+			duplicateNoteMutate.mockResolvedValue({ id: "n2", path: "folder/note 1.md" });
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
+			expect(duplicateNoteMutate).toHaveBeenCalledWith(
+				expect.objectContaining({ src_path: "folder/note.md" }),
+			);
+		});
+
+		it("moves the note to the folder picked in the dialog", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Move to…" }));
+			fireEvent.click(await screen.findByRole("option", { name: "other" }));
+			expect(batchMoveMutate).toHaveBeenCalledWith({
+				ids: ["note-1"],
+				target_folder: "other",
+				paths: { "note-1": "folder/note.md" },
+			});
+		});
+
+		it("deletes only after confirmation, then leaves the dead route", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+			expect(deleteNoteMutate).not.toHaveBeenCalled();
+			fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
+			expect(deleteNoteMutate).toHaveBeenCalledWith(
+				expect.objectContaining({ id: "note-1", path: "folder/note.md" }),
+			);
+			expect(navigateMock).toHaveBeenCalledWith("/my-vault");
+		});
+
+		it("adds a property to the frontmatter doc", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
+			expect(await screen.findByTestId("note-properties")).toHaveTextContent("new-property");
 		});
 	});
 });

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
+import { readRows } from "../crdt/frontmatter-doc";
 import { RightToolsProvider } from "../layout/right-tools-context";
 import { ActiveEditorProvider, useActiveEditor } from "./editor/active-editor-context";
 import NotePage from "./note-page";
@@ -560,6 +561,31 @@ describe("NotePage (CRDT)", () => {
 				expect.objectContaining({ id: "note-1", path: "folder/note.md" }),
 			);
 			expect(navigateMock).toHaveBeenCalledWith("/my-vault");
+		});
+
+		// The reported symptom was "I can set keys but not values". Proves the
+		// write path end to end from the real note page, so a fix for it can't be
+		// mistaken for a styling change.
+		it("writes a value typed into a property row", async () => {
+			const doc = new Y.Doc();
+			openDoc.mockResolvedValue({
+				ytext: doc.getText("content"),
+				awareness: new Awareness(doc),
+				doc,
+			});
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
+
+			const row = await screen.findByTestId("property-row-new-property");
+			const value = within(row).getByRole("textbox");
+			fireEvent.change(value, { target: { value: "hello" } });
+			fireEvent.blur(value);
+
+			await waitFor(() =>
+				expect(readRows(doc).find((r) => r.key === "new-property")?.value).toBe("hello"),
+			);
 		});
 
 		it("adds a property to the frontmatter doc", async () => {

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -225,7 +225,7 @@ describe("NotePage (CRDT)", () => {
 		renderPage();
 
 		// Widget should appear in the default rendered mode
-		await waitFor(() => expect(screen.getByText("status")).toBeInTheDocument());
+		await waitFor(() => expect(screen.getByDisplayValue("status")).toBeInTheDocument());
 	});
 
 	// Inline rename from the header — same semantics as the tree's rename
@@ -340,7 +340,7 @@ describe("NotePage (CRDT)", () => {
 		renderPage();
 
 		// Default "rendered" mode: pills visible, editor visible, no raw YAML region.
-		await waitFor(() => expect(screen.getByText("status")).toBeInTheDocument());
+		await waitFor(() => expect(screen.getByDisplayValue("status")).toBeInTheDocument());
 		expect(screen.getByTestId("note-editor")).toBeInTheDocument();
 		expect(screen.queryByLabelText(/Frontmatter \(raw YAML\)/i)).not.toBeInTheDocument();
 		await openMenu();
@@ -354,7 +354,7 @@ describe("NotePage (CRDT)", () => {
 		await waitFor(() =>
 			expect(screen.getByLabelText(/Frontmatter \(raw YAML\)/i)).toBeInTheDocument(),
 		);
-		expect(screen.queryByText("status")).not.toBeInTheDocument();
+		expect(screen.queryByDisplayValue("status")).not.toBeInTheDocument();
 		expect(screen.getByTestId("note-editor")).toBeInTheDocument();
 
 		// Switch to "reading": NoteView visible, neither frontmatter surface shown.
@@ -362,7 +362,7 @@ describe("NotePage (CRDT)", () => {
 		fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
 		await waitFor(() => expect(screen.getByTestId("note-view")).toBeInTheDocument());
 		expect(screen.queryByLabelText(/Frontmatter \(raw YAML\)/i)).not.toBeInTheDocument();
-		expect(screen.queryByText("status")).not.toBeInTheDocument();
+		expect(screen.queryByDisplayValue("status")).not.toBeInTheDocument();
 		expect(screen.queryByTestId("note-editor")).not.toBeInTheDocument();
 	});
 
@@ -579,7 +579,7 @@ describe("NotePage (CRDT)", () => {
 			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
 
 			const row = await screen.findByTestId("property-row-new-property");
-			const value = within(row).getByRole("textbox");
+			const value = within(row).getByRole("textbox", { name: "new-property value" });
 			fireEvent.change(value, { target: { value: "hello" } });
 			fireEvent.blur(value);
 
@@ -593,7 +593,7 @@ describe("NotePage (CRDT)", () => {
 			await screen.findByTestId("note-editor");
 			await openMenu();
 			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
-			expect(await screen.findByTestId("note-properties")).toHaveTextContent("new-property");
+			expect(await screen.findByDisplayValue("new-property")).toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -278,4 +278,28 @@ describe("NotePage (CRDT)", () => {
 		expect(screen.queryByText("status")).not.toBeInTheDocument();
 		expect(screen.queryByTestId("note-editor")).not.toBeInTheDocument();
 	});
+
+	describe("layout", () => {
+		it("renders the note name as an inline h1, not just chrome text", async () => {
+			renderPage();
+			await waitFor(() =>
+				expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("note"),
+			);
+		});
+
+		it("puts the title above the properties widget in document order", async () => {
+			renderPage();
+			const title = await screen.findByRole("heading", { level: 1 });
+			const properties = await screen.findByTestId("note-properties");
+			// Node.compareDocumentPosition: 4 = "properties FOLLOWS title".
+			expect(title.compareDocumentPosition(properties)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+		});
+
+		it("keeps the onboarding tour anchor present", async () => {
+			renderPage();
+			await waitFor(() =>
+				expect(document.querySelector('[data-tour="note-editor"]')).toBeInTheDocument(),
+			);
+		});
+	});
 });

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -384,6 +384,43 @@ describe("NotePage (CRDT)", () => {
 		});
 	});
 
+	describe("reading toggle", () => {
+		it("switches to reading view and back", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			fireEvent.click(screen.getByRole("button", { name: "Reading view" }));
+			expect(screen.getByTestId("note-view")).toBeInTheDocument();
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			expect(screen.getByTestId("note-editor")).toBeInTheDocument();
+		});
+
+		// Raw is an edit mode, so a round trip through reading must not silently
+		// demote it to rendered.
+		it("returns to raw when that was the editor in use", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Raw" }));
+			await screen.findByLabelText(/Frontmatter \(raw YAML\)/i);
+
+			fireEvent.click(screen.getByRole("button", { name: "Reading view" }));
+			expect(screen.getByTestId("note-view")).toBeInTheDocument();
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			expect(await screen.findByLabelText(/Frontmatter \(raw YAML\)/i)).toBeInTheDocument();
+		});
+
+		it("stays in step with the kebab's active-mode marker", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			fireEvent.click(screen.getByRole("button", { name: "Reading view" }));
+			await openMenu();
+			expect(screen.getByRole("menuitem", { name: "Reading" })).toHaveAttribute(
+				"aria-current",
+				"true",
+			);
+		});
+	});
+
 	describe("kebab", () => {
 		it("switches view mode from the menu", async () => {
 			renderPage();

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -30,9 +30,22 @@ vi.mock("./note-view", () => ({
 }));
 
 // NoteEditor is lazy-loaded and requires ThemeProvider context. Stub it so the
-// live-mode editor path doesn't crash the test environment.
+// live-mode editor path doesn't crash the test environment. The button stands
+// in for typing `---` on the first line, and records what the page answered —
+// the real gesture is covered in editor/frontmatter-shortcut.test.ts.
+const { shortcutAnswer } = vi.hoisted(() => ({ shortcutAnswer: vi.fn() }));
 vi.mock("./note-editor", () => ({
-	default: () => <div data-testid="note-editor" />,
+	default: ({ onFrontmatterShortcut }: { onFrontmatterShortcut?: () => boolean }) => (
+		<div data-testid="note-editor">
+			<button
+				type="button"
+				data-testid="type-frontmatter-fence"
+				onClick={() => shortcutAnswer(onFrontmatterShortcut?.())}
+			>
+				---
+			</button>
+		</div>
+	),
 }));
 
 const { openDoc, closeDoc, enroll } = vi.hoisted(() => ({
@@ -392,6 +405,53 @@ describe("NotePage (CRDT)", () => {
 			await openMenu();
 			fireEvent.click(screen.getByRole("menuitem", { name: "Reading" }));
 			expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("note");
+		});
+	});
+
+	describe("frontmatter shortcut", () => {
+		const withFrontmatter = () => {
+			const doc = new Y.Doc();
+			doc.getMap("frontmatter").set("status", JSON.stringify("draft"));
+			doc.getArray("frontmatter_order").insert(0, ["status"]);
+			openDoc.mockResolvedValue({
+				ytext: doc.getText("content"),
+				awareness: new Awareness(doc),
+				doc,
+			});
+		};
+
+		it("opens an empty properties editor on a note with no frontmatter", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			expect(screen.queryByTestId("note-properties")).not.toBeInTheDocument();
+
+			fireEvent.click(screen.getByTestId("type-frontmatter-fence"));
+
+			expect(await screen.findByTestId("note-properties")).toBeInTheDocument();
+			expect(shortcutAnswer).toHaveBeenCalledWith(true);
+		});
+
+		it("closes it again when focus leaves with nothing added", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			fireEvent.click(screen.getByTestId("type-frontmatter-fence"));
+			await screen.findByTestId("note-properties");
+
+			fireEvent.pointerDown(document.body);
+
+			await waitFor(() => expect(screen.queryByTestId("note-properties")).not.toBeInTheDocument());
+		});
+
+		// Declining is what leaves the typed `---` in the body as a real
+		// horizontal rule instead of silently eating it.
+		it("declines when the note already has frontmatter", async () => {
+			withFrontmatter();
+			renderPage();
+			await screen.findByTestId("note-properties");
+
+			fireEvent.click(screen.getByTestId("type-frontmatter-fence"));
+
+			expect(shortcutAnswer).toHaveBeenCalledWith(false);
 		});
 	});
 

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -140,7 +140,7 @@ describe("NotePage (CRDT)", () => {
 			error: null,
 		});
 		renderPage();
-		await waitFor(() => expect(screen.getByText("note")).toBeInTheDocument());
+		await waitFor(() => expect(screen.getByTestId("header-note-name")).toBeInTheDocument());
 		expect(openDoc).not.toHaveBeenCalled();
 		expect(enroll).not.toHaveBeenCalled();
 	});
@@ -217,10 +217,40 @@ describe("NotePage (CRDT)", () => {
 	// Inline rename from the header — same semantics as the tree's rename
 	// (leaf-name edit, folder untouched, extension preserved), so the two
 	// entry points can't drift apart.
+	// The header keeps its own rename affordance: the full path is always
+	// visible even when the document is scrolled past the inline title, so it
+	// stays the reachable place to retitle a note.
+	describe("header path", () => {
+		it("shows the folder crumb and the file name", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			expect(screen.getByTestId("header-note-name")).toHaveTextContent("note");
+			expect(screen.getByText("folder/")).toBeInTheDocument();
+		});
+
+		it("renames from the header without also opening the inline title's box", async () => {
+			renderPage();
+			fireEvent.click(await screen.findByTestId("header-note-name"));
+			// Two boxes would mean two focus targets fighting over the same commit.
+			expect(screen.getAllByRole("textbox", { name: "Rename file" })).toHaveLength(1);
+			expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("note");
+		});
+
+		it("opens the inline title's box for a kebab rename, not the header's", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+			expect(screen.getAllByRole("textbox", { name: "Rename file" })).toHaveLength(1);
+			// The header still shows its button; the h1 is the one that swapped.
+			expect(screen.getByTestId("header-note-name")).toBeInTheDocument();
+		});
+	});
+
 	describe("inline rename", () => {
 		const openRename = async () => {
 			renderPage();
-			fireEvent.click(await screen.findByRole("button", { name: "note" }));
+			fireEvent.click(await screen.findByTestId("header-note-name"));
 			return screen.getByRole("textbox", { name: "Rename file" });
 		};
 

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -361,6 +361,17 @@ describe("NotePage (CRDT)", () => {
 		});
 
 		it("puts the title above the properties widget in document order", async () => {
+			// Seeded: the widget hides itself on a note with no frontmatter, so
+			// there has to be a property for it to be ordered against.
+			const doc = new Y.Doc();
+			doc.getMap("frontmatter").set("status", JSON.stringify("draft"));
+			doc.getArray("frontmatter_order").insert(0, ["status"]);
+			openDoc.mockResolvedValue({
+				ytext: doc.getText("content"),
+				awareness: new Awareness(doc),
+				doc,
+			});
+
 			renderPage();
 			const title = await screen.findByRole("heading", { level: 1 });
 			const properties = await screen.findByTestId("note-properties");

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -76,7 +76,7 @@ vi.mock("../api/queries", () => ({
 	useNote: (...a: unknown[]) => useNoteMock(...a),
 	useRenameNote: () => ({ mutate: renameNoteMutate, isPending: false }),
 	useDeleteNote: () => ({ mutate: deleteNoteMutate, isPending: false }),
-	useDuplicateNote: () => ({ mutateAsync: duplicateNoteMutate, isPending: false }),
+	useDuplicateNote: () => ({ mutate: duplicateNoteMutate, isPending: false }),
 	useBatchMoveNotes: () => ({ mutate: batchMoveMutate, isPending: false }),
 	useFolders: () => ({ data: [{ name: "folder" }, { name: "other" }], isLoading: false }),
 }));
@@ -551,15 +551,19 @@ describe("NotePage (CRDT)", () => {
 			expect(screen.getByRole("textbox", { name: "Rename file" })).toHaveValue("note");
 		});
 
-		it("duplicates with a collision-safe name", async () => {
-			duplicateNoteMutate.mockResolvedValue({ id: "n2", path: "folder/note 1.md" });
+		it("duplicates with a collision-safe name, leaving errors to the mutation", async () => {
 			renderPage();
 			await screen.findByTestId("note-editor");
 			await openMenu();
 			fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
 			expect(duplicateNoteMutate).toHaveBeenCalledWith(
 				expect.objectContaining({ src_path: "folder/note.md" }),
+				expect.objectContaining({ onSuccess: expect.any(Function) }),
 			);
+			// useDuplicateNote's onError already toasts, and it tells a name
+			// collision apart from a general failure. Reporting here as well
+			// stacked a second, vaguer toast on top of the useful one.
+			expect(duplicateNoteMutate.mock.calls[0]?.[1]).not.toHaveProperty("onError");
 		});
 
 		it("moves the note to the folder picked in the dialog", async () => {

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -385,13 +385,23 @@ describe("NotePage (CRDT)", () => {
 	});
 
 	describe("reading toggle", () => {
-		it("switches to reading view and back", async () => {
+		// One stable name with aria-pressed, not a name that flips between
+		// "Edit"/"Reading view": the icon shows the CURRENT mode, so a label
+		// naming the next action would contradict it.
+		const toggle = () => screen.getByRole("button", { name: "Reading view" });
+
+		it("switches to reading view and back, reporting its state", async () => {
 			renderPage();
 			await screen.findByTestId("note-editor");
-			fireEvent.click(screen.getByRole("button", { name: "Reading view" }));
+			expect(toggle()).toHaveAttribute("aria-pressed", "false");
+
+			fireEvent.click(toggle());
 			expect(screen.getByTestId("note-view")).toBeInTheDocument();
-			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			expect(toggle()).toHaveAttribute("aria-pressed", "true");
+
+			fireEvent.click(toggle());
 			expect(screen.getByTestId("note-editor")).toBeInTheDocument();
+			expect(toggle()).toHaveAttribute("aria-pressed", "false");
 		});
 
 		// Raw is an edit mode, so a round trip through reading must not silently
@@ -403,16 +413,16 @@ describe("NotePage (CRDT)", () => {
 			fireEvent.click(screen.getByRole("menuitem", { name: "Raw" }));
 			await screen.findByLabelText(/Frontmatter \(raw YAML\)/i);
 
-			fireEvent.click(screen.getByRole("button", { name: "Reading view" }));
+			fireEvent.click(toggle());
 			expect(screen.getByTestId("note-view")).toBeInTheDocument();
-			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			fireEvent.click(toggle());
 			expect(await screen.findByLabelText(/Frontmatter \(raw YAML\)/i)).toBeInTheDocument();
 		});
 
 		it("stays in step with the kebab's active-mode marker", async () => {
 			renderPage();
 			await screen.findByTestId("note-editor");
-			fireEvent.click(screen.getByRole("button", { name: "Reading view" }));
+			fireEvent.click(toggle());
 			await openMenu();
 			expect(screen.getByRole("menuitem", { name: "Reading" })).toHaveAttribute(
 				"aria-current",

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -72,7 +72,10 @@ vi.mock("../api/queries", () => ({
 // before initialization" at import time.
 const { navigateMock, locationMock } = vi.hoisted(() => ({
 	navigateMock: vi.fn(),
-	locationMock: vi.fn(() => ({ pathname: "/my-vault/note-1", state: null })),
+	locationMock: vi.fn<() => { pathname: string; state: { justCreated?: boolean } | null }>(() => ({
+		pathname: "/my-vault/note-1",
+		state: null,
+	})),
 }));
 vi.mock("react-router", () => ({
 	useParams: () => ({ itemId: "note-1", slug: "my-vault" }),
@@ -417,6 +420,42 @@ describe("NotePage (CRDT)", () => {
 			await openMenu();
 			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
 			expect(await screen.findByTestId("note-properties")).toHaveTextContent("new-property");
+		});
+	});
+
+	describe("new-note rename", () => {
+		it("opens the title in rename mode when navigated to as just-created", async () => {
+			locationMock.mockReturnValue({
+				pathname: "/my-vault/note-1",
+				state: { justCreated: true },
+			});
+			renderPage();
+			const input = (await screen.findByRole("textbox", {
+				name: "Rename file",
+			})) as HTMLInputElement;
+			expect(input.value).toBe("note");
+			expect(input.selectionStart).toBe(0);
+			expect(input.selectionEnd).toBe("note".length);
+		});
+
+		it("clears the flag so a back-navigation does not reopen the rename box", async () => {
+			locationMock.mockReturnValue({
+				pathname: "/my-vault/note-1",
+				state: { justCreated: true },
+			});
+			renderPage();
+			await screen.findByRole("textbox", { name: "Rename file" });
+			expect(navigateMock).toHaveBeenCalledWith("/my-vault/note-1", {
+				replace: true,
+				state: {},
+			});
+		});
+
+		it("does not start renaming on an ordinary navigation", async () => {
+			locationMock.mockReturnValue({ pathname: "/my-vault/note-1", state: null });
+			renderPage();
+			await screen.findByTestId("note-editor");
+			expect(screen.queryByRole("textbox", { name: "Rename file" })).not.toBeInTheDocument();
 		});
 	});
 });

--- a/frontend/src/viewer/note-page.test.tsx
+++ b/frontend/src/viewer/note-page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
@@ -443,6 +443,31 @@ describe("NotePage (CRDT)", () => {
 			await waitFor(() => expect(screen.queryByTestId("note-properties")).not.toBeInTheDocument());
 		});
 
+		// The gesture deletes the user's typed characters, so it must never
+		// report success without actually opening something — otherwise the
+		// three dashes vanish and nothing happens.
+		it("still works after the first attempt was abandoned", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+
+			fireEvent.click(screen.getByTestId("type-frontmatter-fence"));
+			fireEvent.keyDown(await screen.findByPlaceholderText("Property name"), { key: "Escape" });
+
+			fireEvent.click(screen.getByTestId("type-frontmatter-fence"));
+
+			expect(await screen.findByPlaceholderText("Property name")).toBeInTheDocument();
+		});
+
+		it("leaves nothing behind when the row is abandoned with Escape", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			fireEvent.click(screen.getByTestId("type-frontmatter-fence"));
+
+			fireEvent.keyDown(await screen.findByPlaceholderText("Property name"), { key: "Escape" });
+
+			await waitFor(() => expect(screen.queryByTestId("note-properties")).not.toBeInTheDocument());
+		});
+
 		// Declining is what leaves the typed `---` in the body as a real
 		// horizontal rule instead of silently eating it.
 		it("declines when the note already has frontmatter", async () => {
@@ -578,22 +603,62 @@ describe("NotePage (CRDT)", () => {
 			await openMenu();
 			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
 
-			const row = await screen.findByTestId("property-row-new-property");
-			const value = within(row).getByRole("textbox", { name: "new-property value" });
+			fireEvent.change(await screen.findByPlaceholderText("Property name"), {
+				target: { value: "status" },
+			});
+			const value = screen.getByPlaceholderText("Value");
 			fireEvent.change(value, { target: { value: "hello" } });
-			fireEvent.blur(value);
+			fireEvent.keyDown(value, { key: "Enter" });
 
 			await waitFor(() =>
-				expect(readRows(doc).find((r) => r.key === "new-property")?.value).toBe("hello"),
+				expect(readRows(doc).find((r) => r.key === "status")?.value).toBe("hello"),
 			);
 		});
 
-		it("adds a property to the frontmatter doc", async () => {
+		it("opens the property adder from the note menu", async () => {
 			renderPage();
 			await screen.findByTestId("note-editor");
 			await openMenu();
 			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
-			expect(await screen.findByDisplayValue("new-property")).toBeInTheDocument();
+			expect(await screen.findByPlaceholderText("Property name")).toBeInTheDocument();
+		});
+
+		// The menu used to write a key called "new-property" straight into the doc.
+		// A second use collided with the first, addKey refused it, and the menu item
+		// did nothing at all — no row, no error.
+		it("reopens the adder after a property has already been added", async () => {
+			const doc = new Y.Doc();
+			openDoc.mockResolvedValue({
+				ytext: doc.getText("content"),
+				awareness: new Awareness(doc),
+				doc,
+			});
+			renderPage();
+			await screen.findByTestId("note-editor");
+
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
+			fireEvent.change(await screen.findByPlaceholderText("Property name"), {
+				target: { value: "status" },
+			});
+			fireEvent.keyDown(screen.getByPlaceholderText("Value"), { key: "Enter" });
+			await screen.findByTestId("property-row-status");
+
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
+			expect(await screen.findByPlaceholderText("Property name")).toBeInTheDocument();
+		});
+
+		// The properties widget only renders in rendered mode, so from reading mode
+		// the old handler wrote a property the user could not see locally while it
+		// synced out to every other device.
+		it("switches to rendered mode so the adder it opens is on screen", async () => {
+			renderPage();
+			await screen.findByTestId("note-editor");
+			fireEvent.click(screen.getByRole("button", { name: "Reading view" }));
+			await openMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: "Add property" }));
+			expect(await screen.findByPlaceholderText("Property name")).toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -1,11 +1,19 @@
 import type { EditorView } from "@codemirror/view";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
+import { toast } from "sonner";
 import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
-import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { useNote, useRenameNote } from "../api/queries";
+import {
+	useBatchMoveNotes,
+	useDeleteNote,
+	useDuplicateNote,
+	useFolders,
+	useNote,
+	useRenameNote,
+} from "../api/queries";
+import { addKey } from "../crdt/frontmatter-doc";
 import {
 	type CrdtSyncStatus,
 	closeDoc,
@@ -21,20 +29,19 @@ import { RawFrontmatterEditor } from "./editor/raw-frontmatter-editor";
 import { EditorToolbar } from "./editor/toolbar";
 import { InlineTitle } from "./inline-title";
 import LoadingPane from "./loading-pane";
+import { NoteMenu } from "./note-menu";
 import NoteToc from "./note-toc";
 import NoteView from "./note-view";
 import { PropertiesWidget } from "./properties-widget";
+import type { ActionId, ViewMode } from "./tree-actions/action-list";
+import { DeleteConfirm } from "./tree-actions/delete-confirm";
+import { nextCopyName } from "./tree-actions/duplicate";
+import { MoveDialog } from "./tree-actions/move-dialog";
 import { renameBaseName } from "./tree-actions/rename-path";
 import { useLiveContent } from "./use-live-content";
 
 const NoteEditor = lazy(() => import("./note-editor"));
 
-type Mode = "rendered" | "raw" | "reading";
-const MODES: ReadonlyArray<{ value: Mode; label: string }> = [
-	{ value: "rendered", label: "Rendered" },
-	{ value: "raw", label: "Raw" },
-	{ value: "reading", label: "Reading" },
-];
 interface DocHandle {
 	ytext: Y.Text;
 	awareness: Awareness;
@@ -42,15 +49,21 @@ interface DocHandle {
 }
 
 export default function NotePage() {
-	const params = useParams();
-	const idStr = params.itemId;
+	const { itemId: idStr, slug } = useParams();
 	const validId = idStr && idStr.length > 0 ? idStr : null;
 
 	const { data: note, isLoading, error } = useNote(validId);
 	const { setSlot } = useRightTools();
 	const { setEditor } = useActiveEditor();
 
-	const [mode, setMode] = useState<Mode>("rendered");
+	const navigate = useNavigate();
+	const { data: folders } = useFolders();
+	const deleteNote = useDeleteNote();
+	const duplicateNote = useDuplicateNote();
+	const batchMoveNotes = useBatchMoveNotes();
+	const [dialog, setDialog] = useState<"move" | "delete" | null>(null);
+
+	const [mode, setMode] = useState<ViewMode>("rendered");
 	// Which note the rename box belongs to, not a bare boolean: navigating to
 	// another note keeps this component mounted, and an id-keyed value closes
 	// the box on its own instead of carrying over onto the newly opened note.
@@ -163,6 +176,57 @@ export default function NotePage() {
 		renameNote.mutate({ id: note.id, old_path: note.path, new_path });
 	};
 
+	// Deliberately NOT shared with folder-tree.tsx's handleActionPick: that one
+	// is welded to tree state (getItemInstance().startRenaming(), rowsFor, its
+	// own dialog reducer). The portable parts — the action list and the dialog
+	// components — are already reused. See the design spec.
+	const handleAction = (action: ActionId) => {
+		switch (action) {
+			case "view-rendered":
+				setMode("rendered");
+				break;
+			case "view-raw":
+				setMode("raw");
+				break;
+			case "view-reading":
+				setMode("reading");
+				break;
+			case "rename":
+				setRenamingFor(note.id);
+				break;
+			case "move":
+				setDialog("move");
+				break;
+			case "delete":
+				setDialog("delete");
+				break;
+			case "duplicate": {
+				// No reliable sibling-name set on hand — pass an empty Set and let the
+				// backend reject a collision; the toast surfaces it. Mirrors the tree.
+				const new_path = nextCopyName(note.path, new Set<string>());
+				duplicateNote
+					.mutateAsync({ src_path: note.path, new_path })
+					.then(() => toast.success("Duplicated"))
+					.catch(() => toast.error("Duplicate failed"));
+				break;
+			}
+			case "copy-wikilink":
+				// Wikilinks resolve by filename in Obsidian, never by H1 title.
+				navigator.clipboard
+					.writeText(`[[${name || note.path}]]`)
+					.then(() => toast.success("Copied wikilink"))
+					.catch(() => toast.error("Copy failed"));
+				break;
+			case "add-property":
+				if (handle) {
+					addKey(handle.doc, "new-property", "text");
+				}
+				break;
+			default:
+				break;
+		}
+	};
+
 	return (
 		<section className="mx-auto flex h-full min-h-0 w-full min-w-0 max-w-[840px] flex-col overflow-hidden border-border border-x bg-card text-card-foreground md:-my-6 md:h-[calc(100%+3rem)]">
 			{syncStatus === "error" && (
@@ -176,25 +240,14 @@ export default function NotePage() {
 				<p className="min-w-0 flex-1 truncate text-muted-foreground text-sm" title={titlePath}>
 					{note.folder ? `${note.folder}/` : ""}
 				</p>
-				<fieldset className="m-0 flex shrink-0 gap-1 border-0 p-0">
-					<legend className="sr-only">View mode</legend>
-					{MODES.map(({ value, label }) => (
-						<Button
-							key={value}
-							variant={mode === value ? "secondary" : "ghost"}
-							size="sm"
-							aria-pressed={mode === value}
-							onClick={() => setMode(value)}
-						>
-							{label}
-						</Button>
-					))}
-				</fieldset>
+				<NoteMenu mode={mode} title={name} onPick={handleAction} />
 			</div>
 
 			{/* Pinned above the scroll area: a formatting toolbar that scrolled away
 			    would be unreachable exactly when you are typing further down. */}
-			{mode !== "reading" && handle ? <EditorToolbar getView={() => editorViewRef.current} /> : null}
+			{mode !== "reading" && handle ? (
+				<EditorToolbar getView={() => editorViewRef.current} />
+			) : null}
 
 			<ScrollArea className="min-h-0 flex-1">
 				<div className="w-full pb-5" data-tour="note-editor">
@@ -214,9 +267,7 @@ export default function NotePage() {
 							<NoteView content={liveContent} tags={note.tags} />
 						</div>
 					) : (
-						<Suspense
-							fallback={<p className="px-5 py-5 text-muted-foreground">Loading editor…</p>}
-						>
+						<Suspense fallback={<p className="px-5 py-5 text-muted-foreground">Loading editor…</p>}>
 							{handle ? (
 								<NoteEditor
 									ytext={handle.ytext}
@@ -234,6 +285,37 @@ export default function NotePage() {
 					)}
 				</div>
 			</ScrollArea>
+
+			{dialog === "move" ? (
+				<MoveDialog
+					folders={folders ?? []}
+					nodes={[{ kind: "file", path: note.path }]}
+					onPick={(folder) => {
+						setDialog(null);
+						batchMoveNotes.mutate({
+							ids: [note.id],
+							target_folder: folder,
+							paths: { [note.id]: note.path },
+						});
+					}}
+					onCancel={() => setDialog(null)}
+				/>
+			) : null}
+
+			{dialog === "delete" ? (
+				<DeleteConfirm
+					nodes={[{ kind: "file", path: note.path }]}
+					onConfirm={() => {
+						setDialog(null);
+						deleteNote.mutate({ id: note.id, path: note.path });
+						// useDeleteNote does not navigate — from the tree the deleted note
+						// usually isn't open, but here it is, so staying would strand the
+						// user on a dead route.
+						navigate(slug ? `/${slug}` : "/");
+					}}
+					onCancel={() => setDialog(null)}
+				/>
+			) : null}
 		</section>
 	);
 }

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -269,10 +269,13 @@ export default function NotePage() {
 				// No reliable sibling-name set on hand — pass an empty Set and let the
 				// backend reject a collision; the toast surfaces it. Mirrors the tree.
 				const new_path = nextCopyName(note.path, new Set<string>());
-				duplicateNote
-					.mutateAsync({ src_path: note.path, new_path })
-					.then(() => toast.success("Duplicated"))
-					.catch(() => toast.error("Duplicate failed"));
+				// `mutate`, not `mutateAsync` — the hook's onError already toasts, and
+				// it distinguishes a name collision from a general failure. Catching
+				// here too put a second, vaguer toast on top of the useful one.
+				duplicateNote.mutate(
+					{ src_path: note.path, new_path },
+					{ onSuccess: () => toast.success("Duplicated") },
+				);
 				break;
 			}
 			case "copy-wikilink":

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -37,6 +37,7 @@ import type { ActionId, ViewMode } from "./tree-actions/action-list";
 import { DeleteConfirm } from "./tree-actions/delete-confirm";
 import { nextCopyName } from "./tree-actions/duplicate";
 import { MoveDialog } from "./tree-actions/move-dialog";
+import { RenameInput } from "./tree-actions/rename-input";
 import { renameBaseName } from "./tree-actions/rename-path";
 import { useLiveContent } from "./use-live-content";
 
@@ -67,7 +68,12 @@ export default function NotePage() {
 	// Which note the rename box belongs to, not a bare boolean: navigating to
 	// another note keeps this component mounted, and an id-keyed value closes
 	// the box on its own instead of carrying over onto the newly opened note.
-	const [renamingFor, setRenamingFor] = useState<string | null>(null);
+	//
+	// `at` names the surface because there are two of them — the header path and
+	// the inline title. Rendering a box in both would put two autofocusing
+	// inputs on screen, each committing the other's blur.
+	const [renaming, setRenaming] = useState<{ id: string; at: "header" | "title" } | null>(null);
+	const renamingAt = renaming && renaming.id === note?.id ? renaming.at : null;
 	const [handle, setHandle] = useState<DocHandle | null>(null);
 	const renameNote = useRenameNote();
 	const [syncStatus, setSyncStatus] = useState<CrdtSyncStatus>(getCrdtSyncStatus);
@@ -144,7 +150,7 @@ export default function NotePage() {
 		if (!(justCreated && noteId)) {
 			return;
 		}
-		setRenamingFor(noteId);
+		setRenaming({ id: noteId, at: "title" });
 		navigate(location.pathname, { replace: true, state: {} });
 	}, [justCreated, noteId, navigate, location.pathname]);
 
@@ -177,7 +183,7 @@ export default function NotePage() {
 	const name = noteName(note.path);
 	const titlePath = note.folder ? `${note.folder}/${name}` : name;
 	const commitRename = (next: string) => {
-		setRenamingFor(null);
+		setRenaming(null);
 		// Base-name rename: the header never shows the extension, so the user
 		// can't change the file type from here — the original one is always
 		// re-attached. (The tree's rename is the place to swap .md <-> .canvas.)
@@ -205,7 +211,7 @@ export default function NotePage() {
 				setMode("reading");
 				break;
 			case "rename":
-				setRenamingFor(note.id);
+				setRenaming({ id: note.id, at: "title" });
 				break;
 			case "move":
 				setDialog("move");
@@ -247,11 +253,39 @@ export default function NotePage() {
 					Not syncing - reconnecting...
 				</p>
 			)}
-			{/* Chrome is now just the breadcrumb and the view-mode control — the
-			    title moved into the document so it scrolls with the content. */}
+			{/* The big title moved into the document so it scrolls away, but the
+			    path stays pinned here — it is the only rename affordance still
+			    reachable once you have scrolled the title out of view. */}
 			<div className="flex shrink-0 items-center gap-2 border-border border-b px-4 py-2">
-				<p className="min-w-0 flex-1 truncate text-muted-foreground text-sm" title={titlePath}>
-					{note.folder ? `${note.folder}/` : ""}
+				<p className="flex min-w-0 flex-1 items-baseline gap-1 text-sm" title={titlePath}>
+					{Boolean(note.folder) && (
+						<span className="min-w-0 shrink truncate text-muted-foreground">{note.folder}/</span>
+					)}
+					{renamingAt === "header" ? (
+						<RenameInput
+							initial={name}
+							kind="file"
+							// This reads as a title field, not a modal edit: you click it,
+							// retype, and click into the document. Losing the rename because
+							// you did not press Enter is a surprise, so focus leaving saves.
+							// Escape still abandons.
+							commitOnBlur
+							onCommit={commitRename}
+							onCancel={() => setRenaming(null)}
+						/>
+					) : (
+						<button
+							type="button"
+							data-testid="header-note-name"
+							// -mx-1 cancels the padding so the hover target is roomier than
+							// the text without nudging the name off the folder crumb.
+							className="-mx-1 min-w-0 truncate rounded px-1 font-medium hover:bg-accent"
+							title="Click to rename"
+							onClick={() => setRenaming({ id: note.id, at: "header" })}
+						>
+							{name}
+						</button>
+					)}
 				</p>
 				<NoteMenu mode={mode} title={name} onPick={handleAction} />
 			</div>
@@ -266,10 +300,10 @@ export default function NotePage() {
 				<div className="w-full pb-5" data-tour="note-editor">
 					<InlineTitle
 						name={name}
-						renaming={renamingFor === note.id}
-						onStartRename={() => setRenamingFor(note.id)}
+						renaming={renamingAt === "title"}
+						onStartRename={() => setRenaming({ id: note.id, at: "title" })}
 						onCommitRename={commitRename}
-						onCancelRename={() => setRenamingFor(null)}
+						onCancelRename={() => setRenaming(null)}
 					/>
 
 					{handle && mode === "rendered" ? <PropertiesWidget doc={handle.doc} /> : null}

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -15,7 +15,7 @@ import {
 	useNote,
 	useRenameNote,
 } from "../api/queries";
-import { addKey } from "../crdt/frontmatter-doc";
+import { addKey, readRows } from "../crdt/frontmatter-doc";
 import {
 	type CrdtSyncStatus,
 	closeDoc,
@@ -64,6 +64,10 @@ export default function NotePage() {
 	const duplicateNote = useDuplicateNote();
 	const batchMoveNotes = useBatchMoveNotes();
 	const [dialog, setDialog] = useState<"move" | "delete" | null>(null);
+	// Local-only: an "open but empty" properties block, from the `---` gesture.
+	// Never written to the Y.Doc — the other devices should not sprout an empty
+	// frontmatter section because someone typed three dashes here.
+	const [frontmatterDraft, setFrontmatterDraft] = useState(false);
 
 	const [mode, setMode] = useState<ViewMode>("rendered");
 	// Written only from the reading toggle's handler, never during render.
@@ -157,6 +161,16 @@ export default function NotePage() {
 		navigate(location.pathname, { replace: true, state: {} });
 	}, [justCreated, noteId, navigate, location.pathname]);
 
+	// The draft belongs to the note you are looking at, not to the page, which
+	// stays mounted across note switches. Adjusted during render rather than in
+	// an effect — React's documented pattern for resetting state on a prop
+	// change, and it avoids rendering the stale draft for one frame.
+	const [draftNoteId, setDraftNoteId] = useState(noteId);
+	if (draftNoteId !== noteId) {
+		setDraftNoteId(noteId);
+		setFrontmatterDraft(false);
+	}
+
 	// Publish the editor so right-sidebar tools (the markdown reference panel)
 	// can insert at the caret. Gated on the SAME condition that renders
 	// NoteEditor below, so "Insert" is disabled in reading mode and on
@@ -196,6 +210,18 @@ export default function NotePage() {
 		}
 		// `mutate`, not `mutateAsync` — the mutation's onError owns the toast.
 		renameNote.mutate({ id: note.id, old_path: note.path, new_path });
+	};
+
+	// `---` on the first line opens the properties editor instead of leaving a
+	// horizontal rule. Declined — so the fence survives as a real rule — when
+	// the note already has frontmatter (the editor is showing anyway) or when
+	// raw mode is up, where the YAML block is the frontmatter surface.
+	const handleFrontmatterShortcut = () => {
+		if (mode !== "rendered" || !handle || readRows(handle.doc).length > 0) {
+			return false;
+		}
+		setFrontmatterDraft(true);
+		return true;
 	};
 
 	// Obsidian's binary edit/read toggle, sitting beside the kebab that still
@@ -335,7 +361,13 @@ export default function NotePage() {
 						onCancelRename={() => setRenaming(null)}
 					/>
 
-					{handle && mode === "rendered" ? <PropertiesWidget doc={handle.doc} /> : null}
+					{handle && mode === "rendered" ? (
+						<PropertiesWidget
+							doc={handle.doc}
+							draft={frontmatterDraft}
+							onAbandonDraft={() => setFrontmatterDraft(false)}
+						/>
+					) : null}
 					{handle && mode === "raw" ? <RawFrontmatterEditor doc={handle.doc} /> : null}
 
 					{mode === "reading" ? (
@@ -353,6 +385,7 @@ export default function NotePage() {
 									awareness={handle.awareness}
 									mode={mode === "raw" ? "raw" : "rendered"}
 									resolveWikiLink={resolveWikiLink}
+									onFrontmatterShortcut={handleFrontmatterShortcut}
 									onView={(v) => {
 										editorViewRef.current = v;
 									}}

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -1,6 +1,6 @@
 import type { EditorView } from "@codemirror/view";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router";
+import { useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
@@ -134,6 +134,19 @@ export default function NotePage() {
 		setSlot("outline", <NoteToc content={liveContent} />);
 		return () => setSlot("outline", null);
 	}, [notePath, liveContent, setSlot]);
+
+	// Consume the just-created flag exactly once: start renaming, then strip the
+	// state so a later back-navigation to this history entry doesn't reopen the
+	// rename box on a note the user already named.
+	const location = useLocation();
+	const justCreated = Boolean((location.state as { justCreated?: boolean } | null)?.justCreated);
+	useEffect(() => {
+		if (!(justCreated && noteId)) {
+			return;
+		}
+		setRenamingFor(noteId);
+		navigate(location.pathname, { replace: true, state: {} });
+	}, [justCreated, noteId, navigate, location.pathname]);
 
 	// Publish the editor so right-sidebar tools (the markdown reference panel)
 	// can insert at the caret. Gated on the SAME condition that renders

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -15,7 +15,7 @@ import {
 	useNote,
 	useRenameNote,
 } from "../api/queries";
-import { addKey, readRows } from "../crdt/frontmatter-doc";
+import { readRows } from "../crdt/frontmatter-doc";
 import {
 	type CrdtSyncStatus,
 	closeDoc,
@@ -217,7 +217,10 @@ export default function NotePage() {
 	// the note already has frontmatter (the editor is showing anyway) or when
 	// raw mode is up, where the YAML block is the frontmatter surface.
 	const handleFrontmatterShortcut = () => {
-		if (mode !== "rendered" || !handle || readRows(handle.doc).length > 0) {
+		// Declining when the editor is ALREADY open matters: accepting deletes the
+		// user's three characters, and setting an unchanged flag is a React
+		// bailout that would open nothing in exchange for them.
+		if (frontmatterDraft || mode !== "rendered" || !handle || readRows(handle.doc).length > 0) {
 			return false;
 		}
 		setFrontmatterDraft(true);
@@ -279,9 +282,13 @@ export default function NotePage() {
 					.catch(() => toast.error("Copy failed"));
 				break;
 			case "add-property":
-				if (handle) {
-					addKey(handle.doc, "new-property", "text");
-				}
+				// Opens the adder row rather than writing a key. Inventing a name
+				// meant a second use silently collided and did nothing, and from
+				// reading or raw mode — where this widget is not on screen — it wrote
+				// a property the user could not see but every other device received.
+				// Forcing rendered mode makes the row it opens actually visible.
+				setMode("rendered");
+				setFrontmatterDraft(true);
 				break;
 			default:
 				break;

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -339,7 +339,10 @@ export default function NotePage() {
 					{handle && mode === "raw" ? <RawFrontmatterEditor doc={handle.doc} /> : null}
 
 					{mode === "reading" ? (
-						<div className="px-5 pt-2">
+						// pt matches .cm-content's 20px top padding in note-editor.tsx so
+						// the title sits the same distance above the body in reading mode
+						// as it does in the editor.
+						<div className="px-5 pt-5">
 							<NoteView content={liveContent} tags={note.tags} />
 						</div>
 					) : (

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -307,13 +307,16 @@ export default function NotePage() {
 				<Button
 					variant="ghost"
 					size="icon"
-					// The label names the DESTINATION, not the current state — the icon
-					// is the affordance you are about to use, same as Obsidian's.
-					aria-label={mode === "reading" ? "Edit" : "Reading view"}
-					title={mode === "reading" ? "Edit" : "Reading view"}
+					// The icon shows the mode you are IN — book while reading, pencil
+					// while editing — so the name has to stay put and let aria-pressed
+					// carry the state. A name that flipped to the next action would
+					// tell a screen reader the opposite of what the icon shows.
+					aria-label="Reading view"
+					aria-pressed={mode === "reading"}
+					title="Reading view"
 					onClick={toggleReading}
 				>
-					{mode === "reading" ? <Pencil className="size-4" /> : <BookOpen className="size-4" />}
+					{mode === "reading" ? <BookOpen className="size-4" /> : <Pencil className="size-4" />}
 				</Button>
 				<NoteMenu mode={mode} title={name} onPick={handleAction} />
 			</div>

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -25,6 +25,7 @@ import {
 	subscribeToCrdtSyncStatus,
 } from "../crdt/session";
 import { useRightTools } from "../layout/right-tools-context";
+import { copyToClipboard } from "../lib/clipboard";
 import { noteName } from "../lib/note-name";
 import { useActiveEditor } from "./editor/active-editor-context";
 import { RawFrontmatterEditor } from "./editor/raw-frontmatter-editor";
@@ -276,10 +277,9 @@ export default function NotePage() {
 			}
 			case "copy-wikilink":
 				// Wikilinks resolve by filename in Obsidian, never by H1 title.
-				navigator.clipboard
-					.writeText(`[[${name || note.path}]]`)
-					.then(() => toast.success("Copied wikilink"))
-					.catch(() => toast.error("Copy failed"));
+				copyToClipboard(`[[${name || note.path}]]`).then((ok) =>
+					ok ? toast.success("Copied wikilink") : toast.error("Copy failed"),
+				);
 				break;
 			case "add-property":
 				// Opens the adder row rather than writing a key. Inventing a name

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -1,9 +1,11 @@
 import type { EditorView } from "@codemirror/view";
+import { BookOpen, Pencil } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	useBatchMoveNotes,
@@ -65,6 +67,8 @@ export default function NotePage() {
 	const [dialog, setDialog] = useState<"move" | "delete" | null>(null);
 
 	const [mode, setMode] = useState<ViewMode>("rendered");
+	// Written only from the reading toggle's handler, never during render.
+	const lastEditMode = useRef<Exclude<ViewMode, "reading">>("rendered");
 	// Which note the rename box belongs to, not a bare boolean: navigating to
 	// another note keeps this component mounted, and an id-keyed value closes
 	// the box on its own instead of carrying over onto the newly opened note.
@@ -195,6 +199,19 @@ export default function NotePage() {
 		renameNote.mutate({ id: note.id, old_path: note.path, new_path });
 	};
 
+	// Obsidian's binary edit/read toggle, sitting beside the kebab that still
+	// carries all three modes. Raw counts as an EDIT mode, so returning from
+	// reading restores whichever editor you left rather than always landing on
+	// rendered — a round trip must not silently demote raw.
+	const toggleReading = () => {
+		if (mode === "reading") {
+			setMode(lastEditMode.current);
+			return;
+		}
+		lastEditMode.current = mode;
+		setMode("reading");
+	};
+
 	// Deliberately NOT shared with folder-tree.tsx's handleActionPick: that one
 	// is welded to tree state (getItemInstance().startRenaming(), rowsFor, its
 	// own dialog reducer). The portable parts — the action list and the dialog
@@ -287,6 +304,17 @@ export default function NotePage() {
 						</button>
 					)}
 				</p>
+				<Button
+					variant="ghost"
+					size="icon"
+					// The label names the DESTINATION, not the current state — the icon
+					// is the affordance you are about to use, same as Obsidian's.
+					aria-label={mode === "reading" ? "Edit" : "Reading view"}
+					title={mode === "reading" ? "Edit" : "Reading view"}
+					onClick={toggleReading}
+				>
+					{mode === "reading" ? <Pencil className="size-4" /> : <BookOpen className="size-4" />}
+				</Button>
 				<NoteMenu mode={mode} title={name} onPick={handleAction} />
 			</div>
 

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -19,11 +19,11 @@ import { noteName } from "../lib/note-name";
 import { useActiveEditor } from "./editor/active-editor-context";
 import { RawFrontmatterEditor } from "./editor/raw-frontmatter-editor";
 import { EditorToolbar } from "./editor/toolbar";
+import { InlineTitle } from "./inline-title";
 import LoadingPane from "./loading-pane";
 import NoteToc from "./note-toc";
 import NoteView from "./note-view";
 import { PropertiesWidget } from "./properties-widget";
-import { RenameInput } from "./tree-actions/rename-input";
 import { renameBaseName } from "./tree-actions/rename-path";
 import { useLiveContent } from "./use-live-content";
 
@@ -170,36 +170,12 @@ export default function NotePage() {
 					Not syncing - reconnecting...
 				</p>
 			)}
+			{/* Chrome is now just the breadcrumb and the view-mode control — the
+			    title moved into the document so it scrolls with the content. */}
 			<div className="flex shrink-0 items-center gap-2 border-border border-b px-4 py-2">
-				<h2 className="flex min-w-0 flex-1 items-baseline gap-1 text-sm" title={titlePath}>
-					{Boolean(note.folder) && (
-						<span className="min-w-0 shrink truncate text-muted-foreground">{note.folder}/</span>
-					)}
-					{renamingFor === note.id ? (
-						<RenameInput
-							initial={name}
-							kind="file"
-							// This reads as a title field, not a modal edit: you click it,
-							// retype, and click into the document. Losing the rename because
-							// you did not press Enter is a surprise, so focus leaving saves.
-							// Escape still abandons.
-							commitOnBlur
-							onCommit={commitRename}
-							onCancel={() => setRenamingFor(null)}
-						/>
-					) : (
-						<button
-							type="button"
-							// -mx-1 cancels the padding so the hover target is roomier than
-							// the text without nudging the name off the folder crumb.
-							className="-mx-1 min-w-0 truncate rounded px-1 font-medium hover:bg-accent"
-							title="Click to rename"
-							onClick={() => setRenamingFor(note.id)}
-						>
-							{name}
-						</button>
-					)}
-				</h2>
+				<p className="min-w-0 flex-1 truncate text-muted-foreground text-sm" title={titlePath}>
+					{note.folder ? `${note.folder}/` : ""}
+				</p>
 				<fieldset className="m-0 flex shrink-0 gap-1 border-0 p-0">
 					<legend className="sr-only">View mode</legend>
 					{MODES.map(({ value, label }) => (
@@ -216,21 +192,32 @@ export default function NotePage() {
 				</fieldset>
 			</div>
 
-			{handle && mode === "rendered" ? <PropertiesWidget doc={handle.doc} /> : null}
-			{handle && mode === "raw" ? <RawFrontmatterEditor doc={handle.doc} /> : null}
+			{/* Pinned above the scroll area: a formatting toolbar that scrolled away
+			    would be unreachable exactly when you are typing further down. */}
+			{mode !== "reading" && handle ? <EditorToolbar getView={() => editorViewRef.current} /> : null}
 
-			{mode === "reading" ? (
-				<ScrollArea className="min-h-0 flex-1">
-					<div className="w-full px-5 py-5">
-						<NoteView content={liveContent} tags={note.tags} />
-					</div>
-				</ScrollArea>
-			) : (
-				<div className="min-h-0 flex-1 overflow-hidden" data-tour="note-editor">
-					<Suspense fallback={<p className="py-5 text-muted-foreground">Loading editor…</p>}>
-						{handle ? (
-							<>
-								<EditorToolbar getView={() => editorViewRef.current} />
+			<ScrollArea className="min-h-0 flex-1">
+				<div className="w-full pb-5" data-tour="note-editor">
+					<InlineTitle
+						name={name}
+						renaming={renamingFor === note.id}
+						onStartRename={() => setRenamingFor(note.id)}
+						onCommitRename={commitRename}
+						onCancelRename={() => setRenamingFor(null)}
+					/>
+
+					{handle && mode === "rendered" ? <PropertiesWidget doc={handle.doc} /> : null}
+					{handle && mode === "raw" ? <RawFrontmatterEditor doc={handle.doc} /> : null}
+
+					{mode === "reading" ? (
+						<div className="px-5 pt-2">
+							<NoteView content={liveContent} tags={note.tags} />
+						</div>
+					) : (
+						<Suspense
+							fallback={<p className="px-5 py-5 text-muted-foreground">Loading editor…</p>}
+						>
+							{handle ? (
 								<NoteEditor
 									ytext={handle.ytext}
 									awareness={handle.awareness}
@@ -240,13 +227,13 @@ export default function NotePage() {
 										editorViewRef.current = v;
 									}}
 								/>
-							</>
-						) : (
-							<p className="py-5 text-muted-foreground">Connecting…</p>
-						)}
-					</Suspense>
+							) : (
+								<p className="px-5 py-5 text-muted-foreground">Connecting…</p>
+							)}
+						</Suspense>
+					)}
 				</div>
-			)}
+			</ScrollArea>
 		</section>
 	);
 }

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -28,7 +28,6 @@ import { useRightTools } from "../layout/right-tools-context";
 import { noteName } from "../lib/note-name";
 import { useActiveEditor } from "./editor/active-editor-context";
 import { RawFrontmatterEditor } from "./editor/raw-frontmatter-editor";
-import { EditorToolbar } from "./editor/toolbar";
 import { InlineTitle } from "./inline-title";
 import LoadingPane from "./loading-pane";
 import { NoteMenu } from "./note-menu";
@@ -321,11 +320,10 @@ export default function NotePage() {
 				<NoteMenu mode={mode} title={name} onPick={handleAction} />
 			</div>
 
-			{/* Pinned above the scroll area: a formatting toolbar that scrolled away
-			    would be unreachable exactly when you are typing further down. */}
-			{mode !== "reading" && handle ? (
-				<EditorToolbar getView={() => editorViewRef.current} />
-			) : null}
+			{/* EditorToolbar is deliberately NOT mounted — see editor/toolbar.tsx.
+			    A desktop-width strip of format buttons earns little next to the
+			    markdown shortcuts, and the case it does earn is mobile, where it
+			    belongs above the keyboard rather than under the header. */}
 
 			<ScrollArea className="min-h-0 flex-1">
 				<div className="w-full pb-5" data-tour="note-editor">

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -25,10 +25,41 @@ describe("PropertiesWidget", () => {
 
 	test("add property row appends a key", async () => {
 		const doc = new Y.Doc();
+		// Seeded: the widget hides itself (and its adder) on a note with no
+		// frontmatter, so there has to be a row for the inline adder to exist.
+		addKey(doc, "title", "text");
 		render(<PropertiesWidget doc={doc} />);
 		fireEvent.change(screen.getByPlaceholderText("Property name"), { target: { value: "status" } });
 		fireEvent.click(screen.getByRole("button", { name: /add property/i }));
 		await waitFor(() => expect(readRows(doc).map((r) => r.key)).toContain("status"));
+	});
+
+	// An empty frontmatter block is a bordered strip of nothing above every
+	// note that never got a property. Obsidian hides it; so do we.
+	describe("when the note has no frontmatter", () => {
+		test("renders nothing at all", () => {
+			const { container } = render(<PropertiesWidget doc={new Y.Doc()} />);
+			expect(screen.queryByTestId("note-properties")).not.toBeInTheDocument();
+			expect(container).toBeEmptyDOMElement();
+		});
+
+		// Hidden must mean "returns null while still observing", not
+		// "unmounted" — otherwise nothing is listening to bring it back.
+		test("appears as soon as a property arrives", async () => {
+			const doc = new Y.Doc();
+			render(<PropertiesWidget doc={doc} />);
+			expect(screen.queryByTestId("note-properties")).not.toBeInTheDocument();
+			addKey(doc, "status", "text");
+			await waitFor(() => expect(screen.getByTestId("note-properties")).toBeInTheDocument());
+		});
+
+		test("goes away again when the last property is removed", async () => {
+			const doc = new Y.Doc();
+			addKey(doc, "status", "text");
+			render(<PropertiesWidget doc={doc} />);
+			fireEvent.click(await screen.findByRole("button", { name: "Remove status" }));
+			await waitFor(() => expect(screen.queryByTestId("note-properties")).not.toBeInTheDocument());
+		});
 	});
 
 	test("does not clobber a field being actively edited by a remote update", async () => {

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import * as Y from "yjs";
 import { addKey, readRows, setValue } from "../crdt/frontmatter-doc";
 import { PropertiesWidget } from "./properties-widget";
@@ -51,6 +51,51 @@ describe("PropertiesWidget", () => {
 			expect(screen.queryByTestId("note-properties")).not.toBeInTheDocument();
 			addKey(doc, "status", "text");
 			await waitFor(() => expect(screen.getByTestId("note-properties")).toBeInTheDocument());
+		});
+
+		// The `---` gesture opens the editor before any property exists. That
+		// "open but empty" state is LOCAL — it must never reach the Y.Doc, or an
+		// empty properties block would sync to the user's other devices.
+		describe("draft mode", () => {
+			test("shows the empty editor and puts the caret in the name field", async () => {
+				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={() => {}} />);
+				expect(screen.getByTestId("note-properties")).toBeInTheDocument();
+				await waitFor(() => expect(screen.getByPlaceholderText("Property name")).toHaveFocus());
+			});
+
+			// Clicking dead space is the ordinary way out, and it focuses nothing —
+			// which is exactly the case a relatedTarget check would miss.
+			test("abandons on a click outside when nothing was added", () => {
+				const onAbandonDraft = vi.fn();
+				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={onAbandonDraft} />);
+				fireEvent.pointerDown(document.body);
+				expect(onAbandonDraft).toHaveBeenCalled();
+			});
+
+			test("abandons on tabbing away", () => {
+				const onAbandonDraft = vi.fn();
+				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={onAbandonDraft} />);
+				fireEvent.focusIn(document.body);
+				expect(onAbandonDraft).toHaveBeenCalled();
+			});
+
+			test("stays once a property was added", () => {
+				const onAbandonDraft = vi.fn();
+				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={onAbandonDraft} />);
+				fireEvent.change(screen.getByPlaceholderText("Property name"), {
+					target: { value: "status" },
+				});
+				fireEvent.click(screen.getByRole("button", { name: /add property/i }));
+				fireEvent.pointerDown(document.body);
+				expect(onAbandonDraft).not.toHaveBeenCalled();
+			});
+
+			test("does not abandon on interaction inside the editor", () => {
+				const onAbandonDraft = vi.fn();
+				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={onAbandonDraft} />);
+				fireEvent.pointerDown(screen.getByRole("button", { name: /add property/i }));
+				expect(onAbandonDraft).not.toHaveBeenCalled();
+			});
 		});
 
 		test("goes away again when the last property is removed", async () => {

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -105,6 +105,25 @@ describe("PropertiesWidget", () => {
 				expect(onAbandonDraft).toHaveBeenCalled();
 			});
 
+			// Clicking away from a property you just filled in should keep it. The
+			// draft has committed nothing yet, so a naive "is the doc empty?" check
+			// throws the typed key and value away.
+			test("commits what was typed instead of discarding it", () => {
+				const doc = new Y.Doc();
+				const onAbandonDraft = vi.fn();
+				render(<PropertiesWidget doc={doc} draft onAbandonDraft={onAbandonDraft} />);
+				fireEvent.change(screen.getByPlaceholderText("Property name"), {
+					target: { value: "status" },
+				});
+				fireEvent.change(screen.getByPlaceholderText("Value"), { target: { value: "draft" } });
+
+				fireEvent.pointerDown(document.body);
+
+				// Synchronous: the commit writes to the Y.Doc inside the handler.
+				expect(readRows(doc).find((r) => r.key === "status")?.value).toBe("draft");
+				expect(onAbandonDraft).not.toHaveBeenCalled();
+			});
+
 			test("abandons on tabbing away", () => {
 				const onAbandonDraft = vi.fn();
 				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={onAbandonDraft} />);

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import * as Y from "yjs";
 import { addKey, readRows, setValue } from "../crdt/frontmatter-doc";
@@ -34,18 +34,37 @@ describe("PropertiesWidget", () => {
 		await waitFor(() => expect(readRows(doc).map((r) => r.key)).toContain("status"));
 	});
 
-	// Naming a property is only half the job — the point of adding one is to
-	// give it a value, so the caret has to end up there.
-	test("adding a property leaves its value ready to type into", async () => {
+	// The row being filled in is the ONLY row on a note with no properties, so
+	// if it has nowhere to type a value there is nowhere to type one at all.
+	test("the new-property row has a value field, not just a key", () => {
+		render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={() => {}} />);
+		expect(screen.getByPlaceholderText("Property name")).toBeInTheDocument();
+		expect(screen.getByPlaceholderText("Value")).toBeInTheDocument();
+	});
+
+	test("commits key and value together, then waits for the next property", async () => {
 		const doc = new Y.Doc();
-		render(<PropertiesWidget doc={doc} />);
-		addKey(doc, "seed", "text"); // make the widget visible
-		const name = await screen.findByPlaceholderText("Property name");
+		render(<PropertiesWidget doc={doc} draft onAbandonDraft={() => {}} />);
+		fireEvent.change(screen.getByPlaceholderText("Property name"), {
+			target: { value: "status" },
+		});
+		fireEvent.change(screen.getByPlaceholderText("Value"), { target: { value: "draft" } });
+		fireEvent.keyDown(screen.getByPlaceholderText("Value"), { key: "Enter" });
+
+		await waitFor(() => expect(readRows(doc).find((r) => r.key === "status")?.value).toBe("draft"));
+		expect(screen.getByPlaceholderText("Property name")).toHaveFocus();
+		expect(screen.getByPlaceholderText("Property name")).toHaveValue("");
+	});
+
+	test("Enter in the key field moves to the value rather than committing early", () => {
+		const doc = new Y.Doc();
+		render(<PropertiesWidget doc={doc} draft onAbandonDraft={() => {}} />);
+		const name = screen.getByPlaceholderText("Property name");
 		fireEvent.change(name, { target: { value: "status" } });
 		fireEvent.keyDown(name, { key: "Enter" });
 
-		const row = await screen.findByTestId("property-row-status");
-		expect(within(row).getByRole("textbox")).toHaveFocus();
+		expect(screen.getByPlaceholderText("Value")).toHaveFocus();
+		expect(readRows(doc)).toHaveLength(0);
 	});
 
 	// An empty frontmatter block is a bordered strip of nothing above every

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -4,6 +4,9 @@ import * as Y from "yjs";
 import { addKey, readRows, setValue } from "../crdt/frontmatter-doc";
 import { PropertiesWidget } from "./properties-widget";
 
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: toastError } }));
+
 describe("PropertiesWidget", () => {
 	test("renders rows from the doc and writes value edits back", async () => {
 		const doc = new Y.Doc();
@@ -194,6 +197,31 @@ describe("PropertiesWidget", () => {
 
 				// Synchronous: the commit writes to the Y.Doc inside the handler.
 				expect(readRows(doc).find((r) => r.key === "status")?.value).toBe("draft");
+				// Committed still closes the row, so the parent must hear about it —
+				// its `draft` flag is a request to open, and a flag left raised can
+				// never be raised again.
+				expect(onAbandonDraft).toHaveBeenCalled();
+			});
+
+			// A name that is taken is NOT "never mind" — the user typed something
+			// real. Collapsing it into the empty case destroyed both fields.
+			test("keeps a colliding row open instead of wiping what was typed", () => {
+				const doc = new Y.Doc();
+				addKey(doc, "status", "text");
+				const onAbandonDraft = vi.fn();
+				render(<PropertiesWidget doc={doc} draft onAbandonDraft={onAbandonDraft} />);
+				fireEvent.change(screen.getByPlaceholderText("Property name"), {
+					target: { value: "status" },
+				});
+				fireEvent.change(screen.getByPlaceholderText("Value"), {
+					target: { value: "IMPORTANT" },
+				});
+
+				fireEvent.pointerDown(document.body);
+
+				expect(screen.getByPlaceholderText("Property name")).toHaveValue("status");
+				expect(screen.getByPlaceholderText("Value")).toHaveValue("IMPORTANT");
+				expect(toastError).toHaveBeenCalled();
 				expect(onAbandonDraft).not.toHaveBeenCalled();
 			});
 
@@ -204,15 +232,22 @@ describe("PropertiesWidget", () => {
 				expect(onAbandonDraft).toHaveBeenCalled();
 			});
 
+			// Once a real property exists the widget is no longer a draft — it stays
+			// on screen off the doc's own contents, whatever the parent's flag says.
 			test("stays once a property was added", () => {
 				const onAbandonDraft = vi.fn();
-				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={onAbandonDraft} />);
+				const doc = new Y.Doc();
+				const { rerender } = render(
+					<PropertiesWidget doc={doc} draft onAbandonDraft={onAbandonDraft} />,
+				);
 				fireEvent.change(screen.getByPlaceholderText("Property name"), {
 					target: { value: "status" },
 				});
-				fireEvent.click(screen.getByRole("button", { name: /add property/i }));
 				fireEvent.pointerDown(document.body);
-				expect(onAbandonDraft).not.toHaveBeenCalled();
+
+				rerender(<PropertiesWidget doc={doc} draft={false} onAbandonDraft={onAbandonDraft} />);
+				expect(screen.getByTestId("note-properties")).toBeInTheDocument();
+				expect(screen.getByTestId("property-row-status")).toBeInTheDocument();
 			});
 
 			// Radix portals its menu to document.body, so a click on a type option

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import * as Y from "yjs";
 import { addKey, readRows, setValue } from "../crdt/frontmatter-doc";
@@ -32,6 +32,20 @@ describe("PropertiesWidget", () => {
 		fireEvent.change(screen.getByPlaceholderText("Property name"), { target: { value: "status" } });
 		fireEvent.click(screen.getByRole("button", { name: /add property/i }));
 		await waitFor(() => expect(readRows(doc).map((r) => r.key)).toContain("status"));
+	});
+
+	// Naming a property is only half the job — the point of adding one is to
+	// give it a value, so the caret has to end up there.
+	test("adding a property leaves its value ready to type into", async () => {
+		const doc = new Y.Doc();
+		render(<PropertiesWidget doc={doc} />);
+		addKey(doc, "seed", "text"); // make the widget visible
+		const name = await screen.findByPlaceholderText("Property name");
+		fireEvent.change(name, { target: { value: "status" } });
+		fireEvent.keyDown(name, { key: "Enter" });
+
+		const row = await screen.findByTestId("property-row-status");
+		expect(within(row).getByRole("textbox")).toHaveFocus();
 	});
 
 	// An empty frontmatter block is a bordered strip of nothing above every
@@ -87,6 +101,21 @@ describe("PropertiesWidget", () => {
 				});
 				fireEvent.click(screen.getByRole("button", { name: /add property/i }));
 				fireEvent.pointerDown(document.body);
+				expect(onAbandonDraft).not.toHaveBeenCalled();
+			});
+
+			// Radix portals its menu to document.body, so a click on a type option
+			// lands OUTSIDE the widget's root — the dismissal must not read that
+			// as clicking away, or picking a type destroys the draft.
+			test("picking a property type does not abandon the draft", async () => {
+				const onAbandonDraft = vi.fn();
+				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={onAbandonDraft} />);
+				const trigger = screen.getByRole("button", { name: "Property type" });
+				fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+				fireEvent.click(trigger);
+				const option = await screen.findByRole("menuitem", { name: "number" });
+				fireEvent.pointerDown(option);
+				fireEvent.click(option);
 				expect(onAbandonDraft).not.toHaveBeenCalled();
 			});
 

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -23,15 +23,34 @@ describe("PropertiesWidget", () => {
 		await waitFor(() => expect(screen.getByText("author")).toBeInTheDocument());
 	});
 
-	test("add property row appends a key", async () => {
+	// Obsidian shows no placeholder row — the list is exactly the properties you
+	// have, and the button appends one to author.
+	test("no row to author until Add property is clicked", async () => {
 		const doc = new Y.Doc();
-		// Seeded: the widget hides itself (and its adder) on a note with no
-		// frontmatter, so there has to be a row for the inline adder to exist.
 		addKey(doc, "title", "text");
 		render(<PropertiesWidget doc={doc} />);
-		fireEvent.change(screen.getByPlaceholderText("Property name"), { target: { value: "status" } });
+		await screen.findByText("title");
+		expect(screen.queryByPlaceholderText("Property name")).not.toBeInTheDocument();
+
 		fireEvent.click(screen.getByRole("button", { name: /add property/i }));
-		await waitFor(() => expect(readRows(doc).map((r) => r.key)).toContain("status"));
+
+		expect(screen.getByPlaceholderText("Property name")).toBeInTheDocument();
+		expect(screen.getByPlaceholderText("Value")).toBeInTheDocument();
+	});
+
+	test("Escape drops the row being authored without adding it", async () => {
+		const doc = new Y.Doc();
+		addKey(doc, "title", "text");
+		render(<PropertiesWidget doc={doc} />);
+		await screen.findByText("title");
+		fireEvent.click(screen.getByRole("button", { name: /add property/i }));
+
+		const name = screen.getByPlaceholderText("Property name");
+		fireEvent.change(name, { target: { value: "status" } });
+		fireEvent.keyDown(name, { key: "Escape" });
+
+		expect(screen.queryByPlaceholderText("Property name")).not.toBeInTheDocument();
+		expect(readRows(doc).map((r) => r.key)).not.toContain("status");
 	});
 
 	// The row being filled in is the ONLY row on a note with no properties, so
@@ -42,7 +61,7 @@ describe("PropertiesWidget", () => {
 		expect(screen.getByPlaceholderText("Value")).toBeInTheDocument();
 	});
 
-	test("commits key and value together, then waits for the next property", async () => {
+	test("commits key and value together, then closes the authoring row", async () => {
 		const doc = new Y.Doc();
 		render(<PropertiesWidget doc={doc} draft onAbandonDraft={() => {}} />);
 		fireEvent.change(screen.getByPlaceholderText("Property name"), {
@@ -51,9 +70,9 @@ describe("PropertiesWidget", () => {
 		fireEvent.change(screen.getByPlaceholderText("Value"), { target: { value: "draft" } });
 		fireEvent.keyDown(screen.getByPlaceholderText("Value"), { key: "Enter" });
 
-		await waitFor(() => expect(readRows(doc).find((r) => r.key === "status")?.value).toBe("draft"));
-		expect(screen.getByPlaceholderText("Property name")).toHaveFocus();
-		expect(screen.getByPlaceholderText("Property name")).toHaveValue("");
+		await waitFor(() => expect(screen.getByTestId("property-row-status")).toBeInTheDocument());
+		expect(readRows(doc).find((r) => r.key === "status")?.value).toBe("draft");
+		expect(screen.queryByPlaceholderText("Property name")).not.toBeInTheDocument();
 	});
 
 	test("Enter in the key field moves to the value rather than committing early", () => {

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -20,7 +20,61 @@ describe("PropertiesWidget", () => {
 		const doc = new Y.Doc();
 		render(<PropertiesWidget doc={doc} />);
 		addKey(doc, "author", "text"); // simulate remote mutation
-		await waitFor(() => expect(screen.getByText("author")).toBeInTheDocument());
+		await waitFor(() => expect(screen.getByDisplayValue("author")).toBeInTheDocument());
+	});
+
+	describe("renaming a property", () => {
+		const openRow = async (doc: Y.Doc) => {
+			addKey(doc, "status", "text");
+			setValue(doc, "status", "draft");
+			render(<PropertiesWidget doc={doc} />);
+			return (await screen.findByDisplayValue("status")) as HTMLInputElement;
+		};
+
+		test("commits the new name on Enter, keeping the value", async () => {
+			const doc = new Y.Doc();
+			const key = await openRow(doc);
+			fireEvent.change(key, { target: { value: "state" } });
+			fireEvent.keyDown(key, { key: "Enter" });
+
+			await waitFor(() => expect(readRows(doc).map((r) => r.key)).toEqual(["state"]));
+			expect(readRows(doc)[0]?.value).toBe("draft");
+		});
+
+		test("commits on blur too, since a title field you click away from should save", async () => {
+			const doc = new Y.Doc();
+			const key = await openRow(doc);
+			fireEvent.change(key, { target: { value: "state" } });
+			fireEvent.blur(key);
+
+			await waitFor(() => expect(readRows(doc).map((r) => r.key)).toEqual(["state"]));
+		});
+
+		test("Escape puts the original name back", async () => {
+			const doc = new Y.Doc();
+			const key = await openRow(doc);
+			fireEvent.change(key, { target: { value: "state" } });
+			fireEvent.keyDown(key, { key: "Escape" });
+
+			expect(key.value).toBe("status");
+			expect(readRows(doc).map((r) => r.key)).toEqual(["status"]);
+		});
+
+		// A collision would silently destroy one of the two properties.
+		test("refuses a name another property already has", async () => {
+			const doc = new Y.Doc();
+			const key = await openRow(doc);
+			addKey(doc, "taken", "text");
+			fireEvent.change(key, { target: { value: "taken" } });
+			fireEvent.keyDown(key, { key: "Enter" });
+
+			await waitFor(() => expect(key.value).toBe("status"));
+			expect(
+				readRows(doc)
+					.map((r) => r.key)
+					.sort(),
+			).toEqual(["status", "taken"]);
+		});
 	});
 
 	// Obsidian shows no placeholder row — the list is exactly the properties you
@@ -29,7 +83,7 @@ describe("PropertiesWidget", () => {
 		const doc = new Y.Doc();
 		addKey(doc, "title", "text");
 		render(<PropertiesWidget doc={doc} />);
-		await screen.findByText("title");
+		await screen.findByDisplayValue("title");
 		expect(screen.queryByPlaceholderText("Property name")).not.toBeInTheDocument();
 
 		fireEvent.click(screen.getByRole("button", { name: /add property/i }));
@@ -42,7 +96,7 @@ describe("PropertiesWidget", () => {
 		const doc = new Y.Doc();
 		addKey(doc, "title", "text");
 		render(<PropertiesWidget doc={doc} />);
-		await screen.findByText("title");
+		await screen.findByDisplayValue("title");
 		fireEvent.click(screen.getByRole("button", { name: /add property/i }));
 
 		const name = screen.getByPlaceholderText("Property name");

--- a/frontend/src/viewer/properties-widget.test.tsx
+++ b/frontend/src/viewer/properties-widget.test.tsx
@@ -256,7 +256,7 @@ describe("PropertiesWidget", () => {
 			test("picking a property type does not abandon the draft", async () => {
 				const onAbandonDraft = vi.fn();
 				render(<PropertiesWidget doc={new Y.Doc()} draft onAbandonDraft={onAbandonDraft} />);
-				const trigger = screen.getByRole("button", { name: "Property type" });
+				const trigger = screen.getByRole("button", { name: /^Property type/ });
 				fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
 				fireEvent.click(trigger);
 				const option = await screen.findByRole("menuitem", { name: "number" });

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -15,6 +15,10 @@ import { PropertyField } from "./property-fields";
 import { PropertyTypeMenu } from "./property-type-menu";
 import { effectiveType, type PropertyType } from "./property-types";
 
+// Obsidian's --metadata-label-width is 9em against the 16px root, so 144px,
+// and it does NOT shrink — long values never squeeze the key column.
+const KEY_CELL = "flex min-h-7 w-36 min-w-36 shrink-0 items-center overflow-hidden rounded-md";
+
 interface Props {
 	doc: Y.Doc;
 	/**
@@ -48,6 +52,12 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 
 	const [newKey, setNewKey] = useState("");
 	const [newType, setNewType] = useState<PropertyType>("text");
+
+	const commitNewKey = () => {
+		if (addKey(doc, newKey, newType)) {
+			setNewKey("");
+		}
+	};
 
 	// The `---` gesture opens this with nothing in it, so the caret has to land
 	// in the name field — otherwise there is nothing to click away FROM.
@@ -94,22 +104,33 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 	}
 
 	return (
-		<div className="px-5 py-3" data-testid="note-properties" ref={rootRef}>
-			<dl className="grid grid-cols-[max-content_max-content_1fr_max-content] items-center gap-x-2 gap-y-1 text-xs">
+		// Geometry lifted from Obsidian's app.css: 8px block padding, a 2rem gap
+		// down to the body, 3px between rows, a 9em key column, 28px row height.
+		<section className="mb-8 px-5 py-2" data-testid="note-properties" ref={rootRef}>
+			<dl className="flex flex-col gap-[3px]">
 				{rows.map((row) => {
 					const type = effectiveType(row.value, row.typeOverride);
 					return (
-						<div key={row.key} className="contents" data-testid={`property-row-${row.key}`}>
-							<dt className="font-medium text-muted-foreground">{row.key}</dt>
-							<PropertyTypeMenu value={type} onChange={(t) => setType(doc, row.key, t)} />
-							<dd>
+						<div
+							key={row.key}
+							className="group flex items-start rounded-md"
+							data-testid={`property-row-${row.key}`}
+						>
+							<dt className={KEY_CELL}>
+								<PropertyTypeMenu value={type} onChange={(t) => setType(doc, row.key, t)} />
+								<span className="truncate px-1 text-muted-foreground text-sm">{row.key}</span>
+							</dt>
+							<dd className="flex min-h-7 flex-1 items-center gap-1">
 								<PropertyField
 									type={type}
 									value={row.value}
 									onCommit={(v) => setValue(doc, row.key, v)}
 								/>
 							</dd>
-							<div className="flex items-center gap-0.5 text-muted-foreground">
+							{/* Obsidian keeps row actions in a right-click menu, so the
+							    default view stays clean. We surface ours on hover/focus
+							    rather than dropping the capability. */}
+							<div className="flex min-h-7 items-center gap-0.5 text-muted-foreground opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
 								<button
 									type="button"
 									aria-label={`Move ${row.key} up`}
@@ -139,28 +160,35 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 					);
 				})}
 			</dl>
-			<div className="mt-2 flex items-center gap-2">
-				<input
-					ref={newKeyRef}
-					className="rounded border border-border bg-transparent px-2 py-1 text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-ring"
-					placeholder="Property name"
-					value={newKey}
-					onChange={(e) => setNewKey(e.target.value)}
-				/>
-				<PropertyTypeMenu value={newType} onChange={setNewType} />
+
+			{/* The adder wears the same row geometry, so a property being named
+			    looks like the row it is about to become. */}
+			<div className="mt-[3px] flex items-start">
+				<div className={KEY_CELL}>
+					<PropertyTypeMenu value={newType} onChange={setNewType} />
+					<input
+						ref={newKeyRef}
+						className="w-full min-w-0 border-0 bg-transparent px-1 text-muted-foreground text-sm outline-none placeholder:text-muted-foreground/60"
+						placeholder="Property name"
+						value={newKey}
+						onChange={(e) => setNewKey(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								commitNewKey();
+							}
+						}}
+					/>
+				</div>
 				<button
 					type="button"
 					aria-label="Add property"
-					className="rounded border border-border px-2 py-1 text-muted-foreground text-xs hover:bg-muted"
-					onClick={() => {
-						if (addKey(doc, newKey, newType)) {
-							setNewKey("");
-						}
-					}}
+					className="min-h-7 rounded px-1.5 text-muted-foreground text-sm hover:text-foreground"
+					onClick={commitNewKey}
 				>
 					Add property
 				</button>
 			</div>
-		</div>
+		</section>
 	);
 }

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -1,3 +1,4 @@
+import { Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type * as Y from "yjs";
 import {
@@ -66,8 +67,17 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 	const [newKey, setNewKey] = useState("");
 	const [newValue, setNewValue] = useState("");
 	const [newType, setNewType] = useState<PropertyType>("text");
+	// Obsidian shows no placeholder row: the list is exactly the properties you
+	// have, and "Add property" appends one to author. `adding` is that row.
+	const [adding, setAdding] = useState(false);
 
-	const commitNewKey = ({ refocus = true } = {}) => {
+	const cancelAdding = () => {
+		setNewKey("");
+		setNewValue("");
+		setAdding(false);
+	};
+
+	const commitNewKey = () => {
 		const key = newKey.trim();
 		if (!addKey(doc, newKey, newType)) {
 			return false;
@@ -75,27 +85,28 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 		if (newValue !== "") {
 			setValue(doc, key, coerceValue(newValue, newType));
 		}
-		setNewKey("");
-		setNewValue("");
-		if (refocus) {
-			// Straight back to the key field, ready for the next one.
-			newKeyRef.current?.focus();
-		}
+		cancelAdding();
 		return true;
 	};
 
 	// Read by the click-away effect, which must not re-subscribe on every
-	// keystroke just to see the latest draft text.
-	const commitOnLeave = useRef<() => boolean>(() => false);
-	commitOnLeave.current = () => commitNewKey({ refocus: false });
+	// keystroke just to see the latest text.
+	const leaving = useRef<{ commit: () => boolean; cancel: () => void } | null>(null);
+	leaving.current = { commit: commitNewKey, cancel: cancelAdding };
 
-	// The `---` gesture opens this with nothing in it, so the caret has to land
-	// in the name field — otherwise there is nothing to click away FROM.
+	// The `---` gesture means "I want a property", so it opens the new row
+	// directly rather than making the user find the button.
 	useEffect(() => {
 		if (draft) {
-			newKeyRef.current?.focus();
+			setAdding(true);
 		}
 	}, [draft]);
+
+	useEffect(() => {
+		if (adding) {
+			newKeyRef.current?.focus();
+		}
+	}, [adding]);
 
 	// An empty draft closes as soon as the user goes elsewhere. Watched on the
 	// document rather than as an onBlur prop: clicking dead space blurs the
@@ -104,7 +115,7 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 	// covers tabbing away. Reads the doc, not `rows`, so a key added in this
 	// same interaction already counts.
 	useEffect(() => {
-		if (!draft) {
+		if (!adding) {
 			return;
 		}
 		const dismiss = (event: Event) => {
@@ -119,16 +130,18 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 			if (target?.closest?.(PORTALLED_SURFACES)) {
 				return;
 			}
-			if (readRows(doc).length > 0) {
+			// A half-filled row is still the user's work, so leaving saves it
+			// rather than throwing it away. Only a row with no key at all counts
+			// as "never mind".
+			if (leaving.current?.commit()) {
 				return;
 			}
-			// Nothing committed yet — but a half-filled row is still the user's
-			// work, so leaving saves it rather than throwing it away. Only a row
-			// with no key at all counts as "never mind".
-			if (commitOnLeave.current()) {
-				return;
+			leaving.current?.cancel();
+			// Nothing typed and nothing stored: the `---` gesture opened an editor
+			// the user turned out not to want.
+			if (readRows(doc).length === 0) {
+				onAbandonDraft?.();
 			}
-			onAbandonDraft?.();
 		};
 		document.addEventListener("pointerdown", dismiss);
 		document.addEventListener("focusin", dismiss);
@@ -136,14 +149,14 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 			document.removeEventListener("pointerdown", dismiss);
 			document.removeEventListener("focusin", dismiss);
 		};
-	}, [draft, doc, onAbandonDraft]);
+	}, [adding, doc, onAbandonDraft]);
 
 	// A note with no frontmatter gets no bordered strip of nothing. Returning
 	// null keeps the component MOUNTED and its Yjs observers live, so the
 	// widget reappears the moment a key arrives — from the note menu's "Add
 	// property" or from a remote peer. Unmounting it at the call site instead
 	// would leave nobody listening for that.
-	if (rows.length === 0 && !draft) {
+	if (rows.length === 0 && !draft && !adding) {
 		return null;
 	}
 
@@ -199,54 +212,66 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 						</div>
 					);
 				})}
+
+				{/* The row being authored. Same geometry as a committed one, so
+				    naming a property looks like the row it is about to become. */}
+				{adding ? (
+					<div className={ROW}>
+						<dt className={KEY_CELL}>
+							<PropertyTypeMenu value={newType} onChange={setNewType} />
+							<input
+								ref={newKeyRef}
+								className="w-full min-w-0 border-0 bg-transparent px-1 text-muted-foreground text-sm outline-none placeholder:text-muted-foreground/60"
+								placeholder="Property name"
+								value={newKey}
+								onChange={(e) => setNewKey(e.target.value)}
+								// Enter moves ALONG the row rather than committing —
+								// committing from the key would close the row before its
+								// value could be typed.
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										newValueRef.current?.focus();
+									} else if (e.key === "Escape") {
+										e.preventDefault();
+										cancelAdding();
+									}
+								}}
+							/>
+						</dt>
+						<dd className="flex min-h-7 flex-1 items-center gap-1">
+							<input
+								ref={newValueRef}
+								className="w-full min-w-0 border-0 bg-transparent px-2 py-1 text-foreground text-sm outline-none placeholder:text-muted-foreground/60"
+								placeholder="Value"
+								value={newValue}
+								onChange={(e) => setNewValue(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										commitNewKey();
+									} else if (e.key === "Escape") {
+										e.preventDefault();
+										cancelAdding();
+									}
+								}}
+							/>
+						</dd>
+					</div>
+				) : null}
 			</dl>
 
-			{/* The adder wears the same row geometry, so a property being named
-			    looks like the row it is about to become. */}
-			<div className={`mt-[3px] ${ROW}`}>
-				<div className={KEY_CELL}>
-					<PropertyTypeMenu value={newType} onChange={setNewType} />
-					<input
-						ref={newKeyRef}
-						className="w-full min-w-0 border-0 bg-transparent px-1 text-muted-foreground text-sm outline-none placeholder:text-muted-foreground/60"
-						placeholder="Property name"
-						value={newKey}
-						onChange={(e) => setNewKey(e.target.value)}
-						// Enter moves along the row instead of committing: on a note with
-						// no properties this IS the only row, so committing from the key
-						// would close the one place a value can be typed.
-						onKeyDown={(e) => {
-							if (e.key === "Enter") {
-								e.preventDefault();
-								newValueRef.current?.focus();
-							}
-						}}
-					/>
-				</div>
-				<div className="flex min-h-7 flex-1 items-center gap-1">
-					<input
-						ref={newValueRef}
-						className="w-full min-w-0 border-0 bg-transparent px-2 py-1 text-foreground text-sm outline-none placeholder:text-muted-foreground/60"
-						placeholder="Value"
-						value={newValue}
-						onChange={(e) => setNewValue(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") {
-								e.preventDefault();
-								commitNewKey();
-							}
-						}}
-					/>
-				</div>
-				<button
-					type="button"
-					aria-label="Add property"
-					className="min-h-7 shrink-0 rounded px-1.5 text-muted-foreground text-sm hover:text-foreground"
-					onClick={() => commitNewKey()}
-				>
-					Add
-				</button>
-			</div>
+			<button
+				type="button"
+				aria-label="Add property"
+				// Obsidian's .metadata-add-button: 6px inline-start, 0.5em above,
+				// at the label's font size.
+				className="mt-2 flex items-center gap-1 pl-1.5 text-muted-foreground text-sm hover:text-foreground"
+				onClick={() => setAdding(true)}
+			>
+				<Plus aria-hidden="true" className="size-3.5" />
+				Add property
+			</button>
 		</section>
 	);
 }

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type * as Y from "yjs";
 import {
 	addKey,
@@ -15,8 +15,22 @@ import { PropertyField } from "./property-fields";
 import { PropertyTypeMenu } from "./property-type-menu";
 import { effectiveType, type PropertyType } from "./property-types";
 
-export function PropertiesWidget({ doc }: { doc: Y.Doc }) {
+interface Props {
+	doc: Y.Doc;
+	/**
+	 * Show the editor even with no properties yet, for the `---` gesture.
+	 * LOCAL-ONLY state: an "open but empty" block must never reach the Y.Doc,
+	 * or every other device would grow an empty properties section.
+	 */
+	draft?: boolean;
+	/** Focus left the editor with nothing added — the draft should close. */
+	onAbandonDraft?: () => void;
+}
+
+export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) {
 	const [rows, setRows] = useState<PropertyRow[]>(() => sortRowsOkfFirst(readRows(doc)));
+	const newKeyRef = useRef<HTMLInputElement>(null);
+	const rootRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		const refresh = () => setRows(sortRowsOkfFirst(readRows(doc)));
@@ -35,17 +49,52 @@ export function PropertiesWidget({ doc }: { doc: Y.Doc }) {
 	const [newKey, setNewKey] = useState("");
 	const [newType, setNewType] = useState<PropertyType>("text");
 
+	// The `---` gesture opens this with nothing in it, so the caret has to land
+	// in the name field — otherwise there is nothing to click away FROM.
+	useEffect(() => {
+		if (draft) {
+			newKeyRef.current?.focus();
+		}
+	}, [draft]);
+
+	// An empty draft closes as soon as the user goes elsewhere. Watched on the
+	// document rather than as an onBlur prop: clicking dead space blurs the
+	// input without focusing anything, so a relatedTarget check would miss the
+	// most ordinary way to dismiss this. pointerdown covers the mouse, focusin
+	// covers tabbing away. Reads the doc, not `rows`, so a key added in this
+	// same interaction already counts.
+	useEffect(() => {
+		if (!draft) {
+			return;
+		}
+		const dismiss = (event: Event) => {
+			const root = rootRef.current;
+			if (!root || root.contains(event.target as Node | null)) {
+				return;
+			}
+			if (readRows(doc).length === 0) {
+				onAbandonDraft?.();
+			}
+		};
+		document.addEventListener("pointerdown", dismiss);
+		document.addEventListener("focusin", dismiss);
+		return () => {
+			document.removeEventListener("pointerdown", dismiss);
+			document.removeEventListener("focusin", dismiss);
+		};
+	}, [draft, doc, onAbandonDraft]);
+
 	// A note with no frontmatter gets no bordered strip of nothing. Returning
 	// null keeps the component MOUNTED and its Yjs observers live, so the
 	// widget reappears the moment a key arrives — from the note menu's "Add
 	// property" or from a remote peer. Unmounting it at the call site instead
 	// would leave nobody listening for that.
-	if (rows.length === 0) {
+	if (rows.length === 0 && !draft) {
 		return null;
 	}
 
 	return (
-		<div className="border-border border-b px-5 py-3" data-testid="note-properties">
+		<div className="border-border border-b px-5 py-3" data-testid="note-properties" ref={rootRef}>
 			<dl className="grid grid-cols-[max-content_max-content_1fr_max-content] items-center gap-x-2 gap-y-1 text-xs">
 				{rows.map((row) => {
 					const type = effectiveType(row.value, row.typeOverride);
@@ -92,6 +141,7 @@ export function PropertiesWidget({ doc }: { doc: Y.Doc }) {
 			</dl>
 			<div className="mt-2 flex items-center gap-2">
 				<input
+					ref={newKeyRef}
 					className="rounded border border-border bg-transparent px-2 py-1 text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-ring"
 					placeholder="Property name"
 					value={newKey}

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -94,7 +94,7 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 	}
 
 	return (
-		<div className="border-border border-b px-5 py-3" data-testid="note-properties" ref={rootRef}>
+		<div className="px-5 py-3" data-testid="note-properties" ref={rootRef}>
 			<dl className="grid grid-cols-[max-content_max-content_1fr_max-content] items-center gap-x-2 gap-y-1 text-xs">
 				{rows.map((row) => {
 					const type = effectiveType(row.value, row.typeOverride);

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -1,10 +1,9 @@
-import { Plus } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type * as Y from "yjs";
 import {
 	addKey,
 	frontmatterMaps,
-	moveKey,
 	type PropertyRow,
 	readRows,
 	removeKey,
@@ -180,35 +179,17 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 									onCommit={(v) => setValue(doc, row.key, v)}
 								/>
 							</dd>
-							{/* Obsidian keeps row actions in a right-click menu, so the
-							    default view stays clean. We surface ours on hover/focus
-							    rather than dropping the capability. */}
-							<div className="flex min-h-7 items-center gap-0.5 text-muted-foreground opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
-								<button
-									type="button"
-									aria-label={`Move ${row.key} up`}
-									onClick={() => moveKey(doc, row.key, "up")}
-									className="rounded px-1 hover:bg-muted"
-								>
-									^
-								</button>
-								<button
-									type="button"
-									aria-label={`Move ${row.key} down`}
-									onClick={() => moveKey(doc, row.key, "down")}
-									className="rounded px-1 hover:bg-muted"
-								>
-									v
-								</button>
-								<button
-									type="button"
-									aria-label={`Remove ${row.key}`}
-									onClick={() => removeKey(doc, row.key)}
-									className="rounded px-1 hover:bg-muted hover:text-destructive"
-								>
-									x
-								</button>
-							</div>
+							{/* Remove only. Reordering was two permanent buttons per row for
+							    something you do once in a while; `moveKey` is still there
+							    for a right-click menu, which is where Obsidian keeps it. */}
+							<button
+								type="button"
+								aria-label={`Remove ${row.key}`}
+								onClick={() => removeKey(doc, row.key)}
+								className="mr-1 flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus:opacity-100 group-hover:opacity-100"
+							>
+								<X aria-hidden="true" className="size-3.5" />
+							</button>
 						</div>
 					);
 				})}

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -7,6 +7,7 @@ import {
 	type PropertyRow,
 	readRows,
 	removeKey,
+	renameKey,
 	setType,
 	setValue,
 	sortRowsOkfFirst,
@@ -30,6 +31,54 @@ const ROW = "flex items-start rounded-md border border-border";
 // as "inside" for the click-away rule.
 const PORTALLED_SURFACES =
 	'[data-radix-popper-content-wrapper],[role="menu"],[role="listbox"],[role="dialog"]';
+
+/**
+ * The property's name, editable in place like Obsidian's key input.
+ *
+ * Keeps its own draft so a remote edit elsewhere in the doc cannot rewrite the
+ * text under the caret — the same guard the value fields use. A rejected
+ * rename (empty, unchanged, or a name already taken) snaps back rather than
+ * leaving the input showing a name the doc does not have.
+ */
+function PropertyKeyInput({ doc, name }: { doc: Y.Doc; name: string }) {
+	const [draft, setDraft] = useState(name);
+	const ref = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		if (document.activeElement !== ref.current) {
+			setDraft(name);
+		}
+	}, [name]);
+
+	const commit = () => {
+		if (draft.trim() === name) {
+			setDraft(name);
+			return;
+		}
+		if (!renameKey(doc, name, draft)) {
+			setDraft(name);
+		}
+	};
+
+	return (
+		<input
+			ref={ref}
+			aria-label={`Rename ${name}`}
+			className="w-full min-w-0 truncate border-0 bg-transparent px-1 text-muted-foreground text-sm outline-none"
+			value={draft}
+			onChange={(e) => setDraft(e.target.value)}
+			onBlur={commit}
+			onKeyDown={(e) => {
+				if (e.key === "Enter") {
+					e.preventDefault();
+					commit();
+				} else if (e.key === "Escape") {
+					e.preventDefault();
+					setDraft(name);
+				}
+			}}
+		/>
+	);
+}
 
 interface Props {
 	doc: Y.Doc;
@@ -170,12 +219,13 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 						<div key={row.key} className={`group ${ROW}`} data-testid={`property-row-${row.key}`}>
 							<dt className={KEY_CELL}>
 								<PropertyTypeMenu value={type} onChange={(t) => setType(doc, row.key, t)} />
-								<span className="truncate px-1 text-muted-foreground text-sm">{row.key}</span>
+								<PropertyKeyInput doc={doc} name={row.key} />
 							</dt>
 							<dd className="flex min-h-7 flex-1 items-center gap-1">
 								<PropertyField
 									type={type}
 									value={row.value}
+									label={row.key}
 									onCommit={(v) => setValue(doc, row.key, v)}
 								/>
 							</dd>

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -63,7 +63,7 @@ function PropertyKeyInput({ doc, name }: { doc: Y.Doc; name: string }) {
 		<input
 			ref={ref}
 			aria-label={`Rename ${name}`}
-			className="w-full min-w-0 truncate border-0 bg-transparent px-1 text-muted-foreground text-sm outline-none"
+			className="w-full min-w-0 truncate border-0 bg-transparent px-2 py-1 text-muted-foreground text-sm outline-none"
 			value={draft}
 			onChange={(e) => setDraft(e.target.value)}
 			onBlur={commit}
@@ -252,7 +252,7 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 							<PropertyTypeMenu value={newType} onChange={setNewType} />
 							<input
 								ref={newKeyRef}
-								className="w-full min-w-0 border-0 bg-transparent px-1 text-muted-foreground text-sm outline-none placeholder:text-muted-foreground/60"
+								className="w-full min-w-0 border-0 bg-transparent px-2 py-1 text-muted-foreground text-sm outline-none placeholder:text-muted-foreground/60"
 								placeholder="Property name"
 								value={newKey}
 								onChange={(e) => setNewKey(e.target.value)}

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -19,6 +19,11 @@ import { effectiveType, type PropertyType } from "./property-types";
 // and it does NOT shrink — long values never squeeze the key column.
 const KEY_CELL = "flex min-h-7 w-36 min-w-36 shrink-0 items-center overflow-hidden rounded-md";
 
+// Anything this editor opens that renders outside its own DOM subtree. Treated
+// as "inside" for the click-away rule.
+const PORTALLED_SURFACES =
+	'[data-radix-popper-content-wrapper],[role="menu"],[role="listbox"],[role="dialog"]';
+
 interface Props {
 	doc: Y.Doc;
 	/**
@@ -34,7 +39,11 @@ interface Props {
 export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) {
 	const [rows, setRows] = useState<PropertyRow[]>(() => sortRowsOkfFirst(readRows(doc)));
 	const newKeyRef = useRef<HTMLInputElement>(null);
-	const rootRef = useRef<HTMLDivElement>(null);
+	const rootRef = useRef<HTMLElement>(null);
+	// Keyed by property name rather than looked up by selector: property keys
+	// are user text and would need escaping in a querySelector.
+	const valueCells = useRef(new Map<string, HTMLElement | null>());
+	const [pendingValueFocus, setPendingValueFocus] = useState<string | null>(null);
 
 	useEffect(() => {
 		const refresh = () => setRows(sortRowsOkfFirst(readRows(doc)));
@@ -54,10 +63,26 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 	const [newType, setNewType] = useState<PropertyType>("text");
 
 	const commitNewKey = () => {
+		const key = newKey.trim();
 		if (addKey(doc, newKey, newType)) {
 			setNewKey("");
+			// Naming a property is half the job. The row does not exist until the
+			// Y.Doc observer fires, so record the intent and let the effect below
+			// move the caret once it has rendered.
+			setPendingValueFocus(key);
 		}
 	};
+
+	useEffect(() => {
+		if (!(pendingValueFocus && rows.some((r) => r.key === pendingValueFocus))) {
+			return;
+		}
+		valueCells.current
+			.get(pendingValueFocus)
+			?.querySelector<HTMLElement>("input, textarea")
+			?.focus();
+		setPendingValueFocus(null);
+	}, [pendingValueFocus, rows]);
 
 	// The `---` gesture opens this with nothing in it, so the caret has to land
 	// in the name field — otherwise there is nothing to click away FROM.
@@ -79,7 +104,14 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 		}
 		const dismiss = (event: Event) => {
 			const root = rootRef.current;
-			if (!root || root.contains(event.target as Node | null)) {
+			const target = event.target as Element | null;
+			if (!root || root.contains(target)) {
+				return;
+			}
+			// Radix portals menus to document.body, so a click on a type option is
+			// physically outside `root` while being very much inside this editor.
+			// Without this the type picker destroyed the draft it was opened from.
+			if (target?.closest?.(PORTALLED_SURFACES)) {
 				return;
 			}
 			if (readRows(doc).length === 0) {
@@ -120,7 +152,12 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 								<PropertyTypeMenu value={type} onChange={(t) => setType(doc, row.key, t)} />
 								<span className="truncate px-1 text-muted-foreground text-sm">{row.key}</span>
 							</dt>
-							<dd className="flex min-h-7 flex-1 items-center gap-1">
+							<dd
+								className="flex min-h-7 flex-1 items-center gap-1"
+								ref={(el) => {
+									valueCells.current.set(row.key, el);
+								}}
+							>
 								<PropertyField
 									type={type}
 									value={row.value}

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -36,7 +36,7 @@ export function PropertiesWidget({ doc }: { doc: Y.Doc }) {
 	const [newType, setNewType] = useState<PropertyType>("text");
 
 	return (
-		<div className="border-border border-b px-5 py-3">
+		<div className="border-border border-b px-5 py-3" data-testid="note-properties">
 			<dl className="grid grid-cols-[max-content_max-content_1fr_max-content] items-center gap-x-2 gap-y-1 text-xs">
 				{rows.map((row) => {
 					const type = effectiveType(row.value, row.typeOverride);

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -13,7 +13,7 @@ import {
 } from "../crdt/frontmatter-doc";
 import { PropertyField } from "./property-fields";
 import { PropertyTypeMenu } from "./property-type-menu";
-import { effectiveType, type PropertyType } from "./property-types";
+import { coerceValue, effectiveType, type PropertyType } from "./property-types";
 
 // Obsidian's --metadata-label-width is 9em against the 16px root, so 144px,
 // and it does NOT shrink — long values never squeeze the key column. The right
@@ -46,11 +46,8 @@ interface Props {
 export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) {
 	const [rows, setRows] = useState<PropertyRow[]>(() => sortRowsOkfFirst(readRows(doc)));
 	const newKeyRef = useRef<HTMLInputElement>(null);
+	const newValueRef = useRef<HTMLInputElement>(null);
 	const rootRef = useRef<HTMLElement>(null);
-	// Keyed by property name rather than looked up by selector: property keys
-	// are user text and would need escaping in a querySelector.
-	const valueCells = useRef(new Map<string, HTMLElement | null>());
-	const [pendingValueFocus, setPendingValueFocus] = useState<string | null>(null);
 
 	useEffect(() => {
 		const refresh = () => setRows(sortRowsOkfFirst(readRows(doc)));
@@ -67,29 +64,22 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 	}, [doc]);
 
 	const [newKey, setNewKey] = useState("");
+	const [newValue, setNewValue] = useState("");
 	const [newType, setNewType] = useState<PropertyType>("text");
 
 	const commitNewKey = () => {
 		const key = newKey.trim();
-		if (addKey(doc, newKey, newType)) {
-			setNewKey("");
-			// Naming a property is half the job. The row does not exist until the
-			// Y.Doc observer fires, so record the intent and let the effect below
-			// move the caret once it has rendered.
-			setPendingValueFocus(key);
-		}
-	};
-
-	useEffect(() => {
-		if (!(pendingValueFocus && rows.some((r) => r.key === pendingValueFocus))) {
+		if (!addKey(doc, newKey, newType)) {
 			return;
 		}
-		valueCells.current
-			.get(pendingValueFocus)
-			?.querySelector<HTMLElement>("input, textarea")
-			?.focus();
-		setPendingValueFocus(null);
-	}, [pendingValueFocus, rows]);
+		if (newValue !== "") {
+			setValue(doc, key, coerceValue(newValue, newType));
+		}
+		setNewKey("");
+		setNewValue("");
+		// Straight back to the key field, ready for the next one.
+		newKeyRef.current?.focus();
+	};
 
 	// The `---` gesture opens this with nothing in it, so the caret has to land
 	// in the name field — otherwise there is nothing to click away FROM.
@@ -155,12 +145,7 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 								<PropertyTypeMenu value={type} onChange={(t) => setType(doc, row.key, t)} />
 								<span className="truncate px-1 text-muted-foreground text-sm">{row.key}</span>
 							</dt>
-							<dd
-								className="flex min-h-7 flex-1 items-center gap-1"
-								ref={(el) => {
-									valueCells.current.set(row.key, el);
-								}}
-							>
+							<dd className="flex min-h-7 flex-1 items-center gap-1">
 								<PropertyField
 									type={type}
 									value={row.value}
@@ -212,6 +197,24 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 						placeholder="Property name"
 						value={newKey}
 						onChange={(e) => setNewKey(e.target.value)}
+						// Enter moves along the row instead of committing: on a note with
+						// no properties this IS the only row, so committing from the key
+						// would close the one place a value can be typed.
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								newValueRef.current?.focus();
+							}
+						}}
+					/>
+				</div>
+				<div className="flex min-h-7 flex-1 items-center gap-1">
+					<input
+						ref={newValueRef}
+						className="w-full min-w-0 border-0 bg-transparent px-2 py-1 text-foreground text-sm outline-none placeholder:text-muted-foreground/60"
+						placeholder="Value"
+						value={newValue}
+						onChange={(e) => setNewValue(e.target.value)}
 						onKeyDown={(e) => {
 							if (e.key === "Enter") {
 								e.preventDefault();
@@ -223,10 +226,10 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 				<button
 					type="button"
 					aria-label="Add property"
-					className="min-h-7 rounded px-1.5 text-muted-foreground text-sm hover:text-foreground"
+					className="min-h-7 shrink-0 rounded px-1.5 text-muted-foreground text-sm hover:text-foreground"
 					onClick={commitNewKey}
 				>
-					Add property
+					Add
 				</button>
 			</div>
 		</section>

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -1,5 +1,6 @@
 import { Plus, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import type * as Y from "yjs";
 import {
 	addKey,
@@ -50,11 +51,18 @@ function PropertyKeyInput({ doc, name }: { doc: Y.Doc; name: string }) {
 	}, [name]);
 
 	const commit = () => {
-		if (draft.trim() === name) {
+		const next = draft.trim();
+		if (next === name) {
 			setDraft(name);
 			return;
 		}
 		if (!renameKey(doc, name, draft)) {
+			// Refusing is right; refusing in silence is not. In a chromeless input
+			// a value snapping back is easy to miss, and the user walks away
+			// believing the rename landed.
+			if (next !== "") {
+				toast.error(`A property named "${next}" already exists`);
+			}
 			setDraft(name);
 		}
 	};
@@ -123,23 +131,38 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 		setNewKey("");
 		setNewValue("");
 		setAdding(false);
+		// Always tell the parent the row is gone, committed or not. `draft` is a
+		// REQUEST to open, and the parent lowers its flag here; leaving it raised
+		// latches the editor shut, because asking again just sets an unchanged
+		// flag and React bails out. The `---` gesture would then eat the user's
+		// three characters and open nothing.
+		onAbandonDraft?.();
 	};
 
-	const commitNewKey = () => {
+	/**
+	 * `duplicate` is NOT a failure to discard — the user typed a real name that
+	 * happens to be taken. Collapsing it into "nothing was entered" threw away
+	 * both the key and the value they had just typed.
+	 */
+	const commitNewKey = (): "committed" | "empty" | "duplicate" => {
 		const key = newKey.trim();
+		if (key === "") {
+			return "empty";
+		}
 		if (!addKey(doc, newKey, newType)) {
-			return false;
+			toast.error(`A property named "${key}" already exists`);
+			return "duplicate";
 		}
 		if (newValue !== "") {
 			setValue(doc, key, coerceValue(newValue, newType));
 		}
 		cancelAdding();
-		return true;
+		return "committed";
 	};
 
 	// Read by the click-away effect, which must not re-subscribe on every
 	// keystroke just to see the latest text.
-	const leaving = useRef<{ commit: () => boolean; cancel: () => void } | null>(null);
+	const leaving = useRef<{ commit: typeof commitNewKey; cancel: () => void } | null>(null);
 	leaving.current = { commit: commitNewKey, cancel: cancelAdding };
 
 	// The `---` gesture means "I want a property", so it opens the new row
@@ -180,16 +203,13 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 			}
 			// A half-filled row is still the user's work, so leaving saves it
 			// rather than throwing it away. Only a row with no key at all counts
-			// as "never mind".
-			if (leaving.current?.commit()) {
+			// as "never mind"; a name that collides keeps the row open so the
+			// user can fix it instead of losing what they typed.
+			const outcome = leaving.current?.commit();
+			if (outcome !== "empty") {
 				return;
 			}
 			leaving.current?.cancel();
-			// Nothing typed and nothing stored: the `---` gesture opened an editor
-			// the user turned out not to want.
-			if (readRows(doc).length === 0) {
-				onAbandonDraft?.();
-			}
 		};
 		document.addEventListener("pointerdown", dismiss);
 		document.addEventListener("focusin", dismiss);
@@ -197,13 +217,16 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 			document.removeEventListener("pointerdown", dismiss);
 			document.removeEventListener("focusin", dismiss);
 		};
-	}, [adding, doc, onAbandonDraft]);
+		// `doc` and `onAbandonDraft` are reached through `leaving`, so they are
+		// deliberately not deps — re-subscribing on every keystroke would be
+		// churn for no behaviour change.
+	}, [adding]);
 
 	// A note with no frontmatter gets no bordered strip of nothing. Returning
 	// null keeps the component MOUNTED and its Yjs observers live, so the
-	// widget reappears the moment a key arrives — from the note menu's "Add
-	// property" or from a remote peer. Unmounting it at the call site instead
-	// would leave nobody listening for that.
+	// widget reappears the moment a key arrives from a remote peer or the raw
+	// editor. Unmounting it at the call site instead would leave nobody
+	// listening for that.
 	if (rows.length === 0 && !draft && !adding) {
 		return null;
 	}

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -209,9 +209,15 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 	}
 
 	return (
-		// Geometry lifted from Obsidian's app.css: 8px block padding, a 2rem gap
-		// down to the body, 3px between rows, a 9em key column, 28px row height.
-		<section className="mb-8 px-5 py-2" data-testid="note-properties" ref={rootRef}>
+		// Geometry lifted from Obsidian's app.css: 8px block padding, 3px between
+		// rows, a 9em key column, 28px row height.
+		//
+		// The gap down to the body is theirs (2rem) but NOT their margin value.
+		// Obsidian nests this block inside .cm-content, so the editor's 20px top
+		// padding sits above the whole thing; ours is a sibling above CodeMirror,
+		// so that 20px lands in this gap instead. 8px padding + 4px + 20px = the
+		// 2rem they intend, rather than stacking 2rem on top of it.
+		<section className="mb-1 px-5 py-2" data-testid="note-properties" ref={rootRef}>
 			<dl className="flex flex-col gap-[3px]">
 				{rows.map((row) => {
 					const type = effectiveType(row.value, row.typeOverride);

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -35,6 +35,15 @@ export function PropertiesWidget({ doc }: { doc: Y.Doc }) {
 	const [newKey, setNewKey] = useState("");
 	const [newType, setNewType] = useState<PropertyType>("text");
 
+	// A note with no frontmatter gets no bordered strip of nothing. Returning
+	// null keeps the component MOUNTED and its Yjs observers live, so the
+	// widget reappears the moment a key arrives — from the note menu's "Add
+	// property" or from a remote peer. Unmounting it at the call site instead
+	// would leave nobody listening for that.
+	if (rows.length === 0) {
+		return null;
+	}
+
 	return (
 		<div className="border-border border-b px-5 py-3" data-testid="note-properties">
 			<dl className="grid grid-cols-[max-content_max-content_1fr_max-content] items-center gap-x-2 gap-y-1 text-xs">

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -67,19 +67,27 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 	const [newValue, setNewValue] = useState("");
 	const [newType, setNewType] = useState<PropertyType>("text");
 
-	const commitNewKey = () => {
+	const commitNewKey = ({ refocus = true } = {}) => {
 		const key = newKey.trim();
 		if (!addKey(doc, newKey, newType)) {
-			return;
+			return false;
 		}
 		if (newValue !== "") {
 			setValue(doc, key, coerceValue(newValue, newType));
 		}
 		setNewKey("");
 		setNewValue("");
-		// Straight back to the key field, ready for the next one.
-		newKeyRef.current?.focus();
+		if (refocus) {
+			// Straight back to the key field, ready for the next one.
+			newKeyRef.current?.focus();
+		}
+		return true;
 	};
+
+	// Read by the click-away effect, which must not re-subscribe on every
+	// keystroke just to see the latest draft text.
+	const commitOnLeave = useRef<() => boolean>(() => false);
+	commitOnLeave.current = () => commitNewKey({ refocus: false });
 
 	// The `---` gesture opens this with nothing in it, so the caret has to land
 	// in the name field — otherwise there is nothing to click away FROM.
@@ -111,9 +119,16 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 			if (target?.closest?.(PORTALLED_SURFACES)) {
 				return;
 			}
-			if (readRows(doc).length === 0) {
-				onAbandonDraft?.();
+			if (readRows(doc).length > 0) {
+				return;
 			}
+			// Nothing committed yet — but a half-filled row is still the user's
+			// work, so leaving saves it rather than throwing it away. Only a row
+			// with no key at all counts as "never mind".
+			if (commitOnLeave.current()) {
+				return;
+			}
+			onAbandonDraft?.();
 		};
 		document.addEventListener("pointerdown", dismiss);
 		document.addEventListener("focusin", dismiss);
@@ -227,7 +242,7 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 					type="button"
 					aria-label="Add property"
 					className="min-h-7 shrink-0 rounded px-1.5 text-muted-foreground text-sm hover:text-foreground"
-					onClick={commitNewKey}
+					onClick={() => commitNewKey()}
 				>
 					Add
 				</button>

--- a/frontend/src/viewer/properties-widget.tsx
+++ b/frontend/src/viewer/properties-widget.tsx
@@ -16,8 +16,15 @@ import { PropertyTypeMenu } from "./property-type-menu";
 import { effectiveType, type PropertyType } from "./property-types";
 
 // Obsidian's --metadata-label-width is 9em against the 16px root, so 144px,
-// and it does NOT shrink — long values never squeeze the key column.
-const KEY_CELL = "flex min-h-7 w-36 min-w-36 shrink-0 items-center overflow-hidden rounded-md";
+// and it does NOT shrink — long values never squeeze the key column. The right
+// border is Obsidian's --metadata-divider turned on: stock Obsidian ships it
+// at 0 width, which leaves an empty value as an invisible target with no hint
+// that the row is even editable.
+const KEY_CELL =
+	"flex min-h-7 w-36 min-w-36 shrink-0 items-center overflow-hidden border-border border-r";
+
+// One box per row so the key/value boundary and the row boundary both read.
+const ROW = "flex items-start rounded-md border border-border";
 
 // Anything this editor opens that renders outside its own DOM subtree. Treated
 // as "inside" for the click-away rule.
@@ -143,11 +150,7 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 				{rows.map((row) => {
 					const type = effectiveType(row.value, row.typeOverride);
 					return (
-						<div
-							key={row.key}
-							className="group flex items-start rounded-md"
-							data-testid={`property-row-${row.key}`}
-						>
+						<div key={row.key} className={`group ${ROW}`} data-testid={`property-row-${row.key}`}>
 							<dt className={KEY_CELL}>
 								<PropertyTypeMenu value={type} onChange={(t) => setType(doc, row.key, t)} />
 								<span className="truncate px-1 text-muted-foreground text-sm">{row.key}</span>
@@ -200,7 +203,7 @@ export function PropertiesWidget({ doc, draft = false, onAbandonDraft }: Props) 
 
 			{/* The adder wears the same row geometry, so a property being named
 			    looks like the row it is about to become. */}
-			<div className="mt-[3px] flex items-start">
+			<div className={`mt-[3px] ${ROW}`}>
 				<div className={KEY_CELL}>
 					<PropertyTypeMenu value={newType} onChange={setNewType} />
 					<input

--- a/frontend/src/viewer/property-fields.test.tsx
+++ b/frontend/src/viewer/property-fields.test.tsx
@@ -12,6 +12,46 @@ describe("PropertyField", () => {
 		expect(onCommit).toHaveBeenCalledWith("bye");
 	});
 
+	// Every other input in the properties widget takes Enter and Escape. The
+	// value field took neither, so the most obvious way to say "done" did
+	// nothing and there was no way to back out of a half-typed value.
+	test("Enter commits without needing the user to click elsewhere", () => {
+		const onCommit = vi.fn();
+		render(<PropertyField type="text" value="hi" onCommit={onCommit} />);
+		const input = screen.getByRole("textbox");
+		input.focus();
+		fireEvent.change(input, { target: { value: "bye" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onCommit).toHaveBeenCalledWith("bye");
+	});
+
+	test("Escape restores the old value and writes nothing", () => {
+		const onCommit = vi.fn();
+		render(<PropertyField type="text" value="hi" onCommit={onCommit} />);
+		const input = screen.getByRole("textbox");
+		input.focus();
+		fireEvent.change(input, { target: { value: "bye" } });
+		fireEvent.keyDown(input, { key: "Escape" });
+		expect(onCommit).not.toHaveBeenCalled();
+		expect(input).toHaveValue("hi");
+	});
+
+	// The cancel flag must not leak into the next edit: a field that was once
+	// escaped would otherwise refuse to ever commit again.
+	test("commits normally on the edit after an Escape", () => {
+		const onCommit = vi.fn();
+		render(<PropertyField type="text" value="hi" onCommit={onCommit} />);
+		const input = screen.getByRole("textbox");
+		input.focus();
+		fireEvent.change(input, { target: { value: "bye" } });
+		fireEvent.keyDown(input, { key: "Escape" });
+
+		input.focus();
+		fireEvent.change(input, { target: { value: "later" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onCommit).toHaveBeenCalledWith("later");
+	});
+
 	test("number commits a parsed number on blur, null when empty", () => {
 		const onCommit = vi.fn();
 		render(<PropertyField type="number" value={3} onCommit={onCommit} />);

--- a/frontend/src/viewer/property-fields.tsx
+++ b/frontend/src/viewer/property-fields.tsx
@@ -45,6 +45,12 @@ function ScalarField({ type, value, onCommit, onFocusChange, label }: FieldProps
 		}
 	};
 
+	// Escape has to survive a round trip through blur. Reverting the draft and
+	// blurring in the same handler would not work: the state update is async, so
+	// the blur handler's `commit` still closes over the typed text and writes the
+	// value Escape was meant to throw away. The flag lets blur decide instead.
+	const cancelled = useRef(false);
+
 	return (
 		<input
 			ref={inputRef}
@@ -54,8 +60,28 @@ function ScalarField({ type, value, onCommit, onFocusChange, label }: FieldProps
 			value={draft}
 			onChange={(e) => setDraft(e.target.value)}
 			onFocus={() => onFocusChange?.(true)}
+			// Enter and Escape both leave the field, and blur is already the commit
+			// point — so they route through it rather than duplicating the write.
+			// Every other input in this widget (the list chips, the adder row, the
+			// key rename box) takes both keys; the value field was the one place
+			// where Enter did nothing at all.
+			onKeyDown={(e) => {
+				if (e.key === "Enter") {
+					e.preventDefault();
+					e.currentTarget.blur();
+				} else if (e.key === "Escape") {
+					e.preventDefault();
+					cancelled.current = true;
+					e.currentTarget.blur();
+				}
+			}}
 			onBlur={() => {
-				commit();
+				if (cancelled.current) {
+					cancelled.current = false;
+					setDraft(initial);
+				} else {
+					commit();
+				}
 				onFocusChange?.(false);
 			}}
 		/>

--- a/frontend/src/viewer/property-fields.tsx
+++ b/frontend/src/viewer/property-fields.tsx
@@ -10,8 +10,10 @@ interface FieldProps {
 	onFocusChange?: (focused: boolean) => void;
 }
 
+// Obsidian's value inputs carry no border and no fill, in any state — the
+// caret is the only affordance. See docs/context/obsidian-properties-parity.md.
 const inputCls =
-	"w-full rounded border border-border bg-transparent px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring";
+	"w-full rounded-md border-0 bg-transparent px-2 py-1 text-foreground text-sm outline-none";
 
 function ScalarField({ type, value, onCommit, onFocusChange }: FieldProps) {
 	const initial = value === null || value === undefined ? "" : String(value);

--- a/frontend/src/viewer/property-fields.tsx
+++ b/frontend/src/viewer/property-fields.tsx
@@ -8,6 +8,8 @@ interface FieldProps {
 	value: unknown;
 	onCommit: (value: unknown) => void;
 	onFocusChange?: (focused: boolean) => void;
+	/** Property name, so the field announces as more than "edit text". */
+	label?: string;
 }
 
 // Obsidian's value inputs carry no border and no fill, in any state — the
@@ -15,7 +17,7 @@ interface FieldProps {
 const inputCls =
 	"w-full rounded-md border-0 bg-transparent px-2 py-1 text-foreground text-sm outline-none";
 
-function ScalarField({ type, value, onCommit, onFocusChange }: FieldProps) {
+function ScalarField({ type, value, onCommit, onFocusChange, label }: FieldProps) {
 	const initial = value === null || value === undefined ? "" : String(value);
 	const [draft, setDraft] = useState(initial);
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -47,6 +49,7 @@ function ScalarField({ type, value, onCommit, onFocusChange }: FieldProps) {
 		<input
 			ref={inputRef}
 			type={htmlType}
+			aria-label={label ? `${label} value` : undefined}
 			className={inputCls}
 			value={draft}
 			onChange={(e) => setDraft(e.target.value)}
@@ -63,9 +66,10 @@ interface ListFieldProps {
 	value: string[];
 	onCommit: (v: unknown) => void;
 	onFocusChange?: (focused: boolean) => void;
+	label?: string;
 }
 
-function ListField({ value, onCommit, onFocusChange }: ListFieldProps) {
+function ListField({ value, onCommit, onFocusChange, label }: ListFieldProps) {
 	const [pending, setPending] = useState("");
 
 	const add = () => {
@@ -97,6 +101,7 @@ function ListField({ value, onCommit, onFocusChange }: ListFieldProps) {
 				</span>
 			))}
 			<input
+				aria-label={label ? `${label} value` : undefined}
 				className={cn(inputCls, "w-24 flex-1")}
 				placeholder="Add item..."
 				value={pending}
@@ -114,13 +119,13 @@ function ListField({ value, onCommit, onFocusChange }: ListFieldProps) {
 	);
 }
 
-export function PropertyField({ type, value, onCommit, onFocusChange }: FieldProps) {
+export function PropertyField({ type, value, onCommit, onFocusChange, label }: FieldProps) {
 	if (type === "checkbox") {
 		return (
 			<Checkbox
 				checked={Boolean(value)}
 				onCheckedChange={(c) => onCommit(c === true)}
-				aria-label="Toggle value"
+				aria-label={label ? `${label} value` : "Toggle value"}
 			/>
 		);
 	}
@@ -130,10 +135,17 @@ export function PropertyField({ type, value, onCommit, onFocusChange }: FieldPro
 				value={Array.isArray(value) ? value.map(String) : []}
 				onCommit={onCommit}
 				onFocusChange={onFocusChange}
+				label={label}
 			/>
 		);
 	}
 	return (
-		<ScalarField type={type} value={value} onCommit={onCommit} onFocusChange={onFocusChange} />
+		<ScalarField
+			type={type}
+			value={value}
+			onCommit={onCommit}
+			onFocusChange={onFocusChange}
+			label={label}
+		/>
 	);
 }

--- a/frontend/src/viewer/property-type-menu.test.tsx
+++ b/frontend/src/viewer/property-type-menu.test.tsx
@@ -7,6 +7,10 @@ describe("PropertyTypeMenu", () => {
 		const onChange = vi.fn();
 		render(<PropertyTypeMenu value="text" onChange={onChange} />);
 		const trigger = screen.getByRole("button", { name: /property type/i });
+		// The trigger is an icon, so the name is the ONLY place the current type
+		// is stated — without this a screen reader is told a type picker exists
+		// but never which type the property already has.
+		expect(trigger).toHaveAccessibleName("Property type: text");
 		// Radix DropdownMenu opens on pointerdown in happy-dom
 		fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
 		fireEvent.click(trigger);

--- a/frontend/src/viewer/property-type-menu.tsx
+++ b/frontend/src/viewer/property-type-menu.tsx
@@ -1,3 +1,4 @@
+import { Calendar, Clock, Hash, List, type LucideIcon, SquareCheck, Text } from "lucide-react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -8,6 +9,18 @@ import type { PropertyType } from "./property-types";
 
 const TYPES: PropertyType[] = ["text", "list", "number", "checkbox", "date", "datetime"];
 
+// Obsidian shows the property's type as the leading icon of the key cell, and
+// that icon IS the type picker. The old uppercase text label ate most of the
+// key column for something the icon says in 16px.
+const TYPE_ICONS: Record<PropertyType, LucideIcon> = {
+	text: Text,
+	list: List,
+	number: Hash,
+	checkbox: SquareCheck,
+	date: Calendar,
+	datetime: Clock,
+};
+
 export function PropertyTypeMenu({
 	value,
 	onChange,
@@ -15,20 +28,25 @@ export function PropertyTypeMenu({
 	value: PropertyType;
 	onChange: (t: PropertyType) => void;
 }) {
+	const Icon = TYPE_ICONS[value];
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger
 				aria-label="Property type"
-				className="rounded px-1 text-[10px] text-muted-foreground uppercase tracking-wide hover:bg-muted"
+				className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
 			>
-				{value}
+				<Icon aria-hidden="true" className="size-4" />
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="start">
-				{TYPES.map((t) => (
-					<DropdownMenuItem key={t} onSelect={() => onChange(t)}>
-						{t}
-					</DropdownMenuItem>
-				))}
+				{TYPES.map((t) => {
+					const ItemIcon = TYPE_ICONS[t];
+					return (
+						<DropdownMenuItem key={t} onSelect={() => onChange(t)}>
+							<ItemIcon aria-hidden="true" className="size-4" />
+							{t}
+						</DropdownMenuItem>
+					);
+				})}
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/frontend/src/viewer/property-type-menu.tsx
+++ b/frontend/src/viewer/property-type-menu.tsx
@@ -32,7 +32,11 @@ export function PropertyTypeMenu({
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger
-				aria-label="Property type"
+				// The name carries the CURRENT type, not just the control's purpose.
+				// Once the label became an icon the type was conveyed by pixels alone,
+				// so a screen reader could open the menu without ever being told what
+				// the property already is.
+				aria-label={`Property type: ${value}`}
 				// Obsidian's .metadata-property-icon: full row height, and a 4px
 				// leading gutter it fakes with a zero-width-space ::before.
 				className="ml-1 flex h-7 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"

--- a/frontend/src/viewer/property-type-menu.tsx
+++ b/frontend/src/viewer/property-type-menu.tsx
@@ -33,7 +33,9 @@ export function PropertyTypeMenu({
 		<DropdownMenu>
 			<DropdownMenuTrigger
 				aria-label="Property type"
-				className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+				// Obsidian's .metadata-property-icon: full row height, and a 4px
+				// leading gutter it fakes with a zero-width-space ::before.
+				className="ml-1 flex h-7 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
 			>
 				<Icon aria-hidden="true" className="size-4" />
 			</DropdownMenuTrigger>

--- a/frontend/src/viewer/tree-actions/action-list.test.ts
+++ b/frontend/src/viewer/tree-actions/action-list.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { actionsFor } from "./action-list";
+import { ACTION_ICONS, actionsFor, noteMenuActions } from "./action-list";
 
 describe("actionsFor", () => {
 	it("file actions: rename, move, duplicate, copy-wikilink, delete", () => {
@@ -49,5 +49,43 @@ describe("actionsFor", () => {
 			const destructive = actionsFor({ kind }).filter((a) => a.destructive);
 			expect(destructive.map((a) => a.id)).toEqual(["delete"]);
 		}
+	});
+});
+
+describe("noteMenuActions", () => {
+	it("lists the three view modes, the file actions, and add-property", () => {
+		const ids = noteMenuActions("rendered").map((a) => a.id);
+		expect(ids).toEqual([
+			"view-rendered",
+			"view-raw",
+			"view-reading",
+			"rename",
+			"move",
+			"duplicate",
+			"copy-wikilink",
+			"add-property",
+			"delete",
+		]);
+	});
+
+	it("marks the active mode so the menu can show a checkmark", () => {
+		const raw = noteMenuActions("raw").find((a) => a.id === "view-raw");
+		const rendered = noteMenuActions("raw").find((a) => a.id === "view-rendered");
+		expect(raw?.active).toBe(true);
+		expect(rendered?.active).toBe(false);
+	});
+
+	// ActionDrawer renders ACTION_ICONS[id] unconditionally — a missing entry
+	// is a crash, not a degraded menu.
+	it("has an icon for every action it can render", () => {
+		for (const action of noteMenuActions("rendered")) {
+			expect(ACTION_ICONS[action.id]).toBeDefined();
+		}
+	});
+
+	// The tree's menus must not grow the new entries.
+	it("leaves the tree's file menu unchanged", () => {
+		const ids = actionsFor({ kind: "file" }).map((a) => a.id);
+		expect(ids).toEqual(["rename", "move", "duplicate", "copy-wikilink", "delete"]);
 	});
 });

--- a/frontend/src/viewer/tree-actions/action-list.ts
+++ b/frontend/src/viewer/tree-actions/action-list.ts
@@ -1,11 +1,15 @@
 import {
 	Copy,
+	Eye,
 	FilePlus,
+	FileText,
 	FolderInput,
 	FolderPlus,
 	Link2,
+	ListPlus,
 	type LucideIcon,
 	Pencil,
+	SquareCode,
 	Trash2,
 } from "lucide-react";
 
@@ -19,6 +23,10 @@ const ACTION_ICONS: Record<ActionId, LucideIcon> = {
 	duplicate: Copy,
 	"copy-wikilink": Link2,
 	delete: Trash2,
+	"add-property": ListPlus,
+	"view-rendered": FileText,
+	"view-raw": SquareCode,
+	"view-reading": Eye,
 };
 
 const FILE_ACTIONS: readonly Action[] = [
@@ -62,12 +70,18 @@ export type ActionId =
 	| "move"
 	| "duplicate"
 	| "copy-wikilink"
-	| "delete";
+	| "delete"
+	| "add-property"
+	| "view-rendered"
+	| "view-raw"
+	| "view-reading";
 
 export interface Action {
 	id: ActionId;
 	label: string;
 	destructive?: boolean;
+	/** Set by `noteMenuActions` for the current view mode. The tree omits it. */
+	active?: boolean;
 }
 
 // Every folder gets the same menu, derived or not. A derived folder has no id
@@ -90,6 +104,25 @@ export function actionsFor({
 		return ATTACHMENT_ACTIONS;
 	}
 	return FILE_ACTIONS;
+}
+
+export type ViewMode = "rendered" | "raw" | "reading";
+
+// The note page's kebab. Deliberately NOT part of `actionsFor` — that function
+// answers "what can you do to a tree node", and the view modes are a property
+// of the open editor, not of the file.
+export function noteMenuActions(mode: ViewMode): readonly Action[] {
+	return [
+		{ id: "view-rendered", label: "Rendered", active: mode === "rendered" },
+		{ id: "view-raw", label: "Raw", active: mode === "raw" },
+		{ id: "view-reading", label: "Reading", active: mode === "reading" },
+		{ id: "rename", label: "Rename" },
+		{ id: "move", label: "Move to…" },
+		{ id: "duplicate", label: "Duplicate" },
+		{ id: "copy-wikilink", label: "Copy wikilink" },
+		{ id: "add-property", label: "Add property" },
+		{ id: "delete", label: "Delete", destructive: true },
+	];
 }
 
 export { ACTION_ICONS };

--- a/frontend/src/viewer/tree-actions/rename-input.tsx
+++ b/frontend/src/viewer/tree-actions/rename-input.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
 
 interface Props {
 	initial: string;
@@ -28,6 +29,13 @@ interface Props {
 	 * than as a side effect of this one.
 	 */
 	commitOnBlur?: boolean;
+	/**
+	 * Restyle the input. Merged with `cn`, so Tailwind conflicts REPLACE the
+	 * defaults rather than stacking — the inline title passes heading
+	 * typography and a transparent, borderless look so renaming reads as
+	 * typing into the title instead of a form field appearing in its place.
+	 */
+	className?: string;
 }
 
 export function RenameInput({
@@ -38,6 +46,7 @@ export function RenameInput({
 	onCommit,
 	onCancel,
 	commitOnBlur,
+	className,
 }: Props) {
 	const [value, setValue] = useState(initial);
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -106,7 +115,10 @@ export function RenameInput({
 				// wikilinks and sync. `settled` then latches, so it cannot be undone in
 				// place. Alt-tabbing away now leaves the edit open, exactly where it was.
 				onBlur={() => settle(Boolean(commitOnBlur) && document.hasFocus())}
-				className="w-full rounded border border-ring bg-background px-1 py-0.5 text-foreground text-sm outline-none"
+				className={cn(
+					"w-full rounded border border-ring bg-background px-1 py-0.5 text-foreground text-sm outline-none",
+					className,
+				)}
 			/>
 			{Boolean(error) && (
 				<span className="text-destructive text-xs" role="alert">


### PR DESCRIPTION
Makes the note page read like Obsidian: a thin chrome bar, a document title that scrolls with the content, and a Properties block that behaves like Obsidian's.

Design spec: Engram vault → `50 Engineering/_Superpowers Specs/2026-08-02-note-header-inline-title-kebab-design.md`
Plan: `docs/superpowers/plans/2026-08-02-note-header-inline-title-kebab.md`

## Header

- **Inline title** — a large `h1` in the document flow, so it scrolls away with the text instead of staying pinned. Click it to rename; the box is chromeless at heading size, so renaming reads as typing into the title rather than a form field appearing in its place.
- **CodeMirror gives up its scrollbar.** It had `height: 100%` and its own `.cm-scroller` overflow, which is what pinned everything rendered above it. It now grows with its content and one `ScrollArea` in `note-page` scrolls title, properties and body together in all three view modes.
- **Kebab menu** absorbing the three view-mode buttons plus rename / move / duplicate / copy-wikilink / add-property / delete, reusing the file tree's existing action vocabulary and dialogs.
- **Read/edit toggle** beside it, Obsidian-style. The icon shows the mode you are *in*; raw counts as an edit mode, so a round trip through reading restores the editor you left.
- **The header path keeps its own rename.** It is the affordance that stays reachable once the inline title has scrolled out of view.
- **New notes open with the title selected** — `useCreateNote` navigates with `{ justCreated: true }`, consumed once and then stripped so a back-navigation cannot reopen it.

## Frontmatter

- **Hidden when there is none.** The widget returns `null` while staying mounted, so its Y.Doc observers keep running and it reappears the moment a key arrives — locally or from a peer.
- **`---` on the first line opens it.** Frontmatter lives in its own `Y.Map`/`Y.Array`, never in the body, so the fence can never *become* frontmatter; a CodeMirror extension reports the gesture and the note page accepts it (removing the fence) or declines, leaving a real horizontal rule. The empty-but-open state is local React state and is never written to the doc.
- **Obsidian's Properties geometry**, taken from its own `app.css` rather than guessed — 9em key column that never shrinks, 28px rows, 3px gaps, the type picker as the key cell's leading icon.
- **Properties are renameable in place.** New `renameKey` in `frontmatter-doc` — deliberately not remove-then-add, which would drop the value and push the property to the end of the order. One transaction, so peers never observe both names at once.
- **Add via a button, not a phantom row**, as Obsidian does.

## Fixes found along the way

- `DropdownMenuContent` pinned its width to the trigger. Five of the six menus in the app hang off icon buttons, so all of them sat at the `min-w-32` floor and wrapped longer labels. The one menu that wants trigger-width already asked for it explicitly.
- The note kebab needs `modal={false}`: Radix's focus trap yanked focus back out of the inline rename box, and `RenameInput` settles on blur, so rename-from-the-kebab closed in the tick it opened. Written up in `docs/context/radix-modal-menu-vs-blur-committing-input.md`.
- A click-away handler treated clicks on portalled Radix menus as "outside", so picking a property type destroyed the editor it was opened from.

## Deliberately not here

- **Unit B** — the formatting toolbar is unmounted, not deleted. It is marked `PARKED`; its natural home is docked above the mobile keyboard, and `docs/context/mobile-keyboard-inset-apis.md` records which API to use (`interactive-widget` is the standards-track one; `navigator.virtualKeyboard` is a WICG incubation neither Apple nor Mozilla has committed to).
- **Property reordering UI.** `moveKey` stays in `frontmatter-doc`, tested, for a right-click menu later — which is where Obsidian keeps it.

## Review pass

A review of the branch turned up four correctness bugs in the frontmatter editor. Each got a failing test before a fix.

- **The `---` gesture latched.** The widget only told the page "nothing came of this draft" when the doc was still empty, so after the first property the page's flag stayed raised. Raising an already-raised flag is a React bailout, so the next `---` was consumed and opened nothing. The widget now reports every close.
- **A duplicate key threw away what was typed.** `addKey` and `renameKey` refused in silence, and the caller read the refusal as "nothing was entered" and discarded the row. Both now report; a collision keeps the row open with the text intact and says why.
- **A degraded key could corrupt the frontmatter on its way to the vault.** Uniqueness checked `values`, but a key whose YAML we cannot model lives only in `order` and the raw map. Letting one through put the name in `order` twice, and because `emitFrontmatter` gives raws precedence, the *other* property's value stopped being emitted at all.
- **Deleting the last character of the fence left the editor open.** The shortcut tested the pre-change range, whose endpoint is inclusive, so the deletion that removed the fence did not look like it touched it. It now reads post-change coordinates off `iterChanges`.

The kebab's "Add property" now opens the adder row rather than writing a key named `new-property`. It collided with itself on a second use and did nothing at all, and from reading or raw mode — where this widget is not rendered — it wrote a property that was invisible locally while syncing to every other device.

### Caught by CI, not by me

`e2e-browser` failed the Properties specs on the first run, for two reasons that are the same mistake twice — **replacing text with a control changes what the DOM says about itself**.

- The spec waited on the `<dt>`'s text. The key is an `<input>` now, and an input's value is not text content, so that wait could never succeed however well the widget worked.
- Worse, the type trigger. When its label became an icon I left the icon `aria-hidden` and the button named a static "Property type", so the current type was carried by pixels alone — a screen reader was told a type picker exists but never *which type the property already is*. The name now includes the value. The unit test that claimed to check this only ever asserted the select, which is how it got past me; it asserts the name now.

### Fixes for findings that were not blockers

- **`copy-wikilink` threw on a non-secure origin.** `navigator.clipboard` does not exist there — the ordinary self-host case, a LAN box over plain http — so reaching through it threw a synchronous `TypeError`. The `.catch()` sitting right there never ran, because no promise was ever created, and the copy escaped as an uncaught error instead of the "Copy failed" toast. Settings already had a guarded helper with an `execCommand` fallback, module-private; it is now `lib/clipboard.ts`, tested, and used by both wikilink call sites. Three raw uses remain in AdminPanel / InvitesTab / email-readonly-section with the same latent bug but different error handling around them — left for a focused pass rather than smuggled in here.
- **Duplicate reported failure twice.** `useDuplicateNote`'s `onError` already toasts and distinguishes a name collision from a general failure; both callers then caught the same rejection and stacked a vaguer "Duplicate failed" on top — and that was the one left on screen. Both now use `mutate` with an `onSuccess`, which is the pattern this file already documents for rename.
- **Enter and Escape in a property value field.** Every other input in the widget takes both; the value field, the one people use most, took neither.

## Verification

- 171 test files / 1248 tests green; biome clean over `src/` and `e2e/`; `bun run build` (tsc) clean.
- New context docs: `radix-modal-menu-vs-blur-committing-input.md`, `mobile-keyboard-inset-apis.md`, `obsidian-properties-parity.md` (includes the recipe for extracting Obsidian's real `app.css` from the AppImage).

Manual pass still owed on the two things happy-dom structurally cannot check — that a long note scrolls with a single scrollbar, and that arrowing the caret past the bottom edge drags the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz
