### PR TITLE
fix(ui): guard the last three clipboard call sites

### DIFF
--- a/frontend/src/features/admin/AdminPanel.tsx
+++ b/frontend/src/features/admin/AdminPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useMe } from "@/api/queries";
 import { useConfig } from "@/config-context";
+import { copyToClipboard } from "@/lib/clipboard";
 import InvitesTab from "./InvitesTab";
 import MembersTab from "./MembersTab";
 import RegistrationTab from "./RegistrationTab";
@@ -17,8 +18,14 @@ export default function AdminPanel() {
 		if (!resetUrl) {
 			return;
 		}
-		await navigator.clipboard.writeText(resetUrl);
-		toast.success("Copied to clipboard");
+		// Self-host runs on a LAN box over plain http, where navigator.clipboard
+		// does not exist — reaching through it threw before any promise existed,
+		// and the success toast below fired for a copy that never happened.
+		if (await copyToClipboard(resetUrl)) {
+			toast.success("Copied to clipboard");
+		} else {
+			toast.error("Could not copy");
+		}
 	}
 
 	// Defensive gate — the nav entry is hidden when these don't hold, but a user

--- a/frontend/src/features/admin/InvitesTab.tsx
+++ b/frontend/src/features/admin/InvitesTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
+import { copyToClipboard } from "@/lib/clipboard";
 import { adminApi, type Invite } from "./api";
 
 export default function InvitesTab() {
@@ -62,8 +63,13 @@ export default function InvitesTab() {
 	}
 
 	async function copy(url: string) {
-		await navigator.clipboard.writeText(url);
-		toast.success("Copied to clipboard");
+		// Invites are the one flow an admin runs from a fresh self-host box, which
+		// is exactly where navigator.clipboard is missing (non-secure origin).
+		if (await copyToClipboard(url)) {
+			toast.success("Copied to clipboard");
+		} else {
+			toast.error("Could not copy");
+		}
 	}
 
 	return (

--- a/frontend/src/settings/account/email-readonly-section.test.tsx
+++ b/frontend/src/settings/account/email-readonly-section.test.tsx
@@ -29,4 +29,20 @@ describe("EmailReadonlySection", () => {
 
 		expect(writeText).toHaveBeenCalledWith("me@example.com");
 	});
+
+	// Self-host serves over plain http on the LAN, where the whole
+	// navigator.clipboard namespace is absent. Copy has to still work there.
+	it("falls back to execCommand when there is no clipboard namespace", async () => {
+		Object.defineProperty(navigator, "clipboard", {
+			value: undefined,
+			writable: true,
+			configurable: true,
+		});
+		const execCommand = vi.fn().mockReturnValue(true);
+		document.execCommand = execCommand;
+
+		render(<EmailReadonlySection />);
+		fireEvent.click(screen.getByRole("button", { name: /copy email/iu }));
+		await vi.waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+	});
 });

--- a/frontend/src/settings/account/email-readonly-section.tsx
+++ b/frontend/src/settings/account/email-readonly-section.tsx
@@ -1,6 +1,7 @@
 import { Copy } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 import { useMe } from "../../api/queries";
 import { SettingsSectionCard } from "./section-card";
 
@@ -9,10 +10,12 @@ export function EmailReadonlySection() {
 	const email = data?.email ?? "";
 
 	async function copy() {
-		try {
-			await navigator.clipboard.writeText(email);
+		// This one already degraded politely — its try/catch caught the missing
+		// namespace — but it could never actually copy on a non-secure origin.
+		// The shared helper adds the execCommand fallback that can.
+		if (await copyToClipboard(email)) {
 			toast.success("Email copied");
-		} catch {
+		} else {
 			toast.error("Could not copy");
 		}
 	}


### PR DESCRIPTION
Follow-up to #1219, which hoisted `lib/clipboard.ts` but converted only the two `copy-wikilink` callers. These three were deliberately left behind because each wrapped errors differently and deserved reading rather than a sed.

| Site | Before | Why it mattered |
|---|---|---|
| `AdminPanel.copyResetUrl` | no try/catch | threw a **synchronous** TypeError, then toasted success anyway |
| `InvitesTab.copy` | no try/catch | same — and this is the one flow an admin runs from a fresh self-host box |
| `email-readonly-section.copy` | had try/catch | degraded honestly, but could never actually copy |

On a non-secure origin `navigator.clipboard` is `undefined`, so `navigator.clipboard.writeText(...)` throws while the expression is being *evaluated* — before any promise exists. A `.catch()` cannot help, and neither can `await`, because there is nothing to await. Only optional chaining guards the namespace, which is what `copyToClipboard` does before falling back to `execCommand`.

Self-host is served over plain http on the LAN, so this is the normal case there, not an edge case.

All three now report what actually happened rather than claiming success. Regression test added for the no-namespace path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz