### PR TITLE
feat(observability): export the fan-out pacer cold-queue gauges (#1004)

### DIFF
--- a/lib/engram/prom_ex/reliability.ex
+++ b/lib/engram/prom_ex/reliability.ex
@@ -22,12 +22,31 @@ defmodule Engram.PromEx.Reliability do
       terminal Oban discard.
     * `[:engram, :oban, :discarded]` → `..._oban_discarded_total`, tags
       `[:worker, :queue, :error_kind]` — jobs dropped after max_attempts.
+    * `[:engram, :fanout_pacer, :drain]` → `..._fanout_pacer_queue_depth`,
+      `..._fanout_pacer_queued`, `..._fanout_pacer_topics` (#1004) — the
+      vault-channel pacer's cold-queue state, sampled on every drain tick.
+      Untagged **on purpose**: the event's natural dimension is the topic,
+      which is per-vault and therefore unbounded cardinality.
+
+      `queue_depth` (deepest single vault) is the one to alert on — a genesis
+      flood of one large vault is the failure this pacer exists to absorb, and
+      a total across vaults would hide it. These are `last_value` gauges, not
+      counters: depth is a level, and a rate over it is meaningless.
+
+      No separate drain-lag series. Lag is derivable — the drain loop is a
+      fixed `fanout_drain_batch` every `fanout_drain_interval_ms`, so
+      `depth / batch * interval` is the wait at the back of the queue, and a
+      pacer that stalls outright stops emitting rather than reporting a low
+      number. Measuring per-frame lag would mean timestamping every queued
+      frame for a number Grafana can already compute.
 
   Cardinality contract: only the bounded tags above. NEVER user_id, vault_id,
   note_id, tenant_id, or job_id — those would explode the series count.
   """
 
   use PromEx.Plugin
+
+  @fanout_drain_event [:engram, :fanout_pacer, :drain]
 
   @impl true
   def event_metrics(opts) do
@@ -66,6 +85,24 @@ defmodule Engram.PromEx.Reliability do
           event_name: [:engram, :oban, :discarded],
           description: "Oban jobs discarded after max_attempts.",
           tags: [:worker, :queue, :error_kind]
+        ),
+        last_value(
+          metric_prefix ++ [:fanout_pacer, :queue_depth],
+          event_name: @fanout_drain_event,
+          measurement: :max_topic_depth,
+          description: "Deepest per-vault cold-queue seen at the last pacer drain tick."
+        ),
+        last_value(
+          metric_prefix ++ [:fanout_pacer, :queued],
+          event_name: @fanout_drain_event,
+          measurement: :queued,
+          description: "Total frames queued across all vaults at the last pacer drain tick."
+        ),
+        last_value(
+          metric_prefix ++ [:fanout_pacer, :topics],
+          event_name: @fanout_drain_event,
+          measurement: :topics,
+          description: "Vault topics with a non-empty cold queue at the last pacer drain tick."
         )
       ]
     )

--- a/test/engram/env_var_docs_test.exs
+++ b/test/engram/env_var_docs_test.exs
@@ -50,4 +50,51 @@ defmodule Engram.EnvVarDocsTest do
              ".\nAdd a `| VAR | default | purpose |` row to the matching section — " <>
              "the doc is what operators read, so an undocumented knob is an unusable one."
   end
+
+  # .env.example IS the self-host quickstart — `cp .env.example .env && docker
+  # compose up -d` is the documented path — so a knob left there after being
+  # renamed or removed silently does nothing, and the operator has no way to
+  # tell. That file has already shipped wrong content once (it set
+  # ENGRAM_DEFAULT_REGISTRATION_MODE=open while its own comment claimed
+  # invite_only, producing an open-signup instance).
+  #
+  # This checks EXISTENCE, not values. A test cannot know the right default for
+  # a knob, so the wrong-value class above stays a human review problem; what it
+  # can do is prove every name still resolves to something real.
+  @build_time_vars ~w(SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT)
+  test "every var in .env.example is actually read somewhere" do
+    read_at_runtime =
+      @runtime_config
+      |> File.stream!()
+      |> Stream.reject(&String.starts_with?(String.trim_leading(&1), "#"))
+      |> Stream.flat_map(
+        &Regex.scan(~r/System\.(?:get_env|fetch_env!?)\("([A-Z][A-Z0-9_]*)"/, &1,
+          capture: :all_but_first
+        )
+      )
+      |> Stream.concat()
+      |> MapSet.new()
+
+    orphaned =
+      ".env.example"
+      |> File.stream!()
+      |> Stream.flat_map(&Regex.scan(~r/^#?\s*([A-Z][A-Z0-9_]+)=/, &1, capture: :all_but_first))
+      |> Stream.concat()
+      |> Enum.uniq()
+      # Keep only names nothing accounts for. VITE_* are consumed by the
+      # frontend build, not the Elixir runtime, and the three SENTRY_* by the CI
+      # source-map upload — a prefix rule rather than a name list, so adding a
+      # frontend var needs no edit here.
+      |> Enum.reject(
+        &(String.starts_with?(&1, "VITE_") or &1 in @build_time_vars or
+            MapSet.member?(read_at_runtime, &1))
+      )
+      |> Enum.sort()
+
+    assert orphaned == [],
+           ".env.example offers vars nothing reads: " <>
+             Enum.join(orphaned, ", ") <>
+             ".\nEither the knob was renamed/removed (drop it from .env.example) or it is " <>
+             "consumed outside runtime.exs (add it to @build_time_vars with a reason)."
+  end
 end

--- a/test/engram/notes/fanout_pacer_test.exs
+++ b/test/engram/notes/fanout_pacer_test.exs
@@ -114,6 +114,47 @@ defmodule Engram.Notes.FanoutPacerTest do
     assert_receive(%Phoenix.Socket.Broadcast{payload: %{"note_id" => "live"}}, 150)
   end
 
+  # Pins the emitter side of the #1004 gauges. Engram.PromEx.Reliability reads
+  # these measurement keys by name, so renaming one here would leave the prod
+  # dashboards reporting nothing — silently, and exactly when a queue is
+  # backing up. The metric-shape test cannot catch that; only this can.
+  test "drain tick emits the cold-queue measurements the PromEx gauges read" do
+    Application.put_env(:engram, :fanout_pacing_enabled, true)
+    Application.put_env(:engram, :fanout_hot_window_ms, 60_000)
+    Application.put_env(:engram, :fanout_drain_batch, 1)
+    Application.put_env(:engram, :fanout_drain_interval_ms, 20)
+
+    ref = make_ref()
+    parent = self()
+
+    :telemetry.attach(
+      "pacer-drain-#{inspect(ref)}",
+      [:engram, :fanout_pacer, :drain],
+      fn _event, measurements, _meta, _cfg -> send(parent, {ref, measurements}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach("pacer-drain-#{inspect(ref)}") end)
+
+    topic = "sync:u6:v6"
+    for i <- 1..3, do: FanoutPacer.emit(topic, "note_yjs_update", payload("m#{i}"), "m#{i}")
+
+    assert_receive {^ref, measurements}, 1_000
+    assert %{queued: _, max_topic_depth: _, topics: _} = measurements
+
+    # A backlog is still pending on the first tick (3 frames, batch of 1), so
+    # this also proves the gauge reports a real level rather than a constant 0.
+    assert measurements.max_topic_depth > 0
+    assert measurements.topics > 0
+
+    # Drain fully before finishing. The module shares one named pacer, and the
+    # drain loop only stops rescheduling once its queues empty — leaving frames
+    # behind would keep a 20ms timer alive into the NEXT test, which sets a
+    # slower interval and asserts on tick spacing. That stale timer fires
+    # inside its refute window and fails it (observed, not hypothetical).
+    await_drained(topic)
+  end
+
   test "two topics drain independently (per-vault fairness)" do
     Application.put_env(:engram, :fanout_pacing_enabled, true)
     Application.put_env(:engram, :fanout_hot_window_ms, 60_000)

--- a/test/engram/prom_ex/reliability_test.exs
+++ b/test/engram/prom_ex/reliability_test.exs
@@ -22,6 +22,15 @@ defmodule Engram.PromEx.ReliabilityTest do
     end)
   end
 
+  # Matches on the measurement too: one event carries several gauges, so the
+  # event name alone would not distinguish depth from queued from topics.
+  defp gauge_for(event_name, measurement) do
+    Enum.find(metrics(), fn m ->
+      match?(%Telemetry.Metrics.LastValue{}, m) and m.event_name == event_name and
+        m.measurement == measurement
+    end)
+  end
+
   describe "event_metrics/1" do
     test "returns Event struct(s) prefixed [:engram, :prom_ex, :reliability]" do
       events = Plugin.event_metrics(otp_app: :engram) |> List.wrap()
@@ -57,6 +66,20 @@ defmodule Engram.PromEx.ReliabilityTest do
       assert :worker in tags
       assert :queue in tags
       assert :error_kind in tags
+    end
+
+    # #1004: the pacer already emitted [:engram, :fanout_pacer, :drain] but
+    # nothing exported it, so a cold queue backing up in prod was invisible.
+    # These are last_value gauges, not counters — depth is a level, not a rate.
+    test "gauges the fan-out pacer cold-queue depth" do
+      m = gauge_for([:engram, :fanout_pacer, :drain], :max_topic_depth)
+      assert m, "expected a last_value on the pacer drain event's :max_topic_depth"
+      assert m.tags == [], "pacer depth must stay untagged — topic is per-vault"
+    end
+
+    test "gauges total queued frames and active topic count" do
+      assert gauge_for([:engram, :fanout_pacer, :drain], :queued)
+      assert gauge_for([:engram, :fanout_pacer, :drain], :topics)
     end
 
     test "no per-tenant / high-cardinality tags" do


### PR DESCRIPTION
Follow-ups from the #1217 config audit. Two commits, separate concerns, bundled because both close gaps that audit surfaced.

## `e4ac9cab` — pacer cold-queue gauges (#1004)

#1004 asks for "a telemetry gauge of per-topic cold-queue depth … right now if the cold queue backs up in prod we're blind to it". **The premise was half out of date:** `FanoutPacer` already emits `[:engram, :fanout_pacer, :drain]` with `queued` / `max_topic_depth` / `topics` on every drain tick. Nothing subscribed, so the event went nowhere — the blindness was real, but the gap was a missing **PromEx export**, not a missing measurement. That makes this much smaller than the issue implies.

Wired into the `Reliability` plugin rather than a new one: that module is explicitly *"cross-cutting incident counters — the signals an on-call alert should key on"*, which is what a backing-up queue is, and #1004's remaining box wants an alarm on exactly this series.

Design notes, all deliberate:
- **Untagged.** The event's natural dimension is the topic, which is per-vault — unbounded cardinality, the one thing this plugin's cardinality contract forbids.
- **`queue_depth` (deepest single vault) is the alert series.** A genesis flood of one large vault is the failure the pacer exists to absorb; a cross-vault total would average it away.
- **`last_value`, not `counter`.** Depth is a level; a rate over it is meaningless.
- **No drain-lag series**, though #1004 mentions one. Lag is derivable from what this exports: the loop drains a fixed `fanout_drain_batch` every `fanout_drain_interval_ms`, so `depth / batch * interval` is the wait at the back of the queue. A pacer that stalls outright stops emitting rather than reporting a low number, so absence covers that case. Per-frame lag would mean timestamping every queued frame for a number Grafana can already compute.

Also **pins the emitter side**. `Reliability` reads these measurement keys by name, so renaming one would leave the dashboards reporting nothing — silently, and precisely when a queue is backing up. A metric-shape test can't catch that; a telemetry-handler test in `fanout_pacer_test` can.

That new test initially **broke a sibling**, which is worth recording: it left a 20ms drain loop running with frames still queued, and the stale timer fired inside the next test's refute window. The module shares one named pacer, so a test must leave it idle — it now drains fully before finishing.

## `6b038997` — `.env.example` orphan-var guard

`.env.example` **is** the self-host quickstart, so a knob left there after being renamed or removed silently does nothing and the operator can't tell. It has already shipped wrong content once — #1217 found it setting `ENGRAM_DEFAULT_REGISTRATION_MODE=open` while its own comment claimed `invite_only`.

Checks **existence, not values**, and that limit is the point: a test can't know the right default, so the wrong-value class stays a human review problem. What it can do is prove every name still resolves to something real.

Eight vars there aren't read by `runtime.exs` and all are legitimate, so a naive check would be pure false positives: `VITE_*` go to the frontend build, three `SENTRY_*` to the CI source-map upload. Handled with a prefix rule plus a three-name list, so adding a frontend var needs no edit here.

Both guards verified by making them fail — an orphaned knob is named in the failure.

## Verification

`format`, `credo --strict`, and `dialyzer` clean. Full `mix test --warnings-as-errors`: **3992 tests, 0 failures**, real exit code.

An earlier run of that suite showed 8 failures with `connection is closed` across unrelated modules — self-inflicted, from running `mix dialyzer` concurrently with the suite and starving the DB. Re-run with nothing else going: clean. Noting it because the same overlap likely explains an unattributed failure during #1218's verification.

Refs #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyirNUaZY19uVvzwBL8yX4