### PR TITLE
fix(oauth): negotiate CIMD metadata instead of policing it

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,6 +24,7 @@ on:
     - cron: '17 13 * * 1'   # frontend-major-updates   (Mon 13:17 UTC)
     - cron: '0 14 * * 1'    # plan-triage              (Mon 14:00 UTC)
     - cron: '0 3 * * 6'     # dependency-submission    (Sat 03:00 UTC)
+    - cron: '40 5 * * *'    # mcp-conformance          (daily 05:40 UTC)
   workflow_dispatch:
     inputs:
       task:
@@ -38,10 +39,15 @@ on:
           - frontend-major-updates
           - runner-diagnostics
           - dependency-submission
+          - mcp-conformance
       force:
         description: '(obsidian-update only) Force re-download even if version matches'
         type: boolean
         default: false
+      target-url:
+        description: '(mcp-conformance only) MCP endpoint to test'
+        type: string
+        default: 'https://staging.engram.page/api/mcp'
 
 # No workflow-level permissions — each job grants what it actually needs.
 permissions: {}
@@ -537,3 +543,46 @@ jobs:
         uses: erlef/mix-dependency-submission@v1
         with:
           install-deps: true
+
+  # ── MCP OAuth conformance against a DEPLOYED authorization server.
+  #
+  # Deliberately here and not in verify.yml: this tests a running deployment,
+  # and on a PR the deployment still runs main, so a per-PR job would grade the
+  # wrong code. It is a post-deploy conformance check, so it rides the cron.
+  #
+  # It exists because on 2026-08-04 every Claude connect failed with
+  # `invalid_client` while the unit suite stayed 100% green — the CIMD fixture
+  # was authored alongside the validator it tested, so it could only assert that
+  # our code accepts what our code expects. This runs somebody else's real
+  # client (MCPJam's published metadata document, which declares a grant we do
+  # not implement and lists 14 redirect URIs) against us. Against pre-fix main
+  # it fails at exactly one step, HTTP 400 on the authorization request.
+  #
+  # Non-gating on purpose for now: it grades a deployment rather than a commit,
+  # so a red run means "staging is wrong", which is a page, not a merge block.
+  mcp-conformance:
+    if: |
+      github.event.schedule == '40 5 * * *'
+      || github.event.inputs.task == 'mcp-conformance'
+    name: mcp-conformance
+    runs-on: [self-hosted, linux, x64, isolated, light]
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: OAuth conformance (DCR + CIMD)
+        run: ./scripts/mcp-conformance.sh "${{ github.event.inputs.target-url || 'https://staging.engram.page/api/mcp' }}"
+
+      - name: Upload conformance results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcp-conformance-results
+          path: conformance-results/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ frontend/test-results/
 frontend/playwright-report/
 frontend/e2e/.auth-state.json
 .superpowers/
+conformance-results/

--- a/docs/context/cimd-vs-dcr-validation-policy.md
+++ b/docs/context/cimd-vs-dcr-validation-policy.md
@@ -1,0 +1,154 @@
+# CIMD documents are negotiated, DCR registrations are policed — don't share the changeset
+
+_Last verified: 2026-08-04_
+
+Root cause of the 2026-08-04 prod outage where **every Claude connect died on `invalid_client`**. Fix in `fix/cimd-spec-validation`. Related: [[connections-client-identity]], [[mcp-oauth]].
+
+## Symptom
+
+User adds the connector in Claude (Desktop/web/mobile/Code), gets our own error page:
+
+```
+Authorization error
+Error: invalid_client.
+The OAuth client or redirect URI is not recognized. The request was rejected to prevent code-leak attacks.
+```
+
+That copy is **ours** — `oauth_authorize_controller.ex` `render_client_error/2`. It is not a claude.ai page. Seeing it means `OAuth.validate_authorization_request/1` returned `{:client_error, "invalid_client"}`.
+
+Prod log signature (Loki, `{service_name="engram", env="prod"}`):
+
+```
+mcp_cimd_rejected  host=claude.ai  reason=:invalid_document
+GET 400            route=EngramWeb.OAuthAuthorizeController#show
+```
+
+Both lines share a `trace` + `request_id`. That pairing is how you confirm the 400 *is* the CIMD rejection rather than a coincidence.
+
+## Why it started (the part that surprises people)
+
+Nothing in the DCR path broke. **Claude stopped using DCR.**
+
+Anthropic's clients select CIMD when — and only when — the authorization-server metadata advertises *both*:
+
+```json
+"client_id_metadata_document_supported": true,
+"token_endpoint_auth_methods_supported": ["none", ...]
+```
+
+PR #1167 turned the first one on. From that deploy onward every Claude surface sent a `claude.ai` URL as `client_id` instead of registering. A one-word change to a `/.well-known/` document silently repointed every client at a code path that had never carried real traffic.
+
+**Rule: a change to a discovery document is a client-behaviour change, not a config change.** Treat it like a deploy of the code path it enables.
+
+## The actual bug
+
+`Cimd.store/3` validated a fetched vendor document by calling `Client.registration_changeset/2` — the **DCR registration policy**. A prior test even defended this as DRY ("a CIMD-specific validation path would be a second copy of those rules").
+
+Half right. Two different questions were sharing one answer:
+
+| | DCR (`POST /oauth/register`) | CIMD (fetched document) |
+|---|---|---|
+| Who is speaking | an anonymous stranger asking permission | a vendor describing itself to *every* AS on the internet |
+| Unknown `grant_types` | reject — they can fix and retry | **intersect** — they weren't asking us |
+| Bad `logo_uri` | reject | **drop the field** — a logo must not cost a connector |
+| Over-long `client_name` | reject | **truncate** |
+| Unsafe `redirect_uri` | reject | **reject** — code-leak vector, not a capability |
+
+Applying registration policy to a published document means any metadata we happen not to implement kills the whole authorization. RFC 7591 §3.2.1 says the opposite: the AS records what *it* supports and reports back what it granted.
+
+The likeliest concrete trigger: Anthropic's hosted document declaring a `urn:ietf:params:oauth:grant-type:*` entry (Enterprise Managed Auth does token exchange), tripping `validate_subset(:grant_types, ~w(authorization_code refresh_token))`.
+
+**The fix is the split, not a longer allowlist.** Widening the subset list would have worked until the next field. `Cimd.negotiate/1` now intersects capability metadata and drops decoration *before* the changeset; safety rules (redirect URIs, the self-referential `client_id` binding, confidential-method refusal) stay shared and still refuse.
+
+## Two things that made it undiagnosable
+
+Both cost more investigation time than the bug itself.
+
+**1. `:invalid_document` collapsed two unrelated failures** — a changeset refusal and a lost insert race — and discarded the changeset errors. The log named the host and nothing else, so it could not say *which field* died. Now: `{:invalid_document, errors}` vs `:store_conflict`, and the log carries `fields=[...]`.
+
+> Log the field **names**, never the changeset messages. Several messages interpolate the offending value (`"missing scheme: #{uri}"`), which is attacker-supplied on an unauthenticated endpoint — the same reason `cimd_host` is a host and not the full URL.
+
+**2. Every CIMD failure was reported as `invalid_client`,** including `:rate_limited`, `:fetch_failed`, 5xx from the vendor, and the lost race. Two consequences, and the second is nasty:
+
+- `invalid_client` is *terminal*. Clients stop retrying; users see a permanently dead connector.
+- `:rate_limited` is **deliberately never logged** (unbounded log volume behind a bounded side effect — the argument in `Cimd`'s moduledoc is sound). So once the first store failed, no row existed, *every* retry re-entered discovery and burned the 10/min per-host bucket **silently**.
+
+Net effect: one log line, many user-visible failures. If you ever see a single `mcp_cimd_rejected` and a user reporting persistent failure, **assume the retries were absorbed by the limiter** — absence of logs is not absence of attempts.
+
+`OAuth.cimd_error/1` now splits transient (→ `{:server_error, "temporarily_unavailable"}`, HTTP 503, distinct page) from terminal (→ `invalid_client`).
+
+## Reproducing without a Claude client
+
+The whole flow is a plain GET. Claude Code's real document is public:
+
+```bash
+curl -s https://claude.ai/oauth/claude-code-client-metadata
+# {"client_id":"https://claude.ai/oauth/claude-code-client-metadata","client_name":"Claude Code",
+#  "redirect_uris":["http://localhost/callback","http://127.0.0.1/callback"], ...}
+
+CID=$(python3 -c "import urllib.parse;print(urllib.parse.quote('https://claude.ai/oauth/claude-code-client-metadata',safe=''))")
+RU=$(python3 -c "import urllib.parse;print(urllib.parse.quote('http://localhost:3118/callback',safe=''))")
+curl -si "https://mcp.engram.page/oauth/authorize?response_type=code&client_id=$CID&redirect_uri=$RU\
+&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&scope=mcp&state=probe"
+# 302 → app.engram.page/oauth/consent?...   = healthy
+```
+
+Note the **portless** `redirect_uris` in that document against a **ported** runtime redirect. Our RFC 8252 §7.3 loopback port exemption (`OAuth.loopback_port_match?/2`) is what makes that work — it is load-bearing for every local-first connector, not a nicety.
+
+To test validation logic without booting the app or a DB:
+
+```bash
+mix run --no-start /path/to/probe.exs   # changeset validation is pure
+```
+
+## Dead ends (don't repeat these)
+
+- **Guessing the failing URL from claude.ai paths.** Only `/oauth/claude-code-client-metadata` is publicly readable; other `/oauth/*` paths return a Cloudflare challenge to curl. The hosted-surface CIMD URL is undocumented. You cannot recover it from our logs either — `request_query` is redacted and `cimd_host` is host-only, both on purpose.
+- **Assuming the changeset must be rejecting a malformed document.** The live Claude Code document passes `cimd_changeset` cleanly, and so do the obvious hosted-surface shapes. Verify before theorising.
+- **Reproducing the insert race on staging.** Six concurrent cold-cache authorizes all 302. Staging is single-container; under READ COMMITTED the losing insert blocks until the winner commits and then finds the row, so the race branch is genuinely hard to hit.
+
+## The regression net that actually catches this class
+
+Two things, both drawn from outside our own head.
+
+**1. Real published documents as fixtures.** `cimd_test.exs` now pins the live
+Claude Code document *and* MCPJam's. The second is the valuable one: it declares
+`urn:ietf:params:oauth:grant-type:device_code` and lists **14** redirect URIs, so
+against pre-fix code it failed twice over (`contains an unsupported grant_type`
+and `should have at most 10 item(s)`). Fetch them again if they start failing;
+do not edit them to fit.
+
+That second failure is worth dwelling on. During review I noticed the 10-URI cap
+was DCR policy sitting in the safety bucket, reasoned that "Claude publishes two,
+revisit if a real document approaches it", and left it. A real document blew past
+it about ten minutes later. The cap is now per-path: 10 for DCR (anonymous POST,
+anti-abuse), 50 for CIMD (already bounded by the fetcher's mid-stream body cap).
+
+**2. `scripts/mcp-conformance.sh`** — MCPJam's OAuth conformance CLI, run daily
+against staging by the `mcp-conformance` job in `cron.yml`. It performs the real
+handshakes Claude Desktop/Code and ChatGPT perform. Against pre-fix main:
+
+```
+==> dcr  reached the consent gate cleanly (10 steps passed)
+==> cimd REGRESSION: received_authorization_code [HTTP 400]
+```
+
+### Two traps in that script, both already paid for
+
+**Judge the HTTP status, not the step name.** The first version of the classifier
+excused `received_authorization_code` as "consent-gated" and therefore reported
+**green against a server we knew was broken**. Our authorization endpoint needs a
+Clerk session, so that step fails on a healthy server too — but healthy fails
+*after* a `302` to consent, and broken fails *with a* `400`. Same step name, and
+only the status separates them. Anything ≥400 is a regression no matter which
+step reports it.
+
+**It belongs in `cron.yml`, not `verify.yml`.** It grades a running deployment.
+On a PR the deployment still runs `main`, so a per-PR job would grade the wrong
+code and be reliably, meaninglessly green.
+
+Pin the CLI version. The npm package carries registry signatures but **no build
+provenance attestation**, so the tarball is not cryptographically tied to a
+commit, and `@latest` would give a compromised publish network access to our
+authorization server from CI. It also bundles `posthog-node` and is telemetry-
+opt-out rather than opt-in — hence `--no-telemetry`.

--- a/lib/engram/oauth.ex
+++ b/lib/engram/oauth.ex
@@ -164,6 +164,10 @@ defmodule Engram.OAuth do
     * `{:client_error, code}` — bad client_id or redirect_uri; render an HTML
       error page rather than redirect (a redirect would let an attacker
       exfiltrate codes via a forged redirect_uri)
+    * `{:server_error, code}` — we could not resolve a CIMD client for a reason
+      that is ours and transient. Same "render, never redirect" rule (there is
+      no validated redirect_uri to trust yet), but a 503 rather than a 400, so
+      the client retries instead of writing the connector off.
   """
   def validate_authorization_request(params) when is_map(params) do
     with {:ok, client} <- fetch_client(params["client_id"]),
@@ -594,7 +598,7 @@ defmodule Engram.OAuth do
     if Cimd.url_shaped?(client_id) do
       case Cimd.ensure_client(client_id) do
         {:ok, client} -> {:ok, client}
-        {:error, _reason} -> {:client_error, "invalid_client"}
+        {:error, reason} -> cimd_error(reason)
       end
     else
       case get_client(client_id) do
@@ -603,6 +607,26 @@ defmodule Engram.OAuth do
       end
     end
   end
+
+  # "We could not resolve this client" is not "this client does not exist".
+  #
+  # `invalid_client` is terminal: the client stops retrying and the user sees a
+  # permanently dead connector. But our own fetch rate limiter, a vendor's 5xx,
+  # a transport blip and a lost insert race are all OUR side of the wire and all
+  # clear on their own. Reporting them as the vendor's fault is both wrong and
+  # self-concealing — `:rate_limited` is deliberately never logged (see
+  # `Engram.OAuth.Cimd`), so before this split a user in a retry loop produced a
+  # stream of `invalid_client` pages and not one line of evidence.
+  defp cimd_error(reason)
+       when reason in [:rate_limited, :fetch_failed, :store_conflict],
+       do: {:server_error, "temporarily_unavailable"}
+
+  defp cimd_error({:http_status, status}) when status >= 500 or status == 429,
+    do: {:server_error, "temporarily_unavailable"}
+
+  # A 4xx on the document URL is the vendor's to fix, as is a malformed or
+  # unbindable document. Those are genuinely terminal for this client_id.
+  defp cimd_error(_reason), do: {:client_error, "invalid_client"}
 
   defp match_redirect_uri(_client, nil), do: {:client_error, "invalid_redirect_uri"}
 

--- a/lib/engram/oauth/cimd.ex
+++ b/lib/engram/oauth/cimd.ex
@@ -96,11 +96,15 @@ defmodule Engram.OAuth.Cimd do
           | :rate_limited
           | :client_id_mismatch
           | :missing_redirect_uris
+          | :missing_client_name
           | :confidential_not_supported
+          | :no_supported_grant_type
+          | :no_supported_response_type
           | :body_too_large
           | :not_json
           | :invalid_json
-          | :invalid_document
+          | {:invalid_document, keyword()}
+          | :store_conflict
           | :fetch_failed
           | {:http_status, pos_integer()}
           | SsrfGuard.reason()
@@ -172,13 +176,91 @@ defmodule Engram.OAuth.Cimd do
     with :ok <- rate_limit(url, existing),
          {:ok, document} <- Fetcher.impl().fetch(url),
          :ok <- validate_document(document, url),
-         {:ok, client} <- store(url, document, existing) do
+         {:ok, negotiated} <- negotiate(document),
+         {:ok, client} <- store(url, negotiated, existing) do
       {:ok, client}
     else
       {:error, reason} ->
         log_unless_rate_limited("mcp_cimd_rejected", url, reason)
         {:error, reason}
     end
+  end
+
+  # Capability metadata is NEGOTIATED, not enforced.
+  #
+  # `validate_document/2` above is about safety and binding, and it refuses.
+  # This is about what the two ends can do together, and it intersects. The
+  # distinction is the whole lesson of the 2026-08-04 incident: a fetched
+  # document was being run through `Client.registration_changeset/2`, which is
+  # DCR *registration policy* — subset allowlists, size caps, https-only
+  # decoration. Those are the right questions to ask an anonymous stranger
+  # POSTing to `/oauth/register`. They are the wrong questions to ask a document
+  # a vendor published for every authorization server in existence, and asking
+  # them cost every Claude user their connector over metadata we simply had no
+  # use for.
+  #
+  # RFC 7591 §3.2.1 is explicit that the server records what IT supports and
+  # reports back what it granted, rather than failing the registration.
+  #
+  # Redirect URIs are deliberately NOT negotiated here — they stay under the
+  # shared changeset validation, because an unsafe redirect is a code-leak
+  # vector, not a capability we can politely decline.
+  #
+  # KNOWN RESIDUAL: `validate_length(:redirect_uris, max: 10)` is DCR anti-abuse
+  # policy, not safety, and it still hard-rejects — so the split below is not
+  # total. A vendor publishing an eleventh redirect loses its connector the same
+  # way an extra grant_type used to. Left as-is on purpose: silently dropping the
+  # overflow could discard the very URI in use and fail later and worse, and the
+  # bound is already redundant for CIMD (the body is capped mid-stream). Revisit
+  # if a real document ever approaches it — Claude's publishes two.
+  defp negotiate(document) do
+    with {:ok, grants} <-
+           intersect(
+             document["grant_types"],
+             Client.supported_grant_types(),
+             :no_supported_grant_type
+           ),
+         {:ok, responses} <-
+           intersect(
+             document["response_types"],
+             Client.supported_response_types(),
+             :no_supported_response_type
+           ) do
+      {:ok,
+       document
+       |> Map.put("grant_types", grants)
+       |> Map.put("response_types", responses)
+       |> Map.put("client_name", truncate_name(document["client_name"]))
+       |> drop_undisplayable_uris()}
+    end
+  end
+
+  # Absent or malformed means "unstated", which the changeset's own defaults
+  # answer. Only an explicit list that shares nothing with us is fatal: at that
+  # point there is no flow left to run, and the refusal is a statement about us
+  # rather than about tidiness.
+  defp intersect(declared, supported, empty_error) when is_list(declared) do
+    case Enum.filter(supported, &(&1 in declared)) do
+      [] -> {:error, empty_error}
+      kept -> {:ok, kept}
+    end
+  end
+
+  defp intersect(_declared, _supported, _empty_error), do: {:ok, nil}
+
+  defp truncate_name(name) when is_binary(name),
+    do: String.slice(name, 0, Client.client_name_max_length())
+
+  defp truncate_name(other), do: other
+
+  defp drop_undisplayable_uris(document) do
+    Enum.reduce(Client.metadata_uri_fields(), document, fn field, acc ->
+      key = Atom.to_string(field)
+
+      if Map.has_key?(acc, key) and not Client.displayable_metadata_uri?(acc[key]),
+        do: Map.put(acc, key, nil),
+        else: acc
+    end)
   end
 
   # A rate-limit denial is deliberately NOT logged, on either path. The fetch is
@@ -250,6 +332,20 @@ defmodule Engram.OAuth.Cimd do
       not valid_redirect_uris?(document["redirect_uris"]) ->
         {:error, :missing_redirect_uris}
 
+      # MCP 2025-11-25: "The metadata document MUST include at least the
+      # following properties: client_id, client_name, redirect_uris." We enforced
+      # two of the three.
+      #
+      # This is a required field, not capability metadata, so it belongs here
+      # with the refusals rather than in negotiate/1 — but the line is worth
+      # drawing carefully given how this PR started. An unknown grant_type costs
+      # us nothing to ignore; a nameless client cannot be rendered on the consent
+      # screen at all, and "Authorize this app" is a worse outcome than a legible
+      # refusal. Both real documents in the test suite supply it, as does every
+      # client that reads the spec.
+      not valid_client_name?(document["client_name"]) ->
+        {:error, :missing_client_name}
+
       # A CIMD client never registered, so no secret was ever minted for it. If we
       # honoured a confidential method the client could never authenticate (its
       # stored hash is nil), and if we silently downgraded to `none` the client
@@ -267,13 +363,18 @@ defmodule Engram.OAuth.Cimd do
   defp valid_redirect_uris?([_ | _] = uris), do: Enum.all?(uris, &is_binary/1)
   defp valid_redirect_uris?(_), do: false
 
+  # Whitespace-only is absent with extra steps — it renders as nothing on the
+  # consent screen, which is the whole reason the field is required.
+  defp valid_client_name?(name) when is_binary(name), do: String.trim(name) != ""
+  defp valid_client_name?(_), do: false
+
   defp store(url, document, existing) do
     changeset = Client.cimd_changeset(existing || %Client{}, url, document)
 
     if existing do
       case Repo.update(changeset, skip_tenant_check: true) do
         {:ok, client} -> {:ok, client}
-        {:error, _changeset} -> {:error, :invalid_document}
+        {:error, failed} -> {:error, {:invalid_document, failed.errors}}
       end
     else
       insert_new(changeset, url)
@@ -294,12 +395,16 @@ defmodule Engram.OAuth.Cimd do
       {:error, %Ecto.Changeset{} = failed} ->
         if Keyword.has_key?(failed.errors, :cimd_url),
           do: get_by_url(url) |> normalize_race_result(),
-          else: {:error, :invalid_document}
+          else: {:error, {:invalid_document, failed.errors}}
     end
   end
 
   defp normalize_race_result({:ok, client}), do: {:ok, client}
-  defp normalize_race_result({:error, :not_found}), do: {:error, :invalid_document}
+
+  # Losing the insert race and then not finding the winner is OUR problem, not a
+  # statement about the vendor's document — the caller must be able to tell them
+  # apart, because one is retryable and the other is terminal.
+  defp normalize_race_result({:error, :not_found}), do: {:error, :store_conflict}
 
   # Host only, never the full URL or the reason's payload: `:lifecycle` ships to
   # Loki (`:auth` info does not — see Engram.Logger.Category), and the host is
@@ -310,8 +415,19 @@ defmodule Engram.OAuth.Cimd do
       event,
       Metadata.with_category(:warning, :lifecycle,
         cimd_host: URI.parse(url).host,
-        reason: inspect(reason)
+        reason: format_reason(reason)
       )
     )
   end
+
+  # Field NAMES, never the changeset messages. Several of those interpolate the
+  # offending value (`"missing scheme: #{uri}"`), which is attacker-supplied on
+  # an unauthenticated endpoint — the same reason the host, not the URL, is
+  # logged above. The names are ours, and they are the whole diagnosis: on
+  # 2026-08-04 a bare `:invalid_document` left us unable to say which field of a
+  # vendor's document had killed every Claude connection.
+  defp format_reason({:invalid_document, errors}),
+    do: "invalid_document fields=#{inspect(errors |> Keyword.keys() |> Enum.uniq())}"
+
+  defp format_reason(reason), do: inspect(reason)
 end

--- a/lib/engram/oauth/client.ex
+++ b/lib/engram/oauth/client.ex
@@ -29,6 +29,18 @@ defmodule Engram.OAuth.Client do
   @valid_grant_types ~w(authorization_code refresh_token)
   @valid_response_types ~w(code)
   @loopback_hosts ~w(localhost 127.0.0.1 ::1)
+  @client_name_max_length 200
+
+  # Both bound row size; they answer to different threats.
+  #
+  # DCR is an anonymous POST, so the cap is anti-abuse and 10 is generous for a
+  # real registrant. A CIMD document is bounded already — the fetcher caps the
+  # body mid-stream — and belongs to a vendor supporting many surfaces at once.
+  # MCPJam's published document lists 14 (three ports x several paths, plus app
+  # and staging hosts) and is a perfectly ordinary client. Holding it to DCR's
+  # number rejects it for being popular.
+  @max_redirect_uris_dcr 10
+  @max_redirect_uris_cimd 50
 
   schema "oauth_clients" do
     field :client_secret_hash, :string
@@ -85,6 +97,40 @@ defmodule Engram.OAuth.Client do
   def confidential?(method), do: method in @confidential_auth_methods
 
   @doc """
+  The grant and response types this authorization server actually implements.
+
+  Exposed for `Engram.OAuth.Cimd`, which INTERSECTS a fetched document against
+  these rather than refusing a client for declaring more than we do. DCR keeps
+  using them as a `validate_subset` allowlist — a registration request is a
+  stranger asking our permission, a published metadata document is a vendor
+  describing itself to every authorization server in the world. Same lists, two
+  different questions; the lists live here so the two answers cannot drift.
+  """
+  @spec supported_grant_types() :: [String.t()]
+  def supported_grant_types, do: @valid_grant_types
+
+  @spec supported_response_types() :: [String.t()]
+  def supported_response_types, do: @valid_response_types
+
+  @doc "The optional RFC 7591 §2 metadata URIs, and the cap on `client_name`."
+  # No @spec on either: both return a compile-time constant, so any spec loose
+  # enough to be worth writing is a supertype of the success typing and dialyzer
+  # rejects it, while a spec tight enough to pass just restates the literal.
+  def metadata_uri_fields, do: @metadata_uri_fields
+
+  def client_name_max_length, do: @client_name_max_length
+
+  @doc """
+  True when an optional metadata URI is one we would actually render.
+
+  Shares `parse_https_uri/1` with `validate_metadata_uris/1` so the rule has one
+  implementation. DCR rejects a bad value (the registrant can fix it and retry);
+  CIMD drops it, because losing a logo must never cost a vendor its connector.
+  """
+  @spec displayable_metadata_uri?(term()) :: boolean()
+  def displayable_metadata_uri?(value), do: parse_https_uri(value) == :ok
+
+  @doc """
   True for the loopback hosts RFC 8252 §7.3 permits over plain `http`.
 
   Shared with `Engram.OAuth.match_redirect_uri/2`, which grants those hosts a
@@ -95,7 +141,7 @@ defmodule Engram.OAuth.Client do
   @spec loopback_host?(String.t() | nil) :: boolean()
   def loopback_host?(host), do: host in @loopback_hosts
 
-  def registration_changeset(client, attrs) do
+  def registration_changeset(client, attrs, opts \\ []) do
     client
     |> cast(attrs, @cast_fields)
     |> coerce_kind()
@@ -103,7 +149,9 @@ defmodule Engram.OAuth.Client do
     |> ensure_redirect_uris_present()
     # Attacker-controlled on a public, unauthenticated endpoint; bound the
     # array size so registration can't be used to store an unbounded blob.
-    |> validate_length(:redirect_uris, max: 10)
+    |> validate_length(:redirect_uris,
+      max: Keyword.get(opts, :max_redirect_uris, @max_redirect_uris_dcr)
+    )
     |> validate_redirect_uris()
     |> validate_subset(:grant_types, @valid_grant_types,
       message: "contains an unsupported grant_type"
@@ -114,7 +162,7 @@ defmodule Engram.OAuth.Client do
     |> validate_inclusion(:token_endpoint_auth_method, @valid_auth_methods,
       message: "must be one of: #{Enum.join(@valid_auth_methods, ", ")}"
     )
-    |> validate_length(:client_name, max: 200)
+    |> validate_length(:client_name, max: @client_name_max_length)
     # Attacker-controlled on a public, unauthenticated endpoint; cap to bound
     # row/metadata size.
     |> validate_length(:software_id, max: 255)
@@ -146,18 +194,21 @@ defmodule Engram.OAuth.Client do
   """
   def cimd_changeset(client, url, document) when is_binary(url) and is_map(document) do
     client
-    |> registration_changeset(%{
-      "redirect_uris" => document["redirect_uris"],
-      "client_name" => document["client_name"],
-      "scope" => document["scope"],
-      "grant_types" => document["grant_types"],
-      "response_types" => document["response_types"],
-      "logo_uri" => document["logo_uri"],
-      "tos_uri" => document["tos_uri"],
-      "policy_uri" => document["policy_uri"],
-      "kind" => "mcp",
-      "token_endpoint_auth_method" => "none"
-    })
+    |> registration_changeset(
+      %{
+        "redirect_uris" => document["redirect_uris"],
+        "client_name" => document["client_name"],
+        "scope" => document["scope"],
+        "grant_types" => document["grant_types"],
+        "response_types" => document["response_types"],
+        "logo_uri" => document["logo_uri"],
+        "tos_uri" => document["tos_uri"],
+        "policy_uri" => document["policy_uri"],
+        "kind" => "mcp",
+        "token_endpoint_auth_method" => "none"
+      },
+      max_redirect_uris: @max_redirect_uris_cimd
+    )
     |> put_change(:cimd_url, url)
     |> put_change(:cimd_fetched_at, DateTime.utc_now())
     |> validate_length(:cimd_url, max: 2048)

--- a/lib/engram_web/controllers/oauth_authorize_controller.ex
+++ b/lib/engram_web/controllers/oauth_authorize_controller.ex
@@ -35,6 +35,9 @@ defmodule EngramWeb.OAuthAuthorizeController do
       {:client_error, code} ->
         render_client_error(conn, code)
 
+      {:server_error, code} ->
+        render_server_error(conn, code)
+
       {:redirect_error, redirect_uri, error, state} ->
         redirect_with_error(conn, redirect_uri, error, state)
     end
@@ -64,6 +67,11 @@ defmodule EngramWeb.OAuthAuthorizeController do
       {:client_error, code} ->
         conn
         |> put_status(400)
+        |> json(%{error: code})
+
+      {:server_error, code} ->
+        conn
+        |> put_status(503)
         |> json(%{error: code})
 
       {:redirect_error, redirect_uri, error, state} ->
@@ -109,6 +117,26 @@ defmodule EngramWeb.OAuthAuthorizeController do
     conn
     |> put_resp_content_type("text/html")
     |> send_resp(400, body)
+  end
+
+  # Deliberately NOT the invalid_client page. That copy tells the user their app
+  # is not recognized, which is a lie when the truth is that we could not reach
+  # or store the client's metadata document — and it is the lie that sent the
+  # 2026-08-04 Claude outage looking for a misconfigured connector. 503 also
+  # tells well-behaved clients to try again, which is the actual remedy.
+  defp render_server_error(conn, code) do
+    body = """
+    <!doctype html>
+    <html><body>
+    <h1>Authorization temporarily unavailable</h1>
+    <p>Error: <code>#{html_escape(code)}</code>.</p>
+    <p>We could not verify this application's metadata just now. This is a problem on our side, not with the app — please try connecting again in a moment.</p>
+    </body></html>
+    """
+
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_resp(503, body)
   end
 
   defp redirect_with_error(conn, redirect_uri, error, state) do

--- a/scripts/mcp-conformance.sh
+++ b/scripts/mcp-conformance.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# MCP OAuth conformance — runs real OAuth handshakes against a deployed Engram
+# authorization server, the same ones Claude Desktop, Claude Code and ChatGPT
+# perform.
+#
+# WHY THIS EXISTS
+#
+# On 2026-08-04 every Claude connect failed with `invalid_client`, and our unit
+# suite was 100% green throughout. The CIMD fixture was three fields long and
+# had been written alongside the validator it was testing, so it could only ever
+# assert that our code accepts what our code expects. This runs somebody else's
+# client against us instead. Against pre-fix main it fails at exactly one step:
+#
+#   FAILED received_authorization_code -- HTTP 400 Bad Request
+#
+# See docs/context/cimd-vs-dcr-validation-policy.md.
+#
+# CONSENT: our authorization endpoint requires a Clerk session, so the flow
+# cannot complete headlessly and everything from `received_authorization_code`
+# onward is expected to fail here. That is fine — every step this suite exists
+# to protect (discovery, PRM/AS metadata, CIMD fetch + document acceptance, the
+# authorization request itself) happens BEFORE consent. Driving consent needs
+# Playwright and belongs in the e2e job, not this one.
+#
+# Usage:
+#   scripts/mcp-conformance.sh                                  # staging
+#   scripts/mcp-conformance.sh https://mcp.engram.page/api/mcp  # explicit target
+set -euo pipefail
+
+# Pinned deliberately. The npm package carries registry signatures but NO build
+# provenance attestation, so the tarball is not cryptographically tied to a
+# commit. `@latest` would let a compromised publish reach CI with network access
+# to our auth server. Bump this line consciously.
+CLI_VERSION="3.18.0"
+
+TARGET_URL="${1:-https://staging.engram.page/api/mcp}"
+OUT_DIR="${CONFORMANCE_OUT_DIR:-./conformance-results}"
+mkdir -p "$OUT_DIR"
+
+# `--no-telemetry`: the CLI ships posthog-node and is opt-out, not opt-in. Their
+# docs say it excludes URLs, tokens and headers, and that reads honest — but CI
+# runs against our production-shaped auth server and does not need to phone
+# anywhere.
+COMMON=(--no-telemetry --auth-mode headless --conformance-checks)
+
+# Both registration paths, because they are genuinely different code in our AS
+# and the CIMD one is newer and less travelled. `cimd` uses MCPJam's own
+# published metadata document, which is the point: it declares a device_code
+# grant we do not implement and lists 14 redirect URIs. Both of those were fatal
+# before the fix, and neither has anything to do with whether MCPJam can safely
+# use us.
+FAILED=0
+
+# PREFLIGHT. This job runs on an isolated self-hosted runner and reaches both
+# npmjs.org and the target through Cloudflare — for staging that is a hairpin
+# back into the same physical host. When either leg is down, the CLI fails at
+# step one and the run looks exactly like "the authorization server is broken".
+# Distinguishing an infrastructure failure from a conformance failure after the
+# fact costs far more than checking first.
+echo "==> preflight"
+if ! curl -fsS --max-time 15 -o /dev/null https://registry.npmjs.org/@mcpjam/cli; then
+  echo "    ENVIRONMENT: cannot reach the npm registry — not a conformance result." >&2
+  exit 2
+fi
+if ! curl -fsS --max-time 15 -o /dev/null "${TARGET_URL%/api/mcp}/.well-known/oauth-authorization-server"; then
+  echo "    ENVIRONMENT: cannot reach $TARGET_URL — not a conformance result." >&2
+  exit 2
+fi
+echo "    npm and $TARGET_URL reachable"
+
+for strategy in dcr cimd; do
+  echo "==> $strategy against $TARGET_URL"
+
+  # The exit code is deliberately NOT the verdict, and `|| true` is load-bearing
+  # rather than sloppy. The CLI exits non-zero unless the WHOLE flow completes,
+  # which it cannot here: our authorization endpoint requires a Clerk session and
+  # nothing headless can sit through that. An earlier revision of this script
+  # branched on the exit code and reported a clean pass against a server we knew
+  # was broken. The classifier below is the only verdict, and it runs every time.
+  npx -y "@mcpjam/cli@${CLI_VERSION}" oauth conformance \
+      --url "$TARGET_URL" \
+      --protocol-version 2025-11-25 \
+      --registration "$strategy" \
+      "${COMMON[@]}" \
+      > "$OUT_DIR/$strategy.json" 2>&1 || true
+
+  python3 - "$OUT_DIR/$strategy.json" "$strategy" <<'PY' || FAILED=1
+import json, sys
+
+path, strategy = sys.argv[1], sys.argv[2]
+try:
+    doc = json.load(open(path))
+except Exception:
+    print(f"    could not parse output for {strategy} — see {path}")
+    sys.exit(1)
+
+# Everything from here on needs a human at a Clerk login form.
+CONSENT_GATED = {
+    "received_authorization_code",
+    "token_request",
+    "received_tokens",
+    "authenticated_mcp_request",
+}
+
+# The step NAME is not enough, and getting this wrong once already cost a green
+# run against a server we knew was broken.
+#
+# `received_authorization_code` fails on a HEALTHY server too — the runner has
+# no way to sit through a Clerk login. But it failed on the BROKEN server as
+# well, for an entirely different reason, and both surface under the same name.
+# The distinguishing signal is the HTTP status our authorization endpoint
+# returned:
+#
+#   302 -> we accepted the client and sent it to consent. Healthy; the runner
+#          simply cannot go further without a human.
+#   400 -> `render_client_error(conn, "invalid_client")`. THE BUG.
+#
+# So a consent-gated step is excused only when the server did not answer 4xx.
+# Anything else is a regression regardless of which step reported it.
+def http_status(step):
+    resp = (step.get("http") or {}).get("response") or {}
+    return resp.get("status")
+
+problems = []
+for step in doc.get("steps", []):
+    if step.get("status") != "failed":
+        continue
+    name = step.get("step")
+    status = http_status(step)
+    msg = (step.get("error") or {}).get("message", "")
+    if name not in CONSENT_GATED:
+        problems.append((name, status, msg))
+    elif status is not None and status >= 400:
+        problems.append((name, status, msg))
+
+if problems:
+    print(f"    REGRESSION — {strategy}:")
+    for name, status, msg in problems:
+        print(f"      {name} [HTTP {status}]: {msg[:150]}")
+    sys.exit(1)
+
+reached = {s["step"] for s in doc.get("steps", []) if s.get("status") == "passed"}
+print(f"    reached the consent gate cleanly ({len(reached)} steps passed)")
+sys.exit(0)
+PY
+done
+
+exit "$FAILED"

--- a/test/engram/oauth/cimd_test.exs
+++ b/test/engram/oauth/cimd_test.exs
@@ -24,6 +24,16 @@ defmodule Engram.OAuth.CimdTest do
 
   @url "https://claude.ai/.well-known/oauth-client"
 
+  defp authorize(url) do
+    Engram.OAuth.validate_authorization_request(%{
+      "client_id" => url,
+      "redirect_uri" => "http://127.0.0.1:9999/callback",
+      "response_type" => "code",
+      "code_challenge" => "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      "code_challenge_method" => "S256"
+    })
+  end
+
   defp document(overrides \\ %{}) do
     Map.merge(
       %{
@@ -95,6 +105,24 @@ defmodule Engram.OAuth.CimdTest do
       end
     end
 
+    # MCP 2025-11-25 lists client_id, client_name and redirect_uris as the three
+    # properties a metadata document MUST carry. We enforced two.
+    #
+    # Refusing here rather than negotiating is a deliberate line: an unknown
+    # grant_type costs nothing to ignore, but a nameless client cannot be
+    # rendered on the consent screen, and "Authorize this app" is a worse
+    # outcome for the user than a legible refusal.
+    test "rejects a document with no usable client_name" do
+      for name <- [nil, "", "   ", 42] do
+        expect(FetcherMock, :fetch, fn @url -> {:ok, document(%{"client_name" => name})} end)
+
+        assert {:error, :missing_client_name} = Cimd.ensure_client(@url),
+               "expected #{inspect(name)} to be refused"
+      end
+
+      assert Repo.aggregate(Client, :count) == 0
+    end
+
     # A CIMD client never registered, so no secret was ever minted for it.
     # Honouring the request would leave it unable to authenticate (nil hash);
     # silently downgrading would make it send a secret we must then reject for
@@ -120,12 +148,261 @@ defmodule Engram.OAuth.CimdTest do
     # The document goes through the same redirect-URI validation as a DCR body:
     # a CIMD-specific validation path would be a second copy of those rules, free
     # to drift from the ones PR #1147 hardened.
+    #
+    # Safety rules stay shared. What must NOT be shared is DCR's *registration
+    # policy* — see the "negotiated, not enforced" tests below.
     test "applies DCR redirect-URI validation to the document" do
       expect(FetcherMock, :fetch, fn @url ->
         {:ok, document(%{"redirect_uris" => ["javascript:alert(1)"]})}
       end)
 
-      assert {:error, :invalid_document} = Cimd.ensure_client(@url)
+      assert {:error, {:invalid_document, _errors}} = Cimd.ensure_client(@url)
+    end
+  end
+
+  # A published CIMD document describes what its vendor's client can do, against
+  # every authorization server in the world. It is not a registration request
+  # asking our permission. RFC 7591 §3.2.1 has the AS record what it supports and
+  # report back what it granted; the CIMD draft asks for structural validation
+  # plus the self-referential binding. Neither licenses "reject the client because
+  # it also declares a grant you don't implement".
+  #
+  # Regression for the 2026-08-04 prod incident: Claude connect died on
+  # `invalid_client` because DCR's registration policy was being applied to a
+  # fetched vendor document.
+  # WHY THIS EXISTS, and why it is verbatim.
+  #
+  # `document/1` above is a three-key fixture — client_id, client_name,
+  # redirect_uris. Those happen to be exactly the three fields
+  # `registration_changeset/2` was never going to reject, so every CIMD test
+  # written against it passed no matter how strict the changeset became. The
+  # subset allowlists, the size caps and the https-only rules all sat on fields
+  # no test ever populated. The fixture was named after a real client and shaped
+  # like our own validator, which is how #1167 shipped green and took out every
+  # Claude connect on contact with a real one.
+  #
+  # So this one is copied byte-for-byte from what claude.ai actually serves, and
+  # it is the shape of the regression test this class needs: not "does our
+  # validator accept what our validator expects", but "does it accept what is
+  # actually on the wire". If Anthropic changes the document and this starts
+  # failing, that is the test doing its job — re-fetch it, don't edit it to fit.
+  describe "the real published Claude Code document" do
+    # curl https://claude.ai/oauth/claude-code-client-metadata  (2026-08-04)
+    @claude_code_url "https://claude.ai/oauth/claude-code-client-metadata"
+    @claude_code_document %{
+      "client_id" => "https://claude.ai/oauth/claude-code-client-metadata",
+      "client_name" => "Claude Code",
+      "client_uri" => "https://claude.ai",
+      "redirect_uris" => ["http://localhost/callback", "http://127.0.0.1/callback"],
+      "grant_types" => ["authorization_code", "refresh_token"],
+      "response_types" => ["code"],
+      "token_endpoint_auth_method" => "none"
+    }
+
+    test "is accepted as published" do
+      expect(FetcherMock, :fetch, fn @claude_code_url -> {:ok, @claude_code_document} end)
+
+      assert {:ok, client} = Cimd.ensure_client(@claude_code_url)
+      assert client.client_name == "Claude Code"
+      assert client.token_endpoint_auth_method == "none"
+    end
+
+    # The document declares its loopback redirects WITHOUT a port; the client
+    # binds an ephemeral one at runtime (RFC 8252 §7.3). If the port exemption
+    # ever regressed, CIMD clients would authorize once and fail forever after,
+    # which no unit test of `match_redirect_uri/2` alone would surface.
+    test "authorizes against the ephemeral port it actually binds" do
+      expect(FetcherMock, :fetch, fn @claude_code_url -> {:ok, @claude_code_document} end)
+
+      assert {:ok, validated} =
+               Engram.OAuth.validate_authorization_request(%{
+                 "client_id" => @claude_code_url,
+                 "redirect_uri" => "http://localhost:3118/callback",
+                 "response_type" => "code",
+                 "code_challenge" => "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                 "code_challenge_method" => "S256"
+               })
+
+      assert validated.redirect_uri == "http://localhost:3118/callback"
+    end
+  end
+
+  # The second external fixture, and the one that actually reproduces the
+  # incident. MCPJam is a widely-used MCP inspector; this is its real published
+  # document, and against the pre-fix code it failed TWICE over:
+  #
+  #   grant_types:   "contains an unsupported grant_type"  (device_code)
+  #   redirect_uris: "should have at most 10 item(s)"      (it lists 14)
+  #
+  # Neither has anything to do with whether MCPJam can safely use us. The first
+  # is a grant we don't implement and it never asked us to; the second is a tool
+  # supporting three ports and two hosted environments. Both were fatal.
+  #
+  # Keep this fixture verbatim too. Its value is precisely that nobody here
+  # chose its contents.
+  describe "the real published MCPJam document" do
+    @mcpjam_url "https://www.mcpjam.com/.well-known/oauth/client-metadata.json"
+    @mcpjam_document %{
+      "client_id" => "https://www.mcpjam.com/.well-known/oauth/client-metadata.json",
+      "client_name" => "MCPJam",
+      "client_uri" => "https://www.mcpjam.com",
+      "logo_uri" => "https://www.mcpjam.com/mcp_jam_2row.png",
+      "redirect_uris" => [
+        "http://127.0.0.1:6274/oauth/callback",
+        "http://127.0.0.1:6274/callback",
+        "http://127.0.0.1:6274/oauth/callback/debug",
+        "http://localhost:6274/oauth/callback",
+        "http://localhost:6274/callback",
+        "http://localhost:6274/oauth/callback/debug",
+        "http://127.0.0.1:5173/oauth/callback",
+        "http://127.0.0.1:5173/oauth/callback/debug",
+        "http://localhost:5173/oauth/callback",
+        "http://localhost:5173/oauth/callback/debug",
+        "https://app.mcpjam.com/oauth/callback",
+        "https://app.mcpjam.com/oauth/callback/debug",
+        "https://staging.mcpjam.com/oauth/callback",
+        "https://staging.mcpjam.com/oauth/callback/debug"
+      ],
+      "grant_types" => [
+        "authorization_code",
+        "refresh_token",
+        "urn:ietf:params:oauth:grant-type:device_code"
+      ],
+      "response_types" => ["code"],
+      "token_endpoint_auth_method" => "none",
+      "application_type" => "native"
+    }
+
+    test "is accepted, keeping the grants we implement and all 14 redirects" do
+      expect(FetcherMock, :fetch, fn @mcpjam_url -> {:ok, @mcpjam_document} end)
+
+      assert {:ok, client} = Cimd.ensure_client(@mcpjam_url)
+      assert client.grant_types == ["authorization_code", "refresh_token"]
+      assert length(client.redirect_uris) == 14
+      assert client.logo_uri == "https://www.mcpjam.com/mcp_jam_2row.png"
+    end
+
+    test "authorizes on one of the redirects it published" do
+      expect(FetcherMock, :fetch, fn @mcpjam_url -> {:ok, @mcpjam_document} end)
+
+      assert {:ok, validated} =
+               Engram.OAuth.validate_authorization_request(%{
+                 "client_id" => @mcpjam_url,
+                 "redirect_uri" => "https://app.mcpjam.com/oauth/callback",
+                 "response_type" => "code",
+                 "code_challenge" => "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                 "code_challenge_method" => "S256"
+               })
+
+      assert validated.redirect_uri == "https://app.mcpjam.com/oauth/callback"
+    end
+  end
+
+  # DCR's tighter cap is unchanged: an anonymous POST is a different threat from
+  # a fetched, size-capped vendor document.
+  describe "the DCR redirect cap is untouched by the CIMD one" do
+    test "an 11-entry DCR registration is still refused" do
+      uris = for i <- 1..11, do: "https://dcr.example/cb#{i}"
+
+      changeset =
+        Client.registration_changeset(%Client{}, %{
+          "client_name" => "Greedy",
+          "redirect_uris" => uris
+        })
+
+      refute changeset.valid?
+      assert Keyword.has_key?(changeset.errors, :redirect_uris)
+    end
+  end
+
+  describe "ensure_client/1 capability metadata is negotiated, not enforced" do
+    test "keeps only the grant types we implement, rather than refusing the client" do
+      expect(FetcherMock, :fetch, fn @url ->
+        {:ok,
+         document(%{
+           "grant_types" => [
+             "authorization_code",
+             "refresh_token",
+             "urn:ietf:params:oauth:grant-type:token-exchange"
+           ]
+         })}
+      end)
+
+      assert {:ok, client} = Cimd.ensure_client(@url)
+      assert client.grant_types == ["authorization_code", "refresh_token"]
+    end
+
+    test "keeps only the response types we implement" do
+      expect(FetcherMock, :fetch, fn @url ->
+        {:ok, document(%{"response_types" => ["code", "code id_token", "token"]})}
+      end)
+
+      assert {:ok, client} = Cimd.ensure_client(@url)
+      assert client.response_types == ["code"]
+    end
+
+    # Intersecting to nothing is different: there is no flow left to run, so the
+    # refusal is about us, not about tidiness.
+    test "refuses a document with no grant type in common with us" do
+      expect(FetcherMock, :fetch, fn @url ->
+        {:ok, document(%{"grant_types" => ["client_credentials"]})}
+      end)
+
+      assert {:error, :no_supported_grant_type} = Cimd.ensure_client(@url)
+    end
+
+    test "refuses a document with no response type in common with us" do
+      expect(FetcherMock, :fetch, fn @url ->
+        {:ok, document(%{"response_types" => ["token"]})}
+      end)
+
+      assert {:error, :no_supported_response_type} = Cimd.ensure_client(@url)
+    end
+
+    # Decorative metadata must never cost a client its authorization. Dropping the
+    # field loses a logo; refusing the document loses the connector.
+    test "drops metadata URIs we will not display instead of refusing the client" do
+      expect(FetcherMock, :fetch, fn @url ->
+        {:ok,
+         document(%{
+           "logo_uri" => "http://claude.ai/logo.png",
+           "tos_uri" => "not a uri at all",
+           "policy_uri" => "https://claude.ai/policy"
+         })}
+      end)
+
+      assert {:ok, client} = Cimd.ensure_client(@url)
+      assert is_nil(client.logo_uri)
+      assert is_nil(client.tos_uri)
+      assert client.policy_uri == "https://claude.ai/policy"
+    end
+
+    test "truncates an over-long client_name instead of refusing the client" do
+      long = String.duplicate("a", 500)
+      expect(FetcherMock, :fetch, fn @url -> {:ok, document(%{"client_name" => long})} end)
+
+      assert {:ok, client} = Cimd.ensure_client(@url)
+      assert byte_size(client.client_name) == 200
+    end
+
+    test "an absent grant_types/response_types still gets our defaults" do
+      expect(FetcherMock, :fetch, fn @url -> {:ok, document()} end)
+
+      assert {:ok, client} = Cimd.ensure_client(@url)
+      assert client.grant_types == ["authorization_code", "refresh_token"]
+      assert client.response_types == ["code"]
+    end
+
+    # The rejection reason is the tripwire's whole value. `:invalid_document` on
+    # its own could not tell us WHICH field a vendor's document died on, which is
+    # what left the 2026-08-04 incident undiagnosable from logs.
+    test "a genuine changeset refusal carries the offending fields" do
+      expect(FetcherMock, :fetch, fn @url ->
+        {:ok, document(%{"redirect_uris" => ["javascript:alert(1)"]})}
+      end)
+
+      assert {:error, {:invalid_document, errors}} = Cimd.ensure_client(@url)
+      assert Keyword.has_key?(errors, :redirect_uris)
     end
 
     test "propagates a transport error without storing anything" do
@@ -273,6 +550,54 @@ defmodule Engram.OAuth.CimdTest do
       # No expectation set: a fetch here would fail verify_on_exit!.
       assert {:error, :not_found} = Cimd.get_by_url(@url)
       assert {:error, :not_found} = Cimd.get_by_url(nil)
+    end
+  end
+
+  # `invalid_client` is terminal — the client gives up and the user is told their
+  # app is not recognized. Reserving it for failures that really are the client's
+  # is what keeps a transient outage on our side from looking like a permanently
+  # broken connector, which is exactly how the 2026-08-04 incident presented.
+  describe "how a CIMD failure is reported to the authorization endpoint" do
+    test "a transport failure is retryable, not the client's fault" do
+      expect(FetcherMock, :fetch, fn @url -> {:error, :fetch_failed} end)
+      assert {:server_error, "temporarily_unavailable"} = authorize(@url)
+    end
+
+    test "the vendor being down or throttling us is retryable" do
+      for status <- [429, 500, 503] do
+        expect(FetcherMock, :fetch, fn @url -> {:error, {:http_status, status}} end)
+
+        assert {:server_error, "temporarily_unavailable"} = authorize(@url),
+               "expected HTTP #{status} to be reported as transient"
+      end
+    end
+
+    # Our own limiter refusing the fetch must never be dressed up as the vendor's
+    # fault: it is silent by design, so `invalid_client` here produced pages of
+    # user-visible failure with no matching log line at all.
+    # Coupled to Cimd's @per_host_limit (10/min, same host). If that constant
+    # moves, raise the loop bound rather than deleting the test — the behaviour
+    # it pins is "our limiter is not the vendor's fault", not the number.
+    test "our own fetch rate limiter is retryable" do
+      stub(FetcherMock, :fetch, fn url -> {:ok, %{document() | "client_id" => url}} end)
+
+      for i <- 1..11, do: authorize("https://claude.ai/limiter-probe-#{i}")
+
+      assert {:server_error, "temporarily_unavailable"} =
+               authorize("https://claude.ai/limiter-probe-over")
+    end
+
+    test "a document we cannot bind or parse really is the client's fault" do
+      expect(FetcherMock, :fetch, fn @url ->
+        {:ok, document(%{"client_id" => "https://claude.ai/someone-else"})}
+      end)
+
+      assert {:client_error, "invalid_client"} = authorize(@url)
+    end
+
+    test "a 404 on the document URL really is the client's fault" do
+      expect(FetcherMock, :fetch, fn @url -> {:error, {:http_status, 404}} end)
+      assert {:client_error, "invalid_client"} = authorize(@url)
     end
   end
 


### PR DESCRIPTION
Every Claude connect has failed with `invalid_client` since 2026-08-01.

Nothing in the DCR path broke — **Claude stopped using DCR.** #1167 advertised
`client_id_metadata_document_supported: true`, and Anthropic's clients select CIMD the
moment an AS advertises that plus `none` in `token_endpoint_auth_methods_supported`. A
one-word change to a `/.well-known/` document repointed every client at a path that had
never carried real traffic.

## Root cause

`Cimd.store/3` validated a fetched vendor document with `Client.registration_changeset/2`
— DCR **registration policy**. Two different questions sharing one answer:

| | DCR (`POST /oauth/register`) | CIMD (fetched document) |
|---|---|---|
| Who is speaking | an anonymous stranger asking permission | a vendor describing itself to every AS on the internet |
| Unknown `grant_types` | reject | **intersect** — they weren't asking us |
| Bad `logo_uri` | reject | **drop the field** |
| Over-long `client_name` | reject | **truncate** |
| Unsafe `redirect_uri` | reject | **reject** — code-leak vector, not a capability |

RFC 7591 §3.2.1 has the AS record what *it* supports and report back what it granted.
`negotiate/1` now intersects capability metadata before the changeset; safety rules stay
shared and still refuse.

## Proof

MCPJam's **real published** document declares `urn:ietf:params:oauth:grant-type:device_code`
and lists 14 redirect URIs. Against pre-fix code it fails twice over:

```
grant_types:   "contains an unsupported grant_type"
redirect_uris: "should have at most 10 item(s)"
```

Both are now fixtures. And the MCPJam OAuth conformance CLI, run against staging (still on
pre-fix `main`), reproduces the outage end-to-end:

```
==> dcr  reached the consent gate cleanly (10 steps passed)
==> cimd REGRESSION: received_authorization_code [HTTP 400]
```

DCR green, CIMD red — independent confirmation that DCR was never the broken part.

## Also in here

- **Diagnosability.** `:invalid_document` collapsed a changeset refusal and a lost insert
  race and discarded the errors. Now `{:invalid_document, errors}` vs `:store_conflict`,
  logged as `fields=[...]` — names only, never messages (several interpolate the
  attacker-supplied URI).
- **Transient vs terminal.** Every CIMD failure reported `invalid_client`, which is
  terminal. Worse, `:rate_limited` is deliberately never logged, so after the first store
  failed every retry re-entered discovery and burned the per-host bucket silently: one log
  line, many failures. Transient reasons now yield `temporarily_unavailable` + 503.
- **Per-path redirect caps** — 10 for DCR, 50 for CIMD.
- `scripts/mcp-conformance.sh` + a daily `mcp-conformance` job in `cron.yml`.
- `docs/context/cimd-vs-dcr-validation-policy.md`.

## Why the suite didn't catch it

The CIMD fixture was three fields long and authored alongside the validator it tested, so
it could only assert that our code accepts what our code expects. Every strict rule sat on
fields no test populated. Both new fixtures are copied verbatim from the wire.

## Reviewer notes

- The Claude Code fixture is a **canary, not a repro** — it passes pre-fix too.
- Full-flow conformance stops at consent (needs a Clerk session). Everything this protects
  happens before that, so it is still a real signal.
- `mcp-conformance` lives in `cron.yml`, not `verify.yml`: it grades a deployment, and on a
  PR the deployment still runs `main`.

Refs #1167