### PR TITLE
feat(health): report the build sha so a deploy is observable over HTTP

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4448,6 +4448,12 @@ jobs:
           build-args: |
             VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
             VITE_GIT_SHA=${{ github.sha }}
+            # Backend counterpart to VITE_GIT_SHA. Baked into the image so
+            # /api/health can report what code is actually running: `version`
+            # reads mix.exs, which release-please keeps sticky between cuts,
+            # so it never moves on a non-release deploy. Same full 40-char
+            # SHA the frontend and Sentry use, so all three agree.
+            RELEASE_SHA=${{ github.sha }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}
             SENTRY_PROJECT=${{ vars.SENTRY_PROJECT_FRONTEND }}
             HEX_MIRROR=${{ env.HEX_MIRROR }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,6 +169,22 @@ EXPOSE 4000
 
 ENV PHX_SERVER=true
 
+# The commit this image was built from, baked in at build time so the image
+# knows what it is in EVERY environment. Previously RELEASE_SHA was injected
+# per-environment from Terraform (`var.engram_release_sha`), which prod set
+# and staging-fastraid did not — so there was no way to tell what code
+# staging was running short of `docker inspect` on the host. That blind spot
+# is how a broken staging deploy chain went unnoticed for weeks: /api/health
+# reports Application.spec(:engram, :vsn), which release-please keeps sticky
+# between cuts, so it cannot change on a non-release deploy.
+#
+# Baking it here also removes the lockstep requirement between the image and
+# a TF variable — the value can no longer drift from the bytes it describes.
+# Empty default keeps local `docker build` and self-host builds working; the
+# health endpoint and Sentry both treat "" as unset.
+ARG RELEASE_SHA=""
+ENV RELEASE_SHA=${RELEASE_SHA}
+
 # T3.0.3 — refuse to write erl_crash.dump on BEAM crash. The dump would
 # include plaintext DEKs (ETS) + master key (LocalKeyProvider state) from
 # process heap. Unraid templates also set this; this line is the defense-

--- a/docs/context/ci-fingerprint-markers.md
+++ b/docs/context/ci-fingerprint-markers.md
@@ -1,0 +1,116 @@
+# CI fingerprint markers — how job skipping stays honest
+
+How `verify.yml` decides a job can skip, and the one invariant that makes it
+safe. Read this before adding a "fast mode" to any fingerprinted job, or
+before widening a cache restore-key.
+
+Companion to [ci-pipeline-gating.md](ci-pipeline-gating.md) (what gates vs
+reports) and [ci-mix-compile-cache-runner-path.md](ci-mix-compile-cache-runner-path.md).
+
+## The mechanism
+
+`ci/fingerprint/groups.sh` defines **content groups** (`elixir-src`,
+`unit-tests`, `priv`, `docker-image`, `lint-config`, `e2e-harness`,
+`frontend`, `ci-meta`). Each group hashes `git ls-tree -r HEAD -- <paths>`,
+which emits blob SHAs — so the hash is pure tracked-content, stable across
+rebases and squashes.
+
+`ci/fingerprint/compute.sh` maps each job to a **superset** of groups and
+hashes them together into one `job_hash`. When a job passes, it pushes an
+empty image tagged `ci-<job>:<hash>` to the FastRaid registry
+(`ci/fingerprint/record.sh`). A later run that computes the same hash finds
+the marker and skips the job.
+
+The store is the **FastRaid Docker registry, not `actions/cache`** — chosen
+deliberately, because `actions/cache` scopes entries to the writing ref, so a
+PR's marker would be invisible to the `main` push that squash-merges it. The
+registry is ref-agnostic: a squash-merge preserves the tree, so main computes
+the same hash and replays the branch's proof.
+
+## THE INVARIANT
+
+> A marker means **this job ran to FULL success for this exact content.**
+
+Everything else follows from it. Two ways to break it:
+
+**1. Under-hashing.** If a job reads a file that is in none of its groups, a
+stale marker skips the check that file was supposed to trigger. Config files
+are the dangerous case because they fail **open** — a loosened rule rides in
+silently and permanently.
+
+Two such gaps were live until 2026-08-05: `openapi.json` (the OpenAPI drift
+gate) and `.squawk.toml` (squawk's cwd-discovered config), both read by
+`unit-tests`, both in no group. `groups_test.sh` now carries a static
+input-coverage assertion — add a pair there whenever a job step starts reading
+a new path.
+
+**2. Reduced modes.** If a job can pass while doing *less* work, its marker
+lies. `record-job-markers` therefore refuses to seed when
+`e2e-target-suite` is set (a `pytest -k` subset must never seed a full-hash
+e2e marker), and `mix test --stale` was **removed** for the same reason.
+
+If you add a fast path to a fingerprinted job, you must either exclude that
+run from marker seeding, or fold the mode into the hash.
+
+## Why `--stale` was removed (2026-08-05)
+
+It never narrowed anything. Measured: 4081 tests under `--stale` vs 4081 on
+main for the identical tree.
+
+Root cause was not ExUnit — the `_build` cache key stopped at the mix.lock
+hash, and `actions/cache` does not re-save on an exact hit. So `_build` was
+written once, on the first run after the lockfile moved, then frozen.
+mix.lock had not changed in 114 commits, so every run restored a
+114-commit-stale tree; with `use`-macro fan-out (Phoenix/Ecto) that
+recompiled ~all 355 lib files, making every test a stale compile-dependent.
+
+Fixed by putting the commit SHA in the `_build` key so every run saves a
+fresh build, with a **lockfile-scoped** restore-key prefix for fallback.
+
+> Do NOT widen that prefix to beam-only. A restore across a mix.lock change
+> reuses a `_build` compiled against different deps and crashes protocol
+> consolidation (`FunctionClauseError` in `:elixir_erl.dynamic_form/1`). The
+> lockfile hash in the prefix is what prevents it.
+
+Also verified and rejected: normalizing source mtimes in the consumers.
+`prebuild-mix` has such a step and it is **vestigial** — on Elixir 1.17,
+touching every source to `now` recompiles 0 files, because the compiler
+compares content digests and only uses mtime to pick what to re-hash. Adding
+it (plus the `fetch-depth: 0` it needs) is pure cost.
+
+## main is not special any more
+
+`is-full` used to include `refs/heads/main`, pinning every `skip-<job>` to
+false. That defeated the ref-agnostic marker store on the exact push it was
+built for: ~61 main pushes/week re-deriving what the branch had proved.
+
+Now `is-full` means only the nightly schedule, `[ci-full]`, and
+`force_full`. main runs anything whose hash **missed** — that is the real
+safety net. Measured effect on a main push: **28 → 5 runner-minutes.**
+
+Two things still key on main explicitly, not via `is-full`:
+
+- **Targeted-e2e suppression** (`IS_MAIN`), so a squash-merge whose body still
+  carries the branch's `[e2e: ...]` tag cannot narrow main's e2e matrix.
+- **`build-and-publish-image`**, which is about deployable bytes, not tests.
+
+## What content hashing cannot model
+
+`mix_audit` is time-dependent: the same `mix.lock` yields a different verdict
+once a new CVE is published. No content hash can express that. The 06:00 UTC
+nightly is a genuine full run and bounds the exposure at 24h. This is an
+accepted limit, documented inline at the `lint` job — do not "fix" it by
+disabling lint skipping.
+
+## Gotchas
+
+- `ci-meta` (`.github/workflows/verify.yml` + `ci/fingerprint`) is in **every**
+  job's group list, so any CI change busts every hash and forces a full run.
+  A PR editing `verify.yml` therefore validates itself — and its markers seed
+  the merge, which is why main can skip immediately after such a PR lands.
+- `record()` seeds only on `result == "success"`. A **skipped** job reports
+  `skipped`, not `success`, so it cannot re-seed a marker it did not earn.
+- `migration-gates` is deliberately never marker-skipped: it has early `exit 0`
+  success paths that return green without running the rollforward.
+- Marker hashes come from the fingerprint job via `MARKER_HASH`, never
+  recomputed on the recording runner (which may not have BEAM on PATH).

--- a/docs/context/ci-pipeline-gating.md
+++ b/docs/context/ci-pipeline-gating.md
@@ -19,7 +19,17 @@ merge gate is now the **deterministic** layer:
   barriers, no Obsidian) — currently report-only, baking toward required.
 
 Flaky is no longer blocking, but flaky is still **visible** and still hard-gates
-`main`, the nightly run, and every release.
+the nightly run and every release.
+
+> **Updated 2026-08-05 (#1244).** "Hard-gates `main`" used to mean main
+> re-executed every suite from scratch. It no longer does: main replays the
+> branch's proof via the content-addressed marker store when the tree hash
+> matches, and only executes what **missed**. The proof is the same proof —
+> same content, same full run — it just is not repeated. The genuine
+> re-execution before ship is the release gate below, which dispatches with
+> `force_full=true` against the tagged commit. See
+> [ci-fingerprint-markers.md](ci-fingerprint-markers.md) for the invariant
+> that makes replaying safe.
 
 ## Triggers
 
@@ -129,12 +139,17 @@ fine — that control comparison is what isolates it.
 
 | Check | PR | main (post-merge) | nightly | release (`release-v*`) |
 |---|---|---|---|---|
-| Deterministic (unit/lint/migration/…) | 🔒 gate | 🔒 gate | runs | 🔒 gate |
-| Real-Obsidian e2e | 👁 report | 🔒 gate | 🔒 gate + logged | 🔒 **blocks deploy** |
+| Deterministic (unit/lint/migration/…) | 🔒 gate | 🔒 gate ♻️ | runs | 🔒 gate |
+| Real-Obsidian e2e | 👁 report | 🔒 gate ♻️ | 🔒 gate + logged | 🔒 **blocks deploy** |
 | `headless-protocol` | 👁 report | 👁 report | 👁 logged | — |
 | Flake ledger | — | — | ✍️ writes | — |
 
-🔒 blocks · 👁 runs but informational · ✍️ measures
+🔒 blocks · 👁 runs but informational · ✍️ measures · ♻️ replays the branch's
+proof when the content hash matches, executes on a miss
+
+Only the nightly and the release gate are guaranteed **re-executions**. main is
+a content-equality check, not a re-run — which is the point, since re-deriving a
+result the branch already established cost ~1039 runner-min/week.
 
 ## The release gate (deploy-prod.yml)
 

--- a/lib/engram_web/controllers/health_controller.ex
+++ b/lib/engram_web/controllers/health_controller.ex
@@ -17,7 +17,28 @@ defmodule EngramWeb.HealthController do
   )
 
   def index(conn, _params) do
-    json(conn, %{status: "ok", version: Application.spec(:engram, :vsn) |> to_string()})
+    json(conn, %{
+      status: "ok",
+      version: Application.spec(:engram, :vsn) |> to_string(),
+      build_sha: build_sha()
+    })
+  end
+
+  # `version` reads mix.exs, which release-please keeps STICKY between release
+  # cuts — so it does NOT change on a non-release deploy and cannot answer
+  # "did my merge actually ship?". That blind spot is how a broken staging
+  # deploy chain went unnoticed for weeks. build_sha is baked into the image
+  # at build time (Dockerfile `ARG RELEASE_SHA`), so it always describes the
+  # bytes actually running, in every environment.
+  #
+  # Blank coerces to nil to mirror config/runtime.exs's Sentry `release`
+  # handling: an empty env var means "not configured" (local build, self-host),
+  # not a real empty identifier.
+  defp build_sha do
+    case System.get_env("RELEASE_SHA") do
+      v when is_binary(v) and v != "" -> v
+      _ -> nil
+    end
   end
 
   operation(:deep,

--- a/lib/engram_web/schemas.ex
+++ b/lib/engram_web/schemas.ex
@@ -17,7 +17,19 @@ defmodule EngramWeb.Schemas do
       type: :object,
       properties: %{
         status: %Schema{type: :string, example: "ok", description: "ok | degraded"},
-        version: %Schema{type: :string, example: "0.5.464", description: "Running app version"},
+        version: %Schema{
+          type: :string,
+          example: "0.5.464",
+          description:
+            "Running app version from mix.exs. Sticky between release-please cuts, so it does NOT change on a non-release deploy — use build_sha to tell what code is actually running."
+        },
+        build_sha: %Schema{
+          type: :string,
+          nullable: true,
+          example: "e998801f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d",
+          description:
+            "Commit the running image was built from, baked in at build time. null on local/self-host builds where it was not supplied."
+        },
         checks: %Schema{
           type: :object,
           description: "Per-dependency status map (present on /deep only)",
@@ -25,7 +37,7 @@ defmodule EngramWeb.Schemas do
         }
       },
       required: [:status],
-      example: %{"status" => "ok", "version" => "0.5.464"}
+      example: %{"status" => "ok", "version" => "0.5.464", "build_sha" => "e998801"}
     })
   end
 end

--- a/openapi.json
+++ b/openapi.json
@@ -2520,10 +2520,19 @@
       "HealthStatus": {
         "description": "Service health status.",
         "example": {
+          "build_sha": "e998801",
           "status": "ok",
           "version": "0.5.464"
         },
         "properties": {
+          "build_sha": {
+            "description": "Commit the running image was built from, baked in at build time. null on local/self-host builds where it was not supplied.",
+            "example": "e998801f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
           "checks": {
             "additionalProperties": {
               "type": "string",
@@ -2543,7 +2552,7 @@
             "x-validate": null
           },
           "version": {
-            "description": "Running app version",
+            "description": "Running app version from mix.exs. Sticky between release-please cuts, so it does NOT change on a non-release deploy — use build_sha to tell what code is actually running.",
             "example": "0.5.464",
             "type": "string",
             "x-struct": null,

--- a/test/engram_web/controllers/health_controller_test.exs
+++ b/test/engram_web/controllers/health_controller_test.exs
@@ -19,6 +19,51 @@ defmodule EngramWeb.HealthControllerTest do
     assert is_binary(body["version"])
   end
 
+  describe "GET /health build_sha" do
+    # `version` comes from mix.exs, which release-please keeps STICKY between
+    # cuts — so it cannot change on a non-release deploy and is useless as a
+    # "did my merge ship?" probe. build_sha is baked into the image at build
+    # time (Dockerfile ARG RELEASE_SHA) precisely so that question is
+    # answerable over HTTP instead of `docker inspect` on the host.
+    setup do
+      original = System.get_env("RELEASE_SHA")
+
+      on_exit(fn ->
+        if original,
+          do: System.put_env("RELEASE_SHA", original),
+          else: System.delete_env("RELEASE_SHA")
+      end)
+
+      :ok
+    end
+
+    test "reports the baked build sha when set", %{conn: conn} do
+      System.put_env("RELEASE_SHA", "e998801abc")
+
+      body = conn |> get("/api/health") |> json_response(200)
+
+      assert body["build_sha"] == "e998801abc"
+    end
+
+    test "is nil when unset, so a local or self-host build reads as unknown", %{conn: conn} do
+      System.delete_env("RELEASE_SHA")
+
+      body = conn |> get("/api/health") |> json_response(200)
+
+      assert body["build_sha"] == nil
+    end
+
+    test "treats an empty value as unset rather than reporting an empty sha", %{conn: conn} do
+      # Mirrors the Sentry `release` coercion in config/runtime.exs: a blank
+      # env var is "not configured", not a real (empty) release identifier.
+      System.put_env("RELEASE_SHA", "")
+
+      body = conn |> get("/api/health") |> json_response(200)
+
+      assert body["build_sha"] == nil
+    end
+  end
+
   describe "GET /health/deep (ALB readiness — Postgres only)" do
     test "returns 200 with postgres ok when DB is running", %{conn: conn} do
       conn = get(conn, "/api/health/deep")


### PR DESCRIPTION
`/api/health` returned `version` from `mix.exs`, which release-please keeps **sticky** between release cuts — so it doesn't change on a non-release deploy and **cannot answer "did my merge actually ship?"**.

That blind spot is why the broken staging deploy chain went unnoticed for weeks: the only way to tell what staging was running was `docker inspect` on the host.

```
GET /api/health
{"status":"ok","version":"0.13.0","build_sha":"e998801f2a3b..."}
```

## Why baked into the image, not a Terraform variable

`RELEASE_SHA` was *already* wired for prod via `var.engram_release_sha` — but staging-fastraid never set it, which is exactly the environment that needed it. Adding it per-environment would have repeated that failure mode.

Baking it via a Dockerfile `ARG` means:
- the image knows what it is in **every** environment, including self-host
- no lockstep where a TF variable can drift from the bytes it describes

Uses the same full 40-char SHA the frontend already receives through `VITE_GIT_SHA`, so app / frontend / Sentry all agree on one string.

Blank coerces to `nil`, mirroring the Sentry `release` handling in `config/runtime.exs`: unset means "not configured" (local build, self-host), not a real empty identifier.

## Also in this PR — the docs commit

New `docs/context/ci-fingerprint-markers.md` records the invariant the whole skip system rests on: **a marker means the job ran to FULL success for that exact content.** Both ways to break it have already happened — under-hashing (`openapi.json`, `.squawk.toml` sat outside every group, and config files fail *open*) and reduced modes (`mix test --stale`, targeted e2e).

It also corrects `ci-pipeline-gating.md`, which #1244 made wrong: it claimed real-Obsidian e2e "hard-gates main". main now **replays** the branch's proof when the hash matches and executes only on a miss. Same proof, not repeated — only the nightly and the release gate are guaranteed re-executions.

## Verification

- `mix format` ✓ · `mix credo --strict` (24 mods/funs, no issues) ✓ · `sobelow` ✓ · 15 tests / 0 failures ✓
- `openapi.json` regenerated — the schema change would otherwise red the OpenAPI drift gate
- Honest note on TDD: of the 3 new tests, only **one** goes red without the implementation. The other two assert `build_sha == nil`, which is trivially true when the key is absent — they're guards against returning `""`, not red-first tests.

Refs #1218