### PR TITLE
chore(deps): bump actions/setup-node from v4 to v7 in cron.yml

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -574,7 +574,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '20'
 


### PR DESCRIPTION
Recreates the bump from Dependabot #1249, which **I closed by mistake**. Dependabot deletes its branch on close, so the PR couldn't be reopened, and `github-actions` updates only run on Fridays — so this hand-rolls it rather than losing a week.

Single occurrence, in the `mcp-conformance` cron job. `node-version` stays `'20'`; setup-node v7 still installs arbitrary versions.

⚠️ **`cron.yml` is not exercised by PR CI** — `mcp-conformance` runs on the 05:40 UTC schedule. A green CI here does **not** validate this bump. I'll `workflow_dispatch` the task after merge to actually confirm it.