### PR TITLE
chore(e2e): docstring says Test 88, matching the filename

### DIFF
--- a/e2e/tests/api_only/test_88_mcp_conformance.py
+++ b/e2e/tests/api_only/test_88_mcp_conformance.py
@@ -1,4 +1,4 @@
-"""Test 79: MCP OAuth + protocol conformance against THIS build.
+"""Test 88: MCP OAuth + protocol conformance against THIS build.
 
 Runs `scripts/mcp-conformance.sh` — a real third-party client (MCPJam's CLI)
 plus our own RFC 9728 assertions — against the CI stack.


### PR DESCRIPTION
One-line follow-up to #1260.

The renumber moved `test_79_mcp_conformance.py` → `test_88_mcp_conformance.py` (79 was
already taken by the Obsidian tier's `test_79_attachment_move_convergence.py`), but I
committed the rename without staging the docstring edit. It landed with a `Test 79`
header on a `test_88` file — exactly the mismatch the renumber was meant to avoid, since
issues here refer to tests by number.

Refs #1260