### PR TITLE
ci(mcp): nightly OAuth conformance against staging

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,6 +24,7 @@ on:
     - cron: '17 13 * * 1'   # frontend-major-updates   (Mon 13:17 UTC)
     - cron: '0 14 * * 1'    # plan-triage              (Mon 14:00 UTC)
     - cron: '0 3 * * 6'     # dependency-submission    (Sat 03:00 UTC)
+    - cron: '40 5 * * *'    # mcp-conformance          (daily 05:40 UTC)
   workflow_dispatch:
     inputs:
       task:
@@ -38,10 +39,15 @@ on:
           - frontend-major-updates
           - runner-diagnostics
           - dependency-submission
+          - mcp-conformance
       force:
         description: '(obsidian-update only) Force re-download even if version matches'
         type: boolean
         default: false
+      target-url:
+        description: '(mcp-conformance only) MCP endpoint to test'
+        type: string
+        default: 'https://staging.engram.page/api/mcp'
 
 # No workflow-level permissions — each job grants what it actually needs.
 permissions: {}
@@ -537,3 +543,181 @@ jobs:
         uses: erlef/mix-dependency-submission@v1
         with:
           install-deps: true
+
+  # ── MCP OAuth conformance against a DEPLOYED authorization server.
+  #
+  # COMPLEMENTS the per-PR gate rather than substituting for it. test_88 gates
+  # every PR on the `spec` stage against a CI stack; this runs the `oauth`
+  # stage, which CANNOT run there: MCPJam's SDK refuses outbound OAuth fetches
+  # to RFC 6890 special-use addresses and the CLI exposes no opt-in, so the
+  # matrix needs a publicly-addressed deployment. See
+  # docs/context/mcp-conformance-suite-limits.md.
+  #
+  # `protocol` is deliberately absent: it is genuinely red (#1259 — ping
+  # unimplemented, no Host-rebinding rejection, we announce protocol
+  # 2025-03-26). Including it would page nightly for a known, filed issue.
+  # Add it to CONFORMANCE_STAGES when #1259 closes.
+  #
+  # Non-gating on purpose: it grades a deployment rather than a commit, so a red
+  # run means "staging is wrong" — a page, not a merge block. The page is the
+  # last step in this job; a failing cron nobody subscribes to is not one.
+  mcp-conformance:
+    if: |
+      github.event.schedule == '40 5 * * *'
+      || github.event.inputs.task == 'mcp-conformance'
+    name: mcp-conformance
+    runs-on: [self-hosted, linux, x64, isolated, light]
+    # 8 CLI runs (2 strategies x 4 protocol versions) plus the spec assertions.
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      issues: write   # regressions open/update a tracking issue (see last step)
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: the drift calculation below needs the deployed sha to
+          # exist locally and needs origin/main's ancestry. The default shallow
+          # clone silently yields "?" for every run.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      # Which BUILD is under test. Without this a red run is ambiguous: a stale
+      # deployment and a real regression look identical, and the first instinct
+      # is to go hunting through OAuth code. Observed 2026-08-05 — staging sat
+      # 3 commits behind because an engram-infra bump PR was green but never
+      # auto-merged, so the spec assertions failed for a deploy-valve reason.
+      - name: Identify the deployed build
+        id: deployed
+        shell: bash
+        env:
+          TARGET: ${{ github.event.inputs.target-url || 'https://staging.engram.page/api/mcp' }}
+        run: |
+          origin="${TARGET%/api/mcp}"
+          sha=$(curl -fsS --max-time 15 "$origin/api/health" \
+                  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("build_sha","unknown"))' \
+                  || echo "unreachable")
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          if [ "$sha" = "unknown" ] || [ "$sha" = "unreachable" ]; then
+            echo "deployed build: $sha (drift unknown)"
+            echo "drift=unknown" >> "$GITHUB_OUTPUT"
+          else
+            behind=$(git rev-list --count "$sha..origin/main" 2>/dev/null || echo "?")
+            echo "deployed build: $sha ($behind commits behind main)"
+            echo "drift=$behind" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: OAuth conformance (DCR + CIMD matrix)
+        id: conformance
+        shell: bash
+        # `set -o pipefail` is load-bearing. GitHub's default shell is `bash -e`
+        # WITHOUT pipefail, so `script | tee` would report tee's exit code and
+        # every regression would land as a green run.
+        #
+        # The target goes in `env:` rather than being interpolated into the
+        # script body — `target-url` is a workflow_dispatch input, and `${{ }}`
+        # inside `run:` is textual substitution.
+        env:
+          TARGET: ${{ github.event.inputs.target-url || 'https://staging.engram.page/api/mcp' }}
+          CONFORMANCE_STAGES: spec,oauth
+        run: |
+          set -o pipefail
+          mkdir -p conformance-results
+          rc=0
+          ./scripts/mcp-conformance.sh "$TARGET" 2>&1 \
+            | tee conformance-results/run.log || rc=$?
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+
+      - name: Upload conformance results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcp-conformance-results
+          path: conformance-results/
+          retention-days: 14
+
+      # Gated on rc == 1 specifically: the script exits 2 when npm or the target
+      # is unreachable, which is infrastructure, not a conformance result. Those
+      # still fail the run; they just do not open "the auth server is broken"
+      # and send someone reading OAuth code over a DNS blip.
+      - name: Open or update the regression issue
+        if: failure() && steps.conformance.outputs.rc == '1'
+        uses: actions/github-script@v9
+        env:
+          TARGET: ${{ github.event.inputs.target-url || 'https://staging.engram.page/api/mcp' }}
+          DEPLOYED_SHA: ${{ steps.deployed.outputs.sha }}
+          DEPLOYED_DRIFT: ${{ steps.deployed.outputs.drift }}
+        with:
+          script: |
+            const fs = require('fs')
+            const target = process.env.TARGET
+            const host = new URL(target).host
+            const sha = process.env.DEPLOYED_SHA
+            const drift = process.env.DEPLOYED_DRIFT
+            const title = `ops(mcp): OAuth conformance regression on ${host}`
+
+            let log = '(no output captured)'
+            try {
+              log = fs.readFileSync('conformance-results/run.log', 'utf8').slice(-4000)
+            } catch (e) {
+              core.warning(`could not read run.log: ${e.message}`)
+            }
+
+            const staleness = drift === 'unknown'
+              ? 'Could not determine which build is deployed.'
+              : Number(drift) > 0
+                ? `**The deployed build is ${drift} commit(s) behind main.** Check that before reading this as a regression — a stale deployment fails these assertions for a deploy-pipeline reason, not an OAuth one.`
+                : 'The deployed build is level with main, so this is not deploy lag.'
+
+            const body = [
+              `The nightly MCP OAuth conformance run failed against \`${target}\`.`,
+              '',
+              `Deployed build: \`${sha}\``,
+              '',
+              staleness,
+              '',
+              'This runs MCPJam\'s CLI — a real third-party client — through both the DCR',
+              'and CIMD registration paths across every protocol version. It grades a',
+              '**deployment**, not a commit, and covers the one stage the per-PR gate',
+              'cannot: MCPJam refuses loopback targets, so the OAuth matrix can only run',
+              'against a publicly-addressed host.',
+              '',
+              '## Output',
+              '',
+              '```',
+              log.trimEnd(),
+              '```',
+              '',
+              '## Where to start',
+              '',
+              '- `docs/context/mcp-conformance-suite-limits.md` — what each stage can and cannot prove.',
+              '- `docs/context/cimd-vs-dcr-validation-policy.md` — why DCR and CIMD validate differently.',
+              '- Step-by-step JSON is in the `mcp-conformance-results` artifact.',
+              '- `NO SIGNAL` (rather than `REGRESSION`) means the CLI output shape changed and the',
+              '  suite graded nothing — fix the harness first; the server may be fine.',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n')
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'mcp', per_page: 100,
+            })
+            const match = existing.find((i) => i.title === title)
+
+            if (match) {
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: match.number, body,
+              })
+              core.info(`Updated existing issue #${match.number}`)
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['mcp', 'area/auth'],
+              })
+              core.info(`Opened issue #${created.number}`)
+            }


### PR DESCRIPTION
Adds the nightly you asked for. It **complements** the per-PR gate rather than replacing
the arrangement we just landed.

## Why both, and why this stage here

`test_88` gates every PR on the **`spec`** stage against a CI stack. This job runs the
**`oauth`** stage, which cannot run there at all — MCPJam's SDK refuses outbound OAuth
fetches to RFC 6890 special-use addresses, and the CLI exposes no opt-in in 3.18.0 or
3.19.0:

```
Refusing outbound OAuth fetch to loopback host "localhost" (no loopback opt-in)
```

A CI stack is loopback by construction, so the DCR/CIMD matrix needs a publicly-addressed
deployment. Two stages in two places, for a measured reason rather than a preference.

**`protocol` is deliberately excluded.** It is genuinely red (#1259 — `ping` unimplemented,
no Host-rebinding rejection, we announce protocol `2025-03-26`). A nightly that pages for
a known, filed issue trains people to ignore it. Add it to `CONFORMANCE_STAGES` when #1259
closes.

## It reports which build it graded

A deployment-grading job has a failure mode a commit-grading one doesn't: **a stale
deployment and a real regression look identical**, and the instinct is to go read OAuth
code.

That is not hypothetical — I hit it building this. Staging was **3 commits behind** main
because `engram-app/engram-infra#912` was green on every check but **never auto-merged**,
so the spec assertions failed for a deploy-valve reason:

```
sha=c2fd9a7a...   behind=3 commits
SPEC VIOLATION: 401 ... carries no WWW-Authenticate header
```

The job now resolves `/api/health`'s `build_sha`, counts commits behind main, and the
issue body **leads with that** before the output.

`fetch-depth: 0` is required — the default shallow clone can't resolve the deployed sha
and silently yields `?` on every run. `python3` rather than `jq`, which isn't guaranteed
on these runners.

## Verified

Both stages run against real staging (output in the commit body). Drift detection tested
against live staging and against an unreachable host. Issue filing stays gated on
`rc == 1`, so exit 2 (ENVIRONMENT — npm or target unreachable) fails the run without
opening "the auth server is broken".

## Note

Tonight's first run will likely be **red**, correctly: staging is 3 commits behind and
genuinely lacks the #1255 discovery fix. The issue it opens will say so on the first line.
See engram-infra#912 — it's green and unmerged; I did not merge it, since that moves a
deployment in another repo.

Refs #1260, #1259