### PR TITLE
ci(aws): reap superseded AWS CLI installs on the runner

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4404,6 +4404,36 @@ jobs:
           echo "$HOME/.aws-cli/bin" >> "$GITHUB_PATH"
           "$BIN" --version
 
+          # Reap superseded installs. `aws/install --update` creates a NEW
+          # versioned directory under v2/ and repoints `current` — it never
+          # removes the old one. Seven runner services share one $HOME on the
+          # SlowRaid VM, so the `[ ! -x "$BIN" ]` guard above does not prevent
+          # concurrent first-installs racing, and each race leaves another
+          # 268MB directory behind forever.
+          #
+          # By 2026-08-05 that was 23 versions / 6.0GB on a 76GB root with no
+          # free LVM extents, and it took the whole runner pool down twice in
+          # one day with "No space left on device" — surfacing as unrelated red
+          # CI, since all seven runners share the filesystem.
+          #
+          # Keeps the newest two: `current` plus one for rollback margin.
+          # Failures here must never fail the build — this is hygiene, not a
+          # dependency of the step.
+          if [ -d "$HOME/.aws-cli/v2" ]; then
+            # Keep set = newest two by version sort, PLUS whatever `current`
+            # actually resolves to. The union matters: if `current` ever points
+            # at something that is not among the newest two, a pure
+            # version-sort would delete the live install out from under the
+            # symlink. `[0-9]*` never matches the `current` symlink itself.
+            keep="$(ls -d "$HOME"/.aws-cli/v2/[0-9]* 2>/dev/null | sort -V | tail -2)"
+            live="$(readlink -f "$HOME/.aws-cli/v2/current" 2>/dev/null || true)"
+            [ -n "$live" ] && keep="$keep
+          $live"
+            for d in "$HOME"/.aws-cli/v2/[0-9]*; do
+              printf '%s\n' "$keep" | grep -qxF "$d" || rm -rf "$d" || true
+            done
+          fi
+
       - name: Configure AWS credentials (OIDC)
         if: steps.version.outputs.image_exists != 'true'
         # v6 (Node 24). v4 used Node 20, which GH deprecates 2026-09-16.


### PR DESCRIPTION
One of two unbounded growth sources that took the runner pool down **twice on
2026-08-05** with `No space left on device`. See #1261.

## The mechanism

`aws/install --update` creates a **new versioned directory** under `v2/` and repoints
`current`. It never removes the old one.

The `[ ! -x "$BIN" ]` guard was meant to make this a one-time cost. But **seven runner
services share one `$HOME`** on the SlowRaid VM, so concurrent first-installs race past
the guard — and every race leaks another 268 MB directory, permanently. The existing
comment already names that race as why `--update` is there; what it missed is that the
race also *leaks*.

```
268M  ~/.aws-cli/v2/2.35.17
268M  ~/.aws-cli/v2/2.35.18
...   23 versions
6.0G  ~/.aws-cli/v2      ← 22 of 23 unreferenced
```

On a 76 GB root whose volume group has **zero free extents**, that matters. And because
all seven runners share the filesystem, one full disk fails everything at once — both
outages surfaced as confusing red CI on unrelated PRs.

## The fix

Keep the newest two (current + rollback margin). The keep-set is the **union** of "newest
two by version sort" and "whatever `current` actually resolves to" — a pure version sort
would delete the live install out from under the symlink if `current` were ever pinned to
an older build.

Verified against fixtures before shipping, since it's an `rm -rf`:

| case | result |
|---|---|
| 6 versions incl. 2.35.9 / 2.35.10 | → newest 2 kept; `sort -V` orders them correctly |
| `current` pinned to an **old** version | that version survives alongside the newest two |
| empty `v2/` | no-op, rc=0 |

Never fails the build — hygiene, not a dependency of the step.

## Not in this PR

- **`.terraform.d` was 12 GB** of per-runner plugin caches, last written 2026-07-14 and
  orphaned when engram-infra moved to a workspace-scoped `TF_PLUGIN_CACHE_DIR`. Deleted
  live (nothing referenced them: no env var, no `.terraformrc`) — VM went 92% → 79%.
  Nothing to change in this repo.
- **engram-infra has the same pattern** in `prod-pg18-wipe-redeploy.yml` and
  `prod-task-diag.yml` (`--install-dir "$HOME/.local/aws-cli" --update`). Smaller, same
  leak. Separate repo, separate PR.
- **The homelab `runner_vm` auto-prune only covers docker** and runs weekly. Neither of
  the two consumers found here is docker. Tracked in #1261.

Refs #1261