### PR TITLE
ci(e2e): name the MinIO storage-full failure instead of leaving it as 502

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1430,6 +1430,26 @@ jobs:
         run: |
           mkdir -p ci-artifacts
           docker compose -f ci/compose.yml -p "$CI_PROJECT" logs > ci-artifacts/docker-compose.log 2>&1
+
+          # Name the storage-full failure mode instead of leaving it as
+          # `assert 502 == 200`. Once the drive crosses MinIO's minimum free
+          # threshold it refuses every PUT with 507 XMinioStorageFull, and the
+          # only symptom the suite shows is EVERY attachment test failing 502 —
+          # which reads like an application bug. It is not.
+          #
+          # Run 31024858500 lost 5 attachment tests exactly this way while the
+          # diff under test was unrelated, and the cluster was misattributed to
+          # a dependency bump (req 0.7.1) that had nothing to do with it. The
+          # proof was already in this very artifact; nobody grepped for it.
+          #
+          # Checked HERE, not at stack bring-up: the disk is not full when the
+          # stack starts, it fills DURING the run as concurrent stacks write.
+          # A free-space probe up front reads healthy and tells you nothing --
+          # measured 12% free on a box that still 507'd mid-run.
+          if grep -q "XMinioStorageFull" ci-artifacts/docker-compose.log 2>/dev/null; then
+            echo "::error title=CI storage full::MinIO returned 507 XMinioStorageFull -- the runner drive crossed its minimum free threshold, so every attachment PUT failed and the attachment tests report 502. This is runner CAPACITY, not a code or dependency regression. Do not bisect the diff."
+            df -h / || true
+          fi
           cp ${MARKER_PREFIX}-*.log ci-artifacts/ 2>/dev/null || true
           # Pytest detailed log (captures DEBUG+ from all helpers)
           cp e2e/pytest-e2e.log ci-artifacts/ 2>/dev/null || true


### PR DESCRIPTION
## The failure mode

When the runner drive crosses MinIO's minimum free threshold, MinIO refuses **every** PUT:

```
attachment storage PUT failed: {:http_error, 507,
  <Code>XMinioStorageFull</Code>
  <Message>Storage backend has reached its minimum free drive threshold.</Message>
```

The only thing the suite surfaces is every attachment test failing `assert 502 == 200`. That reads like an application bug.

## It isn't, and the misread already happened

Run `31024858500` lost 5 attachment tests to a full drive while the diff under test was unrelated. **I misattributed the cluster to a dependency bump (`req 0.7.1`) that had nothing to do with it**, and shipped a pin on that reasoning before main reproduced the same failure at `req 0.6.3`.

The proof was in that run's own `docker-compose.log` artifact the entire time. Nobody grepped for it — including me, despite `gh run download` being the documented first move for CI debugging.

So: grep for it, at the moment the artifact is collected, and say plainly what it is.

```
::error title=CI storage full::MinIO returned 507 XMinioStorageFull — the runner drive
crossed its minimum free threshold ... This is runner CAPACITY, not a code or dependency
regression. Do not bisect the diff.
```

## Why at failure time, not bring-up — this is the whole design

My first attempt probed free space **before** `compose up` and warned under a threshold. **It would have stayed silent on the very box that failed.**

The drive isn't full when the stack starts — it fills *during* the run as five concurrent stacks write. I measured **12% free** on a runner that still 507'd mid-run, so an up-front probe reads healthy and tells you nothing. Threw it away and moved the check to where the evidence actually exists.

## Verified, not assumed

Extracted the check back out of the **parsed YAML** (not a copy) and ran it:

| Input | Result |
|---|---|
| real `docker-compose.log` from run 31024858500 | **fires**, with `df -h` output |
| clean log | silent |

## What this does not fix

The underlying capacity problem. Both runner VMs sit at **88%** and **79%** used, and teardown is already correct (`down -v --remove-orphans` plus `docker volume prune -f`), so it's not a leak — it's genuine pressure from image/build cache plus five concurrent checkouts per box. That needs a disk or pruning-policy decision on shared infra, which isn't mine to make unilaterally.

This PR only ensures the next occurrence costs a glance instead of an hour and a wrong fix.

Refs #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz