### PR TITLE
fix(links): delayed sweep closes the late-index rewrite window

### DIFF
--- a/lib/engram/workers/rewrite_note_links.ex
+++ b/lib/engram/workers/rewrite_note_links.ex
@@ -18,6 +18,26 @@ defmodule Engram.Workers.RewriteNoteLinks do
   counts `[:engram, :links, :rewrite, :failed]` and the rest proceed.
   A rewrite failure never fails or rolls back the rename.
 
+  Delayed sweep (closes the late-index rewrite window): a source note's
+  `[[link]]` is only visible to this worker once async indexing has
+  written its `note_links` edge. If a note is created (or edited to add a
+  new link) and its target is renamed within that indexing lag (~30s
+  observed on staging), the initial walk finds zero sources — the edge
+  doesn't exist yet — and completes clean, leaving the late-arriving edge
+  permanently dangling with stale text. When a chain's FINAL chunk (this
+  module's terminating branch, batch came back short) belongs to a run
+  that is not itself a sweep, it enqueues ONE follow-up job: same args,
+  cursor reset to the start, `"sweep" => true`, scheduled ~60s out. A
+  sweep-marked chain terminates WITHOUT enqueueing another sweep (no
+  recursion) — mid-chain successors still preserve the marker so the
+  sweep's own chunking doesn't spawn a third pass. This is cheap and safe
+  to run unconditionally: the rewrite is idempotent (already-current
+  occurrences plan no edits, so a clean run's second walk is a no-op),
+  old-path recovery still works on the delayed job (tombstones persist;
+  CRDT-origin ciphertext args are carried through verbatim), and there is
+  no `unique:` on this worker (see below) so the extra insert can't
+  collide with an in-flight chain.
+
   Args carry ids + base64 HMACs only (T3.2/H3 — plaintext in
   `oban_jobs.args` JSONB defeats at-rest encryption). The old plaintext
   path is recovered at run time from one of two sources: the rename
@@ -50,6 +70,7 @@ defmodule Engram.Workers.RewriteNoteLinks do
 
   @default_batch_size 100
   @start_cursor "00000000-0000-0000-0000-000000000000"
+  @sweep_delay_seconds 60
 
   # The tagged error atoms the rewrite pipeline actually produces
   # (rewrite_source_note/attempt/persist + this worker's own path recovery).
@@ -153,8 +174,25 @@ defmodule Engram.Workers.RewriteNoteLinks do
           {:error, reason} -> {:error, reason}
         end
       else
-        :ok
+        maybe_enqueue_sweep(args)
       end
+    end
+  end
+
+  # Chain terminated. A plain run schedules one delayed sweep to catch any
+  # edge that indexed in after this walk started (see moduledoc). A sweep
+  # run terminates quietly — no third pass.
+  defp maybe_enqueue_sweep(%{"sweep" => true}), do: :ok
+
+  defp maybe_enqueue_sweep(args) do
+    args
+    |> Map.put("cursor", @start_cursor)
+    |> Map.put("sweep", true)
+    |> new(schedule_in: @sweep_delay_seconds)
+    |> Oban.insert()
+    |> case do
+      {:ok, _job} -> :ok
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/test/engram/workers/rewrite_note_links_test.exs
+++ b/test/engram/workers/rewrite_note_links_test.exs
@@ -64,7 +64,10 @@ defmodule Engram.Workers.RewriteNoteLinksTest do
   end
 
   # Drain every enqueued rewrite + rebind job, including cursor successors a
-  # rewrite job enqueues mid-run. Loops until the queues are quiet.
+  # rewrite job enqueues mid-run AND the delayed sweep job a terminating
+  # chain now enqueues (schedule_in: 60 -> state "scheduled", not
+  # "available" — must be swept up here too or this loop never quiesces).
+  # Loops until the queues are quiet.
   defp drain_link_jobs! do
     jobs =
       all_enqueued(worker: RewriteNoteLinks) ++ all_enqueued(worker: RebindNoteLinks)
@@ -83,7 +86,7 @@ defmodule Engram.Workers.RewriteNoteLinksTest do
           from(j in Oban.Job,
             where:
               j.worker in ^["Engram.Workers.RewriteNoteLinks", "Engram.Workers.RebindNoteLinks"] and
-                j.state == "available"
+                j.state in ["available", "scheduled"]
           )
         )
 
@@ -150,6 +153,104 @@ defmodule Engram.Workers.RewriteNoteLinksTest do
     for {s, i} <- Enum.with_index(sources, 1) do
       assert authoritative!(user, s.id) == "see [[Fresh]] #{i}"
     end
+  end
+
+  describe "delayed sweep (closes the late-index rewrite window, #1231 follow-up)" do
+    test "chain termination without a sweep marker enqueues one delayed sweep job, preserving identity/hmac/ciphertext args",
+         %{user: user, vault: vault} do
+      # CRDT-relocate style target so the round trip also proves the
+      # ciphertext args survive into the sweep job, not just the hmacs.
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "Old.md", "content" => "# t"})
+      _source = seed_source!(user, vault, "S.md", "see [[Old]]")
+      {:ok, _moved} = Notes.genesis_crdt_note(user, vault, note.id, "Fresh.md")
+      Repo.delete_all(from(j in Oban.Job, where: j.worker == "Engram.Workers.RewriteNoteLinks"))
+
+      args = ciphertext_args(user, vault, note, "Old.md")
+      assert :ok = perform_job(RewriteNoteLinks, args)
+
+      assert [job] = all_enqueued(worker: RewriteNoteLinks)
+      assert job.args["sweep"] == true
+      assert job.args["cursor"] == "00000000-0000-0000-0000-000000000000"
+
+      for key <- Map.keys(args), key != "cursor" do
+        assert job.args[key] == args[key], "expected #{key} to be preserved on the sweep job"
+      end
+
+      diff = DateTime.diff(job.scheduled_at, DateTime.utc_now())
+      assert diff in 55..65, "expected ~60s delay, got #{diff}s"
+    end
+
+    test "a sweep-marked chain termination enqueues no further job (recursion guard)", %{
+      user: user,
+      vault: vault
+    } do
+      {_old_id, renamed} = seed_rename!(user, vault)
+      _source = seed_source!(user, vault, "S.md", "see [[Old]]")
+
+      args = args_for(user, vault, renamed) |> Map.put("sweep", true)
+      assert :ok = perform_job(RewriteNoteLinks, args)
+
+      assert all_enqueued(worker: RewriteNoteLinks) == []
+    end
+
+    test "a full-batch sweep job enqueues its successor with the sweep marker preserved", %{
+      user: user,
+      vault: vault
+    } do
+      {_old_id, renamed} = seed_rename!(user, vault)
+      _sources = for i <- 1..3, do: seed_source!(user, vault, "S#{i}.md", "see [[Old]] #{i}")
+
+      args =
+        args_for(user, vault, renamed)
+        |> Map.put("sweep", true)
+        |> Map.put("batch_size", 2)
+
+      assert :ok = perform_job(RewriteNoteLinks, args)
+
+      assert [job] = all_enqueued(worker: RewriteNoteLinks)
+      assert job.args["sweep"] == true
+      assert job.args["cursor"] > "00000000-0000-0000-0000-000000000000"
+    end
+
+    test "the bug itself: an edge that lands after the initial walk is caught by the delayed sweep",
+         %{user: user, vault: vault} do
+      {_old_id, renamed} = seed_rename!(user, vault)
+
+      # Simulate the pre-index state: the referring note exists, but its
+      # note_links edge has not been written yet (async indexing lag).
+      {:ok, source} =
+        Notes.upsert_note(user, vault, %{"path" => "Late.md", "content" => "see [[Old]]"})
+
+      args = args_for(user, vault, renamed)
+      assert :ok = perform_job(RewriteNoteLinks, args)
+
+      # No edge existed yet -> nothing found -> nothing rewritten.
+      assert authoritative!(user, source.id) == "see [[Old]]"
+      assert [sweep_job] = all_enqueued(worker: RewriteNoteLinks)
+      assert sweep_job.args["sweep"] == true
+
+      # Late indexing arrives: the edge is created now. Old.md is gone
+      # (renamed away), so this resolves dangling on insert.
+      :ok = Links.replace_links(user, vault, source.id, Parser.extract("see [[Old]]"))
+
+      assert dangling_target(user, source.id) == nil
+
+      # The delayed sweep re-walks from the start cursor and catches it.
+      assert :ok = perform_job(RewriteNoteLinks, sweep_job.args)
+
+      assert authoritative!(user, source.id) == "see [[Fresh]]"
+      assert dangling_target(user, source.id) == renamed.id
+    end
+  end
+
+  defp dangling_target(user, source_id) do
+    Repo.one(
+      from(l in Engram.Links.NoteLink,
+        where: l.user_id == ^user.id and l.source_note_id == ^source_id,
+        select: l.target_note_id
+      ),
+      skip_tenant_check: true
+    )
   end
 
   # Regression for the no-`unique:` invariant. `Oban.insert/1` called twice


### PR DESCRIPTION
Staging-verified race from #1240's rename propagation: create a `[[link]]` and rename its target within the source note's async indexing lag (~32s observed), and `RewriteNoteLinks` runs before the referring edge exists in `note_links` — zero sources found, job completes, and the late-arriving edge lands with stale text and goes permanently dangling. Timestamps from the staging repro: rewrite job attempted `18:31:09.58`, referring edge inserted `18:31:41.7`.

**Fix:** when a rewrite chain terminates and its args carry no `sweep` marker, the worker enqueues exactly one follow-up pass at +60s with the same args (ciphertext/nonce copied verbatim when present), cursor reset, and `"sweep" => true`. Sweep chunks chain normally with the marker preserved; a sweep's own termination enqueues nothing (recursion impossible — the marker is read from the job's persisted args every run). The rewrite is idempotent, so the second pass is a cheap no-op when nothing was missed. No `unique:` (cursor-chain rule), no enqueue-site changes.

Tests: the exact staging race reproduced end to end (initial job with no edge → edge inserted late → the real enqueued sweep job's args driven through perform → text rewritten + edge rebound), plus marker-preservation, recursion-guard, and args-fidelity pins. One shared test-helper change: `drain_link_jobs!` now also clears `scheduled` rows (the +60s sweep otherwise spins its drain loop); its single caller asserts only on content/edges, verified unmaskable.

Gauntlet green: format, credo --strict, dialyzer, 4,165 tests 0 failures with warnings-as-errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqgVPyDtDbXmTqm4PkTioK