### PR TITLE
feat(web): create-on-click for unresolved wikilinks

### DIFF
--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -1229,6 +1229,21 @@ describe("useCreateNote — optimistic placeholder", () => {
 		expect(crdtCreateNote.mock.calls[1]![0]).toBe(MINTED_ID);
 	});
 
+	// The unresolved-wikilink "create this note" affordance passes a specific
+	// filename derived from the link target, instead of taking the "Untitled.md"
+	// default — same mutation/hook as the sidebar "New note" button.
+	it("creates at a caller-supplied name instead of Untitled.md", async () => {
+		qc.setQueryData(["folder-notes-by-id", "42", "root"], []);
+		crdtCreateNote.mockImplementation((docId: string) => Promise.resolve(docId));
+
+		const { result } = renderHook(() => useCreateNote(), { wrapper });
+		await act(async () => {
+			await result.current.mutateAsync({ folder: "", id: MINTED_ID, name: "songebobsss.md" });
+		});
+
+		expect(crdtCreateNote).toHaveBeenCalledWith(MINTED_ID, "songebobsss.md");
+	});
+
 	it("surfaces notes_cap_reached without retrying", async () => {
 		qc.setQueryData(["folder-notes-by-id", "42", "root"], []);
 		crdtCreateNote.mockRejectedValue(new CrdtOpError("notes_cap_reached", "crdt_create"));

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -619,10 +619,13 @@ export function useCreateNote() {
 	return useMutation<
 		{ path: string; id: string },
 		ApiError,
-		{ folder: string; id: string },
+		// `name` defaults to "Untitled.md" (the sidebar "New note" button) — the
+		// unresolved-wikilink "create this note" affordance passes the target's
+		// derived filename instead. Either way collideBump still guards a race.
+		{ folder: string; id: string; name?: string },
 		CreateNoteContext | undefined
 	>({
-		mutationFn: async ({ folder, id }) => {
+		mutationFn: async ({ folder, id, name: desiredName = "Untitled.md" }) => {
 			const folderId = folderIdForPath(qc, vaultId, folder);
 			const existingNotes = folderId
 				? (qc.getQueryData<NoteSummary[]>(["folder-notes-by-id", vaultId, folderId]) ?? [])
@@ -633,7 +636,7 @@ export function useCreateNote() {
 
 			const MAX_RACES = 5;
 			for (let attempt = 0; attempt < MAX_RACES; attempt++) {
-				const name = collideBump(existingNames, "Untitled.md", { cap: 1000 });
+				const name = collideBump(existingNames, desiredName, { cap: 1000 });
 				const path = folder ? `${folder}/${name}` : name;
 				try {
 					// crdt_create genesis over the live channel (replaces POST /notes);
@@ -661,7 +664,7 @@ export function useCreateNote() {
 		// Drop a placeholder row into the id-keyed list the tree reads so a new
 		// note shows instantly (on-disk feel), then swap it for the server row on
 		// success. Root and subfolders share one cache keyed by folder id.
-		onMutate: async ({ folder, id }) => {
+		onMutate: async ({ folder, id, name: desiredName = "Untitled.md" }) => {
 			const folderId = folderIdForPath(qc, vaultId, folder);
 			// Unknown non-root folder not in the cache yet — skip; surfaces on expand.
 			if (folderId === null) {
@@ -676,7 +679,7 @@ export function useCreateNote() {
 				return;
 			}
 
-			const name = collideBump(realFilenames(snapshot), "Untitled.md", { cap: 1000 });
+			const name = collideBump(realFilenames(snapshot), desiredName, { cap: 1000 });
 			const path = folder ? `${folder}/${name}` : name;
 			const now = new Date().toISOString();
 			const placeholder: NoteSummary = {

--- a/frontend/src/viewer/wiki-link-redirect.test.tsx
+++ b/frontend/src/viewer/wiki-link-redirect.test.tsx
@@ -1,13 +1,15 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import WikiLinkRedirect from "./wiki-link-redirect";
 
 let mockManifest: { notes: { id: string; path: string }[] } | undefined;
 let mockPending = false;
+const createNoteMutate = vi.fn();
 
 vi.mock("../api/queries", () => ({
 	useSyncManifest: () => ({ data: mockManifest, isPending: mockPending }),
+	useCreateNote: () => ({ mutate: createNoteMutate, isPending: false }),
 }));
 
 // NotFoundPage pulls in ThemeToggle, which needs a ThemeProvider we are not
@@ -41,6 +43,7 @@ beforeEach(() => {
 		],
 	};
 	mockPending = false;
+	createNoteMutate.mockClear();
 });
 
 describe("WikiLinkRedirect", () => {
@@ -59,15 +62,49 @@ describe("WikiLinkRedirect", () => {
 		expect(await screen.findByTestId("loc")).toHaveTextContent("/work/n-2#some-heading");
 	});
 
-	it("shows not-found for an unresolvable target", () => {
-		renderAt("/work/wiki/Ghost");
-		expect(screen.getByText(/not found/i)).toBeInTheDocument();
-	});
-
 	it("waits rather than 404ing while the manifest loads", () => {
 		mockManifest = undefined;
 		mockPending = true;
 		renderAt("/work/wiki/Unique");
 		expect(screen.queryByText(/not found/i)).toBeNull();
+	});
+
+	describe("unresolved target — create affordance", () => {
+		it("shows the create-note offer instead of a dead-end 404", () => {
+			renderAt("/work/wiki/Ghost");
+			expect(screen.getByText(/"Ghost" doesn't exist yet/i)).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: 'Create "Ghost"' })).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+		});
+
+		it("creates a bare target at the vault root", () => {
+			renderAt("/work/wiki/songebobsss");
+
+			fireEvent.click(screen.getByRole("button", { name: 'Create "songebobsss"' }));
+
+			expect(createNoteMutate).toHaveBeenCalledWith(
+				expect.objectContaining({ folder: "", name: "songebobsss.md" }),
+			);
+		});
+
+		it("creates a path-qualified target at that path", () => {
+			renderAt("/work/wiki/folder/sub/Name");
+
+			fireEvent.click(screen.getByRole("button", { name: 'Create "Name"' }));
+
+			expect(createNoteMutate).toHaveBeenCalledWith(
+				expect.objectContaining({ folder: "folder/sub", name: "Name.md" }),
+			);
+		});
+
+		it("strips a #heading segment before deriving the create path", () => {
+			renderAt("/work/wiki/Ghost#Some%20Heading");
+
+			fireEvent.click(screen.getByRole("button", { name: 'Create "Ghost"' }));
+
+			expect(createNoteMutate).toHaveBeenCalledWith(
+				expect.objectContaining({ folder: "", name: "Ghost.md" }),
+			);
+		});
 	});
 });

--- a/frontend/src/viewer/wiki-link-redirect.tsx
+++ b/frontend/src/viewer/wiki-link-redirect.tsx
@@ -1,25 +1,64 @@
-import { Navigate, useLocation, useParams } from "react-router";
-import { useSyncManifest } from "../api/queries";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router";
+import { Button } from "@/components/ui/button";
+import { heading } from "@/lib/ui-classes";
+import { useCreateNote, useSyncManifest } from "../api/queries";
+import { uuid7 } from "../crdt/uuid7";
+import AuthPanel from "../layout/auth-panel";
+import AuthShell from "../layout/auth-shell";
 import NotFoundPage from "../not-found";
 import LoadingPane from "./loading-pane";
-import { resolveWikiTarget } from "./wiki-link";
+import { resolveWikiTarget, stripMd, wikiCreatePath } from "./wiki-link";
 
 // `/:slug/wiki/<target>` — the landing route for every wikilink href. Wikilinks
 // name a note by path or bare title, but note routes are id-keyed, so this
 // resolves the target against the vault manifest (Obsidian rules: exact path,
 // then vault-wide basename, shortest path wins) and bounces to `/:slug/:id`.
 // The heading hash (already slugged by wikiHref) rides along untouched.
+//
+// Unresolved (dangling) targets get an inline "create this note" affordance
+// instead of a dead-end 404 — Obsidian parity. Creating goes through the same
+// useCreateNote mutation the sidebar "New note" button uses, so success
+// navigation and failure toasts come for free; the dangling edges self-heal
+// server-side once the note exists.
 export default function WikiLinkRedirect() {
 	const { slug, "*": target } = useParams();
 	const location = useLocation();
+	const navigate = useNavigate();
 	const { data: manifest, isPending } = useSyncManifest();
+	const createNote = useCreateNote();
 
 	if (isPending && !manifest) {
 		return <LoadingPane />;
 	}
 	const note = resolveWikiTarget(target ?? "", manifest?.notes ?? []);
-	if (!(note && slug)) {
+	if (note && slug) {
+		return <Navigate to={{ pathname: `/${slug}/${note.id}`, hash: location.hash }} replace />;
+	}
+	// Route always provides :slug in practice; this guard just keeps the type
+	// narrowed for the mutate() call below, same as the old resolved-branch check.
+	if (!slug) {
 		return <NotFoundPage />;
 	}
-	return <Navigate to={{ pathname: `/${slug}/${note.id}`, hash: location.hash }} replace />;
+
+	const { folder, name } = wikiCreatePath(target ?? "");
+	const title = stripMd(name);
+
+	return (
+		<AuthShell>
+			<AuthPanel className="flex flex-col items-center gap-4 text-center">
+				<h1 className={heading}>"{title}" doesn't exist yet.</h1>
+				<div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+					<Button variant="outline" onClick={() => navigate(-1)}>
+						Back
+					</Button>
+					<Button
+						onClick={() => createNote.mutate({ folder, id: uuid7(), name })}
+						disabled={createNote.isPending}
+					>
+						Create "{title}"
+					</Button>
+				</div>
+			</AuthPanel>
+		</AuthShell>
+	);
 }

--- a/frontend/src/viewer/wiki-link.test.ts
+++ b/frontend/src/viewer/wiki-link.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { buildWikiMap, parseWikiTarget, resolveWikiTarget, wikiHref } from "./wiki-link";
+import {
+	buildWikiMap,
+	parseWikiTarget,
+	resolveWikiTarget,
+	wikiCreatePath,
+	wikiHref,
+} from "./wiki-link";
 
 describe("parseWikiTarget", () => {
 	test("plain path has no hash", () => {
@@ -80,6 +86,31 @@ describe("wikiHref", () => {
 
 	test("no vault slug renders an inert anchor", () => {
 		expect(wikiHref("My Note", undefined)).toBe("#");
+	});
+});
+
+describe("wikiCreatePath", () => {
+	test("bare target creates at the vault root", () => {
+		expect(wikiCreatePath("songebobsss")).toEqual({ folder: "", name: "songebobsss.md" });
+	});
+
+	test("path-qualified target splits into folder + filename", () => {
+		expect(wikiCreatePath("folder/sub/Name")).toEqual({ folder: "folder/sub", name: "Name.md" });
+	});
+
+	test("strips a #heading segment before deriving the path", () => {
+		expect(wikiCreatePath("folder/Name#Some Heading")).toEqual({
+			folder: "folder",
+			name: "Name.md",
+		});
+	});
+
+	test("strips a redundant .md extension rather than doubling it", () => {
+		expect(wikiCreatePath("Name.md")).toEqual({ folder: "", name: "Name.md" });
+	});
+
+	test("trims surrounding whitespace", () => {
+		expect(wikiCreatePath("  Name  ")).toEqual({ folder: "", name: "Name.md" });
 	});
 });
 

--- a/frontend/src/viewer/wiki-link.ts
+++ b/frontend/src/viewer/wiki-link.ts
@@ -4,7 +4,7 @@ import GithubSlugger from "github-slugger";
 // the /:slug/wiki/* redirect route and both link producers (note-view's
 // remark-wiki-link config, note-page's editor resolveWikiLink) share it.
 
-const stripMd = (p: string) => p.replace(/\.md$/iu, "");
+export const stripMd = (p: string) => p.replace(/\.md$/iu, "");
 
 export interface ManifestNote {
 	id: string;
@@ -66,6 +66,18 @@ export function resolveWikiTarget(page: string, notes: ManifestNote[]): Manifest
 		})
 		.sort((a, b) => a.path.length - b.path.length);
 	return byName[0] ?? null;
+}
+
+// Vault-root-relative create path for the unresolved-wikilink "create this
+// note" affordance. Strips #heading/|alias via parseWikiTarget and any
+// redundant .md, then splits on the last '/' — bare target creates at the
+// vault root, path-qualified target creates (and implicitly folders) along
+// that path, matching Obsidian's click-to-create behavior.
+export function wikiCreatePath(raw: string): { folder: string; name: string } {
+	const { page } = parseWikiTarget(raw);
+	const segments = stripMd(page).split("/");
+	const name = `${segments.pop() ?? ""}.md`;
+	return { folder: segments.join("/"), name };
 }
 
 // No slug = rendered outside a vault route (markdown reference panel) —


### PR DESCRIPTION
Clicking a dangling `[[link]]` currently dead-ends on the 404 page. Obsidian's behavior is to create the note. The `/:slug/wiki/*` unresolved branch now renders an inline affordance — `"<name>" doesn't exist yet.` with `Create "<name>"` / `Back` — wired to the same `useCreateNote` mutation the sidebar's New-note button uses (extended with an optional exact filename), so success-navigation and failure toasts are inherited. `wikiCreatePath` derives folder + `<name>.md` from the target via the existing `parseWikiTarget` (heading/alias stripped); path-qualified targets create at their qualified path. Once created, the pre-existing dangling edges self-heal server-side (danglers-bind machinery, shipped in #1229/#1240).

Panel reuses the `AuthShell`/`AuthPanel` pair `NotFoundPage` already renders in this route, so the unresolved state stays visually consistent.

Tests: red-first unit coverage for `wikiCreatePath` (bare, path-qualified, heading/alias-stripped), component tests for the unresolved branch (affordance renders; mutation receives the right folder/name), `useCreateNote` name-threading pins; 148 tests across the touched files, `tsc --noEmit` + `biome ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqgVPyDtDbXmTqm4PkTioK