### PR TITLE
fix(web): invalidate the sync manifest on note inventory events

### DIFF
--- a/frontend/src/api/channel.test.ts
+++ b/frontend/src/api/channel.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { beacon, tracingEnabled } from "../observability/trace";
 import {
 	__resetNoteChangeBatch,
+	backfillStructural,
 	handleFoldersBatch,
 	handleNoteChanged,
 	handleNotesBatch,
@@ -78,6 +79,29 @@ describe("handleNoteChanged", () => {
 		// Untargeted folderNotes (whole-prefix) must not be used when the
 		// folder is known.
 		expect(keys).not.toContainEqual(["folderNotes", "7"]);
+	});
+
+	// The manifest is the vault-wide path→id inventory behind [[ autocomplete
+	// and /:slug/wiki/* resolution. Any note event can change it (create/
+	// rename/delete, incl. per-note events from folder ops), so it rides the
+	// same coalesced flush as the other list-level keys — it had ZERO
+	// invalidation sites before, leaving new/renamed notes invisible to
+	// autocomplete until an incidental refetch.
+	it("invalidates the sync manifest in the coalesced flush", () => {
+		const qc = mockQueryClient();
+		handleNoteChanged(
+			{ event_type: "upsert", path: "docs/a.md", folder: "docs", vault_id: "7" },
+			qc,
+			"7",
+		);
+
+		const syncKeys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey);
+		expect(syncKeys).not.toContainEqual(["syncManifest", "7"]);
+
+		vi.advanceTimersByTime(250);
+
+		const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey);
+		expect(keys).toContainEqual(["syncManifest", "7"]);
 	});
 
 	it("coalesces a sync burst into one flush per distinct folder", () => {
@@ -307,6 +331,18 @@ describe("handleFoldersBatch", () => {
 		const qc = mockQueryClient();
 		handleFoldersBatch({ op: "create", folder: "New/Empty" }, qc, "7");
 		expect(qc.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["folders", "7"] });
+	});
+});
+
+describe("backfillStructural", () => {
+	// A backgrounded/offline tab misses note events with no replay, so the
+	// reconnect backfill must also stale the manifest — otherwise notes
+	// created elsewhere during the gap stay missing from [[ autocomplete.
+	it("invalidates the sync manifest alongside the structural views", () => {
+		const qc = mockQueryClient();
+		backfillStructural(qc, "7");
+		const keys = qc.invalidateQueries.mock.calls.map((c) => c[0].queryKey);
+		expect(keys).toContainEqual(["syncManifest", "7"]);
 	});
 });
 

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -151,6 +151,12 @@ function flushBatch(batch: PendingBatch): void {
 	const { queryClient, vaultId, folders } = batch;
 	queryClient.invalidateQueries({ queryKey: ["folders", vaultId] });
 	queryClient.invalidateQueries({ queryKey: ["search", vaultId] });
+	// The vault-wide path→id inventory behind [[ autocomplete + /:slug/wiki/*
+	// resolution (useSyncManifest). Every note event that reaches this flush can
+	// change it (create/rename/delete — folder ops emit per-note note_changed
+	// too), and it previously had ZERO invalidation sites, so a new/renamed note
+	// stayed missing from autocomplete until an incidental refetch.
+	queryClient.invalidateQueries({ queryKey: ["syncManifest", vaultId] });
 
 	// The by-id keys are keyed on folder-marker ids; resolve names through
 	// the cached tree. Unknown folders (just created, tree not refetched
@@ -234,6 +240,9 @@ export function backfillStructural(queryClient: QueryClient, vaultId: string): v
 	queryClient.invalidateQueries({ queryKey: ["folders", vaultId] });
 	queryClient.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 	queryClient.invalidateQueries({ queryKey: ["attachments", vaultId] });
+	// The wikilink path inventory misses events during the gap like everything
+	// else — stale it so autocomplete/wiki resolution converge on wake too.
+	queryClient.invalidateQueries({ queryKey: ["syncManifest", vaultId] });
 	// The sidebar tree renders note rows from the id-keyed family, not the
 	// name-keyed ["folderNotes"] above (that feeds the dashboard). Its expanded
 	// subfolders have no mounted observer, so a default ("active") invalidate

--- a/frontend/src/api/sync-manifest-invalidation.test.tsx
+++ b/frontend/src/api/sync-manifest-invalidation.test.tsx
@@ -1,0 +1,90 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetNoteChangeBatch, handleNoteChanged } from "./channel";
+import { useSyncManifest } from "./queries";
+
+// Real cache wiring: a real QueryClient + the real channel handler + the real
+// useSyncManifest hook. Only the HTTP layer and the active-vault id are mocked.
+// This is the staleness bug's exact seam — ["syncManifest", vaultId] had zero
+// invalidation sites, so a note created/renamed mid-session never reached the
+// [[ autocomplete list (note-page.tsx derives it as manifest.notes.map(path))
+// until an incidental remount/refocus refetched it.
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("./client", async () => {
+	const actual = await vi.importActual<typeof import("./client")>("./client");
+	return { ...actual, api: { get, post: vi.fn(), patch: vi.fn(), del: vi.fn() } };
+});
+
+vi.mock("./active-vault", async () => {
+	const actual = await vi.importActual<typeof import("./active-vault")>("./active-vault");
+	return { ...actual, useActiveVaultId: () => "42" };
+});
+
+// The [[ autocomplete candidate list, exactly as note-page.tsx derives it.
+function useCompletionPaths(): string[] {
+	const { data: manifest } = useSyncManifest();
+	return manifest?.notes.map((n) => n.path) ?? [];
+}
+
+let qc: QueryClient;
+let wrapper: React.FC<{ children: React.ReactNode }>;
+
+beforeEach(() => {
+	get.mockReset();
+	qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	wrapper = ({ children }) => <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+});
+
+afterEach(() => {
+	__resetNoteChangeBatch();
+	qc.clear();
+});
+
+describe("sync manifest staleness (issue: [[ autocomplete misses new notes)", () => {
+	it("a newly created note appears in the completion paths without remount/refocus", async () => {
+		get.mockResolvedValue({ notes: [{ id: "n1", path: "a.md" }] });
+		const { result } = renderHook(() => useCompletionPaths(), { wrapper });
+		await waitFor(() => expect(result.current).toEqual(["a.md"]));
+
+		// The server-side create lands (local echo or another device) — the sync
+		// channel delivers note_changed; the NEXT manifest fetch includes the note.
+		get.mockResolvedValue({
+			notes: [
+				{ id: "n1", path: "a.md" },
+				{ id: "n2", path: "new-note.md" },
+			],
+		});
+		act(() => {
+			handleNoteChanged(
+				{ event_type: "upsert", path: "new-note.md", id: "n2", vault_id: "42" },
+				qc,
+				"42",
+			);
+		});
+
+		// No remount, no refocus — the invalidation alone must refetch (the
+		// coalescing window is 250ms; waitFor spans it).
+		await waitFor(() => expect(result.current).toContain("new-note.md"));
+	});
+
+	it("a rename updates the completion paths without remount/refocus", async () => {
+		get.mockResolvedValue({ notes: [{ id: "n1", path: "old.md" }] });
+		const { result } = renderHook(() => useCompletionPaths(), { wrapper });
+		await waitFor(() => expect(result.current).toEqual(["old.md"]));
+
+		get.mockResolvedValue({ notes: [{ id: "n1", path: "new.md" }] });
+		act(() => {
+			handleNoteChanged(
+				{ event_type: "upsert", path: "new.md", id: "n1", vault_id: "42" },
+				qc,
+				"42",
+			);
+		});
+
+		await waitFor(() => expect(result.current).toEqual(["new.md"]));
+	});
+});


### PR DESCRIPTION
The vault-wide path→id inventory behind `[[` autocomplete and `/:slug/wiki/*` resolution (`useSyncManifest`) had ZERO invalidation sites — a newly created or renamed note stayed missing from the completion list until an incidental refetch (remount/refocus past the 30s staleTime). Found in dev testing.

Fix is event-driven (no timers): two central hooks in `channel.ts` — the coalesced `flushBatch` (every inventory-changing note event arrives there, including local mutations via their own channel echo — verified against `crdt_deliver.ex` and the folder ops' per-note deferred broadcasts) and `backfillStructural` (reconnect/wake gap catch-up). One manifest refetch per 250ms event burst. Consumers untouched: note-page's ref-based completion callback keeps its stable identity; the redirect route still self-fetches standalone.

Considered and rejected: consolidating onto the tree's cache (per-folder, populated on expand — can't serve the vault-wide standalone resolver).

Tests: red-first — handler-level invalidation pins for both hooks, plus real-QueryClient wiring tests (create appears / rename updates the completion list without remount); 74 tests across touched areas, tsc + biome clean.

Known bound (documented): new-note visibility depends on the server echo — sub-second in practice, not optimistic-instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqgVPyDtDbXmTqm4PkTioK