### PR TITLE
fix(web): resolve wikilinks via the manifest before the /wiki fallback

### DIFF
--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -437,7 +437,12 @@ export default function NotePage() {
 						// the title sits the same distance above the body in reading mode
 						// as it does in the editor.
 						<div className="px-5 pt-5">
-							<NoteView content={liveContent} tags={note.tags} links={note.links} />
+							<NoteView
+								content={liveContent}
+								tags={note.tags}
+								links={note.links}
+								manifestNotes={manifest?.notes}
+							/>
 						</div>
 					) : (
 						<Suspense fallback={<p className="px-5 py-5 text-muted-foreground">Loading editor…</p>}>

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -94,10 +94,16 @@ export default function NotePage() {
 	// resolved link routes straight to the note id instead of through the
 	// lazy /:slug/wiki/* resolver.
 	const wikiMap = useMemo(() => buildWikiMap(note?.links), [note?.links]);
+	// Manifest layer for wikiHref, read through a ref (same identity-stability
+	// reasoning as manifestPathsRef below): edges lag behind fresh links, the
+	// manifest resolves them without the /wiki redirect flash, and a manifest
+	// refetch must not change these callbacks' identity.
+	const wikiManifestRef = useRef<{ id: string; path: string }[]>([]);
+	wikiManifestRef.current = manifest?.notes ?? [];
 	// useCallback keeps a stable identity so passing it to NoteEditor doesn't
 	// re-fire the decorationsCompartment reconfigure effect on every render.
 	const resolveWikiLink = useCallback(
-		(permalink: string) => wikiHref(permalink, slug, wikiMap),
+		(permalink: string) => wikiHref(permalink, slug, wikiMap, wikiManifestRef.current),
 		[slug, wikiMap],
 	);
 	// Editor-mode click-to-open. Router nav must come from the React tree —
@@ -105,7 +111,7 @@ export default function NotePage() {
 	// router singleton itself.
 	const openWikiLink = useCallback(
 		(permalink: string) => {
-			const href = wikiHref(permalink, slug, wikiMap);
+			const href = wikiHref(permalink, slug, wikiMap, wikiManifestRef.current);
 			if (href.startsWith("/")) {
 				navigate(href);
 			} else if (href.startsWith("#")) {

--- a/frontend/src/viewer/note-view.test.tsx
+++ b/frontend/src/viewer/note-view.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import NoteView from "./note-view";
-import type { NoteLinkEdge } from "./wiki-link";
+import type { ManifestNote, NoteLinkEdge } from "./wiki-link";
 
 let mockTier: "free" | "starter" | "pro" | "trial" | "none" = "free";
 // SaaS by default; self-host flips false (no billing → attachments ungated).
@@ -50,14 +50,16 @@ function LocationProbe() {
 }
 
 // NoteView reads the vault slug from the route to build wikilink hrefs.
-function renderNote(content: string, links?: NoteLinkEdge[]) {
+function renderNote(content: string, links?: NoteLinkEdge[], manifestNotes?: ManifestNote[]) {
 	return render(
 		<MemoryRouter initialEntries={["/work/n-1"]}>
 			<LocationProbe />
 			<Routes>
 				<Route
 					path="/:slug/:itemId"
-					element={<NoteView content={content} tags={[]} links={links} />}
+					element={
+						<NoteView content={content} tags={[]} links={links} manifestNotes={manifestNotes} />
+					}
 				/>
 			</Routes>
 		</MemoryRouter>,
@@ -104,6 +106,12 @@ describe("NoteView wikilinks", () => {
 		]);
 		const link = screen.getByRole("link", { name: "My Note" });
 		expect(link).toHaveAttribute("href", "/work/n-1");
+	});
+
+	it("resolves a manifest-only target to the direct id href", () => {
+		renderNote("See [[Fresh Note]].", [], [{ id: "m-9", path: "Sub/Fresh Note.md" }]);
+		const link = screen.getByRole("link", { name: "Fresh Note" });
+		expect(link).toHaveAttribute("href", "/work/m-9");
 	});
 });
 

--- a/frontend/src/viewer/note-view.tsx
+++ b/frontend/src/viewer/note-view.tsx
@@ -16,7 +16,7 @@ import { useIsFreeTier } from "../billing/use-is-free-tier";
 import { AttachmentFallback } from "./attachment-fallback";
 import AttachmentImg from "./attachment-img";
 import MermaidBlock from "./mermaid-block";
-import { buildWikiMap, type NoteLinkEdge, wikiHref } from "./wiki-link";
+import { buildWikiMap, type ManifestNote, type NoteLinkEdge, wikiHref } from "./wiki-link";
 
 interface NoteViewProps {
 	content: string;
@@ -25,6 +25,11 @@ interface NoteViewProps {
 	// outside a note context and has no links to resolve — wikilinks there
 	// fall back to the lazy /:slug/wiki/* route same as before this prop existed.
 	links?: NoteLinkEdge[];
+	// Optional second resolution layer (see wikiHref): the sync manifest covers
+	// freshly typed links whose server-indexed edge isn't in `links` yet.
+	// NotePage threads its already-subscribed useSyncManifest data; the
+	// reference panel omits it (no vault context to resolve against anyway).
+	manifestNotes?: ManifestNote[];
 }
 
 // Sentinel marks images rewritten from Obsidian `![[X]]` embed syntax. The
@@ -41,7 +46,11 @@ function rewriteEmbeds(raw: string): string {
 // Slug-parameterized: wikilinks route through the vault-scoped resolver
 // (`/:slug/wiki/*`, see wiki-link.ts). pageResolver is identity — the default
 // would mangle names (`My Note` → `my_note`) before the resolver ever saw them.
-const remarkPluginsFor = (slug: string | undefined, map: Map<string, NoteLinkEdge>) =>
+const remarkPluginsFor = (
+	slug: string | undefined,
+	map: Map<string, NoteLinkEdge>,
+	manifestNotes?: ManifestNote[],
+) =>
 	[
 		remarkGfm,
 		remarkMath,
@@ -50,7 +59,7 @@ const remarkPluginsFor = (slug: string | undefined, map: Map<string, NoteLinkEdg
 			remarkWikiLink,
 			{
 				pageResolver: (name: string) => [name],
-				hrefTemplate: (permalink: string) => wikiHref(permalink, slug, map),
+				hrefTemplate: (permalink: string) => wikiHref(permalink, slug, map, manifestNotes),
 				aliasDivider: "|",
 			},
 		],
@@ -74,11 +83,17 @@ const TEXT_EMBED = /\.(?:md|canvas)$/iu;
 // the preview stays force-mounted with identical props; react-markdown has
 // no internal memoization, so an unmemoized NoteView re-ran the full
 // remark/rehype pipeline (gfm + KaTeX + highlight) per keystroke.
-function NoteView({ content, tags, links }: NoteViewProps) {
+function NoteView({ content, tags, links, manifestNotes }: NoteViewProps) {
 	const isFreeTier = useIsFreeTier();
 	const { slug } = useParams();
 	const wikiMap = useMemo(() => buildWikiMap(links), [links]);
-	const remarkPlugins = useMemo(() => remarkPluginsFor(slug, wikiMap), [slug, wikiMap]);
+	// TanStack's structural sharing keeps manifestNotes referentially stable
+	// across no-change refetches, so this memo (and the memo(NoteView) above
+	// it) only re-runs when the manifest actually changed.
+	const remarkPlugins = useMemo(
+		() => remarkPluginsFor(slug, wikiMap, manifestNotes),
+		[slug, wikiMap, manifestNotes],
+	);
 	const body = useMemo(() => {
 		try {
 			return rewriteEmbeds(matter(content).content);

--- a/frontend/src/viewer/wiki-link.test.ts
+++ b/frontend/src/viewer/wiki-link.test.ts
@@ -158,3 +158,46 @@ describe("wikiHref with resolver map", () => {
 		expect(wikiHref("My Note", "v")).toBe("/v/wiki/My%20Note");
 	});
 });
+
+describe("wikiHref layered manifest fallback", () => {
+	const map = buildWikiMap([
+		{
+			target_text: "My Note",
+			target_note_id: "edge-id",
+			target_attachment_id: null,
+			target_path: "a/My Note.md",
+			alias: null,
+			anchor: null,
+			link_type: "wikilink",
+			dangling: false,
+		},
+	]);
+	const notes = [
+		{ id: "manifest-id", path: "b/My Note.md" },
+		{ id: "fresh-id", path: "Fresh/Renamed Note.md" },
+	];
+
+	test("edge-map hit wins over a manifest match", () => {
+		expect(wikiHref("My Note", "v", map, notes)).toBe("/v/edge-id");
+	});
+
+	test("manifest-only target links straight to the note id", () => {
+		expect(wikiHref("Renamed Note", "v", map, notes)).toBe("/v/fresh-id");
+	});
+
+	test("unknown in both falls back to the wiki resolver route", () => {
+		expect(wikiHref("Brand New", "v", map, notes)).toBe("/v/wiki/Brand%20New");
+	});
+
+	test("heading hash preserved on edge-map hit", () => {
+		expect(wikiHref("My Note#A Heading", "v", map, notes)).toBe("/v/edge-id#a-heading");
+	});
+
+	test("heading hash preserved on manifest hit", () => {
+		expect(wikiHref("Renamed Note#A Heading", "v", map, notes)).toBe("/v/fresh-id#a-heading");
+	});
+
+	test("heading hash preserved on wiki fallback", () => {
+		expect(wikiHref("Brand New#A Heading", "v", map, notes)).toBe("/v/wiki/Brand%20New#a-heading");
+	});
+});

--- a/frontend/src/viewer/wiki-link.ts
+++ b/frontend/src/viewer/wiki-link.ts
@@ -81,13 +81,17 @@ export function wikiCreatePath(raw: string): { folder: string; name: string } {
 }
 
 // No slug = rendered outside a vault route (markdown reference panel) —
-// nothing to resolve against, so the anchor stays inert. A resolved entry in
-// `map` (from buildWikiMap) short-circuits straight to the note id instead of
-// the lazy /:slug/wiki/* redirect; anything unresolved keeps that fallback.
+// nothing to resolve against, so the anchor stays inert. Layered resolution:
+// (1) a resolved entry in `map` (from buildWikiMap, server-indexed edges)
+// short-circuits straight to the note id; (2) a miss there tries the sync
+// manifest (client cache — covers freshly typed links whose edge isn't
+// indexed yet); (3) only then the lazy /:slug/wiki/* redirect, kept for deep
+// links and the create-affordance on truly nonexistent targets.
 export function wikiHref(
 	raw: string,
 	slug: string | undefined,
 	map?: Map<string, NoteLinkEdge>,
+	manifestNotes?: ManifestNote[],
 ): string {
 	const { page, hash } = parseWikiTarget(raw);
 	if (!page) {
@@ -99,6 +103,10 @@ export function wikiHref(
 	const resolved = map?.get(page.toLowerCase());
 	if (resolved?.target_note_id) {
 		return `/${slug}/${resolved.target_note_id}${hash}`;
+	}
+	const fromManifest = manifestNotes ? resolveWikiTarget(page, manifestNotes) : null;
+	if (fromManifest) {
+		return `/${slug}/${fromManifest.id}${hash}`;
 	}
 	const encoded = page.split("/").map(encodeURIComponent).join("/");
 	return `/${slug}/wiki/${encoded}${hash}`;


### PR DESCRIPTION
User-visible bug from dev testing: link a freshly renamed/created note before its edge is server-indexed and clicking flashes through `/:slug/wiki/<name>` before forwarding. The client had the answer all along — the sync manifest (fresh since #1269) knew the note; only the edge map (async indexing) didn't.

Resolution is now layered at href-generation/click time in BOTH modes: edge map → `resolveWikiTarget` against the cached manifest → `/wiki` fallback. The `/wiki` route keeps its two legitimate jobs (external deep links, the create-affordance for nonexistent targets) but is never emitted for a note that exists.

- `wikiHref` gains an optional `manifestNotes` layer (pure module, hash handling untouched)
- Editor path: note-page reads the manifest through the same ref pattern as `manifestPathsRef` — callback identities unchanged (editor-rebuild hazard respected)
- Reading mode: NoteView takes an optional `manifestNotes` prop threaded from note-page; the reference-panel mount stays inert by design. No rebuild hazard there — the remark pipeline correctly keys on manifest identity, and TanStack structural sharing keeps it stable across no-change refetches (comment records this)

Tests: red-first — 6 resolution-order cases (edge-map precedence, manifest-only → direct id, unknown → /wiki, hash preserved in each) + a reading-mode integration case that failed as `/work/wiki/Fresh%20Note` pre-fix; 128 tests across touched suites, tsc + biome clean. A browser-level e2e (click through, assert no /wiki in the URL) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqgVPyDtDbXmTqm4PkTioK