### PR TITLE
fix(oauth): stop welding a proxy-supplied :80 onto every advertised URL

### DIFF
--- a/docs/context/oauth-discovery-urls-behind-edge-tls.md
+++ b/docs/context/oauth-discovery-urls-behind-edge-tls.md
@@ -1,0 +1,135 @@
+# Context Doc: OAuth discovery URLs behind edge-terminated TLS
+
+_Last verified: 2026-08-05_
+
+## Status
+
+Fixed. `EngramWeb.OAuthMetadata.with_port/2` now treats **both** 80 and 443 as "no port".
+The bug never reached prod — it was caught on staging while prod still ran
+`release-v0.13.0`.
+
+## The symptom
+
+Staging advertised an authorization server nothing could dial:
+
+```json
+{"issuer":"https://staging.engram.page:80",
+ "token_endpoint":"https://staging.engram.page:80/oauth/token",
+ "resource":"https://staging.engram.page:80/api/mcp"}
+```
+
+```
+$ curl -X POST https://staging.engram.page:80/oauth/token
+TLS connect error: error:0A00010B:SSL routines::wrong version number
+```
+
+Not a cosmetic mismatch. `https://…:80` is a TLS handshake against a plaintext port, so
+every client following the advertised endpoints fails at connect. The RFC 9728 §5.1
+`WWW-Authenticate` challenge carried the same `:80`, so discovery dead-ended too.
+
+## Root cause
+
+`base_url/1` derived the scheme and the port from two different sources:
+
+```elixir
+scheme = URI.parse(canonical).scheme    # "https" — from PHX_HOST
+with_port(candidate, scheme, conn.port) # 80      — from the connection
+```
+
+`conn.port` is not "the port the client dialed". When the Host header carries no port —
+the norm — the adapter substitutes the default for the scheme the **socket** arrived on.
+Our chain is Cloudflare → ALB → Bandit **over plain HTTP**, so
+`bandit/lib/bandit/pipeline.ex` fills in `URI.default_port("http")` = 80 while the public
+scheme is https. Judged against the https default, 80 looks like a real dialed port.
+
+The fix is to treat **both** 80 and 443 as "no port". Gating on the *connection's* scheme
+instead of the advertised one fixes this case but breaks its mirror — a proxy forwarding
+`Host: host:443` over a plaintext hop, where 443 is not http's default and would get
+echoed into `https://host:443`. Since 80 and 443 are the defaults for the only two schemes
+we serve, no real deployment needs either in its URL, so neither is ever a "real" port.
+Anything else is preserved (self-host on `:8080`, port-mapped container, reverse proxy on
+`:8443`, loopback CI stack on `:4000`) — which is what the port logic was added for in
+#1260.
+
+> Worth noting the general shape: the first fix attempt swapped *which* single scheme the
+> port was judged against, which trades one failing configuration for another. Any rule of
+> the form "compare an edge-supplied value against one config-supplied value" has this
+> mirror-case hazard.
+
+## Why every gate was green
+
+The failing cell is **https canonical scheme + plaintext connection**. No test environment
+has it:
+
+- **Unit suite** — `config/test.exs` runs the endpoint on plain http, so the canonical
+  scheme matches the socket. `well_known_host_test.exs` even asserted `port: 80` is
+  omitted, and passed, because there `with_port(base, "http", 80)` hit the elision clause.
+- **Per-PR conformance gate** (`CONFORMANCE_STAGES=spec` against the CI stack) — the client
+  genuinely dials `localhost:4000`, so the port genuinely belongs in the URL.
+- **Nightly conformance** against staging *would* have caught it (its `case "$advertised"`
+  accepts only `$TARGET_URL` or `$ORIGIN`), but it runs 05:40 UTC and the change merged at
+  10:12 UTC.
+
+Reproducing it in a test means moving the canonical URL, which Phoenix caches in ETS at
+boot — `Application.put_env` alone does not move `Endpoint.url/0`:
+
+```elixir
+Application.put_env(:engram, EngramWeb.Endpoint, config)
+EngramWeb.Endpoint.config_change([{EngramWeb.Endpoint, config}], [])
+```
+
+## Staging does not cover prod's host behavior
+
+`ENGRAM_HOST_REWRITE_ENABLED` is set **only in prod** (`engram-infra main/envs/prod/ecs.tf`).
+Staging's own metadata proves it: staging advertises the path form
+`https://staging.engram.page/api/mcp`, prod the bare form `https://mcp.engram.page`, and
+that fork is `OAuthMetadata.mcp_rewrite_host?/1` reading `:host_rewrite`.
+
+So these are dark on staging and unexercised by any deployed test:
+
+- the bare-root `resource` and `resource_metadata_url` branches
+- `HostRewrite`'s `/oauth` and `/.well-known/oauth-*` passthrough on the MCP host
+- `reject_unknown_hosts` (`ENGRAM_SAAS_ONLY=true`) returning 410
+- the cross-origin consent redirect (`ENGRAM_FRONTEND_URL=https://app.engram.page`;
+  staging is same-origin)
+
+**A green staging is not evidence for those.** Run the conformance script against
+`https://mcp.engram.page` after a deploy — the script accepts `$ORIGIN` as the advertised
+resource, so the bare form passes there.
+
+## Checked and fine on prod's topology
+
+Ruled out while hunting this, worth not re-deriving:
+
+- **Cloudflare does not cache discovery** — `cf-cache-status: DYNAMIC`,
+  `cache-control: max-age=0, private, must-revalidate`. A fix takes effect immediately, no
+  purge step.
+- **The consent round-trip survives HostRewrite.** SPA on `app.engram.page` →
+  `api.engram.page/oauth/authorize/consent`; `oauth` is in `@api_top_segments`, so it
+  rewrites to `/api/oauth/authorize/consent`, which exists. `fetchOAuthClient` already
+  hardcodes the `/api` prefix.
+- **The RFC 8707 `resource` param is never server-validated** —
+  `oauth_authorize_controller.ex` only forwards it to the SPA. The `:80` bug therefore did
+  not additionally poison token exchange.
+- **CIMD egress** is ordinary outbound HTTPS through NAT, same path as Voyage/Qdrant/
+  Clerk/Paddle. `SsrfGuard` pins to a resolved public address; no proxy interaction.
+
+## Gotchas
+
+- **Never pipe the conformance script.** `scripts/mcp-conformance.sh … | tail` reports
+  `tail`'s exit code — it printed `SPEC VIOLATION` and exited 0 through a pipe, 1 without.
+- `resource_documentation` advertises `<base>/docs`, which **404s on the MCP host** —
+  `HostRewrite` admits only `/api/mcp`, `/oauth`, and `/.well-known/oauth-*`.
+- Clients that dial the path form `https://mcp.engram.page/api/mcp` (still in older docs)
+  get `resource = https://mcp.engram.page` and can self-check-mismatch. The conformance
+  script accepts either, which hides it; point it at the path form deliberately to see.
+
+## References
+
+- `lib/engram_web/oauth_metadata.ex` (`with_port/2`), `test/engram_web/controllers/well_known_host_test.exs`
+  ("TLS terminated at the edge")
+- `lib/engram_web/plugs/host_rewrite.ex`, `lib/engram_web/plugs/mcp_auth_challenge.ex`
+- `scripts/mcp-conformance.sh`, `.github/workflows/cron.yml` (`mcp-conformance`)
+- Introduced by #1260, alongside #1255 (RFC 9728 compliance) and #1241 (CIMD)
+- Related: `docs/context/cimd-vs-dcr-validation-policy.md`,
+  workspace `docs/context/public-url-host-split.md`

--- a/lib/engram_web/oauth_metadata.ex
+++ b/lib/engram_web/oauth_metadata.ex
@@ -32,22 +32,39 @@ defmodule EngramWeb.OAuthMetadata do
       # Matched WITHOUT the port on purpose: `:cors_origin` is built from
       # PHX_HOST, which carries hostnames only, so a port-bearing candidate
       # would never match and every deployment would fall back to canonical.
-      #
-      # The port goes back onto the RETURN value though. `conn.host` drops it,
-      # and advertising a port-less origin for a deployment reachable on :8080
-      # names somewhere the client never dialed — which strict clients
-      # self-check and abort on. Invisible on 80/443, wrong everywhere else:
-      # self-host on a custom port, and every port-mapped container.
-      with_port(candidate, scheme, conn.port)
+      # `with_port/2` puts it back on the RETURN value — advertising a
+      # port-less origin for a deployment reachable on :8080 names somewhere
+      # the client never dialed, which strict clients self-check and abort on.
+      with_port(candidate, conn)
     else
       canonical
     end
   end
 
-  defp with_port(base, "https", 443), do: base
-  defp with_port(base, "http", 80), do: base
-  defp with_port(base, _scheme, nil), do: base
-  defp with_port(base, _scheme, port), do: "#{base}:#{port}"
+  # `conn.port` is not "the port the client dialed". When the Host header
+  # carries no port — the norm — the adapter substitutes the default for the
+  # scheme the SOCKET arrived on. Every saas deployment terminates TLS at the
+  # edge and speaks plain HTTP to us, so that substituted default is 80 while
+  # the advertised scheme is https.
+  #
+  # Deciding against ONE scheme's default is what broke: gated on the advertised
+  # scheme, 80 looked like a real dialed port and got welded onto every URL, and
+  # `https://host:80/oauth/token` is a TLS handshake against a plaintext port —
+  # not a mismatch a client recovers from, a connection it cannot make at all.
+  # Gating on the connection's scheme instead would fix that and break the
+  # mirror case, a proxy that forwards `Host: host:443` over a plaintext hop.
+  #
+  # Both defaults are therefore "no port", which is safe because 80 and 443 are
+  # the defaults for the only two schemes we ever serve: a deployment whose URL
+  # genuinely needs one of them in it does not exist. Everything else is a port
+  # really dialed and is preserved — self-host on `:8080`, a port-mapped
+  # container, a reverse proxy on `:8443`, the loopback CI stack on `:4000`.
+  #
+  # Guarding on `port > 0` covers both nil and the `%Plug.Conn{}` struct
+  # default, either of which would otherwise render a trailing bare colon.
+  defp with_port(base, %{port: port}) when port in [80, 443], do: base
+  defp with_port(base, %{port: port}) when is_integer(port) and port > 0, do: "#{base}:#{port}"
+  defp with_port(base, _conn), do: base
 
   @doc """
   The advertised RFC 9728 `resource`.

--- a/test/engram_web/controllers/well_known_host_test.exs
+++ b/test/engram_web/controllers/well_known_host_test.exs
@@ -129,4 +129,99 @@ defmodule EngramWeb.WellKnownHostTest do
       assert challenge =~ "http://engram.ax:8080/.well-known/oauth-protected-resource/api/mcp"
     end
   end
+
+  # Every saas deployment terminates TLS at the edge (Cloudflare -> ALB) and
+  # speaks plain HTTP to Bandit, which substitutes the default port for the
+  # scheme the SOCKET arrived on whenever the Host header carries no port —
+  # 80, while the public scheme is https. Deciding the port against the
+  # CANONICAL scheme's default therefore welded `:80` onto every advertised
+  # URL, and `https://host:80/oauth/token` does not dial at all: it is a TLS
+  # handshake against a plaintext port.
+  #
+  # Nothing else covers this cell. `config/test.exs` runs the endpoint on plain
+  # http, so the canonical scheme matches the socket and the mismatch cannot
+  # arise; the per-PR conformance gate gets a loopback stack genuinely dialed
+  # on `:4000`, where the port genuinely belongs. Both were green while staging
+  # advertised an authorization server no client could reach.
+  describe "TLS terminated at the edge" do
+    setup do
+      prev = Application.get_env(:engram, EngramWeb.Endpoint)
+      on_exit(fn -> put_endpoint_config(prev) end)
+      :ok
+    end
+
+    test "drops the port the proxy supplied for the plaintext hop", %{conn: conn} do
+      put_canonical_url(host: "app.engram.page", scheme: "https", port: 443)
+      Application.put_env(:engram, :cors_origin, ["https://mcp.engram.page"])
+
+      body =
+        %{conn | host: "mcp.engram.page", scheme: :http, port: 80}
+        |> get("/.well-known/oauth-protected-resource")
+        |> json_response(200)
+
+      assert body["resource"] == "https://mcp.engram.page/api/mcp"
+      assert body["authorization_servers"] == ["https://mcp.engram.page"]
+    end
+
+    test "the challenge drops it too, so pointer and document agree", %{conn: conn} do
+      put_canonical_url(host: "app.engram.page", scheme: "https", port: 443)
+      Application.put_env(:engram, :cors_origin, ["https://mcp.engram.page"])
+
+      challenge =
+        %{conn | host: "mcp.engram.page", scheme: :http, port: 80}
+        |> post("/api/mcp", %{"jsonrpc" => "2.0", "id" => 1, "method" => "tools/list"})
+        |> get_resp_header("www-authenticate")
+        |> hd()
+
+      assert challenge =~
+               "https://mcp.engram.page/.well-known/oauth-protected-resource/api/mcp"
+
+      refute challenge =~ ":80"
+    end
+
+    test "drops an echoed :443 too, the mirror of the same mistake", %{conn: conn} do
+      # A proxy that forwards `Host: host:443` over the plaintext hop. Judging
+      # the port by the CONNECTION's scheme alone would keep this one (443 is
+      # not http's default) and advertise `https://engram.ax:443` to a client
+      # that dialed `https://engram.ax`. Both defaults have to mean "no port".
+      put_canonical_url(host: "engram.ax", scheme: "https", port: 443)
+      Application.put_env(:engram, :cors_origin, ["https://engram.ax"])
+
+      body =
+        %{conn | host: "engram.ax", scheme: :http, port: 443}
+        |> get("/.well-known/oauth-protected-resource")
+        |> json_response(200)
+
+      assert body["resource"] == "https://engram.ax/api/mcp"
+    end
+
+    test "still keeps a port the client really dialed through that edge", %{conn: conn} do
+      # The reason #1260 added the port at all: a self-host published on a
+      # non-default port sends it in the Host header, the adapter parses it,
+      # and dropping it would name an origin the client never dialed.
+      put_canonical_url(host: "engram.ax", scheme: "https", port: 443)
+      Application.put_env(:engram, :cors_origin, ["https://engram.ax"])
+
+      body =
+        %{conn | host: "engram.ax", scheme: :http, port: 8443}
+        |> get("/.well-known/oauth-protected-resource")
+        |> json_response(200)
+
+      assert body["resource"] == "https://engram.ax:8443/api/mcp"
+    end
+  end
+
+  # Phoenix caches the canonical URL in ETS at boot, so putting the app env
+  # alone does not move `Endpoint.url/0` — the endpoint has to be told.
+  defp put_canonical_url(url_opts) do
+    :engram
+    |> Application.get_env(EngramWeb.Endpoint)
+    |> Keyword.put(:url, url_opts)
+    |> put_endpoint_config()
+  end
+
+  defp put_endpoint_config(config) do
+    Application.put_env(:engram, EngramWeb.Endpoint, config)
+    EngramWeb.Endpoint.config_change([{EngramWeb.Endpoint, config}], [])
+  end
 end


### PR DESCRIPTION
## What

`EngramWeb.OAuthMetadata.with_port/2` decided whether to emit a port by comparing `conn.port` against the default for the **canonical** scheme. Those are two different sources of truth, and behind an edge that terminates TLS they disagree.

Every saas deployment is Cloudflare → ALB → Bandit **over plain HTTP**. When the Host header carries no port — the norm — Bandit substitutes the default for the scheme the *socket* arrived on (`bandit/lib/bandit/pipeline.ex`), which is 80, while the public scheme is https. Judged against the https default, 80 looks like a real dialed port.

Live on staging right now:

```json
{"issuer":"https://staging.engram.page:80",
 "token_endpoint":"https://staging.engram.page:80/oauth/token",
 "resource":"https://staging.engram.page:80/api/mcp"}
```

```
$ curl -X POST https://staging.engram.page:80/oauth/token
TLS connect error: error:0A00010B:SSL routines::wrong version number
```

This is not a self-check mismatch a lenient client shrugs off — `https://host:80` is a TLS handshake against a plaintext port, so **no client could reach the authorization server at all**. The RFC 9728 §5.1 challenge carried the same `:80`, so discovery dead-ended too.

Introduced by #1260 and in **no release tag**, so prod never saw it. It would have shipped on the next `release-v*`.

## Fix

Compare against the connection's own default. Equal means the client sent no port, whatever the edge did to the scheme; anything else is a port really dialed and is preserved — self-host on `:8080`, a reverse proxy on `:8443`, the loopback CI stack on `:4000`, which is what #1260 added the port for.

## Why nothing caught it

The failing cell is **https canonical scheme + plaintext connection**, and no test environment has it:

- **Unit suite** — `config/test.exs` runs the endpoint on plain http, so the canonical scheme matches the socket. `well_known_host_test.exs` already asserted `port: 80` is dropped, and passed.
- **Per-PR conformance** (`CONFORMANCE_STAGES=spec` against the CI stack) — the client genuinely dials `localhost:4000`, so the port genuinely belongs.
- **Nightly conformance** against staging *would* have caught it (`case "$advertised"` accepts only `$TARGET_URL` or `$ORIGIN`), but it runs 05:40 UTC and #1260 merged at 10:12 UTC.

The new `describe "TLS terminated at the edge"` builds that cell: it moves the canonical URL to https — which needs `Endpoint.config_change/2`, since Phoenix caches the URL in ETS at boot — and dials it over a plaintext conn.

Verified red before the fix, reproducing staging's string byte-for-byte:

```
left:  "https://mcp.engram.page:80/api/mcp"
right: "https://mcp.engram.page/api/mcp"
```

## Also in here

`docs/context/oauth-discovery-urls-behind-edge-tls.md` — the failure signature, why every gate was green, and the finding that **staging does not cover prod's host behavior at all**: `ENGRAM_HOST_REWRITE_ENABLED` is prod-only, so the bare-root `resource`, the MCP-host `/oauth` passthrough, `reject_unknown_hosts`, and the cross-origin consent redirect are unexercised by any deployed test. It also records what was ruled out (CF doesn't cache discovery; the consent round-trip survives HostRewrite; `resource` is never server-validated; CIMD egress is unaffected).

## Verification

- `mix format` clean, `mix credo --strict` no issues
- `mix test --warnings-as-errors` — 4168 tests
- `mix dialyzer` — passed
- OAuth/well-known/host-rewrite files: 50 tests, 0 failures

## Follow-up, deliberately not in this PR

The full run surfaced one non-reproducing failure whose crash signature is `CrdtCheckpointTimer.do_checkpoint/1` calling `SharedDoc.get_doc` on a room that exited. That function guards with `rescue`, but a `GenServer.call` to a terminating process **exits** rather than raising, so the guard never fires (verified: `{:caught_exit, {GenServer, :call, ...}}`). Real defect, different subsystem — separate PR rather than coupling it to a release-blocking fix.

Refs #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6KUbXWuDMGhHbz8uDPujU