### PR TITLE
fix(ci): CI_MINIO_ACCESS_KEY is a plain value, not a secret

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -98,6 +98,15 @@ env:
   # pull hex from the LAN instead of WAN. Signatures still verified client-side.
   HEX_MIRROR: "http://10.0.20.214:8090"
 
+  # MinIO username for the central FastRaid instance, scoped by policy to
+  # `ci-*` buckets (engram-infra: SOPS + main/github/secrets.tf). A PLAIN value,
+  # deliberately not a secret: it is also the CI image repository name
+  # (`${LOCAL_REGISTRY}/engram-ci:<hash>`), and GitHub redacts secret values out
+  # of job OUTPUTS by substring — as a secret it blanked ENGRAM_CI_IMAGE for
+  # every downstream e2e job, which then failed with `invalid reference format`.
+  # Only the paired CI_MINIO_SECRET_KEY is a secret.
+  CI_MINIO_ACCESS_KEY: "engram-ci"
+
   # CI-only encryption master key. Ephemeral — CI databases are recreated per run,
   # so the key does not protect persistent data. Production deploys must override
   # with a secret via `fly secrets set ENCRYPTION_MASTER_KEY=...`.
@@ -546,6 +555,13 @@ jobs:
         env:
           HASH: ${{ steps.tag.outputs.hash }}
           IMAGE: ${{ steps.tag.outputs.image }}
+          # `docker compose build` interpolates the WHOLE file before it builds
+          # anything, so the `:?` required-guards on the minio-init/engram
+          # runtime env abort a build that never reads those values (#1267 added
+          # the guards; this job was not given the secret alongside them). The
+          # guards are deliberate — supply the value rather than weakening them.
+          # The paired access key is workflow-level env, not a secret (see there).
+          CI_MINIO_SECRET_KEY: ${{ secrets.CI_MINIO_SECRET_KEY }}
           # Use buildx's plain progress writer instead of the fancy tty printer.
           # The latter races on `--load`/LoadImage: a progress goroutine writes
           # to a closed channel and panics *after* the image built fine, failing
@@ -965,7 +981,6 @@ jobs:
       # also carries staging's live attachments. The `ci-` prefix is
       # load-bearing: e2e teardown refuses to purge anything outside it.
       CI_MINIO_BUCKET: ci-${{ github.run_id }}-obsidian
-      CI_MINIO_ACCESS_KEY: ${{ secrets.CI_MINIO_ACCESS_KEY }}
       CI_MINIO_SECRET_KEY: ${{ secrets.CI_MINIO_SECRET_KEY }}
       MARKER_PREFIX: /tmp/ci-${{ github.run_id }}-obsidian
       E2E_VAULT_PREFIX: /tmp/e2e-vault-${{ github.run_id }}-obsidian
@@ -1580,7 +1595,6 @@ jobs:
       CI_PROJECT: engram-ci-crdt-${{ github.run_id }}
       QDRANT_COLLECTION: ci_crdt_${{ github.run_id }}
       CI_MINIO_BUCKET: ci-crdt-${{ github.run_id }}
-      CI_MINIO_ACCESS_KEY: ${{ secrets.CI_MINIO_ACCESS_KEY }}
       CI_MINIO_SECRET_KEY: ${{ secrets.CI_MINIO_SECRET_KEY }}
       MARKER_PREFIX: /tmp/ci-crdt-${{ github.run_id }}
       E2E_VAULT_PREFIX: /tmp/e2e-crdt-vault-${{ github.run_id }}
@@ -2112,7 +2126,6 @@ jobs:
       CI_PROJECT: engram-ci-headless-${{ github.run_id }}
       QDRANT_COLLECTION: ci_headless_${{ github.run_id }}
       CI_MINIO_BUCKET: ci-headless-${{ github.run_id }}
-      CI_MINIO_ACCESS_KEY: ${{ secrets.CI_MINIO_ACCESS_KEY }}
       CI_MINIO_SECRET_KEY: ${{ secrets.CI_MINIO_SECRET_KEY }}
       ENGRAM_CI_IMAGE: ${{ needs.prebuild-ci-image.outputs.image || needs.fingerprint.outputs.image }}
     steps:


### PR DESCRIPTION
## main is red

```
error while interpolating services.minio-init.environment.CI_MINIO_ACCESS_KEY:
required variable CI_MINIO_ACCESS_KEY is missing a value
```

`prebuild-ci-image` runs `docker compose -f ci/compose.yml build engram`. Compose interpolates the **entire** file before building anything, so the `:?` required-guards #1267 added to the `minio-init`/`engram` runtime env abort a build that never reads those values.

## Why no secret fixes it

`${{ secrets.CI_MINIO_ACCESS_KEY }}` resolved to empty in **all four** places `verify.yml` referenced it — because that secret does not exist, and must not.

engram-infra's SOPS+Terraform commit records the reasoning, learned the hard way:

> Only the SECRET key is managed here. The access key is the username `engram-ci` and stays a plain value in Engram's verify.yml: its value is also the CI image repository name (`${LOCAL_REGISTRY}/engram-ci:<hash>`), and GitHub redacts secret values from job OUTPUTS by substring — **as a secret it blanked `ENGRAM_CI_IMAGE` for every downstream e2e job and failed them with `invalid reference format`**.

So the access key is deliberately plain. Only `CI_MINIO_SECRET_KEY` is a secret, and it already exists (set 2026-08-05 20:37).

## Fix

- Set `CI_MINIO_ACCESS_KEY: "engram-ci"` once at workflow level, with the redaction rationale recorded inline so nobody "fixes" it back into a secret
- Drop the four per-job `${{ secrets.CI_MINIO_ACCESS_KEY }}` overrides that all resolved to empty
- Give `prebuild-ci-image` the `CI_MINIO_SECRET_KEY` half it was never given when #1267 landed

## Scope is wider than the prebuild job

`e2e-obsidian`, `e2e-crdt` and `headless-protocol` were passing an **empty** access key into their MinIO bucket create/reap steps. Same root cause, one layer further in — they would have failed on MinIO auth even after the prebuild job was unblocked.

## Why it did not break at the #1267 merge

`prebuild-ci-image` short-circuits when the image is already in the registry for that tree hash; the #1267 merge hit that path. The first run that actually had to rebuild is the one that surfaced it — `8b539e76` — and from there it is every PR touching `lib/`, `config/`, `frontend/`, `mix.exs` or the Dockerfile.

```
2026-08-05T22:05  8b539e76  failure   <- first rebuild after #1267
2026-08-05T21:52  636c4f9e  success
2026-08-05T21:14  28d50890  success   <- the #1267 merge
```

## Deliberately not done

**Not** defaulting the compose guards away. #1267 added them so a forgotten `CI_MINIO_BUCKET` cannot write into a shared bucket; softening a runtime protection to fix a build-time parse error is the wrong trade.

**Known wart left alone:** the retry loop reports this as `build attempt N failed (daemon reclaimed?)` and burns all three attempts in under a second, because a compose interpolation error is deterministic. That misattribution is what makes this read as an infra flake. Teaching it to separate config errors from daemon errors is a separate change.

## Verification

- `yaml.safe_load` parses; workflow-level `CI_MINIO_ACCESS_KEY` resolves to `engram-ci`
- This PR exercises the fixed path on its own run — same-repo PRs use the head branch's workflow, so a green `prebuild-ci-image` here *is* the test

Refs #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6KUbXWuDMGhHbz8uDPujU