### PR TITLE
fix(ci): drop my prebuild-ci-image MinIO override, #1272 already had it

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -581,16 +581,9 @@ jobs:
           # the job (issue #334, upstream docker/buildx bug). Plain writer = no
           # such goroutine.
           BUILDKIT_PROGRESS: plain
-          # `ci/compose.yml` declares these with the `:?` (required) form, which
-          # docker compose enforces while PARSING the file — so even
-          # `docker compose build engram`, which needs no object storage at all,
-          # dies on "required variable CI_MINIO_ACCESS_KEY is missing a value".
-          # #1267 added the requirement and wired the secrets into e2e-clerk,
-          # e2e-crdt and headless-protocol, but this job parses the same file
-          # and was missed. Any future job that touches ci/compose.yml needs
-          # them too, for parsing alone.
-          CI_MINIO_ACCESS_KEY: ${{ secrets.CI_MINIO_ACCESS_KEY }}
-          CI_MINIO_SECRET_KEY: ${{ secrets.CI_MINIO_SECRET_KEY }}
+          # CI_MINIO_* deliberately NOT set here. They come from the
+          # workflow-level env, where CI_MINIO_ACCESS_KEY is a literal on
+          # purpose (#1272) — see the comment on that block before touching it.
         run: |
           # Already published for this exact tree? Reuse — the registry is the
           # cross-host source of truth, so probe IT (not the local daemon, which


### PR DESCRIPTION
Reverts the env block added in #1277. **It is breaking `prebuild-ci-image` on every open PR right now.**

## What happened

#1277 and #1272 fixed the same problem in parallel. #1272 landed first and did it **correctly**, at workflow level, with `CI_MINIO_ACCESS_KEY` as a **literal** rather than a secret. Its comment explains why, and says exactly what not to do:

> GitHub redacts secret values from job OUTPUTS as well as logs, by substring. Once this was in scope for prebuild-ci-image, that job's `image` output was redacted away, ENGRAM_CI_IMAGE arrived empty in every downstream e2e job, and docker rejected the empty reference with `invalid reference format`.
>
> Only the secret key is a secret. **Do not "helpfully" promote this one back.**

#1277 then landed on top and did exactly that.

## Why it fails

Step-level `env:` wins over workflow-level. So `${{ secrets.CI_MINIO_ACCESS_KEY }}` shadowed the working literal `engram-ci` — and **that secret no longer exists**, deleted when #1272 made it a literal. It resolves to `""`, and empty fails compose's `:?` guard identically to unset:

```
error while interpolating services.engram.environment.STORAGE_ACCESS_KEY_ID:
required variable CI_MINIO_ACCESS_KEY is missing a value
##[error]CI image build failed after 3 attempts
```

`headless-protocol` and the rest then cascade on `manifest unknown: manifest unknown`, since no image was ever pushed.

## Why CI did not catch it

#1277 was **correct when written** — main had no workflow-level env at that point, which is why `prebuild-ci-image` was genuinely failing. It became wrong only when #1272 landed underneath it. #1277's own run passed because it predated the interaction. Green CI on a branch cannot detect that a *different* branch already fixed the same thing a better way.

Verified: `CI_MINIO_ACCESS_KEY` is absent from `gh secret list`; only `CI_MINIO_SECRET_KEY` remains.

Refs #1272, #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz