### PR TITLE
fix(admin): build invite and reset links from the canonical URL

### DIFF
--- a/lib/engram_web/controllers/admin/invite_controller.ex
+++ b/lib/engram_web/controllers/admin/invite_controller.ex
@@ -15,7 +15,7 @@ defmodule EngramWeb.Admin.InviteController do
       {:ok, {raw, invite}} ->
         conn
         |> put_status(:created)
-        |> json(%{token: raw, url: invite_url(conn, raw), invite: render_invite(invite)})
+        |> json(%{token: raw, url: invite_url(raw), invite: render_invite(invite)})
 
       {:error, _cs} ->
         conn |> put_status(422) |> json(%{error: "invalid_invite"})
@@ -44,8 +44,11 @@ defmodule EngramWeb.Admin.InviteController do
     }
   end
 
-  defp invite_url(conn, raw),
-    do: "#{conn.scheme}://#{conn.host}/sign-up?invite=#{raw}"
+  # Canonical URL, never the connection — see the admin password-reset link for
+  # the full reasoning. `conn.scheme` is :http behind an edge that terminates
+  # TLS, which would hand out a plaintext link carrying this live token, and
+  # `conn.host` may be a backend host that serves no SPA.
+  defp invite_url(raw), do: EngramWeb.Endpoint.url() <> "/sign-up?invite=#{raw}"
 
   defp parse_int(nil, default), do: default
   defp parse_int(v, _default) when is_integer(v), do: v

--- a/lib/engram_web/controllers/admin/user_controller.ex
+++ b/lib/engram_web/controllers/admin/user_controller.ex
@@ -50,7 +50,13 @@ defmodule EngramWeb.Admin.UserController do
       {:ok, {raw, _tok}} ->
         conn
         |> put_status(:created)
-        |> json(%{token: raw, url: "#{conn.scheme}://#{conn.host}/reset-password?token=#{raw}"})
+        # Canonical URL, never the connection. `conn.scheme` is :http on every
+        # saas deployment (TLS terminates at the edge), which would emit a
+        # plaintext link carrying this live token in its query string; and
+        # `conn.host` is whichever backend host the admin happened to reach —
+        # `api.engram.page` serves no SPA, so that link 404s too. Same source
+        # the device-flow `verification_url` and account emails already use.
+        |> json(%{token: raw, url: EngramWeb.Endpoint.url() <> "/reset-password?token=#{raw}"})
 
       {:error, _cs} ->
         conn |> put_status(422) |> json(%{error: "reset_issue_failed"})

--- a/test/engram_web/controllers/admin/invite_controller_test.exs
+++ b/test/engram_web/controllers/admin/invite_controller_test.exs
@@ -23,6 +23,22 @@ defmodule EngramWeb.Admin.InviteControllerTest do
     assert body["invite"]["max_uses"] == 3
   end
 
+  # Same reasoning as the admin password-reset link: an invite URL carries a
+  # live token and is handed to a human, so it must not inherit `conn.scheme`
+  # (:http behind an edge that terminates TLS) or `conn.host` (a backend host
+  # that may serve no SPA).
+  test "the invite link is absolute against the canonical URL, not the dialed host",
+       %{conn: conn, admin: admin} do
+    body =
+      %{conn | host: "api.engram.page", scheme: :http}
+      |> authenticate(admin)
+      |> post(~p"/api/admin/invites", %{label: "Mom"})
+      |> json_response(201)
+
+    assert body["url"] == EngramWeb.Endpoint.url() <> "/sign-up?invite=#{body["token"]}"
+    refute body["url"] =~ "api.engram.page"
+  end
+
   test "GET lists active invites without exposing tokens", %{conn: conn, admin: admin} do
     {:ok, _} = Engram.Invites.create_invite(admin, %{label: "x"})
     conn = conn |> authenticate(admin) |> get(~p"/api/admin/invites")

--- a/test/engram_web/controllers/admin/user_controller_test.exs
+++ b/test/engram_web/controllers/admin/user_controller_test.exs
@@ -61,4 +61,25 @@ defmodule EngramWeb.Admin.UserControllerTest do
     # Path must match the frontend route (`/reset-password`).
     assert body["url"] =~ ~r{/reset-password\?token=}
   end
+
+  # This link carries a live credential in its query string and gets handed to a
+  # human, so its ORIGIN matters as much as its path. Built from the connection,
+  # it inherited two things it should never have: `conn.scheme`, which is :http
+  # on every saas deployment because TLS terminates at the edge — emitting a
+  # plaintext link with the token in the URL — and `conn.host`, whichever
+  # backend host the admin's request happened to land on. `api.engram.page`
+  # serves no SPA, so that link 404s as well as being plaintext.
+  test "the reset link is absolute against the canonical URL, not the dialed host",
+       %{conn: conn, admin: admin} do
+    m = insert(:user, role: "member")
+
+    body =
+      %{conn | host: "api.engram.page", scheme: :http}
+      |> authenticate(admin)
+      |> post(~p"/api/admin/users/#{m.id}/password-reset")
+      |> json_response(201)
+
+    assert body["url"] == EngramWeb.Endpoint.url() <> "/reset-password?token=#{body["token"]}"
+    refute body["url"] =~ "api.engram.page"
+  end
 end


### PR DESCRIPTION
## What

Two admin endpoints built user-facing links out of the request:

```elixir
# admin/user_controller.ex
url: "#{conn.scheme}://#{conn.host}/reset-password?token=#{raw}"

# admin/invite_controller.ex
"#{conn.scheme}://#{conn.host}/sign-up?invite=#{raw}"
```

Both carry a **live credential in the query string** and get handed to a human, so the origin matters as much as the path. Deriving it from the connection inherited two things it never should have.

## `conn.scheme` is `:http` in prod

TLS terminates at the edge and the hop into Bandit is plaintext, so the password-reset link was emitted as:

```
http://app.engram.page/reset-password?token=<live token>
```

An admin copies that to a user, whose browser makes a **plaintext request carrying the credential** before Cloudflare can redirect it.

## `conn.host` is whichever backend host the admin reached

On `api.engram.page` the link points at a host that **serves no SPA** — so it 404s as well as being plaintext.

Actual failing output before the fix:

```
left:  "http://api.engram.page/reset-password?token=L34iQA4-KMz-Jk_zB_VkqaCcxAilb8fu1MRMVViLKlE"
right: "http://localhost:4000/reset-password?token=L34iQA4-KMz-Jk_zB_VkqaCcxAilb8fu1MRMVViLKlE"
```

## Fix

`EngramWeb.Endpoint.url()` — the source both should have used, and the one the device-flow `verification_url` and the account emails already use. It is `PHX_HOST` + `PHX_SCHEME`, so `https://app.engram.page` in prod, and correct for self-host and dev without special-casing.

No new helper or config: this is the existing pattern, reused.

## Why the tests missed it

They asserted only the path:

```elixir
assert body["url"] =~ ~r{/reset-password\?token=}
```

The new tests dial from a different host and scheme than the canonical one and pin the whole URL, including a `refute body["url"] =~ "api.engram.page"`.

## Verification

- Confirmed red before the fix (2 failures), green after — output above
- `mix format`, `mix credo --strict` clean
- `mix test --warnings-as-errors` — 4167 tests, 0 failures
- `mix dialyzer` — passed

## Provenance

Found while reviewing #1278, which fixes the same bug class in the OAuth discovery documents. `docs/context/oauth-discovery-urls-behind-edge-tls.md` (added there) covers why anything derived from the connection is untrustworthy behind an edge that terminates TLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6KUbXWuDMGhHbz8uDPujU