### PR TITLE
fix(ci): stop overriding the MinIO access key with an empty secret

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -589,8 +589,15 @@ jobs:
           # e2e-crdt and headless-protocol, but this job parses the same file
           # and was missed. Any future job that touches ci/compose.yml needs
           # them too, for parsing alone.
-          CI_MINIO_ACCESS_KEY: ${{ secrets.CI_MINIO_ACCESS_KEY }}
-          CI_MINIO_SECRET_KEY: ${{ secrets.CI_MINIO_SECRET_KEY }}
+          #
+          # Both now come from workflow-level env and must NOT be redeclared
+          # here. `CI_MINIO_ACCESS_KEY` is deliberately a plain value there, not
+          # a secret — it is also the CI image repository name
+          # (`${LOCAL_REGISTRY}/engram-ci:<hash>`), and GitHub redacts secret
+          # values out of job outputs by substring, which blanked
+          # ENGRAM_CI_IMAGE for every downstream e2e job. A step-level
+          # `${{ secrets.CI_MINIO_ACCESS_KEY }}` OVERRIDES the good value with
+          # the empty string, which is what re-broke the build.
         run: |
           # Already published for this exact tree? Reuse — the registry is the
           # cross-host source of truth, so probe IT (not the local daemon, which


### PR DESCRIPTION
## main is red again

```
error while interpolating services.engram.environment.STORAGE_ACCESS_KEY_ID:
required variable CI_MINIO_ACCESS_KEY is missing a value
```

#1272 fixed this by setting `CI_MINIO_ACCESS_KEY` as **workflow-level plain env**. #1277 then added a **step-level** `${{ secrets.CI_MINIO_ACCESS_KEY }}` to `prebuild-ci-image`.

Step-level env wins over workflow-level, and that secret does not exist — so the override replaced the working value with the empty string and put main back exactly where #1272 found it.

```yaml
line 124 (workflow):  CI_MINIO_ACCESS_KEY: engram-ci                           # #1272, correct
line 592 (step):      CI_MINIO_ACCESS_KEY: ${{ secrets.CI_MINIO_ACCESS_KEY }}  # #1277, empty, wins
```

## The secret does not exist on purpose

The access key **is** the username `engram-ci`, which is also the CI image repository name (`${LOCAL_REGISTRY}/engram-ci:<hash>`). GitHub redacts secret values out of job outputs by substring, so registered as a secret it blanked `ENGRAM_CI_IMAGE` for every downstream e2e job, which then failed with `invalid reference format`.

engram-infra's SOPS + Terraform change records exactly this and deliberately manages **only** the paired `CI_MINIO_SECRET_KEY`:

> Only the SECRET key is managed here. The access key is the username `engram-ci` and stays a plain value in Engram's verify.yml.

## Fix

Drop both step-level lines. Workflow-level env already supplies them, which is all `docker compose build` needs to parse the file.

Kept #1277's comment explaining *why* the job needs the vars at all — that reasoning was right, only the source was wrong — and added why they must not be redeclared at step level.

## Verification

```
YAML OK; workflow-level access key = 'engram-ci'
prebuild step env keys: ['BUILDKIT_PROGRESS', 'HASH', 'IMAGE']
```

A green `prebuild-ci-image` on this PR is the test — same-repo PRs run the head branch's workflow.

## Note

This blocks **every** PR touching `lib/`, `config/`, `frontend/`, `mix.exs` or the Dockerfile, not just mine — worth merging ahead of anything else in flight.

Refs #1272, #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6KUbXWuDMGhHbz8uDPujU