### PR TITLE
fix(crdt): a checkpoint tick must survive the room exiting under it

### DIFF
--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -185,11 +185,25 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
       captured_version: captured_version
     )
   rescue
-    err ->
-      Logger.warning(
-        "crdt checkpoint timer could not fetch doc note_id=#{state.note_id} reason=#{inspect(err)}",
-        Engram.Logger.Metadata.with_category(:warning, :sync, note_id: state.note_id)
-      )
+    err -> log_read_failure(state, err)
+  catch
+    # `get_doc/1` is a GenServer.call, and a call to a process that terminates
+    # mid-call EXITS rather than raising — `rescue` never sees it, so the timer
+    # died here instead of degrading the way the comment above intends.
+    #
+    # The race is routine: the room stops with a `:tick` already in our mailbox,
+    # and the `{:EXIT, room_pid, _}` that stops us cleanly is queued behind it.
+    # There is nothing to checkpoint once the room is gone — the doc it held is
+    # what we were trying to read — so falling through is the correct outcome,
+    # and the EXIT message right behind this tick shuts us down in order.
+    :exit, reason -> log_read_failure(state, {:exit, reason})
+  end
+
+  defp log_read_failure(state, reason) do
+    Logger.warning(
+      "crdt checkpoint timer could not fetch doc note_id=#{state.note_id} reason=#{inspect(reason)}",
+      Engram.Logger.Metadata.with_category(:warning, :sync, note_id: state.note_id)
+    )
   end
 
   defp monotonic_ms, do: System.monotonic_time(:millisecond)

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -874,4 +874,42 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     {:ok, reloaded} = Crypto.maybe_decrypt_note_fields(reloaded, user)
     assert reloaded.content == "IMPORTANT"
   end
+
+  # ── Timer tick racing the room's shutdown ─────────────────────────────────
+
+  # `do_checkpoint/1` reads the doc with `SharedDoc.get_doc/1`, a GenServer.call.
+  # A call to a process that terminates mid-call EXITS rather than raising, and
+  # `rescue` does not catch exits — so the timer died instead of degrading, even
+  # though its own comment says a read failure should fall through unfenced.
+  #
+  # The race is routine, not exotic: the room stops with a `:tick` already in the
+  # timer's mailbox, and the `{:EXIT, room_pid, _}` that stops us cleanly is
+  # behind that tick in the same queue. Observed in a full-suite run as
+  #
+  #     GenServer.call(#PID<...>, :get_doc, 5000) ** (EXIT) normal
+  #       crdt_checkpoint_timer.ex:182: CrdtCheckpointTimer.do_checkpoint/1
+  #
+  # Driving `handle_info/2` directly makes it deterministic — no sleeps, no
+  # scheduler luck — because a dead pid reproduces exactly the same exit.
+  test "a tick whose room has already exited degrades instead of killing the timer", ctx do
+    %{user: user, vault: vault, note: note} = ctx
+
+    dead_room = spawn(fn -> :ok end)
+    ref = Process.monitor(dead_room)
+    assert_receive {:DOWN, ^ref, :process, ^dead_room, _}
+
+    state = %{
+      room_pid: dead_room,
+      user_id: user.id,
+      vault_id: vault.id,
+      note_id: note.id,
+      first_dirty_at: 123,
+      settle_timer: nil
+    }
+
+    assert {:noreply, new_state} = CrdtCheckpointTimer.handle_info(:tick, state)
+    # Still reset the dirty anchor: the tick was handled, just with nothing to
+    # flush, and leaving it set would re-arm against a room that is gone.
+    assert new_state.first_dirty_at == nil
+  end
 end


### PR DESCRIPTION
## The bug

`do_checkpoint/1` reads the doc with `SharedDoc.get_doc/1` — a `GenServer.call`. A call to a process that terminates mid-call **exits** rather than raising, and `rescue` does not catch exits.

So the guard directly above it never fired, and the timer died instead of degrading — even though the surrounding code explicitly reasons about surviving a read failure (*"nil on read failure → unfenced"*).

Verified rather than assumed:

```
outcome: {:caught_exit, {GenServer, :call, [#PID<0.106.0>, :get_doc, 1000]}}
```

`rescue` never fires; only `catch :exit` does.

## Why it happens

Routine, not exotic: the room stops with a `:tick` already in the timer's mailbox, and the `{:EXIT, room_pid, _}` that would stop the timer cleanly is queued *behind* that tick. Surfaced in a full-suite run as:

```
GenServer.call(#PID<...>, :get_doc, 5000) ** (EXIT) normal
  crdt_checkpoint_timer.ex:182: CrdtCheckpointTimer.do_checkpoint/1
```

## Fix

A `catch :exit` beside the existing `rescue`, sharing one log path.

Falling through is the *correct* outcome here, not merely a tolerable one: once the room is gone there is nothing to checkpoint, because the doc it held is exactly what we were trying to read. The EXIT message queued behind this tick then shuts the timer down in order.

## Test

Driving `handle_info/2` directly makes it deterministic — no sleeps, no scheduler luck — because an already-dead pid reproduces the identical exit.

Confirmed red before the fix:

```
** (exit) exited in: GenServer.call(#PID<0.17440.0>, :get_doc, 5000)
    ** (EXIT) no process: the process is not alive or there's no process
```

## Verification

- Red before, green after (output above)
- `mix format`, `mix credo --strict` clean
- `mix test --warnings-as-errors` — 4166 tests, 0 failures
- `mix dialyzer` — passed

## Provenance

Found because the full suite reported one failure that passed on re-run. Rather than accept the rerun-pass, I traced the crash signature to this defect — which is independently verifiable regardless of whether it caused that particular flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6KUbXWuDMGhHbz8uDPujU