### PR TITLE
perf(ci): move buildx cache to LAN MinIO

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -807,8 +807,11 @@ jobs:
       # runner injects the S3 config via its environment, so no secret lives here;
       # absent that env the action falls back to the default GitHub cache. EVERY
       # deps/_build/PLT save + restore must stay on runs-on/cache (an S3 save paired
-      # with a GitHub restore is a guaranteed miss). buildx cache stays on
-      # actions/cache (separate Docker-layer concern).
+      # with a GitHub restore is a guaranteed miss). The buildx cache in
+      # build-and-publish-image is on runs-on/cache too, for the same reason: it was
+      # left on actions/cache as a "separate Docker-layer concern" and cost 14 min of
+      # post-step upload per lockfile change until that was fixed. Nothing large
+      # belongs on the GitHub cache backend from these runners.
       - name: Cache deps/
         id: cache-deps
         uses: runs-on/cache@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
@@ -4543,9 +4546,22 @@ jobs:
       # over HTTPS on every build; local cache is ~10× faster for cache hits.
       # Pre-fold, ECR built without this cache (cold every time); ECR push
       # now benefits from the same warm layers GHCR has used since #391.
+      #
+      # On runs-on/cache (LAN MinIO), NOT actions/cache, for exactly the
+      # reason deps/_build moved there (see "Cache deps/" above). This
+      # export is ~1.15GB at mode=max. The GitHub cache backend restored it
+      # at ~13 MB/s but SAVED at ~1.4 MB/s from these runners, and the save
+      # fires only when the key misses, so the cost was invisible on a
+      # normal merge and 14 MINUTES of post-step upload on any push that
+      # touched Dockerfile/mix.lock/bun.lock. The old note here carved buildx
+      # out of the MinIO migration as a "separate Docker-layer concern", but
+      # the bottleneck was never the content, it was the uplink: same bytes,
+      # same ~10 Mbps ceiling. Restore AND save must move together (an S3
+      # save paired with a GitHub restore is a guaranteed miss); they are the
+      # same action plus its post step, so swapping the `uses:` moves both.
       - name: Restore buildx cache
         if: steps.version.outputs.image_exists != 'true'
-        uses: actions/cache@v6
+        uses: runs-on/cache@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
         with:
           path: /tmp/buildx-cache
           key: buildx-${{ runner.os }}-${{ hashFiles('Dockerfile', 'mix.lock', 'frontend/bun.lock') }}


### PR DESCRIPTION
## The symptom

`Post Restore buildx cache` in `build-and-publish-image` takes **14 minutes** on any merge to main that touches `Dockerfile`, `mix.lock`, or `frontend/bun.lock`. On every other merge it takes **1 second**, which is why this stayed invisible.

## Measurements

Run [31057787877](https://github.com/engram-app/engram/actions/runs/31057787877) (bandit 1.12.4 bump, so `mix.lock` moved):

| Step | Duration |
|---|---|
| Restore buildx cache | 1m31s (1.15 GB down, ~13 MB/s) |
| Build compute (deps.compile 100s, release 128s, frontend 49s) | ~4m |
| `preparing build cache for export` | 62s |
| pushing layers → GHCR | 4m19s |
| pushing layers → ECR | 5m33s |
| **Post Restore buildx cache** | **14m00s** (1.15 GB up, ~1.4 MB/s) |

```
Cache Size: ~1153 MB (1209118098 B)
Cache saved with key: buildx-Linux-337aea55...   # 00:19:50 -> 00:33:50
```

Same step on [31063142232](https://github.com/engram-app/engram/actions/runs/31063142232) (no lockfile change): **1s**. `actions/cache` only saves when the key misses, and the key is `hashFiles('Dockerfile', 'mix.lock', 'frontend/bun.lock')`.

## Root cause

Transport, not content. These runners restore from GitHub's cache backend at ~13 MB/s and **save at ~1.4 MB/s** — the exact asymmetry that moved `deps/` and `_build` onto the LAN MinIO via `runs-on/cache`. The note at `verify.yml:810` carved buildx out of that migration as a *"separate Docker-layer concern"*, but that splits on what the bytes **are** rather than where they **go**. Same ~10 Mbps uplink either way.

1.15 GB at 200+ MB/s is ~6s each way.

## Change

One `uses:` swap, `actions/cache@v6` → `runs-on/cache@88d9064` (the same SHA pin as the other 4 call sites), plus refreshing the two comments that asserted the old rationale.

Restore and save move together as the `deps/` note requires — they are one action plus its post step, so the single swap moves both. No S3-save/GitHub-restore mismatch.

## Expected effect

- 14m → ~6s on lockfile-change merges
- 1m31s–1m56s → ~6s restore on **every** merge
- Frees ~8 GB of the repo's 10 GB GitHub cache quota (7 near-identical 1.15 GB buildx entries were sitting in it)

## Risk

First run after merge takes one cold-cache build (MinIO has no buildx entry under either key yet). Falls back to the GitHub backend automatically if the runner's S3 env is ever absent, same as the deps/ caches.

## Verification

- `verify.yml` parses (23 jobs)
- All 5 `runs-on/cache` references now share one SHA pin
- Real proof is the timing on this PR's own `build-and-publish-image`, which only runs on the push to main, so the first post-merge run is the check

## Not addressed here

The build pushes the same image over the uplink twice: GHCR 4m19s (staging on FastRaid + self-host distribution) and ECR 5m33s (ECS). The ECR leg re-uploads bytes already sitting in GHCR; fixing it needs a cloud-side registry copy, which is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz