### PR TITLE
docs(deploy): the prod bump PR is not auto-merged

### DIFF
--- a/docs/context/deploy-prod.md
+++ b/docs/context/deploy-prod.md
@@ -10,7 +10,7 @@ Two-stage pipeline. Image build lives in this repo; image-tag selection lives in
 
 1. **`build-and-publish-image` job in `verify.yml`** (this repo) — runs on every push to `main` (the former standalone `build-ecr.yml`, since folded into `verify.yml`). Builds the Docker image and pushes to ECR tagged `sha-<7>`. The image sits in ECR; **nothing rolls.**
 
-2. **`deploy-prod.yml`** (this repo) — runs only when a `release-v*` git tag is pushed. Opens a PR in engram-infra rewriting `engram_image_tag` default to the `sha-<7>` of the tagged commit, enables auto-merge.
+2. **`deploy-prod.yml`** (this repo) — runs only when a `release-v*` git tag is pushed. Opens a PR in engram-infra rewriting `engram_image_tag` default to the `sha-<7>` of the tagged commit, and **stops there — it does NOT merge and does NOT enable auto-merge** (#1155; see "Promotion gate" below). Prod does not move until a human merges that PR. The workflow prints the exact command in its step summary.
 
 3. **engram-infra `terraform (prod)`** (engram-infra `.github/workflows/ci.yml`, `matrix: env: [staging, prod]`) — runs `terraform apply -auto-approve` on push to main. The new image tag flows into `aws_ecs_task_definition.engram`; a new revision is registered; `aws_ecs_service.engram` rolls onto it.
 


### PR DESCRIPTION
The "How it works" summary in `docs/context/deploy-prod.md` still said `deploy-prod.yml` **"enables auto-merge"**. #1155 removed that.

The same doc contradicts itself two sections down — *"The PR is now opened and left alone"* — so the runbook asserted both behaviours and a reader could reasonably take either.

This is the wrong thing to leave ambiguous. Whoever believes the stale half waits for a prod roll that is never coming, and the gate being described exists *precisely* because auto-merge used to race the staging check:

> When this step enabled auto-merge unconditionally, the prod PR merged as soon as its checks went green — which is well before anyone could look at staging.

It cost real confusion during the 0.14.0 release: the tag was cut, the pin PR sat open and green, and prod looked stalled.

The workflow is already unambiguous —

```
# NO auto-merge. This is the staging-first promotion gate (#1155).
```

— and prints the merge command in its step summary. This just makes the summary agree with it and cross-references the gate section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6KUbXWuDMGhHbz8uDPujU