### PR TITLE
fix(mcp): point resource_documentation at docs that exist

### DIFF
--- a/lib/engram_web/controllers/well_known_controller.ex
+++ b/lib/engram_web/controllers/well_known_controller.ex
@@ -17,6 +17,24 @@ defmodule EngramWeb.WellKnownController do
 
   alias EngramWeb.OAuthMetadata
 
+  # RFC 9728 `resource_documentation` — where a developer is sent to learn how
+  # to use this resource. Optional in the spec, which is exactly why a link that
+  # does not resolve is worse than no link: a client following it lands nowhere.
+  #
+  # NOT derived from the request. As `<base>/docs` it resolved nowhere on any
+  # deployment we run:
+  #
+  #   * `mcp.engram.page/docs` -> 404. `HostRewrite` admits only `/api/mcp`,
+  #     `/oauth` and `/.well-known/oauth-*` on the dedicated MCP host.
+  #   * `app.engram.page/docs` -> 200, but it is the SPA shell. A 200 that is
+  #     not documentation is the worse outcome — nothing reports it as broken.
+  #   * selfhost serves no `/docs` route at all.
+  #
+  # The docs are published on the marketing site for every deployment, self-host
+  # included, so this is a fixed absolute URL. No config knob: there is one set
+  # of Engram MCP docs, and a self-hoster's users want that same page.
+  @resource_documentation "https://engram.page/docs/mcp"
+
   def protected_resource(conn, _params) do
     base = OAuthMetadata.base_url(conn)
 
@@ -43,7 +61,7 @@ defmodule EngramWeb.WellKnownController do
       resource: OAuthMetadata.resource(conn),
       authorization_servers: [base],
       bearer_methods_supported: ["header"],
-      resource_documentation: base <> "/docs"
+      resource_documentation: @resource_documentation
     })
   end
 

--- a/test/engram_web/controllers/well_known_controller_test.exs
+++ b/test/engram_web/controllers/well_known_controller_test.exs
@@ -28,6 +28,29 @@ defmodule EngramWeb.WellKnownControllerTest do
 
       assert ["application/json" <> _] = get_resp_header(conn, "content-type")
     end
+
+    # `resource_documentation` is where a developer is sent to learn how to use
+    # this resource, so a link that does not resolve is worse than the field
+    # being absent — RFC 9728 makes it optional precisely so you can omit it.
+    #
+    # Derived as `<base>/docs` it resolved nowhere on any deployment:
+    #   * mcp.engram.page/docs -> 404. HostRewrite admits only /api/mcp, /oauth
+    #     and /.well-known/oauth-* on that host.
+    #   * app.engram.page/docs -> 200, but it is the SPA shell. A 200 that is
+    #     not documentation is the worse failure: nothing reports it as broken.
+    #   * selfhost has no /docs route at all.
+    #
+    # The docs are published on the marketing site for every deployment, so the
+    # value is a fixed absolute URL rather than anything host-derived.
+    test "documentation link is absolute and not derived from the dialed host", %{conn: conn} do
+      body =
+        %{conn | host: "engram.ax"}
+        |> get("/.well-known/oauth-protected-resource")
+        |> json_response(200)
+
+      assert body["resource_documentation"] == "https://engram.page/docs/mcp"
+      refute body["resource_documentation"] =~ "engram.ax"
+    end
   end
 
   # RFC 9728 §3.1: for a resource with a path (`https://host/api/mcp`), the


### PR DESCRIPTION
## What

`resource_documentation` was derived as `<base>/docs`, which resolved nowhere on any deployment we run:

| host | result |
|---|---|
| `mcp.engram.page/docs` | **404** — `HostRewrite` admits only `/api/mcp`, `/oauth`, `/.well-known/oauth-*` |
| `app.engram.page/docs` | **200, but it's the SPA shell** |
| selfhost | no `/docs` route at all |

The middle one is the worse failure. A 200 that isn't documentation means no monitor ever reports it broken — verified it's the SPA fallback, not a page:

```
$ curl -s https://app.engram.page/docs | grep -oE "<title>[^<]*</title>|__ENGRAM_CONFIG__"
<title>Engram</title>
__ENGRAM_CONFIG__
```

And the irony of the first one: the host whose entire purpose is MCP is the one that cannot serve its own doc link.

RFC 9728 makes this field **optional**, which is precisely why a dead link is worse than no link — its presence advertises that we have docs for this resource.

## Fix

Point it at the docs that actually exist:

```
$ curl -sL https://engram.page/docs/mcp | grep -oE "<title>[^<]*</title>"
<title>About MCP | Engram Docs</title>
```

A fixed absolute URL, not a config knob. There is one set of Engram MCP docs, and a self-hoster's users want that same page — a per-deployment override would only create a way for it to be wrong.

## Verification

- Confirmed red before the fix: `left: "http://localhost:4000/docs"` vs `right: "https://engram.page/docs/mcp"`
- `mix format`, `mix credo --strict` clean
- `mix test --warnings-as-errors` — 4199 tests, 0 failures
- `mix dialyzer` — passed

The new test dials from a different host and asserts the value is absolute and *not* derived from it, so a future refactor back to `<base>/docs` fails.

## Provenance

Found while verifying the 0.14.0 prod deploy. Already recorded as an open item in `docs/context/oauth-discovery-urls-behind-edge-tls.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6KUbXWuDMGhHbz8uDPujU