### PR TITLE
ci: cover prod in the nightly conformance, and stop reporting config errors as flakes

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -565,13 +565,41 @@ jobs:
     if: |
       github.event.schedule == '40 5 * * *'
       || github.event.inputs.task == 'mcp-conformance'
-    name: mcp-conformance
+    name: mcp-conformance (${{ matrix.label }})
     runs-on: [self-hosted, linux, x64, isolated, light]
     # 8 CLI runs (2 strategies x 4 protocol versions) plus the spec assertions.
     timeout-minutes: 25
     permissions:
       contents: read
       issues: write   # regressions open/update a tracking issue (see last step)
+    strategy:
+      # Independent deployments — one being red says nothing about the other,
+      # and finding out about both in one run is the point.
+      fail-fast: false
+      matrix:
+        include:
+          # Staging carries the full matrix: the OAuth stage performs real DCR
+          # and CIMD registrations, which write client rows, so it belongs on a
+          # deployment we are happy to dirty.
+          - label: staging
+            target: https://staging.engram.page/api/mcp
+            stages: spec,oauth
+
+          # Prod runs the spec stage ONLY — it is plain unauthenticated curl, so
+          # it writes nothing. Not thoroughness-limited by accident: the OAuth
+          # matrix would register throwaway clients in the production database
+          # every night.
+          #
+          # Prod is not redundant with staging, it is the only coverage that
+          # exists for a whole branch of the code. `ENGRAM_HOST_REWRITE_ENABLED`
+          # is prod-only, so `mcp_rewrite_host?/1` is FALSE everywhere else and
+          # the bare-root `resource`, its `resource_metadata_url`, and the
+          # MCP-host `/oauth` passthrough are unexercised by staging, by the CI
+          # stack, and by the unit suite. Dial the BARE host, because that is
+          # what the docs tell users to paste and what that branch produces.
+          - label: prod
+            target: https://mcp.engram.page
+            stages: spec
     steps:
       - uses: actions/checkout@v7
         with:
@@ -593,7 +621,7 @@ jobs:
         id: deployed
         shell: bash
         env:
-          TARGET: ${{ github.event.inputs.target-url || 'https://staging.engram.page/api/mcp' }}
+          TARGET: ${{ github.event.inputs.target-url || matrix.target }}
         run: |
           origin="${TARGET%/api/mcp}"
           sha=$(curl -fsS --max-time 15 "$origin/api/health" \
@@ -620,8 +648,8 @@ jobs:
         # script body — `target-url` is a workflow_dispatch input, and `${{ }}`
         # inside `run:` is textual substitution.
         env:
-          TARGET: ${{ github.event.inputs.target-url || 'https://staging.engram.page/api/mcp' }}
-          CONFORMANCE_STAGES: spec,oauth
+          TARGET: ${{ github.event.inputs.target-url || matrix.target }}
+          CONFORMANCE_STAGES: ${{ matrix.stages }}
         run: |
           set -o pipefail
           mkdir -p conformance-results
@@ -635,7 +663,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: mcp-conformance-results
+          # Per-target name: upload-artifact@v4+ ERRORS on a duplicate name
+          # rather than merging, so a bare `mcp-conformance-results` would make
+          # whichever matrix leg finished second fail on the upload — losing the
+          # evidence for the leg that may be the one that failed.
+          name: mcp-conformance-results-${{ matrix.label }}
           path: conformance-results/
           retention-days: 14
 
@@ -647,7 +679,7 @@ jobs:
         if: failure() && steps.conformance.outputs.rc == '1'
         uses: actions/github-script@v9
         env:
-          TARGET: ${{ github.event.inputs.target-url || 'https://staging.engram.page/api/mcp' }}
+          TARGET: ${{ github.event.inputs.target-url || matrix.target }}
           DEPLOYED_SHA: ${{ steps.deployed.outputs.sha }}
           DEPLOYED_DRIFT: ${{ steps.deployed.outputs.drift }}
         with:
@@ -721,3 +753,45 @@ jobs:
               })
               core.info(`Opened issue #${created.number}`)
             }
+
+      # Discord alert. The tracking issue above is the durable record; this is
+      # the push notification, because a prod OAuth regression is silent from
+      # the outside — every existing client keeps working on its issued token
+      # and only NEW connections fail, so nothing else surfaces it.
+      #
+      # Guarded on the secret being present so this is a no-op until the webhook
+      # consolidation lands (one `announce` + one `alert` channel, replacing the
+      # per-repo DISCORD_RELEASES_/DISCORD_DEPLOY_ sprawl). Same
+      # `env.WEBHOOK != ''` idiom deploy-prod.yml already uses.
+      #
+      # Fires for BOTH targets: staging red blocks the next release, prod red is
+      # user-facing. The host is in the message so severity is obvious at a
+      # glance rather than encoded in which channel it lands in.
+      - name: Alert Discord (conformance regression)
+        if: failure() && steps.conformance.outputs.rc == '1' && env.WEBHOOK != ''
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
+          TARGET: ${{ github.event.inputs.target-url || matrix.target }}
+          LABEL: ${{ matrix.label }}
+          DEPLOYED_SHA: ${{ steps.deployed.outputs.sha }}
+          DEPLOYED_DRIFT: ${{ steps.deployed.outputs.drift }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Deploy lag is the most common false alarm here — a stale deployment
+          # fails these assertions for a pipeline reason, not an OAuth one. Say
+          # so in the alert instead of making the reader go look.
+          case "${DEPLOYED_DRIFT}" in
+            0)       DRIFT_NOTE="deployed build is level with main" ;;
+            unknown) DRIFT_NOTE="could not determine the deployed build" ;;
+            *)       DRIFT_NOTE="deployed build is ${DEPLOYED_DRIFT} commit(s) BEHIND main — check deploy lag before reading this as a regression" ;;
+          esac
+
+          CONTENT="[MCP-CONFORMANCE] \`${LABEL}\` — OAuth conformance FAILED against ${TARGET}
+          Build: \`${DEPLOYED_SHA}\` (${DRIFT_NOTE})
+          A tracking issue has been opened or updated.
+          Run: ${RUN_URL}"
+
+          curl -sS -X POST -H 'Content-Type: application/json' \
+            --max-time 5 \
+            --data "$(jq -nc --arg c "$CONTENT" '{content:$c}')" \
+            "$WEBHOOK"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -619,13 +619,29 @@ jobs:
             # (#567) — a host/daemon event, not a build error. The build is
             # idempotent (cache-reused), so retry a few times before failing the
             # whole job; the daemon typically comes back within seconds.
+            # Classify the failure before retrying. A compose CONFIG error is
+            # deterministic: re-running re-parses the same file and fails
+            # identically, so all three attempts burn in under a second while
+            # the warning blames the daemon. That misattribution is not
+            # cosmetic — it is why the CI_MINIO_ACCESS_KEY break read as
+            # "registry down" and took three separate PRs to actually fix.
+            build_log="$(mktemp)"
             for attempt in 1 2 3; do
-              if ENGRAM_CI_IMAGE="$IMAGE_LOCAL" \
-                   docker compose -f ci/compose.yml build engram; then
-                break
+              ENGRAM_CI_IMAGE="$IMAGE_LOCAL" \
+                docker compose -f ci/compose.yml build engram 2>&1 | tee "$build_log"
+              # tee's exit status is not the build's, and GitHub's default shell
+              # is `bash -e` WITHOUT pipefail, so read the real one out of
+              # PIPESTATUS rather than setting a shell option mid-block.
+              rc=${PIPESTATUS[0]}
+              [ "$rc" -eq 0 ] && break
+
+              if grep -qE 'error while interpolating|required variable|^validating ' "$build_log"; then
+                echo "::error::ci/compose.yml CONFIG error — NOT retrying. This is deterministic (missing/invalid variable or malformed compose file), not a daemon event. Retries cannot help; fix the config. See the parse error above."
+                exit 1
               fi
+
               if [ "$attempt" = 3 ]; then
-                echo "::error::CI image build failed after 3 attempts"
+                echo "::error::CI image build failed after 3 attempts (transient-looking; no compose config error detected)"
                 exit 1
               fi
               echo "::warning::build attempt $attempt failed (daemon reclaimed?) — retrying in 15s"


### PR DESCRIPTION
Two CI-truthfulness fixes, one commit each so they're separable.

## 1. Prod has no recurring conformance coverage

`mcp_rewrite_host?/1` reads `:host_rewrite`, which **only prod sets**. So the bare-root `resource`, its derived `resource_metadata_url`, and the MCP-host `/oauth` passthrough are `false` on staging, on the CI stack, and in the unit suite. Their only verification to date was one manual run during the 0.14.0 deploy.

That is precisely the shape of the bug 0.14.0 shipped to fix: **prod-only code, no recurring coverage, green everywhere anyone could look.**

Adds prod as a second matrix leg:

| leg | target | stages |
|---|---|---|
| staging | `https://staging.engram.page/api/mcp` | `spec,oauth` |
| prod | `https://mcp.engram.page` (bare) | `spec` |

**Prod is `spec`-only deliberately.** The OAuth matrix performs real DCR and CIMD registrations — that would write throwaway client rows into the production database every night. `spec` is unauthenticated curl and writes nothing. It dials the **bare** host because that's what the docs tell users to paste, and what the prod-only branch actually produces.

`fail-fast: false` — independent deployments; one being red says nothing about the other.

### Alerting

The tracking issue stays the durable record (and now gets a distinct title per host, since it's derived from the target). The Discord post is the push notification.

Worth having because **a prod OAuth regression is silent from outside**: existing clients keep working on their issued tokens, and only *new* connections fail. Nothing else surfaces it.

The alert reports deploy drift inline, because a stale deployment failing these assertions is the most common false alarm and otherwise sends the reader hunting through OAuth code.

Guarded on `env.WEBHOOK != ''` — the idiom `deploy-prod.yml` already uses — so it **no-ops until the webhook consolidation lands** rather than blocking on it. Secret name `DISCORD_ALERT_WEBHOOK_URL`, matching the intended `announce`/`alert` scheme.

### One matrix gotcha handled

Artifact names gain the matrix label. `upload-artifact@v4+` **errors** on a duplicate name instead of merging, so a bare `mcp-conformance-results` would have failed whichever leg finished second — losing the evidence for the leg that may be the one that failed.

## 2. The retry loop blamed the daemon for config errors

```
::warning::build attempt 1 failed (daemon reclaimed?) — retrying in 15s
```

A compose interpolation error is deterministic — re-running re-parses the same file and fails identically — so all three attempts burned in **under a second** while the warning pointed at infrastructure.

That misattribution has a measured cost: it's why the missing `CI_MINIO_ACCESS_KEY` read as "the CI registry is down" and took **three separate PRs** to actually fix. The failure text said daemon, so nobody read the parse error two lines above it.

Now it classifies before retrying. Config error → fail immediately and say it's deterministic. Transient → retry exactly as before.

Reads the build's real status out of `PIPESTATUS` rather than setting `pipefail` mid-block: GitHub's default shell is `bash -e` **without** pipefail, so `build | tee` would otherwise report `tee`'s status and every failure would look like a pass.

### Verified both directions against real captured output

```
error while interpolating ... required variable CI_MINIO_ACCESS_KEY is missing a value
  -> CONFIG (fail fast)

#12 ERROR: failed to solve: rpc error: code = Unavailable ... graceful_stop
  -> transient (retry)
```

## Follow-up this sets up

Webhook consolidation onto `announce` + `alert`. Current sprawl is small: `DISCORD_RELEASES_WEBHOOK_URL` (4 refs in engram, 1 in Engram-obsidian) and `DISCORD_DEPLOY_WEBHOOK_URL` (**orphaned — referenced by no workflow in either repo**), all per-repo, none org-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6KUbXWuDMGhHbz8uDPujU