### PR TITLE
fix(frontend): route onboarding gate off live status, not stale bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,7 @@ Grouped index into `docs/context/`. Each entry is a trigger → doc; read the do
 - Folder-tree `rebuildTree()` triggers, optimistic move/delete/duplicate → `docs/context/folder-tree-optimistic-rebuild.md`
 - Frontend/backend deploy-trigger skew (different pipelines) — 2026-06-20 incident + fix → `docs/context/frontend-backend-deploy-skew-cors.md`
 - Writing a CM6 live-preview decoration (lezer reads `[!type]` as a Link; one highlight tag serves many nodes; `syntaxTree` is lazy) → `docs/context/codemirror-live-preview-extensions.md`
+- A route guard or view acts on state that mutations definitely updated (user bounced back to a completed onboarding/wizard step; loop only a full page reload escapes) → `docs/context/bootstrap-seed-cache-dual-authority.md`
 
 **Testing & CI**
 - Full test strategy, ExUnit tooling, CI pipeline → `docs/context/testing-strategy.md`

--- a/docs/context/bootstrap-seed-cache-dual-authority.md
+++ b/docs/context/bootstrap-seed-cache-dual-authority.md
@@ -1,0 +1,32 @@
+# Context Doc: Bootstrap Seed Cache — Dual-Authority Bug Class
+
+_Last verified: 2026-08-06_
+
+## Status
+Working — architecture rule documented after PR #1299 fixed the third instance of this bug class.
+
+## What This Is
+The SPA's `useAppBootstrap` (`frontend/src/api/queries.ts`) fetches `GET /bootstrap` once (`staleTime: Infinity`, key `["bootstrap"]`) and **seeds** the granular caches via `qc.setQueryData`: `["onboarding","status"]`, `["capabilities"]`, `["vaults"]`, and `["billing","status"]` (when billing is enabled). The architecture rule: **bootstrap is a fetch-and-seed vehicle; the granular keys are the only readable source of truth.** Nothing may route or render off the bootstrap payload's own copy of a slice.
+
+## The Bug (fixed in PR #1299)
+`OnboardingGate` (`frontend/src/onboarding/onboarding-gate.tsx`) routed off `data.onboarding` from the bootstrap payload. Wizard mutations (`useAcceptTerms`, `useSetOnboardingProfile`, `useCreateVault`) invalidate only `["onboarding","status"]` — the bootstrap copy stayed frozen forever. A user completing the wizard got bounced back to `/onboard/agreement` in a redirect loop: the fresh granular status said "done" at `/onboard`, the stale bootstrap copy said "agreement" at `/`. Only a full page reload escaped. Hit a real paying user mid-onboarding on 2026-08-06.
+
+Fix: the gate now reads `useOnboardingStatus({ enabled: data !== undefined })` — the granular key every wizard mutation invalidates — with `enabled` gating on the bootstrap seed so first load stays one request.
+
+## Prior Instances (same class)
+- **Capabilities/tier stuck after upgrade (#603)** — see the `invalidateBillingState` comment in `queries.ts`.
+- **Vault-count staleness** — `useDeleteVault` / `useRestoreVault` / `usePurgeVault` invalidate `["bootstrap"]` because vault deletion changes onboarding `next_step` server-side; the refetch re-seeds all granular keys.
+
+## Rules Going Forward
+1. **Read via the granular hooks** (`useOnboardingStatus`, `useCapabilities`, ...) — never `bootstrap.data.<slice>`.
+2. A mutation that changes a seeded slice **invalidates the granular key** — that is sufficient for any reader.
+3. Invalidating `["bootstrap"]` is only needed when the server recomputes a slice as a **side effect the client can't name** (e.g. vault deletion changing `next_step`) — its refetch re-seeds everything.
+4. A consumer that must mount alongside the gate before the seed lands should use `useOnboardingStatus({ enabled })` to avoid racing bootstrap with a duplicate fetch.
+
+## Gotchas / Debug Tell
+"Works after a hard refresh, but loops or goes stale within the SPA session" = a reader is on a never-invalidated cache copy. Find who reads the stale slice and move them to the granular key; don't add more `["bootstrap"]` invalidations.
+
+## References
+- `frontend/src/api/queries.ts` — `useAppBootstrap`, `useOnboardingStatus`, `invalidateBillingState`, vault lifecycle mutations
+- `frontend/src/onboarding/onboarding-gate.tsx`
+- PR #1299 (gate fix), #603 (tier staleness)

--- a/frontend/e2e/local-auth.spec.ts
+++ b/frontend/e2e/local-auth.spec.ts
@@ -129,4 +129,45 @@ test.describe("Local auth provider", () => {
 
 		await expect(page).toHaveURL(/\/onboard\/tools/u, { timeout: 10_000 });
 	});
+
+	// Regression for the stale-bootstrap redirect loop (PR #1299): the wizard
+	// must complete in one SPA session and actually open the dashboard. Routing
+	// off the never-invalidated bootstrap payload bounced finished users back to
+	// the first wizard step in a loop only a full page reload escaped.
+	test("completing the wizard in one session lands on the dashboard", async ({ page }) => {
+		const email = testEmail("wizard");
+		await page.goto("/sign-up/");
+		await page.getByLabel("Email").fill(email);
+		await page.getByLabel("Password", { exact: true }).fill(TEST_PASSWORD);
+		await page.getByLabel("Confirm password").fill(TEST_PASSWORD);
+		await page.getByRole("button", { name: "Create account" }).click();
+
+		// Self-host chain: tools → vault (agreement/billing auto-pass).
+		await expect(page).toHaveURL(/\/onboard\/tools/u, { timeout: 10_000 });
+
+		// Prime the trigger: a full page load on "/" mid-wizard caches the
+		// bootstrap payload (staleTime Infinity) with next_step="tools" in the
+		// SPA session that will finish the wizard — same shape as the real
+		// incident's post-auth landing on "/". The gate bounces us straight
+		// back to the wizard; the poisoned cache stays behind.
+		await page.goto("/");
+		await expect(page).toHaveURL(/\/onboard\/tools/u, { timeout: 10_000 });
+
+		await page.getByLabel("I'm not connecting an AI tool yet").check();
+		await page.getByRole("button", { name: "Continue" }).click();
+
+		await expect(page).toHaveURL(/\/onboard\/vault/u, { timeout: 10_000 });
+		await page.getByRole("button", { name: /starting fresh/iu }).click();
+		await page.getByLabel("Vault name").fill("Wizard Vault");
+		await page.getByRole("button", { name: /create vault & continue/iu }).click();
+
+		// Element-based oracle, not URL: during the bounce loop the URL flickers
+		// through "/" (which a URL wait can false-pass on) but the gate never
+		// renders its Outlet, so no dashboard chrome ever mounts. The checklist
+		// widget (open heading or its dismissed-state pill) proves the app opened.
+		const openHeading = page.getByRole("heading", { name: /finish setup/iu });
+		const closedPill = page.getByLabel(/open setup checklist/iu);
+		await expect(openHeading.or(closedPill).first()).toBeVisible({ timeout: 15_000 });
+		expect(new URL(page.url()).pathname.startsWith("/onboard")).toBe(false);
+	});
 });

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1046,12 +1046,16 @@ export interface OnboardingProfile {
 
 // Onboarding hooks
 
-export function useOnboardingStatus() {
+// `enabled: false` lets a consumer that mounts alongside useAppBootstrap (the
+// onboarding gate) wait for the bootstrap seed instead of racing it with its
+// own /onboarding/status fetch.
+export function useOnboardingStatus(opts: { enabled?: boolean } = {}) {
 	return useQuery({
 		queryKey: ["onboarding", "status"],
 		queryFn: () => api.get<OnboardingStatus>("/onboarding/status"),
 		staleTime: Number.POSITIVE_INFINITY,
 		refetchOnWindowFocus: true,
+		enabled: opts.enabled ?? true,
 	});
 }
 

--- a/frontend/src/onboarding/onboarding-gate.test.tsx
+++ b/frontend/src/onboarding/onboarding-gate.test.tsx
@@ -2,22 +2,15 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { describe, expect, it, vi } from "vitest";
-import { useAppBootstrap } from "../api/queries";
+import { useAppBootstrap, useOnboardingStatus } from "../api/queries";
 import OnboardingGate from "./onboarding-gate";
 
 vi.mock("../api/queries", () => ({
 	useAppBootstrap: vi.fn(),
+	useOnboardingStatus: vi.fn(),
 }));
 
-// The gate reads onboarding state out of the consolidated bootstrap payload, so
-// wrap each onboarding status under `data.onboarding`.
-function renderWith(onboarding: unknown, rest: Record<string, unknown> = {}) {
-	vi.mocked(useAppBootstrap).mockReturnValue({
-		data: onboarding === null || onboarding === undefined ? undefined : { onboarding },
-		isLoading: false,
-		isError: false,
-		...rest,
-	} as never);
+function mountGate() {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	return render(
 		<QueryClientProvider client={qc}>
@@ -34,6 +27,22 @@ function renderWith(onboarding: unknown, rest: Record<string, unknown> = {}) {
 			</MemoryRouter>
 		</QueryClientProvider>,
 	);
+}
+
+// Steady state: the bootstrap payload and the granular ["onboarding","status"]
+// cache it seeds agree. The stale-bootstrap regression test below diverges them.
+function renderWith(onboarding: unknown, rest: Record<string, unknown> = {}) {
+	vi.mocked(useAppBootstrap).mockReturnValue({
+		data: onboarding === null || onboarding === undefined ? undefined : { onboarding },
+		isLoading: false,
+		isError: false,
+		...rest,
+	} as never);
+	vi.mocked(useOnboardingStatus).mockReturnValue({
+		data: onboarding ?? undefined,
+		isLoading: onboarding === null || onboarding === undefined,
+	} as never);
+	return mountGate();
 }
 
 describe("OnboardingGate", () => {
@@ -81,6 +90,26 @@ describe("OnboardingGate", () => {
 			profile_complete: false,
 		});
 		expect(screen.getByText("tools-step")).toBeInTheDocument();
+	});
+
+	// Regression: completing the wizard refetches ["onboarding","status"] but
+	// never touches the bootstrap payload (staleTime Infinity). Routing off
+	// bootstrap's own copy bounced finished users back to /onboard/agreement in
+	// a loop only a full page reload escaped.
+	it("routes from live onboarding status, not bootstrap's stale copy", () => {
+		vi.mocked(useAppBootstrap).mockReturnValue({
+			data: {
+				onboarding: { enabled: true, next_step: "agreement", terms_ok: false },
+			},
+			isLoading: false,
+			isError: false,
+		} as never);
+		vi.mocked(useOnboardingStatus).mockReturnValue({
+			data: { enabled: true, next_step: "done", terms_ok: true, subscription_ok: true },
+			isLoading: false,
+		} as never);
+		mountGate();
+		expect(screen.getByText("dashboard")).toBeInTheDocument();
 	});
 
 	it("redirects to /onboard/vault when next_step=vault", () => {

--- a/frontend/src/onboarding/onboarding-gate.tsx
+++ b/frontend/src/onboarding/onboarding-gate.tsx
@@ -1,5 +1,5 @@
 import { Navigate, Outlet } from "react-router";
-import { useAppBootstrap } from "../api/queries";
+import { useAppBootstrap, useOnboardingStatus } from "../api/queries";
 import LoadingScreen from "../layout/loading-screen";
 
 export default function OnboardingGate() {
@@ -7,12 +7,15 @@ export default function OnboardingGate() {
 	// vaults / capabilities caches, so the views mounted past this gate read from
 	// cache instead of each issuing their own request.
 	const { data, isLoading } = useAppBootstrap();
+	// Route off the granular ["onboarding","status"] cache — the one every
+	// wizard mutation invalidates — never bootstrap's own copy, which is cached
+	// forever and once looped finished users back to /onboard/agreement.
+	// `enabled` waits for the bootstrap seed so first load stays one request.
+	const { data: onboarding } = useOnboardingStatus({ enabled: data !== undefined });
 
-	if (isLoading || !data) {
+	if (isLoading || !data || !onboarding) {
 		return <LoadingScreen />;
 	}
-
-	const { onboarding } = data;
 
 	if (!onboarding.enabled || onboarding.next_step === "done") {
 		return <Outlet />;


### PR DESCRIPTION
## Bug

A real user completing the signup wizard (terms → billing → tools → vault) was bounced back to the accept-terms step at the end and locked in a redirect loop; only editing the URL to the base domain (a full page reload) let them into the app.

## Root cause

`OnboardingGate` routed off the **bootstrap payload's own copy** of onboarding state — cached with `staleTime: Infinity` and never invalidated by any wizard mutation (`useAcceptTerms` / `useSetOnboardingProfile` / `useCreateVault` refetch only `["onboarding","status"]`). After the final wizard step navigates to `/`, the gate replayed the day-one `next_step: "agreement"`:

1. re-accept terms → `/onboard` → `OnboardRedirect` reads **fresh** status → `done` → `/`
2. gate reads **stale** bootstrap → back to `/onboard/agreement` → loop

The gate was the only component reading the bootstrap payload directly; everything else already reads the granular caches it seeds. The backend (`RequireOnboarding`) was correct throughout.

## Fix

The gate now decides from the granular `["onboarding","status"]` cache — the key every wizard mutation already invalidates — while `useAppBootstrap` keeps its fetch-and-seed role. A new `enabled` option on `useOnboardingStatus` waits for the bootstrap seed, so first load remains a single request. No mutation changes needed; vault delete/restore/purge keep working via bootstrap refetch re-seeding the status cache.

Kills the bug class: any future onboarding mutation that invalidates the status key re-runs the gate automatically, instead of every author having to remember a second `["bootstrap"]` invalidation.

## Testing

- New regression test: stale bootstrap (`agreement`) + live status (`done`) → gate renders the dashboard (fails on main)
- Full frontend suite: 176 files / 1324 tests green; `tsc` and `biome ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyirNUaZY19uVvzwBL8yX4