### PR TITLE
fix(links): rewrite links on resurrect-rename, not just live relocate

### DIFF
--- a/lib/engram/links/rewriter.ex
+++ b/lib/engram/links/rewriter.ex
@@ -7,10 +7,10 @@ defmodule Engram.Links.Rewriter do
   `[[wikilink]]`/`![[embed]]` targets are rewritten to the new name. The
   server is the SINGLE rewriter for every origin EXCEPT plugin-origin
   renames (Obsidian's "Automatically update internal links" owns those) —
-  exactly one party rewrites, never both. Known deliberate gap:
-  `genesis_resurrect`'s rename-restore leg (web-origin resurrect-rename)
-  currently enqueues no rewriter — deferred, tracked for the
-  untagged-default flip follow-up.
+  exactly one party rewrites, never both. Both CRDT rename legs are wired:
+  `genesis_relocate_live` (live row) and `genesis_resurrect`'s
+  rename-restore leg (tombstoned row), each behind
+  `Notes.crdt_rename_rewrites?/1`.
 
   POLICY: the server authors only mechanical, semantics-preserving
   transforms — the rewritten target resolves to the same row the old text

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -754,7 +754,7 @@ defmodule Engram.Notes do
                  end
 
                {:tombstone, %Note{} = prior} ->
-                 genesis_resurrect(prior, user, sanitized_path, folder)
+                 genesis_resurrect(prior, user, vault, sanitized_path, folder, origin)
 
                :none ->
                  genesis_adopt_or_insert(user, vault, canonical_id, sanitized_path, folder)
@@ -1056,10 +1056,10 @@ defmodule Engram.Notes do
     end
   end
 
-  defp genesis_resurrect(prior, user, sanitized_path, folder) do
+  defp genesis_resurrect(prior, user, vault, sanitized_path, folder, origin) do
     case Crypto.maybe_decrypt_note_fields(prior, user) do
       {:ok, prior} ->
-        genesis_resurrect_decrypted(prior, user, sanitized_path, folder)
+        genesis_resurrect_decrypted(prior, user, vault, sanitized_path, folder, origin)
 
       {:error, reason} ->
         log_resurrect_decrypt_failure(reason, user, prior)
@@ -1067,7 +1067,7 @@ defmodule Engram.Notes do
     end
   end
 
-  defp genesis_resurrect_decrypted(prior, user, sanitized_path, folder) do
+  defp genesis_resurrect_decrypted(prior, user, vault, sanitized_path, folder, origin) do
     # FIX 1 — delete-wins (#970): a tombstone re-created at its OWN path within
     # the delete window is a stale device un-deleting a note another device
     # deleted. Mirror the REST upsert_pathless guard EXACTLY — refuse so the
@@ -1105,6 +1105,17 @@ defmodule Engram.Notes do
                   ),
                   "rebind_note_links"
                 )
+
+              # #648 Phase 2 — a resurrect-rename IS a rename (move_note over a
+              # tombstoned row), so it owes the same server-side link rewrite
+              # genesis_relocate_live enqueues, under the same one-rewriter
+              # gate. Same in-txn, never-raises discipline; the old path rides
+              # as AAD-bound ciphertext because move_note repointed the row and
+              # left no old-path tombstone for the worker to read.
+              _ =
+                if renamed? and crdt_rename_rewrites?(origin) do
+                  enqueue_crdt_rename_rewrite(user, vault, decrypted.id, prior.path)
+                end
 
               # A rename-restore carries the OLD (tombstone) path so peers clear
               # it; a same-path resurrect just announces.

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -918,10 +918,11 @@ defmodule Engram.Notes do
   def untagged_crdt_client_type, do: @untagged_crdt_client_type
 
   @doc """
-  ONE-REWRITER INVARIANT gate for CRDT-origin renames (relocates reached via
-  `genesis_crdt_note/5`): `"obsidian"` never triggers a server rewrite; any
-  other PRESENT tag does; an ABSENT tag (nil) takes the
-  `untagged_crdt_client_type/0` compromise default (see attribute comment).
+  ONE-REWRITER INVARIANT gate for CRDT-origin renames — BOTH legs reached via
+  `genesis_crdt_note/5`: live relocates (`genesis_relocate_live`) and
+  resurrect-renames (`genesis_resurrect`). `"obsidian"` never triggers a
+  server rewrite; any other PRESENT tag does; an ABSENT tag (nil) takes the
+  `untagged_crdt_client_type/0` default (see attribute comment).
   """
   @spec crdt_rename_rewrites?(String.t() | nil) :: boolean()
   def crdt_rename_rewrites?(client_type) do

--- a/lib/engram/workers/rewrite_note_links.ex
+++ b/lib/engram/workers/rewrite_note_links.ex
@@ -2,12 +2,14 @@ defmodule Engram.Workers.RewriteNoteLinks do
   @moduledoc """
   Oban worker: rewrite `[[wikilink]]`/`![[embed]]` occurrences in every
   note referring to a just-renamed note/attachment (issues #648/#1231).
-  Four enqueue origins: REST/MCP note rename (`Notes.do_rename_note`),
-  attachment move (`Attachments.move_attachment/4`), CRDT-origin relocate
-  (`Notes.genesis_relocate_live`, gated by `Notes.crdt_rename_rewrites?/1`
-  so only non-Obsidian origins — web/MCP — enqueue), and the folder-rename
+  Five enqueue origins: REST/MCP note rename (`Notes.do_rename_note`),
+  attachment move (`Attachments.move_attachment/4`), the two CRDT-origin
+  rename legs — live relocate (`Notes.genesis_relocate_live`) and
+  resurrect-rename (`Notes.genesis_resurrect`, the same rename arriving for a
+  TOMBSTONED row) — both gated by `Notes.crdt_rename_rewrites?/1` so only
+  non-Obsidian origins enqueue, and the folder-rename
   cascade (`Notes.do_rename_folder`, one job per moved note). The gating
-  rule across all four: plugin/Obsidian-origin renames never enqueue —
+  rule across all five: plugin/Obsidian-origin renames never enqueue —
   Obsidian's "Automatically update internal links" rewrites those itself,
   preserving the exactly-one-rewriter invariant.
 

--- a/test/engram/links/rewrite_wiring_test.exs
+++ b/test/engram/links/rewrite_wiring_test.exs
@@ -6,6 +6,7 @@ defmodule Engram.Links.RewriteWiringTest do
   alias Engram.Folders
   alias Engram.MCP.Handlers
   alias Engram.Notes
+  alias Engram.Notes.Note
   alias Engram.Workers.RebindNoteLinks
   alias Engram.Workers.RewriteNoteLinks
 
@@ -13,6 +14,16 @@ defmodule Engram.Links.RewriteWiringTest do
     {:ok, user} = Engram.Fixtures.user_with_dek_fixture()
     vault = insert(:vault, user: user)
     %{user: user, vault: vault}
+  end
+
+  # Force a tombstone's deleted_at into the past so the delete-wins window
+  # (Notes @delete_tombstone_window_seconds) has expired, without sleeping.
+  # Same idiom as notes_delete_tombstone_test.exs.
+  defp backdate_delete(note_id, seconds_ago) do
+    past = DateTime.add(DateTime.utc_now(), -seconds_ago, :second)
+
+    from(n in Note, where: n.id == ^note_id)
+    |> Repo.update_all([set: [deleted_at: past]], skip_tenant_check: true)
   end
 
   test "REST-origin note rename enqueues a rewrite job with hmac-only args", %{
@@ -158,9 +169,27 @@ defmodule Engram.Links.RewriteWiringTest do
     test "same-path resurrect (not a rename) enqueues nothing even for web origin",
          %{user: user, vault: vault, note: note} do
       :ok = Notes.delete_note(user, vault, "Old.md")
-      # Delete-wins refuses a same-path resurrect inside the window; either way
-      # nothing was renamed, so nothing may be rewritten.
-      _ = Notes.genesis_crdt_note(user, vault, note.id, "Old.md", origin: "web")
+
+      # Backdate past the delete-wins window so the resurrect actually SUCCEEDS.
+      # Without this the `recently_deleted` guard short-circuits before
+      # `renamed?` is ever computed, and the assertion below would pass
+      # vacuously — proving the guard, not the `renamed?` half of the gate.
+      backdate_delete(note.id, 120)
+
+      assert {:ok, resurrected} =
+               Notes.genesis_crdt_note(user, vault, note.id, "Old.md", origin: "web")
+
+      assert resurrected.id == note.id
+      assert all_enqueued(worker: RewriteNoteLinks) == []
+    end
+
+    test "delete-wins still refuses a same-path resurrect inside the window",
+         %{user: user, vault: vault, note: note} do
+      :ok = Notes.delete_note(user, vault, "Old.md")
+
+      assert {:error, :recently_deleted} =
+               Notes.genesis_crdt_note(user, vault, note.id, "Old.md", origin: "web")
+
       assert all_enqueued(worker: RewriteNoteLinks) == []
     end
   end

--- a/test/engram/links/rewrite_wiring_test.exs
+++ b/test/engram/links/rewrite_wiring_test.exs
@@ -128,6 +128,41 @@ defmodule Engram.Links.RewriteWiringTest do
       {:ok, _} = Notes.genesis_crdt_note(user, vault, note.id, "Old.md", origin: "web")
       assert all_enqueued(worker: RewriteNoteLinks) == []
     end
+
+    # The resurrect-rename leg: the row is a TOMBSTONE when the crdt_create for
+    # its id lands at a new path. Same user-visible operation as a live
+    # relocate (a rename), so it owes the same rewrite — it just reaches
+    # move_note through genesis_resurrect instead of genesis_relocate_live.
+    test "web-origin resurrect-rename enqueues, same encrypted old-path args as a relocate",
+         %{user: user, vault: vault, note: note} do
+      :ok = Notes.delete_note(user, vault, "Old.md")
+      {:ok, _} = Notes.genesis_crdt_note(user, vault, note.id, "Fresh.md", origin: "web")
+
+      assert [job] = all_enqueued(worker: RewriteNoteLinks)
+      assert job.args["target_kind"] == "note"
+      assert job.args["target_id"] == note.id
+      assert {:ok, _} = Base.decode64(job.args["old_path_hmac"])
+      assert {:ok, _} = Base.decode64(job.args["old_basename_hmac"])
+      assert {:ok, _} = Base.decode64(job.args["old_path_ciphertext"])
+      assert {:ok, _} = Base.decode64(job.args["old_path_nonce"])
+      refute Map.has_key?(job.args, "old_path")
+    end
+
+    test "obsidian-origin resurrect-rename enqueues NOTHING (one-rewriter invariant)",
+         %{user: user, vault: vault, note: note} do
+      :ok = Notes.delete_note(user, vault, "Old.md")
+      {:ok, _} = Notes.genesis_crdt_note(user, vault, note.id, "Fresh.md", origin: "obsidian")
+      assert all_enqueued(worker: RewriteNoteLinks) == []
+    end
+
+    test "same-path resurrect (not a rename) enqueues nothing even for web origin",
+         %{user: user, vault: vault, note: note} do
+      :ok = Notes.delete_note(user, vault, "Old.md")
+      # Delete-wins refuses a same-path resurrect inside the window; either way
+      # nothing was renamed, so nothing may be rewritten.
+      _ = Notes.genesis_crdt_note(user, vault, note.id, "Old.md", origin: "web")
+      assert all_enqueued(worker: RewriteNoteLinks) == []
+    end
   end
 
   describe "folder rename fan-out (Phase 3, #648/#1231)" do


### PR DESCRIPTION
## Problem

A CRDT rename reaches `move_note` down two different roads:

- `genesis_relocate_live` — the row is **live** when the `crdt_create` for its id lands at a new path
- `genesis_resurrect` — the row is a **tombstone** when it lands

Same user action (a rename), same DB primitive, two call sites — and only the live one enqueued `RewriteNoteLinks`. So a web-origin rename of a note the server had tombstoned left every `[[Old]]` reference in every other note pointing at the dead path, with no error surface. The `Rewriter` moduledoc already carried this as a known deferred gap.

## Fix

Thread `vault` + `origin` through `genesis_resurrect`/`genesis_resurrect_decrypted` and enqueue behind the same `Notes.crdt_rename_rewrites?/1` gate, so the **one-rewriter invariant** holds on both legs:

- Obsidian-origin renames stay server-silent — the plugin's own "Automatically update internal links" owns those
- Everything else (web / REST / MCP) rewrites server-side exactly once

The old path rides as AAD-bound ciphertext in the job args, same as the live leg: `move_note` repoints the row, so there's no old-path tombstone left for the worker to read.

Moduledoc updated — the gap note becomes a statement that both legs are wired.

## Tests

Three added to the existing Phase 2 `describe` block in `rewrite_wiring_test.exs`:

- web-origin resurrect-rename enqueues one job with the same encrypted old-path args as a relocate (**red before this change**, green after)
- obsidian-origin resurrect-rename enqueues nothing
- same-path resurrect (not a rename) enqueues nothing even for web origin

## Verification

```
mix format          ok
mix credo --strict  4343 mods/funs, found no issues
mix dialyzer        Total errors: 5, Skipped: 5, Unnecessary Skips: 0 — passed
mix test --warnings-as-errors
                    1 property, 4202 tests, 0 failures (8 excluded)
```

One earlier full run showed a single failure in `crdt_head_property_test`. It has zero references to `genesis_crdt_note`, `genesis_resurrect`, or `delete_note`, passed 3/3 in isolation, and the full rerun above is clean — pre-existing load-dependent flake, filed as #1303 rather than dropped.

## Context

Found while auditing how [No-Instructions/Relay](https://github.com/No-Instructions/Relay) handles rename link propagation. Relay has no rewriter at all: it delegates to Obsidian on both ends, applying remote renames with `fileManager.renameFile` (the link-*updating* API), so every client rewrites independently and diff3 collapses the duplicates. That only holds while all clients' link-format settings agree. Our model — one rewriter chosen by origin, with the plugin applying remote renames via `vault.rename` (which never touches links) — is the stronger position; this PR closes the one leg where "exactly one" was actually "zero".

Related follow-ups filed, not in this PR: #1301 (flip the untagged `client_type` default once 1.20.x has circulated), #1302 (parser is wikilink-only, `[text](path.md)` never graphed or rewritten).

Refs #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqgVPyDtDbXmTqm4PkTioK