### PR TITLE
fix(sync): flip untagged CRDT client default to "web" (#1301)

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -891,15 +891,27 @@ defmodule Engram.Notes do
   # 2026-07-06 wrong-mint corruption signature).
   # ── Phase 2 (#648/#1231) — CRDT-origin rename rewrite gate ─────────────────
   #
-  # TEMPORARY COMPROMISE — REMOVE BY FLIPPING TO "web" (one line, this
-  # attribute only): an UNTAGGED crdt socket is treated as plugin-origin so a
-  # version-skewed plugin that predates the client_type join tag never
-  # double-rewrites (Obsidian rewrites its own links; the server rewriting too
-  # would violate the one-rewriter invariant). Once the plugin release that
-  # tags itself "obsidian" has been out for one release cycle, flip this to
-  # "web" so untagged defaults to enqueue — the spec's safe default.
+  # FLIPPED to "web" 2026-08-07 (#1301). The prior "obsidian" value was a
+  # deliberate skew compromise: while plugins predating the client_type join
+  # tag (< 1.20.0) were the majority, treating an untagged socket as
+  # plugin-origin kept Obsidian the sole rewriter. Flipping early would have
+  # had BOTH sides rewrite the same wikilinks — concurrent positional edits in
+  # one Y-doc, which is exactly what the one-rewriter invariant exists to
+  # prevent.
+  #
+  # "web" is the spec's safe default and is now the correct one: any NON-
+  # Obsidian client that omits the tag (an old web build, a future mobile
+  # client) previously got no rewrite at all and silently rotted links with no
+  # error surface. Obsidian still opts out explicitly by tagging itself.
+  #
+  # Skew gate at flip time: plugin 1.20.0 shipped 2026-08-05 and 1.20.1 on
+  # 2026-08-06, against a 2-5 day release cadence. Note the drain could not be
+  # evidenced directly — client_type was threaded into this gate but never
+  # logged, so "untagged joins in Loki" was unobservable. The join-time log now
+  # carries client_type (see EngramWeb.CrdtChannel) so a straggler is greppable:
+  #   {service_name="engram"} | json | metadata_client_type=`untagged`
   # Pinned by test/engram/notes_crdt_origin_gate_test.exs. Tracked in #648.
-  @untagged_crdt_client_type "obsidian"
+  @untagged_crdt_client_type "web"
 
   @doc false
   @spec untagged_crdt_client_type() :: String.t()

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -129,6 +129,21 @@ defmodule EngramWeb.CrdtChannel do
                         conn_id: socket.assigns[:conn_id],
                         device_id: socket.assigns[:device_id],
                         topic: socket.topic,
+                        # Skew tripwire for the Notes.untagged_crdt_client_type/0
+                        # default, flipped to "web" in #1301. An untagged socket
+                        # now gets a SERVER-side link rewrite on rename, which is
+                        # wrong for a pre-1.20.0 plugin (it rewrites its own links
+                        # — both sides editing one Y-doc is the double-rewrite the
+                        # one-rewriter invariant forbids). Before this field the
+                        # gate's own input was unobservable, so "has the skew
+                        # drained?" had no answer. nil is materialised as the
+                        # literal "untagged" rather than left absent: a MISSING
+                        # field is indistinguishable from a log line predating
+                        # this change, which would make the tripwire query lie.
+                        # Safe to echo — client_type/1 above already bounds it to
+                        # a ≤32-byte binary, and this is a JSON field, not a Loki
+                        # stream label, so an odd value costs no index cardinality.
+                        client_type: socket.assigns[:client_type] || "untagged",
                         user_id: HMAC.hash_user_id(to_string(user.id))
                       )
                     )

--- a/test/engram/links/rewrite_wiring_test.exs
+++ b/test/engram/links/rewrite_wiring_test.exs
@@ -114,13 +114,13 @@ defmodule Engram.Links.RewriteWiringTest do
       assert all_enqueued(worker: RewriteNoteLinks) == []
     end
 
-    test "untagged relocate enqueues NOTHING while the compromise flag holds",
+    test "untagged relocate enqueues the rewrite (spec safe default)",
          %{user: user, vault: vault, note: note} do
-      # Pinned to Notes.untagged_crdt_client_type/0 == "obsidian" (see
-      # notes_crdt_origin_gate_test.exs). When the flag flips to "web", this
-      # test flips to assert [_] = all_enqueued(...) in the same commit.
+      # Flipped with Notes.untagged_crdt_client_type/0 -> "web" in #1301 (see
+      # notes_crdt_origin_gate_test.exs). Untagged is no longer assumed to be a
+      # skewed plugin, so the server owns the rewrite for it.
       {:ok, _} = Notes.genesis_crdt_note(user, vault, note.id, "Fresh.md")
-      assert all_enqueued(worker: RewriteNoteLinks) == []
+      assert [_] = all_enqueued(worker: RewriteNoteLinks)
     end
 
     test "same-path idempotent re-genesis enqueues nothing even for web origin",

--- a/test/engram/links_lifecycle_test.exs
+++ b/test/engram/links_lifecycle_test.exs
@@ -209,7 +209,19 @@ defmodule Engram.LinksLifecycleTest do
 
     # Same id, different FREE path — genesis_crdt_note's Phase E2 relocate leg
     # (genesis_relocate_live), not a REST rename_note call.
-    assert {:ok, _moved} = Notes.genesis_crdt_note(user, vault, a_short.id, "CrdtZ.md")
+    #
+    # origin: "obsidian" is LOAD-BEARING, not decoration (#1301). This test's
+    # subject is the rebind hook — proving [[CrdtA]] FALLS THROUGH to the
+    # b/CrdtA.md sibling once the root CrdtA.md vacates the basename. That
+    # fall-through is only correct for a non-rewriting client. A rewriting
+    # origin would rewrite the text to [[CrdtZ]] and keep it bound to a_short,
+    # which is the opposite outcome and a different feature (#648's rewrite,
+    # covered by rewrite_wiring_test + e2e test_88). This call previously
+    # inherited "obsidian" from the untagged default; that default flipped to
+    # "web", so the dependency is now explicit rather than silent.
+    assert {:ok, _moved} =
+             Notes.genesis_crdt_note(user, vault, a_short.id, "CrdtZ.md", origin: "obsidian")
+
     drain_indexing!()
 
     link = only_link(user, source.id)

--- a/test/engram/notes_crdt_origin_gate_test.exs
+++ b/test/engram/notes_crdt_origin_gate_test.exs
@@ -17,14 +17,15 @@ defmodule Engram.NotesCrdtOriginGateTest do
     assert Notes.crdt_rename_rewrites?("mobile")
   end
 
-  test "untagged (nil) takes the flip flag — currently plugin-origin, NO enqueue" do
-    # TEMPORARY COMPROMISE PIN (#648 Phase 2): version-skewed plugins that
-    # predate the client_type join tag must not double-rewrite, so untagged
-    # defaults to "obsidian" until the tagged plugin release has been out one
-    # release cycle. The flip (this assertion changing to "web" / assert) is a
-    # ONE-LINE change to @untagged_crdt_client_type in Engram.Notes. If this
-    # test fails because the flag flipped, update BOTH asserts below together.
-    assert Notes.untagged_crdt_client_type() == "obsidian"
-    refute Notes.crdt_rename_rewrites?(nil)
+  test "untagged (nil) takes the spec safe default — server-origin, DOES enqueue" do
+    # FLIPPED 2026-08-07 (#1301). Was pinned to "obsidian" while plugins
+    # predating the client_type join tag (< 1.20.0) were the majority — an
+    # untagged socket had to be assumed plugin-origin so Obsidian stayed the
+    # sole rewriter. Now that the tagged release has circulated, untagged means
+    # "some non-Obsidian client that didn't say" (old web build, future mobile),
+    # which must get the server rewrite or its links silently rot. Obsidian opts
+    # out explicitly by tagging itself — see the "obsidian" case above.
+    assert Notes.untagged_crdt_client_type() == "web"
+    assert Notes.crdt_rename_rewrites?(nil)
   end
 end

--- a/test/engram_web/channels/crdt_channel_origin_test.exs
+++ b/test/engram_web/channels/crdt_channel_origin_test.exs
@@ -67,11 +67,17 @@ defmodule EngramWeb.CrdtChannelOriginTest do
     assert all_enqueued(worker: RewriteNoteLinks) == []
   end
 
-  test "untagged join (a pre-tag plugin): relocate enqueues nothing — compromise default",
+  test "untagged join: relocate enqueues — spec safe default",
        %{user: user, vault: vault, note: note} do
+    # Flipped with Notes.untagged_crdt_client_type/0 -> "web" in #1301. Was
+    # pinned to "enqueues nothing" while pre-1.20.0 plugins (which predate the
+    # client_type join param) were the majority and had to be assumed to be the
+    # sole rewriter. Untagged now means "a non-Obsidian client that didn't say",
+    # which must get the server rewrite. Obsidian opts out explicitly above.
     socket = join!(user, vault, %{"crdt_proto" => 2})
     relocate!(socket, note)
-    assert all_enqueued(worker: RewriteNoteLinks) == []
+    assert [job] = all_enqueued(worker: RewriteNoteLinks)
+    assert job.args["target_id"] == note.id
   end
 
   test "batch-path relocate carries the same origin",


### PR DESCRIPTION
Closes #1301. Follow-up to #648 Phase 2.

## What

`Engram.Notes.@untagged_crdt_client_type` `"obsidian"` → `"web"`, so a CRDT client that joins **without** a `client_type` param now gets the server-side link rewrite on rename.

The old value was a deliberate skew compromise: while plugins predating the tag (< 1.20.0) were the majority, an untagged socket had to be assumed plugin-origin so Obsidian stayed the sole rewriter. Flipping early would have had **both** sides rewrite the same wikilinks — concurrent positional edits in one Y-doc, which is precisely what the one-rewriter invariant exists to prevent.

It's now the wrong default: any *non*-Obsidian client that omits the tag (a stale web bundle, a future mobile client) silently rots its links with no error surface. Obsidian still opts out explicitly by tagging itself.

## The gate could not be evaluated as written

The issue's verify step was *"confirm plugin < 1.20.0 traffic has drained — untagged CRDT joins in Loki."* **That telemetry does not exist.** `client_type` is threaded from join params → socket assign → `crdt_rename_rewrites?/1`, but it is never logged and never counted. The one join-time log line carries `conn_id` / `device_id` / `topic` / `user_id` — not `client_type`. Plugin remote logs carry no version either. Verified against prod Loki: zero matches, and the `"crdt join"` line itself doesn't appear at all (3 websocket-category lines in 7d; prod CRDT traffic is effectively nil).

So this PR **adds the missing signal in the same change**:

```
{service_name="engram"} | json | metadata_client_type=`untagged`
```

`nil` is materialised as the literal `"untagged"` rather than left absent — a *missing* field is indistinguishable from a log line predating this change, which would make the tripwire query lie. `:websocket` info already ships to Loki (it's in `@info_to_loki`), so this is a field addition, not new plumbing.

## Why the flip is safe now

- **Both shipping clients tag explicitly** — `frontend/src/api/channel.ts:549` sends `client_type: "web"`, plugin `src/channel.ts:894` sends `"obsidian"`. No live client is untagged.
- **Cadence** — 1.20.0 shipped 2026-08-05, 1.20.1 on 2026-08-06, against a 2–5 day release cadence; a 1.21.1 prerelease exists.
- **Residual risk** is narrowly a pre-1.20.0 plugin or a stale cached web bundle. For the stale bundle this is a straight bugfix — it was getting *no* rewrite. For a pre-1.20.0 plugin the tripwire above now makes it greppable instead of invisible.

## Tests — three flipped, not the two the issue listed

The issue's change-list named `notes_crdt_origin_gate_test.exs` and `rewrite_wiring_test.exs`. **`crdt_channel_origin_test.exs` also pinned the old default** and would have shipped red.

`links_lifecycle_test.exs` is handled differently — it gets an explicit `origin: "obsidian"` rather than a re-baselined assertion. Its subject is the rebind **fall-through** (`[[CrdtA]]` re-resolving to the `b/CrdtA.md` sibling once the root vacates the basename), which is only correct for a *non*-rewriting client. Re-baselining it to the rewrite outcome would have deleted that coverage instead of preserving it; the rewrite path is already covered by `rewrite_wiring_test` + e2e `test_88`.

## Verification

Full gauntlet, run sequentially:

| gate | result |
|---|---|
| `mix compile --warnings-as-errors` | clean |
| `mix format --check-formatted` | clean |
| `mix credo --strict` | 4343 mods/funs, no issues |
| `mix dialyzer` | passed, **Unnecessary Skips: 0** |
| `mix test --warnings-as-errors` | **4199 tests, 0 failures** |

One unrelated pre-existing issue surfaced and is filed separately, not folded in: `Engram.Notes.CrdtHeadPropertyTest` hit its 60s timeout on the first local run. It is structurally unreachable from this change (its command set is `[:edit_via_room, :checkpoint_now, :terminate_room, :recreate_room, :read_updates]` — no rename/relocate, never calls `genesis_crdt_note`), and it runs **200 iterations locally vs 50 in CI** (`@max_runs`), taking 58.4s isolated against a 60s ceiling. Local-only headroom problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2