### PR TITLE
fix(test): budget crdt_head_property's timeout off its run count

### DIFF
--- a/test/engram/notes/crdt_head_property_test.exs
+++ b/test/engram/notes/crdt_head_property_test.exs
@@ -43,6 +43,18 @@ defmodule Engram.Notes.CrdtHeadPropertyTest do
 
   @max_runs if System.get_env("CI"), do: 50, else: 200
 
+  # Each run creates a note and drives real CRDT rooms, checkpoints and
+  # terminate/recreate cycles against Postgres, so 200 local runs do not fit
+  # ExUnit's 60s default once a full-suite run puts 20 cases in contention —
+  # it fails as an ExUnit.TimeoutError blocked in a normal sandbox query, with
+  # no ownership error and nothing wrong with the property itself (#1303).
+  # CI's 50 runs always fit, which is why this only ever went red locally.
+  # Measured ~55s for 200 runs in isolation — already at the 60s line before
+  # any contention, which is why load tips it over. Budget 2s/run: ~4x the
+  # observed 0.27s/run, and derived from @max_runs so raising the run count
+  # cannot silently walk back into the same wall.
+  @moduletag timeout: :timer.seconds(@max_runs * 2)
+
   setup do
     user = insert(:user)
     insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})


### PR DESCRIPTION
## Problem

`Engram.Notes.CrdtHeadPropertyTest` intermittently failed a full local `mix test` with:

```
** (ExUnit.TimeoutError) property timed out after 60000ms
   ...
   (postgrex) Postgrex.Protocol.msg_recv/4
   (ecto_sql) Ecto.Adapters.SQL.Sandbox.Connection.proxy/3
```

The stack is the property blocked on an ordinary sandbox query when ExUnit's 60s default fired — no ownership error, no disconnect, nothing wrong with the property itself. My first guess when filing #1303 was the sandbox-connection-ownership class from `docs/context/channel-parallelism-db-pool.md`. That was wrong.

## Cause

```elixir
@max_runs if System.get_env("CI"), do: 50, else: 200
```

Locally that is 200 randomized iterations, each creating a note and driving real CRDT rooms, checkpoints and terminate/recreate cycles against Postgres. Measured **~55s in isolation** — already at the 60s line before any contention — so a full-suite run at `max_cases: 20` tips it over. CI's 50 runs always fit, which is why `unit-tests` has stayed green and this only ever went red locally.

Reproduced twice on full local runs; passes in isolation and via `mix test --failed`, because neither carries the parallel load.

## Fix

`@moduletag timeout: :timer.seconds(@max_runs * 2)` — 400s local, 100s CI.

Not a suppression: the 60s default is simply the wrong budget for a 200-iteration property doing real DB work, and 2s/run is ~4x the observed 0.27s/run. Derived from `@max_runs` rather than hardcoded so raising the run count later cannot silently walk back into the same wall.

The alternative — lowering local `@max_runs` toward the CI value — buys speed at the cost of local coverage on the exact invariant this property exists to defend (no acked write is ever lost). Not worth it.

## Verification

```
mix test test/engram/notes/crdt_head_property_test.exs
1 property, 0 failures    (54.4s)
```

Closes #1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqgVPyDtDbXmTqm4PkTioK