### PR TITLE
fix(backfill): drop self-colliding unique from content-hash backfill (#1230)

### DIFF
--- a/lib/engram/workers/backfill_content_hash_hmac.ex
+++ b/lib/engram/workers/backfill_content_hash_hmac.ex
@@ -5,7 +5,7 @@ defmodule Engram.Workers.BackfillContentHashHmac do
   Walks notes (and attachments) for one (user, vault) pair, recomputes
   `content_hash` with the per-user HKDF-derived content-hash key, and writes
   the new 64-char hex digest in place. Cursor-driven, batched, re-enqueues
-  itself until the batch is shorter than `@batch_size`.
+  itself until the batch is shorter than the batch size.
 
   Invoked per-scope: `"scope" => "notes" | "attachments"`. The mix task
   `mix engram.content_hash_hmac` enqueues both scopes for every (user, vault)
@@ -18,10 +18,22 @@ defmodule Engram.Workers.BackfillContentHashHmac do
   re-embedding of unchanged content.
   """
 
+  # No `unique`: a cursor worker re-enqueues its own successor mid-run, which
+  # collides with `:incomplete` uniqueness (the still-"executing" job counts as
+  # an in-flight match on the same user_id/vault_id/scope, because `cursor` is
+  # not a unique key) and Oban's unique-insert silently returns the EXISTING
+  # job instead of inserting the successor. The loop then dies after the first
+  # batch and every row past @default_batch_size is left un-migrated, with no
+  # error anywhere — the insert "succeeds". This is #1230; the same defect was
+  # caught pre-merge on Engram.Workers.BackfillNoteLinks, which carries the
+  # matching comment.
+  #
+  # Idempotence comes from the scope filters instead — both scopes select only
+  # `length(content_hash) = 32` (legacy MD5 hex), so a re-run after a partial
+  # batch skips already-rehashed rows rather than double-hashing them.
   use Oban.Worker,
     queue: :crypto_backfill,
-    max_attempts: 5,
-    unique: [keys: [:user_id, :vault_id, :scope], states: :incomplete]
+    max_attempts: 5
 
   import Ecto.Query
 
@@ -36,7 +48,7 @@ defmodule Engram.Workers.BackfillContentHashHmac do
 
   require Logger
 
-  @batch_size 100
+  @default_batch_size 100
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
@@ -44,6 +56,9 @@ defmodule Engram.Workers.BackfillContentHashHmac do
     vault_id = args["vault_id"]
     cursor = normalize_cursor(args["cursor"])
     scope = args["scope"] || "notes"
+    # Overridable so the real-dispatch regression test can drive multiple
+    # batches without inserting 101 rows. Production never sets it.
+    batch_size = args["batch_size"] || @default_batch_size
 
     # T3.7 — gate DEK-accessing work during per-user rotation. The user_id
     # is available directly in args so we can check before acquiring a
@@ -62,15 +77,15 @@ defmodule Engram.Workers.BackfillContentHashHmac do
         {:discard, :user_deleted}
 
       :ok ->
-        run_backfill(user_id, vault_id, cursor, scope)
+        run_backfill(user_id, vault_id, cursor, scope, batch_size)
     end
   end
 
-  defp run_backfill(user_id, vault_id, cursor, scope) do
+  defp run_backfill(user_id, vault_id, cursor, scope, batch_size) do
     Repo.with_tenant(user_id, fn ->
       with {:ok, user} <- load_user(user_id),
            {:ok, content_key} <- Crypto.dek_content_hash_key(user) do
-        case process_batch(scope, user, content_key, vault_id, cursor) do
+        case process_batch(scope, user, content_key, vault_id, cursor, batch_size) do
           {:done, _last} ->
             :ok
 
@@ -79,7 +94,8 @@ defmodule Engram.Workers.BackfillContentHashHmac do
               "user_id" => user_id,
               "vault_id" => vault_id,
               "cursor" => last_id,
-              "scope" => scope
+              "scope" => scope,
+              "batch_size" => batch_size
             })
             |> Oban.insert()
         end
@@ -105,7 +121,7 @@ defmodule Engram.Workers.BackfillContentHashHmac do
     end
   end
 
-  defp process_batch("notes", user, content_key, vault_id, cursor) do
+  defp process_batch("notes", user, content_key, vault_id, cursor, batch_size) do
     notes =
       from(n in Note,
         where: n.vault_id == ^vault_id,
@@ -113,7 +129,7 @@ defmodule Engram.Workers.BackfillContentHashHmac do
         where: not is_nil(n.content_hash),
         where: fragment("length(?) = 32", n.content_hash),
         order_by: [asc: n.id],
-        limit: @batch_size
+        limit: ^batch_size
       )
       |> Repo.all()
 
@@ -128,7 +144,7 @@ defmodule Engram.Workers.BackfillContentHashHmac do
 
         last_id = notes |> List.last() |> Map.fetch!(:id)
 
-        if length(notes) == @batch_size do
+        if length(notes) == batch_size do
           {:more, last_id}
         else
           {:done, last_id}
@@ -136,7 +152,7 @@ defmodule Engram.Workers.BackfillContentHashHmac do
     end
   end
 
-  defp process_batch("attachments", user, content_key, vault_id, cursor) do
+  defp process_batch("attachments", user, content_key, vault_id, cursor, batch_size) do
     attachments =
       from(a in Attachment,
         where: a.vault_id == ^vault_id,
@@ -144,7 +160,7 @@ defmodule Engram.Workers.BackfillContentHashHmac do
         where: not is_nil(a.content_hash),
         where: fragment("length(?) = 32", a.content_hash),
         order_by: [asc: a.id],
-        limit: @batch_size
+        limit: ^batch_size
       )
       |> Repo.all()
 
@@ -159,7 +175,7 @@ defmodule Engram.Workers.BackfillContentHashHmac do
 
         last_id = attachments |> List.last() |> Map.fetch!(:id)
 
-        if length(attachments) == @batch_size do
+        if length(attachments) == batch_size do
           {:more, last_id}
         else
           {:done, last_id}

--- a/test/engram/workers/backfill_content_hash_hmac_test.exs
+++ b/test/engram/workers/backfill_content_hash_hmac_test.exs
@@ -1,5 +1,12 @@
 defmodule Engram.Workers.BackfillContentHashHmacTest do
-  use Engram.DataCase, async: true
+  # async: false — the #1230 regression test below drives a REAL Oban dispatch
+  # (`Oban.drain_queue/1`) rather than `perform_job/2`, which is the only way to
+  # reproduce the self-collision it guards. Real dispatch needs a stable sandbox
+  # connection owner; running it async invites the ownership flake class in
+  # docs/context/channel-parallelism-db-pool.md. Matches
+  # Engram.Workers.BackfillNoteLinksTest, which made the same call for the same
+  # test.
+  use Engram.DataCase, async: false
   use Oban.Testing, repo: Engram.Repo
 
   import Ecto.Query, only: [from: 2]
@@ -224,6 +231,63 @@ defmodule Engram.Workers.BackfillContentHashHmacTest do
 
       assert_received {:skip_meta, meta}
       assert is_atom(meta.reason), "telemetry reason must be the bounded error_kind atom"
+    end
+  end
+
+  describe "cursor chain under real dispatch (#1230)" do
+    # Regression for #1230: the worker carried
+    # `unique: [keys: [:user_id, :vault_id, :scope], states: :incomplete]`.
+    # A cursor worker re-enqueues its OWN successor mid-run, and because
+    # `cursor` is not a unique key, that successor matched the still-
+    # "executing" job. Oban's unique-insert then silently returned the
+    # existing job instead of inserting the successor — no error, insert
+    # "succeeds" — so the chain died after batch 1 and every row past the
+    # batch size stayed on its legacy MD5 hash forever.
+    #
+    # `perform_job/2` CANNOT catch this: it never creates a DB row for the
+    # "currently running" job, so there is nothing for the successor to
+    # collide with and the insert always looks fine. Only `Oban.drain_queue/1`
+    # goes through the real fetch path (state -> "executing" before perform
+    # runs), which is what makes the collision observable.
+    #
+    # Proof this test catches the regression: re-adding the `unique:` option
+    # to the worker makes it fail with only the first note rehashed.
+    test "rehashes every row across multiple batches, not just the first",
+         %{user: user, vault: vault} do
+      contents = for i <- 1..3, do: "# Note #{i}\nbody"
+
+      notes =
+        for {content, i} <- Enum.with_index(contents, 1) do
+          legacy_md5 = :crypto.hash(:md5, content) |> Base.encode16(case: :lower)
+
+          insert_note!(user, vault, %{
+            "path" => "Chain#{i}.md",
+            "content" => content,
+            "content_hash" => legacy_md5
+          })
+        end
+
+      {:ok, _job} =
+        BackfillContentHashHmac.new(%{
+          "user_id" => user.id,
+          "vault_id" => vault.id,
+          "cursor" => 0,
+          "scope" => "notes",
+          "batch_size" => 1
+        })
+        |> Oban.insert()
+
+      result = Oban.drain_queue(queue: :crypto_backfill, with_recursion: true)
+      assert result.failure == 0, "chain must not fail: #{inspect(result)}"
+
+      {:ok, content_key} = Crypto.dek_content_hash_key(user)
+
+      for {note, content} <- Enum.zip(notes, contents) do
+        {:ok, reloaded} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+
+        assert reloaded.content_hash == Crypto.hmac_content_hash(content_key, content),
+               "note #{note.id} still on its legacy hash — the cursor chain stalled after the first batch"
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #1230.

## The bug

```elixir
unique: [keys: [:user_id, :vault_id, :scope], states: :incomplete]
```

A cursor worker re-enqueues its **own successor mid-run**. `cursor` isn't a unique key, so that successor matched the still-`executing` job — and Oban's unique-insert **silently returned the existing job instead of inserting it**.

Nothing raises. The insert "succeeds". So the chain died after batch 1 and **every row past 100 was left on its legacy MD5 `content_hash` indefinitely**, with no error anywhere to notice.

The identical defect was caught pre-merge on `BackfillNoteLinks`, which carries the matching why-no-unique comment. This worker never got it.

Idempotence never depended on `unique` here — both scopes select only `length(content_hash) = 32`, so a re-run skips already-rehashed rows.

## The regression test is proven non-vacuous

This matters more than usual, because **`perform_job/2` cannot catch this bug**: it never creates a DB row for the "currently running" job, so there's nothing for the successor to collide with and the insert always looks fine. A test written the obvious way would pass with or without the bug — the trap this repo already documented under "vacuous Oban uniqueness tests".

Only `Oban.drain_queue(with_recursion: true)` goes through the real fetch path (state → `executing` before `perform` runs).

**Verified by reintroducing the bug:** re-adding the `unique:` option makes the new test fail with exactly its own message —

```
1) test cursor chain under real dispatch (#1230) rehashes every row across multiple batches
   note 019fde17-... still on its legacy hash — the cursor chain stalled after the first batch
9 tests, 1 failure
```

— then restored. Without that check I couldn't honestly claim the test guards anything.

## Class audit

All six cursor-chain workers checked, not just the reported one:

| worker | `unique` | verdict |
|---|---|---|
| `backfill_content_hash_hmac` | ~~`:incomplete`~~ → none | **fixed here** |
| `backfill_crdt_head` | none | ok |
| `backfill_crdt_state` | none | ok |
| `backfill_note_links` | none | ok (already documented) |
| `rewrite_note_links` | none | ok |
| `extract_note_links` | `[:available, :scheduled]` | ok — deliberately excludes `executing`, cannot self-collide |

This was the last worker carrying the defect.

## Also

- **Overridable `batch_size`** (mirrors `BackfillNoteLinks`) so the test drives multiple batches without inserting 101 rows. Production never sets it.
- **Test file → `async: false`.** Real Oban dispatch needs a stable sandbox connection owner; async invites the ownership flake class in `docs/context/channel-parallelism-db-pool.md`. `BackfillNoteLinksTest` made the same call for the same test.

## ⚠️ This repairs the worker, not already-stranded rows

Prod may hold rows past the first batch still on legacy MD5 hashes. Re-running the enqueue **will** pick them up — `gather_pairs` selects on `length(content_hash) = 32`, so stranded rows still qualify.

But the documented recovery command doesn't work:

```
docker exec engram-saas /app/bin/engram rpc 'Mix.Tasks.Engram.ContentHashHmac.run([])'
```

`Mix.Task` is unavailable in a release — which is precisely why `BackfillNoteLinks` is enqueued via `Engram.Links.Backfill.enqueue_all/0`, documented as *"a plain function, not `Mix.Task`, so it's release-rpc callable."* The content-hash task never got that treatment.

Deliberately **not** bundled here: whether prod has affected rows is unverified, and building a repair path for a possibly-empty set is speculative. Checking prod first.

## Verification

| gate | result |
|---|---|
| `mix compile --warnings-as-errors` | clean |
| `mix format --check-formatted` | clean |
| `mix credo --strict` | no issues |
| `mix dialyzer` | passed |
| `mix test --warnings-as-errors` | **4204 tests, 0 failures** |
| bug-reintroduction check | new test fails as designed ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2