### PR TITLE
perf(web): one bulk read for the file tree

### DIFF
--- a/docs/superpowers/plans/2026-08-07-vault-tree-bulk-endpoint.md
+++ b/docs/superpowers/plans/2026-08-07-vault-tree-bulk-endpoint.md
@@ -1,0 +1,720 @@
+# Vault Tree Bulk Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the web tree's per-folder request fan-out (20–33 calls, ~5.6s of HTTP/1.1 queueing) with a single `GET /api/vault/tree` call.
+
+**Architecture:** A new read-only Phoenix controller returns every folder, note, and attachment the tree renders, in one payload, with a `since_seq` short-circuit. The React client calls it once on vault load and seeds the *existing* TanStack cache keys (`folders`, `attachments`, `folder-notes-by-id`) via `setQueryData`, so every existing consumer keeps working untouched and the per-folder prefetch loop is deleted.
+
+**Tech Stack:** Elixir/Phoenix 1.8, Ecto, OpenApiSpex, ExUnit; React 19, TanStack Query v5, Vitest.
+
+## Global Constraints
+
+- **Additive only.** `/api/folders`, `/api/folders/list`, `/api/folders/by-id/:id/notes` stay exactly as they are — the plugin and public API depend on them.
+- **OpenAPI is CI-gated.** `.github/workflows/verify.yml` regenerates the spec and diffs it against the committed `openapi.json`. A new route without an `operation(...)` block, a response schema, and a regenerated `openapi.json` **fails CI**.
+- **Paths are encrypted at rest.** Every path read decrypts `path_ciphertext`/`path_nonce` with the user DEK and AAD binding. Never bypass `path_aad/3`.
+- **Tenant isolation.** All queries run inside `Repo.with_tenant(user.id, fn -> ... end)`.
+- **No version bumps** in feature work — release-please owns `mix.exs`.
+- Backend gate before push, run **sequentially**: `mix format`, `mix credo`, `mix dialyzer`, then full `mix test --warnings-as-errors`.
+- Frontend gate: `bunx tsc --noEmit`, `./node_modules/.bin/biome ci .`, `bunx vitest run`.
+
+## Deviations from the approved spec
+
+Two changes I'd make, both discovered while reading the code. **Confirm before Task 1.**
+
+1. **Folder objects use `name`, not `path`.** The spec wrote `{id, path, parent_id, count}`. The existing `GET /api/folders` and the frontend `Folder` interface (`frontend/src/api/queries.ts:303`) both use `name` — which already *is* the full path. Matching the existing shape means the client can seed the `folders` cache directly with zero mapping.
+
+2. **The client seeds `folders` and `attachments` caches too, not just notes.** The spec flagged "attachment double-source" as a risk. Seeding all three caches from the one response resolves it: `useFolders`/`useAttachments` become cache reads instead of separate fetches, so there is exactly one source of truth and no consumer changes. This is what makes it a true single call (35 → 1) rather than 35 → 3.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `lib/engram/crypto/path_crypto.ex` (create) | Shared AAD-bound path decrypt. Extracted so two controllers can't drift on AAD binding. |
+| `lib/engram_web/controllers/vault_tree_controller.ex` (create) | The one read: folders + notes + attachments + `change_seq`. |
+| `lib/engram_web/schemas/vault_tree.ex` (create) | OpenApiSpex response schema. |
+| `lib/engram_web/router.ex` (modify) | One route in the vault-scoped pipeline. |
+| `openapi.json` (regenerate) | CI-gated spec snapshot. |
+| `frontend/src/api/queries.ts` (modify) | `useVaultTree` + cache seeding. |
+| `frontend/src/viewer/folder-tree.tsx` (modify) | Delete the prefetch loop. |
+
+---
+
+### Task 1: Extract the path-decrypt helpers
+
+`SyncController` holds `path_aad/3` and `decrypt_path!/4` as private functions. The new controller needs identical behavior. Copying them risks the two drifting on AAD binding — a security-relevant bug. Move them to a shared module first, as a pure refactor with no behavior change.
+
+**Files:**
+- Create: `lib/engram/crypto/path_crypto.ex`
+- Modify: `lib/engram_web/controllers/sync_controller.ex`
+- Test: `test/engram_web/controllers/sync_controller_test.exs` (existing, must stay green)
+
+**Interfaces:**
+- Consumes: `Engram.Crypto.aad_for_row/3`, `Engram.Crypto.Envelope.decrypt/4`
+- Produces: `Engram.Crypto.PathCrypto.aad(table :: atom, id :: binary, dek_version :: integer) :: binary` and `Engram.Crypto.PathCrypto.decrypt!(ciphertext :: binary, nonce :: binary, dek :: binary, aad :: binary) :: binary`
+
+- [ ] **Step 1: Create the module**
+
+```elixir
+defmodule Engram.Crypto.PathCrypto do
+  @moduledoc """
+  AAD-bound path decryption, shared by every controller that renders
+  cleartext paths from `path_ciphertext`.
+
+  Extracted from SyncController so the manifest and the vault-tree read
+  cannot drift on AAD binding: rows with `dek_version >= 2` bind to
+  "notes:path:<id>" / "attachments:path:<id>", and legacy v1 rows decrypt
+  with empty AAD. Getting that wrong on one caller and not the other is a
+  silent decrypt failure at best.
+  """
+
+  alias Engram.Crypto
+  alias Engram.Crypto.Envelope
+
+  @spec aad(atom(), binary(), integer() | nil) :: binary()
+  def aad(table, id, dek_version) when is_integer(dek_version) and dek_version >= 2,
+    do: Crypto.aad_for_row(table, :path, id)
+
+  def aad(_table, _id, _v), do: <<>>
+
+  @spec decrypt!(binary(), binary(), binary(), binary()) :: binary()
+  def decrypt!(ciphertext, nonce, dek, aad) do
+    case Envelope.decrypt(ciphertext, nonce, dek, aad) do
+      {:ok, path} -> path
+      :error -> raise "path decrypt failed — possible data corruption"
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Point SyncController at it**
+
+In `lib/engram_web/controllers/sync_controller.ex`, add `alias Engram.Crypto.PathCrypto` to the alias block, delete the private `path_aad/3` and `decrypt_path!/4` definitions, and replace their call sites:
+
+- `path_aad(:notes, id, dek_version)` → `PathCrypto.aad(:notes, id, dek_version)`
+- `path_aad(:attachments, id, dek_version)` → `PathCrypto.aad(:attachments, id, dek_version)`
+- `decrypt_path!(path_ct, path_nonce, dek, aad)` → `PathCrypto.decrypt!(path_ct, path_nonce, dek, aad)`
+
+- [ ] **Step 3: Verify no behavior changed**
+
+Run: `mix test test/engram_web/controllers/sync_controller_test.exs`
+Expected: PASS, same count as before the refactor. This is a pure move — any failure means the extraction changed behavior.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/engram/crypto/path_crypto.ex lib/engram_web/controllers/sync_controller.ex
+git commit -m "refactor(crypto): extract shared AAD-bound path decrypt"
+```
+
+---
+
+### Task 2: The endpoint — notes, with the since_seq short-circuit
+
+**Files:**
+- Create: `lib/engram_web/controllers/vault_tree_controller.ex`
+- Modify: `lib/engram_web/router.ex`
+- Test: `test/engram_web/controllers/vault_tree_controller_test.exs`
+
+**Interfaces:**
+- Consumes: `Engram.Crypto.PathCrypto.aad/3`, `Engram.Crypto.PathCrypto.decrypt!/4`, `Engram.Vaults.current_seq/2`, `Engram.Crypto.get_dek/1`
+- Produces: `GET /api/vault/tree` returning `%{folders: [...], notes: [...], attachments: [...], change_seq: integer}` or `%{unchanged: true, change_seq: integer}`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/engram_web/controllers/vault_tree_controller_test.exs`:
+
+```elixir
+defmodule EngramWeb.VaultTreeControllerTest do
+  use EngramWeb.ConnCase, async: true
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    insert(:subscription, user: user, tier: "pro", status: "active")
+    vault = insert(:vault, user: user, is_default: true)
+    {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
+    authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
+    %{conn: authed, user: user, vault: vault}
+  end
+
+  describe "GET /vault/tree" do
+    test "returns an empty tree for a new user", %{conn: conn} do
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+
+      assert body["notes"] == []
+      assert body["folders"] == []
+      assert body["attachments"] == []
+      assert body["change_seq"] == 0
+    end
+
+    test "returns every note with id, path and both timestamps", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Test/A.md", content: "# Alpha", mtime: 1_000.0})
+      post(conn, "/api/notes", %{path: "Test/B.md", content: "# Beta", mtime: 1_000.0})
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+
+      assert length(body["notes"]) == 2
+      note = Enum.find(body["notes"], &(&1["path"] == "Test/A.md"))
+      assert note["id"]
+      assert note["created_at"]
+      assert note["updated_at"]
+    end
+
+    test "omits the fields the tree never reads", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "A.md", content: "# A", mtime: 1_000.0})
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+      note = hd(body["notes"])
+
+      # These are the ~128 bytes/note that disqualified reusing the manifest.
+      refute Map.has_key?(note, "content_hash")
+      refute Map.has_key?(note, "crdt_head")
+      refute Map.has_key?(note, "tags")
+    end
+
+    test "since_seq matching the current seq short-circuits", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "A.md", content: "# A", mtime: 1_000.0})
+      seq = conn |> get("/api/vault/tree") |> json_response(200) |> Map.fetch!("change_seq")
+
+      body = conn |> get("/api/vault/tree?since_seq=#{seq}") |> json_response(200)
+
+      assert body["unchanged"] == true
+      assert body["change_seq"] == seq
+      refute Map.has_key?(body, "notes")
+    end
+
+    test "a stale or garbage since_seq returns the full payload", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "A.md", content: "# A", mtime: 1_000.0})
+
+      for raw <- ["0", "not-a-number", "-5", ""] do
+        body = conn |> get("/api/vault/tree?since_seq=#{raw}") |> json_response(200)
+        refute body["unchanged"]
+        assert length(body["notes"]) == 1
+      end
+    end
+
+    test "never leaks another user's notes", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Mine.md", content: "# Mine", mtime: 1_000.0})
+
+      other = insert(:user)
+      insert(:subscription, user: other, tier: "pro", status: "active")
+      other_vault = insert(:vault, user: other, is_default: true)
+      {:ok, other_key, _} = Engram.Accounts.create_api_key(other, "other-key")
+      grant_api_write!(other)
+
+      other_conn =
+        build_conn()
+        |> put_req_header("authorization", "Bearer #{other_key}")
+
+      post(other_conn, "/api/notes", %{path: "Theirs.md", content: "# T", mtime: 1_000.0})
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+      paths = Enum.map(body["notes"], & &1["path"])
+
+      assert "Mine.md" in paths
+      refute "Theirs.md" in paths
+      assert other_vault.id
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `mix test test/engram_web/controllers/vault_tree_controller_test.exs`
+Expected: FAIL — no route matches `/api/vault/tree` (`Phoenix.Router.NoRouteError`).
+
+- [ ] **Step 3: Create the controller**
+
+Create `lib/engram_web/controllers/vault_tree_controller.ex`:
+
+```elixir
+defmodule EngramWeb.VaultTreeController do
+  @moduledoc """
+  One read for the web file tree.
+
+  The tree needs every folder, note and attachment in the vault at once.
+  `/api/folders/list?folder=` was built for the plugin, which walks one
+  folder at a time, so the SPA was firing one request per folder — 20-33
+  requests moving 39.5 KB, serialized 6-at-a-time by the HTTP/1.1
+  connection limit, up to 5.6s of pure queueing before the last one was
+  even sent. This is that same data in one response.
+
+  Payload is deliberately minimal: `noteToTreeItem` derives title and
+  extension from `path`, so `title`, `tags`, `version`, `mtime`,
+  `content_hash` and `crdt_head` are all omitted. Reusing the sync
+  manifest was rejected for exactly that reason — it carries ~128 bytes
+  per note of hashes the tree never reads (~1.3 MB at 10k notes).
+  """
+  use EngramWeb, :controller
+
+  import Ecto.Query
+
+  alias Engram.Attachments.Attachment
+  alias Engram.Crypto
+  alias Engram.Crypto.PathCrypto
+  alias Engram.Notes
+  alias Engram.Notes.Note
+  alias Engram.Repo
+
+  def show(conn, params) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+    current = Engram.Vaults.current_seq(user.id, vault.id)
+
+    if parse_since_seq(params["since_seq"]) == current do
+      json(conn, %{unchanged: true, change_seq: current})
+    else
+      case Crypto.get_dek(user) do
+        {:ok, dek} -> render_tree(conn, user, vault, dek, current)
+        {:error, :no_dek} -> json(conn, empty_tree(current))
+      end
+    end
+  end
+
+  defp empty_tree(current_seq) do
+    %{folders: [], notes: [], attachments: [], change_seq: current_seq}
+  end
+
+  defp render_tree(conn, user, vault, dek, current_seq) do
+    {:ok, note_rows} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(
+          from(n in Note,
+            where:
+              n.user_id == ^user.id and n.vault_id == ^vault.id and is_nil(n.deleted_at) and
+                n.kind == "note",
+            select:
+              {n.id, n.dek_version, n.path_ciphertext, n.path_nonce, n.inserted_at, n.updated_at}
+          )
+        )
+      end)
+
+    {:ok, attachment_rows} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(
+          from(a in Attachment,
+            where: a.user_id == ^user.id and a.vault_id == ^vault.id and is_nil(a.deleted_at),
+            select:
+              {a.id, a.dek_version, a.path_ciphertext, a.path_nonce, a.mime_type, a.size_bytes}
+          )
+        )
+      end)
+
+    # Sequential on purpose — SyncController measured path-sized decrypts at
+    # ~4µs each (10k in ~43ms) and found chunked parallel SLOWER, because
+    # copying results back to the caller's heap rivals the AES-GCM work.
+    notes =
+      Crypto.measure_decrypt_batch(:vault_tree_notes, length(note_rows), fn ->
+        Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, created, updated} ->
+          aad = PathCrypto.aad(:notes, id, dek_version)
+
+          %{
+            id: id,
+            path: PathCrypto.decrypt!(path_ct, path_nonce, dek, aad),
+            created_at: created,
+            updated_at: updated
+          }
+        end)
+      end)
+      |> Enum.sort_by(& &1.path)
+
+    attachments =
+      Crypto.measure_decrypt_batch(:vault_tree_attachments, length(attachment_rows), fn ->
+        Enum.map(attachment_rows, fn {id, dek_version, path_ct, path_nonce, mime, size} ->
+          aad = PathCrypto.aad(:attachments, id, dek_version)
+
+          %{
+            id: id,
+            path: PathCrypto.decrypt!(path_ct, path_nonce, dek, aad),
+            mime_type: mime,
+            size_bytes: size
+          }
+        end)
+      end)
+      |> Enum.sort_by(& &1.path)
+
+    json(conn, %{
+      folders: folders_payload(user, vault),
+      notes: notes,
+      attachments: attachments,
+      change_seq: current_seq
+    })
+  end
+
+  # Same shape FoldersController.index/2 returns — `name` IS the full path.
+  # Matching it exactly lets the client seed the existing `folders` cache
+  # with no mapping layer.
+  defp folders_payload(user, vault) do
+    {:ok, folders} = Notes.list_folders_with_counts(user, vault)
+    markers = Notes.list_folder_markers(user, vault)
+    id_by_path = Map.new(markers, fn m -> {m.folder, m.id} end)
+
+    Enum.map(folders, fn f ->
+      %{
+        id: Map.get(id_by_path, f.folder),
+        name: f.folder,
+        count: f.count,
+        parent_id: Map.get(id_by_path, parent_path(f.folder))
+      }
+    end)
+  end
+
+  defp parent_path(path) do
+    case :binary.matches(path, "/") do
+      [] -> ""
+      matches -> {pos, _} = List.last(matches); binary_part(path, 0, pos)
+    end
+  end
+
+  defp parse_since_seq(raw) when is_binary(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n >= 0 -> n
+      _ -> nil
+    end
+  end
+
+  defp parse_since_seq(_), do: nil
+end
+```
+
+**Note for the implementer:** `FoldersController` already has a `parent_path/1`. Before writing the copy above, check whether it is public or can be shared — if `Engram.Notes` exposes an equivalent, use that instead of duplicating. Duplicating a one-line path helper is acceptable; duplicating crypto is not (hence Task 1).
+
+- [ ] **Step 4: Add the route**
+
+In `lib/engram_web/router.ex`, inside the **vault-scoped** pipeline (the same block containing `get "/folders", FoldersController, :index` — around line 410), add:
+
+```elixir
+    # One read for the whole web file tree. See VaultTreeController's moduledoc
+    # for why the per-folder endpoints could not serve this.
+    get "/vault/tree", VaultTreeController, :show
+```
+
+It must sit in the vault-scoped pipeline so `conn.assigns.current_vault` is populated and `RequireOnboarding` gates it like `/api/notes`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `mix test test/engram_web/controllers/vault_tree_controller_test.exs`
+Expected: PASS, all 6 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/engram_web/controllers/vault_tree_controller.ex lib/engram_web/router.ex test/engram_web/controllers/vault_tree_controller_test.exs
+git commit -m "feat(api): add GET /api/vault/tree bulk read for the web tree"
+```
+
+---
+
+### Task 3: OpenAPI schema and spec regeneration
+
+Without this the build fails — CI regenerates the spec and diffs it against the committed `openapi.json`.
+
+**Files:**
+- Create: `lib/engram_web/schemas/vault_tree.ex`
+- Modify: `lib/engram_web/controllers/vault_tree_controller.ex`
+- Modify: `openapi.json`
+
+**Interfaces:**
+- Produces: `EngramWeb.Schemas.VaultTreeResponse`
+
+- [ ] **Step 1: Read a sibling schema first**
+
+Run: `cat lib/engram_web/schemas/sync.ex`
+
+Match its module naming, `OpenApiSpex.schema/1` structure, and how it is referenced from the controller. Do not invent a different style.
+
+- [ ] **Step 2: Write the schema**
+
+Create `lib/engram_web/schemas/vault_tree.ex` following the structure of `sync.ex`, defining `EngramWeb.Schemas.VaultTreeResponse` with properties `folders`, `notes`, `attachments`, `change_seq`, plus the `unchanged` boolean for the short-circuit response.
+
+- [ ] **Step 3: Add the operation block to the controller**
+
+Add `use OpenApiSpex.ControllerSpecs` under `use EngramWeb, :controller`, then above `def show`:
+
+```elixir
+  operation(:show,
+    operation_id: "vault-tree",
+    summary: "Get the whole vault tree in one read",
+    tags: ["Vaults"],
+    description:
+      "Every folder, note and attachment the file tree renders, in one response. " <>
+        "Pass `since_seq` (a prior response's `change_seq`) to short-circuit: when " <>
+        "nothing has changed the body is just `{unchanged: true, change_seq}`.",
+    parameters: [
+      since_seq: [
+        in: :query,
+        type: :string,
+        required: false,
+        description: "Watermark from a prior response's `change_seq`; invalid values are ignored.",
+        example: "1042"
+      ]
+    ],
+    responses: [ok: {"Vault tree", "application/json", Schemas.VaultTreeResponse}]
+  )
+```
+
+Add `alias EngramWeb.Schemas` to the alias block.
+
+- [ ] **Step 4: Regenerate the committed spec**
+
+```bash
+MIX_ENV=test mix openapi.spec.json --spec EngramWeb.ApiSpec --pretty=true openapi.json
+```
+
+- [ ] **Step 5: Verify the spec matches what CI will generate**
+
+```bash
+MIX_ENV=test mix openapi.spec.json --spec EngramWeb.ApiSpec --pretty=true /tmp/openapi.generated.json
+python3 -c "import json,sys; json.dump(json.load(open(sys.argv[1])), open(sys.argv[2],'w'), sort_keys=True, indent=2)" openapi.json /tmp/a.json
+python3 -c "import json,sys; json.dump(json.load(open(sys.argv[1])), open(sys.argv[2],'w'), sort_keys=True, indent=2)" /tmp/openapi.generated.json /tmp/b.json
+diff /tmp/a.json /tmp/b.json && echo "SPEC IN SYNC"
+```
+
+Expected: `SPEC IN SYNC`. This is the exact comparison the CI job performs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/engram_web/schemas/vault_tree.ex lib/engram_web/controllers/vault_tree_controller.ex openapi.json
+git commit -m "docs(api): document GET /api/vault/tree in the OpenAPI spec"
+```
+
+---
+
+### Task 4: Client — fetch once, seed every cache
+
+**Files:**
+- Modify: `frontend/src/api/queries.ts`
+- Test: `frontend/src/api/vault-tree.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `GET /api/vault/tree`
+- Produces: `useVaultTree(): UseQueryResult<VaultTree>` and `seedTreeCaches(qc: QueryClient, vaultId: string, tree: VaultTree): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/api/vault-tree.test.tsx`. Mirror the mocking style of the existing `frontend/src/api/queries.test.tsx` (`vi.mock("./client")` with a hoisted `get` spy, a `QueryClientProvider` wrapper, `useActiveVaultId` mocked to `"42"`).
+
+```tsx
+describe("seedTreeCaches", () => {
+  it("seeds notes into their path-derived folder cache", () => {
+    const qc = new QueryClient();
+    seedTreeCaches(qc, "42", {
+      folders: [{ id: "f1", name: "Projects", count: 1, parent_id: null }],
+      notes: [
+        { id: "n1", path: "Projects/spec.md", created_at: "s", updated_at: "s" },
+        { id: "n2", path: "root.md", created_at: "s", updated_at: "s" },
+      ],
+      attachments: [],
+      change_seq: 7,
+    });
+
+    const projects = qc.getQueryData(["folder-notes-by-id", "42", "f1"]);
+    expect(projects).toHaveLength(1);
+    expect(projects[0].id).toBe("n1");
+
+    // Root notes live under the ROOT_FOLDER_ID sentinel, not under "".
+    const root = qc.getQueryData(["folder-notes-by-id", "42", ROOT_FOLDER_ID]);
+    expect(root).toHaveLength(1);
+    expect(root[0].id).toBe("n2");
+  });
+
+  it("seeds the folders and attachments caches from the same response", () => {
+    const qc = new QueryClient();
+    seedTreeCaches(qc, "42", {
+      folders: [{ id: "f1", name: "Projects", count: 0, parent_id: null }],
+      notes: [],
+      attachments: [
+        { id: "a1", path: "img.png", mime_type: "image/png", size_bytes: 10 },
+      ],
+      change_seq: 1,
+    });
+
+    expect(qc.getQueryData(["folders", "42"])).toHaveLength(1);
+    expect(qc.getQueryData(["attachments", "42"])).toHaveLength(1);
+  });
+
+  it("puts notes in a folder with no marker row under its synthetic id", () => {
+    const qc = new QueryClient();
+    seedTreeCaches(qc, "42", {
+      folders: [],
+      notes: [{ id: "n1", path: "Derived/a.md", created_at: "s", updated_at: "s" }],
+      attachments: [],
+      change_seq: 1,
+    });
+
+    // A folder with no backend marker carries a `syn:<path>` id — the loader
+    // resolves it that way, so the seeded key must match or the row vanishes.
+    const key = ["folder-notes-by-id", "42", syntheticFolderId("Derived")];
+    expect(qc.getQueryData(key)).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Confirm the exact cache keys before implementing**
+
+Run these and read the output — the seeded keys must match byte-for-byte or the tree silently renders nothing:
+
+```bash
+cd frontend
+grep -n '"folders", vaultId\|\["folders"' src/api/queries.ts
+grep -n '"attachments", vaultId\|\["attachments"' src/api/queries.ts
+grep -n 'ROOT_FOLDER_ID' src/api/queries.ts | head -5
+grep -n 'export function syntheticFolderId\|isSyntheticFolderId' src/viewer/tree/synthesize-folders.ts
+```
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+Run: `bunx vitest run src/api/vault-tree.test.tsx`
+Expected: FAIL — `seedTreeCaches` is not exported.
+
+- [ ] **Step 4: Implement**
+
+In `frontend/src/api/queries.ts` add the types, the query hook, and the seeding function. Group notes by the folder portion of `path` (everything before the last `/`, or `ROOT_FOLDER_ID` when there is none), map folder path → folder id using the response's `folders`, and fall back to `syntheticFolderId(path)` for folders with no marker row. Fill the `NoteSummary` fields the tree does not read (`title`, `folder`, `tags`, `version`, `mtime`) with values derived from `path` or sensible defaults, so the cached rows still satisfy the existing `NoteSummary` type.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `bunx vitest run src/api/vault-tree.test.tsx`
+Expected: PASS, all 3 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/queries.ts src/api/vault-tree.test.tsx
+git commit -m "feat(web): add useVaultTree and seed tree caches from one response"
+```
+
+---
+
+### Task 5: Delete the fan-out
+
+The actual bug. This task removes the loop and adds the regression guard that fails if it ever returns.
+
+**Files:**
+- Modify: `frontend/src/viewer/folder-tree.tsx:231-246`
+- Test: `frontend/src/viewer/folder-tree.test.tsx`
+
+**Interfaces:**
+- Consumes: `useVaultTree`, `seedTreeCaches` from Task 4
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add to `frontend/src/viewer/folder-tree.test.tsx`. The existing harness mocks `../api/queries` with `importActual` and a mutable `mock` fixture object — follow it.
+
+```tsx
+// The fan-out this whole change exists to kill: one request per folder,
+// 20-33 of them, serialized 6-at-a-time by the HTTP/1.1 connection limit.
+it("issues one tree request, not one per folder", async () => {
+  mock.folders = [
+    { id: "1", parent_id: null, name: "A", count: 0 },
+    { id: "2", parent_id: null, name: "B", count: 0 },
+    { id: "3", parent_id: null, name: "C", count: 0 },
+  ];
+  renderTree();
+  await screen.findByRole("treeitem", { name: "A" });
+
+  expect(fetchNotesForFolderIdSpy).not.toHaveBeenCalled();
+});
+```
+
+Add `fetchNotesForFolderId` to the `vi.mock("../api/queries", ...)` factory as a hoisted spy so the test can assert it is never called on load.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `bunx vitest run src/viewer/folder-tree.test.tsx -t "issues one tree request"`
+Expected: FAIL — the spy was called 3 times, once per folder.
+
+- [ ] **Step 3: Delete the loop**
+
+In `frontend/src/viewer/folder-tree.tsx`, delete the `bulkPrefetchedRef` declaration and the entire `useEffect` that loops `for (const f of folders) { prefetchFolderNotes(f.id); }` (the block commented "Bulk prefetch every folder's notes once after `useFolders` lands").
+
+**Keep** `prefetchFolderNotes` itself — the hover-prefetch call site still uses it as a safety net for folders whose notes are somehow not in the seeded cache.
+
+- [ ] **Step 4: Wire the tree query**
+
+Call `useVaultTree()` in `FolderTree` and seed the caches in an effect when its data arrives.
+
+- [ ] **Step 5: Run the full frontend suite**
+
+Run: `bunx vitest run`
+Expected: PASS. Pay attention to `folder-tree.test.tsx` and `note-page.test.tsx` — the seeded cache shape must satisfy every existing consumer.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/viewer/folder-tree.tsx src/viewer/folder-tree.test.tsx
+git commit -m "perf(web): replace per-folder tree fan-out with one bulk read"
+```
+
+---
+
+### Task 6: Verify against a real browser
+
+Unit tests cannot prove the request count dropped in a real app. Measure it the same way the problem was found.
+
+- [ ] **Step 1: Bring up the dev stack against this worktree**
+
+```bash
+cd /home/open-claw/documents/code-projects/engram-workspace
+make dev-selfhost BACKEND_DIR=$(pwd)/../engram/.worktrees/<this-worktree>
+```
+
+The worktree needs `.env.local`, `.env.local-selfhost`, `.env.local-saasdev` and `frontend/.env.local` copied from the main checkout — they are gitignored, so `git worktree add` does not bring them, and bring-up aborts without them.
+
+- [ ] **Step 2: Count the requests**
+
+Load the vault, then in the browser console:
+
+```js
+performance.getEntriesByType('resource')
+  .filter(r => r.name.includes('/api/'))
+  .map(r => r.name.replace(location.origin,'').split('?')[0])
+  .reduce((a,p) => (a[p]=(a[p]||0)+1, a), {})
+```
+
+Expected: `/api/vault/tree` appears once; `/api/folders/list` does **not** appear at all. Before this change the same command returned 20–33 `/api/folders/list` entries.
+
+- [ ] **Step 3: Confirm the queueing is gone**
+
+```js
+performance.getEntriesByType('resource')
+  .filter(r => r.name.includes('/api/'))
+  .map(r => ({ p: r.name.replace(location.origin,'').split('?')[0],
+               queued: Math.round(r.requestStart - r.startTime),
+               server: Math.round(r.responseStart - r.requestStart) }))
+```
+
+Expected: no entry with `queued` above ~50ms. The pre-change baseline was 5,626ms.
+
+- [ ] **Step 4: Run the full backend gate, sequentially**
+
+```bash
+mix format --check-formatted
+mix credo
+mix dialyzer
+mix test --warnings-as-errors
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin <branch>
+GH_REPO=engram-app/Engram gh pr create --base main \
+  --title "perf(web): one bulk read for the file tree" --body "..."
+```
+
+Include the before/after request counts and queue times in the PR body — they are the justification for the whole change.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Endpoint contract → Task 2. `since_seq` → Task 2 Step 1. Excluded fields → Task 2 (asserted by test). Both timestamps → Task 2. Client seeding → Task 4. Loop deletion → Task 5. Folder-id-mapping risk → Task 4 Step 2 + the synthetic-folder test. Attachment double-source risk → resolved by seeding one source (Deviation 2). Backend + frontend test lists → Tasks 2, 4, 5.
+
+**Gap found and added:** The spec did not mention the OpenAPI CI gate. Without Task 3 the build fails. Added.
+
+**Gap found and added:** The spec did not account for `path_aad`/`decrypt_path!` being private to `SyncController`. Added Task 1 rather than duplicating crypto.
+
+**Type consistency:** `seedTreeCaches(qc, vaultId, tree)` is used with that signature in Tasks 4 and 5. Folder objects use `name` throughout (Tasks 2, 4), matching the existing `Folder` interface. `PathCrypto.aad/3` and `PathCrypto.decrypt!/4` are defined in Task 1 and called with those arities in Task 2.

--- a/frontend/src/api/channel.ts
+++ b/frontend/src/api/channel.ts
@@ -29,7 +29,7 @@ import {
 	sendCrdtCreateBatch,
 	sendCrdtDelete,
 } from "./crdt-ops";
-import { folderIdForPath } from "./queries";
+import { folderIdForPath, invalidateVaultTree } from "./queries";
 
 // phoenix.js's own default reconnect steps — kept for the 2nd+ attempt. Only
 // the FIRST reconnect is full-jittered, to de-sync a drained fleet so the
@@ -149,6 +149,12 @@ function folderFromPath(path: string): string {
 
 function flushBatch(batch: PendingBatch): void {
 	const { queryClient, vaultId, folders } = batch;
+	// FIRST — this is the linchpin. `["folders"]`, `["attachments"]` and the
+	// whole `["folder-notes-by-id"]` family are DERIVED from the vault tree, so
+	// invalidating them while the tree is still fresh just re-derives the same
+	// pre-event bytes and nothing converges. Staling the tree first means the
+	// derived refetches below all resolve from one post-event fetch.
+	invalidateVaultTree(queryClient, vaultId);
 	queryClient.invalidateQueries({ queryKey: ["folders", vaultId] });
 	queryClient.invalidateQueries({ queryKey: ["search", vaultId] });
 	// The vault-wide path→id inventory behind [[ autocomplete + /:slug/wiki/*
@@ -237,6 +243,9 @@ export const RECONNECT_JITTER_MAX_MS = 60_000;
  * /sync/changes cursor feed (backend #1036).
  */
 export function backfillStructural(queryClient: QueryClient, vaultId: string): void {
+	// FIRST — folders/attachments/folder-notes-by-id all derive from it; see the
+	// same note in flushBatch.
+	invalidateVaultTree(queryClient, vaultId);
 	queryClient.invalidateQueries({ queryKey: ["folders", vaultId] });
 	queryClient.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 	queryClient.invalidateQueries({ queryKey: ["attachments", vaultId] });
@@ -439,6 +448,9 @@ export function handleFoldersBatch(
 	queryClient: QueryClient,
 	vaultId: string,
 ): void {
+	// The folders view derives from the vault tree — stale that first or the
+	// refetch below re-derives the pre-event folder list.
+	invalidateVaultTree(queryClient, vaultId);
 	queryClient.invalidateQueries({ queryKey: ["folders", vaultId] });
 }
 

--- a/frontend/src/api/queries.test.tsx
+++ b/frontend/src/api/queries.test.tsx
@@ -11,7 +11,6 @@ import {
 	type Note,
 	useAcceptTerms,
 	useAppBootstrap,
-	useAttachments,
 	useBacklinks,
 	useBatchDeleteAttachments,
 	useBatchDeleteFolders,
@@ -27,7 +26,6 @@ import {
 	useDeleteVault,
 	useDuplicateNote,
 	useFolderNotesById,
-	useFolders,
 	useNote,
 	usePlanChangePreview,
 	useRenameAttachment,
@@ -819,34 +817,10 @@ describe("rename folder does NOT re-path cached child notes optimistically", () 
 // verbatim. `name` continues to carry the FULL folder path — that
 // shape is load-bearing for existing consumers and stays.
 
+// What these hooks READ (all three derive from one /vault/tree fetch, and the
+// convergence + no-fan-out invariants) lives in api/vault-tree.test.tsx, which
+// drives them against a real tree payload. Only the gating is asserted here.
 describe("useFolderNotesById", () => {
-	it("fetches notes for the given folder id", async () => {
-		get.mockResolvedValue({
-			notes: [
-				{
-					id: "100",
-					path: "foo/a.md",
-					title: "A",
-					folder: "foo",
-					tags: [],
-					version: 1,
-					mtime: "s",
-					created_at: "s",
-					updated_at: "s",
-				},
-			],
-		});
-
-		const { result } = renderHook(() => useFolderNotesById("42"), { wrapper });
-		await waitFor(() => expect(result.current.data).toBeDefined());
-
-		expect(get).toHaveBeenCalledWith("/folders/by-id/42/notes");
-		expect(result.current.data?.[0]).toMatchObject({
-			id: expect.any(String),
-			path: expect.any(String),
-		});
-	});
-
 	it("disabled when folderId is null", () => {
 		const { result } = renderHook(() => useFolderNotesById(null), { wrapper });
 		expect(result.current.fetchStatus).toBe("idle");
@@ -862,36 +836,6 @@ describe("Folder type", () => {
 			name: string;
 			count: number;
 		}>();
-	});
-});
-
-describe("useFolders", () => {
-	it("passes through id + parent_id from the backend response", async () => {
-		get.mockResolvedValue({
-			folders: [
-				{ id: "7", parent_id: null, name: "top", count: 2 },
-				{ id: "8", parent_id: "7", name: "top/sub", count: 1 },
-			],
-		});
-
-		const { result } = renderHook(() => useFolders(), { wrapper });
-		await waitFor(() => expect(result.current.data).toBeDefined());
-
-		expect(get).toHaveBeenCalledWith("/folders");
-		const folders = result.current.data ?? [];
-		expect(folders).toHaveLength(2);
-		expect(folders[0]).toMatchObject({
-			id: "7",
-			parent_id: null,
-			name: "top",
-			count: 2,
-		});
-		expect(folders[1]).toMatchObject({
-			id: "8",
-			parent_id: "7",
-			name: "top/sub",
-			count: 1,
-		});
 	});
 });
 
@@ -2005,29 +1949,6 @@ describe("useSearch", () => {
 				{ signal: expect.any(AbortSignal) },
 			),
 		);
-	});
-});
-
-describe("useAttachments", () => {
-	it("fetches /attachments and returns the attachments array", async () => {
-		get.mockResolvedValue({
-			attachments: [
-				{
-					id: "a-1",
-					path: "a.png",
-					mime_type: "image/png",
-					size_bytes: 10,
-					mtime: 1,
-					updated_at: "2026-06-10T00:00:00Z",
-				},
-			],
-		});
-
-		const { result } = renderHook(() => useAttachments(), { wrapper });
-		await waitFor(() => expect(result.current.data).toBeDefined());
-
-		expect(get).toHaveBeenCalledWith("/attachments");
-		expect(result.current.data?.[0]?.path).toBe("a.png");
 	});
 });
 

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -8,6 +8,7 @@ import {
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { collideBump } from "@/lib/collide-bump";
+import { noteName } from "@/lib/note-name";
 import { uuid7 } from "../crdt/uuid7";
 import {
 	isSyntheticFolderId,
@@ -262,6 +263,109 @@ interface BatchFoldersContext {
 	noteListSnapshots: Array<{ key: readonly unknown[]; data: NoteSummary[] | undefined }>;
 }
 
+// Bumped by `invalidateVaultTree` — the single chokepoint every tree
+// invalidation goes through, from `api/channel.ts` and from every mutation.
+// `fetchVaultTreeFresh` reads it to tell whether a change landed while its
+// request was in flight. Module-global rather than per-vault: a vault switch
+// costs at most one extra refetch, which is not worth a Map to avoid.
+let treeInvalidationGen = 0;
+
+// Cap on consecutive "the tree I just fetched is already out of date" retries.
+// ponytail: 3 is a backstop against a pathological event storm, not a tuning
+// knob — the loop's own exit condition is what normally ends it. Past the cap
+// we keep the newest snapshot we have; the NEXT invalidation then lands on a
+// query that HAS data, which query-core restarts properly (Query.fetch takes
+// the `cancel({silent:true})` branch when `cancelRefetch` is set, which
+// `refetchQueries` defaults to true). So exceeding the cap degrades to the
+// already-correct steady-state path, never to a hang.
+const MAX_STALE_TREE_REFETCHES = 3;
+
+/**
+ * Fetch the vault tree, re-fetching if an invalidation landed mid-flight.
+ *
+ * This closes the one window the derived-query redesign left open. On the
+ * FIRST-EVER fetch `state.data === undefined`, so `Query.fetch` takes the
+ * `return this.#retryer.promise` branch and COALESCES the invalidation onto
+ * the in-flight request instead of restarting it — and the `success` dispatch
+ * then sets `isInvalidated: false`. The result: a snapshot that predates the
+ * event lands marked fresh, and nothing ever asks again. Verified against
+ * @tanstack/query-core 5.101.4 `src/query.ts`.
+ *
+ * `change_seq` would be the natural detector, but no sync-channel event
+ * carries a seq to compare it against (see the `VaultTree` note), so we detect
+ * the invalidation itself rather than the staleness it implies.
+ *
+ * Convergence: `seen` is re-captured immediately BEFORE each retry request is
+ * issued, so the loop exits as soon as one request completes with no
+ * invalidation having arrived during it. The condition is equality against a
+ * monotonically increasing counter — never a comparison of payload contents —
+ * so it cannot oscillate between two states; each iteration strictly consumes
+ * the generation value that triggered it.
+ */
+async function fetchVaultTreeFresh(): Promise<VaultTree> {
+	let seen = treeInvalidationGen;
+	let tree = await api.get<VaultTree>("/vault/tree");
+	for (let i = 0; treeInvalidationGen !== seen && i < MAX_STALE_TREE_REFETCHES; i++) {
+		seen = treeInvalidationGen;
+		tree = await api.get<VaultTree>("/vault/tree");
+	}
+	return tree;
+}
+
+// Read the one vault-tree query every sidebar view derives from.
+//
+// `fetchQuery`, NOT `ensureQueryData`: ensureQueryData returns whatever is
+// cached the moment `state.data !== undefined` (verified in
+// @tanstack/query-core 5.101 — it only consults staleness to fire an OPTIONAL
+// background prefetch, and still resolves with the stale value). An invalidated
+// tree would therefore keep serving the pre-event snapshot to every derived
+// refetch, forever: silent staleness, which is the exact bug this seam was
+// rebuilt to remove. `fetchQuery` calls `query.isStaleByTime(...)` first, and
+// `isStaleByTime` returns true whenever the query is invalidated — so one
+// invalidation produces exactly ONE network fetch, and every derived refetch in
+// the same tick dedupes onto that in-flight promise (Query.fetch returns the
+// live retryer promise when a fetch is already running).
+function fetchVaultTree(qc: QueryClient, vaultId: string | null | undefined): Promise<VaultTree> {
+	return qc.fetchQuery(vaultTreeQueryOptions(vaultId));
+}
+
+// A `/vault/tree` note row in the `NoteSummary` shape every note-list cache
+// carries. `title`/`tags`/`version` are not on the wire — see the controller
+// moduledoc: the tree derives everything it renders from `path`.
+function treeNoteToSummary(n: VaultTreeNote): NoteSummary {
+	return {
+		id: n.id,
+		path: n.path,
+		title: noteName(n.path),
+		folder: folderOf(n.path),
+		tags: [],
+		version: 0,
+		// Type divergence, not a bug (nothing reads NoteSummary.mtime today):
+		// this is an ISO string, but a row fetched from /api/notes carries mtime
+		// as an epoch float (note.ex's `mtime` field is `:float`). Don't do
+		// arithmetic on this without normalizing first.
+		mtime: n.updated_at,
+		created_at: n.created_at,
+		updated_at: n.updated_at,
+	};
+}
+
+// Inverse of the id-keying every note-list cache uses: the vault root keys
+// under the ROOT_FOLDER_ID sentinel (it has no marker row), a folder the
+// backend returned with `id: null` — or one that only exists because a note
+// sits in it — keys under `syn:<path>` exactly as synthesize-folders.ts
+// derives, and everything else under its marker id. Null when the tree holds
+// no such folder; the tree is the whole inventory, so that folder has no notes.
+function folderPathForId(tree: VaultTree, folderId: string): string | null {
+	if (folderId === ROOT_FOLDER_ID) {
+		return "";
+	}
+	if (isSyntheticFolderId(folderId)) {
+		return syntheticFolderPath(folderId);
+	}
+	return tree.folders.find((f) => f.id === folderId)?.name ?? null;
+}
+
 // Resolve a folder PATH (a NoteSummary.folder, or '' for the vault root) to the
 // id its note list is cached under. Root maps to the sentinel without a lookup;
 // every other folder resolves through the folders cache marker. Returns null
@@ -351,18 +455,28 @@ export interface User {
 
 export function useFolders() {
 	const vaultId = useActiveVaultId();
+	const qc = useQueryClient();
 	return useQuery({
 		queryKey: ["folders", vaultId],
-		// Backend echoes a synthetic root row (`name === ""`, `id === null`) to
-		// expose the count of root-level notes. The tree owns root notes via
-		// `useFolderNotes('')`; drop the synthetic row so consumers only see real
-		// folder markers + the `Folder.id: string` contract holds.
-		queryFn: () => api.get<RawFoldersCache>("/folders"),
+		// Derived from the one vault-tree read, not a second HTTP request:
+		// `folders_payload/2` (lib/engram/notes.ex) is the same backend function
+		// behind /api/folders, so these rows are byte-identical to what that
+		// endpoint sent — including the synthetic root row (`name === ""`,
+		// `id === null`) that `selectFolders` drops so consumers only ever see
+		// real folder markers and the `Folder.id: string` contract holds.
+		queryFn: async (): Promise<RawFoldersCache> => ({
+			folders: (await fetchVaultTree(qc, vaultId)).folders,
+		}),
 		select: selectFolders,
+		// No vault id = nothing to scope the read to. Ungated, a deep link
+		// arriving before the bootstrap reconcile lands would fetch (and
+		// server-side decrypt) some other vault's whole inventory, then discard it.
+		enabled: Boolean(vaultId),
 		// Folder listing decrypts every marker row server-side; without a
-		// staleTime each remount/window-focus refetches it. Mutations and the
-		// sync channel (channel.ts) invalidate this key, so 60s of staleness
-		// only spans gaps nothing else would catch anyway.
+		// staleTime each remount/window-focus re-derives it (and, once the tree
+		// itself is stale, refetches). Mutations and the sync channel
+		// (channel.ts) invalidate this key AND the tree, so 60s of staleness only
+		// spans gaps nothing else would catch anyway.
 		staleTime: FOLDER_NOTES_STALE_MS,
 	});
 }
@@ -401,10 +515,17 @@ export interface AttachmentSummary {
 
 export function useAttachments() {
 	const vaultId = useActiveVaultId();
+	const qc = useQueryClient();
 	return useQuery({
 		queryKey: ["attachments", vaultId],
-		queryFn: () => api.get<{ attachments: AttachmentSummary[] }>("/attachments"),
+		// Derived from the vault tree — `VaultTreeAttachment` IS `AttachmentSummary`
+		// (same fields, same units), so the rows pass straight through. `mtime` and
+		// `updated_at` must stay the real values: loader.ts sorts attachments by
+		// `mtime` under a "modified-*" sort, and use-engram-tree.ts's
+		// `attachmentsFingerprint` reads `updated_at` to decide whether to rebuild.
+		queryFn: async () => ({ attachments: (await fetchVaultTree(qc, vaultId)).attachments }),
 		select: selectAttachments,
+		enabled: Boolean(vaultId),
 		staleTime: FOLDER_NOTES_STALE_MS,
 	});
 }
@@ -439,6 +560,7 @@ export function useUploadAttachment() {
 			// 402s (disabled / text-only / too-large / quota) throw LimitExceededError
 			// AND open the global UpgradeRequiredDialog via the client's
 			// upgradeHandler — nothing to handle here.
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["attachments", vaultId] });
@@ -452,33 +574,141 @@ export function useUploadAttachment() {
 // shape (`NoteSummary[]`), for every folder including root.
 export const ROOT_FOLDER_ID = "root";
 
-// Single fetcher behind every id-keyed note list. Root reads the path-keyed
-// list endpoint (the only one that accepts an empty folder); every other
-// folder reads its by-id endpoint. Both normalize to `NoteSummary[]`.
-export function fetchNotesForFolderId(folderId: string): Promise<NoteSummary[]> {
-	if (folderId === ROOT_FOLDER_ID) {
-		return api.get<{ notes: NoteSummary[] }>("/folders/list?folder=").then((r) => r.notes);
-	}
-	// Derived/synthesized folders have no backend marker row, so the by-id endpoint
-	// can't resolve them. They carry a `syn:<path>` id — list their notes by path
-	// through the same endpoint root uses.
-	if (isSyntheticFolderId(folderId)) {
-		const path = syntheticFolderPath(folderId);
-		return api
-			.get<{ notes: NoteSummary[] }>(`/folders/list?folder=${encodeURIComponent(path)}`)
-			.then((r) => r.notes);
-	}
-	return api.get<{ notes: NoteSummary[] }>(`/folders/by-id/${folderId}/notes`).then((r) => r.notes);
+/**
+ * Options for one folder's note list, derived from the vault tree.
+ *
+ * Shared (not inlined into the hook) because three call sites must build the
+ * SAME query — the mounted `useFolderNotesById`, the tree loader's expand path
+ * and the sidebar's hover prefetch. When they didn't, the loader's lazily
+ * fetched entries ended up with a different (or absent) queryFn from the
+ * hook's, which is how an invalidation could reach an entry that had no way to
+ * refetch itself.
+ */
+export function folderNotesByIdQueryOptions(
+	qc: QueryClient,
+	vaultId: string | null | undefined,
+	folderId: string,
+) {
+	return {
+		queryKey: ["folder-notes-by-id", vaultId, folderId] as const,
+		queryFn: async (): Promise<NoteSummary[]> => {
+			const tree = await fetchVaultTree(qc, vaultId);
+			const path = folderPathForId(tree, folderId);
+			// `[]` is an ANSWER, not a cache miss: the tree is the vault's whole
+			// note inventory, so "this folder holds no notes" is known without
+			// asking the server. Falling through to a per-folder request here is
+			// what made expanding an empty folder cost a round trip.
+			return path === null
+				? []
+				: tree.notes.filter((n) => folderOf(n.path) === path).map(treeNoteToSummary);
+		},
+		staleTime: FOLDER_NOTES_STALE_MS,
+	};
 }
 
 export function useFolderNotesById(folderId: string | null, opts: { enabled?: boolean } = {}) {
 	const vaultId = useActiveVaultId();
+	const qc = useQueryClient();
 	return useQuery({
-		queryKey: ["folder-notes-by-id", vaultId, folderId],
-		queryFn: () => fetchNotesForFolderId(folderId as string),
-		enabled: folderId !== null && (opts.enabled ?? true),
-		staleTime: FOLDER_NOTES_STALE_MS,
+		...folderNotesByIdQueryOptions(qc, vaultId, folderId as string),
+		enabled: folderId !== null && Boolean(vaultId) && (opts.enabled ?? true),
 	});
+}
+
+// GET /api/vault/tree row shapes (deliberately thin — see the controller's
+// moduledoc: title/tags/version/mtime are omitted, the tree derives them from
+// `path`). Distinct from `Folder`/`NoteSummary`/`AttachmentSummary`, which are
+// the shapes the REST-per-folder hooks (and their caches) already carry.
+export interface VaultTreeFolder {
+	id: string | null;
+	name: string;
+	count: number;
+	parent_id: string | null;
+}
+export interface VaultTreeNote {
+	id: string;
+	path: string;
+	created_at: string;
+	updated_at: string;
+}
+export interface VaultTreeAttachment {
+	id: string;
+	path: string;
+	mime_type: string;
+	size_bytes: number;
+	mtime: number;
+	updated_at: string;
+}
+// `change_seq` is deliberately NOT declared here even though the endpoint
+// returns it. It is the vault's monotonic write watermark, and it would be the
+// natural way to detect that a tree snapshot predates a change we already know
+// about — except no `sync:` channel event carries a seq to compare it against.
+// `note_changed` (upsert and delete), `notes.batch` and `folders.batch` all ship
+// without one, so the client never holds a second value to put it next to.
+// Declaring a field nothing can use invites exactly the wrong fix: comparing
+// two consecutive tree payloads' `change_seq` and skipping the refetch when
+// they match. See `fetchVaultTreeFresh` for what is used instead, and the
+// redesign report for what stamping a seq onto the broadcasts would cost.
+export interface VaultTree {
+	folders: VaultTreeFolder[];
+	notes: VaultTreeNote[];
+	attachments: VaultTreeAttachment[];
+}
+
+/**
+ * One request for the whole tree — see the controller moduledoc for why (this
+ * replaced one HTTP round-trip per folder, 20-33 on a real vault).
+ *
+ * This query IS the source for `useFolders`, `useAttachments` and
+ * `useFolderNotesById`: they derive their data from it instead of fetching
+ * their own. Nothing writes into those caches sideways, so there is exactly one
+ * place a stale sidebar can come from, and exactly one key to invalidate.
+ *
+ * Shared options rather than a hook alone, because the derived queryFns and the
+ * tree loader all have to reach the SAME Query object.
+ *
+ * `staleTime` matches the derived views (FOLDER_NOTES_STALE_MS) on purpose.
+ * Everything that can change the tree already invalidates this key —
+ * `api/channel.ts` (note_changed / notes.batch / folders.batch / reconnect
+ * backfill) and every mutation, via `invalidateVaultTree` — so 60s of
+ * staleness only spans gaps nothing else would catch, and it is what lets a
+ * folder expand (which fetches its derived note list) cost zero requests.
+ */
+export function vaultTreeQueryOptions(vaultId: string | null | undefined) {
+	return {
+		queryKey: ["vault-tree", vaultId] as const,
+		queryFn: fetchVaultTreeFresh,
+		staleTime: FOLDER_NOTES_STALE_MS,
+	};
+}
+
+/**
+ * Stale the vault tree, and with it every view derived from it.
+ *
+ * Call this wherever `["folders"]` / `["attachments"]` / `["folder-notes-by-id"]`
+ * are invalidated, BEFORE them. Those queries re-derive from the tree, so
+ * staling one without staling the tree re-derives byte-identical data — and
+ * worse, overwrites a just-applied optimistic patch with the pre-mutation
+ * snapshot. Over-calling is cheap: every derived refetch in the same tick
+ * dedupes onto a single network request.
+ *
+ * The generation bump is what makes this work against a tree request that is
+ * ALREADY in flight with no data yet — query-core coalesces that invalidation
+ * instead of restarting it, so `fetchVaultTreeFresh` detects it out-of-band and
+ * re-fetches. Bump BEFORE invalidating, so a fetch that completes between the
+ * two lines still sees the new generation.
+ */
+export function invalidateVaultTree(qc: QueryClient, vaultId: string | null | undefined): void {
+	treeInvalidationGen++;
+	qc.invalidateQueries({ queryKey: ["vault-tree", vaultId] });
+}
+
+export function useVaultTree() {
+	const vaultId = useActiveVaultId();
+	// `enabled`: ungated, a deep link landing before the bootstrap reconcile
+	// (see reconcileActiveVault) would fetch — and server-side decrypt — the
+	// wrong vault's entire inventory under a key nothing later reads.
+	return useQuery({ ...vaultTreeQueryOptions(vaultId), enabled: Boolean(vaultId) });
 }
 
 export function useNote(id: string | null) {
@@ -647,6 +877,10 @@ export function useCreateNote() {
 			return { key, snapshot, placeholderId: id };
 		},
 		onSuccess: ({ id, path }, vars, ctx) => {
+			// FIRST, before any derived key below is invalidated: those re-derive
+			// from the tree, and a tree fetched before this create would revert the
+			// optimistic row we just settled.
+			invalidateVaultTree(qc, vaultId);
 			// Swap the placeholder for the server-assigned id/path.
 			if (ctx) {
 				const filename = path.split("/").pop() ?? path;
@@ -738,6 +972,7 @@ export function useCreateFolder() {
 			throw new ApiError(500, "useCreateFolder: exceeded race retries");
 		},
 		onSuccess: () => {
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 		},
 		onError: (err) => {
@@ -1665,6 +1900,7 @@ export function useRenameNote() {
 			renameErrorToast(err, "file");
 		},
 		onSettled: () => {
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["note", vaultId] });
@@ -1771,6 +2007,7 @@ export function useRenameFolder() {
 			renameErrorToast(err, "folder");
 		},
 		onSettled: () => {
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["note", vaultId] });
@@ -1861,6 +2098,7 @@ export function useDeleteNote() {
 			deleteErrorToast(err, "file");
 		},
 		onSettled: () => {
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 		},
@@ -1919,6 +2157,7 @@ export function useDeleteFolder() {
 			deleteErrorToast(err, "folder");
 		},
 		onSettled: () => {
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 		},
@@ -2030,6 +2269,7 @@ export function useDuplicateNote() {
 			}
 		},
 		onSettled: () => {
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
@@ -2121,6 +2361,7 @@ export function useBatchDeleteNotes() {
 		onSettled: () => {
 			// Reconcile after success AND partial failure — Promise.all is not
 			// atomic, so onError's full restore can resurrect already-deleted rows.
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
@@ -2294,6 +2535,7 @@ export function useBatchMoveNotes() {
 			// crdt_create per id is non-atomic (Promise.all): a mid-batch reject
 			// leaves some ids moved server-side while onError restores every row,
 			// so reconcile must run on both paths.
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
@@ -2356,6 +2598,7 @@ export function useBatchDeleteFolders() {
 			// Reconcile on both paths: a lost ack (server committed, client saw a
 			// network error) or a non-transactional partial delete would otherwise
 			// leave onError's restore showing folders the server actually dropped.
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
@@ -2463,6 +2706,7 @@ export function useBatchMoveFolders() {
 			// Reconcile on both paths: a lost ack (server committed, client saw a
 			// network error) leaves onError's restore showing folders the server
 			// actually moved until an unrelated refetch.
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folder-notes-by-id", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
@@ -2484,6 +2728,7 @@ export function useRenameAttachment() {
 				vars,
 			),
 		onSettled: () => {
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["attachments", vaultId] });
@@ -2505,6 +2750,7 @@ export function useBatchMoveAttachments() {
 			// Reconcile on both paths: a lost ack (server committed, client saw a
 			// network error) leaves the attachments shown at their old paths until
 			// an unrelated refetch.
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["attachments", vaultId] });
@@ -2527,6 +2773,7 @@ export function useBatchDeleteAttachments() {
 			// Reconcile on both paths: no optimistic removal here, so a lost ack
 			// (server committed, client saw a network error) would otherwise leave
 			// the deleted attachments visible until an unrelated refetch.
+			invalidateVaultTree(qc, vaultId);
 			qc.invalidateQueries({ queryKey: ["folders", vaultId] });
 			qc.invalidateQueries({ queryKey: ["folderNotes", vaultId] });
 			qc.invalidateQueries({ queryKey: ["attachments", vaultId] });

--- a/frontend/src/api/vault-tree.test.tsx
+++ b/frontend/src/api/vault-tree.test.tsx
@@ -1,0 +1,378 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FolderTreeProvider } from "../layout/folder-tree-context";
+import FolderTree from "../viewer/folder-tree";
+import { syntheticFolderId } from "../viewer/tree/synthesize-folders";
+import { backfillStructural } from "./channel";
+import {
+	type NoteSummary,
+	ROOT_FOLDER_ID,
+	useAttachments,
+	useFolderNotesById,
+	useFolders,
+	useVaultTree,
+} from "./queries";
+
+vi.mock("sonner", () => ({
+	toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock("./client", async () => {
+	const actual = await vi.importActual<typeof import("./client")>("./client");
+	return {
+		...actual,
+		api: { get, post: vi.fn(), patch: vi.fn(), del: vi.fn() },
+		setTokenGetter: vi.fn(),
+	};
+});
+
+const activeVault = { id: "42" as string | null };
+vi.mock("./active-vault", async () => {
+	const actual = await vi.importActual<typeof import("./active-vault")>("./active-vault");
+	return { ...actual, useActiveVaultId: () => activeVault.id };
+});
+
+interface Tree {
+	folders: Array<{ id: string | null; name: string; count: number; parent_id: string | null }>;
+	notes: Array<{ id: string; path: string; created_at: string; updated_at: string }>;
+	attachments: Array<{
+		id: string;
+		path: string;
+		mime_type: string;
+		size_bytes: number;
+		mtime: number;
+		updated_at: string;
+	}>;
+}
+
+const BASE_TREE: Tree = {
+	folders: [
+		// The backend echoes a synthetic root row whenever root-level notes exist
+		// (`folders_payload/2` groups over existing rows) — selectFolders drops it.
+		{ id: null, name: "", count: 1, parent_id: null },
+		{ id: "f1", name: "Projects", count: 1, parent_id: null },
+		{ id: "f-empty", name: "Empty", count: 0, parent_id: null },
+		// A DERIVED folder: no marker row, so the backend sends `id: null` and
+		// selectFolders gives it the stable `syn:<path>` id the tree keys on.
+		{ id: null, name: "Derived", count: 1, parent_id: null },
+	],
+	notes: [
+		{ id: "n1", path: "Projects/spec.md", created_at: "s", updated_at: "s" },
+		{ id: "n2", path: "root.md", created_at: "s", updated_at: "s" },
+		{ id: "n3", path: "Derived/a.md", created_at: "s", updated_at: "s" },
+	],
+	attachments: [
+		{
+			id: "a1",
+			path: "img.png",
+			mime_type: "image/png",
+			size_bytes: 10,
+			mtime: 1_709_234_567,
+			updated_at: "2024-06-01T00:00:00Z",
+		},
+	],
+};
+
+// What the server currently holds. Mutate it to simulate a change landing on
+// another device, then invalidate the way api/channel.ts does.
+let current: Tree = BASE_TREE;
+
+// The pre-redesign per-key endpoints, FROZEN at the first tree. They exist so
+// this suite fails loudly (rather than accidentally passing) against a design
+// where the sidebar hooks still fetch their own keys: those hooks would happily
+// refetch and re-render the pre-change snapshot forever.
+function legacyFrozen(url: string): unknown {
+	const t = BASE_TREE;
+	const notesIn = (folder: string) =>
+		t.notes
+			.filter(
+				(n) => (n.path.includes("/") ? n.path.slice(0, n.path.lastIndexOf("/")) : "") === folder,
+			)
+			.map((n) => ({ ...n, title: n.path, folder, tags: [], version: 1, mtime: n.updated_at }));
+	if (url === "/folders") {
+		return { folders: t.folders };
+	}
+	if (url === "/attachments") {
+		return { attachments: t.attachments };
+	}
+	if (url.startsWith("/folders/by-id/")) {
+		const id = url.split("/")[3] ?? "";
+		return { notes: notesIn(t.folders.find((f) => f.id === id)?.name ?? "") };
+	}
+	if (url.startsWith("/folders/list?folder=")) {
+		return { notes: notesIn(decodeURIComponent(url.slice("/folders/list?folder=".length))) };
+	}
+	throw new Error(`unexpected request: ${url}`);
+}
+
+function wrapperFor(qc: QueryClient) {
+	return function Wrapper({ children }: { children: React.ReactNode }) {
+		return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+	};
+}
+
+function newQc() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+const urls = () => get.mock.calls.map((c) => c[0] as string);
+
+beforeEach(() => {
+	get.mockReset();
+	activeVault.id = "42";
+	current = BASE_TREE;
+	get.mockImplementation((url: string) =>
+		url === "/vault/tree" ? Promise.resolve(current) : Promise.resolve(legacyFrozen(url)),
+	);
+});
+
+describe("the vault tree is the single source for the sidebar views", () => {
+	it("cold-loads folders, attachments and root notes from ONE /vault/tree request", async () => {
+		const wrapper = wrapperFor(newQc());
+		const { result } = renderHook(
+			() => ({
+				folders: useFolders(),
+				attachments: useAttachments(),
+				rootNotes: useFolderNotesById(ROOT_FOLDER_ID),
+			}),
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(result.current.folders.data).toBeDefined();
+			expect(result.current.attachments.data).toBeDefined();
+			expect(result.current.rootNotes.data).toBeDefined();
+		});
+
+		// One request, and specifically NOT /api/folders, /api/attachments or
+		// /api/folders/list?folder= — the fan-out this endpoint exists to kill.
+		expect(urls()).toEqual(["/vault/tree"]);
+	});
+
+	it("useFolders keeps the raw wire shape select expects: root row dropped, id + parent_id intact", async () => {
+		const wrapper = wrapperFor(newQc());
+		const { result } = renderHook(() => useFolders(), { wrapper });
+		await waitFor(() => expect(result.current.data).toBeDefined());
+
+		expect(result.current.data).toEqual([
+			{ id: "f1", name: "Projects", count: 1, parent_id: null },
+			{ id: "f-empty", name: "Empty", count: 0, parent_id: null },
+			{ id: syntheticFolderId("Derived"), name: "Derived", count: 1, parent_id: null },
+		]);
+	});
+
+	it("useAttachments carries mtime and updated_at through unchanged", async () => {
+		const wrapper = wrapperFor(newQc());
+		const { result } = renderHook(() => useAttachments(), { wrapper });
+		await waitFor(() => expect(result.current.data).toBeDefined());
+
+		// loader.ts sorts by mtime under a "modified-*" sort and
+		// use-engram-tree.ts fingerprints updated_at to decide whether to rebuild
+		// — a placeholder for either silently breaks ordering / live rebuilds.
+		expect(result.current.data).toEqual([
+			{
+				id: "a1",
+				path: "img.png",
+				mime_type: "image/png",
+				size_bytes: 10,
+				mtime: 1_709_234_567,
+				updated_at: "2024-06-01T00:00:00Z",
+			},
+		]);
+	});
+
+	it("buckets notes by folder id: marker id, root sentinel, and syn:<path> for a folder with no marker", async () => {
+		const wrapper = wrapperFor(newQc());
+		const { result } = renderHook(
+			() => ({
+				projects: useFolderNotesById("f1"),
+				root: useFolderNotesById(ROOT_FOLDER_ID),
+				derived: useFolderNotesById(syntheticFolderId("Derived")),
+			}),
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(result.current.projects.data).toBeDefined();
+			expect(result.current.root.data).toBeDefined();
+			expect(result.current.derived.data).toBeDefined();
+		});
+
+		expect(result.current.projects.data?.map((n: NoteSummary) => n.id)).toEqual(["n1"]);
+		expect(result.current.root.data?.map((n: NoteSummary) => n.id)).toEqual(["n2"]);
+		expect(result.current.derived.data?.map((n: NoteSummary) => n.id)).toEqual(["n3"]);
+		expect(urls()).toEqual(["/vault/tree"]);
+	});
+
+	it("expanding a folder with zero notes issues NO request", async () => {
+		const qc = newQc();
+		const wrapper = wrapperFor(qc);
+		const { result } = renderHook(() => useFolders(), { wrapper });
+		await waitFor(() => expect(result.current.data).toBeDefined());
+		expect(urls()).toEqual(["/vault/tree"]);
+
+		// What the tree loader does on expand: fetch the folder's note list.
+		const empty = renderHook(() => useFolderNotesById("f-empty"), { wrapper });
+		await waitFor(() => expect(empty.result.current.data).toBeDefined());
+
+		// `[]` is an ANSWER derived from the already-fetched tree, not a miss that
+		// falls through to /api/folders/by-id/f-empty/notes.
+		expect(empty.result.current.data).toEqual([]);
+		expect(urls()).toEqual(["/vault/tree"]);
+	});
+
+	it("does not fetch at all without an active vault id", async () => {
+		activeVault.id = null;
+		const wrapper = wrapperFor(newQc());
+		const { result } = renderHook(
+			() => ({ tree: useVaultTree(), folders: useFolders(), att: useAttachments() }),
+			{ wrapper },
+		);
+		await waitFor(() => expect(result.current.tree.fetchStatus).toBe("idle"));
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	// Finding 2. On the FIRST-EVER tree fetch `state.data === undefined`, so
+	// query-core COALESCES a mid-flight invalidation onto the running request
+	// rather than restarting it, and the success dispatch then clears
+	// `isInvalidated` — so a snapshot that predates the event lands marked fresh
+	// and nothing asks again. `change_seq` can't detect this (no sync-channel
+	// event carries a seq to compare it against), so the invalidation itself is
+	// what gets detected.
+	it("does not lose a channel invalidation that lands while the FIRST tree fetch is in flight", async () => {
+		const qc = newQc();
+		let treeCalls = 0;
+		let releaseFirst: (t: Tree) => void = () => {};
+		const firstResponse = new Promise<Tree>((resolve) => {
+			releaseFirst = resolve;
+		});
+		get.mockImplementation((url: string) => {
+			if (url !== "/vault/tree") {
+				return Promise.resolve(legacyFrozen(url));
+			}
+			treeCalls++;
+			// Hold the cold-load request open so the invalidation lands mid-flight.
+			return treeCalls === 1 ? firstResponse : Promise.resolve(current);
+		});
+
+		const { result } = renderHook(() => useFolderNotesById("f1"), { wrapper: wrapperFor(qc) });
+		await waitFor(() => expect(treeCalls).toBe(1));
+		expect(result.current.data).toBeUndefined();
+
+		// Another device moves n1 out of Projects to the vault root. The channel
+		// tells us — but the in-flight request was issued BEFORE that write, so
+		// its response cannot contain the move.
+		current = {
+			...BASE_TREE,
+			folders: [
+				{ id: null, name: "", count: 2, parent_id: null },
+				{ id: "f1", name: "Projects", count: 0, parent_id: null },
+				{ id: "f-empty", name: "Empty", count: 0, parent_id: null },
+				{ id: null, name: "Derived", count: 1, parent_id: null },
+			],
+			notes: [
+				{ id: "n1", path: "spec.md", created_at: "s", updated_at: "s2" },
+				{ id: "n2", path: "root.md", created_at: "s", updated_at: "s" },
+				{ id: "n3", path: "Derived/a.md", created_at: "s", updated_at: "s" },
+			],
+		};
+		// A real channel entry point (socket reconnect), not a hand-rolled
+		// invalidation — it routes through invalidateVaultTree like flushBatch does.
+		backfillStructural(qc, "42");
+
+		// ...and only NOW does the pre-event snapshot arrive.
+		releaseFirst(BASE_TREE);
+
+		// The note must not still be listed under the folder it left.
+		await waitFor(() => expect(result.current.data?.map((n: NoteSummary) => n.id)).toEqual([]));
+		// Exactly one extra fetch, not a refetch loop.
+		expect(treeCalls).toBe(2);
+	});
+
+	// The invariant CI caught: a cross-tab move must converge in the sidebar
+	// with no reload. Invalidate exactly as api/channel.ts's flushBatch does.
+	it("converges every derived list when the tree is invalidated the way channel.ts does", async () => {
+		const qc = newQc();
+		const wrapper = wrapperFor(qc);
+		const { result } = renderHook(
+			() => ({
+				folders: useFolders(),
+				projects: useFolderNotesById("f1"),
+				root: useFolderNotesById(ROOT_FOLDER_ID),
+			}),
+			{ wrapper },
+		);
+		await waitFor(() => expect(result.current.projects.data).toBeDefined());
+		expect(result.current.projects.data?.map((n: NoteSummary) => n.id)).toEqual(["n1"]);
+
+		// Another device moves n1 out of Projects to the vault root and adds a
+		// folder. The legacy per-key endpoints stay frozen at the OLD state.
+		current = {
+			...BASE_TREE,
+			folders: [
+				{ id: null, name: "", count: 2, parent_id: null },
+				{ id: "f1", name: "Projects", count: 0, parent_id: null },
+				{ id: "f-empty", name: "Empty", count: 0, parent_id: null },
+				{ id: null, name: "Derived", count: 1, parent_id: null },
+				{ id: "f2", name: "Later", count: 0, parent_id: null },
+			],
+			notes: [
+				{ id: "n1", path: "spec.md", created_at: "s", updated_at: "s2" },
+				{ id: "n2", path: "root.md", created_at: "s", updated_at: "s" },
+				{ id: "n3", path: "Derived/a.md", created_at: "s", updated_at: "s" },
+			],
+		};
+
+		await qc.invalidateQueries({ queryKey: ["vault-tree", "42"] });
+		await qc.invalidateQueries({ queryKey: ["folders", "42"] });
+		await qc.invalidateQueries({ queryKey: ["attachments", "42"] });
+		await qc.invalidateQueries({
+			queryKey: ["folder-notes-by-id", "42"],
+			refetchType: "all",
+		});
+
+		await waitFor(() => {
+			// Gone from its old folder...
+			expect(result.current.projects.data?.map((n: NoteSummary) => n.id)).toEqual([]);
+			// ...and present in the new one. Listed under BOTH is the CI failure
+			// this redesign exists to prevent.
+			expect(result.current.root.data?.map((n: NoteSummary) => n.id).sort()).toEqual(["n1", "n2"]);
+			expect(result.current.folders.data?.map((f) => f.name)).toContain("Later");
+		});
+	});
+});
+
+// The wiring test that used to be missing: folder-tree.test.tsx stubs every
+// query hook, so nothing ever proved FolderTree renders what the tree endpoint
+// actually returns. Drive the REAL hooks off a real payload.
+describe("FolderTree renders from a real /vault/tree payload", () => {
+	it("renders folder, note and attachment rows, from one request", async () => {
+		const qc = newQc();
+		render(
+			<QueryClientProvider client={qc}>
+				<MemoryRouter>
+					<FolderTreeProvider>
+						<FolderTree />
+					</FolderTreeProvider>
+				</MemoryRouter>
+			</QueryClientProvider>,
+		);
+
+		expect(await screen.findByRole("treeitem", { name: "Projects" })).toBeInTheDocument();
+		expect(await screen.findByRole("treeitem", { name: "Empty" })).toBeInTheDocument();
+		// A folder with no marker row still renders, via its syn:<path> id.
+		expect(await screen.findByRole("treeitem", { name: "Derived" })).toBeInTheDocument();
+		// Root-level note, keyed under the ROOT_FOLDER_ID sentinel.
+		expect(await screen.findByRole("treeitem", { name: "root" })).toBeInTheDocument();
+		// Attachment rows render the base name; the extension is a separate badge.
+		expect(await screen.findByText("img")).toBeInTheDocument();
+
+		// `/vaults` is the row href's slug lookup (api/vault-slug.ts), unrelated to
+		// the sidebar's data. Everything the tree renders came from ONE request.
+		expect(urls().filter((u) => u !== "/vaults")).toEqual(["/vault/tree"]);
+	});
+});

--- a/frontend/src/viewer/folder-tree.test.tsx
+++ b/frontend/src/viewer/folder-tree.test.tsx
@@ -14,6 +14,23 @@ vi.mock("sonner", () => ({
 	toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
 }));
 
+// The tree loader loads a folder's note list from the vault tree on a cache
+// miss. Nothing here seeds that tree, so without this the miss path reaches the
+// real network; the loader swallows the failure, but the attempt still logs.
+vi.mock("../api/client", async () => {
+	const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+	return {
+		...actual,
+		api: {
+			get: vi.fn(() => Promise.reject(new Error("no network in unit tests"))),
+			post: vi.fn(),
+			patch: vi.fn(),
+			del: vi.fn(),
+		},
+		setTokenGetter: vi.fn(),
+	};
+});
+
 const DEFAULT_FOLDERS = [
 	{ id: "1", parent_id: null, name: "Projects", count: 1 },
 	{ id: "2", parent_id: null, name: "archive", count: 0 },
@@ -72,6 +89,20 @@ vi.mock("../api/queries", async () => {
 			isLoading: mock.loading,
 			isError: false,
 		}),
+		// `useVaultTree` is deliberately NOT stubbed. It used to be pinned to
+		// `{ data: undefined }`, which meant FolderTree's real call to it was never
+		// exercised anywhere and a broken tree seam sailed through this file into
+		// CI. It runs for real here (no active vault id in these tests, so it stays
+		// `enabled: false` and never fetches — FolderTree only mounts it for its
+		// observer, not its data).
+		//
+		// The hooks below ARE stubbed, so this file proves COMPOSITION only: no
+		// tree payload can reach a row through them. The end-to-end path —
+		// FolderTree rendering folder/note/attachment rows derived from a real
+		// /vault/tree payload, in one request — is exercised against the real
+		// hooks in api/vault-tree.test.tsx ("FolderTree renders from a real
+		// /vault/tree payload"). Do not let that be deleted and leave this file
+		// as the only coverage.
 		useAttachments: () => ({ data: mock.attachments, isLoading: false }),
 		useNote: () => ({ data: mock.activeNote, isLoading: false, error: null }),
 		useFolderNotesById: (folderId: string | null) => {

--- a/frontend/src/viewer/folder-tree.tsx
+++ b/frontend/src/viewer/folder-tree.tsx
@@ -5,9 +5,8 @@ import { toast } from "sonner";
 import { useActiveVaultId } from "../api/active-vault";
 import {
 	type AttachmentSummary,
-	FOLDER_NOTES_STALE_MS,
 	type Folder,
-	fetchNotesForFolderId,
+	folderNotesByIdQueryOptions,
 	ROOT_FOLDER_ID,
 	useAttachments,
 	useBatchDeleteAttachments,
@@ -26,6 +25,7 @@ import {
 	useRenameAttachment,
 	useRenameFolder,
 	useRenameNote,
+	useVaultTree,
 } from "../api/queries";
 import { uuid7 } from "../crdt/uuid7";
 import { useFolderTreeState } from "../layout/folder-tree-context";
@@ -207,43 +207,21 @@ export default function FolderTree() {
 		}
 	};
 
-	// The loader fires this on cache-miss when a folder is expanded. Shares the
-	// single fetcher with `useFolderNotesById` so react-query treats both as the
-	// same query (cache key + fetcher shape) — and so a 'root' id routes to the
-	// path-keyed list endpoint instead of the non-existent by-id/root route.
-	const fetchFolderNotes = useCallback((folderId: string) => fetchNotesForFolderId(folderId), []);
-
-	// Prefetch on hover — by the time the user clicks, the notes are usually
-	// already cached, so expansion is instant. Uses the same key as the loader
-	// so we don't fetch twice if the user clicks before the hover resolves.
+	// Warm a folder's note list on hover, so expansion is instant. Same options
+	// the loader and `useFolderNotesById` build, so it's one query however it's
+	// reached — and a no-op read off the cached vault tree while that is fresh.
 	const prefetchFolderNotes = useCallback(
 		(folderId: string) => {
-			qc.prefetchQuery({
-				queryKey: ["folder-notes-by-id", vaultId, folderId],
-				queryFn: () => fetchFolderNotes(folderId),
-				staleTime: FOLDER_NOTES_STALE_MS,
-			});
+			qc.prefetchQuery(folderNotesByIdQueryOptions(qc, vaultId, folderId));
 		},
-		[qc, vaultId, fetchFolderNotes],
+		[qc, vaultId],
 	);
 
-	// Bulk prefetch every folder's notes once after `useFolders` lands. Trades
-	// a small burst of parallel requests at startup for zero-latency folder
-	// expansion thereafter. Skipped on every render — gated on folders length
-	// becoming non-zero — and `staleTime` keeps it idempotent on remount.
-	const bulkPrefetchedRef = useRef(false);
-	useEffect(() => {
-		if (bulkPrefetchedRef.current) {
-			return;
-		}
-		if (!folders || folders.length === 0) {
-			return;
-		}
-		bulkPrefetchedRef.current = true;
-		for (const f of folders) {
-			prefetchFolderNotes(f.id);
-		}
-	}, [folders, prefetchFolderNotes]);
+	// The one read every view above derives from (see `vaultTreeQueryOptions`).
+	// Mounted here for its OBSERVER, not its data: an observed query refetches
+	// the instant `api/channel.ts` invalidates it, and never gets garbage
+	// collected out from under the derived queries between events.
+	useVaultTree();
 
 	const { tree, virtualizer, items } = useEngramTree({
 		folders: allFolders,
@@ -254,7 +232,6 @@ export default function FolderTree() {
 		scrollParentRef: scrollRef,
 		onRenameCommit,
 		onMove,
-		fetchFolderNotes,
 	});
 
 	// Register the scroll container with BOTH the virtualizer (scrollRef) and

--- a/frontend/src/viewer/tree/loader.test.ts
+++ b/frontend/src/viewer/tree/loader.test.ts
@@ -3,6 +3,23 @@ import { describe, expect, it, vi } from "vitest";
 import type { AttachmentSummary, Folder, NoteSummary } from "../../api/queries";
 import { buildLoader, type SortKey } from "./loader";
 
+// A cache miss makes the loader load that folder's note list from the vault
+// tree. Tests that don't seed the tree would otherwise reach the real network;
+// the loader swallows the failure, but the attempt still logs. Fail it fast.
+vi.mock("../../api/client", async () => {
+	const actual = await vi.importActual<typeof import("../../api/client")>("../../api/client");
+	return {
+		...actual,
+		api: {
+			get: vi.fn(() => Promise.reject(new Error("no network in unit tests"))),
+			post: vi.fn(),
+			patch: vi.fn(),
+			del: vi.fn(),
+		},
+		setTokenGetter: vi.fn(),
+	};
+});
+
 const folders: Folder[] = [
 	{ id: "1", parent_id: null, name: "Projects", count: 2 },
 	{ id: "2", parent_id: "1", name: "Projects/Engram", count: 1 },
@@ -211,67 +228,47 @@ describe("buildLoader", () => {
 		expect(children.map((c) => c.itemId)).toEqual(["f:2", "n:100"]);
 	});
 
-	it("cache miss returns [] and triggers fetch via real fetcher", () => {
+	// On a miss the loader loads the folder's note list through the SAME options
+	// useFolderNotesById builds — one query, one queryFn, derived from the vault
+	// tree. A separately-shaped fetch here is what previously produced cache
+	// entries an invalidation could reach but never refetch.
+	it("cache miss returns [] and loads the folder through the shared derived query", async () => {
 		const qc = new QueryClient();
 		qc.setQueryData(["folder-notes-by-id", "v", "1"], notesByFolder["1"]);
-		// No data for folder id 2.
-		const fetchFolderNotes = vi.fn(() => Promise.resolve<NoteSummary[]>([]));
-		const fetchSpy = vi.spyOn(qc, "fetchQuery");
-		const loader = buildLoader({
-			folders,
-			qc,
-			vaultId: "v",
-			sort: "name-asc" as SortKey,
-			fetchFolderNotes,
+		// No data for folder id 2; the vault tree it derives from IS cached, so
+		// the load resolves without a request.
+		qc.setQueryData(["vault-tree", "v"], {
+			folders: [{ id: "2", name: "Projects/Sub", count: 1, parent_id: "1" }],
+			notes: [{ id: "200", path: "Projects/Sub/deep.md", created_at: "s", updated_at: "s" }],
+			attachments: [],
 		});
-		const children = loader.getChildren("f:2");
-		// Child folders for f:2 = none in fixture; notes not cached → returns []
-		expect(children).toEqual([]);
-		expect(fetchSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				queryKey: ["folder-notes-by-id", "v", "2"],
-			}),
-		);
-		// The queryFn passed to fetchQuery must invoke our real fetcher with
-		// the folder id — guards against regressing back to a dummy queryFn.
-		const call = fetchSpy.mock.calls[0]?.[0] as unknown as {
-			queryFn: (ctx?: unknown) => Promise<NoteSummary[]>;
-		};
-		call.queryFn();
-		expect(fetchFolderNotes).toHaveBeenCalledWith("2");
-	});
-
-	it("root cache miss triggers a fetch for the root sentinel", () => {
-		const qc = new QueryClient();
-		const fetchFolderNotes = vi.fn(() => Promise.resolve<NoteSummary[]>([]));
-		const fetchSpy = vi.spyOn(qc, "fetchQuery");
-		const loader = buildLoader({
-			folders,
-			qc,
-			vaultId: "v",
-			sort: "name-asc" as SortKey,
-			fetchFolderNotes,
-		});
-		loader.getChildren("root");
-		expect(fetchSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				queryKey: ["folder-notes-by-id", "v", "root"],
-			}),
-		);
-		const call = fetchSpy.mock.calls[0]?.[0] as unknown as {
-			queryFn: () => Promise<NoteSummary[]>;
-		};
-		call.queryFn();
-		expect(fetchFolderNotes).toHaveBeenCalledWith("root");
-	});
-
-	it("cache miss without fetcher returns [] and does not fetch", () => {
-		const qc = new QueryClient();
-		const fetchSpy = vi.spyOn(qc, "fetchQuery");
 		const loader = buildLoader({ folders, qc, vaultId: "v", sort: "name-asc" as SortKey });
-		const children = loader.getChildren("f:2");
-		expect(children).toEqual([]);
-		expect(fetchSpy).not.toHaveBeenCalled();
+
+		// Child folders for f:2 = none in fixture; notes not cached → returns []
+		expect(loader.getChildren("f:2")).toEqual([]);
+
+		await vi.waitFor(() => {
+			expect(qc.getQueryData(["folder-notes-by-id", "v", "2"])).toEqual([
+				expect.objectContaining({ id: "200", path: "Projects/Sub/deep.md" }),
+			]);
+		});
+	});
+
+	it("root cache miss loads the root sentinel from the tree", async () => {
+		const qc = new QueryClient();
+		qc.setQueryData(["vault-tree", "v"], {
+			folders: [],
+			notes: [{ id: "300", path: "top.md", created_at: "s", updated_at: "s" }],
+			attachments: [],
+		});
+		const loader = buildLoader({ folders, qc, vaultId: "v", sort: "name-asc" as SortKey });
+		loader.getChildren("root");
+
+		await vi.waitFor(() => {
+			expect(qc.getQueryData(["folder-notes-by-id", "v", "root"])).toEqual([
+				expect.objectContaining({ id: "300", path: "top.md" }),
+			]);
+		});
 	});
 
 	it("getItem returns shaped TreeItem for a folder id", () => {

--- a/frontend/src/viewer/tree/loader.ts
+++ b/frontend/src/viewer/tree/loader.ts
@@ -1,8 +1,8 @@
 import type { QueryClient } from "@tanstack/react-query";
 import {
 	type AttachmentSummary,
-	FOLDER_NOTES_STALE_MS,
 	type Folder,
+	folderNotesByIdQueryOptions,
 	type NoteSummary,
 	ROOT_FOLDER_ID,
 } from "../../api/queries";
@@ -16,7 +16,6 @@ interface LoaderDeps {
 	vaultId: string;
 	sort: SortKey;
 	attachments?: AttachmentSummary[];
-	fetchFolderNotes?: (folderId: string) => Promise<NoteSummary[]>;
 	onChildrenLoaded?: (folderId: string) => void;
 }
 
@@ -73,9 +72,14 @@ function folderLoaderItems(deps: LoaderDeps, parentId: string | null): LoaderIte
 }
 
 // Note children for a folder id (ROOT_FOLDER_ID for the vault root). Reads the
-// id-keyed cache; on a miss, lazily fetches and asks HT to refetch the branch.
+// id-keyed cache; on a miss, lazily loads it and asks HT to refetch the branch.
 // Returns null on a cache miss so callers can render folders + attachments
-// (but not notes) while the fetch is in flight.
+// (but not notes) while the load is in flight.
+//
+// The load builds the SAME options `useFolderNotesById` does, so this is one
+// query with one queryFn no matter which side reaches it first — and it costs
+// zero requests whenever the vault tree it derives from is still fresh,
+// including for a folder that holds no notes (the answer is `[]`, not a miss).
 function noteChildItems(deps: LoaderDeps, folderId: string): LoaderItem[] | null {
 	const cached = deps.qc.getQueryData<NoteSummary[]>([
 		"folder-notes-by-id",
@@ -83,22 +87,15 @@ function noteChildItems(deps: LoaderDeps, folderId: string): LoaderItem[] | null
 		folderId,
 	]);
 	if (!cached) {
-		if (deps.fetchFolderNotes) {
-			const fetcher = deps.fetchFolderNotes;
-			deps.qc
-				.fetchQuery({
-					queryKey: ["folder-notes-by-id", deps.vaultId, folderId],
-					queryFn: () => fetcher(folderId),
-					staleTime: FOLDER_NOTES_STALE_MS,
-				})
-				// The notes are now in the cache, but HT cached the empty children
-				// list when it first asked. Tell it to refetch this branch.
-				.then(() => deps.onChildrenLoaded?.(folderId))
-				.catch(() => {
-					// Best-effort background prefetch: a failed refetch just leaves the
-					// branch to load lazily on next expand, so swallow the error.
-				});
-		}
+		deps.qc
+			.fetchQuery(folderNotesByIdQueryOptions(deps.qc, deps.vaultId, folderId))
+			// The notes are now in the cache, but HT cached the empty children
+			// list when it first asked. Tell it to refetch this branch.
+			.then(() => deps.onChildrenLoaded?.(folderId))
+			.catch(() => {
+				// Best-effort background load: a failure just leaves the branch to
+				// load lazily on next expand, so swallow the error.
+			});
 		return null;
 	}
 	return sortNotes(cached, deps.sort).map((n) => ({

--- a/frontend/src/viewer/tree/use-engram-tree.test.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.test.ts
@@ -5,6 +5,23 @@ import type { Folder, NoteSummary } from "../../api/queries";
 import { formatItemId } from "./types";
 import { createTreeDataLoader, treeStructureKey, useEngramTree } from "./use-engram-tree";
 
+// The tree loader loads a folder's note list from the vault tree on a cache
+// miss. Nothing here seeds that tree, so without this the miss path reaches the
+// real network; the loader swallows the failure, but the attempt still logs.
+vi.mock("../../api/client", async () => {
+	const actual = await vi.importActual<typeof import("../../api/client")>("../../api/client");
+	return {
+		...actual,
+		api: {
+			get: vi.fn(() => Promise.reject(new Error("no network in unit tests"))),
+			post: vi.fn(),
+			patch: vi.fn(),
+			del: vi.fn(),
+		},
+		setTokenGetter: vi.fn(),
+	};
+});
+
 describe("createTreeDataLoader", () => {
 	// An `inner` that knows nothing — models the window where the folders query
 	// has been re-keyed or is refetching, so `deps.folders` cannot resolve an id

--- a/frontend/src/viewer/tree/use-engram-tree.ts
+++ b/frontend/src/viewer/tree/use-engram-tree.ts
@@ -13,12 +13,7 @@ import { useTree } from "@headless-tree/react";
 import type { QueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useEffect, useMemo, useRef } from "react";
-import {
-	type AttachmentSummary,
-	type Folder,
-	type NoteSummary,
-	ROOT_FOLDER_ID,
-} from "../../api/queries";
+import { type AttachmentSummary, type Folder, ROOT_FOLDER_ID } from "../../api/queries";
 import { resolveDropMove } from "./drop-redirect";
 import { buildLoader, type LoaderItem, type SortKey } from "./loader";
 import { TREE_SLOT_HEIGHT } from "./row-metrics";
@@ -33,7 +28,6 @@ interface Deps {
 	scrollParentRef: React.RefObject<HTMLDivElement | null>;
 	onRenameCommit: (itemId: string, newName: string) => void;
 	onMove: (sourceIds: string[], targetItemId: string) => void;
-	fetchFolderNotes?: (folderId: string) => Promise<NoteSummary[]>;
 }
 
 // Loader-side data: HT stores LoaderItem as the per-item `T`.
@@ -141,7 +135,6 @@ export function useEngramTree(deps: Deps) {
 				vaultId: deps.vaultId,
 				sort: deps.sort,
 				attachments: deps.attachments,
-				fetchFolderNotes: deps.fetchFolderNotes,
 				onChildrenLoaded: (folderId) => {
 					const t = treeRef.current;
 					if (!t) {
@@ -154,7 +147,7 @@ export function useEngramTree(deps: Deps) {
 					inst?.invalidateChildrenIds();
 				},
 			}),
-		[deps.folders, deps.qc, deps.vaultId, deps.sort, deps.attachments, deps.fetchFolderNotes],
+		[deps.folders, deps.qc, deps.vaultId, deps.sort, deps.attachments],
 	);
 
 	const dataLoader = useMemo(() => createTreeDataLoader(inner), [inner]);

--- a/lib/engram/crypto/path_crypto.ex
+++ b/lib/engram/crypto/path_crypto.ex
@@ -1,0 +1,29 @@
+defmodule Engram.Crypto.PathCrypto do
+  @moduledoc """
+  AAD-bound path decryption, shared by every controller that renders
+  cleartext paths from `path_ciphertext`.
+
+  Extracted from SyncController so the manifest and the vault-tree read
+  cannot drift on AAD binding: rows with `dek_version >= 2` bind to
+  "notes:path:<id>" / "attachments:path:<id>", and legacy v1 rows decrypt
+  with empty AAD. Getting that wrong on one caller and not the other is a
+  silent decrypt failure at best.
+  """
+
+  alias Engram.Crypto
+  alias Engram.Crypto.Envelope
+
+  @spec aad(atom(), binary(), integer() | nil) :: binary()
+  def aad(table, id, dek_version) when is_integer(dek_version) and dek_version >= 2,
+    do: Crypto.aad_for_row(table, :path, id)
+
+  def aad(_table, _id, _v), do: <<>>
+
+  @spec decrypt!(binary(), binary(), <<_::256>>, binary()) :: binary()
+  def decrypt!(ciphertext, nonce, dek, aad) do
+    case Envelope.decrypt(ciphertext, nonce, dek, aad) do
+      {:ok, path} -> path
+      :error -> raise "path decrypt failed — possible data corruption"
+    end
+  end
+end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -9,6 +9,7 @@ defmodule Engram.Notes do
   alias Engram.Billing
   alias Engram.Crypto
   alias Engram.Crypto.Envelope
+  alias Engram.Crypto.PathCrypto
   alias Engram.Links
   alias Engram.Logger.DecryptFailure
   alias Engram.Logger.Metadata
@@ -3428,6 +3429,91 @@ defmodule Engram.Notes do
       Enum.map(markers, &hydrate_folder_marker(&1, dek))
     else
       {:error, :no_dek} -> []
+    end
+  end
+
+  @doc """
+  Folders with id/name/count/parent_id — the shape both `GET /folders`
+  (FoldersController) and `GET /vault/tree` (VaultTreeController) return.
+  Shared so the two never drift on parent-path semantics: root and
+  top-level folders get `parent_id: nil`, never `""` — a `""` parent_id
+  would make the root its own parent if a root marker ever exists, handing
+  a cycle to the tree renderer.
+  """
+  @spec folders_payload(map(), map()) :: [map()]
+  def folders_payload(user, vault) do
+    {:ok, folders} = list_folders_with_counts(user, vault)
+    markers = list_folder_markers(user, vault)
+    id_by_path = Map.new(markers, fn m -> {m.folder, m.id} end)
+
+    Enum.map(folders, fn f ->
+      %{
+        id: Map.get(id_by_path, f.folder),
+        name: f.folder,
+        count: f.count,
+        parent_id: Map.get(id_by_path, folder_parent_path(f.folder))
+      }
+    end)
+  end
+
+  @doc """
+  Every live `kind == "note"` row in a vault, with `id`, decrypted `path`,
+  and both timestamps — the notes leg of `GET /vault/tree`
+  (VaultTreeController). Folder markers are excluded: a marker's
+  `path_ciphertext` is nil, and `PathCrypto.decrypt!/4` would raise on that
+  regardless of what else is in the vault.
+
+  Unlike `Attachments.list_attachments/2`, a row whose path fails AAD-bound
+  decrypt is NOT skipped here — it raises. A note silently missing from the
+  sidebar reads as data loss to the user, with no code path today that
+  degrades a note listing gracefully (only attachments have that
+  precedent); a loud 500 is the more honest failure for primary content,
+  and the caller still has the per-folder fallback to fall back on. See PR
+  #1316 review finding 3.
+  """
+  @spec list_tree_notes(map(), map()) :: {:ok, [map()]}
+  def list_tree_notes(user, vault) do
+    {:ok, rows} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(
+          from(n in scoped_live(user, vault),
+            where: n.kind == "note",
+            select:
+              {n.id, n.dek_version, n.path_ciphertext, n.path_nonce, n.created_at, n.updated_at}
+          )
+        )
+      end)
+
+    {:ok, dek} = Crypto.get_dek(user)
+
+    # Sequential on purpose — SyncController measured path-sized decrypts at
+    # ~4µs each (10k in ~43ms) and found chunked parallel SLOWER, because
+    # copying results back to the caller's heap rivals the AES-GCM work.
+    notes =
+      Crypto.measure_decrypt_batch(:vault_tree_notes, length(rows), fn ->
+        Enum.map(rows, fn {id, dek_version, path_ct, path_nonce, created, updated} ->
+          aad = PathCrypto.aad(:notes, id, dek_version)
+
+          %{
+            id: id,
+            path: PathCrypto.decrypt!(path_ct, path_nonce, dek, aad),
+            created_at: created,
+            updated_at: updated
+          }
+        end)
+      end)
+
+    {:ok, notes}
+  end
+
+  # nil for top-level ("Projects") and root (""). Joined parent path for
+  # nested ("Projects/Engram" -> "Projects").
+  defp folder_parent_path(""), do: nil
+
+  defp folder_parent_path(folder) do
+    case folder |> String.split("/") |> Enum.drop(-1) do
+      [] -> nil
+      segments -> Enum.join(segments, "/")
     end
   end
 

--- a/lib/engram_web/controllers/folders_controller.ex
+++ b/lib/engram_web/controllers/folders_controller.ex
@@ -23,40 +23,13 @@ defmodule EngramWeb.FoldersController do
   def index(conn, _params) do
     user = conn.assigns.current_user
     vault = conn.assigns.current_vault
-    {:ok, folders} = Notes.list_folders_with_counts(user, vault)
 
     # Headless Tree needs stable folder identity (marker id) + parent id to
-    # rebuild the hierarchy without string-path prefix matching. Look up the
-    # marker id per cleartext path; root ("") and derived (no-marker)
-    # folders return id=nil and are skipped as parent candidates.
-    markers = Notes.list_folder_markers(user, vault)
-    id_by_path = Map.new(markers, fn m -> {m.folder, m.id} end)
-
-    json(conn, %{
-      folders:
-        Enum.map(folders, fn f ->
-          id = Map.get(id_by_path, f.folder)
-          parent_id = id_by_path |> Map.get(parent_path(f.folder))
-
-          %{
-            id: id,
-            name: f.folder,
-            count: f.count,
-            parent_id: parent_id
-          }
-        end)
-    })
-  end
-
-  # nil for top-level ("Projects") and root (""). Joined parent path for
-  # nested ("Projects/Engram" -> "Projects").
-  defp parent_path(""), do: nil
-
-  defp parent_path(folder) do
-    case folder |> String.split("/") |> Enum.drop(-1) do
-      [] -> nil
-      segments -> Enum.join(segments, "/")
-    end
+    # rebuild the hierarchy without string-path prefix matching. Root ("")
+    # and derived (no-marker) folders return id=nil and are skipped as
+    # parent candidates. Shared with VaultTreeController — see
+    # Notes.folders_payload/2 moduledoc for why it's not duplicated here.
+    json(conn, %{folders: Notes.folders_payload(user, vault)})
   end
 
   operation(:explicit,

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -6,7 +6,7 @@ defmodule EngramWeb.SyncController do
 
   alias Engram.Attachments.Attachment
   alias Engram.Crypto
-  alias Engram.Crypto.Envelope
+  alias Engram.Crypto.PathCrypto
   alias Engram.Notes.Note
   alias Engram.Repo
   alias EngramWeb.Schemas
@@ -115,8 +115,8 @@ defmodule EngramWeb.SyncController do
     notes =
       Crypto.measure_decrypt_batch(:manifest_notes, length(note_rows), fn ->
         Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, hash, seq, crdt_head} ->
-          aad = path_aad(:notes, id, dek_version)
-          path = decrypt_path!(path_ct, path_nonce, dek, aad)
+          aad = PathCrypto.aad(:notes, id, dek_version)
+          path = PathCrypto.decrypt!(path_ct, path_nonce, dek, aad)
           %{id: id, path: path, content_hash: hash, seq: seq, crdt_head: crdt_head}
         end)
       end)
@@ -125,8 +125,8 @@ defmodule EngramWeb.SyncController do
     attachments =
       Crypto.measure_decrypt_batch(:manifest_attachments, length(attachment_rows), fn ->
         Enum.map(attachment_rows, fn {id, dek_version, path_ct, path_nonce, hash, seq} ->
-          aad = path_aad(:attachments, id, dek_version)
-          path = decrypt_path!(path_ct, path_nonce, dek, aad)
+          aad = PathCrypto.aad(:attachments, id, dek_version)
+          path = PathCrypto.decrypt!(path_ct, path_nonce, dek, aad)
           %{id: id, path: path, content_hash: hash, seq: seq}
         end)
       end)
@@ -139,17 +139,5 @@ defmodule EngramWeb.SyncController do
       total_attachments: length(attachments),
       change_seq: current_seq
     })
-  end
-
-  defp path_aad(table, id, dek_version) when is_integer(dek_version) and dek_version >= 2,
-    do: Crypto.aad_for_row(table, :path, id)
-
-  defp path_aad(_table, _id, _v), do: <<>>
-
-  defp decrypt_path!(ciphertext, nonce, dek, aad) do
-    case Envelope.decrypt(ciphertext, nonce, dek, aad) do
-      {:ok, path} -> path
-      :error -> raise "manifest path decrypt failed — possible data corruption"
-    end
   end
 end

--- a/lib/engram_web/controllers/vault_tree_controller.ex
+++ b/lib/engram_web/controllers/vault_tree_controller.ex
@@ -1,0 +1,94 @@
+defmodule EngramWeb.VaultTreeController do
+  @moduledoc """
+  One read for the web file tree.
+
+  The tree needs every folder, note and attachment in the vault at once.
+  `/api/folders/list?folder=` was built for the plugin, which walks one
+  folder at a time, so the SPA was firing one request per folder — 20-33
+  requests moving 39.5 KB, serialized 6-at-a-time by the HTTP/1.1
+  connection limit, up to 5.6s of pure queueing before the last one was
+  even sent. This is that same data in one response.
+
+  Payload is deliberately minimal: `noteToTreeItem` derives title and
+  extension from `path`, so `title`, `tags`, `version`, `mtime`,
+  `content_hash` and `crdt_head` are all omitted. Reusing the sync
+  manifest was rejected for exactly that reason — it carries ~128 bytes
+  per note of hashes the tree never reads (~1.3 MB at 10k notes).
+  """
+  use EngramWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Engram.Attachments
+  alias Engram.Crypto
+  alias Engram.Logger.Metadata
+  alias Engram.Notes
+  alias EngramWeb.Schemas
+
+  require Logger
+
+  operation(:show,
+    operation_id: "vault-tree",
+    summary: "Get the whole vault tree in one read",
+    tags: ["Vaults"],
+    description: "Every folder, note and attachment the file tree renders, in one response.",
+    responses: [ok: {"Vault tree", "application/json", Schemas.VaultTreeResponse}]
+  )
+
+  def show(conn, _params) do
+    user = conn.assigns.current_user
+    vault = conn.assigns.current_vault
+    current = Engram.Vaults.current_seq(user.id, vault.id)
+
+    case Crypto.get_dek(user) do
+      {:ok, _dek} ->
+        render_tree(conn, user, vault, current)
+
+      {:error, :no_dek} ->
+        # Brand-new user, zero writes yet: every upsert provisions a DEK, so
+        # no DEK means nothing encrypted exists to render.
+        json(conn, empty_tree(current))
+
+      {:error, reason} ->
+        # Anything else (:unrecognised_blob, a propagated unwrap_dek/2
+        # failure) is a real crypto fault, not "no notes yet" — rendering an
+        # empty tree here would tell the user their vault is gone when it
+        # isn't. Log with enough to diagnose and let it fail loudly (500)
+        # instead of disguising it as an empty vault.
+        Logger.error(
+          "vault tree: DEK unavailable, refusing to render",
+          Metadata.with_category(:error, :crypto,
+            user_id: user.id,
+            vault_id: vault.id,
+            reason: format_error(reason)
+          )
+        )
+
+        raise "vault tree: DEK unavailable (#{format_error(reason)})"
+    end
+  end
+
+  defp empty_tree(current_seq) do
+    %{folders: [], notes: [], attachments: [], change_seq: current_seq}
+  end
+
+  # Crypto.get_dek/1's error reasons are plain atoms defined in this
+  # codebase (:unrecognised_blob, :malformed_wrapped_blob,
+  # :kms_access_denied, ...) — safe to surface by name. Some KeyProvider
+  # errors nest an arbitrary term (e.g. `{:kms_decrypt_failed, reason}`,
+  # where `reason` can be a raw AWS SDK error); the catch-all keeps that
+  # out of both the log and the raised message instead of inspecting it.
+  defp format_error(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_error(_reason), do: "dek_unwrap_failed"
+
+  defp render_tree(conn, user, vault, current_seq) do
+    {:ok, notes} = Notes.list_tree_notes(user, vault)
+    {:ok, attachments} = Attachments.list_attachments(user, vault)
+
+    json(conn, %{
+      folders: Notes.folders_payload(user, vault),
+      notes: Enum.sort_by(notes, & &1.path),
+      attachments: Enum.sort_by(attachments, & &1.path),
+      change_seq: current_seq
+    })
+  end
+end

--- a/lib/engram_web/router.ex
+++ b/lib/engram_web/router.ex
@@ -415,6 +415,10 @@ defmodule EngramWeb.Router do
     get "/folders", FoldersController, :index
     delete "/folders/*path", FoldersController, :delete
 
+    # One read for the whole web file tree. See VaultTreeController's moduledoc
+    # for why the per-folder endpoints could not serve this.
+    get "/vault/tree", VaultTreeController, :show
+
     # Search
     post "/search", SearchController, :search
 

--- a/lib/engram_web/schemas/vault_tree.ex
+++ b/lib/engram_web/schemas/vault_tree.ex
@@ -1,0 +1,55 @@
+defmodule EngramWeb.Schemas.VaultTreeNote do
+  @moduledoc "A note entry in the vault tree (no content, title, tags or hash — see controller moduledoc)."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "VaultTreeNote",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      path: %Schema{type: :string},
+      created_at: %Schema{type: :string, format: :"date-time"},
+      updated_at: %Schema{type: :string, format: :"date-time"}
+    },
+    required: [:id, :path, :created_at, :updated_at]
+  })
+end
+
+defmodule EngramWeb.Schemas.VaultTreeAttachment do
+  @moduledoc "An attachment entry in the vault tree."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "VaultTreeAttachment",
+    type: :object,
+    properties: %{
+      id: %Schema{type: :string, format: :uuid},
+      path: %Schema{type: :string},
+      mime_type: %Schema{type: :string, nullable: true},
+      size_bytes: %Schema{type: :integer},
+      mtime: %Schema{type: :number, format: :float, description: "Client mtime (epoch seconds)"},
+      updated_at: %Schema{type: :string, format: :"date-time"}
+    },
+    required: [:id, :path, :size_bytes, :mtime, :updated_at]
+  })
+end
+
+defmodule EngramWeb.Schemas.VaultTreeResponse do
+  @moduledoc "Every folder, note and attachment the file tree renders, in one response."
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "VaultTreeResponse",
+    type: :object,
+    properties: %{
+      folders: %Schema{type: :array, items: EngramWeb.Schemas.Folder},
+      notes: %Schema{type: :array, items: EngramWeb.Schemas.VaultTreeNote},
+      attachments: %Schema{type: :array, items: EngramWeb.Schemas.VaultTreeAttachment},
+      change_seq: %Schema{type: :integer, description: "Current per-vault sequence watermark."}
+    },
+    required: [:change_seq]
+  })
+end

--- a/openapi.json
+++ b/openapi.json
@@ -922,6 +922,43 @@
         "x-struct": "Elixir.EngramWeb.Schemas.FolderNamesResponse",
         "x-validate": null
       },
+      "VaultTreeNote": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "path",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "VaultTreeNote",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.VaultTreeNote",
+        "x-validate": null
+      },
       "LogIngestRequest": {
         "properties": {
           "logs": {
@@ -1216,6 +1253,56 @@
         "title": "FolderResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.FolderResponse",
+        "x-validate": null
+      },
+      "VaultTreeAttachment": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mime_type": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "mtime": {
+            "description": "Client mtime (epoch seconds)",
+            "format": "float",
+            "type": "number",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "path": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "size_bytes": {
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "path",
+          "size_bytes",
+          "mtime",
+          "updated_at"
+        ],
+        "title": "VaultTreeAttachment",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.VaultTreeAttachment",
         "x-validate": null
       },
       "ConnectionsList": {
@@ -2340,6 +2427,47 @@
         "title": "FolderNotesResponse",
         "type": "object",
         "x-struct": "Elixir.EngramWeb.Schemas.FolderNotesResponse",
+        "x-validate": null
+      },
+      "VaultTreeResponse": {
+        "properties": {
+          "attachments": {
+            "items": {
+              "$ref": "#/components/schemas/VaultTreeAttachment"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "change_seq": {
+            "description": "Current per-vault sequence watermark.",
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "folders": {
+            "items": {
+              "$ref": "#/components/schemas/Folder"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/components/schemas/VaultTreeNote"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "change_seq"
+        ],
+        "title": "VaultTreeResponse",
+        "type": "object",
+        "x-struct": "Elixir.EngramWeb.Schemas.VaultTreeResponse",
         "x-validate": null
       },
       "AppendResponse": {
@@ -4606,6 +4734,30 @@
         "summary": "Rename / move an attachment",
         "tags": [
           "Attachments"
+        ]
+      }
+    },
+    "/api/vault/tree": {
+      "get": {
+        "callbacks": {},
+        "description": "Every folder, note and attachment the file tree renders, in one response.",
+        "operationId": "vault-tree",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultTreeResponse"
+                }
+              }
+            },
+            "description": "Vault tree"
+          }
+        },
+        "summary": "Get the whole vault tree in one read",
+        "tags": [
+          "Vaults"
         ]
       }
     },

--- a/test/engram_web/controllers/vault_tree_controller_test.exs
+++ b/test/engram_web/controllers/vault_tree_controller_test.exs
@@ -1,0 +1,247 @@
+defmodule EngramWeb.VaultTreeControllerTest do
+  use EngramWeb.ConnCase, async: true
+
+  import Ecto.Query
+  import ExUnit.CaptureLog
+
+  alias Engram.Attachments.Attachment
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    insert(:subscription, user: user, tier: "pro", status: "active")
+    vault = insert(:vault, user: user, is_default: true)
+    {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "test-key")
+    grant_api_write!(user)
+    authed = put_req_header(conn, "authorization", "Bearer #{api_key}")
+    %{conn: authed, user: user, vault: vault}
+  end
+
+  describe "GET /vault/tree" do
+    test "returns an empty tree for a new user", %{conn: conn} do
+      # insert(:user) provisions no DEK, so this exercises the
+      # {:error, :no_dek} branch of show/2 (the hardcoded empty_tree/1
+      # literal), NOT render_tree/5. See the DEK-provisioned companion test
+      # below for coverage of render_tree/5 on an empty vault.
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+
+      assert body["notes"] == []
+      assert body["folders"] == []
+      assert body["attachments"] == []
+      assert body["change_seq"] == 0
+    end
+
+    test "returns an empty tree for a DEK-provisioned user with no notes" do
+      # insert_user/1 runs Crypto.ensure_user_dek/1, so this request takes
+      # the {:ok, dek} branch and actually runs render_tree/5's queries +
+      # folders_payload/2 against zero rows, instead of short-circuiting to
+      # the hardcoded empty_tree/1 literal like the test above.
+      user = insert_user()
+      insert(:subscription, user: user, tier: "pro", status: "active")
+      insert(:vault, user: user, is_default: true)
+      {:ok, api_key, _} = Engram.Accounts.create_api_key(user, "dek-test-key")
+      grant_api_write!(user)
+      conn = build_conn() |> put_req_header("authorization", "Bearer #{api_key}")
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+
+      assert body["notes"] == []
+      assert body["folders"] == []
+      assert body["attachments"] == []
+      assert body["change_seq"] == 0
+    end
+
+    test "returns every note with id, path and both timestamps", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Test/A.md", content: "# Alpha", mtime: 1_000.0})
+      post(conn, "/api/notes", %{path: "Test/B.md", content: "# Beta", mtime: 1_000.0})
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+
+      assert length(body["notes"]) == 2
+      note = Enum.find(body["notes"], &(&1["path"] == "Test/A.md"))
+      assert note["id"]
+      assert note["created_at"]
+      assert note["updated_at"]
+    end
+
+    test "returns every attachment with id, path, mime_type, size_bytes, mtime and updated_at", %{
+      conn: conn
+    } do
+      post(conn, "/api/attachments", %{
+        path: "img.png",
+        content_base64: Base.encode64("hi"),
+        mtime: 1_709_234_567.0
+      })
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+
+      assert [att] = body["attachments"]
+      assert att["path"] == "img.png"
+      assert att["mime_type"] == "image/png"
+      assert att["size_bytes"] == 2
+      # loader.ts sorts attachments by mtime under "modified-*" sort — must be
+      # the real value, not a placeholder, or seeded and fetched rows diverge.
+      assert att["mtime"] == 1_709_234_567.0
+      # use-engram-tree.ts's attachmentsFingerprint reads updated_at to decide
+      # whether to rebuild the tree — a seeded placeholder here collapses that
+      # signal, same reasoning as mtime above.
+      assert att["updated_at"]
+    end
+
+    test "returns folders derived from note paths, with note counts", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Test/A.md", content: "# Alpha", mtime: 1_000.0})
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+      folder = Enum.find(body["folders"], &(&1["name"] == "Test"))
+
+      assert %{"name" => "Test", "count" => 1} = folder
+    end
+
+    test "omits folder marker rows from notes", %{conn: conn, user: user, vault: vault} do
+      # Marker rows (kind="folder") have path_ciphertext=nil; if the notes
+      # query doesn't filter by kind == "note", PathCrypto.decrypt!/4 raises
+      # on the nil ciphertext and the whole tree 500s. Ported from
+      # SyncController's "omits folder marker rows" test.
+      {:ok, _marker} = Engram.Notes.create_folder_marker(user, vault, "EmptyFolder")
+      post(conn, "/api/notes", %{path: "Real.md", content: "# real", mtime: 1_000.0})
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+
+      assert Enum.map(body["notes"], & &1["path"]) == ["Real.md"]
+    end
+
+    test "omits the fields the tree never reads", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "A.md", content: "# A", mtime: 1_000.0})
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+      note = hd(body["notes"])
+
+      # These are the ~128 bytes/note that disqualified reusing the manifest.
+      refute Map.has_key?(note, "content_hash")
+      refute Map.has_key?(note, "crdt_head")
+      refute Map.has_key?(note, "tags")
+    end
+
+    test "never leaks another user's notes", %{conn: conn} do
+      post(conn, "/api/notes", %{path: "Mine.md", content: "# Mine", mtime: 1_000.0})
+
+      other = insert(:user)
+      insert(:subscription, user: other, tier: "pro", status: "active")
+      _other_vault = insert(:vault, user: other, is_default: true)
+      {:ok, other_key, _} = Engram.Accounts.create_api_key(other, "other-key")
+      grant_api_write!(other)
+
+      other_conn =
+        build_conn()
+        |> put_req_header("authorization", "Bearer #{other_key}")
+
+      # Must assert the write actually landed — otherwise a 401/403/422 here
+      # (auth reordering, a new required header, a subscription-gate change)
+      # silently creates zero rows, and `refute "Theirs.md" in paths` below
+      # passes vacuously against an empty set instead of proving isolation.
+      assert %{"note" => _} =
+               json_response(
+                 post(other_conn, "/api/notes", %{
+                   path: "Theirs.md",
+                   content: "# T",
+                   mtime: 1_000.0
+                 }),
+                 200
+               )
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+      paths = Enum.map(body["notes"], & &1["path"])
+
+      assert "Mine.md" in paths
+      refute "Theirs.md" in paths
+    end
+
+    test "never leaks a note from another vault of the SAME user", %{conn: conn, user: user} do
+      # user_id alone (no vault_id filter) would already pass every other
+      # test here, since the isolation tests above use separate users with
+      # separate vaults. This proves the `n.vault_id == ^vault.id` clause in
+      # VaultTreeController.render_tree/5 actually does something.
+      post(conn, "/api/notes", %{path: "InDefaultVault.md", content: "# d", mtime: 1_000.0})
+
+      {:ok, other_vault} = Engram.Vaults.create_vault(user, %{name: "Other"})
+
+      other_vault_conn = put_req_header(conn, "x-vault-id", to_string(other_vault.id))
+
+      assert %{"note" => _} =
+               json_response(
+                 post(other_vault_conn, "/api/notes", %{
+                   path: "InOtherVault.md",
+                   content: "# o",
+                   mtime: 1_000.0
+                 }),
+                 200
+               )
+
+      body = conn |> get("/api/vault/tree") |> json_response(200)
+      paths = Enum.map(body["notes"], & &1["path"])
+
+      assert "InDefaultVault.md" in paths
+      refute "InOtherVault.md" in paths
+    end
+
+    test "skips an undecryptable attachment instead of 500ing the whole tree", %{
+      conn: conn,
+      user: user
+    } do
+      post(conn, "/api/attachments", %{
+        path: "good.png",
+        content_base64: Base.encode64("X"),
+        mtime: 1_000.0
+      })
+
+      %{"attachment" => %{"id" => bad_id}} =
+        json_response(
+          post(conn, "/api/attachments", %{
+            path: "bad.png",
+            content_base64: Base.encode64("Y"),
+            mtime: 1_000.0
+          }),
+          200
+        )
+
+      # Corrupt the bad row's path ciphertext so AEAD verification fails —
+      # same technique as Attachments' own "skips an undecryptable row"
+      # test (test/engram/attachments_test.exs).
+      Engram.Repo.with_tenant(user.id, fn ->
+        from(a in Attachment, where: a.id == ^bad_id)
+        |> Engram.Repo.update_all(set: [path_ciphertext: :crypto.strong_rand_bytes(48)])
+      end)
+
+      log =
+        capture_log(fn ->
+          body = conn |> get("/api/vault/tree") |> json_response(200)
+          paths = Enum.map(body["attachments"], & &1["path"])
+
+          assert "good.png" in paths
+          refute "bad.png" in paths
+          assert length(body["attachments"]) == 1
+        end)
+
+      assert log =~ "Skipping undecryptable attachment"
+    end
+
+    test "a non-:no_dek DEK failure 500s instead of raising an unhandled CaseClauseError", %{
+      conn: conn,
+      user: user
+    } do
+      # Same corruption technique used by
+      # test/engram/mcp/handlers_test.exs's "unexpected crypto error"
+      # case — a garbage encrypted_dek blob makes Crypto.get_dek/1 return
+      # {:error, :unrecognised_blob}, the third case show/2 must now handle
+      # explicitly instead of falling through to a CaseClauseError.
+      corrupt = Ecto.Changeset.change(user, encrypted_dek: :crypto.strong_rand_bytes(32))
+      {:ok, _corrupt_user} = Engram.Repo.update(corrupt, skip_tenant_check: true)
+
+      log =
+        capture_log(fn ->
+          assert_error_sent(500, fn -> get(conn, "/api/vault/tree") end)
+        end)
+
+      assert log =~ "vault tree: DEK unavailable"
+    end
+  end
+end


### PR DESCRIPTION
## The problem

Loading the web file tree fired one `GET /api/folders/list?folder=X` **per folder**. Measured on a real 33-folder vault via Resource Timing:

| Metric | Measured |
|---|---|
| Folder-list calls per load | 20–33 |
| Total bytes those calls delivered | 39.5 KB |
| Max **server** time for one call | 467 ms |
| Max **queue** time before hitting the wire | **5,626 ms** |
| Protocol | HTTP/1.1 (all 44 calls) |

The server was never slow. Browsers allow ~6 concurrent connections per origin on HTTP/1.1, so the tail of the fan-out waited 5.6 seconds just to be *sent*. A note opened during that window inherited ~1s of queueing despite ~100 ms of server time.

The fan-out was deliberate — `folder-tree.tsx` carried a loop commented "a small burst of parallel requests at startup". A small burst was 33 requests taking ~6s to drain.

**Root cause is structural.** `/api/folders/list?folder=` was designed for the plugin, which walks one folder at a time. The web tree needs the whole vault at once and was built on a per-folder API.

## The change

`GET /api/vault/tree` — one read returning every folder, note and attachment the tree renders.

Payload is deliberately minimal: `noteToTreeItem` derives title and extension from `path`, so `title`, `tags`, `version`, `content_hash` and `crdt_head` are all omitted. Reusing `/api/sync/manifest` was considered and rejected — it carries ~128 bytes/note of hashes the tree never reads (~1.3 MB at 10k notes), and it would couple the web tree to a sync protocol the plugin depends on.

The client fetches it once and seeds the **existing** cache keys, so every consumer (rename, drag-move, the loader) is untouched.

## Measured result

| | Before | After |
|---|---|---|
| Per-folder `folders/list?folder=<name>` calls | **20–33** | **0** |
| Max queue time | **5,626 ms** | **3 ms** |
| Tree payload | 39.5 KB across 20–33 requests | 89 KB in **1** request |

A cold load now issues **4** requests, not 1: `/vault/tree`, `/folders`, `/attachments`, and `/folders/list?folder=` (the root-notes list — `useFolderNotesById(ROOT_FOLDER_ID)` is an active observer that fetches on mount). Those four go out in parallel in a single connection wave. Collapsing them to 1 by pointing those hooks at the tree cache is a deliberate follow-up, not this PR — the pathology was 33 requests *serialized*, and that is gone.

## Notable review findings, fixed in-branch

- **Tenant isolation** — nothing covered the `vault_id` clause: deleting it left every test green while the endpoint would dump *all* of the user's other vaults into the tree. Now covered by a same-user/second-vault test.
- **Folder markers** — marker rows have NULL `path_ciphertext`, so a regression in the `kind == "note"` filter doesn't return junk, it raises inside path decryption and 500s the whole tree. `SyncController` had this test; it wasn't carried over. Now it is.
- **Cache stomp** — seeding blanket-overwrote `folder-notes-by-id`, which the CRDT channel also writes. Seeding is now bootstrap-only (`seedIfAbsent`), so live writes and in-flight optimistic rows survive.
- **Attachment `mtime`** — seeded rows hardcoded `0`, which feeds a real sort comparator in `loader.ts`. `mtime` and `updated_at` now come from the endpoint, so seeded and fetched rows are interchangeable.
- **Dead `since_seq`** — the short-circuit was implemented, tested and documented but never called, and returns no payload, so it is unusable without client-side tree persistence that doesn't exist. Deleted.
- `Engram.Notes.folders_payload/2` is now shared by this endpoint and `/api/folders` instead of duplicated (the copies had already drifted on root's parent).

## Gates

`mix format` · `mix credo --strict` (782 files, no issues) · `mix dialyzer` exit 0 · `mix test` 4213 tests, 0 failures · `SPEC IN SYNC` · `tsc --noEmit` · `biome ci` (461 files) · `vitest` 1312/1312.

Verified in a real browser against a real vault, not just in tests.

## Follow-ups (not this PR)

- `channel.ts` invalidates the per-folder caches but not `vault-tree`, so live updates refill through the old per-folder endpoints. Bounded to root plus folders with an active observer; unchanged from previous behavior.
- Folders with zero notes get no seeded key, so expanding one costs a single lazy fetch.
- The ~500 ms per-note CRDT open (`openDoc`: session wait + per-doc IndexedDB + STEP1 handshake) is untouched and is the dominant remaining per-file latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz