### PR TITLE
chore(e2e): update open_settings_tab docstring for the Connection tab

### DIFF
--- a/e2e/helpers/cdp.py
+++ b/e2e/helpers/cdp.py
@@ -1595,7 +1595,7 @@ class CdpClient:
     async def open_settings_tab(self, tab: str) -> None:
         """Open plugin settings and navigate to a sub-tab.
 
-        tab ∈ {'cloud','self-hosted','sync-center','advanced'}
+        tab ∈ {'about','connection','sync-center','advanced'}
         """
         await self.evaluate(
             "app.commands.executeCommandById("


### PR DESCRIPTION
## Summary

- The plugin merges its Cloud and Self-hosted settings tabs into one Connection tab (engram-app/Engram-obsidian#408), so the tab ids documented on `open_settings_tab` are stale.
- Docstring only. No behaviour change.

## Test plan

- [x] `grep -rn "self-hosted|'cloud'|\"cloud\"" e2e/ --include=*.py` returns no hits outside the changed docstring
- [x] Verified the rest of the suite is unaffected: every settings seed (`e2e/helpers/obsidian.py:148-149`, `e2e/helpers/oauth.py:249-250`) already writes both a URL and a credential, and the plugin's new `migrateBackendMode` classifies those local URLs as self-hosted on its own. No seed needs a new field.

## Scope note

`open_settings_tab` has **zero callers** and calls `app.setting.activeTab.selectSubtab(...)`, which does not exist anywhere in the plugin source. Only the docstring is corrected here; making the helper functional is unrelated scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC