### PR TITLE
fix(api): DEK-fault handling on the sync manifest + the missing attachment decrypt span

### DIFF
--- a/lib/engram/attachments.ex
+++ b/lib/engram/attachments.ex
@@ -1011,9 +1011,17 @@ defmodule Engram.Attachments do
     |> unwrap_tenant()
     |> case do
       {:ok, atts} ->
+        # Measured like every other bulk path decrypt (:notes,
+        # :vault_tree_notes, :manifest_*). /api/vault/tree delegates its
+        # attachment half here rather than duplicating the query, so without
+        # this span that endpoint reports only its notes decrypt cost. Label
+        # is caller-agnostic because this function is: per-endpoint
+        # attribution comes from the OTel request span, not this tag.
         {:ok,
-         decrypt_each(atts, user, fn att, meta ->
-           meta |> Map.delete(:deleted_at) |> Map.put(:id, att.id)
+         Crypto.measure_decrypt_batch(:attachments, length(atts), fn ->
+           decrypt_each(atts, user, fn att, meta ->
+             meta |> Map.delete(:deleted_at) |> Map.put(:id, att.id)
+           end)
          end)}
 
       err ->

--- a/lib/engram/crypto.ex
+++ b/lib/engram/crypto.ex
@@ -170,6 +170,21 @@ defmodule Engram.Crypto do
   end
 
   @doc """
+  Renders a `get_dek/1` error reason as a short, log-safe string.
+
+  The reasons `get_dek/1` returns are plain atoms defined in this codebase
+  (`:no_dek`, `:unrecognised_blob`, `:malformed_wrapped_blob`,
+  `:kms_access_denied`, ...) — safe to surface by name. Some KeyProvider
+  errors nest an arbitrary term (e.g. `{:kms_decrypt_failed, reason}`, where
+  `reason` can be a raw AWS SDK error carrying request context); the
+  catch-all keeps that out of logs and error messages instead of
+  `inspect/1`-ing it into them.
+  """
+  @spec format_dek_error(term()) :: String.t()
+  def format_dek_error(reason) when is_atom(reason), do: Atom.to_string(reason)
+  def format_dek_error(_reason), do: "dek_unwrap_failed"
+
+  @doc """
   Returns the plaintext DEK for a user, unwrapping via the provider if not cached.
   """
   @spec get_dek(User.t()) :: {:ok, <<_::256>>} | {:error, term()}

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -7,9 +7,12 @@ defmodule EngramWeb.SyncController do
   alias Engram.Attachments.Attachment
   alias Engram.Crypto
   alias Engram.Crypto.PathCrypto
+  alias Engram.Logger.Metadata
   alias Engram.Notes.Note
   alias Engram.Repo
   alias EngramWeb.Schemas
+
+  require Logger
 
   operation(:manifest,
     operation_id: "sync-manifest",
@@ -55,8 +58,30 @@ defmodule EngramWeb.SyncController do
       # possible without a DEK (every upsert provisions one), so short-circuit
       # to an empty manifest instead of crashing on `{:ok, dek}` match.
       case Crypto.get_dek(user) do
-        {:ok, dek} -> render_manifest(conn, user, vault, dek, current)
-        {:error, :no_dek} -> render_empty_manifest(conn, current)
+        {:ok, dek} ->
+          render_manifest(conn, user, vault, dek, current)
+
+        {:error, :no_dek} ->
+          render_empty_manifest(conn, current)
+
+        {:error, reason} ->
+          # Anything else (:unrecognised_blob, a propagated unwrap_dek/2
+          # failure) is a real crypto fault, not "this vault is empty".
+          # Reaching render_empty_manifest here would be worse than a 500:
+          # the plugin diffs this manifest against the local vault, so an
+          # empty one reads as "every note was deleted remotely". Fail
+          # loudly. Previously fell through to a CaseClauseError — same
+          # 500, but with nothing logged to diagnose it.
+          Logger.error(
+            "sync manifest: DEK unavailable, refusing to render",
+            Metadata.with_category(:error, :crypto,
+              user_id: user.id,
+              vault_id: vault.id,
+              reason: Crypto.format_dek_error(reason)
+            )
+          )
+
+          raise "sync manifest: DEK unavailable (#{Crypto.format_dek_error(reason)})"
       end
     end
   end

--- a/lib/engram_web/controllers/vault_tree_controller.ex
+++ b/lib/engram_web/controllers/vault_tree_controller.ex
@@ -59,26 +59,17 @@ defmodule EngramWeb.VaultTreeController do
           Metadata.with_category(:error, :crypto,
             user_id: user.id,
             vault_id: vault.id,
-            reason: format_error(reason)
+            reason: Crypto.format_dek_error(reason)
           )
         )
 
-        raise "vault tree: DEK unavailable (#{format_error(reason)})"
+        raise "vault tree: DEK unavailable (#{Crypto.format_dek_error(reason)})"
     end
   end
 
   defp empty_tree(current_seq) do
     %{folders: [], notes: [], attachments: [], change_seq: current_seq}
   end
-
-  # Crypto.get_dek/1's error reasons are plain atoms defined in this
-  # codebase (:unrecognised_blob, :malformed_wrapped_blob,
-  # :kms_access_denied, ...) — safe to surface by name. Some KeyProvider
-  # errors nest an arbitrary term (e.g. `{:kms_decrypt_failed, reason}`,
-  # where `reason` can be a raw AWS SDK error); the catch-all keeps that
-  # out of both the log and the raised message instead of inspecting it.
-  defp format_error(reason) when is_atom(reason), do: Atom.to_string(reason)
-  defp format_error(_reason), do: "dek_unwrap_failed"
 
   defp render_tree(conn, user, vault, current_seq) do
     {:ok, notes} = Notes.list_tree_notes(user, vault)

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -351,6 +351,33 @@ defmodule Engram.AttachmentsTest do
       :ok
     end
 
+    # Every other bulk path decrypt in the codebase is measured
+    # (:notes, :vault_tree_notes, :manifest_notes, :manifest_attachments).
+    # This one was the blind spot: /api/vault/tree delegates its attachment
+    # half here, so without a span the tree endpoint reports only half its
+    # decrypt cost. See PR #1316 review follow-up.
+    test "emits a decrypt_batch span sized to the rows decrypted", %{user: user, vault: vault} do
+      for name <- ["one.png", "two.png"] do
+        {:ok, _} =
+          Attachments.upsert_attachment(user, vault, %{
+            "path" => name,
+            "content_base64" => Base.encode64("PNGDATA"),
+            "mime_type" => "image/png"
+          })
+      end
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:engram, :crypto, :decrypt_batch]])
+
+      {:ok, list} = Attachments.list_attachments(user, vault)
+      assert length(list) == 2
+
+      assert_receive {[:engram, :crypto, :decrypt_batch], ^ref, measurements,
+                      %{kind: :attachments}}
+
+      assert measurements.count == 2
+      assert is_integer(measurements.duration_us) and measurements.duration_us >= 0
+    end
+
     test "returns non-deleted attachment metadata for the vault", %{user: user, vault: vault} do
       {:ok, _} =
         Attachments.upsert_attachment(user, vault, %{

--- a/test/engram/crypto_test.exs
+++ b/test/engram/crypto_test.exs
@@ -712,4 +712,22 @@ defmodule Engram.CryptoTest do
                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
   end
+
+  describe "format_dek_error/1" do
+    test "surfaces known atom reasons by name" do
+      assert Crypto.format_dek_error(:no_dek) == "no_dek"
+      assert Crypto.format_dek_error(:unrecognised_blob) == "unrecognised_blob"
+    end
+
+    # The whole point of the helper: a nested provider error can carry a raw
+    # SDK term with request context in it, and inspect/1-ing that into a log
+    # line or a raised message is how that context leaks.
+    test "collapses nested provider errors instead of inspecting them" do
+      assert Crypto.format_dek_error({:kms_decrypt_failed, %{secret: "sk-live-abc123"}}) ==
+               "dek_unwrap_failed"
+
+      refute Crypto.format_dek_error({:kms_decrypt_failed, %{secret: "sk-live-abc123"}}) =~
+               "sk-live"
+    end
+  end
 end

--- a/test/engram_web/controllers/sync_controller_test.exs
+++ b/test/engram_web/controllers/sync_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule EngramWeb.SyncControllerTest do
   use EngramWeb.ConnCase, async: true
 
+  import ExUnit.CaptureLog
+
   setup %{conn: conn} do
     user = insert(:user)
     # Free-tier launch §4.5 — attachment uploads now gate on attachments_enabled,
@@ -194,6 +196,32 @@ defmodule EngramWeb.SyncControllerTest do
 
       assert body["unchanged"] == true
       assert body["change_seq"] == 0
+    end
+  end
+
+  describe "GET /sync/manifest — DEK failures" do
+    # `{:error, :no_dek}` means a brand-new user with zero writes, and an
+    # empty manifest is the honest answer. Any OTHER crypto error is not
+    # "you have no notes" — and the manifest is the one endpoint where
+    # saying that is actively destructive: the plugin diffs the manifest
+    # against the local vault, so an empty one reads as "everything was
+    # deleted remotely". Fail loudly instead. See PR #1316 review follow-up.
+    test "unexpected crypto error raises rather than rendering an empty manifest", %{
+      conn: conn,
+      user: user
+    } do
+      # Same corruption technique as vault_tree_controller_test — a garbage
+      # encrypted_dek blob makes Crypto.get_dek/1 return
+      # {:error, :unrecognised_blob}.
+      corrupt = Ecto.Changeset.change(user, encrypted_dek: :crypto.strong_rand_bytes(32))
+      {:ok, _corrupt_user} = Engram.Repo.update(corrupt, skip_tenant_check: true)
+
+      log =
+        capture_log(fn ->
+          assert_error_sent(500, fn -> get(conn, "/api/sync/manifest") end)
+        end)
+
+      assert log =~ "sync manifest: DEK unavailable"
     end
   end
 end


### PR DESCRIPTION
Two follow-ups from the #1316 review, both in the same crypto/observability seam.

## 1. The sync manifest could crash on any DEK fault it didn't name

`Crypto.get_dek/1` is specced `{:ok, dek} | {:error, term()}`. `SyncController.manifest/2` matched only `{:ok, dek}` and `{:error, :no_dek}` — every other reason hit a `CaseClauseError`.

Verified reachable, not theoretical: corrupting a user's `encrypted_dek` blob raises exactly that today (probed before writing the fix — the 500 in the logs comes from this `case`, not from the `vault decrypt_failed` line above it, which only logs and returns the row unchanged).

**Why the missing clause had to raise rather than render empty.** The plugin diffs this manifest against the local vault. Had the clause instead fallen through to `render_empty_manifest`, a transient KMS fault would tell the client every note was deleted remotely. A 500 is the honest answer; an empty manifest is a data-loss hazard. The new clause logs `user_id`/`vault_id`/`reason` and raises.

## 2. `/api/vault/tree` was measuring only half its decrypt cost

#1316 made the tree endpoint delegate its attachment half to `Attachments.list_attachments/2` instead of duplicating the query — good — but that dropped the decrypt span that half used to carry. The endpoint reported `:vault_tree_notes` and nothing for attachments.

Span added inside `list_attachments/2`, so `list_in_folder/3` (the plugin path) gets it too. The label is caller-agnostic because the function is; per-endpoint attribution comes from the OTel request span, and the metric already tags by `[:kind]` with no enumeration to update.

## Also

Lifted the DEK-reason formatter out of `VaultTreeController` into `Crypto.format_dek_error/1`, beside the function whose errors it names. Two call sites need it now and only `Crypto` owns that vocabulary. Its catch-all is load-bearing: nested provider errors can carry a raw AWS SDK term with request context, and that must not reach a log line or a raised message — there's a test pinning that.

## Testing

TDD, both tests red first for the right reason (the manifest one failed on the missing log line, not on the status code — it already 500'd, just silently).

Full gate, sequential: `format` ✓ `credo --strict` ✓ `dialyzer` ✓ `mix test --warnings-as-errors` → **4248 tests, 0 failures**.

Refs #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz