### PR TITLE
perf(web): instrument the note-open path (#1317 step 0)

### DIFF
--- a/frontend/src/crdt/channel.ts
+++ b/frontend/src/crdt/channel.ts
@@ -3,6 +3,7 @@ import * as encoding from "lib0/encoding";
 import * as syncProtocol from "y-protocols/sync";
 import { rlog } from "../observability/remote-log";
 import { type CrdtManager, REMOTE_ORIGIN } from "./manager";
+import { crdtMark } from "./perf";
 
 /** Outer y-protocols message-type tag — we only speak `messageSync`. */
 const MESSAGE_SYNC = 0;
@@ -46,6 +47,7 @@ export class CrdtChannel {
 		encoding.writeVarUint(encoder, MESSAGE_SYNC);
 		syncProtocol.writeSyncStep1(encoder, doc);
 		this.transport(id, toB64(encoding.toUint8Array(encoder)));
+		crdtMark(path, "step1:sent");
 	}
 
 	resetSync(path: string): void {
@@ -81,6 +83,7 @@ export class CrdtChannel {
 			const replyEncoder = encoding.createEncoder();
 			encoding.writeVarUint(replyEncoder, MESSAGE_SYNC);
 			syncProtocol.readSyncMessage(decoder, replyEncoder, doc, REMOTE_ORIGIN);
+			crdtMark(path, "step1:reply");
 			if (encoding.length(replyEncoder) > 1) {
 				this.transport(this.mgr.docId(path), toB64(encoding.toUint8Array(replyEncoder)));
 			}

--- a/frontend/src/crdt/manager.ts
+++ b/frontend/src/crdt/manager.ts
@@ -2,6 +2,7 @@ import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
 import { frontmatterMaps } from "./frontmatter-doc";
 import { rememberCrdtDb } from "./idb-registry";
+import { crdtMark } from "./perf";
 
 interface Entry {
 	doc: Y.Doc;
@@ -153,9 +154,11 @@ export class CrdtManager {
 		const id = this.docId(noteId);
 		const cached = this.docs.get(id);
 		if (cached) {
+			crdtMark(noteId, "entry:warm");
 			await cached.ready;
 			return cached;
 		}
+		crdtMark(noteId, "entry:cold");
 		const doc = new Y.Doc();
 		const dbName = CRDT_IDB_PREFIX + id;
 		// Write the name down BEFORE opening it: on a browser with no
@@ -186,6 +189,7 @@ export class CrdtManager {
 		const entry: Entry = { doc, persistence, text, ready };
 		this.docs.set(id, entry);
 		await ready;
+		crdtMark(noteId, "idb:synced");
 		return entry;
 	}
 }

--- a/frontend/src/crdt/perf.test.ts
+++ b/frontend/src/crdt/perf.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { crdtMark, report, reset } from "./perf";
+
+describe("crdt open-path timing", () => {
+	beforeEach(() => {
+		localStorage.setItem("engramCrdtPerf", "1");
+		reset();
+	});
+
+	it("reports each phase as a delta from that open's start", () => {
+		crdtMark("n1", "open:start");
+		crdtMark("n1", "open:session-ready");
+		crdtMark("n1", "open:resolved");
+
+		const rows = report();
+		expect(rows).toHaveLength(1);
+		const [row] = rows;
+		if (!row) {
+			throw new Error("unreachable: length asserted above");
+		}
+		expect(row.noteId).toBe("n1");
+		// Real clock, so assert ordering and presence rather than exact ms.
+		expect(row["open:session-ready"]).toBeGreaterThanOrEqual(0);
+		expect(row["open:resolved"]).toBeGreaterThanOrEqual(row["open:session-ready"] ?? 0);
+		expect(row.total).toBe(row["open:resolved"]);
+	});
+
+	// The reason rows are cut on `open:start` and not grouped by note id: a
+	// note reopened later must not have its phases folded into the first
+	// open's row, which would silently report one bogus blended timing.
+	it("splits a reopened note into separate rows", () => {
+		crdtMark("n1", "open:start");
+		crdtMark("n1", "entry:cold");
+		crdtMark("n1", "open:start");
+		crdtMark("n1", "entry:warm");
+
+		const rows = report();
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toHaveProperty("entry:cold");
+		expect(rows[0]).not.toHaveProperty("entry:warm");
+		expect(rows[1]).toHaveProperty("entry:warm");
+		expect(rows[1]).not.toHaveProperty("entry:cold");
+	});
+
+	// Marks that arrive with no open:start to anchor them (instrumentation
+	// switched on mid-open) are dropped, not attributed to some other open.
+	it("drops phases with no preceding open:start", () => {
+		crdtMark("orphan", "step1:reply");
+		expect(report()).toHaveLength(0);
+	});
+
+	it("keeps concurrent opens of different notes apart", () => {
+		crdtMark("a", "open:start");
+		crdtMark("b", "open:start");
+		crdtMark("b", "idb:synced");
+		crdtMark("a", "step1:sent");
+
+		const rows = report();
+		expect(rows.map((r) => r.noteId)).toEqual(["a", "b"]);
+		expect(rows[0]).toHaveProperty("step1:sent");
+		expect(rows[0]).not.toHaveProperty("idb:synced");
+		expect(rows[1]).toHaveProperty("idb:synced");
+	});
+});

--- a/frontend/src/crdt/perf.ts
+++ b/frontend/src/crdt/perf.ts
@@ -1,0 +1,110 @@
+/** Opt-in timing for the note-open path (#1317).
+ *
+ * A cached note still takes ~550ms to show content, and the cost is spread
+ * across four things nobody has measured against each other: the session
+ * wait, the per-note IndexedDB open, the STEP1 handshake round-trip, and
+ * CodeMirror construction. Every fix proposed in #1317 is sized differently
+ * depending on that split, so measure before designing.
+ *
+ * Off unless `localStorage.engramCrdtPerf === "1"`, so this costs a single
+ * boolean read per mark in normal use. Read the results with
+ * `window.__engramCrdtPerf()` — see `report()` below.
+ */
+
+const STORAGE_KEY = "engramCrdtPerf";
+/** Bounded so a long session can't grow this without limit. Ample for the
+ *  handful of opens a measurement run performs. */
+const MAX_SAMPLES = 2000;
+
+type Phase =
+	| "open:start"
+	| "open:session-ready"
+	| "entry:warm"
+	| "entry:cold"
+	| "idb:synced"
+	| "open:resolved"
+	| "step1:sent"
+	| "step1:reply"
+	| "editor:construct-start"
+	| "editor:construct-end";
+
+interface Sample {
+	t: number;
+	noteId: string;
+	phase: Phase;
+}
+
+interface OpenBase {
+	noteId: string;
+	total: number;
+}
+
+const samples: Sample[] = [];
+let enabled: boolean | null = null;
+
+function on(): boolean {
+	if (enabled === null) {
+		try {
+			enabled = localStorage.getItem(STORAGE_KEY) === "1";
+		} catch {
+			// Private mode / storage disabled — stay off rather than throw on
+			// every mark.
+			enabled = false;
+		}
+	}
+	return enabled;
+}
+
+// Exposed for reading over CDP without a UI. `report`/`reset` are function
+// declarations, so they hoist — wiring them here keeps every export last.
+// Guarded so it never throws in a non-browser (test/SSR) context.
+if (typeof window !== "undefined") {
+	(window as unknown as { __engramCrdtPerf: typeof report }).__engramCrdtPerf = report;
+	(window as unknown as { __engramCrdtPerfReset: typeof reset }).__engramCrdtPerfReset = reset;
+}
+
+/** One note open: each phase as ms elapsed since that open's `open:start`. */
+export type OpenRow = OpenBase & Partial<Record<Phase, number>>;
+
+export type CrdtPhase = Phase;
+
+export function crdtMark(noteId: string, phase: Phase): void {
+	if (!on()) {
+		return;
+	}
+	if (samples.length >= MAX_SAMPLES) {
+		samples.shift();
+	}
+	samples.push({ t: performance.now(), noteId, phase });
+}
+
+/** One row per note open, phases as deltas in ms from `open:start`.
+ *
+ * Grouped by `open:start` boundary rather than by note id alone, so
+ * reopening the same note yields separate rows instead of one row whose
+ * phases came from two different opens. */
+export function report(): OpenRow[] {
+	const rows: OpenRow[] = [];
+	const current = new Map<string, { start: number; row: OpenRow }>();
+
+	for (const s of samples) {
+		if (s.phase === "open:start") {
+			const row: OpenRow = { noteId: s.noteId, total: 0 };
+			rows.push(row);
+			current.set(s.noteId, { start: s.t, row });
+			continue;
+		}
+		const cur = current.get(s.noteId);
+		if (!cur) {
+			continue; // phase from before instrumentation was switched on
+		}
+		const delta = Math.round(s.t - cur.start);
+		cur.row[s.phase] = delta;
+		cur.row.total = Math.max(cur.row.total, delta);
+	}
+	return rows;
+}
+
+export function reset(): void {
+	samples.length = 0;
+}

--- a/frontend/src/crdt/perf.ts
+++ b/frontend/src/crdt/perf.ts
@@ -19,6 +19,12 @@ const MAX_SAMPLES = 2000;
 type Phase =
 	| "open:start"
 	| "open:session-ready"
+	// NOTE when reading a report: `entry:warm` also fires from
+	// ChannelBridge.handleFrame's getDoc, so on an open that went through
+	// `entry:cold` you will see a LATER `entry:warm` stamped at the moment the
+	// first sync frame arrived. That is the frame handler, not the open path —
+	// do not read it as the open taking that long. It is also why `total` can
+	// exceed the real time-to-content.
 	| "entry:warm"
 	| "entry:cold"
 	| "idb:synced"
@@ -26,7 +32,13 @@ type Phase =
 	| "step1:sent"
 	| "step1:reply"
 	| "editor:construct-start"
-	| "editor:construct-end";
+	| "editor:construct-end"
+	// Emitted when the view is built over an EMPTY Y.Text: the local
+	// IndexedDB copy had nothing, so the user stares at a blank editor until
+	// step1:reply lands. Its presence is what separates "content was local"
+	// from "content came over the wire" — the two have wildly different
+	// times-to-content and want completely different fixes.
+	| "editor:seeded-empty";
 
 interface Sample {
 	t: number;

--- a/frontend/src/crdt/session.ts
+++ b/frontend/src/crdt/session.ts
@@ -4,6 +4,7 @@ import { rlog } from "../observability/remote-log";
 import { CrdtChannel } from "./channel";
 import { CrdtEnrollment } from "./enrollment";
 import { CrdtManager } from "./manager";
+import { crdtMark } from "./perf";
 
 interface Session {
 	vaultId: string;
@@ -166,9 +167,11 @@ export function stopCrdtSession(): void {
 export async function openDoc(
 	noteId: string,
 ): Promise<{ ytext: Y.Text; awareness: Awareness; doc: Y.Doc } | null> {
+	crdtMark(noteId, "open:start");
 	const epoch = docEpochs.get(noteId) ?? 0;
 	const gen = sessionGeneration;
 	await waitForSessionStart();
+	crdtMark(noteId, "open:session-ready");
 	const s = session;
 	if (!s || sessionGeneration !== gen || (docEpochs.get(noteId) ?? 0) !== epoch) {
 		return null; // closed or torn down while waiting
@@ -187,6 +190,7 @@ export async function openDoc(
 		awareness = new Awareness(ytext.doc!);
 		s.awareness.set(noteId, awareness);
 	}
+	crdtMark(noteId, "open:resolved");
 	return { ytext, awareness, doc: ytext.doc! };
 }
 

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -639,6 +639,9 @@ export default function NotePage() {
 										// load it also carries the lazy chunk fetch (#1317).
 										if (v && shownId) {
 											crdtMark(shownId, "editor:construct-end");
+											if (handle && handle.ytext.length === 0) {
+												crdtMark(shownId, "editor:seeded-empty");
+											}
 										}
 									}}
 								/>

--- a/frontend/src/viewer/note-page.tsx
+++ b/frontend/src/viewer/note-page.tsx
@@ -18,6 +18,7 @@ import {
 	useSyncManifest,
 } from "../api/queries";
 import { readRows } from "../crdt/frontmatter-doc";
+import { crdtMark } from "../crdt/perf";
 import {
 	type CrdtSyncStatus,
 	closeDoc,
@@ -632,6 +633,13 @@ export default function NotePage() {
 									onFrontmatterShortcut={handleFrontmatterShortcut}
 									onView={(v) => {
 										editorViewRef.current = v;
+										// The view existing is the first moment content is on
+										// screen. Delta from open:resolved is the CodeMirror
+										// construction cost, and on the first open of a page
+										// load it also carries the lazy chunk fetch (#1317).
+										if (v && shownId) {
+											crdtMark(shownId, "editor:construct-end");
+										}
 									}}
 								/>
 							) : (


### PR DESCRIPTION
#1317 step 0: measure before designing. Opt-in marks across the four phases of a note open, plus the measurement they produced — which reorders the issue's plan.

## What this adds

`frontend/src/crdt/perf.ts` — marks at `openDoc` entry/session-ready/resolved, the IndexedDB open (cold vs warm), STEP1 sent/reply, and CodeMirror construction. Off unless `localStorage.engramCrdtPerf = "1"`; read with `window.__engramCrdtPerf()`.

Rows are cut on `open:start` rather than grouped by note id, so reopening a note yields a second row instead of one blended timing. Four unit tests cover that grouping.

## Measured (dev-selfhost, real browser, real vault)

| Phase | First open of a page load | Cold local cache | Warm local cache |
|---|---|---|---|
| session wait | **369 ms** | 1-3 ms | 1-3 ms |
| IndexedDB open | 38 ms | 15-21 ms | 15-21 ms |
| CodeMirror construct | **~1358 ms** (incl. lazy chunk) | 40-45 ms | 45-105 ms |
| STEP1 round trip | 282 ms | **~345 ms** | ~345 ms (after content) |
| **time to content** | **~1763 ms** | **~365 ms** | **85-124 ms** |

## What this changes about the plan

**The issue's option 1 (warm-document LRU) was predicted to be "almost certainly the largest win". It is the smallest.** The premise — "every note open is a cold start", costing the full ~500 ms — doesn't survive measurement: a revisit costs **124 ms**, because the parts that are actually expensive (session, lazy chunk) are already warm. An LRU saves the IndexedDB open, which is **15-21 ms**.

**Option 2 (one IndexedDB store instead of one DB per note) targets 15-21 ms.** Not the bottleneck. It may still scale badly with vault size, which this run didn't test.

What the numbers actually indict, in order:

1. **The lazy editor chunk — ~1358 ms, once per page load.** The single biggest number here by 4x, and the issue lists it only as a footnote ("two lazy-chunk spinners"). Preloading it is cheap.
2. **The STEP1 round trip — ~345 ms**, and this is what a cold-cache note waits on. The editor is already built and empty at ~60 ms; everything after that is the wire. 345 ms on **localhost** is suspicious on its own and deserves its own look (server-side pacing?).
3. **Option 4 (render from materialized content, bind CRDT when ready) is the fix that matters**, because the note payload already carries the content — it closes the ~300 ms empty-editor window directly. Its read-only-until-bound constraint still stands.
4. **Option 3 (prefetch on intent)** hides both the STEP1 wait and the CodeMirror build. Highest leverage for the reported click-to-click symptom.

No behaviour change in this PR — marks only, off by default.

## Testing

`bun run test` → **176 files, 1347 tests, 0 failures**. `tsc` and `biome` clean.

Refs #1317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz