### PR TITLE
fix(api): return 422 for a blank vault name instead of falling through

### DIFF
--- a/lib/engram_web/controllers/vaults_controller.ex
+++ b/lib/engram_web/controllers/vaults_controller.ex
@@ -330,7 +330,8 @@ defmodule EngramWeb.VaultsController do
       ok: {"Existing vault", "application/json", Schemas.RegisterVaultResponse},
       created: {"Newly created vault", "application/json", Schemas.RegisterVaultResponse},
       bad_request: {"name and client_id are required", "application/json", Schemas.MessageError},
-      payment_required: {"Vault cap reached", "application/json", Schemas.LimitError}
+      payment_required: {"Vault cap reached", "application/json", Schemas.LimitError},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
     ]
   )
 
@@ -369,6 +370,11 @@ defmodule EngramWeb.VaultsController do
             limit,
             current
           )
+
+        # Reachable since blank names became rejectable (#1213): a blank
+        # `name` passes the is_nil guard above but fails the changeset.
+        {:error, %Ecto.Changeset{}} = error ->
+          error
       end
     end
   end

--- a/openapi.json
+++ b/openapi.json
@@ -4438,6 +4438,16 @@
               }
             },
             "description": "Vault cap reached"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Validation error"
           }
         },
         "summary": "Register or fetch a vault by client_id (idempotent)",

--- a/test/engram_web/api_spec_test.exs
+++ b/test/engram_web/api_spec_test.exs
@@ -199,10 +199,13 @@ defmodule EngramWeb.ApiSpecTest do
       assert Enum.sort(Map.keys(op.responses)) == [201, 402, 422]
     end
 
-    test "POST /api/vaults/register documents request + 200/201/400/402", %{spec: spec} do
+    test "POST /api/vaults/register documents request + 200/201/400/402/422", %{spec: spec} do
       op = spec.paths["/api/vaults/register"].post
       assert op.requestBody
-      assert Enum.sort(Map.keys(op.responses)) == [200, 201, 400, 402]
+      # 422 joins the set with the blank-name fix: a name that is present but
+      # blank clears the is_nil guard and fails the changeset, which the
+      # controller now surfaces instead of falling out of the case.
+      assert Enum.sort(Map.keys(op.responses)) == [200, 201, 400, 402, 422]
     end
 
     test "GET /api/vaults/{id} documents id path param + 404", %{spec: spec} do

--- a/test/engram_web/controllers/vaults_controller_test.exs
+++ b/test/engram_web/controllers/vaults_controller_test.exs
@@ -322,6 +322,14 @@ defmodule EngramWeb.VaultsControllerTest do
       assert body["status"] == "created"
     end
 
+    test "returns 422 with blank name", %{conn: conn} do
+      conn = post(conn, "/api/vaults/register", %{name: "  ", client_id: "mac-blank"})
+
+      assert json_response(conn, 422) == %{
+               "errors" => %{"name" => ["can't be blank"]}
+             }
+    end
+
     test "returns existing vault on duplicate client_id (200)", %{conn: conn} do
       post(conn, "/api/vaults/register", %{name: "My Mac", client_id: "mac-dup"})
       conn2 = post(conn, "/api/vaults/register", %{name: "My Mac", client_id: "mac-dup"})


### PR DESCRIPTION
`POST /api/vaults/register` guards on `is_nil(name)` and returns 400 — but a name that is **present and blank** (`"  "`) clears that guard and then fails the changeset. `register_vault/3` returns `{:error, %Ecto.Changeset{}}`, the controller's `case` had no clause for it, and the request died with a `CaseClauseError`: **a 500 for what is plainly a validation error.**

Reachable since blank names became rejectable (#1213).

## Change

- The missing `{:error, %Ecto.Changeset{}}` clause, so the existing changeset→422 rendering runs.
- `unprocessable_entity` documented on the operation. The sibling create endpoint already documents a 422, so this brings the pair in line.
- A test asserting `422` with `{"errors": {"name": ["can't be blank"]}}`.
- `api_spec_test`'s pinned response set for this endpoint updated from `[200, 201, 400, 402]` to include `422`.

## Provenance

Found as **uncommitted work in a worktree** with no branch pushed and no PR — it existed only on disk and would have been lost with the worktree. Rebased from a 6-day-old base onto current `main`, where the bug is still live (verified: `main`'s `case` still has no changeset clause).

## Testing

`mix format --check-formatted` ✓ · `mix credo --strict` ✓ · `mix dialyzer` ✓ · `mix test --warnings-as-errors` → **4253 tests, 0 failures**.

Note for anyone running the suite locally: both this worktree and `test/mid-txn-interleave-harness` default to the same `engram_test` database, so concurrent runs produce ~26 phantom failures from shared state. Run with a distinct `MIX_TEST_PARTITION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz