### PR TITLE
fix(sync): stop the batch create leg reporting an adopt as a create

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -813,6 +813,7 @@ defmodule Engram.Notes do
   """
   @spec genesis_crdt_note(map(), map(), String.t(), String.t(), keyword()) ::
           {:ok, Note.t()}
+          | {:adopted, Note.t()}
           | {:error, :invalid_id}
           | {:error, :recently_deleted}
           | {:error, :id_conflict, Note.t()}
@@ -917,6 +918,12 @@ defmodule Engram.Notes do
 
           {:ok, note}
 
+        {:ok, {:ok, note, :adopted}} ->
+          # Surfaced, not flattened to {:ok, note}: the batch create leg has to
+          # tell "we made this row" from "a different note already owned the
+          # path", because only the former means the caller's frame was applied.
+          {:adopted, note}
+
         {:ok, inner} ->
           inner
 
@@ -947,11 +954,32 @@ defmodule Engram.Notes do
       {:ok, lookup_query} ->
         case Repo.one(lookup_query) do
           %Note{} = live ->
-            {:ok, decrypt_or_raise!(live, user)}
+            # ADOPTED, not created: the path is already owned by a live note under
+            # a DIFFERENT id, and this caller's content frame was never applied to
+            # it. Tagged so the batch leg can say so instead of reporting a create
+            # (see crdt_channel prepare_create/4) -- a plain {:ok, note} here reads
+            # as success and silently discards the client's body.
+            {:ok, decrypt_or_raise!(live, user), :adopted}
 
           nil ->
-            if taken_id, do: log_id_taken(user, vault.id, taken_id, canonical_id)
-            genesis_insert_bare(user, vault, canonical_id, sanitized_path, folder, lookup_query)
+            # Logged AFTER the insert lands, not before: genesis_insert_bare can
+            # still fail on the notes cap or a changeset, and a tripwire naming a
+            # reminted_to id that never existed makes the Loki count lie.
+            case genesis_insert_bare(
+                   user,
+                   vault,
+                   canonical_id,
+                   sanitized_path,
+                   folder,
+                   lookup_query
+                 ) do
+              {:ok, _note, _tag} = ok ->
+                if taken_id, do: log_id_taken(user, vault.id, taken_id, canonical_id)
+                ok
+
+              other ->
+                other
+            end
         end
 
       {:error, _} = err ->
@@ -1498,18 +1526,18 @@ defmodule Engram.Notes do
       end
   end
 
+  # Row-or-nil view of classify_by_id/2, kept for upsert_pathless's legacy REST
+  # branching. A projection rather than a second copy of the rule: both used to
+  # spell out cast -> Repo.get -> vault+kind, so a change to what counts as
+  # "this vault's note" had to be made twice or the CRDT genesis path and the
+  # REST path would silently disagree.
   defp existing_by_client_id(nil, _vault), do: nil
 
   defp existing_by_client_id(client_id, vault) do
-    case Ecto.UUID.cast(client_id) do
-      {:ok, uuid} ->
-        case Repo.get(Note, uuid) do
-          %Note{vault_id: vault_id, kind: "note"} = note when vault_id == vault.id -> note
-          _ -> nil
-        end
-
-      :error ->
-        nil
+    case classify_by_id(vault, client_id) do
+      {:live, note} -> note
+      {:tombstone, note} -> note
+      _ -> nil
     end
   end
 

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -250,6 +250,13 @@ defmodule EngramWeb.CrdtChannel do
         {:ok, note} ->
           {:reply, {:ok, %{doc_id: note.id}}, socket}
 
+        {:adopted, note} ->
+          # Unchanged behaviour for the single create: the client's crdtCreate
+          # promise resolves to the authoritative id and pushFile's ADOPT then
+          # transfers the local body onto that lineage. Only the BATCH leg has to
+          # distinguish this from a create (it reports frame-applied, not id).
+          {:reply, {:ok, %{doc_id: note.id}}, socket}
+
         {:error, :id_conflict, note} ->
           {:reply, {:error, %{reason: "id_conflict", doc_id: note.id}}, socket}
 
@@ -578,6 +585,15 @@ defmodule EngramWeb.CrdtChannel do
       # crdt_create above always replied note.id; this leg has to match it.
       {:created, note.id, frame}
     else
+      {:adopted, note} ->
+        # The path was already owned by a live note under a different id, so this
+        # entry's content frame was NOT applied to it. Reporting "ok" would have
+        # the plugin mark the file pushed (adoptCreateAck stamps the LOCAL body as
+        # the baseline) while the body never reached the server. id_conflict is
+        # the existing contract for exactly this, and the plugin already routes it
+        # to pushFile's full ADOPT, which transfers the body onto that lineage.
+        {:result, %{doc_id: note.id, status: "error", reason: "id_conflict"}}
+
       {:error, :id_conflict, note} ->
         {:result, %{doc_id: note.id, status: "error", reason: "id_conflict"}}
 
@@ -612,7 +628,7 @@ defmodule EngramWeb.CrdtChannel do
         # whole dumps its `changes` -- every ciphertext blob on the note -- into
         # Loki. Only metadata keys are redacted, never the message body.
         Logger.warning(
-          "crdt_create_batch prepare failed: #{inspect(Engram.Telemetry.error_kind(other))}",
+          "crdt_create_batch prepare failed: #{inspect(prepare_error_kind(other))}",
           Metadata.with_category(:warning, :websocket,
             doc_id: doc_id,
             user_id: user.id,
@@ -853,6 +869,15 @@ defmodule EngramWeb.CrdtChannel do
       )
     )
   end
+
+  # `other` in prepare_create's with/else is always a 2-tuple {:error, term}, so
+  # error_kind/1 applied to it returns the literal :error and every failure logs
+  # identically -- the swallow the arm exists to prevent. Unwrap first, then
+  # classify the INNER term, which is what carries the useful distinction (a
+  # changeset vs a KMS failure vs a filter-key error) without forwarding a raw
+  # term that could carry key material.
+  defp prepare_error_kind({:error, reason}), do: Engram.Telemetry.error_kind(reason)
+  defp prepare_error_kind(other), do: Engram.Telemetry.error_kind(other)
 
   # ensure_room/2 only ever fails as {:error, atom}, so that reason is safe to
   # name verbatim. Anything else goes through error_kind/1 rather than inspect,

--- a/lib/engram_web/channels/crdt_channel.ex
+++ b/lib/engram_web/channels/crdt_channel.ex
@@ -876,8 +876,9 @@ defmodule EngramWeb.CrdtChannel do
   # classify the INNER term, which is what carries the useful distinction (a
   # changeset vs a KMS failure vs a filter-key error) without forwarding a raw
   # term that could carry key material.
+  # Total by construction: every arm reaching prepare_create's else is a
+  # {:error, term} (dialyzer rejects a fallback clause here as uncoverable).
   defp prepare_error_kind({:error, reason}), do: Engram.Telemetry.error_kind(reason)
-  defp prepare_error_kind(other), do: Engram.Telemetry.error_kind(other)
 
   # ensure_room/2 only ever fails as {:error, atom}, so that reason is safe to
   # name verbatim. Anything else goes through error_kind/1 rather than inspect,

--- a/test/engram/notes/genesis_crdt_note_test.exs
+++ b/test/engram/notes/genesis_crdt_note_test.exs
@@ -43,7 +43,10 @@ defmodule Engram.Notes.GenesisCrdtNoteTest do
   } do
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "Notes/b.md", "content" => "world"})
     other = Ecto.UUID.generate()
-    assert {:ok, got} = Notes.genesis_crdt_note(user, vault, other, "Notes/b.md")
+    # Tagged :adopted rather than a plain {:ok, _}: the caller's content frame was
+    # NOT applied to this row, and the batch create leg has to be able to say so
+    # instead of reporting a create (a plain ok made it discard the client body).
+    assert {:adopted, got} = Notes.genesis_crdt_note(user, vault, other, "Notes/b.md")
     # adopted the server's id
     assert got.id == note.id
     refute Notes.note_in_vault?(user, vault.id, other)

--- a/test/engram_web/channels/crdt_channel_test.exs
+++ b/test/engram_web/channels/crdt_channel_test.exs
@@ -438,6 +438,40 @@ defmodule EngramWeb.CrdtChannelTest do
       assert_note_content_eventually(user, vault, id2, "beta")
     end
 
+    test "a path already owned by another note reports id_conflict, never ok", %{
+      socket: socket,
+      user: user,
+      vault: vault
+    } do
+      # Genesis ADOPTS when the path is taken by a live note under a different id,
+      # and the entry's content frame is NOT applied to it. Reporting "ok" would
+      # have the client call adoptCreateAck, stamp its LOCAL body as the CRDT
+      # baseline and count the file pushed, while that body never reached the
+      # server -- a silent upload loss. id_conflict routes the file to pushFile's
+      # ADOPT, which actually transfers it.
+      {:ok, existing} =
+        Notes.upsert_note(user, vault, %{"path" => "Owned.md", "content" => "server body"})
+
+      creates = [
+        %{
+          "doc_id" => Ecto.UUID.generate(),
+          "path" => "Owned.md",
+          "b64" => frame_for_content("client body")
+        }
+      ]
+
+      ref = push(socket, "crdt_create_batch", %{"creates" => creates})
+      assert_reply ref, :ok, %{results: [result]}
+
+      assert result.status == "error"
+      assert result.reason == "id_conflict"
+      assert result.doc_id == existing.id
+
+      # And the adopted note is untouched -- the frame was not merged into it.
+      {:ok, still} = Notes.get_note(user, vault, "Owned.md")
+      assert still.content == "server body"
+    end
+
     test "an id owned by another of the user's vaults is re-minted, with content", %{
       socket: socket,
       user: user,


### PR DESCRIPTION
## What

Post-merge review follow-ups to #1318. A deep review of the half of #1318 that shipped **after** its first review found that the batch fix introduced a new silent data loss. Nothing has been released (`b359e77a` is in no release tag), so this is a correction on main, not an incident.

Plugin half is Engram-obsidian#410.

## The one that matters

#1318 made `prepare_create/4` forward the **created** id instead of the sent one. That was right for the re-mint, but it also made the **ADOPT** path reach phase 2/3 for the first time.

Genesis adopts when the path is already owned by a live note under a different id — and that note's content is not the caller's. `seed_genesis_if_empty` skips a non-empty doc, so the entry reported `status: "ok"` while the client's frame was never applied. The plugin then calls `adoptCreateAck`, **stamps its LOCAL body as the CRDT baseline** and counts the file pushed. The body never reached the server, no issue was recorded, and the server's different content flows back down over it.

That is strictly worse than the `create_failed` it used to return, which the plugin correctly retried through `pushFile`'s ADOPT.

**Fix:** `genesis_adopt_or_insert` tags that branch `{:ok, note, :adopted}`; `genesis_crdt_note` surfaces `{:adopted, note}`.

| leg | on adopt |
|---|---|
| `crdt_create` (single) | unchanged — reply the authoritative id; `pushFile`'s ADOPT transfers the body |
| `crdt_create_batch` | `id_conflict`, the existing contract for "path owned by another note, your frame was not applied" |

The plugin **already** routes `id_conflict` to `pushFile`'s full ADOPT, so no plugin change is needed.

## Also from the review

- **`error_kind/1` swallowed every reason.** `other` in `prepare_create`'s else is always a 2-tuple `{:error, term}`, and `error_kind` reads the tuple head — so every failure logged the literal `:error`, the exact swallow that arm exists to prevent. Unwrap first, classify the inner term. (Dialyzer independently confirmed the premise by rejecting a fallback clause as uncoverable.)
- **The re-mint tripwire fired before the insert.** A re-mint that then failed on the notes cap or a changeset logged a `reminted_to` id that never landed, so the Loki count lied. Moved after the insert succeeds.
- **The id-scoping rule lived in two places.** `existing_by_client_id/2` is now a projection of `classify_by_id/2` rather than a second copy of cast → `Repo.get` → vault+kind.

## Tests

- new: a batch create whose path is owned by another note replies `id_conflict`, never `ok`, and the adopted note keeps its content. **Verified red** with the `:adopted` tag reverted (`left: "ok"`).
- updated: the existing adopt test now asserts the `{:adopted, _}` contract.

## Gates

format ✓ · credo --strict 0 issues ✓ · dialyzer ✓ (caught a real dead clause) · `mix test` see below

## Local suite flakiness — read this

Being explicit rather than claiming green. Local full-suite samples:

| run | result |
|---|---|
| clean `origin/main` | 4253 tests, **0 failures** |
| clean `origin/main` (2nd) | 4253 tests, **0 failures** |
| this branch | 6 failures, all Oban job-count assertions |
| this branch (re-run) | 1 failure, a different test (`crdt_msg` rate-limit timing) |

The six do **not** reproduce in isolation (those files pass 68/68 on their own) and the two branch runs failed on disjoint sets, which reads as order-dependent shared state (the `oban_jobs` table and the rate-limiter buckets) rather than a deterministic regression — I cannot construct a mechanism by which any of this diff changes job enqueues. But main went 2/2 clean and this branch went 0/2, and I am not going to call that proven either way. CI runs partitioned with fresh databases; if `unit-tests` is green here, that is the signal I am trusting. Flagging it so it is not discovered later as something I quietly waved through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC