### PR TITLE
fix(crdt): never half-migrate a legacy row from a checkpoint

### DIFF
--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -511,6 +511,33 @@ defmodule Engram.Notes.CrdtCheckpoint do
     |> Repo.one()
   end
 
+  # `Crypto.encrypt_crdt_state/3` ALWAYS binds the AAD to the row id, so writing
+  # crdt_state forces `dek_version` up to the AAD-bound version. On a legacy row
+  # that leaves content/title/path/folder/tags bound under the EMPTY AAD while
+  # the row claims bound: they never decrypt again, `list_tree_notes` raises
+  # through `PathCrypto.decrypt!` so ONE row 500s the WHOLE vault tree, and
+  # `AadRebind` (which selects on the legacy version) can no longer see the row
+  # to repair it. #1336.
+  #
+  # `<`, not `!=`: UserDekRotation stamps `user.dek_version + 1`, so a rotated
+  # row carries 3, 4, ... and is still AAD-bound. An equality test against 2
+  # would treat every rotated user's rows as legacy.
+  #
+  # Only the branches that write crdt_state WITHOUT re-encrypting the rest need
+  # this guard. The materialize branch re-encrypts every envelope, so it migrates
+  # the row wholesale and is the one path that may run on a legacy row.
+  defp legacy_row?(%Note{dek_version: v}) when is_integer(v),
+    do: v < Crypto.row_version_aad_bound()
+
+  # Unknown version => treat as legacy, i.e. SKIP. This is unreachable today
+  # (`dek_version` is NOT NULL DEFAULT 1 and the checkpoint always loads a full
+  # row), but it is the guard's only safety net, so it has to fail the safe way.
+  # `Crypto.decrypt_aad/3` makes the same call: its catch-all reads an unknown
+  # version as legacy. Answering `false` here would let a partially-selected
+  # `%Note{}` be READ as legacy and WRITTEN as bound — the exact half-migration
+  # above. Skipping costs one deferred compaction and cannot lose data.
+  defp legacy_row?(_note), do: true
+
   # Prune the consumed tail-log rows. Two boundary shapes:
   #
   #   * `{:ids, ids}` — delete EXACTLY these rows (detached callers). A concurrent
@@ -523,26 +550,6 @@ defmodule Engram.Notes.CrdtCheckpoint do
   #
   # Runs inside the same `Repo.with_tenant` transaction as the notes UPDATE for
   # atomicity.
-  # `Crypto.encrypt_crdt_state/3` ALWAYS binds the AAD to the row id, so writing
-  # crdt_state forces `dek_version` up to the AAD-bound version. On a legacy row
-  # that leaves content/title/path/folder/tags bound under the EMPTY AAD while
-  # the row claims bound: they never decrypt again, `list_tree_notes` raises
-  # through `PathCrypto.decrypt!` so ONE row 500s the WHOLE vault tree, and
-  # `AadRebind` (which selects on the legacy version) can no longer see the row
-  # to repair it. #1336.
-  #
-  # `>=`, not `==`: UserDekRotation stamps `user.dek_version + 1`, so a rotated
-  # row carries 3, 4, ... and is still AAD-bound. An equality test against 2
-  # would treat every rotated user's rows as legacy.
-  #
-  # Only the branches that write crdt_state WITHOUT re-encrypting the rest need
-  # this guard. The materialize branch re-encrypts every envelope, so it migrates
-  # the row wholesale and is the one path that may run on a legacy row.
-  defp legacy_row?(%Note{dek_version: v}) when is_integer(v),
-    do: v < Crypto.row_version_aad_bound()
-
-  defp legacy_row?(_note), do: false
-
   defp prune_tail(_note_id, {:ids, []}), do: :ok
 
   defp prune_tail(note_id, {:ids, ids}) do

--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -286,6 +286,14 @@ defmodule Engram.Notes.CrdtCheckpoint do
   # ceiling keeps its full state vector; add a structural (nodes/edges-preserving)
   # flatten in Phase 2 if a real board ever hits it.
   defp do_structural_checkpoint(note, note_id, live_state, prune, user) do
+    if legacy_row?(note) do
+      {:skip, :legacy_row_needs_rebind}
+    else
+      do_structural_checkpoint_bound(note, note_id, live_state, prune, user)
+    end
+  end
+
+  defp do_structural_checkpoint_bound(note, note_id, live_state, prune, user) do
     with {:ok, union_doc} <- union_with_row_state(note, live_state, user),
          {:ok, raw_state} <- encode(union_doc),
          {:ok, {ct, nonce}} <- Crypto.encrypt_crdt_state(raw_state, user, note_id) do
@@ -338,88 +346,98 @@ defmodule Engram.Notes.CrdtCheckpoint do
     %{text: text, tags: tags, content_hash: content_hash, ct: ct, nonce: nonce, user: user} = m
     prev = note.content_hash
 
-    if prev == content_hash do
-      # Text unchanged: compact the snapshot + prune, but do NOT touch
-      # version/seq/content — legacy /changes pullers must not see phantom edits.
-      {1, _} =
-        Repo.update_all(
-          from(n in Note, where: n.id == ^note_id and n.kind == "note"),
-          set: [
-            crdt_state_ciphertext: ct,
-            crdt_state_nonce: nonce,
-            dek_version: Crypto.row_version_aad_bound()
-          ]
-        )
+    cond do
+      prev == content_hash and legacy_row?(note) ->
+        # Compaction writes crdt_state and NOTHING else, so on a legacy row it
+        # can only half-migrate (see legacy_row?/1). It is an optimisation --
+        # the tail stays unpruned and the next bind re-checkpoints -- so
+        # skipping costs nothing, while writing costs the whole vault's
+        # decryptability.
+        {:skip, :legacy_row_needs_rebind}
 
-      prune_tail(note_id, prune)
-      {prev, content_hash, note.path}
-    else
-      # Re-derive title from the note's decrypted (sanitized-at-write) path.
-      title = Helpers.extract_title(text, note.path)
-
-      merged = %{content: text, title: title, tags: tags, content_hash: content_hash}
-      {:ok, encrypted} = Crypto.encrypt_note_fields(merged, user, note_id)
-
-      phase_b =
-        Notes.inject_phase_b_fields_pub(
-          encrypted,
-          user,
-          note_id,
-          note.path,
-          note.folder,
-          tags
-        )
-        |> Notes.inject_okf_fields_pub(user, note_id, text)
-        |> Map.put(:crdt_state_ciphertext, ct)
-        |> Map.put(:crdt_state_nonce, nonce)
-        |> Map.put(:content_hash, content_hash)
-
-      # #902 fence. When the caller captured the doc at a known row version,
-      # persist only if the row is STILL at that version. A REST/MCP write
-      # that committed after the snapshot bumped `version`, so the CAS matches
-      # zero rows and we ABORT — never overwriting the newer committed content
-      # with our stale encoding. `captured_version` nil (e.g. the unbind path)
-      # keeps the prior unfenced behaviour. The field set is derived through
-      # Note.changeset (identical casting to the previous Repo.update!) and
-      # applied via a version-fenced update_all, mirroring the compaction branch.
-      captured = Keyword.get(opts, :captured_version)
-      fence_version = captured || note.version
-
-      changeset =
-        note
-        |> Note.changeset(Map.put(phase_b, :version, fence_version + 1))
-        |> Ecto.Changeset.put_change(:seq, Vaults.next_seq!(vault_id))
-
-      base_query = from(n in Note, where: n.id == ^note_id and n.kind == "note")
-
-      fenced_query =
-        if captured, do: where(base_query, [n], n.version == ^captured), else: base_query
-
-      # update_all does NOT auto-manage timestamps (Repo.update! does), and
-      # `updated_at` is never cast into changeset.changes. Set it explicitly,
-      # matching every sibling notes update_all, so the row's recency stays
-      # truthful for everything that orders/filters on updated_at. (The
-      # /api/notes/changes timestamp feed this originally guarded is retired.)
-      set = changeset.changes |> Map.put(:updated_at, DateTime.utc_now()) |> Map.to_list()
-
-      case Repo.update_all(fenced_query, set: set) do
-        {1, _} ->
-          prune_tail(note_id, prune)
-          {prev, content_hash, note.path}
-
-        {0, _} ->
-          # The row advanced since our snapshot — a newer write is already
-          # committed. Do NOT prune (its tail rows may be unmerged) and do NOT
-          # revert. Return equal hashes so the caller enqueues no embed for a
-          # write that did not happen; the next debounce tick re-captures the
-          # now-merged doc and checkpoints that.
-          Logger.info(
-            "crdt checkpoint skipped stale write note_id=#{note_id} captured_version=#{fence_version}",
-            Metadata.with_category(:info, :sync, note_id: note_id)
+      prev == content_hash ->
+        # Text unchanged: compact the snapshot + prune, but do NOT touch
+        # version/seq/content — legacy /changes pullers must not see phantom edits.
+        {1, _} =
+          Repo.update_all(
+            from(n in Note, where: n.id == ^note_id and n.kind == "note"),
+            set: [
+              crdt_state_ciphertext: ct,
+              crdt_state_nonce: nonce,
+              dek_version: Crypto.row_version_aad_bound()
+            ]
           )
 
-          {content_hash, content_hash, note.path}
-      end
+        prune_tail(note_id, prune)
+        {prev, content_hash, note.path}
+
+      true ->
+        # Re-derive title from the note's decrypted (sanitized-at-write) path.
+        title = Helpers.extract_title(text, note.path)
+
+        merged = %{content: text, title: title, tags: tags, content_hash: content_hash}
+        {:ok, encrypted} = Crypto.encrypt_note_fields(merged, user, note_id)
+
+        phase_b =
+          Notes.inject_phase_b_fields_pub(
+            encrypted,
+            user,
+            note_id,
+            note.path,
+            note.folder,
+            tags
+          )
+          |> Notes.inject_okf_fields_pub(user, note_id, text)
+          |> Map.put(:crdt_state_ciphertext, ct)
+          |> Map.put(:crdt_state_nonce, nonce)
+          |> Map.put(:content_hash, content_hash)
+
+        # #902 fence. When the caller captured the doc at a known row version,
+        # persist only if the row is STILL at that version. A REST/MCP write
+        # that committed after the snapshot bumped `version`, so the CAS matches
+        # zero rows and we ABORT — never overwriting the newer committed content
+        # with our stale encoding. `captured_version` nil (e.g. the unbind path)
+        # keeps the prior unfenced behaviour. The field set is derived through
+        # Note.changeset (identical casting to the previous Repo.update!) and
+        # applied via a version-fenced update_all, mirroring the compaction branch.
+        captured = Keyword.get(opts, :captured_version)
+        fence_version = captured || note.version
+
+        changeset =
+          note
+          |> Note.changeset(Map.put(phase_b, :version, fence_version + 1))
+          |> Ecto.Changeset.put_change(:seq, Vaults.next_seq!(vault_id))
+
+        base_query = from(n in Note, where: n.id == ^note_id and n.kind == "note")
+
+        fenced_query =
+          if captured, do: where(base_query, [n], n.version == ^captured), else: base_query
+
+        # update_all does NOT auto-manage timestamps (Repo.update! does), and
+        # `updated_at` is never cast into changeset.changes. Set it explicitly,
+        # matching every sibling notes update_all, so the row's recency stays
+        # truthful for everything that orders/filters on updated_at. (The
+        # /api/notes/changes timestamp feed this originally guarded is retired.)
+        set = changeset.changes |> Map.put(:updated_at, DateTime.utc_now()) |> Map.to_list()
+
+        case Repo.update_all(fenced_query, set: set) do
+          {1, _} ->
+            prune_tail(note_id, prune)
+            {prev, content_hash, note.path}
+
+          {0, _} ->
+            # The row advanced since our snapshot — a newer write is already
+            # committed. Do NOT prune (its tail rows may be unmerged) and do NOT
+            # revert. Return equal hashes so the caller enqueues no embed for a
+            # write that did not happen; the next debounce tick re-captures the
+            # now-merged doc and checkpoints that.
+            Logger.info(
+              "crdt checkpoint skipped stale write note_id=#{note_id} captured_version=#{fence_version}",
+              Metadata.with_category(:info, :sync, note_id: note_id)
+            )
+
+            {content_hash, content_hash, note.path}
+        end
     end
   end
 
@@ -505,6 +523,26 @@ defmodule Engram.Notes.CrdtCheckpoint do
   #
   # Runs inside the same `Repo.with_tenant` transaction as the notes UPDATE for
   # atomicity.
+  # `Crypto.encrypt_crdt_state/3` ALWAYS binds the AAD to the row id, so writing
+  # crdt_state forces `dek_version` up to the AAD-bound version. On a legacy row
+  # that leaves content/title/path/folder/tags bound under the EMPTY AAD while
+  # the row claims bound: they never decrypt again, `list_tree_notes` raises
+  # through `PathCrypto.decrypt!` so ONE row 500s the WHOLE vault tree, and
+  # `AadRebind` (which selects on the legacy version) can no longer see the row
+  # to repair it. #1336.
+  #
+  # `>=`, not `==`: UserDekRotation stamps `user.dek_version + 1`, so a rotated
+  # row carries 3, 4, ... and is still AAD-bound. An equality test against 2
+  # would treat every rotated user's rows as legacy.
+  #
+  # Only the branches that write crdt_state WITHOUT re-encrypting the rest need
+  # this guard. The materialize branch re-encrypts every envelope, so it migrates
+  # the row wholesale and is the one path that may run on a legacy row.
+  defp legacy_row?(%Note{dek_version: v}) when is_integer(v),
+    do: v < Crypto.row_version_aad_bound()
+
+  defp legacy_row?(_note), do: false
+
   defp prune_tail(_note_id, {:ids, []}), do: :ok
 
   defp prune_tail(note_id, {:ids, ids}) do

--- a/test/engram/notes/crdt_checkpoint_legacy_row_test.exs
+++ b/test/engram/notes/crdt_checkpoint_legacy_row_test.exs
@@ -1,0 +1,118 @@
+defmodule Engram.Notes.CrdtCheckpointLegacyRowTest do
+  @moduledoc """
+  A checkpoint must never HALF-migrate a row's encryption (#1336).
+
+  `Crypto.encrypt_crdt_state/3` always binds the AAD to the row id, so writing
+  `crdt_state` forces `dek_version` up to the AAD-bound version. On a legacy
+  (`dek_version = 1`) row the compaction and structural branches do exactly that
+  while leaving content/title/path/folder/tags bound under the EMPTY AAD.
+
+  After such a write `decrypt_aad/3` hands the bound AAD to v1 envelopes, so:
+
+    * the note reads as `{:error, :decrypt_failed}`
+    * `list_tree_notes` uses `PathCrypto.decrypt!`, so ONE such row 500s the
+      whole vault tree, not just that note
+    * `AadRebind` filters on the legacy `dek_version`, so it can no longer see
+      the row to repair it
+
+  Compaction runs on every room exit whose text is unchanged, so this is an
+  ordinary path, not an exotic one. `do_rename_note_inner` documents the same
+  hazard and re-encrypts everything; these branches were the exception.
+  """
+  use Engram.DataCase, async: false
+
+  alias Engram.Crypto
+  alias Engram.Crypto.{DekCache, Envelope}
+  alias Engram.Notes.{CrdtBridge, CrdtCheckpoint, Note}
+  alias Engram.Repo
+
+  setup do
+    DekCache.invalidate_all()
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "LegacyRow"})
+    %{user: user, vault: vault}
+  end
+
+  test "a compaction does not half-migrate a legacy row", %{user: user, vault: vault} do
+    body = "legacy body"
+    note = insert_legacy_note!(user, vault, body)
+
+    # Same text as the row, so the checkpoint takes the COMPACTION branch
+    # (prev == content_hash): it writes crdt_state and nothing else.
+    {:ok, doc} = CrdtBridge.doc_from_state(nil_state())
+    :ok = CrdtBridge.diff_into_text(Yex.Doc.get_text(doc, CrdtBridge.text_name()), body)
+
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+
+    {:ok, raw} = Repo.with_tenant(user.id, fn -> Repo.get(Note, note.id) end)
+
+    # The row must still be internally consistent: whatever dek_version it
+    # claims, every envelope on it must decrypt under that version.
+    assert {:ok, fresh} = Crypto.maybe_decrypt_note_fields(raw, user),
+           """
+           the checkpoint half-migrated a legacy row: it stamped
+           dek_version=#{raw.dek_version} while leaving the other envelopes
+           bound under the empty AAD, so the note no longer decrypts at all.
+           """
+
+    assert fresh.content == body
+    assert fresh.path == "legacy/path.md"
+  end
+
+  # An empty Yjs state, so doc_from_state builds a fresh doc.
+  defp nil_state do
+    {:ok, doc} = CrdtBridge.doc_from_state(nil)
+    {:ok, state} = Yex.encode_state_as_update(doc)
+    state
+  end
+
+  # Every ciphertext column written with the EMPTY AAD, row stamped
+  # dek_version = 1 — the shape AadRebind exists to migrate. Mirrors the
+  # hand-built row in crypto/aad_rebind_test.exs.
+  defp insert_legacy_note!(user, vault, body) do
+    {:ok, dek} = Crypto.get_dek(user)
+    {:ok, filter_key} = Crypto.dek_filter_key(user)
+    {:ok, hash_key} = Crypto.dek_content_hash_key(user)
+
+    {content_ct, content_n} = Envelope.encrypt(body, dek)
+    {title_ct, title_n} = Envelope.encrypt("legacy title", dek)
+    {path_ct, path_n} = Envelope.encrypt("legacy/path.md", dek)
+    {folder_ct, folder_n} = Envelope.encrypt("legacy", dek)
+    {tags_ct, tags_n} = Envelope.encrypt(:erlang.term_to_binary([]), dek)
+
+    attrs = %{
+      kind: "note",
+      content_hash: Crypto.hmac_content_hash(hash_key, body),
+      seq: 1,
+      mtime: 0.0,
+      version: 1,
+      user_id: user.id,
+      vault_id: vault.id,
+      content_ciphertext: content_ct,
+      content_nonce: content_n,
+      title_ciphertext: title_ct,
+      title_nonce: title_n,
+      path_ciphertext: path_ct,
+      path_nonce: path_n,
+      path_hmac: Crypto.hmac_field(filter_key, "legacy/path.md"),
+      folder_ciphertext: folder_ct,
+      folder_nonce: folder_n,
+      folder_hmac: Crypto.hmac_field(filter_key, "legacy"),
+      tags_ciphertext: tags_ct,
+      tags_nonce: tags_n,
+      tags_hmac: [],
+      dek_version: Crypto.row_version_legacy()
+    }
+
+    {:ok, note} =
+      Repo.with_tenant(user.id, fn ->
+        %Note{}
+        |> Ecto.Changeset.cast(attrs, Map.keys(attrs))
+        |> Repo.insert!()
+      end)
+
+    note
+  end
+end

--- a/test/engram/notes/crdt_checkpoint_legacy_row_test.exs
+++ b/test/engram/notes/crdt_checkpoint_legacy_row_test.exs
@@ -61,6 +61,37 @@ defmodule Engram.Notes.CrdtCheckpointLegacyRowTest do
     assert fresh.path == "legacy/path.md"
   end
 
+  # The structural branch is the OTHER half of the guard, and it is the worse
+  # half: markdown self-heals on the first real edit (materialize re-encrypts
+  # every envelope) but nothing else ever writes a canvas note's state, so a
+  # half-migrated legacy board is permanent. Without a test here the guard at
+  # do_structural_checkpoint/5 can be refactored away with the suite still green.
+  test "a structural (.canvas) checkpoint does not half-migrate a legacy row", %{
+    user: user,
+    vault: vault
+  } do
+    note = insert_legacy_note!(user, vault, "{}", path: "legacy/board.canvas")
+
+    # Non-markdown path => checkpoint dispatches to do_structural_checkpoint/5,
+    # which writes crdt_state and nothing else.
+    {:ok, doc} = CrdtBridge.doc_from_state(nil_state())
+    :ok = CrdtBridge.diff_into_text(Yex.Doc.get_text(doc, CrdtBridge.text_name()), "{}")
+
+    :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+
+    {:ok, raw} = Repo.with_tenant(user.id, fn -> Repo.get(Note, note.id) end)
+
+    assert {:ok, fresh} = Crypto.maybe_decrypt_note_fields(raw, user),
+           """
+           the structural checkpoint half-migrated a legacy row: it stamped
+           dek_version=#{raw.dek_version} while leaving the other envelopes
+           bound under the empty AAD, so the board no longer decrypts and
+           list_tree_notes raises for the WHOLE vault.
+           """
+
+    assert fresh.path == "legacy/board.canvas"
+  end
+
   # An empty Yjs state, so doc_from_state builds a fresh doc.
   defp nil_state do
     {:ok, doc} = CrdtBridge.doc_from_state(nil)
@@ -71,14 +102,16 @@ defmodule Engram.Notes.CrdtCheckpointLegacyRowTest do
   # Every ciphertext column written with the EMPTY AAD, row stamped
   # dek_version = 1 — the shape AadRebind exists to migrate. Mirrors the
   # hand-built row in crypto/aad_rebind_test.exs.
-  defp insert_legacy_note!(user, vault, body) do
+  defp insert_legacy_note!(user, vault, body, opts \\ []) do
+    path = Keyword.get(opts, :path, "legacy/path.md")
+
     {:ok, dek} = Crypto.get_dek(user)
     {:ok, filter_key} = Crypto.dek_filter_key(user)
     {:ok, hash_key} = Crypto.dek_content_hash_key(user)
 
     {content_ct, content_n} = Envelope.encrypt(body, dek)
     {title_ct, title_n} = Envelope.encrypt("legacy title", dek)
-    {path_ct, path_n} = Envelope.encrypt("legacy/path.md", dek)
+    {path_ct, path_n} = Envelope.encrypt(path, dek)
     {folder_ct, folder_n} = Envelope.encrypt("legacy", dek)
     {tags_ct, tags_n} = Envelope.encrypt(:erlang.term_to_binary([]), dek)
 
@@ -96,7 +129,7 @@ defmodule Engram.Notes.CrdtCheckpointLegacyRowTest do
       title_nonce: title_n,
       path_ciphertext: path_ct,
       path_nonce: path_n,
-      path_hmac: Crypto.hmac_field(filter_key, "legacy/path.md"),
+      path_hmac: Crypto.hmac_field(filter_key, path),
       folder_ciphertext: folder_ct,
       folder_nonce: folder_n,
       folder_hmac: Crypto.hmac_field(filter_key, "legacy"),


### PR DESCRIPTION
Closes the half-migration half of #1336. **Live on `main` today** — not introduced by any open PR.

## The bug

`Crypto.encrypt_crdt_state/3` **always** binds the AAD to the row id, so writing `crdt_state` forces `dek_version` up to the AAD-bound version. Two branches do exactly that while writing nothing else:

- **compaction** (`prev == content_hash`) — runs on **every room exit whose text is unchanged**
- **the structural `.canvas` branch** — never touches content at all

On a `dek_version = 1` row that leaves content/title/path/folder/tags bound under the **empty** AAD while the row claims bound. Consequences:

- the note reads as `{:error, :decrypt_failed}`
- `list_tree_notes` raises through `PathCrypto.decrypt!`, so **one such row 500s the whole vault tree**, not just that note
- `AadRebind` selects on the legacy `dek_version`, so it **can no longer see the row to repair it**

Permanent, and silent until someone opens the vault.

## Reproduced first, on unmodified `main`

```
1) test a compaction does not half-migrate a legacy row
   ** (MatchError) no match of right hand side value:
       {:error, :decrypt_failed}
```

The tests hand-build a legacy row (empty-AAD envelopes, `dek_version = 1`) the way `crypto/aad_rebind_test.exs` does, then run a checkpoint over it. **No existing test constructs a legacy row**, which is why this survived. Both arms are covered and both were verified to fail with their guard removed.

## The fix

Both branches skip on a legacy row and return `{:skip, :legacy_row_needs_rebind}`, which the existing skip handler already logs as a warning — so it comes with a tripwire for free.

Skipping is free for markdown: compaction is an optimisation whose tail stays unpruned, and the next bind re-checkpoints once `AadRebind` has migrated the row.

**The materialize branch is untouched.** It re-encrypts every envelope, so it migrates the row wholesale — it is the one path that may legitimately run on a legacy row, and blanket-skipping would have broken the migration that currently works.

## One detail worth not repeating

`<`, not `!=`. `UserDekRotation` stamps `user.dek_version + 1`, so a rotated row carries 3, 4, … and is **still AAD-bound**. An equality test against 2 would treat every rotated user's rows as legacy — a trap that cost a review round on #1330.

## From the deep review

Two findings applied here:

- the unknown-`dek_version` fallback now answers **`true`** (skip). It is unreachable today, but it is the guard's only safety net and it has to fail the safe way — `Crypto.decrypt_aad/3`'s own catch-all reads an unknown version as legacy, so answering `false` would let a row be READ legacy and WRITTEN bound.
- the structural/`.canvas` arm now has its own test. It previously had none, so that half of the guard could have been refactored away with CI green.

The review also confirmed **three** things outside this diff, filed as #1341: `UserDekRotation` never rewraps `crdt_state` at all (breaks every synced note in a rotated vault, legacy or not), `BackfillCrdtState.do_seed/3` writes bound state onto a v1 row, and legacy `.canvas` rows have no self-heal path once this guard skips them. That last one is a consequence of this PR and is stated plainly there — the trade is a bounded degradation (unpruned tail) in place of permanent corruption, which is the right way round, but it does owe a heal path.

## Gates

format ✓ · credo --strict 0 issues ✓ · dialyzer ✓ · `test/engram/notes/` 351 tests 0 failures ✓ · full `mix test` 4255 tests, **2 failures** — `NotesTest` write-rejection logging and `CimdTest` global rate budget. Both **pass in isolation** (160/160), neither touches `crdt_checkpoint`, and this is the same ambient order-dependence (shared Oban table / rate-limiter buckets) seen on other branches today. Flagging rather than claiming green; CI runs partitioned with fresh databases and is the signal I am trusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC