### PR TITLE
test: cover the release rpc entrypoints and the attachments backfill

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2544,6 +2544,39 @@ jobs:
           echo "$OUT"
           echo "$OUT" | grep -q STORAGE_DATABASE_ROUNDTRIP_OK
 
+      # Piggybacks on this job purely because it already has a booted RELEASE
+      # container — the check costs ~2s here versus minutes for a job that
+      # boots its own. It is unrelated to STORAGE_BACKEND (none of these three
+      # touch the storage adapter); if this job is ever deleted, this step
+      # needs a new home rather than deletion.
+      #
+      # Why it exists (#1311): `Mix` is not in the release, so anything we
+      # document as `bin/engram rpc '...'` must be a plain module. Nothing
+      # caught the three broken entrypoints because boot only ever invokes
+      # Engram.Release.migrate/prepare_database — code that already had the
+      # right shape. Documentation that names a command is not an invocation,
+      # so this step turns each documented entrypoint into a real one.
+      #
+      # Deliberately asserts the RETURN VALUES, not just absence of a crash:
+      # on a fresh CI database every one of these is a zero/no-op, which is
+      # what makes the check safe to run and still meaningful.
+      - name: Documented release rpc entrypoints are callable
+        run: |
+          OUT=$(docker compose -f ci/compose.database.yml -p "$CI_PROJECT" exec -T engram \
+            /app/bin/engram rpc '
+              # Empty CI DB: no legacy-MD5 rows, so both scopes enqueue nothing.
+              %{notes: 0, attachments: 0} = Engram.ContentHash.Backfill.enqueue_all()
+              # No vaults, so no onboarding rows to seed.
+              0 = Engram.Onboarding.Backfill.first_vault_created()
+              # Migrations already ran at boot, so this reports "up to date".
+              # Also proves the migrations dir resolves OUTSIDE a Mix project
+              # root — the relative path this used to carry raised File.Error.
+              :ok = Engram.Release.Preflight.run()
+              IO.puts("RELEASE_ENTRYPOINTS_OK")
+            ')
+          echo "$OUT"
+          echo "$OUT" | grep -q RELEASE_ENTRYPOINTS_OK
+
       - name: Collect logs on failure
         if: failure()
         run: docker compose -f ci/compose.database.yml -p "$CI_PROJECT" logs || true

--- a/test/engram/onboarding/backfill_test.exs
+++ b/test/engram/onboarding/backfill_test.exs
@@ -1,0 +1,37 @@
+defmodule Engram.Onboarding.BackfillTest do
+  # Calls first_vault_created/0 directly — no Mix.Task in the path, which is
+  # how release rpc invokes it (#1311). The mix-task test covers the wrapper.
+  use Engram.DataCase, async: false
+
+  alias Engram.Onboarding
+  alias Engram.Onboarding.Action
+  alias Engram.Onboarding.Backfill
+  alias Engram.Repo
+  alias Engram.Vaults
+
+  test "records first_vault_created for every user holding a vault, and no one else" do
+    user_with = insert_user()
+    user_without = insert_user()
+    {:ok, _} = Vaults.create_vault(user_with, %{name: "Main"})
+
+    # Clear the row the T5 hook creates so this exercises pure backfill.
+    # Cross-tenant test cleanup — onboarding_actions is a tenant table (#788).
+    Repo.delete_all(Action, skip_tenant_check: true)
+
+    assert Backfill.first_vault_created() == 1
+
+    assert ["first_vault_created"] = Onboarding.list_actions(user_with.id)
+    assert [] = Onboarding.list_actions(user_without.id)
+  end
+
+  test "is idempotent — a second run inserts nothing" do
+    user = insert_user()
+    {:ok, _} = Vaults.create_vault(user, %{name: "Main"})
+    Repo.delete_all(Action, skip_tenant_check: true)
+
+    assert Backfill.first_vault_created() == 1
+    assert Backfill.first_vault_created() == 0
+
+    assert ["first_vault_created"] = Onboarding.list_actions(user.id)
+  end
+end

--- a/test/engram/release/preflight_test.exs
+++ b/test/engram/release/preflight_test.exs
@@ -200,4 +200,71 @@ defmodule Engram.Release.PreflightTest do
     refute result.pending == []
     assert Enum.all?(result.pending, &String.starts_with?(&1.file, Application.app_dir(:engram)))
   end
+
+  # print/1 had no coverage at all — it was `Mix.shell().info` until #1343 and
+  # is the entire operator-facing surface of this module. The irreversible
+  # branch in particular is the only thing that tells a self-host operator to
+  # take a backup before an upgrade they cannot roll back.
+  describe "print/1" do
+    import ExUnit.CaptureIO
+
+    test "reports the up-to-date case" do
+      out = capture_io(fn -> Preflight.print(%{pending: [], already_run: 12}) end)
+
+      assert out =~ "No pending migrations"
+      assert out =~ "12"
+    end
+
+    test "lists each pending migration with phase, irreversibility and lock risk" do
+      out =
+        capture_io(fn ->
+          Preflight.print(%{
+            pending: [
+              %{
+                version: "20260101000000",
+                name: "add_thing",
+                phase: :expand,
+                irreversible: false,
+                lock_risk: :low
+              }
+            ],
+            already_run: 3,
+            rollback_command: "bin/engram eval 'x'",
+            warnings: []
+          })
+        end)
+
+      assert out =~ "PENDING MIGRATIONS (1)"
+      assert out =~ "20260101000000"
+      assert out =~ "add_thing"
+      assert out =~ "phase: expand"
+      assert out =~ "irreversible: false"
+      assert out =~ "lock_risk: low"
+      assert out =~ "bin/engram eval 'x'"
+    end
+
+    test "warns to take a backup when no rollback command is available" do
+      out =
+        capture_io(fn ->
+          Preflight.print(%{
+            pending: [
+              %{
+                version: "20260101000000",
+                name: "drop_thing",
+                phase: :contract,
+                irreversible: true,
+                lock_risk: :high
+              }
+            ],
+            already_run: 3,
+            rollback_command: nil,
+            warnings: []
+          })
+        end)
+
+      assert out =~ "Rollback unavailable"
+      assert out =~ "backup"
+      refute out =~ "Rollback command (if needed"
+    end
+  end
 end

--- a/test/engram/workers/backfill_content_hash_hmac_test.exs
+++ b/test/engram/workers/backfill_content_hash_hmac_test.exs
@@ -13,6 +13,7 @@ defmodule Engram.Workers.BackfillContentHashHmacTest do
   import Engram.Fixtures
 
   alias Engram.Accounts.User
+  alias Engram.Attachments.Attachment
   alias Engram.Crypto
   alias Engram.Notes.Note
   alias Engram.Repo
@@ -140,6 +141,109 @@ defmodule Engram.Workers.BackfillContentHashHmacTest do
   # ---------------------------------------------------------------------------
   # T3.7 — RotationGate
   # ---------------------------------------------------------------------------
+
+  # The attachments scope had NO coverage at all until #1343's review — every
+  # test above drives `"scope" => "notes"`. It is not a mirror of the notes
+  # path: `rehash_attachment/3` reads the blob back out of storage and
+  # decrypts it with an AAD that depends on `dek_version`, none of which the
+  # notes path does.
+  describe "perform/1 — attachments scope" do
+    test "rehashes an attachment whose content_hash is legacy MD5", %{user: user, vault: vault} do
+      content = <<9, 8, 7, 6, 5>>
+      att = insert_legacy_attachment!(user, vault, content)
+
+      assert :ok = perform_attachments_job(user, vault)
+
+      {:ok, content_key} = Crypto.dek_content_hash_key(user)
+      expected = Crypto.hmac_content_hash(content_key, content)
+
+      reloaded = reload_attachment(user, att)
+      assert reloaded.content_hash == expected
+      assert String.length(reloaded.content_hash) == 64
+    end
+
+    test "skips attachments that already have HMAC-format content_hash", %{
+      user: user,
+      vault: vault
+    } do
+      att = insert_attachment!(user, vault, %{"content" => <<1, 2, 3>>})
+      before = reload_attachment(user, att).content_hash
+
+      assert :ok = perform_attachments_job(user, vault)
+
+      assert reload_attachment(user, att).content_hash == before
+    end
+
+    # The skip branch is the dangerous one: it must leave the legacy hash in
+    # place rather than writing a hash of whatever it managed to read. A row
+    # left at 32 chars gets retried on the next run; a row written wrong is
+    # silently corrupt forever, because the `length = 32` filter will never
+    # select it again.
+    test "leaves the legacy hash intact and emits bounded telemetry when the blob is gone",
+         %{user: user, vault: vault} do
+      content = <<4, 4, 4, 4>>
+      att = insert_legacy_attachment!(user, vault, content)
+      legacy_hash = reload_attachment(user, att).content_hash
+
+      # Point the row at a key that was never written.
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          from(a in Attachment, where: a.id == ^att.id)
+          |> Repo.update_all(set: [storage_key: "999/#{Ecto.UUID.generate()}/missing.bin"])
+        end)
+
+      handler_id = "backfill-att-skip-#{System.unique_integer([:positive])}"
+      parent = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:engram, :backfill, :content_hash_skipped],
+        fn _event, _meas, meta, _cfg -> send(parent, {:skip_meta, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok = perform_attachments_job(user, vault)
+        end)
+
+      assert reload_attachment(user, att).content_hash == legacy_hash,
+             "a row it could not read must keep its legacy hash, not gain a wrong one"
+
+      assert_received {:skip_meta, meta}
+      assert meta.scope == :attachment
+      assert is_atom(meta.reason), "telemetry reason must be the bounded error_kind atom"
+
+      worker_lines =
+        log |> String.split("\n") |> Enum.filter(&String.contains?(&1, "BackfillContentHashHmac"))
+
+      assert Enum.any?(worker_lines, &String.contains?(&1, "skipping attachment"))
+
+      refute Enum.any?(worker_lines, &String.contains?(&1, " reason=")),
+             "raw reason must not reach the log metadata (only error_kind)"
+    end
+
+    test "re-enqueues itself when the batch is full, carrying the cursor forward", %{
+      user: user,
+      vault: vault
+    } do
+      for _ <- 1..3, do: insert_legacy_attachment!(user, vault, :crypto.strong_rand_bytes(8))
+
+      # batch_size 2 with 3 legacy rows ⇒ first batch is full ⇒ {:more, last_id}.
+      assert {:ok, %Oban.Job{}} =
+               perform_job(BackfillContentHashHmac, %{
+                 "user_id" => user.id,
+                 "vault_id" => vault.id,
+                 "cursor" => 0,
+                 "scope" => "attachments",
+                 "batch_size" => 2
+               })
+
+      assert_enqueued(worker: BackfillContentHashHmac, args: %{"scope" => "attachments"})
+    end
+  end
 
   describe "perform/1 — T3.7 rotation gate" do
     test "snoozes for 60 seconds when user's DEK rotation is in progress", %{
@@ -289,5 +393,34 @@ defmodule Engram.Workers.BackfillContentHashHmacTest do
                "note #{note.id} still on its legacy hash — the cursor chain stalled after the first batch"
       end
     end
+  end
+
+  defp perform_attachments_job(user, vault) do
+    perform_job(BackfillContentHashHmac, %{
+      "user_id" => user.id,
+      "vault_id" => vault.id,
+      "cursor" => 0,
+      "scope" => "attachments"
+    })
+  end
+
+  # insert_attachment! always writes an HMAC hash (it has the content key in
+  # hand), so the legacy state has to be written back over it.
+  defp insert_legacy_attachment!(user, vault, content) do
+    att = insert_attachment!(user, vault, %{"content" => content})
+    md5 = :crypto.hash(:md5, content) |> Base.encode16(case: :lower)
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        from(a in Attachment, where: a.id == ^att.id)
+        |> Repo.update_all(set: [content_hash: md5])
+      end)
+
+    att
+  end
+
+  defp reload_attachment(user, att) do
+    {:ok, reloaded} = Repo.with_tenant(user.id, fn -> Repo.get!(Attachment, att.id) end)
+    reloaded
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #1343, answering "why didn't CI catch this?"

- **The gap was never "release code is untested"** — it was *"release code that nothing calls automatically is untested."* `entrypoint.sh` invokes `Engram.Release.migrate/prepare_database/verify_schema_baseline` on every container boot, so those had 100% de facto coverage from every job that starts a stack. The three entrypoints #1343 fixed had 0%, and the difference was purely whether something ran them. A moduledoc naming a command reads like a tested contract; it is not an invocation.
- **CI**: assert each documented entrypoint against a booted release container. Piggybacks on `storage-database` purely because that job already has one up — ~2s there versus minutes for a job that boots its own — and it gates the `ci` rollup. None of the three touch the storage adapter. Verified it will actually run on this PR: `ci-meta` is in every job's fingerprint group precisely so a workflow change re-runs it.
- It asserts **return values**, not just absence of a crash. On a fresh CI database all three are provably zero/no-ops, which is what makes the check both safe and meaningful — a crash-only check would pass if `enqueue_all` silently returned the wrong shape. Preflight also proves the migrations dir resolves *outside* a Mix project root, which no unit test can: unit tests run inside one, where the old relative path happened to work.

## Test coverage

**`BackfillContentHashHmac` attachments scope had none at all** — all five existing cases drive `"notes"`. It is not a mirror of that path: `rehash_attachment/3` reads the blob back out of storage and decrypts with an AAD that depends on `dek_version`. Added: happy path, already-HMAC skip, batch re-enqueue, and the branch that matters most —

> a row whose blob is unreadable must **keep** its legacy 32-char hash. Failing to write is recoverable (the `length = 32` filter reselects it next run); a wrong 64-char hash is never selected again and is **silently corrupt forever**.

Also: `Preflight.print/1`, previously untested and now the entire operator-facing surface of that module — including the branch that tells a self-host operator to take a backup before an irreversible upgrade; and `Engram.Onboarding.Backfill.first_vault_created/0` directly, which is how rpc calls it.

## Test plan

- [x] `mix compile --warnings-as-errors` / `credo --strict` / `test --warnings-as-errors` / `dialyzer` — **all exit 0**; 1 property, 4273 tests, 0 failures (up 9)
- [x] The rpc expression was executed against a real running node before being committed, not just eyeballed — returns `%{notes: 0, attachments: 0}`, `0`, `:ok` exactly as asserted
- [x] **All four new worker tests were mutation-tested**, because a test passing while asserting the value a *broken* query also returns is exactly what review caught in #1343:
  - stubbing `rehash_attachment` to a no-op → fails "rehashes an attachment whose content_hash is legacy MD5"
  - making the error branch write a hash anyway → fails "leaves the legacy hash intact…"
  - each mutation failed *only* its intended test

No `lib/` changes — additions only.

Refs #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2
