### PR TITLE
fix(crdt): gate checkpoints on DEK rotation and fail loud on an unreadable snapshot

### DIFF
--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -19,6 +19,7 @@ defmodule Engram.Notes.CrdtCheckpoint do
   import Ecto.Query
 
   alias Engram.{Accounts, Crypto, Notes, Repo, Vaults}
+  alias Engram.Crypto.RotationGate
   alias Engram.Logger.Metadata
   alias Engram.Notes.{CrdtBridge, CrdtDeliver, CrdtUpdateLog, Enqueue, Helpers, Note}
   alias Engram.Workers.{EmbedNote, ExtractNoteLinks}
@@ -65,7 +66,33 @@ defmodule Engram.Notes.CrdtCheckpoint do
         :ok
 
       user ->
-        do_checkpoint(user, user_id, vault_id, note_id, doc, opts)
+        # #1341. A checkpoint encrypts crdt_state with the user's CURRENT DEK.
+        # Run one mid-rotation and it writes an old-DEK snapshot over a row the
+        # sweep has already rewrapped, or over one the flip is about to move to
+        # the new generation — either way the note can never be bound again.
+        #
+        # The gate lives HERE, not in the callers, because all four legs funnel
+        # through this function: the room-unbind path (which
+        # `SessionInvalidator.disconnect_user/1` triggers at the TOP of a
+        # rotation, so it is the likeliest one to race), the debounce timer, the
+        # channel, and the CheckpointNote worker. Gating only the worker leg
+        # left the one that actually fires open.
+        #
+        # `check_user/1`, not `check/1`: `user` was just read from the DB one
+        # line above, so re-reading buys nothing. Skipping prunes nothing, so
+        # every edit stays in the tail-WAL and replays on the next bind.
+        case RotationGate.check_user(user) do
+          {:error, :rotation_in_progress} ->
+            Logger.warning(
+              "crdt checkpoint skipped — dek rotation in progress note_id=#{note_id}",
+              Metadata.with_category(:warning, :sync, note_id: note_id)
+            )
+
+            :ok
+
+          _ ->
+            do_checkpoint(user, user_id, vault_id, note_id, doc, opts)
+        end
     end
   rescue
     # The user-resolve above is the ONE DB call outside do_checkpoint's rescue.

--- a/lib/engram/workers/checkpoint_note.ex
+++ b/lib/engram/workers/checkpoint_note.ex
@@ -22,7 +22,10 @@ defmodule Engram.Workers.CheckpointNote do
 
   alias Engram.{Accounts, Crypto, Repo}
   alias Engram.Crypto.RotationGate
+  alias Engram.Logger.Metadata
   alias Engram.Notes.{CrdtBridge, CrdtCheckpoint, CrdtPersistence, CrdtRegistry, Note}
+
+  require Logger
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
@@ -89,18 +92,40 @@ defmodule Engram.Workers.CheckpointNote do
                 {false, []}
 
               %Note{} = note ->
-                from_snapshot? =
-                  case Crypto.decrypt_crdt_state(note, user) do
-                    {:ok, snapshot} when is_binary(snapshot) ->
-                      :ok = Yex.apply_update(doc, snapshot)
-                      true
+                case Crypto.decrypt_crdt_state(note, user) do
+                  {:ok, snapshot} when is_binary(snapshot) ->
+                    :ok = Yex.apply_update(doc, snapshot)
+                    applied_ids = CrdtPersistence.replay_tail(doc, user, note_id)
+                    {true, applied_ids}
 
-                    _ ->
-                      false
-                  end
+                  # No snapshot at all — legitimate for a note that has never
+                  # been checkpointed. bind/3 documents the same case: the tail
+                  # IS the doc's whole history, so replaying it is complete.
+                  {:ok, nil} ->
+                    applied_ids = CrdtPersistence.replay_tail(doc, user, note_id)
+                    {applied_ids != [], applied_ids}
 
-                applied_ids = CrdtPersistence.replay_tail(doc, user, note_id)
-                {from_snapshot? or applied_ids != [], applied_ids}
+                  # A snapshot that will not decrypt is NOT the same as no
+                  # snapshot, and treating it as one is how a note loses its
+                  # body. The tail holds deltas that sit ON TOP of that
+                  # snapshot; replaying them onto an empty doc yields a
+                  # base-less fragment, and this worker would then materialize
+                  # that fragment over notes.content and prune the tail that
+                  # proved it wrong. bind/3 raises on this exact signal
+                  # (unreadable != absent); the detached path used to swallow
+                  # it. Skip: nothing is written, nothing is pruned, and the
+                  # row keeps every byte it had. #1341.
+                  {:error, reason} ->
+                    Logger.warning(
+                      "crdt checkpoint skipped — unreadable snapshot note_id=#{note_id} reason=#{inspect(reason)}",
+                      Metadata.with_category(:warning, :sync,
+                        note_id: note_id,
+                        reason: inspect(reason)
+                      )
+                    )
+
+                    {:unreadable, []}
+                end
             end
           end)
 
@@ -108,17 +133,20 @@ defmodule Engram.Workers.CheckpointNote do
         # but never edited has no snapshot and no tail, so the doc rebuilds
         # EMPTY; checkpointing an empty doc would blank notes.content. In that
         # case notes.content is already authoritative, so there is nothing to do.
-        if has_state? do
-          {:ok,
-           %{
-             user_id: user_id,
-             vault_id: vault_id,
-             note_id: note_id,
-             doc: doc,
-             prune_ids: applied_ids
-           }}
-        else
-          :skip
+        # `:unreadable` is a THIRD state, not a falsy one — see above.
+        case has_state? do
+          true ->
+            {:ok,
+             %{
+               user_id: user_id,
+               vault_id: vault_id,
+               note_id: note_id,
+               doc: doc,
+               prune_ids: applied_ids
+             }}
+
+          _ ->
+            :skip
         end
     end
   end

--- a/test/engram/notes/crdt_checkpoint_rotation_fence_test.exs
+++ b/test/engram/notes/crdt_checkpoint_rotation_fence_test.exs
@@ -1,0 +1,188 @@
+defmodule Engram.Notes.CrdtCheckpointRotationFenceTest do
+  @moduledoc """
+  A checkpoint must not write a snapshot the current DEK generation cannot read
+  back (#1341).
+
+  `Crypto.encrypt_crdt_state/3` uses the user's CURRENT DEK. `UserDekRotation`
+  rewraps every row and then flips that DEK. A checkpoint landing inside the
+  rotation window therefore writes an OLD-DEK snapshot over a row the sweep has
+  already rewrapped — and `CrdtPersistence.bind/3` is fail-loud on an unreadable
+  snapshot, so that note can never be opened or synced again from any device.
+
+  `RotationGate` in `checkpoint/5` covers all four legs (room unbind, debounce
+  timer, channel, `CheckpointNote`). The unbind leg is the one that matters:
+  `rotate_user/1` calls `SessionInvalidator.disconnect_user/1` at the TOP of the
+  rotation, which is precisely what makes rooms terminate and checkpoint.
+  The gate is a check-then-act: a lock acquired between the user read and the
+  row write still slips through. That residual window is narrow and is tracked
+  on the issue — closing it needs the sweep to drain rooms and WAIT, not another
+  guard here.
+
+  Skipping rather than failing is what makes this safe: nothing is pruned, so
+  every edit stays in the tail-WAL and replays on the next bind.
+  """
+  use Engram.DataCase, async: false
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Accounts.User
+  alias Engram.Crypto
+  alias Engram.Crypto.DekCache
+  alias Engram.Notes.{CrdtBridge, CrdtCheckpoint, CrdtUpdateLog, Note}
+  alias Engram.Repo
+
+  setup do
+    DekCache.invalidate_all()
+    user = insert(:user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "RotationFence"})
+    %{user: user, vault: vault}
+  end
+
+  test "a checkpoint is skipped while a DEK rotation holds the lock", ctx do
+    %{user: user, vault: vault} = ctx
+
+    {:ok, note} =
+      Engram.Notes.upsert_note(user, vault, %{"path" => "fence/a.md", "content" => "body"})
+
+    before = reload(user, note.id)
+
+    # Exactly what RotationLock.acquire/1 writes. Every leg of the checkpoint
+    # resolves the user itself, so setting the column is enough to simulate the
+    # window without running a real rotation.
+    lock!(user.id)
+
+    doc = doc_with("body and more")
+    assert :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+
+    after_run = reload(user, note.id)
+
+    assert after_run.crdt_state_ciphertext == before.crdt_state_ciphertext,
+           """
+           the checkpoint wrote a snapshot with the pre-rotation DEK while the
+           rotation lock was held. The sweep rewraps every row and then flips the
+           DEK, so this row is now unreadable and bind/3 will raise on it.
+           """
+
+    # And nothing was materialized either — content must be untouched.
+    assert after_run.content_hash == before.content_hash
+    assert after_run.version == before.version
+  end
+
+  test "a checkpoint on an unlocked user still writes", ctx do
+    %{user: user, vault: vault} = ctx
+
+    {:ok, note} =
+      Engram.Notes.upsert_note(user, vault, %{"path" => "fence/d.md", "content" => "body"})
+
+    before = reload(user, note.id)
+
+    doc = doc_with("body and more")
+    assert :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
+
+    after_run = reload(user, note.id)
+
+    # The guard must not be so broad it stops the normal path — otherwise the
+    # test above would pass with checkpointing entirely broken.
+    refute after_run.crdt_state_ciphertext == before.crdt_state_ciphertext
+
+    # The checkpoint UNIONS the stored state with the live doc rather than
+    # replacing it (identity-as-CRDT), so assert the new text landed, not that
+    # it is the whole body.
+    {:ok, fresh} = Crypto.maybe_decrypt_note_fields(after_run, user)
+    assert fresh.content =~ "and more"
+  end
+
+  test "the detached rebuild refuses an UNREADABLE snapshot instead of rebuilding from the tail",
+       ctx do
+    %{user: user, vault: vault} = ctx
+
+    {:ok, note} =
+      Engram.Notes.upsert_note(user, vault, %{
+        "path" => "fence/e.md",
+        "content" => "THE WHOLE BODY"
+      })
+
+    # A delta sitting ON TOP of the snapshot — the shape a live edit leaves.
+    seed_tail!(user, vault, note.id, "fragment")
+
+    # Now corrupt the snapshot. This is what a half-finished rotation leaves
+    # behind: the tail is readable, the snapshot is not.
+    Repo.update_all(
+      from(n in Note, where: n.id == ^note.id),
+      [
+        set: [
+          crdt_state_ciphertext: :crypto.strong_rand_bytes(64),
+          crdt_state_nonce: :crypto.strong_rand_bytes(12)
+        ]
+      ],
+      skip_tenant_check: true
+    )
+
+    before = reload(user, note.id)
+
+    # rebuild_detached must NOT treat "will not decrypt" as "absent". Replaying
+    # the tail onto an empty doc yields a base-less fragment, and checkpointing
+    # that materializes the fragment over the body AND prunes the tail that
+    # proved it wrong. bind/3 raises on this signal for exactly this reason.
+    assert :skip =
+             Engram.Workers.CheckpointNote.rebuild_detached(user.id, vault.id, note.id),
+           """
+           the detached rebuild accepted an unreadable snapshot and fell back to
+           the tail alone. finalize/1 would then write a base-less fragment over
+           notes.content and prune the tail.
+           """
+
+    after_run = reload(user, note.id)
+    assert after_run.content_ciphertext == before.content_ciphertext
+
+    {:ok, remaining} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.aggregate(from(l in CrdtUpdateLog, where: l.note_id == ^note.id), :count)
+      end)
+
+    assert remaining == 1, "the tail must survive: it is the only copy of that edit"
+  end
+
+  defp seed_tail!(user, vault, note_id, text) do
+    {:ok, doc} = CrdtBridge.doc_from_state(nil)
+    :ok = CrdtBridge.diff_into_text(Yex.Doc.get_text(doc, CrdtBridge.text_name()), text)
+    {:ok, update} = Yex.encode_state_as_update(doc)
+    {:ok, {ct, nonce}} = Crypto.encrypt_crdt_state(update, user, note_id)
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        %CrdtUpdateLog{}
+        |> CrdtUpdateLog.changeset(%{
+          note_id: note_id,
+          user_id: user.id,
+          vault_id: vault.id,
+          update_ciphertext: ct,
+          update_nonce: nonce
+        })
+        |> Repo.insert!()
+      end)
+
+    :ok
+  end
+
+  defp lock!(user_id) do
+    Repo.update_all(
+      from(u in User, where: u.id == ^user_id),
+      [set: [dek_rotation_locked_at: DateTime.utc_now()]],
+      skip_tenant_check: true
+    )
+  end
+
+  defp reload(user, note_id) do
+    {:ok, note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note_id) end)
+    note
+  end
+
+  defp doc_with(text) do
+    {:ok, doc} = CrdtBridge.doc_from_state(nil)
+    :ok = CrdtBridge.diff_into_text(Yex.Doc.get_text(doc, CrdtBridge.text_name()), text)
+    doc
+  end
+end


### PR DESCRIPTION
Closes both remaining items on #1341.

## 1. Checkpoints race the DEK rotation

A checkpoint encrypts `crdt_state` with the user's **current** DEK. `UserDekRotation` rewraps every row and then flips that DEK. A checkpoint landing inside the rotation window writes an old-DEK snapshot over a row the sweep has already rewrapped — and `CrdtPersistence.bind/3` is fail-loud on an unreadable snapshot, so that note can never be opened or synced again from any device.

The gate goes in `CrdtCheckpoint.checkpoint/5`, **not in its callers**, because all four legs funnel through it: room unbind, debounce timer, channel, and `CheckpointNote`. #1342 gated only the worker leg and left open the one that actually fires — `rotate_user/1` calls `SessionInvalidator.disconnect_user/1` at the *top* of the rotation, which is precisely what makes rooms terminate and checkpoint.

`check_user/1` rather than `check/1`: the user struct was read one line above, so re-reading buys nothing.

Skipping is safe **because it prunes nothing** — every edit stays in the tail-WAL and replays on the next bind.

## 2. `rebuild_detached/3` failed open where `bind/3` fails loud

It swallowed a `crdt_state` decrypt failure with a catch-all and then derived `has_state?` from the tail alone. The tail holds deltas that sit **on top of** that snapshot, so replaying them onto an empty doc yields a base-less fragment — which `finalize/1` would then materialize over `notes.content` and prune the tail that proved it wrong.

"Will not decrypt" is now a third state, distinct from both "no snapshot" (legitimate — the tail is the whole history, and `bind/3` documents this) and "readable".

## What I did NOT do

The residual **check-then-act window**: the lock can be acquired between the user read and the row write.

A `dek_version` fence on the write looked like the answer and is not. That column is documented as the **AAD schema version, not a DEK generation** (`UserDekRotation` moduledoc), and the materialize branch legitimately rewrites it — so fencing on it is both conceptually wrong and untestable without an interleave harness this repo does not have. I built it, could not write a test that exercised it rather than something else, and removed it.

Closing that window properly means making the sweep drain rooms and **wait** before sweeping. Left on #1341 with this reasoning.

## Tests

Three, in `crdt_checkpoint_rotation_fence_test.exs`:

- a checkpoint under a held rotation lock leaves the snapshot, `content_hash` and `version` untouched
- the detached rebuild returns `:skip` on an unreadable snapshot, leaves `content_ciphertext` intact, and **leaves the tail row in place** (it is the only copy of that edit)
- an unlocked user still checkpoints normally — without this the other two would pass with checkpointing entirely broken

Both guards verified to fail with their fix reverted.

## Gates

format ✓ · credo --strict 0 issues ✓ · sobelow ✓ · dialyzer ✓ · full `mix test` **4286 tests, 0 failures** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC