### PR TITLE
fix(onboarding): scope request-path tenant reads to their tenant

### DIFF
--- a/lib/engram/onboarding.ex
+++ b/lib/engram/onboarding.ex
@@ -417,16 +417,24 @@ defmodule Engram.Onboarding do
   end
 
   def record_action(user_id, action) when is_binary(user_id) and is_binary(action) do
-    %Action{}
-    |> Action.changeset(%{user_id: user_id, action: action})
-    |> Repo.insert(
-      on_conflict: :nothing,
-      conflict_target: [:user_id, :action],
-      skip_tenant_check: true
-    )
+    # Inside with_tenant, not `skip_tenant_check: true` alone (#1354).
+    # `onboarding_actions` carries FORCE ROW LEVEL SECURITY and prod's role
+    # (`engram_admin`, verified rolbypassrls=false) is bound by it even as the
+    # table owner, so with no `app.current_tenant` the policy's WITH CHECK
+    # fails and this INSERT RAISES on prod. skip_tenant_check only silences
+    # Engram's own guard; it does not set the tenant.
+    Repo.with_tenant(user_id, fn ->
+      %Action{}
+      |> Action.changeset(%{user_id: user_id, action: action})
+      |> Repo.insert(on_conflict: :nothing, conflict_target: [:user_id, :action])
+      |> case do
+        {:ok, _} -> :ok
+        {:error, %Ecto.Changeset{} = cs} -> {:error, cs}
+      end
+    end)
     |> case do
-      {:ok, _} -> :ok
-      {:error, %Ecto.Changeset{} = cs} -> {:error, cs}
+      {:ok, result} -> result
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -437,7 +445,16 @@ defmodule Engram.Onboarding do
   def list_actions(user_id) when is_binary(user_id) do
     import Ecto.Query
 
-    from(a in Action, where: a.user_id == ^user_id, select: a.action)
-    |> Repo.all(skip_tenant_check: true)
+    # Inside with_tenant (#1354): the unscoped form returned [] for EVERY user
+    # on prod under FORCE RLS, so the onboarding wizard showed nobody's
+    # completed steps. Locally it looked fine — dev/CI connect as a superuser,
+    # which bypasses RLS regardless of FORCE.
+    {:ok, actions} =
+      Repo.with_tenant(user_id, fn ->
+        from(a in Action, where: a.user_id == ^user_id, select: a.action)
+        |> Repo.all()
+      end)
+
+    actions
   end
 end

--- a/lib/engram/vaults.ex
+++ b/lib/engram/vaults.ex
@@ -329,12 +329,16 @@ defmodule Engram.Vaults do
   """
   @spec count_for(Engram.Accounts.User.t()) :: non_neg_integer()
   def count_for(%Engram.Accounts.User{id: user_id}) do
-    Repo.aggregate(
-      active(scoped(user_id)),
-      :count,
-      :id,
-      skip_tenant_check: true
-    )
+    # Inside with_tenant, matching has_vault?/1 twenty lines down (#1354).
+    # `vaults` is FORCE-RLS, so the unscoped form counted 0 for every user on
+    # prod even though `scoped(user_id)` makes the app-level predicate correct
+    # — RLS filters first. "The query looks right" is not evidence here.
+    {:ok, count} =
+      Repo.with_tenant(user_id, fn ->
+        Repo.aggregate(active(scoped(user_id)), :count, :id)
+      end)
+
+    count
   end
 
   # ── Content counts ───────────────────────────────────────────────────────

--- a/test/engram/request_path_tenant_scope_test.exs
+++ b/test/engram/request_path_tenant_scope_test.exs
@@ -1,0 +1,92 @@
+defmodule Engram.RequestPathTenantScopeTest do
+  @moduledoc """
+  Regression guard for #1354.
+
+  These functions sit on the onboarding request path and read/write
+  FORCE-RLS tenant tables. Before #1354 they passed `skip_tenant_check: true`
+  with no `app.current_tenant` set, which on prod means the policy filters
+  every row (reads return empty) or the WITH CHECK fails (writes raise).
+
+  Verified against prod on 2026-08-10 via the read-only bastion:
+
+      engram_admin  super=false  bypassrls=false   (owner of every tenant table)
+      onboarding_actions / vaults   rls=true  force=true
+
+  `FORCE` binds even the owner, and no role on the instance has BYPASSRLS —
+  RDS will not grant it. So the unscoped form genuinely returned zero.
+
+  **A value assertion cannot catch this.** Dev and CI connect as a superuser,
+  which bypasses RLS regardless of FORCE, so `assert actions == ["x"]` passes
+  identically before and after the fix. What is asserted instead is
+  structural: these calls must emit no `[:engram, :repo, :tenant_check_skipped]`
+  telemetry, which `Engram.Repo` fires whenever the guard is skipped. That
+  holds on any Postgres role.
+  """
+  use Engram.DataCase, async: false
+
+  alias Engram.Crypto
+  alias Engram.Onboarding
+  alias Engram.Vaults
+
+  setup do
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, vault} = Vaults.create_vault(user, %{name: "RequestScope"})
+
+    %{user: user, vault: vault}
+  end
+
+  defp skipped_tables(fun) do
+    handler_id = "req-scope-#{System.unique_integer([:positive])}"
+    parent = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:engram, :repo, :tenant_check_skipped],
+      fn _e, _m, meta, _c -> send(parent, {:skipped, meta[:table]}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    fun.()
+    drain([])
+  end
+
+  defp drain(acc) do
+    receive do
+      {:skipped, t} -> drain([t | acc])
+    after
+      0 -> acc |> Enum.uniq() |> Enum.sort()
+    end
+  end
+
+  test "Onboarding.list_actions/1 reads inside its tenant context", %{user: user} do
+    :ok = Onboarding.record_action(user.id, "first_vault_created")
+
+    assert skipped_tables(fn ->
+             assert "first_vault_created" in Onboarding.list_actions(user.id)
+           end) == []
+  end
+
+  test "Onboarding.record_action/2 writes inside its tenant context", %{user: user} do
+    assert skipped_tables(fn ->
+             assert :ok = Onboarding.record_action(user.id, "plugin_connected")
+           end) == []
+  end
+
+  test "Vaults.count_for/1 counts inside its tenant context", %{user: user} do
+    assert skipped_tables(fn ->
+             assert Vaults.count_for(user) >= 1
+           end) == []
+  end
+
+  # The whole payload in one pass — this is what the wizard actually calls, and
+  # it is the combination that was wrong on prod (no vaults AND no actions).
+  test "the onboarding status payload takes no unscoped tenant read", %{user: user} do
+    assert skipped_tables(fn ->
+             payload = EngramWeb.OnboardingController.status_payload(user)
+             assert payload.vault_count >= 1
+           end) == []
+  end
+end


### PR DESCRIPTION
## Summary

Three functions on the **onboarding request path** queried FORCE-RLS tenant tables with `skip_tenant_check: true` and no `app.current_tenant`. On prod that means reads return nothing and writes raise — so the wizard saw **no vaults and no completed steps for every user**.

| function | table | symptom on prod |
|---|---|---|
| `Onboarding.list_actions/1` | `onboarding_actions` | returns `[]` always |
| `Onboarding.record_action/2` | `onboarding_actions` | policy `WITH CHECK` fails → **raises** |
| `Vaults.count_for/1` | `vaults` | counts `0` always |

## Measured, not inferred

Queried the prod catalog via the read-only bastion (`engram_audit_ro`, bastion stopped afterwards):

```
engram_admin     super=false bypassrls=false     ← what DATABASE_URL connects as
engram_app       super=false bypassrls=false
rds_superuser    super=false bypassrls=false     ← engram_admin is a member
onboarding_actions  rls=true force=true owner=engram_admin
vaults              rls=true force=true owner=engram_admin
```

`FORCE` binds even the table owner, and RDS grants `BYPASSRLS` to nothing because it exposes no true superuser — there is no escape hatch on that instance. `skip_tenant_check` only silences Engram's own `prepare_query/3` guard; it never sets the tenant. This also retroactively confirms #1349 was a real production bug rather than a defensive fix.

`Vaults.count_for/1` is the instructive one: it **already had** the correct app-level predicate (`scoped(user_id)`) and still counted zero, because RLS filters before your `WHERE` is ever relevant. "The query looks correct" is not evidence for this bug class. Its own neighbour `has_vault?/1`, twenty lines below, was already wrapped — the bug was inconsistency inside a single module.

## The guard

`test/engram/request_path_tenant_scope_test.exs` asserts no `[:engram, :repo, :tenant_check_skipped]` telemetry.

**A value assertion cannot catch this.** Dev and CI connect as a superuser, so RLS is switched off for the entire suite and `assert actions == [...]` passes identically before and after the fix. Mutation-tested: reverting `count_for/1` fails it with `left: ["vaults"]`, from both the direct test and the full-payload test.

`with_tenant/2` is reentrant for the same tenant, so wrapping is safe even where an outer scope already exists.

## Test plan

- [x] `credo --strict` (no issues), `dialyzer` (baseline), `compile --warnings-as-errors` — all exit 0
- [x] 4299 tests; targeted onboarding/vaults/controller suites 133 green
- [x] New guard mutation-tested

**One unrelated failure seen in a full run**, filed separately: `Engram.NotesTest` "does NOT log a rewrite when the path is already clean" is `async: true` with a bare `refute log =~ "note_path_rewritten"` on `capture_log`, which captures output from all concurrent async tests. Passes in isolation on two seeds; this diff touches nothing in note path handling.

Closes #1354
Refs #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2
