### PR TITLE
docs(crdt): correct the stale "nil captured_version is unfenced" claims

### DIFF
--- a/lib/engram/notes/crdt_checkpoint.ex
+++ b/lib/engram/notes/crdt_checkpoint.ex
@@ -435,7 +435,8 @@ defmodule Engram.Notes.CrdtCheckpoint do
         # that committed after the snapshot bumped `version`, so the CAS matches
         # zero rows and we ABORT — never overwriting the newer committed content
         # with our stale encoding. `captured_version` nil (e.g. the unbind path)
-        # keeps the prior unfenced behaviour. The field set is derived through
+        # drops THIS layer only — `snapshot_fence/2` below still applies, so
+        # there is no unfenced write path left (#1360). The field set is derived through
         # Note.changeset (identical casting to the previous Repo.update!) and
         # applied via a version-fenced update_all, mirroring the compaction branch.
         captured = Keyword.get(opts, :captured_version)
@@ -527,10 +528,12 @@ defmodule Engram.Notes.CrdtCheckpoint do
   That residual self-heals: deliver_out applies the merged state, which fires
   `update_v1` → a follow-up tick re-checkpoints the merged content.
 
-  Returns nil on read failure, which degrades to an UNfenced write (prior
-  behaviour). This is deliberate: nil is indistinguishable from the unbind
-  path's absent `captured_version` (which must stay unfenced to persist on room
-  exit), and a transient version-read blip is rare + self-heals on the next tick.
+  Returns nil on read failure, which drops the version CAS — but NOT the fence.
+  Since #1360 every checkpoint write path is fenced unconditionally on
+  `snapshot_fence/2` (the row's `seq` + `crdt_state_ciphertext` pre-image), and
+  the version CAS is layered on top of it. Degrading to nil is therefore safe:
+  it is indistinguishable from the unbind path's absent `captured_version`, and
+  a transient version-read blip is rare + self-heals on the next tick.
   """
   @spec current_version(String.t(), String.t()) :: integer() | nil
   def current_version(user_id, note_id) do

--- a/lib/engram/notes/crdt_checkpoint_timer.ex
+++ b/lib/engram/notes/crdt_checkpoint_timer.ex
@@ -177,7 +177,11 @@ defmodule Engram.Notes.CrdtCheckpointTimer do
     # Capture the row version BEFORE snapshotting the doc so it never exceeds the
     # version the snapshot reflects (#902 fence). A REST/MCP write committing
     # after this read bumps the version, so the fenced checkpoint write aborts
-    # instead of reverting the committed content. nil on read failure → unfenced.
+    # instead of reverting the committed content.
+    #
+    # nil on read failure is NOT an unfenced write (it was, before #1360). The
+    # version CAS is layered ON TOP of `snapshot_fence/2`, which applies to every
+    # checkpoint write path unconditionally. nil just drops the extra layer.
     captured_version = CrdtCheckpoint.current_version(state.user_id, state.note_id)
     doc = Yex.Sync.SharedDoc.get_doc(room_pid)
 

--- a/test/engram/notes/crdt_checkpoint_test.exs
+++ b/test/engram/notes/crdt_checkpoint_test.exs
@@ -286,8 +286,11 @@ defmodule Engram.Notes.CrdtCheckpointTest do
     {:ok, _} =
       Notes.upsert_note(user, vault, %{"path" => "p.md", "content" => "before APPEND"})
 
-    # Room exits (unbind path: no captured_version). Today this blindly writes
-    # "before EDIT" over "before APPEND" — content AND crdt_state regress.
+    # Room exits (unbind path: no captured_version, so no version CAS). Without
+    # the union this writes "before EDIT" over "before APPEND" — content AND
+    # crdt_state regress. The union, not the fence, is what saves this case:
+    # the REST write committed BEFORE the checkpoint's row read, so the fence
+    # sees a consistent row and correctly lets the write through.
     :ok = CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, doc)
 
     {:ok, fresh} = Notes.get_note(user, vault, "p.md")
@@ -880,7 +883,7 @@ defmodule Engram.Notes.CrdtCheckpointTest do
   # `do_checkpoint/1` reads the doc with `SharedDoc.get_doc/1`, a GenServer.call.
   # A call to a process that terminates mid-call EXITS rather than raising, and
   # `rescue` does not catch exits — so the timer died instead of degrading, even
-  # though its own comment says a read failure should fall through unfenced.
+  # though its own comment says a read failure should degrade, not crash.
   #
   # The race is routine, not exotic: the room stops with a `:tick` already in the
   # timer's mailbox, and the `{:EXIT, room_pid, _}` that stops us cleanly is


### PR DESCRIPTION
Comment-only. Fallout from reviewing #1330, which is being closed as superseded.

## The problem

#1360 made `snapshot_fence/2` (the row's `seq` + `crdt_state_ciphertext` pre-image) apply to **every** checkpoint write path unconditionally. The `:captured_version` CAS became a second layer stacked on top of it, not the fence itself.

Four comments still describe the pre-#1360 world, where a nil `captured_version` fell through to an unfenced `update_all`:

| file | claim |
|---|---|
| `lib/engram/notes/crdt_checkpoint_timer.ex:180` | "nil on read failure → unfenced" |
| `lib/engram/notes/crdt_checkpoint.ex` (`current_version/2` @doc) | "degrades to an UNfenced write (prior behaviour)" |
| `lib/engram/notes/crdt_checkpoint.ex:438` | "`captured_version` nil (e.g. the unbind path) keeps the prior unfenced behaviour" |
| `test/engram/notes/crdt_checkpoint_test.exs:289` | "Today this blindly writes ... over ..." |

Read literally they say **the room-exit path writes unprotected**. That is the conclusion a reader must not reach in this module — it is the premise behind three failed attempts on #1325 and the whole #847/#902 loss class.

Also corrected a fifth line at `crdt_checkpoint_test.exs:883` that reused "fall through unfenced" to mean "degrade instead of crash", an unrelated property.

The `:289` note is rewritten to say what the test actually proves: the REST write there commits **before** the checkpoint's row read, so the fence correctly lets the write through and it is the **union** — not the fence — that preserves both sides.

## Gates

`mix format --check-formatted` ✓ · `mix compile --warnings-as-errors` ✓ · `mix credo --strict` **no issues** ✓ · `mix test test/engram/notes/crdt_checkpoint_test.exs --warnings-as-errors` **26 tests, 0 failures** ✓

Full suite left to CI — the diff is comments and one test-scenario note, no behaviour change.

Refs #1360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC