### PR TITLE
fix(e2e): drop setCrdtCreateBatch wiring removed by plugin #413

### DIFF
--- a/e2e/headless/run.ts
+++ b/e2e/headless/run.ts
@@ -376,8 +376,10 @@ class Replica {
 			if (!connected) manager.setConnected(false);
 		};
 
+		// Genesis notes ride this per-file loop now. The engine's batch-create
+		// port went away with plugin #413, and the harness mirrors main.ts, so the
+		// setCrdtCreateBatch wiring went with it.
 		engine.setCrdtCreate((docId: string, p: string) => channel.crdtCreate(docId, p)); // main.ts:1815
-		engine.setCrdtCreateBatch((creates: unknown) => channel.crdtCreateBatch(creates));
 		engine.setCrdtDelete((docId: string) => channel.crdtDeleteAcked(docId));
 		engine.setCrdtCatchupSince((cursorSeq: number, limit: number) =>
 			channel.crdtCatchupSince(cursorSeq, limit),


### PR DESCRIPTION
**main is red and has been since 05:35 UTC — this unblocks it and every open backend PR.**

## Cause

Plugin PR #413 (`759c467`, "genesis notes ride the per-file push loop") removed the `SyncEngine`'s batch-create port. The headless harness mirrors `main.ts`'s wiring and still called it:

```
TypeError: engine.setCrdtCreateBatch is not a function
```

## Why this is the plugin pairing, not a backend change

- `headless-protocol` **passed 04:11 UTC** and **failed 08:07 UTC** on identical harness code; plugin #413 merged between them.
- main's **only** failing job is `headless-protocol`.
- `setCrdtCreateBatch` no longer exists anywhere in the plugin; `setCrdtCreate` (per-file) still does at `src/sync.ts:1032`.

## Why deleting is correct, not a coverage loss

Genesis notes now ride the per-file `setCrdtCreate` loop — that is the point of #413. This was the sole `crdtCreateBatch` reference under `e2e/`.

Verification is `headless-protocol` itself; the harness has no local typecheck (bun runs it in CI against the plugin build). `bun build` on the file reports no errors other than the expected unresolved `obsidian` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz