### PR TITLE
fix(links): RebindNoteLinks.new_for skips nil basename_hmac instead of crashing

### DIFF
--- a/lib/engram/notes/enqueue.ex
+++ b/lib/engram/notes/enqueue.ex
@@ -24,8 +24,16 @@ defmodule Engram.Notes.Enqueue do
   `{:error, _}`, logs at `:error` with the worker label and emits
   failure telemetry. Always returns the underlying result.
   """
-  @spec enqueue(term(), String.t(), insert_fn()) :: result()
+  @spec enqueue(term(), String.t(), insert_fn()) :: result() | {:ok, :skipped}
   def enqueue(changeset, worker_label, insert_fn \\ &Oban.insert/1)
+
+  # A worker's builder can decline the job (e.g. RebindNoteLinks.new_for/3 on a
+  # nil basename_hmac — nothing to rebind). No-op here so no enqueue site
+  # needs its own guard.
+  def enqueue(:skip, worker_label, _insert_fn) when is_binary(worker_label),
+    do: {:ok, :skipped}
+
+  def enqueue(changeset, worker_label, insert_fn)
       when is_binary(worker_label) and is_function(insert_fn, 1) do
     case insert_fn.(changeset) do
       {:ok, _job} = ok ->

--- a/lib/engram/workers/rebind_note_links.ex
+++ b/lib/engram/workers/rebind_note_links.ex
@@ -26,8 +26,18 @@ defmodule Engram.Workers.RebindNoteLinks do
   alias Engram.Repo
   alias Engram.Vaults.Vault
 
-  @doc "Builds a rebind job for the raw `basename_hmac` bytes within `vault_id`."
-  @spec new_for(binary(), binary(), binary()) :: Ecto.Changeset.t()
+  @doc """
+  Builds a rebind job for the raw `basename_hmac` bytes within `vault_id`.
+
+  A `nil` hmac (legacy pre-backfill rows) returns `:skip` — no link edge can
+  reference a basename hmac the row never had, so there is nothing to rebind.
+  `Enqueue.enqueue/3` no-ops on `:skip`, keeping every enqueue site safe
+  without per-caller guards (incident 2026-08-12: `Base.encode64(nil)` here
+  500'd attachment deletes AFTER the soft-delete had committed, #1369).
+  """
+  @spec new_for(binary(), binary(), binary() | nil) :: Ecto.Changeset.t() | :skip
+  def new_for(_user_id, _vault_id, nil), do: :skip
+
   def new_for(user_id, vault_id, basename_hmac) do
     new(%{user_id: user_id, vault_id: vault_id, basename_hmac: Base.encode64(basename_hmac)})
   end

--- a/test/engram/attachments_test.exs
+++ b/test/engram/attachments_test.exs
@@ -886,4 +886,34 @@ defmodule Engram.AttachmentsTest do
       assert live_paths(user, vault) == []
     end
   end
+
+  describe "delete_attachment on a legacy row (nil basename_hmac)" do
+    # Incident 2026-08-12 (Engram-obsidian#416 / #1369): rows created before
+    # the basename_hmac backfill have NULL basename_hmac; the post-delete
+    # RebindNoteLinks enqueue crashed on Base.encode64(nil) AFTER the
+    # soft-delete + blob delete had committed, so the client saw a 500 for a
+    # delete that had actually succeeded and queued a doomed retry.
+    test "returns :ok instead of crashing after commit", %{user: user, vault: vault} do
+      Mox.stub(Engram.MockStorage, :put, fn _key, _bin, _opts -> :ok end)
+      Mox.stub(Engram.MockStorage, :delete, fn _key -> :ok end)
+
+      {:ok, _} =
+        Attachments.upsert_attachment(user, vault, %{
+          "path" => "legacy/old.png",
+          "content_base64" => Base.encode64("PNGDATA"),
+          "mime_type" => "image/png"
+        })
+
+      # Regress the row to its pre-backfill shape.
+      {:ok, {1, _}} =
+        Engram.Repo.with_tenant(user.id, fn ->
+          import Ecto.Query
+
+          from(a in Engram.Attachments.Attachment, where: is_nil(a.deleted_at))
+          |> Engram.Repo.update_all(set: [basename_hmac: nil])
+        end)
+
+      assert :ok = Attachments.delete_attachment(user, vault, "legacy/old.png")
+    end
+  end
 end


### PR DESCRIPTION
## Why

Every attachment DELETE in the 2026-08-12 incident 500'd via `Base.encode64(nil)` in `RebindNoteLinks.new_for/3` — legacy rows with NULL `basename_hmac`. Worse, the crash fired AFTER the soft-delete + S3 blob delete committed, so clients got a 500 for a delete that succeeded and queued retries of already-applied deletes.

## What

- `new_for/3` returns `:skip` on a nil hmac — a row that never had a basename hmac has no edges to rebind.
- `Notes.Enqueue.enqueue/3` no-ops on `:skip` (`{:ok, :skipped}`), covering all ~10 enqueue sites without per-caller guards.
- Regression test reproduces the exact prod stack trace (attachment upserted, row regressed to NULL basename_hmac, delete must return :ok).

Gauntlet: format ✓ credo --strict ✓ dialyzer ✓ full suite 4308 tests 0 failures.

Closes #1369. Refs Engram-obsidian#416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC