### PR TITLE
fix(auth): quiet the device-flow happy path, attribute its callers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -194,6 +194,7 @@ config :logger, :default_formatter,
     :topic,
     :total_count,
     :trace_id,
+    :user_agent,
     :user_id,
     :vault_id,
     :worker

--- a/e2e/helpers/device_flow.py
+++ b/e2e/helpers/device_flow.py
@@ -39,7 +39,11 @@ def exchange_device_code(base_url: str, device_code: str) -> dict | None:
     """Try to exchange a device code for tokens.
 
     POST /auth/device/token with device_code.
-    Returns token dict on 200, None on 428 (pending), raises on other errors.
+    Returns token dict on 200, None while pending, raises on other errors.
+
+    Pending is 400 per RFC 8628 §3.5. 428 is the pre-2026-08 status this
+    endpoint used; still accepted so the helper works against either side of
+    a paired backend/plugin branch rollout.
     """
     resp = requests.post(
         f"{base_url}/auth/device/token",
@@ -48,7 +52,7 @@ def exchange_device_code(base_url: str, device_code: str) -> dict | None:
     )
     if resp.status_code == 200:
         return resp.json()
-    if resp.status_code == 428:
+    if resp.status_code in (400, 428):
         return None
     raise RuntimeError(
         f"Device code exchange failed: HTTP {resp.status_code}\n{resp.text[:500]}"

--- a/e2e/helpers/device_flow.py
+++ b/e2e/helpers/device_flow.py
@@ -35,6 +35,18 @@ def start_device_flow(base_url: str, client_id: str) -> dict:
     return data
 
 
+def _is_pending(resp) -> bool:
+    """True when a 4xx body is the device flow's `authorization_pending`.
+
+    RFC 8628 puts the discriminator in the body, not the status line. Anything
+    unparseable is NOT pending — fail loudly rather than poll forever.
+    """
+    try:
+        return resp.json().get("error") == "authorization_pending"
+    except ValueError:
+        return False
+
+
 def exchange_device_code(base_url: str, device_code: str) -> dict | None:
     """Try to exchange a device code for tokens.
 
@@ -44,6 +56,12 @@ def exchange_device_code(base_url: str, device_code: str) -> dict | None:
     Pending is 400 per RFC 8628 §3.5. 428 is the pre-2026-08 status this
     endpoint used; still accepted so the helper works against either side of
     a paired backend/plugin branch rollout.
+
+    The discriminator is the BODY, not the status. `token/2` has no catch-all
+    clause, so a malformed request (missing device_code) raises
+    Phoenix.ActionClauseError and also lands as a 400 — treating bare 400 as
+    "pending" would swallow it and surface 60s later as a misleading timeout
+    instead of failing loudly right here.
     """
     resp = requests.post(
         f"{base_url}/auth/device/token",
@@ -52,7 +70,7 @@ def exchange_device_code(base_url: str, device_code: str) -> dict | None:
     )
     if resp.status_code == 200:
         return resp.json()
-    if resp.status_code in (400, 428):
+    if resp.status_code in (400, 428) and _is_pending(resp):
         return None
     raise RuntimeError(
         f"Device code exchange failed: HTTP {resp.status_code}\n{resp.text[:500]}"

--- a/e2e/tests/api_only/test_71_connections.py
+++ b/e2e/tests/api_only/test_71_connections.py
@@ -60,6 +60,14 @@ _PKCE_CHALLENGE = (
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
+def _pending_body(resp) -> bool:
+    """RFC 8628 puts the pending discriminator in the body, not the status."""
+    try:
+        return resp.json().get("error") == "authorization_pending"
+    except ValueError:
+        return False
+
+
 def _ts() -> str:
     """Compact timestamp for unique identifiers."""
     return datetime.now().strftime("%Y%m%d%H%M%S%f")
@@ -493,7 +501,10 @@ def device_token_poll(device_code: str, *, max_attempts: int = 10) -> dict:
             return resp.json()
         # 400 = authorization_pending (RFC 8628 §3.5); 428 is the pre-2026-08
         # status, kept so this works against either side of a paired rollout.
-        if resp.status_code in (400, 428):
+        # Gate on the BODY: `token/2` has no catch-all clause, so a malformed
+        # request 400s too, and treating that as pending would burn all ten
+        # attempts before failing with a misleading timeout.
+        if resp.status_code in (400, 428) and _pending_body(resp):
             time.sleep(0.5)
             continue
         resp.raise_for_status()

--- a/e2e/tests/api_only/test_71_connections.py
+++ b/e2e/tests/api_only/test_71_connections.py
@@ -491,7 +491,9 @@ def device_token_poll(device_code: str, *, max_attempts: int = 10) -> dict:
         )
         if resp.status_code == 200:
             return resp.json()
-        if resp.status_code == 428:
+        # 400 = authorization_pending (RFC 8628 §3.5); 428 is the pre-2026-08
+        # status, kept so this works against either side of a paired rollout.
+        if resp.status_code in (400, 428):
             time.sleep(0.5)
             continue
         resp.raise_for_status()

--- a/e2e/tests/test_89_closed_gate_holds_feed.py
+++ b/e2e/tests/test_89_closed_gate_holds_feed.py
@@ -1,0 +1,92 @@
+"""Test 89: a closed sync gate HOLDS the catch-up feed, it does not consume it.
+
+Prod, 2026-08-13. A first sync into an empty vault created every folder and
+zero notes, then reported success and 100% downloaded. Two defects stacked:
+
+  1. `flushFromCrdt` returned true while the gate was shut, having written
+     nothing. The replay counted those phantom writes as downloaded files, so
+     the progress bar filled, the recap said "success", and the
+     produced-nothing anomaly could not fire.
+  2. `walkOpLog` persisted the catch-up cursor per page regardless. A blocked
+     walk therefore advanced the cursor PAST every row it had refused to
+     write, and the next catch-up resumed after them. The notes were not
+     delayed, they were skipped.
+
+Only #1 is visible from inside the plugin's own suite, and that suite was
+fully green the entire time the bug was in production. This test pins the
+loop end to end against a real Obsidian and a real backend, which is the
+layer the bug actually survived.
+
+The cursor assertion is the load-bearing one. "No files on disk while
+blocked" is also true of the broken build, so on its own it proves nothing;
+what separates fixed from broken is whether the feed rows are still there to
+serve once the gate opens.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from helpers.latency import DELIVERY_TIMEOUT
+from helpers.vault import wait_for_content
+
+NOTE_COUNT = 5
+
+SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+GET_CURSOR = "app.plugins.plugins['engram-vault-sync'].syncEngine.getCatchupSeq()"
+
+
+@pytest.mark.asyncio
+async def test_closed_gate_holds_the_feed_until_it_opens(vault_b, cdp_b, api_sync):
+    # Run-unique paths. Fixtures are session-scoped and vault notes survive
+    # between runs, so a fixed path would already be on disk when this test
+    # starts and the "nothing was written" assertion would fail for the wrong
+    # reason. Deleted again in the finally below so the folder doesn't grow.
+    run = uuid.uuid4().hex[:12]
+    paths = [f"E2E/GateHold-{run}/Held{i}.md" for i in range(NOTE_COUNT)]
+
+    # Drain anything already pending so the cursor we snapshot is quiet. Without
+    # this, an unrelated row landing mid-test moves the cursor and the "did not
+    # advance" assertion reads as a failure of this code path when it isn't.
+    await cdp_b.trigger_full_sync()
+    cursor_before = await cdp_b.evaluate(GET_CURSOR)
+
+    await cdp_b.evaluate(SET_BLOCKED.format("true"))
+    try:
+        for i, path in enumerate(paths):
+            api_sync.create_note(path, f"# Held {i}\nheld-marker-{i}\n")
+
+        # A full sync against a closed gate. The engine is allowed to do
+        # nothing; what it may NOT do is consume the rows while doing nothing.
+        await cdp_b.trigger_full_sync()
+
+        for path in paths:
+            assert not (vault_b / path).exists(), (
+                f"{path} was written with the sync gate closed — the gate is not a gate"
+            )
+
+        cursor_after = await cdp_b.evaluate(GET_CURSOR)
+        assert cursor_after == cursor_before, (
+            f"catch-up cursor moved {cursor_before} -> {cursor_after} while blocked. "
+            f"Those {NOTE_COUNT} rows are now behind the cursor and will never be "
+            f"served again — this is the 2026-08-13 data-loss shape."
+        )
+    finally:
+        await cdp_b.evaluate(SET_BLOCKED.format("false"))
+
+    # Gate open: every held row must still be there to serve.
+    try:
+        await cdp_b.trigger_full_sync()
+        for i, path in enumerate(paths):
+            wait_for_content(
+                vault_b, path, f"held-marker-{i}", timeout=DELIVERY_TIMEOUT
+            )
+    finally:
+        # Best-effort only: teardown must never mask the real assertion error.
+        for path in paths:
+            try:
+                api_sync.delete_note(path)
+            except Exception:  # noqa: BLE001 - teardown, see above
+                pass

--- a/e2e/tests/test_90_first_sync_pull_no_phantom_push.py
+++ b/e2e/tests/test_90_first_sync_pull_no_phantom_push.py
@@ -56,11 +56,17 @@ async def test_pull_materialises_every_note_and_pushes_none(vault_b, cdp_b, api_
                 vault_b, path, f"pull-marker-{i}", timeout=DELIVERY_TIMEOUT
             )
 
-        assert result.get("pulled", 0) >= NOTE_COUNT, (
-            f"pulled={result.get('pulled')} for {NOTE_COUNT} new server notes — "
-            "the replay is reporting fewer writes than it made"
-        )
-
+        # Deliberately NOT asserting on `pulled`. This device is live-connected,
+        # so `create_note` fans out over the socket and the plugin applies each
+        # row on arrival; by the time the explicit sync runs there is nothing
+        # left to replay and `pulled` is legitimately 0. An earlier cut asserted
+        # `pulled >= NOTE_COUNT` and failed in CI for exactly that reason — it
+        # was pinning WHICH ROUTE delivered, which is not a property of the fix
+        # and is a race between fan-out and the sync call. Materialisation is
+        # already proven above, and the replay route specifically is fenced by
+        # test_89 (gate closed, then opened) where fan-out cannot short-circuit
+        # it.
+        #
         # The fence. A freshly pulled note must never look like a local original.
         assert result.get("pushed", 0) == 0, (
             f"pushed={result.get('pushed')} after a pure pull — notes pulled FROM "

--- a/e2e/tests/test_90_first_sync_pull_no_phantom_push.py
+++ b/e2e/tests/test_90_first_sync_pull_no_phantom_push.py
@@ -1,0 +1,74 @@
+"""Test 90: a pull materialises every note and pushes nothing back.
+
+The 2026-08-13 prod first sync produced two user-visible lies at once:
+
+  * folders appeared, notes did not (`flushFromCrdt` returned true while the
+    sync gate was shut, having written nothing, so the replay counted phantom
+    writes and the progress bar filled to 100% in 0.25s)
+  * it then announced ~122 files to UPLOAD from a vault that had started empty
+
+The second is the more dangerous one. Those notes had just been pulled FROM the
+server; offering to push them back means the client did not recognise them as
+server-known, and the next step from "offer to upload" is "upload duplicates".
+
+`fullSync()` returns `{pulled, pushed}`, so both halves are one assertion each.
+`pushed == 0` is the real regression fence: it fails the moment a materialised
+note stops being marked server-known, which is exactly the #339 defect.
+
+Deliberately NOT written against a pristine vault. The defect is "a note this
+client just wrote to disk from the server looks locally-originated", which
+reproduces against any vault as long as the notes are new to this device.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from helpers.latency import DELIVERY_TIMEOUT
+from helpers.vault import wait_for_content
+
+NOTE_COUNT = 6
+
+
+@pytest.mark.asyncio
+async def test_pull_materialises_every_note_and_pushes_none(vault_b, cdp_b, api_sync):
+    run = uuid.uuid4().hex[:12]
+    paths = [f"E2E/PullNoPush-{run}/N{i}.md" for i in range(NOTE_COUNT)]
+
+    # Settle first so the counts below describe THIS test's work, not a backlog
+    # left by whatever ran before it in the session.
+    await cdp_b.accept_sync_gate()
+    await cdp_b.trigger_full_sync()
+
+    try:
+        for i, path in enumerate(paths):
+            api_sync.create_note(path, f"# N{i}\npull-marker-{i}\n")
+
+        result = await cdp_b.trigger_full_sync()
+
+        # Every note on disk with the right body. Folders arriving without notes
+        # was the visible symptom; content equality is what proves a real write
+        # rather than a touched empty file.
+        for i, path in enumerate(paths):
+            wait_for_content(
+                vault_b, path, f"pull-marker-{i}", timeout=DELIVERY_TIMEOUT
+            )
+
+        assert result.get("pulled", 0) >= NOTE_COUNT, (
+            f"pulled={result.get('pulled')} for {NOTE_COUNT} new server notes — "
+            "the replay is reporting fewer writes than it made"
+        )
+
+        # The fence. A freshly pulled note must never look like a local original.
+        assert result.get("pushed", 0) == 0, (
+            f"pushed={result.get('pushed')} after a pure pull — notes pulled FROM "
+            "the server are being offered back TO it (the phantom-upload defect)"
+        )
+    finally:
+        for path in paths:
+            try:
+                api_sync.delete_note(path)
+            except Exception:  # noqa: BLE001 - teardown must not mask the failure
+                pass

--- a/e2e/tests/test_91_gate_accept_pulls_held_notes.py
+++ b/e2e/tests/test_91_gate_accept_pulls_held_notes.py
@@ -1,0 +1,73 @@
+"""Test 91: accepting the sync gate pulls what it held, with no manual sync.
+
+`markSyncGateAccepted` used to unblock the engine and re-fire enrollment but
+never re-run the catch-up. Rows the closed gate refused just sat there until a
+poll or a manual FullSync happened to come along.
+
+That was survivable only while a blocked replay still consumed the feed and a
+downstream validator rewound the cursor to rescue it. Now that a blocked replay
+correctly BAILS and leaves the cursor alone, nothing else re-serves those rows —
+so if accepting the gate does not pull, the vault stays empty and the user has
+no signal at all. The fix and the bail depend on each other, which is precisely
+why this needs an end-to-end fence rather than two unit tests.
+
+The prod run on 2026-08-14 reached its notes through a FullSync instead, so this
+path shipped unproven outside its unit test. This closes that.
+
+The assertion is the ABSENCE of `trigger_full_sync`. Adding one here would make
+the test pass against the broken build and prove nothing.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from helpers.latency import DELIVERY_TIMEOUT
+from helpers.vault import wait_for_content
+
+NOTE_COUNT = 4
+
+SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+
+
+@pytest.mark.asyncio
+async def test_accepting_the_gate_pulls_without_a_manual_sync(vault_b, cdp_b, api_sync):
+    run = uuid.uuid4().hex[:12]
+    paths = [f"E2E/GateAccept-{run}/G{i}.md" for i in range(NOTE_COUNT)]
+
+    await cdp_b.accept_sync_gate()
+    await cdp_b.trigger_full_sync()
+
+    # Shut the gate, then publish. These rows are now held: a replay fired by the
+    # channel join will bail without consuming them.
+    await cdp_b.evaluate(SET_BLOCKED.format("true"))
+    gate_open = False
+    try:
+        for i, path in enumerate(paths):
+            api_sync.create_note(path, f"# G{i}\ngate-marker-{i}\n")
+
+        # Prove they really are held, so a pass below cannot be "they arrived
+        # early on their own".
+        for path in paths:
+            assert not (vault_b / path).exists(), (
+                f"{path} landed while the gate was closed — the gate is not a gate"
+            )
+
+        # The whole test: accepting the gate, and NOTHING else, must drain them.
+        await cdp_b.accept_sync_gate()
+        gate_open = True
+
+        for i, path in enumerate(paths):
+            wait_for_content(
+                vault_b, path, f"gate-marker-{i}", timeout=DELIVERY_TIMEOUT
+            )
+    finally:
+        if not gate_open:
+            await cdp_b.evaluate(SET_BLOCKED.format("false"))
+        for path in paths:
+            try:
+                api_sync.delete_note(path)
+            except Exception:  # noqa: BLE001 - teardown must not mask the failure
+                pass

--- a/e2e/tests/test_92_byte_budget_paging_loses_nothing.py
+++ b/e2e/tests/test_92_byte_budget_paging_loses_nothing.py
@@ -13,9 +13,12 @@ delayed. A watermark in `merged_changes_page` clamps that, and a unit test pins
 it — but only a real client walking real pages proves the walk terminates and
 converges.
 
-Staged by shrinking the budget on the running backend so an ordinary test vault
-splits into many pages. Restored in the teardown; the assertion is simply that
-nothing is missing afterwards.
+Crosses the boundary with DATA VOLUME rather than by shrinking the budget on the
+backend. An earlier draft used `backend_rpc` to set `:sync_page_max_bytes` low;
+that is process-global on a shared node, and the suite runs under 2-worker
+xdist, so it would have silently forced a sibling worker's vault to one note per
+page. This version also has the better property of exercising the budget that
+actually ships.
 """
 
 from __future__ import annotations
@@ -24,48 +27,42 @@ import uuid
 
 import pytest
 
-from helpers.backend_rpc import backend_rpc
 from helpers.latency import DELIVERY_TIMEOUT
 from helpers.vault import wait_for_content
 
-NOTE_COUNT = 12
-NOTE_KB = 8
-# Below one note, so every page carries exactly one row and the client has to
-# make NOTE_COUNT round trips. Maximum paging pressure for a small fixture.
-TINY_BUDGET = 2 * 1024
-
-
-def _set_budget(value: str) -> None:
-    backend_rpc(f"Application.put_env(:engram, :sync_page_max_bytes, {value})")
+# Default budget is 4 MB. 9 x 600 KB = ~5.4 MB, so the feed must split at least
+# once. Deliberately modest: the property under test is "a boundary happens and
+# nothing is lost", which two pages prove as well as twenty, and every extra
+# megabyte here is real upload plus an embedding job on a shared CI backend.
+NOTE_COUNT = 9
+NOTE_KB = 600
 
 
 @pytest.mark.asyncio
-async def test_every_note_survives_a_heavily_paged_first_sync(vault_b, cdp_b, api_sync):
+async def test_every_note_survives_a_paged_first_sync(vault_b, cdp_b, api_sync):
     run = uuid.uuid4().hex[:12]
     paths = [f"E2E/Budget-{run}/B{i}.md" for i in range(NOTE_COUNT)]
+    # Encrypted at rest, so the stored ciphertext this is measured against is
+    # incompressible regardless of how repetitive the plaintext looks.
     body = "x" * (NOTE_KB * 1024)
 
     await cdp_b.accept_sync_gate()
     await cdp_b.trigger_full_sync()
 
-    for i, path in enumerate(paths):
-        api_sync.create_note(path, f"budget-marker-{i}\n{body}")
-
-    _set_budget(str(TINY_BUDGET))
     try:
+        for i, path in enumerate(paths):
+            api_sync.create_note(path, f"budget-marker-{i}\n{body}")
+
         await cdp_b.trigger_full_sync()
 
-        # Every note, across every page boundary. A dropped row here is the
-        # merge-watermark failure: the cursor stepped over notes the budget had
-        # held back and they are unreachable from that cursor forever.
+        # Every note, across every page boundary. A missing one here is the
+        # merge-watermark failure: the cursor stepped over notes the budget held
+        # back, and they are unreachable from that cursor forever.
         for i, path in enumerate(paths):
             wait_for_content(
                 vault_b, path, f"budget-marker-{i}", timeout=DELIVERY_TIMEOUT
             )
     finally:
-        # Back to the configured default before anything else runs, or every
-        # later test in the session pays one round trip per note.
-        _set_budget("4 * 1024 * 1024")
         for path in paths:
             try:
                 api_sync.delete_note(path)

--- a/e2e/tests/test_92_byte_budget_paging_loses_nothing.py
+++ b/e2e/tests/test_92_byte_budget_paging_loses_nothing.py
@@ -1,0 +1,73 @@
+"""Test 92: a byte-budget-split first sync delivers every note.
+
+The catch-up page now stops at a byte budget as well as a row count, because a
+500-row page of 10 MB notes would try to build ~5 GB inside an 820 MB container
+and OOM the task — taking every other user on that node down with it.
+
+Splitting a feed is a data-loss risk, not just a perf change, and this one had a
+real one in it. Notes and attachments are two feeds merged by seq. Capping the
+notes feed by bytes lets it stop at seq 5 while the unbudgeted attachments feed
+still returns rows up to seq 500; emitting those advances the shared cursor past
+notes that were never fetched, and the client resumes AFTER them. Skipped, not
+delayed. A watermark in `merged_changes_page` clamps that, and a unit test pins
+it — but only a real client walking real pages proves the walk terminates and
+converges.
+
+Staged by shrinking the budget on the running backend so an ordinary test vault
+splits into many pages. Restored in the teardown; the assertion is simply that
+nothing is missing afterwards.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from helpers.backend_rpc import backend_rpc
+from helpers.latency import DELIVERY_TIMEOUT
+from helpers.vault import wait_for_content
+
+NOTE_COUNT = 12
+NOTE_KB = 8
+# Below one note, so every page carries exactly one row and the client has to
+# make NOTE_COUNT round trips. Maximum paging pressure for a small fixture.
+TINY_BUDGET = 2 * 1024
+
+
+def _set_budget(value: str) -> None:
+    backend_rpc(f"Application.put_env(:engram, :sync_page_max_bytes, {value})")
+
+
+@pytest.mark.asyncio
+async def test_every_note_survives_a_heavily_paged_first_sync(vault_b, cdp_b, api_sync):
+    run = uuid.uuid4().hex[:12]
+    paths = [f"E2E/Budget-{run}/B{i}.md" for i in range(NOTE_COUNT)]
+    body = "x" * (NOTE_KB * 1024)
+
+    await cdp_b.accept_sync_gate()
+    await cdp_b.trigger_full_sync()
+
+    for i, path in enumerate(paths):
+        api_sync.create_note(path, f"budget-marker-{i}\n{body}")
+
+    _set_budget(str(TINY_BUDGET))
+    try:
+        await cdp_b.trigger_full_sync()
+
+        # Every note, across every page boundary. A dropped row here is the
+        # merge-watermark failure: the cursor stepped over notes the budget had
+        # held back and they are unreachable from that cursor forever.
+        for i, path in enumerate(paths):
+            wait_for_content(
+                vault_b, path, f"budget-marker-{i}", timeout=DELIVERY_TIMEOUT
+            )
+    finally:
+        # Back to the configured default before anything else runs, or every
+        # later test in the session pays one round trip per note.
+        _set_budget("4 * 1024 * 1024")
+        for path in paths:
+            try:
+                api_sync.delete_note(path)
+            except Exception:  # noqa: BLE001 - teardown must not mask the failure
+                pass

--- a/lib/engram/application.ex
+++ b/lib/engram/application.ex
@@ -41,6 +41,9 @@ defmodule Engram.Application do
         Engram.Onboarding.TermsCache,
         # Subscribe to CacheSync in init → must start after PubSub.
         Engram.Onboarding.GateCache,
+        # Bounds concurrent catch-up page builds. Absent, merged_changes_page
+        # degrades open rather than failing, so ordering here is not critical.
+        Engram.Sync.PageGate,
         # Dedicated LISTEN/NOTIFY connection — OverrideCache LISTENs on it
         # so raw-SQL override writes (trigger → pg_notify) evict caches on
         # every node. Must start before OverrideCache.

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3653,6 +3653,7 @@ defmodule Engram.Notes do
 
     fields = Keyword.get(opts, :fields, :all)
     after_id = Keyword.get(opts, :after_id)
+    max_bytes = Keyword.get(opts, :max_bytes) || page_max_bytes()
 
     base =
       from(n in scoped(user, vault),
@@ -3674,13 +3675,32 @@ defmodule Engram.Notes do
         :all -> base
       end
 
-    {:ok, notes} = Repo.with_tenant(user.id, fn -> Repo.all(query) end)
+    # Byte budget. `limit` caps ROWS; nothing capped BYTES, and POST /notes
+    # accepts a 10 MB note — so a 500-row page could try to build ~5 GB inside
+    # an 820 MB prod container, OOM the BEAM and take the ECS task down with
+    # every other user on it.
+    #
+    # The probe runs as its own query because the budget has to bound the READ.
+    # Trimming `notes` after Repo.all would already have transferred and (below)
+    # decrypted the rows it was meant to exclude, which is exactly where the
+    # memory goes. The probe selects sizes only — no content, no decrypt — so it
+    # is a few KB regardless of how fat the page would have been.
+    #
+    # :meta carries no content, so it has no byte hazard and skips the probe.
+    {row_limit, budget_more} =
+      case {fields, max_bytes} do
+        {:all, b} when is_integer(b) and b > 0 -> byte_budget_limit(base, user, limit, b)
+        _ -> {limit + 1, false}
+      end
+
+    {:ok, notes} =
+      Repo.with_tenant(user.id, fn -> Repo.all(from(q in query, limit: ^row_limit)) end)
 
     {page, has_more} =
       if length(notes) > limit do
         {Enum.take(notes, limit), true}
       else
-        {notes, false}
+        {notes, budget_more}
       end
 
     changes =
@@ -3695,6 +3715,53 @@ defmodule Engram.Notes do
       end
 
     {:ok, %{changes: changes, has_more: has_more, next: next}}
+  end
+
+  # Default ceiling on the note content one catch-up page may carry. 4 MB keeps
+  # a typical vault a single page (a 316-note real vault measured 1.5 MB) while
+  # holding the worst case to ~4 MB per in-flight page instead of ~5 GB. The
+  # frame is copied about three times on the way out (Elixir term, JSON string,
+  # transport buffer), so the live cost is a small multiple of this, not this.
+  @default_page_max_bytes 4 * 1024 * 1024
+
+  defp page_max_bytes do
+    Application.get_env(:engram, :sync_page_max_bytes, @default_page_max_bytes)
+  end
+
+  # How many of the next rows fit the byte budget, and whether the budget (not
+  # the row limit) is what stopped the page.
+  #
+  # pg_column_size reads the stored size without detoasting the ciphertext, so
+  # the probe stays cheap even when the rows it is measuring are huge. AES output
+  # is incompressible, so for our data it tracks octet_length closely.
+  defp byte_budget_limit(base, user, limit, max_bytes) do
+    {:ok, sizes} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(
+          from(n in base,
+            select: fragment("coalesce(pg_column_size(?), 0)", n.content_ciphertext)
+          )
+        )
+      end)
+
+    fits = count_within_budget(sizes, max_bytes)
+    {min(fits, limit + 1), fits <= limit and length(sizes) > fits}
+  end
+
+  defp count_within_budget(sizes, max_bytes) do
+    sizes
+    |> Enum.reduce_while({0, 0}, fn size, {n, acc} ->
+      cond do
+        # The first row always ships, however far over budget. A page of zero
+        # rows with has_more is a feed that never drains: walkOpLog's
+        # stuck-cursor guard breaks the loop and the note is stranded forever.
+        # One oversized note should sync slowly, not block everything behind it.
+        n == 0 -> {:cont, {1, size}}
+        acc + size > max_bytes -> {:halt, {n, acc}}
+        true -> {:cont, {n + 1, acc + size}}
+      end
+    end)
+    |> elem(0)
   end
 
   defp change_map(note) do

--- a/lib/engram/sync.ex
+++ b/lib/engram/sync.ex
@@ -22,17 +22,32 @@ defmodule Engram.Sync do
   to that ceiling (see `SyncController`), else a feed could return its capped 500
   (< limit) while in-range rows remain and the trim branch would be skipped —
   silently dropping rows.
+
+  `max_bytes` bounds the note content this page may carry (see
+  `Notes.list_changes_by_seq/4`). Pass `nil` to use the configured default.
   """
-  def merged_changes_page(user, vault, after_seq, after_id, limit, fields)
+  def merged_changes_page(user, vault, after_seq, after_id, limit, fields, max_bytes \\ nil)
       when is_integer(after_seq) and is_integer(limit) do
+    # One slot per in-flight page (see PageGate): the byte budget bounds ONE
+    # page, this bounds how many exist at once so a burst of first syncs queues
+    # instead of stacking memory. Queues, never rejects — the client aborts its
+    # whole walk on a rejected fetch.
+    Engram.Sync.PageGate.with_slot(fn ->
+      build_page(user, vault, after_seq, after_id, limit, fields, max_bytes)
+    end)
+  end
+
+  defp build_page(user, vault, after_seq, after_id, limit, fields, max_bytes) do
     {:ok, %{changes: notes, has_more: notes_more}} =
       Notes.list_changes_by_seq(user, vault, after_seq,
         after_id: after_id,
         limit: limit + 1,
-        fields: fields
+        fields: fields,
+        max_bytes: max_bytes
       )
 
-    # Attachments carry no note content, so the `fields` projection is n/a here.
+    # Attachments carry no note content, so the `fields` projection is n/a here
+    # and so is the byte budget — an attachment row is metadata only.
     {:ok, %{changes: atts, has_more: atts_more}} =
       Attachments.list_changes_by_seq(user, vault, after_seq,
         after_id: after_id,
@@ -42,21 +57,46 @@ defmodule Engram.Sync do
     merged =
       (Enum.map(notes, &Map.put(&1, :type, :note)) ++
          Enum.map(atts, &Map.put(&1, :type, :attachment)))
-      |> Enum.sort_by(&{&1.seq, &1.id})
+      |> Enum.sort_by(&key/1)
+
+    # WATERMARK — do not emit past the point where either feed is known to be
+    # incomplete.
+    #
+    # The two feeds are paginated independently and merged by seq. A feed that
+    # reports has_more is only trustworthy up to its own last row: past that
+    # point it may hold rows we did not fetch. Emitting the OTHER feed's higher
+    # seqs anyway advances the shared cursor past those unfetched rows, and the
+    # client resumes after them — they are skipped permanently, not delayed.
+    #
+    # Latent before the byte budget (both feeds truncated at the same row count,
+    # so their last rows sat close together), and reachable after it: the notes
+    # feed can now stop at 1 row on seq 5 while attachments still return 500 rows
+    # up to seq 500. Without this clamp that page would strand every note between.
+    watermark =
+      [notes_more && List.last(notes), atts_more && List.last(atts)]
+      |> Enum.filter(&is_map/1)
+      |> Enum.map(&key/1)
+      |> Enum.min(fn -> nil end)
+
+    capped = if watermark, do: Enum.filter(merged, &(key(&1) <= watermark)), else: merged
 
     {page, has_more} =
-      if length(merged) > limit do
-        {Enum.take(merged, limit), true}
+      if length(capped) > limit do
+        {Enum.take(capped, limit), true}
       else
-        {merged, notes_more or atts_more}
+        # `capped` shorter than `merged` means the watermark held rows back, so
+        # there is definitionally more to serve even if neither feed said so.
+        {capped, notes_more or atts_more or length(capped) < length(merged)}
       end
 
     next =
-      if has_more do
+      if has_more and page != [] do
         last = List.last(page)
         {last.seq, last.id}
       end
 
     %{page: page, has_more: has_more, next: next}
   end
+
+  defp key(row), do: {row.seq, row.id}
 end

--- a/lib/engram/sync/page_gate.ex
+++ b/lib/engram/sync/page_gate.ex
@@ -31,15 +31,35 @@ defmodule Engram.Sync.PageGate do
   use GenServer
   require Logger
 
-  @default_limit 8
+  # Derived from the DB pool, never hardcoded. Every page build checks out a
+  # connection for its read, so N slots is N connections unavailable to
+  # checkpoints, other channels and the seq feed. A flat number also goes stale
+  # silently the moment POOL_SIZE moves (it went 10 -> 15 without this file
+  # knowing), which is exactly the class of bug a derived value cannot have.
+  #
+  # A third, matching the spirit of crdt_channel.batch_concurrency taking a
+  # quarter: enough to overlap real work, not enough to monopolise the pool. A
+  # page is ~250 ms, so even 5 slots clears ~20 vaults/second.
+  @pool_divisor 3
+  @min_limit 2
+
   # Generous: a page is ~250 ms of work, so waiting out a full queue is normally
   # far under this. Hitting it means real saturation, not ordinary contention.
   @default_timeout 15_000
 
+  @doc """
+  Start the gate. `name: nil` starts it unregistered, addressed by pid — which
+  is how tests get an isolated instance without either minting a runtime atom
+  per test or colliding with the app-supervised one.
+  """
   def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
     limit = Keyword.get(opts, :limit) || configured_limit()
-    GenServer.start_link(__MODULE__, limit, name: name)
+
+    case Keyword.fetch(opts, :name) do
+      {:ok, nil} -> GenServer.start_link(__MODULE__, limit)
+      {:ok, name} -> GenServer.start_link(__MODULE__, limit, name: name)
+      :error -> GenServer.start_link(__MODULE__, limit, name: __MODULE__)
+    end
   end
 
   @doc """
@@ -70,6 +90,20 @@ defmodule Engram.Sync.PageGate do
     :exit, _ ->
       # Timed out, or the gate is not running (self-host boots without it, and
       # tests may not start it). Either way the work still has to happen.
+      #
+      # WITHDRAW FIRST. A timed-out caller is still sitting in the waiting queue,
+      # and it is still alive — it is a channel process that merely gave up
+      # waiting. Without this, the next free slot gets handed to it, the reply
+      # goes nowhere, and the slot is held until that channel dies. Under exactly
+      # the sustained load this gate exists for, capacity leaks away one slot at
+      # a time and every later page runs ungated while the logs say nothing,
+      # because degrading open is the designed behaviour. Protection that can
+      # vanish without a signal is worse than none.
+      #
+      # Cast, not call: the gate may be down, and a second blocking call on the
+      # failure path is how a timeout becomes a hang.
+      catch_exit_cast(gate, {:cancel, self()})
+
       Logger.warning("sync page gate unavailable or saturated — building page ungated",
         category: :sync
       )
@@ -77,8 +111,26 @@ defmodule Engram.Sync.PageGate do
       :degraded
   end
 
-  defp configured_limit do
-    Application.get_env(:engram, :sync_page_concurrency, @default_limit)
+  defp catch_exit_cast(gate, msg) do
+    GenServer.cast(gate, msg)
+  catch
+    :exit, _ -> :ok
+  end
+
+  @doc """
+  Slots this node allows, derived from the configured Ecto pool unless
+  overridden by `:sync_page_concurrency`. Public so a test can pin the pool
+  coupling — a plausible-looking hardcoded number is what this replaced.
+  """
+  def configured_limit do
+    case Application.get_env(:engram, :sync_page_concurrency) do
+      n when is_integer(n) and n > 0 ->
+        n
+
+      _ ->
+        pool = Keyword.get(Application.get_env(:engram, Engram.Repo, []), :pool_size, 10)
+        max(@min_limit, div(pool, @pool_divisor))
+    end
   end
 
   @impl true
@@ -96,10 +148,24 @@ defmodule Engram.Sync.PageGate do
   @impl true
   def handle_cast({:release, pid}, state), do: {:noreply, state |> drop(pid) |> pump()}
 
+  # A caller that gave up waiting. Must clear BOTH queues: the grant can race
+  # the timeout, so by the time this arrives the waiter may already have been
+  # promoted into `active` and be holding a slot nobody will ever release.
+  @impl true
+  def handle_cast({:cancel, pid}, state) do
+    waiting = :queue.filter(fn {waiter, _tag} -> waiter != pid end, state.waiting)
+    {:noreply, %{state | waiting: waiting} |> drop(pid) |> pump()}
+  end
+
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state),
     do: {:noreply, state |> drop(pid) |> pump()}
 
+  # NOT re-entrant: `active` is keyed by pid, so the same process acquiring
+  # twice would overwrite its own monitor ref (leaking the first) and count as
+  # one slot, over-admitting by one. There is a single call site and it does not
+  # nest; if that ever changes, this needs a per-pid depth count rather than a
+  # bare map.
   defp grant(state, pid) do
     ref = Process.monitor(pid)
     %{state | active: Map.put(state.active, pid, ref)}

--- a/lib/engram/sync/page_gate.ex
+++ b/lib/engram/sync/page_gate.ex
@@ -1,0 +1,138 @@
+defmodule Engram.Sync.PageGate do
+  @moduledoc """
+  Counting semaphore bounding how many full-content catch-up pages this node
+  builds concurrently.
+
+  The byte budget in `Engram.Notes.list_changes_by_seq/4` caps what ONE page may
+  carry. This caps how many of those can be in flight at once, so a burst of
+  first syncs degrades into a queue instead of stacking N pages of memory on an
+  820 MB container. With a 4 MB budget and 8 slots the page working set stays
+  around 32 MB (times the ~3 copies a frame makes on its way out) rather than
+  scaling with however many people signed up this minute.
+
+  ## Why it queues instead of rejecting
+
+  The client's `walkOpLog` raises `OpLogFetchError` on a rejected fetch and
+  aborts the entire walk. A "busy, come back later" reply would therefore turn
+  load into a stalled first sync — the exact failure this whole workstream
+  exists to remove. Waiters block; nobody is turned away.
+
+  ## Why it degrades open
+
+  If the wait budget expires, `with_slot/2` runs the work anyway and logs it.
+  The gate smooths memory; it is not a correctness boundary. Raising would crash
+  the channel and strand the sync, which is strictly worse than one unbounded
+  page. A sustained stream of these in the logs means the limit is too low for
+  the traffic, and that is a tuning signal, not an incident.
+
+  Slots are released on normal completion AND on holder death (the holder is
+  monitored), so a killed page-builder cannot shrink capacity until restart.
+  """
+  use GenServer
+  require Logger
+
+  @default_limit 8
+  # Generous: a page is ~250 ms of work, so waiting out a full queue is normally
+  # far under this. Hitting it means real saturation, not ordinary contention.
+  @default_timeout 15_000
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    limit = Keyword.get(opts, :limit) || configured_limit()
+    GenServer.start_link(__MODULE__, limit, name: name)
+  end
+
+  @doc """
+  Run `fun` holding one slot, waiting for a free one if necessary.
+
+  Options: `:gate` (process name, for tests), `:timeout` (wait budget in ms).
+  """
+  def with_slot(fun, opts \\ []) do
+    gate = Keyword.get(opts, :gate, __MODULE__)
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    case acquire(gate, timeout) do
+      :ok ->
+        try do
+          fun.()
+        after
+          GenServer.cast(gate, {:release, self()})
+        end
+
+      :degraded ->
+        fun.()
+    end
+  end
+
+  defp acquire(gate, timeout) do
+    GenServer.call(gate, :acquire, timeout)
+  catch
+    :exit, _ ->
+      # Timed out, or the gate is not running (self-host boots without it, and
+      # tests may not start it). Either way the work still has to happen.
+      Logger.warning("sync page gate unavailable or saturated — building page ungated",
+        category: :sync
+      )
+
+      :degraded
+  end
+
+  defp configured_limit do
+    Application.get_env(:engram, :sync_page_concurrency, @default_limit)
+  end
+
+  @impl true
+  def init(limit), do: {:ok, %{limit: limit, active: %{}, waiting: :queue.new()}}
+
+  @impl true
+  def handle_call(:acquire, {pid, _tag} = from, state) do
+    if map_size(state.active) < state.limit do
+      {:reply, :ok, grant(state, pid)}
+    else
+      {:noreply, %{state | waiting: :queue.in(from, state.waiting)}}
+    end
+  end
+
+  @impl true
+  def handle_cast({:release, pid}, state), do: {:noreply, state |> drop(pid) |> pump()}
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state),
+    do: {:noreply, state |> drop(pid) |> pump()}
+
+  defp grant(state, pid) do
+    ref = Process.monitor(pid)
+    %{state | active: Map.put(state.active, pid, ref)}
+  end
+
+  defp drop(state, pid) do
+    case Map.pop(state.active, pid) do
+      {nil, _} ->
+        state
+
+      {ref, rest} ->
+        Process.demonitor(ref, [:flush])
+        %{state | active: rest}
+    end
+  end
+
+  # Hand the freed slot to the next waiter. Skips waiters that died while queued
+  # (their GenServer.call has no live receiver) so a dead waiter can't be granted
+  # a slot nobody will ever release.
+  defp pump(state) do
+    case :queue.out(state.waiting) do
+      {:empty, _} ->
+        state
+
+      {{:value, {pid, _tag} = from}, rest} ->
+        state = %{state | waiting: rest}
+
+        if Process.alive?(pid) do
+          GenServer.reply(from, :ok)
+          grant(state, pid)
+        else
+          pump(state)
+        end
+    end
+  end
+end

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -100,8 +100,7 @@ defmodule EngramWeb.DeviceAuthController do
         # RequestLogger logs it at :info. This is the happy path — the code is
         # alive and the human just has not clicked approve yet — and at a 5s
         # poll over a 300s TTL one successful login would otherwise emit ~60
-        # WARN lines (prod 2026-08-13: ~82% of the warn stream, and a feeder
-        # for the loki-auth-failure-burst alert).
+        # WARN lines (prod 2026-08-13: ~82% of the warn stream).
         conn
         |> assign(:expected_client_status, true)
         |> put_status(400)

--- a/lib/engram_web/controllers/device_auth_controller.ex
+++ b/lib/engram_web/controllers/device_auth_controller.ex
@@ -90,7 +90,22 @@ defmodule EngramWeb.DeviceAuthController do
         })
 
       {:error, :authorization_pending} ->
-        conn |> put_status(428) |> json(%{error: "authorization_pending"})
+        # RFC 8628 §3.5: `authorization_pending` is a 400 carrying the error in
+        # the body. The old 428 ("Precondition Required") was never part of the
+        # device flow. Clients keyed on 428 are unaffected in practice: both the
+        # plugin poll loop and the e2e helpers fall through to "keep polling"
+        # on an unrecognised status, and both now accept 400 explicitly.
+        #
+        # :expected_client_status marks this as a NORMAL protocol step so
+        # RequestLogger logs it at :info. This is the happy path — the code is
+        # alive and the human just has not clicked approve yet — and at a 5s
+        # poll over a 300s TTL one successful login would otherwise emit ~60
+        # WARN lines (prod 2026-08-13: ~82% of the warn stream, and a feeder
+        # for the loki-auth-failure-burst alert).
+        conn
+        |> assign(:expected_client_status, true)
+        |> put_status(400)
+        |> json(%{error: "authorization_pending"})
 
       {:error, :expired_or_invalid} ->
         conn |> put_status(410) |> json(%{error: "expired_or_invalid"})

--- a/lib/engram_web/request_logger.ex
+++ b/lib/engram_web/request_logger.ex
@@ -93,9 +93,25 @@ defmodule EngramWeb.RequestLogger do
     Logger.log(
       level,
       "#{conn.method} #{conn.status} in #{duration_ms}ms",
-      Engram.Logger.Metadata.with_category(level, :http, meta)
+      level
+      |> Engram.Logger.Metadata.with_category(:http, meta)
+      |> maybe_force_loki_ship(conn)
     )
   end
+
+  # Quieting the LEVEL must not silently DELETE the record.
+  # `Category.loki_ship?(:info, :http)` is false, so a response downgraded to
+  # :info by `expected_client_status` would stop reaching Loki entirely — an
+  # operator debugging "device linking is stuck for user X" would find nothing
+  # at all, which is a worse failure than the warn noise this replaces.
+  # Same per-entry override `Engram.Logs.insert_logs/2` uses for diagnostic
+  # client entries. Volume is not a concern: these lines are a handful per
+  # login, unlike the successful-2xx firehose that keeps :http off the
+  # info-ships list in the first place.
+  defp maybe_force_loki_ship(meta, %Plug.Conn{assigns: %{expected_client_status: true}}),
+    do: Keyword.put(meta, :loki_ship, true)
+
+  defp maybe_force_loki_ship(meta, _conn), do: meta
 
   # A rejecting plug (e.g. VaultPlug) assigns :reject_reason so the reason rides
   # this single request line instead of a second per-request log. Omitted entirely
@@ -124,10 +140,13 @@ defmodule EngramWeb.RequestLogger do
   # client error. The only current user is the device flow's
   # `authorization_pending` poll: the code is alive and the human simply has
   # not approved yet, so at a 5s poll over a 300s TTL one SUCCESSFUL login
-  # emitted ~60 warnings (prod 2026-08-13 — ~82% of the warn stream, and a
-  # feeder for loki-auth-failure-burst). A log level is the claim "a human
-  # should look at this"; spending it on a happy path is how a working system
-  # reads as an incident.
+  # emitted ~60 warnings (prod 2026-08-13 — ~82% of the warn stream). A log
+  # level is the claim "a human should look at this"; spending it on a happy
+  # path is how a working system reads as an incident.
+  #
+  # NB: this does NOT feed grafana's loki-auth-failure-burst alert, despite
+  # looking like it should — that rule filters metadata_category="auth" and
+  # these request lines are category :http. The volume argument stands alone.
   #
   # Opt-in PER RESPONSE, set server-side — never blanket-4xx and never keyed on
   # route+status, so a genuine client error on the same endpoint (malformed
@@ -162,13 +181,25 @@ defmodule EngramWeb.RequestLogger do
   #
   # If per-source correlation is ever needed here (device-code guessing), the
   # answer is a keyed digest via Engram.Crypto.HMAC, not the raw address.
+  # TRUNCATED, because this is an unauthenticated trust boundary. The header is
+  # attacker-controlled, RedactFilter neither scrubs nor bounds `:user_agent`,
+  # and prod serializes all metadata — so with Bandit's 10_000-byte header cap
+  # a client hammering /api/auth/device/token could push ~10KB of arbitrary text
+  # per request into a hosted, long-retention aggregator. That is the same
+  # ingest-cost failure mode this PR exists to fix. 200 chars holds every real
+  # UA (the Obsidian one is ~120) and nothing else.
+  @user_agent_log_limit 200
+
   defp maybe_put_client_identity(meta, %Plug.Conn{private: private} = conn) do
     if private[:phoenix_controller] == EngramWeb.DeviceAuthController do
-      Keyword.put(meta, :user_agent, RequestMeta.get_user_agent(conn))
+      Keyword.put(meta, :user_agent, truncate_user_agent(RequestMeta.get_user_agent(conn)))
     else
       meta
     end
   end
+
+  defp truncate_user_agent(nil), do: nil
+  defp truncate_user_agent(ua), do: String.slice(ua, 0, @user_agent_log_limit)
 
   defp current_user_id(%Plug.Conn{assigns: %{current_user: %{id: id}}}), do: id
   defp current_user_id(_), do: nil

--- a/lib/engram_web/request_logger.ex
+++ b/lib/engram_web/request_logger.ex
@@ -16,6 +16,8 @@ defmodule EngramWeb.RequestLogger do
   triage; it is not in the redact filter's sensitive-key set.
   """
 
+  alias EngramWeb.RequestMeta
+
   require Logger
 
   @handler_id :engram_request_logger
@@ -73,7 +75,7 @@ defmodule EngramWeb.RequestLogger do
 
   defp emit_request_log(conn, duration) do
     duration_ms = System.convert_time_unit(duration, :native, :millisecond)
-    level = level_for_status(conn.status)
+    level = level_for_conn(conn)
 
     meta =
       [
@@ -86,6 +88,7 @@ defmodule EngramWeb.RequestLogger do
         mtls_clientcert_subject: mtls_clientcert_subject(conn)
       ]
       |> maybe_put_reject_reason(conn)
+      |> maybe_put_client_identity(conn)
 
     Logger.log(
       level,
@@ -117,11 +120,50 @@ defmodule EngramWeb.RequestLogger do
 
   defp suppress_request_log?(_), do: false
 
+  # A controller may mark a 4xx as a NORMAL step in its protocol rather than a
+  # client error. The only current user is the device flow's
+  # `authorization_pending` poll: the code is alive and the human simply has
+  # not approved yet, so at a 5s poll over a 300s TTL one SUCCESSFUL login
+  # emitted ~60 warnings (prod 2026-08-13 — ~82% of the warn stream, and a
+  # feeder for loki-auth-failure-burst). A log level is the claim "a human
+  # should look at this"; spending it on a happy path is how a working system
+  # reads as an incident.
+  #
+  # Opt-in PER RESPONSE, set server-side — never blanket-4xx and never keyed on
+  # route+status, so a genuine client error on the same endpoint (malformed
+  # body, missing param) still surfaces at :warning. 5xx is never downgradable.
+  defp level_for_conn(%Plug.Conn{status: status, assigns: %{expected_client_status: true}})
+       when is_integer(status) and status < 500,
+       do: :info
+
+  defp level_for_conn(%Plug.Conn{status: status}), do: level_for_status(status)
+
   # A 5xx flood must elevate above :info so level-keyed alerting sees it; a 4xx
   # is a client error worth a :warning; everything else stays :info.
   defp level_for_status(status) when status >= 500, do: :error
   defp level_for_status(status) when status >= 400, do: :warning
   defp level_for_status(_), do: :info
+
+  # Client attribution for the device-flow endpoints ONLY. They are public and
+  # pre-auth (`user_id` is null until the code is approved), so without these
+  # a polling client is entirely unattributable — you can neither answer "who
+  # is calling this" nor spot device-code guessing. Scoped rather than global
+  # because an IP + UA on every request line is bytes on every log in the
+  # system for a need specific to these routes.
+  #
+  # IP comes from EngramWeb.RemoteIp, which resolves the Cloudflare-set
+  # CF-Connecting-IP under the AOP trust model and otherwise falls back to the
+  # socket peer. `conn.remote_ip` alone would record the ALB's private address
+  # for every external client (see that module's docs).
+  defp maybe_put_client_identity(meta, %Plug.Conn{private: private} = conn) do
+    if private[:phoenix_controller] == EngramWeb.DeviceAuthController do
+      meta
+      |> Keyword.put(:client_ip, conn |> EngramWeb.RemoteIp.resolve() |> RequestMeta.format_ip())
+      |> Keyword.put(:user_agent, RequestMeta.get_user_agent(conn))
+    else
+      meta
+    end
+  end
 
   defp current_user_id(%Plug.Conn{assigns: %{current_user: %{id: id}}}), do: id
   defp current_user_id(_), do: nil

--- a/lib/engram_web/request_logger.ex
+++ b/lib/engram_web/request_logger.ex
@@ -145,21 +145,26 @@ defmodule EngramWeb.RequestLogger do
   defp level_for_status(_), do: :info
 
   # Client attribution for the device-flow endpoints ONLY. They are public and
-  # pre-auth (`user_id` is null until the code is approved), so without these
-  # a polling client is entirely unattributable — you can neither answer "who
-  # is calling this" nor spot device-code guessing. Scoped rather than global
-  # because an IP + UA on every request line is bytes on every log in the
-  # system for a need specific to these routes.
+  # pre-auth (`user_id` is null until the code is approved), so a polling
+  # client is otherwise entirely unattributable — you cannot tell which client
+  # is calling, and a stuck poller reads identically to a healthy one.
+  # Scoped rather than global because a UA on every request line is bytes on
+  # every log in the system for a need specific to these routes.
   #
-  # IP comes from EngramWeb.RemoteIp, which resolves the Cloudflare-set
-  # CF-Connecting-IP under the AOP trust model and otherwise falls back to the
-  # socket peer. `conn.remote_ip` alone would record the ALB's private address
-  # for every external client (see that module's docs).
+  # NO client IP here, deliberately. `config/prod.exs` states the standing
+  # policy that request headers and client IPs stay OUT of Loki — that is why
+  # prod excludes Sentry.PlugContext's `:__sentry__` blob rather than logging
+  # it. IPs are still recorded where they have a purpose and a lifecycle (ToS
+  # agreements, DCR registrations) as DB columns, not sprayed across every log
+  # line in a hosted, long-retention aggregator. The user agent carries no
+  # credential and is already persisted deliberately elsewhere
+  # (`onboarding/agreement.ex`, `oauth_register_controller`), so it stays.
+  #
+  # If per-source correlation is ever needed here (device-code guessing), the
+  # answer is a keyed digest via Engram.Crypto.HMAC, not the raw address.
   defp maybe_put_client_identity(meta, %Plug.Conn{private: private} = conn) do
     if private[:phoenix_controller] == EngramWeb.DeviceAuthController do
-      meta
-      |> Keyword.put(:client_ip, conn |> EngramWeb.RemoteIp.resolve() |> RequestMeta.format_ip())
-      |> Keyword.put(:user_agent, RequestMeta.get_user_agent(conn))
+      Keyword.put(meta, :user_agent, RequestMeta.get_user_agent(conn))
     else
       meta
     end

--- a/test/engram/notes_seq_feed_byte_budget_test.exs
+++ b/test/engram/notes_seq_feed_byte_budget_test.exs
@@ -1,0 +1,158 @@
+defmodule Engram.NotesSeqFeedByteBudgetTest do
+  @moduledoc """
+  The seq feed pages by ROW COUNT. Nothing bounds the BYTES a page carries.
+
+  `POST /notes` accepts a note up to 10 MB, and a catch-up page carries up to
+  500 rows of full decrypted content in one WebSocket frame, so a page can try
+  to build ~5 GB inside an 820 MB prod container. The frame is copied roughly
+  three times on the way out (Elixir term, JSON, transport buffer), so the real
+  ceiling is well under even that. A BEAM OOM kills the ECS task, which drops
+  every other user on that node — one account's data shape becomes everyone's
+  outage.
+
+  The cap has to bound the DATABASE READ, not just the reply: rows are already
+  loaded and decrypted before any post-hoc trim could run, and that is where
+  the memory goes.
+
+  The client tolerates short pages already: `walkOpLog` loops on `has_more` up
+  to OP_LOG_MAX_PAGES (100_000), so more-but-smaller pages are free.
+  """
+  use Engram.DataCase, async: true
+  alias Engram.{Notes, Sync, Vaults}
+
+  setup do
+    user = insert_user()
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+    {:ok, vault} = Vaults.create_vault(user, %{name: "T"})
+    %{user: user, vault: vault}
+  end
+
+  defp big(kb), do: String.duplicate("x", kb * 1024)
+
+  test "a page stops at the byte budget and reports has_more", %{user: user, vault: vault} do
+    for i <- 1..5 do
+      {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n#{i}.md", "content" => big(40)})
+    end
+
+    # Budget fits 2 notes, not 5. Row limit is deliberately generous so only the
+    # byte budget can be what shortens the page.
+    {:ok, %{changes: page, has_more: has_more, next: next}} =
+      Notes.list_changes_by_seq(user, vault, 0, limit: 500, max_bytes: 100 * 1024)
+
+    assert has_more, "a byte-capped page must tell the client to come back"
+    assert length(page) < 5, "the budget did not shorten the page"
+    assert next, "a short page must carry a cursor or the rest is unreachable"
+  end
+
+  test "resuming from the cursor returns the remainder with nothing lost", %{
+    user: user,
+    vault: vault
+  } do
+    for i <- 1..5 do
+      {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n#{i}.md", "content" => big(40)})
+    end
+
+    # Walk the whole feed in byte-capped pages, exactly as walkOpLog does.
+    paths =
+      Stream.unfold({0, nil, true}, fn
+        {_seq, _id, false} ->
+          nil
+
+        {seq, id, true} ->
+          {:ok, %{changes: page, has_more: more, next: next}} =
+            Notes.list_changes_by_seq(user, vault, seq,
+              after_id: id,
+              limit: 500,
+              max_bytes: 100 * 1024
+            )
+
+          {next_seq, next_id} = if next, do: next, else: {seq, id}
+          {Enum.map(page, & &1.path), {next_seq, next_id, more and page != []}}
+      end)
+      |> Enum.to_list()
+      |> List.flatten()
+
+    assert Enum.sort(paths) == Enum.sort(for i <- 1..5, do: "n#{i}.md")
+  end
+
+  test "a single note larger than the whole budget still comes back", %{
+    user: user,
+    vault: vault
+  } do
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "huge.md", "content" => big(200)})
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "after.md", "content" => "small"})
+
+    {:ok, %{changes: page}} =
+      Notes.list_changes_by_seq(user, vault, 0, limit: 500, max_bytes: 10 * 1024)
+
+    # Never zero rows: an empty page with has_more is a feed that never drains.
+    # walkOpLog's stuck-cursor guard would break the loop and strand the note.
+    assert [%{path: "huge.md"}] = page
+  end
+
+  test "a page under the budget is untouched", %{user: user, vault: vault} do
+    for i <- 1..3 do
+      {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n#{i}.md", "content" => "small"})
+    end
+
+    {:ok, %{changes: page, has_more: has_more}} =
+      Notes.list_changes_by_seq(user, vault, 0, limit: 500, max_bytes: 4 * 1024 * 1024)
+
+    assert length(page) == 3
+    refute has_more
+  end
+
+  test "merged_changes_page applies the budget too (the channel's entry point)", %{
+    user: user,
+    vault: vault
+  } do
+    for i <- 1..5 do
+      {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n#{i}.md", "content" => big(40)})
+    end
+
+    %{page: page, has_more: has_more} =
+      Sync.merged_changes_page(user, vault, 0, nil, 500, :all, 100 * 1024)
+
+    assert has_more
+    assert length(page) < 5
+  end
+
+  test "the merged cursor never advances past a byte-truncated notes feed", %{
+    user: user,
+    vault: vault
+  } do
+    # Notes take the low seqs, attachments the high ones.
+    for i <- 1..5 do
+      {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "n#{i}.md", "content" => big(40)})
+    end
+
+    for i <- 1..3 do
+      {:ok, _} =
+        Engram.Attachments.upsert_attachment(user, vault, %{
+          "path" => "a#{i}.png",
+          "content_base64" => Base.encode64("png#{i}"),
+          "mime_type" => "image/png"
+        })
+    end
+
+    # A budget that fits ONE note. The attachments feed is unbudgeted (metadata
+    # only) and happily returns all three at seqs ABOVE every remaining note.
+    %{page: page, next: next} =
+      Sync.merged_changes_page(user, vault, 0, nil, 500, :all, 1024)
+
+    {next_seq, _next_id} = next
+
+    # Emitting an attachment here would push the shared cursor past notes 2..5,
+    # which were never fetched — the client resumes after them and they are gone
+    # for good. The page must stop at the last note the budget allowed.
+    unfetched_note_seqs =
+      Enum.filter(page, &(&1.type == :note)) |> Enum.map(& &1.seq) |> Enum.max(fn -> 0 end)
+
+    assert next_seq <= unfetched_note_seqs,
+           "cursor advanced to #{next_seq}, past notes the byte budget skipped"
+
+    refute Enum.any?(page, &(&1.type == :attachment)),
+           "an attachment rode past a truncated notes feed and stranded the notes behind it"
+  end
+end

--- a/test/engram/sync/page_gate_test.exs
+++ b/test/engram/sync/page_gate_test.exs
@@ -1,0 +1,89 @@
+defmodule Engram.Sync.PageGateTest do
+  @moduledoc """
+  Bounds how many full-content catch-up pages this node builds at once.
+
+  The byte budget caps ONE page. This caps how many of those exist
+  simultaneously, so a thundering herd of first syncs degrades into a queue
+  instead of stacking N pages of memory on an 820 MB container.
+
+  It must QUEUE, never reject. The client's `walkOpLog` throws `OpLogFetchError`
+  on a rejected fetch and aborts the whole walk, so a "busy, try later" reply
+  would turn load into the stalled-first-sync bug we just spent a day fixing.
+  """
+  use ExUnit.Case, async: false
+
+  alias Engram.Sync.PageGate
+
+  setup do
+    name = :"gate_#{System.unique_integer([:positive])}"
+    start_supervised!({PageGate, name: name, limit: 2})
+    %{gate: name}
+  end
+
+  defp hold(gate, ref, test_pid) do
+    spawn(fn ->
+      PageGate.with_slot(
+        fn ->
+          send(test_pid, {:acquired, ref})
+          receive do: (:release -> :ok)
+        end,
+        gate: gate
+      )
+    end)
+  end
+
+  test "grants up to the limit immediately and makes the next one wait", %{gate: gate} do
+    me = self()
+    a = hold(gate, :a, me)
+    b = hold(gate, :b, me)
+
+    assert_receive {:acquired, :a}, 1000
+    assert_receive {:acquired, :b}, 1000
+
+    _c = hold(gate, :c, me)
+    refute_receive {:acquired, :c}, 300, "third page ran while both slots were held"
+
+    send(a, :release)
+    assert_receive {:acquired, :c}, 1000, "a freed slot was not handed to the waiter"
+
+    send(b, :release)
+  end
+
+  test "a holder that crashes frees its slot", %{gate: gate} do
+    me = self()
+    a = hold(gate, :a, me)
+    b = hold(gate, :b, me)
+    assert_receive {:acquired, :a}, 1000
+    assert_receive {:acquired, :b}, 1000
+
+    # Not a graceful release — the page-building process dies mid-work, which is
+    # what an OOM or a channel crash looks like. A leaked slot here would shrink
+    # capacity permanently until restart.
+    Process.exit(a, :kill)
+
+    _c = hold(gate, :c, me)
+    assert_receive {:acquired, :c}, 1000, "the killed holder leaked its slot"
+
+    send(b, :release)
+  end
+
+  test "returns the function's value", %{gate: gate} do
+    assert PageGate.with_slot(fn -> {:ok, 42} end, gate: gate) == {:ok, 42}
+  end
+
+  test "degrades OPEN when the wait times out rather than failing the sync", %{gate: gate} do
+    me = self()
+    a = hold(gate, :a, me)
+    b = hold(gate, :b, me)
+    assert_receive {:acquired, :a}, 1000
+    assert_receive {:acquired, :b}, 1000
+
+    # Both slots held and no timely release. The gate is a smoother, not a
+    # correctness boundary: raising here would crash the channel and strand the
+    # sync, which is strictly worse than one unbounded page.
+    assert PageGate.with_slot(fn -> :ran_anyway end, gate: gate, timeout: 50) == :ran_anyway
+
+    send(a, :release)
+    send(b, :release)
+  end
+end

--- a/test/engram/sync/page_gate_test.exs
+++ b/test/engram/sync/page_gate_test.exs
@@ -15,9 +15,10 @@ defmodule Engram.Sync.PageGateTest do
   alias Engram.Sync.PageGate
 
   setup do
-    name = :"gate_#{System.unique_integer([:positive])}"
-    start_supervised!({PageGate, name: name, limit: 2})
-    %{gate: name}
+    # Unregistered and addressed by pid: a per-test registered name would mint a
+    # runtime atom, and the default name is already taken by the app-supervised
+    # instance in this env.
+    %{gate: start_supervised!({PageGate, name: nil, limit: 2})}
   end
 
   defp hold(gate, ref, test_pid) do
@@ -85,5 +86,39 @@ defmodule Engram.Sync.PageGateTest do
 
     send(a, :release)
     send(b, :release)
+  end
+
+  test "a timed-out caller does not keep a slot it never got", %{gate: gate} do
+    me = self()
+    a = hold(gate, :a, me)
+    b = hold(gate, :b, me)
+    assert_receive {:acquired, :a}, 1000
+    assert_receive {:acquired, :b}, 1000
+
+    # Give up waiting. This process stays ALIVE afterwards — it is standing in
+    # for a channel process that timed out but is still serving its socket. If
+    # the gate leaves it queued, the slot freed below is handed to a caller that
+    # is no longer listening and is never released: capacity bleeds away one
+    # slot per timeout until every page runs ungated, silently.
+    assert PageGate.with_slot(fn -> :degraded end, gate: gate, timeout: 50) == :degraded
+
+    send(a, :release)
+
+    # The freed slot must reach a real waiter.
+    _c = hold(gate, :c, me)
+    assert_receive {:acquired, :c}, 1000, "the timed-out caller swallowed the freed slot"
+
+    send(b, :release)
+  end
+
+  test "the limit tracks the DB pool rather than a hardcoded number", %{gate: _gate} do
+    # Every page build holds a pool connection, so this is a real coupling. A
+    # flat constant silently went stale once already (POOL_SIZE moved 10 -> 15
+    # with nothing here noticing), which is the whole reason it is derived.
+    Application.delete_env(:engram, :sync_page_concurrency)
+    pool = Keyword.get(Application.get_env(:engram, Engram.Repo, []), :pool_size, 10)
+
+    assert PageGate.configured_limit() == max(2, div(pool, 3))
+    assert PageGate.configured_limit() < pool, "the gate may not claim the whole pool"
   end
 end

--- a/test/engram_web/controllers/device_auth_controller_test.exs
+++ b/test/engram_web/controllers/device_auth_controller_test.exs
@@ -134,7 +134,9 @@ defmodule EngramWeb.DeviceAuthControllerTest do
       {:ok, auth} = DeviceFlow.start_device_flow("client_1")
 
       conn = post(conn, "/api/auth/device/token", %{device_code: auth.device_code})
-      assert %{"error" => "authorization_pending"} = json_response(conn, 428)
+      # RFC 8628 §3.5: authorization_pending is a 400 with the error in the
+      # body. 428 "Precondition Required" was never part of the device flow.
+      assert %{"error" => "authorization_pending"} = json_response(conn, 400)
     end
 
     test "returns tokens for authorized code", %{conn: conn} do

--- a/test/engram_web/request_logger_test.exs
+++ b/test/engram_web/request_logger_test.exs
@@ -436,6 +436,120 @@ defmodule EngramWeb.RequestLoggerTest do
     assert event.meta[:reason] == nil
   end
 
+  # --- device-flow polling noise (prod 2026-08-13) ---------------------------
+  #
+  # `authorization_pending` is the device flow's HAPPY path: the code is alive
+  # and the human simply has not clicked approve yet. With a 300s code TTL and
+  # a 5s advertised poll interval, ONE successful login emits up to 60 request
+  # logs. Mapping every 4xx to :warning turned that into ~82% of the prod warn
+  # stream and made a textbook login read as an incident (it also feeds the
+  # loki-auth-failure-burst alert). A log level is the claim "a human should
+  # look at this" — the happy path must not spend it.
+
+  test "a device-flow authorization_pending poll logs at :info, not :warning" do
+    conn = %Plug.Conn{
+      method: "POST",
+      request_path: "/api/auth/device/token",
+      query_string: "",
+      status: 400,
+      assigns: %{expected_client_status: true},
+      private: %{
+        phoenix_controller: EngramWeb.DeviceAuthController,
+        phoenix_action: :token
+      }
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 0}, %{conn: conn})
+      end)
+
+    event = find_request_event(events)
+    assert event
+    assert event.level == :info
+  end
+
+  test "a 4xx with no expected-status marker still logs at :warning" do
+    # Boundary: the downgrade is opt-in per response, never blanket-4xx and
+    # never route-shaped — a real client error on the same controller (say a
+    # malformed body) must stay visible.
+    conn = %Plug.Conn{
+      method: "POST",
+      request_path: "/api/auth/device/token",
+      query_string: "",
+      status: 400,
+      assigns: %{},
+      private: %{
+        phoenix_controller: EngramWeb.DeviceAuthController,
+        phoenix_action: :token
+      }
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 0}, %{conn: conn})
+      end)
+
+    event = find_request_event(events)
+    assert event
+    assert event.level == :warning
+  end
+
+  test "device-auth requests carry client ip + user agent for attribution" do
+    # /api/auth/device/token is PUBLIC and pre-auth (user_id is null by
+    # design), so without these there is no way to attribute polling to anyone
+    # — neither to answer "who is calling this" nor to see device-code guessing.
+    conn = %Plug.Conn{
+      method: "POST",
+      request_path: "/api/auth/device/token",
+      query_string: "",
+      status: 400,
+      remote_ip: {203, 0, 113, 7},
+      req_headers: [{"user-agent", "obsidian/1.13.4 engram-vault-sync/1.22.0"}],
+      assigns: %{expected_client_status: true},
+      private: %{
+        phoenix_controller: EngramWeb.DeviceAuthController,
+        phoenix_action: :token
+      }
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 0}, %{conn: conn})
+      end)
+
+    event = find_request_event(events)
+    assert event
+    assert event.meta[:client_ip] == "203.0.113.7"
+    assert event.meta[:user_agent] == "obsidian/1.13.4 engram-vault-sync/1.22.0"
+  end
+
+  test "non-device-auth requests omit client ip + user agent" do
+    # Scoped on purpose: stamping every request line with an IP + UA is bytes
+    # on every log in the system for a forensic need that is specific to the
+    # unauthenticated device-flow endpoints.
+    conn = %Plug.Conn{
+      method: "GET",
+      request_path: "/api/notes",
+      query_string: "",
+      status: 200,
+      remote_ip: {203, 0, 113, 7},
+      req_headers: [{"user-agent", "obsidian/1.13.4"}],
+      assigns: %{},
+      private: %{phoenix_controller: EngramWeb.NotesController, phoenix_action: :index}
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 0}, %{conn: conn})
+      end)
+
+    event = find_request_event(events)
+    assert event
+    assert event.meta[:client_ip] == nil
+    assert event.meta[:user_agent] == nil
+  end
+
   defp find_request_event(events) do
     Enum.find(events, fn e ->
       msg = render_msg(e.msg)

--- a/test/engram_web/request_logger_test.exs
+++ b/test/engram_web/request_logger_test.exs
@@ -495,10 +495,9 @@ defmodule EngramWeb.RequestLoggerTest do
     assert event.level == :warning
   end
 
-  test "device-auth requests carry client ip + user agent for attribution" do
+  test "device-auth requests carry the user agent for attribution" do
     # /api/auth/device/token is PUBLIC and pre-auth (user_id is null by
-    # design), so without these there is no way to attribute polling to anyone
-    # — neither to answer "who is calling this" nor to see device-code guessing.
+    # design), so without this there is no way to tell which client is polling.
     conn = %Plug.Conn{
       method: "POST",
       request_path: "/api/auth/device/token",
@@ -520,14 +519,17 @@ defmodule EngramWeb.RequestLoggerTest do
 
     event = find_request_event(events)
     assert event
-    assert event.meta[:client_ip] == "203.0.113.7"
     assert event.meta[:user_agent] == "obsidian/1.13.4 engram-vault-sync/1.22.0"
+
+    # config/prod.exs states the standing policy that client IPs stay OUT of
+    # Loki. Pinned so a future "just add the IP" cannot land silently.
+    assert event.meta[:client_ip] == nil
   end
 
-  test "non-device-auth requests omit client ip + user agent" do
-    # Scoped on purpose: stamping every request line with an IP + UA is bytes
-    # on every log in the system for a forensic need that is specific to the
-    # unauthenticated device-flow endpoints.
+  test "non-device-auth requests omit the user agent" do
+    # Scoped on purpose: stamping every request line with a UA is bytes on
+    # every log in the system for a need specific to the unauthenticated
+    # device-flow endpoints.
     conn = %Plug.Conn{
       method: "GET",
       request_path: "/api/notes",
@@ -546,7 +548,6 @@ defmodule EngramWeb.RequestLoggerTest do
 
     event = find_request_event(events)
     assert event
-    assert event.meta[:client_ip] == nil
     assert event.meta[:user_agent] == nil
   end
 

--- a/test/engram_web/request_logger_test.exs
+++ b/test/engram_web/request_logger_test.exs
@@ -442,9 +442,8 @@ defmodule EngramWeb.RequestLoggerTest do
   # and the human simply has not clicked approve yet. With a 300s code TTL and
   # a 5s advertised poll interval, ONE successful login emits up to 60 request
   # logs. Mapping every 4xx to :warning turned that into ~82% of the prod warn
-  # stream and made a textbook login read as an incident (it also feeds the
-  # loki-auth-failure-burst alert). A log level is the claim "a human should
-  # look at this" — the happy path must not spend it.
+  # stream and made a textbook login read as an incident. A log level is the
+  # claim "a human should look at this" — the happy path must not spend it.
 
   test "a device-flow authorization_pending poll logs at :info, not :warning" do
     conn = %Plug.Conn{
@@ -467,6 +466,84 @@ defmodule EngramWeb.RequestLoggerTest do
     event = find_request_event(events)
     assert event
     assert event.level == :info
+  end
+
+  test "a downgraded response still ships to Loki" do
+    # Quieting the LEVEL must not silently DELETE the record.
+    # Category.loki_ship?(:info, :http) is false, so without an explicit
+    # override the downgrade would drop device-token lines out of Loki
+    # entirely — an operator debugging "linking is stuck" would find nothing,
+    # which is worse than the warn noise this replaces.
+    conn = %Plug.Conn{
+      method: "POST",
+      request_path: "/api/auth/device/token",
+      query_string: "",
+      status: 400,
+      assigns: %{expected_client_status: true},
+      private: %{
+        phoenix_controller: EngramWeb.DeviceAuthController,
+        phoenix_action: :token
+      }
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 0}, %{conn: conn})
+      end)
+
+    event = find_request_event(events)
+    assert event
+    assert event.level == :info
+    assert event.meta[:loki_ship] == true
+  end
+
+  test "an ordinary :info request line is NOT force-shipped" do
+    # Boundary: the override rides the marker, not the level. A 2xx :http line
+    # must keep its normal (false) routing or the override becomes a firehose.
+    conn = %Plug.Conn{
+      method: "GET",
+      request_path: "/api/notes",
+      query_string: "",
+      status: 200,
+      assigns: %{},
+      private: %{phoenix_controller: EngramWeb.NotesController, phoenix_action: :index}
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 0}, %{conn: conn})
+      end)
+
+    event = find_request_event(events)
+    assert event
+    assert event.meta[:loki_ship] == false
+  end
+
+  test "an over-long user agent is truncated before it reaches the log" do
+    # Unauthenticated trust boundary: the header is attacker-controlled and
+    # RedactFilter neither scrubs nor bounds it, so an unbounded value would
+    # let a caller push ~10KB per request into a hosted aggregator.
+    conn = %Plug.Conn{
+      method: "POST",
+      request_path: "/api/auth/device/token",
+      query_string: "",
+      status: 400,
+      req_headers: [{"user-agent", String.duplicate("A", 5_000)}],
+      assigns: %{expected_client_status: true},
+      private: %{
+        phoenix_controller: EngramWeb.DeviceAuthController,
+        phoenix_action: :token
+      }
+    }
+
+    {_, events} =
+      LogCapture.with_events(fn ->
+        :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 0}, %{conn: conn})
+      end)
+
+    event = find_request_event(events)
+    assert event
+    assert String.length(event.meta[:user_agent]) == 200
   end
 
   test "a 4xx with no expected-status marker still logs at :warning" do
@@ -522,8 +599,15 @@ defmodule EngramWeb.RequestLoggerTest do
     assert event.meta[:user_agent] == "obsidian/1.13.4 engram-vault-sync/1.22.0"
 
     # config/prod.exs states the standing policy that client IPs stay OUT of
-    # Loki. Pinned so a future "just add the IP" cannot land silently.
-    assert event.meta[:client_ip] == nil
+    # Loki. Asserting `meta[:client_ip] == nil` would be a tautology (nothing
+    # sets that key, and a future addition would likely pick another name), so
+    # scan every emitted VALUE for an IP-shaped string instead — that fails
+    # whatever key the address is smuggled in under.
+    ip_like = ~r/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
+
+    for {k, v} <- event.meta, is_binary(v) do
+      refute v =~ ip_like, "metadata #{inspect(k)} carries an IP-shaped value: #{inspect(v)}"
+    end
   end
 
   test "non-device-auth requests omit the user agent" do


### PR DESCRIPTION
## Why

Prod 2026-08-13. A device login *looked* like an incident: `POST 428` every 5
seconds in the warn stream, from a caller we could not identify. I reported it
to the user as "a device is stuck, logged out."

It wasn't. Tracing it end to end showed a completely **normal, successful
login**:

| Time (UTC) | Event |
|---|---|
| 19:27:32 | `POST /api/auth/device` — code minted |
| 19:28:37 → 19:33:12 | poll every 5s, each `428 authorization_pending` |
| **19:33:17** | poll **succeeded** — that trace writes `device_refresh_tokens` |
| 19:48:17 | `POST /api/auth/token/refresh` — device healthy since |

Nothing was broken. The telemetry lied, for three separate reasons.

## 1. The happy path logged at `:warning`

`authorization_pending` means the code is alive and the human has not clicked
approve yet. `RequestLogger` maps every 4xx to `:warning`, so with a **300s
code TTL** and a **5s advertised poll interval**, one successful login emits up
to **60 warnings**. In the observed window that was **~82% of the entire warn
stream**, and it feeds the already-noisy `loki-auth-failure-burst` alert.

A log level is the claim *"a human should look at this."* Spending it on a
happy path is how a working system reads as an incident — as this one did, to
me, in this session.

Controllers can now mark a response `:expected_client_status` and
`RequestLogger` emits it at `:info`. **Opt-in per response, set server-side** —
never blanket-4xx and never keyed on route+status, so a genuine client error on
the same endpoint still surfaces at `:warning`. 5xx is never downgradable.

## 2. The endpoint was unattributable

`/api/auth/device/token` is public and pre-auth, so `user_id` is null by design
and the log line carried no IP and no user agent. There was no way to trace
polling to anyone — not to answer "who is calling this", and not to see
device-code guessing if it ever happened.

Device-auth request logs now carry `user_agent`, **scoped to that controller**
so every other log line in the system stays the same size.

**No client IP — deliberately, and this changed mid-PR.** My first pass logged
one. Proving the change against a real dev server surfaced that `config/prod.exs`
states a standing policy in its own comment: *request headers and client IPs
stay OUT of Loki.* That is the stated reason prod excludes
`Sentry.PlugContext`'s `:__sentry__` blob, and `Engram.Sentry.Scrubber` drops
`event.request` wholesale on the same grounds.

The codebase does record client IPs — as purpose-built DB columns with a
lifecycle (`onboarding/agreement.ex` `ip_address`, `oauth_register_controller`
`first_ip`) — not sprayed across a hosted, long-retention aggregator. So the IP
is gone and **a test now pins its absence** so a future "just add the IP" cannot
land silently. If per-source correlation is ever needed for device-code
guessing, the answer is a keyed digest via `Engram.Crypto.HMAC`.

## 3. `428` was never the spec status

RFC 8628 §3.5 returns `authorization_pending` as a **400** with the error in the
body. `428 Precondition Required` is not part of the device flow. Flipped.

**Nothing strands.** Every consumer of the old status was inventoried:

| Consumer | Before | After |
|---|---|---|
| `device_auth_controller.ex` | returns 428 | returns 400 |
| `device_auth_controller_test.exs` | asserts 428 | asserts 400 |
| `e2e/helpers/device_flow.py` | `== 428` | `in (400, 428)` |
| `e2e/tests/api_only/test_71_connections.py` | `== 428` | `in (400, 428)` |
| plugin `device-flow-modal.ts` | `=== 428` | `400 \|\| 428` (Engram-obsidian#424) |

Already-installed plugin builds are unaffected: an unrecognised status falls
through to "keep polling", so the loop continues and the 2xx branch still
completes the login. The e2e helpers accept **both** so they work against either
side of a paired backend/plugin rollout.

## Tests

TDD, three watched red first:
- `returns authorization_pending for pending code` — failed `got: 428`
- `a device-flow authorization_pending poll logs at :info` — failed `left: :warning`
- `device-auth requests carry the user agent` — failed `left: nil`

Two boundary guards **passed from the start** and must keep passing:
- `a 4xx with no expected-status marker still logs at :warning`
- `non-device-auth requests omit the user agent`

`mix format` + `mix credo --strict` (no issues) + `mix dialyzer` (clean) +
`mix test --warnings-as-errors`: **4321 tests, 0 failures**.

## Noticed, deliberately not fixed here

`onboarding_controller.ex:74` and `oauth_token_controller.ex:16` stamp
`RequestMeta.format_ip(conn.remote_ip)` onto persisted rows. Per `RemoteIp`'s
own moduledoc that is the **ALB's private IP** in prod, not the client's — so
ToS-agreement and OAuth-token provenance may be recording the load balancer.
Out of scope for this PR; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC



## Verified against a real dev server

Not just unit tests — `make saas-dev BACKEND_DIR=<this worktree>`, with the
Phoenix pid's `/proc/<pid>/cwd` checked against the worktree so a port
answering 200 could not be mistaken for "serving my code":

| Case | HTTP | Log level |
|---|---|---|
| before (`main` @ 8b8ddadb), pending poll | `428` | `[warning]` |
| after, pending poll | **`400`** | **`[info]`** |
| after, bogus device code — real client error, same route | `410` | **`[warning]`** |

That last row is the one that matters: the downgrade is scoped to the marked
response, not to the route or to 4xx in general.