### PR TITLE
fix(folders): re-assert folder membership at delete time

### DIFF
--- a/lib/engram/folders.ex
+++ b/lib/engram/folders.ex
@@ -161,12 +161,16 @@ defmodule Engram.Folders do
     end
   end
 
-  defp delete_scanned(user, vault, note_rows, att_paths, notes) do
-    with {:ok, %{deleted: _}} <- Notes.delete_scanned(user, vault, note_rows),
+  defp delete_scanned(user, vault, note_rows, att_paths, _scanned_notes) do
+    with {:ok, %{notes: notes}} <- Notes.delete_scanned(user, vault, note_rows),
          {:ok, a} <- Attachments.delete_scanned_paths(user, vault, att_paths) do
-      # Notes.delete_folder's `deleted` includes folder markers; report
-      # the content-note count already computed so the caller sees
-      # notes, not markers.
+      # `notes` comes from what was ACTUALLY deleted, not from the pre-delete
+      # scan. Since #1346 the membership fence can skip a row that moved in the
+      # gap, so the scan count is aspirational — a concurrent folder rename
+      # re-keys every descendant's folder_hmac and the delete legitimately
+      # removes nothing, while the scan still said 3. The attachment leg on the
+      # same tuple has always counted real removals; reporting one true number
+      # beside one hopeful one is worse than either.
       {:ok, %{notes: notes, attachments: a}}
     end
   end

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -4797,24 +4797,53 @@ defmodule Engram.Notes do
       now = DateTime.utc_now()
       ids = Enum.map(matches, & &1.id)
 
-      {real_notes, markers} = Enum.split_with(matches, fn r -> r.kind == "note" end)
+      # Re-assert folder membership at WRITE time, on the pre-image the scan
+      # read. #1334 closed the create-in-the-gap race by deleting by id from a
+      # single scan; that traded it for the opposite one — under READ COMMITTED
+      # a concurrent same-user transaction can move a note OUT of the folder
+      # between `scan_folders/3` and here, and an id-only WHERE still deletes
+      # it. The user loses a note from a folder they never asked to touch.
+      #
+      # Fencing on `folder_hmac` rather than re-deriving the folder keeps this
+      # a pure predicate on the row: a move re-keys folder_hmac (every writer
+      # goes through phase_b_keyword_for/5 or phase_b_path_folder_for/4, both
+      # of which set it), so the moved row no longer matches any hmac the scan
+      # saw. An in-place EDIT does not touch folder_hmac, so it still matches
+      # and is still deleted — the fence must catch moves, not writes. #1346.
+      folder_hmacs =
+        matches |> Enum.map(& &1.folder_hmac) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
-      Repo.with_tenant(user.id, fn ->
-        seq = Engram.Vaults.next_seq!(vault.id)
+      {:ok, deleted_ids} =
+        Repo.with_tenant(user.id, fn ->
+          seq = Engram.Vaults.next_seq!(vault.id)
 
-        {updated, _} =
-          from(n in Note,
-            where: n.id in ^ids and is_nil(n.deleted_at)
-          )
-          |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
+          # `select:` so the side effects below run on what was ACTUALLY
+          # deleted. Driving them off `matches` was survivable while the WHERE
+          # was id-only (the two sets were identical); with a fence that can
+          # skip rows it is not — the meter would over-decrement, and worse,
+          # the broadcast loop would tell every client to delete a note that
+          # is still live at its new path.
+          {_updated, returned_ids} =
+            from(n in Note,
+              where: n.id in ^ids and n.folder_hmac in ^folder_hmacs and is_nil(n.deleted_at),
+              select: n.id
+            )
+            |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
 
-        # Decrement only real notes — markers don't count against the meter.
-        # `updated` may include both kinds; recompute live-real-note count from
-        # the matched set so the meter delta lines up with notes_count semantics.
-        real_count = length(real_notes)
-        if real_count > 0, do: :ok = UsageMeters.dec_notes_count(user.id, real_count)
-        updated
-      end)
+          deleted = MapSet.new(returned_ids)
+
+          # Decrement only real notes — markers don't count against the meter.
+          real_count =
+            Enum.count(matches, fn r -> r.kind == "note" and MapSet.member?(deleted, r.id) end)
+
+          if real_count > 0, do: :ok = UsageMeters.dec_notes_count(user.id, real_count)
+          deleted
+        end)
+
+      {real_notes, markers} =
+        matches
+        |> Enum.filter(&MapSet.member?(deleted_ids, &1.id))
+        |> Enum.split_with(fn r -> r.kind == "note" end)
 
       # Side effects outside the transaction context, so they never fire if
       # the update_all above rolled back. Qdrant cleanup + broadcasts.
@@ -4844,7 +4873,9 @@ defmodule Engram.Notes do
         :ok = broadcast_change(user.id, vault.id, "delete", marker.folder, nil, [])
       end)
 
-      {:ok, %{deleted: length(matches)}}
+      # The count the caller reports to the user. `length(matches)` was the
+      # scanned set, which is only the deleted set when nothing raced.
+      {:ok, %{deleted: MapSet.size(deleted_ids)}}
     end
   end
 

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -4684,8 +4684,11 @@ defmodule Engram.Notes do
   filters by exact-match-or-prefix on `folder`, then bulk-updates
   `deleted_at` in one `update_all`.
 
-  Returns `{:ok, %{deleted: count}}` where count includes the folder
-  marker (if present) plus every descendant note and sub-marker. A folder
+  Returns `{:ok, %{deleted: count}}` where count is what was ACTUALLY
+  soft-deleted: the folder marker (if present) plus every descendant note and
+  sub-marker that still belonged to the folder at write time. Since #1346 a row
+  that moved between the scan and the write is fenced out, so this can be lower
+  than the scan matched — it is a count of removals, not of candidates. A folder
   that doesn't exist (no marker AND no notes underneath) returns
   `{:ok, %{deleted: 0}}` — same idempotency contract as `rename_folder/4`,
   which returns `{:ok, 0}` for an empty target.
@@ -4709,7 +4712,7 @@ defmodule Engram.Notes do
   (after-commit hooks) is tracked as a follow-up.
   """
   @spec delete_folder(map(), map(), String.t()) ::
-          {:ok, %{deleted: non_neg_integer()}} | {:error, term()}
+          {:ok, %{deleted: non_neg_integer(), notes: non_neg_integer()}} | {:error, term()}
   def delete_folder(user, vault, folder) when is_binary(folder) do
     with {:ok, user} <- Crypto.ensure_user_dek(user) do
       do_delete_folder(user, vault, folder)
@@ -4782,9 +4785,16 @@ defmodule Engram.Notes do
   @doc """
   Soft-deletes rows produced by `scan_folders/3`, with the usual meter
   decrement, Qdrant cleanup enqueue and `note_changed` broadcasts.
+
+  Re-asserts folder membership at write time (#1346), so a row that moved
+  between the scan and here is skipped rather than deleted from a folder the
+  caller never named. `:deleted` counts every row removed (notes + markers),
+  `:notes` only the content notes — both measured from what the write actually
+  touched, which is what the side effects here are driven from.
   """
   # No error branch: every failure inside is a raise, not a tuple.
-  @spec delete_scanned(map(), map(), [map()]) :: {:ok, %{deleted: non_neg_integer()}}
+  @spec delete_scanned(map(), map(), [map()]) ::
+          {:ok, %{deleted: non_neg_integer(), notes: non_neg_integer()}}
   def delete_scanned(user, vault, matches) do
     # `Links.basename_hmac/2` below needs the DEK, and callers reach here with
     # the struct they started with — the same staleness `scan_folders/3`
@@ -4792,45 +4802,31 @@ defmodule Engram.Notes do
     user = Crypto.fresh_user(user)
 
     if matches == [] do
-      {:ok, %{deleted: 0}}
+      {:ok, %{deleted: 0, notes: 0}}
     else
       now = DateTime.utc_now()
-      ids = Enum.map(matches, & &1.id)
-
-      # Re-assert folder membership at WRITE time, on the pre-image the scan
-      # read. #1334 closed the create-in-the-gap race by deleting by id from a
-      # single scan; that traded it for the opposite one — under READ COMMITTED
-      # a concurrent same-user transaction can move a note OUT of the folder
-      # between `scan_folders/3` and here, and an id-only WHERE still deletes
-      # it. The user loses a note from a folder they never asked to touch.
-      #
-      # Fencing on `folder_hmac` rather than re-deriving the folder keeps this
-      # a pure predicate on the row: a move re-keys folder_hmac (every writer
-      # goes through phase_b_keyword_for/5 or phase_b_path_folder_for/4, both
-      # of which set it), so the moved row no longer matches any hmac the scan
-      # saw. An in-place EDIT does not touch folder_hmac, so it still matches
-      # and is still deleted — the fence must catch moves, not writes. #1346.
-      folder_hmacs =
-        matches |> Enum.map(& &1.folder_hmac) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
       {:ok, deleted_ids} =
         Repo.with_tenant(user.id, fn ->
           seq = Engram.Vaults.next_seq!(vault.id)
 
-          # `select:` so the side effects below run on what was ACTUALLY
-          # deleted. Driving them off `matches` was survivable while the WHERE
-          # was id-only (the two sets were identical); with a fence that can
-          # skip rows it is not — the meter would over-decrement, and worse,
-          # the broadcast loop would tell every client to delete a note that
-          # is still live at its new path.
-          {_updated, returned_ids} =
-            from(n in Note,
-              where: n.id in ^ids and n.folder_hmac in ^folder_hmacs and is_nil(n.deleted_at),
-              select: n.id
-            )
-            |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
+          # Chunked for the reason `@rename_update_chunk` already documents in
+          # this module: each statement binds its rows' ids AND their folder
+          # hmacs, so an unchunked delete of a deep tree walks into Postgres's
+          # 65535-parameter ceiling — and carrying the hmac list moved that wall
+          # closer than the id list alone did. Chunking `matches` rather than
+          # `ids` keeps each statement's hmac list scoped to its own rows.
+          deleted =
+            matches
+            |> Enum.chunk_every(@rename_update_chunk)
+            |> Enum.reduce(MapSet.new(), fn chunk, acc ->
+              {_updated, returned_ids} =
+                chunk
+                |> fenced_delete_query()
+                |> Repo.update_all(set: [deleted_at: now, updated_at: now, seq: seq])
 
-          deleted = MapSet.new(returned_ids)
+              MapSet.union(acc, MapSet.new(returned_ids))
+            end)
 
           # Decrement only real notes — markers don't count against the meter.
           real_count =
@@ -4839,6 +4835,8 @@ defmodule Engram.Notes do
           if real_count > 0, do: :ok = UsageMeters.dec_notes_count(user.id, real_count)
           deleted
         end)
+
+      log_fenced_skips(user, vault, matches, deleted_ids)
 
       {real_notes, markers} =
         matches
@@ -4873,10 +4871,61 @@ defmodule Engram.Notes do
         :ok = broadcast_change(user.id, vault.id, "delete", marker.folder, nil, [])
       end)
 
-      # The count the caller reports to the user. `length(matches)` was the
-      # scanned set, which is only the deleted set when nothing raced.
-      {:ok, %{deleted: MapSet.size(deleted_ids)}}
+      # The counts the caller reports to the user. `length(matches)` was the
+      # scanned set, which equals the deleted set only when nothing raced.
+      # `:notes` excludes markers so `Folders.delete/4` can report content
+      # notes without recounting a set it no longer owns.
+      {:ok, %{deleted: MapSet.size(deleted_ids), notes: length(real_notes)}}
     end
+  end
+
+  # The fence skipping a row is the ONLY in-prod evidence that the #1346 race
+  # is real, and the row it spares becomes a live note whose ancestor folder
+  # markers were just deleted — an orphan, exactly the shape
+  # `Folders.log_orphaned_attachments/4` refuses to let pass silently.
+  #
+  # Two distinct causes land here and the log does not try to tell them apart,
+  # because the operator response is the same (look at the note, it is intact):
+  #
+  #   1. A move OUT of the tree — the case this fence exists for.
+  #   2. A move deeper INSIDE the tree, into a folder created after the scan.
+  #      The predicate is membership in the hmacs the scan OBSERVED, not "under
+  #      the target prefix" — and it cannot be the latter, because `folder` is
+  #      HMAC'd and SQL cannot prefix-match a keyed hash. So `Docs/a.md` moving
+  #      to `Docs/new-sub/a.md` mid-delete is skipped even though it is still
+  #      inside the tree the user asked to delete. Fail-safe (the note lives)
+  #      and self-healing (a fresh scan sees it), but it is a real skip class.
+  defp log_fenced_skips(user, vault, matches, deleted_ids) do
+    skipped = Enum.reject(matches, &MapSet.member?(deleted_ids, &1.id))
+
+    if skipped != [] do
+      Logger.warning(
+        "folder delete: membership fence skipped rows — they moved between scan and delete",
+        Metadata.with_category(:warning, :sync,
+          user_id: user.id,
+          vault_id: vault.id,
+          scanned: length(matches),
+          deleted: MapSet.size(deleted_ids),
+          skipped: length(skipped)
+        )
+      )
+    end
+
+    :ok
+  end
+
+  # The membership fence itself. `folder_hmac` is NOT NULL for both `kind`s by
+  # check constraint (`notes_kind_shape_check`, validated in the empty-folders
+  # phase-2 migration), so the hmac list can never contain a nil that would
+  # silently drop a row from the match set.
+  defp fenced_delete_query(chunk) do
+    ids = Enum.map(chunk, & &1.id)
+    hmacs = chunk |> Enum.map(& &1.folder_hmac) |> Enum.uniq()
+
+    from(n in Note,
+      where: n.id in ^ids and n.folder_hmac in ^hmacs and is_nil(n.deleted_at),
+      select: n.id
+    )
   end
 
   @doc """

--- a/test/engram/folders_test.exs
+++ b/test/engram/folders_test.exs
@@ -414,6 +414,67 @@ defmodule Engram.FoldersTest do
                Attachments.list_attachments_strict(user, vault)
     end
 
+    # #1334 closed the create-in-the-gap race by scanning once and deleting by
+    # id from that scan. This is the opposite race it traded for: under READ
+    # COMMITTED each statement takes its own snapshot, so a concurrent same-user
+    # transaction can move a note OUT of the folder after `scan_folders/3`
+    # captured its id and before `delete_scanned/3` applies. The id is still in
+    # the match set, so the note is deleted from a folder the user never asked
+    # to touch.
+    #
+    # Driving scan and delete as separate calls with a move between them is the
+    # race made deterministic — it is the exact interleaving, minus the
+    # scheduling luck needed to hit it with real concurrency.
+    test "a note moved out between scan and delete is NOT deleted", %{user: user, vault: vault} do
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "Docs/a.md", "content" => "x", "mtime" => 1.0})
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "Docs/b.md", "content" => "y", "mtime" => 1.0})
+
+      {:ok, matches} = Notes.scan_folders(user, vault, ["Docs"])
+      assert Enum.count(matches, &(&1.kind == "note")) == 2
+
+      # The concurrent transaction commits here.
+      {:ok, _} = Notes.rename_note(user, vault, "Docs/a.md", "Archive/a.md")
+
+      {:ok, %{deleted: _}} = Notes.delete_scanned(user, vault, matches)
+
+      # The moved note lives in a folder that was never targeted.
+      assert {:ok, _} = Notes.get_note(user, vault, "Archive/a.md")
+
+      # ...and the delete still did its job for what genuinely remained.
+      assert {:error, :not_found} = Notes.get_note(user, vault, "Docs/b.md")
+    end
+
+    # The fence must re-assert membership, not merely count rows: a same-folder
+    # write between scan and delete changes seq/updated_at but not folder_hmac,
+    # so it must NOT be mistaken for a move and skipped.
+    test "a note edited in place between scan and delete is still deleted", %{
+      user: user,
+      vault: vault
+    } do
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "Docs/a.md", "content" => "x", "mtime" => 1.0})
+
+      {:ok, matches} = Notes.scan_folders(user, vault, ["Docs"])
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{
+          "path" => "Docs/a.md",
+          "content" => "edited",
+          "mtime" => 2.0
+        })
+
+      {:ok, %{deleted: _}} = Notes.delete_scanned(user, vault, matches)
+
+      assert {:error, :not_found} = Notes.get_note(user, vault, "Docs/a.md")
+    end
+
     # The first attempt at the fix above applied the fail-closed check to the
     # WHOLE vault before filtering by folder, so one corrupt row anywhere made
     # every folder delete in the vault fail — including recursive. Worse than

--- a/test/engram/folders_test.exs
+++ b/test/engram/folders_test.exs
@@ -449,6 +449,59 @@ defmodule Engram.FoldersTest do
       assert {:error, :not_found} = Notes.get_note(user, vault, "Docs/b.md")
     end
 
+    # The count reaching the user has to come from the write, not the scan.
+    # A concurrent folder RENAME re-keys folder_hmac on every descendant, so
+    # the fence legitimately removes nothing — and reporting the scan's count
+    # would tell the user "3 notes removed" when the answer is zero.
+    test "reports notes actually deleted, not notes scanned", %{user: user, vault: vault} do
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "Docs/a.md", "content" => "x", "mtime" => 1.0})
+
+      {:ok, matches} = Notes.scan_folders(user, vault, ["Docs"])
+      {:ok, _} = Notes.rename_note(user, vault, "Docs/a.md", "Archive/a.md")
+
+      assert {:ok, %{deleted: 0, notes: 0}} = Notes.delete_scanned(user, vault, matches)
+    end
+
+    # The fence firing is the only in-prod evidence the race is real, and it
+    # leaves a live note under a folder whose markers were just removed.
+    test "logs a warning when the fence skips a row", %{user: user, vault: vault} do
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "Docs/a.md", "content" => "x", "mtime" => 1.0})
+
+      {:ok, matches} = Notes.scan_folders(user, vault, ["Docs"])
+      {:ok, _} = Notes.rename_note(user, vault, "Docs/a.md", "Archive/a.md")
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          {:ok, _} = Notes.delete_scanned(user, vault, matches)
+        end)
+
+      assert log =~ "membership fence skipped rows"
+    end
+
+    # A clean delete must stay quiet — a warning on every folder delete would
+    # train the operator to ignore the one that matters.
+    test "logs nothing when the fence skips nothing", %{user: user, vault: vault} do
+      {:ok, user} = Engram.Crypto.ensure_user_dek(user)
+
+      {:ok, _} =
+        Notes.upsert_note(user, vault, %{"path" => "Docs/a.md", "content" => "x", "mtime" => 1.0})
+
+      {:ok, matches} = Notes.scan_folders(user, vault, ["Docs"])
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          {:ok, %{notes: 1}} = Notes.delete_scanned(user, vault, matches)
+        end)
+
+      refute log =~ "membership fence skipped rows"
+    end
+
     # The fence must re-assert membership, not merely count rows: a same-folder
     # write between scan and delete changes seq/updated_at but not folder_hmac,
     # so it must NOT be mistaken for a move and skipped.


### PR DESCRIPTION
## The race

#1334 closed the create-in-the-gap race by scanning once and deleting by id from that scan. Under READ COMMITTED that trades it for the opposite one:

1. `scan_folders(user, vault, ["Docs"])` captures `Docs/a.md` (id X)
2. A concurrent same-user transaction moves `Docs/a.md` → `Archive/a.md` and commits
3. `delete_scanned` soft-deletes id X

The user loses a note from `Archive/`, a folder they never asked to touch.

## The fix

`delete_scanned/3` now re-asserts folder membership at **write** time, fencing on the `folder_hmac` pre-image the scan read:

```elixir
where: n.id in ^ids and n.folder_hmac in ^folder_hmacs and is_nil(n.deleted_at)
```

`folder_hmac` is the right field rather than a re-derived folder string, because it is a pure predicate on the row and every writer re-keys it (`phase_b_keyword_for/5`, `phase_b_path_folder_for/4`). A **move** changes it, so the moved row matches no hmac the scan saw. An **in-place edit** does not, so it still matches and is still deleted. The fence has to catch moves without catching writes, and that distinction is exactly what this column encodes.

## Why the predicate alone would have been half a fix

The meter decrement, the delete broadcasts and the returned count all keyed off the **scanned** set. That was survivable only because the old `WHERE` was id-only, which made scanned and deleted the same set by construction. A fence that can skip rows breaks that equality, and the consequences are asymmetric:

- the meter over-decrements (annoying, self-corrects on reconcile)
- **the broadcast loop tells every connected client to delete a note that is still live at its new path** — which converts a server-side skip into client-side data loss, i.e. the exact failure this PR exists to prevent, re-entering through the side door

So `update_all` now carries `select: n.id` and every side effect runs off the ids actually touched. `{:ok, %{deleted: n}}` also becomes truthful; it previously reported `length(matches)`.

## Tests

Both written first and watched fail for the right reason.

- **`a note moved out between scan and delete is NOT deleted`** — drives scan and delete as separate calls with a `rename_note` between them. That is the real interleaving made deterministic, minus the scheduling luck needed to hit it with threads. Before the fix it failed on `Notes.get_note(user, vault, "Archive/a.md")` returning `{:error, :not_found}` — the reported bug, reproduced.
- **`a note edited in place between scan and delete is still deleted`** — the over-fencing guard. A same-folder write changes `seq`/`updated_at` but not `folder_hmac`, and must not be mistaken for a move.

## Verification

Run sequentially on `main` @ `8b8ddadb`:

| gate | result |
|---|---|
| `mix format` | clean |
| `mix credo --strict` | 4474 mods/funs, no issues |
| `mix test --warnings-as-errors` | 1 property, **4319 tests, 0 failures** |
| `mix dialyzer` | passed (5 skipped, baseline) |

## Note for review

Rows with a NULL `folder_hmac` are excluded from the hmac list and would therefore be skipped by the fence. Every current writer sets the column, so this should be unreachable — but it is a fail-safe direction (does not delete) rather than fail-open, and it is the one input I would most like a second opinion on.

Closes #1346
