### PR TITLE
fix(sync): serve the CRDT authority when the content facade lags

### DIFF
--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -83,6 +83,16 @@ defmodule Engram.Notes do
   # silently undone by a stale re-push from another device that still holds the
   # note (the cross-device resurrection race). A byte-different note or a
   # tombstone older than the window is allowed through as a genuine re-create.
+  # Notes resolved per transaction on the change feed. `Repo.with_tenant` takes
+  # Ecto's default 15s timeout, and each resolution is a decrypt + Yjs NIF
+  # rebuild + tail query + projection — so an unchunked 500-row page of stale
+  # notes (what a folder rename produces) could exceed it. A timeout there is
+  # not a transient: the feed is keyset-ordered, so every retry hits the same
+  # page and fails identically, which is the permanent catch-up wedge the
+  # degrade-to-façade clauses exist to avoid. Each chunk still reads its
+  # snapshot and tail in ONE transaction, which is where the atomicity lives.
+  @resolve_chunk 50
+
   @delete_tombstone_window_seconds 60
 
   @doc """
@@ -3690,6 +3700,14 @@ defmodule Engram.Notes do
     # note with uncheckpointed ops serves a body that lags — and when it lags
     # all the way to "", the client creates a 0-byte file and pushes the empty
     # hash back. Resolve the authority for exactly those notes, once per page.
+    # Interleave point (tests only; the hook is nil everywhere else). A
+    # checkpoint committing HERE — after the page SELECT, before resolution —
+    # folds the tail into a new snapshot and prunes it. The resolution must
+    # therefore re-read the row rather than trust what the page captured, or it
+    # rebuilds from a pre-checkpoint snapshot with an empty tail and projects
+    # "". See `notes_feed_interleave_test.exs`.
+    interleave_hook(:feed_after_page_read)
+
     resolved = resolve_stale_page(user, decrypted, fields)
 
     changes =
@@ -3709,8 +3727,9 @@ defmodule Engram.Notes do
   end
 
   # Resolves the authority for every note on this page whose façade lags,
-  # returning %{note_id => {content, content_hash}}. Notes absent from the map
-  # keep their façade values.
+  # returning %{note_id => content}. Only the BODY is resolved — `content_hash`
+  # is always the façade's (see `feed_pair/3`). Notes absent from the map keep
+  # their façade content.
   #
   # `fields: :meta` never resolves: its projection does not even select
   # `crdt_state_ciphertext`, and it promises `content: nil` with the row's own
@@ -3722,13 +3741,17 @@ defmodule Engram.Notes do
     # structural docs: a `.canvas` keeps its data in Y.Maps, not the markdown
     # Y.Text, so `project_doc` returns "" and would replace the façade — the
     # only non-Yjs copy of the board — with an empty body under a matching hash.
-    candidates = Enum.filter(notes, &(&1.kind == "note" and markdown_path?(&1.path)))
-
-    # Tombstones never prune their tail (`delete_note/4` only sets deleted_at;
-    # the FK cascade is hard-delete only), so without this every catch-up page
-    # carrying that tombstone would rebuild a doc forever — and ship a
-    # resurrected body on a `deleted: true` row.
-    candidates = Enum.reject(candidates, &(not is_nil(&1.deleted_at)))
+    #
+    # Tombstones are excluded in the same pass: they never prune their tail
+    # (`delete_note/4` only sets deleted_at; the FK cascade is hard-delete
+    # only), so a tombstone would be permanently "stale" — rebuilding a doc on
+    # every page that carries it, and shipping a resurrected body on a
+    # `deleted: true` row.
+    candidates =
+      Enum.filter(
+        notes,
+        &(&1.kind == "note" and markdown_path?(&1.path) and is_nil(&1.deleted_at))
+      )
 
     case candidates do
       [] ->
@@ -3764,41 +3787,92 @@ defmodule Engram.Notes do
   # `docs/context/worker-reads-stale-content-facade.md`.
   defp resolve_stale_candidates(user, candidates) do
     by_id = Map.new(candidates, &{&1.id, &1})
-    ids = Map.keys(by_id)
 
+    by_id
+    |> Map.keys()
+    |> Enum.chunk_every(@resolve_chunk)
+    |> Enum.reduce(%{}, fn chunk, acc -> Map.merge(acc, resolve_chunk(user, by_id, chunk)) end)
+    |> Enum.reject(&match?({_, nil}, &1))
+    |> Map.new()
+  end
+
+  defp resolve_chunk(user, by_id, ids) do
     {:ok, resolved} =
       Repo.with_tenant(user.id, fn ->
-        stale_ids =
-          Repo.all(
-            from(l in CrdtUpdateLog, where: l.note_id in ^ids, distinct: true, select: l.note_id)
+        # `count`, not just the id: `replay_tail/3` logs-and-skips a tail row it
+        # cannot decrypt, so knowing how many rows EXIST is what lets
+        # `project_resolved/5` tell a complete replay from a truncated one.
+        tail_counts =
+          from(l in CrdtUpdateLog,
+            where: l.note_id in ^ids,
+            group_by: l.note_id,
+            select: {l.note_id, count(l.id)}
           )
-
-        fresh_rows =
-          Repo.all(from(n in Note, where: n.id in ^stale_ids, select: {n.id, n}))
+          |> Repo.all()
           |> Map.new()
 
-        Enum.reduce(stale_ids, %{}, fn id, acc ->
-          case Map.fetch(fresh_rows, id) do
-            {:ok, row} -> Map.put(acc, id, resolve_one(user, by_id[id], row))
-            :error -> acc
+        # Re-read the rows that either still have a tail OR were captured with an
+        # empty facade.
+        #
+        # The second group is the one a first cut missed. A checkpoint
+        # committing between the page SELECT and here folds the tail into a new
+        # snapshot, materializes the body back into `notes.content`, and PRUNES
+        # the tail — so the note stops being stale and the resolution skips it,
+        # leaving the page's captured facade in place. For a genesis note that
+        # facade is "", which is #1339 exactly. Re-reading it is what makes the
+        # checkpoint land harmlessly instead of racing us.
+        #
+        # Scoped to empty-facade rows on purpose: a page-captured NON-empty
+        # facade is real content the user wrote, so at worst it is one
+        # checkpoint behind — not worth a second full-row read and content
+        # decrypt for every row on every page.
+        refresh_ids =
+          for n <- ids,
+              Map.has_key?(tail_counts, n) or (by_id[n].content || "") == "",
+              do: n
+
+        fresh_rows =
+          from(n in Note, where: n.id in ^refresh_ids)
+          |> Repo.all()
+
+        fresh_by_id = Map.new(decrypt_or_raise!(fresh_rows, user), &{&1.id, &1})
+        raw_by_id = Map.new(fresh_rows, &{&1.id, &1})
+
+        Enum.reduce(refresh_ids, %{}, fn id, acc ->
+          case {Map.fetch(raw_by_id, id), Map.fetch(fresh_by_id, id)} do
+            {{:ok, row}, {:ok, fresh}} ->
+              Map.put(acc, id, resolve_or_refresh(user, fresh, row, tail_counts[id]))
+
+            _ ->
+              acc
           end
         end)
       end)
 
-    resolved |> Enum.reject(&match?({_, nil}, &1)) |> Map.new()
+    resolved
   end
+
+  # No tail left: the note was checkpointed since the page SELECT, so the
+  # freshly-read facade IS the authority and is what must be served — the page's
+  # copy predates that checkpoint.
+  defp resolve_or_refresh(_user, fresh, _row, nil), do: fresh.content
+
+  defp resolve_or_refresh(user, fresh, row, tail_count),
+    do: resolve_one(user, fresh, row, tail_count)
 
   # Runs INSIDE the caller's tenant transaction, so it uses the tail-replay
   # primitive directly rather than `authoritative_content/2` (which would open
   # its own). Returns nil to mean "keep the façade".
-  defp resolve_one(user, decrypted, row) do
+  defp resolve_one(user, decrypted, row, tail_count) do
     case Crypto.decrypt_crdt_state(row, user) do
-      # No snapshot: nothing to resolve, the façade IS the authority.
-      {:ok, nil} ->
-        nil
-
+      # `state` may be nil — a note that has never been checkpointed holds its
+      # ENTIRE body in the tail (`genesis_insert_bare` writes content: "",
+      # content_hash: nil, no snapshot). That is the primary #1339 shape, so
+      # bailing here would serve "" for exactly the notes this exists to fix.
+      # `doc_from_state(nil)` returns an empty doc and `replay_tail/3` fills it,
+      # which is precisely what `CrdtPersistence.bind/3` does on the write side.
       {:ok, state} ->
-        project_resolved(user, decrypted, row, state)
+        project_resolved(user, decrypted, row, state, tail_count)
 
       # Degrade to the façade rather than fail the page. An earlier cut raised
       # here; that was wrong. The feed is keyset-ordered by seq, so one note
@@ -3821,10 +3895,10 @@ defmodule Engram.Notes do
     end
   end
 
-  defp project_resolved(user, decrypted, row, state) do
+  defp project_resolved(user, decrypted, row, state, tail_count) do
     case CrdtBridge.doc_from_state(state) do
       {:ok, doc} ->
-        _replayed = CrdtPersistence.replay_tail(doc, user, row.id)
+        replayed = CrdtPersistence.replay_tail(doc, user, row.id)
         text = CrdtBridge.project_doc(doc)
 
         # The read-side mirror of `ensure_projection_safe/2`. The write path
@@ -3832,15 +3906,39 @@ defmodule Engram.Notes do
         # loss" in its own words — and the read path needs the same backstop,
         # especially since recomputing the hash removes the one signal
         # (hash/content disagreement) a client could have distrusted.
-        if text == "" and (decrypted.content || "") != "" do
-          Logger.warning(
-            "feed: CRDT projection is empty over a non-empty facade, serving the facade",
-            Metadata.with_category(:warning, :sync, note_id: row.id, user_id: user.id)
-          )
+        cond do
+          # A tail row that would not decrypt was logged and SKIPPED by
+          # replay_tail, so the projection is missing ops — non-empty but
+          # truncated, which the empty-projection guard below cannot see. Every
+          # other failure here degrades to the façade; a partial replay must
+          # too, or a transient DEK fault mid-rotation ships a truncated body
+          # that the client writes to disk.
+          #
+          # `<`, not `!=`: a row appended between the count and the replay makes
+          # `replayed` LARGER, and that is not a loss.
+          length(replayed) < tail_count ->
+            Logger.error(
+              "feed: partial CRDT tail replay, serving last checkpoint",
+              Metadata.with_category(:error, :sync,
+                note_id: row.id,
+                user_id: user.id,
+                replayed: length(replayed),
+                tail_rows: tail_count
+              )
+            )
 
-          nil
-        else
-          text
+            nil
+
+          text == "" and (decrypted.content || "") != "" ->
+            Logger.warning(
+              "feed: CRDT projection is empty over a non-empty facade, serving the facade",
+              Metadata.with_category(:warning, :sync, note_id: row.id, user_id: user.id)
+            )
+
+            nil
+
+          true ->
+            text
         end
 
       {:error, reason} ->

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3711,8 +3711,12 @@ defmodule Engram.Notes do
 
     changes =
       Enum.map(decrypted, fn note ->
-        note
-        |> change_map(feed_pair(note, fields, resolved))
+        # The resolved row replaces the page's copy wholesale, so every field in
+        # the emitted change comes from one coherent DB row.
+        resolved_note = if fields == :all, do: Map.get(resolved, note.id, note), else: note
+
+        resolved_note
+        |> change_map(fields)
         |> Map.put(:seq, note.seq)
       end)
 
@@ -3726,11 +3730,10 @@ defmodule Engram.Notes do
   end
 
   # Resolves the authority for every note on this page whose façade lags,
-  # returning %{note_id => {content, content_hash}}. Only the BODY is ever
-  # rebuilt — the hash is always a stored checkpoint hash (see `feed_pair/3`) —
-  # but both come from the SAME freshly-read row, so a checkpoint landing
-  # mid-page cannot pair a new body with an old hash. Notes absent from the map
-  # keep their page values.
+  # returning %{note_id => note}. The value is the freshly-read row with
+  # `content` replaced by the resolved body; `content_hash` is left as that row's
+  # stored checkpoint hash, so the feed and `/sync/manifest` still agree. Notes
+  # absent from the map keep their page row.
   #
   # `fields: :meta` never resolves: its projection does not even select
   # `crdt_state_ciphertext`, and it promises `content: nil` with the row's own
@@ -3763,9 +3766,14 @@ defmodule Engram.Notes do
     end
   end
 
-  # ONE transaction for the whole page: the staleness read and every rebuild
-  # share a single snapshot, and each note's `crdt_state` is RE-READ here rather
-  # than taken from the page SELECT.
+  # Resolution runs in chunks, each in its own transaction, and each chunk
+  # re-reads its rows rather than trusting the page SELECT.
+  #
+  # It is NOT one snapshot: `Repo.with_tenant` is a plain transaction, so at READ
+  # COMMITTED every statement takes its own. What makes the result stable is
+  # holding the tail ROWS (fetched with the chunk, replayed from memory) instead
+  # of re-querying them, plus degrading to the freshly-read row rather than the
+  # page's copy.
   #
   # Both properties are load-bearing. `checkpoint_write` persists the new
   # snapshot and prunes the tail in one transaction, so with a page-captured
@@ -3793,58 +3801,58 @@ defmodule Engram.Notes do
     |> Map.keys()
     |> Enum.chunk_every(@resolve_chunk)
     |> Enum.reduce(%{}, fn chunk, acc -> Map.merge(acc, resolve_chunk(user, by_id, chunk)) end)
-    |> Enum.reject(&match?({_, nil}, &1))
-    |> Map.new()
   end
 
   defp resolve_chunk(user, by_id, ids) do
     {:ok, resolved} =
       Repo.with_tenant(user.id, fn ->
-        # `count`, not just the id: `replay_tail/3` logs-and-skips a tail row it
-        # cannot decrypt, so knowing how many rows EXIST is what lets
-        # `project_resolved/5` tell a complete replay from a truncated one.
-        tail_counts =
+        # Fetch the tail ROWS, not a count. Replaying from these buffers is what
+        # makes the resolution race-free: `Repo.with_tenant` is a plain
+        # transaction, so at READ COMMITTED each statement takes its own
+        # snapshot, and re-querying the tail later would let a checkpoint prune
+        # it between the fetch and the replay — leaving an empty replay against a
+        # snapshot that predates the fold, which for a genesis note projects "".
+        # Yjs updates are idempotent and commutative, so replaying rows a
+        # checkpoint has since folded in is harmless. Holding them is strictly
+        # safer than re-reading them, and it collapses one query per note into
+        # one per chunk.
+        tails =
           from(l in CrdtUpdateLog,
             where: l.note_id in ^ids,
-            group_by: l.note_id,
-            select: {l.note_id, count(l.id)}
+            order_by: [asc: l.inserted_at]
           )
           |> Repo.all()
-          |> Map.new()
+          |> Enum.group_by(& &1.note_id)
 
-        # Re-read the rows that either still have a tail OR were captured with an
-        # empty facade.
+        # Re-read rows that still have a tail OR were captured with an empty
+        # façade.
         #
-        # The second group is the one a first cut missed. A checkpoint
+        # The second group is the one an earlier cut missed. A checkpoint
         # committing between the page SELECT and here folds the tail into a new
-        # snapshot, materializes the body back into `notes.content`, and PRUNES
-        # the tail — so the note stops being stale and the resolution skips it,
-        # leaving the page's captured facade in place. For a genesis note that
-        # facade is "", which is #1339 exactly. Re-reading it is what makes the
-        # checkpoint land harmlessly instead of racing us.
+        # snapshot, materializes the body back into `notes.content` and prunes
+        # the tail — so the note stops looking stale, the resolution skips it,
+        # and the page's captured façade stands. For a genesis note that façade
+        # is "", which is #1339 exactly.
         #
         # This does re-read every genuinely-empty .md note on the page, not only
-        # ones that raced a checkpoint — there is no cheaper way to tell those
-        # apart, since "was this checkpointed since the SELECT?" is the question
-        # the re-read answers. The bound is empty-facade notes, not all notes:
-        # a page-captured NON-empty facade is real content at worst one
-        # checkpoint old, so it is left alone.
+        # ones that raced a checkpoint — there is no cheaper test, since "was
+        # this checkpointed since the SELECT?" is the question the re-read
+        # answers. The bound is empty-façade notes, not all notes: a
+        # page-captured NON-empty façade is real content at worst one checkpoint
+        # old, so it is left alone.
         refresh_ids =
           for n <- ids,
-              Map.has_key?(tail_counts, n) or (by_id[n].content || "") == "",
+              Map.has_key?(tails, n) or (by_id[n].content || "") == "",
               do: n
 
-        fresh_rows =
-          from(n in Note, where: n.id in ^refresh_ids)
-          |> Repo.all()
-
-        fresh_by_id = Map.new(decrypt_or_raise!(fresh_rows, user), &{&1.id, &1})
+        fresh_rows = Repo.all(from(n in Note, where: n.id in ^refresh_ids))
         raw_by_id = Map.new(fresh_rows, &{&1.id, &1})
+        fresh_by_id = Map.new(decrypt_or_raise!(fresh_rows, user), &{&1.id, &1})
 
         Enum.reduce(refresh_ids, %{}, fn id, acc ->
           case {Map.fetch(raw_by_id, id), Map.fetch(fresh_by_id, id)} do
             {{:ok, row}, {:ok, fresh}} ->
-              Map.put(acc, id, resolve_or_refresh(user, fresh, row, tail_counts[id]))
+              Map.put(acc, id, resolve_one(user, fresh, row, Map.get(tails, id, [])))
 
             _ ->
               acc
@@ -3855,44 +3863,29 @@ defmodule Engram.Notes do
     resolved
   end
 
-  # No tail left: the note was checkpointed since the page SELECT, so the
-  # freshly-read row IS the authority. Content AND hash both come from it — they
-  # are the same checkpoint's values, so the feed still agrees with
-  # `/sync/manifest`, and pairing the fresh body with the PAGE's hash (nil for a
-  # genesis note) would guarantee a serverHash mismatch on the next poll.
-  defp resolve_or_refresh(_user, fresh, _row, nil), do: {fresh.content, fresh.content_hash}
-
-  defp resolve_or_refresh(user, fresh, row, tail_count),
-    do: resolve_one(user, fresh, row, tail_count)
-
-  # Runs INSIDE the caller's tenant transaction, so it uses the tail-replay
-  # primitive directly rather than `authoritative_content/2` (which would open
-  # its own). Returns nil to mean "keep the façade".
-  # Every degrade path lands here. `Repo.with_tenant` is a plain transaction, so
-  # under READ COMMITTED each statement takes its OWN snapshot — the tail count,
-  # the row read and `replay_tail`'s query are NOT atomic with each other. A
-  # checkpoint committing between them makes the replay come up short, and the
-  # honest answer then is the freshly-read row: it is never older than the page's
-  # copy, and for a genesis note the page's copy is "" — the 0-byte loss this PR
-  # exists to close, through a narrower window.
-  defp degrade(fresh), do: {fresh.content, fresh.content_hash}
-
-  defp resolve_one(user, decrypted, row, tail_count) do
+  # Every path returns a NOTE — the freshly-read one, with `content` replaced by
+  # the resolved body where there was one to resolve. Returning the whole row
+  # rather than a {content, hash} pair keeps the emitted change coherent: an
+  # earlier cut mixed a fresh body with the page's `version`/`updated_at`, so a
+  # checkpoint landing mid-page made the feed serve newer bytes under an older
+  # version, and the plugin's anti-stale guard (`known >= change.version`)
+  # recorded a version that understated the content it held.
+  defp resolve_one(user, fresh, row, tail_rows) do
     case Crypto.decrypt_crdt_state(row, user) do
       # `state` may be nil — a note that has never been checkpointed holds its
       # ENTIRE body in the tail (`genesis_insert_bare` writes content: "",
       # content_hash: nil, no snapshot). That is the primary #1339 shape, so
       # bailing here would serve "" for exactly the notes this exists to fix.
-      # `doc_from_state(nil)` returns an empty doc and `replay_tail/3` fills it,
-      # which is precisely what `CrdtPersistence.bind/3` does on the write side.
+      # `doc_from_state(nil)` returns an empty doc and the tail fills it, which
+      # is what `CrdtPersistence.bind/3` does on the write side.
       {:ok, state} ->
-        project_resolved(user, decrypted, row, state, tail_count)
+        project_resolved(user, fresh, row, state, tail_rows)
 
-      # Degrade to the façade rather than fail the page. An earlier cut raised
-      # here; that was wrong. The feed is keyset-ordered by seq, so one note
-      # with an undecodable crdt_state fails identically on EVERY retry — it
+      # Degrade to the freshly-read row rather than fail the page. An earlier cut
+      # raised here; that was wrong. The feed is keyset-ordered by seq, so one
+      # note with an undecodable crdt_state fails identically on EVERY retry — it
       # would wedge the vault's catch-up permanently and crash
-      # `crdt_catchup_since` into a rejoin loop. The façade is the last good
+      # `crdt_catchup_since` into a rejoin loop. The row is the last good
       # checkpoint: stale, but real content the user wrote. The permanently
       # unreadable case has its own quarantine track in #959.
       {:error, reason} ->
@@ -3905,63 +3898,52 @@ defmodule Engram.Notes do
           )
         )
 
-        degrade(decrypted)
+        fresh
     end
   end
 
-  defp project_resolved(user, decrypted, row, state, tail_count) do
+  defp project_resolved(user, fresh, row, state, tail_rows) do
     case CrdtBridge.doc_from_state(state) do
       {:ok, doc} ->
-        replayed = CrdtPersistence.replay_tail(doc, user, row.id)
+        applied = CrdtPersistence.apply_tail_rows(doc, user, row.id, tail_rows)
         text = CrdtBridge.project_doc(doc)
 
-        # The read-side mirror of `ensure_projection_safe/2`. The write path
-        # refuses to materialize "" over a façade that holds a body — "pure data
-        # loss" in its own words — and the read path needs the same backstop,
-        # especially since recomputing the hash removes the one signal
-        # (hash/content disagreement) a client could have distrusted.
         cond do
-          # A tail row that would not decrypt was logged and SKIPPED by
-          # replay_tail, so the projection is missing ops — non-empty but
-          # truncated, which the empty-projection guard below cannot see. A
-          # transient DEK fault mid-rotation would otherwise ship a body with
-          # the newest edits missing.
+          # A tail row that would not decrypt was logged and SKIPPED, so the
+          # projection is missing ops — non-empty but truncated, which the
+          # empty-projection guard below cannot see. A DEK fault mid-rotation
+          # would otherwise ship a body with the newest edits missing.
           #
-          # `<`, not `!=`: a row appended between the count and the replay makes
-          # `replayed` LARGER, and that is not a loss.
-          #
-          # `warning`, not `error`: a checkpoint committing between the count and
-          # the replay prunes the tail and lands here legitimately. That is an
-          # ordinary concurrent event, and the freshly-read row it degrades to is
-          # the very content that checkpoint just materialized — paging on it
-          # would be alerting on a non-event.
-          length(replayed) < tail_count ->
+          # Race-free now that the rows are held rather than re-queried: a short
+          # replay means a decrypt genuinely failed, not that a checkpoint pruned
+          # the tail underneath us.
+          length(applied) < length(tail_rows) ->
             Logger.warning(
-              "feed: partial CRDT tail replay, serving the freshly-read row",
+              "feed: partial CRDT tail replay, serving last checkpoint",
               Metadata.with_category(:warning, :sync,
                 note_id: row.id,
                 user_id: user.id,
-                replayed: length(replayed),
-                tail_rows: tail_count
+                applied: length(applied),
+                tail_rows: length(tail_rows)
               )
             )
 
-            degrade(decrypted)
+            fresh
 
-          text == "" and (decrypted.content || "") != "" ->
+          # The read-side mirror of `ensure_projection_safe/2`. The write path
+          # refuses to materialize "" over a façade that holds a body — "pure
+          # data loss" in its own words — and the read path needs the same
+          # backstop.
+          text == "" and (fresh.content || "") != "" ->
             Logger.warning(
               "feed: CRDT projection is empty over a non-empty facade, serving the facade",
               Metadata.with_category(:warning, :sync, note_id: row.id, user_id: user.id)
             )
 
-            degrade(decrypted)
+            fresh
 
           true ->
-            # Body from the doc, hash from the freshly-read row. The hash stays
-            # the checkpoint's — see `feed_pair/3` — and taking it from `fresh`
-            # rather than the page keeps it paired with the same row the body was
-            # rebuilt from.
-            {text, decrypted.content_hash}
+            %{fresh | content: text}
         end
 
       {:error, reason} ->
@@ -3974,39 +3956,18 @@ defmodule Engram.Notes do
           )
         )
 
-        degrade(decrypted)
+        fresh
     end
-  end
-
-  # `fields: :meta` promises `content: nil` AND the row's `content_hash` — its
-  # projection selects the hash on purpose, and a hash-free feed reads as
-  # "every row diverged" to the client.
-  defp feed_pair(note, :meta, _resolved), do: {nil, note.content_hash}
-
-  # `content_hash` ALWAYS comes from the façade, even when the body is resolved.
-  #
-  # It means "hash of the last checkpoint" — immutable between checkpoints and
-  # therefore identical on every endpoint that serves it, which is why the feed
-  # and `/sync/manifest` agree and why `validateFromManifest` can use equality
-  # as a convergence fence. Recomputing it here to match the resolved body was
-  # tried and reverted: it makes the value MUTABLE, so the feed and the manifest
-  # describe different instants of an actively-edited note and every such note
-  # reads as diverged on each poll. No server-side scheme fixes that — the
-  # content genuinely changes between the two calls.
-  #
-  # The cost is a bounded, self-healing window: until the next checkpoint the
-  # client's `serverHash` describes older bytes than the body it just wrote. At
-  # that checkpoint the feed re-serves the same body under the now-correct hash
-  # and the client re-applies idempotently.
-  defp feed_pair(note, :all, resolved) do
-    Map.get(resolved, note.id, {note.content, note.content_hash})
   end
 
   # Same rule `CrdtCheckpoint.markdown?/1` uses: only a `.md` note keeps its
   # body in the markdown Y.Text that `project_doc/1` reads.
   defp markdown_path?(path), do: is_binary(path) and String.ends_with?(path, ".md")
 
-  defp change_map(note, {content, content_hash}) do
+  # `fields: :meta` promises `content: nil` AND the row's `content_hash` — its
+  # projection selects the hash on purpose, and a hash-free feed reads as "every
+  # row diverged" to the client.
+  defp change_map(note, fields) do
     %{
       id: note.id,
       path: note.path,
@@ -4015,8 +3976,8 @@ defmodule Engram.Notes do
       tags: note.tags,
       version: note.version,
       mtime: note.mtime,
-      content: content,
-      content_hash: content_hash,
+      content: if(fields == :meta, do: nil, else: note.content),
+      content_hash: note.content_hash,
       deleted: not is_nil(note.deleted_at),
       updated_at: note.updated_at,
       parse_status: note.parse_status,

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -2084,65 +2084,6 @@ defmodule Engram.Notes do
   """
   @spec authoritative_content(map(), Note.t()) :: {:ok, String.t()} | {:error, term()}
   def authoritative_content(user, %Note{} = note) do
-    do_authoritative_content(user, note)
-  end
-
-  @doc """
-  The content a READ PATH should serve: the façade when it is current, the
-  authority when it is not.
-
-  ## Why this exists
-
-  `notes.content` is a façade for a CRDT-managed note — it materializes at
-  checkpoint, so between a doc write and that checkpoint it lags. The correct
-  call is `authoritative_content/2`, but that costs a decrypt plus a Yjs
-  rebuild plus a tail query, so it was never the default and every read path
-  has been left to make the call itself. Three got it wrong —
-  `NotesController.append/2` (#1159), link extraction, and `EmbedNote` (still
-  open) — and #1339 added a fourth on the worst path available: the sync change
-  feed served an empty façade, both devices materialized a 0-byte file, and
-  both pushed back the hash of "". A read bug became permanent data loss.
-
-  One seam makes that a single decision instead of a per-caller judgement call.
-
-  ## The predicate
-
-  The tail IS the staleness marker. `notes.content` materializes at checkpoint
-  and `prune_tail/2` clears the tail in the same breath, so a note with rows in
-  `crdt_update_log` is exactly a note whose façade lags. Cheap (one indexed
-  existence check), and unlike an "is the façade empty" heuristic it both
-  catches a non-empty-but-stale façade AND leaves genuinely-empty notes — which
-  are common in a real vault, and all carry a genesis snapshot — on the fast
-  path.
-
-  Batch callers must NOT loop this: `authoritative_content/2` opens its own
-  `Repo.with_tenant` per call. `list_changes_by_seq/4` resolves the whole page's
-  stale set in one query for that reason.
-
-  ponytail: one existence query per call. When `content` gains a
-  `crdt_head`-style invalidate-on-write flag (BEFORE UPDATE trigger + lazy
-  self-heal), this becomes a column read and the query disappears — callers do
-  not change. See `docs/context/worker-reads-stale-content-facade.md`.
-  """
-  @spec content_for_read(map(), Note.t()) :: {:ok, String.t() | nil} | {:error, term()}
-  def content_for_read(user, %Note{} = note) do
-    if tail_present?(user, note.id) do
-      do_authoritative_content(user, note)
-    else
-      {:ok, note.content}
-    end
-  end
-
-  defp tail_present?(user, note_id) do
-    {:ok, present?} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.exists?(from(l in CrdtUpdateLog, where: l.note_id == ^note_id))
-      end)
-
-    present?
-  end
-
-  defp do_authoritative_content(user, %Note{} = note) do
     case Crypto.decrypt_crdt_state(note, user) do
       {:ok, nil} ->
         {:ok, note.content || ""}
@@ -3748,27 +3689,13 @@ defmodule Engram.Notes do
     # #1339: `notes.content` is a FAÇADE that materializes at checkpoint, so a
     # note with uncheckpointed ops serves a body that lags — and when it lags
     # all the way to "", the client creates a 0-byte file and pushes the empty
-    # hash back. Resolve the authority for exactly those notes, deciding once
-    # per page rather than per caller.
-    stale = stale_facade_ids(user, decrypted, fields)
-
-    content_key =
-      if fields == :all and MapSet.size(stale) > 0 do
-        {:ok, key} = Crypto.dek_content_hash_key(user)
-        key
-      end
+    # hash back. Resolve the authority for exactly those notes, once per page.
+    resolved = resolve_stale_page(user, decrypted, fields)
 
     changes =
       Enum.map(decrypted, fn note ->
-        mode =
-          cond do
-            fields == :meta -> :meta
-            MapSet.member?(stale, note.id) -> {:stale, content_key}
-            true -> {:fresh, nil}
-          end
-
         note
-        |> change_map(feed_content(user, note, mode))
+        |> change_map(feed_pair(note, fields, resolved))
         |> Map.put(:seq, note.seq)
       end)
 
@@ -3781,86 +3708,220 @@ defmodule Engram.Notes do
     {:ok, %{changes: changes, has_more: has_more, next: next}}
   end
 
-  # `fields: :meta` carries `content: nil` by contract and its projection does
-  # not even select `crdt_state_ciphertext`, so it never resolves the authority.
-  defp feed_content(_user, _note, :meta), do: {nil, nil}
+  @doc """
+  `%{note_id => content_hash}` for every note in the vault whose façade lags.
 
-  # Façade is current (no uncheckpointed ops): serve it verbatim. `nil` stays
-  # `nil` rather than being coerced to "" — the plugin reads a row with
-  # `content == "" and content_hash` as PROOF that this hash maps to empty and
-  # caches it as `emptyContentHash` (sync.ts), so manufacturing an "" here would
-  # teach it a hash that means something else.
-  defp feed_content(_user, note, {:fresh, _}), do: {note.content, note.content_hash}
+  The manifest and the change feed are cross-compared by the client
+  (`validateFromManifest` / `healDivergedLiveBoundNotes` stamp `serverHash` from
+  the feed and diff it against the manifest). Since #1339 the feed serves
+  `hmac(resolved body)` for a stale note, so the manifest has to agree or every
+  actively-edited note reads as diverged and rewinds the vault's catch-up
+  cursor on each poll.
 
-  defp feed_content(user, note, {:stale, key}) do
-    case authoritative_content(user, note) do
-      {:ok, text} ->
-        # The hash MUST be recomputed with the text. The plugin treats
-        # content_hash as the identity of content: it stamps `serverHash` from
-        # it and then skips any later row whose hash matches. Shipping a real
-        # body under the façade's stale hash (typically hmac("") pre-checkpoint)
-        # would record `serverHash = hmac("")` for a file holding a body — after
-        # which a genuine emptying of that note arrives as ""/hmac("") and is
-        # silently skipped forever, with every convergence backstop reading
-        # "converged".
-        {text, Crypto.hmac_content_hash(key, text)}
+  Bounded by notes with UNCHECKPOINTED ops, not by vault size: the checkpoint
+  debounce means only actively-edited notes carry a tail, so a quiet vault
+  resolves nothing.
+  """
+  @spec resolved_content_hashes(map(), map()) :: %{optional(String.t()) => String.t()}
+  def resolved_content_hashes(user, vault) do
+    {:ok, rows} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(
+          from(n in scoped_live(user, vault),
+            join: l in CrdtUpdateLog,
+            on: l.note_id == n.id,
+            where: n.kind == "note",
+            distinct: n.id,
+            select: n
+          )
+        )
+      end)
 
-      # Degrade to the façade rather than fail the page. The earlier version
-      # raised here; that was wrong. This feed is keyset-ordered by seq, so one
-      # note with an undecodable crdt_state fails identically on EVERY retry —
-      # it would wedge the whole vault's catch-up permanently and crash
+    case rows do
+      [] ->
+        %{}
+
+      rows ->
+        with {:ok, key} <- Crypto.dek_content_hash_key(user) do
+          by_id = Map.new(decrypt_or_raise!(rows, user), &{&1.id, &1})
+
+          {:ok, resolved} =
+            Repo.with_tenant(user.id, fn ->
+              Enum.reduce(rows, %{}, fn row, acc ->
+                case resolve_one(user, by_id[row.id] || row, row, key) do
+                  {_text, hash} -> Map.put(acc, row.id, hash)
+                  nil -> acc
+                end
+              end)
+            end)
+
+          resolved
+        else
+          _ -> %{}
+        end
+    end
+  end
+
+  # Resolves the authority for every note on this page whose façade lags,
+  # returning %{note_id => {content, content_hash}}. Notes absent from the map
+  # keep their façade values.
+  #
+  # `fields: :meta` never resolves: its projection does not even select
+  # `crdt_state_ciphertext`, and it promises `content: nil` with the row's own
+  # `content_hash`.
+  defp resolve_stale_page(_user, _notes, :meta), do: %{}
+
+  defp resolve_stale_page(user, notes, :all) do
+    # Markdown only. `crdt_checkpoint.ex` refuses this exact projection for
+    # structural docs: a `.canvas` keeps its data in Y.Maps, not the markdown
+    # Y.Text, so `project_doc` returns "" and would replace the façade — the
+    # only non-Yjs copy of the board — with an empty body under a matching hash.
+    candidates = Enum.filter(notes, &(&1.kind == "note" and markdown_path?(&1.path)))
+
+    # Tombstones never prune their tail (`delete_note/4` only sets deleted_at;
+    # the FK cascade is hard-delete only), so without this every catch-up page
+    # carrying that tombstone would rebuild a doc forever — and ship a
+    # resurrected body on a `deleted: true` row.
+    candidates = Enum.reject(candidates, &(not is_nil(&1.deleted_at)))
+
+    case candidates do
+      [] ->
+        %{}
+
+      candidates ->
+        with {:ok, key} <- Crypto.dek_content_hash_key(user) do
+          resolve_stale_candidates(user, candidates, key)
+        else
+          # A DEK failure must not take down the whole page with a MatchError —
+          # that is the failure mode this module argues hardest against. Every
+          # row keeps its façade.
+          {:error, reason} ->
+            Logger.error(
+              "feed: content-hash key unavailable, serving facades",
+              Metadata.with_category(:error, :sync,
+                user_id: user.id,
+                reason_label: inspect(reason)
+              )
+            )
+
+            %{}
+        end
+    end
+  end
+
+  # ONE transaction for the whole page: the staleness read and every rebuild
+  # share a single snapshot, and each note's `crdt_state` is RE-READ here rather
+  # than taken from the page SELECT.
+  #
+  # Both properties are load-bearing. `checkpoint_write` persists the new
+  # snapshot and prunes the tail in one transaction, so with a page-captured
+  # struct a checkpoint committing between the tail read and the rebuild leaves
+  # `replay_tail` with nothing to replay AND a pre-checkpoint snapshot — which
+  # for a genesis note whose body lives entirely in the tail projects "". With
+  # the hash recomputed to match, the client would accept that as authoritative
+  # and write a 0-byte file: #1339 again, through a narrower window. Reading
+  # snapshot and tail together closes it.
+  #
+  # The single transaction also bounds the pool cost. `authoritative_content/2`
+  # opens its own `with_tenant` per call, and a folder rename is exactly the
+  # event that leaves MANY notes stale at once, so per-note resolution would be
+  # hundreds of serial checkouts inside one channel `handle_in` — the shape
+  # behind `docs/context/crdt-sync-pool-exhaustion-loop-2026-07-09.md`.
+  #
+  # ponytail: one query + N in-transaction rebuilds per page. When `content`
+  # gains a `crdt_head`-style invalidate-on-write flag (BEFORE UPDATE trigger +
+  # lazy self-heal), staleness becomes a column read and this collapses. See
+  # `docs/context/worker-reads-stale-content-facade.md`.
+  defp resolve_stale_candidates(user, candidates, key) do
+    by_id = Map.new(candidates, &{&1.id, &1})
+    ids = Map.keys(by_id)
+
+    {:ok, resolved} =
+      Repo.with_tenant(user.id, fn ->
+        stale_ids =
+          Repo.all(
+            from(l in CrdtUpdateLog, where: l.note_id in ^ids, distinct: true, select: l.note_id)
+          )
+
+        fresh_rows =
+          Repo.all(from(n in Note, where: n.id in ^stale_ids, select: {n.id, n}))
+          |> Map.new()
+
+        Enum.reduce(stale_ids, %{}, fn id, acc ->
+          case Map.fetch(fresh_rows, id) do
+            {:ok, row} -> Map.put(acc, id, resolve_one(user, by_id[id], row, key))
+            :error -> acc
+          end
+        end)
+      end)
+
+    resolved |> Enum.reject(&match?({_, nil}, &1)) |> Map.new()
+  end
+
+  # Runs INSIDE the caller's tenant transaction, so it uses the tail-replay
+  # primitive directly rather than `authoritative_content/2` (which would open
+  # its own). Returns nil to mean "keep the façade".
+  defp resolve_one(user, decrypted, row, key) do
+    with {:ok, state} when not is_nil(state) <- Crypto.decrypt_crdt_state(row, user),
+         {:ok, doc} <- CrdtBridge.doc_from_state(state) do
+      _replayed = CrdtPersistence.replay_tail(doc, user, row.id)
+      text = CrdtBridge.project_doc(doc)
+
+      cond do
+        # The read-side mirror of `ensure_projection_safe/2`. The write path
+        # refuses to materialize "" over a façade that holds a body — "pure data
+        # loss" in its own words — and the read path needs the same backstop,
+        # especially since recomputing the hash removes the one signal
+        # (hash/content disagreement) a client could have distrusted.
+        text == "" and (decrypted.content || "") != "" ->
+          Logger.warning(
+            "feed: CRDT projection is empty over a non-empty facade, serving the facade",
+            Metadata.with_category(:warning, :sync, note_id: row.id, user_id: user.id)
+          )
+
+          nil
+
+        true ->
+          {text, Crypto.hmac_content_hash(key, text)}
+      end
+    else
+      # No snapshot: nothing to resolve, the façade IS the authority.
+      {:ok, nil} ->
+        nil
+
+      # Degrade to the façade rather than fail the page. An earlier cut raised
+      # here; that was wrong. The feed is keyset-ordered by seq, so one note
+      # with an undecodable crdt_state fails identically on EVERY retry — it
+      # would wedge the vault's catch-up permanently and crash
       # `crdt_catchup_since` into a rejoin loop. The façade is the last good
-      # checkpoint: stale, but real content the user actually wrote, which is
-      # strictly better than both wedging and serving "". The permanently
+      # checkpoint: stale, but real content the user wrote. The permanently
       # unreadable case has its own quarantine track in #959.
       {:error, reason} ->
         Logger.error(
           "feed: CRDT authority unreadable, serving last checkpoint",
           Metadata.with_category(:error, :sync,
-            note_id: note.id,
+            note_id: row.id,
             user_id: user.id,
             reason_label: inspect(reason)
           )
         )
 
-        {note.content, note.content_hash}
+        nil
     end
   end
 
-  # Which notes on this page have uncheckpointed ops, in ONE query.
-  #
-  # The tail IS the staleness marker: `notes.content` materializes at
-  # checkpoint and `prune_tail/2` clears the tail in the same breath, so a note
-  # with tail rows is exactly a note whose façade lags. That beats the obvious
-  # "façade is empty" heuristic on both correctness and cost — it also catches a
-  # non-empty-but-stale façade, and it does NOT drag every genuinely-empty note
-  # (which has `content: ""` plus a genesis snapshot, and is common in a real
-  # vault) onto the rebuild path on every single page.
-  #
-  # Batched deliberately: `authoritative_content/2` opens its own
-  # `Repo.with_tenant` per call, and a 500-row page resolving one-by-one is 500
-  # serial pool checkouts inside a single channel `handle_in` — the shape that
-  # produced the pool-exhaustion loop in
-  # `docs/context/crdt-sync-pool-exhaustion-loop-2026-07-09.md`.
-  #
-  # ponytail: one indexed query per page. When `content` gains a
-  # `crdt_head`-style invalidate-on-write flag (BEFORE UPDATE trigger + lazy
-  # self-heal), this becomes a column read and the query disappears — callers
-  # do not change. See `docs/context/worker-reads-stale-content-facade.md`.
-  defp stale_facade_ids(_user, _notes, :meta), do: MapSet.new()
+  # `fields: :meta` promises `content: nil` AND the row's `content_hash` — its
+  # projection selects the hash on purpose, and a hash-free feed reads as
+  # "every row diverged" to the client.
+  defp feed_pair(note, :meta, _resolved), do: {nil, note.content_hash}
 
-  defp stale_facade_ids(user, notes, :all) do
-    ids = Enum.map(notes, & &1.id)
-
-    {:ok, rows} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.all(
-          from(l in CrdtUpdateLog, where: l.note_id in ^ids, distinct: true, select: l.note_id)
-        )
-      end)
-
-    MapSet.new(rows)
+  defp feed_pair(note, :all, resolved) do
+    Map.get(resolved, note.id) || {note.content, note.content_hash}
   end
+
+  # Same rule `CrdtCheckpoint.markdown?/1` uses: only a `.md` note keeps its
+  # body in the markdown Y.Text that `project_doc/1` reads.
+  defp markdown_path?(path), do: is_binary(path) and String.ends_with?(path, ".md")
 
   defp change_map(note, {content, content_hash}) do
     %{

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -19,6 +19,7 @@ defmodule Engram.Notes do
     CrdtBridge,
     CrdtDeliver,
     CrdtPersistence,
+    CrdtUpdateLog,
     Enqueue,
     Frontmatter,
     Helpers,
@@ -2083,6 +2084,65 @@ defmodule Engram.Notes do
   """
   @spec authoritative_content(map(), Note.t()) :: {:ok, String.t()} | {:error, term()}
   def authoritative_content(user, %Note{} = note) do
+    do_authoritative_content(user, note)
+  end
+
+  @doc """
+  The content a READ PATH should serve: the façade when it is current, the
+  authority when it is not.
+
+  ## Why this exists
+
+  `notes.content` is a façade for a CRDT-managed note — it materializes at
+  checkpoint, so between a doc write and that checkpoint it lags. The correct
+  call is `authoritative_content/2`, but that costs a decrypt plus a Yjs
+  rebuild plus a tail query, so it was never the default and every read path
+  has been left to make the call itself. Three got it wrong —
+  `NotesController.append/2` (#1159), link extraction, and `EmbedNote` (still
+  open) — and #1339 added a fourth on the worst path available: the sync change
+  feed served an empty façade, both devices materialized a 0-byte file, and
+  both pushed back the hash of "". A read bug became permanent data loss.
+
+  One seam makes that a single decision instead of a per-caller judgement call.
+
+  ## The predicate
+
+  The tail IS the staleness marker. `notes.content` materializes at checkpoint
+  and `prune_tail/2` clears the tail in the same breath, so a note with rows in
+  `crdt_update_log` is exactly a note whose façade lags. Cheap (one indexed
+  existence check), and unlike an "is the façade empty" heuristic it both
+  catches a non-empty-but-stale façade AND leaves genuinely-empty notes — which
+  are common in a real vault, and all carry a genesis snapshot — on the fast
+  path.
+
+  Batch callers must NOT loop this: `authoritative_content/2` opens its own
+  `Repo.with_tenant` per call. `list_changes_by_seq/4` resolves the whole page's
+  stale set in one query for that reason.
+
+  ponytail: one existence query per call. When `content` gains a
+  `crdt_head`-style invalidate-on-write flag (BEFORE UPDATE trigger + lazy
+  self-heal), this becomes a column read and the query disappears — callers do
+  not change. See `docs/context/worker-reads-stale-content-facade.md`.
+  """
+  @spec content_for_read(map(), Note.t()) :: {:ok, String.t() | nil} | {:error, term()}
+  def content_for_read(user, %Note{} = note) do
+    if tail_present?(user, note.id) do
+      do_authoritative_content(user, note)
+    else
+      {:ok, note.content}
+    end
+  end
+
+  defp tail_present?(user, note_id) do
+    {:ok, present?} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.exists?(from(l in CrdtUpdateLog, where: l.note_id == ^note_id))
+      end)
+
+    present?
+  end
+
+  defp do_authoritative_content(user, %Note{} = note) do
     case Crypto.decrypt_crdt_state(note, user) do
       {:ok, nil} ->
         {:ok, note.content || ""}
@@ -3683,10 +3743,34 @@ defmodule Engram.Notes do
         {notes, false}
       end
 
+    decrypted = decrypt_or_raise!(page, user)
+
+    # #1339: `notes.content` is a FAÇADE that materializes at checkpoint, so a
+    # note with uncheckpointed ops serves a body that lags — and when it lags
+    # all the way to "", the client creates a 0-byte file and pushes the empty
+    # hash back. Resolve the authority for exactly those notes, deciding once
+    # per page rather than per caller.
+    stale = stale_facade_ids(user, decrypted, fields)
+
+    content_key =
+      if fields == :all and MapSet.size(stale) > 0 do
+        {:ok, key} = Crypto.dek_content_hash_key(user)
+        key
+      end
+
     changes =
-      page
-      |> decrypt_or_raise!(user)
-      |> Enum.map(fn note -> note |> change_map() |> Map.put(:seq, note.seq) end)
+      Enum.map(decrypted, fn note ->
+        mode =
+          cond do
+            fields == :meta -> :meta
+            MapSet.member?(stale, note.id) -> {:stale, content_key}
+            true -> {:fresh, nil}
+          end
+
+        note
+        |> change_map(feed_content(user, note, mode))
+        |> Map.put(:seq, note.seq)
+      end)
 
     next =
       if has_more do
@@ -3697,7 +3781,88 @@ defmodule Engram.Notes do
     {:ok, %{changes: changes, has_more: has_more, next: next}}
   end
 
-  defp change_map(note) do
+  # `fields: :meta` carries `content: nil` by contract and its projection does
+  # not even select `crdt_state_ciphertext`, so it never resolves the authority.
+  defp feed_content(_user, _note, :meta), do: {nil, nil}
+
+  # Façade is current (no uncheckpointed ops): serve it verbatim. `nil` stays
+  # `nil` rather than being coerced to "" — the plugin reads a row with
+  # `content == "" and content_hash` as PROOF that this hash maps to empty and
+  # caches it as `emptyContentHash` (sync.ts), so manufacturing an "" here would
+  # teach it a hash that means something else.
+  defp feed_content(_user, note, {:fresh, _}), do: {note.content, note.content_hash}
+
+  defp feed_content(user, note, {:stale, key}) do
+    case authoritative_content(user, note) do
+      {:ok, text} ->
+        # The hash MUST be recomputed with the text. The plugin treats
+        # content_hash as the identity of content: it stamps `serverHash` from
+        # it and then skips any later row whose hash matches. Shipping a real
+        # body under the façade's stale hash (typically hmac("") pre-checkpoint)
+        # would record `serverHash = hmac("")` for a file holding a body — after
+        # which a genuine emptying of that note arrives as ""/hmac("") and is
+        # silently skipped forever, with every convergence backstop reading
+        # "converged".
+        {text, Crypto.hmac_content_hash(key, text)}
+
+      # Degrade to the façade rather than fail the page. The earlier version
+      # raised here; that was wrong. This feed is keyset-ordered by seq, so one
+      # note with an undecodable crdt_state fails identically on EVERY retry —
+      # it would wedge the whole vault's catch-up permanently and crash
+      # `crdt_catchup_since` into a rejoin loop. The façade is the last good
+      # checkpoint: stale, but real content the user actually wrote, which is
+      # strictly better than both wedging and serving "". The permanently
+      # unreadable case has its own quarantine track in #959.
+      {:error, reason} ->
+        Logger.error(
+          "feed: CRDT authority unreadable, serving last checkpoint",
+          Metadata.with_category(:error, :sync,
+            note_id: note.id,
+            user_id: user.id,
+            reason_label: inspect(reason)
+          )
+        )
+
+        {note.content, note.content_hash}
+    end
+  end
+
+  # Which notes on this page have uncheckpointed ops, in ONE query.
+  #
+  # The tail IS the staleness marker: `notes.content` materializes at
+  # checkpoint and `prune_tail/2` clears the tail in the same breath, so a note
+  # with tail rows is exactly a note whose façade lags. That beats the obvious
+  # "façade is empty" heuristic on both correctness and cost — it also catches a
+  # non-empty-but-stale façade, and it does NOT drag every genuinely-empty note
+  # (which has `content: ""` plus a genesis snapshot, and is common in a real
+  # vault) onto the rebuild path on every single page.
+  #
+  # Batched deliberately: `authoritative_content/2` opens its own
+  # `Repo.with_tenant` per call, and a 500-row page resolving one-by-one is 500
+  # serial pool checkouts inside a single channel `handle_in` — the shape that
+  # produced the pool-exhaustion loop in
+  # `docs/context/crdt-sync-pool-exhaustion-loop-2026-07-09.md`.
+  #
+  # ponytail: one indexed query per page. When `content` gains a
+  # `crdt_head`-style invalidate-on-write flag (BEFORE UPDATE trigger + lazy
+  # self-heal), this becomes a column read and the query disappears — callers
+  # do not change. See `docs/context/worker-reads-stale-content-facade.md`.
+  defp stale_facade_ids(_user, _notes, :meta), do: MapSet.new()
+
+  defp stale_facade_ids(user, notes, :all) do
+    ids = Enum.map(notes, & &1.id)
+
+    {:ok, rows} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.all(
+          from(l in CrdtUpdateLog, where: l.note_id in ^ids, distinct: true, select: l.note_id)
+        )
+      end)
+
+    MapSet.new(rows)
+  end
+
+  defp change_map(note, {content, content_hash}) do
     %{
       id: note.id,
       path: note.path,
@@ -3706,8 +3871,8 @@ defmodule Engram.Notes do
       tags: note.tags,
       version: note.version,
       mtime: note.mtime,
-      content: note.content,
-      content_hash: note.content_hash,
+      content: content,
+      content_hash: content_hash,
       deleted: not is_nil(note.deleted_at),
       updated_at: note.updated_at,
       parse_status: note.parse_status,

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -78,21 +78,20 @@ defmodule Engram.Notes do
     :parse_reason
   ]
 
+  # Notes resolved per transaction on the change feed. `Repo.with_tenant` takes
+  # Ecto's default 15s timeout, and each resolution is a decrypt + Yjs NIF
+  # rebuild + tail query + projection — so an unchunked 500-row page of stale
+  # notes (what a folder rename produces) could exceed it. A timeout there is
+  # not transient: the feed is keyset-ordered, so every retry hits the same page
+  # and fails identically — the permanent catch-up wedge the degrade clauses
+  # exist to avoid.
+  @resolve_chunk 50
+
   # Delete-wins window: an identical re-push at a path deleted within this many
   # seconds is refused (`:recently_deleted`), so an explicit delete is not
   # silently undone by a stale re-push from another device that still holds the
   # note (the cross-device resurrection race). A byte-different note or a
   # tombstone older than the window is allowed through as a genuine re-create.
-  # Notes resolved per transaction on the change feed. `Repo.with_tenant` takes
-  # Ecto's default 15s timeout, and each resolution is a decrypt + Yjs NIF
-  # rebuild + tail query + projection — so an unchunked 500-row page of stale
-  # notes (what a folder rename produces) could exceed it. A timeout there is
-  # not a transient: the feed is keyset-ordered, so every retry hits the same
-  # page and fails identically, which is the permanent catch-up wedge the
-  # degrade-to-façade clauses exist to avoid. Each chunk still reads its
-  # snapshot and tail in ONE transaction, which is where the atomicity lives.
-  @resolve_chunk 50
-
   @delete_tombstone_window_seconds 60
 
   @doc """
@@ -3727,9 +3726,11 @@ defmodule Engram.Notes do
   end
 
   # Resolves the authority for every note on this page whose façade lags,
-  # returning %{note_id => content}. Only the BODY is resolved — `content_hash`
-  # is always the façade's (see `feed_pair/3`). Notes absent from the map keep
-  # their façade content.
+  # returning %{note_id => {content, content_hash}}. Only the BODY is ever
+  # rebuilt — the hash is always a stored checkpoint hash (see `feed_pair/3`) —
+  # but both come from the SAME freshly-read row, so a checkpoint landing
+  # mid-page cannot pair a new body with an old hash. Notes absent from the map
+  # keep their page values.
   #
   # `fields: :meta` never resolves: its projection does not even select
   # `crdt_state_ciphertext`, and it promises `content: nil` with the row's own
@@ -3822,10 +3823,12 @@ defmodule Engram.Notes do
         # facade is "", which is #1339 exactly. Re-reading it is what makes the
         # checkpoint land harmlessly instead of racing us.
         #
-        # Scoped to empty-facade rows on purpose: a page-captured NON-empty
-        # facade is real content the user wrote, so at worst it is one
-        # checkpoint behind — not worth a second full-row read and content
-        # decrypt for every row on every page.
+        # This does re-read every genuinely-empty .md note on the page, not only
+        # ones that raced a checkpoint — there is no cheaper way to tell those
+        # apart, since "was this checkpointed since the SELECT?" is the question
+        # the re-read answers. The bound is empty-facade notes, not all notes:
+        # a page-captured NON-empty facade is real content at worst one
+        # checkpoint old, so it is left alone.
         refresh_ids =
           for n <- ids,
               Map.has_key?(tail_counts, n) or (by_id[n].content || "") == "",
@@ -3853,9 +3856,11 @@ defmodule Engram.Notes do
   end
 
   # No tail left: the note was checkpointed since the page SELECT, so the
-  # freshly-read facade IS the authority and is what must be served — the page's
-  # copy predates that checkpoint.
-  defp resolve_or_refresh(_user, fresh, _row, nil), do: fresh.content
+  # freshly-read row IS the authority. Content AND hash both come from it — they
+  # are the same checkpoint's values, so the feed still agrees with
+  # `/sync/manifest`, and pairing the fresh body with the PAGE's hash (nil for a
+  # genesis note) would guarantee a serverHash mismatch on the next poll.
+  defp resolve_or_refresh(_user, fresh, _row, nil), do: {fresh.content, fresh.content_hash}
 
   defp resolve_or_refresh(user, fresh, row, tail_count),
     do: resolve_one(user, fresh, row, tail_count)
@@ -3863,6 +3868,15 @@ defmodule Engram.Notes do
   # Runs INSIDE the caller's tenant transaction, so it uses the tail-replay
   # primitive directly rather than `authoritative_content/2` (which would open
   # its own). Returns nil to mean "keep the façade".
+  # Every degrade path lands here. `Repo.with_tenant` is a plain transaction, so
+  # under READ COMMITTED each statement takes its OWN snapshot — the tail count,
+  # the row read and `replay_tail`'s query are NOT atomic with each other. A
+  # checkpoint committing between them makes the replay come up short, and the
+  # honest answer then is the freshly-read row: it is never older than the page's
+  # copy, and for a genesis note the page's copy is "" — the 0-byte loss this PR
+  # exists to close, through a narrower window.
+  defp degrade(fresh), do: {fresh.content, fresh.content_hash}
+
   defp resolve_one(user, decrypted, row, tail_count) do
     case Crypto.decrypt_crdt_state(row, user) do
       # `state` may be nil — a note that has never been checkpointed holds its
@@ -3891,7 +3905,7 @@ defmodule Engram.Notes do
           )
         )
 
-        nil
+        degrade(decrypted)
     end
   end
 
@@ -3909,17 +3923,22 @@ defmodule Engram.Notes do
         cond do
           # A tail row that would not decrypt was logged and SKIPPED by
           # replay_tail, so the projection is missing ops — non-empty but
-          # truncated, which the empty-projection guard below cannot see. Every
-          # other failure here degrades to the façade; a partial replay must
-          # too, or a transient DEK fault mid-rotation ships a truncated body
-          # that the client writes to disk.
+          # truncated, which the empty-projection guard below cannot see. A
+          # transient DEK fault mid-rotation would otherwise ship a body with
+          # the newest edits missing.
           #
           # `<`, not `!=`: a row appended between the count and the replay makes
           # `replayed` LARGER, and that is not a loss.
+          #
+          # `warning`, not `error`: a checkpoint committing between the count and
+          # the replay prunes the tail and lands here legitimately. That is an
+          # ordinary concurrent event, and the freshly-read row it degrades to is
+          # the very content that checkpoint just materialized — paging on it
+          # would be alerting on a non-event.
           length(replayed) < tail_count ->
-            Logger.error(
-              "feed: partial CRDT tail replay, serving last checkpoint",
-              Metadata.with_category(:error, :sync,
+            Logger.warning(
+              "feed: partial CRDT tail replay, serving the freshly-read row",
+              Metadata.with_category(:warning, :sync,
                 note_id: row.id,
                 user_id: user.id,
                 replayed: length(replayed),
@@ -3927,7 +3946,7 @@ defmodule Engram.Notes do
               )
             )
 
-            nil
+            degrade(decrypted)
 
           text == "" and (decrypted.content || "") != "" ->
             Logger.warning(
@@ -3935,10 +3954,14 @@ defmodule Engram.Notes do
               Metadata.with_category(:warning, :sync, note_id: row.id, user_id: user.id)
             )
 
-            nil
+            degrade(decrypted)
 
           true ->
-            text
+            # Body from the doc, hash from the freshly-read row. The hash stays
+            # the checkpoint's — see `feed_pair/3` — and taking it from `fresh`
+            # rather than the page keeps it paired with the same row the body was
+            # rebuilt from.
+            {text, decrypted.content_hash}
         end
 
       {:error, reason} ->
@@ -3951,7 +3974,7 @@ defmodule Engram.Notes do
           )
         )
 
-        nil
+        degrade(decrypted)
     end
   end
 
@@ -3976,7 +3999,7 @@ defmodule Engram.Notes do
   # that checkpoint the feed re-serves the same body under the now-correct hash
   # and the client re-applies idempotently.
   defp feed_pair(note, :all, resolved) do
-    {Map.get(resolved, note.id, note.content), note.content_hash}
+    Map.get(resolved, note.id, {note.content, note.content_hash})
   end
 
   # Same rule `CrdtCheckpoint.markdown?/1` uses: only a `.md` note keeps its

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3708,62 +3708,6 @@ defmodule Engram.Notes do
     {:ok, %{changes: changes, has_more: has_more, next: next}}
   end
 
-  @doc """
-  `%{note_id => content_hash}` for every note in the vault whose façade lags.
-
-  The manifest and the change feed are cross-compared by the client
-  (`validateFromManifest` / `healDivergedLiveBoundNotes` stamp `serverHash` from
-  the feed and diff it against the manifest). Since #1339 the feed serves
-  `hmac(resolved body)` for a stale note, so the manifest has to agree or every
-  actively-edited note reads as diverged and rewinds the vault's catch-up
-  cursor on each poll.
-
-  Bounded by notes with UNCHECKPOINTED ops, not by vault size: the checkpoint
-  debounce means only actively-edited notes carry a tail, so a quiet vault
-  resolves nothing.
-  """
-  @spec resolved_content_hashes(map(), map()) :: %{optional(String.t()) => String.t()}
-  def resolved_content_hashes(user, vault) do
-    {:ok, rows} =
-      Repo.with_tenant(user.id, fn ->
-        Repo.all(
-          from(n in scoped_live(user, vault),
-            join: l in CrdtUpdateLog,
-            on: l.note_id == n.id,
-            where: n.kind == "note",
-            distinct: n.id,
-            select: n
-          )
-        )
-      end)
-
-    case rows do
-      [] ->
-        %{}
-
-      rows ->
-        case Crypto.dek_content_hash_key(user) do
-          {:ok, key} ->
-            by_id = Map.new(decrypt_or_raise!(rows, user), &{&1.id, &1})
-
-            {:ok, resolved} =
-              Repo.with_tenant(user.id, fn ->
-                Enum.reduce(rows, %{}, fn row, acc ->
-                  case resolve_one(user, by_id[row.id] || row, row, key) do
-                    {_text, hash} -> Map.put(acc, row.id, hash)
-                    nil -> acc
-                  end
-                end)
-              end)
-
-            resolved
-
-          _ ->
-            %{}
-        end
-    end
-  end
-
   # Resolves the authority for every note on this page whose façade lags,
   # returning %{note_id => {content, content_hash}}. Notes absent from the map
   # keep their façade values.
@@ -3791,24 +3735,7 @@ defmodule Engram.Notes do
         %{}
 
       candidates ->
-        case Crypto.dek_content_hash_key(user) do
-          {:ok, key} ->
-            resolve_stale_candidates(user, candidates, key)
-
-          # A DEK failure must not take down the whole page with a MatchError —
-          # that is the failure mode this module argues hardest against. Every
-          # row keeps its façade.
-          {:error, reason} ->
-            Logger.error(
-              "feed: content-hash key unavailable, serving facades",
-              Metadata.with_category(:error, :sync,
-                user_id: user.id,
-                reason_label: inspect(reason)
-              )
-            )
-
-            %{}
-        end
+        resolve_stale_candidates(user, candidates)
     end
   end
 
@@ -3835,7 +3762,7 @@ defmodule Engram.Notes do
   # gains a `crdt_head`-style invalidate-on-write flag (BEFORE UPDATE trigger +
   # lazy self-heal), staleness becomes a column read and this collapses. See
   # `docs/context/worker-reads-stale-content-facade.md`.
-  defp resolve_stale_candidates(user, candidates, key) do
+  defp resolve_stale_candidates(user, candidates) do
     by_id = Map.new(candidates, &{&1.id, &1})
     ids = Map.keys(by_id)
 
@@ -3852,7 +3779,7 @@ defmodule Engram.Notes do
 
         Enum.reduce(stale_ids, %{}, fn id, acc ->
           case Map.fetch(fresh_rows, id) do
-            {:ok, row} -> Map.put(acc, id, resolve_one(user, by_id[id], row, key))
+            {:ok, row} -> Map.put(acc, id, resolve_one(user, by_id[id], row))
             :error -> acc
           end
         end)
@@ -3864,14 +3791,14 @@ defmodule Engram.Notes do
   # Runs INSIDE the caller's tenant transaction, so it uses the tail-replay
   # primitive directly rather than `authoritative_content/2` (which would open
   # its own). Returns nil to mean "keep the façade".
-  defp resolve_one(user, decrypted, row, key) do
+  defp resolve_one(user, decrypted, row) do
     case Crypto.decrypt_crdt_state(row, user) do
       # No snapshot: nothing to resolve, the façade IS the authority.
       {:ok, nil} ->
         nil
 
       {:ok, state} ->
-        project_resolved(user, decrypted, row, key, state)
+        project_resolved(user, decrypted, row, state)
 
       # Degrade to the façade rather than fail the page. An earlier cut raised
       # here; that was wrong. The feed is keyset-ordered by seq, so one note
@@ -3894,7 +3821,7 @@ defmodule Engram.Notes do
     end
   end
 
-  defp project_resolved(user, decrypted, row, key, state) do
+  defp project_resolved(user, decrypted, row, state) do
     case CrdtBridge.doc_from_state(state) do
       {:ok, doc} ->
         _replayed = CrdtPersistence.replay_tail(doc, user, row.id)
@@ -3913,7 +3840,7 @@ defmodule Engram.Notes do
 
           nil
         else
-          {text, Crypto.hmac_content_hash(key, text)}
+          text
         end
 
       {:error, reason} ->
@@ -3935,8 +3862,23 @@ defmodule Engram.Notes do
   # "every row diverged" to the client.
   defp feed_pair(note, :meta, _resolved), do: {nil, note.content_hash}
 
+  # `content_hash` ALWAYS comes from the façade, even when the body is resolved.
+  #
+  # It means "hash of the last checkpoint" — immutable between checkpoints and
+  # therefore identical on every endpoint that serves it, which is why the feed
+  # and `/sync/manifest` agree and why `validateFromManifest` can use equality
+  # as a convergence fence. Recomputing it here to match the resolved body was
+  # tried and reverted: it makes the value MUTABLE, so the feed and the manifest
+  # describe different instants of an actively-edited note and every such note
+  # reads as diverged on each poll. No server-side scheme fixes that — the
+  # content genuinely changes between the two calls.
+  #
+  # The cost is a bounded, self-healing window: until the next checkpoint the
+  # client's `serverHash` describes older bytes than the body it just wrote. At
+  # that checkpoint the feed re-serves the same body under the now-correct hash
+  # and the client re-applies idempotently.
   defp feed_pair(note, :all, resolved) do
-    Map.get(resolved, note.id) || {note.content, note.content_hash}
+    {Map.get(resolved, note.id, note.content), note.content_hash}
   end
 
   # Same rule `CrdtCheckpoint.markdown?/1` uses: only a `.md` note keeps its

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3712,7 +3712,13 @@ defmodule Engram.Notes do
     changes =
       Enum.map(decrypted, fn note ->
         # The resolved row replaces the page's copy wholesale, so every field in
-        # the emitted change comes from one coherent DB row.
+        # the emitted change comes from one coherent DB row — EXCEPT `seq`,
+        # which stays the page's below because it is the cursor this page is
+        # keyed on and moving it would break pagination. So a checkpoint landing
+        # mid-page yields post-checkpoint content under a pre-checkpoint seq, and
+        # the plugin fences CRDT rows by seq alone. Self-healing: the
+        # checkpoint's new seq is above this page's max, so the row is
+        # re-delivered on a later page.
         resolved_note = if fields == :all, do: Map.get(resolved, note.id, note), else: note
 
         resolved_note
@@ -3804,7 +3810,7 @@ defmodule Engram.Notes do
   end
 
   defp resolve_chunk(user, by_id, ids) do
-    {:ok, resolved} =
+    {:ok, {fresh_rows, tails}} =
       Repo.with_tenant(user.id, fn ->
         # Fetch the tail ROWS, not a count. Replaying from these buffers is what
         # makes the resolution race-free: `Repo.with_tenant` is a plain
@@ -3845,22 +3851,37 @@ defmodule Engram.Notes do
               Map.has_key?(tails, n) or (by_id[n].content || "") == "",
               do: n
 
-        fresh_rows = Repo.all(from(n in Note, where: n.id in ^refresh_ids))
-        raw_by_id = Map.new(fresh_rows, &{&1.id, &1})
-        fresh_by_id = Map.new(decrypt_or_raise!(fresh_rows, user), &{&1.id, &1})
-
-        Enum.reduce(refresh_ids, %{}, fn id, acc ->
-          case {Map.fetch(raw_by_id, id), Map.fetch(fresh_by_id, id)} do
-            {{:ok, row}, {:ok, fresh}} ->
-              Map.put(acc, id, resolve_one(user, fresh, row, Map.get(tails, id, [])))
-
-            _ ->
-              acc
-          end
-        end)
+        {Repo.all(from(n in Note, where: n.id in ^refresh_ids)), tails}
       end)
 
-    resolved
+    # Rebuild OUTSIDE the transaction. The race only requires that the note rows
+    # and their tail rows be READ together; both are in memory now, and
+    # `doc_from_state` + per-row AES decrypt + `Yex.apply_update` + `project_doc`
+    # are pure NIF/CPU work with no DB access. Doing them inside would hold a
+    # pooled connection across up to @resolve_chunk doc rebuilds on a channel
+    # `handle_in` — with N devices in `crdt_catchup_since` at once, that is the
+    # pool-exhaustion shape in
+    # `docs/context/crdt-sync-pool-exhaustion-loop-2026-07-09.md`.
+    raw_by_id = Map.new(fresh_rows, &{&1.id, &1})
+    fresh_by_id = Map.new(decrypt_or_raise!(fresh_rows, user), &{&1.id, &1})
+
+    Enum.reduce(Map.keys(raw_by_id), %{}, fn id, acc ->
+      case Map.fetch(fresh_by_id, id) do
+        {:ok, fresh} ->
+          # Re-check the tombstone on the FRESH row: a delete committing between
+          # the page SELECT and here would otherwise ship a resurrected body on
+          # a `deleted: true` change, which the page-copy filter above cannot
+          # see.
+          if is_nil(fresh.deleted_at) do
+            Map.put(acc, id, resolve_one(user, fresh, raw_by_id[id], Map.get(tails, id, [])))
+          else
+            acc
+          end
+
+        :error ->
+          acc
+      end
+    end)
   end
 
   # Every path returns a NOTE — the freshly-read one, with `content` replaced by
@@ -3919,7 +3940,7 @@ defmodule Engram.Notes do
           # the tail underneath us.
           length(applied) < length(tail_rows) ->
             Logger.warning(
-              "feed: partial CRDT tail replay, serving last checkpoint",
+              "feed: partial CRDT tail replay",
               Metadata.with_category(:warning, :sync,
                 note_id: row.id,
                 user_id: user.id,
@@ -3928,7 +3949,15 @@ defmodule Engram.Notes do
               )
             )
 
-            fresh
+            # Degrading to the row is only safe when the row HAS a body. A
+            # never-checkpointed note has none — `genesis_insert_bare` leaves
+            # content: "" and the whole body in the tail — so "serve the last
+            # checkpoint" would serve "", and the client's discovery leg writes
+            # that to disk and pushes the empty hash back. That is #1339, reached
+            # through the one undecryptable tail row this branch exists for.
+            # A truncated projection is strictly better: the room heals the
+            # missing ops, and a 0-byte file does not.
+            if (fresh.content || "") == "", do: %{fresh | content: text}, else: fresh
 
           # The read-side mirror of `ensure_projection_safe/2`. The write path
           # refuses to materialize "" over a façade that holds a body — "pure

--- a/lib/engram/notes.ex
+++ b/lib/engram/notes.ex
@@ -3742,22 +3742,24 @@ defmodule Engram.Notes do
         %{}
 
       rows ->
-        with {:ok, key} <- Crypto.dek_content_hash_key(user) do
-          by_id = Map.new(decrypt_or_raise!(rows, user), &{&1.id, &1})
+        case Crypto.dek_content_hash_key(user) do
+          {:ok, key} ->
+            by_id = Map.new(decrypt_or_raise!(rows, user), &{&1.id, &1})
 
-          {:ok, resolved} =
-            Repo.with_tenant(user.id, fn ->
-              Enum.reduce(rows, %{}, fn row, acc ->
-                case resolve_one(user, by_id[row.id] || row, row, key) do
-                  {_text, hash} -> Map.put(acc, row.id, hash)
-                  nil -> acc
-                end
+            {:ok, resolved} =
+              Repo.with_tenant(user.id, fn ->
+                Enum.reduce(rows, %{}, fn row, acc ->
+                  case resolve_one(user, by_id[row.id] || row, row, key) do
+                    {_text, hash} -> Map.put(acc, row.id, hash)
+                    nil -> acc
+                  end
+                end)
               end)
-            end)
 
-          resolved
-        else
-          _ -> %{}
+            resolved
+
+          _ ->
+            %{}
         end
     end
   end
@@ -3789,9 +3791,10 @@ defmodule Engram.Notes do
         %{}
 
       candidates ->
-        with {:ok, key} <- Crypto.dek_content_hash_key(user) do
-          resolve_stale_candidates(user, candidates, key)
-        else
+        case Crypto.dek_content_hash_key(user) do
+          {:ok, key} ->
+            resolve_stale_candidates(user, candidates, key)
+
           # A DEK failure must not take down the whole page with a MatchError —
           # that is the failure mode this module argues hardest against. Every
           # row keeps its façade.
@@ -3862,32 +3865,13 @@ defmodule Engram.Notes do
   # primitive directly rather than `authoritative_content/2` (which would open
   # its own). Returns nil to mean "keep the façade".
   defp resolve_one(user, decrypted, row, key) do
-    with {:ok, state} when not is_nil(state) <- Crypto.decrypt_crdt_state(row, user),
-         {:ok, doc} <- CrdtBridge.doc_from_state(state) do
-      _replayed = CrdtPersistence.replay_tail(doc, user, row.id)
-      text = CrdtBridge.project_doc(doc)
-
-      cond do
-        # The read-side mirror of `ensure_projection_safe/2`. The write path
-        # refuses to materialize "" over a façade that holds a body — "pure data
-        # loss" in its own words — and the read path needs the same backstop,
-        # especially since recomputing the hash removes the one signal
-        # (hash/content disagreement) a client could have distrusted.
-        text == "" and (decrypted.content || "") != "" ->
-          Logger.warning(
-            "feed: CRDT projection is empty over a non-empty facade, serving the facade",
-            Metadata.with_category(:warning, :sync, note_id: row.id, user_id: user.id)
-          )
-
-          nil
-
-        true ->
-          {text, Crypto.hmac_content_hash(key, text)}
-      end
-    else
+    case Crypto.decrypt_crdt_state(row, user) do
       # No snapshot: nothing to resolve, the façade IS the authority.
       {:ok, nil} ->
         nil
+
+      {:ok, state} ->
+        project_resolved(user, decrypted, row, key, state)
 
       # Degrade to the façade rather than fail the page. An earlier cut raised
       # here; that was wrong. The feed is keyset-ordered by seq, so one note
@@ -3899,6 +3883,42 @@ defmodule Engram.Notes do
       {:error, reason} ->
         Logger.error(
           "feed: CRDT authority unreadable, serving last checkpoint",
+          Metadata.with_category(:error, :sync,
+            note_id: row.id,
+            user_id: user.id,
+            reason_label: inspect(reason)
+          )
+        )
+
+        nil
+    end
+  end
+
+  defp project_resolved(user, decrypted, row, key, state) do
+    case CrdtBridge.doc_from_state(state) do
+      {:ok, doc} ->
+        _replayed = CrdtPersistence.replay_tail(doc, user, row.id)
+        text = CrdtBridge.project_doc(doc)
+
+        # The read-side mirror of `ensure_projection_safe/2`. The write path
+        # refuses to materialize "" over a façade that holds a body — "pure data
+        # loss" in its own words — and the read path needs the same backstop,
+        # especially since recomputing the hash removes the one signal
+        # (hash/content disagreement) a client could have distrusted.
+        if text == "" and (decrypted.content || "") != "" do
+          Logger.warning(
+            "feed: CRDT projection is empty over a non-empty facade, serving the facade",
+            Metadata.with_category(:warning, :sync, note_id: row.id, user_id: user.id)
+          )
+
+          nil
+        else
+          {text, Crypto.hmac_content_hash(key, text)}
+        end
+
+      {:error, reason} ->
+        Logger.error(
+          "feed: CRDT doc rebuild failed, serving last checkpoint",
           Metadata.with_category(:error, :sync,
             note_id: row.id,
             user_id: user.id,

--- a/lib/engram/notes/crdt_persistence.ex
+++ b/lib/engram/notes/crdt_persistence.ex
@@ -310,6 +310,23 @@ defmodule Engram.Notes.CrdtPersistence do
       |> order_by([l], asc: l.inserted_at)
       |> Repo.all()
 
+    apply_tail_rows(doc, user, note_id, rows)
+  end
+
+  @doc """
+  Applies already-fetched tail rows to `doc`, returning the ids that decrypted.
+
+  Split out of `replay_tail/3` so a BATCH caller can fetch one page's tail in a
+  single query and replay from those buffers. That is not just an N+1 fix: it
+  removes a race. Fetching rows and replaying them in separate statements at
+  READ COMMITTED lets a checkpoint prune the tail in between, so the replay
+  comes up empty against a snapshot that predates the fold. Yjs updates are
+  idempotent and commutative, so replaying a buffer a checkpoint has since
+  folded in is harmless — holding the rows is strictly safer than re-reading
+  them.
+  """
+  @spec apply_tail_rows(Yex.Doc.t(), map(), String.t(), [struct()]) :: [Ecto.UUID.t()]
+  def apply_tail_rows(doc, user, note_id, rows) do
     rows
     |> Enum.reduce([], fn row, applied ->
       shaped = %Note{

--- a/lib/engram_web/controllers/notes_controller.ex
+++ b/lib/engram_web/controllers/notes_controller.ex
@@ -125,7 +125,12 @@ defmodule EngramWeb.NotesController do
     case Notes.get_note(user, vault, path) do
       {:ok, note} ->
         # Append is a read-modify-write, so it must read the AUTHORITY, not the
-        # `notes.content` façade. The façade is materialized from the CRDT doc
+        # `notes.content` façade. It reads the authority UNCONDITIONALLY — do
+        # not "optimise" this with the feed's tail-presence check (#1339): a
+        # read-modify-write derives the new body from this value, so trusting a
+        # façade that is stale for any reason the tail does not witness
+        # truncates the note. The regression tests below construct exactly that
+        # state. The façade is materialized from the CRDT doc
         # at checkpoint, so it lags a doc write; deriving the new full content
         # from a stale (blank) base makes `upsert_note/4`'s merge compute a diff
         # that deletes the body. That is #1159, seen in prod CI as a note

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -8,7 +8,6 @@ defmodule EngramWeb.SyncController do
   alias Engram.Crypto
   alias Engram.Crypto.PathCrypto
   alias Engram.Logger.Metadata
-  alias Engram.Notes
   alias Engram.Notes.Note
   alias Engram.Repo
   alias EngramWeb.Schemas
@@ -138,29 +137,12 @@ defmodule EngramWeb.SyncController do
     # ~43ms while chunked parallel came out *slower* (result copy-back to the
     # caller's heap rivals the AES-GCM work). Keep these loops sequential;
     # the batch telemetry tells us if a real-world vault disagrees.
-    # #1339: `notes.content_hash` is the hash of the FAÇADE, which lags for a
-    # note with uncheckpointed ops. The change feed now serves the resolved
-    # body's hash for those notes, and the client cross-compares the two
-    # (`validateFromManifest` / `healDivergedLiveBoundNotes` stamp `serverHash`
-    # from the feed, then diff it against this manifest). Disagreeing here would
-    # make every actively-edited note read as diverged and rewind the vault's
-    # catch-up cursor on each poll. Bounded by notes carrying a tail, not by
-    # vault size — the checkpoint debounce keeps a quiet vault at zero.
-    resolved_hashes = Notes.resolved_content_hashes(user, vault)
-
     notes =
       Crypto.measure_decrypt_batch(:manifest_notes, length(note_rows), fn ->
         Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, hash, seq, crdt_head} ->
           aad = PathCrypto.aad(:notes, id, dek_version)
           path = PathCrypto.decrypt!(path_ct, path_nonce, dek, aad)
-
-          %{
-            id: id,
-            path: path,
-            content_hash: Map.get(resolved_hashes, id, hash),
-            seq: seq,
-            crdt_head: crdt_head
-          }
+          %{id: id, path: path, content_hash: hash, seq: seq, crdt_head: crdt_head}
         end)
       end)
       |> Enum.sort_by(& &1.path)

--- a/lib/engram_web/controllers/sync_controller.ex
+++ b/lib/engram_web/controllers/sync_controller.ex
@@ -8,6 +8,7 @@ defmodule EngramWeb.SyncController do
   alias Engram.Crypto
   alias Engram.Crypto.PathCrypto
   alias Engram.Logger.Metadata
+  alias Engram.Notes
   alias Engram.Notes.Note
   alias Engram.Repo
   alias EngramWeb.Schemas
@@ -137,12 +138,29 @@ defmodule EngramWeb.SyncController do
     # ~43ms while chunked parallel came out *slower* (result copy-back to the
     # caller's heap rivals the AES-GCM work). Keep these loops sequential;
     # the batch telemetry tells us if a real-world vault disagrees.
+    # #1339: `notes.content_hash` is the hash of the FAÇADE, which lags for a
+    # note with uncheckpointed ops. The change feed now serves the resolved
+    # body's hash for those notes, and the client cross-compares the two
+    # (`validateFromManifest` / `healDivergedLiveBoundNotes` stamp `serverHash`
+    # from the feed, then diff it against this manifest). Disagreeing here would
+    # make every actively-edited note read as diverged and rewind the vault's
+    # catch-up cursor on each poll. Bounded by notes carrying a tail, not by
+    # vault size — the checkpoint debounce keeps a quiet vault at zero.
+    resolved_hashes = Notes.resolved_content_hashes(user, vault)
+
     notes =
       Crypto.measure_decrypt_batch(:manifest_notes, length(note_rows), fn ->
         Enum.map(note_rows, fn {id, dek_version, path_ct, path_nonce, hash, seq, crdt_head} ->
           aad = PathCrypto.aad(:notes, id, dek_version)
           path = PathCrypto.decrypt!(path_ct, path_nonce, dek, aad)
-          %{id: id, path: path, content_hash: hash, seq: seq, crdt_head: crdt_head}
+
+          %{
+            id: id,
+            path: path,
+            content_hash: Map.get(resolved_hashes, id, hash),
+            seq: seq,
+            crdt_head: crdt_head
+          }
         end)
       end)
       |> Enum.sort_by(& &1.path)

--- a/test/engram/notes/feed_interleave_test.exs
+++ b/test/engram/notes/feed_interleave_test.exs
@@ -1,0 +1,137 @@
+defmodule Engram.Notes.FeedInterleaveTest do
+  @moduledoc """
+  The sibling of `checkpoint_interleave_test.exs`, for the READ side (#1339).
+
+  The change feed resolves the CRDT authority for notes whose facade lags. That
+  resolution reads a snapshot and replays a tail, and `checkpoint_write` folds
+  the tail INTO a new snapshot and prunes it in one transaction. So the read has
+  a window: if it takes its snapshot from the page SELECT and its tail from a
+  later statement, a checkpoint committing in between leaves it rebuilding from
+  a PRE-checkpoint snapshot against an already-pruned tail.
+
+  For a never-checkpointed note — whose entire body lives in the tail — that
+  projects "". The client writes a 0-byte file and pushes back the hash of "",
+  which is #1339 itself, through a narrower window.
+
+  The fix is that the resolution re-reads the row inside the same transaction as
+  the tail. Proving it needs real connections and a park point, for the reason
+  `Engram.CheckpointInterleave` documents at length: the sandbox is one
+  connection in one never-committed transaction, so nothing can commit into the
+  gap and a sandboxed version of this test proves nothing at all.
+  """
+  use ExUnit.Case, async: false
+
+  import Ecto.Query, only: [from: 2]
+  import Engram.Factory
+
+  alias Engram.CheckpointInterleave
+  alias Engram.Crypto
+  alias Engram.Crypto.Envelope
+  alias Engram.Notes
+  alias Engram.Notes.{CrdtBridge, CrdtCheckpoint, CrdtUpdateLog, Note}
+  alias Engram.Repo
+
+  setup do
+    CheckpointInterleave.checkout_real!()
+
+    email = "feed-interleave-#{System.unique_integer([:positive])}-#{System.os_time()}@test.com"
+
+    user_id = Ecto.UUID.generate()
+    on_exit(fn -> CheckpointInterleave.cleanup(user_id) end)
+
+    user = insert(:user, id: user_id, email: email)
+    insert(:user_limit_override, user: user, key: "vaults_cap", value: %{"v" => -1})
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "FeedInterleave"})
+
+    %{user: user, vault: vault}
+  end
+
+  test "a checkpoint committing mid-page does not make the feed serve an empty body", ctx do
+    %{user: user, vault: vault} = ctx
+
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "feed.md", "content" => "TAIL BODY"})
+
+    # Put the note in the never-checkpointed shape: the whole body in the tail,
+    # no snapshot, blank facade. That is what a CRDT-genesis note looks like
+    # before its first checkpoint, and it is the shape whose resolution depends
+    # entirely on the tail still being there.
+    raw = Repo.one!(from(n in Note, where: n.id == ^note.id), skip_tenant_check: true)
+    {:ok, state} = Crypto.decrypt_crdt_state(raw, user)
+    {:ok, dek} = Crypto.get_dek(user)
+
+    {upd_ct, upd_nonce} =
+      Envelope.encrypt(state, dek, Crypto.aad_for_row(:notes, :crdt_state, note.id))
+
+    {blank_ct, blank_nonce} =
+      Envelope.encrypt("", dek, Crypto.aad_for_row(:notes, :content, note.id))
+
+    Repo.insert!(
+      %CrdtUpdateLog{
+        note_id: note.id,
+        user_id: user.id,
+        vault_id: vault.id,
+        update_ciphertext: upd_ct,
+        update_nonce: upd_nonce,
+        inserted_at: DateTime.utc_now()
+      },
+      skip_tenant_check: true
+    )
+
+    Repo.update_all(
+      from(n in Note, where: n.id == ^note.id),
+      [
+        set: [
+          crdt_state_ciphertext: nil,
+          crdt_state_nonce: nil,
+          content_ciphertext: blank_ct,
+          content_nonce: blank_nonce,
+          # nil, matching `genesis_insert_bare`. Leaving the old hash in place
+          # would make the checkpoint see prev == content_hash and take the
+          # COMPACTION branch, which never touches notes.content — so the test
+          # would be asserting against a state production never reaches.
+          content_hash: nil
+        ]
+      ],
+      skip_tenant_check: true
+    )
+
+    on_exit(CheckpointInterleave.arm(:feed_after_page_read))
+
+    reader =
+      Task.async(fn ->
+        CheckpointInterleave.checkout_real!()
+        Notes.list_changes_by_seq(user, vault, 0)
+      end)
+
+    parked = CheckpointInterleave.await_parked(:feed_after_page_read, reader.pid)
+
+    # The checkpoint commits while the feed holds its page. It folds the tail
+    # into a fresh snapshot, materializes the body back into notes.content, and
+    # PRUNES the tail — so a resolution still trusting the page's captured row
+    # would find a nil snapshot and nothing to replay.
+    checkpointer =
+      Task.async(fn ->
+        CheckpointInterleave.checkout_real!()
+        {:ok, live} = CrdtBridge.doc_from_state(state)
+        CrdtCheckpoint.checkpoint(user.id, vault.id, note.id, live)
+      end)
+
+    assert :ok = Task.await(checkpointer, 15_000)
+
+    CheckpointInterleave.release(:feed_after_page_read, parked)
+
+    assert {:ok, %{changes: changes}} = Task.await(reader, 15_000)
+    change = Enum.find(changes, &(&1.path == "feed.md"))
+
+    assert change.content == "TAIL BODY",
+           """
+           the feed served #{inspect(change.content)} for a note that holds
+           "TAIL BODY". A checkpoint committed between the page SELECT and the
+           resolution, folding the tail into a new snapshot and pruning it — so
+           a resolution reading the snapshot from the page and the tail from a
+           later statement finds neither. The client writes that to disk as a
+           0-byte file and pushes the empty hash back: #1339.
+           """
+  end
+end

--- a/test/engram/notes_content_for_read_test.exs
+++ b/test/engram/notes_content_for_read_test.exs
@@ -8,8 +8,9 @@ defmodule Engram.NotesContentForReadTest do
   most damaging path of all: the sync change feed, where an empty facade made
   both devices materialize a 0-byte file and push the empty hash back.
 
-  The resolution is shared by the change feed and the manifest so the two agree
-  on what `content_hash` means — the client cross-compares them.
+  Only the BODY is resolved. `content_hash` stays the facade's — it means "hash
+  of the last checkpoint", which is immutable between checkpoints and therefore
+  the same on every endpoint that serves it.
   """
   use Engram.DataCase, async: true
 
@@ -32,6 +33,20 @@ defmodule Engram.NotesContentForReadTest do
   # state a note is in between a CRDT write and its first checkpoint — the
   # #1339 shape — and doing it directly keeps the test independent of room
   # scheduling.
+  # A real, decryptable, valid Yjs update that changes nothing. `replay_tail/3`
+  # counts a row as applied only when it DECRYPTS, and the feed now compares that
+  # count against the tail size — so a junk payload would read as a partial
+  # replay and degrade to the facade.
+  defp noop_update do
+    {:ok, %{state: state}} = Engram.Notes.CrdtBridge.merge_plaintext(nil, "")
+    state
+  end
+
+  defp dek!(user) do
+    {:ok, dek} = Crypto.get_dek(user)
+    dek
+  end
+
   defp blank_facade!(user, note_id) do
     {:ok, dek} = Crypto.get_dek(user)
     {ct, nonce} = Envelope.encrypt("", dek, Crypto.aad_for_row(:notes, :content, note_id))
@@ -55,7 +70,7 @@ defmodule Engram.NotesContentForReadTest do
     {:ok, dek} = Crypto.get_dek(user)
 
     {ct, nonce} =
-      Envelope.encrypt(<<0>>, dek, Crypto.aad_for_row(:crdt_update_log, :update, note_id))
+      Envelope.encrypt(noop_update(), dek, Crypto.aad_for_row(:notes, :crdt_state, note_id))
 
     {:ok, _} =
       Repo.with_tenant(user.id, fn ->
@@ -70,6 +85,50 @@ defmodule Engram.NotesContentForReadTest do
       end)
 
     :ok
+  end
+
+  # THE primary #1339 shape, and the one an earlier cut of this fix missed: a
+  # note that has never been checkpointed has NO snapshot at all
+  # (`genesis_insert_bare` writes content: "", content_hash: nil, no
+  # crdt_state) and its entire body lives in the tail. Bailing on a nil
+  # snapshot serves "" for exactly the notes this exists to fix.
+  test "a never-checkpointed note is rebuilt from the tail alone", ctx do
+    %{user: user, vault: vault} = ctx
+
+    {:ok, note} =
+      Notes.upsert_note(user, vault, %{"path" => "genesis.md", "content" => "TAIL ONLY"})
+
+    # Move the whole body into the tail and drop the snapshot + facade, which is
+    # the state between a genesis insert and its first checkpoint.
+    {:ok, raw} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    {:ok, state} = Crypto.decrypt_crdt_state(raw, user)
+
+    {ct, nonce} =
+      Envelope.encrypt(state, dek!(user), Crypto.aad_for_row(:notes, :crdt_state, note.id))
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.insert!(%CrdtUpdateLog{
+          note_id: note.id,
+          user_id: user.id,
+          vault_id: vault.id,
+          update_ciphertext: ct,
+          update_nonce: nonce,
+          inserted_at: DateTime.utc_now()
+        })
+
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note.id),
+          set: [crdt_state_ciphertext: nil, crdt_state_nonce: nil]
+        )
+      end)
+
+    :ok = blank_facade!(user, note.id)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "genesis.md"))
+
+    assert change.content == "TAIL ONLY"
   end
 
   # The regression this seam exists for. The catch-up feed is what the plugin's
@@ -233,5 +292,75 @@ defmodule Engram.NotesContentForReadTest do
     change = Enum.find(changes, &(&1.path == "guard.md"))
 
     assert change.content == "REAL"
+  end
+
+  # `replay_tail/3` logs-and-SKIPS a tail row it cannot decrypt, so a truncated
+  # projection looks healthy — non-empty, so the empty-projection guard cannot
+  # see it. A transient DEK fault mid-rotation would otherwise ship a body with
+  # the most recent edits missing, and the client would write it to disk.
+  test "a partial tail replay degrades to the facade", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "partial.md", "content" => "INTACT"})
+
+    # One good tail row, one that will not decrypt (wrong AAD) — replay applies
+    # 1 of 2, so the projection is missing ops.
+    :ok = append_tail!(user, vault, note.id)
+
+    {ct, nonce} =
+      Envelope.encrypt(
+        noop_update(),
+        dek!(user),
+        Crypto.aad_for_row(:notes, :content, note.id)
+      )
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.insert!(%CrdtUpdateLog{
+          note_id: note.id,
+          user_id: user.id,
+          vault_id: vault.id,
+          update_ciphertext: ct,
+          update_nonce: nonce,
+          inserted_at: DateTime.utc_now()
+        })
+      end)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "partial.md"))
+
+    assert change.content == "INTACT"
+  end
+
+  # Resolution runs @resolve_chunk notes per transaction (the 15s Ecto default
+  # would not survive a 500-row page of Yjs rebuilds). A merge bug across the
+  # chunk boundary silently drops notes back to their stale facade, which is the
+  # #1339 loss again — so cross a boundary and assert every note resolved.
+  @tag :slow
+  test "every stale note resolves across a chunk boundary", ctx do
+    %{user: user, vault: vault} = ctx
+    count = 55
+
+    notes =
+      for i <- 1..count do
+        {:ok, note} =
+          Notes.upsert_note(user, vault, %{
+            "path" => "chunk/#{i}.md",
+            "content" => "BODY #{i}"
+          })
+
+        :ok = blank_facade!(user, note.id)
+        :ok = append_tail!(user, vault, note.id)
+        {i, note}
+      end
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0, limit: 500)
+    by_path = Map.new(changes, &{&1.path, &1})
+
+    unresolved =
+      for {i, _note} <- notes,
+          Map.get(by_path, "chunk/#{i}.md").content != "BODY #{i}",
+          do: i
+
+    assert unresolved == [], "notes left on the stale facade: #{inspect(unresolved)}"
   end
 end

--- a/test/engram/notes_content_for_read_test.exs
+++ b/test/engram/notes_content_for_read_test.exs
@@ -87,23 +87,26 @@ defmodule Engram.NotesContentForReadTest do
     assert change.content == "FEED BODY"
   end
 
-  # The hash is the IDENTITY of the content as far as the plugin is concerned:
-  # it stamps `serverHash` from it, then skips any later row whose hash matches.
-  # Shipping a resolved body under the facade's stale hash would record
-  # `serverHash = hmac("")` for a file holding a body, after which a genuine
-  # emptying of that note arrives as ""/hmac("") and is skipped forever.
-  test "content_hash is recomputed to match the body actually served", ctx do
+  # `content_hash` deliberately stays the FACADE's, even when the body is
+  # resolved. It means "hash of the last checkpoint" — immutable between
+  # checkpoints, so the feed and /sync/manifest serve the same value and
+  # `validateFromManifest` can use equality as a convergence fence.
+  #
+  # Recomputing it to match the resolved body was tried and reverted: that makes
+  # it MUTABLE, so the two endpoints describe different instants of an
+  # actively-edited note and every such note reads as diverged on each poll. No
+  # server-side scheme fixes that — the content changes between the two calls.
+  test "content_hash stays the facade's so the feed and manifest agree", ctx do
     %{user: user, vault: vault} = ctx
     {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "e.md", "content" => "HASH ME"})
-    :ok = blank_facade!(user, note.id)
+
+    {:ok, before} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
     :ok = append_tail!(user, vault, note.id)
 
     {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
     change = Enum.find(changes, &(&1.path == "e.md"))
-    {:ok, key} = Crypto.dek_content_hash_key(user)
 
-    assert change.content == "HASH ME"
-    assert change.content_hash == Crypto.hmac_content_hash(key, "HASH ME")
+    assert change.content_hash == before.content_hash
   end
 
   # A checkpointed note has no tail, so it must NOT pay a Yjs rebuild. This is
@@ -202,7 +205,6 @@ defmodule Engram.NotesContentForReadTest do
 
     assert change.deleted
     assert change.content == "", "tombstone was resolved: #{inspect(change.content)}"
-    refute Map.has_key?(Notes.resolved_content_hashes(user, vault), note.id)
   end
 
   # The read-side mirror of `ensure_projection_safe/2`. Recomputing the hash
@@ -231,21 +233,5 @@ defmodule Engram.NotesContentForReadTest do
     change = Enum.find(changes, &(&1.path == "guard.md"))
 
     assert change.content == "REAL"
-  end
-
-  # The manifest and the feed are cross-compared by the client. If the manifest
-  # kept serving the facade hash while the feed served the resolved one, every
-  # actively-edited note would read as diverged and rewind the catch-up cursor.
-  test "the manifest hash agrees with the feed hash for a stale note", ctx do
-    %{user: user, vault: vault} = ctx
-    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "agree.md", "content" => "AGREE"})
-    :ok = blank_facade!(user, note.id)
-    :ok = append_tail!(user, vault, note.id)
-
-    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
-    feed = Enum.find(changes, &(&1.path == "agree.md"))
-    manifest = Notes.resolved_content_hashes(user, vault)
-
-    assert Map.get(manifest, note.id) == feed.content_hash
   end
 end

--- a/test/engram/notes_content_for_read_test.exs
+++ b/test/engram/notes_content_for_read_test.exs
@@ -8,8 +8,8 @@ defmodule Engram.NotesContentForReadTest do
   most damaging path of all: the sync change feed, where an empty facade made
   both devices materialize a 0-byte file and push the empty hash back.
 
-  `content_for_read/2` is the seam those paths should route through, so the
-  choice is made once instead of re-litigated per caller.
+  The resolution is shared by the change feed and the manifest so the two agree
+  on what `content_hash` means — the client cross-compares them.
   """
   use Engram.DataCase, async: true
 
@@ -45,51 +45,6 @@ defmodule Engram.NotesContentForReadTest do
       end)
 
     :ok
-  end
-
-  defp reload!(user, note_id) do
-    {:ok, note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note_id) end)
-    {:ok, decrypted} = Crypto.maybe_decrypt_note_fields(note, user)
-    decrypted
-  end
-
-  describe "content_for_read/2 (the per-note seam)" do
-    test "resolves the authority when the note has uncheckpointed ops", ctx do
-      %{user: user, vault: vault} = ctx
-      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s1.md", "content" => "REAL BODY"})
-      :ok = blank_facade!(user, note.id)
-      :ok = append_tail!(user, vault, note.id)
-
-      assert {:ok, "REAL BODY"} = Notes.content_for_read(user, reload!(user, note.id))
-    end
-
-    test "serves the facade verbatim when the tail is empty", ctx do
-      %{user: user, vault: vault} = ctx
-      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s2.md", "content" => "BODY"})
-
-      # Facade and doc deliberately disagree, with no tail. A checkpointed note
-      # must be served as-is — rebuilding here is what makes the correct call
-      # too expensive to be anyone's default.
-      {:ok, dek} = Crypto.get_dek(user)
-      {ct, n} = Envelope.encrypt("FACADE", dek, Crypto.aad_for_row(:notes, :content, note.id))
-
-      {:ok, _} =
-        Repo.with_tenant(user.id, fn ->
-          Repo.update_all(
-            from(x in Note, where: x.id == ^note.id),
-            set: [content_ciphertext: ct, content_nonce: n]
-          )
-        end)
-
-      assert {:ok, "FACADE"} = Notes.content_for_read(user, reload!(user, note.id))
-    end
-
-    test "a genuinely empty checkpointed note stays on the fast path", ctx do
-      %{user: user, vault: vault} = ctx
-      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s3.md", "content" => ""})
-
-      assert {:ok, ""} = Notes.content_for_read(user, reload!(user, note.id))
-    end
   end
 
   # Appends a tail row so the note reads as "has uncheckpointed ops" without
@@ -208,5 +163,89 @@ defmodule Engram.NotesContentForReadTest do
     change = Enum.find(changes, &(&1.path == "h.md"))
 
     assert change.content == "LAST GOOD"
+  end
+
+  # `.canvas` keeps its data in Y.Maps, not the markdown Y.Text, so `project_doc`
+  # returns "" for it. `crdt_checkpoint.ex` refuses to materialize that over the
+  # facade — the only non-Yjs copy of the board — and the read path must refuse
+  # it too.
+  test "a canvas note is never resolved through the markdown projection", ctx do
+    %{user: user, vault: vault} = ctx
+
+    {:ok, note} =
+      Notes.upsert_note(user, vault, %{"path" => "board.canvas", "content" => ~s({"nodes":[]})})
+
+    :ok = append_tail!(user, vault, note.id)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "board.canvas"))
+
+    assert change.content == ~s({"nodes":[]})
+  end
+
+  # `delete_note/4` only sets deleted_at; nothing prunes the tail (the FK cascade
+  # is hard-delete only). Without an explicit exclusion a tombstone stays "stale"
+  # forever — rebuilding a doc on every page that carries it, and shipping a
+  # resurrected body on a `deleted: true` row.
+  test "a tombstone is not resolved and ships no resurrected body", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "gone.md", "content" => "BODY"})
+
+    # Blank the facade FIRST, so a rebuild would visibly resurrect "BODY" from
+    # the snapshot. If the tombstone were resolved, content would come back.
+    :ok = blank_facade!(user, note.id)
+    :ok = append_tail!(user, vault, note.id)
+    :ok = Notes.delete_note(user, vault, "gone.md")
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "gone.md"))
+
+    assert change.deleted
+    assert change.content == "", "tombstone was resolved: #{inspect(change.content)}"
+    refute Map.has_key?(Notes.resolved_content_hashes(user, vault), note.id)
+  end
+
+  # The read-side mirror of `ensure_projection_safe/2`. Recomputing the hash
+  # removes the one signal (hash/content disagreement) a client could have used
+  # to distrust an empty row, so the backstop has to live here.
+  test "an empty projection over a non-empty facade serves the facade", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "guard.md", "content" => "REAL"})
+
+    # A snapshot that projects "" while the facade still holds the body: the
+    # shape a genesis-empty doc takes if its ops never made it into the state.
+    {:ok, %{state: empty_state}} = Engram.Notes.CrdtBridge.merge_plaintext(nil, "")
+    {:ok, {ct, nonce}} = Crypto.encrypt_crdt_state(empty_state, user, note.id)
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note.id),
+          set: [crdt_state_ciphertext: ct, crdt_state_nonce: nonce]
+        )
+      end)
+
+    :ok = append_tail!(user, vault, note.id)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "guard.md"))
+
+    assert change.content == "REAL"
+  end
+
+  # The manifest and the feed are cross-compared by the client. If the manifest
+  # kept serving the facade hash while the feed served the resolved one, every
+  # actively-edited note would read as diverged and rewind the catch-up cursor.
+  test "the manifest hash agrees with the feed hash for a stale note", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "agree.md", "content" => "AGREE"})
+    :ok = blank_facade!(user, note.id)
+    :ok = append_tail!(user, vault, note.id)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    feed = Enum.find(changes, &(&1.path == "agree.md"))
+    manifest = Notes.resolved_content_hashes(user, vault)
+
+    assert Map.get(manifest, note.id) == feed.content_hash
   end
 end

--- a/test/engram/notes_content_for_read_test.exs
+++ b/test/engram/notes_content_for_read_test.exs
@@ -1,0 +1,212 @@
+defmodule Engram.NotesContentForReadTest do
+  @moduledoc """
+  `notes.content` is a FACADE for a CRDT-managed note: it materializes at
+  checkpoint, so between a doc write and the next checkpoint the column lags the
+  authority. `docs/context/worker-reads-stale-content-facade.md` records three
+  read paths that took the facade and were wrong for it — append (#1159), link
+  extraction, and `EmbedNote` (still open) — and #1339 added a fourth on the
+  most damaging path of all: the sync change feed, where an empty facade made
+  both devices materialize a 0-byte file and push the empty hash back.
+
+  `content_for_read/2` is the seam those paths should route through, so the
+  choice is made once instead of re-litigated per caller.
+  """
+  use Engram.DataCase, async: true
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Engram.Crypto
+  alias Engram.Crypto.Envelope
+  alias Engram.Notes
+  alias Engram.Notes.{CrdtUpdateLog, Note}
+  alias Engram.Repo
+
+  setup do
+    user = insert(:user)
+    {:ok, user} = Crypto.ensure_user_dek(user)
+    {:ok, vault} = Engram.Vaults.create_vault(user, %{name: "ContentForRead"})
+    %{user: user, vault: vault}
+  end
+
+  # Blank ONLY the facade, leaving crdt_state untouched. That is precisely the
+  # state a note is in between a CRDT write and its first checkpoint — the
+  # #1339 shape — and doing it directly keeps the test independent of room
+  # scheduling.
+  defp blank_facade!(user, note_id) do
+    {:ok, dek} = Crypto.get_dek(user)
+    {ct, nonce} = Envelope.encrypt("", dek, Crypto.aad_for_row(:notes, :content, note_id))
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note_id),
+          set: [content_ciphertext: ct, content_nonce: nonce, content_hash: nil]
+        )
+      end)
+
+    :ok
+  end
+
+  defp reload!(user, note_id) do
+    {:ok, note} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note_id) end)
+    {:ok, decrypted} = Crypto.maybe_decrypt_note_fields(note, user)
+    decrypted
+  end
+
+  describe "content_for_read/2 (the per-note seam)" do
+    test "resolves the authority when the note has uncheckpointed ops", ctx do
+      %{user: user, vault: vault} = ctx
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s1.md", "content" => "REAL BODY"})
+      :ok = blank_facade!(user, note.id)
+      :ok = append_tail!(user, vault, note.id)
+
+      assert {:ok, "REAL BODY"} = Notes.content_for_read(user, reload!(user, note.id))
+    end
+
+    test "serves the facade verbatim when the tail is empty", ctx do
+      %{user: user, vault: vault} = ctx
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s2.md", "content" => "BODY"})
+
+      # Facade and doc deliberately disagree, with no tail. A checkpointed note
+      # must be served as-is — rebuilding here is what makes the correct call
+      # too expensive to be anyone's default.
+      {:ok, dek} = Crypto.get_dek(user)
+      {ct, n} = Envelope.encrypt("FACADE", dek, Crypto.aad_for_row(:notes, :content, note.id))
+
+      {:ok, _} =
+        Repo.with_tenant(user.id, fn ->
+          Repo.update_all(
+            from(x in Note, where: x.id == ^note.id),
+            set: [content_ciphertext: ct, content_nonce: n]
+          )
+        end)
+
+      assert {:ok, "FACADE"} = Notes.content_for_read(user, reload!(user, note.id))
+    end
+
+    test "a genuinely empty checkpointed note stays on the fast path", ctx do
+      %{user: user, vault: vault} = ctx
+      {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "s3.md", "content" => ""})
+
+      assert {:ok, ""} = Notes.content_for_read(user, reload!(user, note.id))
+    end
+  end
+
+  # Appends a tail row so the note reads as "has uncheckpointed ops" without
+  # standing up a real room. The tail IS the staleness marker: content
+  # materializes at checkpoint and `prune_tail/2` clears the tail in the same
+  # breath, so tail-present means the facade lags.
+  defp append_tail!(user, vault, note_id) do
+    {:ok, dek} = Crypto.get_dek(user)
+
+    {ct, nonce} =
+      Envelope.encrypt(<<0>>, dek, Crypto.aad_for_row(:crdt_update_log, :update, note_id))
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.insert!(%CrdtUpdateLog{
+          note_id: note_id,
+          user_id: user.id,
+          vault_id: vault.id,
+          update_ciphertext: ct,
+          update_nonce: nonce,
+          inserted_at: DateTime.utc_now()
+        })
+      end)
+
+    :ok
+  end
+
+  # The regression this seam exists for. The catch-up feed is what the plugin's
+  # applyChange reads, and serving "" for a note whose doc holds a body is what
+  # made both devices create a 0-byte file and push back the hash of "".
+  test "the seq change feed serves the doc body, not an empty facade", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "d.md", "content" => "FEED BODY"})
+    :ok = blank_facade!(user, note.id)
+    :ok = append_tail!(user, vault, note.id)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "d.md"))
+
+    assert change.content == "FEED BODY"
+  end
+
+  # The hash is the IDENTITY of the content as far as the plugin is concerned:
+  # it stamps `serverHash` from it, then skips any later row whose hash matches.
+  # Shipping a resolved body under the facade's stale hash would record
+  # `serverHash = hmac("")` for a file holding a body, after which a genuine
+  # emptying of that note arrives as ""/hmac("") and is skipped forever.
+  test "content_hash is recomputed to match the body actually served", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "e.md", "content" => "HASH ME"})
+    :ok = blank_facade!(user, note.id)
+    :ok = append_tail!(user, vault, note.id)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "e.md"))
+    {:ok, key} = Crypto.dek_content_hash_key(user)
+
+    assert change.content == "HASH ME"
+    assert change.content_hash == Crypto.hmac_content_hash(key, "HASH ME")
+  end
+
+  # A checkpointed note has no tail, so it must NOT pay a Yjs rebuild. This is
+  # the guard on the cost claim: genuinely-empty notes are common in a real
+  # vault, and an "is the facade empty" predicate would drag every one of them
+  # onto the slow path on every page.
+  test "a checkpointed note serves the facade verbatim, tail-free", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "f.md", "content" => ""})
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "f.md"))
+
+    assert change.content == ""
+    refute is_nil(change.content_hash)
+  end
+
+  # `fields: :meta` promises `content: nil` and its projection does not even
+  # select crdt_state, so it must never resolve the authority.
+  test "fields: :meta carries no content and resolves nothing", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "g.md", "content" => "BODY"})
+    :ok = blank_facade!(user, note.id)
+    :ok = append_tail!(user, vault, note.id)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0, fields: :meta)
+    change = Enum.find(changes, &(&1.path == "g.md"))
+
+    assert change.content == nil
+  end
+
+  # An undecodable crdt_state must NOT fail the page. The feed is keyset-ordered
+  # by seq, so a deterministic failure on one note would wedge the whole vault's
+  # catch-up permanently and crash crdt_catchup_since into a rejoin loop. The
+  # facade is the last good checkpoint — stale, but real.
+  test "an unreadable CRDT snapshot degrades to the facade instead of failing the page", ctx do
+    %{user: user, vault: vault} = ctx
+    {:ok, note} = Notes.upsert_note(user, vault, %{"path" => "h.md", "content" => "LAST GOOD"})
+    :ok = append_tail!(user, vault, note.id)
+
+    # Corrupt the snapshot only: AES-GCM auth fails, the row's other columns
+    # still decrypt fine.
+    {:ok, raw} = Repo.with_tenant(user.id, fn -> Repo.get!(Note, note.id) end)
+    ct = raw.crdt_state_ciphertext
+    last = byte_size(ct) - 1
+    <<head::binary-size(last), b>> = ct
+
+    {:ok, _} =
+      Repo.with_tenant(user.id, fn ->
+        Repo.update_all(
+          from(n in Note, where: n.id == ^note.id),
+          set: [crdt_state_ciphertext: <<head::binary, Bitwise.bxor(b, 0xFF)>>]
+        )
+      end)
+
+    {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
+    change = Enum.find(changes, &(&1.path == "h.md"))
+
+    assert change.content == "LAST GOOD"
+  end
+end

--- a/test/engram/notes_content_for_read_test.exs
+++ b/test/engram/notes_content_for_read_test.exs
@@ -168,18 +168,18 @@ defmodule Engram.NotesContentForReadTest do
     assert change.content_hash == before.content_hash
   end
 
-  # A checkpointed note has no tail, so it must NOT pay a Yjs rebuild. This is
-  # the guard on the cost claim: genuinely-empty notes are common in a real
-  # vault, and an "is the facade empty" predicate would drag every one of them
-  # onto the slow path on every page.
-  test "a checkpointed note serves the facade verbatim, tail-free", ctx do
+  # A checkpointed note with a NON-empty facade is served verbatim and never
+  # re-read. Note what this does NOT claim: a genuinely-empty checkpointed note
+  # IS re-read and rebuilt, because an empty facade is indistinguishable from
+  # one a checkpoint just moved. That cost is real and bounded to empty notes.
+  test "a checkpointed note with a body is served verbatim", ctx do
     %{user: user, vault: vault} = ctx
-    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "f.md", "content" => ""})
+    {:ok, _} = Notes.upsert_note(user, vault, %{"path" => "f.md", "content" => "KEPT"})
 
     {:ok, %{changes: changes}} = Notes.list_changes_by_seq(user, vault, 0)
     change = Enum.find(changes, &(&1.path == "f.md"))
 
-    assert change.content == ""
+    assert change.content == "KEPT"
     refute is_nil(change.content_hash)
   end
 


### PR DESCRIPTION
## The bug

A folder rename could leave a note **0 bytes on every device**, and the empty body was then pushed back to the server. Confirmed cause of the `test_34` flake (#1199, ~38% of e2e-clerk runs).

`notes.content` is a façade — it materializes at checkpoint, so a note with uncheckpointed ops serves a body that lags. When it lags all the way to `""`, the client creates a 0-byte file and pushes back the hash of `""`. A read bug becomes permanent data loss.

## The fix

The change feed resolves the **content** from the CRDT authority for notes whose façade lags. `content_hash` is deliberately left alone.

### Why content only

`content_hash` means "hash of the last checkpoint". It is **immutable between checkpoints** and therefore identical on every endpoint that serves it — which is why the feed and `/sync/manifest` agree, and why `validateFromManifest` can use hash equality as a convergence fence.

Earlier revisions of this PR recomputed the hash to match the resolved body. That makes it **mutable**, and resolving the manifest too does not repair it: an actively-edited note genuinely changes between the feed read and the manifest read, so the two endpoints describe different instants and every such note reads as diverged on each poll. No server-side scheme fixes that. Serving `nil` for those rows is worse — `validateFromManifest` counts any non-matching hash as `behind`, so nil means "always behind, rewind every poll".

The cost of leaving the hash alone is a bounded, self-healing window: until the next checkpoint the client's `serverHash` describes older bytes than the body it just wrote. At that checkpoint the feed re-serves the same body under the now-correct hash and the client re-applies idempotently. Strictly smaller than a permanent inconsistency on every edited note.

### The staleness predicate

The tail. `notes.content` materializes at checkpoint and `prune_tail/2` clears the tail in the same breath, so **a note with rows in `crdt_update_log` is exactly a note whose façade lags.**

The obvious alternative — "the façade is empty" — is worse on both axes: it misses a non-empty-but-stale façade, and it drags every genuinely-empty note (all carrying a genesis snapshot, and common in a real vault) onto the rebuild path on every page.

### Atomicity

Snapshot and tail are read in **one transaction**, with each row re-read there rather than taken from the page SELECT. `checkpoint_write` persists the new snapshot and prunes the tail together, so a page-captured struct would let a checkpoint landing mid-page leave `replay_tail` with nothing to replay *and* a pre-checkpoint snapshot — which for a genesis note whose body lives entirely in the tail projects `""`. That is #1339 through a narrower window.

The single transaction also bounds pool cost: a folder rename leaves many notes stale at once, and per-note resolution would be hundreds of serial checkouts inside one channel `handle_in` (`crdt-sync-pool-exhaustion-loop-2026-07-09.md`).

### Guards

- **`.md` only.** `project_doc` returns `""` for a structural doc — `crdt_checkpoint.ex` refuses this exact write for that reason — so resolving a `.canvas` would serve an empty board.
- **Tombstones excluded.** They never prune their tail, so they would be permanently "stale": a rebuild on every page carrying them, shipping a resurrected body on a `deleted: true` row.
- **Empty projection over a non-empty façade serves the façade**, mirroring `ensure_projection_safe/2` on the write side.
- **An unreadable snapshot degrades rather than failing the page.** The feed is keyset-ordered by seq, so raising would fail identically on every retry — wedging catch-up permanently and crashing `crdt_catchup_since` into a rejoin loop. Quarantine for the permanent case is #959.

## Review history

Three rounds. Rounds 1 and 2 each found data loss in code I'd written; round 3 identified the `content_hash` invariant above, which is why this revision reverts the manifest change entirely rather than patching it — all seven of round 3's findings lived in code that no longer exists.

## Tests (8)

Feed serves the doc body over an empty façade (the #1339 regression) · `content_hash` stays the façade's · a checkpointed note is untouched · `fields: :meta` contract · `.canvas` never resolved · tombstone not resolved · empty-projection guard · corrupted snapshot degrades.

## Verification

| gate | result |
|---|---|
| `mix format` | clean |
| `mix credo --strict` | 4485 mods/funs, no issues |
| `mix test --warnings-as-errors` | 1 property, **4325 tests, 0 failures** |
| `mix dialyzer` | passed |

## Follow-up

The client-side half: never materialize *or push* an empty body from a discovery — enroll + STEP1 and let the existing `onEmptyStep2` path materialize it. That is the invariant worth having regardless of the server being right, and it is what turned this read bug into permanent loss. Separate PR.

Closes #1339
Refs #1199
