### PR TITLE
test(e2e): a closed sync gate must hold the feed, not consume it

### DIFF
--- a/e2e/tests/test_89_closed_gate_holds_feed.py
+++ b/e2e/tests/test_89_closed_gate_holds_feed.py
@@ -1,0 +1,92 @@
+"""Test 89: a closed sync gate HOLDS the catch-up feed, it does not consume it.
+
+Prod, 2026-08-13. A first sync into an empty vault created every folder and
+zero notes, then reported success and 100% downloaded. Two defects stacked:
+
+  1. `flushFromCrdt` returned true while the gate was shut, having written
+     nothing. The replay counted those phantom writes as downloaded files, so
+     the progress bar filled, the recap said "success", and the
+     produced-nothing anomaly could not fire.
+  2. `walkOpLog` persisted the catch-up cursor per page regardless. A blocked
+     walk therefore advanced the cursor PAST every row it had refused to
+     write, and the next catch-up resumed after them. The notes were not
+     delayed, they were skipped.
+
+Only #1 is visible from inside the plugin's own suite, and that suite was
+fully green the entire time the bug was in production. This test pins the
+loop end to end against a real Obsidian and a real backend, which is the
+layer the bug actually survived.
+
+The cursor assertion is the load-bearing one. "No files on disk while
+blocked" is also true of the broken build, so on its own it proves nothing;
+what separates fixed from broken is whether the feed rows are still there to
+serve once the gate opens.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from helpers.latency import DELIVERY_TIMEOUT
+from helpers.vault import wait_for_content
+
+NOTE_COUNT = 5
+
+SET_BLOCKED = "app.plugins.plugins['engram-vault-sync'].syncEngine.setSyncBlocked({})"
+GET_CURSOR = "app.plugins.plugins['engram-vault-sync'].syncEngine.getCatchupSeq()"
+
+
+@pytest.mark.asyncio
+async def test_closed_gate_holds_the_feed_until_it_opens(vault_b, cdp_b, api_sync):
+    # Run-unique paths. Fixtures are session-scoped and vault notes survive
+    # between runs, so a fixed path would already be on disk when this test
+    # starts and the "nothing was written" assertion would fail for the wrong
+    # reason. Deleted again in the finally below so the folder doesn't grow.
+    run = uuid.uuid4().hex[:12]
+    paths = [f"E2E/GateHold-{run}/Held{i}.md" for i in range(NOTE_COUNT)]
+
+    # Drain anything already pending so the cursor we snapshot is quiet. Without
+    # this, an unrelated row landing mid-test moves the cursor and the "did not
+    # advance" assertion reads as a failure of this code path when it isn't.
+    await cdp_b.trigger_full_sync()
+    cursor_before = await cdp_b.evaluate(GET_CURSOR)
+
+    await cdp_b.evaluate(SET_BLOCKED.format("true"))
+    try:
+        for i, path in enumerate(paths):
+            api_sync.create_note(path, f"# Held {i}\nheld-marker-{i}\n")
+
+        # A full sync against a closed gate. The engine is allowed to do
+        # nothing; what it may NOT do is consume the rows while doing nothing.
+        await cdp_b.trigger_full_sync()
+
+        for path in paths:
+            assert not (vault_b / path).exists(), (
+                f"{path} was written with the sync gate closed — the gate is not a gate"
+            )
+
+        cursor_after = await cdp_b.evaluate(GET_CURSOR)
+        assert cursor_after == cursor_before, (
+            f"catch-up cursor moved {cursor_before} -> {cursor_after} while blocked. "
+            f"Those {NOTE_COUNT} rows are now behind the cursor and will never be "
+            f"served again — this is the 2026-08-13 data-loss shape."
+        )
+    finally:
+        await cdp_b.evaluate(SET_BLOCKED.format("false"))
+
+    # Gate open: every held row must still be there to serve.
+    try:
+        await cdp_b.trigger_full_sync()
+        for i, path in enumerate(paths):
+            wait_for_content(
+                vault_b, path, f"held-marker-{i}", timeout=DELIVERY_TIMEOUT
+            )
+    finally:
+        # Best-effort only: teardown must never mask the real assertion error.
+        for path in paths:
+            try:
+                api_sync.delete_note(path)
+            except Exception:  # noqa: BLE001 - teardown, see above
+                pass


### PR DESCRIPTION
## What

One e2e test, `test_89_closed_gate_holds_feed.py`, for the 2026-08-13 first-sync failure: every folder created, zero notes, "success" recap at 100%.

## Why this layer

The plugin's own suite was fully green the entire time that bug was in production. Unit coverage landed in engram-app/Engram-obsidian#424 (22 tests, red-first), but the loop that actually broke crosses a real Obsidian, a real backend and a persisted cursor, so it needs pinning here too.

## The assertion that carries it

"Nothing on disk while the gate is closed" is equally true of the broken build, so on its own it proves nothing. What separates fixed from broken is the **catch-up cursor**: `walkOpLog` used to persist it per page regardless of the gate, so a blocked walk advanced past every row it had refused to write and the next catch-up resumed after them. The rows were skipped, not delayed.

So the test asserts, in order:
1. gate closed + 5 new server notes + full sync → nothing on disk
2. **cursor did not move**
3. gate open + full sync → all 5 materialise

## Red/green

This branch has no matching plugin branch, so e2e auto-links plugin `main` — the pre-fix build. **This run is expected to fail on step 2 or 3.** That failure is the proof the test catches the bug. It should go green once engram-app/Engram-obsidian#424 merges into plugin main; I'll re-run then and will not merge this on red.

Rerun-safe: run-unique paths (session-scoped vault survives runs) and a best-effort server-side delete in a `finally` that can't mask a real assertion.

Refs engram-app/Engram-obsidian#424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC